### PR TITLE
docs(hicasso): draft user guide first cut (rf2-2rtt6.6)

### DIFF
--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -1,0 +1,166 @@
+# Getting started
+
+> **Pre-implementation draft — Hicasso does not exist yet.** This page describes the
+> *designed* surface so it can be read before it is built. Spellings marked
+> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
+> is rewritten after the P2 fork ruling, against a real implementation. Normative
+> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+
+Booting a re-frame2 app today takes about thirty lines: create a React root, install
+an adapter, render a `frame-root` inside it, remember the root across hot reloads so
+React doesn't get a second `create-root` for a live node. Every app writes the same
+thirty lines and every app gets one of them subtly wrong at least once.
+
+Hicasso collapses that into one call. HD-021 pins the semantics: **one root
+operation associates a DOM node, a frame, and initial events, and returns an
+idempotent teardown.** The names wait for the donor spike; the behaviour does not.
+
+## Your first app
+
+Three namespaces, in the shape any re-frame2 app already uses.
+
+```clojure
+(ns todo.events
+  (:require [re-frame.core :as rf]))
+
+(rf/reg-event :todo/initialise
+  (fn [_cofx _event]
+    {:db {:todos [{:id 1 :title "Read the draft guide" :done? false}]}}))
+
+(rf/reg-event :todo/toggle
+  (fn [{:keys [db]} [_ id]]
+    {:db (update db :todos
+                 (fn [todos]
+                   (mapv #(cond-> % (= id (:id %)) (update :done? not))
+                         todos)))}))
+```
+
+```clojure
+(ns todo.subs
+  (:require [re-frame.core :as rf]))
+
+(rf/reg-sub :todo/all
+  (fn [db _query] (:todos db)))
+```
+
+```clojure
+(ns todo.views
+  (:require [re-frame.hicasso :as h :refer [defview sub]]))
+
+(defview todo-app [_]
+  [:ul
+   (for [{:keys [id title done?]} (sub [:todo/all])]
+     [:li {:key id}
+      [:label
+       [:input {:type :checkbox :checked done? :on-change [:todo/toggle id]}]
+       title]])])
+```
+
+And the boot namespace, which is the actual subject of this page:
+
+```clojure
+(ns todo.main
+  (:require [re-frame.hicasso :as h]
+            ;; Required for their registrations, not for anything named here.
+            [todo.events]
+            [todo.subs]
+            [todo.views :as views]))
+
+(defonce stop!                                    ;; h/root! is [unfrozen]
+  (h/root! (js/document.getElementById "app")
+           {:frame          :rf/default
+            :initial-events [[:todo/initialise]]}
+           [views/todo-app {}]))
+```
+
+That is the whole boot. `h/root!` **[unfrozen]** takes the DOM node, a config map,
+and one view, and hands back a teardown function.
+
+`:initial-events` behaves exactly as it does under
+[`frame-root`](../../../core/how-to/boot-and-mount-an-app.md): ordinary events, run
+once in order, seeding app-db before first paint. Even initial values arrive by
+event — that rule does not change because the view layer did.
+
+## The teardown
+
+`h/root!` returns a function. Call it and the root unmounts, the subscriptions
+release, and the DOM node is yours again:
+
+```clojure
+(stop!)   ;; idempotent — calling it twice is not an error
+```
+
+Idempotence is in the ruling, not a courtesy. Teardown paths get called from
+`finally` blocks, test fixtures, and reload hooks that don't coordinate, so a second
+call has to be a no-op rather than a crash.
+
+The standing assertion behind it is worth knowing even if you never write it
+yourself: **zero leaked subscription ref-counts after teardown**. If a root goes
+away and a subscription cache entry survives, that is a bug in Hicasso, not a
+lifecycle subtlety you were supposed to manage.
+
+## Hot reload
+
+HD-021 gives hot reload a floor rather than a mechanism. After a body swap:
+
+- the root, the frame, and app-db survive;
+- the changed view body is the one that runs;
+- no subscriptions leak.
+
+Preserving hook-local state across a swap is explicitly optional, so don't build on
+it.
+
+Note what the floor implies for the code above. `defonce` keeps the root alive
+across reloads, and the guarantee says the *changed body* is used — so on the
+designed behaviour a `^:dev/after-load` remount hook is not part of the story.
+Whether a swap needs an explicit re-render call, or `defview` re-reads its var and
+the next commit picks the change up for free, is a mechanism question the record
+leaves open. See **Not settled yet**.
+
+If you edit `:todo/initialise` itself and want the new seed to run, reset the frame
+or reload the page. Hot reload preserves state by design, and it will happily
+preserve it right past your edited setup event.
+
+## More than one frame
+
+`:frame` names the frame the root ensures, the same way `:id` does for `frame-root`.
+Two roots with two different frame ids give you two isolated apps on one page — own
+app-db, own queue, own subscription cache. This is how the multi-frame witnesses in
+[validation.md](../validation.md) are built, and views inside one root never reach
+into another frame's state.
+
+## Troubleshooting
+
+No Hicasso error ids exist yet, so this table names mechanisms rather than
+`:rf.error/*` ids. Expect the real guide to replace the middle column with minted
+ids.
+
+| Symptom | What went wrong | Fix |
+|---|---|---|
+| `sub` throws outside a view | `sub` is render-scoped; there is no `@`-anywhere in Hicasso | Use `rf/subscribe-once` in handler and utility code |
+| Async callback dispatches and nothing happens | A bare `dispatch` from a timeout has no frame | Callbacks generated from intent vectors carry their boundary's frame; hand-written async needs the frame explicitly |
+| First paint shows empty state, then flickers | Seeding raced the first render | Seed through `:initial-events`, not a post-mount dispatch |
+| A view renders twice on mount in dev | React StrictMode double-invokes bodies | Nothing to fix — bodies are pure and re-runnable by contract |
+| Second `h/root!` on the same node | The node already has a live root | Keep the root in a `defonce`; call the teardown before re-rooting |
+
+## When not to use this
+
+**Server-side rendering is out of v0**, explicitly (HD-020). `defview` bodies stay
+`.cljc`-compatible by construction, so nothing is being painted into a corner, but no
+JVM or SSR render path ships in v0 and `defhost`'s SSR-placeholder default is inert
+policy for a later phase. If you need SSR now, use a
+[Reagent or UIx adapter](../../../core/views.md), which are first-class and
+supported.
+
+The same applies to the whole programme, not just this page: adapters continuing to
+be the answer is a *successful* outcome for Hicasso, not a failure mode.
+
+## Not settled yet
+
+| Question | Status |
+|---|---|
+| The root operation's name, its config keys, and the teardown's name | Semantics pinned by HD-021; names explicitly unfrozen until the donor spike |
+| Does `rf/init!` and adapter installation still apply? | **Not addressed.** Hicasso is a native view layer rather than an adapter, but the record never says whether the root operation subsumes process setup or whether an `init!`-equivalent survives |
+| May a boundary child omit its props map — `[views/todo-app]` rather than `[views/todo-app {}]`? | **Not addressed.** HD-016 says bodies take a single props map; whether the map is optional at the call site is unstated. This page writes `{}` to stay inside what is ruled |
+| Does a hot-reload body swap need an explicit re-render call? | **Not addressed.** HD-021 pins the guarantees, not the mechanism |
+| Where the frame config other than `:initial-events` goes | **Not addressed.** `frame-root` takes a config map today; whether the root operation passes one through is unstated |

