### PR TITLE
spec: the form-action pattern says which layer actually validates (rf2-eane2, rf2-ppi5k)

### DIFF
--- a/skills/re-frame2/patterns/form-action.md
+++ b/skills/re-frame2/patterns/form-action.md
@@ -13,7 +13,7 @@ The prompt mentions: an SSR app handling a form POST, progressive enhancement, "
 1. **The HTML form** renders `method="POST" action="/<route>"` + a hidden CSRF token. The standard Pattern-Forms slice (server-rendered from `app-db`) drives field values.
 2. **The host adapter receives the POST**, parses the body (form-urlencoded or multipart), binds it under `:form-params`, and creates a per-request frame.
 3. **`:rf/server-init` routes** by declaring `:rf.cofx/requires [:rf.server/request]` — on GET dispatch the page loader (Pattern-SSR-Loaders); on POST dispatch the domain event with `form-params`.
-4. **The domain handler validates** `form-params` against the registered schema. On failure → write structured errors into the form slice's `:errors`, let the drain settle, re-render the page with inline errors. On success → run the side effect, then `:rf.server/redirect` (303) or a success re-render.
+4. **The domain handler validates** `form-params` **in its own body** — not via `:schema`, which is a dev tripwire and elides from the production build. On failure → write the submitted fields back into the form slice's `:draft` and structured errors into its `:errors`, emit `[:rf.server/set-status 400]`, let the drain settle, re-render the page populated and with inline errors. On success → run the side effect, then `:rf.server/redirect` (303) or a success re-render.
 5. **The drain settles**, the SSR emitter runs (or is short-circuited by the redirect), the host materialises the response accumulator (read via `get-response`).
 6. **Once JS hydrates**, the form's `:on-submit` calls `(.preventDefault e)` and dispatches the *same* event. Only the dispatch site differs.
 
@@ -42,7 +42,7 @@ The view runs on both platforms; the `action` attribute is what makes it work JS
      [:button {:type "submit"} "Add to cart"]]))
 ```
 
-`:rf/server-init` routes GET vs POST; the action handler validates via `:schema` and emits per-platform effects:
+`:rf/server-init` routes GET vs POST; the action handler validates **in its own body** and emits per-platform effects:
 
 ```clojure
 (rf/reg-event :rf/server-init
@@ -58,27 +58,45 @@ The view runs on both platforms; the `action` attribute is what makes it work JS
 
 (rf/reg-event :cart/add-item
   {:doc    "Add an item to the cart. Same handler tree both platforms."
-   :schema [:cat [:= :cart/add-item] AddToCartForm]      ;; server-side schema check, never skipped
+   :schema [:cat [:= :cart/add-item] AddToCartForm]      ;; DEV TRIPWIRE ONLY — elided in production
    :rf.cofx/requires [:rf.server/request
                       :app.csrf/active-token]}            ;; app-owned cofx — see §CSRF
   (fn [{:keys [db rf.server/request app.csrf/active-token]} [_ form-params]]
-    (if (not= (:csrf-token form-params) active-token)    ;; CSRF first — fail loud
-      {:db (assoc-in db [:cart :add-form :errors :_form] ["Session expired. Refresh and retry."])
-       :fx [[:rf.server/set-status 403]]}
-      {:db (-> db
-               (update-in [:cart :items] (fnil conj []) (select-keys form-params [:item-id :quantity]))
-               (assoc-in  [:cart :add-form :status] :submitted))
-       ;; ONE destination, CHOSEN by a platform boundary the handler already
-       ;; reads: the :rf.server/request cofx is present on the server and, being
-       ;; :platforms #{:server}, skipped (absent) on the client. Server → the
-       ;; POST-redirect-GET 303; client → in-app navigation. We do NOT emit both:
-       ;; :rf.route/navigate is not a server no-op — dispatched server-side it
-       ;; writes the route slice and can fire the target route's :on-match work,
-       ;; with no browser history to anchor it.
-       :fx (if request
-             [[:rf.server/redirect {:status 303 :location "/cart"}]]      ;; server: POST-redirect-GET
-             [[:dispatch [:rf.route/navigate {:to :route/cart}]]])})))    ;; client: shipped routing event
+    (let [explanation (m/explain AddToCartForm form-params)          ;; nil when the form is clean
+          fields      (select-keys form-params [:item-id :quantity])] ;; editable fields ONLY — never the token
+      (cond
+        (not= (:csrf-token form-params) active-token)    ;; CSRF first — fail closed
+        {:db (assoc-in db [:cart :add-form :errors :_form] ["Session expired. Refresh and retry."])
+         :fx [[:rf.server/set-status 403]]}
+
+        ;; THE validation branch, and it is not optional. `:schema` above elides
+        ;; from the release build, so this is the only check standing between an
+        ;; untrusted POST body and app-db in production. Repopulate `:draft`
+        ;; before writing the errors: with JS off the re-render reads the SLICE,
+        ;; not the POST body, so skipping it hands the user a blank form.
+        (some? explanation)
+        {:db (-> db
+                 (assoc-in [:cart :add-form :draft] fields)
+                 (write-form-errors [:cart :add-form] (explain->errors explanation)))
+         :fx [[:rf.server/set-status 400]]}
+
+        :else
+        {:db (-> db
+                 (update-in [:cart :items] (fnil conj []) fields)
+                 (assoc-in  [:cart :add-form :status] :submitted))
+         ;; ONE destination, CHOSEN by a platform boundary the handler already
+         ;; reads: the :rf.server/request cofx is present on the server and, being
+         ;; :platforms #{:server}, skipped (absent) on the client. Server → the
+         ;; POST-redirect-GET 303; client → in-app navigation. We do NOT emit both:
+         ;; :rf.route/navigate is not a server no-op — dispatched server-side it
+         ;; writes the route slice and can fire the target route's :on-match work,
+         ;; with no browser history to anchor it.
+         :fx (if request
+               [[:rf.server/redirect {:status 303 :location "/cart"}]]      ;; server: POST-redirect-GET
+               [[:dispatch [:rf.route/navigate {:to :route/cart}]]])}))))   ;; client: shipped routing event
 ```
+
+`m` / `me` are `malli.core` / `malli.error`; `write-form-errors` and `explain->errors` are app-level helpers (`spec/Pattern-FormAction.md` gives both in full). The point is that the call sits in the **handler body**, where it survives into the release build. `:rf.schema/at-boundary` does not substitute for it: its check *is* ungated and a rejection does answer `400` via the SSR error projector, but it skips the handler, so the user gets a generic public-error body rather than their own form back with the values they typed.
 
 The success path is the only platform-divergent slot, and the handler **chooses** the destination — it does not emit both. The boundary is one the handler already reads: the `:rf.server/request` cofx is present on the server and, being `:platforms #{:server}`, is skipped (absent) on the client, so `(if request …)` is a clean platform switch. On the server, emit the server-only POST-redirect-GET fx `:rf.server/redirect`; on the client, navigate in-app via the shipped routing event `[:rf.route/navigate {:to :route/cart}]`. Do **not** emit both and label the navigate "client-only": `:rf.route/navigate` is **not** a server no-op — dispatched server-side it writes the route slice and can run the target's `:on-match` loaders even though there is no browser history. (`:rf.route/navigate` is the framework's programmatic-navigation event, registered by `day8/re-frame2-routing`; there is **no** `:rf.nav/navigate` fx.) For a **raw URL** rather than a route id, the shipped request grammar takes one directly — `[:rf.route/navigate {:url "/cart"}]` (the `:url` escape hatch) — so **no app-owned navigation fx is needed**. Reserve an app-owned fx only for a deliberate routing *bypass* that skips the router entirely (a hard `window.location` assignment, an external redirect), on the rare occasion you actually want that.
 
@@ -105,7 +123,9 @@ The scrub is per-named-path, owned by the registration, not a whole-action toggl
 ## Anti-patterns
 
 - **Skipping the `action` attribute.** A JS-only form breaks progressive enhancement. Always emit `method` + `action`; `:on-submit` is additive.
