### PR TITLE
perf(core): flatten the ambient-frame reader's hot path (rf2-2ix22)

### DIFF
--- a/implementation/core/src/re_frame/substrate/adapter.cljc
+++ b/implementation/core/src/re_frame/substrate/adapter.cljc
@@ -736,14 +736,32 @@
   Public so adapter-side driver guards that gate on \"is MY adapter the
   installed one?\" (e.g. the Test-React `mount!` driver) share the one
   stable-token predicate `route-hook!` uses, rather than re-deriving an
-  object-identity check that would reject a copied canonical map."
+  object-identity check that would reject a copied canonical map.
+
+  SPELLING IS LOAD-BEARING, and the flat nest of `if`s below is deliberate
+  (rf2-2ix22). The obvious spelling — `(boolean (and a b (let [ka (:kind a)]
+  …)))` — puts a `let` in EXPRESSION position under `boolean`/`and`, and
+  ClojureScript emits a `let` in expression context as an IIFE (compiler.cljc
+  L1139-1162, r1.12.145). `:advanced` does not remove it, so every call
+  allocated one JS closure plus its context: measured at 144.1 B/call against
+  4.1 for this flat form, CLJS / node 24.13.0 / V8 13.6, `:advanced` +
+  `goog.DEBUG=false`. This predicate is on the ambient-frame reader's hot
+  path — every routed hook call, on every chain link, of every routed hook in
+  the bundle — so that was 53% of the reader's whole per-call cost. The two
+  spellings are semantically identical (every leaf of both is already
+  boolean: canonical kinds compare with `=`, custom/kindless adapters with
+  `identical?`, falsey inputs return `false`), and the read-attribution
+  bench's agreement gate runs them over nine discriminating cases. Do not
+  \"tidy\" this back into `boolean`/`and`."
   [a b]
-  (boolean
-    (and a b
-         (let [ka (:kind a)]
-           (if (canonical-kind? ka)
-             (= ka (:kind b))
-             (identical? a b))))))
+  (if a
+    (if b
+      (let [ka (:kind a)]
+        (if (canonical-kind? ka)
+          (= ka (:kind b))
+          (identical? a b)))
+      false)
+    false))
 
 ;; ---- late-bind hook routing (rf2-0d35) ------------------------------------
 ;;
@@ -794,7 +812,38 @@
   ([adapter-spec hook-key impl-fn fallback-fn]
    (let [previous (late-bind/get-fn hook-key)]
      (late-bind/set-fn! hook-key
-       (fn routed-hook [& args]
-         (if (same-adapter? adapter-spec (current-adapter-spec))
-           (apply impl-fn args)
-           (if previous (apply previous args) (fallback-fn))))))))
+       ;; EXPLICIT ARITIES, and the repetition is the mechanism (rf2-2ix22).
+       ;; The obvious spelling is one variadic body forwarding with
+       ;; `(apply impl-fn args)` — but `route-hook!` publishes ~11 hook keys
+       ;; for every adapter in the bundle and they would all share that ONE
+       ;; `apply` site, so its callee is polymorphic there and
+       ;; `cljs.core/apply` cannot be inlined: it enters generic invocation
+       ;; dispatch and examines the function and the argument seq on every
+       ;; call. Spelling the common arities out calls `impl-fn` (and the
+       ;; chained `previous`) DIRECTLY instead. Repository call sites use 0,
+       ;; 1 or 2 arguments routinely; `:adapter/wrap-view`'s 3 and any
+       ;; future/custom arity take the variadic tail, which keeps the
+       ;; generality and pays the old cost only where it is rare.
+       ;;
+       ;; The generated shape is not a contract. What IS — and what
+       ;; `routing_arity_cljs_test` pins at 0/1/2/3/4 arguments on all three
+       ;; routes — is that every arity forwards the same arguments, answers
+       ;; the same value, chains in the same order, and calls `fallback-fn`
+       ;; as a ZERO-argument thunk.
+       (fn routed-hook
+         ([]
+          (if (same-adapter? adapter-spec (current-adapter-spec))
+            (impl-fn)
+            (if previous (previous) (fallback-fn))))
+         ([a]
+          (if (same-adapter? adapter-spec (current-adapter-spec))
+            (impl-fn a)
+            (if previous (previous a) (fallback-fn))))
+         ([a b]
+          (if (same-adapter? adapter-spec (current-adapter-spec))
+            (impl-fn a b)
+            (if previous (previous a b) (fallback-fn))))
+         ([a b & more]
+          (if (same-adapter? adapter-spec (current-adapter-spec))
+            (apply impl-fn a b more)
+            (if previous (apply previous a b more) (fallback-fn)))))))))