--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -56,6 +56,10 @@ Three namespaces, in the shape any re-frame2 app already uses.
        title]])])
 ```
 
+That view reads with `sub`, which is the *collector* surface — one of two candidates
+still under adjudication. [Views and reads](02-views-and-reads.md) covers both and
+explains why this draft doesn't choose. Nothing on this page turns on it.
+
 And the boot namespace, which is the actual subject of this page:
 
 ```clojure

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -1,0 +1,271 @@
+# Views and reads
+
+> **Pre-implementation draft — Hicasso does not exist yet.** This page describes the
+> *designed* surface so it can be read before it is built. Spellings marked
+> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
+> is rewritten after the P2 fork ruling, against a real implementation. Normative
+> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+
+A Hicasso view is a function from a props map to hiccup, which reads whatever
+subscriptions it needs along the way. That much is settled and has been since the
+charter.
+
+**How the reads are spelled is not.** HD-002 has two candidate surfaces in the ring
+and a measurement scheduled to choose between them. This page teaches both, because
+that is the honest state of the design — and because if you skip to one of them you
+will pick the wrong one about half the time.
+
+Everything before the fork applies to both.
+
+## Boundaries and inlining
+
+Two ways to reach another function from a view body, and the difference is visible
+in the syntax.
+
+```clojure
+[todo-row {:key id :id id}]   ;; a vector — a BOUNDARY child
+(todo-row {:id id})           ;; a call — INLINED into the enclosing boundary
+```
+
+A **vector** in head position mints a React element. It is its own boundary: React
+owns its identity, and it can re-render without its parent.
+
+A **plain call** is just a function call. Its hiccup is spliced into the caller's
+tree, it has no boundary of its own, and — this is the part that matters for
+performance — any subscription it reads donates that read *upward* to the enclosing
+boundary. Helpers are free; they cost nothing and buy nothing.
+
+One rule, one visible distinction. This is deliberate: re-render granularity is a
+thing you should be able to see by reading the source, and Reagent's `^{:key}`
+metadata folklore is deleted along with it. Keys go in the props map:
+
+```clojure
+(defview todo-list [_]
+  [:ul
+   (for [id (sub [:todo/visible-ids])]     ;; read surface — see the fork below
+     [todo-row {:key id :id id}])])
+```
+
+A bare seq of boundary children needs keys, and you get a dev warning if you forget.
+The `for`-lowering sugar that would derive the key from the binding is **not v0** —
+you write `:key` yourself. A plain function in head position (`[todo-row {...}]`
+where `todo-row` is not a view) is a loud error rather than a silent embedding.
+
+### The component ABI
+
+HD-016 pins this table, and the keyed insert/delete/reorder witness enforces it.
+
+| Head | Props | Children | `:key` | `:ref` |
+|---|---|---|---|---|
+| Native tag — `[:div …]` | attribute map | trailing forms | `:key` in the attribute map | callback ref, legal |
+| Hicasso view — `[todo-row …]` | one props map | trailing forms, arriving as `(:children props)` | in the props map, **extracted before your body sees props** | not a v0 surface — use ids |
+| Fragment — `[:<> …]` | — | trailing forms | on the fragment's props map | — |
+| Foreign — `defhost` or `[:>]` | converted per declaration | hiccup children become elements | `:key` in props | callback ref, legal |
+
+Children arrive realized and predictably flattened: nested and lazy sequences are
+realized once and flattened one level, `nil` and `false` render nothing, `true` is an
+error, and an existing React element is a legal child anywhere. A view may return
+`nil`, a single root, or a fragment.
+
+`:key` never reaches your body. That is React's contract, not a Hicasso choice, and
+pretending otherwise would be the kind of leaky convenience that costs you a day
+when it finally bites.
+
+### Bodies are pure and re-runnable
+
+React StrictMode runs your body twice in development. That is fine — bodies are pure
+by contract. Anything that would break under a second run (mutating a captured atom,
+kicking off a fetch, counting renders) does not belong in a body.
+
+### There is no automatic memoization
+
+React semantics stand: a child may render because its parent did. Hicasso adds **no
+default `=` or argv comparison** (HD-006).
+
+If you are coming from Reagent this is the change most likely to surprise you.
+Reagent compares argv and skips; Hicasso does not, because every default comparison
+is a cost every render pays whether it helps or not. Narrow updates come from
+**where you put your boundaries**, and `React.memo` is available as an explicit
+opt-out when you have measured a reason.
+
+## The fork: how a view reads a subscription
+
+HD-002 ranks three tiers. One of them is not a product surface at all — **scalar
+per-read hooks** (one `useSyncExternalStore` per read, the raw UIx spine) are a
+measurement control only. They can't be the product: N reads means N hooks, which
+blows HD-020's ≤2-hook budget on the very first realistic view, and React's hook
+rules forbid reading conditionally.
+
+That leaves two real candidates, and this guide does not pick between them, because
+**HD-002 is a measurement and the measurement has not run.**
+
+### Surface A — grouped `use-subs` (the current default)
+
+One hook, at the top of the body, receiving every query the body needs. The hook
+count and order are fixed; the *query values* are free to vary.
+
+```clojure
+(ns todo.views
+  (:require [re-frame.hicasso :as h :refer [defview use-subs]]))
+
+(defview todo-row [{:keys [id]}]
+  (let [{:keys [todo editing? draft]}
+        (use-subs {:todo     [:todo/by-id id]
+                   :editing? [:todo.ui/editing? id]
+                   :draft    [:todo.ui/draft id]})]
+    [:li
+     [:span (:title todo)]
+     [:button {:on-click [:todo/toggle id]} "✓"]
+     (when editing?
+       [:input {:value draft :on-input [:todo.ui/edit id ::h/value]}])]))
+```
+
+`use-subs` **[unfrozen]** takes a map of names to query vectors and returns a map of
+names to values. You destructure it and use plain locals for the rest of the body.
+
+**Status.** This is the **product default** today. It is the only budget-compliant
+surface with a fixed hook count, and HD-002 requires it to be dogfooded from the
+start of P1 rather than held in reserve — precisely so that if the challenger loses,
+the fallback is a surface that has already been scored, not one discovered mid-clock.
+
+**What it costs you.** Reads sit at fixed sites, so conditional reads need a
+different shape. Two moves cover it:
+
+```clojure
+;; 1. Conditionally-constructed query values, at a fixed site.
+(defview article [{:keys [id draft?]}]
+  (let [{:keys [body]} (use-subs {:body (if draft?
+                                          [:article/draft-body id]
+                                          [:article/published-body id])})]
+    [:article body]))
+
+;; 2. A conditional child boundary — the read moves into the child,
+;;    which only exists when the condition holds.
+(defview article-comments [{:keys [id]}]
+  (let [{:keys [comments]} (use-subs {:comments [:comments/for id]})]
+    [:ul (for [c comments] [comment-row {:key (:id c) :comment c}])]))
+
+(defview article-page [{:keys [id show-comments?]}]
+  [:<>
+   [article {:id id}]
+   (when show-comments? [article-comments {:id id}])])
+```
+
+The second move is the one to internalise: **a conditional read is a conditional
+boundary.** Which is often the right design anyway, since it is also where you
+wanted the re-render granularity.
+
+There is a sharper consequence for helpers. An inlined helper cannot call `use-subs`
+— it would be a hook in a function called conditionally, which React forbids. So
+under Surface A, helpers take values as arguments and read nothing:
+
+```clojure
+(defn- badge [{:keys [count]}]         ;; plain fn, plain args, no reads
+  [:span.badge count])
+```
+
+That inference is this guide's, not a ruling; see **Not settled yet**.
+
+### Surface B — the ambient collector (the challenger)
+
+`sub` is an ordinary function call. Call it anywhere in the body: inside a `when`,
+inside a `for`, inside an inlined helper. One fixed runtime hook collects the reads,
+and the runtime diffs the edge set after the body returns.
+
+```clojure
+(ns todo.views
+  (:require [re-frame.hicasso :as h :refer [defview sub]]))
+
+(defview todo-row [{:keys [id]}]
+  (let [todo     (sub [:todo/by-id id])
+        editing? (sub [:todo.ui/editing? id])]
+    [:li
+     [:span (:title todo)]
+     [:button {:on-click [:todo/toggle id]} "✓"]
+     (when editing?
+       [:input {:value    (sub [:todo.ui/draft id])   ;; read inside a conditional
+                :on-input [:todo.ui/edit id ::h/value]}])]))
+```
+
+Note the third read: it happens only when `editing?` is true, in the middle of an
+expression, and that is the entire point of the surface.
+
+**Status.** This is the **challenger**, and HD-002 says it is ridden hardest in P1 —
+but it ships only by *winning*. It is the same mechanism class as the per-read
+dependency ledger that the predecessor programme measured as its single largest
+cost, so it has to earn its place rather than defend it. There is a standing
+tripwire that **overrides the clock**: the first time correctness requires a
+candidate ledger or generic post-render dependency reconciliation, the collector
+dies, however good its numbers look.
+
+**What it buys you.** The census's tier-1 shape is conditional-reads-legal, and most
+of the authoring differentiation against raw UIx lives here. Helpers can read.
+Loops can read. You write the obvious thing.
+
+### How this gets decided
+
+Four adjudication clauses are pinned before any P1 code is written:
+
+1. a render/commit **ownership state machine** — how a candidate read survives a
+   winning render and disappears after an abandoned render, a replay, or a teardown;
+2. the **exact allowed edge-diff operation**, distinguished from the ledger class
+   that trips the kill rule;
+3. **two pre-registered strategy hypotheses**, each counted only by a benchmarked
+   commit — tuning passes don't count;
+4. the **survival metric** — steady-state allocation slope across warm 1/3/7/20
+   reads, plus zero retained per-occurrence objects after commit or teardown.
+
+Three outcomes, and only three. Collector wins and becomes the product mechanism;
+collector loses and grouped stays the default; **both fail their gates and the
+outcome is null.** There is no fourth read model, and there is no "internal swap" —
+either way this is an API choice made on evidence, in public.
+
+The dogfood screen is written in all three renderings — collector, grouped, and raw
+UIx — and judged on diff and on the authors' preference. Ergonomics is half the
+verdict, not a tiebreaker.
+
+## Reads that are the same either way
+
+Whichever surface wins:
+
+- **Reading outside a render is an error.** There is no `@`-anywhere. Handler and
+  utility code uses `rf/subscribe-once`, which is a one-shot read that retains no
+  reactive handle.
+- **Framework subscriptions read identically to your own** — machine tags, resource
+  and mutation state, route identity. They are 27% of the census's read traffic, so
+  the index serves them first-class rather than as a special case.
+- **Sub-key identity is `(query-id, args)` under value equality.** Building a fresh
+  map as a query argument on every render will thrash the index. Documented,
+  programmer-trusted, not policed.
+
+## Troubleshooting
+
+No Hicasso error ids exist yet; this table names mechanisms.
+
+| Symptom | What went wrong | Fix |
+|---|---|---|
+| A child re-renders whenever its parent does | Expected — there is no default memoization (HD-006) | Move the boundary, or apply `React.memo` where you measured a reason |
+| One cell changes and 300 boundaries re-render | The read lives too high in the tree | Push the read down into the boundary that displays it |
+| Nothing re-renders when app-db changes | The value was passed down as a prop instead of read where it is used | Read at the point of use |
+| Hook-order error in a helper | Surface A only: a hook in a conditionally-called function | Helpers take values as arguments; keep `use-subs` in view bodies |
+| Index thrash, subscriptions constantly re-created | Unstable query args — a fresh map or vector each render | Pass values with stable identity under `=` |
+| A body's side effect fires twice | StrictMode double-invoke | Bodies are pure; move the effect out |
+
+## When not to use a boundary
+
+Not every function needs to be a view. If a piece of markup has no reads of its own
+and always re-renders with its parent anyway, a plain function is cheaper and
+simpler — no element, no identity, no index membership. Boundaries are for
+*re-render granularity*. Reach for one when you want something to update
+independently, not because the markup got long.
+
+## Not settled yet
+
+| Question | Status |
+|---|---|
+| Which read surface ships | **Open by design.** HD-002 is decided by P1 measurement; three outcomes, including null |
+| `use-subs` and `sub` spellings | Pre-declared working names; [authoring.md](../authoring.md) holds all declaration spellings unfrozen until the tournament |
+| Does `use-subs` accept anything but a map — a vector of queries, a single query? | **Not addressed.** Only the map form appears in the record |
+| Can an inlined helper read under Surface A? | **This guide's inference is no** (React hook rules), and helpers therefore take values as arguments. The record states the consequence only for the collector case — HD-016 calls helper-donated reads "collector-contingent" — and never spells out the grouped-surface answer |
+| `defview`'s own spelling and whether a props-map argument is required | Working name; the single-props-map body signature is ruled by HD-016 |
+| The dev warning for an unkeyed seq — its id and whether it is dev-only | **Not addressed** beyond "dev warning" |

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -33,7 +33,8 @@ owns its identity, and it can re-render without its parent.
 A **plain call** is just a function call. Its hiccup is spliced into the caller's
 tree, it has no boundary of its own, and — this is the part that matters for
 performance — any subscription it reads donates that read *upward* to the enclosing
