### PR TITLE
test(core): the trace suites declare they require the debug build (rf2-d2841)

### DIFF
--- a/implementation/core/deps.edn
+++ b/implementation/core/deps.edn
@@ -148,17 +148,51 @@
   ;; arriving.
   ;;
   ;; NOT THE WHOLE SUITE, YET. Under the real gate 91 of this artefact's 174
-  ;; test namespaces are red, almost all of them asserting dev instrumentation
+  ;; test namespaces were red, almost all of them asserting dev instrumentation
   ;; (traces, the `:errors` sink, doc metadata, source coords) inline with
   ;; semantics — legitimate dev-posture tests, not defects. The runnable
   ;; roster therefore lives in `scripts/test-core-prod-gate.sh`, which appends
   ;; `-n` selectors for every namespace MINUS a documented known-red list, so
-  ;; a NEW namespace joins the lane by default. What runs today is 83
-  ;; namespaces / 915 tests / 4257 assertions, green. Do not invoke this alias
+  ;; a NEW namespace joins the lane by default. Do not invoke this alias
   ;; bare; run the script.
+  ;;
+  ;; `-e :requires-debug` — THE DEV-ONLY DECLARATION (rf2-d2841, seventh pass).
+  ;; Most of that bead's namespaces were SPLIT: the instrumentation assertions
+  ;; went inside `(when interop/debug-enabled? …)` and the semantics beside
+  ;; them stayed always-on, so the namespace joined this lane carrying real
+  ;; claims. Fifteen could not be split, because they are about the trace
+  ;; machinery ITSELF, end to end — the ten `trace-listener-*` suites plus
+  ;; `trace`, `db-pending-trace`, `sub-dispose-trace`, `trace-buffer` and
+  ;; `trace.structural-retention-cljs`. Guarding those wholesale would leave
+  ;; EMPTY deftests reporting green, which is the false green this lane exists
+  ;; to close. So they declare the posture they need instead, per deftest, and
+  ;; this lane skips the tag.
+  ;;
+  ;; THE TAG IS VAR-LEVEL, AND THAT IS THE WHOLE POINT. cognitect-test-runner's
+  ;; `-e` reads VAR metadata (`var-filter` calls `(meta v)` on each interned
+  ;; test var); it never consults namespace metadata, so a marker on the `(ns
+  ;; …)` form would be silently INERT — a suppression that suppresses nothing,
+  ;; or, read the other way, an exclusion nobody can see the effect of. Var
+  ;; granularity also keeps this lane's polarity: a new deftest added to a
+  ;; tagged namespace is UNTAGGED, so it joins the gate lane by default and has
+  ;; to be excluded deliberately. A namespace-level marker would swallow it.
+  ;;
+  ;; AND THE NAMESPACE STILL RUNS SOMETHING. cognitect `require`s every `-n`
+  ;; namespace BEFORE it filters vars, so a tagged namespace is still LOADED
+  ;; under `-Dre-frame.debug=false` and a load-time failure there still reddens
+  ;; this job — strictly more than the roster line it replaced, which kept the
+  ;; file off the classpath altogether. What the tag does NOT do is claim the
+  ;; tests ran: `contains-tests?` drops a fully-tagged namespace before
+  ;; `run-tests` sees it, so it contributes no test and no assertion to the
+  ;; tally, and nothing green is reported for work that did not happen.
+  ;;
+  ;; The tag is DEV-LANE-NEUTRAL. It appears in no other `:main-opts` in this
+  ;; file, so `clojure -M:test` runs every tagged deftest exactly as before;
+  ;; the tag narrows this lane only.
   :prod-gate
   {:jvm-opts  ["-Dre-frame.debug=false"]
-   :main-opts ["-m" "re-frame.test-quiet.runner" "-e" ":slow" "-e" ":stress"]}
+   :main-opts ["-m" "re-frame.test-quiet.runner"
+               "-e" ":slow" "-e" ":stress" "-e" ":requires-debug"]}
 
   ;; Nightly/rigorous slow-test gate. INCLUDES ONLY the
   ;; `^:slow` / `^:stress` tests (the union the default `:test` alias

--- a/implementation/core/test/re_frame/db_pending_trace_test.clj
+++ b/implementation/core/test/re_frame/db_pending_trace_test.clj
@@ -60,7 +60,17 @@
 
 ;; ---- t1 fires when the handler returns `:db` -----------------------------
 
-(deftest t1-emits-when-handler-returns-db
+;; ---- Posture: dev-only, declared by `^:requires-debug` (rf2-d2841) ---------
+;; Trace machinery end to end: under `-Dre-frame.debug=false` `trace/emit` is a
+;; no-op, so there is no semantic residue to run under that posture, and a
+;; `(when interop/debug-enabled? ...)` split -- the shape the rest of rf2-d2841
+;; used -- would leave EMPTY deftests reporting green (class 2).  Every deftest
+;; below is therefore TAGGED, and the production-gate lane skips the tag rather
+;; than the file: the namespace is still LOADED there, so a load-time failure
+;; under the gate still reddens the job, and an untagged new deftest joins that
+;; lane BY DEFAULT.  Mechanism + rationale: `scripts/test-core-prod-gate.sh`.
+
+(deftest ^:requires-debug t1-emits-when-handler-returns-db
   (testing ":rf.event/db-pending fires once per dispatch when the handler
    returned a :db slot, carrying the returned value under :tags :rf.event/db"
     (rf/reg-event :t1/seed-db
@@ -81,7 +91,7 @@
         (finally
           (rf/unregister-listener! :trace ::t1-db-only))))))
 
-(deftest t1-suppressed-when-handler-returns-no-db
+(deftest ^:requires-debug t1-suppressed-when-handler-returns-no-db
   (testing "an :fx-only handler return (no :db slot) does NOT emit
    :rf.event/db-pending — mirrors how :rf.event/db-present? rides on
    :rf.fx/do-fx as `false` when no :db was returned"
@@ -97,7 +107,7 @@
         (finally
           (rf/unregister-listener! :trace ::t1-fx-only))))))
 
-(deftest t1-value-is-identical-by-reference-no-copy
+(deftest ^:requires-debug t1-value-is-identical-by-reference-no-copy
   (testing "Mike's ruling: the t1 stamp is the SAME persistent reference
    the handler returned — no `into`, no walk, no copy. Persistent data
    structures + structural sharing make the cost pointer-sized; the
@@ -121,7 +131,7 @@
 
 ;; ---- ordering against the canonical sequence -----------------------------
 
-(deftest t1-precedes-db-changed-and-do-fx
+(deftest ^:requires-debug t1-precedes-db-changed-and-do-fx
   (testing "Spec 009 §Canonical per-event trace sequence — :rf.event/db-pending
    sits AFTER :rf.event/run-start and BEFORE :rf.event/db-changed (and BEFORE
    :rf.fx/do-fx). The atomicity-contract pipeline is reflected in the trace
@@ -153,7 +163,7 @@
 
 ;; ---- t2 contract from the core perspective -------------------------------
 
-(deftest t2-never-fires-without-flows-artefact
+(deftest ^:requires-debug t2-never-fires-without-flows-artefact
   (testing "with no flows artefact loaded, t2 (:rf.event/db-pending-post-flow)
    is by definition impossible — no flow could have transformed the pending
    value. The flows artefact is NOT a dependency of the core test fixture
@@ -171,7 +181,7 @@
 
 ;; ---- payload-shape pin ---------------------------------------------------
 
-(deftest db-pending-payload-rides-under-tags
+(deftest ^:requires-debug db-pending-payload-rides-under-tags
   (testing "payload-shaped slots (:rf.event/db, :frame) ride under :tags
    — top level is reserved for substrate-hoisted slots
    (:rf.trace/call-site, :rf.trace/trigger-handler, :source, etc.).

--- a/implementation/core/test/re_frame/sub_dispose_trace_test.clj
+++ b/implementation/core/test/re_frame/sub_dispose_trace_test.clj
@@ -34,6 +34,7 @@
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
+            [re-frame.interop :as interop]
             [re-frame.subs :as subs]
             [re-frame.subs.cache :as subs-cache]
             [re-frame.substrate.plain-atom :as plain-atom]))
@@ -76,7 +77,30 @@
 ;; drops to 0, and the slot is disposed synchronously inside the
 ;; `unsubscribe` call (per rf2-cmfln).
 
-(deftest dispose-emits-on-last-unsubscribe
+;; ---- Posture split (rf2-d2841) --------------------------------------------
+;; MOST of this namespace is dev instrumentation end to end: the dispose EMIT
+;; is `trace/emit`, a no-op under `-Dre-frame.debug=false`, and a deftest whose
+;; every claim is about that emit has no semantic residue to run under the
+;; production posture. Those deftests are tagged `^:requires-debug`, which the
+;; `:prod-gate` lane excludes (`implementation/core/deps.edn`); guarding them
+;; instead would leave EMPTY deftests reporting green, the class-2 false green
+;; the lane exists to close. The tag is VAR-level, so a new deftest added below
+;; is untagged and joins the gate lane by default; the namespace itself is
+;; still LOADED there. See `scripts/test-core-prod-gate.sh`.
+;;
+;; TWO ARE NOT TAGGED, and finding them is why the premise was checked rather
+;; than assumed. `dispose-then-resubscribe-builds-fresh-slot` and
+;; `input-dispose-throw-is-surfaced-and-isolated` were on the roster for their
+;; emit assertions while carrying PRODUCTION sub-cache claims — the rf2-cmfln
+;; fresh-reaction rebuild, and rf2-is8ov5's guarantee that one input's throwing
+;; release does not abort the walk over its siblings. `release-input!` puts the
+;; `try`/`catch` OUTSIDE `interop/debug-enabled?` and only the `emit-error!`
+;; inside it, so that second claim splits cleanly in half: SURFACED is dev,
+;; ISOLATED ships. Both keep their emit assertions verbatim inside a
+;; `(when interop/debug-enabled? …)` arm and run their semantics in both
+;; postures.
+
+(deftest ^:requires-debug dispose-emits-on-last-unsubscribe
   (testing ":rf.sub/dispose fires synchronously with :reason
             :no-more-derefers when the last subscriber detaches;
             carries the canonical tags (frame, id, query-v, reason);
@@ -107,7 +131,7 @@
         (finally
           (rf/unregister-listener! :trace ::layer-1-no-derefers))))))
 
-(deftest no-dispose-when-ref-count-still-positive
+(deftest ^:requires-debug no-dispose-when-ref-count-still-positive
   (testing "with two subscribers, one unsubscribe does NOT emit
             :rf.sub/dispose — the slot's ref-count is still > 0; only
             the SECOND unsubscribe (the last derefer dropping) emits"
@@ -129,7 +153,7 @@
         (finally
           (rf/unregister-listener! :trace ::two-subs))))))
 
-(deftest dispose-cascade-emits-per-evicted-layer
+(deftest ^:requires-debug dispose-cascade-emits-per-evicted-layer
   (testing "a layer-2 sub's disposal cascades to its layer-1 inputs —
             each evicted slot emits its own :rf.sub/dispose with
             :reason :no-more-derefers"
@@ -159,6 +183,11 @@
         (finally
           (rf/unregister-listener! :trace ::cascade-emit))))))
 
+;; NOT `^:requires-debug` — rf2-d2841 seventh pass. The CLAIM here is
+;; rf2-cmfln's: a synchronous dispose closes the slot, so the next subscribe
+;; rebuilds a FRESH reaction. That is `interop/dispose!` and the cache map,
+;; not the trace, and it holds in both postures; only the emit COUNTS below
+;; are dev instrumentation, and they are guarded individually.
 (deftest dispose-then-resubscribe-builds-fresh-slot
   (testing "per rf2-cmfln: unsubscribe disposes synchronously, so a
             subsequent subscribe rebuilds against a fresh cache miss.
@@ -174,8 +203,13 @@
         (let [r1 (rf/subscribe [:sub/a])]
           (is (= 42 @r1))
           (rf/unsubscribe [:sub/a])
-          (is (= 1 (count (dispose-events @acc)))
-              "one :rf.sub/dispose fired at the sync 1 → 0 transition")
+          ;; rf2-d2841 — dev instrumentation. `trace/emit` is a no-op under
+          ;; `-Dre-frame.debug=false`, so the emit COUNT is a dev-posture
+          ;; claim. The sync dispose it reports is not: the identity
+          ;; assertions below witness it in both postures.
+          (when interop/debug-enabled?
+            (is (= 1 (count (dispose-events @acc)))
+                "one :rf.sub/dispose fired at the sync 1 → 0 transition"))
           ;; A resubscribe after the sync dispose rebuilds — fresh
           ;; reaction, not the disposed one. No additional dispose emit
           ;; (the new slot is still live).
@@ -184,8 +218,9 @@
                 "resubscribe returned a FRESH reaction (rf2-cmfln —
                  sync dispose closed the old slot before this rebuild)")
             (is (= 42 @r2) "the rebuilt sub computes the same value")
-            (is (= 1 (count (dispose-events @acc)))
-                "no additional dispose emit — the new slot is alive")))
+            (when interop/debug-enabled?
+              (is (= 1 (count (dispose-events @acc)))
+                  "no additional dispose emit — the new slot is alive"))))
         (finally
           (rf/unregister-listener! :trace ::sync-dispose-then-resub))))))
 
@@ -195,7 +230,7 @@
 ;; sub-id across every frame. The invalidate path emits one
 ;; `:rf.sub/dispose` per evicted slot with `:reason :hot-reload`.
 
-(deftest dispose-emits-on-hot-reload
+(deftest ^:requires-debug dispose-emits-on-hot-reload
   (testing "re-registering a :sub fires :rf.sub/dispose with :reason
             :hot-reload for the affected slot (regardless of ref-count)"
     (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 42}}))
@@ -219,7 +254,7 @@
         (finally
           (rf/unregister-listener! :trace ::hot-reload))))))
 
