### PR TITLE
bench(hicasso): tighten the lane control, make the yield scheduler-aware, settle the batched window (rf2-egdaq, rf2-pq7d8, rf2-9zysg)

### DIFF
--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -32,8 +32,20 @@ Bead **`rf2-2rtt6.7`**. Decision **[HD-008](../decisions.md)**. The standard is
 |---|---|
 | **Producing commit** | `d46ede4fb05a8f4c5af9900f0a010772f0b0883a` — every row except the `reagent-slim` write rows |
 | **Producing commit, re-take** | `b943c7ed20d63d66fade4775059dad9fcf0012a7` — the `reagent-slim` write rows only (`rf2-b69lw`) |
-| **Producing commit, re-take** | `1c7c963e219a6f5cf0f5620b248e69c2ec6a990f` — the **narrow write rows** only, on a batched window (`rf2-9zysg`) |
+| **Producing commit, re-take** | `d3f1c2fff6` on `worker/lane-control-cluster` — the **narrow write rows** only, on a batched window (`rf2-9zysg`) |
+| **Producing instrument** | `hd8_rows.cljs` blob `e6bca24420b7fc4c9de2c6137f5b2f7144ad243d`, `lane.cljs` blob `671756751ecdb25c4c3d81e164c3204b022e93ae` |
 | **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs` — runs at every commit above |
+
+**The narrow rows are anchored by BLOB HASH as well as by commit, and that is
+not belt-and-braces.** The run was executed at `1c7c963e`; rebasing onto a main
+that had moved rewrote it to `d3f1c2fff6`, and merging this branch will rewrite
+it again. `git diff 1c7c963e d3f1c2fff6 -- implementation/` is empty, so the
+instrument did not change — but a reader handed only a rewritten SHA cannot
+check that. The two blob hashes above identify the exact instrument these
+figures came off regardless of how the commit carrying it is rebased, and
+`git rev-parse HEAD:implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs`
+is how a reader confirms the checkout in front of them is the one that produced
+this row.
 | **Build** | `:hicasso-bench` (rf2-2rtt6.2's lane) — `:advanced`, `goog.DEBUG false` |
 | **Runtime** | Chromium `HeadlessChrome/147.0.7727.15` (Windows NT 10.0 x64), React 19.2.0, node v24.13.0 |
 | **Rounds** | 6 · mount `{:warmup 4 :samples 12}` · write `{:warmup 3 :samples 10}` |
@@ -146,8 +158,9 @@ Against the floor: `reagent` 4.800 – 6.700, `reagent-slim` 5.500 – 7.750, `u
 
 ### Write — narrow (one cell in a 300-cell grid)
 
