### PR TITLE
bench(hicasso): P0 UIx-on-subs frontier arm (rf2-2rtt6.4)

### DIFF
--- a/docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md
+++ b/docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md
@@ -1,0 +1,271 @@
+# P0 — UIx on re-frame2 subs: the frontier arm, and the red-zones
+
+**These figures are the red-zone thresholds.** The delegated ruling recorded on
+the operator-owned standard bead **rf2-2rtt6.1** (mayor, 2026-07-30, on Mike's
+explicit *"accept your recommendation and proceed"*) says it mechanically:
+
+> RED-ZONE THRESHOLD = THE MEASURED UIx RATIO FOR THAT WITNESS FAMILY, on both
+> axes (clock, retained heap). A candidate row WORSE THAN UIx on either axis is
+> RED. A red row needs an explicit operator waiver naming the dogfood benefit.
+> Silence is still not a pass.
+
+So every number in the two "red-zone" tables below *is* a threshold, not a
+supporting figure. **Red is not fail** — the ship bar (HD-012: mount AND bulk
+≤ 1.0× Reagent, like-for-like, clock only) is independent, and a row can clear
+the bar and still be red. That tension is intended.
+
+Bead **rf2-2rtt6.4**. Rows are appended to rf2-2rtt6.1; only the operator amends
+the bar, the budgets, the kill criteria, or these thresholds.
+
+## Provenance
+
+| | |
+|---|---|
+| **Producing commit** | `bc5f38f10a` |
+| **Reproduction (clock)** | `P0_ROUNDS=5 P0_SAMPLES=10 P0_WARMUPS=4 node implementation/core/test/re_frame/bench/p0_run.cjs --only clock` |
+| **Reproduction (heap)** | `P0_ROUNDS=5 P0_ROOTS=4 node implementation/core/test/re_frame/bench/p0_run.cjs --only heap` |
+| **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium via Playwright), Windows x64 |
+| **Build** | `:advanced`, `goog.DEBUG false`, plain `:browser` module. Compiler settings donated by the `:freehand-release` build id via `--config-merge`; **no `implementation/shadow-cljs.edn` change** (the epic's sequencing law gives that file to rf2-2rtt6.2) |
+| **React** | 19.2.0 · **Reagent** 2.0.1 · **UIx** `com.pitch/uix.core` 1.4.4 |
+| **Adapters** | `:rf.adapter/reagent` and `:rf.adapter/uix`, one per segment |
+| **Schedule** | 5 rounds × (4 warm-up + 10 samples) per arm per round; arms interleaved at the sample level, order chosen by measured adjacency; one round per page |
+| **Arm-order guard** | **reportable on every row**, clock and heap. Self-test 8/8 before anything was measured; driver exit 0 |
+| **Canonical-DOM parity** | clean under `:advanced` in both segments and across the seam, all 5 rounds — `{:problems [] :ok? true}` |
+| **Verification (clock)** | **0 unverified of 6,600** — 200 mounts W1 + 1,600 mounts W3 + 800 broad writes + 4,000 narrow writes, every one read back out of the DOM inside its own window |
+| **Verification (heap)** | **0 unverified of 48 mounts** |
+
+All bar numbers here are browser numbers. No JVM or Node figure appears on this
+page.
+
+## The arms
+
+Every figure is a ratio, and every ratio is to the floor measured in the **same
+round and the same segment**.
+
+| arm | what it is | role |
+|---|---|---|
+| `:floor` | the same DOM hand-built with `react/createElement` — no substrate, no boundary, no subscription | the **calibrator**, and the thing that makes the cross-segment ratio legitimate |
+| `:reagent-subs` | `reg-view` boundaries reading `@(subscribe [:p0/… i])` against one frame, `rf/frame-provider` at the root, `reagent.dom.client` for the mount | **the denominator** |
+| `:uix-subs` | `defui` boundaries reading `(use-subscribe [:p0/… i])` — the existing spine — `frame-provider` at the root, `uix.dom` for the mount | **the frontier** |
+
+Both substrate arms read **re-frame2 subscriptions**, both write through
+`dispatch-sync` on a shared event, and both run against one frame. Neither is
+hand-optimised: no `set-hiccup-emitter!` on the UIx side (that would measure a
+hiccup interpreter, not UIx), no `use-memo` around subscription args, no prop
+threading in place of a read.
+
+### Two segments, and why
+
+`install-adapter!` is once per process (Spec 006 §Single adapter per process), so
+the two candidate arms **cannot be interleaved inside one round**. Each round
+therefore runs two segments — destroy the adapter, install the other, re-seed —
+with the **floor in both**. The floor holds no re-frame state and is untouched by
+which adapter is installed, so a UIx-over-Reagent figure is a ratio of two
+floor-normalised ratios and the seam cancels.
+
+That cancellation is relied upon heavily and is **published rather than assumed**.
+The floor's own UIx-segment p50 over its Reagent-segment p50, per round:
+
+| witness | seam control, per round |
+|---|---|
+| W1-list | 1.762 · 0.938 · 1.406 · 0.860 · 1.486 |
+| W3-form | 1.531 · 0.552 · 1.317 · 0.627 · 1.250 |
+| U-broad | 1.038 · 0.846 · 0.821 · 0.800 · 0.688 |
+| U-narrow | 0.861 · 0.896 · 0.670 · 0.738 · 0.646 |
+
+The seam moves by up to 1.8×, and the red-zone ratios derived through it move by
+far less (W3-form: 0.843–0.956 across the same rounds) — which is the evidence
+that the normalisation is doing its job rather than an argument that it should.
+**A single-segment absolute millisecond from this page is not a quotable figure.**
+
+## The witnesses
+
+| id | shape | elements | sub read per boundary |
+|---|---|---|---|
+| **W1-list** | a large template: 300 rows, multi-class sugar, style map, `data-*` passthrough, image + label + number | 1,203 | `[:p0/row i]` |
+| **W3-form** | the ordinary 12-field form: label, controlled input, error line | 51 | `[:p0/field i]` |
+| **U-broad** | 300 independently-subscribed cells; one commit every cell reads | 301 | `[:p0/cell i]` |
+| **U-narrow** | the same grid; one commit exactly ONE cell reads | 301 | `[:p0/cell i]` |
+
+One read per boundary — the first rung of the HD-002 1/3/7/20 ladder. Sub keys are
+`(query-id, long)` under value equality, deliberately not maps, because unstable
+map args are a documented thrashing hazard and a bench that used one would be
+measuring the hazard.
+
+## RED-ZONE — clock
+
+**UIx-on-subs ÷ Reagent-on-subs**, both floor-normalised in the same round.
+Ranges are min–max across the five rounds. A range that includes 1.0 means the
+two are **indistinguishable** and is reported as such rather than as a winner.
+
+| witness | **threshold (mean)** | range | per round | verdict |
+|---|---|---|---|---|
+| **W1-list** mount | **1.057×** | 0.907 – 1.156 | 0.907 · 1.156 · 1.071 · 1.008 · 1.141 | **straddles 1.0 — indistinguishable** |
+| **W3-form** mount | **0.893×** | 0.843 – 0.956 | 0.843 · 0.956 · 0.852 · 0.914 · 0.899 | UIx faster, disjoint from 1.0 |
+| **U-broad** bulk | **0.838×** | 0.760 – 0.953 | 0.760 · 0.857 · 0.832 · 0.786 · 0.953 | UIx faster, disjoint from 1.0 |
+| **U-narrow** bulk | **1.536×** | 1.226 – 1.876 | 1.361 · 1.226 · 1.876 · 1.588 · 1.630 | **UIx slower**, disjoint from 1.0 |
+
+Both arms against the floor, for context:
+
+| witness | `reagent-subs ÷ floor` | `uix-subs ÷ floor` |
+|---|---|---|
+| W1-list | 2.350× [2.077 – 2.651] | 2.472× [2.196 – 2.710] |
+| W3-form | 1.948× [1.857 – 2.028] | 1.738× [1.633 – 1.827] |
+| U-broad | 8.064× [7.250 – 8.769] | 6.729× [6.100 – 7.318] |
+| U-narrow | 4.277× [3.875 – 4.731] | 6.502× [5.800 – 7.271] |
+
+### Reading the narrow row
+
+U-narrow is the localisation row — one commit that exactly one of 300 subscribed
+cells reads — and it is the one place UIx-on-subs is materially behind. The
+window decomposition says where the time goes: on the Reagent arm the cost is in
+the drain (`r/flush` inside the flush), while on the UIx arm it is in the
+**write** leg, before React is involved at all — the `useSyncExternalStore`
+notification path fanning out across 300 subscribed boundaries. That is a
+statement about the React-hook spine's invalidation, not about UIx's rendering,
+and it is the row a native view layer has the clearest structural claim on.
+
+## RED-ZONE — retained heap
+
+Retention, never allocation: V8's sampling heap profiler drops the samples of
+collected objects, and on the predecessor's instrument the same 80,000 objects
+read 4.77 MB when a global held them and 0.00 MB when nothing did. Here the
+driver forces a collection, reads, asks the page to mount 4 roots and keep them,
+collects, reads again, releases, collects, reads a third time.
+
+**Exclusive** = `arm − floor` in the same segment: the substrate's own standing
+cost, and the axis [validation.md](../validation.md) states the budget on
+(~0.4–0.5 KB per boundary target, > 1 KB fails on paper).
+
+| family | **threshold — exclusive (mean)** | range | absolute (mean) | range |
+|---|---|---|---|---|
+| **list** (300 sub-reading rows) | **2.262×** | 2.196 – 2.335 | 1.580× | 1.564 – 1.603 |
+| **grid** (300 sub-reading cells) | **2.254×** | 2.217 – 2.288 | 1.989× | 1.968 – 2.002 |
+
+Bytes per boundary, CDP `Runtime.getHeapUsage` after a forced collection, 4 roots
+held:
+
+| arm | B/boundary (mean) | range |
+|---|---|---|
+| `reagent-subs \| list/floor` | 1,105 | 1,099 – 1,108 |
+| `reagent-subs \| list/reagent` | 2,059 | 2,040 – 2,086 |
+| `uix-subs \| list/floor` | 1,096 | 1,084 – 1,113 |
+| `uix-subs \| list/uix` | **3,252** | 3,210 – 3,271 |
+| `reagent-subs \| grid/floor` | 248 | 244 – 259 |
+| `reagent-subs \| grid/reagent` | 1,195 | 1,190 – 1,208 |
+| `uix-subs \| grid/floor` | 244 | 239 – 247 |
+| `uix-subs \| grid/uix` | **2,378** | 2,372 – 2,388 |
+
+**Exclusive per boundary**: Reagent-on-subs ≈ **954 B** (list) and **947 B**
+(grid); UIx-on-subs ≈ **2,156 B** (list) and **2,134 B** (grid).
+
+Against the paper budget that is a finding in its own right, and it belongs to
+K3 rather than to the ship number: **the frontier comparator is itself over the
+1 KB paper-fail line, by more than 2×, and the Reagent denominator is close to
+it.** A candidate is red above 2.26×; it is over budget above ~0.5 KB. The two
+lines are far apart and a candidate can sit between them.
+
+DOM nodes live in Blink's C++ heap, not V8's, so none of these figures contain
+the elements themselves. Every arm builds the identical DOM — the canonical-DOM
+parity gate is what establishes that — so the omission cancels exactly in
+`arm − floor`. The absolute column is a JS-heap figure and is labelled as one.
+
+## The positive controls
+
+Every run reports predicted against measured. A figure nobody can falsify is not
+a measurement.
+
+**Heap.** A dense JS array of 587,500 doubles, which V8 stores as unboxed 8-byte
+slots — **predicted 4,700,000 B**, measured **4,700,317 B** [4,699,074 –
+4,700,974], **ratio 1.0001**. The instrument reads a known retained size to four
+significant figures.
+
+**Clock.** The floor's W1 page against the floor's W1 page with twice the rows
+and nothing else changed. Element count fixes the prediction before the run:
+`w1-elements(600) / w1-elements(300)` = 2403 / 1203 = **1.9975**. Measured
+**1.8381** [1.8182 – 1.8548] — an **8% undershoot**, stable across all five
+rounds.
+
+That miss is characterised rather than waved through. Mount time is
+`fixed + k · elements`, and the element-count prediction models only the second
+term. Solving `(f + 2403k)/(f + 1203k) = 1.8381` gives `f ≈ 229k` — a fixed
+per-mount cost worth about 229 element-equivalents, roughly 19% of the
+1,203-element page, which is the React root creation and the `flushSync` bracket.
+So the clock window behaves exactly as a linear model of it predicts, and its
+work-proportionality is understated by that fixed term. **Consequence for the
+thresholds: the clock instrument compresses ratios slightly toward 1.0, so a
+threshold above 1.0 is if anything conservative and one below 1.0 is if anything
+generous to UIx.**
+
+## Instrument faults found and repaired
+
+Each was caught by one of this arm's own gates, and each had produced a plausible
+precise wrong number first. They are recorded because the next arm will meet them.
+
+1. **The reflecting schedule degenerates at two arms.** Rotate `[0 1]` → `[1 0]`,
+   reflect → `[0 1]` again: the shared `slot-order` emits the identical order at
+   every sample index, every arm has one predecessor for ever, and the guard
+   refused as `:unchecked` on every substrate row. The schedule is now *chosen* —
+   both candidates are scored with the guard's own `adjacency` over the run about
+   to be performed, and the one that actually gives every arm two distinct
+   predecessors with the lowest modal share wins. At two arms that is the plain
+   rotation; at three or more it is the reflection, exactly as the guard's
+   self-test proves.
+2. **The 51-element form sat on the timer's clamp.** At one mount per sample both
+   segments returned exactly 0.75 ms and the ratio came out at precisely 1.0000 —
+   a "tie" that was Chrome's 100 µs quantum. Eight mounts to a sample; the
+   witness is unchanged, only the sample is bigger.
+3. **The broad write sat on it too.** A single broad write read 0.25–0.50 ms on
+   the floor, and the floor's two segment readings came out exactly 2× apart on
+   quantisation alone. Four writes to a sample.
+4. **A separate warm-up loop leaves the first sample of every round with no
+   predecessor.** That `<none>` stratum read 1.35× its siblings with disjoint
+   ranges and the guard refused. The warm-up now runs *inside* the round with
+   `:previous` threaded through it, so the first recorded sample has a real
+   predecessor like every other.
+5. **The page accumulated ~12 MB per segment entry** — with `body-children`
+   pinned at 2 throughout, so nothing was leaking into the document — and on that
+   heap the floor arm, which cannot change, drifted 3.4 → 5.8 → 7.0 ms. The guard
+   refused on phase, correctly. Three repairs were tried and are recorded because
+   each narrows what the cause can be: a forced *major* collection between every
+   sample (no effect), hoisting each arm so every round calls identical closures
+   (no effect), and unwrapping the `flushSync` around every unmount (no effect on
+   the climb — though a root's own `unmount()` opens a flush internally and the
+   nested one is scheduled rather than performed, so the unwrapping is right and
+   stays). **One round per page removes the drift by construction.** The
+   accumulation itself is a finding, not swept up: see the open items below.
+6. **A fixed witness order makes "second" a permanent property of one witness.**
+   With W1 always first, W3's UIx segment read LAST-THIRD 1.4815× FIRST-THIRD,
+   ranges disjoint, while W1 came out clean. Witness order now alternates with
+   the round, exactly as the segment order does.
+7. **A cold page pulls a work-proportional ratio toward 1.0.** With one round per
+   page the positive control fell to 1.7727 / 1.7681 / 1.8000 against a page that
+   ran three rounds and settled at 1.9167 / 1.9574 / 1.9574. The control gets its
+   own, larger warm-up, and the residual 8% is the fixed-cost term quantified
+   above.
+
+## Open items — stated, not swept up
+
+- **The ~12 MB-per-segment accumulation is unexplained.** It is proportional to
+  mounts, survives a forced major collection (so it is retained, not garbage),
+  does not reach the document, and is absent from the floor-only positive
+  control — which places it on the substrate arms and their adapter segments, not
+  on the harness. One round per page makes it harmless to these figures; it does
+  not make it fixed.
+- **The witness set does not match rf2-2rtt6.2's.** That arm's branch (not yet
+  merged) uses a 901-element M1 list reading `[:p0/cell i]` and a 51-element M2
+  form reading the same sub; this page uses a 1,203-element W1 reading
+  `[:p0/row i]`, a 51-element W3 reading `[:p0/field i]`, and a 301-element
+  300-boundary grid reading `[:p0/cell i]`. **The thresholds above are still
+  sound as thresholds**, because each is a ratio between two arms measured in the
+  same run, on the same shapes, through the same sub graph, in the same rounds —
+  but they are thresholds *on this witness set*. If P0's witness set converges on
+  rf2-2rtt6.2's, the UIx arm must be re-pointed and the red-zones re-derived; the
+  closest existing correspondence is this page's **U-broad** (300 boundaries,
+  one commit all read, `[:p0/cell i]`), which matches that arm's bulk row in
+  boundary count and sub graph and differs only in markup density.
+- **This arm rides `:freehand-release` for its compiler settings** because the
+  epic's sequencing law gives `implementation/shadow-cljs.edn` to rf2-2rtt6.2 and
+  that arm had not merged. `P0_BUILD` points the driver at another build id;
+  when the measurement-lane id lands, set it and delete the paragraph in
+  `p0_run.cjs` that explains this.

--- a/implementation/core/test/re_frame/bench/p0_app.cljs
+++ b/implementation/core/test/re_frame/bench/p0_app.cljs
@@ -1,5 +1,5 @@
 (ns re-frame.bench.p0-app
-  "EP-0038 P0 — the `:advanced` browser entry. One bundle, two modes.
+  "EP-0038 P0 — the `:advanced` browser entry. One bundle, three modes.
 
   **All bar numbers are browser numbers** (HD-012 / validation.md): a real
   browser, `:advanced`, `goog.DEBUG false`. JVM and Node figures are
@@ -13,19 +13,49 @@
   2. `:advanced` cannot compile shadow's `:browser-test` target —
      `cljs-test-display`'s `goog.define`s collide under Closure.
 
-  `?mode=clock` runs the mount and bulk rows to completion in the page and
-  parks the records on `window.P0_RESULTS`.
+  ## ONE ROUND PER PAGE, and the measurement that forced it
 
-  `?mode=heap` installs the retention instrument on `window.P0H` and then
-  does nothing at all. Heap readings belong to the DRIVER, which owns the
-  collector: the page cannot force a garbage collection, and a page that
-  decided when a heap reading was taken would be reading whatever the
-  collector happened to have done.
+  `?round=N` runs exactly ONE round and parks its raw record on
+  `window.P0_ROUND`; the driver reloads the page for the next one. That is
+  not fastidiousness. Run as a single page, this instrument's own probe
+  measured `usedJSHeapSize` climbing 34 -> 46 -> 55 -> 63 -> 75 -> 87 MB
+  across six segment entries — about 12 MB each, with `body-children`
+  pinned at 2 the whole way, so nothing was leaking into the document —
+  and on that heap the FLOOR arm, a hand-written `createElement` walk
+  that cannot change, drifted 3.4 -> 5.8 -> 7.0 ms. The arm-order guard
+  refused on phase, correctly.
+
+  Three repairs were tried against it and are recorded because each one
+  narrows what the cause can be: a forced major collection between every
+  sample (no effect), hoisting each arm so every round calls the identical
+  closures (no effect), and unwrapping the `flushSync` around every
+  unmount (no effect on the climb, though it is the right shape and stays
+  — see `p0-harness`). What did not drift, in the same page and the same
+  run, was the POSITIVE CONTROL: two floor arms, no adapter installed and
+  destroyed between its rounds, sitting at 1.9167 / 1.9574 / 1.9574. The
+  accumulation belongs to the substrate arms and their adapter segments,
+  not to the harness around them.
+
+  Rather than publish a figure against a page that is getting slower, the
+  round is made the unit of a page. A fresh document cannot inherit the
+  previous round's heap, so the drift cannot exist across rounds by
+  construction, and the guard's phase factor is then asking a question
+  about the machine rather than about a leak this arm already knows it has.
+  **The accumulation itself is a finding and is filed, not swept up.**
+
+  `?mode=heap` installs the retention instrument on `window.P0H` and does
+  nothing else — heap readings belong to the driver, which owns the
+  collector.
+
+  `?mode=aggregate` installs `window.P0A`, which folds the driver's
+  collected per-round EDN into the published records: ranges across
+  rounds, the red-zone ratios, and the arm-order verdict.
 
   Built and driven by `p0_run.cjs` beside this file.
 
   Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
-  (:require [re-frame.bench.order-guard :as guard]
+  (:require [cljs.reader :as reader]
+            [re-frame.bench.order-guard :as guard]
             [re-frame.bench.p0-arms :as arms]
             [re-frame.bench.p0-fixture :as fx]
             [re-frame.bench.p0-harness :as h]
@@ -44,17 +74,11 @@
     default))
 
 (defn- mode []
-  (or (.get (js/URLSearchParams. (.-search js/location)) "mode") "clock"))
+  (or (.get (js/URLSearchParams. (.-search js/location)) "mode") "round"))
 
 (defn- fail! [why]
   (set! (.-P0_ERROR js/window) (str why))
   (js/console.error (str ";; P0 FAILED — " why)))
