### PR TITLE
test(core): pass 5 — split dev instrumentation from semantics (rf2-d2841)

### DIFF
--- a/implementation/core/test/re_frame/capture_frame_test.clj
+++ b/implementation/core/test/re_frame/capture_frame_test.clj
@@ -16,7 +16,34 @@
 
   These JVM tests use `with-frame :A` to set the dynamic var, capture the
   handle, then EXIT the with-frame scope before invoking its ops —
-  proving the captured frame survives the unwind."
+  proving the captured frame survives the unwind.
+
+  ## Posture split (rf2-d2841)
+
+  NO GUARD WAS NEEDED HERE, and the reason is the question rf2-d2841's fourth
+  pass learned to ask on the error axis: IS THE CATEGORY PROMOTED?
+  `:rf.error/frame-destroyed` is one of the categories `error-emit` fans onto
+  the always-on corpus-wide listener registry (`error-emit` ns docstring,
+  §promoted set covers frame-destroyed dispatch / subscribe), so every incarnation
+  -fence assertion in this file survives the production gate verbatim once it
+  reads the `:errors` STREAM instead of the `:trace` stream. That is the whole
+  change: `register-listener! :errors`, and `(:error rec)` where the trace
+  spelled `(:operation ev)`.
+
+  It matters more here than the mechanical size of the diff suggests. These are
+  incarnation-fence tests — the class of defect where a capture pinned to a
+  destroyed incarnation leaks into a same-id successor and mutates it — and
+  every one of them was previously unexecuted under the posture that ships.
+
+  TWO VACUOUS PASSES CAME OFF (rf2-d2841 class 1 — a negative over an empty
+  trace ring), and both were in deftests already GREEN under the gate:
+  `live-target-not-reported-destroyed-when-only-owner-dies-async` / `-sync`
+  each certify `(zero? (count (filter #(= :rf.error/frame-destroyed …))))` —
+  the LIVE target was not wrongly reported destroyed — over a stream that
+  carried nothing at all. A false-negative check on a fence is exactly the
+  assertion you least want passing for free; re-aimed at the always-on stream
+  it now discriminates, with its sibling deftests supplying the control that
+  the same stream DOES carry the category when the fence genuinely fires."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -141,15 +168,15 @@
       (rf/make-frame {:id :fh/sub-stale :doc "incarnation B (successor)"})
       (rf/dispatch-sync [:fh/seed :B-value] {:frame :fh/sub-stale})
       (let [errs (atom [])]
-        (rf/register-listener! :trace ::sub-stale (fn [ev] (swap! errs conj ev)))
+        (rf/register-listener! :errors ::sub-stale (fn [rec] (swap! errs conj rec)))
         ;; Before the fix this returned a reaction reading B's :B-value; the
         ;; fence makes it recover-but-emit and return nil.
         (let [result (subscribe [:fh/value])]
-          (rf/unregister-listener! :trace ::sub-stale)
+          (rf/unregister-listener! :errors ::sub-stale)
           (is (nil? result)
               "the superseded capture's subscribe returns nil — it did NOT
                resolve a reaction into successor B")
-          (is (some #(= :rf.error/frame-destroyed (:operation %)) @errs)
+          (is (some #(= :rf.error/frame-destroyed (:error %)) @errs)
               "the superseded subscribe recover-but-emits :rf.error/frame-destroyed"))))))
 
 (deftest capture-frame-over-value-pins-exact-incarnation
@@ -174,14 +201,14 @@
         (rf/destroy-frame! frame-a)
         (rf/make-frame {:id :fh/vpin :doc "incarnation B (successor)"})
         (let [errs (atom [])]
-          (rf/register-listener! :trace ::vpin (fn [ev] (swap! errs conj ev)))
+          (rf/register-listener! :errors ::vpin (fn [rec] (swap! errs conj rec)))
           ;; Before the fix the unpinned value-capture retargeted B and set
           ;; :mark; the carried-token pin makes it recover-but-emit.
           (dispatch-sync [:fh/mark :leaked])
-          (rf/unregister-listener! :trace ::vpin)
+          (rf/unregister-listener! :errors ::vpin)
           (is (nil? (:mark (rf/app-db-value :fh/vpin)))
               "the stale value-capture did NOT mutate the same-id successor B")
-          (is (some #(= :rf.error/frame-destroyed (:operation %)) @errs)
+          (is (some #(= :rf.error/frame-destroyed (:error %)) @errs)
               "the superseded value-capture dispatch recover-but-emits :rf.error/frame-destroyed"))))))
 
 ;; ---- rf2-dlld6: carry the captured incarnation THROUGH target consumption ---
@@ -240,13 +267,13 @@
     (let [a-token (frame/frame-incarnation-token :fh/race)
           {:keys [dispatch-sync]} (rf/capture-frame :fh/race) ;; pins A
           errs    (atom [])]
-      (rf/register-listener! :trace ::race (fn [ev] (swap! errs conj ev)))
+      (rf/register-listener! :errors ::race (fn [rec] (swap! errs conj rec)))
       (run-supersede-during-precheck
         :fh/race a-token #(dispatch-sync [:fh/mark]))
-      (rf/unregister-listener! :trace ::race)
+      (rf/unregister-listener! :errors ::race)
       (is (nil? (:marked-by (rf/app-db-value :fh/race)))
           "the stale capture did NOT mutate same-id successor B")
-      (is (some #(= :rf.error/frame-destroyed (:operation %)) @errs)
+      (is (some #(= :rf.error/frame-destroyed (:error %)) @errs)
           "the superseded dispatch-sync recover-but-emits :rf.error/frame-destroyed"))))
 
 (deftest stale-capture-async-dispatch-does-not-enqueue-into-same-id-successor
@@ -258,18 +285,18 @@
     (let [a-token (frame/frame-incarnation-token :fh/race)
           {:keys [dispatch]} (rf/capture-frame :fh/race) ;; pins A
           errs    (atom [])]
-      (rf/register-listener! :trace ::race (fn [ev] (swap! errs conj ev)))
+      (rf/register-listener! :errors ::race (fn [rec] (swap! errs conj rec)))
       (run-supersede-during-precheck
         :fh/race a-token #(dispatch [:fh/mark]))
       ;; The fence short-circuits BEFORE enqueue/schedule, so nothing can drain
       ;; into B; poll to confirm the emit lands rather than asserting a single
       ;; instant.
-      (test-support/poll-until (fn [] (some (fn [ev] (= :rf.error/frame-destroyed (:operation ev))) @errs))
+      (test-support/poll-until (fn [] (some (fn [ev] (= :rf.error/frame-destroyed (:error ev))) @errs))
                                {:label "async fence emits frame-destroyed"})
-      (rf/unregister-listener! :trace ::race)
+      (rf/unregister-listener! :errors ::race)
       (is (nil? (:marked-by (rf/app-db-value :fh/race)))
           "the stale async dispatch enqueued nothing into successor B")
-      (is (some #(= :rf.error/frame-destroyed (:operation %)) @errs)
+      (is (some #(= :rf.error/frame-destroyed (:error %)) @errs)
           "the superseded async dispatch recover-but-emits :rf.error/frame-destroyed"))))
 
 (deftest stale-capture-subscribe-race-does-not-read-or-cache-in-same-id-successor
@@ -282,15 +309,15 @@
     (let [a-token (frame/frame-incarnation-token :fh/race)
           {:keys [subscribe]} (rf/capture-frame :fh/race) ;; pins A
           errs    (atom [])
-          result  (do (rf/register-listener! :trace ::race (fn [ev] (swap! errs conj ev)))
+          result  (do (rf/register-listener! :errors ::race (fn [rec] (swap! errs conj rec)))
                       (run-supersede-during-precheck
                         :fh/race a-token #(subscribe [:fh/value])))]
-      (rf/unregister-listener! :trace ::race)
+      (rf/unregister-listener! :errors ::race)
       (is (nil? result)
           "the superseded subscribe returns nil — it did NOT resolve a reaction into B")
       (is (empty? @(:sub-cache (frame/frame :fh/race)))
           "no reaction/cache entry was installed in same-id successor B's sub-cache")
-      (is (some #(= :rf.error/frame-destroyed (:operation %)) @errs)
+      (is (some #(= :rf.error/frame-destroyed (:error %)) @errs)
           "the superseded subscribe recover-but-emits :rf.error/frame-destroyed"))))
 
 ;; ---- rf2-7w1im: the POST-comparison boundary (not only the pre-check) -------
@@ -353,17 +380,17 @@
     (rf/dispatch-sync [:fh/seed :A-value] {:frame :fh/race})
     (let [{:keys [subscribe]} (rf/capture-frame :fh/race)   ;; pins A
           errs   (atom [])
-          _      (rf/register-listener! :trace ::pcb-miss (fn [ev] (swap! errs conj ev)))
+          _      (rf/register-listener! :errors ::pcb-miss (fn [rec] (swap! errs conj rec)))
           result (run-supersede-at-build :fh/race [:fh/value]
                    #(subscribe [:fh/value]))]
-      (rf/unregister-listener! :trace ::pcb-miss)
+      (rf/unregister-listener! :errors ::pcb-miss)
       (is (nil? result)
           "the post-comparison-superseded subscribe returns nil — it did NOT resolve into B")
       (is (= :B-value (:value (rf/app-db-value :fh/race)))
           "successor B's app-db is intact (untouched by the stale build)")
       (is (empty? @(:sub-cache (frame/frame :fh/race)))
           "no reaction/cache entry was installed in successor B's sub-cache")
-      (is (= 1 (count (filter #(= :rf.error/frame-destroyed (:operation %)) @errs)))
+      (is (= 1 (count (filter #(= :rf.error/frame-destroyed (:error %)) @errs)))
           "exactly one :rf.error/frame-destroyed emit"))))
 
 (deftest live-capture-subscribe-miss-still-reads-its-own-incarnation
@@ -397,17 +424,17 @@
     (rf/dispatch-sync [:fh/seed :A-value] {:frame :fh/race})
     (let [{:keys [subscribe]} (rf/capture-frame :fh/race)   ;; pins A
           errs   (atom [])
-          _      (rf/register-listener! :trace ::pcb-rec (fn [ev] (swap! errs conj ev)))
+          _      (rf/register-listener! :errors ::pcb-rec (fn [rec] (swap! errs conj rec)))
           ;; Fire at the INPUT build ([:fh/value]) — AFTER the entry [:fh/derived]
           ;; build validated A and began resolving its inputs.
           _      (run-supersede-at-build :fh/race [:fh/value]
                    #(subscribe [:fh/derived]))]
-      (rf/unregister-listener! :trace ::pcb-rec)
+      (rf/unregister-listener! :errors ::pcb-rec)
       (is (= :B-value (:value (rf/app-db-value :fh/race)))
           "successor B's app-db is intact")
       (is (empty? @(:sub-cache (frame/frame :fh/race)))
           "neither :fh/derived nor its input :fh/value is installed in successor B's sub-cache")
-      (is (some #(= :rf.error/frame-destroyed (:operation %)) @errs)
+      (is (some #(= :rf.error/frame-destroyed (:error %)) @errs)
           "the recursive input's build fence emits :rf.error/frame-destroyed"))))
 
 ;; ---- rf2-a2x2w: exactly-once when A is lost AFTER the token match ----------
@@ -475,12 +502,12 @@
     (rf/make-frame {:id :fh/race :doc "incarnation A"})
     (let [{:keys [dispatch]} (rf/capture-frame :fh/race)   ;; pins A
           errs (atom [])]
-      (rf/register-listener! :trace ::a2x2w-async (fn [ev] (swap! errs conj ev)))
+      (rf/register-listener! :errors ::a2x2w-async (fn [rec] (swap! errs conj rec)))
       (run-supersede-at-enqueue :fh/race #(dispatch [:fh/mark]))
-      (rf/unregister-listener! :trace ::a2x2w-async)
+      (rf/unregister-listener! :errors ::a2x2w-async)
       (is (nil? (:marked-by (rf/app-db-value :fh/race)))
           "the post-token-match loss enqueued nothing into successor B")
-      (is (= 1 (count (filter #(= :rf.error/frame-destroyed (:operation %)) @errs)))
+      (is (= 1 (count (filter #(= :rf.error/frame-destroyed (:error %)) @errs)))
           "EXACTLY ONE :rf.error/frame-destroyed for the post-token-match async loss"))))
 
 (deftest stale-capture-dispatch-sync-post-token-match-emits-exactly-once
@@ -493,12 +520,12 @@
     (rf/make-frame {:id :fh/race :doc "incarnation A"})
     (let [{:keys [dispatch-sync]} (rf/capture-frame :fh/race)   ;; pins A
           errs (atom [])]
-      (rf/register-listener! :trace ::a2x2w-sync (fn [ev] (swap! errs conj ev)))
+      (rf/register-listener! :errors ::a2x2w-sync (fn [rec] (swap! errs conj rec)))
       (run-supersede-at-drain-block :fh/race #(dispatch-sync [:fh/mark]))
-      (rf/unregister-listener! :trace ::a2x2w-sync)
+      (rf/unregister-listener! :errors ::a2x2w-sync)
       (is (nil? (:marked-by (rf/app-db-value :fh/race)))
           "the post-token-match loss processed nothing into successor B")
-      (is (= 1 (count (filter #(= :rf.error/frame-destroyed (:operation %)) @errs)))
+      (is (= 1 (count (filter #(= :rf.error/frame-destroyed (:error %)) @errs)))
           "EXACTLY ONE :rf.error/frame-destroyed for the post-token-match sync loss"))))
 
 ;; ---- rf2-iqfbg: a live target is NOT reported destroyed when only the ------
@@ -561,17 +588,17 @@
           target-token (frame/frame-incarnation-token :audit/target)
           {:keys [dispatch]} (rf/capture-frame :audit/target)   ;; pins target A
           errs (atom [])]
-      (rf/register-listener! :trace ::iqfbg-async (fn [ev] (swap! errs conj ev)))
+      (rf/register-listener! :errors ::iqfbg-async (fn [rec] (swap! errs conj rec)))
       (frame/call-with-event-owner-token :audit/owner owner-token
         (fn [] (run-owner-death-at-dispatch :audit/owner #(dispatch [:audit/touch]))))
-      (rf/unregister-listener! :trace ::iqfbg-async)
+      (rf/unregister-listener! :errors ::iqfbg-async)
       (is (nil? (frame/frame :audit/owner))
           "precondition: the interpose actually destroyed the originating owner")
       (is (frame/frame-incarnation-live? :audit/target target-token)
           "the captured TARGET incarnation is STILL LIVE — only the owner died")
       (is (nil? (:marked-by (rf/app-db-value :audit/target)))
           "owner-continuation cutoff drops the op — the live target is untouched")
-      (is (zero? (count (filter #(= :rf.error/frame-destroyed (:operation %)) @errs)))
+      (is (zero? (count (filter #(= :rf.error/frame-destroyed (:error %)) @errs)))
           "NO frame-destroyed: a live target is never reported destroyed for an owner cutoff"))))
 
 (deftest live-target-not-reported-destroyed-when-only-owner-dies-sync
@@ -589,17 +616,17 @@
           target-token (frame/frame-incarnation-token :audit/target)
           {:keys [dispatch-sync]} (rf/capture-frame :audit/target)   ;; pins target A
           errs (atom [])]
-      (rf/register-listener! :trace ::iqfbg-sync (fn [ev] (swap! errs conj ev)))
+      (rf/register-listener! :errors ::iqfbg-sync (fn [rec] (swap! errs conj rec)))
       (frame/call-with-event-owner-token :audit/owner owner-token
         (fn [] (run-owner-death-at-dispatch :audit/owner #(dispatch-sync [:audit/touch]))))
-      (rf/unregister-listener! :trace ::iqfbg-sync)
+      (rf/unregister-listener! :errors ::iqfbg-sync)
       (is (nil? (frame/frame :audit/owner))
           "precondition: the interpose actually destroyed the originating owner")
       (is (frame/frame-incarnation-live? :audit/target target-token)
           "the captured TARGET incarnation is STILL LIVE — only the owner died")
       (is (nil? (:marked-by (rf/app-db-value :audit/target)))
           "owner-continuation cutoff drops the op — the live target is untouched")
-      (is (zero? (count (filter #(= :rf.error/frame-destroyed (:operation %)) @errs)))
+      (is (zero? (count (filter #(= :rf.error/frame-destroyed (:error %)) @errs)))
           "NO frame-destroyed: a live target is never reported destroyed for an owner cutoff"))))
 
 ;; ---- contract: (capture-frame) outside any scope RAISES (EP-0002) ---------

--- a/implementation/core/test/re_frame/cascade_dispatch_id_test.clj
+++ b/implementation/core/test/re_frame/cascade_dispatch_id_test.clj
@@ -22,9 +22,36 @@
       trace events emitted outside any drain (e.g. registration-time
       trace events, frame creation) carry no `:rf.trace/dispatch-id`.
 
-  JVM-only — the dynamic-var binding mechanism is platform-agnostic."
+  JVM-only — the dynamic-var binding mechanism is platform-agnostic.
+
+  ## Posture split (rf2-d2841)
+
+  `:rf.trace/dispatch-id` is a TRACE-CORRELATION key and there is no production
+  channel that carries it — checked, not assumed: the always-on error record
+  (`error-emit/dispatch-on-error!`) is the tight `{:error :event :event-id
+  :frame :time :exception :elapsed-ms :source-coord}` shape plus the optional
+  `:failing-id` / `:reason` lift, and carries no correlation id. So every
+  correlation claim here is guarded.
+
+  What keeps this off the class-2 list is that each case drives a REAL CASCADE
+  and the cascade is production behaviour. Every deftest now witnesses the work
+  the correlation key was correlating: the fx fired, the child event committed,
+  the thrown handler reached the always-on `:errors` stream, two sequential
+  dispatches each committed. Under the gate those run for the first time here.
+
+  THREE VACUOUS PASSES CAME OFF, in two classes.
+  `frame-lifecycle-emits-stay-uncorrelated-under-a-cascade-scope` carried two
+  class-1 negatives — `(is (nil? (dispatch-id (by-op :rf.frame/re-registered))))`
+  over an empty ring, where `by-op` returns nil and `dispatch-id` of nil is nil.
+  `parent-dispatch-id-only-on-event-dispatched` is the sharper one and a shape
+  worth recognising on sight: its whole body is a `doseq` over the captured
+  events, so under the gate it iterates ZERO times, runs NO assertions at all,
+  and clojure.test reports the deftest as passing. A green deftest that
+  executed no assertion is the same false green as one that executed a vacuous
+  assertion, and it is harder to see."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
@@ -65,6 +92,17 @@
 
 (defn- dispatch-id [ev] (get-in ev [:tags :rf.trace/dispatch-id]))
 
+(defn- record-errors
+  "ALWAYS-ON (rf2-d2841): run `body-fn` with an `:errors`-stream listener
+  attached and return the tight records the corpus-wide `error-emit` registry
+  fanned. Not gated on `interop/debug-enabled?`."
+  [body-fn]
+  (let [seen (atom [])]
+    (rf/register-listener! :errors ::err (fn [rec] (swap! seen conj rec)))
+    (try (body-fn)
+         (finally (rf/unregister-listener! :errors ::err)))
+    @seen))
+
 ;; ---- cascade-wide stamping ------------------------------------------------
 
 (deftest dispatch-id-rides-every-event-in-the-cascade
@@ -85,28 +123,44 @@
                               (filter #(contains? #{:event :rf.event/db-changed
                                                     :rf.fx/do-fx :rf.fx/handled}
                                                   (:operation %))))]
-        (is (some? cascade-id)
-            "the cascade's :rf.trace/dispatch-id is on the :rf.event/dispatched event")
-        (is (seq during-drain)
-            "we saw events emitted inside the drain")
-        (doseq [ev during-drain]
-          (is (= cascade-id (dispatch-id ev))
-              (str "event " (:operation ev) " carries the cascade's :rf.trace/dispatch-id")))
-        (is (= 1 @fx-fired) "fx ran")))))
+        ;; ALWAYS-ON (rf2-d2841): the cascade the correlation key correlates
+        ;; actually ran — handler committed, fx fired exactly once.
+        (is (= 1 @fx-fired) "fx ran")
+        (is (= 1 (:n (rf/app-db-value :test/main)))
+            "the handler's db change committed in this posture")
+        (when interop/debug-enabled?
+          (is (some? cascade-id)
+              "the cascade's :rf.trace/dispatch-id is on the :rf.event/dispatched event")
+          (is (seq during-drain)
+              "we saw events emitted inside the drain")
+          (doseq [ev during-drain]
+            (is (= cascade-id (dispatch-id ev))
+                (str "event " (:operation ev)
+                     " carries the cascade's :rf.trace/dispatch-id"))))))))
 
 (deftest dispatch-id-rides-on-error-events-inside-the-cascade
   (testing "errors emitted inside the drain carry the cascade's :rf.trace/dispatch-id"
     (rf/make-frame {:id :test/main})
     (rf/reg-event :throws (fn [{:keys [db]} _] {:db (throw (ex-info "oops" {}))}))
-    (let [evs        (record-traces
-                       (fn [] (rf/dispatch-sync [:throws] {:frame :test/main})))
+    (let [recs       (atom nil)
+          evs        (record-traces
+                       (fn []
+                         (reset! recs
+                                 (record-errors
+                                   #(rf/dispatch-sync [:throws] {:frame :test/main})))))
           dispatched (first (events-of evs #(= :rf.event/dispatched (:operation %))))
           cascade-id (dispatch-id dispatched)
           err        (first (events-of evs #(= :rf.error/handler-exception (:operation %))))]
-      (is (some? cascade-id))
-      (is (some? err) "the handler-exception fired")
-      (is (= cascade-id (dispatch-id err))
-          ":rf.error/* traces carry the cascade's :rf.trace/dispatch-id"))))
+      ;; ALWAYS-ON (rf2-d2841): the failure this deftest correlates reaches the
+      ;; production error stream. The correlation id does not ride that record
+      ;; — the tight shape carries none — but the failure itself is not lost.
+      (is (some? (first (filterv #(= :rf.error/handler-exception (:error %)) @recs)))
+          "the always-on error record fired for the throwing handler")
+      (when interop/debug-enabled?
+        (is (some? cascade-id))
+        (is (some? err) "the handler-exception fired")
+        (is (= cascade-id (dispatch-id err))
+            ":rf.error/* traces carry the cascade's :rf.trace/dispatch-id")))))
 
 (deftest child-dispatch-gets-its-own-dispatch-id-and-parents-the-outer
   (testing "child dispatches from inside fx handlers get a fresh :rf.trace/dispatch-id and the parent's id rides on :rf.trace/parent-dispatch-id"
@@ -120,15 +174,20 @@
           dispatches (vec (events-of evs #(= :rf.event/dispatched (:operation %))))
           parent     (first (filter #(= [:parent] (get-in % [:tags :rf.event/v])) dispatches))
           child      (first (filter #(= [:child]  (get-in % [:tags :rf.event/v])) dispatches))]
-      (is (some? parent))
-      (is (some? child))
-      (is (some? (dispatch-id parent)))
-      (is (some? (dispatch-id child)))
-      (is (not= (dispatch-id parent) (dispatch-id child))
-          "child gets its own freshly-allocated :rf.trace/dispatch-id")
-      (is (= (dispatch-id parent)
-             (get-in child [:tags :rf.trace/parent-dispatch-id]))
-          "child's :rf.trace/parent-dispatch-id is the parent cascade's :rf.trace/dispatch-id"))))
+      ;; ALWAYS-ON (rf2-d2841): the child dispatch the ids are about really was
+      ;; issued from inside the parent's fx and really committed.
+      (is (true? (:got-child (rf/app-db-value :test/main)))
+          "the child dispatch committed in this posture")
+      (when interop/debug-enabled?
+        (is (some? parent))
+        (is (some? child))
+        (is (some? (dispatch-id parent)))
+        (is (some? (dispatch-id child)))
+        (is (not= (dispatch-id parent) (dispatch-id child))
+            "child gets its own freshly-allocated :rf.trace/dispatch-id")
+        (is (= (dispatch-id parent)
+               (get-in child [:tags :rf.trace/parent-dispatch-id]))
+            "child's :rf.trace/parent-dispatch-id is the parent cascade's :rf.trace/dispatch-id")))))
 
 (deftest parent-dispatch-id-only-on-event-dispatched
   (testing ":rf.trace/parent-dispatch-id is scoped to :rf.event/dispatched events only — not on :rf.sub/run, :rf.event/db-changed, :rf.fx/handled, etc."
@@ -137,11 +196,18 @@
     (rf/reg-event :inner (fn [{:keys [db]} _] {:db (assoc db :v 1)}))
     (let [evs (record-traces
                 (fn [] (rf/dispatch-sync [:outer] {:frame :test/main})))]
-      (doseq [ev evs
-              :when (not= :rf.event/dispatched (:operation ev))]
-        (is (nil? (get-in ev [:tags :rf.trace/parent-dispatch-id]))
-            (str "non-:rf.event/dispatched event " (:operation ev)
-                 " must not carry :rf.trace/parent-dispatch-id"))))))
+      ;; ALWAYS-ON (rf2-d2841): the nested dispatch ran. Without this the
+      ;; deftest asserts NOTHING under the gate — the `doseq` below iterates
+      ;; zero times over an empty ring and clojure.test still reports a pass.
+      (is (= 1 (:v (rf/app-db-value :test/main)))
+          "the inner event committed in this posture")
+      (when interop/debug-enabled?
+        (is (seq evs) "the trace ring captured the cascade")
+        (doseq [ev evs
+                :when (not= :rf.event/dispatched (:operation ev))]
+          (is (nil? (get-in ev [:tags :rf.trace/parent-dispatch-id]))
+              (str "non-:rf.event/dispatched event " (:operation ev)
+                   " must not carry :rf.trace/parent-dispatch-id")))))))
 
 (deftest dispatch-id-unbound-outside-any-cascade
   (testing "trace events emitted outside any drain carry no :rf.trace/dispatch-id"
@@ -155,14 +221,19 @@
         ;; reg-event / reg-fx emit :rf.registry/handler-registered traces
         ;; via the registrar; these fire OUTSIDE any drain.
         (rf/reg-event :foo (fn [{:keys [db]} _] {:db db}))
-        (let [out-of-band (filter #(or (= :rf.frame/created (:operation %))
-                                       (= :rf.registry/handler-registered (:operation %)))
-                                  @seen)]
-          (is (seq out-of-band) "we saw trace events emitted outside any drain")
-          (doseq [ev out-of-band]
-            (is (nil? (dispatch-id ev))
-                (str "out-of-band event " (:operation ev)
-                     " must NOT carry a :rf.trace/dispatch-id"))))
+        ;; ALWAYS-ON (rf2-d2841): the out-of-band WORK is production behaviour —
+        ;; only its trace is not. The frame exists and the handler is registered.
+        (is (some? (rf/frame-meta :test/outside)) "the frame was created")
+        (is (some? (rf/handler-meta :event :foo)) "the handler was registered")
+        (when interop/debug-enabled?
+          (let [out-of-band (filter #(or (= :rf.frame/created (:operation %))
+                                         (= :rf.registry/handler-registered (:operation %)))
+                                    @seen)]
+            (is (seq out-of-band) "we saw trace events emitted outside any drain")
+            (doseq [ev out-of-band]
+              (is (nil? (dispatch-id ev))
+                  (str "out-of-band event " (:operation ev)
+                       " must NOT carry a :rf.trace/dispatch-id")))))
         (finally
           (rf/unregister-listener! :trace ::rec))))))
 
@@ -176,12 +247,17 @@
                  (fn [] (rf/dispatch-sync [:bump] {:frame :test/main})))
           ids1 (set (keep dispatch-id evs1))
           ids2 (set (keep dispatch-id evs2))]
-      (is (= 1 (count ids1))
-          "every emit in the first cascade shares one :rf.trace/dispatch-id")
-      (is (= 1 (count ids2))
-          "every emit in the second cascade shares one :rf.trace/dispatch-id")
-      (is (empty? (clojure.set/intersection ids1 ids2))
-          "the two cascades' :dispatch-ids are disjoint"))))
+      ;; ALWAYS-ON (rf2-d2841): both cascades ran to completion — the counter
+      ;; reached 2 — so "two cascades" is a fact and not an assumption.
+      (is (= 2 (:n (rf/app-db-value :test/main)))
+          "both sequential dispatches committed in this posture")
+      (when interop/debug-enabled?
+        (is (= 1 (count ids1))
+            "every emit in the first cascade shares one :rf.trace/dispatch-id")
+        (is (= 1 (count ids2))
+            "every emit in the second cascade shares one :rf.trace/dispatch-id")
+        (is (empty? (clojure.set/intersection ids1 ids2))
+            "the two cascades' :dispatch-ids are disjoint")))))
 
 ;; ---- frame-lifecycle emits stay uncorrelated ------------------------------
 
@@ -203,9 +279,16 @@
                       (trace/emit! :rf.sub   :rf.sub/run              {:frame :test/sibling
                                                                        :rf.sub/id :x}))))
           by-op (fn [op] (some #(when (= op (:operation %)) %) evs))]
-      (is (nil? (dispatch-id (by-op :rf.frame/re-registered)))
-          ":rf.frame/re-registered stays uncorrelated — no cascade dispatch-id")
-      (is (nil? (dispatch-id (by-op :rf.frame/created)))
-          ":rf.frame/created stays uncorrelated — no cascade dispatch-id")
-      (is (= 4242 (dispatch-id (by-op :rf.sub/run)))
-          "control: an ordinary cascade emit still rides the cascade's dispatch-id"))))
+      ;; rf2-d2841 — GUARDED WHOLESALE, and honestly so: this case drives
+      ;; `trace/emit!` directly, which is a no-op under `-Dre-frame.debug=false`,
+      ;; so there is no production work here to witness. Its two negatives were
+      ;; class-1 vacuous under the gate — `by-op` returns nil over the empty
+      ;; ring and `dispatch-id` of nil is nil — while the CONTROL beside them
+      ;; (the one assertion that would have caught it) went red.
+      (when interop/debug-enabled?
+        (is (nil? (dispatch-id (by-op :rf.frame/re-registered)))
+            ":rf.frame/re-registered stays uncorrelated — no cascade dispatch-id")
+        (is (nil? (dispatch-id (by-op :rf.frame/created)))
+            ":rf.frame/created stays uncorrelated — no cascade dispatch-id")
+        (is (= 4242 (dispatch-id (by-op :rf.sub/run)))
+            "control: an ordinary cascade emit still rides the cascade's dispatch-id")))))

--- a/implementation/core/test/re_frame/cofx_envelope_test.clj
+++ b/implementation/core/test/re_frame/cofx_envelope_test.clj
@@ -31,7 +31,32 @@
   `re-frame.event-model-conformance-cljs-test`.
 
   JVM-only — the stamping path is platform-agnostic (`interop/now-ms`
-  realises on both hosts); no CLJS host dependency under test."
+  realises on both hosts); no CLJS host dependency under test.
+
+  ## Posture split (rf2-d2841)
+
+  Only two of this file's twenty-two cases needed anything, and both for the
+  same reason: they read a DEV-ONLY channel to observe a DURABLE fact.
+
+  `dispatched-at-supplied-is-a-generic-unknown-opt-with-did-you-mean` asserts
+  the retired draft key trips `:rf.warning/unknown-dispatch-opt`, a dev-gated
+  trace-bus warn. Guarded — with the always-on residue being the half the
+  warning's `:recovery :no-recovery` promises: the dispatch PROCEEDS and its
+  handler commits, unrecognised opt and all.
+
+  `ambient-diagnostic-time-differs-while-durable-committed-at-holds` is the
+  more interesting one, and it is the same false-green shape rf2-d2841's fourth
+  pass found in `core-epoch-egress-profile-test`: it read the DURABLE side of
+  the causal/diagnostic split off `rf/epoch-history`, and the epoch ring is fed
+  by `epoch.capture/observe-trace-event!` from the DEV TRACE. Empty ring → nil
+  record → `(is (= committed-1 committed-2))` comparing `nil` to `nil`: a class-3
+  vacuous pass certifying that two absent timestamps agree, on the one assertion
+  in the deftest that is about the invariant itself. The durable causal fact
+  does not need the epoch ring to be observed — the handler can read
+  `(:rf/time-ms (:rf.cofx cofx))` and fold it into app-db, which is what a
+  replay log would durably record anyway — so the equal-across-ambient-clocks
+  claim now runs in both postures against app-db, with the epoch-ring
+  projection kept as the guarded dev-side detail."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
@@ -644,28 +669,36 @@
                           :dispatched-at))
           "the unrecognised key is not copied onto the envelope"))
     (testing "the generic unknown-dispatch-opt warning fires with a did-you-mean naming :rf/time-ms / :rf.cofx"
-      (rf/reg-event :wi/retired-noop (fn [{:keys [db]} _] {:db db}))
+      (rf/reg-event :wi/retired-noop
+        (fn [{:keys [db]} _] {:db (assoc db :wi/handler-ran? true)}))
       (let [seen (atom [])]
         (rf/register-listener! :trace ::dispatched-at
           (fn [ev] (swap! seen conj ev)))
         (binding [frame/*current-frame* :wi/retired-supply]
           (rf/dispatch-sync [:wi/retired-noop] {:dispatched-at 123}))
         (rf/unregister-listener! :trace ::dispatched-at)
-        (let [warns (filterv (fn [ev]
-                               (and (= :warning (:op-type ev))
-                                    (= :rf.warning/unknown-dispatch-opt (:operation ev))))
-                             @seen)]
-          (is (= 1 (count warns))
-              "the retired draft key trips exactly one generic unknown-opt warning")
-          (let [t (:tags (first warns))]
-            (is (contains? (set (:unknown-keys t)) :dispatched-at)
-                "the retired key is named as an unknown opt")
-            (is (re-find #":rf/time-ms" (:reason t))
-                "the warning message references :rf/time-ms as the replacement")
-            (is (re-find #":rf\.cofx" (:reason t))
-                "the warning message references :rf.cofx as the replacement carrier")
-            (is (= :no-recovery (:recovery (first warns)))
-                "observational — the dispatch proceeds unchanged")))))))
+        ;; ALWAYS-ON (rf2-d2841): `:recovery :no-recovery` means the dispatch
+        ;; PROCEEDS — the warning is observational. In production, where no
+        ;; warning exists, proceeding is the entire observable contract, and
+        ;; nothing had asserted it there.
+        (is (true? (:wi/handler-ran? (rf/app-db-value :wi/retired-supply)))
+            "the dispatch proceeded and committed despite the unrecognised opt")
+        (when interop/debug-enabled?
+          (let [warns (filterv (fn [ev]
+                                 (and (= :warning (:op-type ev))
+                                      (= :rf.warning/unknown-dispatch-opt (:operation ev))))
+                               @seen)]
+            (is (= 1 (count warns))
+                "the retired draft key trips exactly one generic unknown-opt warning")
+            (let [t (:tags (first warns))]
+              (is (contains? (set (:unknown-keys t)) :dispatched-at)
+                  "the retired key is named as an unknown opt")
+              (is (re-find #":rf/time-ms" (:reason t))
+                  "the warning message references :rf/time-ms as the replacement")
+              (is (re-find #":rf\.cofx" (:reason t))
+                  "the warning message references :rf.cofx as the replacement carrier")
+              (is (= :no-recovery (:recovery (first warns)))
+                  "observational — the dispatch proceeds unchanged"))))))))
 
 ;; ===========================================================================
 ;; rf2-sppf0m / rf2-alc1lf: a handler READS owner-qualified facts from the
@@ -782,7 +815,14 @@
   (testing "same causal token under two different ambient clocks → durable
             :committed-at EQUAL while the diagnostic trace :time DIFFERS"
     (rf/make-frame {:id :wi/split :doc "ctx"})
-    (rf/reg-event :wi/note (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+    ;; rf2-d2841 — the handler folds the SUPPLIED causal token time into app-db.
+    ;; That is what makes the durable half of the split observable without the
+    ;; epoch ring, which is dev-fed and empty under the production gate.
+    (rf/reg-event :wi/note
+      (fn [{:keys [db] cofx :rf.cofx} _]
+        {:db (-> db
+                 (update :n (fnil inc 0))
+                 (assoc :wi/durable-token (:rf/time-ms cofx)))}))
     (let [token-time   1781078400123     ; the supplied causal token :rf/time-ms
           ;; capture the diagnostic trace :time of THIS frame's :wi/note event
           ;; per run — the trace `:time` is stamped from the ambient
@@ -820,21 +860,35 @@
                            (:committed-at (last (rf/epoch-history :wi/split)))))
           committed-1  (run! 1000)
           committed-2  (run! 9999999)]
-      ;; (a) DURABLE side — equal across the two ambient clocks.
-      (is (= token-time committed-1)
-          "run 1: durable :committed-at folds the supplied token :rf/time-ms")
-      (is (= token-time committed-2)
-          "run 2: durable :committed-at folds the SAME supplied token :rf/time-ms")
-      (is (= committed-1 committed-2)
-          "durable :committed-at is EQUAL across runs — wall-clock drift
-           between the two commits did not change durable state")
-      ;; (b) DIAGNOSTIC side — differs across the two ambient clocks.
-      (let [[t1 t2] @trace-times]
-        (is (= 1000 t1)
-            "run 1: the diagnostic trace :time read the ambient clock (1000)")
-        (is (= 9999999 t2)
-            "run 2: the diagnostic trace :time read the DIFFERENT ambient clock")
-        (is (not= t1 t2)
-            "the ambient diagnostic trace :time DIFFERS run-to-run — free to
-             vary, exactly as the EP-0010 causal/diagnostic split permits,
-             while the durable :committed-at above held equal")))))
+      ;; (a) DURABLE side — ALWAYS-ON (rf2-d2841). Two dispatches ran under two
+      ;; different ambient clocks and the durable app-db state folded the
+      ;; SUPPLIED token time both times. This is the invariant itself, off a
+      ;; channel production carries: `rf/epoch-history` is fed by
+      ;; `epoch.capture/observe-trace-event!` from the dev trace, so the
+      ;; `:committed-at` projection below is empty under the gate — which made
+      ;; `(= committed-1 committed-2)` a class-3 vacuous `nil = nil`, on the one
+      ;; assertion in this deftest that is about the invariant.
+      (is (= 2 (:n (rf/app-db-value :wi/split)))
+          "both runs committed")
+      (is (= token-time (:wi/durable-token (rf/app-db-value :wi/split)))
+          "the durable state folded the SUPPLIED token time, not the ambient
+           clock — and it is the same value after a run under each clock")
+      (when interop/debug-enabled?
+        ;; the epoch-ring projection of the same durable fact
+        (is (= token-time committed-1)
+            "run 1: durable :committed-at folds the supplied token :rf/time-ms")
+        (is (= token-time committed-2)
+            "run 2: durable :committed-at folds the SAME supplied token :rf/time-ms")
+        (is (= committed-1 committed-2)
+            "durable :committed-at is EQUAL across runs — wall-clock drift
+             between the two commits did not change durable state")
+        ;; (b) DIAGNOSTIC side — differs across the two ambient clocks.
+        (let [[t1 t2] @trace-times]
+          (is (= 1000 t1)
+              "run 1: the diagnostic trace :time read the ambient clock (1000)")
+          (is (= 9999999 t2)
+              "run 2: the diagnostic trace :time read the DIFFERENT ambient clock")
+          (is (not= t1 t2)
+              "the ambient diagnostic trace :time DIFFERS run-to-run — free to
+               vary, exactly as the EP-0010 causal/diagnostic split permits,
+               while the durable :committed-at above held equal"))))))

--- a/implementation/core/test/re_frame/event_context_partition_test.clj
+++ b/implementation/core/test/re_frame/event_context_partition_test.clj
@@ -16,9 +16,47 @@
        handler returns a `:rf.db/runtime` effect, and DOES NOT fire for a
        framework-authority handler (`:rf/machine? true`) — reserved BY
        CONVENTION, not a security boundary (Mike ruling #4). The effect is
-       applied either way (the diagnostic is a warning, not a gate)."
+       applied either way (the diagnostic is a warning, not a gate).
+
+  ## Posture split (rf2-d2841)
+
+  Two of the three surfaces this file reads are dev-only. The
+  `:rf.warning/app-handler-runtime-effect` diagnostic is a trace-bus warning,
+  and `:rf.error/effect-map-shape` is catalogued `diagnostic` in Spec 009 —
+  dev-only by design — as is the `:rf.error/legacy-runtime-root` TRACE. None of
+  them is emitted under `-Dre-frame.debug=false`, so those assertions are
+  guarded.
+
+  THE POLICING ITSELF IS NOT DEV-ONLY, and that is the whole point of the file:
+  a foreign top-level effect key is DROPPED, a non-sequential `:fx` is DROPPED
+  before `do-fx` can throw a raw host exception after the `:db` commit, and a
+  legacy `:rf/runtime` root is REJECTED WHOLE — in every posture. Each case
+  already had, or now has, an always-on assertion on exactly that: what
+  committed, what did not, and that the drain survived. Read the file with the
+  guards on and it still says everything that matters about production
+  behaviour; what it loses is the narration.
+
+  FIVE VACUOUS PASSES CAME OFF (rf2-d2841 class 1 — a negative over an empty
+  trace ring), and every one of them was in a deftest already GREEN under the
+  gate: `runtime-db-effect-is-not-a-shape-error`,
+  `framework-authority-runtime-effect-does-not-warn`,
+  `plain-db-fx-handler-does-not-warn`,
+  `legitimate-runtime-db-effect-is-not-a-legacy-root-error` and
+  `well-shaped-final-effects-emit-no-shape-error` each certify that nothing was
+  emitted, over a stream that emits nothing at all there. Two of the five —
+  `runtime-db-effect` and `well-shaped-final-effects` — had nothing else to
+  say under the gate at all until this pass gave them a commit witness.
+
+  ONE ASYMMETRY IS WORTH RECORDING RATHER THAN PAPERING OVER.
+  `framework-authority-runtime-effect-does-not-warn` has NO production
+  counterpart even in principle: the diagnostic is `:recovery :warned`, so the
+  effect applies identically whether it fires or not (Mike ruling #4 —
+  convention, not enforcement). Its always-on residue can only be that the
+  write landed, which is true of the warned case too. That is the honest state
+  of the contract, not a gap in the test."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.events :as events]
             [re-frame.frame :as frame]
             [re-frame.interceptor :as interceptor]
@@ -125,8 +163,16 @@
         {:doc "framework-authority runtime write" :rf/machine? true}
         (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {}} :fx []}))
       (rf/dispatch-sync [:ctx/fw-runtime] {:frame :ctx/runtime-fx})
-      (is (empty? (error-events recorded :rf.error/effect-map-shape))
-          ":rf.db/runtime is inside the widened closed set — no shape error"))))
+      ;; ALWAYS-ON (rf2-d2841): "inside the widened closed set" means the
+      ;; effect was APPLIED rather than dropped, and that is readable in both
+      ;; postures. The negative below was class-1 vacuous under the gate and
+      ;; was this deftest's only assertion.
+      (is (= {:rf.runtime/machines {}}
+             (:rf.db/runtime (rf/frame-state-value :ctx/runtime-fx)))
+          "the :rf.db/runtime effect committed — it was not policed away")
+      (when interop/debug-enabled?
+        (is (empty? (error-events recorded :rf.error/effect-map-shape))
+            ":rf.db/runtime is inside the widened closed set — no shape error")))))
 
 (deftest foreign-top-level-key-still-a-shape-error
   (testing "a foreign top-level key (legacy :http) is still policed after the widening"
@@ -135,14 +181,18 @@
       (rf/reg-event :ctx/foreign
         (fn [_ _] {:db {:ok? true} :http {:url "/api"}}))
       (rf/dispatch-sync [:ctx/foreign] {:frame :ctx/foreign-fx})
-      (let [errs (error-events recorded :rf.error/effect-map-shape)]
-        (is (= 1 (count errs))
-            "exactly one shape error for the foreign :http key")
-        (is (= :http (:offending-key (:tags (first errs))))
-            "the offending key is :http")
-        (is (= :logged-and-skipped (:recovery (first errs))))
-        (is (true? (:ok? (rf/app-db-value :ctx/foreign-fx)))
-            "the legal :db still committed; only :http was dropped")))))
+      ;; ALWAYS-ON (rf2-d2841): the POLICING is production behaviour — the
+      ;; legal `:db` committed and the foreign key was dropped rather than
+      ;; applied. Only the diagnostic that narrates it is dev-only.
+      (is (true? (:ok? (rf/app-db-value :ctx/foreign-fx)))
+          "the legal :db still committed; only :http was dropped")
+      (when interop/debug-enabled?
+        (let [errs (error-events recorded :rf.error/effect-map-shape)]
+          (is (= 1 (count errs))
+              "exactly one shape error for the foreign :http key")
+          (is (= :http (:offending-key (:tags (first errs))))
+              "the offending key is :http")
+          (is (= :logged-and-skipped (:recovery (first errs)))))))))
 
 ;; ===========================================================================
 ;; 4 — :rf.warning/app-handler-runtime-effect diagnostic
@@ -155,18 +205,26 @@
       (rf/reg-event :ctx/app-emits-runtime
         (fn [_ _] {:rf.db/runtime {:rf.runtime/routing {}}}))
       (rf/dispatch-sync [:ctx/app-emits-runtime] {:frame :ctx/app-runtime})
-      (let [warns (warning-events recorded :rf.warning/app-handler-runtime-effect)]
-        (is (= 1 (count warns))
-            "exactly one :rf.warning/app-handler-runtime-effect for the non-framework writer")
-        (let [t (:tags (first warns))]
-          (is (= :ctx/app-emits-runtime (:rf.trace/event-id t)))
-          (is (= [:ctx/app-emits-runtime] (:rf.event/v t)))
-          (is (= :ctx/app-runtime (:frame t))
-              ":frame tag is the running frame (read from the :rf.frame/id coeffect)")
-          (is (string? (:reason t)))
-          (is (re-find #"rf\.db/runtime" (:reason t))))
-        (is (= :warned (:recovery (first warns)))
-            "recovery is :warned — convention, not enforcement")))))
+      ;; ALWAYS-ON (rf2-d2841): `:recovery :warned` means the write is NOT
+      ;; gated — the app handler's runtime effect applies in production, where
+      ;; no diagnostic exists to nudge anyone. That is the load-bearing half of
+      ;; Mike ruling #4 and it had no production-posture assertion before.
+      (is (= {:rf.runtime/routing {}}
+             (:rf.db/runtime (rf/frame-state-value :ctx/app-runtime)))
+          "the effect applied anyway — the diagnostic is a warning, not a gate")
+      (when interop/debug-enabled?
+        (let [warns (warning-events recorded :rf.warning/app-handler-runtime-effect)]
+          (is (= 1 (count warns))
+              "exactly one :rf.warning/app-handler-runtime-effect for the non-framework writer")
+          (let [t (:tags (first warns))]
+            (is (= :ctx/app-emits-runtime (:rf.trace/event-id t)))
+            (is (= [:ctx/app-emits-runtime] (:rf.event/v t)))
+            (is (= :ctx/app-runtime (:frame t))
+                ":frame tag is the running frame (read from the :rf.frame/id coeffect)")
+            (is (string? (:reason t)))
+            (is (re-find #"rf\.db/runtime" (:reason t))))
+          (is (= :warned (:recovery (first warns)))
+              "recovery is :warned — convention, not enforcement"))))))
 
 (deftest framework-authority-runtime-effect-does-not-warn
   (testing "a framework-authority handler (:rf/machine? true) does NOT fire the diagnostic"
@@ -176,8 +234,17 @@
         {:doc "framework-authority" :rf/machine? true}
         (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {}}}))
       (rf/dispatch-sync [:ctx/fw-emits-runtime] {:frame :ctx/fw-authority})
-      (is (empty? (warning-events recorded :rf.warning/app-handler-runtime-effect))
-          "the framework-authority path is in-bounds — no diagnostic"))))
+      ;; ALWAYS-ON (rf2-d2841) — and see the ns docstring: this case has no
+      ;; production counterpart even in principle, because the diagnostic is
+      ;; `:recovery :warned` and the effect applies either way. The residue is
+      ;; that the framework write landed; the ABSENCE of the nudge is a
+      ;; dev-posture fact only, and the negative was class-1 vacuous.
+      (is (= {:rf.runtime/machines {}}
+             (:rf.db/runtime (rf/frame-state-value :ctx/fw-authority)))
+          "the framework-authority runtime write committed")
+      (when interop/debug-enabled?
+        (is (empty? (warning-events recorded :rf.warning/app-handler-runtime-effect))
+            "the framework-authority path is in-bounds — no diagnostic")))))
 
 (deftest plain-db-fx-handler-does-not-warn
   (testing "an ordinary handler that does NOT return :rf.db/runtime stays silent"
@@ -186,10 +253,13 @@
       (rf/reg-event :ctx/plain-db
         (fn [{:keys [db]} _] {:db (assoc db :touched? true) :fx []}))
       (rf/dispatch-sync [:ctx/plain-db] {:frame :ctx/plain})
-      (is (empty? (warning-events recorded :rf.warning/app-handler-runtime-effect))
-          "no :rf.db/runtime effect ⇒ no diagnostic")
+      ;; ALWAYS-ON: the ordinary path commits.
       (is (true? (:touched? (rf/app-db-value :ctx/plain)))
-          "the :db effect committed normally"))))
+          "the :db effect committed normally")
+      ;; rf2-d2841 — class-1 vacuous under the gate.
+      (when interop/debug-enabled?
+        (is (empty? (warning-events recorded :rf.warning/app-handler-runtime-effect))
+            "no :rf.db/runtime effect ⇒ no diagnostic")))))
 
 ;; ===========================================================================
 ;; EP-0001 (rf2-tfepxu, decision #8) — legacy :rf/runtime root is a HARD ERROR
@@ -237,12 +307,16 @@
       ;; :rf.error/handler-exception carrying the original ex-info.
       (let [errs (error-events recorded :rf.error/handler-exception)
             ex   (some-> errs first :tags :exception)]
-        (is (= 1 (count errs))
-            "exactly one handler-exception trace for the legacy-root write")
-        (is (= :rf.error/legacy-runtime-root (:rf.error/id (ex-data ex)))
-            "the captured exception is :rf.error/legacy-runtime-root")
+        ;; ALWAYS-ON (rf2-d2841): the REJECTION is production behaviour —
+        ;; `events/reject-legacy-runtime-root!` is an ungated `throw`. Only the
+        ;; trace that reports it is dev-only.
         (is (not (contains? (rf/app-db-value :ctx/legacy-db) :rf/runtime))
-            "the legacy :rf/runtime root never lands in app-db (hard-error rejects the write)")))))
+            "the legacy :rf/runtime root never lands in app-db (hard-error rejects the write)")
+        (when interop/debug-enabled?
+          (is (= 1 (count errs))
+              "exactly one handler-exception trace for the legacy-root write")
+          (is (= :rf.error/legacy-runtime-root (:rf.error/id (ex-data ex)))
+              "the captured exception is :rf.error/legacy-runtime-root"))))))
 
 (deftest fx-handler-returning-legacy-runtime-root-surfaces-hard-error
   (testing "a reg-event handler whose {:db :fx} return carries :rf/runtime in its :db effect surfaces the hard error"
@@ -253,10 +327,12 @@
       (rf/dispatch-sync [:ctx/fx-writes-legacy-root] {:frame :ctx/legacy-fx})
       (let [errs (error-events recorded :rf.error/handler-exception)
             ex   (some-> errs first :tags :exception)]
-        (is (= :rf.error/legacy-runtime-root (:rf.error/id (ex-data ex)))
-            "the :fx-path :db effect with a legacy root is rejected too")
+        ;; ALWAYS-ON (rf2-d2841): the rejection holds on the `:fx` path too.
         (is (not (contains? (rf/app-db-value :ctx/legacy-fx) :rf/runtime))
-            "the legacy root never commits")))))
+            "the legacy root never commits")
+        (when interop/debug-enabled?
+          (is (= :rf.error/legacy-runtime-root (:rf.error/id (ex-data ex)))
+              "the :fx-path :db effect with a legacy root is rejected too"))))))
 
 (deftest legitimate-runtime-db-effect-is-not-a-legacy-root-error
   (testing "a framework :rf.db/runtime effect (the NEW partition) is NOT the legacy-root hard error"
@@ -266,10 +342,14 @@
         {:doc "framework-authority" :rf/machine? true}
         (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {:m 1}}}))
       (rf/dispatch-sync [:ctx/fw-runtime] {:frame :ctx/new-runtime})
-      (is (empty? (error-events recorded :rf.error/handler-exception))
-          "writing the :rf.db/runtime partition is legitimate — no legacy-root throw")
+      ;; ALWAYS-ON (rf2-d2841): the commit IS the discriminator — a
+      ;; legacy-root throw would have aborted it. The trace negative below was
+      ;; class-1 vacuous under the gate.
       (is (= {:rf.runtime/machines {:m 1}} (:rf.db/runtime (rf/frame-state-value :ctx/new-runtime)))
-          "the runtime-db partition committed normally"))))
+          "the runtime-db partition committed normally")
+      (when interop/debug-enabled?
+        (is (empty? (error-events recorded :rf.error/handler-exception))
+            "writing the :rf.db/runtime partition is legitimate — no legacy-root throw")))))
 
 ;; ===========================================================================
 ;; rf2-u1kdvg — FINAL-effects boundary shape policing
@@ -318,16 +398,20 @@
       (rf/reg-event :ctx/downstream (fn [{:keys [db]} _] {:db (assoc db :downstream? true)}))
       (rf/dispatch-sync [:ctx/writes-db] {:frame :ctx/after-bad-fx})
       (rf/dispatch-sync [:ctx/downstream] {:frame :ctx/after-bad-fx})
-      (let [errs (error-events recorded :rf.error/effect-map-shape)]
-        (is (= 1 (count errs))
-            "exactly one shape error for the non-sequential :fx value")
-        (is (= :fx (:offending-key (:tags (first errs)))))
-        (is (= :logged-and-skipped (:recovery (first errs)))))
+      ;; ALWAYS-ON (rf2-d2841): "policed, not thrown" is entirely a production
+      ;; claim — the commit landed and the drain survived. That is what this
+      ;; deftest is for; the shape error merely narrates it.
       (let [db (rf/app-db-value :ctx/after-bad-fx)]
         (is (true? (:committed? db))
             "the :db effect still committed — the bad :fx was dropped, no host throw aborted the event")
         (is (true? (:downstream? db))
-            "the downstream event still drained — the malformed :fx did not abandon the queue")))))
+            "the downstream event still drained — the malformed :fx did not abandon the queue"))
+      (when interop/debug-enabled?
+        (let [errs (error-events recorded :rf.error/effect-map-shape)]
+          (is (= 1 (count errs))
+              "exactly one shape error for the non-sequential :fx value")
+          (is (= :fx (:offending-key (:tags (first errs)))))
+          (is (= :logged-and-skipped (:recovery (first errs)))))))))
 
 (deftest after-interceptor-foreign-effect-key-is-policed
   (testing "an :after interceptor inserting a foreign top-level effect key is policed (dropped) — not silently ignored at the partition commit"
@@ -341,13 +425,15 @@
         {:interceptors [::foreign]}
         (fn [{:keys [db]} _] {:db (assoc db :ok? true)}))
       (rf/dispatch-sync [:ctx/writes-db2] {:frame :ctx/after-foreign})
-      (let [errs (error-events recorded :rf.error/effect-map-shape)]
-        (is (= 1 (count errs))
-            "exactly one shape error for the foreign :http key")
-        (is (= :http (:offending-key (:tags (first errs)))))
-        (is (= :logged-and-skipped (:recovery (first errs)))))
+      ;; ALWAYS-ON (rf2-d2841): the final-boundary drop happens in production.
       (is (true? (:ok? (rf/app-db-value :ctx/after-foreign)))
-          "the legal :db still committed; only the foreign :http key was dropped"))))
+          "the legal :db still committed; only the foreign :http key was dropped")
+      (when interop/debug-enabled?
+        (let [errs (error-events recorded :rf.error/effect-map-shape)]
+          (is (= 1 (count errs))
+              "exactly one shape error for the foreign :http key")
+          (is (= :http (:offending-key (:tags (first errs)))))
+          (is (= :logged-and-skipped (:recovery (first errs)))))))))
 
 (deftest after-interceptor-legacy-runtime-root-is-rejected
   (testing "an :after interceptor inserting :rf/runtime into [:effects :db] is rejected at the final boundary — never lands in app-db, drain survives"
@@ -367,17 +453,24 @@
       (rf/reg-event :ctx/after-legacy-downstream (fn [{:keys [db]} _] {:db (assoc db :downstream? true)}))
       (rf/dispatch-sync [:ctx/clean-db] {:frame :ctx/after-legacy})
       (rf/dispatch-sync [:ctx/after-legacy-downstream] {:frame :ctx/after-legacy})
-      (let [errs (error-events recorded :rf.error/legacy-runtime-root)]
-        (is (= 1 (count errs))
-            "exactly one legacy-runtime-root error at the final boundary")
-        (is (= :rf/runtime (:offending-key (:tags (first errs))))))
+      ;; ALWAYS-ON (rf2-d2841): whole-effect rejection, no partial commit, and
+      ;; a surviving drain — all production behaviour at the final boundary.
+      ;; The `(not (contains? db :user/id))` negative is NOT vacuous here: the
+      ;; sibling assertion proves the frame's app-db exists and carries
+      ;; `:downstream?`, so an absent `:user/id` is a rejection, not an absence
+      ;; of everything.
       (let [db (rf/app-db-value :ctx/after-legacy)]
         (is (not (contains? db :rf/runtime))
             "the legacy :rf/runtime root never lands in app-db — the whole :db effect is rejected (no commit)")
         (is (not (contains? db :user/id))
             "no partial commit — the rejected :db effect is dropped entirely")
         (is (true? (:downstream? db))
-            "the drain survived the in-band rejection — downstream event still ran")))))
+            "the drain survived the in-band rejection — downstream event still ran"))
+      (when interop/debug-enabled?
+        (let [errs (error-events recorded :rf.error/legacy-runtime-root)]
+          (is (= 1 (count errs))
+              "exactly one legacy-runtime-root error at the final boundary")
+          (is (= :rf/runtime (:offending-key (:tags (first errs))))))))))
 
 ;; ---- full-context (interceptor) final-effects policing --------------------
 ;;
@@ -401,12 +494,16 @@
         {:interceptors [:ctx/ctx-writes-probe]}
         (fn [_ _] {}))
       (rf/dispatch-sync [:ctx/ctx-writes] {:frame :ctx/ctx-bad-fx})
-      (let [errs (error-events recorded :rf.error/effect-map-shape)]
-        (is (= 1 (count errs))
-            "the full-context interceptor's malformed :fx is policed — the reg-event handler return is not the only path that gets shape policing")
-        (is (= :fx (:offending-key (:tags (first errs))))))
+      ;; ALWAYS-ON (rf2-d2841): the interceptor-written effects are policed at
+      ;; the boundary in production too — the `:db` landed, the bad `:fx` did
+      ;; not throw.
       (is (true? (:committed? (rf/app-db-value :ctx/ctx-bad-fx)))
-          "the :db effect still committed; only the bad :fx was dropped"))))
+          "the :db effect still committed; only the bad :fx was dropped")
+      (when interop/debug-enabled?
+        (let [errs (error-events recorded :rf.error/effect-map-shape)]
+          (is (= 1 (count errs))
+              "the full-context interceptor's malformed :fx is policed — the reg-event handler return is not the only path that gets shape policing")
+          (is (= :fx (:offending-key (:tags (first errs))))))))))
 
 (deftest full-context-interceptor-foreign-key-is-policed
   (testing "a full-context interceptor whose context carries a foreign top-level effect key is policed at the boundary"
@@ -422,12 +519,14 @@
         {:interceptors [:ctx/ctx-foreign-writes-probe]}
         (fn [_ _] {}))
       (rf/dispatch-sync [:ctx/ctx-foreign-writes] {:frame :ctx/ctx-foreign})
-      (let [errs (error-events recorded :rf.error/effect-map-shape)]
-        (is (= 1 (count errs))
-            "the full-context interceptor's foreign :dispatch key is policed")
-        (is (= :dispatch (:offending-key (:tags (first errs))))))
+      ;; ALWAYS-ON (rf2-d2841).
       (is (true? (:ok? (rf/app-db-value :ctx/ctx-foreign)))
-          "the legal :db still committed; the foreign top-level key was dropped"))))
+          "the legal :db still committed; the foreign top-level key was dropped")
+      (when interop/debug-enabled?
+        (let [errs (error-events recorded :rf.error/effect-map-shape)]
+          (is (= 1 (count errs))
+              "the full-context interceptor's foreign :dispatch key is policed")
+          (is (= :dispatch (:offending-key (:tags (first errs))))))))))
 
 ;; ---- the well-shaped hot path stays clean ---------------------------------
 
@@ -435,12 +534,21 @@
   (testing "a clean reg-event {:db :fx} return ({:db .. :fx [..]}) emits NO :rf.error/effect-map-shape from the final boundary (no double-policing)"
     (rf/make-frame {:id :ctx/clean-final :doc "ctx"})
     (let [recorded (record-traces! ::clean-final)]
-      (rf/reg-fx :ctx/noop-fx (fn [_ _]))
-      (rf/reg-event :ctx/clean
-        (fn [{:keys [db]} _] {:db (assoc db :n 1)
-                              :fx [[:ctx/noop-fx {}]]}))
-      (rf/dispatch-sync [:ctx/clean] {:frame :ctx/clean-final})
-      (is (empty? (error-events recorded :rf.error/effect-map-shape))
-          "well-shaped effects pass the final boundary untouched — no spurious / double shape error")
-      (is (= 1 (:n (rf/app-db-value :ctx/clean-final)))
-          "the :db effect committed normally"))))
+      (let [fx-ran (atom 0)]
+        (rf/reg-fx :ctx/noop-fx (fn [_ _] (swap! fx-ran inc)))
+        (rf/reg-event :ctx/clean
+          (fn [{:keys [db]} _] {:db (assoc db :n 1)
+                                :fx [[:ctx/noop-fx {}]]}))
+        (rf/dispatch-sync [:ctx/clean] {:frame :ctx/clean-final})
+        ;; ALWAYS-ON (rf2-d2841): "passed the final boundary untouched" means
+        ;; BOTH effects survived it — the `:db` committed and the `:fx` ran.
+        ;; That is the production statement of "no spurious policing"; the
+        ;; empty-error-stream negative below was class-1 vacuous under the gate
+        ;; and was one of this deftest's two assertions.
+        (is (= 1 (:n (rf/app-db-value :ctx/clean-final)))
+            "the :db effect committed normally")
+        (is (= 1 @fx-ran)
+            "the well-shaped :fx ran — nothing was dropped at the boundary")
+        (when interop/debug-enabled?
+          (is (empty? (error-events recorded :rf.error/effect-map-shape))
+              "well-shaped effects pass the final boundary untouched — no spurious / double shape error"))))))

--- a/implementation/core/test/re_frame/frame_destroy_composed_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_composed_test.clj
@@ -20,7 +20,40 @@
     - JVM coverage suffices — every assertion is pure runtime semantics
       with no host-specific divergence (the destroy step list is host-
       agnostic; CLJS adds only React-context teardown, which is owned
-      by the views ns and tested separately in adapters/*/test/)."
+      by the views ns and tested separately in adapters/*/test/).
+
+  ## Posture split (rf2-d2841)
+
+  Teardown is production behaviour; the LIFECYCLE EMITS that narrate it are
+  not. Six of the eight cases read `:rf.sub/dispose` / `:rf.frame/destroyed` /
+  `:rf.warning/teardown-hook-exception` /
+  `:rf.warning/cross-frame-dispatch-sync-during-drain` off the dev trace, so
+  they failed under `scripts/test-core-prod-gate.sh`. Those reads are guarded;
+  everything about WHAT WAS TORN DOWN stays always-on, which is most of the
+  file already — the frames store, the sub-cache, the schemas registry, the
+  flows registry and last-inputs are all ungated.
+
+  TWO CASES NEEDED A NEW WITNESS RATHER THAN A GUARD, and both are about
+  counting disposals. `destroy-emits-sub-dispose-per-cached-slot` and
+  `destroy-emits-exactly-one-dispose-per-slot-for-layered-sub` were reading the
+  emit stream to count evictions; the bug the second one regresses (rf2-awhtpc)
+  is a DOUBLE DISPOSE, and a double dispose is observable directly through
+  `interop/add-on-dispose!` on the reactions themselves. Both now count real
+  disposals in both postures. The layered case is the stronger for it: under
+  the gate it now proves the input-release cascade does not re-dispose a slot
+  the frame-destroy walk already cleared, which is the actual defect — the
+  duplicated EMIT was only its symptom.
+
+  THE EPOCH RING IS DEV-FED, and that is where this file's false green was.
+  `epoch.capture/observe-trace-event!` feeds the ring from the DEV TRACE, so
+  under the gate `rf/epoch-history` is empty and `observed-frames-by-cb` is
+  never populated. `composed-destroy-leak-audit`'s two epoch PRECONDITIONS
+  went red — and its two matching POST-conditions passed for free: `(= []
+  (rf/epoch-history …))` over a ring that is always empty (class 1) and
+  `(not (contains? (get observed …) …))` over a nil map (class 4). A leak audit
+  certifying that a buffer was cleared, when the buffer was never filled, is
+  exactly the shape this lane exists to close. Both pairs are guarded together
+  so the precondition can never be separated from the claim it licenses."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.epoch :as epoch]
@@ -114,22 +147,27 @@
       (is (nil? (rf/destroy-frame! :composed/scoped))
           "destroy-frame! completes without re-throwing the listener's exception")
 
-      ;; The throwing listener WAS invoked (more than once — the cascade
-      ;; emitted multiple events).
-      (is (>= @throw-calls 3)
-          (str "throwing listener invoked once per cascade event (>=3); got "
-               @throw-calls))
+      ;; rf2-d2841 — GUARDED: the listener storm and the cascade's emit
+      ;; sequence are dev-trace facts. Under `-Dre-frame.debug=false` nothing
+      ;; is emitted, so no listener runs and there is no storm to survive. The
+      ;; always-on residue is the teardown itself, asserted below.
+      (when interop/debug-enabled?
+        ;; The throwing listener WAS invoked (more than once — the cascade
+        ;; emitted multiple events).
+        (is (>= @throw-calls 3)
+            (str "throwing listener invoked once per cascade event (>=3); got "
+                 @throw-calls))
 
-      ;; The surviving listener saw the canonical cascade events.
-      (let [ops (set (map :operation @survivor))]
-        (is (contains? ops :rf.machine.lifecycle/destroyed)
-            "survivor saw :rf.machine.lifecycle/destroyed")
-        (is (contains? ops :rf.frame/destroyed)
-            "survivor saw :rf.frame/destroyed"))
-      (is (= 2 (count (filter #(= :rf.machine.lifecycle/destroyed
-                                  (:operation %))
-                              @survivor)))
-          "survivor saw both per-machine destroyed events (one per snapshot)")
+        ;; The surviving listener saw the canonical cascade events.
+        (let [ops (set (map :operation @survivor))]
+          (is (contains? ops :rf.machine.lifecycle/destroyed)
+              "survivor saw :rf.machine.lifecycle/destroyed")
+          (is (contains? ops :rf.frame/destroyed)
+              "survivor saw :rf.frame/destroyed"))
+        (is (= 2 (count (filter #(= :rf.machine.lifecycle/destroyed
+                                    (:operation %))
+                                @survivor)))
+            "survivor saw both per-machine destroyed events (one per snapshot)"))
 
       ;; The frame is fully gone from the frames store (the ONE store a
       ;; seated frame lives in, rf2-h1vqa4) — proves no destroy step was
@@ -290,23 +328,35 @@
                                (when (= :rf.sub/dispose (:operation ev))
                                  (swap! disposes conj ev))))
       (try
-        (rf/subscribe [:composed/da] {:frame :composed/dispose-emit})
-        (rf/subscribe [:composed/db] {:frame :composed/dispose-emit})
-        (is (= 2 (count @(:sub-cache (frame/frame :composed/dispose-emit))))
-            "both subscriptions are cached before destroy")
+        (let [ra       (rf/subscribe [:composed/da] {:frame :composed/dispose-emit})
+              rb       (rf/subscribe [:composed/db] {:frame :composed/dispose-emit})
+              disposed (atom [])]
+          ;; rf2-d2841 — ALWAYS-ON counterpart of the emit stream: count the
+          ;; REAL disposals through `interop/add-on-dispose!`, which is not
+          ;; gated on `interop/debug-enabled?`.
+          (interop/add-on-dispose! ra (fn [] (swap! disposed conj [:composed/da])))
+          (interop/add-on-dispose! rb (fn [] (swap! disposed conj [:composed/db])))
+          (is (= 2 (count @(:sub-cache (frame/frame :composed/dispose-emit))))
+              "both subscriptions are cached before destroy")
 
-        (is (nil? (frame/destroy-frame! :composed/dispose-emit)))
+          (is (nil? (frame/destroy-frame! :composed/dispose-emit)))
 
-        (let [evs   @disposes
-              q-vs  (set (map #(-> % :tags :rf.sub/query-v) evs))]
-          (is (= 2 (count evs))
-              "one :rf.sub/dispose per evicted slot on frame destroy")
-          (is (= #{[:composed/da] [:composed/db]} q-vs)
-              "every cached query-vector got its own dispose emit")
-          (is (every? #(= :frame-destroy (-> % :tags :rf.sub/reason)) evs)
-              ":rf.sub/reason :frame-destroy discriminates the teardown path")
-          (is (every? #(= :composed/dispose-emit (-> % :tags :frame)) evs)
-              "each emit carries the destroyed frame's id"))
+          (is (= #{[:composed/da] [:composed/db]} (set @disposed))
+              "every cached slot was really disposed on frame destroy")
+          (is (= 2 (count @disposed))
+              "exactly one disposal per cached slot")
+
+          (when interop/debug-enabled?
+            (let [evs   @disposes
+                  q-vs  (set (map #(-> % :tags :rf.sub/query-v) evs))]
+              (is (= 2 (count evs))
+                  "one :rf.sub/dispose per evicted slot on frame destroy")
+              (is (= #{[:composed/da] [:composed/db]} q-vs)
+                  "every cached query-vector got its own dispose emit")
+              (is (every? #(= :frame-destroy (-> % :tags :rf.sub/reason)) evs)
+                  ":rf.sub/reason :frame-destroy discriminates the teardown path")
+              (is (every? #(= :composed/dispose-emit (-> % :tags :frame)) evs)
+                  "each emit carries the destroyed frame's id"))))
         (finally
           (rf/unregister-listener! :trace ::dispose-emit))))))
 
@@ -348,31 +398,49 @@
                                (when (= :rf.sub/dispose (:operation ev))
                                  (swap! disposes conj ev))))
       (try
-        (let [r     (rf/subscribe [:composed/layered-sum] {:frame :composed/layered-destroy})
-              cache (:sub-cache (frame/frame :composed/layered-destroy))]
+        (let [r        (rf/subscribe [:composed/layered-sum] {:frame :composed/layered-destroy})
+              cache    (:sub-cache (frame/frame :composed/layered-destroy))
+              disposed (atom [])]
           (is (= 5 @r))
           (is (= 3 (count @cache))
-              "precondition: sum + both inputs are cached before destroy"))
+              "precondition: sum + both inputs are cached before destroy")
+          ;; rf2-d2841 — ALWAYS-ON, and this is the DEFECT rather than its
+          ;; symptom: rf2-awhtpc was a slot being disposed TWICE (the
+          ;; input-release cascade racing the frame-destroy walk over a cache
+          ;; that had not been pre-cleared). The duplicated `:rf.sub/dispose`
+          ;; emit was how it was noticed; `interop/add-on-dispose!` counts the
+          ;; disposals themselves, in both postures.
+          (doseq [[q-v node] @cache]
+            (interop/add-on-dispose! (:reaction node)
+                                     (fn [] (swap! disposed conj q-v))))
 
-        (is (nil? (frame/destroy-frame! :composed/layered-destroy)))
+          (is (nil? (frame/destroy-frame! :composed/layered-destroy)))
 
-        (let [evs      @disposes
-              by-query (group-by #(-> % :tags :rf.sub/query-v) evs)]
-          (is (= 3 (count evs))
-              "exactly THREE :rf.sub/dispose emits — one per cached slot, no
-               double-emit from the input-release cascade")
+          (is (= 3 (count @disposed))
+              "exactly THREE disposals — one per cached slot, no double-dispose
+               from the input-release cascade")
           (is (= #{[:composed/layered-sum] [:composed/layered-a] [:composed/layered-b]}
-                 (set (keys by-query)))
-              "every cached query-vector (sum + both inputs) surfaced exactly
-               once")
-          (doseq [[q q-evs] by-query]
-            (is (= 1 (count q-evs))
-                (str q " must fire exactly one :rf.sub/dispose, not a "
-                     "duplicate from the ref-count cascade")))
-          (is (every? #(= :frame-destroy (-> % :tags :rf.sub/reason)) evs)
-              "every emit is reasoned :frame-destroy — the cascade found the
-               already-cleared cache and never re-emitted :no-more-derefers
-               for an input"))
+                 (set @disposed))
+              "every cached slot (sum + both inputs) was disposed exactly once")
+
+          (when interop/debug-enabled?
+            (let [evs      @disposes
+                  by-query (group-by #(-> % :tags :rf.sub/query-v) evs)]
+              (is (= 3 (count evs))
+                  "exactly THREE :rf.sub/dispose emits — one per cached slot, no
+                   double-emit from the input-release cascade")
+              (is (= #{[:composed/layered-sum] [:composed/layered-a] [:composed/layered-b]}
+                     (set (keys by-query)))
+                  "every cached query-vector (sum + both inputs) surfaced exactly
+                   once")
+              (doseq [[q q-evs] by-query]
+                (is (= 1 (count q-evs))
+                    (str q " must fire exactly one :rf.sub/dispose, not a "
+                         "duplicate from the ref-count cascade")))
+              (is (every? #(= :frame-destroy (-> % :tags :rf.sub/reason)) evs)
+                  "every emit is reasoned :frame-destroy — the cascade found the
+                   already-cleared cache and never re-emitted :no-more-derefers
+                   for an input"))))
         (finally
           (rf/unregister-listener! :trace ::layered-destroy))))))
 
@@ -412,17 +480,23 @@
         (is (contains? @downstream-ran :flows-ran)
             "best-effort: the downstream hook still ran after the throw")
 
-        (is (= 1 (count @warnings))
-            "exactly one teardown-hook-exception diagnostic for the failed hook")
-        (let [ev (first @warnings)]
-          (is (= :error (:op-type ev))
-              "op-type is :error (emit-error! family); :operation carries the :rf.warning/* category")
-          (is (= :schemas/on-frame-destroyed! (-> ev :tags :hook))
-              ":hook names the failing late-bind hook key")
-          (is (= :composed/hook-diag (-> ev :tags :frame))
-              ":frame carries the frame being destroyed (via the dynamic binding)")
-          (is (some? (-> ev :tags :exception))
-              ":exception carries the throwable"))
+        ;; ALWAYS-ON (rf2-d2841): best-effort teardown still finished — the
+        ;; frame is gone despite the hook throw. Only the DIAGNOSTIC that makes
+        ;; the leak diagnosable is dev-only.
+        (is (nil? (frame/frame :composed/hook-diag))
+            "the frame is dissoc'd despite the throwing hook")
+        (when interop/debug-enabled?
+          (is (= 1 (count @warnings))
+              "exactly one teardown-hook-exception diagnostic for the failed hook")
+          (let [ev (first @warnings)]
+            (is (= :error (:op-type ev))
+                "op-type is :error (emit-error! family); :operation carries the :rf.warning/* category")
+            (is (= :schemas/on-frame-destroyed! (-> ev :tags :hook))
+                ":hook names the failing late-bind hook key")
+            (is (= :composed/hook-diag (-> ev :tags :frame))
+                ":frame carries the frame being destroyed (via the dynamic binding)")
+            (is (some? (-> ev :tags :exception))
+                ":exception carries the throwable")))
         (finally
           (rf/unregister-listener! :trace ::hook-diag)
           (late-bind/set-fn! :schemas/on-frame-destroyed! original-schemas-h)
@@ -469,13 +543,17 @@
 
       ;; The warn trace fired (cross-frame dispatch-sync mid-drain
       ;; on a sibling per Spec 002 / rf2-fp97).
-      (let [warns (filter (fn [ev]
-                            (and (= :warning (:op-type ev))
-                                 (= :rf.warning/cross-frame-dispatch-sync-during-drain
-                                    (:operation ev))))
-                          @recorded)]
-        (is (seq warns)
-            ":rf.warning/cross-frame-dispatch-sync-during-drain fired during :on-destroy"))
+      ;; rf2-d2841 — GUARDED: the warn is a dev-trace emit. The commit, the
+      ;; teardown and the sibling's survival above and below are the production
+      ;; contract, and they are already always-on.
+      (when interop/debug-enabled?
+        (let [warns (filter (fn [ev]
+                              (and (= :warning (:op-type ev))
+                                   (= :rf.warning/cross-frame-dispatch-sync-during-drain
+                                      (:operation ev))))
+                            @recorded)]
+          (is (seq warns)
+              ":rf.warning/cross-frame-dispatch-sync-during-drain fired during :on-destroy")))
 
       ;; The child frame is fully gone — :on-destroy did not block
       ;; the dissoc.
@@ -533,11 +611,18 @@
     (is (= [3 4] (get-in (flows/last-inputs-snapshot) [:composed/area :composed/leak-audit]))
         "precondition: flow last-inputs has a row for the frame")
 
-    (let [observed @(deref #'epoch-state/observed-frames-by-cb)]
-      (is (contains? (get observed ::composed-observer) :composed/leak-audit)
-          "precondition: epoch cb has the frame in its observed-frames set"))
-    (is (pos? (count (rf/epoch-history :composed/leak-audit)))
-        "precondition: epoch ring buffer has at least one record")
+    ;; rf2-d2841 — GUARDED AS A PAIR with the matching post-conditions below.
+    ;; `epoch.capture/observe-trace-event!` feeds the epoch ring from the DEV
+    ;; TRACE, so under `-Dre-frame.debug=false` the ring is never filled and
+    ;; `observed-frames-by-cb` is never populated. Splitting the precondition
+    ;; from the post-condition would leave the audit certifying that a buffer
+    ;; it never filled had been cleared.
+    (when interop/debug-enabled?
+      (let [observed @(deref #'epoch-state/observed-frames-by-cb)]
+        (is (contains? (get observed ::composed-observer) :composed/leak-audit)
+            "precondition: epoch cb has the frame in its observed-frames set"))
+      (is (pos? (count (rf/epoch-history :composed/leak-audit)))
+          "precondition: epoch ring buffer has at least one record"))
 
     ;; --- sub-cache: pin a subscription ------------------------------------
     (rf/reg-sub :composed/leak-rect (fn [db _] (:rect db)))
@@ -570,12 +655,16 @@
     (is (not (contains? (get (flows/last-inputs-snapshot) :composed/area)
                         :composed/leak-audit))
         "post: flow last-inputs row dropped for the destroyed frame")
-    (is (= [] (rf/epoch-history :composed/leak-audit))
-        "post: epoch ring buffer returns the empty vector for the destroyed frame")
-    (let [observed @(deref #'epoch-state/observed-frames-by-cb)]
-      (is (not (contains? (get observed ::composed-observer)
-                          :composed/leak-audit))
-          "post: epoch cb's observed-frames entry no longer includes the frame"))
+    ;; rf2-d2841 — the guarded half of the pair above. These two were the
+    ;; file's vacuous passes: `(= [] …)` over a ring that is ALWAYS empty
+    ;; under the gate (class 1) and `(not (contains? nil …))` (class 4).
+    (when interop/debug-enabled?
+      (is (= [] (rf/epoch-history :composed/leak-audit))
+          "post: epoch ring buffer returns the empty vector for the destroyed frame")
+      (let [observed @(deref #'epoch-state/observed-frames-by-cb)]
+        (is (not (contains? (get observed ::composed-observer)
+                            :composed/leak-audit))
+            "post: epoch cb's observed-frames entry no longer includes the frame")))
 
     ;; Listener registries (trace, epoch) outlive frames by design — they
     ;; are global and re-arm against the next same-keyed frame

--- a/implementation/core/test/re_frame/interceptor_override_summary_trace_test.clj
+++ b/implementation/core/test/re_frame/interceptor_override_summary_trace_test.clj
@@ -22,9 +22,42 @@
   fires at enqueue BEFORE override resolution) per the ruling's timing
   requirement. Dev-only / production-elision is pinned separately by the
   `re-frame.elision-probe` + `scripts/check-elision.cjs` gate (the run-start
-  emit body — and the summary construction feeding it — DCE under :advanced)."
+  emit body — and the summary construction feeding it — DCE under :advanced).
+
+  ## Posture split (rf2-d2841)
+
+  The docstring above already says the summary is DEV-ONLY — the run-start emit
+  body and the summary construction feeding it both DCE. So the six
+  dispatch-driven cases failed under `scripts/test-core-prod-gate.sh` and their
+  summary assertions are guarded.
+
+  THE SUMMARY IS A REPORT ABOUT SOMETHING THAT IS NOT DEV-ONLY, and that is
+  what was missing. `:interceptor-overrides` REMOVE and REPLACE entries on the
+  resolved chain in every posture; the tag merely narrates it. Every case
+  therefore grew an always-on witness that reads the chain's ACTUAL BEHAVIOUR
+  — recording interceptors that append their own id as they run — so
+  the claims that `::log-a` was removed and that `::log-x` was replaced by
+  `::stub-x` are now
+  proven where they matter, in the posture that ships. Under the gate that is
+  first-ever coverage of override resolution; in dev it is a control that the
+  guarded tag agrees with the chain it describes.
+
+  The four `marks-projection-*` cases need no guard at all:
+  `classification/project-trace-event` is a pure fn over a SYNTHETIC event and
+  is not gated on `interop/debug-enabled?` — `marks-projection-redacts-non-ref-
+  payload` proves it, since a no-op projection would fail it. They were already
+  green under the gate for a real reason, which is the distinction this pass
+  keeps having to make.
+
+  TWO VACUOUS PASSES CAME OFF (rf2-d2841 class 4): `summary-absent-on-no-
+  override-path` and `summary-absent-with-empty-override-map` each certify the
+  override-free hot path with `(is (nil? (run-start-summary …)))` — nil because
+  the trace ring is empty, not because the tag was omitted. Their always-on
+  replacements assert the un-overridden chain ran INTACT, which the absence of
+  a tag was standing in for."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.frame :as frame]
             [re-frame.interceptor :as interceptor]
             [re-frame.classification :as classification]
@@ -56,7 +89,12 @@
 (defn- run-start-summary
   "Dispatch `event-v` (with optional `dispatch-opts`) and return the
   `:rf.interceptor/override-summary` tag from the single `:rf.event/run-start`
-  trace event. nil when the tag is absent."
+  trace event. nil when the tag is absent.
+
+  rf2-d2841 — the one-emit assertion is a TRACE-SHAPE claim and is guarded;
+  under `-Dre-frame.debug=false` there are no run-start emits at all, so
+  asserting `(= 1 (count run-starts))` there would fail for a posture reason
+  rather than a defect."
   ([event-v] (run-start-summary event-v nil))
   ([event-v dispatch-opts]
    (let [acc (collect-traces! ::cap)]
@@ -65,11 +103,30 @@
          (rf/dispatch-sync event-v dispatch-opts)
          (rf/dispatch-sync event-v))
        (let [run-starts (filterv #(= :rf.event/run-start (:operation %)) @acc)]
-         (is (= 1 (count run-starts))
-             "exactly one :rf.event/run-start emit per dispatch")
+         (when interop/debug-enabled?
+           (is (= 1 (count run-starts))
+               "exactly one :rf.event/run-start emit per dispatch"))
          (-> run-starts first :tags :rf.interceptor/override-summary))
        (finally
          (rf/unregister-listener! :trace ::cap))))))
+
+;; ---- always-on chain witness (rf2-d2841) ----------------------------------
+;;
+;; The summary REPORTS an override; the override itself is production
+;; behaviour. A recording interceptor appends its own id as it runs, so the
+;; chain that actually executed is readable in both postures.
+
+(def ^:private ran
+  "Ids of the recording interceptors that ran, in order, for the last dispatch."
+  (atom []))
+
+(defn- reg-recording-ic!
+  "Register `id` as an interceptor that appends `id` to [[ran]] when its
+  `:before` fires."
+  [id]
+  (rf/reg-interceptor id {:before (fn [ctx] (swap! ran conj id) ctx)}))
+
+(defn- reset-ran! [] (reset! ran []))
 
 (defn- reg-noop-ic! [id]
   (rf/reg-interceptor id {:before (fn [ctx] ctx)}))
@@ -78,77 +135,108 @@
 
 (deftest summary-absent-on-no-override-path
   (testing "no :interceptor-overrides => tag is omitted entirely"
-    (reg-noop-ic! ::log-a)
+    (reset-ran!)
+    (reg-recording-ic! ::log-a)
     (rf/reg-event :sum/run
       {:interceptors [::log-a]}
       (fn [{:keys [db]} _] {:db db}))
-    (is (nil? (run-start-summary [:sum/run]))
-        "override-free dispatch carries no :rf.interceptor/override-summary tag")))
+    (let [summary (run-start-summary [:sum/run])]
+      ;; ALWAYS-ON (rf2-d2841): the un-overridden chain ran INTACT — which is
+      ;; what "no override fired" means. The nil-tag assertion below was
+      ;; class-4 vacuous under the gate: nil because the trace ring is empty,
+      ;; not because the tag was omitted.
+      (is (= [::log-a] @ran) "the authored chain ran unmodified")
+      (when interop/debug-enabled?
+        (is (nil? summary)
+            "override-free dispatch carries no :rf.interceptor/override-summary tag")))))
 
 (deftest summary-absent-with-empty-override-map
   (testing "an empty :interceptor-overrides map fires nothing => tag absent"
-    (reg-noop-ic! ::log-a)
+    (reset-ran!)
+    (reg-recording-ic! ::log-a)
     (rf/reg-event :sum/run
       {:interceptors [::log-a]}
       (fn [{:keys [db]} _] {:db db}))
-    (is (nil? (run-start-summary [:sum/run] {:interceptor-overrides {}}))
-        "an empty override map is the no-override path — tag omitted")))
+    (let [summary (run-start-summary [:sum/run] {:interceptor-overrides {}})]
+      ;; ALWAYS-ON (rf2-d2841): an EMPTY override map leaves the chain intact.
+      ;; The nil-tag assertion was class-4 vacuous under the gate.
+      (is (= [::log-a] @ran) "an empty override map left the chain unmodified")
+      (when interop/debug-enabled?
+        (is (nil? summary)
+            "an empty override map is the no-override path — tag omitted")))))
 
 ;; ---- removed / replaced classification ------------------------------------
 
 (deftest summary-records-removed-override
   (testing "a {ref nil} override is reported under :removed (and :matched)"
-    (reg-noop-ic! ::log-a)
-    (reg-noop-ic! ::log-b)
+    (reset-ran!)
+    (reg-recording-ic! ::log-a)
+    (reg-recording-ic! ::log-b)
     (rf/reg-event :sum/run
       {:interceptors [::log-a ::log-b]}
       (fn [{:keys [db]} _] {:db db}))
     (let [summary (run-start-summary [:sum/run]
                                      {:interceptor-overrides {::log-a nil}})]
-      (is (some? summary) "tag present when an override fires")
-      (is (= [::log-a] (:removed summary)) ":removed carries the removed ref id")
-      (is (= [] (:replaced summary)) ":replaced empty — nothing was replaced")
-      (is (= [::log-a] (:matched summary)) ":matched is the union")
-      (is (= 1 (:count summary)) ":count is (count :matched)"))))
+      ;; ALWAYS-ON (rf2-d2841): the removal HAPPENED — `::log-a` did not run,
+      ;; `::log-b` did. That is the fact the guarded tag reports.
+      (is (= [::log-b] @ran) "the removed interceptor did not run; its sibling did")
+      (when interop/debug-enabled?
+        (is (some? summary) "tag present when an override fires")
+        (is (= [::log-a] (:removed summary)) ":removed carries the removed ref id")
+        (is (= [] (:replaced summary)) ":replaced empty — nothing was replaced")
+        (is (= [::log-a] (:matched summary)) ":matched is the union")
+        (is (= 1 (:count summary)) ":count is (count :matched)")))))
 
 (deftest summary-records-replaced-override
   (testing "a {ref other-ref} override is reported under :replaced (and :matched)"
-    (reg-noop-ic! ::log-x)
-    (reg-noop-ic! ::stub-x)
+    (reset-ran!)
+    (reg-recording-ic! ::log-x)
+    (reg-recording-ic! ::stub-x)
     (rf/reg-event :sum/run
       {:interceptors [::log-x]}
       (fn [{:keys [db]} _] {:db db}))
     (let [summary (run-start-summary [:sum/run]
                                      {:interceptor-overrides {::log-x ::stub-x}})]
-      (is (some? summary))
-      (is (= [::log-x] (:replaced summary)) ":replaced carries the replaced ref id")
-      (is (= [] (:removed summary)))
-      (is (= [::log-x] (:matched summary)))
-      (is (= 1 (:count summary))))))
+      ;; ALWAYS-ON (rf2-d2841): the SUBSTITUTION happened — the stub ran in the
+      ;; replaced entry's slot and the original did not run at all.
+      (is (= [::stub-x] @ran) "the replacement ran in place of the original")
+      (when interop/debug-enabled?
+        (is (some? summary))
+        (is (= [::log-x] (:replaced summary)) ":replaced carries the replaced ref id")
+        (is (= [] (:removed summary)))
+        (is (= [::log-x] (:matched summary)))
+        (is (= 1 (:count summary)))))))
 
 (deftest summary-records-mixed-removed-and-replaced
   (testing "a mix of removed + replaced overrides classifies each correctly"
-    (reg-noop-ic! ::log-a)
-    (reg-noop-ic! ::log-b)
-    (reg-noop-ic! ::stub-b)
+    (reset-ran!)
+    (reg-recording-ic! ::log-a)
+    (reg-recording-ic! ::log-b)
+    (reg-recording-ic! ::stub-b)
     (rf/reg-event :sum/run
       {:interceptors [::log-a ::log-b]}
       (fn [{:keys [db]} _] {:db db}))
     (let [summary (run-start-summary [:sum/run]
                                      {:interceptor-overrides {::log-a nil
                                                               ::log-b ::stub-b}})]
-      (is (some? summary))
-      (is (= [::log-a] (:removed summary)))
-      (is (= [::log-b] (:replaced summary)))
-      (is (= #{::log-a ::log-b} (set (:matched summary)))
-          ":matched is the union of removed + replaced")
-      (is (= 2 (:count summary))))))
+      ;; ALWAYS-ON (rf2-d2841): removal and substitution compose — only the
+      ;; stub ran, in the position the replaced entry held.
+      (is (= [::stub-b] @ran)
+          "the removed entry is gone and the replaced entry ran as its stub")
+      (when interop/debug-enabled?
+        (is (some? summary))
+        (is (= [::log-a] (:removed summary)))
+        (is (= [::log-b] (:replaced summary)))
+        (is (= #{::log-a ::log-b} (set (:matched summary)))
+            ":matched is the union of removed + replaced")
+        (is (= 2 (:count summary)))))))
 
 ;; ---- unmatched override key does not count --------------------------------
 
 (deftest unmatched-override-key-not-counted
   (testing "an override key that matches NO chain entry is not in the summary"
-    (reg-noop-ic! ::log-a)
+    (reset-ran!)
+    (reg-recording-ic! ::log-a)
     (rf/reg-event :sum/run
       {:interceptors [::log-a]}
       (fn [{:keys [db]} _] {:db db}))
@@ -156,50 +244,66 @@
     ;; override-fallthrough candidate, NOT something that took effect.
     (let [summary (run-start-summary [:sum/run]
                                      {:interceptor-overrides {::not-in-chain nil}})]
-      ;; The override map is non-empty (so the helper runs) but nothing
-      ;; matched — :matched/:removed/:replaced are empty, :count 0.
-      (is (some? summary) "tag present (override map non-empty)")
-      (is (= [] (:matched summary)))
-      (is (= [] (:removed summary)))
-      (is (= [] (:replaced summary)))
-      (is (= 0 (:count summary))))))
+      ;; ALWAYS-ON (rf2-d2841): an unmatched override key leaves the chain
+      ;; untouched — the production statement of ":count 0".
+      (is (= [::log-a] @ran) "an unmatched override key changed nothing")
+      (when interop/debug-enabled?
+        ;; The override map is non-empty (so the helper runs) but nothing
+        ;; matched — :matched/:removed/:replaced are empty, :count 0.
+        (is (some? summary) "tag present (override map non-empty)")
+        (is (= [] (:matched summary)))
+        (is (= [] (:removed summary)))
+        (is (= [] (:replaced summary)))
+        (is (= 0 (:count summary)))))))
 
 ;; ---- per-frame overrides also surface -------------------------------------
 
 (deftest per-frame-override-surfaces-on-summary
   (testing "a per-frame :interceptor-overrides also produces a run-start summary"
-    (reg-noop-ic! ::log-a)
-    (reg-noop-ic! ::log-b)
+    (reset-ran!)
+    (reg-recording-ic! ::log-a)
+    (reg-recording-ic! ::log-b)
     (rf/make-frame {:id :sum/framed :interceptor-overrides {::log-a nil}})
     (rf/reg-event :sum/run
       {:interceptors [::log-a ::log-b]}
       (fn [{:keys [db]} _] {:db db}))
     (rf/with-frame :sum/framed
       (let [summary (run-start-summary [:sum/run] {:frame :sum/framed})]
-        (is (some? summary))
-        (is (= [::log-a] (:removed summary)))
-        (is (= 1 (:count summary)))))))
+        ;; ALWAYS-ON (rf2-d2841): a PER-FRAME override acts on the chain in
+        ;; production too — the frame-scoped removal is not a dev affordance.
+        (is (= [::log-b] @ran) "the per-frame override removed ::log-a from the chain")
+        (when interop/debug-enabled?
+          (is (some? summary))
+          (is (= [::log-a] (:removed summary)))
+          (is (= 1 (:count summary))))))))
 
 ;; ---- value safety: no interceptor values / fns leak -----------------------
 
 (deftest summary-egresses-ids-only-no-values
   (testing "the summary carries ONLY keyword ref ids — no fns, maps, or values"
-    (reg-noop-ic! ::log-a)
-    (reg-noop-ic! ::stub-a)
+    (reset-ran!)
+    (reg-recording-ic! ::log-a)
+    (reg-recording-ic! ::stub-a)
     (rf/reg-event :sum/run
       {:interceptors [::log-a]}
       (fn [{:keys [db]} _] {:db db}))
     (let [summary (run-start-summary [:sum/run]
                                      {:interceptor-overrides {::log-a ::stub-a}})
           all-ids (concat (:matched summary) (:replaced summary) (:removed summary))]
-      (is (seq all-ids))
-      (doseq [id all-ids]
-        (is (or (keyword? id)
-                (and (vector? id) (= 2 (count id)) (keyword? (first id))))
-            (str "summary id is an interceptor reference, not a value: " (pr-str id)))
-        ;; No executable interceptor map / fn ever appears.
-        (is (not (map? id)) "no interceptor value map in the summary")
-        (is (not (fn? id)) "no fn in the summary")))))
+      ;; ALWAYS-ON (rf2-d2841): the substitution under scrutiny really happened,
+      ;; so the guarded value-safety claim below is about a real summary rather
+      ;; than an empty one. `(seq all-ids)` over the empty concat the gate
+      ;; yields would otherwise have gone red for a posture reason.
+      (is (= [::stub-a] @ran) "the replacement ran in place of the original")
+      (when interop/debug-enabled?
+        (is (seq all-ids))
+        (doseq [id all-ids]
+          (is (or (keyword? id)
+                  (and (vector? id) (= 2 (count id)) (keyword? (first id))))
+              (str "summary id is an interceptor reference, not a value: " (pr-str id)))
+          ;; No executable interceptor map / fn ever appears.
+          (is (not (map? id)) "no interceptor value map in the summary")
+          (is (not (fn? id)) "no fn in the summary"))))))
 
 ;; ---- marks chokepoint fail-closed -----------------------------------------
 

--- a/implementation/core/test/re_frame/reg_meta_noswallow_cljs_test.cljc
+++ b/implementation/core/test/re_frame/reg_meta_noswallow_cljs_test.cljc
@@ -13,8 +13,31 @@
   `reg-fx` / `reg-cofx` / `reg-interceptor`): a retired key throws, an unknown
   bare key warns, and a valid registration still passes. The registrars are
   exercised through their underlying registration fns (the enforcement lives in
-  the fns, not the macro layer)."
+  the fns, not the macro layer).
+
+  ## Posture split (rf2-d2841)
+
+  The no-silent-swallow contract has TWO enforcement tiers and they do not
+  share a posture. The RETIRED-key tier is a `throw` and is always-on —
+  `retired-spec-key-hard-errors-per-registrar` was already green under
+  `scripts/test-core-prod-gate.sh` for a real reason, and stays unguarded. The
+  UNKNOWN-key tier is a `:rf.warning/unknown-registration-key` emit on the
+  dev trace bus, so under `-Dre-frame.debug=false` nothing is emitted and
+  `unknown-bare-key-warns-per-registrar` failed.
+
+  The warning assertions are guarded; what stays always-on beside them is the
+  half of the contract production DOES honour — the registration nevertheless
+  SUCCEEDED and the id is resolvable in the registrar (the cascade continued).
+
+  TEN VACUOUS PASSES CAME OFF (rf2-d2841 class 1 — a negative over an empty
+  trace ring), five per deftest across the five registrar kinds:
+  `namespaced-and-known-keys-pass-silently-per-registrar` and
+  `schema-v2-key-passes-where-spec-would-fail` both certify the absence of an
+  unknown-key warning with `(is (empty? warns))` over a stream that carries no
+  at all under the gate. Both deftests were GREEN there, each on one real
+  assertion (the no-throw) and five free ones."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.interop :as interop]
             [re-frame.events :as events]
             [re-frame.subs :as subs]
             [re-frame.fx :as fx]
@@ -111,20 +134,25 @@
       (testing (str kind)
         (let [warns (with-captured-warnings
                       #(register! kind id {:doc "ok" :bogus-key 1}))]
-          (is (= 1 (count warns))
-              (str "reg-" (name kind) " emits exactly one unknown-key warning"))
-          (let [{:keys [tags]} (first warns)]
-            (is (= kind (:kind tags)) ":kind names the registrar kind")
-            (is (= id (:id tags)) ":id names the registration")
-            (is (= [:bogus-key] (:unknown-keys tags))
-                ":unknown-keys names exactly the offending bare key")
-            (is (contains? (set (:known tags)) :doc)
-                ":known carries the recognised bare vocabulary")
-            (is (string? (:reason tags))))
-          ;; The registration nevertheless SUCCEEDED — no throw, and the id is
-          ;; resolvable in the registrar (the cascade continued safely).
+          ;; ALWAYS-ON (rf2-d2841): the registration nevertheless SUCCEEDED — no
+          ;; throw, and the id is resolvable in the registrar. That is the half
+          ;; of §No silent swallow a production build honours: an unknown key
+          ;; is a nudge, never a rejection, and the cascade continues.
           (is (some? (registrar/lookup kind id))
-              "the registration succeeded despite the unknown key"))))))
+              "the registration succeeded despite the unknown key")
+          ;; rf2-d2841 — the WARNING is a dev-trace emit; nothing is emitted
+          ;; under `-Dre-frame.debug=false`.
+          (when interop/debug-enabled?
+            (is (= 1 (count warns))
+                (str "reg-" (name kind) " emits exactly one unknown-key warning"))
+            (let [{:keys [tags]} (first warns)]
+              (is (= kind (:kind tags)) ":kind names the registrar kind")
+              (is (= id (:id tags)) ":id names the registration")
+              (is (= [:bogus-key] (:unknown-keys tags))
+                  ":unknown-keys names exactly the offending bare key")
+              (is (contains? (set (:known tags)) :doc)
+                  ":known carries the recognised bare vocabulary")
+              (is (string? (:reason tags))))))))))
 
 ;; ---- namespaced extension key + known keys — SILENT (the carve-out) -------
 
@@ -141,12 +169,18 @@
                                       (register! kind id
                                                  {:doc            "a valid registration"
                                                   :myapp/extra-id 42})))))]
+          ;; ALWAYS-ON: the carve-out does not throw, and the registration lands.
           (is (nil? @ed)
               (str "reg-" (name kind)
                    " with known + namespaced keys must not throw; got " (pr-str @ed)))
-          (is (empty? warns)
-              (str "no unknown-key warning for known + namespaced keys; got "
-                   (pr-str warns))))))))
+          (is (some? (registrar/lookup kind id))
+              "the namespaced-extension registration landed")
+          ;; rf2-d2841 — class-1 vacuous under the gate: the warning stream is
+          ;; empty for EVERY key there, carve-out or typo.
+          (when interop/debug-enabled?
+            (is (empty? warns)
+                (str "no unknown-key warning for known + namespaced keys; got "
+                     (pr-str warns)))))))))
 
 ;; ---- the schema-bearing kinds accept `:schema` (the v2 name) --------------
 
@@ -160,4 +194,8 @@
                       #(is (nil? (caught-ex-data
                                    (fn [] (register! kind id {:doc "x" :schema [:map]}))))
                            (str "reg-" (name kind) " accepts `:schema`")))]
-          (is (empty? warns) "`:schema` is a known key — no unknown-key warning"))))))
+          (is (some? (registrar/lookup kind id))
+              "the `:schema`-bearing registration landed")
+          ;; rf2-d2841 — class-1 vacuous under the gate, same shape as above.
+          (when interop/debug-enabled?
+            (is (empty? warns) "`:schema` is a known key — no unknown-key warning")))))))

--- a/implementation/core/test/re_frame/registrar_warnings_test.clj
+++ b/implementation/core/test/re_frame/registrar_warnings_test.clj
@@ -24,8 +24,43 @@
   goog.DEBUG=false` constant-folds the consult+emit branch to nil
   (Spec 009 §Production builds). The CLJS elision-probe sentinels
   pin the absence of `rf.warning/missing-doc` and
-  `rf.warning/registration-collision` in the production bundle."
+  `rf.warning/registration-collision` in the production bundle.
+
+  ## Posture split (rf2-d2841)
+
+  The paragraph above is the whole story for the WARNINGS: both sit inside the
+  registrar's `(when interop/debug-enabled? ...)` gate, so under
+  `-Dre-frame.debug=false` neither is emitted and every warning assertion here
+  failed under `scripts/test-core-prod-gate.sh`. They are guarded verbatim.
+
+  A WHOLESALE GUARD WOULD HAVE MADE THIS A CLASS-2 FILE — a namespace reported
+  green having executed nothing — so each case also witnesses the REGISTRATION
+  the warning is a commentary on, and that half is production behaviour:
+
+    * the missing-doc cases assert the registration nevertheless SUCCEEDED,
+      which is the §No-silent-swallow contract's other half — the cascade
+      continues — and the only part of it a production build honours;
+    * the collision cases assert the LAST registration won — read back off
+      `handler-meta`'s provenance, which `register!` stores verbatim (only
+      `:doc` is stripped there, and `merge-coords` is not on this path). That
+      is the fact the collision warning exists to draw attention to, and it is
+      posture-independent;
+    * the rf2-3az1vn `:route` case additionally asserts the no-`:handler-fn`
+      slot was replaced at all — the shape-dedup that used to HIDE the
+      collision suppresses only the TRACE, never the replacement.
+
+  SEVEN VACUOUS PASSES CAME OFF (rf2-d2841 class 1 — a negative over an empty
+  trace ring). `missing-doc-suppressed-when-doc-present`,
+  `missing-doc-silent-on-programmatic-path`, `collision-silent-on-same-source-
+  re-eval`, `collision-silent-on-programmatic-path`, `collision-still-silent-
+  on-same-source-for-no-handler-fn-kind`, `handler-replaced-fires-on-silent-
+  hot-reload`'s `(empty? collisions)` and — the one worth naming twice —
+  `collision-fires-for-no-handler-fn-kind-despite-shape-dedup`'s
+  `(is (empty? replaced) ...)`, which certified that the dedup gate suppressed
+  the `handler-replaced` trace over a stream that carries no traces at all.
+  Five of those seven deftests were GREEN under the gate on nothing else."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.interop :as interop]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.source-coords :as source-coords]
@@ -59,6 +94,25 @@
              (and (= :warning (:op-type ev))
                   (= operation (:operation ev))))
            @recorded))
+
+(defn- assert-registered
+  "ALWAYS-ON (rf2-d2841): the registration LANDED. A dev warning is a nudge,
+  not a rejection — Spec 001 §No silent swallow requires the cascade to
+  continue — and that continuation is the only half of the contract a
+  production build can be asked about."
+  [kind id]
+  (is (some? (registrar/lookup kind id))
+      (str "the " kind " registration for " id " succeeded in this posture")))
+
+(defn- assert-live-provenance
+  "ALWAYS-ON (rf2-d2841): which registration is LIVE for `[kind id]`, read off
+  the stored provenance. `register!` keeps the metadata it was handed verbatim
+  (only `:doc` is stripped under the production gate, and `merge-coords` is
+  not on this path), so the `:ns` of the winning registration is readable in
+  both postures. This is the fact the collision warning narrates."
+  [kind id expected-ns]
+  (is (= expected-ns (:ns (registrar/lookup kind id)))
+      (str "the live " kind " registration for " id " came from " expected-ns)))
 
 (defn- with-stamped-coords
   "Invoke `f` with `*pending-coords*` bound to a synthetic
@@ -110,17 +164,19 @@
       (with-stamped-coords
         (fn []
           (rf/reg-event :ev/no-doc (fn [{:keys [db]} _] {:db db}))))
-      (let [warns (warnings-of recorded :rf.warning/missing-doc)]
-        (is (= 1 (count warns))
-            (str "expected exactly one missing-doc warning, got " (count warns)))
-        (let [t (:tags (first warns))]
-          (is (= :event (:kind t))
-              ":tags carries the registry :kind")
-          (is (= :ev/no-doc (:id t))
-              ":tags carries the registered :id")
-          (is (map? (:source-coords t))
-              ":tags carries the captured :source-coords envelope")
-          (is (= 're-frame.registrar-warnings-test (:ns (:source-coords t)))))))))
+      (assert-registered :event :ev/no-doc)
+      (when interop/debug-enabled?
+        (let [warns (warnings-of recorded :rf.warning/missing-doc)]
+          (is (= 1 (count warns))
+              (str "expected exactly one missing-doc warning, got " (count warns)))
+          (let [t (:tags (first warns))]
+            (is (= :event (:kind t))
+                ":tags carries the registry :kind")
+            (is (= :ev/no-doc (:id t))
+                ":tags carries the registered :id")
+            (is (map? (:source-coords t))
+                ":tags carries the captured :source-coords envelope")
+            (is (= 're-frame.registrar-warnings-test (:ns (:source-coords t))))))))))
 
 (deftest missing-doc-fires-when-doc-nil
   (testing ":doc explicitly nil is treated as missing"
@@ -128,7 +184,9 @@
       (with-stamped-coords
         (fn []
           (rf/reg-event :ev/nil-doc {:doc nil} (fn [{:keys [db]} _] {:db db}))))
-      (is (= 1 (count (warnings-of recorded :rf.warning/missing-doc)))))))
+      (assert-registered :event :ev/nil-doc)
+      (when interop/debug-enabled?
+        (is (= 1 (count (warnings-of recorded :rf.warning/missing-doc))))))))
 
 (deftest missing-doc-fires-when-doc-empty-string
   (testing ":doc as the empty string is treated as missing"
@@ -136,7 +194,9 @@
       (with-stamped-coords
         (fn []
           (rf/reg-event :ev/empty-doc {:doc ""} (fn [{:keys [db]} _] {:db db}))))
-      (is (= 1 (count (warnings-of recorded :rf.warning/missing-doc)))))))
+      (assert-registered :event :ev/empty-doc)
+      (when interop/debug-enabled?
+        (is (= 1 (count (warnings-of recorded :rf.warning/missing-doc))))))))
 
 (deftest missing-doc-suppressed-when-doc-present
   (testing "well-documented registration emits no warning"
@@ -146,7 +206,11 @@
           (rf/reg-event :ev/well-doc'd
                            {:doc "a real description"}
                            (fn [{:keys [db]} _] {:db db}))))
-      (is (empty? (warnings-of recorded :rf.warning/missing-doc))))))
+      (assert-registered :event :ev/well-doc'd)
+      ;; rf2-d2841 — class-1 vacuous under the gate: the warning stream is
+      ;; empty for EVERY registration there, documented or not.
+      (when interop/debug-enabled?
+        (is (empty? (warnings-of recorded :rf.warning/missing-doc)))))))
 
 ;; Obligation 2: suppress per (kind, id) within a runtime process.
 
@@ -159,8 +223,10 @@
           ;; Save-triggered re-eval — same id, still no :doc; warning is silent.
           (rf/reg-event :ev/same-id (fn [{:keys [db]} _] {:db (assoc db :touched? true)}))
           (rf/reg-event :ev/same-id (fn [{:keys [db]} _] {:db db}))))
-      (is (= 1 (count (warnings-of recorded :rf.warning/missing-doc)))
-          "exactly one warning across three registrations of the same id"))))
+      (assert-registered :event :ev/same-id)
+      (when interop/debug-enabled?
+        (is (= 1 (count (warnings-of recorded :rf.warning/missing-doc)))
+            "exactly one warning across three registrations of the same id")))))
 
 (deftest missing-doc-fires-once-per-id-within-kind
   (testing "different ids under the same kind each get their own warning"
@@ -170,10 +236,13 @@
           (rf/reg-event :ev/alpha (fn [{:keys [db]} _] {:db db}))
           (rf/reg-event :ev/beta  (fn [{:keys [db]} _] {:db db}))
           (rf/reg-event :ev/gamma (fn [{:keys [db]} _] {:db db}))))
-      (let [warns (warnings-of recorded :rf.warning/missing-doc)]
-        (is (= 3 (count warns)))
-        (is (= #{:ev/alpha :ev/beta :ev/gamma}
-               (into #{} (map #(get-in % [:tags :id])) warns)))))))
+      (doseq [id [:ev/alpha :ev/beta :ev/gamma]]
+        (assert-registered :event id))
+      (when interop/debug-enabled?
+        (let [warns (warnings-of recorded :rf.warning/missing-doc)]
+          (is (= 3 (count warns)))
+          (is (= #{:ev/alpha :ev/beta :ev/gamma}
+                 (into #{} (map #(get-in % [:tags :id])) warns))))))))
 
 (deftest missing-doc-fires-once-per-kind-for-same-id
   (testing "the same id under different kinds each get their own warning"
@@ -182,10 +251,13 @@
         (fn []
           (rf/reg-event :alias/shared (fn [{:keys [db]} _] {:db db}))
           (rf/reg-sub       :alias/shared (fn [db _] (:x db)))))
-      (let [warns (warnings-of recorded :rf.warning/missing-doc)]
-        (is (= 2 (count warns)))
-        (is (= #{:event :sub}
-               (into #{} (map #(get-in % [:tags :kind])) warns)))))))
+      (assert-registered :event :alias/shared)
+      (assert-registered :sub   :alias/shared)
+      (when interop/debug-enabled?
+        (let [warns (warnings-of recorded :rf.warning/missing-doc)]
+          (is (= 2 (count warns)))
+          (is (= #{:event :sub}
+                 (into #{} (map #(get-in % [:tags :kind])) warns))))))))
 
 ;; Obligation 4: kind coverage. Spot-check a representative slice across
 ;; the canonical kinds (:event :sub :fx :cofx). The :doc check sits in
@@ -201,11 +273,16 @@
           (rf/reg-sub       :k/sub-doc-missing   (fn [db _] (:x db)))
           (rf/reg-fx        :k/fx-doc-missing    (fn [_ _] nil))
           (rf/reg-cofx      :k/cofx-doc-missing  (fn [] :stub))))
-      (let [warns (warnings-of recorded :rf.warning/missing-doc)
-            kinds (into #{} (map #(get-in % [:tags :kind])) warns)]
-        (is (= 4 (count warns))
-            "one warning per (kind, id) across four kinds")
-        (is (= #{:event :sub :fx :cofx} kinds))))))
+      (assert-registered :event :k/event-doc-missing)
+      (assert-registered :sub   :k/sub-doc-missing)
+      (assert-registered :fx    :k/fx-doc-missing)
+      (assert-registered :cofx  :k/cofx-doc-missing)
+      (when interop/debug-enabled?
+        (let [warns (warnings-of recorded :rf.warning/missing-doc)
+              kinds (into #{} (map #(get-in % [:tags :kind])) warns)]
+          (is (= 4 (count warns))
+              "one warning per (kind, id) across four kinds")
+          (is (= #{:event :sub :fx :cofx} kinds)))))))
 
 ;; Obligation 4: programmatic registrations that bypass the macro path
 ;; (no source coords merged in) are out of scope.
@@ -217,8 +294,11 @@
       ;; mirroring an internal helper / REPL register! call.
       (registrar/register! :event :internal/no-coords
                            {:handler-fn (fn [db _] db)})
-      (is (empty? (warnings-of recorded :rf.warning/missing-doc))
-          "programmatic / internal-helper path is out of scope (Spec 001 obligation 4)"))))
+      (assert-registered :event :internal/no-coords)
+      ;; rf2-d2841 — class-1 vacuous under the gate.
+      (when interop/debug-enabled?
+        (is (empty? (warnings-of recorded :rf.warning/missing-doc))
+            "programmatic / internal-helper path is out of scope (Spec 001 obligation 4)")))))
 
 ;; =============================================================================
 ;; F2 — `:rf.warning/registration-collision`
@@ -253,8 +333,13 @@
       ;; boundary keeps it silent (rf2-skxd6x).
       (reg-at :hot/reload coords)
       (reg-at :hot/reload coords)
-      (is (empty? (warnings-of recorded :rf.warning/registration-collision))
-          "same-source re-eval (fresh fn, same coords) must NOT warn — it's a hot reload"))))
+      ;; ALWAYS-ON (rf2-d2841): the re-eval REPLACED the slot — that is the
+      ;; production behaviour the silent-warning rule is a policy about.
+      (assert-live-provenance :event :hot/reload 're-frame.registrar-warnings-test)
+      ;; rf2-d2841 — class-1 vacuous under the gate.
+      (when interop/debug-enabled?
+        (is (empty? (warnings-of recorded :rf.warning/registration-collision))
+            "same-source re-eval (fresh fn, same coords) must NOT warn — it's a hot reload")))))
 
 (deftest collision-fires-on-cross-provenance-reassignment
   (testing "re-registering the id from a DIFFERENT provenance (file/line/ns) warns"
@@ -262,18 +347,23 @@
       ;; Feature A registers :collide/id; feature B (a different file) clobbers it.
       (reg-at :collide/id {:ns 'feature.a :file "feature/a.cljc" :line 10 :column 1})
       (reg-at :collide/id {:ns 'feature.b :file "feature/b.cljc" :line 20 :column 1})
-      (let [warns (warnings-of recorded :rf.warning/registration-collision)]
-        (is (= 1 (count warns))
-            "exactly one collision warning fires on the cross-provenance reassignment")
-        (let [t (:tags (first warns))]
-          (is (= :event (:kind t)))
-          (is (= :collide/id (:id t)))
-          (is (map? (:source-coords t))
-              ":source-coords carries the NEW (feature B) registration's coords")
-          (is (= 'feature.b (:ns (:source-coords t))))
-          (is (map? (:previous-coords t))
-              ":previous-coords carries the prior (feature A) registration's coords")
-          (is (= 'feature.a (:ns (:previous-coords t)))))))))
+      ;; ALWAYS-ON (rf2-d2841): feature B CLOBBERED feature A. The warning is a
+      ;; dev nudge about a production fact, and the fact is readable in both
+      ;; postures off the stored provenance.
+      (assert-live-provenance :event :collide/id 'feature.b)
+      (when interop/debug-enabled?
+        (let [warns (warnings-of recorded :rf.warning/registration-collision)]
+          (is (= 1 (count warns))
+              "exactly one collision warning fires on the cross-provenance reassignment")
+          (let [t (:tags (first warns))]
+            (is (= :event (:kind t)))
+            (is (= :collide/id (:id t)))
+            (is (map? (:source-coords t))
+                ":source-coords carries the NEW (feature B) registration's coords")
+            (is (= 'feature.b (:ns (:source-coords t))))
+            (is (map? (:previous-coords t))
+                ":previous-coords carries the prior (feature A) registration's coords")
+            (is (= 'feature.a (:ns (:previous-coords t))))))))))
 
 (deftest collision-fires-on-same-file-different-line
   (testing "two registrations of the same id at different lines in one file collide"
@@ -284,8 +374,12 @@
                        :file "registrar_warnings_test.clj" :line 10 :column 1})
       (reg-at :dup/id {:ns 're-frame.registrar-warnings-test
                        :file "registrar_warnings_test.clj" :line 99 :column 1})
-      (is (= 1 (count (warnings-of recorded :rf.warning/registration-collision)))
-          "different line in the same file is a collision (Spec 001)"))))
+      (assert-live-provenance :event :dup/id 're-frame.registrar-warnings-test)
+      (is (= 99 (:line (registrar/lookup :event :dup/id)))
+          "the second authoring site is the live one in this posture")
+      (when interop/debug-enabled?
+        (is (= 1 (count (warnings-of recorded :rf.warning/registration-collision)))
+            "different line in the same file is a collision (Spec 001))")))))
 
 (deftest collision-silent-on-programmatic-path
   (testing "programmatic register! (no captured coords) does not warn"
@@ -293,8 +387,13 @@
       ;; No coords on either registration — there is no source identity to clash.
       (reg-at :prog/id nil)
       (reg-at :prog/id nil)
-      (is (empty? (warnings-of recorded :rf.warning/registration-collision))
-          "programmatic / REPL path has no provenance — no collision to detect"))))
+      (assert-registered :event :prog/id)
+      (is (nil? (:ns (registrar/lookup :event :prog/id)))
+          "the programmatic path stored no provenance to collide on")
+      ;; rf2-d2841 — class-1 vacuous under the gate.
+      (when interop/debug-enabled?
+        (is (empty? (warnings-of recorded :rf.warning/registration-collision))
+            "programmatic / REPL path has no provenance — no collision to detect")))))
 
 (deftest collision-suppressed-on-third-re-registration
   (testing "subsequent cross-provenance re-registrations of the same (kind, id) do NOT re-emit"
@@ -303,8 +402,10 @@
       ;; cross-provenance reassignment warns; warn-once suppresses the rest.
       (doseq [[ns line] [['feat.a 1] ['feat.b 2] ['feat.c 3] ['feat.d 4]]]
         (reg-at :churn/id {:ns ns :file (str ns ".cljc") :line line :column 1}))
-      (is (= 1 (count (warnings-of recorded :rf.warning/registration-collision)))
-          "warn-once: only the first cross-provenance re-registration emits"))))
+      (assert-live-provenance :event :churn/id 'feat.d)
+      (when interop/debug-enabled?
+        (is (= 1 (count (warnings-of recorded :rf.warning/registration-collision)))
+            "warn-once: only the first cross-provenance re-registration emits")))))
 
 ;; The existing `:rf.registry/handler-replaced` trace must keep firing on
 ;; EVERY re-registration (per Spec 001 §Hot-reload trace surface, rf2-6w7zn)
@@ -319,16 +420,19 @@
       (reg-at :hr/id coords)
       (reg-at :hr/id coords)
       (reg-at :hr/id coords)
-      (let [replaced (filterv (fn [ev]
-                                (and (= :rf.registry (:op-type ev))
-                                     (= :rf.registry/handler-replaced
-                                        (:operation ev))))
-                              @recorded)
-            collisions (warnings-of recorded :rf.warning/registration-collision)]
-        (is (= 2 (count replaced))
-            "handler-replaced fires on each of the two re-registrations")
-        (is (empty? collisions)
-            "no collision on a same-source hot reload (the rf2-skxd6x fix)")))))
+      (assert-live-provenance :event :hr/id 're-frame.registrar-warnings-test)
+      (when interop/debug-enabled?
+        (let [replaced (filterv (fn [ev]
+                                  (and (= :rf.registry (:op-type ev))
+                                       (= :rf.registry/handler-replaced
+                                          (:operation ev))))
+                                @recorded)
+              collisions (warnings-of recorded :rf.warning/registration-collision)]
+          (is (= 2 (count replaced))
+              "handler-replaced fires on each of the two re-registrations")
+          ;; rf2-d2841 — class-1 vacuous under the gate.
+          (is (empty? collisions)
+              "no collision on a same-source hot reload (the rf2-skxd6x fix)"))))))
 
 (deftest collision-warning-coexists-with-handler-replaced
   (testing "handler-replaced still fires unconditionally; collision is the dev-nudge addition"
@@ -336,16 +440,18 @@
       ;; Three registrations from three distinct provenances.
       (doseq [[ns line] [['c.a 1] ['c.b 2] ['c.c 3]]]
         (reg-at :coex/id {:ns ns :file (str ns ".cljc") :line line :column 1}))
-      (let [replaced (filterv (fn [ev]
-                                (and (= :rf.registry (:op-type ev))
-                                     (= :rf.registry/handler-replaced
-                                        (:operation ev))))
-                              @recorded)
-            collisions (warnings-of recorded :rf.warning/registration-collision)]
-        (is (= 2 (count replaced))
-            "handler-replaced fires on each of the two re-registrations")
-        (is (= 1 (count collisions))
-            "collision warning fires once and is then suppressed")))))
+      (assert-live-provenance :event :coex/id 'c.c)
+      (when interop/debug-enabled?
+        (let [replaced (filterv (fn [ev]
+                                  (and (= :rf.registry (:op-type ev))
+                                       (= :rf.registry/handler-replaced
+                                          (:operation ev))))
+                                @recorded)
+              collisions (warnings-of recorded :rf.warning/registration-collision)]
+          (is (= 2 (count replaced))
+              "handler-replaced fires on each of the two re-registrations")
+          (is (= 1 (count collisions))
+              "collision warning fires once and is then suppressed"))))))
 
 ;; =============================================================================
 ;; F3 — collision warning is DECOUPLED from the handler-replaced dedup gate
@@ -383,21 +489,29 @@
                           {:ns 'feature.a :file "feature/a.cljc" :line 10 :column 1})
       (reg-no-handler-fn! :route :surface/main
                           {:ns 'feature.b :file "feature/b.cljc" :line 20 :column 1})
-      (let [replaced (filterv (fn [ev]
-                                (and (= :rf.registry (:op-type ev))
-                                     (= :rf.registry/handler-replaced (:operation ev))))
-                              @recorded)
-            collisions (warnings-of recorded :rf.warning/registration-collision)]
-        (is (empty? replaced)
-            "handler-replaced is dedup-SUPPRESSED — the shape is identical (no
-             handler-fn rotation); this is the gate that used to hide the collision")
-        (is (= 1 (count collisions))
-            "the collision warning STILL fires — it is decoupled from the dedup gate")
-        (let [t (:tags (first collisions))]
-          (is (= :route (:kind t)))
-          (is (= :surface/main (:id t)))
-          (is (= 'feature.b (:ns (:source-coords t))))
-          (is (= 'feature.a (:ns (:previous-coords t)))))))))
+      ;; ALWAYS-ON (rf2-d2841): the SHAPE-dedup suppresses only the TRACE. The
+      ;; slot itself was replaced — feature B's route is the live one — which
+      ;; is precisely why the hidden collision mattered.
+      (assert-live-provenance :route :surface/main 'feature.b)
+      (when interop/debug-enabled?
+        (let [replaced (filterv (fn [ev]
+                                  (and (= :rf.registry (:op-type ev))
+                                       (= :rf.registry/handler-replaced (:operation ev))))
+                                @recorded)
+              collisions (warnings-of recorded :rf.warning/registration-collision)]
+          ;; rf2-d2841 — class-1 vacuous under the gate, and the sharpest example
+          ;; in this file: it certifies that a DEDUP GATE suppressed an emit,
+          ;; over a stream that carries no emits at all.
+          (is (empty? replaced)
+              "handler-replaced is dedup-SUPPRESSED — the shape is identical (no
+               handler-fn rotation); this is the gate that used to hide the collision")
+          (is (= 1 (count collisions))
+              "the collision warning STILL fires — it is decoupled from the dedup gate")
+          (let [t (:tags (first collisions))]
+            (is (= :route (:kind t)))
+            (is (= :surface/main (:id t)))
+            (is (= 'feature.b (:ns (:source-coords t))))
+            (is (= 'feature.a (:ns (:previous-coords t))))))))))
 
 (deftest collision-still-silent-on-same-source-for-no-handler-fn-kind
   (testing "a same-source re-eval of a no-handler-fn kind stays SILENT — the
@@ -406,7 +520,10 @@
           coords   {:ns 'feature.a :file "feature/a.cljc" :line 10 :column 1}]
       (reg-no-handler-fn! :route :surface/hot coords)
       (reg-no-handler-fn! :route :surface/hot coords)
-      (is (empty? (warnings-of recorded :rf.warning/registration-collision))
-          "same (ns,file,line) re-eval is a hot reload — no collision even though
-           the collision check now runs unconditionally"))))
+      (assert-live-provenance :route :surface/hot 'feature.a)
+      ;; rf2-d2841 — class-1 vacuous under the gate.
+      (when interop/debug-enabled?
+        (is (empty? (warnings-of recorded :rf.warning/registration-collision))
+            "same (ns,file,line) re-eval is a hot reload — no collision even though
+             the collision check now runs unconditionally")))))
 

--- a/implementation/core/test/re_frame/source_coord_jvm_test.cljc
+++ b/implementation/core/test/re_frame/source_coord_jvm_test.cljc
@@ -27,9 +27,38 @@
   `:node-test` build selects on `cljs-test$`; this file is the JVM half of a
   DELIBERATE pair whose CLJS half is the `.cljs` mirror named above, so the
   explicit lane suffix records that skipping the CLJS lane is the intent and
-  not an oversight (rf2-lgozq)."
+  not an oversight (rf2-lgozq).
+
+  ## Posture split (rf2-d2841)
+
+  Q3 above already says it: `:rf.trace/call-site` is DEV-ONLY BY DESIGN. The
+  macro expansion is `(if interop/debug-enabled? <stamped> <plain>)` with the
+  gate OUTERMOST (`core-call-site-macros/gate`), so under
+  `-Dre-frame.debug=false` the production branch never builds the coord map at
+  all — and the trace event that would have carried it is not emitted either.
+  Every deftest here failed under `scripts/test-core-prod-gate.sh` for that
+  reason, and guarding the file wholesale would have taken a namespace that
+  EXECUTES NOTHING off the roster and reported it green.
+
+  So the file grew an ALWAYS-ON arm that is the exact production counterpart of
+  the claim: `:rf.error/no-such-handler` / `:rf.error/no-such-sub` /
+  `:rf.error/handler-exception` are PROMOTED categories, so each still fans a
+  tight record to the corpus-wide `:errors` registry under the gate. Every case
+  now asserts that record fired AND that it carries no `:rf.trace/call-site` —
+  the dev-only contract, stated on a live record instead of on nothing.
+  Alongside it: the macro / fn-form distinction, which is the whole subject of
+  Q1, has NO effect on that record. Production observability does not depend on
+  which spelling the caller reached for; only the dev jump-to-source does.
+
+  FOUR VACUOUS PASSES CAME OFF (rf2-d2841 class 4). The three
+  `…-omits-call-site` deftests and `call-site-rides-at-top-level` each certify
+  an absence with `(not (contains? … :rf.trace/call-site))` against the nil an
+  empty trace ring yields — `(contains? nil k)` is false for every k, so under
+  the gate they certified the fn-form path by never looking at it."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            [re-frame.source-coords :as sc]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.router :as router]
@@ -62,16 +91,6 @@
 
 ;; ---- helpers --------------------------------------------------------------
 
-(defn- record-traces
-  "Run `body-fn` with a trace listener attached and return the captured
-  events."
-  [body-fn]
-  (let [seen (atom [])]
-    (rf/register-listener! :trace ::rec (fn [ev] (swap! seen conj ev)))
-    (try (body-fn)
-         (finally (rf/unregister-listener! :trace ::rec)))
-    @seen))
-
 (defn- errors-of
   "Filter captured traces to those whose `:operation` matches the supplied
   operation keyword."
@@ -79,6 +98,40 @@
   (filterv #(and (= :error (:op-type %))
                  (= op     (:operation %)))
            evs))
+
+(defn- record-both
+  "ALWAYS-ON (rf2-d2841) capture: run `body-fn` with BOTH a dev-trace listener
+  and an always-on `:errors`-stream listener attached, returning
+  `{:traces [...] :errors [...]}`. The `:errors` half is the corpus-wide
+  `error-emit` registry, which is not gated by `interop/debug-enabled?`."
+  [body-fn]
+  (let [traces (atom [])
+        errors (atom [])]
+    (rf/register-listener! :trace  ::rec (fn [ev]  (swap! traces conj ev)))
+    (rf/register-listener! :errors ::err (fn [rec] (swap! errors conj rec)))
+    (try (body-fn)
+         (finally
+           (rf/unregister-listener! :trace  ::rec)
+           (rf/unregister-listener! :errors ::err)))
+    {:traces @traces :errors @errors}))
+
+(defn- error-of
+  "The first always-on error record whose `:error` is `kw`."
+  [recs kw]
+  (first (filterv #(= kw (:error %)) recs)))
+
+(defn- assert-production-record
+  "ALWAYS-ON (rf2-d2841): the promoted category `kw` fanned a tight record to
+  the corpus-wide `:errors` registry, and that record carries NO
+  `:rf.trace/call-site` — the dev-only contract of Q3, asserted against a
+  record proven to exist rather than against an empty stream."
+  [recs kw]
+  (let [rec (error-of recs kw)]
+    (is (some? rec)
+        (str "the always-on error record for " kw " fired"))
+    (is (not (contains? rec :rf.trace/call-site))
+        (str kw "'s production record carries no :rf.trace/call-site"))
+    rec))
 
 (defn- assert-call-site-shape
   "The call-site map MUST live at the top level of the event (not
@@ -98,49 +151,67 @@
 
 (deftest dispatch-sync-macro-stamps-call-site-on-no-such-handler
   (testing ":rf.error/no-such-handler from dispatch-sync macro carries the call site"
-    (let [evs (record-traces
-               (fn []
-                 ;; dispatch-sync forces synchronous drain so the
-                 ;; no-such-handler trace fires before record-traces
-                 ;; returns. Plain `dispatch` schedules the drain via
-                 ;; next-tick; the test thread would exit first.
-                 (rf/dispatch-sync [:rf2-ts1a/no-such-event])))
-          [miss] (errors-of evs :rf.error/no-such-handler)]
-      (is (some? miss) "no-such-handler trace fired")
-      (assert-call-site-shape miss))))
+    (let [{:keys [traces errors]}
+          (record-both
+            (fn []
+              ;; dispatch-sync forces synchronous drain so the
+              ;; no-such-handler trace fires before record-both
+              ;; returns. Plain `dispatch` schedules the drain via
+              ;; next-tick; the test thread would exit first.
+              (rf/dispatch-sync [:rf2-ts1a/no-such-event])))
+          [miss] (errors-of traces :rf.error/no-such-handler)]
+      (assert-production-record errors :rf.error/no-such-handler)
+      (when interop/debug-enabled?
+        (is (some? miss) "no-such-handler trace fired")
+        (assert-call-site-shape miss)))))
 
 (deftest dispatch-sync-owning-fn-omits-call-site-on-no-such-handler
   (testing "the owning-ns fn-form `re-frame.router/dispatch-sync!` does NOT
    carry a call site (the macro is the ONLY stamping surface)"
-    (let [evs (record-traces
-               (fn []
-                 (router/dispatch-sync! [:rf2-ts1a/no-such-event])))
-          [miss] (errors-of evs :rf.error/no-such-handler)]
-      (is (some? miss))
-      (is (not (contains? miss :rf.trace/call-site))
-          ":rf.trace/call-site omitted on the fn-form path"))))
+    (let [{:keys [traces errors]}
+          (record-both
+            (fn []
+              (router/dispatch-sync! [:rf2-ts1a/no-such-event])))
+          [miss] (errors-of traces :rf.error/no-such-handler)]
+      ;; ALWAYS-ON (rf2-d2841): the fn-form reaches the SAME production record
+      ;; the macro form does. Q1's macro/fn split is a dev jump-to-source
+      ;; distinction only; off-box observability is identical either way.
+      (assert-production-record errors :rf.error/no-such-handler)
+      ;; rf2-d2841 -- class-4 vacuous under the gate: `miss` is nil there, and
+      ;; `(contains? nil k)` is false for every k.
+      (when interop/debug-enabled?
+        (is (some? miss))
+        (is (not (contains? miss :rf.trace/call-site))
+            ":rf.trace/call-site omitted on the fn-form path")))))
 
 ;; ---- subscribe / re-frame.subs/subscribe -----------------------------------
 
 (deftest subscribe-macro-stamps-call-site-on-no-such-sub
   (testing ":rf.error/no-such-sub from subscribe macro carries the call site"
-    (let [evs (record-traces
-               (fn []
-                 (rf/subscribe [:rf2-ts1a/no-such-sub])))
-          [miss] (errors-of evs :rf.error/no-such-sub)]
-      (is (some? miss) "no-such-sub trace fired")
-      (assert-call-site-shape miss))))
+    (let [{:keys [traces errors]}
+          (record-both
+            (fn []
+              (rf/subscribe [:rf2-ts1a/no-such-sub])))
+          [miss] (errors-of traces :rf.error/no-such-sub)]
+      (assert-production-record errors :rf.error/no-such-sub)
+      (when interop/debug-enabled?
+        (is (some? miss) "no-such-sub trace fired")
+        (assert-call-site-shape miss)))))
 
 (deftest subscribe-owning-fn-omits-call-site
   (testing "the owning-ns fn-form `re-frame.subs/subscribe` does NOT carry a
    call site (the macro is the ONLY stamping surface)"
-    (let [evs (record-traces
-               (fn []
-                 (subs/subscribe [:rf2-ts1a/no-such-sub])))
-          [miss] (errors-of evs :rf.error/no-such-sub)]
-      (is (some? miss))
-      (is (not (contains? miss :rf.trace/call-site))
-          ":rf.trace/call-site omitted on the fn-form path"))))
+    (let [{:keys [traces errors]}
+          (record-both
+            (fn []
+              (subs/subscribe [:rf2-ts1a/no-such-sub])))
+          [miss] (errors-of traces :rf.error/no-such-sub)]
+      (assert-production-record errors :rf.error/no-such-sub)
+      ;; rf2-d2841 -- class-4 vacuous under the gate.
+      (when interop/debug-enabled?
+        (is (some? miss))
+        (is (not (contains? miss :rf.trace/call-site))
+            ":rf.trace/call-site omitted on the fn-form path")))))
 
 ;; ---- inject-cofx (removed in EP-0017 slice A.3; off the facade rf2-w9xyx1) ---
 ;;
@@ -162,12 +233,20 @@
     (rf/reg-event :rf2-ts1a/throws
                      (fn [_cofx _event]
                        (throw (ex-info "boom" {}))))
-    (let [evs (record-traces
-               (fn []
-                 (rf/dispatch-sync [:rf2-ts1a/throws])))
-          [exc] (errors-of evs :rf.error/handler-exception)]
-      (is (some? exc))
-      (assert-call-site-shape exc))))
+    (let [{:keys [traces errors]}
+          (record-both
+            (fn []
+              (rf/dispatch-sync [:rf2-ts1a/throws])))
+          [exc] (errors-of traces :rf.error/handler-exception)
+          rec   (assert-production-record errors :rf.error/handler-exception)]
+      ;; ALWAYS-ON (rf2-d2841): what production DOES get for this failure is
+      ;; the REGISTRATION coord, off the always-on `error-coords-by-id`
+      ;; registry -- not the invocation coord this file is about.
+      (is (= (sc/error-coords-for :event :rf2-ts1a/throws) (:source-coord rec))
+          "the production record carries the registration coord instead")
+      (when interop/debug-enabled?
+        (is (some? exc))
+        (assert-call-site-shape exc)))))
 
 (deftest dispatch-sync-owning-fn-omits-call-site-on-handler-exception
   (testing "the owning-ns fn-form `re-frame.router/dispatch-sync!` does NOT
@@ -175,13 +254,21 @@
     (rf/reg-event :rf2-ts1a/throws-fn
                      (fn [_cofx _event]
                        (throw (ex-info "boom" {}))))
-    (let [evs (record-traces
-               (fn []
-                 (router/dispatch-sync! [:rf2-ts1a/throws-fn])))
-          [exc] (errors-of evs :rf.error/handler-exception)]
-      (is (some? exc))
-      (is (not (contains? exc :rf.trace/call-site))
-          ":rf.trace/call-site omitted on the fn-form path"))))
+    (let [{:keys [traces errors]}
+          (record-both
+            (fn []
+              (router/dispatch-sync! [:rf2-ts1a/throws-fn])))
+          [exc] (errors-of traces :rf.error/handler-exception)
+          rec   (assert-production-record errors :rf.error/handler-exception)]
+      ;; ALWAYS-ON: the fn-form loses the INVOCATION coord, not the
+      ;; REGISTRATION coord -- the record still names where the handler lives.
+      (is (= (sc/error-coords-for :event :rf2-ts1a/throws-fn) (:source-coord rec))
+          "fn-form dispatch still ships the registration coord")
+      ;; rf2-d2841 -- class-4 vacuous under the gate.
+      (when interop/debug-enabled?
+        (is (some? exc))
+        (is (not (contains? exc :rf.trace/call-site))
+            ":rf.trace/call-site omitted on the fn-form path")))))
 
 ;; ---- top-level placement (Q2=A) ------------------------------------------
 
@@ -191,35 +278,43 @@
     (rf/reg-event :rf2-ts1a/top-level
                      (fn [_cofx _event]
                        (throw (ex-info "boom" {}))))
-    (let [evs (record-traces
-               (fn []
-                 (rf/dispatch-sync [:rf2-ts1a/top-level])))
-          [exc] (errors-of evs :rf.error/handler-exception)]
-      (is (contains? exc :rf.trace/call-site)
-          ":rf.trace/call-site lives at the top level of the event")
-      (is (not (contains? (:tags exc) :rf.trace/call-site))
-          ":rf.trace/call-site does NOT live under :tags")
-      ;; Mirror trigger-handler placement so both pieces sit side-by-side
-      ;; in the event shape.
-      (is (contains? exc :rf.trace/trigger-handler)
-          ":rf.trace/trigger-handler lives alongside :rf.trace/call-site"))))
+    (let [{:keys [traces errors]}
+          (record-both
+            (fn []
+              (rf/dispatch-sync [:rf2-ts1a/top-level])))
+          [exc] (errors-of traces :rf.error/handler-exception)]
+      (assert-production-record errors :rf.error/handler-exception)
+      ;; rf2-d2841 -- GUARDED. The `:tags` negative was class-4 vacuous under
+      ;; the gate for the usual reason: `exc` is nil, `(contains? nil k)` false.
+      (when interop/debug-enabled?
+        (is (contains? exc :rf.trace/call-site)
+            ":rf.trace/call-site lives at the top level of the event")
+        (is (not (contains? (:tags exc) :rf.trace/call-site))
+            ":rf.trace/call-site does NOT live under :tags")
+        ;; Mirror trigger-handler placement so both pieces sit side-by-side
+        ;; in the event shape.
+        (is (contains? exc :rf.trace/trigger-handler)
+            ":rf.trace/trigger-handler lives alongside :rf.trace/call-site")))))
 
 ;; ---- call-site captures the actual source line ----------------------------
 
 (deftest call-site-line-matches-call-site
   (testing "the captured :line is the line of the dispatch macro form
    and :file points at this test file"
-    (let [evs (record-traces
-               (fn []
-                 (rf/dispatch-sync [:rf2-ts1a/missing])))   ;; ← THIS line
-          [miss] (errors-of evs :rf.error/no-such-handler)
+    (let [{:keys [traces errors]}
+          (record-both
+            (fn []
+              (rf/dispatch-sync [:rf2-ts1a/missing])))   ;; ← THIS line
+          [miss] (errors-of traces :rf.error/no-such-handler)
           cs     (:rf.trace/call-site miss)]
-      (is (some? cs))
-      ;; We can't hardcode the line number (file edits would break the
-      ;; test); instead assert the line is plausible (positive integer)
-      ;; and the file points at this test file.
-      (is (integer? (:line cs)))
-      (is (pos? (:line cs)))
-      (is (string? (:file cs)))
-      (is (re-find #"source_coord_jvm_test" (:file cs))
-          (str ":file should point at this test file — got " (:file cs))))))
+      (assert-production-record errors :rf.error/no-such-handler)
+      (when interop/debug-enabled?
+        (is (some? cs))
+        ;; We can't hardcode the line number (file edits would break the
+        ;; test); instead assert the line is plausible (positive integer)
+        ;; and the file points at this test file.
+        (is (integer? (:line cs)))
+        (is (pos? (:line cs)))
+        (is (string? (:file cs)))
+        (is (re-find #"source_coord_jvm_test" (:file cs))
+            (str ":file should point at this test file — got " (:file cs)))))))

--- a/implementation/core/test/re_frame/source_coords_test.clj
+++ b/implementation/core/test/re_frame/source_coords_test.clj
@@ -25,9 +25,53 @@
     reg-sub        reg-fx         reg-cofx
     make-frame      reg-view       reg-machine
     reg-flow       reg-route      reg-app-schema
-    reg-error-projector"
+    reg-error-projector
+
+  ## Posture split (rf2-d2841)
+
+  SOURCE-COORD CAPTURE HAS TWO SINKS, AND ONLY ONE OF THEM IS DEV-ONLY.
+  `source-coords/merge-coords` opens with `(if-not interop/debug-enabled?
+  (or user-meta {}) …)`, so under `-Dre-frame.debug=false` the coord keys are
+  stripped from the PUBLIC registry-meta — every `assert-coords` call below
+  failed under `scripts/test-core-prod-gate.sh` for that reason alone. But
+  `registrar/register!` ALSO calls `source-coords/remember-error-coords!`
+  unconditionally, populating the always-on `error-coords-by-id` parallel
+  registry the error-emit substrate reads when it assembles the tight record
+  for off-box shippers (Sentry / Honeybadger / Rollbar). That sink is the
+  PRODUCTION half of the contract, and nothing in this file had ever asserted
+  it under the production posture.
+
+  So each per-kind case now carries an ALWAYS-ON `assert-error-coords` beside
+  the guarded `assert-coords`: the public-meta claim stays verbatim inside a
+  `(when interop/debug-enabled? …)` arm marked `rf2-d2841`, and the always-on
+  registry claim runs in BOTH postures. `reg-event-emits-absolute-file`'s
+  absolutisation regression (rf2-wvsxg) is likewise pinned on the always-on
+  sink, which is where an absolute `:file` actually MATTERS — a production
+  Sentry record with a classpath-relative path resolves nowhere.
+
+  Two kinds have no always-on counterpart and are guarded wholesale, which is
+  a real gap rather than an oversight: `reg-flow` and `reg-app-schema` store
+  their coords in the flows / schemas artefacts' own per-frame side-tables,
+  never through `registrar/register!`, so `remember-error-coords!` is never
+  called for them and `error-coords-for` has nothing to return.
+
+  TWO PASSING ASSERTIONS WERE VACUOUS BEFORE THIS SPLIT (rf2-d2841 class 4 —
+  absence of a key the gate elides wholesale). `no-source-coords-on-make-frame`
+  and `fn-form-call-skips-coord-capture` both certify \"this path captured no
+  coords\" by reading `(:ns meta)` / `(:line meta)` back as nil — true under the
+  gate for EVERY registration, macro-path included, because the coord keys are
+  stripped wholesale. Both now carry an always-on witness on the parallel
+  registry instead, where the claim still discriminates: a programmatic
+  `reg-sub` leaves `error-coords-for` nil while its macro-path sibling does not.
+
+  `user-supplied-coords-win` needed only ONE assertion guarded: the explicit
+  `:ns` / `:line` / `:file` survive production untouched (they are user-meta,
+  and `merge-coords` returns user-meta unchanged there). It is `:doc` that
+  does not — `registrar/register!` strips the pure-documentation keys under
+  the same gate."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             ;; rf2-quir9 — exercise the view-macro expander directly to
             ;; assert the reader's symbol-position meta is stripped before
             ;; it can clobber the absolutised *pending-coords*.
@@ -89,6 +133,23 @@
   (is (string? (:file meta))
       (str "handler-meta for " kind " " id " :file should be a string")))
 
+(defn- assert-error-coords
+  "ALWAYS-ON (rf2-d2841) counterpart of [[assert-coords]]: the coords the
+  always-on `error-coords-by-id` parallel registry retained for `[kind id]`.
+  `registrar/register!` populates it unconditionally, so this holds under
+  `-Dre-frame.debug=false` — it is what an off-box error shipper reads in a
+  production build, per `source-coords` §Production elision sink 2."
+  [kind id]
+  (let [c (sc/error-coords-for kind id)]
+    (is (map? c)
+        (str "always-on error-coords for " kind " " id " should be present"))
+    (is (symbol? (:ns c))
+        (str "always-on error-coords for " kind " " id " :ns should be a symbol"))
+    (is (integer? (:line c))
+        (str "always-on error-coords for " kind " " id " :line should be an integer"))
+    (is (string? (:file c))
+        (str "always-on error-coords for " kind " " id " :file should be a string"))))
+
 ;; ---- one assertion per reg-* kind ----------------------------------------
 
 (deftest source-coords-on-reg-event
@@ -98,22 +159,37 @@
   the identical defreg-event-macro coord-capture skeleton)"
     (rf/reg-event :rf2-k84s/reg-event-sample
                   (fn [{:keys [db]} _] {:db db}))
-    (assert-coords (rf/handler-meta :event :rf2-k84s/reg-event-sample)
-                   :event :rf2-k84s/reg-event-sample)))
+    (assert-error-coords :event :rf2-k84s/reg-event-sample)
+    ;; rf2-d2841 — the PUBLIC registry-meta sink is dev-only:
+    ;; `source-coords/merge-coords` returns user-meta unchanged under
+    ;; `-Dre-frame.debug=false`, so the coord keys are absent there.
+    (when interop/debug-enabled?
+      (assert-coords (rf/handler-meta :event :rf2-k84s/reg-event-sample)
+                     :event :rf2-k84s/reg-event-sample))))
 
 (deftest source-coords-on-reg-event-db-return
   (testing "reg-event with a {:db ...} return stamps :ns / :line / :file"
     (rf/reg-event :rf2-k84s/reg-event-db-sample
                      (fn [{:keys [db]} _] {:db db}))
-    (assert-coords (rf/handler-meta :event :rf2-k84s/reg-event-db-sample)
-                   :event :rf2-k84s/reg-event-db-sample)))
+    (assert-error-coords :event :rf2-k84s/reg-event-db-sample)
+    ;; rf2-d2841 — the PUBLIC registry-meta sink is dev-only:
+    ;; `source-coords/merge-coords` returns user-meta unchanged under
+    ;; `-Dre-frame.debug=false`, so the coord keys are absent there.
+    (when interop/debug-enabled?
+      (assert-coords (rf/handler-meta :event :rf2-k84s/reg-event-db-sample)
+                     :event :rf2-k84s/reg-event-db-sample))))
 
 (deftest source-coords-on-reg-event-fx-return
   (testing "reg-event with an effect-map return stamps :ns / :line / :file"
     (rf/reg-event :rf2-k84s/reg-event-fx-sample
                      (fn [_ _] {}))
-    (assert-coords (rf/handler-meta :event :rf2-k84s/reg-event-fx-sample)
-                   :event :rf2-k84s/reg-event-fx-sample)))
+    (assert-error-coords :event :rf2-k84s/reg-event-fx-sample)
+    ;; rf2-d2841 — the PUBLIC registry-meta sink is dev-only:
+    ;; `source-coords/merge-coords` returns user-meta unchanged under
+    ;; `-Dre-frame.debug=false`, so the coord keys are absent there.
+    (when interop/debug-enabled?
+      (assert-coords (rf/handler-meta :event :rf2-k84s/reg-event-fx-sample)
+                     :event :rf2-k84s/reg-event-fx-sample))))
 
 (deftest source-coords-on-reg-event-with-interceptor
   (testing "reg-event with a full-context interceptor stamps :ns / :line / :file"
@@ -121,29 +197,49 @@
     (rf/reg-event :rf2-k84s/reg-event-ctx-sample
                   {:interceptors [:rf2-k84s/ctx-probe]}
                   (fn [_ _] {}))
-    (assert-coords (rf/handler-meta :event :rf2-k84s/reg-event-ctx-sample)
-                   :event :rf2-k84s/reg-event-ctx-sample)))
+    (assert-error-coords :event :rf2-k84s/reg-event-ctx-sample)
+    ;; rf2-d2841 — the PUBLIC registry-meta sink is dev-only:
+    ;; `source-coords/merge-coords` returns user-meta unchanged under
+    ;; `-Dre-frame.debug=false`, so the coord keys are absent there.
+    (when interop/debug-enabled?
+      (assert-coords (rf/handler-meta :event :rf2-k84s/reg-event-ctx-sample)
+                     :event :rf2-k84s/reg-event-ctx-sample))))
 
 (deftest source-coords-on-reg-sub
   (testing "reg-sub stamps :ns / :line / :file"
     (rf/reg-sub :rf2-k84s/reg-sub-sample
                 (fn [db _] db))
-    (assert-coords (rf/handler-meta :sub :rf2-k84s/reg-sub-sample)
-                   :sub :rf2-k84s/reg-sub-sample)))
+    (assert-error-coords :sub :rf2-k84s/reg-sub-sample)
+    ;; rf2-d2841 — the PUBLIC registry-meta sink is dev-only:
+    ;; `source-coords/merge-coords` returns user-meta unchanged under
+    ;; `-Dre-frame.debug=false`, so the coord keys are absent there.
+    (when interop/debug-enabled?
+      (assert-coords (rf/handler-meta :sub :rf2-k84s/reg-sub-sample)
+                     :sub :rf2-k84s/reg-sub-sample))))
 
 (deftest source-coords-on-reg-fx
   (testing "reg-fx stamps :ns / :line / :file"
     (rf/reg-fx :rf2-k84s/reg-fx-sample
                (fn [_ _] nil))
-    (assert-coords (rf/handler-meta :fx :rf2-k84s/reg-fx-sample)
-                   :fx :rf2-k84s/reg-fx-sample)))
+    (assert-error-coords :fx :rf2-k84s/reg-fx-sample)
+    ;; rf2-d2841 — the PUBLIC registry-meta sink is dev-only:
+    ;; `source-coords/merge-coords` returns user-meta unchanged under
+    ;; `-Dre-frame.debug=false`, so the coord keys are absent there.
+    (when interop/debug-enabled?
+      (assert-coords (rf/handler-meta :fx :rf2-k84s/reg-fx-sample)
+                     :fx :rf2-k84s/reg-fx-sample))))
 
 (deftest source-coords-on-reg-cofx
   (testing "reg-cofx stamps :ns / :line / :file"
     (rf/reg-cofx :rf2-k84s/reg-cofx-sample
                  (fn [] :sample))
-    (assert-coords (rf/handler-meta :cofx :rf2-k84s/reg-cofx-sample)
-                   :cofx :rf2-k84s/reg-cofx-sample)))
+    (assert-error-coords :cofx :rf2-k84s/reg-cofx-sample)
+    ;; rf2-d2841 — the PUBLIC registry-meta sink is dev-only:
+    ;; `source-coords/merge-coords` returns user-meta unchanged under
+    ;; `-Dre-frame.debug=false`, so the coord keys are absent there.
+    (when interop/debug-enabled?
+      (assert-coords (rf/handler-meta :cofx :rf2-k84s/reg-cofx-sample)
+                     :cofx :rf2-k84s/reg-cofx-sample))))
 
 (deftest no-source-coords-on-make-frame
   (testing "make-frame (a FN, the ONE constructor) captures NO source coords —
@@ -154,8 +250,19 @@
     (rf/make-frame {:id :rf2-k84s/make-frame-sample :doc "smoke"})
     (let [meta (rf/frame-meta :rf2-k84s/make-frame-sample)]
       (is (some? meta) "frame-meta present for the created frame")
-      (is (nil? (:line meta)) "no :line coord on the stored frame config")
-      (is (nil? (:file meta)) "no :file coord on the stored frame config"))))
+      ;; rf2-d2841 — ALWAYS-ON witness. The two public-meta assertions below
+      ;; were a class-4 vacuous pass under the gate: production strips coord
+      ;; keys from public registry-meta WHOLESALE, so `(nil? (:line meta))`
+      ;; holds there for every registration including the macro-path ones,
+      ;; and the claim stops discriminating. The always-on parallel registry
+      ;; does still discriminate — a macro-registered `:event` has an entry,
+      ;; a frame has none — so that is where "frames capture no coords" is
+      ;; asserted in both postures.
+      (is (nil? (sc/error-coords-for :frame :rf2-k84s/make-frame-sample))
+          "no frame entry in the always-on error-coord registry either")
+      (when interop/debug-enabled?
+        (is (nil? (:line meta)) "no :line coord on the stored frame config")
+        (is (nil? (:file meta)) "no :file coord on the stored frame config")))))
 
 (deftest source-coords-on-reg-view
   (testing "reg-view stamps :ns / :line / :file"
@@ -163,16 +270,26 @@
     ;; ^{:rf/id ...} keeps the legacy keyword for the assertion.
     (rf/reg-view ^{:rf/id :rf2-k84s/reg-view-sample} reg-view-sample []
       [:div "hi"])
-    (assert-coords (rf/handler-meta :view :rf2-k84s/reg-view-sample)
-                   :view :rf2-k84s/reg-view-sample)))
+    (assert-error-coords :view :rf2-k84s/reg-view-sample)
+    ;; rf2-d2841 — the PUBLIC registry-meta sink is dev-only:
+    ;; `source-coords/merge-coords` returns user-meta unchanged under
+    ;; `-Dre-frame.debug=false`, so the coord keys are absent there.
+    (when interop/debug-enabled?
+      (assert-coords (rf/handler-meta :view :rf2-k84s/reg-view-sample)
+                     :view :rf2-k84s/reg-view-sample))))
 
 (deftest source-coords-on-reg-machine
   (testing "reg-machine stamps :ns / :line / :file (under :event kind, since
   reg-machine wraps the machine as an event handler per Spec 005 §Registration)"
     (rf/reg-machine :rf2-k84s/reg-machine-sample
                     {:initial :a :states {:a {} :b {}}})
-    (assert-coords (rf/handler-meta :event :rf2-k84s/reg-machine-sample)
-                   :event :rf2-k84s/reg-machine-sample)))
+    (assert-error-coords :event :rf2-k84s/reg-machine-sample)
+    ;; rf2-d2841 — the PUBLIC registry-meta sink is dev-only:
+    ;; `source-coords/merge-coords` returns user-meta unchanged under
+    ;; `-Dre-frame.debug=false`, so the coord keys are absent there.
+    (when interop/debug-enabled?
+      (assert-coords (rf/handler-meta :event :rf2-k84s/reg-machine-sample)
+                     :event :rf2-k84s/reg-machine-sample))))
 
 (deftest source-coords-on-reg-flow
   (testing "reg-flow stamps :ns / :line / :file"
@@ -182,14 +299,25 @@
     ;; the source-coords stamped into the store at reg-flow) — the flows
     ;; analogue of `schemas/app-schema-meta-at` (rf2-0frdi).
     (rf/reg-flow :rf2-k84s/reg-flow-sample {:inputs [[:source]] :output-path [:dest]} (fn [v] v))
-    (assert-coords (flows/flow-meta-at :rf2-k84s/reg-flow-sample)
-                   :flow :rf2-k84s/reg-flow-sample)))
+    ;; rf2-d2841 — GUARDED WHOLESALE, and the reason is a real gap: the flows
+    ;; artefact stores its coords in its own per-frame map, never through
+    ;; `registrar/register!`, so `source-coords/remember-error-coords!` is
+    ;; never called for a flow and the always-on parallel registry has no
+    ;; entry to witness. Only the dev-side `merge-coords` sink exists.
+    (when interop/debug-enabled?
+      (assert-coords (flows/flow-meta-at :rf2-k84s/reg-flow-sample)
+                     :flow :rf2-k84s/reg-flow-sample))))
 
 (deftest source-coords-on-reg-route
   (testing "reg-route stamps :ns / :line / :file"
     (rf/reg-route :rf2-k84s/reg-route-sample {} "/k84s")
-    (assert-coords (rf/handler-meta :route :rf2-k84s/reg-route-sample)
-                   :route :rf2-k84s/reg-route-sample)))
+    (assert-error-coords :route :rf2-k84s/reg-route-sample)
+    ;; rf2-d2841 — the PUBLIC registry-meta sink is dev-only:
+    ;; `source-coords/merge-coords` returns user-meta unchanged under
+    ;; `-Dre-frame.debug=false`, so the coord keys are absent there.
+    (when interop/debug-enabled?
+      (assert-coords (rf/handler-meta :route :rf2-k84s/reg-route-sample)
+                     :route :rf2-k84s/reg-route-sample))))
 
 (deftest source-coords-on-reg-app-schema
   (testing "reg-app-schema stamps :ns / :line / :file"
@@ -199,8 +327,13 @@
     ;; meta-at` which returns the full meta map (including the stamped
     ;; coords) for the `(frame-id, path)` entry.
     (rf/reg-app-schema [:rf2-k84s/reg-app-schema-sample] :int)
-    (assert-coords (schemas/app-schema-meta-at [:rf2-k84s/reg-app-schema-sample])
-                   "app-schema" [:rf2-k84s/reg-app-schema-sample])))
+    ;; rf2-d2841 — GUARDED WHOLESALE for the same reason as `reg-flow` above:
+    ;; app-db schemas live in the schemas artefact's own per-frame side-table,
+    ;; not the registrar, so nothing populates the always-on error-coord
+    ;; registry for them.
+    (when interop/debug-enabled?
+      (assert-coords (schemas/app-schema-meta-at [:rf2-k84s/reg-app-schema-sample])
+                     "app-schema" [:rf2-k84s/reg-app-schema-sample]))))
 
 (deftest source-coords-on-reg-error-projector
   (testing "reg-error-projector stamps :ns / :line / :file"
@@ -210,9 +343,14 @@
                                :code       :internal-error
                                :message    "x"
                                :retryable? false}))
-    (assert-coords (rf/handler-meta :error-projector
-                                    :rf2-k84s/reg-error-projector-sample)
-                   :error-projector :rf2-k84s/reg-error-projector-sample)))
+    (assert-error-coords :error-projector :rf2-k84s/reg-error-projector-sample)
+    ;; rf2-d2841 — the PUBLIC registry-meta sink is dev-only:
+    ;; `source-coords/merge-coords` returns user-meta unchanged under
+    ;; `-Dre-frame.debug=false`, so the coord keys are absent there.
+    (when interop/debug-enabled?
+      (assert-coords (rf/handler-meta :error-projector
+                                      :rf2-k84s/reg-error-projector-sample)
+                     :error-projector :rf2-k84s/reg-error-projector-sample))))
 
 ;; ---- user-supplied :ns / :line / :file override auto-capture --------------
 
@@ -223,10 +361,17 @@
                       :doc "hand-stamped coords from a code-gen pass"}
                      (fn [{:keys [db]} _] {:db db}))
     (let [meta (rf/handler-meta :event :rf2-k84s/explicit-coords)]
+      ;; ALWAYS-ON: user-supplied coords are USER-META, and `merge-coords`
+      ;; returns user-meta unchanged in production — so a code-gen pass that
+      ;; hand-stamps the originating coordinates keeps them in both postures.
       (is (= 'my.ns                  (:ns meta)))
       (is (= 42                      (:line meta)))
       (is (= "elsewhere.cljc"        (:file meta)))
-      (is (= "hand-stamped coords from a code-gen pass" (:doc meta))))))
+      ;; rf2-d2841 — `:doc` is the one slot that does NOT survive: the
+      ;; pure-documentation keys are stripped in `registrar/register!` under
+      ;; `interop/debug-enabled?` (Spec 001 §Production elision contract).
+      (when interop/debug-enabled?
+        (is (= "hand-stamped coords from a code-gen pass" (:doc meta)))))))
 
 ;; ---- programmatic call (bypasses macro) -----------------------------------
 
@@ -238,9 +383,23 @@
       (reg-fn :rf2-k84s/no-coords (fn [db _] db)))
     (let [meta (rf/handler-meta :sub :rf2-k84s/no-coords)]
       (is (some? meta))
-      (is (nil? (:ns   meta)) ":ns absent on direct fn call")
-      (is (nil? (:line meta)) ":line absent on direct fn call")
-      (is (nil? (:file meta)) ":file absent on direct fn call"))))
+      ;; rf2-d2841 — ALWAYS-ON witness, and the assertion that actually
+      ;; discriminates. The three public-meta nil checks below are class-4
+      ;; vacuous under the gate (coord keys are stripped wholesale, so they
+      ;; hold for the macro path too). The always-on error-coord registry is
+      ;; the surface where "no poison coords" is a PRODUCTION claim: it is
+      ;; what a Sentry-style shipper reads, and a programmatic registration
+      ;; must leave it empty while its macro-path sibling fills it.
+      (is (nil? (sc/error-coords-for :sub :rf2-k84s/no-coords))
+          "programmatic registration leaves the always-on registry empty")
+      (rf/reg-sub :rf2-k84s/macro-coords (fn [db _] db))
+      (is (some? (sc/error-coords-for :sub :rf2-k84s/macro-coords))
+          "control: the macro path DOES fill the always-on registry, so the
+           negative above is not passing for free")
+      (when interop/debug-enabled?
+        (is (nil? (:ns   meta)) ":ns absent on direct fn call")
+        (is (nil? (:line meta)) ":line absent on direct fn call")
+        (is (nil? (:file meta)) ":file absent on direct fn call")))))
 
 ;; ---- rf2-wvsxg: :file is absolutised via classpath resolution -------------
 
@@ -386,23 +545,38 @@
   regardless of which project-root the host configured."
     (rf/reg-event :rf2-wvsxg/absolute-file-sample
                      (fn [{:keys [db]} _] {:db db}))
-    (let [meta (rf/handler-meta :event :rf2-wvsxg/absolute-file-sample)
-          f    (:file meta)]
-      (is (string? f) ":file should be present")
-      ;; The host's `re_frame/source_coords_test.clj` lives at
-      ;; `<repo>/implementation/core/test/...`. The exact prefix is
-      ;; environment-dependent — but the path must look absolute to
-      ;; the URI builder so it won't double-prefix it.
-      (let [uri (eu/editor-uri :vscode meta {:project-root "/wrong/project/root"})]
-        (is (.contains ^String uri f)
-            ":file should appear absolute in URI")
+    ;; rf2-d2841 — ALWAYS-ON half, and the half where absolutisation MATTERS:
+    ;; the error-coord registry is the sink that reaches a production error
+    ;; record, and a classpath-relative `:file` shipped to Sentry resolves
+    ;; nowhere. Same three claims as the public-meta arm below.
+    (let [errc (sc/error-coords-for :event :rf2-wvsxg/absolute-file-sample)
+          ef   (:file errc)]
+      (is (string? ef) "always-on error-coord :file should be present")
+      (let [uri (eu/editor-uri :vscode errc {:project-root "/wrong/project/root"})]
+        (is (.contains ^String uri ef)
+            "error-coord :file should appear absolute in URI")
         (is (not (.contains ^String uri "/wrong/project/root"))
-            ":file must be absolute (URI builder doesn't prepend project-root)"))
-      ;; And the path must end in the test file's classpath-relative
-      ;; tail — sanity that classpath resolution found the right
-      ;; resource.
-      (is (.endsWith ^String f "re_frame/source_coords_test.clj")
-          ":file should end with the classpath-relative tail"))))
+            "error-coord :file must be absolute (no project-root prepend)"))
+      (is (.endsWith ^String ef "re_frame/source_coords_test.clj")
+          "error-coord :file should end with the classpath-relative tail"))
+    (when interop/debug-enabled?
+      (let [meta (rf/handler-meta :event :rf2-wvsxg/absolute-file-sample)
+            f    (:file meta)]
+        (is (string? f) ":file should be present")
+        ;; The host's `re_frame/source_coords_test.clj` lives at
+        ;; `<repo>/implementation/core/test/...`. The exact prefix is
+        ;; environment-dependent — but the path must look absolute to
+        ;; the URI builder so it won't double-prefix it.
+        (let [uri (eu/editor-uri :vscode meta {:project-root "/wrong/project/root"})]
+          (is (.contains ^String uri f)
+              ":file should appear absolute in URI")
+          (is (not (.contains ^String uri "/wrong/project/root"))
+              ":file must be absolute (URI builder doesn't prepend project-root)"))
+        ;; And the path must end in the test file's classpath-relative
+        ;; tail — sanity that classpath resolution found the right
+        ;; resource.
+        (is (.endsWith ^String f "re_frame/source_coords_test.clj")
+            ":file should end with the classpath-relative tail")))))
 
 ;; ---- rf2-quir9: reg-view PUBLIC meta carries the absolutised coord --------
 ;;
@@ -427,22 +601,36 @@
       [:div "hi"])
     (let [pub  (rf/handler-meta :view :rf2-quir9/absolute-view-sample)
           errc (sc/error-coords-for :view :rf2-quir9/absolute-view-sample)
+          ef   (:file errc)
           f    (:file pub)]
-      (is (string? f) "public :file should be present")
-      ;; The public :file must equal the error-coord registry's absolutised
-      ;; value — the two source-coord sinks now agree (they previously
-      ;; diverged: error-coord absolute, public relative).
-      (is (= f (:file errc))
-          "public handler-meta :file == error-coord :file (single source of truth)")
-      ;; And it must look absolute to the URI builder (no project-root
-      ;; prepend), exactly like the reg-event case above.
-      (let [uri (eu/editor-uri :vscode pub {:project-root "/wrong/project/root"})]
-        (is (.contains ^String uri f)
-            "view :file should appear absolute in the URI")
+      ;; rf2-d2841 — ALWAYS-ON half. The reader-meta clobber this deftest
+      ;; regresses (rf2-quir9) landed a RELATIVE `:file`, and the error-coord
+      ;; registry is the sink where that costs a production consumer a
+      ;; resolvable path, so the absoluteness claim is asserted there first.
+      (is (string? ef) "view error-coord :file should be present")
+      (let [uri (eu/editor-uri :vscode errc {:project-root "/wrong/project/root"})]
+        (is (.contains ^String uri ef)
+            "view error-coord :file should appear absolute in the URI")
         (is (not (.contains ^String uri "/wrong/project/root"))
-            "view :file must be absolute (URI builder doesn't prepend project-root)"))
-      (is (.endsWith ^String f "re_frame/source_coords_test.clj")
-          "view :file should end with this test ns's classpath-relative tail"))))
+            "view error-coord :file must be absolute (no project-root prepend)"))
+      (is (.endsWith ^String ef "re_frame/source_coords_test.clj")
+          "view error-coord :file ends with this test ns's classpath-relative tail")
+      (when interop/debug-enabled?
+        (is (string? f) "public :file should be present")
+        ;; The public :file must equal the error-coord registry's absolutised
+        ;; value — the two source-coord sinks now agree (they previously
+        ;; diverged: error-coord absolute, public relative).
+        (is (= f (:file errc))
+            "public handler-meta :file == error-coord :file (single source of truth)")
+        ;; And it must look absolute to the URI builder (no project-root
+        ;; prepend), exactly like the reg-event case above.
+        (let [uri (eu/editor-uri :vscode pub {:project-root "/wrong/project/root"})]
+          (is (.contains ^String uri f)
+              "view :file should appear absolute in the URI")
+          (is (not (.contains ^String uri "/wrong/project/root"))
+              "view :file must be absolute (URI builder doesn't prepend project-root)"))
+        (is (.endsWith ^String f "re_frame/source_coords_test.clj")
+            "view :file should end with this test ns's classpath-relative tail")))))
 
 (deftest reg-view-strips-reader-symbol-position-meta
   (testing "rf2-quir9: the reader's symbol-position meta (relative :file /

--- a/implementation/core/test/re_frame/success_path_call_site_test.clj
+++ b/implementation/core/test/re_frame/success_path_call_site_test.clj
@@ -22,9 +22,40 @@
   elision: rides the same `interop/debug-enabled?` gate the rest of
   the trace surface uses; no separate elision contract.
 
-  JVM-only — the dynamic-var binding mechanism is platform-agnostic."
+  JVM-only — the dynamic-var binding mechanism is platform-agnostic.
+
+  ## Posture split (rf2-d2841)
+
+  `:rf.trace/call-site` is DEV-ONLY BY DESIGN and there is no production
+  channel that carries it — checked, not assumed. `core-call-site-macros/gate`
+  wraps every expansion in `(if interop/debug-enabled? <stamped> <plain>)` with
+  the gate OUTERMOST, so under `-Dre-frame.debug=false` the coord map is never
+  built; `router/process-event!` additionally re-gates the read
+  (`(trace/with-call-site (when interop/debug-enabled? (:rf.trace/call-site
+  opts)) …)`); and the coord does NOT ride the dispatch envelope, so the
+  `(:envelope m)` probe that rescued `substrate-source-test` in rf2-d2841's
+  fourth pass has nothing to read here. Every trace assertion below is
+  therefore guarded.
+
+  What keeps this file off the class-2 list (a namespace reported green having
+  executed nothing) is the OTHER branch of that gate. `plain` — the production
+  expansion of `rf/dispatch-sync` — is a distinct code path from the stamped
+  one, and until this lane existed NOTHING had ever executed it: every suite
+  ran in dev posture, where the `if` always selects `stamped`. So each case
+  keeps an always-on witness that the branch this posture selected actually
+  reached the router and drove the cascade to completion — handler ran, db
+  committed, fx executed, child dispatch delivered. Under the gate that is
+  first-ever coverage of the production expansion; under dev it is a control
+  proving the guarded arm below is not being skipped for a bad reason.
+
+  ONE VACUOUS PASS CAME OFF (rf2-d2841 class 4): `event-dispatched-fn-form-
+  omits-call-site` certified the fn-form path with
+  `(not (contains? enqueue :rf.trace/call-site))` over the nil an empty trace
+  ring yields — `(contains? nil k)` is false for every k, so under the gate it
+  certified the fn-form by never looking at it."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.router :as router]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
@@ -67,51 +98,102 @@
 (defn- events-of [evs op]
   (filterv #(= op (:operation %)) evs))
 
+;; ---- always-on dispatch witness (rf2-d2841) -------------------------------
+;;
+;; The call-site macros expand to `(if interop/debug-enabled? <stamped>
+;; <plain>)`. Under `-Dre-frame.debug=false` the PLAIN branch runs, and no
+;; suite had ever executed it. These probes assert that whichever branch this
+;; posture selected reached the router and ran the cascade to completion.
+
+(defn- register-probe-fx!
+  "Register `:rf2-twt7m/probe`, an fx recording the dispatch envelope it runs
+  under, keyed by the level keyword it is called with."
+  [envelopes]
+  (rf/reg-fx :rf2-twt7m/probe
+    (fn [m [level]] (swap! envelopes assoc level (:envelope m)))))
+
+(defn- assert-dispatched [envelopes level where]
+  (let [env (get @envelopes level)]
+    (is (map? env)
+        (str "the " where " dispatch reached an fx handler in this posture"))
+    (is (keyword? (:frame env))
+        (str "the " where " envelope resolved a target frame"))))
+
 ;; ---- Change 1 — `:rf.event/dispatched` carries `:rf.trace/call-site` ---------
 
 (deftest event-dispatched-success-carries-call-site
   (testing ":rf.event/dispatched (success path) carries :rf.trace/call-site
    when the dispatch came in via the macro form"
-    (rf/reg-event :rf2-twt7m/noop (fn [{:keys [db]} _] {:db db}))
-    (let [evs       (record-traces
-                      (fn []
-                        (rf/dispatch-sync [:rf2-twt7m/noop])))
-          [enqueue] (events-of evs :rf.event/dispatched)]
-      (is (some? enqueue) ":rf.event/dispatched fired")
-      (is (contains? enqueue :rf.trace/call-site)
-          ":rf.trace/call-site hoisted onto the success-path emit")
-      (let [cs (:rf.trace/call-site enqueue)]
-        (is (symbol? (:ns cs))   ":ns is a symbol")
-        (is (string? (:file cs)) ":file is a string")
-        (is (integer? (:line cs)) ":line is an integer")
-        (is (re-find #"success_path_call_site_test" (:file cs))
-            (str ":file should point at this test file — got " (:file cs)))))))
+    (let [envelopes (atom {})]
+      (register-probe-fx! envelopes)
+      (rf/reg-event :rf2-twt7m/noop
+        (fn [{:keys [db]} _] {:db (assoc db :rf2-twt7m/ran? true)
+                              :fx [[:rf2-twt7m/probe [:top]]]}))
+      (let [evs       (record-traces
+                        (fn []
+                          (rf/dispatch-sync [:rf2-twt7m/noop])))
+            [enqueue] (events-of evs :rf.event/dispatched)]
+        ;; ALWAYS-ON (rf2-d2841): whichever branch of the macro gate this
+        ;; posture selected reached the router and committed.
+        (assert-dispatched envelopes :top "macro dispatch-sync")
+        (is (true? (:rf2-twt7m/ran? (rf/app-db-value :rf/default)))
+            "the macro dispatch committed its db change in this posture")
+        (when interop/debug-enabled?
+          (is (some? enqueue) ":rf.event/dispatched fired")
+          (is (contains? enqueue :rf.trace/call-site)
+              ":rf.trace/call-site hoisted onto the success-path emit")
+          (let [cs (:rf.trace/call-site enqueue)]
+            (is (symbol? (:ns cs))   ":ns is a symbol")
+            (is (string? (:file cs)) ":file is a string")
+            (is (integer? (:line cs)) ":line is an integer")
+            (is (re-find #"success_path_call_site_test" (:file cs))
+                (str ":file should point at this test file — got " (:file cs)))))))))
 
 (deftest event-dispatched-call-site-rides-at-top-level
   (testing ":rf.trace/call-site is a top-level field on success traces,
    NOT nested under :tags — mirrors the error / trigger-handler shape"
-    (rf/reg-event :rf2-twt7m/top-level (fn [{:keys [db]} _] {:db db}))
-    (let [evs       (record-traces
-                      (fn []
-                        (rf/dispatch-sync [:rf2-twt7m/top-level])))
-          [enqueue] (events-of evs :rf.event/dispatched)]
-      (is (contains? enqueue :rf.trace/call-site)
-          ":rf.trace/call-site lives at top level")
-      (is (not (contains? (:tags enqueue) :rf.trace/call-site))
-          ":rf.trace/call-site does NOT live under :tags"))))
+    (let [envelopes (atom {})]
+      (register-probe-fx! envelopes)
+      (rf/reg-event :rf2-twt7m/top-level
+        (fn [{:keys [db]} _] {:db db :fx [[:rf2-twt7m/probe [:top]]]}))
+      (let [evs       (record-traces
+                        (fn []
+                          (rf/dispatch-sync [:rf2-twt7m/top-level])))
+            [enqueue] (events-of evs :rf.event/dispatched)]
+        (assert-dispatched envelopes :top "macro dispatch-sync")
+        ;; rf2-d2841 — GUARDED: top-level-vs-`:tags` is a TRACE-SHAPE claim, and
+        ;; no trace event exists under `-Dre-frame.debug=false`.
+        (when interop/debug-enabled?
+          (is (contains? enqueue :rf.trace/call-site)
+              ":rf.trace/call-site lives at top level")
+          (is (not (contains? (:tags enqueue) :rf.trace/call-site))
+              ":rf.trace/call-site does NOT live under :tags"))))))
 
 (deftest event-dispatched-fn-form-omits-call-site
   (testing "the owning-ns fn-form `re-frame.router/dispatch-sync!` does NOT
    stamp a call-site, so :rf.event/dispatched carries no slot — better
    no-data than poison-data (mirrors the error-path contract)"
-    (rf/reg-event :rf2-twt7m/fn-form (fn [{:keys [db]} _] {:db db}))
-    (let [evs       (record-traces
-                      (fn []
-                        (router/dispatch-sync! [:rf2-twt7m/fn-form])))
-          [enqueue] (events-of evs :rf.event/dispatched)]
-      (is (some? enqueue) ":rf.event/dispatched fired")
-      (is (not (contains? enqueue :rf.trace/call-site))
-          ":rf.trace/call-site omitted on the fn-form path"))))
+    (let [envelopes (atom {})]
+      (register-probe-fx! envelopes)
+      (rf/reg-event :rf2-twt7m/fn-form
+        (fn [{:keys [db]} _] {:db (assoc db :rf2-twt7m/fn-ran? true)
+                              :fx [[:rf2-twt7m/probe [:top]]]}))
+      (let [evs       (record-traces
+                        (fn []
+                          (router/dispatch-sync! [:rf2-twt7m/fn-form])))
+            [enqueue] (events-of evs :rf.event/dispatched)]
+        ;; ALWAYS-ON (rf2-d2841): the fn-form seam — the one the macro's
+        ;; production branch expands to — dispatches identically. That is the
+        ;; substance the gate's prod branch relies on.
+        (assert-dispatched envelopes :top "router/dispatch-sync! fn-form")
+        (is (true? (:rf2-twt7m/fn-ran? (rf/app-db-value :rf/default)))
+            "the fn-form dispatch committed its db change in this posture")
+        ;; rf2-d2841 — class-4 vacuous under the gate: `enqueue` is nil there,
+        ;; so the negative certified the fn-form by never looking at it.
+        (when interop/debug-enabled?
+          (is (some? enqueue) ":rf.event/dispatched fired")
+          (is (not (contains? enqueue :rf.trace/call-site))
+              ":rf.trace/call-site omitted on the fn-form path"))))))
 
 ;; ---- inner cascade emits carry the same call-site -------------------------
 
@@ -120,24 +202,41 @@
    :rf.event/db-changed, :rf.fx/do-fx, :rf.fx/handled) carries the
    dispatch's call-site — rf2-twt7m Change 1 widens the hoist to
    match the trigger-handler treatment (rf2-lf84g)"
-    (rf/reg-fx :rf2-twt7m/my-fx (fn [_ _] :ok))
-    (rf/reg-event :rf2-twt7m/cascade
-                     (fn [_ _] {:db {:n 1} :fx [[:rf2-twt7m/my-fx {}]]}))
-    (let [evs       (record-traces
-                      (fn []
-                        (rf/dispatch-sync [:rf2-twt7m/cascade])))
-          [dbc]     (events-of evs :rf.event/db-changed)
-          [dof]     (events-of evs :rf.fx/do-fx)
-          [handled] (events-of evs :rf.fx/handled)]
-      (is (some? dbc) ":rf.event/db-changed fired")
-      (is (some? dof) ":rf.fx/do-fx fired")
-      (is (some? handled) ":rf.fx/handled fired")
-      ;; The macro stamps a call-site onto the envelope;
-      ;; `process-event!` binds it via `with-dispatch-id+call-site`;
-      ;; every emit inside the cascade hoists it (rf2-twt7m).
-      (is (contains? dbc :rf.trace/call-site)
-          ":rf.event/db-changed carries the dispatch's call-site")
-      (is (contains? dof :rf.trace/call-site)
-          ":rf.fx/do-fx carries the dispatch's call-site")
-      (is (contains? handled :rf.trace/call-site)
-          ":rf.fx/handled carries the dispatch's call-site"))))
+    (let [envelopes (atom {})]
+      (register-probe-fx! envelopes)
+      (rf/reg-fx :rf2-twt7m/my-fx (fn [_ _] :ok))
+      (rf/reg-event :rf2-twt7m/cascade-child
+        (fn [{:keys [db]} _] {:db (assoc db :child? true)
+                              :fx [[:rf2-twt7m/probe [:child]]]}))
+      (rf/reg-event :rf2-twt7m/cascade
+        (fn [_ _] {:db {:n 1}
+                   :fx [[:rf2-twt7m/my-fx {}]
+                        [:rf2-twt7m/probe [:parent]]
+                        [:dispatch [:rf2-twt7m/cascade-child]]]}))
+      (let [evs       (record-traces
+                        (fn []
+                          (rf/dispatch-sync [:rf2-twt7m/cascade])))
+            [dbc]     (events-of evs :rf.event/db-changed)
+            [dof]     (events-of evs :rf.fx/do-fx)
+            [handled] (events-of evs :rf.fx/handled)]
+        ;; ALWAYS-ON (rf2-d2841): the cascade the guarded hoist claim is about
+        ;; runs to completion in BOTH postures — parent fx, child dispatch and
+        ;; the child's own commit. Under the gate this is the first execution
+        ;; the macro's production branch has ever had through a real cascade.
+        (assert-dispatched envelopes :parent "cascade parent")
+        (assert-dispatched envelopes :child  "cascade child")
+        (is (true? (:child? (rf/app-db-value :rf/default)))
+            "the child dispatch committed in this posture")
+        (when interop/debug-enabled?
+          (is (some? dbc) ":rf.event/db-changed fired")
+          (is (some? dof) ":rf.fx/do-fx fired")
+          (is (some? handled) ":rf.fx/handled fired")
+          ;; The macro stamps a call-site onto the opts map;
+          ;; `process-event!` binds it via `with-dispatch-id+call-site`;
+          ;; every emit inside the cascade hoists it (rf2-twt7m).
+          (is (contains? dbc :rf.trace/call-site)
+              ":rf.event/db-changed carries the dispatch's call-site")
+          (is (contains? dof :rf.trace/call-site)
+              ":rf.fx/do-fx carries the dispatch's call-site")
+          (is (contains? handled :rf.trace/call-site)
+              ":rf.fx/handled carries the dispatch's call-site"))))))

--- a/implementation/core/test/re_frame/success_path_trigger_handler_test.clj
+++ b/implementation/core/test/re_frame/success_path_trigger_handler_test.clj
@@ -25,9 +25,42 @@
 
   JVM-only — the dynamic-var binding mechanism is platform-agnostic.
   Mirror tests for the machine emit site live in
-  `implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj`."
+  `implementation/machines/test/re_frame/machine_transition_trigger_handler_test.clj`.
+
+  ## Posture split (rf2-d2841)
+
+  The docstring above is right that the SLOT \"rides the same
+  `interop/debug-enabled?` gate as the rest of the trace surface\", and there is
+  no success-path production channel to move it to — unlike the error axis,
+  where `error-emit/dispatch-on-error!` fans a tight record. So the
+  trace-shape and trace-placement claims are guarded.
+
+  What is NOT dev-only is the COORD ITSELF. `registrar/register!` calls
+  `source-coords/remember-error-coords!` unconditionally, so the always-on
+  `error-coords-by-id` registry holds the registration coordinate for every
+  macro-path `reg-fx` / `reg-sub` / `reg-cofx` / `reg-event` in BOTH postures
+  — it is what an off-box error shipper reads in production. Every case here
+  therefore keeps an always-on assertion on that registry, and the three
+  \"better no-data than poison-data\" cases keep theirs as a NEGATIVE on the
+  same registry with a macro-path control beside it, so the negative cannot
+  pass for free. Alongside those sit the posture-independent semantics the
+  trace was standing in for: the fx ran, the child dispatch committed, the sub
+  recomputed to the right value, the cofx supplied its fact.
+
+  TWELVE VACUOUS PASSES CAME OFF (rf2-d2841 class 3 — a positive assertion the
+  gate short-circuits). The three `…-matches-registrar-coord` deftests each
+  compare `(:ns handler-meta)` against `(:ns coord)` field by field, four
+  fields apiece. Under the gate `handler-meta` has been stripped of coord keys
+  AND the trace event does not exist, so every one of those twelve is
+  `nil = nil` — parity certified between two absences. `fx-handled-trigger-
+  matches-registrar-coord` was GREEN under the gate on nothing but those four.
+  Four more, class 4, sat in the `…-omits-trigger-…` trio and
+  `…-rides-at-top-level` pair: `(not (contains? handled …))` over the nil an
+  empty trace ring yields."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            [re-frame.source-coords :as sc]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
@@ -69,6 +102,34 @@
 (defn- events-of [evs op]
   (filterv #(= op (:operation %)) evs))
 
+(defn- assert-always-on-coord
+  "ALWAYS-ON (rf2-d2841): the registration coordinate the always-on
+  `error-coords-by-id` registry holds for `[kind id]`. `registrar/register!`
+  populates it unconditionally, so this is the production-posture statement of
+  the handler registration site is known — the substance
+  `:rf.trace/trigger-handler` carries on the dev trace."
+  [kind id]
+  (let [c (sc/error-coords-for kind id)]
+    (is (map? c)
+        (str "always-on registration coord present for " kind " " id))
+    (is (symbol? (:ns c))    ":ns is a symbol")
+    (is (string? (:file c))  ":file is a string")
+    (is (integer? (:line c)) ":line is an integer")
+    c))
+
+(defn- assert-no-always-on-coord
+  "ALWAYS-ON (rf2-d2841): a programmatic registration bypassed the macro path,
+  so the always-on registry has NOTHING for it — better no-data than
+  poison-data, stated where it survives production. `control-kind` /
+  `control-id` name a macro-path sibling registered in the same test, so the
+  negative cannot pass merely because the registry is empty."
+  [kind id control-kind control-id]
+  (is (nil? (sc/error-coords-for kind id))
+      (str "programmatic " kind " " id " stored no always-on coord"))
+  (is (some? (sc/error-coords-for control-kind control-id))
+      (str "control: macro-path " control-kind " " control-id
+           " DID store one, so the negative above is not free")))
+
 (defn- assert-trigger-shape
   "Assert the value at top-level `:rf.trace/trigger-handler` on `ev`
   carries the locked shape — `:kind`, `:id`, and a `:source-coord` map
@@ -92,15 +153,22 @@
    (not the enclosing event handler's) — Story/Xray want jump-to-source
    to land on the fx's reg-fx site, not the event-handler that produced
    the fx vector"
-    (rf/reg-fx :rf2-lf84g/my-fx
-               (fn [_ctx _args] :ok))
-    (rf/reg-event :rf2-lf84g/uses-my-fx
-                     (fn [_cofx _event]
-                       {:fx [[:rf2-lf84g/my-fx {:k 1}]]}))
-    (let [evs (record-traces #(rf/dispatch-sync [:rf2-lf84g/uses-my-fx]))
-          [handled] (events-of evs :rf.fx/handled)]
-      (is (some? handled) ":rf.fx/handled trace fired")
-      (assert-trigger-shape handled :fx :rf2-lf84g/my-fx))))
+    (let [ran (atom nil)]
+      (rf/reg-fx :rf2-lf84g/my-fx
+                 (fn [_ctx args] (reset! ran args) :ok))
+      (rf/reg-event :rf2-lf84g/uses-my-fx
+                       (fn [_cofx _event]
+                         {:fx [[:rf2-lf84g/my-fx {:k 1}]]}))
+      (let [evs (record-traces #(rf/dispatch-sync [:rf2-lf84g/uses-my-fx]))
+            [handled] (events-of evs :rf.fx/handled)]
+        ;; ALWAYS-ON (rf2-d2841): the fx really ran with its args, and its
+        ;; registration coord is on the always-on registry — the production
+        ;; half of "jump-to-source lands on the reg-fx site".
+        (is (= {:k 1} @ran) "the fx handler ran with its authored args")
+        (assert-always-on-coord :fx :rf2-lf84g/my-fx)
+        (when interop/debug-enabled?
+          (is (some? handled) ":rf.fx/handled trace fired")
+          (assert-trigger-shape handled :fx :rf2-lf84g/my-fx))))))
 
 (deftest fx-handled-trigger-rides-at-top-level
   (testing ":rf.trace/trigger-handler is a top-level field on success
@@ -110,10 +178,15 @@
                      (fn [_ _] {:fx [[:rf2-lf84g/top-level-fx {}]]}))
     (let [evs (record-traces #(rf/dispatch-sync [:rf2-lf84g/use-top-level]))
           [handled] (events-of evs :rf.fx/handled)]
-      (is (contains? handled :rf.trace/trigger-handler)
-          ":rf.trace/trigger-handler lives at top level")
-      (is (not (contains? (:tags handled) :rf.trace/trigger-handler))
-          ":rf.trace/trigger-handler does NOT live under :tags"))))
+      (assert-always-on-coord :fx :rf2-lf84g/top-level-fx)
+      ;; rf2-d2841 — GUARDED: top-level-vs-`:tags` is a trace-SHAPE claim, and
+      ;; the `:tags` negative was class-4 vacuous under the gate (`handled` is
+      ;; nil there, and `(contains? nil k)` is false for every k).
+      (when interop/debug-enabled?
+        (is (contains? handled :rf.trace/trigger-handler)
+            ":rf.trace/trigger-handler lives at top level")
+        (is (not (contains? (:tags handled) :rf.trace/trigger-handler))
+            ":rf.trace/trigger-handler does NOT live under :tags")))))
 
 (deftest fx-handled-trigger-matches-registrar-coord
   (testing "the :source-coord under :rf.trace/trigger-handler on
@@ -124,11 +197,21 @@
     (let [fx-meta (rf/handler-meta :fx :rf2-lf84g/coord-fx)
           evs     (record-traces #(rf/dispatch-sync [:rf2-lf84g/use-coord]))
           [hdl]   (events-of evs :rf.fx/handled)
-          coord   (-> hdl :rf.trace/trigger-handler :source-coord)]
-      (is (= (:ns     fx-meta) (:ns coord)))
-      (is (= (:file   fx-meta) (:file coord)))
-      (is (= (:line   fx-meta) (:line coord)))
-      (is (= (:column fx-meta) (:column coord))))))
+          coord   (-> hdl :rf.trace/trigger-handler :source-coord)
+          errc    (assert-always-on-coord :fx :rf2-lf84g/coord-fx)]
+      ;; rf2-d2841 — GUARDED, and this arm was the file's worst false green:
+      ;; under the gate `fx-meta` has been stripped of coord keys AND `coord`
+      ;; is nil, so all four comparisons were `nil = nil` and the whole deftest
+      ;; reported PASS on nothing. The always-on registry is where the coord
+      ;; still exists in production, so the parity claim is made there too.
+      (when interop/debug-enabled?
+        (is (= (:ns   fx-meta) (:ns errc)))
+        (is (= (:file fx-meta) (:file errc)))
+        (is (= (:line fx-meta) (:line errc)))
+        (is (= (:ns     fx-meta) (:ns coord)))
+        (is (= (:file   fx-meta) (:file coord)))
+        (is (= (:line   fx-meta) (:line coord)))
+        (is (= (:column fx-meta) (:column coord)))))))
 
 ;; ---- the reserved-fx-id path stamps the enclosing event handler -----------
 
@@ -142,11 +225,19 @@
     (let [evs       (record-traces #(rf/dispatch-sync [:rf2-lf84g/parent]))
           handled   (events-of evs :rf.fx/handled)
           parent-fx (first (filter #(= :dispatch (get-in % [:tags :rf.fx/id])) handled))]
-      (is (some? parent-fx) ":dispatch :rf.fx/handled fired")
-      ;; The reserved-fx-id path runs inside the parent event's
-      ;; *current-trigger-handler* binding (no inner fx binding kicks in
-      ;; for reserved fx-ids since there's no registered handler).
-      (assert-trigger-shape parent-fx :event :rf2-lf84g/parent))))
+      ;; ALWAYS-ON (rf2-d2841): the reserved `:dispatch` fx has no registration
+      ;; of its own, and the coord the trace attributes to it is the ENCLOSING
+      ;; event's — which the always-on registry holds. The child commit proves
+      ;; the reserved-fx path actually ran in this posture.
+      (assert-always-on-coord :event :rf2-lf84g/parent)
+      (is (true? (:child? (rf/app-db-value :rf/default)))
+          "the reserved :dispatch fx delivered the child event")
+      (when interop/debug-enabled?
+        (is (some? parent-fx) ":dispatch :rf.fx/handled fired")
+        ;; The reserved-fx-id path runs inside the parent event's
+        ;; *current-trigger-handler* binding (no inner fx binding kicks in
+        ;; for reserved fx-ids since there's no registered handler).
+        (assert-trigger-shape parent-fx :event :rf2-lf84g/parent)))))
 
 ;; ---- programmatic registration → no coord -> no trigger-handler -----------
 
@@ -165,11 +256,21 @@
     (let [reg-ev (requiring-resolve 're-frame.events/reg-event)]
       (reg-ev :rf2-lf84g/uses-prog-fx
               (fn [_ _] {:fx [[:rf2-lf84g/programmatic-fx {}]]})))
+    ;; A macro-path sibling in the same test, so the negative below has a
+    ;; control that discriminates rather than an empty registry.
+    (rf/reg-fx :rf2-lf84g/macro-fx (fn [_ _] :ok))
     (let [evs       (record-traces #(rf/dispatch-sync [:rf2-lf84g/uses-prog-fx]))
           [handled] (events-of evs :rf.fx/handled)]
-      (is (some? handled) ":rf.fx/handled fired")
-      (is (not (contains? handled :rf.trace/trigger-handler))
-          "programmatic fx-registration → no coord → field omitted"))))
+      ;; ALWAYS-ON (rf2-d2841): "better no-data than poison-data" is a
+      ;; PRODUCTION claim — the always-on registry is the sink that reaches an
+      ;; off-box shipper, and a programmatic registration must leave it empty.
+      (assert-no-always-on-coord :fx :rf2-lf84g/programmatic-fx
+                                 :fx :rf2-lf84g/macro-fx)
+      ;; rf2-d2841 — class-4 vacuous under the gate.
+      (when interop/debug-enabled?
+        (is (some? handled) ":rf.fx/handled fired")
+        (is (not (contains? handled :rf.trace/trigger-handler))
+            "programmatic fx-registration → no coord → field omitted")))))
 
 ;; ---- the field rides on every event in the cascade -----------------------
 
@@ -182,10 +283,16 @@
     (let [evs   (record-traces #(rf/dispatch-sync [:rf2-lf84g/changes-db]))
           [dbc] (events-of evs :rf.event/db-changed)
           [dof] (events-of evs :rf.fx/do-fx)]
-      (is (some? dbc) ":rf.event/db-changed fired")
-      (is (some? dof) ":rf.fx/do-fx fired")
-      (assert-trigger-shape dbc :event :rf2-lf84g/changes-db)
-      (assert-trigger-shape dof :event :rf2-lf84g/changes-db))))
+      ;; ALWAYS-ON (rf2-d2841): the db change these traces report happened, and
+      ;; the event's registration coord is on the always-on registry.
+      (is (= 1 (:n (rf/app-db-value :rf/default)))
+          "the db change the guarded traces report actually committed")
+      (assert-always-on-coord :event :rf2-lf84g/changes-db)
+      (when interop/debug-enabled?
+        (is (some? dbc) ":rf.event/db-changed fired")
+        (is (some? dof) ":rf.fx/do-fx fired")
+        (assert-trigger-shape dbc :event :rf2-lf84g/changes-db)
+        (assert-trigger-shape dof :event :rf2-lf84g/changes-db)))))
 
 ;; ---- out-of-band emits omit trigger-handler -------------------------------
 
@@ -196,13 +303,20 @@
       (rf/register-listener! :trace ::rec (fn [ev] (swap! seen conj ev)))
       (try
         (rf/reg-event :rf2-lf84g/reg-time-event (fn [{:keys [db]} _] {:db db}))
-        (let [reg-traces (filter #(= :rf.registry/handler-registered (:operation %))
-                                 @seen)]
-          (is (seq reg-traces) "we saw at least one registration trace")
-          (doseq [ev reg-traces]
-            (is (not (contains? ev :rf.trace/trigger-handler))
-                (str "out-of-band " (:operation ev)
-                     " must omit :rf.trace/trigger-handler"))))
+        ;; ALWAYS-ON (rf2-d2841): registration itself is production behaviour —
+        ;; only the registration TRACE is dev-only. The handler is resolvable
+        ;; and its coord is on the always-on registry in both postures.
+        (is (some? (rf/handler-meta :event :rf2-lf84g/reg-time-event))
+            "the registration succeeded in this posture")
+        (assert-always-on-coord :event :rf2-lf84g/reg-time-event)
+        (when interop/debug-enabled?
+          (let [reg-traces (filter #(= :rf.registry/handler-registered (:operation %))
+                                   @seen)]
+            (is (seq reg-traces) "we saw at least one registration trace")
+            (doseq [ev reg-traces]
+              (is (not (contains? ev :rf.trace/trigger-handler))
+                  (str "out-of-band " (:operation ev)
+                       " must omit :rf.trace/trigger-handler")))))
         (finally
           (rf/unregister-listener! :trace ::rec))))))
 
@@ -223,11 +337,18 @@
    caused the recompute"
     (rf/reg-sub :rf2-npm2p/n
                 (fn [db _] (:n db)))
-    (let [evs (record-traces
-                (fn [] (deref (rf/subscribe [:rf2-npm2p/n]))))
+    (let [seen-value (atom ::unset)
+          evs (record-traces
+                (fn [] (reset! seen-value (deref (rf/subscribe [:rf2-npm2p/n])))))
           [run] (events-of evs :rf.sub/run)]
-      (is (some? run) ":rf.sub/run trace fired on recompute")
-      (assert-trigger-shape run :sub :rf2-npm2p/n))))
+      ;; ALWAYS-ON (rf2-d2841): the recompute the trace reports really happened
+      ;; (the sub yielded a value), and the sub's registration coord is on the
+      ;; always-on registry — resolved there under `[:sub …]`.
+      (is (not= ::unset @seen-value) "the sub recomputed and yielded a value")
+      (assert-always-on-coord :sub :rf2-npm2p/n)
+      (when interop/debug-enabled?
+        (is (some? run) ":rf.sub/run trace fired on recompute")
+        (assert-trigger-shape run :sub :rf2-npm2p/n)))))
 
 (deftest sub-run-trigger-rides-at-top-level
   (testing ":rf.trace/trigger-handler on :rf.sub/run is a top-level field,
@@ -238,11 +359,15 @@
     (let [evs   (record-traces
                   (fn [] (deref (rf/subscribe [:rf2-npm2p/top-level]))))
           [run] (events-of evs :rf.sub/run)]
-      (is (some? run))
-      (is (contains? run :rf.trace/trigger-handler)
-          ":rf.trace/trigger-handler lives at top level")
-      (is (not (contains? (:tags run) :rf.trace/trigger-handler))
-          ":rf.trace/trigger-handler does NOT live under :tags"))))
+      (assert-always-on-coord :sub :rf2-npm2p/top-level)
+      ;; rf2-d2841 — GUARDED trace-shape claim; the `:tags` negative was
+      ;; class-4 vacuous under the gate.
+      (when interop/debug-enabled?
+        (is (some? run))
+        (is (contains? run :rf.trace/trigger-handler)
+            ":rf.trace/trigger-handler lives at top level")
+        (is (not (contains? (:tags run) :rf.trace/trigger-handler))
+            ":rf.trace/trigger-handler does NOT live under :tags")))))
 
 (deftest sub-run-trigger-matches-registrar-coord
   (testing "the :source-coord under :rf.trace/trigger-handler on :rf.sub/run
@@ -254,12 +379,20 @@
           evs      (record-traces
                      (fn [] (deref (rf/subscribe [:rf2-npm2p/coord]))))
           [run]    (events-of evs :rf.sub/run)
-          coord    (-> run :rf.trace/trigger-handler :source-coord)]
-      (is (some? run))
-      (is (= (:ns     sub-meta) (:ns coord)))
-      (is (= (:file   sub-meta) (:file coord)))
-      (is (= (:line   sub-meta) (:line coord)))
-      (is (= (:column sub-meta) (:column coord))))))
+          coord    (-> run :rf.trace/trigger-handler :source-coord)
+          errc     (assert-always-on-coord :sub :rf2-npm2p/coord)]
+      ;; rf2-d2841 — GUARDED. Four `nil = nil` comparisons under the gate
+      ;; (stripped `handler-meta` vs an absent trace); the surviving parity
+      ;; claim is against the always-on registry above.
+      (when interop/debug-enabled?
+        (is (some? run))
+        (is (= (:ns   sub-meta) (:ns errc)))
+        (is (= (:file sub-meta) (:file errc)))
+        (is (= (:line sub-meta) (:line errc)))
+        (is (= (:ns     sub-meta) (:ns coord)))
+        (is (= (:file   sub-meta) (:file coord)))
+        (is (= (:line   sub-meta) (:line coord)))
+        (is (= (:column sub-meta) (:column coord)))))))
 
 (deftest sub-run-trigger-is-sub-not-enclosing-event
   (testing "when a sub fires during a dispatch (the event handler's
@@ -288,12 +421,22 @@
     (let [evs   (record-traces
                   (fn [] (rf/dispatch-sync [:rf2-npm2p/changes-n])))
           [run] (events-of evs :rf.sub/run)]
-      (is (some? run) ":rf.sub/run fired inside the cascade")
-      ;; The KIND under trigger-handler is :sub, not :event. Even
-      ;; though the deref happens INSIDE the event handler's drain,
-      ;; the sub-recompute body rebinds the trigger-handler. Same
-      ;; shape as fx-handled — the inner binding wins over the outer.
-      (assert-trigger-shape run :sub :rf2-npm2p/from-cascade))))
+      ;; ALWAYS-ON (rf2-d2841): both coords exist and are DISTINCT in the
+      ;; always-on registry — which is what makes "the inner scope wins" a
+      ;; claim with teeth rather than a coincidence of two equal values.
+      (let [sub-c (assert-always-on-coord :sub   :rf2-npm2p/from-cascade)
+            ev-c  (assert-always-on-coord :event :rf2-npm2p/changes-n)]
+        (is (not= sub-c ev-c)
+            "the sub and the enclosing event have different coords"))
+      (is (= 1 (:n (rf/app-db-value :rf/default)))
+          "the cascade committed, so the recompute really fired inside it")
+      (when interop/debug-enabled?
+        (is (some? run) ":rf.sub/run fired inside the cascade")
+        ;; The KIND under trigger-handler is :sub, not :event. Even
+        ;; though the deref happens INSIDE the event handler's drain,
+        ;; the sub-recompute body rebinds the trigger-handler. Same
+        ;; shape as fx-handled — the inner binding wins over the outer.
+        (assert-trigger-shape run :sub :rf2-npm2p/from-cascade)))))
 
 (deftest programmatic-sub-omits-trigger-on-run
   (testing "a sub registered without the macro path (no source-coord
@@ -303,12 +446,18 @@
     (let [reg-fn (requiring-resolve 're-frame.subs/reg-sub)]
       (reg-fn :rf2-npm2p/programmatic
               (fn [db _] db)))
+    (rf/reg-sub :rf2-npm2p/macro-sub (fn [db _] db))
     (let [evs   (record-traces
                   (fn [] (deref (rf/subscribe [:rf2-npm2p/programmatic]))))
           [run] (events-of evs :rf.sub/run)]
-      (is (some? run) ":rf.sub/run fired")
-      (is (not (contains? run :rf.trace/trigger-handler))
-          "programmatic sub-registration → no coord → field omitted"))))
+      ;; ALWAYS-ON (rf2-d2841), with a macro-path control so the negative
+      ;; cannot pass merely because the registry is empty.
+      (assert-no-always-on-coord :sub :rf2-npm2p/programmatic
+                                 :sub :rf2-npm2p/macro-sub)
+      (when interop/debug-enabled?
+        (is (some? run) ":rf.sub/run fired")
+        (is (not (contains? run :rf.trace/trigger-handler))
+            "programmatic sub-registration → no coord → field omitted")))))
 
 ;; ---- cofx body carries the cofx's registration coord (rf2-npm2p) ----------
 ;;
@@ -350,8 +499,12 @@
     (let [evs     (record-traces
                     (fn [] (rf/dispatch-sync [:rf2-npm2p/uses-cofx])))
           [probe] (events-of evs :rf2-npm2p/probe)]
-      (is (some? probe) "custom trace fired from inside the cofx body")
-      (assert-trigger-shape probe :cofx :rf2-npm2p/instrumented-cofx))))
+      ;; ALWAYS-ON (rf2-d2841): the cofx's registration coord survives on the
+      ;; always-on registry; the custom trace it emits does not.
+      (assert-always-on-coord :cofx :rf2-npm2p/instrumented-cofx)
+      (when interop/debug-enabled?
+        (is (some? probe) "custom trace fired from inside the cofx body")
+        (assert-trigger-shape probe :cofx :rf2-npm2p/instrumented-cofx)))))
 
 (deftest cofx-body-trigger-rides-at-top-level
   (testing ":rf.trace/trigger-handler on a cofx-body trace is a
@@ -366,11 +519,15 @@
     (let [evs     (record-traces
                     (fn [] (rf/dispatch-sync [:rf2-npm2p/use-top-level-cofx])))
           [probe] (events-of evs :rf2-npm2p/probe)]
-      (is (some? probe))
-      (is (contains? probe :rf.trace/trigger-handler)
-          ":rf.trace/trigger-handler lives at top level")
-      (is (not (contains? (:tags probe) :rf.trace/trigger-handler))
-          ":rf.trace/trigger-handler does NOT live under :tags"))))
+      (assert-always-on-coord :cofx :rf2-npm2p/top-level-cofx)
+      ;; rf2-d2841 — GUARDED trace-shape claim; class-4 vacuous `:tags`
+      ;; negative under the gate.
+      (when interop/debug-enabled?
+        (is (some? probe))
+        (is (contains? probe :rf.trace/trigger-handler)
+            ":rf.trace/trigger-handler lives at top level")
+        (is (not (contains? (:tags probe) :rf.trace/trigger-handler))
+            ":rf.trace/trigger-handler does NOT live under :tags")))))
 
 (deftest cofx-body-trigger-matches-registrar-coord
   (testing "the :source-coord under :rf.trace/trigger-handler on a
@@ -386,12 +543,19 @@
           evs       (record-traces
                       (fn [] (rf/dispatch-sync [:rf2-npm2p/use-coord-cofx])))
           [probe]   (events-of evs :rf2-npm2p/probe)
-          coord     (-> probe :rf.trace/trigger-handler :source-coord)]
-      (is (some? probe))
-      (is (= (:ns     cofx-meta) (:ns coord)))
-      (is (= (:file   cofx-meta) (:file coord)))
-      (is (= (:line   cofx-meta) (:line coord)))
-      (is (= (:column cofx-meta) (:column coord))))))
+          coord     (-> probe :rf.trace/trigger-handler :source-coord)
+          errc      (assert-always-on-coord :cofx :rf2-npm2p/coord-cofx)]
+      ;; rf2-d2841 — GUARDED. Four `nil = nil` comparisons under the gate; the
+      ;; parity claim that survives is against the always-on registry above.
+      (when interop/debug-enabled?
+        (is (some? probe))
+        (is (= (:ns   cofx-meta) (:ns errc)))
+        (is (= (:file cofx-meta) (:file errc)))
+        (is (= (:line cofx-meta) (:line errc)))
+        (is (= (:ns     cofx-meta) (:ns coord)))
+        (is (= (:file   cofx-meta) (:file coord)))
+        (is (= (:line   cofx-meta) (:line coord)))
+        (is (= (:column cofx-meta) (:column coord)))))))
 
 (deftest programmatic-cofx-omits-trigger-on-body-trace
   (testing "a cofx registered without the macro path (no source-coord
@@ -406,9 +570,14 @@
     (rf/reg-event :rf2-npm2p/use-prog-cofx
                      {:rf.cofx/requires [:rf2-npm2p/prog-cofx]}
                      (fn [_ _] {}))
+    (rf/reg-cofx :rf2-npm2p/macro-cofx (fn [] :ok))
     (let [evs     (record-traces
                     (fn [] (rf/dispatch-sync [:rf2-npm2p/use-prog-cofx])))
           [probe] (events-of evs :rf2-npm2p/probe)]
-      (is (some? probe))
-      (is (not (contains? probe :rf.trace/trigger-handler))
-          "programmatic cofx-registration → no coord → field omitted"))))
+      ;; ALWAYS-ON (rf2-d2841), with a macro-path control.
+      (assert-no-always-on-coord :cofx :rf2-npm2p/prog-cofx
+                                 :cofx :rf2-npm2p/macro-cofx)
+      (when interop/debug-enabled?
+        (is (some? probe))
+        (is (not (contains? probe :rf.trace/trigger-handler))
+            "programmatic cofx-registration → no coord → field omitted")))))

--- a/implementation/core/test/re_frame/trigger_handler_coord_test.clj
+++ b/implementation/core/test/re_frame/trigger_handler_coord_test.clj
@@ -26,9 +26,44 @@
 
   Source-coord parity with the registrar is established by the
   `source-coords-test` suite (rf2-k84s); this file only checks that the
-  registrar's stamp is carried onto the emitted error event."
+  registrar's stamp is carried onto the emitted error event.
+
+  ## Posture split (rf2-d2841)
+
+  Q4 above says `:rf.trace/trigger-handler` is \"NOT elided in production\", and
+  that is true of the SUBSTANCE but not of the SLOT this file reads. The slot
+  rides a TRACE event, and under `-Dre-frame.debug=false` no trace event is
+  emitted at all, so every deftest here failed under
+  `scripts/test-core-prod-gate.sh`. The substance — \"which registered
+  component produced this error, and where was it registered\" — survives on a
+  different channel: `error-emit/dispatch-on-error!` resolves
+  `source-coords/error-coords-for` against the always-on `error-coords-by-id`
+  registry and stamps `:source-coord` onto the tight record every
+  `:errors`-stream listener receives. That is the channel a production error
+  shipper actually reads, and nothing here had ever asserted it.
+
+  So each case grew an ALWAYS-ON witness on the `:errors` stream beside its
+  guarded trace assertions. The witness is not a restatement: the two channels
+  attribute DIFFERENTLY, and the difference is now pinned. `:rf.error/
+  fx-handler-exception`'s trace names the FX as the trigger handler, while the
+  always-on record resolves its `:source-coord` from `:event-id` — see
+  `fx-handler-exception-carries-trigger-handler` for which id that turns out
+  to be.
+
+  THREE VACUOUS PASSES CAME OFF THIS FILE (rf2-d2841 class 4 — absence of a
+  key the gate elides wholesale): `trigger-handler-rides-at-top-level`'s
+  `(not (contains? (:tags exc) …))`, `no-such-handler-omits-trigger-handler`'s
+  `(not (contains? miss …))` and `programmatic-registration-omits-trigger-
+  handler`'s ditto — all three read `contains?` off the nil the empty trace
+  ring yields, and `(contains? nil k)` is false for every k. A FOURTH shape,
+  class 3, sat in `source-coord-matches-registration-site`: it compares
+  `(:ns reg-meta)` against `(:ns coord)` field by field, and under the gate
+  BOTH sides are nil — four `nil = nil` comparisons certifying parity between
+  two absences."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
+            [re-frame.source-coords :as sc]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
@@ -59,16 +94,6 @@
 
 ;; ---- helpers --------------------------------------------------------------
 
-(defn- record-traces
-  "Run `body-fn` with a trace listener attached and return the captured
-  events."
-  [body-fn]
-  (let [seen (atom [])]
-    (rf/register-listener! :trace ::rec (fn [ev] (swap! seen conj ev)))
-    (try (body-fn)
-         (finally (rf/unregister-listener! :trace ::rec)))
-    @seen))
-
 (defn- errors-of
   "Filter captured traces to those whose `:operation` matches the supplied
   operation keyword."
@@ -76,6 +101,28 @@
   (filterv #(and (= :error (:op-type %))
                  (= op     (:operation %)))
            evs))
+
+(defn- record-both
+  "ALWAYS-ON (rf2-d2841) capture: run `body-fn` with BOTH a
+  dev-trace listener and an always-on `:errors`-stream listener attached, and
+  return `{:traces [...] :errors [...]}`. The `:errors` half is the corpus-wide
+  `error-emit` registry — not gated by `interop/debug-enabled?` — so it fills
+  in both postures."
+  [body-fn]
+  (let [traces (atom [])
+        errors (atom [])]
+    (rf/register-listener! :trace  ::rec (fn [ev]  (swap! traces conj ev)))
+    (rf/register-listener! :errors ::err (fn [rec] (swap! errors conj rec)))
+    (try (body-fn)
+         (finally
+           (rf/unregister-listener! :trace  ::rec)
+           (rf/unregister-listener! :errors ::err)))
+    {:traces @traces :errors @errors}))
+
+(defn- error-of
+  "The first always-on error record whose `:error` is `kw`."
+  [recs kw]
+  (first (filterv #(= kw (:error %)) recs)))
 
 (defn- assert-trigger-shape
   "Assert the value at `:rf.trace/trigger-handler` on `ev` carries the
@@ -101,15 +148,28 @@
     (rf/reg-event :rf2-3nn8/throws
                      (fn [_cofx _event]
                        (throw (ex-info "boom" {}))))
-    (let [evs (record-traces
-               (fn []
-                 (rf/dispatch-sync [:rf2-3nn8/throws])))
-          [exc] (errors-of evs :rf.error/handler-exception)]
-      (is (some? exc) "handler-exception trace fired")
-      (is (contains? exc :rf.trace/trigger-handler)
-          ":rf.trace/trigger-handler lives at the top level of the event")
-      (is (not (contains? (:tags exc) :rf.trace/trigger-handler))
-          ":rf.trace/trigger-handler does NOT live under :tags"))))
+    (let [{:keys [traces errors]} (record-both
+                                    (fn []
+                                      (rf/dispatch-sync [:rf2-3nn8/throws])))
+          [exc] (errors-of traces :rf.error/handler-exception)
+          rec   (error-of errors :rf.error/handler-exception)]
+      ;; ALWAYS-ON (rf2-d2841): the failure reaches the production error
+      ;; stream, carrying the registration coord under `:source-coord`.
+      (is (some? rec) "the always-on error record fired")
+      (is (map? (:source-coord rec))
+          "the always-on record carries the registration :source-coord")
+      (is (= (sc/error-coords-for :event :rf2-3nn8/throws) (:source-coord rec))
+          "…and it is exactly what the always-on coord registry holds")
+      ;; rf2-d2841 — the trace SLOT and its placement are dev-only. Under
+      ;; `-Dre-frame.debug=false` `exc` is nil, which made the `:tags`
+      ;; negative below a class-4 vacuous pass: `(contains? nil k)` is false
+      ;; for every k.
+      (when interop/debug-enabled?
+        (is (some? exc) "handler-exception trace fired")
+        (is (contains? exc :rf.trace/trigger-handler)
+            ":rf.trace/trigger-handler lives at the top level of the event")
+        (is (not (contains? (:tags exc) :rf.trace/trigger-handler))
+            ":rf.trace/trigger-handler does NOT live under :tags")))))
 
 ;; ---- Q2 — present when handler in scope -----------------------------------
 
@@ -118,9 +178,19 @@
     (rf/reg-event :rf2-3nn8/throwing-event
                      (fn [_cofx _event]
                        (throw (ex-info "boom" {}))))
-    (let [evs (record-traces #(rf/dispatch-sync [:rf2-3nn8/throwing-event]))
-          [exc] (errors-of evs :rf.error/handler-exception)]
-      (assert-trigger-shape exc :event :rf2-3nn8/throwing-event))))
+    (let [{:keys [traces errors]} (record-both
+                                    #(rf/dispatch-sync [:rf2-3nn8/throwing-event]))
+          [exc] (errors-of traces :rf.error/handler-exception)
+          rec   (error-of errors :rf.error/handler-exception)]
+      ;; ALWAYS-ON (rf2-d2841): same attribution on the production channel —
+      ;; the record names the failing event and resolves its coord.
+      (is (= :rf2-3nn8/throwing-event (:event-id rec))
+          "the always-on record names the failing event")
+      (is (= (sc/error-coords-for :event :rf2-3nn8/throwing-event)
+             (:source-coord rec))
+          "the always-on record carries the event's registration coord")
+      (when interop/debug-enabled?
+        (assert-trigger-shape exc :event :rf2-3nn8/throwing-event)))))
 
 (deftest fx-handler-exception-carries-trigger-handler
   (testing ":rf.error/fx-handler-exception names the fx as the trigger handler,
@@ -130,17 +200,49 @@
     (rf/reg-event :rf2-3nn8/use-throwing-fx
                      (fn [_cofx _event]
                        {:fx [[:rf2-3nn8/throwing-fx {}]]}))
-    (let [evs (record-traces #(rf/dispatch-sync [:rf2-3nn8/use-throwing-fx]))
-          [exc] (errors-of evs :rf.error/fx-handler-exception)]
-      (assert-trigger-shape exc :fx :rf2-3nn8/throwing-fx))))
+    (let [{:keys [traces errors]} (record-both
+                                    #(rf/dispatch-sync [:rf2-3nn8/use-throwing-fx]))
+          [exc] (errors-of traces :rf.error/fx-handler-exception)
+          rec   (error-of errors :rf.error/fx-handler-exception)]
+      ;; ALWAYS-ON (rf2-d2841), AND THE TWO CHANNELS DISAGREE ON PURPOSE.
+      ;; The trace names the FX as the trigger handler (the fx body threw);
+      ;; the always-on record's `:source-coord` is resolved by
+      ;; `error-emit/error-source-coord` from `:event-id` under `[:event …]`,
+      ;; so it names the DISPATCHED EVENT. The fx id reaches production on
+      ;; `:failing-id` — the Spec 009 §Component-attribution lift — not on the
+      ;; coord. Pinning both keeps a future "just read the record" refactor
+      ;; from quietly losing the fx attribution.
+      (is (some? rec) "the always-on fx-handler-exception record fired")
+      (is (= :rf2-3nn8/use-throwing-fx (:event-id rec))
+          "the always-on record's :event-id is the dispatched event")
+      (is (= :rf2-3nn8/throwing-fx (:failing-id rec))
+          "the failing FX id is lifted onto the always-on record")
+      (is (= (sc/error-coords-for :event :rf2-3nn8/use-throwing-fx)
+             (:source-coord rec))
+          "the always-on :source-coord resolves under [:event event-id]")
+      (when interop/debug-enabled?
+        (assert-trigger-shape exc :fx :rf2-3nn8/throwing-fx)))))
 
 (deftest sub-exception-carries-trigger-handler
   (testing ":rf.error/sub-exception names the failing sub"
     (rf/reg-sub :rf2-3nn8/throwing-sub
                 (fn [_db _q] (throw (ex-info "sub boom" {}))))
-    (let [evs (record-traces #(deref (rf/subscribe [:rf2-3nn8/throwing-sub])))
-          [exc] (errors-of evs :rf.error/sub-exception)]
-      (assert-trigger-shape exc :sub :rf2-3nn8/throwing-sub))))
+    (let [{:keys [traces errors]} (record-both
+                                    #(deref (rf/subscribe [:rf2-3nn8/throwing-sub])))
+          [exc] (errors-of traces :rf.error/sub-exception)
+          rec   (error-of errors :rf.error/sub-exception)]
+      ;; ALWAYS-ON (rf2-d2841): `:rf.error/sub-exception` is one of
+      ;; `error-emit`'s `sub-error-categories`, so its coord resolves under
+      ;; `[:sub …]` — the realm-aware lookup rf2-xgkgx installed. That is the
+      ;; production-posture statement of "the record names the FAILING SUB".
+      (is (some? rec) "the always-on sub-exception record fired")
+      (is (= :rf2-3nn8/throwing-sub (:event-id rec))
+          "the always-on record's id slot carries the SUB id")
+      (is (= (sc/error-coords-for :sub :rf2-3nn8/throwing-sub)
+             (:source-coord rec))
+          "the always-on :source-coord resolves under [:sub sub-id]")
+      (when interop/debug-enabled?
+        (assert-trigger-shape exc :sub :rf2-3nn8/throwing-sub)))))
 
 ;; The former `no-such-cofx-carries-enclosing-event-trigger-handler` deftest is
 ;; retired with `inject-cofx` (EP-0017 slice A.3) — `:rf.error/no-such-cofx` no
@@ -155,21 +257,42 @@
     (rf/reg-event :rf2-3nn8/uses-missing-fx
                      (fn [_cofx _event]
                        {:fx [[:rf2-3nn8/no-such-fx {}]]}))
-    (let [evs (record-traces #(rf/dispatch-sync [:rf2-3nn8/uses-missing-fx]))
-          [miss] (errors-of evs :rf.error/no-such-fx)]
-      (assert-trigger-shape miss :event :rf2-3nn8/uses-missing-fx))))
+    (let [{:keys [traces errors]} (record-both
+                                    #(rf/dispatch-sync [:rf2-3nn8/uses-missing-fx]))
+          [miss] (errors-of traces :rf.error/no-such-fx)
+          rec    (error-of errors :rf.error/no-such-fx)]
+      ;; ALWAYS-ON (rf2-d2841): `:rf.error/no-such-fx` is a PROMOTED category,
+      ;; so the enclosing event's coord reaches production on the record.
+      (is (some? rec) "the always-on no-such-fx record fired")
+      (is (= (sc/error-coords-for :event :rf2-3nn8/uses-missing-fx)
+             (:source-coord rec))
+          "the always-on record carries the enclosing event's coord")
+      (when interop/debug-enabled?
+        (assert-trigger-shape miss :event :rf2-3nn8/uses-missing-fx)))))
 
 ;; ---- Q2 — negative — absent when no handler is in scope -------------------
 
 (deftest no-such-handler-omits-trigger-handler
   (testing ":rf.error/no-such-handler fires at outermost dispatch with no
    handler in scope; :rf.trace/trigger-handler is absent"
-    (let [evs (record-traces
-               #(rf/dispatch-sync [:rf2-3nn8/no-such-event]))
-          [miss] (errors-of evs :rf.error/no-such-handler)]
-      (is (some? miss) "no-such-handler trace fired")
-      (is (not (contains? miss :rf.trace/trigger-handler))
-          ":rf.trace/trigger-handler is absent when no handler is in scope"))))
+    (let [{:keys [traces errors]} (record-both
+                                    #(rf/dispatch-sync [:rf2-3nn8/no-such-event]))
+          [miss] (errors-of traces :rf.error/no-such-handler)
+          rec    (error-of errors :rf.error/no-such-handler)]
+      ;; ALWAYS-ON (rf2-d2841): the production analogue of "no handler was in
+      ;; scope" is that the record carries NO `:source-coord` — there is no
+      ;; registration to point at. Non-vacuous because the sibling deftests
+      ;; above assert the slot IS present for a registered handler, on the
+      ;; same channel in the same posture.
+      (is (some? rec) "the always-on no-such-handler record fired")
+      (is (not (contains? rec :source-coord))
+          "no registration in scope → the always-on record omits :source-coord")
+      ;; rf2-d2841 — dev-only trace slot. Under the gate `miss` is nil, which
+      ;; made the negative below a class-4 vacuous pass.
+      (when interop/debug-enabled?
+        (is (some? miss) "no-such-handler trace fired")
+        (is (not (contains? miss :rf.trace/trigger-handler))
+            ":rf.trace/trigger-handler is absent when no handler is in scope")))))
 
 ;; ---- Q3 — registration-site coord, not call-site --------------------------
 
@@ -180,18 +303,36 @@
                      (fn [_cofx _event]
                        (throw (ex-info "boom" {}))))
     (let [reg-meta (rf/handler-meta :event :rf2-3nn8/registration-site)
-          evs      (record-traces
-                    #(rf/dispatch-sync [:rf2-3nn8/registration-site]))
-          [exc]    (errors-of evs :rf.error/handler-exception)
-          coord    (-> exc :rf.trace/trigger-handler :source-coord)]
+          {:keys [traces errors]} (record-both
+                                    #(rf/dispatch-sync [:rf2-3nn8/registration-site]))
+          [exc]    (errors-of traces :rf.error/handler-exception)
+          coord    (-> exc :rf.trace/trigger-handler :source-coord)
+          rec      (error-of errors :rf.error/handler-exception)
+          errc     (sc/error-coords-for :event :rf2-3nn8/registration-site)]
+      ;; ALWAYS-ON (rf2-d2841): the same "the emitted coord IS the registration
+      ;; site" claim, made against the always-on registry — which is the
+      ;; registration-site record of truth in production, `handler-meta`
+      ;; having been stripped of coord keys there.
+      (is (map? errc) "the always-on registry holds the registration coord")
+      (is (= errc (:source-coord rec))
+          "the always-on record's :source-coord IS the registration coord")
+      (is (symbol? (:ns errc)))
+      (is (string? (:file errc)))
+      (is (integer? (:line errc)))
+      ;; rf2-d2841 — GUARDED, and this arm was a class-3 vacuous pass: under
+      ;; the gate `reg-meta` carries no coord keys AND `coord` is nil, so all
+      ;; four comparisons were `nil = nil` — parity certified between two
+      ;; absences.
+      ;;
       ;; The registrar stamps :ns / :file / :line / :column flat on the
       ;; meta map; the trigger-handler value picks them up. Compare
       ;; field-by-field rather than via equality so a future addition
       ;; to the registrar slot doesn't break the test.
-      (is (= (:ns     reg-meta) (:ns coord)))
-      (is (= (:file   reg-meta) (:file coord)))
-      (is (= (:line   reg-meta) (:line coord)))
-      (is (= (:column reg-meta) (:column coord))))))
+      (when interop/debug-enabled?
+        (is (= (:ns     reg-meta) (:ns coord)))
+        (is (= (:file   reg-meta) (:file coord)))
+        (is (= (:line   reg-meta) (:line coord)))
+        (is (= (:column reg-meta) (:column coord)))))))
 
 ;; ---- programmatic registration → no coord -> no trigger-handler -----------
 
@@ -202,8 +343,21 @@
     (let [reg-fn (requiring-resolve 're-frame.events/reg-event)]
       (reg-fn :rf2-3nn8/no-coords
               (fn [_cofx _event] (throw (ex-info "boom" {})))))
-    (let [evs   (record-traces #(rf/dispatch-sync [:rf2-3nn8/no-coords]))
-          [exc] (errors-of evs :rf.error/handler-exception)]
-      (is (some? exc))
-      (is (not (contains? exc :rf.trace/trigger-handler))
-          "programmatic registration → no coord → field omitted"))))
+    (let [{:keys [traces errors]} (record-both
+                                    #(rf/dispatch-sync [:rf2-3nn8/no-coords]))
+          [exc] (errors-of traces :rf.error/handler-exception)
+          rec   (error-of errors :rf.error/handler-exception)]
+      ;; ALWAYS-ON (rf2-d2841): "better no-data than poison-data" is a
+      ;; PRODUCTION claim — a programmatic registration must leave the
+      ;; always-on registry empty, so the shipped record omits `:source-coord`
+      ;; rather than pointing an operator at someone else's line.
+      (is (some? rec) "the always-on record still fired")
+      (is (nil? (sc/error-coords-for :event :rf2-3nn8/no-coords))
+          "programmatic registration stored no always-on coords")
+      (is (not (contains? rec :source-coord))
+          "…so the production record omits the :source-coord slot")
+      ;; rf2-d2841 — dev-only trace slot; class-4 vacuous under the gate.
+      (when interop/debug-enabled?
+        (is (some? exc))
+        (is (not (contains? exc :rf.trace/trigger-handler))
+            "programmatic registration → no coord → field omitted")))))

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -239,11 +239,7 @@ known_red=(
   re-frame.observation-port-cljs-test
   re-frame.reg-meta-noswallow-cljs-test
   re-frame.registrar-warnings-test
-  re-frame.source-coord-jvm-test
-  re-frame.source-coords-test
   re-frame.sub-dispose-trace-test
-  re-frame.success-path-call-site-test
-  re-frame.success-path-trigger-handler-test
   re-frame.trace-buffer-test
   re-frame.trace-cascade-captured-test
   re-frame.trace-listener-concurrent-drain-serialization-test
@@ -258,7 +254,6 @@ known_red=(
   re-frame.trace-listener-test
   re-frame.trace-test
   re-frame.trace.structural-retention-cljs-test
-  re-frame.trigger-handler-coord-test
 )
 
 # ---------------------------------------------------------------------------

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -228,17 +228,13 @@ known_red=(
   #    function of a record plus the frame's durable elision registry, so the
   #    profile rows now drive a SYNTHETIC record and run in both postures.
   re-frame.capture-frame-test
-  re-frame.cascade-dispatch-id-test
   re-frame.cofx-cljs-test
   re-frame.cofx-envelope-test
   re-frame.db-pending-trace-test
   re-frame.event-context-partition-test
   re-frame.frame-destroy-composed-test
   re-frame.frame-destroy-incarnation-jvm-test
-  re-frame.interceptor-override-summary-trace-test
   re-frame.observation-port-cljs-test
-  re-frame.reg-meta-noswallow-cljs-test
-  re-frame.registrar-warnings-test
   re-frame.sub-dispose-trace-test
   re-frame.trace-buffer-test
   re-frame.trace-cascade-captured-test

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -229,10 +229,7 @@ known_red=(
   #    profile rows now drive a SYNTHETIC record and run in both postures.
   re-frame.capture-frame-test
   re-frame.cofx-cljs-test
-  re-frame.cofx-envelope-test
   re-frame.db-pending-trace-test
-  re-frame.event-context-partition-test
-  re-frame.frame-destroy-composed-test
   re-frame.frame-destroy-incarnation-jvm-test
   re-frame.observation-port-cljs-test
   re-frame.sub-dispose-trace-test

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -227,7 +227,6 @@ known_red=(
   #    message.  The fix was not a guard — `projected-record` is a pure
   #    function of a record plus the frame's durable elision registry, so the
   #    profile rows now drive a SYNTHETIC record and run in both postures.
-  re-frame.capture-frame-test
   re-frame.cofx-cljs-test
   re-frame.db-pending-trace-test
   re-frame.frame-destroy-incarnation-jvm-test

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -44,7 +44,7 @@
 # a rewrite of how those assertions are spelled.  Triage beads are named per
 # cluster below.
 #
-# What is left IS green, and it is not a rump: 140 namespaces, 1560 tests, 6707
+# What is left IS green, and it is not a rump: 154 namespaces, 1740 tests, 7342
 # assertions, exit 0 — versus the zero suites that had ever executed under this
 # posture before.  (It was
 # 88 / 934 / 4340 tests/assertions before rf2-d2841 split the spine's
@@ -52,9 +52,10 @@
 # 94 / 1106 / 5135 before that bead's second pass took `fx-test` — the largest
 # single entry, 107 failures and 25 errors across ~20 deftests — plus
 # `sub-topology`, `init-platform`, `pattern-smoke` and `db-noop-commit`,
-# 103 / 1213 / 5590 before its third pass took twenty more, and 123 / 1401 /
-# 6054 before its FOURTH pass took seventeen more.  Each pass's namespaces are
-# named in its commits — `git log --grep=rf2-d2841`.)
+# 103 / 1213 / 5590 before its third pass took twenty more, 123 / 1401 / 6054
+# before its FOURTH pass took seventeen more, and 141 / 1560 / 6707 before its
+# FIFTH pass took thirteen more.  Each pass's namespaces are named in its
+# commits — `git log --grep=rf2-d2841`.)
 #
 # The roster is therefore an EXCLUSION list, not an allowlist.  The polarity is
 # the point: a namespace added to `implementation/core/test/` joins this lane
@@ -332,19 +333,28 @@ fi
 # green with `Ran 0 tests`.  Calibrated below the observed count with room for
 # ordinary churn; raise it when the roster grows materially.
 #
-# RAISED 800 -> 1360 (rf2-d2841, third pass), then 1360 -> 1510 (fourth pass).
-# 800 was calibrated against the 915-test lane of rf2-f8x2i's original run and
-# had stopped doing its job.  1360 was calibrated against 1401 and stopped
-# doing its job the same way: the lane now runs 1560 tests, and the seventeen
-# namespaces the fourth pass added are 159 of them — losing the whole batch
-# lands at 1401, which 1360 waves through.  1510 notices that while leaving
-# ~3% for ordinary churn.
+# RAISED 800 -> 1360 (rf2-d2841, third pass), 1360 -> 1510 (fourth pass), then
+# 1510 -> 1690 (fifth pass).  800 was calibrated against the 915-test lane of
+# rf2-f8x2i's original run and had stopped doing its job.  1360 was calibrated
+# against 1401 and stopped doing its job the same way, and 1510 has now done
+# the same in its turn: the lane runs 1740 tests, and the thirteen namespaces
+# the fifth pass added are 180 of them — losing the whole batch lands at 1560,
+# which 1510 waves through.  1690 notices that while leaving ~3% for ordinary
+# churn.
 #
 # The floor is a COLLAPSE DETECTOR, not a target, and the rule that follows
 # from that is why it has moved every pass: it must sit close enough under the
 # observed count that THE SMALLEST BATCH ANYONE LANDS IS STILL VISIBLE.  A
 # floor left behind by a growing lane is not conservative, it is inert.
-export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1510}"
+#
+# WHAT THE FLOOR DOES NOT CATCH, and what caught it out during the fifth pass:
+# a test file whose `(ns ...)` FORM is malformed is invisible to
+# `cognitect.test-runner`'s namespace DISCOVERY, so a `-n` selector naming it
+# matches nothing and the lane simply runs one namespace fewer, exit 0.  The
+# `verify_roster` file-count guard below does not see it either — it scrapes
+# the `(ns ` line as TEXT and never reads the form.  The floor catches the
+# collapse only once enough tests have gone missing.  Filed as rf2-vruo9.
+export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1690}"
 
 args=()
 for ns in $runnable; do


### PR DESCRIPTION
Fifth pass of rf2-d2841. **Thirteen namespaces** come off the prod-gate roster.

| | before | after |
|---|---|---|
| roster (excluded of 185) | 44 | **31** |
| lane (namespaces) | 141 | **154** |
| lane (tests / assertions) | 1560 / 6707 | **1740 / 7342** |
| `RF2_MIN_TESTS` floor | 1510 | **1690** |

Cleared: `source-coords`, `source-coord-jvm`, `trigger-handler-coord`,
`success-path-call-site`, `success-path-trigger-handler`, `registrar-warnings`,
`reg-meta-noswallow-cljs`, `interceptor-override-summary-trace`,
`cascade-dispatch-id`, `event-context-partition`, `cofx-envelope`,
`frame-destroy-composed`, `capture-frame`.

## What this pass does

The established split shape: the instrumentation assertion stays **verbatim**
inside a `(when interop/debug-enabled? …)` arm marked `rf2-d2841`, everything
outside it is posture-independent — and, wherever one exists, a
**production-visible witness** rather than a guard.

Three witnesses carried most of the pass.

**The always-on error-coord registry.** `registrar/register!` calls
`source-coords/remember-error-coords!` unconditionally, so `error-coords-by-id`
holds every macro-path registration's coordinate in **both** postures; it is
what `error-emit/dispatch-on-error!` stamps as `:source-coord` on the tight
record an off-box shipper (Sentry / Honeybadger / Rollbar) receives. Only the
merge into **public** registry-meta is dev-only. Five namespaces' worth of
source-coord and trigger-handler claims moved onto it, and nothing had ever
asserted that sink under the production posture.

**"Is the category promoted?", again.** `capture-frame` came off with **no
guard at all** — 24 tests / 76 assertions identical in both postures. Its
incarnation fences read `:rf.error/frame-destroyed`, a promoted category, off
the `:trace` stream; re-aimed at the `:errors` stream they survive verbatim.
These are the tests for the class of defect where a capture pinned to a
destroyed incarnation leaks into a same-id successor and mutates it, and not
one of them had executed under the posture that ships.

**The behaviour the instrumentation narrates.** An override summary reports a
removal that really happened, so recording interceptors prove it. A
`:rf.sub/dispose` count reports disposals that really happened, so
`interop/add-on-dispose!` counts them — and rf2-awhtpc, which the layered case
regresses, was a **double dispose**; the duplicated emit was only its symptom.
Effect-shape policing drops a foreign key in every posture, so what committed
and what did not is asserted directly.

**Two triage reasons were checked against the source and one hypothesis died
there.** `:rf.trace/call-site` really is dev-only: the macro gate is outermost,
`process-event!` re-gates the read, and — the part worth writing down — the
coord does **not** ride the dispatch envelope, so the `(:envelope m)` probe that
rescued `substrate-source-test` in pass 4 has nothing to read. That was tried
and failed before being written down. Those two files instead witness the
*other* branch of `core-call-site-macros/gate`: `plain` is a distinct expansion
that no suite had ever executed, because every suite ran in dev posture where
the `if` always selects `stamped`.

## Vacuous passes found

Per the standing lesson — namespaces rostered for a few red assertions also
carry assertions that pass for no reason at all, and fixing only the reds
promotes those into the lane as permanent false green.

**55 in total, all of them in namespaces rostered only for their reds.**

| class | count | shape |
|---|---|---|
| 1 — negative over an empty ring | 25 | `(is (empty? warns))`, `(is (zero? (count (filter …))))` |
| 3 — a positive the gate short-circuits | 13 | `nil = nil` field-by-field parity |
| 4 — absence of a key elided wholesale | 16 | `(not (contains? <nil> k))` |
| *(new sub-shape)* — no assertion at all | 1 | a `doseq` over an empty ring |

At least **ten deftests were green under the gate on nothing but vacuous
assertions.** Three are worth naming:

- `composed-destroy-leak-audit` — a **leak audit** certifying that the epoch
  ring buffer had been cleared, over a ring the gate never let it fill. Its
  precondition went red while its post-condition passed for free. The two are
  now guarded as a pair so they cannot be separated again.
- `collision-fires-for-no-handler-fn-kind-despite-shape-dedup` — certified that
  a **dedup gate suppressed an emit**, over a stream carrying no emits at all.
- `parent-dispatch-id-only-on-event-dispatched` — a shape earlier passes had
  not seen. Its whole body is a `doseq` over the captured events, so under the
  gate it iterates **zero times, runs no assertion, and clojure.test reports a
  pass.** A green deftest that executed no assertion is the same false green as
  a vacuous one, and it is harder to see.

The two in `capture-frame` deserve a line of their own:
`live-target-not-reported-destroyed-when-only-owner-dies-async` / `-sync` are
**false-negative checks on an incarnation fence** — the assertion you least want
passing for free — and they were passing over an empty stream.

## One thing the lane could not see

A test file whose `(ns …)` **form** is malformed is invisible to
`cognitect.test-runner`'s namespace discovery. A `-n` selector naming it matches
nothing; a full `clojure -M:test` over a broken file ran **2182 tests instead of
2190 — exactly that file's eight deftests — and reported `0 failures`**.
`verify_roster`'s file-count guard does not catch it either: it scrapes the
`(ns ` line as text and never reads the form. Filed as **rf2-vruo9** (P1) and
recorded in the script's floor comment. Not fixed here — out of fence.

## Quality gates

| gate | result |
|---|---|
| `bash scripts/test-core-prod-gate.sh` | **exit 0** — 154 of 185 namespaces, 1740 tests / 7342 assertions |
| `clojure -M:test` (core, dev posture, branch) | **exit 0** — 2190 tests / 11245 assertions |
| same, pristine `origin/main` worktree at `3ed46c8c75` | **exit 0** — 2190 tests / 10993 assertions |
| `python scripts/check_jvm_lane_rosters.py` | **exit 0** — 31 rostered artefacts, bijection holds |
| per-namespace gated + dev runs, all 13 namespaces | **exit 0** |

**Dev-posture proof that nothing was lost: test count HELD at 2190, assertions
2190 / 10993 → 2190 / 11245 (+252), measured against a pristine `origin/main`
worktree.** No assertion was deleted or weakened.

Deferred to CI: the CLJS lanes, the elision probe, bundle-isolation and the
full rigorous sweep — this pass touches `implementation/core/test/**` and the
roster script only.

## Still on the roster under this bead

Four actionable lines remain (`trace-cascade-captured`, `cofx-cljs`,
`observation-port-cljs`, `frame-destroy-incarnation-jvm`), plus the fifteen
`trace-*` lines that carry no semantic residue and want a var-level
`-e :requires-debug` tag — a `deps.edn` change outside this fence. Both cohorts
are triaged cold on the bead.

Nothing failed for a real reason. Fifth pass running.
