### PR TITLE
docs(ssr): the reg-error-projector example conforms (rf2-0aqd4)

### DIFF
--- a/docs/api/re-frame.ssr.md
+++ b/docs/api/re-frame.ssr.md
@@ -365,11 +365,16 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   ```
 - **Description**: Register a projector keyed by id. The projector signature is `(fn [trace-event] :rf/public-error)`. Named per-frame via the frame's `:ssr {:public-error-id ...}` metadata. Returns `id`.
   - **The return shape is closed — get it wrong and your projector is discarded silently.** Conformant output carries **exactly** the four [`public-error-keys`](#public-error-keys): `:status` (an integer in `400`–`599`), `:code` (a keyword), `:message` (a string), `:retryable?` (a boolean). None missing, none extra — including a `:details` of your own, which only the runtime may append, *after* validation, under `:ssr {:dev-error-detail? true}`. A non-conforming return makes [`project-error`](#project-error) emit `:rf.error/sanitised-on-projection` and serve the locked generic-500 [`fallback-public-error`](#fallback-public-error) instead, on **every** error, for the life of the registration.
+  - **A custom projector inherits none of the default's condition-gating.** Two `:rf.error/*` categories carry a discriminator tag that decides the status, and a projector that branches on `:operation` alone gets both wrong: `:rf.error/no-such-handler` is a `404` only under `[:tags :kind]` `:route`, and `:rf.error/schema-validation-failure` a `400` only under `[:tags :where]` `:event`. Gate on the tag the way the example below does, or an unregistered event id answers `404` and a server-side `:where :fx-args` failure blames the client for a server bug — see [`default-error-projector-fn`](#default-error-projector-fn) for the reasoning.
 - **Example**:
   ```clojure
   (rf/reg-error-projector :app/public-error
     (fn [trace-event]
-      (if (= :rf.error/no-such-route (:operation trace-event))
+      ;; Gate the 404 on `:kind :route` — only a URL that matched no route
+      ;; is a missing PAGE. An unregistered event id or frame-id arrives
+      ;; under the same category and is a SERVER defect: 500, not 404.
+      (if (and (= :rf.error/no-such-handler (:operation trace-event))
+               (= :route (get-in trace-event [:tags :kind])))
         {:status     404
          :code       :not-found
          :message    "We couldn't find that page."
@@ -409,7 +414,7 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   (default-error-projector-fn trace-event) → :rf/public-error
   ```
 - **Description**: The runtime's built-in default projector, registered under `:rf.ssr/default-error-projector`. Maps trace events to public errors:
-  - `:rf.error/no-such-handler` → `404 :not-found`. This is the arm that answers an unroutable URL, and it survives production hardening. Its sibling `:rf.error/no-such-route` maps to `404` too, but that category is caller misuse of `route-url` and rides the dev-gated trace stream, so a release build never reaches this arm through it.
+  - `:rf.error/no-such-handler` → `404 :not-found`, but **only when the miss's `:kind` tag is `:route`**. Spec 009 catalogues three misses under this one category, discriminated by a mandatory `:kind`: a URL that matched no route (`:kind :route`), a dispatch to an unregistered event id (`:kind :event`), and a Tool-Pair surface addressing an unknown frame-id (`:kind :frame`). Only the first is a missing-*page* condition. The other two are server defects — answering `404` would tell the client its URL was wrong when the server forgot a registration, and a crawler will act on that — so they fall through to the generic `500`, as does a miss carrying no `:kind` at all. The arm is opt-in on the discriminator, fail-safe, exactly like the `:where`-gated arm below. Gated so it stays that way once the URL-driven miss was promoted onto the always-on error axis: before that promotion no `:rf.error/no-such-handler` reached this projector in production at all, and an ungated arm would now answer `404` for an unregistered event id. The `:kind :route` arm is the one that answers an unroutable URL, and it survives production hardening. Its sibling `:rf.error/no-such-route` maps to `404` unconditionally — one failure mode, no `:kind` discriminator — but that category is caller misuse of `route-url` and rides the dev-gated trace stream, so a release build never reaches this arm through it.
   - `:rf.error/cofx-value-invalid` (a client-supplied coeffect rejected at the dispatch boundary) → `400 :bad-request`.
   - `:rf.error/schema-validation-failure` → `400 :bad-request`, but only when the failure's `:where` tag is `:event` (a client-supplied event payload). Server-side surfaces such as `:where :fx-args` fall through, and so does a record carrying no `:where` at all — the arm is opt-in on the discriminator, fail-safe. **This arm fires under production hardening as well as in dev** — see below.
   - Everything else → the locked generic `500 :internal-error` ([`fallback-public-error`](#fallback-public-error)).

--- a/implementation/ssr/src/re_frame/ssr/error_projector.cljc
+++ b/implementation/ssr/src/re_frame/ssr/error_projector.cljc
@@ -245,10 +245,26 @@
       {:doc \"Project internal error trace events to public response shapes.\"}
       (fn [trace-event]
         (case (:operation trace-event)
-          :rf.error/no-such-handler           {:status 404 :code :not-found
-                                               :message \"Not found\" :retryable? false}
-          :rf.error/schema-validation-failure {:status 400 :code :bad-request
-                                               :message \"Invalid input\" :retryable? false}
+          ;; GATE the 404 on `:kind :route`: only a URL that matched no
+          ;; route is a missing PAGE. `:kind :event` (an unregistered event
+          ;; id) and `:kind :frame` are SERVER defects and take the 500,
+          ;; exactly as `default-error-projector-fn` does.
+          :rf.error/no-such-handler
+          (if (= :route (get-in trace-event [:tags :kind]))
+            {:status 404 :code :not-found
+             :message \"Not found\" :retryable? false}
+            {:status 500 :code :internal-error
+             :message \"Something went wrong\" :retryable? false})
+
+          ;; GATE the 400 on `:where :event` — a client-supplied event
+          ;; payload. `:where :fx-args` is a SERVER defect, not bad input.
+          :rf.error/schema-validation-failure
+          (if (= :event (get-in trace-event [:tags :where]))
+            {:status 400 :code :bad-request
+             :message \"Invalid input\" :retryable? false}
+            {:status 500 :code :internal-error
+             :message \"Something went wrong\" :retryable? false})
+
           ;; ...
           {:status 500 :code :internal-error
            :message \"Something went wrong\" :retryable? false})))

--- a/implementation/ssr/test/re_frame/ssr_doc_example_projector_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_doc_example_projector_test.clj
@@ -1,0 +1,210 @@
+(ns re-frame.ssr-doc-example-projector-test
+  "rf2-0aqd4 ACCEPTANCE — the `reg-error-projector` example printed in
+  `docs/api/re-frame.ssr.md` is executed, not merely read.
+
+  WHY THIS SUITE EXISTS. An API-page example is the artefact a reader
+  COPIES, and nothing was checking it. The api-manifest doc gate
+  (`re-frame.api-manifest.doc-api-check`) verifies that every public var
+  HAS a docs/api entry — var existence, the APPEARANCE of documentation.
+  The runtime suites (`re-frame.ssr-route-miss-404-production-test`,
+  `re-frame.ssr-error-projector-substrate-test`) verify the BUILT-IN
+  projector. Between those two sits the one projector a reader actually
+  ships: the documented one. It drifted twice, silently, because no gate
+  evaluated it.
+
+    - rf2-0aqd4 as filed: the example returned two of the four locked
+      `public-error-keys`, so `project-error` discarded it on EVERY error
+      in favour of the locked generic-500. The page stated the closed-shape
+      rule 22 lines below the example that broke it.
+    - rf2-0aqd4 after the #7168 audit: the repaired example branched on
+      `:rf.error/no-such-route` — a category the same page describes as
+      caller misuse of `route-url` riding the DEV-gated trace stream, so a
+      release build never reaches it. The example's only 404 arm was dead
+      under production hardening, while the category that DOES answer an
+      unroutable URL in production (`:rf.error/no-such-handler` with
+      `[:tags :kind]` `:route`) fell through to the example's generic 500.
+
+  Both defects are invisible to a reader and to every existing gate. Both
+  are caught below by DRIVING the documented projector, so the test cannot
+  drift from the page: the fn under test is read out of the markdown fence
+  at run time rather than copied here.
+
+  WHY 404-ON-THE-WIRE IS THE CONFORMANCE PROOF. A non-conformant projector
+  return is replaced by `fallback-public-error` — status 500, message
+  \"Something went wrong\". So observing the EXAMPLE'S OWN 404 and its own
+  message on the response accumulator proves the example passed
+  `public-error-shape?`; there is no path by which a malformed return
+  produces them. That makes one assertion cover both the closed-key-set
+  rule and the `:kind` gate's positive arm.
+
+  POSTURE-INDEPENDENT. Every assertion reads the response accumulator and
+  the pure projector; none touches the dev trace bus. The namespace
+  therefore executes under `scripts/test-ssr-prod-gate.sh`'s real
+  `-Dre-frame.debug=false` gate as well as in the ordinary lane — which is
+  the posture that matters, since the drift this suite pins was
+  specifically a 404 arm that only ever fired in dev."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.test-fixture :as tf]))
+
+;; The fixture must NOT clear the always-on error-listener registry:
+;; `re-frame.ssr` installs its `::error-projection` listener at ns-load
+;; time and that listener IS the production status-projection path these
+;; assertions exercise. Wiping it would turn every 404 below into a
+;; vacuous 200. Same note as `re-frame.ssr-route-miss-404-production-test`.
+(use-fixtures :each tf/reset-runtime)
+
+;; ---------------------------------------------------------------------------
+;; Reading the documented example out of the page
+;; ---------------------------------------------------------------------------
+
+(def ^:private api-page
+  "`docs/api/re-frame.ssr.md`, anchored to a CLASSPATH RESOURCE rather than
+  the working directory (rf2-ywrwkl; the same anchoring
+  `re-frame.ssr-conformance-test` uses for the conformance corpus). A
+  `(io/file \"../../docs/...\")` form would resolve correctly under the
+  per-artefact gate run from `implementation/ssr/` and silently MIS-SCOPE
+  under the combined `implementation/deps.edn :test` alias. This namespace's
+  own source is on the test classpath, so five parents
+  (`…_test.clj → re_frame → test → ssr → implementation → repo root`)
+  reach the repo root from wherever the JVM was started."
+  (let [res (io/resource "re_frame/ssr_doc_example_projector_test.clj")]
+    (assert res
+            (str "ssr-doc-example-projector-test cannot locate its own source "
+                 "on the classpath — the ssr test/ dir must be on the test "
+                 "classpath for the API page to be found."))
+    (-> (io/file res)  ; …/ssr/test/re_frame/ssr_doc_example_projector_test.clj
+        .getParentFile .getParentFile .getParentFile .getParentFile .getParentFile
+        (io/file "docs" "api" "re-frame.ssr.md")
+        .getCanonicalFile)))
+
+(defn- fence
+  "The text of the one ```clojure fence on the API page containing
+  `needle`. Hard-errors on zero or many matches, so a rewritten page fails
+  loudly rather than silently pinning nothing.
+
+  Line endings are normalised first: the page is stored LF but checks out
+  CRLF on a Windows dev box (`core.autocrlf`), and a `\\n`-only fence regex
+  matches zero blocks there while passing on the Linux CI runner."
+  [needle]
+  (let [md   (str/replace (slurp api-page) "\r\n" "\n")
+        hits (->> (re-seq #"(?s)```clojure\n(.*?)```" md)
+                  (map second)
+                  (filter #(str/includes? % needle)))]
+    (assert (= 1 (count hits))
+            (str "expected EXACTLY ONE ```clojure fence in " api-page
+                 " containing " (pr-str needle) ", found " (count hits)
+                 " — the pin has lost its anchor."))
+    (first hits)))
+
+(def ^:private documented-projector-fn
+  "The `(fn [trace-event] …)` from the page's `reg-error-projector`
+  example, read and evaluated. `read-string` drops the fence's `;;`
+  comments; the body uses only `clojure.core`, so evaluating it in this
+  namespace resolves every symbol."
+  (delay
+    (let [form (read-string (fence "rf/reg-error-projector :app/public-error"))]
+      (is (= 'rf/reg-error-projector (first form))
+          "the example still calls reg-error-projector")
+      (binding [*ns* (find-ns 're-frame.ssr-doc-example-projector-test)]
+        (eval (last form))))))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures — the proven production path from the route-miss suite
+;; ---------------------------------------------------------------------------
+
+(defn- register-routes! []
+  (rf/reg-route :route/home {} "/")
+  (rf/reg-route :rf.route/not-found {} "/not-found")
+  (rf/reg-view* :pages/not-found (fn [] [:main.not-found [:h1 "No such page"]])))
+
+(defn- server-frame-using-the-documented-projector []
+  (rf/reg-error-projector :app/public-error @documented-projector-fn)
+  (frame/make-anon-frame-record!
+    {:platform :server
+     :ssr      {:public-error-id   :app/public-error
+                :dev-error-detail? false}}))
+
+;; ===========================================================================
+;; (1) The documented projector is CONFORMANT and answers a real route miss
+;; ===========================================================================
+
+(deftest the-documented-example-answers-an-unroutable-url-with-its-own-404
+  (testing "rf2-0aqd4: a reader who pastes the page's `reg-error-projector`
+            example gets a projector that survives `public-error-shape?`
+            (its own 404 reaches the wire rather than the locked
+            generic-500) AND fires on the category that actually reports an
+            unroutable URL in production."
+    (register-routes!)
+    (let [f (server-frame-using-the-documented-projector)]
+      (rf/dispatch-sync [:rf.route/handle-url-change "/no-such-page"] {:frame f})
+      (let [{:keys [response public-error]} (ssr/flush-response-result! f)]
+        (is (= 404 (:status response))
+            "the documented projector's 404 reached the response accumulator")
+        (is (= :not-found (:code public-error))
+            "and it is the example's OWN projection, not the locked fallback")
+        (is (= "We couldn't find that page." (:message public-error))
+            "the example's own message proves the four-key shape passed
+             conformance — a non-conforming return would have been replaced
+             by fallback-public-error's \"Something went wrong\"")
+        (is (= ssr/public-error-keys (set (keys public-error)))
+            "exactly the four locked keys, none extra (:dev-error-detail?
+             is false, so the runtime appended no :details)")))))
+
+;; ===========================================================================
+;; (2) The documented projector carries the `:kind :route` gate
+;; ===========================================================================
+
+(deftest the-documented-example-gates-its-404-on-kind-route
+  (testing "rf2-0aqd4 (#7168 audit): `:rf.error/no-such-handler` covers three
+            misses discriminated by `:kind`. An example that branched on
+            `:operation` alone would answer 404 for an event id the server
+            forgot to register — telling the client its URL was wrong when
+            the server was. Driven through a real dispatch, then unit-tested
+            on the extracted fn so a regression names the arm."
+    (register-routes!)
+    (let [f (server-frame-using-the-documented-projector)]
+      (rf/dispatch-sync [:never/registered] {:frame f})
+      (is (= 500 (:status (ssr/flush-response! f)))
+          "an unregistered EVENT dispatch is a server defect — generic 500"))
+    (let [project @documented-projector-fn]
+      (is (= 404 (:status (project {:operation :rf.error/no-such-handler
+                                    :tags      {:kind :route}})))
+          ":kind :route → 404")
+      (is (= 500 (:status (project {:operation :rf.error/no-such-handler
+                                    :tags      {:kind :event}})))
+          ":kind :event → 500")
+      (is (= 500 (:status (project {:operation :rf.error/no-such-handler
+                                    :tags      {:kind :frame}})))
+          ":kind :frame → 500")
+      (is (= 500 (:status (project {:operation :rf.error/no-such-handler
+                                    :tags      {}})))
+          "no :kind → 500; the 404 arm is opt-in on the discriminator"))))
+
+;; ===========================================================================
+;; (3) The `project-error` example's `;; =>` result comment is the real one
+;; ===========================================================================
+
+(deftest the-project-error-example-result-comment-matches-the-runtime
+  (testing "rf2-0aqd4 acceptance 2: the page's `project-error` example claims
+            a return value in a `;; =>` comment. It is the default
+            projector's actual 404 projection — all four locked keys,
+            `:retryable?` included (it was the key the original filing found
+            missing)."
+    (let [claimed (-> (fence "ssr/project-error :rf/default trace-event")
+                      (->> (re-find #"(?m)^\s*;;\s*=>\s*(\{.*\})\s*$"))
+                      second
+                      edn/read-string)]
+      (is (some? claimed) "the example still carries a `;; =>` result comment")
+      (is (= ssr/public-error-keys (set (keys claimed)))
+          "the documented result names exactly the four locked keys")
+      (is (= claimed
+             (ssr/default-error-projector-fn {:operation :rf.error/no-such-handler
+                                              :tags      {:kind :route}}))
+          "and it is byte-for-byte what the default projector returns for the
+           route miss the example describes"))))


### PR DESCRIPTION
Closes rf2-0aqd4.

## The clause the example violated

`default-error-projector-fn`'s own contract, `implementation/ssr/src/re_frame/ssr/error_projector.cljc:140-145`:

> The `:rf.error/no-such-handler` 404 arm is GATED on the miss's `:kind` tag (rf2-ov56u, ruling rf2-rqje9). … Only the first is a missing-PAGE condition.

The example did not implement that gate. It branched on a different category entirely:

```clojure
(if (= :rf.error/no-such-route (:operation trace-event))
  {:status 404 …}
  {:status 500 …})
```

`:rf.error/no-such-route` is the category the *same page* describes, 40 lines below, as one "a release build never reaches this arm through it" — caller misuse of `route-url`, riding the dev-gated trace stream. So a reader who pasted this example registered a projector whose **only 404 arm is dead under production hardening**, while the category that actually reports an unroutable URL in production — `:rf.error/no-such-handler` with `[:tags :kind]` `:route`, promoted onto the always-on error axis by rf2-ov56u — fell straight through to the example's generic 500. A real 404 answered 500: a soft-500 on the security-adjacent surface, and the exact misclassification PR #7168 had just fixed in the runtime, reintroduced by the canonical example.

The page's `default-error-projector-fn` summary had the same drift in prose — `` `:rf.error/no-such-handler` → `404 :not-found` `` with no discriminator — while its own *next* bullet spells out the sibling `:where :event` gate in full. Two adjacent bullets, one gate documented and one not.

## What changed

- **`docs/api/re-frame.ssr.md`** — the example branches on `:rf.error/no-such-handler` and gates on `[:tags :kind]` `:route`. Same size, same two arms; the smallest change that makes it correct. The `default-error-projector-fn` summary now names the gate and the three `:kind` misses, symmetric with the `:where :event` bullet. `reg-error-projector`'s Description gains one line saying plainly that a custom projector inherits none of the default's condition-gating.
- **`error_projector.cljc`** — docstring only, no behaviour change. `reg-error-projector`'s own docstring example carried the pre-#7168 ungated shape for *both* gated categories. The bead's audit note names this file explicitly, which is why a `src/` file is in a docs bead.
- **`re-frame.ssr-doc-example-projector-test`** — the pin (below).

## Why no gate caught it

The api-manifest doc gate (`re-frame.api-manifest.doc-api-check`) checks that every public var **has** a `docs/api/` entry — var existence, the *appearance* of documentation, not the conformance of what the entry says. The runtime suites (`ssr-route-miss-404-production-test`, `ssr-error-projector-substrate-test`) exhaustively pin the **built-in** projector, including this very `:kind` gate. Between those two sat the one projector a reader actually ships — the documented one — and nothing evaluated it. It drifted twice: first to a two-key non-conformant return, then to a dead 404 arm.

It pins cheaply, so it is pinned. The new suite **reads both examples out of the markdown fence at run time and executes them**, so the test cannot drift from the page — there is no copy to fall out of sync:

1. The `reg-error-projector` example is registered and driven through a real unroutable-URL request on a server frame. Its **own** 404 and its **own** message reaching the response accumulator is the conformance proof: a non-conforming return would have been replaced by `fallback-public-error`'s 500 / "Something went wrong", so one assertion covers both the closed-key-set rule and the gate's positive arm.
2. The same extracted fn is driven with `:kind` `:event` / `:frame` / absent (all 500), plus a real unregistered-event dispatch through the wire.
3. The `project-error` example's `;; =>` result comment is compared against what `default-error-projector-fn` actually returns.

Every assertion reads the response accumulator or the pure projector; none touches the dev trace bus, so the suite is posture-independent and joins the production lane automatically (the exclusion roster is empty). It is not a generalised doc gate — it pins two named examples on one page.

**Mutation-proved.** Reverting the example's 404 arm to the pre-fix `:rf.error/no-such-route` branch reds **4 of 13 assertions** (exit 1). Restored byte-identical afterwards.

## Sweep of the page's other examples

All conformant — checked against source rather than read. Every `;; =>` result claim on the page (the class this bead's original filing found wrong) matches its implementation exactly: `public-error-keys` (`error_projector.cljc:77`), `fallback-public-error` (`:111-114`), `default-response` and `get-response` (`response.cljc:519-522`), `drain-blocking-resources!` (`ssr.cljc:227`), and the two streaming return shapes (`streaming.cljc:543-544`, `:572-576`). `:rf/server-init` is a genuine app-registered id. Nothing to fix, nothing to file.

## Quality gates

| Gate | Exit |
| --- | --- |
| `python -m mkdocs build --strict` | `0` (no warning against `docs/api/re-frame.ssr.md` — the new anchors resolve) |
| `python scripts/check_doc_slugs.py` | `0` |
| `clojure -M:test` in `implementation/ssr` (dev posture) | `0` — 592 tests, 2892 assertions, 0 failures / 0 errors |
| `bash scripts/test-ssr-prod-gate.sh` (real `-Dre-frame.debug=false`) | `0` — 594 tests, 2722 assertions, 0 failures / 0 errors |
| new pin alone | `0` — 3 tests, 13 assertions |
| new pin against the mutated example | `1` — 4 of 13 red, as intended |

The lane count rose (589 → 594) and the `RF2_MIN_TESTS` floor is a minimum, so no regression. Everything else deferred to CI.
