### PR TITLE
fix(resources): the SSR wire key honours a :scope declaration (rf2-5e2ye)

### DIFF
--- a/implementation/resources/src/re_frame/resources/classification.cljc
+++ b/implementation/resources/src/re_frame/resources/classification.cljc
@@ -446,39 +446,93 @@
          :rf.egress/profile boundary-profile})
       data)))
 
+(defn- project-entry-key-component
+  "Project ONE component of an entry's scoped key for egress against `frame-id`'s
+  per-frame elision registry — the shared body behind `project-entry-scope`
+  (index 0) and `project-entry-params` (index 2).
+
+  The scoped key is the vector `[scope resource-id params]` and it lives at the
+  entry's absolute `:resource/key` carrier, so `instance-declaration-paths`
+  lowers a `:scope`-rooted declaration to `[… :resource/key 0 …]` and a
+  `:params`-rooted one to `[… :resource/key 2 …]` (`reconcile-registry`). Here
+  we walk the bare component value through `re-frame.projection/project-egress`
+  SEEDED at that same offset, so the lowered `:source :resource` decls match and
+  a marked slot redacts (`:sensitive` → `:rf/redacted`) / elides (`:large` →
+  `:rf.size/large-elided`) without the raw value riding in the wire key.
+
+  ONE rule, applied at both indices by parameterising the index alone — the
+  scope and params components of a key carry the same classification (Spec 016
+  clause 4 \"params, scopes, and data carry the same classification\"), so they
+  must not be able to drift into two rules.
+
+  GATED on a registry declaration under the component's offset
+  (`registry-classifies-under?`): when nothing is declared there the component
+  rides VERBATIM (reference / byte-identity preserving — the scoped key is a
+  CEDN-1 byte-keyed identity, so a list↔vector collapse from an unnecessary walk
+  would break the cache-key-identity round-trip). Frame-SCOPED: a nil /
+  unresolvable `frame-id` rides the component VERBATIM. Pure w.r.t. the value."
+  [component index key-id frame-id boundary-profile]
+  (let [prefix (conj (state/entry-path-by-id key-id) :resource/key index)]
+    (if (and frame-id (registry-classifies-under? frame-id prefix))
+      (projection/project-egress
+        component
+        {:frame             frame-id
+         :path              prefix
+         :rf.egress/profile boundary-profile})
+      component)))
+
 (defn project-entry-params
-  "Project a resource entry's scoped-key PARAMS value for egress against
-  `frame-id`'s per-frame elision registry — the CO-EQUAL params counterpart to
-  `project-entry-data` (Spec 016 clause 4 \"params, scopes,
-  and data carry the same classification\"). The resource's projection-relative
-  `:params` (and `:scope`) declarations were lowered into the registry at the
-  scoped key's absolute `:resource/key` carrier (`[… :resource/key 2 …]` for
-  params, `[… :resource/key 0 …]` for scope, `reconcile-registry`). The scoped
-  key is `[scope resource-id params]`, so the params component sits at index 2 of
-  that carrier; here we walk the bare params value through
-  `re-frame.projection/project-egress` SEEDED at the params offset
-  (`[… :resource/key 2]`) so the lowered `:source :resource` decls match — a
-  marked slot redacts / elides without the raw value riding in the wire key.
+  "Project a resource entry's scoped-key PARAMS value (index 2 of
+  `[scope resource-id params]`) for egress against `frame-id`'s per-frame
+  elision registry — the CO-EQUAL params counterpart to `project-entry-data`
+  (Spec 016 clause 4 \"params, scopes, and data carry the same
+  classification\"), and the sibling of `project-entry-scope` below.
 
   Used on a `:serialize` entry (no coarse whole-entry claim) — the COARSE
   `:redact` / `:omit` dispositions still replace the WHOLE params component with
   an opaque content-addressed digest (`re-frame.resources.ssr/project-scoped-key`),
-  irrespective of frame. GATED on a registry declaration under the params offset
-  (`registry-classifies-under?`): when nothing is declared there the params ride
-  VERBATIM (reference / byte-identity preserving — the scoped key is a CEDN-1
-  byte-keyed identity, so a list↔vector collapse from an unnecessary walk would
-  break the cache-key-identity round-trip). Frame-SCOPED: a nil / unresolvable
-  `frame-id` rides `params` VERBATIM. `key-id` is the entry's CEDN-1 byte key-id.
-  Pure w.r.t. the value."
+  irrespective of frame, which subsumes the per-slot surface. Declaration-GATED
+  and frame-SCOPED per `project-entry-key-component`. `key-id` is the entry's
+  CEDN-1 byte key-id. Pure w.r.t. the value."
   [params key-id frame-id boundary-profile]
-  (let [params-prefix (conj (state/entry-path-by-id key-id) :resource/key 2)]
-    (if (and frame-id (registry-classifies-under? frame-id params-prefix))
-      (projection/project-egress
-        params
-        {:frame             frame-id
-         :path              params-prefix
-         :rf.egress/profile boundary-profile})
-      params)))
+  (project-entry-key-component params 2 key-id frame-id boundary-profile))
+
+(defn project-entry-scope
+  "Project a resource entry's scoped-key SCOPE value (index 0 of
+  `[scope resource-id params]`) for egress — the CO-EQUAL scope counterpart to
+  `project-entry-params` (rf2-5e2ye).
+
+  ## The asymmetry this closes
+
+  `instance-declaration-paths` has always lowered a `:scope`-rooted declaration
+  to the entry's absolute `[… :resource/key 0 …]` path exactly as it lowers a
+  `:params`-rooted one to `[… :resource/key 2 …]`, so the epoch / registry walk
+  over the runtime-db honoured BOTH, and (since rf2-dl7bz)
+  `trace-egress/redact-key-declarations` honours both on every trace and tool
+  key. But the SSR wire key projected only index 2, so on a `:serialize` owner
+  declaring `{:sensitive [[:scope :tenant-id]]}` the resolved tenant id rode RAW
+  in the hydration payload — the LAST carrier of that value that disagreed, and
+  the only one that is not dev-gated.
+
+  ## Reaching through the `[tier {identity}]` tuple
+
+  A scope component is `:rf.scope/global` or the tuple `[tier {identity-map}]`,
+  so the declared `:tenant-id` sits at the INDEXED runtime path
+  `[… :resource/key 0 1 :tenant-id]` while the lowered decl is the index-FREE
+  `[… :resource/key 0 :tenant-id]`. `elide-wire-value`'s index-free fork
+  (`fork-index-paths`) matches the two — the same mechanism that lets ONE
+  `[… :data :token]` decl cover every page of an infinite feed's `:data` vector,
+  and the same reading `redact-key-declarations` walks index-free on the trace
+  side. The scope TIER keyword at index 0 of the tuple is not a declared path,
+  so it survives and attribution is preserved.
+
+  Declaration-GATED and frame-SCOPED per `project-entry-key-component`: an
+  UNDECLARED scope rides byte-identical (`:rf.scope/global` is untouched, and so
+  is an undeclared sibling of a declared identity slot), which is what preserves
+  the CEDN-1 key identity. `key-id` is the entry's CEDN-1 byte key-id. Pure
+  w.r.t. the value."
+  [scope key-id frame-id boundary-profile]
+  (project-entry-key-component scope 0 key-id frame-id boundary-profile))
 
 ;; ---------------------------------------------------------------------------
 ;; Invalid-params error-payload projection.

