### PR TITLE
test(core): pass 4 — split dev instrumentation from semantics (rf2-d2841)

### DIFF
--- a/implementation/core/test/re_frame/capture_frame_reincarnation_sink_route_cljs_test.cljc
+++ b/implementation/core/test/re_frame/capture_frame_reincarnation_sink_route_cljs_test.cljc
@@ -47,12 +47,31 @@
   (`npm run test:cljs`) AND the JVM `clojure -M:test` runner both run it. Plain
   CLJC; no DOM dependency. The interposition redefines the PUBLIC
   `frame/frame-incarnation-live?` (a plain `defn`), so `with-redefs` intercepts
-  the cross-namespace pre-check call on both hosts."
+  the cross-namespace pre-check call on both hosts.
+
+  ## Posture split (rf2-d2841)
+
+  This file is almost entirely ALWAYS-ON already, because the bead it pins is
+  itself an always-on concern: the EP-0015 §9 frame-owned `:errors` sink route
+  and the corpus-wide error record (axis 1) both survive
+  `-Dre-frame.debug=false`. The regression — B's sink staying clean — the
+  recovery, the attribution on the surviving record, and the vacuity probe that
+  proves B's sink is armed therefore ALL run under
+  `scripts/test-core-prod-gate.sh` unchanged.
+
+  Exactly ONE assertion is posture-dependent: `(= 1 (count traces))`, the axis-2
+  DEV TRACE counterpart in `assert-preserved-record!`. It sits inside a
+  `(when interop/debug-enabled? …)` arm. Note what does NOT need one — the
+  `(zero? (count @b-sink))` negative, which would be the textbook vacuous pass
+  if the sink were dev-gated. It is not, and `probe-vacuity!` proves it by
+  landing a real record in the same sink immediately afterwards. That probe is
+  the shape worth copying."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core          :as rf]
             [re-frame.error-emit    :as error-emit]
             [re-frame.frame         :as frame]
+            [re-frame.interop       :as interop]
             [re-frame.observability :as observability]
             [re-frame.privacy       :as privacy]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -135,7 +154,12 @@
   carrying A's bare captured frame id, the `:op` realm, and the structural head."
   [{:keys [records traces]} op fid head raw-event]
   (is (= 1 (count records)) "EXACTLY ONE corpus-wide :rf.error/frame-destroyed record still fans")
-  (is (= 1 (count traces))  "EXACTLY ONE dev trace on axis 2 still fires")
+  ;; rf2-d2841 — axis 2 is the DEV trace and emits nothing under
+  ;; -Dre-frame.debug=false. Axis 1, asserted above and picked apart below, is
+  ;; the production-survivable channel and the one this bead's regression
+  ;; actually lives on, so the rest of this fn stays outside the arm.
+  (when interop/debug-enabled?
+    (is (= 1 (count traces))  "EXACTLY ONE dev trace on axis 2 still fires"))
   (let [r (first records)]
     (is (= :rf.error/frame-destroyed (:error r))    "corpus category retained")
     (is (= fid (:frame r))                          "corpus record carries A's captured bare frame id")

--- a/implementation/core/test/re_frame/classification_effects_cljs_test.cljc
+++ b/implementation/core/test/re_frame/classification_effects_cljs_test.cljc
@@ -29,12 +29,37 @@
 
   Dual-runtime: named `*_cljs_test.cljc` so the shadow-cljs `:node-test`
   build (`npm run test:cljs`) AND the JVM `clojure -M:test` runner both run
-  it. Plain CLJC; no DOM dependency."
+  it. Plain CLJC; no DOM dependency.
+
+  ## Posture split (rf2-d2841)
+
+  Legs 1, 2, 3 and 5 read the per-frame elision registry and app-db — durable
+  production state — and run under `scripts/test-core-prod-gate.sh` unchanged.
+
+  Leg 4 (fail-loud) was the only thing rostering this file, and it did NOT need
+  a guard. `:rf.error/classification-effect-shape` is a PROMOTED category:
+  `router/emit-classification-effect-shape!` goes through
+  `error-emit/emit-error-both!`, so the rejection fans out on the always-on
+  corpus axis as well as the dev trace. Every \"exactly one error was emitted\"
+  row is therefore RE-AIMED at the `:errors` stream, where it stays live in
+  production posture — which is the posture that matters for a fail-loud claim.
+
+  What genuinely is dev-only is the DIAGNOSTIC DETAIL. `emit-error-both!` lifts
+  only `:failing-id` / `:reason` onto the always-on record, and this category
+  passes no `:failing-id`, so `:offending-key` rides the dev-trace tags alone: a
+  production listener learns that a classification effect was malformed but not
+  WHICH key. Those `:offending-key` rows — and the dev-trace counts beside them
+  — sit inside `(when interop/debug-enabled? …)` arms.
+
+  The `no :db commit happened` rows stay outside every arm. They are the
+  fail-CLOSED half of the contract and the reason the error rows are not
+  vacuous: something was rejected, and the rejection had a consequence."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.privacy :as privacy]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as ts]))
@@ -65,6 +90,18 @@
              (and (= :error (:op-type ev))
                   (= operation (:operation ev))))
            @recorded))
+
+;; rf2-d2841 — the ALWAYS-ON corpus axis. `:rf.error/classification-effect-shape`
+;; is a promoted category (`router/emit-classification-effect-shape!` fans it
+;; through `error-emit/emit-error-both!`), so the fail-loud COUNT is readable in
+;; production posture off `:errors` rather than off the dev trace.
+(defn- record-errors! [listener-id]
+  (let [a (atom [])]
+    (rf/register-listener! :errors listener-id (fn [rec] (swap! a conj rec)))
+    a))
+
+(defn- error-records [recorded category]
+  (filterv #(= category (:error %)) @recorded))
 
 ;; ---------------------------------------------------------------------------
 ;; 1. classify-then-egress in the SAME event redacts
@@ -425,13 +462,27 @@
       (fn [{:keys [db]} _]
         {:db        (assoc db :counter 99)
          :sensitive :not-a-vector}))
-    (let [recorded (record-traces! :bad-classify-probe)]
+    (let [recorded (record-traces! :bad-classify-probe)
+          records  (record-errors! :bad-classify-errors)]
       (rf/dispatch-sync [:bad-classify])
-      (let [errs (error-events recorded :rf.error/classification-effect-shape)]
-        (is (= 1 (count errs))
-            "exactly one :rf.error/classification-effect-shape error was emitted")
-        (is (= :sensitive (:offending-key (:tags (first errs))))
-            "the diagnostic names the offending effect key"))
+      ;; ALWAYS-ON axis (rf2-d2841): the fail-loud COUNT reads the corpus-wide
+      ;; error-emit registry, which survives -Dre-frame.debug=false.
+      (let [recs (error-records records :rf.error/classification-effect-shape)]
+        (is (= 1 (count recs))
+            "exactly one :rf.error/classification-effect-shape record fans on the always-on axis")
+        (is (= :bad-classify (:event-id (first recs)))
+            "the always-on record attributes the rejection to the offending event"))
+      ;; rf2-d2841 — the dev-trace arm. `:offending-key` is NOT lifted onto the
+      ;; always-on record (`emit-error-both!` lifts only `:failing-id` /
+      ;; `:reason`, and this category passes no `:failing-id`), so it is
+      ;; readable on the trace tags alone. Kept verbatim.
+      (when interop/debug-enabled?
+        (let [errs (error-events recorded :rf.error/classification-effect-shape)]
+          (is (= 1 (count errs))
+              "exactly one :rf.error/classification-effect-shape error was emitted")
+          (is (= :sensitive (:offending-key (:tags (first errs))))
+              "the diagnostic names the offending effect key")))
+      (rf/unregister-listener! :errors :bad-classify-errors)
       (rf/unregister-listener! :trace :bad-classify-probe))
     ;; the :db commit did NOT happen — app-db is still at the pre-handler value
     (is (= 1 (:counter (frame/frame-app-db-value :rf/default)))
@@ -445,10 +496,17 @@
     (rf/reg-event :bad-entry
       (fn [{:keys [db]} _]
         {:db (assoc db :n 2) :sensitive [:not-a-path-vector]}))
-    (let [recorded (record-traces! :bad-entry-probe)]
+    (let [recorded (record-traces! :bad-entry-probe)
+          records  (record-errors! :bad-entry-errors)]
       (rf/dispatch-sync [:bad-entry])
-      (is (= 1 (count (error-events recorded :rf.error/classification-effect-shape)))
-          "a non-sequential path entry fails loud (one error emitted)")
+      ;; ALWAYS-ON axis (rf2-d2841).
+      (is (= 1 (count (error-records records :rf.error/classification-effect-shape)))
+          "a non-sequential path entry fails loud on the always-on axis (one record)")
+      ;; rf2-d2841 — dev-trace arm.
+      (when interop/debug-enabled?
+        (is (= 1 (count (error-events recorded :rf.error/classification-effect-shape)))
+            "a non-sequential path entry fails loud (one error emitted)"))
+      (rf/unregister-listener! :errors :bad-entry-errors)
       (rf/unregister-listener! :trace :bad-entry-probe))
     (is (= 1 (:n (frame/frame-app-db-value :rf/default)))
         "no :db commit happened on the malformed-entry abort")))
@@ -478,13 +536,24 @@
   (rf/reg-event ev-id
     (fn [{:keys [db]} _]
       {:db (assoc db :n 2) effect-key payload}))
-  (let [recorded (record-traces! probe-id)]
+  (let [recorded (record-traces! probe-id)
+        records  (record-errors! (keyword (namespace probe-id) (str (name probe-id) "-errors")))]
     (rf/dispatch-sync [ev-id])
-    (let [errs (error-events recorded :rf.error/classification-effect-shape)]
-      (is (= 1 (count errs))
-          (str "exactly one classification-effect-shape error for " effect-key))
-      (is (= effect-key (:offending-key (:tags (first errs))))
-          (str "the diagnostic names " effect-key " as the offending key")))
+    ;; ALWAYS-ON axis (rf2-d2841): every one of the four axes fails loud on the
+    ;; corpus-wide channel, which is the channel a production build has.
+    (let [recs (error-records records :rf.error/classification-effect-shape)]
+      (is (= 1 (count recs))
+          (str "exactly one always-on classification-effect-shape record for " effect-key))
+      (is (= ev-id (:event-id (first recs)))
+          (str "the always-on record attributes the " effect-key " rejection to its event")))
+    ;; rf2-d2841 — `:offending-key` rides the dev-trace tags only. Verbatim.
+    (when interop/debug-enabled?
+      (let [errs (error-events recorded :rf.error/classification-effect-shape)]
+        (is (= 1 (count errs))
+            (str "exactly one classification-effect-shape error for " effect-key))
+        (is (= effect-key (:offending-key (:tags (first errs))))
+            (str "the diagnostic names " effect-key " as the offending key"))))
+    (rf/unregister-listener! :errors (keyword (namespace probe-id) (str (name probe-id) "-errors")))
     (rf/unregister-listener! :trace probe-id))
   (is (= 1 (:n (frame/frame-app-db-value :rf/default)))
       (str "no :db commit happened on the malformed " effect-key " abort")))
@@ -536,13 +605,25 @@
     (rf/reg-event :bad-segment
       (fn [{:keys [db]} _]
         {:db (assoc db :n 2) :sensitive [[(fn [] :nope)]]}))
-    (let [recorded (record-traces! :bad-segment-probe)]
+    (let [recorded (record-traces! :bad-segment-probe)
+          records  (record-errors! :bad-segment-errors)]
       (rf/dispatch-sync [:bad-segment])
-      (let [errs (error-events recorded :rf.error/classification-effect-shape)]
-        (is (= 1 (count errs))
-            "a non-segment path element fails loud as ONE classification-effect-shape error")
-        (is (= :sensitive (:offending-key (:tags (first errs))))
-            "the offending key is named"))
+      ;; ALWAYS-ON axis (rf2-d2841): the whole fail-closed `:rf/path` boundary
+      ;; collapses to ONE record on the corpus channel, not a throw and not a
+      ;; second category.
+      (let [recs (error-records records :rf.error/classification-effect-shape)]
+        (is (= 1 (count recs))
+            "a non-segment path element fails loud as ONE always-on record")
+        (is (empty? (error-records records :rf.error/bad-path))
+            ":rf.error/bad-path is re-reported, not surfaced as its own category"))
+      ;; rf2-d2841 — dev-trace arm.
+      (when interop/debug-enabled?
+        (let [errs (error-events recorded :rf.error/classification-effect-shape)]
+          (is (= 1 (count errs))
+              "a non-segment path element fails loud as ONE classification-effect-shape error")
+          (is (= :sensitive (:offending-key (:tags (first errs))))
+              "the offending key is named")))
+      (rf/unregister-listener! :errors :bad-segment-errors)
       (rf/unregister-listener! :trace :bad-segment-probe))
     (is (= 1 (:n (frame/frame-app-db-value :rf/default)))
         "no :db commit happened on the non-segment-path abort")))

--- a/implementation/core/test/re_frame/core_epoch_egress_profile_test.clj
+++ b/implementation/core/test/re_frame/core_epoch_egress_profile_test.clj
@@ -19,12 +19,37 @@
   registry write a `reg-event` returning `:large` performs) — the same setup
   the epoch artefact's own privacy suite uses. Lives in core's test tree
   because the surface under test is the CORE facade wrapper, not the artefact
-  internals."
+  internals.
+
+  ## Posture split (rf2-d2841)
+
+  Two halves that look like one. The epoch RING is fed from the dev trace
+  stream and `epoch.capture/observe-trace-event!` opens with
+  `(when interop/debug-enabled? ...)`, so under
+  `scripts/test-core-prod-gate.sh` `rf/epoch-history` is empty by construction.
+  The PROJECTION under test is a different animal: `projected-record` is a pure
+  function of a record map plus the frame's DURABLE elision registry, and both
+  of those exist in production.
+
+  Reading the profile claims off the live ring conflated the two, and the
+  conflation was expensive. With the ring empty, `raw` is nil,
+  `large-marker-body` is nil, and SIX assertions passed for that reason alone:
+  `(= default-body obs-body)` (nil = nil), `(not (contains? obs-body :digest))`
+  (nil contains nothing), `(= (dissoc tool-body :digest) obs-body)`, the raw-
+  bytes-never-egress row over an empty string, `(not-any? ... obs-hist)` over an
+  empty history, and the human-sentence check over a nil message. An egress-
+  PRIVACY suite certifying that no raw bytes escaped, having projected nothing.
+
+  So the profile rows now drive a SYNTHETIC record — the same shape the ring
+  holds — and run in both postures. The live-ring rows are kept verbatim inside
+  `(when interop/debug-enabled? ...)` arms as what they always were: the CAPTURE
+  half."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
             [re-frame.error :as error]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.projection :as projection]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
@@ -47,6 +72,17 @@
   nil)
 
 (defn- big-string [n] (apply str (repeat n "X")))
+
+(defn- synthetic-record
+  "A hand-built epoch record of the shape the ring holds (rf2-d2841). The ring
+  is fed from the dev trace stream and is empty under -Dre-frame.debug=false;
+  the PROJECTION being tested is a pure function of the record plus the frame's
+  durable elision registry, so driving it directly exercises the same wrapper
+  code path in BOTH postures."
+  [frame-id payload]
+  {:frame     frame-id
+   :db-before {:blob {:payload nil}}
+   :db-after  {:blob {:payload payload}}})
 
 (defn- large-marker-body
   "The `:rf.size/large-elided` marker body at `[:db-after :blob :payload]` of a
@@ -73,6 +109,37 @@
                     {:db (assoc-in db [:blob :payload] payload)}))
     (rf/dispatch-sync [:store (big-string 50000)] {:frame :ep/main})
 
+    ;; ---- ALWAYS-ON (rf2-d2841): the profile selector, driven on a record
+    ;;      whose existence does not depend on the dev trace stream.
+    (let [synth        (synthetic-record :ep/main (big-string 50000))
+          default-body (large-marker-body (rf/projected-record synth))
+          obs-body     (large-marker-body
+                         (rf/projected-record
+                           synth {:rf.egress/profile :rf.egress/off-box-observability}))
+          tool-body    (large-marker-body
+                         (rf/projected-record
+                           synth {:rf.egress/profile :rf.egress/off-box-tool}))]
+      (is (some? default-body) "the default boundary elides the large slot")
+      (is (some? obs-body)     "the named observability boundary elides it too")
+      (is (some? tool-body)    "the tool boundary elides the large slot")
+      (is (not= 50000 (count (str (get-in (rf/projected-record synth)
+                                          [:db-after :blob :payload]))))
+          "the raw 50KB string never egresses under either off-box boundary")
+      (is (= default-body obs-body)
+          "the bare 1-arity default == :rf.egress/off-box-observability")
+      (is (not (contains? obs-body :digest))
+          ":rf.egress/off-box-observability (through the wrapper) omits :digest")
+      (is (contains? tool-body :digest)
+          ":rf.egress/off-box-tool (through the wrapper) includes the structural
+           :digest — the named selector is honored end-to-end")
+      (is (= (dissoc tool-body :digest) obs-body)
+          "tool boundary == observability marker PLUS the structural digest"))
+
+    ;; ---- rf2-d2841 dev arm: the CAPTURE half — that a real dispatch put a
+    ;;      record of exactly that shape into the ring. The ring is fed from the
+    ;;      dev trace stream (`epoch.capture/observe-trace-event!` is gated), so
+    ;;      it is empty under -Dre-frame.debug=false.
+    (when interop/debug-enabled?
     (let [raw       (last-record :ep/main)
           ;; The bare 1-arity (default observability boundary), through the
           ;; CORE wrapper.
@@ -104,7 +171,7 @@
           ":rf.egress/off-box-tool (through the wrapper) includes the structural
            :digest — the named selector is honored end-to-end")
       (is (= (dissoc tool-body :digest) obs-body)
-          "tool boundary == observability marker PLUS the structural digest"))))
+          "tool boundary == observability marker PLUS the structural digest")))))
 
 (deftest core-projected-record-rejects-unknown-profile
   (testing "rf2-ylvp4m — an unknown :rf.egress/profile through the core wrapper
@@ -113,7 +180,12 @@
     (rf/make-frame {:id :ep/main})
     (rf/reg-event :store (fn [{:keys [db]} [_ v]] {:db (assoc db :v v)}))
     (rf/dispatch-sync [:store 1] {:frame :ep/main})
-    (let [raw  (last-record :ep/main)
+    ;; ALWAYS-ON (rf2-d2841): a closed-enum rejection is a property of the
+    ;; wrapper, not of the ring. Driven on a synthetic record so a typo stays
+    ;; loud in the posture that ships — reading it off the live ring meant that
+    ;; under the gate `raw` was nil, `projected-record` returned nil for a
+    ;; non-map, and NOTHING was rejected at all.
+    (let [raw  (synthetic-record :ep/main "v")
           ex   (try (rf/projected-record raw {:rf.egress/profile :rf.egress/not-real})
                     nil
                     (catch clojure.lang.ExceptionInfo e e))
@@ -144,6 +216,11 @@
             "the epoch throw's ex-data == the shared builder's")))))
 
 (deftest core-projected-history-threads-egress-profile
+  ;; rf2-d2841 — `projected-history` maps `projected-record` over the RING, so
+  ;; it has nothing to thread a profile to under -Dre-frame.debug=false. There
+  ;; is no synthetic stand-in: the ring is the subject. The per-record profile
+  ;; threading it delegates to is covered always-on above. Kept verbatim.
+  (when interop/debug-enabled?
   (testing "rf2-ylvp4m — `rf/projected-history` threads the named
             :rf.egress/profile boundary to every record (the whole-ring
             convenience over `projected-record`)."
@@ -162,4 +239,4 @@
           "every large marker in the tool-profile history carries the :digest")
       (is (not-any? #(contains? (large-marker-body %) :digest)
                     (filter large-marker-body obs-hist))
-          "the default observability history omits the :digest on every record"))))
+          "the default observability history omits the :digest on every record")))))

