### PR TITLE
fix(core): a malformed classification effect names its key in production (rf2-eg61l)

### DIFF
--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1935,20 +1935,60 @@
   (the classification is not installed and neither is the `:db` write).
 
   `defect` is the `re-frame.elision/classification-effect-defect` map
-  (`{:offending-key … :value … :reason …}`)."
+  (`{:offending-key … :value … :reason …}`).
+
+  ## Which key, not merely that one was malformed (rf2-eg61l)
+
+  `:offending-key` is lifted onto the ALWAYS-ON record through
+  `emit-error-both!`'s trailing `record-attrs` map — the seam the flow-eval
+  category already uses for `{:flow-id … :where :flow-eval}`, so no other
+  category's record widens and the shared `:failing-id` lift rule is untouched.
+  Without it a production build heard only that SOME classification payload
+  aborted an event: the four axes are independently malformable and
+  `:offending-key` is the ONLY discriminator between them (rf2-mz582u added it
+  for exactly that), and it rode the DCE'd dev trace alone. An off-box shipper
+  (Sentry / Datadog) had an error with no route to the cause.
+
+  ## Why the KEY egresses and the VALUE does not
+
+  This record is production-surviving and NOT privacy-gated, so every slot on
+  it is an egress decision. `:offending-key` is PROGRAM STRUCTURE with a CLOSED
+  domain: `classification-effect-defect` stamps it by iterating
+  `elision/classification-effect-keys`, so its value is always one of the four
+  framework-owned keywords `:sensitive` / `:large` / `:clear-sensitive` /
+  `:clear-large`. It is not application-authored, not derived from the payload,
+  and cannot be widened by a caller — it carries two bits of \"which axis\",
+  nothing more.
+
+  `:value` is the REJECTED PAYLOAD itself — handler- or `:after`-interceptor-
+  authored, and on a fail-loud path by definition not what the framework
+  expected — so it stays on the dev trace, which DCEs. `:reason` stays with it:
+  it is prose that INTERPOLATES that payload through `pr-str`, so shipping it
+  would ship the value by the back door. Note that the trace tags deliberately
+  carry NO `:failing-id`: adding one would trip `emit-error-both!`'s shared lift
+  and drag the interpolating `:reason` onto the always-on record. The closed key
+  set of the record that egresses is pinned by
+  `re-frame.classification-effect-shape-record-cljs-test`."
   [defect event event-id frame start-ms]
