### PR TITLE
test(freehand): the ownership witnesses carry their comparative counts (rf2-drpa3.182.9)

### DIFF
--- a/docs/core/freehand/host/ownership-routing.md
+++ b/docs/core/freehand/host/ownership-routing.md
@@ -122,6 +122,72 @@ and the DOM disagree, and nothing errors or warns. **The recovery is not a
 mechanism** — it is to stop authoring the property the library owns and drive it
 through the library's own prop instead.
 
+## What each route costs, counted
+
+The table above says *one door* and *one behavior + one extra root*, and that is
+the part you actually route by. Underneath it there are four numbers, and the
+three witnesses publish them so the routes can be **compared** rather than
+described.
+
+Read them as shape, not as a score. Nothing asserts these numbers, there is no
+threshold anywhere near them, and a route is not better for being smaller — the
+imperative one is larger because the library owns more.
+
+### What the counts count
+
+The definitions live here, once, so that three rows written in three files stay
+comparable. Each is counted by **reading the declarations**: these are static
+properties of a route, not a runtime measurement, and nothing about them changes
+between node and a browser.
+
+| Count | Definition |
+|---|---|
+| **Exports** | Top-level names the route publishes for a call site to name: one per `v/defhost`, `v/defbehavior` or `v/->react`. |
+| **Crossings** | Declared positions at which control or a value passes the boundary: the props/config channel of each export (one each), plus one per declared `:callbacks` entry, plus one per explicit nested root the route opens. |
+| **Glue sites** | Author-written function bodies that exist *only* to join the two planes and that no change to the call site would remove: each `:connect` / `:update` / `:disconnect`, each declaration-level adapter such as `:map-props`, and each shared helper those bodies call. |
+| **Glue lines** | Approximate source lines those glue sites occupy — non-blank, and neither comment nor docstring. |
+
+Three things are deliberately **not** counted, and the exclusions are what make
+the numbers mean anything:
+
+- **The library's own side.** A wrapper that composes a compound library's parts
+  is React code you would write in a pure-React app too. It is the library's
+  idiom, not something the boundary added.
+- **Your application.** The views, events and subscriptions that consume the
+  route are yours; the route did not add them.
+- **The measurement.** Each witness carries probes and commands so a case can
+  drive a path from a chosen side. Those belong to the fixture, not the route.
+
+### The three witnesses
+
+| Route | Exports | Crossings | Glue sites | Glue lines |
+|---|---:|---:|---:|---:|
+| Pure / headless core — *the control* | 0 | 0 | 0 | 0 |
+| **`FH-REACT-009`** — compound React owner | 1 | 2 | 0 | 0 |
+| **`FH-REACT-010`** — clock owner | 2 | 3 | 1 | 1 |
+| **`FH-BEHAVIOR-010`** — imperative SDK plus a host-created pane | 1 | 2 | 4 | 27 |
+
+Each row is the number in that witness's own `:evidence :comparative`, where the
+arithmetic is written out name by name. The first row is the control: a library
+that owns nothing needs no route, so every count is zero — and if a definition
+above ever produced something other than zero there, the definition would be the
+thing that was wrong.
+
+The shape is the finding.
+
+- **A compound React library costs no glue at all.** Its whole protocol is
+  React's own, and one registration of the wrapper carries it across intact.
+  Registering the four parts instead would have cost four exports and four
+  crossings, for a protocol that then no longer works.
+- **The clock owner costs one line** — the adapter that converts a Clojure style
+  map for React's own style writer. Its two exports are two because the library
+  has two ownership shapes in it, not because the route needed two doors.
+- **The imperative SDK costs an order of magnitude more,** because it owns a
+  node, a void-returning setter, and a second initiator of teardown, and someone
+  has to write all three down. That is not a verdict on the route: it is what
+  *the library owns the node* costs, and the route is still the cheapest way to
+  pay it.
+
 ## Permanent limits, and what each one buys
 
 Some of these are recoverable and some are the price of the route. The difference
@@ -161,6 +227,11 @@ the boundary — which is the thing the route depends on — and not any vendor'
 implementation of it. Maps cannot run in CI at all (network, API key, a billed
 account); a real animation is driven against a wall clock, so a gate on it would
 be measuring frame timing rather than ownership.
+
+`:evidence :limits` carries the other half of that honesty as well: alongside
+what the *proof* cannot reach, each fixture states what its *route* permanently
+loses — context, evidence, and SSR — so the entries in the table above are
+machine-readable beside the law they qualify rather than only prose here.
 
 ## Where to go next
 