--- a/implementation/core/test/re_frame/dispatched_trace_cofx_test.clj
+++ b/implementation/core/test/re_frame/dispatched_trace_cofx_test.clj
@@ -24,9 +24,28 @@
   JVM test pins the DEV-SIDE PRESENCE contract (`interop/debug-enabled?` is
   true by default on the JVM).
 
-  JVM-only — the trace-listener mechanism is platform-agnostic."
+  JVM-only — the trace-listener mechanism is platform-agnostic.
+
+  ## Posture split (rf2-d2841)
+
+  The STAMP is dev-gated; the CAUSAL TOKEN it stamps is not. `:rf.cofx` is a
+  slot on the DISPATCH ENVELOPE (`router/build-envelope` calls it the EP-0017
+  recordable-coeffect map), the router fills `:rf/time-ms` there at the causal
+  boundary, and a user fx-handler receives that envelope as `(:envelope m)`
+  — the production surface
+  `cascade-envelope-propagation-test/fx-handler-ctx-carries-envelope-slot`
+  pins. Reading the map off the `:rf.event/dispatched` trace was one way to see
+  it, and the one that disappears under `-Dre-frame.debug=false`.
+
+  So the three CONTENT claims — the framework stamps `:rf/time-ms`, a
+  caller-supplied map rides verbatim, a map missing `:rf/time-ms` has it filled
+  — are now read off the envelope and hold in both postures. What stays
+  inside the `(when interop/debug-enabled? ...)` arms is the narrower claim the
+  trace still owns: that the slot is STAMPED on `:rf.event/dispatched`, under
+  `:tags` rather than at top level, which is what the Xray Event lens reads."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
@@ -62,33 +81,55 @@
 (defn- dispatched-of [evs]
   (filterv #(= :rf.event/dispatched (:operation %)) evs))
 
+;; rf2-d2841 — the ALWAYS-ON read of the same map. `:rf.cofx` lives on the
+;; dispatch envelope; a user fx-handler is handed that envelope verbatim.
+(def ^:private envelopes (atom {}))
+
+(defn- register-probe! []
+  (reset! envelopes {})
+  (rf/reg-fx :rf2-jt854w/probe
+    (fn [m [k]] (swap! envelopes assoc k (:envelope m)))))
+
 ;; ---- the dispatched trace carries :rf.cofx ------------------------
 
 (deftest dispatched-trace-carries-cofx-with-time-ms
   (testing ":rf.event/dispatched carries the envelope's :rf.cofx map,
    and that map carries the framework-stamped causal :time-ms"
-    (rf/reg-event :rf2-jt854w/noop (fn [{:keys [db]} _] {:db db}))
+    (register-probe!)
+    (rf/reg-event :rf2-jt854w/noop
+      (fn [{:keys [db]} _] {:db db :fx [[:rf2-jt854w/probe [:noop]]]}))
     (let [evs        (record-traces
                        (fn [] (rf/dispatch-sync [:rf2-jt854w/noop])))
           [enqueue]  (dispatched-of evs)
           ;; The op-type-specific payload slots (`:rf.event/v`,
           ;; `:rf.event/origin`, `:rf.cofx`, ...) ride under
           ;; `:tags`; `build-event` hoists only `:source` to top-level.
-          rf-cofx    (get-in enqueue [:tags :rf.cofx])]
-      (is (some? enqueue) ":rf.event/dispatched fired")
-      (is (contains? (:tags enqueue) :rf.cofx)
-          ":rf.cofx is stamped on the dispatched trace (rf2-jt854w)")
-      (is (map? rf-cofx) ":rf.cofx is a map")
-      (is (contains? rf-cofx :rf/time-ms)
+          rf-cofx    (get-in enqueue [:tags :rf.cofx])
+          env-cofx   (:rf.cofx (:noop @envelopes))]
+      ;; ---- ALWAYS-ON: the causal token on the envelope -------------------
+      (is (map? env-cofx) ":rf.cofx is a map on the dispatch envelope")
+      (is (contains? env-cofx :rf/time-ms)
           "the recordable-coeffect map carries the framework-stamped :rf/time-ms")
-      (is (integer? (:rf/time-ms rf-cofx))
-          ":rf/time-ms is an epoch-ms integer"))))
+      (is (integer? (:rf/time-ms env-cofx))
+          ":rf/time-ms is an epoch-ms integer")
+      ;; ---- rf2-d2841 dev arm: the STAMP onto the trace -------------------
+      (when interop/debug-enabled?
+        (is (some? enqueue) ":rf.event/dispatched fired")
+        (is (contains? (:tags enqueue) :rf.cofx)
+            ":rf.cofx is stamped on the dispatched trace (rf2-jt854w)")
+        (is (map? rf-cofx) ":rf.cofx is a map")
+        (is (contains? rf-cofx :rf/time-ms)
+            "the recordable-coeffect map carries the framework-stamped :rf/time-ms")
+        (is (integer? (:rf/time-ms rf-cofx))
+            ":rf/time-ms is an epoch-ms integer")))))
 
 (deftest dispatched-trace-preserves-caller-supplied-cofx
   (testing "a caller-supplied :rf.cofx (test/replay/SSR fixture) rides
    onto the dispatched trace verbatim — additional owner-qualified facts
    are preserved alongside the framework-required :rf/time-ms"
-    (rf/reg-event :rf2-jt854w/scripted (fn [{:keys [db]} _] {:db db}))
+    (register-probe!)
+    (rf/reg-event :rf2-jt854w/scripted
+      (fn [{:keys [db]} _] {:db db :fx [[:rf2-jt854w/probe [:scripted]]]}))
     (let [scripted   {:rf/time-ms 1234567890123
                       :todo/id    #uuid "00000000-0000-0000-0000-000000000001"
                       :todo/score 0.42}
@@ -97,26 +138,45 @@
                          (rf/dispatch-sync [:rf2-jt854w/scripted]
                                            {:rf.cofx scripted})))
           [enqueue]  (dispatched-of evs)]
-      (is (some? enqueue) ":rf.event/dispatched fired")
-      (is (= scripted (get-in enqueue [:tags :rf.cofx]))
-          "the caller-supplied causal :rf.cofx map is stamped verbatim"))))
+      ;; ---- ALWAYS-ON: the caller's map reaches the cascade verbatim ------
+      (is (= scripted (:rf.cofx (:scripted @envelopes)))
+          "the caller-supplied causal :rf.cofx map rides the envelope verbatim")
+      ;; ---- rf2-d2841 dev arm --------------------------------------------
+      (when interop/debug-enabled?
+        (is (some? enqueue) ":rf.event/dispatched fired")
+        (is (= scripted (get-in enqueue [:tags :rf.cofx]))
+            "the caller-supplied causal :rf.cofx map is stamped verbatim")))))
 
 (deftest dispatched-trace-fills-missing-time-ms-from-supplied-map
   (testing "a caller-supplied map WITHOUT :rf/time-ms has it filled by the router;
    the dispatched trace reflects the filled-and-preserved map"
-    (rf/reg-event :rf2-jt854w/fill (fn [{:keys [db]} _] {:db db}))
+    (register-probe!)
+    (rf/reg-event :rf2-jt854w/fill
+      (fn [{:keys [db]} _] {:db db :fx [[:rf2-jt854w/probe [:fill]]]}))
     (let [evs        (record-traces
                        (fn []
                          (rf/dispatch-sync [:rf2-jt854w/fill]
                                            {:rf.cofx {:todo/score 0.99}})))
           [enqueue]  (dispatched-of evs)
-          rf-cofx    (get-in enqueue [:tags :rf.cofx])]
-      (is (some? enqueue) ":rf.event/dispatched fired")
-      (is (= 0.99 (:todo/score rf-cofx)) "caller-supplied fact preserved")
-      (is (integer? (:rf/time-ms rf-cofx))
-          ":rf/time-ms filled by the router at the causal boundary"))))
+          rf-cofx    (get-in enqueue [:tags :rf.cofx])
+          env-cofx   (:rf.cofx (:fill @envelopes))]
+      ;; ---- ALWAYS-ON: the FILL happens at the causal boundary, not at the
+      ;;      trace-stamping site — which is the whole point of the claim.
+      (is (= 0.99 (:todo/score env-cofx)) "caller-supplied fact preserved")
+      (is (integer? (:rf/time-ms env-cofx))
+          ":rf/time-ms filled by the router at the causal boundary")
+      ;; ---- rf2-d2841 dev arm --------------------------------------------
+      (when interop/debug-enabled?
+        (is (some? enqueue) ":rf.event/dispatched fired")
+        (is (= 0.99 (:todo/score rf-cofx)) "caller-supplied fact preserved")
+        (is (integer? (:rf/time-ms rf-cofx))
+            ":rf/time-ms filled by the router at the causal boundary")))))
 
 (deftest cofx-rides-under-tags-alongside-event-payload-slots
+ ;; rf2-d2841 — a claim about the TRACE EVENT's SHAPE (which slot is hoisted,
+ ;; which rides under `:tags`), not about the coeffect map, whose content the
+ ;; three deftests above now pin in both postures. Kept verbatim.
+ (when interop/debug-enabled?
   (testing ":rf.cofx rides under :tags alongside the other op-type-
    specific payload slots (:rf.event/v, :rf.event/origin, :rf.event/sync?) —
    build-event hoists only :source to top-level, so the Event lens reads the
@@ -132,4 +192,4 @@
           ":rf.cofx is NOT a top-level slot (only :source is hoisted)")
       ;; Co-located with the other dispatched payload slots under :tags.
       (is (contains? (:tags enqueue) :rf.event/v)
-          ":rf.event/v also rides under :tags — same placement"))))
+          ":rf.event/v also rides under :tags — same placement")))))

--- a/implementation/core/test/re_frame/ep0026_inline_grammar_cljs_test.cljc
+++ b/implementation/core/test/re_frame/ep0026_inline_grammar_cljs_test.cljc
@@ -34,10 +34,28 @@
   Dual-runtime (`-cljs-test` rides `npm run test:cljs`; cognitect-test-runner
   discovers the `.cljc` on the JVM). The four core kind namespaces are required
   so their `:image/lower-inline-<kind>` publishers are installed (they
-  `set-fn!` at ns load); no adapter/runtime state, so no reset fixture."
+  `set-fn!` at ns load); no adapter/runtime state, so no reset fixture.
+
+  ## Posture split (rf2-d2841)
+
+  The grammar itself — which sections lower, which are rejected, which slots the
+  runtime owns — is entirely posture-independent and runs unchanged under
+  `scripts/test-core-prod-gate.sh`. The exception is `:doc`: it is PURE
+  DOCUMENTATION, and `registrar/strip-pure-documentation` removes it under
+  `-Dre-frame.debug=false`, so any row that reads `:doc` back (or compares the
+  authored metadata map WHOLE, `:doc` included) is a dev-posture row and sits
+  inside a `(when interop/debug-enabled? …)` arm.
+
+  Two of those rows were the ONLY witness their claim had, and a doc-only
+  witness is a bad one — it makes the claim unprovable in the posture that
+  ships. Each is now paired with an always-on partner that reads a LOAD-BEARING
+  key instead: `(dissoc meta :doc)` still nested for the hostile-metadata row,
+  and a `:rf.cofx/requires` middle slot for \"a 3-tuple is how metadata is
+  attached\"."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.image          :as image]
             [re-frame.image-assembly :as asm]
+            [re-frame.interop        :as interop]
             ;; Required so the late-bind lowering publishers are installed:
             ;; each ns calls (late-bind/set-fn! :image/lower-inline-<kind> …) at
             ;; load. image-assembly cannot static-require them (a cycle), so the
@@ -123,11 +141,22 @@
       (is (= :sub (:kind d)))
       (is (= :counter/value (:id d)))
       (is (= body (:impl d)))
-      (is (= meta (:metadata d))
-          "the authored metadata remains nested for provenance/introspection")
+      ;; rf2-d2841 — `:doc` is stripped under -Dre-frame.debug=false, so the
+      ;; WHOLE-map comparison and the `:doc` read-back are dev-posture rows.
+      ;; Kept verbatim inside the arm.
+      (when interop/debug-enabled?
+        (is (= meta (:metadata d))
+            "the authored metadata remains nested for provenance/introspection")
+        (is (= "Image-owned counter value." (:doc d))))
+      ;; The always-on half of the same claim: every NON-documentation authored
+      ;; key — including the hostile `:handler-fn` / `:input-kind` /
+      ;; `:input-signals` this deftest is really about — remains nested in both
+      ;; postures, so the "runtime slots win" rows below are contrasted against
+      ;; metadata that is genuinely still there.
+      (is (= (dissoc meta :doc) (dissoc (:metadata d) :doc))
+          "the non-documentation authored metadata remains nested in every posture")
       (is (= :counter/int (:schema d))
           "runtime metadata is also flat, matching reg-sub's runnable shape")
-      (is (= "Image-owned counter value." (:doc d)))
       (is (= body (:handler-fn d))
           "the runtime handler wins over a hostile metadata slot")
       (is (= :db (:input-kind d))
@@ -219,8 +248,22 @@
   (testing "a 3-tuple [id metadata body] is the way to attach metadata"
     (let [body (fn [_ _] {})
           d    (runnable {:reg-event [[:x {:doc "ok"} body]]})]
-      (is (= {:doc "ok"} (:metadata d)))
-      (is (= body (:impl d))))))
+      ;; rf2-d2841 — a doc-ONLY metadata map is the weakest possible witness
+      ;; for this claim: `:doc` is stripped under -Dre-frame.debug=false, so
+      ;; the map reduces to nothing and the row cannot distinguish "the middle
+      ;; slot was read as metadata" from "the middle slot was ignored".
+      ;; Kept verbatim in the arm...
+      (when interop/debug-enabled?
+        (is (= {:doc "ok"} (:metadata d))))
+      (is (= body (:impl d))))
+    ;; ...and given an always-on partner that reads a LOAD-BEARING middle slot,
+    ;; so the grammar claim holds in the posture that ships.
+    (let [body (fn [_ _] {})
+          d    (runnable {:reg-event [[:x {:rf.cofx/requires [:rf.cofx/now]} body]]})]
+      (is (= {:rf.cofx/requires [:rf.cofx/now]} (:metadata d))
+          "the 3-tuple's middle slot is read as metadata in every posture")
+      (is (= body (:impl d))
+          "and the third slot is the handler body, not the metadata"))))
 
 ;; ===========================================================================
 ;; 4. The two grammars compose: a single image carrying all four supported kinds

--- a/implementation/core/test/re_frame/frame_teardown_report_cljs_test.cljc
+++ b/implementation/core/test/re_frame/frame_teardown_report_cljs_test.cljc
@@ -28,11 +28,28 @@
   Dual-runtime: named `*_cljs_test.cljc` so the shadow-cljs `:node-test`
   build (`npm run test:cljs`, `:ns-regexp \"cljs-test$\"`) AND the JVM
   `clojure -M:test` runner both pick it up. The teardown path is plain
