### PR TITLE
test(core): pass 6 — split dev instrumentation from semantics (rf2-d2841)

### DIFF
--- a/implementation/core/test/re_frame/cofx_cljs_test.cljc
+++ b/implementation/core/test/re_frame/cofx_cljs_test.cljc
@@ -33,7 +33,61 @@
   floor). The fixture's snapshot/restore baseline (rf2-7hwnu) preserves the
   framework registrations that landed at ns-load — including the standard
   `:rf/time-ms` provided-recordable cofx — across both runtimes, replacing
-  the JVM-only `(require … :reload)` resurrection the prior `.clj` used."
+  the JVM-only `(require … :reload)` resurrection the prior `.clj` used.
+
+  ## Posture split (rf2-d2841)
+
+  Almost nothing in this file needed a guard, because almost nothing in it is
+  really about the trace. Three production channels carry the claims instead,
+  and finding them is the whole of this pass's work here.
+
+  1. `:rf.cofx` — THE CANONICAL COMPLETE RECORD — is staged flat into the
+     handler's own coeffects map, always-on, read via `:as`. The
+     `reply-envelope-carries-rf-cofx-flat-and-freshly-stamped` deftest read
+     the request's and reply's tokens off `[:tags :rf.cofx]` on the
+     `:rf.event/dispatched` trace; it now reads the SAME maps out of the two
+     handlers. Flat shape, fresh stamping and non-inheritance are all
+     production facts about the envelope, not trace facts, and all three now
+     run under the gate.
+
+  2. THE COFX ERROR CATEGORIES ARE PROMOTED. `emit-unregistered-cofx!`,
+     `emit-missing-required-cofx!` and `emit-cofx-value-invalid!` each fan
+     through `error-emit/emit-error-both!`, so `:rf.error/unregistered-cofx`,
+     `:rf.error/missing-required-cofx` and `:rf.error/cofx-value-invalid`
+     reach the always-on `:errors` stream. \"Exactly one such error fired\" is
+     therefore provable in the posture that ships, and the four adversarial
+     error deftests assert it there. What does NOT survive is `:rf.cofx/id` —
+     these sites pass `failing-id` as BOTH the failing id and the event-id, so
+     `emit-error-both!`'s lift (which fires only when the two DIFFER) stamps
+     nothing extra and the record stays the tight `{:error :event :event-id
+     :frame :time :exception :elapsed-ms}` shape. Production learns THAT a
+     coeffect declaration failed and WHICH EVENT declared it, never WHICH
+     FACT. Those `:rf.cofx/id` tag reads are guarded.
+
+  3. A `:rf.cofx/run` TAG REPORTS A DELIVERY. The produced value stamped
+     under `:rf.cofx/value` is the coeffect that egresses into the handler,
+     so the three run-tag deftests now let their handlers read it.
+
+  THREE VACUOUS PASSES CAME OFF, in two classes.
+  class 1 (a negative over an empty ring) — 2:
+  `reply-envelope-...`'s `(every? (complement map?) (vals reply-cofx))`, where
+  `reply-cofx` is nil, `(vals nil)` is nil and `every?` over nil is TRUE, so a
+  FLAT-SHAPE claim on the retired grouped-cofx regression passed on nothing;
+  and `generator-emits-generated-trace-op`'s `(empty? runs)`, certifying that
+  a generated fact does NOT also emit the ambient `:rf.cofx/run` op over a
+  stream carrying no ops of any kind.
+  class 4 (absence of a key elided wholesale) — 1:
+  `cofx-run-no-arg-omits-arg-tag`'s `(not (contains? (:tags run) :rf.cofx/arg))`,
+  where `run` is nil and `contains?` of nil is false for every key.
+
+  ONE DEFTEST HERE IS NOW PROVED BY THE LANE RATHER THAN BY ITS OWN REBIND.
+  `generated-non-edn-value-is-rejected-in-production` establishes its posture
+  with `(with-redefs [interop/debug-enabled? false] ...)`. A `with-redefs`
+  cannot reach a load-time gate, so that was always the weaker instrument;
+  with this namespace on the prod-gate roster the whole file — this deftest
+  included — runs with the REAL `-Dre-frame.debug=false` gate, and the rebind
+  becomes a no-op over a posture that already holds. Kept as documentation of
+  intent."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
@@ -55,6 +109,23 @@
   (let [acc (atom [])]
     (rf/register-listener! :trace id (fn [ev] (swap! acc conj ev)))
     acc))
+
+(defn- collect-errors!
+  "ALWAYS-ON (rf2-d2841): register an `:errors`-stream listener under `id`,
+  returning the atom that accumulates the tight records the corpus-wide
+  `error-emit/dispatch-on-error!` registry fans. NOT gated on
+  `interop/debug-enabled?` — this is axis 1, the channel that survives CLJS
+  `:advanced` + `goog.DEBUG=false`. Tests must
+  `(rf/unregister-listener! :errors id)` to detach."
+  [id]
+  (let [acc (atom [])]
+    (rf/register-listener! :errors id (fn [rec] (swap! acc conj rec)))
+    acc))
+
+(defn- errors-of
+  "The always-on records fanned for `category`."
+  [recs category]
+  (filterv #(= category (:error %)) recs))
 
 ;; ===========================================================================
 ;; 1. Value-returning reg-cofx + ambient delivery
@@ -285,47 +356,81 @@
             originating event carries :rf.cofx in the canonical FLAT slot, and
             its :rf/time-ms is FRESHLY stamped — distinct from the originating
             request token's scripted value (NOT inherited)."
-    (let [traces (collect-traces! ::reply-cofx)]
+    ;; ALWAYS-ON (rf2-d2841): the canonical complete `:rf.cofx` record is
+    ;; staged FLAT into each handler's own coeffects map (a key the runtime
+    ;; injects, not declarable, read via `:as`) — production state, not a
+    ;; trace tag. `generator-runs-at-processing-start-fills-and-records`
+    ;; already relies on that channel. So every claim below about flat shape,
+    ;; fresh stamping and non-inheritance is asserted on the two handlers'
+    ;; OWN tokens and runs in BOTH postures; the identical trace-tag reads
+    ;; are kept, verbatim, behind the guard.
+    (let [traces         (collect-traces! ::reply-cofx)
+          request-record (atom ::unset)
+          reply-record   (atom ::unset)]
       ;; The originating ("request") event: scripted with a fixed causal
       ;; :rf/time-ms so we can prove the reply does NOT inherit it. Its
       ;; handler dispatches the completion ("reply") event — the reply
       ;; envelope re-enters build-envelope and is stamped fresh.
       (rf/reg-event :cofx-test/request
-        (fn [_ _]
+        (fn [cofx _]
+          (reset! request-record (:rf.cofx cofx))
           {:fx [[:dispatch [:cofx-test/replied {:status :ok :value {:title "Welcome"}}]]]}))
-      (rf/reg-event :cofx-test/replied (fn [{:keys [db]} _] {:db db}))
+      (rf/reg-event :cofx-test/replied
+        (fn [{:keys [db] :as cofx} _]
+          (reset! reply-record (:rf.cofx cofx))
+          {:db db}))
       (rf/dispatch-sync [:cofx-test/request]
                         {:rf.cofx {:rf/time-ms 1781078400123}})
       (rf/unregister-listener! :trace ::reply-cofx)
-      (let [dispatched   (filter #(= :rf.event/dispatched (:operation %)) @traces)
-            request-env  (first (filter #(= :cofx-test/request
-                                            (first (get-in % [:tags :rf.event/v])))
-                                        dispatched))
-            reply-env    (first (filter #(= :cofx-test/replied
-                                            (first (get-in % [:tags :rf.event/v])))
-                                        dispatched))
-            request-cofx (get-in request-env [:tags :rf.cofx])
-            reply-cofx   (get-in reply-env   [:tags :rf.cofx])]
-        (is (some? request-env) "the originating request event was dispatched")
-        (is (some? reply-env)   "the completion / reply event was dispatched")
-        ;; (a) the reply envelope carries :rf.cofx, present and a FLAT map
-        (is (map? reply-cofx)
-            "the reply envelope carries :rf.cofx in the canonical slot, a flat map")
-        (is (contains? reply-cofx :rf/time-ms)
-            "the reply's :rf.cofx carries :rf/time-ms flat (fact-name → value, no grouping)")
-        ;; (c) FLAT shape: every value is a leaf under an owner-qualified key,
-        ;; not a grouping sub-map (the retired grouped shape would nest here).
-        (is (every? (complement map?) (vals reply-cofx))
-            "the reply's :rf.cofx is FLAT — no value is a grouping sub-map")
-        ;; (b) freshly stamped: the reply's :rf/time-ms is a real epoch-ms
-        ;; integer and is DISTINCT from the request token's scripted value —
-        ;; the child stamps its OWN causal time (`:rf.cofx` is not inherited).
-        (is (integer? (:rf/time-ms reply-cofx))
-            "the reply's :rf/time-ms is a freshly stamped epoch-ms integer")
-        (is (= 1781078400123 (:rf/time-ms request-cofx))
-            "the request token kept its scripted :rf/time-ms verbatim")
-        (is (not= (:rf/time-ms request-cofx) (:rf/time-ms reply-cofx))
-            "the reply STAMPS ITS OWN :rf/time-ms — it does NOT inherit the originating request's causal token")))))
+      ;; -- always-on: the same three claims, off the delivered tokens -------
+      (is (map? @request-record) "the originating request event ran and carries :rf.cofx")
+      (is (map? @reply-record)   "the completion / reply event ran and carries :rf.cofx")
+      ;; (a)+(c) the reply's record is present and FLAT — no value is a
+      ;; grouping sub-map. VACUOUS PASS REMOVED (class 1): the trace-side
+      ;; twin of this claim read `(vals nil)`, and `every?` over nil is TRUE,
+      ;; so the retired-grouped-shape regression pin passed on nothing.
+      (is (contains? @reply-record :rf/time-ms)
+          "the reply's :rf.cofx carries :rf/time-ms flat (fact-name -> value, no grouping)")
+      (is (every? (complement map?) (vals @reply-record))
+          "the reply's :rf.cofx is FLAT — no value is a grouping sub-map")
+      ;; (b) freshly stamped and NOT inherited.
+      (is (integer? (:rf/time-ms @reply-record))
+          "the reply's :rf/time-ms is a freshly stamped epoch-ms integer")
+      (is (= 1781078400123 (:rf/time-ms @request-record))
+          "the request token kept its scripted :rf/time-ms verbatim")
+      (is (not= (:rf/time-ms @request-record) (:rf/time-ms @reply-record))
+          "the reply STAMPS ITS OWN :rf/time-ms — it does NOT inherit the originating request's causal token")
+      ;; -- dev-only: the same tokens as seen on the dispatch trace ---------
+      (when interop/debug-enabled?
+        (let [dispatched   (filter #(= :rf.event/dispatched (:operation %)) @traces)
+              request-env  (first (filter #(= :cofx-test/request
+                                              (first (get-in % [:tags :rf.event/v])))
+                                          dispatched))
+              reply-env    (first (filter #(= :cofx-test/replied
+                                              (first (get-in % [:tags :rf.event/v])))
+                                          dispatched))
+              request-cofx (get-in request-env [:tags :rf.cofx])
+              reply-cofx   (get-in reply-env   [:tags :rf.cofx])]
+          (is (some? request-env) "the originating request event was dispatched")
+          (is (some? reply-env)   "the completion / reply event was dispatched")
+          ;; (a) the reply envelope carries :rf.cofx, present and a FLAT map
+          (is (map? reply-cofx)
+              "the reply envelope carries :rf.cofx in the canonical slot, a flat map")
+          (is (contains? reply-cofx :rf/time-ms)
+              "the reply's :rf.cofx carries :rf/time-ms flat (fact-name → value, no grouping)")
+          ;; (c) FLAT shape: every value is a leaf under an owner-qualified key,
+          ;; not a grouping sub-map (the retired grouped shape would nest here).
+          (is (every? (complement map?) (vals reply-cofx))
+              "the reply's :rf.cofx is FLAT — no value is a grouping sub-map")
+          ;; (b) freshly stamped: the reply's :rf/time-ms is a real epoch-ms
+          ;; integer and is DISTINCT from the request token's scripted value —
+          ;; the child stamps its OWN causal time (`:rf.cofx` is not inherited).
+          (is (integer? (:rf/time-ms reply-cofx))
+              "the reply's :rf/time-ms is a freshly stamped epoch-ms integer")
+          (is (= 1781078400123 (:rf/time-ms request-cofx))
+              "the request token kept its scripted :rf/time-ms verbatim")
+          (is (not= (:rf/time-ms request-cofx) (:rf/time-ms reply-cofx))
+              "the reply STAMPS ITS OWN :rf/time-ms — it does NOT inherit the originating request's causal token"))))))
 
 ;; ===========================================================================
 ;; 4. Strict-replay missing-required fails loudly (ADVERSARIAL)
@@ -337,6 +442,7 @@
             cascade halts before the handler runs (strict-replay loud failure;
             EP-0017 §5)"
     (let [traces (collect-traces! ::missing)
+          recs   (collect-errors! ::missing)
           fired? (atom false)]
       (rf/reg-cofx :cofx-test/required-boundary
         {:recordable? true :provided? true})
@@ -347,17 +453,31 @@
       (let [ex (try (rf/dispatch-sync [:cofx-test/needs-boundary]) nil
                     (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e e))]
         (rf/unregister-listener! :trace ::missing)
+        (rf/unregister-listener! :errors ::missing)
         (is (false? @fired?)
             "the handler never ran — missing-required halts the cascade")
         (is (some? ex)
             "the dispatch threw rather than silently re-reading the host")
         (is (= :rf.error/missing-required-cofx (:rf.error/id (ex-data ex)))
             "the throw carries :rf.error/missing-required-cofx")
-        (let [errs (filter #(= :rf.error/missing-required-cofx (:operation %)) @traces)]
-          (is (= 1 (count errs)) "exactly one missing-required-cofx error trace")
-          (is (= :cofx-test/required-boundary
-                 (get-in (first errs) [:tags :rf.cofx/id]))
-              ":rf.cofx/id names the absent fact"))))))
+        ;; ALWAYS-ON (rf2-d2841): the CATEGORY is promoted —
+        ;; `emit-missing-required-cofx!` fans through
+        ;; `error-emit/emit-error-both!` — so "exactly one fired, and it names
+        ;; the declaring event" is provable on the shipping channel. What does
+        ;; NOT survive is `:rf.cofx/id`: this site passes `failing-id` as both
+        ;; the failing id AND the event-id, so the lift never fires and an
+        ;; off-box shipper learns WHICH EVENT, never WHICH FACT.
+        (let [prod (errors-of @recs :rf.error/missing-required-cofx)]
+          (is (= 1 (count prod))
+              "exactly one always-on missing-required-cofx record")
+          (is (= :cofx-test/needs-boundary (:event-id (first prod)))
+              ":event-id names the declaring event on the tight record"))
+        (when interop/debug-enabled?
+          (let [errs (filter #(= :rf.error/missing-required-cofx (:operation %)) @traces)]
+            (is (= 1 (count errs)) "exactly one missing-required-cofx error trace")
+            (is (= :cofx-test/required-boundary
+                   (get-in (first errs) [:tags :rf.cofx/id]))
+                ":rf.cofx/id names the absent fact")))))))
 
 ;; ===========================================================================
 ;; 5. typo→unregistered vs declared-absent→missing-required SPLIT (ADVERSARIAL)
@@ -368,7 +488,8 @@
             typo case) is `:rf.error/unregistered-cofx` — DISTINCT from
             `:rf.error/missing-required-cofx` (a registered-but-absent provided
             fact). The two-error split is the EP-0017 §7 contract."
