### PR TITLE
bench(hicasso): P0 ratom-spine narrow-write leg (rf2-2rtt6.3)

### DIFF
--- a/docs/design/hicasso/studio/p0-ratom-spine-narrow-write.md
+++ b/docs/design/hicasso/studio/p0-ratom-spine-narrow-write.md
@@ -1,0 +1,254 @@
+# P0 — the ratom-spine narrow write (write + flush, summed)
+
+**Bead** `rf2-2rtt6.3` · **Producing commit** `99eeeafcde7aa11db6c0925a8aa0e1113a57c2a0`
+
+```bash
+cd implementation && npm ci
+node adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
+```
+
+**Runtime, and it is the same for every figure on this page:** Chromium
+147.0.7727.15, `:advanced`, `goog.DEBUG=false`, Windows 11 (10.0.26200), 24
+logical CPUs, six sibling agents live on the box. Exit `0` = reportable,
+`1` = a gate failed, `2` = the arm-order guard refused.
+
+---
+
+## What this page settles
+
+A narrow write — one cell of three hundred — on **re-frame2 running the
+Reagent adapter**, which is `re-frame.substrate.spine/make-ratom-spine`:
+Reagent's own `r/atom`, Reagent's own `make-reaction`, Reagent's own
+batching. The figure is **write + flush, summed**, and the split is
+published beside it.
+
+It exists because the withdrawn predecessor programme's narrow-update row
+was not a valid target as measured, in two separate ways, and both are
+repaired here.
+
+**The comparison arm was not the same amount of framework.** It read a
+bare `reagent.core/atom` through a `reagent.core/cursor` — Reagent's own
+idiom, and a fair arm for *what does Reagent cost*, but not for *what does
+re-frame on Reagent cost*. A re-frame-shaped application pays a frame
+write and a subscription graph the bare-ratom arm never touches. Both arms
+are measured here, in the same interleave on the same page, so the size of
+that framing error is a row rather than a claim.
+
+**And the write leg alone means nothing on this substrate.** On the ratom
+spine a write is a bare install into the frame's one physical container;
+the reactions do not recompute there, they recompute on Reagent's flush.
+A harness that timed the write leg and stopped would have published
+0.0006–0.0017 ms per write for an operation that costs 0.44. That is a
+factor of about 400, and it is why the summed figure is the published one.
+
+---
+
+## The headline
+
+**A narrow write on the ratom spine costs 0.44–0.45 ms, and 99.6% of it is
+the flush.**
+
+Three independent runs at the same commit, 300 cells, 300 layer-1
+subscriptions, one per cell. Per-write milliseconds; a sample is 20 writes
+and the per-write figure is the sample divided by twenty.
+
+| arm | write+flush (mean, 3 runs) | write | flush | write share |
+|---|---|---|---|---|
+| bare `r/atom` + cursor, no re-frame | 0.0437 / 0.0558 / 0.0485 | 0.0006–0.0015 | 0.0432–0.0543 | 1.3–2.7% |
+| **re-frame ratom spine, `replace-app-db!`** | **0.4506 / 0.4383 / 0.4500** | 0.0006–0.0017 | 0.4367–0.4500 | **0.1–0.4%** |
+| re-frame ratom spine, `dispatch-sync` | 0.4807 / 0.5264 / 0.4979 | 0.0239–0.0315 | 0.4501–0.4946 | 4.8–6.3% |
+
+Within-run **ranges** for the headline arm, median [min–max] across 36
+samples per run:
+
+| run | write+flush |
+|---|---|
+| 1 | 0.4750 [0.1700–0.7250] |
+| 2 | 0.4100 [0.1500–0.9600] |
+| 3 | 0.4250 [0.1600–0.7200] |
+
+The three runs' ranges overlap throughout, so they are one measurement
+taken three times, not three measurements. The within-run spread is wide —
+a factor of four between best and worst sample — because the box is
+carrying six other agents; the median is stable to 6% across runs and the
+**mean is stable to 3%**, which is what the arms are compared on.
+
+### Both orders
+
+Arms are interleaved at the sample level with the slot order rotating
+**and reflecting** on the sample index, so every arm is measured under two
+different adjacencies. A bare rotation would not vary that at all: arm `a`
+sits at slot `(a − s) mod k`, so its predecessor is `(a − 1) mod k` at
+every index.
+
+| arm | forward | reflected | verdict |
+|---|---|---|---|
+| bare-ratom | 0.0450 [0.0100–0.0800] | 0.0450 [0.0150–0.0800] | overlapping — indistinguishable |
+| spine-replace | 0.4725 [0.2450–0.7050] | 0.4750 [0.1700–0.7250] | overlapping — indistinguishable |
+| spine-dispatch | 0.4750 [0.2600–0.6800] | 0.4950 [0.1550–0.7600] | overlapping — indistinguishable |
+
+The arm-order guard returned **reportable** on all three runs: no arm's
+figure is separated by what ran before it or by where in the run it was
+measured, on either factor, at a 10% tolerance.
+
+---
+
+## Where the money goes, and why "flush" needed splitting further
+
+"The flush" is one word doing two jobs — Reagent re-running every dirtied
+reaction, and React committing the one cell that changed — and the
+distinction is exactly the one the predecessor got wrong. Three cell
+counts separate them: the React commit is the same one-cell commit at
+every rung and only the subscription count moves.
+
+| subscriptions | flush ms/write | per subscription | local slope vs the rung below |
+|---|---|---|---|
+| 30 | 0.0129–0.0150 | 0.43–0.50 µs | — |
+| 100 | 0.0681–0.0815 | 0.68–0.82 µs | 0.79–0.89 µs/sub |
+| 300 | 0.4367–0.4500 | 1.46–1.50 µs | 1.83–1.88 µs/sub |
+
+**No per-subscription cost is quoted, and that is a finding rather than a
+caution.** A line fitted through the top and bottom rungs has an intercept
+of **−0.032 to −0.036 ms**, and the work that does *not* scale with the
+subscription count — React's one-cell commit, Reagent's drain overhead —
+cannot cost less than nothing. The two-rung fit was tried first and
+produced a clean-looking "2.27 µs per subscription"; the negative
+intercept is the data refusing that model. Ten times the subscriptions
+costs **34.8× / 29.1× / 33.8×** the flush across the three runs — an
+exponent of **1.46–1.54**.
+
+So a narrow write's cost on this substrate is **super-linear in the number
+of layer-1 subscriptions in the frame**, and essentially all of it lands
+in Reagent's reaction drain rather than in React.
+
+What is *not* in doubt is the shape, which is substrate-independent: a
+one-cell write marks **every** layer-1 subscription in the frame dirty and
+re-evaluates all of them, because a layer-1 body is an opaque function of
+the whole app-db and the graph holds no path. This page prices that shape
+on the ratom spine; it does not discover it.
+
+---
+
+## The like-for-like correction
+
+| | mean ms/write | ratio to bare ratom |
+|---|---|---|
+| bare `r/atom` + cursor (no re-frame) | 0.0437 / 0.0558 / 0.0485 | 1.0× |
+| re-frame ratom spine, `replace-app-db!` | 0.4506 / 0.4383 / 0.4500 | **10.3× / 7.9× / 9.3×** |
+| re-frame ratom spine, `dispatch-sync` | 0.4807 / 0.5264 / 0.4979 | 11.0× / 9.4× / 10.3× |
+
+**Any narrow-update ratio quoted against the bare-ratom column is
+measuring this gap and calling it something else.** A ratio of, say, 15×
+against a bare ratom is not 15× against a re-frame application: on these
+numbers roughly eight to ten of it is already paid by re-frame reading its
+own subscriptions, whatever renders them.
+
+The event drain — the difference between the two write doors — is
+**0.030 / 0.088 / 0.048 ms per write** — 6%, 17% and 10% of the total, the
+one figure on this page whose three runs do *not* sit tightly together.
+It is also the only part of the cost that shows up in the *write* leg at
+all: `dispatch-sync` is the only arm whose write leg clears the clock
+grid, and it clears it because the event drain runs there.
+
+---
+
+## The instrument's own gates
+
+Every one of these ran before any figure was taken, on every run.
+
+| gate | result |
+|---|---|
+| **Arm-order guard self-test**, replayed from recorded fixtures, run inside the `:advanced` bundle | 8/8 passed |
+| **Key-renaming integrity probe** — the bundle writes and reads its own accumulator keys under the renaming it was compiled with | passed; keys `control,write,gap,force,total,span,bad,writes` |
+| **Clock quantum**, measured in-page | 0.100 ms — Chrome's documented clamp, confirmed rather than assumed |
+| **DOM read-back**, every write read back out of the page inside its own window | **0 unverified of 4320**, all three runs |
+| **Empty-`flushSync` negative control** — the same arm with an empty drain, which must go red | **20 unverified of 20**, all three runs |
+| **Positive control**, predicted vs measured | see below |
+| **Leg identity** — write + gap + force = total, exactly | holds on every arm |
+| **Position completeness** — every sample reached the guard with a finite position | 36 of 36 per arm |
+
+### The positive control
+
+A predicted burn inside every measured window, as its own leg, read three
+ways.
+
+| | predicted | measured (p50, run 1 / 2 / 3) |
+|---|---|---|
+| rung 1 | 0.3000 ms/write | 0.3300 / 0.3300 / 0.3300 |
+| rung 2 | 0.9000 ms/write | 0.9700 / 0.9600 / 0.9550 |
+| **slope** | 0.6000 ms | 0.6400 / 0.6300 / 0.6250 — **4.2–6.7% high** |
+
+The direct readings run ~0.03 ms above prediction and the slope runs 4–7%
+high; both are the spin loop's own clock-read overhead, which the slope
+reduces but does not remove, since the loop reads the clock at both rungs.
+
+The third reading is the one that matters, because it is falsifiable: **an
+arm's write+flush must not move when the control's size changes.** It
+does not — every arm's rung-1 and rung-2 ranges overlap on every run. Had
+the control's time leaked into the arms' legs, the leg accounting would be
+wrong and nothing on this page would be quotable.
+
+### What is *not* quotable
+
+The clamp check names these, and they are listed rather than quietly
+rounded:
+
+- **`write` on every arm but `spine-dispatch`** sits under the 100 µs
+  grid. Its median is 0 by construction, so no median-derived write share
+  appears anywhere on this page; the split above is taken from the
+  **quantisation-unbiased mean**, which recovers a sub-quantum leg because
+  `floor(t₁/q)·q − floor(t₀/q)·q` has expectation exactly `t₁ − t₀`.
+- **`bare-ratom` and `spine-30` totals** carry only 2–9× the quantum per
+  sample. They are reported, and they are not absolute figures.
+
+### Warm-up
+
+Each arm is warmed at full window size until the first third of its
+trajectory stops separating from the last third by median, floor 8 windows
+and ceiling 20. `spine-replace` reached the ceiling still trending on one
+run of the three; the guard's phase factor passed on all three regardless,
+which is the direct evidence that warm-up was adequate for the figures
+published.
+
+The settle test is the median one **only**. Accepting "medians within
+tolerance *or* ranges overlap" let every arm settle at the floor while
+still visibly trending — on a loaded box the ranges always overlap, so
+that test passes by being uninformative. Overlapping ranges are the right
+rule for adjudicating two measured strata; they are the wrong rule for
+deciding a site has stopped moving.
+
+---
+
+## Three faults this harness found in itself
+
+Recorded because each produced a plausible, precise, wrong number first.
+
+1. **A shadowed binding silenced three quarters of the guard.** The
+   destructured `{:keys [samples …]}` in the round driver shadowed the
+   numeric `samples` parameter, so the running position counter came back
+   `NaN` and every sample from round two onward reached the arm-order
+   guard with a non-finite position. The guard filters those — so it went
+   on reporting "24 samples" per arm while adjudicating the phase question
+   on the **six** that survived. Nothing threw; the verdict read `[ok]`.
+   The driver now prints the finite-position count per arm beside the
+   strata and **fails the run** if any is missing.
+
+2. **A median write-share read a flat 0%.** With the write leg under the
+   clock grid its median is exactly zero, so a share computed from it was
+   0% on every arm — a precise wrong number that looked like a finding.
+   The split moved to the mean and the median table lost its share column.
+
+3. **A two-rung ladder fitted a negative intercept.** Reported above; the
+   third rung exists because of it.
+
+---
+
+## Lane note
+
+This bead adds **no build id**. `implementation/shadow-cljs.edn` is
+hot-zone and `rf2-2rtt6.2` owns the lane's id, so the driver overrides an
+existing `:advanced` `:browser` build's entry point and output directory
+with `--config-merge` — the technique the donor's own `b8_run.cjs` uses.
+It prefers `:hicasso-bench` when the checkout has it and falls back to
+`:freehand-release` otherwise, so the lane's id is picked up with no edit
+once it lands. `HN_BASE_BUILD` overrides both.

--- a/docs/design/hicasso/studio/p0-ratom-spine-narrow-write.md
+++ b/docs/design/hicasso/studio/p0-ratom-spine-narrow-write.md
@@ -1,6 +1,8 @@
 # P0 — the ratom-spine narrow write (write + flush, summed)
 