-  CLJC; no DOM dependency."
+  CLJC; no DOM dependency.
+
+  ## Posture split (rf2-d2841)
+
+  Legs (a), (b), (c) and the rf2-c80lom no-raw-values property all read the
+  ALWAYS-ON `:errors` axis — which is the whole point of the EP-0008 C4
+  promotion — so they run under `scripts/test-core-prod-gate.sh` unchanged,
+  including the `(empty? @seen)` negatives, which are genuine there because
+  that channel is live.
+
+  Leg (d) is the only dev-posture material, and this file already said so:
+  \"the contract is that they ride the DIAGNOSTIC channel, not that they
+  survive prod\". Its deftest, and the one diagnostic-count row inside
+  `both-channels-fire-together`, are kept verbatim inside
+  `(when interop/debug-enabled? …)` arms. What `both-channels-fire-together`
+  proves in production posture is the half that matters there: ONE bounded
+  report carrying BOTH hook failures, rather than a per-hook flood."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.error-emit :as error-emit]
             [re-frame.late-bind :as late-bind]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -259,6 +276,9 @@
 ;; ===========================================================================
 
 (deftest dev-per-hook-diagnostic-rows-still-emit
+ ;; rf2-d2841 — this deftest IS the diagnostic channel; it has no production
+ ;; residue by design (see the body's own comment). Kept verbatim in the arm.
+ (when interop/debug-enabled?
   (testing "Per rf2-ini4wr EP-0008 R2 / Spec 009: the per-hook
             `:rf.warning/teardown-hook-exception` DIAGNOSTIC trace still
             emits at its causal position inside `safe-call-hook!` (dev
@@ -287,7 +307,7 @@
                (set (map #(get-in % [:tags :hook]) warns)))
             "each diagnostic row names the hook that threw")
         (is (every? #(= :teardown/diagnostic (get-in % [:tags :frame])) warns)
-            "each diagnostic row is frame-attributed")))))
+            "each diagnostic row is frame-attributed"))))))
 
 (deftest both-channels-fire-together
   (testing "Per rf2-ini4wr: a single destroy with failing hooks fires
@@ -311,10 +331,19 @@
       (let [warns   (filter #(= :rf.warning/teardown-hook-exception (:operation %))
                             @traces)
             reps    (filter #(= :rf.error/frame-teardown-failed (:error %)) @reports)]
-        (is (= 2 (count warns)) "diagnostic channel: one per-hook row each")
+        ;; rf2-d2841 — the diagnostic half only exists in dev. The always-on
+        ;; half below is what a production build has, and it carries BOTH
+        ;; failures, which is the promotion this bead pinned.
+        (when interop/debug-enabled?
+          (is (= 2 (count warns)) "diagnostic channel: one per-hook row each"))
         (is (= 1 (count reps)) "always-on channel: ONE bounded report")
         (is (= 2 (count (:hook-failures (first reps))))
-            "the single report carries both hook failures")))))
+            "the single report carries both hook failures")
+        (is (= #{:ssr/on-frame-destroyed :schemas/on-frame-destroyed!}
+               (set (map :hook (:hook-failures (first reps)))))
+            "and names BOTH hooks on the always-on axis — the per-hook detail
+             the diagnostic channel carries is not lost in production, it is
+             folded into the one report")))))
 
 ;; ===========================================================================
 ;; (e) No-raw-values property of the always-on report (rf2-c80lom)

--- a/implementation/core/test/re_frame/fx_aggregate_classification_cljs_test.cljc
+++ b/implementation/core/test/re_frame/fx_aggregate_classification_cljs_test.cljc
@@ -30,12 +30,34 @@
 
   Dual-runtime `*_cljs_test.cljc`: the shadow `:node-test` build
   (`npm run test:cljs`, `cljs-test$` ns-regexp) AND the JVM `clojure -M:test`
-  runner both run it (http + machines ride core's test-only classpath)."
+  runner both run it (http + machines ride core's test-only classpath).
+
+  ## Posture split (rf2-d2841)
+
+  Section A is the chokepoint under a microscope — `project-trace-event` driven
+  on hand-built shapes — and needs no trace stream at all, so ALL of it runs
+  under `scripts/test-core-prod-gate.sh` unchanged. That is where the teeth are.
+
+  Section B's live round-trips read the DEV TRACE stream, which emits nothing
+  under `-Dre-frame.debug=false`. Their trace-reading steps are kept verbatim
+  inside `(when interop/debug-enabled? …)` arms — INCLUDING the two closing
+  whole-stream sweeps. Those sweeps are the reason the arm wraps the trace half
+  as a block: `(is (not (some #(leaks? pw-sentinel %) @traces)))` over an EMPTY
+  `@traces` is a redaction suite reporting green for having emitted nothing,
+  the exact false-green shape rf2-d2841's third pass found in the two
+  `machine-*-classification` suites.
+
+  What stays OUTSIDE the arm is each round-trip's step 1 — the handler / fx
+  body receiving the RAW value. Redaction here is EGRESS-ONLY, so that step is
+  posture-independent, it is the half of the contract a production build
+  actually executes, and without it \"the sentinel appears nowhere\" would be
+  satisfied by a cascade that never carried the sentinel in the first place."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [clojure.string :as str]
             [re-frame.classification :as classification]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             ;; Boot the optional http artefact so the
             ;; `:http/project-managed-fx-args` hook is bound (published at
             ;; `re-frame.http.managed` load — the artefact's load-time anchor).
@@ -195,9 +217,14 @@
         (rf/unregister-listener! :trace ::probe)
 
         ;; 1. control flow untouched — the target handler read the raw secret.
+        ;;    ALWAYS-ON (rf2-d2841): egress-only redaction, and the proof that
+        ;;    the secret was ever in flight.
         (is (= pw-sentinel @captured)
             "the target handler received the RAW secret (egress-only redaction)")
 
+       ;; rf2-d2841 — steps 2-5 read the dev trace stream; step 5's sweep would
+       ;; certify "no leak" over an empty `@traces`. Kept verbatim in the arm.
+       (when interop/debug-enabled?
         ;; 2. the parent's :rf.event/fx aggregate redacts the nested payload.
         (let [entries (for [ev    @traces
                             :let  [fx-vec (get-in ev [:tags :rf.event/fx])]
@@ -232,7 +259,7 @@
 
         ;; 5. the whole-stream sweep — the secret appears NOWHERE.
         (is (not (some #(leaks? pw-sentinel %) @traces))
-            "no emitted trace event leaks the secret sentinel")))))
+            "no emitted trace event leaks the secret sentinel"))))))
 
 (deftest live-managed-http-dynamic-flag-redacts-in-aggregate
   (testing "GAP (b) acceptance: a handler combining [:dispatch [bare]] with a
@@ -263,9 +290,13 @@
         (rf/unregister-listener! :trace ::probe)
 
         ;; 1. the fx body received the RAW body (egress-only redaction).
+        ;;    ALWAYS-ON (rf2-d2841) — see step 1 of the deftest above.
         (is (= pw-sentinel (get-in (first @http) [:request :body :password]))
             "the managed fx received the RAW password")
 
+       ;; rf2-d2841 — steps 2-4 read the dev trace stream; step 4's sweep would
+       ;; certify "no leak" over an empty `@traces`. Kept verbatim in the arm.
+       (when interop/debug-enabled?
         ;; 2. the :rf.event/fx aggregate redacts the managed entry's body.
         (let [entries (for [ev    @traces
                             :let  [fx-vec (get-in ev [:tags :rf.event/fx])]
@@ -291,4 +322,4 @@
 
         ;; 4. whole-stream sweep.
         (is (not (some #(leaks? pw-sentinel %) @traces))
-            "no emitted trace event leaks the password sentinel")))))
+            "no emitted trace event leaks the password sentinel"))))))

--- a/implementation/core/test/re_frame/fx_args_trace_egress_cljs_test.cljc
+++ b/implementation/core/test/re_frame/fx_args_trace_egress_cljs_test.cljc
@@ -11,10 +11,10 @@
     1. `:rf.event/fx` on the `:rf.fx/do-fx` trace — the handler's WHOLE returned
        effect vector, stamped raw. (The projector walked the sibling
        `:rf.event/db` slot but not this one.)
-    2. `:rf.fx/args` on the ALWAYS-ON fx error traces
-       (`:rf.error/fx-handler-exception` + siblings). The more serious of the
-       two: that trace is production-survivable — it fans out through the
-       always-on error-emit listener, not just the dev trace.
+    2. `:rf.fx/args` on the fx error traces (`:rf.error/fx-handler-exception` +
+       siblings). The more serious of the two: those CATEGORIES are promoted
+       onto the always-on axis, so the failure itself reaches production
+       observability.
 
   This suite is the adversarial regression: it drives a `reg-fx` declaring
   `{:sensitive [[:token]]}` through a SUCCESS arm and an ERROR arm and pins the
@@ -24,11 +24,47 @@
 
   Dual-runtime `.cljc` (`*-cljs-test` ns): the shadow-cljs `:node-test` build
   (`npm run test:cljs`) AND the JVM `clojure -M:test` runner both pick it up —
-  traces fire in both runtimes (`goog.DEBUG` / JVM `debug-enabled?` default on)."
+  traces fire in both runtimes (`goog.DEBUG` / JVM `debug-enabled?` default on).
+
+  ## Posture split (rf2-d2841)
+
+  A CORRECTION TO THIS FILE'S OWN PREMISE FIRST. The `.2` bullet above used to
+  read \"that trace is production-survivable — it fans out through the always-on
+  error-emit listener, not just the dev trace\", and used that to call the error
+  arm the more serious of the two slots. The CATEGORY is promoted; the SLOT is
+  not. `fx.cljc`'s `:rf.error/no-such-fx` site says so in as many words —
+  \"the tight-record discipline is intact: `:rf.fx/args` stays on the dev trace
+  and does NOT reach the production record\" — and `error-emit/emit-error-both!`
+  lifts only `:failing-id` / `:reason` out of the trace tags onto the always-on
+  record. So `:rf.fx/args` is a DEV-TRACE slot on both arms, and there is no
+  `:errors`-stream re-aim available for it the way there was for `fx-test`'s
+  `:reason` (rf2-d2841 pass 2). Checked against the source, not the story.
+
+  Consequently both live arms read a channel that emits nothing under
+  `-Dre-frame.debug=false`, and both are kept VERBATIM — sweeps included —
+  inside `(when interop/debug-enabled? …)` arms. The whole-stream sweeps are
+  the reason the arm is drawn around the WHOLE body rather than around the
+  failing rows: `(is (not (contains-sentinel? v)))` over an empty stream is a
+  redaction suite certifying itself green having emitted nothing.
+
+  What stays ALWAYS-ON is what makes the guarded rows mean something:
+
+    * the classified fx BODIES receive the RAW token — redaction is
+      egress-only, and a suite that proved absence without proving the secret
+      was ever in flight would be pinning nothing;
+    * the registration owns its `[:token]` declaration (`:sensitive` is
+      load-bearing metadata, NOT pure documentation, so it survives the strip);
+    * `classification/project-trace-event` — the rf2-6h3c02 chokepoint itself —
+      redacts both fx-arg-bearing slot shapes and leaves the control fx raw,
+      driven deterministically on hand-built shapes. That is the same
+      \"projector teeth\" pattern `fx-aggregate-classification-cljs-test` and
+      `fx-redirect-classification-cljs-test` use for their section A, and it is
+      what this file had NO always-on counterpart to before."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
             [re-frame.classification :as classification]
+            [re-frame.interop :as interop]
             [re-frame.privacy :as privacy]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as ts]))
@@ -43,19 +79,27 @@
 
 (def ^:private frame-id :fx-args-egress/frame)
 
+;; What the fx BODIES actually received. Redaction is EGRESS-ONLY, so these are
+;; the always-on control: the token must be in flight for its absence from the
+;; trace slots to mean anything (rf2-d2841).
+(def ^:private body-args (atom {}))
+
 (defn- register! []
+  (reset! body-args {})
   (rf/make-frame {:id frame-id})
   ;; A CLASSIFIED fx — its own registration declares [:token] sensitive.
   (rf/reg-fx :fx-args/store {:sensitive [[:token]]}
-    (fn [_ _] nil))
+    (fn [_ args] (swap! body-args assoc :fx-args/store args) nil))
   ;; A CLASSIFIED fx that THROWS — to exercise the error-arm :rf.fx/args slot
-  ;; carried by :rf.error/fx-handler-exception (production-survivable).
+  ;; carried by :rf.error/fx-handler-exception.
   (rf/reg-fx :fx-args/store-throwing {:sensitive [[:token]]}
-    (fn [_ _] (throw (ex-info "fx blew up" {}))))
+    (fn [_ args]
+      (swap! body-args assoc :fx-args/store-throwing args)
+      (throw (ex-info "fx blew up" {}))))
   ;; A NON-sensitive control fx — its args must ride RAW (guard against
   ;; over-redaction of unclassified fx).
   (rf/reg-fx :fx-args/audit
-    (fn [_ _] nil))
+    (fn [_ args] (swap! body-args assoc :fx-args/audit args) nil))
   ;; SUCCESS event: returns both the classified store fx and the control fx.
   (rf/reg-event :fx-args/succeed
     (fn [_ _]
@@ -87,7 +131,23 @@
 ;; the control fx rides raw.
 ;; ---------------------------------------------------------------------------
 
+(deftest success-arm-bodies-receive-raw-args
+  (testing "ALWAYS-ON control (rf2-d2841): redaction is EGRESS-ONLY, so both the
+            classified fx and the control fx receive their args RAW — the token
+            IS in flight, which is what makes its absence from the trace slots
+            below a fact rather than a vacuum"
+    (register!)
+    (rf/dispatch-sync [:fx-args/succeed] {:frame frame-id})
+    (is (= {:token sentinel} (:fx-args/store @body-args))
+        "the classified fx body received the RAW token")
+    (is (= {:msg "a benign audit line"} (:fx-args/audit @body-args))
+        "the control fx body received its args unchanged")))
+
 (deftest success-arm-redacts-classified-fx-args-in-every-slot
+ ;; rf2-d2841 — every row below reads the DEV TRACE stream. Under
+ ;; -Dre-frame.debug=false nothing is emitted, and the whole-stream sweep at
+ ;; the end would then certify "no leak" over an empty stream. Kept verbatim.
+ (when interop/debug-enabled?
   (testing "a classified fx's token is redacted in BOTH the :rf.event/fx
             aggregate (on :rf.fx/do-fx) AND the per-effect :rf.fx/handled slot,
             while the non-sensitive control fx rides raw"
@@ -132,16 +192,28 @@
           (swap! checked inc)
           (is (not (contains-sentinel? v))
               (str "the token must not appear raw in " (:operation ev))))
-        (is (pos? @checked) "the sweep actually inspected trace tags")))))
+        (is (pos? @checked) "the sweep actually inspected trace tags"))))))
 
 ;; ---------------------------------------------------------------------------
-;; ERROR arm — the production-survivable :rf.error/fx-handler-exception carries
-;; :rf.fx/args; it must redact the classified token.
+;; ERROR arm — :rf.error/fx-handler-exception carries :rf.fx/args; it must
+;; redact the classified token. The CATEGORY is always-on; the `:rf.fx/args`
+;; SLOT rides the dev trace only (see the ns docstring's correction).
 ;; ---------------------------------------------------------------------------
+
+(deftest error-arm-body-receives-raw-args
+  (testing "ALWAYS-ON control (rf2-d2841): the throwing classified fx also
+            receives its args RAW before it throws"
+    (register!)
+    (rf/dispatch-sync [:fx-args/fail] {:frame frame-id})
+    (is (= {:token sentinel} (:fx-args/store-throwing @body-args))
+        "the throwing fx body received the RAW token")))
 
 (deftest error-arm-redacts-fx-args-on-fx-handler-exception
+ ;; rf2-d2841 — dev-trace stream; the trailing `contains-sentinel?` negative
+ ;; would pass over an empty stream. Kept verbatim inside the arm.
+ (when interop/debug-enabled?
   (testing "when a classified fx throws, :rf.error/fx-handler-exception redacts
-            its :rf.fx/args :token (the always-on, production-survivable slot)"
+            its :rf.fx/args :token"
     (register!)
     (let [acc (collect-traces! ::error)]
       (rf/dispatch-sync [:fx-args/fail] {:frame frame-id})
@@ -157,7 +229,7 @@
           (is (= :fx-args/store-throwing (get-in ev [:tags :rf.fx/id]))
               "shape retained — the fx-id survives")
           (is (not (contains-sentinel? (:tags ev)))
-              "the token appears nowhere raw in the error trace tags"))))))
+              "the token appears nowhere raw in the error trace tags")))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The registration owns its classification (what the projector consumes).
@@ -169,4 +241,65 @@
     (register!)
     (is (= {:sensitive [[:token]]}
            (classification/registration-classification :fx :fx-args/store))
-        ":fx-args/store owns [:token]")))
+        ":fx-args/store owns [:token]")
+    (is (nil? (classification/registration-classification :fx :fx-args/audit))
+        "the control fx declares nothing — precision, not blanket redaction")))
+
+;; ---------------------------------------------------------------------------
+;; ALWAYS-ON projector teeth (rf2-d2841) — the rf2-6h3c02 chokepoint itself,
+;; driven deterministically on the two fx-arg-bearing slot SHAPES rather than
+;; through the dev trace stream. Runs in BOTH postures, so the regression this
+;; file exists for is pinned under `scripts/test-core-prod-gate.sh` too.
+;;
+;; Same pattern as `fx-aggregate-classification-cljs-test` §A and
+;; `fx-redirect-classification-cljs-test` §A; this file previously had no
+;; always-on counterpart at all.
+;; ---------------------------------------------------------------------------
+
+(defn- project [ev] (:tags (classification/project-trace-event ev)))
+
+(deftest projector-redacts-the-do-fx-aggregate-slot
+  (testing "the :rf.event/fx aggregate on :rf.fx/do-fx — the slot rf2-6h3c02
+            added to the walk — redacts the classified entry's declared path
+            while the control entry rides raw"
+    (register!)
+    (let [t      (project {:operation :rf.fx/do-fx
+                           :tags {:frame       frame-id
+                                  :rf.event/fx [[:fx-args/store {:token sentinel}]
+                                                [:fx-args/audit {:msg "a benign audit line"}]]}})
+          fx-vec (:rf.event/fx t)
+          store  (first (filter #(= :fx-args/store (first %)) fx-vec))
+          audit  (first (filter #(= :fx-args/audit (first %)) fx-vec))]
+      (is (= privacy/redacted-sentinel (get-in store [1 :token]))
+          "the classified fx's :token reads :rf/redacted in :rf.event/fx")
+      (is (= :fx-args/store (first store)) "shape retained — the fx-id survives")
+      (is (= {:msg "a benign audit line"} (second audit))
+          "the NON-sensitive control fx rides RAW (no over-redaction)")
+      (is (not (contains-sentinel? t))
+          "the token appears nowhere in the projected aggregate"))))
+
+(deftest projector-redacts-the-per-effect-args-slot-on-every-op
+  (testing "the [:rf.fx/id :rf.fx/args] pair redacts on the success op AND on
+            the fx error ops that carry the same pair"
+    (register!)
+    (doseq [op [:rf.fx/handled :rf.error/fx-handler-exception
+                :rf.fx/skipped-on-platform]]
+      (let [t (project {:operation op
+                        :tags {:frame      frame-id
+                               :rf.fx/id   :fx-args/store
+                               :rf.fx/args {:token sentinel :note "plain"}}})]
+        (is (= privacy/redacted-sentinel (get-in t [:rf.fx/args :token]))
+            (str op " redacts the declared :token path"))
+        (is (= "plain" (get-in t [:rf.fx/args :note]))
+            (str op " keeps the non-secret sibling (path-precise)"))
+        (is (= :fx-args/store (:rf.fx/id t)) "shape retained — the fx-id survives")
+        (is (not (contains-sentinel? t)) (str op " leaks no token")))))
+  (testing "precision: the unclassified control fx's args ride raw on the same
+            slot shape (the documented fail-open)"
+    (register!)
+    (let [t (project {:operation :rf.fx/handled
+                      :tags {:frame      frame-id
+                             :rf.fx/id   :fx-args/audit
+                             :rf.fx/args {:token sentinel}}})]
+      (is (= sentinel (get-in t [:rf.fx/args :token]))
+          "no declaration, no redaction — precision over blanket scrubbing"))))

--- a/implementation/core/test/re_frame/fx_redirect_classification_cljs_test.cljc
+++ b/implementation/core/test/re_frame/fx_redirect_classification_cljs_test.cljc
@@ -24,12 +24,33 @@
 
   Dual-runtime `*_cljs_test.cljc`: the shadow `:node-test` build
   (`npm run test:cljs`) AND the JVM `clojure -M:test` runner both run it
-  (http rides core's test-only classpath)."
+  (http rides core's test-only classpath).
+
+  ## Posture split (rf2-d2841)
+
+  Section A drives `project-trace-event` on hand-built shapes and needs no
+  trace stream, so all of it — the composition of the original id's static
+  paths with the target's, the dynamic `:sensitive?` case, and the fail-open
+  precision rows — runs under `scripts/test-core-prod-gate.sh` unchanged.
+
+  Section B's live round-trips read the DEV TRACE stream. Their trace-reading
+  steps sit verbatim inside `(when interop/debug-enabled? …)` arms, sweeps
+  included: `(is (not (some #(leaks? pw-sentinel %) @traces)))` over an EMPTY
+  `@traces` passes for free, and a redirect-redaction suite that certifies
+  itself green having emitted nothing is worse than no suite.
+
+  Each round-trip's step 1 stays OUTSIDE the arm, and it is the strongest
+  production claim this file makes: the KEYWORD REDIRECT ITSELF still happens
+  and the target still receives the args RAW. `::stub` capturing the raw token,
+  and the canned success reply reaching `:on-success`, prove the redirect
+  resolved and the cascade completed — in the posture that ships, where the
+  provenance tag that names the redirect is invisible."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [clojure.string :as str]
             [re-frame.classification :as classification]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             ;; Boot the optional http artefact so the
             ;; `:http/project-managed-fx-args` hook is bound…
             [re-frame.http.managed]
@@ -164,9 +185,17 @@
         (rf/unregister-listener! :trace ::probe)
 
         ;; 1. control flow untouched — the stub received the raw token.
+        ;;    ALWAYS-ON (rf2-d2841): this row alone proves the keyword redirect
+        ;;    RESOLVED (`::stub` ran, not `::orig`) and that redaction is
+        ;;    egress-only. It is the production half of the whole scenario.
         (is (= pw-sentinel (:token @got))
             "the redirect target received the RAW token (egress-only redaction)")
+        (is (= "plain" (:note @got))
+            "and the non-secret sibling too — the body sees the args verbatim")
 
+       ;; rf2-d2841 — steps 2-4 read the dev trace stream; step 4's sweep would
+       ;; certify "no leak" over an empty `@traces`. Kept verbatim in the arm.
+       (when interop/debug-enabled?
         ;; 2. the stub's own handled slot stamps provenance + redacts.
         (let [handled (filter #(= ::stub (get-in % [:tags :rf.fx/id])) @traces)]
           (is (seq handled) "the stub emitted a :rf.fx/handled trace")
@@ -193,7 +222,7 @@
 
         ;; 4. whole-stream sweep — the token appears NOWHERE.
         (is (not (some #(leaks? pw-sentinel %) @traces))
-            "no emitted trace event leaks the token sentinel")))))
+            "no emitted trace event leaks the token sentinel"))))))
 
 (deftest live-canned-stub-redirect-redacts-sensitive-managed-request
   (testing "rf2-2siusz acceptance: a :sensitive? true :rf.http/managed request
@@ -222,9 +251,15 @@
         (rf/unregister-listener! :trace ::probe)
 
         ;; 1. control — the canned stub actually ran and replied.
+        ;;    ALWAYS-ON (rf2-d2841): the redirect resolved to the framework
+        ;;    canned stub, the stub ran, and its reply completed the cascade —
+        ;;    all of it true in the posture that ships.
         (is (= {:status :ok :value {:ok true}} @reply)
             "the canned success reply reached the :on-success target")
 
+       ;; rf2-d2841 — steps 2-4 read the dev trace stream; step 4's sweep would
+       ;; certify "no leak" over an empty `@traces`. Kept verbatim in the arm.
+       (when interop/debug-enabled?
         ;; 2. the stub's own handled slot: provenance + dynamic redaction.
         (let [handled (filter #(= :rf.http/managed-canned-success
                                   (get-in % [:tags :rf.fx/id]))
@@ -250,4 +285,4 @@
 
         ;; 4. whole-stream sweep — the password appears NOWHERE.
         (is (not (some #(leaks? pw-sentinel %) @traces))
-            "no emitted trace event leaks the password sentinel")))))
+            "no emitted trace event leaks the password sentinel"))))))

