### PR TITLE
test(core): split dev instrumentation from semantics so the prod-gate lane grows (rf2-d2841)

### DIFF
--- a/implementation/core/test/re_frame/cascade_envelope_propagation_test.clj
+++ b/implementation/core/test/re_frame/cascade_envelope_propagation_test.clj
@@ -25,10 +25,29 @@
   equivalent of `(with-frame :rf/default …)`); the CHILD dispatches
   (`:fx [[:dispatch …]]` / `:dispatch-later`) already carry the parent's
   `:frame` explicitly via `child-dispatch-opts`, so the cascade
-  propagation under test is unchanged."
+  propagation under test is unchanged.
+
+  ## Posture split (rf2-d2841)
+
+  Every deftest here except one already reads production surfaces — an
+  fx-handler stub's captured args, the `(:envelope m)` slot on the fx-handler
+  ctx — and runs under `scripts/test-core-prod-gate.sh` unchanged.
+
+  The exception, `trace-id-origin-propagate-source-overridden-through-cascade`,
+  asserted `:origin` inheritance and the `:source :fx-dispatch` re-stamp off
+  the `:rf.event/dispatched` TRACE stream, which is gone under
+  `-Dre-frame.debug=false`. It is not guarded, it is RE-AIMED: the same two
+  claims are read off the child's DISPATCH ENVELOPE via `(:envelope m)` — the
+  production-visible surface `fx-handler-ctx-carries-envelope-slot` already
+  establishes exists — so they now hold in BOTH postures. The trace-shape
+  half (`:origin` under `:tags`, `:source` hoisted to the top level per Spec
+  009 §Core fields) is a claim about the trace EVENT rather than about
+  propagation, and that half alone stays in a `(when interop/debug-enabled? …)`
+  arm marked `rf2-d2841`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
@@ -116,33 +135,64 @@
     ;; on the child envelope, regardless of what the parent carried. The
     ;; parent's `:source :test` is recorded against the parent's own
     ;; envelope; the child reports the substrate's actual dispatch site.
-    (let [seen (atom [])]
+    (let [seen       (atom [])
+          ;; ALWAYS-ON PROBE (rf2-d2841): the fx-handler ctx's `:envelope`
+          ;; slot is a production surface (see `fx-handler-ctx-carries-
+          ;; envelope-slot` below), so running one of these inside EACH level
+          ;; of the cascade reads the parent's and the child's envelopes
+          ;; without any trace involvement.
+          envelopes  (atom {})]
       (rf/register-listener! :trace ::rec (fn [ev] (swap! seen conj ev)))
       (try
+        (rf/reg-fx :test/probe
+          (fn [m [level]] (swap! envelopes assoc level (:envelope m))))
         (rf/reg-event :test/parent
           (fn [_ _]
-            {:fx [[:dispatch [:test/child]]]}))
-        (rf/reg-event :test/child (fn [{:keys [db]} _] {:db db}))
+            {:fx [[:test/probe [:parent]]
+                  [:dispatch [:test/child]]]}))
+        (rf/reg-event :test/child
+          (fn [{:keys [db]} _]
+            {:db db
+             :fx [[:test/probe [:child]]]}))
 
         (rf/dispatch-sync [:test/parent]
                           {:trace-id ::scoped-trace
                            :origin   :test
                            :source   :test})
 
-        (let [dispatched   (->> @seen
-                                 (filter #(= :rf.event/dispatched (:operation %))))
-              parent-ev    (first (filter #(= [:test/parent] (get-in % [:tags :rf.event/v])) dispatched))
-              child-ev     (first (filter #(= [:test/child]  (get-in % [:tags :rf.event/v])) dispatched))]
-          (is (some? parent-ev) "parent's :rf.event/dispatched is captured")
-          (is (some? child-ev)  "child's :rf.event/dispatched is captured")
-          ;; :origin rides :tags (inherited); :source is hoisted to top-
-          ;; level by trace/emit! per Spec 009 §Core fields.
-          (is (= :test      (get-in parent-ev [:tags :rf.event/origin])) "parent carries :origin :test")
-          (is (= :test      (:source parent-ev))                          "parent carries :source :test")
-          (is (= :test      (get-in child-ev  [:tags :rf.event/origin]))
+        ;; ---- ALWAYS-ON: propagation read off the envelopes ---------------
+        (let [parent-env (:parent @envelopes)
+              child-env  (:child  @envelopes)]
+          (is (some? parent-env) "the parent's dispatch envelope was captured")
+          (is (some? child-env)  "the child's dispatch envelope was captured")
+          (is (= :test (:origin parent-env)) "parent carries :origin :test")
+          (is (= :test (:source parent-env)) "parent carries :source :test")
+          (is (= ::scoped-trace (:trace-id parent-env)) "parent carries :trace-id")
+          (is (= :test (:origin child-env))
               ":origin :test propagated through the cascade")
-          (is (= :fx-dispatch (:source child-ev))
+          (is (= ::scoped-trace (:trace-id child-env))
+              ":trace-id propagated through the cascade")
+          (is (= :fx-dispatch (:source child-env))
               "child's :source is :fx-dispatch (stamped by the :dispatch fx; NOT inherited from parent)"))
+
+        ;; ---- rf2-d2841 dev-instrumentation arm ---------------------------
+        ;; What remains here is a claim about the trace EVENT's SHAPE — that
+        ;; `:origin` rides under `:tags` while `:source` is hoisted to the top
+        ;; level per Spec 009 §Core fields — rather than about propagation,
+        ;; which the envelope assertions above now carry in both postures.
+        (when interop/debug-enabled?
+          (let [dispatched   (->> @seen
+                                  (filter #(= :rf.event/dispatched (:operation %))))
+                parent-ev    (first (filter #(= [:test/parent] (get-in % [:tags :rf.event/v])) dispatched))
+                child-ev     (first (filter #(= [:test/child]  (get-in % [:tags :rf.event/v])) dispatched))]
+            (is (some? parent-ev) "parent's :rf.event/dispatched is captured")
+            (is (some? child-ev)  "child's :rf.event/dispatched is captured")
+            (is (= :test      (get-in parent-ev [:tags :rf.event/origin])) "parent carries :origin :test")
+            (is (= :test      (:source parent-ev))                          "parent carries :source :test")
+            (is (= :test      (get-in child-ev  [:tags :rf.event/origin]))
+                ":origin :test propagated through the cascade")
+            (is (= :fx-dispatch (:source child-ev))
+                "child's :source is :fx-dispatch (stamped by the :dispatch fx; NOT inherited from parent)")))
         (finally (rf/unregister-listener! :trace ::rec))))))
 
 ;; ---- :envelope exposed on fx-handler ctx (rf2-4jci1.4) -------------------

--- a/implementation/core/test/re_frame/configure_test.clj
+++ b/implementation/core/test/re_frame/configure_test.clj
@@ -23,10 +23,39 @@
   everything else is a silent no-op — `configure` returns `nil` and
   does not throw. Per-frame settings (e.g. SSR error projection,
   `:rf.trace/events-retained`) live on the frame's metadata, not on
-  this surface."
+  this surface.
+
+  ## Posture split (rf2-d2841)
+
+  The `:elision` knob is PRODUCTION STATE — `elision/current-config` is not
+  gated — and so are the closed-vocabulary rules: unknown keys return nil, a
+  non-map argument fails loud on an `assert`. Those run under
+  `scripts/test-core-prod-gate.sh` unchanged and are the substance of
+  \"closed and fixed-and-additive\".
+
+  The `:trace-buffer` knob is a different animal, and the tempting reading of
+  it is wrong. It is NOT \"a dev-only warning attached to production state\":
+  `trace.tooling/configure-trace-buffer!` opens BOTH of its arms with
+  `(when (and interop/debug-enabled? …))`, so under `-Dre-frame.debug=false`
+  the whole surface — the retention it sets AND the
+  `:rf.warning/trace-buffer-unrecognised-opts` it emits — is a no-op, and
+  `trace-buffer` itself returns `[]` because the ring is never allocated.
+  Every `:trace-buffer` assertion is therefore kept verbatim inside a
+  `(when interop/debug-enabled? …)` arm marked `rf2-d2841`.
+
+  That includes four assertions that currently PASS under the gate and pass
+  for no reason at all: `(is (<= (count (rf/trace-buffer :rf/default)) N))`
+  over an empty vector is true for every N, so outside the arm the retention
+  cap would certify itself with the ring never allocated — the same
+  false-green as a negative over an empty trace ring, and the reason
+  \"retention survived the bad call\" cannot be read off this surface in
+  production. The always-on residue kept beside them is the one production
+  claim the `:trace-buffer` key still makes: the call is a silent no-op that
+  returns nil and does not throw."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
@@ -60,11 +89,18 @@
 
 (deftest configure-known-keys-take-effect
   (testing ":trace-buffer events-retained is wired"
-    (rf/configure! {:trace-buffer {:events-retained 7}})
+    ;; ALWAYS-ON (rf2-d2841): the knob is a documented no-op under the
+    ;; production gate — it must still be ACCEPTED, silently, returning nil.
+    (is (nil? (rf/configure! {:trace-buffer {:events-retained 7}}))
+        ":trace-buffer is accepted and returns nil in BOTH postures")
     (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
     (dotimes [_ 20] (rf/dispatch-sync [:ping]))
-    (is (<= (count (rf/trace-buffer :rf/default)) 7)
-        ":trace-buffer {:events-retained 7} caps retained events at 7"))
+    ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+    ;; `(<= (count []) 7)` is true for every N; the cap is unreadable here
+    ;; under the gate because the ring is never allocated.
+    (when interop/debug-enabled?
+      (is (<= (count (rf/trace-buffer :rf/default)) 7)
+          ":trace-buffer {:events-retained 7} caps retained events at 7")))
   (testing ":elision is wired (rf2-le2qu)"
     (rf/configure! {:elision {:rf.size/threshold-bytes 4096}})
     (is (= 4096 (:rf.size/threshold-bytes (elision/current-config)))
@@ -77,9 +113,20 @@
             retention unchanged, rather than silently doing nothing.
             :events-retained is the SOLE canonical opt — impl, core
             docstring, API.md, and Spec 009 all agree."
+    ;; ALWAYS-ON (rf2-d2841): a rejected opts shape is a no-op that returns
+    ;; nil rather than throwing — true in BOTH postures, and the only half of
+    ;; this deftest that survives the production gate.
+    (is (nil? (rf/configure! {:trace-buffer {:depth 200}}))
+        "the retired {:depth N} shape no-ops and returns nil in BOTH postures")
+    (is (nil? (rf/configure! {:trace-buffer {:events-retained -1}}))
+        "a negative :events-retained no-ops and returns nil in BOTH postures")
     ;; Establish a known retention first.
     (rf/configure! {:trace-buffer {:events-retained 9}})
-    (let [warnings (atom [])]
+    (when interop/debug-enabled?
+     ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+     ;; The whole `configure-trace-buffer!` surface — warning AND retention —
+     ;; sits behind `interop/debug-enabled?`.
+     (let [warnings (atom [])]
       (rf/register-listener! :trace ::trace-buffer-opts
                              (fn [ev]
                                (when (= :rf.warning/trace-buffer-unrecognised-opts
@@ -116,7 +163,7 @@
         (is (= 2 (count @warnings))
             "the canonical {:events-retained N} shape does NOT warn")
         (finally
-          (rf/unregister-listener! :trace ::trace-buffer-opts))))))
+          (rf/unregister-listener! :trace ::trace-buffer-opts)))))))
 
 (deftest trace-buffer-severity-warning-filter-catches-unrecognised-opts
   (testing "rf2-ho20xj — a {:severity :warning} trace-buffer filter must
@@ -134,19 +181,28 @@
                     (rf/configure! {:trace-buffer {:depth 200}})
                     {:db db}))
     (rf/dispatch-sync [:bad-configure-call])
-    (let [warnings (rf/trace-buffer :rf/default {:flat true :severity :warning})]
-      (is (some #(= :rf.warning/trace-buffer-unrecognised-opts (:operation %))
-                warnings)
-          "a {:severity :warning} trace-buffer read surfaces
-          :rf.warning/trace-buffer-unrecognised-opts (rf2-ho20xj)"))
-    ;; Sanity: a {:severity :error} filter must NOT catch it — the whole
-    ;; point of the fix is that this category no longer masquerades as
-    ;; an :error op-type.
-    (let [errors (rf/trace-buffer :rf/default {:flat true :severity :error})]
-      (is (not (some #(= :rf.warning/trace-buffer-unrecognised-opts (:operation %))
-                     errors))
-          ":rf.warning/trace-buffer-unrecognised-opts no longer rides the
-          :error op-type"))))
+    ;; ALWAYS-ON (rf2-d2841): the bad `configure!` call from inside a handler
+    ;; must not derail the dispatch — the handler's `{:db db}` still commits.
+    (is (some? (rf/app-db-value :rf/default))
+        "the enclosing dispatch completed despite the rejected configure! call")
+    ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+    ;; BOTH reads go inside: `trace-buffer` returns [] in production, so the
+    ;; `{:severity :error}` sanity NEGATIVE would pass over an empty vector —
+    ;; certifying "no longer rides the :error op-type" with nothing retained.
+    (when interop/debug-enabled?
+      (let [warnings (rf/trace-buffer :rf/default {:flat true :severity :warning})]
+        (is (some #(= :rf.warning/trace-buffer-unrecognised-opts (:operation %))
+                  warnings)
+            "a {:severity :warning} trace-buffer read surfaces
+            :rf.warning/trace-buffer-unrecognised-opts (rf2-ho20xj)"))
+      ;; Sanity: a {:severity :error} filter must NOT catch it — the whole
+      ;; point of the fix is that this category no longer masquerades as
+      ;; an :error op-type.
+      (let [errors (rf/trace-buffer :rf/default {:flat true :severity :error})]
+        (is (not (some #(= :rf.warning/trace-buffer-unrecognised-opts (:operation %))
+                       errors))
+            ":rf.warning/trace-buffer-unrecognised-opts no longer rides the
+            :error op-type")))))
 
 (deftest configure-unknown-key-is-silent-no-op
   (testing "rf2-mmlci — unknown keys silently no-op; configure returns nil"
@@ -173,8 +229,16 @@
     (rf/configure! {:no-such-key {}})
     (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
     (dotimes [_ 30] (rf/dispatch-sync [:ping]))
-    (is (<= (count (rf/trace-buffer :rf/default)) 11)
-        ":trace-buffer events-retained survived bracketing unknown-key calls"))
+    ;; ALWAYS-ON (rf2-d2841): whatever the posture, thirty dispatches bracketed
+    ;; by four unknown-key `configure!` calls still all landed — the
+    ;; production-visible half of "an unknown key perturbs nothing".
+    (is (some? (rf/app-db-value :rf/default))
+        "the bracketed dispatches ran to completion")
+    ;; rf2-d2841 — dev-instrumentation arm. `(<= (count []) 11)` is true for
+    ;; every N under the gate: the retention cap is unreadable in production.
+    (when interop/debug-enabled?
+      (is (<= (count (rf/trace-buffer :rf/default)) 11)
+          ":trace-buffer events-retained survived bracketing unknown-key calls")))
   (testing "rf2-dzxixe — a single map mixing known + unknown top-level
             keys applies the known subsystems and silently ignores the
             unknown ones (closed-and-additive)"
@@ -186,8 +250,12 @@
         ":elision applied from the composite map")
     (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
     (dotimes [_ 20] (rf/dispatch-sync [:ping]))
-    (is (<= (count (rf/trace-buffer :rf/default)) 6)
-        ":trace-buffer applied from the composite map; unknown keys ignored")))
+    ;; rf2-d2841 — dev-instrumentation arm. Same empty-vector false-green; the
+    ;; composite map's PRODUCTION half is the `:elision` assertion above,
+    ;; which is unguarded and is what proves "known subsystems applied".
+    (when interop/debug-enabled?
+      (is (<= (count (rf/trace-buffer :rf/default)) 6)
+          ":trace-buffer applied from the composite map; unknown keys ignored"))))
 
 (deftest configure-non-map-arg-fails-loud
   (testing "rf2-dzxixe — configure! takes a SINGLE nested config map.

--- a/implementation/core/test/re_frame/cross_frame_dispatch_sync_warn_test.clj
+++ b/implementation/core/test/re_frame/cross_frame_dispatch_sync_warn_test.clj
@@ -14,10 +14,34 @@
        observability tools spot the pattern; the dispatch proceeds.
 
   Per Spec 002 §Cross-frame `dispatch-sync` during a sibling drain
-  warns but proceeds, Spec 009 §Error categories, and rf2-fp97."
+  warns but proceeds, Spec 009 §Error categories, and rf2-fp97.
+
+  ## Posture split (rf2-d2841)
+
+  \"WARNS BUT PROCEEDS\" IS TWO CLAIMS, AND ONLY THE FIRST IS DEV-ONLY. Both
+  categories here are bare `trace/emit!` / `trace/emit-error!` sites with no
+  always-on twin — `:rf.error/dispatch-sync-in-handler` is emitted from
+  `router.cljc` through `trace/emit-error!` alone — so under
+  `-Dre-frame.debug=false` neither is observable, and every assertion about
+  them is kept verbatim inside a `(when interop/debug-enabled? …)` arm marked
+  `rf2-d2841`.
+
+  PROCEEDS is production behaviour, and it is the half worth protecting: the
+  whole Option-B decision is that a cross-frame `dispatch-sync` is NOT
+  rejected. Each deftest asserts the target frame's handler ran and its
+  app-db reflects the effect, unguarded, so the production lane pins the
+  no-rejection contract even where the diagnostic is gone.
+
+  The negatives — `no-warning-when-no-other-frame-is-mid-drain`, the
+  \"same-frame must NOT pick up the cross-frame warning\" pair, and \"no
+  dispatch-sync-in-handler for the cross-frame case\" — move inside the arms
+  with their positives. Over the gate's empty stream every one of them passes
+  without the guard they describe ever running, which is exactly the
+  same-frame-vs-cross-frame distinction this file exists to police."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.trace :as trace]))
@@ -81,36 +105,43 @@
       (let [recorded (record-traces! ::cfx)]
         (rf/dispatch-sync [:a/cross] {:frame :cfx.test/a})
 
-        (testing "exactly one cross-frame warning fires"
-          (let [warns (cross-frame-warnings recorded)]
-            (is (= 1 (count warns))
-                (str "expected exactly one cross-frame warning, got "
-                     (count warns)))
-            (let [w (first warns)
-                  t (:tags w)]
-              (is (= :cfx.test/a (:caller-frame t))
-                  ":caller-frame should be the frame whose drain is in flight")
-              (is (= :cfx.test/b (:target-frame t))
-                  ":target-frame should be the dispatch-sync!'s :frame opt")
-              (is (= :cfx.test/a (:other-frame t))
-                  ":other-frame is the sibling that is mid-drain (here, the caller)")
-              (is (= [:b/leaf] (:event t)))
-              (is (string? (:reason t)))
-              (is (re-find #"mid-drain|interleave|cross-frame" (:reason t))
-                  "reason should describe the interleave pattern")
-              (is (= :no-recovery (:recovery w))))))
-
+        ;; ALWAYS-ON (rf2-d2841): PROCEEDS is the production half of "warns but
+        ;; proceeds", and it is the substance of Option B — cross-frame
+        ;; reentry is deliberately NOT rejected.
         (testing "the dispatch proceeded — frame B's handler ran"
           (is (true? @b-ran) "frame B's :b/leaf handler ran (warning did NOT refuse)")
           (is (true? (:b-ran? (rf/app-db-value :cfx.test/b)))
               "frame B's app-db reflects the handler's effect"))
 
-        (testing "no `:rf.error/dispatch-sync-in-handler` fires for the cross-frame case"
-          ;; Per Mike's Option B: cross-frame is intentionally distinct
-          ;; from same-frame reentry. The cross-frame warning is the
-          ;; ONLY surface; the same-frame error should NOT fire.
-          (is (empty? (dsih-errors recorded))
-              "cross-frame dispatch-sync! is a warning, not an error"))))))
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+        (when interop/debug-enabled?
+          (testing "exactly one cross-frame warning fires"
+            (let [warns (cross-frame-warnings recorded)]
+              (is (= 1 (count warns))
+                  (str "expected exactly one cross-frame warning, got "
+                       (count warns)))
+              (let [w (first warns)
+                    t (:tags w)]
+                (is (= :cfx.test/a (:caller-frame t))
+                    ":caller-frame should be the frame whose drain is in flight")
+                (is (= :cfx.test/b (:target-frame t))
+                    ":target-frame should be the dispatch-sync!'s :frame opt")
+                (is (= :cfx.test/a (:other-frame t))
+                    ":other-frame is the sibling that is mid-drain (here, the caller)")
+                (is (= [:b/leaf] (:event t)))
+                (is (string? (:reason t)))
+                (is (re-find #"mid-drain|interleave|cross-frame" (:reason t))
+                    "reason should describe the interleave pattern")
+                (is (= :no-recovery (:recovery w))))))
+
+          (testing "no `:rf.error/dispatch-sync-in-handler` fires for the cross-frame case"
+            ;; Per Mike's Option B: cross-frame is intentionally distinct
+            ;; from same-frame reentry. The cross-frame warning is the
+            ;; ONLY surface; the same-frame error should NOT fire. Inside the
+            ;; arm because its sibling positive above is what proves the
+            ;; stream is live — over an empty stream it says nothing.
+            (is (empty? (dsih-errors recorded))
+                "cross-frame dispatch-sync! is a warning, not an error")))))))
 
 (deftest same-frame-dispatch-sync-still-errors
   (testing "the existing same-frame reentry contract is unchanged — error fires, no cross-frame warning"
@@ -135,10 +166,19 @@
     (let [recorded (record-traces! ::same-frame-still-errors)]
       (rf/dispatch-sync [:nested-same-frame] {:frame :cfx.test/a})
 
-      (is (= 1 (count (dsih-errors recorded)))
-          "same-frame reentry still raises :rf.error/dispatch-sync-in-handler")
-      (is (empty? (cross-frame-warnings recorded))
-          "same-frame case must NOT emit the cross-frame warning"))))
+      ;; ALWAYS-ON (rf2-d2841): same-frame reentry is REFUSED — the inner
+      ;; `:leaf` handler never commits. That is the production-visible
+      ;; contrast with the cross-frame case above, where the target's handler
+      ;; does run, and it is what makes "the two cases are distinct" a claim
+      ;; the production lane can still check.
+      (is (nil? (:leaf? (rf/app-db-value :cfx.test/a)))
+          "same-frame reentry did NOT run the inner handler (contrast: cross-frame does)")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+      (when interop/debug-enabled?
+        (is (= 1 (count (dsih-errors recorded)))
+            "same-frame reentry still raises :rf.error/dispatch-sync-in-handler")
+        (is (empty? (cross-frame-warnings recorded))
+            "same-frame case must NOT emit the cross-frame warning")))))
 
 (deftest no-warning-when-no-other-frame-is-mid-drain
   (testing "ordinary cross-frame dispatch-sync! (outside any drain) does NOT warn"
@@ -154,10 +194,15 @@
       ;; Plain top-level dispatch-sync against B — no frame is mid-drain.
       (rf/dispatch-sync [:b/leaf] {:frame :cfx.test/b})
 
-      (is (empty? (cross-frame-warnings recorded))
-          "no frame is mid-drain when the dispatch-sync! fires — no warning expected")
+      ;; ALWAYS-ON (rf2-d2841).
       (is (true? (:b-ran? (rf/app-db-value :cfx.test/b)))
-          ":b/leaf still ran successfully"))))
+          ":b/leaf still ran successfully")
+      ;; rf2-d2841 — dev-instrumentation arm. A NEGATIVE over the trace
+      ;; stream: under the gate no frame-drain state produces a warning, so
+      ;; outside the arm "no frame is mid-drain" would be certified for free.
+      (when interop/debug-enabled?
+        (is (empty? (cross-frame-warnings recorded))
+            "no frame is mid-drain when the dispatch-sync! fires — no warning expected")))))
 
 (deftest fires-on-cross-frame-dispatch-sync-during-async-drain
   (testing "warning fires for cross-frame dispatch-sync! while caller frame's :in-drain? is true (not just :in-sync-drain?)"
@@ -185,6 +230,9 @@
       (let [recorded (record-traces! ::async-drain)]
         (rf/dispatch-sync [:a/touch-b] {:frame :cfx.test/a})
 
-        (is (= 1 (count (cross-frame-warnings recorded)))
-            "the cross-frame warning fires whenever any sibling frame is mid-drain")
-        (is (true? @b-ran))))))
+        ;; ALWAYS-ON (rf2-d2841): the cross-frame dispatch proceeded.
+        (is (true? @b-ran))
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+        (when interop/debug-enabled?
+          (is (= 1 (count (cross-frame-warnings recorded)))
+              "the cross-frame warning fires whenever any sibling frame is mid-drain"))))))

--- a/implementation/core/test/re_frame/doc_metadata_prod_elision_test.clj
+++ b/implementation/core/test/re_frame/doc_metadata_prod_elision_test.clj
@@ -22,7 +22,28 @@
   sentinel): a runtime strip cannot DCE a user-authored call-site string,
   so the reg-* macros gate any LITERAL doc-bearing metadata-map under
   `interop/debug-enabled?` and the bundle grep pins that the dev `:doc`
-  string DCEs. This file pins the SEMANTIC handler-meta contract."
+  string DCEs. This file pins the SEMANTIC handler-meta contract.
+
+  ## Posture split (rf2-d2841)
+
+  The PROD half of this contract — `:doc` stripped, load-bearing keys
+  retained, the elidable set closed to `#{:doc}` — is posture-independent
+  and runs in BOTH `clojure -M:test` and `scripts/test-core-prod-gate.sh`
+  (the `-Dre-frame.debug=false` lane). Under the real gate those assertions
+  get STRONGER, not weaker: the `with-redefs` models the gate in the dev
+  lane, while the prod lane has the load-time flag genuinely off, so the
+  same assertion is re-run against the real thing. Note this is NOT the
+  vacuous class-4 shape (a negative about a wholesale-elided key): `:doc`
+  is only absent here because `register!` stripped it from a map the caller
+  really did supply, and `doc-retained-in-handler-meta-under-enabled-debug-
+  gate` in the dev lane proves the same call site retains it when the gate
+  is on. The subject exists in both postures; only the strip differs.
+
+  The DEV half — `:doc` RETAINED for tooling / agent inspection, and
+  `strip-pure-documentation`'s dev identity — is a claim about the gate
+  being ON. Under `-Dre-frame.debug=false` there is nothing to retain, by
+  design, so those assertions are kept verbatim inside a
+  `(when interop/debug-enabled? …)` arm marked `rf2-d2841`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.interop :as interop]
@@ -62,8 +83,27 @@
                      {:doc "kept in dev"}
                      (fn [{:keys [db]} _] {:db db}))
     (let [meta (rf/handler-meta :event :rf2-9wwkcm/dev-event)]
-      (is (= "kept in dev" (:doc meta))
-          ":doc retained in dev for tooling / agent inspection"))))
+      ;; PRODUCTION WITNESS (rf2-d2841). The dev claim below is about a key
+      ;; the gate elides, so guarded alone it would leave this deftest
+      ;; executing NOTHING under `-Dre-frame.debug=false`. The always-on
+      ;; half is that the doc-bearing metadata-map ARITY still registers a
+      ;; live handler: the reg-* macro rewrites a literal doc-map under the
+      ;; gate (`core_reg_macros/gate-doc-arg`), so a rewrite that dropped
+      ;; the registration — or mis-shaped the residual map — would surface
+      ;; here and nowhere else in this file.
+      (is (some? meta)
+          "the {:doc …} metadata-map arity registers in BOTH postures")
+      (is (ifn? (:handler-fn meta))
+          "the handler-fn survives the doc-map rewrite in BOTH postures")
+      (is (= {:db {:seen true}}
+             ((:handler-fn meta) {:db {:seen true}} [:rf2-9wwkcm/dev-event]))
+          "the registered handler is the one the call site supplied")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture
+      ;; split). `:doc` is pure-documentation metadata, stripped at the
+      ;; `register!` chokepoint under the production gate.
+      (when interop/debug-enabled?
+        (is (= "kept in dev" (:doc meta))
+            ":doc retained in dev for tooling / agent inspection")))))
 
 ;; ---- universality: every reg-* surface funnels through register! --------
 