-boundary. Helpers are free; they cost nothing and buy nothing.
+boundary. Helpers cost nothing at runtime and buy no re-render granularity, which is
+the trade in one sentence.
 
 One rule, one visible distinction. This is deliberate: re-render granularity is a
 thing you should be able to see by reading the source, and Reagent's `^{:key}`
@@ -42,14 +43,15 @@ metadata folklore is deleted along with it. Keys go in the props map:
 ```clojure
 (defview todo-list [_]
   [:ul
-   (for [id (sub [:todo/visible-ids])]     ;; read surface — see the fork below
+   (for [id (sub [:todo/visible-ids])]     ;; collector spelling — see the fork below
      [todo-row {:key id :id id}])])
 ```
 
 A bare seq of boundary children needs keys, and you get a dev warning if you forget.
 The `for`-lowering sugar that would derive the key from the binding is **not v0** —
-you write `:key` yourself. A plain function in head position (`[todo-row {...}]`
-where `todo-row` is not a view) is a loud error rather than a silent embedding.
+you write `:key` yourself. Putting a plain `defn` in head position — `[badge {...}]`
+where `badge` was never minted by `defview` — is a loud error rather than a silent
+embedding.
 
 ### The component ABI
 

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -1,0 +1,136 @@
+# Events as data
+
+> **Pre-implementation draft — Hicasso does not exist yet.** This page describes the
+> *designed* surface so it can be read before it is built. Spellings marked
+> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
+> is rewritten after the P2 fork ruling, against a real implementation. Normative
+> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+
+Handler attributes are where a data-oriented view layer usually gives up. You have
+been writing pure data all the way down the tree, and then `:on-click` needs a
+function, so you write `#(rf/dispatch [:todo/toggle id])` and the node stops being
+inspectable, comparable, or assertable by equality.
+
+Hicasso's answer: **put the event vector in the attribute.** The runtime builds the
+callback.
+
+```clojure
+[:button {:on-click [:todo/toggle id]} "✓"]
+```
+
+That is not sugar for a closure you could have written. The tree still holds data at
+that node, which means a test can assert it with `=` and a tool can read it.
+
+## The value placeholder
+
+Most handlers need something out of the event object. `::h/value` **[unfrozen]** is
+the placeholder that gets substituted at dispatch time:
+
+```clojure
+[:input {:value    draft
+         :on-input [:todo.ui/edit id ::h/value]}]
+```
+
+At dispatch, the placeholder is replaced by the input's value, so the handler
+receives `[:todo.ui/edit 7 "milk"]` — an ordinary event vector, indistinguishable
+from one you dispatched by hand.
+
+The census says this covers about **97% of the corpus's 183 handler sites**. That
+number is why the placeholder exists: one marker turns nearly every handler
+attribute in a real application into data.
+
+## Functions still work
+
+An ordinary function remains legal at any event position:
+
+```clojure
+[:canvas {:on-pointer-move (fn [e] (draw! (.-clientX e) (.-clientY e)))}]
+```
+
+Use one when you genuinely need the event object — geometry, pointer capture, an
+imperative call. The intent vector is the taught default because it covers almost
+everything, not because functions are forbidden.
+
+## Policy defaults the runtime owns
+
+Two things a form does every single time, and every codebase reimplements badly.
+
+### Submit auto-prevents
+
+An intent vector at `:on-submit` prevents the browser's default navigation:
+
+```clojure
+[:form {:on-submit [:signup/submit]}
+ [:input {:value email :on-input [:signup/set-email ::h/value]}]
+ [:button {:type :submit} "Sign up"]]
+```
+
+No `(.preventDefault e)`. It is census-weighted policy — forms in the corpus wanted
+it every time — so the runtime does it and offers an opt-out for the rare case that
+doesn't. The opt-out's spelling is not in the record; see **Not settled yet**.
+
+### The key map
+
+Keyboard handling arrives as data, not as a `case` over `.-key`:
+
+```clojure
+[:input {:value    draft
+         :on-input [:todo.ui/edit id ::h/value]
+         :on-keydown {"Enter"  [:todo.ui/commit id]
+                      "Escape" [:todo.ui/cancel id]}}]
+```
+
+A map from key name to intent. Keys you don't list are ignored.
+
+The reason this belongs in the runtime rather than in your view is the composition
+law: **a composing Enter commits nothing.** Mid-IME, Enter selects a candidate — it
+is not a submit, and treating it as one is how a Japanese or Chinese user loses a
+sentence. The runtime centralises that check, including the legacy keyCode-229
+signal that some browsers still use to say "this keystroke belongs to the IME."
+
+Get this wrong in your own handler and it fails silently for every user who
+composes. Which is a good argument for it not being your handler.
+
+## Callbacks carry their frame
+
+A generated callback closes over its boundary's frame, resolved once per boundary
+from the substrate's single internal context.
+
+That matters because the browser invokes the callback long after the render that
+created it, when the render's dynamic extent is gone. A hand-written
+`#(rf/dispatch …)` from an async context raises `:rf.error/no-frame-context` for
+exactly this reason. Intent vectors don't, because the frame was captured when the
+callback was built.
+
+The rule of thumb: **intents are always safe; hand-written async needs the frame
+explicitly.**
+
+## Troubleshooting
+
+No Hicasso error ids exist yet; this table names mechanisms.
+
+| Symptom | What went wrong | Fix |
+|---|---|---|
+| Page navigates and reloads on form submit | Something bypassed the intent path — a hand-written `:on-submit` function | Use an intent vector, or call `.preventDefault` yourself in the function |
+| Handler receives the placeholder keyword instead of a value | The placeholder was used at an event position with no value to substitute | `::h/value` is for value-bearing events; read the event object with a function elsewhere |
+| Enter commits half-typed Japanese text | Composition handling was written by hand | Use the `:on-keydown` key map — the composition law is centralised there |
+| `:rf.error/no-frame-context` from a timeout | A bare `dispatch` in async code | Capture the frame at the call site, or dispatch an event that owns the async work through `:fx` |
+| An intent fires but no handler runs | Unregistered event id | Registration happens on namespace load; check the boot namespace requires it |
+
+## When not to use an intent
+
+When you need the event object itself. Pointer coordinates, `dataTransfer`,
+`stopPropagation`, anything measuring the DOM — those are functions, and reaching
+for one is not a failure. The census puts these at roughly 3% of handler sites,
+which is the right size for an escape hatch: too small to design the syntax around,
+too real to pretend away.
+
+## Not settled yet
+
+| Question | Status |
+|---|---|
+| The auto-prevent opt-out spelling | **Not addressed.** HD-002-era record says "opt-out available" and stops there |
+| Whether markers other than `::h/value` exist | **Not addressed.** The charter names "the intent-marker roster and its one pure materializer" as a micro-mechanic worth copying from the predecessor, but only `::h/value` is spelled. A checked-state marker for checkboxes is an obvious gap this guide could not fill honestly — the example on [Getting started](01-getting-started.md) sidesteps it by passing the id and letting the handler flip the value |
+| Which attributes get intent lowering | **Not addressed.** `:on-click`, `:on-input`, `:on-submit`, and `:on-keydown` appear in the record; whether lowering is universal across `:on-*` or a named roster is unstated |
+| The key map's key vocabulary | Key names appear as strings (`"Enter"`, `"Escape"`); whether keywords are accepted, and how modifiers are spelled, is unstated |
+| `::h/value` semantics on non-input elements | **Not addressed** |

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -1,0 +1,154 @@
+# Controlled inputs
+
+> **Pre-implementation draft — Hicasso does not exist yet.** This page describes the
+> *designed* surface so it can be read before it is built. Spellings marked
+> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
+> is rewritten after the P2 fork ruling, against a real implementation. Normative
+> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+
+A controlled text input is the hardest correctness problem a view layer has, and
+almost none of the difficulty is visible in the code you write.
+
+Here is what you write:
+
+```clojure
+(defview title-field [{:keys [id]}]
+  (let [{:keys [draft]} (use-subs {:draft [:todo.ui/draft id]})]
+    [:input {:type     :text
+             :value    draft
+             :on-input [:todo.ui/edit id ::h/value]}]))
+```
+
+That's it. Value in from a subscription, intent out to an event. The rest of this
+page is about the machinery underneath, because you need to know what it guarantees
+and where it stops.
+
+The read above uses the grouped surface; on the collector surface the same line is
+`(sub [:todo.ui/draft id])` inline in the attribute map.
+[Views and reads](02-views-and-reads.md) explains why there are two and why this
+draft doesn't choose. Nothing on this page depends on which one wins — the door is
+below both of them.
+
+## Why this is hard
+
+The value shown on screen lives in app-db, which means every keystroke makes a round
+trip: keystroke → dispatch → event handler → app-db commit → subscription →
+re-render → DOM value.
+
+If any part of that is asynchronous, you get the classic failure set. Fast typists
+drop characters. The caret jumps to the end of the field on every edit. IME
+composition breaks mid-word. Reagent pays for this with a dedicated caret-heuristic
+module that tracks the last DOM value and repositions the cursor — the comment in
+its source says the alternative "gives the user a jarring experience," which is
+generous.
+
+## The synchronous door
+
+HD-019 names the mechanism instead of leaving it to taste, because the first
+controlled-input commit cannot stall on an undecided design.
+
+On the lean-React arm, a controlled element's intent **dispatches synchronously
+inside the discrete browser event**, and the subscription layer's store notification
+runs synchronously too, so React commits the echo in the same turn. The value is
+back in the DOM before the browser's event handling finishes.
+
+`flushSync` is the evidence-gated last resort, never the default. If Hicasso ends up
+needing it routinely, that is a finding, not an implementation detail.
+
+## What the door guarantees
+
+Two requirements from the fitness harness, and they are v0's acceptance bar:
+
+**R-A1 — same-tick echo.** A keystroke flows event → commit → re-render such that
+the DOM value never lags the accepted keystroke. No dropped characters, no
+reordering, under the substrate's scheduling. A substrate that batches or defers
+renders must state its input-path exception mechanically — the synchronous door *is*
+that statement.
+
+**R-A2 — caret and selection preservation** when the rendered value differs from
+what was typed. Reject, transform, reformat: mid-string edits included, and IME
+composition is never broken by value reassertion. **Remount-as-reset is
+disqualified** — it destroys focus, selection, and composition state, so "just
+change the key" is not an available answer here.
+
+Six browser witnesses prove the door, all on a 100-cell editing grid: same-turn
+echo, mid-string caret, selection, IME composition (including the keyCode-229
+signal), unchanged-model rejection, and async normalisation. K4 in
+[validation.md](../validation.md) kills the whole programme if controlled text fails
+same-tick echo or IME on Chromium and WebKit for a simple form. This is not a
+polish item.
+
+## Rejection: when the model says no
+
+Your handler doesn't have to accept what was typed:
+
+```clojure
+(rf/reg-event :order/set-quantity
+  (fn [{:keys [db]} [_ id typed]]
+    (if (re-matches #"\d*" typed)
+      {:db (assoc-in db [:orders id :qty] typed)}
+      nil)))                                       ;; rejected — no-op, model unchanged
+```
+
+On the lean-React arm the rejected path leans on **React's own end-of-discrete-event
+restore**: the DOM node briefly holds the typed character, the model doesn't change,
+and React reasserts the model value when the discrete event ends. You get the
+rejection for free from the host, and R-A2 says the caret survives it.
+
+This is one of the concrete payoffs of accepting React's model rather than owning
+the DOM. On a PATCH back end the obligation transfers to the renderer, which must
+converge value and checked state against the live node after every controlled
+dispatch, caret preserved, composition fenced — a hard gate in
+[architecture.md](../architecture.md). A PATCH spike that cannot demonstrate that on
+the 100-cell grid has failed regardless of its clock numbers.
+
+## Resets are by revision, never by value
+
+When you need to force a field back to a value — a form reset, a "revert" button, a
+server-supplied normalisation — **the trigger is an explicit caller revision, not
+value equality.**
+
+The reason is a specific bug. If you reset whenever the incoming value equals some
+target, then a user who legitimately types that value gets their field yanked out
+from under them, and a rejected same-value reassertion becomes invisible. Explicit
+revision means the reset fires exactly when the caller says so: zero stale paints,
+loop-impossible, correct on retry.
+
+This is the predecessor's ruled reset law, kept deliberately. The prop that carries
+the revision does not have a Hicasso spelling yet; see **Not settled yet**.
+
+## Troubleshooting
+
+No Hicasso error ids exist yet; this table names mechanisms.
+
+| Symptom | What went wrong | Fix |
+|---|---|---|
+| Characters drop when typing fast | The dispatch path went async — a debounce, a `setTimeout`, a queued effect between keystroke and commit | Keep the controlled path on the synchronous door; debounce the *consumer* of the value, not the write |
+| Caret jumps to end of field on every keystroke | The value was reasserted without caret preservation | R-A2 territory — a real bug in the runtime, not in your view |
+| IME composition breaks mid-word | Value reassertion during composition | The runtime fences composition; a hand-written handler bypassing the intent path won't |
+| Typing the "reset" value clears the field | Reset keyed on value equality somewhere | Reset on explicit revision |
+| Field goes read-only after an async normalise | The model round-trip didn't complete | Async normalisation is one of the six door witnesses; check the handler returns a `:db` write |
+| Focus lost after a validation failure | Something remounted the node | Remount-as-reset is disqualified precisely for this |
+
+## When not to control an input
+
+Controlled means every keystroke writes to app-db. On a 100-cell grid that is 100
+event dispatches and 100 commits per pass, which is why the predecessor's grid
+example deliberately went uncontrolled. Price it before you reach for it: the
+per-keystroke budget in [validation.md](../validation.md) demands a stated path for
+both a 4-field form and a 100-cell grid, and "which subs recompute" matters as much
+as "which boundaries re-render."
+
+If a field's intermediate values are nobody's business — a search box whose only
+consumer is a debounced query, a scratch field in a modal — an uncontrolled input
+with a commit on blur is not a compromise. It is the right shape.
+
+## Not settled yet
+
+| Question | Status |
+|---|---|
+| The revision prop's spelling on a controlled element | **Not addressed.** The reset law is ruled; the attribute that carries the revision is unnamed |
+| The buffered / draft-and-commit input ladder | **Post-v0, explicitly.** The charter defers "the full buffered/revision input ladder"; v0 ships R-A1/R-A2 and no more |
+| The controls kit that owns drafts and revisions | **Post-v0.** HD-009 leans on it for ephemeral state, and it does not exist in v0 — so in v0 a draft is app-db state you write yourself |
+| Which props count as controlled | HD-010's merge law names `:value` and `:checked`; whether the roster is longer is unstated |
+| Whether `:on-input` or `:on-change` is the taught attribute | Both appear across the record. This guide uses `:on-input` for text and `:on-change` for checkboxes, matching the source examples, but the choice is not ruled |

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -1,0 +1,151 @@
+# Interop
+
+> **Pre-implementation draft — Hicasso does not exist yet.** This page describes the
+> *designed* surface so it can be read before it is built. Spellings marked
+> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
+> is rewritten after the P2 fork ruling, against a real implementation. Normative
+> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+
+You want a date picker from npm. In Reagent you write `[:> DatePicker {...}]` and
+move on. Hicasso asks you to write one line first:
+
+```clojure
+(ns app.hosts.date-picker
+  (:require [re-frame.hicasso :as h]
+            ["react-datepicker" :default DatePicker]))
+
+(h/defhost date-picker DatePicker)     ;; defhost is [unfrozen]
+```
+
+Then use it anywhere, and it is indistinguishable from a native view:
+
+```clojure
+(ns app.views
+  (:require [app.hosts.date-picker :refer [date-picker]]))
+
+[date-picker {:selected  due-date
+              :on-change [:task/set-due ::h/value]}]
+```
+
+## Why a declaration instead of `[:>]`
+
+`[:> DatePicker {...}]` puts a raw JavaScript value inside your data tree. Three
+things break at that node, all of them quietly:
+
+- **`.cljc` purity.** The namespace can no longer load on the JVM, so it can no
+  longer be tested headlessly.
+- **Structural testing.** The node holds an opaque JS object, so you can't assert
+  the tree with `=`.
+- **Tooling identity.** There is nothing for a tool to name — the crossing has no
+  identity, just a value.
+
+`defhost` gives the crossing a name, keeps the JS require quarantined in one `.cljs`
+host namespace, and leaves the rest of your view tree pure data.
+
+The honest counter-argument is that a declaration is friction, and the counter to
+*that* is arithmetic: it amortizes to zero over every use site, and a codemod exists
+for migration. The expensive half of leaving Reagent was never `[:>]` — it was
+`r/atom`.
+
+## The defaults
+
+`defhost` with no options gives you:
+
+| Default | Behaviour |
+|---|---|
+| Props | shallow camelCase conversion — `:on-change` becomes `onChange` |
+| Children | hiccup children are converted to React elements |
+| Functions | pass through unconverted |
+| SSR | a placeholder (declared policy; inert in v0, since SSR is out of v0 per HD-020) |
+
+Policy overrides live on the declaration rather than at the call site, which is the
+whole point: one place decides how this component is crossed, and every use site
+inherits it. The option keys are not in the record; see **Not settled yet**.
+
+## The escape: `[:>]` is legal
+
+`[:> Component props & children]` lowers through the same foreign path with the same
+default conversions. It is `.cljs`-only at that node and has reduced structural
+identity — exactly the costs listed above, accepted knowingly.
+
+Use it when a static declaration genuinely cannot express the case:
+
+- the component is **selected at runtime** from a map or a prop;
+- it is a `memo` or `lazy` value;
+- it arrives from a **render prop**;
+- it is a **provider an ecosystem library hands you**, not one you named;
+- it is a **one-off migration site** you have not got to yet.
+
+**The rule is: declare what you use twice.** First use, take the escape if it's
+faster. Second use, write the `defhost`. That is not a moral position; it is where
+the amortization crosses over.
+
+One thing stays rejected: **bare-head auto-hosting**. Putting a raw JS component in
+head position — `[DatePicker {...}]` — and having the runtime identity-key it is
+*not* legal. One sentinel, not two shortcuts. If `[:>]` and a bare head both worked,
+every codebase would have both, and the reader would have to know which node is
+which by looking somewhere else.
+
+## Migrating from Reagent
+
+A codemod handles the mechanical part: collect the `[:> X …]` sites, emit the
+`defhost` block, rewrite the call sites. It runs incrementally, so a large app
+converts a namespace at a time rather than in one commit. The codemod's name and
+invocation are not in the record.
+
+## Imperative SDKs
+
+A mapping SDK, a chart library that wants a DOM node, anything that hands you a
+handle and expects you to feed it — that is **not** an interop-door problem. It is
+ordinary host-edge React (HD-003): a callback ref, an effect, and a cleanup, written
+in a `.cljs` namespace at the edge of your app.
+
+```clojure
+;; Sketch only — host-edge React inside a defview body.
+(defview map-panel [_]
+  (let [attach (react/useCallback
+                 (fn [node] (when node (sdk/mount! node)))
+                 #js [])]
+    [:div.map {:ref attach}]))
+```
+
+There is no Hicasso concept for this, deliberately. "Behaviors" — a predecessor
+product concept for imperative host ownership — is **not v0 vocabulary**. A richer
+host-ownership pattern is a product-phase question; the v0 answer is React, used
+honestly, at the edge.
+
+Note the two hook-budget consequences: this body now has hooks in it, so it is
+outside the headless testing scope ([Testing](08-testing.md)) and you have taken on
+React's hook rules yourself. Both are fine. Both are on you.
+
+## Troubleshooting
+
+No Hicasso error ids exist yet; this table names mechanisms.
+
+| Symptom | What went wrong | Fix |
+|---|---|---|
+| Prop arrives as `on-change` and the library ignores it | Deep conversion expected; the default is shallow | Convert the nested map yourself, or set a policy on the declaration |
+| A namespace stops loading on the JVM | A JS require reached a `.cljc` file | Quarantine the require in a `.cljs` host namespace |
+| Structural test can't match a node | It's a `[:>]` node — reduced structural identity, by design | Declare it with `defhost`, or assert around it |
+| Provider from a library needs to wrap the tree | Hosted like anything else | `defhost` the provider; it is a component |
+| The SDK mounts twice in dev | StrictMode double-invoke of effects | Make attach and cleanup idempotent — the same discipline React requires of any JS app |
+
+## When not to reach for the door
+
+If the library is a thin wrapper over DOM you could write yourself in twenty lines
+of hiccup, write the twenty lines. Every hosted component is a node your tools can
+see less of and your tests can assert less about. The census found **zero** foreign
+components across 85 idiomatic files, which is why this is an escape hatch and not
+tier-1 syntax — most applications never need it, and the ones that do need it for
+two or three genuinely hard widgets.
+
+## Not settled yet
+
+| Question | Status |
+|---|---|
+| `defhost`'s option keys | **Not addressed.** "Policy overrides live on the declaration" is as far as the record goes |
+| The codemod's name and invocation | **Not addressed** |
+| Whether `::h/value` works across a host crossing | **Not addressed.** The example above assumes it does; a foreign `onChange` may hand you something other than a DOM event |
+| The SSR placeholder's shape | Declared policy, inert in v0 |
+| Whether a hosted component can be a `defview`'s child via `(:children props)` | The ABI says an existing React element is a legal child anywhere, which implies yes; not stated for the host case specifically |
+| Embedding Hicasso *inside* a React-primary app | Named in the charter's use-case roster (item 11); no surface designed |

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -101,10 +101,15 @@ ordinary host-edge React (HD-003): a callback ref, an effect, and a cleanup, wri
 in a `.cljs` namespace at the edge of your app.
 
 ```clojure
-;; Sketch only — host-edge React inside a defview body.
+;; Sketch only — host-edge React inside a defview body, in a .cljs namespace.
+(ns app.hosts.map-panel
+  (:require [re-frame.hicasso :as h :refer [defview]]
+            ["react" :as react]
+            ["some-map-sdk" :as sdk]))
+
 (defview map-panel [_]
   (let [attach (react/useCallback
-                 (fn [node] (when node (sdk/mount! node)))
+                 (fn [node] (when node (sdk/mount node)))
                  #js [])]
     [:div.map {:ref attach}]))
 ```

