### PR TITLE
ci: a test file with a broken ns form cannot vanish silently (rf2-vruo9)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -96,11 +96,24 @@
   `--probe` is this wrapper's only own flag and is stripped before args are
   forwarded to cognitect.  Nothing is printed on a green probe: the
   silent-on-success contract stands, and the probe's proof is the assertion,
-  not an announcement."
+  not an announcement.
+
+  ## What the lane will DISCOVER
+
+  Both rules above are about the tests that RAN.  Neither can see a test
+  file that never entered the run at all, because cognitect's discovery
+  reads each file's `(ns ...)` form and silently drops the ones it cannot
+  read.  `discovery-defects` is the third rule and it fires BEFORE any test
+  does; see its own docstring, and rf2-vruo9."
   (:require
     [re-frame.test-quiet]
+    [clojure.java.io :as io]
     [clojure.string :as str]
     [clojure.test]
+    [clojure.tools.cli :as cli]
+    [clojure.tools.namespace.file :as ns-file]
+    [clojure.tools.namespace.find :as ns-find]
+    [clojure.tools.namespace.parse :as ns-parse]
     [cognitect.test-runner]))
 
 (def ^:private discovery-banner-prefix
@@ -590,6 +603,178 @@
           (System/exit 2))
       parsed)))
 
