### PR TITLE
bench(hicasso): converge the P0 witness sets so the table is comparable (rf2-a4x1o)

### DIFF
--- a/docs/design/hicasso/studio/README.md
+++ b/docs/design/hicasso/studio/README.md
@@ -47,6 +47,10 @@ HICASSO_INIT_FN=re-frame.bench.hicasso.<arm>-app/-main \
 HICASSO_OUT_DIR=out/hicasso-<arm> \
 HICASSO_PORT=8132 \
   node freehand/test/re_frame/bench/hicasso/run.cjs
+
+# an arm that needs more than one page load brings its own thin driver on
+# the same build id — e.g. the converged clock table, one row per page
+node freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
 ```
 
 Exit codes: `0` measured and clean, `1` the run failed, **`2` the arm-order
@@ -63,4 +67,23 @@ requires nothing from any donor `src/` tree.
 | Page | Phase | What it settles |
 |---|---|---|
 | [P0 — Reagent-on-subs baseline (mount + bulk)](p0-reagent-on-subs-baseline.md) | P0 | The ship bar's **denominator**: mount and bulk view work for Reagent reading re-frame2 subscriptions. |
+| [P0 — ratom-spine narrow write](p0-ratom-spine-narrow-write.md) | P0 | What a narrow write on the ratom spine costs, and the write-versus-flush split. |
+| [P0 — the UIx-on-subs frontier arm](p0-uix-on-subs-frontier-arm.md) | P0 | The frontier against the denominator, on the arm's own witnesses. Its **retained-heap** red-zones stand; its clock rows are superseded by the converged page. |
+| [P0 — the converged witness set, and the red-zones re-derived on it](p0-converged-witness-set.md) | P0 | The **clock red-zones** on the denominator's own witnesses, and how far the earlier per-arm witness sets moved the verdicts. |
+| [P0 — the reads-per-boundary heap ladder](reads-per-boundary-heap-ladder.md) | P0 | Retained heap per subscribing boundary across the 1/3/7/20 reads ladder, both donors. |
+| [HD-008 — the composed donor arm](hd8-composed-donor-arm.md) | donor gate | What the composed donor arm costs against both Reagent paths and against the frontier. |
+| [The UIx spine's per-read allocation, decomposed](uix-spine-per-read-decomposition.md) | P0 | Where a UIx-on-subs read's bytes go. |
 | [The reagent-slim non-reactive arm — diagnosis](slim-non-reactive-arm-diagnosis.md) | P0 | Why HD-008's reagent-slim arm read `78 unverified of 78`: the **arm's composition**, not the adapter and not the mixed bundle. A single-substrate slim bundle re-renders on every write. |
+
+**Clock red-zones live on the converged page.** Where it and the frontier arm
+disagree, the converged row is the operative one: the bar's denominator is
+Reagent-on-subs, so the denominator's witness set defines the comparison by
+construction, and a threshold measured on a different witness is a threshold on
+a different question.
+
+**Retained-heap red-zones are not superseded.** They live on the heap ladder and
+on the frontier arm's own record, and stand as published. Three shapes spanning
+a 4× range in markup density agree within 8% — because retained bytes per
+subscribing boundary is a property of the boundary. The clock is not: element
+count decides what fraction of the window is React's own work, which is why the
+clock rows had to move to the denominator's pages and the heap rows did not.

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -87,7 +87,7 @@ rows do not.
 
 | | |
 |---|---|
-| **Producing commit** | `44900cd4fd35815b3e2462ae7752242efcb296b9` |
+| **Producing commit** | `44900cd4fd35815b3e2462ae7752242efcb296b9` — the branch was later rebased onto PR #7265, which **rewrote that commit's id without touching the instrument**: the four bench files are byte-identical (same blob hashes) at the rebased commit, so the reproduction command is unaffected. Nothing was re-measured. |
 | **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` |
 | **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium via Playwright), Windows 11 x64, sibling agents live on the box |
 | **Build** | `:hicasso-bench` — `:browser`, `:advanced`, `goog.DEBUG false`. **No new build id; `implementation/shadow-cljs.edn` untouched** |
@@ -384,9 +384,13 @@ first cut produced looked entirely plausible.
   tried batching mounts on this exact witness and the guard refused the whole
   run (exit 2, all four arms 3.2×–5.4× last-third over first-third, ranges
   disjoint). This entry does not re-litigate that; the row stays diagnostic.