-- **Validating only on the client.** Client validation is UX; the server is the authority. Re-run the schema check via `:schema` on every POST — never trust the body.
+- **Validating only on the client.** Client validation is UX; the server is the authority. Re-check the body in the **handler**, on every POST.
+- **Letting `:schema` be the server-side check.** The commonest way to ship an unvalidated form endpoint: declare `:schema`, read it as "the framework checks this", write no branch. It elides from the production build, so the endpoint that passes every test accepts anything in production. Keep the `:schema` as the dev tripwire and the introspection surface; write the branch as the guard.
+- **Dropping the user's input on the failure path.** `write-form-errors` writes `:status` / `:errors` / `:submit-attempted?` — not `:draft`. With JS on the browser still holds the field values so nothing looks wrong; with JS off the server renders the fields from the slice and the user gets an empty form above "should be at least 1". Repopulate `:draft` from the submitted fields (editable fields only) before writing the errors.
 - **Emitting both the redirect and the navigate unconditionally.** `:rf.route/navigate` is **not** a server no-op — dispatched on the server it writes the route slice and can run the target's `:on-match` work, with no browser history to back it. Choose per platform (the `:rf.server/request` cofx, present only on the server, is the boundary): `:rf.server/redirect` for the server's POST-redirect-GET, `[:rf.route/navigate …]` for the client. (And do not invent `:rf.nav/navigate` — it does not exist; `:rf.route/navigate` is the shipped programmatic-navigation event.)
 - **`302 Found` for POST success.** Some clients re-POST on 302; the canonical status is **303 See Other**. Set `:status 303` explicitly.
 - **CSRF token from a hardcoded value or query string.** Sessions rotate tokens; your app-owned `:app.csrf/active-token` cofx is the single source of truth. URL-borne tokens leak to referrer logs.

--- a/skills/re-frame2/patterns/form-action.md
+++ b/skills/re-frame2/patterns/form-action.md
@@ -61,11 +61,20 @@ The view runs on both platforms; the `action` attribute is what makes it work JS
    :schema [:cat [:= :cart/add-item] AddToCartForm]      ;; DEV TRIPWIRE ONLY — elided in production
    :rf.cofx/requires [:rf.server/request
                       :app.csrf/active-token]}            ;; app-owned cofx — see §CSRF