--- a/implementation/resources/src/re_frame/resources/classification.cljc
+++ b/implementation/resources/src/re_frame/resources/classification.cljc
@@ -29,9 +29,11 @@
   family-private resource elider. The fine-grained per-slot declarations
   are LOWERED per instance into the per-frame elision registry
   (`reconcile-registry`), and the egress boundaries READ THAT REGISTRY: the
-  SSR projector walks the entry's `:data` / scoped-key params through
-  `project-egress` SEEDED AT THE ABSOLUTE OFFSET where the lowered decls
-  live (`project-entry-data` / `project-entry-params`), so a declared slot
+  SSR projector walks the entry's `:data` and BOTH classification-bearing
+  components of its scoped key through `project-egress` SEEDED AT THE ABSOLUTE
+  OFFSET where the lowered decls live (`project-entry-data`,
+  `project-entry-scope` at `:resource/key` index 0, `project-entry-params` at
+  index 2), so a declared slot
   redacts / elides with no second derivation from the spec. This is the
   resources peer of routing's `project-routing-egress` (the
   `[:rf.runtime/routing]`-offset slice walk) and machines'
@@ -130,7 +132,9 @@
 ;; under the entry's absolute `:data` path and the `:params` / `:scope`-rooted
 ;; paths under the scoped-key carrier, writing them into the per-frame elision
 ;; registry (`reconcile-registry`) — the egress boundaries read them back from
