### PR TITLE
bench(freehand): the two-clock operating envelope, with guidance (rf2-drpa3.182.12)

### DIFF
--- a/docs/design/freehand/studio/two-clock-operating-envelope.md
+++ b/docs/design/freehand/studio/two-clock-operating-envelope.md
@@ -1,7 +1,8 @@
 # The two-clock operating envelope — DC-09, measured
 
-Beads: `rf2-drpa3.182.12` (the development reading), `rf2-drpa3.182.15` (the
-production reading). Owner of the claim: **DC-09** in
+Beads: `rf2-drpa3.182.12` (the development reading, and the settlement-tail
+correction and guidance that make this the third edition),
+`rf2-drpa3.182.15` (the production reading). Owner of the claim: **DC-09** in
 [`../product-completion-setpoint.md`](../product-completion-setpoint.md).
 Owner of the method:
 [`../decisions/D021-performance-budgets-and-release-evidence.md`](../decisions/D021-performance-budgets-and-release-evidence.md).
@@ -28,6 +29,18 @@ shape.
 **And the headline the production reading changed: 120 Hz clears its latency
 budget at every rung of the ladder, including 200 dirty siblings.** In a
 development build it cleared none of them. Section 6 restates the envelope.
+
+**If you are here to decide what to do rather than to check what was measured,
+[section 9](#9-guidance-for-a-high-rate-host) is the section — drive it
+directly, spend your attention on how much you dirty rather than on how often
+you dispatch, and do not build a throttle.**
+
+**One figure in the first two editions was wrong and is corrected here.** The
+settlement tail was read off a clock started at settle time rather than at the
+last offer; what it published was largely the polling delay that stood in for
+it. Section 6 states the correction, section 2's C3 is the control that now
+guards the anchor, and the corrected number turns out to strengthen the
+recommendation rather than soften it.
 
 ---
 
@@ -82,7 +95,7 @@ the instrumentation seam costs, and it is worth publishing once.
 
 ---
 
-## 2. The instrument, and the two controls that make it readable
+## 2. The instrument, and the three controls that make it readable
 
 A crossing is timed across `react-dom/flushSync` with the dispatch inside it,
 and split at the instant the dispatch returns:
@@ -161,6 +174,44 @@ counts**. A different window, a different clock and a different call site
 agreeing to three significant figures with the fixture's arithmetic is the
 strongest statement this report can make that the thing being timed is the
 thing being described.
+
+### C3 — a control of the tail's anchor
+
+C1 and C2 check that the window measures what it brackets and that the fixture
+dirties what it claims. Neither of them could catch a clock started in the
+wrong place, and one was: the driven arm's settlement tail, in the first two
+editions, was read off a clock **started at settle time**. Section 6 states the
+correction and what the old field was actually reporting.
+
+The control that now stands where that fault was is a prediction. The last
+offer and the settle decision are consecutive fires of one `setInterval`, so
+the gap between them is **one interval** — and the run can predict that
+interval from a different counter, `duration ÷ offered`, which is arithmetic
+over what the driver did rather than a second reading of the same clock.
+
+| k | rate | predicted gap (`duration ÷ offered`) | **measured gap (last offer → settle decision)** |
+|---:|---:|---:|---|
+| 0 | 30 | 33.3–35.0 | **33.4–37.1** |
+| 0 | 60 | 16.3 | **15.4–17.5** |
+| 0 | 120 | 8.0 | **7.0–8.1** |
+| 0 | 240 | 4.0 | **4.2–5.0** |
+| 200 | 30 | 33.3–35.0 | **32.7–41.0** |
+| 200 | 60 | 16.3 | **15.3–16.2** |
+| 200 | 120 | 8.0 | **7.1–7.9** |
+| 200 | 240 | 4.0–4.1 | **3.5–4.6** |
+
+Milliseconds, production, ranges over three runs. Predicted and measured agree
+at every one of the eight cells; the largest single-run disagreement is 6.0 ms
+at the 30 Hz rung, where one interval is 33 ms, so the worst cell is within
+18% and every other is within 15%.
+
+The control is also a **gate**, not only a table. `:tail-anchored?` fails a run
+whose gap is under half a requested period — a floor `setInterval` cannot
+violate, since it cannot fire faster than its period however far behind the
+browser has fallen. A tail read off a settle-time clock has no last-offer
+timestamp and cannot produce the gap at all, so it fails rather than
+publishing. It is asserted in the browser row and in the production entry's
+coherence filter, beside "applied cannot exceed offered".
 
 ---
 
@@ -389,6 +440,71 @@ load-bearing observation for section 8's throttle argument, and production
 tested it under genuinely higher throughput (244 offers/s at k = 200 rather
 than 49) and found the same answer.
 
+### The settlement tail — corrected, and it is one crossing
+
+**The first two editions measured this wrong, and the wrong number was
+published.** `:tail-ms` claimed to run "from the last offer to the DOM showing
+the last generation". It was read off a clock started at *settle* time: the
+interval callback that notices the drive duration has elapsed is the one
+**after** the last offer — a whole period later, by construction, since it is
+the next fire of the same `setInterval` — and the tail clock started there. Its
+own docstring named a quantity it did not measure. Where the last generation
+had already committed, which at low rates is most of the time, what it
+published was approximately the 4 ms polling delay.
+
+So `≤ 5.4 ms even at 240 Hz against a 20 ms crossing` was not a tail. It was
+the poll. The correction reads the tail from the last offer's retained
+timestamp to the `MutationObserver`'s sighting of the last generation — the
+same clock the latency distribution comes from, so the poll's 4 ms resolution
+no longer quantises a quantity that is often smaller than 4 ms. The poll and
+its 2 s ceiling remain, as the `settled?` detector they always were. C3 in
+section 2 is the control that now stands where the fault was.
+
+| k | rate | **tail, production** | tail, dev | *what the old field published (the poll delay)* |
+|---:|---:|---|---|---|
+| 0 | 30 | **0.8–1.1** | 5.1 | *4.1–5.3* |
+| 0 | 60 | **0.5–0.8** | 3.9 | *4.1–4.5* |
+| 0 | 120 | **0.3–0.5** | 3.8 | *4.2–6.0* |
+| 0 | 240 | **0.4–0.5** | 3.0 | *4.1–5.8* |
+| 200 | 30 | **4.6–5.4** | 15.8 | *4.3–5.1* |
+| 200 | 60 | **2.2–2.5** | 24.3 | *4.3–4.8* |
+| 200 | 120 | **2.4–3.7** | 14.0 | *4.7–5.4* |
+| 200 | 240 | **3.2–3.5** | 21.1 | *4.5–6.0* |
+
+Milliseconds, Chrome. Production ranges are across three runs at revision
+`65abc3b99e`; the dev column is a single run at the same revision through the
+`bench:freehand-browser` gate. `:tail-source` was `:observer` in all sixteen —
+the poll never had to answer. **This is a different run from the offered/latency
+table above**, which is why the offer counts are not restated here; the dev
+build's offer ceiling at k = 200 varies run to run and the published counts
+belong to their own run.
+
+**The tail is one crossing.** Compare it against section 3's synchronous
+window: at k = 200 the production tail of 2.2–5.4 ms straddles that window's
+p50 of 2.6–3.6 and p95 of 3.3–5.1; at k = 0 the tail of 0.3–1.1 straddles a p50
+of 0.3–0.5. In the development build, where a crossing at k = 200 costs
+18.3–22.2 ms, the tail is 14.0–24.3. At every rung and in both bundles, **the
+time between the host's last offer and the page being current is one
+crossing — and nothing after it.**
+
+That identity is not a coincidence, and it is worth being precise about what it
+does and does not prove. The tail *is* the last generation's own offer→DOM
+latency: same two timestamps, so it is one sample of the distribution beside it
+rather than an independent measurement of it. What makes it a result is what
+sits next to it — **`outstanding` was 0 and `settled?` true in all sixteen
+runs.** A settlement tail of one crossing means there was never a second one
+waiting. Had the queue been growing, the tail would have been the backlog
+draining, and it would have scaled with the requested rate. It does not: at
+k = 200 the production tail at 240 Hz (3.2–3.5) is *smaller* than at 30 Hz
+(4.6–5.4), which is noise around one crossing and not a queue.
+
+**The corrected number strengthens section 8 rather than weakening it**, and it
+strengthens it in both directions. At k = 200 in a development build the real
+tail is three to four times what was published — the old figure was flattering
+— and it is still exactly one crossing, which is the claim that matters. At
+k = 0 in production the real tail is *under a millisecond*, six to ten times
+smaller than the poll delay that stood in for it.
+
 ### Derived and driven agree — in production too
 
 Two independent windows — a synchronous `flushSync`-bracketed crossing and an
@@ -532,6 +648,15 @@ away the low-load responsiveness that costs nothing. Production tested this at
 **five times the development throughput** at k = 200 (244 offers/s against 49)
 and the backlog was still 1.
 
+The settlement tail says the same thing from the other end, and it says it
+*better* now that it is measured correctly. When the host stops offering, the
+page is current **one crossing later** — 0.3–1.1 ms at k = 0, 2.2–5.4 at
+k = 200 — with `outstanding` 0 in all sixteen runs. A throttle exists to stop a
+queue forming. There is no queue: the thing a throttle would drain is one event
+that has already been dispatched. Note that this argument survived the
+correction *against* its own interest at k = 200, where the true tail is three
+to four times the figure previously published.
+
 **No host-local state model.** The `:host-only` arm is under Chrome's clock
 resolution at every rung. The existing behavior boundary is already the answer;
 nothing needs adding to make host-rate motion cheap, because it already is.
@@ -570,7 +695,114 @@ guide), not new Freehand surface.
 
 ---
 