-
-(defn- record! [k v]
-  (let [acc (or (.-P0_RESULTS js/window) #js {})]
-    (aset acc (name k) (pr-str v))
-    (set! (.-P0_RESULTS js/window) acc)
-    v))
 
 (defn- segment-order
   "Segment order for round `r`: forward on even rounds, REVERSED on odd.
@@ -65,7 +89,21 @@
   reported — that is the arm-order guard's rule, applied at the seam it
   cannot see."
   [r]
-  (if (even? r) arms/segments (vec (rseq (vec arms/segments)))))
+  (if (even? r) (vec arms/segments) (vec (rseq (vec arms/segments)))))
+
+(defn- witness-order
+  "Witness order for round `r`, alternating exactly as the segments do.
+
+  The witnesses are a nuisance factor in their own right and this was
+  measured, not anticipated. With W1 always first and W3 always second,
+  W3 ran its samples on a page that W1's 36 mounts had already loaded, and
+  the arm-order guard reported W3's UIx segment as phase-contaminated —
+  LAST-THIRD 1.4815x FIRST-THIRD, ranges disjoint — while W1, which always
+  ran first, came out clean. A fixed witness order makes 'second' a
+  permanent property of one witness, which is the same trap as a fixed arm
+  order one level up."
+  [r]
+  (if (even? r) (vec arms/mount-witnesses) (vec (rseq (vec arms/mount-witnesses)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The parity gate — run before any clock is read, in EVERY segment
@@ -98,132 +136,183 @@
     {}
     arms/mount-witnesses))
 
-;; ---------------------------------------------------------------------------
-;; The mount row
-;; ---------------------------------------------------------------------------
-
-(defn- run-mount-rows!
-  "Every mount witness, every segment, `rounds` rounds, segment order
-  alternating with the round. Answers
-  `{witness-id {segment-id {:per-round-ratio [...] :p50 [...] :bad :total}}}`."
-  [rounds sampling warmups]
-  (let [acc (atom {})
-        pos (atom 0)]
-    (dotimes [r rounds]
-      (doseq [{:keys [id] :as segment} (segment-order r)]
-        (arms/enter-segment! segment)
-        (doseq [{:keys [elements arms-for] :as w} arms/mount-witnesses]
-          (let [as (arms-for id)]
-            (h/warm! as warmups)
-            (let [{:keys [readings order bad total position]}
-                  (h/mount-round! as sampling elements @pos)
-                  norm (h/normalise readings :floor)]
-              (reset! pos position)
-              (swap! acc update-in [(:id w) id]
-                     (fn [m]
-                       (-> (or m {:p50 [] :ratio [] :order [] :bad 0 :total 0})
-                           (update :p50 conj (:p50 norm))
-                           (update :ratio conj (:ratio norm))
-                           (update :order into order)
-                           (update :bad + bad)
-                           (update :total + total)))))))))
-    @acc))
+(defn- parity!
+  "Both segments' parity, plus the CROSS-segment check. The floor is in
+  both segments and is the reference in both, so if each segment agrees
+  internally and the two floors agree with each other, all four arms
+  built one page."
+  []
+  (let [parities (reduce (fn [acc {:keys [id] :as segment}]
+                           (arms/enter-segment! segment)
+                           (assoc acc id (parity-of-segment! id)))
+                         {}
+                         arms/segments)
+        problems (into []
+                       (for [[seg ws] parities
+                             [w {:keys [problems]}] ws
+                             p problems]
+                         (assoc p :segment seg :witness w)))
+        cross    (into []
+                       (for [{:keys [id]} arms/mount-witnesses
+                             :let [a (get-in parities [:reagent-subs id :canon :floor])
+                                   b (get-in parities [:uix-subs id :canon :floor])]
+                             :when (not= a b)]
+                         {:problem :cross-segment-floor-disagreement :witness id}))]
+    {:problems (into problems cross)
+     :ok?      (and (empty? problems) (empty? cross))
+     :counts   (into {} (for [[seg ws] parities]
+                          [seg (into {} (for [[w v] ws] [w (:counts v)]))]))}))
 
 ;; ---------------------------------------------------------------------------
-;; The positive control
+;; One round
 ;; ---------------------------------------------------------------------------
 
-(defn- run-control!
-  "The clock's positive control, run in the same page and the same rounds
-  as the arms, reported as PREDICTED against MEASURED.
+(defn- mount-round-of-segments!
+  "One round's mount rows over both segments, in this round's segment
+  order. Answers `{witness-id {segment-id {:p50 :ratio :order :bad :total
+  :schedule}}}` plus the heap/DOM probes taken at each segment entry."
+  [r sampling arms-of]
+  (let [acc    (atom {})
+        pos    (atom 0)
+        probes (atom [])]
+    (doseq [{:keys [id] :as segment} (segment-order r)]
+      (arms/enter-segment! segment)
+      (swap! probes conj (assoc (h/probe) :round r :segment id))
+      (doseq [{:keys [elements per-sample] :as w} (witness-order r)]
+        (let [as (get arms-of [(:id w) id])
+              {:keys [readings order bad total position schedule]}
+              (h/mount-round! as sampling elements per-sample @pos)
+              norm (h/normalise readings :floor)]
+          (reset! pos position)
+          (swap! acc assoc-in [(:id w) id]
+                 {:p50 (:p50 norm) :ratio (:ratio norm) :order order
+                  :bad bad :total total :schedule schedule}))))
+    {:rows @acc :probes @probes}))
 
-  `control-2x` is the floor's W1 page with twice the rows and nothing else
-  changed, so its ratio to `control-1x` is fixed by element arithmetic at
-  2403/1203 = 1.997 before anything is measured. A run whose control
-  misses has not earned the right to publish the arms beside it."
-  [rounds sampling warmups]
-  (let [as  (arms/control-arms)
-        pos (atom 100000)
-        rs  (atom [])]
-    (h/warm! as warmups)
-    (dotimes [_ rounds]
-      (let [{:keys [readings position]} (h/mount-round! as sampling nil @pos)
-            norm (h/normalise readings :control-1x)]
-        (reset! pos position)
-        (swap! rs conj (get-in norm [:ratio :control-2x]))))
-    ;; `mount-round!` was handed `nil` as the expectation, so its own
-    ;; verification counter is meaningless here and is not reported: the
-    ;; two control arms build DIFFERENT pages by construction, which is
-    ;; the entire point of the control and the one place the element gate
-    ;; cannot apply.
-    (let [vs @rs]
-      {:predicted    arms/control-predicted
-       :measured     {:mean (/ (reduce + 0.0 vs) (count vs))
-                      :min  (apply min vs)
-                      :max  (apply max vs)}
-       :per-round    vs
-       :rounds       rounds
-       :note         (str "control-2x / control-1x. Predicted from element arithmetic: "
-                          "w1-elements(2n)/w1-elements(n) = "
-                          (fx/w1-elements (* 2 fx/w1-rows)) "/"
-                          (fx/w1-elements fx/w1-rows)
-                          ". Both arms are FLOOR arms — no substrate, no boundary, no "
-                          "subscription — so the control prices the instrument and not "
-                          "a candidate.")})))
+(defn- control-round!
+  "The clock's positive control for this round, PREDICTED before it is
+  measured: `control-2x` is the floor's W1 page with twice the rows and
+  nothing else changed, so its ratio to `control-1x` is fixed by element
+  arithmetic at 2403/1203 = 1.997. A run whose control misses has not
+  earned the right to publish the arms beside it.
 
-;; ---------------------------------------------------------------------------
-;; The bulk rows
-;; ---------------------------------------------------------------------------
+  Both arms are FLOOR arms — no substrate, no boundary, no subscription —
+  so the control prices the INSTRUMENT and not a candidate, and reads the
+  same in either segment.
 
-(defn- bulk-segment!
-  "One segment of one bulk round, for one `kind`. Answers a promise of
-  `{:p50 … :ratio … :legs … :order … :bad … :total …}`."
-  [segment kind sampling warmups pos]
-  (arms/enter-segment! segment)
-  (let [mounts (arms/mount-bulk-arms! (arms/bulk-arms (:id segment)))]
-    (-> (arms/warm-bulk! mounts kind warmups)
-        (.then (fn [_] (arms/bulk-round! mounts kind sampling @pos)))
-        (.then (fn [{:keys [readings legs order bad total position]}]
-                 (reset! pos position)
-                 (arms/release-bulk-arms! mounts)
-                 (let [norm (h/normalise readings :floor)]
-                   {:p50   (:p50 norm)
-                    :ratio (:ratio norm)
-                    :legs  (arms/leg-summary legs)
-                    :order order
-                    :bad   bad
-                    :total total})))
-        (.catch (fn [e]
-                  (arms/release-bulk-arms! mounts)
-                  (throw e))))))
+  **The control gets its own, larger warm-up, and the reason is the
+  control's own reading.** Run at the arms' warm-up on a page whose single
+  round is the only thing it will ever do, it read 1.7727 / 1.7681 /
+  1.8000 against a predicted 1.9975 — an 11% miss — where the same control
+  in a page that ran three rounds read 1.9167 / 1.9574 / 1.9574, settling
+  as the page warmed. A cold page's mount is dominated by first-call costs
+  that do NOT scale with element count, and those costs pull a
+  work-proportional ratio toward 1.0. That is a fact about cold pages
+  rather than about the arms, and the control is the instrument that shows
+  it."
+  [sampling arms]
+  (let [{:keys [readings]} (h/mount-round! arms
+                                           (update sampling :warmup * 3)
+                                           nil 1 100000)]
+    ;; `nil` as the expectation: the two control arms build DIFFERENT
+    ;; pages by construction, which is the whole point of the control and
+    ;; the one place the element gate cannot apply.
+    (get-in (h/normalise readings :control-1x) [:ratio :control-2x])))
 
-(defn- run-bulk-row!
-  "`rounds` rounds of one bulk `kind`, segment order alternating with the
-  round. Answers a promise of `{segment-id {:p50 [...] :ratio [...] …}}`."
-  [kind rounds sampling warmups]
+(defn- bulk-round-of-segments!
+  "One round of one bulk `kind` over both segments, in this round's
+  segment order. Answers a promise of `{segment-id {...}}`."
+  [r kind sampling]
   (let [acc (atom {})
         pos (atom 200000)]
-    (-> (arms/chain nil
-                    (for [r (range rounds) s (segment-order r)] s)
+    (-> (arms/chain nil (segment-order r)
                     (fn [_ segment]
-                      (-> (bulk-segment! segment kind sampling warmups pos)
-                          (.then (fn [res]
-                                   (swap! acc update (:id segment)
-                                          (fn [m]
-                                            (-> (or m {:p50 [] :ratio [] :legs []
-                                                       :order [] :bad 0 :total 0})
-                                                (update :p50 conj (:p50 res))
-                                                (update :ratio conj (:ratio res))
-                                                (update :legs conj (:legs res))
-                                                (update :order into (:order res))
-                                                (update :bad + (:bad res))
-                                                (update :total + (:total res)))))
-                                   nil)))))
+                      (arms/enter-segment! segment)
+                      (let [mounts (arms/mount-bulk-arms! (arms/bulk-arms (:id segment)))]
+                        (-> (arms/bulk-round! mounts kind sampling @pos)
+                            (.then (fn [{:keys [readings legs order bad total
+                                                position schedule]}]
+                                     (reset! pos position)
+                                     (arms/release-bulk-arms! mounts)
+                                     (let [norm (h/normalise readings :floor)]
+                                       (swap! acc assoc (:id segment)
+                                              {:p50   (:p50 norm)
+                                               :ratio (:ratio norm)
+                                               :legs  (arms/leg-summary legs)
+                                               :order order
+                                               :bad   bad
+                                               :total total
+                                               :schedule schedule})
+                                       nil)))
+                            (.catch (fn [e]
+                                      (arms/release-bulk-arms! mounts)
+                                      (throw e)))))))
         (.then (fn [_] @acc)))))
 
+(defn- run-round!
+  "Everything one round measures, in one fresh page."
+  [r]
+  (let [sampling {:warmup (q "warmup" 4) :samples (q "samples" 12)}
+        ;; THE ARMS ARE BUILT ONCE PER PAGE. When they were rebuilt per
+        ;; round inside one page, every round pushed a fresh closure
+        ;; through one call site and the sites went megamorphic on nothing
+        ;; the benchmark is trying to measure.
+        arms-of  (into {}
+                       (for [{:keys [id]} arms/segments
+                             {w :id :keys [arms-for]} arms/mount-witnesses]
+                         [[w id] (arms-for id)]))
+        par      (parity! )]
+    (if-not (:ok? par)
+      (do (fail! (str "the arms do not build the same page under :advanced — "
+                      (pr-str (:problems par))))
+          (js/Promise.resolve nil))
+      (let [control (control-round! sampling (arms/control-arms))
+            {mount-rows :rows probes :probes}
+            (mount-round-of-segments! r sampling arms-of)]
+        (-> (bulk-round-of-segments! r :broad sampling)
+            (.then (fn [broad]
+                     (-> (bulk-round-of-segments! r :narrow sampling)
+                         (.then (fn [narrow]
+                                  {:round       r
+                                   :parity      par
+                                   :probes      probes
+                                   :control     control
+                                   :collector   @h/gc-available?
+                                   :mount       mount-rows
+                                   :bulk-broad  broad
+                                   :bulk-narrow narrow}))))))))))
+
 ;; ---------------------------------------------------------------------------
-;; Assembling a published row
+;; Aggregation — ranges, red-zones, and the verdict
 ;; ---------------------------------------------------------------------------
+
+(defn- reposition
+  "Make one round's order samples orderable against another round's.
+
+  Every round runs in its OWN page, so its positions restart at zero.
+  Offsetting by the round index keeps the within-round order intact and
+  puts the rounds in sequence, which is what lets the guard's `:phase`
+  factor ask whether an arm reads differently early in the SESSION than
+  late in it."
+  [r samples]
+  (mapv #(update % :position + (* 1000000 (inc r))) samples))
+
+(defn- collect-segment
+  "Fold one segment's per-round slices into the shape `frontier-row`
+  consumes."
+  [round-records path seg]
+  (reduce (fn [acc {:keys [round] :as rec}]
+            (let [s (get-in rec (conj path seg))]
+              (-> acc
+                  (update :p50 conj (:p50 s))
+                  (update :ratio conj (:ratio s))
+                  (update :order into (reposition round (:order s)))
+                  (update :bad + (:bad s))
+                  (update :total + (:total s))
+                  (assoc :schedule (:schedule s))
+                  (assoc :legs (conj (:legs acc) (:legs s))))))
+          {:p50 [] :ratio [] :order [] :legs [] :bad 0 :total 0}
+          round-records))
 
 (defn- frontier-row
   "Turn one witness family's two segments into the published record —
@@ -234,10 +323,8 @@
   because the delegated ruling on rf2-2rtt6.1 makes this number the
   threshold itself: a later candidate row worse than this on the clock is
   RED and needs an operator waiver naming the dogfood benefit."
-  [witness-id doc by-segment]
-  (let [rg      (get by-segment :reagent-subs)
-        ux      (get by-segment :uix-subs)
-        rg-r    (mapv #(get % :reagent-subs) (:ratio rg))
+  [witness-id doc rg ux]
+  (let [rg-r    (mapv #(get % :reagent-subs) (:ratio rg))
         ux-r    (mapv #(get % :uix-subs) (:ratio ux))
         floor-r (mapv (fn [a b] (/ (:floor a) (:floor b))) (:p50 ux) (:p50 rg))]
     {:witness              witness-id
@@ -247,6 +334,7 @@
                             :uix-subs     (h/across-rounds (:ratio ux))}
      :per-round            {:reagent-subs {:p50 (:p50 rg) :ratio (:ratio rg)}
                             :uix-subs     {:p50 (:p50 ux) :ratio (:ratio ux)}}
+     :legs                 {:reagent-subs (:legs rg) :uix-subs (:legs ux)}
      :red-zone-clock       (assoc (h/ratio-of-ratios ux-r rg-r)
                                   :axis :clock
                                   :numerator :uix-subs
@@ -265,6 +353,7 @@
                                  "work in both and holds no re-frame state, so this is the "
                                  "seam's drift and nothing else. It is published rather "
                                  "than assumed to be 1.0.")}
+     :schedule             {:reagent-subs (:schedule rg) :uix-subs (:schedule ux)}
      :order-verdict        {:reagent-subs (guard/verdict (:order rg)
                                                          {:tolerance order-tolerance})
                             :uix-subs     (guard/verdict (:order ux)
@@ -273,87 +362,61 @@
                             :of         (+ (:total rg) (:total ux))}}))
 
 (defn- refused?
-  "Did the arm-order guard refuse any segment of `row`? A refusal is about
-  what may be QUOTED, not about throwing the run away — the data stands as
-  raw data and nothing in it may be published as measured. The driver
-  turns this into exit 2, and the repair is to the ARM, never to the
-  guard."
+  "Did the arm-order guard refuse either segment of `row`? A refusal is
+  about what may be QUOTED, not about throwing the run away — the data
+  stands as raw data and nothing in it may be published as measured. The
+  driver turns this into exit 2, and the repair is to the ARM, never to
+  the guard."
   [row]
   (boolean (some :refuse? (vals (:order-verdict row)))))
 
-;; ---------------------------------------------------------------------------
-;; The clock run
-;; ---------------------------------------------------------------------------
-
-(defn- run-clock!
-  []
-  (let [rounds   (q "rounds" 6)
-        sampling {:samples (q "samples" 12)}
-        warmups  (q "warmups" 3)
-        parities (reduce (fn [acc {:keys [id] :as segment}]
-                           (arms/enter-segment! segment)
-                           (assoc acc id (parity-of-segment! id)))
-                         {}
-                         arms/segments)
-        problems (into []
-                       (for [[seg ws] parities
-                             [w {:keys [problems]}] ws
-                             p problems]
-                         (assoc p :segment seg :witness w)))
-        ;; Cross-SEGMENT parity: the floor is in both segments and is the
-        ;; reference in both, so if each segment agrees internally and the
-        ;; floors agree with each other, all four arms built one page.
-        cross    (into []
-                       (for [{:keys [id]} arms/mount-witnesses
-                             :let [a (get-in parities [:reagent-subs id :canon :floor])
-                                   b (get-in parities [:uix-subs id :canon :floor])]
-                             :when (not= a b)]
-                         {:problem :cross-segment-floor-disagreement :witness id}))]
-    (record! :parity {:problems (into problems cross)
-                      :ok?      (and (empty? problems) (empty? cross))
-                      :counts   (into {} (for [[seg ws] parities]
-                                           [seg (into {} (for [[w v] ws]
-                                                           [w (:counts v)]))]))})
-    (if (or (seq problems) (seq cross))
-      (do (fail! (str "the arms do not build the same page under :advanced — "
-                      (pr-str (into problems cross))))
-          (js/Promise.resolve nil))
-      (let [refusals (atom [])
-            keep!    (fn [k row]
-                       (when (refused? row) (swap! refusals conj k))
-                       (record! k row)
-                       row)]
-        (record! :control (run-control! rounds sampling warmups))
-        (let [mount-rows (run-mount-rows! rounds sampling warmups)]
-          (record! :mount
-                   (into {}
-                         (map (fn [{:keys [id doc]}]
-                                (let [row (frontier-row id doc (get mount-rows id))]
-                                  (when (refused? row) (swap! refusals conj id))
-                                  [id row])))
-                         arms/mount-witnesses))
-          (-> (run-bulk-row! :broad rounds sampling warmups)
-              (.then (fn [by-seg]
-                       (keep! :bulk-broad
-                              (frontier-row :U-broad
-                                            (str "one write that all " fx/cells-n
-                                                 " subscribed cells read — re-render "
-                                                 "THROUGHPUT, where fine grain buys "
-                                                 "nothing because all the work is "
-                                                 "genuinely required")
-                                            by-seg))
-                       (run-bulk-row! :narrow rounds sampling warmups)))
-              (.then (fn [by-seg]
-                       (keep! :bulk-narrow
-                              (frontier-row :U-narrow
-                                            (str "one write exactly ONE of " fx/cells-n
-                                                 " subscribed cells reads — "
-                                                 "LOCALISATION, where fine grain either "
-                                                 "shows up or does not")
-                                            by-seg))
-                       (record! :refused (vec @refusals))
-                       (set! (.-P0_REFUSED js/window) (clj->js (mapv name @refusals)))
-                       nil)))))))))
+(defn aggregate
+  "Fold the driver's per-round EDN into the published records."
+  [round-edns]
+  (let [recs     (mapv reader/read-string round-edns)
+        controls (mapv :control recs)
+        row      (fn [witness doc path]
+                   (frontier-row witness doc
+                                 (collect-segment recs path :reagent-subs)
+                                 (collect-segment recs path :uix-subs)))
+        mount    (into {}
+                       (map (fn [{:keys [id doc]}]
+                              [id (row id doc [:mount id])]))
+                       arms/mount-witnesses)
+        broad    (row :U-broad
+                      (str "one write that all " fx/cells-n " subscribed cells read — "
+                           "re-render THROUGHPUT, where fine grain buys nothing because "
+                           "all the work is genuinely required")
+                      [:bulk-broad])
+        narrow   (row :U-narrow
+                      (str "one write exactly ONE of " fx/cells-n " subscribed cells "
+                           "reads — LOCALISATION, where fine grain either shows up or "
+                           "does not")
+                      [:bulk-narrow])
+        all      (into mount {:bulk-broad broad :bulk-narrow narrow})]
+    {:rounds    (count recs)
+     :parity    (mapv :parity recs)
+     :probes    (mapv :probes recs)
+     :collector {:forced-between-samples? (every? true? (map :collector recs))
+                 :note
+                 (str "window.gc() between samples, never inside a window, and one "
+                      "ROUND PER PAGE so no round inherits another's heap. false here "
+                      "means the page was launched without --js-flags=--expose-gc and "
+                      "this is a DIFFERENT instrument.")}
+     :control   {:predicted arms/control-predicted
+                 :per-round controls
+                 :measured  {:mean (/ (reduce + 0.0 controls) (count controls))
+                             :min  (apply min controls)
+                             :max  (apply max controls)}
+                 :note      (str "control-2x / control-1x, predicted from element "
+                                 "arithmetic: w1-elements(2n)/w1-elements(n) = "
+                                 (fx/w1-elements (* 2 fx/w1-rows)) "/"
+                                 (fx/w1-elements fx/w1-rows)
+                                 ". Both arms are FLOOR arms, so the control prices the "
+                                 "instrument and not a candidate.")}
+     :mount     mount
+     :bulk      {:broad broad :narrow narrow}
+     :refused   (into [] (comp (filter (fn [[_ v]] (refused? v))) (map key)) all)}))
 
 ;; ---------------------------------------------------------------------------
 
@@ -366,25 +429,35 @@
     ;; 2.0125x, the 0.43% slope, the twelve-window warm-up sweep, the
     ;; rotation arithmetic — so this is deterministic. A broken guard makes
     ;; every figure below unpublishable, and finding that out after the run
-    ;; is wasteful. THE GUARD EXITS ON REFUSAL; the repair is to the arm.
+    ;; is wasteful. THE GUARD REFUSES AND THE DRIVER EXITS 2; the repair is
+    ;; to the arm.
     (let [st (guard/self-test)]
-      (record! :order-guard-self-test st)
+      (set! (.-P0_GUARD_SELF_TEST js/window) (pr-str st))
       (doseq [c (:checks st)]
         (js/console.log (str ";; P0 order-guard " (if (:ok c) "ok  " "FAIL") " " (:name c)
                              (when (:detail c) (str "  — " (:detail c))))))
       (when-not (:ok? st)
         (fail! "the arm-order guard's self-test FAILED — nothing may be measured")))
     (case (mode)
-      "heap" (do (heap/install!)
-                 (js/console.log ";; P0 heap instrument installed")
-                 (set! (.-P0_READY js/window) true))
-      (-> (run-clock!)
-          (.then (fn [_]
+      "heap"
+      (do (heap/install!)
+          (js/console.log ";; P0 heap instrument installed")
+          (set! (.-P0_READY js/window) true))
+
+      "aggregate"
+      (do (set! (.-P0A js/window)
+                #js {:aggregate (fn [edns] (pr-str (aggregate (vec edns))))})
+          (js/console.log ";; P0 aggregator installed")
+          (set! (.-P0_READY js/window) true))
+
+      (-> (run-round! (q "round" 0))
+          (.then (fn [rec]
+                   (when rec (set! (.-P0_ROUND js/window) (pr-str rec)))
                    (set! (.-P0_DONE js/window) true)
-                   (js/console.log ";; P0 CLOCK DONE")
+                   (js/console.log (str ";; P0 ROUND " (q "round" 0) " DONE"))
                    nil))
           (.catch (fn [e]
-                    (fail! (str "clock run rejected: " e))
+                    (fail! (str "round rejected: " e))
                     (set! (.-P0_DONE js/window) true)))))
     (catch :default e
       (fail! (str "p0 run threw: " e))

--- a/implementation/core/test/re_frame/bench/p0_app.cljs
+++ b/implementation/core/test/re_frame/bench/p0_app.cljs
@@ -1,0 +1,392 @@
+(ns re-frame.bench.p0-app
+  "EP-0038 P0 — the `:advanced` browser entry. One bundle, two modes.
+
+  **All bar numbers are browser numbers** (HD-012 / validation.md): a real
+  browser, `:advanced`, `goog.DEBUG false`. JVM and Node figures are
+  diagnostic only and are never quotable against the bar. Two independent
+  reasons force a plain `:browser` entry rather than a test target:
+
+  1. Spec 009 instrumentation, schema validation and trace emission are
+     all `goog.DEBUG`-gated and all sit on the subscription and render
+     paths these rows measure. A development build would publish a cost no
+     user pays.
+  2. `:advanced` cannot compile shadow's `:browser-test` target —
+     `cljs-test-display`'s `goog.define`s collide under Closure.
+
+  `?mode=clock` runs the mount and bulk rows to completion in the page and
+  parks the records on `window.P0_RESULTS`.
+
+  `?mode=heap` installs the retention instrument on `window.P0H` and then
+  does nothing at all. Heap readings belong to the DRIVER, which owns the
+  collector: the page cannot force a garbage collection, and a page that
+  decided when a heap reading was taken would be reading whatever the
+  collector happened to have done.
+
+  Built and driven by `p0_run.cjs` beside this file.
+
+  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
+  (:require [re-frame.bench.order-guard :as guard]
+            [re-frame.bench.p0-arms :as arms]
+            [re-frame.bench.p0-fixture :as fx]
+            [re-frame.bench.p0-harness :as h]
+            [re-frame.bench.p0-heap :as heap]))
+
+(def order-tolerance
+  "A relative difference of medians for the arm-order guard. A browser
+  mount window moves several percent between rounds where a JVM allocation
+  counter does not, so this sits above this instrument's noise and far
+  below the 2.01x the recorded fault made."
+  0.25)
+
+(defn- q [k default]
+  (if-some [v (.get (js/URLSearchParams. (.-search js/location)) k)]
+    (js/parseInt v 10)
+    default))
+
+(defn- mode []
+  (or (.get (js/URLSearchParams. (.-search js/location)) "mode") "clock"))
+
+(defn- fail! [why]
+  (set! (.-P0_ERROR js/window) (str why))
+  (js/console.error (str ";; P0 FAILED — " why)))
+
+(defn- record! [k v]
+  (let [acc (or (.-P0_RESULTS js/window) #js {})]
+    (aset acc (name k) (pr-str v))
+    (set! (.-P0_RESULTS js/window) acc)
+    v))
+
+(defn- segment-order
+  "Segment order for round `r`: forward on even rounds, REVERSED on odd.
+
+  Two segments admit exactly two orders, and running both is what makes
+  the cross-segment figure a both-orders result rather than a single-order
+  one. A single-order result has not been checked and may not be
+  reported — that is the arm-order guard's rule, applied at the seam it
+  cannot see."
+  [r]
+  (if (even? r) arms/segments (vec (rseq (vec arms/segments)))))
+
+;; ---------------------------------------------------------------------------
+;; The parity gate — run before any clock is read, in EVERY segment
+;; ---------------------------------------------------------------------------
+
+(defn- parity-of-segment!
+  "Mount every arm of every mount witness and answer
+  `{witness-id {:canon {arm html} :counts {arm n} :problems [...]}}`.
+
+  A canonical-DOM gate once caught an arm rendering an empty page, so this
+  runs under `:advanced` too: a parity that held under `:none` and failed
+  under `:advanced` would be a renaming bug silently deciding the
+  comparison."
+  [segment-id]
+  (reduce
+    (fn [acc {:keys [id elements arms-for]}]
+      (let [{:keys [mounts agree? canon counts disagree]} (h/parity (arms-for segment-id))]
+        (try
+          (assoc acc id
+                 {:canon    canon
+                  :counts   counts
+                  :problems (cond-> []
+                              (not agree?)
+                              (conj {:problem :canonical-dom-disagreement :arms disagree})
+                              (not (every? #(= elements %) (vals counts)))
+                              (conj {:problem  :element-count
+                                     :expected elements
+                                     :got      counts}))})
+          (finally (doseq [m mounts] (h/release! m))))))
+    {}
+    arms/mount-witnesses))
+
+;; ---------------------------------------------------------------------------
+;; The mount row
+;; ---------------------------------------------------------------------------
+
+(defn- run-mount-rows!
+  "Every mount witness, every segment, `rounds` rounds, segment order
+  alternating with the round. Answers
+  `{witness-id {segment-id {:per-round-ratio [...] :p50 [...] :bad :total}}}`."
+  [rounds sampling warmups]
+  (let [acc (atom {})
+        pos (atom 0)]
+    (dotimes [r rounds]
+      (doseq [{:keys [id] :as segment} (segment-order r)]
+        (arms/enter-segment! segment)
+        (doseq [{:keys [elements arms-for] :as w} arms/mount-witnesses]
+          (let [as (arms-for id)]
+            (h/warm! as warmups)
+            (let [{:keys [readings order bad total position]}
+                  (h/mount-round! as sampling elements @pos)
+                  norm (h/normalise readings :floor)]
+              (reset! pos position)
+              (swap! acc update-in [(:id w) id]
+                     (fn [m]
+                       (-> (or m {:p50 [] :ratio [] :order [] :bad 0 :total 0})
+                           (update :p50 conj (:p50 norm))
+                           (update :ratio conj (:ratio norm))
+                           (update :order into order)
+                           (update :bad + bad)
+                           (update :total + total)))))))))
+    @acc))
+
+;; ---------------------------------------------------------------------------
+;; The positive control
+;; ---------------------------------------------------------------------------
+
+(defn- run-control!
+  "The clock's positive control, run in the same page and the same rounds
+  as the arms, reported as PREDICTED against MEASURED.
+
+  `control-2x` is the floor's W1 page with twice the rows and nothing else
+  changed, so its ratio to `control-1x` is fixed by element arithmetic at
+  2403/1203 = 1.997 before anything is measured. A run whose control
+  misses has not earned the right to publish the arms beside it."
+  [rounds sampling warmups]
+  (let [as  (arms/control-arms)
+        pos (atom 100000)
+        rs  (atom [])]
+    (h/warm! as warmups)
+    (dotimes [_ rounds]
+      (let [{:keys [readings position]} (h/mount-round! as sampling nil @pos)
+            norm (h/normalise readings :control-1x)]
+        (reset! pos position)
+        (swap! rs conj (get-in norm [:ratio :control-2x]))))
+    ;; `mount-round!` was handed `nil` as the expectation, so its own
+    ;; verification counter is meaningless here and is not reported: the
+    ;; two control arms build DIFFERENT pages by construction, which is
+    ;; the entire point of the control and the one place the element gate
+    ;; cannot apply.
+    (let [vs @rs]
+      {:predicted    arms/control-predicted
+       :measured     {:mean (/ (reduce + 0.0 vs) (count vs))
+                      :min  (apply min vs)
+                      :max  (apply max vs)}
+       :per-round    vs
+       :rounds       rounds
+       :note         (str "control-2x / control-1x. Predicted from element arithmetic: "
+                          "w1-elements(2n)/w1-elements(n) = "
+                          (fx/w1-elements (* 2 fx/w1-rows)) "/"
+                          (fx/w1-elements fx/w1-rows)
+                          ". Both arms are FLOOR arms — no substrate, no boundary, no "
+                          "subscription — so the control prices the instrument and not "
+                          "a candidate.")})))
+
+;; ---------------------------------------------------------------------------
+;; The bulk rows
+;; ---------------------------------------------------------------------------
+
+(defn- bulk-segment!
+  "One segment of one bulk round, for one `kind`. Answers a promise of
+  `{:p50 … :ratio … :legs … :order … :bad … :total …}`."
+  [segment kind sampling warmups pos]
+  (arms/enter-segment! segment)
+  (let [mounts (arms/mount-bulk-arms! (arms/bulk-arms (:id segment)))]
+    (-> (arms/warm-bulk! mounts kind warmups)
+        (.then (fn [_] (arms/bulk-round! mounts kind sampling @pos)))
+        (.then (fn [{:keys [readings legs order bad total position]}]
+                 (reset! pos position)
+                 (arms/release-bulk-arms! mounts)
+                 (let [norm (h/normalise readings :floor)]
+                   {:p50   (:p50 norm)
+                    :ratio (:ratio norm)
+                    :legs  (arms/leg-summary legs)
+                    :order order
+                    :bad   bad
+                    :total total})))
+        (.catch (fn [e]
+                  (arms/release-bulk-arms! mounts)
+                  (throw e))))))
+
+(defn- run-bulk-row!
+  "`rounds` rounds of one bulk `kind`, segment order alternating with the
+  round. Answers a promise of `{segment-id {:p50 [...] :ratio [...] …}}`."
+  [kind rounds sampling warmups]
+  (let [acc (atom {})
+        pos (atom 200000)]
+    (-> (arms/chain nil
+                    (for [r (range rounds) s (segment-order r)] s)
+                    (fn [_ segment]
+                      (-> (bulk-segment! segment kind sampling warmups pos)
+                          (.then (fn [res]
+                                   (swap! acc update (:id segment)
+                                          (fn [m]
+                                            (-> (or m {:p50 [] :ratio [] :legs []
+                                                       :order [] :bad 0 :total 0})
+                                                (update :p50 conj (:p50 res))
+                                                (update :ratio conj (:ratio res))
+                                                (update :legs conj (:legs res))
+                                                (update :order into (:order res))
+                                                (update :bad + (:bad res))
+                                                (update :total + (:total res)))))
+                                   nil)))))
+        (.then (fn [_] @acc)))))
+
+;; ---------------------------------------------------------------------------
+;; Assembling a published row
+;; ---------------------------------------------------------------------------
+
+(defn- frontier-row
+  "Turn one witness family's two segments into the published record —
+  including the RED-ZONE figure, which is UIx's floor-normalised ratio
+  over Reagent's, per round, as a range.
+
+  `:red-zone-clock` is labelled here rather than in prose downstream
+  because the delegated ruling on rf2-2rtt6.1 makes this number the
+  threshold itself: a later candidate row worse than this on the clock is
+  RED and needs an operator waiver naming the dogfood benefit."
+  [witness-id doc by-segment]
+  (let [rg      (get by-segment :reagent-subs)
+        ux      (get by-segment :uix-subs)
+        rg-r    (mapv #(get % :reagent-subs) (:ratio rg))
+        ux-r    (mapv #(get % :uix-subs) (:ratio ux))
+        floor-r (mapv (fn [a b] (/ (:floor a) (:floor b))) (:p50 ux) (:p50 rg))]
+    {:witness              witness-id
+     :doc                  doc
+     :arms                 [:floor :reagent-subs :uix-subs]
+     :ratio-to-floor       {:reagent-subs (h/across-rounds (:ratio rg))
+                            :uix-subs     (h/across-rounds (:ratio ux))}
+     :per-round            {:reagent-subs {:p50 (:p50 rg) :ratio (:ratio rg)}
+                            :uix-subs     {:p50 (:p50 ux) :ratio (:ratio ux)}}
+     :red-zone-clock       (assoc (h/ratio-of-ratios ux-r rg-r)
+                                  :axis :clock
+                                  :numerator :uix-subs
+                                  :denominator :reagent-subs
+                                  :meaning
+                                  (str "THE RED-ZONE THRESHOLD for " (name witness-id)
+                                       " on the clock (delegated ruling, rf2-2rtt6.1). A "
+                                       "later candidate row WORSE than this needs an "
+                                       "explicit operator waiver naming the dogfood "
+                                       "benefit. Ranges, not the mean: a range that "
+                                       "straddles 1.0 means indistinguishable."))
+     :segment-seam-control {:floor-uix-over-floor-reagent floor-r
+                            :note
+                            (str "the FLOOR's own p50 in the UIx segment over its p50 in "
+                                 "the Reagent segment, same round. The floor is identical "
+                                 "work in both and holds no re-frame state, so this is the "
+                                 "seam's drift and nothing else. It is published rather "
+                                 "than assumed to be 1.0.")}
+     :order-verdict        {:reagent-subs (guard/verdict (:order rg)
+                                                         {:tolerance order-tolerance})
+                            :uix-subs     (guard/verdict (:order ux)
+                                                         {:tolerance order-tolerance})}
+     :verification         {:unverified (+ (:bad rg) (:bad ux))
+                            :of         (+ (:total rg) (:total ux))}}))
+
+(defn- refused?
+  "Did the arm-order guard refuse any segment of `row`? A refusal is about
+  what may be QUOTED, not about throwing the run away — the data stands as
+  raw data and nothing in it may be published as measured. The driver
+  turns this into exit 2, and the repair is to the ARM, never to the
+  guard."
+  [row]
+  (boolean (some :refuse? (vals (:order-verdict row)))))
+
+;; ---------------------------------------------------------------------------
+;; The clock run
+;; ---------------------------------------------------------------------------
+
+(defn- run-clock!
+  []
+  (let [rounds   (q "rounds" 6)
+        sampling {:samples (q "samples" 12)}
+        warmups  (q "warmups" 3)
+        parities (reduce (fn [acc {:keys [id] :as segment}]
+                           (arms/enter-segment! segment)
+                           (assoc acc id (parity-of-segment! id)))
+                         {}
+                         arms/segments)
+        problems (into []
+                       (for [[seg ws] parities
+                             [w {:keys [problems]}] ws
+                             p problems]
+                         (assoc p :segment seg :witness w)))
+        ;; Cross-SEGMENT parity: the floor is in both segments and is the
+        ;; reference in both, so if each segment agrees internally and the
+        ;; floors agree with each other, all four arms built one page.
+        cross    (into []
+                       (for [{:keys [id]} arms/mount-witnesses
+                             :let [a (get-in parities [:reagent-subs id :canon :floor])
+                                   b (get-in parities [:uix-subs id :canon :floor])]
+                             :when (not= a b)]
+                         {:problem :cross-segment-floor-disagreement :witness id}))]
+    (record! :parity {:problems (into problems cross)
+                      :ok?      (and (empty? problems) (empty? cross))
+                      :counts   (into {} (for [[seg ws] parities]
+                                           [seg (into {} (for [[w v] ws]
+                                                           [w (:counts v)]))]))})
+    (if (or (seq problems) (seq cross))
+      (do (fail! (str "the arms do not build the same page under :advanced — "
+                      (pr-str (into problems cross))))
+          (js/Promise.resolve nil))
+      (let [refusals (atom [])
+            keep!    (fn [k row]
+                       (when (refused? row) (swap! refusals conj k))
+                       (record! k row)
+                       row)]
+        (record! :control (run-control! rounds sampling warmups))
+        (let [mount-rows (run-mount-rows! rounds sampling warmups)]
+          (record! :mount
+                   (into {}
+                         (map (fn [{:keys [id doc]}]
+                                (let [row (frontier-row id doc (get mount-rows id))]
+                                  (when (refused? row) (swap! refusals conj id))
+                                  [id row])))
+                         arms/mount-witnesses))
+          (-> (run-bulk-row! :broad rounds sampling warmups)
+              (.then (fn [by-seg]
+                       (keep! :bulk-broad
+                              (frontier-row :U-broad
+                                            (str "one write that all " fx/cells-n
+                                                 " subscribed cells read — re-render "
+                                                 "THROUGHPUT, where fine grain buys "
+                                                 "nothing because all the work is "
+                                                 "genuinely required")
+                                            by-seg))
+                       (run-bulk-row! :narrow rounds sampling warmups)))
+              (.then (fn [by-seg]
+                       (keep! :bulk-narrow
+                              (frontier-row :U-narrow
+                                            (str "one write exactly ONE of " fx/cells-n
+                                                 " subscribed cells reads — "
+                                                 "LOCALISATION, where fine grain either "
+                                                 "shows up or does not")
+                                            by-seg))
+                       (record! :refused (vec @refusals))
+                       (set! (.-P0_REFUSED js/window) (clj->js (mapv name @refusals)))
+                       nil)))))))))
+
+;; ---------------------------------------------------------------------------
+
+(defn ^:export -main
+  []
+  (try
+    (h/leave-act-environment!)
+    ;; The arm-order guard's own self-test, BEFORE anything is measured.
+    ;; Its checks are recorded fixtures replayed from the live study — the
+    ;; 2.0125x, the 0.43% slope, the twelve-window warm-up sweep, the
+    ;; rotation arithmetic — so this is deterministic. A broken guard makes
+    ;; every figure below unpublishable, and finding that out after the run
+    ;; is wasteful. THE GUARD EXITS ON REFUSAL; the repair is to the arm.
+    (let [st (guard/self-test)]
+      (record! :order-guard-self-test st)
+      (doseq [c (:checks st)]
+        (js/console.log (str ";; P0 order-guard " (if (:ok c) "ok  " "FAIL") " " (:name c)
+                             (when (:detail c) (str "  — " (:detail c))))))
+      (when-not (:ok? st)
+        (fail! "the arm-order guard's self-test FAILED — nothing may be measured")))
+    (case (mode)
+      "heap" (do (heap/install!)
+                 (js/console.log ";; P0 heap instrument installed")
+                 (set! (.-P0_READY js/window) true))
+      (-> (run-clock!)
+          (.then (fn [_]
+                   (set! (.-P0_DONE js/window) true)
+                   (js/console.log ";; P0 CLOCK DONE")
+                   nil))
+          (.catch (fn [e]
+                    (fail! (str "clock run rejected: " e))
+                    (set! (.-P0_DONE js/window) true)))))
+    (catch :default e
+      (fail! (str "p0 run threw: " e))
+      (set! (.-P0_DONE js/window) true)
+      (set! (.-P0_READY js/window) true))))

--- a/implementation/core/test/re_frame/bench/p0_arms.cljs
+++ b/implementation/core/test/re_frame/bench/p0_arms.cljs
@@ -60,7 +60,6 @@
             [re-frame.bench.p0-fixture :as fx]
             [re-frame.bench.p0-floor :as floor]
             [re-frame.bench.p0-harness :as h]
-            [re-frame.bench.order-guard :as guard]
             [re-frame.bench.p0-reagent :as rg]
             [re-frame.bench.p0-uix :as ux]
             [re-frame.core :as rf]
@@ -144,10 +143,13 @@
   "The mount witness families. `:arms-for` answers the arms for a segment,
   always `[floor <substrate>]` in that declaration order — the harness
   reorders them per sample index, so declaration order decides nothing."
-  [{:id       :W1-list
-    :doc      (str "a large template — " fx/w1-rows " rows, one boundary and ONE "
-                   "re-frame2 subscription read per row")
-    :elements (fx/w1-elements fx/w1-rows)
+  [{:id        :W1-list
+    :doc       (str "a large template — " fx/w1-rows " rows, one boundary and ONE "
+                    "re-frame2 subscription read per row")
+    :elements   (fx/w1-elements fx/w1-rows)
+    ;; 1,203 elements mounts in tens of timer quanta on every arm, so one
+    ;; mount is a sample.
+    :per-sample 1
     :arms-for (fn [segment-id]
                 [(floor-arm :floor #(floor/w1 (mapv fx/row-value (range fx/w1-rows))))
                  (case segment-id
@@ -156,11 +158,17 @@
                    :uix-subs     (uix-arm :uix-subs
                                           #(ux/w1-root frame-id fx/w1-rows)))])}
 
-   {:id       :W3-form
-    :doc      (str "an ordinary " fx/w3-fields "-field form with controlled inputs — "
-                   "the shape most applications are made of; one subscription read "
-                   "per field")
-    :elements (fx/w3-elements fx/w3-fields)
+   {:id        :W3-form
+    :doc       (str "an ordinary " fx/w3-fields "-field form with controlled inputs — "
+                    "the shape most applications are made of; one subscription read "
+                    "per field")
+    :elements   (fx/w3-elements fx/w3-fields)
+    ;; 51 elements sits three to eight quanta above Chrome's 100 us clamp,
+    ;; and at one mount a sample this instrument MEASURED both segments
+    ;; returning exactly 0.75 ms — a ratio of precisely 1.0000 that was the
+    ;; timer's resolution, not a tie. Eight mounts to a sample lifts every
+    ;; arm clear of the clamp; the witness is unchanged.
+    :per-sample 8
     :arms-for (fn [segment-id]
                 [(floor-arm :floor
                             #(floor/w3 (mapv (fn [i] {:value (fx/field-value i)
@@ -222,7 +230,9 @@
                   (swap! state assoc i v)))
      :force!  (fn [] (react-dom/flushSync
                        (fn [] (.render ^js @root (floor/u-grid @state)))))
-     :unmount (fn [rt] (react-dom/flushSync (fn [] (.unmount rt))))}))
+     ;; NOT inside a flushSync — a root's own unmount opens one, and a
+     ;; nested flush is scheduled rather than performed (p0-harness).
+     :unmount (fn [rt] (.unmount rt))}))
 
 (defn- subs-bulk-arm
   "Both substrate bulk arms, one constructor. They differ ONLY in the mount
@@ -248,7 +258,7 @@
       (let [rt (rdc/create-root container)]
         (react-dom/flushSync (fn [] (rdc/render rt (rg/u-root frame-id))))
         rt))
-    (fn [rt] (react-dom/flushSync (fn [] (rdc/unmount rt))))
+    (fn [rt] (rdc/unmount rt))
     (fn [] (react-dom/flushSync (fn [] (r/flush))))))
 
 (defn- uix-bulk-arm []
@@ -258,7 +268,7 @@
       (let [rt (uix-dom/create-root container)]
         (react-dom/flushSync (fn [] (uix-dom/render-root (ux/u-root frame-id) rt)))
         rt))
-    (fn [rt] (react-dom/flushSync (fn [] (uix-dom/unmount-root rt))))
+    (fn [rt] (uix-dom/unmount-root rt))
     (fn [] (react-dom/flushSync (fn [] nil)))))
 
 (defn bulk-arms
@@ -277,7 +287,7 @@
 
 (defn release-bulk-arms! [mounts]
   (doseq [{:keys [arm handle container]} mounts]
-    (try ((:unmount arm) handle) (catch :default _ nil))
+    ((:unmount arm) handle)
     (.remove container)))
 
 ;; ---------------------------------------------------------------------------
@@ -313,7 +323,7 @@
                         :ok?      (and (= (str v) (cell-text container probe))
                                        (or (not= i :all)
                                            (= (str v) (cell-text container
-                                                                 (dec fx/cells-n)))))})))))))))
+                                                                 (dec fx/cells-n)))))}))))))))
 
 (defn chain
   "Fold `xs` into a serial promise chain, threading an accumulator."
@@ -323,13 +333,20 @@
 (def writes-per-sample
   "How many writes one SAMPLE contains.
 
-  Chrome clamps `performance.now()` to 100 us. A broad write costs every
-  arm well above that, so one write is a sample. A NARROW write does not:
-  measured one at a time on the predecessor's harness both the floor and
-  Reagent returned exactly 0.1 ms — the quantum itself, which is a null
-  result wearing a different hat. Twenty writes to a sample lifts every
-  arm clear of the clamp and the per-write figure is the sample over 20."
-  {:broad 1 :narrow 20})
+  Chrome clamps `performance.now()` to 100 us, and BOTH rows have to clear
+  it on their FASTEST arm, which is the floor.
+
+  A single broad write read 0.25-0.50 ms on the floor when this instrument
+  was first run — two to five quanta, close enough that the floor's own
+  two segment readings came out exactly 2x apart on quantisation alone.
+  Four writes to a sample lifts it to a couple of milliseconds. A NARROW
+  write is smaller again: measured one at a time on the predecessor's
+  harness both the floor and Reagent returned exactly 0.1 ms, the quantum
+  itself, which is a null result wearing a different hat.
+
+  The per-write figure is always the sample divided by this number, and
+  every write in a sample is verified at the DOM individually."
+  {:broad 4 :narrow 20})
 
 (defn- n-writes! [mnt kind n]
   (chain {:ms 0 :write-ms 0 :gap-ms 0 :force-ms 0 :bad 0 :total 0} (range n)
@@ -346,48 +363,54 @@
                                       (update :total inc))
                             (not ok?) (update :bad inc)))))))))
 
