### PR TITLE
bench: C-FRAME measures a per-call cost, and thunk arms say what they measure (rf2-tmzie, rf2-ktrvw)

### DIFF
--- a/docs/design/freehand/studio/read-path-on-the-shipping-host.md
+++ b/docs/design/freehand/studio/read-path-on-the-shipping-host.md
@@ -36,7 +36,7 @@ every term.
 | `call-with-frame-resolution` | 720–800 | 41% | **112.3** | **6.6%** | collapses to a seventh |
 | — of which the **dynamic `binding`** | **~760** | **41–46%** | **0.1 ≤ floor** | **0.0%** | **VANISHES** |
 | — of which the generation read | 16–40 | ~2% | 48.0 | 2.8% | holds |
-| — of which the harness's own thunk | — | — | 64.0 | 3.8% | instrument, not product |
+| — of which the harness's own thunk | — | — | 64.0–128.1 | 3.8% | instrument, not product — and **bimodal**, see below |
 | `(frame/frame id)` + `(get @cache k)` | 0–8 | 0% | 96.7 | 5.7% | appears, small |
 | `frame-target->id` | 0 | 0% | 0.0 | 0.0% | free in both |
 | **= `subscribe`, cache hit, no deref** | **1220–1364** | | **1698.1** | | |
@@ -177,7 +177,9 @@ binding costs 48 B/read". It costs nothing.
 closure per call that *escapes*, while an inline re-spelling allocates one that
 does not, and V8 elides what it can prove never escapes. That subtraction prices
 the closure. Same error as (a), opposite sign. Confirmed directly:
-`N-CALLTHUNK` (one escaping thunk and nothing else) reads **64.0 B/read**.
+`N-CALLTHUNK` (one escaping thunk and nothing else) reads **64.0 B/read** in its
+settled mode — and `N-NEWFN`, which is nothing *but* a closure, reads the same,
+which is what pins that 64 B on the closure rather than on `cwfr`.
 
 **(c) The symmetric pair itself, when V8 compiles the two halves differently.**
 The repair for (b) was a symmetric pair: two sibling functions of identical arity
@@ -222,8 +224,44 @@ read the floor — measuring **nothing** — except in some windows, where it re
 `N-CWFRRAW`'s ranges simultaneously.
 
 The repair was to the **arm**, not the guard: the thunk is now stored where
-nothing can prove it dead. It escapes for real and the arm reads a stable
-64.0 B/read. **The guard's tolerance was never touched.**
+nothing can prove it dead. It escapes for real and the arm reads 64.0 B/read.
+**The guard's tolerance was never touched.**
+
+**And that repair went as far as a repair can go (`rf2-ktrvw`).** It removed the
+*elision*; it did not remove a residual ~64 B/read step, and nothing done to the
+arm could have. `N-NEWFN` creates one closure per inner iteration and does
+nothing else at all — no callee, no binding, not even a call — and it carries
+the same step:
+
+| arm | settled | high | step | = closures |
+|---|---:|---:|---:|---:|
+| `N-NEWFN` | 64.0 | 128.1 | 64.1 | 1.00 |
+| `N-CALLTHUNK` | 64.0 | 128.1 | 64.1 | 1.00 |
+| `N-CWFRNOG` | 64.0 | 128.6 | 64.6 | 1.01 |
+| `N-CWFRBIND` | 112.0 | 176.4 | 64.3 | 1.01 |
+| `N-CWFRGEN` | 112.0 | 176.6 | 64.6 | 1.01 |
+| `N-CWFRRAW` | 112.0 | 176.5 | 64.5 | 1.01 |
+
+B/read net of `NOOP`, reversed plan; the forward plan agrees at 64.1–77.4. The
+step is the **same absolute size** on arms whose totals differ by 75%, so it is
+additive and belongs to **closure creation**, not to any arm's subject.
+`N-CALLTHUNK − N-NEWFN` is 0.0 B/read against a prediction of 0, so `call-thunk`
+itself costs nothing beyond the closure.
+
+So a closure on this runtime is **two numbers, 64 B and 128 B, chosen per
+window with nothing in between** — and an arm whose subject is a closure cannot
+be re-shaped out of it without ceasing to measure the thing. A thunk-dominated
+arm is quotable as its **range**, and as an upper bound at the high mode, never
+as a p50 alone.
+
+It also explains why the forward plan now passes where it once refused: the step
+appears in the forward plan and the reversed one **alike**, so it is not a
+position effect, and the `phase` factor adjudicates it by luck — it fires when a
+third lands wholly in one mode and passes when a third straddles both. That is
+the house rule working correctly on a factor that does not describe the
+phenomenon. Widening the tolerance would hide a real bimodality and narrowing it
+would refuse at random, so the guard is **still** left alone. A later green run
+is not evidence the effect went away.
 
 **Refusal 2 — the instrument's upper working limit.** An `RA_N=1000` run was
 refused, and correctly: at n=1000 the arms are large enough that calibration
@@ -236,7 +274,13 @@ thing that run suggests, and it is left as a suggestion.
 25% tolerance was not widened. Both refusing arms are non-headline —
 `N-CALLTHUNK` is a control, and `N-CWFRNOG` is the arm this document explicitly
 says *not* to subtract with. Every headline term passed the guard in both orders.
-Filed as `rf2-ktrvw`.
+Filed as `rf2-ktrvw`, and **closed by the bimodality finding above**: the arms
+were not defective, they were measuring something that has two values, and the
+answer was to say so rather than to repair an arm or relax a guard.
+
+None of the headline terms is exposed to it. The binding figure is `N-BINDONLY`,
+which allocates no closure at all; the budget and symmetric-pair reconstructions
+each difference two arms carrying exactly one, so the mode cancels.
 
 ### Runs
 

--- a/implementation/core/test/re_frame/bench/read_attribution_cljs.cljs
+++ b/implementation/core/test/re_frame/bench/read_attribution_cljs.cljs
@@ -126,6 +126,26 @@
   floor down by `n` as well. That amplification is the only reason a
   ~0 B/read arm is separable from the floor at all.
 
+  ## A closure is not one number, and neither is an arm made of one
+
+  A floor is not the only thing that makes a p50 unquotable. Five arms here
+  hand a freshly-allocated thunk to a callee, and on this runtime a closure
+  costs 64 B in one mode and 128 B in another — a per-WINDOW choice, with
+  nothing in between. `N-NEWFN` is the control that establishes it: one
+  closure per inner iteration and nothing else at all, and it steps by
+  exactly one closure just as the thunk arms do, in BOTH plan orders.
+
+  So the step is closure CREATION, not any arm's subject, and it is additive
+  rather than proportional — the same absolute size on arms whose totals
+  differ by 75%. No re-shaping of a thunk arm can remove it: the arm would
+  have to stop allocating the thing it exists to price. `-main` prints the
+  bimodality table, and a thunk-dominated arm is quotable as its RANGE and as
+  an upper bound at the high mode, never as a p50 alone (rf2-ktrvw).
+
+  Nothing this file publishes rests on one: the binding figure is
+  `N-BINDONLY`, which carries no closure, and the budget and symmetry checks
+  difference two arms that each carry exactly one, so the mode cancels.
+
   ## The ladder — the same arms as `read_attribution.clj`
 
     GETIN     the application's own work — `(get-in db [:items i])`