--- a/spec/conformance/freehand/fixtures/fh-behavior-010.edn
+++ b/spec/conformance/freehand/fixtures/fh-behavior-010.edn
@@ -103,9 +103,51 @@
   {:reads   [:behaviors/connections :behaviors/targets :root/live-root-ids]
    :counts  [:maps/live :maps/listeners :maps/overlays]
    :residue :none
+
+   ;; The four comparative counts. They are STATIC properties of the route,
+   ;; obtained by READING the declarations in the mounted proof — not a runtime
+   ;; measurement, and nothing asserts them. They are published so the three
+   ;; ownership routes can be compared rather than described; they are not a
+   ;; score and not a threshold, and a route is not better for being smaller.
+   ;;
+   ;; The definitions are written ONCE, for all three witnesses together, in
+   ;; `docs/core/freehand/host/ownership-routing.md` §"What the counts count".
+   ;; One copy, because three definitions in three files is three incomparable
+   ;; numbers. This row's own arithmetic, name by name:
+   ;;
+   ;;   :exports    1 — `maps-canvas`, one `v/defbehavior`. `overlay-legend` is
+   ;;                   NOT counted: it is the view the author chose to mount in
+   ;;                   the pane, application code the route did not add.
+   ;;   :crossings  2 — the behavior's `:config` channel, and the explicit nested
+   ;;                   root `v/mount`ed into the node the library made. The two
+   ;;                   `:commands` positions are NOT counted: they exist so a
+   ;;                   case can enter reclamation from a chosen side, which is
+   ;;                   the measurement rather than the route. The library's own
+   ;;                   removal callback is not a crossing either — it is
+   ;;                   registered with the LIBRARY, and it is glue.
+   ;;   :glue-sites 4 — `reclaim!`, `:connect`, `:update`, `:disconnect`. Each is
+   ;;                   irreducible: the SDK's setter is void so someone must
+   ;;                   call it, the instance must be constructed and released,
+   ;;                   and two initiators over one set of resources is what
+   ;;                   makes the shared path a fourth body rather than a line.
+   ;;   :glue-lines 27 — the non-blank, non-comment, non-docstring lines of those
+   ;;                   four forms: 9 + 14 + 3 + 1. The suite's own `entries` /
+   ;;                   `worked` bookkeeping is excluded for the same reason the
+   ;;                   commands are.
+   ;;
+   ;; This is the most expensive of the three routes by an order of magnitude,
+   ;; and that is the finding rather than a fault: it is what "the library owns
+   ;; the node" costs, and the route is still the cheapest way to pay it.
+   :comparative
+   {:exports 1 :crossings 2 :glue-sites 4 :glue-lines 27
+    :method  :read-from-source}
+
    ;; Stated in the record, not only in prose, so a reader of the roster sees
-   ;; the boundary without opening the suite.
+   ;; the boundary without opening the suite. The first two entries bound the
+   ;; PROOF; the third states what the ROUTE permanently loses, which is the
+   ;; other half of the same honesty and is not recoverable by any recipe.
    :limits  ["Google's `google.maps` code is NOT executed: it loads from the network under an API key against a billed account, which no CI lane can do. The mounted proof drives a surrogate reproducing the API's ownership shape — node takeover, void-returning `setOptions`, a listener handle released by `.remove()`, an `OverlayView` supplying a host-created pane and calling back on removal — so what is proven is Freehand's ownership routing at that boundary, not Google's implementation of it."
-             "No npm dependency was added for this row. A real `@googlemaps/js-api-loader` in the browser lane would make the gate a test of a network."]}
+             "No npm dependency was added for this row. A real `@googlemaps/js-api-loader` in the browser lane would make the gate a test of a network."
+             "WHAT THE ROUTE PERMANENTLY LOSES, stated beside what it proves. CONTEXT: the nested root in the library's own pane is an ISLAND — it does not inherit the outer tree's React context, its Suspense boundaries, or its event bubbling, and nothing here pretends it does; app-db is shared regardless, because a frame is not a tree. EVIDENCE: the SDK's subtree is a LEAF to Freehand — no structural render, nothing in any manifest, and nothing inside it visible to the substrate's own bookkeeping. SSR: none for either tree — a behavior connects only on commit, so a server render emits the empty node and the island does not exist at all until the client mounts. None of the three is recoverable; each is the price of letting the library own the node."]}
 
   :prose :executable}}

