### PR TITLE
bench(hicasso): P0 reads-per-boundary heap ladder (rf2-2rtt6.5)

### DIFF
--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -1,0 +1,362 @@
+# What does a *subscribing* boundary cost in memory, at 1, 3, 7 and 20 reads?
+
+Seat: EVIDENCE SPIKE, EP-0038 Wave 0. Bead `rf2-2rtt6.5`; numbers appended to
+the operator-owned standard `rf2-2rtt6.1`.
+
+Measured: 2026-07-30, at commit **`b083b060cb`**, which the rebase onto `main`
+carried forward as **`77ec2aa19a`** — the three instrument files are byte-identical
+across the two (verified by `git hash-object`), and `77ec2aa19a` is the one to
+`git show`. The instrument ships in the same PR as this page. Reagent **2.0.1**, UIx
+**1.4.4**, React **19.2.0**, shadow-cljs **3.4.10**, node **24.13.0**, headless
+**Chromium 147.0.7727.15** via Playwright 1.59.1. Windows 11, single developer
+workstation with other agents running concurrently. Every arm is an
+`:advanced` ClojureScript bundle with `goog.DEBUG false`
+(`:freehand-release`). **Browser numbers**; nothing here is a JVM or Node
+figure.
+
+Reproduce:
+
+```
+node implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs
+```
+
+(defaults `LADDER_ROUNDS=6 LADDER_SNAPSHOT=1 LADDER_SUBSTRATES=reagent,uix`;
+exits **2** if the arm-order guard refuses, **3** on an unverified mount.)
+
+---
+
+## The answer, first
+
+**The 516-vs-251 tension is not a disagreement. It is two measurements of two
+different things, neither of which is what a subscribing boundary costs.**
+
+- **251 B was measuring the INTERCEPT** — the per-boundary shell of a UIx
+  boundary that reads *nothing*. This ladder measures that shell directly at
+  **212 B** [207–216] and recovers it as the fitted intercept of the reads
+  curve at **150 B** [146–160].
+- **516 B was measuring one hook slot in isolation** — `useSyncExternalStore`
+  alone, decomposed out of a Freehand boundary by `rf2-oob3g`. It is neither a
+  boundary nor a read. It is one component of the slope, and a minority one.
+- **Neither priced a read.** A UIx boundary's *first* re-frame2 subscription
+  read costs **3,550 B** [3,549–3,551] — **6.9× the 516 B hook figure** and
+  **16.7× the 212 B boundary figure**. On Reagent the same read costs **942 B**
+  [941–943].
+
+Put the two figures on one line and they stop arguing. The fitted lines are
+`cost = 150 + 3,550 · R` on UIx and `cost = 406 + 942 · R` on Reagent, with the
+directly measured R=0 rungs — 212 B and 431 B — sitting a couple of hundred
+bytes above each intercept, which is the width of this instrument's zero against
+a 71 KB range. **251 is the first term; 516 is a fraction of the second.** There
+was never a contradiction to resolve — only a category error, and a category
+error is exactly what a ladder cannot make.
+
+Three consequences, and the second is the one the programme has to act on.
+
+1. **On memory, UIx is not the frontier — it inverts.** UIx wins the
+   per-boundary shell (**212 B** against Reagent's **431 B**, 0.49×) and loses
+   the read by **3.77×** (3,550 against 942). The crossover is *below one read*:
+   any boundary that subscribes at all is cheaper on Reagent. The census's
+   seven-read archetype costs **24,762 B/boundary on the raw UIx spine against
+   Reagent's 6,580 B**.
+2. **The ~0.4–0.5 KB exclusive-retained budget is a SHELL budget, and nothing
+   measured meets it for a boundary that reads once.** Both shells clear it
+   (UIx 212 B, Reagent 431 B). At one read UIx is at **3,811 B** — 7.6× the
+   1 KB paper-fail line — and Reagent at **1,565 B**, 1.6×. The budget row in
+   [validation.md](../validation.md) needs a per-read companion, or it is
+   unfalsifiable; see [§5](#5-what-this-hands-the-programme).
+3. **HD-002's tier-1 exclusion now has a price in bytes.** The scalar per-read
+   hook spine was excluded as product on hook-rule grounds (N reads = N hooks
+   breaks HD-020's ≤2-hook budget). Memory says the same thing independently and
+   louder: the comparator arm allocates **128.5 objects per read** against the
+   Reagent path's **36.2**, at an almost identical **~27 bytes per object**. The
+   spine is not allocating bigger things; it is allocating **3.55× as many of
+   them**.
+
+And a null result worth stating because its absence would have been the worse
+finding: **neither arm retains anything after teardown.** Released heap returns
+to baseline within ±17 B per boundary on every arm, and under ±5 B on almost
+all of them — HD-002's clause-(d) survival metric, met by both substrates
+([§4](#4-what-happens-after-teardown)).
+
+---
+
+## Method, and the fault it is built around
+
+**Retention, never allocation.** V8's CDP *sampling* heap profiler drops the
+samples of collected objects: pointed at a mount/unmount loop it reports the
+residue of a page that has already been discarded, not the cost of the page —
+the same 80,000 objects read **4.77 MB when a global held them and 0.00 MB when
+nothing did**. That fault has already produced one wrong table on this surface.
+So a reading here is: **mount an arm and keep it**, force a full collection,
+read the heap; release, collect, read again.
+
+**Readers.**
+
+| | reader |
+|---|---|
+| **A** | CDP `Runtime.getHeapUsage().usedSize`, after 3× `HeapProfiler.collectGarbage` |
+| **B** | in-page `performance.memory.usedJSHeapSize`, same moment, `--enable-precise-memory-info` |
+| **C** | a full heap **snapshot**, every node's `self_size` summed by a streaming scan, as its own pass |
+
+**A and B are not independent** — two doors onto one V8 counter — and this page
+does not bank them as if they were. **C** walks the object graph and is the
+reader that makes the table falsifiable. It also carries the object *counts*
+that §1's third consequence rests on.
+
+**The in-situ positive control, predicted before anything is measured.** A dense
+JS array of 587,500 doubles, which V8 stores as unboxed 8-byte slots:
+**4,700,000 bytes, known in advance** — deliberately the same ~4.7 MB the broken
+sampler once reported as 0.00 MB. It rides **every round**, on the same readers
+as the arms.
+
+| page | reader | predicted | measured | error |
+|---|---|---:|---:|---:|
+| Reagent | A | 4,700,000 B | 4,700,365 B [4,699,074–4,700,974] | **+0.008%** |
+| Reagent | B | 4,700,000 B | 4,700,358 B | +0.008% |
+| Reagent | C | 4,700,000 B | **4,700,024 B** | **+0.001%** |
+| UIx | A | 4,700,000 B | 4,700,068 B [4,692,128–4,700,910] | **+0.001%** |
+| UIx | B | 4,700,000 B | 4,700,068 B | +0.001% |
+| UIx | C | 4,700,000 B | 4,698,540 B | −0.031% |
+
+**Verification: 0 unverified of 186 mounts.** Every mount counts the boundary
+elements it should have produced and answers the count beside the expectation —
+an arm that silently rendered nothing would otherwise read as the cheapest
+substrate in the table.
+
+**Order.** Six rounds per page; the schedule rotates *and reflects*, so every arm
+is measured after at least two distinct predecessors and both whole-plan orders
+run. Even rounds forward, odd reversed, reported **separately, never as a mean**
+— the pair exists to show the figure does not move, and by the house rule
+overlapping ranges mean indistinguishable. **Position dominates adjacency**, so
+an unread warm-up pass over every arm precedes round 1. The arm-order guard
+(`order_guard.cjs`, self-tested before the bundle is built) returned **clean on
+both pages**; it refuses on a contaminated *or* an unchecked arm and the driver
+exits 2 when it does. It did exactly that on a one-round trial run, which is how
+the refusal path is known to work here.
+
+**Like-for-like, and why two pages.** Both arms read **re-frame2 subscriptions**
+— the same registrar, the same `[:lad/cell i]` query vectors, one shared frame
+behind every boundary. The difference measured is Reagent's `deref`-capture
+against UIx's `useSyncExternalStore` spine, not one substrate's store against
+another's. `rf/init!` installs at most one adapter per JS context, so each
+substrate gets its own page load with **its own floor arms**; every figure below
+is `arm − floor` **within a page and within a round**, which is what cancels the
+box's drift.
+
+**The floor** is plain React: the same element count, the same classes, the same
+one-character text, and **no component per boundary and no reactivity at all**.
+That is `b6-floor/w2`'s choice, and matching it is what allows the R=0 rung here
+to be compared with the published sub-free rows.
+
+**Every read is a distinct query.** Boundary *i* at *R* reads takes cells
+`i·R … i·R+R−1`, so no two boundaries share a reaction and the per-read figure
+carries the subscription as well as the hook. That is the editing-grid shape
+(use-case A4, and A3's bulk row), and it is the honest worst case: a page where
+many boundaries read *one* shared sub pays the reaction once, not once each.
+
+---
+
+## 1. Curve B — fixed boundaries × growing reads
+
+1,200 boundaries, reads varying. `y` is retained bytes per boundary above the
+1,200-boundary floor. **A** is six rounds; **fwd**/**rev** split those six by
+plan direction; **C** is the independent snapshot pass.
+
+### Reagent on re-frame2 subs
+
+| reads | A (6 rounds) | A, forward | A, reversed | C |
+|---:|---:|---:|---:|---:|
+| 0 *(anchor)* | 431 [420–440] | 421 [420–427] | 436 [436–440] | 428 |
+| **1** | **1,565** [1,552–1,570] | 1,564 [1,553–1,566] | 1,565 [1,552–1,570] | 1,597 |
+| **3** | **3,292** [3,280–3,363] | 3,297 [3,287–3,363] | 3,285 [3,280–3,299] | 3,301 |
+| **7** | **6,580** [6,565–6,616] | 6,582 [6,576–6,616] | 6,578 [6,565–6,585] | 6,577 |
+| **20** | **19,379** [19,368–19,399] | 19,376 [19,368–19,399] | 19,382 [19,368–19,392] | 19,377 |
+
+> **slope = 942 B per read** [941–943] · forward 942 [941–943] · reversed 942
+> [942–942] · **intercept = 406 B** [401–431] · r² 0.99896 [0.99895–0.99905]
+
+### UIx on re-frame2 subs
+
+| reads | A (6 rounds) | A, forward | A, reversed | C |
+|---:|---:|---:|---:|---:|
+| 0 *(anchor)* | 212 [207–216] | 214 [207–216] | 211 [210–214] | 212 |
+| **1** | **3,811** [3,799–3,813] | 3,810 [3,799–3,812] | 3,812 [3,809–3,813] | 3,848 |
+| **3** | **10,788** [10,779–10,815] | 10,794 [10,789–10,815] | 10,781 [10,779–10,788] | 10,807 |
+| **7** | **24,762** [24,740–24,772] | 24,770 [24,767–24,772] | 24,752 [24,740–24,757] | 24,792 |
+| **20** | **71,232** [71,206–71,246] | 71,235 [71,230–71,242] | 71,224 [71,206–71,246] | 71,291 |
+
+> **slope = 3,550 B per read** [3,549–3,551] · forward 3,550 [3,550–3,551] ·
+> reversed 3,550 [3,549–3,551] · **intercept = 150 B** [146–160] · r² 0.99998
+
+**Every rung's forward and reversed ranges overlap**, on both substrates, so by
+this studio's own rule the plan direction is indistinguishable on every figure
+above. The independent reader agrees with A to better than **1.0%** on UIx and
+**2.1%** on Reagent (worst case the R=1 rung, 1,597 against 1,565).
+
+**Both curves are lines.** r² ≥ 0.9989 in every round on both substrates. That
+matters more than it looks: a per-read cost that grew or shrank with the number
+of reads would mean the slope was not a per-read cost at all, and the fit is
+what forecloses that reading.
+
+---
+
+## 2. Curve A — fixed reads × growing boundaries
+
+Three reads throughout; boundaries doubling. `y` is *total* excess over the
+same-size floor, so the slope is bytes per boundary and the intercept is
+whatever the page pays once.
+
+| boundaries | Reagent, fwd | Reagent, rev | UIx, fwd | UIx, rev |
+|---:|---:|---:|---:|---:|
+| 300 | 3,580 [3,574–3,592] | 3,545 [3,538–3,557] | 10,979 [10,959–11,206] | 10,991 [10,978–10,994] |
+| 600 | 3,388 [3,380–3,420] | 3,429 [3,359–3,430] | 10,844 [10,841–10,865] | 10,873 [10,844–10,879] |
+| 1,200 | 3,297 [3,287–3,363] | 3,285 [3,280–3,299] | 10,794 [10,789–10,815] | 10,781 [10,779–10,788] |
+| 2,400 | 3,231 [3,222–3,233] | 3,224 [3,132–3,228] | 10,742 [10,736–10,742] | 10,750 [10,750–10,754] |
+
+*(bytes per boundary, so the visible decline down each column is the page
+constant amortising — which is the thing this curve exists to separate out.)*
+
+| | bytes per boundary @ 3 reads | page constant | r² |
+|---|---:|---:|---:|
+| **Reagent** | **3,177** [3,061–3,186] | 136,731 B [115,998–199,589] | 0.99997 |
+| — forward / reversed | 3,182 [3,165–3,186] / 3,174 [3,061–3,180] | | |
+| **UIx** | **10,711** [10,687–10,718] | 89,929 B [76,356–125,879] | 1.00000 |
+| — forward / reversed | 10,700 [10,687–10,710] / 10,718 [10,712–10,718] | | |
+
+**The two curves agree, and that is the point of separating them.** Curve B's
+fit predicts a three-read boundary at `406 + 3·942 = 3,232 B` on Reagent and
+`150 + 3·3,550 = 10,800 B` on UIx. Curve A, built from four different arms and
+a different regression, answers **3,177 B** and **10,711 B** — within **1.7%**
+and **0.8%**. A per-boundary cost measured by growing the boundaries and a
+per-boundary cost inferred from growing the reads land on the same number, so
+the decomposition into a shell plus a per-read term is not an artefact of either
+fit.
+
+**The page constant is small and does not carry the result**: 90–137 KB against
+3.4–25.8 MB of boundary term, i.e. **0.3%–4%**. So Curve B's per-boundary
+figures are per-boundary figures, not a page constant divided by 1,200.
+
+---
+
+## 3. What the reads are made of
+
+Reader C counts nodes as well as bytes.
+
+| | objects per boundary, R=0 | per boundary, R=20 | **objects per read** | **bytes per object** |
+|---|---:|---:|---:|---:|
+| Reagent | 24.9 | 749.6 | **36.2** | 26.0 |
+| UIx | 18.0 | 2,587.6 | **128.5** | 27.6 |
+
+The two substrates allocate objects of **essentially the same size**. The entire
+3.77× is **object count**: the UIx spine's `use-subscribe` — `useSyncExternalStore`
+plus the two `useRef`s, the `useMemo` and the committed-snapshot bookkeeping
+around it, per read — costs 3.55× as many objects as one `deref` of the same
+subscription under Reagent's capture.
+
+This is where 516 B belongs. `rf2-oob3g` put React's six hooks at 1,171 B for a
+whole boundary and `useSyncExternalStore` alone at 516 B of that. Against
+**3,550 B for one read**, the store hook is **14.5%** — real, and nowhere near
+the whole story. **A read is not a hook.** It is a hook stack *and* a
+subscription: a reaction, a cache entry keyed by `(query-id, args)`, a query
+vector, and a watch registration, all of which the Reagent arm pays too. Reagent's
+942 B is the closest thing this page has to a floor for *the subscription
+itself*, which makes it the number a grouped or collected read mechanism has to
+beat — see §5.
+
+---
+
+## 4. What happens after teardown
+
+Every arm is released, collected and read again in the same window. A substrate
+whose released heap does not return to baseline is retaining something after
+unmount, which is a different and worse finding than a large per-boundary figure.
+
+Residue after release, bytes per boundary, median of six rounds:
+
+| | worst arm | typical |
+|---|---:|---:|
+| Reagent | +17.1 (`a-r3-b300`) | 0.1 – 7.5 |
+| UIx | +7.2 (`b-r20-b1200`) | −0.4 – 4.7 |
+
+Floors read −3.5 to +1.3, which is the size of this instrument's zero. **Both
+arms return to baseline.** HD-002's clause-(d) survival metric — *zero retained
+per-occurrence objects after commit/teardown* — is met by both substrates, and
+any candidate that misses it is missing something both donors already have.
+
+---
+
+## 5. What this hands the programme
+
+**The red-zones for this witness family.** Under the delegated ruling on
+`rf2-2rtt6.1`, the measured UIx retained-heap figure *is* the red-zone
+threshold, and these are it:
+
+| axis | UIx red-zone |
+|---|---:|
+| per-boundary shell (R=0) | **212 B** [207–216] |
+| per read | **3,550 B** [3,549–3,551] |
+| boundary @ 1 read | **3,811 B** |
+| boundary @ 3 reads | **10,788 B** |
+| boundary @ 7 reads | **24,762 B** |
+| boundary @ 20 reads | **71,232 B** |
+
+**One thing the operator should look at before those are applied mechanically.**
+The ruling's rationale is that *UIx is the frontier comparator*. On the clock
+that is the recorded position. **On retained heap, in this family, it is not**:
+UIx is 3.77× worse than Reagent per read, and the crossover sits below a single
+read. A red-zone derived from UIx alone would therefore set a per-read ceiling
+**3.77× looser than the best measured option**, and a candidate could clear it
+comfortably while being worse than the Reagent adapter that already ships. The
+rule as written is still the rule; this page only records that on this axis it
+is not binding, and that **942 B/read is the number a native layer actually has
+to beat.** Whether to tighten the memory red-zone to the per-axis best rather
+than to UIx is the operator's call, and only the operator's.
+
+**A target for HD-002's grouped tier.** Grouped `use-subs` — one fixed hook
+receiving the whole query collection — can only remove the *hook* half of a
+read. The subscription half is common to both arms. So the floor a grouped
+mechanism can reach on this witness is bounded below by roughly Reagent's
+**942 B/read**, and the prize for grouping is the difference: **≈2,600 B per
+read**, or **≈18 KB on the census's seven-read archetype**. That is a large
+prize and a concrete pre-registered number, which is what HD-002 clause (c) asks
+strategy hypotheses to be counted against.
+
+**A budget that needs a second row.** `validation.md` sets *exclusive retained
+per boundary* at ~0.4–0.5 KB target, >1 KB paper-fail. Read as a **shell**
+budget it is exactly right and both donors pass. Read as a *boundary including
+its reads* it is unreachable — the cheapest substrate measured is 1.6× the
+paper-fail line at **one** read. The budget table wants a per-read row beside
+the per-boundary one, and the per-read row's honest anchor is 942 B.
+
+---
+
+## Anchors, and one that does not fully reproduce
+
+The R=0 rung is here to tie this instrument to the published sub-free rows
+before anything it says about reads is believed. **Nothing in §§1–5 is derived
+from it**; every reactive figure above is measured at 1, 3, 7 or 20 reads
+directly.
+
+| | published (`freehand-vs-reagent-memory.md` §2) | here, R=0 | |
+|---|---:|---:|---:|
+| Reagent sub-free boundary | 411 / 409 (A), 403 (C) | 431 [420–440] (A), 428 (C) | **+4.9% / +6.2%** |
+| UIx sub-free boundary | 251 / 252 (A), 251 (C) | 212 [207–216] (A), 212 (C) | **−15.5%** |
+
+The Reagent anchor reproduces. **The UIx anchor reads 15% below the published
+figure and is not reconciled away here.** The witnesses are not identical —
+`storm` is 10 roots × 300 `span.leaf` boundaries carrying a text child; this is
+1 root × 1,200 `span.cell` boundaries carrying a `data-i` attribute the floor
+also carries — and two differently-built instruments landing 39 B apart on a
+251 B figure is the size of effect a witness change can produce. It is recorded
+rather than explained, and it is small against the thing the page is for: the
+shell is O(200 B) on either reading, the read is O(3,550 B), and the ratio
+between them is what the ladder was built to measure.
+
+---
+
+## What a JS-heap reading cannot see
+
+DOM nodes live in Blink's C++ heap, not V8's, so none of these figures contain
+the elements themselves. Every arm builds the identical DOM — same element
+count, same classes, same one-character text — so the omission cancels exactly
+in `arm − floor`, which is the only figure quoted.

--- a/implementation/freehand/test/re_frame/freehand/bench/reads_ladder.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/reads_ladder.cljs
@@ -1,0 +1,422 @@
+(ns re-frame.freehand.bench.reads-ladder
+  "THE READS-PER-BOUNDARY HEAP LADDER — what a SUBSCRIBING boundary costs
+  in standing bytes, on Reagent and on UIx, at 1 / 3 / 7 / 20 reads.
+
+  Wave-0 instrument for EP-0038 (bead `rf2-2rtt6.5`, epic `rf2-2rtt6`).
+  Reported into `rf2-2rtt6.1`'s P0 table and
+  `docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md`.
+
+  ## The disagreement this exists to settle
+
+  Two published figures are read as though they priced the same thing.
+
+  * **251 B** — `docs/design/freehand/studio/freehand-vs-reagent-memory.md`,
+    the `storm/uix` row: a UIx boundary above a component-free React floor.
+    That witness reads **nothing**. No subscription, no store, no hook.
+  * **516 B** — `rf2-oob3g`, an isolated `useSyncExternalStore` rung inside
+    a decomposition of the 2,430 B Freehand boundary. That is the cost of
+    **one hook**, not of a boundary.
+
+  A UIx boundary that reads a re-frame2 subscription pays both: the
+  boundary, once, and `use-subscribe` — which
+  `re-frame.substrate.spine` implements over `useSyncExternalStore` plus
+  two `useRef`s and a `useMemo` — once **per read**. So the two numbers
+  are candidates for the INTERCEPT and the SLOPE of one line, and the only
+  way to find out is to measure the line. The charter says so in as many
+  words: *\"the 516-vs-251 tension is a reason to measure the real arms
+  (1/3/7/20 reads, directly), not to reject hooks in advance\"*.
+
+  Neither figure may be reached by inference from the other, and neither
+  may be reached from a sub-free rung. Hence a ladder.
+
+  ## Two curves, deliberately separated
+
+  A single blended curve cannot tell a per-boundary cost from a per-read
+  one — that conflation is what produced the disagreement. So:
+
+  * **Curve B — fixed boundaries × growing reads.** `B = 1,200`
+    boundaries, `R ∈ {1, 3, 7, 20}`. Regressed against `R`, the SLOPE is
+    the per-read cost and the INTERCEPT is the per-boundary shell.
+  * **Curve A — fixed reads × growing boundaries.** `R = 3`,
+    `B ∈ {300, 600, 1,200, 2,400}`. Regressed against `B`, the SLOPE is
+    the per-boundary cost at three reads and the INTERCEPT is whatever the
+    page pays once. A non-zero intercept here would mean the per-boundary
+    figure Curve B reports is partly a page constant, and the two curves
+    would have to be re-read together.
+
+  `R = 0` rides along as an **anchor, not as evidence**: it is the
+  published `storm/uix` 251 B / `storm/reagent` 411 B shape rebuilt in
+  this harness, so a reader can see whether this instrument lands where
+  the predecessor's did before believing anything it says about reads.
+  No reactive figure on this page is derived from it.
+
+  ## Like-for-like, and why the two substrates need two pages
+
+  Both arms read **re-frame2 subscriptions** — the same registrar, the
+  same `[:lad/cell i]` query vectors, the same one frame behind every
+  boundary. That is HD-012's like-for-like: the difference measured is
+  Reagent's `deref`-capture against UIx's `useSyncExternalStore`, not one
+  substrate's store against another's.
+
+  `rf/init!` installs at most one adapter per JS context and silently
+  keeps the first, so a page cannot host both. Each substrate therefore
+  gets its own page load (`?adapter=reagent` / `?adapter=uix`) with its
+  own floor arms, and every figure is `arm − floor` **within a page and
+  within a round**. That is the same subtraction B7 uses, for the same
+  reason: the box's drift cancels.
+
+  ## What this namespace does NOT do
+
+  It does not decide when a heap reading is taken. The page cannot force a
+  collection, so it only mounts and holds; the driver
+  (`reads_ladder_run.cjs`) owns the collector, both readers and the
+  control. Nothing here counts allocations — V8's CDP *sampling* heap
+  profiler drops the samples of collected objects (the same 80,000 objects
+  read 4.77 MB when held and 0.00 MB when not), and that fault has already
+  produced one wrong table on this surface.
+
+  Every mount is verified at the DOM: [[mount!]] counts the boundary
+  elements the arm should have produced and answers the count beside the
+  expectation, because an arm that silently rendered nothing would
+  otherwise read as the cheapest substrate in the table.
+
+  ## Where this file lives, and why
+
+  Beside B7, in the bench lane, because it RIDES B7's collector design and
+  because `freehand/test` is the only `:advanced`-capable browser source
+  path on the classpath until `rf2-2rtt6.2` mints the Hicasso lane. It
+  requires nothing from `re-frame.freehand`. When the Hicasso lane exists
+  this file moves there unchanged.
+
+  Normative owner: bead `rf2-2rtt6.1`; programme
+  `docs/design/hicasso/charter.md`."
+  (:require ["react" :as react]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [reagent.dom.client :as rdc]
+            [uix.core :refer [$ defui]]
+            [uix.dom :as uix-dom]))
+
+;; ---------------------------------------------------------------------------
+;; The ladder's shape
+;; ---------------------------------------------------------------------------
+
+(def reads-rungs
+  "The mandated ladder. `0` is the anchor to the published sub-free rows
+  and is never a source of reactive inference; 1/3/7/20 are the bead's."
+  [0 1 3 7 20])
+
+(def curve-b-boundaries
+  "Curve B holds boundaries fixed here and grows the reads. Large enough
+  that the thinnest rung (R=1) still puts several hundred kilobytes above
+  the floor, which is where this box's retention reading is legible."
+  1200)
+
+(def curve-a-reads
+  "Curve A holds reads fixed here and grows the boundaries. Three, so the
+  arm is unambiguously reactive without the 20-read rung's mount cost."
+  3)
+
+(def curve-a-boundaries
+  "Doubling, so a straight line through the four points is a claim that
+  can fail. 1,200 is shared with Curve B — the same arm, one reading,
+  appearing on both curves and pinning them to each other."
+  [300 600 1200 2400])
+
+(def frame-id
+  "ONE frame behind every boundary of every arm — the application shape,
+  and the shape that prices a boundary rather than a store. K frames would
+  price frame construction."
+  :lad/frame)
+
+(def ^:private cells-needed
+  "Every boundary reads DISTINCT cells, so no two boundaries share a
+  reaction and the per-read figure carries the reaction as well as the
+  hook. This is the widest the page ever gets."
+  (max (* curve-b-boundaries (apply max reads-rungs))
+       (* (apply max curve-a-boundaries) curve-a-reads)))
+
+;; ---------------------------------------------------------------------------
+;; The store
+;; ---------------------------------------------------------------------------
+
+;; Every cell is ZERO, which is not laziness. A boundary renders the sum of
+;; its reads, so with zeros every arm and every floor renders the identical
+;; one-character text node "0" at every rung. Had the cells been `(range n)`
+;; the arms would carry per-boundary strings the floor does not, and a
+;; 24,000-boundary page would put a few kilobytes of string data on the
+;; reactive side of a subtraction that is supposed to isolate the
+;; subscription. The reads are still live: `use-subscribe` and
+;; `rf/subscribe` are calls with registrar side effects, and their results
+;; reach the DOM, so nothing here is elidable under `:advanced`.
+(rf/reg-event :lad/seed
+  (fn [_ctx [_ n]] {:db {:cells (vec (repeat n 0))}}))
+
+(rf/reg-sub :lad/cell
+  (fn [db [_ i]] (nth (:cells db) i)))
+
+(defn ensure-frame!
+  "Create the one shared frame, seeded wide enough for the widest arm.
+  Idempotent — `rf/make-frame` on an existing id is."
+  []
+  (rf/make-frame {:id frame-id :initial-events [[:lad/seed cells-needed]]}))
+
+;; ---------------------------------------------------------------------------
+;; The floor — plain React, no component per boundary, no reactivity
+;; ---------------------------------------------------------------------------
+
+(defn- el [tag props children] (apply react/createElement tag props children))
+
+(defn floor-grid
+  "`n` boundary elements and the container, and NOTHING else: no component
+  per cell, no store, no hook. `arm − floor` is therefore the substrate's
+  own standing cost and not a figure dominated by React fibers and DOM
+  handles both sides pay for.
+
+  The floor deliberately has no component per boundary. That is the same
+  choice `b6-floor/w2` makes and the reason the published 251 B / 411 B
+  rows are boundary costs rather than wrapper deltas — matching it is what
+  lets this ladder's R=0 anchor be compared with them at all."
+  [n]
+  (el "div" #js {:className "lad"}
+      (into-array
+        (map (fn [i] (el "span" #js {:key i :className "cell" :data-i i} "0"))
+             (range n)))))
+
+;; ---------------------------------------------------------------------------
+;; The Reagent arm — R re-frame2 subscription derefs per boundary
+;; ---------------------------------------------------------------------------
+
+(defn- rg-cell
+  "One Reagent boundary reading `r` DISTINCT subscriptions.
+
+  A loop rather than an unrolled body, because Reagent has no hook-order
+  rule: a form-1 component may deref a computed number of reactions and
+  Reagent's `deref`-capture learns all of them. The UIx arm below is
+  unrolled for exactly the opposite reason, and the asymmetry is in the
+  substrates, not in the measurement."
+  [base r]
+  (let [v (loop [k 0 acc 0]
+            (if (< k r)
+              (recur (inc k)
+                     (+ acc @(rf/subscribe [:lad/cell (+ base k)] {:frame frame-id})))
+              acc))]
+    [:span.cell {:data-i base} (str v)]))
+
+(defn- rg-grid [n r]
+  (into [:div.lad]
+        (map (fn [i] ^{:key i} [rg-cell (* i r) r]))
+        (range n)))
+
+;; ---------------------------------------------------------------------------
+;; The UIx arm — R `use-subscribe` hooks per boundary
+;; ---------------------------------------------------------------------------
+
+;; UNROLLED, and it has to be. `use-subscribe` is a hook over
+;; `useSyncExternalStore`, so React's rule is that the call sequence is
+;; identical on every render of an instance. A loop would satisfy that in
+;; fact (`r` never changes for a mounted instance) but not by
+;; construction, and UIx's linter reads the loop, not the fact. Writing
+;; the calls out is also the honest thing for a page that is pricing hook
+;; calls: the reader can count them.
+
+(defn- us [i] (uix-adapter/use-subscribe frame-id [:lad/cell i]))
+
+(defui ux-cell-0 [{:keys [base]}]
+  ($ :span.cell {:data-i base} "0"))
+
+(defui ux-cell-1 [{:keys [base]}]
+  (let [v (us (+ base 0))]
+    ($ :span.cell {:data-i base} (str v))))
+
+(defui ux-cell-3 [{:keys [base]}]
+  (let [v (+ (us (+ base 0)) (us (+ base 1)) (us (+ base 2)))]
+    ($ :span.cell {:data-i base} (str v))))
+
+(defui ux-cell-7 [{:keys [base]}]
+  (let [v (+ (us (+ base 0)) (us (+ base 1)) (us (+ base 2)) (us (+ base 3))
+             (us (+ base 4)) (us (+ base 5)) (us (+ base 6)))]
+    ($ :span.cell {:data-i base} (str v))))
+
+(defui ux-cell-20 [{:keys [base]}]
+  (let [v (+ (us (+ base 0))  (us (+ base 1))  (us (+ base 2))  (us (+ base 3))
+             (us (+ base 4))  (us (+ base 5))  (us (+ base 6))  (us (+ base 7))
+             (us (+ base 8))  (us (+ base 9))  (us (+ base 10)) (us (+ base 11))
+             (us (+ base 12)) (us (+ base 13)) (us (+ base 14)) (us (+ base 15))
+             (us (+ base 16)) (us (+ base 17)) (us (+ base 18)) (us (+ base 19)))]
+    ($ :span.cell {:data-i base} (str v))))
+
+(def ^:private ux-cell-by-reads
+  {0 ux-cell-0, 1 ux-cell-1, 3 ux-cell-3, 7 ux-cell-7, 20 ux-cell-20})
+
+(defui ux-grid [{:keys [n r]}]
+  ($ :div.lad
+     (let [c (get ux-cell-by-reads r)]
+       (for [i (range n)]
+         ($ c {:key i :base (* i r)})))))
+
+;; The Reagent R=0 rung takes the same shape as UIx's: a component per
+;; boundary that reads nothing. `rg-cell` with `r = 0` already is one — the
+;; loop runs zero times — so no separate arm is needed and none is defined.
+
+;; ---------------------------------------------------------------------------
+;; Arms
+;; ---------------------------------------------------------------------------
+
+(defn- container! []
+  (let [c (js/document.createElement "div")]
+    (.appendChild js/document.body c)
+    c))
+
+(defn- floor-arm [n]
+  {:boundaries  n
+   :selector    ".cell"
+   :mount-one   (fn [c]
+                  (let [rt (react-dom-client/createRoot c)]
+                    (react-dom/flushSync (fn [] (.render rt (floor-grid n))))
+                    rt))
+   :unmount-one (fn [rt] (react-dom/flushSync (fn [] (.unmount rt))))})
+
+(defn- reagent-arm [n r]
+  {:boundaries  n
+   :selector    ".cell"
+   :mount-one   (fn [c]
+                  (let [rt (rdc/create-root c)]
+                    (react-dom/flushSync (fn [] (rdc/render rt [rg-grid n r])))
+                    rt))
+   :unmount-one (fn [rt] (react-dom/flushSync (fn [] (rdc/unmount rt))))})
+
+(defn- uix-arm [n r]
+  {:boundaries  n
+   :selector    ".cell"
+   :mount-one   (fn [c]
+                  (let [rt (uix-dom/create-root c)]
+                    (react-dom/flushSync
+                      (fn [] (uix-dom/render-root ($ ux-grid {:n n :r r}) rt)))
+                    rt))
+   :unmount-one (fn [rt] (react-dom/flushSync (fn [] (uix-dom/unmount-root rt))))})
+
+(defn- arm-id [kind curve r n]
+  (keyword (str (name kind) "/" (name curve) "-r" r "-b" n)))
+
+(defn arms
+  "The arm table for one substrate. Floors are substrate-neutral (plain
+  React) but are built per page anyway, so `arm − floor` never crosses a
+  page.
+
+  Curve A's `R = 3, B = 1,200` rung IS Curve B's `R = 3` rung — one arm,
+  one reading, on both curves. Duplicating it would have given the two
+  curves two different numbers for the same point and no way to say which
+  was the curve and which was the noise."
+  [substrate]
+  (let [make (case substrate :reagent reagent-arm :uix uix-arm)
+        b-ns (into (sorted-set) (concat curve-a-boundaries [curve-b-boundaries]))]
+    (into {}
+          (concat
+            ;; floors, one per distinct boundary count on either curve
+            (for [n b-ns] [(arm-id :floor :b 0 n) (floor-arm n)])
+            ;; Curve B — fixed boundaries, growing reads
+            (for [r reads-rungs]
+              [(arm-id substrate :b r curve-b-boundaries)
+               (make curve-b-boundaries r)])
+            ;; Curve A — fixed reads, growing boundaries (1,200 shared)
+            (for [n curve-a-boundaries
+                  :when (not= n curve-b-boundaries)]
+              [(arm-id substrate :a curve-a-reads n)
+               (make n curve-a-reads)])))))
+
+;; ---------------------------------------------------------------------------
+;; Holding, and letting go
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private installed (atom nil))
+(defonce ^:private held (atom nil))
+
+(defn- release!* []
+  (when-some [{:keys [arm handle container]} @held]
+    (let [{:keys [unmount-one]} (get @installed arm)]
+      (try (unmount-one handle) (catch :default _ nil)))
+    (.remove container)
+    (reset! held nil))
+  nil)
+
+(defn mount!
+  "Mount `arm-id` and KEEP it. Answers `{:elements :expected :ok
+  :boundaries}` — the DOM read-back over the boundary class the arm should
+  have produced, and the divisor the driver needs, since arms on Curve A
+  deliberately do not share one.
+
+  A literal `#js` object rather than `clj->js`: `clj->js` renders `:ok?` as
+  the key `\"ok?\"` and a driver reading `verify.ok` sees `undefined`, so
+  every mount reports unverified while every mount is in fact fine. That
+  happened once already, on B7's first run."
+  [arm-id]
+  (release!*)
+  (let [{:keys [mount-one selector boundaries]} (get @installed arm-id)
+        container (container!)
+        handle    (mount-one container)
+        elements  (.-length (.querySelectorAll js/document selector))]
+    (reset! held {:arm arm-id :handle handle :container container})
+    #js {:elements   elements
+         :expected   boundaries
+         :boundaries boundaries
+         :ok         (= elements boundaries)}))
+
+;; ---------------------------------------------------------------------------
+;; The positive control
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private control-cell (atom nil))
+
+(defn control!
+  "Hold a dense JS array of exactly `n` doubles and answer its length, so
+  the allocation cannot be proved dead and elided.
+
+  V8 stores a packed double array as `n` unboxed 8-byte slots behind a
+  small header, so the retained cost is **8n bytes, PREDICTED** — a figure
+  the instrument has to hit, not one it gets to report. It rides every
+  round, in situ, on the same readers as the arms.
+
+  B7 records what happens when a control is a fiction: its first draft was
+  a flat one-byte string of the same nominal size and read as SIX
+  KILOBYTES on all three readers, because V8 does not materialise
+  `'x'.repeat(n)`. The instrument was fine and the control was wrong, and
+  only running it found that out."
+  [n]
+  (let [a (js/Array. n)]
+    (dotimes [i n] (aset a i (+ i 0.5)))
+    (reset! control-cell a)
+    (.-length a)))
+
+(defn control-release! [] (reset! control-cell nil) 0)
+
+;; ---------------------------------------------------------------------------
+;; The page-side door
+;; ---------------------------------------------------------------------------
+
+(defn install!
+  "Publish the instrument on `window.LADDER` for the CDP driver, which owns
+  the collector and both heap readers. The page mounts; it never decides
+  when a reading is taken."
+  [substrate]
+  (reset! installed (arms substrate))
+  (set! (.-LADDER js/window)
+        #js {:mount          (fn [arm] (mount! (keyword arm)))
+             :release        (fn [] (release!*) true)
+             :control        (fn [n] (control! n))
+             :controlRelease (fn [] (control-release!))
+             :perfMem        (fn []
+                               (if-some [m (.-memory js/performance)]
+                                 (.-usedJSHeapSize m)
+                                 -1))
+             :substrate      (name substrate)
+             :plan           (clj->js
+                               {:curveB {:boundaries curve-b-boundaries
+                                         :reads      reads-rungs}
+                                :curveA {:reads      curve-a-reads
+                                         :boundaries curve-a-boundaries}
+                                :cells  cells-needed})
+             :arms           (into-array (map name (keys @installed)))})
+  nil)

--- a/implementation/freehand/test/re_frame/freehand/bench/reads_ladder.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/reads_ladder.cljs
@@ -418,5 +418,8 @@
                                 :curveA {:reads      curve-a-reads
                                          :boundaries curve-a-boundaries}
                                 :cells  cells-needed})
-             :arms           (into-array (map name (keys @installed)))})
+             ;; `(subs (str kw) 1)`, NOT `name` — `name` drops the namespace,
+             ;; so every arm reached the driver as `b-r0-b2400` with the
+             ;; `floor`/`reagent`/`uix` half missing and nothing to parse.
+             :arms           (into-array (map #(subs (str %) 1) (keys @installed)))})
   nil)

--- a/implementation/freehand/test/re_frame/freehand/bench/reads_ladder_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/reads_ladder_app.cljs
@@ -1,0 +1,56 @@
+(ns re-frame.freehand.bench.reads-ladder-app
+  "The reads-per-boundary ladder's `:advanced` entry — one bundle, one
+  substrate per page load.
+
+  Read from the artefact a consumer ships (`:advanced`, `goog.DEBUG
+  false`) for the reason B7's entry gives: Spec 009 instrumentation,
+  schema validation and trace emission are all `goog.DEBUG`-gated, all sit
+  on the subscription path being priced, and a development build would
+  charge the re-frame2 side of every arm for machinery a release bundle
+  does not contain. `:advanced` cannot compile shadow's `:browser-test`
+  target, so the reading needs a plain `:browser` entry — this one.
+
+  `?adapter=reagent` and `?adapter=uix` are two PAGE LOADS of the same
+  bundle, not two modes. `rf/init!` installs at most one adapter per JS
+  context and silently keeps the first, so one page cannot host both arms;
+  a fresh context per substrate is the only honest way to run them, and
+  each page carries its own floor arms so no subtraction ever crosses the
+  page boundary.
+
+  The page installs the instrument on `window.LADDER` and then does
+  nothing at all. Heap readings belong to the DRIVER, which owns the
+  collector: a page cannot force a garbage collection, and a page that
+  tried to decide when a reading was taken would be reading whatever the
+  collector happened to have done.
+
+  Built and driven by
+  `implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs`."
+  (:require [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.freehand.bench.reads-ladder :as ladder]))
+
+(defn- fail! [why]
+  (set! (.-LADDER_ERROR js/window) (str why))
+  (js/console.error (str ";; LADDER FAILED — " why)))
+
+(defn- requested-substrate []
+  (let [v (.get (js/URLSearchParams. (.-search js/location)) "adapter")]
+    (case v
+      "reagent" :reagent
+      "uix"     :uix
+      nil)))
+
+(defn ^:export -main []
+  (try
+    (if-some [substrate (requested-substrate)]
+      (do
+        (rf/init! (case substrate
+                    :reagent reagent-adapter/adapter
+                    :uix     uix-adapter/adapter))
+        (ladder/ensure-frame!)
+        (ladder/install! substrate)
+        (set! (.-LADDER_READY js/window) true))
+      (fail! "no ?adapter=reagent|uix on the query string — this bundle runs one substrate per page load"))
+    (catch :default e
+      (fail! (str "boot threw: " (.-message e))))))

--- a/implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs
@@ -1,0 +1,632 @@
+#!/usr/bin/env node
+// THE READS-PER-BOUNDARY HEAP LADDER — driver.
+//
+//   node implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs
+//   LADDER_ROUNDS=6 LADDER_SNAPSHOT=1 node .../reads_ladder_run.cjs
+//   LADDER_SUBSTRATES=uix node .../reads_ladder_run.cjs        # one arm only
+//
+// Bead rf2-2rtt6.5, epic rf2-2rtt6 (EP-0038). Reports into rf2-2rtt6.1's
+// P0 table and docs/design/hicasso/studio/.
+//
+// ## What this measures, and the fault it is built around
+//
+// RETENTION, never allocation. V8's CDP *sampling* heap profiler drops the
+// samples of collected objects: pointed at a mount/unmount loop it reports
+// the residue of a page that has already been discarded, not the cost of
+// the page — the same 80,000 objects read 4.77 MB when a global held them
+// and 0.00 MB when nothing did. That fault has already produced one wrong
+// table on this surface, and the reasoning that rationalised it ("allocation
+// is a counter; a collection inside the window cannot make it smaller") is
+// simply false of a sampler. So a reading here is: MOUNT AN ARM AND KEEP
+// IT, force a full collection, read the heap; release, collect, read again.
+//
+// ## Why this driver exists rather than `b7_run.cjs` with different env
+//
+// B7's driver is deliberately re-pointable (`B7_ARMS`, `B7_INIT_FN`) and
+// this ladder started there. Two properties it cannot express:
+//
+//   1. **A per-arm boundary count.** B7 divides every arm by one global
+//      `ROOTS * perRoot`. Curve A's whole point is that the boundary count
+//      VARIES across arms, so the divisor has to travel with the arm.
+//   2. **Two pages in one run.** `rf/init!` keeps the first adapter
+//      installed in a JS context, so the Reagent-on-subs and UIx-on-subs
+//      arms cannot share a page. Each substrate needs its own page load,
+//      its own floors, and its own within-page subtraction.
+//
+// Everything else is B7's design, reused rather than reinvented: the
+// three-collections-with-a-beat collector, the pre/held/post triple, the
+// unread warm-up pass, the in-situ predicted control, the streaming
+// snapshot reader, and `order_guard.cjs` itself, which is REQUIRED here
+// rather than copied.
+//
+// ## Readers
+//
+//   A  CDP `Runtime.getHeapUsage().usedSize`, after 3x collectGarbage.
+//   B  in-page `performance.memory.usedJSHeapSize`, same moment, under
+//      `--enable-precise-memory-info`.
+//   C  a full heap SNAPSHOT, every node's `self_size` summed by a
+//      streaming scan, as its own pass.
+//
+// A and B are NOT independent — two doors onto one V8 counter; on 80,000
+// held objects B7 got 3,868,954 from both. B is a cross-check that the page
+// and the debugger see the same heap, nothing more. C walks the object
+// graph and is the reader that makes the table falsifiable.
+//
+// ## The positive control
+//
+// A dense JS array of N doubles, which V8 stores as N unboxed 8-byte slots,
+// so its retained size is 8N bytes PREDICTED BEFORE ANYTHING IS MEASURED.
+// It rides EVERY round, in situ, read by the same instrument as the arms.
+// A heap number without a control is not a measurement.
+//
+// ## Order
+//
+// `order_guard.schedule` rotates AND REFLECTS with the round, so every arm
+// is measured after at least two distinct predecessors and both whole-plan
+// orders run. Even rounds are FORWARD, odd rounds REVERSED, and the report
+// carries the two separately — position dominates adjacency, so the pair is
+// there to show the figure does not move, not to average. `verdict` refuses
+// on a contaminated OR an unchecked arm and this driver EXITS 2 on refusal.
+// Repair the arm, not the guard.
+
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+const guard = require('./order_guard.cjs');
+const { navigate, NAV_TIMEOUT_MS } = require('./navigate.cjs');
+
+const IMPL = path.resolve(__dirname, '../../../../..');
+const OUT_DIR = process.env.LADDER_OUT_DIR || path.join('out', 'reads-ladder');
+const OUT = path.join(IMPL, OUT_DIR);
+const PORT = Number(process.env.LADDER_PORT || 8137);
+
+const ROUNDS = Number(process.env.LADDER_ROUNDS || 6);
+const SUBSTRATES = (process.env.LADDER_SUBSTRATES || 'reagent,uix')
+  .split(',').map((s) => s.trim()).filter(Boolean);
+const WANT_SNAPSHOT = process.env.LADDER_SNAPSHOT !== '0';
+// 587,500 unboxed doubles = 4,700,000 bytes — deliberately the same ~4.7 MB
+// the predecessor's broken sampler reported as 0.00 MB.
+const CONTROL_DOUBLES = Number(process.env.LADDER_CONTROL_DOUBLES || 587500);
+const CONTROL_PREDICTED = CONTROL_DOUBLES * 8;
+// A relative difference of medians, matching B7's. A retention reading taken
+// across a mount/collect/release cycle moves several percent between rounds,
+// so this sits above that and far below the 2.01x the recorded fault made.
+const TOLERANCE = Number(process.env.LADDER_TOLERANCE || 0.25);
+const INIT_FN = 're-frame.freehand.bench.reads-ladder-app/-main';
+
+// ---------------------------------------------------------------------------
+// Build and serve
+// ---------------------------------------------------------------------------
+
+// ONE LINE, deliberately: shadow-cljs's CLI re-splits `--config-merge` on
+// whitespace when the EDN contains a newline and then reports `EOF while
+// reading` from a fragment.
+const CONFIG_MERGE =
+  `{:output-dir "${OUT_DIR}" :asset-path "." ` +
+  `:modules {:main {:init-fn ${INIT_FN}}}}`;
+
+function build() {
+  console.error('[ladder] building :advanced bundle ...');
+  const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+  const r = spawnSync(
+    process.execPath,
+    [runner, 'release', 'freehand-release', '--config-merge', CONFIG_MERGE],
+    { cwd: IMPL, stdio: ['ignore', 'inherit', 'inherit'] }
+  );
+  if (r.status !== 0) {
+    console.error(`[ladder] build failed with status ${r.status}`);
+    process.exit(1);
+  }
+}
+
+const MIME = { '.js': 'text/javascript', '.html': 'text/html', '.map': 'application/json' };
+
+function serve() {
+  fs.writeFileSync(
+    path.join(OUT, 'index.html'),
+    '<!doctype html><html><head><meta charset="utf-8"><title>reads ladder</title></head>' +
+      '<body><div id="app"></div><script src="main.js"></script></body></html>'
+  );
+  return http
+    .createServer((req, res) => {
+      const rel = decodeURIComponent(req.url.split('?')[0]);
+      const file = path.join(OUT, rel === '/' ? 'index.html' : rel);
+      if (!file.startsWith(OUT) || !fs.existsSync(file)) {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      fs.createReadStream(file).pipe(res);
+    })
+    .listen(PORT);
+}
+
+// ---------------------------------------------------------------------------
+// The collector and the readers
+// ---------------------------------------------------------------------------
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function newPage(chromium, query, budget) {
+  const browser = await chromium.launch({
+    args: ['--enable-precise-memory-info', '--js-flags=--expose-gc'],
+  });
+  const page = await browser.newPage();
+  page.on('pageerror', (e) => console.error('[ladder] page error:', e.message));
+  // `'commit'`, not `'load'` (rf2-p9fa3): the bundle's `:init-fn` runs
+  // synchronously inside the `<script>`, so the load event is downstream of
+  // work this driver budgets separately.
+  await navigate(page, `http://127.0.0.1:${PORT}/${query}`, {
+    waitUntil: 'commit',
+    timeoutMs: NAV_TIMEOUT_MS,
+    budget,
+  });
+  return { browser, page };
+}
+
+async function makeReaders(page) {
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('HeapProfiler.enable');
+  await cdp.send('Runtime.enable');
+
+  // Three collections with a beat between them. One is not enough: React
+  // roots die in stages (fibers, then the host instances they point at),
+  // and a single pass leaves the second stage standing.
+  const gc = async () => {
+    for (let i = 0; i < 3; i++) {
+      await cdp.send('HeapProfiler.collectGarbage');
+      await sleep(80);
+    }
+  };
+
+  const read = async () => {
+    const { usedSize } = await cdp.send('Runtime.getHeapUsage');
+    const perf = await page.evaluate(() => window.LADDER.perfMem());
+    return { cdp: usedSize, perf };
+  };
+
+  return { cdp, gc, read };
+}
+
+// Sum every node's `self_size` out of a streaming heap snapshot. The
+// snapshot arrives as JSON text in chunks and can be hundreds of megabytes,
+// so it is never assembled or `JSON.parse`d: `nodes` is a flat run of
+// integers, `node_fields` names the stride, and this consumes complete
+// integers per chunk and carries the partial one. It is the only reader here
+// that walks the object graph, which is what makes it a check on the other
+// two rather than a restatement of them.
+function snapshotTotal(cdp) {
+  return new Promise((resolve, reject) => {
+    let phase = 0;
+    let buf = '';
+    let nFields = 0;
+    let selfIdx = -1;
+    let idx = 0;
+    let total = 0;
+    let nodeCount = 0;
+
+    const onChunk = ({ chunk }) => {
+      if (phase === 2) return;
+      buf += chunk;
+      if (phase === 0) {
+        const at = buf.indexOf('"nodes":[');
+        if (at === -1) return;
+        const fm = /"node_fields":\s*\[([^\]]*)\]/.exec(buf.slice(0, at));
+        if (!fm) { phase = 2; reject(new Error('node_fields absent from snapshot header')); return; }
+        const fields = fm[1].split(',').map((s) => s.trim().replace(/^"|"$/g, ''));
+        nFields = fields.length;
+        selfIdx = fields.indexOf('self_size');
+        if (selfIdx < 0) { phase = 2; reject(new Error('self_size absent from node_fields')); return; }
+        buf = buf.slice(at + '"nodes":['.length);
+        phase = 1;
+      }
+      let last = 0;
+      let done = false;
+      for (let i = 0; i < buf.length; i++) {
+        const c = buf.charCodeAt(i);
+        if (c === 44 || c === 93) {
+          const s = buf.slice(last, i);
+          if (s.length) {
+            if (idx % nFields === selfIdx) total += Number(s);
+            if (idx % nFields === 0) nodeCount++;
+            idx++;
+          }
+          last = i + 1;
+          if (c === 93) { done = true; break; }
+        }
+      }
+      buf = done ? '' : buf.slice(last);
+      if (done) phase = 2;
+    };
+
+    cdp.on('HeapProfiler.addHeapSnapshotChunk', onChunk);
+    cdp.send('HeapProfiler.takeHeapSnapshot', { reportProgress: false })
+      .then(() => { cdp.off('HeapProfiler.addHeapSnapshotChunk', onChunk); resolve({ totalSelfSize: total, nodeCount }); })
+      .catch((e) => { cdp.off('HeapProfiler.addHeapSnapshotChunk', onChunk); reject(e); });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Arm naming — the plan is derived from the page, never assumed here
+// ---------------------------------------------------------------------------
+
+// `floor/b-r0-b1200`, `uix/b-r7-b1200`, `reagent/a-r3-b2400`. The driver
+// parses rather than reconstructs, so a rename in the CLJS cannot silently
+// desynchronise the two halves of the instrument.
+function parseArm(id) {
+  const m = /^([a-z]+)\/([ab])-r(\d+)-b(\d+)$/.exec(id);
+  if (!m) throw new Error(`unparseable arm id: ${id}`);
+  return { id, kind: m[1], curve: m[2], reads: Number(m[3]), boundaries: Number(m[4]) };
+}
+
+const floorFor = (arms, boundaries) =>
+  arms.find((a) => a.kind === 'floor' && a.boundaries === boundaries);
+
+// ---------------------------------------------------------------------------
+// One substrate's page
+// ---------------------------------------------------------------------------
+
+async function runSubstrate(chromium, substrate) {
+  const { browser, page } = await newPage(
+    chromium, `?adapter=${substrate}`, `the 120s wait for window.LADDER_READY (${substrate})`
+  );
+  await page.waitForFunction(
+    'window.LADDER_READY === true || window.LADDER_ERROR', null, { timeout: 120000 }
+  );
+  const err = await page.evaluate('window.LADDER_ERROR || null');
+  if (err) { await browser.close(); throw new Error(`${substrate} page failed to initialise: ${err}`); }
+
+  const armIds = await page.evaluate(() => Array.from(window.LADDER.arms));
+  const plan = await page.evaluate(() => window.LADDER.plan);
+  const arms = armIds.map(parseArm);
+  const { cdp, gc, read } = await makeReaders(page);
+
+  const rounds = [];
+  const orderSamples = [];
+  let position = 0;
+  let previous = null;
+  let unverified = 0;
+  let mounts = 0;
+
+  // A WARM-UP PASS, mounted and released once per arm and never read. The
+  // first mount of any arm allocates things that are not the page and never
+  // go away: compiled code for the paths it just took, inline caches,
+  // interned keywords, one-time module state. Charged to round 1 they read
+  // as retention per boundary, and they are not. Position dominates
+  // adjacency, so this pass matters more than the interleaving does.
+  console.error(`[ladder] ${substrate}: warm-up pass over ${arms.length} arms ...`);
+  for (const a of arms) {
+    const v = await page.evaluate((id) => window.LADDER.mount(id), a.id);
+    mounts++;
+    if (!v.ok) { unverified++; console.error(`[ladder] UNVERIFIED warm-up ${a.id}: ${v.elements}/${v.expected}`); }
+    await page.evaluate(() => window.LADDER.release());
+  }
+  await page.evaluate((n) => window.LADDER.control(n), CONTROL_DOUBLES);
+  await page.evaluate(() => window.LADDER.controlRelease());
+
+  for (let round = 0; round < ROUNDS; round++) {
+    console.error(`[ladder] ${substrate}: round ${round + 1}/${ROUNDS} (${round % 2 ? 'REVERSED' : 'FORWARD'})`);
+
+    // --- the positive control, IN SITU, before this round's arms ---------
+    await gc();
+    const ctlBefore = await read();
+    const ctlLen = await page.evaluate((n) => window.LADDER.control(n), CONTROL_DOUBLES);
+    await gc();
+    const ctlHeld = await read();
+    await page.evaluate(() => window.LADDER.controlRelease());
+    await gc();
+    const ctlAfter = await read();
+    const control = {
+      doubles: ctlLen,
+      predictedBytes: CONTROL_PREDICTED,
+      measuredCdp: ctlHeld.cdp - (ctlBefore.cdp + ctlAfter.cdp) / 2,
+      measuredPerf: ctlHeld.perf - (ctlBefore.perf + ctlAfter.perf) / 2,
+      baselineDriftCdp: ctlAfter.cdp - ctlBefore.cdp,
+    };
+    control.errorCdp = control.measuredCdp / CONTROL_PREDICTED - 1;
+    control.errorPerf = control.measuredPerf / CONTROL_PREDICTED - 1;
+
+    // --- the arms, rotating AND REFLECTING with the round ----------------
+    const byArm = {};
+    for (const j of guard.schedule(arms.length, round)) {
+      const a = arms[j];
+      await gc();
+      const pre = await read();
+      const verify = await page.evaluate((id) => window.LADDER.mount(id), a.id);
+      mounts++;
+      if (!verify.ok) { unverified++; console.error(`[ladder] UNVERIFIED ${a.id}: ${verify.elements}/${verify.expected}`); }
+      await gc();
+      const held = await read();
+      await page.evaluate(() => window.LADDER.release());
+      await gc();
+      const post = await read();
+      byArm[a.id] = {
+        verify,
+        boundaries: a.boundaries,
+        retainedCdp: held.cdp - pre.cdp,
+        retainedPerf: held.perf - pre.perf,
+        residueCdp: post.cdp - pre.cdp,
+        bytesPerBoundaryCdp: (held.cdp - pre.cdp) / a.boundaries,
+        raw: { pre, held, post },
+      };
+      orderSamples.push({
+        arm: a.id,
+        value: byArm[a.id].bytesPerBoundaryCdp,
+        predecessor: previous,
+        position: position++,
+      });
+      previous = a.id;
+    }
+    rounds.push({ round, order: round % 2 ? 'reversed' : 'forward', control, arms: byArm });
+  }
+
+  // --- the independent reader, as its own pass --------------------------
+  // Curve B plus its floor only. C is slow (a full graph walk over a heap
+  // that reaches ~12 MB above baseline at the 20-read rung) and its job is
+  // to falsify the HEADLINE curve, which is the one that prices a read.
+  let snapshots = null;
+  if (WANT_SNAPSHOT) {
+    snapshots = {};
+    const want = arms.filter((a) => a.curve === 'b' || a.boundaries === plan.curveB.boundaries);
+    try {
+      for (const a of want) {
+        console.error(`[ladder] ${substrate}: snapshot pass ${a.id}`);
+        await gc();
+        const pre = await snapshotTotal(cdp);
+        const verify = await page.evaluate((id) => window.LADDER.mount(id), a.id);
+        mounts++;
+        if (!verify.ok) unverified++;
+        await gc();
+        const held = await snapshotTotal(cdp);
+        await page.evaluate(() => window.LADDER.release());
+        snapshots[a.id] = {
+          verify,
+          boundaries: a.boundaries,
+          retained: held.totalSelfSize - pre.totalSelfSize,
+          bytesPerBoundary: (held.totalSelfSize - pre.totalSelfSize) / a.boundaries,
+          nodeDelta: held.nodeCount - pre.nodeCount,
+        };
+      }
+      await gc();
+      const cpre = await snapshotTotal(cdp);
+      await page.evaluate((n) => window.LADDER.control(n), CONTROL_DOUBLES);
+      await gc();
+      const cheld = await snapshotTotal(cdp);
+      await page.evaluate(() => window.LADDER.controlRelease());
+      snapshots.control = {
+        predictedBytes: CONTROL_PREDICTED,
+        measured: cheld.totalSelfSize - cpre.totalSelfSize,
+        error: (cheld.totalSelfSize - cpre.totalSelfSize) / CONTROL_PREDICTED - 1,
+      };
+    } catch (e) {
+      snapshots = { error: String(e && e.message ? e.message : e) };
+    }
+  }
+
+  await browser.close();
+  return {
+    substrate,
+    plan,
+    arms: arms.map((a) => a.id),
+    verification: { mounts, unverified },
+    perRound: rounds,
+    orderVerdict: guard.verdict(orderSamples, { tolerance: TOLERANCE }),
+    snapshots,
+    curves: curves(arms, rounds),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The two curves, computed PER ROUND and only then summarised
+// ---------------------------------------------------------------------------
+
+const median = guard.median;
+const rangeOf = (xs) => ({ n: xs.length, min: Math.min(...xs), p50: median(xs), max: Math.max(...xs) });
+
+// Ordinary least squares. Returned with the residual sum so a curve that is
+// not a line cannot be reported as one by accident.
+function fit(points) {
+  const n = points.length;
+  const sx = points.reduce((t, p) => t + p.x, 0);
+  const sy = points.reduce((t, p) => t + p.y, 0);
+  const sxx = points.reduce((t, p) => t + p.x * p.x, 0);
+  const sxy = points.reduce((t, p) => t + p.x * p.y, 0);
+  const slope = (n * sxy - sx * sy) / (n * sxx - sx * sx);
+  const intercept = (sy - slope * sx) / n;
+  const ss = points.reduce((t, p) => t + Math.pow(p.y - (slope * p.x + intercept), 2), 0);
+  const my = sy / n;
+  const tot = points.reduce((t, p) => t + Math.pow(p.y - my, 2), 0);
+  return { slope, intercept, r2: tot === 0 ? 1 : 1 - ss / tot, points };
+}
+
+function curves(arms, rounds) {
+  const subst = arms.find((a) => a.kind !== 'floor').kind;
+  const curveB = [];
+  const curveA = [];
+  const perRung = {};   // arm id -> [excess-bytes-per-boundary per round]
+  const orders = { forward: { b: [], a: [] }, reversed: { b: [], a: [] } };
+
+  for (const r of rounds) {
+    const excess = (a) => {
+      const f = floorFor(arms, a.boundaries);
+      return r.arms[a.id].retainedCdp - r.arms[f.id].retainedCdp;
+    };
+    // Curve B — fixed boundaries, growing reads. y is PER BOUNDARY.
+    const bArms = arms.filter((a) => a.kind === subst && a.curve === 'b')
+      .sort((p, q) => p.reads - q.reads);
+    const bPts = bArms.map((a) => ({ x: a.reads, y: excess(a) / a.boundaries, arm: a.id }));
+    // Curve A — fixed reads, growing boundaries. y is TOTAL excess.
+    const aArms = arms.filter((a) => a.kind === subst && (a.curve === 'a' || a.reads === 3))
+      .sort((p, q) => p.boundaries - q.boundaries);
+    const aPts = aArms.map((a) => ({ x: a.boundaries, y: excess(a), arm: a.id }));
+
+    for (const p of bPts) {
+      (perRung[p.arm] = perRung[p.arm] || []).push(p.y);
+    }
+    const bFit = fit(bPts);
+    const aFit = fit(aPts);
+    curveB.push({ round: r.round, order: r.order, ...bFit });
+    curveA.push({ round: r.round, order: r.order, ...aFit });
+    orders[r.order].b.push(bFit);
+    orders[r.order].a.push(aFit);
+  }
+
+  const sum = (fits, key) => rangeOf(fits.map((f) => f[key]));
+  return {
+    curveB: {
+      what: 'fixed boundaries x growing reads — SLOPE is bytes per READ, INTERCEPT is bytes per BOUNDARY',
+      perRound: curveB,
+      bytesPerRead: sum(curveB, 'slope'),
+      bytesPerBoundaryIntercept: sum(curveB, 'intercept'),
+      r2: sum(curveB, 'r2'),
+      forward: { bytesPerRead: sum(orders.forward.b, 'slope'), intercept: sum(orders.forward.b, 'intercept') },
+      reversed: { bytesPerRead: sum(orders.reversed.b, 'slope'), intercept: sum(orders.reversed.b, 'intercept') },
+      rungs: Object.fromEntries(Object.entries(perRung).map(([k, v]) => [k, rangeOf(v)])),
+    },
+    curveA: {
+      what: 'fixed reads x growing boundaries — SLOPE is bytes per BOUNDARY at 3 reads, INTERCEPT is the page constant',
+      perRound: curveA,
+      bytesPerBoundary: sum(curveA, 'slope'),
+      pageConstant: sum(curveA, 'intercept'),
+      r2: sum(curveA, 'r2'),
+      forward: { bytesPerBoundary: sum(orders.forward.a, 'slope'), pageConstant: sum(orders.forward.a, 'intercept') },
+      reversed: { bytesPerBoundary: sum(orders.reversed.a, 'slope'), pageConstant: sum(orders.reversed.a, 'intercept') },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+const b = (v) => (Number.isFinite(v) ? Math.round(v).toLocaleString('en-US') : String(v));
+const pct = (v) => (Number.isFinite(v) ? `${(v * 100).toFixed(3)}%` : String(v));
+
+function report(all) {
+  const L = [];
+  L.push(';; ================================================================');
+  L.push(';; READS-PER-BOUNDARY HEAP LADDER — rf2-2rtt6.5 (EP-0038 Wave 0)');
+  L.push(';; retention instrument, :advanced, headless Chromium');
+  L.push(';; ================================================================');
+  for (const s of all) {
+    const ctl = s.perRound.map((r) => r.control);
+    L.push('');
+    L.push(`;; ---- ${s.substrate.toUpperCase()} on re-frame2 subs -----------------------------`);
+    L.push(`;; verification: ${s.verification.unverified} unverified of ${s.verification.mounts}`);
+    L.push(`;; IN-SITU POSITIVE CONTROL  predicted ${b(CONTROL_PREDICTED)} B`);
+    L.push(`;;   reader A  measured ${b(median(ctl.map((c) => c.measuredCdp)))} B  ` +
+           `[${b(Math.min(...ctl.map((c) => c.measuredCdp)))}-${b(Math.max(...ctl.map((c) => c.measuredCdp)))}]  ` +
+           `error ${pct(median(ctl.map((c) => c.errorCdp)))}`);
+    L.push(`;;   reader B  measured ${b(median(ctl.map((c) => c.measuredPerf)))} B  ` +
+           `error ${pct(median(ctl.map((c) => c.errorPerf)))}`);
+    if (s.snapshots && s.snapshots.control) {
+      L.push(`;;   reader C  measured ${b(s.snapshots.control.measured)} B  error ${pct(s.snapshots.control.error)}`);
+    }
+    L.push('');
+    L.push(';;   CURVE B — fixed boundaries x growing reads');
+    for (const [arm, r] of Object.entries(s.curves.curveB.rungs)) {
+      const reads = parseArm(arm).reads;
+      L.push(`;;     R=${String(reads).padStart(2)}  ${b(r.p50).padStart(7)} B/boundary  [${b(r.min)}-${b(r.max)}]`);
+    }
+    const cb = s.curves.curveB;
+    L.push(`;;     => BYTES PER READ      ${b(cb.bytesPerRead.p50)}  [${b(cb.bytesPerRead.min)}-${b(cb.bytesPerRead.max)}]`);
+    L.push(`;;        fwd ${b(cb.forward.bytesPerRead.p50)} [${b(cb.forward.bytesPerRead.min)}-${b(cb.forward.bytesPerRead.max)}]  ` +
+           `rev ${b(cb.reversed.bytesPerRead.p50)} [${b(cb.reversed.bytesPerRead.min)}-${b(cb.reversed.bytesPerRead.max)}]`);
+    L.push(`;;     => PER-BOUNDARY INTERCEPT ${b(cb.bytesPerBoundaryIntercept.p50)}  ` +
+           `[${b(cb.bytesPerBoundaryIntercept.min)}-${b(cb.bytesPerBoundaryIntercept.max)}]`);
+    L.push(`;;        r2 ${cb.r2.p50.toFixed(5)} [${cb.r2.min.toFixed(5)}-${cb.r2.max.toFixed(5)}]`);
+    L.push('');
+    L.push(';;   CURVE A — fixed reads (3) x growing boundaries');
+    for (const p of s.curves.curveA.perRound[0].points) {
+      L.push(`;;     B=${String(p.x).padStart(5)}  ${b(p.y).padStart(10)} B excess (round 0)`);
+    }
+    const ca = s.curves.curveA;
+    L.push(`;;     => BYTES PER BOUNDARY @3 ${b(ca.bytesPerBoundary.p50)}  [${b(ca.bytesPerBoundary.min)}-${b(ca.bytesPerBoundary.max)}]`);
+    L.push(`;;        fwd ${b(ca.forward.bytesPerBoundary.p50)} [${b(ca.forward.bytesPerBoundary.min)}-${b(ca.forward.bytesPerBoundary.max)}]  ` +
+           `rev ${b(ca.reversed.bytesPerBoundary.p50)} [${b(ca.reversed.bytesPerBoundary.min)}-${b(ca.reversed.bytesPerBoundary.max)}]`);
+    L.push(`;;     => PAGE CONSTANT ${b(ca.pageConstant.p50)}  [${b(ca.pageConstant.min)}-${b(ca.pageConstant.max)}]`);
+    L.push(`;;        r2 ${ca.r2.p50.toFixed(5)} [${ca.r2.min.toFixed(5)}-${ca.r2.max.toFixed(5)}]`);
+    L.push(`;;   ORDER GUARD: ${s.orderVerdict.refuse ? 'REFUSED' : 'clean'}` +
+           `${s.orderVerdict.contaminated ? ' (contaminated)' : ''}${s.orderVerdict.unchecked ? ' (unchecked)' : ''}`);
+  }
+  if (all.length === 2) {
+    const [x, y] = all;
+    L.push('');
+    L.push(';; ---- cross-substrate ---------------------------------------------');
+    L.push(`;;   bytes per READ      ${x.substrate} ${b(x.curves.curveB.bytesPerRead.p50)}  ` +
+           `${y.substrate} ${b(y.curves.curveB.bytesPerRead.p50)}  ` +
+           `ratio ${(y.curves.curveB.bytesPerRead.p50 / x.curves.curveB.bytesPerRead.p50).toFixed(3)}`);
+    L.push(`;;   per-boundary shell  ${x.substrate} ${b(x.curves.curveB.bytesPerBoundaryIntercept.p50)}  ` +
+           `${y.substrate} ${b(y.curves.curveB.bytesPerBoundaryIntercept.p50)}`);
+  }
+  return L.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+(async () => {
+  // The guard's own self-test runs BEFORE the bundle is even built: an
+  // instrument whose refusal machinery is broken must not produce a table.
+  const st = guard.selfTest();
+  if (!st.ok) {
+    console.error('[ladder] order-guard self-test FAILED — refusing to measure');
+    for (const c of st.checks) if (!c.ok) console.error(`  FAIL ${c.name} — ${c.detail || ''}`);
+    process.exit(1);
+  }
+  console.error(`[ladder] order-guard self-test ok (${st.checks.length} checks)`);
+
+  fs.mkdirSync(OUT, { recursive: true });
+  build();
+  const server = serve();
+  const { chromium } = require('playwright');
+
+  const all = [];
+  try {
+    for (const s of SUBSTRATES) all.push(await runSubstrate(chromium, s));
+  } finally {
+    server.close();
+  }
+
+  const result = {
+    benchmark: 'hicasso:reads-per-boundary-heap-ladder',
+    bead: 'rf2-2rtt6.5',
+    epic: 'rf2-2rtt6',
+    rounds: ROUNDS,
+    tolerance: TOLERANCE,
+    instruments: {
+      A: 'CDP Runtime.getHeapUsage().usedSize after 3x HeapProfiler.collectGarbage',
+      B: 'in-page performance.memory.usedJSHeapSize, same moment, --enable-precise-memory-info',
+      C: 'full heap snapshot, every node self_size summed by a streaming scan (own pass, Curve B only)',
+      note: 'A and B are two doors onto one V8 counter and are NOT independent. C walks the object graph.',
+    },
+    control: { shape: 'dense JS array of doubles', doubles: CONTROL_DOUBLES, predictedBytes: CONTROL_PREDICTED },
+    substrates: all,
+  };
+
+  fs.writeFileSync(path.join(OUT, 'reads-ladder.json'), JSON.stringify(result, null, 2));
+  const text = report(all);
+  console.log(text);
+  fs.writeFileSync(path.join(OUT, 'reads-ladder.txt'), text + '\n');
+  console.error(`[ladder] wrote ${path.join(OUT, 'reads-ladder.json')}`);
+
+  const refused = all.filter((s) => s.orderVerdict.refuse);
+  const unverified = all.reduce((t, s) => t + s.verification.unverified, 0);
+  if (unverified > 0) {
+    console.error(`[ladder] ${unverified} UNVERIFIED mounts — the DOM read-back did not match`);
+    process.exit(3);
+  }
+  if (refused.length) {
+    for (const s of refused) {
+      for (const line of guard.format(s.orderVerdict, `${s.substrate}: arm order`)) console.error(line);
+    }
+    console.error('[ladder] ORDER GUARD REFUSED — repair the arm, not the guard');
+    process.exit(2);
+  }
+  console.error('[ladder] done');
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs
@@ -80,8 +80,13 @@ const guard = require('./order_guard.cjs');
 const { navigate, NAV_TIMEOUT_MS } = require('./navigate.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
-const OUT_DIR = process.env.LADDER_OUT_DIR || path.join('out', 'reads-ladder');
-const OUT = path.join(IMPL, OUT_DIR);
+// FORWARD SLASHES, and not by accident. `:output-dir` is spliced into the
+// `--config-merge` EDN string below, and on Windows `path.join('out',
+// 'reads-ladder')` yields `out\reads-ladder` whose `\r` the EDN reader takes
+// as a carriage return: shadow-cljs then writes `outeads-ladder\main.js` and
+// dies on a filename the OS will not accept. Seen once, here.
+const OUT_DIR = process.env.LADDER_OUT_DIR || 'out/reads-ladder';
+const OUT = path.resolve(IMPL, OUT_DIR);
 const PORT = Number(process.env.LADDER_PORT || 8137);
 
 const ROUNDS = Number(process.env.LADDER_ROUNDS || 6);


### PR DESCRIPTION
Wave-0 P0 instrument for EP-0038 (`rf2-2rtt6.5`). Measures retained heap for
**subscribing** boundaries directly, on **Reagent-on-subs** and **UIx-on-subs**,
at **1 / 3 / 7 / 20 reads**, as **two separated curves**. Rows appended to the
operator-owned standard `rf2-2rtt6.1`; full record in
`docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md`.

## What it resolves

**The 516 B-uSES vs 251 B-UIx tension is not a disagreement — it is two
measurements of two different things, neither of which is what a subscribing
boundary costs.**

- **251 B was the INTERCEPT** — a UIx boundary that reads *nothing*. Measured
  here directly at **212 B** [207–216] and recovered as the fitted intercept at
  **150 B** [146–160].
- **516 B was one hook slot in isolation** — `useSyncExternalStore` alone,
  decomposed out of a Freehand boundary. Neither a boundary nor a read.
- **Neither priced a read.** A UIx read costs **3,550 B** [3,549–3,551] — 6.9×
  the hook figure — because a read is a hook stack *and* a subscription
  (reaction, cache entry, query vector, watch). Reagent's **942 B** [941–943]
  prices the subscription half that both arms pay.

| reads | Reagent-on-subs, B/boundary | UIx-on-subs, B/boundary |
|---:|---:|---:|
| 0 *(anchor)* | 431 [420–440] | 212 [207–216] |
| **1** | **1,565** [1,552–1,570] | **3,811** [3,799–3,813] |
| **3** | **3,292** [3,280–3,363] | **10,788** [10,779–10,815] |
| **7** | **6,580** [6,565–6,616] | **24,762** [24,740–24,772] |
| **20** | **19,379** [19,368–19,399] | **71,232** [71,206–71,246] |
| **slope** | **942 B/read** [941–943] | **3,550 B/read** [3,549–3,551] |

Curve A (fixed 3 reads × 300/600/1,200/2,400 boundaries) answers **3,177 B** and
**10,711 B** per boundary from four different arms and a different regression —
within **1.7%** and **0.8%** of what Curve B's fit predicts. Separating the
curves is what lets a per-boundary cost be told from a per-read one, and the
conflation of the two is what produced the disagreement.

**On retained heap UIx is not the frontier — it inverts.** It wins the sub-free
shell 0.49× and loses the read **3.77×**, with the crossover below a single
read. Reader C says the whole 3.77× is object *count* — 128.5 objects/read
against 36.2, at ~27 B per object on both.

## Two things surfaced for the operator (on the bead, not decided here)

1. **RULING 1's red-zone derives from UIx because UIx is the frontier.** On this
   axis it is not: a per-read red-zone taken from UIx is 3.77× looser than the
   best measured option. The rule as written is applied and the red-zones are
   published; whether the *memory* red-zone should instead be the per-axis best
   is the operator's call. **942 B/read is what a native layer has to beat.**
2. **The ~0.4–0.5 KB exclusive-retained budget is a SHELL budget.** Both donors
   clear it sub-free; **nothing measured meets it for a boundary that reads
   once** (UIx 3,811 B = 7.6× the paper-fail line; Reagent 1,565 B = 1.6×).
   `validation.md`'s budget table wants a per-read row. Derived target for
   HD-002's grouped tier: grouping removes only the hook half, so its floor is
   ~942 B and the prize is ~2,600 B/read — **~18 KB on the census's seven-read
   archetype**, a concrete pre-registered number for clause (c).

Also, a null result: **neither arm retains anything after teardown** (worst
+17 B/boundary, typically <5 B), so HD-002 clause (d) is met by both donors.

## Instrument

Retention, never allocation — V8's CDP *sampling* profiler drops the samples of
collected objects. **In-situ positive control of predicted size on every round**:
a dense double array, 4,700,000 B known in advance, measured to **+0.001%**
(reader A) and **+0.001%** (reader C). **0 unverified of 186 mounts.** Both plan
orders reported separately and **overlapping on every rung**. Order guard clean
on both pages; it exited 2 on a one-round trial, so the refusal path is known
good. `:advanced`, `goog.DEBUG false`, headless Chromium 147 — browser numbers
only.

**No new build-id and no `shadow-cljs.edn` touch** (`rf2-2rtt6.2` owns the lane):
the `:advanced` bundle comes from `freehand-release` via `--config-merge`, on an
existing source path. The instrument sits beside B7 because it rides B7's
collector design and `require`s its order guard rather than copying it; it
requires nothing from `re-frame.freehand` and moves to the Hicasso lane
unchanged once that lane exists.

## Quality gates

| gate | command | exit |
|---|---|---:|
| order-guard self-test | `node implementation/freehand/test/re_frame/freehand/bench/order_guard.cjs` | **0** |
| `:advanced` bundle build | `shadow-cljs release freehand-release --config-merge …` | **0** |
| **the ladder, to completion** | `node …/reads_ladder_run.cjs` (6 rounds × 2 substrates + snapshot pass) | **0** |
| browser-DOM lane partition | `node --test implementation/scripts/_browser-dom-lane-partition.test.cjs` | **0** |
| freehand suite (1,393 tests / 7,733 assertions) | `npm run test:freehand` | **0** |

Ladder run: guard **clean** on both pages, **0 unverified of 186** mounts,
control error **+0.001%**. `docs/design/hicasso/` is mkdocs-excluded, so the new
studio page does not enter the site build.