-- **rf2-2rtt6.4's page and tree are not on main** (PR #7265 was open when this
-  was measured). Its clock rows remain sound as ratios and are superseded as
-  *thresholds* by the table above. Its **heap** rows are not superseded by
-  anything here — this entry measures no heap.
+- **rf2-2rtt6.4's page and tree were not on main when this was measured** (PR
+  #7265 was still open; it has since merged, and this entry was rebased onto it
+  rather than re-measured — both records keep their own producing SHAs). Its
+  clock rows remain sound as ratios and are superseded as *thresholds* by the
+  table above; [its page](p0-uix-on-subs-frontier-arm.md) is marked accordingly
+  rather than rewritten. Its **heap** rows are not superseded by anything here —
+  this entry measures no heap, and retained bytes per boundary is a property of
+  the boundary rather than of the page.
 - **The per-page accumulation is still unexplained.** One row per page makes it
   harmless to these figures; it does not make it fixed.

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -1,0 +1,392 @@
+# P0 — the converged witness set, and the red-zones re-derived on it
+
+**The P0 clock table now describes one set of pages.** It did not before. This
+page re-measures the frontier arm — UIx reading re-frame2 subscriptions — on
+[rf2-2rtt6.2's witnesses](p0-reagent-on-subs-baseline.md), so that the ship
+bar's rows and the red-zone thresholds a candidate is judged against can be
+read down one column.
+
+Bead **rf2-a4x1o**. The rows are appended to the operator-owned standard bead
+**rf2-2rtt6.1**; only the operator amends the bar, the budgets, the kill
+criteria or the red-zones. Nothing here amends any of them.
+
+## The extent of the mismatch, measured rather than feared
+
+rf2-2rtt6.4 said on its own page that its witnesses did not match
+rf2-2rtt6.2's, and that its **U-broad** row was the closest correspondence.
+That is right as far as it goes. Setting the two arms' declarations beside each
+other gives the full extent:
+
+| rf2-2rtt6.2 row | rf2-2rtt6.4 row | comparable? |
+|---|---|---|
+| **M1 mount** — 901 el, 300 boundaries, `[:p0/cell i]`, `li > span + span` | **W1 mount** — 1,203 el, 300 boundaries, `[:p0/row i]`, `li > img + span + em` with a style map and a `data-*` passthrough | **No.** Same boundary count and the same *kind* of sub graph, but 33% more elements and four per row against three. Markup density is exactly what a clock ratio is sensitive to. |
+| **M2 mount** — 51 el, 12 fields, `[:p0/cell i]` | **W3 mount** — 51 el, 12 fields, `[:p0/field i]` | **Nearly.** Identical element count and identical markup skeleton (`div > label + input + p`); the class on the form differs and nothing else does. Two real differences remain: the sub's *value* is a scalar on one side and a `{:value :error}` map on the other, and the two rows are graded differently — see below. |
+| **bulk broad** — the 901-el M1 page, 300 boundaries, one commit all read, `[:p0/cell i]`, written with `frame/replace-app-db!` | **U-broad** — a 301-el grid, 300 boundaries, one commit all read, `[:p0/cell i]`, written with `dispatch-sync` | **No, but closest.** Boundary count and sub graph match, as rf2-2rtt6.4 said. Markup density differs by 3× and the write path differs by an event pipeline. |
+| — | **U-narrow** | **No counterpart at all.** rf2-2rtt6.2 has no narrow row. |
+| — | heap: **list** and **grid** | A different axis; see *What did not need re-running*. |
+
+**And one mismatch that is not about witnesses at all.** rf2-2rtt6.2 grades its
+51-element form row **diagnostic** and says explicitly that it *must not be
+quoted against the bar*, because at one mount a sample it sits within three to
+six of Chrome's 100 µs quanta. rf2-2rtt6.4 batched eight mounts to a sample,
+lifted the same-sized witness clear of the clamp, and published its form row as
+a **threshold** — `0.893×`, disjoint from 1.0. So the table asked a candidate's
+form row to be judged red or not red against a threshold whose bar-row
+counterpart is, by the denominator arm's own ruling, unquotable. That is an
+internal inconsistency independent of page shape, and it is resolved here by
+grading the converged form row **diagnostic**, like its bar row.
+
+**So: one arm needed re-running, not two, and not none.** The clock axis was
+genuinely incomparable and is re-measured below. The heap axis was not.
+
+## What did not need re-running, and why
+
+Retained heap. The red-zones on that axis already rest on **two independent
+witness families measured by two independent instruments**, and they agree:
+
+| source | witness | UIx ÷ Reagent, exclusive retained per boundary |
+|---|---|---|
+| rf2-2rtt6.4 | list, 1,203-el page, 300 boundaries | **2.262×** [2.196 – 2.335] |
+| rf2-2rtt6.4 | grid, 301-el page, 300 boundaries | **2.254×** [2.217 – 2.288] |
+| [rf2-2rtt6.5](reads-per-boundary-heap-ladder.md) | 1,200 boundaries × 1 read | **2.435×** (3,811 B ÷ 1,565 B above a component-free React floor) |
+
+Those three shapes differ in markup density by 4× and in boundary count by 4×,
+and the answers sit within 8% of each other. **Retained bytes per subscribing
+boundary is a property of the boundary.** The clock is not: a page's element
+count decides what fraction of the measured window is React's own work, which
+is precisely the term that moves a substrate ratio toward or away from 1.0.
+
+That asymmetry is the reason exactly one arm is re-run here, and it is stated as
+a claim the operator can reject rather than assumed. The three figures come from
+two different instruments and are not a replication in the strict sense; what
+they are is three independent shapes agreeing on an axis where the clock's four
+rows do not.
+
+## Which witness set, and why that one
+
+**rf2-2rtt6.2's.** Four reasons, in order of weight:
+
+1. **The bar's denominator defines the witness set by construction.**
+   [HD-012](../decisions.md) states the ship number as *mount and bulk view-work
+   ≤ 1.0× Reagent, like-for-like*. The red-zone is a second threshold layered
+   onto the same rows — a rule about where a candidate sits relative to UIx — so
+   it must be derived on the pages the denominator lives on, not the reverse.
+2. **rf2-2rtt6.2 is on main and owns the measurement lane.**
+   [HD-017](../decisions.md) gives `:hicasso-bench` and its driver to that arm;
+   rf2-2rtt6.4's tree rides `:freehand-release`'s compiler settings through a
+   `--config-merge` precisely because the lane had not landed when it was built.
+   Running the frontier arm on the lane retires that workaround, and this entry
+   touches no build id and no `implementation/shadow-cljs.edn`.
+3. **rf2-2rtt6.4 nominated it.** Its *Open items* names rf2-2rtt6.2's set as the
+   convergence target.
+4. **rf2-2rtt6.2's witnesses already carry the control and the lower bound.**
+   `:ctl-2x` is an in-plan positive control at exactly twice the boundaries, and
+   the published `:reagent-ratom` arm is a labelled lower bound on the same page.
+
+## Provenance
+
+| | |
+|---|---|
+| **Producing commit** | `44900cd4fd35815b3e2462ae7752242efcb296b9` |
+| **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` |
+| **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium via Playwright), Windows 11 x64, sibling agents live on the box |
+| **Build** | `:hicasso-bench` — `:browser`, `:advanced`, `goog.DEBUG false`. **No new build id; `implementation/shadow-cljs.edn` untouched** |
+| **Adapters** | `:rf.adapter/reagent` and `:rf.adapter/uix`, one per segment. Reagent 2.0.1 · UIx 1.4.4 · React 19.2.0 |
+| **Schedule** | 5 rounds × 2 segments × (8 warm-up + 12 samples) per arm; three arms interleaved at the sample level, order rotating **and reflecting** on the sample index; segment order alternating with the round; **one row per page** |
+| **Arm-order guard** | **reportable on every row**, both factors, no refusal. Self-test 8/8 before anything was measured; driver exit **0** |
+| **Canonical-DOM parity** | clean under `:advanced` in both segments **and across the seam**, every row — `{:problems [] :ok? true}` |
+| **Verification** | **0 unverified of 2,460** — 600 M1 mounts + 600 M2 mounts + 630 broad writes + 630 narrow writes, each read back out of the DOM inside its own window |
+
+The reproduction command was run **at this commit, on a clean working tree**,
+and the figures below are that run's. A second, independent five-round run of
+the identical instrument is published beside them; where the two disagree, the
+page says so rather than picking one.
+
+All bar numbers are browser numbers. No JVM or Node figure appears on this page.
+
+## The arms, and the seam
+
+| arm | what it is | role |
+|---|---|---|
+| `:floor` | the same DOM hand-built with `react/createElement` — no substrate, no boundary, no subscription | the **calibrator**, in *both* segments, and the thing that makes a cross-segment ratio legitimate |
+| `:reagent-subs` | `reg-view` boundaries reading `@(rf/subscribe [:p0/cell i])`, `rf/frame-provider` at the root, `reagent.dom.client` for the mount | **the denominator** |
+| `:uix-subs` | `defui` boundaries reading `(use-subscribe [:p0/cell i])`, `frame-provider` at the root, `uix.dom` for the mount | **the frontier** |
+| `:ctl-2x` | the floor at exactly twice the boundaries | the **positive control**, predicted before the run, measured *inside* the interleave |
+
+Neither substrate arm is hand-optimised: no `set-hiccup-emitter!` on the UIx
+side (that would measure a hiccup interpreter, not UIx), no `use-memo` around
+subscription args, no prop threading in place of a read. The markup is
+rf2-2rtt6.2's markup on both sides, and the canonical-DOM gate is what proves
+it — attribute names sorted, inside each segment and across the seam.
+
+**Three arms a segment, never two.** rf2-ouwh8 records that `slot-order` rotates
+and then reflects, and at k=2 those cancel: `[0 1]` rotates to `[1 0]` and
+reflects back to `[0 1]`, at every sample index, for ever, so a two-arm plan
+runs in one order and *both orders* is a claim it cannot support. Keeping
+`:ctl-2x` inside the interleave — which is where rf2-2rtt6.2 puts it — means
+this entry never forms a two-arm plan. The property is **asserted at boot**, in
+both directions (degenerate at 2, varied at 3), and the run refuses to measure
+if either assertion fails.
+
+**`install-adapter!` is once per process** (Spec 006 §Single adapter per
+process), so each round runs two segments — destroy the adapter, install the
+other, re-register, re-seed — with the floor in both. The floor holds no
+re-frame state and is untouched by which adapter is installed, so a
+UIx-over-Reagent figure is a ratio of two floor-normalised ratios and the seam
+cancels. **That cancellation is published, not assumed:**
+
+| row | floor(UIx segment) ÷ floor(Reagent segment), per round | verdict |
+|---|---|---|
+| mount M1 | 0.900 · 1.056 · 1.000 · 0.938 · 1.000 | straddles 1.0 |
+| mount M2 | 0.800 · 1.000 · 1.167 · 0.875 · 1.000 | straddles 1.0 |
+| bulk broad | 0.625 · 1.000 · 1.200 · 0.667 · 1.200 | straddles 1.0 |
+| bulk narrow | 1.000 · 1.000 · 1.000 · 1.200 · 1.000 | straddles 1.0 |
+
+The seam is indistinguishable from unity on every row — a materially quieter
+seam than the one rf2-2rtt6.4 published, which moved by up to 1.8×.
+**A single-segment absolute millisecond from this page is still not a quotable
+figure.**
+
+## RED-ZONE — clock, on rf2-2rtt6.2's witnesses
+
+**UIx-on-subs ÷ Reagent-on-subs**, both floor-normalised in the same round and
+the same segment. Ranges are min–max across the five rounds. A range that
+includes 1.0 means the two are **indistinguishable** and is reported as such
+rather than as a winner.
+
+| witness | **threshold (mean)** | range | per round | verdict |
+|---|---|---|---|---|
+| **M1 mount** — 901 el, 300 boundaries | **1.2301×** | 1.1099 – 1.3538 | 1.3065 · 1.1417 · 1.2388 · 1.1099 · 1.3538 | **UIx slower**, disjoint from 1.0 |
+| **M2 mount** — 51 el, 12 fields · *diagnostic* | 1.0539× | 0.8572 – 1.4286 | 1.4286 · 0.8572 · 0.8572 · 1.0550 · 1.0714 | **straddles 1.0 — indistinguishable** |
+| **bulk broad** — one commit all 300 read | **0.6239×** | 0.4701 – 0.7857 | 0.7172 · 0.6046 · 0.5417 · 0.7857 · 0.4701 | **UIx faster**, disjoint from 1.0 |
+| **bulk narrow** — one commit exactly one reads | 1.1556× | 1.0417 – 1.2500 | 1.1111 · 1.2500 · 1.2500 · 1.0417 · 1.1250 | UIx slower — **but see the stability note** |
+
+Both arms against the floor, for context:
+
+| witness | `reagent-subs ÷ floor` | `uix-subs ÷ floor` |
+|---|---|---|
+| M1 mount | 4.352× [4.063 – 4.625] | 5.343× [4.947 – 5.944] |
+| M2 mount | 2.102× [1.625 – 2.800] | 2.261× [1.714 – 4.000] |
+| bulk broad | 7.443× [7.000 – 8.000] | 4.607× [3.667 – 5.500] |
+| bulk narrow | 1.820× [1.500 – 2.000] | 2.117× [1.667 – 2.500] |
+
+### The denominator reproduces rf2-2rtt6.2
+
+The Reagent arm here is a second implementation of rf2-2rtt6.2's arm, written
+against the same witnesses in a different app namespace and run in a different
+schedule. Its `reagent-subs ÷ floor` ranges **overlap that arm's published
+ranges on all three shared rows**:
+
+| row | rf2-2rtt6.2, published | here | overlap |
+|---|---|---|---|
+| M1 mount | 3.899× [3.447 – 4.300] | 4.352× [4.063 – 4.625] | yes, 4.063 – 4.300 |
+| M2 mount | 1.874× [1.750 – 2.050] | 2.102× [1.625 – 2.800] | yes |
+| bulk broad | 7.064× [6.200 – 7.700] | 7.443× [7.000 – 8.000] | yes, 7.000 – 7.700 |
+
+That is the check that says the convergence moved the *frontier* arm onto the
+denominator's pages without moving the denominator.
+
+### Two estimators, published together
+
+Every threshold above divides one floor-normalised ratio by another, so the two
+segments' floors enter it. On the bulk rows a floor sample is only two to four
+of Chrome's 100 µs quanta, which is coarse enough to be worth checking. The
+**raw** cross-segment estimator — `uix-subs` p50 over `reagent-subs` p50 in the
+same round, touching neither floor — is therefore reported beside it:
+
+| row | floor-normalised | raw cross-segment | agree? |
+|---|---|---|---|
+| M1 mount | 1.2301 [1.1099 – 1.3538] | 1.2028 [1.0405 – 1.3538] | yes — same verdict, 2% apart on the mean |
+| M2 mount | 1.0539 [0.8572 – 1.4286] | 0.9989 [0.8571 – 1.1429] | yes — both straddle |
+| bulk broad | 0.6239 [0.4701 – 0.7857] | 0.5582 [0.4483 – 0.6500] | yes — same verdict, both far from 1.0 |
+| bulk narrow | 1.1556 [1.0417 – 1.2500] | 1.1972 [1.1111 – 1.2500] | yes |
+
+The two estimators agree on the verdict of every row, which is the evidence that
+the floor normalisation is doing its job rather than injecting the quantisation
+it is exposed to.
+
+### Stability across runs — and the one row that is not stable
+
+The identical instrument was run twice, five rounds each, minutes apart:
+
+| row | run at the published commit | independent second run | stable? |
+|---|---|---|---|
+| M1 mount | **1.2301** [1.110 – 1.354] disjoint | 1.2103 [1.021 – 1.316] disjoint | **yes** |
+| M2 mount | 1.0539 [0.857 – 1.429] straddles | 1.1000 [1.000 – 1.458] straddles | **yes** |
+| bulk broad | **0.6239** [0.470 – 0.786] disjoint | 0.5682 [0.444 – 0.691] disjoint | **yes** |
+| bulk narrow | 1.1556 [1.042 – 1.250] disjoint | 1.0405 [0.750 – 1.333] **straddles** | **NO** |
+
+**The narrow row does not settle.** Four estimates of it (two runs × two
+estimators) read 1.0405, 1.1556, 1.1738, 1.1972 — the *direction* is the same
+every time and UIx is the slower arm — but whether the range clears 1.0 depends
+on the run, and one of the four has a minimum of exactly `1.0000`, which is the
+clamp's signature and not a tie. Every leg of that row is three to five quanta.
+**The narrow row is therefore published as clamp-limited and NOT as a resolved
+threshold**: read it as *UIx is somewhere between indistinguishable and ~1.2×
+slower on a narrow write*, and do not judge a candidate red on a margin finer
+than that. Lifting it would need a bigger sample per window — batching k writes
+into one clock window, as rf2-2rtt6.4 did for its own clamped rows — which is a
+change to the instrument, not to the witness, and is left as a stated open item
+rather than made silently.
+
+### Clock resolution, per row
+
+Stated rather than smoothed. One sample, p50 milliseconds, expressed in Chrome's
+100 µs quanta:
+
+| row | floor | `reagent-subs` | `uix-subs` | usable? |
+|---|---|---|---|---|
+| M1 mount | 8 – 10 | 33 – 46 | 39 – 54 | yes |
+| M2 mount | 2 – 4 | 6 – 7 | 6 – 8 | **diagnostic only** |
+| bulk broad | 2.5 – 4 | 20 – 29 | 11 – 13 | yes on the substrate legs; the floor is coarse, which is why the raw estimator is published beside the normalised one |
+| bulk narrow | 2 – 3 | 4 – 4.5 | 4.5 – 5 | **clamp-limited** — see above |
+
+## What the convergence changed
+
+Three of rf2-2rtt6.4's four clock verdicts do not survive the move onto
+rf2-2rtt6.2's witnesses. That is the answer to *how much did the mismatch
+matter*, and it is not small.
+
+| question | rf2-2rtt6.4, on its own witnesses | converged, on rf2-2rtt6.2's | change |
+|---|---|---|---|
+| large-list mount | W1: **1.057×** [0.907 – 1.156] — indistinguishable | M1: **1.2301×** [1.110 – 1.354] — UIx slower, disjoint | **verdict flips**: an indistinguishable row becomes a resolved one |
+| ordinary-form mount | W3: **0.893×** [0.843 – 0.956] — UIx faster, disjoint, published as a threshold | M2: **1.0539×** [0.857 – 1.429] — indistinguishable, graded diagnostic | **verdict flips**, and so does the grade |
+| broad commit | U-broad: **0.838×** [0.760 – 0.953] — UIx faster | bulk broad: **0.6239×** [0.470 – 0.786] — UIx faster | same direction, **much larger margin** |
+| narrow commit | U-narrow: **1.536×** [1.226 – 1.876] — UIx slower, disjoint | bulk narrow: 1.1556× / 1.0405× — direction the same, magnitude far smaller, **does not stably resolve** | **strength collapses** |
+
+None of this makes rf2-2rtt6.4 wrong. Each of its ratios is still a ratio
+between two arms measured in one run, on one page, through one sub graph, in
+both orders — which is exactly what it claimed. What the table above shows is
+that a clock ratio *on this axis* moves by more than the effects being measured
+when the page changes, so the thresholds and the bar rows have to come off the
+same page or the comparison means nothing.
+
+The mechanism is visible in the two extremes. The broad row's margin widens on
+the 901-element page because more of the window is markup construction, where
+UIx's compile-time `$` beats Reagent's runtime hiccup walk; the narrow row's
+margin narrows because on the bigger page the floor's top-down re-render — the
+thing a narrow write is compared against — is three times as much work.
+
+## Where the time goes, per leg
+
+p50 milliseconds, split at the microtask boundary. This is the same
+decomposition rf2-2rtt6.4 published on its narrow row, reproduced on the
+converged witness:
+
+| row / arm | write | microtask gap | forced drain |
+|---|---|---|---|
+| broad / `reagent-subs` | 0.0 | 0.0 | **2.10** |
+| broad / `uix-subs` | **0.40** | **0.80** | 0.0 |
+| narrow / `reagent-subs` | 0.0 | 0.0 | **0.40** |
+| narrow / `uix-subs` | **0.40** | 0.10 | 0.0 |
+| both / `floor` | 0.0 | 0.0 | 0.20 – 0.30 |
+
+The two substrates put their cost in different legs and the split is total. On
+Reagent everything is the drain — `reagent.core/flush`, the reaction walk. On
+UIx nothing is the drain: the cost is in the **write leg and the microtask that
+follows it**, before React is involved at all — the `useSyncExternalStore`
+notification fanning out across 300 subscribed boundaries. On the narrow row the
+UIx write leg *alone* (0.40 ms) is the whole of Reagent's window (0.40 ms) for
+the same operation, which is the structural claim a native view layer has on
+that row, and it is a claim about the React-hook spine's invalidation rather
+than about UIx's rendering.
+
+## The positive controls
+
+Predicted from the element count, written down before the run, published every
+run whether they pass or not. Slack 25%, and it is generous on purpose: the
+claim a clock control certifies is *the instrument has signal*, not *the model
+is exact*. (The ±0.001% standard this wave set belongs to the **heap** control,
+where the predicted quantity is a known retained byte count; no clock control
+can honestly be held to it.)
+
+| row | predicted | Reagent segment | UIx segment | basis |
+|---|---|---|---|---|
+| M1 mount | 1.9989× | 1.863× [1.750 – 2.000] ✅ | 1.979× [1.895 – 2.000] ✅ | 1801 / 901 elements |
+| M2 mount | 1.9412× | 1.803× [1.600 – 2.000] ✅ | 1.731× [1.333 – 2.000] ✅ | 99 / 51 elements |
+| bulk broad | 1.9989× | 1.817× [1.667 – 2.000] ✅ | 1.923× [1.667 – 2.250] ✅ | 1801 / 901 elements |
+| bulk narrow | 1.9989× | 2.013× [1.667 – 2.400] ✅ | 1.867× [1.667 – 2.000] ✅ | 1801 / 901 elements |
+
+Eight controls, eight passes, and seven of the eight sit **below** their
+prediction — the direction a fixed per-root term predicts, and the same
+direction rf2-2rtt6.2 and rf2-2rtt6.4 both recorded.
+
+## The guard refused this arm, twice, and the arm was repaired
+
+The first cut ran all four rows in one page. **The arm-order guard refused it,
+exit 2**, on two independent faults. Both were the arm's; the tolerance was not
+touched.
+
+**1. Phase — the page degraded as it ran.** `M1/uix-subs/floor` — an arm that
+hand-builds React elements and *cannot change* — read
+
+| arm | last third ÷ first third | ranges |
+|---|---|---|
+| `M1/uix-subs/floor` | **2.1739×** | **disjoint** |
+| `M1/reagent-subs/floor` | 2.0909× | overlapping |
+| `M1/reagent-subs/ctl-2x` | 2.0652× | overlapping |
+| `M1/uix-subs/ctl-2x` | 1.9608× | overlapping |
+| `M1/uix-subs/uix-subs` | 1.4086× | overlapping |
+
+Everything on the page climbed together; the floor climbed hardest. This is the
+accumulation rf2-2rtt6.4 recorded and could not explain — proportional to
+mounts, surviving a forced major collection, never reaching the document — whose
+repair there was *one round per page*. **The repair here is one ROW per page**,
+which cuts a page's measured work from about 2,460 operations to about 600 and
+is the smaller of the two changes. It was enough: every arm of every row is
+`clean` on both factors in both subsequent runs, with round-per-page held in
+reserve.
+
+**2. Predecessor — the collector mislabelled adjacency.**
+`narrow/reagent-subs/ctl-2x` was refused on a **two-sample stratum labelled with
+an arm that ran in a different row** (`M1/reagent-subs/reagent-subs`, 3.6250×,
+ranges disjoint). `lane/collect!` advances the `:previous` pointer only for
+*recorded* samples, so the first recorded sample after a warm-up block carries
+whatever ran twenty operations earlier. rf2-2rtt6.4 met the same class from the
+other side, where the untagged samples became a `<none>` stratum reading 1.35×
+its siblings. **Two repairs, both in the arm:** the warm-up now advances the
+pointer without banking a sample, so every recorded sample carries its real
+predecessor; and one row per page leaves no cross-row adjacency to mislabel.
+
+A refusal is not a broken script. It is the instrument saying that a figure it
+produced depends on where in the plan it was measured — and every figure the
+first cut produced looked entirely plausible.
+
+## Method
+
+- **Both orders.** Arms rotate *and reflect* on the sample index; segment order
+  alternates with the round. Three arms a segment, never two, because at two the
+  rotation and the reflection cancel (rf2-ouwh8) — asserted at boot in both
+  directions, and the run refuses to measure if the assertion fails.
+- **Position before adjacency.** Every sample carries its position in the whole
+  page and the guard partitions on first-third against last-third as well as on
+  predecessor. Warm-up matters more than interleaving, and warm-up samples are
+  discarded but still count as predecessors.
+- **Ranges, never a mean alone.** Overlapping ranges mean indistinguishable and
+  the page says so.
+- **Every measured mount and every measured write is read back out of the DOM
+  inside its own window**, and the count is published as `N unverified of M`.
+  Mounts are checked against a *written* element count (901, 51) as well as
+  their content, so the gate can answer false for an arm that rendered nothing.
+- **A positive control with predicted vs measured, every run, per segment.**
+- **Canonical-DOM parity before any clock**, inside each segment and across the
+  seam — the two substrate arms are compared with each other directly, not
+  merely each with its own floor.
+
+## Open items — stated, not swept up
+
+- **The narrow row is clamp-limited and does not stably resolve.** Lifting it
+  needs k writes to a clock window. That is a change to the instrument and not
+  to the witness, so it can be made without disturbing the convergence — but it
+  is a change, and rf2-2rtt6.2 has a recorded refusal from batching *mounts*, so
+  the guard must be re-run against it rather than assumed.
+- **The 51-element form row cannot be lifted the same way here.** rf2-2rtt6.2
+  tried batching mounts on this exact witness and the guard refused the whole
+  run (exit 2, all four arms 3.2×–5.4× last-third over first-third, ranges
+  disjoint). This entry does not re-litigate that; the row stays diagnostic.
+- **rf2-2rtt6.4's page and tree are not on main** (PR #7265 was open when this
+  was measured). Its clock rows remain sound as ratios and are superseded as
+  *thresholds* by the table above. Its **heap** rows are not superseded by
+  anything here — this entry measures no heap.
+- **The per-page accumulation is still unexplained.** One row per page makes it
+  harmless to these figures; it does not make it fixed.

--- a/docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md
+++ b/docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md
@@ -17,6 +17,25 @@ the bar and still be red. That tension is intended.
 Bead **rf2-2rtt6.4**. Rows are appended to rf2-2rtt6.1; only the operator amends
 the bar, the budgets, the kill criteria, or these thresholds.
 
+> **Superseded on the clock axis only — rf2-a4x1o, PR #7268.** The clock
+> thresholds in the first red-zone table below are superseded *as thresholds* by
+> [the converged witness set](p0-converged-witness-set.md), which re-derived them
+> on the bar denominator's own witnesses and moved three of the four verdicts.
+> They remain sound *as ratios* — each is still two arms measured against each
+> other in one run, on one page, through one sub graph. But the bar's denominator
+> is Reagent-on-subs, so the denominator's witness set defines the comparison by
+> construction, and a threshold measured on a different witness is a threshold on
+> a different question. This page's own *Open items* anticipated the move; quote
+> the converged table.
+>
+> **The retained-heap table is NOT superseded, and stands as published.** It was
+> deliberately not re-run: three shapes spanning a 4× range in markup density
+> agree within 8% — this page's list at 2.262×, its grid at 2.254×, and the heap
+> ladder's 2.435× — because retained bytes per subscribing boundary is a property
+> of *the boundary*. The clock is not, since element count decides what fraction
+> of the window is React's own work. That asymmetry is why the clock rows had to
+> move onto the denominator's pages and these did not.
+
 ## Provenance
 
 | | |
@@ -94,6 +113,9 @@ measuring the hazard.
 
 ## RED-ZONE — clock
 
+**Superseded as thresholds** by [the converged witness set](p0-converged-witness-set.md);
+retained here as the ratios this arm measured, on this arm's witnesses.
+
 **UIx-on-subs ÷ Reagent-on-subs**, both floor-normalised in the same round.
 Ranges are min–max across the five rounds. A range that includes 1.0 means the
 two are **indistinguishable** and is reported as such rather than as a winner.
@@ -126,6 +148,10 @@ statement about the React-hook spine's invalidation, not about UIx's rendering,
 and it is the row a native view layer has the clearest structural claim on.
 
 ## RED-ZONE — retained heap
+
+**Not superseded.** These are the operative retained-heap thresholds; the
+convergence re-ran the clock axis only, for the reason given at the top of the
+page.
 
 Retention, never allocation: V8's sampling heap profiler drops the samples of
 collected objects, and on the predecessor's instrument the same 80,000 objects
@@ -264,6 +290,12 @@ precise wrong number first. They are recorded because the next arm will meet the
   closest existing correspondence is this page's **U-broad** (300 boundaries,
   one commit all read, `[:p0/cell i]`), which matches that arm's bulk row in
   boundary count and sub graph and differs only in markup density.
+  **Settled — this happened.** rf2-a4x1o re-pointed the UIx arm at rf2-2rtt6.2's
+  witnesses and re-derived the clock red-zones there; three of the four verdicts
+  moved, and U-broad's margin widened from 0.838× to 0.624×. See
+  [the converged witness set](p0-converged-witness-set.md). The clock rows above
+  are superseded as thresholds by that page; the heap rows are not, and were
+  deliberately not re-run.
 - **This arm rides `:freehand-release` for its compiler settings** because the
   epic's sequencing law gives `implementation/shadow-cljs.edn` to rf2-2rtt6.2 and
   that arm had not merged. `P0_BUILD` points the driver at another build id;

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
@@ -83,9 +83,25 @@
   a reader can see how far it moves and how much less the derived ratio
   moves.
 
-  Segment order alternates with the round, and so does witness order
-  within a segment: rf2-2rtt6.4 recorded a fixed witness order making
-  `second` a permanent property of one witness, with the guard refusing.
+  Segment order alternates with the round, so the cross-segment figure is
+  a both-orders result rather than a single-order one however many rounds
+  it averages.
+
+  ## One row per page
+
+  The first cut ran all four rows in one page and THE ARM-ORDER GUARD
+  REFUSED IT (exit 2) on two independent faults, both the arm's:
+  `M1/uix-subs/floor` — an arm that hand-builds React elements and cannot
+  change — read LAST-THIRD 2.1739x FIRST-THIRD with disjoint ranges while
+  every other arm on the page climbed with it, which is the accumulation
+  rf2-2rtt6.4 recorded and repaired with one round per page; and
+  `narrow/reagent-subs/ctl-2x` was refused on a two-sample stratum
+  labelled with an arm from a DIFFERENT ROW, an artefact of the shared
+  collector advancing its predecessor pointer only for recorded samples.
+  The repairs are one ROW per page (a quarter of the work in a page, and
+  no cross-row adjacency to mislabel) and [[mark-predecessor!]] (the
+  warm-up advances the pointer without banking a sample, so every recorded
+  sample carries its real predecessor). The tolerance was not touched.
 
   ## What this entry does NOT measure
 
@@ -133,6 +149,27 @@
 
 (defonce ^:private gen (atom 1000))
 (defn- next-gen! [] (swap! gen inc))
+
+(defn- mark-predecessor!
+  "Advance the sample collector's `:previous` pointer WITHOUT banking a
+  sample. Warm-up samples call this.
+
+  `lane/collect!` both banks a sample and advances the pointer, so a
+  harness that skips it during warm-up leaves the first RECORDED sample of
+  a block tagged with whatever ran before the warm-up — an arm that has
+  not touched the site for twenty operations. The first cut of this entry
+  published exactly that and the guard refused it: `narrow/reagent-subs/
+  ctl-2x` was contaminated by a two-sample stratum labelled
+  `M1/reagent-subs/reagent-subs`, an arm from a different ROW. rf2-2rtt6.4
+  met the same class from the other side, where the untagged samples
+  became a `<none>` stratum reading 1.35x its siblings.
+
+  A predecessor label that names something that did not run immediately
+  before is not a weaker fact than a real one; it is a different fact
+  wearing its clothes."
+  [coll id]
+  (swap! coll assoc :prev id)
+  nil)
 
 ;; ---------------------------------------------------------------------------
 ;; Segments
@@ -293,8 +330,7 @@
                  (floor-mount-arm :ctl-2x v/m2-floor
                                   (fn [{:keys [n]}] (zeros (* 2 n))) true)])}])
 
-(defn- witness-order [r]
-  (if (even? r) mount-witnesses (vec (rseq (vec mount-witnesses)))))
+(defn- witness-named [id] (first (filter #(= id (:id %)) mount-witnesses)))
 
 ;; ---------------------------------------------------------------------------
 ;; Bulk arms
@@ -431,9 +467,13 @@
               (swap! t (fn [{:keys [of bad]}]
                          {:of (inc of) :bad (if ok? bad (inc bad))}))))
           (doseq [m mounts] (lane/release! m))
-          (when (>= s (:warmup mount-sampling))
-            (lane/collect! coll (str (name id) "/" (name segment-id) "/" (name (:id arm))) ms)
-            (swap! acc update (:id arm) conj ms)))))
+          (let [label (str (name id) "/" (name segment-id) "/" (name (:id arm)))]
+            (if (>= s (:warmup mount-sampling))
+              (do (lane/collect! coll label ms)
+                  (swap! acc update (:id arm) conj ms))
+              ;; A warm-up sample is DISCARDED but it still ran, so it is
+              ;; still the next sample's predecessor.
+              (mark-predecessor! coll label))))))
     @acc))
 
 ;; ---------------------------------------------------------------------------
@@ -480,19 +520,18 @@
     (lane/chain {:readings acc0}
                 (for [s (range total) j (lane/slot-order n s)] [s j])
                 (fn [acc [s j]]
-                  (let [mnt (nth mounts j)
-                        id  (:id (:arm mnt))]
+                  (let [mnt   (nth mounts j)
+                        id    (:id (:arm mnt))
+                        label (str (name kind) "/" (name segment-id) "/" (name id))]
                     (-> (bulk-write! t mnt kind s)
                         (.then (fn [{:keys [ms write-ms gap-ms force-ms]}]
                                  (if (>= s (:warmup bulk-sampling))
-                                   (do (lane/collect! coll
-                                                      (str (name kind) "/" (name segment-id)
-                                                           "/" (name id))
-                                                      ms)
+                                   (do (lane/collect! coll label ms)
                                        (swap! legs update [kind segment-id id] (fnil conj [])
                                               {:write write-ms :gap gap-ms :force force-ms})
                                        (update-in acc [:readings id] conj ms))
-                                   acc)))))))))
+                                   (do (mark-predecessor! coll label)
+                                       acc))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Aggregation
@@ -571,45 +610,39 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- parity-of-segment!
-  [segment-id]
-  (reduce
-    (fn [acc {:keys [id props elements arms-for]}]
-      (let [{:keys [mounts agree? counts disagree reference]} (lane/parity (arms-for segment-id) props)]
-        (try
-          (-> acc
-              (assoc-in [:reference id] reference)
-              (update :problems
-                      (fn [problems]
-                        (cond-> problems
-                          (not agree?)
-                          (conj {:segment segment-id :witness id
-                                 :problem :canonical-dom-disagreement :arms disagree})
+  [{:keys [id props elements arms-for]} segment-id]
+  (let [{:keys [mounts agree? counts disagree reference]}
+        (lane/parity (arms-for segment-id) props)]
+    (try
+      {:reference reference
+       :problems  (cond-> []
+                    (not agree?)
+                    (conj {:segment segment-id :witness id
+                           :problem :canonical-dom-disagreement :arms disagree})
 
-                          (not (every? #(= elements %) (vals counts)))
-                          (conj {:segment segment-id :witness id :problem :element-count
-                                 :expected elements :got counts})))))
-          (finally (doseq [m mounts] (lane/release! m))))))
-    {:problems [] :reference {}}
-    mount-witnesses))
+                    (not (every? #(= elements %) (vals counts)))
+                    (conj {:segment segment-id :witness id :problem :element-count
+                           :expected elements :got counts}))}
+      (finally (doseq [m mounts] (lane/release! m))))))
 
 (defn- parity!
-  "Both segments' parity, plus the CROSS-segment check.
+  "Both segments' parity for this page's witness, plus the CROSS-segment
+  check.
 
   Within a segment the floor and the substrate arm must build the same
   page. Across the seam the two SUBSTRATE arms must build the same page as
   each other — which is the comparison the red-zone actually makes, and it
   is checked directly rather than inferred from each segment agreeing with
   its own floor."
-  []
+  [witness]
   (let [by-seg (reduce (fn [acc {:keys [id] :as segment}]
                          (enter-segment! segment)
-                         (assoc acc id (parity-of-segment! id)))
+                         (assoc acc id (parity-of-segment! witness id)))
                        {}
                        segments)
-        cross  (for [{:keys [id]} mount-witnesses
-                     :when (not= (get-in by-seg [:reagent-subs :reference id])
-                                 (get-in by-seg [:uix-subs :reference id]))]
-                 {:problem :cross-segment-disagreement :witness id})]
+        cross  (when (not= (get-in by-seg [:reagent-subs :reference])
+                           (get-in by-seg [:uix-subs :reference]))
+                 [{:problem :cross-segment-disagreement :witness (:id witness)}])]
     {:problems (into (vec (mapcat (comp :problems val) by-seg)) cross)}))
 
 ;; ---------------------------------------------------------------------------
@@ -634,35 +667,64 @@
 ;; The run
 ;; ---------------------------------------------------------------------------
 
-(defn- bulk-kinds [r] (if (even? r) [:broad :narrow] [:narrow :broad]))
+(def ^:private bulk-control
+  {:predicted (/ (double (v/m1-elements (* 2 v/cells-n)))
+                 (double (v/m1-elements v/cells-n)))
+   :basis (str "element count: " (v/m1-elements (* 2 v/cells-n)) " / "
+               (v/m1-elements v/cells-n))})
+
+(def ^:private row-specs
+  "ONE ROW PER PAGE. The first cut ran all four in one page and the guard
+  refused it — the page degraded as it ran (`M1/uix-subs/floor`, an arm
+  that cannot change, read LAST-THIRD 2.1739x FIRST-THIRD with disjoint
+  ranges) and the shared collector manufactured cross-row predecessor
+  strata. One row per page cuts a page's measured work by about four and
+  removes cross-row adjacency by construction."
+  {:M1     {:kind :mount :witness :M1 :row :mount-M1 :grade :bar}
+   :M2     {:kind :mount :witness :M2 :row :mount-M2 :grade :diagnostic}
+   :broad  {:kind :bulk  :witness :M1 :row :bulk-broad :grade :bar
+            :doc (str "one commit that all " v/cells-n " sub-reading boundaries read, on "
+                      "rf2-2rtt6.2's M1 page — the make-or-break row")
+            :control bulk-control}
+   :narrow {:kind :bulk  :witness :M1 :row :bulk-narrow :grade :bar
+            :doc (str "one commit that exactly ONE of " v/cells-n
+                      " sub-reading boundaries reads — the localisation row")
+            :note (str "NEW ROW. rf2-2rtt6.2 has no narrow counterpart, so this is not a "
+                       "re-measurement of a published figure: it is rf2-2rtt6.4's U-narrow "
+                       "question asked on rf2-2rtt6.2's witness. The two numbers are NOT "
+                       "comparable with each other and neither supersedes the other; this "
+                       "one is the comparable one, because its page is the page every other "
+                       "row here uses.")
+            :control bulk-control}})
+
+(defn- query-row
+  "Which row this page runs. One row per page (see [[row-specs]]); the
+  driver loads the page once per row."
+  []
+  (let [s (or (some-> js/window .-location .-search) "")]
+    (or (some (fn [k] (when (re-find (re-pattern (str "row=" (name k))) s) k))
+              [:M1 :M2 :broad :narrow])
+        :M1)))
 
 (defn- run-round!
-  "One round: both segments, in this round's order; within each segment
-  both mount witnesses in this round's order, then the standing bulk
-  arms driven through both write kinds in this round's order.
-
-  Answers a promise of
-  `{:mount {witness-id {segment-id readings}} :bulk {kind {segment-id readings}}}`."
-  [r coll tallies legs]
+  "One round of THIS PAGE'S row: both segments, in this round's order.
+  Answers a promise of `{segment-id readings}`."
+  [{:keys [kind witness] :as _spec} row-key r coll t legs]
   (lane/chain
-    {:mount {} :bulk {}}
+    {}
     (segment-order r)
     (fn [acc {:keys [id] :as segment}]
       (enter-segment! segment)
-      (let [acc' (reduce (fn [a w]
-                           (assoc-in a [:mount (:id w) id]
-                                     (mount-round! coll (get tallies (:id w)) w id)))
-                         acc
-                         (witness-order r))
-            mounts (mount-bulk-arms! (bulk-arms id))]
-        (-> (lane/chain acc' (bulk-kinds r)
-                        (fn [a kind]
-                          (-> (seed-bulk! mounts (get tallies kind))
-                              (.then (fn [_] (bulk-round! mounts (get tallies kind)
-                                                          legs coll kind id)))
-                              (.then (fn [rd] (assoc-in a [:bulk kind id] (:readings rd)))))))
-            (.then (fn [a] (release-bulk-arms! mounts) a))
-            (.catch (fn [e] (release-bulk-arms! mounts) (throw e))))))))
+      (if (= kind :mount)
+        (js/Promise.resolve
+          (assoc acc id (mount-round! coll t (witness-named witness) id)))
+        (let [mounts (mount-bulk-arms! (bulk-arms id))]
+          (-> (seed-bulk! mounts t)
+              (.then (fn [_] (bulk-round! mounts t legs coll row-key id)))
+              (.then (fn [rd]
+                       (release-bulk-arms! mounts)
+                       (assoc acc id (:readings rd))))
+              (.catch (fn [e] (release-bulk-arms! mounts) (throw e)))))))))
 
 (defn- leg-summary [legs]
   (into {}
@@ -673,70 +735,43 @@
         legs))
 
 (defn- publish!
-  [slices tallies legs coll]
-  (let [m1 (row-record {:row :mount-M1 :grade :bar
-                        :doc (:doc (first mount-witnesses))
-                        :control (:control (first mount-witnesses))}
-                       (mapv #(get-in % [:mount :M1]) slices))
-        m2 (row-record {:row :mount-M2 :grade :diagnostic
-                        :doc (:doc (second mount-witnesses))
-                        :clock-note (:clock-note (second mount-witnesses))
-                        :control (:control (second mount-witnesses))}
-                       (mapv #(get-in % [:mount :M2]) slices))
-        bulk-control {:predicted (/ (double (v/m1-elements (* 2 v/cells-n)))
-                                    (double (v/m1-elements v/cells-n)))
-                      :basis (str "element count: " (v/m1-elements (* 2 v/cells-n)) " / "
-                                  (v/m1-elements v/cells-n))}
-        broad (row-record {:row :bulk-broad :grade :bar
-                           :doc (str "one commit that all " v/cells-n
-                                     " sub-reading boundaries read, on rf2-2rtt6.2's M1 "
-                                     "page — the make-or-break row")
-                           :control bulk-control}
-                          (mapv #(get-in % [:bulk :broad]) slices))
-        narrow (row-record {:row :bulk-narrow :grade :bar
-                            :doc (str "one commit that exactly ONE of " v/cells-n
-                                      " sub-reading boundaries reads — the localisation row")
-                            :note (str "NEW ROW. rf2-2rtt6.2 has no narrow counterpart, so "
-                                       "this is not a re-measurement of a published figure: "
-                                       "it is rf2-2rtt6.4's U-narrow question asked on "
-                                       "rf2-2rtt6.2's witness. The two numbers are NOT "
-                                       "comparable with each other and neither supersedes "
-                                       "the other; this one is the comparable one, because "
-                                       "its page is the page every other row here uses.")
-                            :control bulk-control}
-                           (mapv #(get-in % [:bulk :narrow]) slices))
-        rows [m1 m2 broad narrow]]
-    (doseq [[k {:keys [record]}] (map vector
-                                      ["mount-M1" "mount-M2" "bulk-broad" "bulk-narrow"]
-                                      rows)]
-      (lane/record! k record))
-    (lane/record! "verification"
-                  (into {} (map (fn [[k t]] [k (lane/tally-value t)])) tallies))
-    (lane/record! "write-legs" (leg-summary @legs))
-    (lane/record! "red-zones"
-                  {:axis :clock
+  [{:keys [kind witness row grade doc note control] :as _spec} row-key slices t legs coll]
+  (let [w   (witness-named witness)
+        {:keys [record controls]}
+        (row-record {:row row
+                     :grade grade
+                     :doc (or doc (:doc w))
+                     :clock-note (when (= kind :mount) (:clock-note w))
+                     :note note
+                     :control (or control (:control w))}
+                    slices)]
+    (lane/record! (name row) record)
+    (lane/record! "verification" {row-key (lane/tally-value t)})
+    (when (= kind :bulk) (lane/record! "write-legs" (leg-summary @legs)))
+    (lane/record! "red-zone"
+                  {:row row
+                   :axis :clock
                    :witness-set "rf2-2rtt6.2"
+                   :threshold (select-keys (:red-zone record)
+                                           [:mean :min :max :per-round :straddles-1?])
                    :rule (str "RULING 1 on rf2-2rtt6.1: the red-zone threshold IS the "
                               "measured UIx ratio for that witness family. A candidate row "
                               "worse than it is RED and needs an explicit operator waiver "
-                              "naming the dogfood benefit. Silence is not a pass. These "
-                              "SUPERSEDE the clock thresholds rf2-2rtt6.4 published on its "
-                              "own witnesses, which remain sound as ratios and are not "
-                              "comparable with the bar rows.")
-                   :thresholds
-                   (into {} (map (fn [[k {:keys [record]}]]
-                                   [k (select-keys (:red-zone record)
-                                                   [:mean :min :max :per-round :straddles-1?])]))
-                         (map vector ["mount-M1" "mount-M2" "bulk-broad" "bulk-narrow"] rows))})
-    (let [vd (lane/guard! (:samples @coll) "Hicasso P0 — converged witness set")]
+                              "naming the dogfood benefit. Silence is not a pass. This "
+                              "SUPERSEDES the clock threshold rf2-2rtt6.4 published on its "
+                              "own witnesses — that figure remains sound as a ratio and is "
+                              "simply not comparable with the bar rows.")})
+    (let [vd (lane/guard! (:samples @coll)
+                          (str "Hicasso P0 converged — " (name row)))]
       (lane/record! "arm-order-guard"
-                    {:tolerance (:tolerance vd)
+                    {:row row
+                     :tolerance (:tolerance vd)
                      :contaminated? (:contaminated? vd)
                      :unchecked? (:unchecked? vd)
                      :refuse? (:refuse? vd)
                      :arms (:arms vd)})
       (when (:refuse? vd) (set! (.-HICASSO_GUARD_REFUSED js/window) true)))
-    (when (some (complement :ok?) (mapcat :controls rows))
+    (when (some (complement :ok?) controls)
       (set! (.-HICASSO_CONTROL_FAILED js/window) true))
     nil))
 
@@ -765,28 +800,31 @@
           (lane/done!))
 
       :else
-      (let [{:keys [problems]} (parity!)]
+      (let [row-key (query-row)
+            spec    (get row-specs row-key)
+            w       (witness-named (:witness spec))
+            {:keys [problems]} (parity! w)]
+        (js/console.log (str ";; HICASSO row " (name row-key)))
         (lane/record! "parity"
-                      {:problems problems :ok? (empty? problems)
+                      {:row row-key :problems problems :ok? (empty? problems)
                        :note (str "canonical DOM with attribute names sorted, inside each "
-                                  "segment AND across the seam. Element counts are checked "
-                                  "against written arithmetic — 901 for M1, 51 for M2 — so "
-                                  "the gate can answer false for an arm that rendered "
-                                  "nothing.")})
+                                  "segment AND across the seam. The element count is checked "
+                                  "against written arithmetic — " (:elements w) " for "
+                                  (name (:id w)) " — so the gate can answer false for an arm "
+                                  "that rendered nothing.")})
         (if (seq problems)
           (do (lane/fail! (str "the arms do not build the same page under :advanced — "
                                (pr-str problems)))
               (lane/done!))
-          (let [coll    (lane/sample-collector)
-                tallies {:M1 (lane/tally) :M2 (lane/tally)
-                         :broad (lane/tally) :narrow (lane/tally)}
-                legs    (atom {})]
+          (let [coll (lane/sample-collector)
+                t    (lane/tally)
+                legs (atom {})]
             (-> (lane/chain [] (range rounds)
                             (fn [acc r]
-                              (-> (run-round! r coll tallies legs)
+                              (-> (run-round! spec row-key r coll t legs)
                                   (.then (fn [slice] (conj acc slice))))))
                 (.then (fn [slices]
-                         (publish! slices tallies legs coll)
+                         (publish! spec row-key slices t legs coll)
                          (lane/done!)
                          nil))
                 (.catch (fn [e]

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
@@ -1,0 +1,797 @@
+(ns re-frame.bench.hicasso.p0-converge-app
+  "THE CONVERGED P0 CLOCK TABLE — Reagent-on-subs AND UIx-on-subs on ONE
+  witness set, so the bar and the red-zones can be read down one column
+  (rf2-a4x1o; EP-0038 P0; the standard is rf2-2rtt6.1).
+
+  ## What was wrong, precisely
+
+  rf2-2rtt6.2 published the bar's DENOMINATOR — Reagent reading re-frame2
+  subscriptions — on a 901-element `M1` list and a 51-element `M2` form,
+  both reading `[:p0/cell i]`. rf2-2rtt6.4 published the RED-ZONE
+  THRESHOLDS — the measured UIx ratio per witness family, under RULING 1
+  on rf2-2rtt6.1 — on a 1,203-element `W1` list reading `[:p0/row i]`, a
+  51-element `W3` form reading `[:p0/field i]`, and a 301-element grid.
+  Its branch was designed before rf2-2rtt6.2 merged and it said so on its
+  own page.
+
+  Each of rf2-2rtt6.4's thresholds is sound AS A THRESHOLD: a ratio
+  between two arms measured in one run, on one page, through one sub
+  graph, in both orders. What is not sound is the TABLE, because a
+  red-zone whose page differs from the bar row's page cannot be applied to
+  a candidate measured on either one. This entry re-measures the frontier
+  arm on rf2-2rtt6.2's witnesses so that every row of the clock table
+  describes the same page.
+
+  ## Which witness set, and why that one
+
+  rf2-2rtt6.2's. Four reasons, in order of weight:
+
+  1. **The bar's denominator defines the witness set by construction.**
+     HD-012 states the ship number as `<= 1.0x Reagent, like-for-like`.
+     The red-zone is a second threshold layered onto the same rows — a
+     rule about where a candidate sits relative to UIx — so it has to be
+     derived on the pages the denominator lives on, not the other way
+     round.
+  2. **rf2-2rtt6.2 is on main and owns the measurement lane.** HD-017
+     gives `:hicasso-bench` and `run.cjs` to that arm; rf2-2rtt6.4's tree
+     rides `:freehand-release`'s compiler settings through a
+     `--config-merge` precisely because the lane had not landed. Running
+     the frontier arm on the lane retires that workaround.
+  3. **rf2-2rtt6.4 nominated it.** Its own `Open items` names
+     rf2-2rtt6.2's set as the convergence target and names its `U-broad`
+     row as the closest existing correspondence.
+  4. **rf2-2rtt6.2's witnesses already carry the control and the lower
+     bound.** `:ctl-2x` is an in-plan positive control at exactly twice
+     the boundaries, and the `:reagent-ratom` arm is a published labelled
+     lower bound on the same page. Moving to the other set would strand
+     both.
+
+  ## What runs
+
+  Four rows, two segments each. The rows are rf2-2rtt6.2's three plus one:
+
+  | row | witness | why |
+  |---|---|---|
+  | `mount-M1` | 901 el, 300 boundaries, `[:p0/cell i]` | the bar row |
+  | `mount-M2` | 51 el, 12 fields, `[:p0/cell i]` | DIAGNOSTIC, per rf2-2rtt6.2 |
+  | `bulk-broad` | the M1 page, one commit ALL 300 boundaries read | the bar row |
+  | `bulk-narrow` | the M1 page, one commit exactly ONE boundary reads | the converged counterpart of rf2-2rtt6.4's `U-narrow` — the localisation row, and the one row where that arm found UIx materially behind. It has NO counterpart in rf2-2rtt6.2, so it is a NEW row on rf2-2rtt6.2's witness, labelled as such rather than presented as a re-measurement of something |
+
+  ## Three arms a segment, and why not two
+
+  rf2-ouwh8: `lane/slot-order` rotates and then REFLECTS, and at k=2 those
+  two operations cancel — `[0 1]` rotates to `[1 0]` and reflects back to
+  `[0 1]`, at every sample index, for ever. A two-arm plan therefore runs
+  in ONE order and `both orders` is a claim it cannot support. This entry
+  never forms a two-arm plan: `:ctl-2x` is measured INSIDE the interleave
+  as rf2-2rtt6.2 measures it, so every segment carries three arms and the
+  reflection does what the guard's self-test says it does. The property is
+  asserted at boot ([[slot-order-degenerates-at-2?]]) rather than trusted,
+  and the run refuses to measure if the assertion does not hold.
+
+  ## Two segments, and what makes the seam legitimate
+
+  `install-adapter!` is once per process (Spec 006 SS Single adapter per
+  process), so the Reagent and UIx arms cannot be interleaved inside one
+  round. Each round runs two SEGMENTS — destroy the adapter, install the
+  other, re-register, re-seed — with the FLOOR IN BOTH. The floor holds no
+  re-frame state, reads no subscription and is untouched by which adapter
+  is installed, so a UIx-over-Reagent figure is a ratio of two
+  floor-normalised ratios and the seam cancels. That cancellation is
+  PUBLISHED rather than assumed: the floor's own p50 in the UIx segment
+  over its p50 in the Reagent segment is reported per round per row, and
+  a reader can see how far it moves and how much less the derived ratio
+  moves.
+
+  Segment order alternates with the round, and so does witness order
+  within a segment: rf2-2rtt6.4 recorded a fixed witness order making
+  `second` a permanent property of one witness, with the guard refusing.
+
+  ## What this entry does NOT measure
+
+  Retained heap. The heap red-zones on rf2-2rtt6.1 come from two
+  independent witness families already — rf2-2rtt6.5's 1,200-boundary
+  reads ladder and rf2-2rtt6.4's list/grid pair — and they agree: 2.262x
+  (list) and 2.254x (grid) on markup densities that differ by 4x, against
+  a per-read ratio of 3,550/942 on a third shape. Retained bytes per
+  subscribing boundary is a property of the BOUNDARY; the clock is not,
+  because a page's element count decides what fraction of the window is
+  React's own work. The heap axis was therefore already converged in
+  substance and the clock axis was not, which is why exactly one arm is
+  re-run here.
+
+  Driven by `p0_converge_run.cjs`, which sets this namespace as the
+  `:hicasso-bench` build's `:init-fn` through rf2-2rtt6.2's own driver and
+  touches no build id and no `implementation/shadow-cljs.edn`."
+  (:require ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.p0-reagent-views :as v]
+            [re-frame.bench.hicasso.p0-uix-views :as ux]
+            [re-frame.bench.order-guard :as guard]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [reagent.core :as r]
+            [reagent.dom.client :as rdc]
+            [uix.dom :as uix-dom]))
+
+(def ^:private rounds 5)
+(def ^:private mount-sampling {:warmup 8 :samples 12})
+(def ^:private bulk-sampling {:warmup 8 :samples 12})
+
+;; rf2-2rtt6.2's slack, unchanged and for its reasons: the claim a clock
+;; control certifies is THE INSTRUMENT HAS SIGNAL, not THE MODEL IS EXACT.
+;; A top-down React re-render is not perfectly linear in element count —
+;; the root, the commit and the diff walk do not double — so 2.00 +/- 5%
+;; would fail an instrument that is working. (The +/-0.001% standard this
+;; wave set belongs to the HEAP control, where the predicted quantity is a
+;; known retained byte count; no clock control can be held to it and
+;; pretending otherwise would be theatre.)
+(def ^:private control-slack 0.25)
+
+(defonce ^:private gen (atom 1000))
+(defn- next-gen! [] (swap! gen inc))
+
+;; ---------------------------------------------------------------------------
+;; Segments
+;; ---------------------------------------------------------------------------
+
+(def ^:private segments
+  [{:id :reagent-subs :adapter reagent-adapter/adapter :name "Reagent-on-subs"}
+   {:id :uix-subs     :adapter uix-adapter/adapter     :name "UIx-on-subs"}])
+
+(defn- segment-order
+  "Two segments admit exactly two orders and this runs both. A
+  cross-segment figure taken in one order only is a single-order result
+  however many rounds it averages."
+  [r]
+  (if (even? r) (vec segments) (vec (rseq (vec segments)))))
+
+(defn- enter-segment!
+  "Tear down whatever adapter is installed, install this segment's,
+  re-register the sub graph and stand the frame back up seeded.
+
+  All of it OUTSIDE every measured window."
+  [{:keys [adapter]}]
+  (try (rf/destroy-frame! v/subs-frame) (catch :default _ nil))
+  (when (rf/current-adapter)
+    (try (rf/destroy-adapter!) (catch :default _ nil)))
+  (rf/init! adapter)
+  (v/register!)
+  (rf/make-frame {:id v/subs-frame})
+  (frame/replace-app-db! v/subs-frame (v/seed-cells v/cells-n 0))
+  (lane/leave-act-environment!)
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Mount arms
+;; ---------------------------------------------------------------------------
+
+(defn- zeros [n] (vec (repeat n 0)))
+
+(defn- floor-mount-arm
+  [id element-of cells-of & [exempt?]]
+  {:id             id
+   :parity-exempt? (boolean exempt?)
+   :mount          (fn [container props _n]
+                     (let [root (react-dom-client/createRoot container)]
+                       (.render root (element-of (cells-of props)))
+                       root))
+   :unmount        (fn [root] (.unmount root))})
+
+(defn- reagent-mount-arm
+  "Reagent's own mount door — what a Reagent application calls."
+  [id form-of]
+  {:id      id
+   :mount   (fn [container props _n]
+              (let [root (rdc/create-root container)]
+                (rdc/render root (form-of props))
+                root))
+   :unmount (fn [root] (rdc/unmount root))})
+
+(defn- uix-mount-arm
+  "UIx's own mount door — `uix.dom/create-root` + `render-root`, which is
+  what a UIx application calls. A shared door would measure the shim."
+  [id element-of]
+  {:id      id
+   :mount   (fn [container props _n]
+              (let [root (uix-dom/create-root container)]
+                (uix-dom/render-root (element-of props) root)
+                root))
+   :unmount (fn [root] (uix-dom/unmount-root root))})
+
+(defn- input-value
+  "The DOM PROPERTY, not the attribute. React installs a controlled
+  `value` as a property and mirrors it to the attribute only on first
+  render, so a property read is the one that stays true."
+  [container sel]
+  (some-> (.querySelector container sel) (.-value)))
+
+(defn- verify-m1
+  "Both ends of the list. A page that committed only its head would pass a
+  single-probe check at index 0."
+  [container]
+  (and (= "0" (lane/text-at container 0))
+       (= "0" (lane/text-at container (dec v/cells-n)))))
+
+(defn- verify-m2
+  "The first and last field of the SHARED prefix — the control arm has
+  twice the fields, so a probe past `fields-n` would not exist in every
+  arm."
+  [container]
+  (and (= (v/field-value 0 0) (input-value container "#f0"))
+       (= (v/field-value (dec v/fields-n) 0)
+          (input-value container (str "#f" (dec v/fields-n))))))
+
+(def ^:private mount-witnesses
+  [{:id       :M1
+    :grade    :bar
+    :verify   verify-m1
+    :doc      (str "the 300-boundary sub-reading list — the bulk shape's mount "
+                   "counterpart, one subscription read per boundary. "
+                   "rf2-2rtt6.2's M1, unchanged")
+    :props    {:n v/cells-n}
+    :elements (v/m1-elements v/cells-n)
+    :control  {:predicted (/ (double (v/m1-elements (* 2 v/cells-n)))
+                             (double (v/m1-elements v/cells-n)))
+               :basis     (str "element count: " (v/m1-elements (* 2 v/cells-n)) " / "
+                               (v/m1-elements v/cells-n))}
+    :arms-for (fn [segment-id]
+                [(floor-mount-arm :floor v/m1-floor (fn [{:keys [n]}] (zeros n)))
+                 (case segment-id
+                   :reagent-subs (reagent-mount-arm
+                                   :reagent-subs
+                                   (fn [{:keys [n]}] [v/subs-root v/m1-subs n]))
+                   :uix-subs     (uix-mount-arm
+                                   :uix-subs
+                                   (fn [{:keys [n]}] (ux/subs-root ux/m1 n))))
+                 (floor-mount-arm :ctl-2x v/m1-floor
+                                  (fn [{:keys [n]}] (zeros (* 2 n))) true)])}
+
+   {:id         :M2
+    :grade      :diagnostic
+    :verify     verify-m2
+    ;; ONE mount per sample, exactly as rf2-2rtt6.2 publishes it. That arm
+    ;; TRIED the batch that would lift this witness clear of Chrome's
+    ;; 100 us clamp — eight 51-element roots in one flushSync — and THE
+    ;; ARM-ORDER GUARD REFUSED THE WHOLE RUN, exit 2, with all four M2 arms
+    ;; reading 3.2x-5.4x slower in the last third than in the first, ranges
+    ;; disjoint, while the unbatched M1 row in the same page drifted
+    ;; 1.13x-1.16x with ranges overlapping. Re-taking the batch here would
+    ;; be re-litigating a refusal the denominator arm already resolved
+    ;; against itself. The resulting coarseness is stated on the row and
+    ;; the row is graded DIAGNOSTIC.
+    :per-sample 1
+    :clock-note (str "DIAGNOSTIC-GRADE, not a bar row and not a red-zone a "
+                     "candidate is judged against. A 51-element mount takes a few "
+                     "tenths of a millisecond — three to six of Chrome's 100 us "
+                     "performance.now() quanta — so this witness's ratios are "
+                     "quantised more coarsely than a 10% effect. rf2-2rtt6.4 "
+                     "recorded the failure mode this row is exposed to: at one "
+                     "mount a sample its 51-element form returned exactly 0.75 ms "
+                     "from BOTH segments and the ratio came out at precisely "
+                     "1.0000 — the quantum wearing a tie's clothes.")
+    :doc      (str "the ordinary 12-field form on subs — the shape most "
+                   "applications are made of. rf2-2rtt6.2's M2, unchanged")
+    :props    {:n v/fields-n}
+    :elements (v/m2-elements v/fields-n)
+    :control  {:predicted (/ (double (v/m2-elements (* 2 v/fields-n)))
+                             (double (v/m2-elements v/fields-n)))
+               :basis     (str "element count: " (v/m2-elements (* 2 v/fields-n)) " / "
+                               (v/m2-elements v/fields-n))}
+    :arms-for (fn [segment-id]
+                [(floor-mount-arm :floor v/m2-floor (fn [{:keys [n]}] (zeros n)))
+                 (case segment-id
+                   :reagent-subs (reagent-mount-arm
+                                   :reagent-subs
+                                   (fn [{:keys [n]}] [v/subs-root v/m2-subs n]))
+                   :uix-subs     (uix-mount-arm
+                                   :uix-subs
+                                   (fn [{:keys [n]}] (ux/subs-root ux/m2 n))))
+                 (floor-mount-arm :ctl-2x v/m2-floor
+                                  (fn [{:keys [n]}] (zeros (* 2 n))) true)])}])
+
+(defn- witness-order [r]
+  (if (even? r) mount-witnesses (vec (rseq (vec mount-witnesses)))))
+
+;; ---------------------------------------------------------------------------
+;; Bulk arms
+;; ---------------------------------------------------------------------------
+
+(defn- floor-bulk-arm
+  "The floor's `force!` renders INSIDE the `flushSync`, and that is not a
+  convenience. `root.render` called outside a React event schedules at
+  React's DEFAULT lane and an empty `flushSync` flushes only the SYNC
+  lane, so a floor arm that rendered in `write!` would have its commit
+  land outside the measured window entirely — the recorded fault is 80 of
+  320 floor samples ending on a cell that still held its old value."
+  [id n & [exempt?]]
+  (let [state (atom (zeros n))
+        rt    (volatile! nil)]
+    {:id             id
+     :parity-exempt? (boolean exempt?)
+     :cells          n
+     :mount          (fn [container]
+                       (let [root (react-dom-client/createRoot container)]
+                         (vreset! rt root)
+                         (react-dom/flushSync (fn [] (.render root (v/m1-floor @state))))
+                         root))
+     :write!         (fn [i val]
+                       (if (= i :all)
+                         (reset! state (vec (repeat n val)))
+                         (swap! state assoc i val)))
+     :force!         (fn [] (react-dom/flushSync
+                              (fn [] (.render ^js @rt (v/m1-floor @state)))))
+     :unmount        (fn [root] (react-dom/flushSync (fn [] (.unmount root))))}))
+
+(defn- subs-bulk-arm
+  "Both substrate bulk arms, one constructor, so they differ in exactly
+  two places: the mount door and the drain.
+
+  THE WRITE IS IDENTICAL and it is rf2-2rtt6.2's write —
+  `frame/replace-app-db!` — not a `dispatch-sync`. HD-012 states the bar
+  over VIEW WORK, and rf2-2rtt6.3 measured the event drain at 11%-16% of
+  a write on this substrate; routing the converged row through the event
+  pipeline would add that leg to both arms, shrink the view-work
+  difference the row exists to show, and make the Reagent figures here
+  uncomparable with the ones rf2-2rtt6.2 already published. The pipeline
+  is priced on rf2-2rtt6.3's own row.
+
+  The NARROW write installs a whole new app-db with one cell changed, so
+  all 300 layer-1 subscriptions recompute and exactly one boundary's
+  value changes. That is the localisation question as a re-frame2
+  application actually meets it, and it is the same operation on both
+  substrate arms."
+  [id mount unmount force!]
+  (let [cells (atom (zeros v/cells-n))]
+    {:id      id
+     :cells   v/cells-n
+     :mount   mount
+     :unmount unmount
+     :write!  (fn [i val]
+                (if (= i :all)
+                  (reset! cells (vec (repeat v/cells-n val)))
+                  (swap! cells assoc i val))
+                (frame/replace-app-db! v/subs-frame {:cells @cells}))
+     :force!  force!}))
+
+(defn- reagent-bulk-arm []
+  (subs-bulk-arm
+    :reagent-subs
+    (fn [container]
+      (let [root (rdc/create-root container)]
+        (react-dom/flushSync
+          (fn [] (rdc/render root [v/subs-root v/m1-subs v/cells-n])))
+        root))
+    (fn [root] (react-dom/flushSync (fn [] (rdc/unmount root))))
+    ;; `reagent.core/flush` is Reagent's own documented synchronous render
+    ;; drain — the same drain rf2-2rtt6.2's published row used.
+    (fn [] (react-dom/flushSync (fn [] (r/flush))))))
+
+(defn- uix-bulk-arm []
+  (subs-bulk-arm
+    :uix-subs
+    (fn [container]
+      (let [root (uix-dom/create-root container)]
+        (react-dom/flushSync
+          (fn [] (uix-dom/render-root (ux/subs-root ux/m1 v/cells-n) root)))
+        root))
+    (fn [root] (react-dom/flushSync (fn [] (uix-dom/unmount-root root))))
+    ;; `useSyncExternalStore` notifications schedule at React's SYNC lane,
+    ;; so an EMPTY flushSync commits them inside the window. Not
+    ;; `uix-adapter/flush-views!`, which wraps React's `act()` — `act`
+    ;; diverts work to a queue that is not the browser's, and every
+    ;; window in this lane is taken outside it.
+    (fn [] (react-dom/flushSync (fn [] nil)))))
+
+(defn- bulk-arms [segment-id]
+  [(floor-bulk-arm :floor v/cells-n)
+   (case segment-id
+     :reagent-subs (reagent-bulk-arm)
+     :uix-subs     (uix-bulk-arm))
+   (floor-bulk-arm :ctl-2x (* 2 v/cells-n) true)])
+
+(defn- mount-bulk-arms! [arms]
+  (mapv (fn [a]
+          (let [c (lane/fresh-container!)]
+            {:arm a :container c :handle ((:mount a) c)}))
+        arms))
+
+(defn- release-bulk-arms! [mounts]
+  (doseq [{:keys [arm handle container]} mounts]
+    (try ((:unmount arm) handle) (catch :default _ nil))
+    (.remove container)))
+
+;; ---------------------------------------------------------------------------
+;; One round of one mount witness in one segment
+;; ---------------------------------------------------------------------------
+
+(defn- mount-round!
+  [coll t {:keys [id verify elements props per-sample arms-for]} segment-id]
+  (let [arms (arms-for segment-id)
+        n    (count arms)
+        k    (or per-sample 1)
+        acc  (atom (zipmap (map :id arms) (repeat [])))]
+    (dotimes [s (+ (:warmup mount-sampling) (:samples mount-sampling))]
+      (doseq [j (lane/slot-order n s)]
+        (let [arm (nth arms j)
+              {:keys [ms mounts]} (lane/mount-batch! arm props k)
+              expected (if (:parity-exempt? arm) nil elements)]
+          ;; EVERY mount is read back out of the document — the element
+          ;; count against WRITTEN arithmetic, and the witness's own probe
+          ;; at both ends of the page. An arm that rendered an empty page
+          ;; is the cheapest arm in any table and this is the line that
+          ;; catches it.
+          (doseq [m mounts]
+            (let [ok? (and (or (nil? expected)
+                               (= expected (lane/element-count (:container m))))
+                           (verify (:container m)))]
+              (swap! t (fn [{:keys [of bad]}]
+                         {:of (inc of) :bad (if ok? bad (inc bad))}))))
+          (doseq [m mounts] (lane/release! m))
+          (when (>= s (:warmup mount-sampling))
+            (lane/collect! coll (str (name id) "/" (name segment-id) "/" (name (:id arm))) ms)
+            (swap! acc update (:id arm) conj ms)))))
+    @acc))
+
+;; ---------------------------------------------------------------------------
+;; One round of one bulk kind in one segment
+;; ---------------------------------------------------------------------------
+
+(defn- bulk-write!
+  "One write on one arm, timed as one sample and verified at the DOM
+  inside its own window.
+
+  BROAD changes every cell, so the probe rotates with the value AND the
+  far end of the grid is checked: a stale page can still carry one fresh
+  cell from the previous write and a single fixed probe would accept it.
+
+  NARROW changes exactly one cell, so there is nothing else in the page
+  to check — the strength of the read-back comes from the value being
+  fresh on every write, which means a stale page holds the PREVIOUS value
+  at the probed cell and fails. The cell also rotates, so no index is
+  special."
+  [t mnt kind s]
+  (let [n   (:cells (:arm mnt))
+        val (next-gen!)]
+    (if (= kind :broad)
+      (lane/verified-write! t mnt :all val [(mod val n) (dec n) 0])
+      (let [i (mod (* 7 s) n)]
+        (lane/verified-write! t mnt i val [i])))))
+
+(defn- seed-bulk!
+  [mounts t]
+  (lane/chain nil mounts
+              (fn [_ mnt] (-> (lane/verified-write! t mnt :all 0
+                                                    [0 (dec (:cells (:arm mnt)))])
+                              (.then (fn [_] nil))))))
+
+(defn- bulk-round!
+  "One round. The guard's samples are banked AT THE SAMPLE, inside the
+  interleave — banking them per arm after the round would record every
+  arm's readings as consecutive and hand the guard a `:position` factor
+  that says only what the loop's shape was."
+  [mounts t legs coll kind segment-id]
+  (let [n     (count mounts)
+        total (+ (:warmup bulk-sampling) (:samples bulk-sampling))
+        acc0  (zipmap (map #(:id (:arm %)) mounts) (repeat []))]
+    (lane/chain {:readings acc0}
+                (for [s (range total) j (lane/slot-order n s)] [s j])
+                (fn [acc [s j]]
+                  (let [mnt (nth mounts j)
+                        id  (:id (:arm mnt))]
+                    (-> (bulk-write! t mnt kind s)
+                        (.then (fn [{:keys [ms write-ms gap-ms force-ms]}]
+                                 (if (>= s (:warmup bulk-sampling))
+                                   (do (lane/collect! coll
+                                                      (str (name kind) "/" (name segment-id)
+                                                           "/" (name id))
+                                                      ms)
+                                       (swap! legs update [kind segment-id id] (fnil conj [])
+                                              {:write write-ms :gap gap-ms :force force-ms})
+                                       (update-in acc [:readings id] conj ms))
+                                   acc)))))))))
+
+;; ---------------------------------------------------------------------------
+;; Aggregation
+;; ---------------------------------------------------------------------------
+
+(defn- ratios-of
+  "One segment-round's raw readings as `{:p50 {id ms} :ratio {id r}}`,
+  every ratio against the floor measured in THAT segment of THAT round."
+  [readings]
+  (lane/normalise readings :floor))
+
+(defn- range-of [vs]
+  {:mean (lane/round4 (/ (reduce + 0.0 vs) (count vs)))
+   :min  (lane/round4 (apply min vs))
+   :max  (lane/round4 (apply max vs))
+   :per-round (mapv lane/round4 vs)
+   :straddles-1? (and (<= (apply min vs) 1.0) (>= (apply max vs) 1.0))})
+
+(defn- row-record
+  "Turn one row's per-round, per-segment slices into the published record.
+
+  `slices` is `[{segment-id {arm-id [ms ...]}} ...]`, one entry per round."
+  [{:keys [row doc grade clock-note control note]} slices]
+  (let [norm       (mapv (fn [by-seg]
+                           (into {} (map (fn [[sid rd]] [sid (ratios-of rd)])) by-seg))
+                         slices)
+        rz         (mapv (fn [m] (/ (get-in m [:uix-subs :ratio :uix-subs])
+                                    (get-in m [:reagent-subs :ratio :reagent-subs])))
+                         norm)
+        rg-floor   (mapv #(get-in % [:reagent-subs :ratio :reagent-subs]) norm)
+        ux-floor   (mapv #(get-in % [:uix-subs :ratio :uix-subs]) norm)
+        seam       (mapv (fn [m] (/ (get-in m [:uix-subs :p50 :floor])
+                                    (get-in m [:reagent-subs :p50 :floor])))
+                         norm)
+        ctl-rg     (mapv #(get-in % [:reagent-subs :ratio :ctl-2x]) norm)
+        ctl-ux     (mapv #(get-in % [:uix-subs :ratio :ctl-2x]) norm)
+        verdict-of (fn [vs] (lane/control-verdict (:predicted control)
+                                                  (select-keys (range-of vs) [:min :max :mean])
+                                                  control-slack))
+        c-rg       (verdict-of ctl-rg)
+        c-ux       (verdict-of ctl-ux)]
+    {:record
+     {:benchmark   (keyword "hicasso.P0.converged" (name row))
+      :doc         doc
+      :bead        "rf2-a4x1o"
+      :grade       grade
+      :clock-note  clock-note
+      :note        note
+      :witness-set "rf2-2rtt6.2"
+      :red-zone    (assoc (range-of rz)
+                          :numerator :uix-subs
+                          :denominator :reagent-subs
+                          :axis :clock)
+      :uix-over-floor     (range-of ux-floor)
+      :reagent-over-floor (range-of rg-floor)
+      :segment-seam-control
+      {:floor-uix-over-floor-reagent (range-of seam)
+       :why (str "the FLOOR's own p50 in the UIx segment over its p50 in the "
+                 "Reagent segment, same round. The floor is identical work in both "
+                 "and holds no re-frame state, so this is drift between the segments "
+                 "and nothing else. Every published figure is a ratio to the floor "
+                 "measured in the SAME segment of the SAME round, so the seam "
+                 "cancels — and the evidence for that is this range against the "
+                 "red-zone's, not an argument that it should.")}
+      :positive-control {:predicted (:predicted control)
+                         :basis     (:basis control)
+                         :reagent-segment c-rg
+                         :uix-segment     c-ux}
+      :per-round   {:reagent (mapv #(get-in % [:reagent-subs :p50]) norm)
+                    :uix     (mapv #(get-in % [:uix-subs :p50]) norm)}
+      :status      :evidence}
+     :controls [c-rg c-ux]}))
+
+;; ---------------------------------------------------------------------------
+;; Parity — before any clock is read, in EVERY segment and ACROSS the seam
+;; ---------------------------------------------------------------------------
+
+(defn- parity-of-segment!
+  [segment-id]
+  (reduce
+    (fn [acc {:keys [id props elements arms-for]}]
+      (let [{:keys [mounts agree? counts disagree reference]} (lane/parity (arms-for segment-id) props)]
+        (try
+          (-> acc
+              (assoc-in [:reference id] reference)
+              (update :problems
+                      (fn [problems]
+                        (cond-> problems
+                          (not agree?)
+                          (conj {:segment segment-id :witness id
+                                 :problem :canonical-dom-disagreement :arms disagree})
+
+                          (not (every? #(= elements %) (vals counts)))
+                          (conj {:segment segment-id :witness id :problem :element-count
+                                 :expected elements :got counts})))))
+          (finally (doseq [m mounts] (lane/release! m))))))
+    {:problems [] :reference {}}
+    mount-witnesses))
+
+(defn- parity!
+  "Both segments' parity, plus the CROSS-segment check.
+
+  Within a segment the floor and the substrate arm must build the same
+  page. Across the seam the two SUBSTRATE arms must build the same page as
+  each other — which is the comparison the red-zone actually makes, and it
+  is checked directly rather than inferred from each segment agreeing with
+  its own floor."
+  []
+  (let [by-seg (reduce (fn [acc {:keys [id] :as segment}]
+                         (enter-segment! segment)
+                         (assoc acc id (parity-of-segment! id)))
+                       {}
+                       segments)
+        cross  (for [{:keys [id]} mount-witnesses
+                     :when (not= (get-in by-seg [:reagent-subs :reference id])
+                                 (get-in by-seg [:uix-subs :reference id]))]
+                 {:problem :cross-segment-disagreement :witness id})]
+    {:problems (into (vec (mapcat (comp :problems val) by-seg)) cross)}))
+
+;; ---------------------------------------------------------------------------
+;; The schedule's own precondition (rf2-ouwh8)
+;; ---------------------------------------------------------------------------
+
+(defn- slot-order-degenerates-at-2?
+  "Does `slot-order` emit the SAME order at every sample index when there
+  are two arms? rf2-ouwh8 says yes — rotate `[0 1]` to `[1 0]`, reflect
+  back to `[0 1]` — and three copies of the rule carry it. Asserted here
+  rather than trusted, because this entry's whole `both orders` claim
+  rests on never forming a two-arm plan."
+  []
+  (apply = (map #(guard/slot-order 2 %) (range 8))))
+
+(defn- slot-order-varies-at-3?
+  "And the three-arm plan this entry actually runs must NOT degenerate."
+  []
+  (> (count (distinct (map #(guard/slot-order 3 %) (range 8)))) 1))
+
+;; ---------------------------------------------------------------------------
+;; The run
+;; ---------------------------------------------------------------------------
+
+(defn- bulk-kinds [r] (if (even? r) [:broad :narrow] [:narrow :broad]))
+
+(defn- run-round!
+  "One round: both segments, in this round's order; within each segment
+  both mount witnesses in this round's order, then the standing bulk
+  arms driven through both write kinds in this round's order.
+
+  Answers a promise of
+  `{:mount {witness-id {segment-id readings}} :bulk {kind {segment-id readings}}}`."
+  [r coll tallies legs]
+  (lane/chain
+    {:mount {} :bulk {}}
+    (segment-order r)
+    (fn [acc {:keys [id] :as segment}]
+      (enter-segment! segment)
+      (let [acc' (reduce (fn [a w]
+                           (assoc-in a [:mount (:id w) id]
+                                     (mount-round! coll (get tallies (:id w)) w id)))
+                         acc
+                         (witness-order r))
+            mounts (mount-bulk-arms! (bulk-arms id))]
+        (-> (lane/chain acc' (bulk-kinds r)
+                        (fn [a kind]
+                          (-> (seed-bulk! mounts (get tallies kind))
+                              (.then (fn [_] (bulk-round! mounts (get tallies kind)
+                                                          legs coll kind id)))
+                              (.then (fn [rd] (assoc-in a [:bulk kind id] (:readings rd)))))))
+            (.then (fn [a] (release-bulk-arms! mounts) a))
+            (.catch (fn [e] (release-bulk-arms! mounts) (throw e))))))))
+
+(defn- leg-summary [legs]
+  (into {}
+        (map (fn [[k xs]]
+               [k {:write-ms (:p50 (lane/summarise (map :write xs)))
+                   :gap-ms   (:p50 (lane/summarise (map :gap xs)))
+                   :force-ms (:p50 (lane/summarise (map :force xs)))}]))
+        legs))
+
+(defn- publish!
+  [slices tallies legs coll]
+  (let [m1 (row-record {:row :mount-M1 :grade :bar
+                        :doc (:doc (first mount-witnesses))
+                        :control (:control (first mount-witnesses))}
+                       (mapv #(get-in % [:mount :M1]) slices))
+        m2 (row-record {:row :mount-M2 :grade :diagnostic
+                        :doc (:doc (second mount-witnesses))
+                        :clock-note (:clock-note (second mount-witnesses))
+                        :control (:control (second mount-witnesses))}
+                       (mapv #(get-in % [:mount :M2]) slices))
+        bulk-control {:predicted (/ (double (v/m1-elements (* 2 v/cells-n)))
+                                    (double (v/m1-elements v/cells-n)))
+                      :basis (str "element count: " (v/m1-elements (* 2 v/cells-n)) " / "
+                                  (v/m1-elements v/cells-n))}
+        broad (row-record {:row :bulk-broad :grade :bar
+                           :doc (str "one commit that all " v/cells-n
+                                     " sub-reading boundaries read, on rf2-2rtt6.2's M1 "
+                                     "page — the make-or-break row")
+                           :control bulk-control}
+                          (mapv #(get-in % [:bulk :broad]) slices))
+        narrow (row-record {:row :bulk-narrow :grade :bar
+                            :doc (str "one commit that exactly ONE of " v/cells-n
+                                      " sub-reading boundaries reads — the localisation row")
+                            :note (str "NEW ROW. rf2-2rtt6.2 has no narrow counterpart, so "
+                                       "this is not a re-measurement of a published figure: "
+                                       "it is rf2-2rtt6.4's U-narrow question asked on "
+                                       "rf2-2rtt6.2's witness. The two numbers are NOT "
+                                       "comparable with each other and neither supersedes "
+                                       "the other; this one is the comparable one, because "
+                                       "its page is the page every other row here uses.")
+                            :control bulk-control}
+                           (mapv #(get-in % [:bulk :narrow]) slices))
+        rows [m1 m2 broad narrow]]
+    (doseq [[k {:keys [record]}] (map vector
+                                      ["mount-M1" "mount-M2" "bulk-broad" "bulk-narrow"]
+                                      rows)]
+      (lane/record! k record))
+    (lane/record! "verification"
+                  (into {} (map (fn [[k t]] [k (lane/tally-value t)])) tallies))
+    (lane/record! "write-legs" (leg-summary @legs))
+    (lane/record! "red-zones"
+                  {:axis :clock
+                   :witness-set "rf2-2rtt6.2"
+                   :rule (str "RULING 1 on rf2-2rtt6.1: the red-zone threshold IS the "
+                              "measured UIx ratio for that witness family. A candidate row "
+                              "worse than it is RED and needs an explicit operator waiver "
+                              "naming the dogfood benefit. Silence is not a pass. These "
+                              "SUPERSEDE the clock thresholds rf2-2rtt6.4 published on its "
+                              "own witnesses, which remain sound as ratios and are not "
+                              "comparable with the bar rows.")
+                   :thresholds
+                   (into {} (map (fn [[k {:keys [record]}]]
+                                   [k (select-keys (:red-zone record)
+                                                   [:mean :min :max :per-round :straddles-1?])]))
+                         (map vector ["mount-M1" "mount-M2" "bulk-broad" "bulk-narrow"] rows))})
+    (let [vd (lane/guard! (:samples @coll) "Hicasso P0 — converged witness set")]
+      (lane/record! "arm-order-guard"
+                    {:tolerance (:tolerance vd)
+                     :contaminated? (:contaminated? vd)
+                     :unchecked? (:unchecked? vd)
+                     :refuse? (:refuse? vd)
+                     :arms (:arms vd)})
+      (when (:refuse? vd) (set! (.-HICASSO_GUARD_REFUSED js/window) true)))
+    (when (some (complement :ok?) (mapcat :controls rows))
+      (set! (.-HICASSO_CONTROL_FAILED js/window) true))
+    nil))
+
+(defn ^:export -main
+  []
+  (try
+    (lane/leave-act-environment!)
+    (cond
+      (not (lane/self-test!))
+      (do (lane/fail! (str "the arm-order guard's SELF-TEST failed — this copy of the rule "
+                           "no longer behaves like the one the .cjs drivers use, so nothing "
+                           "was measured"))
+          (lane/done!))
+
+      (not (slot-order-degenerates-at-2?))
+      (do (lane/fail! (str "slot-order no longer degenerates at k=2. rf2-ouwh8 is the reason "
+                           "this entry puts three arms in every segment; if the rule has "
+                           "changed, the schedule's justification has to be re-derived before "
+                           "anything here is measured"))
+          (lane/done!))
+
+      (not (slot-order-varies-at-3?))
+      (do (lane/fail! (str "slot-order emits ONE order at k=3, so the three-arm plan this "
+                           "entry runs is a single-order plan and `both orders` would be a "
+                           "claim it cannot support"))
+          (lane/done!))
+
+      :else
+      (let [{:keys [problems]} (parity!)]
+        (lane/record! "parity"
+                      {:problems problems :ok? (empty? problems)
+                       :note (str "canonical DOM with attribute names sorted, inside each "
+                                  "segment AND across the seam. Element counts are checked "
+                                  "against written arithmetic — 901 for M1, 51 for M2 — so "
+                                  "the gate can answer false for an arm that rendered "
+                                  "nothing.")})
+        (if (seq problems)
+          (do (lane/fail! (str "the arms do not build the same page under :advanced — "
+                               (pr-str problems)))
+              (lane/done!))
+          (let [coll    (lane/sample-collector)
+                tallies {:M1 (lane/tally) :M2 (lane/tally)
+                         :broad (lane/tally) :narrow (lane/tally)}
+                legs    (atom {})]
+            (-> (lane/chain [] (range rounds)
+                            (fn [acc r]
+                              (-> (run-round! r coll tallies legs)
+                                  (.then (fn [slice] (conj acc slice))))))
+                (.then (fn [slices]
+                         (publish! slices tallies legs coll)
+                         (lane/done!)
+                         nil))
+                (.catch (fn [e]
+                          (lane/fail! (str "the run rejected: " e))
+                          (lane/done!))))))))
+    (catch :default e
+      (lane/fail! (str "the run threw: " e))
+      (lane/done!))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
@@ -3,28 +3,234 @@
 //
 //   node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
 //
-// There is no new driver here and there is no new build id. rf2-2rtt6.2
-// built `run.cjs` so that a sibling arm rides the `:hicasso-bench` lane by
-// naming its own `:init-fn`, and HD-017 makes a build-id touch a hot-zone
-// edit. This file is the three environment variables that name this arm's
-// entry, and then rf2-2rtt6.2's driver unchanged — which also makes the
-// reproduction command ABOVE runnable on Windows, where an inline
-// `VAR=value node ...` prefix is not a thing the shell understands and a
-// published repro that only runs on a POSIX shell is a repro that half the
-// maintainers cannot take.
+// Build once, serve once, load the page ONE ROW AT A TIME, and refuse a
+// figure that moves with its position in the plan.
 //
-// Exit codes are `run.cjs`'s and are not this file's to change:
+// ## No new build id
 //
-//   0  measured, guard clean, control passed
+// `implementation/shadow-cljs.edn` is not touched. rf2-2rtt6.2 owns the
+// measurement lane and HD-017 makes a build-id addition a hot-zone,
+// sequenced edit; this rides `:hicasso-bench` with an output directory and
+// an `:init-fn` merged in at the CLI, which is the seam that arm's own
+// driver established for exactly this.
+//
+// ## ONE ROW PER PAGE, and why the first cut was not
+//
+// The first cut ran all four rows in one page and THE ARM-ORDER GUARD
+// REFUSED IT, exit 2, on two independent faults. Both were the arm's and
+// both are repaired here; the tolerance was not touched.
+//
+//   1. PHASE. `M1/uix-subs/floor` — an arm that hand-builds React
+//      elements and cannot change — read LAST-THIRD 2.1739x FIRST-THIRD
+//      with ranges DISJOINT (p50 1.15 ms -> 2.50 ms). Its Reagent-segment
+//      twin climbed 2.09x and the two control arms climbed 1.96x-2.07x,
+//      so the whole page was degrading, not one arm. That is the
+//      accumulation rf2-2rtt6.4 recorded and could not explain (~12 MB per
+//      segment entry, surviving a forced major collection, never reaching
+//      the document); its repair was ONE ROUND PER PAGE. The repair here
+//      is one ROW per page, which cuts a page's measured work from ~2,460
+//      operations to ~600 and is the smaller change of the two — with
+//      round-per-page held in reserve if the guard says it is not enough.
+//
+//   2. PREDECESSOR. `narrow/reagent-subs/ctl-2x` was refused on a stratum
+//      of TWO samples labelled `M1/reagent-subs/reagent-subs` — an arm
+//      that ran in a different ROW. Those tiny cross-row strata are an
+//      artefact of the shared sample collector: `lane/collect!` advances
+//      the `:previous` pointer only for RECORDED samples, so the first
+//      recorded sample after a warm-up block is tagged with whatever ran
+//      before the warm-up rather than with what actually ran before it.
+//      rf2-2rtt6.4 hit the same class from the other side (`<none>`
+//      strata reading 1.35x their siblings). Two repairs, both in the arm:
+//      the warm-up now advances the predecessor pointer without banking a
+//      sample, so every recorded sample carries its REAL predecessor; and
+//      one row per page means no cross-row adjacency exists to mislabel.
+//
+// ## Exit codes — the guard owns 2, and it is not the arm's to move
+//
+//   0  measured, guard clean, controls passed
 //   1  the run failed (build, page error, a fatal the page recorded, a
 //      positive control that did not see what it predicted)
-//   2  THE ARM-ORDER GUARD REFUSED. Repair the ARM, never the tolerance.
+//   2  THE ARM-ORDER GUARD REFUSED. A figure whose value depends on where
+//      in the plan it was measured is not a figure. The repair is the ARM
+//      — more warm-up, fewer arms per page, a longer window — never the
+//      guard's tolerance.
+//
+// A Chromium `pageerror` is FATAL: a benchmark that threw and kept going
+// publishes a precise number for a page that is not the page under test.
 
 'use strict';
 
-process.env.HICASSO_INIT_FN =
-  process.env.HICASSO_INIT_FN || 're-frame.bench.hicasso.p0-converge-app/-main';
-process.env.HICASSO_OUT_DIR = process.env.HICASSO_OUT_DIR || 'out/hicasso-converge';
-process.env.HICASSO_PORT = process.env.HICASSO_PORT || '8134';
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
 
-require('./run.cjs');
+// The directory's ONE navigation, with its ceiling named (rf2-p9fa3).
+const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs');
+
+const IMPL = path.resolve(__dirname, '../../../../..');
+
+const BUILD_ID = 'hicasso-bench';
+const OUT_DIR = process.env.HICASSO_OUT_DIR || 'out/hicasso-converge';
+const INIT_FN = 're-frame.bench.hicasso.p0-converge-app/-main';
+const OUT = path.join(IMPL, OUT_DIR);
+const PORT = Number(process.env.HICASSO_PORT || 8134);
+
+// One row, one page, one fresh heap. The order is the order the studio
+// page reports them in; each is self-contained, so it is not load-bearing.
+const ROWS = [
+  { id: 'M1', why: 'mount, 901 elements, 300 sub-reading boundaries — a bar row' },
+  { id: 'M2', why: 'mount, 51 elements, 12 fields — DIAGNOSTIC, per rf2-2rtt6.2' },
+  { id: 'broad', why: 'one commit all 300 boundaries read — a bar row' },
+  { id: 'narrow', why: 'one commit exactly one boundary reads — localisation' },
+];
+
+// A page's own budget. Five rounds of two segments with warm-up is
+// minutes, not seconds, and a loaded workstation is the normal case.
+const SENTINEL_TIMEOUT_MS = 20 * 60 * 1000;
+
+// ONE LINE, deliberately: shadow-cljs's CLI re-splits `--config-merge` on
+// whitespace when the EDN contains a newline.
+const CONFIG_MERGE =
+  `{:output-dir "${OUT_DIR}" :asset-path "." ` +
+  `:modules {:main {:init-fn ${INIT_FN}}}}`;
+
+function build() {
+  console.error(`[converge] building :advanced bundle — ${INIT_FN} -> ${OUT_DIR}`);
+  const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+  const r = spawnSync(
+    process.execPath,
+    [runner, 'release', BUILD_ID, '--config-merge', CONFIG_MERGE],
+    { cwd: IMPL, stdio: ['ignore', 'inherit', 'inherit'] }
+  );
+  if (r.status !== 0) {
+    console.error(`[converge] build failed with status ${r.status}`);
+    process.exit(1);
+  }
+}
+
+const MIME = { '.js': 'text/javascript', '.html': 'text/html', '.map': 'application/json' };
+
+function serve() {
+  fs.writeFileSync(
+    path.join(OUT, 'index.html'),
+    '<!doctype html><html><head><meta charset="utf-8"><title>Hicasso P0 converged</title></head>' +
+      '<body><div id="app"></div><script src="main.js"></script></body></html>'
+  );
+  return http
+    .createServer((req, res) => {
+      const rel = decodeURIComponent(req.url.split('?')[0]);
+      const file = path.join(OUT, rel === '/' ? 'index.html' : rel);
+      if (!file.startsWith(OUT) || !fs.existsSync(file)) {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      fs.createReadStream(file).pipe(res);
+    })
+    .listen(PORT);
+}
+
+async function runRow(browser, row) {
+  // A FRESH PAGE per row, not a fresh navigation in the same one: the
+  // fault this driver was rebuilt around is a page that gets slower the
+  // longer it runs, and a reused page carries whatever caused that across
+  // the row boundary.
+  const page = await browser.newPage();
+  const pageErrors = [];
+  page.on('pageerror', (e) => {
+    pageErrors.push(e.message);
+    console.error(`[converge] PAGE ERROR (${row.id}):`, e.message);
+  });
+  page.on('console', (msg) => {
+    const t = msg.text();
+    if (t.startsWith(';; ') || t.startsWith('[converge]')) console.log(t);
+  });
+
+  // `'commit'`, not `'load'`. The bundle's `:init-fn` runs inside the
+  // `<script>`, so the measurement happens while the document is still
+  // loading and `load` cannot fire until it is over.
+  await navigate(page, `http://127.0.0.1:${PORT}/?row=${row.id}`, {
+    waitUntil: 'commit',
+    timeoutMs: NAV_TIMEOUT_MS,
+    budget: `the ${SENTINEL_TIMEOUT_MS / 60000}-minute wait for window.HICASSO_DONE`,
+  });
+  await page.waitForFunction('window.HICASSO_DONE === true || window.HICASSO_ERROR', null, {
+    timeout: SENTINEL_TIMEOUT_MS,
+  });
+
+  const err = await page.evaluate('window.HICASSO_ERROR || null');
+  const refused = await page.evaluate('window.HICASSO_GUARD_REFUSED === true');
+  const controlFailed = await page.evaluate('window.HICASSO_CONTROL_FAILED === true');
+  const results = await page.evaluate('window.HICASSO_RESULTS || {}');
+  await page.close();
+  return { row, err, refused, controlFailed, results, pageErrors };
+}
+
+(async () => {
+  build();
+  const server = serve();
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch();
+  const version = browser.version();
+  const outcomes = [];
+  try {
+    for (const row of ROWS) {
+      console.error(`[converge] row ${row.id} — ${row.why}`);
+      outcomes.push(await runRow(browser, row));
+    }
+  } finally {
+    await browser.close();
+    server.close();
+  }
+
+  console.log(`;; ==== HICASSO RUNTIME ====`);
+  console.log(`;; chromium ${version} (playwright), :advanced, goog.DEBUG false`);
+  console.log(`;; one row per page; ${ROWS.length} pages`);
+  for (const o of outcomes) {
+    for (const [k, v] of Object.entries(o.results)) {
+      console.log(`;; ==== HICASSO ${o.row.id} / ${k} ====`);
+      console.log(v);
+    }
+  }
+
+  const errored = outcomes.filter((o) => o.pageErrors.length > 0);
+  if (errored.length > 0) {
+    console.error(
+      `[converge] FAILED: uncaught page error(s) — every figure above was taken on a ` +
+        `page that had already thrown:\n  ` +
+        errored.map((o) => `${o.row.id}: ${o.pageErrors.join(' | ')}`).join('\n  ')
+    );
+    process.exit(1);
+  }
+  const refused = outcomes.filter((o) => o.refused);
+  if (refused.length > 0) {
+    console.error(
+      `[converge] ARM-ORDER GUARD REFUSED (exit 2) on: ${refused
+        .map((o) => o.row.id)
+        .join(', ')}. At least one arm reads differently for WHERE IN THE PLAN it was ` +
+        `measured, so no figure in that row is reportable. Repair the ARM — more ` +
+        `warm-up, fewer arms per page, a longer measured window. The guard tolerance ` +
+        `is not yours to move.`
+    );
+    process.exit(2);
+  }
+  const ctlFailed = outcomes.filter((o) => o.controlFailed);
+  if (ctlFailed.length > 0) {
+    console.error(
+      `[converge] FAILED: the positive control did not see the change its own ` +
+        `arithmetic predicts on: ${ctlFailed.map((o) => o.row.id).join(', ')}. An ` +
+        `instrument that cannot see a predicted change cannot be trusted with an ` +
+        `unpredicted one.`
+    );
+    process.exit(1);
+  }
+  const failed = outcomes.filter((o) => o.err);
+  if (failed.length > 0) {
+    console.error(
+      `[converge] FAILED:\n  ` + failed.map((o) => `${o.row.id}: ${o.err}`).join('\n  ')
+    );
+    process.exit(1);
+  }
+  console.error('[converge] ok');
+})();

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// THE CONVERGED P0 CLOCK TABLE — driver (rf2-a4x1o).
+//
+//   node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
+//
+// There is no new driver here and there is no new build id. rf2-2rtt6.2
+// built `run.cjs` so that a sibling arm rides the `:hicasso-bench` lane by
+// naming its own `:init-fn`, and HD-017 makes a build-id touch a hot-zone
+// edit. This file is the three environment variables that name this arm's
+// entry, and then rf2-2rtt6.2's driver unchanged — which also makes the
+// reproduction command ABOVE runnable on Windows, where an inline
+// `VAR=value node ...` prefix is not a thing the shell understands and a
+// published repro that only runs on a POSIX shell is a repro that half the
+// maintainers cannot take.
+//
+// Exit codes are `run.cjs`'s and are not this file's to change:
+//
+//   0  measured, guard clean, control passed
+//   1  the run failed (build, page error, a fatal the page recorded, a
+//      positive control that did not see what it predicted)
+//   2  THE ARM-ORDER GUARD REFUSED. Repair the ARM, never the tolerance.
+
+'use strict';
+
+process.env.HICASSO_INIT_FN =
+  process.env.HICASSO_INIT_FN || 're-frame.bench.hicasso.p0-converge-app/-main';
+process.env.HICASSO_OUT_DIR = process.env.HICASSO_OUT_DIR || 'out/hicasso-converge';
+process.env.HICASSO_PORT = process.env.HICASSO_PORT || '8134';
+
+require('./run.cjs');

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_views.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_views.cljs
@@ -102,7 +102,21 @@
 ;; The subscriptions and the frames
 ;; ---------------------------------------------------------------------------
 