-  (let [end-ms     (interop/now-ms)
-        elapsed-ms (elapsed-ms-from start-ms end-ms)]
+  ;; Build the discriminator ONCE, before either axis sees it — the two axes
+  ;; must never be able to disagree about which key was at fault.
+  (let [end-ms        (interop/now-ms)
+        elapsed-ms    (elapsed-ms-from start-ms end-ms)
+        offending-key (:offending-key defect)]
     (error-emit/emit-error-both!
       :rf.error/classification-effect-shape
       event event-id frame nil elapsed-ms end-ms
+      ;; Axis 2 — the dev trace. Carries the full diagnosis, DCE'd in prod.
       {:frame             frame
        :rf.trace/event-id event-id
        :rf.event/v        event
-       :offending-key     (:offending-key defect)
+       :offending-key     offending-key
        :value             (:value defect)
        :recovery          :fix-effect
-       :reason            (:reason defect)})))
+       :reason            (:reason defect)}
+      ;; Axis 1 — the always-on record. The bounded structural discriminator
+      ;; ONLY; see §Why the KEY egresses and the VALUE does not above.
+      {:offending-key offending-key})))
 
 (defn- run-fx-effects!
   "Walk :fx in source order, threading fx-overrides through so per-frame

--- a/implementation/core/test/re_frame/classification_effect_shape_record_cljs_test.cljc
+++ b/implementation/core/test/re_frame/classification_effect_shape_record_cljs_test.cljc
@@ -1,0 +1,269 @@
+(ns re-frame.classification-effect-shape-record-cljs-test
+  "rf2-eg61l — what a PRODUCTION build learns when a malformed commit-plane
+  classification effect aborts an event.
+
+  `router/emit-classification-effect-shape!` fans the EP-0025 rejection through
+  `error-emit/emit-error-both!`, and axis 1 of that helper —
+  `dispatch-on-error!` — is NOT gated on `interop/debug-enabled?`. So the record
+  really does reach an off-box shipper (Sentry / Datadog) from a `:advanced` +
+  `goog.DEBUG=false` build. Until this bead it said only that SOME
+  classification payload was malformed: `:offending-key` — the one slot
+  rf2-mz582u added so a malformed `:clear-large` could be told from a malformed
+  `:sensitive` — rode the DCE'd dev trace alone, so the operator holding the
+  error had no route to the cause.
+
+  ## What this namespace pins
+
+    1. The record NAMES THE KEY, for each of the four independently-malformable
+       axes (`:sensitive` / `:large` / `:clear-sensitive` / `:clear-large`).
+    2. The key set is CLOSED. This record egresses; a slot added later reaches a
+       shipper whether or not anyone reviewed it, and that assertion is the
+       review.
+    3. The record carries NO payload-derived value — not the rejected payload
+       under `:value`, not the prose `:reason` that interpolates it, and not the
+       payload's content by any other route.
+
+  ## Why the KEY is safe to ship where the VALUE is not
+
+  `:offending-key` is PROGRAM STRUCTURE with a CLOSED domain.
+  `elision/classification-effect-defect` stamps it by iterating
+  `elision/classification-effect-keys`, so it is always one of four
+  framework-owned keywords. It is not application-authored, not lifted out of
+  the payload, and cannot be widened by a caller — it carries \"which of four
+  axes\", nothing more. `the-offending-key-domain-is-the-closed-framework-set`
+  pins that domain so the argument stays true.
+
+  `:value` is the rejected payload itself — handler- or `:after`-interceptor-
+  authored, and by definition not what the framework expected — so it is
+  attacker-controlled or user-private on any path fed from a boundary. It is
+  omitted OUTRIGHT rather than scrubbed, the same discipline
+  `re-frame.always-on-validation-production-test` applies to the at-boundary
+  record. `:reason` goes with it: `classification-effect-defect` builds that
+  sentence by `pr-str`-ing the payload into it, so shipping the prose ships the
+  value by the back door.
+
+  ## Posture
+
+  Every assertion here is POSTURE-INDEPENDENT and reads the ALWAYS-ON `:errors`
+  registry, never the dev `:trace` stream. That is the whole subject: the claim
+  is about what survives `-Dre-frame.debug=false`, so the namespace joins
+  `scripts/test-core-prod-gate.sh` (that lane's roster is an EXCLUSION list — a
+  new namespace joins by default) and must be green there. Deliberately NOT
+  used: `with-redefs` on `interop/debug-enabled?` — the flag is read once at
+  namespace-load time and a rebind cannot reach it (rf2-f7qj4).
+
+  Dual-runtime: named `*_cljs_test.cljc` so the shadow-cljs `:node-test` build
+  (`npm run test:cljs`) AND the JVM `clojure -M:test` runner both pick it up.
+  Plain CLJC; no DOM dependency."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [clojure.set :as set]
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as ts]))
+
+(use-fixtures :each
+  (ts/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (error-emit/clear-error-listeners!))}))
+
+;; ---------------------------------------------------------------------------
+;; The CLOSED key set of the always-on record.
+;; ---------------------------------------------------------------------------
+
+(def ^:private record-keys
+  "Every slot `:rf.error/classification-effect-shape` puts on the ALWAYS-ON
+  record — pinned rather than sampled, because widening it is an egress
+  decision and this assertion is where that decision gets made.
+
+  `:error` / `:recovery`-free framework fields plus the observability spine
+  `dispatch-on-error!` builds (`:event` — wire-elided there, `:event-id`,
+  `:frame`, `:time`, `:exception` (nil: an in-band rejection is not a throw),
+  `:elapsed-ms`, `:source-coord` from the always-on parallel coord registry),
+  plus the one lifted attribution slot `:offending-key` (rf2-eg61l)."
+  #{:error :event :event-id :frame :time :exception :elapsed-ms :source-coord
+    :offending-key})
+
+(def ^:private payload-bearing-keys
+  "Slots the DEV TRACE carries that the always-on record must NEVER.
+
+  `:value` is the rejected classification payload verbatim; `:reason` is prose
+  that `pr-str`s it into a sentence; `:rf.event/v` is the whole event vector
+  unelided. All three stay on the axis that DCEs."
+  #{:value :reason :rf.event/v :rf.trace/event-id})
+
+;; ---------------------------------------------------------------------------
+;; Helpers — read the ALWAYS-ON axis, which is what a production build has.
+;; ---------------------------------------------------------------------------
+
+(defn- record-always-on-errors
+  "Capture through the always-on `:errors` registry — NOT `register-listener!
+  :trace`, which is dev-only and sees nothing under the production gate. These
+  records are what an off-box shipper receives from a production build."
+  [body-fn]
+  (let [seen (atom [])]
+    (rf/register-listener! :errors ::rec (fn [r] (swap! seen conj r)))
+    (try (body-fn)
+         (finally (rf/unregister-listener! :errors ::rec)))
+    @seen))
+
+(defn- shape-records [records]
+  (filterv #(= :rf.error/classification-effect-shape (:error %)) records))
+
+(defn- reject!
+  "Seed `:n` to 1, then dispatch an event whose ONLY classification key is
+  `effect-key` carrying the malformed `payload`. Returns the always-on records
+  the rejection fanned. Asserts the abort actually happened (no `:db` commit),
+  so a green key-set assertion can never be green over a record that was never
+  produced."
+  [effect-key payload ev-id]
+  (rf/reg-event :seed (fn [{:keys [db]} _] {:db (assoc db :n 1)}))
+  (rf/dispatch-sync [:seed])
+  (rf/reg-event ev-id
+    (fn [{:keys [db]} _]
+      {:db (assoc db :n 2) effect-key payload}))
+  (let [records (record-always-on-errors #(rf/dispatch-sync [ev-id]))]
+    (is (= 1 (:n (frame/frame-app-db-value :rf/default)))
+        "precondition: the event aborted pre-commit (no :db write landed)")
+    (shape-records records)))
+
+;; ===========================================================================
+;; 1. The record NAMES THE KEY — on the axis that survives production.
+;; ===========================================================================
+
+(deftest the-always-on-record-names-the-offending-key
+  (testing "rf2-eg61l — a malformed classification effect fans exactly ONE
+            always-on record, and that record says WHICH of the four axes was
+            at fault. Before this the operator learned only that an event had
+            been aborted for a classification defect: `:offending-key` is the
+            sole discriminator between the four (rf2-mz582u) and it rode the
+            DCE'd dev trace alone."
+    (doseq [[effect-key payload ev-id]
+            [[:sensitive       :not-a-vector       :bad/sensitive]
+             [:large           :not-a-vector       :bad/large]
+             [:clear-sensitive :not-a-vector       :bad/clear-sensitive]
+             [:clear-large     :not-a-vector       :bad/clear-large]]]
+      (let [records (reject! effect-key payload ev-id)
+            rec     (first records)]
+        (is (= 1 (count records))
+            (str "exactly ONE always-on record for a malformed " effect-key))
+        (is (= effect-key (:offending-key rec))
+            (str "the always-on record names " effect-key " as the offending "
+                 "key. Red here means production is back to knowing only THAT "
+                 "a classification effect was malformed."))
+        (is (= ev-id (:event-id rec))
+            "and attributes it to the dispatch, so a shipper can count per-event")
+        (is (= :rf/default (:frame rec))
+            "and to the owning frame")))))
+
+(deftest a-malformed-path-entry-names-its-key-too
+  (testing "rf2-eg61l — the OTHER defect arm. A payload that IS a vector but
+            whose entry is not a path vector (or carries a non-EDN-identity
+            segment, which `path/normalize-concrete` throws on and
+            `classification-effect-defect` re-reports as the same defect) also
+            reaches the always-on record with its key named — the two arms of
+            `classification-effect-defect` must not disagree about attribution."
+    (let [rec (first (reject! :large [:not-a-path-vector] :bad/large-entry))]
+      (is (= :large (:offending-key rec))
+          "the bad-path-entry arm names its key on the always-on record too"))
+    (let [rec (first (reject! :sensitive [[(fn [] :nope)]] :bad/segment))]
+      (is (= :sensitive (:offending-key rec))
+          "and so does the caught `:rf.error/bad-path` arm"))))
+
+;; ===========================================================================
+;; 2. The KEY SET is CLOSED.
+;; ===========================================================================
+
+(deftest the-always-on-record-key-set-is-closed
+  (testing "rf2-eg61l — whatever this record carries ships to Sentry / Datadog.
+            The key set is pinned CLOSED, not sampled: a slot added later
+            reaches a shipper whether or not anyone reviewed it, and this
+            assertion is the review. Widening it is an EGRESS decision — read
+            `re-frame.router/emit-classification-effect-shape!`'s §Why the KEY
+            egresses and the VALUE does not first."
+    (let [rec (first (reject! :sensitive :not-a-vector :bad/closed))]
+      (is (some? rec) "precondition: the rejection fanned its record")
+      (is (= record-keys (set (keys rec)))
+          (str "the always-on record's key set is CLOSED. Extra keys are an "
+               "unreviewed egress widening; a MISSING `:offending-key` is "
+               "rf2-eg61l reopening.")))))
+
+(deftest the-offending-key-domain-is-the-closed-framework-set
+  (testing "rf2-eg61l — the safety argument for shipping this slot depends on
+            its DOMAIN being closed. `classification-effect-defect` stamps
+            `:offending-key` by iterating its own private four-key literal, so
+            every value the slot can take is a framework-owned keyword: never
+            application-authored, never lifted out of the payload. Pinned
+            STRUCTURALLY (drive the surface) rather than by reading that private
+            def — an app key that reached the slot would be an unbounded egress
+            widening, and the assertion below is what catches it."
+    (testing "an APPLICATION-authored effect key never becomes the offending key"
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db (assoc db :n 1)}))
+      (rf/dispatch-sync [:seed])
+      ;; Both keys carry a malformed payload; only ONE of them is a
+      ;; classification effect. An `:offending-key` naming the app key would
+      ;; mean the domain had opened up to caller-authored keywords.
+      (rf/reg-event :bad/mixed
+        (fn [{:keys [db]} _]
+          {:db                        (assoc db :n 2)
+           :sensitive                 :not-a-vector
+           :acme.billing/card-numbers :also-not-a-vector}))
+      (let [rec (->> (record-always-on-errors #(rf/dispatch-sync [:bad/mixed]))
+                     shape-records
+                     first)]
+        (is (= :sensitive (:offending-key rec))
+            "the framework key is named; the caller's key is not eligible")
+        (is (not (str/includes? (pr-str rec) "acme.billing"))
+            "and the caller's key appears nowhere on the record at all")))
+    (testing "a malformed value under a NON-classification key raises no
+              classification-effect-shape record at all"
+      (rf/reg-event :bad/app-only
+        (fn [_ _] {:acme.billing/card-numbers :not-a-vector}))
+      (let [recs (->> (record-always-on-errors #(rf/dispatch-sync [:bad/app-only]))
+                      shape-records)]
+        (is (empty? recs)
+            "the four-key set is the whole surface — an unknown effect key is
+             not a classification effect and cannot reach this category")))))
+
+;; ===========================================================================
+;; 3. The record carries NO payload-derived value.
+;; ===========================================================================
+
+(deftest the-always-on-record-carries-no-payload-derived-value
+  (testing "rf2-eg61l — the key is program structure; the VALUE is not. A
+            rejected classification payload is handler- or `:after`-interceptor-
+            authored and, on any path fed from a system boundary,
+            attacker-controlled or user-private. It is omitted OUTRIGHT rather
+            than scrubbed — no redactor can be trusted to have seen a key the
+            framework never named."
+    (let [secret   "sentinel-secret-value"
+          rec      (first (reject! :sensitive [secret] :bad/secret-carrier))]
+      (is (some? rec) "precondition: the rejection fanned its record")
+      (is (empty? (set/intersection payload-bearing-keys (set (keys rec))))
+          (str "no payload-bearing slot rides the always-on record — `:value`, "
+               "the interpolating `:reason` and the raw `:rf.event/v` are "
+               "DEV-TRACE ONLY."))
+      (is (not (str/includes? (pr-str rec) secret))
+          (str "and the rejected payload's own content appears NOWHERE in the "
+               "record, by any route — not stringified into a `:reason` "
+               "sentence, not smuggled through an identifier.")))))
+
+(deftest the-reason-lift-stays-shut-for-this-category
+  (testing "rf2-eg61l — `emit-error-both!` lifts `:reason` out of the dev-trace
+            tags ONLY alongside a `:failing-id` that differs from `:event-id`.
+            This category deliberately passes NO `:failing-id`, so that shared
+            rule stays shut here — which matters, because this category's
+            `:reason` is prose built by `pr-str`-ing the rejected payload into
+            it. Adding a `:failing-id` to the tags would ship the value.
+
+            Guarding the mechanism rather than the outcome: the assertion above
+            would still pass if the lift fired with a `:reason` that happened
+            not to quote THIS payload."
+    (let [rec (first (reject! :clear-sensitive :not-a-vector :bad/no-lift))]
+      (is (not (contains? rec :reason))
+          "no `:reason` on the always-on record")
+      (is (not (contains? rec :failing-id))
+          "and no `:failing-id`, which is what keeps the shared lift shut"))))


### PR DESCRIPTION
Closes rf2-eg61l.

## The gap

`router/emit-classification-effect-shape!` fans the EP-0025 commit-plane
rejection through `error-emit/emit-error-both!`, and axis 1 of that helper —
`dispatch-on-error!` — is **not** gated on `interop/debug-enabled?`. So a
production build already heard that *some* classification payload had aborted
an event, and shipped that record to Sentry / Datadog.

It did not hear **which key**. The four axes (`:sensitive`, `:large`,
`:clear-sensitive`, `:clear-large`) are independently malformable, and
`:offending-key` is the sole discriminator between them — rf2-mz582u added the
slot for exactly that — but the call passed no `record-attrs`, so the slot rode
the DCE'd dev trace alone. `emit-error-both!`'s own `:failing-id` lift does not
reach it either: this category passes no `:failing-id`, so the lift stays shut.
An operator reading that record had an error with no route to the cause.

Premise verified against current source before implementing; it held exactly as
filed.

## The change

One slot, lifted through the seam that already exists for it — the trailing
`record-attrs` map the flow-eval category uses for `{:flow-id … :where
:flow-eval}`. No other category's record widens and the shared lift rule is
untouched. The discriminator is bound **once** in the `let`, before either axis
sees it, so the trace tags and the always-on record can never disagree about
which key was at fault.

### The record's key set

| | before | after |
|---|---|---|
| always-on record | `:error` `:event` `:event-id` `:frame` `:time` `:exception` `:elapsed-ms` `:source-coord` | *(unchanged)* **+ `:offending-key`** |

Identical in both postures, verified under the real gate.

### Is a classification-effect KEY safe to ship?

Yes, and this is the argument.

**`:offending-key` is program structure with a CLOSED domain.**
`elision/classification-effect-defect` stamps it by iterating its own four-key
literal, so the value is always one of `:sensitive` / `:large` /
`:clear-sensitive` / `:clear-large` — framework-owned keywords, four of them,
not application-authored, not lifted out of the payload, and not extensible by
a caller. It carries "which of four axes", nothing more. The domain is pinned
structurally by test rather than asserted in prose: an event whose effects carry
a malformed payload under an app-authored key (`:acme.billing/card-numbers`)
still names `:sensitive`, and the app key appears nowhere on the record; an
event carrying *only* the app key raises no classification-effect-shape record
at all.

**The VALUE is not, and does not ship.** `:value` is the rejected payload
itself — handler- or `:after`-interceptor-authored, and on any path fed from a
system boundary attacker-controlled or user-private. It is omitted **outright**
rather than scrubbed, the same discipline `always-on-validation-production-test`
applies to the at-boundary record: no redactor can be trusted to have seen a key
the framework never named.

**`:reason` goes with it, and that is not incidental.**
`classification-effect-defect` builds that sentence by `pr-str`-ing the payload
into it, so shipping the prose would ship the value by the back door. This is
why the trace tags deliberately carry **no** `:failing-id` — adding one would
trip `emit-error-both!`'s shared `:reason` lift and do precisely that. A test
pins the mechanism (`:reason` and `:failing-id` both absent from the record),
not just the outcome, so a future `:failing-id` addition reds here rather than
leaking quietly.

## The test

New namespace `re-frame.classification-effect-shape-record-cljs-test`
(`.cljc`, so both the shadow-cljs `:node-test` build and the JVM runner take
it). It reads the always-on `:errors` stream only — never the dev `:trace`
stream — so every assertion is posture-independent, and it joins
`scripts/test-core-prod-gate.sh` **by default** (that lane's roster is an
exclusion list). No `with-redefs` on `interop/debug-enabled?`: the flag is read
at namespace-load time and a rebind cannot reach it.

It pins: the key is named for all four axes and both defect arms; the key set is
**closed**; the `:offending-key` domain is closed; no payload-bearing slot rides
the record and a sentinel from the rejected payload appears nowhere in it.

## Quality gates

Every gate run foreground to completion from the worker worktree, exit code
captured from the runner.

| gate | command | exit | result |
|---|---|---|---|
| new ns, dev posture | `clojure -M:test -n re-frame.classification-effect-shape-record-cljs-test` | **0** | 6 tests / 37 assertions, 0 failures |
| new ns, real production gate | `clojure -J-Dre-frame.debug=false -M:test -n …` | **0** | 6 tests / 37 assertions, 0 failures |
| conformance + neighbours | `clojure -M:test -n egress-chokepoint-conformance -n error-catalogue-channel-conformance -n classification-effects-cljs -n always-on-axis-conformance-cljs -n always-on-validation-production` | **0** | 62 tests / 285 assertions, 0 failures |
| core JVM, dev posture | `clojure -M:test` (implementation/core) | **0** | 2186 tests / 10897 assertions, 0 failures |
| **core production-gate lane** | `bash scripts/test-core-prod-gate.sh` | **0** | **124 of 185** namespaces, 1407 tests / 6091 assertions, 0 failures |
| CLJS node-test suite | `npm run test:cljs` | **0** | 11904 tests / 59431 assertions, 0 failures |

The prod-gate lane goes **123 → 124 of 185**: the new namespace joined by
default and is green there, so the lane is not regressed. (PR #7246 takes it to
140; the two are additive.)

Nothing deferred — no gate was skipped as too slow.

### Mutation evidence

Remove the lifted slot (delete the trailing `{:offending-key offending-key}`
from the `emit-error-both!` call), leave everything else alone, and re-run the
new namespace **under the real production gate**:

```
$ clojure -J-Dre-frame.debug=false -M:test -n re-frame.classification-effect-shape-record-cljs-test
EXIT=1
Ran 6 tests containing 37 assertions.
8 failures, 0 errors.
```

The closed-key-set assertion names the missing slot outright:

```
FAIL in (the-always-on-record-key-set-is-closed)
the always-on record's key set is CLOSED. Extra keys are an unreviewed egress
widening; a MISSING `:offending-key` is rf2-eg61l reopening.
expected: (= record-keys (set (keys rec)))
  actual: (not (= #{:event-id :source-coord :frame :time :event :error :exception
                    :elapsed-ms :offending-key}
                  #{:event-id :source-coord :frame :time :event :error :exception
                    :elapsed-ms}))