--- a/implementation/core/test/re_frame/adapter/routing_arity_cljs_test.cljc
+++ b/implementation/core/test/re_frame/adapter/routing_arity_cljs_test.cljc
@@ -1,0 +1,141 @@
+(ns re-frame.adapter.routing-arity-cljs-test
+  "Arity fidelity of `substrate-adapter/route-hook!`'s routed closure
+  (rf2-2ix22).
+
+  The wrapper used to be spelled `(fn routed-hook [& args] … (apply impl-fn
+  args) …)`: one `apply` site shared by every routed hook in the bundle,
+  hence callee-POLYMORPHIC and never inlined. It is now spelled with
+  explicit 0/1/2-argument paths that call `impl-fn` (or the chained
+  `previous` handler) DIRECTLY, plus a variadic tail for 3-and-up.
+
+  The generated shape is not a contract; what IS contract is that the routed
+  closure forwards the SAME arguments, answers the SAME value, chains in the
+  SAME order, and calls its fallback as a ZERO-argument thunk — at every
+  arity, on all three routes:
+
+    * ACTIVE       — this adapter is installed, so `impl-fn` runs
+    * CHAIN        — another adapter is installed, so the previously
+                     registered routed closure runs, with the args intact
+    * FALLBACK     — nothing is installed and there is no previous handler,
+                     so `(fallback-fn)` runs with no arguments at all
+
+  Splitting one variadic body into four is exactly the kind of change that
+  silently drops an argument or mis-routes an arity, so each route is
+  exercised at 0, 1, 2, 3 and 4 arguments: the three explicit paths and two
+  that must reach the variadic tail. Repository call sites use 0, 1 or 2
+  args routinely and `:adapter/wrap-view` uses 3.
+
+  `.cljc`, so the pin runs on the JVM (`clojure -M:test`) AND in the
+  `:node-test` CLJS lane where the `apply` this change removes was actually
+  costing bytes. The per-substrate hook wiring is pinned by the adapter
+  suites; this ns pins the routing MECHANISM against the plain-atom adapter,
+  substrate-agnostically — the same division of labour as
+  `routing_token_cljs_test`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.late-bind :as late-bind]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+;; ---- fixture --------------------------------------------------------------
+;; Each test installs/disposes explicitly (install-time routing is the unit
+;; under test), so the fixture only guarantees a cold adapter slot either side.
+
+(defn- cold-adapter [test-fn]
+  (adapter/dispose-adapter!)
+  (adapter/reset-lifecycle-state-for-tests!)
+  (test-fn)
+  (adapter/dispose-adapter!)
+  (adapter/reset-lifecycle-state-for-tests!))
+
+(use-fixtures :each cold-adapter)
+
+;; A DISTINCT probe key per test: `route-hook!` chains onto whatever is
+;; already registered under the key, so a shared key would leave each test
+;; running on top of its predecessors' links.
+(def ^:private active-key   :rf.test/routing-arity-active)
+(def ^:private chain-key    :rf.test/routing-arity-chain)
+(def ^:private fallback-key :rf.test/routing-arity-fallback)
+
+;; The five call shapes: the three arities the wrapper spells explicitly,
+;; then two that must reach its variadic tail.
+(def ^:private arg-vectors [[] [:a] [:a :b] [:a :b :c] [:a :b :c :d]])
+
+(defn- call-at-every-arity
+  "Invoke `f` at 0, 1, 2, 3 and 4 arguments — written out rather than
+  `apply`d, so each explicit arity path of the routed closure is entered the
+  way a real caller enters it — and answer the five results in order."
+  [f]
+  [(f) (f :a) (f :a :b) (f :a :b :c) (f :a :b :c :d)])
+
+(defn- recorder
+  "A hook impl that records the argument vector it received into `log` and
+  answers `[tag args]`. Variadic, so it accepts whatever it is handed and
+  the ASSERTION — not an arity exception — is what reports a dropped arg."
+  [log tag]
+  (fn [& args]
+    (let [args (vec args)]
+      (swap! log conj args)
+      [tag args])))
+
+;; ---- ACTIVE: the installed adapter's impl, at every arity ------------------
+
+(deftest routed-hook-forwards-every-arity-to-the-live-impl
+  (testing "the ACTIVE adapter's routed hook forwards its arguments verbatim at 0/1/2/3/4 args"
+    (let [seen   (atom [])
+          _      (adapter/route-hook! plain-atom/adapter active-key
+                                      (recorder seen :impl)
+                                      (constantly :fell-through))
+          routed (late-bind/get-fn active-key)]
+      (adapter/install-adapter! plain-atom/adapter)
+      (is (= (mapv (fn [args] [:impl args]) arg-vectors)
+             (call-at-every-arity routed))
+          "the impl's return value is answered unchanged at every arity")
+      (is (= arg-vectors @seen)
+          "the impl received exactly the arguments the caller passed, at every arity"))))
+
+;; ---- CHAIN: fall-through to the previously-registered routed closure -------
+
+(deftest routed-hook-falls-through-to-the-chain-at-every-arity
+  (testing "an INACTIVE adapter's routed hook chains to the previous handler with the args intact"
+    (let [inner-seen (atom [])
+          outer-seen (atom [])
+          ;; INNER link first: plain-atom's hook. Then an OUTER link for a
+          ;; different-kind adapter registers on top of it.
+          _          (adapter/route-hook! plain-atom/adapter chain-key
+                                          (recorder inner-seen :inner)
+                                          (constantly :inner-fallback))
+          other      (assoc plain-atom/adapter :kind :rf.adapter/uix)
+          _          (adapter/route-hook! other chain-key
+                                          (recorder outer-seen :outer)
+                                          (constantly :outer-fallback))
+          routed     (late-bind/get-fn chain-key)]
+      ;; plain-atom is installed, so the OUTER (uix-kind) link is inactive and
+      ;; must chain rather than fire.
+      (adapter/install-adapter! plain-atom/adapter)
+      (is (= (mapv (fn [args] [:inner args]) arg-vectors)
+             (call-at-every-arity routed))
+          "the chained inner impl's value is answered at every arity")
+      (is (= arg-vectors @inner-seen)
+          "the arguments survived the hop through the inactive outer link, at every arity")
+      (is (= [] @outer-seen)
+          "the inactive adapter's own impl never ran"))))
+
+;; ---- FALLBACK: the zero-argument thunk, whatever the call arity ------------
+
+(deftest routed-hook-falls-back-to-a-zero-arg-thunk-at-every-arity
+  (testing "with nothing installed and no previous handler, every arity calls the fallback with NO args"
+    (let [fallback-seen (atom [])
+          impl-seen     (atom [])
+          _             (adapter/route-hook! plain-atom/adapter fallback-key
+                                             (recorder impl-seen :impl)
+                                             (recorder fallback-seen :fell-through))
+          routed        (late-bind/get-fn fallback-key)]
+      ;; No adapter installed: `same-adapter?` is false and `previous` is nil.
+      (is (= (repeat 5 [:fell-through []])
+             (call-at-every-arity routed))
+          "the fallback's value is answered at every arity")
+      (is (= (repeat 5 []) @fallback-seen)
+          "the fallback is invoked as a ZERO-argument thunk regardless of the call's arity")
+      (is (= [] @impl-seen)
+          "the impl never ran with no adapter installed"))))


