### PR TITLE
fix(resources): the trace path honours a :serialize owner's per-slot declarations (rf2-dl7bz)

### DIFF
--- a/implementation/resources/src/re_frame/resources/tooling.cljc
+++ b/implementation/resources/src/re_frame/resources/tooling.cljc
@@ -41,6 +41,13 @@
             [re-frame.resources.scope-registry :as scope-registry]
             [re-frame.resources.ssr :as ssr]
             [re-frame.resources.state :as state]
+            ;; rf2-dl7bz — the per-slot arm of the key projection lives in the
+            ;; production-reachable trace-egress ns (beside the reply's), and
+            ;; this TOOL boundary opts into the same helper so the two off-box
+            ;; boundaries cannot answer differently. The edge points from the
+            ;; bundle-isolated sibling INTO a production-reachable ns, which is
+            ;; the safe direction: nothing here is pulled toward a bundle.
+            [re-frame.resources.trace-egress :as trace-egress]
             [re-frame.resources.transport :as transport]
             [re-frame.resources.work-ledger :as work-ledger]))
 
@@ -378,9 +385,18 @@
 ;;     scoped key per that disposition — `:redact` / `:omit` replace scope +
 ;;     params with opaque content-addressed `{:rf/redacted <digest>}` tokens
 ;;     (distinct values stay distinct, so graph connectivity by projected key
-;;     is preserved), while `:serialize` applies the resource's per-slot
-;;     `:params` projection-relative declarations and otherwise rides verbatim
-;;     (non-sensitive identity is preserved).
+;;     is preserved), while `:serialize` rides verbatim (non-sensitive identity
+;;     is preserved);
+;;   - `trace-egress/redact-key-declarations` (rf2-dl7bz) then applies the
+;;     resource's per-slot `:params` / `:scope` PROJECTION-RELATIVE declarations
+;;     to a `:serialize` key — the arm the coarse disposition above is blind to,
+;;     since a spec declaring only paths makes no root-prop claim and classifies
+;;     `:serialize`. It lives in the trace-egress ns rather than inside
+;;     `project-scoped-key` because `project-scoped-key`'s `:serialize` deferral
+;;     is deliberate: the SSR durable path resolves the same declaration from
+;;     the per-frame elision REGISTRY, which this boundary has no `key-id` or
+;;     live frame to read. Both boundaries therefore opt into ONE helper and
+;;     answer identically.
 ;; The resource-id (position 1 of the 3-tuple) always survives, so a tool still
 ;; sees WHICH resource each node names and edges still join nodes by the same
 ;; projected key.
@@ -389,14 +405,23 @@
   "Project a `scoped-key` for TOOL egress against the resource owner spec +
   the `frame-id` classification (rf2-0t0l3w). Returns `[projected-key
   disposition]`. `:redact` / `:omit` replace scope + params with opaque
-  tokens; `:serialize` projects per-slot `:params-schema` marks (a no-op when
-  none) — the resource-id always survives. Pure. Delegates to the shared
+  tokens; `:serialize` substitutes the owner's per-slot `:params` / `:scope`
+  PROJECTION-RELATIVE declarations (a no-op when the spec declares none) — the
+  resource-id always survives. Pure. Delegates to the shared
   `ssr/disposition+project-key` pipeline (rf2-366u0g — the SAME owner
   classification + key projection the SSR durable-egress + off-box trace-egress
-  paths use), dropping the spec it does not need."
+  paths use), then to `trace-egress/redact-key-declarations` for the per-slot
+  arm that pipeline defers (rf2-dl7bz), which is the SAME helper the off-box
+  trace projector applies — one declaration, one answer at both boundaries.
+
+  The earlier spelling of this docstring said `:params-schema` marks, which was
+  doubly wrong: nothing was applied at all, and EP-0025 had already removed the
+  schema route into durable classification (Spec 015 §Schemas describe shape,
+  not durable egress policy). The projection-relative declaration on the spec is
+  the single durable classification surface."
   [scoped-key frame-id]
-  (let [[projected-key disposition _spec] (ssr/disposition+project-key scoped-key frame-id)]
-    [projected-key disposition]))
+  (let [[projected-key disposition spec] (ssr/disposition+project-key scoped-key frame-id)]
+    [(trace-egress/redact-key-declarations projected-key disposition spec) disposition]))
 
 (defn- project-work-id
   "Project the scoped key embedded in a resource work-id

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -218,6 +218,41 @@
                  decls)
       scoped-key)))
 