```

and the four naming assertions read `(not (= :sensitive nil))`,
`(not (= :large nil))`, `(not (= :clear-sensitive nil))`,
`(not (= :clear-large nil))` — one per axis.

Restored, re-run under the same gate: **exit 0**, 6 tests / 37 assertions, 0
failures, and `git diff --stat` empty.

## Notes for the merge queue

- **No collision with PR #7246.** That PR rewrites
  `classification_effects_cljs_test.cljc` (+103/−22) and
  `scripts/test-core-prod-gate.sh`. This PR touches **neither** — the pin went
  into a new namespace precisely to keep the two apart, and a new namespace
  needs no roster edit because the roster is an exclusion list. The two files
  this PR touches appear in no other open PR.
- **spec/009 needs nothing for this change** — the catalogue's Tags column for
  the row already lists `:offending-key`, and that column describes the dev-trace
  tags, which are unchanged. Not edited (hot zone).
- **Reported separately, not fixed here:** spec/009's Channel column for
  `:rf.error/classification-effect-shape` reads `diagnostic`, but the code fans
  it on the always-on axis via `emit-error-both!`, and the category is absent
  from `always-on-axis-conformance-cljs-test`'s `always-on-categories` literal.
  `:rf.error/legacy-runtime-root` — the sibling in-band router rejection, same
  emit shape — has exactly the same mismatch. That is a channel-classification
  ruling across at least two catalogue rows, coupled to the literal such that
  either edit alone reds the conformance test; it is filed rather than smuggled
  into a one-slot fix. This PR is correct either way: if the rows graduate, the
  record is now worth shipping; if the emissions are demoted instead, the slot
  goes with them.