### PR DESCRIPTION
Closes rf2-2ix22. One small, deliberately local hot-path change to
`implementation/core/src/re_frame/substrate/adapter.cljc`, plus the routing test
the bead asks for. Follows rf2-f70iq, which attributed the reader's 264 B/read
but changed nothing.

Both levers sit on the path **every routed-hook call** takes, so `subscribe`,
ambient dispatch (`router/build-envelope`), `rf/current-frame-id`, `use-frame`
and the spine's `use-subscribe` all pay them — and pay them again per
*publishing* adapter, because `route-hook!` chains one closure per adapter and
an inactive adapter loaded in the same bundle adds another link.

## Lever 1 — `same-adapter?`'s expression-position IIFE

The body was `(boolean (and a b (let [ka (:kind a)] …)))`. A `let` in
**expression** position under `boolean`/`and` makes ClojureScript emit an
**IIFE** closing over `a` and `b` (compiler.cljc L1139-1162, r1.12.145), and
`:advanced` does not remove it — one JS closure plus its context and feedback
cell, per call. It is now a flat nest of `if`s, which compiles to
`function(a,b){if(n(a)&&n(b)){var c=…;return …}return !1}`.

Semantically identical: every leaf of both spellings is already boolean
(canonical kinds compare with `=`, custom/kindless adapters with `identical?`,
falsey inputs return `false`). The harness's own agreement gate runs the two
forms over nine discriminating cases and reports **AGREE** in every run below.

## Lever 2 — `apply` at `route-hook!`'s shared, polymorphic site