@@ -181,6 +201,10 @@
     N-CWFRNOG  `cwfr` on a target that names no image-loaded frame, so the
                binding branch is NOT taken. `S3-CWFR - S2-TGTID - N-CWFRNOG`
                is the binding by subtraction, and must agree with N-BINDONLY.
+    N-NEWFN    ONE closure per inner iteration and nothing else — no callee,
+               no binding, not even a call. It prices the thunk every arm
+               above hands to somebody, and it is what says the bimodal step
+               those arms carry is closure CREATION (rf2-ktrvw, below).
     N-LOOKGEN  `registrar/lookup :sub` with `*generation*` BOUND — the
                generation-routed branch that allocates a `[kind id]` key
                vector per call (rf2-ezwnl, ~98 B/call JVM)
@@ -238,7 +262,9 @@
   (default 6 — at least six, so the guard's phase thirds are ranges rather
   than single samples), RA_WARM_WINDOWS (full-size discarded windows per
   arm, default 12 — 6 was `write_attribution`'s figure and the FORWARD plan
-  refuses on two arms at 6 while the reversed plan passes), RA_WARMUP (bare
+  refuses on two arms at 6 while the reversed plan passes. More warm-up
+  cannot settle the closure bimodality above, and is not meant to: that is a
+  per-window choice, not a settling curve), RA_WARMUP (bare
   calls before calibration, default 3),
   RA_TOLERANCE (the guard's relative-median tolerance, default 0.25),
   RA_ORDER=rev (reverse the base plan before scheduling — a knob, not the
@@ -759,12 +785,44 @@
 ;; reading V8's optimization state as much as its own allocation.
 ;;
 ;; So the thunk is made to ESCAPE for real — stored where nothing can prove it
-;; dead. The arm then prices one closure, stably, which is what it was always
-;; supposed to do. This repairs the ARM; the guard's tolerance is untouched.
+;; dead. The arm then prices one closure, which is what it was always supposed
+;; to do. This repairs the ARM; the guard's tolerance is untouched.
 ;;
 ;; It is also why the binding is isolated by a SYMMETRIC PAIR and not by any
 ;; subtraction between differently-shaped arms: whatever V8 does to a closure it
 ;; does to both halves, and cancels.
+;;
+;; rf2-ktrvw — AND IT PRICES ONE CLOSURE *BIMODALLY*, WHICH NO ARM CAN FIX.
+;;
+;; The escape repair above removed the ELISION. It did not, and could not,
+;; remove the remaining ~64 B/read step, because that step is not the arm's:
+;; `N-NEWFN` creates one closure per inner iteration and does NOTHING else —
+;; no callee, no binding, not even a call — and it carries the step too.
+;;
+;;   N-NEWFN      settled  64.0   high  128.1   step 64.1 B/read = 1.00 closures
+;;   N-CALLTHUNK  settled  64.0   high  128.1   step 64.1        = 1.00
+;;   N-CWFRRAW    settled 112.0   high  176.5   step 64.5        = 1.01
+;;
+;; The step is the SAME ABSOLUTE SIZE on arms whose totals differ by 75%, so it
+;; is ADDITIVE and belongs to closure CREATION. `N-CALLTHUNK - N-NEWFN` is
+;; 0.0 B/read against a prediction of 0, so `call-thunk` itself costs nothing
+;; beyond the closure and there is no arm-shaped defect left to repair.
+;;
+;; It appears in the FORWARD plan and the REVERSED one alike, so it is NOT a
+;; position effect. That is why the guard's PHASE factor adjudicates it by
+;; luck — it fires when a third happens to land wholly in one mode and passes
+;; when a third straddles both, which is the house rule working correctly on a
+;; factor that does not describe the phenomenon. Widening the tolerance would
+;; hide a real bimodality; narrowing it would refuse runs at random. Neither is
+;; the repair, and the guard is left alone.
+;;
+;; WHAT THESE ARMS THEREFORE MEASURE: one closure, in whichever of two modes
+;; V8's closure site is in — 64 B or 128 B. They are quotable as a RANGE and as
+;; an upper bound at the high mode, never as a p50 alone, and `-main` prints
+;; that table. No headline here depends on one: the published binding figure is
+;; `N-BINDONLY`, which allocates no closure at all, and the BUDGET
+;; reconstruction and SYMMETRY CHECK both difference two arms that each carry
+;; exactly one, so the mode cancels.
 
 (defonce ^:private thunk-escape (volatile! nil))
 
@@ -775,6 +833,38 @@
   [thunk]
   (vreset! thunk-escape thunk)
   (thunk))
+
+;; rf2-ktrvw — THE CLOSURE, PRICED ON ITS OWN, because every arm that hands a
+;; thunk to another function is dominated by it and none of them could say what
+;; the thunk cost without assuming it.
+;;
+;; This arm creates ONE closure per inner iteration and does nothing else with
+;; it: no callee, no binding, no generation read, not even a call. The thunk is
+;; stored where nothing can prove it dead — `call-thunk`'s own discipline — so
+;; escape analysis cannot remove it.
+;;
+;; TWO PREDICTIONS, both stated before the measurement:
+;;
+;;   1. `N-NEWFN` reads what one closure costs, and `N-CALLTHUNK - N-NEWFN` is
+;;      then `call-thunk`'s own work — a `vreset!` and a call — which is 0.
+;;   2. If the ~64 B/read STEP that appears on every thunk arm at once is a
+;;      property of CLOSURE CREATION rather than of any arm's subject, this
+;;      arm — which is nothing but closure creation — must show the SAME step.
+;;
+;; The second is the one the bead is about. An arm cannot be re-shaped out of a
+;; cost its own subject carries, so if the step is here it is not a defect in
+;; `N-CALLTHUNK` and no repair of `N-CALLTHUNK` can remove it.
+
+(defonce ^:private fn-escape (volatile! nil))
+
+(defn- arm-n-newfn []
+  (let [{:keys [n]} @rig]
+    (dotimes [_ n]
+      ;; created and made to escape, never called — so the counter advances
+      ;; exactly `n` times per call, as every arm here must.
+      (vreset! fn-escape (fn [] (keep! true)))
+      (keep! true))
+    nil))
 
 (defn- arm-n-cwfr-bind []
   (let [{:keys [n]} @rig]
@@ -1220,6 +1310,7 @@
                          ["N-CWFRBIND" arm-n-cwfr-bind n]
                          ["N-CWFRGEN"  arm-n-cwfr-gen  n]
                          ["N-CALLTHUNK" arm-n-callthunk n]
+                         ["N-NEWFN"    arm-n-newfn     n]
                          ["N-CWFRWRAP" arm-n-cwfr-wrap n]
                          ["N-CWFRRAW"  arm-n-cwfr-raw  n]
                          ["N-LOOKGEN"  arm-n-lookgen   n]
@@ -1355,6 +1446,51 @@
                              r (fmt (:p50 m)) (fmt (:lo m)) (fmt (:hi m))
                              (fmt (* r (:p50 m))) (fmt3 (/ (:p50 m) n))
                              (:unverified m)))))