--- a/docs/design/hicasso/draft-guide/06-theming.md
+++ b/docs/design/hicasso/draft-guide/06-theming.md
@@ -1,0 +1,172 @@
+# Theming
+
+> **Pre-implementation draft — Hicasso does not exist yet.** This page describes the
+> *designed* surface so it can be read before it is built. Spellings marked
+> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
+> is rewritten after the P2 fork ruling, against a real implementation. Normative
+> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+
+Every React component library reaches for context to theme itself. Hicasso doesn't
+ship a context API at all, and its theming uses none.
+
+This is not asceticism. Context is a side channel: it is invisible to the data tree,
+which kills headless testing and makes SSR harder; it costs a hook per consumer,
+against a ≤2 hook budget already fully spent; it re-renders every consumer when it
+changes; and it is a second dependency-injection channel next to props. The platform
+cascade and the data tree each do the job better on every axis the charter measures,
+and the predecessor library's real usage — a global theme plus per-instance
+overrides — never needed subtree context in the first place.
+
+Three layers do the work.
+
+## Layer 1 — design tokens as CSS custom properties
+
+The cascade *is* a context system. Nearest ancestor wins, it is subtree-scoped, and
+it is platform-native.
+
+```css
+:root {
+  --app-color-accent:  #2b6cb0;
+  --app-color-surface: #ffffff;
+  --app-radius:        4px;
+}
+
+[data-theme="dark"] {
+  --app-color-accent:  #63b3ed;
+  --app-color-surface: #1a202c;
+}
+
+.app-button {
+  background: var(--app-color-accent);
+  border-radius: var(--app-radius);
+}
+```
+
+Switching theme is one attribute flip on one element. **Zero React work** — no
+re-render, no hook, no diff. Nothing in your component tree knows it happened, which
+is exactly right, because nothing in your component tree needed to.
+
+## Layer 2 — parts as data addresses
+
+A control emits keyword-tagged **parts**: named addresses for its internal pieces.
+A theme is a map from part address to classes and attributes, and applying it is a
+pure tree-to-tree transform.
+
+```clojure
+;; A theme: part address → classes/attrs.
+(def compact-theme
+  {[:typeahead :root]  {:class "ta ta--compact"}
+   [:typeahead :input] {:class "ta__input"}
+   [:typeahead :menu]  {:class "ta__menu" :role "listbox"}})
+```
+
+Merge order is fixed: **`base < app-theme < instance-props`**. The control's own base
+wins least, the app's theme overrides it, and props at a specific use site override
+both.
+
+The property that makes this worth having: because it is a pure function from tree
+to tree, you can unit-test a theme with `=`. No registry, no multimethods, no
+runtime resolution order to reason about.
+
+The spellings for declaring a part in a control and installing a theme in an app are
+not in the record. See **Not settled yet** — this layer is the least specified of
+the three.
+
+## Layer 3 — app-db for the choice
+
+Which theme is selected is application state like any other: read it with a
+subscription, write it with an event, and get frame isolation, time travel, and
+Xray visibility for free.
+
+```clojure
+(rf/reg-sub :theme/current
+  (fn [db _query] (:theme/current db)))
+
+(rf/reg-event :theme/choose
+  (fn [{:keys [db]} [_ theme]] {:db (assoc db :theme/current theme)}))
+```
+
+App-db holds the *choice*. It does not hold the tokens, and it does not hold the
+part maps.
+
+## The two laws
+
+Layers 1 and 2 would be a footgun without these. Both are ruled in HD-010.
+
+### (a) The owned-literal merge law
+
+**`:key`, `:ref`, controlled `:value` and `:checked`, and owned event handlers are
+unoverridable by a theme or by parts.**
+
+A theme can style a field. It can never rewrite the field's controlled contract.
+Without this law, a stylesheet-shaped piece of data could reach in and clobber the
+`:value` of a controlled input — and you would debug that as an input bug for a day
+before you thought to look at the theme.
+
+### (b) The static-map law
+
+**Anything runtime-switchable lives in CSS variables. Part-to-class maps are
+boot-static per app. Structural replacement goes through children and slots, never
+through parts.**
+
+The three halves of that, spelled out:
+
+- If it changes while the app runs — light and dark, density, brand — it is a CSS
+  variable.
+- A part-to-class map is fixed at boot. Changing one is an app rebuild, **by
+  design**. The "theme switch is zero React work" claim holds for the token layer,
+  and this is the price.
+- If you want a different *structure* — a custom menu row, a replaced icon — that is
+  a child or a slot. Parts address the pieces a control renders; they do not replace
+  them.
+
+Break (b) and parts become a second, worse rendering system driven by data at
+runtime. That is the failure mode the law exists to prevent.
+
+## React context is still there
+
+HD-010 bans a *Hicasso* context API and context-based *theming*. It does not ban
+React.
+
+The substrate keeps exactly one internal context — frame identity — and ordinary
+React context remains available to an advanced author at the HD-003 escape hatch: a
+compound-component contract you are implementing, or a provider an ecosystem library
+demands. Foreign providers come in through [`defhost`](05-interop.md) like any other
+component.
+
+Using it means taking on React's rules, a hook per consumer, and a node your
+structural tests can see less of. Which is the honest trade, stated once, rather
+than a mechanism the guide pretends doesn't exist.
+
+## Troubleshooting
+
+No Hicasso error ids exist yet; this table names mechanisms.
+
+| Symptom | What went wrong | Fix |
+|---|---|---|
+| Theme switch re-renders the whole app | The switch went through app-db into a prop that every view reads | Switch a CSS variable scope instead — the token layer is the runtime-switchable one |
+| A controlled input's value gets clobbered by a theme | Should be impossible — law (a) | A runtime bug, not a usage error |
+| A part override doesn't take effect | Merge order: instance props beat app theme beat base | Check which layer you set it in |
+| Theme change needs a rebuild | Expected, if you changed a part-to-class map — law (b) | Move the switchable part into a CSS variable |
+| A themed control renders the wrong structure | Parts address pieces; they don't replace them | Use children or a slot |
+
+## When not to theme
+
+If you have one application and one look, skip layer 2 entirely. Parts are for
+**component-library authorship** — the case where someone else's app consumes your
+control and needs to restyle its internals without forking it. An app styling its
+own components has CSS, and CSS is enough.
+
+Reaching for parts inside a single app buys you an indirection layer and a merge
+order to remember, in exchange for a flexibility nobody is going to use.
+
+## Not settled yet
+
+| Question | Status |
+|---|---|
+| How a control declares a part | **Not addressed.** "Controls emit keyword-tagged parts" is the whole of the record; the attribute or macro that does it is unnamed |
+| How an app installs a theme | **Not addressed.** The merge order `base < app-theme < instance-props` is ruled; the mechanism that supplies the app-theme layer is not. Since there is no context, it is presumably passed or registered — the record does not say which |
+| The part-address shape | This guide writes `[:typeahead :root]` by analogy with the record's "part address" language; the actual shape is unstated |
+| CSS custom property naming convention | **Not addressed.** The `--app-*` prefix above is this guide's invention |
+| Where the boot-static part map lives | Implied by law (b) to be fixed at build; the residence is unstated |
+| The controls kit that would ship parts | **Post-v0** |

