### PR TITLE
bench(hicasso): decompose the UIx spine's per-read allocation (rf2-2rtt6.12)

### DIFF
--- a/docs/design/hicasso/README.md
+++ b/docs/design/hicasso/README.md
@@ -9,6 +9,7 @@ by [EP-0038](../../EP/EP-0038-the-hicasso-view-layer-programme.md).
 |---|---|
 | [charter.md](charter.md) | Product identity, evidence base, goals, constraints, use-case roster, known losses |
 | [decisions.md](decisions.md) | HD-001…HD-021 — every design decision, resolved, with rationale and reopen conditions |
+| [hd-002-adjudication.md](hd-002-adjudication.md) | HD-002 adjudicated — the tripwire, the boundary, ownership, and the hypotheses under test |
 | [architecture.md](architecture.md) | The architecture space, the two spike arms, the shared front half, inside-React feasibility, the sub-read mechanism ladder |
 | [validation.md](validation.md) | The bar, the budgets, the P0→P1→P2 plan, witnesses, tournament and measurement discipline, kill criteria |
 | [authoring.md](authoring.md) | The authoring surface: views, subs, intents, interop door, theming, ephemeral state, testing doors |

--- a/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
+++ b/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
@@ -1,0 +1,300 @@
+# The UIx spine's per-read allocation, decomposed
+
+**Bead** `rf2-2rtt6.12` · **epic** `rf2-2rtt6` (EP-0038) · **Wave 0**
+**Producing commit** `0cf86fb580` · **measured** 2026-07-31 AUSEST
+**Runtime for every figure on this page: headless Chromium, `:advanced`, `goog.DEBUG false`.**
+
+Reproduce:
+
+```bash
+cd implementation
+ABL_ROUNDS=4 ABL_SNAP_ROUNDS=2 \
+  node freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs
+```
+
+Instrument: `implementation/freehand/test/re_frame/freehand/bench/spine_ablation.cljs`
+(page), `…/spine_ablation_app.cljs` (`:advanced` entry),
+`…/spine_ablation_run.cjs` (driver). It rides `freehand-release` through
+`--config-merge` and adds no build id.
+
+---
+
+## The question
+
+`rf2-2rtt6.5`'s reads-per-boundary ladder priced a re-frame2 subscription read
+at **3,550 B** on the UIx spine against **942 B** on Reagent — 3.77× — and
+attributed the whole difference to object **count**: 128.5 objects per read
+against 36.2, at ~27 B per object on both arms.
+
+One `useSyncExternalStore`, two `useRef`s, one `useMemo` and two `useCallback`s
+do not come to 128 objects. So: what are the other objects, how many of them are
+irreducible, and is any of it a defect?
+
+---
+
+## The answer, largest term first
+
+The shipped UIx read costs **3,501 B** and **125.8 objects**. It decomposes into
+three terms that **sum to the whole with no residual**:
+
+| term | bytes/read | objects/read | share |
+|---|---:|---:|---:|
+| **one live subscription**, as the spine represents it | 1,684 `[1,660–1,687]` | 56.7 | 48.1% |
+| **React's six-hook stack** | 1,037 `[1,035–1,039]` | 46.1 | 29.6% |
+| **a second, disposed, unreachable reaction** | 769 `[765–793]` | 23.0 | 22.0% |
+| sum | 3,490 | 125.8 | 99.7% |
+| measured whole (`xcript`) | 3,489 `[3,488–3,492]` | 125.8 | |
+
+Reagent, measured in the same run on the same subs and the same page shape, pays
+**866 B / 31.5 objects** for the subscription half. So:
+
+* The hook stack is **not** a small minority. At 46.1 objects it is 37% of the
+  read, and it is what a `useSyncExternalStore`-shaped substrate costs.
+* The subscription half costs the spine **1,684 B / 56.7 obj** against Reagent's
+  **866 B / 31.5 obj** — **1.94×** for the same job, because the two adapters
+  build different objects (below).
+* **22% of the read is waste**: a reaction that is built, disposed, and then
+  retained for the lifetime of the component with no verb that can reach it.
+
+---
+
+## The third term is a defect, and it was settled by counting
+
+`re-frame.substrate.spine`'s `use-subscribe` takes a **balanced round trip** in
+the render phase — `subs/subscribe` immediately followed by `subs/unsubscribe` —
+so that a render which never commits retains no ref-count (rf2-es09qq). The
+comment there anticipates the steady state correctly: with a durable +1 already
+held, the round trip goes 1 → 2 → 1 and never crosses the disposal edge.
+
+For a query with **no live cache entry** it goes 0 → 1 → 0, and 1 → 0 *is* the
+disposal edge. `re-frame.subs.cache/unsubscribe!` disposes in-tick with no grace
+period: the reaction the render phase just built is disposed and its cache slot
+evicted. The commit-phase `subscribe-fn` then misses the cache again and builds a
+**second** reaction.
+
+The first one does not go away. `use-memo` returns it into the fiber's hook slot,
+and `get-snap` closes over it as its pre-commit fallback. So a disposed reaction —
+no source watches, no cache slot, no `-dispose` left to call — is retained for as
+long as the component is mounted.
+
+**That is not a claim about bytes, so it was not settled with a heap instrument.**
+The page also mounts a small grid through a transcription carrying three counters.
+The prediction was written into the driver before the run:
+
+```
+PREDICTED, for N reads:   uix  commits N, rebuilt N, bodyRuns 2N
+                      reagent  commits 0, rebuilt 0, bodyRuns  N
+```
+
+Measured, at N = 600, twice per page over **disjoint** cells so no call could be
+served by another's cache entries:
+
+| page | commits | rebuilt | bodyRuns |
+|---|---:|---:|---:|
+| uix, offset 0 | 600 (1.00N) | **600 (1.00N)** | **1200 (2.00N)** |
+| uix, offset 900 | 600 (1.00N) | **600 (1.00N)** | **1200 (2.00N)** |
+| reagent, offset 0 | 0 | 0 | 600 (1.00N) |
+| reagent, offset 900 | 0 | 0 | 600 (1.00N) |
+
+`rebuilt = N` says every read's commit-phase acquire hands back a reaction that
+is **not `identical?`** to the one the render phase built and the fiber is still
+holding. `bodyRuns = 2N` is its shadow: the memoised body caches on
+`(= @last-db db)`, so a second deref of the *same* reaction against an unchanged
+app-db is a memo hit and does not re-run the body — two body runs therefore means
+two distinct reactions, not two derefs of one.
+
+Exact integers, no ranges, immune to every fault a heap instrument has.
+
+`bodyRuns = 2N` proves a second thing that matters below: React **does** call
+`getSnapshot` again after `subscribe-fn` has run, and that call reads the live
+committed reaction.
+
+### What the dead reaction actually holds
+
+Its `-dispose` cleared `watchers` and `own-keys`, but the object graph survives:
+the `reify`, three atoms, three volatiles, six closures, the recompute closure and
+the memoised body — **23.0 objects, 769 B on this page**. That is a floor, not a
+ceiling: the memoised body's `last-result` volatile pins the sub's last computed
+value, and every cell here is the integer `0`. A sub returning a collection has
+that collection retained twice.
+
+---
+
+## Term by term
+
+### 1,684 B / 56.7 obj — one live subscription, as the spine represents it
+
+`noretain − hooks`. Both arms allocate the query vector, the stable key, both
+refs and all six hooks, so this difference is the reaction, its cache entry, and
+the watch wiring, and nothing else.
+
+Reagent's arm pays **866 B / 31.5 obj** for the same job. The two adapters build
+different objects, and the gap is structural rather than accidental:
+
+* `re-frame.adapter.reagent` passes `ratom/make-reaction` into
+  `spine/make-ratom-spine` — one Reagent `Reaction` deftype instance with
+  mutable fields.
+* `re-frame.substrate.spine/make-derived-value-fn` has no reaction primitive to
+  lean on, so it constructs one: a `reify`, three atoms (`watchers`,
+  `on-dispose-fns`, `own-keys`), three volatiles (`disposed?`, `prev-state`,
+  `dirty?`), six closures (`recompute`, `notify`, `deref-derived`, `flush!`,
+  `mark-dirty!`, the on-dispose), and a dependent entry in the epoch scheduler's
+  per-source fan-out coordinator.
+
+Every one of those exists for a reason the spine's own comments give — glitch-free
+recompute (rf2-i21f5), failure containment (rf2-qcmzc, rf2-2u4rw), a real terminal
+for a raw-source fan-out (rf2-7ryt0), idempotent dispose (rf2-1bzlai). **This term
+is the price of satisfying the Spec 006 invalidation contract explicitly instead of
+inheriting it from a native reactive atom, and it is not a defect.** Whether the
+representation could be flattened is a separate design question and is not
+answered here.
+
+### 1,037 B / 46.1 obj — React's six-hook stack
+
+`hooks`, the floor-subtracted cost of two `useRef`s, the stable-key derivation
+(including the query vector, so that allocation cancels in the difference above),
+one `useMemo`, two `useCallback`s and one `useSyncExternalStore` — with no
+re-frame anywhere. Per read.
+
+For scale, `rf2-oob3g` priced an isolated `useSyncExternalStore` rung at 516 B.
+Six hooks at 1,037 B is that number and change, which is the shape one would
+expect.
+
+**This term is irreducible for a hook-based substrate.** It is not re-frame's, it
+does not shrink by writing better re-frame, and it is the reason a subscribing UIx
+boundary loses to Reagent even after the defect above is fixed. It is also the
+term Hicasso is in a position to avoid, since a substrate that does not route
+reads through hooks does not pay it.
+
+### 769 B / 23.0 obj — the retained render-phase reaction
+
+`xcript − noretain`, the single-variable ablation described above.
+
+---
+
+## The fix, priced
+
+**Recommendation: land it, in `re-frame.substrate.spine`, as a separate reviewed
+change.** It is a production edit to a first-class shipped adapter and was
+deliberately not made under this bead.
+
+**The change.** The render-phase `use-memo` currently returns the reaction handle;
+have it deref the handle and return the **value**, and have `get-snap`'s pre-commit
+fallback read that value. Roughly six lines. Every `subs/subscribe` /
+`subs/unsubscribe` call, every hook and every watch stays exactly where it is.
+
+**Measured effect** (this is precisely what the `noretain` arm is):
+
+| | bytes/read | objects/read | vs Reagent |
+|---|---:|---:|---:|
+| shipped | 3,501 `[3,499–3,503]` | 125.8 | 4.04× |
+| with the fix | 2,720 `[2,698–2,722]` | 102.8 | **3.14×** |
+
+−769 B and −23.0 objects per read, −22%.
+
+**Blast radius.** `make-react-spine` is shared by three substrates —
+`re-frame.adapter.uix` (first-class, shipped), `re-frame.freehand.substrate`, and
+`re-frame.ui.substrate`. One change, three beneficiaries.
+
+**Correctness.** The fallback stops being a live re-read. That window is covered:
+
+* React's `useSyncExternalStore` calls `getSnapshot` again after `subscribe`
+  returns, and by then `subscribe-fn` has published the committed reaction, so
+  that call reads the **live** one and any app-db write landing between render
+  and commit is detected. This is not inferred from React's source — `bodyRuns =
+  2N` above measures it happening.
+* A frozen value satisfies React's "the result of getSnapshot should be cached"
+  rule at least as well as the current live deref does.
+* The key-change path (rf2-naz09e) is unchanged in shape: the memo is keyed on
+  `stable-key`, so a key change recomputes the snapshot for the **new** target and
+  the key guard still rejects the stale `committed-ref`.
+
+**What it does not fix.** Two reactions are still *built* per read on a first
+mount (`bodyRuns` stays 2N); the fix stops the first being *retained*. Removing the
+double build needs the cache to tolerate a ref-count-0 tenancy so the render-phase
+materialisation survives to be adopted by the commit — which is a change to
+`re-frame.subs` **and** to Spec 006 §Reference counting and disposal's
+no-grace-period rule. That is a ruling, not a patch, and is filed separately.
+
+**Rejected alternative.** Making the fallback live *without* retention — having
+`get-snap` call `subs/subscribe-once` on the fallback path — is unsafe. Each call
+builds a fresh reaction with a fresh memo cell, so a sub returning a collection
+yields a fresh, non-`Object.is` value on every `getSnapshot`, which is React's
+documented infinite-render-loop condition.
+
+---
+
+## Instrument discipline
+
+**Retention, never allocation.** Mount an arm and keep it, collect three times
+with a beat, read; release, collect, read again. V8's CDP *sampling* heap profiler
+drops the samples of collected objects and has already produced one wrong table on
+this surface.
+
+**In-situ positive control, predicted before the run.** A dense JS array of
+587,500 doubles, which V8 stores as unboxed 8-byte slots: **4,700,000 B predicted**.
+Same shape and same size as `rf2-2rtt6.5`'s, so the errors are directly comparable.
+
+| page | reader A | reader B | reader C |
+|---|---|---|---|
+| uix | 4,699,971 B, **−0.001%** | 4,699,971 B, −0.001% | 4,700,146 B, +0.003% |
+| reagent | 4,700,796 B, +0.017% | 4,700,751 B, +0.016% | 4,700,014 B, **0.000%** |
+
+**Fidelity control.** An ablation is attributable only if the transcribed-but-
+unablated arm reproduces the shipped hook. Shipped `uix` 3,501 `[3,499–3,503]`;
+transcription `xcript` 3,489 `[3,488–3,492]` — **0.332% apart**, inside the 3%
+band the driver declares before it measures. The band is an order of magnitude
+below the 22% term being resolved, so it cannot manufacture the finding.
+
+**Order guard.** `order_guard.schedule` rotates and reflects with the round; even
+rounds forward, odd rounds reversed, both reported separately. Its self-test (8
+checks) runs before the bundle is built. **Verdict: clean on both pages, no
+refusal.** Forward/reversed slopes: uix 3,501/3,501, xcript 3,489/3,490, noretain
+2,710/2,721, hooks 1,036/1,038, reagent 866/866.
+
+**Verification.** Every mount reads the DOM back against the boundary count the arm
+should have produced: **0 unverified of 154 mounts** across both pages.
+
+**Linearity.** r² ≥ 0.9999 on all four UIx variants for bytes and for object counts.
+Reagent's is 0.9973 (bytes) / 0.9961 (objects) — visibly less linear, and its R=0
+rung is the reason: a Reagent boundary shell costs 427 B / 12.1 obj against UIx's
+~215 B / 5.2 obj.
+
+**Readers.** A = `Runtime.getHeapUsage().usedSize`; B = in-page
+`performance.memory.usedJSHeapSize`; C = a full heap snapshot with every node's
+`self_size` summed **and every node counted** by a streaming scan. A and B are two
+doors onto one V8 counter and are not independent. C walks the object graph and is
+the object-count reader — the signal this bead was filed about. A and C agree to
+within 0.1% on every arm (e.g. uix 3,501 vs 3,503; reagent 866 vs 865).
+
+---
+
+## Cross-checks against the ladder
+
+Different rung set (0/1/3/7 here, 0/1/3/7/20 there), different run, same box and
+same collector design.
+
+| | this page | `rf2-2rtt6.5` ladder | agreement |
+|---|---:|---:|---|
+| UIx bytes/read | 3,501 | 3,550 | 1.4% |
+| UIx objects/read | 125.8 | 128.5 | 2.1% |
+| Reagent bytes/read | 866 | 942 | 8.1% |
+| Reagent objects/read | 31.5 | 36.2 | 13% |
+| UIx/Reagent ratio | 4.04× | 3.77× | |
+| UIx shell ÷ Reagent shell | 267 ÷ 586 = 0.46× | 0.49× | |
+
+The UIx arms agree closely; the Reagent arms sit ~8–13% below the ladder's, which
+is the rung set — dropping R=20 removes the point with the most leverage from a
+line whose r² is 0.997 rather than 0.9999. The ratio is quoted here from
+same-run arms, which is the comparison that carries.
+
+---
+
+## What this page does not claim
+
+* It does not claim the 3.14× that remains after the fix is acceptable, or that it
+  is not. That is the P0 bar's question.
+* It does not claim the spine's derived-value representation should be flattened.
+  It measures that the representation costs 1.94× Reagent's for the same job and
+  stops there.
+* It does not price the CPU of the double build, only its retention.

--- a/implementation/freehand/test/re_frame/freehand/bench/spine_ablation.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/spine_ablation.cljs
@@ -1,0 +1,624 @@
+(ns re-frame.freehand.bench.spine-ablation
+  "THE UIx SPINE PER-READ ABLATION — what the 3,550 bytes a UIx
+  subscription read costs are actually made of.
+
+  Wave-0 instrument for EP-0038 (bead `rf2-2rtt6.12`, epic `rf2-2rtt6`).
+  Reports into `docs/design/hicasso/studio/uix-spine-per-read-decomposition.md`.
+
+  ## The question
+
+  `rf2-2rtt6.5`'s reads-per-boundary ladder priced a re-frame2
+  subscription read at **3,550 B** on the UIx spine against **942 B** on
+  Reagent — 3.77x — and its reader C attributed the whole difference to
+  object COUNT: **128.5 objects per read against 36.2**, at ~27 B per
+  object on both arms. One `useSyncExternalStore`, two `useRef`s, one
+  `useMemo` and two `useCallback`s do not come to 128 objects, so the
+  spine is holding something the hook stack does not account for.
+
+  Reading `re-frame.substrate.spine/use-subscribe` says what. The render
+  phase takes a BALANCED round trip — `subs/subscribe` immediately
+  followed by `subs/unsubscribe` — so that a render which never commits
+  retains no ref-count (rf2-es09qq). For a query with no prior cache
+  entry that round trip is `0 -> 1 -> 0`, and 1 -> 0 is the DISPOSAL
+  edge: the reaction it just built is disposed and its cache slot
+  evicted (`re-frame.subs.cache/unsubscribe!`, no grace period). The
+  commit-phase `subscribe-fn` then misses the cache again and builds a
+  SECOND reaction. Two reactions are built per read — and the first one
+  does not go away, because `use-memo` returns it into the fiber's hook
+  slot and the `get-snap` callback closes over it as its pre-commit
+  fallback. A disposed, unreachable-by-any-verb reaction is retained for
+  the lifetime of the component.
+
+  That is a hypothesis about retained bytes, so it is settled by a
+  retention measurement and not by reading.
+
+  ## The ablation
+
+  Four UIx arms, differing by ONE term each, all reading the same
+  `[:abl/cell i]` subs in the same frame at 1,200 boundaries:
+
+  | arm        | what it is                                                  |
+  |------------|-------------------------------------------------------------|
+  | `uix`      | the SHIPPED `re-frame.adapter.uix/use-subscribe`             |
+  | `xcript`   | a transcription of the shipped hook, term for term           |
+  | `noretain` | the transcription with the render-phase reaction NOT held    |
+  | `hooks`    | the same six hooks over a trivial JS store — no re-frame     |
+
+  `xcript` is the FIDELITY CONTROL and it is the reason the other two
+  mean anything: an ablation is only attributable if the unablated
+  transcription reproduces the shipped hook. If `xcript` does not land on
+  `uix` within the round-to-round range, the transcription is wrong and
+  every delta taken from it is void. The report says so in as many words
+  and the driver refuses to call the decomposition attributable.
+
+  The differences then read off directly:
+
+      uix - noretain   the retained render-phase reaction
+      noretain - hooks one live subscription as the spine pays for it
+      hooks  - floor   React's own six-hook stack, per read
+      reagent          the subscription half BOTH substrates pay
+
+  `noretain` differs from `xcript` in exactly one expression: its
+  render-phase `use-memo` derefs the reaction and returns the VALUE
+  rather than the reaction itself, and `get-snap`'s pre-commit fallback
+  reads that value. Every `subs/subscribe` / `subs/unsubscribe` call, every
+  hook, every deps array and every watch is otherwise identical — so the
+  build/dispose/rebuild CHURN is still paid on both sides and the delta
+  isolates RETENTION alone. `noretain` is a MEASUREMENT ARM, not a
+  proposed patch: it drops the live-reread property of the current
+  fallback (see the studio page).
+
+  ## What this namespace does NOT do
+
+  It does not decide when a heap reading is taken. The page mounts and
+  holds; the driver (`spine_ablation_run.cjs`) owns the collector, all
+  three readers and the in-situ control. Nothing here counts allocations
+  — V8's CDP *sampling* heap profiler drops the samples of collected
+  objects, and that fault has already produced one wrong table on this
+  surface.
+
+  Every mount is verified at the DOM: [[mount!]] counts the boundary
+  elements the arm should have produced and answers the count beside the
+  expectation, because an arm that silently rendered nothing would
+  otherwise read as the cheapest variant in the table.
+
+  ## Where this file lives, and why
+
+  Beside B7 and `reads-ladder`, in the bench lane, because it RIDES their
+  collector design and because `freehand/test` is the only
+  `:advanced`-capable browser source path on the classpath until the
+  Hicasso lane (`rf2-2rtt6.2`, PR #7259) merges. It requires nothing from
+  `re-frame.freehand`. When the Hicasso lane exists this file moves there
+  unchanged.
+
+  Normative owner: bead `rf2-2rtt6.12`; programme
+  `docs/design/hicasso/charter.md`."
+  (:require ["react" :as react]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.subs :as subs]
+            [reagent.dom.client :as rdc]
+            [uix.core :refer [$ defui]]
+            [uix.dom :as uix-dom]
+            [uix.hooks.alpha :as uix-hooks]))
+
+;; ---------------------------------------------------------------------------
+;; The ladder's shape
+;; ---------------------------------------------------------------------------
+
+(def reads-rungs
+  "Four rungs, so a straight line through them is a claim that can fail.
+  `0` is the boundary shell — a component per boundary that reads nothing
+  — and is the intercept anchor, never a source of reactive inference.
+  20 is dropped relative to `rf2-2rtt6.5`'s ladder: this instrument runs
+  FOUR variants where that one ran two, and the slope over 0/1/3/7 is
+  already over-determined."
+  [0 1 3 7])
+
+(def boundaries
+  "Fixed, because this instrument regresses against READS only. 1,200 is
+  `rf2-2rtt6.5`'s Curve B count, so the `uix` arm here is directly
+  comparable with the 3,550 B/read that page published."
+  1200)
+
+(def frame-id
+  "ONE frame behind every boundary of every arm."
+  :abl/frame)
+
+(def ^:private cells-needed
+  "Every boundary reads DISTINCT cells, so no two boundaries share a
+  reaction and the per-read figure carries the reaction as well as the
+  hook. Matches the ladder, and it is the shape that makes the
+  double-build visible: a distinct query is a cache MISS on the
+  render-phase round trip AND again on the commit-phase acquire."
+  (* boundaries (apply max reads-rungs)))
+
+;; ---------------------------------------------------------------------------
+;; The store
+;; ---------------------------------------------------------------------------
+
+;; Every cell is ZERO, for the reason the ladder gives: a boundary renders
+;; the sum of its reads, so with zeros every arm and every floor renders the
+;; identical one-character text node "0" at every rung, and no arm carries
+;; per-boundary string data the floor does not. The reads are still live —
+;; `use-subscribe` and `subs/subscribe` are calls with registrar side effects
+;; and their results reach the DOM — so nothing here is elidable under
+;; `:advanced`.
+(rf/reg-event :abl/seed
+  (fn [_ctx [_ n]] {:db {:cells (vec (repeat n 0))}}))
+
+(rf/reg-sub :abl/cell
+  (fn [db [_ i]] (nth (:cells db) i)))
+
+(defn ensure-frame! []
+  (rf/make-frame {:id frame-id :initial-events [[:abl/seed cells-needed]]}))
+
+;; ---------------------------------------------------------------------------
+;; The floor — plain React, no component per boundary, no reactivity
+;; ---------------------------------------------------------------------------
+
+(defn- el [tag props children] (apply react/createElement tag props children))
+
+(defn floor-grid
+  "`n` boundary elements and the container, and NOTHING else. `arm - floor`
+  is therefore the variant's own standing cost and not a figure dominated
+  by React fibers and DOM handles every arm pays for. Same shape as the
+  ladder's floor, so the R=0 rungs here are comparable with its."
+  [n]
+  (el "div" #js {:className "abl"}
+      (into-array
+        (map (fn [i] (el "span" #js {:key i :className "cell" :data-i i} "0"))
+             (range n)))))
+
+;; ---------------------------------------------------------------------------
+;; ARM 2 — `xcript`: the shipped hook, transcribed term for term
+;; ---------------------------------------------------------------------------
+;;
+;; This is `re-frame.substrate.spine`'s `use-subscribe-2` body, copied. The
+;; ONLY differences are cosmetic: the hook fns are named directly
+;; (`uix.hooks.alpha/use-memo` — which is exactly what the UIx adapter passes
+;; into `make-react-spine`) rather than reached through the factory's closure,
+;; and the watch-key namespace string is spelled here instead of derived from
+;; `:gensym-prefix-use-sub`. It is a copy on purpose: an ablation that does not
+;; start from a faithful copy prices something else and says nothing about the
+;; shipped adapter. The `xcript` vs `uix` comparison in the report is what
+;; makes that claim falsifiable rather than asserted.
+
+(def ^:private watch-ns "rf-uix-use-sub")
+
+(defn- stable-key-of
+  "The `useRef` + `=` memo-by-value from the spine (rf2-mwft2), shared by
+  all three transcribed arms so the stable-key term is identical across
+  them and cancels in every difference."
+  [key-ref frame-kw query-v]
+  (let [prev    (.-current key-ref)
+        new-key #js [frame-kw query-v]]
+    (if (and prev
+             (= (aget prev 0) frame-kw)
+             (= (aget prev 1) query-v))
+      prev
+      (do (set! (.-current key-ref) new-key)
+          new-key))))
+
+(defn- use-sub-xcript [frame-kw query-v]
+  (let [key-ref       (react/useRef nil)
+        committed-ref (react/useRef nil)
+        stable-key      (stable-key-of key-ref frame-kw query-v)
+        stable-frame-kw (aget stable-key 0)
+        stable-query-v  (aget stable-key 1)
+        ;; Balanced, net-zero render-phase fetch of the reaction HANDLE
+        ;; (rf2-es09qq). For a query with no live cache entry this is
+        ;; 0 -> 1 -> 0: build, then dispose + evict. The handle is
+        ;; returned, so React's hook slot keeps it.
+        reaction
+        (uix-hooks/use-memo
+          (fn []
+            (let [r (subs/subscribe stable-query-v {:frame stable-frame-kw})]
+              (subs/unsubscribe stable-frame-kw stable-query-v)
+              r))
+          #js [stable-key])
+        get-snap
+        (uix-hooks/use-callback
+          (fn []
+            (let [stored (.-current committed-ref)
+                  r      (if (and stored
+                                  (identical? (aget stored 0) stable-key))
+                           (aget stored 1)
+                           reaction)]
+              (when r @r)))
+          #js [stable-key reaction])
+        subscribe-fn
+        (uix-hooks/use-callback
+          (fn [on-change]
+            (let [committed (subs/subscribe stable-query-v
+                                            {:frame stable-frame-kw})]
+              (set! (.-current committed-ref) #js [stable-key committed])
+              (let [k (keyword watch-ns (str (gensym "watch-")))]
+                (when committed
+                  (add-watch committed k (fn [_ _ _ _] (on-change))))
+                (fn unsubscribe []
+                  (when committed (remove-watch committed k))
+                  (let [stored (.-current committed-ref)]
+                    (when (and stored (identical? (aget stored 1) committed))
+                      (set! (.-current committed-ref) nil)))
+                  (subs/unsubscribe stable-frame-kw stable-query-v)))))
+          #js [stable-key])]
+    (react/useSyncExternalStore subscribe-fn get-snap get-snap)))
+
+;; ---------------------------------------------------------------------------
+;; ARM 3 — `noretain`: the transcription, minus the retained reaction
+;; ---------------------------------------------------------------------------
+;;
+;; ONE expression differs from `xcript`. The render-phase `use-memo` still
+;; performs the identical balanced round trip — same `subs/subscribe`, same
+;; `subs/unsubscribe`, same build + dispose + commit-phase rebuild — but it
+;; DEREFS the handle and returns the VALUE, so nothing holds the disposed
+;; reaction once the factory returns. `get-snap`'s pre-commit fallback reads
+;; that value.
+;;
+;; Everything else — both refs, the stable key, both `use-callback`s, the
+;; watch, `useSyncExternalStore` — is character-for-character `xcript`. The
+;; CHURN is therefore on both sides of the subtraction and only RETENTION
+;; is isolated.
+;;
+;; This is a measurement arm and not a proposed patch. Freezing the fallback
+;; snapshot gives up one property the live handle has: today's fallback
+;; `@r` on the disposed reaction still recomputes (the derived value is
+;; pull-based), so an app-db write landing between render and the
+;; commit-phase watch install is observed by React's store-consistency
+;; check. A frozen value is not. The studio page prices the fix that keeps
+;; that property; this arm exists to price the term, not to ship it.
+
+(defn- use-sub-noretain [frame-kw query-v]
+  (let [key-ref       (react/useRef nil)
+        committed-ref (react/useRef nil)
+        stable-key      (stable-key-of key-ref frame-kw query-v)
+        stable-frame-kw (aget stable-key 0)
+        stable-query-v  (aget stable-key 1)
+        snapshot
+        (uix-hooks/use-memo
+          (fn []
+            (let [r (subs/subscribe stable-query-v {:frame stable-frame-kw})
+                  v (when r @r)]
+              (subs/unsubscribe stable-frame-kw stable-query-v)
+              v))
+          #js [stable-key])
+        get-snap
+        (uix-hooks/use-callback
+          (fn []
+            (let [stored (.-current committed-ref)]
+              (if (and stored (identical? (aget stored 0) stable-key))
+                (let [r (aget stored 1)] (when r @r))
+                snapshot)))
+          #js [stable-key snapshot])
+        subscribe-fn
+        (uix-hooks/use-callback
+          (fn [on-change]
+            (let [committed (subs/subscribe stable-query-v
+                                            {:frame stable-frame-kw})]
+              (set! (.-current committed-ref) #js [stable-key committed])
+              (let [k (keyword watch-ns (str (gensym "watch-")))]
+                (when committed
+                  (add-watch committed k (fn [_ _ _ _] (on-change))))
+                (fn unsubscribe []
+                  (when committed (remove-watch committed k))
+                  (let [stored (.-current committed-ref)]
+                    (when (and stored (identical? (aget stored 1) committed))
+                      (set! (.-current committed-ref) nil)))
+                  (subs/unsubscribe stable-frame-kw stable-query-v)))))
+          #js [stable-key])]
+    (react/useSyncExternalStore subscribe-fn get-snap get-snap)))
+
+;; ---------------------------------------------------------------------------
+;; ARM 4 — `hooks`: the same six hooks, no re-frame at all
+;; ---------------------------------------------------------------------------
+;;
+;; Two `useRef`s, the stable-key derivation (INCLUDING the `[:abl/cell i]`
+;; query vector, so the query-v allocation cancels in `noretain - hooks`
+;; and that difference is the subscription machinery alone), one `useMemo`,
+;; two `useCallback`s and `useSyncExternalStore` over a trivial JS store.
+;; No `subs/subscribe`, no reaction, no cache entry.
+;;
+;; The store is a shared `js/Set` of listeners and never notifies, which is
+;; the same standing shape the real arms have on this page: every cell is
+;; zero, so no subscriber is ever called there either.
+
+(def ^:private hooks-listeners (js/Set.))
+
+(defn- use-sub-hooks [frame-kw query-v]
+  (let [key-ref       (react/useRef nil)
+        committed-ref (react/useRef nil)
+        stable-key (stable-key-of key-ref frame-kw query-v)
+        handle     (uix-hooks/use-memo (fn [] hooks-listeners) #js [stable-key])
+        get-snap   (uix-hooks/use-callback
+                     (fn [] (if (and handle stable-key) 0 0))
+                     #js [stable-key handle])
+        subscribe-fn
+        (uix-hooks/use-callback
+          (fn [on-change]
+            (set! (.-current committed-ref) #js [stable-key on-change])
+            (.add hooks-listeners on-change)
+            (fn unsubscribe []
+              (.delete hooks-listeners on-change)
+              (let [stored (.-current committed-ref)]
+                (when (and stored (identical? (aget stored 1) on-change))
+                  (set! (.-current committed-ref) nil)))))
+          #js [stable-key])]
+    (react/useSyncExternalStore subscribe-fn get-snap get-snap)))
+
+;; ---------------------------------------------------------------------------
+;; The read shims, one per variant
+;; ---------------------------------------------------------------------------
+
+(defn- r-uix      [i] (uix-adapter/use-subscribe frame-id [:abl/cell i]))
+(defn- r-xcript   [i] (use-sub-xcript   frame-id [:abl/cell i]))
+(defn- r-noretain [i] (use-sub-noretain frame-id [:abl/cell i]))
+(defn- r-hooks    [i] (use-sub-hooks    frame-id [:abl/cell i]))
+
+;; ---------------------------------------------------------------------------
+;; The components — UNROLLED, per variant, per rung
+;; ---------------------------------------------------------------------------
+;;
+;; UNROLLED for the ladder's reason: these are hooks, React's rule is that
+;; the call sequence is identical on every render of an instance, and a loop
+;; would satisfy that in fact but not by construction. Writing the calls out
+;; is also the honest thing for a page pricing hook calls — the reader can
+;; count them. Four variants x four rungs is sixteen components and no
+;; abstraction over them, deliberately: an abstraction that routed the hook
+;; through a prop would be the one thing a reader could not verify by eye.
+
+(defui c-uix-0 [{:keys [base]}] ($ :span.cell {:data-i base} "0"))
+
+(defui c-uix-1 [{:keys [base]}]
+  (let [v (r-uix (+ base 0))]
+    ($ :span.cell {:data-i base} (str v))))
+
+(defui c-uix-3 [{:keys [base]}]
+  (let [v (+ (r-uix (+ base 0)) (r-uix (+ base 1)) (r-uix (+ base 2)))]
+    ($ :span.cell {:data-i base} (str v))))
+
+(defui c-uix-7 [{:keys [base]}]
+  (let [v (+ (r-uix (+ base 0)) (r-uix (+ base 1)) (r-uix (+ base 2))
+             (r-uix (+ base 3)) (r-uix (+ base 4)) (r-uix (+ base 5))
+             (r-uix (+ base 6)))]
+    ($ :span.cell {:data-i base} (str v))))
+
+(defui c-xcript-0 [{:keys [base]}] ($ :span.cell {:data-i base} "0"))
+
+(defui c-xcript-1 [{:keys [base]}]
+  (let [v (r-xcript (+ base 0))]
+    ($ :span.cell {:data-i base} (str v))))
+
+(defui c-xcript-3 [{:keys [base]}]
+  (let [v (+ (r-xcript (+ base 0)) (r-xcript (+ base 1)) (r-xcript (+ base 2)))]
+    ($ :span.cell {:data-i base} (str v))))
+
+(defui c-xcript-7 [{:keys [base]}]
+  (let [v (+ (r-xcript (+ base 0)) (r-xcript (+ base 1)) (r-xcript (+ base 2))
+             (r-xcript (+ base 3)) (r-xcript (+ base 4)) (r-xcript (+ base 5))
+             (r-xcript (+ base 6)))]
+    ($ :span.cell {:data-i base} (str v))))
+
+(defui c-noretain-0 [{:keys [base]}] ($ :span.cell {:data-i base} "0"))
+
+(defui c-noretain-1 [{:keys [base]}]
+  (let [v (r-noretain (+ base 0))]
+    ($ :span.cell {:data-i base} (str v))))
+
+(defui c-noretain-3 [{:keys [base]}]
+  (let [v (+ (r-noretain (+ base 0)) (r-noretain (+ base 1))
+             (r-noretain (+ base 2)))]
+    ($ :span.cell {:data-i base} (str v))))
+
+(defui c-noretain-7 [{:keys [base]}]
+  (let [v (+ (r-noretain (+ base 0)) (r-noretain (+ base 1))
+             (r-noretain (+ base 2)) (r-noretain (+ base 3))
+             (r-noretain (+ base 4)) (r-noretain (+ base 5))
+             (r-noretain (+ base 6)))]
+    ($ :span.cell {:data-i base} (str v))))
+
+(defui c-hooks-0 [{:keys [base]}] ($ :span.cell {:data-i base} "0"))
+
+(defui c-hooks-1 [{:keys [base]}]
+  (let [v (r-hooks (+ base 0))]
+    ($ :span.cell {:data-i base} (str v))))
+
+(defui c-hooks-3 [{:keys [base]}]
+  (let [v (+ (r-hooks (+ base 0)) (r-hooks (+ base 1)) (r-hooks (+ base 2)))]
+    ($ :span.cell {:data-i base} (str v))))
+
+(defui c-hooks-7 [{:keys [base]}]
+  (let [v (+ (r-hooks (+ base 0)) (r-hooks (+ base 1)) (r-hooks (+ base 2))
+             (r-hooks (+ base 3)) (r-hooks (+ base 4)) (r-hooks (+ base 5))
+             (r-hooks (+ base 6)))]
+    ($ :span.cell {:data-i base} (str v))))
+
+(def ^:private component-table
+  {:uix      {0 c-uix-0      1 c-uix-1      3 c-uix-3      7 c-uix-7}
+   :xcript   {0 c-xcript-0   1 c-xcript-1   3 c-xcript-3   7 c-xcript-7}
+   :noretain {0 c-noretain-0 1 c-noretain-1 3 c-noretain-3 7 c-noretain-7}
+   :hooks    {0 c-hooks-0    1 c-hooks-1    3 c-hooks-3    7 c-hooks-7}})
+
+(defui uix-grid [{:keys [variant n r]}]
+  ($ :div.abl
+     (let [c (get-in component-table [(keyword variant) r])]
+       (for [i (range n)]
+         ($ c {:key i :base (* i r)})))))
+
+;; ---------------------------------------------------------------------------
+;; The Reagent arm — the shared-subscription floor
+;; ---------------------------------------------------------------------------
+;;
+;; A loop rather than an unrolled body, because Reagent has no hook-order
+;; rule: a form-1 component may deref a computed number of reactions and
+;; Reagent's `deref`-capture learns all of them. The asymmetry with the UIx
+;; components above is in the substrates, not in the measurement. Same shape
+;; as `rf2-2rtt6.5`'s Reagent arm, so its 942 B/read is directly comparable.
+
+(defn- rg-cell [base r]
+  (let [v (loop [k 0 acc 0]
+            (if (< k r)
+              (recur (inc k)
+                     (+ acc @(rf/subscribe [:abl/cell (+ base k)]
+                                           {:frame frame-id})))
+              acc))]
+    [:span.cell {:data-i base} (str v)]))
+
+(defn- rg-grid [n r]
+  (into [:div.abl]
+        (map (fn [i] ^{:key i} [rg-cell (* i r) r]))
+        (range n)))
+
+;; ---------------------------------------------------------------------------
+;; Arms
+;; ---------------------------------------------------------------------------
+
+(defn- container! []
+  (let [c (js/document.createElement "div")]
+    (.appendChild js/document.body c)
+    c))
+
+(defn- floor-arm [n]
+  {:boundaries  n
+   :selector    ".cell"
+   :mount-one   (fn [c]
+                  (let [rt (react-dom-client/createRoot c)]
+                    (react-dom/flushSync (fn [] (.render rt (floor-grid n))))
+                    rt))
+   :unmount-one (fn [rt] (react-dom/flushSync (fn [] (.unmount rt))))})
+
+(defn- uix-arm [variant n r]
+  {:boundaries  n
+   :selector    ".cell"
+   :mount-one   (fn [c]
+                  (let [rt (uix-dom/create-root c)]
+                    (react-dom/flushSync
+                      (fn []
+                        (uix-dom/render-root
+                          ($ uix-grid {:variant (name variant) :n n :r r}) rt)))
+                    rt))
+   :unmount-one (fn [rt] (react-dom/flushSync (fn [] (uix-dom/unmount-root rt))))})
+
+(defn- reagent-arm [n r]
+  {:boundaries  n
+   :selector    ".cell"
+   :mount-one   (fn [c]
+                  (let [rt (rdc/create-root c)]
+                    (react-dom/flushSync (fn [] (rdc/render rt [rg-grid n r])))
+                    rt))
+   :unmount-one (fn [rt] (react-dom/flushSync (fn [] (rdc/unmount rt))))})
+
+(def uix-variants
+  "The four UIx-page arms, in decomposition order."
+  [:uix :xcript :noretain :hooks])
+
+(defn- arm-id [variant r n]
+  (keyword (str (name variant) "/r" r "-b" n)))
+
+(defn arms
+  "The arm table for one page. `rf/init!` keeps the first adapter installed
+  in a JS context, so the UIx variants and the Reagent baseline cannot share
+  a page; each gets its own load and its own floor, and no subtraction ever
+  crosses the page boundary."
+  [substrate]
+  (into {}
+        (concat
+          [[(arm-id :floor 0 boundaries) (floor-arm boundaries)]]
+          (case substrate
+            :uix (for [v uix-variants r reads-rungs]
+                   [(arm-id v r boundaries) (uix-arm v boundaries r)])
+            :reagent (for [r reads-rungs]
+                       [(arm-id :reagent r boundaries)
+                        (reagent-arm boundaries r)])))))
+
+;; ---------------------------------------------------------------------------
+;; Holding, and letting go
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private installed (atom nil))
+(defonce ^:private held (atom nil))
+
+(defn- release!* []
+  (when-some [{:keys [arm handle container]} @held]
+    (let [{:keys [unmount-one]} (get @installed arm)]
+      (try (unmount-one handle) (catch :default _ nil)))
+    (.remove container)
+    (reset! held nil))
+  nil)
+
+(defn mount!
+  "Mount `arm-id` and KEEP it. Answers `{:elements :expected :ok
+  :boundaries}` — the DOM read-back over the boundary class the arm should
+  have produced.
+
+  A literal `#js` object rather than `clj->js`: `clj->js` renders `:ok?` as
+  the key `\"ok?\"` and a driver reading `verify.ok` sees `undefined`, so
+  every mount reports unverified while every mount is in fact fine. That
+  happened once already, on B7's first run."
+  [arm-id]
+  (release!*)
+  (let [{:keys [mount-one selector boundaries]} (get @installed arm-id)
+        container (container!)
+        handle    (mount-one container)
+        elements  (.-length (.querySelectorAll js/document selector))]
+    (reset! held {:arm arm-id :handle handle :container container})
+    #js {:elements   elements
+         :expected   boundaries
+         :boundaries boundaries
+         :ok         (= elements boundaries)}))
+
+;; ---------------------------------------------------------------------------
+;; The positive control
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private control-cell (atom nil))
+
+(defn control!
+  "Hold a dense JS array of exactly `n` doubles and answer its length, so
+  the allocation cannot be proved dead and elided.
+
+  V8 stores a packed double array as `n` unboxed 8-byte slots behind a small
+  header, so the retained cost is **8n bytes, PREDICTED** — a figure the
+  instrument has to hit, not one it gets to report. It rides every round,
+  in situ, on the same readers as the arms. Deliberately the same shape and
+  the same 587,500 doubles `rf2-2rtt6.5` used, so the control error here is
+  directly comparable with the +0.001% that page recorded."
+  [n]
+  (let [a (js/Array. n)]
+    (dotimes [i n] (aset a i (+ i 0.5)))
+    (reset! control-cell a)
+    (.-length a)))
+
+(defn control-release! [] (reset! control-cell nil) 0)
+
+;; ---------------------------------------------------------------------------
+;; The page-side door
+;; ---------------------------------------------------------------------------
+
+(defn install!
+  "Publish the instrument on `window.ABL` for the CDP driver, which owns the
+  collector and all three heap readers. The page mounts; it never decides
+  when a reading is taken."
+  [substrate]
+  (reset! installed (arms substrate))
+  (set! (.-ABL js/window)
+        #js {:mount          (fn [arm] (mount! (keyword arm)))
+             :release        (fn [] (release!*) true)
+             :control        (fn [n] (control! n))
+             :controlRelease (fn [] (control-release!))
+             :perfMem        (fn []
+                               (if-some [m (.-memory js/performance)]
+                                 (.-usedJSHeapSize m)
+                                 -1))
+             :substrate      (name substrate)
+             :plan           (clj->js {:boundaries boundaries
+                                       :reads      reads-rungs
+                                       :cells      cells-needed})
+             ;; `(subs (str kw) 1)`, NOT `name` — `name` drops the namespace,
+             ;; so every arm would reach the driver with the variant half
+             ;; missing and nothing to parse.
+             :arms           (into-array (map #(subs (str %) 1)
+                                              (keys @installed)))})
+  nil)