+        (println ";;")
+        ;; --- rf2-ktrvw: what a thunk-dominated arm actually measures ----------
+        ;;
+        ;; Five arms here hand a freshly-allocated thunk to another function,
+        ;; and every one of them reads TWO values across windows: a settled one
+        ;; and a high one, bit-identical, with nothing between. The bead was
+        ;; opened on the suspicion that this is escape analysis eliding the
+        ;; subject in some windows. `N-NEWFN` decides it, by pricing the closure
+        ;; with nothing else in the arm at all.
+        (println ";; rf2-ktrvw — THE THUNK-DOMINATED ARMS ARE BIMODAL, and the mode is the CLOSURE")
+        (let [closure (net* "N-NEWFN")
+              steps   (volatile! [])]
+          (println (gstring/format ";;   N-NEWFN  one closure per inner iteration, nothing else:  %s B/read net" (fmt closure)))
+          (println (gstring/format ";;   N-CALLTHUNK - N-NEWFN = %s B/read   predicted 0 (a vreset! and a call)"
+                           (fmt (- (net* "N-CALLTHUNK") closure))))
+          (println ";;   arm           settled      high      step  = closures")
+          (doseq [l ["N-NEWFN" "N-CALLTHUNK" "N-CWFRNOG" "N-CWFRBIND" "N-CWFRGEN" "N-CWFRRAW"]]
+            (let [r    (get res l)
+                  lo   (/ (- (:lo r) noop) n)
+                  hi   (/ (- (:hi r) noop) n)
+                  step (- hi lo)]
+              (vswap! steps conj step)
+              (println (gstring/format ";;     %-12s %9s %9s %9s    %s"
+                               l (fmt lo) (fmt hi) (fmt step)
+                               (if (pos? closure)
+                                 (gstring/format "%.2f" (/ step closure))
+                                 "n/a")))))
+          ;; The point the table has to carry: the step is the SAME ABSOLUTE
+          ;; SIZE on arms whose totals differ by 75%, so it is additive and
+          ;; belongs to closure creation rather than to any arm's own subject.
+          (let [ss (filterv pos? @steps)]
+            (when (seq ss)
+              (println (gstring/format ";;   step across those arms: %s – %s B/read  (one closure = %s)"
+                               (fmt (apply min ss)) (fmt (apply max ss)) (fmt closure)))))
+          (println ";;   READ THIS AS: the step is ONE closure, the same absolute size on arms whose")
+          (println ";;   totals differ — additive, so it is closure CREATION and not any arm's")
+          (println ";;   subject. `N-NEWFN` carries it too, and `N-NEWFN` is nothing BUT a closure,")
+          (println ";;   so no re-shaping of a thunk arm can remove it: the arm would have to stop")
+          (println ";;   allocating the thing it exists to price. It appears in the FORWARD plan")
+          (println ";;   and the REVERSED one alike, so it is NOT a position effect — which is why")
+          (println ";;   the guard's phase factor catches it only when a third happens to straddle")
+          (println ";;   both modes, and why tuning that factor would be the wrong repair.")
+          (println ";;   CONSEQUENCE: a thunk-dominated arm is quotable as its RANGE and as an")
+          (println ";;   UPPER BOUND at the high mode, never as a p50 alone. The binding figure")
+          (println ";;   this file publishes is N-BINDONLY, which allocates no closure at all."))
         (println ";;")
         ;; --- the read ladder ------------------------------------------------
         (println ";; THE READ LADDER — bytes per READ (CLJS / node V8; NOT JVM, NOT Chrome)")

--- a/implementation/core/test/re_frame/bench/write_attribution.cljs
+++ b/implementation/core/test/re_frame/bench/write_attribution.cljs
@@ -213,8 +213,35 @@
   the missing browser figures. Ratios between two arms measured the same way
   are unaffected by any of this.
 
+  ## A near-zero arm is bounded, not measured (rf2-tmzie)
+
+  `C-NOOP` is `keep!` and nothing else, so whatever it reads is what an arm
+  that allocates NOTHING reads — the instrument's FLOOR, measured rather
+  than assumed. The floor is a roughly fixed number of bytes per WINDOW, so
+  it falls as `1/reps`, and an arm sitting on it has been BOUNDED, not
+  measured. `-main` prints the floor and lists every arm at or under it.
+
+  `WA_REPS_MAX` is the sweep that tells the two apart without leaving the
+  measured plan: a REAL per-call cost is cap-independent in B/call, a floor
+  is cap-independent in B/WINDOW. That distinction is what settled rf2-tmzie
+  — `C-FRAME` holds 32.0 B/call from `WA_REPS_MAX=64` to `4000`, a 62x range,
+  so it is a real per-call cost here and not the floor.
+
+  What it is NOT is the visibility walk it was published as. The bisection
+  (`C-FRAMEV` / `C-FRAMEL` / `C-FRAMES`) puts all 32 B in TWO
+  `PersistentHashMap` lookups on the frame record, 16 B each and additive,
+  and the `C-PHMGET` / `C-PAMGET` pair reproduces exactly that on maps built
+  for the purpose: a `get` on a 17-entry map costs 16 B, the same `get` on a
+  4-entry map costs 0. The registry itself holds four entries, which is why
+  `C-FRAMEG` is free. And `-diagnose` PROBE 4/5 read ~0 for the SAME closure
+  — a process whose only work is that one arm lets V8 elide the box, and a
+  second live caller does not restore it. So 32.0 B/call is an UPPER BOUND:
+  the cost this plan pays, and one a differently-optimised process does not.
+
   Environment: WA_N (subscriptions, default 300), WA_SAMPLES (samples per
-  arm across ALL rounds, default 40), WA_ROUNDS (default 6 — at least six,
+  arm across ALL rounds, default 40), WA_REPS_MAX (the window-size cap
+  `calibrate` clamps to, default 4000 — the rf2-tmzie sweep),
+  WA_ROUNDS (default 6 — at least six,
   so the guard's phase thirds are ranges rather than single samples),
   WA_WARM_WINDOWS (full-size discarded windows per arm before the first
   measured round, default 6), WA_WARMUP (bare calls before calibration,
@@ -490,9 +517,19 @@
 ;;              measuring by accident until rf2-c0awb.
 ;;   C-FRAMEG   the registry `get` ALONE on the same hit, which is what says
 ;;              WHICH HALF of `frame/frame` a hit-vs-miss difference is in.
-;;              It reads 0.0, so the `get` is free and the difference is the
-;;              visibility walk. That difference is DISPUTED between the two
-;;              entry points and is not quotable — see rf2-tmzie.
+;;              It reads 0.0 — the registry is a FOUR-entry map, so `get` is
+;;              an array scan and no hash is taken.
+;;   C-FRAMEV   the same walk `frame/frame` performs, re-spelled INLINE.
+;;              C-FRAME − C-FRAMEV is what the CALL costs; it is 0 (rf2-tmzie)
+;;   C-FRAMEL   the `:lifecycle` half of the walk alone
+;;   C-FRAMES   the `:construction` half alone. L + S = V, additively, and
+;;              each half is one `PersistentHashMap` lookup on the record.
+;;   C-PHMGET   CONTROL: one `get` on a 17-entry map. Predicted 16 B — a
+;;   C-PAMGET   CONTROL: one `get` on a 4-entry map. Predicted 0 B. The pair
+;;              differs only in the map's SIZE, which is what selects between
+;;              a hashed lookup and an array scan.
+;;   C-NOOP     CONTROL: `keep!` alone — the instrument's measured FLOOR at
+;;              this window size. No arm at or below it has been measured.
 ;;   C-PARTS    `commit-frame-record-transition!`'s partition bookkeeping:
 ;;              the two `contains?`, the four `get`, the `next-fs` map, the
 ;;              `changed` cond-> set, the two `not=` partition comparisons and
@@ -573,6 +610,114 @@
     (fn []
       (keep! (get @frame/frames id))
       nil)))