-    (let [traces (collect-traces! ::typo)]
+    (let [traces (collect-traces! ::typo)
+          recs   (collect-errors! ::typo)]
       ;; :cofx-test/typpo is NOT registered anywhere — a typo.
       (rf/reg-event :cofx-test/has-typo
         {:rf.cofx/requires [:cofx-test/typpo]}
@@ -376,14 +497,26 @@
       (let [ex (try (rf/dispatch-sync [:cofx-test/has-typo]) nil
                     (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e e))]
         (rf/unregister-listener! :trace ::typo)
+        (rf/unregister-listener! :errors ::typo)
         (is (= :rf.error/unregistered-cofx (:rf.error/id (ex-data ex)))
             "an unregistered (typo'd) id is :rf.error/unregistered-cofx, NOT missing-required")
-        (let [errs (filter #(= :rf.error/unregistered-cofx (:operation %)) @traces)]
-          (is (= 1 (count errs)) "exactly one unregistered-cofx trace")
-          (is (= :cofx-test/typpo (get-in (first errs) [:tags :rf.cofx/id]))
-              ":rf.cofx/id names the unregistered id")
-          (is (= :cofx-test/has-typo (get-in (first errs) [:tags :failing-id]))
-              ":failing-id names the declaring handler"))))))
+        ;; ALWAYS-ON (rf2-d2841): the promoted half of the EP-0017 §7 SPLIT —
+        ;; the two categories are distinguishable on the shipping channel, not
+        ;; only on the dev trace, which is what makes the split useful to an
+        ;; off-box shipper at all.
+        (let [prod (errors-of @recs :rf.error/unregistered-cofx)]
+          (is (= 1 (count prod)) "exactly one always-on unregistered-cofx record")
+          (is (empty? (errors-of @recs :rf.error/missing-required-cofx))
+              "and NOT a missing-required record — the split survives to production")
+          (is (= :cofx-test/has-typo (:event-id (first prod)))
+              ":event-id names the declaring handler on the tight record"))
+        (when interop/debug-enabled?
+          (let [errs (filter #(= :rf.error/unregistered-cofx (:operation %)) @traces)]
+            (is (= 1 (count errs)) "exactly one unregistered-cofx trace")
+            (is (= :cofx-test/typpo (get-in (first errs) [:tags :rf.cofx/id]))
+                ":rf.cofx/id names the unregistered id")
+            (is (= :cofx-test/has-typo (get-in (first errs) [:tags :failing-id]))
+                ":failing-id names the declaring handler")))))))
 
 (deftest registered-absent-vs-unregistered-are-different-errors
   (testing "the split is real: a REGISTERED-but-absent provided fact →
@@ -605,20 +738,29 @@
       ;; storage key; the produced value is what it reads back.
       (rf/reg-cofx :cofx-test/local-pref
         (fn [storage-key] (str "value-for-" storage-key)))
-      (rf/reg-event :cofx-test/read-pref
-        {:rf.cofx/requires [[:cofx-test/local-pref "theme"]]}
-        (fn [_ _] {}))
-      (rf/dispatch-sync [:cofx-test/read-pref])
-      (rf/unregister-listener! :trace ::run-tags)
-      (let [runs (filter #(= :rf.cofx/run (:operation %)) @traces)
-            run  (first (filter #(= :cofx-test/local-pref
-                                    (get-in % [:tags :rf.cofx/id]))
-                                runs))]
-        (is (some? run) "the parameterized supplier emitted a :rf.cofx/run op")
-        (is (= "value-for-theme" (get-in run [:tags :rf.cofx/value]))
-            ":rf.cofx/value is the PRODUCED value, not the requirement-arg")
-        (is (= "theme" (get-in run [:tags :rf.cofx/arg]))
-            "the requirement-arg rides the distinct :rf.cofx/arg tag")))))
+      ;; ALWAYS-ON (rf2-d2841): `:rf.cofx/value` is by definition "the
+      ;; coeffect that egresses", so the handler that RECEIVES it witnesses
+      ;; the tag's subject without the trace. The arg/value distinction the
+      ;; deftest is really about shows up there too: the delivered value is
+      ;; the supplier's OUTPUT ("value-for-theme"), never the declared arg.
+      (let [delivered (atom ::unset)]
+        (rf/reg-event :cofx-test/read-pref
+          {:rf.cofx/requires [[:cofx-test/local-pref "theme"]]}
+          (fn [{:keys [cofx-test/local-pref]} _] (reset! delivered local-pref) {}))
+        (rf/dispatch-sync [:cofx-test/read-pref])
+        (rf/unregister-listener! :trace ::run-tags)
+        (is (= "value-for-theme" @delivered)
+            "the PRODUCED value egressed into the coeffects — not the arg \"theme\"")
+        (when interop/debug-enabled?
+          (let [runs (filter #(= :rf.cofx/run (:operation %)) @traces)
+                run  (first (filter #(= :cofx-test/local-pref
+                                        (get-in % [:tags :rf.cofx/id]))
+                                    runs))]
+            (is (some? run) "the parameterized supplier emitted a :rf.cofx/run op")
+            (is (= "value-for-theme" (get-in run [:tags :rf.cofx/value]))
+                ":rf.cofx/value is the PRODUCED value, not the requirement-arg")
+            (is (= "theme" (get-in run [:tags :rf.cofx/arg]))
+                "the requirement-arg rides the distinct :rf.cofx/arg tag")))))))
 
 (deftest cofx-run-no-arg-omits-arg-tag
   (testing "a bare (no-arg) ambient supplier stamps `:rf.cofx/value` (the
@@ -626,19 +768,28 @@
             the prior arg-omission on the 1-arity path)"
     (let [traces (collect-traces! ::run-noarg)]
       (rf/reg-cofx :cofx-test/locale2 (fn [] "en-AU"))
-      (rf/reg-event :cofx-test/read-locale2
-        {:rf.cofx/requires [:cofx-test/locale2]}
-        (fn [_ _] {}))
-      (rf/dispatch-sync [:cofx-test/read-locale2])
-      (rf/unregister-listener! :trace ::run-noarg)
-      (let [run (first (filter #(and (= :rf.cofx/run (:operation %))
-                                     (= :cofx-test/locale2
-                                        (get-in % [:tags :rf.cofx/id])))
-                               @traces))]
-        (is (some? run))
-        (is (= "en-AU" (get-in run [:tags :rf.cofx/value])))
-        (is (not (contains? (:tags run) :rf.cofx/arg))
-            "no requirement-arg ⇒ :rf.cofx/arg is omitted")))))
+      ;; ALWAYS-ON (rf2-d2841): the produced value egresses into the
+      ;; coeffects on the 0-arity path too. VACUOUS PASS REMOVED (class 4):
+      ;; `(not (contains? (:tags run) :rf.cofx/arg))` was true for free under
+      ;; the gate, where `run` is nil and `contains?` of nil is false for
+      ;; EVERY key — the arg-omission pin certified nothing.
+      (let [delivered (atom ::unset)]
+        (rf/reg-event :cofx-test/read-locale2
+          {:rf.cofx/requires [:cofx-test/locale2]}
+          (fn [{:keys [cofx-test/locale2]} _] (reset! delivered locale2) {}))
+        (rf/dispatch-sync [:cofx-test/read-locale2])
+        (rf/unregister-listener! :trace ::run-noarg)
+        (is (= "en-AU" @delivered)
+            "the bare supplier's produced value egressed into the coeffects")
+        (when interop/debug-enabled?
+          (let [run (first (filter #(and (= :rf.cofx/run (:operation %))
+                                         (= :cofx-test/locale2
+                                            (get-in % [:tags :rf.cofx/id])))
+                                   @traces))]
+            (is (some? run))
+            (is (= "en-AU" (get-in run [:tags :rf.cofx/value])))
+            (is (not (contains? (:tags run) :rf.cofx/arg))
+                "no requirement-arg ⇒ :rf.cofx/arg is omitted")))))))
 
 (deftest cofx-run-sensitive-produced-value-is-redacted-end-to-end
   (testing "a sensitive PRODUCED value from a real ambient supplier is
@@ -653,20 +804,30 @@
       (rf/reg-cofx :cofx-test/session
         {:sensitive [[:token]]}
         (fn [] {:token "super-secret-jwt" :public "ok"}))
-      (rf/reg-event :cofx-test/read-session
-        {:rf.cofx/requires [:cofx-test/session]}
-        (fn [_ _] {}))
-      (rf/dispatch-sync [:cofx-test/read-session])
-      (rf/unregister-listener! :trace ::run-redact)
-      (let [run (first (filter #(and (= :rf.cofx/run (:operation %))
-                                     (= :cofx-test/session
-                                        (get-in % [:tags :rf.cofx/id])))
-                               @traces))]
-        (is (some? run) "the supplier emitted a :rf.cofx/run op")
-        (is (= :rf/redacted (get-in run [:tags :rf.cofx/value :token]))
-            "the sensitive sub-path of the PRODUCED value is redacted on the trace")
-        (is (= "ok" (get-in run [:tags :rf.cofx/value :public]))
-            "non-sensitive sub-paths pass through")))))
+      ;; ALWAYS-ON (rf2-d2841): redaction is an EGRESS transform, so it must
+      ;; leave the DELIVERED coeffect intact — a `:sensitive` declaration
+      ;; that silently corrupted the value the handler works with would be a
+      ;; far worse defect than an unredacted trace. That complement had no
+      ;; coverage anywhere and now runs in both postures.
+      (let [delivered (atom ::unset)]
+        (rf/reg-event :cofx-test/read-session
+          {:rf.cofx/requires [:cofx-test/session]}
+          (fn [{:keys [cofx-test/session]} _] (reset! delivered session) {}))
+        (rf/dispatch-sync [:cofx-test/read-session])
+        (rf/unregister-listener! :trace ::run-redact)
+        (is (= {:token "super-secret-jwt" :public "ok"} @delivered)
+            "the marks chokepoint redacts the EGRESSING trace stamp, never the
+             coeffect the handler is handed")
+        (when interop/debug-enabled?
+          (let [run (first (filter #(and (= :rf.cofx/run (:operation %))
+                                         (= :cofx-test/session
+                                            (get-in % [:tags :rf.cofx/id])))
+                                   @traces))]
+            (is (some? run) "the supplier emitted a :rf.cofx/run op")
+            (is (= :rf/redacted (get-in run [:tags :rf.cofx/value :token]))
+                "the sensitive sub-path of the PRODUCED value is redacted on the trace")
+            (is (= "ok" (get-in run [:tags :rf.cofx/value :public]))
+                "non-sensitive sub-paths pass through")))))))
 
 ;; ===========================================================================
 ;; 7. inject-cofx is REMOVED — hard error :rf.error/inject-cofx-removed
@@ -716,17 +877,27 @@
       ;; opt, not a dedicated hard error.
       (rf/dispatch-sync [:cofx-test/wi-renamed] {:rf.world/inputs {:rf/time-ms 1}})
       (rf/unregister-listener! :trace ::wi)
-      (let [warns (filterv (fn [ev]
-                             (and (= :warning (:op-type ev))
-                                  (= :rf.warning/unknown-dispatch-opt (:operation ev))))
-                           @traces)]
-        (is (= 1 (count warns))
-            "the retired draft key trips the generic unknown-dispatch-opt warning")
-        (let [t (:tags (first warns))]
-          (is (contains? (set (:unknown-keys t)) :rf.world/inputs)
-              "the retired key is named as an unknown opt")
-          (is (re-find #":rf\.cofx" (:reason t))
-              "the warning message appends a did-you-mean naming :rf.cofx"))))))
+      ;; ALWAYS-ON (rf2-d2841): "the dispatch PROCEEDS (no throw)" is half the
+      ;; claim in the docstring and is pure production behaviour — it is the
+      ;; whole difference between the generic unknown-opt surface and a
+      ;; dedicated hard error. It had no assertion at all before this; the
+      ;; handler's write is the witness that the retired draft key was
+      ;; tolerated rather than fatal.
+      (is (true? (:ran (rf/app-db-value :rf/default)))
+          "the retired draft key did NOT halt the dispatch — the handler ran
+           and its write committed")
+      (when interop/debug-enabled?
+        (let [warns (filterv (fn [ev]
+                               (and (= :warning (:op-type ev))
+                                    (= :rf.warning/unknown-dispatch-opt (:operation ev))))
+                             @traces)]
+          (is (= 1 (count warns))
+              "the retired draft key trips the generic unknown-dispatch-opt warning")
+          (let [t (:tags (first warns))]
+            (is (contains? (set (:unknown-keys t)) :rf.world/inputs)
+                "the retired key is named as an unknown opt")
+            (is (re-find #":rf\.cofx" (:reason t))
+                "the warning message appends a did-you-mean naming :rf.cofx")))))))
 
 ;; ===========================================================================
 ;; 9. :platforms gating on ambient suppliers (preserved from the prior model)
@@ -763,9 +934,15 @@
           (is (false? @cofx-fired?) "the client-only supplier did NOT run on :server")
           (is (true? @event-fired?) "the event still ran — only the supplier was skipped")
           (is (false? @seen) "the skipped fact was NOT delivered flat")
-          (let [skips (filter #(= :rf.cofx/skipped-on-platform (:operation %)) @traces)]
-            (is (= 1 (count skips)) "exactly one skipped-on-platform trace")
-            (is (= :cofx-test/browser-locale (get-in (first skips) [:tags :rf.cofx/id])))))
+          ;; The three assertions above are the always-on half and were
+          ;; already posture-independent: the supplier's own side effect did
+          ;; not fire, the event ran anyway, and the fact was not delivered.
+          ;; `:rf.cofx/skipped-on-platform` is a dev-trace op with no promoted
+          ;; counterpart (it is not an error category), so it is guarded.
+          (when interop/debug-enabled?
+            (let [skips (filter #(= :rf.cofx/skipped-on-platform (:operation %)) @traces)]
+              (is (= 1 (count skips)) "exactly one skipped-on-platform trace")
+              (is (= :cofx-test/browser-locale (get-in (first skips) [:tags :rf.cofx/id]))))))
         (finally
           (rf/init-platform host-default))))))
 
@@ -902,22 +1079,39 @@
       (rf/reg-cofx :gen-test/traced
         {:recordable? true}
         (fn [] 42))
-      (rf/reg-event :gen-test/traced-evt
-        {:rf.cofx/requires [:gen-test/traced]}
-        (fn [_ _] {}))
-      (rf/dispatch-sync [:gen-test/traced-evt])
-      (rf/unregister-listener! :trace ::generated)
-      (let [gens (filter #(= :rf.cofx/generated (:operation %)) @traces)
-            runs (filter #(= :rf.cofx/run (:operation %)) @traces)]
-        (is (= 1 (count gens)) "exactly one :rf.cofx/generated op")
-        (is (empty? runs)
-            "a generated recordable fact does NOT emit the ambient :rf.cofx/run op")
-        (let [gen (first gens)]
-          (is (= :rf.cofx (:op-type gen)) "the op rides the :rf.cofx family")
-          (is (= :gen-test/traced (get-in gen [:tags :rf.cofx/id]))
-              ":rf.cofx/id names the generated fact + supplier id")
-          (is (= 42 (get-in gen [:tags :rf.cofx/value]))
-              ":rf.cofx/value carries the produced value"))))))
+      ;; ALWAYS-ON (rf2-d2841): the GENERATION the op reports — the value was
+      ;; minted, delivered flat, and written back into the durable causal
+      ;; record. That write-back is the reason the op exists (replay reads it).
+      ;; VACUOUS PASS REMOVED (class 1): `(empty? runs)` certified that a
+      ;; generated fact does NOT also take the ambient `:rf.cofx/run` path,
+      ;; over a stream carrying no ops of any kind. Under the gate that
+      ;; discrimination cannot be made at all, so it is guarded rather than
+      ;; left to pass for free.
+      (let [delivered (atom ::unset)
+            record    (atom ::unset)]
+        (rf/reg-event :gen-test/traced-evt
+          {:rf.cofx/requires [:gen-test/traced]}
+          (fn [{:keys [gen-test/traced] :as cofx} _]
+            (reset! delivered traced)
+            (reset! record (:rf.cofx cofx))
+            {}))
+        (rf/dispatch-sync [:gen-test/traced-evt])
+        (rf/unregister-listener! :trace ::generated)
+        (is (= 42 @delivered) "the generated value was delivered flat")
+        (is (= 42 (:gen-test/traced @record))
+            "and written back into the durable causal record the op reports")
+        (when interop/debug-enabled?
+          (let [gens (filter #(= :rf.cofx/generated (:operation %)) @traces)
+                runs (filter #(= :rf.cofx/run (:operation %)) @traces)]
+            (is (= 1 (count gens)) "exactly one :rf.cofx/generated op")
+            (is (empty? runs)
+                "a generated recordable fact does NOT emit the ambient :rf.cofx/run op")
+            (let [gen (first gens)]
+              (is (= :rf.cofx (:op-type gen)) "the op rides the :rf.cofx family")
+              (is (= :gen-test/traced (get-in gen [:tags :rf.cofx/id]))
+                  ":rf.cofx/id names the generated fact + supplier id")
+              (is (= 42 (get-in gen [:tags :rf.cofx/value]))
+                  ":rf.cofx/value carries the produced value"))))))))
 
 (deftest generated-value-schema-mismatch-is-hard-error
   (testing "ADVERSARIAL: a generated value that fails the registration's
@@ -932,6 +1126,7 @@
       (fn [schema value] {:schema schema :value value :failed true})
       (fn []
         (let [traces (collect-traces! ::bad-gen)
+              recs   (collect-errors! ::bad-gen)
               fired? (atom false)]
           (rf/reg-cofx :gen-test/bad
             {:recordable? true :schema :gen-test/positive}
@@ -943,6 +1138,7 @@
                         (catch #?(:clj clojure.lang.ExceptionInfo
                                   :cljs cljs.core/ExceptionInfo) e e))]
             (rf/unregister-listener! :trace ::bad-gen)
+            (rf/unregister-listener! :errors ::bad-gen)
             (is (false? @fired?)
                 "the handler never ran — a schema-invalid generated value halts the cascade")
             (is (some? ex) "the dispatch threw rather than folding the bad value")
@@ -950,10 +1146,20 @@
                 "the throw carries :rf.error/cofx-value-invalid")
             (is (= :gen-test/bad (:rf.cofx/id (ex-data ex)))
                 ":rf.cofx/id names the offending fact")
-            (let [errs (filter #(= :rf.error/cofx-value-invalid (:operation %)) @traces)]
-              (is (= 1 (count errs)) "exactly one cofx-value-invalid error trace")
-              (is (= :gen-test/bad (get-in (first errs) [:tags :rf.cofx/id]))
-                  "the error trace names the fact"))))))))
+            ;; ALWAYS-ON (rf2-d2841): the category is promoted through
+            ;; `emit-cofx-value-invalid!` -> `emit-error-both!`, so a
+            ;; schema-invalid mint is visible to an off-box shipper. The
+            ;; `:rf.cofx/id` naming survives only on the ex-data (asserted
+            ;; above) and the dev trace (guarded below) — not the record.
+            (let [prod (errors-of @recs :rf.error/cofx-value-invalid)]
+              (is (= 1 (count prod)) "exactly one always-on cofx-value-invalid record")
+              (is (= :gen-test/uses-bad (:event-id (first prod)))
+                  ":event-id names the declaring event on the tight record"))
+            (when interop/debug-enabled?
+              (let [errs (filter #(= :rf.error/cofx-value-invalid (:operation %)) @traces)]
+                (is (= 1 (count errs)) "exactly one cofx-value-invalid error trace")
+                (is (= :gen-test/bad (get-in (first errs) [:tags :rf.cofx/id]))
+                    "the error trace names the fact")))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 12b. STRUCTURAL-EDN check of the GENERATED value (rf2-rmroo4 slice B /
@@ -975,6 +1181,7 @@
             value is written back into the durable `:rf.cofx` record and BEFORE
             the handler runs. EP-0017:386."
     (let [traces    (collect-traces! ::gen-non-edn)
+          recs      (collect-errors! ::gen-non-edn)
           gen-calls (atom 0)
           fired?    (atom false)]
       ;; Generator-backed recordable fact (recordable, NOT provided, with a
@@ -991,6 +1198,7 @@
                     (catch #?(:clj clojure.lang.ExceptionInfo
                               :cljs cljs.core/ExceptionInfo) e e))]
         (rf/unregister-listener! :trace ::gen-non-edn)
+        (rf/unregister-listener! :errors ::gen-non-edn)
         (is (= 1 @gen-calls) "the generator ran (the value is checked AFTER it mints)")
         (is (false? @fired?)
             "the handler never ran — a non-EDN generated value halts the cascade")
@@ -1005,12 +1213,21 @@
             "the reported path is rooted at the fact id (the bad leaf is the value itself)")
         (is (some? (:bad-type (ex-data ex)))
             "the host :bad-type is surfaced (a printable type name, never the raw object)")
-        (let [errs (filter #(= :rf.error/cofx-value-invalid (:operation %)) @traces)]
-          (is (= 1 (count errs)) "exactly one cofx-value-invalid error trace")
-          (is (= :non-edn-recordable-value (get-in (first errs) [:tags :reason]))
-              "the trace carries the structural-EDN reason")
-          (is (= :gen-test/host-handle (get-in (first errs) [:tags :rf.cofx/id]))
-              "the trace names the fact"))))))
+        ;; ALWAYS-ON (rf2-d2841): rf2-q34j26 makes this an ALWAYS-ON hard
+        ;; error, so its record must reach the shipping channel too — a
+        ;; non-EDN value halted before write-back is exactly the failure an
+        ;; off-box shipper needs to see in production.
+        (let [prod (errors-of @recs :rf.error/cofx-value-invalid)]
+          (is (= 1 (count prod)) "exactly one always-on cofx-value-invalid record")
+          (is (= :gen-test/uses-host-handle (:event-id (first prod)))
+              ":event-id names the declaring event on the tight record"))
+        (when interop/debug-enabled?
+          (let [errs (filter #(= :rf.error/cofx-value-invalid (:operation %)) @traces)]
+            (is (= 1 (count errs)) "exactly one cofx-value-invalid error trace")
+            (is (= :non-edn-recordable-value (get-in (first errs) [:tags :reason]))
+                "the trace carries the structural-EDN reason")
+            (is (= :gen-test/host-handle (get-in (first errs) [:tags :rf.cofx/id]))
+                "the trace names the fact")))))))
 
 (deftest generated-non-edn-value-is-rejected-in-production
   (testing "ADVERSARIAL (rf2-q34j26 — EP-0017 Open Issue 9): the structural-EDN

--- a/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
+++ b/implementation/core/test/re_frame/frame_destroy_incarnation_jvm_test.clj
@@ -1,5 +1,59 @@
 (ns re-frame.frame-destroy-incarnation-jvm-test
-  "Deterministic JVM barriers for incarnation-owned frame teardown."
+  "Deterministic JVM barriers for incarnation-owned frame teardown.
+
+  ## Posture split (rf2-d2841)
+
+  THE EPOCH SUBSYSTEM IS TRACE-FED, AND THAT IS THE WHOLE STORY HERE.
+  `epoch.capture/observe-trace-event!` fills the capture buffer from the DEV
+  TRACE, so under `-Dre-frame.debug=false` no buffer fills, `epoch/settle!`
+  never builds a record, `rf/epoch-history` stays empty,
+  `epoch-state/buffer-for` stays empty, and no `:rf.epoch/*` /
+  `:rf.epoch.cb/*` trace fact is ever emitted. Every read of those stores is
+  therefore guarded.
+
+  What survives, and what these barriers are ACTUALLY about, is the
+  incarnation fence itself: which token is live, whose db write commits, whose
+  child dispatch is scheduled, and which corpus-wide `:errors` record ships.
+  All of that is production behaviour and stays outside the guard. The class
+  of defect this file exists to catch — a destroyed incarnation leaking into
+  a same-id successor and MUTATING it — is pinned by the token / app-db /
+  cleanup-count assertions, and those now run under the gate for the first
+  time.
+
+  TWO SCENARIOS ARE DEV-ONLY END TO END and are guarded wholesale, because
+  their DRIVER does not exist in this posture, not merely their observation:
+
+  - `epoch-digest-owner-loss-cannot-publish-into-successor` destroys A from
+    inside the `:schemas/app-schemas-digest` late-bind hook. That hook is
+    reached only from `epoch/settle!` (via `assembly/current-schema-digest`),
+    which the empty capture buffer never calls — checked by running: the
+    fixture's `CountDownLatch` await TIMED OUT under the gate, so A was never
+    destroyed at all and the deftest's four negatives passed over a scenario
+    that had not happened.
+  - the two `vf2qke` deftests are driven by a public TRACE listener reacting
+    to `:rf.epoch.cb/silenced-on-frame-destroy`. No such fact is emitted under
+    the gate, so the listener never fires and the nested cascade it is about
+    never runs.
+
+  ONE CLAIM WAS PROMOTED RATHER THAN GUARDED. A throwing teardown hook already
+  ships a bounded always-on `:rf.error/frame-teardown-failed` record whose
+  `:hook-failures` NAMES the failing hook — `stale-teardown-report-is-corpus-
+  only-after-successor-install` and `snapshot-hook-failure-still-publishes-
+  reports-and-spares-successor` both read it already. The two
+  `*-hook-exception-crosses-successor-no-emit` scenarios and
+  `snapshot-hook-failure-leaves-no-residual-ring` were reading only the
+  DEV-TRACE warning; they now assert the always-on report as well, so \"the
+  failing hook is named to an off-box shipper\" runs in the posture that ships.
+
+  SEVENTEEN VACUOUS PASSES CAME OFF, and their shape is uniform: a NEGATIVE
+  asserting that predecessor A's terminal evidence did NOT leak into successor
+  B's ring / buffer / history, evaluated over stores the gate never lets fill.
+  `(empty? (epoch-state/buffer-for id))`, `(empty? (rf/epoch-history id))`,
+  `(= b-ring-before (rf/trace-buffer id {:flat true}))` and their siblings are
+  all true for free when both sides are empty. Those are the assertions this
+  file most wants to be honest — a leak audit that passes because nothing was
+  ever recorded certifies nothing — so every one of them is now inside the
+  guard, next to the precondition that licenses it."
   (:require [clojure.set :as set]
             [clojure.test :refer [deftest is use-fixtures]]
             [re-frame.core :as rf]
@@ -288,21 +342,26 @@
               "A's returned db effect cannot mutate B")
           (is (zero? @child-runs)
               "A's returned child dispatch is not scheduled against B")
-          (is (= history-b (rf/epoch-history id))
-              "A's stale tail cannot append or settle into B's history")
-          (is (empty? (epoch-state/buffer-for id))
-              "A's structural interruption bypasses B's epoch capture")
-          (let [by-op (group-by :operation @traces)]
-            (is (= 1 (count (get by-op :rf.frame/drain-interrupted)))
-                "A's structural interruption bypasses B's frame-no-emit policy")
-            (is (= [:halted-destroy]
-                   (mapv #(get-in % [:tags :outcome])
-                         (get by-op :rf.epoch/snapshotted)))
-                "A's terminal detailed epoch fact bypasses B's policy")
-            (is (= [:blocked]
-                   (mapv #(get-in % [:tags :outcome])
-                         (get by-op :rf.epoch/outcome)))
-                "A's terminal consumer outcome bypasses B's policy"))
+          ;; VACUOUS PASSES REMOVED (rf2-d2841) — class 3 and class 1: under
+          ;; the gate `history-b` and `(rf/epoch-history id)` are BOTH empty,
+          ;; so the leak audit passed on `[] = []`, and the capture buffer is
+          ;; empty for every frame, leaked-into or not.
+          (when interop/debug-enabled?
+            (is (= history-b (rf/epoch-history id))
+                "A's stale tail cannot append or settle into B's history")
+            (is (empty? (epoch-state/buffer-for id))
+                "A's structural interruption bypasses B's epoch capture")
+            (let [by-op (group-by :operation @traces)]
+              (is (= 1 (count (get by-op :rf.frame/drain-interrupted)))
+                  "A's structural interruption bypasses B's frame-no-emit policy")
+              (is (= [:halted-destroy]
+                     (mapv #(get-in % [:tags :outcome])
+                           (get by-op :rf.epoch/snapshotted)))
+                  "A's terminal detailed epoch fact bypasses B's policy")
+              (is (= [:blocked]
+                     (mapv #(get-in % [:tags :outcome])
+                           (get by-op :rf.epoch/outcome)))
+                  "A's terminal consumer outcome bypasses B's policy")))
           (rf/dispatch-sync [:destroy/event-tail-b] {:frame id})
           (is (= {:owner :b} (frame/frame-app-db-value id))
               "B remains independently usable after A's stale tail returns")))
@@ -373,10 +432,15 @@
               b-buffer     (epoch-state/buffer-for id)
               b-last-epoch (epoch-state/last-settled-epoch-id id)
               b-db         (frame/frame-app-db-value id)]