-## 9. What this report could not determine
+## 9. Guidance for a high-rate host
+
+Section 8 answers a framework question: should Freehand grow vocabulary? This
+section answers the one an application author actually has — *I have a pointer
+drag, a camera, an animation loop or a scroll handler producing updates faster
+than a human can perceive them. What do I do?*
+
+**In one line: drive it directly, and spend your attention on how much you
+dirty rather than on how often you dispatch.**
+
+### The default, named
+
+**A behavior may own high-rate host motion outright, while only semantic
+`started`, optional `preview` and `committed` events cross into `app-db`.**
+That is not a compromise made for performance; it is what the behavior boundary
+is for. It happens also to be free: the `:host-only` arm — a behavior writing
+its own node's transform with nothing crossing — sits at or under Chrome's
+0.1 ms clock clamp at every rung of the ladder, in every bundle, and its
+spread across the ladder measured 0.0 ms. Host-rate motion already costs
+nothing measurable. Nothing has to be added to make it cheap, and nothing you
+add can make it cheaper.
+
+So keep host-local style, geometry and motion out of `app-db` **unless the
+application genuinely needs the live value** — because another view renders
+from it, because it is persisted, because a machine transitions on it. "The
+number happens to be in my hand" is not a reason.
+
+### When it does have to cross, it crosses cheaply
+
+If the live value *is* semantically required, the measured envelope is wide.
+In a shipped bundle, at 120 Hz, with two hundred siblings dirtied by every
+single update, 95% of crossings finish in 5.1 ms against an 8.33 ms budget.
+60 Hz is comfortable across the entire ladder. The framework refused nothing,
+dropped nothing and coalesced nothing away in any of the sixteen driven runs;
+`applied` equalled `offered` equalled committed every time.
+
+**So: dispatch on every move.** Not on every third move, not on a
+`requestAnimationFrame` you installed yourself, not behind a 16 ms trailing
+edge you wrote by hand.
+
+### What not to bother building
+
+Each of these is a thing hosts commonly build, and each is answered by a
+measurement rather than by taste.
+
+- **A throttle, a debounce, or a rAF coalescer in front of `dispatch`.** Peak
+  backlog was **1** — one event in flight — at every rate, both loads and both
+  bundles, and the settlement tail is one crossing with nothing behind it. The
+  browser's timer is already the back-pressure: under load you get *fewer
+  offers*, never a growing queue. A throttle would suppress offers the browser
+  has already stopped making, and would cost you responsiveness at the low
+  load where you were paying nothing.
+- **Memoising or ref-caching a config to dodge an equality walk.** A
+  fresh-but-`rf=`-equal config sits on the 0.1 ms clock clamp at 96 leaves and
+  at 900, indistinguishable from re-installing the identical reference, and
+  Freehand already elides an `:update` whose config is equal — counted, 52 of
+  52, in every bundle. Building the config fresh each frame is fine. A full
+  structural walk of a 900-leaf map costs at most a couple of tenths of a
+  millisecond.
+- **A "settling" or "in flight" UI state.** After the last offer the page is
+  current within about a millisecond at k = 0 and within one crossing at
+  k = 200. There is no interval a user could observe, and nothing to show them
+  during it.
+- **A preview lane distinct from an ordinary crossing.** Nothing measured here
+  tells the two apart. `started` / `preview` / `committed` is worth having
+  because those are different *facts*, not because they cost different amounts.
+
+### What to do instead, in priority order
+
+1. **Read the subscription at the boundary that uses it.** This is the one
+   attributed bottleneck in the report and the whole remedy is a call site.
+   Reading a high-rate value in a view that also builds a collection costs a
+   constant **3.1–3.3 ms** more than reading it one boundary down — while
+   moving *more* DOM nodes, not fewer. Move the `v/sub` down. It is free and it
+   is the largest single number in this report that you control.
+2. **Count how many cells one update dirties.** The event half of a crossing is
+   flat — 0.2–0.7 ms whether one cell moved or two hundred and one. The commit
+   half is what scales, at roughly **0.012 ms per dirtied cell** in a shipped
+   bundle. Your lever is the size of the dirty set, and it is React's cost, not
+   re-frame's. If a crossing is expensive, it is expensive in React.
+3. **Measure dispatch-per-move before adding any policy.** A single move that
+   dispatches once is a 0.3–0.5 ms crossing. A handler that dispatches four
+   times per move is a 2 ms one, and no throttle fixes that — it is four events
+   where the application meant one. Count the dispatches first; it is nearly
+   always the answer when a high-rate host feels slow, and it is the only
+   diagnosis in this list that does not need a profiler.
+4. **Type into it.** Controlled input is the case where correctness, not
+   smoothness, is at stake, and correctness held unconditionally: no dropped
+   characters and an intact caret at every rung, including 200 siblings dirtied
+   by every keystroke. Only the smoothness of the accompanying repaint
+   degrades, and only past 50 siblings.
+
+### The one caveat that would change this advice
+
+**Real pointer streams were not measured.** The driver is a `setInterval`, and
+a `setInterval` hands the main thread one event per task. A browser delivering
+coalesced `pointermove`, or `pointerrawupdate` bursts, can hand *several* events
+to one task — the single shape that could produce a backlog greater than 1, and
+therefore the single shape that could change the throttle answer. If you are
+driving from raw pointer events at a rate the display cannot show, read
+`getCoalescedEvents` and dispatch what you mean rather than what arrived. That
+is not a framework verb; it is the pointer API's own answer to its own
+question. The backlog-of-1 result should not be quoted for a raw-pointer burst
+without re-measuring, and section 10 records this as undetermined.
+
+---
+
+## 10. What this report could not determine
 
 **~~The production envelope.~~** *Resolved by `rf2-drpa3.182.15`; this is what
 the second edition adds.* The first edition recorded that every figure came
