### PR TITLE
bench(hicasso): P0 Reagent-on-subs baseline arms (rf2-2rtt6.2)

### DIFF
--- a/docs/design/hicasso/studio/README.md
+++ b/docs/design/hicasso/studio/README.md
@@ -1,0 +1,65 @@
+# Hicasso — studio
+
+The programme's measured record. Every number Hicasso publishes lands here and
+on its bead; the operator-owned standard bead (`rf2-2rtt6.1`) carries the bar,
+the budgets and the kill criteria, and this tree carries the evidence those
+rulings are made against.
+
+Minted by the first P0 worker per [HD-017](../decisions.md). **The Freehand
+studio at `docs/design/freehand/studio/` is frozen and is never extended** — it
+is the predecessor programme's record and it stays exactly as its own programme
+left it.
+
+## What a page in here owes its reader
+
+The measurement discipline in [validation.md](../validation.md) is binding, and
+these four obligations are the ones a page can silently fail:
+
+- **The producing commit SHA and a reproduction command, per row.** Evidence
+  must not outlive the code that produced it.
+- **The runtime, beside every figure** — browser and version, build
+  optimisation level, `goog.DEBUG`. All bar numbers are browser numbers
+  (`:advanced`, real browser); JVM and Node figures are diagnostic-only and are
+  never quotable against the bar.
+- **Ranges across rounds, never a mean alone.** Overlapping ranges mean
+  *indistinguishable*, and the page says so rather than quoting the mean as a
+  winner.
+- **`N unverified of M`** for any row that writes, and the positive control's
+  **predicted vs measured**, on every run, passing or not.
+
+A ratio stays attached to its exact witness, denominator, commit and build.
+Never average across instruments.
+
+## The lane
+
+One build id serves the whole programme —
+[`:hicasso-bench`](../../../../implementation/shadow-cljs.edn) — and one driver
+rides it, so an arm needs no hot-zone edit of its own:
+
+```bash
+cd implementation
+
+# the default entry: the P0 Reagent-on-subs baseline
+npm run bench:hicasso
+
+# any other arm, same build id, same driver
+HICASSO_INIT_FN=re-frame.bench.hicasso.<arm>-app/-main \
+HICASSO_OUT_DIR=out/hicasso-<arm> \
+HICASSO_PORT=8132 \
+  node freehand/test/re_frame/bench/hicasso/run.cjs
+```
+
+Exit codes: `0` measured and clean, `1` the run failed, **`2` the arm-order
+guard refused** — a figure that moves with its position in the plan is not a
+figure, and the repair is the arm, never the tolerance.
+
+The instrument is
+`implementation/freehand/test/re_frame/bench/hicasso/lane.cljs`; it lives in the
+bench/test measurement lane HD-017 carves out of the donor freeze, and it
+requires nothing from any donor `src/` tree.
+
+## Pages
+
+| Page | Phase | What it settles |
+|---|---|---|
+| [P0 — Reagent-on-subs baseline (mount + bulk)](p0-reagent-on-subs-baseline.md) | P0 | The ship bar's **denominator**: mount and bulk view work for Reagent reading re-frame2 subscriptions. |

--- a/docs/design/hicasso/studio/p0-reagent-on-subs-baseline.md
+++ b/docs/design/hicasso/studio/p0-reagent-on-subs-baseline.md
@@ -1,0 +1,180 @@
+# P0 — the Reagent-on-subs baseline (mount + bulk)
+
+**The ship bar's denominator.** [HD-012](../decisions.md) states the bar as *mount
+AND bulk view work ≤ 1.0× Reagent, like-for-like — both sides reading re-frame2
+subscriptions*. Until this page there was no such denominator in the repo: every
+published Reagent row compared against Reagent reading a bare `reagent.core/atom`
+through an `r/cursor`, which is Reagent's own idiom but is a denominator no
+re-frame2 application has. This page supplies the one the bar names, and prices
+the difference between the two.
+
+Bead **rf2-2rtt6.2**. The rows are appended to the operator-owned standard bead
+**rf2-2rtt6.1**; only the operator amends the bar, the budgets, the kill criteria
+or the red-zones.
+
+## Provenance
+
+| | |
+|---|---|
+| **Producing commit** | `19401ad083e895b19d55151157f37a59551cb5e2` |
+| **Reproduction** | `cd implementation && npm run bench:hicasso` |
+| **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium, via Playwright), Windows x64 |
+| **Build** | `:hicasso-bench` — `:advanced`, `goog.DEBUG false` |
+| **Adapter** | `:rf.adapter/reagent`; Reagent 2.0.1 |
+| **Schedule** | 5 rounds × (8 warm-up + 12 samples) per arm per round, arms interleaved at the sample level, order rotating **and reflecting** on the sample index |
+| **Arm-order guard** | **reportable** — no arm reads differently for its position in the plan. Self-test 8/8 before anything was measured |
+| **Canonical-DOM parity** | clean under `:advanced` — `{:problems [] :ok? true}` |
+| **Verification** | **0 unverified of 1220** (400 mounts M1 + 400 mounts M2 + 420 writes bulk) |
+
+All bar numbers are browser numbers. No JVM or Node figure appears on this page.
+
+## The arms
+
+| arm | what it is | role |
+|---|---|---|
+| `:floor` | the same DOM, hand-built with `react/createElement`, no substrate | the **per-round calibrator**. This box drifts further across rounds than several of the effects being measured, so every figure is a ratio to the floor measured in *that* round |
+| `:reagent-subs` | `reg-view` boundaries reading `@(rf/subscribe [:p0/cell i])` against one frame, `rf/frame-provider` at the root | **the denominator.** The bar's `1.0×` is this arm |
+| `:reagent-ratom` | form-2 components over `r/cursor` on a bare `r/atom` | a **labelled lower bound**, never the bar. `subs ÷ ratom` is the reactive system's price, measured rather than argued |
+| `:ctl-2x` | the floor at exactly twice the boundaries | the **positive control**, predicted from the element count before the run; parity-exempt because it builds a different page on purpose |
+
+One page hosts all four. The predecessor programme costed this arm at *"two
+adapter phases bridged by the floor"* because its own view substrate was inert
+under a ratom adapter; every arm here is Reagent or nothing, so one
+`(rf/init! reagent/adapter)` serves all of them.
+
+## The rows
+
+Ranges are min–max **across the five rounds**. A range that includes 1.0 means
+the two arms are **indistinguishable**, and is reported as such rather than as a
+winner.
+
+### Mount — M1: 300 sub-reading boundaries (901 elements) · **bar row**
+
+| ratio | mean | range | verdict |
+|---|---|---|---|
+| `reagent-subs ÷ floor` | **3.899×** | 3.447 – 4.300 | disjoint from 1.0 |
+| `reagent-ratom ÷ floor` | 3.224× | 2.632 – 3.633 | disjoint from 1.0 |
+| **`reagent-subs ÷ reagent-ratom`** — the reactive leg | **1.218×** | 1.122 – 1.310 | disjoint from 1.0 |
+
+Absolute p50 per round, ms: floor 1.80 / 1.90 / 1.65 / 1.50 / 1.50 ·
+`reagent-subs` 7.35 / 6.55 / 6.05 / 6.45 / 6.00 · `reagent-ratom` 6.25 / 5.00 /
+4.65 / 5.45 / 5.35.
+
+### Mount — M2: the ordinary 12-field form (51 elements) · **diagnostic only**
+
+| ratio | mean | range | verdict |
+|---|---|---|---|
+| `reagent-subs ÷ floor` | 1.874× | 1.750 – 2.050 | disjoint from 1.0 |
+| `reagent-ratom ÷ floor` | 1.785× | 1.625 – 2.083 | disjoint from 1.0 |
+| **`reagent-subs ÷ reagent-ratom`** — the reactive leg | 1.056× | 0.960 – 1.242 | **straddles 1.0 — indistinguishable** |
+
+**This row is diagnostic-grade and must not be quoted against the bar.** A
+51-element mount takes a few tenths of a millisecond — three to six of Chrome's
+100 µs `performance.now()` quanta — so its ratios are quantised more coarsely
+than a 10% effect. What it does say is that the ordinary form shape shows **no
+large reactive-system penalty on mount**: at this size the subscription graph and
+the bare cursor are not distinguishable.
+
+### Bulk — one commit that all 300 sub-reading boundaries read · **bar row**
+
+| ratio | mean | range | verdict |
+|---|---|---|---|
+| `reagent-subs ÷ floor` | **7.064×** | 6.200 – 7.700 | disjoint from 1.0 |
+| `reagent-ratom ÷ floor` | 3.519× | 3.200 – 3.900 | disjoint from 1.0 |
+| **`reagent-subs ÷ reagent-ratom`** — the reactive leg | **2.008×** | 1.938 – 2.100 | disjoint from 1.0 |
+
+Absolute p50 per round, ms: floor 0.60 / 0.50 / 0.55 / 0.50 / 0.50 ·
+`reagent-subs` 4.20 / 3.85 / 3.75 / 3.80 / 3.10 · `reagent-ratom` 2.00 / 1.95 /
+1.85 / 1.90 / 1.60.
+
+Window decomposition (p50 ms): the write leg and the microtask gap both read
+**0.0** on every arm — `frame/replace-app-db!` installs into the container and
+returns, and Reagent commits inside its own drain — so essentially the entire
+window is the drain: floor 0.50, `reagent-subs` 3.80, `reagent-ratom` 1.90,
+`ctl-2x` 1.00.
+
+**The bulk floor is not a lower bound.** It is a plain top-down React re-render,
+which is what an application with no reactive substrate costs. A fine-grained
+substrate can and should beat it on a narrow write; on a *broad* write, where
+every boundary changes, it is the thing to beat.
+
+## The positive control
+
+Predicted from the element count, written down before the run, published every
+run whether it passes or not.
+
+| row | predicted | measured (mean) | range | basis | verdict |
+|---|---|---|---|---|---|
+| mount M1 | 1.999× | 1.839× | 1.632 – 1.944 | 1801 / 901 elements | ✅ within ±25% |
+| mount M2 | 1.941× | 1.674× | 1.500 – 1.833 | 99 / 51 elements | ✅ within ±25% |
+| bulk | 1.999× | 1.930× | 1.800 – 2.200 | 1801 / 901 elements | ✅ within ±25% |
+
+The slack is 25% and is generous on purpose: the claim being certified is *the
+instrument has signal*, not *the model is exact* — a top-down React re-render is
+not perfectly linear in element count, because the root, the commit and the diff
+walk do not double. Every measured control sits **below** its prediction, which
+is the direction that fixed per-root overhead predicts.
+
+## What this settles, and what it does not
+
+**Settles.** The bar's denominator exists and is a browser number. Reading
+re-frame2 subscriptions rather than a bare cursor costs Reagent **≈1.22× on
+mount** of the 300-boundary shape and **≈2.01× on a broad commit** — both
+disjoint from 1.0, so both real. That figure was previously argued rather than
+measured, and it is the term that made the predecessor's `13.5×` broad-update row
+an upper bound of unknown content.
+
+**Does not settle.** Nothing about a candidate: no Hicasso arm exists, and none is
+quotable against this table until it does. Nothing about UIx (rf2-2rtt6.4 owns the
+frontier comparator and the red-zone ratios are set from it). Nothing about narrow
+writes (rf2-2rtt6.3) or retained heap (rf2-2rtt6.5). And nothing about the
+ordinary form shape at better than clock resolution.
+
+## Instrument faults caught, and what each cost
+
+Both were caught by the harness's own discipline **before** any number was
+published, and both were repaired in the arm.
+
+**1. A read-back that could not pass — `400 unverified of 400`.** The mount
+verification probed a `data-i` cell in both witnesses; the form witness carries no
+such attribute, so every M2 mount was counted unverified while the page was in
+fact perfectly correct. A read-back that cannot pass is worse than none: it
+manufactures a defect and would hide a real one behind it. Verification is now per
+witness and reads **both ends** of the page — a page that committed only its head
+passes a single-probe check at index 0.
+
+**2. The arm-order guard refused a plausible instrument change — exit 2.**
+Batching M2 to eight 51-element roots in one `flushSync` window, to lift it clear
+of the clock clamp, produced this:
+
+| arm | last third ÷ first third | predecessor factor |
+|---|---|---|
+| `M2/floor` | **5.017×**, ranges disjoint | clean |
+| `M2/ctl-2x` | **5.427×**, ranges disjoint | clean |
+| `M2/reagent-ratom` | **4.766×**, ranges disjoint | clean |
+| `M2/reagent-subs` | **3.234×**, ranges disjoint | clean |
+
+— while the unbatched M1 row, running immediately before it in the same page,
+drifted 1.13×–1.16× with ranges overlapping. Position, not adjacency; a property
+of the batched arm, not of anything under test. **The batch was withdrawn and the
+tolerance was not touched.** The resulting clock coarseness is stated on the M2
+row above and that row is graded diagnostic. A refused figure and a quantised
+figure are not the same thing: the first may not be published at all, the second
+may be published with its resolution named.
+
+## Method
+
+- **Both orders.** Every pairing runs in both arm orders — the schedule rotates
+  *and reflects* on the sample index, because a bare cyclic rotation changes only
+  which arm goes first and leaves every adjacency intact.
+- **Position before adjacency.** Every sample carries its position in the whole
+  run, and the guard partitions on first-third against last-third as well as on
+  predecessor. Warm-up matters more than interleaving.
+- **Ranges, never a mean alone.** Overlapping ranges mean indistinguishable.
+- **Every measured write and every measured mount is read back out of the DOM
+  inside its own window**, and the count is published as `N unverified of M`.
+- **A positive control with predicted vs measured, every run.**
+- **Arm labels are row-qualified** (`M1/floor`, `M2/floor`, `bulk/floor`) before
+  they reach the guard: three witnesses' floor arms are three different amounts of
+  work, and pooled under one name their ranges are disjoint by construction —
+  the guard would refuse the witness table rather than a contamination.

