### PR TITLE
bench(hicasso): diagnose the reagent-slim non-reactive arm (rf2-z3vlz)

### DIFF
--- a/docs/design/hicasso/studio/README.md
+++ b/docs/design/hicasso/studio/README.md
@@ -63,3 +63,4 @@ requires nothing from any donor `src/` tree.
 | Page | Phase | What it settles |
 |---|---|---|
 | [P0 — Reagent-on-subs baseline (mount + bulk)](p0-reagent-on-subs-baseline.md) | P0 | The ship bar's **denominator**: mount and bulk view work for Reagent reading re-frame2 subscriptions. |
+| [The reagent-slim non-reactive arm — diagnosis](slim-non-reactive-arm-diagnosis.md) | P0 | Why HD-008's reagent-slim arm read `78 unverified of 78`: the **arm's composition**, not the adapter and not the mixed bundle. A single-substrate slim bundle re-renders on every write. |

--- a/docs/design/hicasso/studio/slim-non-reactive-arm-diagnosis.md
+++ b/docs/design/hicasso/studio/slim-non-reactive-arm-diagnosis.md
@@ -1,0 +1,185 @@
+# The reagent-slim non-reactive arm — diagnosis (rf2-z3vlz)
+
+**Verdict: the bench arm's composition. Not the adapter, not the bundle.**
+
+HD-008's donor-gate instrument reported that in the `:advanced` bench bundle
+compiling stock `reagent`, `reagent2` (reagent-slim) and `uix` together, a
+`reg-view` tree mounted through `reagent2.dom.client` rendered correctly at
+mount and then never re-rendered on a write — 78 of 78 writes failed the DOM
+read-back, while the stock-Reagent arm in the identical harness passed 78 of
+78. [rf2-z3vlz](../decisions.md) named three candidates and established none:
+
+- **(a)** a reagent-slim **adapter defect** — shipped, first-class, users
+  affected;
+- **(b)** a **mixed-bundle artefact** — stock `reagent` and `reagent2`
+  coexisting in one `:advanced` bundle;
+- **(c)** a defect in the **bench arm's composition**.
+
+It is (c), and the failing ingredient is one microtask.
+
+`lane/verified-write!` writes, **yields one microtask**, and only then calls the
+arm's drain. reagent-slim's render scheduler is **microtask-based**
+(`reagent2.impl.batching`: *"a microtask-based scheduler … no
+requestAnimationFrame fallback is required"*), so by the time the drain runs,
+reagent-slim has already emptied its own component queue and issued its
+`forceUpdate` **outside** any `flushSync` boundary. React holds that work at the
+default lane — which is precisely the hazard
+`reagent2.dom.client/flush-render!` documents (*"a bare `forceUpdate` issued
+from outside React's batching context is subject to automatic batching: React
+SCHEDULES the re-render rather than committing it"*) — and the `flush-render!`
+that follows finds an empty queue and commits nothing. Stock Reagent survives
+the identical harness because its component queue is **`requestAnimationFrame`**
+-scheduled and is therefore still full one microtask later: its drain finds the
+work and commits it inside the boundary.
+
+Two corrections to the bead's statement of the symptom fall out of this:
+
+1. **The arm is not non-reactive; its commit is LATE.** All 12 of 12 writes
+   reach the DOM at the `:macrotask` rung. `NEVER` and `LATE` are different
+   findings and the escalation ladder below tells them apart.
+2. **re-frame is not on the causal path at all.** The positive control — a
+   plain reagent-slim component reading a plain `reagent2.core/atom`, no frame,
+   no subscription, no adapter hook — reproduces the failure exactly, in every
+   bundle.
+
+## What was run
+
+| | |
+|---|---|
+| Producing commit | `f998a74c4aeb44ddc4dc2830dff31cb7181d3dfb` |
+| Runtime | **chromium 147.0.7727.15** (playwright, headless), `:advanced`, `goog.DEBUG false` |
+| Host | Windows 11, 24 logical cores, 32 GB |
+| Taken | 2026-07-31 00:36 AUSEST |
+| Instrument | `implementation/freehand/test/re_frame/bench/hicasso/z3vlz_{probe,slim_substrate,reagent_substrate}.cljs` |
+| Entries | `z3vlz_{slim_only,slim_reagent,slim_uix,mixed}.cljs` |
+| Build id | `:hicasso-bench` via `--config-merge` — **no new build id**, `implementation/shadow-cljs.edn` untouched |
+
+```bash
+cd C:/path/to/re-frame2
+node implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs
+
+# one rung at a time
+Z3VLZ_ONLY=slim-only Z3VLZ_PORT=8171 \
+  node implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs
+```
+
+Exit codes: `0` every declared bundle matched and every page ran; `1` a build
+failed, a bundle did not match its declared composition, a page threw, or the
+probe recorded a fatal. **The arm-order guard is NOT ENGAGED** — this driver
+publishes no timed figure and no arm-to-arm ratio, so there is nothing for it to
+adjudicate. The only numbers here are write and DOM read-back counts.
+
+## The design: bundle composition is the variable, the probe is the constant
+
+One probe namespace holds everything that does not change — the subscription,
+the event, the `reg-view` boundaries, the frame provider, both write mechanisms
+the bead reproduced with, the drain escalation ladder and the DOM read-back
+accounting. Four entry namespaces differ **only** in what they `:require`, one
+added namespace per rung. Each bundle's composition is then checked against its
+own **source map** before its page is driven, so *"no stock reagent compiled in"*
+is verified rather than asserted:
+
+| bundle | compiled sources | stock `reagent` | `reagent2` | `uix` |
+|---|---:|---|---|---|
+| `slim-only` | 96 | **no** | yes | no |
+| `slim+reagent` | 108 | yes | yes | no |
+| `slim+uix` | 102 | **no** | yes | yes |
+| `mixed` (the bead's bundle) | 114 | yes | yes | yes |
+
+## The result
+
+Every cell is `N unverified of M` — all 8 cells read back out of the DOM inside
+each write's own window, `M` = 12 writes per order, alternating
+`frame/replace-app-db!` and `dispatch-sync` of a registered event.
+
+### The arm under test — `reg-view` boundaries reading `rf/subscribe`
+
+| page | mount correct | write **inside** the drain | write, **drain immediately** | write, **yield**, then drain |
+|---|---|---|---|---|
+| `slim-only` / install reagent-slim | yes | **0 of 12** | **0 of 12** | **12 of 12** |
+| `slim+reagent` / install reagent-slim | yes | **0 of 12** | **0 of 12** | **12 of 12** |
+| `slim+uix` / install reagent-slim | yes | **0 of 12** | **0 of 12** | **12 of 12** |
+| `mixed` / install reagent-slim | yes | **0 of 12** | **0 of 12** | **12 of 12** |
+| `slim+reagent` / install **stock reagent** | yes | **0 of 12** | **0 of 12** | **0 of 12** |
+| `mixed` / install **stock reagent** | yes | **0 of 12** | **0 of 12** | **0 of 12** |
+
+### The positive control — plain component, plain `reagent2.core/atom`, no re-frame
+
+| page | write **inside** the drain | write, **drain immediately** | write, **yield**, then drain |
+|---|---|---|---|
+| every reagent-slim page (4 of them) | **0 of 12** | **0 of 12** | **12 of 12** |
+| every stock-Reagent page (2 of them) | **0 of 12** | **0 of 12** | **0 of 12** |
+
+Read the two tables together and the three candidates resolve themselves.
+
+- **Not (a).** The single-substrate reagent-slim bundle — 96 compiled sources,
+  stock Reagent verifiably absent — re-renders on **every** write under the
+  adapter's own documented drain contract: `0 unverified of 12`, all at the
+  `:sync` rung, under both write mechanisms. There is no adapter defect to fix.
+- **Not (b).** Bundle composition changes nothing. Four bundles spanning 96 to
+  114 compiled sources, with and without stock Reagent, with and without UIx,
+  return byte-identical verdicts.
+- **Not a late-binding collision either.** The positive control has no re-frame
+  on its path — no frame, no `subscribe`, no `:adapter/*` hook — and fails in
+  exactly the same pattern. Whatever this is, `re-frame.views` cannot be
+  reaching it.
+- **(c), and precisely located.** The only variable that moves the result is
+  the microtask between the write and the drain, and it moves the result only
+  for the substrate whose scheduler is a microtask.
+
+The `db-followed-all? true` slot is recorded on every write: `app-db` took the
+new value in all 36 writes per arm, in every bundle, so the failure is on the
+**view leg** and never on the event leg.
+
+## The escalation ladder, and why the answer is LATE rather than NEVER
+
+Each failed read-back is retried through progressively more generous drains:
+the arm's own drain again (`:redrain`), then a macrotask (`:macrotask`), then
+two animation frames (`:raf2`). Under `yield-then-drain` on reagent-slim, all
+12 writes land at `:macrotask` — never at `:sync`, never at `:redrain`, and
+never lost. A second synchronous `flush-render!` does **not** recover the
+commit, which is the load-bearing detail: once reagent-slim has issued its
+`forceUpdate` outside a boundary, no synchronous drain gets it back. Only
+letting React's own scheduler run does.
+
+## The repair, and where it belongs
+
+The repair is the ARM, not the adapter and not the guard. A reagent-slim write
+row must not put a microtask between the write and the drain. Either shape
+works and both read `0 unverified of 12`:
+
+```clojure
+;; the adapter's documented production contract — the write inside `f`
+(rdc2/flush-render! (fn [] (write!) (ratom2/flush!)))
+
+;; or: no yield between the two
+(write!)
+(rdc2/flush-render! (fn [] (ratom2/flush!)))
+```
+
+`lane/verified-write!`'s microtask is deliberate and is load-bearing for the
+React-hook arms, whose notification really is queued — its docstring says so,
+and `:gap-ms` prices it per arm. It is simply not neutral: for an arm whose
+substrate schedules on the same microtask queue the harness is yielding to, the
+yield hands the commit to React and the drain arrives a turn too late. A shared
+instrument that yields once for everybody cannot serve both scheduler families,
+and the fix therefore belongs in the arm's composition (or in an arm-level
+opt-out), not in the shared yield.
+
+**This is a measurement finding, not a shipped-code finding.** No consumer is
+affected: an application does not write and then yield before flushing — it
+dispatches, and the adapter's own path commits. The behaviour is already
+covered by the shipped reagent-slim adapter smoke
+(`implementation/adapters/reagent-slim/testbed/smoke.cjs`), which mounts a
+`reg-view` tree under `rf/frame-provider` through `reagent2.dom.client`, clicks,
+and asserts the counter text changes — in a slim-only bundle. That smoke was
+green throughout, and it was right.
+
+## What this page does NOT claim
+
+No timing. Nothing here is comparable with a bar row, and the driver publishes
+no ratio precisely so that it cannot be quoted as one. The HD-008 slim write
+figures the instrument suppressed — reading 0.16–0.50× the floor while changing
+nothing — remain unpublished and unpublishable: they were taken through the
+composition this page identifies as broken, so they price a commit that had not
+happened. They must be re-taken through a corrected arm, not rescued.

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_mixed.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_mixed.cljs
@@ -1,0 +1,34 @@
+(ns re-frame.bench.hicasso.z3vlz-mixed
+  "RUNG 4 — THE BEAD'S OWN BUNDLE. All three adapters compiled together —
+  stock `reagent`, `reagent2` (reagent-slim) and `uix` — exactly as
+  HD-008's `:advanced` bench bundle does, with reagent-slim installed.
+
+  This rung exists to prove the probe REPRODUCES the reported symptom
+  before any conclusion is drawn from the rungs below it. A single-substrate
+  bundle that re-renders is only evidence about the bead if the mixed
+  bundle, in the same probe, does not: otherwise the difference could be
+  the probe rather than the bundle.
+
+  `?install=reagent` runs the identical probe with stock Reagent installed
+  — the bead's positive control, in the bead's own bundle."
+  (:require [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.z3vlz-probe :as probe]
+            [re-frame.bench.hicasso.z3vlz-reagent-substrate :as stock]
+            [re-frame.bench.hicasso.z3vlz-slim-substrate :as slim]
+            [re-frame.core :as rf]))
+
+(def ^:export adapter-ref uix-adapter/adapter)
+
+(defn- install-stock? []
+  (boolean (some->> (some-> js/window .-location .-search)
+                    (re-find #"install=reagent"))))
+
+(defn ^:export -main []
+  (set! (.-Z3VLZ_UIX_ADAPTER js/window) (pr-str (:kind adapter-ref)))
+  (let [stock? (install-stock?)]
+    (rf/init! (if stock? stock/adapter slim/adapter))
+    (probe/run! (if stock? stock/substrate slim/substrate)
+                {:bundle      :mixed
+                 :installed   (if stock? :reagent :reagent-slim)
+                 :compiled-in [:reagent2 :reagent :uix]}
+                (if stock? :z3vlz/mixed-stock :z3vlz/mixed-slim))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_mixed.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_mixed.cljs
@@ -27,7 +27,7 @@
   (set! (.-Z3VLZ_UIX_ADAPTER js/window) (pr-str (:kind adapter-ref)))
   (let [stock? (install-stock?)]
     (rf/init! (if stock? stock/adapter slim/adapter))
-    (probe/run! (if stock? stock/substrate slim/substrate)
+    (probe/run-probe! (if stock? stock/substrate slim/substrate)
                 {:bundle      :mixed
                  :installed   (if stock? :reagent :reagent-slim)
                  :compiled-in [:reagent2 :reagent :uix]}

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_probe.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_probe.cljs
@@ -1,0 +1,323 @@
+(ns re-frame.bench.hicasso.z3vlz-probe
+  "THE rf2-z3vlz DISCRIMINATOR — one reactivity probe, four bundles.
+
+  rf2-z3vlz records that in HD-008's `:advanced` bench bundle — which
+  compiles stock `reagent`, `reagent2` (reagent-slim) AND `uix` together —
+  a `reg-view` tree mounted through `reagent2.dom.client` renders
+  CORRECTLY at mount and then NEVER re-renders on a write: 78 of 78 writes
+  failed the DOM read-back, while the stock-Reagent arm in the identical
+  harness passed 78 of 78.
+
+  The bead names three candidates and establishes none:
+
+    (a) a reagent-slim ADAPTER DEFECT — shipped code, users affected;
+    (b) a MIXED-BUNDLE ARTEFACT — stock `reagent` and `reagent2`
+        coexisting in one `:advanced` bundle;
+    (c) a `re-frame.views` LATE-BINDING problem — the late bind resolving
+        to the wrong substrate's hooks when both are present.
+
+  THE DISCRIMINATOR IS ONE QUESTION: does a SINGLE-SUBSTRATE reagent-slim
+  bundle — reagent-slim ALONE, no stock reagent compiled in — re-render on
+  a write? If yes it is (b) or (c) and no user is affected; if no it is (a)
+  and the bug is in shipped code.
+
+  So this namespace holds EVERYTHING that is the same across the bundles —
+  the subscription, the event, the `reg-view` boundaries, the frame
+  provider, the write mechanisms, the drain escalation ladder and the DOM
+  read-back accounting — and the four entry namespaces differ ONLY in what
+  they `:require`. That is the whole experimental design: the probe is a
+  constant and the bundle composition is the variable.
+
+  ## What is measured, and what is deliberately NOT
+
+  Nothing here reads a clock. This is a DIAGNOSIS, not a benchmark: the
+  only numbers it publishes are write counts and DOM read-back counts, so
+  there is no bar-comparable figure, no arm-to-arm ratio, and therefore
+  nothing for the arm-order guard to adjudicate. (Stated rather than
+  omitted: a run that quietly skipped the guard while publishing a ratio
+  would be exactly the fault the guard exists to catch.)
+
+  ## The instrument disciplines that DO apply, and how
+
+  1. **Every write is read back out of the DOM**, all cells, inside the
+     write's own window, and every result is reported as `N unverified of
+     M`. That rule is what turned this from a headline into a bead: the
+     unverified slim arm was reading 0.16-0.50x the floor while changing
+     nothing, which would have published as `reagent-slim narrow write is
+     2-6x faster than a top-down re-render`.
+  2. **A negative result needs a positive control**, and this probe
+     carries TWO, both inside the same bundle and the same harness:
+       - the RAW control: a plain substrate component reading a plain
+         substrate atom, no re-frame at all. It proves the bundle's
+         reactive engine and this harness's drain + read-back can see a
+         change AT ALL. A slim arm that fails while its own raw control
+         passes is a re-frame-side finding; a slim arm that fails
+         alongside its raw control is a harness or engine finding.
+       - the app-db witness: `frame-app-db-value` is read after every
+         write, so a failed read-back is attributed to the VIEW leg rather
+         than left ambiguous with the event leg.
+  3. **The drain escalation ladder.** A write that fails its read-back is
+     retried through progressively more generous drains — the substrate's
+     own synchronous drain again, then a macrotask, then two animation
+     frames. `NEVER` and `LATE` are different findings and an instrument
+     that cannot tell them apart has not measured the thing in the bead.
+
+  Owner: rf2-z3vlz. Normative context: `docs/design/hicasso/decisions.md`
+  HD-008."
+  (:require [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ---------------------------------------------------------------------------
+;; The shape — small on purpose
+;; ---------------------------------------------------------------------------
+
+(def cells-n
+  "Eight cells. The bead's arm ran 300; the question here is BINARY (does
+  the DOM follow a write, yes or no), and eight cells make every failure
+  printable in full rather than summarised."
+  8)
+
+(def writes-n
+  "Twelve writes per arm, alternating the two mechanisms the bead
+  reproduced with. Enough that `0 of 12` and `12 of 12` are both
+  unambiguous, few enough that the whole per-write record fits in the run
+  log."
+  12)
+
+;; ---------------------------------------------------------------------------
+;; The re-frame side
+;; ---------------------------------------------------------------------------
+
+(rf/reg-sub :z3vlz/cell (fn [db [_ i]] (get-in db [:cells i])))
+
+(rf/reg-event-db :z3vlz/set-all (fn [db [_ v]] (assoc db :cells (vec (repeat cells-n v)))))
+
+(defn seed-db [v] {:cells (vec (repeat cells-n v))})
+
+(reg-view ^{:rf/id :z3vlz/cell-view} cell-view
+  "One boundary, one subscription read — the unit whose re-render is in
+  question."
+  [i]
+  (let [v @(rf/subscribe [:z3vlz/cell i])]
+    [:li.row
+     [:span.lbl "cell "]
+     [:span.cell {:data-i i} (str v)]]))
+
+(reg-view ^{:rf/id :z3vlz/list-view} list-view
+  [n]
+  [:ul.grid {:role "list"}
+   (for [i (range n)]
+     ^{:key i} [cell-view i])])
+
+(defn root
+  "`rf/frame-provider` is how a re-frame2 application supplies the frame a
+  `reg-view` boundary resolves `subscribe` against — a plain fn carries no
+  `:contextType`, so leaving it out would raise
+  `:rf.error/no-frame-context` rather than measure anything."
+  [fid n]
+  [rf/frame-provider {:frame fid} [list-view n]])
+
+;; ---------------------------------------------------------------------------
+;; Yielding
+;; ---------------------------------------------------------------------------
+
+(defn- microtask [] (js/Promise.resolve nil))
+
+(defn- macrotask []
+  (js/Promise. (fn [res] (js/setTimeout (fn [] (res nil)) 0))))
+
+(defn- two-frames []
+  (js/Promise. (fn [res]
+                 (js/requestAnimationFrame
+                   (fn [] (js/requestAnimationFrame (fn [] (res nil))))))))
+
+;; ---------------------------------------------------------------------------
+;; The read-back
+;; ---------------------------------------------------------------------------
+
+(defn- cells-text [container]
+  (mapv (fn [i] (lane/text-at container i)) (range cells-n)))
+
+(defn- all-at?
+  "EVERY cell, not one. A stale page can still hold one fresh cell from a
+  previous write, so a single-probe check verifies almost nothing."
+  [container v]
+  (let [want (str v)]
+    (every? (fn [i] (= want (lane/text-at container i))) (range cells-n))))
+
+;; ---------------------------------------------------------------------------
+;; One verified write, with the escalation ladder
+;; ---------------------------------------------------------------------------
+
+(defn- verified-write!
+  "Perform one write, then chase it through progressively more generous
+  drains until the DOM shows it or the ladder is exhausted.
+
+  Answers a promise of
+  `{:v :mechanism :db-followed? :ok? :rung :cells}` where `:rung` is the
+  first drain that got the value onto the page — `:sync` (the substrate's
+  own drain after one microtask, which is what an application gets),
+  `:redrain`, `:macrotask`, `:raf2` — or `:never`.
+
+  The rungs past `:sync` are diagnostic ONLY. A value that needs a
+  macrotask is a LATE re-render, which is a different (and far milder)
+  finding from a re-render that never happens; collapsing the two would
+  lose the distinction the bead turns on."
+  [{:keys [drain!]} container fid v mechanism write!]
+  (write!)
+  (let [db-followed? (= (vec (repeat cells-n v))
+                        (:cells (frame/frame-app-db-value fid)))
+        rung         (volatile! nil)]
+    (-> (microtask)
+        (.then (fn [_]
+                 (drain!)
+                 (when (all-at? container v) (vreset! rung :sync))))
+        (.then (fn [_]
+                 (when-not @rung
+                   (drain!)
+                   (when (all-at? container v) (vreset! rung :redrain)))))
+        (.then (fn [_] (when-not @rung (macrotask))))
+        (.then (fn [_]
+                 (when-not @rung
+                   (drain!)
+                   (when (all-at? container v) (vreset! rung :macrotask)))))
+        (.then (fn [_] (when-not @rung (two-frames))))
+        (.then (fn [_]
+                 (when-not @rung
+                   (drain!)
+                   (when (all-at? container v) (vreset! rung :raf2)))))
+        (.then (fn [_]
+                 {:v            v
+                  :mechanism    mechanism
+                  :db-followed? db-followed?
+                  :ok?          (= :sync @rung)
+                  :rung         (or @rung :never)
+                  :cells        (when-not (= :sync @rung) (cells-text container))})))))
+
+;; ---------------------------------------------------------------------------
+;; The two write mechanisms the bead reproduced with
+;; ---------------------------------------------------------------------------
+
+(defn- write-fn
+  "Alternate `frame/replace-app-db!` and a registered event through
+  `dispatch-sync`. The bead reproduced with BOTH, so a probe that used one
+  would leave the other unanswered."
+  [fid v mechanism]
+  (case mechanism
+    :replace-app-db (fn [] (frame/replace-app-db! fid (seed-db v)))
+    :dispatch-sync  (fn [] (rf/dispatch-sync [:z3vlz/set-all v] {:frame fid}))))
+
+;; ---------------------------------------------------------------------------
+;; One arm
+;; ---------------------------------------------------------------------------
+
+(defn- mount!
+  [{:keys [create-root render]} container tree]
+  (let [r (create-root container)]
+    (render r tree)
+    r))
+
+(defn- tally [results]
+  {:of         (count results)
+   :unverified (count (remove :ok? results))
+   :by-rung    (frequencies (map :rung results))
+   :by-mechanism
+   (into {} (map (fn [[m rs]]
+                   [m {:of (count rs) :unverified (count (remove :ok? rs))}]))
+         (group-by :mechanism results))
+   :db-followed-all? (every? :db-followed? results)})
+
+(defn- run-subs-arm!
+  "The arm under test: `reg-view` boundaries reading `rf/subscribe`,
+  mounted through the substrate's own door, written through re-frame."
+  [{:keys [unmount] :as substrate} fid]
+  (rf/make-frame {:id fid})
+  (frame/replace-app-db! fid (seed-db 0))
+  (let [container (lane/fresh-container!)
+        handle    (mount! substrate container (root fid cells-n))
+        mount-cells (cells-text container)
+        mount-ok?   (all-at? container 0)]
+    (-> (lane/chain []
+                    (range 1 (inc writes-n))
+                    (fn [acc v]
+                      (let [mech (if (odd? v) :replace-app-db :dispatch-sync)]
+                        (-> (verified-write! substrate container fid v mech
+                                             (write-fn fid v mech))
+                            (.then (fn [r] (conj acc r)))))))
+        (.then (fn [results]
+                 (try (unmount handle) (catch :default _ nil))
+                 (.remove container)
+                 {:mount  {:ok? mount-ok? :cells mount-cells}
+                  :writes (tally results)
+                  :detail (mapv #(dissoc % :cells) results)
+                  :failed (vec (take 3 (remove :ok? results)))})))))
+
+(defn- run-raw-control!
+  "THE POSITIVE CONTROL, in the same bundle and the same harness: a plain
+  substrate component reading a plain substrate atom, with no re-frame
+  anywhere on the path.
+
+  Its job is to make a negative result mean something. If the subs arm
+  fails while this passes, the substrate's reactivity and this harness's
+  drain + read-back both work and the finding is on the re-frame side. If
+  both fail, the finding is the harness or the engine, and nothing about
+  re-frame has been shown."
+  [{:keys [unmount raw-element raw-write!] :as substrate}]
+  (raw-write! 0)
+  (let [container (lane/fresh-container!)
+        handle    (mount! substrate container (raw-element))
+        mount-ok? (all-at? container 0)]
+    (-> (lane/chain []
+                    (range 1 (inc writes-n))
+                    (fn [acc v]
+                      (-> (verified-write! substrate container nil v :raw-atom
+                                           (fn [] (raw-write! v)))
+                          (.then (fn [r] (conj acc (dissoc r :db-followed?)))))))
+        (.then (fn [results]
+                 (try (unmount handle) (catch :default _ nil))
+                 (.remove container)
+                 {:mount  {:ok? mount-ok?}
+                  :writes (dissoc (tally results) :db-followed-all? :by-mechanism)})))))
+
+;; ---------------------------------------------------------------------------
+;; The run
+;; ---------------------------------------------------------------------------
+
+(defn run!
+  "Run the probe for one bundle. `substrate` is
+  `{:label :create-root :render :unmount :drain! :raw-element :raw-write!}`;
+  `manifest` describes the bundle so the record is self-describing.
+
+  Answers a promise of the whole record and parks it under
+  `window.HICASSO_RESULTS` via [[re-frame.bench.hicasso.lane/record!]]."
+  [substrate {:keys [bundle installed compiled-in] :as manifest} fid]
+  (lane/leave-act-environment!)
+  (lane/record! :manifest (assoc manifest :runtime (lane/runtime-label)
+                                          :cells cells-n :writes writes-n))
+  (-> (run-raw-control! substrate)
+      (.then (fn [control]
+               (lane/record! :raw-control control)
+               (run-subs-arm! substrate fid)))
+      (.then (fn [subs]
+               (lane/record! :subs-arm subs)
+               (lane/record! :verdict
+                 {:bundle        bundle
+                  :installed     installed
+                  :compiled-in   compiled-in
+                  :mount-correct? (:ok? (:mount subs))
+                  :reactive?     (zero? (:unverified (:writes subs)))
+                  :unverified-of (str (:unverified (:writes subs)) " unverified of "
+                                      (:of (:writes subs)))
+                  :arm-order-guard
+                  (str "NOT ENGAGED — this run publishes no timed figure and no "
+                       "arm-to-arm ratio, so there is nothing for the guard to "
+                       "adjudicate. The only numbers here are write and DOM "
+                       "read-back counts.")})
+               (lane/done!)
+               nil))
+      (.catch (fn [e]
+                (lane/fail! (str "the probe threw: " (.-message e) "\n" (.-stack e)))
+                (lane/done!)
+                nil))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_probe.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_probe.cljs
@@ -64,7 +64,8 @@
 
   Owner: rf2-z3vlz. Normative context: `docs/design/hicasso/decisions.md`
   HD-008."
-  (:require [re-frame.bench.hicasso.lane :as lane]
+  (:require ["react-dom" :as react-dom]
+            [re-frame.bench.hicasso.lane :as lane]
             [re-frame.core :as rf]
             [re-frame.frame :as frame])
   (:require-macros [re-frame.core :refer [reg-view]]))
@@ -92,7 +93,12 @@
 
 (rf/reg-sub :z3vlz/cell (fn [db [_ i]] (get-in db [:cells i])))
 
-(rf/reg-event-db :z3vlz/set-all (fn [db [_ v]] (assoc db :cells (vec (repeat cells-n v)))))
+;; `reg-event-db` is REMOVED in EP-0018 (no alias): the db arrives
+;; destructured out of the coeffects map and the return is wrapped in
+;; `{:db …}`.
+(rf/reg-event :z3vlz/set-all
+  (fn [{:keys [db]} [_ v]]
+    {:db (assoc db :cells (vec (repeat cells-n v)))}))
 
 (defn seed-db [v] {:cells (vec (repeat cells-n v))})
 
@@ -148,32 +154,86 @@
     (every? (fn [i] (= want (lane/text-at container i))) (range cells-n))))
 
 ;; ---------------------------------------------------------------------------
+;; THE THIRD VARIABLE — the ORDER of write against drain
+;; ---------------------------------------------------------------------------
+;;
+;; The first run of this rig made a single-substrate reagent-slim bundle
+;; fail 12 of 12, which by the bead's stated logic would have read as
+;; candidate (a) — a defect in shipped adapter code. It is not, and the
+;; reason is a variable the bead does not name: WHEN the drain runs
+;; relative to the write.
+;;
+;; The two Reagent builds schedule their component queue differently, and
+;; that difference is documented in both of them:
+;;
+;;   - stock Reagent drains on a three-phase `requestAnimationFrame` queue;
+;;   - reagent-slim drains on a MICROTASK queue
+;;     (`reagent2.impl.batching`: "a microtask-based scheduler ... no
+;;     requestAnimationFrame fallback is required").
+;;
+;; `reagent2.dom.client/flush-render!` is documented as running `(do (f)
+;; (batching/flush!))` INSIDE a `react-dom/flushSync` boundary, and that
+;; boundary is the load-bearing part: "under React 19 `createRoot`, a bare
+;; `forceUpdate` issued from outside React's batching context is subject to
+;; automatic batching: React SCHEDULES the re-render rather than committing
+;; it synchronously".
+;;
+;; Put those two facts together. A harness that writes, YIELDS ONE
+;; MICROTASK, and only then drains has already let reagent-slim's own
+;; microtask scheduler run: the component queue is empty by the time
+;; `flush-render!` sees it, and the `forceUpdate` it issued went out
+;; OUTSIDE any `flushSync` boundary, so React holds it. `flush-render!`
+;; then finds nothing to flush and the DOM read-back reads the old value.
+;; Stock Reagent survives the identical harness because its rAF queue has
+;; NOT fired after one microtask — the drain still finds the queue full and
+;; commits it inside the boundary.
+;;
+;; So the order is measured rather than assumed. Three of them, every arm,
+;; every bundle:
+
+(def orders
+  [{:id    :inside-drain
+    :doc   (str "the write happens INSIDE `flush-render!`'s `f` — the adapter's own "
+                "documented production contract, and the shape the shipped "
+                "reagent-slim adapter smoke exercises through clicks")}
+   {:id    :drain-immediately
+    :doc   (str "write, then drain with NO yield in between. The component queue is "
+                "still full, so the drain has something to flush")}
+   {:id    :yield-then-drain
+    :doc   (str "write, yield ONE microtask, then drain — the shape of "
+                "`lane/verified-write!`, and therefore of HD-008's arm")}])
+
+;; ---------------------------------------------------------------------------
 ;; One verified write, with the escalation ladder
 ;; ---------------------------------------------------------------------------
 
 (defn- verified-write!
-  "Perform one write, then chase it through progressively more generous
-  drains until the DOM shows it or the ladder is exhausted.
+  "Perform one write under `order`, then chase it through progressively
+  more generous drains until the DOM shows it or the ladder is exhausted.
 
-  Answers a promise of
-  `{:v :mechanism :db-followed? :ok? :rung :cells}` where `:rung` is the
-  first drain that got the value onto the page — `:sync` (the substrate's
-  own drain after one microtask, which is what an application gets),
-  `:redrain`, `:macrotask`, `:raf2` — or `:never`.
+  Answers a promise of `{:v :order :mechanism :db-followed? :ok? :rung
+  :cells}` where `:rung` is the first drain that got the value onto the
+  page — `:sync` (the order's own drain, which is what an application
+  gets), then `:redrain`, `:macrotask`, `:raf2` — or `:never`.
 
   The rungs past `:sync` are diagnostic ONLY. A value that needs a
   macrotask is a LATE re-render, which is a different (and far milder)
   finding from a re-render that never happens; collapsing the two would
   lose the distinction the bead turns on."
-  [{:keys [drain!]} container fid v mechanism write!]
-  (write!)
-  (let [db-followed? (= (vec (repeat cells-n v))
-                        (:cells (frame/frame-app-db-value fid)))
-        rung         (volatile! nil)]
-    (-> (microtask)
-        (.then (fn [_]
-                 (drain!)
-                 (when (all-at? container v) (vreset! rung :sync))))
+  [{:keys [drain! drain-with!]} container fid order v mechanism write!]
+  (let [rung    (volatile! nil)
+        started (case order
+                  :inside-drain      (do (drain-with! write!)
+                                         (js/Promise.resolve nil))
+                  :drain-immediately (do (write!) (drain!)
+                                         (js/Promise.resolve nil))
+                  :yield-then-drain  (do (write!)
+                                         (.then (microtask) (fn [_] (drain!)))))
+        db-followed? (when fid
+                       (= (vec (repeat cells-n v))
+                          (:cells (frame/frame-app-db-value fid))))]
+    (-> started
+        (.then (fn [_] (when (all-at? container v) (vreset! rung :sync))))
         (.then (fn [_]
                  (when-not @rung
                    (drain!)
@@ -189,12 +249,13 @@
                    (drain!)
                    (when (all-at? container v) (vreset! rung :raf2)))))
         (.then (fn [_]
-                 {:v            v
-                  :mechanism    mechanism
-                  :db-followed? db-followed?
-                  :ok?          (= :sync @rung)
-                  :rung         (or @rung :never)
-                  :cells        (when-not (= :sync @rung) (cells-text container))})))))
+                 (cond-> {:v         v
+                          :order     order
+                          :mechanism mechanism
+                          :ok?       (= :sync @rung)
+                          :rung      (or @rung :never)}
+                   (some? db-followed?) (assoc :db-followed? db-followed?)
+                   (not= :sync @rung)   (assoc :cells (cells-text container))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The two write mechanisms the bead reproduced with
@@ -214,20 +275,54 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- mount!
+  "Create the root and render INSIDE a `react-dom/flushSync`.
+
+  `root.render` called outside a React event schedules at the default lane
+  and does not commit before the next line runs, so a mount read-back taken
+  without this boundary reads an EMPTY container — which is what the first
+  run of this probe did, in every arm including the raw control. The raw
+  control failing beside the arm under test is the whole reason that was a
+  ten-minute harness fix rather than a published finding about
+  reagent-slim.
+
+  The boundary is React's, not a substrate's, so all three substrates take
+  the identical mount and no arm is billed for a commit another arm skipped."
   [{:keys [create-root render]} container tree]
   (let [r (create-root container)]
-    (render r tree)
+    (react-dom/flushSync (fn [] (render r tree)))
     r))
 
-(defn- tally [results]
-  {:of         (count results)
-   :unverified (count (remove :ok? results))
-   :by-rung    (frequencies (map :rung results))
-   :by-mechanism
-   (into {} (map (fn [[m rs]]
-                   [m {:of (count rs) :unverified (count (remove :ok? rs))}]))
-         (group-by :mechanism results))
-   :db-followed-all? (every? :db-followed? results)})
+(defn- tally
+  "`N unverified of M` per ORDER, plus the rung histogram that tells a
+  never-re-rendered apart from a late one."
+  [results]
+  (into {}
+        (map (fn [[order rs]]
+               [order (cond-> {:of         (count rs)
+                               :unverified (count (remove :ok? rs))
+                               :summary    (str (count (remove :ok? rs))
+                                                " unverified of " (count rs))
+                               :by-rung    (frequencies (map :rung rs))}
+                        (some :mechanism rs)
+                        (assoc :by-mechanism
+                               (into {} (map (fn [[m ms]]
+                                               [m {:of (count ms)
+                                                   :unverified (count (remove :ok? ms))}]))
+                                     (group-by :mechanism rs)))
+                        (some :db-followed? rs)
+                        (assoc :db-followed-all? (every? :db-followed? rs)))]))
+        (group-by :order results)))
+
+(defn- writes-over-orders!
+  "Run [[writes-n]] verified writes under EVERY order, serially, against a
+  standing mount. Answers a promise of the flat result vector."
+  [substrate container fid write-of]
+  (lane/chain []
+              (for [{:keys [id]} orders, v (range 1 (inc writes-n))] [id v])
+              (fn [acc [order v]]
+                (let [[mech write!] (write-of v)]
+                  (-> (verified-write! substrate container fid order v mech write!)
+                      (.then (fn [r] (conj acc r))))))))
 
 (defn- run-subs-arm!
   "The arm under test: `reg-view` boundaries reading `rf/subscribe`,
@@ -235,23 +330,19 @@
   [{:keys [unmount] :as substrate} fid]
   (rf/make-frame {:id fid})
   (frame/replace-app-db! fid (seed-db 0))
-  (let [container (lane/fresh-container!)
-        handle    (mount! substrate container (root fid cells-n))
+  (let [container   (lane/fresh-container!)
+        handle      (mount! substrate container (root fid cells-n))
         mount-cells (cells-text container)
         mount-ok?   (all-at? container 0)]
-    (-> (lane/chain []
-                    (range 1 (inc writes-n))
-                    (fn [acc v]
-                      (let [mech (if (odd? v) :replace-app-db :dispatch-sync)]
-                        (-> (verified-write! substrate container fid v mech
-                                             (write-fn fid v mech))
-                            (.then (fn [r] (conj acc r)))))))
+    (-> (writes-over-orders! substrate container fid
+                             (fn [v]
+                               (let [mech (if (odd? v) :replace-app-db :dispatch-sync)]
+                                 [mech (write-fn fid v mech)])))
         (.then (fn [results]
                  (try (unmount handle) (catch :default _ nil))
                  (.remove container)
                  {:mount  {:ok? mount-ok? :cells mount-cells}
-                  :writes (tally results)
-                  :detail (mapv #(dissoc % :cells) results)
+                  :orders (tally results)
                   :failed (vec (take 3 (remove :ok? results)))})))))
 
 (defn- run-raw-control!
@@ -263,61 +354,80 @@
   fails while this passes, the substrate's reactivity and this harness's
   drain + read-back both work and the finding is on the re-frame side. If
   both fail, the finding is the harness or the engine, and nothing about
-  re-frame has been shown."
+  re-frame has been shown — which is exactly what this control said on the
+  first run of this rig, when an unflushed mount was making every arm look
+  inert."
   [{:keys [unmount raw-element raw-write!] :as substrate}]
   (raw-write! 0)
   (let [container (lane/fresh-container!)
         handle    (mount! substrate container (raw-element))
         mount-ok? (all-at? container 0)]
-    (-> (lane/chain []
-                    (range 1 (inc writes-n))
-                    (fn [acc v]
-                      (-> (verified-write! substrate container nil v :raw-atom
-                                           (fn [] (raw-write! v)))
-                          (.then (fn [r] (conj acc (dissoc r :db-followed?)))))))
+    (-> (writes-over-orders! substrate container nil
+                             (fn [v] [nil (fn [] (raw-write! v))]))
         (.then (fn [results]
                  (try (unmount handle) (catch :default _ nil))
                  (.remove container)
                  {:mount  {:ok? mount-ok?}
-                  :writes (dissoc (tally results) :db-followed-all? :by-mechanism)})))))
+                  :orders (tally results)})))))
 
 ;; ---------------------------------------------------------------------------
 ;; The run
 ;; ---------------------------------------------------------------------------
 
-(defn run!
-  "Run the probe for one bundle. `substrate` is
-  `{:label :create-root :render :unmount :drain! :raw-element :raw-write!}`;
-  `manifest` describes the bundle so the record is self-describing.
-
-  Answers a promise of the whole record and parks it under
-  `window.HICASSO_RESULTS` via [[re-frame.bench.hicasso.lane/record!]]."
-  [substrate {:keys [bundle installed compiled-in] :as manifest} fid]
-  (lane/leave-act-environment!)
-  (lane/record! :manifest (assoc manifest :runtime (lane/runtime-label)
-                                          :cells cells-n :writes writes-n))
+(defn- run-chain!
+  [substrate {:keys [bundle installed compiled-in]} fid]
   (-> (run-raw-control! substrate)
       (.then (fn [control]
                (lane/record! :raw-control control)
                (run-subs-arm! substrate fid)))
       (.then (fn [subs]
                (lane/record! :subs-arm subs)
-               (lane/record! :verdict
-                 {:bundle        bundle
-                  :installed     installed
-                  :compiled-in   compiled-in
-                  :mount-correct? (:ok? (:mount subs))
-                  :reactive?     (zero? (:unverified (:writes subs)))
-                  :unverified-of (str (:unverified (:writes subs)) " unverified of "
-                                      (:of (:writes subs)))
-                  :arm-order-guard
-                  (str "NOT ENGAGED — this run publishes no timed figure and no "
-                       "arm-to-arm ratio, so there is nothing for the guard to "
-                       "adjudicate. The only numbers here are write and DOM "
-                       "read-back counts.")})
+               (let [o (:orders subs)
+                     un (fn [k] (get-in o [k :summary]))]
+                 (lane/record! :verdict
+                   {:bundle         bundle
+                    :installed      installed
+                    :compiled-in    compiled-in
+                    :mount-correct? (:ok? (:mount subs))
+                    ;; REACTIVE means: under the substrate's OWN documented
+                    ;; drain contract — the write inside `flush-render!` — the
+                    ;; DOM followed every write. That is the question the bead
+                    ;; asks about the ADAPTER. The `:yield-then-drain` row
+                    ;; beside it is the question about the HARNESS.
+                    :reactive?      (zero? (:unverified (:inside-drain o)))
+                    :unverified-of  {:inside-drain      (un :inside-drain)
+                                     :drain-immediately (un :drain-immediately)
+                                     :yield-then-drain  (un :yield-then-drain)}
+                    :arm-order-guard
+                    (str "NOT ENGAGED — this run publishes no timed figure and no "
+                         "arm-to-arm ratio, so there is nothing for the guard to "
+                         "adjudicate. The only numbers here are write and DOM "
+                         "read-back counts.")}))
                (lane/done!)
                nil))
       (.catch (fn [e]
                 (lane/fail! (str "the probe threw: " (.-message e) "\n" (.-stack e)))
                 (lane/done!)
                 nil))))
+
+(defn run-probe!
+  "Run the probe for one bundle. `substrate` is
+  `{:label :create-root :render :unmount :drain! :raw-element :raw-write!}`;
+  `manifest` describes the bundle so the record is self-describing.
+
+  Answers a promise of the whole record and parks it under
+  `window.HICASSO_RESULTS` via [[re-frame.bench.hicasso.lane/record!]]."
+  [substrate manifest fid]
+  (lane/leave-act-environment!)
+  (lane/record! :manifest (assoc manifest :runtime (lane/runtime-label)
+                                          :cells cells-n :writes writes-n))
+  ;; SYNCHRONOUS throws get the same treatment as rejections. A mount that
+  ;; throws before the first `.then` would otherwise escape the chain
+  ;; entirely, leaving `HICASSO_DONE` unset and the driver waiting out its
+  ;; whole sentinel on what is really a one-line stack.
+  (try
+    (run-chain! substrate manifest fid)
+    (catch :default e
+      (lane/fail! (str "the probe threw synchronously: " (.-message e) "\n" (.-stack e)))
+      (lane/done!)
+      nil)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_reagent_substrate.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_reagent_substrate.cljs
@@ -1,0 +1,47 @@
+(ns re-frame.bench.hicasso.z3vlz-reagent-substrate
+  "The stock-Reagent substrate (rf2-z3vlz) — the bead's positive control,
+  and the thing whose PRESENCE IN THE BUNDLE is candidate (b).
+
+  This namespace does double duty, and both are deliberate:
+
+  1. It is the arm that passed 78 of 78 in HD-008's harness while the slim
+     arm failed 78 of 78. A negative result about reagent-slim is only
+     meaningful beside it, so it is carried into every mixed bundle here
+     and run through the identical probe.
+  2. Requiring it is what MAKES a bundle mixed. Candidate (b) is that
+     stock `reagent` and `reagent2` coexisting in one `:advanced` bundle
+     is itself the fault; the way to test that is to add exactly this
+     namespace and change nothing else.
+
+  Its arms are USED, not merely required, in every bundle that names it —
+  a require whose code `:advanced` could prove dead would not reproduce
+  the bundle the bead describes."
+  (:require ["react-dom" :as react-dom]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.bench.hicasso.z3vlz-probe :as probe]
+            [reagent.core :as r]
+            [reagent.dom.client :as rdc]
+            [reagent.ratom :as reagent-ratom]))
+
+(defonce ^:private raw-cells (r/atom (vec (repeat probe/cells-n 0))))
+
+(defn- raw-list []
+  [:ul.grid {:role "list"}
+   (for [i (range probe/cells-n)]
+     ^{:key i} [:li.row
+                [:span.lbl "cell "]
+                [:span.cell {:data-i i} (str (get @raw-cells i))]])])
+
+(def adapter reagent-adapter/adapter)
+
+(def substrate
+  {:label       :reagent
+   :create-root (fn [container] (rdc/create-root container))
+   :render      (fn [root tree] (rdc/render root tree))
+   :unmount     (fn [root] (rdc/unmount root))
+   ;; SETTLE, THEN RENDER. `ratom/flush!` runs the queued Reactions and
+   ;; `reagent.core/flush` renders the dirty components; draining only the
+   ;; component queue leaves the page reading a stale snapshot.
+   :drain!      (fn [] (react-dom/flushSync (fn [] (reagent-ratom/flush!) (r/flush))))
+   :raw-element (fn [] [raw-list])
+   :raw-write!  (fn [v] (reset! raw-cells (vec (repeat probe/cells-n v))))})

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_reagent_substrate.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_reagent_substrate.cljs
@@ -26,11 +26,12 @@
 (defonce ^:private raw-cells (r/atom (vec (repeat probe/cells-n 0))))
 
 (defn- raw-list []
-  [:ul.grid {:role "list"}
-   (for [i (range probe/cells-n)]
-     ^{:key i} [:li.row
-                [:span.lbl "cell "]
-                [:span.cell {:data-i i} (str (get @raw-cells i))]])])
+  (let [cells @raw-cells]
+    [:ul.grid {:role "list"}
+     (for [i (range probe/cells-n)]
+       ^{:key i} [:li.row
+                  [:span.lbl "cell "]
+                  [:span.cell {:data-i i} (str (get cells i))]])]))
 
 (def adapter reagent-adapter/adapter)
 
@@ -43,5 +44,10 @@
    ;; `reagent.core/flush` renders the dirty components; draining only the
    ;; component queue leaves the page reading a stale snapshot.
    :drain!      (fn [] (react-dom/flushSync (fn [] (reagent-ratom/flush!) (r/flush))))
+   ;; The stock counterpart of the slim `:drain-with!`. Stock Reagent's
+   ;; component queue is rAF-scheduled, so it is still full a microtask
+   ;; later and this arm passes under every order — which is precisely why
+   ;; it passed 78 of 78 in HD-008 beside a slim arm that failed 78 of 78.
+   :drain-with! (fn [f] (react-dom/flushSync (fn [] (f) (reagent-ratom/flush!) (r/flush))))
    :raw-element (fn [] [raw-list])
    :raw-write!  (fn [v] (reset! raw-cells (vec (repeat probe/cells-n v))))})

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+// THE rf2-z3vlz DISCRIMINATOR DRIVER — build four bundles, drive six
+// pages, and answer (a), (b) or (c).
+//
+//   node implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs
+//
+//   Z3VLZ_ONLY=slim-only,mixed \
+//   Z3VLZ_PORT=8171 \
+//     node implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs
+//
+// Rides rf2-2rtt6.2's `:hicasso-bench` build id through `--config-merge`,
+// exactly as `run.cjs` does and for the same reason: HD-017 makes a build-id
+// touch a hot-zone edit to `implementation/shadow-cljs.edn`, and four bundles
+// would otherwise be four of them. NOTHING here adds a build id.
+//
+// WHAT THE BUNDLE-COMPOSITION CHECK IS FOR. The whole experiment turns on
+// "reagent-slim ALONE, no stock reagent compiled in", so a claim that a
+// bundle is single-substrate must be VERIFIED rather than asserted from a
+// namespace's `:require` list. Each build is emitted with a source map and
+// the driver reads the map's `sources` array — the definitive list of what
+// the compiler consumed — and refuses to run a page whose bundle does not
+// match its declared composition. A run whose slim-only bundle silently
+// contained stock Reagent would answer the wrong question with a precise
+// number, which is the failure mode this whole lane is built against.
+//
+// A Chromium `pageerror` is FATAL, as it is in every adjacent runner: a
+// probe that threw and kept going reports on a page that is not the page
+// under test.
+//
+// EXIT CODES
+//   0  every declared bundle matched, every page ran, every record printed
+//   1  a build failed, a bundle did not match its declared composition, a
+//      page threw, or the probe recorded a fatal
+//
+// The arm-order guard owns exit 2 on the timed lanes. It is NOT ENGAGED
+// here and the run says so in its own record: this driver publishes no
+// timed figure and no arm-to-arm ratio, so there is nothing for the guard
+// to adjudicate. The only numbers are write and DOM read-back counts.
+
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs');
+
+const IMPL = path.resolve(__dirname, '../../../../..');
+const BUILD_ID = 'hicasso-bench';
+const PORT = Number(process.env.Z3VLZ_PORT || 8171);
+const SENTINEL_TIMEOUT_MS = 5 * 60 * 1000;
+
+// Each rung adds ONE namespace to the one above it. The `expect` map is
+// checked against the build's own source map before the page is driven.
+const VARIANTS = [
+  {
+    name: 'slim-only',
+    initFn: 're-frame.bench.hicasso.z3vlz-slim-only/-main',
+    outDir: 'out/z3vlz-slim-only',
+    expect: { reagent: false, reagent2: true, uix: false },
+    pages: [{ label: 'slim-only / install=reagent-slim', query: '' }],
+  },
+  {
+    name: 'slim+reagent',
+    initFn: 're-frame.bench.hicasso.z3vlz-slim-reagent/-main',
+    outDir: 'out/z3vlz-slim-reagent',
+    expect: { reagent: true, reagent2: true, uix: false },
+    pages: [
+      { label: 'slim+reagent / install=reagent-slim', query: '' },
+      { label: 'slim+reagent / install=reagent (control)', query: '?install=reagent' },
+    ],
+  },
+  {
+    name: 'slim+uix',
+    initFn: 're-frame.bench.hicasso.z3vlz-slim-uix/-main',
+    outDir: 'out/z3vlz-slim-uix',
+    expect: { reagent: false, reagent2: true, uix: true },
+    pages: [{ label: 'slim+uix / install=reagent-slim', query: '' }],
+  },
+  {
+    name: 'mixed',
+    initFn: 're-frame.bench.hicasso.z3vlz-mixed/-main',
+    outDir: 'out/z3vlz-mixed',
+    expect: { reagent: true, reagent2: true, uix: true },
+    pages: [
+      { label: 'mixed / install=reagent-slim', query: '' },
+      { label: 'mixed / install=reagent (control)', query: '?install=reagent' },
+    ],
+  },
+];
+
+function selected() {
+  const only = (process.env.Z3VLZ_ONLY || '').trim();
+  if (!only) return VARIANTS;
+  const want = new Set(only.split(',').map((s) => s.trim()).filter(Boolean));
+  const got = VARIANTS.filter((v) => want.has(v.name));
+  if (got.length === 0) {
+    console.error(`[z3vlz] Z3VLZ_ONLY=${only} matched no variant`);
+    process.exit(1);
+  }
+  return got;
+}
+
+function build(variant) {
+  console.error(`[z3vlz] building :advanced — ${variant.name} -> ${variant.outDir}`);
+  // ONE LINE, deliberately: shadow-cljs's CLI re-splits `--config-merge` on
+  // whitespace when the EDN contains a newline and then reports `EOF while
+  // reading` from a fragment.
+  const merge =
+    `{:output-dir "${variant.outDir}" :asset-path "." ` +
+    `:compiler-options {:source-map true} ` +
+    `:modules {:main {:init-fn ${variant.initFn}}}}`;
+  const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+  const r = spawnSync(process.execPath, [runner, 'release', BUILD_ID, '--config-merge', merge], {
+    cwd: IMPL,
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+  if (r.status !== 0) {
+    console.error(`[z3vlz] build failed with status ${r.status}`);
+    process.exit(1);
+  }
+}
+
+// `reagent2/...` also contains the substring `reagent`, so stock Reagent is
+// matched by a path segment that is EXACTLY `reagent` — the one distinction
+// the whole experiment rests on.
+const STOCK_REAGENT = /(^|[\\/])reagent[\\/](core|ratom|dom|impl)[\\/.]/;
+const SLIM_REAGENT = /(^|[\\/])reagent2[\\/]/;
+const UIX = /(^|[\\/])uix[\\/]/;
+
+function composition(variant) {
+  const mapFile = path.join(IMPL, variant.outDir, 'main.js.map');
+  if (!fs.existsSync(mapFile)) {
+    console.error(
+      `[z3vlz] FAILED: no source map at ${mapFile} — the bundle-composition check ` +
+        `cannot run, and an unverified single-substrate claim is the one thing this ` +
+        `experiment may not assert`
+    );
+    process.exit(1);
+  }
+  const sources = JSON.parse(fs.readFileSync(mapFile, 'utf8')).sources || [];
+  return {
+    sources: sources.length,
+    reagent: sources.some((s) => STOCK_REAGENT.test(s)),
+    reagent2: sources.some((s) => SLIM_REAGENT.test(s)),
+    uix: sources.some((s) => UIX.test(s)),
+    stockFiles: sources.filter((s) => STOCK_REAGENT.test(s)).slice(0, 6),
+  };
+}
+
+function checkComposition(variant) {
+  const got = composition(variant);
+  const want = variant.expect;
+  const bad = ['reagent', 'reagent2', 'uix'].filter((k) => got[k] !== want[k]);
+  console.log(
+    `;; ==== Z3VLZ BUNDLE ${variant.name} ====\n` +
+      `;; compiled sources: ${got.sources}  stock-reagent: ${got.reagent}  ` +
+      `reagent2: ${got.reagent2}  uix: ${got.uix}` +
+      (got.stockFiles.length ? `\n;; stock-reagent files: ${got.stockFiles.join(' ')}` : '')
+  );
+  if (bad.length) {
+    console.error(
+      `[z3vlz] FAILED: bundle ${variant.name} does not match its declared ` +
+        `composition (${bad.map((k) => `${k}: want ${want[k]}, got ${got[k]}`).join('; ')}). ` +
+        `Every conclusion below would be drawn from a bundle that is not the one named.`
+    );
+    process.exit(1);
+  }
+  return got;
+}
+
+const MIME = { '.js': 'text/javascript', '.html': 'text/html', '.map': 'application/json' };
+
+function serve(outDir) {
+  const OUT = path.join(IMPL, outDir);
+  fs.writeFileSync(
+    path.join(OUT, 'index.html'),
+    '<!doctype html><html><head><meta charset="utf-8"><title>z3vlz</title></head>' +
+      '<body><div id="app"></div><script src="main.js"></script></body></html>'
+  );
+  return http
+    .createServer((req, res) => {
+      const rel = decodeURIComponent(req.url.split('?')[0]);
+      const file = path.join(OUT, rel === '/' ? 'index.html' : rel);
+      if (!file.startsWith(OUT) || !fs.existsSync(file)) {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      fs.createReadStream(file).pipe(res);
+    })
+    .listen(PORT);
+}
+
+async function drive(page, url) {
+  const pageErrors = [];
+  const onError = (e) => {
+    pageErrors.push(e.message);
+    console.error('[z3vlz] PAGE ERROR:', e.message);
+  };
+  page.on('pageerror', onError);
+
+  // `'commit'`, not `'load'`: the bundle's `:init-fn` runs inside the
+  // `<script>`, so the probe is already running while the document is
+  // loading and `load` cannot fire until it is over.
+  await navigate(page, url, {
+    waitUntil: 'commit',
+    timeoutMs: NAV_TIMEOUT_MS,
+    budget: `the ${SENTINEL_TIMEOUT_MS / 60000}-minute wait for window.HICASSO_DONE`,
+  });
+  await page.waitForFunction('window.HICASSO_DONE === true || window.HICASSO_ERROR', null, {
+    timeout: SENTINEL_TIMEOUT_MS,
+  });
+  const err = await page.evaluate('window.HICASSO_ERROR || null');
+  const results = await page.evaluate('window.HICASSO_RESULTS || {}');
+  page.off('pageerror', onError);
+  return { err, results, pageErrors };
+}
+
+(async () => {
+  const variants = selected();
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch();
+  const version = browser.version();
+  const rows = [];
+  let failed = false;
+
+  for (const variant of variants) {
+    build(variant);
+    const comp = checkComposition(variant);
+    const server = serve(variant.outDir);
+    try {
+      for (const p of variant.pages) {
+        const page = await browser.newPage();
+        page.on('console', (msg) => {
+          const t = msg.text();
+          if (t.startsWith(';; ') || t.startsWith('[z3vlz]')) console.log(t);
+        });
+        console.log(`;; ==== Z3VLZ PAGE ${p.label} ====`);
+        const outcome = await drive(page, `http://127.0.0.1:${PORT}/${p.query}`);
+        await page.close();
+        for (const [k, v] of Object.entries(outcome.results)) {
+          console.log(`;; ---- ${p.label} :${k}\n${v}`);
+        }
+        if (outcome.pageErrors.length) {
+          console.error(
+            `[z3vlz] FAILED: ${outcome.pageErrors.length} uncaught page error(s) on ` +
+              `${p.label} — every figure above was taken on a page that had already ` +
+              `thrown:\n  ${outcome.pageErrors.join('\n  ')}`
+          );
+          failed = true;
+        }
+        if (outcome.err) {
+          console.error(`[z3vlz] FAILED: ${p.label}: ${outcome.err}`);
+          failed = true;
+        }
+        rows.push({ page: p.label, comp, verdict: outcome.results.verdict || null });
+      }
+    } finally {
+      server.close();
+    }
+  }
+  await browser.close();
+
+  console.log(`;; ==== Z3VLZ RUNTIME ====`);
+  console.log(`;; chromium ${version} (playwright), :advanced, goog.DEBUG false`);
+  console.log(`;; ==== Z3VLZ SUMMARY ====`);
+  for (const r of rows) {
+    const reactive = r.verdict ? /:reactive\?\s+true/.test(r.verdict) : null;
+    const mount = r.verdict ? /:mount-correct\?\s+true/.test(r.verdict) : null;
+    const unver = r.verdict ? (r.verdict.match(/:unverified-of "([^"]+)"/) || [])[1] : null;
+    console.log(
+      `;; ${r.page.padEnd(42)} stock-reagent-in-bundle=${String(r.comp.reagent).padEnd(5)} ` +
+        `mount-correct=${String(mount).padEnd(5)} reactive=${String(reactive).padEnd(5)} ` +
+        `${unver || ''}`
+    );
+  }
+  console.log(
+    `;; arm-order guard: NOT ENGAGED — no timed figure and no arm-to-arm ratio is ` +
+      `published by this driver, so there is nothing to adjudicate.`
+  );
+
+  if (failed) process.exit(1);
+  console.error('[z3vlz] ok');
+})();

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs
@@ -107,15 +107,26 @@ function build(variant) {
   // ONE LINE, deliberately: shadow-cljs's CLI re-splits `--config-merge` on
   // whitespace when the EDN contains a newline and then reports `EOF while
   // reading` from a fragment.
+  // `Z3VLZ_OPT=none` builds the SAME entries unoptimised. It is a
+  // rig-debugging aid ONLY and never a source of a finding: `goog.DEBUG` is
+  // true there, which puts the whole Spec 009 instrumentation seam back on
+  // the subscription path this probe walks. Every conclusion in the bead is
+  // taken from the default `:advanced` build, which is the artefact a
+  // consumer ships and the one HD-008 measured.
+  // `release` is what carries `:advanced`; the unoptimised aid is the
+  // `compile` command, because `release` refuses `:optimizations :none`
+  // outright ("optimizations set to :none, can't optimize").
+  const dev = process.env.Z3VLZ_OPT === 'none';
   const merge =
     `{:output-dir "${variant.outDir}" :asset-path "." ` +
     `:compiler-options {:source-map true} ` +
     `:modules {:main {:init-fn ${variant.initFn}}}}`;
   const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
-  const r = spawnSync(process.execPath, [runner, 'release', BUILD_ID, '--config-merge', merge], {
-    cwd: IMPL,
-    stdio: ['ignore', 'inherit', 'inherit'],
-  });
+  const r = spawnSync(
+    process.execPath,
+    [runner, dev ? 'compile' : 'release', BUILD_ID, '--config-merge', merge],
+    { cwd: IMPL, stdio: ['ignore', 'inherit', 'inherit'] }
+  );
   if (r.status !== 0) {
     console.error(`[z3vlz] build failed with status ${r.status}`);
     process.exit(1);
@@ -139,7 +150,23 @@ function composition(variant) {
     );
     process.exit(1);
   }
-  const sources = JSON.parse(fs.readFileSync(mapFile, 'utf8')).sources || [];
+  // shadow-cljs emits an INDEXED source map (`sections`), one section per
+  // compiled input, so the file has no top-level `sources` array. Both
+  // shapes are read here: a driver that silently found zero sources would
+  // report "stock reagent absent" for every bundle, including the ones that
+  // contain it, and the bundle-composition check would pass vacuously.
+  const raw = JSON.parse(fs.readFileSync(mapFile, 'utf8'));
+  const sources = [
+    ...(raw.sources || []),
+    ...(raw.sections || []).flatMap((s) => (s.map && s.map.sources) || []),
+  ];
+  if (sources.length === 0) {
+    console.error(
+      `[z3vlz] FAILED: ${mapFile} yielded no source list — the bundle-composition ` +
+        `check would pass vacuously for every bundle`
+    );
+    process.exit(1);
+  }
   return {
     sources: sources.length,
     reagent: sources.some((s) => STOCK_REAGENT.test(s)),
@@ -195,11 +222,46 @@ function serve(outDir) {
 
 async function drive(page, url) {
   const pageErrors = [];
+  // Resolved by the FIRST uncaught page error, and raced against the
+  // done-sentinel below. A throw that escapes the probe's own promise chain
+  // leaves `window.HICASSO_DONE` unset for ever, so without this race the
+  // driver would sit out its whole sentinel and then report a TIMEOUT —
+  // burying the actual stack under a budget failure it did not have.
+  let onFirstError;
+  const firstError = new Promise((res) => {
+    onFirstError = res;
+  });
   const onError = (e) => {
-    pageErrors.push(e.message);
+    pageErrors.push({ message: e.message, stack: e.stack });
     console.error('[z3vlz] PAGE ERROR:', e.message);
+    if (e.stack) console.error(e.stack);
+    onFirstError('pageerror');
   };
   page.on('pageerror', onError);
+
+  // Playwright's `pageerror` reports `name: message`, and an `:advanced`
+  // bundle renames the constructor of any Error subclass — so a CLJS
+  // `ExceptionInfo` with an empty message arrives as a two-letter munged
+  // token and nothing else. The page-side listener keeps what the driver
+  // side cannot see: the raw stack and, for a fail-loud `ex-info`, its
+  // `ex-data` (which is where every re-frame diagnostic actually lives).
+  await page.addInitScript(() => {
+    window.addEventListener('error', (ev) => {
+      const e = ev.error;
+      let data = null;
+      try {
+        data = e && e.data ? JSON.stringify(e.data, (k, v) => (v === undefined ? null : v)) : null;
+      } catch (_) {
+        data = e && e.data ? String(e.data) : null;
+      }
+      window.Z3VLZ_UNCAUGHT = {
+        str: String(e),
+        message: e && e.message,
+        stack: e && e.stack,
+        data,
+      };
+    });
+  });
 
   // `'commit'`, not `'load'`: the bundle's `:init-fn` runs inside the
   // `<script>`, so the probe is already running while the document is
@@ -209,13 +271,24 @@ async function drive(page, url) {
     timeoutMs: NAV_TIMEOUT_MS,
     budget: `the ${SENTINEL_TIMEOUT_MS / 60000}-minute wait for window.HICASSO_DONE`,
   });
-  await page.waitForFunction('window.HICASSO_DONE === true || window.HICASSO_ERROR', null, {
-    timeout: SENTINEL_TIMEOUT_MS,
-  });
+  await Promise.race([
+    page.waitForFunction('window.HICASSO_DONE === true || window.HICASSO_ERROR', null, {
+      timeout: SENTINEL_TIMEOUT_MS,
+    }),
+    firstError,
+  ]);
   const err = await page.evaluate('window.HICASSO_ERROR || null');
   const results = await page.evaluate('window.HICASSO_RESULTS || {}');
+  const uncaught = await page.evaluate('window.Z3VLZ_UNCAUGHT || null');
+  if (uncaught) {
+    console.error('[z3vlz] UNCAUGHT (page-side capture):');
+    console.error(`  toString: ${uncaught.str}`);
+    console.error(`  message:  ${uncaught.message}`);
+    console.error(`  ex-data:  ${uncaught.data}`);
+    console.error(`  stack:    ${uncaught.stack}`);
+  }
   page.off('pageerror', onError);
-  return { err, results, pageErrors };
+  return { err, results, pageErrors, uncaught };
 }
 
 (async () => {
@@ -247,7 +320,7 @@ async function drive(page, url) {
           console.error(
             `[z3vlz] FAILED: ${outcome.pageErrors.length} uncaught page error(s) on ` +
               `${p.label} — every figure above was taken on a page that had already ` +
-              `thrown:\n  ${outcome.pageErrors.join('\n  ')}`
+              `thrown:\n  ${outcome.pageErrors.map((e) => e.stack || e.message).join('\n  ')}`
           );
           failed = true;
         }
@@ -266,14 +339,23 @@ async function drive(page, url) {
   console.log(`;; ==== Z3VLZ RUNTIME ====`);
   console.log(`;; chromium ${version} (playwright), :advanced, goog.DEBUG false`);
   console.log(`;; ==== Z3VLZ SUMMARY ====`);
+  // The three ORDER rows side by side. `inside-drain` is the substrate's own
+  // documented contract and is therefore the row that answers the bead's
+  // question about the ADAPTER; `yield-then-drain` is `lane/verified-write!`'s
+  // shape and is the row that answers the question about the HARNESS.
+  const order = (v, k) =>
+    v ? ((v.match(new RegExp(`:${k} "([^"]+)"`)) || [])[1] || '?') : '?';
+  console.log(
+    `;; ${'page'.padEnd(40)} ${'stock?'.padEnd(7)} ${'mount'.padEnd(6)} ` +
+      `${'inside-drain'.padEnd(20)} ${'drain-immediately'.padEnd(20)} yield-then-drain`
+  );
   for (const r of rows) {
-    const reactive = r.verdict ? /:reactive\?\s+true/.test(r.verdict) : null;
     const mount = r.verdict ? /:mount-correct\?\s+true/.test(r.verdict) : null;
-    const unver = r.verdict ? (r.verdict.match(/:unverified-of "([^"]+)"/) || [])[1] : null;
     console.log(
-      `;; ${r.page.padEnd(42)} stock-reagent-in-bundle=${String(r.comp.reagent).padEnd(5)} ` +
-        `mount-correct=${String(mount).padEnd(5)} reactive=${String(reactive).padEnd(5)} ` +
-        `${unver || ''}`
+      `;; ${r.page.padEnd(40)} ${String(r.comp.reagent).padEnd(7)} ${String(mount).padEnd(6)} ` +
+        `${order(r.verdict, 'inside-drain').padEnd(20)} ` +
+        `${order(r.verdict, 'drain-immediately').padEnd(20)} ` +
+        `${order(r.verdict, 'yield-then-drain')}`
     );
   }
   console.log(

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_slim_only.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_slim_only.cljs
@@ -1,0 +1,33 @@
+(ns re-frame.bench.hicasso.z3vlz-slim-only
+  "RUNG 1 — reagent-slim ALONE. THE EXPERIMENT THAT SETTLES rf2-z3vlz.
+
+  The bead's question is whether a SINGLE-SUBSTRATE reagent-slim bundle —
+  reagent-slim alone, no stock reagent compiled in — re-renders on a
+  write. If it does, HD-008's finding is a mixed-bundle artefact (b) or a
+  late-binding collision (c) and no user is affected. If it does not, it is
+  an adapter defect (a): shipped, first-class, and a correctness bug.
+
+  This entry's whole content is one `rf/init!` and one probe call. What
+  makes it the experiment is what it does NOT require: no
+  `re-frame.adapter.reagent`, no `reagent.core`, no `uix.core`, and
+  nothing that reaches them transitively. `re-frame.bench.hicasso.lane`
+  (through the probe) requires only `react-dom` and the order guard; the
+  slim substrate namespace requires only `reagent2.*`. The
+  `:compiled-in` manifest below is checked against the BUILD'S OWN source
+  map by the driver, so the claim is verified rather than asserted.
+
+  Built and driven by
+  `implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs` on
+  rf2-2rtt6.2's `:hicasso-bench` build id — no new build id, so
+  `implementation/shadow-cljs.edn` is untouched."
+  (:require [re-frame.bench.hicasso.z3vlz-probe :as probe]
+            [re-frame.bench.hicasso.z3vlz-slim-substrate :as slim]
+            [re-frame.core :as rf]))
+
+(defn ^:export -main []
+  (rf/init! slim/adapter)
+  (probe/run! slim/substrate
+              {:bundle      :slim-only
+               :installed   :reagent-slim
+               :compiled-in [:reagent2]}
+              :z3vlz/slim-only))

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_slim_only.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_slim_only.cljs
@@ -26,7 +26,7 @@
 
 (defn ^:export -main []
   (rf/init! slim/adapter)
-  (probe/run! slim/substrate
+  (probe/run-probe! slim/substrate
               {:bundle      :slim-only
                :installed   :reagent-slim
                :compiled-in [:reagent2]}

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_slim_reagent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_slim_reagent.cljs
@@ -26,7 +26,7 @@
 (defn ^:export -main []
   (let [stock? (install-stock?)]
     (rf/init! (if stock? stock/adapter slim/adapter))
-    (probe/run! (if stock? stock/substrate slim/substrate)
+    (probe/run-probe! (if stock? stock/substrate slim/substrate)
                 {:bundle      :slim+reagent
                  :installed   (if stock? :reagent :reagent-slim)
                  :compiled-in [:reagent2 :reagent]}

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_slim_reagent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_slim_reagent.cljs
@@ -1,0 +1,33 @@
+(ns re-frame.bench.hicasso.z3vlz-slim-reagent
+  "RUNG 2 — reagent-slim WITH stock Reagent compiled alongside it.
+
+  One namespace more than rung 1 and nothing else changed. If rung 1 is
+  reactive and this is not, candidate (b) is established AND NARROWED to
+  exactly this pair — stock `reagent` and `reagent2` in one bundle —
+  without uix having to be in the room.
+
+  `?install=reagent` runs the identical probe with the stock-Reagent
+  substrate installed instead. That is the bead's positive control (the
+  arm that passed 78 of 78 while the slim arm failed 78 of 78), preserved
+  here as the brief requires: a negative result about reagent-slim is only
+  meaningful beside a positive one taken in the same harness."
+  (:require [re-frame.bench.hicasso.z3vlz-probe :as probe]
+            [re-frame.bench.hicasso.z3vlz-reagent-substrate :as stock]
+            [re-frame.bench.hicasso.z3vlz-slim-substrate :as slim]
+            [re-frame.core :as rf]))
+
+(defn install-stock?
+  "`?install=reagent` selects the stock-Reagent control arm; anything else
+  (including no query string) runs the arm under test."
+  []
+  (boolean (some->> (some-> js/window .-location .-search)
+                    (re-find #"install=reagent"))))
+
+(defn ^:export -main []
+  (let [stock? (install-stock?)]
+    (rf/init! (if stock? stock/adapter slim/adapter))
+    (probe/run! (if stock? stock/substrate slim/substrate)
+                {:bundle      :slim+reagent
+                 :installed   (if stock? :reagent :reagent-slim)
+                 :compiled-in [:reagent2 :reagent]}
+                (if stock? :z3vlz/slim-reagent-stock :z3vlz/slim-reagent-slim))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_slim_substrate.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_slim_substrate.cljs
@@ -1,0 +1,49 @@
+(ns re-frame.bench.hicasso.z3vlz-slim-substrate
+  "The reagent-slim substrate under test (rf2-z3vlz).
+
+  THE `:require` LIST OF THIS NAMESPACE IS THE EXPERIMENT. It names
+  `reagent2.*` and the reagent-slim adapter and NOTHING ELSE from any
+  other substrate — no `reagent.core`, no `uix.core` — so a bundle whose
+  entry reaches the probe only through here compiles reagent-slim ALONE.
+  That is the single-substrate arm the bead asks for, and adding a
+  convenience require here would silently destroy it.
+
+  The mount door, the drain and the raw control are all reagent-slim's own
+  documented surfaces:
+
+    - `reagent2.dom.client/create-root` + `render` is what a reagent-slim
+      application calls;
+    - the drain is `reagent2.dom.client/flush-render!` wrapping
+      `reagent2.ratom/flush!` — SETTLE, THEN RENDER. Both halves are
+      load-bearing and this is the same drain HD-008's arm used, so a
+      difference between the two runs cannot be the drain."
+  (:require [re-frame.adapter.reagent-slim :as slim-adapter]
+            [re-frame.bench.hicasso.z3vlz-probe :as probe]
+            [reagent2.core :as r2]
+            [reagent2.dom.client :as rdc2]
+            [reagent2.ratom :as ratom2]))
+
+(defonce ^:private raw-cells (r2/atom (vec (repeat probe/cells-n 0))))
+
+(defn- raw-list
+  "The positive control's component: plain reagent-slim reading a plain
+  `reagent2.core/atom`, no re-frame on the path."
+  []
+  [:ul.grid {:role "list"}
+   (for [i (range probe/cells-n)]
+     ^{:key i} [:li.row
+                [:span.lbl "cell "]
+                [:span.cell {:data-i i} (str (get @raw-cells i))]])])
+
+(def adapter slim-adapter/adapter)
+
+(def substrate
+  {:label       :reagent-slim
+   :create-root (fn [container] (rdc2/create-root container))
+   :render      (fn [root tree] (rdc2/render root tree))
+   :unmount     (fn [root] (rdc2/unmount root))
+   ;; reagent-slim's drain brings its OWN `flushSync` boundary, and its
+   ;; `f` slot is exactly where the subscription-graph settle belongs.
+   :drain!      (fn [] (rdc2/flush-render! (fn [] (ratom2/flush!))))
+   :raw-element (fn [] [raw-list])
+   :raw-write!  (fn [v] (reset! raw-cells (vec (repeat probe/cells-n v))))})

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_slim_substrate.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_slim_substrate.cljs
@@ -27,13 +27,20 @@
 
 (defn- raw-list
   "The positive control's component: plain reagent-slim reading a plain
-  `reagent2.core/atom`, no re-frame on the path."
+  `reagent2.core/atom`, no re-frame on the path.
+
+  The deref is in the COMPONENT BODY, not inside the `for`. A deref that
+  happens only when a lazy seq child is realised is captured by whatever
+  reactive context realises it, which is not necessarily this component's
+  render reaction — and a control whose reactivity depends on that
+  subtlety cannot certify anything about the arm beside it."
   []
-  [:ul.grid {:role "list"}
-   (for [i (range probe/cells-n)]
-     ^{:key i} [:li.row
-                [:span.lbl "cell "]
-                [:span.cell {:data-i i} (str (get @raw-cells i))]])])
+  (let [cells @raw-cells]
+    [:ul.grid {:role "list"}
+     (for [i (range probe/cells-n)]
+       ^{:key i} [:li.row
+                  [:span.lbl "cell "]
+                  [:span.cell {:data-i i} (str (get cells i))]])]))
 
 (def adapter slim-adapter/adapter)
 
@@ -45,5 +52,11 @@
    ;; reagent-slim's drain brings its OWN `flushSync` boundary, and its
    ;; `f` slot is exactly where the subscription-graph settle belongs.
    :drain!      (fn [] (rdc2/flush-render! (fn [] (ratom2/flush!))))
+   ;; THE DOCUMENTED PRODUCTION CONTRACT: the write goes in `f`, so the
+   ;; `forceUpdate` it provokes is issued INSIDE `flush-render!`'s
+   ;; `react-dom/flushSync` boundary and commits before the call returns.
+   ;; `reagent2.dom.client/flush-render!` says so in as many words, and the
+   ;; adapter's own `reagent_slim_flush_render_dom_cljs_test` pins it.
+   :drain-with! (fn [f] (rdc2/flush-render! (fn [] (f) (ratom2/flush!))))
    :raw-element (fn [] [raw-list])
    :raw-write!  (fn [v] (reset! raw-cells (vec (repeat probe/cells-n v))))})

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_slim_uix.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_slim_uix.cljs
@@ -20,7 +20,7 @@
 (defn ^:export -main []
   (set! (.-Z3VLZ_UIX_ADAPTER js/window) (pr-str (:kind adapter-ref)))
   (rf/init! slim/adapter)
-  (probe/run! slim/substrate
+  (probe/run-probe! slim/substrate
               {:bundle      :slim+uix
                :installed   :reagent-slim
                :compiled-in [:reagent2 :uix]}

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_slim_uix.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_slim_uix.cljs
@@ -1,0 +1,27 @@
+(ns re-frame.bench.hicasso.z3vlz-slim-uix
+  "RUNG 3 — reagent-slim WITH the UIx adapter compiled alongside it, and
+  stock Reagent ABSENT.
+
+  The other half of the bisection. HD-008's bundle carries three adapters,
+  so `mixed` on its own would not say WHICH coexistence matters. Rung 2
+  adds stock Reagent alone; this adds UIx alone. Between them the collider
+  is named rather than guessed.
+
+  The UIx adapter is REFERENCED, not merely required — `adapter-ref` is
+  exported onto `window` — so `:advanced` cannot prove the namespace dead
+  and elide the load-time hook publication that candidate (c) is about."
+  (:require [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.z3vlz-probe :as probe]
+            [re-frame.bench.hicasso.z3vlz-slim-substrate :as slim]
+            [re-frame.core :as rf]))
+
+(def ^:export adapter-ref uix-adapter/adapter)
+
+(defn ^:export -main []
+  (set! (.-Z3VLZ_UIX_ADAPTER js/window) (pr-str (:kind adapter-ref)))
+  (rf/init! slim/adapter)
+  (probe/run! slim/substrate
+              {:bundle      :slim+uix
+               :installed   :reagent-slim
+               :compiled-in [:reagent2 :uix]}
+              :z3vlz/slim-uix))


### PR DESCRIPTION
## The answer

**Candidate (c) — the bench arm's composition.** Not **(a)** a reagent-slim adapter defect, and not **(b)** a mixed-bundle artefact. **No user is affected and no shipped code changes.**

### The single-substrate experiment that settles it

A reagent-slim bundle with stock Reagent verifiably absent — 96 compiled sources, checked against the build's own **source map** rather than asserted from a `:require` list — re-renders on **every** write under the adapter's own documented drain contract:

| bundle | sources | stock `reagent` in bundle | write **inside** the drain | write, **drain immediately** | write, **yield**, then drain |
|---|---:|---|---|---|---|
| `slim-only`, install reagent-slim | 96 | **no** | **0 unverified of 12** | **0 of 12** | 12 of 12 |
| `slim+reagent`, install reagent-slim | 108 | yes | **0 of 12** | **0 of 12** | 12 of 12 |
| `slim+uix`, install reagent-slim | 102 | **no** | **0 of 12** | **0 of 12** | 12 of 12 |
| `mixed` (the bead's bundle), install reagent-slim | 114 | yes | **0 of 12** | **0 of 12** | 12 of 12 |
| `slim+reagent`, install **stock reagent** | 108 | yes | **0 of 12** | **0 of 12** | **0 of 12** |
| `mixed`, install **stock reagent** | 114 | yes | **0 of 12** | **0 of 12** | **0 of 12** |

`M` = 12 writes per order, all 8 cells read back out of the DOM inside each write's own window, alternating `frame/replace-app-db!` and `dispatch-sync` of a registered event. chromium 147.0.7727.15 (playwright), `:advanced`, `goog.DEBUG false`.

Four bundles spanning 96 to 114 compiled sources return **byte-identical** verdicts, so the mixing is not it. The stock-Reagent arm in the *same* mixed bundle passes all three orders, reproducing the bead's 78-of-78 control.

### It is not late-binding either

The positive control — a plain reagent-slim component reading a plain `reagent2.core/atom`, with **no frame, no `subscribe` and no `:adapter/*` hook** on its path — reproduces the failure exactly, `0 / 0 / 12 of 12`, in every reagent-slim bundle and `0 / 0 / 0` in every stock one. re-frame is not on the causal path at all, so `re-frame.views` cannot be reaching it.

### The actual cause: one microtask

`lane/verified-write!` writes, yields **one microtask**, and only then drains. reagent-slim's render scheduler is **microtask**-based (`reagent2.impl.batching`), so by the time the drain runs it has already emptied its own component queue and issued its `forceUpdate` **outside** any `flushSync` boundary — the precise hazard `reagent2.dom.client/flush-render!` documents its boundary as existing to avoid. React holds that work at the default lane and the `flush-render!` that follows finds nothing to flush. Stock Reagent survives the identical harness because its queue is **`requestAnimationFrame`**-scheduled and is therefore still full one microtask later.

### Two corrections to the symptom as filed

1. **The arm is not non-reactive — its commit is LATE.** All 12 of 12 writes reach the DOM at the `:macrotask` rung, and no synchronous re-drain recovers them.
2. **`app-db` followed every write** in every bundle (`db-followed-all? true`), so the failure was always on the view leg.

## What is in this PR, and what is deliberately not

**In:** a standalone discriminator rig under `implementation/freehand/test/re_frame/bench/hicasso/` — one probe namespace holding everything constant, four entry namespaces differing *only* in what they `:require`, and a driver that rides the `:hicasso-bench` build id through `--config-merge` (**no new build id; `implementation/shadow-cljs.edn` untouched**) and refuses to drive a page whose bundle does not match its declared composition. Plus the studio page recording the evidence.

**Not in:** any change to `implementation/adapters/**/src/**` or `implementation/core/src/**` — the diagnosis says there is nothing to fix there. And no change to `lane.cljs`: it is a shared instrument with six live worker checkouts, and the arm that needs the repair (`hd8_rows`) is not on `main`, so the change would land unexercised and conflict-prone. Both repairs are filed instead:

- **rf2-b69lw** (P2) — fix the HD-008 slim write arm's write/drain ordering and **re-take** the suppressed slim write figures. They read 0.16–0.50× the floor while changing nothing; they price a commit that had not happened and must not be rescued.
- **rf2-pq7d8** (P3) — `lane/verified-write!`'s fixed microtask yield is not neutral across scheduler families; give an arm a `:drain-with!` opt-out.

## Instrument discipline

- Every measured write is read back out of the DOM — **all 8 cells**, inside its own window — and every row is reported as `N unverified of M`.
- **Two positive controls in-bundle**: the raw substrate atom (no re-frame on the path) and the stock-Reagent arm through `?install=reagent`.
- A **drain escalation ladder** (`:sync` → `:redrain` → `:macrotask` → `:raf2` → `:never`) so LATE and NEVER are distinguishable findings.
- **The arm-order guard is NOT ENGAGED, and the run says so in its own record.** This driver publishes no timed figure and no arm-to-arm ratio, so there is nothing for it to adjudicate. It did not refuse; it was not asked.
- Three faults were caught by the rig's own controls before any conclusion was drawn: an unflushed mount (the raw control failed beside the arm under test), a control derefing inside a lazy seq, and the unnamed order variable — the first run made a *single-substrate* bundle read `12 unverified of 12`, which by the bead's stated logic would have published as an adapter defect.

## Quality gates

| gate | exit |
|---|---|
| `node implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs` (4 bundles, 6 pages, to completion) | **0** |
| `npm run test:reagent-slim:smoke` — *the reagent-slim adapter smoke; 1 smoke, 0 failures* | **0** |
| `npm run test:browser` — *842 tests, 5469 assertions, 0 failures, 0 errors* | **0** |

The reagent-slim adapter smoke is the existing coverage for this behaviour and it **does** cover it: `implementation/adapters/reagent-slim/testbed/smoke.cjs` mounts a `reg-view` tree under `rf/frame-provider` through `reagent2.dom.client`, clicks, and asserts the counter text changes — in a slim-only bundle. It was green throughout, and it was right. (It lives under `npm run test:reagent-slim:smoke`, not `npm run test:browser`; both were run.)

Closes rf2-z3vlz.