--- a/implementation/core/test/re_frame/image_inline_metadata_normalization_cljs_test.cljc
+++ b/implementation/core/test/re_frame/image_inline_metadata_normalization_cljs_test.cljc
@@ -32,7 +32,27 @@
   namespaces are required so their `:image/lower-inline-<kind>` publishers are
   installed (they `set-fn!` at ns load); image-assembly cannot static-require
   them (a cycle), so the test requires them directly to exercise the LIVE
-  lowering."
+  lowering.
+
+  ## Posture split (rf2-d2841)
+
+  Section 1's SUBJECT is the dev half of the contract — authored `:doc`
+  surviving for tooling — and it is unreachable under
+  `scripts/test-core-prod-gate.sh`, where `interop/debug-enabled?` is already
+  false at load and `registrar/strip-pure-documentation` has removed `:doc`
+  before the descriptor is built. The two `:doc` rows are therefore kept
+  verbatim inside a `(when interop/debug-enabled? …)` arm.
+
+  Everything else in section 1 is posture-independent and STAYS OUTSIDE it —
+  the `:kind` echo, the load-bearing `[:audit]` witness key nested and (for the
+  spreading kinds) hoisted, and the runnable `:handler-fn` slot. Those are what
+  make sections 2 and 3 mean something: without them \"no `:doc` anywhere\"
+  would also be satisfied by a lowering that produced nothing at all.
+
+  Sections 2 and 3 run in BOTH postures unchanged. Their
+  `with-redefs [interop/debug-enabled? false]` is a no-op under the real gate
+  (the var is already false) and the assertions are the production claim
+  itself, so they are load-bearing on both sides."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.image          :as image]
             [re-frame.image-assembly :as asm]
@@ -85,14 +105,18 @@
       (let [d (assemble section (keyword "counter" (str label "-doc"))
                         {:doc "author note" :tags [:audit]} body)]
         (is (= kind (:kind d)) "kind is preserved")
-        (is (= "author note" (get-in d [:metadata :doc]))
-            "nested [:metadata :doc] retained in dev")
+        ;; rf2-d2841 — `:doc` retention is the DEV half of the contract, elided
+        ;; at source under -Dre-frame.debug=false. Kept verbatim.
+        (when interop/debug-enabled?
+          (is (= "author note" (get-in d [:metadata :doc]))
+              "nested [:metadata :doc] retained in dev"))
         (is (= [:audit] (get-in d [:metadata :tags]))
             "the load-bearing witness key is nested")
         (is (fn? (:handler-fn d)) "the runnable :handler-fn slot is installed")
         (when spreads-meta?
-          (is (= "author note" (:doc d))
-              "kinds that spread metadata carry :doc at the top level too in dev")
+          (when interop/debug-enabled?
+            (is (= "author note" (:doc d))
+                "kinds that spread metadata carry :doc at the top level too in dev"))
           (is (= [:audit] (:tags d))
               "and the load-bearing witness key at the top level"))))))
 

--- a/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
+++ b/implementation/core/test/re_frame/live_frame_reload_cljs_test.cljc
@@ -1022,11 +1022,18 @@
                    (:handler-fn (asm/resolve-descriptor
                                   (lf/frame-generation (lf/live-frame :rpf-good/main))
                                   :event :rpf-good/inc)))))
