### PR TITLE
bench(hicasso): repair the shared harness — ordering, lanes, retention (rf2-ouwh8, rf2-uhw11, rf2-f5roa, rf2-flqpd)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs
@@ -117,12 +117,34 @@
   `goog.object` with string literals, and [[integrity-probe]] proves it
   from inside the shipped bundle before anything is measured.
 
+  ## Two instruments, one method (rf2-uhw11)
+
+  `re-frame.bench.hicasso.lane` is the other P0 harness, and it is not a
+  rival: a mount is ONE timed commit and a narrow write is write,
+  microtask, flush, verify, so the two windows genuinely differ and
+  neither subsumes the other. What must not differ is the METHOD, and it
+  was written down twice — `summarise`, `chain`, the schedule and the
+  verification tally all existed here and there.
+
+  So the shared parts are TAKEN from the lane rather than restated:
+  [[summarise]] and `chain` are `lane/`'s, and the schedule is
+  `guard/slot-order`, which the lane also merely holds. What stays local
+  is what is genuinely this window's — the clock (`(js/performance.now)`
+  with no branch inside a timed leg), the six-leg accumulator, and the
+  `goog.object` string-literal discipline the `:advanced` bundle needs.
+
+  The cost of getting this wrong is on record: `slot-order` was one rule
+  written down three times, one copy was repaired, and the other two went
+  on returning a single order for two-arm plans until the guard refused
+  four rows (rf2-ouwh8).
+
   Authority: `docs/EP/EP-0038-the-hicasso-view-layer-programme.md`;
   the bar and the P0 table are operator-owned on bead rf2-2rtt6.1.
   Spec donor: rf2-ssn1o (closed, do-not-refile)."
   (:require ["react-dom" :as react-dom]
             [goog.object :as gobj]
             [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.bench.hicasso.lane :as lane]
             [re-frame.bench.order-guard :as guard]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -462,10 +484,10 @@
 (defonce ^:private gen-seq (atom 1000))
 (defn next-gen! [] (swap! gen-seq inc))
 
-(defn- chain
-  "Fold `xs` into a serial promise chain, threading an accumulator."
-  [init xs f]
-  (reduce (fn [p x] (.then p (fn [acc] (f acc x)))) (js/Promise.resolve init) xs))
+(def ^:private chain
+  "Fold `xs` into a serial promise chain, threading an accumulator —
+  `lane/chain`, not a restatement of it (rf2-uhw11)."
+  lane/chain)
 
 (defn- timed-write!
   "One narrow write, clocked at every leg boundary, then verified at the
@@ -589,21 +611,18 @@
 ;; Summaries
 ;; ---------------------------------------------------------------------------
 
-(defn median [xs]
-  (let [s (vec (sort xs)) c (count s) m (quot c 2)]
-    (cond
-      (zero? c) nil
-      (odd? c)  (nth s m)
-      :else     (/ (+ (nth s (dec m)) (nth s m)) 2.0))))
-
-(defn summarise
+(def summarise
   "`{:n :min :p50 :max}` over `xs`. A RANGE, always — never a mean alone.
   Overlapping ranges mean indistinguishable, and a report that quotes a
-  central value without its range cannot say that."
-  [xs]
-  (let [xs (vec xs)]
-    (when (seq xs)
-      {:n (count xs) :min (apply min xs) :p50 (median xs) :max (apply max xs)})))
+  central value without its range cannot say that.
+
+  `lane/summarise`, not a restatement of it. This lane and the mount lane
+  are two INSTRUMENTS — a mount is one timed commit, a narrow write is
+  write, microtask, flush, verify — but they are one METHOD, and the
+  method must not be written down twice (rf2-uhw11). The `slot-order`
+  degeneracy this repository has just finished repairing was a method
+  written down three times and fixed in one of them (rf2-ouwh8)."
+  lane/summarise)
 
 (defn per-write
   "Divide a per-SAMPLE leg figure by the writes it contains."

--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
@@ -29,8 +29,8 @@
 // own b8 driver does: it takes an EXISTING `:advanced` `:browser` build as
 // a config template and overrides the entry point and the output directory
 // with `--config-merge`, so the repository gains no build id from this
-// bead. `HN_BASE_BUILD` selects the template; point it at the Hicasso lane
-// build the moment rf2-2rtt6.2 lands one, with no change to this file.
+// bead. The template is rf2-2rtt6.2's `:hicasso-bench`, which is the lane
+// every Hicasso arm compiles through.
 //
 // THE INSTRUMENT'S OWN GATES, all of which run BEFORE any figure is taken
 // ----------------------------------------------------------------------
@@ -123,35 +123,27 @@ const TOLERANCE = Number(process.env.HN_TOLERANCE || 0.10);
 const CTL_1 = Number(process.env.HN_CTL_1 || 0.3);
 const CTL_2 = Number(process.env.HN_CTL_2 || 0.9);
 
-// The build TEMPLATE, chosen from what the checkout actually has.
+// The build TEMPLATE.
 //
 // `implementation/shadow-cljs.edn` is hot-zone and rf2-2rtt6.2 owns the
-// measurement lane's build id, so this bead adds none: it overrides an
-// existing `:advanced` `:browser` build's entry point and output directory
-// with `--config-merge`, which is the technique the donor's own b8 driver
-// uses. Which build it borrows is decided here rather than pinned, so that
-// when rf2-2rtt6.2's `:hicasso-bench` lands this driver picks it up with no
-// edit and no rebase conflict.
+// measurement lane's build id, so this bead adds none: it overrides
+// `:hicasso-bench`'s entry point and output directory with
+// `--config-merge`, which is the technique the donor's own b8 driver uses,
+// and the repository gains no build id from this driver.
 //
-// The preference is not cosmetic. `:freehand-release` is CLEANED AND
-// REBUILT by `test:freehand-reachability` and `test:freehand-matched`, so a
-// bench run and a gate run racing the same
-// `.shadow-cljs/builds/freehand-release` cache is a live hazard — and
-// Closure's renaming for a build compiled fresh differs from the same build
-// compiled with a sibling warm, which the donor measured at 4,075 bytes.
-// The Hicasso lane's own id has neither problem.
-function pickBaseBuild() {
-  if (process.env.HN_BASE_BUILD) return process.env.HN_BASE_BUILD;
-  try {
-    const cfg = fs.readFileSync(path.join(IMPL, 'shadow-cljs.edn'), 'utf8');
-    if (/^\s*:hicasso-bench\b/m.test(cfg)) return 'hicasso-bench';
-  } catch (_) {
-    /* fall through to the donor template */
-  }
-  return 'freehand-release';
-}
-
-const BASE_BUILD = pickBaseBuild();
+// This used to CHOOSE its template — `:hicasso-bench` when the checkout had
+// it, `:freehand-release` otherwise — because the lane's build id had not
+// landed yet. It has (rf2-2rtt6.2), so the fallback was unreachable code
+// carrying a paragraph of reasoning for a branch that could no longer be
+// taken, and rf2-uhw11 removes both. The donor template was never
+// equivalent anyway: `:freehand-release` is CLEANED AND REBUILT by
+// `test:freehand-reachability` and `test:freehand-matched`, so a bench run
+// and a gate run raced the same `.shadow-cljs/builds/freehand-release`
+// cache — and Closure's renaming for a build compiled fresh differs from
+// the same build compiled with a sibling warm, which the donor measured at
+// 4,075 bytes. A figure taken through the fallback would not have been
+// comparable with one taken through the lane.
+const BASE_BUILD = 'hicasso-bench';
 const NO_BUILD = process.argv.includes('--no-build');
 
 const CONFIG_MERGE =

--- a/implementation/core/test/re_frame/bench/order_guard.cljc
+++ b/implementation/core/test/re_frame/bench/order_guard.cljc
@@ -82,6 +82,23 @@
   so the case is not exotic. [[slot-order]] drops the reflection at `n = 2`,
   where the bare rotation already supplies both of the orders that exist.
 
+  ## A LOST position is a refusal, not a smaller question
+
+  Every instrument fault on this programme produced a plausible PRECISE
+  WRONG NUMBER before it was caught, and one of them was aimed straight at
+  this namespace: a shadowed binding in a harness made every `:position`
+  `NaN` from round 2 on. [[stratify]] filters non-finite positions out of
+  the phase contrast, so the phase question was quietly answered over the
+  six samples that still had one while [[report-lines]] printed the arm's
+  full twenty-four beside it — and the run returned `[ok]`.
+
+  A harness that records NO positions is a different and documented case:
+  it is excused the phase contrast (and still owes the predecessor one). A
+  harness that records positions and LOSES them is broken, and
+  [[lost-positions]] separates the two so the second refuses. [[self-test]]
+  check 11 replays it with deliberately flat values, so nothing but the
+  lost positions can be what refuses.
+
   ## What the `:predecessor` factor can and cannot attribute (rf2-om73r)
 
   Under [[slot-order]] an arm's predecessor is `(a - 1) mod n` on EVEN
@@ -230,6 +247,21 @@
          (sort-by :p50)
          vec)))
 
+(defn lost-positions
+  "How many of `samples` CARRY a `:position` that is not a finite number.
+
+  Not the same question as \"how many have no position\". A harness that
+  records no positions at all is a documented case and is excused the phase
+  contrast; a harness that records `NaN` has LOST them, and the difference
+  between the two is the difference between a question not asked and a
+  question answered over a silently smaller set."
+  [samples]
+  (count (filterv (fn [s]
+                    (and (contains? s :position)
+                         (some? (:position s))
+                         (not (finite? (:position s)))))
+                  samples)))
+
 (defn adjudicate
   "Adjudicate one arm's strata on one factor.
 
@@ -306,16 +338,43 @@
                              [arm {:n       (count ss)
                                    :factors (reduce
                                               (fn [acc f]
-                                                (let [strata (stratify ss f)]
-                                                  ;; `:phase` is only askable when
-                                                  ;; positions were recorded; a
-                                                  ;; harness that does not record
-                                                  ;; them is not thereby excused
-                                                  ;; the predecessor question, so
-                                                  ;; an empty phase stratification
-                                                  ;; is skipped rather than failed.
-                                                  (if (and (= f :phase) (empty? strata))
+                                                (let [strata (stratify ss f)
+                                                      lost   (if (= f :phase) (lost-positions ss) 0)]
+                                                  (cond
+                                                    ;; A sample that CARRIES a position
+                                                    ;; and whose position is not a number
+                                                    ;; is a HARNESS FAULT, and it is the
+                                                    ;; recorded one: a shadowed binding
+                                                    ;; made every position `NaN` from
+                                                    ;; round 2 on, `stratify` dropped
+                                                    ;; them, and the report said
+                                                    ;; "24 samples" over a phase
+                                                    ;; contrast adjudicated on six —
+                                                    ;; and answered `[ok]`. Silently
+                                                    ;; narrowing the question is the one
+                                                    ;; thing this namespace must not do.
+                                                    (pos? lost)
+                                                    (assoc acc f
+                                                           {:strata         strata
+                                                            :status         :unchecked
+                                                            :lost-positions lost
+                                                            :why (str lost " of " (count ss)
+                                                                      " samples carry a NON-FINITE :position"
+                                                                      " — the harness lost them, so this"
+                                                                      " contrast is over the rest and the"
+                                                                      " sample count above is not it")})
+
+                                                    ;; `:phase` is only askable when
+                                                    ;; positions were recorded at all; a
+                                                    ;; harness that does not record them
+                                                    ;; is not thereby excused the
+                                                    ;; predecessor question, so an empty
+                                                    ;; phase stratification is skipped
+                                                    ;; rather than failed.
+                                                    (and (= f :phase) (empty? strata))
                                                     acc
+
+                                                    :else
                                                     (assoc acc f (adjudicate strata tolerance)))))
                                               {}
                                               factors)}]))
@@ -466,6 +525,20 @@
         fix-d (mapv :distinct (vals (:arms fix2)))
         fix-s (apply max (map :modal-share (vals (:arms fix2))))
 
+        ;; 11. THE LOST POSITIONS, replayed. A shadowed binding made every
+        ;;     position `NaN` from round 2 on; `stratify` dropped them, the
+        ;;     report printed the arm's full sample count beside a phase
+        ;;     contrast taken over the survivors, and the run came back
+        ;;     `[ok]`. Values are deliberately flat, so nothing but the lost
+        ;;     positions can be what refuses this.
+        nan*   #?(:clj Double/NaN :cljs js/NaN)
+        lost   (mapv (fn [i] {:arm "A" :predecessor "B"
+                              :position (if (< i 6) i nan*)
+                              :value 1.0})
+                     (range 24))
+        v-lost (verdict lost {:tolerance 0.10})
+        lost-r (one v-lost "A" :phase)
+
         checks
         [{:name "the recorded 2.01x is REFUSED"
           :ok   (and (:refuse? v-smi)
@@ -516,7 +589,12 @@
           :detail (str "slot-order: " fix-orders " distinct orders, predecessors per arm "
                        (str/join "," fix-d) ", largest modal share "
                        #?(:clj (format "%.0f" (* 100.0 fix-s))
-                          :cljs (.toFixed (* 100.0 fix-s) 0)) "%")}]]
+                          :cljs (.toFixed (* 100.0 fix-s) 0)) "%")}
+         {:name "samples whose :position went NON-FINITE refuse instead of narrowing the question"
+          :ok   (and (:refuse? v-lost)
+                     (= :unchecked (:status lost-r))
+                     (= 18 (:lost-positions lost-r)))
+          :detail (:why lost-r)}]]
     {:ok?     (every? :ok checks)
      :checks  checks}))
 