--- a/spec/conformance/freehand/fixtures/fh-react-009.edn
+++ b/spec/conformance/freehand/fixtures/fh-react-009.edn
@@ -88,7 +88,48 @@
   {:reads   [:root/live-root-ids :document/active-element]
    :counts  [:radix/body-content-nodes]
    :residue :none
+
+   ;; The four comparative counts. They are STATIC properties of the route,
+   ;; obtained by READING the declarations in the mounted proof — not a runtime
+   ;; measurement, and nothing asserts them. They are published so the three
+   ;; ownership routes can be compared rather than described; they are not a
+   ;; score and not a threshold, and a route is not better for being smaller.
+   ;;
+   ;; The definitions are written ONCE, for all three witnesses together, in
+   ;; `docs/core/freehand/host/ownership-routing.md` §"What the counts count".
+   ;; One copy, because three definitions in three files is three incomparable
+   ;; numbers. This row's own arithmetic, name by name:
+   ;;
+   ;;   :exports    1 — `dialog`, one `v/defhost`, and it is on the WRAPPER.
+   ;;                   `as-child-probe` is NOT counted: it is the A/B instrument
+   ;;                   behind the withheld promise, the measurement rather than
+   ;;                   the route.
+   ;;   :crossings  2 — the host's props channel, and the ONE declared
+   ;;                   `:callbacks` position `:onOpenChange`. The portal is not
+   ;;                   a crossing: React re-parents its own subtree into a
+   ;;                   target Freehand never named and has no vocabulary for.
+   ;;   :glue-sites 0 — the declaration carries no lifecycle body and no adapter,
+   ;;                   so there is no author-written code joining the planes at
+   ;;                   all. `radix-dialog`, which composes Root, Trigger, Portal
+   ;;                   and Content, is NOT counted: composing a compound
+   ;;                   library's parts is React code an author writes in a
+   ;;                   pure-React app too, so it is the library's own idiom
+   ;;                   rather than something the boundary added.
+   ;;   :glue-lines 0 — follows.
+   ;;
+   ;; The zero is the finding, and it is the whole argument for registering the
+   ;; wrapper: a compound React library crosses WHOLE, and the boundary adds no
+   ;; joining code at all. Registering the four parts instead would have cost
+   ;; four exports and four crossings for a protocol that then no longer works.
+   :comparative
+   {:exports 1 :crossings 2 :glue-sites 0 :glue-lines 0
+    :method  :read-from-source}
+
+   ;; The first two entries bound the PROOF; the third states what the ROUTE
+   ;; permanently loses, which is the other half of the same honesty and is not
+   ;; recoverable by any recipe.
    :limits  ["Radix's own packages are NOT installed. Adding `@radix-ui/react-dialog` to `implementation/package.json` is a shared-file change, and the law is about where ownership falls rather than about Radix's implementation of it. The mounted proof drives a surrogate reproducing the compound shape — context between the parts, `asChild` cloning with a ref, a real `react-dom` `createPortal` into `document.body`, and focus moved on open and restored on close."
-             "The `:as-child` row records what React 19 does with a `ref` prop handed to a function component: it arrives as an ordinary unused prop rather than an error. A future React whose ref protocol changed would move that cell, and moving it is the correct outcome — the row states what an author will observe, not what the substrate guarantees."]}
+             "The `:as-child` row records what React 19 does with a `ref` prop handed to a function component: it arrives as an ordinary unused prop rather than an error. A future React whose ref protocol changed would move that cell, and moving it is the correct outcome — the row states what an author will observe, not what the substrate guarantees."
+             "WHAT THE ROUTE PERMANENTLY LOSES, stated beside what it proves. CONTEXT: React context does not survive a Freehand boundary, which is exactly why the WRAPPER is registered and not the parts — four registered parts would be four crossings with the conversation between them broken. In the other direction, the withheld promise this row measures: a Freehand-authored child does not participate in `asChild`, arbitrary `cloneElement`, or ref injection, and does not fail either. EVIDENCE: everything inside the registered component is React's — Freehand's manifest records one host crossing and nothing under it — and the portalled content lands OUTSIDE the Freehand root's container, where a container-scoped inspection does not reach it, which is why `:after-unmount` reads `document.body` instead. SSR: the declaration is `:ssr :client-only`, so the compound renders nothing on the server. None of the three is recoverable; each is the price of keeping the protocol React-primary."]}
 
   :prose :executable}}

