### PR TITLE
bench(hicasso): re-take HD-008's reagent-slim rows against a scheduler-aware drain (rf2-b69lw)

### DIFF
--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -31,7 +31,7 @@ Bead **`rf2-2rtt6.7`**. Decision **[HD-008](../decisions.md)**. The standard is
 | | |
 |---|---|
 | **Producing commit** | `d46ede4fb05a8f4c5af9900f0a010772f0b0883a` — every row except the `reagent-slim` write rows |
-| **Producing commit** | `b943c7ed20d63d66fade4775059dad9fcf0012a7` — the `reagent-slim` write rows, re-taken (`rf2-b69lw`) |
+| **Producing commit, re-take** | `b943c7ed20d63d66fade4775059dad9fcf0012a7` — the `reagent-slim` write rows only (`rf2-b69lw`) |
 | **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs` |
 | **Build** | `:hicasso-bench` (rf2-2rtt6.2's lane) — `:advanced`, `goog.DEBUG false` |
 | **Runtime** | Chromium `HeadlessChrome/147.0.7727.15` (Windows NT 10.0 x64), React 19.2.0, node v24.13.0 |

--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -30,7 +30,8 @@ Bead **`rf2-2rtt6.7`**. Decision **[HD-008](../decisions.md)**. The standard is
 
 | | |
 |---|---|
-| **Producing commit** | `d46ede4fb05a8f4c5af9900f0a010772f0b0883a` |
+| **Producing commit** | `d46ede4fb05a8f4c5af9900f0a010772f0b0883a` — every row except the `reagent-slim` write rows |
+| **Producing commit** | `b943c7ed20d63d66fade4775059dad9fcf0012a7` — the `reagent-slim` write rows, re-taken (`rf2-b69lw`) |
 | **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs` |
 | **Build** | `:hicasso-bench` (rf2-2rtt6.2's lane) — `:advanced`, `goog.DEBUG false` |
 | **Runtime** | Chromium `HeadlessChrome/147.0.7727.15` (Windows NT 10.0 x64), React 19.2.0, node v24.13.0 |
@@ -38,6 +39,16 @@ Bead **`rf2-2rtt6.7`**. Decision **[HD-008](../decisions.md)**. The standard is
 
 Every figure below is a **browser** figure, which is what HD-012 requires of
 anything quotable against the bar.
+
+**Two producing commits, and the second one only re-took what the first
+suppressed.** At `d46ede4f` the `reagent-slim` write rows read *78 of 78*
+unverified and their figures were withheld. `rf2-z3vlz` diagnosed why and
+`rf2-b69lw` repaired it; `b943c7ed` is that repair, and the `reagent-slim`
+write rows below are its. **No other row was replaced.** The repair changes the
+write window for arms on a **microtask-scheduled** substrate and leaves every
+other arm's window byte-for-byte as it was, so the rows taken at `d46ede4f`
+stand as published — see [the re-take](#the-re-take-rf2-b69lw) for what was
+changed and the reproduction check that says the change was inert for them.
 
 ## The arms
 
@@ -137,8 +148,15 @@ Within-run, `uix` run:
 | `donor-r2 / donor-r1` — the shell | 1.000 – 1.167 · *indistinguishable* |
 
 Cross-run, floor-normalised — **the weaker warrant**: `donor-r1` 5.000 – 8.000 and
-`donor-r2` 5.000 – 8.000 against `reagent` 3.000 – 5.000. This row's precision is the
-instrument's weakest (see limitations). `reagent-slim`: **UNPUBLISHED** — 78/78 unverified.
+`donor-r2` 5.000 – 8.000 against `reagent` 3.000 – 5.000 and **`reagent-slim`
+2.667 – 6.000**. This row's precision is the instrument's weakest (see
+limitations), and the `reagent-slim` figure is the weakest of those: **the floor
+it is normalised against has a p50 of 0.10 – 0.15 ms against a 100 µs quantum**,
+so the denominator is one to one-and-a-half quanta wide. An independent
+slim-only replication at `f5bd4b49` read 3.000 – 5.500 on the same row — inside
+the published range, and the run-to-run spread is the honest size of this row's
+precision. Absolute p50s: `reagent-slim` 0.40 – 0.60 ms, floor 0.10 – 0.15 ms.
+**0 unverified of 78.**
 
 ### Write — bulk (all 300 cells in one commit)
 
@@ -151,7 +169,11 @@ Within-run, `uix` run:
 | `donor-r2 / donor-r1` — the shell | 1.046 – 1.125 |
 
 Cross-run, floor-normalised — **the weaker warrant**: `donor-r1` 7.750 – 11.000 and
-`donor-r2` 8.250 – 11.750 against `reagent` 8.750 – 17.000. `reagent-slim`: **UNPUBLISHED** — 78/78 unverified.
+`donor-r2` 8.250 – 11.750 against `reagent` 8.750 – 17.000 and **`reagent-slim`
+11.000 – 13.667**. The independent slim-only replication at `f5bd4b49` read
+9.500 – 13.000. Absolute p50s: `reagent-slim` 2.05 – 2.70 ms, floor
+0.15 – 0.20 ms — four to eighteen quanta, so this row is far better resolved
+than the narrow one beside it. **0 unverified of 78.**
 
 ### What the rungs cost
 
@@ -178,7 +200,10 @@ is not passing vacuously.
 two sizes interleaved as arms in one round. **Predicted 1.9934** from the
 witness's own arithmetic `(3 + 3N) / (3 + 3(N/2))` at N = 300, before any clock
 was read. Measured `1.800–2.000` (uix run), `1.750–2.000` (reagent run) and
-`1.667–1.833` (slim run) — every round inside ±30%.
+`1.667–1.833` (slim run) — every round inside ±30%. The re-take predicted the
+same `1.9934` before its own clock and measured `1.750–1.833`, `1.750–2.083`
+and `1.714–1.846` — again every round inside the band, on the run that produced
+the `reagent-slim` figures as much as on the two that did not.
 
 **Event-vector lowering** — one click fired through rung 2's codec-lowered
 handler, outside every measured window, read back out of the DOM:
@@ -189,12 +214,21 @@ call — the fastest possible implementation of the wrong thing.
 **Arm-order guard** — every sample carries its predecessor **and its position in
 the run**; the guard partitions on both and refuses any arm whose figure moves
 with the plan. All **twelve** rows across the three runs came back
-*reportable*, on both factors, with none refused.
+*reportable*, on both factors, with none refused — and the same twelve did on
+the re-take. The two-arm write rows are the ones the `k = 2` degeneracy below
+would have silenced, and they did not run in one order: each arm's 60 samples
+split **30 / 30** across its two possible predecessors, which is the local
+`slot-order` override working.
 
-**156 unverified of 936** measured writes — every one of them the
-`reagent-slim` arm, whose figures are suppressed rather than published.
+**DOM read-back — 0 unverified of 1,248**, which is every write the driver
+executes across the three runs (`0 of 960` counting only the timed post-warmup
+samples). At `d46ede4f` the same counts read **156 of 1,248** and **120 of 960**,
+every one of them the `reagent-slim` arm, and its write figures were suppressed
+rather than published. *An earlier version of this page reported that as "156
+unverified of 936", which is not a like-for-like denominator and is corrected
+here.*
 
-### Four faults the instrument caught before they became numbers
+### Five faults the instrument caught before they became numbers
 
 1. **The floor ignored the witness's `n`** and built 300 rows for a 6-row
    witness. Caught by parity at the small size.
@@ -214,6 +248,12 @@ with the plan. All **twelve** rows across the three runs came back
    Three copies of that arithmetic carry the defect; filed as **`rf2-ouwh8`**
    and repaired locally, because sibling P0 arms were measuring on the shared
    copies at the time.
+5. **The write window waited one fixed microtask for every arm**, and one
+   fixed wait is not neutral across scheduler families. The `reagent-slim`
+   write rows read **78 of 78** unverified on the first publication and were
+   suppressed — which is the read-back doing its job, because unsuppressed
+   they said `0.16–0.50×` the floor while the page never changed. The cause
+   is below.
 
 ### Two findings that are not about the clock
 
@@ -226,15 +266,75 @@ fixes it — `ratom/flush!` settles the subscription graph and
 neither. This bounds what *"composed from parts already in the repo"* can mean:
 the composition cannot share a process with the thing it must beat.
 
-**The `reagent-slim` arm is not reactive in this bundle.** Its mount is
-correct — parity passes at both sizes, values right — but 78 of 78 writes
-failed their DOM read-back, under both write mechanisms and every drain tried.
-Its write figures are therefore **suppressed, not published**: unsuppressed
-they read 0.16–0.50× the floor while the page never changed, which is a precise,
-plausible, entirely wrong number and exactly the fault the read-back exists to
-catch. Filed as **`rf2-z3vlz`**; the leading hypothesis is a mixed-bundle
-artefact of stock `reagent` and `reagent2` coexisting, which would make it
-bench-only.
+**A benchmark harness cannot hold one wait for every substrate.** The
+`reagent-slim` arm looked non-reactive and was in fact merely **late** — every
+write landed, one macrotask after the window closed — because
+`reagent2.impl.batching` schedules its render queue on the **microtask** queue
+and the harness yielded a microtask between the write and the drain. Stock
+Reagent survived the identical harness only because its queue is
+`requestAnimationFrame`-scheduled and was therefore still full when the drain
+arrived. `app-db` followed **every** write in every bundle, so the failure was
+always on the view leg; and the positive control that reproduces it is a plain
+`reagent2` component reading a plain `reagent2.core/atom`, with no frame, no
+`subscribe` and no adapter hook, which puts **re-frame nowhere on the causal
+path**. Diagnosed under **`rf2-z3vlz`**
+([slim-non-reactive-arm-diagnosis.md](slim-non-reactive-arm-diagnosis.md)), and
+neither the adapter nor the mixed bundle is implicated: four bundle
+compositions from 96 to 114 compiled sources return byte-identical verdicts.
+**No shipped code needs changing and no consumer is affected** — an application
+does not write and then yield before flushing; the shipped reagent-slim adapter
+smoke was green throughout, and it was right.
+
+## The re-take (`rf2-b69lw`)
+
+**What changed.** The write window's wait now belongs to the **arm** rather than
+to the harness. `hd8-rows/arm-scheduler` names the queue each arm's own render
+work is scheduled on — `:none` for the floor and for the React spine,
+`:animation-frame` for stock Reagent, `:microtask` for reagent-slim — and
+`window-of` gives a `:microtask` arm a window with **nothing between the write
+and the drain**. Every other arm's window is the same three operations in the
+same order as before, and the DOM read-back still runs in the same turn as the
+drain, so a commit that arrives a turn late still reads as unverified rather
+than as a pass.
+
+**The suppressed figures were not rescued; they were re-taken.** They priced a
+commit that had not happened, and the size of the correction says so: the narrow
+write moved from `0.16–0.50×` the floor to `2.667–6.000×`, and the bulk write
+to `11.000–13.667×`. A number roughly an order of magnitude below the truth is
+what an unpaid commit looks like from inside a clock.
+
+**Two windows do not bill the same wait, so the difference was measured.** The
+`reagent-slim` window omits one harness microtask that the floor's contains.
+`hd8-rows/yield-cost!` prices exactly that turn against the same clock, outside
+every arm's window, and read **p50 0.0 ms, min 0.0, max 0.0 over 10 samples in
+all three runs** — the harness microtask is below the 100 µs quantum, so the
+asymmetry is beneath this instrument's resolution and nothing has to be
+subtracted before the ratios above are read. Had it read anything else, this
+page would owe the reader a subtraction.
+
+**Reproduction check — NOT a republication.** The re-take ran all three
+adapters, so the rows published at `d46ede4f` were measured again by a driver
+carrying the change. Every one of them reproduced: on the mount rows, which are
+the well-resolved ones, `donor-r1 / uix` in the `uix` run read `1.150 – 1.233`
+against the published `1.149 – 1.230`. On the write rows five of the six
+published cross-run ranges are **contained in** the re-take's and the sixth
+overlaps it (narrow `donor-r1` `4.000 – 8.000` ⊃ `5.000 – 8.000`; narrow
+`reagent` `2.500 – 7.000` ⊃ `3.000 – 5.000`; bulk `donor-r1` `6.000 – 12.000`
+⊃ `7.750 – 11.000`; bulk `reagent` `9.750 – 19.000` overlapping
+`8.750 – 17.000`). The re-take's write ranges are **wider** — four sibling
+workers were live on the host — which is why they are cited as a check and not
+as a replacement. **No figure moved systematically, and nothing published was
+invalidated.** `HD8_ONLY` exists so that a future re-take of one run cannot mint
+a competing set of figures for rows published at another commit.
+
+**Where the general fix belongs, and why it is not here.** The same fixed yield
+lives in the shared `lane/verified-write!`, which every Hicasso arm uses, and
+the general repair — an arm-declared drain slot, additive, today's path
+unchanged when it is absent — is filed as **`rf2-pq7d8`**. It is deliberately
+**not** made here: `lane.cljs` is a shared instrument with sibling arms
+measuring on it, and a shared instrument must not change under a measurement in
+flight. HD-008's own `timed-write!` is a separate copy, which is why this repair
+could land without touching it.
 
 ## Known limitations of this instrument
 
@@ -245,7 +345,15 @@ bench-only.
 - **The bulk write verifies one probe cell**, where the shared lane verifies a
   seq including the far end of the grid. Same bead.
 - **The write rows' donor-vs-Reagent comparison is cross-run**, floor-normalised.
-  The mount rows' is not.
+  The mount rows' is not. **The `reagent-slim` write column is normalised through
+  the floor of a run taken at a different commit** from the donor and `reagent`
+  columns beside it, which is weaker again; the reproduction check above is what
+  that reading rests on.
+- **Two window shapes now exist**, and only one of them contains the harness
+  microtask. Measured at 0.0 ms against a 100 µs quantum, so it is beneath this
+  instrument's resolution — but a future instrument with a finer clock inherits
+  a real asymmetry, not a settled one, and `rf2-pq7d8` is where it gets settled
+  properly.
 - **No retained-heap leg.** The red-zone rule governs clock *and* retained heap;
   this arm measures the clock. The heap ladder is `rf2-2rtt6.5`'s
   ([reads-per-boundary-heap-ladder.md](reads-per-boundary-heap-ladder.md)).

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
@@ -197,7 +197,16 @@
                           (doseq [wit rows/witnesses]
                             (record-row! (keyword (str "mount-" (name (:id wit))))
                                          (rows/measure-mount! wit arm-ids rounds mount-sampling)))
-                          (-> (rows/measure-write! write-ids which :narrow rounds write-sampling)
+                          ;; The harness microtask, priced before the write rows
+                          ;; and outside every one of their windows. A
+                          ;; microtask-scheduled arm's window does not contain
+                          ;; that turn and its rivals' do (rf2-b69lw), so the
+                          ;; size of the asymmetry is published beside the rows
+                          ;; rather than argued about after them.
+                          (-> (rows/yield-cost! write-sampling)
+                              (.then (fn [yc]
+                                       (record! :yield-cost yc)
+                                       (rows/measure-write! write-ids which :narrow rounds write-sampling)))
                               (.then (fn [r]
                                        (record-row! :write-narrow r)
                                        (rows/measure-write! write-ids which :bulk rounds write-sampling)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
@@ -494,6 +494,90 @@
     ;; scheduler a couple of milliseconds later.
     (react-dom/flushSync (fn [] nil))))
 
+(defn arm-scheduler
+  "Which queue THIS arm's own render work is scheduled on — and therefore
+  how its write window must wait for it (rf2-b69lw).
+
+  This is the fact [[window-of]] needs and the one the instrument
+  previously did not ask for. A window that waits a fixed one microtask
+  serves an arm whose notification is queued somewhere ELSE and silently
+  breaks an arm whose notification is queued on the very queue the
+  harness is yielding to.
+
+    - `:none` — the floor (a local `swap!` and a `flushSync` render, with
+      nothing queued anywhere) and the React spine (`use-subscribe`'s
+      containers notify synchronously; the empty `flushSync` is the whole
+      drain).
+    - `:animation-frame` — stock Reagent. `reagent.impl.batching` schedules
+      its component queue on `requestAnimationFrame`, so the queue is still
+      full a microtask later and the drain finds the work.
+    - `:microtask` — reagent-slim. `reagent2.impl.batching` is *\"a
+      microtask-based scheduler … no requestAnimationFrame fallback is
+      required\"*, so a microtask yield hands the queue to the substrate
+      BEFORE the drain: it issues its `forceUpdate` outside any `flushSync`
+      boundary, React parks the work at the default lane, and the drain
+      that follows finds nothing to commit."
+  [arm-id adapter]
+  (if (= arm-id :floor)
+    :none
+    (case adapter
+      :slim    :microtask
+      :reagent :animation-frame
+      :none)))
+
+(defn- window-of
+  "The measured write window for an arm on `scheduler`.
+
+  Answers `(fn [write! verify!] → promise of {:ms :ok?})`. The clock starts
+  before the write and stops after the arm's own synchronous drain; the DOM
+  read-back runs in the SAME turn as the drain, never in a later one, so a
+  commit that arrived a turn late reads as UNVERIFIED rather than as a pass.
+
+  TWO SHAPES, BECAUSE ONE FIXED WAIT IS NOT NEUTRAL ACROSS SCHEDULER
+  FAMILIES. That is rf2-b69lw, and rf2-z3vlz diagnosed it against a
+  standalone rig: the reagent-slim write row read `78 of 78` unverified —
+  and, unsuppressed, `0.16–0.50x` the floor while the page never changed —
+  purely because the harness put a microtask between the write and the
+  drain. `docs/design/hicasso/studio/slim-non-reactive-arm-diagnosis.md`
+  carries the evidence, including the positive control (a plain component
+  reading a plain `reagent2.core/atom`, no re-frame anywhere on the path)
+  that reproduces it in all four bundle compositions. The general form —
+  the same fixed yield in the shared `lane/verified-write!` — is filed as
+  rf2-pq7d8 and is NOT repaired here: `lane.cljs` is a shared instrument
+  with sibling arms measuring on it.
+
+    `:microtask`  write, then drain, with NOTHING between them. The
+                  substrate's queue is filled synchronously by the write and
+                  is still there when `flush-render!` opens its boundary, so
+                  the commit lands inside the window.
+
+    everything else  today's window, unchanged: write, yield ONE microtask,
+                  drain. b6 records that with the microtask deleted every
+                  arm whose notification is queued elsewhere fails its own
+                  read-back on every write, and the published HD-008 rows
+                  were taken through exactly this shape.
+
+  The two shapes do NOT bill the same wait, and that difference is not left
+  as an assurance: [[yield-cost!]] prices the harness microtask against the
+  same clock, outside every arm's window, and it is published beside the
+  write rows."
+  [scheduler force!]
+  (if (= scheduler :microtask)
+    (fn [write! verify!]
+      (let [t0 (lane/now-ms)]
+        (write!)
+        (force!)
+        (let [ms (- (lane/now-ms) t0)]
+          (js/Promise.resolve {:ms ms :ok? (verify!)}))))
+    (fn [write! verify!]
+      (let [t0 (lane/now-ms)]
+        (write!)
+        (-> (js/Promise.resolve nil)
+            (.then (fn [_]
+                     (force!)
+                     (let [ms (- (lane/now-ms) t0)]
+                       {:ms ms :ok? (verify!)}))))))))
+
 (defn- write-arm
   "The write door for `arm-id` on the U page.
 
@@ -501,12 +585,22 @@
   records: `root.render` outside a React event schedules at the default
   lane, and an EMPTY flushSync flushes only the sync lane — a floor arm
   that rendered in `write!` would have its commit land outside the window
-  entirely. Every other arm drains through [[spine-drain!]]."
+  entirely. Every other arm drains through [[spine-drain!]].
+
+  The arm also carries its own `:window!` ([[window-of]]), because the wait
+  between the write and that drain is a property of the arm's scheduler and
+  not of the harness."
   [arm-id adapter]
   (let [fid   (frame-of arm-id)
         state (atom nil)
         rt    (volatile! nil)
-        arm   (u-arm arm-id)]
+        arm   (u-arm arm-id)
+        sched (arm-scheduler arm-id adapter)
+        force! (fn []
+                 (if (= arm-id :floor)
+                   (react-dom/flushSync
+                     (fn [] (.render ^js @rt (w/floor-u {:cells @state :n w/cells-n}))))
+                   (spine-drain! adapter)))]
     {:id     arm-id
      :mount  (fn [container]
                (if (= arm-id :floor)
@@ -535,11 +629,9 @@
                  (if (= i :all)
                    (rf/dispatch-sync [:hd8/set-all val] {:frame fid})
                    (rf/dispatch-sync [:hd8/set i val] {:frame fid}))))
-     :force! (fn []
-               (if (= arm-id :floor)
-                 (react-dom/flushSync
-                   (fn [] (.render ^js @rt (w/floor-u {:cells @state :n w/cells-n}))))
-                 (spine-drain! adapter)))
+     :force!    force!
+     :scheduler sched
+     :window!   (window-of sched force!)
      :unmount (fn [handle]
                 (react-dom/flushSync
                   (fn [] (if (= arm-id :floor)
@@ -563,25 +655,26 @@
     (.remove container)))
 
 (defn timed-write!
-  "Write, yield ONE microtask, force the arm's own synchronous drain, stop
-  the clock — then VERIFY at the DOM that the probed cell holds what was
-  written. Answers a promise of `{:ms … :ok? …}`.
+  "Write, wait the way THIS ARM'S SCHEDULER requires, force the arm's own
+  synchronous drain, stop the clock — then VERIFY at the DOM that the
+  probed cell holds what was written. Answers a promise of
+  `{:ms … :ok? …}`.
 
-  The yield is not historical and not optional: b6 records that with the
-  microtask deleted every reactive arm fails this function's own read-back
-  on every write. The read-back is inside the window's own iteration, so
-  an arm that silently rendered nothing reports as UNVERIFIED rather than
-  as the fastest substrate in the table — which is the exact shape of the
-  fault this exists to prevent."
+  The wait belongs to the arm ([[window-of]]) and not to this function,
+  which is the whole of rf2-b69lw: a fixed one-microtask yield is
+  load-bearing for an arm whose notification is queued somewhere else and
+  is FATAL for an arm whose notification is queued on the microtask queue
+  itself.
+
+  The read-back is inside the window's own iteration and in the same turn
+  as the drain, so an arm that silently rendered nothing — or rendered a
+  turn late — reports as UNVERIFIED rather than as the fastest substrate in
+  the table, which is the exact shape of the fault this exists to prevent."
   [{:keys [arm container]} i val]
-  (let [t0 (lane/now-ms)]
-    ((:write! arm) i val)
-    (-> (js/Promise.resolve nil)
-        (.then (fn [_]
-                 ((:force! arm))
-                 (let [ms    (- (lane/now-ms) t0)
-                       probe (if (= i :all) 0 i)]
-                   {:ms ms :ok? (= val (cell-text container probe))}))))))
+  (let [probe (if (= i :all) 0 i)]
+    ((:window! arm)
+     (fn [] ((:write! arm) i val))
+     (fn [] (= val (cell-text container probe))))))
 
 (defn- chain
   "Sequence `f` over `xs` through promises, threading `acc`."
@@ -678,6 +771,48 @@
                   :writes     (:total acc)
                   :samples    (:samples acc)})))
         (.catch (fn [e] (release-write-arms! mounts) (throw e))))))
+
+;; ===========================================================================
+;; What the two window shapes cost differently
+;; ===========================================================================
+
+(defn yield-cost!
+  "Price ONE harness microtask against the same clock the write rows use:
+  `now-ms`, a resolved-promise turn, `now-ms`, and nothing else in between.
+
+  [[window-of]] gives a microtask-scheduled arm a window that does NOT
+  contain this turn while every other arm's does, and that asymmetry has to
+  be a NUMBER rather than an assurance — it is the only thing separating
+  the reagent-slim write row from a like-for-like comparison against the
+  floor beside it. Chrome clamps `performance.now()` to 100 µs, so a
+  reading of `0.0` here is the instrument saying the difference is below
+  its own resolution; anything else has to be subtracted before a ratio is
+  quoted, and the report must say which happened.
+
+  Measured OUTSIDE every arm's window, in its own turns, so it perturbs no
+  published figure. Warmed like every other row, because a first promise
+  turn is not a representative one."
+  [{:keys [warmup samples]}]
+  (-> (chain []
+             (range (+ warmup samples))
+             (fn [acc s]
+               (let [t0 (lane/now-ms)]
+                 (-> (js/Promise.resolve nil)
+                     (.then (fn [_]
+                              (let [ms (- (lane/now-ms) t0)]
+                                (cond-> acc (>= s warmup) (conj ms)))))))))
+      (.then (fn [xs]
+               (let [s (lane/summarise xs)]
+                 {:control :harness-microtask-yield
+                  :p50     (:p50 s)
+                  :min     (:min s)
+                  :max     (:max s)
+                  :n       (:n s)
+                  :clamp   "Chrome clamps performance.now() to 100 µs"
+                  :note    (str "the turn every non-microtask-scheduled arm's write "
+                                "window contains and the reagent-slim arm's does not "
+                                "(rf2-b69lw); 0.0 means the asymmetry is below this "
+                                "instrument's resolution")})))))
 
 ;; ===========================================================================
 ;; The positive control — predicted against measured, every run
@@ -807,6 +942,16 @@
    :adapter           adapter
    :mount-arms        (vec arm-ids)
    :write-arms        (vec write-ids)
+   ;; Which window shape each write arm was measured through, stated rather
+   ;; than left to be inferred from the adapter (rf2-b69lw). A row whose
+   ;; reader cannot tell whether its window contained a harness microtask
+   ;; cannot tell whether two arms in it were compared like for like.
+   :write-windows     (into {} (map (fn [id]
+                                      [id (let [s (arm-scheduler id adapter)]
+                                            (if (= s :microtask)
+                                              {:scheduler s :window :write-then-drain}
+                                              {:scheduler s :window :write-yield-drain}))]))
+                            write-ids)
    ;; The runtime is labelled beside every figure, not in a footnote. HD-012
    ;; makes every bar-relevant number a BROWSER number under `:advanced`
    ;; with goog.DEBUG false; a JVM or Node figure is diagnostic only and is

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
@@ -75,11 +75,23 @@ const PORT = Number(process.env.HD8_PORT || 8129);
 // Reagent paths need the ratom spine while the frontier and donor arms
 // ride React hooks — so the arms that can be compared head to head are
 // partitioned this way and every HD-008 comparison lands WITHIN a run.
-const RUNS = [
+const ALL_RUNS = [
   { id: 'uix', query: '?adapter=uix', why: 'donor rungs against the frontier' },
   { id: 'reagent', query: '?adapter=reagent', why: 'donor rungs against stock Reagent' },
   { id: 'slim', query: '?adapter=slim', why: 'donor rungs against reagent-slim' },
 ];
+
+// `HD8_ONLY=slim` drives one run instead of three, over the SAME bundle and
+// the same gates. Not a shortcut: re-taking one run's suppressed row must not
+// mint a competing set of figures for the rows already published at another
+// SHA, and a driver that could only run all three would force exactly that.
+// Unset is the full three, so the published shape is the default.
+const ONLY = (process.env.HD8_ONLY || '').trim();
+const RUNS = ONLY ? ALL_RUNS.filter((r) => ONLY.split(',').includes(r.id)) : ALL_RUNS;
+if (RUNS.length === 0) {
+  console.error(`[hd8] HD8_ONLY=${ONLY} selects no run; known ids: ${ALL_RUNS.map((r) => r.id).join(', ')}`);
+  process.exit(1);
+}
 
 // The guard's tolerance. `order_guard.cjs` defends the choice: 0.10 sits far
 // below the 2.01x the recorded fault produced and far above the 0.4% the same
@@ -268,6 +280,7 @@ function crossRun(runs) {
   console.log(`;;   reproduce   node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs`);
   console.log(`;;   build       shadow-cljs release freehand-release (:advanced, goog.DEBUG false)`);
   console.log(`;;   node        ${process.version}`);
+  console.log(`;;   runs        ${RUNS.map((r) => r.id).join(', ')}${ONLY ? `  (HD8_ONLY=${ONLY})` : ''}`);
 
   build();
   const server = serve();

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
@@ -277,7 +277,12 @@ function crossRun(runs) {
   console.log(`;; ==== HD8 PROVENANCE ====`);
   console.log(`;;   bead        rf2-2rtt6.7 (HD-008, EP-0038)`);
   console.log(`;;   commit      ${sha}`);
-  console.log(`;;   reproduce   node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs`);
+  // The repro line carries the environment it was actually run with, not the
+  // bare command: a published figure whose repro command does not reproduce it
+  // is a figure nobody can check.
+  console.log(
+    `;;   reproduce   ${ONLY ? `HD8_ONLY=${ONLY} ` : ''}node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs`
+  );
   console.log(`;;   build       shadow-cljs release freehand-release (:advanced, goog.DEBUG false)`);
   console.log(`;;   node        ${process.version}`);
   console.log(`;;   runs        ${RUNS.map((r) => r.id).join(', ')}${ONLY ? `  (HD8_ONLY=${ONLY})` : ''}`);


### PR DESCRIPTION
HD-008's `reagent-slim` write rows were suppressed rather than published, and that
was right: unsuppressed they read **0.16–0.50× the floor while the page never
changed**. `rf2-z3vlz` diagnosed the cause and it is the instrument, not the
adapter. This fixes it and re-takes the figures.

## N unverified of M — before and after

| | executed writes | timed samples | per `reagent-slim` row |
|---|---|---|---|
| **before** (`d46ede4f`) | 156 of 1,248 | 120 of 960 | 78 of 78 |
| **after** (`b943c7ed`) | **0 of 1,248** | **0 of 960** | **0 of 78** |

Zero unverified across every arm and every row in all three runs. The page's
earlier `156 unverified of 936` was not a like-for-like denominator and is
corrected.

## The figures, which I can now stand behind

Ratio to the floor measured in the same round, range over 6 rounds, cross-run and
floor-normalised — the weaker warrant this row has always carried.

| row | `reagent-slim` vs floor | replication (`HD8_ONLY=slim`, `f5bd4b49`) |
|---|---|---|
| write **narrow** | **2.667 – 6.000** | 3.000 – 5.500 |
| write **bulk** | **11.000 – 13.667** | 9.500 – 13.000 |

The narrow row is this instrument's weakest figure and is quoted as such: its
floor has a p50 of 0.10–0.15 ms against a 100 µs quantum, so the denominator is
one to one-and-a-half quanta wide (`rf2-f5roa` is the recorded repair). The bulk
row's floor is 0.15–0.20 ms against a `reagent-slim` 2.05–2.70 ms and is far
better resolved.

For scale against what was withheld: the suppressed narrow figure said
`0.16–0.50×`. An unpaid commit is roughly an order of magnitude cheap, which is
exactly why it could not be published.

## The fix

The write window's wait now belongs to the **arm** instead of to the harness.
`arm-scheduler` names the queue each arm's own render work is scheduled on
(`:none` for the floor and the React spine, `:animation-frame` for stock Reagent,
`:microtask` for reagent-slim) and `window-of` gives a `:microtask` arm a window
with **nothing between the write and the drain**. Every other arm's window is the
same three operations in the same order as before, and the read-back still runs in
the same turn as the drain, so a late commit still reads as unverified.

A fixed one-microtask yield is not neutral across scheduler families:
`reagent2.impl.batching` schedules on the very queue the harness was yielding to,
so the yield handed the commit to React outside any `flushSync` boundary and the
drain found nothing. Stock Reagent was immune only because its queue is
rAF-scheduled.

**The general form belongs in `lane.cljs` and I did not edit it.** The same fixed
yield is in the shared `lane/verified-write!`, which every Hicasso arm uses;
`rf2-pq7d8` is that repair and it is reported, not made here, because `lane.cljs`
is a shared instrument with sibling arms measuring on it right now. HD-008's
`timed-write!` is a separate copy, which is why this could land without touching
it. `b6-harness` is likewise untouched — `rf2-ouwh8`'s cluster owns it.

## The asymmetry the fix introduces, measured rather than asserted

The `reagent-slim` window omits one harness microtask its rivals' windows contain.
`yield-cost!` prices exactly that turn against the same clock, outside every arm's
window: **p50 0.0 ms, min 0.0, max 0.0, n = 10, in all three runs** — below the
100 µs quantum, so nothing is subtracted before the ratios are read. Had it read
anything else, the page would owe the reader a subtraction, and it says so.

## Nothing published was replaced

The re-take ran all three adapters, so the rows published at `d46ede4f` were
measured again by a driver carrying the change — cited as a **reproduction check,
not a republication**. Mount rows reproduce closely (`donor-r1 / uix` in the `uix`
run: 1.150–1.233 against the published 1.149–1.230). On the write rows five of the
six published cross-run ranges are contained in the re-take's and the sixth
overlaps; the re-take's are wider because four sibling workers were live on the
host. No figure moved systematically. `HD8_ONLY` is added so a future re-take of
one run cannot mint competing figures for rows published at another commit.

`k = 2` ordering (`rf2-ouwh8`) did **not** affect this arm: `hd8_rows` carries the
local `slot-order` override and each two-arm row's 60 samples split 30 / 30 across
its two possible predecessors.

## Records updated

- `docs/design/hicasso/studio/hd8-composed-donor-arm.md` — the rows, the corrected
  cause (the arm was **late**, not non-reactive; `app-db` followed every write;
  re-frame is not on the causal path; bundle composition was never implicated),
  the re-take section and two new limitations.
- **`rf2-2rtt6.1`** — appended, operator-owned, **append only**: nothing amends the
  bar, the budgets, the kill criteria, the red-zones or the clock.
- **`rf2-2rtt6.7`** — its close/evidence record corrected (it still described
  reagent-slim as non-reactive with mixed-bundle composition the leading
  hypothesis).

**No shipped code changed and no consumer is affected.** An application does not
write and then yield before flushing; the shipped reagent-slim adapter smoke was
green throughout, and it was right.

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/hd8-slim-retake-b69lw`,
foreground, to completion, logs kept worktree-local.

| gate | command | exit |
|---|---|---|
| HD-008 arm, all three runs (the publishing run, at `b943c7ed`) | `node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs` | **0** |
| HD-008 arm, slim-only replication (at `f5bd4b49`) | `HD8_ONLY=slim node .../hd8_run.cjs` | **0** |
| arm-order guard self-test, standalone | `node implementation/freehand/test/re_frame/freehand/bench/order_guard.cjs` | **0** |
| browser suite | `npm run test:browser` — 842 tests, 5,469 assertions, 0 failures, 0 errors | **0** |
| docs | `python -m mkdocs build --strict` | **0** |

Gate detail on the publishing run: positive control **predicted 1.9934 before the
clock**, measured 1.750–1.833 (uix), 1.750–2.083 (reagent), 1.714–1.846 (slim) —
every round inside ±30%. Arm-order guard self-test 8/8 and **all twelve rows
reportable on both factors, none refused**. Canonical-DOM parity passed at both
sizes and the same comparison at two sizes answers false.

The instrument files are byte-identical between the publishing commit `b943c7ed`
and the branch head, so the repro command runs at the SHA the figures are
published against.