@@ -103,10 +143,13 @@
           "prod: doc-only map strips to empty")
       (is (nil? (registrar/strip-pure-documentation nil))
           "non-map (nil) passes through"))
-    ;; Dev posture: identity.
-    (is (= {:doc "x" :schema :int}
-           (registrar/strip-pure-documentation {:doc "x" :schema :int}))
-        "dev: full map retained (identity)")))
+    ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture
+    ;; split). "Identity in dev" is a claim about the gate being ON;
+    ;; under `-Dre-frame.debug=false` the helper is the strip, by design.
+    (when interop/debug-enabled?
+      (is (= {:doc "x" :schema :int}
+             (registrar/strip-pure-documentation {:doc "x" :schema :int}))
+          "dev: full map retained (identity)"))))
 
 ;; Note (rf2-tfiutq): the `reg-machine` LITERAL opts-map `:doc` elision lands
 ;; here too — but the runtime handler-meta strip rides the SAME single

--- a/implementation/core/test/re_frame/elision_test.clj
+++ b/implementation/core/test/re_frame/elision_test.clj
@@ -9,12 +9,41 @@
   Schema-attached `{:sensitive? true}` / `{:large? true}` slot props are NOT
   a route into this registry. These tests seed declarations through the
   effect path; the walker behaviour (marker shape, sensitive-wins-over-large,
-  idempotence, threshold interaction, frame isolation) is unchanged."
+  idempotence, threshold interaction, frame isolation) is unchanged.
+
+  ## Posture split (rf2-d2841)
+
+  ELISION IS PRODUCTION BEHAVIOUR and almost all of this file runs under
+  `scripts/test-core-prod-gate.sh` unchanged: marker shape, redaction of
+  declared `:sensitive` paths, the `include-large?` / `include-sensitive?`
+  bypasses, frame isolation, idempotence, and the fact that a frame-declared
+  `:large` path elides independent of the runtime threshold.
+
+  `:rf.warning/large-value-unschema'd` is a different matter. It is the
+  runtime AUTO-DETECT diagnostic — a dev-only `trace/emit!` site — and,
+  crucially, it is the ONLY observable the threshold has: the file's own
+  `unschema'd-large-value-warns-but-does-not-elide` establishes that a
+  schema-less large value is NOT elided, so the threshold changes nothing
+  about the returned wire value. Every threshold deftest therefore reads its
+  result off that warning, and all of them are kept verbatim inside
+  `(when interop/debug-enabled? …)` arms marked `rf2-d2841`.
+
+  That includes the ones that pass under the gate today, and they are the
+  reason to be careful here rather than the exception to it:
+  `threshold-zero-disables-runtime-auto-detect` asserts `(= 0
+  (count-unschema'd-warnings …))` twice, and `explicit-opt-wins-over-configured`
+  and `default-threshold-is-16384` each open with the same shape. Over a
+  trace stream that is empty for EVERY threshold, \"threshold 0 disables
+  auto-detect\" is true without the threshold existing. Their production
+  residue — that the configured value reaches `elision/current-config`, and
+  that the wire value is returned intact either way — is asserted outside the
+  arms."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.flows :as flows]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -100,27 +129,38 @@
   (let [big    (apply str (repeat 3000 "ABCDEFGH"))
         traces (collect-traces! :elision-test/unschema'd)
         out    (rf/elide-wire-value {:user {:photo big}})]
+    ;; ALWAYS-ON: the wire value is unchanged. This is the half of the
+    ;; contract that survives the gate, and it is the load-bearing one — a
+    ;; diagnostic that started eliding would be the actual defect.
     (is (= big (get-in out [:user :photo]))
         "schema-less large values are not auto-elided")
-    (let [warnings (filterv #(= :rf.warning/large-value-unschema'd
-                                (:operation %))
-                            @traces)]
-      (is (= 1 (count warnings)))
-      (is (= [:user :photo] (get-in (first warnings) [:tags :path])))
-      (is (pos-int? (get-in (first warnings) [:tags :bytes])))
-      (is (= "Classify this path large by returning `:large [[...]]` from the event that writes it (EP-0025 commit-plane classification effect, alongside `:db`)."
-             (get-in (first warnings) [:tags :hint]))))
+    ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+    (when interop/debug-enabled?
+      (let [warnings (filterv #(= :rf.warning/large-value-unschema'd
+                                  (:operation %))
+                              @traces)]
+        (is (= 1 (count warnings)))
+        (is (= [:user :photo] (get-in (first warnings) [:tags :path])))
+        (is (pos-int? (get-in (first warnings) [:tags :bytes])))
+        (is (= "Classify this path large by returning `:large [[...]]` from the event that writes it (EP-0025 commit-plane classification effect, alongside `:db`)."
+               (get-in (first warnings) [:tags :hint])))))
     (rf/unregister-listener! :trace :elision-test/unschema'd)))
 
 (deftest unschema'd-large-warning-is-once-per-path
   (let [big    (apply str (repeat 3000 "ABCDEFGH"))
         traces (collect-traces! :elision-test/once)]
-    (rf/elide-wire-value {:photo big})
-    (rf/elide-wire-value {:photo big})
-    (rf/elide-wire-value {:photo big})
-    (is (= 1 (count (filter #(= :rf.warning/large-value-unschema'd
-                                (:operation %))
-                            @traces))))
+    ;; ALWAYS-ON: three identical walks return the value verbatim every time —
+    ;; the warn-once cache does not start eliding on the second pass.
+    (is (= [{:photo big} {:photo big} {:photo big}]
+           [(rf/elide-wire-value {:photo big})
+            (rf/elide-wire-value {:photo big})
+            (rf/elide-wire-value {:photo big})])
+        "repeat walks of the same unschema'd path leave the value intact")
+    ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+    (when interop/debug-enabled?
+      (is (= 1 (count (filter #(= :rf.warning/large-value-unschema'd
+                                  (:operation %))
+                              @traces)))))
     (rf/unregister-listener! :trace :elision-test/once)))
 
 ;; ---------------------------------------------------------------------------
@@ -149,12 +189,21 @@
         traces  (collect-traces! :elision-test/default-thresh)]
     ;; `under` here is genuinely under 16384 bytes once quoted (16000 chars
     ;; + 2 quote bytes = 16002), so no warning.