--- a/spec/conformance/freehand/fixtures/fh-react-010.edn
+++ b/spec/conformance/freehand/fixtures/fh-react-010.edn
@@ -94,7 +94,45 @@
   {:reads   [:root/live-root-ids :motion/committed-props]
    :counts  [:motion/writes]
    :residue :none
+
+   ;; The four comparative counts. They are STATIC properties of the route,
+   ;; obtained by READING the declarations in the mounted proof — not a runtime
+   ;; measurement, and nothing asserts them. They are published so the three
+   ;; ownership routes can be compared rather than described; they are not a
+   ;; score and not a threshold, and a route is not better for being smaller.
+   ;;
+   ;; The definitions are written ONCE, for all three witnesses together, in
+   ;; `docs/core/freehand/host/ownership-routing.md` §"What the counts count".
+   ;; One copy, because three definitions in three files is three incomparable
+   ;; numbers. This row's own arithmetic, name by name:
+   ;;
+   ;;   :exports    2 — `motion-panel` and `motion-collection`, two `v/defhost`
+   ;;                   declarations. The library contributes two distinct
+   ;;                   ownership shapes — one that animates a property and one
+   ;;                   that retains a departed child — and each is its own door.
+   ;;                   This is the only row of the three whose export count is
+   ;;                   above one, and the reason is the library, not the route.
+   ;;   :crossings  3 — the props channel of each of the two hosts, plus the ONE
+   ;;                   declared `:callbacks` position `:onExitComplete`. The
+   ;;                   library's imperative write onto its own ref is NOT a
+   ;;                   crossing: it never passes the boundary at all, which is
+   ;;                   the whole of the one-writer finding.
+   ;;   :glue-sites 1 — `motion-panel`'s `:map-props` adapter, and nothing else.
+   ;;                   Irreducible: ordinary props cross SHALLOWLY AND EXACTLY
+   ;;                   (FH-REACT-002), so an authored `{:transform "…"}` reaches
+   ;;                   React as the Clojure map it is and React's style writer
+   ;;                   finds nothing on it. Converting it is the one thing the
+   ;;                   boundary adds.
+   ;;   :glue-lines 1 — that adapter is one line.
+   :comparative
+   {:exports 2 :crossings 3 :glue-sites 1 :glue-lines 1
+    :method  :read-from-source}
+
+   ;; The first two entries bound the PROOF; the third states what the ROUTE
+   ;; permanently loses, which is the other half of the same honesty and is not
+   ;; recoverable by any recipe.
    :limits  ["`framer-motion` is NOT installed. A real animation is driven by `requestAnimationFrame` against a wall clock, so a gate built on it would measure frame timing rather than ownership; and adding the dependency is a shared-file change on a repository where five witnesses land in parallel. The mounted proof drives a surrogate with the clock removed — an imperative `transform` write on the component's own ref, performed when the case says so, and a keyed list retaining a departed child until the case says the exit is done."
-             "`:two-writers` records a CONFLICT, not a defect in either party. Two writers to one DOM property is last-write-wins by construction; what the row establishes is that the loss is SILENT — no error, no warning, and the library's own book unchanged — which is why the recovery is a routing decision rather than a mechanism."]}
+             "`:two-writers` records a CONFLICT, not a defect in either party. Two writers to one DOM property is last-write-wins by construction; what the row establishes is that the loss is SILENT — no error, no warning, and the library's own book unchanged — which is why the recovery is a routing decision rather than a mechanism."
+             "WHAT THE ROUTE PERMANENTLY LOSES, stated beside what it proves. CONTEXT: the retention lives in a ref inside the registered component, and nothing outside it can read or influence it — which is the point (one owner) and equally the loss (no substrate vocabulary reaches it). EVIDENCE: the retained child is on the page and in NONE of Freehand's books; the divergence between `:dom` and `:props` in the `:exit` rows IS that absence, so a residue check reading the substrate sees nothing retained while a child is still mounted. SSR: both declarations are `:ssr :client-only`, so an animation has no server output and neither does the list while it is retaining. None of the three is recoverable; the first two are what \"one retention owner\" means."]}
 
   :prose :executable}}


### PR DESCRIPTION
Closes the last open criterion on **rf2-drpa3.182.9**. The bead's EVIDENCE clause
asks each of the three ownership witnesses to publish four comparative
quantities — *top-level exports, boundary crossings, irreducible glue sites,
approximate glue lines* — beside "explicit context/evidence/SSR loss". The
qualitative half shipped with the routing page (one door / one path / one
writer); the numeric half was absent from all three fixtures, and
`:evidence :limits` recorded only what the *proof* could not reach.

## The counts

