### PR TITLE
test(core): the layer-1 memo guard is NOT futile on the flush path for :frame-state (rf2-gncxk)

### DIFF
--- a/implementation/core/test/re_frame/sub_memo_flush_path_cljs_test.cljs
+++ b/implementation/core/test/re_frame/sub_memo_flush_path_cljs_test.cljs
@@ -1,0 +1,175 @@
+(ns re-frame.sub-memo-flush-path-cljs-test
+  "rf2-gncxk — WHICH callers reach the layer-1 memo guard, and on which of
+  them can it actually HIT?
+
+  `subs.memo/make-layer-1-memoised-body` guards the user's sub body with
+  `(= @last-db db)`. The wrapper is handed to the substrate as a
+  `compute-fn`, and on the React-hook spine exactly TWO callers reach it
+  (`substrate/spine.cljs`, `make-derived-value-fn`):
+
+    * `deref-derived` — the READ path. Pull-based: it recomputes on EVERY
+      `-deref`, so this guard is the only thing stopping a view render from
+      re-running every sub body. It hits constantly and it is cheap here,
+      because a repeat read yields the *identical* app-db object and CLJS
+      `=` short-circuits on `identical?`.
+
+    * `flush!` — the WRITE path, run once per dirty entry at epoch drain.
+
+  rf2-gncxk records a proof that the guard is guaranteed to MISS on the
+  flush path: `flush!` runs only if the value was marked dirty, which
+  happens only if the source's `notify` fired, which requires movement by
+  `rf=` — and `rf=` moved implies `=` differs.
+
+  **That proof is sound for `:db` and `:runtime-db`, and UNSOUND for
+  `:frame-state` — all three of which share this one wrapper**
+  (`subs/single-source-input-kinds`). The difference is what sits between
+  the sub and the physical frame-state atom:
+
+    * `:db` / `:runtime-db` read a PROJECTION — a `make-derived-value` whose
+      `notify` is gated on `rf=`. A commit that installs a value-equal
+      app-db does not propagate, so the sub is never marked dirty and
+      `flush!` never runs. The guard genuinely cannot hit on this path.
+
+    * `:frame-state` reads the RAW physical container. A raw atom source is
+      wired through the spine's per-source fan-out coordinator, whose
+      `mark-dirty!` fan-out is NOT movement-gated — it fires on every
+      `reset!`. And `commit-frame-transition!` short-circuits only when both
+      partitions are `identical?`, rebuilding a FRESH partition map
+      otherwise. So a commit whose new app-db is `=`-but-not-`identical?`
+      installs a fresh frame-state, marks every `:frame-state` sub dirty,
+      and reaches the wrapper on the FLUSH path with a value-equal input —
+      where the guard HITS and suppresses the body.
+
+  These two tests pin exactly that asymmetry, so a future change that
+  teaches the flush path to skip the comparison cannot silently start
+  re-running `:frame-state` sub bodies on value-equal commits — which would
+  break Spec 006 §Invalidation algorithm (\"invalidated ONLY when an input
+  changes value by `rf=`\") and turn a spec'd `:rf.sub/skip` into a
+  `:rf.sub/run` (Spec 009 §`:rf.sub/skip`).
+
+  The instrument is the `:rf.sub/skip` trace counted DURING `dispatch-sync`
+  with no interleaved deref: the commit and its epoch drain both complete
+  inside that call, so a skip observed there was emitted by `flush!` and by
+  nothing else.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.subs :as subs]
+            [re-frame.substrate.spine :as spine]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+;; A test-local React-hook spine with inert hook stubs — the same shape the
+;; write-attribution harness builds. It needs no React and mounts nothing; we
+;; only ever drive it through `dispatch-sync` / `subscribe`, which is enough to
+;; exercise the real epoch scheduler and the real `flush!` path. (Core cannot
+;; require an adapter artefact, so the spine is built here rather than borrowed
+;; from `re-frame.adapter.uix`.)
+(def ^:private spine-adapter
+  (spine/make-react-adapter
+    (spine/make-react-spine
+      {:substrate-name        "gncxk-flush-path"
+       :gensym-prefix-sub     "gncxk-sub-"
+       :gensym-prefix-derived "gncxk-derived-"
+       :gensym-prefix-use-sub "gncxk-use-sub-"
+       :use-memo              (fn [t _] (t))
+       :use-callback          (fn [t _] t)
+       :use-context           (fn [_] nil)})
+    {:kind :rf.adapter/gncxk-flush-path :frame-provider nil}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter spine-adapter}))
+
+(defn- skips-for
+  "Count `:rf.sub/skip` trace events naming `sub-id` that are emitted while
+  `body-fn` runs. Callers pass a `body-fn` that performs a `dispatch-sync`
+  and NOTHING else, so every skip counted was emitted from `flush!`."
+  [sub-id body-fn]
+  (let [n (atom 0)
+        k ::skip-probe]
+    (trace-tooling/register-listener!
+      k
+      (fn [ev]
+        (when (and (= :rf.sub/skip (:operation ev))
+                   (= sub-id (get-in ev [:tags :rf.sub/id])))
+          (swap! n inc))))
+    (try (body-fn)
+         (finally (trace-tooling/unregister-listener! k)))
+    @n))
+
+;; ---------------------------------------------------------------------------
+;; :db — the guard CANNOT hit on the flush path (rf2-gncxk's proof, pinned)
+;; ---------------------------------------------------------------------------
+
+(deftest db-sub-guard-never-hits-on-the-flush-path
+  (testing "a value-equal commit never marks a `:db` sub dirty, so `flush!`
+            never runs and the guard is never consulted there — the app-db
+            projection's `rf=` gate absorbed the write one layer up"
+    (rf/with-frame :rf/default
+      (let [runs (atom 0)]
+        (rf/reg-event :seed   (fn [_ _] {:db {:n 42 :other :a}}))
+        ;; a FRESH map that is `=` to the seeded one
+        (rf/reg-event :reseed (fn [_ _] {:db {:n 42 :other :a}}))
+        (rf/reg-event :bump   (fn [{:keys [db]} _] {:db (assoc db :n 43)}))
+        (rf/reg-sub :n (fn [db _] (swap! runs inc) (:n db)))
+        (rf/dispatch-sync [:seed])
+        (let [r (rf/subscribe [:n])]
+          (is (= 42 @r))
+          (is (= 1 @runs) "first deref runs the body")
+          ;; The value-equal commit. No deref inside, so any skip counted
+          ;; would have come from `flush!`.
+          (let [flush-skips (skips-for :n #(rf/dispatch-sync [:reseed]))]
+            (is (zero? flush-skips)
+                "the `:db` sub is never marked dirty by a value-equal commit,
+                 so the memo guard is not reached on the flush path at all"))
+          (is (= 42 @r))
+          (is (= 1 @runs)
+              "body still has not re-run — the projection's rf= gate stopped
+               propagation, and the deref-path guard absorbed the fresh object")
+          ;; A genuine move DOES reach the sub, and the guard MISSES there —
+          ;; which is exactly rf2-gncxk's point: on this path the comparison
+          ;; is paid and is known in advance to fail.
+          (rf/dispatch-sync [:bump])
+          (is (= 43 @r))
+          (is (= 2 @runs) "a real value move re-runs the body"))))))
+
+;; ---------------------------------------------------------------------------
+;; :frame-state — the guard DOES hit on the flush path (the counterexample)
+;; ---------------------------------------------------------------------------
+
+(deftest frame-state-sub-guard-does-hit-on-the-flush-path
+  (testing "a `:frame-state` sub reads the RAW container, whose fan-out is not
+            movement-gated, so a value-equal commit DOES reach the wrapper on
+            the flush path — and the memo guard is what suppresses the body"
+    (rf/with-frame :rf/default
+      (let [runs (atom 0)]
+        (subs/reg-frame-state-sub
+          :whole-state
+          (fn [frame-state _] (swap! runs inc) (:n (:rf.db/app frame-state))))
+        (rf/reg-event :seed   (fn [_ _] {:db {:n 42 :other :a}}))
+        (rf/reg-event :reseed (fn [_ _] {:db {:n 42 :other :a}}))
+        (rf/reg-event :bump   (fn [{:keys [db]} _] {:db (assoc db :n 43)}))
+        (rf/dispatch-sync [:seed])
+        (let [r (rf/subscribe [:whole-state])]
+          (is (= 42 @r))
+          (let [before      @runs
+                ;; The commit installs a FRESH frame-state map (the
+                ;; `identical?` short-circuit in `commit-frame-transition!`
+                ;; does not fire, because the new app-db is a different
+                ;; object), the raw container's coordinator marks this sub
+                ;; dirty unconditionally, and `flush!` invokes the wrapper.
+                flush-skips (skips-for :whole-state #(rf/dispatch-sync [:reseed]))]
+            (is (pos? flush-skips)
+                "THE COUNTEREXAMPLE: the memo guard HIT on the flush path — so
+                 the guard is not universally futile there and a flush-path
+                 fast-path that skips the comparison would re-run this body")
+            (is (= before @runs)
+                "and the hit is load-bearing: the body did NOT re-run on a
+                 value-equal commit (Spec 006 §Invalidation algorithm)"))
+          (is (= 42 @r))
+          ;; A genuine move still recomputes, so the sub is demonstrably live
+          ;; and wired — the assertions above are not passing vacuously.
+          (rf/dispatch-sync [:bump])
+          (is (= 43 @r))
+          (is (= 2 @runs) "a real value move re-runs the body"))))))


### PR DESCRIPTION
## What this is, and what it is not

rf2-gncxk asked for a comparison on the write hot path to stop being paid, on the grounds that it is provably guaranteed to fail. **I did not make that change.** The proof is sound for two of the three input kinds that share the wrapper and **unsound for the third**, and both available fix shapes alter a normative Spec 006 / Spec 009 promise. What lands here is the verification plus two tests that pin the asymmetry, so whoever implements the ruled fix cannot break it silently.

No `src/` file is modified.

## Does the proof hold against current source?

**For `:db` and `:runtime-db` — yes, exactly as the bead states it.** Every link re-verified:

| link | site |
|---|---|
| `flush!` runs only if marked dirty | `spine.cljs:796` `mark-dirty!` |
| marked dirty only if the source's watch fired | `spine.cljs:833-836` |
| a derived source's `notify` requires movement by `rf=` | `spine.cljs:689` `(when-not (rf= prev nu) …)` |
| `rf=` is `Object.is` OR `=` | `spine.cljs:570` |
| the source *is* an `rf=`-gated projection | `frame/app-db-container` — "the read-only derived value `(make-derived-value [frame-state] :rf.db/app)`" |

`rf=` moved ⇒ `=` differs. The guard cannot hit on the flush path for these two.

**For `:frame-state` — no. And it shares the same wrapper.** `subs/single-source-input-kinds` is `#{:db :runtime-db :frame-state}`, and all three route to `make-layer-1-memoised-body` (`subs.cljc:1262`).

The difference is what sits between the sub and the physical container. `:db` / `:runtime-db` read a **projection**. `:frame-state` reads `frame/frame-state-container` — the **raw physical atom**. A raw atom source is wired through the spine's per-source fan-out coordinator (`spine.cljs:833-835`), whose `mark-dirty!` fan-out is **not** movement-gated: it fires on every `reset!`. And `commit-frame-transition!` short-circuits only when **both** partitions are `identical?` (`frame.cljc:1401-1402`), rebuilding a fresh partition map otherwise.

So a commit whose new app-db is `=`-but-not-`identical?` installs a fresh frame-state, marks every `:frame-state` sub dirty, and reaches the wrapper **on the flush path** with a value-equal input — where the guard **hits** and suppresses the body. Confirmed empirically, not just by reading: see the mutation result below.

## Is flush the only caller?

**No.** On the spine, `compute-fn` is reached from exactly two sites, both in `make-derived-value-fn`:

- **`deref-derived` (`spine.cljs:766`) — the READ path.** Pull-based: recomputes on *every* `-deref`. This is where the guard earns its keep, as the bead says. It is also cheap here — a repeat read yields the *identical* app-db object and CLJS `=` short-circuits on `identical?` before any structural walk. So the guard is cheap-and-necessary on read, expensive-and-futile on write, and the wrapper cannot tell the two apart.
- **`flush!` (`spine.cljs:792`) — the WRITE path.**

Beyond the spine: the ratom adapters wrap the same compute-fn in `make-reaction` (`spine.cljs:2892`), and **plain-atom recomputes on every deref with no flush path at all** (`plain_atom.cljc:82`) — there this guard is the only memoisation that exists. `compute-sub` does **not** use the wrapper (it calls `body-fn` directly), so it is not a caller.

## So: removal, or narrowing?

**Neither, without a ruling** — both shapes cross the fence I was given ("if the change alters what Spec 006 or the subs contract promises, STOP and report"). The bead says the same: "NOT a mechanical edit… a design question".

1. **Narrow the guard to `identical?`.** Rejected. Spec 006 §Invalidation algorithm pins invalidation "**only when an input … changes value** (by `rf=` equality)"; Spec 009 §`:rf.sub/skip` pins the emit to "the input value was `=` to last-seen". `identical?` is strictly narrower than `=`. It also reds the **pre-existing** pin `layer-1-memo-value-equal-but-not-identical-skips` (`sub_memo_layer_1_test.clj:84`) — that contract was already tested, and I confirmed the red by running it under the mutation rather than inferring it:

```
FAIL in (layer-1-memo-value-equal-but-not-identical-skips) (sub_memo_layer_1_test.clj:101)
  value-equal db short-circuits the memo (no body re-run)
  expected: (= 1 @runs)
    actual: (not (= 1 2))
Ran 6 tests containing 34 assertions.  1 failures, 0 errors.
```

2. **Let the flush path tell the wrapper the input already moved** (the bead's own sketch). This changes `compute-fn`'s signature, which Spec 006 §`make-derived-value` pins verbatim: `compute-fn signature: (fn [& source-values] ...) — pure; called with deref'd values`. It must **also** be gated on whether the source is movement-gated — the `:frame-state` finding above — which is an adapter-contract question, and it must degrade correctly on Reagent / plain-atom / UIx, where no such signal exists and where (for plain-atom) there is no flush path to signal from.

The saving is real and worth taking; the mechanism needs a decision this worker should not make alone.

## The measurement

Re-ran the existing harness on the current (post-#7229 / #7230) instrument. **`P-EQDB` reproduces the bead's figure exactly at 147.0 B/sub.**

Runtime: **node V8 24.13.0 / V8 13.6.233.17, `:advanced`, `goog.DEBUG false`, pointer compression OFF, Windows 11.** Chrome ships pointer compression ON (4 B tagged slot vs 8 B here) — shares transfer, absolutes do not.

| | forward | reversed (`WA_ORDER=rev`) |
|---|---|---|
| `P-EQDB` B/call | 44107.0 `[44050.6 – 44661.4]` | 44112.0 `[44050.6 – 44701.6]` |
| `P-EQDB` per-sub | **147.0 B** | **147.0 B** |
| per-subscription slope | 835.4 B | 834.5 B |
| `P-EQDB` share of slope | **17.6 %** | 17.6 % |

Ranges overlap across both orders → **indistinguishable**. 42 windows ok, 0 dropped, in each.

**One figure disagrees with the bead, and the harness is the more correct one.** The bead records 15.6 % of the post-fix slope; it now reads **17.6 %**. The absolute is unchanged — the *slope* fell (≈942 → 835 B/sub) as later work landed, so the same 147.0 B is a larger share of a smaller total.

Controls, predicted vs measured: `DBL` slope small pair (100→200) **8.0033** vs predicted **8.0000** (+0.04 %); `SMI` slope small pair **8.0027** B/slot (+0.03 % off the 8 B width, confirming compression OFF). The large pair (1000→10000) reads **8.7290** vs 8.0000 (**+9.11 %**) — the known large-allocation over-read. Both pairs are reported rather than the flattering one alone; the small pair is the trustworthy one.

**Arm-order guard: did NOT refuse.** All 8 self-test fixtures passed and all 70 per-arm strata read `[ok]` in both orders.

## The behavioural pin, and the mutation-proof

Two tests in `sub_memo_flush_path_cljs_test.cljs`, driving a **real React-hook spine** — real epoch scheduler, real `flush!`, no React needed.

The instrument is the `:rf.sub/skip` trace counted **during `dispatch-sync` with no interleaved deref**: the commit and its epoch drain both complete inside that call, so a skip observed there was emitted by `flush!` and by nothing else.

- `db-sub-guard-never-hits-on-the-flush-path` — asserts **zero** flush-path skips for a `:db` sub on a value-equal commit (never marked dirty), and that a real move re-runs the body. The bead's proof, executable.
- `frame-state-sub-guard-does-hit-on-the-flush-path` — asserts **≥ 1** flush-path skip for a `:frame-state` sub on the *same* commit, and that the body did **not** re-run. The counterexample. Both tests end by driving a genuine value move, so neither can pass vacuously.

**Mutation-proof.** Nothing was removed, so the meaningful mutation is the inverse — apply candidate fix (1) and weaken the guard to `identical?`:

```
FAIL frame-state-sub-guard-does-hit-on-the-flush-path
  expected: (pos? flush-skips)
    actual: (not (pos? 0))        ;; the guard stops hitting on flush
  expected: (= before @runs)
    actual: (not (= 1 2))         ;; and the :frame-state body RE-RUNS
Ran 2 tests containing 13 assertions.  5 failures, 0 errors.
```

That is the whole finding in four lines: the guard's `=` semantics is exactly what makes it hit on the flush path, and the hit is load-bearing. The mutation was reverted; `(= @last-db db)` is unchanged at `memo.cljc:514`.

## Quality gates

| gate | exit |
|---|---|
| `npm run test:cljs` — 11,896 tests / 59,378 assertions, 0 failures 0 errors | **0** |
| `implementation/core` JVM `clojure -M:test` — 2,180 tests / 10,805 assertions, 0 failures 0 errors | **0** |
| targeted run, the two new tests — 2 tests / 13 assertions, 0 failures | **0** |
| mutation check (guard → `identical?`; reverted after) | **1** — 5 failures, as intended |
| write-attribution harness, forward | **0** |
| write-attribution harness, reversed (`WA_ORDER=rev`) | **0** |
| arm-order guard | **0** — did not refuse |
| `bash scripts/test-core-prod-gate.sh` — 1,213 tests / 5,590 assertions, 0 failures 0 errors | **0** |
| mutation check on the pre-existing pin (`sub-memo-layer-1-test`, guard → `identical?`) | **1** — 1 failure, as intended |
| same pin after revert — 6 tests / 34 assertions | **0** |

**Core production-gate lane still reads 103 namespaces** (`namespaces : 103 of 184 (81 excluded as known-red)`) — unchanged by this PR.

The core lane was run in **both postures** — dev `clojure -M:test` and the real `-Dre-frame.debug=false` prod gate, both green. No `src/` file is modified, so `egress_chokepoint_conformance_test`'s source scan sees an unchanged surface. Everything else is deferred to CI.

Refs rf2-gncxk.