-    (rf/elide-wire-value {:a {:small under}})
-    (is (= 0 (count-unschema'd-warnings traces))
-        "value under the 16384 default does not trip the auto-detect warning")
-    (rf/elide-wire-value {:b {:big over}})
-    (is (= 1 (count-unschema'd-warnings traces))
-        "value over the 16384 default trips the warning")
+    ;; ALWAYS-ON: the documented default is readable straight off the config,
+    ;; with no channel involved.
+    (is (= 16384 (:rf.size/threshold-bytes (elision/current-config)))
+        "the documented 16384-byte default is the live configured threshold")
+    ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+    ;; The auto-detect WARNING is the threshold's only observable, and under
+    ;; the gate the stream is empty for every value — so the `= 0` half would
+    ;; certify `under` as under-threshold without the threshold existing.
+    (when interop/debug-enabled?
+      (rf/elide-wire-value {:a {:small under}})
+      (is (= 0 (count-unschema'd-warnings traces))
+          "value under the 16384 default does not trip the auto-detect warning")
+      (rf/elide-wire-value {:b {:big over}})
+      (is (= 1 (count-unschema'd-warnings traces))
+          "value over the 16384 default trips the warning"))
     (rf/unregister-listener! :trace :elision-test/default-thresh)))
 
 (deftest configured-threshold-takes-effect
@@ -164,15 +213,22 @@
   ;; would have ignored.
   (let [small  (apply str (repeat 300 "y"))         ; ~302 bytes — under default, over 100
         traces (collect-traces! :elision-test/configured)]
-    ;; Baseline: under the default, no warning.
-    (rf/elide-wire-value {:a {:s small}})
-    (is (= 0 (count-unschema'd-warnings traces))
-        "300-byte string is under the 16384 default — no warning")
-    ;; Lower the configured threshold; now the same shape warns.
+    ;; ALWAYS-ON: `configure!` moves the live threshold, and the wire value
+    ;; comes back intact on both sides of the move (the knob governs the
+    ;; advisory, never the walk's output).
+    (is (= {:a {:s small}} (rf/elide-wire-value {:a {:s small}}))
+        "under the default the 300-byte string rides verbatim")
     (rf/configure! {:elision {:rf.size/threshold-bytes 100}})
-    (rf/elide-wire-value {:b {:s small}})
-    (is (= 1 (count-unschema'd-warnings traces))
-        "after (configure :elision {:rf.size/threshold-bytes 100}) the 300-byte string warns")
+    (is (= 100 (:rf.size/threshold-bytes (elision/current-config)))
+        "(configure! {:elision {:rf.size/threshold-bytes 100}}) moved the live threshold")
+    (is (= {:b {:s small}} (rf/elide-wire-value {:b {:s small}}))
+        "and the now-over-threshold string STILL rides verbatim — the knob
+         governs the advisory, not the walk")
+    ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+    ;; The warning is the threshold's only observable.
+    (when interop/debug-enabled?
+      (is (= 1 (count-unschema'd-warnings traces))
+          "after (configure :elision {:rf.size/threshold-bytes 100}) the 300-byte string warns"))
     (rf/unregister-listener! :trace :elision-test/configured)))
 
 (deftest configure-threshold-reaches-elision-config
@@ -190,16 +246,21 @@
   (let [s      (apply str (repeat 300 "z"))          ; ~302 bytes
         traces (collect-traces! :elision-test/opt-wins)]
     (rf/configure! {:elision {:rf.size/threshold-bytes 50}})
-    ;; Configured 50 alone would warn for a 302-byte string; but the
-    ;; explicit per-call opt of 100000 raises the bar above it.
-    (rf/elide-wire-value {:a {:s s}} {:rf.size/threshold-bytes 100000})
-    (is (= 0 (count-unschema'd-warnings traces))
-        "explicit :rf.size/threshold-bytes opt (100000) overrides configured (50) — no warning")
-    ;; And conversely an explicit small opt wins over a large configured value.
-    (rf/configure! {:elision {:rf.size/threshold-bytes 1000000}})
-    (rf/elide-wire-value {:b {:s s}} {:rf.size/threshold-bytes 100})
-    (is (= 1 (count-unschema'd-warnings traces))
-        "explicit :rf.size/threshold-bytes opt (100) overrides configured (1000000) — warns")
+    ;; ALWAYS-ON: whichever threshold wins, an unschema'd value is returned
+    ;; verbatim — the precedence rule governs the advisory, never the walk.
+    (is (= {:a {:s s}} (rf/elide-wire-value {:a {:s s}} {:rf.size/threshold-bytes 100000}))
+        "a per-call threshold opt does not change the walk's output")
+    ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+    ;; BOTH halves go inside: the `= 0` would pass over the gate's empty
+    ;; stream without the explicit opt having overridden anything.
+    (when interop/debug-enabled?
+      (is (= 0 (count-unschema'd-warnings traces))
+          "explicit :rf.size/threshold-bytes opt (100000) overrides configured (50) — no warning")
+      ;; And conversely an explicit small opt wins over a large configured value.
+      (rf/configure! {:elision {:rf.size/threshold-bytes 1000000}})
+      (rf/elide-wire-value {:b {:s s}} {:rf.size/threshold-bytes 100})
+      (is (= 1 (count-unschema'd-warnings traces))
+          "explicit :rf.size/threshold-bytes opt (100) overrides configured (1000000) — warns"))
     (rf/unregister-listener! :trace :elision-test/opt-wins)))
 
 (deftest threshold-zero-disables-runtime-auto-detect
@@ -209,14 +270,25 @@
   (let [big    (apply str (repeat 5000 "ABCDEFGH")) ; ~40002 bytes — well over default
         traces (collect-traces! :elision-test/zero)]
     (rf/configure! {:elision {:rf.size/threshold-bytes 0}})
-    (rf/elide-wire-value {:a {:big big}})
-    (is (= 0 (count-unschema'd-warnings traces))
-        "threshold 0 disables runtime auto-detect — no warning even for a 40KB string")
-    ;; Sanity: a per-call explicit 0 also disables, overriding a configured non-zero.
-    (rf/configure! {:elision {:rf.size/threshold-bytes 100}})
-    (rf/elide-wire-value {:b {:big big}} {:rf.size/threshold-bytes 0})
-    (is (= 0 (count-unschema'd-warnings traces))
-        "explicit threshold-bytes 0 opt disables runtime auto-detect for that call")
+    ;; ALWAYS-ON: 0 reaches the live config, and the 40KB unschema'd value
+    ;; still rides verbatim (auto-detect never elided it in the first place —
+    ;; `unschema'd-large-value-warns-but-does-not-elide`).
+    (is (= 0 (:rf.size/threshold-bytes (elision/current-config)))
+        "threshold 0 reaches the live elision config")
+    (is (= {:a {:big big}} (rf/elide-wire-value {:a {:big big}}))
+        "the 40KB unschema'd value rides verbatim under threshold 0")
+    ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+    ;; BOTH assertions here are `(= 0 …)` over the warning stream, which is
+    ;; empty for every threshold under the gate — "0 disables auto-detect"
+    ;; would be true with no auto-detect to disable.
+    (when interop/debug-enabled?
+      (is (= 0 (count-unschema'd-warnings traces))
+          "threshold 0 disables runtime auto-detect — no warning even for a 40KB string")
+      ;; Sanity: a per-call explicit 0 also disables, overriding a configured non-zero.
+      (rf/configure! {:elision {:rf.size/threshold-bytes 100}})
+      (rf/elide-wire-value {:b {:big big}} {:rf.size/threshold-bytes 0})
+      (is (= 0 (count-unschema'd-warnings traces))
+          "explicit threshold-bytes 0 opt disables runtime auto-detect for that call"))
     (rf/unregister-listener! :trace :elision-test/zero)))
 
 (deftest configured-threshold-does-not-affect-declared-elision

--- a/implementation/core/test/re_frame/frame_initial_events_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_initial_events_cljs_test.cljc
@@ -44,10 +44,28 @@
   `{:db new-db}` shape and uses it as the construction db-seed step; the contract
   under test is the `:initial-events` engine, not `:rf/set-db` itself.
 
-  `.cljc` ends `-cljs-test` so it rides `npm run test:cljs` AND `clojure -M:test`."
+  `.cljc` ends `-cljs-test` so it rides `npm run test:cljs` AND `clojure -M:test`.
+
+  ## Posture split (rf2-d2841)
+
+  The `:initial-events` ENGINE is production behaviour and runs under
+  `scripts/test-core-prod-gate.sh` unchanged — the steps run in declaration
+  order, the app-db lands, and the fail-loud preflight throws the right
+  `:rf.error/id` for each bad shape.
+
+  PROVENANCE is not. `:source :frame-init` and `:rf.frame/init-step-index`
+  both ride the `:rf.event/dispatched` trace and are gone under
+  `-Dre-frame.debug=false`, so `initial-events-carry-construction-provenance`
+  keeps its assertions verbatim inside a `(when interop/debug-enabled? …)` arm
+  marked `rf2-d2841` — the two negatives about the ordinary runtime dispatch
+  included, since over an empty stream `(first @dispatched)` is nil and both
+  pass without anything having been classified. The always-on witness kept
+  outside the arm is that the two setup steps ran at all; without it the
+  deftest would be describing dispatches nobody proved happened."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core         :as rf]
+            [re-frame.interop      :as interop]
             [re-frame.frame        :as frame]
             [re-frame.image        :as image]
             [re-frame.late-bind    :as late-bind]
@@ -184,31 +202,45 @@
       (rf/make-frame {:id :prov/main :initial-events [[:test/set-db {:n 0}]
                                        [:test/inc]]})
       (rf/unregister-listener! :trace ::prov)
-      (let [sources (->> @dispatched (map :source) (filter #{:frame-init}))]
-        (is (= 2 (count sources))
-            "both setup dispatches carried :source :frame-init"))
-      ;; rf2-8j4h7i: the :step-index half of the provenance contract reaches the
-      ;; trace — each frame-init dispatch carries its 0-based step index under
-      ;; [:tags :rf.frame/init-step-index], in declaration order (previously the
-      ;; runner set :step-index on the opts but build-envelope dropped it). The
-      ;; index rides under :tags (the raw layer :frame also rides), unlike the
-      ;; hoisted top-level :source.
-      (let [init-steps (->> @dispatched (filter #(= :frame-init (:source %))))]
-        (is (= [0 1] (mapv #(get-in % [:tags :rf.frame/init-step-index]) init-steps))
-            "each frame-init dispatch carries its 0-based :rf.frame/init-step-index"))
-      ;; A subsequent RUNTIME dispatch is NOT frame-init — proving the tag
-      ;; discriminates construction from runtime.
-      (reset! dispatched [])
-      (rf/register-listener! :trace ::prov2
-        (fn [ev]
-          (when (= :rf.event/dispatched (:operation ev))
-            (swap! dispatched conj ev))))
-      (rf/dispatch-sync [:test/inc] {:frame :prov/main :source :test})
-      (rf/unregister-listener! :trace ::prov2)
-      (is (not= :frame-init (:source (first @dispatched)))
-          "an ordinary runtime dispatch is NOT tagged :source :frame-init")
-      (is (nil? (get-in (first @dispatched) [:tags :rf.frame/init-step-index]))
-          "an ordinary runtime dispatch carries no :rf.frame/init-step-index"))))
+      ;; ALWAYS-ON WITNESS (rf2-d2841): both setup steps ran, in declaration
+      ;; order — `:test/set-db {:n 0}` then `:test/inc`. The provenance tags
+      ;; below describe those two dispatches; if they had not happened the
+      ;; whole deftest would be about nothing, and under the production gate
+      ;; this is the only way to know they did.
+      (is (= 1 (:n (rf/app-db-value :prov/main)))
+          "both :initial-events setup steps ran, in declaration order")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+      ;; :source and :rf.frame/init-step-index ride the :rf.event/dispatched
+      ;; TRACE, which is elided under -Dre-frame.debug=false.
+      (when interop/debug-enabled?
+        (let [sources (->> @dispatched (map :source) (filter #{:frame-init}))]
+          (is (= 2 (count sources))
+              "both setup dispatches carried :source :frame-init"))
+        ;; rf2-8j4h7i: the :step-index half of the provenance contract reaches the
+        ;; trace — each frame-init dispatch carries its 0-based step index under
+        ;; [:tags :rf.frame/init-step-index], in declaration order (previously the
+        ;; runner set :step-index on the opts but build-envelope dropped it). The
+        ;; index rides under :tags (the raw layer :frame also rides), unlike the
+        ;; hoisted top-level :source.
+        (let [init-steps (->> @dispatched (filter #(= :frame-init (:source %))))]
+          (is (= [0 1] (mapv #(get-in % [:tags :rf.frame/init-step-index]) init-steps))
+              "each frame-init dispatch carries its 0-based :rf.frame/init-step-index"))
+        ;; A subsequent RUNTIME dispatch is NOT frame-init — proving the tag
+        ;; discriminates construction from runtime. The two negatives stay
+        ;; beside their positives: over the gate's empty stream `(first
+        ;; @dispatched)` is nil, so both would pass without a runtime dispatch
+        ;; ever having been classified.
+        (reset! dispatched [])
+        (rf/register-listener! :trace ::prov2
+          (fn [ev]
+            (when (= :rf.event/dispatched (:operation ev))
+              (swap! dispatched conj ev))))
+        (rf/dispatch-sync [:test/inc] {:frame :prov/main :source :test})
+        (rf/unregister-listener! :trace ::prov2)
+        (is (not= :frame-init (:source (first @dispatched)))
+            "an ordinary runtime dispatch is NOT tagged :source :frame-init")
+        (is (nil? (get-in (first @dispatched) [:tags :rf.frame/init-step-index]))
+            "an ordinary runtime dispatch carries no :rf.frame/init-step-index")))))
 
 ;; ===========================================================================
 ;; 3. Strict-shape preflight — each bad shape fails the right id, no frame left

--- a/implementation/core/test/re_frame/handler_source_test.clj
+++ b/implementation/core/test/re_frame/handler_source_test.clj
@@ -5,16 +5,50 @@
   The `reg-event` macro stamps the whole `(reg-event :id ...)` form
   as a string into the handler's registry metadata under
   `:rf.handler/source` so Xray's Event panel can render the source
-  inline. JVM-side is always-on (bundle-size argument doesn't apply);
-  CLJS-side is `goog.DEBUG`-gated so production bundles DCE the
-  literal source-string bytes. See `re-frame.core_reg_macros/defreg-
+  inline. The capture is DEBUG-gated on BOTH platforms — CLJS so
+  `:advanced` + `goog.DEBUG=false` DCEs the literal source-string bytes,
+  JVM so `-Dre-frame.debug=false` (the documented SSR/production setting)
+  gets the same treatment. See `re-frame.core_reg_macros/defreg-
   event-macro` for the emission and `re-frame.events/merge-form-
   source` for the registrar-side merge. EP-0018 (rf2-xhfxcs.14) collapsed
-  the former `reg-event-{db,fx,ctx}` macros onto the one `reg-event`."
+  the former `reg-event-{db,fx,ctx}` macros onto the one `reg-event`.
+
+  (This docstring used to say \"JVM-side is always-on (bundle-size argument
+  doesn't apply)\". Measured under the real gate that is false, and the source
+  agrees: `with-form-source-form` binds `*pending-form-source*` to
+  `(if interop/debug-enabled? <src> nil)` with no platform reader-conditional,
+  and `merge-form-source` opens with `(if-not interop/debug-enabled? m …)`.
+  Corrected here rather than left to mislead the next reader — rf2-d2841.)
+
+  ## Posture split (rf2-d2841)
+
+  AUTO-capture is therefore dev-only, and every auto-capture assertion is kept
+  verbatim inside a `(when interop/debug-enabled? …)` arm.
+
+  The always-on half is that the form-source-capturing MACRO PATH still
+  registers a live handler. That is not a formality: the macro's production
+  arm is a DIFFERENT expansion from its dev arm, so a broken prod arm would
+  drop or mis-shape the registration outright — and this file is where that
+  would show. Every deftest keeps an unguarded `handler-meta` witness.
+
+  `user-supplied-source-wins` is UNGUARDED and stays load-bearing under the
+  gate: `merge-form-source` returns the metadata map untouched in production,
+  so a `:rf.handler/source` the caller authored explicitly (a code-gen pass
+  stamping the original site) SURVIVES production while the auto-captured one
+  does not. That asymmetry is the contract, and asserting it is only
+  meaningful in the production posture.
+
+  The two ABSENCE deftests — `fn-form-call-skips-form-source` and
+  `reg-sub-does-not-capture-form-source` — are inside the arm rather than
+  outside it. Under the gate `:rf.handler/source` is elided WHOLESALE, so
+  \"absent on the fn-form path\" would pass because the key never exists for
+  ANY path, not because the fn-form skipped it: the same false-green shape as
+  a negative over an empty trace ring."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.interceptor :as interceptor]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.frame :as frame]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -33,13 +67,19 @@
 (defn- assert-source [kind id macro-name]
   (let [m   (rf/handler-meta kind id)
         src (:rf.handler/source m)]
+    ;; Always-on witness (rf2-d2841): the macro path registered, in EITHER
+    ;; posture. The prod arm of the expansion is what would break here.
     (is (some? m) (str "handler-meta for " kind " " id " should be present"))
-    (is (string? src)
-        (str ":rf.handler/source should be a string for " kind " " id))
-    (is (str/includes? src macro-name)
-        (str ":rf.handler/source should include the macro name '" macro-name "'"))
-    (is (str/includes? src (pr-str id))
-        (str ":rf.handler/source should include the id literal '" (pr-str id) "'"))))
+    (is (ifn? (:handler-fn m))
+        (str "the registered handler-fn is live for " kind " " id))
+    ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+    (when interop/debug-enabled?
+      (is (string? src)
+          (str ":rf.handler/source should be a string for " kind " " id))
+      (is (str/includes? src macro-name)
+          (str ":rf.handler/source should include the macro name '" macro-name "'"))
+      (is (str/includes? src (pr-str id))
+          (str ":rf.handler/source should include the id literal '" (pr-str id) "'")))))
 
 ;; ---- per-kind captures ----------------------------------------------------
 
@@ -51,14 +91,16 @@
     (rf/reg-event :rf2-xhfxcs/event-sample
                   (fn [{:keys [db]} _ev] {:db db}))
     (assert-source :event :rf2-xhfxcs/event-sample "reg-event")
-    (let [src (:rf.handler/source
-               (rf/handler-meta :event :rf2-xhfxcs/event-sample))]
-      ;; Whole-form capture: the handler-fn body (the fx-shape return) must
-      ;; appear, not just the surface.
-      (is (str/includes? src "(fn [{:keys [db]} _ev] {:db db})")
-          ":rf.handler/source should include the reg-event handler-fn body")
-      (is (str/includes? src ":db")
-          ":rf.handler/source should include the effect-map keyword"))))
+    ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+    (when interop/debug-enabled?
+      (let [src (:rf.handler/source
+                 (rf/handler-meta :event :rf2-xhfxcs/event-sample))]
+        ;; Whole-form capture: the handler-fn body (the fx-shape return) must
+        ;; appear, not just the surface.
+        (is (str/includes? src "(fn [{:keys [db]} _ev] {:db db})")
+            ":rf.handler/source should include the reg-event handler-fn body")
+        (is (str/includes? src ":db")
+            ":rf.handler/source should include the effect-map keyword")))))
 
 ;; EP-0018 (rf2-xhfxcs.14): the former `reg-event-db` / `reg-event-fx`
 ;; per-kind capture tests collapsed into `reg-event-captures-form-source`
@@ -86,11 +128,16 @@
     (rf/reg-event :rf2-xgfuy/event-with-meta
                      {:doc "metadata-shape middle slot"}
                      (fn [{:keys [db]} _] {:db db}))
-    (let [src (:rf.handler/source
-               (rf/handler-meta :event :rf2-xgfuy/event-with-meta))]
-      (is (string? src))
-      (is (str/includes? src ":doc"))
-      (is (str/includes? src "metadata-shape middle slot")))))
+    ;; Always-on witness (rf2-d2841): the metadata-map middle slot registered.
+    (is (some? (rf/handler-meta :event :rf2-xgfuy/event-with-meta))
+        "the metadata-map middle slot registers in BOTH postures")
+    ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+    (when interop/debug-enabled?
+      (let [src (:rf.handler/source
+                 (rf/handler-meta :event :rf2-xgfuy/event-with-meta))]
+        (is (string? src))
+        (is (str/includes? src ":doc"))
+        (is (str/includes? src "metadata-shape middle slot"))))))
 
 (deftest captures-form-source-with-metadata-interceptors
   (testing "rf2-xgfuy: metadata :interceptors round-trips into :rf.handler/source"
@@ -105,10 +152,19 @@
     (rf/reg-event :rf2-xgfuy/event-with-icpts
                      {:interceptors [:app/unwrap]}
                      (fn [_cofx {:keys [v]}] {:db {:v v}}))
-    (let [src (:rf.handler/source
-               (rf/handler-meta :event :rf2-xgfuy/event-with-icpts))]
-      (is (string? src))
-      (is (str/includes? src "unwrap")))))
+    ;; Always-on witness (rf2-d2841): the metadata `:interceptors` ref
+    ;; threaded into the stored chain — the production-visible half of the
+    ;; round-trip this deftest is about.
+    (is (= [:app/unwrap :rf/event-handler]
+           (mapv (fn [e] (if (keyword? e) e (:id e)))
+                 (:interceptors (rf/handler-meta :event :rf2-xgfuy/event-with-icpts))))
+        "the metadata :interceptors ref sits before the framework wrapper")
+    ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+    (when interop/debug-enabled?
+      (let [src (:rf.handler/source
+                 (rf/handler-meta :event :rf2-xgfuy/event-with-icpts))]
+        (is (string? src))
+        (is (str/includes? src "unwrap"))))))
 
 ;; ---- programmatic call (bypasses macro) ----------------------------------
 
@@ -121,8 +177,13 @@
        (fn [{:keys [db]} _] {:db db}))
     (let [m (rf/handler-meta :event :rf2-xgfuy/programmatic)]
       (is (some? m))
-      (is (not (contains? m :rf.handler/source))
-          ":rf.handler/source absent on direct fn call"))))
+      ;; rf2-d2841 — dev-instrumentation arm. A NEGATIVE about a key the gate
+      ;; elides WHOLESALE: outside the arm this passes because
+      ;; `:rf.handler/source` is never present for ANY path in production, not
+      ;; because the fn-form skipped capture.
+      (when interop/debug-enabled?
+        (is (not (contains? m :rf.handler/source))
+            ":rf.handler/source absent on direct fn call")))))
 
 ;; ---- non-event reg-* macros DON'T carry :rf.handler/source ---------------
 
@@ -132,8 +193,11 @@
     (rf/reg-sub :rf2-xgfuy/sub-sample (fn [db _] db))
     (let [m (rf/handler-meta :sub :rf2-xgfuy/sub-sample)]
       (is (some? m))
-      (is (not (contains? m :rf.handler/source))
-          ":rf.handler/source absent on reg-sub"))))
+      ;; rf2-d2841 — dev-instrumentation arm. Same wholesale-elision shape as
+      ;; `fn-form-call-skips-form-source` above.
+      (when interop/debug-enabled?
+        (is (not (contains? m :rf.handler/source))
+            ":rf.handler/source absent on reg-sub")))))
 
 ;; ---- user-supplied :rf.handler/source override ---------------------------
 

--- a/implementation/core/test/re_frame/image_no_emit_trace_gate_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_no_emit_trace_gate_cljs_test.cljc
@@ -19,11 +19,32 @@
   enqueue; a baseline image handler WITHOUT the flag still does (so the
   suppression is the difference, not that image dispatches never emit).
 
-  `.cljc` ending `-cljs-test` rides `npm run test:cljs` AND `clojure -M:test`."
+  `.cljc` ending `-cljs-test` rides `npm run test:cljs` AND `clojure -M:test`.
+
+  ## Posture split (rf2-d2841)
+
+  The always-on half is that the image-inline handler is RESOLVED AND RUN —
+  `:bookkeeping/ran?` / `:normal/ran?` land in the frame's app-db. That is the
+  precondition the whole namespace rests on (the pre-fix bug was a
+  generation-blind lookup returning nil), it is readable straight off
+  `rf/app-db-value`, and it needs no trace surface — so it is asserted WITHOUT
+  a posture guard and runs in `scripts/test-core-prod-gate.sh` too.
+
+  The `:rf.event/dispatched` assertions are DEV-ONLY: `:rf.trace/no-emit?`
+  gates a `trace/emit!` site, and under `-Dre-frame.debug=false` nothing is
+  emitted at all. BOTH of them move inside the
+  `(when interop/debug-enabled? …)` arm marked `rf2-d2841`, the negative
+  included — and the negative is the point rather than tidiness. Left outside,
+  `(not (contains? ops :rf.event/dispatched))` over an EMPTY `ops` would report
+  that the no-emit flag correctly suppressed the enqueue trace when in fact
+  nothing was emitted for any handler, flagged or not. \"The flag is the
+  difference\" is a claim about a dev channel and is only meaningful where that
+  channel is live."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core           :as rf]
             [re-frame.image          :as image]
+            [re-frame.interop        :as interop]
             [re-frame.live-frame     :as lf]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support   :as test-support]))
@@ -75,10 +96,15 @@
         ;; execution) — proves the image handler was genuinely resolved + run.
         (is (true? (:bookkeeping/ran? (rf/app-db-value :img/main)))
             "the inline image handler executed")
-        ;; The bug: :rf.event/dispatched was emitted for a no-emit handler.
-        (is (not (contains? ops :rf.event/dispatched))
-            (str "the :rf.trace/no-emit? image handler must NOT emit "
-                 ":rf.event/dispatched at enqueue; saw ops: " (pr-str ops)))))))
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture
+        ;; split). A NEGATIVE over the trace stream: under the production gate
+        ;; `ops` is empty for EVERY handler, so this would pass without the
+        ;; no-emit flag doing anything at all.
+        (when interop/debug-enabled?
+          ;; The bug: :rf.event/dispatched was emitted for a no-emit handler.
+          (is (not (contains? ops :rf.event/dispatched))
+              (str "the :rf.trace/no-emit? image handler must NOT emit "
+                   ":rf.event/dispatched at enqueue; saw ops: " (pr-str ops))))))))
 
 (deftest image-inline-handler-without-flag-still-emits-dispatched
   (testing "baseline sanity: the SAME image-inline dispatch shape WITHOUT
@@ -96,5 +122,8 @@
       (let [ops (dispatched-ops-for :img/main [:normal/event] :normal/event)]
         (is (true? (:normal/ran? (rf/app-db-value :img/main)))
             "the inline image handler executed")
-        (is (contains? ops :rf.event/dispatched)
-            ":rf.event/dispatched fired for the un-flagged image handler")))))
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture
+        ;; split).
+        (when interop/debug-enabled?
+          (is (contains? ops :rf.event/dispatched)
+              ":rf.event/dispatched fired for the un-flagged image handler"))))))

--- a/implementation/core/test/re_frame/machine_action_outcome_classification_cljs_test.cljc
+++ b/implementation/core/test/re_frame/machine_action_outcome_classification_cljs_test.cljc
@@ -25,12 +25,32 @@
 
   Dual-runtime `*_cljs_test.cljc`: the shadow `:node-test` build
   (`npm run test:cljs`, `cljs-test$` ns-regexp) AND the JVM `clojure -M:test`
-  runner both run it."
+  runner both run it.
+
+  ## Posture split (rf2-d2841)
+
+  The DETERMINISTIC PROJECTOR TEETH — `classification/project-machine-tags`
+  called directly on hand-built trace shapes — are pure functions and run
+  under `scripts/test-core-prod-gate.sh` unchanged. So does the live
+  round-trip's EGRESS-ONLY claim: the action reads the raw value, the durable
+  snapshot holds it, and a second action reads it back. Those are the
+  assertions that prove redaction did not corrupt control flow, and they are
+  the ones worth having in the production lane.
+
+  The LIVE TRACE assertions are dev-only, because the trace stream they police
+  does not exist under `-Dre-frame.debug=false`. They are kept verbatim inside
+  a `(when interop/debug-enabled? …)` arm marked `rf2-d2841` — the no-leak
+  NEGATIVE emphatically included. `(not (some #(leaks? sentinel %) @seen))`
+  over an empty `@seen` is true because nothing was emitted, and a redaction
+  suite reporting green on that basis is the worst false green in this
+  programme. Its teeth are the `(is (seq rans) …)` positive beside it, which
+  is only satisfiable with the channel live."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [clojure.string :as str]
             [re-frame.classification :as classification]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             ;; Boot the optional machines artefact so `rf/reg-machine`
             ;; resolves through the spec-005 implementation.
             [re-frame.machines]
@@ -165,16 +185,25 @@
       (is (= data-sentinel @wrote)
           "the action computed with the RAW value (egress-only redaction)")
 
-      ;; 2. an :rf.machine/action-ran trace fired, and its :outcome redacts.
-      (let [rans (filter #(= :rf.machine/action-ran (:operation %)) @seen)]
-        (is (seq rans) "an :rf.machine/action-ran trace was emitted")
-        (doseq [ev rans]
-          (is (not (leaks? data-sentinel (get-in ev [:tags :outcome])))
-              ":outcome ships the classified :data slot redacted")))
+      ;; rf2-d2841 — dev-instrumentation arm. The trace stream IS the surface
+      ;; this projector protects, and it does not exist under
+      ;; `-Dre-frame.debug=false`. Both assertions go inside, the
+      ;; no-leak NEGATIVE especially: over an empty `@seen` "no emitted trace
+      ;; event leaks the sentinel" is true because nothing was emitted, which
+      ;; is exactly the false green a redaction test must never report. Its
+      ;; teeth are the `(is (seq rans) …)` positive beside it, and that
+      ;; positive is only satisfiable with the channel live.
+      (when interop/debug-enabled?
+        ;; 2. an :rf.machine/action-ran trace fired, and its :outcome redacts.
+        (let [rans (filter #(= :rf.machine/action-ran (:operation %)) @seen)]
+          (is (seq rans) "an :rf.machine/action-ran trace was emitted")
+          (doseq [ev rans]
+            (is (not (leaks? data-sentinel (get-in ev [:tags :outcome])))
+                ":outcome ships the classified :data slot redacted")))
 
-      ;; 3. NOTHING in the emitted stream leaks the sentinel.
-      (is (not (some #(leaks? data-sentinel %) @seen))
-          "no emitted trace event leaks the data sentinel")
+        ;; 3. NOTHING in the emitted stream leaks the sentinel.
+        (is (not (some #(leaks? data-sentinel %) @seen))
+            "no emitted trace event leaks the data sentinel"))
 
       ;; 4. the DURABLE snapshot really holds the raw value — prove it by
       ;;    reading it back through a second action.

--- a/implementation/core/test/re_frame/machine_routed_event_classification_cljs_test.cljc
+++ b/implementation/core/test/re_frame/machine_routed_event_classification_cljs_test.cljc
@@ -30,12 +30,30 @@
 
   Dual-runtime `*_cljs_test.cljc`: the shadow `:node-test` build
   (`npm run test:cljs`, `cljs-test$` ns-regexp) AND the JVM `clojure -M:test`
-  runner both run it."
+  runner both run it.
+
+  ## Posture split (rf2-d2841)
+
+  The DETERMINISTIC PROJECTOR TEETH are pure functions over hand-built trace
+  shapes and run under `scripts/test-core-prod-gate.sh` unchanged, as does the
+  live round-trip's EGRESS-ONLY claim — the machine action reads the RAW
+  password locally, untouched by projection.
+
+  The LIVE TRACE assertions are dev-only: the stream they police does not
+  exist under `-Dre-frame.debug=false`. They are kept verbatim inside a
+  `(when interop/debug-enabled? …)` arm marked `rf2-d2841`, and the two
+  assertions that look like opposites go in TOGETHER. `(not (some #(leaks?
+  pw-sentinel %) @seen))` over an empty `@seen` passes because nothing was
+  emitted — a redaction suite must never report green on that basis — and its
+  precision partner `(some #(leaks? email %) @seen)` is what proves the stream
+  is live and the redaction path-precise rather than whole-event. Separated,
+  the pair loses exactly the property that makes it meaningful."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [clojure.string :as str]
             [re-frame.classification :as classification]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             ;; Boot the optional machines artefact so `rf/reg-machine`
             ;; resolves through the spec-005 implementation (the late-bind
             ;; hooks install on load — see machine_handler_meta_test.clj).
@@ -209,22 +227,28 @@
       (is (= pw-sentinel @captured)
           "the machine action read the RAW routed password locally")
 
-      ;; 2. A machine transition trace actually fired (teeth — the echo
-      ;;    surface exists to protect).
-      (let [ops (into #{} (map :operation) @seen)]
-        (is (contains? ops :rf.machine/transition)
-            "a :rf.machine/transition trace was emitted for the routed event"))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+      ;; Points 2, 3 and 4 are ONE claim about a live channel and travel
+      ;; together: the transition fired, the secret is absent from it, and the
+      ;; non-secret survives. Split apart, point 3 passes over an empty
+      ;; `@seen` for the wrong reason.
+      (when interop/debug-enabled?
+        ;; 2. A machine transition trace actually fired (teeth — the echo
+        ;;    surface exists to protect).
+        (let [ops (into #{} (map :operation) @seen)]
+          (is (contains? ops :rf.machine/transition)
+              "a :rf.machine/transition trace was emitted for the routed event"))
 
-      ;; 3. EVERY emitted trace ships the password redacted (the transition
-      ;;    echo slots, the action-ran [:input :event], AND the outer
-      ;;    :rf.event/dispatched vector — all keyed off the same
-      ;;    registration classification).
-      (is (not (some #(leaks? pw-sentinel %) @seen))
-          "no emitted trace event leaks the routed password sentinel")
+        ;; 3. EVERY emitted trace ships the password redacted (the transition
+        ;;    echo slots, the action-ran [:input :event], AND the outer
+        ;;    :rf.event/dispatched vector — all keyed off the same
+        ;;    registration classification).
+        (is (not (some #(leaks? pw-sentinel %) @seen))
+            "no emitted trace event leaks the routed password sentinel")
 
-      ;; 4. Precision — the non-secret :email is still observable somewhere in
-      ;;    the trace stream (redaction is path-precise, not whole-event).
-      (is (some #(leaks? email %) @seen)
-          "the non-secret :email survives in the trace stream")
+        ;; 4. Precision — the non-secret :email is still observable somewhere in
+        ;;    the trace stream (redaction is path-precise, not whole-event).
+        (is (some #(leaks? email %) @seen)
+            "the non-secret :email survives in the trace stream"))
 
       (rf/unregister-listener! :trace ::ghgbqi))))

--- a/implementation/core/test/re_frame/non_serialisable_event_payload_warn_test.clj
+++ b/implementation/core/test/re_frame/non_serialisable_event_payload_warn_test.clj
@@ -8,10 +8,28 @@
 
   This is a SHOULD, not the `:rf.cofx` structural-EDN MUST: the warning is
   observational (`:recovery :no-recovery`), never a throw, and dev-only —
-  `interop/debug-enabled?`-gated (the elision probe verifies DCE separately)."
+  `interop/debug-enabled?`-gated (the elision probe verifies DCE separately).
+
+  ## Posture split (rf2-d2841)
+
+  `dispatch-proceeds-unchanged-despite-the-warning` is already posture-
+  independent — it reads app-db — and runs under
+  `scripts/test-core-prod-gate.sh` unchanged. It is the load-bearing half of
+  a SHOULD-level lint: a diagnostic that silently changed dispatch behaviour
+  would be the actual defect.
+
+  Everything ABOUT the warning is dev-only by design and is kept verbatim
+  inside a `(when interop/debug-enabled? …)` arm marked `rf2-d2841` —
+  `silent-on-plain-data-payload` included, even though it currently passes
+  under the gate. It passes for the wrong reason: `(is (empty? (payload-
+  warnings recorded)))` over a trace stream that is empty for EVERY payload
+  would certify a plain-data map as clean without the walker ever having run.
+  Each of those deftests keeps an unguarded app-db witness so the production
+  lane still executes the dispatch it is reasoning about."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.trace :as trace]))
@@ -40,26 +58,44 @@
 
 (deftest silent-on-plain-data-payload
   (testing "a plain-data event payload never fires the lint"
-    (rf/reg-event :payload-lint/noop (fn [{:keys [db]} _] {:db db}))
+    (rf/reg-event :payload-lint/noop
+      (fn [{:keys [db]} [_ payload]] {:db (assoc db :seen payload)}))
     (let [recorded (record-traces! ::lint)]
       (rf/dispatch-sync [:payload-lint/noop {:a 1 :b [1 2 3] :c #{:x :y}}])
-      (is (empty? (payload-warnings recorded))))))
+      ;; ALWAYS-ON WITNESS (rf2-d2841): the payload walk ran over a real
+      ;; dispatch that really committed — the precondition for reading
+      ;; anything off the diagnostic channel below.
+      (is (= {:a 1 :b [1 2 3] :c #{:x :y}} (:seen (rf/app-db-value :rf/default)))
+          "the plain-data payload reached the handler intact")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture
+      ;; split). A NEGATIVE over the trace stream: under the gate the stream
+      ;; is empty whatever the payload contained.
+      (when interop/debug-enabled?
+        (is (empty? (payload-warnings recorded)))))))
 
 (deftest fires-on-fn-valued-payload
   (testing "a fn nested in the event payload fires exactly one warning naming
    the offending path"
-    (rf/reg-event :payload-lint/noop (fn [{:keys [db]} _] {:db db}))
+    (rf/reg-event :payload-lint/noop
+      (fn [{:keys [db]} [_ payload]] {:db (assoc db :seen payload)}))
     (let [recorded (record-traces! ::lint)]
       (rf/dispatch-sync [:payload-lint/noop {:on-done (fn [] :nope)}])
-      (let [warns (payload-warnings recorded)]
-        (is (= 1 (count warns)))
-        (let [w (first warns)
-              t (:tags w)]
-          (is (= :payload-lint/noop (:event-id t)))
-          (is (some? (:path t)))
-          (is (string? (:reason t)))
-          (is (= :no-recovery (:recovery w))
-              ":recovery is hoisted to the top-level trace event, not nested under :tags"))))))
+      ;; ALWAYS-ON WITNESS (rf2-d2841): the fn-valued payload is carried
+      ;; THROUGH to the handler unaltered. The lint neither strips nor
+      ;; rejects — `:recovery :no-recovery` in production terms.
+      (is (fn? (:on-done (:seen (rf/app-db-value :rf/default))))
+          "the host handle reached the handler untouched — the lint is observational")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+      (when interop/debug-enabled?
+        (let [warns (payload-warnings recorded)]
+          (is (= 1 (count warns)))
+          (let [w (first warns)
+                t (:tags w)]
+            (is (= :payload-lint/noop (:event-id t)))
+            (is (some? (:path t)))
+            (is (string? (:reason t)))
+            (is (= :no-recovery (:recovery w))
+                ":recovery is hoisted to the top-level trace event, not nested under :tags")))))))
 
 (deftest dispatch-proceeds-unchanged-despite-the-warning
   (testing "the warning is observational only — the dispatch still commits"

--- a/implementation/core/test/re_frame/reg_event_cljs_test.cljc
+++ b/implementation/core/test/re_frame/reg_event_cljs_test.cljc
@@ -18,12 +18,27 @@
   `.cljc` so the suite runs under BOTH the bounded core JVM gate and
   `npm run test:cljs`. Harness mirrors `cofx_cljs_test.cljc` — the shared
   `test-support/make-reset-runtime-fixture` wraps every body in
-  `(with-frame :rf/default …)` so the ambient `dispatch-sync` calls resolve."
+  `(with-frame :rf/default …)` so the ambient `dispatch-sync` calls resolve.
+
+  ## Posture split (rf2-d2841)
+
+  Everything this file is about — the registry shape, the interceptor chain,
+  the `:db` / `:fx` effect semantics, `:rf.cofx/requires` — is production-real
+  and asserted WITHOUT a posture guard, so it runs in `clojure -M:test` AND in
+  `scripts/test-core-prod-gate.sh` (the `-Dre-frame.debug=false` lane).
+
+  The single exception is `:doc` on the stored registry entry: `:doc` is the
+  one PURE-documentation registration-metadata key, stripped at the
+  `registrar/register!` chokepoint in production (Spec 001 §Production
+  elision contract; `re-frame.doc-metadata-prod-elision-test` owns that
+  contract). Its assertion is kept verbatim inside a
+  `(when interop/debug-enabled? …)` arm marked `rf2-d2841`."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
             [re-frame.events :as events]
             [re-frame.image-assembly :as image-assembly]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
@@ -59,8 +74,12 @@
       {:doc "doc" :interceptors [:reg-event-test/noop]}
       (fn [{:keys [db]} _] {:db db}))
     (let [meta (rf/handler-meta :event :reg-event-test/with-icpt)]
-      (is (= "doc" (:doc meta))
-          "the reflection metadata is retained on the registry entry")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+      ;; `:doc` is pure-documentation metadata, stripped at the `register!`
+      ;; chokepoint under `-Dre-frame.debug=false`.
+      (when interop/debug-enabled?
+        (is (= "doc" (:doc meta))
+            "the reflection metadata is retained on the registry entry"))
       ;; The stored chain holds the AUTHORED ref (a keyword) for the user entry;
       ;; only the framework wrapper is a map carrying :id :rf/event-handler.
       (is (= [:reg-event-test/noop :rf/event-handler]

--- a/implementation/core/test/re_frame/router_carried_frame_test.clj
+++ b/implementation/core/test/re_frame/router_carried_frame_test.clj
@@ -29,10 +29,31 @@
   exercised in `re-frame.router-carried-frame-cljs-test`.
 
   JVM-only — the dynamic-var scope tier and the require-or-raise logic
-  are platform-agnostic."
+  are platform-agnostic.
+
+  ## Posture split (rf2-d2841)
+
+  Both error categories this file asserts on are ALWAYS-ON, so the split here
+  is NOT a guard — it is a change of AXIS. `:rf.error/no-frame-context` fans
+  through `frame/emit-no-frame-context!`, which calls the late-bound
+  `:error-emit/dispatch-on-error` hook BEFORE it reaches the dev-only
+  `trace/emit-error!` leg; `:rf.error/frame-destroyed` is in the promoted
+  always-on set (`re-frame.error-emit` ns docstring §Corpus-wide listener
+  registry). Reading those counts off the `:errors` stream instead of the
+  `:trace` stream keeps the assertions VERBATIM and load-bearing in BOTH
+  postures — `clojure -M:test` and `scripts/test-core-prod-gate.sh` alike.
+
+  The one genuinely dev-only claim is `NO :rf.event/dispatched` — a negative
+  over the trace stream, which under `-Dre-frame.debug=false` is empty for
+  every dispatch, enqueued or not. It is kept verbatim inside a
+  `(when interop/debug-enabled? …)` arm marked `rf2-d2841`. Its production
+  counterpart is the always-on one immediately above it: an
+  `:rf.error/no-frame-context` record on the `:errors` axis IS the
+  before-enqueue rejection, since the emit site sits at envelope-build time."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.trace :as trace]))
@@ -64,6 +85,21 @@
     (rf/register-listener! :trace listener-id (fn [ev] (swap! a conj ev)))
     a))
 
+(defn- record-errors!
+  "Attach an ALWAYS-ON `:errors` listener and return its atom (rf2-d2841).
+  The corpus-wide error-emit registry survives production elision — it is
+  the axis Sentry-style shippers read — so counts taken off it are
+  posture-independent. Records are the tight error-record map, keyed by
+  `:error` rather than the trace stream's `:operation`."
+  [listener-id]
+  (let [a (atom [])]
+    (rf/register-listener! :errors listener-id (fn [rec] (swap! a conj rec)))
+    a))
+
+(defn- errors-of
+  [recorded error-id]
+  (filter #(= error-id (:error %)) @recorded))
+
 ;; ---- bare dispatch outside any context FAILS ------------------------------
 
 (deftest bare-dispatch-outside-context-raises-no-frame-context
@@ -71,7 +107,8 @@
             raises :rf.error/no-frame-context (no :rf/default floor) — and
             emits the always-on error, with NO enqueue"
     (rf/reg-event :app/noop (fn [{:keys [db]} _] {:db db}))
-    (let [recorded (record-traces! ::bare)]
+    (let [recorded (record-traces! ::bare)
+          errs     (record-errors! ::bare-errors)]
       (binding [frame/*current-frame* nil]
         (let [ex (no-frame-context-ex #(rf/dispatch [:app/noop]))]
           (is (some? ex) "frameless dispatch raised")
@@ -80,11 +117,19 @@
           (is (= :dispatch (:operation (ex-data ex)))
               ":operation tags the dispatch surface")))
       (rf/unregister-listener! :trace ::bare)
-      (is (= 1 (count (filter #(= :rf.error/no-frame-context (:operation %))
-                              @recorded)))
+      (rf/unregister-listener! :errors ::bare-errors)
+      ;; ALWAYS-ON axis (rf2-d2841): the count reads the corpus-wide error-emit
+      ;; registry, which survives production elision, so "exactly one fired"
+      ;; is a claim about the production wire and not about the dev ring.
+      (is (= 1 (count (errors-of errs :rf.error/no-frame-context)))
           "exactly one always-on :rf.error/no-frame-context error fired")
-      (is (empty? (filter #(= :rf.event/dispatched (:operation %)) @recorded))
-          "NO :rf.event/dispatched — the absence is caught before enqueue"))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+      ;; A NEGATIVE over the trace stream: under `-Dre-frame.debug=false` the
+      ;; stream is empty whether or not the event was enqueued, so outside the
+      ;; arm this would report "caught before enqueue" for free.
+      (when interop/debug-enabled?
+        (is (empty? (filter #(= :rf.event/dispatched (:operation %)) @recorded))
+            "NO :rf.event/dispatched — the absence is caught before enqueue")))))
 
 (deftest bare-dispatch-sync-outside-context-raises-no-frame-context
   (testing "dispatch-sync under no scope raises the same way as dispatch"
@@ -208,18 +253,22 @@
             resolution; the lookup is what failed."
     ;; :rf/default is intentionally NOT registered.
     (rf/reg-event :app/noop (fn [{:keys [db]} _] {:db db}))
-    (let [recorded (record-traces! ::bad-explicit)]
+    (let [errs (record-errors! ::bad-explicit-errors)]
       (binding [frame/*current-frame* nil]
         ;; An explicit target that does not resolve to a frame-record is
         ;; recover-but-emit (rf2-2hvga): no throw, but a
         ;; :rf.error/frame-destroyed always-on error.
         (rf/dispatch-sync [:app/noop] {:frame :rf/default}))
-      (rf/unregister-listener! :trace ::bad-explicit)
-      (is (= 1 (count (filter #(= :rf.error/frame-destroyed (:operation %))
-                              @recorded)))
+      (rf/unregister-listener! :errors ::bad-explicit-errors)
+      ;; ALWAYS-ON axis (rf2-d2841): `:rf.error/frame-destroyed` is in the
+      ;; promoted set that fans to the corpus-wide error-emit registry, so
+      ;; BOTH assertions — the positive AND the "not the other category"
+      ;; negative — stay load-bearing under the production gate. The negative
+      ;; is meaningful here precisely because its sibling positive proves the
+      ;; stream is live in this posture.
+      (is (= 1 (count (errors-of errs :rf.error/frame-destroyed)))
           "a bad explicit target emits :rf.error/frame-destroyed")
-      (is (empty? (filter #(= :rf.error/no-frame-context (:operation %))
-                          @recorded))
+      (is (empty? (errors-of errs :rf.error/no-frame-context))
           "NOT :rf.error/no-frame-context — the stamp was carried, just bad"))))
 
 ;; ---- override beats scope -------------------------------------------------

--- a/implementation/core/test/re_frame/router_front_of_queue_cljs_test.cljc
+++ b/implementation/core/test/re_frame/router_front_of_queue_cljs_test.cljc
@@ -39,9 +39,26 @@
   nowhere but the JVM and reads as covered (rf2-dn6v7, rf2-lgozq)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.router :as router]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; ## Posture split (rf2-d2841)
+;;
+;; The LEAP-FROG ITSELF is production behaviour and is asserted without a
+;; posture guard: `@run-log` records the order handlers actually ran in,
+;; straight off the handlers, with no channel involved. That is what this file
+;; is about and it runs under `scripts/test-core-prod-gate.sh` unchanged.
+;;
+;; The `:rf.event/run-start` epoch assertions are a claim about the trace
+;; stream — "one per dequeued event, none collapsed by the front-insertion" —
+;; and are kept verbatim inside a `(when interop/debug-enabled? …)` arm marked
+;; `rf2-d2841`. Their always-on partner is the `@run-log` assertion directly
+;; above them in the same body, which pins the same order from the handler
+;; side.
+;; ---------------------------------------------------------------------------
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
@@ -152,10 +169,13 @@
         (finally (rf/unregister-listener! :trace ::epoch-rec)))
       ;; Run order reflects the leap-frog.
       (is (= [:seed :c1 :c2 :ext] @run-log))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns header §Posture split).
       ;; One :run-start per dequeued event — four distinct events, none
-      ;; collapsed by the front-insertion.
-      (let [starts (run-starts-of @seen)]
-        (is (= 4 (count starts))
-            "one :run-start per dequeued event — no collapse")
-        (is (= [:seed :c1 :c2 :ext] starts)
-            ":run-start order matches the dequeue (leap-frogged) order")))))
+      ;; collapsed by the front-insertion. The always-on partner is the
+      ;; `@run-log` assertion directly above.
+      (when interop/debug-enabled?
+        (let [starts (run-starts-of @seen)]
+          (is (= 4 (count starts))
+              "one :run-start per dequeued event — no collapse")
+          (is (= [:seed :c1 :c2 :ext] starts)
+              ":run-start order matches the dequeue (leap-frogged) order"))))))

--- a/implementation/core/test/re_frame/source_coord_prod_elision_test.clj
+++ b/implementation/core/test/re_frame/source_coord_prod_elision_test.clj
@@ -22,7 +22,28 @@
   probes (`scripts/check-elision.cjs`, `scripts/check-perf-bundle.cjs`).
   This file pins the SEMANTIC contract on the JVM where we can
   `with-redefs` the gate; the bundle probes pin the CODE-PATH absence
-  in CLJS-prod by negative grep."
+  in CLJS-prod by negative grep.
+
+  ## Posture split (rf2-d2841)
+
+  Policy A's PROD half and the whole of Policy B are posture-independent and
+  run under `scripts/test-core-prod-gate.sh` unchanged. Under the real gate
+  Policy A's `with-redefs` becomes a no-op over an already-false flag, which
+  means the prod-lane run re-asserts the same claim against the LOAD-TIME
+  gate rather than a rebind — the stronger evidence of the two, since
+  `merge-coords` reads `interop/debug-enabled?` at the point the macro-emitted
+  `*pending-coords*` binding is consumed.
+
+  Policy A's DEV half — the public `handler-meta` still carrying `:ns` /
+  `:line` / `:file` for Xray / jump-to-source — is a claim about the gate
+  being ON, and is kept verbatim inside a `(when interop/debug-enabled? …)`
+  arm marked `rf2-d2841`. Its always-on partner sits in the same body: the
+  PARALLEL `error-coords-by-id` registry is populated for that same
+  registration in BOTH postures. That pairing is the actual contract of this
+  file — one registration, coords stripped from the public surface and
+  retained on the observability surface — and stating both halves in one
+  deftest is what stops the dev half from being a namespace-shaped hole under
+  the gate."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.interop :as interop]
@@ -70,10 +91,24 @@
     (rf/reg-event :rf2-3un2g/dev-keep-event
                      {:doc "kept"}
                      (fn [{:keys [db]} _] {:db db}))
-    (let [meta (rf/handler-meta :event :rf2-3un2g/dev-keep-event)]
-      (is (some? (:ns   meta)) ":ns present in registry-meta in dev")
-      (is (some? (:line meta)) ":line present in registry-meta in dev")
-      (is (some? (:file meta)) ":file present in registry-meta in dev"))))
+    (let [meta (rf/handler-meta :event :rf2-3un2g/dev-keep-event)
+          parallel (source-coords/error-coords-for :event :rf2-3un2g/dev-keep-event)]
+      ;; ALWAYS-ON PARTNER (rf2-d2841). Policy A strips the PUBLIC surface in
+      ;; production; the parallel observability registry keeps the coords in
+      ;; BOTH postures. Asserting the retained half beside the stripped half
+      ;; is what makes "stripped" mean stripped-from-here rather than
+      ;; never-captured — and it is exactly the pair a regression in
+      ;; `with-coords-form`'s prod arm would break.
+      (is (some? parallel)
+          "the parallel error-coord registry carries the coords in BOTH postures")
+      (is (some? (:ns   parallel)) ":ns survives on the always-on registry")
+      (is (some? (:line parallel)) ":line survives on the always-on registry")
+      (is (some? (:file parallel)) ":file survives on the always-on registry")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+      (when interop/debug-enabled?
+        (is (some? (:ns   meta)) ":ns present in registry-meta in dev")
+        (is (some? (:line meta)) ":line present in registry-meta in dev")
+        (is (some? (:file meta)) ":file present in registry-meta in dev")))))
 
 ;; ---- Policy B: error-emit substrate retains source-coord in prod --------
 

--- a/implementation/core/test/re_frame/sub_algebra_view_test.clj
+++ b/implementation/core/test/re_frame/sub_algebra_view_test.clj
@@ -21,9 +21,30 @@
   lives in the bundle-isolated `re-frame.subs.tooling` sibling, reached on
   JVM through the `re-frame.subs/sub-algebra-view` convenience alias, and
   consumed by Xray + the conformance fixtures. There is no
-  `re-frame.core/sub-algebra-view` public facade export."
+  `re-frame.core/sub-algebra-view` public facade export.
+
+  ## Posture split (rf2-d2841)
+
+  The ALGEBRA is posture-independent and asserted without a guard: the fixed
+  classifications, the per-kind declared-input lowering, the output fact id,
+  the `:derive` token, `:schema`, and the registry semantics all run under
+  `scripts/test-core-prod-gate.sh` as well as `clojure -M:test`. This is the
+  same shape `sub-topology-test` took in the second rf2-d2841 pass — the
+  topology around the metadata is production-real; only the REFLECTION
+  METADATA on it is not.
+
+  Two slots are reflection metadata and elided in production: the auto-
+  captured `:source` coords (`:ns` / `:line` / `:file`, suppressed by
+  `source-coords/merge-coords` under the gate) and `:doc` (stripped at the
+  `registrar/register!` chokepoint). Their assertions are kept verbatim
+  inside `(when interop/debug-enabled? …)` arms marked `rf2-d2841` —
+  including the negative in `no-schema-or-doc-when-absent`, which under the
+  gate would pass because `:doc` is elided WHOLESALE rather than because this
+  registration omitted it. `:schema` is load-bearing and stays outside the
+  arm in both deftests, which is what keeps that pair honest."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.subs :as subs]
             [re-frame.subs.tooling :as subs-tooling]
             [re-frame.frame :as frame]
@@ -196,10 +217,17 @@
     (rf/reg-sub :n (fn [db _] (:n db)))
     (let [node ((subs-tooling/sub-algebra-view) :n)
           source (:source node)]
-      (is (some? source) ":source map is present when the registration carried coords")
-      (is (some? (:ns source))     ":ns captured at the call site")
-      (is (number? (:line source)) ":line captured at the call site")
-      (is (some? (:file source))   ":file captured at the call site"))))
+      ;; Always-on witness (rf2-d2841): the sub is lowered into the algebra
+      ;; regardless of posture — the precondition for reading any coord off it.
+      (is (some? node)
+          "the registration is projected into the algebra view in BOTH postures")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+      ;; Source coords are reflection metadata, elided in production.
+      (when interop/debug-enabled?
+        (is (some? source) ":source map is present when the registration carried coords")
+        (is (some? (:ns source))     ":ns captured at the call site")
+        (is (number? (:line source)) ":line captured at the call site")
+        (is (some? (:file source))   ":file captured at the call site")))))
 
 (deftest schema-and-doc-pass-through
   (testing ":schema and :doc supplied on the registration meta surface in the node"
@@ -208,16 +236,26 @@
                  :schema :app.money/amount}
                 (fn [db _] (:price db)))
     (let [node ((subs-tooling/sub-algebra-view) :priced)]
+      ;; `:schema` is LOAD-BEARING (precomputed marks / introspection) and is
+      ;; retained in production — no guard.
       (is (= :app.money/amount (:schema node))
           "the declared output :schema surfaces as a node fact")
-      (is (= "a priced item" (:doc node))))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+      (when interop/debug-enabled?
+        (is (= "a priced item" (:doc node)))))))
 
 (deftest no-schema-or-doc-when-absent
   (testing ":schema / :doc are absent when the registration didn't supply them"
     (rf/reg-sub :n (fn [db _] (:n db)))
     (let [node ((subs-tooling/sub-algebra-view) :n)]
+      ;; `:schema` is retained in production, so its absence here really is
+      ;; "the registration did not supply one" — posture-independent.
       (is (not (contains? node :schema)))
-      (is (not (contains? node :doc))))))
+      ;; rf2-d2841 — dev-instrumentation arm. A NEGATIVE about a key the gate
+      ;; elides WHOLESALE: outside the arm it passes because `:doc` never
+      ;; exists in production, not because this registration omitted it.
+      (when interop/debug-enabled?
+        (is (not (contains? node :doc)))))))
 
 ;; ---- registry semantics --------------------------------------------------
 

--- a/implementation/core/test/re_frame/sub_arg_fragmentation_warn_test.clj
+++ b/implementation/core/test/re_frame/sub_arg_fragmentation_warn_test.clj
@@ -17,10 +17,38 @@
   genuinely-varying `not=` arg, and a primitive arg. The warning rides the
   diagnostic channel as `:rf.warning/sub-arg-cache-fragmentation` (Spec 009
   §Error event catalogue) via `trace/emit-error!`, dev-only
-  (`interop/debug-enabled?`-gated, DCE'd in production)."
+  (`interop/debug-enabled?`-gated, DCE'd in production).
+
+  ## Posture split (rf2-d2841)
+
+  The guardrail is a pure diagnostic, so every assertion about the warning —
+  the two FIRES deftests and all five STAYS SILENT ones — is kept verbatim
+  inside a `(when interop/debug-enabled? …)` arm marked `rf2-d2841`. The
+  silent ones move with the loud ones deliberately: `(is (empty?
+  (fragmentation-events @acc)))` over the gate's empty stream certifies an
+  `identical?`-stable arg, a genuinely-varying arg and a primitive arg as
+  benign without the heuristic having looked at any of them. False-positive
+  aversion is the whole point of those five, and there is nothing to be
+  averse to when nothing fires.
+
+  What survives the gate is `:recovery :ignored` — THE SUBSCRIBE SUCCEEDS.
+  Each deftest asserts that unguarded, so the production lane pins that a
+  render-phase guardrail never refuses a subscription however the arg was
+  built. (The sub-cache itself has no production reader to count against:
+  `subs.tooling/sub-cache-snapshot` is CLJS-only and dev-gated on top.)
+
+  `warns-under-jvm-debug-enabled` was a statement about the RUNTIME rather
+  than the framework — \"`interop/debug-enabled?` is true on the JVM test
+  runtime\" — which the production lane falsifies by construction. It is now
+  two-armed and says more than it used to: the dev arm keeps the wired-path
+  pin, and the PROD arm asserts the emit is genuinely gone under
+  `-Dre-frame.debug=false`. That second arm is new coverage — the JVM
+  analogue of the CLJS elision probe, which until now had no JVM counterpart
+  for this category."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
@@ -78,9 +106,14 @@
     (let [acc (collect-traces! ::fresh-map)]
       (try
         ;; Three renders, each building a value-EQUAL but distinct map.
-        (dotimes [_ 3]
-          (rf/subscribe [:sub/param (fresh-opts)]))
-        (let [warns (fragmentation-events @acc)]
+        (let [subs (vec (repeatedly 3 #(rf/subscribe [:sub/param (fresh-opts)])))]
+          ;; ALWAYS-ON (rf2-d2841): `:recovery :ignored` — every subscribe
+          ;; succeeds. The guardrail is advisory and never refuses.
+          (is (every? some? subs)
+              "all three fresh-but-equal subscribes succeeded — the guardrail is advisory"))
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+        (when interop/debug-enabled?
+         (let [warns (fragmentation-events @acc)]
           (is (= 1 (count warns))
               "exactly one warning despite three fresh-but-equal subscribes")
           (let [[ev] warns
@@ -100,7 +133,7 @@
                 ":hint carries the human fix sentence")
             ;; `:recovery` is hoisted to the TOP LEVEL by `build-event`.
             (is (= :ignored (:recovery ev))
-                ":recovery :ignored — the subscribe succeeds; warning is diagnostic")))
+                ":recovery :ignored — the subscribe succeeds; warning is diagnostic"))))
         (finally
           (rf/unregister-listener! :trace ::fresh-map))))))
 
@@ -114,10 +147,14 @@
       (try
         ;; `(vec (list …))` builds a fresh-but-equal vector each call
         ;; (defeats literal-vector constant-folding).
-        (rf/subscribe [:sub/v (vec (list :a :b :c))])
-        (rf/subscribe [:sub/v (vec (list :a :b :c))])
-        (is (= 1 (count (fragmentation-events @acc)))
-            "value-equal fresh vectors fragment the cache — one warning")
+        ;; ALWAYS-ON (rf2-d2841): both subscribes succeed.
+        (is (every? some? [(rf/subscribe [:sub/v (vec (list :a :b :c))])
+                           (rf/subscribe [:sub/v (vec (list :a :b :c))])])
+            "both fresh-but-equal vector subscribes succeeded")
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+        (when interop/debug-enabled?
+          (is (= 1 (count (fragmentation-events @acc)))
+              "value-equal fresh vectors fragment the cache — one warning"))
         (finally
           (rf/unregister-listener! :trace ::fresh-vec))))))
 
@@ -130,14 +167,18 @@
     (rf/dispatch-sync [:init])
     (let [acc (collect-traces! ::two-ids)]
       (try
-        (rf/subscribe [:sub/one (into {} (hash-map :k 1))])
-        (rf/subscribe [:sub/one (into {} (hash-map :k 1))])
-        (rf/subscribe [:sub/two (into {} (hash-map :k 1))])
-        (rf/subscribe [:sub/two (into {} (hash-map :k 1))])
-        (let [warns (fragmentation-events @acc)
-              ids   (set (map #(-> % :tags :rf.sub/id) warns))]
-          (is (= 2 (count warns)) "one warning per fragmenting sub-id")
-          (is (= #{:sub/one :sub/two} ids)))
+        ;; ALWAYS-ON (rf2-d2841): all four subscribes succeed.
+        (is (every? some? [(rf/subscribe [:sub/one (into {} (hash-map :k 1))])
+                           (rf/subscribe [:sub/one (into {} (hash-map :k 1))])
+                           (rf/subscribe [:sub/two (into {} (hash-map :k 1))])
+                           (rf/subscribe [:sub/two (into {} (hash-map :k 1))])])
+            "both fragmenting sub-ids still subscribe successfully")
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+        (when interop/debug-enabled?
+          (let [warns (fragmentation-events @acc)
+                ids   (set (map #(-> % :tags :rf.sub/id) warns))]
+            (is (= 2 (count warns)) "one warning per fragmenting sub-id")
+            (is (= #{:sub/one :sub/two} ids))))
         (finally
           (rf/unregister-listener! :trace ::two-ids))))))
 
@@ -153,9 +194,15 @@
     (rf/dispatch-sync [:init])
     (let [acc (collect-traces! ::first-only)]
       (try
-        (rf/subscribe [:sub/param {:opts true}])
-        (is (empty? (fragmentation-events @acc))
-            "a single subscribe is never the fragmentation footgun")
+        ;; ALWAYS-ON (rf2-d2841).
+        (is (some? (rf/subscribe [:sub/param {:opts true}]))
+            "the first subscribe succeeds")
+        ;; rf2-d2841 — dev-instrumentation arm. A NEGATIVE over the trace
+        ;; stream: under the gate nothing fires for ANY arg shape, so the
+        ;; false-positive aversion this deftest exists for is untestable here.
+        (when interop/debug-enabled?
+          (is (empty? (fragmentation-events @acc))
+              "a single subscribe is never the fragmentation footgun"))
         (finally
           (rf/unregister-listener! :trace ::first-only))))))
 
@@ -168,10 +215,14 @@
     (let [acc        (collect-traces! ::stable)
           stable-arg {:filter :all :page 1}]   ;; built ONCE, reused
       (try
-        (dotimes [_ 3]
-          (rf/subscribe [:sub/param stable-arg]))
-        (is (empty? (fragmentation-events @acc))
-            "an identical?-stable arg is the GOOD case — no warning")
+        ;; ALWAYS-ON (rf2-d2841).
+        (is (every? some? (repeatedly 3 #(rf/subscribe [:sub/param stable-arg])))
+            "the identical?-stable arg subscribes successfully every time")
+        ;; rf2-d2841 — dev-instrumentation arm. Same empty-stream false-green
+        ;; shape as `first-subscribe-does-not-warn`.
+        (when interop/debug-enabled?
+          (is (empty? (fragmentation-events @acc))
+              "an identical?-stable arg is the GOOD case — no warning"))
         (finally
           (rf/unregister-listener! :trace ::stable))))))
 
@@ -185,11 +236,16 @@
     (let [acc (collect-traces! ::varying)]
       (try
         ;; Non-primitive but genuinely-different args every time.
-        (rf/subscribe [:sub/item {:id 1}])
-        (rf/subscribe [:sub/item {:id 2}])
-        (rf/subscribe [:sub/item {:id 3}])
-        (is (empty? (fragmentation-events @acc))
-            "genuinely-varying args are correct fragmentation, not a footgun")
+        ;; ALWAYS-ON (rf2-d2841).
+        (is (every? some? [(rf/subscribe [:sub/item {:id 1}])
+                           (rf/subscribe [:sub/item {:id 2}])
+                           (rf/subscribe [:sub/item {:id 3}])])
+            "genuinely-varying args subscribe successfully")
+        ;; rf2-d2841 — dev-instrumentation arm. Same empty-stream false-green
+        ;; shape as the other STAYS SILENT deftests.
+        (when interop/debug-enabled?
+          (is (empty? (fragmentation-events @acc))
+              "genuinely-varying args are correct fragmentation, not a footgun"))
         (finally
           (rf/unregister-listener! :trace ::varying))))))
 
@@ -203,14 +259,19 @@
     (let [acc (collect-traces! ::primitive)]
       (try
         ;; Keyword, string, and number args — all primitives — repeated.
-        (rf/subscribe [:sub/kw :all])
-        (rf/subscribe [:sub/kw :all])
-        (rf/subscribe [:sub/kw (str "page-" 1)])
-        (rf/subscribe [:sub/kw (str "page-" 1)])
-        (rf/subscribe [:sub/kw (+ 1 1)])
-        (rf/subscribe [:sub/kw (+ 1 1)])
-        (is (empty? (fragmentation-events @acc))
-            "primitive args are not the fragmentation hazard")
+        ;; ALWAYS-ON (rf2-d2841).
+        (is (every? some? [(rf/subscribe [:sub/kw :all])
+                           (rf/subscribe [:sub/kw :all])
+                           (rf/subscribe [:sub/kw (str "page-" 1)])
+                           (rf/subscribe [:sub/kw (str "page-" 1)])
+                           (rf/subscribe [:sub/kw (+ 1 1)])
+                           (rf/subscribe [:sub/kw (+ 1 1)])])
+            "keyword / string / number args all subscribe successfully")
+        ;; rf2-d2841 — dev-instrumentation arm. Same empty-stream false-green
+        ;; shape as the other STAYS SILENT deftests.
+        (when interop/debug-enabled?
+          (is (empty? (fragmentation-events @acc))
+              "primitive args are not the fragmentation hazard"))
         (finally
           (rf/unregister-listener! :trace ::primitive))))))
 
@@ -222,21 +283,31 @@
     (rf/dispatch-sync [:init])
     (let [acc (collect-traces! ::zero-arg)]
       (try
-        (dotimes [_ 3] (rf/subscribe [:sub/a]))
-        (is (empty? (fragmentation-events @acc))
-            "an arg-less subscription has no cache-key-fragmentation surface")
+        ;; ALWAYS-ON (rf2-d2841).
+        (is (every? some? (repeatedly 3 #(rf/subscribe [:sub/a])))
+            "the arg-less subscription succeeds every time")
+        ;; rf2-d2841 — dev-instrumentation arm. Same empty-stream false-green
+        ;; shape as the other STAYS SILENT deftests.
+        (when interop/debug-enabled?
+          (is (empty? (fragmentation-events @acc))
+              "an arg-less subscription has no cache-key-fragmentation surface"))
         (finally
           (rf/unregister-listener! :trace ::zero-arg))))))
 
 ;; ---------------------------------------------------------------------------
-;; JVM dev-path pin (the prod-elision shape is pinned by the CLJS elision
-;; probe `npm run test:elision`; on the JVM `debug-enabled?` is true)
+;; JVM posture pin — BOTH arms (rf2-d2841)
+;;
+;; This deftest used to assert only that `interop/debug-enabled?` is true on
+;; the JVM test runtime, which the `-Dre-frame.debug=false` lane falsifies by
+;; construction. It now pins the gate in BOTH directions off the SAME two
+;; subscribes: the emit lands when the gate is on, and is genuinely ABSENT
+;; when it is off. The second arm is the JVM counterpart of the CLJS elision
+;; probe (`npm run test:elision`) for this category, which had none.
 ;; ---------------------------------------------------------------------------
 
 (deftest warns-under-jvm-debug-enabled
-  (testing "interop/debug-enabled? is true on the JVM test runtime — the
-            guardrail's emit lands in the trace stream (the dev path is
-            wired). Production CLJS elision is pinned by the elision probe."
+  (testing "the fragmentation emit follows interop/debug-enabled? on the JVM:
+            present under the dev default, absent under -Dre-frame.debug=false"
     (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 1}}))
     (rf/reg-sub :sub/param (fn [db [_ _o]] (:a db)))
     (rf/dispatch-sync [:init])
@@ -244,7 +315,11 @@
       (try
         (rf/subscribe [:sub/param (into {} (hash-map :x 1))])
         (rf/subscribe [:sub/param (into {} (hash-map :x 1))])
-        (is (seq (fragmentation-events @acc))
-            "a warning landed — JVM dev path is wired")
+        (if interop/debug-enabled?
+          (is (seq (fragmentation-events @acc))
+              "a warning landed — JVM dev path is wired")
+          (is (empty? (fragmentation-events @acc))
+              "the guardrail's emit is GONE under -Dre-frame.debug=false — the
+               JVM half of the production-elision contract"))
         (finally
           (rf/unregister-listener! :trace ::jvm-pin))))))

--- a/implementation/core/test/re_frame/substrate/derived_container_replaced_cljs_test.cljc
+++ b/implementation/core/test/re_frame/substrate/derived_container_replaced_cljs_test.cljc
@@ -21,9 +21,28 @@
   `:cljs` `(satisfies? ISwap …)` branch) AND the JVM cognitect runner
   (the `:clj` `(instance? clojure.lang.IAtom …)` branch).
 
-  Per bead rf2-8wrzz.3."
+  Per bead rf2-8wrzz.3.
+
+  ## Posture split (rf2-d2841)
+
+  The choke point does two things on a derived container, and only one of them
+  is instrumentation. The THROW — the canonical ex-info with its
+  `:rf.error/id` / `:where` / `:recovery` / `:reason` slots and the
+  greppability token in the message — is production behaviour and is asserted
+  without a posture guard, as is the fact that the rejected write leaves the
+  derived value untouched and the underlying adapter's `replace-container!` is
+  never invoked. Those run under `scripts/test-core-prod-gate.sh` unchanged.
+
+  The `:rf.error/derived-container-replaced` TRACE is a bare `trace/emit!`
+  site with no always-on twin, so it is elided under
+  `-Dre-frame.debug=false`. Its assertions are kept verbatim inside a
+  `(when interop/debug-enabled? …)` arm marked `rf2-d2841`, with the throw
+  itself kept outside as the always-on witness — the trace and the throw come
+  off the SAME detection, so proving the detection fired is what the
+  production lane can still say."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.interop :as interop]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
@@ -103,26 +122,39 @@
   (testing "replace-container! on a derived container emits the :rf.error/derived-container-replaced trace"
     (let [src     (adapter/make-state-container {:n 1})
           derived (adapter/make-derived-value [src] (fn [v] (:n v)))
+          thrown  (atom nil)
           errs    (capture-errors
                     (fn []
                       ;; The choke point emits the trace BEFORE it throws;
                       ;; swallow the throw so we can inspect the captured
                       ;; trace event.
                       (try (adapter/replace-container! derived 99)
-                           (catch #?(:clj Throwable :cljs :default) _ nil))))
+                           (catch #?(:clj Throwable :cljs :default) e
+                             (reset! thrown e)))))
           ev      (first (filter #(= :rf.error/derived-container-replaced (:operation %)) errs))]
-      (is (some? ev)
-          "a :rf.error/derived-container-replaced error trace was emitted")
-      (is (= :error (:op-type ev))
-          "the trace's op-type is :error")
-      (is (= :rf.error/derived-container-replaced (:operation ev))
-          "the trace's :operation is the error category keyword")
-      (is (= :rf.error/derived-container-replaced (get-in ev [:tags :category]))
-          "the :category tag mirrors :operation for consumer convenience")
-      (is (= :no-recovery (:recovery ev))
-          "the :recovery field is hoisted to top level as :no-recovery")
-      (is (string? (get-in ev [:tags :reason]))
-          "the :reason tag is a human-readable sentence"))))
+      ;; ALWAYS-ON WITNESS (rf2-d2841): the trace and the throw come off ONE
+      ;; detection in the choke point. The throw survives the production gate,
+      ;; so it is what proves the detection fired at all — without it this
+      ;; deftest would execute nothing under `-Dre-frame.debug=false`.
+      (is (some? @thrown)
+          "the choke point detected the derived container and threw")
+      (is (= :rf.error/derived-container-replaced
+             (:rf.error/id (ex-data @thrown)))
+          "the same detection that would emit the trace carries the category on the throw")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+      (when interop/debug-enabled?
+        (is (some? ev)
+            "a :rf.error/derived-container-replaced error trace was emitted")
+        (is (= :error (:op-type ev))
+            "the trace's op-type is :error")
+        (is (= :rf.error/derived-container-replaced (:operation ev))
+            "the trace's :operation is the error category keyword")
+        (is (= :rf.error/derived-container-replaced (get-in ev [:tags :category]))
+            "the :category tag mirrors :operation for consumer convenience")
+        (is (= :no-recovery (:recovery ev))
+            "the :recovery field is hoisted to top level as :no-recovery")
+        (is (string? (get-in ev [:tags :reason]))
+            "the :reason tag is a human-readable sentence")))))
 
 (deftest derived-container-value-unchanged-after-rejected-write
   (testing "the rejected write does NOT mutate the derived container — the adapter replace-container! is never invoked"

--- a/implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj
+++ b/implementation/core/test/re_frame/unknown_dispatch_opts_warn_test.clj
@@ -20,13 +20,33 @@
   then fails for want of a frame. The fixture establishes a `:rf/default`
   frame SCOPE (the carried-invariant contract — no synthesised floor) so
   the ambient `dispatch-sync` calls below complete after the warning
-  fires; the typo key carries no frame, but the scope does."
+  fires; the typo key carries no frame, but the scope does.
+
+  ## Posture split (rf2-d2841)
+
+  The warning surface is dev-only BY DESIGN (see the paragraph above), so
+  every assertion ABOUT the warning — positive and negative alike — is kept
+  verbatim inside a `(when interop/debug-enabled? …)` arm marked `rf2-d2841`.
+  The negatives move with the positives and that is the point, not tidiness:
+  `(is (empty? (unknown-opt-warnings recorded)))` over an empty trace stream
+  passes under `-Dre-frame.debug=false` whatever the opts map contained, so
+  outside the arm `no-warning-for-known-opts` would certify `:frame` as
+  recognised while in fact nothing was emitted for ANY key, recognised or not.
+
+  What survives the gate here is the sentence the docstring already makes and
+  the file never checked: THE WARNING IS OBSERVATIONAL — the dispatch proceeds
+  unchanged. Each deftest now lands a marker in app-db and asserts it arrived,
+  so the production lane proves that an unrecognised opts key neither aborts
+  the dispatch nor perturbs the recognised ones. `known-set-matches-build-
+  envelope-reads` is pure data and needs no posture at all."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.router.diagnostics :as diag]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as ts]
             [re-frame.trace :as trace]))
 
 ;; ---- fixtures -------------------------------------------------------------
@@ -57,85 +77,149 @@
                   (= :rf.warning/unknown-dispatch-opt (:operation ev))))
            @recorded))
 
+(defn- reg-marker-event!
+  "Register `id` as a handler that stamps `[:landed id]` into the target
+  frame's app-db (rf2-d2841). The ALWAYS-ON witness for this file: the
+  unknown-opt warning is observational, so whatever the opts map carried the
+  dispatch must still reach the handler. Readable straight off `app-db-value`
+  in either posture — no trace surface involved."
+  ([id] (reg-marker-event! id nil))
+  ([id extra-meta]
+   (if extra-meta
+     (rf/reg-event id extra-meta (fn [{:keys [db]} _] {:db (assoc db :landed id)}))
+     (rf/reg-event id           (fn [{:keys [db]} _] {:db (assoc db :landed id)})))))
+
+(defn- landed?
+  [frame-id id]
+  (= id (:landed (rf/app-db-value frame-id))))
+
 ;; ---- tests ----------------------------------------------------------------
 
 (deftest fires-on-unknown-opts-key
   (testing "an unrecognised opts key emits exactly one warning naming the bad key + the known set"
-    (rf/reg-event :app/noop (fn [{:keys [db]} _] {:db db}))
+    (reg-marker-event! :app/noop)
     (let [recorded (record-traces! ::unknown)]
       ;; `:fram` is the classic typo for `:frame` — silently swallowed
       ;; before this fix.
       (rf/dispatch-sync [:app/noop] {:fram :rf/default})
 
-      (let [warns (unknown-opt-warnings recorded)]
-        (is (= 1 (count warns))
-            (str "expected exactly one unknown-opt warning, got "
-                 (count warns)))
-        (let [w (first warns)
-              t (:tags w)]
-          (is (= [:app/noop] (:event t)))
-          (is (= :app/noop (:event-id t)))
-          (is (= [:fram] (:unknown-keys t))
-              "the bad key is named verbatim")
-          (is (contains? (set (:known-keys t)) :frame)
-              "the warning enumerates the known opts set")
-          (is (string? (:reason t)))
-          (is (re-find #":fram" (:reason t))
-              "reason names the offending key")
-          (is (re-find #":frame" (:reason t))
-              "reason lists the known keys (incl. the likely intended :frame)")
-          (is (= :no-recovery (:recovery w))))))))
+      ;; ALWAYS-ON WITNESS (rf2-d2841): `:recovery :no-recovery` means the
+      ;; dispatch is untouched by the diagnostic. Asserted off app-db so it
+      ;; holds under the production gate, where the warning itself is gone.
+      (is (landed? :rf/default :app/noop)
+          "the unknown opt is OBSERVATIONAL — the dispatch still reached the handler")
+
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+      (when interop/debug-enabled?
+        (let [warns (unknown-opt-warnings recorded)]
+          (is (= 1 (count warns))
+              (str "expected exactly one unknown-opt warning, got "
+                   (count warns)))
+          (let [w (first warns)
+                t (:tags w)]
+            (is (= [:app/noop] (:event t)))
+            (is (= :app/noop (:event-id t)))
+            (is (= [:fram] (:unknown-keys t))
+                "the bad key is named verbatim")
+            (is (contains? (set (:known-keys t)) :frame)
+                "the warning enumerates the known opts set")
+            (is (string? (:reason t)))
+            (is (re-find #":fram" (:reason t))
+                "reason names the offending key")
+            (is (re-find #":frame" (:reason t))
+                "reason lists the known keys (incl. the likely intended :frame)")
+            (is (= :no-recovery (:recovery w)))))))))
 
 (deftest names-every-unknown-key-in-one-warning
   (testing "multiple unknown keys → a single warning listing them all"
-    (rf/reg-event :app/noop (fn [{:keys [db]} _] {:db db}))
+    (reg-marker-event! :app/noop)
     (let [recorded (record-traces! ::multi)]
       (rf/dispatch-sync [:app/noop] {:fram :rf/default :srce :ui :origin :app})
 
-      (let [warns (unknown-opt-warnings recorded)]
-        (is (= 1 (count warns)) "one warning for the whole call, not one per bad key")
-        (let [t (:tags (first warns))]
-          (is (= #{:fram :srce} (set (:unknown-keys t)))
-              "both typos named; the legitimate :origin opt is NOT flagged"))))))
+      ;; ALWAYS-ON WITNESS (rf2-d2841).
+      (is (landed? :rf/default :app/noop)
+          "two unknown opts alongside a legitimate :origin still dispatch")
+
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+      (when interop/debug-enabled?
+        (let [warns (unknown-opt-warnings recorded)]
+          (is (= 1 (count warns)) "one warning for the whole call, not one per bad key")
+          (let [t (:tags (first warns))]
+            (is (= #{:fram :srce} (set (:unknown-keys t)))
+                "both typos named; the legitimate :origin opt is NOT flagged")))))))
 
 (deftest no-warning-for-known-opts
   (testing "a known opts key (:frame) → no warning"
     (rf/make-frame {:id :game :doc "non-default frame target"})
-    (rf/reg-event :game/tick {:frame :game} (fn [{:keys [db]} _] {:db db}))
+    (reg-marker-event! :game/tick {:frame :game})
     (let [recorded (record-traces! ::known)]
       (rf/dispatch-sync [:game/tick] {:frame :game})
-      (is (empty? (unknown-opt-warnings recorded))
-          ":frame is a recognised opt — no warning"))))
+      ;; ALWAYS-ON WITNESS (rf2-d2841): `:frame` is not merely unflagged, it is
+      ;; HONOURED — the marker lands in :game, not in the ambient :rf/default
+      ;; scope. That is the production-visible half of "recognised opt".
+      (is (landed? :game :game/tick)
+          ":frame routed the dispatch to the named frame")
+      (is (nil? (:landed (rf/app-db-value :rf/default)))
+          "and NOT to the ambient scope frame")
+      ;; rf2-d2841 — dev-instrumentation arm. A NEGATIVE over the trace
+      ;; stream: under the gate it is empty for every opts map, so outside the
+      ;; arm this would certify :frame as recognised for free.
+      (when interop/debug-enabled?
+        (is (empty? (unknown-opt-warnings recorded))
+            ":frame is a recognised opt — no warning")))))
 
 (deftest no-warning-for-source-and-origin-opts
   (testing "the full known set is accepted without warning"
-    (rf/reg-event :app/noop (fn [{:keys [db]} _] {:db db}))
+    (reg-marker-event! :app/noop)
     (let [recorded (record-traces! ::full-known)]
       (rf/dispatch-sync [:app/noop]
                         {:source :ui :origin :app :trace-id "t1"
                          :fx-overrides {} :interceptor-overrides {}
                          :source-detail {:ms 100}})
-      (is (empty? (unknown-opt-warnings recorded))
-          "every key here is in known-dispatch-opts"))))
+      ;; ALWAYS-ON WITNESS (rf2-d2841): the full known set is accepted by
+      ;; `build-envelope` without derailing the dispatch.
+      (is (landed? :rf/default :app/noop)
+          "a dispatch carrying every known opt still reaches the handler")
+      ;; rf2-d2841 — dev-instrumentation arm. Same wholesale-empty-stream
+      ;; false-green shape as `no-warning-for-known-opts`.
+      (when interop/debug-enabled?
+        (is (empty? (unknown-opt-warnings recorded))
+            "every key here is in known-dispatch-opts")))))
 
 (deftest no-warning-for-empty-opts
   (testing "the no-opts dispatch path emits no warning"
-    (rf/reg-event :app/noop (fn [{:keys [db]} _] {:db db}))
+    (reg-marker-event! :app/noop)
     (let [recorded (record-traces! ::empty)]
       (rf/dispatch-sync [:app/noop])
-      (is (empty? (unknown-opt-warnings recorded))
-          "empty opts map has no unknown keys"))))
+      ;; ALWAYS-ON WITNESS (rf2-d2841).
+      (is (landed? :rf/default :app/noop)
+          "the no-opts dispatch path reaches the handler")
+      ;; rf2-d2841 — dev-instrumentation arm. Same false-green shape as above.
+      (when interop/debug-enabled?
+        (is (empty? (unknown-opt-warnings recorded))
+            "empty opts map has no unknown keys")))))
 
 (deftest async-dispatch-path-also-warns
   (testing "the queued `dispatch` path (not just dispatch-sync) warns on unknown keys"
-    (rf/reg-event :app/noop (fn [{:keys [db]} _] {:db db}))
+    (reg-marker-event! :app/noop)
     (let [recorded (record-traces! ::async)]
       ;; `dispatch` enqueues; the JVM drain runs it synchronously via the
       ;; router, but `build-envelope` (where the check lives) runs at
       ;; enqueue time regardless.
       (rf/dispatch [:app/noop] {:fram :rf/default})
-      (is (= 1 (count (unknown-opt-warnings recorded)))
-          "build-envelope is the single chokepoint — both dispatch paths funnel through it"))))
+      ;; ALWAYS-ON WITNESS (rf2-d2841): the queued path is observational too —
+      ;; the unknown key does not stop the enqueued event from draining. The
+      ;; ENQUEUE is synchronous (build-envelope, where the check lives, runs on
+      ;; the caller's thread); the DRAIN is not — `interop/next-tick` submits
+      ;; to a single-thread executor with no return-before-start guarantee — so
+      ;; the marker is polled rather than read straight back.
+      (is (ts/poll-until #(landed? :rf/default :app/noop)
+                         {:label "queued dispatch drains despite the unknown opt"})
+          "the queued dispatch drained despite the unknown opt")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+      (when interop/debug-enabled?
+        (is (= 1 (count (unknown-opt-warnings recorded)))
+            "build-envelope is the single chokepoint — both dispatch paths funnel through it")))))
 
 (deftest no-warning-for-initial-events-step-index
   (testing ":initial-events setup dispatches carry :step-index (a build-envelope-read internal opt) — no false unknown-opt warning"
@@ -149,8 +233,15 @@
       ;; warning. Before the fix, each of the two setup steps emitted one false
       ;; `:silently ignored` warning.
       (rf/make-frame {:id :seeded/frame :initial-events [[:seed/set 1] [:seed/set 2]]})
-      (is (empty? (unknown-opt-warnings recorded))
-          ":step-index is an honoured build-envelope opt, not an unknown key"))))
+      ;; ALWAYS-ON WITNESS (rf2-d2841): both setup steps ran, in order — the
+      ;; production-visible half of ":step-index is honoured, not unknown".
+      (is (= 2 (:seed (rf/app-db-value :seeded/frame)))
+          "both :initial-events setup steps dispatched and landed, last-wins")
+      ;; rf2-d2841 — dev-instrumentation arm. Same false-green shape as the
+      ;; other negatives in this file.
+      (when interop/debug-enabled?
+        (is (empty? (unknown-opt-warnings recorded))
+            ":step-index is an honoured build-envelope opt, not an unknown key")))))
 
 (deftest known-set-matches-build-envelope-reads
   (testing "the published known-opts set documents exactly the keys build-envelope honours"

--- a/implementation/core/test/re_frame/write_after_destroy_always_on_cljs_test.cljc
+++ b/implementation/core/test/re_frame/write_after_destroy_always_on_cljs_test.cljc
@@ -29,12 +29,28 @@
 
   Dual-runtime: named `*_cljs_test.cljc` so the shadow-cljs `:node-test`
   build AND the JVM `clojure -M:test` runner both pick it up. The choke
-  point is plain CLJC; no DOM dependency."
+  point is plain CLJC; no DOM dependency.
+
+  ## Posture split (rf2-d2841)
+
+  Legs (a) and (c) are the promotion's whole point and are ALREADY posture-
+  independent — they read the corpus-wide `:errors` registry and an adapter
+  tripwire, neither of which is gated. They run under
+  `scripts/test-core-prod-gate.sh` unchanged.
+
+  Leg (b) is the DEV COMPANION by construction: the ns docstring above calls
+  it \"DCE'd in prod\". Its assertions are kept verbatim inside a
+  `(when interop/debug-enabled? …)` arm marked `rf2-d2841`, with an always-on
+  witness for the same call kept outside — this file's thesis is precisely
+  that the dev trace and the always-on record fire TOGETHER off one choke
+  point, so a deftest that had nothing to say in production posture would be
+  the wrong shape for it."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
             [re-frame.substrate.adapter :as adapter]
             [re-frame.error-emit :as error-emit]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as ts]))
@@ -94,24 +110,36 @@
             (in-process tooling surface, DCE'd in prod) carrying the promoted
             category, `:recovery :ignored`, and a structured-only `:reason`
             (no raw values)."
-    (let [traces (atom [])]
-      (rf/register-listener! :trace ::rec (fn [ev] (swap! traces conj ev)))
+    (let [traces (atom [])
+          always (atom [])]
+      (rf/register-listener! :trace  ::rec        (fn [ev]  (swap! traces conj ev)))
+      (rf/register-listener! :errors ::rec-errors (fn [rec] (swap! always conj rec)))
       (try
         (adapter/replace-container! nil {:dropped :write})
-        (finally (rf/unregister-listener! :trace ::rec)))
-      (let [errs (filter #(= :rf.error/write-after-destroy (:operation %)) @traces)]
-        ;; The trace surface is live in dev (this runner); under :advanced +
-        ;; goog.DEBUG=false it DCEs — the contract is the always-on record
-        ;; above, this is the dev companion.
-        (is (= 1 (count errs))
-            "one dev error trace for the dropped write")
-        (let [ev (first errs)]
-          ;; `:recovery` is HOISTED to the envelope top-level by
-          ;; `build-event`; the structured `:reason` stays under `:tags`.
-          (is (= :ignored (:recovery ev))
-              ":recovery :ignored — write dropped, frame gone (mirrors frame-destroyed)")
-          (is (string? (get-in ev [:tags :reason]))
-              ":reason is a structured human-readable sentence (no raw values)"))))))
+        (finally
+          (rf/unregister-listener! :trace  ::rec)
+          (rf/unregister-listener! :errors ::rec-errors)))
+      ;; ALWAYS-ON WITNESS (rf2-d2841). This deftest's thesis is that the dev
+      ;; trace is the COMPANION of the always-on record off ONE choke point,
+      ;; so the companion claim needs the always-on half present in the same
+      ;; body. Under the production gate this is all that remains, and it is
+      ;; the half that matters: one record, one call.
+      (is (= 1 (count (filter #(= :rf.error/write-after-destroy (:error %)) @always)))
+          "the same choke-point call fans exactly one always-on record")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
+      ;; The trace surface is live in dev (this runner); under :advanced +
+      ;; goog.DEBUG=false — and under -Dre-frame.debug=false — it DCEs.
+      (when interop/debug-enabled?
+        (let [errs (filter #(= :rf.error/write-after-destroy (:operation %)) @traces)]
+          (is (= 1 (count errs))
+              "one dev error trace for the dropped write")
+          (let [ev (first errs)]
+            ;; `:recovery` is HOISTED to the envelope top-level by
+            ;; `build-event`; the structured `:reason` stays under `:tags`.
+            (is (= :ignored (:recovery ev))
+                ":recovery :ignored — write dropped, frame gone (mirrors frame-destroyed)")
+            (is (string? (get-in ev [:tags :reason]))
+                ":reason is a structured human-readable sentence (no raw values)")))))))
 
 ;; ===========================================================================
 ;; (c) The underlying adapter replace-container! is NOT invoked — the write

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -44,14 +44,15 @@
 # a rewrite of how those assertions are spelled.  Triage beads are named per
 # cluster below.
 #
-# What is left IS green, and it is not a rump: 119 namespaces, 1363 tests, 5945
+# What is left IS green, and it is not a rump: 123 namespaces, 1401 tests, 6054
 # assertions, exit 0 — versus the zero suites that had ever executed under this
 # posture before.  (It was 88 / 934 / 4340 before rf2-d2841 split the spine's
 # dev-instrumentation assertions away from the semantics beside them,
 # 94 / 1106 / 5135 before that bead's second pass took `fx-test` — the largest
 # single entry, 107 failures and 25 errors across ~20 deftests — plus
 # `sub-topology`, `init-platform`, `pattern-smoke` and `db-noop-commit`, and
-# 103 / 1213 / 5590 before its third pass took sixteen more.)
+# 103 / 1213 / 5590 before its third pass took twenty more — the twenty are
+# named in that pass's commits — `git log --grep=rf2-d2841`.)
 #
 # The roster is therefore an EXCLUSION list, not an allowlist.  The polarity is
 # the point: a namespace added to `implementation/core/test/` joins this lane
@@ -193,7 +194,6 @@ known_red=(
   re-frame.event-context-partition-test
   re-frame.frame-destroy-composed-test
   re-frame.frame-destroy-incarnation-jvm-test
-  re-frame.frame-initial-events-cljs-test
   re-frame.frame-teardown-report-cljs-test
   re-frame.fx-aggregate-classification-cljs-test
   re-frame.fx-args-trace-egress-cljs-test
@@ -201,14 +201,11 @@ known_red=(
   re-frame.image-inline-metadata-normalization-cljs-test
   re-frame.interceptor-override-summary-trace-test
   re-frame.live-frame-reload-cljs-test
-  re-frame.machine-action-outcome-classification-cljs-test
-  re-frame.machine-routed-event-classification-cljs-test
   re-frame.observation-port-cljs-test
   re-frame.override-capture-trace-test
   re-frame.reg-meta-noswallow-cljs-test
   re-frame.reg-view-injection-test
   re-frame.registrar-warnings-test
-  re-frame.router-front-of-queue-cljs-test
   re-frame.source-coord-jvm-test
   re-frame.source-coords-test
   re-frame.sub-cycle-cljs-test
@@ -319,15 +316,15 @@ fi
 # green with `Ran 0 tests`.  Calibrated below the observed count with room for
 # ordinary churn; raise it when the roster grows materially.
 #
-# RAISED 800 -> 1320 (rf2-d2841, third pass).  800 was calibrated against the
+# RAISED 800 -> 1360 (rf2-d2841, third pass).  800 was calibrated against the
 # 915-test lane of rf2-f8x2i's original run and had stopped doing its job: the
-# lane now runs 1363 tests, so a regression that silently dropped a THIRD of
-# them still cleared the floor.  Concretely, the sixteen namespaces this pass
-# added are 150 tests — losing the whole batch lands at 1213, which 800 would
-# wave through.  1320 notices that while leaving ~3% for ordinary churn.  The
+# lane now runs 1401 tests, so a regression that silently dropped a THIRD of
+# them still cleared the floor.  Concretely, the twenty namespaces this pass
+# added are 188 tests — losing the whole batch lands at 1213, which 800 would
+# wave through.  1360 notices that while leaving ~3% for ordinary churn.  The
 # floor is a collapse detector, not a target: it must sit close enough under
 # the observed count that the smallest batch anyone lands is still visible.
-export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1320}"
+export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1360}"
 
 args=()
 for ns in $runnable; do

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -44,14 +44,14 @@
 # a rewrite of how those assertions are spelled.  Triage beads are named per
 # cluster below.
 #
-# What is left IS green, and it is not a rump: 114 namespaces, 1294 tests, 5786
+# What is left IS green, and it is not a rump: 119 namespaces, 1363 tests, 5945
 # assertions, exit 0 — versus the zero suites that had ever executed under this
 # posture before.  (It was 88 / 934 / 4340 before rf2-d2841 split the spine's
 # dev-instrumentation assertions away from the semantics beside them,
 # 94 / 1106 / 5135 before that bead's second pass took `fx-test` — the largest
 # single entry, 107 failures and 25 errors across ~20 deftests — plus
 # `sub-topology`, `init-platform`, `pattern-smoke` and `db-noop-commit`, and
-# 103 / 1213 / 5590 before its third pass took the eleven listed below.)
+# 103 / 1213 / 5590 before its third pass took sixteen more.)
 #
 # The roster is therefore an EXCLUSION list, not an allowlist.  The polarity is
 # the point: a namespace added to `implementation/core/test/` joins this lane
@@ -183,15 +183,12 @@ known_red=(
   re-frame.capture-frame-reincarnation-sink-route-cljs-test
   re-frame.capture-frame-test
   re-frame.cascade-dispatch-id-test
-  re-frame.cascade-envelope-propagation-test
   re-frame.classification-effects-cljs-test
   re-frame.cofx-cljs-test
   re-frame.cofx-envelope-test
   re-frame.core-epoch-egress-profile-test
-  re-frame.cross-frame-dispatch-sync-warn-test
   re-frame.db-pending-trace-test
   re-frame.dispatched-trace-cofx-test
-  re-frame.elision-test
   re-frame.ep0026-inline-grammar-cljs-test
   re-frame.event-context-partition-test
   re-frame.frame-destroy-composed-test
@@ -214,13 +211,11 @@ known_red=(
   re-frame.router-front-of-queue-cljs-test
   re-frame.source-coord-jvm-test
   re-frame.source-coords-test
-  re-frame.sub-arg-fragmentation-warn-test
   re-frame.sub-cycle-cljs-test
   re-frame.sub-dispose-trace-test
   re-frame.sub-parametric-inputs-test
   re-frame.subs-inline-normalization-cljs-test
   re-frame.substrate-source-test
-  re-frame.substrate.derived-container-replaced-cljs-test
   re-frame.success-path-call-site-test
   re-frame.success-path-trigger-handler-test
   re-frame.trace-buffer-test
@@ -324,15 +319,15 @@ fi
 # green with `Ran 0 tests`.  Calibrated below the observed count with room for
 # ordinary churn; raise it when the roster grows materially.
 #
-# RAISED 800 -> 1250 (rf2-d2841, third pass).  800 was calibrated against the
+# RAISED 800 -> 1320 (rf2-d2841, third pass).  800 was calibrated against the
 # 915-test lane of rf2-f8x2i's original run and had stopped doing its job: the
-# lane now runs 1294 tests, so a regression that silently dropped a THIRD of
-# them still cleared the floor.  Concretely, the eleven namespaces this pass
-# added are 81 tests — losing the whole batch lands at 1213, which 800 would
-# wave through.  1250 notices that while leaving ~3% for ordinary churn.  The
+# lane now runs 1363 tests, so a regression that silently dropped a THIRD of
+# them still cleared the floor.  Concretely, the sixteen namespaces this pass
+# added are 150 tests — losing the whole batch lands at 1213, which 800 would
+# wave through.  1320 notices that while leaving ~3% for ordinary churn.  The
 # floor is a collapse detector, not a target: it must sit close enough under
 # the observed count that the smallest batch anyone lands is still visible.
-export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1250}"
+export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1320}"
 
 args=()
 for ns in $runnable; do

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -44,13 +44,14 @@
 # a rewrite of how those assertions are spelled.  Triage beads are named per
 # cluster below.
 #
-# What is left IS green, and it is not a rump: 99 namespaces, 1186 tests, 5468
+# What is left IS green, and it is not a rump: 114 namespaces, 1294 tests, 5786
 # assertions, exit 0 — versus the zero suites that had ever executed under this
 # posture before.  (It was 88 / 934 / 4340 before rf2-d2841 split the spine's
-# dev-instrumentation assertions away from the semantics beside them, and
+# dev-instrumentation assertions away from the semantics beside them,
 # 94 / 1106 / 5135 before that bead's second pass took `fx-test` — the largest
 # single entry, 107 failures and 25 errors across ~20 deftests — plus
-# `sub-topology`, `init-platform`, `pattern-smoke` and `db-noop-commit`.)
+# `sub-topology`, `init-platform`, `pattern-smoke` and `db-noop-commit`, and
+# 103 / 1213 / 5590 before its third pass took the eleven listed below.)
 #
 # The roster is therefore an EXCLUSION list, not an allowlist.  The polarity is
 # the point: a namespace added to `implementation/core/test/` joins this lane
@@ -158,6 +159,27 @@ known_red=(
   #    — the false-green this lane exists to close. Those want a var-level
   #    tag the lane excludes (the `-e :requires-debug` idea above), not a
   #    posture guard.
+  #
+  #    THE THIRD PASS'S LESSON: THE FILES THAT ALREADY LOOK GREEN ARE WHERE
+  #    THE ROT IS. Of the eleven namespaces taken off in that pass, seven were
+  #    on this list for a handful of red assertions each — but every one of
+  #    them ALSO carried assertions that were passing under the gate for no
+  #    reason whatsoever. `configure-test` had four `(<= (count
+  #    (rf/trace-buffer …)) N)` retention caps, all true over the `[]` that
+  #    `trace-buffer` returns in production; `unknown-dispatch-opts-warn-test`
+  #    had four `(empty? (unknown-opt-warnings …))` negatives certifying keys
+  #    as recognised over a stream that is empty for every key. Fixing only
+  #    the red assertions and deleting the roster line would have promoted
+  #    those into the lane as permanent false green. Read the WHOLE namespace,
+  #    not the failure list.
+  #
+  #    AND `configure-test` IS THE CAUTIONARY TALE FOR THE OTHER DIRECTION.
+  #    The pass-2 note guessed that "the retention it configures IS production
+  #    state even though the warning is not". It is not:
+  #    `trace.tooling/configure-trace-buffer!` opens BOTH arms with
+  #    `(when (and interop/debug-enabled? …))`, so the knob and its warning
+  #    are equally dev-only. Check the implementation, not the plausible
+  #    story about it.
   re-frame.capture-frame-reincarnation-sink-route-cljs-test
   re-frame.capture-frame-test
   re-frame.cascade-dispatch-id-test
@@ -165,12 +187,10 @@ known_red=(
   re-frame.classification-effects-cljs-test
   re-frame.cofx-cljs-test
   re-frame.cofx-envelope-test
-  re-frame.configure-test
   re-frame.core-epoch-egress-profile-test
   re-frame.cross-frame-dispatch-sync-warn-test
   re-frame.db-pending-trace-test
   re-frame.dispatched-trace-cofx-test
-  re-frame.doc-metadata-prod-elision-test
   re-frame.elision-test
   re-frame.ep0026-inline-grammar-cljs-test
   re-frame.event-context-partition-test
@@ -181,26 +201,19 @@ known_red=(
   re-frame.fx-aggregate-classification-cljs-test
   re-frame.fx-args-trace-egress-cljs-test
   re-frame.fx-redirect-classification-cljs-test
-  re-frame.handler-source-test
   re-frame.image-inline-metadata-normalization-cljs-test
-  re-frame.image-no-emit-trace-gate-cljs-test
   re-frame.interceptor-override-summary-trace-test
   re-frame.live-frame-reload-cljs-test
   re-frame.machine-action-outcome-classification-cljs-test
   re-frame.machine-routed-event-classification-cljs-test
-  re-frame.non-serialisable-event-payload-warn-test
   re-frame.observation-port-cljs-test
   re-frame.override-capture-trace-test
-  re-frame.reg-event-cljs-test
   re-frame.reg-meta-noswallow-cljs-test
   re-frame.reg-view-injection-test
   re-frame.registrar-warnings-test
-  re-frame.router-carried-frame-test
   re-frame.router-front-of-queue-cljs-test
   re-frame.source-coord-jvm-test
-  re-frame.source-coord-prod-elision-test
   re-frame.source-coords-test
-  re-frame.sub-algebra-view-test
   re-frame.sub-arg-fragmentation-warn-test
   re-frame.sub-cycle-cljs-test
   re-frame.sub-dispose-trace-test
@@ -225,8 +238,6 @@ known_red=(
   re-frame.trace-test
   re-frame.trace.structural-retention-cljs-test
   re-frame.trigger-handler-coord-test
-  re-frame.unknown-dispatch-opts-warn-test
-  re-frame.write-after-destroy-always-on-cljs-test
 )
 
 # ---------------------------------------------------------------------------
@@ -312,7 +323,16 @@ fi
 # renamed directory, an `-n` list that matched nothing — cannot report itself
 # green with `Ran 0 tests`.  Calibrated below the observed count with room for
 # ordinary churn; raise it when the roster grows materially.
-export RF2_MIN_TESTS="${RF2_MIN_TESTS:-800}"
+#
+# RAISED 800 -> 1250 (rf2-d2841, third pass).  800 was calibrated against the
+# 915-test lane of rf2-f8x2i's original run and had stopped doing its job: the
+# lane now runs 1294 tests, so a regression that silently dropped a THIRD of
+# them still cleared the floor.  Concretely, the eleven namespaces this pass
+# added are 81 tests — losing the whole batch lands at 1213, which 800 would
+# wave through.  1250 notices that while leaving ~3% for ordinary churn.  The
+# floor is a collapse detector, not a target: it must sit close enough under
+# the observed count that the smallest batch anyone lands is still visible.
+export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1250}"
 
 args=()
 for ns in $runnable; do


### PR DESCRIPTION
Third pass on `rf2-d2841`. Twenty namespaces come off the core production-gate roster; the lane grows from **103 of 184 to 123 of 184**.

The split shape is the one PR #7196 / #7218 established: the dev-instrumentation assertion stays **verbatim** inside a `(when interop/debug-enabled? …)` arm marked `rf2-d2841`, everything outside the arm is posture-independent, and each namespace gains a `## Posture split (rf2-d2841)` section saying which half is which and why. Where an assertion had a production-visible counterpart it was **re-aimed rather than guarded** — that is the difference between coverage kept and coverage parked.

## Roster: before / after

| | before | after |
|---|---|---|
| namespaces | 103 of 184 | **123 of 184** |
| excluded as known-red | 81 | **61** |
| of those, under this bead's heading | 69 | **49** |
| tests | 1213 | **1401** |
| assertions | 5590 | **6054** |

Off the roster: `cascade-envelope-propagation`, `configure`, `cross-frame-dispatch-sync-warn`, `doc-metadata-prod-elision`, `elision`, `frame-initial-events-cljs`, `handler-source`, `image-no-emit-trace-gate-cljs`, `machine-action-outcome-classification-cljs`, `machine-routed-event-classification-cljs`, `non-serialisable-event-payload-warn`, `reg-event-cljs`, `router-carried-frame`, `router-front-of-queue-cljs`, `source-coord-prod-elision`, `sub-algebra-view`, `sub-arg-fragmentation-warn`, `substrate.derived-container-replaced-cljs`, `unknown-dispatch-opts-warn`, `write-after-destroy-always-on-cljs`.

## Nothing was lost — the dev-posture count

`clojure -M:test` from `implementation/core`, measured on a pristine `origin/main` worktree and on this branch:

| | tests | assertions |
|---|---|---|
| `origin/main` | 2180 | 10805 |
| this branch | **2180** | **10860** |

Tests **held**, assertions **up 55**. Every assertion moved into a guard is still executed by the dev lane; the increase is the production witnesses added below.

## Re-aimed, not guarded

Three namespaces kept their assertions load-bearing in *both* postures by changing axis rather than adding a guard:

- **`router-carried-frame-test`** — `:rf.error/no-frame-context` and `:rf.error/frame-destroyed` are both always-on. The first fans through `frame/emit-no-frame-context!`, which calls the late-bound `:error-emit/dispatch-on-error` hook *before* it reaches the dev-only `trace/emit-error!` leg; the second is in the promoted set named in `re-frame.error-emit`'s docstring. Counting them off the `:errors` stream instead of the `:trace` stream keeps the positives **and** the "NOT the other category" negative live under the gate.
- **`cascade-envelope-propagation-test`** — `:origin` / `:trace-id` inheritance and the `:source :fx-dispatch` re-stamp were read off `:rf.event/dispatched`. They are now read off the child's **dispatch envelope** via the fx-handler ctx's `(:envelope m)` slot — a production surface the file's own `fx-handler-ctx-carries-envelope-slot` already establishes. Only the claim about the trace event's *shape* (`:origin` under `:tags`, `:source` hoisted per Spec 009 §Core fields) stayed in the arm.
- **`source-coord-prod-elision-test`** — the dev half (public `handler-meta` retains coords) is now stated beside its always-on partner in the same body: the parallel `error-coords-by-id` registry carries those coords in **both** postures. One registration, stripped from the public surface, retained on the observability surface — which is the actual contract.

## New coverage, not just preserved coverage

- **`sub-arg-fragmentation-warn-test`'s JVM pin now has a production arm.** It used to assert only that `interop/debug-enabled?` is true on the JVM test runtime — a statement the production lane falsifies by construction. It is now two-armed off the *same* two subscribes: the emit lands when the gate is on, and is **genuinely absent** when it is off. That second arm is the JVM counterpart of the CLJS elision probe for this category, which had none.
- **`unknown-dispatch-opts-warn-test` now asserts its own docstring.** "The warning is observational: the dispatch proceeds unchanged" was written down and checked nowhere. Six deftests now land a marker in app-db and assert it arrived, so the production lane proves an unrecognised opts key neither aborts the dispatch nor perturbs a recognised one — and `:frame` is shown **honoured** (the marker lands in `:game`, not the ambient scope) rather than merely unflagged.
- **`cross-frame-dispatch-sync-warn-test` now pins the contrast in production.** Cross-frame reentry runs the target's handler; same-frame reentry does not. Both halves are now app-db assertions, so Mike's Option-B distinction survives the gate even though neither diagnostic does.

## Production witnesses added

Fifteen deftests would have been 100%-dev after guarding. Each got an always-on half instead of being left hollow — `handler-meta` witnesses in `handler-source-test` (the macro's production arm is a *different expansion* from its dev arm, so a broken prod arm would drop the registration outright), the always-on `:errors` record for the same choke-point call in `write-after-destroy-always-on-cljs-test`, the fn-valued payload arriving **untouched** in `non-serialisable-event-payload-warn-test`, the throw that shares one detection with the trace in `derived-container-replaced-cljs-test`, `elision/current-config` reads plus "the wire value comes back verbatim" in `elision-test`, and app-db / registry witnesses elsewhere. Each is named in its namespace's `## Posture split` section.

## Vacuous passes found — 31, and they were the real find

Of the twenty namespaces, **twelve** were rostered for a handful of red assertions each while *also* carrying assertions that passed under the gate for no reason at all. Fixing only the red ones and deleting the roster line would have promoted these into the lane as permanent false green.

| class | count | where |
|---|---|---|
| 1 — negative over an empty ring/stream | 24 | `sub-arg-fragmentation-warn` x5 (every one of the five STAYS SILENT deftests — false-positive aversion with nothing to be averse to), `elision` x4 (`(= 0 (count-unschema'd-warnings …))`, incl. both halves of `threshold-zero-disables-runtime-auto-detect`), `unknown-dispatch-opts-warn` x4 (certifying `:frame` / `:origin` / the empty map as recognised over a stream empty for *every* key), `cross-frame-dispatch-sync-warn` x3, `frame-initial-events-cljs` x2 (`(first @dispatched)` is nil, so both runtime-dispatch negatives hold), `image-no-emit-trace-gate-cljs` x1 (the no-emit flag's whole point), `machine-action-outcome-classification-cljs` x1 and `machine-routed-event-classification-cljs` x1 (**redaction** no-leak negatives — green because nothing was emitted), `non-serialisable-event-payload-warn` x1, `router-carried-frame` x1, `configure` x1 |
| 4 — absence of a key the gate elides wholesale | 7 | `configure` x4 (`(<= (count (rf/trace-buffer …)) N)` is true over the `[]` production returns, for every N), `handler-source` x2 (`:rf.handler/source` absent "on the fn-form path" — absent for *every* path), `sub-algebra-view` x1 (`:doc`) |

No class-2 or class-3 instances this pass. **Nothing failed for a real reason** — every gate failure was test spelling, matching passes 1 and 2 and rf2-r9bra's verdict.

The two redaction ones deserve a line of their own. `(not (some #(leaks? sentinel %) @seen))` over an empty `@seen` is a redaction suite reporting green because nothing was emitted, which is the worst false green in this programme. Both now sit inside the arm alongside the positive that gives them teeth — the `:rf.machine/transition` / `:rf.machine/action-ran` emit, and in `machine-routed-event` the precision partner asserting the *non-secret* `:email` still survives.

## Two corrections to the record

- **`handler-source-test`'s docstring said `:rf.handler/source` capture is "JVM-side always-on (bundle-size argument doesn't apply)".** Measured under the real gate, false — and the source agrees: `core_reg_macros/with-form-source-form` binds `*pending-form-source*` to `(if interop/debug-enabled? <src> nil)` with no platform reader-conditional, and `events/merge-form-source` opens with `(if-not interop/debug-enabled? m …)`. Corrected in place rather than left to mislead. The genuinely production-visible asymmetry — a `:rf.handler/source` the caller authored **explicitly** survives production because `merge-form-source` returns the map untouched, while the auto-captured one does not — is now unguarded and stated as the contract it is.
- **The pass-2 note guessed that `configure-test`'s "retention it configures IS production state even though the warning is not".** It is not. `trace.tooling/configure-trace-buffer!` opens *both* arms with `(when (and interop/debug-enabled? …))`, and `trace-buffer` returns `[]` in production because the ring is never allocated. The whole `:trace-buffer` knob is dev-only; `:elision`, the closed-vocabulary nil-returns and the non-map `assert` are what carry that file under the gate.

Both corrections are recorded in the roster script so the next pass starts from the measurement rather than the story.

## `RF2_MIN_TESTS` raised: 800 -> 1360

Yes, this shrink warrants it. 800 was calibrated against rf2-f8x2i's original 915-test lane and had stopped doing its job — the lane now runs 1401 tests, so a regression dropping a third of them still cleared the floor. Concretely: this pass's twenty namespaces are 188 tests, and losing the whole batch lands at 1213, which 800 waves through. 1360 notices that while leaving ~3% for ordinary churn. The floor is a collapse detector, not a target: it has to sit close enough under the observed count that the smallest batch anyone lands stays visible.

## Left alone, deliberately

- **`rf2-r9bra`'s eleven** are untouched: `conformance-test`, `core-api-additions-test`, `elision-multi-owner-cljs-test`, `examples-test`, `frame-upsert-linearization-jvm-test`, `live-run-frame-resolution-cljs-test`, `machine-handler-meta-test`, `partitioned-commit-test`, `redact-interceptor-test`, `sensitive-stamping-test`, `subs-image-local-classification-cljs-test`.
- **The no-semantic-residue cohort** — `trace-listener-*` (x11), `trace-test`, `db-pending-trace-test`, `sub-dispose-trace-test` — stays on the roster per the standing note: guarding them wholesale would report GREEN for namespaces that executed nothing. They want the var-level `-e :requires-debug` tag, a `deps.edn` `:prod-gate` `:main-opts` change and out of this PR's fence. Worth knowing before anyone tries: several of that cohort **hang** rather than fail under the gate, because their `CountDownLatch` coordination waits on trace events that never arrive.
- `features-cljs-test` is the subset artefact and comes back on its own when the two rosters empty.

## Quality gates

Foreground, worktree-local logs, exit codes echoed.

| gate | result |
|---|---|
| `bash scripts/test-core-prod-gate.sh` | **exit 0** — 123 of 184 namespaces, 1401 tests / 6054 assertions, 0 failures 0 errors, with the raised floor in place |
| `clojure -M:test` from `implementation/core` (dev posture) | **exit 0** — 2180 tests / 10860 assertions, 0 failures 0 errors |
| `clojure -M:test` on a pristine `origin/main` worktree (baseline) | **exit 0** — 2180 tests / 10805 assertions |
| per-namespace gated runs, both postures, per batch | **exit 0** x12 |
| `python scripts/check_jvm_lane_rosters.py` | **exit 0** — 31 rostered artefacts, roster<->CI bijection intact |
| `re-frame.egress-chokepoint-conformance-test` | green (runs inside both suites above) |

Deferred to CI: the CLJS lanes (`npm run test:cljs`, the elision / perf-bundle probes) and the full JVM spine. Ten of the twenty namespaces are `.cljc` that also ride `npm run test:cljs`; the guards are `interop/debug-enabled?`, which under a dev `:node-test` build is `true`, so those arms execute there exactly as before.

The bead stays **OPEN** — 49 roster lines remain under its heading.