| Route | Exports | Crossings | Glue sites | Glue lines |
|---|---:|---:|---:|---:|
| Pure / headless core — *the control* | 0 | 0 | 0 | 0 |
| `FH-REACT-009` — compound React owner | 1 | 2 | 0 | 0 |
| `FH-REACT-010` — clock owner | 2 | 3 | 1 | 1 |
| `FH-BEHAVIOR-010` — imperative SDK + host-created pane | 1 | 2 | 4 | 27 |

**How they were obtained: by READING the declarations, not by running
anything.** These are static properties of a route — they do not vary between
node and a browser, and there is no runtime to label. The fixtures say so in the
value itself (`:method :read-from-source`). Nothing asserts them, nothing gates
on them, and they are explicitly not a score: the imperative route is the
largest because the library owns the most.

**One definition, in one place.** `docs/core/freehand/host/ownership-routing.md`
§"What the counts count" states what an export, a crossing, a glue site and a
glue line are — once, for all three witnesses. Three definitions in three files
would have been three incomparable numbers. Each fixture then writes out its own
arithmetic name by name, *including the exclusions and why*: the library's own
side (a wrapper composing a compound library's parts is React code you write in
a pure-React app too), your application, and the fixture's measurement apparatus
(Maps' two `:commands`, Radix's `as-child-probe`).

**The control row is the check on the definition.** A library that owns nothing
routes to nothing, so the pure/headless core must be four zeros — and a
definition that produced anything else there would be the thing that was wrong.
The one arithmetic figure was also reproduced mechanically: Maps' 27 glue lines
are `1 + 8 + 14 + 3 + 1` over `reclaim!`, `:connect`, `:update`, `:disconnect`,
with the suite's own `entries` / `worked` bookkeeping excluded.

The shape is the finding. A compound React library costs **no glue at all** — its
whole protocol is React's, and one registration of the wrapper carries it across
intact; registering the four parts would have cost four exports and four
crossings for a protocol that then no longer works. The clock owner costs one
line, the adapter converting a Clojure style map for React's own style writer.
The imperative SDK costs an order of magnitude more, which is what "the library
owns the node" costs rather than a verdict on the route.

## `:evidence :limits` gains its other half

It recorded what the **proof** cannot reach — no `google.maps`, no Radix
packages, no `framer-motion`. Each fixture now also records what the **route**
loses, permanently and irrecoverably:

- **`FH-BEHAVIOR-010`** — the island inherits no outer React context, Suspense or
  bubbling; the SDK's subtree is a leaf with no structural render and nothing in
  any manifest; no SSR for either tree, since a behavior connects only on commit.
- **`FH-REACT-009`** — React context does not survive a Freehand boundary (which
  is *why* the wrapper is registered and not the parts), the withheld
  `asChild`/ref promise in the other direction, one manifest crossing with
  nothing under it, portalled content outside the container, `:ssr :client-only`.
- **`FH-REACT-010`** — retention lives in a ref no substrate vocabulary reaches;
  the retained child is on the page and in none of Freehand's books (the
  `:dom` / `:props` divergence *is* that absence); `:ssr :client-only`.

## Nothing qualitative was revised

The routing page's existing claims were verified in the previous pass and are
untouched. This PR only adds: one section, one paragraph, and a `:comparative`
key plus a third `:limits` entry per fixture.

## Fences

`spec/**` is hot-zone for prose, and none was edited — the three files under
`spec/conformance/freehand/fixtures/` are this bead's own witnesses. The roster
spine (`roster.cljc`), `implementation/deps.edn` and `implementation/core/**`
were not touched; no overlap with the sibling worker. `:evidence` sub-keys are
free-form to the roster (only `:residue` is validated), so `:comparative` needs
no spine change.

## Quality gates

Foreground, worktree-local, exit codes echoed, never piped through `tail`.

| Gate | Exit | Result |
|---|---|---|
| `python scripts/check_freehand_conformance_index.py` | 0 | clean |
| `implementation/freehand` `clojure -M:test` (incl. the roster test) | 0 | 1288 tests / 8856 assertions, 0 failures, 0 errors; guide digest roster 114 of 138 blocks, unchanged |
| `python -m mkdocs build --strict` | 0 | no new warning |
| `npm run test:browser` | 0 | 842 tests / 5469 assertions, 0 failures, 0 errors |
| `sh scripts/test-freehand-prod-gate.sh` | 0 | **137 of 137**, 0 excluded as known-red — roster empty, not regressed |

Deferred to CI: the full JVM implementation sweep, the Xray feature-matrix gate,
bundle isolation, the perf-bundle gate and mcp-conformance — none of which this
diff can reach.
