### PR TITLE
docs(hicasso): reconcile the HD-011 interop door with its escape (rf2-2rtt6.11)

### DIFF
--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -54,6 +54,8 @@ an API early. Decisions cited as HD-nnn are normative in
 the default surface is scored from day one, not discovered mid-clock:
 
 ```clojure
+(:require [re-frame.hicasso :as h :refer [defview use-subs]])
+
 (defview todo-row [{:keys [id]}]
   (let [{:keys [todo editing? draft]}
         (use-subs {:todo     [:todo/by-id id]
@@ -101,8 +103,8 @@ end-of-discrete-event restore is React's; a PATCH back end must own it
 
 ## The interop door (HD-011)
 
-No `[:> Component …]` form. One declaration per foreign component, with strong
-defaults:
+`defhost` is the door, and the only form taught — one declaration per foreign
+component, with strong defaults:
 
 ```clojure
 (h/defhost date-picker DatePicker)  ;; defaults: shallow camelCase props,
@@ -114,7 +116,8 @@ Usage `[date-picker {...}]` is indistinguishable from a native view; the JS
 require stays quarantined in one `.cljs` host namespace; the crossing has a
 declared identity for tooling; policy overrides live on the declaration. A
 migration codemod (collect `[:> X …]` sites → emit the defhost block → rewrite
-call sites) upgrades sites incrementally. **The one raw escape** (HD-011):
+call sites) upgrades sites incrementally. **The one raw escape** (HD-011),
+explicitly secondary to the declaration:
 `[:> Component props & children]` — same foreign lowering path, same default
 conversions, `.cljs`-only at that node, reduced structural identity; for
 runtime-selected components, `memo`/`lazy` values, render-prop-supplied

--- a/docs/design/hicasso/charter.md
+++ b/docs/design/hicasso/charter.md
@@ -51,7 +51,7 @@ canonical.
   dependency ledger — the two measured killers — are omitted as *designed
   mechanisms* and their residual costs re-priced under explicit budgets, with
   tripwires rather than intentions (boundary-exclusive retention is inventoried
-  and priced, never claimed absent ([validation.md](validation.md)).
+  and priced, never claimed absent; see [validation.md](validation.md)).
 
 ## The measured evidence base
 

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -220,12 +220,14 @@ instance props can express.
 
 ## HD-011 — The interop door
 
-**Ruling.** No `[:> Component …]` form. One-line `defhost` with strong defaults
-(shallow camelCase props, hiccup children → elements, functions pass through,
-SSR placeholder), policy overrides on the declaration, and a migration codemod
-for Reagent's `[:>]` sites. Identity-keyed auto-hosting of a raw JS component in
-head position is held in reserve, gated on dogfood evidence and the concept
-budget.
+**Ruling.** **`defhost` is the door, and the only form taught**: a one-line
+declaration with strong defaults (shallow camelCase props, hiccup children →
+elements, functions pass through, SSR placeholder), policy overrides on the
+declaration, and a migration codemod for Reagent's `[:>]` sites. **`[:> Component
+…]` is not that door** — it survives only as the explicitly secondary raw escape
+recorded below, for the cases a static declaration cannot express. Identity-keyed
+auto-hosting of a raw JS component in head position was held in reserve; the
+escape supersedes that reserve, leaving bare-head auto-hosting rejected.
 **Rationale.** A raw JS value in data position kills `.cljc` purity, structural
 testing, and tooling identity at that node, and `[:>]`'s implicit conversions are
 a documented support burden. The one-line declaration amortizes to zero while


### PR DESCRIPTION
Closes rf2-2rtt6.11.

PR #7257 made `docs/design/hicasso/decisions.md` normative, and the chronological
merged-PR audit found four defects in what it made normative. Three are wording;
one is a copyable example that could not compile as printed.

## HD-011 forbade and mandated the same form

`decisions.md` HD-011 opened with **"No `[:> Component …]` form"** and then, a
paragraph later, adopted that exact form as **"the one raw escape (adversarial
review, adopted)"**. `authoring.md` repeated the same no-form/escape pair.

**This is a stale headline, not a live disagreement.** The record already
contains both halves and merely states them as if they conflict:

- The escape paragraph is labelled *(adversarial review, adopted)* — an
  amendment the record accepted after the Ruling sentence was drafted, and the
  Ruling sentence was never updated to match.
- `**Reopens** n/a — the escape supersedes the earlier auto-hosting reserve`
  already names the escape as the live position.
- The Rationale never argues `[:>]` is illegal; it prices the costs of a raw JS
  value in data position — which is exactly the argument for making `[:>]`
  *secondary*, not for deleting it.
- `docs/EP/EP-0038-…md` already summarises HD-011 as "`defhost` + the one `[:>]`
  escape", and the draft guide (written from the record) teaches door-plus-escape
  with no prohibition anywhere.

So HD-011's Ruling now states the hierarchy the section already means:
**`defhost` is the door and the only form taught; `[:> Component …]` is the
explicitly secondary raw escape, for the cases a static declaration cannot
express.** The escape roster (runtime-selected components, `memo`/`lazy` values,
render-prop-supplied components, ecosystem-handed providers, one-off migration
sites), the "declare what you use twice" rule, the bare-head rejection, and the
Rationale are all untouched — **no decision changed, only its wording moved.**

One same-defect fix inside the same paragraph, called out so it is easy to
revert if unwanted: the Ruling held identity-keyed auto-hosting "in reserve"
while the escape paragraph says it "stays **rejected**" and Reopens says the
escape "supersedes the earlier auto-hosting reserve". That sentence now reads as
the history the other two sentences already say it is.

`authoring.md` §"The interop door (HD-011)" takes the matching one-sentence fix,
and its escape is marked explicitly secondary.

## The grouped example could not compile as printed

The grouped `use-subs` block called `use-subs` bare while the section's displayed
require was `[re-frame.hicasso :as h :refer [defview sub]]` — an unresolved
symbol for anyone pasting it. It now carries its own require,
`:refer [defview use-subs]`, which is how `draft-guide/02-views-and-reads.md`
writes the grouped surface (and is more accurate than extending the first
require, since the two blocks show two different read surfaces).

## The charter parenthesis

`charter.md`'s boundary-retention sentence opened a parenthetical and closed only
the nested citation. Balanced by dropping the redundant inner parens:
`… never claimed absent; see [validation.md](validation.md)).`

## Sequencing note

`rf2-2rtt6.6` (the draft guide) is sequenced behind this PR. Its
`05-interop.md` already teaches door-plus-escape and needs no reversal — after
this lands it can cite HD-011's Ruling directly instead of reconstructing it, and
must not re-import a "no `[:>]` form" line.

`docs/design/hicasso/architecture.md` mentions `defhost` once, in passing
(line 87) — the contradiction is not in it, so it is untouched. No `spec/` file
is touched.

## Quality gates

Run in this worktree, foreground, unpiped.

| Gate | Command | Exit |
|---|---|---|
| Strict docs build | `python -m mkdocs build --strict` | **0** |
| Doc slugs | `python scripts/check_doc_slugs.py` | **0** |
| Paren balance (charter bullet) | link-stripped paren count | **0** — 1 open / 1 close |

Note that `design/hicasso/` is `exclude_docs`'d in `mkdocs.yml`, so a green
strict build is *not* evidence about these pages. The exclusion was re-verified
against the built output: `site/design/` does not exist, and the only `hicasso`
path in `site/` is the separately-homed `EP/EP-0038-…` page. These three files
were therefore also read end-to-end by hand.