--- a/implementation/core/test/re_frame/bench/order_guard.cljc
+++ b/implementation/core/test/re_frame/bench/order_guard.cljc
@@ -71,6 +71,17 @@
   `a -> a+1` adjacency with `a -> a-1`. [[self-test]] proves both halves of
   that arithmetically.
 
+  ## Two arms are the case where the reflection cancels (rf2-ouwh8)
+
+  Reversing a pair IS rotating it by one. So at `n = 2` — and only there —
+  composing the rotation with the reflection returns `[0 1]` at every index,
+  and a two-arm plan runs in a SINGLE ORDER for ever. That is not a weaker
+  version of the property; it is the absence of it, and the guard says so:
+  four two-arm rows came back `only 1 stratum — the question was never
+  asked`. Two arms is the natural shape for *candidate versus comparator*,
+  so the case is not exotic. [[slot-order]] drops the reflection at `n = 2`,
+  where the bare rotation already supplies both of the orders that exist.
+
   ## What the `:predecessor` factor can and cannot attribute (rf2-om73r)
 
   Under [[slot-order]] an arm's predecessor is `(a - 1) mod n` on EVEN
@@ -107,11 +118,26 @@
 
 (defn slot-order
   "Slot order for `n` arms in `round`: rotate forward by `round`, then REFLECT
-  on odd rounds. The same arithmetic as `order_guard.cjs`'s `schedule` and
-  `b6-harness/slot-order`."
+  on odd rounds — EXCEPT at `n = 2`, where the two operations are the SAME
+  permutation and composing them cancels.
+
+  Reversing a pair is rotating it by one, so `(rseq [1 0])` is `[0 1]` and a
+  schedule that always composes returns `[0 1]` at every index: a two-arm
+  plan runs in ONE ORDER FOR EVER, which is the single-order result this
+  namespace exists to refuse. `rf2-ouwh8` records it, and the guard is how it
+  was found — four two-arm rows came back `only 1 stratum — the question was
+  never asked` and were REFUSED. The repair belongs to the plan, never to the
+  tolerance. At `n = 2` the plain rotation already alternates `[0 1]` and
+  `[1 0]`, which is every order two arms have, so the reflection is dropped
+  rather than composed. [[self-test]] check 9 prices both halves.
+
+  The same arithmetic as `order_guard.cjs`'s `schedule`. `b6-harness` and
+  `re-frame.bench.hicasso.lane` take this function rather than restate it, so
+  there are two copies of the rule and not four — and the two are the ones a
+  Node driver and a ClojureScript harness genuinely cannot share."
   [n round]
   (let [xs (mapv #(mod (+ % round) n) (range n))]
-    (if (odd? round) (vec (rseq xs)) xs)))
+    (if (and (odd? round) (> n 2)) (vec (rseq xs)) xs)))
 
 (defn rotation-only
   "The plain cyclic rotation, kept so [[self-test]] can price it."
@@ -420,6 +446,26 @@
         ref-d (mapv :distinct (vals (:arms refl)))
         ref-s (apply max (map :modal-share (vals (:arms refl))))
 
+        ;; 9. TWO ARMS, where the reflection cancels the rotation. Priced
+        ;;    beside 7 and 8 because it is the same arithmetic asked at the
+        ;;    smallest `n` a comparison can have. `always-reflect` is what
+        ;;    [[slot-order]] used to be, kept HERE and nowhere else so the
+        ;;    defect stays reproducible rather than merely described.
+        ;;
+        ;;    A pair has exactly one adjacency per round, so the WITHIN-round
+        ;;    question is unaskable at `n = 2` for any schedule; the seams
+        ;;    are the run, and `:seams? true` is the honest setting.
+        always-reflect (fn [n' round]
+                         (let [xs (mapv #(mod (+ % round) n') (range n'))]
+                           (if (odd? round) (vec (rseq xs)) xs)))
+        deg-orders (count (set (map #(always-reflect 2 %) (range r))))
+        fix-orders (count (set (map #(slot-order 2 %) (range r))))
+        deg2  (adjacency 2 r always-reflect)
+        fix2  (adjacency 2 r slot-order)
+        deg-d (mapv :distinct (vals (:arms deg2)))
+        fix-d (mapv :distinct (vals (:arms fix2)))
+        fix-s (apply max (map :modal-share (vals (:arms fix2))))
+
         checks
         [{:name "the recorded 2.01x is REFUSED"
           :ok   (and (:refuse? v-smi)
@@ -458,7 +504,19 @@
           :detail (str "reflected: " (str/join "," ref-d)
                        " predecessors per arm, largest modal share "
                        #?(:clj (format "%.0f" (* 100.0 ref-s))
-                          :cljs (.toFixed (* 100.0 ref-s) 0)) "%")}]]
+                          :cljs (.toFixed (* 100.0 ref-s) 0)) "%")}
+         {:name "at k=2 an ALWAYS-reflecting schedule runs one order for ever and is UNCHECKED"
+          :ok   (and (= 1 deg-orders) (some #(= 1 %) deg-d))
+          :detail (str "always-reflect over " r " rounds of 2 arms: "
+                       deg-orders " distinct order(s), predecessors per arm "
+                       (str/join "," deg-d)
+                       " — rotating a pair by one IS reversing it, so the two cancel")}
+         {:name "at k=2 slot-order alternates, and every arm gets TWO predecessors in balance"
+          :ok   (and (= 2 fix-orders) (every? #(>= % 2) fix-d) (<= fix-s 0.75))
+          :detail (str "slot-order: " fix-orders " distinct orders, predecessors per arm "
+                       (str/join "," fix-d) ", largest modal share "
+                       #?(:clj (format "%.0f" (* 100.0 fix-s))
+                          :cljs (.toFixed (* 100.0 fix-s) 0)) "%")}]]
     {:ok?     (every? :ok checks)
      :checks  checks}))
 

--- a/implementation/core/test/re_frame/bench/p0_harness.cljs
+++ b/implementation/core/test/re_frame/bench/p0_harness.cljs
@@ -328,14 +328,24 @@
   `slot-order` — rotate then reflect on odd indices — is the shared rule,
   and for three or more arms it is the right one: a bare cyclic rotation
   changes which arm goes FIRST and nothing else, so every arm keeps the
-  same predecessor in every round. **But for exactly TWO arms it
-  degenerates**: rotating `[0 1]` gives `[1 0]`, reversing that gives
-  `[0 1]` again, so the reflecting schedule emits the identical order at
-  every index and each arm has exactly one predecessor for ever. This run
+  same predecessor in every round. **For exactly TWO arms it used to
+  degenerate**: rotating `[0 1]` gives `[1 0]`, reversing that gives
+  `[0 1]` again, so the reflecting schedule emitted the identical order at
+  every index and each arm had exactly one predecessor for ever. This run
   measured that too — the guard reported `:unchecked`, `only 1 stratum —
   the question was never asked`, on every substrate arm, and refused.
-  That is the guard doing its job, and the repair belongs HERE, in the
-  arm, not in the guard.
+  That is the guard doing its job, and the repair belonged in the ARM, not
+  in the guard.
+
+  **`rf2-ouwh8` has since repaired it at the source**: `slot-order` drops
+  the reflection at `k = 2`, where the bare rotation already supplies both
+  of the orders two arms have. The two candidates below therefore now
+  COINCIDE at `k = 2` and this function no longer has a degenerate case to
+  route around. It stays because scoring is worth more than assuming — it
+  publishes the measured adjacency of the schedule it actually ran, which
+  is the difference between a mitigation and a claim of one — but a reader
+  should not take its presence as evidence that the shared rule is still
+  broken.
 
   So rather than hard-coding either rule, both candidates are scored with
   the guard's own `adjacency` over the run this harness is about to

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
@@ -319,33 +319,25 @@
 (defn- round4 [x] (/ (js/Math.round (* (double x) 10000.0)) 10000.0))
 (defn- p50 [xs] (:p50 (lane/summarise xs)))
 
-(defn slot-order
-  "Slot order for `k` arms at sample index `s`.
+(def slot-order
+  "Slot order for `k` arms at sample index `s` — `lane/slot-order`, and
+  nothing local.
 
-  `lane/slot-order` rotates forward by `s` and then REFLECTS on odd
-  `s`, which gives every arm at least two distinct predecessors — for
-  `k >= 3`. AT `k = 2` THE TWO OPERATIONS CANCEL: rotating a pair by one is
-  the same permutation as reversing it, so `[0 1]` comes back at every
-  index and the plan runs in ONE ORDER for ever.
+  This was a local override, added because `lane/slot-order` composed a
+  rotation with a reflection and the two CANCEL at `k = 2`: rotating a pair
+  by one is the same permutation as reversing it, so `[0 1]` came back at
+  every index and a two-arm plan ran in ONE ORDER for ever. The arm-order
+  guard found that rather than a reader — the two-arm runs came back `only
+  1 stratum — the question was never asked`, and REFUSED, which is
+  precisely what a single-order result is supposed to do.
 
-  The arm-order guard found this rather than a reader: the two-arm runs
-  came back `only 1 stratum — the question was never asked`, and REFUSED,
-  which is precisely what a single-order result is supposed to do. The
-  repair belongs to the PLAN, never to the guard — so a pair alternates
-  explicitly here, and everything wider defers to the shared harness.
-
-  The shared copies are left alone deliberately. There are THREE of them —
-  `re-frame.bench.order-guard/slot-order` (which `lane/slot-order`
-  re-exports), `b6-harness/slot-order`, and `order_guard.cjs`'s
-  `schedule` — all carrying the same arithmetic and therefore the same
-  degeneracy, and sibling P0 arms are measuring on them right now. A shared
-  instrument must not change under a measurement in flight, so the defect
-  is FILED (rf2-ouwh8) rather than patched here, and this local override is
-  deleted when that lands."
-  [k s]
-  (if (= k 2)
-    (if (even? s) [0 1] [1 0])
-    (lane/slot-order k s)))
+  The override was local rather than shared because sibling P0 arms were
+  measuring on the shared copies at the time, and a shared instrument must
+  not change under a measurement in flight. Those arms have landed, and
+  `rf2-ouwh8` has since repaired the schedule where it lives — so the
+  override is gone and this name is the lane's, exactly like every other
+  mechanism in this file."
+  lane/slot-order)
 
 (defn mount-round!
   "One round over `arms`: `(+ warmup samples)` sample indices, every arm

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
@@ -51,6 +51,46 @@
   IMPLEMENTATION contributes: the same UIx arm measured over Reagent
   reactions and over the React spine's containers.
 
+  ## What this arm takes from the lane, and what it deliberately does not
+
+  This instrument was written before rf2-2rtt6.2's shared lane landed. It
+  now takes mount, release, parity, `across-rounds`, `slot-order`,
+  `now-ms`, `round4`, `summarise`, `ratio-between` and `bulk-probes` from
+  `re-frame.bench.hicasso.lane` (rf2-f5roa). Four of the lane's mechanisms
+  are deliberately NOT adopted, and the reasons are here so the question is
+  not reopened by inspection:
+
+  1. **The BATCHED write window is not adopted, and adopting it is a
+     RE-RUN.** `lane/mount-batch!` times `k` operations as one sample to
+     lift a reading clear of Chrome's 100 µs `performance.now()` clamp, and
+     the write-narrow row here reads p50s of 0.4–1.2 ms — 4 to 12 quanta,
+     which is why its published ranges are as wide as they are. Batching
+     the write window would narrow them. It would also CHANGE THE MEASURED
+     WINDOW, which invalidates the HD-008 rows already published in
+     `docs/design/hicasso/studio/hd8-composed-donor-arm.md`; a window
+     change cannot be validated by anything but a re-run, and re-running is
+     a separate piece of work with its own publication obligations. The
+     mount rows (4–13 ms) do not need it.
+
+  2. **`lane/control-verdict` is WEAKER than [[positive-control!]]'s own
+     rule and would be a downgrade.** The lane passes a control whose
+     measured range merely OVERLAPS ±slack of the prediction; this one
+     requires EVERY round inside the band. Letting a good round vouch for a
+     bad one is how an instrument stops being one, and the stricter rule
+     stays.
+
+  3. **`lane/tally` counts `{:of :bad}` in one atom; this row counts them
+     PER ARM.** A pooled count says half the writes failed and leaves a
+     reader to guess which arm. The per-arm map is the difference between a
+     diagnosis and a mystery, and it is threaded immutably through the
+     promise chain rather than mutated beside it.
+
+  4. **The verdict is adjudicated in the DRIVER, not in ClojureScript.**
+     `lane/guard!` adjudicates in-bundle with the `.cljc` copy of the rule;
+     `hd8_run.cjs` adjudicates with the `.cjs` copy. The two copies are
+     held in step by shared self-test fixtures, and a lane that exercises
+     the other one is worth more than the symmetry.
+
   Normative owner: `docs/design/hicasso/decisions.md` HD-008; results to
   `rf2-2rtt6.1` and `docs/design/hicasso/studio/`."
   (:require ["react-dom" :as react-dom]
@@ -316,7 +356,7 @@
 ;; The mount clock — with the order-guard's per-sample records
 ;; ===========================================================================
 
-(defn- round4 [x] (/ (js/Math.round (* (double x) 10000.0)) 10000.0))
+(def ^:private round4 lane/round4)
 (defn- p50 [xs] (:p50 (lane/summarise xs)))
 
 (def slot-order
@@ -402,20 +442,21 @@
   between rounds cancels exactly as it does for the floor-normalised
   figures. Reported as a RANGE, with `:straddles-1?` set when the range
   includes 1.0 — in which case the two arms are INDISTINGUISHABLE on this
-  witness and the mean must not be quoted as a winner."
+  witness and the mean must not be quoted as a winner.
+
+  The arithmetic is `lane/ratio-between` and no longer a second copy of it
+  (rf2-f5roa). It is fed this row's raw `:p50` maps rather than its
+  floor-normalised `:ratio` maps — algebraically the floor cancels either
+  way, but rounding to four places twice is not the same as rounding once,
+  and these are the digits the published rows carry."
   [per-round]
-  (let [present (set (keys (:p50 (first per-round))))]
+  (let [present (set (keys (:p50 (first per-round))))
+        p50s    (mapv :p50 per-round)]
     (into {}
           (keep (fn [[a b]]
                   (when (and (contains? present a) (contains? present b))
-                    (let [vs (mapv (fn [r] (round4 (/ (get-in r [:p50 a])
-                                                      (get-in r [:p50 b]))))
-                                   per-round)
-                          lo (apply min vs)
-                          hi (apply max vs)]
-                      [(keyword (str (name a) "-over-" (name b)))
-                       {:min lo :max hi :rounds vs
-                        :straddles-1? (and (<= lo 1.0) (>= hi 1.0))}]))))
+                    [(keyword (str (name a) "-over-" (name b)))
+                     (lane/ratio-between p50s a b)])))
           head-to-head-pairs)))
 
 (defn measure-mount!
@@ -648,8 +689,8 @@
 
 (defn timed-write!
   "Write, wait the way THIS ARM'S SCHEDULER requires, force the arm's own
-  synchronous drain, stop the clock — then VERIFY at the DOM that the
-  probed cell holds what was written. Answers a promise of
+  synchronous drain, stop the clock — then VERIFY at the DOM that EVERY
+  cell in `probes` holds what was written. Answers a promise of
   `{:ms … :ok? …}`.
 
   The wait belongs to the arm ([[window-of]]) and not to this function,
@@ -658,15 +699,24 @@
   is FATAL for an arm whose notification is queued on the microtask queue
   itself.
 
+  `probes` is a SEQ and used to be a single cell, which was thin on the
+  BULK row (rf2-f5roa): a broad write changes all 300 cells, this probed
+  cell 0, and a page left stale by a commit landing outside the window can
+  still carry one fresh cell from the previous write. `lane/bulk-probes`
+  is the rule now, and the P0 arm three files away already used it. The
+  NARROW row is unchanged and was already right — one cell changes, so one
+  probe is the whole page's worth of verification.
+
   The read-back is inside the window's own iteration and in the same turn
   as the drain, so an arm that silently rendered nothing — or rendered a
   turn late — reports as UNVERIFIED rather than as the fastest substrate in
-  the table, which is the exact shape of the fault this exists to prevent."
-  [{:keys [arm container]} i val]
-  (let [probe (if (= i :all) 0 i)]
-    ((:window! arm)
-     (fn [] ((:write! arm) i val))
-     (fn [] (= val (cell-text container probe))))))
+  the table, which is the exact shape of the fault this exists to prevent.
+  Widening the probe seq does not move the measured window: the clock stops
+  before the first `querySelector` either way."
+  [{:keys [arm container]} i val probes]
+  ((:window! arm)
+   (fn [] ((:write! arm) i val))
+   (fn [] (every? #(= val (cell-text container %)) probes))))
 
 (defn- chain
   "Sequence `f` over `xs` through promises, threading `acc`."
@@ -696,8 +746,16 @@
                     (fn [a j]
                       (let [mnt (nth mounts j)
                             id  (:id (:arm mnt))
-                            v   (str "v" (:position a))]
-                        (-> (timed-write! mnt (if (= kind :bulk) :all (mod (:position a) w/cells-n)) v)
+                            v   (str "v" (:position a))
+                            cell (mod (:position a) w/cells-n)
+                            ;; A broad write changes every cell, so it is
+                            ;; verified at three (`lane/bulk-probes`); a
+                            ;; narrow write changes one, so it is verified
+                            ;; at that one.
+                            [i probes] (if (= kind :bulk)
+                                         [:all (lane/bulk-probes (:position a) w/cells-n)]
+                                         [cell [cell]])]
+                        (-> (timed-write! mnt i v probes)
                             (.then (fn [{:keys [ms ok?]}]
                                      (cond-> (-> a
                                                  (assoc :position (inc (:position a)) :prev id)

--- a/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
@@ -419,6 +419,27 @@
                         :force-ms (- t3 t2)
                         :ok?      ok?}))))))))
 
+(defn bulk-probes
+  "The probe seq for a BROAD write over `n` cells: a cell that ROTATES with
+  `rotor`, the far end of the grid, and cell 0.
+
+  A broad write changes every cell, so verifying one of them verifies
+  almost nothing — a page left stale by a commit that landed outside the
+  window can still carry one fresh cell from the PREVIOUS write, and a
+  single fixed probe accepts it. Rotating one probe means a stale page has
+  to have been stale in the same place twice; the far end means a partial
+  commit that got as far as the front of the grid is caught.
+
+  Stated once, here, because it is a RULE and not an argument list: HD-008
+  probed cell 0 alone on its bulk row while the P0 arm three files away
+  probed three cells, which is the shape of divergence this lane exists to
+  prevent (rf2-f5roa).
+
+  A NARROW write is the other case and does not use this: it changes
+  exactly one cell, so its probe seq is that cell and nothing else."
+  [rotor n]
+  [(mod rotor n) (dec n) 0])
+
 (defn chain
   "Fold `xs` into a serial promise chain, threading an accumulator."
   [init xs f]

--- a/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
@@ -255,9 +255,12 @@
 (def slot-order
   "The reflecting schedule, taken from the guard itself rather than
   restated. `order-guard`'s self-test carries the arithmetic proof that a
-  bare rotation gives every arm exactly ONE within-round predecessor and
-  that reflecting on odd rounds gives it two in balance; a second copy
-  here would be a second authority with nothing holding it in step."
+  bare rotation gives every arm exactly ONE within-round predecessor, that
+  reflecting on odd rounds gives it two in balance, and that at `k = 2` the
+  reflection CANCELS the rotation and so is dropped (`rf2-ouwh8`); a second
+  copy here would be a second authority with nothing holding it in step —
+  and the copy that did exist, in `b6-harness`, is exactly where the `k = 2`
+  degeneracy survived a fix to this one."
   guard/slot-order)
 
 (defn sample-collector

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_app.cljs
@@ -355,11 +355,12 @@
   A broad write changes every cell, so the probe rotates with the value
   AND the far end of the grid is checked: a stale page can still carry one
   fresh cell from the previous write, and a single fixed probe would
-  accept it."
+  accept it. The rule is `lane/bulk-probes`, not a literal here — HD-008's
+  bulk row probed cell 0 alone while this one probed three (rf2-f5roa)."
   [t mnt]
   (let [n   (:cells (:arm mnt))
         val (next-gen!)]
-    (lane/verified-write! t mnt :all val [(mod val n) (dec n) 0])))
+    (lane/verified-write! t mnt :all val (lane/bulk-probes val n))))
 
 (defn- seed-bulk! [mounts t]
   (lane/chain nil mounts

--- a/implementation/freehand/test/re_frame/bench/hicasso/retention_probe.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/retention_probe.cljs
@@ -1,0 +1,220 @@
+(ns re-frame.bench.hicasso.retention-probe
+  "rf2-flqpd — WHAT HOLDS THE 12 MB. A diagnostic, not a row.
+
+  ## The observation this exists to explain
+
+  rf2-2rtt6.4's own probe measured, while building the P0 UIx-on-subs
+  frontier arm, `performance.memory.usedJSHeapSize` climbing
+  34 -> 46 -> 55 -> 63 -> 75 -> 87 MB across six adapter-segment entries —
+  about 12 MB per entry — with `document.body.childElementCount` at 2
+  throughout, so nothing was leaking into the document. On that heap a
+  FLOOR arm doing byte-identical work every round drifted 3.4 -> 7.0 ms and
+  the arm-order guard refused on phase. A forced MAJOR collection between
+  samples did not move it, so the memory is RETAINED and not garbage;
+  hoisting the arms did not move it, so it is not call-site polymorphism;
+  the floor-only positive control, which installs and destroys no adapter,
+  stayed flat. ~12 MB is about every root mounted in a segment.
+
+  rf2-2rtt6.4 MITIGATED it by running one round per page and filed this.
+
+  ## Why this counts REFERENCES rather than taking a snapshot
+
+  A retained-heap figure says HOW MUCH and never WHAT. The bead's next
+  step is a heap snapshot with retainer paths, and a snapshot is the right
+  instrument for a cause nobody can name. But two causes CAN be named, and
+  naming one is cheaper to check than to search for:
+
+    H1  every mounted boundary subscribes, and if unmounting does not
+        unsubscribe, each cached subscription's watcher set grows by one
+        per boundary and every watcher is a closure over a dead component.
+        PREDICTS: watchers linear in cumulative roots; sub-cache ENTRIES
+        flat, because the arms re-use the same query vectors every mount.
+
+    H2  the SEGMENT ENTRY is what retains — `destroy-frame!` +
+        `destroy-adapter!` + `init!` + `make-frame` leaves the previous
+        incarnation reachable. PREDICTS: a step per `prepare!` with
+        nothing mounted at all.
+
+  Both are falsifiable by counting, and the two predict different SHAPES,
+  which is why the driver runs mount cycles and bare segment entries as
+  separate series. If every count is flat while the heap climbs, both
+  hypotheses are dead and the snapshot is the next instrument — and this
+  probe will have said so rather than implied it.
+
+  ## WHAT IT FOUND — the retention is not retention
+
+  Run on 2026-07-31, Chromium 147.0.7727.15 under Playwright, `:advanced`
+  with `goog.DEBUG` false, in the bead's own shape: six adapter-segment
+  entries alternating UIx and Reagent, 50 mount/unmount cycles of 4 roots
+  each (200 roots, 60,000 boundaries per segment), every cycle verified at
+  the DOM at 1,200 elements.
+
+      segment   COLLECTED MB   UNCOLLECTED MB   garbage MB
+      baseline      4.73            4.75            0.02
+      1             5.13           17.73           12.60
+      2             5.42           65.03           59.60
+      3             5.52           30.92           25.39
+      4             5.50           81.03           75.52
+      5             5.61           12.44            6.84
+      6             5.63           55.72           50.09
+
+  **The UNCOLLECTED column is the bead's observation.** It reaches the
+  reported magnitude — 12.6 MB after the first segment, 81 MB later — and
+  it SAWTOOTHS rather than climbing, which a leak cannot do. The COLLECTED
+  column, read at the same instants after a forced major collection,
+  climbs 0.90 MB in total across six segments and settles. Repeating it
+  with `RETENTION_COLLECT=page` — `window.gc({type:'major',
+  execution:'sync'})` and nothing else, the same door rf2-2rtt6.4 used —
+  gives 2.99 -> 5.90 MB, so the page's own collector reclaims it too and
+  the CDP door is not doing something the page could not have asked for.
+
+  So the ~12 MB per segment is GARBAGE, not retained memory: the arms
+  allocate heavily, and `usedJSHeapSize` read without a collection
+  immediately before it measures how much rubbish is lying about rather
+  than how much is held. The floor-only control stayed flat in the
+  original observation for the same reason it stays flat here — it
+  allocates a fraction as much, so it leaves a fraction as much rubbish.
+
+  **NOTHING SHIPPED IS LEAKING.** The sub-cache census (positive-controlled:
+  it reads 300 entries with the roots standing and 0 after release, on
+  every cycle) says every subscription is disposed on unmount, so H1 is
+  dead; the collected heap does not step at a segment seam, so H2 is dead.
+
+  **The instrument lesson stands, and rf2-2rtt6.4's mitigation was right
+  for a reason it did not have:** one round per page keeps allocation
+  pressure off the clock, and 30-80 MB of uncollected rubbish in a page IS
+  what makes an unchanging floor arm drift 3.4 -> 7.0 ms — a scavenge
+  inside a timed window is a measurement of the collector. A heap figure
+  must be preceded by a forced collection AT THE READING, not merely
+  somewhere earlier in the run.
+
+  ## What this probe still cannot say
+
+  The WATCHERS column is BLIND under `:advanced`: `watches` is a `deftype`
+  field and Closure renames it, so `goog.object/get` cannot reach it from
+  outside the type. The driver's positive control reports that in so many
+  words, and the column must not be read as evidence that nothing is
+  watching. The sub-cache ENTRIES column is the one with a working
+  control, and it is the one the conclusion above rests on.
+
+  ## What is deliberately absent
+
+  No verdict, no threshold, no published figure, and no arm of its own:
+  the arms are `re-frame.bench.p0-heap`'s, reached through the `window.P0H`
+  door it already publishes, so this diagnostic cannot change what the P0
+  heap row measures. Every number here is a census of live references
+  beside a heap reading, printed as a SERIES so the shape — flat, linear,
+  stepped — is what a reader judges. A diagnostic that adjudicated would
+  be a row, and rows on this programme are operator-owned (rf2-2rtt6.1).
+
+  Owner: rf2-flqpd."
+  (:require [goog.object :as gobj]
+            [re-frame.bench.p0-arms :as arms]
+            [re-frame.bench.p0-heap :as heap]
+            [re-frame.frame :as frame]))
+
+;; ---------------------------------------------------------------------------
+;; The census
+;; ---------------------------------------------------------------------------
+
+(defn- watch-count
+  "How many watchers `x` carries, or `nil` when it is not a thing that has
+  watchers.
+
+  Duck-typed on purpose. Reagent's `Reaction`, reagent-slim's, an
+  `IWatchable` atom and the React spine's container are four different
+  types across three artefacts, and a census that picked one and silently
+  reported `nil` for the others would be the exact shape of fault this
+  programme keeps finding: a precise number over a smaller set than the
+  one it names. `:watchers-of` in the reading says how many of the objects
+  offered actually answered, so a census that stopped counting is visible."
+  [x]
+  (try
+    (let [w (gobj/get x "watches")]
+      (cond
+        (nil? w)    nil
+        (map? w)    (count w)
+        (object? w) (count (gobj/getKeys w))
+        :else       nil))
+    (catch :default _ nil)))
+
+(defn- sub-cache-census
+  "The frame's sub-cache: entries, and the watchers its reactions carry.
+
+  ENTRIES should be FLAT across cycles — the P0 arms subscribe to the same
+  query vectors every mount and the cache keys by query-vector equality.
+  WATCHERS are H1: one per live boundary, so they must return to their
+  starting value once every root is unmounted."
+  [frame-id]
+  (try
+    (if-let [f (frame/frame frame-id)]
+      (if-let [cache (:sub-cache f)]
+        (let [entries   (vals @cache)
+              ;; The entry shape is the sub-cache's, not this probe's, so
+              ;; every plausible slot is offered to `watch-count` and the
+              ;; reading says how many ANSWERED. A census that assumed one
+              ;; key would read a confident zero for ever.
+              reactions (into [] (comp (mapcat (fn [e]
+                                                 (if (map? e)
+                                                   (vals e)
+                                                   [e])))
+                                       (remove nil?))
+                              entries)
+              counts    (keep watch-count reactions)]
+          {:entries        (count entries)
+           :reactions      (count reactions)
+           :watchers-of    (count counts)
+           :watchers-total (reduce + 0 counts)
+           :watchers-max   (if (seq counts) (apply max counts) 0)})
+        {:entries :no-sub-cache})
+      {:entries :no-frame})
+    (catch :default e {:error (str e)})))
+
+(defn- projection-census
+  "Watchers on the frame's two partition projections. `destroy-frame!`
+  disposes these; a segment entry that left them watched would retain the
+  physical container and everything reachable from it — which is H2."
+  [frame-id]
+  {:app-db     (try (watch-count (frame/app-db-container frame-id))
+                    (catch :default _ :unreadable))
+   :runtime-db (try (watch-count (frame/runtime-db-container frame-id))
+                    (catch :default _ :unreadable))})
+
+(defn census
+  "One reading: the DOM, the sub-cache, the projections, the JS heap.
+
+  `usedJSHeapSize` wants `--enable-precise-memory-info`; without it Chrome
+  quantises to 100 KB buckets, which still shows a 12 MB climb perfectly
+  well, so its absence is reported (`-1`) rather than fatal."
+  []
+  (let [mem (when (exists? js/performance) (gobj/get js/performance "memory"))]
+    #js {"subCache"     (clj->js (sub-cache-census arms/frame-id))
+         "projections"  (clj->js (projection-census arms/frame-id))
+         "bodyChildren" (.-childElementCount js/document.body)
+         "domElements"  (.-length (.querySelectorAll js/document "*"))
+         ;; WHETHER THE PAGE CAN COLLECT AT ALL, reported on every reading.
+         ;; rf2-flqpd's evidence that the climb was RETENTION and not
+         ;; garbage is that `gc({type:'major',execution:'sync'})` between
+         ;; samples did not move it. That argument is only as good as the
+         ;; function existing: `--js-flags=--expose-gc` is given to the
+         ;; BROWSER process and a renderer does not necessarily inherit it,
+         ;; so a page can call a `gc` that is not there and a guarded call
+         ;; skips silently. A probe that assumed it worked would repeat the
+         ;; assumption rather than test it.
+         "gcAvailable"  (boolean (gobj/get js/window "gc"))
+         "usedJSHeap"   (if mem (gobj/get mem "usedJSHeapSize") -1)}))
+
+;; ---------------------------------------------------------------------------
+;; The page-side door
+;; ---------------------------------------------------------------------------
+
+(defn ^:export -main
+  "Install the P0 heap instrument's own door and this census beside it,
+  then stop. The DRIVER decides when anything happens, because only the
+  driver can force a collection and a reading taken on the collector's
+  own schedule is a reading of the collector."
+  []
+  (heap/install!)
+  (set! (.-RETENTION js/window) #js {:census (fn [] (census))})
+  (set! (.-RETENTION_READY js/window) true)
+  nil)

--- a/implementation/freehand/test/re_frame/bench/hicasso/retention_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/retention_run.cjs
@@ -1,0 +1,377 @@
+#!/usr/bin/env node
+// rf2-flqpd — the retention diagnostic's driver.
+//
+//   node implementation/freehand/test/re_frame/bench/hicasso/retention_run.cjs
+//   RETENTION_SEGMENT=uix-subs RETENTION_CYCLES=8 node .../retention_run.cjs
+//   node .../retention_run.cjs --no-build      (reuse the last bundle)
+//
+// ## What it drives, and why the driver holds the clock
+//
+// A page cannot force a garbage collection, so it cannot decide when a
+// RETAINED figure is taken; a page that tried would be reading whatever
+// the collector happened to have done. So every reading here is taken by
+// this driver, over a CDP session, in the order: collect, read, act,
+// collect, read.
+//
+// Two series, because rf2-flqpd's two candidate causes predict different
+// shapes and one run can separate them:
+//
+//   SERIES A — SEGMENT ENTRIES, nothing mounted. `P0H.prepare(segment)`
+//     destroys the adapter and the frame and stands both back up. If the
+//     climb is here, the segment entry retains its predecessor and the
+//     mounts are innocent.
+//
+//   SERIES B — MOUNT CYCLES inside ONE segment. Mount k roots, unmount
+//     every one, drop every container. If the climb is here, an unmounted
+//     root is still held, and the census says by how many watchers.
+//
+// ## No verdict
+//
+// This prints a table. The stop/continue rulings on this programme are
+// operator-owned on rf2-2rtt6.1 and a diagnostic must never learn to
+// issue one — exit 0 means the probe RAN, not that the heap is clean.
+// Exit 1 is reserved for the probe failing: a page error, a mount that
+// did not verify at the DOM, a census that could not be read.
+//
+// ## The build id
+//
+// `implementation/shadow-cljs.edn` is hot-zone. This rides rf2-2rtt6.2's
+// `:hicasso-bench` with an output directory and an `:init-fn` merged in at
+// the CLI, which is the seam that lane established for exactly this.
+
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs');
+
+const IMPL = path.resolve(__dirname, '../../../../..');
+
+const BUILD_ID = 'hicasso-bench';
+const OUT_DIR = process.env.RETENTION_OUT_DIR || 'out/hicasso-retention';
+const OUT = path.join(IMPL, OUT_DIR);
+const INIT_FN = 're-frame.bench.hicasso.retention-probe/-main';
+const PORT = Number(process.env.RETENTION_PORT || 8137);
+
+// The arm, the segment it needs, and how many roots a cycle mounts.
+// `grid/uix` and `grid/reagent` are the two the observation was made on;
+// `grid/floor` is the control that has no substrate, no subscription and
+// no re-frame state at all, and the bead records it staying flat.
+const SEGMENT = process.env.RETENTION_SEGMENT || 'uix-subs';
+const ARM = process.env.RETENTION_ARM || 'grid/uix';
+const CONTROL_ARM = process.env.RETENTION_CONTROL_ARM || 'grid/floor';
+const CYCLES = Number(process.env.RETENTION_CYCLES || 6);
+const ROOTS = Number(process.env.RETENTION_ROOTS || 4);
+const ENTRIES = Number(process.env.RETENTION_ENTRIES || 6);
+
+// SERIES C reproduces the bead's OWN shape: six adapter-segment entries,
+// alternating substrate, ~200 mount/unmount cycles each. Six entries is
+// what produced 34 -> 46 -> 55 -> 63 -> 75 -> 87 MB.
+const REPRO_SEGMENTS = Number(process.env.RETENTION_REPRO_SEGMENTS || 6);
+const REPRO_CYCLES = Number(process.env.RETENTION_REPRO_CYCLES || 50);
+const REPRO_ROOTS = Number(process.env.RETENTION_REPRO_ROOTS || 4);
+
+const NO_BUILD = process.argv.includes('--no-build');
+
+// WHICH collector forces the reading, and it is a real question rather
+// than a knob. `window.gc({type:'major',execution:'sync'})` is V8's
+// `--expose-gc` door and is what rf2-flqpd used from inside the page;
+// `HeapProfiler.collectGarbage` is the CDP door, which exists because a
+// measurement needs a collection the page cannot ask for. If the two
+// disagree, a mitigation built on the first is resting on the second.
+//   both (default) | page | cdp | none
+const COLLECT = process.env.RETENTION_COLLECT || 'both';
+// `all` (default) | repro — the two cheap series are worth running once,
+// not on every variant of the collector question.
+const ONLY = process.env.RETENTION_ONLY || 'all';
+
+const CONFIG_MERGE =
+  `{:output-dir "${OUT_DIR}" :asset-path "." :modules {:main {:init-fn ${INIT_FN}}}}`;
+
+function build() {
+  console.error(`[ret] building :advanced bundle — ${INIT_FN} -> ${OUT_DIR}`);
+  // `node cli/runner.js` rather than the `.cmd` shim: spawning a shim on
+  // Windows needs `shell: true`, and a shell concatenates argv, which is
+  // how the config-merge EDN gets torn in half.
+  const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+  const r = spawnSync(process.execPath, [runner, 'release', BUILD_ID, '--config-merge', CONFIG_MERGE], {
+    cwd: IMPL,
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+  if (r.status !== 0) {
+    console.error(`[ret] build failed with status ${r.status}`);
+    process.exit(1);
+  }
+}
+
+const MIME = { '.js': 'text/javascript', '.html': 'text/html', '.map': 'application/json' };
+
+function serve() {
+  fs.mkdirSync(OUT, { recursive: true });
+  fs.writeFileSync(
+    path.join(OUT, 'index.html'),
+    '<!doctype html><html><head><meta charset="utf-8"><title>retention</title></head>' +
+      '<body><div id="app"></div><script src="main.js"></script></body></html>'
+  );
+  return http
+    .createServer((req, res) => {
+      const rel = decodeURIComponent(req.url.split('?')[0]);
+      const file = path.join(OUT, rel === '/' ? 'index.html' : rel);
+      if (!file.startsWith(OUT) || !fs.existsSync(file)) {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      fs.createReadStream(file).pipe(res);
+    })
+    .listen(PORT);
+}
+
+const MB = (b) => (b < 0 ? '   n/a' : (b / 1048576).toFixed(2).padStart(7));
+
+async function run() {
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch({
+    // Precise memory info, because the 100 KB bucketing Chrome applies
+    // without it is coarse enough to hide a per-cycle step even though it
+    // could not hide the 12 MB one.
+    args: ['--enable-precise-memory-info', '--js-flags=--expose-gc'],
+  });
+  const page = await browser.newPage();
+  const pageErrors = [];
+  page.on('pageerror', (e) => {
+    pageErrors.push(e.message);
+    console.error('[ret] PAGE ERROR:', e.message);
+  });
+  page.on('console', (m) => {
+    if (m.type() === 'error' || m.type() === 'warning') {
+      console.error(`[ret] page ${m.type()}: ${m.text().slice(0, 300)}`);
+    }
+  });
+
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('HeapProfiler.enable');
+  // A MAJOR collection, synchronously, before every reading. The bead
+  // records that this did not move the climb — which is what makes the
+  // figure RETENTION rather than garbage, and it is repeated here so this
+  // probe's numbers carry the same property.
+  const collect = async () => {
+    if (COLLECT === 'cdp' || COLLECT === 'both') await cdp.send('HeapProfiler.collectGarbage');
+    if (COLLECT === 'page' || COLLECT === 'both') {
+      await page.evaluate('window.gc && window.gc({type:"major",execution:"sync"})');
+    }
+  };
+
+  await navigate(page, `http://127.0.0.1:${PORT}/`, {
+    waitUntil: 'commit',
+    timeoutMs: NAV_TIMEOUT_MS,
+    budget: 'the wait for window.RETENTION_READY',
+  });
+  await page.waitForFunction('window.RETENTION_READY === true', null, { timeout: 120000 });
+
+  const raw = () => page.evaluate('window.RETENTION.census()');
+  const census = async () => {
+    await collect();
+    return raw();
+  };
+  // A reading BEFORE the collection and one AFTER it, from the same point
+  // in the run. The gap between them is how much of an apparent climb is
+  // GARBAGE the page had not been asked to drop — which is the one
+  // possibility rf2-flqpd ruled out by calling `gc()` from inside the
+  // page, and it is only ruled out if that `gc` existed.
+  const bothCensus = async () => {
+    const before = await raw();
+    const after = await census();
+    return { ...after, uncollectedHeap: before.usedJSHeap };
+  };
+
+  // --- SERIES A: bare segment entries, nothing mounted -------------------
+  const entries = [];
+  for (let i = 0; ONLY === 'all' && i <= ENTRIES; i++) {
+    if (i > 0) await page.evaluate(`window.P0H.prepare(${JSON.stringify(SEGMENT)})`);
+    entries.push({ i, ...(await census()) });
+  }
+
+  // --- SERIES B: mount cycles inside ONE segment -------------------------
+  //
+  // Each cycle takes TWO censuses: one while the roots are STANDING and
+  // one after they are released. The mounted reading is this probe's
+  // POSITIVE CONTROL — a census that reads zero subscriptions with 1,200
+  // boundaries live is blind, and a blind census reporting "nothing is
+  // retained" is worse than no census at all. It is printed on every row,
+  // passing or not, because a control quoted only when it passes is not a
+  // control.
+  const series = async (arm) => {
+    await page.evaluate(`window.P0H.prepare(${JSON.stringify(SEGMENT)})`);
+    const rows = [];
+    rows.push({ i: 0, verify: null, mounted: null, ...(await census()) });
+    for (let i = 1; i <= CYCLES; i++) {
+      const verify = await page.evaluate(
+        `(() => { const v = window.P0H.mount(${JSON.stringify(arm)}, ${ROOTS});` +
+          ' return {elements: v.elements, expected: v.expected, ok: v.ok}; })()'
+      );
+      const mounted = await census();
+      await page.evaluate('window.P0H.release()');
+      rows.push({ i, verify, mounted, ...(await census()) });
+    }
+    return rows;
+  };
+
+  const armRows = ONLY === 'all' ? await series(ARM) : [];
+  const controlRows = ONLY === 'all' ? await series(CONTROL_ARM) : [];
+
+  // --- SERIES C: THE REPRODUCTION ---------------------------------------
+  //
+  // The bead's own shape and not a smaller one: SIX adapter-segment
+  // entries, alternating substrate, each followed by ~200 mount/unmount
+  // cycles against the live frame. That is the run whose heap read
+  // 34 -> 46 -> 55 -> 63 -> 75 -> 87 MB. Censuses are taken at the segment
+  // seams only, which is where the observation was made and which keeps
+  // the collector out of the cycle loop.
+  const repro = [];
+  const plan = [];
+  for (let s = 0; s < REPRO_SEGMENTS; s += 1) {
+    plan.push(s % 2 === 0 ? ['uix-subs', 'grid/uix'] : ['reagent-subs', 'grid/reagent']);
+  }
+  repro.push({ i: 0, segment: 'baseline', verify: null, ...(await bothCensus()) });
+  for (let s = 0; s < plan.length; s += 1) {
+    const [seg, arm] = plan[s];
+    await page.evaluate(`window.P0H.prepare(${JSON.stringify(seg)})`);
+    const verify = await page.evaluate(
+      `(async () => {
+         let last = null;
+         for (let i = 0; i < ${REPRO_CYCLES}; i++) {
+           last = window.P0H.mount(${JSON.stringify(arm)}, ${REPRO_ROOTS});
+           window.P0H.release();
+         }
+         return {elements: last.elements, expected: last.expected, ok: last.ok};
+       })()`
+    );
+    repro.push({ i: s + 1, segment: seg, verify, ...(await bothCensus()) });
+  }
+
+  const version = browser.version();
+  await browser.close();
+  return { entries, armRows, controlRows, repro, pageErrors, version };
+}
+
+const cell = (c) => `${String(c.entries).padStart(5)}/${String(c['watchers-total']).padStart(6)}`;
+
+function table(title, rows, label) {
+  console.log(`;; ==== ${title} ====`);
+  console.log(
+    `;;   ${label.padEnd(7)} COLLECTED  delta  UNCOLLECTED garbage  released  MOUNTED  gc?   DOM  verified`
+  );
+  console.log(
+    `;;   ${''.padEnd(7)}     MB        MB        MB        MB    ent/watch ent/watch     elems`
+  );
+  let prev = null;
+  for (const r of rows) {
+    const heap = r.usedJSHeap;
+    const delta = prev === null || heap < 0 || prev < 0 ? null : heap - prev;
+    prev = heap;
+    const sc = r.subCache || {};
+    const m = r.mounted ? cell(r.mounted.subCache || {}) : '       —';
+    const un = r.uncollectedHeap === undefined ? null : r.uncollectedHeap;
+    const garbage = un === null || un < 0 || heap < 0 ? null : un - heap;
+    console.log(
+      `;;   ${String(r.i).padEnd(7)} ${MB(heap)} ${delta === null ? '     —' : MB(delta)} ` +
+        `${un === null ? '     —' : MB(un)} ${garbage === null ? '     —' : MB(garbage)} ` +
+        `${cell(sc)} ${m} ${r.gcAvailable ? ' yes' : '  NO'} ` +
+        `${String(r.domElements).padStart(5)}  ` +
+        `${r.verify ? (r.verify.ok ? `ok ${r.verify.elements}` : `UNVERIFIED ${r.verify.elements}/${r.verify.expected}`) : '—'}`
+    );
+  }
+}
+
+(async () => {
+  if (!NO_BUILD) build();
+  const server = serve();
+  let out;
+  try {
+    out = await run();
+  } finally {
+    server.close();
+  }
+
+  console.log(';; ==== RETENTION DIAGNOSTIC (rf2-flqpd) ====');
+  console.log(`;; chromium ${out.version} (playwright), :advanced, goog.DEBUG false`);
+  console.log(`;; segment ${SEGMENT}; arm ${ARM}; control ${CONTROL_ARM};`);
+  console.log(`;; ${ROOTS} roots per cycle, ${CYCLES} cycles, ${ENTRIES} bare segment entries`);
+  console.log(`;; collector forcing every COLLECTED reading: ${COLLECT}`);
+  console.log(';; every reading follows a forced MAJOR collection, so every figure is RETAINED');
+  console.log(';; THIS PRINTS NO VERDICT. Rows are operator-owned on rf2-2rtt6.1.');
+
+  table('SERIES A — bare segment entries, nothing mounted', out.entries, 'entry');
+  table(`SERIES B — mount/unmount cycles, arm ${ARM}`, out.armRows, 'cycle');
+  table(`SERIES B — mount/unmount cycles, CONTROL ${CONTROL_ARM}`, out.controlRows, 'cycle');
+  table(
+    `SERIES C — the bead's own shape: ${REPRO_SEGMENTS} segment entries x ` +
+      `${REPRO_CYCLES} cycles x ${REPRO_ROOTS} roots`,
+    out.repro,
+    'segment'
+  );
+
+  // THE CENSUS'S OWN POSITIVE CONTROL. `MOUNTED` is read with 1,200
+  // boundaries standing; if it is the same as `released` on every row, the
+  // census cannot see a live subscription and no conclusion may be drawn
+  // from it about a dead one.
+  const mountedRows = out.armRows.filter((r) => r.mounted);
+  if (mountedRows.length === 0) {
+    console.log(';; ==== CENSUS POSITIVE CONTROL — not run in this mode ====');
+    console.error('[ret] ok — the probe ran; the table above is the finding');
+    return;
+  }
+  const sawEntries = mountedRows.filter(
+    (r) => ((r.mounted.subCache || {}).entries || 0) > ((r.subCache || {}).entries || 0)
+  );
+  const sawWatchers = mountedRows.filter(
+    (r) =>
+      ((r.mounted.subCache || {})['watchers-total'] || 0) >
+      ((r.subCache || {})['watchers-total'] || 0)
+  );
+  console.log(';; ==== CENSUS POSITIVE CONTROL — published passing or not ====');
+  console.log(
+    `;;   sub-cache ENTRIES:  ${sawEntries.length} of ${mountedRows.length} cycles read MORE ` +
+      'while mounted than after release'
+  );
+  console.log(
+    sawEntries.length === mountedRows.length
+      ? ';;     [ok  ] the census SEES a live subscription, so a zero after release is a real zero'
+      : ';;     [FAIL] the census cannot see a live subscription, so its zero after release is\n' +
+        ';;            not evidence of anything'
+  );
+  console.log(
+    `;;   reaction WATCHERS:  ${sawWatchers.length} of ${mountedRows.length} cycles read MORE ` +
+      'while mounted than after release'
+  );
+  console.log(
+    sawWatchers.length === 0
+      ? ';;     [UNCH] BLIND. `:advanced` renames a deftype field, so `watches` is not reachable\n' +
+        ';;            by name from outside the type. This column carries NO information in\n' +
+        ';;            EITHER direction and must not be read as "nothing is watching".'
+      : ';;     [ok  ] the watcher census can see a live watcher'
+  );
+
+  const unverified = [...out.armRows, ...out.controlRows, ...out.repro].filter(
+    (r) => r.verify && !r.verify.ok
+  );
+  if (out.pageErrors.length > 0) {
+    console.error(
+      `[ret] FAILED: ${out.pageErrors.length} uncaught page error(s) — every census above ` +
+        `was taken on a page that had already thrown:\n  ${out.pageErrors.join('\n  ')}`
+    );
+    process.exit(1);
+  }
+  if (unverified.length > 0) {
+    console.error(
+      `[ret] FAILED: ${unverified.length} cycle(s) did not verify at the DOM. An arm that ` +
+        'silently rendered nothing would read as the substrate that retains least.'
+    );
+    process.exit(1);
+  }
+  console.error('[ret] ok — the probe ran; the table above is the finding');
+})();

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_harness.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_harness.cljs
@@ -39,6 +39,7 @@
   `D021-performance-budgets-and-release-evidence.md`."
   (:require ["react-dom" :as react-dom]
             [clojure.string :as str]
+            [re-frame.bench.order-guard :as guard]
             [re-frame.freehand.bench.measure :as m]))
 
 ;; ---------------------------------------------------------------------------
@@ -171,9 +172,9 @@
 
 (defn- p50 [xs] (:p50 (m/summarise xs)))
 
-(defn slot-order
+(def slot-order
   "Slot order for `k` arms at sample index `s`: rotate forward by `s`, then
-  REFLECT on odd indices.
+  REFLECT on odd indices — TAKEN FROM THE GUARD, never restated here.
 
   The reflection is not decoration and this used to be a bare rotation.
   `rf2-88pie` records a fault class in which an arm's reading depends on
@@ -184,13 +185,20 @@
   `:measurement-method` said 'order rotating on the sample index' and
   meant it as a mitigation, and it was not one.
 
-  Reversing a sequence replaces every `a -> a+1` adjacency with
-  `a -> a-1`, so alternating the two gives every arm two predecessors in
-  balance. `order_guard.cjs` carries the arithmetic proof of both halves
-  of that sentence, and the guard that refuses a figure the order moves."
-  [k s]
-  (let [xs (mapv #(mod (+ % s) k) (range k))]
-    (if (odd? s) (vec (rseq xs)) xs)))
+  This was a third copy of that arithmetic, and it drifted the way a
+  restated method drifts: at `k = 2` the rotation and the reflection are
+  the same permutation and cancel, so a two-arm plan ran in ONE ORDER for
+  ever (`rf2-ouwh8`, found by the guard as `only 1 stratum — the question
+  was never asked`). The repair is not a fourth spelling of the fix — it
+  is to stop spelling it. `re-frame.bench.order-guard` owns the schedule
+  and its self-test carries the arithmetic proof for `k = 2` and for
+  `k >= 3`; `re-frame.bench.hicasso.lane` takes it the same way.
+
+  Two copies of the rule remain and both are structurally forced: this
+  one's authority in `order_guard.cljc`, and `order_guard.cjs` for the
+  Node drivers that own a Chromium page and cannot consume ClojureScript.
+  Their shared self-test fixtures are what hold them in step."
+  guard/slot-order)
 
 (defn round!
   "One round: `(+ warmup samples)` sample indices, every arm mounted at

--- a/implementation/freehand/test/re_frame/freehand/bench/order_guard.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/order_guard.cjs
@@ -116,6 +116,23 @@
 // the case is not exotic. [[schedule]] drops the reflection at `n === 2`,
 // where the bare rotation already supplies both of the orders that exist.
 //
+// ## A LOST position is a refusal, not a smaller question
+//
+// Every instrument fault on this programme produced a plausible PRECISE
+// WRONG NUMBER before it was caught, and one of them was aimed straight at
+// this module: a shadowed binding in a harness made every `position` `NaN`
+// from round 2 on. `stratifyArm` filters non-finite positions out of the
+// phase contrast, so the phase question was quietly answered over the six
+// samples that still had one while `format` printed the arm's full
+// twenty-four beside it — and the run returned `[ok]`.
+//
+// A harness that records NO positions is a different and documented case:
+// it is excused the phase contrast (and still owes the predecessor one). A
+// harness that records positions and LOSES them is broken, and
+// [[lostPositions]] separates the two so the second refuses. `selfTest`
+// check 10 replays it with deliberately flat values, so nothing but the
+// lost positions can be what refuses.
+//
 // ## What the `predecessor` factor can and cannot attribute (rf2-om73r)
 //
 // Under [[schedule]] an arm's predecessor is `(a - 1) mod n` on EVEN rounds
@@ -269,6 +286,23 @@ function stratifyArm(samples, factor) {
 }
 
 /**
+ * How many of `samples` CARRY a `position` that is not a finite number.
+ *
+ * Not the same question as "how many have no position". A harness that
+ * records no positions at all is a documented case and is excused the phase
+ * contrast; a harness that records `NaN` has LOST them, and the difference
+ * between the two is the difference between a question not asked and a
+ * question answered over a silently smaller set.
+ */
+function lostPositions(samples) {
+  let n = 0;
+  for (const s of samples) {
+    if (s.position !== undefined && s.position !== null && !Number.isFinite(s.position)) n += 1;
+  }
+  return n;
+}
+
+/**
  * Adjudicate one arm's strata on one factor.
  *
  * Strata of a single sample carry no range, so they are adjudicated on the
@@ -344,10 +378,29 @@ function verdict(samples, opts = {}) {
     const per = {};
     for (const f of factors) {
       const strata = stratifyArm(ss, f);
-      // `phase` is only askable when positions were recorded; a driver
-      // that does not record them is not thereby excused the predecessor
-      // question, so an empty phase stratification is skipped rather than
-      // failed.
+      const lost = f === 'phase' ? lostPositions(ss) : 0;
+      if (lost > 0) {
+        // A sample that CARRIES a position and whose position is not a
+        // number is a HARNESS FAULT, and it is the recorded one: a shadowed
+        // binding made every position `NaN` from round 2 on, `stratifyArm`
+        // dropped them, and the report said "24 samples" over a phase
+        // contrast adjudicated on six — and answered `[ok]`. Silently
+        // narrowing the question is the one thing this module must not do.
+        per[f] = {
+          strata,
+          status: 'unchecked',
+          lostPositions: lost,
+          why:
+            `${lost} of ${ss.length} samples carry a NON-FINITE position — the harness ` +
+            'lost them, so this contrast is over the rest and the sample count above is not it',
+        };
+        unchecked = true;
+        continue;
+      }
+      // `phase` is only askable when positions were recorded at all; a
+      // driver that does not record them is not thereby excused the
+      // predecessor question, so an empty phase stratification is skipped
+      // rather than failed.
       if (f === 'phase' && strata.length === 0) continue;
       per[f] = adjudicate(strata, tolerance);
       if (per[f].status === 'contaminated') contaminated = true;
@@ -563,6 +616,25 @@ function selfTest() {
     fixOrders === 2 && fixDistinct.every((d) => d >= 2) && fixShare <= 0.75,
     `schedule: ${fixOrders} distinct orders, predecessors per arm ${fixDistinct.join(',')}, ` +
       `largest modal share ${(fixShare * 100).toFixed(0)}%`
+  );
+
+  // 10. THE LOST POSITIONS, replayed. A shadowed binding made every position
+  //     `NaN` from round 2 on; `stratifyArm` dropped them, the report printed
+  //     the arm's full sample count beside a phase contrast taken over the
+  //     survivors, and the run came back `[ok]`. Values are deliberately flat,
+  //     so nothing but the lost positions can be what refuses this.
+  const lostSamples = Array.from({ length: 24 }, (_, i) => ({
+    arm: 'A',
+    predecessor: 'B',
+    position: i < 6 ? i : NaN,
+    value: 1.0,
+  }));
+  const vLost = verdict(lostSamples, { tolerance: 0.1 });
+  const lostR = one(vLost, 'A', 'phase');
+  check(
+    'samples whose position went NON-FINITE refuse instead of narrowing the question',
+    vLost.refuse && lostR.status === 'unchecked' && lostR.lostPositions === 18,
+    lostR.why
   );
 
   return { ok: checks.every((c) => c.ok), checks };

--- a/implementation/freehand/test/re_frame/freehand/bench/order_guard.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/order_guard.cjs
@@ -105,6 +105,17 @@
 // `a -> a+1` adjacency with `a -> a-1`. `selfTest` proves both halves of
 // that arithmetically.
 //
+// ## Two arms are the case where the reflection cancels (rf2-ouwh8)
+//
+// Reversing a pair IS rotating it by one. So at `n === 2` — and only there —
+// composing the rotation with the reflection returns `[0, 1]` at every index,
+// and a two-arm plan runs in a SINGLE ORDER for ever. That is not a weaker
+// version of the property; it is the absence of it, and the guard says so:
+// four two-arm rows came back `only 1 stratum — the question was never
+// asked`. Two arms is the natural shape for *candidate versus comparator*, so
+// the case is not exotic. [[schedule]] drops the reflection at `n === 2`,
+// where the bare rotation already supplies both of the orders that exist.
+//
 // ## What the `predecessor` factor can and cannot attribute (rf2-om73r)
 //
 // Under [[schedule]] an arm's predecessor is `(a - 1) mod n` on EVEN rounds
@@ -125,11 +136,24 @@
 // The schedule
 // ---------------------------------------------------------------------------
 
-/** Slot order for `n` arms in `round`: rotate forward, then REFLECT on odd rounds. */
+/**
+ * Slot order for `n` arms in `round`: rotate forward, then REFLECT on odd
+ * rounds — EXCEPT at `n === 2`, where the two operations are the SAME
+ * permutation and composing them cancels.
+ *
+ * Reversing a pair is rotating it by one, so a schedule that always composes
+ * returns `[0, 1]` at every index and a two-arm plan runs in ONE ORDER FOR
+ * EVER — the single-order result this module exists to refuse (`rf2-ouwh8`;
+ * the guard found it, four two-arm rows deep, as `only 1 stratum — the
+ * question was never asked`). At `n === 2` the bare rotation already
+ * alternates `[0, 1]` and `[1, 0]`, which is every order two arms have, so
+ * the reflection is dropped rather than composed. `selfTest` checks 9 and 10
+ * price both halves.
+ */
 function schedule(n, round) {
   const xs = [];
   for (let j = 0; j < n; j++) xs.push((j + round) % n);
-  return round % 2 === 1 ? xs.reverse() : xs;
+  return round % 2 === 1 && n > 2 ? xs.reverse() : xs;
 }
 
 /** The plain cyclic rotation, kept so `selfTest` can price it. */
@@ -502,6 +526,43 @@ function selfTest() {
     refDistinct.every((d) => d >= 2) && refShare <= 0.75,
     `reflected: ${refDistinct.join(',')} predecessors per arm, largest modal share ` +
       `${(refShare * 100).toFixed(0)}%`
+  );
+
+  // 8. TWO ARMS, where the reflection CANCELS the rotation. Priced beside 7
+  //    because it is the same arithmetic asked at the smallest `n` a
+  //    comparison can have, and two arms is the natural shape for
+  //    "candidate versus comparator". `alwaysReflect` is what [[schedule]]
+  //    used to be, kept HERE and nowhere else so the defect stays
+  //    reproducible rather than merely described (rf2-ouwh8).
+  //
+  //    A pair has exactly one adjacency per round, so the WITHIN-round
+  //    question is unaskable at `n = 2` under any schedule; the seams are
+  //    the run, and seams-on is the honest setting here.
+  const alwaysReflect = (n, round) => {
+    const xs = [];
+    for (let j = 0; j < n; j++) xs.push((j + round) % n);
+    return round % 2 === 1 ? xs.reverse() : xs;
+  };
+  const orders = (sched) => new Set(Array.from({ length: R }, (_, s) => sched(2, s).join(','))).size;
+  const degOrders = orders(alwaysReflect);
+  const fixOrders = orders(schedule);
+  const deg2 = adjacency(2, R, alwaysReflect);
+  const fix2 = adjacency(2, R, schedule);
+  const degDistinct = Object.values(deg2.arms).map((a) => a.distinct);
+  const fixDistinct = Object.values(fix2.arms).map((a) => a.distinct);
+  const fixShare = Math.max(...Object.values(fix2.arms).map((a) => a.modalShare));
+  check(
+    'at k=2 an ALWAYS-reflecting schedule runs one order for ever and is UNCHECKED',
+    degOrders === 1 && degDistinct.some((d) => d === 1),
+    `always-reflect over ${R} rounds of 2 arms: ${degOrders} distinct order(s), ` +
+      `predecessors per arm ${degDistinct.join(',')} — rotating a pair by one IS ` +
+      'reversing it, so the two cancel'
+  );
+  check(
+    'at k=2 schedule alternates, and every arm gets TWO predecessors in balance',
+    fixOrders === 2 && fixDistinct.every((d) => d >= 2) && fixShare <= 0.75,
+    `schedule: ${fixOrders} distinct orders, predecessors per arm ${fixDistinct.join(',')}, ` +
+      `largest modal share ${(fixShare * 100).toFixed(0)}%`
   );
 
   return { ok: checks.every((c) => c.ok), checks };

--- a/implementation/freehand/test/re_frame/freehand/bench/order_schedule_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/order_schedule_cljs_test.cljs
@@ -1,0 +1,159 @@
+(ns re-frame.freehand.bench.order-schedule-cljs-test
+  "rf2-ouwh8 — the arm-order SCHEDULE, priced at the three arm counts that
+  matter, and pinned to ONE authority.
+
+  ## What this file exists to stop
+
+  The rule 'rotate, then reflect on odd indices' was written out three
+  times: `re-frame.bench.order-guard/slot-order`, `b6-harness/slot-order`
+  and `order_guard.cjs`'s `schedule`. All three carried the same defect,
+  and it is the defect a restated method always eventually has — reversing
+  a PAIR is rotating it by one, so at `k = 2` the two operations cancel and
+  the schedule returns `[0 1]` at every index. A two-arm plan therefore ran
+  in ONE ORDER for ever, which is the single-order result the guard exists
+  to refuse; it duly refused four rows with `only 1 stratum — the question
+  was never asked`.
+
+  Two of the three copies are structurally forced — a Node driver owning a
+  Chromium page cannot consume ClojureScript, and `implementation/core` may
+  not require out of `implementation/freehand` — and their shared self-test
+  fixtures hold them in step. The third was not forced, and is now a `def`
+  onto the guard. This suite is the other end of that: it asserts the
+  ClojureScript harnesses hold the guard's own function rather than a
+  lookalike, so a future restatement fails here rather than in a published
+  row.
+
+  ## Why the assertions are about ORDERS and STRATA, not about a fix
+
+  A repair that satisfies the guard without demonstrably varying the order
+  is the same defect wearing a passing verdict. So the checks below count
+  the DISTINCT ORDERS a schedule produces and the PREDECESSOR STRATA the
+  guard can then partition on, at `k = 2`, `3` and `4`, and they carry the
+  degenerate schedule alongside so the contrast is measured rather than
+  asserted."
+  (:require [cljs.test :refer [deftest is testing]]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.order-guard :as guard]
+            [re-frame.freehand.bench.b6-harness :as h]))
+
+(defn- always-reflect
+  "The schedule as it was: rotate forward, then reflect on odd indices at
+  EVERY arm count. Kept here so the defect is reproducible rather than
+  merely described."
+  [k s]
+  (let [xs (mapv #(mod (+ % s) k) (range k))]
+    (if (odd? s) (vec (rseq xs)) xs)))
+
+(def ^:private rounds 6)
+
+(defn- distinct-orders [sched k]
+  (count (set (map #(sched k %) (range rounds)))))
+
+(defn- strata-per-arm
+  "Predecessor strata per arm, as the guard counts them, over `rounds`
+  rounds run back to back in one process. The seams are part of the run —
+  the last arm of a round really does precede the first of the next — and
+  at `k = 2` they are the ONLY adjacencies there are, since a round of two
+  contains exactly one."
+  [sched k]
+  (->> (guard/adjacency k rounds sched)
+       :arms
+       (sort-by key)
+       (mapv (comp :distinct val))))
+
+;; ---------------------------------------------------------------------------
+;; One authority
+;; ---------------------------------------------------------------------------
+
+(deftest the-cljs-harnesses-hold-the-guards-own-schedule
+  (testing "Identity, not equivalence. `=` on two functions that agree
+            everywhere tested would pass for a lookalike that drifts at
+            some `k` nobody thought to test — which is precisely how this
+            bug survived a fix to one copy. `identical?` cannot."
+    (is (identical? guard/slot-order h/slot-order)
+        "b6-harness must hold order-guard's schedule, not a restatement of it")
+    (is (identical? guard/slot-order lane/slot-order)
+        "the Hicasso lane must hold order-guard's schedule, not a restatement of it")))
+
+;; ---------------------------------------------------------------------------
+;; k = 2 — where the reflection cancels
+;; ---------------------------------------------------------------------------
+
+(deftest at-two-arms-the-old-schedule-ran-one-order-for-ever
+  (testing "The defect, reproduced. Rotating a pair by one IS reversing it,
+            so composing the two is the identity and every index yields the
+            same slot vector."
+    (is (= [[0 1] [0 1] [0 1] [0 1] [0 1] [0 1]]
+           (mapv #(always-reflect 2 %) (range rounds))))
+    (is (= 1 (distinct-orders always-reflect 2)))
+    (is (some #{1} (strata-per-arm always-reflect 2))
+        "an arm with ONE predecessor stratum is what the guard calls :unchecked")))
+
+(deftest at-two-arms-slot-order-alternates
+  (testing "Both of the orders two arms have, alternating on the index."
+    (is (= [[0 1] [1 0] [0 1] [1 0] [0 1] [1 0]]
+           (mapv #(guard/slot-order 2 %) (range rounds))))
+    (is (= 2 (distinct-orders guard/slot-order 2)))
+    (is (every? #(>= % 2) (strata-per-arm guard/slot-order 2))
+        "every arm must reach at least two predecessor strata for the question to be asked")))
+
+(deftest at-two-arms-the-guard-stops-refusing-a-balanced-plan
+  (testing "The stratum count is the point, and the verdict is what a driver
+            acts on. The same synthetic plan — one flat reading per sample,
+            so nothing but the ORDER differs between the two runs — is
+            REFUSED under the old schedule and reportable under the new."
+    (let [plan (fn [sched k]
+                 (:samples
+                   (reduce (fn [acc s]
+                             (reduce (fn [{:keys [pos prev samples]} j]
+                                       {:pos     (inc pos)
+                                        :prev    (str "A" j)
+                                        :samples (conj samples
+                                                       {:arm         (str "A" j)
+                                                        :value       1.0
+                                                        :predecessor prev
+                                                        :position    pos})})
+                                     acc
+                                     (sched k s)))
+                           {:pos 0 :prev nil :samples []}
+                           (range rounds))))
+          before (guard/verdict (plan always-reflect 2) {:tolerance 0.10})
+          after  (guard/verdict (plan guard/slot-order 2) {:tolerance 0.10})]
+      (is (:unchecked? before) "the old schedule leaves the order question unasked")
+      (is (:refuse? before)    "and an unasked question refuses as loudly as a failed one")
+      (is (not (:unchecked? after)))
+      (is (not (:refuse? after))
+          "every reading here is 1.0, so a refusal after the repair could only be the plan"))))
+
+;; ---------------------------------------------------------------------------
+;; k = 3 and k = 4 — unchanged, and that is an assertion
+;; ---------------------------------------------------------------------------
+
+(deftest above-two-arms-the-schedule-is-untouched
+  (testing "The repair is confined to `k = 2`. Three and four arms must come
+            back the schedule the published multi-arm rows were measured
+            on — if they did not, this change would have moved a measuring
+            device under numbers already in the studio."
+    (doseq [k [3 4]]
+      (is (= (mapv #(always-reflect k %) (range rounds))
+             (mapv #(guard/slot-order k %) (range rounds)))
+          (str "k=" k " must be byte-identical to the pre-repair schedule")))
+    (is (= 6 (distinct-orders guard/slot-order 3)))
+    (is (= 4 (distinct-orders guard/slot-order 4)))
+    (is (every? #(>= % 2) (strata-per-arm guard/slot-order 3)))
+    (is (every? #(>= % 2) (strata-per-arm guard/slot-order 4)))))
+
+;; ---------------------------------------------------------------------------
+;; The self-test travels with the harness
+;; ---------------------------------------------------------------------------
+
+(deftest the-shared-self-test-passes-in-this-runtime
+  (testing "`guard/self-test` is what every harness runs before it measures
+            anything, and it is the fixture set that holds the ClojureScript
+            copy of the rule in step with `order_guard.cjs`'s. Running it
+            here means a drift is a red suite rather than a refused run
+            three hours into a measurement."
+    (let [st (guard/self-test)]
+      (is (:ok? st)
+          (str "failing checks: "
+               (pr-str (mapv :name (remove :ok (:checks st)))))))))


### PR DESCRIPTION
Four beads on one surface — the shared Hicasso/B6 bench instruments. Safe to
touch now and not before: all four P0 arms and the donor gate have landed, so
nothing is measuring on these copies.

**No measured window moves in this PR, and no published row is invalidated.**
Every bench file whose numbers are on `rf2-2rtt6.1` or in the studio and which
this branch does not name below came out blob-identical to `origin/main` after
the rebase: `hd8_app.cljs`, `hd8_run.cjs`, `hd8_witnesses.cljs`,
`hicasso/run.cjs`, `p0_run.cjs`, `p0_heap.cljs`, `p0_arms.cljs`,
`hicasso_narrow_app.cljs`.

## rf2-ouwh8 — the two-arm schedule ran one order for ever

Rotating a pair by one IS reversing it. The schedule every interleaved harness
here uses — rotate forward by the sample index, then REFLECT on odd indices —
therefore composes two *identical* permutations at `k = 2` and returns `[0 1]`
at every index. A two-arm plan ran in ONE ORDER for ever, which is the
single-order result the arm-order guard exists to refuse; it duly refused four
rows with `only 1 stratum — the question was never asked`.

**Three copies carried it**, all three defective:

| copy | disposition |
|---|---|
| `core/test/re_frame/bench/order_guard.cljc` `slot-order` | repaired (the authority) |
| `freehand/…/bench/order_guard.cjs` `schedule` | repaired (Node drivers cannot consume CLJS) |
| `freehand/…/bench/b6_harness.cljs` `slot-order` | **deleted** — now a `def` onto the guard |

Two of the three are structurally forced; b6-harness's was not, and restating
it is exactly how the defect survived a fix to a sibling. Three copies become
two, and the two remaining are the irreducible ones held in step by shared
self-test fixtures.

Measured, before and after — distinct orders and predecessor strata per arm:

| k | orders before | strata before | verdict before | orders after | strata after | verdict after |
|---|---|---|---|---|---|---|
| 2 | **1** | **2,1** | **REFUSE (`:unchecked`)** | **2** | **3,2** | reportable |
| 3 | 6 | 3,2,2 | reportable | 6 | 3,2,2 | reportable |
| 4 | 4 | 3,2,2,2 | reportable | 4 | 3,2,2,2 | reportable |

`k >= 3` is byte-identical to the pre-repair schedule and the new suite asserts
that rather than trusting it. Every published row carries 3+ arms, so **no
published row is affected.**

Proved by mutation: reverting `slot-order` to the always-reflecting form turns
`npm run test:freehand` red with 6 failures — all the `k = 2` assertions plus
the shared self-test — and restoring gives a byte-identical file
(md5 `81e1132a29101b71f88364277dd50fe0`) and 0 failures. rf2-2rtt6.7's local
override in `hd8_rows.cljs` is deleted as its own docstring said it would be.

### A sibling of the shadowed-binding fault, found while in there

Live in **both** shared copies of the guard. The recorded fault: a shadowed
binding made every `:position` `NaN` from round 2 on. `stratify` filters
non-finite positions out of the phase contrast, so phase was quietly answered
over the survivors while the report printed the arm's full count beside it —
and the run answered `[ok]`. Reproduced here with the new branch mutated out,
on 24 flat samples of which 18 carry a NaN position:

```
;;   A  (24 samples)
;;     [UNCH] by predecessor  only 1 stratum — the question was never asked
;;     [ok  ] by phase        within 10%
;;              FIRST-THIRD              n= 2  p50  1.0000  [1.0000–1.0000]
;;              LAST-THIRD               n= 2  p50  1.0000  [1.0000–1.0000]
```

Twenty-four samples on the arm line; a phase contrast decided by four. A
harness that records NO positions is a different, documented case and stays
excused; one that records them and LOSES them now refuses, naming the count.
Every position producer in the tree is an integer counter, so this cannot fire
on an honest run.

## rf2-uhw11 — the two P0 lanes converge on one method

`summarise` and `chain` are now `lane/`'s rather than restatements (identical
arithmetic, identical values); the schedule was already `guard/slot-order` on
both sides and is now pinned by `identical?`. Deliberately NOT converged, with
the header saying why: the **clock** (`lane/now-ms` branches on
`(exists? js/performance)`; this lane's `now` does not, and it is called five
times *inside* a measured window), and the **tally** (the lane counts
`{:of :bad}` in one atom; the narrow lane carries `writes`/`bad` inside the
six-leg `goog.object` accumulator that `:advanced` requires).

The narrow driver's build-template FALLBACK is removed — it chose
`:hicasso-bench` when present and `:freehand-release` otherwise, and the lane's
id has landed. The two were never interchangeable: `:freehand-release` is
cleaned and rebuilt by two gates, so a bench run raced them for one build cache.

## rf2-f5roa — the HD-008 arm on the lane's mechanisms

**Multi-probe read-back.** HD-008's bulk row wrote all 300 cells and verified
CELL 0; a page left stale by a commit outside the window can still carry one
fresh cell from the previous write. The rule is now `lane/bulk-probes` — a cell
that rotates with the write, the far end of the grid, and cell 0 — stated once
and used by HD-008 and the P0 arm. The NARROW row is unchanged and was already
right. The clock stops before the first `querySelector`, so the window is
unchanged; what can move is the `N unverified of M` count, in the direction of
catching more.

**Head-to-head** was a second copy of `lane/ratio-between` and is now that
function, fed raw `:p50` maps so the digits are unchanged.

**Four of the lane's mechanisms are deliberately NOT adopted**, recorded in the
ns docstring: (1) the BATCHED write window — it would change the measured
window and invalidate the published HD-008 rows, and a window change cannot be
validated without a re-run this branch does not do; (2) `lane/control-verdict`,
which is *weaker* than HD-008's own rule (overlap vs containment); (3)
`lane/tally`, which pools where HD-008 counts per arm; (4) the CLJS-side
verdict — HD-008 adjudicates in its driver with the `.cjs` copy, and a lane
exercising the other copy is worth more than the symmetry.

## rf2-flqpd — the 12 MB is GARBAGE, not retention

New diagnostic (`retention_probe.cljs` + `retention_run.cjs`) driving the P0
heap arm's own `window.P0H` door — no arm of its own, so a diagnostic cannot
change what a row measures — taking every reading from the driver over CDP,
twice: as the page has it, and after a forced major collection. Run in the
bead's own shape: six segment entries alternating UIx and Reagent, 50 cycles of
4 roots each (200 roots, 60,000 boundaries per segment), every cycle verified
at 1,200 DOM elements.

| segment | COLLECTED MB | UNCOLLECTED MB | garbage MB |
|---|---|---|---|
| baseline | 4.73 | 4.75 | 0.02 |
| 1 | 5.13 | 17.73 | 12.60 |
| 2 | 5.42 | 65.03 | 59.60 |
| 3 | 5.52 | 30.92 | 25.39 |
| 4 | 5.50 | 81.03 | 75.52 |
| 5 | 5.61 | 12.44 | 6.84 |
| 6 | 5.63 | 55.72 | 50.09 |

**The UNCOLLECTED column is the observation** — it reaches the reported
magnitude and SAWTOOTHS, which a leak cannot do. The COLLECTED column, read at
the same instants, climbs 0.90 MB in total and settles. Repeated with
`RETENTION_COLLECT=page` (`window.gc({type:'major',execution:'sync'})` alone)
it reads 2.99 to 5.90 MB, so the page's own collector reclaims it too.

**Nothing shipped is leaking**, so this does not become somebody else's bead.
H1 (unmount does not unsubscribe) is dead: the sub-cache census reads 300
entries with the roots standing and 0 after release, 6 of 6 cycles. H2 (the
segment entry retains its predecessor) is dead: the collected heap does not
step at a seam. This corroborates `p0_harness/collect!`'s own landed note that
a bare `gc()` is a scavenge and not enough; the instrument lesson is that a
heap figure must be preceded by a forced major collection **at the reading**.

The probe publishes its own limits: the WATCHERS column is BLIND under
`:advanced` (`watches` is a `deftype` field Closure renames) and the driver's
positive control says so in words on every run. The ENTRIES column is the one
with a working control and the conclusion rests on it.

## Rebase note

Rebased onto `origin/main` after #7265/#7266/#7269 landed. One conflict,
`hd8_rows.cljs` `timed-write!`, resolved by **merging both intents**:
rf2-b69lw's per-arm `(:window! arm)` scheduler-family wait is kept intact and
the verify thunk now checks every probe. Nothing from rf2-b69lw was deleted.
`rf2-pq7d8` (the same fixed yield in the shared `lane/verified-write!`) is
**not** repaired here — it would change the measured window for P0 arms whose
rows are published.

## Quality gates

| gate | exit |
|---|---|
| `npm run test:cljs` (11,946 tests / 59,635 assertions, 0 failures) | **0** |
| `npm run test:browser` (842 tests / 5,469 assertions, 0 failures) | **0** |
| `npm run test:freehand` (1,399 tests / 7,752 assertions, 0 failures) | **0** |
| order-guard `self-test`, JVM CLJC (11 checks) | **0** |
| order-guard `selfTest`, Node CJS (11 checks) | **0** |
| `slot-order` at k=2/3/4, CLJC — 2/6/4 distinct orders, no refusal | **0** |
| `schedule` at k=2/3/4, CJS — 2/6/4 distinct orders | **0** |
| mutation proof — schedule reverted, `test:freehand` red with 6 failures | **1** (expected) |
| mutation proof — lost-position branch removed, `selfTest` red | **1** (expected) |
| `shadow-cljs compile hicasso-bench` for hd8-app / narrow-app / p0-reagent-app / retention-probe | **0** each |
| `retention_run.cjs` (`both` collector) | **0** |
| `retention_run.cjs` (`page` collector) | **0** |

All gates run foreground to completion, unpiped, after the rebase.

## Flagged, not edited (fenced trees)

- `docs/design/hicasso/studio/p0-ratom-spine-narrow-write.md:279` documents
  `HN_BASE_BUILD`, which this PR removes.
- `docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md:269` documents
  `P0_BUILD`. `p0_run.cjs`'s `:freehand-release` default is left **untouched** —
  `rf2-39caf` says that repoint belongs to a pending operator decision.