+
+;; rf2-tmzie — BISECTING the hit, because `C-FRAME − C-FRAMEG` was published as
+;; "the visibility walk" and no expression in that walk allocates.
+;;
+;; `frame-record-visible-to-current-actor?` is, for a FINAL record — which is
+;; every record `build-rig!` installs — two keyword invokes, a `not`, a third
+;; keyword invoke and a `not=`. The `:provisional` branch is unreachable: the
+;; `or`'s first arm is true, so `*frame-transaction-owner*` is never read and
+;; `owner-holds-frame-id?` never runs. Not one of those steps allocates on any
+;; reading of `cljs.core`, so a 32 B/call figure attributed to them is a claim
+;; about V8, not about the predicate — and V8 is exactly what a bisection can
+;; separate.
+;;
+;;   C-FRAMEG  the registry `get` alone                          (already there)
+;;   C-FRAMEV  + the WHOLE reachable predicate, re-spelled INLINE — the
+;;             `Q-SCHED` discipline. Identical WORK to `C-FRAME`, with the
+;;             cross-namespace CALL removed and nothing else changed.
+;;   C-FRAMEL  + the `:lifecycle` half alone
+;;   C-FRAMES  + the `:construction` half alone
+;;
+;; So `C-FRAME − C-FRAMEV` is what the CALL costs over the work, and
+;; `C-FRAMEV − C-FRAMEG` is what the work costs on its own. A figure that lands
+;; entirely in the first is not the visibility walk however stable it reads.
+
+(defn- arm-c-frame-vis
+  "The reachable predicate, INLINE. Verbatim `frame-record-visible-to-current-
+  actor?` minus the provisional branch, which a final record short-circuits
+  before it."
+  []
+  (let [id (nth (:frames @rig) 0)]
+    (fn []
+      (let [f (get @frame/frames id)]
+        (keep! (and (not (-> f :lifecycle :destroyed?))
+                    (not= :provisional (-> f :construction :state)))))
+      nil)))
+
+(defn- arm-c-frame-life
+  "The `:lifecycle` half alone — one two-level keyword walk and a `not`."
+  []
+  (let [id (nth (:frames @rig) 0)]
+    (fn []
+      (keep! (not (-> (get @frame/frames id) :lifecycle :destroyed?)))
+      nil)))
+
+(defn- arm-c-frame-state
+  "The `:construction` half alone — one two-level keyword walk and a `not=`.
+  `:construction` is ABSENT from a `new-frame-record` map, so this is the
+  missing-key path, which is the path the real predicate takes."
+  []
+  (let [id (nth (:frames @rig) 0)]
+    (fn []
+      (keep! (not= :provisional (-> (get @frame/frames id) :construction :state)))
+      nil)))
+
+;; rf2-tmzie — THE MECHANISM, as a PREDICTION stated before it is measured.
+;;
+;; The bisection lands on `16.0 B` per two-level keyword walk, twice, additive.
+;; 16 B is this file's OWN standing figure for a boxed `HeapNumber` with pointer
+;; compression OFF (see the `sink` header), and the two walks differ from the
+;; free registry `get` in exactly one structural way: the map they index.
+;;
+;;   `@frames` holds FOUR entries, so it is a `PersistentArrayMap` and `get` is
+;;   a linear `identical?` scan over an array — no hash is ever taken.
+;;
+;;   A frame record holds a dozen, so it is a `PersistentHashMap` and `get`
+;;   runs `(hash k)` then `inode-lookup`, whose first act is
+;;   `(bit-shift-right-zero-fill hash shift)`. A CLJS hash is a SIGNED int32;
+;;   `>>>` re-reads it as UNSIGNED, and any int32 with the sign bit set becomes
+;;   a value above 2^31 — outside Smi range, hence a `HeapNumber`.
+;;
+;; PREDICTION: one `get` on a >8-entry map costs 16 B/call; the same `get` on a
+;; <=8-entry map costs 0. If that is right, `C-FRAME`'s 32 B is two hash-map
+;; lookups on the frame record and has nothing to do with visibility.
+;;
+;; Both maps are built here rather than borrowed, so the sizes are chosen and
+;; not inherited, and both TYPES are printed by `-main` rather than asserted —
+;; the collection type is the whole claim, so it is read off the process.
+
+(def ^:private phm-probe
+  "SEVENTEEN entries. `PersistentArrayMap` promotes to `PersistentHashMap`
+  above eight, so this is comfortably clear of the boundary."
+  (into {} (map (fn [i] [(keyword "wa" (str "probe" i)) (inc i)])) (range 17)))
+
+(def ^:private pam-probe
+  "FOUR entries — the same shape as the rig's `@frames`, and below the
+  promotion boundary, so `get` is an array scan with no hash."
+  (into {} (map (fn [i] [(keyword "wa" (str "probe" i)) (inc i)])) (range 4)))
+
+(defn- arm-c-phm-get
+  "One `get` on a PersistentHashMap. Predicted 16.0 B/call."
+  []
+  (keep! (get phm-probe :wa/probe3))
+  nil)
+
+(defn- arm-c-pam-get
+  "The SAME `get`, same key, same value, on a PersistentArrayMap. Predicted
+  0.0 B/call. The pair differs in the map's SIZE and in nothing else."
+  []
+  (keep! (get pam-probe :wa/probe3))
+  nil)
+
+(defn- arm-c-noop
+  "The FLOOR, measured rather than inferred: `keep!` and nothing else. Whatever
+  this arm reads is what an arm that allocates nothing reads at this window
+  size, and no arm at or below it has been measured — it has been bounded."
+  []
+  (keep! true)
+  nil)
 
 (defn- arm-c-parts []
   (let [{:keys [fs-a fs-b db-a db-b]} @rig
@@ -821,13 +966,22 @@
 
 (defn- calibrate
   "Pick a rep count that puts one sample near `target` bytes, so no sample
-  outgrows the nursery and no sample is lost in the counter's own noise."
-  [f target]
+  outgrows the nursery and no sample is lost in the counter's own noise.
+
+  `cap` bounds the answer. It is a KNOB (`WA_REPS_MAX`) and not a constant
+  because an arm that allocates ~nothing per call always lands on it, and an
+  arm pinned at the cap cannot be told apart from the instrument's own
+  per-window floor by looking at one window size. Re-running the whole plan at
+  several caps IS the sweep: a real per-call cost is cap-INDEPENDENT in B/call,
+  a per-window constant is cap-independent in B/WINDOW and so falls as 1/reps.
+  That is the distinction rf2-tmzie was opened on, and `-main` can now make it
+  without leaving `-main` (see `floor-lines`)."
+  [f target cap]
   (collect!)
   (let [h0 (used-heap)
         _  (dotimes [_ 4] (f))
         per (max 1 (/ (- (used-heap) h0) 4))]
-    (-> (js/Math.round (/ target per)) (max 1) (min 4000))))
+    (-> (js/Math.round (/ target per)) (max 1) (min cap))))
 
 ;; ---------------------------------------------------------------------------
 ;; rig construction
@@ -952,6 +1106,11 @@
         warmup   (env-int "WA_WARMUP" 3)
         warm-windows (env-int "WA_WARM_WINDOWS" 6)
         rounds   (max 2 (env-int "WA_ROUNDS" 6))
+        ;; rf2-tmzie — the window-size cap `calibrate` clamps to. Every arm that
+        ;; allocates ~nothing per call pins here, so this is the ONE knob that
+        ;; separates a per-CALL cost from a per-WINDOW one without leaving the
+        ;; measured plan.
+        reps-max (max 1 (env-int "WA_REPS_MAX" 4000))
         per-round (max 1 (js/Math.ceil (/ samples rounds)))
         tolerance (env-num "WA_TOLERANCE" 0.25)
         rev?     (= "rev" (env "WA_ORDER" ""))
@@ -981,8 +1140,8 @@
     (println (gstring/format ";; node %s  V8 %s  pointer-compression=%s (Chrome ships it ON: a tagged slot is 4 B there, 8 B here)"
                      (.-node js/process.versions) (.-v8 js/process.versions)
                      (if (= 1 (gobj/getValueByKeys js/process "config" "variables" "v8_enable_pointer_compression")) "ON" "OFF")))
-    (println (gstring/format ";; n=%d samples=%d (%d rounds x %d) warmup=%d calls + %d windows  base order=%s frames=%s"
-                     n samples rounds per-round warmup warm-windows
+    (println (gstring/format ";; n=%d samples=%d (%d rounds x %d) warmup=%d calls + %d windows  reps-max=%d  base order=%s frames=%s"
+                     n samples rounds per-round warmup warm-windows reps-max
                      (if rev? "REVERSED" "forward")
                      (pr-str ns-per-frame)))
     (println (gstring/format ";; arm order ROTATES AND REFLECTS with the round (rf2-88pie); guard tolerance %s"
@@ -1004,6 +1163,24 @@
                        (if (trace/trigger-handler-from-meta :sub :probe slot)
                          "BUILT — P-SCOPEM is the predictive arm"
                          "nil — P-SCOPE is the predictive arm"))))
+    ;; rf2-tmzie — the mechanism pair's whole claim is the COLLECTION TYPE, so
+    ;; the type is read off the process rather than asserted from an entry
+    ;; count. `@frames` is printed beside them because `C-FRAMEG`'s 0.0 is only
+    ;; evidence about array maps while the registry actually is one.
+    ;; Type NAMES are minified under `:advanced`, so the claim is put as an
+    ;; identity comparison, which survives minification: the big map's type
+    ;; must DIFFER from the small one's, and the registry's must MATCH it.
+    (println (gstring/format ";; probe maps: %d-entry %s   %d-entry %s   registry @frames %d-entry %s"
+                     (count phm-probe) (pr-str (type phm-probe))
+                     (count pam-probe) (pr-str (type pam-probe))
+                     (count @frame/frames) (pr-str (type @frame/frames))))
+    (println (gstring/format ";;   big differs from small = %s   registry is the SMALL-map type = %s  (%s)"
+                     (not (identical? (type phm-probe) (type pam-probe)))
+                     (identical? (type @frame/frames) (type pam-probe))
+                     (if (and (not (identical? (type phm-probe) (type pam-probe)))
+                              (identical? (type @frame/frames) (type pam-probe)))
+                       "as the C-PHMGET / C-PAMGET pair requires"
+                       "*** the mechanism pair is NOT contrasting what it claims ***")))
     ;; Agreement gate: every held subscription must read what the writer
     ;; wrote, or the graph is not wired and nothing below is evidence.
     (let [f (last (:frames @rig))
@@ -1028,6 +1205,14 @@
                         ["C-FRAME"   (arm-c-frame)        1]
                         ["C-FRAMEX"  (arm-c-frame-miss)   1]
                         ["C-FRAMEG"  (arm-c-frame-get)    1]
+                        ;; rf2-tmzie — the same work with the CALL removed
+                        ["C-FRAMEV"  (arm-c-frame-vis)    1]
+                        ["C-FRAMEL"  (arm-c-frame-life)   1]
+                        ["C-FRAMES"  (arm-c-frame-state)  1]
+                        ;; rf2-tmzie — the mechanism pair, and the measured floor
+                        ["C-PHMGET"  arm-c-phm-get        1]
+                        ["C-PAMGET"  arm-c-pam-get        1]
+                        ["C-NOOP"    arm-c-noop           1]
                         ["C-PARTS"   arm-c-parts          1]
                         ["C-TAGPAIR" arm-c-tagpair        1]
                         ["C-BUMP"    arm-c-bump           1]
@@ -1060,7 +1245,7 @@
           ;; refuses. So every arm is walked to its settled value first.
           reps (mapv (fn [[label f _]]
                        (dotimes [_ warmup] (f))
-                       (let [r (calibrate f 2000000)]
+                       (let [r (calibrate f 2000000 reps-max)]
                          (dotimes [_ warm-windows] (measure f r 1))
                          (println (gstring/format ";; warm %-12s reps=%-6d %d discarded windows"
                                           label r warm-windows))
@@ -1106,6 +1291,26 @@
                            label (:reps r) (fmt (:p50 r)) (fmt (:lo r)) (fmt (:hi r))
                            (fmt (/ (:p50 r) per)) (:accepted r) (:dropped r)
                            (fmt (apply min rnd)) (fmt (apply max rnd))))))
+      ;; rf2-tmzie — THE FLOOR, measured rather than assumed. `C-NOOP` is
+      ;; `keep!` and nothing else, so whatever it reads is what "allocates
+      ;; nothing" reads at THIS window size. The floor is window-size
+      ;; dependent — it is a roughly fixed number of bytes per WINDOW, so it
+      ;; falls as 1/reps — which is why `WA_REPS_MAX` exists and why an arm
+      ;; that sits on it must be reported as an upper bound rather than a
+      ;; measurement. Re-run at a smaller `WA_REPS_MAX` and an arm whose figure
+      ;; RISES was never measuring itself.
+      (println ";;")
+      (println ";; THE FLOOR — what an arm that allocates NOTHING reads in this run")
+      (let [nreps (:reps (get res "C-NOOP"))
+            floor (b "C-NOOP")]
+        (println (gstring/format ";;   C-NOOP  %s B/call at reps=%-6d (%s B per WINDOW)  [reps-max=%d]"
+                         (fmt floor) nreps (fmt (* floor nreps)) reps-max))
+        (let [bounded (filterv (fn [[label _ _]] (<= (b label) floor)) plan)]
+          (if (seq bounded)
+            (do (println ";;   AT OR UNDER IT — bounded, not measured; report these as <=:")
+                (doseq [[label _ _] bounded]
+                  (println (gstring/format ";;     <= %-10s %10s B/call" label (fmt (b label))))))
+            (println ";;   no arm is at the floor in this run"))))
       (println ";;")
       (println ";; CONTROLS")
       ;; rf2-l3jv4 — the ABSOLUTE, checked, at every size. The slopes below
@@ -1206,7 +1411,7 @@
             sp0    (b "SPINE0")
             delta  (- rf0 sp0)
             proj   (- (b "SPINE0P") (b "SPINE0B"))
-            comps  [["C-FRAME    (frame id) registry lookup, HIT" (b "C-FRAME")]
+            comps  [["C-FRAME    (frame id) lookup, HIT  [<= — rf2-tmzie]" (b "C-FRAME")]
                     ["C-PARTS    partition bookkeeping"      (b "C-PARTS")]
                     ["C-TAGPAIR  two [::ok v] pairs"         (b "C-TAGPAIR")]
                     ["C-PROJ     the two projections"        proj]
@@ -1232,15 +1437,46 @@
         (println (gstring/format ";;   C-FRAME (registry HIT) %s B vs C-FRAMEX (MISS) %s B  -> a HIT costs %s B/lookup more than a miss"
                          (fmt (b "C-FRAME")) (fmt (b "C-FRAMEX"))
                          (fmt (- (b "C-FRAME") (b "C-FRAMEX")))))
-        (println (gstring/format ";;   C-FRAMEG (the registry `get` alone, same hit) %s B  -> the visibility walk is the remaining %s B"
+        (println (gstring/format ";;   C-FRAMEG (the registry `get` alone, same hit) %s B  -> the record walk is the remaining %s B"
                          (fmt (b "C-FRAMEG"))
                          (fmt (- (b "C-FRAME") (b "C-FRAMEG")))))
-        (println ";;   ^ that non-zero is DISPUTED and may NOT be quoted (rf2-tmzie): `-diagnose`")
-        (println ";;     PROBE 4 sweeps the SAME closure and reads a CONSTANT 32 B per WINDOW from")
-        (println ";;     reps=64 to reps=4000 — i.e. ~0 B/call — where the plan reads 32 B/CALL at")
-        (println ";;     reps=4000. One of the two is wrong and it is not yet known which. What IS")
-        (println ";;     settled is that the arm takes the HIT path now, and that the registry")
-        (println ";;     `get` is free in both."))
+        ;; rf2-tmzie — WHAT THAT NON-ZERO IS. It was published as "the
+        ;; visibility walk" and disputed against `-diagnose`, which reads a
+        ;; constant 32 B per WINDOW for the same closure. Both readings stand;
+        ;; they are of different things, and these arms say which is which.
+        (println ";;")
+        (println ";;   rf2-tmzie — WHAT THE 32 B IS, bisected")
+        (doseq [[lbl v note]
+                [["C-FRAME   frame/frame, the shipped call" (b "C-FRAME")
+                  "the whole hit"]
+                 ["C-FRAMEV  the same walk, re-spelled INLINE" (b "C-FRAMEV")
+                  "no call: so the cost is the WORK, not the call"]
+                 ["C-FRAMEL  the :lifecycle half alone" (b "C-FRAMEL")
+                  "one PersistentHashMap `get` on the record"]
+                 ["C-FRAMES  the :construction half alone" (b "C-FRAMES")
+                  "one PersistentHashMap `get` on the record"]
+                 ["C-FRAMEG  the registry `get` alone" (b "C-FRAMEG")
+                  "PersistentArrayMap: no hash is taken"]]]
+          (println (gstring/format ";;     %-44s %8s B   %s" lbl (fmt v) note)))
+        (println (gstring/format ";;     -> C-FRAMEL + C-FRAMES = %s B against C-FRAMEV's %s B  (%+.1f%%)"
+                         (fmt (+ (b "C-FRAMEL") (b "C-FRAMES"))) (fmt (b "C-FRAMEV"))
+                         (let [s (+ (b "C-FRAMEL") (b "C-FRAMES"))
+                               v (b "C-FRAMEV")]
+                           (if (zero? v) 0.0 (* 100.0 (/ (- s v) v))))))
+        ;; The mechanism, predicted before it was measured, on maps built for
+        ;; the purpose and differing only in size.
+        (let [phm (b "C-PHMGET") pam (b "C-PAMGET")]
+          (println (gstring/format ";;     CONTROL  `get` on a %d-entry map %8s B   predicted 16.0 (one boxed HeapNumber)  %+.1f%%"
+                           (count phm-probe) (fmt phm) (* 100.0 (/ (- phm 16.0) 16.0))))
+          (println (gstring/format ";;     CONTROL  `get` on a %d-entry map %8s B   predicted  0.0 (array scan, no hash)"
+                           (count pam-probe) (fmt pam)))
+          (println (str ";;     So the 32 B is TWO boxed hash values, one per PersistentHashMap lookup on"))
+          (println (str ";;     the frame record — NOT the visibility test, which is a `not`, a `not=` and"))
+          (println (str ";;     nothing else. `-diagnose` PROBE 4/5 read ~0 B/call for the same closure"))
+          (println (str ";;     because a process whose only work is that one arm lets V8 keep the shift"))
+          (println (str ";;     result in a register; PROBE 5 shows a second live caller does NOT restore"))
+          (println (str ";;     it. So this figure is an UPPER BOUND — the cost this plan pays and a"))
+          (println (str ";;     single-arm process does not. Quote it as <=, with the runtime named."))))
       ;; --- arm order, LAST, and it governs everything above ----------------
       ;; The figures are printed and the refusal is about what may be QUOTED,
       ;; not about throwing the measurement away — so the exit code carries
@@ -1466,6 +1702,49 @@
                 ;; the miss feeds `keep!` a nil, so the counter must NOT move —
                 ;; a window where it did was not measuring the miss
                 (fn [before after _] (== after before))]]]
+        (dotimes [_ 3] (f*))
+        (dotimes [_ 6] (measure f* 256 1))
+        (doseq [reps sweep]
+          (let [r (probe f* reps windows seed verify)]
+            (probe-line label reps r reps))))
+      ;; ---- PROBE 5 — the SAME sweep, once `frame/frame` has a SECOND caller --
+      ;;
+      ;; rf2-tmzie. PROBE 4 above and the measured plan disagree about the same
+      ;; closure by a factor of the rep count, and the sweep says which is which:
+      ;; PROBE 4 is flat in B/WINDOW (so ~0 B/call), the plan is flat in B/CALL
+      ;; across a 62x range of window sizes. Both are stable, so this is not
+      ;; noise; something about the two PROCESSES differs.
+      ;;
+      ;; The candidate is escape analysis, and it is testable. In PROBE 4 the
+      ;; measured loop is the ONLY thing in the process that calls
+      ;; `frame/frame`, so V8 can inline it whole — registry `get`, visibility
+      ;; predicate and all — into one loop body, prove nothing it builds
+      ;; escapes, and delete it. `-main` cannot offer that: its `RFWRITE-*` arms
+      ;; drive `frame/replace-app-db!`, whose `commit-frame-transition!` calls
+      ;; `frame/frame` on every write, so the function is hot from a second site
+      ;; whose result genuinely escapes.
+      ;;
+      ;; So: run the real write path until that second call site is hot, then
+      ;; re-run PROBE 4's exact sweep on a FRESH closure over the same id, in
+      ;; the SAME process. Nothing else changes. If the arm converts from
+      ;; ~constant-per-window to ~32-per-call, the elision is named and `-main`
+      ;; is the reading a real application — which never has a single-caller
+      ;; `frame/frame` — actually gets.
+      (println ";;")
+      (println ";; PROBE 5 — PROBE 4's sweep again, after the SHIPPED write path has made")
+      (println ";;   `frame/frame` hot from a SECOND call site (commit-frame-transition!).")
+      (println ";;   ~constant B/window -> still elided;  flat B/call -> the elision is gone")
+      (let [writer (fn [] (arm-rfwrite 0))]
+        (dotimes [_ 20000] (writer))
+        (println (gstring/format ";;   (20000 frame/replace-app-db! writes through frame 0 first; sink2 %s)"
+                         (some? @sink2))))
+      (doseq [[label f* seed verify]
+              [["C-FRAME  HIT s=1"  (arm-c-frame)     1 (advanced-by 1)]
+               ["C-FRAMEG get-only" (arm-c-frame-get) 1 (advanced-by 1)]
+               ;; the inline re-spelling of the same work — it has no call to
+               ;; leave un-inlined, so if the step is the CALL and not the WALK
+               ;; this arm stays on the floor while `C-FRAME` leaves it.
+               ["C-FRAMEV inline"   (arm-c-frame-vis) 1 (advanced-by 1)]]]
         (dotimes [_ 3] (f*))
         (dotimes [_ 6] (measure f* 256 1))
         (doseq [reps sweep]

--- a/implementation/core/test/re_frame/bench/write_attribution.cljs
+++ b/implementation/core/test/re_frame/bench/write_attribution.cljs
@@ -915,6 +915,23 @@
 ;; The derived-value fan-out over a two-plus-subscriber watcher map, in BOTH
 ;; spellings. `P-VALS` is the RETIRED `(run! f (vals ws))`; `P-RKV` is the
 ;; `reduce-kv` walk that replaced it.
+;;
+;; rf2-ktrvw — BOTH ARMS HAND A FRESH CLOSURE TO A CALLEE, one per call, and
+;; that is a bimodal cost on this runtime. `read_attribution_cljs`'s `N-NEWFN`
+;; prices a bare closure at 64.0 B settled and 128.1 B in its high mode — a
+;; step of exactly ONE closure, per WINDOW, in both plan orders — and an arm
+;; whose subject IS a closure cannot be re-shaped out of it.
+;;
+;; It is visible here on `P-RKV`, which allocates one closure per call against
+;; a body of ~81 B: it reads 80.9 B/call [80.9 – 83.6] at the default
+;; `WA_REPS_MAX=4000` and 86.9 [86.9 – 145.2] at 512 — a ~58 B step, one
+;; closure — and that step is what makes the guard refuse it by PHASE at the
+;; smaller cap. A long window hammers the closure site enough to settle inside
+;; the window; a short one can sit wholly in either mode.
+;;
+;; So `P-RKV`'s and `P-VALS`'s ranges are load-bearing and their p50s are not
+;; quotable alone. The SHIPPED-vs-RETIRED difference these two exist for is
+;; unaffected: both halves allocate one closure, so it cancels.
 
 (defn- arm-p-vals []
   (let [{:keys [watch-map]} @rig]


### PR DESCRIPTION
Two measurement loose ends that earlier diagnoses deliberately left open. Both are **diagnoses**; neither turned out to need a product change, and no production source is touched.

## rf2-tmzie — the 32 B is per-CALL, and it is two hash-map lookups

`-main` read `C-FRAME` at 32.0 B/call while `-diagnose` PROBE 4 read a constant 32 B per **window** for the same closure — a factor of ~4000. Neither is wrong; they are readings of different things.

**Which is per-call, settled inside `-main`.** `calibrate`'s window cap was a hardcoded 4000, and every arm allocating ~nothing pins to it, so a per-call cost and a per-window floor look identical from one window size. It is now `WA_REPS_MAX`, and re-running the plan at several caps *is* the sweep:

| `WA_REPS_MAX` | 64 | 256 | 512 | 1024 | 4000 |
|---|---:|---:|---:|---:|---:|
| `C-FRAME` | 34.8 | 32.7 | 32.1 | 32.0 | 32.0 |
| `C-FRAMEG` (paired control) | 2.3 | 0.6 | 0.0 | 0.0 | 0.0 |

Flat in **B/call** across a 62× range, so it is a real per-call cost. The control's residual is the floor, and it falls as 1/reps exactly as a floor must.

**What it is — and it is not what was published.** It went out as "the visibility walk", and no expression in that walk allocates. Bisected:

| arm | B/call | |
|---|---:|---|
| `C-FRAME` — the shipped call | 32.0 | the whole hit |
| `C-FRAMEV` — the same walk re-spelled INLINE | 32.0 | so it is **not** the call |
| `C-FRAMEL` — the `:lifecycle` half | 16.0 | one `PersistentHashMap` `get` |
| `C-FRAMES` — the `:construction` half | 16.0 | one `PersistentHashMap` `get` |
| `C-FRAMEG` — the registry `get` | 0.0 | `PersistentArrayMap`: no hash taken |

L + S = V at **+0.0%**. Mechanism stated as a prediction *before* measurement — a frame record holds a dozen keys so it is a hash map, and `inode-lookup` opens with `>>>` on a signed int32 hash; any hash with the sign bit set re-reads above 2^31, outside Smi range, hence a 16 B `HeapNumber` with pointer compression off. `@frames` holds four entries, so it is an array map and `get` is a scan.

| control | measured | predicted | |
|---|---:|---:|---:|
| `get` on a 17-entry map | 16.0 | 16.0 | **+0.0%** |
| `get` on a 4-entry map | 0.0 | 0.0 | — |

Both collection types are **read off the process**, as an identity comparison rather than a type name, which minification survives.

**And it is an upper bound.** `-diagnose` was not wrong either. New **PROBE 5** re-runs PROBE 4's exact sweep after 20,000 real `replace-app-db!` writes have made `frame/frame` hot from `commit-frame-transition!` — a genuine second call site — and the elision **survives** at 32 B/window across the whole sweep. So the difference cannot be closed by adding callers; it is the optimisation state of the whole process.

**rf2-78ejq's component survives, qualified**: `C-FRAME` stays at 32.0 B / 1.3% of the `RFWRITE-0 − SPINE0` delta, now labelled `[<=]`, and the attribution names hash-map lookups rather than visibility.

The **floor is now measured**, not assumed: `C-NOOP` is `keep!` and nothing else, and `-main` lists every arm at or under it as bounded rather than measured.

## rf2-ktrvw — a thunk arm prices a closure, and a closure is two numbers

The bead asked whether these arms can be re-shaped so escape analysis cannot elide the subject. **They cannot**, and the reason is worth more than the repair. `N-NEWFN` creates one closure per inner iteration and does nothing else — no callee, no binding, not even a call — and carries the whole step:

| arm | settled | high | step | = closures |
|---|---:|---:|---:|---:|
| `N-NEWFN` | 64.0 | 128.1 | 64.1 | 1.00 |
| `N-CALLTHUNK` | 64.0 | 128.1 | 64.1 | 1.00 |
| `N-CWFRNOG` | 64.0 | 128.6 | 64.6 | 1.01 |
| `N-CWFRBIND` | 112.0 | 176.4 | 64.3 | 1.01 |
| `N-CWFRGEN` | 112.0 | 176.6 | 64.6 | 1.01 |
| `N-CWFRRAW` | 112.0 | 176.5 | 64.5 | 1.01 |

B/read net of `NOOP`, reversed plan; forward agrees at 64.0–64.6. The step is the **same absolute size** on arms whose totals differ by 75% — additive, so it is closure **creation**, not any arm's subject. `N-CALLTHUNK − N-NEWFN` = 0.0 against a prediction of 0.

So what these arms measure is *one closure, in whichever of two modes V8's site is in* — quotable as a **range** and an upper bound at the high mode, never a p50 alone. No headline depends on one: `N-BINDONLY` carries no closure, and the budget and symmetric-pair reconstructions each difference two arms carrying exactly one, so the mode cancels.

**The guard is left alone.** The step appears in the forward and reversed plans alike, so it is not a position effect and `phase` does not describe it — that factor fires when a third lands wholly in one mode and passes when a third straddles both. Widening the tolerance would hide a real bimodality; narrowing it would refuse at random. Both orders currently exit 0 for that reason, **not** because the phenomenon went away, and the header and studio doc now say so. Tolerance untouched at 25%; both self-tests untouched.

**Does `write_attribution` have the same exposure?** Yes, on `P-RKV`, and it is the arm that refuses there — 80.9 [80.9–83.6] at `WA_REPS_MAX=4000`, 86.9 [86.9–145.2] at 512, a ~58 B step, one closure. Recorded beside the arm.

The bead's third idea, a per-arm guard verdict, is **not** taken: the arms it would have excused are not contaminated, they are bimodal, and the honest fix was to say what they measure.

## Quality gates

Node 24.13.0 / V8 13.6.233.17-node.37, pointer compression **OFF**, `:advanced` + `goog.DEBUG=false`, n=300, 42 windows, 6 rounds. Foreground, unpiped, exit codes echoed.

| gate | exit |
|---|---:|
| `write-attribution` run 1 (guard: reportable) | 0 |
| `write-attribution` run 2 (guard: reportable) | 0 |
| `write-attribution` run 3 (guard: reportable) | 0 |
| `read-attribution-cljs` forward (guard: reportable) | 0 |
| `read-attribution-cljs` reversed (guard: reportable) | 0 |
| order-guard self-test, `.cljc` copy (runs inside both harnesses) | 0 |
| order-guard self-test, `.cjs` copy | 0 |
| `npm run test:cljs` — 11896 tests, 59378 assertions, 0 failures, 0 errors | 0 |
| `python -m mkdocs build --strict` | 0 |

**Guard refusals seen, and what they are.** At the default cap all 41 arms are reportable in all three runs, with the bisection identical to the printed precision. At the diagnostic caps `WA_REPS_MAX=256` and `512` the guard refuses by phase on `C-TAGPAIR` and `P-RKV` — near-zero arms sitting on a coarser floor at a smaller window, not arms this PR changed, and not the default.

**Controls, predicted vs measured**: DBL slope small pair +0.5%, SMI/DBL ratio ×1.0000 (8 B/slot, compression OFF), `C-PHMGET` +0.0%, `C-PAMGET` on prediction, `N-CALLTHUNK − N-NEWFN` on prediction. The large DBL pair remains +9% (V8 page-tail filler on large objects) — pre-existing, documented, and every arm here allocates small objects.

**Read-back**: 0 unverified of 42 windows on every `read-attribution-cljs` arm; 0 dropped samples on every `write-attribution` arm.

**Runtime**: node, not Chrome (~2× on pointer compression); CLJS, not JVM. Shares transfer, absolutes do not.

Not in scope and deliberately not done: no Freehand-versus-Reagent verdict, and no production source touched — this is measurement, not optimisation.