+;; ----------------------------------------------------------------------
+;; What the lane will DISCOVER (rf2-vruo9) — a file the runner cannot see
+;; is not a file that passed.
+;;
+;; `cognitect.test-runner/test` builds its namespace set by READING each
+;; source file's `(ns ...)` form:
+;;
+;;     (mapcat find/find-namespaces-in-dir dirs)
+;;
+;; and `clojure.tools.namespace.find/find-ns-decls-in-dir` is a `keep` over
+;; a helper named `ignore-reader-exception` — which is precisely what it
+;; does.  A file whose `(ns ...)` FORM the reader cannot read contributes NO
+;; namespace, and downstream nothing can tell a file that was dropped from a
+;; file that was never written.  One unescaped `"` inside the ns docstring
+;; is enough.
+;;
+;; MEASURED on this repo, 2026-07-29.  A single stray quote in the ns
+;; docstring of `implementation/core/test/re_frame/late_bind_drift_test.clj`
+;; took `clojure -M:test` in `implementation/core` from 2190 tests / 11245
+;; assertions to 2182 / 10571 — exactly that file's eight deftests — and it
+;; printed `0 failures, 0 errors.` and exited 0.  Exit code zero, honestly
+;; earned, over a suite missing a whole file.
+;;
+;; NOTHING ELSE SEES IT, and that is not for want of guards.  `RF2_MIN_TESTS`
+;; above is a COLLAPSE detector: eight tests out of 2190 sit far inside the
+;; headroom any growing lane must leave itself.  `verify_roster` in
+;; `scripts/test-core-prod-gate.sh` compares the file count against the
+;; namespace count but SCRAPES the `(ns ` line with `sed`, and
+;; `scripts/check_test_lane_bijection.py` matches it with a regex — both
+;; therefore match the APPEARANCE of a declaration rather than the
+;; declaration, and both were measured green over the broken file above.
+;; Reading the form is the whole point, so the check lives HERE, in the one
+;; process that already has the lane's classpath and the discovery library
+;; on it, rather than in a script that would have to imitate a reader.
+;;
+;; THE RULE, and why it is one rule rather than three.  Every source file in
+;; a discovery directory must declare — readably — the namespace its own
+;; path spells.  That single sentence closes every silent door:
+;;
+;;   * an unreadable form declares nothing, so it cannot match its path;
+;;   * a file declaring somebody else's namespace is loaded by nobody:
+;;     `require` resolves the DECLARED name back to a path, so whatever
+;;     lives at THAT path is what runs, and this file never does;
+;;   * and two files cannot both spell one namespace, because their paths
+;;     differ — so the shadowing pair, where one file's tests run twice and
+;;     the other's never run at all, is caught by the same comparison.
+;;
+;; "The discovered count equals the file count" was the other candidate and
+;; it is strictly weaker: a count is satisfiable by coincidence (a file lost
+;; while another gains a second declaration nets zero), it cannot NAME the
+;; file it is missing, and it is implied anyway — a total, injective map
+;; from files to namespaces has exactly as many namespaces as it has files.
+;; It is a consequence of this rule, not a second rule.
+;;
+;; SCOPE.  This is the JVM lane's discovery, so it covers every artefact
+;; whose `:test` alias runs this wrapper — which is every JVM artefact in
+;; the repo bar `migration/from-re-frame-v1/codemod`, which deliberately
+;; calls cognitect directly.  The CLJS lanes discover through shadow-cljs's
+;; own indexer and are not in this rule's reach.
+
+(def ^:private discovery-platform
+  "The platform cognitect discovers under.  `cognitect.test-runner/test`
+  calls the single-arity `find/find-namespaces-in-dir`, which defaults to
+  `find/clj`: `.clj` + `.cljc`, read with `{:read-cond :allow :features
+  #{:clj}}`.  Named rather than inlined so the guard and the runner cannot
+  drift apart about what a source file even is."
+  ns-find/clj)
+
+(defn discovery-dirs
+  "The directories this run will scan, or nil when `args` do not parse.
+
+  Resolved with cognitect's OWN option spec and its OWN default —
+  `(or (:dir options) #{\"test\"})` — so there is no second, hand-rolled
+  reading of `-d` to disagree with the first.  Unparseable args yield nil
+  and the guard stands down: cognitect prints its parse diagnostics and
+  exits 1 before discovery, so at that point there is nothing to guard."
+  [args]
+  (let [{:keys [options errors]} (cli/parse-opts args cognitect.test-runner/cli-options)]
+    (when-not (seq errors)
+      (or (:dir options) #{"test"}))))
+
+(defn- ns->path
+  "The classpath-relative path `require` resolves `ns-sym` to, under `ext`."
+  [ns-sym ext]
+  (str (-> (name ns-sym) (str/replace "-" "_") (str/replace "." "/")) ext))
+
+(defn- relative-path
+  "`file`'s path relative to `dir`, forward-slashed on every platform."
+  [^java.io.File dir ^java.io.File file]
+  (-> (.relativize (.toPath dir) (.toPath file)) str (str/replace "\\" "/")))
+
+(defn- declared-namespace
+  "What `file` declares to discovery: `[ns-sym nil]`, or `[nil complaint]`
+  when it declares nothing discovery can use.
+
+  `read-file-ns-decl` THROWS on a file the reader cannot read — that is why
+  `find-ns-decls-in-dir` wraps this very call in `ignore-reader-exception`,
+  and the exception it discards is the one sentence saying where the file is
+  broken.  Catching it here instead is the whole difference between a red an
+  operator can act on and a red they have to bisect, so the reader's own
+  line and column travel with the complaint."
+  [^java.io.File file]
+  (try
+    (if-let [decl (ns-file/read-file-ns-decl file (:read-opts discovery-platform))]
+      [(ns-parse/name-from-ns-decl decl) nil]
+      [nil "it holds no `(ns ...)` form."])
+    (catch Exception e
+      (let [{:keys [line col]} (ex-data e)
+            msg (or (some-> (ex-message e) str/split-lines first)
+                    (.getName (class e)))]
+        [nil (str "the reader cannot read it"
+                  (when line (str " (line " line ", column " col ")"))
+                  ": " msg)]))))
+
+(defn discovery-defects
+  "Every source file under `dirs` that will NOT reach the runner as its own
+  namespace, as `[path complaint]` pairs sorted by path.
+
+  Empty is the only acceptable answer.  The files come from
+  `find/find-sources-in-dir` — the same walk `find-ns-decls-in-dir` makes,
+  before it drops anything — so the comparison is between what discovery
+  SAW and what discovery KEPT, rather than between discovery and a
+  file-naming convention this guard invented."
+  [dirs]
+  (vec
+    (sort
+      (for [d               (sort dirs)
+            :let            [dir (io/file d)]
+            ^java.io.File f (ns-find/find-sources-in-dir dir discovery-platform)
+            :let  [rel       (relative-path dir f)
+                   ext       (subs rel (str/last-index-of rel "."))
+                   [declared complaint] (declared-namespace f)]
+            :when (not= rel (some-> declared (ns->path ext)))]
+        [(str/replace (.getPath f) "\\" "/")
+         (or complaint
+             (str "it declares `" declared "`, which discovery resolves to `"
+                  (ns->path declared ext) "` - a different file."))]))))
+
+(defn- verify-discovery!
+  "Refuse the run when any file in this lane's discovery directories will
+  not reach the runner as its own namespace (rf2-vruo9).
+
+  Called before `-main` rebinds anything, so the diagnostic goes straight
+  to the real stderr rather than into the red-replay ring, and exits 1
+  before a single test runs.  ASCII only: this text goes through the
+  platform-default stderr encoding, where an em dash renders as a
+  replacement character on a Windows console.  Silent when clean."
+  [args]
+  (when-let [dirs (discovery-dirs args)]
+    (when-let [defects (seq (discovery-defects dirs))]
+      (binding [*out* *err*]
+        (println (str "\n[test-quiet] ERROR: " (count defects) " file(s) under "
+                      (pr-str (vec (sort dirs)))
+                      " will not reach the runner as their own namespace:"))
+        (doseq [[path complaint] defects]
+          (println (str "  " path))
+          (println (str "      " complaint)))
+        (println (str "cognitect.test-runner discovers a namespace by READING each"
+                      " file's `(ns ...)` form and\n"
+                      "silently drops the files it cannot read"
+                      " (clojure.tools.namespace.find/find-ns-decls-in-dir\n"
+                      "is a `keep` over `ignore-reader-exception`). Such a file"
+                      " contributes no namespace: its\n"
+                      "tests do not run, the suite still prints `0 failures, 0"
+                      " errors.`, and the run exits 0.\n"
+                      "Measured: one stray quote in an ns docstring took"
+                      " implementation/core from 2190 tests\n"
+                      "to 2182, green. Fix the file, or move it out of the"
+                      " discovery directory (rf2-vruo9).\n"))
+        (flush))
+      (System/exit 1))))
+
 (defn- install-summary-method!
   "Install `f` as `clojure.test/report`'s `:summary` method, or — when `f`
   is nil — remove any installed method so the multimethod falls back to its
@@ -777,6 +962,12 @@
         ;; what cognitect sees.
         [{:keys [probe?]} forwarded-args] (split-runner-args args)
         claim      {:probe? probe? :min-tests (resolve-min-tests!)}
+        ;; And what this lane will DISCOVER, resolved from the same args
+        ;; cognitect is about to parse (rf2-vruo9). Also before anything is
+        ;; rebound, and before a single test runs: a file the reader cannot
+        ;; read is invisible to discovery, so no later hook — not the floor,
+        ;; not the summary — has anything left to notice.
+        _          (verify-discovery! forwarded-args)
         real-out   *out*
         real-err   *err*
         sys-err    System/err

--- a/implementation/test-quiet/test/re_frame/test_quiet_discovery_integrity_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_discovery_integrity_test.clj
@@ -1,0 +1,183 @@
+(ns re-frame.test-quiet-discovery-integrity-test
+  "The rule `re-frame.test-quiet.runner/discovery-defects` states, and the
+  defect it exists to make impossible (rf2-vruo9).
+
+  A test file whose `(ns ...)` FORM the reader cannot read is INVISIBLE to
+  `cognitect.test-runner`: discovery reads each file's form and
+  `clojure.tools.namespace.find/find-ns-decls-in-dir` is a `keep` over a
+  helper called `ignore-reader-exception`, so an unreadable file simply
+  contributes no namespace. Measured on this repo: one stray unescaped
+  quote in the ns docstring of `late_bind_drift_test.clj` took
+  `implementation/core` from 2190 tests to 2182 — exactly that file's eight
+  deftests — reporting `0 failures, 0 errors.` and exiting 0.
+
+  EVERY TEST HERE PINS THE DEFECT BEFORE IT PINS THE GUARD. Each fixture is
+  handed to `find/find-namespaces-in-dir` FIRST, and the assertion is on
+  what discovery does or does not return; only then is `discovery-defects`
+  asked to name it. A guard tested against nothing but its own output would
+  go on passing after the library it mirrors changed underneath it — which
+  is the shape of every check this one replaces.
+
+  The wiring — that `-main` actually calls the rule, exits 1, and says so on
+  stderr — is pinned across a process boundary in
+  `re-frame.test-quiet-runner-contract-test`."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [clojure.tools.namespace.find :as ns-find]
+            [re-frame.test-quiet.runner :as runner]))
+
+;; ----------------------------------------------------------------------
+;; Fixtures
+
+(defn- with-tree
+  "Make a temp directory, write `files` (a map of relative path -> source)
+  into it, hand it to `f`, then delete it."
+  [files f]
+  (let [dir (.toFile (java.nio.file.Files/createTempDirectory
+                       "tq-discovery"
+                       (make-array java.nio.file.attribute.FileAttribute 0)))]
+    (try
+      (doseq [[path source] files]
+        (let [file (io/file dir path)]
+          (.mkdirs (.getParentFile file))
+          (spit file source)))
+      (f dir)
+      (finally
+        (doseq [file (reverse (file-seq dir))]
+          (.delete ^java.io.File file))))))
+
+(def ^:private well-formed
+  "An ordinary suite: readable ns form, name spelling its own path."
+  (str "(ns probe.good-test\n"
+       "  \"An ordinary suite.\"\n"
+       "  (:require [clojure.test :refer [deftest is]]))\n"
+       "(deftest a (is (= 1 1)))\n"))
+
+(def ^:private unreadable
+  "The measured defect: one unescaped `\"` inside the ns docstring. The
+  reader consumes the rest of the file as a string and hits EOF."
+  (str "(ns probe.unreadable-test\n"
+       "  \"A docstring with a stray \" quote in it.\"\n"
+       "  (:require [clojure.test :refer [deftest is]]))\n"
+       "(deftest b (is (= 1 1)))\n"))
+
+(defn- defect-paths [defects]
+  (mapv (comp #(last (str/split % #"/")) first) defects))
+
+(defn- complaint-for [defects stem]
+  (some (fn [[path complaint]]
+          (when (str/ends-with? path stem) complaint))
+        defects))
+
+;; ----------------------------------------------------------------------
+;; The dirs the rule is applied to
+
+(deftest discovery-dirs-are-cognitects-own
+  (testing "the guard reads `-d` with cognitect's own option spec and
+            default, so there is no second reading to disagree with the
+            first"
+    (is (= #{"test"} (runner/discovery-dirs []))
+        "no -d means cognitect's `(or (:dir options) #{\"test\"})`")
+    (is (= #{"test" "extra"} (runner/discovery-dirs ["-d" "test" "-d" "extra"]))
+        "-d accumulates, exactly as cognitect's :assoc-fn does")
+    (is (= #{"other"} (runner/discovery-dirs ["--dir=other"]))
+        "the long form with = is the same option")
+    (is (= #{"test"} (runner/discovery-dirs ["-n" "some.ns-test" "-e" ":slow"]))
+        "selectors narrow what RUNS, never what must be discoverable"))
+
+  (testing "unparseable args stand the guard down: cognitect owns its parse
+            diagnostics and exits before discovery, so there is nothing yet
+            to guard"
+    (is (nil? (runner/discovery-dirs ["--no-such-flag"])))))
+
+;; ----------------------------------------------------------------------
+;; The rule
+
+(deftest an-unreadable-ns-form-is-invisible-and-is-named
+  (with-tree {"probe/good_test.clj"       well-formed
+              "probe/unreadable_test.clj" unreadable}
+    (fn [dir]
+      (testing "THE DEFECT: discovery silently drops the file it cannot read"
+        (let [discovered (set (ns-find/find-namespaces-in-dir dir))]
+          (is (contains? discovered 'probe.good-test))
+          (is (not (contains? discovered 'probe.unreadable-test))
+              (str "the whole bug: an unreadable `(ns ...)` form yields no"
+                   " namespace at all, so nothing downstream — not the"
+                   " summary, not the RF2_MIN_TESTS floor — has anything"
+                   " left to notice. Discovered: " (pr-str discovered)))))
+
+      (testing "THE GUARD: it is named, and only it"
+        (let [defects (runner/discovery-defects [(.getPath dir)])]
+          (is (= ["unreadable_test.clj"] (defect-paths defects)))
+          (is (str/includes? (complaint-for defects "unreadable_test.clj")
+                             "the reader cannot read it")
+              "the complaint must say the form is unreadable")
+          (is (str/includes? (complaint-for defects "unreadable_test.clj")
+                             "EOF")
+              (str "and must carry the reader's OWN message, which"
+                   " `ignore-reader-exception` throws away — that is the"
+                   " difference between a red an operator can act on and"
+                   " one they must bisect")))))))
+
+(deftest a-file-declaring-another-namespace-is-named
+  (with-tree {"probe/good_test.clj"        well-formed
+              "probe/mislabelled_test.clj" (str "(ns probe.elsewhere-test\n"
+                                                "  (:require [clojure.test"
+                                                " :refer [deftest is]]))\n"
+                                                "(deftest c (is (= 1 1)))\n")}
+    (fn [dir]
+      (testing "THE DEFECT: discovery returns a name whose file is not this
+                one, so `require` loads whatever lives at THAT path and this
+                file's tests run nowhere"
+        (is (contains? (set (ns-find/find-namespaces-in-dir dir))
+                       'probe.elsewhere-test))
+        (is (not (.exists (io/file dir "probe/elsewhere_test.clj")))
+            "and nothing lives there"))
+
+      (testing "THE GUARD: named, with the path its declaration resolves to"
+        (let [defects (runner/discovery-defects [(.getPath dir)])]
+          (is (= ["mislabelled_test.clj"] (defect-paths defects)))
+          (is (str/includes? (complaint-for defects "mislabelled_test.clj")
+                             "probe/elsewhere_test.clj")
+              "the complaint names the file discovery will look for"))))))
+
+(deftest two-files-declaring-one-namespace-are-not-two-suites
+  (with-tree {"probe/good_test.clj"   well-formed
+              "probe/shadow_test.clj" (str "(ns probe.good-test\n"
+                                           "  (:require [clojure.test"
+                                           " :refer [deftest is]]))\n"
+                                           "(deftest d (is (= 1 1)))\n")}
+    (fn [dir]
+      (testing "THE DEFECT: one namespace, twice. `require` loads whichever
+                file the classpath resolves and the other never loads —
+                while the tally goes UP, not down, so no coverage floor can
+                see it"
+        (is (= ['probe.good-test 'probe.good-test]
+               (vec (ns-find/find-namespaces-in-dir dir)))))
+
+      (testing "THE GUARD: two files cannot both spell one namespace,
+                because their paths differ"
+        (is (= ["shadow_test.clj"]
+               (defect-paths (runner/discovery-defects [(.getPath dir)]))))))))
+
+(deftest a-well-formed-tree-has-nothing-to-say
+  (testing "silent on success: the rule is a refusal, not a report"
+    (with-tree {"probe/good_test.clj"    well-formed
+                "probe/nested/more_test.clj"
+                (str "(ns probe.nested.more-test\n"
+                     "  (:require [clojure.test :refer [deftest is]]))\n"
+                     "(deftest e (is (= 1 1)))\n")
+                "probe/not_a_test.clj"
+                (str "(ns probe.not-a-test)\n")}
+      (fn [dir]
+        (is (= [] (runner/discovery-defects [(.getPath dir)]))
+            "nested paths, and a file the `-test` selector will skip, are
+             both ordinary"))))
+
+  (testing "a directory that does not exist contributes nothing, exactly as
+            it does to cognitect"
+    (is (= [] (runner/discovery-defects ["no-such-directory-anywhere"]))))
+
+  (testing "and this artefact's own test tree is clean"
+    (is (= [] (runner/discovery-defects ["test"])))))

--- a/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_runner_contract_test.clj
@@ -30,6 +30,10 @@
      discovery banner is still absent.
    - ERROR: exit 1; the `ERROR in` block + the thrown message reach
      stdout.
+   - DISCOVERY: a file whose `(ns ...)` form the reader cannot read
+     refuses the run (exit 1, named on stderr) instead of leaving it
+     silently short a suite — and the same fixture is green the moment
+     before that file arrives.
    - STDERR BUFFER: a green run that emits expected
      stderr warnings stays quiet (the warnings are buffered + dropped);
      a RED run REPLAYS the buffered stderr context so a failing run
@@ -1424,3 +1428,59 @@
           (is (not (str/includes? out "Ran "))
               (str "the run must be rejected BEFORE any test executes; got:\n"
                    out)))))))
+
+;; ----------------------------------------------------------------------
+;; What the lane will DISCOVER (rf2-vruo9).
+;;
+;; The floor above is a COLLAPSE detector and cannot see a lane that lost
+;; ONE file: `cognitect.test-runner` discovers namespaces by READING each
+;; file's `(ns ...)` form, and drops the files it cannot read. Measured on
+;; this repo, a single unescaped quote in an ns docstring took
+;; `implementation/core` from 2190 tests to 2182 — the broken file's eight
+;; deftests — printing `0 failures, 0 errors.` and exiting 0.
+;;
+;; The rule itself is pinned against the discovery library in
+;; `re-frame.test-quiet-discovery-integrity-test`. What is pinned HERE is
+;; the only part that needs a real process: that `-main` applies it, refuses
+;; before a test runs, and says which file — and that the SAME fixture is
+;; green the moment before the broken file arrives, which is what makes the
+;; red attributable to the file rather than to the guard.
+
+(deftest an-undiscoverable-file-refuses-the-run
+  (testing "a file whose `(ns ...)` form the reader cannot read reds the
+            lane instead of vanishing from it"
+    (with-fixture-dir
+      (fn [dir]
+        (write-fixture! dir "discovery_fixture_test" "discovery-fixture-test"
+                        "(deftest a-passing-test (is (= 1 1)))")
+        (let [{:keys [exit out err]} (run-runner dir)]
+          (is (zero? exit)
+              (str "BEFORE: the fixture alone is green, so the red below"
+                   " belongs to the broken file and not to the guard; got "
+                   exit "\n--- stdout ---\n" out "\n--- stderr ---\n" err)))
+
+        ;; One unescaped `"` inside the ns docstring. The reader consumes
+        ;; the rest of the file as a string and hits EOF, so the form never
+        ;; reads and the namespace never enters the discovered set.
+        (write-raw-fixture!
+          dir "unreadable_test"
+          (str "(ns probe.unreadable-test\n"
+               "  \"A docstring with a stray \" quote in it.\"\n"
+               "  (:require [clojure.test :refer [deftest is]]))\n"
+               "(deftest silently-dropped (is (= 1 1)))"))
+
+        (let [{:keys [exit out err]} (run-runner dir)]
+          (is (= 1 exit)
+              (str "AFTER: an undiscoverable file must red the run; exit 0"
+                   " here is the bug — the suite would report `0 failures`"
+                   " over a file it never loaded. Got " exit
+                   "\n--- stdout ---\n" out "\n--- stderr ---\n" err))
+          (is (str/includes? err "unreadable_test.clj")
+              (str "the diagnostic must NAME the file, or the operator is"
+                   " left bisecting; got stderr:\n" err))
+          (is (str/includes? err "will not reach the runner")
+              (str "and must say what is wrong with it; got stderr:\n" err))
+          (is (not (str/includes? out "Ran "))
+              (str "the run must be refused BEFORE any test executes,"
+                   " because by the time a tally exists the missing file is"
+                   " already invisible to it; got:\n" out)))))))

--- a/scripts/check_test_lane_bijection.py
+++ b/scripts/check_test_lane_bijection.py
@@ -105,10 +105,22 @@ THE FIVE RULES
       flag.  Same declaration, same teeth, one tier earlier than the runner's
       own runtime check.
 
-  B5  UNREADABLE NAMESPACE.  A test file must declare exactly one namespace.
+  B5  UNDECLARED NAMESPACE.  A test file must declare exactly one namespace.
       With none, or with two that disagree, there is no name to apply a
       selector to -- and a gate that quietly fell back to a path-derived guess
       would be back to the false green B5 exists to remove.
+        B5 IS ABOUT THE DECLARATION, NOT ABOUT WHETHER IT READS.  `NS_FORM` is
+      a regex over masked source: it sees `(ns some.thing-test`, which is the
+      name a selector is applied to, and that is all this gate needs to decide
+      coverage.  It does NOT decide that the Clojure reader can read the form
+      -- a file with a stray unescaped quote in its ns docstring matches the
+      regex, passes B5, and is invisible to `cognitect.test-runner`'s
+      discovery all the same (measured 2026-07-29: this gate reported PASS
+      while the core lane ran eight tests fewer, rf2-vruo9).  Reading the form
+      needs a reader, so that check lives where one already is: the JVM lanes
+      pass through `re-frame.test-quiet.runner`, which refuses to start when
+      any file in a discovery directory will not reach it as its own
+      namespace.  Do not try to settle it with a better regex here.
 
 Counts belong in a PR body where they carry a date; this file states rules.
 """
@@ -601,7 +613,7 @@ class TestFile:
     #: Every ancestor directory, as strings, so "is this file under one of the
     #: lane's roots?" is a set intersection rather than a walk per (lane, root).
     ancestors: frozenset = frozenset()
-    #: Set when the `(ns ...)` declaration could not be read (B5).
+    #: Set when the `(ns ...)` declaration is missing or self-contradictory (B5).
     ns_problem: str = ""
 
 
@@ -742,11 +754,13 @@ def check(lanes, files, repo: Path):
 
     ordered = sorted(files, key=lambda f: (f.ns or "", str(f.path)))
 
-    # B5 -- no readable namespace, so no selector can be applied at all.
+    # B5 -- no declared namespace, so no selector can be applied at all.
+    # Whether the declaration READS is a different question, settled by a
+    # reader in `re-frame.test-quiet.runner` (rf2-vruo9); see B5 above.
     for test_file in ordered:
         if test_file.ns is None:
             failures.append(
-                f"B5 unreadable namespace: {rel(test_file.path)} defines tests but "
+                f"B5 undeclared namespace: {rel(test_file.path)} defines tests but "
                 f"{test_file.ns_problem}. A lane selector is applied to the DECLARED "
                 f"namespace, so this file's lane membership is undecidable.")
 
@@ -1012,13 +1026,13 @@ def run_self_test() -> int:
     files = dict(GREEN_FILES)
     files["implementation/core/test/app/nameless_cljs_test.cljc"] = "(deftest t (is true))\n"
     case("B5 fires on a test file that declares no namespace",
-         expect="B5 unreadable namespace", files=files)
+         expect="B5 undeclared namespace", files=files)
 
     files = dict(GREEN_FILES)
     files["implementation/core/test/app/two_ns_cljs_test.cljc"] = (
         "(ns app.two-ns-cljs-test)\n(deftest t (is true))\n(ns app.somewhere-else)\n")
     case("B5 fires on two disagreeing namespace declarations",
-         expect="B5 unreadable namespace", files=files)
+         expect="B5 undeclared namespace", files=files)
 
     ok = True
     for name, expect, files, shadow, probe_flag in cases:

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -276,6 +276,16 @@ verify_roster() {
 
   # 1. The `(ns ...)` scrape must still see every test file.  If the regex ever
   #    stops matching, the lane quietly narrows and stays green.
+  #
+  #    THE COUNT IS ABOUT THIS SCRIPT'S SCRAPE, NOT ABOUT DISCOVERY.  It reads
+  #    the `(ns ` line as TEXT, so it goes on counting a file whose FORM the
+  #    Clojure reader cannot read — measured green over exactly such a file
+  #    while the lane ran eight tests fewer (rf2-vruo9).  Whether a file is
+  #    really discoverable is decided by a reader, in
+  #    `re-frame.test-quiet.runner/discovery-defects`, which the run below
+  #    passes through before any test executes.  Do not reach for a cleverer
+  #    regex here: a scrape that imitated a reader would be a second way to be
+  #    wrong about the same thing.
   files="$(find "$test_root" -type f \( -name '*_test.clj' -o -name '*_test.cljc' \) | wc -l)"
   ns_count="$(printf '%s\n' "$nses" | grep -c . || true)"
   if [ "$files" -ne "$ns_count" ]; then
@@ -351,9 +361,18 @@ fi
 # a test file whose `(ns ...)` FORM is malformed is invisible to
 # `cognitect.test-runner`'s namespace DISCOVERY, so a `-n` selector naming it
 # matches nothing and the lane simply runs one namespace fewer, exit 0.  The
-# `verify_roster` file-count guard below does not see it either — it scrapes
-# the `(ns ` line as TEXT and never reads the form.  The floor catches the
-# collapse only once enough tests have gone missing.  Filed as rf2-vruo9.
+# floor catches that collapse only once enough tests have gone missing —
+# measured at eight, out of 2190, which is well inside the ~3% of headroom a
+# growing lane has to leave itself.
+#
+# CLOSED (rf2-vruo9), and NOT here.  The check that catches it reads the form
+# instead of scraping the line, so it belongs in a process that already has a
+# reader and the lane's classpath: `re-frame.test-quiet.runner` now refuses to
+# start when any file in a discovery directory will not reach the runner as
+# its own namespace.  That is the wrapper EVERY JVM artefact's `:test` alias
+# invokes, so the rule covers every lane in the repo rather than this one, and
+# it fires before a single test runs.  `verify_roster` below is unchanged and
+# still cannot see this class on its own — see its guard #1.
 export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1690}"
 
 args=()


### PR DESCRIPTION
A test file whose `(ns …)` **form** is malformed is invisible to
`cognitect.test-runner`'s namespace discovery. Its tests do not run, the suite
reports `0 failures, 0 errors.`, and the process exits 0. A silent deletion is
worse than a failure: a failure gets fixed, a disappearance gets trusted.

## The reproduction

`implementation/core`, on this branch's base, one unescaped `"` added to the ns
docstring of `implementation/core/test/re_frame/late_bind_drift_test.clj` (a
file with eight deftests). Nothing else changed.

| `clojure -M:test` in `implementation/core` | tests | assertions | verdict | exit |
| --- | --- | --- | --- | --- |
| baseline | 2190 | 11245 | `0 failures, 0 errors.` | 0 |
| one broken ns docstring | **2182** | 10571 | `0 failures, 0 errors.` | **0** |

Exactly the file's eight deftests, gone, green.

**And every guard that should have noticed was green over it too**, which is why
this is a P1 rather than a curiosity:

| over the broken file, BEFORE this change | reported | exit |
| --- | --- | --- |
| `bash scripts/test-core-prod-gate.sh --plan` | `namespaces : 154 of 185` — unchanged | 0 |
| `python scripts/check_test_lane_bijection.py` | `PASS … every file selected` | 0 |
| the `RF2_MIN_TESTS` floor (1690, lane runs 1740) | eight tests is inside the headroom | — |

The bijection gate is the sharpest of the three: its own reported universe drops
from **1723 test-defining files to 1722** when the ns form breaks, and it calls
that "every file selected". Measured just now, both ways.

Why they all miss it is one thing, not three: `verify_roster` scrapes the `(ns `
line with `sed`, and the bijection gate matches it with a regex over masked
source. Both match the *appearance* of a declaration rather than the
declaration. `find-ns-decls-in-dir` reads the form, and the helper it reads
through is called `ignore-reader-exception`.

## The fix, and where it lives

In `re-frame.test-quiet.runner` — the wrapper **every** JVM artefact's `:test`
alias already invokes (`-m re-frame.test-quiet.runner`). One edit covers every
lane in the repo, with no roster, no new CI job and no new dependency: the
runner already has the lane's classpath, and `clojure.tools.namespace` arrives
with cognitect test-runner. The `-d` dirs are resolved with **cognitect's own
`cli-options` and its own default**, so there is no second reading of `-d` to
disagree with the first. It runs before `-main` rebinds anything and before a
single test executes, because by the time a tally exists the missing file is
already invisible to it.

**The rule is one sentence.** *Every source file in a discovery directory must
declare — readably — the namespace its own path spells.*

That closes every silent door with one comparison:

* an unreadable form declares nothing, so it cannot match its path;
* a file declaring somebody else's namespace is loaded by nobody — `require`
  resolves the *declared* name back to a path, so whatever lives at *that* path
  runs and this file never does;
* and two files cannot both spell one namespace, because their paths differ —
  so the shadowing pair, where one file's tests run **twice** and the other's
  never run at all, is caught by the same comparison. That one moves the tally
  *up*, so no coverage floor can ever see it.

The alternative — *"the discovered count equals the file count"* — is strictly
weaker and was not taken. A count is satisfiable by coincidence (a file lost
while another gains a second declaration nets zero), it cannot **name** the file
it is missing, and it is implied anyway: a total, injective map from files to
namespaces has exactly as many namespaces as files. It is a consequence of this
rule, not a second rule. *"Declares a readable ns"* alone is weaker in the other
direction: it passes a file that declares someone else's namespace and runs
nowhere.

No list of known-good files. Nothing to maintain by hand.

## Mutation proof

Same mutation, same file, after the change:

```
$ clojure -M:test          # implementation/core
[test-quiet] ERROR: 1 file(s) under ["test"] will not reach the runner as their own namespace:
  test/re_frame/late_bind_drift_test.clj
      the reader cannot read it: Invalid symbol: directions:.
cognitect.test-runner discovers a namespace by READING each file's `(ns ...)` form and
silently drops the files it cannot read …
exit 1
```

No `Ran …` line: refused before a test ran. The reader's own complaint travels
with it — `ignore-reader-exception` throws that sentence away, and it is the
difference between a red an operator can act on and one they must bisect.

`bash scripts/test-core-prod-gate.sh` over the same file: exit 1, same
diagnostic, `FAIL implementation/core under -Dre-frame.debug=false`.

File restored → `git diff --stat` empty → core back to `Ran 2190 tests
containing 11245 assertions. / 0 failures, 0 errors.`, exit 0.

The identical proof run against the **pre-change** guards is the first table
above: three green verdicts and a 0 exit. That is what makes this a pin rather
than a comment.

## Is anything invisible in the repo today?

**No.** The shipped `discovery-defects` applied to all **38** `test/`
directories in the repo reports **0 defects** — 1144 `.clj`/`.cljc` files. A
`.cljs`/`.cljc` sweep over the same trees (1250 files) is also clean, so nothing
believed to be running is silently absent on either side.

## Scope

Fixed in one place, general by construction. Every JVM artefact routes through
this runner, so every JVM lane is covered — the two exceptions are named in the
code: `migration/from-re-frame-v1/codemod`, which deliberately calls cognitect
directly, and the CLJS lanes, which discover through shadow-cljs's own indexer
and are outside this rule's reach. Filed as follow-up rather than guessed at.

`verify_roster` and the bijection gate's B5 are **unchanged in behaviour** — a
scrape that imitated a reader would be a second way to be wrong about the same
thing. Both now state what they actually decide and point at the reader that
decides the rest; B5's failure message is renamed `unreadable` → `undeclared`
to match, since deciding readability was never what it did.

No production code changed. `day8/re-frame2-test-quiet` is test-only and
unpublished (no `clein` alias).

## Quality gates

Foreground, worktree-local logs, exit codes as echoed. Windows 11, this
worktree.

| gate | result | exit |
| --- | --- | --- |
| `clojure -M:test` — `implementation/test-quiet` | `Ran 51 tests containing 271 assertions. / 0 failures, 0 errors.` | 0 |
| `clojure -M:test -n re-frame.test-quiet-discovery-integrity-test` | `Ran 5 tests containing 19 assertions.` | 0 |
| `clojure -M:test` — `implementation/core` | `Ran 2190 tests containing 11245 assertions.` (baseline restored) | 0 |
| `bash scripts/test-core-prod-gate.sh` | `154 of 185`, `Ran 1740 tests containing 7342 assertions.` — **no regression** | 0 |
| `bash scripts/test-core-prod-gate.sh` over a broken ns form | reds, names the file | 1 (intended) |
| `clojure -M:test` — `implementation/adapters/reagent` (`--probe` lane) | `Ran 0 tests` — probe lane still green | 0 |
| `clojure -M:test` — `tools/story` | `Ran 1847 tests containing 6824 assertions.` | 0 |
| `python scripts/check_test_lane_bijection.py --self-test` | `self-test: PASS (19 cases)` | 0 |
| `python scripts/check_test_lane_bijection.py` | `PASS … 1723 test-defining files, 46 lanes` | 0 |
| `npm run test:script-policy` | all policy suites passed | 0 |
| `bash -n scripts/test-core-prod-gate.sh` | — | 0 |
| shipped guard over all 38 repo `test/` dirs | `defects: 0` | 0 |
| multi-`-d` parse (`tools/` 5-dir alias) | 5 dirs resolved, `defects: []` | 0 |

Deferred to CI: the remaining JVM artefact lanes
(`scripts/test-jvm-implementation.sh`, `scripts/test-jvm-tools.sh`) and every
CLJS/browser lane. The change is one pre-flight in a shared runner and is
exercised identically by all of them; three representative lanes plus a
`--probe` lane are green above.

One thing seen and **not** caused by this change: `cd tools && clojure -M:test`
(the combined convenience alias, on no roster — `scripts/test-jvm-tools.sh`
runs per-artefact) fails to load `re-frame.ui.reactive`. That is a classpath gap
after discovery; the guard printed nothing and passed control straight through,
and its five `-d` dirs are clean.

Closes rf2-vruo9.