--- a/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
@@ -1,0 +1,479 @@
+(ns re-frame.bench.hicasso.lane
+  "THE HICASSO P0 MEASUREMENT LANE — the shared instrument every P0 arm
+  runs on (EP-0038, HD-017; built by rf2-2rtt6.2 for rf2-2rtt6.2/.3/.4/.5).
+
+  One instrument, four arms' worth of consumers, so the METHOD is one
+  thing a reader checks once. What lives here is everything that is the
+  same whatever is being measured: the canonical-DOM fairness gate, the
+  timed window, the reflecting schedule, the per-round floor
+  normalisation, the DOM read-back accounting, the positive control's
+  predicted-vs-measured arithmetic, and the arm-order guard's refusal.
+
+  ## Where this file lives, and why the namespace does not say `freehand`
+
+  Physically under `implementation/freehand/test/` because HD-017 carves
+  the bench/test measurement lane out of the donor freeze and that tree
+  is the one whose classpath already carries Reagent, UIx, React and
+  `react-dom` together. The NAMESPACE is `re-frame.bench.hicasso.*`
+  because the charter's anti-regression fence is explicit that Hicasso
+  carries no continuity claim to its predecessors: an instrument that had
+  to spell a withdrawn programme's name to compile would be making one.
+  `implementation/freehand/test` is a shadow `:source-paths` root, so the
+  path under it is the namespace and nothing else is needed.
+
+  Nothing here requires anything out of `implementation/freehand/src`.
+  That is deliberate and it is why `now-ms`/`summarise` are re-derived in
+  eleven lines rather than borrowed from the donor's `bench.measure`: a
+  frozen donor `src/` tree is not a dependency this lane should acquire.
+
+  ## What a reading is
+
+  `react-dom/flushSync` brackets the commit, so the measured window holds
+  the substrate's element construction AND React's render, commit and DOM
+  mutation, with nothing scheduled out of it. Nothing runs inside an
+  `act` environment: `act` diverts work to its own queue, which is not
+  what a browser does, and the whole point of the window is that it is
+  the browser's.
+
+  ## The five disciplines this file enforces, and what each one cost
+
+  Fifteen instrument faults were caught on the predecessor programme's
+  harnesses, and every one of them produced a plausible PRECISE WRONG
+  NUMBER before it was caught. The five that are structural are enforced
+  here rather than left to each arm:
+
+  1. **Both orders, and position before adjacency.** [[rounds!]] schedules
+     with [[re-frame.bench.order-guard/slot-order]], which rotates AND
+     REFLECTS, so every arm has at least two distinct immediate
+     predecessors. A bare cyclic rotation — which four harnesses published
+     as \"order rotating with the round\" — changes only which arm goes
+     first and leaves every adjacency intact. And the larger effect is not
+     adjacency at all: the recorded live reproduction read the same
+     control `10.32 10.26 10.26 10.26 10.33 10.28` and then `8.12` for
+     ever, +27% across six windows with nothing varying but how many times
+     the site had run, while a held-fixed predecessor was worth 0.0–0.3%.
+     So WARM-UP MATTERS MORE THAN INTERLEAVING, every sample carries its
+     `:position` in the whole run, and the guard partitions on thirds.
+  2. **Ranges, never a mean alone.** [[across-rounds]] answers min/max/mean
+     per arm and flags `:straddles-1?`; overlapping ranges mean
+     INDISTINGUISHABLE and a report must say so rather than quote the
+     mean as a winner.
+  3. **Every measured write is read back out of the DOM inside its own
+     window.** [[verified-write!]] reads the written cell after the clock
+     stops and before the sample is banked; [[tally]] carries the count
+     forward so every published row states `N unverified of M`. A clock
+     alone once accepted a window in which 1,320 of 1,320 writes never
+     reached the page.
+  4. **A positive control with predicted vs measured, every run.**
+     [[control-verdict]] takes a stated prediction and the measured range
+     and answers whether the instrument had the signal its own arithmetic
+     says it must. An instrument that cannot see a change it PREDICTS
+     cannot be trusted to see one it does not.
+  5. **The guard refuses, and the refusal is exit code 2.** [[guard!]]
+     runs the shared self-test before anything is measured and the
+     verdict after; `run.cjs` turns `:refuse? true` into `exit 2`. Four
+     workers have hit a refusal on the predecessor harnesses and every one
+     of them repaired the ARM. The tolerance is not the arm's to move."
+  (:require ["react-dom" :as react-dom]
+            [clojure.string :as str]
+            [re-frame.bench.order-guard :as guard]))
+
+;; ---------------------------------------------------------------------------
+;; Clock and summary — eleven lines, so the lane owes the donor tree nothing
+;; ---------------------------------------------------------------------------
+
+(defn now-ms
+  "`performance.now()` where it exists. Chrome clamps it to 100 µs, which
+  is why every row states how many operations one SAMPLE contains."
+  []
+  (if (and (exists? js/performance) (.-now js/performance))
+    (js/performance.now)
+    (.getTime (js/Date.))))
+
+(defn summarise
+  "`{:n :min :max :p50}` over `xs`."
+  [xs]
+  (let [v (vec (sort xs))
+        c (count v)]
+    (when (pos? c)
+      {:n   c
+       :min (nth v 0)
+       :max (peek v)
+       :p50 (if (odd? c)
+              (nth v (quot c 2))
+              (/ (+ (nth v (dec (quot c 2))) (nth v (quot c 2))) 2.0))})))
+
+(defn round4 [x] (/ (js/Math.round (* (double x) 10000.0)) 10000.0))
+
+;; ---------------------------------------------------------------------------
+;; Hosts
+;; ---------------------------------------------------------------------------
+
+(defn browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn leave-act-environment!
+  "React's `act` queue is not the browser's scheduler. Every reading in
+  this lane is taken outside it, so a commit measured here is the commit
+  a user's page performs."
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  nil)
+
+(defn fresh-container! []
+  (let [c (js/document.createElement "div")]
+    (.appendChild js/document.body c)
+    c))
+
+;; ---------------------------------------------------------------------------
+;; Canonical DOM — the fairness gate
+;; ---------------------------------------------------------------------------
+
+(defn canonical
+  "Serialise `node`'s subtree with every element's attribute names SORTED.
+
+  `innerHTML` preserves insertion order and two front ends write props in
+  different orders, so comparing it compares the serialiser rather than
+  the page. Sorting the names compares the DOM. This is the entire
+  fairness guarantee of a cross-arm ratio: without it two arms can be
+  timed against each other while building different pages."
+  [node]
+  (let [out (array)]
+    (letfn [(walk [n]
+              (case (.-nodeType n)
+                1 (let [tag   (str/lower-case (.-tagName n))
+                        attrs (->> (array-seq (.-attributes n))
+                                   (map (fn [a] [(.-name a) (.-value a)]))
+                                   (sort-by first))]
+                    (.push out (str "<" tag))
+                    (doseq [[k v] attrs] (.push out (str " " k "=\"" v "\"")))
+                    (.push out ">")
+                    (doseq [c (array-seq (.-childNodes n))] (walk c))
+                    (.push out (str "</" tag ">")))
+                3 (.push out (.-nodeValue n))
+                8 nil
+                (.push out (str "#" (.-nodeType n)))))]
+      (doseq [c (array-seq (.-childNodes node))] (walk c)))
+    (.join out "")))
+
+(defn element-count [node] (.-length (.querySelectorAll node "*")))
+
+(defn text-at
+  "The text of the `data-i=\"i\"` cell inside `container`, or nil. The
+  read-back probe every verified window uses."
+  [container i]
+  (some-> (.querySelector container (str "[data-i=\"" i "\"]")) (.-textContent)))
+
+;; ---------------------------------------------------------------------------
+;; One timed mount
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private mount-seq (atom 0))
+
+(defn mount-arm!
+  "Mount `arm` over `props` into a fresh host; answer
+  `{:ms … :container … :handle … :arm …}`.
+
+  The container is created and attached OUTSIDE the window: a
+  `document.createElement` billed to one arm and not another would be a
+  systematic error the size of some of the effects here."
+  [arm props]
+  (let [n         (swap! mount-seq inc)
+        container (fresh-container!)
+        handle    (volatile! nil)
+        t0        (now-ms)]
+    (react-dom/flushSync (fn [] (vreset! handle ((:mount arm) container props n))))
+    {:ms (- (now-ms) t0) :container container :handle @handle :arm arm}))
+
+(defn release!
+  "Unmount and detach. Never timed."
+  [{:keys [arm handle container]}]
+  (when handle
+    (try (react-dom/flushSync (fn [] ((:unmount arm) handle)))
+         (catch :default _ nil)))
+  (when container (.remove container))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Parity — run before any clock is read
+;; ---------------------------------------------------------------------------
+
+(defn parity
+  "Mount every arm of `arms` at `props` at once and compare their pages.
+
+  `:parity-exempt?` arms are mounted and released but excluded from the
+  comparison — the positive control builds a DIFFERENT page on purpose
+  (that is what makes it a control), so folding it into the equality
+  would turn the fairness gate into a permanent failure.
+
+  Leaves the mounts standing; the caller releases them, so it can read
+  the pages before they go."
+  [arms props]
+  (let [mounts (mapv (fn [a] (mount-arm! a props)) arms)
+        judged (remove #(:parity-exempt? (:arm %)) mounts)
+        canon  (into {} (map (fn [m] [(:id (:arm m)) (canonical (:container m))])) judged)
+        counts (into {} (map (fn [m] [(:id (:arm m)) (element-count (:container m))])) judged)
+        ref    (get canon (:id (:arm (first judged))))]
+    {:mounts    mounts
+     :canon     canon
+     :counts    counts
+     :reference ref
+     :agree?    (every? #(= ref %) (vals canon))
+     :disagree  (into [] (comp (remove (fn [[_ h]] (= ref h))) (map first)) canon)}))
+
+;; ---------------------------------------------------------------------------
+;; The schedule, and the guard's samples
+;; ---------------------------------------------------------------------------
+
+(def slot-order
+  "The reflecting schedule, taken from the guard itself rather than
+  restated. `order-guard`'s self-test carries the arithmetic proof that a
+  bare rotation gives every arm exactly ONE within-round predecessor and
+  that reflecting on odd rounds gives it two in balance; a second copy
+  here would be a second authority with nothing holding it in step."
+  guard/slot-order)
+
+(defn sample-collector
+  "A mutable collector for the guard's samples.
+
+  `:position` is the index in the WHOLE run, not within a round, because
+  the effect the guard is most likely to catch is warm-up and warm-up
+  does not restart at a round boundary."
+  []
+  (atom {:pos 0 :prev nil :samples []}))
+
+(defn collect!
+  "Bank one sample for arm `id` at `value`, tagged with what ran
+  immediately before it and where in the run it sits."
+  [coll id value]
+  (swap! coll (fn [{:keys [pos prev samples]}]
+                {:pos      (inc pos)
+                 :prev     id
+                 :samples  (conj samples {:arm (name id) :value value
+                                          :predecessor (some-> prev name)
+                                          :position pos})}))
+  value)
+
+;; ---------------------------------------------------------------------------
+;; Rounds
+;; ---------------------------------------------------------------------------
+
+(defn rounds!
+  "Run `rounds` rounds of `sampling` over `arms`, calling
+  `(measure-one! arm)` for each sample and banking the answer.
+
+  Every sample index visits every arm, in [[slot-order]]'s reflecting
+  order. Warm-up samples are taken and DISCARDED — they still move the
+  site's position, which is the point.
+
+  Answers `{:readings [{id [ms …]} …] :samples [guard-samples]}`."
+  [arms {:keys [warmup samples] :as _sampling} rounds measure-one!]
+  (let [k    (count arms)
+        coll (sample-collector)
+        out  (mapv
+               (fn [_round]
+                 (let [acc (atom (zipmap (map :id arms) (repeat [])))]
+                   (dotimes [s (+ warmup samples)]
+                     (doseq [j (slot-order k s)]
+                       (let [arm (nth arms j)
+                             ms  (measure-one! arm)]
+                         (when (>= s warmup)
+                           (collect! coll (:id arm) ms)
+                           (swap! acc update (:id arm) conj ms)))))
+                   @acc))
+               (range rounds))]
+    {:readings out :samples (:samples @coll)}))
+
+(defn normalise
+  "One round's raw readings as `{:p50 {id ms} :ratio {id r}}`, every ratio
+  against the floor measured in THAT round."
+  [readings floor-id]
+  (let [p50s  (into {} (map (fn [[id xs]] [id (:p50 (summarise xs))])) readings)
+        floor (get p50s floor-id)]
+    {:p50   p50s
+     :ratio (into {} (map (fn [[id v]] [id (round4 (/ v floor))])) p50s)}))
+
+(defn across-rounds
+  "Fold per-round ratio maps into
+  `{id {:mean :min :max :rounds :straddles-1?}}`.
+
+  `:straddles-1?` is the honesty flag: when an arm's range includes 1.0
+  the report says the arms are indistinguishable rather than quoting the
+  mean as a winner."
+  [round-ratios]
+  (let [ids (keys (first round-ratios))]
+    (into {}
+          (map (fn [id]
+                 (let [vs (mapv #(get % id) round-ratios)]
+                   [id {:mean         (round4 (/ (reduce + 0.0 vs) (count vs)))
+                        :min          (round4 (apply min vs))
+                        :max          (round4 (apply max vs))
+                        :rounds       (count vs)
+                        :straddles-1? (and (<= (apply min vs) 1.0)
+                                           (>= (apply max vs) 1.0))}])))
+          ids)))
+
+(defn ratio-between
+  "The ratio of arm `a` to arm `b`, per round, as a range. The bar is
+  stated against a DENOMINATOR ARM, not against the floor, so this is the
+  arithmetic a bar row quotes."
+  [round-ratios a b]
+  (let [vs (mapv (fn [r] (round4 (/ (get r a) (get r b)))) round-ratios)]
+    {:numerator a :denominator b
+     :mean (round4 (/ (reduce + 0.0 vs) (count vs)))
+     :min (apply min vs) :max (apply max vs)
+     :per-round vs
+     :straddles-1? (and (<= (apply min vs) 1.0) (>= (apply max vs) 1.0))}))
+
+;; ---------------------------------------------------------------------------
+;; Verified writes — "N unverified of M"
+;; ---------------------------------------------------------------------------
+
+(defn tally
+  "A write-verification tally. `:of` counts every measured write; `:bad`
+  counts those whose value never reached the page inside their own
+  window."
+  []
+  (atom {:of 0 :bad 0}))
+
+(defn tally-value [t] (let [{:keys [of bad]} @t] {:writes of :unverified bad}))
+
+(defn verified-write!
+  "Write, yield ONE microtask, force the arm's own synchronous drain, stop
+  the clock — THEN read the written cell back out of the DOM.
+
+  Answers a promise of `{:ms :write-ms :gap-ms :force-ms :ok?}` and banks
+  the verification in `t`.
+
+  The read-back is inside the sample's own window, not a spot check at
+  the end: a window whose commit lands after the clock stops reads the
+  OLD value and its milliseconds are a measurement of nothing. The
+  recorded fault is 1,320 of 1,320 writes accepted by a clock that never
+  looked at the page.
+
+  The microtask is load-bearing for any arm whose notification is queued
+  rather than synchronous, and it is priced in situ: `:gap-ms` is
+  reported per arm, and an arm that commits without it reads 0.0 there.
+  Splitting the window is what lets a reader see how much of a ratio is
+  the reactive leg and how much is React."
+  [t {:keys [arm container]} i val probe]
+  (let [t0 (now-ms)]
+    ((:write! arm) i val)
+    (let [t1 (now-ms)]
+      (-> (js/Promise.resolve nil)
+          (.then (fn [_]
+                   (let [t2 (now-ms)]
+                     ((:force! arm))
+                     (let [t3  (now-ms)
+                           ok? (= (str val) (text-at container probe))]
+                       (swap! t (fn [{:keys [of bad]}]
+                                  {:of (inc of) :bad (if ok? bad (inc bad))}))
+                       {:ms       (- t3 t0)
+                        :write-ms (- t1 t0)
+                        :gap-ms   (- t2 t1)
+                        :force-ms (- t3 t2)
+                        :ok?      ok?}))))))))
+
+(defn chain
+  "Fold `xs` into a serial promise chain, threading an accumulator."
+  [init xs f]
+  (reduce (fn [p x] (.then p (fn [acc] (f acc x)))) (js/Promise.resolve init) xs))
+
+;; ---------------------------------------------------------------------------
+;; The positive control
+;; ---------------------------------------------------------------------------
+
+(defn control-verdict
+  "Adjudicate a positive control: a STATED prediction against a measured
+  range.
+
+  `predicted` is a number the control's own arithmetic produces before
+  the run — the element count doubles, so the work doubles — and
+  `measured` is `{:min :max :mean}`. `slack` is how far the measured
+  range may sit from the prediction and still count as the instrument
+  having seen what it predicted; it is generous on purpose, because the
+  claim being made is `THE INSTRUMENT HAS SIGNAL`, not `THE MODEL IS
+  EXACT`. A control whose measured range does not contain a value within
+  `slack` of the prediction means the instrument cannot see a change it
+  predicts, and nothing else it measured is worth reading.
+
+  Answers `{:predicted :measured :ok? :why}` — published on every run,
+  passing or not, because a control quoted only when it passes is not a
+  control."
+  [predicted {:keys [min max mean] :as measured} slack]
+  (let [lo (* predicted (- 1.0 slack))
+        hi (* predicted (+ 1.0 slack))
+        ok? (and (<= min hi) (>= max lo))]
+    {:predicted predicted
+     :measured  measured
+     :slack     slack
+     :ok?       ok?
+     :why       (if ok?
+                  (str "predicted " (.toFixed predicted 3) "x, measured "
+                       (.toFixed mean 3) "x [" (.toFixed min 3) "–" (.toFixed max 3)
+                       "] — the range meets the prediction within ±"
+                       (.toFixed (* 100.0 slack) 0) "%")
+                  (str "predicted " (.toFixed predicted 3) "x, measured "
+                       (.toFixed mean 3) "x [" (.toFixed min 3) "–" (.toFixed max 3)
+                       "] — DISJOINT from ±" (.toFixed (* 100.0 slack) 0)
+                       "% of the prediction; the instrument did not see a change "
+                       "its own arithmetic says it must, so no figure in this run "
+                       "is reportable"))}))
+
+;; ---------------------------------------------------------------------------
+;; The guard
+;; ---------------------------------------------------------------------------
+
+(defn self-test!
+  "Run the shared arm-order self-test. A harness that gets `false` must
+  measure nothing — the copy of the rule it is about to rely on no longer
+  behaves like the one the `.cjs` drivers use."
+  []
+  (guard/print-self-test!))
+
+(defn guard!
+  "Adjudicate `samples` and print the report. `:refuse?` is what the
+  driver acts on, and `run.cjs` turns it into exit code 2."
+  ([samples] (guard! samples nil {}))
+  ([samples title] (guard! samples title {}))
+  ([samples title opts]
+   (let [v (guard/verdict samples (merge {:tolerance 0.10} opts))]
+     (doseq [l (guard/report-lines v title)] (js/console.log l))
+     v)))
+
+;; ---------------------------------------------------------------------------
+;; Publication
+;; ---------------------------------------------------------------------------
+
+(defn runtime-label
+  "The runtime a figure was taken on, carried BESIDE the figure. A ratio
+  without its runtime is a number without a denominator."
+  []
+  {:user-agent   (when (exists? js/navigator) (.-userAgent js/navigator))
+   :optimizations :advanced
+   :goog-debug   ^boolean goog/DEBUG
+   :hardware-concurrency (when (exists? js/navigator) (.-hardwareConcurrency js/navigator))
+   :device-memory        (when (exists? js/navigator) (.-deviceMemory js/navigator))})
+
+(defn record!
+  "Park one record on `window.HICASSO_RESULTS` for the driver to read, and
+  echo it to the console as EDN."
+  [k v]
+  (let [acc (or (.-HICASSO_RESULTS js/window) #js {})]
+    (aset acc (name k) (pr-str v))
+    (set! (.-HICASSO_RESULTS js/window) acc)
+    (js/console.log (str ";; HICASSO " (name k) "\n" (pr-str v)))
+    v))
+
+(defn fail!
+  "Record a fatal reason. The driver exits non-zero and publishes nothing
+  as measured."
+  [why]
+  (set! (.-HICASSO_ERROR js/window) (str why))
+  (js/console.error (str ";; HICASSO FAILED — " why))
+  nil)
+
+(defn done! []
+  (set! (.-HICASSO_DONE js/window) true)
+  (js/console.log ";; HICASSO DONE")
+  nil)

--- a/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
@@ -185,6 +185,33 @@
     (react-dom/flushSync (fn [] (vreset! handle ((:mount arm) container props n))))
     {:ms (- (now-ms) t0) :container container :handle @handle :arm arm}))
 
+(defn mount-batch!
+  "Mount `arm` `k` times with ALL k inside ONE timed window; answer
+  `{:ms … :mounts […]}`. The caller releases the mounts.
+
+  `k` exists because Chrome clamps `performance.now()` to 100 µs and a
+  small witness sits on that clamp: the predecessor's narrow row measured
+  one write at a time and got back exactly 0.1 ms from two different
+  arms — the quantum itself, wearing a null result's clothes. Timing `k`
+  operations as ONE sample lifts the window clear of the clamp, and it is
+  not the same as summing `k` separately-clamped readings, which
+  quantises `k` times and adds the errors.
+
+  Every container is created and attached BEFORE the clock starts, for
+  the same reason [[mount-arm!]] does it: a `document.createElement`
+  billed to one arm and not another is a systematic error the size of
+  some of the effects here."
+  [arm props k]
+  (let [containers (vec (repeatedly k fresh-container!))
+        handles    (volatile! nil)
+        t0         (now-ms)]
+    (react-dom/flushSync
+      (fn [] (vreset! handles
+                      (mapv (fn [c] ((:mount arm) c props (swap! mount-seq inc)))
+                            containers))))
+    {:ms     (- (now-ms) t0)
+     :mounts (mapv (fn [c h] {:arm arm :container c :handle h}) containers @handles)}))
+
 (defn release!
   "Unmount and detach. Never timed."
   [{:keys [arm handle container]}]
@@ -266,23 +293,31 @@
   order. Warm-up samples are taken and DISCARDED — they still move the
   site's position, which is the point.
 
+  `label` names an arm to the GUARD, and it must be unique across every
+  row a single verdict pools. Three witnesses' `:floor` arms are three
+  different amounts of work; pooled under one name their ranges are
+  disjoint by construction and the guard refuses a contamination that is
+  really just the witness table.
+
   Answers `{:readings [{id [ms …]} …] :samples [guard-samples]}`."
-  [arms {:keys [warmup samples] :as _sampling} rounds measure-one!]
-  (let [k    (count arms)
-        coll (sample-collector)
-        out  (mapv
-               (fn [_round]
-                 (let [acc (atom (zipmap (map :id arms) (repeat [])))]
-                   (dotimes [s (+ warmup samples)]
-                     (doseq [j (slot-order k s)]
-                       (let [arm (nth arms j)
-                             ms  (measure-one! arm)]
-                         (when (>= s warmup)
-                           (collect! coll (:id arm) ms)
-                           (swap! acc update (:id arm) conj ms)))))
-                   @acc))
-               (range rounds))]
-    {:readings out :samples (:samples @coll)}))
+  ([arms sampling rounds measure-one!]
+   (rounds! arms sampling rounds measure-one! (fn [arm] (name (:id arm)))))
+  ([arms {:keys [warmup samples] :as _sampling} rounds measure-one! label]
+   (let [k    (count arms)
+         coll (sample-collector)
+         out  (mapv
+                (fn [_round]
+                  (let [acc (atom (zipmap (map :id arms) (repeat [])))]
+                    (dotimes [s (+ warmup samples)]
+                      (doseq [j (slot-order k s)]
+                        (let [arm (nth arms j)
+                              ms  (measure-one! arm)]
+                          (when (>= s warmup)
+                            (collect! coll (label arm) ms)
+                            (swap! acc update (:id arm) conj ms)))))
+                    @acc))
+                (range rounds))]
+     {:readings out :samples (:samples @coll)})))
 
 (defn normalise
   "One round's raw readings as `{:p50 {id ms} :ratio {id r}}`, every ratio
@@ -355,8 +390,15 @@
   rather than synchronous, and it is priced in situ: `:gap-ms` is
   reported per arm, and an arm that commits without it reads 0.0 there.
   Splitting the window is what lets a reader see how much of a ratio is
-  the reactive leg and how much is React."
-  [t {:keys [arm container]} i val probe]
+  the reactive leg and how much is React.
+
+  `probes` is a SEQ of cell indices and ALL of them must hold the written
+  value. A broad write changes every cell, so verifying one of them
+  verifies almost nothing: the recorded fault is a commit that landed
+  outside the window, and a stale page can still have one fresh cell in
+  it from the previous write. The rotating probe plus the far end of the
+  grid is the cheapest read that a partial commit cannot satisfy."
+  [t {:keys [arm container]} i val probes]
   (let [t0 (now-ms)]
     ((:write! arm) i val)
     (let [t1 (now-ms)]
@@ -365,7 +407,7 @@
                    (let [t2 (now-ms)]
                      ((:force! arm))
                      (let [t3  (now-ms)
-                           ok? (= (str val) (text-at container probe))]
+                           ok? (every? #(= (str val) (text-at container %)) probes)]
                        (swap! t (fn [{:keys [of bad]}]
                                   {:of (inc of) :bad (if ok? bad (inc bad))}))
                        {:ms       (- t3 t0)

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_app.cljs
@@ -1,0 +1,517 @@
+(ns re-frame.bench.hicasso.p0-reagent-app
+  "THE P0 REAGENT-ON-SUBS BASELINE RUN — mount and bulk, browser,
+  `:advanced` (rf2-2rtt6.2; EP-0038 P0; the bar is HD-012).
+
+  The `:init-fn` of the `:hicasso-bench` build. Driven by
+  `implementation/freehand/test/re_frame/bench/hicasso/run.cjs`, which
+  builds this entry, serves it, drives Chromium, prints every record and
+  turns an arm-order refusal into exit code 2.
+
+  What it produces is the SHIP BAR'S DENOMINATOR: mount and bulk view
+  work for Reagent reading re-frame2 subscriptions, on the shapes the
+  charter names, with the floor as the per-round calibrator, the
+  Reagent/ratom arm as a labelled lower bound, and a positive control
+  whose prediction is written down before the run.
+
+  ## The order of operations, and why it is this order
+
+  1. **The arm-order guard's self-test.** Before anything is measured.
+     A harness whose copy of the rule has drifted must measure nothing,
+     and the self-test replays recorded fixtures from the live study
+     rather than a restatement of itself.
+  2. **Canonical-DOM parity, under `:advanced`.** Repeated here even
+     though it is a deterministic property, because a parity that held
+     under `:none` and failed under `:advanced` would be a renaming bug
+     silently deciding the comparison.
+  3. **The mount rows**, then the bulk row.
+  4. **The positive control's verdict**, then the guard's.
+
+  Nothing publishes until the guard has spoken. `run.cjs` prints the
+  records regardless — a refused figure is still worth looking at, it is
+  simply not reportable — and exits 2.
+
+  ## What is NOT here
+
+  No UIx arm (rf2-2rtt6.4 owns the frontier comparator), no narrow-write
+  leg (rf2-2rtt6.3), no heap ladder (rf2-2rtt6.5). All three ride this
+  lane's `lane.cljs` and this build id; none of them needs to touch
+  `shadow-cljs.edn`."
+  (:require ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.p0-reagent-views :as v]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [reagent.core :as r]
+            [reagent.dom.client :as rdc]))
+
+(def ^:private rounds 5)
+(def ^:private mount-sampling {:warmup 8 :samples 12})
+(def ^:private bulk-sampling {:warmup 8 :samples 12})
+
+;; The control's slack. Generous on purpose: the claim it certifies is
+;; THE INSTRUMENT HAS SIGNAL, not THE MODEL IS EXACT. A top-down React
+;; re-render is not perfectly linear in element count — there is a root,
+;; a commit and a diff walk that do not double — so demanding 2.00 ± 5%
+;; would fail an instrument that is working. 25% is still far tighter
+;; than the difference between "saw the change" and "saw nothing".
+(def ^:private control-slack 0.25)
+
+(defonce ^:private gen (atom 1000))
+(defn- next-gen! [] (swap! gen inc))
+
+;; ---------------------------------------------------------------------------
+;; Mount arms
+;; ---------------------------------------------------------------------------
+
+(defn- floor-mount-arm
+  [id element-of cells-of & [exempt?]]
+  {:id             id
+   :parity-exempt? (boolean exempt?)
+   :mount          (fn [container props _n]
+                     (let [root (react-dom-client/createRoot container)]
+                       (.render root (element-of (cells-of props)))
+                       root))
+   :unmount        (fn [root] (.unmount root))})
+
+(defn- reagent-mount-arm
+  "Reagent's own mount door — `reagent.dom.client/create-root` and
+  `render`, which is what a Reagent application calls."
+  [id form-of]
+  {:id      id
+   :mount   (fn [container props _n]
+              (let [root (rdc/create-root container)]
+                (rdc/render root (form-of props))
+                root))
+   :unmount (fn [root] (rdc/unmount root))})
+
+(defn- zeros [n] (vec (repeat n 0)))
+
+(defn- input-value
+  "The DOM PROPERTY, not the attribute. React installs a controlled
+  `value` as a property and mirrors it to the attribute only on first
+  render, so a property read is the one that stays true."
+  [container sel]
+  (some-> (.querySelector container sel) (.-value)))
+
+(defn- verify-m1
+  "Both ends of the list. A page that committed only its head would pass a
+  single-probe check at index 0."
+  [container]
+  (and (= "0" (lane/text-at container 0))
+       (= "0" (lane/text-at container (dec v/cells-n)))))
+
+(defn- verify-m2
+  "The first and last field of the SHARED prefix — the control arm has
+  twice the fields, so a probe past `fields-n` would not exist in every
+  arm."
+  [container]
+  (and (= (v/field-value 0 0) (input-value container "#f0"))
+       (= (v/field-value (dec v/fields-n) 0)
+          (input-value container (str "#f" (dec v/fields-n))))))
+
+(def ^:private mount-witnesses
+  [{:id       :M1
+    :verify   verify-m1
+    :doc      (str "the 300-boundary sub-reading list — the bulk shape's mount "
+                   "counterpart, one subscription read per boundary")
+    :props    {:n v/cells-n}
+    :elements (v/m1-elements v/cells-n)
+    :control  {:predicted (/ (double (v/m1-elements (* 2 v/cells-n)))
+                             (double (v/m1-elements v/cells-n)))
+               :basis     (str "element count: " (v/m1-elements (* 2 v/cells-n)) " / "
+                               (v/m1-elements v/cells-n))}
+    :arms [(floor-mount-arm :floor v/m1-floor (fn [{:keys [n]}] (zeros n)))
+           (reagent-mount-arm :reagent-subs
+                              (fn [{:keys [n]}] [v/subs-root v/m1-subs n]))
+           (reagent-mount-arm :reagent-ratom (fn [{:keys [n]}] [v/m1-ratom n]))
+           (floor-mount-arm :ctl-2x v/m1-floor (fn [{:keys [n]}] (zeros (* 2 n))) true)]}
+
+   {:id         :M2
+    :verify     verify-m2
+    ;; 51 elements mounts in a few tenths of a millisecond — three to six
+    ;; of Chrome's 100 µs quanta, which is a ratio quantised more coarsely
+    ;; than the effects it is being asked to resolve. Eight mounts in ONE
+    ;; window puts the sample an order of magnitude clear of the clamp.
+    :per-sample 8
+    :doc      (str "the ordinary 12-field form on subs — the shape most "
+                   "applications are made of")
+    :props    {:n v/fields-n}
+    :elements (v/m2-elements v/fields-n)
+    :control  {:predicted (/ (double (v/m2-elements (* 2 v/fields-n)))
+                             (double (v/m2-elements v/fields-n)))
+               :basis     (str "element count: " (v/m2-elements (* 2 v/fields-n)) " / "
+                               (v/m2-elements v/fields-n))}
+    :arms [(floor-mount-arm :floor v/m2-floor (fn [{:keys [n]}] (zeros n)))
+           (reagent-mount-arm :reagent-subs
+                              (fn [{:keys [n]}] [v/subs-root v/m2-subs n]))
+           (reagent-mount-arm :reagent-ratom (fn [{:keys [n]}] [v/m2-ratom n]))
+           (floor-mount-arm :ctl-2x v/m2-floor (fn [{:keys [n]}] (zeros (* 2 n))) true)]}])
+
+;; ---------------------------------------------------------------------------
+;; Bulk arms — mounted once, then written to
+;; ---------------------------------------------------------------------------
+
+(defn- floor-bulk-arm
+  [id n & [exempt?]]
+  (let [state (atom (zeros n))
+        rt    (volatile! nil)]
+    {:id             id
+     :parity-exempt? (boolean exempt?)
+     :cells          n
+     :mount          (fn [container]
+                       (let [root (react-dom-client/createRoot container)]
+                         (vreset! rt root)
+                         (react-dom/flushSync (fn [] (.render root (v/m1-floor @state))))
+                         root))
+     ;; The render lives in `force!`, not in `write!`, and that is not a
+     ;; convenience. `root.render` called outside a React event schedules
+     ;; at React's DEFAULT lane, and an EMPTY `flushSync` flushes only the
+     ;; SYNC lane — so a floor arm that rendered in `write!` and flushed in
+     ;; `force!` would have its commit land outside the measured window
+     ;; entirely, and the recorded fault is exactly that: 80 of 320 floor
+     ;; samples ending on a cell that still held its old value.
+     :write!         (fn [_i val] (reset! state (vec (repeat n val))))
+     :force!         (fn [] (react-dom/flushSync
+                              (fn [] (.render ^js @rt (v/m1-floor @state)))))
+     :unmount        (fn [root] (react-dom/flushSync (fn [] (.unmount root))))}))
+
+(defn- subs-bulk-arm []
+  {:id      :reagent-subs
+   :cells   v/cells-n
+   :mount   (fn [container]
+              (let [root (rdc/create-root container)]
+                (react-dom/flushSync
+                  (fn [] (rdc/render root [v/subs-root v/m1-subs v/cells-n])))
+                root))
+   :write!  (fn [_i val]
+              (frame/replace-app-db! v/subs-frame (v/seed-cells v/cells-n val)))
+   ;; `reagent.core/flush` is Reagent's own documented synchronous render
+   ;; drain, and it is the SAME drain the ratom arm uses. Both Reagent arms
+   ;; therefore differ in exactly one thing — where the value came from —
+   ;; which is the whole point of the pair.
+   :force!  (fn [] (react-dom/flushSync (fn [] (r/flush))))
+   :unmount (fn [root] (react-dom/flushSync (fn [] (rdc/unmount root))))})
+
+(defn- ratom-bulk-arm []
+  {:id      :reagent-ratom
+   :cells   v/cells-n
+   :mount   (fn [container]
+              (let [root (rdc/create-root container)]
+                (react-dom/flushSync
+                  (fn [] (rdc/render root [v/m1-ratom v/cells-n])))
+                root))
+   :write!  (fn [_i val] (reset! v/ratom-cells (vec (repeat v/cells-n val))))
+   :force!  (fn [] (react-dom/flushSync (fn [] (r/flush))))
+   :unmount (fn [root] (react-dom/flushSync (fn [] (rdc/unmount root))))})
+
+(defn- make-bulk-arms []
+  [(floor-bulk-arm :floor v/cells-n)
+   (subs-bulk-arm)
+   (ratom-bulk-arm)
+   (floor-bulk-arm :ctl-2x (* 2 v/cells-n) true)])
+
+(defn- mount-bulk-arms! [arms]
+  (mapv (fn [a]
+          (let [c (lane/fresh-container!)]
+            {:arm a :container c :handle ((:mount a) c)}))
+        arms))
+
+(defn- release-bulk-arms! [mounts]
+  (doseq [{:keys [arm handle container]} mounts]
+    (try ((:unmount arm) handle) (catch :default _ nil))
+    (.remove container)))
+
+;; ---------------------------------------------------------------------------
+;; Records
+;; ---------------------------------------------------------------------------
+
+(defn- fixture-common []
+  {:reagent-version   "2.0.1"
+   :adapter           :rf.adapter/reagent
+   :runtime           (lane/runtime-label)
+   :denominator       :reagent-subs
+   :floor-note        (str "the same DOM built by hand with react/createElement and no "
+                           "substrate at all; every ratio is to the floor measured in "
+                           "THAT round, because this box drifts further across rounds "
+                           "than several of the effects being measured")
+   :ratom-note        (str "the :reagent-ratom arm reads an r/cursor over a bare "
+                           "reagent.core/atom. It is a LABELLED LOWER BOUND and is never "
+                           "the bar: it pays no subscription graph, no query cache and no "
+                           "frame. (subs - ratom) is the price of the reactive system")
+   :control-note      (str "the :ctl-2x arm is the same floor page at exactly twice the "
+                           "boundaries. Its prediction is arithmetic on the element count "
+                           "and is written down before the run; it is parity-exempt "
+                           "because it builds a different page on purpose")})
+
+;; ---------------------------------------------------------------------------
+;; Mount
+;; ---------------------------------------------------------------------------
+
+(defn- measure-mount!
+  [{:keys [id doc props arms elements control verify per-sample]}]
+  (let [k     (or per-sample 1)
+        t     (lane/tally)
+        one!  (fn [arm]
+                (let [{:keys [ms mounts]} (lane/mount-batch! arm props k)
+                      expected (if (:parity-exempt? arm) nil elements)]
+                  ;; EVERY mount in the batch is read back out of the
+                  ;; document. `verify` is PER WITNESS because the probe has
+                  ;; to exist in the witness — the first cut of this
+                  ;; instrument read a `data-i` cell in both witnesses, the
+                  ;; form has no such attribute, and the M2 row published
+                  ;; `400 unverified of 400` while the page was in fact
+                  ;; perfectly correct. A read-back that cannot pass is worse
+                  ;; than none: it manufactures a defect and would hide a real
+                  ;; one behind it.
+                  (doseq [m mounts]
+                    (let [ok? (and (or (nil? expected)
+                                       (= expected (lane/element-count (:container m))))
+                                   (verify (:container m)))]
+                      (swap! t (fn [{:keys [of bad]}]
+                                 {:of (inc of) :bad (if ok? bad (inc bad))}))))
+                  (doseq [m mounts] (lane/release! m))
+                  ms))
+        {:keys [readings samples]} (lane/rounds! arms mount-sampling rounds one!
+                                                 (fn [arm] (str (name id) "/"
+                                                                (name (:id arm)))))
+        norm  (mapv #(lane/normalise % :floor) readings)
+        ratios (mapv :ratio norm)
+        summ  (lane/across-rounds ratios)
+        ctl   (lane/control-verdict (:predicted control)
+                                    (select-keys (:ctl-2x summ) [:min :max :mean])
+                                    control-slack)
+        record
+        {:benchmark        (keyword "hicasso.P0" (str "mount-" (name id)))
+         :doc              doc
+         :bead             "rf2-2rtt6.2"
+         :fixture          (merge (fixture-common)
+                                  {:witness  id
+                                   :props    props
+                                   :elements elements
+                                   :arms     (mapv :id arms)
+                                   :mounts-per-sample k
+                                   :measurement-method
+                                   (str "a SAMPLE is " k " mount(s) inside ONE "
+                                        "react-dom/flushSync window — Chrome clamps "
+                                        "performance.now() to 100 us and a 51-element "
+                                        "witness sits within a handful of quanta of it, so "
+                                        "the small witness batches to lift every arm clear "
+                                        "of the clamp and the per-mount figure is the "
+                                        "sample divided by " k ". Wall time across "
+                                        "react-dom/flushSync around each "
+                                        "arm's own mount door, into fresh containers "
+                                        "attached BEFORE the window; arms interleaved at "
+                                        "the SAMPLE level with the order rotating AND "
+                                        "REFLECTING on the sample index, so no arm always "
+                                        "follows the same neighbour (a bare rotation does "
+                                        "not vary adjacency at all); " rounds " rounds of "
+                                        (:warmup mount-sampling) " warm-up + "
+                                        (:samples mount-sampling) " samples per arm per "
+                                        "round; every measured mount's element count and "
+                                        "first cell read back out of the DOM")})
+         :sampling         mount-sampling
+         :verification     (lane/tally-value t)
+         :positive-control (assoc ctl :basis (:basis control))
+         :per-round        {:p50 (mapv :p50 norm) :ratio ratios}
+         :ratio-to-floor   summ
+         :bar-row          (lane/ratio-between ratios :reagent-subs :floor)
+         :reactive-leg     (lane/ratio-between ratios :reagent-subs :reagent-ratom)
+         :status           :evidence}]
+    (lane/record! (str "mount-" (name id)) record)
+    {:id id :record record :samples samples :control ctl}))
+
+;; ---------------------------------------------------------------------------
+;; Bulk
+;; ---------------------------------------------------------------------------
+
+(defn- bulk-write!
+  "One broad write on one arm, timed as one sample and verified at the DOM
+  inside its own window.
+
+  A broad write changes every cell, so the probe rotates with the value
+  AND the far end of the grid is checked: a stale page can still carry one
+  fresh cell from the previous write, and a single fixed probe would
+  accept it."
+  [t mnt]
+  (let [n   (:cells (:arm mnt))
+        val (next-gen!)]
+    (lane/verified-write! t mnt :all val [(mod val n) (dec n) 0])))
+
+(defn- seed-bulk! [mounts t]
+  (lane/chain nil mounts
+              (fn [_ mnt] (-> (lane/verified-write! t mnt :all 0
+                                                    [0 (dec (:cells (:arm mnt)))])
+                              (.then (fn [_] nil))))))
+
+(defn- bulk-round!
+  "One round. The guard's samples are banked AT THE SAMPLE, inside the
+  interleave — banking them per arm after the round would record every
+  arm's readings as consecutive and hand the guard a `:position` factor
+  that says only what the loop's shape was."
+  [mounts t legs coll]
+  (let [k     (count mounts)
+        total (+ (:warmup bulk-sampling) (:samples bulk-sampling))
+        acc0  (zipmap (map #(:id (:arm %)) mounts) (repeat []))]
+    (lane/chain {:readings acc0}
+                (for [s (range total) j (lane/slot-order k s)] [s j])
+                (fn [acc [s j]]
+                  (let [mnt (nth mounts j)
+                        id  (:id (:arm mnt))]
+                    (-> (bulk-write! t mnt)
+                        (.then (fn [{:keys [ms write-ms gap-ms force-ms]}]
+                                 (if (>= s (:warmup bulk-sampling))
+                                   (do (lane/collect! coll (str "bulk/" (name id)) ms)
+                                       (swap! legs update id (fnil conj [])
+                                              {:write write-ms :gap gap-ms :force force-ms})
+                                       (update-in acc [:readings id] conj ms))
+                                   acc)))))))))
+
+(defn- leg-summary [legs]
+  (into {}
+        (map (fn [[id xs]]
+               [id {:write-ms (:p50 (lane/summarise (map :write xs)))
+                    :gap-ms   (:p50 (lane/summarise (map :gap xs)))
+                    :force-ms (:p50 (lane/summarise (map :force xs)))}]))
+        legs))
+
+(defn- measure-bulk!
+  [mounts]
+  (let [t    (lane/tally)
+        legs (atom {})
+        coll (lane/sample-collector)]
+    (-> (lane/chain [] (range rounds)
+                    (fn [acc _]
+                      (-> (seed-bulk! mounts t)
+                          (.then (fn [_] (bulk-round! mounts t legs coll)))
+                          (.then (fn [rd] (conj acc (:readings rd)))))))
+        (.then
+          (fn [readings]
+            (let [norm   (mapv #(lane/normalise % :floor) readings)
+                  ratios (mapv :ratio norm)
+                  summ   (lane/across-rounds ratios)
+                  predicted (/ (double (v/m1-elements (* 2 v/cells-n)))
+                               (double (v/m1-elements v/cells-n)))
+                  ctl    (lane/control-verdict
+                           predicted
+                           (select-keys (:ctl-2x summ) [:min :max :mean])
+                           control-slack)
+                  record
+                  {:benchmark        :hicasso.P0/bulk-broad
+                   :doc              (str "one commit that all " v/cells-n
+                                          " sub-reading boundaries read — the "
+                                          "make-or-break row")
+                   :bead             "rf2-2rtt6.2"
+                   :fixture          (merge (fixture-common)
+                                            {:cells v/cells-n
+                                             :arms  (mapv #(:id (:arm %)) mounts)
+                                             :writes-per-sample 1
+                                             :measurement-method
+                                             (str "per sample: t0; the arm's own state "
+                                                  "install; ONE microtask yield; the arm's "
+                                                  "own synchronous drain (an empty "
+                                                  "react-dom/flushSync for the floor arms, "
+                                                  "reagent.core/flush inside one for both "
+                                                  "Reagent arms); t1 — then the written "
+                                                  "cells are read back out of the DOM and "
+                                                  "the sample is counted UNVERIFIED if they "
+                                                  "do not hold the written value. Three "
+                                                  "probes per write: a rotating cell, the "
+                                                  "far end of the grid, and cell 0. Arms "
+                                                  "interleaved at the sample level, order "
+                                                  "rotating AND REFLECTING on the sample "
+                                                  "index; " rounds " rounds of "
+                                                  (:warmup bulk-sampling) " warm-up + "
+                                                  (:samples bulk-sampling) " samples. The "
+                                                  "BULK floor is a plain top-down React "
+                                                  "re-render and is NOT a lower bound — a "
+                                                  "fine-grained substrate can beat it")})
+                   :sampling         bulk-sampling
+                   :verification     (lane/tally-value t)
+                   :positive-control (assoc ctl :basis
+                                            (str "element count: "
+                                                 (v/m1-elements (* 2 v/cells-n)) " / "
+                                                 (v/m1-elements v/cells-n)))
+                   :per-round        {:p50 (mapv :p50 norm) :ratio ratios}
+                   :legs             (leg-summary @legs)
+                   :ratio-to-floor   summ
+                   :bar-row          (lane/ratio-between ratios :reagent-subs :floor)
+                   :reactive-leg     (lane/ratio-between ratios :reagent-subs :reagent-ratom)
+                   :status           :evidence}]
+              (lane/record! "bulk-broad" record)
+              {:record record :samples (:samples @coll) :control ctl}))))))
+
+;; ---------------------------------------------------------------------------
+;; Parity
+;; ---------------------------------------------------------------------------
+
+(defn- parity-problems []
+  (reduce
+    (fn [problems {:keys [id props arms elements]}]
+      (let [{:keys [mounts agree? counts disagree]} (lane/parity arms props)]
+        (try
+          (cond-> problems
+            (not agree?)
+            (conj {:witness id :problem :canonical-dom-disagreement :arms disagree})
+
+            (not (every? #(= elements %) (vals counts)))
+            (conj {:witness id :problem :element-count :expected elements :got counts}))
+          (finally (doseq [m mounts] (lane/release! m))))))
+    []
+    mount-witnesses))
+
+;; ---------------------------------------------------------------------------
+;; The run
+;; ---------------------------------------------------------------------------
+
+(defn- finish!
+  [{:keys [samples controls]}]
+  (let [v (lane/guard! samples "Hicasso P0 — Reagent-on-subs")]
+    (lane/record! "arm-order-guard"
+                  {:tolerance (:tolerance v)
+                   :contaminated? (:contaminated? v)
+                   :unchecked? (:unchecked? v)
+                   :refuse? (:refuse? v)
+                   :arms (:arms v)})
+    (when (:refuse? v) (set! (.-HICASSO_GUARD_REFUSED js/window) true))
+    (when (some (complement :ok?) controls)
+      (set! (.-HICASSO_CONTROL_FAILED js/window) true)))
+  (lane/done!))
+
+(defn ^:export -main
+  []
+  (try
+    (rf/init! reagent-adapter/adapter)
+    (rf/make-frame {:id v/subs-frame})
+    (frame/replace-app-db! v/subs-frame (v/seed-cells v/cells-n 0))
+    (reset! v/ratom-cells (:cells (v/seed-cells v/cells-n 0)))
+    (lane/leave-act-environment!)
+
+    (if-not (lane/self-test!)
+      (do (lane/fail! (str "the arm-order guard's SELF-TEST failed — this copy of the "
+                           "rule no longer behaves like the one the .cjs drivers use, "
+                           "so nothing was measured"))
+          (lane/done!))
+      (let [problems (parity-problems)]
+        (lane/record! "parity" {:problems problems :ok? (empty? problems)})
+        (if (seq problems)
+          (do (lane/fail! (str "the arms do not build the same page under :advanced — "
+                               (pr-str problems)))
+              (lane/done!))
+          (let [mounted (mapv measure-mount! mount-witnesses)
+                bulk    (mount-bulk-arms! (make-bulk-arms))]
+            (-> (measure-bulk! bulk)
+                (.then (fn [b]
+                         (release-bulk-arms! bulk)
+                         (finish! {:samples  (into (vec (mapcat :samples mounted))
+                                                   (:samples b))
+                                   :controls (conj (mapv :control mounted) (:control b))})
+                         nil))
+                (.catch (fn [e]
+                          (release-bulk-arms! bulk)
+                          (lane/fail! (str "the bulk row rejected: " e))
+                          (lane/done!))))))))
+    (catch :default e
+      (lane/fail! (str "the run threw: " e))
+      (lane/done!))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_app.cljs
@@ -130,11 +130,31 @@
 
    {:id         :M2
     :verify     verify-m2
-    ;; 51 elements mounts in a few tenths of a millisecond — three to six
-    ;; of Chrome's 100 µs quanta, which is a ratio quantised more coarsely
-    ;; than the effects it is being asked to resolve. Eight mounts in ONE
-    ;; window puts the sample an order of magnitude clear of the clamp.
-    :per-sample 8
+    ;; ONE mount per sample, and the batching that would have lifted this
+    ;; witness clear of Chrome's 100 µs clamp is NOT USED. It was tried —
+    ;; eight mounts in one `flushSync` — and THE ARM-ORDER GUARD REFUSED
+    ;; THE WHOLE RUN, exit 2: with eight 51-element roots standing in the
+    ;; document at once, all four M2 arms read 3.2×–5.4× slower in the last
+    ;; third of the run than in the first, ranges DISJOINT, while the
+    ;; predecessor factor stayed clean on every one of them. That is the
+    ;; recorded position-dominates-adjacency class exactly, and it is a
+    ;; property of the batched arm rather than of anything under test — the
+    ;; unbatched M1 row, running immediately before it in the same page,
+    ;; drifted 1.13×–1.16× with ranges overlapping.
+    ;;
+    ;; The repair is therefore the ARM, never the tolerance: the batch is
+    ;; withdrawn and the resulting clock coarseness is STATED on the row.
+    ;; A refused figure and a quantised figure are not the same thing —
+    ;; the first may not be published at all, the second may be published
+    ;; with its resolution attached, and it is published as DIAGNOSTIC
+    ;; rather than as a bar row.
+    :per-sample 1
+    :clock-note (str "DIAGNOSTIC-GRADE, not a bar row. A 51-element mount takes "
+                     "a few tenths of a millisecond — three to six of Chrome's "
+                     "100 us performance.now() quanta — so this witness's ratios "
+                     "are quantised more coarsely than a 10% effect. Quote M1 and "
+                     "the bulk row against the bar; M2 says only that the ordinary "
+                     "form shape shows no LARGE reactive-system penalty on mount.")
     :doc      (str "the ordinary 12-field form on subs — the shape most "
                    "applications are made of")
     :props    {:n v/fields-n}
@@ -250,7 +270,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- measure-mount!
-  [{:keys [id doc props arms elements control verify per-sample]}]
+  [{:keys [id doc props arms elements control verify per-sample clock-note]}]
   (let [k     (or per-sample 1)
         t     (lane/tally)
         one!  (fn [arm]
@@ -286,6 +306,8 @@
         {:benchmark        (keyword "hicasso.P0" (str "mount-" (name id)))
          :doc              doc
          :bead             "rf2-2rtt6.2"
+         :grade            (if clock-note :diagnostic :bar)
+         :clock-note       clock-note
          :fixture          (merge (fixture-common)
                                   {:witness  id
                                    :props    props

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_views.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_views.cljs
@@ -1,0 +1,253 @@
+(ns re-frame.bench.hicasso.p0-reagent-views
+  "THE SHIP BAR'S DENOMINATOR — Reagent reading re-frame2 subscriptions,
+  and the two arms that make that number mean something (rf2-2rtt6.2).
+
+  HD-012 states the bar as `mount AND bulk view-work ≤ 1.0× Reagent,
+  LIKE-FOR-LIKE — both sides reading re-frame2 subscriptions`. Every
+  Reagent row in this repo before today read a bare `reagent.core/atom`
+  through an `r/cursor`, which is Reagent's own idiom but is NOT the same
+  amount of framework: it pays no subscription graph, no query cache, no
+  frame. A candidate measured against it would be measured against a
+  denominator no re-frame2 application has. This namespace supplies the
+  one the bar actually names.
+
+  ## The four arms, and what each is for
+
+  | arm | what it is | what it is FOR |
+  |---|---|---|
+  | `:floor` | the same DOM, hand-built with `react/createElement`, no substrate | the per-round CALIBRATOR — this box drifts further across rounds than several of the effects being measured, so every published figure is a ratio to the floor measured in THAT round |
+  | `:reagent-subs` | Reagent views reading `@(rf/subscribe [:p0/cell i])` | **the denominator.** The bar's `1.0×` is this arm |
+  | `:reagent-ratom` | Reagent views reading an `r/cursor` over an `r/atom` | a labelled LOWER BOUND, never the bar. `subs − ratom` is the price of the reactive system, stated rather than argued |
+  | `:ctl-2x` | the floor at exactly twice the boundaries | the POSITIVE CONTROL. Element count doubles by arithmetic, so the prediction is 2.00× and it is written down before the run |
+
+  `:ctl-2x` is `:parity-exempt?` because it builds a different page ON
+  PURPOSE — that is what makes it a control — and folding it into the
+  canonical-DOM equality would turn the fairness gate into a permanent
+  failure.
+
+  ## Why one page can host all four
+
+  The missing Reagent-on-subs arm was expensive for the predecessor
+  programme for a reason that does not apply here: its own view substrate
+  was inert under a ratom adapter, so a page could not host it and a
+  re-frame-reading Reagent arm at once, and the design called for `two
+  adapter phases bridged by the floor`. Every arm below is Reagent or
+  nothing. One `(rf/init! reagent/adapter)` serves all four, the floor
+  has no substrate to conflict with, and the whole two-phase problem
+  disappears. That is worth saying because it is the reason this bead is
+  a day's work rather than the week the donor budgeted.
+
+  ## The markup is one markup
+
+  Read the three declarations beside each other: the tag sugar, the
+  class names, the attribute order and the text are the same, because the
+  suite gates canonical-DOM equality across every arm before it reads a
+  clock. Hiccup is a shared dialect, so the Reagent arms are not a
+  translation of the floor so much as the same page under a different
+  reader — and that is exactly the condition that makes a ratio a
+  SUBSTRATE ratio rather than a serialiser ratio.
+
+  ## What is idiomatic here, and why it has to be
+
+  A strawman denominator would make the whole comparison worthless, so
+  the `:reagent-subs` arm is written the way a re-frame2 Reagent
+  application is actually written: `reg-view` boundaries (a plain Reagent
+  `defn` carries no `:contextType`, so its `subscribe` would resolve no
+  frame and the render would raise `:rf.error/no-frame-context`),
+  `^{:key i}` metadata on seq children (Reagent's own spelling), one
+  subscription read per boundary, `reagent.dom.client` for the mount, and
+  `rf/frame-provider` at the root. Nothing is pre-adapted and no React
+  class is hand-built.
+
+  The `:reagent-ratom` arm is the counterpart written the way a plain
+  Reagent application is: a FORM-2 component minting one `r/cursor` per
+  mounted occurrence, which is the reason a single-cell write re-renders
+  one component rather than three hundred."
+  (:require ["react" :as react]
+            [re-frame.core :as rf]
+            [reagent.core :as r])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ---------------------------------------------------------------------------
+;; The shape, as arithmetic
+;; ---------------------------------------------------------------------------
+
+(def cells-n
+  "300 boundaries — the make-or-break bulk shape from the charter's use-case
+  A3, and the mount witness M1's size."
+  300)
+
+(def fields-n
+  "12 fields — the ordinary form the charter's use-case A1 calls `the shape
+  most applications are made of`."
+  12)
+
+(defn m1-elements
+  "One for the list, then three per row: the row, its label and its cell.
+  Arithmetic, so the gate is against a WRITTEN expectation rather than
+  against whatever the mount happened to produce."
+  [n]
+  (+ 1 (* 3 n)))
+
+(defn m2-elements
+  "Three for the skeleton — the form, the fieldset and the submit button —
+  then four per field: the wrapper, the label, the input and the error."
+  [fields]
+  (+ 3 (* 4 fields)))
+
+(defn field-value [i v] (str "value " v "-" i))
+(defn field-error [i] (if (even? i) "" (str "field " i " is required")))
+
+;; ---------------------------------------------------------------------------
+;; The subscriptions and the frames
+;; ---------------------------------------------------------------------------
+
+(rf/reg-sub :p0/cell (fn [db [_ i]] (get-in db [:cells i])))
+
+(def subs-frame
+  "One frame for the `:reagent-subs` arm, created once at boot. A frame is
+  application state, not mount state: views mount and unmount against it
+  exactly as they do in a running application, and minting one per mount
+  would leak 3,000 frames across a six-round run and price frame
+  construction as though it were view work."
+  :p0/subs)
+
+(defn seed-cells [n v] {:cells (vec (repeat n v))})
+
+;; ---------------------------------------------------------------------------
+;; M1 — the 300-boundary sub-reading list
+;; ---------------------------------------------------------------------------
+
+(reg-view ^{:rf/id :p0/cell-view} m1-cell
+  "One boundary, one subscription read. The unit the bar is about."
+  [i]
+  (let [v @(rf/subscribe [:p0/cell i])]
+    [:li.row
+     [:span.lbl "cell "]
+     [:span.cell {:data-i i} (str v)]]))
+
+(reg-view ^{:rf/id :p0/m1} m1-subs
+  [n]
+  [:ul.grid {:role "list"}
+   (for [i (range n)]
+     ^{:key i} [m1-cell i])])
+
+;; -- the ratom counterpart --------------------------------------------------
+
+(defonce ratom-cells (r/atom []))
+
+(defn m1-cell-ratom
+  "A FORM-2 component: the outer call mints a `cursor` once per mounted
+  occurrence and the returned render fn dereferences only that cursor.
+  Reagent's own fine-grained reactive leaf, and the counterpart of
+  [[m1-cell]]'s `subscribe`."
+  [i]
+  (let [c (r/cursor ratom-cells [i])]
+    (fn [i]
+      [:li.row
+       [:span.lbl "cell "]
+       [:span.cell {:data-i i} (str @c)]])))
+
+(defn m1-ratom
+  [n]
+  [:ul.grid {:role "list"}
+   (for [i (range n)]
+     ^{:key i} [m1-cell-ratom i])])
+
+;; -- the floor --------------------------------------------------------------
+
+(defn- el
+  ([tag props] (react/createElement tag props))
+  ([tag props children] (react/createElement tag props children)))
+
+(defn- m1-row-el [i v]
+  (el "li" #js {:key i :className "row"}
+      #js [(el "span" #js {:key "l" :className "lbl"} "cell ")
+           (el "span" #js {:key "c" :className "cell" :data-i i} (str v))]))
+
+(defn m1-floor
+  "The same list, hand-built. No boundary, no reactive wrapper, no props
+  map, no attribute walk — the irreducible cost of asking React to build
+  this page, which is why `arm − floor` is a substrate's OWN overhead
+  rather than a reconciliation both arms pay identically."
+  [cells]
+  (el "ul" #js {:className "grid" :role "list"}
+      (into-array (map-indexed m1-row-el cells))))
+
+;; ---------------------------------------------------------------------------
+;; M2 — the ordinary form, on subs
+;; ---------------------------------------------------------------------------
+
+(reg-view ^{:rf/id :p0/field-view} m2-field
+  [i]
+  (let [v @(rf/subscribe [:p0/cell i])]
+    [:div.field
+     [:label.lbl {:for (str "f" i)} (str "Field " i)]
+     [:input.inp {:id        (str "f" i)
+                  :name      (str "f" i)
+                  :type      "text"
+                  :value     (field-value i v)
+                  :read-only true}]
+     [:p.err (field-error i)]]))
+
+(reg-view ^{:rf/id :p0/m2} m2-subs
+  [fields]
+  [:form.p0form
+   [:fieldset.fields
+    (for [i (range fields)]
+      ^{:key i} [m2-field i])]
+   [:button.submit {:type "submit" :disabled true} "Submit"]])
+
+(defn m2-field-ratom
+  [i]
+  (let [c (r/cursor ratom-cells [i])]
+    (fn [i]
+      [:div.field
+       [:label.lbl {:for (str "f" i)} (str "Field " i)]
+       [:input.inp {:id        (str "f" i)
+                    :name      (str "f" i)
+                    :type      "text"
+                    :value     (field-value i @c)
+                    :read-only true}]
+       [:p.err (field-error i)]])))
+
+(defn m2-ratom
+  [fields]
+  [:form.p0form
+   [:fieldset.fields
+    (for [i (range fields)]
+      ^{:key i} [m2-field-ratom i])]
+   [:button.submit {:type "submit" :disabled true} "Submit"]])
+
+(defn- m2-field-el [i v]
+  (el "div" #js {:key i :className "field"}
+      #js [(el "label" #js {:key "l" :className "lbl" :htmlFor (str "f" i)}
+               (str "Field " i))
+           (el "input" #js {:key       "i"
+                            :className "inp"
+                            :id        (str "f" i)
+                            :name      (str "f" i)
+                            :type      "text"
+                            :value     (field-value i v)
+                            :readOnly  true})
+           (el "p" #js {:key "p" :className "err"} (field-error i))]))
+
+(defn m2-floor
+  [cells]
+  (el "form" #js {:className "p0form"}
+      #js [(el "fieldset" #js {:key "f" :className "fields"}
+               (into-array (map-indexed m2-field-el cells)))
+           (el "button" #js {:key "b" :className "submit" :type "submit" :disabled true}
+               "Submit")]))
+
+;; ---------------------------------------------------------------------------
+;; The root the subs arm renders
+;; ---------------------------------------------------------------------------
+
+(defn subs-root
+  "`rf/frame-provider` is not ceremony added for the bench — it is how a
+  re-frame2 Reagent application supplies the frame its `reg-view`
+  boundaries resolve `subscribe` against, and leaving it out would
+  measure a page that cannot render."
+  [view arg]
+  [rf/frame-provider {:frame subs-frame} [view arg]])

--- a/implementation/freehand/test/re_frame/bench/hicasso/run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/run.cjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+// THE HICASSO P0 LANE DRIVER — build, serve, run, print, judge.
+// EP-0038 / HD-017; built by rf2-2rtt6.2 for rf2-2rtt6.2/.3/.4/.5.
+//
+// ONE driver for the whole P0 lane. Every arm rides it by naming its own
+// entry, so a sibling arm needs no new build id, no new driver, and NO
+// EDIT TO `implementation/shadow-cljs.edn` — which is the point, because
+// HD-017 makes a build-id touch a hot-zone, sequenced dispatch and four
+// arms would otherwise be four of them.
+//
+//   node implementation/freehand/test/re_frame/bench/hicasso/run.cjs
+//
+//   HICASSO_INIT_FN=re-frame.bench.hicasso.my-arm-app/-main \
+//   HICASSO_OUT_DIR=out/hicasso-my-arm \
+//   HICASSO_PORT=8131 \
+//     node implementation/freehand/test/re_frame/bench/hicasso/run.cjs
+//
+// With every variable unset this file is byte-for-byte the published
+// rf2-2rtt6.2 instrument.
+//
+// EXIT CODES — the arm-order guard owns 2, and it is not the arm's to
+// move:
+//
+//   0  measured, guard clean, control passed
+//   1  the run failed (build, page error, a fatal the page recorded, a
+//      positive control that did not see what it predicted)
+//   2  THE ARM-ORDER GUARD REFUSED. A figure whose value depends on where
+//      in the plan it was measured is not a figure. The repair is the
+//      ARM — more warm-up, fewer arms per round, a longer window — never
+//      the guard's tolerance. Four workers have hit this on the
+//      predecessor harnesses and every one of them repaired the arm.
+//
+// A Chromium `pageerror` is FATAL here for the same reason it is fatal in
+// every adjacent runner: a benchmark that threw and kept going publishes
+// a precise number for a page that is not the page under test.
+
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+// The directory's ONE navigation, with its ceiling named (rf2-p9fa3).
+// `page.goto` with no `timeout:` takes Playwright's 30s default — a second
+// budget this driver's own 20-minute sentinel cannot reach, whose failure
+// line reads exactly like the bench timeout it is not.
+const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs');
+
+const IMPL = path.resolve(__dirname, '../../../../..');
+
+const BUILD_ID = 'hicasso-bench';
+const OUT_DIR = process.env.HICASSO_OUT_DIR || 'out/hicasso-bench';
+const INIT_FN = process.env.HICASSO_INIT_FN || 're-frame.bench.hicasso.p0-reagent-app/-main';
+const OUT = path.join(IMPL, OUT_DIR);
+const PORT = Number(process.env.HICASSO_PORT || 8131);
+
+// The page's own budget. Six rounds of four arms with warm-up is minutes,
+// not seconds, and a loaded workstation is the normal case.
+const SENTINEL_TIMEOUT_MS = 20 * 60 * 1000;
+
+// ONE LINE, deliberately: shadow-cljs's CLI re-splits `--config-merge` on
+// whitespace when the EDN contains a newline and then reports `EOF while
+// reading` from a fragment.
+const CONFIG_MERGE =
+  `{:output-dir "${OUT_DIR}" :asset-path "." ` +
+  `:modules {:main {:init-fn ${INIT_FN}}}}`;
+
+function build() {
+  console.error(`[hicasso] building :advanced bundle — ${INIT_FN} -> ${OUT_DIR}`);
+  // `node cli/runner.js` rather than the `.cmd` shim: spawning a shim on
+  // Windows needs `shell: true`, a shell concatenates argv, and a
+  // concatenated argv is the other way the config-merge EDN gets torn in
+  // half. It is also the command-hijack posture every launcher here uses.
+  const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+  const r = spawnSync(
+    process.execPath,
+    [runner, 'release', BUILD_ID, '--config-merge', CONFIG_MERGE],
+    { cwd: IMPL, stdio: ['ignore', 'inherit', 'inherit'] }
+  );
+  if (r.status !== 0) {
+    console.error(`[hicasso] build failed with status ${r.status}`);
+    process.exit(1);
+  }
+}
+
+const MIME = { '.js': 'text/javascript', '.html': 'text/html', '.map': 'application/json' };
+
+function serve() {
+  fs.writeFileSync(
+    path.join(OUT, 'index.html'),
+    '<!doctype html><html><head><meta charset="utf-8"><title>Hicasso P0</title></head>' +
+      '<body><div id="app"></div><script src="main.js"></script></body></html>'
+  );
+  return http
+    .createServer((req, res) => {
+      const rel = decodeURIComponent(req.url.split('?')[0]);
+      const file = path.join(OUT, rel === '/' ? 'index.html' : rel);
+      if (!file.startsWith(OUT) || !fs.existsSync(file)) {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      fs.createReadStream(file).pipe(res);
+    })
+    .listen(PORT);
+}
+
+async function run() {
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  // Tracked SEPARATELY from the console buffer, and fatal on its own. A
+  // green summary that ignored an uncaught pageerror is the recorded
+  // rf2-mwx08 class: the suite measured a page that had already thrown.
+  const pageErrors = [];
+  page.on('pageerror', (e) => {
+    pageErrors.push(e.message);
+    console.error('[hicasso] PAGE ERROR:', e.message);
+  });
+  page.on('console', (msg) => {
+    const t = msg.text();
+    if (t.startsWith(';; ') || t.startsWith('[hicasso]')) console.log(t);
+  });
+
+  // `'commit'`, not `'load'`. The bundle's `:init-fn` runs inside the
+  // `<script>`, so the measurement happens while the document is still
+  // loading and `load` cannot fire until it is over — waiting for it is
+  // waiting for the benchmark, against the one budget never meant to
+  // bound it.
+  await navigate(page, `http://127.0.0.1:${PORT}/`, {
+    waitUntil: 'commit',
+    timeoutMs: NAV_TIMEOUT_MS,
+    budget: `the ${SENTINEL_TIMEOUT_MS / 60000}-minute wait for window.HICASSO_DONE`,
+  });
+  await page.waitForFunction('window.HICASSO_DONE === true || window.HICASSO_ERROR', null, {
+    timeout: SENTINEL_TIMEOUT_MS,
+  });
+
+  const err = await page.evaluate('window.HICASSO_ERROR || null');
+  const refused = await page.evaluate('window.HICASSO_GUARD_REFUSED === true');
+  const controlFailed = await page.evaluate('window.HICASSO_CONTROL_FAILED === true');
+  const results = await page.evaluate('window.HICASSO_RESULTS || {}');
+  const version = browser.version();
+  await browser.close();
+  return { err, refused, controlFailed, results, pageErrors, version };
+}
+
+(async () => {
+  build();
+  const server = serve();
+  let outcome;
+  try {
+    outcome = await run();
+  } finally {
+    server.close();
+  }
+
+  console.log(`;; ==== HICASSO RUNTIME ====`);
+  console.log(`;; chromium ${outcome.version} (playwright), :advanced, goog.DEBUG false`);
+  for (const [k, v] of Object.entries(outcome.results)) {
+    console.log(`;; ==== HICASSO ${k} ====`);
+    console.log(v);
+  }
+
+  if (outcome.pageErrors.length > 0) {
+    console.error(
+      `[hicasso] FAILED: ${outcome.pageErrors.length} uncaught page error(s) — ` +
+        `every figure above was taken on a page that had already thrown:\n  ` +
+        outcome.pageErrors.join('\n  ')
+    );
+    process.exit(1);
+  }
+  if (outcome.refused) {
+    console.error(
+      '[hicasso] ARM-ORDER GUARD REFUSED (exit 2). At least one arm reads ' +
+        'differently for WHERE IN THE PLAN it was measured, so no figure above ' +
+        'is reportable. Repair the ARM — more warm-up, fewer arms per round, a ' +
+        'longer measured window. The guard tolerance is not yours to move.'
+    );
+    process.exit(2);
+  }
+  if (outcome.controlFailed) {
+    console.error(
+      '[hicasso] FAILED: the positive control did not see the change its own ' +
+        'arithmetic predicts. An instrument that cannot see a predicted change ' +
+        'cannot be trusted with an unpredicted one.'
+    );
+    process.exit(1);
+  }
+  if (outcome.err) {
+    console.error(`[hicasso] FAILED: ${outcome.err}`);
+    process.exit(1);
+  }
+  console.error('[hicasso] ok');
+})();

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {
     "dev": "node scripts/dev-testbed.cjs",
+    "bench:hicasso": "node freehand/test/re_frame/bench/hicasso/run.cjs",
     "bench:freehand-node": "shadow-cljs compile freehand-bench-node >&2 && node out/freehand-bench-node.js",
     "bench:freehand-browser": "shadow-cljs compile browser-test-freehand-bench && node scripts/serve-and-run-browser-tests.cjs --root out/browser-test-freehand-bench --port 8024",
     "test:cljs": "shadow-cljs compile node-test && node out/node-test.js",

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -1037,6 +1037,53 @@
    ;; The load-bearing hook is inherited from :build-defaults.
    :compiler-options {:infer-externs false}}
 
+  ;; rf2-2rtt6.2 — THE HICASSO MEASUREMENT LANE (EP-0038 / HD-017).
+  ;;
+  ;; ONE build id for the whole programme, deliberately. HD-017 makes a new
+  ;; build id a hot-zone edit to this file and therefore a SEQUENCED
+  ;; dispatch; four P0 arms landing four build ids would be four
+  ;; sequenced dispatches for what is one compilation shape. This build is
+  ;; that shape, and every arm rides it by MERGING its own entry:
+  ;;
+  ;;   node .../re_frame/bench/hicasso/run.cjs
+  ;;   HICASSO_INIT_FN=<ns>/-main HICASSO_OUT_DIR=out/<arm> node .../run.cjs
+  ;;
+  ;; `run.cjs` passes `--config-merge {:output-dir … :modules {:main
+  ;; {:init-fn …}}}` exactly as `b6_prod_run.cjs` rides `:freehand-release`,
+  ;; so a sibling arm needs NO edit to this file at all. The sequencing law
+  ;; is paid once, here.
+  ;;
+  ;; WHY A NEW ID RATHER THAN RIDING `:freehand-release`. The b6 driver's
+  ;; trick works because a build id is only a template, and this lane could
+  ;; have merged onto the Freehand release build. It does not, for two
+  ;; reasons: the Freehand programme is withdrawn and its release build has
+  ;; its own gates reading its own `out/` dir (`:freehand-release` is
+  ;; cleaned and rebuilt by `test:freehand-reachability` and
+  ;; `test:freehand-matched`), so a bench run and a gate run would race the
+  ;; same `.shadow-cljs/builds/freehand-release` cache; and the charter's
+  ;; anti-regression fence is explicit that Hicasso does not carry a
+  ;; continuity claim to its donors — the measurement lane should not have
+  ;; to borrow a donor's identity to compile.
+  ;;
+  ;; :advanced with goog.DEBUG false, because HD-012 makes every bar number
+  ;; a browser number taken from the artefact a consumer ships. The Spec 009
+  ;; instrumentation seam, schema validation and trace emission are all
+  ;; `goog.DEBUG`-gated and all sit on the subscription path the bulk row
+  ;; measures; a development build would price a cost no user pays. And
+  ;; `:advanced` cannot compile shadow's `:browser-test` target
+  ;; (`cljs-test-display`'s `goog.define`s collide), which is why the lane
+  ;; is a plain `:browser` module with an `:init-fn` rather than a test
+  ;; build. No `:dev-http` — like every other advanced build here it is
+  ;; compiled and driven, never served by shadow.
+  :hicasso-bench
+  {:target     :browser
+   :output-dir "out/hicasso-bench"
+   :asset-path "."
+   :compiler-options {:optimizations   :advanced
+                      :infer-externs   :auto
+                      :closure-defines {goog.DEBUG false}}
+   :modules {:main {:init-fn re-frame.bench.hicasso.p0-reagent-app/-main}}}
+
   ;; rf2-vxgfnd.6 — the G-1 direct-render parity gate (07 §5) for the
   ;; re-frame.ui compiled-view substrate. A :node-script RELEASE build
   ;; (:advanced — the gate measures + inspects PRODUCTION emission):


### PR DESCRIPTION
Wave-0 P0 instrument for EP-0038 (epic `rf2-2rtt6`, bead **rf2-2rtt6.2**).
Builds the **ship bar's denominator** — Reagent reading re-frame2 subscriptions,
mount and bulk, in a real browser under `:advanced`.

## The blocking fact for the three sibling P0 beads

**One build id for the whole P0 lane: `:hicasso-bench`.** HD-017 makes a new
`shadow-cljs.edn` build id a hot-zone, sequenced dispatch; four P0 arms landing
four build ids would be four sequenced dispatches for what is one compilation
shape. So the lane gets exactly one, and every arm rides it by merging its own
entry:

```bash
HICASSO_INIT_FN=re-frame.bench.hicasso.<arm>-app/-main \
HICASSO_OUT_DIR=out/hicasso-<arm> \
HICASSO_PORT=<8132|8133|8134> \
  node implementation/freehand/test/re_frame/bench/hicasso/run.cjs
```

`run.cjs` passes `--config-merge`, so **rf2-2rtt6.3 / .4 / .5 need no edit to
`shadow-cljs.edn` at all.** The sequencing law is paid once, here. `npm run
bench:hicasso` is the generic entry (same env vars) — per-arm scripts would be a
`package.json` conflict for no gain.

## The numbers

Ranges are min–max across five rounds. A range containing 1.0 means
**indistinguishable**. Runtime: **HeadlessChrome 147.0.7727.15** (Chromium via
Playwright), `:advanced`, `goog.DEBUG false`. Producing commit
`19401ad083e895b19d55151157f37a59551cb5e2`; reproduce with `cd implementation &&
npm run bench:hicasso`.

| row | `subs ÷ floor` | `subs ÷ ratom` (the reactive leg) |
|---|---|---|
| **mount M1** — 300 sub-reading boundaries · *bar row* | **3.899×** [3.447–4.300] | **1.218×** [1.122–1.310] |
| mount M2 — the ordinary 12-field form · *diagnostic, clock-coarse* | 1.874× [1.750–2.050] | 1.056× [0.960–1.242] — straddles 1.0 |
| **bulk broad** — one commit, 300 boundaries · *bar row* | **7.064×** [6.200–7.700] | **2.008×** [1.938–2.100] |

So reading re-frame2 subscriptions rather than a bare `r/cursor` costs Reagent
**≈1.22× on mount and ≈2.01× on a broad commit** — the term that made the
predecessor's `13.5×` broad-update row an upper bound of unknown content, now
measured instead of argued.

- **Verification:** 0 unverified of 1220 (every mount and every write read back
  out of the DOM inside its own window).
- **Positive control** (predicted from element count before the run, ±25% slack):
  M1 predicted 1.999× measured 1.839× [1.632–1.944] ✅ · M2 predicted 1.941×
  measured 1.674× [1.500–1.833] ✅ · bulk predicted 1.999× measured 1.930×
  [1.800–2.200] ✅. Every control sits below its prediction — the direction fixed
  per-root overhead predicts.
- **Arm-order guard:** reportable, self-test 8/8 before measuring.
- **Canonical-DOM parity** clean under `:advanced`.

Rows appended to the operator-owned standard bead `rf2-2rtt6.1` (append only —
the bar, budgets, kill criteria and red-zones are untouched) and to
`docs/design/hicasso/studio/p0-reagent-on-subs-baseline.md`.

## Two instrument faults caught before publication — both repaired in the arm

1. **`400 unverified of 400` on M2.** The mount read-back probed a `data-i` cell
   the form witness does not carry, so every M2 mount counted as unverified while
   the page was perfectly correct. A read-back that cannot pass manufactures a
   defect and hides real ones behind it. Verification is now per witness and reads
   **both ends** of the page.
2. **The arm-order guard REFUSED, exit 2.** Batching M2 to eight roots in one
   `flushSync` window (to clear the clock clamp) produced `M2/floor` 5.017×,
   `M2/ctl-2x` 5.427×, `M2/reagent-ratom` 4.766×, `M2/reagent-subs` 3.234×
   last-third over first-third with **ranges disjoint** and the predecessor factor
   clean on all four — while the unbatched M1 row in the same page drifted
   1.13–1.16× with ranges overlapping. Position, not adjacency. **The batch was
   withdrawn and the tolerance was not touched**; M2 is published as
   `:grade :diagnostic` with its resolution named.

## Fence

No `spec/**`, no `.github/**`, no `implementation/*/src/**` (no production code),
no `docs/design/freehand/**`. Instrument-only, in the bench/test measurement lane
HD-017 carves out of the donor freeze. `lane.cljs` requires nothing from any donor
`src/` tree.

## Quality gates

| gate | command | exit |
|---|---|---|
| the arms, to completion (guard-clean run) | `npm run bench:hicasso` | **0** |
| the arm-order guard's self-test | in-page, before measuring | **8/8 ok** |
| the arm-order guard's verdict | in-page | **reportable** |
| browser correctness lane (unaffected) | `npm run test:browser` | **0** — Ran 842 tests / 5469 assertions, 0 failures, 0 errors |
| navigation-ceiling policy (whole-repo sweep) | `node scripts/_navigation-ceiling-policy.test.cjs` | **0** |
| browser DOM lane partition | `node scripts/_browser-dom-lane-partition.test.cjs` | **0** |
| script spawn policy | `node scripts/_script-spawn-policy.test.cjs` | **0** |
| test-lane bijection | `python scripts/check_test_lane_bijection.py` | **0** — 1726 test-defining files, 46 lanes, every file selected |

An earlier run of the arms exited **2** on the guard's refusal (see fault 2
above); that is the guard working, and the arm was repaired rather than the
tolerance.
