### PR TITLE
docs,test(freehand): the witnesses project their identity and the honesty section is true (rf2-drpa3.182.8, rf2-drpa3.182.9)

### DIFF
--- a/docs/core/freehand/advanced/semantic-controllers.md
+++ b/docs/core/freehand/advanced/semantic-controllers.md
@@ -147,6 +147,37 @@ Debounce begins as **library or app policy**. It graduates into reserved re-fram
 vocabulary only after independent UI and non-UI uses share identity, cancellation,
 frame, SSR, and trace semantics (D017). Do not invent `v/debounce`.
 
+### The whole control, proven
+
+The sketch above is the app pattern. The *packaged* version of it — a typeahead
+with an anchored suggestion popover, an IME-safe keyboard, correlation and
+supersession, and an owner’s clear — is proven end to end as **`FH-CTRL-020`**
+in the Freehand conformance index (`spec/conformance/freehand/conformance-index.md`,
+§FH-CTRL). Three things in it are worth borrowing before you write your own:
+
+- **The popover is anchored by the platform, not by you.** The input declares
+  `anchor-name`; the list declares `position-anchor` and takes its insets from
+  `anchor(bottom)` / `anchor(left)`, with `position-try-fallbacks` for collision.
+  So there is no measured rectangle, no `ResizeObserver`, and nothing to release
+  — and nothing to go stale inside a scroll container. The cost is stated rather
+  than hidden: CSS anchor positioning is Chromium-first, so this is the one part
+  of the control bound to a real browser.
+- **A composing Enter commits nothing.** The rule is `controls/key-intent`, a
+  pure function of the key and the composition flag, so it is provable without a
+  browser — and the arrows are withheld during a composition for the same reason
+  Enter is, because a candidate window is what `ArrowDown` is moving through.
+- **Nothing needs cancelling.** Every keystroke mints a token, and the debounce
+  *is* that comparison: a scheduled search firing for a superseded token does
+  nothing, so there is no timer handle to hold and no cleanup to forget.
+
+**One limit, and it is the grammar’s rather than the control’s.** A typeahead
+like this stays **interpreted**. Its options render in a loop and each option’s
+commit closes over that loop’s index, which is not a lexical event site — ask
+`v/check` and it answers `:rf.ui.compile/loop-capturing-handler` with a single
+recovery rung, `:keep-interpreted`. The *call site* around it compiles fine, so
+this is the ordinary composition and not a cliff: promotion is per declaration,
+and a listbox is simply not the shape the compiled tier is for.
+
 ## Where the data lives
 
 Controller state is **ordinary frame-scoped re-frame data** (usually that frame’s

--- a/docs/core/freehand/host/js-libraries.md
+++ b/docs/core/freehand/host/js-libraries.md
@@ -191,17 +191,42 @@ Conditional render stays familiar: drop the toast from app-db, remove the child;
 `AnimatePresence` is supposed to retain it through exit while `motion` reads
 presence through React context (one React tree under the Freehand host).
 
-### Honesty: designed, not yet a proven pilot
+### Honesty: the composition is proven; the vendor package is not installed here
 
-The **AnimatePresence-through-a-Freehand-boundary** path is **designed and
-argued**, not yet proven in a mounted exit pilot. Treat exit animation across a
-Freehand shell as a hypothesis until a test shows:
+This section used to say the **AnimatePresence-through-a-Freehand-boundary** path
+was designed and argued rather than proven, and to ask for a mounted exit pilot
+before you trusted it. That pilot exists. It is **`FH-REACT-010`**, and it
+measures exactly the three steps this section used to ask for:
 
-1. toast removed from app-db  
-2. exit motion runs  
-3. node is gone afterward  
+1. the child is dropped from what Freehand commits;  
+2. the library keeps it on the page, marked exiting, while the last commit’s
+   props no longer name it;  
+3. the library finishes, the child goes, and completion crosses back through the
+   one declared callback position as an ordinary event.  
 
-Enter-only motion is a weaker claim; exit is where composition usually breaks.
+The divergence in step 2 — between what is on the page and what the last commit
+handed over — **is** the retention, and there is no third book: the substrate
+holds nothing for it. So exit across a Freehand shell is no longer a hypothesis,
+and the routing question it raises is not *whether* it works but *who owns the
+retention*. [Ownership routing](ownership-routing.md) answers that one; the short
+version is that two owners over one keyed subtree is two clocks, and `v/presence`
+over a subtree the library is already animating is the second clock.
+
+The same row proves the half that fails silently rather than visibly: the animated
+property must have exactly **one writer**. Where your call does not author
+`transform`, the library’s imperative write survives an ordinary commit. Where it
+*also* authors it, the commit wins, the library’s own state and the DOM disagree,
+and nothing errors or warns.
+
+**What is still not proven, and it is worth being exact about which half.**
+`framer-motion` itself is not installed in this repository: a real animation is
+driven by `requestAnimationFrame` against a wall clock, so a gate built on it
+would be measuring frame timing rather than ownership. The mounted proof therefore
+drives a deterministic surrogate reproducing the ownership shape with the clock
+taken out, and the fixture says so in a machine-readable `:evidence :limits`. What
+remains outstanding is the **vendor’s own timing** — not the composition, and not
+the ownership boundary this page routes by.
+
 Compiled mode is a separate cliff: the compiled grammar refuses `v/client-only`
 outright and cannot see through a `createElement` call, so a view doing this work
 stays interpreted — which is fine, because promotion is per declaration.
@@ -407,7 +432,7 @@ refuses to be released.
 
 ### Proven, not merely argued
 
-Unlike the exit-animation path above, this one is mounted. The ordering that
+Like the exit-animation path above, this one is mounted. The ordering that
 matters — **unmount before the Promise resolves** — is asserted in
 `behavior_async_dom_cljs_test.cljs` against a deterministic surrogate: the late
 handle is disposed exactly once, never configured, and the library's book of
@@ -422,7 +447,7 @@ leak instead of wished away. A real third-party witness is still outstanding.
 | Question | Prefer |
 |---|---|
 | Fade/slide on enter/exit only? | **`v/presence` + CSS** |
-| Framer components only (`motion.*`, `AnimatePresence`)? | **React elements in child positions** (+ pilot for exit) |
+| Framer components only (`motion.*`, `AnimatePresence`)? | **React elements in child positions**; let the library own the retention (`FH-REACT-010`) |
 | You call Framer **hooks** (`useMotionValue`, …)? | a **small React component of your own** — hooks only inside that file |
 | Drive a non-React player (GSAP on a node)? | **Behavior** |
 | Construction answers a Promise? | **Behavior** whose `:connect` returns a **cell** ([Pattern E](#pattern-e--the-handle-arrives-later-promise-acquired-hosts)) |
@@ -449,7 +474,11 @@ motion bus.
 - **Headless** cores (TanStack Table core, etc.) — state in re-frame; Freehand
   markup; no host shape.  
 - **Heavy Radix / `asChild` product shell** — UIx (or similar) for that region;
-  Freehand as islands.  
+  Freehand as islands. Note this is a judgement about *scale*, not capability: a
+  single compound library crosses fine through one `v/defhost` of its wrapper
+  (`FH-REACT-009`). It is a whole shell built out of `asChild` composition —
+  where nearly every element is a cloned child — that is better owned by React
+  outright.  
 - **Fade/slide only** — presence + CSS before any motion library.
 
 ## Other libraries, same shapes

--- a/docs/core/freehand/host/ownership-routing.md
+++ b/docs/core/freehand/host/ownership-routing.md
@@ -1,0 +1,173 @@
+# Ownership routing
+
+There is one question to answer before you integrate anything, and it is not
+which library you picked.
+
+> **Who owns the node, and who owns the state that decides what is on it?**
+
+Every route below falls out of that answer. Nothing here is a rule about Google
+Maps or Radix or Framer Motion — those are *examples of ownership shapes*, and
+two libraries with nothing else in common route identically when they own the
+same things. The [JavaScript libraries](js-libraries.md) page is the recipe
+companion: it shows the code. This page decides which recipe you are writing.
+
+Routing by brand is how integrations go wrong. "Radix is a UI kit, so it goes in
+a component" and "Maps is a map, so it goes in a `<div>`" are both true and both
+useless — the first thing that matters about Radix is that it passes state
+*between* its own parts through React context, and the first thing that matters
+about Maps is that it hands you back a node *it* created.
+
+## The three facts that decide the route
+
+Answer these in order. The first one that is true settles it.
+
+| # | Ownership fact | What it means in practice |
+|---|---|---|
+| 1 | **The library owns a DOM subtree.** | You hand it an element and it builds inside; you must never render into that element again. `new X(el)`, `chart.render(el)`, `map.setCenter(…)`. |
+| 2 | **The library owns state that flows between its own parts.** | A root component publishes through React context, refs, or `asChild` cloning, and the parts are meaningless apart. Compound React libraries live here. |
+| 3 | **The library owns a *clock*.** | Something continues after the commit that started it: an exit animation, a spring, a transition. The DOM disagrees with your last commit *on purpose*, for a while. |
+
+If none of the three is true, the library owns nothing and you have the easy
+case: it is a function, and it belongs in an event handler or a subscription
+like any other pure code.
+
+## The routes
+
+| Ownership shape | Route | Crossings it costs | What stays yours |
+|---|---|---|---|
+| **Pure / headless core** — formatters, geometry, parsers, a date library, a diffing engine | No boundary at all. Call it from an event handler, a subscription, or a view body. | none | everything |
+| **React component: values in, callbacks out** — date pickers, most charts, most inputs | **`v/defhost`**, registered once. | one door | the state, the props, the events |
+| **React compound owner** — context between parts, `asChild` ref cloning, its own portal, its own focus management | **`v/defhost` on the *wrapper*** — the component that composes the parts — never on the parts individually. | one door | which parts render, and the data in them |
+| **Imperative SDK owning a node** — Mapbox, Vega, a grid widget, GSAP on an element | **Registered behavior.** `:connect` establishes one mutable cell; `:update` mutates and its return value is discarded; `:disconnect` releases. | one behavior | the config, as data |
+| **The library hands *you* a node** — an overlay pane, a popup container, a cell renderer target | **An explicit nested Freehand root** into the node you were given, torn down when it is taken back. | one behavior + one extra root | the view you mount there |
+| **The library owns a clock** — exit animation, physics, transitions | Let the library own the retention. Do **not** put `v/presence` over the same keyed subtree. | one door | which children exist |
+| **A React tree needs to render *your* view** — you are the guest, not the host | **`v/->react`**, which answers a component. Hoist it; repeated exports answer the identical one. | one export | the view |
+
+### Pure and headless cores need no route
+
+The largest category, and the one people over-engineer. A library with no DOM and
+no lifecycle is not a host concern. Put it where the answer is needed and keep the
+result in app-db if it is worth time-travelling and out of app-db if it is not.
+
+### One door for a compound owner, and it goes around the whole thing
+
+The temptation with a compound React library is to register each part so the call
+site reads like the library's own docs. Do not. The parts talk to each other
+through React context and refs, and a Freehand declaration between two of them is
+a hole in that conversation.
+
+Register the wrapper. Everything inside stays React-primary and keeps working:
+the portal lands where React put it, focus moves on open and returns on close, and
+the substrate neither moves it nor watches it move.
+
+**The permanent limit here is a promise Freehand withholds:** a Freehand-authored
+child does **not** participate in `asChild`, arbitrary `cloneElement`, or
+ref-injection. It does not fail, either — React hands a `ref` prop to a function
+component as an ordinary unused prop, so the ref simply never arrives and nothing
+says so. **The recovery is the route itself**: if a region needs those protocols,
+that region is React-owned, and its wrapper is what you register.
+
+### An imperative SDK gets one reclamation path, entered from both ends
+
+Two of the three things an SDK owns are ordinary. The one that decides whether the
+integration leaks is that **reclamation can be initiated from either side**: your
+`:disconnect` runs when the view goes away, and the library's own removal callback
+runs when the library, a control, or the user takes the thing away. It can run
+first, or second, or twice — and destroying the parent often *causes* the callback,
+so the library re-enters your release from inside your release.
+
+So write one path, fence it on its own terminal phase, and enter it from both
+sides. Set the phase *before* releasing anything, not after.
+
+**The cost is stated rather than recovered:** an imperative subtree is opaque. It
+has no structural render, no SSR projection, and nothing in it is visible to
+Freehand's own bookkeeping. That is the trade for letting the library do what it
+is good at.
+
+### A host-created pane is an island, and islands are explicit
+
+When the library hands you a node it made, there is no portal to reach for —
+Freehand does not have one and is not going to. Mount an explicit second root into
+that node, and unmount it when the node is taken back.
+
+Be clear-eyed about what an island is not: **it does not inherit the outer tree's
+React context, its Suspense boundaries, or its event bubbling.** Nothing pretends
+it does. Pass what it needs as props or read it from app-db, which the island
+shares because a frame is not a tree.
+
+**One measured consequence worth knowing before you write a leak check.** A nested
+root's release is deferred by one task. At the moment the outer view unmounts, the
+substrate's own books already read empty while the door's registry still holds the
+island; one task later they agree. Both readings are correct and they are about
+different clocks — but a leak check written against the wrong one reports a leak
+that is not there.
+
+### One clock, one retention owner
+
+Freehand has a retention primitive ([presence](presence.md)) and so does every
+animation library. Two owners over one keyed subtree is two clocks deciding when a
+child is gone, and the answer is not to arbitrate between them — it is to pick one.
+
+Where the animation is the library's, the retention is the library's and the
+substrate holds nothing for it: the library keeps a departed child mounted after
+your last commit stopped naming it, and reports completion through a declared
+callback position. Where the exit is a CSS class and a duration, `v/presence` is
+the smaller design and there is no library.
+
+**The same rule one level down, and this one is silent when you break it:** the
+property the library animates must have exactly **one writer**. If your call does
+not author `transform`, the library's imperative write stands through an ordinary
+commit. If your call *also* authors it, the commit wins, the library's own state
+and the DOM disagree, and nothing errors or warns. **The recovery is not a
+mechanism** — it is to stop authoring the property the library owns and drive it
+through the library's own prop instead.
+
+## Permanent limits, and what each one buys
+
+Some of these are recoverable and some are the price of the route. The difference
+matters more than the list.
+
+| Limit | Recoverable? | The recovery, or the reason there is none |
+|---|---|---|
+| A Freehand child cannot take an injected `ref` / `asChild` | No — a withheld promise, deliberate | Register the wrapper; keep the region React-owned |
+| An imperative subtree has no structural render and no SSR | No — it is what "the library owns the node" means | Render a server-side placeholder and let the library take over on the client |
+| A nested root does not inherit outer context, Suspense, or bubbling | No — an island is a second tree | Pass props; share app-db; keep the island small |
+| A nested root's release lands one task late | No — two clocks, both correct | Read the door's registry, or wait a task; do not average them |
+| A host crossing cannot be inside a `{:compiled true}` parent | Yes | Keep the crossing's declaration interpreted — promotion is per declaration |
+| Two writers on one animated property lose silently | Yes | One writer: the library's own prop, never `:style` |
+
+## What is actually proven
+
+Each route above is a conformance law with an executable fixture, not a
+recommendation. In `spec/conformance/freehand/conformance-index.md`:
+
+- **`FH-BEHAVIOR-010`** — the imperative-SDK route, the host-created pane, and the
+  explicit nested root. One reclamation path entered from a host-removal callback
+  and from `:disconnect`, in either order and any number of times, each run ending
+  at exact zeros — zero maps, zero listeners, zero overlays, zero nested roots —
+  plus the deferred release measured across the task boundary.
+- **`FH-REACT-009`** — the compound React owner behind one `v/defhost` door. The
+  portal lands in `document.body` and never in the Freehand container; focus moves
+  on open and returns on close; and the withheld `asChild` promise is an A/B over
+  one `cloneElement(child, {ref})` — a React-authored child takes the ref, a
+  Freehand-authored one takes none and does not fail.
+- **`FH-REACT-010`** — the clock owner. One writer on the animated property, in
+  both directions, and one owner for exit retention.
+
+Each of the three drives a **deterministic surrogate** reproducing its library's
+ownership shape rather than the library itself, and each fixture says so in a
+machine-readable `:evidence :limits`. What is proven is where ownership falls at
+the boundary — which is the thing the route depends on — and not any vendor's
+implementation of it. Maps cannot run in CI at all (network, API key, a billed
+account); a real animation is driven against a wall clock, so a gate on it would
+be measuring frame timing rather than ownership.
+
+## Where to go next
+
+- [Host boundaries](host-boundaries.md) — the contracts: `v/defhost`, registered
+  behaviors, commands, `v/->react`, error boundaries.
+- [JavaScript libraries](js-libraries.md) — the recipes, one per route, with code.
+- [Presence: enter and exit](presence.md) — the retention primitive, and when it
+  is the smaller design.
+- [Reactivity and ownership](../authoring/reactivity-and-ownership.md) — the same
+  question asked about your own views rather than a library's.

--- a/implementation/freehand/test/re_frame/freehand/guide/samples_coverage_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/guide/samples_coverage_jvm_test.clj
@@ -438,6 +438,13 @@
     [ 6 "b104f110d013" host/async-chart]]
    "operate/limits-and-escapes.md"
    []
+   ;; Deliberately sample-free. The page routes an integration to a shape; the
+   ;; shapes' code lives one click away on `host/js-libraries.md` and
+   ;; `host/host-boundaries.md`, each block there already carrying its own row
+   ;; above. A routing page that reprinted them would be two copies of one
+   ;; sample drifting apart, which is the failure this roster exists to catch.
+   "host/ownership-routing.md"
+   []
    "get-running/mental-model.md"
    [[ 1 "207fd114bc23" first-view/greeting]
     [ 2 "0618d0abdbe2" first-view/greeting-call]

--- a/implementation/freehand/test/re_frame/freehand/typeahead_witness.cljc
+++ b/implementation/freehand/test/re_frame/freehand/typeahead_witness.cljc
@@ -434,10 +434,45 @@
 ;; ---------------------------------------------------------------------------
 ;; The view — one instance identity across input, list and status
 ;; ---------------------------------------------------------------------------
+;;
+;; THE COMPILED TIER, AND WHY THIS CONTROL DOES NOT REACH IT. FH-CTRL-020's
+;; applicability is `interpreted jvm browser`, and that is a LIMIT rather
+;; than an omission. `typeahead` is outside the compiled grammar as it
+;; stands, and the grammar's own read-only checker is what says so:
+;;
+;;     (v/check "test/re_frame/freehand/typeahead_witness.cljc")
+;;     ;; => :re-frame.freehand.typeahead-witness/typeahead   ELIGIBLE? false
+;;     ;;      :id       :rf.ui.compile/loop-capturing-handler
+;;     ;;      :form     [:kit.ui.typeahead/chosen k g i on-select]
+;;     ;;      :recovery [:keep-interpreted]
+;;     ;;    :re-frame.freehand.typeahead-witness/reviewer-form ELIGIBLE? true
+;;
+;; The option's commit is an event site inside the `for` over the results,
+;; and it closes over that loop's own `i`. A compiled site is LEXICAL — one
+;; site, one handler, settled at build time — and a handler whose arguments
+;; vary per iteration is not one site. So the recovery ladder has exactly
+;; ONE rung, and it is `:keep-interpreted`: this is the grammar declining,
+;; not the author declining to try.
+;;
+;; The control keeps the ordinary shape anyway, because rendering options in
+;; a loop is what a listbox IS, and contorting a witness to reach a tier it
+;; has no performance reason to want would be the catalogue commitment this
+;; bead's non-goals refuse. That the CALLER is eligible — `reviewer-form`,
+;; `:compile-eligible? true` in the same report — is what makes the verdict
+;; a fact about this body rather than about the file.
+;;
+;; None of the above is taken on trust. `typeahead-witness-cljs-test`'s
+;; `fh-ctrl-020-the-compiled-tier-refuses-this-control-and-says-why` runs the
+;; REAL checker on the JVM and compares it against the fixture's `:compiled`
+;; value, so the day the grammar learns a per-item lexical site, the row goes
+;; red and this paragraph is revisited rather than quietly outliving its
+;; reason.
 
 (def typeahead-props
-  "The declared props, hoisted so the compiled twin declares the same map
-  rather than a copy of it."
+  "The declared props, hoisted so the declaration reads as one thing and the
+  schema can be cited — by the structural suite, and by anything else that
+  wants the control's public shape — without transcribing a second copy of
+  it."
   [:map
    [:name :string]
    [:label :string]

--- a/implementation/freehand/test/re_frame/freehand/typeahead_witness_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/typeahead_witness_cljs_test.cljc
@@ -26,9 +26,20 @@
   is lexical constants naming an anchor, so the tree can be asserted to
   carry no computed geometry at all. That is the half of the anchoring
   contract a headless render can prove, and it is the half that would rot
-  silently the first time a later change reached for a rectangle."
+  silently the first time a later change reached for a rectangle.
+
+  ## And one row that is JVM-only
+
+  The last row asks the compiled grammar whether it will take this control,
+  by running `v/check` — a door verb that reads SOURCE, and therefore one
+  the JVM alone can answer. It lives here rather than in a namespace of its
+  own because it makes the same kind of claim as every row above it: a fact
+  about the declaration, asserted against the fixture. Node simply does not
+  see it."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            #?(:clj [clojure.java.io :as io])
+            #?(:clj [re-frame.freehand :as v])
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.freehand.cell :as cell]
@@ -463,3 +474,58 @@
 
         (send! [:desk/closed k])
         (is (nil? (record)) "releasing twice is releasing once")))))