The wrapper forwarded through one `(apply impl-fn args)` site shared by every
routed hook in the bundle (~11 keys × every adapter), so its callee is
polymorphic there and `cljs.core/apply` cannot be inlined — it enters generic
invocation dispatch and examines the function and the argument seq on every
call. The wrapper now spells **0/1/2 arguments explicitly**, calling `impl-fn`
(and the chained `previous`) directly, with a **variadic tail** for 3-and-up.
`:adapter/wrap-view`'s three arguments and any future/custom arity keep the old
path, so the generality is unchanged and the old cost is paid only where it is
rare.

The generated closure shape is not a contract. What **is** — the forwarded
arguments, the return value, the chain order, and the zero-argument fallback —
is pinned by the new test at every arity.

## The reader, before and after

**CLJS / node 24.13.0 / V8 13.6.233.17-node.37**, `:advanced` +
`goog.DEBUG=false`, pointer compression OFF (Chrome ships it ON — a tagged slot
is 4 B there, 8 B here, so **shares and ratios transfer, absolutes do not**),
n=300, 6 rounds, forward order. Measured on the existing read-attribution
harness through its documented `--config-merge` route onto `:ui-bench`;
**no harness file is touched by this PR.**

| arm | shipped | + lever 1 | + lever 2 (this PR) |
|---|---|---|---|
| **S0-SCOPE** — the whole ambient-frame reader | **264.0** B/read | 152.0 | **4.0** |
| **H-ROUTED** — the routed hook call | **264.0** B/read | 152.0 | **0.5** |
| H-SAMEH — `same-adapter?`, shipped spelling | 144.1 | 0.6 | 0.6 |
| H-SAMEFLAT — the flat re-spelling, as control | 4.1 | 0.6 | 0.6 |
| … the per-call IIFE (SAMEH − SAMEFLAT) | 140.0 (53.0%) | **0.0** | 0.0 |
| … residual `apply` at the polymorphic site | 120.0 (45.4%) | 151.4 (99.6%) | **−0.1 (−1.3%)** |

The reader drops **264.0 → 4.0 B/read**, and each lever's predicted term
vanishes exactly when its lever lands: the IIFE term goes to zero under lever 1
(and the shipped predicate then measures *identically to its own control*,
144.1 → 0.6 against the control's 4.1 → 0.6), and the `apply` residual goes to
zero under lever 2, after which the budget closes — `H-CACHE + H-SPEC + H-SAMEH
+ H-IMPL = 0.6` against `H-ROUTED 0.5`.

## The focused comparison lever 2 was conditioned on

The bead's ruling made lever 2 **contingent**: its 120.0 B was a residual
inference, optimizing runtimes are not perfectly additive, so one focused
comparison of the explicit-arity candidate against the current wrapper **at the
real shared, polymorphic site** had to show the whole routed call improving
materially, or lever 2 was to be discarded and only the predicate rewrite
landed. That comparison is the last two columns above — both arms carry lever 1,
only lever 2 differs, same process shape, same harness, one comparison:

| | variadic + `apply` | explicit arities |
|---|---|---|
| **H-ROUTED**, median | 152.0 B/read | **0.5 B/read** |
| **H-ROUTED**, range across 6 rounds | [24.9 – 152.0] | **[0.5 – 4.0]** |
| residual at the `apply` site | 151.4 B/read (99.6%) | **−0.1 B/read (−1.3%)** |

The ranges are **disjoint**, so under the house rule they are distinguishable —
and they stay disjoint under the most hostile pairing available, the candidate's
*worst* round (4.0) against the incumbent's *best* (24.9), still 6.2×. **Lever 2
survives its discard condition** and is kept.

## Instrument notes, stated plainly

- **0 UNVERIFIED of 1974 windows** in all three runs — every arm advanced the
  shared counter by exactly `per × reps`, so nothing was dead-code-eliminated
  or short-circuited into looking cheap. Controls read +0.03% / +0.04% against
  prediction at the small sizes; instrument floor 0.053 B/read.
- The **baseline run is guard-REPORTABLE and exits 0**, so the 264.0 B/read
  "before" figure is fully certified.
- The two **"after" runs exit 2**: the arm-order guard refuses arms that the
  levers pushed *to the instrument's own floor* (H-ROUTED, H-SAMEH, H-SAMEFLAT,
  S0-SCOPE, S1-CURFRM, S2-TGTID). The refusal signature is a per-**window**
  floor rather than a per-call cost — an identical ~6.37× phase ratio across
  arms with nothing else in common, exactly the behaviour the harness's own
  FLOOR SWEEP documents. This is the known limitation the bead's sequencing
  ruling addressed: the harness cannot self-certify a floor arm, which is an
  instrument limitation and not doubt about the change. Per that ruling the
  cleanup is **not** held hostage to a benchmark enhancement, and **no
  benchmark or harness change is made here**. The post-change figures are
  therefore honest **upper bounds**, and a certified headline quote remains
  available as separate bench-lane work.