--- a/docs/design/hicasso/draft-guide/07-ephemeral-state.md
+++ b/docs/design/hicasso/draft-guide/07-ephemeral-state.md
@@ -1,0 +1,166 @@
+# Ephemeral state
+
+> **Pre-implementation draft — Hicasso does not exist yet.** This page describes the
+> *designed* surface so it can be read before it is built. Spellings marked
+> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
+> is rewritten after the P2 fork ruling, against a real implementation. Normative
+> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+
+Is this dropdown open? Is this row hovered? Is this panel expanded?
+
+In Reagent you reach for `r/atom`. In React you reach for `useState`. In Hicasso
+there is **no `local`** — no component-local reactive cell, no ratom equivalent, and
+no `useState` for application state. Not discouraged. Absent.
+
+That is a strong claim, so here is the evidence it rests on: a census of **85
+idiomatic re-frame files**, containing every classic hard case, found **zero
+view-local reactive cells**. Not few. Zero. Most of Reagent's local-state demand was
+manufactured by machinery — the reaction engine, deref capture, argv memoization —
+that Hicasso deletes structurally. And a second reactive system sits at the top of
+the anti-regression fence in the [charter](../charter.md): a view layer that grows
+one has failed back into its predecessors.
+
+## The placement rule
+
+One rule, and it is *taught*, not policed:
+
+> **Semantic application state belongs in app-db. Component mechanics —
+> composition, measurement, focus, animation, SDK handles — may use ordinary React
+> hooks at the honest escape hatch.**
+
+The test is whether anyone other than this component could care. A dropdown's open
+state affects what the user can do next, so it is semantic. A tooltip's measured
+pixel offset is arithmetic, so it is mechanics.
+
+A `defview` body is an honest React function component. Hooks physically work in it.
+There is no lint police in v0, and if you use one you take on React's hook rules
+yourself — including the loss of headless testability for that body
+([Testing](08-testing.md)).
+
+## The order to try
+
+1. **CSS.** Hover, focus, active, `:has()`, `<details>`. If the platform already
+   tracks it, no state exists at all.
+2. **Platform-carried state.** The top layer owns open and dismiss for overlays;
+   resources and mutations own their own async status; the controls kit owns drafts
+   and revisions. See the v0 caveat below — most of this layer is post-v0.
+3. **Host-private React state at host edges.** Geometry, composition,
+   measure-before-paint. Local to the edge, invisible to the app.
+4. **app-db**, for everything semantically meaningful.
+
+Work down the list, not up it. Most of the time you stop at 1.
+
+## app-db without the ceremony
+
+The objection to app-db for UI state is always ceremony: an event, a subscription,
+and a keypath for something as small as "is this open?"
+
+The answer is that **the tax is per-concern, not per-instance.** One parametric
+subscription and one named event serve every instance of the widget in the app,
+forever:
+
+```clojure
+(rf/reg-sub :panel/expanded?
+  (fn [db [_ panel-id]] (get-in db [:ui :panel/expanded panel-id] false)))
+
+(rf/reg-event :panel/toggle
+  (fn [{:keys [db]} [_ panel-id]]
+    {:db (update-in db [:ui :panel/expanded panel-id] not)}))
+```
+
+```clojure
+;; Read shown in the grouped surface; the collector spelling is
+;; (sub [:panel/expanded? id]) inline. See 02-views-and-reads.md.
+(defview panel [{:keys [id title]}]
+  (let [{:keys [expanded?]} (use-subs {:expanded? [:panel/expanded? id]})]
+    [:section
+     [:h3 {:on-click [:panel/toggle id]} title]
+     (when expanded? [panel-body {:id id}])]))
+```
+
+Ten lines, once. A hundred panels, no further cost. And you get the things a local
+cell can never give you: the state is in app-db, so it time-travels, it is visible
+in Xray, it is isolated per frame, and a test can set it directly without touching a
+component.
+
+That last one is worth sitting with. "Open this dropdown in a test" is a `:db`
+write, not a click simulation.
+
+## Named events, not a generic setter
+
+Write `[:panel/toggle id]`, never a generic `[:ui/set [:panel/expanded id] true]`.
+
+A named event is a name for what happened, which is the entire premise of the event
+log being readable. A generic setter turns your event history into a diff stream and
+takes the meaning out of the one place the framework was keeping it for you. This is
+also why HD-009 pre-commits that any future sugar mints a **named** setter event and
+never a generic `ui/set`.
+
+## What v0 actually gives you
+
+Layer 2 above is mostly a promise. The controls kit that would own drafts and
+revisions is post-v0. So is the overlay top layer. In v0, a dismissible dropdown is
+CSS if you can manage it, and app-db if you can't.
+
+HD-009 is explicit that this is expected to generate complaints, and equally
+explicit about what happens next. If dogfooding shows the residual ceremony
+registering, the pre-agreed *response class* is one-declaration sugar — never a
+state system:
+
+```clojure
+;; SKETCH — v0 ships nothing here, and the shape is unfrozen.
+(h/defstate ::open {:default false})
+;; would mint: a parametric sub (sub [::open id])
+;;             and a NAMED setter event [::open id v]
+```
+
+Read that block as an illustration of a *response class*, not a plan of record. Its
+concrete shape — including whether a declared app-db tier is involved and what that
+tier's frame and persistence scope would be — is **unfrozen until the evidence
+exists**. v0 ships nothing here and pre-commits to nothing beyond "sugar, not a state
+system."
+
+One peer review argued for a `useState` fence and a pre-designed tier. It was
+adopted in part: the tier pre-commitment was withdrawn and there is no lint police.
+The no-`local` core stands.
+
+So: a v0 complaint about state ceremony is **expected signal**, not a verdict. It
+triggers the sugar iteration, not a kill.
+
+## Troubleshooting
+
+No Hicasso error ids exist yet; this table names mechanisms.
+
+| Symptom | What went wrong | Fix |
+|---|---|---|
+| Reaching for `useState` to hold "is this open?" | That's semantic state | app-db, or CSS if the platform tracks it |
+| Every panel in a list opens at once | The state isn't parameterised by instance | Key the app-db path by the widget's id |
+| A hook body can't be tested headlessly | Hooks put a body outside headless scope, by design | Move the semantic half to app-db; mount-test the mechanics |
+| Hook-order error after a conditional early-return | React's rules, now yours | Hooks at the top of the body, unconditionally |
+| app-db is full of `:ui` noise | Expected — it is the honest home | Namespace the keys and exclude the tier from persistence by convention |
+
+## When app-db is the wrong home
+
+Three cases where it genuinely is.
+
+**The platform already knows.** Hover and focus are CSS. Writing them into app-db is
+a re-render per pointer move for a fact the browser was tracking for free.
+
+**High-rate host mechanics.** A drag in flight, a scroll offset, an animation frame
+— 60 to 240 updates a second. That is the two-clock envelope: host-local motion off
+app-db, semantic commits into it. Drag *ends* in app-db. Drag *moves* do not.
+
+**Values nobody else can see.** A measured pixel offset, an SDK handle, a
+composition buffer. Host-private React state at the host edge, and no one outside
+that edge needs to know it exists.
+
+## Not settled yet
+
+| Question | Status |
+|---|---|
+| `defstate`'s shape, and whether it ever ships | **Unfrozen by ruling.** HD-009 pre-commits to a response *class*, not a design; v0 ships nothing |
+| Whether a declared app-db `:ui` tier exists, and its frame and persistence scope | **Withdrawn from pre-commitment.** The `[:ui …]` keypaths on this page are ordinary app-db keys this guide chose, not a ruled tier |
+| The controls kit (drafts, revisions) | **Post-v0** |
+| The overlay top layer that would own open and dismiss | **Post-v0** |
+| The reusable-widget instance-key convention | **Post-v0**, named as a resolved design debt in HD-009's sugar |
+| Where the line falls between "mechanics" and "semantic" in hard cases | **Judgment, by design.** HD-003 makes it a taught rule with no enforcement, and reopens if dogfooding shows it confusing in practice |