+
+;; ===========================================================================
+;; FH-CTRL-020 — the compiled tier, refused out loud
+;; ===========================================================================
+;;
+;; JVM only, and not because ClojureScript is the lesser host here: `v/check`
+;; READS SOURCE, which is a thing only the JVM can do, and the door publishes
+;; it under `#?(:clj …)` for exactly that reason. So this row asks the
+;; question in the one place it can be asked, and node runs the rest of the
+;; file unchanged.
+
+#?(:clj
+   (deftest fh-ctrl-020-the-compiled-tier-refuses-this-control-and-says-why
+     (testing "Per FH-CTRL-020, the mode half: this row's applicability is
+               `interpreted jvm browser`, and a reader deciding whether to
+               depend on that needs to know whether compiled is UNCLAIMED or
+               REFUSED. It is refused, and the refusal is not this suite's
+               opinion — `v/check` runs the same analyzer the build runs,
+               over the declaration as it stands, and its report is compared
+               against the fixture's `:compiled` value.
+
+               Which makes the limitation FALSIFIABLE, and that is the whole
+               reason it is a test rather than a sentence. A sentence saying
+               `this cannot compile` stays green forever, including on the
+               day it stops being true. This row goes red then, and the
+               witness gets its compiled twin."
+       (let [{:keys [view eligible? finding caller]} (:compiled ctrl-020)
+             reports (v/check (-> (io/resource "re_frame/freehand/typeahead_witness.cljc")
+                                  io/file
+                                  .getPath))
+             by-view (into {} (map (juxt :view-id identity)) reports)
+             report  (get by-view view)]
+
+         (is (some? report)
+             "non-vacuous: the checker really did read this declaration")
+         (is (= eligible? (:compile-eligible? report))
+             "the control is outside the compiled grammar")
+
+         (let [[found & others] (:findings report)]
+           (is (empty? others)
+               "and for ONE reason — a second finding would mean the recovery
+                below is not the whole answer")
+           (is (= finding (select-keys found (keys finding)))
+               "which is the reason the fixture names, in the shape the
+                checker answers it: a per-iteration event site is not a
+                lexical one, and the ladder's single rung is the grammar
+                declining rather than the author"))
+
+         (testing "the CONTROL for that refusal — the caller in the same file,
+                   under the same analyzer, in the same report"
+           (let [callers-report (get by-view (:view caller))]
+             (is (some? callers-report))
+             (is (= (:eligible? caller) (:compile-eligible? callers-report))
+                 "so the verdict is a fact about the control's BODY, not
+                  about the file it lives in")))))))

--- a/implementation/freehand/test/re_frame/freehand/typeahead_witness_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/typeahead_witness_dom_cljs_test.cljs
@@ -249,6 +249,26 @@
                                 "the list opens in the top layer")))
         (.then (fn [_] input)))))
 
+(defn- ask!
+  "Everything [[open-with-results!]] does UP TO the answer, and nothing
+  after it: type `query` into the live input and deliver the delayed search
+  the keystrokes scheduled, leaving the request open.
+
+  The rows that need a FAILURE start here, because a failure is an answer
+  too and the control has to have really asked before one can arrive."
+  [container query]
+  (let [input (ms/q container (str "#" (:input-id ctrl-020)))]
+    (ms/live!)
+    (ms/type-string! input query)
+    (-> (settled #(= query (:query (record))) "the keystrokes reach the record")
+        (.then (fn [_]
+                 (ms/act #(rf/dispatch-sync
+                            [:kit.ui.typeahead/due k (:token (record))
+                             [:desk/search-requested]]
+                            {:frame fid}))))
+        (.then (fn [_] (settled #(seq (requests)) "the caller is asked")))
+        (.then (fn [_] input)))))
+
 (defn- finish!
   "The terminal step of every row: tear the mount down through the shared
   lifecycle, assert that NOTHING it created survived, and end the async
@@ -741,4 +761,98 @@
                                 "and the list is out of the top layer with it")
                             (finish! container root done)))
                         (.catch (fail-and-finish! container root done))))))