+(defn- coarse-key-projection
+  "The COARSE arm of a trace-row scoped-key projection — the whole of
+  `project-trace-scoped-key` EXCEPT the owner's per-slot declarations. Takes a
+  `scoped-key` already known to be a 3-vector; returns
+  `[projected-key coarse-redacts? disposition spec]`.
+
+  `coarse-redacts?` answers ONE question and it is not the row's stamp: does
+  this owner's WHOLE-ENTRY claim cover its whole payload? True for a
+  `:sensitive?` / `:large?` root prop, for an UNREGISTERED owner (the
+  trace-egress fail-closed default — tooling / SSR egress treat an unregistered
+  owner as `:serialize`, the algebra read, but a TRACE row whose owner we cannot
+  read is not provably safe), and for an ALREADY-PROJECTED key (both components
+  opaque tokens — the coarse arm fired upstream; idempotent, never re-hashed).
+
+  It is a SEPARATE reading from the row's `:sensitive?` stamp, and rf2-dl7bz is
+  why. `row-owner-redacts?` gates the whole-slot tokenization of the free
+  load-more cursor and of a read reply's `:value` / `:params` — payload the
+  owner made no per-slot claim about — so it must ask the COARSE question. The
+  row STAMP asks the different question \"did anything on this row redact\", and
+  a per-slot declaration substituting inside the key answers yes to that while
+  answering no to this. Borrowing one flag for both is what made a
+  declaration-only owner's whole reply body tokenize, destroying the undeclared
+  siblings rf2-ko5lm's grain argument exists to keep readable."
+  [scoped-key frame-id]
+  (cond
+    (and (redacted-token? (nth scoped-key 0)) (redacted-token? (nth scoped-key 2)))
+    [scoped-key true nil nil]
+
+    (nil? (registry/resource-meta (second scoped-key)))
+    [(ssr/project-scoped-key scoped-key :redact nil) true :redact nil]
+
+    :else
+    (let [[projected-key disposition spec] (ssr/disposition+project-key scoped-key frame-id)]
+      [projected-key (not= :serialize disposition) disposition spec])))
+
 (defn- project-trace-scoped-key
   "Fail-closed projection of one trace-row `scoped-key`
   `[scope resource-id params]` for OFF-BOX trace egress. Returns
@@ -236,40 +271,19 @@
   (the trace-egress fail-closed default). An already-projected key (both scope
   and params are opaque tokens) rides as-is + stays marked sensitive
   (idempotent — never re-hashed). A non-scoped-key value rides unchanged +
-  non-sensitive. Pure."
+  non-sensitive. Pure.
+
+  STAMP-PRECISE, on the rf2-ko5lm reading: a declaration that matched nothing in
+  THIS key leaves the row unstamped, so `sensitive?` keeps meaning \"something
+  on this row redacted\". `not=` is the right comparison and not `identical?` —
+  the walk reconstructs collections, and a bare `(1 2 3)` → `[1 2 3]` kind
+  collapse is not a redaction and must not stamp."
   [scoped-key frame-id]
-  (cond
-    (not (and (vector? scoped-key) (= 3 (count scoped-key))))
+  (if-not (and (vector? scoped-key) (= 3 (count scoped-key)))
     [scoped-key false]
-
-    (and (redacted-token? (nth scoped-key 0)) (redacted-token? (nth scoped-key 2)))
-    [scoped-key true]
-
-    ;; fail closed — owner unreadable, redact scope + params, keep the id. This
-    ;; nil-spec fail-closed-to-`:redact` (and the idempotent-token guard above)
-    ;; is the OUTER wrapper the trace-egress family keeps around the shared
-    ;; disposition+project-key pipeline: tooling / SSR egress treat
-    ;; an unregistered owner as `:serialize` (the algebra read), but a TRACE row
-    ;; whose owner we cannot read is not provably safe.
-    (nil? (registry/resource-meta (second scoped-key)))
-    [(ssr/project-scoped-key scoped-key :redact nil) true]
-
-    ;; REGISTERED owner — the shared pipeline computes the disposition + projects
-    ;; the key exactly as the SSR durable-egress + tool-egress paths do. `:redact`
-    ;; / `:omit` redacts the whole scope+params. A `:serialize` key then takes the
-    ;; owner's per-slot DECLARATIONS (rf2-dl7bz), which is the only arm that can
-    ;; speak for a spec making no coarse claim.
-    ;;
-    ;; STAMP-PRECISE, on the rf2-ko5lm reading: a declaration that matched
-    ;; nothing in THIS key leaves the row unstamped, so the flag still means
-    ;; "something on this row redacted". `not=` is the right comparison and not
-    ;; `identical?` — the walk reconstructs collections, and a bare `(1 2 3)` →
-    ;; `[1 2 3]` kind collapse is not a redaction and must not stamp.
-    :else
-    (let [[projected-key disposition spec] (ssr/disposition+project-key scoped-key frame-id)
+    (let [[projected-key coarse? disposition spec] (coarse-key-projection scoped-key frame-id)
           declared-key (redact-key-declarations projected-key disposition spec)]
-      [declared-key (or (not= :serialize disposition)
-                        (not= declared-key projected-key))])))
+      [declared-key (or coarse? (not= declared-key projected-key))])))
 
 (def ^:private scoped-key-slot
   "Tag slots on a resource / mutation trace row that carry a SINGLE scoped-key
@@ -517,16 +531,23 @@
   fx carrier, a read continuation reply's `reply-payload-slot` entries) must
   tokenize.
   Reuses the SAME owner classification the scoped-key projection uses
-  (`disposition+project-key`), with the trace-egress fail-closed default for an
-  unregistered / unreadable owner (`project-trace-scoped-key`'s nil-spec arm).
+  (`coarse-key-projection` — `disposition+project-key` plus the trace-egress
+  fail-closed default for an unregistered / unreadable owner).
   Returns false when the row carries no usable `:resource/key` (no owner to read
   — the cursor then rides verbatim; structural attribution is unaffected).
-  Pure."
+  Pure.
+
+  Reads the COARSE arm DIRECTLY, not `project-trace-scoped-key`'s `sensitive?`
+  (rf2-dl7bz). The two diverged the moment a `:serialize` key started honouring
+  the owner's per-slot declarations: that substitution makes the KEY redact —
+  which the row stamp must report — while saying nothing about the free cursor
+  or the reply body, which no declaration names. Reading the stamp here made a
+  declaration-only owner's whole `:value` / `:params` tokenize, which is exactly
+  the over-redaction the reply arm's grain argument forbids."
   [tags frame-id]
   (let [sk (:resource/key tags)]
     (when (and (vector? sk) (= 3 (count sk)))
-      (let [[_pk sens?] (project-trace-scoped-key sk frame-id)]
-        sens?))))
+      (second (coarse-key-projection sk frame-id)))))
 
 (def ^:private disposition-rows-slot
   "Tag slots that carry a VECTOR of per-key DISPOSITION maps (each embedding a

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -91,8 +91,13 @@
   as the load-more cursor is through its row's; and, since rf2-ko5lm, that same
   reply's owner-DECLARED projection-relative slots, which the coarse owner read
   is blind to, substituted through the same `redact-continuation-reply` the
-  mutation reply uses at its source."
-  (:require [re-frame.resources.classification :as classification]
+  mutation reply uses at its source; and, since rf2-dl7bz, that SAME
+  declaration's copy inside the scoped KEY beside it — the family's universal
+  carrier — substituted by `redact-key-declarations`, so a `:params` / `:scope`
+  declaration reaches every carrier of the value it names rather than only the
+  ones somebody has looked at."
+  (:require [re-frame.classification :as core-classification]
+            [re-frame.resources.classification :as classification]
             [re-frame.resources.registry :as registry]
             [re-frame.resources.reply :as resources-reply]
             [re-frame.resources.ssr :as ssr]))
@@ -102,13 +107,130 @@
 (defn- redacted-token? [c]
   (and (map? c) (contains? c :rf/redacted)))
 
+(defn- key-slot-declarations
+  "Split a resource `spec`'s scoped-KEY projection-relative declarations into
+  the two components of `[scope resource-id params]`, each path re-rooted at
+  the component it names. Returns
+
+    {0 {:sensitive [paths] :large [paths]}    ; the SCOPE component
+     2 {:sensitive [paths] :large [paths]}}   ; the PARAMS component
+
+  keyed by the component's INDEX in the key vector, with a component that
+  neither axis names dropped — so `nil` means the spec declares nothing the KEY
+  carries and the key must ride VERBATIM.
+
+  Built from the already-public `classification/spec-declaration-marks`, whose
+  `:params` bucket IS the scoped-key bucket: a `:params`-rooted declaration
+  arrives with its head stripped and names the params component, a
+  `:scope`-rooted one arrives WITH its `[:scope …]` head and names the scope
+  component. That is the same reading
+  `classification/instance-declaration-paths` lowers into the per-frame elision
+  registry (`[… :resource/key 2 …]` for params, `[… :resource/key 0 …]` for
+  scope), which is what makes this agree with the durable side by construction
+  rather than by coincidence. Pure / value-independent."
+  [spec]
+  (let [marks (:params (classification/spec-declaration-marks spec))
+        axis  (fn [k]
+                (reduce (fn [acc p]
+                          (let [p (vec p)]
+                            (if (= :scope (first p))
+                              (update acc 0 conj (subvec p 1))
+                              (update acc 2 conj p))))
+                        {0 [] 2 []}
+                        (keys (get marks k))))
+        s     (axis :sensitive)
+        l     (axis :large)]
+    (not-empty
+      (into {}
+            (keep (fn [i]
+                    (when (or (seq (get s i)) (seq (get l i)))
+                      [i {:sensitive (get s i) :large (get l i)}])))
+            [0 2]))))
+
+(defn redact-key-declarations
+  "The SCOPED-KEY analogue of `redact-reply-declarations` below (rf2-dl7bz) —
+  the owner's per-slot `:params` / `:scope` projection-relative declarations,
+  substituted inside the key `[scope resource-id params]` at the trace / tool
+  egress boundary. Takes the key ALREADY projected by
+  `ssr/disposition+project-key`, that call's `disposition`, and the owner
+  `spec` it resolved; returns the key.
+
+  ## Why the coarse projection is not the whole answer
+
+  `ssr/project-scoped-key` projects the key by the COARSE
+  `whole-entry-disposition` — the owner's root `:sensitive?` / `:large?` prop.
+  A spec that declares `{:sensitive [[:params :account-id]]}` and no coarse prop
+  classifies `:serialize`, so that read says nothing and the declared params
+  rode VERBATIM inside `:resource/key` on every family row, inside every
+  scoped-keys vector slot, inside every `[:rf.work/resource <key> <gen>]`
+  work-id, and inside every fx carrier the key reaches — while the SAME bytes
+  in the durable entry redact, because `reconcile-registry` lowered the
+  declaration to `[… :resource/key 2 …]` and the SSR wire key walks it
+  (`classification/project-entry-params`). One value, two carriers, one rule
+  applied: the rf2-irwsq shape the sibling `redact-reply-declarations`
+  (rf2-ko5lm) closed for the reply's copy of those same params, one slot over
+  on the same carrier.
+
+  ## Why HERE and not in `ssr/project-scoped-key`
+
+  `project-scoped-key`'s `:serialize` deferral is DELIBERATE and stays intact:
+  the SSR durable path has a REGISTRY-driven counterpart with the entry's
+  `key-id` and the live frame, so it walks the params component through
+  `project-egress` seeded at the lowered registry offset. The trace / tool
+  boundary has neither, so it derives the same declaration from the SPEC — the
+  frameless derivation the family already uses beside this fn for the reply
+  (`classification/redact-continuation-reply` over `carrier-decl-paths`). The
+  two answers are byte-identical by construction, because both re-root the same
+  `spec-declaration-marks` bucket onto the same two key components and both walk
+  INDEX-FREE. SSR is not a caller that never asked for this — it is not a caller
+  of this at all.
+
+  ## Grain: DECLARATION-conditional, and `:serialize`-only
+
+  A `:redact` / `:omit` key has already had its WHOLE scope + params replaced by
+  opaque content-addressed tokens, which SUBSUMES the per-slot surface, so this
+  fires only under `:serialize`. Within `:serialize` it fires on the paths the
+  owner DECLARED and on nothing else: a spec declaring nothing the key carries
+  rides the key back IDENTICAL (`key-slot-declarations` returns nil), which is
+  what preserves the CEDN-1 byte identity a cache-key round-trip depends on —
+  the walker RECONSTRUCTS collections, so an unnecessary walk would collapse a
+  list-valued param to a vector (rf2-wgutc2). Under a declaration that walk DOES
+  happen and that collapse IS accepted — the SSR durable path already accepts
+  exactly it under the same declaration-existence gate
+  (`registry-classifies-under?`), so this extends an accepted cost rather than
+  introducing one.
+
+  IDEMPOTENT: re-projecting substitutes the same sentinel at the same path. A
+  non-`:serialize` disposition, a nil spec (the unregistered owner the caller
+  has already failed closed on), or a non-3-vector rides UNCHANGED. Pure /
+  value-independent."
+  [scoped-key disposition spec]
+  (if-not (and (= :serialize disposition)
+               (some? spec)
+               (vector? scoped-key)
+               (= 3 (count scoped-key)))
+    scoped-key
+    (if-let [decls (key-slot-declarations spec)]
+      (reduce-kv (fn [k i {:keys [sensitive large]}]
+                   (update k i core-classification/redact-with-paths
+                           sensitive large {:index-free? true}))
+                 scoped-key
+                 decls)
+      scoped-key)))
+
 (defn- project-trace-scoped-key
   "Fail-closed projection of one trace-row `scoped-key`
   `[scope resource-id params]` for OFF-BOX trace egress. Returns
   `[projected-key sensitive?]`. For a REGISTERED owner the scope + params
   tokenize per the owner's `whole-entry-disposition` classification (a
   `:sensitive?` / `:large?` key redacts to opaque content-addressed
-  `{:rf/redacted <digest>}` tokens; a plain key rides verbatim). A key whose
+  `{:rf/redacted <digest>}` tokens; a plain key rides verbatim) and, when that
+  COARSE read says nothing, the owner's per-slot `:params` / `:scope`
+  DECLARATIONS substitute in place (`redact-key-declarations`, rf2-dl7bz) — the
+  two arms composing by grain exactly as the reply's do: coarse claim ⇒ the
+  whole scope + params tokenize; declaration only ⇒ the declared slots
+  substitute and their undeclared siblings ride; neither ⇒ the key is
+  byte-identical. A key whose
   resource-id is UNREGISTERED (nil owner spec — the
   trace names an owner we cannot read) is REDACTED rather than serialized raw
   (the trace-egress fail-closed default). An already-projected key (both scope
@@ -134,11 +256,20 @@
 
     ;; REGISTERED owner — the shared pipeline computes the disposition + projects
     ;; the key exactly as the SSR durable-egress + tool-egress paths do. `:redact`
-    ;; / `:omit` redacts the scope+params; `:serialize` rides verbatim — so the
-    ;; sensitivity flag is `(not= :serialize disposition)`.
+    ;; / `:omit` redacts the whole scope+params. A `:serialize` key then takes the
+    ;; owner's per-slot DECLARATIONS (rf2-dl7bz), which is the only arm that can
+    ;; speak for a spec making no coarse claim.
+    ;;
+    ;; STAMP-PRECISE, on the rf2-ko5lm reading: a declaration that matched
+    ;; nothing in THIS key leaves the row unstamped, so the flag still means
+    ;; "something on this row redacted". `not=` is the right comparison and not
+    ;; `identical?` — the walk reconstructs collections, and a bare `(1 2 3)` →
+    ;; `[1 2 3]` kind collapse is not a redaction and must not stamp.
     :else
-    (let [[projected-key disposition _spec] (ssr/disposition+project-key scoped-key frame-id)]
-      [projected-key (not= :serialize disposition)])))
+    (let [[projected-key disposition spec] (ssr/disposition+project-key scoped-key frame-id)
+          declared-key (redact-key-declarations projected-key disposition spec)]
+      [declared-key (or (not= :serialize disposition)
+                        (not= declared-key projected-key))])))
 
 (def ^:private scoped-key-slot
   "Tag slots on a resource / mutation trace row that carry a SINGLE scoped-key
@@ -718,13 +849,16 @@
   durable side. Opt-IN, so the walker's other callers — which declare concrete
   paths — keep the exact match.
 
-  ## One residue, filed rather than fixed
+  ## The sibling copy, since closed (rf2-dl7bz)
 
-    - rf2-dl7bz — a `:params`-rooted declaration also names bytes that ride
-      the SIBLING `:resource/key`, and a `:serialize` owner's key rides
-      verbatim at trace egress by documented decision
-      (`ssr/project-scoped-key`). This closes the reply's copy; the key's copy
-      is the family's universal carrier and is its own ruling."
+  A `:params`-rooted declaration also names bytes that ride the SIBLING
+  `:resource/key`, one slot over on the same carrier, and a `:serialize`
+  owner's key rode there verbatim. That copy is closed by
+  `redact-key-declarations` above, which is this fn's shape re-rooted onto the
+  key's two components instead of the reply's sibling slots —
+  `ssr/project-scoped-key`'s documented `:serialize` deferral left intact,
+  because the per-slot arm belongs at the boundary that has no registry to read
+  rather than inside the projection the SSR durable path shares."
   [reply]
   (let [rid  (second (:resource/key reply))
         spec (when (keyword? rid) (registry/resource-meta rid))]
@@ -1268,7 +1402,10 @@
 
   A `:sensitive?` / `:large?` owner's scope + params
   tokenize to opaque content-addressed `{:rf/redacted <digest>}` (distinct
-  values stay distinct, so a tool's per-key joins survive); a plain owner's key
+  values stay distinct, so a tool's per-key joins survive); an owner making no
+  coarse claim has its per-slot `:params` / `:scope` DECLARATIONS substituted
+  inside the key (`redact-key-declarations`, rf2-dl7bz) so the declaration the
+  durable entry honours is honoured on the key too; a plain owner's key
   rides verbatim; an UNREGISTERED owner FAILS CLOSED (redacted — the
   trace-egress default). The resource-id (position 1 of every projected key) and
   recognized structural scalar tags (`:rf.frame/id`, `:cause`, `:decision`,

--- a/implementation/resources/test/re_frame/resources_trace_key_declarations_egress_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_trace_key_declarations_egress_cljs_test.cljc
@@ -1,0 +1,425 @@
+(ns re-frame.resources-trace-key-declarations-egress-cljs-test
+  "A `:serialize` owner's per-slot `:params` / `:scope` declaration is honoured
+  INSIDE `:resource/key` at trace / tool egress (rf2-dl7bz).
+
+  ## The leak this suite pins
+
+  A resource declaring
+
+    (rf/reg-resource :account/summary
+      {:sensitive [[:params :account-id]] …} …)
+
+  and NO coarse `:sensitive?` root prop classifies `:serialize`. The trace /
+  tool key projection read only that coarse disposition
+  (`ssr/project-scoped-key`), so the declared `:account-id` rode RAW inside
+  `:resource/key` on every `:rf.resource/*` / `:rf.mutation/*` row, inside every
+  scoped-keys vector slot, inside every `[:rf.work/resource <key> <gen>]`
+  work-id, and inside every fx carrier (`:rf.fx/args` / `:rf.event/fx`) the key
+  reaches — off-box, epoch, MCP. Meanwhile the SAME bytes in the durable entry
+  redact, because `reconcile-registry` lowered the declaration to
+  `[… :resource/key 2 :account-id]` and the SSR wire key walks it
+  (`classification/project-entry-params`). One value, two carriers, one rule
+  applied: the rf2-irwsq shape.
+
+  The artefact ALREADY DOCUMENTED the closed behaviour before it existed —
+  `tooling.cljc` claimed `:serialize` \"applies the resource's per-slot
+  `:params` projection-relative declarations\" and \"projects per-slot
+  `:params-schema` marks\", and `ssr/project-scoped-key` took a `spec` argument
+  it named `_spec`. §1 below is the standing statement that the prose is now
+  true of the code, and §5 is the standing statement that it was made true
+  WITHOUT widening `project-scoped-key`, whose `:serialize` deferral is
+  deliberate (the SSR durable path resolves the same declaration from the
+  per-frame elision REGISTRY, which a frameless trace boundary cannot read).
+
+  ## No over-redaction — every assertion here has a two-sided control
+
+  §2 pins the negative side: a plain owner's key rides BYTE-IDENTICAL, the
+  UNDECLARED sibling param stays readable (a tool must still see `:page 3`),
+  `:rf.scope/global` is untouched, and the resource-id survives at position 1
+  so every per-key join a tool makes still lands. A change that
+  over-redacts fails this suite as loudly as the leak did.
+
+  ## Build posture
+
+  This whole surface is DEV-ONLY. Both callers of the projection sit behind
+  `interop/debug-enabled?` or bundle isolation: the off-box trace projector is
+  reached through the epoch tool-pair, and every trace emit (`trace/emit!` AND
+  the `:rf.error/*` `trace/emit-error!`) is gated on `interop/debug-enabled?`,
+  which folds to `false` under `:advanced` + `goog.DEBUG=false` / a JVM
+  `-Dre-frame.debug=false`; the tool-egress caller lives in the
+  bundle-isolated `re-frame.resources.tooling` sibling. This is therefore a
+  DEV / tool-console guarantee, not an always-on production one — the always-on
+  `:rf.observe/*` axis carries no resource scoped key, and nothing here changes
+  that.
+
+  Dual-target (`.cljc` + `_cljs_test`): the JVM runner picks it up via the
+  `.*-test$` ns regex, Shadow's `:node-test` build via the `cljs-test$` regex.
+  The browser / MCP off-box channel is where this matters most, so the
+  guarantee is asserted on BOTH hosts."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [clojure.string :as str]
+   [re-frame.core :as rf]
+   [re-frame.frame :as frame]
+   ;; load-bearing side-effecting require: the façade registers the
+   ;; :rf.resource/* events + subs + the :resource registrar kind, and
+   ;; publishes the trace-egress hooks the epoch tool-pair consults.
+   [re-frame.resources]
+   [re-frame.resources.classification :as classification]
+   [re-frame.resources.registry :as registry]
+   [re-frame.resources.ssr :as ssr]
+   [re-frame.resources.state :as state]
+   [re-frame.resources.tooling :as resources-tooling]
+   [re-frame.resources.trace-egress :as trace-egress]
+   [re-frame.resources.work-ledger :as work-ledger]
+   ;; production HTTP fx surface (so the transport feature probe resolves).
+   [re-frame.http.managed]
+   [re-frame.schemas]
+   [re-frame.test-support :as core-test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+(def ^:private account-secret "acct-SECRET-4417")
+(def ^:private tenant-secret "tenant-SECRET-99")
+(def ^:private avatar-blob "avatar-bytes-XXXXXXXX")
+
+;; ---- fixture --------------------------------------------------------------
+
+(defn- init!
+  "Four owners spanning the grains this suite discriminates:
+
+    :account/summary — `:serialize` (NO coarse prop) + a per-slot
+                       `[:params :account-id]` declaration. The subject.
+    :plain/summary   — declares NOTHING. The byte-identity control.
+    :tenant/report   — a `[:scope :tenant-id]` declaration, to prove a
+                       `:scope`-rooted path reaches the key's index-0 component
+                       through the `[tier {identity}]` tuple.
+    :sealed/summary  — the COARSE `:sensitive?` owner, to prove the two arms
+                       compose by grain rather than overlap (the coarse arm's
+                       whole-component digests are untouched)."
+  []
+  (rf/make-frame {:id :rf/default :url-bound? true
+                  :doc "per-slot key-declaration trace-egress suite frame."})
+  (rf/reg-resource :account/summary
+    {:scope         :rf.scope/global
+     :sensitive     [[:params :account-id]]
+     :params-schema [:map [:account-id :string] [:page :int]]}
+    (fn [_p _ctx] {:request {:method :get :url "/account"}}))
+  (rf/reg-resource :plain/summary
+    {:scope         :rf.scope/global
+     :params-schema [:map [:account-id :string] [:page :int]]}
+    (fn [_p _ctx] {:request {:method :get :url "/plain"}}))
+  (rf/reg-resource :tenant/report
+    {:scope         :rf.scope/global
+     :sensitive     [[:scope :tenant-id]]
+     :large         [[:params :avatar]]
+     :params-schema [:map [:avatar :string] [:page :int]]}
+    (fn [_p _ctx] {:request {:method :get :url "/tenant"}}))
+  (rf/reg-resource :sealed/summary
+    {:scope         :rf.scope/global
+     :sensitive?    true
+     :sensitive     [[:params :account-id]]
+     :params-schema [:map [:account-id :string] [:page :int]]}
+    (fn [_p _ctx] {:request {:method :get :url "/sealed"}})))
+
+(use-fixtures :each
+  (core-test-support/make-reset-runtime-fixture
+    {:adapter #?(:clj plain-atom/adapter :cljs reagent-adapter/adapter)
+     :init-fn init!}))
+
+;; ---- helpers --------------------------------------------------------------
+
+(def ^:private declared-params {:account-id account-secret :page 3})
+
+(defn- key-for [resource-id]
+  (state/scoped-resource-key :rf.scope/global resource-id declared-params))
+
+(defn- tenant-key []
+  (state/scoped-resource-key [:rf.scope/session {:tenant-id tenant-secret :region "au"}]
+                             :tenant/report
+                             {:avatar avatar-blob :page 3}))
+
+(defn- project-row
+  "Project `tags` for OFF-BOX egress exactly as the epoch tool-pair does —
+  through the late-bound `:resources/project-resource-trace-egress` hook's body,
+  against the row's own `:rf.frame/id`."
+  [tags]
+  (trace-egress/project-resource-trace-egress tags (:rf.frame/id tags)))
+
+(defn- projected-key
+  "The single `:resource/key` slot of a one-key row, projected off-box."
+  [scoped-key]
+  (:resource/key (project-row {:rf.frame/id :rf/default :resource/key scoped-key})))
+
+(defn- leaks?
+  "Whether `secret` survives ANYWHERE in `v` — the plaintext test."
+  [secret v]
+  (str/includes? (pr-str v) secret))
+
+(defn- install-entry!
+  "Write a durable `:loaded` entry for `scoped-key` into the frame's runtime-db
+  AND reconcile the per-frame elision registry, so the SSR durable projection
+  (`project-entry-params`) has the lowered declaration to read — the same two
+  steps a real resource commit folds into one transition. Returns the key."
+  [frame-id scoped-key]
+  (let [resource-id (second scoped-key)]
+    (frame/swap-runtime-db!
+      frame-id
+      (fn [rdb]
+        (-> (or rdb {})
+            (assoc-in (state/entry-path scoped-key)
+                      (assoc (state/empty-entry resource-id scoped-key)
+                             :status :loaded
+                             :data   {:total 1}))
+            (classification/reconcile-registry registry/resource-meta)))))
+  scoped-key)
+
+(defn- ssr-wire-key
+  "The SSR DURABLE wire key for `scoped-key`'s entry — the registry-driven
+  counterpart this suite must agree with byte for byte."
+  [frame-id scoped-key]
+  (let [rdb   (frame/frame-runtime-db-value frame-id)
+        wired (get-in (ssr/project-resources-runtime-db rdb frame-id)
+                      [state/resources-key :entries])]
+    (some (fn [[_k-id e]]
+            (when (= (second (:resource/key e)) (second scoped-key))
+              (:resource/key e)))
+          wired)))
+
+;; ===========================================================================
+;; 1. THE LEAK. A `:serialize` owner's declared params slot must not ride raw
+;;    inside `:resource/key` on the trace path.
+;;
+;;    This is the assertion `epoch_egress_resource_trace_test.clj` §(rf2-ko5lm)
+;;    named in prose and deliberately did not make.
+;; ===========================================================================
+
+(deftest serialize-owner-declared-param-does-not-ride-raw-in-the-key
+  (testing "rf2-dl7bz — a resource declaring {:sensitive [[:params :account-id]]}
+            with NO coarse :sensitive? prop classifies :serialize, and its
+            DECLARED param must be substituted inside the projected
+            :resource/key rather than riding verbatim"
+    (let [k    (key-for :account/summary)
+          tags (project-row {:rf.frame/id :rf/default :resource/key k})
+          pk   (:resource/key tags)]
+      (is (leaks? account-secret k)
+          "premise: the RAW key carries the declared account-id in the clear")
+      (is (not (leaks? account-secret pk))
+          (str "the declared [:params :account-id] MUST NOT survive in the "
+               "projected :resource/key — got " (pr-str pk)))
+      (is (= :rf/redacted (get-in pk [2 :account-id]))
+          "the declared slot carries the redaction sentinel, in place")
+      (is (true? (:sensitive? tags))
+          "a row whose key redacted is stamped :sensitive?"))))
+
+(deftest declared-param-is-closed-on-every-carrier-of-the-key
+  (testing "rf2-dl7bz — :resource/key is the family's UNIVERSAL carrier: the
+            same declaration must close the key inside a scoped-keys VECTOR
+            slot, inside a work-id, and inside the fx carriers a foreign row
+            stamps"
+    (let [k       (key-for :account/summary)
+          work-id (work-ledger/resource-work-id k 1)
+          rows    {:rf.frame/id :rf/default
+                   :matched     [k]
+                   :work/id     work-id
+                   ;; a slot NOBODY has enumerated, reached by the shape-driven
+                   ;; default (rf2-wd9im) rather than by the slot roster.
+                   :unnamed     [[k]]}
+          proj    (project-row rows)]
+      (is (not (leaks? account-secret proj))
+          (str "no carrier on the row may keep the declared param raw — got "
+               (pr-str proj)))
+      (is (= :rf/redacted (get-in proj [:matched 0 2 :account-id]))
+          "the scoped-keys vector slot honours the declaration")
+      (is (= :rf/redacted (get-in proj [:work/id 1 2 :account-id]))
+          "the key EMBEDDED at position 1 of a work-id honours it")
+      (is (= :rf/redacted (get-in proj [:unnamed 0 0 2 :account-id]))
+          "the SHAPE-driven default (an unnamed slot) honours it too"))
+    (testing "…including the FX carriers of a row the family does not own"
+      (let [k    (key-for :account/summary)
+            tags {:rf.frame/id :rf/default
+                  :rf.fx/args  {:request-id [:rf.req :rf/default
+                                             [:rf.work/resource k 1]]}}
+            out  (trace-egress/project-fx-args-egress tags :rf/default)]
+        (is (not (leaks? account-secret out))
+            (str "an ensure's fx carrier must honour the declaration — got "
+                 (pr-str out)))
+        (is (true? (:sensitive? out)) "and the fx row is stamped")))))
+
+;; ===========================================================================
+;; 2. THE TWO-SIDED CONTROL. Over-redaction is as wrong as under-redaction.
+;; ===========================================================================
+
+(deftest plain-owners-key-rides-byte-identical
+  (testing "a resource declaring NOTHING has its key ride verbatim — same value
+            AND same CEDN-1 bytes (no walk, so no list↔vector collapse)"
+    (let [k  (key-for :plain/summary)
+          pk (projected-key k)]
+      (is (= k pk) "a plain owner's key is unchanged")
+      (is (= (state/key-id k) (state/key-id pk))
+          "…byte-identical, so the cache-key-identity round-trip is intact")
+      (is (leaks? account-secret pk)
+          "an undeclared param is app data and stays readable to a tool"))))
+
+(deftest kind-preserving-when-nothing-is-declared
+  (testing "rf2-wgutc2 — the walker reconstructs collections, so an UNNECESSARY
+            walk would collapse a list-valued param to a vector and change the
+            key's bytes. The declaration-existence gate is what stops it"
+    (let [k  (state/scoped-resource-key :rf.scope/global :plain/summary
+                                        {:account-id "a" :page 3 :ids '(1 2 3)})
+          pk (projected-key k)]
+      (is (= (pr-str k) (pr-str pk))
+          "an undeclared owner's key is byte-for-byte the same, list kind included")
+      (is (list? (get-in pk [2 :ids]))
+          "the list stays a list"))))
+
+(deftest undeclared-siblings-and-structure-survive-the-substitution
+  (testing "the substitution is IN PLACE: only the declared slot changes. The
+            undeclared sibling, the scope, and the resource-id all survive —
+            which is what keeps a tool's per-key joins and attribution working"
+    (let [k  (key-for :account/summary)
+          pk (projected-key k)]
+      (is (= :rf.scope/global (nth pk 0))
+          ":rf.scope/global is untouched")
+      (is (= :account/summary (nth pk 1))
+          "the resource-id survives at position 1 (attribution)")
+      (is (= 3 (get-in pk [2 :page]))
+          "the UNDECLARED sibling param stays readable")
+      (is (= #{:account-id :page} (set (keys (nth pk 2))))
+          "no param slot is added or dropped — the params key set is closed"))))
+
+(deftest an-undeclared-row-is-not-stamped-sensitive
+  (testing "stamp-precision: a plain owner's row carries no :sensitive? stamp,
+            so the flag keeps meaning 'something on this row redacted'"
+    (let [tags (project-row {:rf.frame/id :rf/default
+                             :resource/key (key-for :plain/summary)})]
+      (is (nil? (:sensitive? tags))))))
+
+;; ===========================================================================
+;; 3. A `:scope`-rooted declaration reaches the key's index-0 component.
+;; ===========================================================================
+
+(deftest scope-rooted-declaration-is-honoured-in-the-key
+  (testing "rf2-dl7bz — `split-projection-paths` routes a `:scope`-rooted path
+            into the scoped-key bucket, so [:scope :tenant-id] must redact the
+            key's SCOPE component, reaching through the [tier {identity}] tuple
+            the way a projection-relative declaration always reads"
+    (let [k  (tenant-key)
+          pk (projected-key k)]
+      (is (leaks? tenant-secret k) "premise: the raw key carries the tenant id")
+      (is (not (leaks? tenant-secret pk))
+          (str "the declared [:scope :tenant-id] must not survive — got " (pr-str pk)))
+      (is (= :rf.scope/session (get-in pk [0 0]))
+          "the scope TIER keyword survives (attribution)")
+      (is (= "au" (get-in pk [0 1 :region]))
+          "an undeclared sibling of the scope identity stays readable"))
+    (testing "…and a :large declaration on the same spec elides its own slot"
+      (let [pk (projected-key (tenant-key))]
+        (is (not (leaks? avatar-blob pk))
+            "the [:params :avatar] :large declaration elides in the key too")
+        (is (= 3 (get-in pk [2 :page]))
+            "its undeclared sibling still rides")))))
+
+;; ===========================================================================
+;; 4. AGREEMENT WITH THE SSR DURABLE WIRE KEY (the bead's Q1).
+;;
+;;    This is what stops a fourth answer appearing later: the trace key, the
+;;    tool key and the SSR wire key are ONE value derived two ways.
+;; ===========================================================================
+
+(deftest trace-key-agrees-with-the-ssr-durable-wire-key
+  (testing "rf2-dl7bz Q1 — the spec-derived per-slot projection is BYTE-EQUAL
+            to the registry-driven `classification/project-entry-params` the SSR
+            durable path runs. Two derivations, one answer"
+    (let [k        (install-entry! :rf/default (key-for :account/summary))
+          wire     (ssr-wire-key :rf/default k)
+          trace    (projected-key k)]
+      (is (some? wire) "the SSR projection produced a wire key for the entry")
+      (is (= :rf/redacted (get-in wire [2 :account-id]))
+          "premise: the SSR durable path already honours the declaration")
+      (is (= (pr-str (nth wire 2)) (pr-str (nth trace 2)))
+          (str "the trace key's params component must be BYTE-equal to the SSR "
+               "wire key's — wire " (pr-str (nth wire 2))
+               " vs trace " (pr-str (nth trace 2)))))))
+
+(deftest projection-is-idempotent
+  (testing "rf2-dl7bz Q2 — re-projecting an already-projected key substitutes
+            the same sentinel at the same path, so a doubly-projected row and a
+            singly-projected one agree"
+    (let [k (key-for :account/summary)]
+      (is (= (projected-key k) (projected-key (projected-key k)))))))
+
+;; ===========================================================================
+;; 5. THE DEFERRAL IS INTACT. `project-scoped-key` was NOT widened.
+;; ===========================================================================
+
+(deftest project-scoped-key-still-defers-on-serialize
+  (testing "rf2-dl7bz ruling — the per-slot arm lives at the trace / tool
+            boundary, NOT inside `ssr/project-scoped-key`, whose `:serialize`
+            deferral is deliberate (the SSR durable path resolves the same
+            declaration from the per-frame elision registry). This test reds if
+            anyone moves the arm into the shared projection"
+    (let [k    (key-for :account/summary)
+          spec (registry/resource-meta :account/summary)]
+      (is (= k (ssr/project-scoped-key k :serialize spec))
+          "`:serialize` still rides VERBATIM through `project-scoped-key`")
+      (is (= (ssr/project-scoped-key k :serialize spec)
+             (ssr/project-scoped-key k :serialize nil))
+          "…and it still ignores the spec argument, exactly as documented"))))
+
+;; ===========================================================================
+;; 6. THE COARSE ARM IS UNCHANGED — the two arms compose by grain.
+;; ===========================================================================
+
+(deftest coarse-owner-still-tokenizes-the-whole-component
+  (testing "a COARSE :sensitive? owner's key still redacts to the opaque
+            content-addressed tokens, subsuming the per-slot surface — the
+            declaration arm must not change what the coarse arm produces"
+    (let [k    (key-for :sealed/summary)
+          tags (project-row {:rf.frame/id :rf/default :resource/key k})
+          pk   (:resource/key tags)]
+      (is (contains? (nth pk 2) :rf/redacted)
+          "the WHOLE params component is one opaque token")
+      (is (contains? (nth pk 0) :rf/redacted)
+          "…and so is the whole scope component")
+      (is (= :sealed/summary (nth pk 1)) "the resource-id survives")
+      (is (true? (:sensitive? tags)))
+      (is (= pk (ssr/project-scoped-key k :redact nil))
+          "byte-for-byte what `project-scoped-key` alone produced before"))))
+
+(deftest unregistered-owner-still-fails-closed
+  (testing "the nil-spec fail-closed arm is untouched by the declaration arm"
+    (let [k    (state/scoped-resource-key :rf.scope/global :never/registered
+                                          {:account-id account-secret})
+          tags (project-row {:rf.frame/id :rf/default :resource/key k})]
+      (is (not (leaks? account-secret (:resource/key tags))))
+      (is (true? (:sensitive? tags))))))
+
+;; ===========================================================================
+;; 7. THE TOOL BOUNDARY ANSWERS IDENTICALLY.
+;;
+;;    `tooling.cljc` documented this behaviour before it existed. The live
+;;    algebra view is where that prose is cashed out.
+;; ===========================================================================
+
+(deftest tool-egress-honours-the-same-declaration
+  (testing "rf2-dl7bz — the EP-0015 tool-egress projection opts into the SAME
+            helper, so a tool's node identity carries no declared param either.
+            Before this, `project-key-for-egress`'s docstring claimed `:serialize`
+            projected per-slot marks and the code did nothing"
+    (let [k    (install-entry! :rf/default (key-for :account/summary))
+          view (resources-tooling/resource-cache-algebra-view :rf/default)
+          node (first (vals view))]
+      (is (some? node) "the live entry projects to a node")
+      (is (not (leaks? account-secret node))
+          (str "no identity position on the node may carry the declared param — got "
+               (pr-str node)))
+      (is (= :rf/redacted (get-in (:id node) [2 :account-id]))
+          "the node :id is the declaration-projected key")
+      (is (= 3 (get-in (:id node) [2 :page]))
+          "…and the undeclared sibling still rides, so joins survive")
+      (testing "the DURABLE cache key is untouched — this is an egress-only projection"
+        (let [rdb (frame/frame-runtime-db-value :rf/default)]
+          (is (= k (:resource/key (get-in rdb (state/entry-path k))))
+              "the entry still stores the raw scoped key"))))))

--- a/implementation/resources/test/re_frame/resources_trace_key_declarations_egress_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_trace_key_declarations_egress_cljs_test.cljc
@@ -296,6 +296,45 @@
                              :resource/key (key-for :plain/summary)})]
       (is (nil? (:sensitive? tags))))))
 
+(defn- read-reply
+  "The continuation reply map `events/read-continuation-reply` builds, trimmed
+  to the slots this suite reads."
+  [scoped-key value]
+  (let [[scope resource-id params] scoped-key]
+    {:status               :ok
+     :value                value
+     :rf.reply/work-id     [:rf.work/resource scoped-key 1]
+     :rf.reply/work-kind   :resource
+     :rf.reply/work-status :completed
+     :resource             resource-id
+     :params               params
+     :scope                scope
+     :resource/key         scoped-key}))
+
+(deftest a-declared-key-must-not-widen-the-reply-to-a-coarse-redaction
+  (testing "rf2-dl7bz — the row's :sensitive? STAMP and the owner's COARSE claim
+            are two readings, and `row-owner-redacts?` must take the coarse one.
+
+            A `:params` declaration substituting inside the key makes the KEY
+            redact, which the stamp must report. It says NOTHING about the free
+            cursor or the reply body, which no declaration names. Conflating the
+            two tokenized a declaration-only owner's whole :value / :params —
+            destroying exactly the undeclared siblings rf2-ko5lm's grain
+            argument exists to keep readable"
+    (let [k     (key-for :account/summary)
+          reply (read-reply k {:ok true})
+          tags  {:rf.frame/id :rf/default :rf.fx/args reply}
+          out   (:rf.fx/args (trace-egress/project-fx-args-egress tags :rf/default))]
+      (is (= :rf/redacted (:account-id (:params out)))
+          "the reply's own :params copy still redacts through its declaration")
+      (is (= 3 (:page (:params out)))
+          "…and its UNDECLARED sibling still rides — not swallowed by a token")
+      (is (= {:ok true} (:value out))
+          "the body is untouched: this owner declares nothing under :data, and
+           its :params declaration must not promote the row to a coarse claim")
+      (is (= :rf/redacted (get-in out [:resource/key 2 :account-id]))
+          "while the sibling KEY carrier redacts the same declared slot"))))
+
 ;; ===========================================================================
 ;; 3. A `:scope`-rooted declaration reaches the key's index-0 component.
 ;; ===========================================================================


### PR DESCRIPTION
Closes rf2-dl7bz.

## What leaked

A resource declaring

```clojure
(rf/reg-resource :account/summary
  {:sensitive [[:params :account-id]] …} …)
```

and **no coarse `:sensitive?` root prop** classifies `:serialize`, and
`ssr/project-scoped-key` projects a `:serialize` key **verbatim**. So the
declared param rode raw inside `:resource/key` on every `:rf.resource/*` /
`:rf.mutation/*` row, inside every scoped-keys vector slot, inside every
`[:rf.work/resource <key> <gen>]` work-id, and inside every fx carrier
(`:rf.fx/args` / `:rf.event/fx`) the key reaches — while the **same bytes** in
the durable entry redact, because `reconcile-registry` lowered the declaration
to `[… :resource/key 2 :account-id]` and the SSR wire key walks it. Two carriers
of one value, one rule applied: the rf2-irwsq shape the sibling
`redact-reply-declarations` (rf2-ko5lm) closed for the reply's copy of those
same params, one slot over on the same carrier.

**This is a correction, not a design choice.** `tooling.cljc` already documented
the closed behaviour in two places and **both were false against the code**, and
`project-scoped-key` still took and ignored its `spec` argument. The seam was in
the signature; the code never implemented what the prose claimed.

## The shape (rf2-dl7bz ruling, option 1 — kept narrow)

`ssr/project-scoped-key`'s `:serialize` deferral is left **intact** — the SSR
durable path has a registry-driven counterpart with the entry's `key-id` and the
live frame, which a frameless trace boundary cannot read. `implementation/ssr/**`
and `resources/ssr.cljc` are **untouched** by this diff.

The per-slot arm instead lives beside `redact-reply-declarations` in
`trace_egress` as **`redact-key-declarations`**, re-rooting the already-public
`classification/spec-declaration-marks` `:params` bucket onto the key's two
components exactly as `classification/instance-declaration-paths` re-roots it
into the elision registry (`:scope`-rooted to index 0, `:params`-rooted to index
2) and walking **index-free**, as the durable side always has. The tool-egress
projection (`tooling/project-key-for-egress`) opts into the same helper — which
is what makes both documented claims true.

Grain: **`:serialize`-only and declaration-conditional.** A `:redact` / `:omit`
key has already had its whole components tokenized, and a spec declaring nothing
the key carries rides back **byte-identical** — the declaration-existence gate is
what preserves the CEDN-1 identity a cache-key round-trip depends on
(rf2-wgutc2). Under a declaration the walk does collapse a list-valued param to a
vector; the SSR durable path already accepts exactly that under the same gate
(`registry-classifies-under?`), so this extends an accepted cost rather than
introducing one (bead Q4, ruled).

### Second commit: the row stamp and the coarse claim are two readings

`row-owner-redacts?` borrowed `project-trace-scoped-key`'s `sensitive?` flag.
Sound while that flag meant exactly "the owner makes a coarse claim" — and
**unsound the moment a `:serialize` key started honouring declarations**, because
the substitution makes the *key* redact (which the row stamp must report) while
saying nothing about the free load-more cursor or a read reply's `:value` /
`:params`, which no declaration names.

The epoch suite caught it: a declaration-only owner's whole reply body tokenized
to a digest and its undeclared sibling params vanished with it — precisely the
over-redaction rf2-ko5lm's grain argument forbids. The coarse arm is now
extracted as `coarse-key-projection` and read directly by `row-owner-redacts?`.

### Corrected rather than made true

`project-key-for-egress`'s docstring claimed `:serialize` "projects per-slot
`:params-schema` marks". EP-0025 removed the schema route into durable
classification, so that clause could not be honoured as written — it is
**corrected** to name the projection-relative declaration on the spec, with the
correction stated in the docstring itself.

## Build posture

**Dev-only.** Both callers sit behind `interop/debug-enabled?` or bundle
isolation: the off-box trace projector is reached through the epoch tool-pair,
and every trace emit — `trace/emit!` **and** the `:rf.error/*` `trace/emit-error!`
— is gated on `interop/debug-enabled?`, which folds to `false` under `:advanced`
+ `goog.DEBUG=false` / `-Dre-frame.debug=false`; the tool-egress caller lives in
the bundle-isolated `re-frame.resources.tooling` sibling. The always-on
`:rf.observe/*` axis carries no resource scoped key, and nothing here changes
that. This is stated plainly in the suite docstring rather than implied to be an
always-on guarantee.

Egress discipline: the projected key is **built** from its three known
components (`[scope resource-id params]`) with only declared slots substituted —
a closed construction, not a scrub. The params key set is pinned closed by test
(`undeclared-siblings-and-structure-survive-the-substitution`), and no
payload-derived value is added.

## Quality gates

Foreground, worktree-local logs, exit codes echoed. No pipes.

| Gate | Command | Result | Exit |
|---|---|---|---|
| resources JVM (dev posture) | `implementation/resources` then `clojure -M:test` | 757 tests / 6934 assertions, 0 failures, 0 errors | **0** |
| resources JVM (prod posture, new suite) | `clojure -J-Dre-frame.debug=false -M:test -n re-frame.resources-trace-key-declarations-egress-cljs-test` | 14 tests / 48 assertions, 0 failures, 0 errors | **0** |
| epoch JVM (the projector's off-box consumer) | `implementation/epoch` then `clojure -M:test` | 539 tests / 7131 assertions, 0 failures, 0 errors | **0** |
| ssr JVM (the durable path) | `implementation/ssr` then `clojure -M:test` | 592 tests / 2892 assertions, 0 failures, 0 errors | **0** |
| core egress-chokepoint source-scan | `implementation/core` then `clojure -M:test -n re-frame.egress-chokepoint-conformance-test` | 3 tests / 7 assertions, 0 failures, 0 errors | **0** |

Deferred to CI: the CLJS node tier (`npm run test:cljs`) and every other
artefact's JVM lane.

## Mutation evidence

Both `src` files reverted to `origin/main`, test file unchanged, same command:

```
Ran 756 tests containing 6930 assertions.
14 failures, 0 errors.        EXIT=1
```

restored:

```
Ran 756 tests containing 6930 assertions.
0 failures, 0 errors.         EXIT=0
```

**Identical test and assertion counts, differing only in failures** — the bead's
proof standard. (Counts are 756/6930 at the first commit; the second commit adds
one deftest, hence 757/6934 in the gate table.)

The 14 RED failures, and what each pins:

```
FAIL (serialize-owner-declared-param-does-not-ride-raw-in-the-key)   :208 :211 :213
  the declared [:params :account-id] MUST NOT survive in the projected
  :resource/key — got [:rf.scope/global :account/summary
                       {:account-id "acct-SECRET-4417", :page 3}]

FAIL (declared-param-is-closed-on-every-carrier-of-the-key)  :230 :233 :235 :237 :245 :248
  the scoped-keys vector slot / the key EMBEDDED at position 1 of a work-id /
  the SHAPE-driven unnamed-slot default / an ensure's fx carrier
  expected: :rf/redacted   actual: "acct-SECRET-4417"

FAIL (trace-key-agrees-with-the-ssr-durable-wire-key)                :341
  wire  {:account-id :rf/redacted,          :page 3}
  trace {:account-id "acct-SECRET-4417",    :page 3}

FAIL (scope-rooted-declaration-is-honoured-in-the-key)               :311 :319
FAIL (tool-egress-honours-the-same-declaration)                      :415 :418
```

The `:341` failure is the leak and the false docstrings in one line: the SSR
durable path **already** answered `:rf/redacted` while the trace/tool path
answered the secret. The `:415` / `:418` failures are `tooling.cljc`'s two
claims, red against their own prose.

Every **two-sided control** passed in **both** runs — as it must, since none of
them depends on the fix: a plain owner's key rides byte-identical
(`state/key-id` unchanged), a list-valued param keeps its list kind, the
undeclared sibling `:page` stays readable, `:rf.scope/global` and the
resource-id are untouched, an undeclared row is not stamped `:sensitive?`, the
coarse `:sensitive?` owner's whole-component digests are byte-for-byte what
`project-scoped-key` alone produced, the unregistered owner still fails closed,
and `project-scoped-key` still rides `:serialize` verbatim **and still ignores
its `spec` argument** (`project-scoped-key-still-defers-on-serialize` reds if
anyone moves the arm into the shared projection).

## SSR durable path unchanged

`git diff --name-only origin/main...HEAD` touches no SSR file. The wire key is
the same before and after — visible directly in the mutation evidence, where the
RED run prints the SSR side as `wire {:account-id :rf/redacted, :page 3}` under
reverted source and the GREEN run asserts the trace key byte-equal to it.

## Residue found, filed not fixed

**rf2-5e2ye** — `ssr/project-entry` registry-projects only the params component
(index 2) of a `:serialize` wire key; there is no `project-entry-scope`
counterpart, so a `:scope`-rooted declaration is honoured by the epoch/registry
walk and (now) by every trace/tool key, but **not** by the SSR hydration wire
key. Out of scope here by the ruling's own "SSR untouched", and it interacts with
`project-resources-runtime-db`'s re-keying of wire entries on the projected
key's `key-id`, so it needs its own change.

## Spec

No spec change required — `spec/**` untouched. The behaviour this lands is what
`spec/016` §Resource identity clause 4 ("params, scopes, and data carry the same
classification") already says; the code was the thing out of step.