--- a/docs/design/hicasso/draft-guide/08-testing.md
+++ b/docs/design/hicasso/draft-guide/08-testing.md
@@ -1,0 +1,135 @@
+# Testing
+
+> **Pre-implementation draft — Hicasso does not exist yet.** This page describes the
+> *designed* surface so it can be read before it is built. Spellings marked
+> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
+> is rewritten after the P2 fork ruling, against a real implementation. Normative
+> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+
+There are two doors into a Hicasso view under test, and knowing which one you are
+allowed through is most of the skill.
+
+The headless door is fast, runs on the JVM, and asserts hiccup with `=`. It covers
+hook-free tier-1 bodies. Everything else — hooks, foreign components, anything at a
+host edge — goes through the mounted door, in a real browser.
+
+That boundary is a ruling, not a limitation of the current implementation. HD-021
+says it in four words: **no fake hook dispatcher, ever.**
+
+## The headless door
+
+A structural render returns the view's hiccup tree as data. No DOM, no React, no
+browser.
+
+```clojure
+(deftest todo-row-renders-title
+  (let [tree (h/render [todo-row {:id 7}]                 ;; h/render is [unfrozen]
+                       {:subs {[:todo/by-id 7]      {:title "Buy milk"}
+                               [:todo.ui/editing? 7] false}})]
+    (is (= [:li
+            [:span "Buy milk"]
+            [:button {:on-click [:todo/toggle 7]} "✓"]
+            nil]
+           tree))))
+```
+
+Two things are doing the work here.
+
+**Sub reads are overridable through a pure read resolver.** You hand the render a
+map of query vector to value, and the body reads from it. No frame, no app-db, no
+registration — just the values the view is a function of. This works identically
+under either read surface from [Views and reads](02-views-and-reads.md): grouped or
+collector, a read is a read, and the resolver answers it.
+
+**Intent vectors are assertable by equality.** `{:on-click [:todo/toggle 7]}` is
+data. You can `=` it. Compare that with the alternative — asserting that a node
+holds *some function* which, when called, dispatches something — which is why
+codebases end up rendering to a DOM and clicking things just to find out what a
+button was going to do.
+
+This is what deletes the retail. The census counted **364 `data-testid` attributes**
+across the corpus, most of them scaffolding for browser tests that only existed
+because the tree wasn't inspectable. Make the tree data and most of them stop
+earning their place.
+
+## Where headless stops
+
+**Hook-free tier-1 bodies.** That is the scope, exactly.
+
+If a body calls a React hook — a callback ref for measurement, a `useEffect` for an
+SDK, anything at a host edge — headless is out. If a body renders a foreign
+component through [`defhost` or `[:>]`](05-interop.md), the foreign region is out.
+
+The temptation is obvious: stub the hook dispatcher, get the whole tree back, keep
+the fast tests. HD-021 forecloses it. A fake dispatcher passes tests that a real
+React would fail, and the bugs it hides are exactly the ones — abandoned renders,
+StrictMode double-invoke, effect ordering — that you needed a test for. Better a
+loud boundary you can see than a green suite you can't trust.
+
+The practical move is to split. Keep the semantic half of the component in a
+hook-free body that headless can assert, and put the mechanics in a small host-edge
+component you mount-test once.
+
+## The mounted door
+
+A shared browser facade covers `act`, root lifecycle, and residue assertions
+**[unfrozen — the facade has no name in the record]**.
+
+One assertion is standing, on every mounted test: **zero leaked subscription
+ref-counts after teardown.** A related invariant rides with it — an unchanged hot
+read performs no new attach or release, so a re-render that reads the same query
+should show no churn at all.
+
+Reach for a mounted test when you need:
+
+- a real error boundary — `h/boundary` **[unfrozen]** is the runtime's class
+  component, taking `:fallback`, `:reset-key`, and `:on-error`;
+- caret, selection, or IME behaviour, which only a real browser can prove
+  ([Controlled inputs](04-controlled-inputs.md));
+- StrictMode, abandoned first mount, root teardown, or an HMR body swap;
+- keyed insert, delete, and reorder against real DOM nodes;
+- a foreign component's hooks, context, or refs.
+
+## Testing events and subscriptions
+
+Nothing changes. Events are functions from coeffects to an effects map, and
+subscriptions are functions of app-db — both testable without any view layer at all,
+in Hicasso exactly as under Reagent or UIx.
+
+The view-layer testing question is only ever "what tree did this body produce, given
+these reads?" — which is the headless door's whole job.
+
+## Troubleshooting
+
+No Hicasso error ids exist yet; this table names mechanisms.
+
+| Symptom | What went wrong | Fix |
+|---|---|---|
+| Headless render throws on a body with hooks | Out of scope, by ruling | Mount-test it, or split the semantic half into a hook-free body |
+| A sub read returns `nil` in a headless test | The query wasn't in the resolver map | Sub-key identity is `(query-id, args)` under value equality — check the args match exactly |
+| Assertion fails on a `nil` in the tree | A `when` produced `nil`, which renders nothing but is still in the data | Assert the `nil`, or filter before comparing |
+| Ref-count leak after teardown | A subscription outlived its root | A runtime bug — this is the standing assertion, not a test you tune |
+| A test passes headless and fails mounted | Real React does things a data render doesn't — effect order, double invoke, commit timing | The mounted result is the truth |
+| Caret test can't be written headlessly | Correct — caret is a browser fact | 100-cell grid witnesses, in a browser |
+
+## When not to test through the view
+
+If the assertion is about *state*, test the event handler. If it is about *derived
+values*, test the subscription. A view test that dispatches an event and then
+asserts on app-db is testing three things and will fail for reasons that have
+nothing to do with the view.
+
+Headless view tests answer one question — did this body produce the right tree from
+these reads — and they are excellent at it precisely because that is all they do.
+
+## Not settled yet
+
+| Question | Status |
+|---|---|
+| The headless render function's name and signature | **Not addressed.** HD-021 pins the semantics — structural render as data, sub reads overridable — and names nothing. `h/render` and the `{:subs …}` option above are this guide's invention |
+| The read resolver's shape | **Not addressed.** "A pure read resolver" is the whole of the record; a map is the obvious form, and it is a guess |
+| The mounted facade's name and API | **Not addressed** beyond "act, root lifecycle, residue assertions" |
+| Whether headless renders one boundary or a subtree | **Not addressed.** The example above renders one; whether child boundaries are rendered through or returned as unexpanded nodes is unstated, and it changes how every test is written |
+| How intent vectors are *invoked* in a headless test | **Not addressed.** They can be asserted by equality; whether the door lets you fire one and observe the dispatch is unstated |
+| The registry / manifest surface — views enumerable with schemas, docs, source coordinates | **Post-v0.** Named as the AI-ergonomics door |
+| Explain-render tooling | **Post-v0.** HD-005 ships a ~3-line nil-checked evidence sink on the index so it can attach later at zero detached cost; no evidence subsystem ships in v0 |

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -1,0 +1,75 @@
+# Hicasso — draft user guide
+
+> **Pre-implementation draft — Hicasso does not exist yet.** These pages describe the
+> *designed* surface so it can be read before it is built. Spellings marked
+> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
+> is rewritten after the P2 fork ruling, against a real implementation. Normative
+> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+
+Hicasso is re-frame2's native view layer: interpreted Hiccup on a React
+function-component host, optimised for re-frame2. The
+[charter](../charter.md) argues why it should exist and
+[validation](../validation.md) says what would kill it. This draft answers a
+narrower question — **what would a programmer actually type?** — and hands the
+operator something readable before a line of runtime code is written.
+
+It is a first cut in the literal sense. It was written from the design record
+alone, so every claim here is a *designed* claim: nothing on these pages has been
+compiled, run, or measured.
+
+| Page | Its one job |
+|---|---|
+| [Getting started](01-getting-started.md) | Put one Hicasso view on screen inside a frame, and take it down again |
+| [Views and reads](02-views-and-reads.md) | Write a view; read subscriptions from it — in **both** the surfaces still under adjudication |
+| [Events as data](03-events-as-data.md) | Put an event vector in an attribute and let the runtime build the callback |
+| [Controlled inputs](04-controlled-inputs.md) | Type into a text field whose value round-trips through app-db, and keep your caret |
+| [Interop](05-interop.md) | Use a React component from npm |
+| [Theming](06-theming.md) | Style a component library without a context API |
+| [Ephemeral state](07-ephemeral-state.md) | Decide where "is this dropdown open?" lives, given there is no `local` |
+| [Testing](08-testing.md) | Assert a view's output without a browser, and know when you still need one |
+
+Eight pages is not an accident. K5 in [validation.md](../validation.md) kills the
+programme at "more than ~8 public concepts or ~8 guide pages to ship CRUD", so the
+draft deliberately spends its whole budget and no more. If the real guide needs a
+ninth page, that is a signal about the design, not about the writing.
+
+## How to read the markers
+
+**[unfrozen]** after a name means the *semantics* are ruled but the *spelling* is a
+placeholder. Two things drive that. HD-021 pins the root operation's behaviour and
+says outright that its name waits for the donor spike; and
+[authoring.md](../authoring.md) puts a blanket hold on declaration spellings until
+the tournament has measured. So assume every symbol below is provisional, and treat
+the marked ones as *known* to be provisional.
+
+Each page ends with **Not settled yet** — a table of the questions that page raised
+and the design record does not answer. Those tables are the most useful part of this
+draft. A guide that reads as finished when the design is not is worse than one that
+says where the floor is missing.
+
+## What this draft is not
+
+- **Not published.** `design/hicasso/` is in `exclude_docs` in `mkdocs.yml`, so this
+  subtree never reaches the site and is never in the nav. Read it in the source tree
+  or on GitHub.
+- **Not gated.** No fenced block here is digest-pinned by
+  `samples_coverage_jvm_test.clj` — that test scans `docs/core/freehand/` only. Edit
+  freely; nothing downstream breaks.
+- **Not an API freeze.** [authoring.md](../authoring.md) is explicit that nothing in
+  the design record licenses freezing an API early, and this guide inherits that.
+
+Three deviations from the [guide authoring brief](../../../AUTHORING.md), taken
+knowingly. Banners and asides are blockquotes rather than MkDocs admonitions,
+because an excluded tree is read as raw Markdown and `!!! warning` would render as
+literal punctuation. There are no `cljs-rf2` live cells, because there is nothing to
+run. And the troubleshooting tables name symptoms and fixes but carry no
+`:rf.error/*` ids, because no Hicasso error ids have been minted — inventing
+plausible ones would be the single most damaging thing this draft could do.
+
+## Where the vocabulary comes from
+
+[decisions.md](../decisions.md) governs; [validation.md](../validation.md) is next.
+[authoring.md](../authoring.md) holds the canonical spellings that do exist, and
+where this guide shows a symbol that authoring.md does not, the symbol is invented
+here and marked. The programme is sequenced by
+[EP-0038](../../../EP/EP-0038-the-hicasso-view-layer-programme.md).

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -47,6 +47,11 @@ and the design record does not answer. Those tables are the most useful part of 
 draft. A guide that reads as finished when the design is not is worse than one that
 says where the floor is missing.
 