-(rf/reg-sub :p0/cell (fn [db [_ i]] (get-in db [:cells i])))
+(defn register!
+  "The sub graph: ONE layer-1 subscription, keyed by index, one read per
+  boundary — the first rung of the HD-002 1/3/7/20 ladder.
+
+  Called at load, exactly as it was when rf2-2rtt6.2 published, so this
+  arm's behaviour is unchanged. It is a FUNCTION as well because the
+  witness-convergence run (rf2-a4x1o) installs and destroys an adapter
+  once per segment and calls it again on every segment entry. A
+  re-register overwrites with the identical handler, so calling it twice
+  and calling it once are the same registry."
+  []
+  (rf/reg-sub :p0/cell (fn [db [_ i]] (get-in db [:cells i])))
+  nil)
+
+(register!)
 
 (def subs-frame
   "One frame for the `:reagent-subs` arm, created once at boot. A frame is

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_uix_views.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_uix_views.cljs
@@ -1,0 +1,109 @@
+(ns re-frame.bench.hicasso.p0-uix-views
+  "THE FRONTIER ARM, ON rf2-2rtt6.2'S WITNESSES — UIx reading re-frame2
+  subscriptions through the published `use-subscribe` spine (rf2-a4x1o,
+  re-pointing rf2-2rtt6.4).
+
+  ## Why this namespace exists at all
+
+  rf2-2rtt6.4 measured UIx-on-subs and, under RULING 1 on rf2-2rtt6.1,
+  its ratios ARE the red-zone thresholds. It measured them on its own
+  witnesses — a 1,203-element `W1` list reading `[:p0/row i]`, a
+  51-element `W3` form reading `[:p0/field i]`, and a 301-element grid.
+  rf2-2rtt6.2, which had not merged when that run was taken, supplies the
+  bar's DENOMINATOR on different witnesses: a 901-element `M1` list and a
+  51-element `M2` form, both reading `[:p0/cell i]`. A threshold and a bar
+  on two different pages cannot be read down one column, and a red-zone
+  that is not comparable across arms is not a red-zone.
+
+  This namespace is the UIx side of the convergence. There is no new
+  witness here and no new markup: every shape is
+  [[re-frame.bench.hicasso.p0-reagent-views]]'s, transcribed into UIx's
+  own spelling, and the canonical-DOM parity gate is what proves the
+  transcription rather than this docstring. If the two arms build
+  different pages the run stops before a clock is read.
+
+  ## What is deliberately NOT here
+
+  - **No `set-hiccup-emitter!`.** UIx's `$` expands to
+    `react/createElement` at compile time. Routing this arm through the
+    hiccup emitter would price a hiccup interpreter — which is a
+    candidate's product delta, not UIx's — and would set the red-zone from
+    the wrong runtime, flattering every later candidate.
+  - **No `use-memo` around the subscription args.** `use-subscribe`'s own
+    stable-deps handling is part of the spine under test.
+  - **No prop threading in place of a read.** Every boundary the Reagent
+    arm subscribes in, this arm subscribes in: one read per boundary, the
+    first rung of the HD-002 1/3/7/20 ladder. A row that took its text as
+    a prop would be a different sub graph wearing the same name.
+  - **No `flush-views!`.** The UIx adapter's own flush wraps React's
+    `act()`, and `act` diverts work to a queue that is not the browser's.
+    Every window in this lane is taken outside it (`lane/leave-act-
+    environment!`), so the UIx drain here is an empty
+    `react-dom/flushSync` — `useSyncExternalStore` notifications schedule
+    at React's SYNC lane, so that flush commits them inside the window,
+    and the DOM read-back is what checks it rather than this comment.
+
+  Owner: the operator-owned standard bead rf2-2rtt6.1; this arm rf2-a4x1o."
+  (:require [re-frame.adapter.uix :as uixa]
+            [re-frame.bench.hicasso.p0-reagent-views :as v]
+            [uix.core :refer [$ defui]]))
+
+;; ---------------------------------------------------------------------------
+;; M1 — the 300-boundary sub-reading list (901 elements)
+;; ---------------------------------------------------------------------------
+;;
+;; Read this beside `p0-reagent-views/m1-cell`. Same tag sugar, same class
+;; names, same attribute, same text — one boundary, one `[:p0/cell i]`
+;; read, and nothing else.
+
+(defui m1-cell [{:keys [i]}]
+  (let [v (uixa/use-subscribe [:p0/cell i])]
+    ($ :li.row
+       ($ :span.lbl "cell ")
+       ($ :span.cell {:data-i i} (str v)))))
+
+(defui m1 [{:keys [n]}]
+  ($ :ul.grid {:role "list"}
+     (for [i (range n)]
+       ($ m1-cell {:key i :i i}))))
+
+;; ---------------------------------------------------------------------------
+;; M2 — the ordinary 12-field form (51 elements)
+;; ---------------------------------------------------------------------------
+
+(defui m2-field [{:keys [i]}]
+  (let [v (uixa/use-subscribe [:p0/cell i])]
+    ($ :div.field
+       ($ :label.lbl {:for (str "f" i)} (str "Field " i))
+       ($ :input.inp {:id        (str "f" i)
+                      :name      (str "f" i)
+                      :type      "text"
+                      :value     (v/field-value i v)
+                      :read-only true})
+       ($ :p.err (v/field-error i)))))
+
+(defui m2 [{:keys [n]}]
+  ($ :form.p0form
+     ($ :fieldset.fields
+        (for [i (range n)]
+          ($ m2-field {:key i :i i})))
+     ($ :button.submit {:type "submit" :disabled true} "Submit")))
+
+;; ---------------------------------------------------------------------------
+;; The root
+;; ---------------------------------------------------------------------------
+
+(defn subs-root
+  "`frame-provider` SCOPES an already-created frame and renders no DOM of
+  its own, so it cannot move the canonical-DOM gate. The frame is created
+  by the segment's setup, outside every measured window: a mount window
+  containing `make-frame` and a seeding write would price frame
+  construction on whichever arm happened to own it.
+
+  The counterpart of [[re-frame.bench.hicasso.p0-reagent-views/subs-root]],
+  and it is not ceremony added for the bench — it is how a re-frame2 UIx
+  application supplies the frame its boundaries resolve `use-subscribe`
+  against."
+  [view n]
+  ($ uixa/frame-provider {:frame v/subs-frame}
+     ($ view {:n n})))


### PR DESCRIPTION
Converges the P0 clock table onto **one** witness set — rf2-2rtt6.2's — and
re-derives the clock red-zones on it, so a threshold and the bar row it
qualifies describe the same page.

Bead **rf2-a4x1o**. Results appended to the operator-owned standard bead
**rf2-2rtt6.1** (append only; nothing amended). Full record:
`docs/design/hicasso/studio/p0-converged-witness-set.md`.

---

## Rebased onto PR #7265 — what supersedes what, and what does not

PR #7265 (rf2-2rtt6.4, the frontier arm) merged while this branch was in flight,
so both records are now on main. **The two axes resolve differently, and the
resolution is deliberately not symmetric.**

**CLOCK — the converged rows below supersede rf2-2rtt6.4's, as thresholds.** The
bar's denominator is Reagent-on-subs, so the denominator's witness set defines
the comparison by construction; a threshold measured on a different witness is a
threshold on a different question. rf2-2rtt6.4 itself nominated that set in its
*Open items*. Its clock rows are **marked, not erased** — they remain sound as
ratios, and the house rule for overturning a recorded result is that a reader
must be able to see the measurement was revisited and why.

**HEAP — rf2-2rtt6.4's rows stand, and are NOT superseded.** This branch
deliberately did not re-run the heap axis, and that decision is preserved in the
record: three shapes spanning a **4× range in markup density agree within 8%**
(list 2.262×, grid 2.254×, ladder 2.435×), because **retained bytes per
subscribing boundary is a property of the boundary**. The clock is not — element
count decides what fraction of the window is React's own work. That asymmetry is
the whole reason one axis moved and the other did not.

Marked on `docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md` at three
points: a banner above Provenance, a line on each of the two red-zone tables, and
the *Open items* bullet that anticipated the move, now recorded as settled.

**Nothing was re-measured.** Both sets keep their own producing SHAs. The rebase
rewrote this branch's commit ids but left the instrument untouched — all four
bench files are byte-identical (same blob hashes) before and after, so the
reproduction command is unaffected. That is noted in the page's Provenance row.
rf2-2rtt6.4's page on main likewise cites its pre-merge producing SHA, so this
follows the programme's existing practice rather than inventing one.

### Two UIx arm files, both kept — deliberately

`implementation/core/test/re_frame/bench/p0_uix.cljs` (rf2-2rtt6.4's) and
`implementation/freehand/test/re_frame/bench/hicasso/p0_uix_views.cljs` (this
branch's) are **not duplicates**: different witness sets (W1/W3/grid against
M1/M2/bulk), different lanes (`:freehand-release` compiler settings against
`:hicasso-bench`), different drivers. rf2-2rtt6.4's tree is the **reproduction
path for its retained-heap thresholds, which remain operative** — deleting it
would orphan live thresholds that this PR explicitly does not re-measure. Both
stay; neither is silently redundant.

### Conflict resolved

One conflict, in `docs/design/hicasso/studio/README.md`: main had added a Pages
row for the reagent-slim diagnosis, this branch had added five rows plus the
red-zone note. **Both intents merged** — every row from both sides is present,
plus a row for rf2-2rtt6.4's frontier page (which existed on main but was listed
by neither side), and the trailing note now states the clock/heap split. The
README diff against main is additions only.

`rf2-39caf`'s documentation half — "decide what lands so rf2-2rtt6.1 never reads
as two competing thresholds for one witness family" — is discharged here. Its
`P0_BUILD` cleanup is not, and remains on that bead.

---

## The extent of the mismatch, measured

`rf2-2rtt6.2` publishes the bar's denominator on a **901-element M1** and a
51-element M2, both reading `[:p0/cell i]`. `rf2-2rtt6.4` published the frontier
on a **1,203-element W1** reading `[:p0/row i]`, a 51-element W3 reading
`[:p0/field i]`, and a 301-element grid.

| pair | verdict |
|---|---|
| M1 mount ↔ W1 mount | **not comparable** — 33% more elements, four per row against three |
| M2 mount ↔ W3 mount | **nearly comparable** — identical element count and markup skeleton; differs in the sub's value shape and, materially, in **grade** |
| bulk broad ↔ U-broad | **not comparable, but closest** — same boundary count and sub graph, 3× the markup density, different write path |
| — ↔ U-narrow | **no counterpart at all** |
| heap rows | **a different axis — and it did not need re-running** |

Plus one mismatch that is not about pages: rf2-2rtt6.2 grades its 51-element
form row **diagnostic** and says it must not be quoted against the bar;
rf2-2rtt6.4 batched mounts, lifted the same-sized witness off the clamp, and
published its form row as a **threshold**. Resolved here by grading the
converged form row diagnostic, like its bar row.

**One arm needed re-running, not two.** Retained heap already rested on three
shapes agreeing within 8% (2.262× / 2.254× / 2.435×) across a 4× spread in
markup density — bytes per subscribing boundary is a property of the boundary.
The clock is not, and its four rows did not agree.

## What was re-measured

A UIx-on-subs arm on rf2-2rtt6.2's witnesses, in rf2-2rtt6.2's `:hicasso-bench`
lane. **No new build id; `implementation/shadow-cljs.edn` untouched.**

| row | red-zone (UIx ÷ Reagent) | range | verdict |
|---|---|---|---|
| **M1 mount** (901 el, 300 boundaries) | **1.2301×** | 1.110 – 1.354 | UIx slower, disjoint |
| M2 mount (51 el) · *diagnostic* | 1.0539× | 0.857 – 1.429 | straddles 1.0 — indistinguishable |
| **bulk broad** (all 300 read) | **0.6239×** | 0.470 – 0.786 | UIx faster, disjoint |
| bulk narrow (one reads) · *new row* | 1.1556× | 1.042 – 1.250 | **not resolved** — clamp-limited, see below |

**Three of rf2-2rtt6.4's four clock verdicts do not survive the move.** The
large-list mount goes from indistinguishable to *UIx slower, disjoint*; the form
mount goes from *UIx faster, disjoint* to indistinguishable; the broad margin
widens; the narrow row's strength collapses. None of that makes rf2-2rtt6.4
wrong — each of its ratios is still a ratio measured in one run on one page —
it shows that a clock ratio moves by more than the effects being measured when
the page changes.

The **denominator reproduces rf2-2rtt6.2**: this arm's `reagent-subs ÷ floor`
ranges overlap that arm's published ranges on all three shared rows. The
convergence moved the frontier arm onto the denominator's pages without moving
the denominator.

**Nothing re-labelled.** The narrow row is new (rf2-2rtt6.2 has no narrow
counterpart) and is labelled as such. The one row whose verdict is unstable
across two runs is published as **unresolved**, not as a win.

## Instrument

- **0 unverified of 2,460** — 600 M1 mounts + 600 M2 mounts + 630 broad writes +
  630 narrow writes, each read back out of the DOM inside its own window, mounts
  also checked against a *written* element count so the gate can answer false.
- **Positive controls predicted before the run: 8 of 8 pass** at ±25%, seven of
  eight below prediction. (The ±0.001% standard is the heap control's; this run
  measures no heap.)
- **Both orders**, ranges never a mean alone, and **rf2-ouwh8 asserted at boot in
  both directions** — `slot-order` must degenerate at k=2 and must not at k=3, or
  the run refuses to measure. Three arms a segment, so no two-arm plan is ever
  formed.
- **The segment seam is published**: `floor(UIx) ÷ floor(Reagent)` straddles 1.0
  on all four rows.
- **The guard refused this arm twice, exit 2, and the arm was repaired both
  times** — phase drift across a page running four rows (the floor, which cannot
  change, read 2.1739× last-third over first-third with disjoint ranges) and a
  mislabelled predecessor stratum from a different row. Repairs: one row per
  page, and a warm-up that advances the predecessor pointer without banking a
  sample. **The tolerance was not touched.**

## Follow-ups filed

- **rf2-39caf (P1)** — the documentation half is **discharged by this PR** (see
  above): rf2-2rtt6.4's clock rows are marked superseded in place, its heap rows
  marked retained, so rf2-2rtt6.1 no longer reads as two competing thresholds for
  one witness family. The `P0_BUILD` cleanup from rf2-a4x1o's original scope
  remains open on that bead.
- **rf2-zb3qg (P2)** — lift the narrow row off the clock clamp with k writes to a
  window, and re-guard rather than assume (rf2-2rtt6.2 has a recorded refusal
  from batching on this witness family).

## Quality gates

Measurement gates were run by the original worker at `44900cd4fd` on a clean
tree; the rebase left all four bench files byte-identical, so they were **not**
re-run and nothing was re-measured.

| gate | exit |
|---|---|
| `node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` — the measurement, run at `44900cd4fd` on a clean tree; guard reportable on every row | **0** |
| the same command, second independent run (replication) | **0** |
| `node implementation/freehand/test/re_frame/freehand/bench/order_guard.cjs` — order-guard self-test | **0** |
| `npm run test:browser` — 842 tests, 5469 assertions, 0 failures, 0 errors | **0** |
| `npm run test:freehand` — 1393 tests, 7733 assertions, 0 failures, 0 errors | **0** |
| `npm run test:script-policy` | **0** |
| `mkdocs build --strict` | **0** |

Re-run after the rebase, on the merged tree (the rebase touched documentation
only):

| gate | exit |
|---|---|
| `python -m mkdocs build --strict` | **0** |
| `python scripts/check_doc_slugs.py` | **0** |

The first run of the first cut exited **2** — the arm-order guard refusing — and
is recorded on the studio page and on rf2-2rtt6.1 rather than quietly repaired.