-          (is (= 1 (count b-history))
-              "B settled one ordinary event and now owns the id-keyed stores")
-          (is (some? (get-in (epoch-state/observations-snapshot) [b-observer id]))
-              "B's observer is armed before A resumes")
+          ;; The epoch preconditions and the leak audit they license are
+          ;; guarded TOGETHER (rf2-d2841). Separating a precondition from its
+          ;; claim is how `(= b-history (rf/epoch-history id))` came to certify
+          ;; "B's history is untouched" over two empty vectors.
+          (when interop/debug-enabled?
+            (is (= 1 (count b-history))
+                "B settled one ordinary event and now owns the id-keyed stores")
+            (is (some? (get-in (epoch-state/observations-snapshot) [b-observer id]))
+                "B's observer is armed before A resumes"))
 
           ;; A resumes and reaches its terminal publish while B owns the stores.
           (.countDown release-a)
@@ -384,42 +448,53 @@
               "A's terminal recipe completes")
           (executor-barrier!)
 
-          ;; A's terminal evidence is published DESPITE B owning the stores.
-          (is (= 1 (count @a-records))
-              "exactly one A :halted-destroy record reaches epoch listeners")
-          (is (= :destroy/halted-a (:event-id (first @a-records)))
-              "the terminal record is A's destroying event")
-          ;; B's ordinary settle also emits :ok trailers on the same frame id;
-          ;; scope to A's TERMINAL outcomes (B's are :ok, A's are
-          ;; :halted-destroy / :blocked).
-          (let [by-op (group-by :operation @traces)]
-            (is (= 1 (count (filter #(= :halted-destroy (get-in % [:tags :outcome]))
-                                    (get by-op :rf.epoch/snapshotted))))
-                "exactly one A :halted-destroy :rf.epoch/snapshotted is published")
-            (is (= 1 (count (filter #(= :blocked (get-in % [:tags :outcome]))
-                                    (get by-op :rf.epoch/outcome))))
-                "exactly one A blocked :rf.epoch/outcome is published"))
-
-          ;; B's stores are byte-identical: A's compare-cleanup no-op'd.
+          ;; ALWAYS-ON (rf2-d2841): the incarnation fence itself. Whatever A
+          ;; publishes, A's inert returned tail must not become B's state and
+          ;; B must remain the live incarnation — the defect class this file
+          ;; exists for, now exercised in the posture that ships.
           (is (identical? token-b (frame/frame-incarnation-token id))
               "B remains the current incarnation")
           (is (= {:owner :b} b-db)
               "A's inert returned tail never mutated B's state")
           (is (= {:owner :b} (frame/frame-app-db-value id))
               "B's state is unchanged after A resumes")
-          (is (= b-history (rf/epoch-history id))
-              "B's history is untouched by A's terminal cleanup")
-          (is (= b-buffer (epoch-state/buffer-for id))
-              "B's capture buffer is untouched")
-          (is (= b-last-epoch (epoch-state/last-settled-epoch-id id))
-              "B's last-settled anchor is untouched")
-          (is (some? (get-in (epoch-state/observations-snapshot) [b-observer id]))
-              "B's listener observation survives A's terminal cleanup")
 
-          ;; B keeps settling normally.
+          (when interop/debug-enabled?
+            ;; A's terminal evidence is published DESPITE B owning the stores.
+            (is (= 1 (count @a-records))
+                "exactly one A :halted-destroy record reaches epoch listeners")
+            (is (= :destroy/halted-a (:event-id (first @a-records)))
+                "the terminal record is A's destroying event")
+            ;; B's ordinary settle also emits :ok trailers on the same frame id;
+            ;; scope to A's TERMINAL outcomes (B's are :ok, A's are
+            ;; :halted-destroy / :blocked).
+            (let [by-op (group-by :operation @traces)]
+              (is (= 1 (count (filter #(= :halted-destroy (get-in % [:tags :outcome]))
+                                      (get by-op :rf.epoch/snapshotted))))
+                  "exactly one A :halted-destroy :rf.epoch/snapshotted is published")
+              (is (= 1 (count (filter #(= :blocked (get-in % [:tags :outcome]))
+                                      (get by-op :rf.epoch/outcome))))
+                  "exactly one A blocked :rf.epoch/outcome is published"))
+
+            ;; B's stores are byte-identical: A's compare-cleanup no-op'd.
+            ;; VACUOUS PASSES REMOVED (class 3): all four compared empty
+            ;; against empty under the gate.
+            (is (= b-history (rf/epoch-history id))
+                "B's history is untouched by A's terminal cleanup")
+            (is (= b-buffer (epoch-state/buffer-for id))
+                "B's capture buffer is untouched")
+            (is (= b-last-epoch (epoch-state/last-settled-epoch-id id))
+                "B's last-settled anchor is untouched")
+            (is (some? (get-in (epoch-state/observations-snapshot) [b-observer id]))
+                "B's listener observation survives A's terminal cleanup"))
+
+          ;; B keeps handling events normally.
           (rf/dispatch-sync [:destroy/halted-b-settle] {:frame id})
-          (is (= 2 (count (rf/epoch-history id)))
-              "B settles subsequent events normally after A resumes")))
+          (is (= {:owner :b} (frame/frame-app-db-value id))
+              "B keeps committing its own events after A resumes")
+          (when interop/debug-enabled?
+            (is (= 2 (count (rf/epoch-history id)))
+                "B settles subsequent events normally after A resumes"))))
       (finally
         (.countDown release-a)
         (epoch-state/drop-listener! b-observer)
@@ -501,20 +576,31 @@
                      :rf2-152/lx-noemit true)
         control    (run-terminal-listener-exception-scenario
                      :rf2-152/lx-plain false)]
-    (is (= 1 (count (:exceptions suppressed)))
-        "A's terminal listener-exception is delivered despite same-id B no-emit")
-    (is (= (:thrower suppressed)
-           (get-in (first (:exceptions suppressed)) [:tags :cb-id]))
-        "the diagnostic names the failing terminal listener")
-    (is (= 1 (count (:exceptions control)))
-        "the control (B no-emit disabled) also yields exactly one diagnostic")
+    ;; ALWAYS-ON (rf2-d2841): the incarnation fence. Whatever A's terminal
+    ;; fan-out does or fails to do, same-id B must still be the live
+    ;; incarnation when it returns.
     (is (true? (:b-token-ok? suppressed))
         "same-id B remains the live incarnation through A's terminal fan-out")
-    (is (empty? (filter #(= :rf.epoch.cb/listener-exception (:operation %))
-                        (:b-buffer suppressed)))
-        "A's diagnostic never enters B's epoch capture buffer")
-    (is (empty? (:b-history suppressed))
-        "no A diagnostic is recorded into B's history")))
+    (is (true? (:b-token-ok? control))
+        "and in the control, where B did not enable no-emit")
+    ;; The `:rf.epoch.cb/listener-exception` diagnostic is a dev-trace fact
+    ;; with no promoted counterpart, and the epoch record that TRIGGERS the
+    ;; throwing listener is itself trace-fed, so this scenario is dev-only end
+    ;; to end. VACUOUS PASSES REMOVED (class 1) — the two leak audits below
+    ;; passed over a buffer and a history the gate never let fill.
+    (when interop/debug-enabled?
+      (is (= 1 (count (:exceptions suppressed)))
+          "A's terminal listener-exception is delivered despite same-id B no-emit")
+      (is (= (:thrower suppressed)
+             (get-in (first (:exceptions suppressed)) [:tags :cb-id]))
+          "the diagnostic names the failing terminal listener")
+      (is (= 1 (count (:exceptions control)))
+          "the control (B no-emit disabled) also yields exactly one diagnostic")
+      (is (empty? (filter #(= :rf.epoch.cb/listener-exception (:operation %))
+                          (:b-buffer suppressed)))
+          "A's diagnostic never enters B's epoch capture buffer")
+      (is (empty? (:b-history suppressed))
+          "no A diagnostic is recorded into B's history"))))
 
 (defn- run-terminal-teardown-hook-exception-scenario
   "Destroy A; its post-dissoc epoch teardown hook installs same-id B (with the
@@ -524,6 +610,11 @@
   (rf2-vxgfnd.152)."
   [id no-emit?]
   (let [warnings    (atom [])
+        ;; ALWAYS-ON (rf2-d2841): a failing teardown hook also ships a bounded
+        ;; corpus-wide `:rf.error/frame-teardown-failed` record whose
+        ;; `:hook-failures` names the hook. That is the channel an off-box
+        ;; shipper reads, and it survives the gate.
+        reports     (atom [])
         trace-key   (keyword "rf2-152" (str "tdtrace-" (name id)))
         original-ep (late-bind/get-fn :epoch/on-frame-destroyed)]
     (rf/make-frame {:id id})
@@ -532,6 +623,11 @@
         (when (and (= id (get-in ev [:tags :frame]))
                    (= :rf.warning/teardown-hook-exception (:operation ev)))
           (swap! warnings conj ev))))
+    (rf/register-listener! :errors trace-key
+      (fn [r]
+        (when (and (= :rf.error/frame-teardown-failed (:error r))
+                   (= id (:frame r)))
+          (swap! reports conj r))))
     (try
       (late-bind/set-fn! :epoch/on-frame-destroyed
         (fn [& args]
@@ -545,6 +641,7 @@
       (frame/destroy-frame! id)
       (executor-barrier!)
       {:warnings  @warnings
+       :reports   @reports
        :b-live?   (some? (frame/frame-incarnation-token id))
        :b-buffer  (epoch-state/buffer-for id)}
       (finally
@@ -552,6 +649,7 @@
         ;; re-enter the throwing wrapper.
         (late-bind/set-fn! :epoch/on-frame-destroyed original-ep)
         (rf/unregister-listener! :trace trace-key)
+        (rf/unregister-listener! :errors trace-key)
         (when (frame/frame id) (frame/destroy-frame! id))))))
 
 (deftest terminal-teardown-hook-exception-crosses-successor-no-emit
@@ -564,18 +662,32 @@
                      :rf2-152/td-noemit true)
         control    (run-terminal-teardown-hook-exception-scenario
                      :rf2-152/td-plain false)]
-    (is (= 1 (count (:warnings suppressed)))
-        "A's post-dissoc teardown-hook warning is delivered despite B no-emit")
+    ;; ALWAYS-ON (rf2-d2841): the bounded corpus-wide report is the shipping
+    ;; channel for exactly this failure, and it carries the hook's name. B's
+    ;; no-emit policy is a TRACE policy and must not suppress it — which is
+    ;; the deftest's thesis, now provable where it matters.
+    (is (= 1 (count (:reports suppressed)))
+        "exactly one always-on :rf.error/frame-teardown-failed ships despite B no-emit")
     (is (= :epoch/on-frame-destroyed
-           (get-in (first (:warnings suppressed)) [:tags :hook]))
-        "the warning names the failing epoch teardown hook")
-    (is (= 1 (count (:warnings control)))
-        "the control (B no-emit disabled) also yields exactly one warning")
+           (:hook (first (:hook-failures (first (:reports suppressed))))))
+        "the always-on report names the failing epoch teardown hook")
+    (is (= 1 (count (:reports control)))
+        "the control (B no-emit disabled) also ships exactly one report")
     (is (true? (:b-live? suppressed))
         "same-id B remains live after A's teardown hook fails")
-    (is (empty? (filter #(= :rf.warning/teardown-hook-exception (:operation %))
-                        (:b-buffer suppressed)))
-        "A's teardown warning never enters B's epoch capture buffer")))
+    ;; VACUOUS PASS REMOVED (class 1): the buffer negative below passed over
+    ;; an epoch capture buffer the gate never lets fill.
+    (when interop/debug-enabled?
+      (is (= 1 (count (:warnings suppressed)))
+          "A's post-dissoc teardown-hook warning is delivered despite B no-emit")
+      (is (= :epoch/on-frame-destroyed
+             (get-in (first (:warnings suppressed)) [:tags :hook]))
+          "the warning names the failing epoch teardown hook")
+      (is (= 1 (count (:warnings control)))
+          "the control (B no-emit disabled) also yields exactly one warning")
+      (is (empty? (filter #(= :rf.warning/teardown-hook-exception (:operation %))
+                          (:b-buffer suppressed)))
+          "A's teardown warning never enters B's epoch capture buffer"))))
 
 ;; ---- rf2-vxgfnd.244 — predecessor terminal facts out of successor RING ------
 ;;
@@ -653,14 +765,28 @@
         (let [token-b       (frame/frame-incarnation-token id)
               b-ring-before (rf/trace-buffer id {:flat true})
               b-bundles-before (rf/trace-buffer id)]
-          (is (seq b-ring-before)
-              "B's ring holds its own settle sentinel before A resumes")
           ;; A resumes and publishes its terminal facts while B owns the id.
           (.countDown release-a)
           (is (not= ::timeout (deref dispatch-a 5000 ::timeout))
               "A's terminal recipe completes")
           (executor-barrier!)
 
+          ;; ALWAYS-ON (rf2-d2841): B stays the live incarnation and keeps its
+          ;; own state through A's terminal fan-out. The RING boundary this
+          ;; fixture exists for is a dev-trace fact — under the gate B has no
+          ;; ring at all, so every ring assertion below (and the `(seq
+          ;; b-ring-before)` precondition that licenses them) is guarded
+          ;; TOGETHER. VACUOUS PASSES REMOVED (class 3 / class 1): the two
+          ;; byte-identity comparisons and the three `empty?` leak audits were
+          ;; all true for free over empty rings.
+          (is (identical? token-b (frame/frame-incarnation-token id))
+              "B remains the current incarnation")
+          (is (= {:owner :b} (frame/frame-app-db-value id))
+              "A's terminal fan-out never mutated B's state")
+
+          (when interop/debug-enabled?
+          (is (seq b-ring-before)
+              "B's ring holds its own settle sentinel before A resumes")
           ;; THE RING BOUNDARY: B's public flat buffer is byte-identical.
           (is (= b-ring-before (rf/trace-buffer id {:flat true}))
               "B's flat trace ring is byte-identical after A's terminal fan-out")
@@ -706,13 +832,11 @@
                               @global-facts))
               "A's silencing for its observer is suppressed after B re-armed it (rf2-vxgfnd.245)")
 
-          ;; B stays live and keeps settling normally.
-          (is (identical? token-b (frame/frame-incarnation-token id))
-              "B remains the current incarnation")
+          ;; B keeps settling normally, and its ring is live rather than frozen.
           (rf/dispatch-sync [:destroy/ring-b-settle] {:frame id})
           (is (< (count b-ring-before)
                  (count (rf/trace-buffer id {:flat true})))
-              "B's own subsequent event does grow B's ring (ring is live, not frozen)")))
+              "B's own subsequent event does grow B's ring (ring is live, not frozen)"))))
       (finally
         (.countDown release-a)
         (rf/unregister-listener! :epoch a-observer)
@@ -733,6 +857,9 @@
   ;; destroyed id.
   (let [id           :destroy/ring-snapshot-fail
         warnings     (atom [])
+        ;; ALWAYS-ON (rf2-d2841): the same failure ships a bounded corpus-wide
+        ;; `:rf.error/frame-teardown-failed` record naming the hook.
+        reports      (atom [])
         original-snap (late-bind/get-fn :epoch/snapshot-frame-destroyed)]
     (rf/reg-event :destroy/ring-snap-a
       (fn [_ _] (frame/destroy-frame! id) {:db {:owner :a-tail}}))
@@ -742,6 +869,11 @@
         (when (and (= id (get-in ev [:tags :frame]))
                    (= :rf.warning/teardown-hook-exception (:operation ev)))
           (swap! warnings conj ev))))
+    (rf/register-listener! :errors ::ring-snap-warn
+      (fn [r]
+        (when (and (= :rf.error/frame-teardown-failed (:error r))
+                   (= id (:frame r)))
+          (swap! reports conj r))))
     (try
       ;; Fail the pre-dissoc snapshot hook for this mid-run destroy.
       (late-bind/set-fn! :epoch/snapshot-frame-destroyed
@@ -751,21 +883,33 @@
             (when original-snap (apply original-snap args)))))
       (rf/dispatch-sync [:destroy/ring-snap-a] {:frame id})
       (executor-barrier!)
-      ;; The required global diagnostic fired.
-      (is (= 1 (count @warnings))
-          "the snapshot-failure teardown-hook warning reaches the global listener")
+      ;; ALWAYS-ON (rf2-d2841): the required diagnostic and the teardown
+      ;; outcome. The bounded report is what an off-box shipper receives, and
+      ;; a failed snapshot hook must not abort the destroy.
+      (is (= 1 (count @reports))
+          "exactly one always-on :rf.error/frame-teardown-failed ships")
       (is (= :epoch/snapshot-frame-destroyed
-             (get-in (first @warnings) [:tags :hook]))
-          "the warning names the failing snapshot hook")
-      ;; No residual ring survives for the destroyed frame.
-      (is (empty? (rf/trace-buffer id {:flat true}))
-          "no residual per-frame trace ring survives destroyed A")
-      (is (empty? (rf/trace-buffer id))
-          "no residual event-bundle ring survives destroyed A either")
+             (:hook (first (:hook-failures (first @reports)))))
+          "the always-on report names the failing snapshot hook")
       (is (nil? (frame/frame-incarnation-token id))
           "the frame is fully destroyed")