## Test obligations

New `implementation/core/test/re_frame/adapter/routing_arity_cljs_test.cljc` — a
**new namespace** (a sibling worker holds `implementation/core/test/**`, so
nothing existing there is touched). `.cljc`, so it runs on the JVM *and* in the
`:node-test` CLJS lane where the `apply` actually cost bytes. It covers **0, 1,
2, 3 and 4 arguments** — the three explicit paths plus two that must reach the
variadic tail — on all three routes:

- **active** — the installed adapter's `impl-fn` runs, and receives exactly the
  arguments the caller passed
- **chain / fall-through** — an inactive adapter's link hands off to the
  previously registered routed closure *with the arguments intact*, and its own
  impl never fires
- **fallback** — with nothing installed and no previous handler, `fallback-fn`
  is invoked as a **zero-argument thunk** whatever the call's arity

Then the existing adapter suites, which pin every arity path across all six
adapters (Reagent, reagent-slim, UIx, test-react, plain-atom, re-frame.ui) —
lever 2 changes the closure shape of every adapter's routed hooks, which is why
it was held for a ruling.

## Scope

Within the bead's fence: no hook-routing redesign, no keyed registry or
install-time cache, no public performance option, no benchmark/harness change,
and `:adapter/current-frame`'s contract is untouched. Two files:
`substrate/adapter.cljc` and the new test. No file under
`implementation/core/test/re_frame/bench/`, `implementation/adapters/`,
`implementation/freehand/`, `tools/`, `scripts/`, `.github/` or `spec/` is
modified.

## Quality gates

All run locally in the worker worktree, foreground, exit code captured from the
runner itself (never through a pipe):

| gate | command | result | exit |
|---|---|---|---|
| **New routing test** (+ its sibling routing-token suite), JVM | `clojure -M:test -n re-frame.adapter.routing-arity-cljs-test -n re-frame.adapter.routing-token-cljs-test` | 10 tests / 26 assertions, 0 failures, 0 errors | **0** |
| **CLJS lane — all six adapters + core** (this is where the six adapter suites live: `core/test`, `adapters/{reagent,reagent-slim,uix,test-react}/test` and `ui/test` are all on the `:node-test` classpath) | `npm run test:cljs` | **11911 tests / 59519 assertions**, 0 failures, 0 errors | **0** |
| Core, JVM dev posture | `clojure -M:test` in `implementation/core` | 2193 tests / 11318 assertions, 0 failures, 0 errors | **0** |
| Adapter artefact suites, JVM — Reagent | `clojure -M:test` | 0 tests (this artefact's suite is CLJS-only; its coverage is the lane above) | **0** |
| Adapter artefact suites, JVM — reagent-slim | `clojure -M:test` | 11 tests / 12 assertions, 0 failures, 0 errors | **0** |
| Adapter artefact suites, JVM — UIx | `clojure -M:test` | 0 tests (CLJS-only, as above) | **0** |
| Adapter artefact suites, JVM — test-react | `clojure -M:test` | 35 tests / 160 assertions, 0 failures, 0 errors | **0** |
| Adapter artefact suites, JVM — re-frame.ui | `clojure -M:test` | 702 tests / 17602 assertions, 0 failures, 0 errors | **0** |
| **Core production gate** (`-Dre-frame.debug=false`) | `sh scripts/test-core-prod-gate.sh` | 1934 tests / 8332 assertions, 0 failures, 0 errors — **159 namespaces of 186** | **0** |

**The prod-gate roster went 158/185 → 159/186, which is the new namespace joining
the lane by default** (`implementation/core/deps.edn`: "a NEW namespace joins the
lane by default"), not a change to the known-red list. Nothing was excluded and
nothing regressed.

The plain-atom adapter has no artefact of its own — it lives in
`core/src/re_frame/substrate/plain_atom.cljc` and is covered by the core JVM,
prod-gate and CLJS rows above (and is the adapter the two routing test
namespaces drive directly).

**Deferred to CI**, as the expensive/browser tiers: the adapter testbed browser
smokes and re-frame.ui testbed smoke (both auto-skip on this diff — no adapter or
harness surface changed), the browser-test lanes, bundle-isolation, perf-bundle,
G-1/G-8/G-13 and mcp-conformance. `:node-test-ui` is deliberately not run
separately — shadow-cljs.edn documents it as "the *named* surface, not an
additional required gate", and its namespaces already ran under `:node-test`
above.