--- a/implementation/freehand/test/re_frame/freehand/bench/spine_ablation.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/spine_ablation.cljs
@@ -136,6 +136,20 @@
   (* boundaries (apply max reads-rungs)))
 
 ;; ---------------------------------------------------------------------------
+;; The witness counters
+;; ---------------------------------------------------------------------------
+
+(def ^:private witness
+  "Plain counters for the WITNESS probe. Declared here because the witness
+  sub body (below) increments one of them.
+
+    bodyRuns  — sub-body invocations
+    commits   — commit-phase `subscribe-fn` calls, i.e. reads that mounted
+    rebuilt   — commit-phase acquisitions whose reaction is NOT `identical?`
+                to the render-phase handle the same read is holding"
+  (js-obj "bodyRuns" 0 "commits" 0 "rebuilt" 0))
+
+;; ---------------------------------------------------------------------------
 ;; The store
 ;; ---------------------------------------------------------------------------
 
@@ -151,6 +165,19 @@
 
 (rf/reg-sub :abl/cell
   (fn [db [_ i]] (nth (:cells db) i)))
+
+;; ---- the witness sub (see the WITNESS section at the foot of this file) ----
+;;
+;; Identical body to `:abl/cell`, plus a counter. It exists so the
+;; double-registration claim can be settled by COUNTING rather than by
+;; weighing: a count is immune to every fault a heap instrument has, and
+;; fifteen instrument faults have been caught on these surfaces. It is
+;; never read by an arm in the heap table — a sub body with a side effect
+;; has no business on a page that is pricing retention.
+(rf/reg-sub :abl/witness-cell
+  (fn [db [_ i]]
+    (aset witness "bodyRuns" (inc (aget witness "bodyRuns")))
+    (nth (:cells db) i)))
 
 (defn ensure-frame! []
   (rf/make-frame {:id frame-id :initial-events [[:abl/seed cells-needed]]}))