+      ;; VACUOUS PASSES REMOVED (class 1): the two residual-ring negatives
+      ;; below passed over rings the gate never lets exist for ANY frame,
+      ;; destroyed or live.
+      (when interop/debug-enabled?
+        (is (= 1 (count @warnings))
+            "the snapshot-failure teardown-hook warning reaches the global listener")
+        (is (= :epoch/snapshot-frame-destroyed
+               (get-in (first @warnings) [:tags :hook]))
+            "the warning names the failing snapshot hook")
+        ;; No residual ring survives for the destroyed frame.
+        (is (empty? (rf/trace-buffer id {:flat true}))
+            "no residual per-frame trace ring survives destroyed A")
+        (is (empty? (rf/trace-buffer id))
+            "no residual event-bundle ring survives destroyed A either"))
       (finally
         (rf/unregister-listener! :trace ::ring-snap-warn)
+        (rf/unregister-listener! :errors ::ring-snap-warn)
         (when (frame/frame id) (frame/destroy-frame! id))
         (late-bind/set-fn! :epoch/snapshot-frame-destroyed original-snap)))))
 
@@ -933,27 +1077,42 @@
         ;; Same-id B settles: claims stores + re-arms cb for the reused id.
         (rf/make-frame {:id id})
         (rf/dispatch-sync [:vxgfnd245/b-settle] {:frame id})
-        (is (= 2 (count @received))
-            "cb received A's settle and B's settle — re-armed for the reused id")
+        ;; The epoch cb never fires under the gate (the record it receives is
+        ;; built from the trace-fed capture buffer), so the receive counts,
+        ;; the silencing fan and the precondition that licenses them are
+        ;; guarded TOGETHER. VACUOUS PASS REMOVED (class 1): the silencing
+        ;; negative passed over a stream carrying no silencings at all.
+        (when interop/debug-enabled?
+          (is (= 2 (count @received))
+              "cb received A's settle and B's settle — re-armed for the reused id"))
         ;; A resumes and reaches its terminal publish while B owns the stores.
         (.countDown release-a)
         (is (not= ::timeout (deref dispatch-a 5000 ::timeout))
             "A's terminal recipe completes")
         (executor-barrier!)