-(deftest dispose-hot-reload-fires-per-evicted-slot
+(deftest ^:requires-debug dispose-hot-reload-fires-per-evicted-slot
   (testing "hot-reloading a sub with N cached query-arg variants fires
             N :rf.sub/dispose events, one per evicted slot, all with
             :reason :hot-reload"
@@ -253,7 +288,7 @@
 ;; slot; each evicted slot emits a `:rf.sub/dispose` with `:reason
 ;; :cache-clear`.
 
-(deftest dispose-emits-on-clear-sub-cache
+(deftest ^:requires-debug dispose-emits-on-clear-sub-cache
   (testing "(clear-sub-cache!) fires :rf.sub/dispose per evicted slot
             with :reason :cache-clear (regardless of ref-count)"
     (rf/reg-event :init (fn [{:keys [db]} _] {:db {:a 1 :b 2}}))
@@ -278,7 +313,7 @@
         (finally
           (rf/unregister-listener! :trace ::cache-clear))))))
 
-(deftest clear-sub-cache-emits-exactly-one-dispose-per-slot-for-layered-sub
+(deftest ^:requires-debug clear-sub-cache-emits-exactly-one-dispose-per-slot-for-layered-sub
   (testing "clear-sub-cache! on a layered (:<- two inputs) sub: every cached
             slot (the sum + both inputs) gets EXACTLY ONE :rf.sub/dispose,
             reasoned :cache-clear — no double-emit from the on-dispose
@@ -323,7 +358,7 @@
 ;; The exact tag-map shape downstream consumers (Xray Epoch panel
 ;; SUBSCRIPTIONS section per rf2-wpfjo) depend on.
 
-(deftest dispose-tag-shape-is-canonical
+(deftest ^:requires-debug dispose-tag-shape-is-canonical
   (testing "the :rf.sub/dispose tag-map carries exactly the four
             canonical tags + nothing extra: :frame, :rf.sub/id,
             :rf.sub/query-v, :rf.sub/reason. Required for consumer
@@ -362,7 +397,7 @@
 ;; but `debug-enabled?` is `true` so the emit runs — this test pins
 ;; the runtime path's correctness, not the prod-elision shape.
 
-(deftest emits-fire-under-jvm-debug-enabled
+(deftest ^:requires-debug emits-fire-under-jvm-debug-enabled
   (testing "debug-enabled? is true on the JVM test runtime — dispose
             emits land in the trace stream"
     (rf/reg-event :init (fn [{:keys [db]} _] {:db {:x 1}}))
@@ -392,6 +427,15 @@
   [traces]
   (filterv #(= :rf.warning/sub-input-dispose-exception (:operation %)) traces))
 
+;; NOT `^:requires-debug` — rf2-d2841 seventh pass, and this one is the reason
+;; the "100% dev instrumentation" premise had to be checked rather than
+;; assumed. `subs/release-input!` puts the `try`/`catch` OUTSIDE the gate and
+;; only `trace/emit-error!` inside it (see its docstring: "it rides the
+;; DIAGNOSTIC channel — `trace/emit-error!` sits inside
+;; `interop/debug-enabled?`"). So the claim splits exactly in half: SURFACED
+;; is dev, ISOLATED is production. Assertion 2 — the sibling input still
+;; released, the parent slot was still evicted — is the half that ships, and
+;; it had never run under this posture.
 (deftest input-dispose-throw-is-surfaced-and-isolated
   (testing "when ONE `:<-` input's unsubscribe throws during a layer-2
             reaction's recursive disposal, a
@@ -441,34 +485,45 @@
         ;; :rf.warning/sub-input-dispose-exception for the failing input,
         ;; carrying the diagnostic tags (frame, the failing query-v, the
         ;; exception, the release site, recovery).
-        (let [warns (dispose-exception-events @acc)]
-          (is (= 1 (count warns))
-              "exactly one dispose-exception trace for the throwing input")
-          (let [[ev]  warns
-                tags  (:tags ev)]
-            ;; The envelope is built by `trace/emit-error!` → `build-event
-            ;; :error`, so the runtime `:op-type` is `:error` and the
-            ;; warning category rides `:operation` + `[:tags :category]`
-            ;; (the catalogue's `:op-type :warning` column is the SEMANTIC
-            ;; channel classification, not the envelope op-type — mirrors
-            ;; `:rf.warning/teardown-hook-exception`, also emitted via
-            ;; `emit-error!`). Asserting the tag/operation shape, not a
-            ;; `:warning` envelope op-type, matches the existing precedent.
-            (is (= :rf.warning/sub-input-dispose-exception (:operation ev)))
-            (is (= :rf.warning/sub-input-dispose-exception (:category tags))
-                ":category carries the warning id (build-event :error merge)")
-            (is (= :rf/default (:frame tags))
-                ":frame is the disposing frame")
-            (is (= [:sub/a] (:rf.sub/query-v tags))
-                ":rf.sub/query-v is the input whose release threw")
-            (is (some? (:exception tags))
-                "the swallowed exception is carried, not discarded")
-            (is (= :on-dispose (:where tags))
-                ":where pins the cached-reaction on-dispose release site")
-            ;; `:recovery` is hoisted to the TOP LEVEL by `build-event`
-            ;; (the error path always stamps it), NOT left under `:tags`.
-            (is (= :ignored (:recovery ev))
-                ":recovery :ignored — best-effort release")))
+        ;;
+        ;; rf2-d2841 — DEV ONLY, and deliberately the SMALLER half. The
+        ;; surfacing is the diagnostic channel: `release-input!` reaches it
+        ;; through `trace/emit-error!`, which is inside
+        ;; `interop/debug-enabled?`. Every assertion in this arm would pass
+        ;; VACUOUSLY under the production gate if left unguarded — `warns`
+        ;; is `[]` there, so `[ev]` destructures to nil and every `(:x tags)`
+        ;; read below is a nil-vs-nil comparison waiting to happen. Assertion
+        ;; 2 is outside this arm because the ISOLATION it pins is production
+        ;; behaviour: the `try`/`catch` is NOT gated.
+        (when interop/debug-enabled?
+          (let [warns (dispose-exception-events @acc)]
+            (is (= 1 (count warns))
+                "exactly one dispose-exception trace for the throwing input")
+            (let [[ev] warns
+                  tags (:tags ev)]
+              ;; The envelope is built by `trace/emit-error!` → `build-event
+              ;; :error`, so the runtime `:op-type` is `:error` and the
+              ;; warning category rides `:operation` + `[:tags :category]`
+              ;; (the catalogue's `:op-type :warning` column is the SEMANTIC
+              ;; channel classification, not the envelope op-type — mirrors
+              ;; `:rf.warning/teardown-hook-exception`, also emitted via
+              ;; `emit-error!`). Asserting the tag/operation shape, not a
+              ;; `:warning` envelope op-type, matches the existing precedent.
+              (is (= :rf.warning/sub-input-dispose-exception (:operation ev)))
+              (is (= :rf.warning/sub-input-dispose-exception (:category tags))
+                  ":category carries the warning id (build-event :error merge)")
+              (is (= :rf/default (:frame tags))
+                  ":frame is the disposing frame")
+              (is (= [:sub/a] (:rf.sub/query-v tags))
+                  ":rf.sub/query-v is the input whose release threw")
+              (is (some? (:exception tags))
+                  "the swallowed exception is carried, not discarded")
+              (is (= :on-dispose (:where tags))
+                  ":where pins the cached-reaction on-dispose release site")
+              ;; `:recovery` is hoisted to the TOP LEVEL by `build-event`
+              ;; (the error path always stamps it), NOT left under `:tags`.
+              (is (= :ignored (:recovery ev))
+                  ":recovery :ignored — best-effort release"))))
         ;; Assertion 2 — the remaining input STILL released despite the
         ;; sibling throw: `:sub/b`'s slot is gone (the walk did not abort on
         ;; the `:sub/a` throw). `:sub/a`'s slot leaks (its release threw) —

--- a/implementation/core/test/re_frame/trace/structural_retention_cljs_test.cljc
+++ b/implementation/core/test/re_frame/trace/structural_retention_cljs_test.cljc
@@ -25,7 +25,17 @@
 (defn- flat [frame-id]
   (trace-tooling/trace-buffer frame-id {:flat true}))
 
-(deftest ordinary-emit-is-retained-structural-emit-is-not
+;; ---- Posture: dev-only, declared by `^:requires-debug` (rf2-d2841) ---------
+;; Trace machinery end to end: under `-Dre-frame.debug=false` `trace/emit` is a
+;; no-op, so there is no semantic residue to run under that posture, and a
+;; `(when interop/debug-enabled? ...)` split -- the shape the rest of rf2-d2841
+;; used -- would leave EMPTY deftests reporting green (class 2).  Every deftest
+;; below is therefore TAGGED, and the production-gate lane skips the tag rather
+;; than the file: the namespace is still LOADED there, so a load-time failure
+;; under the gate still reddens the job, and an untagged new deftest joins that
+;; lane BY DEFAULT.  Mechanism + rationale: `scripts/test-core-prod-gate.sh`.
+
+(deftest ^:requires-debug ordinary-emit-is-retained-structural-emit-is-not
   (testing "ring retention is gated ONLY by structural delivery; live delivery is not"
     (let [fid  :rf2-244/sync-frame
           did  :rf2-244/run-1
@@ -63,7 +73,7 @@
           (trace-tooling/clear-trace-rings!)
           (trace/clear-listeners!))))))
 
-(deftest structural-emit-never-allocates-a-successor-ring
+(deftest ^:requires-debug structural-emit-never-allocates-a-successor-ring
   (testing "a structural emit tagged with a never-emitted frame id creates no ring"
     ;; This is the same-id-successor case in miniature: `fid` stands in for B's
     ;; freshly-installed id, which has emitted nothing of its own yet. A's
@@ -109,7 +119,7 @@
 ;; explicitly nested `call-with-structural-delivery` can still re-request
 ;; structural semantics.
 
-(deftest listener-triggered-nested-emit-runs-under-normal-scope
+(deftest ^:requires-debug listener-triggered-nested-emit-runs-under-normal-scope
   (testing "a public listener reacting to A's structural terminal fact that emits
             legitimate nested work into unrelated frame C: the nested emit gets
             NORMAL ring retention, not A's outer retentionless scope (rf2-vf2qke)"
@@ -160,7 +170,7 @@
           (trace-tooling/clear-trace-rings!)
           (trace/clear-listeners!))))))
 
-(deftest explicitly-nested-structural-delivery-stays-retentionless
+(deftest ^:requires-debug explicitly-nested-structural-delivery-stays-retentionless
   (testing "a listener that itself re-requests structural delivery for its nested
             emit keeps retentionless semantics — restoring ordinary defaults for
             the fan-out does not defeat an explicit nested request (rf2-vf2qke)"
@@ -196,7 +206,7 @@
           (trace-tooling/clear-trace-rings!)
           (trace/clear-listeners!))))))
 
-(deftest error-emit-under-structural-delivery-is-also-retentionless
+(deftest ^:requires-debug error-emit-under-structural-delivery-is-also-retentionless
   (testing "emit-error! honours the retentionless boundary too (terminal diagnostics)"
     ;; A's terminal diagnostics (`:rf.epoch.cb/listener-exception`,
     ;; `:rf.warning/teardown-hook-exception`) travel through `emit-error!`

--- a/implementation/core/test/re_frame/trace_buffer_test.clj
+++ b/implementation/core/test/re_frame/trace_buffer_test.clj
@@ -65,7 +65,17 @@
 
 ;; ---- 1. Per-frame ring -----------------------------------------------------
 
-(deftest trace-buffer-appends-events-as-cascades
+;; ---- Posture: dev-only, declared by `^:requires-debug` (rf2-d2841) ---------
+;; Trace machinery end to end: under `-Dre-frame.debug=false` `trace/emit` is a
+;; no-op, so there is no semantic residue to run under that posture, and a
+;; `(when interop/debug-enabled? ...)` split -- the shape the rest of rf2-d2841
+;; used -- would leave EMPTY deftests reporting green (class 2).  Every deftest
+;; below is therefore TAGGED, and the production-gate lane skips the tag rather
+;; than the file: the namespace is still LOADED there, so a load-time failure
+;; under the gate still reddens the job, and an untagged new deftest joins that
+;; lane BY DEFAULT.  Mechanism + rationale: `scripts/test-core-prod-gate.sh`.
+
+(deftest ^:requires-debug trace-buffer-appends-events-as-cascades
   (testing "every emit lands in its frame's ring, grouped by :dispatch-id"
     (rf/reg-event :ping (fn [{:keys [db]} _] {:db (assoc db :seen? true)}))
     (rf/dispatch-sync [:ping])
@@ -80,7 +90,7 @@
         (is (seq (:trace-events c)) "trace-events is non-empty")
         (is (some? (:dispatched c)) "cascade carries the :rf.event/dispatched event")))))
 
-(deftest trace-buffer-flat-returns-raw-events
+(deftest ^:requires-debug trace-buffer-flat-returns-raw-events
   (testing "{:flat true} returns the raw event stream"
     (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
     (rf/dispatch-sync [:ping])
@@ -92,7 +102,7 @@
 
 ;; ---- 1b. Event-keyed eviction --------------------------------------------
 
-(deftest event-keyed-eviction
+(deftest ^:requires-debug event-keyed-eviction
   (testing "ring evicts by EVENT-BUNDLE slot, not by raw event count"
     (rf/configure! {:trace-buffer {:events-retained 3}})
     (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
@@ -101,7 +111,7 @@
       (is (= 3 (count bundles))
           (str "ring caps at 3 event-bundle slots; got " (count bundles))))))
 
-(deftest cascade-burst-cannot-evict-prior-cascades
+(deftest ^:requires-debug cascade-burst-cannot-evict-prior-cascades
   (testing "a single cascade's burst of :rf.sub/skip-like noise can't displace OTHER cascades"
     (rf/configure! {:trace-buffer {:events-retained 5}})
     (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
@@ -131,7 +141,7 @@
 
 ;; ---- 1c. Per-frame isolation ---------------------------------------------
 
-(deftest frame-isolation-cascade-bursts-dont-cross-rings
+(deftest ^:requires-debug frame-isolation-cascade-bursts-dont-cross-rings
   (testing "a burst of cascades in one frame cannot evict cascades in another"
     (rf/configure! {:trace-buffer {:events-retained 3}})
     (rf/make-frame {:id :app/main :doc "ordinary application frame"})
@@ -152,7 +162,7 @@
 
 ;; ---- 1d. Frameless emits skip the ring (B3) ------------------------------
 
-(deftest frameless-emits-bypass-the-ring
+(deftest ^:requires-debug frameless-emits-bypass-the-ring
   (testing "trace events emitted OUTSIDE any cascade never land in any ring"
     ;; Emit with no handler-scope and no frame.
     (binding [trace/*handler-scope* nil]
@@ -166,7 +176,7 @@
     (is (empty? (rf/trace-buffer :probe/scope))
         ":probe/scope's ring did NOT pick up the frameless emit either")))
 
-(deftest registration-emits-are-frameless
+(deftest ^:requires-debug registration-emits-are-frameless
   (testing "registering a handler at top level is a frameless emit"
     (rf/clear-trace-buffer! :rf/default)
     ;; reg-event is a frameless emit — no in-flight cascade.
@@ -176,7 +186,7 @@
 
 ;; ---- 1e. events-retained knob ------------------------------------------
 
-(deftest per-frame-events-retained-override
+(deftest ^:requires-debug per-frame-events-retained-override
   (testing ":rf.trace/events-retained on make-frame applies per-frame"
     (rf/configure! {:trace-buffer {:events-retained 5}})
     (rf/make-frame {:id :tb/deep :rf.trace/events-retained 200
@@ -190,7 +200,7 @@
     (is (= 5 (count (rf/trace-buffer :tb/shallow)))
         ":tb/shallow capped at 5 (inherited the process-default of 5)")))
 
-(deftest events-retained-zero-disables-retention
+(deftest ^:requires-debug events-retained-zero-disables-retention
   (testing "{:events-retained 0} disables the ring; surface stays live"
     (rf/configure! {:trace-buffer {:events-retained 0}})
     (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
@@ -208,7 +218,7 @@
 ;; ---- 1e-bis. Re-configuring the process default retunes inherited rings ---
 ;; (rf2-va65k finding 1)
 
-(deftest configure-lowers-already-used-inherited-frame
+(deftest ^:requires-debug configure-lowers-already-used-inherited-frame
   (testing "lowering the process default trims an ALREADY-USED inherited ring"
     ;; The frame's ring is allocated (it emitted cascades) and inherits
     ;; the process default — no per-frame override. Lowering the default
@@ -227,7 +237,7 @@
     (is (<= (count (rf/trace-buffer :rf/default)) 1)
         "post-reconfigure emits stay within the lowered cap")))
 
-(deftest configure-retunes-inherited-but-preserves-override
+(deftest ^:requires-debug configure-retunes-inherited-but-preserves-override
   (testing "a re-configured default retunes inherited frames; explicit overrides survive"
     (rf/configure! {:trace-buffer {:events-retained 50}})
     ;; :tb/inherit takes the process default; :tb/pinned pins its own cap.
@@ -247,7 +257,7 @@
     (is (= 8 (count (rf/trace-buffer :tb/pinned)))
         "explicit per-frame override is NOT clobbered by the new default")))
 
-(deftest configure-zero-disables-inherited-ring-only
+(deftest ^:requires-debug configure-zero-disables-inherited-ring-only
   (testing "configure! 0 disables inherited rings but leaves overrides alone"
     (rf/make-frame {:id :tb/inherit :doc "inherits"})
     (rf/make-frame {:id :tb/pinned :rf.trace/events-retained 4 :doc "override"})
@@ -263,7 +273,7 @@
 ;; ---- 1e-ter. Per-frame override registered BEFORE first emit -------------
 ;; (rf2-va65k finding 2)
 
-(deftest per-frame-override-before-first-emit-does-not-crash
+(deftest ^:requires-debug per-frame-override-before-first-emit-does-not-crash
   (testing "make-frame with a low cap BEFORE first dispatch survives a cap-exceeding burst"
     ;; Pre-fix: set-frame-events-retained! wrote a partial
     ;; {:events-retained N} map (no :run-order). push-to-ring!
@@ -285,7 +295,7 @@
         (is (apply < ids) "retained cascades are in oldest-first order")
         (is (= ids (vec (sort ids))) "oldest-first preserved after eviction")))))
 
-(deftest per-frame-override-zero-before-first-emit-disables-cleanly
+(deftest ^:requires-debug per-frame-override-zero-before-first-emit-disables-cleanly
   (testing "a 0 per-frame override before first emit disables the ring without crashing"
     (rf/make-frame {:id :tb/silent :rf.trace/events-retained 0 :doc "disabled"})
     (rf/reg-event :tb/ev (fn [{:keys [db]} _] {:db db}))
@@ -296,7 +306,7 @@
 
 ;; ---- 1f. clear-trace-buffer! and frame-destroy --------------------------
 
-(deftest clear-trace-buffer-clears-only-the-named-frame
+(deftest ^:requires-debug clear-trace-buffer-clears-only-the-named-frame
   (testing "clear-trace-buffer! is per-frame"
     (rf/make-frame {:id :app/a :doc "a"})
     (rf/make-frame {:id :app/b :doc "b"})
@@ -309,7 +319,7 @@
     (is (= [] (rf/trace-buffer :app/a)) ":app/a's ring is empty")
     (is (seq (rf/trace-buffer :app/b)) ":app/b's ring is intact")))
 
-(deftest frame-destroy-clears-the-rings
+(deftest ^:requires-debug frame-destroy-clears-the-rings
   (testing "destroy-frame! releases the destroyed frame's ring"
     (rf/make-frame {:id :app/transient :doc "short-lived"})
     (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
@@ -320,28 +330,28 @@
     (is (= [] (rf/trace-buffer :app/transient))
         "ring is empty after frame destroy")))
 
-(deftest read-against-unknown-frame-returns-empty
+(deftest ^:requires-debug read-against-unknown-frame-returns-empty
   (testing "trace-buffer for a never-registered frame returns []"
     (is (= [] (rf/trace-buffer :no-such-frame)))
     (is (= [] (rf/trace-buffer :no-such-frame {:flat true})))))
 
 ;; ---- 1g. Filter vocabulary (event-level, :flat true) ---------------------
 
-(deftest trace-buffer-filter-operation
+(deftest ^:requires-debug trace-buffer-filter-operation
   (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:ping])
   (let [dispatched (flat-events :rf/default {:operation :rf.event/dispatched})]
     (is (seq dispatched))
     (is (every? #(= :rf.event/dispatched (:operation %)) dispatched))))
 
-(deftest trace-buffer-filter-op-type
+(deftest ^:requires-debug trace-buffer-filter-op-type
   (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:ping])
   (let [event-only (flat-events :rf/default {:op-type :rf.event})]
     (is (seq event-only))
     (is (every? #(= :rf.event (:op-type %)) event-only))))
 
-(deftest trace-buffer-filter-since
+(deftest ^:requires-debug trace-buffer-filter-since
   (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:ping])
   (let [pre-id (-> (flat-events :rf/default) last :id)]
@@ -350,14 +360,14 @@
       (is (seq after))
       (is (every? #(> (:id %) pre-id) after)))))
 
-(deftest trace-buffer-filter-severity
+(deftest ^:requires-debug trace-buffer-filter-severity
   (testing ":severity :error narrows to :op-type :error events"
     (rf/dispatch-sync [:no-such-event-handler])
     (let [errs (flat-events :rf/default {:severity :error})]
       (is (seq errs))
       (is (every? #(= :error (:op-type %)) errs)))))
 
-(deftest trace-buffer-filter-event-id
+(deftest ^:requires-debug trace-buffer-filter-event-id
   (rf/reg-event :ev/alpha (fn [{:keys [db]} _] {:db db}))
   (rf/reg-event :ev/beta  (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:ev/alpha])
@@ -366,14 +376,14 @@
     (is (seq alpha))
     (is (every? #(= :ev/alpha (get-in % [:tags :rf.trace/event-id])) alpha))))
 
-(deftest trace-buffer-filter-handler-id
+(deftest ^:requires-debug trace-buffer-filter-handler-id
   (rf/reg-event :ev/throws (fn [{:keys [db]} _] {:db (throw (ex-info "boom" {}))}))
   (try (rf/dispatch-sync [:ev/throws]) (catch Throwable _ nil))
   (let [hits (flat-events :rf/default {:handler-id :ev/throws})]
     (is (seq hits))
     (is (every? #(= :ev/throws (get-in % [:tags :handler-id])) hits))))
 
-(deftest trace-buffer-filter-source
+(deftest ^:requires-debug trace-buffer-filter-source
   (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:ping] {:source :repl})
   (rf/dispatch-sync [:ping] {:source :after-timer})
@@ -382,7 +392,7 @@
     (is (every? #(= :repl (or (:source %) (get-in % [:tags :source])))
                 repl-evs))))
 
-(deftest trace-buffer-filter-origin
+(deftest ^:requires-debug trace-buffer-filter-origin
   (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:ping] {:origin :pair})
   (rf/dispatch-sync [:ping] {:origin :story})
@@ -390,7 +400,7 @@
     (is (seq pair-evs))
     (is (every? #(= :pair (get-in % [:tags :rf.event/origin])) pair-evs))))
 
-(deftest trace-buffer-filter-dispatch-id-flat
+(deftest ^:requires-debug trace-buffer-filter-dispatch-id-flat
   (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:ping])
   (rf/dispatch-sync [:ping])
@@ -403,7 +413,7 @@
     (is (seq slice))
     (is (every? #(= target-id (get-in % [:tags :rf.trace/dispatch-id])) slice))))
 
-(deftest trace-buffer-filter-since-ms
+(deftest ^:requires-debug trace-buffer-filter-since-ms
   (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:ping])
   (let [pre-time (-> (flat-events :rf/default) last :time)]
@@ -413,7 +423,7 @@
       (is (seq after))
       (is (every? #(> (:time %) pre-time) after)))))
 
-(deftest trace-buffer-filter-between
+(deftest ^:requires-debug trace-buffer-filter-between
   (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:ping])
   (let [t0 (-> (flat-events :rf/default) first :time)
@@ -424,7 +434,7 @@
   (let [win (flat-events :rf/default {:between [0 1]})]
     (is (= [] win))))
 
-(deftest trace-buffer-filter-sensitive
+(deftest ^:requires-debug trace-buffer-filter-sensitive
   (testing ":sensitive? filter matches top-level slot"
     (rf/reg-event :ev/x {:rf/sensitive? true} (fn [{:keys [db]} _] {:db db}))
     (rf/reg-event :ev/y (fn [{:keys [db]} _] {:db db}))
@@ -437,7 +447,7 @@
       (is (seq plain) "at least one non-sensitive event")
       (is (every? #(not (true? (:sensitive? %))) plain)))))
 
-(deftest trace-buffer-filter-pred
+(deftest ^:requires-debug trace-buffer-filter-pred
   (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:ping])
   (let [evs (flat-events :rf/default
@@ -447,7 +457,7 @@
 
 ;; ---- 1h. Cascade-bundle filters ------------------------------------------
 
-(deftest trace-buffer-cascade-filter-event-id
+(deftest ^:requires-debug trace-buffer-cascade-filter-event-id
   (rf/reg-event :ev/alpha (fn [{:keys [db]} _] {:db db}))
   (rf/reg-event :ev/beta  (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:ev/alpha])
@@ -456,7 +466,7 @@
     (is (seq alpha))
     (is (every? #(= :ev/alpha (first (:event %))) alpha))))
 
-(deftest trace-buffer-cascade-filter-dispatch-id
+(deftest ^:requires-debug trace-buffer-cascade-filter-dispatch-id
   (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:ping])
   (rf/dispatch-sync [:ping])
@@ -467,7 +477,7 @@
         ":dispatch-id narrows event-bundle reads to one cascade")
     (is (= target-id (:dispatch-id (first narrowed))))))
 
-(deftest trace-buffer-cascade-filter-origin
+(deftest ^:requires-debug trace-buffer-cascade-filter-origin
   (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:ping] {:origin :pair})
   (rf/dispatch-sync [:ping] {:origin :story})
@@ -477,7 +487,7 @@
 
 ;; ---- 2. :dispatch-id correlation -----------------------------------------
 
-(deftest dispatch-id-allocated-on-every-dispatch
+(deftest ^:requires-debug dispatch-id-allocated-on-every-dispatch
   (testing "every :rf.event/dispatched trace carries a numeric :rf.trace/dispatch-id"
     (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
     (rf/dispatch-sync [:ping])
@@ -489,7 +499,7 @@
       (is (every? number? ids))
       (is (= (count (distinct ids)) (count ids))))))
 
-(deftest top-level-dispatch-has-no-parent
+(deftest ^:requires-debug top-level-dispatch-has-no-parent
   (rf/reg-event :standalone (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:standalone])
   (let [ev (->> (flat-events :rf/default)
@@ -499,7 +509,7 @@
     (is ev)
     (is (nil? (get-in ev [:tags :rf.trace/parent-dispatch-id])))))
 
-(deftest fx-dispatch-inherits-parent-dispatch-id
+(deftest ^:requires-debug fx-dispatch-inherits-parent-dispatch-id
   (rf/reg-event :outer (fn [_ _] {:fx [[:dispatch [:inner]]]}))
   (rf/reg-event :inner (fn [{:keys [db]} _] {:db (assoc db :inner? true)}))
   (rf/dispatch-sync [:outer])
@@ -517,7 +527,7 @@
 
 ;; ---- 3. :origin opt -------------------------------------------------------
 
-(deftest origin-defaults-to-app
+(deftest ^:requires-debug origin-defaults-to-app
   (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:ping])
   (let [ev (->> (flat-events :rf/default)
@@ -527,7 +537,7 @@
     (is ev)
     (is (= :app (get-in ev [:tags :rf.event/origin])))))
 
-(deftest origin-opt-overrides-default
+(deftest ^:requires-debug origin-opt-overrides-default
   (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:ping] {:origin :pair})
   (let [ev (->> (flat-events :rf/default)
@@ -539,7 +549,7 @@
 
 ;; ---- 4. :source opt (post-rf2-1ve9h — collapsed from :rf/dispatch-origin)
 
-(deftest dispatch-source-defaults-to-unknown
+(deftest ^:requires-debug dispatch-source-defaults-to-unknown
   ;; Per rf2-hxj0d the default `:source` is `:unknown` (the un-stamped
   ;; dispatch site). Per rf2-1ve9h the prior parallel
   ;; `:rf/dispatch-origin :user` default was collapsed — the single
@@ -560,7 +570,7 @@
     (is (nil? (get-in ev [:tags :rf/dispatch-origin]))
         ":rf/dispatch-origin retired per rf2-1ve9h")))
 
-(deftest dispatch-source-opt-overrides-default
+(deftest ^:requires-debug dispatch-source-opt-overrides-default
   (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
   (rf/dispatch-sync [:ping] {:source :tool})
   (let [ev (->> (flat-events :rf/default)
@@ -570,7 +580,7 @@
     (is ev)
     (is (= :tool (:source ev)))))
 
-(deftest dispatch-source-fx-cascade-stamps-fx-dispatch
+(deftest ^:requires-debug dispatch-source-fx-cascade-stamps-fx-dispatch
   (testing "child dispatches emitted by :dispatch fx are tagged :fx-dispatch"
     ;; Per rf2-c3990: a `:dispatch` fx from a non-machine parent stamps
     ;; `:source :fx-dispatch` on the child envelope (the actor-message
@@ -594,7 +604,7 @@
 
 ;; ---- 5. Frame-level trace-emission gate (rf2-2qaqh) ----------------------
 
-(deftest tool-frame-emits-no-trace
+(deftest ^:requires-debug tool-frame-emits-no-trace
   (testing "a frame registered :rf.trace/frame-no-emit? true grows the ring by 0"
     (rf/make-frame {:id :tool/inspector :rf.trace/frame-no-emit? true})
     (rf/reg-event :tool/work (fn [{:keys [db]} _] {:db (assoc db :ran? true)}))
@@ -603,7 +613,7 @@
     (is (= [] (rf/trace-buffer :tool/inspector))
         "no trace event from a trace-disabled frame's cascade reaches the ring")))
 
-(deftest app-frame-emits-trace-while-tool-frame-silent
+(deftest ^:requires-debug app-frame-emits-trace-while-tool-frame-silent
   (testing "an app frame's cascade DOES grow its ring; the tool frame's does NOT"
     (rf/make-frame {:id :tool/inspector :rf.trace/frame-no-emit? true})
     (rf/make-frame {:id :app/main :doc "ordinary application frame"})
@@ -617,7 +627,7 @@
     (is (= [] (rf/trace-buffer :tool/inspector))
         "tool-frame's ring stays empty")))
 
-(deftest destroy-clears-trace-disabled-flag
+(deftest ^:requires-debug destroy-clears-trace-disabled-flag
   ;; rf2-zcl055: `make-frame` adds a `:rf.trace/frame-no-emit? true` frame to
   ;; the process-global trace-disabled set; `destroy-frame!` must remove it
   ;; (the teardown counterpart to `set-frame-no-emit!`, symmetric with the
@@ -651,7 +661,7 @@
 ;; tests call `trace/emit!` directly with tags that carry NO `:frame` key,
 ;; so only the current-frame-hook resolution path is exercised.
 
-(deftest untagged-emit-suppressed-when-current-frame-is-tool-disabled
+(deftest ^:requires-debug untagged-emit-suppressed-when-current-frame-is-tool-disabled
   (testing "an un-tagged emit (no :frame key in tags), resolved via the
             ambient *current-frame* scope, is suppressed when that frame
             is trace-disabled — not just a tagged emit"
@@ -664,7 +674,7 @@
           "the un-tagged emit never reached the listener — suppressed via the current-frame-hook path")
       (rf/unregister-listener! :trace ::untagged))))
 
-(deftest untagged-emit-not-suppressed-under-a-plain-app-frame
+(deftest ^:requires-debug untagged-emit-not-suppressed-under-a-plain-app-frame
   (testing "control: the SAME un-tagged emit under a non-disabled app
             frame's ambient scope IS delivered — proves the suppression
             above is frame-specific, not some other global gate"
@@ -679,7 +689,7 @@
 
 ;; ---- 6. B4 hot-reload dedup-by-shape ------------------------------------
 
-(deftest hot-reload-unchanged-handler-emits-zero-traces
+(deftest ^:requires-debug hot-reload-unchanged-handler-emits-zero-traces
   (testing "re-registering an identical handler emits ZERO traces (B4 dedup)"
     (let [handler-fn (fn [{:keys [db]} _] {:db db})]
       (rf/reg-event :ev/hot {:doc "hot"} handler-fn)
@@ -692,7 +702,7 @@
                                               :op-type :rf.registry}))
           "no :rf.registry/* traces from idempotent hot-reload"))))
 
-(deftest hot-reload-changed-handler-emits-one-trace
+(deftest ^:requires-debug hot-reload-changed-handler-emits-one-trace
   (testing "re-registering a CHANGED handler emits exactly one :rf.registry/handler-replaced"
     (let [recv (atom [])]
       (rf/register-listener! :trace ::probe
@@ -709,7 +719,7 @@
           "exactly one :rf.registry/handler-replaced emitted on real edit")
       (is (= :ev/hot (-> @recv first :tags :id))))))
 
-(deftest hot-reload-dedup-clears-on-reset
+(deftest ^:requires-debug hot-reload-dedup-clears-on-reset
   (testing "clear-listeners! (and clear-trace-rings!) reset the dedup table"
     (let [handler-fn (fn [{:keys [db]} _] {:db db})
           recv (atom [])]
@@ -729,7 +739,7 @@
       (is (seq @recv)
           "post-clear re-registration emits at least one registry trace"))))
 
-(deftest hot-reload-dedup-per-kind-id
+(deftest ^:requires-debug hot-reload-dedup-per-kind-id
   (testing "dedup is per-(kind, id) — separate ids don't interfere"
     (let [recv (atom [])]
       (rf/register-listener! :trace ::probe

--- a/implementation/core/test/re_frame/trace_listener_concurrent_drain_serialization_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_concurrent_drain_serialization_test.clj
@@ -88,7 +88,17 @@
   [frame-id]
   (boolean (some-> (frame/frame frame-id) :drain-lock deref)))
 
-(deftest concurrent-drains-of-different-frames-never-overlap-one-listener
+;; ---- Posture: dev-only, declared by `^:requires-debug` (rf2-d2841) ---------
+;; Trace machinery end to end: under `-Dre-frame.debug=false` `trace/emit` is a
+;; no-op, so there is no semantic residue to run under that posture, and a
+;; `(when interop/debug-enabled? ...)` split -- the shape the rest of rf2-d2841
+;; used -- would leave EMPTY deftests reporting green (class 2).  Every deftest
+;; below is therefore TAGGED, and the production-gate lane skips the tag rather
+;; than the file: the namespace is still LOADED there, so a load-time failure
+;; under the gate still reddens the job, and an untagged new deftest joins that
+;; lane BY DEFAULT.  Mechanism + rationale: `scripts/test-core-prod-gate.sh`.
+
+(deftest ^:requires-debug concurrent-drains-of-different-frames-never-overlap-one-listener
   (testing (str "two simultaneous drains of DIFFERENT frames neither enter one "
                 "listener concurrently nor invoke it under a held drain-lock ("
                 iters " iterations)")

--- a/implementation/core/test/re_frame/trace_listener_concurrent_serialization_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_concurrent_serialization_test.clj
@@ -51,7 +51,17 @@
 
 ;; ---- 1. Deterministic two-thread latch proof -----------------------------
 
-(deftest per-listener-callback-never-overlaps-across-concurrent-emits
+;; ---- Posture: dev-only, declared by `^:requires-debug` (rf2-d2841) ---------
+;; Trace machinery end to end: under `-Dre-frame.debug=false` `trace/emit` is a
+;; no-op, so there is no semantic residue to run under that posture, and a
+;; `(when interop/debug-enabled? ...)` split -- the shape the rest of rf2-d2841
+;; used -- would leave EMPTY deftests reporting green (class 2).  Every deftest
+;; below is therefore TAGGED, and the production-gate lane skips the tag rather
+;; than the file: the namespace is still LOADED there, so a load-time failure
+;; under the gate still reddens the job, and an untagged new deftest joins that
+;; lane BY DEFAULT.  Mechanism + rationale: `scripts/test-core-prod-gate.sh`.
+
+(deftest ^:requires-debug per-listener-callback-never-overlaps-across-concurrent-emits
   ;; A single listener L blocks INSIDE its callback while handling event A
   ;; (emitted on thread t1). While A is blocked, event B is emitted to the SAME
   ;; L on thread t2. Pre-fix, t2's outermost fan-out was a distinct thread-local
@@ -119,7 +129,7 @@
 
 ;; ---- 2. Stress + registration churn (no overlap, no deadlock) ------------
 
-(deftest ^:stress concurrent-emits-serialize-under-registration-churn
+(deftest ^:requires-debug ^:stress concurrent-emits-serialize-under-registration-churn
   ;; Many threads emit concurrently while a churn thread registers /
   ;; unregisters a second listener. A continuously-registered always-on
   ;; listener runs an overlap detector. Invariants:

--- a/implementation/core/test/re_frame/trace_listener_continuation_neutral_cljs_test.cljc
+++ b/implementation/core/test/re_frame/trace_listener_continuation_neutral_cljs_test.cljc
@@ -76,7 +76,17 @@
     (fn []
       (trace/emit! :rf.registry :rf.test/fenced-emit {:frame frame-id}))))
 
-(deftest listener-body-runs-neutral-while-fence-suppresses-a-tail
+;; ---- Posture: dev-only, declared by `^:requires-debug` (rf2-d2841) ---------
+;; Trace machinery end to end: under `-Dre-frame.debug=false` `trace/emit` is a
+;; no-op, so there is no semantic residue to run under that posture, and a
+;; `(when interop/debug-enabled? ...)` split -- the shape the rest of rf2-d2841
+;; used -- would leave EMPTY deftests reporting green (class 2).  Every deftest
+;; below is therefore TAGGED, and the production-gate lane skips the tag rather
+;; than the file: the namespace is still LOADED there, so a load-time failure
+;; under the gate still reddens the job, and an untagged new deftest joins that
+;; lane BY DEFAULT.  Mechanism + rationale: `scripts/test-core-prod-gate.sh`.
+
+(deftest ^:requires-debug listener-body-runs-neutral-while-fence-suppresses-a-tail
   (reg-test-events!)
   (let [a-id       :trace.neutral/subject   ;; A and same-id successor B
         c-id       :trace.neutral/unrelated
@@ -143,7 +153,7 @@
           (trace/unregister-listener! ::destroyer)
           (trace/unregister-listener! ::later-a))))))
 
-(deftest non-destroying-listener-does-not-over-suppress-subsequent-listener
+(deftest ^:requires-debug non-destroying-listener-does-not-over-suppress-subsequent-listener
   ;; Mutation guard for the loop's before/after check. When the first listener
   ;; leaves A LIVE (and merely does its own unrelated nested work under neutral
   ;; scope), the subsequent listener MUST still receive A's fenced event — the

--- a/implementation/core/test/re_frame/trace_listener_deferred_batch_fifo_cljs_test.cljc
+++ b/implementation/core/test/re_frame/trace_listener_deferred_batch_fifo_cljs_test.cljc
@@ -72,7 +72,17 @@
 (defn- index-of [xs x]
   (first (keep-indexed (fn [i y] (when (= x y) i)) xs)))
 
-(deftest deferred-batch-outranks-listener-authored-trace-at-top-level
+;; ---- Posture: dev-only, declared by `^:requires-debug` (rf2-d2841) ---------
+;; Trace machinery end to end: under `-Dre-frame.debug=false` `trace/emit` is a
+;; no-op, so there is no semantic residue to run under that posture, and a
+;; `(when interop/debug-enabled? ...)` split -- the shape the rest of rf2-d2841
+;; used -- would leave EMPTY deftests reporting green (class 2).  Every deftest
+;; below is therefore TAGGED, and the production-gate lane skips the tag rather
+;; than the file: the namespace is still LOADED there, so a load-time failure
+;; under the gate still reddens the job, and an untagged new deftest joins that
+;; lane BY DEFAULT.  Mechanism + rationale: `scripts/test-core-prod-gate.sh`.
+
+(deftest ^:requires-debug deferred-batch-outranks-listener-authored-trace-at-top-level
   ;; OUTERMOST seam: a top-level `dispatch-sync` defers the whole run batch, then
   ;; flushes it with `*fanout-ctx*` unbound (fresh outermost fan-outs). A
   ;; run-start listener authors a later trace; it must not overtake the
@@ -118,7 +128,7 @@
         (trace/unregister-listener! ::emitter)
         (trace/unregister-listener! ::observer)))))
 
-(deftest deferred-batch-outranks-listener-authored-trace-when-integrated
+(deftest ^:requires-debug deferred-batch-outranks-listener-authored-trace-when-integrated
   ;; INTEGRATE seam: a `::trigger` listener reacts to a clean, frameless emit (so
   ;; an OUTER fan-out is in flight and `*fanout-ctx*` is bound) by
   ;; `dispatch-sync`-ing into a frame. That nested drain defers its run batch and,

--- a/implementation/core/test/re_frame/trace_listener_drain_deadlock_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_drain_deadlock_test.clj
@@ -70,7 +70,17 @@
 (def ^:private join-timeout-ms 10000)
 (def ^:private latch-timeout-s 10)
 
-(deftest fanout-monitor-drain-lock-ab-ba-does-not-deadlock
+;; ---- Posture: dev-only, declared by `^:requires-debug` (rf2-d2841) ---------
+;; Trace machinery end to end: under `-Dre-frame.debug=false` `trace/emit` is a
+;; no-op, so there is no semantic residue to run under that posture, and a
+;; `(when interop/debug-enabled? ...)` split -- the shape the rest of rf2-d2841
+;; used -- would leave EMPTY deftests reporting green (class 2).  Every deftest
+;; below is therefore TAGGED, and the production-gate lane skips the tag rather
+;; than the file: the namespace is still LOADED there, so a load-time failure
+;; under the gate still reddens the job, and an untagged new deftest joins that
+;; lane BY DEFAULT.  Mechanism + rationale: `scripts/test-core-prod-gate.sh`.
+
+(deftest ^:requires-debug fanout-monitor-drain-lock-ab-ba-does-not-deadlock
   (testing (str "T1 (fanout-monitor -> listener -> dispatch-sync F) against the "
                 "async drainer (F.:drain-lock -> run-start emit) completes "
                 "bounded and the dispatched event settles exactly once ("

--- a/implementation/core/test/re_frame/trace_listener_frame_tagged_serialization_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_frame_tagged_serialization_test.clj
@@ -55,7 +55,17 @@
   (or (some-> (System/getenv "RF2_RAKQK_LATCH_ITERS") Long/parseLong)
       50))
 
-(deftest frame-tagged-public-emits-not-under-a-drain-serialize
+;; ---- Posture: dev-only, declared by `^:requires-debug` (rf2-d2841) ---------
+;; Trace machinery end to end: under `-Dre-frame.debug=false` `trace/emit` is a
+;; no-op, so there is no semantic residue to run under that posture, and a
+;; `(when interop/debug-enabled? ...)` split -- the shape the rest of rf2-d2841
+;; used -- would leave EMPTY deftests reporting green (class 2).  Every deftest
+;; below is therefore TAGGED, and the production-gate lane skips the tag rather
+;; than the file: the namespace is still LOADED there, so a load-time failure
+;; under the gate still reddens the job, and an untagged new deftest joins that
+;; lane BY DEFAULT.  Mechanism + rationale: `scripts/test-core-prod-gate.sh`.
+
+(deftest ^:requires-debug frame-tagged-public-emits-not-under-a-drain-serialize
   ;; Two frame-TAGGED emits (`{:frame :rf/default}`) issued from two ordinary
   ;; threads, NEITHER of which is draining `:rf/default` — so neither holds its
   ;; `:drain-lock`. A single listener L blocks INSIDE its callback while handling

--- a/implementation/core/test/re_frame/trace_listener_nested_emission_order_cljs_test.cljc
+++ b/implementation/core/test/re_frame/trace_listener_nested_emission_order_cljs_test.cljc
@@ -56,7 +56,17 @@
   [evs]
   (filterv #{outer inner} (mapv :operation evs)))
 
-(deftest nested-emission-preserves-per-listener-event-order
+;; ---- Posture: dev-only, declared by `^:requires-debug` (rf2-d2841) ---------
+;; Trace machinery end to end: under `-Dre-frame.debug=false` `trace/emit` is a
+;; no-op, so there is no semantic residue to run under that posture, and a
+;; `(when interop/debug-enabled? ...)` split -- the shape the rest of rf2-d2841
+;; used -- would leave EMPTY deftests reporting green (class 2).  Every deftest
+;; below is therefore TAGGED, and the production-gate lane skips the tag rather
+;; than the file: the namespace is still LOADED there, so a load-time failure
+;; under the gate still reddens the job, and an untagged new deftest joins that
+;; lane BY DEFAULT.  Mechanism + rationale: `scripts/test-core-prod-gate.sh`.
+
+(deftest ^:requires-debug nested-emission-preserves-per-listener-event-order
   ;; L0 (emitter, registered first) reentrantly emits `inner` while handling the
   ;; outer event. L1 (observer, registered second) must still see `outer` before
   ;; `inner`. Under the bug L1 saw `[inner outer]` — the nested emit reached L1
@@ -82,7 +92,7 @@
         (trace/unregister-listener! ::emitter)
         (trace/unregister-listener! ::observer)))))
 
-(deftest nested-emit-completes-synchronously
+(deftest ^:requires-debug nested-emit-completes-synchronously
   ;; rf2-s522m: a nested emit must return only AFTER its event has reached every
   ;; listener (Spec 009 §Emitting trace events: "the emit returns once every
   ;; listener has been invoked"). L0 (emitter, first) handles outer, emits inner,
@@ -126,7 +136,7 @@
         (trace/unregister-listener! ::emitter)
         (trace/unregister-listener! ::observer)))))
 
-(deftest stateful-tool-finishes-in-the-authored-state
+(deftest ^:requires-debug stateful-tool-finishes-in-the-authored-state
   ;; The bead's stateful-tooling evidence: a tool folds the event stream into a
   ;; live/cleared state. `outer` = the flow was CLEARED; the emitter reacts by
   ;; re-registering (emitting `inner` = REGISTERED). Authored order is
@@ -154,7 +164,7 @@
         (trace/unregister-listener! ::reregistrar)
         (trace/unregister-listener! ::stateful-tool)))))
 
-(deftest nested-exception-isolation-preserves-order
+(deftest ^:requires-debug nested-exception-isolation-preserves-order
   ;; A listener that THROWS between the emitter and the observer must neither
   ;; stop delivery nor corrupt ordering: per-listener exception isolation is
   ;; preserved AND the observer still sees outer before the reentrant inner.

--- a/implementation/core/test/re_frame/trace_listener_post_drain_settled_state_cljs_test.cljc
+++ b/implementation/core/test/re_frame/trace_listener_post_drain_settled_state_cljs_test.cljc
@@ -42,7 +42,17 @@
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
 
-(deftest run-start-listener-observes-settled-db-uniformly
+;; ---- Posture: dev-only, declared by `^:requires-debug` (rf2-d2841) ---------
+;; Trace machinery end to end: under `-Dre-frame.debug=false` `trace/emit` is a
+;; no-op, so there is no semantic residue to run under that posture, and a
+;; `(when interop/debug-enabled? ...)` split -- the shape the rest of rf2-d2841
+;; used -- would leave EMPTY deftests reporting green (class 2).  Every deftest
+;; below is therefore TAGGED, and the production-gate lane skips the tag rather
+;; than the file: the namespace is still LOADED there, so a load-time failure
+;; under the gate still reddens the job, and an untagged new deftest joins that
+;; lane BY DEFAULT.  Mechanism + rationale: `scripts/test-core-prod-gate.sh`.
+
+(deftest ^:requires-debug run-start-listener-observes-settled-db-uniformly
   ;; A drain-owned run-start listener must see the event's SETTLED db on every
   ;; host. Pre-fix CLJS delivered inline and the listener saw the un-settled db.
   (let [seen-at-run-start (atom :not-recorded)]

--- a/implementation/core/test/re_frame/trace_listener_reentrant_dispatch_sync_deferral_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_reentrant_dispatch_sync_deferral_test.clj
@@ -66,7 +66,17 @@
   [frame-id]
   (boolean (some-> (frame/frame frame-id) :drain-lock deref)))
 
-(deftest listener-initiated-dispatch-sync-never-runs-listeners-under-drain-lock
+;; ---- Posture: dev-only, declared by `^:requires-debug` (rf2-d2841) ---------
+;; Trace machinery end to end: under `-Dre-frame.debug=false` `trace/emit` is a
+;; no-op, so there is no semantic residue to run under that posture, and a
+;; `(when interop/debug-enabled? ...)` split -- the shape the rest of rf2-d2841
+;; used -- would leave EMPTY deftests reporting green (class 2).  Every deftest
+;; below is therefore TAGGED, and the production-gate lane skips the tag rather
+;; than the file: the namespace is still LOADED there, so a load-time failure
+;; under the gate still reddens the job, and an untagged new deftest joins that
+;; lane BY DEFAULT.  Mechanism + rationale: `scripts/test-core-prod-gate.sh`.
+
+(deftest ^:requires-debug listener-initiated-dispatch-sync-never-runs-listeners-under-drain-lock
   (testing (str "a listener that dispatch-syncs into F from inside an outer "
                 "fan-out never has F's drain-owned traces fanned out while F's "
                 ":drain-lock is held (" iters " iterations)")

--- a/implementation/core/test/re_frame/trace_listener_test.clj
+++ b/implementation/core/test/re_frame/trace_listener_test.clj
@@ -78,7 +78,17 @@
 
 ;; ---- 1. register-listener! arity + return value ---------------------------
 
-(deftest register-trace-listener-is-2-arity-and-returns-key
+;; ---- Posture: dev-only, declared by `^:requires-debug` (rf2-d2841) ---------
+;; Trace machinery end to end: under `-Dre-frame.debug=false` `trace/emit` is a
+;; no-op, so there is no semantic residue to run under that posture, and a
+;; `(when interop/debug-enabled? ...)` split -- the shape the rest of rf2-d2841
+;; used -- would leave EMPTY deftests reporting green (class 2).  Every deftest
+;; below is therefore TAGGED, and the production-gate lane skips the tag rather
+;; than the file: the namespace is still LOADED there, so a load-time failure
+;; under the gate still reddens the job, and an untagged new deftest joins that
+;; lane BY DEFAULT.  Mechanism + rationale: `scripts/test-core-prod-gate.sh`.
+
+(deftest ^:requires-debug register-trace-listener-is-2-arity-and-returns-key
   (testing "register-listener! takes (key cb) and returns the key"
     (let [k ::pin-arity
           ret (rf/register-listener! :trace k (fn [_ev]))]
@@ -86,14 +96,14 @@
           "register-listener! returns the key per Spec 009 §The listener API")
       (rf/unregister-listener! :trace k))))
 
-(deftest unregister-trace-listener-returns-nil
+(deftest ^:requires-debug unregister-trace-listener-returns-nil
   (testing "unregister-listener! returns nil per Spec 009 §The listener API"
     (rf/register-listener! :trace ::r (fn [_ev]))
     (is (nil? (rf/unregister-listener! :trace ::r)))))
 
 ;; ---- 2. Synchronous, per-event delivery -----------------------------------
 
-(deftest synchronous-delivery
+(deftest ^:requires-debug synchronous-delivery
   (testing "listener has been called by the time dispatch-sync returns — no async wait"
     (let [seen (atom [])]
       (rf/register-listener! :trace ::sync (fn [ev] (swap! seen conj ev)))
@@ -111,7 +121,7 @@
           "the :rf.event/dispatched trace was delivered synchronously")
       (rf/unregister-listener! :trace ::sync))))
 
-(deftest one-call-per-emitted-event
+(deftest ^:requires-debug one-call-per-emitted-event
   (testing "the listener is invoked once per emitted event — no batching, no debounce"
     (let [calls (atom 0)
           seen  (atom [])]
@@ -134,7 +144,7 @@
             "each event was delivered exactly once — no batching, no dedup-by-listener"))
       (rf/unregister-listener! :trace ::counter))))
 
-(deftest in-cascade-emits-land-in-the-ring
+(deftest ^:requires-debug in-cascade-emits-land-in-the-ring
   (testing "every IN-CASCADE listener event also appears in the frame's ring
             (frameless emits ride the live stream only — per B3 ruling rf2-g1b2m).
             For a pure dispatch-sync where all emits carry the cascade's
@@ -157,7 +167,7 @@
 
 ;; ---- 3. Event-emission order ---------------------------------------------
 
-(deftest events-delivered-in-emission-order
+(deftest ^:requires-debug events-delivered-in-emission-order
   (testing "a listener sees events in the same order the runtime fired them"
     (let [seen (atom [])]
       (rf/register-listener! :trace ::ordered (fn [ev] (swap! seen conj ev)))
@@ -176,7 +186,7 @@
 
 ;; ---- 4. Point-event shape (no span fields) -------------------------------
 
-(deftest events-are-point-shaped-not-span-shaped
+(deftest ^:requires-debug events-are-point-shaped-not-span-shaped
   (testing "every emitted event has the canonical point-event keys and NO span-shape keys"
     (let [seen (atom [])]
       (rf/register-listener! :trace ::shape (fn [ev] (swap! seen conj ev)))
@@ -209,7 +219,7 @@
 
 ;; ---- 5. Frame-aware tagging -----------------------------------------------
 
-(deftest trace-events-carry-frame-tag
+(deftest ^:requires-debug trace-events-carry-frame-tag
   (testing "a trace event for a specific frame carries :frame frame-id under :tags"
     (let [seen (atom [])]
       (rf/make-frame {:id :frame/scoped :doc "scoped"})
@@ -225,7 +235,7 @@
             ":frame frame-id is carried under :tags per Spec 009 §The trace event model"))
       (rf/unregister-listener! :trace ::framed))))
 
-(deftest different-frames-carry-distinct-frame-tags
+(deftest ^:requires-debug different-frames-carry-distinct-frame-tags
   (testing "events emitted on behalf of different frames carry their respective :frame ids"
     (rf/make-frame {:id :frame/a})
     (rf/make-frame {:id :frame/b})
@@ -246,7 +256,7 @@
 
 ;; ---- 6. Production-elision contract (structural) -------------------------
 
-(deftest emit-rides-debug-flag
+(deftest ^:requires-debug emit-rides-debug-flag
   (testing "the listener-emission body is wrapped in interop/debug-enabled?"
     ;; Mirror of trace-buffer-rides-debug-flag in trace_buffer_test: the
     ;; production-elision contract is that no listener invocation, event-map
@@ -283,7 +293,7 @@
 ;; registered listener; a subsequent emission lands on NONE of them;
 ;; re-registration after a clear restores delivery.
 
-(deftest clear-trace-listeners-drops-every-listener
+(deftest ^:requires-debug clear-trace-listeners-drops-every-listener
   (testing "clear-listeners! drops every listener; subsequent emits hit
             zero listeners; re-registration after clear restores delivery"
     ;; Setup: three listeners under distinct keys, each appending to its
@@ -334,7 +344,7 @@
         (is (= a-count-1 (count @seen-a))
             "A stays cleared — clear-listeners! is permanent, not pause")))))
 
-(deftest clear-trace-listeners-returns-nil
+(deftest ^:requires-debug clear-trace-listeners-returns-nil
   (testing "clear-listeners! returns nil per Spec 009 §The listener API"
     (rf/register-listener! :trace ::ret-nil (fn [_ev]))
     (is (nil? (trace/clear-listeners!))
@@ -352,7 +362,7 @@
 ;; keyword-valued slot) + `:recovery` + `:reason`, like every other
 ;; framework throw (Spec 009 §The thrown-error shape).
 
-(deftest unknown-listener-stream-carries-canonical-thrown-error-shape
+(deftest ^:requires-debug unknown-listener-stream-carries-canonical-thrown-error-shape
   (testing "an unknown stream throws the canonical thrown-error shape:
             bare :where holding the 'rf/<surface> SYMBOL (NOT the retired
             :rf/where keyword-valued slot), plus :rf.error/id / :recovery /

--- a/implementation/core/test/re_frame/trace_test.clj
+++ b/implementation/core/test/re_frame/trace_test.clj
@@ -109,7 +109,17 @@
 
 ;; ---- comprehensive flow -----------------------------------------------------
 
-(deftest trace-stream-completeness
+;; ---- Posture: dev-only, declared by `^:requires-debug` (rf2-d2841) ---------
+;; Trace machinery end to end: under `-Dre-frame.debug=false` `trace/emit` is a
+;; no-op, so there is no semantic residue to run under that posture, and a
+;; `(when interop/debug-enabled? ...)` split -- the shape the rest of rf2-d2841
+;; used -- would leave EMPTY deftests reporting green (class 2).  Every deftest
+;; below is therefore TAGGED, and the production-gate lane skips the tag rather
+;; than the file: the namespace is still LOADED there, so a load-time failure
+;; under the gate still reddens the job, and an untagged new deftest joins that
+;; lane BY DEFAULT.  Mechanism + rationale: `scripts/test-core-prod-gate.sh`.
+
+(deftest ^:requires-debug trace-stream-completeness
   (testing "a representative dispatch flow emits every documented op-type with the canonical envelope shape"
     (let [recorded (atom [])
           listener (fn [ev] (swap! recorded conj ev))]
@@ -573,7 +583,7 @@
 ;; `:rf.sub/run` + `:rf.view/elapsed-ms` coverage). fx / flows / handler-
 ;; body timing DO fire in plain-atom JVM and are pinned here.
 
-(deftest per-op-timing-tags-on-the-trace-stream
+(deftest ^:requires-debug per-op-timing-tags-on-the-trace-stream
   (testing "fx / flows / handler-body carry elapsed-ms on the dev trace"
     (let [recorded (atom [])]
       (rf/register-listener! :trace ::timing (fn [ev] (swap! recorded conj ev)))
@@ -611,7 +621,7 @@
 
 ;; ---- listener API: lifecycle and isolation --------------------------------
 
-(deftest trace-listener-lifecycle
+(deftest ^:requires-debug trace-listener-lifecycle
   (testing "register-listener! is keyed; same-id re-registration replaces; unregister-listener! removes only that id"
     (let [a-events (atom [])
           b-events (atom [])
@@ -650,7 +660,7 @@
       (rf/unregister-listener! :trace ::a)
       (rf/unregister-listener! :trace ::c))))
 
-(deftest trace-listener-exception-isolation
+(deftest ^:requires-debug trace-listener-exception-isolation
   (testing "a listener that throws does not crash the dispatch flow and does not block other listeners"
     (let [survivor-events (atom [])
           throw-count     (atom 0)]
@@ -702,7 +712,7 @@
 ;;   - A handler WITHOUT the flag emits normally — sanity baseline so
 ;;     the no-emit test doesn't trivially pass on a broken framework.
 
-(deftest no-emit-handler-suppresses-every-cascade-trace
+(deftest ^:requires-debug no-emit-handler-suppresses-every-cascade-trace
   (testing "Handler registration meta `:rf.trace/no-emit? true` causes
             the runtime to emit NO trace events for the dispatch — not
             at queue time (`:event/dispatched`), not at run-start /
@@ -744,7 +754,7 @@
 
       (rf/unregister-listener! :trace ::rec))))
 
-(deftest no-emit-flag-absent-emits-normally
+(deftest ^:requires-debug no-emit-flag-absent-emits-normally
   (testing "Baseline sanity: the SAME dispatch shape WITHOUT
             `:rf.trace/no-emit? true` produces the normal cascade
             traces (`:event/dispatched`, run-start, run-end,

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -44,7 +44,7 @@
 # a rewrite of how those assertions are spelled.  Triage beads are named per
 # cluster below.
 #
-# What is left IS green, and it is not a rump: 158 namespaces, 1931 tests, 8324
+# What is left IS green, and it is not a rump: 173 namespaces, 1933 tests, 8332
 # assertions, exit 0 — versus the zero suites that had ever executed under this
 # posture before.  (It was
 # 88 / 934 / 4340 tests/assertions before rf2-d2841 split the spine's
@@ -54,23 +54,58 @@
 # `sub-topology`, `init-platform`, `pattern-smoke` and `db-noop-commit`,
 # 103 / 1213 / 5590 before its third pass took twenty more, 123 / 1401 / 6054
 # before its FOURTH pass took seventeen more, 141 / 1560 / 6707 before its
-# FIFTH pass took thirteen more, and 154 / 1740 / 7342 before its SIXTH pass
-# took the last four ACTIONABLE lines under that bead's heading.  Each pass's
-# namespaces are named in its commits — `git log --grep=rf2-d2841`.)
+# FIFTH pass took thirteen more, 154 / 1740 / 7342 before its SIXTH pass
+# took the last four ACTIONABLE lines under that bead's heading, and
+# 158 / 1931 / 8324 before its SEVENTH emptied that heading with the
+# `^:requires-debug` tag below.  Each pass's namespaces are named in its
+# commits — `git log --grep=rf2-d2841`.)
 #
-# WHAT REMAINS EXCLUDED, and why it is not more of the same work.  Of the 27,
-# twelve sit under other headings (eleven under rf2-r9bra plus
-# `features-cljs-test`).  The fifteen still under rf2-d2841 — the ten
-# `trace-listener-*` suites plus `trace`, `db-pending-trace`,
-# `sub-dispose-trace`, `trace-buffer` and `trace.structural-retention-cljs` —
-# have NO semantic residue to separate: they are about the trace machinery
-# itself, end to end, so guarding them would leave nothing behind and make each
-# one class 2.  Those want a var-level `-e :requires-debug` exclusion tag
-# declared in `implementation/deps.edn`, not a posture split, and that file is
-# outside this bead's fence.  Several also HANG rather than fail under the gate
-# (a `CountDownLatch` waiting on trace events that never arrive), so keep them
-# out of any exploratory `-n` sweep.  With those fifteen blocked on a change
-# elsewhere, this bead's ACTIONABLE work is complete at the sixth pass.
+# THE SEVENTH PASS IS THE ONE WHOSE NUMBERS LOOK WRONG, and they are worth
+# reading correctly: +15 namespaces but only +2 tests.  That is not a small
+# change, it is a change of a different KIND.  Fourteen of the fifteen
+# contribute no test here BY DESIGN — they are tagged, and the lane's claim
+# about them is that they LOAD under the production gate, not that they ran.
+# The +2 are the two deftests that turned out to be carrying production
+# semantics after all (see the rf2-d2841 heading below).
+#
+# WHERE THE TRACE SUITES WENT (rf2-d2841, seventh pass).  Fifteen namespaces
+# used to sit on this roster under that bead — the ten `trace-listener-*`
+# suites plus `trace`, `db-pending-trace`, `sub-dispose-trace`, `trace-buffer`
+# and `trace.structural-retention-cljs`.  They had no semantic residue to
+# separate: they are about the trace machinery ITSELF, end to end, so the
+# `(when interop/debug-enabled? …)` split every other pass used would have left
+# EMPTY deftests reporting success — the class-2 false green this lane exists
+# to close.  They are no longer excluded HERE.  Each of their deftests now
+# carries `^:requires-debug`, and the `:prod-gate` alias skips that tag
+# (`implementation/core/deps.edn`, `-e :requires-debug`).
+#
+# THE TAG IS HONEST WHERE A GUARD WOULD LIE.  A guard says "this ran and
+# passed"; the tag says "this namespace requires the debug build", and the
+# tally backs it up — cognitect's `contains-tests?` drops a fully-tagged
+# namespace before `run-tests` sees it, so those deftests contribute no test
+# and no assertion here.  Nothing green is claimed for work that did not
+# happen.
+#
+# IT IS ALSO STRICTLY MORE COVERAGE THAN THE ROSTER LINE WAS.  cognitect
+# `require`s every `-n` namespace BEFORE filtering vars, so all fifteen are now
+# LOADED under `-Dre-frame.debug=false`.  A top-level form that blows up under
+# the production gate reddens this job; while they were rostered they were not
+# on the lane's classpath at all.  (This is also why the hazard those files
+# carried is gone: several HANG rather than fail under the gate — a
+# `CountDownLatch` waiting on trace events that never arrive — and the tag
+# means their bodies never run here.  Anyone probing them by hand with a bare
+# `-n` still needs a timeout.)
+#
+# AND THE GRANULARITY IS VAR-LEVEL BY NECESSITY AS WELL AS BY CHOICE.
+# cognitect's `-e` reads VAR metadata; it never looks at the `(ns …)` form's
+# metadata, so a namespace-level marker would be silently inert.  Var
+# granularity is also what preserves this file's polarity one level down: a new
+# deftest added to a tagged namespace is UNTAGGED, so it joins the lane by
+# default and has to be excluded deliberately, exactly as a new FILE does.
+#
+# WHAT REMAINS EXCLUDED, and why it is not more of the same work.  All twelve
+# sit under other headings: eleven under rf2-r9bra, plus `features-cljs-test`.
+# rf2-d2841's heading is empty.
 #
 # The roster is therefore an EXCLUSION list, not an allowlist.  The polarity is
 # the point: a namespace added to `implementation/core/test/` joins this lane
@@ -170,14 +205,27 @@ known_red=(
   #    copying: its adversarial discriminators read frame-state OBJECT
   #    IDENTITY off `frame/frame-state-value`, which needs no channel at all.
   #
-  #    NOTE for whoever finishes this list: a namespace whose EVERY deftest
-  #    is about the dev trace (the `trace-listener-*` cohort, `trace-test`,
-  #    `db-pending-trace-test`, `sub-dispose-trace-test`, …) has no semantic
-  #    residue to run under the gate. Guarding it wholesale and deleting its
+  #    THE NOTE THAT USED TO STAND HERE — that a namespace whose EVERY
+  #    deftest is about the dev trace (the `trace-listener-*` cohort,
+  #    `trace-test`, `db-pending-trace-test`, `sub-dispose-trace-test`, …)
+  #    has no semantic residue, so guarding it wholesale and deleting its
   #    roster line would report GREEN for a namespace that executed nothing
-  #    — the false-green this lane exists to close. Those want a var-level
-  #    tag the lane excludes (the `-e :requires-debug` idea above), not a
-  #    posture guard.
+  #    — is now DISCHARGED rather than pending. Those fifteen declare
+  #    `^:requires-debug` per deftest and this lane excludes the tag. See
+  #    "WHERE THE TRACE SUITES WENT" in the header.
+  #
+  #    AND THE PREMISE WAS NOT UNIFORMLY TRUE, which is the seventh pass's
+  #    finding. "100% dev instrumentation" was right for fourteen of the
+  #    fifteen; `sub-dispose-trace-test` was carrying PRODUCTION sub-cache
+  #    claims — that a synchronous dispose leaves a resubscribe rebuilding a
+  #    FRESH reaction (rf2-cmfln), and that one input's throwing release does
+  #    not abort the walk over the others (rf2-is8ov5) — inline with the
+  #    dispose-emit assertions that were reddening the namespace. Both are
+  #    about `interop/dispose!` and the cache map, neither needs the trace,
+  #    and neither had ever run under this posture. They were split out and
+  #    left UNTAGGED, so they are in the lane. Read the whole namespace before
+  #    accepting "it is all instrumentation" — that is the same rule the third
+  #    pass wrote down for the opposite direction.
   #
   #    THE THIRD PASS'S LESSON: THE FILES THAT ALREADY LOOK GREEN ARE WHERE
   #    THE ROT IS. Of the eleven namespaces taken off in that pass, seven were
@@ -243,21 +291,9 @@ known_red=(
   #    message.  The fix was not a guard — `projected-record` is a pure
   #    function of a record plus the frame's durable elision registry, so the
   #    profile rows now drive a SYNTHETIC record and run in both postures.
-  re-frame.db-pending-trace-test
-  re-frame.sub-dispose-trace-test
-  re-frame.trace-buffer-test
-  re-frame.trace-listener-concurrent-drain-serialization-test
-  re-frame.trace-listener-concurrent-serialization-test
-  re-frame.trace-listener-continuation-neutral-cljs-test
-  re-frame.trace-listener-deferred-batch-fifo-cljs-test
-  re-frame.trace-listener-drain-deadlock-test
-  re-frame.trace-listener-frame-tagged-serialization-test
-  re-frame.trace-listener-nested-emission-order-cljs-test
-  re-frame.trace-listener-post-drain-settled-state-cljs-test
-  re-frame.trace-listener-reentrant-dispatch-sync-deferral-test
-  re-frame.trace-listener-test
-  re-frame.trace-test
-  re-frame.trace.structural-retention-cljs-test
+  #
+  #    THIS HEADING IS NOW EMPTY, and the last fifteen came off WITHOUT a
+  #    posture split — see "WHERE THE TRACE SUITES WENT" below.
 )
 
 # ---------------------------------------------------------------------------
@@ -355,13 +391,11 @@ fi
 # ordinary churn; raise it when the roster grows materially.
 #
 # RAISED 800 -> 1360 (rf2-d2841, third pass), 1360 -> 1510 (fourth pass),
-# 1510 -> 1690 (fifth pass), then 1690 -> 1880 (sixth pass).  800 was
-# calibrated against the 915-test lane of rf2-f8x2i's original run and had
-# stopped doing its job.  1360 was calibrated against 1401 and stopped doing
-# its job the same way; 1510 did the same in its turn; and 1690 has now done
-# the same again: the lane runs 1931 tests, and the FOUR namespaces the sixth
-# pass added are 191 of them — losing the whole batch lands at 1740, which
-# 1690 waves through.  1880 notices that while leaving ~3% for ordinary churn.
+# 1510 -> 1690 (fifth pass), 1690 -> 1880 (sixth pass), then 1880 -> 1900
+# (seventh).  800 was calibrated against the 915-test lane of rf2-f8x2i's
+# original run and had stopped doing its job.  1360 was calibrated against 1401
+# and stopped doing its job the same way; 1510 did the same in its turn; and so
+# did 1690, against the 1931 tests the sixth pass left.
 #
 # Note how much a small batch can be worth: the sixth pass added only four
 # namespaces but 191 tests, because the two largest — `observation-port-cljs`
@@ -370,9 +404,31 @@ fi
 # is the right variable for exactly this reason.
 #
 # The floor is a COLLAPSE DETECTOR, not a target, and the rule that follows
-# from that is why it has moved every pass: it must sit close enough under the
+# from that is why it moved every pass: it must sit close enough under the
 # observed count that THE SMALLEST BATCH ANYONE LANDS IS STILL VISIBLE.  A
 # floor left behind by a growing lane is not conservative, it is inert.
+#
+# THE SEVENTH PASS RAISED IT FOR A DIFFERENT REASON, and the difference
+# matters.  That pass added only two tests, so no floor could have made its
+# batch visible — the rule above ran out of road, because `^:requires-debug` is
+# a VAR-level tag and the smallest thing it can remove is one deftest.  What
+# the tag introduces instead is a new way to lose coverage QUIETLY: a roster
+# line sits in this reviewed file, whereas an over-broad tag is one word in a
+# test file, and nothing else counts what it excluded.
+#
+# So the floor is now doing a second job: it is the budget for tagging.  At
+# 1900 against 1933 there are 33 tests of slack, so tagging more than about
+# thirty tests' worth of deftests reddens this lane and the author has to come
+# here and move the number — which is exactly the review prompt a
+# coverage-reducing change should trigger.  That is deliberate.  Do not raise
+# the floor to make room for a tag without saying, in the same diff, what was
+# tagged and why it has no production residue.
+#
+# Note which direction the OTHER failure mode falls.  If `-e :requires-debug`
+# is ever dropped from the `:prod-gate` alias or misspelled, the fifteen tagged
+# namespaces run under `-Dre-frame.debug=false` and this lane goes RED, loudly.
+# A lost exclusion cannot go quietly green here; only an over-applied tag can,
+# and that is what the 33-test budget above is for.
 #
 # WHAT THE FLOOR DOES NOT CATCH, and what caught it out during the fifth pass:
 # a test file whose `(ns ...)` FORM is malformed is invisible to
@@ -390,7 +446,7 @@ fi
 # invokes, so the rule covers every lane in the repo rather than this one, and
 # it fires before a single test runs.  `verify_roster` below is unchanged and
 # still cannot see this class on its own — see its guard #1.
-export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1880}"
+export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1900}"
 
 args=()
 for ns in $runnable; do


### PR DESCRIPTION
The last fifteen roster lines under `rf2-d2841` come off the core
production-gate lane — and this is the one pass that could not use a posture
split. The ten `trace-listener-*` suites plus `trace`, `db-pending-trace`,
`sub-dispose-trace`, `trace-buffer` and `trace.structural-retention-cljs` are
about the trace machinery **itself**, end to end. Under `-Dre-frame.debug=false`
`trace/emit` is a no-op, so wrapping them in `(when interop/debug-enabled? …)`
would leave EMPTY deftests reporting success — the class-2 false green this lane
exists to close.

So they declare the posture they need instead. Every one of their deftests now
carries `^:requires-debug`, and the `:prod-gate` alias excludes the tag.

## Granularity: var-level, by necessity as well as by choice

A namespace-level marker would have been simpler, and it does not work.
cognitect-test-runner's `var-filter` reads `(meta v)` on each interned **test
var**; it never consults the `(ns …)` form's metadata. A marker there would be
silently **inert** — an exclusion nobody can see the effect of, which is the
same defect class as a stale roster line.

Var granularity also preserves this lane's polarity one level down. The roster
is an exclusion list precisely so a new FILE joins the lane by default; the
var-level tag means a new **deftest** inside a tagged namespace is likewise
untagged, joins the lane by default, and has to be excluded deliberately. A
namespace marker would silently swallow it.

## Why the tag is honest where a guard would lie

A guard reports "this ran and passed". The tag reports the truth, and the tally
backs it up — cognitect's `contains-tests?` drops a fully-tagged namespace
before `run-tests` sees it:

```
$ clojure -M:test:prod-gate -n re-frame.trace-listener-post-drain-settled-state-cljs-test
Ran 0 tests containing 0 assertions.
```

Zero tests, zero assertions, nothing green claimed for work that did not happen.

It is also **strictly more coverage than the roster line was**. cognitect
`require`s every `-n` namespace *before* it filters vars, so all fifteen are now
LOADED under the production gate; a top-level form that blows up there reddens
the job. While they were rostered they were not on the lane's classpath at all.
It also disarms the hazard those files carried: several HANG rather than fail
under the gate (a `CountDownLatch` waiting on trace events that never arrive),
and their bodies no longer run here.

## The finding: two were NOT 100% dev instrumentation

`sub-dispose-trace-test` was on the roster for its emit assertions while carrying
**production sub-cache claims** that had never run under the posture that ships.

- `dispose-then-resubscribe-builds-fresh-slot` pins rf2-cmfln's synchronous
  dispose through **reaction identity** (`(not (identical? r1 r2))`), not through
  the trace.
- `input-dispose-throw-is-surfaced-and-isolated` splits exactly in half.
  `subs/release-input!` puts the `try`/`catch` **outside** `interop/debug-enabled?`
  and only `trace/emit-error!` inside it — so SURFACED is dev, **ISOLATED ships**.
  That rf2-is8ov5 guarantee (one input's throwing release does not abort the walk
  over its siblings) is production behaviour and is now proved under the gate.

Both are left **untagged** and split: emit assertions verbatim inside a
`(when interop/debug-enabled? …)` arm, semantics outside it in both postures.
They are the entire `+2 tests / +8 assertions` below. The premise "these are all
instrumentation" had stood for six passes; it was right fourteen times out of
fifteen.

## Roster

| | before | after |
|---|---|---|
| namespaces in the lane | 158 of 185 | **173 of 185** |
| excluded | 27 | **12** |
| under `rf2-d2841`'s heading | 15 | **0** |

The remaining 12 all sit under other headings: eleven under `rf2-r9bra`, plus
`features-cljs-test`. **This bead's roster heading is empty.**

## The floor

`RF2_MIN_TESTS` 1880 → **1900**, and for a new reason. The old rule — sit close
enough under the observed count that the smallest landed batch is visible — ran
out of road here: this pass adds two tests, and no floor makes a two-test batch
visible.

What the tag introduces instead is a new way to lose coverage **quietly**: a
roster line sits in a reviewed script, whereas an over-broad tag is one word in a
test file. So the floor now does a second job — it is the **budget for tagging**.
At 1900 against 1933 there are 33 tests of slack, so tagging more than about
thirty tests' worth of deftests reddens the lane and the author has to come and
move the number. That is the review prompt a coverage-reducing change should
trigger.

The other failure mode falls the safe way: if `-e :requires-debug` is ever
dropped or misspelled, the fifteen namespaces run under the gate and the lane
goes **red**, loudly. A lost exclusion cannot go quietly green.

## Quality gates

Foreground, worktree-local logs, exit codes echoed.

| gate | result |
|---|---|
| `bash scripts/test-core-prod-gate.sh` | **exit 0** — 173 of 185 namespaces, **1933 tests / 8332 assertions** (was 158 / 1931 / 8324) |
| `clojure -M:test` (core, dev posture) — branch | **exit 0** — **2190 tests / 11310 assertions** |
| `clojure -M:test` (core, dev posture) — pristine `origin/main` worktree @ `abd17ff111` | **exit 0** — **2190 tests / 11310 assertions** |
| `implementation/ssr` `clojure -M:test` | exit 0 — 592 tests / 2892 assertions |
| `implementation/routing` `clojure -M:test` | exit 0 — 513 tests / 2983 assertions |
| `implementation/schemas` `clojure -M:test` | exit 0 — 363 tests / 19188 assertions |
| `implementation/freehand` `clojure -M:test` | exit 0 — 1288 tests / 8856 assertions |
| `scripts/check_jvm_lane_rosters.py` | exit 0 — 31 rostered artefacts, 0 baselined |

**Dev posture is byte-identical to the baseline**: test count HELD and assertion
count HELD at 2190 / 11310. No deftest added, none removed, no assertion deleted
or weakened — the two split deftests keep every assertion they had, and their
guarded arms still execute in dev.

`implementation/deps.edn` was **not** touched. The bead named it, but the
`:prod-gate` alias lives in `implementation/core/deps.edn`, and that is the only
deps file changed: `-e :requires-debug` appended to the alias's `:main-opts`,
plus its rationale comment. The tag appears in no other `:main-opts`, so
`clojure -M:test` runs every tagged deftest exactly as before — the tag narrows
the gate lane only. The nightly `:slow-test` lane is likewise unaffected: its
`-i :slow -i :stress` carries no `exclude`, so cognitect's `test-exclusion` is
`(constantly true)` there and the one `^:requires-debug ^:stress` deftest still
runs.

The other artefacts' suites were run because `implementation/deps.edn` is read by
every JVM artefact and `egress_chokepoint_conformance_test` source-scans every
artefact's `src/` as text. Both concerns are moot here — no `src/` changed and
the top-level deps file was not touched — but the lanes were run rather than
reasoned about.

### Mutation proofs

The tag bites, in both directions:

- **Tag something that should not be excluded.** Tagged
  `dispose-then-resubscribe-builds-fresh-slot` (a lane resident): the gate lane
  for that namespace went **2 tests / 8 assertions → 1 test / 5 assertions**.
  Restored.
- **Untag a wholly-dev trace deftest.** Removed the tag from
  `run-start-listener-observes-settled-db-uniformly`: the gate went **exit 1**,
  `1 failures`. An untagged trace suite still reds the gate. Restored.
- **Dev lane is unaffected.** `clojure -M:test -n re-frame.db-pending-trace-test`
  (six tagged deftests) runs **6 tests / 20 assertions, green**.

All fifteen namespaces were also verified red-or-hanging under the gate
individually before the change (13 × exit 1, 2 × timeout — the two concurrent
serialization suites are the documented hangs).

Deferred to CI: the CLJS suites, the browser/testbed smokes, and the full
`scripts/test-rigorous-local.sh` sweep. This change touches no `src/`.