-**Bead** `rf2-2rtt6.3` · **Producing commit** `99eeeafcde7aa11db6c0925a8aa0e1113a57c2a0`
+**Bead** `rf2-2rtt6.3` · **Producing commit**
+`828d4f1ac0cff850b6fcb44a7fa2d0729fc175d8` — the commit carrying the
+instrument that took these readings; this page is its child.
 
 ```bash
 cd implementation && npm ci
@@ -38,40 +40,43 @@ that framing error is a row rather than a claim.
 spine a write is a bare install into the frame's one physical container;
 the reactions do not recompute there, they recompute on Reagent's flush.
 A harness that timed the write leg and stopped would have published
-0.0006–0.0017 ms per write for an operation that costs 0.44. That is a
-factor of about 400, and it is why the summed figure is the published one.
+0.0006–0.0010 ms per write for an operation that costs 0.39–0.52 — an
+understatement by a factor of between 400 and 850. That is why the summed
+figure is the published one.
 
 ---
 
 ## The headline
 
-**A narrow write on the ratom spine costs 0.44–0.45 ms, and 99.6% of it is
+**A narrow write on the ratom spine costs 0.39–0.52 ms, and 99.8% of it is
 the flush.**
 
-Three independent runs at the same commit, 300 cells, 300 layer-1
-subscriptions, one per cell. Per-write milliseconds; a sample is 20 writes
-and the per-write figure is the sample divided by twenty.
+Three independent runs at the one commit; 300 cells, 300 layer-1
+subscriptions, one per cell. Per-write milliseconds — a sample is 20
+writes and the per-write figure is the sample divided by twenty.
 
-| arm | write+flush (mean, 3 runs) | write | flush | write share |
+| arm | write+flush (mean, r1 / r2 / r3) | write | flush | write share |
 |---|---|---|---|---|
-| bare `r/atom` + cursor, no re-frame | 0.0437 / 0.0558 / 0.0485 | 0.0006–0.0015 | 0.0432–0.0543 | 1.3–2.7% |
-| **re-frame ratom spine, `replace-app-db!`** | **0.4506 / 0.4383 / 0.4500** | 0.0006–0.0017 | 0.4367–0.4500 | **0.1–0.4%** |
-| re-frame ratom spine, `dispatch-sync` | 0.4807 / 0.5264 / 0.4979 | 0.0239–0.0315 | 0.4501–0.4946 | 4.8–6.3% |
+| bare `r/atom` + cursor, no re-frame | 0.0621 / 0.0494 / 0.0310 | 0.0007–0.0008 | 0.0300–0.0613 | 1.1–2.2% |
+| **re-frame ratom spine, `replace-app-db!`** | **0.5244 / 0.5146 / 0.3903** | 0.0006–0.0010 | 0.3892–0.5237 | **0.1–0.2%** |
+| re-frame ratom spine, `dispatch-sync` | 0.5910 / 0.6076 / 0.4653 | 0.0213–0.0360 | 0.4437–0.5750 | 4.6–6.1% |
 
-Within-run **ranges** for the headline arm, median [min–max] across 36
-samples per run:
+Within-run **ranges** for the headline arm — median [min–max] over 36
+samples, which is 720 verified writes per run:
 
 | run | write+flush |
 |---|---|
-| 1 | 0.4750 [0.1700–0.7250] |
-| 2 | 0.4100 [0.1500–0.9600] |
-| 3 | 0.4250 [0.1600–0.7200] |
+| 1 | 0.5475 [0.1850–1.1650] |
+| 2 | 0.5075 [0.1950–0.8800] |
+| 3 | 0.4200 [0.1350–0.7300] |
 
-The three runs' ranges overlap throughout, so they are one measurement
-taken three times, not three measurements. The within-run spread is wide —
-a factor of four between best and worst sample — because the box is
-carrying six other agents; the median is stable to 6% across runs and the
-**mean is stable to 3%**, which is what the arms are compared on.
+All three ranges overlap, so these are one measurement taken three times.
+The spread is wide — a factor of six between the best and worst sample of
+run 1 — because the box is carrying six other agents, and run 3 caught it
+quieter than the other two. **The absolute figure is therefore quoted as a
+range and not as a number**, and the two quantities that matter for the
+comparison are much steadier than it: the write share holds at 0.1–0.2%
+across every run, and the ladder exponent at 1.45–1.53.
 
 ### Both orders
 
@@ -79,16 +84,20 @@ Arms are interleaved at the sample level with the slot order rotating
 **and reflecting** on the sample index, so every arm is measured under two
 different adjacencies. A bare rotation would not vary that at all: arm `a`
 sits at slot `(a − s) mod k`, so its predecessor is `(a − 1) mod k` at
-every index.
+every index, and only the round seam ever differs.
+
+Run 1, per-write medians [min–max]:
 
 | arm | forward | reflected | verdict |
 |---|---|---|---|
-| bare-ratom | 0.0450 [0.0100–0.0800] | 0.0450 [0.0150–0.0800] | overlapping — indistinguishable |
-| spine-replace | 0.4725 [0.2450–0.7050] | 0.4750 [0.1700–0.7250] | overlapping — indistinguishable |
-| spine-dispatch | 0.4750 [0.2600–0.6800] | 0.4950 [0.1550–0.7600] | overlapping — indistinguishable |
+| bare-ratom | 0.0500 [0.0150–0.1450] | 0.0450 [0.0200–0.1300] | overlapping — indistinguishable |
+| spine-replace | 0.4925 [0.1950–1.1650] | 0.5700 [0.1850–0.9400] | overlapping — indistinguishable |
+| spine-dispatch | 0.5300 [0.2350–1.1100] | 0.5875 [0.2500–1.7900] | overlapping — indistinguishable |
+| spine-30 | 0.0150 [0.0000–0.0400] | 0.0125 [0.0000–0.0500] | overlapping — indistinguishable |
+| spine-100 | 0.0850 [0.0200–0.2350] | 0.0750 [0.0250–0.2050] | overlapping — indistinguishable |
 
-The arm-order guard returned **reportable** on all three runs: no arm's
-figure is separated by what ran before it or by where in the run it was
+The arm-order guard returned **reportable on all three runs**: no arm's
+figure is separated by what ran before it, or by where in the run it was
 measured, on either factor, at a 10% tolerance.
 
 ---
@@ -96,26 +105,26 @@ measured, on either factor, at a 10% tolerance.
 ## Where the money goes, and why "flush" needed splitting further
 
 "The flush" is one word doing two jobs — Reagent re-running every dirtied
-reaction, and React committing the one cell that changed — and the
-distinction is exactly the one the predecessor got wrong. Three cell
-counts separate them: the React commit is the same one-cell commit at
-every rung and only the subscription count moves.
+reaction, and React committing the one cell that changed — and telling
+them apart is exactly what the predecessor did not do. Three cell counts
+separate them by construction: the React commit is the same one-cell
+commit at every rung, and only the subscription count moves.
 
-| subscriptions | flush ms/write | per subscription | local slope vs the rung below |
+| subscriptions | flush ms/write (r1 / r2 / r3) | per subscription | local slope vs the rung below |
 |---|---|---|---|
-| 30 | 0.0129–0.0150 | 0.43–0.50 µs | — |
-| 100 | 0.0681–0.0815 | 0.68–0.82 µs | 0.79–0.89 µs/sub |
-| 300 | 0.4367–0.4500 | 1.46–1.50 µs | 1.83–1.88 µs/sub |
+| 30 | 0.0154 / 0.0182 / 0.0114 | 0.38–0.61 µs | — |
+| 100 | 0.0932 / 0.0946 / 0.0557 | 0.56–0.95 µs | 0.63–1.11 µs/sub |
+| 300 | 0.5237 / 0.5140 / 0.3892 | 1.30–1.75 µs | 1.67–2.15 µs/sub |
 
 **No per-subscription cost is quoted, and that is a finding rather than a
 caution.** A line fitted through the top and bottom rungs has an intercept
-of **−0.032 to −0.036 ms**, and the work that does *not* scale with the
+of **−0.031 to −0.041 ms**, and the work that does *not* scale with the
 subscription count — React's one-cell commit, Reagent's drain overhead —
 cannot cost less than nothing. The two-rung fit was tried first and
 produced a clean-looking "2.27 µs per subscription"; the negative
-intercept is the data refusing that model. Ten times the subscriptions
-costs **34.8× / 29.1× / 33.8×** the flush across the three runs — an
-exponent of **1.46–1.54**.
+intercept is the data refusing that model, and the third rung exists
+because of it. Ten times the subscriptions costs **34.0× / 28.2× / 34.1×**
+the flush — an exponent of **1.53 / 1.45 / 1.53**.
 
 So a narrow write's cost on this substrate is **super-linear in the number
 of layer-1 subscriptions in the frame**, and essentially all of it lands
@@ -131,24 +140,28 @@ on the ratom spine; it does not discover it.
 
 ## The like-for-like correction
 
-| | mean ms/write | ratio to bare ratom |
+| | mean ms/write (r1 / r2 / r3) | ratio to bare ratom |
 |---|---|---|
-| bare `r/atom` + cursor (no re-frame) | 0.0437 / 0.0558 / 0.0485 | 1.0× |
-| re-frame ratom spine, `replace-app-db!` | 0.4506 / 0.4383 / 0.4500 | **10.3× / 7.9× / 9.3×** |
-| re-frame ratom spine, `dispatch-sync` | 0.4807 / 0.5264 / 0.4979 | 11.0× / 9.4× / 10.3× |
+| bare `r/atom` + cursor (no re-frame) | 0.0621 / 0.0494 / 0.0310 | 1.0× |
+| re-frame ratom spine, `replace-app-db!` | 0.5244 / 0.5146 / 0.3903 | **8.4× / 10.4× / 12.6×** |
+| re-frame ratom spine, `dispatch-sync` | 0.5910 / 0.6076 / 0.4653 | 9.5× / 12.3× / 15.0× |
 
 **Any narrow-update ratio quoted against the bare-ratom column is
 measuring this gap and calling it something else.** A ratio of, say, 15×
 against a bare ratom is not 15× against a re-frame application: on these
-numbers roughly eight to ten of it is already paid by re-frame reading its
-own subscriptions, whatever renders them.
+numbers between eight and thirteen of it is already paid by re-frame
+reading its own subscriptions, whatever renders them.
+
+The ratio's own run-to-run spread — 8.4× to 12.6× — is real and is stated
+rather than averaged away. Both arms move with the box, and they do not
+move together, so the ratio is not the stable quantity here; **the
+write-versus-flush split is**, and that is what this bead was asked for.
 
 The event drain — the difference between the two write doors — is
-**0.030 / 0.088 / 0.048 ms per write** — 6%, 17% and 10% of the total, the
-one figure on this page whose three runs do *not* sit tightly together.
-It is also the only part of the cost that shows up in the *write* leg at
-all: `dispatch-sync` is the only arm whose write leg clears the clock
-grid, and it clears it because the event drain runs there.
+**0.067 / 0.093 / 0.075 ms per write**, 11–16% of the total. It is the
+only part of the cost that shows up in the *write* leg at all:
+`dispatch-sync` is the one arm whose write leg clears the clock grid, and
+it clears it because the drain runs there.
 
 ---
 
@@ -174,13 +187,15 @@ ways.
 
 | | predicted | measured (p50, run 1 / 2 / 3) |
 |---|---|---|
-| rung 1 | 0.3000 ms/write | 0.3300 / 0.3300 / 0.3300 |
-| rung 2 | 0.9000 ms/write | 0.9700 / 0.9600 / 0.9550 |
-| **slope** | 0.6000 ms | 0.6400 / 0.6300 / 0.6250 — **4.2–6.7% high** |
+| rung 1 | 0.3000 ms/write | 0.3300 / 0.3300 / 0.3250 |
+| rung 2 | 0.9000 ms/write | 0.9600 / 0.9650 / 0.9600 |
+| **slope** | 0.6000 ms | 0.6300 / 0.6350 / 0.6350 — **5.0–5.8% high** |
 
-The direct readings run ~0.03 ms above prediction and the slope runs 4–7%
-high; both are the spin loop's own clock-read overhead, which the slope
-reduces but does not remove, since the loop reads the clock at both rungs.
+The direct readings run 0.025–0.065 ms above prediction and the slope runs
+5–6% high; both are the spin loop's own clock-read overhead, which the
+slope reduces but does not remove, since the loop reads the clock at both
+rungs. The control is a *floor* on the instrument's resolution, not a
+correction applied to anything.
 
 The third reading is the one that matters, because it is falsifiable: **an
 arm's write+flush must not move when the control's size changes.** It
@@ -198,17 +213,27 @@ rounded:
   appears anywhere on this page; the split above is taken from the
   **quantisation-unbiased mean**, which recovers a sub-quantum leg because
   `floor(t₁/q)·q − floor(t₀/q)·q` has expectation exactly `t₁ − t₀`.
-- **`bare-ratom` and `spine-30` totals** carry only 2–9× the quantum per
-  sample. They are reported, and they are not absolute figures.
+- **`bare-ratom` and `spine-30` totals** carry only a few multiples of the
+  quantum per sample. They are reported, and they are not absolute
+  figures — which is one more reason the like-for-like *ratio* is quoted
+  as a range and the *split* is quoted as the finding.
 
 ### Warm-up
 
 Each arm is warmed at full window size until the first third of its
 trajectory stops separating from the last third by median, floor 8 windows
-and ceiling 20. `spine-replace` reached the ceiling still trending on one
-run of the three; the guard's phase factor passed on all three regardless,
-which is the direct evidence that warm-up was adequate for the figures
-published.
+and ceiling 20. **On these three runs several arms reached the ceiling
+still trending** — `bare-ratom` and `spine-dispatch` on all three,
+`spine-replace` on one — and that is stated rather than smoothed, because
+it is the honest account of a box carrying six other agents.
+
+What says the figures are nevertheless usable is not the warm-up rule but
+the guard: its **phase** factor partitions each arm's 36 measured samples
+into thirds by position in the run and compares the first third against
+the last, and it came back clean on every arm of every run. A site that
+was still climbing through the measured window would separate there. The
+whole trajectory is printed on every run, so this is checkable rather than
+asserted.
 
 The settle test is the median one **only**. Accepting "medians within
 tolerance *or* ranges overlap" let every arm settle at the floor while

--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs
@@ -264,6 +264,30 @@
    (for [i (range n)]
      ^{:key i} [spine-cell i])])
 
+(def ladder-cells
+  "The SUBSCRIPTION-COUNT ladder — three rungs, and three rather than two
+  is a repair.
+
+  The headline figure says the flush carries essentially all of a narrow
+  write's cost on this substrate. That is one word doing two jobs: the
+  flush is where Reagent re-runs every dirtied reaction AND where React
+  commits the one cell that changed, and a single number cannot say which
+  of those the money went to.
+
+  Two rungs looked like enough — the React commit is the same one-cell
+  commit at both, so the slope should be the per-subscription cost and the
+  intercept everything else. Measured, 30 and 300 gave a slope of 2.27 us
+  per subscription and an intercept of MINUS 0.048 ms. A negative
+  intercept is not a small error; it is the two points refusing the linear
+  model they were fitted to, because the flush grows FASTER than the
+  subscription count. A third rung makes that visible instead of hiding it
+  inside a number that reads like a per-unit cost.
+
+  30 rather than 1 at the bottom: a one-cell grid changes the shape of
+  both the DOM and the write, and a ladder wants one shape at three
+  sizes."
+  [30 100 300])
+
 ;; ---------------------------------------------------------------------------
 ;; The bare-ratom arm — b6's shape, reproduced character for character
 ;; ---------------------------------------------------------------------------
@@ -308,14 +332,14 @@
   clock reads, one promise, one accumulate. Its read-back is skipped
   because it renders no cell to read back."
   []
-  {:id :instrument :skip-verify? true
+  {:id :instrument :skip-verify? true :cells cells-n
    :mount   (fn [container] container)
    :write!  (fn [_ _] nil)
    :force!  (fn [] nil)
    :unmount (fn [_] nil)})
 
 (defn- bare-ratom-arm []
-  {:id :bare-ratom
+  {:id :bare-ratom :cells cells-n
    :mount   (fn [container]
               (reset! bare-cells (vec (repeat cells-n 0)))
               (let [root (rdc/create-root container)]
@@ -335,35 +359,36 @@
 
   Each arm owns its OWN frame: frames are isolated contexts and two arms
   sharing one would let each other's writes into the other's graph."
-  [id frame-id write-door]
-  {:id id
-   :mount
-   (fn [container]
-     (rf/make-frame {:id frame-id})
-     (rf/with-frame frame-id (rf/dispatch-sync [:hn/seed cells-n]))
-     (let [root (rdc/create-root container)]
-       (react-dom/flushSync
-         (fn [] (rdc/render root [rf/frame-provider {:frame frame-id}
-                                  [spine-grid cells-n]])))
-       root))
-   :write!
-   (fn [i val]
-     (case write-door
-       :replace-app-db
-       (let [db (frame/frame-app-db-value frame-id)]
-         (frame/replace-app-db!
-           frame-id
-           (if (= i :all)
-             (assoc db :cells (vec (repeat cells-n val)))
-             (update db :cells assoc i val))))
+  ([id frame-id write-door] (spine-arm id frame-id write-door cells-n))
+  ([id frame-id write-door n]
+   {:id id :cells n
+    :mount
+    (fn [container]
+      (rf/make-frame {:id frame-id})
+      (rf/with-frame frame-id (rf/dispatch-sync [:hn/seed n]))
+      (let [root (rdc/create-root container)]
+        (react-dom/flushSync
+          (fn [] (rdc/render root [rf/frame-provider {:frame frame-id}
+                                   [spine-grid n]])))
+        root))
+    :write!
+    (fn [i val]
+      (case write-door
+        :replace-app-db
+        (let [db (frame/frame-app-db-value frame-id)]
+          (frame/replace-app-db!
+            frame-id
+            (if (= i :all)
+              (assoc db :cells (vec (repeat n val)))
+              (update db :cells assoc i val))))
 
-       :dispatch-sync
-       (rf/with-frame frame-id
-         (if (= i :all)
-           (rf/dispatch-sync [:hn/set-all cells-n val])
-           (rf/dispatch-sync [:hn/set-cell i val])))))
-   :force!  flush-reagent!
-   :unmount (fn [root] (react-dom/flushSync (fn [] (rdc/unmount root))))})
+        :dispatch-sync
+        (rf/with-frame frame-id
+          (if (= i :all)
+            (rf/dispatch-sync [:hn/set-all n val])
+            (rf/dispatch-sync [:hn/set-cell i val])))))
+    :force!  flush-reagent!
+    :unmount (fn [root] (react-dom/flushSync (fn [] (rdc/unmount root))))}))
 
 (defn negative-control-arm
   "THE READ-BACK GATE'S NON-VACUITY CONTROL, and it is built to FAIL.
@@ -386,10 +411,19 @@
   "The measured arms, in the order they are DECLARED — the run order is
   `guard/slot-order`'s and varies with the sample index."
   []
-  [(instrument-arm)
-   (bare-ratom-arm)
-   (spine-arm :spine-replace  :hn/spine-replace  :replace-app-db)
-   (spine-arm :spine-dispatch :hn/spine-dispatch :dispatch-sync)])
+  (into [(instrument-arm)
+         (bare-ratom-arm)
+         (spine-arm :spine-replace  :hn/spine-replace  :replace-app-db)
+         (spine-arm :spine-dispatch :hn/spine-dispatch :dispatch-sync)]
+        ;; The ladder's rungs BELOW the headline count. The 300-cell rung
+        ;; is `:spine-replace` itself — measuring it twice would price the
+        ;; same arm under two names and invite the two copies to disagree.
+        (map (fn [n]
+               (spine-arm (keyword (str "spine-" n))
+                          (keyword "hn" (str "spine-" n))
+                          :replace-app-db
+                          n)))
+        (butlast ladder-cells)))
 
 ;; ---------------------------------------------------------------------------
 ;; Mounting
@@ -464,17 +498,18 @@
                             "span"    (- t3 t0)
                             "ok"      (or (boolean (:skip-verify? arm))
                                           (= (str val)
-                                             (cell-text container probe))))))))))))))
+                                             (cell-text container probe)))))))))))))
 
 (defn run-sample!
   "One SAMPLE: `n` narrow writes over one arm, legs accumulated, every
   write verified at the DOM in its own window."
   [mnt n]
-  (let [acc (fresh-acc)]
+  (let [acc   (fresh-acc)
+        width (or (:cells (:arm mnt)) cells-n)]
     (chain acc (range n)
       (fn [a _]
         (let [val (next-gen!)
-              i   (mod val cells-n)]
+              i   (mod val width)]
           (-> (timed-write! mnt i val)
               (.then (fn [r]
                        (bump! a "control" (gobj/get r "control"))

--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs
@@ -1,0 +1,636 @@
+(ns re-frame.bench.hicasso-narrow
+  "EP-0038 P0 — the RATOM-SPINE NARROW-WRITE leg, write + flush SUMMED.
+
+  ## The mistake this instrument exists to prevent
+
+  The withdrawn predecessor programme published a narrow-update row that
+  looked catastrophic — roughly 15x — and the number was not a valid
+  target as measured. Two separate faults, and this namespace is built
+  around both.
+
+  **The comparison arm was not the same amount of framework.** The
+  compared substrate read a bare `reagent.core/atom` through a
+  `reagent.core/cursor`. That is Reagent's own idiom and it is a fair
+  arm for the question *what does Reagent cost*, but it is not the
+  question *what does re-frame on Reagent cost*: a re-frame-shaped
+  Reagent application pays a frame write and a subscription graph that
+  the bare-ratom arm never touches. Roughly 90% of the reported gap
+  decomposed to exactly that — the write and the signal graph, not
+  rendering. Optimising against it would have been optimising re-frame
+  under another substrate's name.
+
+  **And the write leg alone means nothing on this substrate.** On the
+  ratom spine a write is a bare install into the frame's one physical
+  container; the reactions do not recompute there, they recompute on
+  Reagent's flush. A harness that timed the write leg and stopped would
+  report a flatteringly small figure that no user experiences. So the
+  published figure here is `write + gap + force`, SUMMED, and the split
+  is published beside it precisely so a reader can see how much of it is
+  re-frame and how much is React.
+
+  ## The four arms
+
+  `:bare-ratom`            b6's arm, reproduced — `r/cursor` over an
+                           `r/atom`, no re-frame at all. This is the arm
+                           the predecessor compared against, and it is
+                           here so the size of the framing error is a
+                           measurement rather than an assertion.
+
+  `:spine-replace`         re-frame2 on the Reagent adapter — which is
+                           `re-frame.substrate.spine/make-ratom-spine`,
+                           Reagent's own `r/atom` and `make-reaction`,
+                           Reagent's own batching. 300 layer-1
+                           subscriptions, one per cell. The write door is
+                           `frame/replace-app-db!`, the SAME door the
+                           donor row used, so the two are comparable
+                           leg-for-leg.
+
+  `:spine-dispatch`        the same views and the same graph, written
+                           through `dispatch-sync` — the door a real
+                           application uses. The difference between this
+                           and `:spine-replace` is the event drain, and
+                           it is a row rather than a sentence.
+
+  `:instrument`            a pseudo-arm that installs nothing and drains
+                           nothing, so a window over it contains the
+                           harness and NOTHING ELSE. It prices the
+                           harness's own footprint, which is otherwise an
+                           unexamined constant inside every figure above.
+
+  ## The window, and why every leg boundary is where it is
+
+      t0 -> control spin -> tc -> write! -> t1 -> microtask -> t2
+         -> force! -> t3 -> READ THE CELL BACK OUT OF THE DOM
+
+  `:total-ms` is `t3 - tc`: write + gap + force, the elapsed time to get
+  one narrow write onto the page. The control's leg is EXCLUDED from it
+  and published separately.
+
+  `force!` is `react-dom/flushSync(reagent.core/flush)` on every real
+  arm. **An EMPTY `flushSync` would not do**, and that is a recorded
+  fault rather than a precaution: an empty `flushSync` drains only
+  React's sync lane, and the donor harness recorded 80 of 320 samples
+  ending with the cell still holding its old value because of it.
+  [[negative-control-arm]] reproduces that fault deliberately, so the
+  read-back gate below is shown to have signal instead of being trusted.
+
+  Nothing runs inside React's `act` environment, and the adapter's own
+  `flush-views!` is deliberately NOT the door used here: it wraps `act`,
+  whose queue is not the browser's scheduler, and the whole point of the
+  window is that it is the browser's.
+
+  ## Every write is verified at the DOM inside its own window
+
+  A clock alone once accepted a window in which 1,320 of 1,320 writes
+  never reached the page. So the written cell is read back out of the
+  DOM after `t3` — inside the write's own window, not once at the end —
+  and the count of failures is published beside every figure as
+  \"N unverified of M\". A sample with any unverified write is still
+  reported; it is the count that is the evidence.
+
+  ## Chrome clamps `performance.now()` to 100 microseconds
+
+  A single narrow write sits on that clamp. So a SAMPLE is 20 writes and
+  the per-write figure is the sample divided by 20; [[clock-quantum]]
+  measures the clamp from inside the page every run, and the driver
+  refuses to quote any leg whose per-sample value is not clear of it.
+
+  ## The positive control
+
+  [[control-spin!]] burns a PREDICTED number of milliseconds inside every
+  measured window, as its own leg. It is read three ways, and the third
+  is the one that matters:
+
+  1. directly — the control leg's p50 against the predicted duration;
+  2. differentially — the slope across two rungs, which cancels the
+     clock-read overhead the direct reading contains;
+  3. **as a falsifiable consequence** — an arm's `:total-ms` must NOT
+     move when the control's size changes. If it does, the window's leg
+     accounting is leaking and no figure here may be quoted.
+
+  ## Every property crossing the JS boundary is a string literal
+
+  Under `:advanced`, `(.-bad o)` is renamed and a `#js {:bad 0}` literal
+  key is not. The donor recorded the consequence: `undefined + 1` is
+  `NaN`, the literal's `bad: 0` stands, and the driver reads ZERO
+  unverified writes for ever. So every accumulator goes through
+  `goog.object` with string literals, and [[integrity-probe]] proves it
+  from inside the shipped bundle before anything is measured.
+
+  Authority: `docs/EP/EP-0038-the-hicasso-view-layer-programme.md`;
+  the bar and the P0 table are operator-owned on bead rf2-2rtt6.1.
+  Spec donor: rf2-ssn1o (closed, do-not-refile)."
+  (:require ["react-dom" :as react-dom]
+            [goog.object :as gobj]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.bench.order-guard :as guard]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [reagent.core :as r]
+            [reagent.dom.client :as rdc])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+(def cells-n
+  "300 cells, the donor row's fixture. Held identical so this arm's
+  numbers sit beside the donor's narrow row without a scaling caveat."
+  300)
+
+(def writes-per-sample
+  "Chrome clamps `performance.now()` to 100 us and a single narrow write
+  sits on that clamp — measured one at a time, the donor's Reagent arm
+  returned exactly 0.1 ms, which is the quantum itself wearing a result's
+  hat. Twenty writes to a sample lifts every arm clear of it."
+  20)
+
+;; ---------------------------------------------------------------------------
+;; The clock
+;; ---------------------------------------------------------------------------
+
+(defn now [] (js/performance.now))
+
+(defn clock-quantum
+  "The smallest non-zero step this page's `performance.now()` can report,
+  measured rather than assumed.
+
+  Chrome's clamp is documented as 100 us but it is a browser policy, not
+  a language guarantee, and it moves with cross-origin-isolation and with
+  the flags a driver happens to pass. Every leg figure below is quoted
+  against this number, so it is read from inside the bundle that produced
+  those figures."
+  []
+  (let [deltas (array)]
+    (loop [tries 0]
+      (when (and (< tries 200000) (< (alength deltas) 64))
+        (let [a (now) b (now)]
+          (when (> b a) (.push deltas (- b a)))
+          (recur (inc tries)))))
+    (if (zero? (alength deltas))
+      -1
+      (apply min (array-seq deltas)))))
+
+;; ---------------------------------------------------------------------------
+;; Accumulators — string literals only (see the namespace docstring)
+;; ---------------------------------------------------------------------------
+
+(defn- bump! [o k v] (gobj/set o k (+ (gobj/get o k) v)))
+
+(defn- fresh-acc []
+  (js-obj "control" 0 "write" 0 "gap" 0 "force" 0 "total" 0 "span" 0
+          "bad" 0 "writes" 0))
+
+(defn integrity-probe
+  "Prove, inside the `:advanced` bundle, that this namespace reads the
+  keys it writes.
+
+  Runs before any measurement. Writes known values through exactly the
+  accessors the measured path uses and hands back both the values and the
+  object's own key list. A renaming mismatch makes this return the wrong
+  number or a short key list, and the driver refuses to measure.
+
+  `bad` is the key this exists for: it is the unverified-write counter,
+  and a renamed accessor would leave it reading a constant zero — a
+  harness that reports perfect DOM verification precisely because it can
+  no longer see a failure."
+  []
+  (let [o (fresh-acc)]
+    (bump! o "control" 7)
+    (bump! o "bad" 5)
+    (bump! o "total" -11)
+    (js-obj "control" (gobj/get o "control")
+            "bad"     (gobj/get o "bad")
+            "total"   (gobj/get o "total")
+            "keys"    (.join (js/Object.keys o) ","))))
+
+;; ---------------------------------------------------------------------------
+;; The positive control — a predicted number of milliseconds
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private ctl-ms (volatile! 0.0))
+(defonce ^:private ctl-sink (volatile! 0.0))
+
+(defn control-prepare!
+  "Set the control's predicted duration, in milliseconds, OUTSIDE every
+  window. Zero disables it."
+  [ms]
+  (vreset! ctl-ms (double ms))
+  (vreset! ctl-sink 0.0)
+  nil)
+
+(defn control-spin!
+  "Burn the predicted duration. Runs as its own leg of every measured
+  window.
+
+  The sink is not decoration: Closure is entitled to delete a loop whose
+  result nothing reads, and this surface has already published a leg of
+  exactly 0.000 in every arm because a property read was dropped. The
+  final clock reading is summed into a volatile that outlives the call,
+  so the loop must run."
+  []
+  (let [d @ctl-ms]
+    (when (pos? d)
+      (let [t0 (now)]
+        (loop []
+          (let [t (now)]
+            (if (< (- t t0) d)
+              (recur)
+              (vreset! ctl-sink (+ @ctl-sink t)))))))
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; The re-frame side — one graph, two write doors
+;; ---------------------------------------------------------------------------
+
+(rf/reg-sub :hn/cell (fn [db [_ i]] (get-in db [:cells i])))
+
+(rf/reg-event :hn/seed
+  (fn [_ [_ n]] {:db {:cells (vec (repeat n 0))}}))
+
+(rf/reg-event :hn/set-cell
+  (fn [{:keys [db]} [_ i v]] {:db (update db :cells assoc i v)}))
+
+(rf/reg-event :hn/set-all
+  (fn [{:keys [db]} [_ n v]] {:db (assoc db :cells (vec (repeat n v)))}))
+
+;; A `reg-view`, not a plain Reagent fn: only a registered view carries the
+;; `:contextType` static-field wiring Reagent needs to read the enclosing
+;; frame-provider's React context, and a render-time `subscribe` that
+;; cannot resolve a frame raises `:rf.error/no-frame-context` (Spec 002
+;; §Reading the frame from React context).
+(reg-view spine-cell [i]
+  [:span.cell {:data-i i} (str @(rf/subscribe [:hn/cell i]))])
+
+(reg-view spine-grid [n]
+  [:div.ugrid
+   (for [i (range n)]
+     ^{:key i} [spine-cell i])])
+
+;; ---------------------------------------------------------------------------
+;; The bare-ratom arm — b6's shape, reproduced character for character
+;; ---------------------------------------------------------------------------
+
+;; `defonce` takes no docstring, hence the comment. This is Reagent's own
+;; reactive primitive with no re-frame anywhere near it: the arm the
+;; predecessor's narrow row compared against.
+(defonce bare-cells (r/atom []))
+
+(defn bare-cell
+  "A FORM-2 component: the outer call mints a `cursor` once per mounted
+  occurrence and the returned render fn dereferences only that cursor.
+  This is Reagent's idiomatic fine-grained leaf, and the counterpart of
+  the spine arms' per-cell subscription."
+  [i]
+  (let [c (r/cursor bare-cells [i])]
+    (fn [i]
+      [:span.cell {:data-i i} (str @c)])))
+
+(defn bare-grid [n]
+  [:div.ugrid
+   (for [i (range n)]
+     ^{:key i} [bare-cell i])])
+
+;; ---------------------------------------------------------------------------
+;; Arms
+;; ---------------------------------------------------------------------------
+
+(defn- flush-reagent!
+  "Reagent's own documented synchronous render drain, inside a
+  `flushSync` so React commits it in this window rather than on its own
+  scheduler a couple of milliseconds later.
+
+  NOT `re-frame.adapter.reagent/flush-views!`, which wraps `act`: act
+  diverts work to its own queue, which is not what a browser does."
+  []
+  (react-dom/flushSync (fn [] (r/flush))))
+
+(defn- instrument-arm
+  "A pseudo-arm that installs no state and drains nothing, so a window
+  over it contains the harness and nothing else — the control spin, four
+  clock reads, one promise, one accumulate. Its read-back is skipped
+  because it renders no cell to read back."
+  []
+  {:id :instrument :skip-verify? true
+   :mount   (fn [container] container)
+   :write!  (fn [_ _] nil)
+   :force!  (fn [] nil)
+   :unmount (fn [_] nil)})
+
+(defn- bare-ratom-arm []
+  {:id :bare-ratom
+   :mount   (fn [container]
+              (reset! bare-cells (vec (repeat cells-n 0)))
+              (let [root (rdc/create-root container)]
+                (react-dom/flushSync (fn [] (rdc/render root [bare-grid cells-n])))
+                root))
+   :write!  (fn [i val]
+              (if (= i :all)
+                (reset! bare-cells (vec (repeat cells-n val)))
+                (swap! bare-cells assoc i val)))
+   :force!  flush-reagent!
+   :unmount (fn [root] (react-dom/flushSync (fn [] (rdc/unmount root))))})
+
+(defn- spine-arm
+  "One re-frame-on-Reagent arm. `write-door` is `:replace-app-db` (the
+  donor row's door — the frame write and the signal graph, with no event
+  drain) or `:dispatch-sync` (the door an application uses).
+
+  Each arm owns its OWN frame: frames are isolated contexts and two arms
+  sharing one would let each other's writes into the other's graph."
+  [id frame-id write-door]
+  {:id id
+   :mount
+   (fn [container]
+     (rf/make-frame {:id frame-id})
+     (rf/with-frame frame-id (rf/dispatch-sync [:hn/seed cells-n]))
+     (let [root (rdc/create-root container)]
+       (react-dom/flushSync
+         (fn [] (rdc/render root [rf/frame-provider {:frame frame-id}
+                                  [spine-grid cells-n]])))
+       root))
+   :write!
+   (fn [i val]
+     (case write-door
+       :replace-app-db
+       (let [db (frame/frame-app-db-value frame-id)]
+         (frame/replace-app-db!
+           frame-id
+           (if (= i :all)
+             (assoc db :cells (vec (repeat cells-n val)))
+             (update db :cells assoc i val))))
+
+       :dispatch-sync
+       (rf/with-frame frame-id
+         (if (= i :all)
+           (rf/dispatch-sync [:hn/set-all cells-n val])
+           (rf/dispatch-sync [:hn/set-cell i val])))))
+   :force!  flush-reagent!
+   :unmount (fn [root] (react-dom/flushSync (fn [] (rdc/unmount root))))})
+
+(defn negative-control-arm
+  "THE READ-BACK GATE'S NON-VACUITY CONTROL, and it is built to FAIL.
+
+  Identical to `:spine-replace` in every respect but one: `force!` is an
+  EMPTY `react-dom/flushSync` instead of `flushSync(reagent.core/flush)`.
+  An empty flush drains only React's sync lane; a Reagent ratom write sits
+  on Reagent's own batched queue and is not on it. So the clock stops on
+  the OLD value and the DOM read-back must catch it.
+
+  This arm is never quoted as a measurement. It exists so that
+  \"0 unverified of N\" on the real arms is evidence — a gate that cannot
+  go red has not verified anything. The driver runs it once, expects
+  nearly every write to fail, and refuses if they do not."
+  []
+  (assoc (spine-arm :negative-control :hn/negative-control :replace-app-db)
+         :force! (fn [] (react-dom/flushSync (fn [] nil)))))
+
+(defn make-arms
+  "The measured arms, in the order they are DECLARED — the run order is
+  `guard/slot-order`'s and varies with the sample index."
+  []
+  [(instrument-arm)
+   (bare-ratom-arm)
+   (spine-arm :spine-replace  :hn/spine-replace  :replace-app-db)
+   (spine-arm :spine-dispatch :hn/spine-dispatch :dispatch-sync)])
+
+;; ---------------------------------------------------------------------------
+;; Mounting
+;; ---------------------------------------------------------------------------
+
+(defn init-adapter!
+  "Install the Reagent adapter and leave React's `act` environment.
+
+  `act` diverts work to its own queue, which is not what a browser does,
+  and every reading here is the browser's."
+  []
+  (rf/init! reagent-adapter/adapter)
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  nil)
+
+(defn mount-arms! [arms]
+  (mapv (fn [a]
+          (let [c (js/document.createElement "div")]
+            (.appendChild js/document.body c)
+            {:arm a :container c :handle ((:mount a) c)}))
+        arms))
+
+(defn release-arms! [mounts]
+  (doseq [{:keys [arm handle container]} mounts]
+    (try ((:unmount arm) handle) (catch :default _ nil))
+    (.remove container))
+  nil)
+
+(defn cell-text [container i]
+  (some-> (.querySelector container (str "[data-i=\"" i "\"]")) (.-textContent)))
+
+;; ---------------------------------------------------------------------------
+;; The measured window
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private gen-seq (atom 1000))
+(defn next-gen! [] (swap! gen-seq inc))
+
+(defn- chain
+  "Fold `xs` into a serial promise chain, threading an accumulator."
+  [init xs f]
+  (reduce (fn [p x] (.then p (fn [acc] (f acc x)))) (js/Promise.resolve init) xs))
+
+(defn- timed-write!
+  "One narrow write, clocked at every leg boundary, then verified at the
+  DOM. Answers a promise of a `js-obj` of legs plus the read-back verdict.
+
+  The microtask between the write and the force is the donor window's and
+  is kept so the two are comparable; on this substrate no arm requires it
+  (a `reagent.core/flush` is already on React's sync lane), so `:gap`
+  prices the boundary itself and is expected to be ~0."
+  [{:keys [arm container]} i val]
+  (let [t0 (now)]
+    (control-spin!)
+    (let [tc (now)]
+      ((:write! arm) i val)
+      (let [t1 (now)]
+        (-> (js/Promise.resolve nil)
+            (.then
+              (fn [_]
+                (let [t2 (now)]
+                  ((:force! arm))
+                  (let [t3    (now)
+                        probe (if (= i :all) 0 i)]
+                    (js-obj "control" (- tc t0)
+                            "write"   (- t1 tc)
+                            "gap"     (- t2 t1)
+                            "force"   (- t3 t2)
+                            ;; THE PUBLISHED FIGURE: write + gap + force,
+                            ;; with the control's leg excluded.
+                            "total"   (- t3 tc)
+                            "span"    (- t3 t0)
+                            "ok"      (or (boolean (:skip-verify? arm))
+                                          (= (str val)
+                                             (cell-text container probe))))))))))))))
+
+(defn run-sample!
+  "One SAMPLE: `n` narrow writes over one arm, legs accumulated, every
+  write verified at the DOM in its own window."
+  [mnt n]
+  (let [acc (fresh-acc)]
+    (chain acc (range n)
+      (fn [a _]
+        (let [val (next-gen!)
+              i   (mod val cells-n)]
+          (-> (timed-write! mnt i val)
+              (.then (fn [r]
+                       (bump! a "control" (gobj/get r "control"))
+                       (bump! a "write"   (gobj/get r "write"))
+                       (bump! a "gap"     (gobj/get r "gap"))
+                       (bump! a "force"   (gobj/get r "force"))
+                       (bump! a "total"   (gobj/get r "total"))
+                       (bump! a "span"    (gobj/get r "span"))
+                       (bump! a "writes"  1)
+                       (when-not (gobj/get r "ok") (bump! a "bad" 1))
+                       a))))))))
+
+(defn seed-arms!
+  "Re-seed every arm to a known state between rounds so no round inherits
+  another's growth. Never timed."
+  [mounts]
+  (chain nil mounts
+    (fn [_ mnt] (-> (timed-write! mnt :all 0) (.then (fn [_] nil))))))
+
+;; ---------------------------------------------------------------------------
+;; A round — arms interleaved, order rotating AND reflecting
+;; ---------------------------------------------------------------------------
+
+(defn run-round!
+  "One round: `(+ warmup samples)` sample indices, every arm measured at
+  every index, arm order `guard/slot-order` — rotate, then REFLECT on odd
+  indices.
+
+  The reflection is the both-orders discipline in situ. A bare cyclic
+  rotation changes which arm goes FIRST and nothing else: arm `a` sits at
+  slot `(a - s) mod k`, so its predecessor is `(a - 1) mod k` at every
+  sample index. Reflecting on odd indices replaces every `a -> a+1`
+  adjacency with `a -> a-1`, which is what gives each arm two
+  predecessors in balance and lets [[guard/verdict]] ask the question at
+  all.
+
+  Answers a promise of `{:samples [...] :bad n}` where each sample carries
+  its arm, its legs, its POSITION in the run and its PREDECESSOR — the two
+  factors the guard stratifies on.
+
+  `position0` is the global sample counter at the start of this round, so
+  positions are continuous across rounds and the phase factor sees the
+  whole trajectory rather than restarting each round."
+  [mounts {:keys [warmup samples writes]} position0]
+  (let [k     (count mounts)
+        total (+ warmup samples)
+        plan  (vec (for [s (range total) j (guard/slot-order k s)] [s j]))]
+    (chain {:samples [] :bad 0 :prev nil :pos position0}
+           (range (count plan))
+      (fn [acc idx]
+        (let [[s j] (nth plan idx)
+              mnt   (nth mounts j)
+              id    (:id (:arm mnt))]
+          (-> (run-sample! mnt writes)
+              (.then (fn [a]
+                       (let [rec {:arm         id
+                                  :position    (:pos acc)
+                                  :predecessor (:prev acc)
+                                  :control     (gobj/get a "control")
+                                  :write       (gobj/get a "write")
+                                  :gap         (gobj/get a "gap")
+                                  :force       (gobj/get a "force")
+                                  :total       (gobj/get a "total")
+                                  :span        (gobj/get a "span")
+                                  :bad         (gobj/get a "bad")
+                                  :writes      (gobj/get a "writes")
+                                  ;; `slot-order` reflects on ODD sample
+                                  ;; indices; this is the label the report
+                                  ;; splits "both orders" on.
+                                  :order       (if (odd? s) :reflected :forward)
+                                  :warmup?     (< s warmup)}]
+                         (cond-> (assoc acc :prev id :pos (inc (:pos acc))
+                                            :bad (+ (:bad acc) (gobj/get a "bad")))
+                           (>= s warmup) (update :samples conj rec)))))))))))
+
+;; ---------------------------------------------------------------------------
+;; Summaries
+;; ---------------------------------------------------------------------------
+
+(defn median [xs]
+  (let [s (vec (sort xs)) c (count s) m (quot c 2)]
+    (cond
+      (zero? c) nil
+      (odd? c)  (nth s m)
+      :else     (/ (+ (nth s (dec m)) (nth s m)) 2.0))))
+
+(defn summarise
+  "`{:n :min :p50 :max}` over `xs`. A RANGE, always — never a mean alone.
+  Overlapping ranges mean indistinguishable, and a report that quotes a
+  central value without its range cannot say that."
+  [xs]
+  (let [xs (vec xs)]
+    (when (seq xs)
+      {:n (count xs) :min (apply min xs) :p50 (median xs) :max (apply max xs)})))
+
+(defn per-write
+  "Divide a per-SAMPLE leg figure by the writes it contains."
+  [ms writes]
+  (/ ms (double writes)))
+
+(defn arm-summary
+  "Per-arm, per-write summaries of every leg, split three ways: pooled,
+  forward-order samples, reflected-order samples.
+
+  The two order strata are the both-orders presentation. They are
+  reported as ranges and adjudicated by the house rule — overlapping
+  ranges mean the order did not move the figure."
+  [samples]
+  (let [legs [:total :write :gap :force :control :span]
+        of   (fn [ss leg] (summarise (map #(per-write (get % leg) (:writes %)) ss)))
+        fwd  (filterv #(= :forward (:order %)) samples)
+        refl (filterv #(= :reflected (:order %)) samples)]
+    {:n        (count samples)
+     :bad      (reduce + 0 (map :bad samples))
+     :writes   (reduce + 0 (map :writes samples))
+     :pooled   (into {} (map (fn [l] [l (of samples l)])) legs)
+     :forward  (into {} (map (fn [l] [l (of fwd l)])) legs)
+     :reflected (into {} (map (fn [l] [l (of refl l)])) legs)}))
+
+(defn summarise-run
+  "Fold every round's samples into `{arm-id summary}` plus the guard's
+  verdict over the same samples."
+  [samples tolerance]
+  (let [by-arm (group-by :arm samples)]
+    {:arms   (into {} (map (fn [[id ss]] [id (arm-summary ss)])) by-arm)
+     :guard  (guard/verdict
+               (mapv (fn [s] {:arm         (name (:arm s))
+                              :value       (per-write (:total s) (:writes s))
+                              :predecessor (some-> (:predecessor s) name)
+                              :position    (:position s)})
+                     samples)
+               {:tolerance tolerance})}))
+
+;; ---------------------------------------------------------------------------
+;; EDN across the boundary
+;; ---------------------------------------------------------------------------
+
+(defn publish!
+  "Write one record to the console as EDN, tagged so the driver can find
+  it in a transcript."
+  [tag record]
+  (js/console.log (str ";; HN " tag "\n" (pr-str record)))
+  nil)
+
+(defn guard-self-test!
+  "Run the order guard's own self-test and answer whether it passed. The
+  checks are fixtures replayed from the recorded study, so this is
+  deterministic — and a harness that gets `false` must measure nothing.
+
+  Run from inside the `:advanced` bundle rather than from the driver,
+  because the guard that adjudicates these figures is the CLJC one this
+  bundle carries, not the `.cjs` copy the donor's Node drivers reach."
+  []
+  (let [st (guard/self-test)]
+    (doseq [c (:checks st)]
+      (js/console.log (str ";; HN order-guard " (if (:ok c) "ok  " "FAIL")
+                           " " (:name c)
+                           (when (:detail c) (str "  — " (:detail c))))))
+    (boolean (:ok? st))))

--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_app.cljs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_app.cljs
@@ -47,14 +47,31 @@
                (hn/per-write (gobj/get a "total") (gobj/get a "writes"))))))
 
 (defn- run-round!
+  "One round, and the driver's running POSITION COUNTER carried across it.
+
+  The counter is threaded through the driver rather than kept here because
+  the phase factor's whole question is *where in the RUN* — not where in
+  the round — a sample was taken, and a per-round counter would restart the
+  trajectory four times and ask nothing.
+
+  `rows` is not called `samples`, and that is a repair rather than a style
+  choice. It was: the destructured `{:keys [samples ...]}` shadowed the
+  numeric `samples` PARAMETER, so `(+ warmup samples)` added a vector to a
+  number, `next` came back `NaN`, and every position from round two onward
+  was non-finite. The guard filters non-finite positions, so it went on
+  reporting `24 samples` per arm while adjudicating the phase question on
+  the SIX that survived — an `[ok]` verdict resting on a quarter of the
+  evidence it named. Nothing threw and no figure looked wrong. The driver
+  now prints the finite-position count per arm beside the strata, so the
+  next version of this cannot hide."
   [warmup samples writes position0]
   (-> (hn/seed-arms! @mounts)
       (.then (fn [_] (hn/run-round! @mounts
                                     {:warmup warmup :samples samples :writes writes}
                                     position0)))
-      (.then (fn [{:keys [samples bad]}]
-               (vswap! collected into samples)
-               (js-obj "samples" (samples->js samples)
+      (.then (fn [{rows :samples bad :bad}]
+               (vswap! collected into rows)
+               (js-obj "samples" (samples->js rows)
                        "bad"     bad
                        "next"    (+ position0
                                     (* (count @mounts) (+ warmup samples))))))))
@@ -98,6 +115,10 @@
         (js-obj
           "arms"          (clj->js (mapv #(name (:id %)) arms))
           "cellsN"        hn/cells-n
+          ;; The subscription-count ladder, top rung LAST and equal to
+          ;; `cellsN` — the top rung is `:spine-replace` itself rather than
+          ;; a fourth mounted copy of it.
+          "ladder"        (clj->js hn/ladder-cells)
           ;; Run before any measurement: proves this bundle reads the keys
           ;; it writes, under the renaming it was actually compiled with.
           "integrity"     (fn [] (hn/integrity-probe))

--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_app.cljs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_app.cljs
@@ -1,0 +1,127 @@
+(ns re-frame.bench.hicasso-narrow-app
+  "The `:advanced` entry for the P0 ratom-spine narrow-write leg — mounts
+  the arms once and hands the page to `hicasso_narrow_run.cjs`.
+
+  The driver owns every window boundary, because only the driver can
+  decide when a warm-up has settled and only the driver holds the plan.
+  This namespace mounts, seeds, and exposes the doors.
+
+  Every name crossing the JS boundary is a STRING LITERAL through
+  `js-obj` / `goog.object`, never a `#js {:kw ...}` literal read back with
+  `(.-kw o)`. Under `:advanced` those two disagree, and the disagreement
+  is SILENT for any key that happens to collide with Closure's browser
+  externs — the reasoning is recorded at the head of
+  [[re-frame.bench.hicasso-narrow]]."
+  (:require [goog.object :as gobj]
+            [re-frame.bench.hicasso-narrow :as hn]
+            [re-frame.bench.order-guard :as guard]))
+
+(defonce ^:private mounts (volatile! nil))
+(defonce ^:private by-id (volatile! {}))
+(defonce ^:private neg-mount (volatile! nil))
+(defonce ^:private collected (volatile! []))
+
+(defn- samples->js
+  "Only what the driver prints. The full sample set stays in the page and
+  is folded there, so no per-sample map crosses the boundary."
+  [ss]
+  (clj->js (mapv (fn [s]
+                   {"arm"      (name (:arm s))
+                    "position" (:position s)
+                    "order"    (name (:order s))
+                    "total"    (hn/per-write (:total s) (:writes s))
+                    "write"    (hn/per-write (:write s) (:writes s))
+                    "gap"      (hn/per-write (:gap s) (:writes s))
+                    "force"    (hn/per-write (:force s) (:writes s))
+                    "control"  (hn/per-write (:control s) (:writes s))
+                    "bad"      (:bad s)})
+                 ss)))
+
+(defn- warm-window!
+  "One full-size window on one arm, discarded — the warm-up unit. Answers
+  the per-write total in milliseconds so the driver can watch the
+  trajectory settle."
+  [arm-id writes]
+  (-> (hn/run-sample! (get @by-id arm-id) writes)
+      (.then (fn [a]
+               (hn/per-write (gobj/get a "total") (gobj/get a "writes"))))))
+
+(defn- run-round!
+  [warmup samples writes position0]
+  (-> (hn/seed-arms! @mounts)
+      (.then (fn [_] (hn/run-round! @mounts
+                                    {:warmup warmup :samples samples :writes writes}
+                                    position0)))
+      (.then (fn [{:keys [samples bad]}]
+               (vswap! collected into samples)
+               (js-obj "samples" (samples->js samples)
+                       "bad"     bad
+                       "next"    (+ position0
+                                    (* (count @mounts) (+ warmup samples))))))))
+
+(defn- negative-control!
+  "Mount the deliberately-broken arm, run one window, unmount. Answers the
+  unverified count and the total, so the driver can assert the read-back
+  gate goes red on an empty `flushSync` — a gate that cannot fail has not
+  verified anything."
+  [writes]
+  (let [mnt (first (hn/mount-arms! [(hn/negative-control-arm)]))]
+    (vreset! neg-mount mnt)
+    (-> (hn/run-sample! mnt writes)
+        (.then (fn [a]
+                 (let [bad (gobj/get a "bad")
+                       n   (gobj/get a "writes")]
+                   (hn/release-arms! [mnt])
+                   (vreset! neg-mount nil)
+                   (js-obj "bad" bad "writes" n)))))))
+
+(defn- report!
+  "Fold every collected sample, adjudicate the order question, and answer
+  the record plus the guard's own report lines."
+  [tolerance]
+  (let [summary (hn/summarise-run @collected tolerance)
+        v       (:guard summary)]
+    (js-obj "edn"     (pr-str summary)
+            "lines"   (clj->js (vec (guard/report-lines v "P0 ratom-spine narrow write")))
+            "refuse"  (boolean (:refuse? v))
+            "contaminated" (boolean (:contaminated? v))
+            "unchecked"    (boolean (:unchecked? v)))))
+
+(defn ^:export -main []
+  (try
+    (hn/init-adapter!)
+    (let [arms (hn/make-arms)
+          ms   (hn/mount-arms! arms)]
+      (vreset! mounts ms)
+      (vreset! by-id (into {} (map (fn [m] [(name (:id (:arm m))) m])) ms))
+      (gobj/set js/window "HN"
+        (js-obj
+          "arms"          (clj->js (mapv #(name (:id %)) arms))
+          "cellsN"        hn/cells-n
+          ;; Run before any measurement: proves this bundle reads the keys
+          ;; it writes, under the renaming it was actually compiled with.
+          "integrity"     (fn [] (hn/integrity-probe))
+          ;; Deterministic fixtures replayed from the recorded study. A
+          ;; harness whose guard is broken may measure nothing.
+          "guardSelfTest" (fn [] (hn/guard-self-test!))
+          "quantum"       (fn [] (hn/clock-quantum))
+          "prepare"       (fn [ms'] (hn/control-prepare! ms'))
+          "warm"          (fn [arm writes] (warm-window! arm writes))
+          ;; The ladder pass runs at a SECOND control size and must not
+          ;; land in the headline fold, so the driver clears the collected
+          ;; set between passes and adjudicates the ladder from the
+          ;; per-sample payload it already holds.
+          "reset"         (fn [] (vreset! collected []) true)
+          "seed"          (fn [] (-> (hn/seed-arms! @mounts) (.then (fn [_] true))))
+          "round"         (fn [warmup samples writes pos]
+                            (run-round! warmup samples writes pos))
+          "negControl"    (fn [writes] (negative-control! writes))
+          "report"        (fn [tol] (report! tol))))
+      (-> (hn/seed-arms! ms)
+          (.then (fn [_]
+                   (gobj/set js/window "HN_READY" true)
+                   (js/console.log ";; HN READY")
+                   nil))))
+    (catch :default e
+      (gobj/set js/window "HN_ERROR" (str e))
+      (js/console.error (str ";; HN FAILED — " e)))))

--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
@@ -77,7 +77,7 @@ const PORT = Number(process.env.HN_PORT || 8141);
 // and compares the first against the last, and a third has to carry a
 // RANGE for the house rule to apply. At six samples a third is one sample
 // and the question collapses to a bare ratio.
-const ROUNDS = Number(process.env.HN_ROUNDS || 4);
+const ROUNDS = Number(process.env.HN_ROUNDS || 6);
 const IN_ROUND_WARMUP = Number(process.env.HN_ROUND_WARMUP || 2);
 const SAMPLES = Number(process.env.HN_SAMPLES || 6);
 // Chrome clamps performance.now() to 100 us and one narrow write sits on
@@ -100,8 +100,17 @@ const WRITES = Number(process.env.HN_WRITES || 20);
 // trajectory still separates from the last third by more than the guard's
 // own tolerance, to a ceiling of HN_WARMUP_MAX. The whole trajectory is
 // printed, so "wide enough" is checkable rather than asserted.
-const WARMUP = Number(process.env.HN_WARMUP || 6);
-const WARMUP_MAX = Number(process.env.HN_WARMUP_MAX || 14);
+//
+// The settle test is the MEDIAN one and only the median one. A first cut
+// accepted "the medians are within tolerance OR the ranges overlap", and on
+// a box this noisy the ranges always overlap, so every arm settled at the
+// floor while still visibly trending — `spine-replace` terminated on
+// 0.98 0.89 0.37 0.33 0.46 0.56 0.48 0.59 0.66, which is not a settled
+// site. Overlapping ranges are the right rule for ADJUDICATING two
+// measured strata; they are the wrong rule for deciding a site has stopped
+// moving, because a wide range makes the test pass by being uninformative.
+const WARMUP = Number(process.env.HN_WARMUP || 8);
+const WARMUP_MAX = Number(process.env.HN_WARMUP_MAX || 20);
 
 // The guard's tolerance, and the donor's. It is NOT a knob for making a
 // refusal go away: a refusal means the figure moved with the plan, and the
@@ -180,6 +189,23 @@ function summarise(xs) {
 const disjoint = (a, b) => a && b && (a.min > b.max || b.min > a.max);
 
 const rng = (s) => (s ? `${num(s.p50)} [${num(s.min)}-${num(s.max)}]` : '--');
+
+// THE QUANTISATION-UNBIASED ESTIMATOR, and why the split needs one.
+//
+// Chrome coarsens `performance.now()` to a 100 us grid, so a leg shorter
+// than the grid reads either 0 or 100 us depending on where the boundary
+// happened to fall. Its MEDIAN is therefore 0 by construction — which is a
+// precise wrong number, and precisely the kind this instrument exists to
+// refuse. The MEAN is not: `floor(t1/q)*q - floor(t0/q)*q` has expectation
+// exactly `t1 - t0` when the phase is uniform, so averaging over enough
+// windows recovers a sub-quantum leg that no single window can see.
+//
+// So the two estimators do two different jobs and both are published:
+// p50 + range adjudicates (the house rule needs a range, and a median is
+// robust to the scheduler), and the mean carries the write-versus-flush
+// SPLIT, which is the whole point of this bead and which a median cannot
+// express when one of the legs is under the clock floor.
+const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : null);
 
 // ---------------------------------------------------------------------------
 
@@ -265,6 +291,13 @@ async function main() {
 
   const arms = await page.evaluate(() => window.HN.arms);
   const cellsN = await page.evaluate(() => window.HN.cellsN);
+  const ladder = await page.evaluate(() => window.HN.ladder);
+  if (ladder[ladder.length - 1] !== cellsN) {
+    throw new Error(
+      `the ladder's top rung (${ladder[ladder.length - 1]}) is not the headline cell count ` +
+        `(${cellsN}) — the ladder would be fitted through a point no arm measured`
+    );
+  }
   console.error(`[hn] arms: ${arms.join(', ')}  (${cellsN} cells, ${WRITES} writes/sample)`);
 
   // --- gate 4: the read-back gate's non-vacuity control -------------------
@@ -291,8 +324,10 @@ async function main() {
   // --- warm-up ------------------------------------------------------------
   await page.evaluate((d) => window.HN.prepare(d), CTL_1);
   const trajectories = {};
+  const settled = {};
   for (const arm of arms) {
     const xs = [];
+    settled[arm] = false;
     for (let i = 0; i < WARMUP_MAX; i++) {
       xs.push(await page.evaluate(([a, w]) => window.HN.warm(a, w), [arm, WRITES]));
       if (i + 1 >= WARMUP) {
@@ -300,14 +335,20 @@ async function main() {
         const first = summarise(xs.slice(0, t));
         const last = summarise(xs.slice(-t));
         const ratio = last.p50 === 0 ? 1 : first.p50 / last.p50;
-        // Settled = the first third and the last third are no longer
-        // separated. Both halves of the house rule: the medians must be
-        // within tolerance OR the ranges must overlap.
-        if (Math.abs(ratio - 1) <= TOLERANCE || !disjoint(first, last)) break;
+        // Settled = the first third of the trajectory no longer reads
+        // differently from the last third, by MEDIAN. See the note on
+        // WARMUP above for why the range test is not offered here.
+        if (Math.abs(ratio - 1) <= TOLERANCE) {
+          settled[arm] = true;
+          break;
+        }
       }
     }
     trajectories[arm] = xs;
-    console.error(`[hn] warm ${arm.padEnd(16)} ${xs.map((x) => num(x, 3)).join(' ')}`);
+    console.error(
+      `[hn] warm ${arm.padEnd(17)} ${xs.map((x) => num(x, 3)).join(' ')}` +
+        `   ${settled[arm] ? 'SETTLED' : `still trending at the ${WARMUP_MAX}-window ceiling`}`
+    );
   }
 
   // --- the measured pass, at control rung 1 -------------------------------
@@ -372,6 +413,11 @@ async function main() {
   say(`sample           ${WRITES} narrow writes; per-write = sample / ${WRITES}`);
   say(`plan             ${ROUNDS} rounds x (${IN_ROUND_WARMUP} in-round warmup + ${SAMPLES} samples), arms interleaved`);
   say(`clock quantum    ${num(quantum, 5)} ms (measured in-page)`);
+  say(
+    `warm-up          ${Object.entries(settled)
+      .map(([a, s]) => `${a}:${trajectories[a].length}${s ? '' : '*'}`)
+      .join(' ')}   (* = still trending at the ${WARMUP_MAX}-window ceiling)`
+  );
   say(`window           t0 -> control -> WRITE -> microtask -> FLUSH -> t3 -> DOM read-back`);
   say(`published figure t3 - t_control  =  write + gap + force`);
   say('');
@@ -379,9 +425,7 @@ async function main() {
   // --- the headline table -------------------------------------------------
   say('PER-WRITE MILLISECONDS — p50 [min-max] across all measured samples');
   say('');
-  say(
-    '  arm               write+flush            write                  flush                  write%'
-  );
+  say('  arm               write+flush            write                  flush');
   const headline = {};
   for (const arm of arms) {
     const rows = byArm(pass1, arm);
@@ -390,14 +434,173 @@ async function main() {
     const fo = legOf(rows, 'force');
     const gp = legOf(rows, 'gap');
     headline[arm] = { total: tot, write: wr, force: fo, gap: gp };
-    const share = tot && tot.p50 > 0 ? ((wr.p50 / tot.p50) * 100).toFixed(0) : '--';
-    say(`  ${arm.padEnd(17)} ${rng(tot).padEnd(22)} ${rng(wr).padEnd(22)} ${rng(fo).padEnd(22)} ${share}%`);
+    say(`  ${arm.padEnd(17)} ${rng(tot).padEnd(22)} ${rng(wr).padEnd(22)} ${rng(fo)}`);
   }
+  say('');
+  say('  NO write-share column here, deliberately. The write leg is under the 100 us grid on');
+  say('  every arm, so its MEDIAN is 0 by construction and a share computed from it reads a');
+  say('  flat 0% — a precise wrong number. The split is taken from the mean table below.');
   say('');
   say('  (the microtask gap is priced separately and is expected to be ~0 on every arm here:');
   say('   a reagent.core/flush is already on React\'s sync lane, so no arm needs the boundary.)');
   for (const arm of arms) {
     say(`     gap  ${arm.padEnd(17)} ${rng(headline[arm].gap)}`);
+  }
+  say('');
+
+  // --- the split ----------------------------------------------------------
+  // The median above reads 0 for any leg under the 100 us grid, which is a
+  // precise wrong number rather than a small one. The mean is unbiased under
+  // that coarsening, so the SPLIT — the question this bead exists to answer
+  // — is taken from it, with the median table above left standing as the
+  // adjudication instrument.
+  say('WRITE vs FLUSH — from the quantisation-unbiased MEAN over every measured write');
+  say('');
+  say('  arm               write+flush     write           flush           write share');
+  const split = {};
+  for (const arm of arms) {
+    const rows = byArm(pass1, arm);
+    const t = mean(rows.map((s) => s.total));
+    const w = mean(rows.map((s) => s.write));
+    const g = mean(rows.map((s) => s.gap));
+    const f = mean(rows.map((s) => s.force));
+    split[arm] = { total: t, write: w, gap: g, force: f, writeShare: t > 0 ? w / t : null };
+    const share = t > 0 ? `${((w / t) * 100).toFixed(1)}%` : '--';
+    say(
+      `  ${arm.padEnd(17)} ${num(t).padEnd(15)} ${num(w).padEnd(15)} ${num(f).padEnd(15)} ${share}`
+    );
+  }
+  say('');
+  // An arithmetic identity, not a check of the substrate: the three legs
+  // are read off the SAME four clock samples the total is, so they must sum
+  // to it exactly. A discrepancy means the accumulator is mis-wired.
+  let identityOk = true;
+  for (const arm of arms) {
+    const s = split[arm];
+    const err = Math.abs(s.write + s.gap + s.force - s.total);
+    if (err > 1e-9) {
+      identityOk = false;
+      say(`  IDENTITY FAILED on ${arm}: write+gap+force - total = ${err}`);
+    }
+  }
+  if (identityOk) say('  write + gap + force = write+flush exactly, on every arm (leg accounting intact)');
+  say('');
+
+  // --- what the flush is actually made of ---------------------------------
+  // "The flush" is one word doing two jobs: Reagent re-running every
+  // dirtied reaction, and React committing the one cell that changed. A
+  // single number cannot separate them, and the separation is the whole
+  // question — the withdrawn predecessor's narrow row was wrong precisely
+  // because a framework cost was read as a rendering cost.
+  //
+  // Two cell counts separate them by construction. The React commit is the
+  // SAME one-cell commit at both rungs; only the number of layer-1
+  // subscriptions moves. So the slope is the per-subscription recompute and
+  // the intercept is everything else, and neither is inferred from a
+  // sentence.
+  const rungArm = (n) => (n === cellsN ? 'spine-replace' : `spine-${n}`);
+  const rungs = ladder
+    .map((n) => ({ n, arm: rungArm(n), split: split[rungArm(n)] }))
+    .filter((r) => r.split);
+  let flushComposition = null;
+  if (rungs.length >= 2) {
+    say('WHERE THE FLUSH GOES — the subscription-count ladder');
+    say('');
+    say('  subscriptions   flush ms/write   per subscription   local slope vs the rung below');
+    for (let i = 0; i < rungs.length; i++) {
+      const r = rungs[i];
+      const each = `${num((r.split.force / r.n) * 1000, 3)} us`;
+      let local = '--';
+      if (i > 0) {
+        const p = rungs[i - 1];
+        local = `${num(((r.split.force - p.split.force) / (r.n - p.n)) * 1000, 3)} us/sub`;
+      }
+      say(
+        `  ${String(r.n).padStart(13)}   ${num(r.split.force).padEnd(15)} ${each.padEnd(18)} ${local}`
+      );
+    }
+    say('');
+
+    // The linear model, and whether the rungs will carry it. A per-unit
+    // cost quoted from two points is only a per-unit cost if a line
+    // through them has a NON-NEGATIVE intercept: the intercept is the
+    // work that does not scale with the subscription count — React's
+    // one-cell commit and Reagent's drain overhead — and that work cannot
+    // cost less than nothing. A negative intercept is the data refusing
+    // the model, not a rounding error, and this ladder produced one at
+    // two rungs (30 -> 300 fitted 2.27 us/sub with an intercept of
+    // -0.048 ms).
+    const lo = rungs[0];
+    const hi = rungs[rungs.length - 1];
+    const slope = (hi.split.force - lo.split.force) / (hi.n - lo.n);
+    const intercept = lo.split.force - slope * lo.n;
+    const growth = lo.split.force > 0 ? hi.split.force / lo.split.force : null;
+    const scale = hi.n / lo.n;
+    const exponent = growth ? Math.log(growth) / Math.log(scale) : null;
+    flushComposition = {
+      rungs: rungs.map((r) => ({ n: r.n, flushMs: r.split.force })),
+      slopeMsPerSub: slope,
+      interceptMs: intercept,
+      exponent,
+      linear: intercept >= 0,
+    };
+    if (intercept >= 0) {
+      say(`  linear fit over ${lo.n}-${hi.n}: ${num(slope * 1000, 3)} us per subscription,`);
+      say(`  intercept ${num(intercept)} ms — React's one-cell commit and Reagent's drain overhead.`);
+      say(
+        `  => of ${num(hi.split.force)} ms of flush at ${hi.n} cells, ` +
+          `${num(slope * hi.n)} ms is the subscription graph.`
+      );
+    } else {
+      say(`  NO PER-SUBSCRIPTION COST IS QUOTED. A line through ${lo.n} and ${hi.n} has an`);
+      say(`  intercept of ${num(intercept)} ms, and the work that does NOT scale with the`);
+      say('  subscription count — React\'s one-cell commit, Reagent\'s drain overhead —');
+      say('  cannot cost less than nothing. The flush grows FASTER than the count:');
+      say(
+        `  ${scale.toFixed(1)}x the subscriptions costs ${growth.toFixed(1)}x the flush, ` +
+          `an exponent of ${exponent.toFixed(2)}.`
+      );
+      say('  The per-rung and local-slope columns above are the honest reading; a single');
+      say('  "us per subscription" figure would be a precise wrong number.');
+    }
+    say('');
+    say('  What is NOT in doubt is the shape. A one-cell write marks EVERY layer-1');
+    say('  subscription in the frame dirty and re-evaluates all of them: a layer-1 body is');
+    say('  an opaque fn of the whole app-db and the graph holds no path. That is intrinsic');
+    say('  and universal; what this ladder prices is what it costs on the ratom spine.');
+    say('');
+  }
+
+  // --- the like-for-like correction ---------------------------------------
+  // The reason this bead exists. The predecessor's narrow row pitted a
+  // re-frame application against a bare `reagent.core/atom` and read the
+  // difference as a substrate cost. Both arms are here, measured in the
+  // same interleave on the same page, so the size of that framing error is
+  // a row rather than a claim.
+  say('LIKE-FOR-LIKE — what the comparison arm was, and what it should have been');
+  say('');
+  {
+    const b = split['bare-ratom'];
+    const s = split['spine-replace'];
+    const d = split['spine-dispatch'];
+    const rb = summarise(byArm(pass1, 'bare-ratom').map((x) => x.total));
+    const rs = summarise(byArm(pass1, 'spine-replace').map((x) => x.total));
+    const rd = summarise(byArm(pass1, 'spine-dispatch').map((x) => x.total));
+    say(`  bare r/atom + cursor (no re-frame)          ${num(b.total)} ms/write   ${rng(rb)}`);
+    say(`  re-frame on the ratom spine, replace-app-db ${num(s.total)} ms/write   ${rng(rs)}`);
+    say(`  re-frame on the ratom spine, dispatch-sync  ${num(d.total)} ms/write   ${rng(rd)}`);
+    say('');
+    say(
+      `  a narrow write costs ${(s.total / b.total).toFixed(1)}x more on re-frame-over-Reagent than on ` +
+        `bare Reagent,`
+    );
+    say(
+      `  and ${(d.total / b.total).toFixed(1)}x through the event drain. Any narrow-update ratio quoted against the`
+    );
+    say('  bare-ratom column is measuring that gap and calling it something else.');
+    say(
+      `  The event drain itself is ${num(d.total - s.total)} ms/write — the difference between the two doors.`
+    );
   }
   say('');
 
@@ -489,6 +692,26 @@ async function main() {
   say('');
 
   // --- the guard ----------------------------------------------------------
+  // What the guard could actually see. The phase factor splits an arm's
+  // trajectory into THIRDS by position, so a run that lost its positions
+  // would silently adjudicate a third of the samples it claims to hold —
+  // an `[ok]` verdict taken on evidence that was never there. The counts
+  // are printed so the strata sizes below are checkable against them.
+  say('WHAT THE GUARD SAW');
+  say('');
+  let positionsLost = false;
+  for (const arm of arms) {
+    const rows = byArm(pass1, arm);
+    const fin = rows.filter((s) => Number.isFinite(s.position));
+    const ps = fin.map((s) => s.position);
+    if (fin.length !== rows.length) positionsLost = true;
+    say(
+      `  ${arm.padEnd(17)} ${rows.length} samples, ${fin.length} with a finite position` +
+        (ps.length ? ` [${Math.min(...ps)}-${Math.max(...ps)}]` : '') +
+        `, thirds of ${Math.max(1, Math.floor(fin.length / 3))}`
+    );
+  }
+  say('');
   for (const l of report.lines) say(l);
   say('');
 
@@ -500,11 +723,23 @@ async function main() {
     sha,
     runtime: RUNTIME,
     quantum,
-    plan: { rounds: ROUNDS, inRoundWarmup: IN_ROUND_WARMUP, samples: SAMPLES, writes: WRITES },
+    plan: {
+      rounds: ROUNDS,
+      inRoundWarmup: IN_ROUND_WARMUP,
+      samples: SAMPLES,
+      writes: WRITES,
+      cells: cellsN,
+      tolerance: TOLERANCE,
+    },
     warmup: trajectories,
+    warmupSettled: settled,
+    ladder,
+    flushComposition,
     control: { rung1: CTL_1, rung2: CTL_2, measured1: c1, measured2: c2 },
     negativeControl: neg,
     headline,
+    split,
+    samples: { rung1: pass1, rung2: pass2 },
     unverified: { bad: badTotal, of: writeTotal },
     guard: { refuse: report.refuse, contaminated: report.contaminated, unchecked: report.unchecked },
     edn: report.edn,
@@ -518,6 +753,16 @@ async function main() {
   say('');
 
   // --- the verdict --------------------------------------------------------
+  // A lost position is worse than a refusal, because it makes the guard's
+  // phase factor quietly adjudicate fewer samples than it names. It gets
+  // its own exit rather than being folded into the guard's.
+  if (positionsLost) {
+    say('VERDICT: FAILED — some samples reached the guard with no finite position, so the');
+    say('         phase factor was adjudicated on less evidence than it reported. Nothing');
+    say('         above may be published until every sample carries its position.');
+    process.exitCode = 1;
+    return;
+  }
   if (report.refuse) {
     say('VERDICT: REFUSED by the arm-order guard. No figure above may be published.');
     say('         Repair the arm — more warm-up, more rounds, a quieter box. Not the tolerance.');

--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
@@ -1,0 +1,567 @@
+#!/usr/bin/env node
+// EP-0038 P0 — the RATOM-SPINE NARROW-WRITE leg, write + flush SUMMED.
+//
+//   node implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
+//   HN_ROUNDS=6 node .../hicasso_narrow_run.cjs --no-build
+//
+// Bead rf2-2rtt6.3. The bar, the budgets and the P0 table this feeds are
+// operator-owned on rf2-2rtt6.1; workers append measurements and only the
+// operator amends the numbers.
+//
+// WHAT IS BEING PRICED, AND WHY IT IS ONE NUMBER AND NOT TWO
+// ----------------------------------------------------------
+// On the ratom spine a write is a bare install into the frame's one
+// physical container. The reactions do not recompute there; they recompute
+// on Reagent's flush. So a harness that timed the write leg and stopped
+// would publish a flatteringly small figure nobody experiences, and a
+// harness that timed only the flush would miss the subscription graph
+// entirely. The published figure is `write + gap + force`, SUMMED. The
+// split is published beside it because the split is the whole point: the
+// withdrawn predecessor's ~15x narrow row decomposed roughly 90% to the
+// frame write and the signal graph rather than to rendering, and it was
+// compared against a bare `reagent.core/atom` — its own idiom, but far
+// less framework.
+//
+// NO BUILD-ID IS ADDED TO shadow-cljs.edn
+// ---------------------------------------
+// `implementation/shadow-cljs.edn` is hot-zone and rf2-2rtt6.2 owns the
+// measurement lane's build-id. This driver therefore does what the donor's
+// own b8 driver does: it takes an EXISTING `:advanced` `:browser` build as
+// a config template and overrides the entry point and the output directory
+// with `--config-merge`, so the repository gains no build id from this
+// bead. `HN_BASE_BUILD` selects the template; point it at the Hicasso lane
+// build the moment rf2-2rtt6.2 lands one, with no change to this file.
+//
+// THE INSTRUMENT'S OWN GATES, all of which run BEFORE any figure is taken
+// ----------------------------------------------------------------------
+//   1. the arm-order guard's self-test, replayed from recorded fixtures,
+//      run INSIDE the :advanced bundle (the guard that adjudicates these
+//      figures is the CLJC one this bundle carries);
+//   2. the key-renaming integrity probe, likewise inside the bundle;
+//   3. the measured `performance.now()` quantum, against which every leg
+//      is checked — a leg sitting on the clamp is not a reading;
+//   4. per-arm warm-up at FULL window size, continued until the guard's
+//      own phase rule stops separating the trajectory's first third from
+//      its last;
+//   5. the positive control, predicted vs measured, every run — read
+//      directly, as a slope across two rungs, and as the falsifiable
+//      consequence that an arm's total must NOT move when the control's
+//      size does;
+//   6. the read-back gate's non-vacuity control: the same arm with an
+//      EMPTY `flushSync` for its drain, which must go red.
+//
+// EXIT CODES
+//   0  reportable
+//   1  a gate failed, or the run could not complete
+//   2  THE ARM-ORDER GUARD REFUSED. No figure from this run may be
+//      published. Repair the arm — more warm-up, more rounds, a quieter
+//      box — never the guard's tolerance.
+
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+
+const IMPL = path.resolve(__dirname, '../../../../..');
+const REPO = path.resolve(IMPL, '..');
+const OUT = path.join(IMPL, 'out', 'hicasso-narrow');
+const PORT = Number(process.env.HN_PORT || 8141);
+
+// --- the plan ---------------------------------------------------------------
+//
+// Four rounds of six measured samples is 24 samples an arm, which is what
+// the guard's phase rule needs: it splits an arm's trajectory into THIRDS
+// and compares the first against the last, and a third has to carry a
+// RANGE for the house rule to apply. At six samples a third is one sample
+// and the question collapses to a bare ratio.
+const ROUNDS = Number(process.env.HN_ROUNDS || 4);
+const IN_ROUND_WARMUP = Number(process.env.HN_ROUND_WARMUP || 2);
+const SAMPLES = Number(process.env.HN_SAMPLES || 6);
+// Chrome clamps performance.now() to 100 us and one narrow write sits on
+// that clamp. Twenty writes to a sample lifts every arm clear of it.
+const WRITES = Number(process.env.HN_WRITES || 20);
+
+// --- warm-up ---------------------------------------------------------------
+//
+// A measurement site reads well above its settled value until it has run
+// several FULL-SIZE windows. The donor recorded the same control over
+// sixteen consecutive windows with nothing varying but the call count:
+//
+//     42.32 | 10.32 10.26 10.26 10.26 10.33 10.28 | 8.12 8.12 ... 8.12
+//
+// the first window 5.3x settled, the next SIX at +27%. Position dominates
+// adjacency, and warm-up matters more than interleaving. So each arm is
+// warmed at its real window size, and warmed until it has stopped
+// TRENDING rather than for a count somebody guessed: a floor of
+// HN_WARMUP windows, then keep going while the first third of the
+// trajectory still separates from the last third by more than the guard's
+// own tolerance, to a ceiling of HN_WARMUP_MAX. The whole trajectory is
+// printed, so "wide enough" is checkable rather than asserted.
+const WARMUP = Number(process.env.HN_WARMUP || 6);
+const WARMUP_MAX = Number(process.env.HN_WARMUP_MAX || 14);
+
+// The guard's tolerance, and the donor's. It is NOT a knob for making a
+// refusal go away: a refusal means the figure moved with the plan, and the
+// repair is the arm.
+const TOLERANCE = Number(process.env.HN_TOLERANCE || 0.10);
+
+// The positive control's two rungs, in milliseconds of predicted burn per
+// write. Both comfortably clear of the 100 us clamp; the difference is
+// what cancels the clock-read overhead the direct reading contains.
+const CTL_1 = Number(process.env.HN_CTL_1 || 0.3);
+const CTL_2 = Number(process.env.HN_CTL_2 || 0.9);
+
+const BASE_BUILD = process.env.HN_BASE_BUILD || 'freehand-release';
+const NO_BUILD = process.argv.includes('--no-build');
+
+const CONFIG_MERGE =
+  '{:output-dir "out/hicasso-narrow" :asset-path "." ' +
+  ':modules {:main {:init-fn re-frame.bench.hicasso-narrow-app/-main}}}';
+
+function build() {
+  console.error(`[hn] building :advanced bundle from template :${BASE_BUILD} ...`);
+  const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+  const r = spawnSync(
+    process.execPath,
+    [runner, 'release', BASE_BUILD, '--config-merge', CONFIG_MERGE],
+    { cwd: IMPL, stdio: ['ignore', 'inherit', 'inherit'] }
+  );
+  if (r.status !== 0) {
+    console.error(`[hn] build failed with status ${r.status}`);
+    process.exit(1);
+  }
+}
+
+const MIME = { '.js': 'text/javascript', '.html': 'text/html', '.map': 'application/json' };
+
+function serve() {
+  fs.mkdirSync(OUT, { recursive: true });
+  fs.writeFileSync(
+    path.join(OUT, 'index.html'),
+    '<!doctype html><html><head><meta charset="utf-8"><title>HN</title></head>' +
+      '<body><div id="app"></div><script src="main.js"></script></body></html>'
+  );
+  return http
+    .createServer((req, res) => {
+      const rel = decodeURIComponent(req.url.split('?')[0]);
+      const file = path.join(OUT, rel === '/' ? 'index.html' : rel);
+      if (!file.startsWith(OUT) || !fs.existsSync(file)) {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      fs.createReadStream(file).pipe(res);
+    })
+    .listen(PORT);
+}
+
+// --- small statistics, kept here so the report is self-contained ------------
+
+const num = (x, d = 4) => (Number.isFinite(x) ? x.toFixed(d) : String(x));
+
+function summarise(xs) {
+  if (!xs.length) return null;
+  const s = [...xs].sort((a, b) => a - b);
+  const m = s.length >> 1;
+  return {
+    n: s.length,
+    min: s[0],
+    p50: s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2,
+    max: s[s.length - 1],
+  };
+}
+
+// THE HOUSE RULE, in one function. Overlapping ranges mean
+// indistinguishable — not "close", not "a small difference", and never a
+// finding. Every comparison in this driver goes through it.
+const disjoint = (a, b) => a && b && (a.min > b.max || b.min > a.max);
+
+const rng = (s) => (s ? `${num(s.p50)} [${num(s.min)}-${num(s.max)}]` : '--');
+
+// ---------------------------------------------------------------------------
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function main() {
+  if (!NO_BUILD) build();
+  const server = serve();
+
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch({
+    args: [
+      // Scheduling only: these stop the headless tab being treated as
+      // backgrounded. They change WHEN the browser is willing to run work,
+      // not how long the synchronous work in the measured window takes.
+      '--disable-background-timer-throttling',
+      '--disable-renderer-backgrounding',
+      '--disable-backgrounding-occluded-windows',
+    ],
+  });
+  const version = browser.version();
+  const RUNTIME =
+    `Chromium ${version} / :advanced / goog.DEBUG=false / ` +
+    `${os.platform()} ${os.release()} / ${os.cpus().length} logical CPUs`;
+
+  const page = await browser.newPage();
+  page.on('console', (m) => {
+    const t = m.text();
+    if (t.startsWith(';; HN')) console.error(t);
+  });
+  page.on('pageerror', (e) => console.error('[hn] page error:', e.message));
+
+  const { navigate, NAV_TIMEOUT_MS } = loadNavigate();
+  await navigate(page, `http://127.0.0.1:${PORT}/`, {
+    waitUntil: 'commit',
+    timeoutMs: NAV_TIMEOUT_MS,
+    budget: 'the 5-minute wait for `window.HN_READY`',
+  });
+  await page.waitForFunction('window.HN_READY === true || window.HN_ERROR', null, {
+    timeout: 5 * 60 * 1000,
+  });
+  const bootErr = await page.evaluate('window.HN_ERROR || null');
+  if (bootErr) throw new Error(`page failed to initialise: ${bootErr}`);
+
+  console.error(`[hn] runtime: ${RUNTIME}`);
+
+  // --- gate 1: the arm-order guard's own self-test ------------------------
+  // Inside the bundle, because the guard that adjudicates these figures is
+  // the CLJC one this bundle carries. Its checks are fixtures replayed from
+  // the recorded study, so this is deterministic, and a harness that gets
+  // `false` may measure nothing.
+  const guardOk = await page.evaluate(() => window.HN.guardSelfTest());
+  if (!guardOk) {
+    throw new Error('order-guard self-test FAILED — nothing may be measured');
+  }
+  console.error('[hn] gate 1 ok — order-guard self-test passed inside the :advanced bundle');
+
+  // --- gate 2: does the bundle read the keys it writes? -------------------
+  // Closure's advanced renaming does not touch a quoted string key but DOES
+  // rename a `(.-foo o)` accessor. The failure is silent for `bad`: an
+  // undefined slot plus one is NaN, the literal's zero stands, and the
+  // driver reads ZERO unverified writes for ever.
+  const integ = await page.evaluate(() => window.HN.integrity());
+  const wantKeys = ['control', 'write', 'gap', 'force', 'total', 'span', 'bad', 'writes'];
+  const gotKeys = integ && typeof integ.keys === 'string' ? integ.keys.split(',') : [];
+  const missing = wantKeys.filter((k) => !gotKeys.includes(k));
+  if (!integ || integ.control !== 7 || integ.bad !== 5 || integ.total !== -11 || missing.length) {
+    throw new Error(
+      `integrity probe FAILED — the :advanced bundle does not read the keys it writes. ` +
+        `got ${JSON.stringify(integ)}; expected control=7 bad=5 total=-11; ` +
+        `missing keys ${JSON.stringify(missing)}`
+    );
+  }
+  console.error(`[hn] gate 2 ok — integrity probe, keys ${gotKeys.join(',')}`);
+
+  // --- gate 3: what can this clock actually resolve? ----------------------
+  const quantum = await page.evaluate(() => window.HN.quantum());
+  if (!(quantum > 0)) throw new Error('could not measure the performance.now() quantum');
+  console.error(
+    `[hn] gate 3 ok — performance.now() quantum ${num(quantum, 5)} ms; ` +
+      `a SAMPLE is ${WRITES} writes, so a leg is quoted only if the sample carries it clear of this`
+  );
+
+  const arms = await page.evaluate(() => window.HN.arms);
+  const cellsN = await page.evaluate(() => window.HN.cellsN);
+  console.error(`[hn] arms: ${arms.join(', ')}  (${cellsN} cells, ${WRITES} writes/sample)`);
+
+  // --- gate 4: the read-back gate's non-vacuity control -------------------
+  // The same arm with an EMPTY `flushSync` for its drain. An empty flush
+  // drains only React's sync lane; a Reagent ratom write is not on it. So
+  // the clock stops on the OLD value and the DOM read-back must catch it.
+  // A gate that cannot go red has not verified anything.
+  await page.evaluate((d) => window.HN.prepare(d), 0);
+  const neg = await page.evaluate((w) => window.HN.negControl(w), WRITES);
+  const negRate = neg.bad / neg.writes;
+  console.error(
+    `[hn] gate 4 — EMPTY-flushSync negative control: ${neg.bad} unverified of ${neg.writes} ` +
+      `(${(negRate * 100).toFixed(0)}%)`
+  );
+  if (negRate < 0.5) {
+    throw new Error(
+      `read-back gate is VACUOUS — an arm whose drain is an empty flushSync should leave the ` +
+        `cell stale, and only ${neg.bad} of ${neg.writes} writes were caught. ` +
+        `Until this goes red, "0 unverified" on the real arms is not evidence.`
+    );
+  }
+  console.error('[hn] gate 4 ok — the DOM read-back catches a stale commit');
+
+  // --- warm-up ------------------------------------------------------------
+  await page.evaluate((d) => window.HN.prepare(d), CTL_1);
+  const trajectories = {};
+  for (const arm of arms) {
+    const xs = [];
+    for (let i = 0; i < WARMUP_MAX; i++) {
+      xs.push(await page.evaluate(([a, w]) => window.HN.warm(a, w), [arm, WRITES]));
+      if (i + 1 >= WARMUP) {
+        const t = Math.max(1, Math.floor(xs.length / 3));
+        const first = summarise(xs.slice(0, t));
+        const last = summarise(xs.slice(-t));
+        const ratio = last.p50 === 0 ? 1 : first.p50 / last.p50;
+        // Settled = the first third and the last third are no longer
+        // separated. Both halves of the house rule: the medians must be
+        // within tolerance OR the ranges must overlap.
+        if (Math.abs(ratio - 1) <= TOLERANCE || !disjoint(first, last)) break;
+      }
+    }
+    trajectories[arm] = xs;
+    console.error(`[hn] warm ${arm.padEnd(16)} ${xs.map((x) => num(x, 3)).join(' ')}`);
+  }
+
+  // --- the measured pass, at control rung 1 -------------------------------
+  await page.evaluate(() => window.HN.reset());
+  await page.evaluate((d) => window.HN.prepare(d), CTL_1);
+  const pass1 = [];
+  let pos = 0;
+  for (let r = 0; r < ROUNDS; r++) {
+    const out = await page.evaluate(
+      ([w, s, n, p]) => window.HN.round(w, s, n, p),
+      [IN_ROUND_WARMUP, SAMPLES, WRITES, pos]
+    );
+    pos = out.next;
+    pass1.push(...out.samples);
+    console.error(`[hn] round ${r + 1}/${ROUNDS} — ${out.samples.length} samples, ${out.bad} unverified`);
+    await sleep(50);
+  }
+
+  const report = await page.evaluate((t) => window.HN.report(t), TOLERANCE);
+
+  // --- the control ladder, at rung 2 --------------------------------------
+  // Two rungs so the control has a SLOPE, which cancels the clock-read
+  // overhead the direct reading contains — and so the falsifiable
+  // consequence can be checked: an arm's total must NOT move when the
+  // control's size does.
+  await page.evaluate(() => window.HN.reset());
+  await page.evaluate((d) => window.HN.prepare(d), CTL_2);
+  const pass2 = [];
+  const LADDER_ROUNDS = Math.max(2, Math.floor(ROUNDS / 2));
+  for (let r = 0; r < LADDER_ROUNDS; r++) {
+    const out = await page.evaluate(
+      ([w, s, n, p]) => window.HN.round(w, s, n, p),
+      [IN_ROUND_WARMUP, SAMPLES, WRITES, pos]
+    );
+    pos = out.next;
+    pass2.push(...out.samples);
+  }
+  console.error(`[hn] control ladder — ${pass2.length} samples at ${CTL_1} -> ${CTL_2} ms`);
+
+  await browser.close();
+  server.close();
+
+  // =========================================================================
+  // The report
+  // =========================================================================
+
+  const byArm = (rows, arm) => rows.filter((s) => s.arm === arm);
+  const legOf = (rows, leg) => summarise(rows.map((s) => s[leg]));
+
+  const lines = [];
+  const say = (s) => {
+    lines.push(s);
+    console.log(s);
+  };
+
+  say('');
+  say('=========================================================================');
+  say('P0 — RATOM-SPINE NARROW WRITE (write + flush, SUMMED)   bead rf2-2rtt6.3');
+  say('=========================================================================');
+  say(`runtime          ${RUNTIME}`);
+  say(`fixture          ${cellsN} cells, one layer-1 subscription per cell`);
+  say(`sample           ${WRITES} narrow writes; per-write = sample / ${WRITES}`);
+  say(`plan             ${ROUNDS} rounds x (${IN_ROUND_WARMUP} in-round warmup + ${SAMPLES} samples), arms interleaved`);
+  say(`clock quantum    ${num(quantum, 5)} ms (measured in-page)`);
+  say(`window           t0 -> control -> WRITE -> microtask -> FLUSH -> t3 -> DOM read-back`);
+  say(`published figure t3 - t_control  =  write + gap + force`);
+  say('');
+
+  // --- the headline table -------------------------------------------------
+  say('PER-WRITE MILLISECONDS — p50 [min-max] across all measured samples');
+  say('');
+  say(
+    '  arm               write+flush            write                  flush                  write%'
+  );
+  const headline = {};
+  for (const arm of arms) {
+    const rows = byArm(pass1, arm);
+    const tot = legOf(rows, 'total');
+    const wr = legOf(rows, 'write');
+    const fo = legOf(rows, 'force');
+    const gp = legOf(rows, 'gap');
+    headline[arm] = { total: tot, write: wr, force: fo, gap: gp };
+    const share = tot && tot.p50 > 0 ? ((wr.p50 / tot.p50) * 100).toFixed(0) : '--';
+    say(`  ${arm.padEnd(17)} ${rng(tot).padEnd(22)} ${rng(wr).padEnd(22)} ${rng(fo).padEnd(22)} ${share}%`);
+  }
+  say('');
+  say('  (the microtask gap is priced separately and is expected to be ~0 on every arm here:');
+  say('   a reagent.core/flush is already on React\'s sync lane, so no arm needs the boundary.)');
+  for (const arm of arms) {
+    say(`     gap  ${arm.padEnd(17)} ${rng(headline[arm].gap)}`);
+  }
+  say('');
+
+  // --- both orders --------------------------------------------------------
+  // slot-order rotates AND reflects on the sample index, so every arm is
+  // measured under two different adjacencies. Reported as two ranges, and
+  // adjudicated by the house rule.
+  say('BOTH ORDERS — the same figure under the forward and the reflected slot order');
+  say('');
+  say('  arm               forward                reflected              verdict');
+  for (const arm of arms) {
+    const rows = byArm(pass1, arm);
+    const f = summarise(rows.filter((s) => s.order === 'forward').map((s) => s.total));
+    const r = summarise(rows.filter((s) => s.order === 'reflected').map((s) => s.total));
+    const v = disjoint(f, r) ? 'DISJOINT — the order moved it' : 'overlapping — indistinguishable';
+    say(`  ${arm.padEnd(17)} ${rng(f).padEnd(22)} ${rng(r).padEnd(22)} ${v}`);
+  }
+  say('');
+
+  // --- DOM verification ---------------------------------------------------
+  say('DOM READ-BACK — every measured write read out of the page inside its own window');
+  say('');
+  let badTotal = 0;
+  let writeTotal = 0;
+  for (const arm of arms) {
+    const rows = byArm(pass1, arm);
+    const bad = rows.reduce((a, s) => a + s.bad, 0);
+    const n = rows.length * WRITES;
+    badTotal += bad;
+    writeTotal += n;
+    const note = arm === 'instrument' ? '  (pseudo-arm: renders no cell, verification skipped)' : '';
+    say(`  ${arm.padEnd(17)} ${bad} unverified of ${n}${note}`);
+  }
+  say(`  ${'ALL ARMS'.padEnd(17)} ${badTotal} unverified of ${writeTotal}`);
+  say(
+    `  negative control  ${neg.bad} unverified of ${neg.writes} — an EMPTY flushSync, which MUST go red`
+  );
+  say('');
+
+  // --- the positive control -----------------------------------------------
+  say('POSITIVE CONTROL — a predicted burn, read three ways');
+  say('');
+  const ctlRows = (rows) => summarise(rows.filter((s) => s.arm !== 'instrument').map((s) => s.control));
+  const c1 = ctlRows(pass1);
+  const c2 = ctlRows(pass2);
+  say(`  rung 1   predicted ${num(CTL_1)} ms/write   measured ${rng(c1)}`);
+  say(`  rung 2   predicted ${num(CTL_2)} ms/write   measured ${rng(c2)}`);
+  const predSlope = CTL_2 - CTL_1;
+  const measSlope = c2.p50 - c1.p50;
+  const slopeErr = Math.abs(measSlope / predSlope - 1);
+  say(
+    `  slope    predicted ${num(predSlope)} ms          measured ${num(measSlope)} ms   ` +
+      `(${(slopeErr * 100).toFixed(1)}% off; the slope cancels the clock-read overhead the`
+  );
+  say('           direct reading carries, so it is the stricter of the two)');
+  say('');
+  say('  falsifiable consequence — an arm\'s write+flush must NOT move when the control does:');
+  let leaked = false;
+  for (const arm of arms) {
+    const a = legOf(byArm(pass1, arm), 'total');
+    const b = legOf(byArm(pass2, arm), 'total');
+    const bad = disjoint(a, b);
+    if (bad) leaked = true;
+    say(
+      `    ${arm.padEnd(17)} rung1 ${rng(a).padEnd(22)} rung2 ${rng(b).padEnd(22)} ` +
+        `${bad ? 'DISJOINT — LEAK' : 'overlapping — no leak'}`
+    );
+  }
+  say('');
+
+  // --- clamp check --------------------------------------------------------
+  say('CLAMP CHECK — a leg sitting on the clock quantum is not a reading');
+  say('');
+  let clamped = [];
+  for (const arm of arms) {
+    if (arm === 'instrument') continue;
+    for (const leg of ['total', 'write', 'force']) {
+      const s = legOf(byArm(pass1, arm), leg);
+      const perSample = s.p50 * WRITES;
+      const mult = perSample / quantum;
+      if (mult < 10) clamped.push(`${arm}/${leg} (${mult.toFixed(1)}x quantum per sample)`);
+    }
+  }
+  if (clamped.length) {
+    say(`  CLAMP-LIMITED, not quotable as absolute: ${clamped.join(', ')}`);
+  } else {
+    say(`  every quoted leg carries at least 10x the quantum per sample — clear of the clamp`);
+  }
+  say('');
+
+  // --- the guard ----------------------------------------------------------
+  for (const l of report.lines) say(l);
+  say('');
+
+  // --- the EDN artefact ---------------------------------------------------
+  const rev = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: REPO, encoding: 'utf8' });
+  const sha = rev.status === 0 ? rev.stdout.trim() : 'unknown';
+  const artefact = {
+    bead: 'rf2-2rtt6.3',
+    sha,
+    runtime: RUNTIME,
+    quantum,
+    plan: { rounds: ROUNDS, inRoundWarmup: IN_ROUND_WARMUP, samples: SAMPLES, writes: WRITES },
+    warmup: trajectories,
+    control: { rung1: CTL_1, rung2: CTL_2, measured1: c1, measured2: c2 },
+    negativeControl: neg,
+    headline,
+    unverified: { bad: badTotal, of: writeTotal },
+    guard: { refuse: report.refuse, contaminated: report.contaminated, unchecked: report.unchecked },
+    edn: report.edn,
+  };
+  fs.mkdirSync(OUT, { recursive: true });
+  fs.writeFileSync(path.join(OUT, 'report.json'), JSON.stringify(artefact, null, 2));
+  fs.writeFileSync(path.join(OUT, 'report.txt'), lines.join('\n') + '\n');
+  say(`producing commit  ${sha}`);
+  say(`reproduce         node implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs`);
+  say(`artefacts         implementation/out/hicasso-narrow/report.{json,txt}`);
+  say('');
+
+  // --- the verdict --------------------------------------------------------
+  if (report.refuse) {
+    say('VERDICT: REFUSED by the arm-order guard. No figure above may be published.');
+    say('         Repair the arm — more warm-up, more rounds, a quieter box. Not the tolerance.');
+    process.exitCode = 2;
+    return;
+  }
+  if (leaked) {
+    say('VERDICT: FAILED — an arm\'s total moved with the control size. The leg accounting leaks.');
+    process.exitCode = 1;
+    return;
+  }
+  say('VERDICT: reportable.');
+}
+
+// The donor's shared navigation, with its ceiling NAMED. Reached by path
+// rather than by package because it lives in a test tree this bead does not
+// own; if it ever moves, the fallback below keeps this driver honest rather
+// than silently taking Playwright's anonymous 30s default.
+function loadNavigate() {
+  try {
+    return require(path.join(
+      IMPL,
+      'freehand/test/re_frame/freehand/bench/navigate.cjs'
+    ));
+  } catch (_) {
+    const NAV_TIMEOUT_MS = 60 * 1000;
+    return {
+      NAV_TIMEOUT_MS,
+      navigate: async (page, url, { timeoutMs, waitUntil, budget }) => {
+        try {
+          await page.goto(url, { waitUntil, timeout: timeoutMs });
+        } catch (err) {
+          throw new Error(
+            `NAVIGATION FAILED — this is the page.goto ceiling (waitUntil '${waitUntil}', ` +
+              `timeout ${timeoutMs}ms), NOT ${budget}, which had not yet started. ` +
+              `Underlying: ${err.message}`
+          );
+        }
+      },
+    };
+  }
+}
+
+main().catch((e) => {
+  console.error('[hn] FAILED —', e && e.stack ? e.stack : e);
+  process.exit(1);
+});

--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
@@ -123,7 +123,35 @@ const TOLERANCE = Number(process.env.HN_TOLERANCE || 0.10);
 const CTL_1 = Number(process.env.HN_CTL_1 || 0.3);
 const CTL_2 = Number(process.env.HN_CTL_2 || 0.9);
 
-const BASE_BUILD = process.env.HN_BASE_BUILD || 'freehand-release';
+// The build TEMPLATE, chosen from what the checkout actually has.
+//
+// `implementation/shadow-cljs.edn` is hot-zone and rf2-2rtt6.2 owns the
+// measurement lane's build id, so this bead adds none: it overrides an
+// existing `:advanced` `:browser` build's entry point and output directory
+// with `--config-merge`, which is the technique the donor's own b8 driver
+// uses. Which build it borrows is decided here rather than pinned, so that
+// when rf2-2rtt6.2's `:hicasso-bench` lands this driver picks it up with no
+// edit and no rebase conflict.
+//
+// The preference is not cosmetic. `:freehand-release` is CLEANED AND
+// REBUILT by `test:freehand-reachability` and `test:freehand-matched`, so a
+// bench run and a gate run racing the same
+// `.shadow-cljs/builds/freehand-release` cache is a live hazard — and
+// Closure's renaming for a build compiled fresh differs from the same build
+// compiled with a sibling warm, which the donor measured at 4,075 bytes.
+// The Hicasso lane's own id has neither problem.
+function pickBaseBuild() {
+  if (process.env.HN_BASE_BUILD) return process.env.HN_BASE_BUILD;
+  try {
+    const cfg = fs.readFileSync(path.join(IMPL, 'shadow-cljs.edn'), 'utf8');
+    if (/^\s*:hicasso-bench\b/m.test(cfg)) return 'hicasso-bench';
+  } catch (_) {
+    /* fall through to the donor template */
+  }
+  return 'freehand-release';
+}
+
+const BASE_BUILD = pickBaseBuild();
 const NO_BUILD = process.argv.includes('--no-build');
 
 const CONFIG_MERGE =


### PR DESCRIPTION
EP-0038 wave-0, bead `rf2-2rtt6.3`. Prices the **ratom-spine narrow-write
leg — write + flush, SUMMED** — so the narrow row of the P0 comparison is
like-for-like. Instrument-only; adds no production code and no build id.

Page: `docs/design/hicasso/studio/p0-ratom-spine-narrow-write.md`.
Rows also appended to the operator-owned standard bead `rf2-2rtt6.1`.

## The number

**A narrow write on the ratom spine costs 0.39–0.52 ms, and 99.8% of it is
the flush.** Three independent runs at `828d4f1ac0`; 300 cells, 300
layer-1 subscriptions, one per cell.

| arm | write+flush mean (r1 / r2 / r3) | write | flush | write share |
|---|---|---|---|---|
| bare `r/atom` + cursor, no re-frame | 0.0621 / 0.0494 / 0.0310 | 0.0007–0.0008 | 0.0300–0.0613 | 1.1–2.2% |
| **ratom spine, `replace-app-db!`** | **0.5244 / 0.5146 / 0.3903** | 0.0006–0.0010 | 0.3892–0.5237 | **0.1–0.2%** |
| ratom spine, `dispatch-sync` | 0.5910 / 0.6076 / 0.4653 | 0.0213–0.0360 | 0.4437–0.5750 | 4.6–6.1% |

Within-run ranges, headline arm: `0.5475 [0.1850–1.1650]`,
`0.5075 [0.1950–0.8800]`, `0.4200 [0.1350–0.7300]`.

## Why this bead existed, and what it changes

The withdrawn predecessor's ~15× narrow row was invalid as measured in two
ways, and both are repaired here.

**It compared against a bare `reagent.core/atom`.** Both arms are measured
here in the same interleave on the same page: re-frame-over-Reagent costs
**8.4× / 10.4× / 12.6×** a bare ratom for the same narrow write. A ratio
quoted against the bare-ratom column is measuring that gap and calling it
a substrate cost.

**And the write leg alone means nothing on this substrate.** On the ratom
spine the reactions recompute on Reagent's *flush*, not on the write. A
harness that timed the write leg and stopped would have published
0.0006–0.0010 ms for an operation costing 0.39–0.52 — an understatement of
**400× to 850×**. That is exactly the trap donor bead `rf2-ssn1o` named,
and it is why the published figure is summed.

**Where the flush actually goes.** "Flush" is one word doing two jobs, so
a three-rung subscription ladder separates them — the React commit is the
same one-cell commit at every rung, only the subscription count moves:

| subscriptions | flush ms/write | per subscription |
|---|---|---|
| 30 | 0.0154 / 0.0182 / 0.0114 | 0.38–0.61 µs |
| 100 | 0.0932 / 0.0946 / 0.0557 | 0.56–0.95 µs |
| 300 | 0.5237 / 0.5140 / 0.3892 | 1.30–1.75 µs |

**No per-subscription cost is quoted**: a line through the end rungs has an
intercept of −0.031 to −0.041 ms, and work that does not scale with the
count cannot cost less than nothing. The flush grows as **N^1.45–1.53** —
super-linear in the frame's layer-1 subscription count, and essentially
all of it is Reagent's reaction drain rather than React.

## Instrument discipline

Six gates run before any figure is taken, on every run:

- **arm-order guard self-test** — 8/8, replayed from recorded fixtures,
  run *inside* the `:advanced` bundle (the guard that adjudicates these
  figures is the CLJC one the bundle carries);
- **key-renaming integrity probe** — the bundle writes and reads its own
  accumulator keys under the renaming it was compiled with;
- **clock quantum**, measured in-page: 0.100 ms, confirmed not assumed;
- **DOM read-back**, every write read out of the page inside its own
  window: **0 unverified of 4320**, all three runs;
- **empty-`flushSync` negative control** — the same arm with an empty
  drain, which *must* go red: **20 unverified of 20**, all three runs. A
  gate that cannot fail has not verified anything, and this is the fault
  aimed directly at a bead measuring a flush;
- **positive control**, predicted vs measured, every run: 0.3000 →
  0.3300/0.3300/0.3250; 0.9000 → 0.9600/0.9650/0.9600; slope 0.6000 →
  0.6300/0.6350/0.6350. Its third reading is falsifiable — an arm's total
  must not move when the control's size changes, and none did.

Both-orders discipline is the slot order rotating **and reflecting** on
the sample index; every arm's two order strata overlap. The guard returned
**reportable** on all three runs. Ranges are reported throughout; no mean
appears without one.

## Three faults the harness found in itself

Recorded in the page and in the code, because each produced a plausible,
precise, wrong number first.

1. **A shadowed binding silenced three quarters of the guard.** A
   destructured `{:keys [samples …]}` shadowed the numeric `samples`
   parameter, so the position counter returned `NaN` and every sample from
   round two on reached the guard with a non-finite position. The guard
   filters those — it reported "24 samples" per arm while adjudicating the
   phase question on the **six** that survived, and read `[ok]`. The
   driver now prints the finite-position count per arm and **fails** if
   any is missing.
2. **A median write-share read a flat 0%.** With the write leg under the
   clock grid its median is exactly zero. The split moved to the
   quantisation-unbiased **mean**; the median table lost its share column.
3. **A two-rung ladder fitted a negative intercept.** The third rung
   exists because of it, and no per-subscription figure is quoted when the
   intercept is negative.

## Lane ownership

**`implementation/shadow-cljs.edn` is not touched.** `rf2-2rtt6.2` owns the
measurement lane's build id, so this driver overrides an existing
`:advanced` `:browser` build's entry point and output dir with
`--config-merge` — the technique the donor's own `b8_run.cjs` uses. It
**prefers `:hicasso-bench`** when the checkout has it and falls back to
`:freehand-release` otherwise, so #7259's id is picked up with no edit and
no rebase conflict once it lands. `HN_BASE_BUILD` overrides both.

Fence respected: no `spec/**`, no `.github/**`, no
`implementation/*/src/**`, no `docs/design/freehand/**`, no sibling arm.
Four files, all new.

`rf2-uhw11` (P3) is filed to converge this lane with #7259's `lane.cljs`
after both merge — `summarise`, `slot-order`, `chain` and the tally exist
twice today, and this repo's own bench headers argue that a method
expressed twice is a method that drifts.

## Quality gates

| gate | command | exit |
|---|---|---|
| the arm, to completion (build + 3 browser runs) | `node implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs` | **0** |
| order-guard self-test | runs as gate 1 inside the `:advanced` bundle — 8/8 | **0** |
| arm-order guard verdict | reportable on all three runs (exit 2 would mean refusal) | **0** |
| script-policy sweep (navigation-ceiling, path, spawn, browser-lane partition, …) | `npm run test:script-policy` | **0** |

Run foreground to completion, never piped through `tail`, logs kept
worktree-local.