-> **These figures were re-taken at `1c7c963e` on a BATCHED window
-> (`rf2-9zysg`).** Ten single-cell writes, to ten distinct cells, now share one
+> **These figures were re-taken on a BATCHED window (`rf2-9zysg`)** — see
+> [Provenance](#provenance) for the producing commit and the blob hashes that
+> survive a rebase. Ten single-cell writes, to ten distinct cells, now share one
 > clock; the per-write figure is the sample divided by ten. The ranges directly
 > below **supersede** the ones taken on the unbatched window, which are kept at
 > the end of this section so a reader can see the measurement was revisited

--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -32,7 +32,8 @@ Bead **`rf2-2rtt6.7`**. Decision **[HD-008](../decisions.md)**. The standard is
 |---|---|
 | **Producing commit** | `d46ede4fb05a8f4c5af9900f0a010772f0b0883a` — every row except the `reagent-slim` write rows |
 | **Producing commit, re-take** | `b943c7ed20d63d66fade4775059dad9fcf0012a7` — the `reagent-slim` write rows only (`rf2-b69lw`) |
-| **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs` |
+| **Producing commit, re-take** | `1c7c963e219a6f5cf0f5620b248e69c2ec6a990f` — the **narrow write rows** only, on a batched window (`rf2-9zysg`) |
+| **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs` — runs at every commit above |
 | **Build** | `:hicasso-bench` (rf2-2rtt6.2's lane) — `:advanced`, `goog.DEBUG false` |
 | **Runtime** | Chromium `HeadlessChrome/147.0.7727.15` (Windows NT 10.0 x64), React 19.2.0, node v24.13.0 |
 | **Rounds** | 6 · mount `{:warmup 4 :samples 12}` · write `{:warmup 3 :samples 10}` |
@@ -40,8 +41,14 @@ Bead **`rf2-2rtt6.7`**. Decision **[HD-008](../decisions.md)**. The standard is
 Every figure below is a **browser** figure, which is what HD-012 requires of
 anything quotable against the bar.
 
-**Two producing commits, and the second one only re-took what the first
-suppressed.** At `d46ede4f` the `reagent-slim` write rows read *78 of 78*
+**Three producing commits, and each later one re-took only the rows whose
+window it changed.** The narrow write rows are `1c7c963e`'s and are marked as
+such in [their own section](#write--narrow-one-cell-in-a-300-cell-grid), where
+the superseded unbatched ranges are kept rather than deleted; `rf2-9zysg`
+batched ten writes under one clock and left every other window alone, so no
+other row moved. Before that:
+
+At `d46ede4f` the `reagent-slim` write rows read *78 of 78*
 unverified and their figures were withheld. `rf2-z3vlz` diagnosed why and
 `rf2-b69lw` repaired it; `b943c7ed` is that repair, and the `reagent-slim`
 write rows below are its. **No other row was replaced.** The repair changes the
@@ -139,24 +146,69 @@ Against the floor: `reagent` 4.800 – 6.700, `reagent-slim` 5.500 – 7.750, `u
 
 ### Write — narrow (one cell in a 300-cell grid)
 
+> **These figures were re-taken at `1c7c963e` on a BATCHED window
+> (`rf2-9zysg`).** Ten single-cell writes, to ten distinct cells, now share one
+> clock; the per-write figure is the sample divided by ten. The ranges directly
+> below **supersede** the ones taken on the unbatched window, which are kept at
+> the end of this section so a reader can see the measurement was revisited
+> rather than quietly replaced. Every other row on this page is unchanged and
+> still carries its original producing commit — the batch touches the narrow
+> window and nothing else.
+
 Within-run, `uix` run:
 
 | comparison | range |
 |---|---|
-| `donor-r1 / uix` | 0.909 – 1.200 · *indistinguishable* |
-| `donor-r2 / uix` | 0.960 – 1.200 · *indistinguishable* |
-| `donor-r2 / donor-r1` — the shell | 1.000 – 1.167 · *indistinguishable* |
+| `donor-r1 / uix` | 0.947 – 1.056 · *indistinguishable* |
+| `donor-r2 / uix` | 0.926 – 1.148 · *indistinguishable* |
+| `donor-r2 / donor-r1` — the shell | 0.939 – 1.088 · *indistinguishable* |
 
-Cross-run, floor-normalised — **the weaker warrant**: `donor-r1` 5.000 – 8.000 and
-`donor-r2` 5.000 – 8.000 against `reagent` 3.000 – 5.000 and **`reagent-slim`
-2.667 – 6.000**. This row's precision is the instrument's weakest (see
-limitations), and the `reagent-slim` figure is the weakest of those: **the floor
-it is normalised against has a p50 of 0.10 – 0.15 ms against a 100 µs quantum**,
-so the denominator is one to one-and-a-half quanta wide. An independent
-slim-only replication at `f5bd4b49` read 3.000 – 5.500 on the same row — inside
-the published range, and the run-to-run spread is the honest size of this row's
-precision. Absolute p50s: `reagent-slim` 0.40 – 0.60 ms, floor 0.10 – 0.15 ms.
-**0 unverified of 78.**
+Cross-run, floor-normalised — **the weaker warrant**: `donor-r1` 5.182 – 6.790
+and `donor-r2` 5.400 – 6.579 against `reagent` 4.130 – 6.947 and
+**`reagent-slim` 4.222 – 5.944**.
+
+Absolute p50s, **per write** (the sample ÷ 10): floor 0.090 – 0.110 ms, `uix`
+0.510 – 0.675, `donor-r1` 0.505 – 0.665, `donor-r2` 0.490 – 0.665; `reagent`
+0.475 – 0.760 against its own floor 0.095 – 0.125; `reagent-slim` 0.380 – 0.535
+against its own floor 0.090 – 0.095. **0 unverified of 780** on every arm of
+every run.
+
+**What the batch bought, and what it did not.** The denominator is no longer on
+the clamp: the floor's *sample* p50 is 0.90 – 1.25 ms, nine to twelve quanta,
+where the unbatched floor was 0.10 – 0.15 ms — one to one-and-a-half. That was
+named as this instrument's weakest figure and it is now the same order of
+resolution as everything else on the page. The ranges tightened where
+quantisation was what made them wide (`reagent-slim` 2.667 – 6.000 → 4.222 –
+5.944, a 2.25× spread down to 1.41×; `donor-r1` 5.000 – 8.000 → 5.182 – 6.790,
+1.60× down to 1.31×). They did **not** tighten for `reagent` (1.67× → 1.68×),
+where round-to-round drift, not the quantum, is what the range is made of.
+Batching cannot help with drift and is not claimed to.
+
+**The per-write absolutes reproduce the unbatched run**, which is the check that
+says the batch measures the same operation: `reagent-slim` reads 0.380 – 0.535
+ms per write here against 0.40 – 0.60 ms published, and its floor 0.090 – 0.095
+against 0.10 – 0.15. The batched ratios sit *higher* than the unbatched ones for
+the same reason — a denominator pinned at one quantum was rounded **up**, and a
+floor rounded up understates every ratio taken against it.
+
+<details><summary><b>Superseded — the same row on the unbatched window</b>
+(`d46ede4f`, and `b943c7ed` for <code>reagent-slim</code>)</summary>
+
+Within-run, `uix` run: `donor-r1 / uix` 0.909 – 1.200, `donor-r2 / uix`
+0.960 – 1.200, `donor-r2 / donor-r1` 1.000 – 1.167 — all *indistinguishable*.
+
+Cross-run, floor-normalised: `donor-r1` 5.000 – 8.000 and `donor-r2`
+5.000 – 8.000 against `reagent` 3.000 – 5.000 and `reagent-slim` 2.667 – 6.000.
+An independent slim-only replication at `f5bd4b49` read 3.000 – 5.500. Absolute
+p50s: `reagent-slim` 0.40 – 0.60 ms, floor 0.10 – 0.15 ms. **0 unverified of
+78.**
+
+These were taken one write per clock, so both numerator and denominator carried
+a 100 µs quantum. They are kept because a superseded measurement is evidence
+about the instrument, and deleting it would hide that this row was ever
+revisited.
+
+</details>
 
 ### Write — bulk (all 300 cells in one commit)
 
@@ -221,8 +273,13 @@ split **30 / 30** across its two possible predecessors, which is the local
 `slot-order` override working.
 
 **DOM read-back — 0 unverified of 1,248**, which is every write the driver
-executes across the three runs (`0 of 960` counting only the timed post-warmup
-samples). At `d46ede4f` the same counts read **156 of 1,248** and **120 of 960**,
+executed across the three runs at `b943c7ed` (`0 of 960` counting only the timed
+post-warmup samples). **At `1c7c963e` the narrow rows carry ten writes per
+sample, so the same three runs execute 0 unverified of 6,864** — `0 of 780` on
+each of the eight narrow arm-columns, plus the bulk rows' `0 of 78` each. The
+denominator grew with the batch; the numerator did not.
+
+At `d46ede4f` the same counts read **156 of 1,248** and **120 of 960**,
 every one of them the `reagent-slim` arm, and its write figures were suppressed
 rather than published. *An earlier version of this page reported that as "156
 unverified of 936", which is not a like-for-like denominator and is corrected
@@ -338,10 +395,17 @@ could land without touching it.
 
 ## Known limitations of this instrument
 
-- **The narrow-write row sits near Chrome's `performance.now()` clamp.** Its
-  p50s are ~0.4–1.2 ms against a 100 µs quantum, and its ranges are wide in
-  proportion. rf2-2rtt6.2's `lane/mount-batch!` — timing *k* operations as one
-  window — is the repair; this arm predates it. Filed as **`rf2-f5roa`**.
+- ~~**The narrow-write row sits near Chrome's `performance.now()` clamp.**~~
+  **Repaired at `1c7c963e` (`rf2-9zysg`).** Ten writes now share one clock, so
+  the row's samples are 3.8–7.6 ms and its floor 0.90–1.25 ms, against a 100 µs
+  quantum. What remains is that an early write in a batch is read back up to
+  nine microtask turns after its own drain — the pre-batch window already
+  granted one such turn by construction, and a commit React parks at the default
+  lane needs a *macrotask*, which never occurs inside the window, so the
+  read-back's actual target is unaffected. The batched window also contains ten
+  harness microtasks for every arm except the microtask-scheduled one, which
+  contains none; each such turn measures 0.0 ms against this clock, so the
+  asymmetry is ten times a quantity below the instrument's own resolution.
 - **The bulk write verifies one probe cell**, where the shared lane verifies a
   seq including the far end of the grid. Same bead.
 - **The write rows' donor-vs-Reagent comparison is cross-run**, floor-normalised.

--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -35,6 +35,12 @@ Bead **`rf2-2rtt6.7`**. Decision **[HD-008](../decisions.md)**. The standard is
 | **Producing commit, re-take** | `d3f1c2fff6` on `worker/lane-control-cluster` — the **narrow write rows** only, on a batched window (`rf2-9zysg`) |
 | **Producing instrument** | `hd8_rows.cljs` blob `e6bca24420b7fc4c9de2c6137f5b2f7144ad243d`, `lane.cljs` blob `671756751ecdb25c4c3d81e164c3204b022e93ae` |
 | **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs` — runs at every commit above |
+| **Build** | `:hicasso-bench` (rf2-2rtt6.2's lane) — `:advanced`, `goog.DEBUG false` |
+| **Runtime** | Chromium `HeadlessChrome/147.0.7727.15` (Windows NT 10.0 x64), React 19.2.0, node v24.13.0 |
+| **Rounds** | 6 · mount `{:warmup 4 :samples 12}` · write `{:warmup 3 :samples 10}` |
+
+Every figure below is a **browser** figure, which is what HD-012 requires of
+anything quotable against the bar.
 
 **The narrow rows are anchored by BLOB HASH as well as by commit, and that is
 not belt-and-braces.** The run was executed at `1c7c963e`; rebasing onto a main
@@ -46,15 +52,9 @@ figures came off regardless of how the commit carrying it is rebased, and
 `git rev-parse HEAD:implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs`
 is how a reader confirms the checkout in front of them is the one that produced
 this row.
-| **Build** | `:hicasso-bench` (rf2-2rtt6.2's lane) — `:advanced`, `goog.DEBUG false` |
-| **Runtime** | Chromium `HeadlessChrome/147.0.7727.15` (Windows NT 10.0 x64), React 19.2.0, node v24.13.0 |
-| **Rounds** | 6 · mount `{:warmup 4 :samples 12}` · write `{:warmup 3 :samples 10}` |
-
-Every figure below is a **browser** figure, which is what HD-012 requires of
-anything quotable against the bar.
 
 **Three producing commits, and each later one re-took only the rows whose
-window it changed.** The narrow write rows are `1c7c963e`'s and are marked as
+window it changed.** The narrow write rows are the batched re-take's and are marked as
 such in [their own section](#write--narrow-one-cell-in-a-300-cell-grid), where
 the superseded unbatched ranges are kept rather than deleted; `rf2-9zysg`
 batched ten writes under one clock and left every other window alone, so no
@@ -287,7 +287,7 @@ split **30 / 30** across its two possible predecessors, which is the local
 
 **DOM read-back — 0 unverified of 1,248**, which is every write the driver
 executed across the three runs at `b943c7ed` (`0 of 960` counting only the timed
-post-warmup samples). **At `1c7c963e` the narrow rows carry ten writes per
+post-warmup samples). **On the batched re-take the narrow rows carry ten writes per
 sample, so the same three runs execute 0 unverified of 6,864** — `0 of 780` on
 each of the eight narrow arm-columns, plus the bulk rows' `0 of 78` each. The
 denominator grew with the batch; the numerator did not.
@@ -409,7 +409,7 @@ could land without touching it.
 ## Known limitations of this instrument
 
 - ~~**The narrow-write row sits near Chrome's `performance.now()` clamp.**~~
-  **Repaired at `1c7c963e` (`rf2-9zysg`).** Ten writes now share one clock, so
+  **Repaired by the batched re-take (`rf2-9zysg`).** Ten writes now share one clock, so
   the row's samples are 3.8–7.6 ms and its floor 0.90–1.25 ms, against a 100 µs
   quantum. What remains is that an early write in a batch is read back up to
   nine microtask turns after its own drain — the pre-batch window already

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
@@ -60,17 +60,23 @@
   are deliberately NOT adopted, and the reasons are here so the question is
   not reopened by inspection:
 
-  1. **The BATCHED write window is not adopted, and adopting it is a
-     RE-RUN.** `lane/mount-batch!` times `k` operations as one sample to
-     lift a reading clear of Chrome's 100 µs `performance.now()` clamp, and
-     the write-narrow row here reads p50s of 0.4–1.2 ms — 4 to 12 quanta,
-     which is why its published ranges are as wide as they are. Batching
-     the write window would narrow them. It would also CHANGE THE MEASURED
-     WINDOW, which invalidates the HD-008 rows already published in
-     `docs/design/hicasso/studio/hd8-composed-donor-arm.md`; a window
-     change cannot be validated by anything but a re-run, and re-running is
-     a separate piece of work with its own publication obligations. The
-     mount rows (4–13 ms) do not need it.
+  1. **The BATCHED write window IS now adopted on the narrow row, and it
+     came with its re-run (rf2-9zysg).** `lane/mount-batch!`'s argument —
+     timing `k` operations as one sample lifts a reading clear of Chrome's
+     100 µs `performance.now()` clamp, and is not the same as summing `k`
+     separately-clamped readings — applies to the narrow write row, which
+     read p50s of 0.4–1.2 ms, i.e. 4 to 12 quanta, and published ranges as
+     wide as `4.500–8.000x` because of it. [[narrow-batch-k]] writes now
+     share one clock ([[window-of]] carries the shape and the argument for
+     why the DOM read-back survives the batching).
+
+     This CHANGED THE MEASURED WINDOW, so the earlier narrow rows were
+     re-taken rather than re-labelled: `docs/design/hicasso/studio/
+     hd8-composed-donor-arm.md` carries the new numbers, the producing SHA
+     and a repro command that runs at that SHA, and says plainly that the
+     superseded ranges were taken on an unbatched window. The BULK row
+     passes a batch of one — the pre-batch window exactly — and did not
+     move; the mount rows (4–13 ms) never needed it.
 
   2. **`lane/control-verdict` is WEAKER than [[positive-control!]]'s own
      rule and would be a downgrade.** The lane passes a control whose
@@ -561,10 +567,43 @@
 (defn- window-of
   "The measured write window for an arm on `scheduler`.
 
-  Answers `(fn [write! verify!] → promise of {:ms :ok?})`. The clock starts
-  before the write and stops after the arm's own synchronous drain; the DOM
-  read-back runs in the SAME turn as the drain, never in a later one, so a
-  commit that arrived a turn late reads as UNVERIFIED rather than as a pass.
+  Answers `(fn [steps] → promise of {:ms :oks})`, where `steps` is a seq of
+  `{:write! :verify!}` and ALL of them share ONE clock. The clock starts
+  before the first write and stops after the last drain; the DOM read-backs
+  run after it, in the same turn as the last drain, never in a later one, so
+  a commit that arrived a turn late reads as UNVERIFIED rather than as a pass.
+
+  ## ONE CLOCK OVER k OPERATIONS, AND WHY THE READ-BACK SURVIVES IT
+
+  Chrome clamps `performance.now()` to 100 µs and the narrow row sits 4 to
+  12 quanta above it, so a per-write clock quantises every reading and the
+  published ranges carry that noise (rf2-9zysg). Timing `k` writes as ONE
+  sample lifts the window clear of the clamp, and it is NOT the same as
+  summing `k` separately-clamped readings, which quantises `k` times and
+  adds the errors. `lane/mount-batch!` does exactly this for mounts.
+
+  The cost is that a batched window cannot verify each write in the turn
+  its own drain ran in, because there is only one clock. It verifies all
+  `k` after the clock stops — and that is not the weakening it looks like,
+  for a reason worth writing down rather than rediscovering:
+
+    NO MACROTASK RUNS INSIDE THE WINDOW. Every turn between the first
+    write and the last drain is a MICROTASK (a resolved-promise turn).
+    The fault this read-back exists to catch is a commit React has PARKED
+    at the default lane — which is scheduled through the Scheduler's
+    `MessageChannel`, i.e. a macrotask — so it cannot land inside the
+    window no matter how many microtasks pass. A parked commit is still
+    parked when the read-backs run, and all `k` read UNVERIFIED.
+
+  What the batch does relax is microtask-scale lateness: an early write in
+  the batch gets up to `k - 1` extra microtask turns before it is read
+  back. Today's unbatched window already tolerates exactly one such turn
+  by construction — that IS the yield — so this is a difference of degree
+  on a tolerance the instrument already grants, not a new blind spot. It
+  is stated in the row's `:measurement-method` rather than left implicit.
+
+  `k = 1` reduces this to the pre-batch window exactly, which is why the
+  BULK row is untouched by any of it.
 
   TWO SHAPES, BECAUSE ONE FIXED WAIT IS NOT NEUTRAL ACROSS SCHEDULER
   FAMILIES. That is rf2-b69lw, and rf2-z3vlz diagnosed it against a
@@ -595,21 +634,31 @@
   same clock, outside every arm's window, and it is published beside the
   write rows."
   [scheduler force!]
-  (if (= scheduler :microtask)
-    (fn [write! verify!]
-      (let [t0 (lane/now-ms)]
-        (write!)
-        (force!)
-        (let [ms (- (lane/now-ms) t0)]
-          (js/Promise.resolve {:ms ms :ok? (verify!)}))))
-    (fn [write! verify!]
-      (let [t0 (lane/now-ms)]
-        (write!)
-        (-> (js/Promise.resolve nil)
-            (.then (fn [_]
-                     (force!)
-                     (let [ms (- (lane/now-ms) t0)]
-                       {:ms ms :ok? (verify!)}))))))))
+  (let [verify-all (fn [steps] (mapv (fn [s] ((:verify! s))) steps))]
+    (if (= scheduler :microtask)
+      ;; Write, then drain, with NOTHING between them — and the whole batch
+      ;; is one synchronous run, so not even a microtask separates a drain
+      ;; from the next write.
+      (fn [steps]
+        (let [t0 (lane/now-ms)]
+          (doseq [s steps] ((:write! s)) (force!))
+          (let [ms (- (lane/now-ms) t0)]
+            (js/Promise.resolve {:ms ms :oks (verify-all steps)}))))
+      ;; Write, yield ONE microtask, drain — per operation, k times, under
+      ;; one clock. The next write starts in the turn the previous drain
+      ;; finished in, so the window holds exactly k harness turns and not
+      ;; 2k: the fixed yield is preserved per operation, never batched away
+      ;; and never doubled.
+      (fn [steps]
+        (let [t0 (lane/now-ms)]
+          (letfn [(run [ss]
+                    (if (empty? ss)
+                      (let [ms (- (lane/now-ms) t0)]
+                        (js/Promise.resolve {:ms ms :oks (verify-all steps)}))
+                      (do ((:write! (first ss)))
+                          (-> (js/Promise.resolve nil)
+                              (.then (fn [_] (force!) (run (next ss))))))))]
+            (run (seq steps))))))))
 
 (defn- write-arm
   "The write door for `arm-id` on the U page.
@@ -688,10 +737,16 @@
     (.remove container)))
 
 (defn timed-write!
-  "Write, wait the way THIS ARM'S SCHEDULER requires, force the arm's own
-  synchronous drain, stop the clock — then VERIFY at the DOM that EVERY
-  cell in `probes` holds what was written. Answers a promise of
-  `{:ms … :ok? …}`.
+  "Run `ops` — a seq of `[i val probes]` — as ONE measured window: each
+  writes, waits the way THIS ARM'S SCHEDULER requires and forces the arm's
+  own synchronous drain; the clock stops after the last of them; then EVERY
+  `probes` cell of EVERY op is read back out of the DOM. Answers a promise
+  of `{:ms … :oks [bool …]}`, one flag per op.
+
+  `ops` is a SEQ because the narrow row batches `k` writes under one clock
+  to clear Chrome's 100 µs quantum ([[window-of]] carries that argument and
+  the read-back's survival of it). The bulk row passes a single op, which
+  is the pre-batch window exactly.
 
   The wait belongs to the arm ([[window-of]]) and not to this function,
   which is the whole of rf2-b69lw: a fixed one-microtask yield is
@@ -713,20 +768,42 @@
   the table, which is the exact shape of the fault this exists to prevent.
   Widening the probe seq does not move the measured window: the clock stops
   before the first `querySelector` either way."
-  [{:keys [arm container]} i val probes]
+  [{:keys [arm container]} ops]
   ((:window! arm)
-   (fn [] ((:write! arm) i val))
-   (fn [] (every? #(= val (cell-text container %)) probes))))
+   (mapv (fn [[i val probes]]
+           {:write!  (fn [] ((:write! arm) i val))
+            :verify! (fn [] (every? #(= val (cell-text container %)) probes))})
+         ops)))
 
 (defn- chain
   "Sequence `f` over `xs` through promises, threading `acc`."
   [acc xs f]
   (reduce (fn [p x] (.then p (fn [a] (f a x)))) (js/Promise.resolve acc) xs))
 
+(def narrow-batch-k
+  "How many narrow writes share ONE clock (rf2-9zysg).
+
+  Chrome clamps `performance.now()` to 100 µs. The unbatched narrow row
+  read p50s of 0.4–1.2 ms — 4 to 12 quanta — and published ranges as wide
+  as `4.500–8.000x` the floor because of it. Ten writes per window puts
+  the sample 40 to 120 quanta above the clamp, where the quantum is
+  roughly 1% of the reading rather than 10–25% of it.
+
+  Ten and not more: the batch's cells must be DISTINCT (they are
+  `(mod o 300)` over consecutive `o`, so any `k` up to 300 is distinct),
+  and the microtask-scale tolerance an early write in the batch receives
+  grows with `k` ([[window-of]]). Ten buys the clamp headroom the row
+  needs and keeps that tolerance at nine turns.
+
+  The BULK row does not use this — it passes a batch of one, which is the
+  pre-batch window exactly — because its readings are already 4–13 ms."
+  10)
+
 (defn- write-round!
   "One write round. Every mounted arm writes at every sample index, order
-  rotating and reflecting; `kind` is `:narrow` (one cell) or `:bulk` (all
-  300 in one commit)."
+  rotating and reflecting; `kind` is `:narrow` ([[narrow-batch-k]] cells,
+  one per commit, all under ONE clock) or `:bulk` (all 300 in one commit,
+  one commit per window)."
   [mounts kind {:keys [warmup samples]} position0]
   (let [k   (count mounts)
         ids (mapv #(:id (:arm %)) mounts)]
@@ -746,28 +823,39 @@
                     (fn [a j]
                       (let [mnt (nth mounts j)
                             id  (:id (:arm mnt))
-                            v   (str "v" (:position a))
-                            cell (mod (:position a) w/cells-n)
+                            p   (:position a)
+                            bk  (if (= kind :bulk) 1 narrow-batch-k)
+                            ;; Every op in a batch gets its OWN value and
+                            ;; its OWN cell, so no read-back can be
+                            ;; satisfied by a neighbour's commit and the
+                            ;; batch's k cells are k distinct cells.
+                            ;;
                             ;; A broad write changes every cell, so it is
                             ;; verified at three (`lane/bulk-probes`); a
                             ;; narrow write changes one, so it is verified
                             ;; at that one.
-                            [i probes] (if (= kind :bulk)
-                                         [:all (lane/bulk-probes (:position a) w/cells-n)]
-                                         [cell [cell]])]
-                        (-> (timed-write! mnt i v probes)
-                            (.then (fn [{:keys [ms ok?]}]
-                                     (cond-> (-> a
-                                                 (assoc :position (inc (:position a)) :prev id)
-                                                 (update-in [:total id] inc)
-                                                 (cond-> (not ok?) (update-in [:unverified id] inc)))
-                                       (>= s warmup)
-                                       (-> (update-in [:readings id] conj ms)
-                                           (update :samples conj
-                                                   {:arm         (name id)
-                                                    :value       ms
-                                                    :predecessor (some-> (:prev a) name)
-                                                    :position    (:position a)})))))))))))))
+                            ops (mapv (fn [c]
+                                        (let [o (+ (* p bk) c)
+                                              v (str "v" o)]
+                                          (if (= kind :bulk)
+                                            [:all v (lane/bulk-probes o w/cells-n)]
+                                            (let [cell (mod o w/cells-n)]
+                                              [cell v [cell]]))))
+                                      (range bk))]
+                        (-> (timed-write! mnt ops)
+                            (.then (fn [{:keys [ms oks]}]
+                                     (let [bad (count (remove identity oks))]
+                                       (cond-> (-> a
+                                                   (assoc :position (inc p) :prev id)
+                                                   (update-in [:total id] + bk)
+                                                   (update-in [:unverified id] + bad))
+                                         (>= s warmup)
+                                         (-> (update-in [:readings id] conj ms)
+                                             (update :samples conj
+                                                     {:arm         (name id)
+                                                      :value       ms
+                                                      :predecessor (some-> (:prev a) name)
+                                                      :position    p}))))))))))))))
 
 (defn measure-write!
   "`rounds` interleaved rounds of the write clock, `kind` ∈ `#{:narrow
@@ -800,7 +888,14 @@
                  {:witness    (keyword (str "U-" (name kind)))
                   :doc        (if (= kind :bulk)
                                 "all 300 cells written in ONE commit — bulk view work"
-                                "one cell written in a 300-cell grid — the narrow-write path")
+                                (str narrow-batch-k " single-cell writes into a 300-cell "
+                                     "grid, each its own commit, all inside ONE timed "
+                                     "window — the narrow-write path. The per-write "
+                                     "figure is the sample divided by " narrow-batch-k))
+                  ;; Stated on the row, because a reader comparing this
+                  ;; against the pre-rf2-9zysg numbers is comparing two
+                  ;; different windows and has to be told so.
+                  :writes-per-sample (if (= kind :bulk) 1 narrow-batch-k)
                   :arms       (vec arm-ids)
                   :per-round  (:rounds-out acc)
                   ;; AN ARM WHOSE WRITES DID NOT REACH THE DOM HAS NO FIGURE.
@@ -1014,6 +1109,11 @@
    :rounds            rounds
    :mount-sampling    mount-sampling
    :write-sampling    write-sampling
+   ;; A narrow SAMPLE is k writes under one clock (rf2-9zysg); a bulk
+   ;; sample is one. Published because the narrow figures before that
+   ;; change were taken through a different window and are not comparable
+   ;; to these without knowing it.
+   :writes-per-sample {:narrow narrow-batch-k :bulk 1}
    :measurement-method
    (str "arms interleaved at the SAMPLE level with the order rotating AND "
         "REFLECTING on the sample index (a cyclic rotation does not vary "
@@ -1021,4 +1121,9 @@
         "the run; ratios taken against the floor measured in the SAME round; "
         "reported as a RANGE across rounds, and a range straddling 1.0 is "
         "INDISTINGUISHABLE rather than a winner; every write read back out of "
-        "the DOM inside its own window")})
+        "the DOM inside its own window — where a NARROW window is "
+        narrow-batch-k " writes to " narrow-batch-k " distinct cells "
+        "under one clock, each read back after the clock stops and in the same "
+        "turn as the last drain, so a commit React parked at the default lane "
+        "(a macrotask, and no macrotask runs inside the window) still reads "
+        "UNVERIFIED")})