-(defn warm-bulk!
-  "Warm every bulk arm before any clock is read, for the reason the
-  harness namespace gives: position dominates adjacency and an unwarmed
-  site reads 1.26x to 5.3x its settled value."
-  [mounts kind n]
-  (chain nil (for [_ (range n) m mounts] m)
-         (fn [_ m] (-> (n-writes! m kind (get writes-per-sample kind))
-                       (.then (fn [_] nil))))))
-
 (defn bulk-round!
-  "One round of a bulk row: `samples` sample indices, every arm written at
-  every index, order rotating AND reflecting with the index. Answers a
-  promise of `{:readings :legs :order :bad :total :position}`."
-  [mounts kind {:keys [samples]} position-start]
-  (let [k (count mounts)
-        n (get writes-per-sample kind)]
+  "One round of a bulk row: `warmup + samples` sample indices, every arm
+  written at every index, order chosen by its MEASURED adjacency property.
+
+  The warm-up indices are measured and thrown away, and `:previous` is
+  threaded through them, so the first RECORDED sample has a real
+  predecessor. A warm-up run as a separate loop leaves a `<none>`
+  predecessor stratum that this instrument measured at 1.35x its siblings
+  with disjoint ranges — a real cold-start effect, and not one to hide.
+
+  Answers a promise of `{:readings :legs :order :bad :total :position
+  :schedule}`."
+  [mounts kind {:keys [warmup samples]} position-start]
+  (let [k     (count mounts)
+        n     (get writes-per-sample kind)
+        total (+ warmup samples)
+        sched (h/choose-schedule k total)
+        order (:fn sched)]
     (chain {:readings (zipmap (map #(:id (:arm %)) mounts) (repeat []))
             :legs     (zipmap (map #(:id (:arm %)) mounts) (repeat []))
             :order    []
             :bad      0
             :total    0
+            :schedule (dissoc sched :fn)
             :position position-start
             :previous nil}
-           (for [s (range samples) j (guard/slot-order k s)] [s j])
-           (fn [acc [_s j]]
+           (for [s (range total) j (order k s)] [s j])
+           (fn [acc [s j]]
              (let [mnt (nth mounts j)
                    id  (:id (:arm mnt))]
                (-> (n-writes! mnt kind n)
                    (.then (fn [{:keys [ms write-ms gap-ms force-ms bad total]}]
-                            (-> acc
-                                (update :bad + bad)
-                                (update :total + total)
-                                (update-in [:readings id] conj ms)
-                                (update-in [:legs id] conj {:write write-ms
-                                                            :gap   gap-ms
-                                                            :force force-ms})
-                                (update :order conj {:arm         id
-                                                     :value       ms
-                                                     :predecessor (:previous acc)
-                                                     :position    (:position acc)})
-                                (update :position inc)
-                                (assoc :previous id))))))))))
+                            ;; Between samples, never inside a window — see
+                            ;; `p0-harness/collect!` for the drift it removes.
+                            (h/collect!)
+                            (cond-> (assoc acc :previous id)
+                              (>= s warmup)
+                              (-> (update :bad + bad)
+                                  (update :total + total)
+                                  (update-in [:readings id] conj ms)
+                                  (update-in [:legs id] conj {:write write-ms
+                                                              :gap   gap-ms
+                                                              :force force-ms})
+                                  (update :order conj {:arm         id
+                                                       :value       ms
+                                                       :predecessor (:previous acc)
+                                                       :position    (:position acc)})
+                                  (update :position inc)))))))))))
 
 (defn leg-summary
   "Per-arm p50 of each leg of the window, in ms per SAMPLE."

--- a/implementation/core/test/re_frame/bench/p0_arms.cljs
+++ b/implementation/core/test/re_frame/bench/p0_arms.cljs
@@ -1,0 +1,403 @@
+(ns re-frame.bench.p0-arms
+  "EP-0038 P0 — the ARMS and the two SEGMENTS, as data and functions with
+  every assertion left to the caller.
+
+  ## Why there are segments at all
+
+  P0 is like-for-like: Reagent reading re-frame2 subs against UIx reading
+  re-frame2 subs. Those are two installed adapters, and
+  `install-adapter!` is once per process (Spec 006 §Single adapter per
+  process) — a second call without an intervening `destroy-adapter!`
+  raises. So the two candidate arms CANNOT be interleaved inside one
+  round.
+
+  What is available, and what this namespace does, is two SEGMENTS of the
+  same round in the same page and the same process:
+
+      round r:  segment A  -> destroy+install adapter, seed, warm,
+                              interleave {floor, <substrate>} at the
+                              sample level
+                segment B  -> the same, other adapter
+      round r+1: the two segments in the OPPOSITE order
+
+  The FLOOR runs in both segments. It holds no re-frame state, reads no
+  subscription and is untouched by which adapter is installed, so it is
+  the same work in both — and every published figure is a ratio to the
+  floor measured in that same segment of that same round. A
+  UIx-over-Reagent figure is therefore a ratio of two floor-normalised
+  ratios and the seam between the segments cancels. The floor's own two
+  segment readings are compared every round and published; a round in
+  which they disagree beyond tolerance is a seam finding, reported rather
+  than absorbed.
+
+  This is a weaker interleaving than one segment's, and the record says so
+  plainly rather than describing the segment order as though it were
+  sample-level interleaving. It is the strongest available shape given a
+  one-adapter-per-process runtime.
+
+  ## The bulk window
+
+  Write, yield ONE microtask, force the arm's own synchronous drain, stop
+  the clock, then READ THE WRITTEN CELL BACK OUT OF THE DOM. Every arm is
+  timed through that one shape, including the arms that do not need the
+  yield — the predecessor's harness established that a window shape has to
+  be uniform across arms or the comparison prices the window.
+
+  The read-back is not decoration. On the predecessor's first pass, an
+  EMPTY `flushSync` flushed only React's sync lane, so the floor arm's
+  default-lane `root.render` landed outside the measured window entirely:
+  80 of 320 floor samples ended on a stale cell and every other arm's
+  ratio was inflated by the difference. On another, deleting the microtask
+  made a substrate arm fail its read-back on EVERY write while reading
+  FASTER, with a range that still overlapped the valid window's — the
+  clock alone would have accepted it. Only the DOM read-back caught either.
+
+  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
+  (:require ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.p0-fixture :as fx]
+            [re-frame.bench.p0-floor :as floor]
+            [re-frame.bench.p0-harness :as h]
+            [re-frame.bench.order-guard :as guard]
+            [re-frame.bench.p0-reagent :as rg]
+            [re-frame.bench.p0-uix :as ux]
+            [re-frame.core :as rf]
+            [reagent.core :as r]
+            [reagent.dom.client :as rdc]
+            [uix.dom :as uix-dom]))
+
+(def frame-id
+  "ONE frame behind every arm of a segment — the application shape. N
+  frames would price frame construction, which is not what any of these
+  rows is for."
+  :p0/frame)
+
+;; ---------------------------------------------------------------------------
+;; Segments
+;; ---------------------------------------------------------------------------
+
+(def segments
+  "The two adapter segments. `:id` is the substrate arm's id, which is also
+  how a published record names the segment."
+  [{:id :reagent-subs :adapter reagent-adapter/adapter :name "Reagent-on-subs"}
+   {:id :uix-subs     :adapter uix-adapter/adapter     :name "UIx-on-subs"}])
+
+(defonce ^:private captured (atom nil))
+
+(defn enter-segment!
+  "Tear down whatever adapter is installed, install this segment's, and
+  stand the frame back up seeded from the shared fixture.
+
+  All of it OUTSIDE every measured window. A mount window that contained
+  `make-frame` and a seeding dispatch would price frame construction on
+  whichever arm happened to own it."
+  [{:keys [adapter]}]
+  (try (rf/destroy-frame! frame-id) (catch :default _ nil))
+  (when (rf/current-adapter)
+    (try (rf/destroy-adapter!) (catch :default _ nil)))
+  (rf/init! adapter)
+  (fx/register!)
+  (rf/make-frame {:id frame-id :initial-events [[:p0/seed]]})
+  (reset! captured (rf/capture-frame frame-id))
+  nil)
+
+(defn- dispatch-sync! [ev]
+  ((:dispatch-sync @captured) ev))
+
+;; ---------------------------------------------------------------------------
+;; MOUNT arms
+;; ---------------------------------------------------------------------------
+;;
+;; Each arm is `{:id :mount :unmount}`; `:mount` takes a container and
+;; answers a handle. Every arm uses ITS OWN substrate's mount door —
+;; `reagent.dom.client` for Reagent, `uix.dom` for UIx, a bare
+;; `react-dom/client` root for the floor — because that is the door an
+;; application calls and a shared door would measure the shim.
+
+(defn- floor-arm [id element-of]
+  {:id      id
+   :mount   (fn [container]
+              (let [root (react-dom-client/createRoot container)]
+                (.render root (element-of))
+                root))
+   :unmount (fn [root] (.unmount root))})
+
+(defn- reagent-arm [id form-of]
+  {:id      id
+   :mount   (fn [container]
+              (let [root (rdc/create-root container)]
+                (rdc/render root (form-of))
+                root))
+   :unmount (fn [root] (rdc/unmount root))})
+
+(defn- uix-arm [id element-of]
+  {:id      id
+   :mount   (fn [container]
+              (let [root (uix-dom/create-root container)]
+                (uix-dom/render-root (element-of) root)
+                root))
+   :unmount (fn [root] (uix-dom/unmount-root root))})
+
+(def mount-witnesses
+  "The mount witness families. `:arms-for` answers the arms for a segment,
+  always `[floor <substrate>]` in that declaration order — the harness
+  reorders them per sample index, so declaration order decides nothing."
+  [{:id       :W1-list
+    :doc      (str "a large template — " fx/w1-rows " rows, one boundary and ONE "
+                   "re-frame2 subscription read per row")
+    :elements (fx/w1-elements fx/w1-rows)
+    :arms-for (fn [segment-id]
+                [(floor-arm :floor #(floor/w1 (mapv fx/row-value (range fx/w1-rows))))
+                 (case segment-id
+                   :reagent-subs (reagent-arm :reagent-subs
+                                              #(rg/w1-root frame-id fx/w1-rows))
+                   :uix-subs     (uix-arm :uix-subs
+                                          #(ux/w1-root frame-id fx/w1-rows)))])}
+
+   {:id       :W3-form
+    :doc      (str "an ordinary " fx/w3-fields "-field form with controlled inputs — "
+                   "the shape most applications are made of; one subscription read "
+                   "per field")
+    :elements (fx/w3-elements fx/w3-fields)
+    :arms-for (fn [segment-id]
+                [(floor-arm :floor
+                            #(floor/w3 (mapv (fn [i] {:value (fx/field-value i)
+                                                      :error (fx/field-error i)})
+                                             (range fx/w3-fields))))
+                 (case segment-id
+                   :reagent-subs (reagent-arm :reagent-subs
+                                              #(rg/w3-root frame-id fx/w3-fields))
+                   :uix-subs     (uix-arm :uix-subs
+                                          #(ux/w3-root frame-id fx/w3-fields)))])}])
+
+;; ---------------------------------------------------------------------------
+;; THE POSITIVE CONTROL — predicted before it is measured
+;; ---------------------------------------------------------------------------
+
+(defn control-arms
+  "The clock's positive control: the floor's W1 page against the floor's W1
+  page with twice the rows, and nothing else changed.
+
+  Predicted ratio `w1-elements(600) / w1-elements(300)` = 2403/1203 =
+  1.997. A window that is measuring the construction and commit of this
+  page has to land there; a window that is measuring a scheduler hop, a
+  constant, or an arm that rendered nothing has no reason to. Built on the
+  FLOOR so it prices the instrument rather than a substrate, and therefore
+  reads the same in both segments."
+  []
+  [(floor-arm :control-1x #(floor/w1 (mapv fx/row-value (range fx/w1-rows))))
+   (floor-arm :control-2x #(floor/w1-double (mapv fx/row-value (range fx/w1-rows))))])
+
+(def control-predicted floor/control-predicted-ratio)
+
+;; ---------------------------------------------------------------------------
+;; BULK arms
+;; ---------------------------------------------------------------------------
+
+(defn- cell-text [container i]
+  (some-> (.querySelector container (str "[data-i=\"" i "\"]")) (.-textContent)))
+
+(defn- floor-bulk-arm
+  "The floor's `force!` renders INSIDE the `flushSync`, and that is not a
+  convenience. `root.render` called outside a React event schedules at
+  React's DEFAULT lane, and an empty `flushSync` flushes only the SYNC
+  lane — so a floor arm that rendered in `write!` and flushed in `force!`
+  would have its commit land outside the measured window. The DOM
+  read-back caught exactly that on the predecessor's harness: 80 of 320
+  floor samples ending on a stale cell."
+  []
+  (let [state (atom (vec (repeat fx/cells-n 0)))
+        root  (volatile! nil)]
+    {:id      :floor
+     :mount   (fn [container]
+                (let [rt (react-dom-client/createRoot container)]
+                  (vreset! root rt)
+                  (react-dom/flushSync (fn [] (.render rt (floor/u-grid @state))))
+                  rt))
+     :write!  (fn [i v]
+                (if (= i :all)
+                  (reset! state (vec (repeat fx/cells-n v)))
+                  (swap! state assoc i v)))
+     :force!  (fn [] (react-dom/flushSync
+                       (fn [] (.render ^js @root (floor/u-grid @state)))))
+     :unmount (fn [rt] (react-dom/flushSync (fn [] (.unmount rt))))}))
+
+(defn- subs-bulk-arm
+  "Both substrate bulk arms, one constructor. They differ ONLY in the mount
+  door and the drain: `reagent.core/flush` is Reagent's own documented
+  synchronous render drain; the React-hook spine's `useSyncExternalStore`
+  notification needs only an empty `flushSync` to be committed in this
+  window. The WRITE is identical — one `dispatch-sync` of a shared event
+  — which is what makes the row like-for-like."
+  [id mount unmount force!]
+  {:id      id
+   :mount   mount
+   :unmount unmount
+   :write!  (fn [i v]
+              (if (= i :all)
+                (dispatch-sync! [:p0/write-all v])
+                (dispatch-sync! [:p0/write-one i v])))
+   :force!  force!})
+
+(defn- reagent-bulk-arm []
+  (subs-bulk-arm
+    :reagent-subs
+    (fn [container]
+      (let [rt (rdc/create-root container)]
+        (react-dom/flushSync (fn [] (rdc/render rt (rg/u-root frame-id))))
+        rt))
+    (fn [rt] (react-dom/flushSync (fn [] (rdc/unmount rt))))
+    (fn [] (react-dom/flushSync (fn [] (r/flush))))))
+
+(defn- uix-bulk-arm []
+  (subs-bulk-arm
+    :uix-subs
+    (fn [container]
+      (let [rt (uix-dom/create-root container)]
+        (react-dom/flushSync (fn [] (uix-dom/render-root (ux/u-root frame-id) rt)))
+        rt))
+    (fn [rt] (react-dom/flushSync (fn [] (uix-dom/unmount-root rt))))
+    (fn [] (react-dom/flushSync (fn [] nil)))))
+
+(defn bulk-arms
+  "`[floor <substrate>]` for a segment."
+  [segment-id]
+  [(floor-bulk-arm)
+   (case segment-id
+     :reagent-subs (reagent-bulk-arm)
+     :uix-subs     (uix-bulk-arm))])
+
+(defn mount-bulk-arms! [arms]
+  (mapv (fn [a]
+          (let [c (h/container!)]
+            {:arm a :container c :handle ((:mount a) c)}))
+        arms))
+
+(defn release-bulk-arms! [mounts]
+  (doseq [{:keys [arm handle container]} mounts]
+    (try ((:unmount arm) handle) (catch :default _ nil))
+    (.remove container)))
+
+;; ---------------------------------------------------------------------------
+;; The bulk window
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private gen-seq (atom 1000))
+(defn next-gen! [] (swap! gen-seq inc))
+
+(defn timed-write!
+  "Write, yield ONE microtask, force the arm's own synchronous drain, stop
+  the clock — then VERIFY at the DOM that the cell holds what was written.
+  Answers a promise of `{:ms :write-ms :gap-ms :force-ms :ok?}`.
+
+  The legs are published beside the total so the microtask boundary is
+  VISIBLE rather than assumed empty: whatever a substrate's notification
+  does, it does it in `:gap-ms`, and the floor — which needs no yield —
+  is the in-situ control that says what an empty gap costs."
+  [{:keys [arm container]} i v]
+  (let [t0 (h/now-ms)]
+    ((:write! arm) i v)
+    (let [t1 (h/now-ms)]
+      (-> (js/Promise.resolve nil)
+          (.then (fn [_]
+                   (let [t2 (h/now-ms)]
+                     ((:force! arm))
+                     (let [t3    (h/now-ms)
+                           probe (if (= i :all) 0 i)]
+                       {:ms       (- t3 t0)
+                        :write-ms (- t1 t0)
+                        :gap-ms   (- t2 t1)
+                        :force-ms (- t3 t2)
+                        :ok?      (and (= (str v) (cell-text container probe))
+                                       (or (not= i :all)
+                                           (= (str v) (cell-text container
+                                                                 (dec fx/cells-n)))))})))))))))
+
+(defn chain
+  "Fold `xs` into a serial promise chain, threading an accumulator."
+  [init xs f]
+  (reduce (fn [p x] (.then p (fn [acc] (f acc x)))) (js/Promise.resolve init) xs))
+
+(def writes-per-sample
+  "How many writes one SAMPLE contains.
+
+  Chrome clamps `performance.now()` to 100 us. A broad write costs every
+  arm well above that, so one write is a sample. A NARROW write does not:
+  measured one at a time on the predecessor's harness both the floor and
+  Reagent returned exactly 0.1 ms — the quantum itself, which is a null
+  result wearing a different hat. Twenty writes to a sample lifts every
+  arm clear of the clamp and the per-write figure is the sample over 20."
+  {:broad 1 :narrow 20})
+
+(defn- n-writes! [mnt kind n]
+  (chain {:ms 0 :write-ms 0 :gap-ms 0 :force-ms 0 :bad 0 :total 0} (range n)
+         (fn [acc _]
+           (let [v (next-gen!)
+                 i (if (= kind :broad) :all (mod v fx/cells-n))]
+             (-> (timed-write! mnt i v)
+                 (.then (fn [{:keys [ms write-ms gap-ms force-ms ok?]}]
+                          (cond-> (-> acc
+                                      (update :ms + ms)
+                                      (update :write-ms + write-ms)
+                                      (update :gap-ms + gap-ms)
+                                      (update :force-ms + force-ms)
+                                      (update :total inc))
+                            (not ok?) (update :bad inc)))))))))
+
+(defn warm-bulk!
+  "Warm every bulk arm before any clock is read, for the reason the
+  harness namespace gives: position dominates adjacency and an unwarmed
+  site reads 1.26x to 5.3x its settled value."
+  [mounts kind n]
+  (chain nil (for [_ (range n) m mounts] m)
+         (fn [_ m] (-> (n-writes! m kind (get writes-per-sample kind))
+                       (.then (fn [_] nil))))))
+
+(defn bulk-round!
+  "One round of a bulk row: `samples` sample indices, every arm written at
+  every index, order rotating AND reflecting with the index. Answers a
+  promise of `{:readings :legs :order :bad :total :position}`."
+  [mounts kind {:keys [samples]} position-start]
+  (let [k (count mounts)
+        n (get writes-per-sample kind)]
+    (chain {:readings (zipmap (map #(:id (:arm %)) mounts) (repeat []))
+            :legs     (zipmap (map #(:id (:arm %)) mounts) (repeat []))
+            :order    []
+            :bad      0
+            :total    0
+            :position position-start
+            :previous nil}
+           (for [s (range samples) j (guard/slot-order k s)] [s j])
+           (fn [acc [_s j]]
+             (let [mnt (nth mounts j)
+                   id  (:id (:arm mnt))]
+               (-> (n-writes! mnt kind n)
+                   (.then (fn [{:keys [ms write-ms gap-ms force-ms bad total]}]
+                            (-> acc
+                                (update :bad + bad)
+                                (update :total + total)
+                                (update-in [:readings id] conj ms)
+                                (update-in [:legs id] conj {:write write-ms
+                                                            :gap   gap-ms
+                                                            :force force-ms})
+                                (update :order conj {:arm         id
+                                                     :value       ms
+                                                     :predecessor (:previous acc)
+                                                     :position    (:position acc)})
+                                (update :position inc)
+                                (assoc :previous id))))))))))
+
+(defn leg-summary
+  "Per-arm p50 of each leg of the window, in ms per SAMPLE."
+  [legs]
+  (into {}
+        (map (fn [[id xs]]
+               [id (when (seq xs)
+                     {:write-ms (h/p50 (map :write xs))
+                      :gap-ms   (h/p50 (map :gap xs))
+                      :force-ms (h/p50 (map :force xs))})]))
+        legs))
+
+(defn canon-of [mounts] (mapv (fn [m] (h/canonical (:container m))) mounts))

--- a/implementation/core/test/re_frame/bench/p0_fixture.cljc
+++ b/implementation/core/test/re_frame/bench/p0_fixture.cljc
@@ -1,0 +1,136 @@
+(ns re-frame.bench.p0-fixture
+  "EP-0038 P0 — the FIXTURE every arm shares: the witness shapes, the
+  element arithmetic, and the re-frame2 SUB GRAPH.
+
+  This namespace is the like-for-like contract. The P0 bar (HD-012) is
+  `mount AND bulk <= 1.0x Reagent, LIKE-FOR-LIKE — both sides reading
+  re-frame2 subscriptions`, and the only way a reader can check that two
+  arms were like-for-like is if the shapes and the subscriptions are one
+  declaration that both arms consume rather than two declarations someone
+  has to diff. Everything substrate-specific — `defui` + `use-subscribe`
+  for UIx, `reg-view` + `@(rf/subscribe …)` for Reagent — lives in the arm
+  namespaces; nothing about WHAT is read lives there.
+
+  ## The witnesses
+
+  Deliberately the shapes the predecessor's cross-substrate report already
+  measured, so the P0 table slots into that record rather than starting a
+  second, incomparable one — but with the sub graph added on BOTH sides,
+  which is the thing the predecessor row never had.
+
+    - **W1-list** — a large template: 300 rows under one boundary each,
+      multi-class sugar, a style map, a `data-*` passthrough, and one
+      subscription read per row boundary. 1,203 elements.
+    - **W3-form** — an ordinary 12-field form: label, controlled input,
+      error line, one subscription read per field boundary. 51 elements.
+    - **U-grid** — 300 independently-subscribed cells; the surface the two
+      bulk rows drive. 301 elements.
+
+  ## The sub graph
+
+  Three layer-1 subscriptions, keyed by index, ONE read per boundary — the
+  first rung of the HD-002 1/3/7/20 ladder. Every arm reads exactly these,
+  so a difference between arms is a difference in how a substrate delivers
+  a subscription value to a boundary and cannot be a difference in what
+  was subscribed to.
+
+  Layer-1 and index-keyed rather than a single whole-db read, because a
+  whole-db read makes every boundary re-render on every write and would
+  make the NARROW row unmeasurable by construction — the row that prices
+  localisation would price nothing.
+
+  ## Sub-key identity
+
+  `(query-id, args)` under value equality, args a bare long. Deliberately
+  not a map: the validation record calls unstable map args out as a
+  thrashing hazard, and a bench that used one would be measuring the
+  hazard.
+
+  Owner: the operator-owned standard bead rf2-2rtt6.1; this arm rf2-2rtt6.4."
+  (:require [re-frame.core :as rf]))
+
+;; ---------------------------------------------------------------------------
+;; Sizes — one place, so the arms cannot drift
+;; ---------------------------------------------------------------------------
+
+(def w1-rows
+  "Rows in the large template. 300 boundaries, which is the
+  `>= ~100 boundaries on one commit` shape the K2 kill criterion names."
+  300)
+
+(def w3-fields "Fields in the ordinary form." 12)
+
+(def cells-n
+  "Cells in the update grid. The same 300 as the mount storm, so a bulk
+  ratio and a mount ratio describe pages of the same size."
+  300)
+
+(defn w1-elements
+  "Three for the skeleton — section, heading, list — then four per row:
+  the row, its image, its label and its number. ARITHMETIC, so the parity
+  gate is against a written expectation rather than against whatever the
+  mount happened to produce. An arm that renders an empty page is the
+  cheapest arm in any table, and this is the line that catches it."
+  [rows]
+  (+ 3 (* 4 rows)))
+
+(defn w3-elements
+  "Three for the skeleton — form, fieldset, submit — then four per field:
+  the wrapper, the label, the input and the error line."
+  [fields]
+  (+ 3 (* 4 fields)))
+
+(defn u-elements
+  "The grid wrapper plus one span per cell."
+  [n]
+  (+ 1 n))
+
+;; ---------------------------------------------------------------------------
+;; The data
+;; ---------------------------------------------------------------------------
+
+(defn row-value
+  "The value the `:p0/row` subscription answers for row `i`. A plain
+  string: every arm renders it as text with no conversion of its own, so
+  the canonical-DOM gate compares pages rather than marshalling."
+  [i]
+  (str "row " i))
+
+(defn field-value [i] (str "value " i))
+
+(defn field-error [i] (if (even? i) "" (str "field " i " is required")))
+
+(defn seed-db
+  "The app-db every arm starts from. One map, so the two adapter segments
+  cannot begin from different data."
+  []
+  {:rows   (mapv row-value (range w1-rows))
+   :fields (mapv (fn [i] {:value (field-value i) :error (field-error i)})
+                 (range w3-fields))
+   :cells  (vec (repeat cells-n 0))})
+
+;; ---------------------------------------------------------------------------
+;; The registrations
+;; ---------------------------------------------------------------------------
+
+(defn register!
+  "Register the sub graph and the seed event. Idempotent — a re-register
+  overwrites with the identical handler — which matters because the clock
+  run installs and destroys an adapter once per segment and re-seeds
+  around each one."
+  []
+  (rf/reg-sub :p0/row   (fn [db [_ i]] (get-in db [:rows i])))
+  (rf/reg-sub :p0/field (fn [db [_ i]] (get-in db [:fields i])))
+  (rf/reg-sub :p0/cell  (fn [db [_ i]] (get-in db [:cells i])))
+  (rf/reg-event :p0/seed (fn [_ _] {:db (seed-db)}))
+  ;; The two BULK writes, as ordinary re-frame events. Both arms drive
+  ;; their bulk row through `dispatch-sync` on these, because in re-frame2
+  ;; the commit IS the write clock and an arm that reached past it — a
+  ;; bare `reagent.core/atom`, a direct app-db replace — would be skipping
+  ;; the event pipeline and the signal graph that a real application pays
+  ;; for on every write. The floor arm has neither and says so.
+  (rf/reg-event :p0/write-all
+    (fn [{:keys [db]} [_ v]] {:db (assoc db :cells (vec (repeat cells-n v)))}))
+  (rf/reg-event :p0/write-one
+    (fn [{:keys [db]} [_ i v]] {:db (update db :cells assoc i v)}))
+  nil)

--- a/implementation/core/test/re_frame/bench/p0_floor.cljs
+++ b/implementation/core/test/re_frame/bench/p0_floor.cljs
@@ -1,0 +1,142 @@
+(ns re-frame.bench.p0-floor
+  "EP-0038 P0 — the React FLOOR: the same three pages built by hand with
+  `react/createElement`, no substrate, no subscription, no boundary.
+
+  The floor is not a candidate and nobody could ship it. It exists to be
+  the CALIBRATOR, and in this arm it carries a second job the predecessor's
+  floor did not have.
+
+  ## Why P0 cannot be measured without it
+
+  A like-for-like P0 needs Reagent reading re-frame2 subscriptions AND UIx
+  reading re-frame2 subscriptions. Those are two different installed
+  adapters, and `install-adapter!` is once-per-process (Spec 006 §Single
+  adapter per process) — so the two arms cannot be interleaved inside one
+  round the way two arms on one adapter can. They are measured in two
+  SEGMENTS of the same round, in the same page, in the same process, with
+  the adapter destroyed and re-installed between them.
+
+  The floor runs in BOTH segments. It is identical work in both, it holds
+  no re-frame state and it is untouched by which adapter is installed, so
+  a difference between its two segment readings in one round is drift
+  between the segments and nothing else — and every published figure is a
+  ratio to the floor measured in the SAME segment of the SAME round. That
+  is what makes a UIx-over-Reagent ratio legitimate across the seam:
+  neither number is an absolute millisecond and the seam cancels.
+
+  A round in which the floor's two segments disagree by more than the
+  stated tolerance is reported as such; it is the seam's own control.
+
+  ## The bulk floor is NOT a lower bound
+
+  On mount the floor is a genuine floor — nothing builds this DOM with
+  less work than a bare `createElement` walk. On BULK it is a plain
+  top-down React re-render, which is what an application with no reactive
+  substrate costs. A fine-grained arm can and should beat it on the narrow
+  row, and a ratio below 1.0 there is a real result about localisation,
+  not an instrument fault.
+
+  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
+  (:require ["react" :as react]
+            [re-frame.bench.p0-fixture :as fx]))
+
+(defn- el
+  ([tag props] (react/createElement tag props))
+  ([tag props children] (react/createElement tag props children)))
+
+;; ---------------------------------------------------------------------------
+;; W1 — the large template
+;; ---------------------------------------------------------------------------
+
+(def ^:private row-style #js {:paddingLeft "4px" :color "rebeccapurple"})
+
+(defn- w1-row-el [i text]
+  (el "li" #js {:key i :className "row cell wide" :style row-style :data-index i}
+      #js [(el "img" #js {:key "a" :className "avatar" :src "/avatar.png" :alt ""})
+           (el "span" #js {:key "b" :className "label"} "row ")
+           (el "em" #js {:key "c" :className "n"} text)]))
+
+(defn w1
+  "The large template, floor arm. Takes the row texts as a plain vector —
+  the same values the `:p0/row` subscription answers, handed over directly
+  because the floor has no subscription to read them through."
+  [rows]
+  (el "section" #js {:className "panel" :aria-label "bench rows"}
+      #js [(el "h1" #js {:key "h" :className "title"} "Rows")
+           (el "ul" #js {:key "l" :className "rows" :role "list"}
+               (into-array (map-indexed w1-row-el rows)))]))
+
+;; ---------------------------------------------------------------------------
+;; W3 — the ordinary form
+;; ---------------------------------------------------------------------------
+
+(defn- w3-field-el [i {:keys [value error]}]
+  (el "div" #js {:key i :className "field"}
+      #js [(el "label" #js {:key "l" :className "lbl" :htmlFor (str "f" i)}
+               (str "Field " i))
+           (el "input" #js {:key       "i"
+                            :className "inp"
+                            :id        (str "f" i)
+                            :name      (str "f" i)
+                            :type      "text"
+                            :value     value
+                            :readOnly  true})
+           (el "p" #js {:key "p" :className "err"} error)]))
+
+(defn w3
+  "The 12-field form, floor arm."
+  [fields]
+  (el "form" #js {:className "w3form"}
+      #js [(el "fieldset" #js {:key "f" :className "fields"}
+               (into-array (map-indexed w3-field-el fields)))
+           (el "button" #js {:key "b" :className "submit" :type "submit" :disabled true}
+               "Submit")]))
+
+;; ---------------------------------------------------------------------------
+;; U — the bulk witness
+;; ---------------------------------------------------------------------------
+
+(defn u-grid
+  "The bulk grid over an explicit `cells` vector. No state and no hook: a
+  write is the caller re-rendering the whole root with a new vector, which
+  is exactly the top-down re-render this arm is here to price."
+  [cells]
+  (el "div" #js {:className "ugrid"}
+      (into-array
+        (map-indexed
+          (fn [i v] (el "span" #js {:key i :className "cell" :data-i i} (str v)))
+          cells))))
+
+;; ---------------------------------------------------------------------------
+;; The positive control — a page of KNOWN relative size
+;; ---------------------------------------------------------------------------
+
+(defn w1-double
+  "W1 with twice the rows, and nothing else changed.
+
+  This is the clock's POSITIVE CONTROL and it is the only arm here whose
+  answer is PREDICTED before it is measured. `w1-elements 600` is 2,403
+  against `w1-elements 300`'s 1,203, so a mount window that is measuring
+  the construction and commit of this page must read
+
+      w1-double / w1  =  2403 / 1203  =  1.997
+
+  to within the run's own noise. A window that is measuring something else
+  — a scheduler hop, a constant, an arm that rendered nothing — has no
+  reason to land there, and the fifteen recorded instrument faults on the
+  predecessor's harnesses all produced a plausible precise wrong number
+  first. A figure nobody can falsify is not a measurement.
+
+  The control is deliberately built on the FLOOR rather than on a
+  substrate arm: it must price the instrument, not a substrate, so it
+  contains no boundary, no subscription and no adapter, and it therefore
+  reads the same in both segments."
+  [rows]
+  (w1 (into (vec rows) rows)))
+
+(def control-predicted-ratio
+  "2403/1203 — the element ratio `w1-double` has to reproduce on the clock.
+  Written as arithmetic over the fixture rather than as a literal, so it
+  moves if the witness does."
+  (/ (double (fx/w1-elements (* 2 fx/w1-rows)))
+     (double (fx/w1-elements fx/w1-rows))))

--- a/implementation/core/test/re_frame/bench/p0_harness.cljs
+++ b/implementation/core/test/re_frame/bench/p0_harness.cljs
@@ -1,0 +1,295 @@
+(ns re-frame.bench.p0-harness
+  "EP-0038 P0 — the INSTRUMENT. Canonical DOM, one timed commit, rounds
+  whose arm order rotates AND reflects, and floor normalisation.
+
+  Kept apart from the arms so the METHOD is one thing a reader checks
+  once. Every rule below is a recorded instrument fault from the
+  predecessor's harnesses, each of which produced a plausible precise
+  WRONG NUMBER before it was caught.
+
+  ## A reading is one `flushSync` window
+
+  `react-dom/flushSync` brackets the commit, so the measured window holds
+  element construction AND React's render, commit and DOM mutation, with
+  nothing scheduled out of it. Nothing runs inside an `act` environment:
+  `act` diverts work to its own queue, which is not what a browser does,
+  and measured, cost ~600 ms a call.
+
+  ## Warm-up matters more than interleaving
+
+  The `.cjs` order guard's live reproduction measured one control over
+  sixteen consecutive windows with nothing varying but how many times the
+  site had run:
+
+      42.32 | 10.26 10.26 10.26 10.33 10.28 | 8.12 8.12 ... 8.12
+
+  — 5.3x the settled value on the first window, +27% for the next five,
+  and 8.122 for ever after the seventh; while the immediate PREDECESSOR,
+  with position held fixed, was worth 0.0-0.3%. So this harness warms
+  every arm before it reads any of them, and it still interleaves,
+  because a plan reversal moves position and adjacency together and
+  neither factor may be left unchecked.
+
+  ## Interleaving at the SAMPLE level, rotating AND reflecting
+
+  A workstation with six other agents on it drifts on a timescale that
+  runs all of one arm and then all of another straight into a systematic
+  error. So every sample index mounts every arm, in an order that rotates
+  AND REFLECTS with the index. A bare cyclic rotation changes which arm
+  goes FIRST and NOTHING ELSE — arm `a` sits at slot `(a - s) mod k`, so
+  its predecessor is `(a - 1) mod k` at every index — and every
+  interleaved harness in this repository published that as a mitigation
+  when it was not one. The order comes from
+  `re-frame.bench.order-guard/slot-order`, which is the shared expression
+  of the rule and carries its own arithmetic self-test.
+
+  ## Ranges, never a mean alone
+
+  Absolute milliseconds are published because a ratio on a 0.2 ms
+  operation is not a product decision and a reader is owed the size of the
+  thing. But no cross-round absolute claim is made: every figure is a
+  ratio to the floor measured in the SAME round and the SAME segment, and
+  a range that straddles 1.0 is reported as INDISTINGUISHABLE rather than
+  as a winner.
+
+  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
+  (:require ["react-dom" :as react-dom]
+            [clojure.string :as str]
+            [re-frame.bench.order-guard :as guard]))
+
+;; ---------------------------------------------------------------------------
+;; The clock
+;; ---------------------------------------------------------------------------
+
+(defn now-ms
+  "`performance.now()` where it exists. Chrome clamps it to 100 us, which
+  is why the bulk rows batch their writes into a sample."
+  []
+  (if (and (exists? js/performance) (.-now js/performance))
+    (js/performance.now)
+    (.getTime (js/Date.))))
+
+(defn- round4 [x]
+  (/ (js/Math.round (* (double x) 10000.0)) 10000.0))
+
+(defn p50 [xs] (guard/median xs))
+
+;; ---------------------------------------------------------------------------
+;; Canonical DOM — the fairness gate
+;; ---------------------------------------------------------------------------
+
+(defn canonical
+  "Serialise `node`'s subtree with every element's attribute names SORTED.
+
+  `innerHTML` preserves insertion order and two front ends write props in
+  different orders, so comparing it compares the serialiser rather than
+  the page — the predecessor's first run reported two witnesses as
+  producing different pages on exactly that mistake, and they did not.
+  Sorting the names compares the DOM.
+
+  This is the entire fairness guarantee. Without it two arms could be
+  timed against each other while building different pages, and a
+  canonical-DOM gate has already caught an arm rendering an EMPTY page."
+  [node]
+  (let [out (array)]
+    (letfn [(walk [n]
+              (case (.-nodeType n)
+                1 (let [tag   (str/lower-case (.-tagName n))
+                        attrs (->> (array-seq (.-attributes n))
+                                   (map (fn [a] [(.-name a) (.-value a)]))
+                                   (sort-by first))]
+                    (.push out (str "<" tag))
+                    (doseq [[k v] attrs]
+                      (.push out (str " " k "=\"" v "\"")))
+                    (.push out ">")
+                    (doseq [c (array-seq (.-childNodes n))] (walk c))
+                    (.push out (str "</" tag ">")))
+                3 (.push out (.-nodeValue n))
+                8 nil
+                (.push out (str "#" (.-nodeType n)))))]
+      (doseq [c (array-seq (.-childNodes node))] (walk c)))
+    (.join out "")))
+
+(defn element-count [node]
+  (.-length (.querySelectorAll node "*")))
+
+;; ---------------------------------------------------------------------------
+;; Hosts
+;; ---------------------------------------------------------------------------
+
+(defn browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn leave-act-environment!
+  "Every reading is taken outside React's `act` queue, so a commit measured
+  here is the commit a user's page performs."
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  nil)
+
+(defn container! []
+  (let [c (js/document.createElement "div")]
+    (.appendChild js/document.body c)
+    c))
+
+;; ---------------------------------------------------------------------------
+;; One timed mount
+;; ---------------------------------------------------------------------------
+
+(defn mount-arm!
+  "Mount `arm` into a fresh host and answer `{:ms … :container … :handle …}`.
+
+  The container is created and attached OUTSIDE the window: a
+  `document.createElement` billed to one arm and not another would be a
+  systematic error the size of some of the effects here."
+  [arm]
+  (let [container (container!)
+        handle    (volatile! nil)
+        t0        (now-ms)]
+    (react-dom/flushSync (fn [] (vreset! handle ((:mount arm) container))))
+    {:ms (- (now-ms) t0) :container container :handle @handle :arm arm}))
+
+(defn release!
+  "Unmount and detach. Never timed."
+  [{:keys [arm handle container]}]
+  (when handle
+    (try (react-dom/flushSync (fn [] ((:unmount arm) handle)))
+         (catch :default _ nil)))
+  (when container (.remove container))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Parity — run before any clock is read
+;; ---------------------------------------------------------------------------
+
+(defn parity
+  "Mount every arm at once and answer
+  `{:canon {id html} :counts {id n} :agree? bool :disagree [id …]}`,
+  LEAVING THE MOUNTS STANDING for the caller to release.
+
+  Every arm mounted simultaneously rather than one at a time, because the
+  comparison is of pages and a page is what is in the document."
+  [arms]
+  (let [mounts (mapv mount-arm! arms)
+        canon  (into {} (map (fn [m] [(:id (:arm m)) (canonical (:container m))]) mounts))
+        counts (into {} (map (fn [m] [(:id (:arm m)) (element-count (:container m))]) mounts))
+        ref    (get canon (:id (:arm (first mounts))))]
+    {:mounts    mounts
+     :canon     canon
+     :counts    counts
+     :reference ref
+     :agree?    (every? #(= ref %) (vals canon))
+     :disagree  (into [] (comp (remove (fn [[_ h]] (= ref h))) (map first)) canon)}))
+
+;; ---------------------------------------------------------------------------
+;; Rounds
+;; ---------------------------------------------------------------------------
+
+(defn warm!
+  "Mount and release every arm `n` times, reading no clock.
+
+  Position dominates adjacency, and a site that has not run enough times
+  yet reads 1.26x to 5.3x its settled value. Warming is therefore not
+  hygiene, it is the largest single correction this instrument makes."
+  [arms n]
+  (dotimes [_ n]
+    (doseq [arm arms]
+      (release! (mount-arm! arm))))
+  nil)
+
+(defn mount-round!
+  "One round of the mount row: `samples` sample indices, every arm mounted
+  at every index, order rotating AND reflecting with the index.
+
+  EVERY measured mount is verified against `expected` element count,
+  OUTSIDE its own window (the window closes when `flushSync` returns).
+  `:bad` / `:total` are the `N unverified of M` a report must carry: an arm
+  that renders an empty page is the cheapest arm in any table, and a
+  canonical-DOM gate has already caught exactly that.
+
+  Answers `{:readings {id [ms …]} :order [{:arm :value :predecessor
+  :position} …] :bad n :total n :position n}` — the order samples carry
+  BOTH nuisance factors, because a plan reversal moves them together and
+  neither may be left unchecked."
+  [arms {:keys [samples]} expected position-start]
+  (let [k    (count arms)
+        acc  (atom {:readings (zipmap (map :id arms) (repeat []))
+                    :order    []
+                    :bad      0
+                    :total    0
+                    :position position-start
+                    :previous nil})]
+    (dotimes [s samples]
+      (doseq [j (guard/slot-order k s)]
+        (let [arm (nth arms j)
+              mnt (mount-arm! arm)
+              ok? (= expected (element-count (:container mnt)))]
+          (swap! acc (fn [a]
+                       (cond-> (-> a
+                                   (update-in [:readings (:id arm)] conj (:ms mnt))
+                                   (update :order conj {:arm         (:id arm)
+                                                        :value       (:ms mnt)
+                                                        :predecessor (:previous a)
+                                                        :position    (:position a)})
+                                   (update :total inc)
+                                   (update :position inc)
+                                   (assoc :previous (:id arm)))
+                         (not ok?) (update :bad inc))))
+          (release! mnt))))
+    (select-keys @acc [:readings :order :bad :total :position])))
+
+(defn normalise
+  "One round's raw readings as `{:p50 {id ms} :ratio {id r}}`, every ratio
+  against the floor measured in THIS round and THIS segment."
+  [readings floor-id]
+  (let [p50s  (into {} (map (fn [[id xs]] [id (p50 xs)])) readings)
+        floor (get p50s floor-id)]
+    {:p50   p50s
+     :ratio (into {} (map (fn [[id v]] [id (round4 (/ v floor))])) p50s)}))
+
+(defn across-rounds
+  "Fold per-round ratio maps into
+  `{id {:mean :min :max :rounds :straddles-1?}}`.
+
+  `:straddles-1?` is the honesty flag: when an arm's range includes 1.0 the
+  report must say the arms are INDISTINGUISHABLE rather than quote the
+  mean as a winner."
+  [round-ratios]
+  (let [ids (keys (first round-ratios))]
+    (into {}
+          (map (fn [id]
+                 (let [vs (mapv #(get % id) round-ratios)]
+                   [id {:mean         (round4 (/ (reduce + 0.0 vs) (count vs)))
+                        :min          (round4 (apply min vs))
+                        :max          (round4 (apply max vs))
+                        :rounds       (count vs)
+                        :straddles-1? (and (<= (apply min vs) 1.0)
+                                           (>= (apply max vs) 1.0))}])))
+          ids)))
+
+(defn ratio-of-ratios
+  "The cross-SEGMENT figure: `numerator`'s floor-normalised ratio over
+  `denominator`'s, per round, folded into a range.
+
+  This is the shape the red-zone thresholds are published in. Both inputs
+  are ratios to the floor measured in their own segment of the same round,
+  so the segment seam — the adapter destroy/install between them — cancels
+  exactly. Answers `{:per-round [r …] :mean :min :max :straddles-1?}`."
+  [num-per-round den-per-round]
+  (let [vs (mapv (fn [n d] (round4 (/ n d))) num-per-round den-per-round)]
+    {:per-round    vs
+     :mean         (round4 (/ (reduce + 0.0 vs) (count vs)))
+     :min          (round4 (apply min vs))
+     :max          (round4 (apply max vs))
+     :rounds       (count vs)
+     :straddles-1? (and (<= (apply min vs) 1.0) (>= (apply max vs) 1.0))}))
+
+;; ---------------------------------------------------------------------------
+;; Publication
+;; ---------------------------------------------------------------------------
+
+(defn publish!
+  "Write one record to the console as EDN, tagged so the driver can find
+  it in the console stream."
+  [tag record]
+  (js/console.log (str ";; P0 " tag "\n" (pr-str record))))

--- a/implementation/core/test/re_frame/bench/p0_harness.cljs
+++ b/implementation/core/test/re_frame/bench/p0_harness.cljs
@@ -132,6 +132,78 @@
     (.appendChild js/document.body c)
     c))
 
+(defn collect!
+  "Force a garbage collection BETWEEN samples, never inside a window.
+
+  This is here because the instrument measured what happens without it,
+  and it was not subtle. The FLOOR arm — a hand-written `createElement`
+  walk with no substrate, no subscription and no re-frame state, doing
+  byte-identical work in every round — read
+
+      W1 mount floor:  2.30 ms -> 4.85 ms -> 6.10 ms   across three rounds
+      W3 mount floor:  1.85 ms -> 3.85 ms -> 5.65 ms
+
+  while the BULK floor over the same run sat flat at 0.75-0.80 ms and
+  2.50-2.60 ms. The arm-order guard caught it as a phase contamination
+  (LAST-THIRD reading 2.16x to 3.05x FIRST-THIRD, ranges disjoint) and
+  refused, which is exactly what it is for. The difference between the two
+  phases is allocation: the mount rows build and discard hundreds of React
+  roots and hundreds of thousands of elements, and the collector's cost
+  climbs with the garbage nobody made it take. The bulk rows mount once
+  and then only write.
+
+  Left alone, that drift does NOT cancel in the ratio — the same round's
+  W1 readings gave 2.48x, then 1.69x, then 1.57x for one arm over the
+  floor. A run that published the mean of those would be publishing the
+  collector's schedule.
+
+  So the page is launched with `--js-flags=--expose-gc` and every sample
+  is followed by a collection. It sits outside every `flushSync` window by
+  construction. The clock and the heap are separate claims and this is the
+  seam between them: allocation is priced by the retained-heap row, and
+  the clock row is not allowed to smear it across whichever arm happened
+  to be measured when a major collection fell due.
+
+  **A bare `gc()` is not enough, and the probe is what established that.**
+  Chrome's exposed `gc()` performs a SCAVENGE — a minor collection of the
+  young generation — and the mount rows' garbage is promoted long before
+  it runs. With a bare `gc()` after every sample the page's
+  `usedJSHeapSize` still climbed monotonically 34 MB -> 46 -> 55 -> 63 ->
+  75 -> 87 across six segment entries, while `body-children` sat at 2 the
+  whole time: nothing was leaking into the document, the collector was
+  simply not being asked to do the work. The floor drifted 4.05 -> 7.95 ->
+  8.60 ms on exactly that heap. So the request is explicit — a synchronous
+  MAJOR collection — with the bare call kept as a fallback for a runtime
+  that does not accept the options form.
+
+  When `gc` is absent the harness does not pretend: nothing is collected
+  and the guard's phase factor will catch the consequence."
+  []
+  (when-some [g (.-gc js/window)]
+    (try (g #js {:type "major" :execution "sync"})
+         (catch :default _ (g))))
+  nil)
+
+(defn probe
+  "A cheap, published snapshot of the two things that make a page get
+  slower as a run proceeds: what it is holding, and what it left attached
+  to the document.
+
+  `:body-children` is the leak canary. Every sample attaches its
+  containers to `document.body` and detaches them again, so this number
+  must be constant across the whole run. A number that CLIMBS says the
+  arms are leaking mounted roots, and a leaking harness reads as a
+  progressively slower machine — which is precisely the diagnosis a
+  phase-contaminated figure invites a reader to make, wrongly."
+  []
+  {:used-heap     (if-some [m (.-memory js/performance)] (.-usedJSHeapSize m) -1)
+   :body-children (.-childElementCount js/document.body)})
+
+(def gc-available?
+  "Published beside every record, because a run without the collector is a
+  different instrument and the reader is owed which one produced the row."
+  (delay (some? (.-gc js/window))))
+
 ;; ---------------------------------------------------------------------------
 ;; One timed mount
 ;; ---------------------------------------------------------------------------
@@ -149,12 +221,37 @@
     (react-dom/flushSync (fn [] (vreset! handle ((:mount arm) container))))
     {:ms (- (now-ms) t0) :container container :handle @handle :arm arm}))
 
+;; ---------------------------------------------------------------------------
+;; Releasing — and the nested-`flushSync` fault that hid inside it
+;; ---------------------------------------------------------------------------
+;;
+;; **An unmount must NOT be wrapped in `react-dom/flushSync`.** Every
+;; React root's own `unmount()` opens a `flushSync` internally to tear the
+;; tree down; wrapping the call in one more makes that a NESTED flush,
+;; which React does not perform — it schedules the work instead. The root
+;; handle is nulled either way, so the caller sees a clean return, and in
+;; an `:advanced` bundle the development warning that would have said so
+;; is compiled out. The container is then detached from a document that
+;; never committed the unmount, and the whole fiber tree stays reachable.
+;;
+;; Measured, on this instrument, with the wrapper in place: the page's
+;; `usedJSHeapSize` climbed 34 -> 46 -> 55 -> 63 -> 75 -> 87 MB across six
+;; segment entries — about 12 MB per entry, which is 18 W1 roots at
+;; ~500 KB plus 144 W3 roots at ~25 KB, i.e. EVERY root retained — while
+;; `body-children` sat at 2 throughout, so nothing was leaking into the
+;; document. The floor arm, which cannot change, drifted 3.4 -> 5.8 -> 7.0
+;; ms and the arm-order guard refused on phase. A forced major collection
+;; between samples did not move it, because the roots were not garbage.
+;;
+;; The `try/catch` that used to sit around the unmount is gone with it. It
+;; swallowed exactly the class of failure that produces this fault, and a
+;; release that fails silently is how a benchmark comes to be measuring a
+;; page that is still standing.
+
 (defn release!
-  "Unmount and detach. Never timed."
+  "Unmount and detach. Never timed. NOT wrapped in `flushSync` — see above."
   [{:keys [arm handle container]}]
-  (when handle
-    (try (react-dom/flushSync (fn [] ((:unmount arm) handle)))
-         (catch :default _ nil)))
+  (when handle ((:unmount arm) handle))
   (when container (.remove container))
   nil)
 
@@ -181,21 +278,109 @@
      :agree?    (every? #(= ref %) (vals canon))
      :disagree  (into [] (comp (remove (fn [[_ h]] (= ref h))) (map first)) canon)}))
 
+(defn mount-sample!
+  "`n` mounts of `arm` as ONE sample, each into its own pre-attached
+  container, the clock bracketing only the mounts.
+
+  `n > 1` exists for the same reason the bulk row batches its narrow
+  writes. Chrome clamps `performance.now()` to 100 us, and the 51-element
+  form mounts in three to eight quanta — close enough to the clamp that
+  two arms can read the identical figure because the timer cannot tell
+  them apart, which is a null result wearing the clothes of a tie. This
+  run MEASURED that: at one mount a sample, both segments of the form
+  witness returned exactly 0.75 ms and the ratio came out at precisely
+  1.0000. Batching lifts every arm clear of the clamp; the witness is
+  unchanged, only the sample is bigger.
+
+  The containers are created and attached OUTSIDE the window: a
+  `document.createElement` billed to one arm and not another would be a
+  systematic error the size of some of the effects here.
+
+  Answers `{:ms … :bad n :total n}` with every mount in the sample
+  verified against `expected` — outside the window, since the window
+  closes when the last `flushSync` returns."
+  [arm n expected]
+  (let [containers (mapv (fn [_] (container!)) (range n))
+        handles    (volatile! [])
+        t0         (now-ms)]
+    (doseq [c containers]
+      (react-dom/flushSync (fn [] (vswap! handles conj ((:mount arm) c)))))
+    (let [ms  (- (now-ms) t0)
+          bad (if (nil? expected)
+                0
+                (count (remove #(= expected (element-count %)) containers)))]
+      ;; Bare, and unguarded. See the release! commentary below: wrapping
+      ;; this in `flushSync` nests a flush React will not perform, and
+      ;; retains every root that was ever mounted.
+      (doseq [hd @handles] ((:unmount arm) hd))
+      (doseq [c containers] (.remove c))
+      (collect!)
+      {:ms ms :bad bad :total n})))
+
+;; ---------------------------------------------------------------------------
+;; The schedule, CHOSEN by its measured property rather than assumed
+;; ---------------------------------------------------------------------------
+
+(defn choose-schedule
+  "Pick the run order whose ADJACENCY actually gives every arm at least two
+  distinct immediate predecessors, and answer it with the evidence.
+
+  `slot-order` — rotate then reflect on odd indices — is the shared rule,
+  and for three or more arms it is the right one: a bare cyclic rotation
+  changes which arm goes FIRST and nothing else, so every arm keeps the
+  same predecessor in every round. **But for exactly TWO arms it
+  degenerates**: rotating `[0 1]` gives `[1 0]`, reversing that gives
+  `[0 1]` again, so the reflecting schedule emits the identical order at
+  every index and each arm has exactly one predecessor for ever. This run
+  measured that too — the guard reported `:unchecked`, `only 1 stratum —
+  the question was never asked`, on every substrate arm, and refused.
+  That is the guard doing its job, and the repair belongs HERE, in the
+  arm, not in the guard.
+
+  So rather than hard-coding either rule, both candidates are scored with
+  the guard's own `adjacency` over the run this harness is about to
+  perform, and the one that satisfies the property with the lowest modal
+  predecessor share wins. `:seams?` is true because these sample indices
+  genuinely run back to back in one call: the last arm of index `s` really
+  does precede the first of index `s+1`.
+
+  Answers `{:name :fn :min-distinct :max-modal-share :sufficient?}`. When
+  neither candidate qualifies the harness does NOT silently proceed — the
+  fact is published and the guard's `:unchecked` refusal stands."
+  [k samples]
+  (let [score (fn [nm f]
+                (let [a  (guard/adjacency k samples f {:seams? true})
+                      as (vals (:arms a))]
+                  {:name            nm
+                   :fn              f
+                   :min-distinct    (apply min (map :distinct as))
+                   :max-modal-share (apply max (map :modal-share as))}))
+        cands [(score :reflecting guard/slot-order)
+               (score :rotating   guard/rotation-only)]
+        ok    (filter #(>= (:min-distinct %) 2) cands)]
+    (if (seq ok)
+      (assoc (apply min-key :max-modal-share ok) :sufficient? true)
+      (assoc (first cands) :sufficient? false))))
+
 ;; ---------------------------------------------------------------------------
 ;; Rounds
 ;; ---------------------------------------------------------------------------
 
-(defn warm!
-  "Mount and release every arm `n` times, reading no clock.
-
-  Position dominates adjacency, and a site that has not run enough times
-  yet reads 1.26x to 5.3x its settled value. Warming is therefore not
-  hygiene, it is the largest single correction this instrument makes."
-  [arms n]
-  (dotimes [_ n]
-    (doseq [arm arms]
-      (release! (mount-arm! arm))))
-  nil)
+;; THE WARM-UP IS INSIDE THE ROUND, and that is not a stylistic choice.
+;;
+;; Position dominates adjacency, and a site that has not run enough times
+;; yet reads 1.26x to 5.3x its settled value — so warming matters more
+;; than interleaving does. But a warm-up run as a SEPARATE loop before the
+;; round leaves the first recorded sample of every round with NO
+;; predecessor, and this instrument measured what that costs: the guard
+;; partitioned the `<none>` stratum against the rest and found the first
+;; sample of a round reading 1.35x its siblings, ranges disjoint, and
+;; refused. The first sample after an adapter destroy/install genuinely IS
+;; cold; hiding it in a stratum of its own is not a fix.
+;;
+;; So `mount-round!` and `bulk-round!` run `warmup` sample indices that are
+;; measured and thrown away, threading `:previous` through them, and the
+;; first RECORDED sample therefore has a real predecessor like every other.
 
 (defn mount-round!
   "One round of the mount row: `samples` sample indices, every arm mounted
@@ -211,32 +396,34 @@
   :position} …] :bad n :total n :position n}` — the order samples carry
   BOTH nuisance factors, because a plan reversal moves them together and
   neither may be left unchecked."
-  [arms {:keys [samples]} expected position-start]
-  (let [k    (count arms)
-        acc  (atom {:readings (zipmap (map :id arms) (repeat []))
-                    :order    []
-                    :bad      0
-                    :total    0
-                    :position position-start
-                    :previous nil})]
-    (dotimes [s samples]
-      (doseq [j (guard/slot-order k s)]
+  [arms {:keys [warmup samples]} expected per-sample position-start]
+  (let [k     (count arms)
+        total (+ warmup samples)
+        sched (choose-schedule k total)
+        order (:fn sched)
+        acc   (atom {:readings (zipmap (map :id arms) (repeat []))
+                     :order    []
+                     :bad      0
+                     :total    0
+                     :position position-start
+                     :previous nil})]
+    (dotimes [s total]
+      (doseq [j (order k s)]
         (let [arm (nth arms j)
-              mnt (mount-arm! arm)
-              ok? (= expected (element-count (:container mnt)))]
+              smp (mount-sample! arm per-sample expected)]
           (swap! acc (fn [a]
-                       (cond-> (-> a
-                                   (update-in [:readings (:id arm)] conj (:ms mnt))
-                                   (update :order conj {:arm         (:id arm)
-                                                        :value       (:ms mnt)
-                                                        :predecessor (:previous a)
-                                                        :position    (:position a)})
-                                   (update :total inc)
-                                   (update :position inc)
-                                   (assoc :previous (:id arm)))
-                         (not ok?) (update :bad inc))))
-          (release! mnt))))
-    (select-keys @acc [:readings :order :bad :total :position])))
+                       (cond-> (assoc a :previous (:id arm))
+                         (>= s warmup)
+                         (-> (update-in [:readings (:id arm)] conj (:ms smp))
+                             (update :order conj {:arm         (:id arm)
+                                                  :value       (:ms smp)
+                                                  :predecessor (:previous a)
+                                                  :position    (:position a)})
+                             (update :total + (:total smp))
+                             (update :bad + (:bad smp))
+                             (update :position inc))))))))
+    (assoc (select-keys @acc [:readings :order :bad :total :position])
+           :schedule (dissoc sched :fn))))
 
 (defn normalise
   "One round's raw readings as `{:p50 {id ms} :ratio {id r}}`, every ratio

--- a/implementation/core/test/re_frame/bench/p0_heap.cljs
+++ b/implementation/core/test/re_frame/bench/p0_heap.cljs
@@ -1,0 +1,252 @@
+(ns re-frame.bench.p0-heap
+  "EP-0038 P0 — RETAINED HEAP per boundary, the second red-zone axis.
+
+  The delegated ruling on rf2-2rtt6.1 sets a UIx threshold on the clock
+  AND on retained heap, per witness family, so this axis is not a
+  supporting number either.
+
+  ## Retention, not allocation, and why that is not a preference
+
+  V8's CDP SAMPLING heap profiler **drops the samples of collected
+  objects**. Pointed at a mount/unmount loop it reports the residue of a
+  page that has already been discarded, not the cost of the page: on the
+  predecessor's instrument the same 80,000 objects read 4.77 MB when a
+  global held them and 0.00 MB when nothing did. Nothing here counts
+  allocations.
+
+  Retention is also the right question. What an application pays for a
+  boundary is what the boundary keeps STANDING — the hook records, the
+  subscription registration, the fiber — not what it touched on the way
+  up. The budget in validation.md is stated the same way: exclusive
+  retained per boundary, ~0.4-0.5 KB target, > 1 KB fails on paper.
+
+  ## The shape of a reading
+
+  Mount K roots and KEEP them. The driver forces a full collection, reads
+  the heap, and only then asks this namespace to mount. Nothing is timed
+  and nothing is unmounted inside a window. Then the roots are released,
+  the heap is collected and read again — and that second read is a control
+  in its own right, because a substrate whose released heap does not
+  return to baseline is retaining something after unmount, which is a
+  different and worse finding than a large per-boundary figure.
+
+  Every mount is verified at the DOM: `mount!` counts the boundary
+  elements the arm should have produced and answers the count beside the
+  expectation. An arm that silently rendered nothing would otherwise read
+  as the leanest substrate in the table.
+
+  ## Segments here too
+
+  One adapter per process, so the Reagent-on-subs and UIx-on-subs arms
+  cannot both be live at once. `prepare!` swaps the adapter and stands the
+  frame back up, and the DRIVER calls it BEFORE the baseline read of the
+  pair it is about to take — so the swap's own residue lands in the
+  baseline rather than in the arm. The floor is measured in both segments
+  and is the shared calibrator, exactly as on the clock.
+
+  ## What a JS-heap reading cannot see
+
+  DOM nodes live in Blink's C++ heap, not V8's, so none of these figures
+  contain the elements themselves. Every arm builds the identical DOM —
+  the clock run's canonical-DOM parity gate is what establishes that — so
+  the omission cancels in `arm - floor`, which is the exclusive figure the
+  red-zone is set from. The absolute column is a JS-heap figure and is
+  labelled as one.
+
+  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
+  (:require ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]
+            [re-frame.bench.order-guard :as guard]
+            [re-frame.bench.p0-arms :as arms]
+            [re-frame.bench.p0-fixture :as fx]
+            [re-frame.bench.p0-floor :as floor]
+            [re-frame.bench.p0-harness :as h]
+            [re-frame.bench.p0-reagent :as rg]
+            [re-frame.bench.p0-uix :as ux]
+            [reagent.dom.client :as rdc]
+            [uix.dom :as uix-dom]))
+
+(def per-root
+  "Boundaries in one root of the `grid` family — the same 300 the clock
+  rows drive, so a per-boundary figure here and a bulk ratio there
+  describe the same page."
+  fx/cells-n)
+
+(def rows-per-root fx/w1-rows)
+
+;; ---------------------------------------------------------------------------
+;; Arms — keyed `family/substrate`, the same naming the driver schedules on
+;; ---------------------------------------------------------------------------
+
+(defn- react-root-arm [element-of selector expected]
+  {:selector    selector
+   :expected    expected
+   :mount-one   (fn [c _i]
+                  (let [r (react-dom-client/createRoot c)]
+                    (react-dom/flushSync (fn [] (.render r (element-of))))
+                    r))
+   :unmount-one (fn [r] (react-dom/flushSync (fn [] (.unmount r))))})
+
+(defn- reagent-root-arm [form-of selector expected]
+  {:selector    selector
+   :expected    expected
+   :mount-one   (fn [c _i]
+                  (let [rt (rdc/create-root c)]
+                    (react-dom/flushSync (fn [] (rdc/render rt (form-of))))
+                    rt))
+   :unmount-one (fn [rt] (react-dom/flushSync (fn [] (rdc/unmount rt))))})
+
+(defn- uix-root-arm [element-of selector expected]
+  {:selector    selector
+   :expected    expected
+   :mount-one   (fn [c _i]
+                  (let [rt (uix-dom/create-root c)]
+                    (react-dom/flushSync (fn [] (uix-dom/render-root (element-of) rt)))
+                    rt))
+   :unmount-one (fn [rt] (react-dom/flushSync (fn [] (uix-dom/unmount-root rt))))})
+
+(def arm-table
+  "`arm-id -> {:segment :selector :expected :mount-one :unmount-one}`.
+
+  `:segment` is which adapter the arm needs; the driver calls `prepare!`
+  with it before taking the baseline of the pair. A floor arm names the
+  segment it is being measured IN, because the floor is the calibrator and
+  has to be read on both sides of the seam."
+  {:list/floor
+   (assoc (react-root-arm #(floor/w1 (mapv fx/row-value (range rows-per-root)))
+                          ".row" rows-per-root)
+          :segment nil)
+
+   :list/reagent
+   (assoc (reagent-root-arm #(rg/w1-root arms/frame-id rows-per-root)
+                            ".row" rows-per-root)
+          :segment :reagent-subs)
+
+   :list/uix
+   (assoc (uix-root-arm #(ux/w1-root arms/frame-id rows-per-root)
+                        ".row" rows-per-root)
+          :segment :uix-subs)
+
+   :grid/floor
+   (assoc (react-root-arm #(floor/u-grid (vec (repeat per-root 0)))
+                          ".cell" per-root)
+          :segment nil)
+
+   :grid/reagent
+   (assoc (reagent-root-arm #(rg/u-root arms/frame-id) ".cell" per-root)
+          :segment :reagent-subs)
+
+   :grid/uix
+   (assoc (uix-root-arm #(ux/u-root arms/frame-id) ".cell" per-root)
+          :segment :uix-subs)})
+
+;; ---------------------------------------------------------------------------
+;; Segment preparation — always OUTSIDE the baseline read
+;; ---------------------------------------------------------------------------
+
+(defn prepare!
+  "Install the adapter `segment-id` names and stand the frame back up.
+
+  Called by the driver BEFORE its baseline read, so the adapter swap's own
+  residue is in the baseline and not in the arm's retained delta. Passing
+  a segment that is already installed still re-seeds, so the two branches
+  cost the same."
+  [segment-id]
+  (let [segment (first (filter #(= segment-id (:id %)) arms/segments))]
+    (when segment (arms/enter-segment! segment)))
+  true)
+
+;; ---------------------------------------------------------------------------
+;; Holding, and letting go
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private held (atom nil))
+
+(defn- release!*
+  []
+  (when-some [{:keys [arm handles containers]} @held]
+    (let [{:keys [unmount-one]} (get arm-table arm)]
+      (doseq [hd (reverse handles)]
+        (try (unmount-one hd) (catch :default _ nil))))
+    (doseq [c containers] (.remove c))
+    (reset! held nil))
+  nil)
+
+(defn mount!
+  "Mount `k` roots of `arm-id` and KEEP them. Answers the DOM read-back
+  over the boundary class the arm should have produced.
+
+  A literal `#js` object rather than `clj->js`: `clj->js` would render
+  `:ok?` as the key `\"ok?\"` and a driver reading `verify.ok` would see
+  `undefined` — every mount reported unverified while every mount was
+  fine. That happened, on the predecessor's first run."
+  [arm-id k]
+  (release!*)
+  (let [{:keys [mount-one selector expected]} (get arm-table (keyword arm-id))
+        containers (mapv (fn [_] (h/container!)) (range k))
+        handles    (into [] (map-indexed (fn [i c] (mount-one c i))) containers)
+        elements   (.-length (.querySelectorAll js/document selector))
+        want       (* k expected)]
+    (reset! held {:arm (keyword arm-id) :handles handles :containers containers})
+    #js {:elements elements :expected want :ok (= elements want)}))
+
+;; ---------------------------------------------------------------------------
+;; The positive control
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private control-cell (atom nil))
+
+(defn control!
+  "Hold a dense JS array of exactly `n` doubles and answer its length, so
+  the allocation cannot be proved dead and elided.
+
+  V8 stores a packed double array as `n` unboxed 8-byte slots behind a
+  small header, so the retained cost is **8n bytes** — PREDICTED, not
+  merely observed. That is the entire point of a control: a figure the
+  instrument has to hit, not one it gets to report.
+
+  The predecessor's first draft of this control was a flat one-byte string
+  of `8n` characters, on the same reasoning, and it was a FICTION: a
+  4.7 MB `'x'.repeat(…)` reads as 6 KB on all three readers because V8
+  does not materialise the characters. Had it shipped, the control would
+  have missed by three orders of magnitude every round and the natural
+  conclusion would have been that the instrument was broken."
+  [n]
+  (let [a (js/Array. n)]
+    (dotimes [i n] (aset a i (+ i 0.5)))
+    (reset! control-cell a)
+    (.-length a)))
+
+(defn control-release! [] (reset! control-cell nil) 0)
+
+;; ---------------------------------------------------------------------------
+;; The page-side door
+;; ---------------------------------------------------------------------------
+
+(defn install!
+  "Publish the instrument on `window.P0H`. The page mounts; it never
+  decides when a reading is taken."
+  []
+  (set! (.-P0H js/window)
+        #js {:prepare        (fn [seg] (prepare! (when seg (keyword seg))))
+             :mount          (fn [arm k] (mount! arm k))
+             :release        (fn [] (release!*) true)
+             :control        (fn [n] (control! n))
+             :controlRelease (fn [] (control-release!))
+             :perfMem        (fn []
+                               (if-some [m (.-memory js/performance)]
+                                 (.-usedJSHeapSize m)
+                                 -1))
+             :slotOrder      (fn [n round] (clj->js (guard/slot-order n round)))
+             ;; ONE expression of the arm-order rule, used by both rows.
+             ;; The heap row's samples are produced by the DRIVER (only it
+             ;; can force a collection), so the driver hands them back in
+             ;; here to be adjudicated by the same `re-frame.bench.order-guard`
+             ;; the clock row uses in-page. A second copy of the rule in
+             ;; JavaScript would be a second place for it to drift.
+             :verdict        (fn [samples tolerance]
+                               (pr-str (guard/verdict (js->clj samples :keywordize-keys true)
+                                                      {:tolerance tolerance})))
+             :guardSelfTest  (fn [] (pr-str (guard/self-test)))
+             :boundariesPerRoot #js {:list rows-per-root :grid per-root}})
+  nil)

--- a/implementation/core/test/re_frame/bench/p0_heap.cljs
+++ b/implementation/core/test/re_frame/bench/p0_heap.cljs
@@ -85,7 +85,7 @@
                   (let [r (react-dom-client/createRoot c)]
                     (react-dom/flushSync (fn [] (.render r (element-of))))
                     r))
-   :unmount-one (fn [r] (react-dom/flushSync (fn [] (.unmount r))))})
+   :unmount-one (fn [r] (.unmount r))})
 
 (defn- reagent-root-arm [form-of selector expected]
   {:selector    selector
@@ -94,7 +94,7 @@
                   (let [rt (rdc/create-root c)]
                     (react-dom/flushSync (fn [] (rdc/render rt (form-of))))
                     rt))
-   :unmount-one (fn [rt] (react-dom/flushSync (fn [] (rdc/unmount rt))))})
+   :unmount-one (fn [rt] (rdc/unmount rt))})
 
 (defn- uix-root-arm [element-of selector expected]
   {:selector    selector
@@ -103,7 +103,7 @@
                   (let [rt (uix-dom/create-root c)]
                     (react-dom/flushSync (fn [] (uix-dom/render-root (element-of) rt)))
                     rt))
-   :unmount-one (fn [rt] (react-dom/flushSync (fn [] (uix-dom/unmount-root rt))))})
+   :unmount-one (fn [rt] (uix-dom/unmount-root rt))})
 
 (def arm-table
   "`arm-id -> {:segment :selector :expected :mount-one :unmount-one}`.
@@ -167,7 +167,7 @@
   (when-some [{:keys [arm handles containers]} @held]
     (let [{:keys [unmount-one]} (get arm-table arm)]
       (doseq [hd (reverse handles)]
-        (try (unmount-one hd) (catch :default _ nil))))
+        (unmount-one hd)))
     (doseq [c containers] (.remove c))
     (reset! held nil))
   nil)

--- a/implementation/core/test/re_frame/bench/p0_reagent.cljs
+++ b/implementation/core/test/re_frame/bench/p0_reagent.cljs
@@ -1,0 +1,101 @@
+(ns re-frame.bench.p0-reagent
+  "EP-0038 P0 — the **denominator**: Reagent reading re-frame2
+  subscriptions.
+
+  The ship bar (HD-012) is stated as a ratio to Reagent, so this arm is
+  what every P0 figure is divided by. It has to be the Reagent an
+  application would actually write, on the same sub graph as the UIx arm,
+  or the bar is set against a straw man and the red-zones derived from it
+  are worthless.
+
+  ## Why every subscribing boundary is a `reg-view`
+
+  A plain Reagent fn does not carry the `:contextType` static-field wiring
+  Reagent needs to read the frame context, so its render-time `subscribe`
+  resolves no frame and raises `:rf.error/no-frame-context` (Spec 002
+  §Reading the frame from React context). `reg-view` is the paved Reagent
+  spelling for a frame-scoped view and it injects a lexical `subscribe`
+  bound to the surrounding frame — the exact counterpart of the UIx arm's
+  `use-subscribe`. Neither arm is doing the other's work, and neither is
+  hand-optimised.
+
+  ## Why NOT a `reagent.core/atom` or a `cursor`
+
+  The predecessor's cross-substrate row put Freehand on re-frame `app-db`
+  against Reagent on a bare `r/atom`, and said in its own docstring that
+  this was not the same amount of framework. It is exactly the asymmetry
+  P0 exists to remove: a bare ratom skips the re-frame write, the event
+  pipeline and the signal graph, so it is a LOWER BOUND on Reagent and not
+  a fair denominator. Everything here goes through `re-frame.core`.
+
+  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
+  (:require [re-frame.bench.p0-fixture :as fx]
+            [re-frame.core :as rf])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ---------------------------------------------------------------------------
+;; W1 — the large template
+;; ---------------------------------------------------------------------------
+
+(reg-view w1-row [i]
+  (let [text @(subscribe [:p0/row i])]
+    [:li.row.cell.wide {:style      {:padding-left "4px" :color "rebeccapurple"}
+                        :data-index i}
+     [:img.avatar {:src "/avatar.png" :alt ""}]
+     [:span.label "row "]
+     [:em.n text]]))
+
+(reg-view w1 [rows]
+  [:section.panel {:aria-label "bench rows"}
+   [:h1.title "Rows"]
+   [:ul.rows {:role "list"}
+    (for [i (range rows)]
+      ^{:key i} [w1-row i])]])
+
+;; ---------------------------------------------------------------------------
+;; W3 — the ordinary form
+;; ---------------------------------------------------------------------------
+
+(reg-view w3-field [i]
+  (let [{:keys [value error]} @(subscribe [:p0/field i])]
+    [:div.field
+     [:label.lbl {:for (str "f" i)} (str "Field " i)]
+     [:input.inp {:id        (str "f" i)
+                  :name      (str "f" i)
+                  :type      "text"
+                  :value     value
+                  :read-only true}]
+     [:p.err error]]))
+
+(reg-view w3 [fields]
+  [:form.w3form
+   [:fieldset.fields
+    (for [i (range fields)]
+      ^{:key i} [w3-field i])]
+   [:button.submit {:type "submit" :disabled true} "Submit"]])
+
+;; ---------------------------------------------------------------------------
+;; U — the bulk witness
+;; ---------------------------------------------------------------------------
+
+(reg-view u-cell [i]
+  (let [v @(subscribe [:p0/cell i])]
+    [:span.cell {:data-i i} (str v)]))
+
+(reg-view u-grid [n]
+  [:div.ugrid
+   (for [i (range n)]
+     ^{:key i} [u-cell i])])
+
+;; ---------------------------------------------------------------------------
+;; Roots
+;; ---------------------------------------------------------------------------
+
+(defn w1-root [frame-id rows]
+  [rf/frame-provider {:frame frame-id} [w1 rows]])
+
+(defn w3-root [frame-id fields]
+  [rf/frame-provider {:frame frame-id} [w3 fields]])
+
+(defn u-root [frame-id]
+  [rf/frame-provider {:frame frame-id} [u-grid fx/cells-n]])

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -67,7 +67,7 @@ const PORT = Number(process.env.P0_PORT || 8149);
 
 const ROUNDS = Number(process.env.P0_ROUNDS || 6);
 const SAMPLES = Number(process.env.P0_SAMPLES || 12);
-const WARMUPS = Number(process.env.P0_WARMUPS || 3);
+const WARMUPS = Number(process.env.P0_WARMUPS || 4);
 const ROOTS = Number(process.env.P0_ROOTS || 4);
 // 587,500 unboxed doubles = 4,700,000 bytes.
 const CONTROL_DOUBLES = Number(process.env.P0_CONTROL_DOUBLES || 587500);
@@ -149,9 +149,17 @@ async function newPage(chromium, query) {
     args: ['--enable-precise-memory-info', '--js-flags=--expose-gc'],
   });
   const page = await browser.newPage();
+  // Every `;; P0` record, and EVERY warning or error the page emits. The
+  // second half is not debug scaffolding: a React warning about a root
+  // that failed to unmount, or a re-frame error recovered on a render
+  // path, is the difference between a slow arm and a broken instrument,
+  // and a driver that filtered them out would publish the number anyway.
   page.on('console', (m) => {
     const t = m.text();
     if (t.startsWith(';; P0')) console.log(t);
+    else if (m.type() === 'error' || m.type() === 'warning') {
+      console.error(`[p0] page ${m.type()}: ${t.slice(0, 400)}`);
+    }
   });
   page.on('pageerror', (e) => console.error('[p0] page error:', e.message));
   await page.goto(`http://127.0.0.1:${PORT}/${query}`, {
@@ -165,18 +173,48 @@ async function newPage(chromium, query) {
 // The clock row
 // ---------------------------------------------------------------------------
 
+// ONE ROUND PER PAGE. Run as a single page, this instrument's own probe
+// measured `usedJSHeapSize` climbing 34 -> 87 MB across six segment
+// entries with `body-children` pinned at 2, and the FLOOR arm — which
+// cannot change — drifting 3.4 -> 7.0 ms on that heap; the arm-order
+// guard refused on phase, correctly. A fresh document cannot inherit the
+// previous round's heap, so a browser restart per round removes the
+// factor by construction rather than by argument. The accumulation is
+// itself a finding and is filed separately, not swept up here.
 async function clockRow(chromium) {
-  const q =
-    `?mode=clock&rounds=${ROUNDS}&samples=${SAMPLES}&warmups=${WARMUPS}`;
-  const { browser, page } = await newPage(chromium, q);
-  await page.waitForFunction('window.P0_DONE === true || window.P0_ERROR', null, {
-    timeout: CLOCK_TIMEOUT_MS,
+  const roundEdns = [];
+  let err = null;
+  for (let r = 0; r < ROUNDS && !err; r++) {
+    console.error(`[p0] clock round ${r + 1}/${ROUNDS} (fresh page) ...`);
+    const q = `?round=${r}&samples=${SAMPLES}&warmup=${WARMUPS}`;
+    const { browser, page } = await newPage(chromium, q);
+    await page.waitForFunction('window.P0_DONE === true || window.P0_ERROR', null, {
+      timeout: CLOCK_TIMEOUT_MS,
+    });
+    err = await page.evaluate('window.P0_ERROR || null');
+    const edn = await page.evaluate('window.P0_ROUND || null');
+    const selfTest = await page.evaluate('window.P0_GUARD_SELF_TEST || null');
+    if (r === 0 && selfTest && !/:ok\? true/.test(selfTest)) {
+      err = 'the arm-order guard self-test failed — nothing may be measured';
+    }
+    await browser.close();
+    if (edn) roundEdns.push(edn);
+  }
+  if (err) return { err, results: null };
+  if (!roundEdns.length) return { err: 'no round produced a record', results: null };
+
+  // The fold runs in a page too, so the ranges, the red-zone ratios and
+  // the arm-order verdict are computed by `re-frame.bench.order-guard`
+  // and `p0-harness` — the same code the rounds ran under — rather than
+  // by a second, drifting expression of the same arithmetic in JavaScript.
+  console.error('[p0] aggregating ...');
+  const { browser, page } = await newPage(chromium, '?mode=aggregate');
+  await page.waitForFunction('window.P0_READY === true || window.P0_ERROR', null, {
+    timeout: 180000,
   });
-  const err = await page.evaluate('window.P0_ERROR || null');
-  const results = await page.evaluate('window.P0_RESULTS || {}');
-  const refused = await page.evaluate('window.P0_REFUSED || []');
+  const edn = await page.evaluate((e) => window.P0A.aggregate(e), roundEdns);
   await browser.close();
-  return { err, results, refused };
+  return { err: null, results: edn };
 }
 
 // ---------------------------------------------------------------------------
@@ -432,16 +470,18 @@ function summariseHeap(row) {
       console.error('[p0] clock row ...');
       const c = await clockRow(chromium);
       out.clock = c.results;
-      for (const [k, v] of Object.entries(c.results)) {
-        console.log(`;; ==== P0 clock / ${k} ====`);
-        console.log(v);
-      }
-      if (c.err) failed = `clock: ${c.err}`;
-      if (c.refused && c.refused.length) {
-        refused = true;
-        console.log(';;');
-        console.log(';; ==== ARM ORDER: THESE CLOCK ROWS ARE NOT REPORTABLE ====');
-        console.log(`;;   ${c.refused.join(', ')}`);
+      if (c.err) {
+        failed = `clock: ${c.err}`;
+      } else {
+        console.log(';; ==== P0 CLOCK ====');
+        console.log(c.results);
+        const m = /:refused \[([^\]]*)\]/.exec(c.results);
+        if (m && m[1].trim()) {
+          refused = true;
+          console.log(';;');
+          console.log(';; ==== ARM ORDER: THESE CLOCK ROWS ARE NOT REPORTABLE ====');
+          console.log(`;;   ${m[1].trim()}`);
+        }
       }
     }
     if (ONLY !== 'clock') {

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -1,0 +1,481 @@
+#!/usr/bin/env node
+// EP-0038 P0 — the driver. Build the `:advanced` bundle once, run both
+// rows, print the table, exit on a refusal.
+//
+//   node implementation/core/test/re_frame/bench/p0_run.cjs
+//   node implementation/core/test/re_frame/bench/p0_run.cjs --only clock
+//   node implementation/core/test/re_frame/bench/p0_run.cjs --only heap
+//   P0_ROUNDS=6 P0_SAMPLES=12 node .../p0_run.cjs
+//
+// ## Why the numbers have to come from here
+//
+// The bar's numbers are BROWSER numbers (HD-012, validation.md §P0): a
+// real browser, `:advanced`, `goog.DEBUG false`. Spec 009 instrumentation,
+// schema validation and trace emission are all `goog.DEBUG`-gated and all
+// sit on the subscription and render paths these rows measure, so a
+// development build publishes a cost no user pays — and it does so in one
+// direction only, because a floor arm has no counterpart to any of them.
+// `:advanced` cannot compile shadow's `:browser-test` target
+// (`cljs-test-display`'s `goog.define`s collide under Closure), so the
+// reading rides a plain `:browser` module.
+//
+// ## No shadow-cljs.edn change, deliberately
+//
+// The epic's SEQUENCING LAW makes `implementation/shadow-cljs.edn`
+// build-id touches hot-zone sequenced, and rf2-2rtt6.2 owns that file for
+// this wave. So this driver does what `b6_prod_run.cjs` and `b7_run.cjs`
+// already do: it merges an output directory and an `:init-fn` into an
+// EXISTING `:advanced` `:browser` build id, which contributes nothing but
+// its compiler settings — `:target :browser`, `:optimizations :advanced`,
+// `:infer-externs :auto`, `goog.DEBUG false`. The module's entry, and
+// therefore everything that ends up in the bundle, is this arm's.
+// `P0_BUILD` overrides the donor id: when rf2-2rtt6.2's measurement-lane
+// build id lands, point this at it and delete this paragraph.
+//
+// ## The heap row runs HERE and the clock row runs in the page
+//
+// A page cannot force a garbage collection, so it cannot decide when a
+// retained-heap reading is taken; a page that tried would be reading
+// whatever the collector happened to have done. The clock row has the
+// opposite constraint — a `flushSync` window must not have a CDP
+// round-trip in it — so it runs entirely in the page and parks its
+// records on `window.P0_RESULTS`.
+//
+// ## The arm-order guard is expressed ONCE, in CLJS
+//
+// `re-frame.bench.order-guard` is the rule, and this driver reaches it
+// through `window.P0H.verdict` rather than carrying a JavaScript copy —
+// there is already a `.cjs` copy of the same rule serving the freehand
+// bench, and a third would be a third place for it to drift. Its
+// self-test runs before anything is measured, in both modes. **A refusal
+// exits 2, and the repair is to the ARM, never to the guard.**
+
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+const IMPL = path.resolve(__dirname, '../../../..');
+
+const BUILD = process.env.P0_BUILD || 'freehand-release';
+const OUT_DIR = process.env.P0_OUT_DIR || 'out/p0-hicasso';
+const OUT = path.join(IMPL, OUT_DIR);
+const INIT_FN = process.env.P0_INIT_FN || 're-frame.bench.p0-app/-main';
+const PORT = Number(process.env.P0_PORT || 8149);
+
+const ROUNDS = Number(process.env.P0_ROUNDS || 6);
+const SAMPLES = Number(process.env.P0_SAMPLES || 12);
+const WARMUPS = Number(process.env.P0_WARMUPS || 3);
+const ROOTS = Number(process.env.P0_ROOTS || 4);
+// 587,500 unboxed doubles = 4,700,000 bytes.
+const CONTROL_DOUBLES = Number(process.env.P0_CONTROL_DOUBLES || 587500);
+const CONTROL_PREDICTED = CONTROL_DOUBLES * 8;
+const HEAP_TOLERANCE = Number(process.env.P0_HEAP_TOLERANCE || 0.25);
+const CLOCK_TIMEOUT_MS = Number(process.env.P0_CLOCK_TIMEOUT_MS || 30 * 60 * 1000);
+
+const ONLY = (() => {
+  const i = process.argv.indexOf('--only');
+  return i === -1 ? null : process.argv[i + 1];
+})();
+
+// The heap families, and which segment each arm needs. `null` is the
+// floor, which needs whichever adapter the segment it is being read in
+// has installed — it holds no re-frame state, so it is the same work
+// either side of the seam and is the calibrator that makes the
+// cross-segment ratio legitimate.
+const HEAP_SEGMENTS = [
+  { segment: 'reagent-subs', arms: ['list/floor', 'list/reagent', 'grid/floor', 'grid/reagent'] },
+  { segment: 'uix-subs', arms: ['list/floor', 'list/uix', 'grid/floor', 'grid/uix'] },
+];
+
+// ---------------------------------------------------------------------------
+// Build and serve
+// ---------------------------------------------------------------------------
+
+// ONE LINE, deliberately: shadow-cljs's CLI re-splits `--config-merge` on
+// whitespace when the EDN contains a newline and then reports `EOF while
+// reading` from a fragment.
+const CONFIG_MERGE =
+  `{:output-dir "${OUT_DIR}" :asset-path "." :modules {:main {:init-fn ${INIT_FN}}}}`;
+
+function build() {
+  console.error(`[p0] building :advanced bundle (donor build id: ${BUILD}) ...`);
+  // `node cli/runner.js` rather than the `.cmd` shim: spawning a shim on
+  // Windows needs `shell: true`, and a shell concatenates argv, which is
+  // the other way the config-merge EDN gets torn in half.
+  const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+  const r = spawnSync(
+    process.execPath,
+    [runner, 'release', BUILD, '--config-merge', CONFIG_MERGE],
+    { cwd: IMPL, stdio: ['ignore', 'inherit', 'inherit'] }
+  );
+  if (r.status !== 0) {
+    console.error(`[p0] build failed with status ${r.status}`);
+    process.exit(1);
+  }
+}
+
+const MIME = { '.js': 'text/javascript', '.html': 'text/html', '.map': 'application/json' };
+
+function serve() {
+  fs.mkdirSync(OUT, { recursive: true });
+  fs.writeFileSync(
+    path.join(OUT, 'index.html'),
+    '<!doctype html><html><head><meta charset="utf-8"><title>P0</title></head>' +
+      '<body><div id="app"></div><script src="main.js"></script></body></html>'
+  );
+  return http
+    .createServer((req, res) => {
+      const rel = decodeURIComponent(req.url.split('?')[0]);
+      const file = path.join(OUT, rel === '/' ? 'index.html' : rel);
+      if (!file.startsWith(OUT) || !fs.existsSync(file)) {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      fs.createReadStream(file).pipe(res);
+    })
+    .listen(PORT);
+}
+
+// `'commit'`, never `'load'`. `p0-app/-main` is this bundle's `:init-fn`,
+// so the whole clock run happens INSIDE the `<script>` and the `load`
+// event is downstream of it. Waiting for `load` would be waiting for the
+// benchmark against a thirty-second ceiling nothing here could see.
+async function newPage(chromium, query) {
+  const browser = await chromium.launch({
+    args: ['--enable-precise-memory-info', '--js-flags=--expose-gc'],
+  });
+  const page = await browser.newPage();
+  page.on('console', (m) => {
+    const t = m.text();
+    if (t.startsWith(';; P0')) console.log(t);
+  });
+  page.on('pageerror', (e) => console.error('[p0] page error:', e.message));
+  await page.goto(`http://127.0.0.1:${PORT}/${query}`, {
+    waitUntil: 'commit',
+    timeout: 120000,
+  });
+  return { browser, page };
+}
+
+// ---------------------------------------------------------------------------
+// The clock row
+// ---------------------------------------------------------------------------
+
+async function clockRow(chromium) {
+  const q =
+    `?mode=clock&rounds=${ROUNDS}&samples=${SAMPLES}&warmups=${WARMUPS}`;
+  const { browser, page } = await newPage(chromium, q);
+  await page.waitForFunction('window.P0_DONE === true || window.P0_ERROR', null, {
+    timeout: CLOCK_TIMEOUT_MS,
+  });
+  const err = await page.evaluate('window.P0_ERROR || null');
+  const results = await page.evaluate('window.P0_RESULTS || {}');
+  const refused = await page.evaluate('window.P0_REFUSED || []');
+  await browser.close();
+  return { err, results, refused };
+}
+
+// ---------------------------------------------------------------------------
+// The collector and the readers
+// ---------------------------------------------------------------------------
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function makeReaders(page) {
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('HeapProfiler.enable');
+  await cdp.send('Runtime.enable');
+  // Three collections with a beat between them. One is not enough: React
+  // roots die in stages — fibers, then the host instances they point at —
+  // and a single pass leaves the second stage standing.
+  const gc = async () => {
+    for (let i = 0; i < 3; i++) {
+      await cdp.send('HeapProfiler.collectGarbage');
+      await sleep(80);
+    }
+  };
+  const read = async () => {
+    const { usedSize } = await cdp.send('Runtime.getHeapUsage');
+    const perf = await page.evaluate(() => window.P0H.perfMem());
+    return { cdp: usedSize, perf };
+  };
+  return { cdp, gc, read };
+}
+
+// ---------------------------------------------------------------------------
+// The heap row
+// ---------------------------------------------------------------------------
+
+async function heapRow(chromium) {
+  const { browser, page } = await newPage(chromium, '?mode=heap');
+  await page.waitForFunction('window.P0_READY === true || window.P0_ERROR', null, {
+    timeout: 180000,
+  });
+  const err = await page.evaluate('window.P0_ERROR || null');
+  if (err) {
+    await browser.close();
+    throw new Error(`heap page failed to initialise: ${err}`);
+  }
+  const perRoot = await page.evaluate(() => window.P0H.boundariesPerRoot);
+  const { gc, read } = await makeReaders(page);
+
+  const boundariesOf = (arm) => ROOTS * perRoot[arm.split('/')[0]];
+
+  let unverified = 0;
+  let mounts = 0;
+  const orderSamples = [];
+  let position = 0;
+  let previous = null;
+
+  // A WARM-UP PASS, mounted and released once per arm and never read. The
+  // first mount of any arm allocates things that are not the page and
+  // never go away: compiled code for the paths it just took, inline
+  // caches, interned keywords, one-time module state. Charged to round 1
+  // they read as retention per boundary, and they are not.
+  console.error('[p0] heap warm-up pass ...');
+  for (const { segment, arms } of HEAP_SEGMENTS) {
+    await page.evaluate((s) => window.P0H.prepare(s), segment);
+    for (const arm of arms) {
+      const v = await page.evaluate(([a, k]) => window.P0H.mount(a, k), [arm, ROOTS]);
+      mounts++;
+      if (!v.ok) unverified++;
+      await page.evaluate(() => window.P0H.release());
+    }
+  }
+  await page.evaluate((n) => window.P0H.control(n), CONTROL_DOUBLES);
+  await page.evaluate(() => window.P0H.controlRelease());
+
+  const rounds = [];
+  for (let round = 0; round < ROUNDS; round++) {
+    console.error(`[p0] heap round ${round + 1}/${ROUNDS}`);
+
+    // --- the positive control, in situ, before this round's arms --------
+    await gc();
+    const ctlBefore = await read();
+    const ctlLen = await page.evaluate((n) => window.P0H.control(n), CONTROL_DOUBLES);
+    await gc();
+    const ctlHeld = await read();
+    await page.evaluate(() => window.P0H.controlRelease());
+    await gc();
+    const ctlAfter = await read();
+    const control = {
+      doubles: ctlLen,
+      predictedBytes: CONTROL_PREDICTED,
+      measuredCdp: ctlHeld.cdp - (ctlBefore.cdp + ctlAfter.cdp) / 2,
+      measuredPerf: ctlHeld.perf - (ctlBefore.perf + ctlAfter.perf) / 2,
+      baselineDriftCdp: ctlAfter.cdp - ctlBefore.cdp,
+    };
+
+    // --- the two segments, in the order this round's parity dictates ----
+    // Segment order alternates with the round for the same reason the
+    // clock row's does: two segments admit two orders, and a single-order
+    // result has not been checked.
+    const segs = round % 2 === 0 ? HEAP_SEGMENTS : [...HEAP_SEGMENTS].slice().reverse();
+    const armsOut = {};
+    for (const { segment, arms } of segs) {
+      // `prepare` BEFORE the baseline read, so the adapter swap's own
+      // residue lands in the baseline and not in the arm's delta.
+      await page.evaluate((s) => window.P0H.prepare(s), segment);
+      const order = await page.evaluate(
+        ([n, r]) => window.P0H.slotOrder(n, r),
+        [arms.length, round]
+      );
+      for (const j of order) {
+        const arm = arms[j];
+        await gc();
+        const pre = await read();
+        const verify = await page.evaluate(([a, k]) => window.P0H.mount(a, k), [arm, ROOTS]);
+        mounts++;
+        if (!verify.ok) unverified++;
+        await gc();
+        const held = await read();
+        await page.evaluate(() => window.P0H.release());
+        await gc();
+        const post = await read();
+        const boundaries = boundariesOf(arm);
+        const key = `${segment}|${arm}`;
+        armsOut[key] = {
+          segment,
+          arm,
+          verify,
+          boundaries,
+          retainedCdp: held.cdp - pre.cdp,
+          retainedPerf: held.perf - pre.perf,
+          residueCdp: post.cdp - pre.cdp,
+          bytesPerBoundaryCdp: (held.cdp - pre.cdp) / boundaries,
+          bytesPerBoundaryPerf: (held.perf - pre.perf) / boundaries,
+        };
+        orderSamples.push({
+          arm: key,
+          value: armsOut[key].bytesPerBoundaryCdp,
+          predecessor: previous,
+          position: position++,
+        });
+        previous = key;
+      }
+    }
+    rounds.push({ round, control, arms: armsOut });
+  }
+
+  const verdictEdn = await page.evaluate(
+    ([s, t]) => window.P0H.verdict(s, t),
+    [orderSamples, HEAP_TOLERANCE]
+  );
+  await browser.close();
+
+  return {
+    benchmark: 'P0:retained-heap-per-boundary',
+    bead: 'rf2-2rtt6.4',
+    roots: ROOTS,
+    perRoot,
+    rounds: ROUNDS,
+    segments: HEAP_SEGMENTS,
+    instruments: {
+      A: 'CDP Runtime.getHeapUsage().usedSize after 3x HeapProfiler.collectGarbage',
+      B: 'in-page performance.memory.usedJSHeapSize, same moment, --enable-precise-memory-info',
+      note:
+        'A and B are two doors onto one V8 counter and are NOT independent — on the ' +
+        'predecessor instrument, pointed at 80,000 held objects, they returned 3868954 both.',
+    },
+    control: {
+      shape: 'dense JS array of doubles',
+      doubles: CONTROL_DOUBLES,
+      predictedBytes: CONTROL_PREDICTED,
+    },
+    verification: { mounts, unverified },
+    perRound: rounds,
+    orderVerdictEdn: verdictEdn,
+    orderRefused: /:refuse\? true/.test(verdictEdn),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The summary
+// ---------------------------------------------------------------------------
+
+const stat = (xs) => {
+  const s = [...xs].sort((a, b) => a - b);
+  const mean = s.reduce((a, b) => a + b, 0) / s.length;
+  return { mean, min: s[0], max: s[s.length - 1] };
+};
+
+function summariseHeap(row) {
+  console.log('\n;; ==== P0 RETAINED HEAP — bytes per boundary ====');
+  console.log(`;; ${row.roots} roots held per arm; list=${row.perRoot.list} rows, grid=${row.perRoot.grid} cells`);
+  const ctlA = stat(row.perRound.map((r) => r.control.measuredCdp));
+  console.log(
+    `;; positive control: predicted ${CONTROL_PREDICTED} B  |  measured ${Math.round(ctlA.mean)} B ` +
+      `[${Math.round(ctlA.min)}–${Math.round(ctlA.max)}]  (ratio ${(ctlA.mean / CONTROL_PREDICTED).toFixed(4)})`
+  );
+  console.log(`;; verification: ${row.verification.unverified} unverified of ${row.verification.mounts} mounts`);
+  console.log(';;');
+  console.log(';; arm                              B/boundary (mean) [min-max]     residue B');
+  const keys = Object.keys(row.perRound[0].arms);
+  const byKey = {};
+  for (const k of keys) {
+    const a = stat(row.perRound.map((r) => r.arms[k].bytesPerBoundaryCdp));
+    const res = stat(row.perRound.map((r) => r.arms[k].residueCdp));
+    byKey[k] = a;
+    console.log(
+      `;; ${k.padEnd(32)} ${String(Math.round(a.mean)).padStart(8)} ` +
+        `[${Math.round(a.min)}–${Math.round(a.max)}]`.padEnd(20) +
+        `${String(Math.round(res.mean)).padStart(10)}`
+    );
+  }
+
+  // --- the red-zone figure, per family -----------------------------------
+  console.log(';;');
+  console.log(';; ==== P0 RED-ZONE (retained heap) — UIx over Reagent, per witness family ====');
+  console.log(';;   EXCLUSIVE = arm - floor, the substrate\'s OWN standing cost, measured');
+  console.log(';;   in the same segment. That is the axis validation.md states the budget on.');
+  const redZone = {};
+  for (const family of ['list', 'grid']) {
+    const perRound = row.perRound.map((r) => {
+      const rf = r.arms[`reagent-subs|${family}/floor`].bytesPerBoundaryCdp;
+      const rs = r.arms[`reagent-subs|${family}/reagent`].bytesPerBoundaryCdp;
+      const uf = r.arms[`uix-subs|${family}/floor`].bytesPerBoundaryCdp;
+      const us = r.arms[`uix-subs|${family}/uix`].bytesPerBoundaryCdp;
+      return { exclusive: (us - uf) / (rs - rf), absolute: us / rs };
+    });
+    const ex = stat(perRound.map((p) => p.exclusive));
+    const ab = stat(perRound.map((p) => p.absolute));
+    redZone[family] = { exclusive: ex, absolute: ab, perRound };
+    const straddles = ex.min <= 1.0 && ex.max >= 1.0;
+    console.log(
+      `;;   ${family.padEnd(6)} EXCLUSIVE ${ex.mean.toFixed(4)}x [${ex.min.toFixed(4)}–${ex.max.toFixed(4)}]` +
+        `   absolute ${ab.mean.toFixed(4)}x [${ab.min.toFixed(4)}–${ab.max.toFixed(4)}]` +
+        (straddles ? '   RANGE STRADDLES 1.0 — INDISTINGUISHABLE' : '')
+    );
+  }
+  row.redZone = redZone;
+  console.log(';;');
+  console.log(';; ==== ARM-ORDER GUARD (heap) ====');
+  console.log(`;;   ${row.orderRefused ? 'VERDICT: REFUSE — no figure above may be published as measured' : 'VERDICT: reportable'}`);
+  if (row.orderRefused) console.log(`;;   ${row.orderVerdictEdn}`);
+}
+
+// ---------------------------------------------------------------------------
+
+(async () => {
+  build();
+  const server = serve();
+  const { chromium } = require('playwright');
+  const out = { generatedAt: new Date().toISOString(), build: BUILD, initFn: INIT_FN };
+  let failed = null;
+  let refused = false;
+  try {
+    if (ONLY !== 'heap') {
+      console.error('[p0] clock row ...');
+      const c = await clockRow(chromium);
+      out.clock = c.results;
+      for (const [k, v] of Object.entries(c.results)) {
+        console.log(`;; ==== P0 clock / ${k} ====`);
+        console.log(v);
+      }
+      if (c.err) failed = `clock: ${c.err}`;
+      if (c.refused && c.refused.length) {
+        refused = true;
+        console.log(';;');
+        console.log(';; ==== ARM ORDER: THESE CLOCK ROWS ARE NOT REPORTABLE ====');
+        console.log(`;;   ${c.refused.join(', ')}`);
+      }
+    }
+    if (ONLY !== 'clock') {
+      console.error('[p0] heap row ...');
+      out.heap = await heapRow(chromium);
+      summariseHeap(out.heap);
+      if (out.heap.verification.unverified > 0) {
+        failed = `heap: ${out.heap.verification.unverified} unverified mounts`;
+      }
+      refused = refused || out.heap.orderRefused;
+    }
+  } catch (e) {
+    failed = String(e && e.stack ? e.stack : e);
+  } finally {
+    server.close();
+  }
+  const raw = process.env.P0_RAW_OUT;
+  if (raw) {
+    fs.mkdirSync(path.dirname(raw), { recursive: true });
+    fs.writeFileSync(raw, JSON.stringify(out, null, 2));
+    console.error(`[p0] raw data -> ${raw}`);
+  }
+  if (failed) {
+    console.error(`[p0] FAILED: ${failed}`);
+    process.exit(1);
+  }
+  // A run whose figures the arm-order guard refused is not a green run.
+  // The data is printed and the raw file written — the refusal is about
+  // what may be QUOTED, not about throwing the measurement away. Exit 2,
+  // the same code the sibling harnesses use for the same verdict. REPAIR
+  // THE ARM, NOT THE GUARD.
+  if (refused) {
+    console.error('[p0] arm-order guard REFUSED — figures are not reportable');
+    process.exit(2);
+  }
+  console.error('[p0] done');
+})();

--- a/implementation/core/test/re_frame/bench/p0_uix.cljs
+++ b/implementation/core/test/re_frame/bench/p0_uix.cljs
@@ -1,0 +1,113 @@
+(ns re-frame.bench.p0-uix
+  "EP-0038 P0 — **the frontier arm**: UIx reading re-frame2 subscriptions
+  through the existing `use-subscribe` spine.
+
+  UIx is the best existing React-idiomatic option on re-frame2 subs, and
+  the delegated ruling recorded on rf2-2rtt6.1 makes the ratios this arm
+  produces the RED-ZONE THRESHOLDS for every later candidate, on both the
+  clock and retained heap. Nothing here may therefore be a convenience
+  spelling: every boundary is written the way the adapter's own
+  documentation and examples write one.
+
+  ## What is deliberately NOT here
+
+  - **No `set-hiccup-emitter!`.** UIx's `$` is a macro that expands to
+    `react/createElement` at compile time. An arm written through the
+    hiccup emitter would be measuring a hiccup interpreter, which is the
+    candidate's product delta and not UIx's. Using it here would set the
+    red-zone from the wrong runtime and flatter every later candidate.
+  - **No `use-memo` around the subscription args.** `use-subscribe`'s own
+    stable-deps-key handling is part of the spine under test; wrapping it
+    would price a hand optimisation no ordinary application writes.
+  - **No prop threading in place of a read.** Every boundary that a
+    Reagent arm subscribes in, this arm subscribes in — one read per
+    boundary, the first rung of the HD-002 ladder. A row that took its
+    text as a prop would be a different sub graph wearing the same name.
+
+  ## One boundary, one read
+
+  `w1-row`, `w3-field` and `u-cell` are each a `defui` — a React function
+  component — calling `use-subscribe` once. That is the paved UIx
+  spelling; the counterpart Reagent arm is a `reg-view` derefing
+  `(rf/subscribe …)` once. Neither is doing the other's work.
+
+  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
+  (:require [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.p0-fixture :as fx]
+            [uix.core :refer [$ defui]]))
+
+;; ---------------------------------------------------------------------------
+;; W1 — the large template
+;; ---------------------------------------------------------------------------
+
+(defui w1-row [{:keys [i]}]
+  (let [text (uix-adapter/use-subscribe [:p0/row i])]
+    ($ :li.row.cell.wide {:style      {:padding-left "4px" :color "rebeccapurple"}
+                          :data-index i}
+       ($ :img.avatar {:src "/avatar.png" :alt ""})
+       ($ :span.label "row ")
+       ($ :em.n text))))
+
+(defui w1 [{:keys [rows]}]
+  ($ :section.panel {:aria-label "bench rows"}
+     ($ :h1.title "Rows")
+     ($ :ul.rows {:role "list"}
+        (for [i (range rows)]
+          ($ w1-row {:key i :i i})))))
+
+;; ---------------------------------------------------------------------------
+;; W3 — the ordinary form
+;; ---------------------------------------------------------------------------
+
+(defui w3-field [{:keys [i]}]
+  (let [{:keys [value error]} (uix-adapter/use-subscribe [:p0/field i])]
+    ($ :div.field
+       ($ :label.lbl {:for (str "f" i)} (str "Field " i))
+       ($ :input.inp {:id        (str "f" i)
+                      :name      (str "f" i)
+                      :type      "text"
+                      :value     value
+                      :read-only true})
+       ($ :p.err error))))
+
+(defui w3 [{:keys [fields]}]
+  ($ :form.w3form
+     ($ :fieldset.fields
+        (for [i (range fields)]
+          ($ w3-field {:key i :i i})))
+     ($ :button.submit {:type "submit" :disabled true} "Submit")))
+
+;; ---------------------------------------------------------------------------
+;; U — the bulk witness
+;; ---------------------------------------------------------------------------
+
+(defui u-cell [{:keys [i]}]
+  (let [v (uix-adapter/use-subscribe [:p0/cell i])]
+    ($ :span.cell {:data-i i} (str v))))
+
+(defui u-grid [{:keys [n]}]
+  ($ :div.ugrid
+     (for [i (range n)]
+       ($ u-cell {:key i :i i}))))
+
+;; ---------------------------------------------------------------------------
+;; Roots — the frame scope every read resolves through
+;; ---------------------------------------------------------------------------
+;;
+;; `frame-provider` SCOPES an already-created frame and renders no DOM of
+;; its own, so it cannot move the canonical-DOM gate. The frame is created
+;; outside the measured window by the segment's setup: a mount window that
+;; contained `make-frame` and a seeding dispatch would be pricing frame
+;; construction on the arm that happens to own it.
+
+(defn w1-root [frame-id rows]
+  ($ uix-adapter/frame-provider {:frame frame-id}
+     ($ w1 {:rows rows})))
+
+(defn w3-root [frame-id fields]
+  ($ uix-adapter/frame-provider {:frame frame-id}
+     ($ w3 {:fields fields})))
+
+(defn u-root [frame-id]
+  ($ uix-adapter/frame-provider {:frame frame-id}
+     ($ u-grid {:n fx/cells-n})))


### PR DESCRIPTION
Wave-0 instrument for EP-0038. **UIx on re-frame2 subs — the frontier comparator — and the red-zone thresholds every later candidate is judged against.**

The delegated ruling on **rf2-2rtt6.1** makes this mechanical: *the red-zone threshold IS the measured UIx ratio for that witness family, on both axes.* So these figures are thresholds, not supporting numbers, and they are labelled as such on the bead, in the studio page, and inside the published records themselves.

Full page: `docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md`. Rows appended to rf2-2rtt6.1 with producing SHA and reproduction command.

## The thresholds

**Clock** — UIx-on-subs ÷ Reagent-on-subs, both floor-normalised in the same round and the same adapter segment. 5 rounds, ranges min–max.

| witness | threshold | range | verdict |
|---|---|---|---|
| W1-list mount (1,203 el, 300 boundaries) | **1.057×** | 0.907 – 1.156 | **straddles 1.0 — indistinguishable** |
| W3-form mount (51 el, 12 fields) | **0.893×** | 0.843 – 0.956 | UIx faster |
| U-broad bulk (300 boundaries, one commit all read) | **0.838×** | 0.760 – 0.953 | UIx faster |
| U-narrow bulk (one commit exactly one reads) | **1.536×** | 1.226 – 1.876 | **UIx slower** |

**Retained heap** — exclusive (`arm − floor`) bytes per boundary, UIx ÷ Reagent, same segment:

| family | threshold | range | absolute |
|---|---|---|---|
| list (300 sub-reading rows) | **2.262×** | 2.196 – 2.335 | 1.580× |
| grid (300 sub-reading cells) | **2.254×** | 2.217 – 2.288 | 1.989× |

Exclusive per boundary: Reagent-on-subs ≈ 954 B / 947 B; UIx-on-subs ≈ 2,156 B / 2,134 B. **For K3 and the budget: the frontier comparator is itself over the 1 KB paper-fail line by more than 2×**, and the Reagent denominator is close to it — red (>2.26×) and over budget (>~0.5 KB) are far apart, and a candidate can sit between them.

## Method

Browser only, `:advanced`, `goog.DEBUG false`. **No `implementation/shadow-cljs.edn` change** — the sequencing law gives that file to rf2-2rtt6.2, so the driver merges an output dir and an `:init-fn` into an existing `:advanced` `:browser` build id for its compiler settings, exactly as `b6_prod_run.cjs` and `b7_run.cjs` already do. `P0_BUILD` re-points it when the lane id lands.

`install-adapter!` is once per process, so the two candidate arms cannot be interleaved in one round. Each round runs two **segments** with the floor in both; every figure is a ratio to the floor measured in that same segment of that same round, so the seam cancels. The seam control is published per round rather than assumed — it moves by up to 1.8× while the ratios derived through it move far less, which is the evidence the normalisation works.

Positive controls, predicted vs measured, every run: **heap** predicted 4,700,000 B, measured 4,700,317 B [4,699,074–4,700,974], **1.0001×**. **Clock** predicted 1.9975 from element count (2403/1203), measured 1.8381 [1.8182–1.8548] — the 8% shortfall quantified as the mount window's fixed per-root term (`f ≈ 229k`, ~19% of the page), which means the clock compresses ratios toward 1.0 and a threshold above 1.0 is conservative.

**0 unverified of 6,600** clock windows and **0 of 48** heap mounts. Canonical-DOM parity clean under `:advanced` in both segments and across the seam, every round. Arm-order guard **reportable on every row on both axes**, self-test 8/8 before anything was measured.

## Seven instrument faults found and repaired

Each caught by one of the arm's own gates; each had produced a plausible precise wrong number first. The reflecting schedule **degenerates at two arms** (so the schedule is now chosen by scoring both candidates with the guard's own `adjacency`); the 51-element form and the broad write both sat on Chrome's 100 µs clamp and returned a ratio of *exactly* 1.0000 and *exactly* 2× respectively; a separate warm-up loop left the first sample of every round with no predecessor, reading 1.35× its siblings; the page accumulated ~12 MB per segment entry and the unchanging floor drifted 3.4 → 7.0 ms on it; a fixed witness order made "second" a permanent property of one witness; and a cold page pulled the positive control 11% low. Full account with the numbers in the studio page.

Two of these produced changes worth reading on their own: unmounts are no longer wrapped in `flushSync` (a root's own `unmount()` opens one, and a nested flush is *scheduled* rather than performed), and the clock now runs **one round per page** so no round can inherit another's heap.

## Open items, filed not swept up

- **rf2-flqpd (P2, bug)** — the ~12 MB-per-segment retention is unexplained. Proportional to mounts, survives a forced major collection, never reaches the document, absent from the floor-only control. Mitigated by one-round-per-page; not fixed.
- **rf2-a4x1o (P1)** — the witness set does not match rf2-2rtt6.2's, which had not merged when this was measured. The thresholds are sound *as thresholds* (each is a ratio between two arms in one run on one witness set) but they are thresholds on this witness set; if P0 converges on that arm's witnesses the UIx arm must be re-pointed and the red-zones re-derived.

## Quality gates

| gate | command | exit |
|---|---|---|
| the arm, both rows, published configuration — clock | `P0_ROUNDS=5 P0_SAMPLES=10 P0_WARMUPS=4 node implementation/core/test/re_frame/bench/p0_run.cjs --only clock` | **0** (guard reportable on every row; `:refused []`) |
| the arm, both rows, published configuration — heap | `P0_ROUNDS=5 P0_ROOTS=4 node implementation/core/test/re_frame/bench/p0_run.cjs --only heap` | **0** (guard reportable; 0 unverified of 48) |
| arm-order guard self-test | runs in-page before anything is measured, both modes | **0** — 8/8 checks |
| CLJS node integration | `cd implementation && npm run test:cljs` | **0** — 11,940 tests, 59,616 assertions, 0 failures |
| per-ns test isolation | `cd implementation && node scripts/check-per-ns-isolation.cjs` | **0** — all 17 namespaces pass standalone |
| core JVM | `cd implementation/core && clojure -M:test` | **0** — 2,193 tests, 11,318 assertions, 0 failures |

Deliberate negative control, reported rather than hidden: the same arm at `P0_ROUNDS=2 P0_SAMPLES=4` exits **2** with `:refused [:W3-form :bulk-broad]`. At that power the guard's strata are two or three samples wide and it refuses — which is the guard having teeth, not a failing gate. The published configuration is the one that clears it.