+              (.catch (fail-and-finish! container root done))))))))
+
+;; ===========================================================================
+;; FH-CTRL-020 — the retry, as something a user can actually reach
+;; ===========================================================================
+
+(deftest fh-ctrl-020-a-retry-is-a-real-button-and-supersedes-the-failure-it-retries
+  (testing "Per FH-CTRL-020: the structural half proves the retry DECIDES
+            correctly — a new token, the failed request's late answer inert.
+            What a browser adds is the half a value cannot carry: that the
+            decision is REACHABLE. The `retry` part is a real `<button>`
+            that the failure puts on the page and nothing else does, and a
+            real pointer click on it is what asks again. A retry no pointer
+            can reach is not a retry, and a fence proven only by a
+            hand-dispatched event is a fence around a door nobody found.
+
+            So this row never names `:kit.ui.typeahead/retried`. It clicks.
+
+            Then the failed request answers LATE, against a live mounted
+            control — which is the arrangement the fence exists for, and the
+            one where getting it wrong resurrects a stale answer on screen
+            rather than merely in a map. The two answer sets differ in
+            LENGTH as well as content, so the option ids below tell them
+            apart: the retry's single option is present and the failed
+            request's second one is absent."
+    (if-not (browser?)
+      (ms/skip! "the browser job runs the live retry")
+      (async done
+        (let [{:keys [query results retry-results error-message error-part
+                      option-ids listbox-id]} ctrl-020
+              _       (seed!)
+              [container root] (stage!)
+              retry-q (str "[data-part=\"" error-part "\"]")
+              failed  (atom nil)
+              retried (atom nil)]
+          (-> (render! root)
+              (.then (fn [_] (ask! container query)))
+              (.then
+                (fn [_]
+                  (reset! failed (last (requests)))
+                  (is (nil? (ms/q container retry-q))
+                      "non-vacuous: nothing offers a retry while nothing has
+                       failed — the part is minted by the state, not rendered
+                       hidden")
+                  (ms/act #(answer! {:results [] :error error-message}))))
+              (.then
+                (fn [_]
+                  (settled #(some? (ms/q container retry-q))
+                           "the failure puts a real retry button on the page")))
+              (.then
+                (fn [_]
+                  (is (= (str "Search failed: " error-message)
+                         (ms/text-of container "[data-part=\"status\"]"))
+                      "beside a status region that says what went wrong")
+                  ;; THE CLICK. Not the event — the button.
+                  (ms/live!)
+                  (click! (ms/q container retry-q))
+                  (settled #(and (nil? (:error (record)))
+                                 (not= (:reply-to @failed) (:reply-to (last (requests)))))
+                           "the click clears the failure and asks again, under a
+                            NEW correlation")))
+              (.then
+                (fn [_]
+                  (reset! retried (last (requests)))
+                  (is (nil? (ms/q container retry-q))
+                      "and the button goes with the error that minted it")
+                  ;; The failed request answers LATE, against a live control.
+                  (ms/act #(rf/dispatch-sync
+                             (conj (vec (:reply-to @failed)) {:results results})
+                             {:frame fid}))))
+              (.then
+                (fn [_]
+                  (is (not (.matches (ms/q container (str "#" listbox-id))
+                                     ":popover-open"))
+                      "the retried-past request's answer opens nothing — the
+                       resurrection this fence exists to prevent")
+                  (ms/act #(rf/dispatch-sync
+                             (conj (vec (:reply-to @retried)) {:results retry-results})
+                             {:frame fid}))))
+              (.then
+                (fn [_]
+                  (settled #(.matches (ms/q container (str "#" listbox-id))
+                                      ":popover-open")
+                           "while the retry's own answer opens the list")))
+              (.then
+                (fn [_]
+                  (is (= (:label (first retry-results))
+                         (ms/text-of container (str "#" (nth option-ids 0))))
+                      "showing the RETRY's answer")
+                  (is (nil? (ms/q container (str "#" (nth option-ids 1))))
+                      "and only it — the failed request answered with two
+                       options and neither of them is on the page")
+                  (release!)))
+              (.then (fn [_] (finish! container root done)))
               (.catch (fail-and-finish! container root done))))))))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -214,6 +214,7 @@ nav:
         - "Accessibility": core/freehand/authoring/accessibility.md
       - "Host edge":
         - "Host boundaries": core/freehand/host/host-boundaries.md
+        - "Ownership routing": core/freehand/host/ownership-routing.md
         - "JavaScript libraries": core/freehand/host/js-libraries.md
         - "Presence: enter and exit": core/freehand/host/presence.md
         - "SSR and hydration": core/freehand/host/ssr.md

--- a/spec/conformance/freehand/fixtures/fh-ctrl-020.edn
+++ b/spec/conformance/freehand/fixtures/fh-ctrl-020.edn
@@ -71,6 +71,37 @@
  :popover-mode "auto"
 
  ;; ---------------------------------------------------------------------------
+ ;; The compiled tier, as a VERDICT rather than a silence
+ ;; ---------------------------------------------------------------------------
+ ;;
+ ;; This row's applicability is `interpreted jvm browser`. The index grammar
+ ;; permits a row to claim no compiled mode and say nothing further, but a
+ ;; silence and a limit read identically to someone who has to decide whether
+ ;; to depend on this, so the limit is a VALUE here and an assertion in the
+ ;; structural suite: `v/check` — the grammar's own read-only checker, the
+ ;; same analyzer the build runs — is executed against this witness's source
+ ;; on the JVM and its report is compared to what is written below.
+ ;;
+ ;; The finding is not incidental. The option's commit is an event site inside
+ ;; the `for` over the results and closes over the loop's `i`; a compiled site
+ ;; is lexical, so a handler whose arguments vary per iteration is not one
+ ;; site. The recovery ladder has a single rung — the grammar declining, not
+ ;; the author. `:caller` is the contrast that makes the verdict a fact about
+ ;; that BODY rather than about the file.
+ ;;
+ ;; Written as the checker answers it, so a report that drifted in shape would
+ ;; be as visible as one that drifted in verdict.
+ :compiled
+ {:view      :re-frame.freehand.typeahead-witness/typeahead
+  :eligible? false
+  :finding   {:id       :rf.ui.compile/loop-capturing-handler
+              :form     [:kit.ui.typeahead/chosen k g i on-select]
+              :reason   :form-outside-the-grammar
+              :recovery [:keep-interpreted]}
+  :caller    {:view      :re-frame.freehand.typeahead-witness/reviewer-form
+              :eligible? true}}
+
+ ;; ---------------------------------------------------------------------------
  ;; The data a run drives
  ;; ---------------------------------------------------------------------------
  :query         "an"
@@ -191,11 +222,11 @@
 
   :structural
   [{:ns  re-frame.freehand.typeahead-witness-cljs-test
-    :law "Everything the control declares rather than does: one instance identity across input, status and listbox with the ARIA wiring that lets focus stay put, a popover whose openness is the reserved desired-state fact and whose position is LEXICAL CONSTANTS naming an anchor — so no measured geometry can hide in the tree — a pure keyboard grammar that delegates Enter and Escape to the kit's own rule, and all three fences as comparisons over ordinary frame data."}]
+    :law "Everything the control declares rather than does: one instance identity across input, status and listbox with the ARIA wiring that lets focus stay put, a popover whose openness is the reserved desired-state fact and whose position is LEXICAL CONSTANTS naming an anchor — so no measured geometry can hide in the tree — a pure keyboard grammar that delegates Enter and Escape to the kit's own rule, all three fences as comparisons over ordinary frame data, and — on the JVM, where a door verb can read source — the compiled grammar's own verdict on this declaration, so the absent compiled mode is a REFUSAL this suite re-derives rather than a silence it inherits."}]
 
   :mounted
   [{:ns  re-frame.freehand.typeahead-witness-dom-cljs-test
-    :law "Against a real Chromium commit: the list is promoted to the top layer and its top-left corner lands on the input's bottom-left corner — measured against a CONTROL popover carrying no anchor, which is not there — arrow keys move the active descendant while `document.activeElement` never stops being the input, a plain Enter and a pointer click each commit and each return focus, an Enter carrying either composition signal commits nothing and discards nothing, Escape and a light dismiss both close without committing, a superseded reply arriving late is inert, and after the owner's release and unmount nothing survives."}]
+    :law "Against a real Chromium commit: the list is promoted to the top layer and its top-left corner lands on the input's bottom-left corner — measured against a CONTROL popover carrying no anchor, which is not there — arrow keys move the active descendant while `document.activeElement` never stops being the input, a plain Enter and a pointer click each commit and each return focus, an Enter carrying either composition signal commits nothing and discards nothing, Escape and a light dismiss both close without committing, a superseded reply arriving late is inert, a failure puts a real `retry` button on the page which a real pointer CLICK — never a hand-dispatched event — turns into a fresh request whose answer is the one shown while the failed request's late answer opens nothing, and after the owner's release and unmount nothing survives."}]
 
   ;; What a run leaves for a reader. The DOM's own value and active
   ;; descendant, read off `document` rather than off the test's bookkeeping;


### PR DESCRIPTION
Two control-witness beads whose merged work was real but whose remaining criteria were about **projection** — making the work visible where readers look, and making a limit a statement instead of a silence.

Both beads stay `in_progress`. Their parent `rf2-drpa3.182` is not touched (`.7` is with another worker).

---

## rf2-drpa3.182.8 — the typeahead witness (FH-CTRL-020)

### Acceptance 1 — retry, now in a real browser

`grep -c retry` on the mounted suite was **0**; retry was proven structurally only. The new mounted row never names `:kit.ui.typeahead/retried`. It waits for the failure to put a real `<button data-part="retry">` on the page, **clicks it**, and only then asserts the new correlation. Then the failed request answers **late, against a live mounted control**, and opens nothing, while the retry's own answer opens the list. The two answer sets differ in length as well as content, so the option ids tell them apart: the retry's single option is present and the failed request's second one is absent.

**Mutation evidence.** Repointing the button's `:on-click` at a different registered handler (`:kit.ui.typeahead/toggle-reported`) reds **exactly one test** — `fh-ctrl-020-a-retry-is-a-real-button-and-supersedes-the-failure-it-retries` — and nothing else. The structural retry row stayed green, which is the point: it proves the decision, not the reachability. Restored from a backup copy and verified blob-identical (`git diff` empty).

### Acceptance 3 — the compiled tier, answered

There was no compiled twin, and `typeahead-props` carried a docstring saying it was hoisted *"so the compiled twin declares the same map"* — an assertion about something that does not exist. **There is still no twin, and now there is a reason**, taken from the grammar's own read-only checker rather than from an author's opinion:

```
(v/check "…/typeahead_witness.cljc")
;; …/typeahead       ELIGIBLE? false
;;   :id       :rf.ui.compile/loop-capturing-handler
;;   :form     [:kit.ui.typeahead/chosen k g i on-select]
;;   :recovery [:keep-interpreted]
;; …/reviewer-form   ELIGIBLE? true
```

The option's commit is an event site inside the `for` over the results and closes over that loop's `i`; a compiled site is lexical, so a handler whose arguments vary per iteration is not one site. The ladder's single rung is **the grammar declining, not the author**.

That verdict is now a **value** in the fixture (`:compiled`) and an **assertion** in the structural suite — JVM-only, because `v/check` reads source and the door publishes it under `#?(:clj …)`. Which makes the limitation *falsifiable*: a sentence saying "this cannot compile" stays green on the day it stops being true; this row goes red then, and the witness gets its twin. The `:caller` contrast is what makes the verdict a fact about that **body** rather than about the file.

### Acceptance 4 — partially discharged, and the reason for the rest is one thing

`git grep -l FH-CTRL-020` returned six files: three tests, the fixture, the index, the tracker. The **guide** half now projects: `advanced/semantic-controllers.md` §"Async search / typeahead" ended at an app-pattern sketch and now names FH-CTRL-020 as the packaged version's executable home, with the three things worth borrowing (platform anchoring with no measured rectangle, the composing-Enter rule, a debounce that is a comparison rather than a timer to cancel) plus the compiled limit stated as the grammar's rather than the control's.

**Xray and the API/parts manifest still do not, and it is one cause rather than two.** The witness is test-only by the epic's own recorded scope decision — promoting a control onto the published door is the API-manifest serial lane, and this bead deliberately did not take it. `spec/api-manifest.edn` is *generated* and drift-checked from the real public vars, so it cannot carry a var that does not exist; and Xray's Freehand surface is a shipped testbed deck reading `re-frame.freehand.tool`, which cannot reach `test/`. Both surfaces can only see shipped code. No `FH-*` id appears anywhere under `tools/` for any row, so there is also no existing convention to follow — inventing one for a single row would be worse than the gap. **Acceptance 4 is therefore a function of the scope decision, not of effort**, and the bead stays open rather than have the criterion weakened to fit.

Also noted, not actioned: `spec/004-Views.md#the-first-party-control-kit` — the paragraph FH-CTRL-020's row cites — lists FH-CTRL-016/017 and does not cite FH-CTRL-020 back. That is a one-line hot-zone edit and was fenced out of this PR.

---

## rf2-drpa3.182.9 — ownership routing

### Acceptance 3 — the routing page

`docs/core/freehand/host/ownership-routing.md` routes an integration **from ownership facts rather than from a library's name**. Three questions decide it, answered in order — does the library own a DOM subtree, does it own state flowing between its own parts, does it own a **clock** — and if none is true, the library owns nothing and there is no boundary to build. From there a route table covers the pure/headless core, the value/callback React component, the compound React owner, the imperative SDK, the host-created pane and its explicit nested root, the clock owner, and `v/->react` outward, each with the crossings it costs beside what stays yours.

Routing by brand is the failure it exists to prevent: *"Radix is a UI kit"* and *"Maps is a map"* are both true and both useless. What matters about Radix is that state flows between its parts; what matters about Maps is that it hands you back a node it made.

Limits sit beside recoveries and are **marked recoverable or not**, because that difference matters more than the list. The four permanent ones: the withheld `asChild`/ref promise (recovery: register the wrapper), an imperative subtree having no structural render or SSR, an island not inheriting outer context/Suspense/bubbling, and the nested root's release landing one task late — two clocks, both correct, and the one place an author's leak check reports a leak that is not there.

The page carries **no fenced blocks**. The code lives one click away on `js-libraries.md` and `host-boundaries.md`, each block there already carrying its digest row; a routing page that reprinted them would be two copies of one sample drifting apart, which is exactly the failure that roster exists to catch. The roster carries the page with an empty vector and says why.

### The stale honesty section — the half that mattered most

`js-libraries.md` §*"Honesty: designed, not yet a proven pilot"* told readers the AnimatePresence-through-a-Freehand-boundary path was a hypothesis, and asked for a mounted exit pilot before trusting it. **That pilot is `FH-REACT-010`**, and it measures exactly the three steps the section named. A page calling proven work unproven is worse than silence, because a reader trusts it.

The replacement says what is proven and, precisely, what is not: the composition and the ownership boundary are proven mounted; `framer-motion` itself is not installed, because a real animation is rAF-driven against a wall clock and a gate on it would measure frame timing rather than ownership. **What remains outstanding is the vendor's own timing, not the composition.**

Two smaller sites went stale with it and are corrected: *"Unlike the exit-animation path above, this one is mounted"* (both are now), and the animation checklist's *"(+ pilot for exit)"*. The "When not" entry sending a heavy Radix shell to UIx now says it is a judgement about **scale** rather than capability, since one compound library crosses fine through one `v/defhost` of its wrapper (`FH-REACT-009`).

Acceptances 1, 2 and 4 were verified by the audit and are unchanged here. The EVIDENCE clause's comparative counts remain absent from the three fixtures; the routing page states the crossings each route costs qualitatively, which is the part a reader routes by, but the numeric half is not claimed.

---

## Quality gates

All foreground, worktree-local logs, exit codes echoed. No pipe through `tail`/`grep` on the runner itself.

| Gate | Result | Exit |
|---|---|---|
| `implementation/freehand` `clojure -M:test` | 1285 tests / 8809 assertions, 0F 0E (was 1284/8803 — the new JVM checker row) | **0** |
| `npm run test:browser` | 842 tests / 5469 assertions, 0F 0E (was 841/5459 — the new mounted retry row) | **0** |
| `python scripts/check_freehand_conformance_index.py` | clean | **0** |
| `python -m mkdocs build --strict` | no new warning; the new page is in nav | **0** |
| Guide digest roster (`…guide.samples-coverage-jvm-test`) | 5 tests / 20 assertions; 114 of 138 blocks covered, unchanged | **0** |
| **Mutation** — retry button's `:on-click` repointed | **1 failure**, naming the new row alone; restored blob-identical | **1** (expected) |

Deferred to CI: the node freehand lane, `test:browser-prod-elision`, the api-manifest job, and the full spine.