--- a/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
@@ -465,7 +465,37 @@
 
   Answers `{:predicted :measured :ok? :why}` — published on every run,
   passing or not, because a control quoted only when it passes is not a
-  control."
+  control.
+
+  ## KNOWN DEFECT: this rule is WEAKER than HD-008's, and the two
+  ## disagree on a row that is already published (rf2-egdaq)
+
+  `:ok?` asks whether the measured range OVERLAPS the ±`slack` band.
+  `hd8-rows/positive-control!` asks whether EVERY ROUND sits INSIDE it,
+  and argues the stricter reading explicitly: a control whose worst round
+  is wrong has caught something, and letting a good round vouch for a bad
+  one is how an instrument stops being one. THE STRICTER RULE IS THE
+  RIGHT ONE. This one is the lane's known defect, and a caller must not
+  read `:ok?` as though it were the strict answer.
+
+  It is not repaired here, and the reason is arithmetic rather than
+  caution. Re-adjudicating the ELEVEN controls this function has already
+  published under the overlap rule flips exactly one:
+
+      docs/design/hicasso/studio/p0-converged-witness-set.md
+      M2 mount, UIx segment — predicted 1.9412, slack 0.25, so the band
+      is [1.4559 – 2.4265]. The published range is [1.333 – 2.000]: its
+      worst round sits 8.4% BELOW the band's floor. It carries a ✅, and
+      it holds that ✅ only because a good round vouched for a bad one —
+      which is precisely the failure the stricter rule exists to catch.
+
+  The other ten pass under either reading. So tightening `:ok?` turns a
+  published pass into a published failure, and that is a finding about a
+  published number rather than a refactor: it needs an operator ruling on
+  rf2-2rtt6.1 (re-adjudicate the row, or apply the strict rule only from
+  the next run), and if the row is re-adjudicated the converged arm needs
+  a re-run to replace it. Whoever takes that must not simply flip the
+  `and` and leave the studio page reading as current."
   [predicted {:keys [min max mean] :as measured} slack]
   (let [lo (* predicted (- 1.0 slack))
         hi (* predicted (+ 1.0 slack))

--- a/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
@@ -377,8 +377,9 @@
 (defn tally-value [t] (let [{:keys [of bad]} @t] {:writes of :unverified bad}))
 
 (defn verified-write!
-  "Write, yield ONE microtask, force the arm's own synchronous drain, stop
-  the clock — THEN read the written cell back out of the DOM.
+  "Write, wait the way THIS ARM'S SCHEDULER requires, force the arm's own
+  synchronous drain, stop the clock — THEN read the written cell back out
+  of the DOM.
 
   Answers a promise of `{:ms :write-ms :gap-ms :force-ms :ok?}` and banks
   the verification in `t`.
@@ -389,11 +390,45 @@
   recorded fault is 1,320 of 1,320 writes accepted by a clock that never
   looked at the page.
 
-  The microtask is load-bearing for any arm whose notification is queued
-  rather than synchronous, and it is priced in situ: `:gap-ms` is
-  reported per arm, and an arm that commits without it reads 0.0 there.
-  Splitting the window is what lets a reader see how much of a ratio is
-  the reactive leg and how much is React.
+  ## THE WAIT BELONGS TO THE ARM'S SCHEDULER, NOT TO THE HARNESS
+
+  An arm declares `:scheduler` — the family its OWN render queue is
+  scheduled on — and gets the window that family needs. This is the
+  general form of rf2-b69lw, which repaired it inside HD-008 only;
+  `hd8-rows/window-of` is these same two shapes, and this is deliberately
+  the same shape lifted rather than a second mechanism (rf2-pq7d8).
+
+    `:scheduler :microtask`   write, then drain, with NOTHING between
+                              them. `:gap-ms` is 0.0 and means it.
+
+    anything else, or the
+    key absent                write, yield ONE microtask, drain. Today's
+                              window, unchanged — which is why no arm
+                              that does not declare `:microtask` moves.
+
+  ONE FIXED YIELD CANNOT SERVE BOTH FAMILIES, and that is the whole of
+  this. The yield is load-bearing for an arm whose notification is queued
+  somewhere ELSE: stock Reagent's `reagent.impl.batching` schedules its
+  component queue on `requestAnimationFrame`, so the queue is still full
+  a microtask later and the drain finds the work. It is FATAL for an arm
+  whose notification is queued on the very queue the harness yields to.
+  `reagent2.impl.batching` (reagent-slim) is microtask-based, so the
+  yield hands it the commit FIRST: it issues its `forceUpdate` outside
+  any `flushSync` boundary, React parks the work at the default lane, and
+  the drain that follows finds nothing to commit. The arm then reads `N
+  unverified of N` against a DOM that is merely LATE — and, with the
+  read-back suppressed, `0.16–0.50x` the floor from a page that never
+  changed. rf2-z3vlz pinned it against a standalone rig and
+  `docs/design/hicasso/studio/slim-non-reactive-arm-diagnosis.md` carries
+  the evidence.
+
+  The two shapes do not bill the same wait, so an arm measured through
+  one is not like-for-like against an arm measured through the other
+  until the harness microtask is priced against the same clock —
+  `hd8-rows/yield-cost!` does exactly that, outside every arm's window,
+  and publishes it beside the write rows. `:gap-ms` is reported per arm
+  for the same reason: splitting the window is what lets a reader see how
+  much of a ratio is the reactive leg and how much is React.
 
   `probes` is a SEQ of cell indices and ALL of them must hold the written
   value. A broad write changes every cell, so verifying one of them
@@ -402,22 +437,42 @@
   it from the previous write. The rotating probe plus the far end of the
   grid is the cheapest read that a partial commit cannot satisfy."
   [t {:keys [arm container]} i val probes]
-  (let [t0 (now-ms)]
-    ((:write! arm) i val)
-    (let [t1 (now-ms)]
-      (-> (js/Promise.resolve nil)
-          (.then (fn [_]
-                   (let [t2 (now-ms)]
-                     ((:force! arm))
-                     (let [t3  (now-ms)
-                           ok? (every? #(= (str val) (text-at container %)) probes)]
-                       (swap! t (fn [{:keys [of bad]}]
-                                  {:of (inc of) :bad (if ok? bad (inc bad))}))
-                       {:ms       (- t3 t0)
-                        :write-ms (- t1 t0)
-                        :gap-ms   (- t2 t1)
-                        :force-ms (- t3 t2)
-                        :ok?      ok?}))))))))
+  (let [verify! (fn [] (every? #(= (str val) (text-at container %)) probes))
+        bank!   (fn [ok?]
+                  (swap! t (fn [{:keys [of bad]}]
+                             {:of (inc of) :bad (if ok? bad (inc bad))}))
+                  ok?)]
+    (if (= (:scheduler arm) :microtask)
+      ;; Write, then drain, with nothing between them: the substrate's queue
+      ;; is filled synchronously by the write and is still there when the
+      ;; drain opens its boundary, so the commit lands INSIDE the window.
+      (let [t0 (now-ms)]
+        ((:write! arm) i val)
+        (let [t1 (now-ms)]
+          ((:force! arm))
+          (let [t2  (now-ms)
+                ok? (verify!)]
+            (bank! ok?)
+            (js/Promise.resolve {:ms       (- t2 t0)
+                                 :write-ms (- t1 t0)
+                                 :gap-ms   0.0
+                                 :force-ms (- t2 t1)
+                                 :ok?      ok?}))))
+      (let [t0 (now-ms)]
+        ((:write! arm) i val)
+        (let [t1 (now-ms)]
+          (-> (js/Promise.resolve nil)
+              (.then (fn [_]
+                       (let [t2 (now-ms)]
+                         ((:force! arm))
+                         (let [t3  (now-ms)
+                               ok? (verify!)]
+                           (bank! ok?)
+                           {:ms       (- t3 t0)
+                            :write-ms (- t1 t0)
+                            :gap-ms   (- t2 t1)
+                            :force-ms (- t3 t2)
+                            :ok?      ok?}))))))))))
 
 (defn bulk-probes
   "The probe seq for a BROAD write over `n` cells: a cell that ROTATES with

--- a/implementation/freehand/test/re_frame/bench/hicasso/lane_window_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/lane_window_dom_cljs_test.cljs
@@ -1,0 +1,256 @@
+(ns re-frame.bench.hicasso.lane-window-dom-cljs-test
+  "`lane/verified-write!`'s two window shapes, and the claim that neither
+  one serves both scheduler families (rf2-pq7d8).
+
+  This is a CORRECTNESS test of the instrument, not a benchmark: nothing
+  here reads a clock for a published figure and no assertion depends on
+  how long anything took. What it pins is the ORDER of operations inside
+  a measured window, which is what the recorded fault turned on.
+
+  ## Why fake substrates rather than Reagent and reagent-slim
+
+  The fault is not about either library. It is about WHICH QUEUE an arm's
+  render work sits on relative to the queue the harness yields to, and
+  that is a two-line property. Two fakes model the two families exactly
+  and deterministically:
+
+    [[queued-notification-arm]]  the notification reaches the render
+        queue ON A MICROTASK and `force!` drains that queue synchronously
+        — stock Reagent's family, whose `reagent.impl.batching` queue is
+        `requestAnimationFrame`-scheduled and so is still full a
+        microtask later. The harness's one microtask yield is
+        LOAD-BEARING here.
+
+    [[microtask-scheduled-arm]]  the write fills the render queue
+        synchronously, and the substrate's OWN microtask drain then takes
+        that work back out of the queue and hands it to React outside any
+        `flushSync` boundary, where React parks it — reagent-slim's
+        family, whose `reagent2.impl.batching` is microtask-based. The
+        same yield is FATAL.
+
+  Using the real substrates would need a bundle carrying both engines and
+  would prove the same two-line property more slowly and less legibly.
+  The real-substrate evidence is not re-derived here because it already
+  exists: rf2-z3vlz's standalone rig, written up in
+  `docs/design/hicasso/studio/slim-non-reactive-arm-diagnosis.md`.
+
+  ## What would have caught the recorded fault
+
+  [[microtask-arm-is-unverified-under-the-yielding-window]] is that test.
+  It goes red on the window `lane/verified-write!` had before rf2-pq7d8,
+  and for the right reason: `N unverified of N` against a DOM that never
+  changed. The row that fault produced read `0.16–0.50x` the floor — a
+  precise wrong number, and the sixteenth of its kind on these surfaces.
+
+  Runtime: these are DOM claims. The file carries the `-dom-cljs-test`
+  suffix so `:browser-test` runs it for real, and every test degrades to
+  a stated skip under `:node-test`, which is the posture the other `*-dom`
+  suites keep."
+  (:require [cljs.test :refer-macros [async deftest is testing]]
+            [re-frame.bench.hicasso.lane :as lane]))
+
+(def ^:private off-browser
+  "no DOM on this runtime — the claim is a DOM read-back inside a measured
+  window, and :browser-test is where it is asked")
+
+;; ---------------------------------------------------------------------------
+;; A page with one cell in it
+;; ---------------------------------------------------------------------------
+
+(defn- cell-container!
+  "A container holding one `data-i=\"0\"` cell reading `\"old\"` — the
+  smallest page `lane/text-at` can probe."
+  []
+  (let [c (js/document.createElement "div")]
+    (set! (.-innerHTML c) "<span data-i=\"0\">old</span>")
+    (.appendChild js/document.body c)
+    c))
+
+(defn- commit!
+  "Put `v` on the page. The ONLY way anything here reaches the DOM, so a
+  window that does not reach it leaves the cell reading `\"old\"`."
+  [container v]
+  (set! (.-textContent (.querySelector container "[data-i=\"0\"]")) (str v)))
+
+;; ---------------------------------------------------------------------------
+;; The two scheduler families, as fakes
+;; ---------------------------------------------------------------------------
+
+(defn- queued-notification-arm
+  "An arm whose notification reaches its render queue ON A MICROTASK.
+
+  `force!` drains whatever is in the queue when it runs, so a window that
+  drains immediately after the write finds it EMPTY and commits nothing.
+  The microtask yield is what makes this arm measurable at all."
+  [container]
+  (let [queue (atom nil)]
+    {:id     :queued-notification
+     :write! (fn [_i v]
+               (.then (js/Promise.resolve nil) (fn [_] (reset! queue v)))
+               nil)
+     :force! (fn [] (when-some [v @queue] (commit! container v) (reset! queue nil)))}))
+
+(defn- microtask-scheduled-arm
+  "An arm whose OWN render queue is drained on the microtask queue.
+
+  The write fills the queue synchronously, so a drain that runs straight
+  away finds the work and commits it. But the substrate's own microtask
+  drain, if it gets to run first, takes the work back OUT of the queue and
+  hands it to React outside any `flushSync` boundary, where it is PARKED
+  and never reaches the DOM inside this window. That is the recorded
+  fault, and `:parked` is where the lost commit can be seen sitting."
+  [container]
+  (let [queue  (atom nil)
+        parked (atom nil)]
+    {:id        :microtask-scheduled
+     :scheduler :microtask
+     :parked    parked
+     :write!    (fn [_i v]
+                  (reset! queue v)
+                  (.then (js/Promise.resolve nil)
+                         (fn [_] (when-some [q @queue]
+                                   (reset! parked q)
+                                   (reset! queue nil))))
+                  nil)
+     :force!    (fn [] (when-some [v @queue] (commit! container v) (reset! queue nil)))}))
+
+(defn- write-once!
+  "One `lane/verified-write!` against `arm`; answers a promise of
+  `[result tally-value]`."
+  [arm container]
+  (let [t (lane/tally)]
+    (-> (lane/verified-write! t {:arm arm :container container} 0 "new" [0])
+        (.then (fn [r] [r (lane/tally-value t)])))))
+
+;; ---------------------------------------------------------------------------
+;; The microtask family — the fault, and the repair
+;; ---------------------------------------------------------------------------
+
+(deftest microtask-arm-is-unverified-under-the-yielding-window
+  (testing "a microtask-scheduled arm measured through the YIELDING window
+           loses its commit, and the DOM read-back is what says so"
+    (async done
+      (if-not (lane/browser?)
+        (do (is true off-browser) (done))
+        (let [c   (cell-container!)
+              arm (dissoc (microtask-scheduled-arm c) :scheduler)]
+          (-> (write-once! arm c)
+              (.then (fn [[r tally]]
+                       (is (false? (:ok? r))
+                           "the yielding window must NOT verify a microtask-scheduled arm")
+                       (is (= {:writes 1 :unverified 1} tally)
+                           "and the tally must publish it as 1 unverified of 1")
+                       ;; The page is untouched, so the milliseconds this
+                       ;; window measured are a measurement of nothing.
+                       (is (= "old" (lane/text-at c 0))
+                           "the cell must still read the OLD value")
+                       ;; The commit is not lost, merely parked: a LATE DOM,
+                       ;; not a dead one, which is why the clock reading
+                       ;; looked plausible.
+                       (is (= "new" @(:parked arm))
+                           "the commit must be sitting parked outside the window")
+                       (.remove c)
+                       (done)))
+              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+
+(deftest microtask-arm-verifies-under-its-own-window
+  (testing "declaring :scheduler :microtask puts NOTHING between the write
+           and the drain, so the commit lands inside the window"
+    (async done
+      (if-not (lane/browser?)
+        (do (is true off-browser) (done))
+        (let [c   (cell-container!)
+              arm (microtask-scheduled-arm c)]
+          (-> (write-once! arm c)
+              (.then (fn [[r tally]]
+                       (is (true? (:ok? r)) "the write-then-drain window must verify")
+                       (is (= {:writes 1 :unverified 0} tally) "0 unverified of 1")
+                       (is (= "new" (lane/text-at c 0))
+                           "and the page must actually carry the written value")
+                       (is (nil? @(:parked arm))
+                           "nothing was parked — the drain got there first")
+                       ;; 0.0 and it MEANS it: there is no harness turn
+                       ;; inside this window to price.
+                       (is (zero? (:gap-ms r)) ":gap-ms must be 0.0, not merely small")
+                       (.remove c)
+                       (done)))
+              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+
+;; ---------------------------------------------------------------------------
+;; The other family — and therefore why ONE shape cannot serve both
+;; ---------------------------------------------------------------------------
+
+(deftest queued-notification-arm-verifies-under-the-yielding-window
+  (testing "the yield is LOAD-BEARING for an arm whose notification is
+           queued somewhere other than the queue the harness yields to"
+    (async done
+      (if-not (lane/browser?)
+        (do (is true off-browser) (done))
+        (let [c   (cell-container!)
+              arm (queued-notification-arm c)]
+          (-> (write-once! arm c)
+              (.then (fn [[r tally]]
+                       (is (true? (:ok? r)) "the yielding window must verify this family")
+                       (is (= {:writes 1 :unverified 0} tally) "0 unverified of 1")
+                       (is (= "new" (lane/text-at c 0)))
+                       (.remove c)
+                       (done)))
+              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+
+(deftest queued-notification-arm-is-unverified-under-the-microtask-window
+  (testing "and the write-then-drain window BREAKS that same arm — so
+           neither shape is universally right, which is the finding"
+    (async done
+      (if-not (lane/browser?)
+        (do (is true off-browser) (done))
+        (let [c   (cell-container!)
+              arm (assoc (queued-notification-arm c) :scheduler :microtask)]
+          (-> (write-once! arm c)
+              (.then (fn [[r tally]]
+                       (is (false? (:ok? r))
+                           "draining immediately must find this arm's queue empty")
+                       (is (= {:writes 1 :unverified 1} tally) "1 unverified of 1")
+                       (is (= "old" (lane/text-at c 0)))
+                       (.remove c)
+                       (done)))
+              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+
+;; ---------------------------------------------------------------------------
+;; The default is the window every published P0 row was taken through
+;; ---------------------------------------------------------------------------
+
+(deftest an-arm-that-declares-no-scheduler-keeps-the-yielding-window
+  (testing "an arm with no :scheduler key is measured through exactly the
+           window it was measured through before rf2-pq7d8 — which is what
+           makes this change additive and leaves every published P0 row
+           standing"
+    (async done
+      (if-not (lane/browser?)
+        (do (is true off-browser) (done))
+        (let [c    (cell-container!)
+              seen (atom [])
+              ;; The write queues a microtask that records the fact. If the
+              ;; window still yields ONE microtask before draining, that
+              ;; microtask has run by the time `force!` is called.
+              arm  {:id     :no-declaration
+                    :write! (fn [_i v]
+                              (.then (js/Promise.resolve nil)
+                                     (fn [_] (swap! seen conj :microtask-ran)))
+                              (swap! seen conj :wrote)
+                              (commit! c v)
+                              nil)
+                    :force! (fn [] (swap! seen conj :forced))}]
+          (is (not (contains? arm :scheduler)) "the arm declares no scheduler")
+          (-> (write-once! arm c)
+              (.then (fn [[r tally]]
+                       (is (= [:wrote :microtask-ran :forced] @seen)
+                           "exactly one microtask must sit between the write and the drain")
+                       (is (true? (:ok? r)))
+                       (is (= {:writes 1 :unverified 0} tally))
+                       ;; The gap is a real, priced turn on this path: the
+                       ;; asymmetry against the microtask window is a NUMBER
+                       ;; rather than an assurance.
+                       (is (number? (:gap-ms r)) ":gap-ms is measured, not asserted")
+                       (.remove c)
+                       (done)))
+              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))


### PR DESCRIPTION
Three beads on one surface: `lane.cljs` and the arms that ride it. Sequenced after PR #7267 repaired the shared harness, so nothing here moved an instrument under a live measurement.

## Which published rows this changes

| row | what happened |
|---|---|
| **HD-008 narrow write rows** (all 3 adapters) | **RE-RUN and republished.** The window changed, so they were re-taken, not re-labelled. The superseded ranges are **kept in place** on the studio page. |
| HD-008 bulk, mount rows | **Unchanged.** The bulk row passes a batch of one — the pre-batch window exactly. Mount rows were never in scope. |
| All P0 rows (`p0_reagent_app`, `p0_converge_app`) | **Unchanged.** The scheduler-aware yield is additive by construction; neither arm declares `:scheduler`. |
| `p0-converged-witness-set.md` — M2 mount, UIx segment | **Flagged, not changed.** See rf2-egdaq: the stricter control rule would fail it, so the rule was not installed. |

## rf2-egdaq — tightening the control would fail a published row, so it was not tightened

`lane/control-verdict` passes a control whose range merely OVERLAPS the ±slack band. `hd8-rows/positive-control!` requires EVERY ROUND inside it: *a control whose worst round is wrong has caught something, and letting a good round vouch for a bad one is how an instrument stops being one.*

The stricter rule is right. **Installing it is not a code decision.** Re-adjudicating the eleven controls `control-verdict` has published flips exactly one:

| | predicted | slack | strict band | published range | overlap | strict |
|---|---|---|---|---|---|---|
| `p0-converged-witness-set.md` — M2 mount, **UIx segment** | 1.9412 | 0.25 | 1.4559 – 2.4265 | **[1.333 – 2.000]** | ✅ | ❌ |

Its worst round sits **8.4% below the band's floor**. The other ten pass under **either** reading. Tightening `:ok?` turns a published pass into a published failure — a finding about a published number, needing an operator ruling on `rf2-2rtt6.1` and a re-run of the converged arm. **No number moved.** The docstring now states the defect where the next reader meets it. **Bead left OPEN deliberately.**

## rf2-pq7d8 — the yield now belongs to the arm

One fixed microtask cannot serve both scheduler families: load-bearing for a rAF-scheduled queue (stock Reagent), **fatal** for a microtask-scheduled one (`reagent2.impl.batching` — the commit is handed over first, React parks it outside any `flushSync` boundary, the drain finds nothing).

Shape **lifted from rf2-b69lw's HD-008-local repair**, not reinvented. An arm declares `:scheduler`; `:microtask` gets write-then-drain and `:gap-ms 0.0`, anything else or absent gets today's window unchanged. `:scheduler` appears nowhere outside `hd8_rows`, so **no published window moves**.

`lane_window_dom_cljs_test.cljs` proves **both** directions — the microtask arm is unverified under the yielding window (lost commit visible parked) and verified under its own; the queued-notification arm is the reverse. Neither shape is universally right.

## rf2-9zysg — batched narrow window, re-run, republished

Ten single-cell writes to ten **distinct** cells now share one clock. The per-arm scheduler wait is preserved per operation — no fixed yield reintroduced, and the window holds k harness turns, not 2k.

**Why the read-back survives the batch:** no macrotask runs inside the window. The fault it catches is a commit React parked at the default lane — scheduled via the Scheduler's `MessageChannel`, a macrotask — so it cannot land inside the window however many microtasks pass, and all k still read UNVERIFIED. What relaxes is microtask-scale lateness, and the pre-batch window already granted one such turn by construction. Stated in the row's `:measurement-method`.

**Re-run: all three adapters, guard did not refuse (exit 0).** `0 unverified of 780` on every arm of every run — 6,864 writes across the three runs, 0 unverified. Positive control passes HD-008's **strict** rule on all three: predicted 1.9934, ±30% band [1.3954 – 2.5914], measured `uix` [1.7143 – 1.9000], `reagent` [1.5000 – 1.8333], `slim` [1.7500 – 2.0000].

New narrow rows, floor-normalised: `donor-r1` 5.182 – 6.790, `donor-r2` 5.400 – 6.579, `reagent` 4.130 – 6.947, `reagent-slim` 4.222 – 5.944. Within-run (uix): all three donor comparisons straddle 1.0 — **indistinguishable**, the same verdict the superseded row carried.

The denominator is off the clamp (floor sample p50 0.90 – 1.25 ms, was 0.10 – 0.15 — one to one-and-a-half quanta, this page's stated weakest figure). Ranges tightened where quantisation made them wide (`reagent-slim` 2.25× spread → 1.41×) and **did not** for `reagent` (1.67× → 1.68×), where drift is what the range is made of — batching cannot help with drift and it is not claimed to. Per-write absolutes reproduce the unbatched run; the batched ratios sit *higher* because a floor rounded up to one quantum understates every ratio taken against it.

**Rows are anchored by blob hash, not only by SHA.** The run was at `1c7c963e`; a rebase rewrote it to `d3f1c2fff6` and merge will rewrite it again. `git diff 1c7c963e d3f1c2fff6 -- implementation/` is empty. The page carries `hd8_rows.cljs` blob `e6bca244…` and `lane.cljs` blob `67175675…`, which survive both.

## Quality gates

| gate | exit | result |
|---|---|---|
| `npm run test:browser` | **0** | 847 tests, 5489 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | **0** | 11951 tests, 59640 assertions, 0 failures, 0 errors |
| `npm run test:freehand` | **0** | 1399 tests, 7752 assertions, 0 failures, 0 errors |
| arm-order guard self-test (in-bundle + `.cjs`) | **0** | 8/8 checks ok, both re-runs |
| `hd8_run.cjs` — all three adapters, at the committed SHA | **0** | *"ok — measured, and no arm reads differently for its position in the plan"* |

`order_guard.cljc` and `order_guard.cjs` verified **byte-identical to `origin/main` by blob hash** after the rebase; tolerance untouched. `implementation/shadow-cljs.edn`, `p0_reagent_app.cljs` and `p0_converge_app.cljs` likewise identical.

Closes rf2-pq7d8, rf2-9zysg. **rf2-egdaq stays open** — it needs an operator ruling, not a patch.