-;; there (`project-entry-data` / `project-entry-params`). A bare-rooted path (no
+;; there (`project-entry-data` for `:data`; `project-entry-scope` /
+;; `project-entry-params` for the key's index-0 / index-2 components). A
+;; bare-rooted path (no
 ;; `:data` / `:params` head) defaults to the DATA projection — the common
 ;; `{:sensitive [[:ssn]]}` shorthand for a data field.
 ;; ---------------------------------------------------------------------------

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -130,8 +130,10 @@
 ;;     `:sensitive` / `:large` PATH declarations on the resource spec (EP-0025).
 ;;     They are LOWERED per instance into the per-frame elision registry
 ;;     (`classification/reconcile-registry`, `:source :resource`) at the entry's
-;;     absolute runtime-db path, and the SSR egress READS that registry back
-;;     (`project-entry-data` / `project-entry-params`). The per-slot
+;;     absolute runtime-db path, and the SSR egress READS that registry back —
+;;     `project-entry-data` for `:data`, and `project-entry-scope` /
+;;     `project-entry-params` for the scoped key's two classification-bearing
+;;     components (indices 0 and 2 of `:resource/key`). The per-slot
 ;;     `:sensitive?` / `:large?` props on a co-present `:data-schema` /
 ;;     `:params-schema` do NOT drive durable egress classification — the schema
 ;;     VALIDATES, it does not classify (rf2-fuqcob); a schema mark serves only
@@ -231,11 +233,14 @@
     - `:serialize` — the key rides VERBATIM (scope + params unchanged). A
       per-slot `:params` / `:scope` projection-relative declaration on a
       `:serialize` resource is the REGISTRY-DRIVEN concern of the SSR
-      `project-entry` path (`classification/project-entry-params`, rf2-d3pku1):
-      it has the entry's `key-id` + the live SSR frame, so it walks the params
-      component through `project-egress` seeded at the lowered registry path.
-      The trace / tool egress callers pass `:serialize` through verbatim (they
-      rely on the coarse disposition + the digest below, not per-slot params);
+      `project-entry` path (`classification/project-entry-params` at index 2,
+      rf2-d3pku1; `classification/project-entry-scope` at index 0, rf2-5e2ye):
+      it has the entry's `key-id` + the live SSR frame, so it walks each
+      component through `project-egress` seeded at that component's own lowered
+      registry path. The trace / tool egress callers do NOT get their per-slot
+      answer here either — `trace-egress/redact-key-declarations` (rf2-dl7bz)
+      derives the same two-component substitution from the SPEC, because a
+      frameless trace boundary cannot read the registry;
     - `:redact` / `:omit` — the scope and params are replaced by opaque
       content-addressed `{:rf/redacted <digest>}` tokens so the sensitive /
       large raw identity does NOT ride, while the resource-id (position 1) and
@@ -269,8 +274,9 @@
        `{:rf/redacted <digest>}` tokens; `:serialize` rides VERBATIM — the
        resource-id always survives. A `:serialize` key's per-slot `:params` /
        `:scope` projection-relative declarations are the registry-driven concern
-       of the SSR `project-entry` caller, `classification/project-entry-params`,
-       which has the entry's `key-id` + the live frame).
+       of the SSR `project-entry` caller — `classification/project-entry-scope`
+       at index 0 and `classification/project-entry-params` at index 2 — which
+       has the entry's `key-id` + the live frame).
 
   The single home for the pipeline the SSR durable-egress projection
   (`project-entry`), the TOOL-egress algebra view (`tooling/project-key-for-
@@ -406,18 +412,37 @@
         ;; key computed above (`disposition+project-key`), matching the wire MAP
         ;; key: a `:redact` / `:omit` resource redacts its scope + params to
         ;; opaque content-addressed tokens here too, so the raw identity never
-        ;; rides in EITHER carrier. A `:serialize` key's PARAMS component (index
-        ;; 2) is REGISTRY-PROJECTED (rf2-d3pku1): `classification/project-entry-
-        ;; params` walks it through `project-egress` seeded at the lowered params
-        ;; path so a per-slot `:params` / `:scope` declaration redacts in the wire
-        ;; key without the raw value riding. The client's `recompute-indexes`
-        ;; keys index members on the byte `key-id` of this projected
-        ;; `:resource/key`.
+        ;; rides in EITHER carrier.
+        ;;
+        ;; A `:serialize` key's BOTH classification-bearing components are
+        ;; REGISTRY-PROJECTED — the SCOPE at index 0 (rf2-5e2ye) and the PARAMS
+        ;; at index 2 (rf2-d3pku1). `reconcile-registry` lowers a `:scope`-rooted
+        ;; declaration to `[… :resource/key 0 …]` and a `:params`-rooted one to
+        ;; `[… :resource/key 2 …]`, so each component walks through
+        ;; `project-egress` seeded at its OWN lowered offset and a per-slot
+        ;; declaration redacts in the wire key without the raw value riding. Both
+        ;; arms are declaration-GATED, so an undeclared component rides
+        ;; byte-identical (the resource-id at index 1 is never a classification
+        ;; carrier and always survives).
+        ;;
+        ;; Projecting either component CHANGES the entry's `key-id`, because
+        ;; `state/key-id` is `canonical-bytes` over the WHOLE key vector. That is
+        ;; the established, intended mechanism, not a hazard:
+        ;; `project-resources-runtime-db` re-keys each wire entry on the `key-id`
+        ;; of THIS projected `:resource/key`, so the wire map key and the entry's
+        ;; own copy are one value by construction, and the client's
+        ;; `recompute-indexes` keys index members on the `:entries` map keys it
+        ;; installed. The coarse `:redact` / `:omit` arm has always re-keyed both
+        ;; components this way, and the params arm has since rf2-d3pku1.
         projected-key (if (= :serialize disposition)
                         (let [[scope rid params] projected-key]
-                          [scope rid (classification/project-entry-params
-                                       params key-id frame-id
-                                       :rf.egress/ssr-hydration)])
+                          [(classification/project-entry-scope
+                             scope key-id frame-id
+                             :rf.egress/ssr-hydration)
+                           rid
+                           (classification/project-entry-params
+                             params key-id frame-id
+                             :rf.egress/ssr-hydration)])
                         projected-key)
         wire-entry  (assoc wire-entry :resource/key projected-key)
         meta'       (assoc base
@@ -469,7 +494,34 @@
   `:large?` resource's scope + params are redacted to opaque content-addressed
   tokens in the wire key (`project-scoped-key`), so the raw identity never
   rides any more than its data does (Spec 016 clause 4). A `:serialize`
-  resource's key rides verbatim."
+  resource's key rides verbatim EXCEPT where the owner's own projection-relative
+  `:scope` / `:params` declarations name a slot, which `project-entry` walks out
+  of index 0 / index 2 against the frame's elision registry (rf2-d3pku1,
+  rf2-5e2ye).
+
+  ## The re-key is the mechanism, not a hazard (rf2-5e2ye)
+
+  `state/key-id` is `canonical-bytes` over the WHOLE `[scope resource-id params]`
+  vector, so projecting EITHER component changes it. The wire map is therefore
+  keyed on the key-id of each entry's PROJECTED `:resource/key` — the wire map
+  key and the entry's own copy are ONE value by construction, and the client
+  `recompute-indexes` over the `:entries` it installed. A declared slot's
+  redaction consequently makes the entry unaddressable by a key the client
+  re-derives from live scope + params, and it refetches — which is the SAME
+  designed consequence the coarse `:redact` / `:omit` digests have always had,
+  and which the params arm has had since rf2-d3pku1. Closing the scope
+  asymmetry extends that accepted cost by one index; it does not introduce it.
+
+  ## Build posture: ALWAYS-ON
+
+  Unlike the trace / tool key projection (`trace-egress/redact-key-declarations`,
+  rf2-dl7bz), which is dev-only — every caller sits behind
+  `interop/debug-enabled?` or bundle isolation — this projection is PRODUCTION.
+  It is the body behind `:ssr/extend-runtime-db-projection`, called from
+  `re-frame.ssr.payload-policy/project-runtime-db` on every SSR render, and its
+  output ships in the `:rf/hydration-payload` to every visitor of every page.
+  That is why the scope asymmetry mattered more here than anywhere else it
+  appeared."
   ([runtime-db]
    ;; Convenience: project under the AMBIENT scope frame. Sound only at a call
    ;; site already inside the frame's own `with-frame` (ambient == the target) —

--- a/implementation/resources/test/re_frame/resources_ssr_wire_key_scope_declaration_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_ssr_wire_key_scope_declaration_cljs_test.cljc
@@ -124,8 +124,18 @@
 
 ;; ---- helpers --------------------------------------------------------------
 
-(defn- session-scope []
-  [:rf.scope/session {:tenant-id tenant-secret :region "au"}])
+(defn- session-scope
+  "The `[tier {identity}]` tuple a `:scope`-rooted declaration has to reach
+  THROUGH. `:roles` is deliberately a LIST: Clojure `=` collapses
+  `(= [:a :b] '(:a :b))` but CEDN-1 `canonical-bytes` never does (`l(…)` vs
+  `v[…]`), so an UNNECESSARY walk of this component would reconstruct the list
+  as a vector and silently change the entry's `key-id` — the rf2-wgutc2 identity
+  break the `registry-classifies-under?` gate exists to prevent. It is what
+  makes §3's byte-identity control load-bearing rather than decorative."
+  []
+  [:rf.scope/session {:tenant-id tenant-secret
+                      :region    "au"
+                      :roles     '(:admin :ops)}])
 
 (defn- key-for
   "A key under the `[tier {identity}]` session scope — the shape a
@@ -275,11 +285,20 @@
 (deftest an-undeclared-owners-key-rides-byte-identical
   (testing "a resource declaring NOTHING must ride its key back byte-identical
             with an UNCHANGED key-id — the declaration-existence gate is what
-            preserves the CEDN-1 identity a cache-key round-trip depends on"
+            preserves the CEDN-1 identity a cache-key round-trip depends on.
+
+            The LIST-valued `:roles` slot is what gives this teeth: `=` cannot
+            see a list↔vector collapse but `canonical-bytes` can, so an
+            ungated walk would change the key-id here while every `=`
+            assertion still passed (rf2-wgutc2)"
     (let [k (install-entry! :rf/default (key-for :plain/report))
           w (wire-key :rf/default :plain/report)]
+      (is (seq? (get-in k [0 1 :roles]))
+          "premise: the canonical scoped key PRESERVES the list kind")
       (is (= k w) "the whole key is unchanged")
       (is (= (pr-str k) (pr-str w)) "…byte-for-byte, not merely `=`")
+      (is (seq? (get-in w [0 1 :roles]))
+          "…the list is still a LIST — no walker reconstruction happened")
       (is (= (state/key-id k) (state/key-id w)) "…so its key-id is unchanged")
       (is (leaks? tenant-secret w)
           "and its scope rides VERBATIM — nothing here scrubs by shape"))))

--- a/implementation/resources/test/re_frame/resources_ssr_wire_key_scope_declaration_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_ssr_wire_key_scope_declaration_cljs_test.cljc
@@ -1,0 +1,446 @@
+(ns re-frame.resources-ssr-wire-key-scope-declaration-cljs-test
+  "A `:serialize` owner's `:scope`-rooted declaration is honoured in the SSR
+  DURABLE wire key (rf2-5e2ye) — the last carrier of that value that disagreed.
+
+  ## The asymmetry this suite closes
+
+  `classification/instance-declaration-paths` has always lowered a
+  `:scope`-rooted declaration to the entry's ABSOLUTE `[… :resource/key 0 …]`
+  path exactly as it lowers a `:params`-rooted one to `[… :resource/key 2 …]`,
+  so the epoch / registry walk over the runtime-db honoured BOTH, and since
+  rf2-dl7bz `trace-egress/redact-key-declarations` honours both on every trace
+  and every tool key. But `ssr/project-entry` projected ONLY index 2. So a
+  resource declaring
+
+    (rf/reg-resource :tenant/report
+      {:sensitive [[:scope :tenant-id]] …} …)
+
+  with NO coarse `:sensitive?` root prop classifies `:serialize`, and the
+  resolved tenant id rode RAW inside `:resource/key` in the hydration payload —
+  while the SAME bytes redacted in the durable epoch export and on every trace
+  row. One value, three carriers, two rules applied: the rf2-irwsq shape.
+
+  ## Build posture: this one is ALWAYS-ON
+
+  rf2-dl7bz's trace / tool arm is DEV-ONLY — every caller sits behind
+  `interop/debug-enabled?` or bundle isolation. This one is NOT. The projection
+  under test is the body behind `:ssr/extend-runtime-db-projection`, called from
+  `re-frame.ssr.payload-policy/project-runtime-db` on every SSR render, and its
+  output ships in the `:rf/hydration-payload` to EVERY VISITOR of every page in
+  a production bundle. There is no debug gate anywhere on that path. That
+  difference is the whole reason this half of the family mattered more than the
+  half that could be reasoned about as a tool-console guarantee.
+
+  ## The re-key is the mechanism, not a hazard — §2 pins it
+
+  `state/key-id` is `canonical-bytes` over the WHOLE `[scope resource-id
+  params]` vector, so projecting EITHER component necessarily changes it. That
+  is not a new consequence of this change: `project-resources-runtime-db` re-keys
+  each wire entry on the key-id of its own PROJECTED `:resource/key`, the coarse
+  `:redact` / `:omit` digests have always re-keyed BOTH components that way, and
+  the params arm has since rf2-d3pku1. §2 pins the invariant that actually has
+  to hold — the wire MAP key and the wire ENTRY's own `:resource/key` are one
+  value — and §4 pins that the client's `recompute-indexes` round-trip still
+  lands on it. Closing the scope asymmetry extends an accepted cost by one
+  index; it does not introduce one.
+
+  ## No over-redaction — every assertion has a two-sided control
+
+  Over-redaction is a DEFECT on this surface, not a safe default (rf2-dl7bz's
+  second finding: a declaration-only owner's whole reply body tokenized and its
+  undeclared siblings vanished). §3 is the negative side: an owner declaring
+  nothing rides BYTE-identical with an UNCHANGED key-id, `:rf.scope/global` is
+  untouched, the scope TIER keyword survives, an undeclared sibling of a
+  declared identity slot stays readable, and the resource-id survives at
+  position 1 so every per-key join still lands.
+
+  Dual-target (`.cljc` + `_cljs_test`): the JVM runner picks it up via the
+  `.*-test$` ns regex, Shadow's `:node-test` build via the `cljs-test$` regex."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [clojure.string :as str]
+   [re-frame.core :as rf]
+   [re-frame.frame :as frame]
+   ;; load-bearing side-effecting require: the façade registers the
+   ;; :rf.resource/* events + subs + the :resource registrar kind, and
+   ;; publishes the trace-egress hooks the epoch tool-pair consults.
+   [re-frame.resources]
+   [re-frame.resources.classification :as classification]
+   [re-frame.resources.registry :as registry]
+   [re-frame.resources.ssr :as ssr]
+   [re-frame.resources.state :as state]
+   [re-frame.resources.trace-egress :as trace-egress]
+   ;; production HTTP fx surface (so the transport feature probe resolves).
+   [re-frame.http.managed]
+   [re-frame.schemas]
+   [re-frame.test-support :as core-test-support]
+   #?@(:clj  [[re-frame.substrate.plain-atom :as plain-atom]]
+       :cljs [[re-frame.adapter.reagent :as reagent-adapter]])))
+
+(def ^:private tenant-secret "tenant-SECRET-99")
+(def ^:private account-secret "acct-SECRET-4417")
+
+;; ---- fixture --------------------------------------------------------------
+
+(defn- init!
+  "Four owners spanning the grains this suite discriminates:
+
+    :tenant/report  — `:serialize` (NO coarse prop) + a `[:scope :tenant-id]`
+                      declaration. THE SUBJECT.
+    :both/report    — declares on BOTH components, to prove the two arms
+                      compose inside one key rather than one winning.
+    :plain/report   — declares NOTHING. The byte-identity control.
+    :sealed/report  — the COARSE `:sensitive?` owner, to prove the per-slot arm
+                      leaves the coarse whole-component digests alone."
+  []
+  (rf/make-frame {:id :rf/default :url-bound? true
+                  :doc "SSR wire-key scope-declaration suite frame."})
+  (rf/reg-resource :tenant/report
+    {:scope         :rf.scope/global
+     :sensitive     [[:scope :tenant-id]]
+     :params-schema [:map [:page :int]]}
+    (fn [_p _ctx] {:request {:method :get :url "/tenant"}}))
+  (rf/reg-resource :both/report
+    {:scope         :rf.scope/global
+     :sensitive     [[:scope :tenant-id] [:params :account-id]]
+     :params-schema [:map [:account-id :string] [:page :int]]}
+    (fn [_p _ctx] {:request {:method :get :url "/both"}}))
+  (rf/reg-resource :plain/report
+    {:scope         :rf.scope/global
+     :params-schema [:map [:page :int]]}
+    (fn [_p _ctx] {:request {:method :get :url "/plain"}}))
+  (rf/reg-resource :sealed/report
+    {:scope         :rf.scope/global
+     :sensitive?    true
+     :sensitive     [[:scope :tenant-id]]
+     :params-schema [:map [:page :int]]}
+    (fn [_p _ctx] {:request {:method :get :url "/sealed"}})))
+
+(use-fixtures :each
+  (core-test-support/make-reset-runtime-fixture
+    {:adapter #?(:clj plain-atom/adapter :cljs reagent-adapter/adapter)
+     :init-fn init!}))
+
+;; ---- helpers --------------------------------------------------------------
+
+(defn- session-scope []
+  [:rf.scope/session {:tenant-id tenant-secret :region "au"}])
+
+(defn- key-for
+  "A key under the `[tier {identity}]` session scope — the shape a
+  `:scope`-rooted declaration has to reach THROUGH."
+  ([resource-id] (key-for resource-id {:page 3}))
+  ([resource-id params]
+   (state/scoped-resource-key (session-scope) resource-id params)))
+
+(defn- install-entry!
+  "Write a durable `:loaded` entry for `scoped-key` into the frame's runtime-db
+  AND reconcile the per-frame elision registry, so the SSR durable projection
+  has the lowered declaration to read — the same two steps a real resource
+  commit folds into one atomic transition. Returns the key."
+  [frame-id scoped-key]
+  (let [resource-id (second scoped-key)]
+    (frame/swap-runtime-db!
+      frame-id
+      (fn [rdb]
+        (-> (or rdb {})
+            (assoc-in (state/entry-path scoped-key)
+                      (assoc (state/empty-entry resource-id scoped-key)
+                             :status :loaded
+                             :data   {:total 1}))
+            (classification/reconcile-registry registry/resource-meta)))))
+  scoped-key)
+
+(defn- wire-entries
+  "The projected `:entries` map exactly as it rides the `:rf/hydration-payload`'s
+  `:rf/runtime-db` slice — keyed on the byte key-id of each entry's PROJECTED
+  `:resource/key`."
+  [frame-id]
+  (get-in (ssr/project-resources-runtime-db
+            (frame/frame-runtime-db-value frame-id) frame-id)
+          [state/resources-key :entries]))
+
+(defn- wire-entry-for
+  "The single wire entry whose key names `resource-id`."
+  [frame-id resource-id]
+  (some (fn [[k-id e]]
+          (when (= (second (:resource/key e)) resource-id) [k-id e]))
+        (wire-entries frame-id)))
+
+(defn- wire-key [frame-id resource-id]
+  (:resource/key (second (wire-entry-for frame-id resource-id))))
+
+(defn- leaks?
+  "Whether `secret` survives ANYWHERE in `v` — the plaintext test."
+  [secret v]
+  (str/includes? (pr-str v) secret))
+
+;; ===========================================================================
+;; 1. THE LEAK. A `:scope`-rooted declaration must not ride raw in the SSR
+;;    hydration wire key.
+;;
+;;    This is the assertion the sibling trace suite
+;;    (`resources_trace_key_declarations_egress_cljs_test` §4) could only make
+;;    about the PARAMS component, because the scope half did not exist yet.
+;; ===========================================================================
+
+(deftest scope-rooted-declaration-does-not-ride-raw-in-the-ssr-wire-key
+  (testing "rf2-5e2ye — a resource declaring {:sensitive [[:scope :tenant-id]]}
+            with NO coarse :sensitive? prop classifies :serialize, and its
+            resolved tenant id must NOT ride raw in the hydration payload"
+    (let [k (install-entry! :rf/default (key-for :tenant/report))
+          w (wire-key :rf/default :tenant/report)]
+      (is (some? w) "premise: the SSR projection produced a wire key")
+      (is (leaks? tenant-secret k) "premise: the RAW key carries the tenant id")
+      (is (not (leaks? tenant-secret w))
+          (str "the declared [:scope :tenant-id] must not survive the SSR wire "
+               "key — got " (pr-str w)))
+      (is (= :rf/redacted (get-in w [0 1 :tenant-id]))
+          "…it is the redaction sentinel, reached index-free through the
+           [tier {identity}] tuple"))))
+
+(deftest the-whole-hydration-payload-slice-is-free-of-the-declared-scope
+  (testing "not only the entry's own :resource/key copy — the tenant id must be
+            absent from the ENTIRE projected slice, map keys included (the byte
+            key-id is a REVERSIBLE plaintext CEDN-1 encoding, so a stale raw
+            key-id in the wire MAP key would leak just as loudly)"
+    (install-entry! :rf/default (key-for :tenant/report))
+    (let [slice (ssr/project-resources-runtime-db
+                  (frame/frame-runtime-db-value :rf/default) :rf/default)]
+      (is (not (leaks? tenant-secret slice))
+          (str "the tenant id survived somewhere in the wire slice: "
+               (pr-str slice))))))
+
+(deftest both-components-of-one-key-are-projected
+  (testing "an owner declaring on BOTH components has both redacted in the ONE
+            wire key — the two arms compose rather than one winning"
+    (install-entry! :rf/default (key-for :both/report
+                                         {:account-id account-secret :page 3}))
+    (let [w (wire-key :rf/default :both/report)]
+      (is (= :rf/redacted (get-in w [0 1 :tenant-id])) "the scope arm fired")
+      (is (= :rf/redacted (get-in w [2 :account-id])) "the params arm fired")
+      (is (not (leaks? tenant-secret w)))
+      (is (not (leaks? account-secret w)))
+      (is (= :both/report (nth w 1)) "the resource-id survives at position 1")
+      (is (= 3 (get-in w [2 :page])) "the undeclared param sibling still rides")
+      (is (= "au" (get-in w [0 1 :region]))
+          "the undeclared scope sibling still rides"))))
+
+;; ===========================================================================
+;; 2. THE RE-KEYING INTERACTION — the bead's Q1, pinned rather than argued.
+;;
+;;    `state/key-id` is `canonical-bytes` over the WHOLE key vector, so
+;;    projecting index 0 CHANGES it. The invariant that has to hold is not
+;;    "the key-id is stable" — it is "the wire MAP key and the wire ENTRY's own
+;;    :resource/key are ONE value". `project-resources-runtime-db` maintains
+;;    that by construction, and always has: the coarse :redact / :omit digests
+;;    re-key both components, and the params arm re-keys index 2.
+;; ===========================================================================
+
+(deftest the-wire-map-key-is-the-key-id-of-the-projected-key
+  (testing "rf2-5e2ye Q1 — every wire entry is keyed on the byte key-id of its
+            OWN projected :resource/key, so a projected component can never
+            leave the map key and the in-entry copy disagreeing"
+    (install-entry! :rf/default (key-for :tenant/report))
+    (install-entry! :rf/default (key-for :both/report
+                                         {:account-id account-secret :page 3}))
+    (install-entry! :rf/default (key-for :plain/report))
+    (install-entry! :rf/default (key-for :sealed/report))
+    (doseq [[k-id e] (wire-entries :rf/default)]
+      (is (= k-id (state/key-id (:resource/key e)))
+          (str "wire map key must equal key-id of the entry's own projected "
+               ":resource/key — entry " (pr-str (:resource/key e)))))))
+
+(deftest projecting-the-scope-changes-the-key-id-exactly-as-params-does
+  (testing "rf2-5e2ye Q1 — the honest statement of the interaction: the raw
+            key's key-id is NOT a wire map key once a component projects, and
+            that is true of the SCOPE arm for exactly the same reason it is
+            already true of the PARAMS arm and of the coarse digests"
+    (let [scope-k  (install-entry! :rf/default (key-for :tenant/report))
+          plain-k  (install-entry! :rf/default (key-for :plain/report))
+          sealed-k (install-entry! :rf/default (key-for :sealed/report))
+          wired    (wire-entries :rf/default)]
+      (is (not (contains? wired (state/key-id scope-k)))
+          "a declared SCOPE re-keys the entry — the raw key-id is gone")
+      (is (not (contains? wired (state/key-id sealed-k)))
+          "…as the coarse whole-component digests always have")
+      (is (contains? wired (state/key-id plain-k))
+          "…while an UNDECLARED key keeps its byte identity exactly"))))
+
+;; ===========================================================================
+;; 3. NO OVER-REDACTION. The two-sided control.
+;; ===========================================================================
+
+(deftest an-undeclared-owners-key-rides-byte-identical
+  (testing "a resource declaring NOTHING must ride its key back byte-identical
+            with an UNCHANGED key-id — the declaration-existence gate is what
+            preserves the CEDN-1 identity a cache-key round-trip depends on"
+    (let [k (install-entry! :rf/default (key-for :plain/report))
+          w (wire-key :rf/default :plain/report)]
+      (is (= k w) "the whole key is unchanged")
+      (is (= (pr-str k) (pr-str w)) "…byte-for-byte, not merely `=`")
+      (is (= (state/key-id k) (state/key-id w)) "…so its key-id is unchanged")
+      (is (leaks? tenant-secret w)
+          "and its scope rides VERBATIM — nothing here scrubs by shape"))))
+
+(deftest the-declared-key-keeps-everything-not-declared
+  (testing "the scope TIER keyword, the undeclared identity sibling, and the
+            resource-id all survive, so every attribution / join a consumer
+            makes still lands"
+    (install-entry! :rf/default (key-for :tenant/report))
+    (let [w (wire-key :rf/default :tenant/report)]
+      (is (= :rf.scope/session (get-in w [0 0]))
+          "the scope TIER keyword survives (attribution)")
+      (is (= "au" (get-in w [0 1 :region]))
+          "an undeclared sibling of the scope identity stays readable")
+      (is (= :tenant/report (nth w 1)) "the resource-id survives at position 1")
+      (is (= 3 (get-in w [2 :page]))
+          "the params component is untouched — nothing is declared there"))))
+
+(deftest a-global-scope-is-never-walked
+  (testing "`:rf.scope/global` is a bare keyword, not a [tier {identity}] tuple.
+            An owner that declares nothing under :scope must leave it exactly
+            as it found it"
+    (let [k (install-entry! :rf/default
+                            (state/scoped-resource-key
+                              :rf.scope/global :plain/report {:page 3}))
+          w (wire-key :rf/default :plain/report)]
+      (is (= :rf.scope/global (nth w 0)))
+      (is (= k w))
+      (is (= (state/key-id k) (state/key-id w))))))
+
+(deftest the-entry-body-is-untouched-by-a-key-declaration
+  (testing "rf2-dl7bz's second finding, on this surface: a declaration naming
+            only the KEY must not promote the entry to a coarse claim and
+            swallow its data. Over-redaction is a defect here, not a default"
+    (install-entry! :rf/default (key-for :tenant/report))
+    (let [[_ e] (wire-entry-for :rf/default :tenant/report)]
+      (is (= {:total 1} (:data e))
+          "the body rides: this owner declares nothing under :data")
+      (is (= :loaded (:status e)) "…and the entry is still a serialized one"))))
+
+;; ===========================================================================
+;; 4. THE CLIENT ROUND-TRIP STILL LANDS (the bead's proof standard).
+;; ===========================================================================
+
+(deftest recompute-indexes-round-trips-over-the-projected-entries
+  (testing "rf2-5e2ye — the client rebuilds its reverse indexes from the
+            INSTALLED :entries rather than trusting the wire, so the index
+            members must be the projected map keys and every member must
+            resolve back to an entry"
+    (install-entry! :rf/default (key-for :tenant/report))
+    (install-entry! :rf/default (key-for :plain/report))
+    (let [wired    (wire-entries :rf/default)
+          subtree  (state/recompute-indexes {:entries wired})
+          members  (into #{} cat (vals (:owner-index subtree)))]
+      (is (= (set (keys wired))
+             (set (keys (:entries subtree))))
+          "install is lossless — one entry in, one entry out")
+      (doseq [m members]
+        (is (contains? wired m)
+            (str "index member " (pr-str m) " must resolve to an installed entry")))
+      (doseq [[k-id e] (:entries subtree)]
+        (is (= k-id (state/key-id (:resource/key e)))
+            "…and the round-tripped entry still agrees with its own key")))))
+
+;; ===========================================================================
+;; 5. ONE VALUE, THREE CARRIERS, ONE RULE. The agreement that stops a fourth
+;;    answer appearing later.
+;; ===========================================================================
+
+(deftest the-ssr-wire-key-agrees-with-the-trace-key-on-the-scope-component
+  (testing "rf2-5e2ye — the registry-driven SSR projection and the spec-derived
+            trace projection (`redact-key-declarations`, rf2-dl7bz) are TWO
+            derivations of ONE answer. They were already byte-equal on the
+            params component; this is the statement that they now are on the
+            scope component too"
+    (let [k     (install-entry! :rf/default (key-for :tenant/report))
+          wire  (wire-key :rf/default :tenant/report)
+          trace (:resource/key
+                  (trace-egress/project-resource-trace-egress
+                    {:rf.frame/id :rf/default :resource/key k} :rf/default))]
+      (is (= (pr-str (nth wire 0)) (pr-str (nth trace 0)))
+          (str "the SSR wire key's SCOPE component must be BYTE-equal to the "
+               "trace key's — wire " (pr-str (nth wire 0))
+               " vs trace " (pr-str (nth trace 0)))))))
+
+(deftest the-two-derivations-agree-on-a-key-declared-on-both-components
+  (testing "…and they agree on the WHOLE key when both components are declared"
+    (let [k     (install-entry! :rf/default
+                                (key-for :both/report
+                                         {:account-id account-secret :page 3}))
+          wire  (wire-key :rf/default :both/report)
+          trace (:resource/key
+                  (trace-egress/project-resource-trace-egress
+                    {:rf.frame/id :rf/default :resource/key k} :rf/default))]
+      (is (= (pr-str wire) (pr-str trace))
+          (str "wire " (pr-str wire) " vs trace " (pr-str trace))))))
+
+;; ===========================================================================
+;; 6. THE COARSE ARM IS UNCHANGED — the two arms compose by grain.
+;; ===========================================================================
+
+(deftest a-coarse-sensitive-owner-still-tokenizes-both-components
+  (testing "a COARSE :sensitive? owner's key still redacts to the opaque
+            content-addressed tokens, subsuming the per-slot surface. The
+            per-slot scope arm must not change what the coarse arm produces"
+    (let [k (install-entry! :rf/default (key-for :sealed/report))
+          w (wire-key :rf/default :sealed/report)]
+      (is (contains? (nth w 0) :rf/redacted) "the WHOLE scope is one token")
+      (is (contains? (nth w 2) :rf/redacted) "…and so is the whole params")
+      (is (= :sealed/report (nth w 1)) "the resource-id survives")
+      (is (not (leaks? tenant-secret w)))
+      (is (= w (ssr/project-scoped-key k :redact nil))
+          "byte-for-byte what `project-scoped-key` alone produces"))))
+
+;; ===========================================================================
+;; 7. THE rf2-dl7bz DEFERRAL IS STILL INTACT. `project-scoped-key` was NOT
+;;    widened by this change either.
+;;
+;;    The standing statement lives in
+;;    `resources_trace_key_declarations_egress_cljs_test` §5
+;;    (`project-scoped-key-still-defers-on-serialize`); this is the local
+;;    restatement, so a future reader of THIS suite sees the fence too.
+;; ===========================================================================
+
+(deftest project-scoped-key-still-defers-on-serialize-for-a-scope-declaration
+  (testing "rf2-dl7bz ruling — the per-slot answer is the REGISTRY's on this
+            path (it has the entry's key-id and the live frame). The shared
+            `project-scoped-key` still rides a `:serialize` key verbatim and
+            still ignores its spec, for a :scope declaration exactly as for a
+            :params one. This test reds if anyone moves the arm into the
+            shared projection"
+    (let [k    (key-for :tenant/report)
+          spec (registry/resource-meta :tenant/report)]
+      (is (= k (ssr/project-scoped-key k :serialize spec))
+          "`:serialize` still rides VERBATIM through `project-scoped-key`")
+      (is (= (ssr/project-scoped-key k :serialize spec)
+             (ssr/project-scoped-key k :serialize nil))
+          "…and it still ignores the spec argument, exactly as documented"))))
+
+;; ===========================================================================
+;; 8. THE UNIT, DIRECTLY. `project-entry-scope` is the co-equal sibling of
+;;    `project-entry-params` — same gate, same frame-scoping, different index.
+;; ===========================================================================
+
+(deftest project-entry-scope-is-frame-scoped-and-declaration-gated
+  (testing "the two guards `project-entry-params` carries, on the scope arm"
+    (let [k      (install-entry! :rf/default (key-for :tenant/report))
+          key-id (state/key-id k)
+          scope  (nth k 0)]
+      (is (= :rf/redacted
+             (get-in (classification/project-entry-scope
+                       scope key-id :rf/default :rf.egress/ssr-hydration)
+                     [1 :tenant-id]))
+          "under a live frame with the declaration lowered, the slot redacts")
+      (is (= scope (classification/project-entry-scope
+                     scope key-id nil :rf.egress/ssr-hydration))
+          "a nil frame rides the scope VERBATIM — the registry is frame-scoped")
+      (let [plain-k (install-entry! :rf/default (key-for :plain/report))]
+        (is (= (nth plain-k 0)
+               (classification/project-entry-scope
+                 (nth plain-k 0) (state/key-id plain-k)
+                 :rf/default :rf.egress/ssr-hydration))
+            "an UNDECLARED offset rides the scope VERBATIM — no walk, no
+             list↔vector collapse, byte identity preserved")))))


### PR DESCRIPTION
Closes rf2-5e2ye. The sibling half of rf2-dl7bz (#7254), one index over.

## The asymmetry

`classification/instance-declaration-paths` has always lowered a `:scope`-rooted declaration to the entry's absolute `[… :resource/key 0 …]` path exactly as it lowers a `:params`-rooted one to `[… :resource/key 2 …]`, so the epoch / registry walk honoured **both**, and since rf2-dl7bz `trace_egress/redact-key-declarations` honours both on every trace and every tool key. But `ssr/project-entry` projected **only index 2**.

So a resource declaring `{:sensitive [[:scope :tenant-id]]}` and no coarse `:sensitive?` root prop classifies `:serialize`, and its resolved tenant id rode **RAW** inside `:resource/key` in the hydration payload — while the same bytes redacted in the durable epoch export and on every trace row. One value, three carriers, two rules applied.

This was the last carrier that disagreed, and **the only one that is not dev-gated**.

## Build posture: this half is ALWAYS-ON

rf2-dl7bz's arm is dev-only — every caller sits behind `interop/debug-enabled?` or bundle isolation, and #7254's suite docstring said so rather than implying a production guarantee. This projection is **production**. It is the body behind `:ssr/extend-runtime-db-projection`, called from `payload-policy/project-runtime-db` on every SSR render, and its output ships in the `:rf/hydration-payload` to **every visitor of every page** in a production bundle. There is no debug gate anywhere on that path. That difference is the whole reason this half mattered more.

## The re-keying interaction — established by reading and running, before anything changed

The bead flagged this as the reason it was P3, so it was settled first, with a throwaway probe against the real runtime rather than by argument.

**`state/key-id` is `identity/canonical-bytes` over the WHOLE `[scope resource-id params]` vector** — the scope component is inside the hashed bytes. So projecting index 0 **does** change the key-id.

**But that is the established mechanism, not a hazard, and the probe showed it already firing:**

- `project-resources-runtime-db` re-keys each wire entry on `(state/key-id (:resource/key wire-entry))` — the key-id of the **projected** key. The wire map key and the entry's own copy are therefore one value by construction, since `project-entry` sets both from the same `projected-key`.
- The coarse `:redact` / `:omit` digests have always re-keyed **both** components this way, and the params arm has since rf2-d3pku1. The probe confirmed the raw key-id of a params-declaring entry is already absent from the wire map today.
- `recompute-indexes` keys index members on the `:entries` map keys it installed, so the client round-trip lands on the projected identity.

The honest consequence, stated rather than glossed: a declared slot makes the entry unaddressable by a key the client re-derives from live scope + params, and it refetches. That is the **same** designed consequence the coarse arm and the params arm already carry. This extends an accepted cost by one index rather than introducing one. `§2` and `§4` of the new suite pin exactly that.

## The change

`project-entry-params` and the new `project-entry-scope` are now two names for **one** parameterised body (`project-entry-key-component`), differing in the index alone — the scope and params components carry the same classification (Spec 016 clause 4), so they must not be able to drift into two rules again. Both keep the `registry-classifies-under?` declaration gate and the frame-scoping.

Not a scrub: the substitution is driven by the closed set of paths the owner **declared** and lowered into the registry, and touches nothing else. The value substituted is the value-free `:rf/redacted` sentinel — no payload-derived digest is introduced on this path. The `[tier {identity}]` scope tuple is reached by `elide-wire-value`'s index-free fork, the same mechanism that lets one `[… :data :token]` decl cover every page of an infinite feed.

**The rf2-dl7bz ruling is untouched.** `ssr/project-scoped-key`'s `:serialize` deferral still rides verbatim and still ignores its `spec`; `project-scoped-key-still-defers-on-serialize` stays green. Only its docstring changed, to stop naming the params arm as if it were the whole registry-driven answer.

Fenced to the scope component. `implementation/ssr/**`, `tools/**`, `spec/**` untouched.

## The test

New suite, 15 tests / 49 assertions, dual-target `.cljc`, green in **both** JVM postures.

**Mutation-proved twice**, because the first attempt caught only half of what it claimed:

1. Removing the scope arm from `project-entry` → **8 failures across 6 tests** (the leak assertion, a whole-slice plaintext scan, the re-key statement, and both cross-carrier agreement tests).
2. Removing the `registry-classifies-under?` gate → initially **passed**, which meant the "rides byte-identical" control was decorative. `=` cannot see a list↔vector collapse but CEDN-1 `canonical-bytes` can, so the undeclared owner's scope now carries `:roles '(:admin :ops)`. With that, dropping the gate reds **4 assertions** (rf2-wgutc2). The no-over-redaction side is now load-bearing.

Over-redaction is a defect on this surface, not a safe default — rf2-dl7bz's second finding. Every positive assertion has a two-sided control: an undeclared owner rides byte-identical with an unchanged key-id, `:rf.scope/global` is untouched, the scope tier keyword survives, an undeclared sibling of a declared identity slot stays readable, the resource-id survives at position 1, and a key-only declaration does not swallow the entry's `:data`.

## Quality gates

Foreground, worktree-local, exit codes echoed.

| gate | result | exit |
|---|---|---|
| `implementation/resources` JVM (dev posture) — 772 tests / 6983 assertions | 0 failures, 0 errors | **0** |
| `implementation/resources` JVM (`-Dre-frame.debug=false`) — 772 tests / 6930 assertions | 267 failures — **exactly the origin/main baseline** (see below) | 1 |
| `implementation/ssr` JVM — 592 tests / 2892 assertions | 0 failures, 0 errors | **0** |
| `implementation/epoch` JVM — 539 tests / 7131 assertions | 0 failures, 0 errors | **0** |
| `re-frame.egress-chokepoint-conformance-test` (core source-scan) — 3 tests / 7 assertions | 0 failures, 0 errors | **0** |
| `resources_trace_key_declarations_egress` (rf2-dl7bz standing suite, incl. `project-scoped-key-still-defers-on-serialize`) — 14 tests / 48 assertions | 0 failures, 0 errors | **0** |
| new suite alone — 15 tests / 49 assertions | 0 failures, 0 errors | **0** |
| mutation 1 (scope arm removed) | 8 failures / 6 tests — **reds as designed** | 1 |
| mutation 2 (declaration gate removed) | 4 failures — **reds as designed** | 1 |

**On the prod-posture row.** `implementation/resources` has no `prod-gate` lane (`scripts/` has core / freehand / routing / ssr only, and its `deps.edn` has no `:prod-gate` alias) because the suite is not prod-posture-clean: 267 assertions are trace-emit stamps that `-Dre-frame.debug=false` disables by design. Rather than assert that, it was measured: the same command at `origin/main` (`ae1fb9b577`) with this suite moved aside runs **757 tests / 6881 assertions, 267 failures**. This branch runs **772 / 6930, 267 failures** — `+15` tests, `+49` assertions, **`+0` failures**. The new suite is green under the prod posture too.

Deferred to CI: CLJS / node-test targets, the browser smoke lane, bundle-isolation, and the full spine.