@@ -570,6 +597,145 @@
          :ok         (= elements boundaries)}))
 
 ;; ---------------------------------------------------------------------------
+;; THE WITNESS — the same claim, settled by counting
+;; ---------------------------------------------------------------------------
+;;
+;; Everything above is a heap measurement, and a heap measurement on this
+;; surface is guilty until it has produced a control. The central claim —
+;; that a UIx read with no live cache entry BUILDS TWO REACTIONS and keeps
+;; the first — is not really a claim about bytes at all. It is a claim about
+;; COUNTS, and counts can be read exactly.
+;;
+;; So: mount a small grid whose reads go through a transcription that is
+;; `use-sub-xcript` PLUS three counter increments, and read the counters
+;; back. The witness components never appear in the heap table (a sub body
+;; with a side effect has no business on a page pricing retention) and the
+;; heap arms never touch the witness sub. The two halves of this file check
+;; each other and share nothing but the frame.
+;;
+;; PREDICTED BEFORE THE RUN, for `n` boundaries x `r` reads = N reads:
+;;
+;;   uix      commits N,  rebuilt N,  bodyRuns 2N
+;;   reagent  commits 0,  rebuilt 0,  bodyRuns  N
+;;
+;; `rebuilt = N` is the whole finding: EVERY read's commit-phase acquire
+;; hands back a DIFFERENT reaction object from the one the render phase
+;; already built and the fiber is still holding. `bodyRuns = 2N` is its
+;; shadow — the second reaction's first deref re-runs the user's sub body.
+;; A `rebuilt` of 0 would falsify the finding outright.
+
+(defn- use-sub-witness [frame-kw query-v]
+  (let [key-ref       (react/useRef nil)
+        committed-ref (react/useRef nil)
+        stable-key      (stable-key-of key-ref frame-kw query-v)
+        stable-frame-kw (aget stable-key 0)
+        stable-query-v  (aget stable-key 1)
+        reaction
+        (uix-hooks/use-memo
+          (fn []
+            (let [r (subs/subscribe stable-query-v {:frame stable-frame-kw})]
+              (subs/unsubscribe stable-frame-kw stable-query-v)
+              r))
+          #js [stable-key])
+        get-snap
+        (uix-hooks/use-callback
+          (fn []
+            (let [stored (.-current committed-ref)
+                  r      (if (and stored
+                                  (identical? (aget stored 0) stable-key))
+                           (aget stored 1)
+                           reaction)]
+              (when r @r)))
+          #js [stable-key reaction])
+        subscribe-fn
+        (uix-hooks/use-callback
+          (fn [on-change]
+            (let [committed (subs/subscribe stable-query-v
+                                            {:frame stable-frame-kw})]
+              (aset witness "commits" (inc (aget witness "commits")))
+              ;; THE WITNESS. `reaction` is the handle the render phase built
+              ;; and the fiber is still holding; `committed` is what the
+              ;; commit-phase acquire just returned. Not `identical?` means
+              ;; the render-phase one was disposed and evicted between the
+              ;; two calls and a second reaction was built to replace it.
+              (when-not (identical? committed reaction)
+                (aset witness "rebuilt" (inc (aget witness "rebuilt"))))
+              (set! (.-current committed-ref) #js [stable-key committed])
+              (let [k (keyword watch-ns (str (gensym "watch-")))]
+                (when committed
+                  (add-watch committed k (fn [_ _ _ _] (on-change))))
+                (fn unsubscribe []
+                  (when committed (remove-watch committed k))
+                  (let [stored (.-current committed-ref)]
+                    (when (and stored (identical? (aget stored 1) committed))
+                      (set! (.-current committed-ref) nil)))
+                  (subs/unsubscribe stable-frame-kw stable-query-v)))))
+          #js [stable-key reaction])]
+    (react/useSyncExternalStore subscribe-fn get-snap get-snap)))
+
+(defn- w [i] (use-sub-witness frame-id [:abl/witness-cell i]))
+
+(defui w-cell [{:keys [base]}]
+  (let [v (+ (w (+ base 0)) (w (+ base 1)) (w (+ base 2)))]
+    ($ :span.wcell {:data-i base} (str v))))
+
+(defui w-grid [{:keys [n offset]}]
+  ($ :div.wab
+     (for [i (range n)]
+       ($ w-cell {:key i :base (+ offset (* i 3))}))))
+
+(defn- w-rg-cell [base]
+  (let [v (loop [k 0 acc 0]
+            (if (< k 3)
+              (recur (inc k)
+                     (+ acc @(rf/subscribe [:abl/witness-cell (+ base k)]
+                                           {:frame frame-id})))
+              acc))]
+    [:span.wcell {:data-i base} (str v)]))
+
+(defn- w-rg-grid [n offset]
+  (into [:div.wab]
+        (map (fn [i] ^{:key i} [w-rg-cell (+ offset (* i 3))]))
+        (range n)))
+
+(defn witness!
+  "Mount `n` witness boundaries of 3 reads each on `substrate`, read the
+  counters, unmount, and answer the counts beside the read count they are
+  to be compared against. Fresh counters per call, and a fresh subtree of
+  cells per call (`offset`) so no call can be served by another's cache
+  entries."
+  [substrate n offset]
+  (aset witness "bodyRuns" 0)
+  (aset witness "commits" 0)
+  (aset witness "rebuilt" 0)
+  (let [c  (container!)
+        rt (case (keyword substrate)
+             :uix     (let [rt (uix-dom/create-root c)]
+                        (react-dom/flushSync
+                          (fn [] (uix-dom/render-root
+                                   ($ w-grid {:n n :offset offset}) rt)))
+                        rt)
+             :reagent (let [rt (rdc/create-root c)]
+                        (react-dom/flushSync
+                          (fn [] (rdc/render rt [w-rg-grid n offset])))
+                        rt))
+        elements (.-length (.querySelectorAll js/document ".wcell"))
+        out #js {:reads    (* n 3)
+                 :offset   offset
+                 :elements elements
+                 :expected n
+                 :ok       (= elements n)
+                 :bodyRuns (aget witness "bodyRuns")
+                 :commits  (aget witness "commits")
+                 :rebuilt  (aget witness "rebuilt")}]
+    (react-dom/flushSync
+      (fn [] (case (keyword substrate)
+               :uix     (uix-dom/unmount-root rt)
+               :reagent (rdc/unmount rt))))
+    (.remove c)
+    out))
+
+;; ---------------------------------------------------------------------------
 ;; The positive control
 ;; ---------------------------------------------------------------------------
 
@@ -608,6 +774,7 @@
              :release        (fn [] (release!*) true)
              :control        (fn [n] (control! n))
              :controlRelease (fn [] (control-release!))
+             :witness        (fn [n offset] (witness! substrate n offset))
              :perfMem        (fn []
                                (if-some [m (.-memory js/performance)]
                                  (.-usedJSHeapSize m)

--- a/implementation/freehand/test/re_frame/freehand/bench/spine_ablation_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/spine_ablation_app.cljs
@@ -1,0 +1,57 @@
+(ns re-frame.freehand.bench.spine-ablation-app
+  "The UIx spine per-read ablation's `:advanced` entry — one bundle, one
+  substrate per page load.
+
+  Read from the artefact a consumer ships (`:advanced`, `goog.DEBUG
+  false`) for the reason B7's entry gives: Spec 009 instrumentation,
+  schema validation and trace emission are all `goog.DEBUG`-gated, all sit
+  on the subscription path being priced, and a development build would
+  charge the re-frame2 side of every arm for machinery a release bundle
+  does not contain. `:advanced` cannot compile shadow's `:browser-test`
+  target, so the reading needs a plain `:browser` entry — this one.
+
+  `?adapter=uix` and `?adapter=reagent` are two PAGE LOADS of the same
+  bundle, not two modes. `rf/init!` installs at most one adapter per JS
+  context and silently keeps the first, so one page cannot host both; a
+  fresh context per substrate is the only honest way to run them, and each
+  page carries its own floor arm so no subtraction crosses the page
+  boundary.
+
+  The page installs the instrument on `window.ABL` and then does nothing
+  at all. Heap readings belong to the DRIVER, which owns the collector: a
+  page cannot force a garbage collection, and a page that tried to decide
+  when a reading was taken would be reading whatever the collector
+  happened to have done.
+
+  Built and driven by
+  `implementation/freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs`."
+  (:require [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.freehand.bench.spine-ablation :as abl]))
+
+(defn- fail! [why]
+  (set! (.-ABL_ERROR js/window) (str why))
+  (js/console.error (str ";; ABLATION FAILED — " why)))
+
+(defn- requested-substrate []
+  (let [v (.get (js/URLSearchParams. (.-search js/location)) "adapter")]
+    (case v
+      "reagent" :reagent
+      "uix"     :uix
+      nil)))
+
+(defn ^:export -main []
+  (try
+    (if-some [substrate (requested-substrate)]
+      (do
+        (rf/init! (case substrate
+                    :reagent reagent-adapter/adapter
+                    :uix     uix-adapter/adapter))
+        (abl/ensure-frame!)
+        (abl/install! substrate)
+        (set! (.-ABL_READY js/window) true))
+      (fail! (str "no ?adapter=uix|reagent on the query string — this bundle "
+                  "runs one substrate per page load")))
+    (catch :default e
+      (fail! (str "boot threw: " (.-message e))))))

--- a/implementation/freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs
@@ -1,0 +1,692 @@
+#!/usr/bin/env node
+// THE UIx SPINE PER-READ ABLATION — driver.
+//
+//   node implementation/freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs
+//   ABL_ROUNDS=6 ABL_SNAP_ROUNDS=2 node .../spine_ablation_run.cjs
+//   ABL_SUBSTRATES=uix node .../spine_ablation_run.cjs      # one page only
+//
+// Bead rf2-2rtt6.12, epic rf2-2rtt6 (EP-0038). Reports into
+// docs/design/hicasso/studio/uix-spine-per-read-decomposition.md.
+//
+// ## What this measures, and the fault it is built around
+//
+// RETENTION, never allocation. V8's CDP *sampling* heap profiler drops the
+// samples of collected objects: pointed at a mount/unmount loop it reports
+// the residue of a page that has already been discarded, not the cost of
+// the page — the same 80,000 objects read 4.77 MB when a global held them
+// and 0.00 MB when nothing did. That fault has already produced one wrong
+// table on this surface. So a reading here is: MOUNT AN ARM AND KEEP IT,
+// force a full collection, read the heap; release, collect, read again.
+//
+// ## Why an ablation needs a fidelity control, and what happens without one
+//
+// The whole instrument turns on subtracting one variant from another. That
+// is only attributable if the transcribed-but-unablated arm (`xcript`)
+// reproduces the SHIPPED hook (`uix`). If it does not, the transcription
+// prices something else and every difference taken from it is void. This
+// driver computes that check, prints it first, and marks the decomposition
+// NOT ATTRIBUTABLE when the two arms' per-read ranges do not overlap. It
+// does not exit non-zero for it — a failed fidelity check is a finding
+// about the instrument, and suppressing the table would hide the evidence
+// that says so.
+//
+// ## Readers
+//
+//   A  CDP `Runtime.getHeapUsage().usedSize`, after 3x collectGarbage.
+//   B  in-page `performance.memory.usedJSHeapSize`, same moment, under
+//      `--enable-precise-memory-info`.
+//   C  a full heap SNAPSHOT: every node's `self_size` summed AND every node
+//      COUNTED by a streaming scan, as its own pass.
+//
+// A and B are NOT independent — two doors onto one V8 counter. C walks the
+// object graph, and it is the only reader that answers the question this
+// bead was filed about: `rf2-2rtt6.5` attributed the 3.77x gap to object
+// COUNT (128.5/read against Reagent's 36.2), so C's node delta is the
+// headline signal here and bytes are the cross-check, the reverse of the
+// ladder's emphasis.
+//
+// ## The positive control
+//
+// A dense JS array of N doubles, which V8 stores as N unboxed 8-byte slots,
+// so its retained size is 8N bytes PREDICTED BEFORE ANYTHING IS MEASURED.
+// It rides EVERY round, in situ, read by the same instrument as the arms.
+// Deliberately the same 587,500 doubles = 4,700,000 B rf2-2rtt6.5 used, so
+// the error here is directly comparable with the +0.001% that page landed.
+// A heap number without a control is not a measurement.
+//
+// ## Order
+//
+// `order_guard.schedule` rotates AND REFLECTS with the round, so every arm
+// is measured after at least two distinct predecessors and both whole-plan
+// orders run. Even rounds are FORWARD, odd rounds REVERSED, and the report
+// carries the two separately — position dominates adjacency, so the pair is
+// there to show the figure does not move, not to average. `verdict` refuses
+// on a contaminated OR an unchecked arm and this driver EXITS 2 on refusal.
+// Repair the arm, not the guard.
+
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+const guard = require('./order_guard.cjs');
+const { navigate, NAV_TIMEOUT_MS } = require('./navigate.cjs');
+
+const IMPL = path.resolve(__dirname, '../../../../..');
+// FORWARD SLASHES, and not by accident. `:output-dir` is spliced into the
+// `--config-merge` EDN string below, and on Windows `path.join('out',
+// 'spine-ablation')` yields `out\spine-ablation` whose `\s` the EDN reader
+// mangles: shadow-cljs then writes to a filename the OS will not accept.
+// Seen once, on the reads ladder.
+const OUT_DIR = process.env.ABL_OUT_DIR || 'out/spine-ablation';
+const OUT = path.resolve(IMPL, OUT_DIR);
+const PORT = Number(process.env.ABL_PORT || 8139);
+
+const ROUNDS = Number(process.env.ABL_ROUNDS || 4);
+const SNAP_ROUNDS = Number(process.env.ABL_SNAP_ROUNDS || 2);
+const SUBSTRATES = (process.env.ABL_SUBSTRATES || 'uix,reagent')
+  .split(',').map((s) => s.trim()).filter(Boolean);
+const CONTROL_DOUBLES = Number(process.env.ABL_CONTROL_DOUBLES || 587500);
+const CONTROL_PREDICTED = CONTROL_DOUBLES * 8;
+// A relative difference of medians, matching B7's and the ladder's. A
+// retention reading taken across a mount/collect/release cycle moves several
+// percent between rounds, so this sits above that and far below the 2.01x
+// the recorded fault made.
+const TOLERANCE = Number(process.env.ABL_TOLERANCE || 0.25);
+const INIT_FN = 're-frame.freehand.bench.spine-ablation-app/-main';
+
+// ---------------------------------------------------------------------------
+// Build and serve
+// ---------------------------------------------------------------------------
+
+// ONE LINE, deliberately: shadow-cljs's CLI re-splits `--config-merge` on
+// whitespace when the EDN contains a newline and then reports `EOF while
+// reading` from a fragment.
+const CONFIG_MERGE =
+  `{:output-dir "${OUT_DIR}" :asset-path "." ` +
+  `:modules {:main {:init-fn ${INIT_FN}}}}`;
+
+function build() {
+  console.error('[abl] building :advanced bundle ...');
+  const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+  const r = spawnSync(
+    process.execPath,
+    [runner, 'release', 'freehand-release', '--config-merge', CONFIG_MERGE],
+    { cwd: IMPL, stdio: ['ignore', 'inherit', 'inherit'] }
+  );
+  if (r.status !== 0) {
+    console.error(`[abl] build failed with status ${r.status}`);
+    process.exit(1);
+  }
+}
+
+const MIME = { '.js': 'text/javascript', '.html': 'text/html', '.map': 'application/json' };
+
+function serve() {
+  fs.writeFileSync(
+    path.join(OUT, 'index.html'),
+    '<!doctype html><html><head><meta charset="utf-8"><title>spine ablation</title></head>' +
+      '<body><div id="app"></div><script src="main.js"></script></body></html>'
+  );
+  return http
+    .createServer((req, res) => {
+      const rel = decodeURIComponent(req.url.split('?')[0]);
+      const file = path.join(OUT, rel === '/' ? 'index.html' : rel);
+      if (!file.startsWith(OUT) || !fs.existsSync(file)) {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      fs.createReadStream(file).pipe(res);
+    })
+    .listen(PORT);
+}
+
+// ---------------------------------------------------------------------------
+// The collector and the readers
+// ---------------------------------------------------------------------------
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function newPage(chromium, query, budget) {
+  const browser = await chromium.launch({
+    args: ['--enable-precise-memory-info', '--js-flags=--expose-gc'],
+  });
+  const page = await browser.newPage();
+  page.on('pageerror', (e) => console.error('[abl] page error:', e.message));
+  // `'commit'`, not `'load'` (rf2-p9fa3): the bundle's `:init-fn` runs
+  // synchronously inside the `<script>`, so the load event is downstream of
+  // work this driver budgets separately.
+  await navigate(page, `http://127.0.0.1:${PORT}/${query}`, {
+    waitUntil: 'commit',
+    timeoutMs: NAV_TIMEOUT_MS,
+    budget,
+  });
+  return { browser, page };
+}
+
+async function makeReaders(page) {
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('HeapProfiler.enable');
+  await cdp.send('Runtime.enable');
+
+  // Three collections with a beat between them. One is not enough: React
+  // roots die in stages (fibers, then the host instances they point at),
+  // and a single pass leaves the second stage standing.
+  const gc = async () => {
+    for (let i = 0; i < 3; i++) {
+      await cdp.send('HeapProfiler.collectGarbage');
+      await sleep(80);
+    }
+  };
+
+  const read = async () => {
+    const { usedSize } = await cdp.send('Runtime.getHeapUsage');
+    const perf = await page.evaluate(() => window.ABL.perfMem());
+    return { cdp: usedSize, perf };
+  };
+
+  return { cdp, gc, read };
+}
+
+// Sum every node's `self_size` AND count the nodes out of a streaming heap
+// snapshot. The snapshot arrives as JSON text in chunks and can be hundreds
+// of megabytes, so it is never assembled or `JSON.parse`d: `nodes` is a flat
+// run of integers, `node_fields` names the stride, and this consumes complete
+// integers per chunk and carries the partial one. It is the only reader here
+// that walks the object graph, which is what makes it a check on the other
+// two rather than a restatement of them — and the node COUNT it yields is
+// this bead's headline signal.
+function snapshotTotal(cdp) {
+  return new Promise((resolve, reject) => {
+    let phase = 0;
+    let buf = '';
+    let nFields = 0;
+    let selfIdx = -1;
+    let idx = 0;
+    let total = 0;
+    let nodeCount = 0;
+
+    const onChunk = ({ chunk }) => {
+      if (phase === 2) return;
+      buf += chunk;
+      if (phase === 0) {
+        const at = buf.indexOf('"nodes":[');
+        if (at === -1) return;
+        const fm = /"node_fields":\s*\[([^\]]*)\]/.exec(buf.slice(0, at));
+        if (!fm) { phase = 2; reject(new Error('node_fields absent from snapshot header')); return; }
+        const fields = fm[1].split(',').map((s) => s.trim().replace(/^"|"$/g, ''));
+        nFields = fields.length;
+        selfIdx = fields.indexOf('self_size');
+        if (selfIdx < 0) { phase = 2; reject(new Error('self_size absent from node_fields')); return; }
+        buf = buf.slice(at + '"nodes":['.length);
+        phase = 1;
+      }
+      let last = 0;
+      let done = false;
+      for (let i = 0; i < buf.length; i++) {
+        const c = buf.charCodeAt(i);
+        if (c === 44 || c === 93) {
+          const s = buf.slice(last, i);
+          if (s.length) {
+            if (idx % nFields === selfIdx) total += Number(s);
+            if (idx % nFields === 0) nodeCount++;
+            idx++;
+          }
+          last = i + 1;
+          if (c === 93) { done = true; break; }
+        }
+      }
+      buf = done ? '' : buf.slice(last);
+      if (done) phase = 2;
+    };
+
+    cdp.on('HeapProfiler.addHeapSnapshotChunk', onChunk);
+    cdp.send('HeapProfiler.takeHeapSnapshot', { reportProgress: false })
+      .then(() => { cdp.off('HeapProfiler.addHeapSnapshotChunk', onChunk); resolve({ totalSelfSize: total, nodeCount }); })
+      .catch((e) => { cdp.off('HeapProfiler.addHeapSnapshotChunk', onChunk); reject(e); });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Arm naming — the plan is derived from the page, never assumed here
+// ---------------------------------------------------------------------------
+
+// `floor/r0-b1200`, `uix/r7-b1200`, `noretain/r3-b1200`. The driver PARSES
+// rather than reconstructs, so a rename in the CLJS cannot silently
+// desynchronise the two halves of the instrument.
+function parseArm(id) {
+  const m = /^([a-z]+)\/r(\d+)-b(\d+)$/.exec(id);
+  if (!m) throw new Error(`unparseable arm id: ${id}`);
+  return { id, variant: m[1], reads: Number(m[2]), boundaries: Number(m[3]) };
+}
+
+const floorFor = (arms) => arms.find((a) => a.variant === 'floor');
+
+// ---------------------------------------------------------------------------
+// One page
+// ---------------------------------------------------------------------------
+
+async function runSubstrate(chromium, substrate) {
+  const { browser, page } = await newPage(
+    chromium, `?adapter=${substrate}`, `the 120s wait for window.ABL_READY (${substrate})`
+  );
+  await page.waitForFunction(
+    'window.ABL_READY === true || window.ABL_ERROR', null, { timeout: 120000 }
+  );
+  const err = await page.evaluate('window.ABL_ERROR || null');
+  if (err) { await browser.close(); throw new Error(`${substrate} page failed to initialise: ${err}`); }
+
+  const armIds = await page.evaluate(() => Array.from(window.ABL.arms));
+  const plan = await page.evaluate(() => window.ABL.plan);
+  const arms = armIds.map(parseArm);
+  const { cdp, gc, read } = await makeReaders(page);
+
+  const rounds = [];
+  const orderSamples = [];
+  let position = 0;
+  let previous = null;
+  let unverified = 0;
+  let mounts = 0;
+
+  // A WARM-UP PASS, mounted and released once per arm and never read. The
+  // first mount of any arm allocates things that are not the page and never
+  // go away: compiled code for the paths it just took, inline caches,
+  // interned keywords, one-time module state. Charged to round 1 they read
+  // as retention per boundary, and they are not. Position dominates
+  // adjacency, so this pass matters more than the interleaving does.
+  console.error(`[abl] ${substrate}: warm-up pass over ${arms.length} arms ...`);
+  for (const a of arms) {
+    const v = await page.evaluate((id) => window.ABL.mount(id), a.id);
+    mounts++;
+    if (!v.ok) { unverified++; console.error(`[abl] UNVERIFIED warm-up ${a.id}: ${v.elements}/${v.expected}`); }
+    await page.evaluate(() => window.ABL.release());
+  }
+  await page.evaluate((n) => window.ABL.control(n), CONTROL_DOUBLES);
+  await page.evaluate(() => window.ABL.controlRelease());
+
+  for (let round = 0; round < ROUNDS; round++) {
+    console.error(`[abl] ${substrate}: round ${round + 1}/${ROUNDS} (${round % 2 ? 'REVERSED' : 'FORWARD'})`);
+
+    // --- the positive control, IN SITU, before this round's arms ---------
+    await gc();
+    const ctlBefore = await read();
+    const ctlLen = await page.evaluate((n) => window.ABL.control(n), CONTROL_DOUBLES);
+    await gc();
+    const ctlHeld = await read();
+    await page.evaluate(() => window.ABL.controlRelease());
+    await gc();
+    const ctlAfter = await read();
+    const control = {
+      doubles: ctlLen,
+      predictedBytes: CONTROL_PREDICTED,
+      measuredCdp: ctlHeld.cdp - (ctlBefore.cdp + ctlAfter.cdp) / 2,
+      measuredPerf: ctlHeld.perf - (ctlBefore.perf + ctlAfter.perf) / 2,
+      baselineDriftCdp: ctlAfter.cdp - ctlBefore.cdp,
+    };
+    control.errorCdp = control.measuredCdp / CONTROL_PREDICTED - 1;
+    control.errorPerf = control.measuredPerf / CONTROL_PREDICTED - 1;
+
+    // --- the arms, rotating AND REFLECTING with the round ----------------
+    const byArm = {};
+    for (const j of guard.schedule(arms.length, round)) {
+      const a = arms[j];
+      await gc();
+      const pre = await read();
+      const verify = await page.evaluate((id) => window.ABL.mount(id), a.id);
+      mounts++;
+      if (!verify.ok) { unverified++; console.error(`[abl] UNVERIFIED ${a.id}: ${verify.elements}/${verify.expected}`); }
+      await gc();
+      const held = await read();
+      await page.evaluate(() => window.ABL.release());
+      await gc();
+      const post = await read();
+      byArm[a.id] = {
+        verify,
+        boundaries: a.boundaries,
+        retainedCdp: held.cdp - pre.cdp,
+        retainedPerf: held.perf - pre.perf,
+        residueCdp: post.cdp - pre.cdp,
+        bytesPerBoundaryCdp: (held.cdp - pre.cdp) / a.boundaries,
+        raw: { pre, held, post },
+      };
+      orderSamples.push({
+        arm: a.id,
+        value: byArm[a.id].bytesPerBoundaryCdp,
+        predecessor: previous,
+        position: position++,
+      });
+      previous = a.id;
+    }
+    rounds.push({ round, order: round % 2 ? 'reversed' : 'forward', control, arms: byArm });
+  }
+
+  // --- the independent reader, as its own pass --------------------------
+  // Reader C over EVERY arm, in its own rounds, because the node COUNT it
+  // yields is the signal this bead exists to explain. Its rounds rotate and
+  // reflect on the same schedule, so the count carries a range too.
+  const snapRounds = [];
+  let snapError = null;
+  if (SNAP_ROUNDS > 0) {
+    try {
+      for (let round = 0; round < SNAP_ROUNDS; round++) {
+        console.error(`[abl] ${substrate}: snapshot round ${round + 1}/${SNAP_ROUNDS}`);
+        const byArm = {};
+        for (const j of guard.schedule(arms.length, round)) {
+          const a = arms[j];
+          await gc();
+          const pre = await snapshotTotal(cdp);
+          const verify = await page.evaluate((id) => window.ABL.mount(id), a.id);
+          mounts++;
+          if (!verify.ok) { unverified++; console.error(`[abl] UNVERIFIED snap ${a.id}`); }
+          await gc();
+          const held = await snapshotTotal(cdp);
+          await page.evaluate(() => window.ABL.release());
+          byArm[a.id] = {
+            verify,
+            boundaries: a.boundaries,
+            retained: held.totalSelfSize - pre.totalSelfSize,
+            nodes: held.nodeCount - pre.nodeCount,
+            bytesPerBoundary: (held.totalSelfSize - pre.totalSelfSize) / a.boundaries,
+            nodesPerBoundary: (held.nodeCount - pre.nodeCount) / a.boundaries,
+          };
+        }
+        // The control rides the snapshot pass too — reader C is the reader
+        // that walks the graph, so it is the one whose 8N prediction most
+        // needs checking, and B7's fictional control was caught exactly here.
+        await gc();
+        const cpre = await snapshotTotal(cdp);
+        await page.evaluate((n) => window.ABL.control(n), CONTROL_DOUBLES);
+        await gc();
+        const cheld = await snapshotTotal(cdp);
+        await page.evaluate(() => window.ABL.controlRelease());
+        snapRounds.push({
+          round,
+          arms: byArm,
+          control: {
+            predictedBytes: CONTROL_PREDICTED,
+            measured: cheld.totalSelfSize - cpre.totalSelfSize,
+            error: (cheld.totalSelfSize - cpre.totalSelfSize) / CONTROL_PREDICTED - 1,
+          },
+        });
+      }
+    } catch (e) {
+      snapError = String(e && e.message ? e.message : e);
+      console.error(`[abl] snapshot pass failed: ${snapError}`);
+    }
+  }
+
+  await browser.close();
+  return {
+    substrate,
+    plan,
+    arms: arms.map((a) => a.id),
+    verification: { mounts, unverified },
+    perRound: rounds,
+    orderVerdict: guard.verdict(orderSamples, { tolerance: TOLERANCE }),
+    snapRounds,
+    snapError,
+    variants: variantCurves(arms, rounds, snapRounds),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// One line per variant, fitted PER ROUND and only then summarised
+// ---------------------------------------------------------------------------
+
+const median = guard.median;
+const rangeOf = (xs) =>
+  xs.length
+    ? { n: xs.length, min: Math.min(...xs), p50: median(xs), max: Math.max(...xs) }
+    : { n: 0, min: NaN, p50: NaN, max: NaN };
+
+// Ordinary least squares. Returned with r2 so a curve that is not a line
+// cannot be reported as one by accident.
+function fit(points) {
+  const n = points.length;
+  const sx = points.reduce((t, p) => t + p.x, 0);
+  const sy = points.reduce((t, p) => t + p.y, 0);
+  const sxx = points.reduce((t, p) => t + p.x * p.x, 0);
+  const sxy = points.reduce((t, p) => t + p.x * p.y, 0);
+  const slope = (n * sxy - sx * sy) / (n * sxx - sx * sx);
+  const intercept = (sy - slope * sx) / n;
+  const ss = points.reduce((t, p) => t + Math.pow(p.y - (slope * p.x + intercept), 2), 0);
+  const my = sy / n;
+  const tot = points.reduce((t, p) => t + Math.pow(p.y - my, 2), 0);
+  return { slope, intercept, r2: tot === 0 ? 1 : 1 - ss / tot };
+}
+
+function variantCurves(arms, rounds, snapRounds) {
+  const floor = floorFor(arms);
+  const names = [...new Set(arms.map((a) => a.variant))].filter((v) => v !== 'floor');
+  const out = {};
+
+  for (const v of names) {
+    const vArms = arms.filter((a) => a.variant === v).sort((p, q) => p.reads - q.reads);
+
+    // Reader A — bytes.
+    const byteFits = { forward: [], reversed: [], all: [] };
+    const perRung = {};
+    for (const r of rounds) {
+      const pts = vArms.map((a) => ({
+        x: a.reads,
+        y: (r.arms[a.id].retainedCdp - r.arms[floor.id].retainedCdp) / a.boundaries,
+        arm: a.id,
+      }));
+      for (const p of pts) (perRung[p.arm] = perRung[p.arm] || []).push(p.y);
+      const f = fit(pts);
+      byteFits.all.push(f);
+      byteFits[r.order].push(f);
+    }
+
+    // Reader C — bytes AND nodes, from the snapshot rounds.
+    const nodeFits = [];
+    const snapByteFits = [];
+    const perRungNodes = {};
+    for (const r of snapRounds) {
+      if (!r.arms[floor.id]) continue;
+      const nPts = vArms.map((a) => ({
+        x: a.reads,
+        y: (r.arms[a.id].nodes - r.arms[floor.id].nodes) / a.boundaries,
+        arm: a.id,
+      }));
+      const bPts = vArms.map((a) => ({
+        x: a.reads,
+        y: (r.arms[a.id].retained - r.arms[floor.id].retained) / a.boundaries,
+        arm: a.id,
+      }));
+      for (const p of nPts) (perRungNodes[p.arm] = perRungNodes[p.arm] || []).push(p.y);
+      nodeFits.push(fit(nPts));
+      snapByteFits.push(fit(bPts));
+    }
+
+    out[v] = {
+      bytesPerRead: rangeOf(byteFits.all.map((f) => f.slope)),
+      bytesPerBoundary: rangeOf(byteFits.all.map((f) => f.intercept)),
+      r2: rangeOf(byteFits.all.map((f) => f.r2)),
+      forward: rangeOf(byteFits.forward.map((f) => f.slope)),
+      reversed: rangeOf(byteFits.reversed.map((f) => f.slope)),
+      rungs: Object.fromEntries(Object.entries(perRung).map(([k, x]) => [k, rangeOf(x)])),
+      objectsPerRead: rangeOf(nodeFits.map((f) => f.slope)),
+      objectsPerBoundary: rangeOf(nodeFits.map((f) => f.intercept)),
+      objectsR2: rangeOf(nodeFits.map((f) => f.r2)),
+      snapshotBytesPerRead: rangeOf(snapByteFits.map((f) => f.slope)),
+      nodeRungs: Object.fromEntries(Object.entries(perRungNodes).map(([k, x]) => [k, rangeOf(x)])),
+    };
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+const b = (v) => (Number.isFinite(v) ? Math.round(v).toLocaleString('en-US') : String(v));
+const n1 = (v) => (Number.isFinite(v) ? v.toFixed(1) : String(v));
+const pct = (v) => (Number.isFinite(v) ? `${(v * 100).toFixed(3)}%` : String(v));
+const overlap = (p, q) =>
+  Number.isFinite(p.min) && Number.isFinite(q.min) && p.min <= q.max && q.min <= p.max;
+
+// The difference of two variants' per-read lines, with a range that is the
+// WIDEST the two ranges admit rather than a difference of medians alone —
+// so a term whose sign is not settled by the data cannot be reported as
+// though it were.
+function delta(a, b_) {
+  if (!a || !b_) return null;
+  return {
+    p50: a.p50 - b_.p50,
+    min: a.min - b_.max,
+    max: a.max - b_.min,
+  };
+}
+const dstr = (d, f = b) => (d ? `${f(d.p50)}  [${f(d.min)}-${f(d.max)}]` : 'n/a');
+
+function report(all) {
+  const L = [];
+  const byName = Object.fromEntries(all.map((s) => [s.substrate, s]));
+  L.push(';; ================================================================');
+  L.push(';; UIx SPINE PER-READ ABLATION — rf2-2rtt6.12 (EP-0038 Wave 0)');
+  L.push(';; retention instrument, :advanced, headless Chromium');
+  L.push(';; ================================================================');
+
+  for (const s of all) {
+    const ctl = s.perRound.map((r) => r.control);
+    L.push('');
+    L.push(`;; ---- page ?adapter=${s.substrate} --------------------------------`);
+    L.push(`;; verification: ${s.verification.unverified} unverified of ${s.verification.mounts}`);
+    L.push(`;; IN-SITU POSITIVE CONTROL  predicted ${b(CONTROL_PREDICTED)} B`);
+    L.push(`;;   reader A  measured ${b(median(ctl.map((c) => c.measuredCdp)))} B  ` +
+           `[${b(Math.min(...ctl.map((c) => c.measuredCdp)))}-${b(Math.max(...ctl.map((c) => c.measuredCdp)))}]  ` +
+           `error ${pct(median(ctl.map((c) => c.errorCdp)))}`);
+    L.push(`;;   reader B  measured ${b(median(ctl.map((c) => c.measuredPerf)))} B  ` +
+           `error ${pct(median(ctl.map((c) => c.errorPerf)))}`);
+    if (s.snapRounds.length) {
+      const cs = s.snapRounds.map((r) => r.control);
+      L.push(`;;   reader C  measured ${b(median(cs.map((c) => c.measured)))} B  ` +
+             `error ${pct(median(cs.map((c) => c.error)))}`);
+    }
+    if (s.snapError) L.push(`;;   reader C FAILED: ${s.snapError}`);
+    L.push(`;;   ORDER GUARD: ${s.orderVerdict.refuse ? 'REFUSED' : 'clean'}` +
+           `${s.orderVerdict.contaminated ? ' (contaminated)' : ''}${s.orderVerdict.unchecked ? ' (unchecked)' : ''}`);
+
+    for (const [v, c] of Object.entries(s.variants)) {
+      L.push('');
+      L.push(`;;   VARIANT ${v}`);
+      for (const [arm, r] of Object.entries(c.rungs)) {
+        const reads = parseArm(arm).reads;
+        const nr = c.nodeRungs[arm];
+        L.push(`;;     R=${String(reads).padStart(2)}  ${b(r.p50).padStart(7)} B/boundary  ` +
+               `[${b(r.min)}-${b(r.max)}]` +
+               (nr && Number.isFinite(nr.p50) ? `   ${n1(nr.p50).padStart(7)} obj/boundary [${n1(nr.min)}-${n1(nr.max)}]` : ''));
+      }
+      L.push(`;;     => BYTES PER READ   ${b(c.bytesPerRead.p50)}  [${b(c.bytesPerRead.min)}-${b(c.bytesPerRead.max)}]  ` +
+             `(fwd ${b(c.forward.p50)} rev ${b(c.reversed.p50)})`);
+      L.push(`;;     => OBJECTS PER READ ${n1(c.objectsPerRead.p50)}  [${n1(c.objectsPerRead.min)}-${n1(c.objectsPerRead.max)}]  ` +
+             `reader C`);
+      L.push(`;;     => reader C bytes/read ${b(c.snapshotBytesPerRead.p50)}  ` +
+             `[${b(c.snapshotBytesPerRead.min)}-${b(c.snapshotBytesPerRead.max)}]`);
+      L.push(`;;     => PER-BOUNDARY SHELL ${b(c.bytesPerBoundary.p50)}  [${b(c.bytesPerBoundary.min)}-${b(c.bytesPerBoundary.max)}]`);
+      L.push(`;;        r2 ${c.r2.p50.toFixed(5)} [${c.r2.min.toFixed(5)}-${c.r2.max.toFixed(5)}]` +
+             (Number.isFinite(c.objectsR2.p50) ? `   obj r2 ${c.objectsR2.p50.toFixed(5)}` : ''));
+    }
+  }
+
+  // --- the fidelity check, and only then the decomposition ---------------
+  const U = byName.uix && byName.uix.variants;
+  const R = byName.reagent && byName.reagent.variants;
+  if (U && U.uix && U.xcript) {
+    const ok = overlap(U.uix.bytesPerRead, U.xcript.bytesPerRead);
+    L.push('');
+    L.push(';; ---- FIDELITY CONTROL --------------------------------------------');
+    L.push(`;;   shipped  uix     ${b(U.uix.bytesPerRead.p50)} B/read  [${b(U.uix.bytesPerRead.min)}-${b(U.uix.bytesPerRead.max)}]`);
+    L.push(`;;   copy     xcript  ${b(U.xcript.bytesPerRead.p50)} B/read  [${b(U.xcript.bytesPerRead.min)}-${b(U.xcript.bytesPerRead.max)}]`);
+    L.push(`;;   ranges ${ok ? 'OVERLAP — the transcription reproduces the shipped hook' : 'DO NOT OVERLAP — the transcription is NOT the shipped hook'}`);
+    L.push(`;;   => decomposition is ${ok ? 'ATTRIBUTABLE' : 'NOT ATTRIBUTABLE; every delta below is void'}`);
+  }
+  if (U && U.uix && U.noretain && U.hooks) {
+    L.push('');
+    L.push(';; ---- DECOMPOSITION of the shipped per-read cost --------------------');
+    L.push(`;;   retained render-phase reaction   xcript - noretain   ${dstr(delta(U.xcript.bytesPerRead, U.noretain.bytesPerRead))} B`);
+    L.push(`;;                                                        ${dstr(delta(U.xcript.objectsPerRead, U.noretain.objectsPerRead), n1)} obj`);
+    L.push(`;;   one live subscription            noretain - hooks    ${dstr(delta(U.noretain.bytesPerRead, U.hooks.bytesPerRead))} B`);
+    L.push(`;;                                                        ${dstr(delta(U.noretain.objectsPerRead, U.hooks.objectsPerRead), n1)} obj`);
+    L.push(`;;   React's six-hook stack           hooks               ${b(U.hooks.bytesPerRead.p50)}  [${b(U.hooks.bytesPerRead.min)}-${b(U.hooks.bytesPerRead.max)}] B`);
+    L.push(`;;                                                        ${n1(U.hooks.objectsPerRead.p50)}  [${n1(U.hooks.objectsPerRead.min)}-${n1(U.hooks.objectsPerRead.max)}] obj`);
+    if (R && R.reagent) {
+      L.push('');
+      L.push(`;;   Reagent, same subs, same page shape                  ${b(R.reagent.bytesPerRead.p50)}  [${b(R.reagent.bytesPerRead.min)}-${b(R.reagent.bytesPerRead.max)}] B`);
+      L.push(`;;                                                        ${n1(R.reagent.objectsPerRead.p50)}  [${n1(R.reagent.objectsPerRead.min)}-${n1(R.reagent.objectsPerRead.max)}] obj`);
+      L.push(`;;   shipped UIx / Reagent ratio                          ${(U.uix.bytesPerRead.p50 / R.reagent.bytesPerRead.p50).toFixed(3)}x`);
+      L.push(`;;   noretain  / Reagent ratio                            ${(U.noretain.bytesPerRead.p50 / R.reagent.bytesPerRead.p50).toFixed(3)}x`);
+    }
+  }
+  return L.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+(async () => {
+  // The guard's own self-test runs BEFORE the bundle is even built: an
+  // instrument whose refusal machinery is broken must not produce a table.
+  const st = guard.selfTest();
+  if (!st.ok) {
+    console.error('[abl] order-guard self-test FAILED — refusing to measure');
+    for (const c of st.checks) if (!c.ok) console.error(`  FAIL ${c.name} — ${c.detail || ''}`);
+    process.exit(1);
+  }
+  console.error(`[abl] order-guard self-test ok (${st.checks.length} checks)`);
+
+  fs.mkdirSync(OUT, { recursive: true });
+  build();
+  const server = serve();
+  const { chromium } = require('playwright');
+
+  const all = [];
+  try {
+    for (const s of SUBSTRATES) all.push(await runSubstrate(chromium, s));
+  } finally {
+    server.close();
+  }
+
+  const result = {
+    benchmark: 'hicasso:uix-spine-per-read-ablation',
+    bead: 'rf2-2rtt6.12',
+    epic: 'rf2-2rtt6',
+    rounds: ROUNDS,
+    snapRounds: SNAP_ROUNDS,
+    tolerance: TOLERANCE,
+    instruments: {
+      A: 'CDP Runtime.getHeapUsage().usedSize after 3x HeapProfiler.collectGarbage',
+      B: 'in-page performance.memory.usedJSHeapSize, same moment, --enable-precise-memory-info',
+      C: 'full heap snapshot, node self_size summed AND nodes counted by a streaming scan',
+      note: 'A and B are two doors onto one V8 counter and are NOT independent. C walks the object graph and is the object-COUNT reader.',
+    },
+    control: { shape: 'dense JS array of doubles', doubles: CONTROL_DOUBLES, predictedBytes: CONTROL_PREDICTED },
+    substrates: all,
+  };
+
+  fs.writeFileSync(path.join(OUT, 'spine-ablation.json'), JSON.stringify(result, null, 2));
+  const text = report(all);
+  console.log(text);
+  fs.writeFileSync(path.join(OUT, 'spine-ablation.txt'), text + '\n');
+  console.error(`[abl] wrote ${path.join(OUT, 'spine-ablation.json')}`);
+
+  const refused = all.filter((s) => s.orderVerdict.refuse);
+  const unverified = all.reduce((t, s) => t + s.verification.unverified, 0);
+  if (unverified > 0) {
+    console.error(`[abl] ${unverified} UNVERIFIED mounts — the DOM read-back did not match`);
+    process.exit(3);
+  }
+  if (refused.length) {
+    for (const s of refused) {
+      for (const line of guard.format(s.orderVerdict, `${s.substrate}: arm order`)) console.error(line);
+    }
+    console.error('[abl] ORDER GUARD REFUSED — repair the arm, not the guard');
+    process.exit(2);
+  }
+  console.error('[abl] done');
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/implementation/freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs
@@ -90,6 +90,19 @@ const SUBSTRATES = (process.env.ABL_SUBSTRATES || 'uix,reagent')
   .split(',').map((s) => s.trim()).filter(Boolean);
 const CONTROL_DOUBLES = Number(process.env.ABL_CONTROL_DOUBLES || 587500);
 const CONTROL_PREDICTED = CONTROL_DOUBLES * 8;
+// The witness grid: small, because it is counting and not weighing. 200
+// boundaries x 3 reads, and the two offsets below must keep every cell index
+// inside the seeded `cells-needed` (1,200 x 7 = 8,400).
+const WITNESS_BOUNDARIES = Number(process.env.ABL_WITNESS_BOUNDARIES || 200);
+// The fidelity control passes when the shipped arm's and the transcription's
+// per-read RANGES overlap, or — DECLARED HERE, BEFORE THE RUN, and not
+// afterwards — when their medians are within 3%. The second clause exists
+// because a range is a range across ROUNDS: at one round every range has
+// zero width and can never overlap, so overlap alone would make the control
+// unpassable at low round counts rather than strict. 3% is an order of
+// magnitude below the 22% term the ablation is here to resolve, so a band
+// this wide cannot manufacture the finding.
+const FIDELITY_BAND = Number(process.env.ABL_FIDELITY_BAND || 0.03);
 // A relative difference of medians, matching B7's and the ladder's. A
 // retention reading taken across a mount/collect/release cycle moves several
 // percent between rounds, so this sits above that and far below the 2.01x
@@ -284,6 +297,22 @@ async function runSubstrate(chromium, substrate) {
   const arms = armIds.map(parseArm);
   const { cdp, gc, read } = await makeReaders(page);
 
+  // --- THE WITNESS, first, because it is the claim ----------------------
+  // Counts, not bytes. 200 boundaries x 3 reads = 600 reads, twice, over
+  // DISJOINT cells so the second call cannot be served by the first's cache
+  // entries. Predicted before the run and printed against the prediction:
+  //   uix      commits 600, rebuilt 600, bodyRuns 1200
+  //   reagent  commits   0, rebuilt   0, bodyRuns  600
+  const witness = [];
+  let unverifiedWitness = 0;
+  for (const offset of [0, 900]) {
+    const w = await page.evaluate(
+      ([n, off]) => window.ABL.witness(n, off), [WITNESS_BOUNDARIES, offset]
+    );
+    witness.push(w);
+    if (!w.ok) { unverifiedWitness++; console.error(`[abl] UNVERIFIED witness ${substrate} offset ${offset}: ${w.elements}/${w.expected}`); }
+  }
+
   const rounds = [];
   const orderSamples = [];
   let position = 0;
@@ -423,7 +452,8 @@ async function runSubstrate(chromium, substrate) {
     substrate,
     plan,
     arms: arms.map((a) => a.id),
-    verification: { mounts, unverified },
+    witness,
+    verification: { mounts, unverified, unverifiedWitness },
     perRound: rounds,
     orderVerdict: guard.verdict(orderSamples, { tolerance: TOLERANCE }),
     snapRounds,
@@ -551,6 +581,23 @@ function report(all) {
   L.push(';; retention instrument, :advanced, headless Chromium');
   L.push(';; ================================================================');
 
+  // --- the witness first: counts, not bytes ------------------------------
+  L.push('');
+  L.push(';; ---- WITNESS — reactions built per read, by COUNT -----------------');
+  L.push(';;   PREDICTED before the run, for N reads:');
+  L.push(';;     uix      commits N, rebuilt N, bodyRuns 2N');
+  L.push(';;     reagent  commits 0, rebuilt 0, bodyRuns  N');
+  for (const s of all) {
+    for (const w of s.witness) {
+      const nn = w.reads;
+      L.push(`;;   ${s.substrate.padEnd(8)} offset ${String(w.offset).padStart(4)}  N=${nn}  ` +
+             `commits ${w.commits} (${(w.commits / nn).toFixed(2)}N)  ` +
+             `rebuilt ${w.rebuilt} (${(w.rebuilt / nn).toFixed(2)}N)  ` +
+             `bodyRuns ${w.bodyRuns} (${(w.bodyRuns / nn).toFixed(2)}N)  ` +
+             `${w.ok ? '' : 'DOM UNVERIFIED'}`);
+    }
+  }
+
   for (const s of all) {
     const ctl = s.perRound.map((r) => r.control);
     L.push('');
@@ -597,12 +644,15 @@ function report(all) {
   const U = byName.uix && byName.uix.variants;
   const R = byName.reagent && byName.reagent.variants;
   if (U && U.uix && U.xcript) {
-    const ok = overlap(U.uix.bytesPerRead, U.xcript.bytesPerRead);
+    const ovl = overlap(U.uix.bytesPerRead, U.xcript.bytesPerRead);
+    const rel = Math.abs(U.xcript.bytesPerRead.p50 / U.uix.bytesPerRead.p50 - 1);
+    const ok = ovl || rel <= FIDELITY_BAND;
     L.push('');
     L.push(';; ---- FIDELITY CONTROL --------------------------------------------');
     L.push(`;;   shipped  uix     ${b(U.uix.bytesPerRead.p50)} B/read  [${b(U.uix.bytesPerRead.min)}-${b(U.uix.bytesPerRead.max)}]`);
     L.push(`;;   copy     xcript  ${b(U.xcript.bytesPerRead.p50)} B/read  [${b(U.xcript.bytesPerRead.min)}-${b(U.xcript.bytesPerRead.max)}]`);
-    L.push(`;;   ranges ${ok ? 'OVERLAP — the transcription reproduces the shipped hook' : 'DO NOT OVERLAP — the transcription is NOT the shipped hook'}`);
+    L.push(`;;   ranges ${ovl ? 'OVERLAP' : 'do not overlap'};  medians ${pct(rel)} apart ` +
+           `(band ${pct(FIDELITY_BAND)})`);
     L.push(`;;   => decomposition is ${ok ? 'ATTRIBUTABLE' : 'NOT ATTRIBUTABLE; every delta below is void'}`);
   }
   if (U && U.uix && U.noretain && U.hooks) {
@@ -676,7 +726,8 @@ function report(all) {
   console.error(`[abl] wrote ${path.join(OUT, 'spine-ablation.json')}`);
 
   const refused = all.filter((s) => s.orderVerdict.refuse);
-  const unverified = all.reduce((t, s) => t + s.verification.unverified, 0);
+  const unverified = all.reduce(
+    (t, s) => t + s.verification.unverified + s.verification.unverifiedWitness, 0);
   if (unverified > 0) {
     console.error(`[abl] ${unverified} UNVERIFIED mounts — the DOM read-back did not match`);
     process.exit(3);


### PR DESCRIPTION
Closes `rf2-2rtt6.12` (P1, epic `rf2-2rtt6` / EP-0038 Wave 0).

`rf2-2rtt6.5`'s ladder priced a re-frame2 subscription read at **3,550 B / 128.5 objects** on the UIx spine against Reagent's **942 B / 36.2**, and asked what the other hundred objects are. This decomposes it.

## What the 128 objects are

The shipped UIx read measures **3,501 B / 125.8 objects** here (1.4% / 2.1% from the ladder, different rung set and different run). It splits into three terms that **sum to the whole with no residual**:

| term | bytes/read | objects/read | share |
|---|---:|---:|---:|
| one live subscription, as the spine represents it | 1,684 `[1,660–1,687]` | 56.7 | 48.1% |
| React's six-hook stack | 1,037 `[1,035–1,039]` | 46.1 | 29.6% |
| **a second, disposed, unreachable reaction** | 769 `[765–793]` | 23.0 | **22.0%** |
| sum | 3,490 | 125.8 | 99.7% |
| measured whole | 3,489 `[3,488–3,492]` | 125.8 | |

Reagent, measured in the **same run** on the same subs and the same page shape, pays **866 B / 31.5 obj** for the subscription half.

So the hook stack is *not* a small minority — at 46.1 objects it is 37% of the read, and it is irreducible for a `useSyncExternalStore`-shaped substrate. The spine's own subscription representation costs **1.94×** Reagent's, structurally: `re-frame.adapter.reagent` passes `ratom/make-reaction` (one deftype instance), while `spine/make-derived-value-fn` has no reaction primitive and builds a `reify` + 3 atoms + 3 volatiles + 6 closures + a fan-out coordinator entry to satisfy Spec 006's invalidation contract explicitly. That term is a price, not a defect.

## The third term is a defect, and it was settled by counting

`use-subscribe`'s render-phase **balanced round trip** (`subs/subscribe` then `subs/unsubscribe`, rf2-es09qq) goes `0 → 1 → 0` for a query with no live cache entry — and `1 → 0` is the disposal edge, which `subs.cache/unsubscribe!` takes in-tick with no grace period. The commit-phase `subscribe-fn` then misses the cache **again** and builds a second reaction. The first is retained for the component's lifetime by `use-memo`'s hook slot and `get-snap`'s closure: a disposed reaction with no source watches, no cache slot, and no verb that can reach it.

That is a claim about counts, so it was not settled with a heap instrument. A **witness** grid carries three counters, predicted in the driver before the run — measured at N=600, twice per page over disjoint cells:

| page | commits | rebuilt | bodyRuns |
|---|---:|---:|---:|
| uix ×2 | 600 (1.00N) | **600 (1.00N)** | **1200 (2.00N)** |
| reagent ×2 | 0 | 0 | 600 (1.00N) |

Exact integers. `bodyRuns = 2N` cannot be two derefs of one reaction — the memoised body caches on `(= @last-db db)`.

## The fix — priced, **not landed**

It is a production edit to a first-class shipped adapter, so it is filed rather than made: **`rf2-2rtt6.13`**.

~6 lines in `re-frame.substrate.spine`: have the render-phase `use-memo` deref the handle and return the **value**, and have `get-snap`'s fallback read that value. Measured (this is exactly the `noretain` arm): **3,501 → 2,720 B/read, 125.8 → 102.8 obj, UIx/Reagent 4.04× → 3.14×**. Blast radius is three substrates (uix, freehand, ui). Correctness is preserved and *measured*, not inferred — `bodyRuns = 2N` is React calling `getSnapshot` again after `subscribe` returns, by which time `subscribe-fn` has published the live committed reaction.

It does **not** remove the double *build*. That needs a ref-count-0 cache tenancy and a Spec 006 ruling on the no-grace-period edge — filed as **`rf2-2rtt6.14`** (P2), un-costed on CPU and explicitly not actioned.

## Instrument discipline

* **Retention, never allocation.** Mount and hold; three collections with a beat; release, collect, read again.
* **In-situ positive control, predicted before the run** — 587,500 unboxed doubles = **4,700,000 B**. Reader A measured 4,699,971 B, **−0.001%**; reader C +0.003%. On the Reagent page A +0.017%, C 0.000%. Same shape and size as `rf2-2rtt6.5`'s, so the errors are directly comparable.
* **Fidelity control** — an ablation is attributable only if the transcribed-but-unablated arm reproduces the shipped hook. Shipped `uix` 3,501 `[3,499–3,503]` vs transcription `xcript` 3,489 `[3,488–3,492]`, **0.332% apart**, inside the 3% band the driver declares before it measures (an order of magnitude below the 22% term being resolved).
* **Order guard** — rotates and reflects; self-test (8 checks) runs before the bundle is built; **clean on both pages, no refusal**. A 1-round smoke correctly exited 2 as UNCHECKED, which is how the refusal path was verified.
* **Reader C counts nodes as well as bytes**, because object count is the signal this bead was filed about. A and C agree to within 0.1% on every arm.
* **0 unverified of 154 mounts**; r² ≥ 0.9999 on all four UIx variants, bytes and objects.

## Lane

No build id added — rides `freehand-release` via `--config-merge`, the approach `rf2-2rtt6.5` used. **`implementation/shadow-cljs.edn` is untouched.** No production source touched. `docs/design/freehand/**` untouched.

Also: adds the missing `hd-002-adjudication.md` row to `docs/design/hicasso/README.md`'s document table (the page lands in #7261; the index row was outside that worker's fence).

## Quality gates

| gate | exit |
|---|---|
| `ABL_ROUNDS=4 ABL_SNAP_ROUNDS=2 node freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs` (full instrument, both pages, to completion) | **0** |
| `node freehand/test/re_frame/freehand/bench/order_guard.cjs` (order-guard self-test, 8 checks) | **0** |
| `npm run test:browser` — 842 tests, 5,469 assertions, 0 failures, 0 errors | **0** |
| `:advanced` release build of the instrument bundle (0 warnings) | **0** |

All run foreground to completion in the worktree, never piped through `tail`/`grep`.