-  (fn [{:keys [db rf.server/request app.csrf/active-token]} [_ form-params]]
-    (let [explanation (m/explain AddToCartForm form-params)          ;; nil when the form is clean
-          fields      (select-keys form-params [:item-id :quantity])] ;; editable fields ONLY — never the token
+  (fn [{:keys [db] :as cofx} [_ form-params]]
+    (let [;; Both declared cofx are :platforms #{:server}. A platform-skipped
+          ;; supplier delivers NO KEY, so key PRESENCE is the platform test —
+          ;; not truthiness, since a delivered-but-unpopulated slot is a
+          ;; present key carrying nil.
+          server?      (contains? cofx :rf.server/request)
+          active-token (:app.csrf/active-token cofx)
+          explanation  (m/explain AddToCartForm form-params)          ;; nil when the form is clean
+          fields       (select-keys form-params [:item-id :quantity])] ;; editable fields ONLY — never the token
       (cond
-        (not= (:csrf-token form-params) active-token)    ;; CSRF first — fail closed
+        ;; CSRF first — fail closed. Guarded on `server?`: the token check is
+        ;; the POST entry point's, and on the client `active-token` is ABSENT,
+        ;; so an unguarded compare 403s every client submission.
+        (and server? (not= (:csrf-token form-params) active-token))
         {:db (assoc-in db [:cart :add-form :errors :_form] ["Session expired. Refresh and retry."])
          :fx [[:rf.server/set-status 403]]}
 
@@ -84,21 +93,22 @@ The view runs on both platforms; the `action` attribute is what makes it work JS
         {:db (-> db
                  (update-in [:cart :items] (fnil conj []) fields)
                  (assoc-in  [:cart :add-form :status] :submitted))
-         ;; ONE destination, CHOSEN by a platform boundary the handler already
-         ;; reads: the :rf.server/request cofx is present on the server and, being
-         ;; :platforms #{:server}, skipped (absent) on the client. Server → the
-         ;; POST-redirect-GET 303; client → in-app navigation. We do NOT emit both:
-         ;; :rf.route/navigate is not a server no-op — dispatched server-side it
-         ;; writes the route slice and can fire the target route's :on-match work,
-         ;; with no browser history to anchor it.
-         :fx (if request
+         ;; ONE destination, CHOSEN. We do NOT emit both: :rf.route/navigate is
+         ;; an EVENT reached through :dispatch, and :dispatch has no platform
+         ;; gate — dispatched server-side it writes the route slice and can fire
+         ;; the target route's work, with no browser history to anchor it.
+         ;; (:rf.server/redirect, being a :platforms #{:server} fx, WOULD lapse
+         ;; on the client. Only one of the two is self-cancelling.)
+         :fx (if server?
                [[:rf.server/redirect {:status 303 :location "/cart"}]]      ;; server: POST-redirect-GET
                [[:dispatch [:rf.route/navigate {:to :route/cart}]]])}))))   ;; client: shipped routing event
 ```
 
 `m` / `me` are `malli.core` / `malli.error`; `write-form-errors` and `explain->errors` are app-level helpers (`spec/Pattern-FormAction.md` gives both in full). The point is that the call sits in the **handler body**, where it survives into the release build. `:rf.schema/at-boundary` does not substitute for it: its check *is* ungated and a rejection does answer `400` via the SSR error projector, but it skips the handler, so the user gets a generic public-error body rather than their own form back with the values they typed.
 
-The success path is the only platform-divergent slot, and the handler **chooses** the destination — it does not emit both. The boundary is one the handler already reads: the `:rf.server/request` cofx is present on the server and, being `:platforms #{:server}`, is skipped (absent) on the client, so `(if request …)` is a clean platform switch. On the server, emit the server-only POST-redirect-GET fx `:rf.server/redirect`; on the client, navigate in-app via the shipped routing event `[:rf.route/navigate {:to :route/cart}]`. Do **not** emit both and label the navigate "client-only": `:rf.route/navigate` is **not** a server no-op — dispatched server-side it writes the route slice and can run the target's `:on-match` loaders even though there is no browser history. (`:rf.route/navigate` is the framework's programmatic-navigation event, registered by `day8/re-frame2-routing`; there is **no** `:rf.nav/navigate` fx.) For a **raw URL** rather than a route id, the shipped request grammar takes one directly — `[:rf.route/navigate {:url "/cart"}]` (the `:url` escape hatch) — so **no app-owned navigation fx is needed**. Reserve an app-owned fx only for a deliberate routing *bypass* that skips the router entirely (a hard `window.location` assignment, an external redirect), on the rare occasion you actually want that.
+Two slots diverge by platform — the CSRF compare and the success destination — and the handler **chooses** both from one test rather than emitting both arms. The boundary is one it already reads: `:rf.server/request` is `:platforms #{:server}`, and a platform-skipped supplier contributes **no key** to the coeffect map, so `(contains? cofx :rf.server/request)` is a clean platform switch. Use `contains?`, not `(if request …)`: on the server the key can legitimately be present carrying `nil` (a supplier that ran but found its slot unpopulated), and truthiness would read that as "client".
+
+Do **not** emit the redirect and the navigate together and label the navigate "client-only". `:rf.route/navigate` is **not** a server no-op — it is an event, `:dispatch` carries no platform gate, and dispatched server-side it writes the route slice and can run the target's `:on-match` work with no browser history behind it. `:rf.server/redirect` *would* lapse on the client, being a `:platforms #{:server}` fx; only one of the two cancels itself, which is why the handler picks. (`:rf.route/navigate` is the framework's programmatic-navigation event, registered by `day8/re-frame2-routing`; there is **no** `:rf.nav/navigate` fx.) For a **raw URL** rather than a route id, the shipped request grammar takes one directly — `[:rf.route/navigate {:url "/cart"}]`, the `:url` escape, exclusive with `:to` — so **no app-owned navigation fx is needed**. Reserve an app-owned fx only for a deliberate routing *bypass* that skips the router entirely (a hard `window.location` assignment, an external redirect), on the rare occasion you actually want that.
 
 ## CSRF
 
@@ -126,7 +136,9 @@ The scrub is per-named-path, owned by the registration, not a whole-action toggl
 - **Validating only on the client.** Client validation is UX; the server is the authority. Re-check the body in the **handler**, on every POST.
 - **Letting `:schema` be the server-side check.** The commonest way to ship an unvalidated form endpoint: declare `:schema`, read it as "the framework checks this", write no branch. It elides from the production build, so the endpoint that passes every test accepts anything in production. Keep the `:schema` as the dev tripwire and the introspection surface; write the branch as the guard.
 - **Dropping the user's input on the failure path.** `write-form-errors` writes `:status` / `:errors` / `:submit-attempted?` — not `:draft`. With JS on the browser still holds the field values so nothing looks wrong; with JS off the server renders the fields from the slice and the user gets an empty form above "should be at least 1". Repopulate `:draft` from the submitted fields (editable fields only) before writing the errors.
-- **Emitting both the redirect and the navigate unconditionally.** `:rf.route/navigate` is **not** a server no-op — dispatched on the server it writes the route slice and can run the target's `:on-match` work, with no browser history to back it. Choose per platform (the `:rf.server/request` cofx, present only on the server, is the boundary): `:rf.server/redirect` for the server's POST-redirect-GET, `[:rf.route/navigate …]` for the client. (And do not invent `:rf.nav/navigate` — it does not exist; `:rf.route/navigate` is the shipped programmatic-navigation event.)
+- **Emitting both the redirect and the navigate unconditionally.** `:rf.route/navigate` is **not** a server no-op — it is an event, `:dispatch` has no platform gate, and dispatched on the server it writes the route slice and can run the target's `:on-match` work with no browser history to back it. (`:rf.server/redirect` *does* lapse on the client; only one arm is self-cancelling.) Choose per platform: `:rf.server/redirect` for the server's POST-redirect-GET, `[:rf.route/navigate …]` for the client. (And do not invent `:rf.nav/navigate` — it does not exist; `:rf.route/navigate` is the shipped programmatic-navigation event, and `{:url "/cart"}` handles a raw URL without any app-owned fx.)
+- **Testing the platform by truthiness.** `(if request …)` is not `(if (contains? cofx :rf.server/request) …)`. A platform-skipped supplier delivers no key; a server-side supplier that ran and found its slot unpopulated delivers the key carrying `nil`. Truthiness reads the second case as "client" and dispatches a browser navigation on a request thread.
+- **Running the CSRF compare on both platforms.** `:app.csrf/active-token` is server-only, so on the client it is absent and `(not= (:csrf-token form-params) nil)` is true for every submission — the handler 403s the whole client path. Guard the arm on the same platform test the success path uses.
 - **`302 Found` for POST success.** Some clients re-POST on 302; the canonical status is **303 See Other**. Set `:status 303` explicitly.
 - **CSRF token from a hardcoded value or query string.** Sessions rotate tokens; your app-owned `:app.csrf/active-token` cofx is the single source of truth. URL-borne tokens leak to referrer logs.
 - **Writing `app-db` from a multipart handler.** The drain runs to fixed point — a long upload inside the handler blocks the request thread. Hand the opaque `:tempfile` to a storage fx.

--- a/spec/Pattern-FormAction.md
+++ b/spec/Pattern-FormAction.md
@@ -18,7 +18,7 @@ A six-step shape:
 1. **The HTML form** renders with `method="POST" action="/<route>"` and a hidden CSRF token. Standard Pattern-Forms slice drives the field values (server-rendered from `app-db`).
 2. **The host adapter receives the POST**. Per [011-SSR.md §HTTP response contract](011-SSR.md#http-response-contract), the host owns the wire layer; it MUST parse the request body (form-urlencoded or multipart), bind it to `*current-request*` under a `:form-params` slot, and create a per-request frame.
 3. **`:rf/server-init` dispatches**, declaring `{:rf.cofx/requires [:rf.server/request]}`. The event reads `:request-method`, `:uri`, and `:form-params` from the supplied request coeffect; on POST it dispatches the domain event (e.g. `[:cart/add-item form-params]`); on GET it dispatches the standard page-load loader (Pattern-SSR-Loaders applies).
-4. **The domain event handler validates the form-params in its own body** and branches on the result — the same shape it already uses for the CSRF check. On failure it writes structured errors into the form slice's `:errors` map (per [Pattern-Forms §Form slice](Pattern-Forms.md#the-form-slice)), emits `[:rf.server/set-status 400]`, and lets the drain settle; the standard SSR render reads the slice and emits the form again with errors. On success it runs the side effect (DB write, external API call), then emits either `:rf.server/redirect` (success path) or writes a structural success flag plus the standard re-render. The handler's `:schema` metadata is a development tripwire that does not run in a production build, so it cannot be the thing that rejects a bad POST — see [§Validation is the handler's job](#validation-is-the-handlers-job).
+4. **The domain event handler validates the form-params in its own body** and branches on the result — the same shape it already uses for the CSRF check. On failure it writes the submitted values back into the form slice's `:draft` and structured errors into its `:errors` map (per [Pattern-Forms §Form slice](Pattern-Forms.md#the-form-slice)), emits `[:rf.server/set-status 400]`, and lets the drain settle; the standard SSR render reads the slice and emits the form again, populated, with the errors beside the fields. On success it runs the side effect (DB write, external API call), then emits either `:rf.server/redirect` (success path) or writes a structural success flag plus the standard re-render. The handler's `:schema` metadata is a development tripwire that does not run in a production build, so it cannot be the thing that rejects a bad POST — see [§Validation is the handler's job](#validation-is-the-handlers-job).
 5. **The drain settles**, the SSR emitter runs (or is short-circuited by `:rf.server/redirect`), and the host adapter materialises the response accumulator (read via `get-response`).
 6. **Once JS hydrates**, the form's `:on-submit` handler intercepts the native submission, calls `(.preventDefault e)`, and dispatches the *same* domain event the server dispatched. The handler tree is identical; only the dispatch site differs.
 
@@ -105,7 +105,11 @@ The `action` attribute is what makes the form work without JS: the browser will 
    :rf.cofx/requires [:rf.server/request                       ;; server request context
                       :app.csrf/active-token]}                 ;; app-owned cofx — see §CSRF
   (fn [{:keys [db rf.server/request app.csrf/active-token]} [_ form-params]]
-    (let [explanation (m/explain AddToCartForm form-params)]   ;; nil when the form is clean
+    (let [explanation (m/explain AddToCartForm form-params)   ;; nil when the form is clean
+          ;; The editable fields, and only those. `:csrf-token` is a secret
+          ;; carrier and never belongs in a slice the page re-renders — the
+          ;; view emits a fresh one from the session on every render.
+          fields      (select-keys form-params [:item-id :quantity])]
       (cond
         ;; CSRF first — fail closed before any state mutation.
         (not= (:csrf-token form-params) active-token)
@@ -116,18 +120,22 @@ The `action` attribute is what makes the form work without JS: the browser will 
         ;; The validation branch. Same shape as the CSRF arm above, and just as
         ;; mandatory: `:schema` is a dev tripwire, so this is the only check
         ;; standing between an untrusted POST body and the cart in production.
+        ;; The submitted values go back into `:draft` before the errors do.
+        ;; With JS off the re-render reads the SLICE, not the POST body, so
+        ;; without this write the user's input is silently dropped.
         (some? explanation)
-        {:db (write-form-errors db [:cart :add-form] (explain->errors explanation))
+        {:db (-> db
+                 (assoc-in [:cart :add-form :draft] fields)
+                 (write-form-errors [:cart :add-form] (explain->errors explanation)))
          :fx [[:rf.server/set-status 400]]}
 
         :else
-        (let [draft (select-keys form-params [:item-id :quantity])]
-          {:db (-> db
-                   (update-in [:cart :items] (fnil conj []) draft)
-                   (assoc-in  [:cart :add-form :status] :submitted)
-                   (assoc-in  [:cart :add-form :submitted] draft))
-           :fx [[:rf.server/redirect {:status 303 :location "/cart"}]   ;; server only
-                [:dispatch [:rf.route/navigate {:to :route/cart}]]]})))))     ;; client only — shipped routing event
+        {:db (-> db
+                 (update-in [:cart :items] (fnil conj []) fields)
+                 (assoc-in  [:cart :add-form :status] :submitted)
+                 (assoc-in  [:cart :add-form :submitted] fields))
+         :fx [[:rf.server/redirect {:status 303 :location "/cart"}]   ;; server only
+              [:dispatch [:rf.route/navigate {:to :route/cart}]]]}))))     ;; client only — shipped routing event
 ```
 
 `write-form-errors` and `explain->errors` are app-level helpers — the first writes the standard `:errors` / `:status` / `:submit-attempted?` triple into a form slice, the second turns a validator explanation into the per-field error map [Pattern-Forms](Pattern-Forms.md) expects. Both are given below.
@@ -136,17 +144,19 @@ The success path emits both a `303 See Other` (the canonical POST-redirect-GET p
 
 ### Validation is the handler's job
 
-A form POST is untrusted input arriving on a production server, and the response it deserves — `400` plus the form re-rendered with inline errors — has to be produced by code that is actually in the production build. The handler's own `cond` arm is that code. Everything the framework offers around it is a development aid:
+A form POST is untrusted input arriving on a production server, and the response it deserves — `400`, plus the form re-rendered with inline errors and the user's values still in the fields — has to be produced by code that is actually in the production build. The handler's own `cond` arm is that code. Three framework surfaces sit close enough to be mistaken for it, and it is worth being precise about how far each one gets:
 
-- **`:schema` on `reg-event` is a tripwire, not a guard.** Per [010 §Production builds](010-Schemas.md#production-builds), every dev-time validation site is compile-time eliminated under `:advanced` + `goog.DEBUG=false` (and on the JVM under `-Dre-frame.debug=false`). On a production server the `:schema` check never runs, `:rf.error/schema-validation-failure` never fires, and a POST body that violates `AddToCartForm` flows straight into the handler body. Keep the `:schema` — it catches the day someone deletes the branch, and it is what tools and agents introspect — but never let it be the check.
-- **`:rf.schema/at-boundary` does not fill the gap here.** The boundary interceptor ([010 §Production builds](010-Schemas.md#production-builds)) does force the `:schema` check to survive elision, which is exactly right for an untrusted HTTP response or websocket frame. But its only recovery is to skip the handler, and a skipped handler writes no `:errors` and emits no status — so in a production build a malformed POST would answer `200` with the page unchanged and the user's submission silently dropped. An ingress that must *answer* cannot delegate its answer to an interceptor that can only decline. Reach for `:rf.schema/at-boundary` on the fire-and-forget ingress events described in 010; on a form action, write the branch.
-- **The error projector's 400 arm is a dev convenience.** [011 §Server error projection](011-SSR.md#server-error-projection) does map `:rf.error/schema-validation-failure` to a 400 public error, but that mapping is fed by the dev-gated trace stream, so it fires in dev and is silent in a release build. The status your users get comes from the handler's `[:rf.server/set-status 400]`.
+- **`:schema` on `reg-event` is a tripwire, not a guard.** Per [010 §Production builds](010-Schemas.md#production-builds), every dev-time validation site is compile-time eliminated under `:advanced` + `goog.DEBUG=false` (and on the JVM under `-Dre-frame.debug=false`). On a production server the `:schema` check never runs, and a POST body that violates `AddToCartForm` flows straight into the handler body. Keep the `:schema` — it catches the day someone deletes the branch, and it is what tools and agents introspect — but never let it be the check. This one gets nowhere in production.
+- **`:rf.schema/at-boundary` gets you a status, not a page.** The boundary interceptor ([010 §Production builds](010-Schemas.md#production-builds)) forces the `:schema` check past elision: its check is ungated and runs in every build, which is exactly right for an untrusted HTTP response or websocket frame. A rejection in a release build is real and it is visible — the handler is skipped so the payload never reaches `app-db`, one always-on structural `:rf.error/schema-validation-failure` record is fanned (`:source :boundary`, identifiers only — no event vector, no offending value, because a boundary payload is attacker-controlled by definition), the event-emit record settles `:outcome :rejected`, and the SSR error projector turns that record into a `400` ([011 §Server error projection](011-SSR.md#server-error-projection)). What the interceptor cannot do is *shape* the answer. A skipped handler writes no `:errors`, keeps no submitted values, and re-renders no form, so the user is handed a generic public-error body instead of their own form back. Reach for `:rf.schema/at-boundary` on the fire-and-forget ingress events described in 010, where a status is the whole answer owed; on a form action, write the branch.
+- **The error projector answers in the public-error shape, which is not a form.** [011 §Server error projection](011-SSR.md#server-error-projection) maps `:rf.error/schema-validation-failure` to a `400`, and that arm does reach a release server — but only via the record a boundary rejection fans, because that is the only schema-validation failure a production build still produces. It never sees a `:schema` step-1 failure, since in production there is no step-1 check left to fail. And what it emits is a status and a generic body. The field errors above the inputs, and the values the user typed, come from the handler's `[:rf.server/set-status 400]` and the slice it wrote.
 
-This is the same division of labour the rest of the corpus draws: the handler *guards* and ships to production, the schema *declares* and vanishes ([010 §Production builds](010-Schemas.md#production-builds)). The CSRF check in the worked example above was always written this way — an explicit arm, failing closed with its own status — and form validation is the same kind of rule, so it gets the same shape.
+So the gap the handler's arm closes is not "nothing else runs" — under [000 §C-000.35](000-Vision.md#contract--pattern-obligations) what the *programmer* declares is a development aid and elides, while what the *framework* promises about its own boundaries holds in every build, and the boundary interceptor is one of the latter. The gap is narrower and more stubborn: a form action owes the user a *page*, and only handler code can compose one. The CSRF check in the worked example above was always written this way — an explicit arm, failing closed with its own status — and form validation is the same kind of rule, so it gets the same shape.
 
 ### Failure path — re-render with errors
 
-When validation fails (e.g. `quantity = 0`), the handler's validation arm runs: it writes the `:errors` map into the form slice, emits `[:rf.server/set-status 400]`, and returns without touching the cart. The drain then proceeds normally — `render-to-string` emits the same page with the error message above the quantity input, and the host adapter materialises the 400. The user sees their bad input plus the validation error; no information is lost. Every step of that runs in a release build, because every step of it is ordinary handler code.
+When validation fails (e.g. `quantity = 0`), the handler's validation arm runs: it writes the submitted fields into the slice's `:draft` and the `:errors` map beside them, emits `[:rf.server/set-status 400]`, and returns without touching the cart. The drain then proceeds normally — `render-to-string` emits the same page with the error message above the quantity input, and the host adapter materialises the 400. Every step of that runs in a release build, because every step of it is ordinary handler code.
+
+**The `:draft` write is what makes the no-JS path honest, and it is easy to leave out.** After hydration the browser still holds the form state, so a re-render appears to preserve the user's input whether or not the handler wrote it. With JS off there is no browser state to fall back on: the server renders the fields from `[:cart :add-form :draft]`, and if the failure arm only wrote `:errors` the page comes back with the pre-submit draft — an empty quantity box above the message "should be at least 1". The arm therefore repopulates the draft before writing the errors. Only the editable fields go back: `:csrf-token` is a secret carrier, it has no business in a slice the page re-renders, and the view emits a fresh one from the session anyway.
 
 The two helpers the arm leans on are plain functions, shared across the app's forms:
 
@@ -249,9 +259,9 @@ Either is acceptable; the worked example above uses the direct-args form for the
 
 ## Composition with the error projector
 
-The default error projector ([011 §Server error projection](011-SSR.md#server-error-projection)) maps `:rf.error/schema-validation-failure` to a 400 response with the public-error shape — in **development builds**. That category rides the dev-gated trace stream and elides with it, so a release server never projects it. Treat the projector as the thing that gives your dev server a sensible status while you are working, and the handler's `[:rf.server/set-status 400]` as the thing that gives your users one.
+The default error projector ([011 §Server error projection](011-SSR.md#server-error-projection)) maps `:rf.error/schema-validation-failure` to a 400 response with the public-error shape, and it does so on a release server as well as in development — but the only such record a release server produces is the one a `:rf.schema/at-boundary` rejection fans, since the dev-time `:schema` arms that feed the category in development have been elided by then. A form action that has not attached the boundary interceptor never reaches this arm in production at all.
 
-The projector still earns its place on the production path for the categories that *do* survive elision — the 500-class failures the always-on error-emit substrate carries ([009 §What IS available in production](009-Instrumentation.md#what-is-available-in-production)). A form action therefore composes with it in one direction only: the handler owns the 4xx, the projector owns the 5xx.
+Which is fine, because the arm is the wrong instrument for a form anyway: it yields a status and a public-error body, and a form action owes a re-rendered page. Treat the projector as the thing that answers when nobody else can, and the handler's `[:rf.server/set-status 400]` as the thing that answers *well*. The projector's clearer claim on the production path is the 500-class — the failures the always-on error-emit substrate carries ([009 §What IS available in production](009-Instrumentation.md#what-is-available-in-production)). A form action therefore composes with it in one direction: the handler owns the 4xx it can shape, the projector owns the 5xx nobody can.
 
 An action without a form slice (a pure-API endpoint sharing the action-event surface) writes the same branch and emits the same status; it just returns the public-error shape instead of re-rendering a page.
 
@@ -259,7 +269,7 @@ An action without a form slice (a pure-API endpoint sharing the action-event sur
 
 - **Skipping the `action` attribute.** A form without `method` and `action` only works with JS — the progressive-enhancement guarantee breaks. Always emit the attributes; the `:on-submit` interceptor is purely additive.
 - **Validating only on the client.** Client validation is for UX; the server is the authority. The action handler MUST re-check the POST body in its own body — never trust what the browser sent.
-- **Letting `:schema` be the server-side validation.** The commonest way to ship an unvalidated form endpoint: declare `:schema` on the action handler, read it as "the framework checks this", and write no branch. It is a dev tripwire and is absent from the production build ([010 §Production builds](010-Schemas.md#production-builds)), so the endpoint that passes every test accepts anything in production. Attaching `:rf.schema/at-boundary` does not rescue it either — the interceptor can skip the handler but cannot answer the request, so the failure becomes a silent 200. See [§Validation is the handler's job](#validation-is-the-handlers-job).
+- **Letting `:schema` be the server-side validation.** The commonest way to ship an unvalidated form endpoint: declare `:schema` on the action handler, read it as "the framework checks this", and write no branch. It is a dev tripwire and is absent from the production build ([010 §Production builds](010-Schemas.md#production-builds)), so the endpoint that passes every test accepts anything in production. Attaching `:rf.schema/at-boundary` gets you further than nothing — the interceptor's check is ungated, so the payload is refused and the projector answers 400 — but it skips the handler, so the user gets a generic error body instead of their form back, with everything they typed gone. See [§Validation is the handler's job](#validation-is-the-handlers-job).
 - **Using a client-navigation event for the server redirect.** The client routing event `[:rf.route/navigate …]` is a no-op on the server ([011 §`:platforms` metadata on `reg-fx`](011-SSR.md#platforms-metadata-on-reg-fx)); use `:rf.server/redirect` (the server-only fx) for the POST-redirect-GET pattern. (And do not reach for a navigate fx under `:rf.nav/*` — the framework ships none; `:rf.route/navigate` is the shipped programmatic-navigation event.)
 - **Reading the CSRF token from a hardcoded value or a query string.** Sessions rotate tokens; cofx-binding via the app-owned `:app.csrf/active-token` is the single source of truth. Apps that put the token in a URL leak it to referrer logs.
 - **Using `302 Found` for POST success.** Some clients re-POST on `302`; the canonical POST-redirect-GET status is `303 See Other`. The `:rf.server/redirect` fx defaults to 302 for GET-side redirects (per [011 §Standard fx](011-SSR.md#standard-fx)); apps MUST explicitly set `:status 303` for post-action redirects.
@@ -276,7 +286,8 @@ A form-action implementation conforms to this convention when:
 - `:rf/server-init` routes GET → page loader; POST → action event. Apps MAY collapse the two when the route's action and loader share an event.
 - The action handler validates `form-params` **in its own body** and branches on the result. This check is what runs on a production server; it is NEVER skipped, even when client validation matches.
 - The action handler ALSO carries a `:schema` matching the form schema, as the dev tripwire and the introspection surface — but the conformance criterion above is not satisfied by the `:schema` alone ([010 §Production builds](010-Schemas.md#production-builds)).
-- On validation failure, the per-form slice's `:errors` map is populated, the handler emits `[:rf.server/set-status 400]`, and the page re-renders; on success, the handler emits `[:rf.server/redirect {:status 303 :location "..."}]`.
+- On validation failure, the handler repopulates the per-form slice's `:draft` from the submitted fields — editable fields only, never a token or other secret carrier — populates its `:errors` map, emits `[:rf.server/set-status 400]`, and the page re-renders. Without the `:draft` write the no-JS path returns a blank form, since the server renders the fields from the slice and not from the POST body.
+- On success, the handler emits `[:rf.server/redirect {:status 303 :location "..."}]`.
 - When the form's fields carry credentials, PII, or other secrets, the credential-bearing app-db slots MUST be marked `{:sensitive? true}` at the schema so a schema-validation-failure trace redacts the value at that path ([010 §`:sensitive?` — privacy in schema-validation error traces](010-Schemas.md#sensitive--privacy-in-schema-validation-error-traces)); on the JS-fetch submit path, the re-POST via `:rf.http/managed` additionally carries the per-request / per-call `:sensitive?` flag ([014 §Per-request / per-call `:sensitive?`](014-HTTPRequests.md#3-per-request--per-call-sensitive)). Sensitivity is a property of the data value at a path, not a flag on the action handler.
 - Multipart uploads expose files as `{:filename :content-type :size :tempfile}` maps; file contents NEVER appear in trace events.
 - The same event runs unchanged on both platforms; platform-divergent effects (server-only `:rf.server/redirect` vs the client-only `:rf.route/navigate` routing event) compose via `:platforms` gating.
@@ -286,7 +297,8 @@ A form-action implementation conforms to this convention when:
 - [011-SSR.md §Server-only `reg-cofx` for request context](011-SSR.md#server-only-reg-cofx-for-request-context) — the `:rf.server/request` cofx the host adapter binds.
 - [011-SSR.md §HTTP response contract](011-SSR.md#http-response-contract) — the side-channel response accumulator (read via `get-response`) and the seven standard server-only fxs.
 - [011-SSR.md §Standard fx](011-SSR.md#standard-fx) — `:rf.server/redirect` and the multi-status policy.
-- [011-SSR.md §Server error projection](011-SSR.md#server-error-projection) — the default mapping from `:rf.error/schema-validation-failure` to a 400 public-error response.
+- [011-SSR.md §Server error projection](011-SSR.md#server-error-projection) — the default mapping from `:rf.error/schema-validation-failure` to a 400 public-error response, and which build each of its inputs survives into.
+- [000-Vision.md §C-000.35](000-Vision.md#contract--pattern-obligations) — the ownership line this pattern's validation story rests on: a `:schema` the programmer declares elides; a check the framework makes on its own boundaries holds in every build.
 - [011-SSR.md §`:platforms` metadata on `reg-fx`](011-SSR.md#platforms-metadata-on-reg-fx) — the platform-gating that lets one handler emit both server and client effects.
 - [010-Schemas.md §Validation timing](010-Schemas.md#validation-timing) — the `:schema` check that runs on every dispatched event in a development build.
 - [010-Schemas.md §Production builds](010-Schemas.md#production-builds) — why that check is absent from a release build, and what `:rf.schema/at-boundary` does and does not cover. The reason this pattern's validation lives in the handler.

--- a/spec/Pattern-FormAction.md
+++ b/spec/Pattern-FormAction.md
@@ -102,17 +102,27 @@ The `action` attribute is what makes the form work without JS: the browser will 
 (rf/reg-event :cart/add-item
   {:doc              "Add an item to the user's cart. Runs on both platforms; the POST entry point lives on the server."
    :schema           [:cat [:= :cart/add-item] AddToCartForm]  ;; DEV TRIPWIRE ONLY — elided in production (010 §Production builds)
-   :rf.cofx/requires [:rf.server/request                       ;; server request context
+   :rf.cofx/requires [:rf.server/request                       ;; server request context — SERVER-ONLY, see below
                       :app.csrf/active-token]}                 ;; app-owned cofx — see §CSRF
-  (fn [{:keys [db rf.server/request app.csrf/active-token]} [_ form-params]]
-    (let [explanation (m/explain AddToCartForm form-params)   ;; nil when the form is clean
+  (fn [{:keys [db] :as cofx} [_ form-params]]
+    (let [;; Both declared coeffects above are `:platforms #{:server}`. A
+          ;; platform-skipped supplier delivers NOTHING — the key is absent from
+          ;; the coeffect map, not present-and-nil — so key PRESENCE is the
+          ;; platform test. Truthiness is not: a delivered-but-unpopulated
+          ;; request slot is a legitimately nil value under a present key.
+          server?      (contains? cofx :rf.server/request)
+          active-token (:app.csrf/active-token cofx)
+          explanation  (m/explain AddToCartForm form-params)   ;; nil when the form is clean
           ;; The editable fields, and only those. `:csrf-token` is a secret
           ;; carrier and never belongs in a slice the page re-renders — the
           ;; view emits a fresh one from the session on every render.
-          fields      (select-keys form-params [:item-id :quantity])]
+          fields       (select-keys form-params [:item-id :quantity])]
       (cond
-        ;; CSRF first — fail closed before any state mutation.
-        (not= (:csrf-token form-params) active-token)
+        ;; CSRF first — fail closed before any state mutation. Guarded on
+        ;; `server?`: the token check belongs to the POST entry point, and on
+        ;; the client `active-token` is absent, so an unguarded compare would
+        ;; measure every client submission against nil and 403 all of them.
+        (and server? (not= (:csrf-token form-params) active-token))
         {:db (assoc-in db [:cart :add-form :errors :_form]
                        ["Session expired. Please refresh and try again."])
          :fx [[:rf.server/set-status 403]]}
@@ -134,13 +144,24 @@ The `action` attribute is what makes the form work without JS: the browser will 
                  (update-in [:cart :items] (fnil conj []) fields)
                  (assoc-in  [:cart :add-form :status] :submitted)
                  (assoc-in  [:cart :add-form :submitted] fields))
-         :fx [[:rf.server/redirect {:status 303 :location "/cart"}]   ;; server only
-              [:dispatch [:rf.route/navigate {:to :route/cart}]]]}))))     ;; client only — shipped routing event
+         ;; ONE destination, CHOSEN. Not both: `:rf.route/navigate` is an EVENT,
+         ;; and `:dispatch` is not platform-gated, so dispatching it on the
+         ;; server really does write the route slice and can run the target's
+         ;; route work — with no browser history to anchor any of it.
+         :fx (if server?
+               [[:rf.server/redirect {:status 303 :location "/cart"}]]   ;; server: POST-redirect-GET
+               [[:dispatch [:rf.route/navigate {:to :route/cart}]]])})))) ;; client: shipped routing event
 ```
 
 `write-form-errors` and `explain->errors` are app-level helpers — the first writes the standard `:errors` / `:status` / `:submit-attempted?` triple into a form slice, the second turns a validator explanation into the per-field error map [Pattern-Forms](Pattern-Forms.md) expects. Both are given below.
 
-The success path emits both a `303 See Other` (the canonical POST-redirect-GET pattern) and a client-side `[:rf.route/navigate {:to :route/cart}]`. On the server, `:platforms` gating no-ops the navigate and the host adapter materialises the redirect — the browser GETs `/cart`, and the cart page renders. On the client (post-hydration), the redirect fx no-ops and `:rf.route/navigate` (the shipped programmatic-navigation event, registered by `day8/re-frame2-routing`) drives the SPA transition. The framework exposes **no** navigate fx under the `:rf.nav/*` namespace (that namespace ships only `push-url`, `replace-url`, `capture-scroll`, and `scroll` fxs); if you need a bare URL push rather than a route id, register an **app-owned** fx (e.g. `:app.nav/navigate`).
+The success path **chooses** its destination; it does not emit both and let the wrong one lapse. On the server it emits the `303 See Other` (the canonical POST-redirect-GET), the host adapter materialises it, the browser GETs `/cart`, and the cart page renders. On the client (post-hydration) it dispatches `[:rf.route/navigate {:to :route/cart}]` — the shipped programmatic-navigation event, registered by `day8/re-frame2-routing` — and the SPA transition runs.
+
+**Why choose rather than emit both.** `:platforms` gating is a property of `reg-fx` and `reg-cofx` ([011 §`:platforms` metadata on `reg-fx`](011-SSR.md#platforms-metadata-on-reg-fx)), so it does neutralise `:rf.server/redirect` on the client. But `:rf.route/navigate` is an **event**, reached through `:dispatch`, and `:dispatch` carries no platform gate. Dispatched on the server it runs: it writes the route slice and can fire the destination route's work, in a per-request frame that is about to be discarded, with no browser history behind any of it. Only one of the two effects is self-cancelling, so the handler picks.
+
+**How the platform is decided.** By the presence of a coeffect key the handler already declares — `:rf.server/request` is `:platforms #{:server}`, and a platform-skipped supplier contributes nothing to the coeffect map, so the key is simply *absent* on the client. Test with `contains?`, not truthiness: on the server the key can legitimately be present carrying `nil` (a supplier that ran but found its slot unpopulated), and a truthiness test would read that as "client" and dispatch a browser navigation on a request thread. One `contains?` is the whole platform boundary this pattern needs; it does not want a platform abstraction.
+
+**For a bare URL rather than a route id**, the shipped request grammar takes one directly — `[:rf.route/navigate {:url "/cart"}]`, the `:url` escape, exclusive with `:to` ([012-Routing.md](012-Routing.md)). No app-owned effect is needed. The framework exposes **no** navigate fx under the `:rf.nav/*` namespace (that namespace ships only `push-url`, `replace-url`, `capture-scroll`, and `scroll` fxs), and reaching for an app-owned one is justified only when you deliberately want to *bypass* the router — a hard `window.location` assignment, an external redirect — which is a different thing from navigating to a URL.
 
 ### Validation is the handler's job
 
@@ -190,7 +211,7 @@ The token lives in two places in `app-db` (both at app-owned slots):
 - `[:app.csrf :session-token]` — the per-session token, seeded by `:rf/server-init` from the request's session/cookie via the `:rf.server/request` cofx.
 - `[:app.csrf :form-token]` — the token rendered into the form (same value as `:session-token` for double-submit, or a freshly-rotated value for sync-pattern tokens). The view subscribes to an app-owned `[:app.csrf/token]` and emits a `<input type="hidden" name="csrf-token" value="…">`.
 
-An app-owned `:app.csrf/active-token` cofx exposes the session token to action handlers; the handler compares against the form-submitted `:csrf-token` field and fails-closed with 403 on mismatch (see the worked example above).
+An app-owned `:app.csrf/active-token` cofx exposes the session token to action handlers; the handler compares against the form-submitted `:csrf-token` field and fails-closed with 403 on mismatch (see the worked example above). Register it `:platforms #{:server}` — the check guards the POST entry point, and there is no session token to read on the client. That makes the arm a server arm: it must be guarded on the same coeffect-presence test the success path uses, or a client submission compares its token against an absent coeffect and 403s every time.
 
 ```clojure
 ;; App-owned — re-frame2 ships no CSRF cofx. Register under your app's prefix.
@@ -229,24 +250,29 @@ Apps that need fine-grained file-vs-field privacy (sensitive password field + no
 
 ## Server vs client — same handler tree
 
-The `:cart/add-item` event runs unchanged on both platforms. The differences are:
+The `:cart/add-item` event runs unchanged on both platforms — one registration, one body. The differences are:
 
 | Concern | Server (no-JS submit) | Client (post-hydration submit) |
 |---|---|---|
 | Dispatch site | `:rf/server-init`'s POST branch | view's `:on-submit` handler |
 | Source of `form-params` | parsed by host adapter from POST body | the view's `:draft` slice (Pattern-Forms) |
-| CSRF cofx | app-owned `:app.csrf/active-token` (server-only) | client reads app-owned `[:app.csrf :session-token]` from app-db directly |
+| `:rf.server/request` cofx | delivered | **absent** (platform-skipped) — this is the platform test |
+| CSRF check | compares against the app-owned `:app.csrf/active-token` cofx | not run — the cofx is server-only, and the submission crosses no trust boundary |
 | Success effect | `[:rf.server/redirect …]` (full-page navigation) | `[:dispatch [:rf.route/navigate {:to :route/cart}]]` (SPA navigation, shipped routing event) |
-| Failure render | `render-to-string` re-emits the page with errors | the form view's existing error subs re-render in place |
+| Failure render | `render-to-string` re-emits the page with errors, fields repopulated from `:draft` | the form view's existing error subs re-render in place |
 
-The success/failure effects are the only platform-divergent slot. Apps express this via `:platforms` ([011 §`:platforms` metadata on `reg-fx`](011-SSR.md#platforms-metadata-on-reg-fx)): `:rf.server/redirect` is server-only, so it no-ops on the client; the client-side `:rf.route/navigate` (the shipped programmatic-navigation event) is a no-op on the server. The same event-handler body emits both, and each platform silently no-ops the one it doesn't own. The mental-model claim of [011-SSR.md](011-SSR.md) — "same handler tree both sides" — holds at this layer.
+"Same handler tree both sides" — the mental-model claim of [011-SSR.md](011-SSR.md) — holds at this layer, but it is a claim about the *tree*, not about every effect in it being platform-neutral. Two of the rows above diverge, and both diverge the same way: the handler reads `(contains? cofx :rf.server/request)` and picks an arm.
 
 ```clojure
-;; Inside the action handler — the fx vector can carry both platform-specific effects;
-;; each platform's `:platforms` gating no-ops the wrong one.
-:fx [[:rf.server/redirect {:status 303 :location "/cart"}]   ;; server only
-     [:dispatch [:rf.route/navigate {:to :route/cart}]]]           ;; client only — shipped routing event
+;; Inside the action handler — ONE arm, chosen. `:rf.server/redirect` would
+;; indeed no-op on the client via `:platforms` gating; `[:dispatch [:rf.route/navigate …]]`
+;; would NOT no-op on the server, because `:dispatch` has no platform gate.
+:fx (if server?
+      [[:rf.server/redirect {:status 303 :location "/cart"}]]     ;; server: POST-redirect-GET
+      [[:dispatch [:rf.route/navigate {:to :route/cart}]]])       ;; client: shipped routing event
 ```
+
+A cofx a handler declares but does not always get is not a hazard to route around — it is the cleanest platform boundary available, because the framework already resolved the platform when it decided whether to run the supplier. Declaring the two server-only coeffects and branching on one of them is the whole mechanism; there is no platform abstraction to build here.
 
 ## Composition with `:rf.server/request` cofx
 
@@ -255,7 +281,7 @@ The action handler's input is `form-params`, which the request cofx exposes per 
 - **Direct args**: `:rf/server-init` extracts `:form-params` from the request and dispatches it as the event's args vector — the handler reads via destructuring, no coeffect declaration required. Simpler, recommended for app-level action handlers.
 - **Declared coeffect**: the handler itself declares `{:rf.cofx/requires [:rf.server/request]}` and reads `:form-params` from the supplied request coeffect — useful when the handler also needs other request slots (session, headers, locale) without the dispatcher having to thread them through.
 
-Either is acceptable; the worked example above uses the direct-args form for the form fields and a declared `:rf.server/request` coeffect for CSRF (since CSRF is cross-cutting).
+Either is acceptable; the worked example above uses the direct-args form for the form fields and a declared `:rf.server/request` coeffect for CSRF (since CSRF is cross-cutting). The declared form has a second use once the handler runs on both platforms: because the cofx is `:platforms #{:server}` and a platform-skipped supplier delivers no key at all, `(contains? cofx :rf.server/request)` is a reliable "am I the POST entry point?" test. Handlers that take the direct-args route and still need to branch by platform should declare the coeffect anyway, for that.
 
 ## Composition with the error projector
 
@@ -270,7 +296,9 @@ An action without a form slice (a pure-API endpoint sharing the action-event sur
 - **Skipping the `action` attribute.** A form without `method` and `action` only works with JS — the progressive-enhancement guarantee breaks. Always emit the attributes; the `:on-submit` interceptor is purely additive.
 - **Validating only on the client.** Client validation is for UX; the server is the authority. The action handler MUST re-check the POST body in its own body — never trust what the browser sent.
 - **Letting `:schema` be the server-side validation.** The commonest way to ship an unvalidated form endpoint: declare `:schema` on the action handler, read it as "the framework checks this", and write no branch. It is a dev tripwire and is absent from the production build ([010 §Production builds](010-Schemas.md#production-builds)), so the endpoint that passes every test accepts anything in production. Attaching `:rf.schema/at-boundary` gets you further than nothing — the interceptor's check is ungated, so the payload is refused and the projector answers 400 — but it skips the handler, so the user gets a generic error body instead of their form back, with everything they typed gone. See [§Validation is the handler's job](#validation-is-the-handlers-job).
-- **Using a client-navigation event for the server redirect.** The client routing event `[:rf.route/navigate …]` is a no-op on the server ([011 §`:platforms` metadata on `reg-fx`](011-SSR.md#platforms-metadata-on-reg-fx)); use `:rf.server/redirect` (the server-only fx) for the POST-redirect-GET pattern. (And do not reach for a navigate fx under `:rf.nav/*` — the framework ships none; `:rf.route/navigate` is the shipped programmatic-navigation event.)
+- **Emitting the redirect and the navigate together.** The tempting shape is one `:fx` vector carrying both, on the theory that each platform no-ops the one it does not own. Only half of that is true. `:platforms` gating is a `reg-fx` / `reg-cofx` property ([011 §`:platforms` metadata on `reg-fx`](011-SSR.md#platforms-metadata-on-reg-fx)), so `:rf.server/redirect` really does lapse on the client — but `:rf.route/navigate` is an event reached through `:dispatch`, and `:dispatch` has no platform gate, so on the server it runs: route slice written, destination route work possibly fired, no browser history behind it. Choose one arm per platform from the presence of a server-only coeffect key.
+- **Deciding the platform by truthiness instead of key presence.** `(if request …)` looks equivalent to `(if (contains? cofx :rf.server/request) …)` and is not. A platform-skipped supplier delivers no key; a supplier that *ran* on the server and found its slot unpopulated delivers the key carrying `nil`. Under truthiness the second case reads as "client" and dispatches a browser navigation on a request thread.
+- **Inventing an app-owned effect for a plain URL.** `[:rf.route/navigate {:url "/cart"}]` is shipped — `:url` is the raw-URL escape in the navigate request grammar, exclusive with `:to`. An app-owned navigation effect earns its place only when you mean to bypass the router outright (hard `window.location`, external redirect). And do not reach for a navigate fx under `:rf.nav/*`: the framework ships none.
 - **Reading the CSRF token from a hardcoded value or a query string.** Sessions rotate tokens; cofx-binding via the app-owned `:app.csrf/active-token` is the single source of truth. Apps that put the token in a URL leak it to referrer logs.
 - **Using `302 Found` for POST success.** Some clients re-POST on `302`; the canonical POST-redirect-GET status is `303 See Other`. The `:rf.server/redirect` fx defaults to 302 for GET-side redirects (per [011 §Standard fx](011-SSR.md#standard-fx)); apps MUST explicitly set `:status 303` for post-action redirects.
 - **Relying on per-field redaction in a mixed form.** When a form mixes sensitive (password) and non-sensitive (avatar) fields, split into two POSTs. Redaction is path-marked at the schema slot and applies to the whole value at that path — it is map-level, not field-level — so a single `:sensitive?` mark on a container slot redacts every sibling field under it. Two POSTs (each with its own slot) is the only way to redact one field but not its sibling.
@@ -281,7 +309,7 @@ An action without a form slice (a pure-API endpoint sharing the action-event sur
 A form-action implementation conforms to this convention when:
 
 - The form HTML carries both `method="POST"` and `action="/<route>"`; submit-handler interception is purely additive on top.
-- The form carries a CSRF token in a hidden `<input>` field with name `csrf-token` (or via header for JS-fetch submits); the action handler MUST verify it before any state mutation.
+- The form carries a CSRF token in a hidden `<input>` field with name `csrf-token` (or via header for JS-fetch submits); the action handler MUST verify it on the server, before any state mutation.
 - The host adapter parses POST bodies (form-urlencoded and multipart) and binds them to `*current-request*` under a `:form-params` slot.
 - `:rf/server-init` routes GET → page loader; POST → action event. Apps MAY collapse the two when the route's action and loader share an event.
 - The action handler validates `form-params` **in its own body** and branches on the result. This check is what runs on a production server; it is NEVER skipped, even when client validation matches.
@@ -290,7 +318,7 @@ A form-action implementation conforms to this convention when:
 - On success, the handler emits `[:rf.server/redirect {:status 303 :location "..."}]`.
 - When the form's fields carry credentials, PII, or other secrets, the credential-bearing app-db slots MUST be marked `{:sensitive? true}` at the schema so a schema-validation-failure trace redacts the value at that path ([010 §`:sensitive?` — privacy in schema-validation error traces](010-Schemas.md#sensitive--privacy-in-schema-validation-error-traces)); on the JS-fetch submit path, the re-POST via `:rf.http/managed` additionally carries the per-request / per-call `:sensitive?` flag ([014 §Per-request / per-call `:sensitive?`](014-HTTPRequests.md#3-per-request--per-call-sensitive)). Sensitivity is a property of the data value at a path, not a flag on the action handler.
 - Multipart uploads expose files as `{:filename :content-type :size :tempfile}` maps; file contents NEVER appear in trace events.
-- The same event runs unchanged on both platforms; platform-divergent effects (server-only `:rf.server/redirect` vs the client-only `:rf.route/navigate` routing event) compose via `:platforms` gating.
+- The same event runs unchanged on both platforms, and it **chooses** its platform-divergent arms rather than emitting both: `:rf.server/redirect` on the server, `[:dispatch [:rf.route/navigate …]]` on the client, the server-only CSRF compare on the server alone. The choice is made from the *presence* of a `:platforms #{:server}` coeffect key, `contains?` rather than truthiness. `:platforms` gating on its own is not sufficient here — it neutralises the server-only fx on the client, but `:dispatch` carries no platform gate, so an unconditionally emitted `:rf.route/navigate` does run on the server.
 
 ## Cross-references
 


### PR DESCRIPTION
Two beads, one surface. `spec/Pattern-FormAction.md` is what a reader copies to build a form POST that reaches a server, and its mirror `skills/re-frame2/patterns/form-action.md` is the copyable summary. Both are corrected here.

## Was the code already correct, or does the path genuinely elide?

**Already correct — the elision was fixed at `19ac4ef6e8`.** The pattern's handler runs `m/explain` in its own body and branches, ordinary code present in every build, exactly the `examples/core/login` shape. What the `#7172` audit reopened is narrower and real:

- **rf2-eane2** — the failure arm *lost the user's submission*. `write-form-errors` writes `:status` / `:errors` / `:submit-attempted?` and nothing else, but the view renders its fields from `[:cart :add-form :draft]`. On a no-JS POST that slice still holds the pre-submit draft while the offending values live only in `form-params`, so the page came back with an empty quantity box above "should be at least 1" — while the prose promised "the user sees their bad input; no information is lost". With JS on, the browser's own form state hides it entirely, which is why it survived.
- **rf2-ppi5k** — the routing guidance was never applied to the canonical source at all. `073acbd7e4` corrected the skill leaf; the spec still taught all three rejected shapes, plus a fourth the skill introduced.

## The layer story was also stale, in the other direction

`spec/Pattern-FormAction` still said a malformed POST "would answer `200` with the page unchanged" and that the projector's 400 arm was "a dev convenience, silent in a release build". Since **rf2-mwv4e (#7203)** and **rf2-lvsen (#7207)** both are false: a boundary rejection fans an always-on structural record, settles `:outcome :rejected`, and the SSR projector answers `400`. `docs/ssr/concepts.md` and `docs/api/re-frame.ssr.md` — which link *at* this section for the worked shape — already say so, so the pattern was contradicting its own inbound references.

**The honest grounding turned out to be the stronger one, so nothing normative moved.** The conformance criteria are unchanged and the check stays in the handler. Only the reason is sharper: it is not that nothing else runs — under `000` C-000.35 a framework promise about its own boundaries holds in every build, and the boundary interceptor is one of them. It is that the interceptor and the projector between them produce a **status**, and a form action owes the user a **page**.

## What each corrected site now says, and on which host

| Site | Now says | Host |
|---|---|---|
| Handler validation arm | repopulates `:draft` from the submitted fields before writing `:errors` | **server** (no-JS); inert but harmless on the client |
| `fields` binding | `select-keys [:item-id :quantity]` hoisted, shared by both arms — never `:csrf-token` | both |
| CSRF arm | guarded on `server?`; unguarded it compared the token against an **absent** coeffect and 403'd every client submission | **server only** |
| Platform test | `(contains? cofx :rf.server/request)`, not `(if request …)` — a skipped supplier delivers no key, but a *delivered-but-unpopulated* slot is a present key carrying `nil` | both |
| Success `:fx` | **one arm chosen**: `:rf.server/redirect` \| `[:dispatch [:rf.route/navigate …]]` | one each |
| Bare URL | `[:rf.route/navigate {:url "/cart"}]` — the shipped `:url` escape; app-owned fx reserved for a deliberate router *bypass* | client |

The "navigation is a server no-op" claim is gone from the prose, the server-vs-client table, the second code block and the anti-pattern that asserted it. `:platforms` is a `reg-fx` / `reg-cofx` property, so `:rf.server/redirect` really does lapse on the client — but `:rf.route/navigate` is an **event**, `:dispatch` carries no platform gate, and on the server it runs: route slice written, destination route work possibly fired, in a per-request frame about to be discarded. Only one of the two arms is self-cancelling, which is why the handler picks.

The skill mirror carried the eane2 defect class in more copyable form — its `:schema` was annotated `;; server-side schema check, never skipped` and its handler had **no validation branch at all**. Corrected, with three new anti-patterns naming the traps.

## Sweep — further sites found, filed not fixed

All three are outside this fence; none had an existing bead.

- **rf2-j6e7r (P1)** — `spec/Security.md` still says a boundary rejection "reports nothing" / `:outcome :ok` / "a known gap … under review", across **five sites** including the trust-boundary matrix's Build-posture cell and the error-catalogue row. This was rf2-5ny45's item 4, explicitly *reported-not-edited* when that bead closed; the obligation was dropped.
- **rf2-v94d6 (P1)** — `spec/010-Schemas.md:235` says the category "has never been promoted onto the always-on error-emit substrate", **citing spec/009** — which since #7207 says the opposite in its own Channel cell. A reader who follows the citation lands on the correction.
- **rf2-zfw16 (P2)** — `spec/README.md:128`'s index row still says the action handler "validates via `:schema`", the exact claim rf2-eane2 removed from the pattern body.

Confirmed clean by the same sweep: the four eane2 sibling sites (`Pattern-Forms`, `Pattern-RemoteData`, `Construction-Prompts`, `Conventions`) were all corrected by the earlier pass, and no other corpus site teaches the routing defects.

## Quality gates

| Gate | Exit |
|---|---|
| `python -m mkdocs build --strict` | **0** (0 WARNING lines; no message names either changed file) |
| `python scripts/check_doc_slugs.py` | **0** |
| `python scripts/check_keyword_catalogue_drift.py` | **0** |

Docs-only change — no `implementation/**` edit, so no artefact suite applies. Deferred to CI: the full doc/skill drift lane and any repo-wide link gate beyond `mkdocs --strict`.