-          (testing "the bad frame's failure was DIAGNOSED (not a silent black
-                    hole) via a :rf.warning/reprojection-failed trace event
-                    naming the frame"
-            (is (= 1 (count @diagnosed)))
-            (is (= :rpf-bad/main (get-in (first @diagnosed) [:tags :frame])))))
+          ;; rf2-d2841 — `:rf.warning/reprojection-failed` rides the DIAGNOSTIC
+          ;; channel and emits nothing under -Dre-frame.debug=false. The
+          ;; production-visible half of the same claim is the assertion above:
+          ;; the sweep REACHED the good frame despite the bad frame throwing,
+          ;; which is the mid-sweep-abort defect this case exists for. Kept
+          ;; verbatim.
+          (when interop/debug-enabled?
+            (testing "the bad frame's failure was DIAGNOSED (not a silent black
+                      hole) via a :rf.warning/reprojection-failed trace event
+                      naming the frame"
+              (is (= 1 (count @diagnosed)))
+              (is (= :rpf-bad/main (get-in (first @diagnosed) [:tags :frame]))))))
         (finally
           (with-redefs [interop/next-tick (fn [_f] nil)]
             (reset! frame/frames {})

--- a/implementation/core/test/re_frame/override_capture_trace_test.clj
+++ b/implementation/core/test/re_frame/override_capture_trace_test.clj
@@ -18,9 +18,37 @@
       opt, same precedence as the live override-application path.
     * `:interceptor-overrides` rides verbatim (EDN by construction).
     * The PER-FRAME override tier is excluded — only the envelope's own
-      per-call + lexical keys are captured (per the ruling's pinned scope)."
+      per-call + lexical keys are captured (per the ruling's pinned scope).
+
+  ## Posture split (rf2-d2841)
+
+  What is captured, and where from, are two claims. `:fx-overrides` /
+  `:interceptor-overrides` are slots on the DISPATCH ENVELOPE that
+  `build-envelope` composes (per-call opt merged over the lexical
+  `*fx-overrides*` binding), and a user fx-handler is handed that envelope as
+  `(:envelope m)` — the production surface
+  `cascade-envelope-propagation-test/fx-handler-ctx-carries-envelope-slot`
+  pins. So the COMPOSITION claims — a keyword entry rides, the lexical
+  binding merges in UNDER the per-call opt, per-call wins on a key collision,
+  the per-frame tier is excluded — are read off the envelope and hold in both
+  postures.
+
+  What the trace genuinely owns, and what therefore sits inside
+  `(when interop/debug-enabled? ...)` arms, is the CAPTURE: the tag rides
+  `:rf.event/run-start`, and a fn-valued override is MARKER-IZED to
+  `:rf/fn-override` at the emission site so the fn never reaches the tag. That
+  marker-ization exists only on the emit path; the envelope holds the raw fn,
+  which is exactly why the marker is worth asserting.
+
+  Two vacuous passes were found and moved. `override-free-dispatch-omits-both-tags`
+  is a pair of `(not (contains? tags ...))` rows, and under the gate `tags` is
+  nil — `contains?` of nil is false for every key, so both certified
+  \"absent\" over an event that never existed. They now sit in the arm, beside a
+  new always-on partner asserting the ENVELOPE omits the keys, which is the
+  claim that survives."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
@@ -45,82 +73,140 @@
     (rf/register-listener! :trace id (fn [ev] (swap! acc conj ev)))
     acc))
 
+;; rf2-d2841 — the ALWAYS-ON read. The override maps the trace CAPTURES are
+;; slots on the dispatch envelope, and a user fx-handler receives the envelope
+;; verbatim, so the composition can be inspected with no trace involvement.
+(def ^:private captured-envelope (atom nil))
+
 (defn- run-start-tags
-  "Register the shared `:ovc/run` no-op handler (each `:each` fixture wipes
-  the registrar via `registrar/clear-all!`, so this must be re-registered
-  per call, not once at namespace load), dispatch `event-v` (with optional
-  `dispatch-opts`), and return the single `:rf.event/run-start` trace
-  event's `:tags` map."
+  "Register the shared `:ovc/run` handler (each `:each` fixture wipes the
+  registrar via `registrar/clear-all!`, so this must be re-registered per call,
+  not once at namespace load), dispatch `event-v` (with optional
+  `dispatch-opts`), and return the single `:rf.event/run-start` trace event's
+  `:tags` map — nil in production posture, where nothing is emitted.
+
+  Side effect (rf2-d2841): the handler runs an `:ovc/probe` fx that stashes the
+  dispatch ENVELOPE in `captured-envelope`, so the caller can read the same
+  override maps off the always-on surface."
   ([event-v] (run-start-tags event-v nil))
   ([event-v dispatch-opts]
-   (rf/reg-event :ovc/run (fn [{:keys [db]} _] {:db db}))
+   (reset! captured-envelope nil)
+   (rf/reg-fx :ovc/probe (fn [m _] (reset! captured-envelope (:envelope m))))
+   (rf/reg-event :ovc/run
+     (fn [{:keys [db]} _] {:db db :fx [[:ovc/probe]]}))
    (let [acc (collect-traces! ::cap)]
      (try
        (if dispatch-opts
          (rf/dispatch-sync event-v dispatch-opts)
          (rf/dispatch-sync event-v))
        (let [run-starts (filterv #(= :rf.event/run-start (:operation %)) @acc)]
-         (is (= 1 (count run-starts))
-             "exactly one :rf.event/run-start emit per dispatch")
+         (when interop/debug-enabled?
+           (is (= 1 (count run-starts))
+               "exactly one :rf.event/run-start emit per dispatch"))
          (:tags (first run-starts)))
        (finally
          (rf/unregister-listener! :trace ::cap))))))
 
 (deftest override-free-dispatch-omits-both-tags
   (testing "no per-call overrides => neither tag rides the run-start emit"
-    (let [tags (run-start-tags [:ovc/run])]
-      (is (not (contains? tags :rf.event/fx-overrides)))
-      (is (not (contains? tags :rf.event/interceptor-overrides))))))
+    (let [tags (run-start-tags [:ovc/run])
+          env  @captured-envelope]
+      ;; ---- ALWAYS-ON (rf2-d2841): the ENVELOPE carries no override maps ----
+      (is (some? env) "the dispatch envelope reached the fx-handler ctx")
+      (is (empty? (:fx-overrides env))
+          "an override-free dispatch composes no :fx-overrides at all")
+      (is (empty? (:interceptor-overrides env))
+          "nor any :interceptor-overrides")
+      ;; ---- rf2-d2841 dev arm. VACUOUS OUTSIDE IT: under the gate `tags` is
+      ;;      nil and `(contains? nil k)` is false for every key, so both rows
+      ;;      would certify "absent" over an emit that never happened.
+      (when interop/debug-enabled?
+        (is (not (contains? tags :rf.event/fx-overrides)))
+        (is (not (contains? tags :rf.event/interceptor-overrides)))))))
 
 (deftest keyword-valued-fx-override-rides-verbatim
   (testing "an id-valued per-call :fx-overrides entry rides the run-start tag
    verbatim"
     (let [tags (run-start-tags [:ovc/run]
                                {:fx-overrides {:ovc/real :ovc/stub}})]
-      (is (= {:ovc/real :ovc/stub} (:rf.event/fx-overrides tags))))))
+      ;; ALWAYS-ON (rf2-d2841): the composed envelope IS the thing captured.
+      (is (= {:ovc/real :ovc/stub} (:fx-overrides @captured-envelope))
+          "the id-redirect composes onto the dispatch envelope")
+      (when interop/debug-enabled?
+        (is (= {:ovc/real :ovc/stub} (:rf.event/fx-overrides tags)))))))
 
 (deftest fn-valued-fx-override-is-marker-ized
   (testing "a fn-valued per-call :fx-overrides entry is marker-ized to
    :rf/fn-override at the emission site — the fn never rides the tag"
     (let [tags (run-start-tags [:ovc/run]
                                {:fx-overrides {:ovc/real (fn [_ _] :ran)}})]
-      (is (= {:ovc/real :rf/fn-override} (:rf.event/fx-overrides tags))))))
+      ;; ALWAYS-ON (rf2-d2841): the ENVELOPE holds the RAW fn — which is
+      ;; precisely why marker-izing it at the emission site is worth pinning.
+      (is (fn? (:ovc/real (:fx-overrides @captured-envelope)))
+          "the envelope carries the fn value itself")
+      ;; rf2-d2841 — the marker-ization exists only on the emit path.
+      (when interop/debug-enabled?
+        (is (= {:ovc/real :rf/fn-override} (:rf.event/fx-overrides tags)))))))
 
 (deftest lexical-with-fx-overrides-merges-under-per-call
   (testing "rf/with-fx-overrides's lexical binding merges into the captured
    :fx-overrides, same precedence as the live override-application path"
     (let [tags (rf/with-fx-overrides {:ovc/lexical :ovc/lexical-stub}
                  (run-start-tags [:ovc/run]))]
-      (is (= {:ovc/lexical :ovc/lexical-stub} (:rf.event/fx-overrides tags))))
+      ;; ALWAYS-ON (rf2-d2841): the MERGE is envelope composition, not a
+      ;; trace-side reconstruction.
+      (is (= {:ovc/lexical :ovc/lexical-stub}
+             (:fx-overrides @captured-envelope))
+          "the lexical binding merges onto the dispatch envelope")
+      (when interop/debug-enabled?
+        (is (= {:ovc/lexical :ovc/lexical-stub} (:rf.event/fx-overrides tags)))))
     (testing "per-call wins over lexical on key collision"
       (let [tags (rf/with-fx-overrides {:ovc/dual :ovc/from-lexical}
                    (run-start-tags [:ovc/run]
                                    {:fx-overrides {:ovc/dual :ovc/from-call}}))]
-        (is (= {:ovc/dual :ovc/from-call} (:rf.event/fx-overrides tags)))))))
+        (is (= {:ovc/dual :ovc/from-call} (:fx-overrides @captured-envelope))
+            "per-call wins over lexical on the envelope itself")
+        (when interop/debug-enabled?
+          (is (= {:ovc/dual :ovc/from-call} (:rf.event/fx-overrides tags))))))))
 
 (deftest interceptor-override-rides-verbatim
   (testing "a per-call :interceptor-overrides entry rides the run-start tag
    verbatim, including a parameterized [id arg] key"
-    (let [tags (run-start-tags [:ovc/run]
-                               {:interceptor-overrides
-                                {::some-icpt nil
-                                 [:ovc/path-icpt [:cart]] nil}})]
-      (is (= {::some-icpt nil [:ovc/path-icpt [:cart]] nil}
-             (:rf.event/interceptor-overrides tags))))))
+    (let [expected {::some-icpt nil [:ovc/path-icpt [:cart]] nil}
+          tags (run-start-tags [:ovc/run]
+                               {:interceptor-overrides expected})]
+      ;; ALWAYS-ON (rf2-d2841).
+      (is (= expected (:interceptor-overrides @captured-envelope))
+          "the parameterized [id arg] key rides the envelope verbatim")
+      (when interop/debug-enabled?
+        (is (= expected (:rf.event/interceptor-overrides tags)))))))
 
 (deftest per-frame-only-fx-override-is-not-captured
   (testing "a per-frame-only :fx-overrides entry (no per-call, no lexical) is
    NOT captured — the run-start tag omits it, matching the ruling's pinned
    per-call + lexical scope"
-    (rf/reg-event :ovc/run (fn [{:keys [db]} _] {:db db}))
+    (reset! captured-envelope nil)
+    (rf/reg-fx :ovc/probe (fn [m _] (reset! captured-envelope (:envelope m))))
+    (rf/reg-event :ovc/run (fn [{:keys [db]} _] {:db db :fx [[:ovc/probe]]}))
     (rf/make-frame {:id :ovc/framed :fx-overrides {:ovc/real :ovc/stub}})
     (let [acc (collect-traces! ::cap)]
       (try
         (rf/dispatch-sync [:ovc/run] {:frame :ovc/framed})
-        (let [run-starts (filterv #(= :rf.event/run-start (:operation %)) @acc)
-              tags       (:tags (first run-starts))]
-          (is (= 1 (count run-starts)))
-          (is (not (contains? tags :rf.event/fx-overrides))
-              "the per-frame tier does not ride the envelope-scoped capture"))
+        ;; ---- ALWAYS-ON (rf2-d2841): the per-frame tier is a FRAME property,
+        ;;      so it is genuinely absent from the envelope rather than merely
+        ;;      absent from an emit that did not happen.
+        (is (some? @captured-envelope) "the dispatch envelope reached the fx ctx")
+        (is (empty? (:fx-overrides @captured-envelope))
+            "the per-frame tier does not compose onto the envelope")
+        (is (= {:ovc/real :ovc/stub}
+               (:fx-overrides (:config (frame/frame :ovc/framed))))
+            "...while the frame really does declare it (the contrast that makes
+             the row above a discrimination rather than an empty read)")
+        (when interop/debug-enabled?
+          (let [run-starts (filterv #(= :rf.event/run-start (:operation %)) @acc)
+                tags       (:tags (first run-starts))]
+            (is (= 1 (count run-starts)))
+            (is (not (contains? tags :rf.event/fx-overrides))
+                "the per-frame tier does not ride the envelope-scoped capture")))
         (finally
           (rf/unregister-listener! :trace ::cap))))))

--- a/implementation/core/test/re_frame/reg_view_injection_test.clj
+++ b/implementation/core/test/re_frame/reg_view_injection_test.clj
@@ -31,15 +31,51 @@
 
   Production-elision shape (dev coord with `:column`, prod slim coord
   without) is pinned below + by the CLJS bundle probe
-  (`scripts/check-elision.cjs` `rf.trace/call-site` sentinel)."
+  (`scripts/check-elision.cjs` `rf.trace/call-site` sentinel).
+
+  ## Posture split (rf2-d2841)
+
+  `:rf.trace/call-site` is dev-only BY DESIGN here — the last deftest in this
+  file asserts exactly that, walking the expansion to show the prod branch is
+  `{:source :ui}` with no coord at all. So every row reading a call-site back
+  off a live trace sits inside a `(when interop/debug-enabled? …)` arm, and
+  that arm's contract is pinned by its own always-on neighbour.
+
+  But the injection is not only about coords, and the parts that are not now
+  run under `scripts/test-core-prod-gate.sh` on witnesses that do not involve
+  the trace at all:
+
+    * the injected `dispatch` noun REALLY DISPATCHES — the handler runs and
+      lands a marker in app-db;
+    * the render-time frame capture survives the opts injection — the marker
+      lands in the RENDER-time frame after the `with-frame` scope has unwound,
+      which is the rf2-tqlmq regression itself and was previously only readable
+      off `[:tags :frame]`;
+    * the subscribe miss really emits `:rf.error/no-such-sub`, re-aimed at the
+      `:errors` stream (a PROMOTED category per Spec 009), so the synchronous
+      error path is proven in the posture that ships.
+
+  The macro-expansion deftest was always posture-independent and is untouched."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]))
+
+(defn- clicked?
+  "The injected `dispatch` noun ENQUEUES (it is not `dispatch-sync`), so the
+  handler's app-db write lands on the drain, not inline. Poll for it — the
+  always-on witness rf2-d2841 uses in place of the synchronous enqueue trace."
+  [frame-id]
+  (try (test-support/poll-until
+         #(true? (:clicked? (rf/app-db-value frame-id)))
+         {:timeout-ms 2000 :label (str "clicked? " frame-id)})
+       (catch Exception _ false)))
 
 (defn reset-runtime [test-fn]
   (registrar/clear-all!)
@@ -75,7 +111,10 @@
         ;; scope — there is no `:rf/default` floor. Render under an
         ;; explicit `with-frame` scope so the handle captures a real frame.
         (rf/make-frame {:id :rf2-cry25/click-frame :doc "the render-time frame"})
-        (rf/reg-event :rf2-cry25/clicked (fn [{:keys [db]} _] {:db db}))
+        ;; The handler lands a marker so the dispatch is observable WITHOUT the
+        ;; trace (rf2-d2841).
+        (rf/reg-event :rf2-cry25/clicked
+          (fn [{:keys [db]} _] {:db (assoc db :clicked? true)}))
         ;; `dispatch` here is the INJECTED noun (shadowing the macro) per
         ;; Spec 004 §reg-view. The reg-view definition site is the coord
         ;; 'go to code' must resolve to.
@@ -86,22 +125,30 @@
         (let [click (rf/with-frame :rf2-cry25/click-frame
                       (on-click-of (rf/view :re-frame.reg-view-injection-test/click-view)))]
           (click))
-        (let [ev (->> @seen
-                      (filter #(= :rf.event/dispatched (:operation %)))
-                      (filter #(= [:rf2-cry25/clicked] (get-in % [:tags :rf.event/v])))
-                      first)]
-          (is (some? ev) "the view's on-click dispatch produced a :rf.event/dispatched trace")
-          (is (= :ui (:source ev))
-              ":source is :ui (the reg-view injection stamps it explicitly), NOT :unknown")
-          (let [cs (:rf.trace/call-site ev)]
-            (is (some? cs)
-                ":rf.trace/call-site is present — Xray dispatch 'go to code' resolves")
-            (is (= 're-frame.reg-view-injection-test (:ns cs))
-                "the call-site coord is the VIEW's definition-site ns")
-            (is (integer? (:line cs))
-                "the call-site coord carries a :line (the reg-view definition line)")
-            (is (integer? (:column cs))
-                "dev coord carries :column (full coords-form)")))
+        ;; ---- ALWAYS-ON (rf2-d2841): the injected noun really dispatched ---
+        (is (true? (clicked? :rf2-cry25/click-frame))
+            "the view's on-click ran the handler through the captured-frame
+             handle op — the injection is a live dispatch, not just a stamp")
+        ;; ---- rf2-d2841 dev arm: the STAMPS the dispatch carried, which ride
+        ;;      the trace and are elided at source under the production gate
+        ;;      (the expansion deftest below pins that elision).
+        (when interop/debug-enabled?
+          (let [ev (->> @seen
+                        (filter #(= :rf.event/dispatched (:operation %)))
+                        (filter #(= [:rf2-cry25/clicked] (get-in % [:tags :rf.event/v])))
+                        first)]
+            (is (some? ev) "the view's on-click dispatch produced a :rf.event/dispatched trace")
+            (is (= :ui (:source ev))
+                ":source is :ui (the reg-view injection stamps it explicitly), NOT :unknown")
+            (let [cs (:rf.trace/call-site ev)]
+              (is (some? cs)
+                  ":rf.trace/call-site is present — Xray dispatch 'go to code' resolves")
+              (is (= 're-frame.reg-view-injection-test (:ns cs))
+                  "the call-site coord is the VIEW's definition-site ns")
+              (is (integer? (:line cs))
+                  "the call-site coord carries a :line (the reg-view definition line)")
+              (is (integer? (:column cs))
+                  "dev coord carries :column (full coords-form)"))))
         (finally (rf/unregister-listener! :trace ::rec))))))
 
 ;; ---- frame-preservation regression (the handle's existing guarantee) ----
@@ -115,7 +162,11 @@
       (rf/register-listener! :trace ::rec (fn [ev] (swap! seen conj ev)))
       (try
         (rf/make-frame {:id :rf2-cry25/render-frame :doc "the render-time frame"})
-        (rf/reg-event :rf2-cry25/clicked (fn [{:keys [db]} _] {:db db}))
+        ;; A SECOND frame, never the render frame, so "landed in the right
+        ;; frame" is a discrimination rather than a coincidence (rf2-d2841).
+        (rf/make-frame {:id :rf2-cry25/other-frame :doc "must stay untouched"})
+        (rf/reg-event :rf2-cry25/clicked
+          (fn [{:keys [db]} _] {:db (assoc db :clicked? true)}))
         (rf/reg-view frame-view [_n]
           [:button {:on-click #(dispatch [:rf2-cry25/clicked])} "go"])
         ;; Render the view UNDER :rf2-cry25/render-frame so the capture-frame
@@ -127,17 +178,27 @@
           (is (nil? frame/*current-frame*)
               "the with-frame scope has unwound before the click fires")
           (click))
-        (let [ev (->> @seen
-                      (filter #(= :rf.event/dispatched (:operation %)))
-                      (filter #(= [:rf2-cry25/clicked] (get-in % [:tags :rf.event/v])))
-                      first)]
-          (is (some? ev))
-          (is (= :rf2-cry25/render-frame (get-in ev [:tags :frame]))
-              "the dispatch routed to the RENDER-time frame, not a click-time
-               :rf/default fall-through — the noun's frame capture survives
-               the opts injection")
-          (is (= :ui (:source ev))
-              ":source :ui rides alongside the preserved frame"))
+        ;; ---- ALWAYS-ON (rf2-d2841): the rf2-tqlmq regression itself, read off
+        ;;      app-db rather than off `[:tags :frame]`. The handler ran in the
+        ;;      RENDER-time frame even though the scope had already unwound.
+        (is (true? (clicked? :rf2-cry25/render-frame))
+            "the dispatch routed to the RENDER-time frame — the noun's frame
+             capture survives the opts injection")
+        (is (nil? (:clicked? (rf/app-db-value :rf2-cry25/other-frame)))
+            "and reached no other frame")
+        ;; ---- rf2-d2841 dev arm ------------------------------------------
+        (when interop/debug-enabled?
+          (let [ev (->> @seen
+                        (filter #(= :rf.event/dispatched (:operation %)))
+                        (filter #(= [:rf2-cry25/clicked] (get-in % [:tags :rf.event/v])))
+                        first)]
+            (is (some? ev))
+            (is (= :rf2-cry25/render-frame (get-in ev [:tags :frame]))
+                "the dispatch routed to the RENDER-time frame, not a click-time
+                 :rf/default fall-through — the noun's frame capture survives
+                 the opts injection")
+            (is (= :ui (:source ev))
+                ":source :ui rides alongside the preserved frame")))
         (finally (rf/unregister-listener! :trace ::rec))))))
 
 ;; ---- subscribe: the view's call-site on the synchronous error path -------
@@ -147,8 +208,13 @@
             :rf.error/no-such-sub carrying the view's :rf.trace/call-site
             (subscriptions carry no :source axis; the handle's :subscribe op
             mirrors the subscribe macro's trace/with-call-site wrapper)"
-    (let [seen (atom [])]
+    (let [seen    (atom [])
+          records (atom [])]
       (rf/register-listener! :trace ::rec (fn [ev] (swap! seen conj ev)))
+      ;; ALWAYS-ON axis (rf2-d2841): `:rf.error/no-such-sub` is a PROMOTED
+      ;; category — the miss fans a corpus-wide record that survives
+      ;; -Dre-frame.debug=false.
+      (rf/register-listener! :errors ::err (fn [r] (swap! records conj r)))
       (try
         ;; EP-0002 (rf2-69r7ui): the reg-view handle captures
         ;; `(current-frame-id)` at render, which REQUIRES a scope. Render
@@ -165,19 +231,31 @@
           ;; build-and-cache miss → :rf.error/no-such-sub emit).
           (rf/with-frame :rf2-cry25/sub-frame
             (view-fn 0)))
-        (let [err (->> @seen
-                       (filter #(= :rf.error/no-such-sub
-                                   (get-in % [:tags :category])))
-                       first)]
-          (is (some? err)
-              "subscribing to an unregistered sub emitted :rf.error/no-such-sub")
-          (let [cs (:rf.trace/call-site err)]
-            (is (some? cs)
-                ":rf.trace/call-site is present on the subscribe error —
-                 the handle's :subscribe op carried the view coord")
-            (is (= 're-frame.reg-view-injection-test (:ns cs))
-                "the subscribe call-site coord is the VIEW's definition-site ns")))
-        (finally (rf/unregister-listener! :trace ::rec))))))
+        ;; ---- ALWAYS-ON: the synchronous miss really surfaced ---------------
+        (let [recs (filterv #(= :rf.error/no-such-sub (:error %)) @records)]
+          (is (= 1 (count recs))
+              "subscribing to an unregistered sub through the injected noun
+               fans exactly one always-on :rf.error/no-such-sub record")
+          (is (= :rf2-cry25/sub-frame (:frame (first recs)))
+              "attributed to the render-time frame the handle captured"))
+        ;; ---- rf2-d2841 dev arm: the VIEW COORD on that error, which rides
+        ;;      `:rf.trace/call-site` on the dev trace only.
+        (when interop/debug-enabled?
+          (let [err (->> @seen
+                         (filter #(= :rf.error/no-such-sub
+                                     (get-in % [:tags :category])))
+                         first)]
+            (is (some? err)
+                "subscribing to an unregistered sub emitted :rf.error/no-such-sub")
+            (let [cs (:rf.trace/call-site err)]
+              (is (some? cs)
+                  ":rf.trace/call-site is present on the subscribe error —
+                   the handle's :subscribe op carried the view coord")
+              (is (= 're-frame.reg-view-injection-test (:ns cs))
+                  "the subscribe call-site coord is the VIEW's definition-site ns"))))
+        (finally
+          (rf/unregister-listener! :errors ::err)
+          (rf/unregister-listener! :trace ::rec))))))
 
 ;; ---- production-elision shape (dev coord vs slim prod coord) -------------
 ;;

--- a/implementation/core/test/re_frame/sub_cycle_cljs_test.cljc
+++ b/implementation/core/test/re_frame/sub_cycle_cljs_test.cljc
@@ -14,11 +14,38 @@
 
   `.cljc` ending `-cljs-test` rides `npm run test:cljs` AND `clojure -M:test`,
   so both the JVM (where the raw SOE was reproduced) and the CLJS node runtime
-  exercise the guard."
+  exercise the guard.
+
+  ## Posture split (rf2-d2841)
+
+  The GUARD is production behaviour; its REPORT is not. `subs/emit-sub-cycle!`
+  is a bare `trace/emit-error!` and says so in its own docstring — the
+  DIAGNOSTIC trace channel, dev-only, DCE'd under `:advanced` +
+  `goog.DEBUG=false` — with no always-on leg. Every row reading the structured
+  event's `:cycle` / `:where` / count therefore sits inside a
+  `(when interop/debug-enabled? ...)` arm.
+
+  Everything that made this bead worth fixing stays OUTSIDE those arms and now
+  runs under `scripts/test-core-prod-gate.sh`: the cyclic subscribe RECOVERS to
+  a nil-yielding reaction instead of blowing the host stack with a raw
+  StackOverflowError, `compute-sub` returns nil, the rf2-t3cpn3 ref-count teeth
+  show the earlier input released on the cycle unwind, and the acyclic diamond
+  still computes `[42 40]`.
+
+  One vacuous pass was found and moved: `acyclic-diamond-does-not-trip-the-cycle-guard`'s
+  two `(is (empty? events))` rows certified an absence of spurious cycle errors
+  over a stream that is empty for EVERY graph under the gate. They now sit in
+  the arm beside the positives that give them teeth.
+
+  And `reactive-cycle-recovery-is-not-cached` had NOTHING but the trace count —
+  guarding it would have left a deftest that subscribed twice and asserted
+  nothing. Its claim is directly readable off production state, so it now
+  asserts the sub-cache miss itself, which is what `not cached` means."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core           :as rf]
             [re-frame.frame          :as frame]
+            [re-frame.interop        :as interop]
             [re-frame.subs           :as subs]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support   :as test-support]))
@@ -59,14 +86,16 @@
     (let [[reaction events] (capture-sub-cycles #(subs/subscribe [:a] {:frame fid}))]
       (is (nil? (deref reaction))
           "the cyclic subscription recovered to a nil-yielding reaction")
-      (is (= 1 (count events))
-          "exactly one structured :rf.error/sub-cycle was emitted")
-      (let [ev (first events)]
-        (is (= :rf.error/sub-cycle (:operation ev)))
-        (is (= :error (:op-type ev)))
-        (is (= :subscribe (:where (:tags ev))))
-        (is (= [:a :b :a] (:cycle (:tags ev)))
-            "the cycle path is the closing-repeat sub-id chain")))))
+      ;; rf2-d2841 - the structured REPORT is diagnostic-channel only.
+      (when interop/debug-enabled?
+        (is (= 1 (count events))
+            "exactly one structured :rf.error/sub-cycle was emitted")
+        (let [ev (first events)]
+          (is (= :rf.error/sub-cycle (:operation ev)))
+          (is (= :error (:op-type ev)))
+          (is (= :subscribe (:where (:tags ev))))
+          (is (= [:a :b :a] (:cycle (:tags ev)))
+              "the cycle path is the closing-repeat sub-id chain"))))))
 
 (deftest reactive-self-cycle-emits-structured-error-and-recovers-to-nil
   (testing "subscribing a self-edge (:self <- [:self]) emits :rf.error/sub-cycle
@@ -75,21 +104,34 @@
     (let [[reaction events] (capture-sub-cycles #(subs/subscribe [:self] {:frame fid}))]
       (is (nil? (deref reaction))
           "the self-cyclic subscription recovered to a nil-yielding reaction")
-      (is (= 1 (count events)))
-      (is (= [:self :self] (:cycle (:tags (first events))))
-          "a self-cycle repeats the one id, e.g. [:self :self]"))))
+      ;; rf2-d2841 - diagnostic-channel report.
+      (when interop/debug-enabled?
+        (is (= 1 (count events)))
+        (is (= [:self :self] (:cycle (:tags (first events))))
+            "a self-cycle repeats the one id, e.g. [:self :self]")))))
 
 (deftest reactive-cycle-recovery-is-not-cached
   (testing "the cyclic build is NOT cached (mirroring the no-such-sub miss), so
             a second subscribe re-detects + re-emits rather than silently
             handing back a broken cached reaction (rf2-x76af2.24)"
     (register-cyclic-subs!)
-    (let [[_ events] (capture-sub-cycles
+    (let [cache      (:sub-cache (frame/frame fid))
+          [_ events] (capture-sub-cycles
                        (fn []
                          (subs/subscribe [:a] {:frame fid})
                          (subs/subscribe [:a] {:frame fid})))]
-      (is (= 2 (count events))
-          "each subscribe of the uncached cyclic sub re-emits the structured error"))))
+      ;; ALWAYS-ON (rf2-d2841): "not cached" is a statement about the sub-cache,
+      ;; and the cache is production state. This IS the claim; the re-emission
+      ;; below is only how it used to be inferred, on a channel a production
+      ;; build does not have.
+      (is (nil? (get @cache [:a]))
+          "the cyclic build left no cache entry - a later subscribe re-detects
+           rather than being handed a broken cached reaction")
+      (is (nil? (get @cache [:b]))
+          "nor did the other node of the cycle get cached mid-build")
+      (when interop/debug-enabled?
+        (is (= 2 (count events))
+            "each subscribe of the uncached cyclic sub re-emits the structured error")))))
 
 (deftest reactive-multi-input-cycle-releases-earlier-input-refs
   (testing "a >=2-input sub whose NON-FIRST input cycles releases the
@@ -113,10 +155,12 @@
       (let [[reaction events] (capture-sub-cycles #(subs/subscribe [:multi] {:frame fid}))]
         (is (nil? (deref reaction))
             "the cyclic multi-input subscription recovered to a nil-yielding reaction")
-        (is (= 1 (count events))
-            "exactly one structured :rf.error/sub-cycle was emitted")
-        (is (= [:multi :cyc :multi] (:cycle (:tags (first events))))
-            "the cycle path is the closing-repeat sub-id chain through the non-first input")
+        ;; rf2-d2841 - diagnostic-channel report; the TEETH below are always-on.
+        (when interop/debug-enabled?
+          (is (= 1 (count events))
+              "exactly one structured :rf.error/sub-cycle was emitted")
+          (is (= [:multi :cyc :multi] (:cycle (:tags (first events))))
+              "the cycle path is the closing-repeat sub-id chain through the non-first input"))
         ;; TEETH (rf2-t3cpn3): :leaf was subscribed (ref bumped) BEFORE :cyc
         ;; cycled. On the cycle-unwind path it must be released so its ref-count
         ;; returns to baseline (entry dropped on the 1→0 transition). Before the
@@ -135,10 +179,12 @@
     (register-cyclic-subs!)
     (let [[v events] (capture-sub-cycles #(rf/compute-sub [:a] {}))]
       (is (nil? v) "compute-sub recovered the cyclic sub to nil")
-      (is (= 1 (count events)))
-      (let [ev (first events)]
-        (is (= :compute-sub (:where (:tags ev))))
-        (is (= [:a :b :a] (:cycle (:tags ev))))))))
+      ;; rf2-d2841 - diagnostic-channel report.
+      (when interop/debug-enabled?
+        (is (= 1 (count events)))
+        (let [ev (first events)]
+          (is (= :compute-sub (:where (:tags ev))))
+          (is (= [:a :b :a] (:cycle (:tags ev)))))))))
 
 (deftest compute-sub-self-cycle-emits-structured-error-and-returns-nil
   (testing "compute-sub of a self-edge emits :rf.error/sub-cycle and returns nil
@@ -146,8 +192,10 @@
     (register-cyclic-subs!)
     (let [[v events] (capture-sub-cycles #(rf/compute-sub [:self] {}))]
       (is (nil? v))
-      (is (= 1 (count events)))
-      (is (= [:self :self] (:cycle (:tags (first events))))))))
+      ;; rf2-d2841 - diagnostic-channel report.
+      (when interop/debug-enabled?
+        (is (= 1 (count events)))
+        (is (= [:self :self] (:cycle (:tags (first events)))))))))
 
 ;; ===========================================================================
 ;; Sanity baseline — a NON-cyclic diamond does not trip the guard
@@ -163,7 +211,13 @@
     (rf/reg-sub :c :<- [:a] :<- [:b] (fn [[a b] _] [a b]))
     (let [[reaction events] (capture-sub-cycles #(subs/subscribe [:c] {:frame fid}))]
       (is (= [42 40] (deref reaction)) "the diamond computed correctly")
-      (is (empty? events) "no spurious :rf.error/sub-cycle for an acyclic graph"))
+      ;; rf2-d2841 - VACUOUS UNDER THE GATE. `events` is empty for EVERY graph
+      ;; when the diagnostic channel emits nothing, so outside the arm this row
+      ;; would certify "no spurious cycle error" having never been able to see
+      ;; one. Kept verbatim beside the positive that gives it teeth.
+      (when interop/debug-enabled?
+        (is (empty? events) "no spurious :rf.error/sub-cycle for an acyclic graph")))
     (let [[v events] (capture-sub-cycles #(rf/compute-sub [:c] {:root 41}))]
       (is (= [42 40] v) "compute-sub diamond computed correctly")
-      (is (empty? events) "no spurious cycle from the compute-sub memo path"))))
+      (when interop/debug-enabled?
+        (is (empty? events) "no spurious cycle from the compute-sub memo path")))))

--- a/implementation/core/test/re_frame/sub_parametric_inputs_test.clj
+++ b/implementation/core/test/re_frame/sub_parametric_inputs_test.clj
@@ -28,6 +28,7 @@
       sub-input-fn-exception / sub-input-fn-bad-return)"
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.subs :as subs]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
@@ -70,6 +71,22 @@
                              (when (= error-kw (:operation ev))
                                (swap! errs conj ev))))
     [errs #(rf/unregister-listener! :trace k)]))
+
+(defn- capture-error-records!
+  "The ALWAYS-ON counterpart of [[capture-errors!]] (rf2-d2841). Both
+  `:rf.error/sub-input-fn-exception` and `:rf.error/sub-input-fn-bad-return`
+  are PROMOTED categories — `subs/emit-sub-input-fn-error!` fans them through
+  `error-emit/emit-error-both!` — so their occurrence, sub-id and query-v are
+  readable in production posture off the corpus-wide registry. (`:where` is
+  not: it rides the dev-trace tags, which `emit-error-both!` does not lift
+  from.) Returns `[records-atom unregister-fn]`."
+  [error-kw]
+  (let [recs (atom [])
+        k    (keyword "rf2-d2841" (str (name error-kw) "-rec-" (gensym)))]
+    (rf/register-listener! :errors k
+                           (fn [r] (when (= error-kw (:error r))
+                                     (swap! recs conj r))))
+    [recs #(rf/unregister-listener! :errors k)]))
 
 (use-fixtures :each reset-runtime)
 
@@ -417,15 +434,21 @@
         ;; A leading :<- with no query-vector.
         (is (thrown-with-msg? clojure.lang.ExceptionInfo #"reg-sub-bad-args"
               (rf/reg-sub :bad2 :<- (fn [x _] x))))
-        (is (seq @errs) "a :rf.error/reg-sub-bad-args trace was emitted")
-        (is (some #(= :bad (get-in % [:tags :rf.sub/id])) @errs)
-            "the trace carries the offending sub id")
+        ;; rf2-d2841 — `:rf.error/reg-sub-bad-args` is a bare
+        ;; `trace/emit-error!` in `subs.cljc` (no always-on leg), so the TRACE
+        ;; half is dev-only. The LOUD half — the two `thrown-with-msg?` rows
+        ;; above — is what a production build has, and it is unguarded.
+        (when interop/debug-enabled?
+          (is (seq @errs) "a :rf.error/reg-sub-bad-args trace was emitted")
+          (is (some #(= :bad (get-in % [:tags :rf.sub/id])) @errs)
+              "the trace carries the offending sub id"))
         (finally (unreg))))))
 
 (deftest sub-input-fn-exception-fires-and-recovers
   (testing ":rf.error/sub-input-fn-exception — an input-fn that throws emits
             loudly (compute-sub path) and recovers the sub to nil"
-    (let [[errs unreg] (capture-errors! :rf.error/sub-input-fn-exception)]
+    (let [[errs unreg] (capture-errors! :rf.error/sub-input-fn-exception)
+          [recs unrec] (capture-error-records! :rf.error/sub-input-fn-exception)]
       (try
         (rf/reg-sub :leaf (fn [db _] (:leaf db)))
         (rf/reg-sub :boom
@@ -434,22 +457,34 @@
         ;; compute-sub path.
         (is (nil? (rf/compute-sub [:boom] {:leaf 1}))
             "the sub recovers to nil when its input-fn throws")
-        (is (some #(= :compute-sub (get-in % [:tags :where])) @errs)
-            "the compute-sub path emitted :rf.error/sub-input-fn-exception")
+        ;; rf2-d2841 — `:where` rides the dev-trace tags only.
+        (when interop/debug-enabled?
+          (is (some #(= :compute-sub (get-in % [:tags :where])) @errs)
+              "the compute-sub path emitted :rf.error/sub-input-fn-exception"))
         ;; reactive path.
         (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:leaf 1}}))
         (rf/dispatch-sync [:seed])
         (is (nil? (rf/subscribe-once [:boom]))
             "the reactive path also recovers to nil")
-        (is (some #(= :reactive (get-in % [:tags :where])) @errs)
-            "the reactive path emitted :rf.error/sub-input-fn-exception")
-        (finally (unreg))))))
+        (when interop/debug-enabled?
+          (is (some #(= :reactive (get-in % [:tags :where])) @errs)
+              "the reactive path emitted :rf.error/sub-input-fn-exception"))
+        ;; ---- ALWAYS-ON (rf2-d2841): BOTH paths fanned a corpus-wide record
+        ;;      naming the failing sub. "Emits loudly" is the claim; the
+        ;;      always-on axis is where a production build hears it.
+        (is (= 2 (count @recs))
+            "both the compute-sub and the reactive path fanned an always-on
+             :rf.error/sub-input-fn-exception record")
+        (is (every? #(= :boom (:event-id %)) @recs)
+            "each always-on record names the failing sub")
+        (finally (unrec) (unreg))))))
 
 (deftest sub-input-fn-bad-return-fires-and-recovers
   (testing ":rf.error/sub-input-fn-bad-return — an input-fn returning a bad
             shape emits loudly (reactive + compute-sub) and recovers to nil;
             it is NEVER silently treated as no inputs"
-    (let [[errs unreg] (capture-errors! :rf.error/sub-input-fn-bad-return)]
+    (let [[errs unreg] (capture-errors! :rf.error/sub-input-fn-bad-return)
+          [recs unrec] (capture-error-records! :rf.error/sub-input-fn-bad-return)]
       (try
         (rf/reg-sub :leaf (fn [db _] (:leaf db)))
         ;; Returns a scalar query vector — the classic ambiguous shape.
@@ -462,12 +497,24 @@
         (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:leaf 1}}))
         (rf/dispatch-sync [:seed])
         (is (nil? (rf/subscribe-once [:bad-shape])))
-        (let [wheres (set (map #(get-in % [:tags :where]) @errs))]
-          (is (contains? wheres :compute-sub))
-          (is (contains? wheres :reactive)))
-        ;; The error carries the outer query-v + sub id.
-        (is (some #(= [:bad-shape] (get-in % [:tags :rf.sub/query-v])) @errs))
-        (finally (unreg))))))
+        ;; rf2-d2841 — `:where` / `:rf.sub/query-v` ride the dev-trace tags.
+        (when interop/debug-enabled?
+          (let [wheres (set (map #(get-in % [:tags :where]) @errs))]
+            (is (contains? wheres :compute-sub))
+            (is (contains? wheres :reactive)))
+          ;; The error carries the outer query-v + sub id.
+          (is (some #(= [:bad-shape] (get-in % [:tags :rf.sub/query-v])) @errs)))
+        ;; ---- ALWAYS-ON (rf2-d2841): the record carries the query-vector
+        ;;      VERBATIM as its positional `:event` (raw identity per
+        ;;      #6441 / rf2-zwgqe), so production learns exactly which
+        ;;      subscription was rejected — not merely that one was.
+        (is (= 2 (count @recs))
+            "both paths fanned an always-on :rf.error/sub-input-fn-bad-return record")
+        (is (every? #(= [:bad-shape] (:event %)) @recs)
+            "each always-on record carries the outer query-vector")
+        (is (every? #(= :bad-shape (:event-id %)) @recs)
+            "and names the sub")
+        (finally (unrec) (unreg))))))
 
 (deftest bad-return-not-treated-as-no-inputs
   (testing "a bad input return does NOT silently feed the body an empty input
@@ -505,7 +552,13 @@
       (is (= [] (:input-signals m)))
       (is (not (contains? m :input-fn))
           "a meta-map + single fn is NOT misread as input-fn + computation-fn")
-      (is (= "a layer-1 sub" (:doc m)) "the meta-map survived onto the registration"))
+      ;; rf2-d2841 — `:doc` is PURE DOCUMENTATION, stripped by
+      ;; `registrar/strip-pure-documentation` under -Dre-frame.debug=false. The
+      ;; claim ("the meta-map was consumed as :meta, not as a handler") is
+      ;; carried in both postures by the `:input-kind` / `:input-fn` rows above
+      ;; and by the live subscribe below.
+      (when interop/debug-enabled?
+        (is (= "a layer-1 sub" (:doc m)) "the meta-map survived onto the registration")))
     (rf/reg-event :seed-m1 (fn [{:keys [db]} _] {:db {:n 7}}))
     (rf/dispatch-sync [:seed-m1])
     (is (= 7 (rf/subscribe-once [:m1])))))
@@ -519,7 +572,9 @@
       (is (= :static (:input-kind m)))
       (is (= [[:base]] (:input-signals m)))
       (is (not (contains? m :input-fn)))
-      (is (= "doubled" (:doc m))))
+      ;; rf2-d2841 — pure-documentation strip; see the deftest above.
+      (when interop/debug-enabled?
+        (is (= "doubled" (:doc m)))))
     (rf/reg-event :seed-m2 (fn [{:keys [db]} _] {:db {:n 5}}))
     (rf/dispatch-sync [:seed-m2])
     (is (= 10 (rf/subscribe-once [:m2])))))
@@ -548,7 +603,9 @@
     (let [m (sub-meta :p1)]
       (is (= :parametric (:input-kind m)))
       (is (fn? (:input-fn m)))
-      (is (= "parametric with meta" (:doc m))))
+      ;; rf2-d2841 — pure-documentation strip; see above.
+      (when interop/debug-enabled?
+        (is (= "parametric with meta" (:doc m)))))
     (rf/reg-event :seed-p1 (fn [{:keys [db]} _] {:db {:by-id {:a 99}}}))
     (rf/dispatch-sync [:seed-p1])
     (is (= 99 (rf/subscribe-once [:p1 :a])))))

--- a/implementation/core/test/re_frame/subs_inline_normalization_cljs_test.cljc
+++ b/implementation/core/test/re_frame/subs_inline_normalization_cljs_test.cljc
@@ -26,7 +26,23 @@
   metadata merge returns or the authored id is dropped.
 
   `.cljc` — the normalizer is host-agnostic, so this runs under both
-  `clojure -M:test` (JVM) and `npm run test:cljs` (node CLJS)."
+  `clojure -M:test` (JVM) and `npm run test:cljs` (node CLJS).
+
+  ## Posture split (rf2-d2841)
+
+  The parity this suite pins is overwhelmingly posture-independent: the retired
+  `:spec` key, the malformed-classification rejection, the runtime-owned slots
+  winning over hostile metadata, the namespaced-extension carve-out and the
+  authored id reaching the diagnostic are all the same under
+  `-Dre-frame.debug=false`. Only the `:doc`-RETAINED-IN-DEV rows are not — they
+  are the dev half of the strip contract, so they sit verbatim inside a
+  `(when interop/debug-enabled? …)` arm beside the production row that gives
+  them their meaning.
+
+  The `with-redefs [interop/debug-enabled? false]` production blocks stay
+  OUTSIDE any arm and are load-bearing in both postures: under the real gate
+  the rebind is a no-op because the var is already false, so those rows are the
+  production claim executed for real rather than simulated."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.subs :as subs]
             [re-frame.image :as image]
@@ -91,9 +107,16 @@
 ;; ---- production `:doc` strip parity ---------------------------------------
 
 (deftest doc-stripped-in-production-retained-in-dev-on-inline-path
-  (testing "dev (default gate on) retains `:doc` for tooling / agent inspection"
-    (let [desc (subs/lower-inline-sub :norm/inline-doc {:doc "kept in dev"} body)]
-      (is (= "kept in dev" (:doc desc)))))
+  ;; rf2-d2841 — the retention half is dev-only by construction; kept verbatim.
+  (when interop/debug-enabled?
+    (testing "dev (default gate on) retains `:doc` for tooling / agent inspection"
+      (let [desc (subs/lower-inline-sub :norm/inline-doc {:doc "kept in dev"} body)]
+        (is (= "kept in dev" (:doc desc))))))
+  (testing "a doc-ONLY inline descriptor still lowers to something runnable —
+            the strip removes documentation, never the registration"
+    (let [desc (subs/lower-inline-sub :norm/inline-doc-runnable {:doc "kept in dev"} body)]
+      (is (= body (:handler-fn desc)) "the runnable slot is installed in both postures")
+      (is (= :db (:input-kind desc)) "and the layer-1 shape is intact")))
   (testing "production (gate off) strips `:doc` from the inline runnable
             descriptor, exactly as the public registrar does"
     (with-redefs [interop/debug-enabled? false]
@@ -138,13 +161,17 @@
       asm/lower-inline-descriptor))
 
 (deftest production-assembly-strips-doc-from-top-level-and-nested-metadata
-  (testing "dev — the authored `:doc` survives at BOTH the top level and under the
-            nested `:metadata` of the assembled image descriptor"
+  (testing "the authored id survives assembly in every posture"
     (let [d (assemble-sub :counter/value {:doc "author note" :schema :int} body)]
-      (is (= "author note" (:doc d)) "top-level :doc retained in dev")
-      (is (= "author note" (get-in d [:metadata :doc]))
-          "nested [:metadata :doc] retained in dev")
-      (is (= :counter/value (:id d)) "authored id survives assembly")))
+      (is (= :counter/value (:id d)) "authored id survives assembly")
+      ;; rf2-d2841 — the two `:doc` rows are the dev half of the strip
+      ;; contract; under -Dre-frame.debug=false the key is gone at source.
+      ;; Kept verbatim inside the arm, beside the production block below that
+      ;; asserts the same two slots are EMPTY.
+      (when interop/debug-enabled?
+        (is (= "author note" (:doc d)) "top-level :doc retained in dev")
+        (is (= "author note" (get-in d [:metadata :doc]))
+            "nested [:metadata :doc] retained in dev"))))
   (testing "production (gate off) — the assembled image carries NO `:doc` at the
             top level OR under nested `:metadata`; load-bearing keys are retained"
     (with-redefs [interop/debug-enabled? false]
@@ -164,6 +191,13 @@
       (let [d (assemble-sub :counter/note {:doc "only a note"} body)]
         (is (not (contains? d :doc)))
         (is (not (contains? (:metadata d) :doc)))
+        ;; rf2-d2841 — the row above is a negative over a map that has been
+        ;; dropped WHOLESALE, so on its own it cannot tell "metadata present
+        ;; without :doc" from "metadata gone". Pin the drop itself, which is
+        ;; what the deftest name actually claims (mirrors the cross-kind
+        ;; assertion in `image-inline-metadata-normalization-cljs-test`).
+        (is (nil? (:metadata d))
+            "the nested :metadata map is dropped once it reduces to empty")
         (is (= body (:handler-fn d)) "the runnable slot is still installed")))))
 
 (deftest retired-key-diagnostic-names-the-authored-inline-id

--- a/implementation/core/test/re_frame/substrate_source_test.clj
+++ b/implementation/core/test/re_frame/substrate_source_test.clj
@@ -19,10 +19,38 @@
   carries `:source :always` and is verified in
   `machines_always_cljs_test.cljs`.
 
-  JVM-only — substrate fx-handler behaviour is platform-agnostic."
+  JVM-only — substrate fx-handler behaviour is platform-agnostic.
+
+  ## Posture split (rf2-d2841)
+
+  The stamp this file is about is a PROPERTY OF THE DISPATCH ENVELOPE. It was
+  only ever READ off the `:rf.event/dispatched` trace, which emits nothing
+  under `-Dre-frame.debug=false` — so every deftest here failed under
+  `scripts/test-core-prod-gate.sh` while the thing being asserted was
+  production behaviour all along.
+
+  Each case therefore grew an ALWAYS-ON probe rather than a guard: a
+  `:test/probe` fx running inside every level of the cascade captures
+  `(:envelope m)`, the production surface
+  `cascade-envelope-propagation-test/fx-handler-ctx-carries-envelope-slot`
+  establishes. The `:source` / `:origin` claims are read off those envelopes and
+  now hold in BOTH postures — including the three-deep override and the
+  `:dispatch-later` deferral, which had no production-posture counterpart
+  anywhere.
+
+  What is left inside the `(when interop/debug-enabled? …)` arms is the
+  narrower claim the trace still owns: that `:source` is HOISTED to the trace
+  event's top level (Spec 009 §Core fields) while `:rf.event/origin` rides under
+  `:tags`. That is a trace-shape claim, not a propagation claim.
+
+  The `:dispatch-later` case additionally moved its completion signal onto the
+  probe. It used to wait on a promise delivered by the TRACE listener — which
+  under the gate simply never arrives, so the case burned its full 2s timeout
+  before failing. The probe delivers it in both postures."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
@@ -50,102 +78,181 @@
 
 (use-fixtures :each reset-runtime)
 
+;; ---- always-on envelope probe (rf2-d2841) --------------------------------
+;;
+;; The `:source` stamp lives on the DISPATCH ENVELOPE; reading it off the
+;; `:rf.event/dispatched` trace was only ever one way to observe it, and the one
+;; that disappears under -Dre-frame.debug=false. A user fx-handler receives
+;; `(:envelope m)` — the production surface pinned by
+;; `cascade-envelope-propagation-test/fx-handler-ctx-carries-envelope-slot` —
+;; so running one inside each level of a cascade reads every envelope directly.
+
+(defn- register-probe-fx!
+  "Register `:test/probe`, an fx that records the dispatch envelope it runs
+  under into `envelopes` keyed by the level keyword it is called with."
+  [envelopes]
+  (rf/reg-fx :test/probe
+    (fn [m [level]] (swap! envelopes assoc level (:envelope m)))))
+
 ;; ---- :fx-dispatch stamp by the :dispatch fx handler ----------------------
 
 (deftest dispatch-fx-stamps-source-fx-dispatch
   (testing ":dispatch fx stamps `:source :fx-dispatch` on the child envelope"
-    (let [seen (atom [])]
+    (let [seen      (atom [])
+          envelopes (atom {})]
       (rf/register-listener! :trace ::rec (fn [ev] (swap! seen conj ev)))
       (try
+        (register-probe-fx! envelopes)
         (rf/reg-event :test/parent
           (fn [_ _]
-            {:fx [[:dispatch [:test/child]]]}))
-        (rf/reg-event :test/child (fn [{:keys [db]} _] {:db db}))
+            {:fx [[:test/probe [:parent]]
+                  [:dispatch [:test/child]]]}))
+        (rf/reg-event :test/child
+          (fn [{:keys [db]} _] {:db db :fx [[:test/probe [:child]]]}))
 
         ;; Parent stamps `:source :ui` (mimicking a UI handler call-site).
         (rf/dispatch-sync [:test/parent] {:source :ui})
 
-        (let [dispatched (->> @seen (filter #(= :rf.event/dispatched (:operation %))))
-              parent-ev  (first (filter #(= [:test/parent] (get-in % [:tags :rf.event/v])) dispatched))
-              child-ev   (first (filter #(= [:test/child]  (get-in % [:tags :rf.event/v])) dispatched))]
-          (is (some? parent-ev) "parent's :rf.event/dispatched is captured")
-          (is (some? child-ev)  "child's :rf.event/dispatched is captured")
-          (is (= :ui (:source parent-ev))
+        ;; ---- ALWAYS-ON (rf2-d2841): read the stamp off the ENVELOPES ------
+        (let [parent-env (:parent @envelopes)
+              child-env  (:child  @envelopes)]
+          (is (some? parent-env) "the parent's dispatch envelope was captured")
+          (is (some? child-env)  "the child's dispatch envelope was captured")
+          (is (= :ui (:source parent-env))
               "parent carries the caller-supplied :source :ui")
-          (is (= :fx-dispatch (:source child-ev))
+          (is (= :fx-dispatch (:source child-env))
               ":dispatch fx stamped :source :fx-dispatch on the child envelope (rf2-ejtpd)"))
+
+        ;; ---- rf2-d2841 dev arm: the same values, HOISTED onto the trace ---
+        (when interop/debug-enabled?
+          (let [dispatched (->> @seen (filter #(= :rf.event/dispatched (:operation %))))
+                parent-ev  (first (filter #(= [:test/parent] (get-in % [:tags :rf.event/v])) dispatched))
+                child-ev   (first (filter #(= [:test/child]  (get-in % [:tags :rf.event/v])) dispatched))]
+            (is (some? parent-ev) "parent's :rf.event/dispatched is captured")
+            (is (some? child-ev)  "child's :rf.event/dispatched is captured")
+            (is (= :ui (:source parent-ev))
+                "parent carries the caller-supplied :source :ui")
+            (is (= :fx-dispatch (:source child-ev))
+                ":dispatch fx stamped :source :fx-dispatch on the child envelope (rf2-ejtpd)")))
         (finally (rf/unregister-listener! :trace ::rec))))))
 
 (deftest dispatch-fx-overrides-parent-source-three-deep
   (testing ":fx-dispatch is the *immediate* trigger — overrides at every cascade depth"
-    (let [seen (atom [])]
+    (let [seen      (atom [])
+          envelopes (atom {})]
       (rf/register-listener! :trace ::rec (fn [ev] (swap! seen conj ev)))
       (try
-        (rf/reg-event :test/lvl-0 (fn [_ _] {:fx [[:dispatch [:test/lvl-1]]]}))
-        (rf/reg-event :test/lvl-1 (fn [_ _] {:fx [[:dispatch [:test/lvl-2]]]}))
-        (rf/reg-event :test/lvl-2 (fn [{:keys [db]} _] {:db db}))
+        (register-probe-fx! envelopes)
+        (rf/reg-event :test/lvl-0
+          (fn [_ _] {:fx [[:test/probe [:lvl-0]] [:dispatch [:test/lvl-1]]]}))
+        (rf/reg-event :test/lvl-1
+          (fn [_ _] {:fx [[:test/probe [:lvl-1]] [:dispatch [:test/lvl-2]]]}))
+        (rf/reg-event :test/lvl-2
+          (fn [{:keys [db]} _] {:db db :fx [[:test/probe [:lvl-2]]]}))
 
         (rf/dispatch-sync [:test/lvl-0] {:source :ui})
 
-        (let [dispatched (->> @seen (filter #(= :rf.event/dispatched (:operation %))))
-              ev-for     (fn [id]
-                           (first (filter #(= [id] (get-in % [:tags :rf.event/v])) dispatched)))]
-          (is (= :ui          (:source (ev-for :test/lvl-0))) "root keeps :ui")
-          (is (= :fx-dispatch (:source (ev-for :test/lvl-1))) "lvl-1 stamped :fx-dispatch")
-          (is (= :fx-dispatch (:source (ev-for :test/lvl-2)))
-              "lvl-2 ALSO stamped :fx-dispatch (immediate trigger, not :ui from the root)"))
+        ;; ---- ALWAYS-ON (rf2-d2841): the override at EVERY depth -----------
+        (is (= :ui          (:source (:lvl-0 @envelopes))) "root keeps :ui")
+        (is (= :fx-dispatch (:source (:lvl-1 @envelopes))) "lvl-1 stamped :fx-dispatch")
+        (is (= :fx-dispatch (:source (:lvl-2 @envelopes)))
+            "lvl-2 ALSO stamped :fx-dispatch (immediate trigger, not :ui from the root)")
+
+        ;; ---- rf2-d2841 dev arm --------------------------------------------
+        (when interop/debug-enabled?
+          (let [dispatched (->> @seen (filter #(= :rf.event/dispatched (:operation %))))
+                ev-for     (fn [id]
+                             (first (filter #(= [id] (get-in % [:tags :rf.event/v])) dispatched)))]
+            (is (= :ui          (:source (ev-for :test/lvl-0))) "root keeps :ui")
+            (is (= :fx-dispatch (:source (ev-for :test/lvl-1))) "lvl-1 stamped :fx-dispatch")
+            (is (= :fx-dispatch (:source (ev-for :test/lvl-2)))
+                "lvl-2 ALSO stamped :fx-dispatch (immediate trigger, not :ui from the root)")))
         (finally (rf/unregister-listener! :trace ::rec))))))
 
 (deftest dispatch-fx-preserves-origin-while-overriding-source
   (testing ":origin propagates through the cascade; :source is OVERRIDDEN per-step"
-    (let [seen (atom [])]
+    (let [seen      (atom [])
+          envelopes (atom {})]
       (rf/register-listener! :trace ::rec (fn [ev] (swap! seen conj ev)))
       (try
-        (rf/reg-event :test/parent (fn [_ _] {:fx [[:dispatch [:test/child]]]}))
-        (rf/reg-event :test/child  (fn [{:keys [db]} _] {:db db}))
+        (register-probe-fx! envelopes)
+        (rf/reg-event :test/parent
+          (fn [_ _] {:fx [[:test/probe [:parent]] [:dispatch [:test/child]]]}))
+        (rf/reg-event :test/child
+          (fn [{:keys [db]} _] {:db db :fx [[:test/probe [:child]]]}))
 
         (rf/dispatch-sync [:test/parent] {:source :ui :origin :pair})
 
-        (let [dispatched (->> @seen (filter #(= :rf.event/dispatched (:operation %))))
-              parent-ev  (first (filter #(= [:test/parent] (get-in % [:tags :rf.event/v])) dispatched))
-              child-ev   (first (filter #(= [:test/child]  (get-in % [:tags :rf.event/v])) dispatched))]
-          (is (= :pair (get-in parent-ev [:tags :rf.event/origin])))
-          (is (= :pair (get-in child-ev  [:tags :rf.event/origin]))
+        ;; ---- ALWAYS-ON (rf2-d2841): the two axes read off the envelopes ---
+        (let [parent-env (:parent @envelopes)
+              child-env  (:child  @envelopes)]
+          (is (= :pair (:origin parent-env)))
+          (is (= :pair (:origin child-env))
               ":origin propagates through the cascade")
-          (is (= :ui          (:source parent-ev)))
-          (is (= :fx-dispatch (:source child-ev))
+          (is (= :ui          (:source parent-env)))
+          (is (= :fx-dispatch (:source child-env))
               ":source is overridden by the substrate's :dispatch fx (rf2-ejtpd)"))
+
+        ;; ---- rf2-d2841 dev arm: the trace SHAPE — `:origin` under `:tags`,
+        ;;      `:source` hoisted to the top level (Spec 009 §Core fields).
+        (when interop/debug-enabled?
+          (let [dispatched (->> @seen (filter #(= :rf.event/dispatched (:operation %))))
+                parent-ev  (first (filter #(= [:test/parent] (get-in % [:tags :rf.event/v])) dispatched))
+                child-ev   (first (filter #(= [:test/child]  (get-in % [:tags :rf.event/v])) dispatched))]
+            (is (= :pair (get-in parent-ev [:tags :rf.event/origin])))
+            (is (= :pair (get-in child-ev  [:tags :rf.event/origin]))
+                ":origin propagates through the cascade")
+            (is (= :ui          (:source parent-ev)))
+            (is (= :fx-dispatch (:source child-ev))
+                ":source is overridden by the substrate's :dispatch fx (rf2-ejtpd)")))
         (finally (rf/unregister-listener! :trace ::rec))))))
 
 ;; ---- :fx-dispatch-later stamp by the :dispatch-later fx handler ----------
 
 (deftest dispatch-later-fx-stamps-source-fx-dispatch-later
   (testing ":dispatch-later fx stamps `:source :fx-dispatch-later` on the deferred dispatch"
-    (let [seen (atom [])
-          done (promise)]
-      (rf/register-listener! :trace ::rec
-        (fn [ev]
-          (swap! seen conj ev)
-          (when (and (= :rf.event/dispatched (:operation ev))
-                     (= [:test/child] (get-in ev [:tags :rf.event/v])))
-            (deliver done :seen))))
+    (let [seen      (atom [])
+          envelopes (atom {})
+          ;; rf2-d2841 — the completion signal rides the ALWAYS-ON probe, not
+          ;; the trace listener. Waiting on a trace under -Dre-frame.debug=false
+          ;; simply never returns, so the case used to burn its whole 2s timeout
+          ;; before failing.
+          done      (promise)]
+      (rf/register-listener! :trace ::rec (fn [ev] (swap! seen conj ev)))
       (try
+        (rf/reg-fx :test/probe
+          (fn [m [level]]
+            (swap! envelopes assoc level (:envelope m))
+            (when (= :child level) (deliver done :seen))))
         (rf/reg-event :test/parent
           (fn [_ _]
-            {:fx [[:dispatch-later {:ms 1 :event [:test/child]}]]}))
-        (rf/reg-event :test/child (fn [{:keys [db]} _] {:db db}))
+            {:fx [[:test/probe [:parent]]
+                  [:dispatch-later {:ms 1 :event [:test/child]}]]}))
+        (rf/reg-event :test/child
+          (fn [{:keys [db]} _] {:db db :fx [[:test/probe [:child]]]}))
 
         (rf/dispatch-sync [:test/parent] {:source :ui})
 
         (is (= :seen (deref done 2000 :timeout))
             "the deferred :test/child dispatch fired")
 
-        (let [dispatched (->> @seen (filter #(= :rf.event/dispatched (:operation %))))
-              parent-ev  (first (filter #(= [:test/parent] (get-in % [:tags :rf.event/v])) dispatched))
-              child-ev   (first (filter #(= [:test/child]  (get-in % [:tags :rf.event/v])) dispatched))]
-          (is (some? parent-ev))
-          (is (some? child-ev))
-          (is (= :ui                (:source parent-ev)))
-          (is (= :fx-dispatch-later (:source child-ev))
+        ;; ---- ALWAYS-ON (rf2-d2841) ---------------------------------------
+        (let [parent-env (:parent @envelopes)
+              child-env  (:child  @envelopes)]
+          (is (some? parent-env))
+          (is (some? child-env))
+          (is (= :ui                (:source parent-env)))
+          (is (= :fx-dispatch-later (:source child-env))
               ":dispatch-later fx stamped :source :fx-dispatch-later on the deferred dispatch (rf2-ejtpd)"))
+
+        ;; ---- rf2-d2841 dev arm --------------------------------------------
+        (when interop/debug-enabled?
+          (let [dispatched (->> @seen (filter #(= :rf.event/dispatched (:operation %))))
+                parent-ev  (first (filter #(= [:test/parent] (get-in % [:tags :rf.event/v])) dispatched))
+                child-ev   (first (filter #(= [:test/child]  (get-in % [:tags :rf.event/v])) dispatched))]
+            (is (some? parent-ev))
+            (is (some? child-ev))
+            (is (= :ui                (:source parent-ev)))
+            (is (= :fx-dispatch-later (:source child-ev))
+                ":dispatch-later fx stamped :source :fx-dispatch-later on the deferred dispatch (rf2-ejtpd)")))
         (finally (rf/unregister-listener! :trace ::rec))))))

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -190,7 +190,6 @@ known_red=(
   re-frame.core-epoch-egress-profile-test
   re-frame.db-pending-trace-test
   re-frame.dispatched-trace-cofx-test
-  re-frame.ep0026-inline-grammar-cljs-test
   re-frame.event-context-partition-test
   re-frame.frame-destroy-composed-test
   re-frame.frame-destroy-incarnation-jvm-test
@@ -198,7 +197,6 @@ known_red=(
   re-frame.fx-aggregate-classification-cljs-test
   re-frame.fx-args-trace-egress-cljs-test
   re-frame.fx-redirect-classification-cljs-test
-  re-frame.image-inline-metadata-normalization-cljs-test
   re-frame.interceptor-override-summary-trace-test
   re-frame.live-frame-reload-cljs-test
   re-frame.observation-port-cljs-test
@@ -211,7 +209,6 @@ known_red=(
   re-frame.sub-cycle-cljs-test
   re-frame.sub-dispose-trace-test
   re-frame.sub-parametric-inputs-test
-  re-frame.subs-inline-normalization-cljs-test
   re-frame.substrate-source-test
   re-frame.success-path-call-site-test
   re-frame.success-path-trigger-handler-test

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -186,13 +186,11 @@ known_red=(
   re-frame.cofx-cljs-test
   re-frame.cofx-envelope-test
   re-frame.db-pending-trace-test
-  re-frame.dispatched-trace-cofx-test
   re-frame.event-context-partition-test
   re-frame.frame-destroy-composed-test
   re-frame.frame-destroy-incarnation-jvm-test
   re-frame.interceptor-override-summary-trace-test
   re-frame.observation-port-cljs-test
-  re-frame.override-capture-trace-test
   re-frame.reg-meta-noswallow-cljs-test
   re-frame.registrar-warnings-test
   re-frame.source-coord-jvm-test

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -44,8 +44,9 @@
 # a rewrite of how those assertions are spelled.  Triage beads are named per
 # cluster below.
 #
-# What is left IS green, and it is not a rump: 140 namespaces, exit 0 — versus
-# the zero suites that had ever executed under this posture before.  (It was
+# What is left IS green, and it is not a rump: 140 namespaces, 1560 tests, 6707
+# assertions, exit 0 — versus the zero suites that had ever executed under this
+# posture before.  (It was
 # 88 / 934 / 4340 tests/assertions before rf2-d2841 split the spine's
 # dev-instrumentation assertions away from the semantics beside them,
 # 94 / 1106 / 5135 before that bead's second pass took `fx-test` — the largest
@@ -344,15 +345,19 @@ fi
 # green with `Ran 0 tests`.  Calibrated below the observed count with room for
 # ordinary churn; raise it when the roster grows materially.
 #
-# RAISED 800 -> 1360 (rf2-d2841, third pass).  800 was calibrated against the
-# 915-test lane of rf2-f8x2i's original run and had stopped doing its job: the
-# lane now runs 1401 tests, so a regression that silently dropped a THIRD of
-# them still cleared the floor.  Concretely, the twenty namespaces this pass
-# added are 188 tests — losing the whole batch lands at 1213, which 800 would
-# wave through.  1360 notices that while leaving ~3% for ordinary churn.  The
-# floor is a collapse detector, not a target: it must sit close enough under
-# the observed count that the smallest batch anyone lands is still visible.
-export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1360}"
+# RAISED 800 -> 1360 (rf2-d2841, third pass), then 1360 -> 1510 (fourth pass).
+# 800 was calibrated against the 915-test lane of rf2-f8x2i's original run and
+# had stopped doing its job.  1360 was calibrated against 1401 and stopped
+# doing its job the same way: the lane now runs 1560 tests, and the seventeen
+# namespaces the fourth pass added are 159 of them — losing the whole batch
+# lands at 1401, which 1360 waves through.  1510 notices that while leaving
+# ~3% for ordinary churn.
+#
+# The floor is a COLLAPSE DETECTOR, not a target, and the rule that follows
+# from that is why it has moved every pass: it must sit close enough under the
+# observed count that THE SMALLEST BATCH ANYONE LANDS IS STILL VISIBLE.  A
+# floor left behind by a growing lane is not conservative, it is inert.
+export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1510}"
 
 args=()
 for ns in $runnable; do

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -181,10 +181,8 @@ known_red=(
   #    `(when (and interop/debug-enabled? …))`, so the knob and its warning
   #    are equally dev-only. Check the implementation, not the plausible
   #    story about it.
-  re-frame.capture-frame-reincarnation-sink-route-cljs-test
   re-frame.capture-frame-test
   re-frame.cascade-dispatch-id-test
-  re-frame.classification-effects-cljs-test
   re-frame.cofx-cljs-test
   re-frame.cofx-envelope-test
   re-frame.core-epoch-egress-profile-test
@@ -194,9 +192,6 @@ known_red=(
   re-frame.frame-destroy-composed-test
   re-frame.frame-destroy-incarnation-jvm-test
   re-frame.frame-teardown-report-cljs-test
-  re-frame.fx-aggregate-classification-cljs-test
-  re-frame.fx-args-trace-egress-cljs-test
-  re-frame.fx-redirect-classification-cljs-test
   re-frame.interceptor-override-summary-trace-test
   re-frame.live-frame-reload-cljs-test
   re-frame.observation-port-cljs-test

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -44,15 +44,16 @@
 # a rewrite of how those assertions are spelled.  Triage beads are named per
 # cluster below.
 #
-# What is left IS green, and it is not a rump: 123 namespaces, 1401 tests, 6054
-# assertions, exit 0 — versus the zero suites that had ever executed under this
-# posture before.  (It was 88 / 934 / 4340 before rf2-d2841 split the spine's
+# What is left IS green, and it is not a rump: 140 namespaces, exit 0 — versus
+# the zero suites that had ever executed under this posture before.  (It was
+# 88 / 934 / 4340 tests/assertions before rf2-d2841 split the spine's
 # dev-instrumentation assertions away from the semantics beside them,
 # 94 / 1106 / 5135 before that bead's second pass took `fx-test` — the largest
 # single entry, 107 failures and 25 errors across ~20 deftests — plus
-# `sub-topology`, `init-platform`, `pattern-smoke` and `db-noop-commit`, and
-# 103 / 1213 / 5590 before its third pass took twenty more — the twenty are
-# named in that pass's commits — `git log --grep=rf2-d2841`.)
+# `sub-topology`, `init-platform`, `pattern-smoke` and `db-noop-commit`,
+# 103 / 1213 / 5590 before its third pass took twenty more, and 123 / 1401 /
+# 6054 before its FOURTH pass took seventeen more.  Each pass's namespaces are
+# named in its commits — `git log --grep=rf2-d2841`.)
 #
 # The roster is therefore an EXCLUSION list, not an allowlist.  The polarity is
 # the point: a namespace added to `implementation/core/test/` joins this lane
@@ -181,6 +182,50 @@ known_red=(
   #    `(when (and interop/debug-enabled? …))`, so the knob and its warning
   #    are equally dev-only. Check the implementation, not the plausible
   #    story about it.
+  #
+  #    THE FOURTH PASS'S LESSON: ASK WHERE THE SUBJECT LIVES, NOT WHERE THE
+  #    TEST HAPPENS TO READ IT.  Over half of that pass's seventeen namespaces
+  #    needed no guard at all for their main claim, because the thing under
+  #    test was production state that the test had merely been OBSERVING
+  #    through the trace.  `:source :fx-dispatch`, `:rf.cofx`, `:fx-overrides`
+  #    and `:interceptor-overrides` are slots on the DISPATCH ENVELOPE, and a
+  #    user fx-handler is handed that envelope verbatim as `(:envelope m)` —
+  #    the surface `cascade-envelope-propagation-test/fx-handler-ctx-carries-
+  #    envelope-slot` pins.  An `:ovc/probe`-style fx inside each level of a
+  #    cascade reads every one of them with no trace involvement, in BOTH
+  #    postures.  `substrate-source-test` went from contributing nothing under
+  #    this lane to contributing sixteen assertions that way.
+  #
+  #    THE SAME QUESTION, ASKED OF THE ERROR AXIS, IS "IS THE CATEGORY
+  #    PROMOTED?"  `:rf.error/classification-effect-shape`,
+  #    `:rf.error/sub-input-fn-exception`, `:rf.error/sub-input-fn-bad-return`
+  #    and `:rf.error/no-such-sub` all fan through
+  #    `error-emit/emit-error-both!`, so "it fails loud" is provable on the
+  #    `:errors` stream in production posture.  What does NOT survive is the
+  #    DETAIL: `emit-error-both!` lifts only `:failing-id` / `:reason`, and
+  #    only when `:failing-id` differs from `:event-id`.  So a category with
+  #    no `:failing-id` — classification-effect-shape — reaches production
+  #    saying THAT an effect was malformed but not WHICH KEY.
+  #
+  #    AND A CORRECTION.  `fx-args-trace-egress-cljs-test`'s docstring claimed
+  #    the `:rf.fx/args` slot on the fx error traces "is production-survivable
+  #    — it fans out through the always-on error-emit listener".  The CATEGORY
+  #    is promoted; the SLOT is not.  `fx.cljc`'s `:rf.error/no-such-fx` site
+  #    says so outright: "the tight-record discipline is intact: `:rf.fx/args`
+  #    stays on the dev trace and does NOT reach the production record".  That
+  #    is the third triage reason across four passes that turned out to be
+  #    wrong when checked against the source.  Check the source.
+  #
+  #    ONE MORE FALSE-GREEN SHAPE, worth recognising because it is not a trace
+  #    ring: `core-epoch-egress-profile-test` read its claims off the EPOCH
+  #    RING, which `epoch.capture/observe-trace-event!` feeds from the dev
+  #    trace.  Empty ring → nil record → nil marker, and SIX assertions on an
+  #    egress-PRIVACY surface passed on the nil: two `(= x y)` where both were
+  #    nil, `(not (contains? nil :digest))`, a `count` over an empty string, a
+  #    `not-any?` over an empty history, and a human-sentence check on a nil
+  #    message.  The fix was not a guard — `projected-record` is a pure
+  #    function of a record plus the frame's durable elision registry, so the
+  #    profile rows now drive a SYNTHETIC record and run in both postures.
   re-frame.capture-frame-test
   re-frame.cascade-dispatch-id-test
   re-frame.cofx-cljs-test

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -191,9 +191,7 @@ known_red=(
   re-frame.event-context-partition-test
   re-frame.frame-destroy-composed-test
   re-frame.frame-destroy-incarnation-jvm-test
-  re-frame.frame-teardown-report-cljs-test
   re-frame.interceptor-override-summary-trace-test
-  re-frame.live-frame-reload-cljs-test
   re-frame.observation-port-cljs-test
   re-frame.override-capture-trace-test
   re-frame.reg-meta-noswallow-cljs-test
@@ -201,10 +199,8 @@ known_red=(
   re-frame.registrar-warnings-test
   re-frame.source-coord-jvm-test
   re-frame.source-coords-test
-  re-frame.sub-cycle-cljs-test
   re-frame.sub-dispose-trace-test
   re-frame.sub-parametric-inputs-test
-  re-frame.substrate-source-test
   re-frame.success-path-call-site-test
   re-frame.success-path-trigger-handler-test
   re-frame.trace-buffer-test

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -185,7 +185,6 @@ known_red=(
   re-frame.cascade-dispatch-id-test
   re-frame.cofx-cljs-test
   re-frame.cofx-envelope-test
-  re-frame.core-epoch-egress-profile-test
   re-frame.db-pending-trace-test
   re-frame.dispatched-trace-cofx-test
   re-frame.event-context-partition-test
@@ -195,12 +194,10 @@ known_red=(
   re-frame.observation-port-cljs-test
   re-frame.override-capture-trace-test
   re-frame.reg-meta-noswallow-cljs-test
-  re-frame.reg-view-injection-test
   re-frame.registrar-warnings-test
   re-frame.source-coord-jvm-test
   re-frame.source-coords-test
   re-frame.sub-dispose-trace-test
-  re-frame.sub-parametric-inputs-test
   re-frame.success-path-call-site-test
   re-frame.success-path-trigger-handler-test
   re-frame.trace-buffer-test


### PR DESCRIPTION
Fourth pass on `rf2-d2841`. **The bead stays OPEN** — roster lines remain.

`implementation/core` is the only artefact still carrying a prod-gate exclusion
list. This pass splits dev-instrumentation assertions from the semantics beside
them in **seventeen** namespaces, so those namespaces' semantics now run under
the real `-Dre-frame.debug=false` posture.

## The lesson this pass earned

**Ask where the subject LIVES, not where the test happens to READ it.**

Over half of the seventeen needed no guard at all for their main claim. `:source`,
`:rf.cofx`, `:fx-overrides` and `:interceptor-overrides` are slots on the
**dispatch envelope** — production state — and a user fx-handler is handed that
envelope verbatim as `(:envelope m)`, the surface
`cascade-envelope-propagation-test/fx-handler-ctx-carries-envelope-slot`
already pins. Reading them off `:rf.event/dispatched` was one way to observe
them, and the one that vanishes under the gate. A probe fx inside each level of
a cascade reads all of them with no trace involvement, in **both** postures.
`substrate-source-test` went from contributing nothing under this lane to
contributing sixteen assertions that way.

On the error axis the same question is *"is the category PROMOTED?"*.
`:rf.error/classification-effect-shape`, `:rf.error/sub-input-fn-exception`,
`:rf.error/sub-input-fn-bad-return` and `:rf.error/no-such-sub` all fan through
`error-emit/emit-error-both!`, so **"it fails loud" is provable in production
posture** — which is the only posture a fail-loud claim is about.

## Vacuous passes found

**Seventeen, every one of them in a namespace rostered only for its reds.**

| class | count | where |
| --- | --- | --- |
| 1 — negative over an empty ring / nil subject | 9 | `fx-aggregate-classification` ×2, `fx-redirect-classification` ×2, `sub-cycle` ×2, `core-epoch-egress-profile` ×3 |
| 3 — a positive assertion the gate short-circuits | 2 | `core-epoch-egress-profile` |
| 4 — absence of a key the gate elides wholesale | 6 | `override-capture-trace` ×3, `core-epoch-egress-profile`, `subs-inline-normalization`, `dispatched-trace-cofx` |

**Class 3 is new** — the third pass looked for it and correctly did not find
one. `core-epoch-egress-profile` has two: `(= default-body obs-body)` and
`(= (dissoc tool-body :digest) obs-body)`, both `nil = nil` because the epoch
ring is empty under the gate.

The four worst are the whole-stream redaction sweeps —
`(is (not (some #(leaks? sentinel %) @traces)))` over an **empty** `@traces` —
the same shape the third pass found in the two `machine-*-classification`
suites, on the same kind of surface. All now sit inside the arm beside the
positives that give them teeth.

**No class 2 was found, and two namespaces were kept out of it deliberately.**
`fx-args-trace-egress` and `substrate-source` would each have become 100% dev
instrumentation under a wholesale guard. Both got always-on witnesses instead
(see below).

**One file already defended itself and is worth copying twice over.**
`fx-args-trace-egress`'s sweep ends `(is (pos? @checked) "the sweep actually
inspected trace tags")` — so under the gate it went RED rather than green, and
contributed no vacuous pass at all. `capture-frame-reincarnation-sink-route`'s
`probe-vacuity!` does the same for its `(zero? (count @b-sink))` negative by
landing a real record in the same sink immediately afterwards.

## A third triage reason that was wrong

`fx-args-trace-egress-cljs-test`'s docstring claimed the `:rf.fx/args` slot on
the fx error traces "is production-survivable — it fans out through the
always-on error-emit listener, not just the dev trace", and used that to call
the error arm the more serious of the two slots. **The category is promoted;
the slot is not.** `fx.cljc`'s own `:rf.error/no-such-fx` site says so outright
— *"the tight-record discipline is intact: `:rf.fx/args` stays on the dev trace
and does NOT reach the production record"* — and `emit-error-both!` lifts only
`:failing-id` / `:reason` out of the trace tags. Corrected in place, and written
into the roster script so nobody re-aims at a channel that never carries it.

## New coverage, not just preserved

* **`substrate-source`** — all four cases now read the `:source` stamp off the
  envelope. The three-deep override and the `:dispatch-later` deferral had no
  production-posture counterpart anywhere. That case also used to wait on a
  promise delivered by the *trace* listener, so under the gate it burned its
  full 2s timeout before failing; the probe delivers it in both postures.
* **`fx-args-trace-egress`** gains the deterministic projector teeth its two
  siblings already had — the `:rf.event/fx` aggregate slot and the
  `[:rf.fx/id :rf.fx/args]` pair on all three ops that stamp it — plus a
  body-receives-RAW-args control on each live arm.
* **`core-epoch-egress-profile`**'s closed-enum rejection was, under the gate,
  *not happening at all*: `raw` was nil, `projected-record` returns nil for a
  non-map, and nothing was rejected. It now drives a synthetic record and stays
  loud in the posture that ships.
* **`reg-view-injection`** proves the injected `dispatch` noun really
  dispatches, and that the RENDER-time frame capture survives the opts
  injection (the rf2-tqlmq regression) — read off app-db, in the render frame
  and no other.
* **`sub-cycle`**'s `reactive-cycle-recovery-is-not-cached` had *nothing* but a
  trace count; "not cached" is a statement about the sub-cache, so it now
  asserts the cache miss itself.
* **`frame-teardown-report`**'s always-on report is now shown to NAME both
  hooks, so the per-hook detail is visibly folded into the one record rather
  than lost with the diagnostic channel.
* **`override-capture-trace`**'s per-frame-tier exclusion gains the contrast
  that makes it a discrimination: the frame really does declare the override in
  its config while the envelope composes nothing.

## An observability gap worth a look (not fixed here — source is out of fence)

`:rf.error/classification-effect-shape` passes no `:failing-id`, so
`emit-error-both!` lifts nothing, and its always-on record tells a production
listener **that** a commit-plane classification effect was malformed but not
**which key**. `emit-error-both!`'s trailing `record-attrs` argument exists for
exactly this (the flow-eval category uses it). Same shape as rf2-g0mep /
rf2-mlh1h.

## Quality gates

| gate | result |
| --- | --- |
| `bash scripts/test-core-prod-gate.sh` | exit 0 — **140 of 184** namespaces |
| `clojure -M:test` (core, dev posture, branch) | exit 0 — 2184 tests / 10956 assertions |
| per-namespace gated runs, every cluster | exit 0 |
| `python scripts/check_jvm_lane_rosters.py` | exit 0 — 31 rostered artefacts, bijection intact |
| `bash -n scripts/test-core-prod-gate.sh` | exit 0 |

Roster: **61 → 44** excluded. Under this bead's own heading: **49 → 32**, of
which **15** are the no-semantic-residue cohort that must NOT come off by
guarding (they want the var-level `-e :requires-debug` tag, a
`implementation/deps.edn` change outside this PR's fence). So **17 of the 34
actionable lines** are discharged and 17 remain.

Dev-posture assertion count, measured against a **pristine `origin/main`
worktree**, not inferred:

| | tests | assertions |
| --- | --- | --- |
| `origin/main` (pristine worktree) | 2180 | 10860 |
| this branch | 2184 | **10956** |

**No assertion was deleted or weakened.** The four extra deftests are the new
always-on witnesses in `fx-args-trace-egress` (two projector-teeth, two
body-receives-raw-args).

**`RF2_MIN_TESTS` RAISED 1360 -> 1510.** The floor is a collapse detector, not a
target, and 1360 had stopped doing its job the same way 800 had before it: the
lane now runs **1560** tests and this pass'''s seventeen namespaces are **159** of
them, so losing the whole batch lands at 1401 — which 1360 waves through. 1510
notices that while leaving ~3% for ordinary churn. A floor left behind by a
growing lane is not conservative, it is inert.

Nothing failed for a REAL reason. Every gate failure across all seventeen
namespaces was a test reading a channel that production does not carry.