@@ -591,11 +823,24 @@ existing `:freehand-release` id, which already carries `:optimizations
 about. `b10_prod_run.cjs` does the same and touches no shared configuration at
 all. The hot-zone contention was real; the dependency on it was not.
 
+**~~The settlement tail.~~** *Corrected by the third edition.* The first two
+editions published a tail read off a clock started at settle time — a precise,
+plausible number that was not the quantity its own docstring named, and at low
+rates was approximately the 4 ms polling delay. It is now anchored at the last
+offer's retained timestamp and read from the `MutationObserver`, with C3
+(section 2) gating the anchor and section 6 stating both the correction and
+what the old field had been publishing. The corrected tail is one crossing at
+every rung of both bundles. **What this cost is worth recording**: the wrong
+number was quoted in a durable recommendation for four days, and only reading
+the code found it. No clock caught it, because a clock cannot tell you where it
+was started.
+
 **Real pointer streams.** The driver is a `setInterval`. A browser delivering
 coalesced `pointermove`, or `pointerrawupdate` bursts, can hand several events
 to one task, which is the one shape that could produce a backlog greater than 1.
 The backlog-of-1 result is measured against a timer and should not be quoted
-for a raw-pointer burst without re-measuring.
+for a raw-pointer burst without re-measuring. Section 9 carries this as the one
+caveat that would change its advice.
 
 **Sub-0.1 ms costs, and there are now many more of them.** Chrome clamps
 `performance.now()` to 100 µs. In the development build only the `:host-only`
@@ -631,7 +876,7 @@ of bundle. The absolutes are not.
 
 ---
 
-## 10. Reproducing
+## 11. Reproducing
 
 **Arm C — the production reading (sections 3–6's headline figures).** No shared
 build configuration is involved; the driver builds, serves, drives and prints

--- a/implementation/freehand/test/re_frame/freehand/bench/b10_prod_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b10_prod_app.cljs
@@ -339,8 +339,16 @@
                 plan)
         (.then
           (fn [_]
-            (let [bad (filterv (fn [{:keys [offered applied]}]
-                                 (or (not (pos? offered)) (> applied offered)))
+            ;; C3 rides here too: a driven run whose tail is not anchored at
+            ;; the last offer is incoherent in the same way a run that applied
+            ;; more than it offered is, and fails the arm rather than
+            ;; publishing a plausible wrong number.
+            (let [bad (filterv (fn [{:keys [offered applied tail-ms tail-anchored?]}]
+                                 (or (not (pos? offered))
+                                     (> applied offered)
+                                     (not tail-anchored?)
+                                     (not (number? tail-ms))
+                                     (neg? tail-ms)))
                                @runs)]
               (record! :m3
                        (b10/record
@@ -358,9 +366,14 @@
                                "measurement; :offered counts driver invocations; :applied is "
                                "incremented inside the reducer; :mutations counts DOM "
                                "records; :peak-backlog is the largest offered-minus-applied "
-                               "ever seen at an offer; :tail-ms is from the last offer to the "
-                               "page showing the last generation, polled at 4 ms with a "
-                               "2000 ms ceiling; :latency-ms is the offer-to-DOM distribution "
+                               "ever seen at an offer; :tail-ms is from the LAST OFFER'S OWN "
+                               "TIMESTAMP to the MutationObserver's sighting of the last "
+                               "generation, with a 4 ms poll and a 2000 ms ceiling serving "
+                               "only as the :settled? detector; :offer-to-poll-start-ms is "
+                               "the one-interval gap between those two instants and "
+                               ":tail-anchored? gates it against half a requested period, so "
+                               "a tail read off a clock restarted at settle time fails rather "
+                               "than publishes; :latency-ms is the offer-to-DOM distribution "
                                "read from the MutationObserver callback that carried each "
                                "generation.")}
                          {:warmup 0 :samples (count @runs)}

--- a/implementation/freehand/test/re_frame/freehand/bench/b10_two_clock.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b10_two_clock.cljs
@@ -605,9 +605,54 @@
     :applied   reducer applications, counted in the reducer itself
     :mutations DOM records observed across the whole run
     :peak-backlog  max over offers of `offered − applied`
-    :tail-ms   from the last offer to the DOM showing the last generation
+    :tail-ms   from the LAST OFFER'S OWN TIMESTAMP to the page showing the
+               last generation
     :latency   per-generation offer→DOM distribution, read from the
-               `MutationObserver` callback that carried it"
+               `MutationObserver` callback that carried it
+
+  ## `:tail-ms` is anchored at the last offer, and a control says so
+
+  The first edition of this driver read the tail off a clock **started at
+  settle time**. The interval callback that notices `duration-ms` has
+  elapsed is the one *after* the last offer — a whole period later by
+  construction, since it is the next fire of the same `setInterval` — so
+  `(now − that-instant)` silently omitted the interval it was supposed to
+  contain, and where the last generation had already committed it
+  reported approximately the 4 ms polling delay instead. The number was
+  precise, plausible, and not the quantity its own docstring named. It is
+  the fault `rf2-drpa3.182.12`'s merged-PR audit found, and it is the
+  fifteenth on this surface to have produced a believable wrong number
+  before anyone read the code.
+
+  Two changes. The last offer's timestamp is **retained** — `offers`
+  already held one per generation, so `t-offer` keeps the last of them
+  rather than re-reading the clock later. And settlement is read from the
+  `MutationObserver` that is already watching, the same clock the latency
+  distribution comes from, rather than from the poll: the poll's 4 ms
+  resolution would otherwise be quantisation on a quantity that is often
+  smaller than 4 ms in a shipped bundle. **The 2 s polling ceiling is
+  unchanged and still separate** — the poll remains the `settled?`
+  detector and nothing else.
+
+  Four fields make the anchoring checkable rather than asserted:
+
+    :offer-to-poll-start-ms  last offer → the settle decision. One
+                             interval, by construction. This is exactly
+                             the term the old reading dropped, so a clock
+                             restarted at settle time cannot produce it.
+    :predicted-gap-ms        the run's own achieved period,
+                             `duration-ms / offered` — what that gap is
+                             predicted to be, computed from a different
+                             counter.
+    :poll-wait-ms            settle decision → the poll noticing. Under
+                             the old reading THIS was published as the
+                             tail.
+    :tail-anchored?          the deterministic control: the gap exists and
+                             is at least half a requested period. A
+                             `setInterval` cannot fire faster than its
+                             period, so the floor holds however badly the
+                             browser is falling behind; a settle-time
+                             clock fails it outright."
   [mnt rate k duration-ms]
   (let [{:keys [container observer]} mnt
         period    (/ 1000.0 rate)
@@ -617,7 +662,9 @@
         latencies (atom [])
         muts      (atom 0)
         start     (m/now-ms)
-        last-gen  (volatile! nil)]
+        last-gen  (volatile! nil)
+        t-offer   (volatile! nil)         ; the LAST offer's own timestamp
+        last-seen (volatile! nil)]        ; [generation when-the-page-showed-it]
     (.disconnect observer)
     (reset-applied!)
     (let [watcher (js/MutationObserver.
@@ -626,9 +673,18 @@
                       (let [now (m/now-ms)
                             txt (cell-text container 0)
                             g   (js/parseInt txt 10)]
-                        (when-let [t (get @offers g)]
-                          (swap! latencies conj (- now t))
-                          (swap! offers dissoc g)))))]
+                        (when-not (js/isNaN g)
+                          ;; The newest generation the page has shown, and
+                          ;; WHEN it showed it. The tail is read from here
+                          ;; rather than from the settle poll, so it carries
+                          ;; this observer's resolution rather than the
+                          ;; poll's 4 ms — which in a shipped bundle is
+                          ;; larger than the quantity itself.
+                          (when (or (nil? @last-seen) (> g (nth @last-seen 0)))
+                            (vreset! last-seen [g now]))
+                          (when-let [t (get @offers g)]
+                            (swap! latencies conj (- now t))
+                            (swap! offers dissoc g))))))]
       (.observe watcher container #js {:subtree true :childList true :characterData true})
       (js/Promise.
         (fn [resolve]
@@ -640,19 +696,30 @@
                   (if (>= (- (m/now-ms) start) duration-ms)
                     (do
                       (js/clearInterval @tid)
-                      ;; settle: wait until the last generation is on the page
-                      ;; or a generous ceiling passes, then read the tail.
-                      (let [t-last (m/now-ms)
-                            poll   (volatile! nil)]
+                      ;; Settle: poll until the last generation is on the
+                      ;; page or a generous ceiling passes. The poll is the
+                      ;; `settled?`/ceiling detector and ONLY that — this
+                      ;; callback is already one period past the last offer,
+                      ;; so a clock started here measures neither end of the
+                      ;; tail. `t-offer` is that end; the observer is this one.
+                      (let [t-poll-start (m/now-ms)
+                            poll         (volatile! nil)]
                         (vreset!
                           poll
                           (js/setInterval
                             (fn []
                               (let [done? (= (str @last-gen) (cell-text container 0))
-                                    over? (> (- (m/now-ms) t-last) 2000)]
+                                    over? (> (- (m/now-ms) t-poll-start) 2000)]
                                 (when (or done? over?)
                                   (js/clearInterval @poll)
-                                  (let [tail (- (m/now-ms) t-last)]
+                                  (let [now      (m/now-ms)
+                                        seen     @last-seen
+                                        by-obs?  (boolean (and done? seen
+                                                               (= (nth seen 0) @last-gen)))
+                                        t-settle (if by-obs? (nth seen 1) now)
+                                        t0       @t-offer
+                                        n        @offered
+                                        gap      (when t0 (- t-poll-start t0))]
                                     (.disconnect watcher)
                                     (.observe observer container
                                               #js {:subtree true :childList true
@@ -661,13 +728,20 @@
                                       {:rate            rate
                                        :siblings        k
                                        :duration-ms     duration-ms
-                                       :offered         @offered
+                                       :offered         n
                                        :expected        (js/Math.floor
                                                           (/ (* duration-ms rate) 1000.0))
                                        :applied         (applied)
                                        :mutations       @muts
                                        :peak-backlog    @backlog
-                                       :tail-ms         tail
+                                       :tail-ms         (when t0 (- t-settle t0))
+                                       :tail-source     (if by-obs? :observer :poll)
+                                       :offer-to-poll-start-ms gap
+                                       :predicted-gap-ms       (when (pos? n)
+                                                                 (/ duration-ms (double n)))
+                                       :poll-wait-ms    (- now t-poll-start)
+                                       :tail-anchored?  (boolean
+                                                          (and gap (>= gap (* 0.5 period))))
                                        :settled?        done?
                                        :outstanding     (count @offers)
                                        :latency-ms      (when (seq @latencies)
@@ -676,7 +750,13 @@
                     (let [gen (next-gen!)]
                       (vreset! last-gen gen)
                       (swap! offered inc)
-                      (swap! offers assoc gen (m/now-ms))
+                      ;; ONE clock read, kept in two places: the per-generation
+                      ;; latency map and `t-offer`. Re-reading the clock for
+                      ;; the second would make the tail and the last
+                      ;; generation's latency disagree for no reason.
+                      (let [t (m/now-ms)]
+                        (vreset! t-offer t)
+                        (swap! offers assoc gen t))
                       (swap! backlog max (- @offered (applied)))
                       (rf/dispatch [:b10/moved k gen] {:frame frame-id}))))
                 period))))))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b10_two_clock_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b10_two_clock_dom_cljs_test.cljs
@@ -365,13 +365,33 @@
                       plan)
               (.then
                 (fn [_]
-                  (doseq [{:keys [rate siblings offered expected applied]} @runs]
+                  (doseq [{:keys [rate siblings offered applied tail-ms tail-anchored?
+                                  offer-to-poll-start-ms predicted-gap-ms]} @runs]
                     (is (pos? offered)
                         (str "rate " rate " / k=" siblings ": the driver ran at all"))
                     (is (<= applied offered)
                         (str "rate " rate " / k=" siblings
                              ": the reducer cannot apply more than was offered ("
-                             applied " applied, " offered " offered)")))
+                             applied " applied, " offered " offered)"))
+                    ;; C3 — the tail anchor. `:tail-ms` claims to start at the
+                    ;; last offer, and the callback that ends the drive is one
+                    ;; interval PAST that offer. So the gap must exist and must
+                    ;; be at least half a requested period — `setInterval`
+                    ;; cannot fire faster than its period, so the floor holds
+                    ;; however far behind the browser has fallen. A tail read
+                    ;; off a clock restarted at settle time reports the poll
+                    ;; delay and cannot produce this gap at all, which is the
+                    ;; fault this assertion exists for.
+                    (is tail-anchored?
+                        (str "rate " rate " / k=" siblings
+                             ": the tail is anchored at the last offer — gap "
+                             offer-to-poll-start-ms " ms against a "
+                             (/ 1000.0 rate) " ms period (predicted "
+                             predicted-gap-ms " ms from the achieved rate)"))
+                    (is (and (number? tail-ms) (not (neg? tail-ms)))
+                        (str "rate " rate " / k=" siblings
+                             ": the tail is a real measurement, not nil ("
+                             (pr-str tail-ms) ")")))
                   (h/publish!
                     "B10 M3 / driven rates"
                     (b10/record
@@ -389,10 +409,15 @@
                             ":offered counts driver invocations; :applied is incremented "
                             "inside the reducer; :mutations counts DOM records; "
                             ":peak-backlog is the largest offered-minus-applied ever seen at "
-                            "an offer; :tail-ms is from the last offer to the page showing "
-                            "the last generation, polled at 4 ms with a 2000 ms ceiling; "
-                            ":latency-ms is the offer-to-DOM distribution read from the "
-                            "MutationObserver callback that carried each generation.")}
+                            "an offer; :tail-ms is from the LAST OFFER'S OWN TIMESTAMP to "
+                            "the MutationObserver's sighting of the last generation, with a "
+                            "4 ms poll and a 2000 ms ceiling serving only as the :settled? "
+                            "detector; :offer-to-poll-start-ms is the one-interval gap "
+                            "between those two instants and :tail-anchored? gates it against "
+                            "half a requested period, so a tail read off a clock restarted "
+                            "at settle time fails rather than publishes; :latency-ms is the "
+                            "offer-to-DOM distribution read from the MutationObserver "
+                            "callback that carried each generation.")}
                       {:warmup 0 :samples (count @runs)}
                       {:runs @runs}))
                   nil))


### PR DESCRIPTION
Closes the reopen on `rf2-drpa3.182.12`. The merged-PR audit of #7179 found
`drive!`'s `:tail-ms` measuring something other than the quantity its own
docstring named. This fixes the instrument, re-measures in both bundles, and
adds the section the report was missing: guidance for the person who has to act
on it.

## What was wrong

The interval callback that notices the drive duration has elapsed is the one
**after** the last offer — a whole period later, by construction, since it is
the next fire of the same `setInterval`. The tail clock was started *there*, so
it omitted that interval entirely; where the last generation had already
committed, which at low rates is most of the time, what it published was
approximately the 4 ms polling delay.

So `≤ 5.4 ms even at 240 Hz against a 20 ms crossing` — quoted in the bead's
durable notes as evidence for the no-throttle recommendation — was not a tail.
It was the poll. Measured, not inferred:

| k | rate | **corrected tail, prod** | corrected tail, dev | *what the old field published* |
|---:|---:|---|---|---|
| 0 | 30 | **0.8–1.1** | 5.1 | *4.1–5.3* |
| 0 | 120 | **0.3–0.5** | 3.8 | *4.2–6.0* |
| 200 | 30 | **4.6–5.4** | 15.8 | *4.3–5.1* |
| 200 | 60 | **2.2–2.5** | 24.3 | *4.3–4.8* |
| 200 | 240 | **3.2–3.5** | 21.1 | *4.5–6.0* |

Milliseconds, HeadlessChrome 147.0.7727.15. Full eight-row table in §6. The old
number was flattering at k=200 in a development build by three to four times,
and pessimistic at k=0 in production by six to ten.

## What the corrected number says

**The tail is one crossing.** Production k=200 reads 2.2–5.4 ms against the
synchronous window's p50 2.6–3.6 and p95 3.3–5.1; k=0 reads 0.3–1.1 against a
p50 of 0.3–0.5. Development reads 14.0–24.3 against 18.3–22.2, and 3.0–5.1
against 3.5–4.6.

§6 is careful about what that does and does not prove. The tail *is* the last
generation's own latency — same two timestamps — so it is one sample of the
distribution beside it, not an independent measurement of it. What makes it a
result is `outstanding` **0** and `settled?` **true** in all sixteen runs: a
settlement tail of one crossing means there was never a second one waiting. Had
the queue been growing, the tail would scale with the requested rate. It does
not — at k=200 the production tail at 240 Hz (3.2–3.5) is *smaller* than at
30 Hz (4.6–5.4).

**"Add no scheduling vocabulary" holds, and this argument survived against its
own interest**: at k=200 in a development build the true tail is three to four
times the figure previously published, and the no-throttle case holds anyway,
because one crossing is one crossing whatever it costs.

## C3 — the new control

The audit asked for an assertion that would fail if the clock were restarted at
settle time. The gap between the last offer and the settle decision is one
interval by construction, and the run predicts it from an **independent
counter** — `duration ÷ offered`, arithmetic over what the driver did rather
than a second reading of the same clock.

| k | rate | predicted gap | **measured gap** |
|---:|---:|---:|---|
| 0 | 30 | 33.3–35.0 | **33.4–37.1** |
| 0 | 60 | 16.3 | **15.4–17.5** |
| 0 | 120 | 8.0 | **7.0–8.1** |
| 0 | 240 | 4.0 | **4.2–5.0** |
| 200 | 30 | 33.3–35.0 | **32.7–41.0** |
| 200 | 60 | 16.3 | **15.3–16.2** |
| 200 | 120 | 8.0 | **7.1–7.9** |
| 200 | 240 | 4.0–4.1 | **3.5–4.6** |

Predicted and measured agree at all eight cells; the worst is within 18%, at
the 30 Hz rung where one interval is 33 ms, and every other is within 15%.
Ranges are across three production runs.

`:tail-anchored?` is also a **gate**, not only a table — it fails a run whose
gap is under half a requested period, a floor `setInterval` cannot violate
however far behind the browser has fallen. A settle-time clock has no
last-offer timestamp and cannot produce the gap at all, so it fails rather than
publishes. Asserted in the browser row and in the production entry's coherence
filter, beside "applied cannot exceed offered".

C1 (computed duration) and C2 (computed mutation count) rode every run
unchanged: C1 predicted 4.00 ms and measured p50 4.0 in every published cell;
C2's predicted mutation counts (1 / 0 / k+1) equalled measured at all fifteen
mode × rung combinations, and the driven arm independently reproduced exactly
201.0 mutations per crossing at k=200.

**0 unverified of 5760** — 0 of 1440 in each of three production runs and 0 of
1440 in the development run. Every measured crossing read back out of the DOM
inside its own window; the `:fresh-equal` arm, whose page must not move, is
verified at the store instead.

## §9 — the guidance, which is what DC-09 was for

The report had eight sections of evidence and one addressed to Freehand's API
designers. It had none addressed to a host author. §9 is that section: *I have
a pointer drag, a camera, an animation loop or a scroll handler producing
updates faster than a human can perceive them — what do I do?*

**Drive it directly, spend your attention on how much you dirty rather than on
how often you dispatch, and do not build a throttle.**

It names the default (a behavior owns high-rate host motion; only semantic
`started`, optional `preview` and `committed` cross), lists four things not to
bother building with the measurement that answers each — throttle/debounce/rAF
coalescer, memoised configs, a "settling" UI state, a distinct preview lane —
gives four things to do in priority order, and carries the one caveat that
would change the advice: real coalesced pointer streams were not measured, and
they are the single shape that could produce a backlog above 1.

## Scope

The rate ladder, the sibling ladder, the behaviour-config axis
(stable-reference / fresh-but-`rf=`-equal / one-leaf at Vega and Spread shapes)
and controlled-input contention were all measured by #7179 and #7198 and are
**reused, not re-run** — §§3–5 and 7 stand. Re-running a published ladder is
waste. The settlement tail was the one item on the bead's MEASURE list whose
published figure did not survive its own audit, and the guidance was the
deliverable that had not been written.

No `implementation/freehand/src/**` change. This is measurement, not
optimisation. No `FH-` id minted, nothing enrols in the conformance roster, no
shared build configuration touched.

## Quality gates

| gate | result | exit |
|---|---|---:|
| `shadow-cljs compile browser-test-freehand-bench` | 259 files, 258 compiled, **0 warnings** | **0** |
| `bench:freehand-browser` (dev arm + the new C3 assertions) | 30 tests, **482 assertions** (466 + 16 new), 0 failures, 0 errors | **0** |
| `order_guard.cjs` self-test | 8 checks ok, **no refusal** | **0** |
| `npm run test:browser` (correctness lane unaffected) | 841 tests, 5459 assertions, 0 failures, 0 errors | **0** |
| `b10_prod_run.cjs` production run 1 | `:d021 :release-evidence`, controls passed | **0** |
| `b10_prod_run.cjs` production run 2 | `:d021 :release-evidence`, controls passed | **0** |
| `b10_prod_run.cjs` production run 3 | `:d021 :release-evidence`, controls passed | **0** |

The 482 assertions are 466 plus exactly the 16 added here (8 driven runs × 2).
`browser-test`'s `:ns-regexp` carries a negative lookahead excluding
`re-frame.freehand.bench.*`, so none of the new assertions can reach that lane
— its 841/5459 differs from the 850/5549 recorded on the bead only through
main-side drift since that run.

The arm-order guard was run and **did not refuse**; its tolerance is untouched.

Nothing slower was run locally; the JVM suites and the full spine are deferred
to CI.

## Provenance

HeadlessChrome 147.0.7727.15, Windows 11 x64, hardware class
`:developer-workstation`, revision `65abc3b99e`. Production arm is
`:optimizations :advanced` with `:instrumentation? false`, read off the running
bundle rather than asserted by the driver. Raw per-run records are local-only
under `ai/findings/2026-07-28.b10-tail-anchored-prod-{1,2,3}.log`.

No Node or JVM figure is quoted for any of this; absolutes do not transfer
across runtimes and none is asked to.

This PR does not touch the Freehand-versus-Reagent question, which is held
pending a ruling on `rf2-lbs3y`.