+Examples deliberately alternate between the two candidate read surfaces rather than
+settling on one, and every page that shows a read says which surface it is using.
+[Views and reads](02-views-and-reads.md) is where the fork is explained; the real
+guide will have exactly one spelling and will be much shorter for it.
+
 ## What this draft is not
 
 - **Not published.** `design/hicasso/` is in `exclude_docs` in `mkdocs.yml`, so this


### PR DESCRIPTION
Wave-0 of EP-0038, operator-requested: a **first-cut user guide** for Hicasso written
into `docs/design/hicasso/draft-guide/` so the shape of the deliverable can be read
*before* it is built. Bead: rf2-2rtt6.6.

Nine files, 1,443 insertions, all inside `docs/design/hicasso/draft-guide/`. Nothing
else in the repo is touched.

## What landed

An index plus the eight sections the bead enumerates, one page each:

| Page | Job |
|---|---|
| `README.md` | Index, marker conventions, what this draft is not |
| `01-getting-started.md` | Mount/root per HD-021 semantics, teardown, HMR floor |
| `02-views-and-reads.md` | Boundaries and inlining, the ABI, and **both** HD-002 read surfaces |
| `03-events-as-data.md` | `::h/value`, submit auto-prevent, the composition-gated key map |
| `04-controlled-inputs.md` | The synchronous door, R-A1/R-A2, revision-not-equality resets |
| `05-interop.md` | `defhost` one-liner, the `[:>]` escape, declare-what-you-use-twice |
| `06-theming.md` | CSS vars, parts as data addresses, the two laws, why no context API |
| `07-ephemeral-state.md` | The HD-003 placement rule, no `local`, the per-concern tax |
| `08-testing.md` | Headless scope per HD-021, the mounted door, no fake hook dispatcher |