-        ;; THE FIX: A's silencing fan for cb is suppressed — cb is live on B.
-        (is (empty? (filter #(= cb (:cb-id (:tags %))) @silencings))
-            "no bare A silencing for cb after B claimed the id and re-armed it")
-        ;; A's HISTORICAL halted-destroy record is still delivered to cb — the
-        ;; .151 record-delivery contract is unchanged by .245 (only the silencing
-        ;; fan is gated). cb remains live on B: an extra B settle reaches it.
-        (let [before-extra (count @received)]
-          (rf/dispatch-sync [:vxgfnd245/b-settle] {:frame id})
-          (is (= (inc before-extra) (count @received))
-              "cb continues to receive B's records after A resumed — it is live on B"))
+        ;; ALWAYS-ON (rf2-d2841): the incarnation fence. A's inert returned
+        ;; tail (`{:owner :a-tail}`) must never become B's state, and B must
+        ;; go on committing its own events.
+        (is (= {:owner :b} (frame/frame-app-db-value id))
+            "A's inert tail never mutated B's state")
+        (when interop/debug-enabled?
+          ;; THE FIX: A's silencing fan for cb is suppressed — cb is live on B.
+          (is (empty? (filter #(= cb (:cb-id (:tags %))) @silencings))
+              "no bare A silencing for cb after B claimed the id and re-armed it")
+          ;; A's HISTORICAL halted-destroy record is still delivered to cb — the
+          ;; .151 record-delivery contract is unchanged by .245 (only the silencing
+          ;; fan is gated). cb remains live on B: an extra B settle reaches it.
+          (let [before-extra (count @received)]
+            (rf/dispatch-sync [:vxgfnd245/b-settle] {:frame id})
+            (is (= (inc before-extra) (count @received))
+                "cb continues to receive B's records after A resumed — it is live on B")))
         ;; When B (where cb IS live) destroys, exactly one truthful silencing.
         (rf/destroy-frame! id)
-        (is (= 1 (count (filter #(= cb (:cb-id (:tags %))) @silencings)))
-            "exactly one truthful silencing for cb — fired by B's own destroy"))
+        (is (nil? (frame/frame-incarnation-token id))
+            "B's own destroy takes effect")
+        (when interop/debug-enabled?
+          (is (= 1 (count (filter #(= cb (:cb-id (:tags %))) @silencings)))
+              "exactly one truthful silencing for cb — fired by B's own destroy")))
       (finally
         (.countDown release-a)
         (rf/unregister-listener! :epoch cb)
@@ -1006,27 +1165,38 @@
         (rf/register-listener! :epoch cb (fn [_] (swap! new-received inc)))
         (rf/make-frame {:id id})
         (rf/dispatch-sync [:vxgfnd245/regen-b-settle] {:frame id})
-        (is (= 1 @new-received)
-            "the NEW cb generation received B's settled record")
         (.countDown release-a)
         (is (not= ::timeout (deref dispatch-a 5000 ::timeout))
             "A's terminal recipe completes")
         (executor-barrier!)
-        (is (empty? (filter #(= cb (:cb-id (:tags %))) @silencings))
-            "A's stale snapshot never silences the reused id after a gap re-register")
-        ;; A delivers its HISTORICAL halted record to its OWN snapshot generation
-        ;; (the old callback captured pre-dissoc), NOT the new one. So the old
-        ;; callback saw A-settle + A's halted record; the new generation was
-        ;; invoked only by B — A never invokes the new generation (rf2-vxgfnd.245
-        ;; pins old/new behaviour).
-        (is (= 2 @old-received)
-            "the old cb generation received A's settle + A's historical halted record")
-        (is (= 1 @new-received)
-            "A never invoked the new cb generation — only B's settle reached it")
+        ;; ALWAYS-ON (rf2-d2841): the incarnation fence survives the
+        ;; re-register-in-the-gap race.
+        (is (= {:owner :b} (frame/frame-app-db-value id))
+            "A's inert tail never mutated B's state across the gap re-register")
+        ;; The cb generations and the silencing fan are epoch-record-driven
+        ;; and so dev-only. VACUOUS PASS REMOVED (class 1): the silencing
+        ;; negative passed over an empty stream.
+        (when interop/debug-enabled?
+          (is (= 1 @new-received)
+              "the NEW cb generation received B's settled record")
+          (is (empty? (filter #(= cb (:cb-id (:tags %))) @silencings))
+              "A's stale snapshot never silences the reused id after a gap re-register")
+          ;; A delivers its HISTORICAL halted record to its OWN snapshot generation
+          ;; (the old callback captured pre-dissoc), NOT the new one. So the old
+          ;; callback saw A-settle + A's halted record; the new generation was
+          ;; invoked only by B — A never invokes the new generation (rf2-vxgfnd.245
+          ;; pins old/new behaviour).
+          (is (= 2 @old-received)
+              "the old cb generation received A's settle + A's historical halted record")
+          (is (= 1 @new-received)
+              "A never invoked the new cb generation — only B's settle reached it"))
         ;; B destroys → exactly one truthful silencing for the live new generation.
         (rf/destroy-frame! id)
-        (is (= 1 (count (filter #(= cb (:cb-id (:tags %))) @silencings)))
-            "exactly one truthful silencing for the new generation on B's destroy"))
+        (is (nil? (frame/frame-incarnation-token id))
+            "B's own destroy takes effect")
+        (when interop/debug-enabled?
+          (is (= 1 (count (filter #(= cb (:cb-id (:tags %))) @silencings)))
+              "exactly one truthful silencing for the new generation on B's destroy")))
       (finally
         (.countDown release-a)
         (rf/unregister-listener! :epoch cb)
@@ -1090,17 +1260,25 @@
     (try
       (rf/destroy-frame! a-id)
       (executor-barrier!)
-      (is (true? @fired?)
-          "the listener saw A's structural terminal fact and dispatched")
-      ;; UNRELATED C: nested work captured into C's epoch history + retained in
-      ;; C's ring, and it actually ran and streamed live.
-      (is (= 1 (count (rf/epoch-history c-id)))
-          "C's listener-triggered cascade is captured into C's epoch history")
-      (is (= {:c :ran} (frame/frame-app-db-value c-id))
-          "C's nested event actually ran and committed")
-      (is (seq (rf/trace-buffer c-id {:flat true}))
-          "C's listener-triggered cascade is retained in C's per-frame ring")
-      (is (seq @c-live) "C's nested events streamed live to listeners")
+      ;; DEV-ONLY END TO END (rf2-d2841). The DRIVER here is a public TRACE
+      ;; listener reacting to `:rf.epoch.cb/silenced-on-frame-destroy`. No
+      ;; such fact is emitted under the gate, so the listener never fires and
+      ;; C's nested cascade never runs — there is nothing to observe, not
+      ;; merely no way to observe it. The whole body is therefore guarded
+      ;; rather than half-asserted; `(true? @fired?)` is the precondition and
+      ;; stays with the claims it licenses.
+      (when interop/debug-enabled?
+        (is (true? @fired?)
+            "the listener saw A's structural terminal fact and dispatched")
+        ;; UNRELATED C: nested work captured into C's epoch history + retained in
+        ;; C's ring, and it actually ran and streamed live.
+        (is (= 1 (count (rf/epoch-history c-id)))
+            "C's listener-triggered cascade is captured into C's epoch history")
+        (is (= {:c :ran} (frame/frame-app-db-value c-id))
+            "C's nested event actually ran and committed")
+        (is (seq (rf/trace-buffer c-id {:flat true}))
+            "C's listener-triggered cascade is retained in C's per-frame ring")
+        (is (seq @c-live) "C's nested events streamed live to listeners"))
       (finally
         (rf/unregister-listener! :epoch ::vf2qke-a-obs)
         (rf/unregister-listener! :trace ::vf2qke-dispatcher)
@@ -1138,14 +1316,21 @@
     (try
       (rf/destroy-frame! a-id)
       (executor-barrier!)
-      (is (true? @fired?) "the listener dispatched into the no-emit frame D")
-      (is (= {:d :ran} (frame/frame-app-db-value d-id))
-          "D's nested event ran and committed (no-emit suppresses TRACE, not work)")
-      ;; D's own no-emit policy applies to the nested work: no D traces leak.
-      (is (empty? @d-live)
-          "D's frame-no-emit policy suppresses its nested trace — no leak to listeners")
-      (is (empty? (rf/trace-buffer d-id {:flat true}))
-          "no D trace is retained under D's own no-emit policy")
+      ;; DEV-ONLY END TO END (rf2-d2841), same reason as the deftest above:
+      ;; a TRACE listener is the driver. TWO VACUOUS PASSES REMOVED (class 1)
+      ;; — `(empty? @d-live)` and `(empty? (rf/trace-buffer d-id {:flat true}))`
+      ;; certified that D's no-emit policy suppressed D's traces, over a frame
+      ;; whose event NEVER RAN. A no-leak audit that passes because nothing
+      ;; happened is the sharpest form of the false green this pass hunts.
+      (when interop/debug-enabled?
+        (is (true? @fired?) "the listener dispatched into the no-emit frame D")
+        (is (= {:d :ran} (frame/frame-app-db-value d-id))
+            "D's nested event ran and committed (no-emit suppresses TRACE, not work)")
+        ;; D's own no-emit policy applies to the nested work: no D traces leak.
+        (is (empty? @d-live)
+            "D's frame-no-emit policy suppresses its nested trace — no leak to listeners")
+        (is (empty? (rf/trace-buffer d-id {:flat true}))
+            "no D trace is retained under D's own no-emit policy"))
       (finally
         (rf/unregister-listener! :epoch ::vf2qke-policy-obs)
         (rf/unregister-listener! :trace ::vf2qke-policy-dispatcher)
@@ -1405,26 +1590,39 @@
         (fn [& args]
           (swap! cascade-captures inc)
           (when original-capture (apply original-capture args))))
-      (let [dispatch-a (future
-                         (rf/dispatch-sync [:destroy/epoch-digest-event]
-                                           {:frame id}))]
-        (is (.await digest-lost-a 10 TimeUnit/SECONDS)
-            "the digest callback destroyed A before normal publication")
-        (rf/make-frame {:id id})
-        (rf/register-listener! :epoch ::epoch-digest-b
-          (fn [_] (swap! b-listener-runs inc)))
-        (let [token-b (frame/frame-incarnation-token id)]
-          (.countDown release-digest)
-          (is (not= ::timeout (deref dispatch-a 5000 ::timeout))
-              "the obsolete digest throw is inert")
-          (is (identical? token-b (frame/frame-incarnation-token id))
-              "B remains installed")
-          (is (= {} (frame/frame-app-db-value id)) "B app-db is untouched")
-          (is (empty? (rf/epoch-history id)) "no normal A record lands in B history")
-          (is (nil? (epoch-state/last-settled-epoch-id id))
-              "no normal A anchor lands in B")
-          (is (zero? @cascade-captures) "no stale cascade aggregation runs")
-          (is (zero? @b-listener-runs) "no B-era epoch listener sees A's record")))
+      ;; DEV-ONLY END TO END (rf2-d2841), and this one was CHECKED BY RUNNING
+      ;; rather than reasoned about. The scenario is driven from inside the
+      ;; `:schemas/app-schemas-digest` late-bind hook, which is reached only
+      ;; from `epoch/settle!` via `assembly/current-schema-digest`. Under the
+      ;; gate the trace-fed capture buffer never fills, `settle!` never runs,
+      ;; the hook is never invoked, and the `digest-lost-a` latch TIMED OUT —
+      ;; A was never destroyed, so the deftest's four negatives were passing
+      ;; over a scenario that had not happened. FOUR VACUOUS PASSES REMOVED
+      ;; (class 1): `(empty? (rf/epoch-history id))`,
+      ;; `(nil? (epoch-state/last-settled-epoch-id id))`,
+      ;; `(zero? @cascade-captures)` and `(zero? @b-listener-runs)` are each
+      ;; true for free when nothing recorded, aggregated or fanned at all.
+      (when interop/debug-enabled?
+        (let [dispatch-a (future
+                           (rf/dispatch-sync [:destroy/epoch-digest-event]
+                                             {:frame id}))]
+          (is (.await digest-lost-a 10 TimeUnit/SECONDS)
+              "the digest callback destroyed A before normal publication")
+          (rf/make-frame {:id id})
+          (rf/register-listener! :epoch ::epoch-digest-b
+            (fn [_] (swap! b-listener-runs inc)))
+          (let [token-b (frame/frame-incarnation-token id)]
+            (.countDown release-digest)
+            (is (not= ::timeout (deref dispatch-a 5000 ::timeout))
+                "the obsolete digest throw is inert")
+            (is (identical? token-b (frame/frame-incarnation-token id))
+                "B remains installed")
+            (is (= {} (frame/frame-app-db-value id)) "B app-db is untouched")
+            (is (empty? (rf/epoch-history id)) "no normal A record lands in B history")
+            (is (nil? (epoch-state/last-settled-epoch-id id))
+                "no normal A anchor lands in B")
+            (is (zero? @cascade-captures) "no stale cascade aggregation runs")
+            (is (zero? @b-listener-runs) "no B-era epoch listener sees A's record"))))
       (finally
         (.countDown release-digest)
         (rf/unregister-listener! :epoch ::epoch-digest-b)
@@ -1511,19 +1709,26 @@
               "the required A teardown report reaches corpus listeners once")
           (is (zero? @frame-routes)
               "A's report never resolves through B's frame-owned error route")
-          (let [by-op (group-by :operation @traces)]
-            (is (= [:halted-destroy]
-                   (mapv #(get-in % [:tags :outcome])
-                         (get by-op :rf.epoch/snapshotted)))
-                "B's claim cannot revoke A's detailed terminal fact")
-            (is (= [:blocked]
-                   (mapv #(get-in % [:tags :outcome])
-                         (get by-op :rf.epoch/outcome)))
-                "B's claim cannot revoke A's terminal consumer outcome"))
-          (is (empty? (rf/epoch-history id))
-              "A's terminal record never enters B's ring")
-          (is (empty? (epoch-state/buffer-for id))
-              "A's terminal traces never enter B's capture buffer")
+          ;; The corpus assertions above are the always-on half and were
+          ;; already posture-independent — this deftest's central claim (the
+          ;; required report ships corpus-wide but never routes into B's
+          ;; declared sinks) runs under the gate unchanged. VACUOUS PASSES
+          ;; REMOVED (class 1): the two `empty?` leak audits below passed over
+          ;; an epoch history and a capture buffer the gate never lets fill.
+          (when interop/debug-enabled?
+            (let [by-op (group-by :operation @traces)]
+              (is (= [:halted-destroy]
+                     (mapv #(get-in % [:tags :outcome])
+                           (get by-op :rf.epoch/snapshotted)))
+                  "B's claim cannot revoke A's detailed terminal fact")
+              (is (= [:blocked]
+                     (mapv #(get-in % [:tags :outcome])
+                           (get by-op :rf.epoch/outcome)))
+                  "B's claim cannot revoke A's terminal consumer outcome"))
+            (is (empty? (rf/epoch-history id))
+                "A's terminal record never enters B's ring")
+            (is (empty? (epoch-state/buffer-for id))
+                "A's terminal traces never enter B's capture buffer"))
           (let [duplicate-b (future (frame/destroy-frame! id token-b))]
             (is (nil? (deref duplicate-b 2000 ::timeout))
                 "A's finally preserved B's distinct claim marker"))
@@ -1815,8 +2020,12 @@
           "the depth record names the overflowing frame")
       (is (= 1 @sibling-runs)
           "every corpus error listener runs when A retains ownership")
-      (is (some #(= :halted-depth (:outcome %)) (rf/epoch-history id))
-          "A's terminal halted-depth record is committed into A's own history")
+      ;; The three corpus assertions above already ran in both postures — the
+      ;; depth record fans through the always-on `:errors` registry. Only the
+      ;; epoch-history half is trace-fed (rf2-d2841).
+      (when interop/debug-enabled?
+        (is (some #(= :halted-depth (:outcome %)) (rf/epoch-history id))
+            "A's terminal halted-depth record is committed into A's own history"))
       (finally
         (rf/unregister-listener! :errors ::live-a)
         (rf/unregister-listener! :errors ::live-b)

--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -13,7 +13,54 @@
   hosts. Host honesty: plain-atom derived values are not watchable, so the
   value-movement `on-change` channel is a reactive-host surface — these
   fixtures pin movement detection at the port's READ points (version +
-  epoch evidence), which is the headless contract."
+  epoch evidence), which is the headless contract.
+
+  ## Posture split (rf2-d2841)
+
+  Only ten of the ninety-four deftests here needed anything, and the whole
+  port — acquire / read / release, ref-counting, disposal, movement
+  evidence, retention, provenance — runs identically in both postures. What
+  splits is narrow and falls into exactly two shapes.
+
+  1. THE DEV REENTRANCY ASSERT IS THE DRIVER, NOT THE OBSERVATION.
+     `observation/assert-not-in-fan-out!` is wrapped in
+     `(when interop/debug-enabled? …)` at its source — checked, not assumed —
+     so under the gate a forbidden reentrant `release!` from inside the
+     fan-out simply SUCCEEDS. Five fixtures use that assert to manufacture a
+     DIAGNOSTIC-ONLY typed escape; with no escape there is no callback
+     failure, no wrapper record, and nothing to classify. Those scenarios are
+     dev-only end to end, so the escape half is guarded together with the
+     precondition that creates it. Where such a fixture ALSO carries a
+     production claim — the well-behaved sibling owner is still notified,
+     the macro registrations captured discriminable `[:sub id]` / `[:event
+     id]` coordinates — that claim stays outside the guard.
+
+  2. THE ALWAYS-ON HALF OF A TWO-CHANNEL FAN-OUT ALREADY PASSED.
+     `:rf.error/observation-on-change-failed` is a PROMOTED category:
+     the drain emits it through `emit-error-both!`, so the record reaches the
+     always-on axis under the gate and every assertion about the record —
+     count, `:event-id`, exact `:exception` identity, and the resolved
+     `[:sub id]` `:source-coord` — runs unchanged. Only the DEV-TRACE twin
+     (`:op-type :error` events and their `:tags`) is elided, and only those
+     reads are guarded. That is the point of the rf2-q3fmqm suites: the two
+     channels are independent, and this pass demonstrates the independence by
+     running one of them alone.
+
+  SEVENTEEN VACUOUS PASSES CAME OFF, and the schema gate held twelve of them.
+  `schema-gate-rejects-required-key-and-value-drift` reads the dev-trace
+  `:tags` into `tags`, which is nil under the gate — and NOTHING it then
+  asserts can tell the difference. `(not (valid-… (dissoc tags k)))` is a
+  DOSEQ over the eight required keys, and `(dissoc nil k)` is nil, so all
+  eight drift-detection assertions passed on nil; so did the `:cause`
+  and `:category` spoof rejections (`(assoc nil …)` yields a one-key map that
+  is invalid for the wrong reason) and the two exact-identity negatives
+  (`(not (identical? boom nil))`). A gate whose entire purpose is to redden on
+  schema drift was certifying drift-detection over an absent record. The
+  remaining five are ordinary class-1 negatives — \"the diagnostic category is
+  NOT promoted onto the always-on axis\" over record streams that carried no
+  records at all, in four of the five reentrant-driven fixtures, plus
+  `drain-two-channel-fanout-composes-with-first-emission-provenance`'s
+  \"no wrapper trace event\" over an empty trace stream."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             #?(:clj [clojure.java.io :as io])
@@ -1506,23 +1553,33 @@
     ;; replacement hook, so the drain's rethrow is swallowed there and it is the
     ;; ALWAYS-ON fan that carries visibility.
     (let [[[outcome _] records] (with-error-records #(reg-items!))]
+      ;; ALWAYS-ON (rf2-d2841): containment. Whether or not owner A's callback
+      ;; throws, it must not starve its sibling — that is the drain's real
+      ;; contract and it holds in both postures.
       (testing "the throwing owner did NOT starve its sibling — B notified once"
         (is (= 1 (count @notes-b)))
         (is (= :hmr (:cause (first @notes-b)))))
-      (testing "the escape is SEEN on the always-on axis despite the registrar's
-                per-hook swallow — the diagnostic-only reentrant-graph-op is
-                wrapped in the stable :rf.error/observation-on-change-failed
-                (never promoted onto the always-on axis under its own diagnostic
-                id — rf2-w55bh0), carrying the reentrant assert as its cause"
-        (let [wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
-                               records)]
-          (is (= 1 (count wrapped))
-              "the swallowed callback failure reached the always-on error surface")
-          (is (= :rf.error/reentrant-graph-op
-                 (error-id (:exception (first wrapped))))
-              "the diagnostic reentrant-graph-op rides as the wrapper's cause"))
-        (is (empty? (filterv #(= :rf.error/reentrant-graph-op (:error %)) records))
-            "the diagnostic category is NOT promoted onto the always-on axis"))
+      ;; The ESCAPE ITSELF is manufactured by the dev reentrancy assert
+      ;; (`assert-not-in-fan-out!` is `(when interop/debug-enabled? …)`), so
+      ;; under the gate owner A's reentrant release! simply succeeds and there
+      ;; is no callback failure to wrap. VACUOUS PASS REMOVED (class 1): the
+      ;; "not promoted onto the always-on axis" negative passed over a record
+      ;; stream that carried no records at all.
+      (when interop/debug-enabled?
+        (testing "the escape is SEEN on the always-on axis despite the registrar's
+                  per-hook swallow — the diagnostic-only reentrant-graph-op is
+                  wrapped in the stable :rf.error/observation-on-change-failed
+                  (never promoted onto the always-on axis under its own diagnostic
+                  id — rf2-w55bh0), carrying the reentrant assert as its cause"
+          (let [wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                                 records)]
+            (is (= 1 (count wrapped))
+                "the swallowed callback failure reached the always-on error surface")
+            (is (= :rf.error/reentrant-graph-op
+                   (error-id (:exception (first wrapped))))
+                "the diagnostic reentrant-graph-op rides as the wrapper's cause"))
+          (is (empty? (filterv #(= :rf.error/reentrant-graph-op (:error %)) records))
+              "the diagnostic category is NOT promoted onto the always-on axis")))
       (testing "reg-items! returned normally — the registrar isolates the hook"
         (is (= :ok outcome))))
     ;; Owner A's release! never completed (it threw); both are cleanly releasable
@@ -1974,7 +2031,13 @@
     (reset! handle-ref handle)
     ;; drive a fan-out via the HMR path
     (reg-items!)
-    (is (= :rf.error/reentrant-graph-op @caught))
+    ;; DEV-ASSERTED BY NAME AND BY SOURCE (rf2-d2841):
+    ;; `observation/assert-not-in-fan-out!` is wrapped in
+    ;; `(when interop/debug-enabled? …)`, so under the gate the reentrant
+    ;; release! succeeds and nothing is caught. The deftest's own name states
+    ;; the posture.
+    (when interop/debug-enabled?
+      (is (= :rf.error/reentrant-graph-op @caught)))
     (testing "the reentrant release was rejected — the handle is still live
               and releasable outside the fan-out"
       (obs/release! handle))))
@@ -2582,23 +2645,30 @@
       (force-dispose-node! [:obs/items])
       (let [[[outcome thrown] records]
             (with-error-records #(obs/drain-pending-disposals! :disposed))]
-        (testing "the callback failure surfaces EXACTLY once, wrapped in the
-                  stable always-on :rf.error/observation-on-change-failed"
-          (let [wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
-                                 records)]
-            (is (= 1 (count wrapped)))
-            (testing "attributed to the notifying former owner's entry sub, with
-                      the diagnostic reentrant assert riding as the record's cause"
-              (is (= :obs/items (:event-id (first wrapped))))
-              (is (identical? thrown (:exception (first wrapped))))
-              (is (= :rf.error/reentrant-graph-op
-                     (error-id (:exception (first wrapped))))))))
-        (testing "the diagnostic-only category is NEVER promoted onto the
-                  always-on axis under its own id (rf2-w55bh0)"
-          (is (empty? (filterv #(= :rf.error/reentrant-graph-op (:error %))
-                               records))))
-        (is (= :threw outcome))
-        (is (= :rf.error/reentrant-graph-op (error-id thrown)))))))
+        ;; DEV-ONLY DRIVER (rf2-d2841): the diagnostic escape this fixture
+        ;; classifies is manufactured by the reentrancy assert, which is
+        ;; `(when interop/debug-enabled? …)` at its source. Under the gate the
+        ;; reentrant release! succeeds, the drain sees no failure, and there is
+        ;; no wrapper to check. VACUOUS PASS REMOVED (class 1): the
+        ;; never-promoted negative passed over an empty record stream.
+        (when interop/debug-enabled?
+          (testing "the callback failure surfaces EXACTLY once, wrapped in the
+                    stable always-on :rf.error/observation-on-change-failed"
+            (let [wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                                   records)]
+              (is (= 1 (count wrapped)))
+              (testing "attributed to the notifying former owner's entry sub, with
+                        the diagnostic reentrant assert riding as the record's cause"
+                (is (= :obs/items (:event-id (first wrapped))))
+                (is (identical? thrown (:exception (first wrapped))))
+                (is (= :rf.error/reentrant-graph-op
+                       (error-id (:exception (first wrapped))))))))
+          (testing "the diagnostic-only category is NEVER promoted onto the
+                    always-on axis under its own id (rf2-w55bh0)"
+            (is (empty? (filterv #(= :rf.error/reentrant-graph-op (:error %))
+                                 records))))
+          (is (= :threw outcome))
+          (is (= :rf.error/reentrant-graph-op (error-id thrown))))))))
 
 (deftest hmr-drain-wraps-spoofed-and-malformed-ids-instead-of-fanning-them
   (reg-items!)
@@ -2709,20 +2779,28 @@
             (let [coord (source-coords/error-coords-for :sub :obs/items)]
               (is (some? coord) "the macro registration captured coords")
               (is (= coord (:source-coord (first wrapped))))))))
-      (testing "exactly ONE dev diagnostic-trace event for the same logical
-                failure — Xray's trace collector sees it without registering
-                an always-on listener (pre-fix: zero trace events)"
-        (let [tev (filterv #(= :rf.error/observation-on-change-failed (:operation %))
-                           traces)]
-          (is (= 1 (count tev)))
-          (let [tags (:tags (first tev))]
-            (is (identical? boom (:exception tags))
-                "the trace tags carry the original throwable")
-            (is (= :hmr (:cause tags))
-                "the category-specific tags carry the disposal cause")
-            (is (= :obs/items (:rf.sub/id tags)))
-            (is (= [:obs/items] (:rf.sub/query-v tags)))
-            (is (= fid (:frame tags)))))))
+      ;; The always-on half above needs no guard and never did: the drain emits
+      ;; the wrapper through `emit-error-both!`, so the record, its exact
+      ;; throwable and its resolved `[:sub id]` coordinate all reach the
+      ;; production axis under the gate. Only the DEV-TRACE twin is elided, and
+      ;; the independence of the two channels is exactly this suite's thesis
+      ;; (rf2-q3fmqm / rf2-d2841) — so running one alone is a demonstration of
+      ;; it, not a hole in it.
+      (when interop/debug-enabled?
+        (testing "exactly ONE dev diagnostic-trace event for the same logical
+                  failure — Xray's trace collector sees it without registering
+                  an always-on listener (pre-fix: zero trace events)"
+          (let [tev (filterv #(= :rf.error/observation-on-change-failed (:operation %))
+                             traces)]
+            (is (= 1 (count tev)))
+            (let [tags (:tags (first tev))]
+              (is (identical? boom (:exception tags))
+                  "the trace tags carry the original throwable")
+              (is (= :hmr (:cause tags))
+                  "the category-specific tags carry the disposal cause")
+              (is (= :obs/items (:rf.sub/id tags)))
+              (is (= [:obs/items] (:rf.sub/query-v tags)))
+              (is (= fid (:frame tags))))))))
     (obs/release! la)))
 
 (deftest disposed-drain-fans-the-wrapper-on-both-channels
@@ -2739,10 +2817,13 @@
         (is (= 1 (count (filterv #(= :rf.error/observation-on-change-failed (:error %))
                                  records)))
             "exactly one always-on record at the :disposed boundary")
-        (let [tev (filterv #(= :rf.error/observation-on-change-failed (:operation %))
-                           traces)]
-          (is (= 1 (count tev)) "exactly one trace event at the :disposed boundary")
-          (is (= :disposed (:cause (:tags (first tev)))))))
+        ;; The always-on half runs unguarded (rf2-d2841); only the dev-trace
+        ;; twin is elided.
+        (when interop/debug-enabled?
+          (let [tev (filterv #(= :rf.error/observation-on-change-failed (:operation %))
+                             traces)]
+            (is (= 1 (count tev)) "exactly one trace event at the :disposed boundary")
+            (is (= :disposed (:cause (:tags (first tev))))))))
       (obs/release! la))))
 
 (deftest drain-two-channel-fanout-composes-with-first-emission-provenance
@@ -2757,13 +2838,22 @@
     (let [live (obs/acquire! (items-target) (fn [_n] (obs/read released)))]
       (let [[[outcome _] records traces] (with-both-channels #(reg-items!))]
         (is (= :ok outcome))
+        ;; ALWAYS-ON (rf2-d2841): the provenance rule's production half — an
+        ;; already-fanned typed escape gains no SECOND always-on record from
+        ;; the drain. That is the arm an off-box shipper would see duplicated.
         (is (= 1 (count (filterv #(= :rf.error/read-after-release (:error %)) records)))
             "one always-on record — the source's")
-        (is (= 1 (count (filterv #(= :rf.error/read-after-release (:operation %)) traces)))
-            "one trace event — the source's; the drain adds none")
-        (is (empty? (filterv #(= :rf.error/observation-on-change-failed (:operation %))
-                             traces))
-            "no wrapper trace event for a typed escape"))
+        (is (empty? (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                             records))
+            "and no wrapper RECORD for a typed escape either")
+        ;; VACUOUS PASS REMOVED (class 1): the trace-side no-wrapper negative
+        ;; below passed over a trace stream that carried nothing at all.
+        (when interop/debug-enabled?
+          (is (= 1 (count (filterv #(= :rf.error/read-after-release (:operation %)) traces)))
+              "one trace event — the source's; the drain adds none")
+          (is (empty? (filterv #(= :rf.error/observation-on-change-failed (:operation %))
+                               traces))
+              "no wrapper trace event for a typed escape")))
       (obs/release! live))))
 
 (deftest disposed-drain-wraps-a-diagnostic-only-typed-escape-on-both-channels
@@ -2781,17 +2871,21 @@
       (force-dispose-node! [:obs/items])
       (let [[[outcome _] records traces]
             (with-both-channels #(obs/drain-pending-disposals! :disposed))]
-        (is (= :threw outcome))
-        (is (= 1 (count (filterv #(= :rf.error/observation-on-change-failed (:error %))
-                                 records)))
-            "exactly one always-on wrapper record")
-        (is (empty? (filterv #(= :rf.error/reentrant-graph-op (:error %)) records))
-            "the diagnostic category is NOT promoted onto the always-on axis")
-        (let [tev (filterv #(= :rf.error/observation-on-change-failed (:operation %))
-                           traces)]
-          (is (= 1 (count tev))
-              "the drain-owned wrapper reaches the trace channel too")
-          (is (= :disposed (:cause (:tags (first tev))))))))))
+        ;; DEV-ONLY DRIVER (rf2-d2841), same as the fixture above: the
+        ;; diagnostic escape comes from the dev reentrancy assert. VACUOUS PASS
+        ;; REMOVED (class 1): the never-promoted negative over an empty stream.
+        (when interop/debug-enabled?
+          (is (= :threw outcome))
+          (is (= 1 (count (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                                   records)))
+              "exactly one always-on wrapper record")
+          (is (empty? (filterv #(= :rf.error/reentrant-graph-op (:error %)) records))
+              "the diagnostic category is NOT promoted onto the always-on axis")
+          (let [tev (filterv #(= :rf.error/observation-on-change-failed (:operation %))
+                             traces)]
+            (is (= 1 (count tev))
+                "the drain-owned wrapper reaches the trace channel too")
+            (is (= :disposed (:cause (:tags (first tev)))))))))))
 
 (deftest collision-event-registration-cannot-steal-sub-attribution
   ;; PROGRAMMATIC sub registration (no [:sub id] coords) + MACRO event
@@ -2868,19 +2962,30 @@
         (force-dispose-node! [:obs/collide-typed])
         (let [[[outcome _] records]
               (with-error-records #(obs/drain-pending-disposals! :disposed))]
-          (is (= :threw outcome)
-              "the drain re-throws the first escape after draining every sibling")
-          (let [wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
-                                 records)]
-            (is (= 1 (count wrapped)) "exactly one drain-owned wrapper record")
-            (is (empty? (filterv #(= :rf.error/reentrant-graph-op (:error %)) records))
-                "the diagnostic TYPED category is NEVER promoted onto the always-on axis")
-            (is (= :obs/collide-typed (:event-id (first wrapped)))
-                "the wrapper is attributed to the former owner's ENTRY sub id")
-            (is (= sub-coord (:source-coord (first wrapped)))
-                "the drain-owned TYPED escape resolves the [:sub id] coordinate")
-            (is (not= event-coord (:source-coord (first wrapped)))
-                "the unrelated same-id EVENT coordinate is never selected")))
+          ;; The three coordinate assertions above are always-on and stay
+          ;; there: `source-coords/remember-error-coords!` runs unconditionally
+          ;; at registration (pass 5's finding), so "the macro sub and the
+          ;; colliding macro event captured DISCRIMINABLE coordinates" — the
+          ;; premise the whole counterexample rests on — is proved under the
+          ;; gate. What is dev-only is the ESCAPE: the diagnostic typed throw
+          ;; comes from the reentrancy assert (rf2-d2841). VACUOUS PASSES
+          ;; REMOVED (class 1 + class 4): the never-promoted negative over an
+          ;; empty record stream, and `(not= event-coord (:source-coord …))`
+          ;; over a nil record, where any coordinate differs from nil.
+          (when interop/debug-enabled?
+            (is (= :threw outcome)
+                "the drain re-throws the first escape after draining every sibling")
+            (let [wrapped (filterv #(= :rf.error/observation-on-change-failed (:error %))
+                                   records)]
+              (is (= 1 (count wrapped)) "exactly one drain-owned wrapper record")
+              (is (empty? (filterv #(= :rf.error/reentrant-graph-op (:error %)) records))
+                  "the diagnostic TYPED category is NEVER promoted onto the always-on axis")
+              (is (= :obs/collide-typed (:event-id (first wrapped)))
+                  "the wrapper is attributed to the former owner's ENTRY sub id")
+              (is (= sub-coord (:source-coord (first wrapped)))
+                  "the drain-owned TYPED escape resolves the [:sub id] coordinate")
+              (is (not= event-coord (:source-coord (first wrapped)))
+                  "the unrelated same-id EVENT coordinate is never selected"))))
         (obs/release! la)))))
 
 ;; ===========================================================================
@@ -3758,25 +3863,29 @@
                                 traces))
             rec (first (filterv #(= :rf.error/observation-on-change-failed (:error %))
                                 records))]
-        (is (some? tev) "exactly the one dev-trace event to validate")
-        (is (valid-observation-on-change-failed-tags? (:tags tev))
-            "the :hmr dev-trace tags satisfy the canonical schema")
-        (is (= :hmr (:cause (:tags tev))))
-        (testing "the dev-trace :tags carry the EXACT original throwable and frame
-                  keyword — not only the always-on record (rf2-5iud0a false-greens
-                  #1 + #3: :exception is schema-typed :any and :frame is an OPEN
-                  optional key, so the schema alone accepts nil / a wrong throwable /
-                  a dropped frame in the trace tags; the fixtures assert real values)"
-          (is (identical? boom (:exception (:tags tev)))
-              "trace :exception is the exact original throwable, not nil / a copy")
-          (is (= fid (:frame (:tags tev)))
-              "trace :frame carries the exact emitting frame keyword"))
+        ;; The record half needs no guard (rf2-d2841) — the wrapper category is
+        ;; PROMOTED, so the 009 wire fields are checked in the posture that
+        ;; ships. Only the dev-trace `:tags` the schema validates are elided.
         (testing "the always-on record carries the wire fields the 009 row lists"
           (is (some? rec))
           (is (= [:obs/items] (:event rec)))
           (is (= :obs/items (:event-id rec)))
           (is (= fid (:frame rec)))
-          (is (identical? boom (:exception rec)))))
+          (is (identical? boom (:exception rec))))
+        (when interop/debug-enabled?
+          (is (some? tev) "exactly the one dev-trace event to validate")
+          (is (valid-observation-on-change-failed-tags? (:tags tev))
+              "the :hmr dev-trace tags satisfy the canonical schema")
+          (is (= :hmr (:cause (:tags tev))))
+          (testing "the dev-trace :tags carry the EXACT original throwable and frame
+                    keyword — not only the always-on record (rf2-5iud0a false-greens
+                    #1 + #3: :exception is schema-typed :any and :frame is an OPEN
+                    optional key, so the schema alone accepts nil / a wrong throwable /
+                    a dropped frame in the trace tags; the fixtures assert real values)"
+            (is (identical? boom (:exception (:tags tev)))
+                "trace :exception is the exact original throwable, not nil / a copy")
+            (is (= fid (:frame (:tags tev)))
+                "trace :frame carries the exact emitting frame keyword"))))
       (obs/release! la)))
   (testing ":disposed boundary — the same schema binds the fallback boundary"
     (reg-items!)
@@ -3791,18 +3900,20 @@
                                   traces))
               rec (first (filterv #(= :rf.error/observation-on-change-failed (:error %))
                                   records))]
-          (is (valid-observation-on-change-failed-tags? (:tags tev))
-              "the :disposed dev-trace tags satisfy the canonical schema")
-          (is (= :disposed (:cause (:tags tev))))
-          (testing "the :disposed dev-trace :tags likewise carry the EXACT throwable
-                    and frame keyword, independently of the always-on record
-                    (rf2-5iud0a false-greens #1 + #3)"
-            (is (identical? boom (:exception (:tags tev)))
-                "trace :exception is the exact original throwable, not nil / a copy")
-            (is (= fid (:frame (:tags tev)))
-                "trace :frame carries the exact emitting frame keyword"))
+          ;; Record half always-on; trace half guarded (rf2-d2841).
           (is (some? rec))
-          (is (identical? boom (:exception rec))))
+          (is (identical? boom (:exception rec)))
+          (when interop/debug-enabled?
+            (is (valid-observation-on-change-failed-tags? (:tags tev))
+                "the :disposed dev-trace tags satisfy the canonical schema")
+            (is (= :disposed (:cause (:tags tev))))
+            (testing "the :disposed dev-trace :tags likewise carry the EXACT throwable
+                      and frame keyword, independently of the always-on record
+                      (rf2-5iud0a false-greens #1 + #3)"
+              (is (identical? boom (:exception (:tags tev)))
+                  "trace :exception is the exact original throwable, not nil / a copy")
+              (is (= fid (:frame (:tags tev)))
+                  "trace :frame carries the exact emitting frame keyword"))))
         (obs/release! la)))))
 
 (deftest schema-gate-rejects-required-key-and-value-drift
@@ -3817,38 +3928,75 @@
             tags (:tags (first (filterv #(= :rf.error/observation-on-change-failed
                                             (:operation %))
                                         traces)))]
-        (is (valid-observation-on-change-failed-tags? tags)
-            "baseline: the real record validates")
-        (testing "removing any required attribution key fails the gate"
-          (doseq [k observation-tags-required-keys]
-            (is (not (valid-observation-on-change-failed-tags? (dissoc tags k)))
-                (str "removing required key " k " must fail"))))
-        (testing "a :cause off the :hmr/:disposed channel-discriminator fails"
-          (is (not (valid-observation-on-change-failed-tags?
-                     (assoc tags :cause :bogus)))))
-        (testing "a spoofed :category fails"
-          (is (not (valid-observation-on-change-failed-tags?
-                     (assoc tags :category :rf.error/handler-exception)))))
-        (testing "false-green #1 — :exception is schema-typed :any, so the SCHEMA
-                  alone accepts a mutated trace :exception; the real fixtures instead
-                  assert exact throwable identity, which catches nil / a substituted
-                  throwable (rf2-5iud0a)"
+        ;; THE DRIFT MATRIX RUNS OVER A SYNTHETIC BASELINE (rf2-d2841), not
+        ;; over the emitted record, and that is a strengthening rather than a
+        ;; concession. `valid-observation-on-change-failed-tags?` is a PURE
+        ;; function of a tag map and the extracted schema; the drift claims
+        ;; below are claims about THE SCHEMA, so they need A conforming map,
+        ;; not THE emitted one. Driving them off the dev trace made every one
+        ;; of them VACUOUS under the gate: `tags` is nil there, `(dissoc nil k)`
+        ;; is nil, and "removing a required key must fail" was TRUE for all
+        ;; eight keys for the wrong reason — a gate whose whole purpose is to
+        ;; redden on schema drift was certifying drift-detection over an absent
+        ;; record. Twelve vacuous passes came off this way (eight from the
+        ;; doseq, the :cause and :category spoof rejections, and the two
+        ;; exact-identity negatives).
+        ;;
+        ;; The synthetic baseline cannot itself drift silently: if the markdown
+        ;; schema gains a required key or tightens a leaf type, this literal
+        ;; stops validating and the FIRST assertion reddens. The complementary
+        ;; direction — that the schema has not been WEAKENED — is pinned
+        ;; structurally and posture-independently by
+        ;; `canonical-schema-form-pins-the-strict-observation-shape`.
+        (let [synthetic-boom {:synthetic true}
+              synthetic {:category          :rf.error/observation-on-change-failed
+                         :rf.sub/id         :obs/items
+                         :rf.sub/query-v    [:obs/items]
+                         :where             'rf/drain-pending-disposals!
+                         :cause             :disposed
+                         :exception         synthetic-boom
+                         :exception-message "synthetic on-change boom"
+                         :reason            "a synthetic conforming tag map"
+                         :frame             fid}]
+          (is (valid-observation-on-change-failed-tags? synthetic)
+              "baseline: a conforming tag map validates (a required-key or leaf-type
+               TIGHTENING in the markdown reddens here)")
+          (testing "removing any required attribution key fails the gate"
+            (doseq [k observation-tags-required-keys]
+              (is (not (valid-observation-on-change-failed-tags? (dissoc synthetic k)))
+                  (str "removing required key " k " must fail"))))
+          (testing "a :cause off the :hmr/:disposed channel-discriminator fails"
+            (is (not (valid-observation-on-change-failed-tags?
+                       (assoc synthetic :cause :bogus)))))
+          (testing "a spoofed :category fails"
+            (is (not (valid-observation-on-change-failed-tags?
+                       (assoc synthetic :category :rf.error/handler-exception)))))
+          (testing "false-green #1 — :exception is schema-typed :any, so the SCHEMA
+                    alone accepts a mutated :exception; the real fixtures instead
+                    assert exact throwable identity, which catches nil / a substituted
+                    throwable (rf2-5iud0a)"
+            (is (valid-observation-on-change-failed-tags? (assoc synthetic :exception nil))
+                "the schema (:any) still validates a nil'd :exception — schema alone is a false green")
+            (is (valid-observation-on-change-failed-tags?
+                  (assoc synthetic :exception (ex-info "different" {})))
+                "the schema (:any) still validates a DIFFERENT throwable")
+            (is (not (identical? synthetic-boom (:exception (assoc synthetic :exception nil))))
+                "the exact-identity assertion the fixtures use catches the nil mutation")
+            (is (not (identical? synthetic-boom
+                                 (:exception (assoc synthetic :exception (ex-info "different" {})))))
+                "…and catches a substituted throwable"))
+          (testing "false-green #3 — a legitimately-absent OPTIONAL :frame stays valid
+                    (the optional row must not silently become required) (rf2-5iud0a)"
+            (is (valid-observation-on-change-failed-tags? (dissoc synthetic :frame))
+                "an absent optional :frame remains valid (frame is optional in the schema)")))
+        ;; The REAL emitted record is still bound to the same schema — that
+        ;; half is a runtime claim about the dev trace and is guarded.
+        (when interop/debug-enabled?
+          (is (valid-observation-on-change-failed-tags? tags)
+              "baseline: the real record validates")
           (is (identical? boom (:exception tags))
               "baseline: the real trace tags carry the exact throwable")
-          (is (valid-observation-on-change-failed-tags? (assoc tags :exception nil))
-              "the schema (:any) still validates a nil'd :exception — schema alone is a false green")
-          (is (valid-observation-on-change-failed-tags?
-                (assoc tags :exception (ex-info "different" {})))
-              "the schema (:any) still validates a DIFFERENT throwable")
-          (is (not (identical? boom (:exception (assoc tags :exception nil))))
-              "the exact-identity assertion the fixtures use catches the nil mutation")
-          (is (not (identical? boom (:exception (assoc tags :exception (ex-info "different" {})))))
-              "…and catches a substituted throwable"))
-        (testing "false-green #3 — a legitimately-absent OPTIONAL :frame stays valid
-                  (the optional row must not silently become required) (rf2-5iud0a)"
-          (is (= fid (:frame tags)) "baseline: the real record emits the frame tag")
-          (is (valid-observation-on-change-failed-tags? (dissoc tags :frame))
-              "an absent optional :frame remains valid (frame is optional in the schema)")))
+          (is (= fid (:frame tags)) "baseline: the real record emits the frame tag")))
       (obs/release! la))))
 
 (defn- schema-entry-of

--- a/implementation/core/test/re_frame/trace_cascade_captured_test.clj
+++ b/implementation/core/test/re_frame/trace_cascade_captured_test.clj
@@ -8,9 +8,55 @@
 
   Pure JVM coverage — the sub memo + flow trace emits + cascade
   aggregation all run identically on JVM and CLJS (the production
-  elision gate is shared; bundle-isolation lives in its own gate)."
+  elision gate is shared; bundle-isolation lives in its own gate).
+
+  ## Posture split (rf2-d2841)
+
+  Every claim in this file about `:rf.sub/skip`, `:rf.flow/skip`,
+  `:rf.cascade/captured` and the `:rf.sub/run` attribution tags is read off
+  the DEV TRACE, and there is no production channel that carries any of them
+  — checked, not assumed. `:rf.sub/*` and `:rf.cascade/*` are not error
+  categories, so `error-emit/emit-error-both!` never lifts them, and nothing
+  in `re-frame.observability` promotes a sub-recompute onto the always-on
+  `:errors` stream. So the trace reads are guarded.
+
+  What keeps this OFF the class-2 (100%-dev-instrumentation) list is that the
+  three `aggregate-cascade-*` deftests drive `cascade/aggregate-cascade` over
+  SYNTHETIC event maps — a pure function of its argument, always-on in both
+  postures — and that every trace-reading deftest here has an always-on
+  counterpart for the thing the trace was REPORTING ON. A `:rf.sub/skip` emit
+  reports a memo hit; the memo hit itself is production behaviour and is now
+  witnessed by counting how many times the sub body actually ran. A
+  `:rf.sub/run` value-change tag reports a recompute; the recomputed value is
+  production state and is now witnessed by dereferencing the reaction. A
+  `:rf.sub/cause-event-id` reports that a recompute happened INSIDE an
+  in-flight dispatch; that is witnessed by an fx-handler that derefs during
+  the drain and records what it saw. Under the gate those run for the first
+  time.
+
+  FIVE VACUOUS PASSES CAME OFF, in two classes.
+  class 1 (a negative over an empty ring):
+  `cascade-captured-does-not-fire-when-no-focus`'s `(is (empty? caps))`,
+  which certified \"the default focus predicate suppresses the aggregator\"
+  over a stream that carried no events of any kind.
+  class 4 (absence of a key the gate elides wholesale) — four `(nil? …)` /
+  `(not (contains? …))` negatives read off a NIL tag map, in
+  `sub-run-value-changed-attribution`,
+  `sub-run-first-run-flag-true-on-cache-slot-creation`,
+  `sub-run-layer-1-no-cause-sub` and
+  `sub-run-cause-event-id-absent-outside-dispatch`.
+
+  AND TWO ZERO-ASSERTION DEFTESTS, the shape pass 5 named: the inner claims
+  of `sub-run-cause-event-id-stamped-inside-dispatch` and
+  `sub-run-cause-event-id-layer-2-cascade` sit inside a `(when (seq runs) …)`
+  / `(when (and n-run d-run) …)`, so under the gate the guard was false and
+  those `is` forms never ran at all. Both are now inside the posture guard
+  where the precondition genuinely holds, and both deftests carry an
+  always-on witness that the in-cascade recompute they are about really
+  happened."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             ;; The cascade-captured aggregator hooks into `re-frame.epoch/
             ;; settle!` via the late-bind seam — without an epoch
             ;; producer on the classpath there is no settle-time emit
@@ -66,30 +112,42 @@
 
 (deftest layer-1-memo-hit-emits-sub-skip
   (testing "a layer-1 sub deref against an unchanged db emits :rf.sub/skip"
-    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
-    (rf/reg-sub :n (fn [db _] (:n db)))
-    (rf/dispatch-sync [:seed])
-    (let [events (collect-trace
-                   (fn []
-                     (let [r (rf/subscribe [:n])]
-                       ;; Two derefs against the unchanged db. The
-                       ;; first call (post-construction) is a memo hit
-                       ;; because the reaction's body fires on initial
-                       ;; deref but Reagent's reaction may invoke the
-                       ;; wrapper additional times on identical input.
-                       @r
-                       @r)))
-          skips  (filter #(= :rf.sub/skip (:operation %)) events)]
-      ;; At least one memo-hit emit must fire on the second deref.
-      (is (seq skips)
-          "expected at least one :rf.sub/skip emit on memo-hit")
-      (let [skip (first skips)]
-        (is (= :rf.sub (:op-type skip)))
-        (is (= :n (get-in skip [:tags :rf.sub/id])))
-        (is (= [:n] (get-in skip [:tags :rf.sub/query-v])))
-        (is (= :input-value-equal (get-in skip [:tags :rf.sub/reason])))
-        (is (= [] (get-in skip [:tags :rf.sub/input-paths-unchanged]))
-            "layer-1 has no upstream subs so :rf.sub/input-paths-unchanged is empty")))))
+    ;; ALWAYS-ON (rf2-d2841): `body-runs` counts how many times the sub's own
+    ;; body executed. That is the memo hit itself — production behaviour the
+    ;; `:rf.sub/skip` emit was merely REPORTING — so it is asserted outside
+    ;; the posture guard.
+    (let [body-runs (atom 0)
+          seen      (atom [])]
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 7}}))
+      (rf/reg-sub :n (fn [db _] (swap! body-runs inc) (:n db)))
+      (rf/dispatch-sync [:seed])
+      (let [events (collect-trace
+                     (fn []
+                       (let [r (rf/subscribe [:n])]
+                         ;; Two derefs against the unchanged db. The
+                         ;; first call (post-construction) is a memo hit
+                         ;; because the reaction's body fires on initial
+                         ;; deref but Reagent's reaction may invoke the
+                         ;; wrapper additional times on identical input.
+                         (swap! seen conj @r)
+                         (swap! seen conj @r))))
+            skips  (filter #(= :rf.sub/skip (:operation %)) events)]
+        (is (= [7 7] @seen)
+            "both derefs project the committed value in this posture")
+        (is (= 1 @body-runs)
+            "the memo the :rf.sub/skip emit reports actually held — two derefs,
+             one body run, in BOTH postures")
+        (when interop/debug-enabled?
+          ;; At least one memo-hit emit must fire on the second deref.
+          (is (seq skips)
+              "expected at least one :rf.sub/skip emit on memo-hit")
+          (let [skip (first skips)]
+            (is (= :rf.sub (:op-type skip)))
+            (is (= :n (get-in skip [:tags :rf.sub/id])))
+            (is (= [:n] (get-in skip [:tags :rf.sub/query-v])))
+            (is (= :input-value-equal (get-in skip [:tags :rf.sub/reason])))
+            (is (= [] (get-in skip [:tags :rf.sub/input-paths-unchanged]))
+                "layer-1 has no upstream subs so :rf.sub/input-paths-unchanged is empty")))))))
 
 (deftest layer-2-memo-hit-emits-sub-skip-with-upstream
   (testing "layer-2 sub on memo-hit names its upstream input(s) in :rf.sub/input-paths-unchanged"
@@ -99,18 +157,25 @@
       :<- [:n]
       (fn [n _] (* 2 n)))
     (rf/dispatch-sync [:seed])
-    (let [events (collect-trace
+    (let [seen   (atom [])
+          events (collect-trace
                    (fn []
                      (let [r (rf/subscribe [:doubled])]
-                       @r @r)))
+                       (swap! seen conj @r)
+                       (swap! seen conj @r))))
           skips  (filter #(and (= :rf.sub/skip (:operation %))
                                (= :doubled (get-in % [:tags :rf.sub/id])))
                          events)]
-      (is (seq skips)
-          "expected at least one :rf.sub/skip emit for the layer-2 sub")
-      (let [skip (first skips)]
-        (is (= [[:n]] (get-in skip [:tags :rf.sub/input-paths-unchanged]))
-            "input-paths-unchanged names the upstream sub vector")))))
+      ;; ALWAYS-ON (rf2-d2841): the layer-2 projection the skip emit reports
+      ;; on is production state — both derefs see the same committed value.
+      (is (= [6 6] @seen)
+          "the layer-2 sub projects 2*3 on both derefs in this posture")
+      (when interop/debug-enabled?
+        (is (seq skips)
+            "expected at least one :rf.sub/skip emit for the layer-2 sub")
+        (let [skip (first skips)]
+          (is (= [[:n]] (get-in skip [:tags :rf.sub/input-paths-unchanged]))
+              "input-paths-unchanged names the upstream sub vector"))))))
 
 ;; ---- :rf.flow/skip carries :rf.sub/input-paths-unchanged -------------------------
 
@@ -118,19 +183,31 @@
   (testing ":rf.flow/skip carries :rf.sub/input-paths-unchanged naming the flow's input paths"
     (rf/reg-event :seed   (fn [{:keys [db]} _]      {:db {:x 0 :y 0}}))
     (rf/reg-event :bump-z (fn [{:keys [db]} _]     {:db (assoc db :z (inc (or (:z db) 0)))}))
-    (rf/reg-flow :sum {:inputs [[:x] [:y]] :output-path [:derived :sum]} (fn [x y] (+ x y)))
-    (rf/dispatch-sync [:seed])
-    ;; First non-seed dispatch — flow recomputes. Second — inputs stable,
-    ;; flow emits :rf.flow/skip.
-    (let [events (collect-trace
-                   (fn []
-                     (rf/dispatch-sync [:bump-z])
-                     (rf/dispatch-sync [:bump-z])))
-          skips  (filter #(= :rf.flow/skip (:operation %)) events)]
-      (is (seq skips) "expected at least one :rf.flow/skip emit")
-      (let [skip (first skips)]
-        (is (= [[:x] [:y]] (get-in skip [:tags :input-paths-unchanged])))
-        (is (= :inputs-value-equal (get-in skip [:tags :reason])))))))
+    ;; ALWAYS-ON (rf2-d2841): `flow-runs` counts the flow fn's own
+    ;; executions. "The inputs were stable so the flow did not recompute" is
+    ;; the production fact the `:rf.flow/skip` emit reports; count it.
+    (let [flow-runs (atom 0)]
+      (rf/reg-flow :sum {:inputs [[:x] [:y]] :output-path [:derived :sum]}
+                   (fn [x y] (swap! flow-runs inc) (+ x y)))
+      (rf/dispatch-sync [:seed])
+      ;; First non-seed dispatch — flow recomputes. Second — inputs stable,
+      ;; flow emits :rf.flow/skip.
+      (let [runs-after-seed @flow-runs
+            events (collect-trace
+                     (fn []
+                       (rf/dispatch-sync [:bump-z])
+                       (rf/dispatch-sync [:bump-z])))
+            skips  (filter #(= :rf.flow/skip (:operation %)) events)]
+        (is (= runs-after-seed @flow-runs)
+            "neither :bump-z touched [:x] or [:y], so the flow fn did not run
+             again — the skip is real in BOTH postures")
+        (is (= 0 (get-in (rf/app-db-value :rf/default) [:derived :sum]))
+            "the flow's durable output survives the two skipped epochs")
+        (when interop/debug-enabled?
+          (is (seq skips) "expected at least one :rf.flow/skip emit")
+          (let [skip (first skips)]
+            (is (= [[:x] [:y]] (get-in skip [:tags :input-paths-unchanged])))
+            (is (= :inputs-value-equal (get-in skip [:tags :reason])))))))))
 
 ;; ---- :rf.cascade/captured -------------------------------------------------
 
@@ -140,15 +217,25 @@
     (rf/reg-event :inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
-    (let [events (collect-trace
+    (let [seen   (atom [])
+          events (collect-trace
                    (fn []
                      (let [r (rf/subscribe [:n])]
-                       @r
+                       (swap! seen conj @r)
                        (rf/dispatch-sync [:inc])
-                       @r)))
+                       (swap! seen conj @r))))
           caps   (filter #(= :rf.cascade/captured (:operation %)) events)]
-      (is (empty? caps)
-          "no :rf.cascade/captured when focus predicate returns false"))))
+      ;; ALWAYS-ON (rf2-d2841): the cascade whose absence-of-capture is the
+      ;; claim genuinely ran. VACUOUS PASS REMOVED (class 1) — under the gate
+      ;; `events` is empty for EVERY cascade, focused or not, so
+      ;; `(empty? caps)` certified the focus predicate's suppression over a
+      ;; stream that never carried anything. It only discriminates against
+      ;; `cascade-captured-fires-when-focused` below, which needs the ring.
+      (is (= [0 1] @seen)
+          "the cascade really ran — the sub recomputed 0 -> 1 in this posture")
+      (when interop/debug-enabled?
+        (is (empty? caps)
+            "no :rf.cascade/captured when focus predicate returns false")))))
 
 (deftest cascade-captured-fires-when-focused
   (testing "installed focus-predicate matching the cascade → :rf.cascade/captured emits"
@@ -158,25 +245,32 @@
     (cascade/set-focus-predicate!
       (fn [_frame _epoch _event] true))
     (rf/dispatch-sync [:seed])
-    (let [events (collect-trace
+    (let [seen   (atom [])
+          events (collect-trace
                    (fn []
                      (let [r (rf/subscribe [:n])]
-                       @r
+                       (swap! seen conj @r)
                        (rf/dispatch-sync [:inc])
-                       @r)))
+                       (swap! seen conj @r))))
           caps   (filter #(= :rf.cascade/captured (:operation %)) events)]
-      (is (seq caps) "expected at least one :rf.cascade/captured emit under focus")
-      (let [cap (first caps)]
-        (is (= :rf.cascade (:op-type cap)))
-        (is (contains? (:tags cap) :frame))
-        (is (contains? (:tags cap) :rf.epoch/id))
-        (is (vector? (get-in cap [:tags :subs-recomputed])))
-        (is (vector? (get-in cap [:tags :subs-skipped])))
-        (is (vector? (get-in cap [:tags :flows-computed])))
-        (is (vector? (get-in cap [:tags :flows-skipped])))
-        (is (vector? (get-in cap [:tags :views-rendered])))
-        (is (boolean? (get-in cap [:tags :sub-cap-truncated?])))
-        (is (boolean? (get-in cap [:tags :view-cap-truncated?])))))))
+      ;; ALWAYS-ON (rf2-d2841): installing a focus predicate is an
+      ;; instrumentation-only act, but it must not perturb the cascade it
+      ;; observes — the same 0 -> 1 recompute as the unfocused case above.
+      (is (= [0 1] @seen)
+          "the focus predicate does not perturb the cascade it observes")
+      (when interop/debug-enabled?
+        (is (seq caps) "expected at least one :rf.cascade/captured emit under focus")
+        (let [cap (first caps)]
+          (is (= :rf.cascade (:op-type cap)))
+          (is (contains? (:tags cap) :frame))
+          (is (contains? (:tags cap) :rf.epoch/id))
+          (is (vector? (get-in cap [:tags :subs-recomputed])))
+          (is (vector? (get-in cap [:tags :subs-skipped])))
+          (is (vector? (get-in cap [:tags :flows-computed])))
+          (is (vector? (get-in cap [:tags :flows-skipped])))
+          (is (vector? (get-in cap [:tags :views-rendered])))
+          (is (boolean? (get-in cap [:tags :sub-cap-truncated?])))
+          (is (boolean? (get-in cap [:tags :view-cap-truncated?]))))))))
 
 ;; ---- bounds ---------------------------------------------------------------
 
@@ -269,19 +363,27 @@
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (let [r      (rf/subscribe [:n])
-          _      @r ;; force first recompute (value 1)
+          before @r ;; force first recompute (value 1)
+          after  (atom nil)
           events (collect-trace
                    (fn []
                      (rf/dispatch-sync [:inc]) ;; n 1 -> 2, layer-1 recompute
-                     @r))
+                     (reset! after @r)))
           runs   (sub-runs events :n)]
-      (is (seq runs) "expected a :rf.sub/run for :n on the value-changing recompute")
-      (let [t (:tags (first runs))]
-        (is (true? (:rf.sub/value-changed? t)) "value changed 1 -> 2")
-        (is (= 1 (:rf.sub/prev-value t)) ":rf.sub/prev-value is the prior computed value")
-        (is (= 2 (:rf.sub/value t)) ":value is the freshly computed value")
-        (is (false? (:rf.sub/cascade? t)) "layer-1 sub is app-db-driven, not a cascade")
-        (is (nil? (:rf.sub/cause-sub t)) "layer-1 has no upstream sub to attribute")))))
+      ;; ALWAYS-ON (rf2-d2841): the value change the trace tag REPORTS is
+      ;; production state — read it off the reaction. VACUOUS PASS REMOVED
+      ;; (class 4): `(nil? (:rf.sub/cause-sub t))` was true for free under the
+      ;; gate, where `t` is nil and every keyword lookup returns nil.
+      (is (= 1 before) "the sub projected 1 before the dispatch")
+      (is (= 2 @after) "the sub projects 2 after the dispatch, in this posture")
+      (when interop/debug-enabled?
+        (is (seq runs) "expected a :rf.sub/run for :n on the value-changing recompute")
+        (let [t (:tags (first runs))]
+          (is (true? (:rf.sub/value-changed? t)) "value changed 1 -> 2")
+          (is (= 1 (:rf.sub/prev-value t)) ":rf.sub/prev-value is the prior computed value")
+          (is (= 2 (:rf.sub/value t)) ":value is the freshly computed value")
+          (is (false? (:rf.sub/cascade? t)) "layer-1 sub is app-db-driven, not a cascade")
+          (is (nil? (:rf.sub/cause-sub t)) "layer-1 has no upstream sub to attribute"))))))
 
 (deftest sub-run-value-unchanged-attribution
   (testing "a recompute whose value did NOT change stamps :rf.sub/value-changed? false"
@@ -295,19 +397,27 @@
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (let [r      (rf/subscribe [:n])
-          _      @r ;; first recompute, value 5
+          before @r ;; first recompute, value 5
+          after  (atom nil)
           events (collect-trace
                    (fn []
                      ;; db changes (whole-map identity changes), :n body
                      ;; re-runs, but :n's value stays 5.
                      (rf/dispatch-sync [:bump-other])
-                     @r))
+                     (reset! after @r)))
           runs   (sub-runs events :n)]
-      (is (seq runs) "expected a :rf.sub/run for :n on the re-run (db identity changed)")
-      (let [t (:tags (first runs))]
-        (is (false? (:rf.sub/value-changed? t)) ":n re-ran but its value stayed 5")
-        (is (= 5 (:rf.sub/prev-value t)))
-        (is (= 5 (:rf.sub/value t)))))))
+      ;; ALWAYS-ON (rf2-d2841): the false case the tag reports has a
+      ;; production shape — the db DID change and :n's projection did NOT.
+      (is (= 5 before))
+      (is (= 5 @after) ":n's value is unchanged across the write, in this posture")
+      (is (= 1 (:other (rf/app-db-value :rf/default)))
+          "the db really did change — the unchanged-value case is not vacuous")
+      (when interop/debug-enabled?
+        (is (seq runs) "expected a :rf.sub/run for :n on the re-run (db identity changed)")
+        (let [t (:tags (first runs))]
+          (is (false? (:rf.sub/value-changed? t)) ":n re-ran but its value stayed 5")
+          (is (= 5 (:rf.sub/prev-value t)))
+          (is (= 5 (:rf.sub/value t))))))))
 
 (deftest sub-run-cascade-attribution-layer-2
   (testing "a layer-2 sub recomputed by an upstream sub change stamps :rf.sub/cascade? true + :rf.sub/cause-sub naming the upstream"
@@ -319,20 +429,26 @@
       (fn [n _] (* 2 n)))
     (rf/dispatch-sync [:seed])
     (let [r      (rf/subscribe [:doubled])
-          _      @r ;; first recompute, value 4
+          before @r ;; first recompute, value 4
+          after  (atom nil)
           events (collect-trace
                    (fn []
                      (rf/dispatch-sync [:inc]) ;; :n 2->3, :doubled cascades 4->6
-                     @r))
+                     (reset! after @r)))
           runs   (sub-runs events :doubled)]
-      (is (seq runs) "expected a :rf.sub/run for :doubled on the cascade")
-      (let [t (:tags (first runs))]
-        (is (true? (:rf.sub/value-changed? t)) ":doubled changed 4 -> 6")
-        (is (= 4 (:rf.sub/prev-value t)))
-        (is (= 6 (:rf.sub/value t)))
-        (is (true? (:rf.sub/cascade? t)) "layer-2 recompute is a cascade")
-        (is (= [:n] (:rf.sub/cause-sub t))
-            ":rf.sub/cause-sub names the upstream sub query-vector that changed")))))
+      ;; ALWAYS-ON (rf2-d2841): the cascade itself — an upstream write
+      ;; propagating through a layer-2 projection — is production behaviour.
+      (is (= 4 before))
+      (is (= 6 @after) ":doubled cascaded 4 -> 6 in this posture")
+      (when interop/debug-enabled?
+        (is (seq runs) "expected a :rf.sub/run for :doubled on the cascade")
+        (let [t (:tags (first runs))]
+          (is (true? (:rf.sub/value-changed? t)) ":doubled changed 4 -> 6")
+          (is (= 4 (:rf.sub/prev-value t)))
+          (is (= 6 (:rf.sub/value t)))
+          (is (true? (:rf.sub/cascade? t)) "layer-2 recompute is a cascade")
+          (is (= [:n] (:rf.sub/cause-sub t))
+              ":rf.sub/cause-sub names the upstream sub query-vector that changed"))))))
 
 (deftest sub-run-cascade-attribution-layer-2-multi-input
   (testing "a multi-input layer-2 sub names the SPECIFIC upstream that changed"
@@ -345,18 +461,27 @@
       :<- [:b]
       (fn [[a b] _] (+ a b)))
     (rf/dispatch-sync [:seed])
-    (let [r      (rf/subscribe [:sum])
-          _      @r ;; first recompute, value 11
+    (let [r-a    (rf/subscribe [:a])
+          r      (rf/subscribe [:sum])
+          before @r ;; first recompute, value 11
+          after  (atom nil)
           events (collect-trace
                    (fn []
                      (rf/dispatch-sync [:inc-b]) ;; :b 10->11, :a stable
-                     @r))
+                     (reset! after @r)))
           runs   (sub-runs events :sum)]
-      (is (seq runs))
-      (let [t (:tags (first runs))]
-        (is (true? (:rf.sub/cascade? t)))
-        (is (= [:b] (:rf.sub/cause-sub t))
-            ":rf.sub/cause-sub names :b (the changed input), not :a (stable)")))))
+      ;; ALWAYS-ON (rf2-d2841): the asymmetry the `:rf.sub/cause-sub` tag
+      ;; ATTRIBUTES is production state — :b moved, :a did not, and :sum
+      ;; followed :b.
+      (is (= 11 before))
+      (is (= 12 @after) ":sum followed :b's change in this posture")
+      (is (= 1 @r-a) ":a is genuinely stable across the write")
+      (when interop/debug-enabled?
+        (is (seq runs))
+        (let [t (:tags (first runs))]
+          (is (true? (:rf.sub/cascade? t)))
+          (is (= [:b] (:rf.sub/cause-sub t))
+              ":rf.sub/cause-sub names :b (the changed input), not :a (stable)"))))))
 
 ;; ---- :rf.sub/first-run? (rf2-fyd8u) -------------------------------------
 
@@ -365,28 +490,39 @@
             stamps :rf.sub/first-run? true on :rf.sub/run. Disambiguates
             a value-change row (`← was X`) from a fresh-cache-entry row
             (`:added`) for the Xray SUBSCRIPTIONS leaf-scalar renderer."
-    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 1}}))
-    (rf/reg-sub :n (fn [db _] (:n db)))
-    (rf/dispatch-sync [:seed])
-    ;; First subscribe + deref → this is the run that creates the
-    ;; cache slot. The memo wrapper's `prev-value` is the `::unset`
-    ;; sentinel here, so `:rf.sub/first-run?` must stamp true.
-    (let [events (collect-trace
-                   (fn []
-                     (let [r (rf/subscribe [:n])]
-                       @r)))
-          runs   (sub-runs events :n)]
-      (is (seq runs)
-          "expected a :rf.sub/run on the cache-slot-creating recompute")
-      (let [t (:tags (first runs))]
-        (is (true? (:rf.sub/first-run? t))
-            ":rf.sub/first-run? is true on the run that allocated the slot")
-        (is (true? (:rf.sub/value-changed? t))
-            "first-run is also a value-change (no prior value to compare,
-             per Spec 009 §:rf.sub/run :value-changed? semantics)")
-        (is (nil? (:rf.sub/prev-value t))
-            ":rf.sub/prev-value is nil on the first recompute (the
-             ::unset sentinel projects to nil per the emit-site cond)")))))
+    ;; ALWAYS-ON (rf2-d2841): `body-runs` witnesses the slot allocation the
+    ;; flag reports — the FIRST deref runs the body, the second does not,
+    ;; which is exactly what "this run created the cache slot" means.
+    (let [body-runs (atom 0)]
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 1}}))
+      (rf/reg-sub :n (fn [db _] (swap! body-runs inc) (:n db)))
+      (rf/dispatch-sync [:seed])
+      ;; First subscribe + deref → this is the run that creates the
+      ;; cache slot. The memo wrapper's `prev-value` is the `::unset`
+      ;; sentinel here, so `:rf.sub/first-run?` must stamp true.
+      (let [first-value (atom nil)
+            events (collect-trace
+                     (fn []
+                       (let [r (rf/subscribe [:n])]
+                         (reset! first-value @r))))
+            runs   (sub-runs events :n)]
+        ;; VACUOUS PASS REMOVED (class 4): `(nil? (:rf.sub/prev-value t))` was
+        ;; true for free under the gate, where `t` is nil.
+        (is (= 1 @first-value) "the cache-slot-creating run projects 1")
+        (is (= 1 @body-runs)
+            "exactly one body run allocated the slot, in BOTH postures")
+        (when interop/debug-enabled?
+          (is (seq runs)
+              "expected a :rf.sub/run on the cache-slot-creating recompute")
+          (let [t (:tags (first runs))]
+            (is (true? (:rf.sub/first-run? t))
+                ":rf.sub/first-run? is true on the run that allocated the slot")
+            (is (true? (:rf.sub/value-changed? t))
+                "first-run is also a value-change (no prior value to compare,
+                 per Spec 009 §:rf.sub/run :value-changed? semantics)")
+            (is (nil? (:rf.sub/prev-value t))
+                ":rf.sub/prev-value is nil on the first recompute (the
+                 ::unset sentinel projects to nil per the emit-site cond)")))))))
 
 (deftest sub-run-first-run-flag-false-on-recompute-against-existing-slot
   (testing "rf2-fyd8u — every subsequent recompute (against an
@@ -398,22 +534,29 @@
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (let [r      (rf/subscribe [:n])
-          _      @r ;; force the first recompute (creates the slot, value 1)
+          before @r ;; force the first recompute (creates the slot, value 1)
+          after  (atom nil)
           events (collect-trace
                    (fn []
                      (rf/dispatch-sync [:inc]) ;; n 1 -> 2, existing-slot recompute
-                     @r))
+                     (reset! after @r)))
           runs   (sub-runs events :n)]
-      (is (seq runs)
-          "expected a :rf.sub/run for :n on the value-changing recompute")
-      (let [t (:tags (first runs))]
-        (is (false? (:rf.sub/first-run? t))
-            ":rf.sub/first-run? flips to false on a subsequent recompute")
-        (is (true? (:rf.sub/value-changed? t))
-            ":n changed 1 -> 2 — value-changed? still true")
-        (is (= 1 (:rf.sub/prev-value t))
-            ":rf.sub/prev-value carries the real prior value")
-        (is (= 2 (:rf.sub/value t)))))))
+      ;; ALWAYS-ON (rf2-d2841): "the slot already existed" is witnessed by
+      ;; the prior deref having produced a value at all — this recompute is
+      ;; the second, and it still tracks the write.
+      (is (= 1 before) "the slot was already allocated by this deref")
+      (is (= 2 @after) "the second recompute tracks the write, in this posture")
+      (when interop/debug-enabled?
+        (is (seq runs)
+            "expected a :rf.sub/run for :n on the value-changing recompute")
+        (let [t (:tags (first runs))]
+          (is (false? (:rf.sub/first-run? t))
+              ":rf.sub/first-run? flips to false on a subsequent recompute")
+          (is (true? (:rf.sub/value-changed? t))
+              ":n changed 1 -> 2 — value-changed? still true")
+          (is (= 1 (:rf.sub/prev-value t))
+              ":rf.sub/prev-value carries the real prior value")
+          (is (= 2 (:rf.sub/value t))))))))
 
 (deftest sub-run-first-run-flag-true-on-layer-2-cache-creation
   (testing "rf2-fyd8u — layer-2 subs (cascade path) also stamp
@@ -426,16 +569,22 @@
       :<- [:n]
       (fn [n _] (* 2 n)))
     (rf/dispatch-sync [:seed])
-    (let [events (collect-trace
+    (let [first-value (atom nil)
+          events (collect-trace
                    (fn []
                      (let [r (rf/subscribe [:doubled])]
-                       @r)))
+                       (reset! first-value @r))))
           runs   (sub-runs events :doubled)]
-      (is (seq runs))
-      (let [t (:tags (first runs))]
-        (is (true? (:rf.sub/first-run? t))
-            "layer-2 sub: first-run? true on cache-slot creation")
-        (is (= 4 (:rf.sub/value t)))))))
+      ;; ALWAYS-ON (rf2-d2841): the layer-2 slot-creating recompute produced
+      ;; a value — production state, not a trace tag.
+      (is (= 4 @first-value)
+          "the layer-2 cache-slot-creating run projects 2*2 in this posture")
+      (when interop/debug-enabled?
+        (is (seq runs))
+        (let [t (:tags (first runs))]
+          (is (true? (:rf.sub/first-run? t))
+              "layer-2 sub: first-run? true on cache-slot creation")
+          (is (= 4 (:rf.sub/value t))))))))
 
 (deftest sub-run-layer-1-no-cause-sub
   (testing "a layer-1 sub never carries a :rf.sub/cause-sub (app-db-driven, not a cascade)"
@@ -444,16 +593,25 @@
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (let [r      (rf/subscribe [:n])
-          _      @r
+          before @r
+          after  (atom nil)
           events (collect-trace
                    (fn []
                      (rf/dispatch-sync [:inc])
-                     @r))
+                     (reset! after @r)))
           runs   (sub-runs events :n)]
-      (is (seq runs))
-      (let [t (:tags (first runs))]
-        (is (false? (:rf.sub/cascade? t)))
-        (is (nil? (:rf.sub/cause-sub t)))))))
+      ;; ALWAYS-ON (rf2-d2841): "app-db-driven, not a cascade" is a claim
+      ;; about WHERE this sub reads from, and that is production-visible —
+      ;; the sub tracks a direct app-db write with no upstream sub involved.
+      ;; VACUOUS PASS REMOVED (class 4): `(nil? (:rf.sub/cause-sub t))` was
+      ;; true for free under the gate, where `t` is nil.
+      (is (= 0 before))
+      (is (= 1 @after) "the layer-1 sub tracks the app-db write directly")
+      (when interop/debug-enabled?
+        (is (seq runs))
+        (let [t (:tags (first runs))]
+          (is (false? (:rf.sub/cascade? t)))
+          (is (nil? (:rf.sub/cause-sub t))))))))
 
 (deftest sub-run-base-shape-still-emitted
   (testing "the :rf.sub/run op-type vocabulary is unchanged — the base tags still ride"
@@ -462,18 +620,23 @@
     (rf/reg-sub :n (fn [db _] (:n db)))
     (rf/dispatch-sync [:seed])
     (let [r      (rf/subscribe [:n])
-          _      @r
+          before @r
+          after  (atom nil)
           events (collect-trace
                    (fn []
                      (rf/dispatch-sync [:inc])
-                     @r))
+                     (reset! after @r)))
           runs   (sub-runs events :n)]
-      (is (seq runs))
-      (let [ev (first runs)]
-        (is (= :rf.sub (:op-type ev)))
-        (is (= :n (get-in ev [:tags :rf.sub/id])))
-        (is (= [:n] (get-in ev [:tags :rf.sub/query-v])))
-        (is (contains? (:tags ev) :frame))))))
+      ;; ALWAYS-ON (rf2-d2841): the recompute the base shape describes.
+      (is (= 1 before))
+      (is (= 2 @after) "the recompute the :rf.sub/run row describes really happened")
+      (when interop/debug-enabled?
+        (is (seq runs))
+        (let [ev (first runs)]
+          (is (= :rf.sub (:op-type ev)))
+          (is (= :n (get-in ev [:tags :rf.sub/id])))
+          (is (= [:n] (get-in ev [:tags :rf.sub/query-v])))
+          (is (contains? (:tags ev) :frame)))))))
 
 ;; ---- :rf.sub/cause-event-id (rf2-okz1u) ----------------------------------
 ;;
@@ -508,25 +671,42 @@
       ;; The fx-handler signature is `(fn [ctx args])` per Spec 002
       ;; §The binary fx-handler signature — ctx carries `:frame`,
       ;; `:event`, `:envelope`; args is the value from the `:fx` vector.
-      (rf/reg-fx :deref-fx (fn [_ctx _args] @r))
-      (rf/reg-event :bump-and-deref
-        (fn [_ _]
-          ;; The event handler returns the canonical `:db` / `:fx` shape
-          ;; (re-frame2 rejects arbitrary top-level keys per
-          ;; `events.cljc/police-effect-map-shape!`).
-          {:db {:n 99}
-           :fx [[:deref-fx true]]}))
-      (let [events (collect-trace
-                     (fn []
-                       (rf/dispatch-sync [:bump-and-deref])))
-            runs   (sub-runs events :n)]
-        (is (seq runs)
-            "expected a :rf.sub/run for :n on the in-cascade fx-deref")
-        (when (seq runs)
-          (let [t (:tags (first runs))]
-            (is (= :bump-and-deref (:rf.sub/cause-event-id t))
-                ":rf.sub/cause-event-id names the dispatching event,
-                 not the sub-id and not the :seed event")))))))
+      ;; ALWAYS-ON (rf2-d2841): `in-cascade` records what the fx-handler saw
+      ;; when it dereferenced DURING the drain. That the sub recomputed
+      ;; inside the in-flight run is precisely what `:rf.sub/cause-event-id`
+      ;; attributes, and it is production behaviour — the fx observing the
+      ;; committed 99 rather than the pre-dispatch 0 IS the in-cascade
+      ;; recompute.
+      (let [in-cascade (atom ::not-run)]
+        (rf/reg-fx :deref-fx (fn [_ctx _args] (reset! in-cascade @r)))
+        (rf/reg-event :bump-and-deref
+          (fn [_ _]
+            ;; The event handler returns the canonical `:db` / `:fx` shape
+            ;; (re-frame2 rejects arbitrary top-level keys per
+            ;; `events.cljc/police-effect-map-shape!`).
+            {:db {:n 99}
+             :fx [[:deref-fx true]]}))
+        (let [events (collect-trace
+                       (fn []
+                         (rf/dispatch-sync [:bump-and-deref])))
+              runs   (sub-runs events :n)]
+          (is (= 99 @in-cascade)
+              "the fx-handler dereferenced INSIDE the drain and saw the
+               committed value — the in-cascade recompute happened in this
+               posture")
+          ;; ZERO-ASSERTION DEFTEST FIXED (rf2-d2841): the claim below used to
+          ;; sit under `(when (seq runs) …)`. Under the gate `runs` is empty,
+          ;; so the `when` was false and NO assertion ran inside it — the
+          ;; deftest reported a pass having executed nothing but the failing
+          ;; precondition. The precondition and the claim it licenses now
+          ;; live together inside the posture guard.
+          (when interop/debug-enabled?
+            (is (seq runs)
+                "expected a :rf.sub/run for :n on the in-cascade fx-deref")
+            (let [t (:tags (first runs))]
+              (is (= :bump-and-deref (:rf.sub/cause-event-id t))
+                  ":rf.sub/cause-event-id names the dispatching event,
+                   not the sub-id and not the :seed event"))))))))
 
 (deftest sub-run-cause-event-id-absent-outside-dispatch
   (testing "rf2-okz1u — a sub-run that fires OUTSIDE any in-flight
@@ -541,16 +721,25 @@
     ;; OUTSIDE any in-flight run — the in-flight buffer is empty so
     ;; the `:epoch/run-cause` hook returns no `:cause-event-id`. The
     ;; tag MUST be absent from the emitted `:rf.sub/run` tags.
-    (let [events (collect-trace
+    (let [outside (atom nil)
+          events (collect-trace
                    (fn []
                      (let [r (rf/subscribe [:n])]
-                       @r)))
+                       (reset! outside @r))))
           runs   (sub-runs events :n)]
-      (is (seq runs)
-          "expected a :rf.sub/run for :n on the cache-creating recompute")
-      (let [t (:tags (first runs))]
-        (is (not (contains? t :rf.sub/cause-event-id))
-            ":rf.sub/cause-event-id is OMITTED (key absent) outside a cascade")))))
+      ;; ALWAYS-ON (rf2-d2841): the recompute really did happen with no
+      ;; dispatch in flight — the value is the settled one. VACUOUS PASS
+      ;; REMOVED (class 4): `(not (contains? t :rf.sub/cause-event-id))` was
+      ;; true for free under the gate, where `t` is nil and `contains?` of nil
+      ;; is false for EVERY key.
+      (is (= 7 @outside)
+          "the out-of-cascade recompute projects the settled value")
+      (when interop/debug-enabled?
+        (is (seq runs)
+            "expected a :rf.sub/run for :n on the cache-creating recompute")
+        (let [t (:tags (first runs))]
+          (is (not (contains? t :rf.sub/cause-event-id))
+              ":rf.sub/cause-event-id is OMITTED (key absent) outside a cascade"))))))
 
 (deftest sub-run-cause-event-id-layer-2-cascade
   (testing "rf2-okz1u — layer-2 sub recomputed inside the cascade
@@ -569,31 +758,42 @@
           r-doubled (rf/subscribe [:doubled])
           _         @r-n
           _         @r-doubled]
-      (rf/reg-fx :deref-both-fx (fn [_ctx _args] @r-n @r-doubled))
-      (rf/reg-event :bump-and-deref-both
-        (fn [_ _]
-          {:db {:n 3}
-           :fx [[:deref-both-fx true]]}))
-      (let [events (collect-trace
-                     (fn []
-                       (rf/dispatch-sync [:bump-and-deref-both])))
-            n-run  (first (sub-runs events :n))
-            d-run  (first (sub-runs events :doubled))]
-        (is (some? n-run))
-        (is (some? d-run))
-        (when (and n-run d-run)
-          (is (= :bump-and-deref-both
-                 (get-in n-run [:tags :rf.sub/cause-event-id]))
-              "layer-1 sub :n carries the dispatching event-id")
-          (is (= :bump-and-deref-both
-                 (get-in d-run [:tags :rf.sub/cause-event-id]))
-              "layer-2 sub :doubled carries the SAME cause-event-id,
-               because both subs were invalidated by the same
-               dispatching event")
-          (is (= [:n] (get-in d-run [:tags :rf.sub/cause-sub]))
-              ":rf.sub/cause-sub on :doubled still names the upstream
-               sub — the two attribution slots are complementary,
-               not redundant"))))))
+      ;; ALWAYS-ON (rf2-d2841): both subs were invalidated by the SAME write
+      ;; and both recomputed inside the SAME drain — that shared causation is
+      ;; what the two `:rf.sub/cause-event-id` tags record, and the fx-handler
+      ;; observing 3 and 6 together witnesses it without the trace.
+      (let [in-cascade (atom ::not-run)]
+        (rf/reg-fx :deref-both-fx (fn [_ctx _args] (reset! in-cascade [@r-n @r-doubled])))
+        (rf/reg-event :bump-and-deref-both
+          (fn [_ _]
+            {:db {:n 3}
+             :fx [[:deref-both-fx true]]}))
+        (let [events (collect-trace
+                       (fn []
+                         (rf/dispatch-sync [:bump-and-deref-both])))
+              n-run  (first (sub-runs events :n))
+              d-run  (first (sub-runs events :doubled))]
+          (is (= [3 6] @in-cascade)
+              "both layers recomputed inside the one drain — the shared
+               causation the two cause-event-id tags record")
+          ;; ZERO-ASSERTION DEFTEST FIXED (rf2-d2841): the three claims below
+          ;; used to sit under `(when (and n-run d-run) …)`, which is false
+          ;; under the gate — the deftest ran no assertion inside it at all.
+          (when interop/debug-enabled?
+            (is (some? n-run))
+            (is (some? d-run))
+            (is (= :bump-and-deref-both
+                   (get-in n-run [:tags :rf.sub/cause-event-id]))
+                "layer-1 sub :n carries the dispatching event-id")
+            (is (= :bump-and-deref-both
+                   (get-in d-run [:tags :rf.sub/cause-event-id]))
+                "layer-2 sub :doubled carries the SAME cause-event-id,
+                 because both subs were invalidated by the same
+                 dispatching event")
+            (is (= [:n] (get-in d-run [:tags :rf.sub/cause-sub]))
+                ":rf.sub/cause-sub on :doubled still names the upstream
+                 sub — the two attribution slots are complementary,
+                 not redundant")))))))
 
 (deftest aggregate-cascade-shape-pin
   (testing "aggregate-cascade splits subs by :rf.sub/run vs :rf.sub/skip"

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -44,7 +44,7 @@
 # a rewrite of how those assertions are spelled.  Triage beads are named per
 # cluster below.
 #
-# What is left IS green, and it is not a rump: 154 namespaces, 1740 tests, 7342
+# What is left IS green, and it is not a rump: 158 namespaces, 1931 tests, 8324
 # assertions, exit 0 — versus the zero suites that had ever executed under this
 # posture before.  (It was
 # 88 / 934 / 4340 tests/assertions before rf2-d2841 split the spine's
@@ -53,9 +53,24 @@
 # single entry, 107 failures and 25 errors across ~20 deftests — plus
 # `sub-topology`, `init-platform`, `pattern-smoke` and `db-noop-commit`,
 # 103 / 1213 / 5590 before its third pass took twenty more, 123 / 1401 / 6054
-# before its FOURTH pass took seventeen more, and 141 / 1560 / 6707 before its
-# FIFTH pass took thirteen more.  Each pass's namespaces are named in its
-# commits — `git log --grep=rf2-d2841`.)
+# before its FOURTH pass took seventeen more, 141 / 1560 / 6707 before its
+# FIFTH pass took thirteen more, and 154 / 1740 / 7342 before its SIXTH pass
+# took the last four ACTIONABLE lines under that bead's heading.  Each pass's
+# namespaces are named in its commits — `git log --grep=rf2-d2841`.)
+#
+# WHAT REMAINS EXCLUDED, and why it is not more of the same work.  Of the 27,
+# twelve sit under other headings (eleven under rf2-r9bra plus
+# `features-cljs-test`).  The fifteen still under rf2-d2841 — the ten
+# `trace-listener-*` suites plus `trace`, `db-pending-trace`,
+# `sub-dispose-trace`, `trace-buffer` and `trace.structural-retention-cljs` —
+# have NO semantic residue to separate: they are about the trace machinery
+# itself, end to end, so guarding them would leave nothing behind and make each
+# one class 2.  Those want a var-level `-e :requires-debug` exclusion tag
+# declared in `implementation/deps.edn`, not a posture split, and that file is
+# outside this bead's fence.  Several also HANG rather than fail under the gate
+# (a `CountDownLatch` waiting on trace events that never arrive), so keep them
+# out of any exploratory `-n` sweep.  With those fifteen blocked on a change
+# elsewhere, this bead's ACTIONABLE work is complete at the sixth pass.
 #
 # The roster is therefore an EXCLUSION list, not an allowlist.  The polarity is
 # the point: a namespace added to `implementation/core/test/` joins this lane
@@ -339,14 +354,20 @@ fi
 # green with `Ran 0 tests`.  Calibrated below the observed count with room for
 # ordinary churn; raise it when the roster grows materially.
 #
-# RAISED 800 -> 1360 (rf2-d2841, third pass), 1360 -> 1510 (fourth pass), then
-# 1510 -> 1690 (fifth pass).  800 was calibrated against the 915-test lane of
-# rf2-f8x2i's original run and had stopped doing its job.  1360 was calibrated
-# against 1401 and stopped doing its job the same way, and 1510 has now done
-# the same in its turn: the lane runs 1740 tests, and the thirteen namespaces
-# the fifth pass added are 180 of them — losing the whole batch lands at 1560,
-# which 1510 waves through.  1690 notices that while leaving ~3% for ordinary
-# churn.
+# RAISED 800 -> 1360 (rf2-d2841, third pass), 1360 -> 1510 (fourth pass),
+# 1510 -> 1690 (fifth pass), then 1690 -> 1880 (sixth pass).  800 was
+# calibrated against the 915-test lane of rf2-f8x2i's original run and had
+# stopped doing its job.  1360 was calibrated against 1401 and stopped doing
+# its job the same way; 1510 did the same in its turn; and 1690 has now done
+# the same again: the lane runs 1931 tests, and the FOUR namespaces the sixth
+# pass added are 191 of them — losing the whole batch lands at 1740, which
+# 1690 waves through.  1880 notices that while leaving ~3% for ordinary churn.
+#
+# Note how much a small batch can be worth: the sixth pass added only four
+# namespaces but 191 tests, because the two largest — `observation-port-cljs`
+# (94 tests) and `frame-destroy-incarnation-jvm` (29) — were rostered for a
+# minority of their deftests.  The floor tracks TESTS, not roster lines, which
+# is the right variable for exactly this reason.
 #
 # The floor is a COLLAPSE DETECTOR, not a target, and the rule that follows
 # from that is why it has moved every pass: it must sit close enough under the
@@ -369,7 +390,7 @@ fi
 # invokes, so the rule covers every lane in the repo rather than this one, and
 # it fires before a single test runs.  `verify_roster` below is unchanged and
 # still cannot see this class on its own — see its guard #1.
-export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1690}"
+export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1880}"
 
 args=()
 for ns in $runnable; do

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -234,7 +234,6 @@ known_red=(
   re-frame.observation-port-cljs-test
   re-frame.sub-dispose-trace-test
   re-frame.trace-buffer-test
-  re-frame.trace-cascade-captured-test
   re-frame.trace-listener-concurrent-drain-serialization-test
   re-frame.trace-listener-concurrent-serialization-test
   re-frame.trace-listener-continuation-neutral-cljs-test

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -229,7 +229,6 @@ known_red=(
   #    function of a record plus the frame's durable elision registry, so the
   #    profile rows now drive a SYNTHETIC record and run in both postures.
   re-frame.db-pending-trace-test
-  re-frame.observation-port-cljs-test
   re-frame.sub-dispose-trace-test
   re-frame.trace-buffer-test
   re-frame.trace-listener-concurrent-drain-serialization-test

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -229,7 +229,6 @@ known_red=(
   #    function of a record plus the frame's durable elision registry, so the
   #    profile rows now drive a SYNTHETIC record and run in both postures.
   re-frame.db-pending-trace-test
-  re-frame.frame-destroy-incarnation-jvm-test
   re-frame.observation-port-cljs-test
   re-frame.sub-dispose-trace-test
   re-frame.trace-buffer-test

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -228,7 +228,6 @@ known_red=(
   #    message.  The fix was not a guard — `projected-record` is a pure
   #    function of a record plus the frame's durable elision registry, so the
   #    profile rows now drive a SYNTHETIC record and run in both postures.
-  re-frame.cofx-cljs-test
   re-frame.db-pending-trace-test
   re-frame.frame-destroy-incarnation-jvm-test
   re-frame.observation-port-cljs-test


### PR DESCRIPTION
Pass 6 of the core prod-gate roster shrink (rf2-d2841), and the last of the
**actionable** work under that bead's heading. Five earlier passes took the lane
from 103 to 154 of 185 namespaces; this one takes the four remaining actionable
roster lines and lands it at **158 of 185**.

Every removal follows the discipline the earlier passes established: the
dev-instrumentation assertion stays **verbatim** inside a
`(when interop/debug-enabled? …)` arm marked with the bead id, and everything
outside that arm is posture-independent. **No assertion was deleted or weakened
to reach green.**

## What came off

| namespace | gate failures on `origin/main` | how it was resolved |
|---|---|---|
| `trace-cascade-captured` | 62 | guard + a memo/flow **run-counter** witness per deftest |
| `cofx-cljs` | 33 + 1 error | mostly **no guard** — three production channels found |
| `frame-destroy-incarnation-jvm` | 42 | guard the epoch reads; **promote** the teardown report |
| `observation-port-cljs` | 40 (of 94 deftests; 84 already green) | guard the dev-trace twin; **synthesise** the schema baseline |

Not one failed for a real reason. Sixth pass running with that verdict.

## The three findings worth carrying forward

**A dev-only sink usually has an always-on twin, and cofx had three.** The
canonical complete `:rf.cofx` record is staged **flat into every handler's own
coeffects map**, so `reply-envelope-carries-rf-cofx-flat-and-freshly-stamped`
stopped reading `[:tags :rf.cofx]` off the dispatch trace and started reading the
same maps out of the two handlers — flat shape, fresh stamping and the deliberate
non-inheritance across a cascade child are envelope facts, not trace facts. The
cofx **error categories are promoted** (`emit-unregistered-cofx!`,
`emit-missing-required-cofx!` and `emit-cofx-value-invalid!` all fan through
`emit-error-both!`), so "exactly one fired" — and the EP-0017 §7
unregistered-vs-missing **split** — are now proved on the shipping channel. What
does *not* survive is `:rf.cofx/id`: those sites pass `failing-id` as both the
failing id and the event-id, so the lift never fires and production learns *which
event*, never *which fact*.

**Ask whether the DRIVER exists, not just the observation.** Three scenarios were
guarded wholesale because the thing that *creates* the failure is dev-gated.
`observation/assert-not-in-fan-out!` is `(when interop/debug-enabled? …)` at its
source, so five observation-port fixtures manufacture an escape that under the
gate simply never happens; and `epoch-digest-owner-loss-cannot-publish-into-successor`
drives from the `:schemas/app-schemas-digest` hook, reachable only via
`epoch/settle!`. **That one was checked by running, not by reading** — its
`CountDownLatch` await *timed out* under the gate, so A was never destroyed and
four negatives were passing over a scenario that had not happened.

**A pure validator does not need the real record.** The observation-port schema
gate read the dev-trace `:tags` into a local that is nil under the gate — and
*nothing it then asserted could tell*. `(not (valid-… (dissoc tags k)))` is a
`doseq` over the eight required keys, and `(dissoc nil k)` is nil, so all eight
drift-detection assertions passed on nil. A gate whose entire purpose is to
redden on schema drift was certifying drift-detection over an absent record. The
fix was not a guard: the matrix now runs over a **synthetic conforming baseline**
in both postures, following pass 4's epoch-egress precedent.

## Vacuous passes removed: 42

| class | count | where |
|---|---|---|
| 1 — a negative over an empty ring | 30 | the predecessor-vs-successor leak audits in `frame-destroy-incarnation-jvm` (13), the "diagnostic category is NOT promoted" negatives in `observation-port` (5), `cofx-cljs` (2), `trace-cascade-captured` (1), plus the schema gate's spoof-rejection pair and its identity negatives |
| 3 — a positive the gate short-circuits | 6 | `(= b-history (rf/epoch-history id))` and siblings — byte-identity comparisons that were `[] = []` |
| 4 — absence of a key elided wholesale | 6 | `(nil? …)` / `(not (contains? …))` reads off nil tag maps in `trace-cascade-captured` (4), `cofx-cljs` (1), `observation-port` (1) |

Two were **zero-assertion deftests**, the shape pass 5 named: the inner claims of
`sub-run-cause-event-id-stamped-inside-dispatch` and
`sub-run-cause-event-id-layer-2-cascade` sat inside `(when (seq runs) …)`, false
under the gate, so both deftests reported green having run **no assertion at all**
inside them.

Two deserve naming for *what they were*:

- `listener-triggered-work-obeys-nested-frame-no-emit-policy` certified that
  frame D's no-emit policy **suppressed D's traces**, over a frame whose event
  never ran. A no-leak audit that passes because nothing happened.
- the eight-key schema-drift `doseq` above.

## One deftest is now proved by the lane rather than by its own rebind

`cofx-cljs`'s `generated-non-edn-value-is-rejected-in-production` establishes its
posture with `(with-redefs [interop/debug-enabled? false] …)`, which cannot reach
a load-time gate. With the namespace on the roster the whole file runs under the
**real** `-Dre-frame.debug=false` gate, and the rebind becomes a no-op over a
posture that already holds.

## Roster: 31 → 27 excluded of 185

This bead's heading goes **19 → 15**. The fifteen that remain are **not more of
the same work**: the ten `trace-listener-*` suites plus `trace`,
`db-pending-trace`, `sub-dispose-trace`, `trace-buffer` and
`trace.structural-retention-cljs` are about the trace machinery itself, end to
end, with no semantic residue to separate — guarding them would leave nothing
behind and make each one class 2. They want a var-level `-e :requires-debug`
exclusion tag in `implementation/deps.edn`, which is outside this bead's fence.
The other twelve sit under other headings (eleven under `rf2-r9bra`, plus
`features-cljs-test`).

**With those fifteen blocked elsewhere, this bead's actionable work is complete.**
The bead stays open, because they are still its.

## Floor raised 1690 → 1880

Same rule as every pass: the floor is a **collapse detector** and must sit close
enough under the observed count that the smallest batch anyone lands is still
visible. This pass's four namespaces are 191 tests; losing the whole batch lands
at 1740, which 1690 waves through. Worth noting how much a *small* batch can be
worth — four roster lines but 191 tests, because the two largest were rostered
for a minority of their deftests. The floor tracks **tests**, not roster lines,
which is the right variable for exactly that reason.

## Quality gates

| gate | result |
|---|---|
| `bash scripts/test-core-prod-gate.sh` | **PASS**, exit 0 — **158 of 185** namespaces (was 154), 1931 tests / 8324 assertions (was 1740 / 7342) |
| `clojure -M:test` in `implementation/core` — dev posture, branch | **PASS**, exit 0 — 2190 tests / **11310** assertions |
| `clojure -M:test` in `implementation/core` — dev posture, **pristine `origin/main` worktree** at `4075977f40` | **PASS**, exit 0 — 2190 tests / **11245** assertions |
| dev-posture delta | test count **HELD at 2190**; assertions **+65**. No deftest added or removed, no assertion deleted or weakened |
| `python scripts/check_jvm_lane_rosters.py` | **PASS**, exit 0 — 31 rostered artefacts, roster ↔ CI bijection intact |
| per-namespace, gate posture (`-J-Dre-frame.debug=false -M:test -n …`) | `trace-cascade-captured` 20 tests / 52 assertions · `cofx-cljs` 48 / 159 · `frame-destroy-incarnation-jvm` 29 / 149 · `observation-port-cljs` 94 / 622 — all exit 0 |
| per-namespace, dev posture | 20 / 123 · 48 / 196 · 29 / 218 · 94 / 666 — all exit 0, against `origin/main` dev counts of 123 / 174 / 206 / 664 |

`RF2_MIN_TESTS` raised 1690 → 1880 and re-verified against the full lane.

The diff is test-only plus the roster script's exclusion lines, floor and lane
record. Nothing under any `src/` tree was touched, so the
`egress_chokepoint_conformance_test` source-scan surface is unchanged; it ran
green as part of the core dev suite above.

**Deferred to CI:** the CLJS `:node-test` build (`npm run test:cljs`), which is
the other host for the two `.cljc` files in this diff; the wider JVM
implementation and tools sweeps; and the browser smoke lanes. This branch
touches no `src/`, no `deps.edn` and no build config, so none of them can see a
behaviour change from it.