Eight teaching pages is deliberate: K5 kills at "> ~8 guide pages to ship CRUD", so
the draft spends the whole budget and no more.

## The frame: disposable by design

- **A banner on every page** — pre-implementation, spellings provisional, rewritten
  after P2 against a real implementation.
- **Every unfrozen spelling carries an inline `[unfrozen]` marker**, and every page
  ends with a **Not settled yet** table listing what the design record does not
  answer. Those tables are the point; a page that reads as settled when it isn't is
  worse than one that flags itself.
- **HD-002 is presented as a live fork**, not a preference. Grouped `use-subs` and
  the ambient collector each get their own section at the same heading level, each
  with its own status paragraph, followed by the four adjudication clauses and the
  three-outcome-including-null statement. Examples across the guide alternate
  between the two surfaces on purpose, and each page says which it is using.
- **No `:rf.error/*` ids are invented.** Troubleshooting tables name symptoms and
  mechanisms; no Hicasso error ids have been minted, and fabricating plausible ones
  would be the most damaging thing this draft could do.

Three deviations from `docs/AUTHORING.md`, taken knowingly and stated in the index:
blockquote banners rather than MkDocs admonitions (an excluded tree is read as raw
Markdown, where `!!! warning` renders as literal punctuation); no `cljs-rf2` live
cells (nothing to run); troubleshooting tables without error ids (none exist).

## Fence compliance

`docs/design/hicasso/draft-guide/**` only. Untouched: `spec/`, `implementation/`,
`.github/`, `docs/core/`, `mkdocs.yml`, `docs/design/freehand/`, and the normative
hicasso record (`decisions.md`, `charter.md`, `architecture.md`, `authoring.md`,
`validation.md` — read and cited, not amended).

**Not wired into the site.** `mkdocs.yml` already carries `design/hicasso/` in
`exclude_docs`, so the subtree is excluded for free — no nav row, no `mkdocs.yml`
edit, and `find site -path "*draft-guide*"` returns nothing after a build.

**No sample-coverage digest moved.** `samples_coverage_jvm_test.clj` scans
`docs/core/freehand` (`guide-dir` at line 86). This diff touches zero files under
`docs/core/` and zero under `implementation/`, so no fenced block it hashes can have
changed.

## Quality gates

| Gate | Exit |
|---|---|
| `python -m mkdocs build --strict` | **0** |
| `python scripts/check_doc_slugs.py` | **0** (no output — no broken targets or anchors) |
| `find site -path "*draft-guide*"` after build | **0 matches** — tree absent from the built site |
| `git diff --name-only origin/main...HEAD \| grep -c "^docs/core/"` | **0** — no digest-pinned file touched |
| `git diff --name-only origin/main...HEAD \| grep -c "^implementation/"` | **0** |
| Paren balance across all 27 fenced `clojure` blocks | **balanced** |

The `mkdocs build` INFO lines about `spec/API.md` anchors and excluded
`design/freehand/` links are pre-existing on `main` and unrelated to this diff.

## Gaps worth the operator's attention

Marked unfrozen because a ruling says so: the root operation and its teardown
(HD-021 names the semantics and explicitly defers the spelling); every declaration
spelling, under `authoring.md`'s blanket hold; `defstate`, whose shape HD-009 leaves
unfrozen until dogfood evidence exists.

Marked unfrozen because the record is simply silent — these are the useful ones:

- whether `rf/init!` and adapter installation survive at all under a native view layer;
- the auto-prevent opt-out spelling, and whether any intent marker other than `::h/value` exists (a checkbox `:checked` marker is a visible hole);
- the revision prop that triggers a controlled reset;
- `defhost`'s policy-override option keys, and the codemod's name;
- how a control *declares* a part and how an app *installs* a theme — theming layer 2 is the least specified surface in the record;
- the headless render function, its read-resolver shape, and whether it renders one boundary or a subtree — the last of those changes how every test is written;
- whether an inlined helper may read under the grouped surface. HD-016 calls helper-donated reads "collector-contingent" and never states the grouped answer; the guide infers "no" from React's hook rules and labels the inference as its own.
