### PR TITLE
bench(hicasso): discharge the P0 audit riders — narrow-write, heap ladder, spine decomposition (rf2-2rtt6.3, rf2-2rtt6.5, rf2-2rtt6.12)

### DIFF
--- a/docs/design/hicasso/studio/p0-ratom-spine-narrow-write.md
+++ b/docs/design/hicasso/studio/p0-ratom-spine-narrow-write.md
@@ -1,26 +1,36 @@
 # P0 — the ratom-spine narrow write (write + flush, summed)
 
-**Bead** `rf2-2rtt6.3` · **Producing commit**
-`a1934a64035ad13a231de82eb94ea6519e432c42` — the commit carrying the
-instrument that took these readings.
+**Bead** `rf2-2rtt6.3`
 
 ```bash
 cd implementation && npm ci
 node adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
 ```
 
-A commit SHA does not survive a rebase and this page has already been
-invalidated once by one. The instrument is therefore also identified by the
-content hashes of its three files, which do:
+**The instrument that took these readings is identified by content hash, not
+by commit SHA.** That is not fastidiousness: this page has now been invalidated
+by a rebase *twice*, once before the audit and once during the repair of it —
+the branch was rebased onto `main` between the run and the merge and every
+commit SHA moved, while the three blobs below did not move at all.
 
-| file | blob |
+| file (`implementation/adapters/reagent/test/re_frame/bench/`) | blob |
 |---|---|
-| `implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs` | `713fb3877dea102213da851bc8c21a8e0a9c835d` |
-| `implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_app.cljs` | `a201ff16debe57b2aa297fe6ae7d27a19c3831d2` |
-| `implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs` | `cbffc0205675b524060f8c956efe2205f9e3570f` |
+| `hicasso_narrow.cljs` | `713fb3877dea102213da851bc8c21a8e0a9c835d` |
+| `hicasso_narrow_app.cljs` | `a201ff16debe57b2aa297fe6ae7d27a19c3831d2` |
+| `hicasso_narrow_run.cjs` | `cbffc0205675b524060f8c956efe2205f9e3570f` |
 
-`git rev-parse HEAD:<path>` answers these at any commit whose tree carries
-the instrument, rebased or not.
+Authored as `7c51e77b4f` on `worker/bench-audit-cluster`. **If that SHA does
+not resolve, a rebase moved it and the blobs above are what to trust** — this
+finds a commit carrying them, and confirms it:
+
+```bash
+P=implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs
+git log --oneline --all -- $P
+git rev-parse <candidate>:$P    # must print 713fb3877dea102213da851bc8c21a8e0a9c835d
+```
+
+The reproduction above runs unchanged at any commit whose tree answers those
+three hashes.
 
 **Runtime, and it is the same for every figure on this page:** Chromium
 147.0.7727.15, `:advanced`, `goog.DEBUG=false`, Windows 11 (10.0.26200), 24

--- a/docs/design/hicasso/studio/p0-ratom-spine-narrow-write.md
+++ b/docs/design/hicasso/studio/p0-ratom-spine-narrow-write.md
@@ -1,18 +1,44 @@
 # P0 — the ratom-spine narrow write (write + flush, summed)
 
 **Bead** `rf2-2rtt6.3` · **Producing commit**
-`828d4f1ac0cff850b6fcb44a7fa2d0729fc175d8` — the commit carrying the
-instrument that took these readings; this page is its child.
+`a1934a64035ad13a231de82eb94ea6519e432c42` — the commit carrying the
+instrument that took these readings.
 
 ```bash
 cd implementation && npm ci
 node adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
 ```
 
+A commit SHA does not survive a rebase and this page has already been
+invalidated once by one. The instrument is therefore also identified by the
+content hashes of its three files, which do:
+
+| file | blob |
+|---|---|
+| `implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs` | `713fb3877dea102213da851bc8c21a8e0a9c835d` |
+| `implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_app.cljs` | `a201ff16debe57b2aa297fe6ae7d27a19c3831d2` |
+| `implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs` | `cbffc0205675b524060f8c956efe2205f9e3570f` |
+
+`git rev-parse HEAD:<path>` answers these at any commit whose tree carries
+the instrument, rebased or not.
+
 **Runtime, and it is the same for every figure on this page:** Chromium
 147.0.7727.15, `:advanced`, `goog.DEBUG=false`, Windows 11 (10.0.26200), 24
-logical CPUs, six sibling agents live on the box. Exit `0` = reportable,
-`1` = a gate failed, `2` = the arm-order guard refused.
+logical CPUs. Exit `0` = reportable, `1` = a gate failed, `2` = the
+arm-order guard refused.
+
+---
+
+## What changed, and what did not
+
+This page has been re-measured. The audit of PR #7262 found that the
+subscription ladder **did not isolate subscriptions**, and the ladder's
+figures and its attribution are withdrawn and replaced below. Two other
+findings survive unchanged in kind and were re-measured with everything
+else: the summed write+flush window, and the like-for-like correction.
+
+The superseded publication is recorded at the foot of this page rather than
+deleted. A reader must be able to see that these numbers were revisited.
 
 ---
 
@@ -40,16 +66,16 @@ that framing error is a row rather than a claim.
 spine a write is a bare install into the frame's one physical container;
 the reactions do not recompute there, they recompute on Reagent's flush.
 A harness that timed the write leg and stopped would have published
-0.0006–0.0010 ms per write for an operation that costs 0.39–0.52 — an
-understatement by a factor of between 400 and 850. That is why the summed
+0.0004–0.0007 ms per write for an operation that costs 0.32–0.33 — an
+understatement by a factor of between 460 and 800. That is why the summed
 figure is the published one.
 
 ---
 
 ## The headline
 
-**A narrow write on the ratom spine costs 0.39–0.52 ms, and 99.8% of it is
-the flush.**
+**A narrow write on the ratom spine costs 0.32–0.33 ms, and 99.8–99.9% of
+it is the flush.**
 
 Three independent runs at the one commit; 300 cells, 300 layer-1
 subscriptions, one per cell. Per-write milliseconds — a sample is 20
@@ -57,26 +83,26 @@ writes and the per-write figure is the sample divided by twenty.
 
 | arm | write+flush (mean, r1 / r2 / r3) | write | flush | write share |
 |---|---|---|---|---|
-| bare `r/atom` + cursor, no re-frame | 0.0621 / 0.0494 / 0.0310 | 0.0007–0.0008 | 0.0300–0.0613 | 1.1–2.2% |
-| **re-frame ratom spine, `replace-app-db!`** | **0.5244 / 0.5146 / 0.3903** | 0.0006–0.0010 | 0.3892–0.5237 | **0.1–0.2%** |
-| re-frame ratom spine, `dispatch-sync` | 0.5910 / 0.6076 / 0.4653 | 0.0213–0.0360 | 0.4437–0.5750 | 4.6–6.1% |
+| bare `r/atom` + cursor, no re-frame | 0.0272 / 0.0221 / 0.0174 | 0.0004–0.0011 | 0.0168–0.0261 | 1.9–4.1% |
+| **re-frame ratom spine, `replace-app-db!`** | **0.3208 / 0.3287 / 0.3226** | 0.0004–0.0007 | 0.3204–0.3278 | **0.1–0.2%** |
+| re-frame ratom spine, `dispatch-sync` | 0.3872 / 0.3757 / 0.3762 | 0.0106–0.0151 | 0.3647–0.3719 | 2.8–3.9% |
 
 Within-run **ranges** for the headline arm — median [min–max] over 36
 samples, which is 720 verified writes per run:
 
 | run | write+flush |
 |---|---|
-| 1 | 0.5475 [0.1850–1.1650] |
-| 2 | 0.5075 [0.1950–0.8800] |
-| 3 | 0.4200 [0.1350–0.7300] |
+| 1 | 0.3075 [0.1350–0.5100] |
+| 2 | 0.3225 [0.1150–0.5050] |
+| 3 | 0.3250 [0.1200–0.5450] |
 
 All three ranges overlap, so these are one measurement taken three times.
-The spread is wide — a factor of six between the best and worst sample of
-run 1 — because the box is carrying six other agents, and run 3 caught it
-quieter than the other two. **The absolute figure is therefore quoted as a
-range and not as a number**, and the two quantities that matter for the
-comparison are much steadier than it: the write share holds at 0.1–0.2%
-across every run, and the ladder exponent at 1.45–1.53.
+The spread within a run is still a factor of four between best and worst
+sample, so **the absolute figure is quoted as a range and not as a
+number**. The quantity that matters for this bead is much steadier than
+the absolute: the write share holds at 0.1–0.2% on every run, exactly as
+it did on the superseded publication, which was taken on a busier box at a
+different absolute level.
 
 ### Both orders
 
@@ -86,15 +112,15 @@ different adjacencies. A bare rotation would not vary that at all: arm `a`
 sits at slot `(a − s) mod k`, so its predecessor is `(a − 1) mod k` at
 every index, and only the round seam ever differs.
 
-Run 1, per-write medians [min–max]:
+Run 3, per-write medians [min–max]:
 
 | arm | forward | reflected | verdict |
 |---|---|---|---|
-| bare-ratom | 0.0500 [0.0150–0.1450] | 0.0450 [0.0200–0.1300] | overlapping — indistinguishable |
-| spine-replace | 0.4925 [0.1950–1.1650] | 0.5700 [0.1850–0.9400] | overlapping — indistinguishable |
-| spine-dispatch | 0.5300 [0.2350–1.1100] | 0.5875 [0.2500–1.7900] | overlapping — indistinguishable |
-| spine-30 | 0.0150 [0.0000–0.0400] | 0.0125 [0.0000–0.0500] | overlapping — indistinguishable |
-| spine-100 | 0.0850 [0.0200–0.2350] | 0.0750 [0.0250–0.2050] | overlapping — indistinguishable |
+| bare-ratom | 0.0150 [0.0050–0.0400] | 0.0175 [0.0050–0.0350] | overlapping — indistinguishable |
+| spine-replace | 0.2800 [0.1600–0.5450] | 0.3750 [0.1200–0.5150] | overlapping — indistinguishable |
+| spine-dispatch | 0.3525 [0.1500–1.0100] | 0.3700 [0.1400–0.6150] | overlapping — indistinguishable |
+| spine-30 | 0.0100 [0.0000–0.0550] | 0.0100 [0.0000–0.0600] | overlapping — indistinguishable |
+| spine-100 | 0.0450 [0.0200–0.1300] | 0.0500 [0.0200–0.1500] | overlapping — indistinguishable |
 
 The arm-order guard returned **reportable on all three runs**: no arm's
 figure is separated by what ran before it, or by where in the run it was
@@ -102,33 +128,60 @@ measured, on either factor, at a 10% tolerance.
 
 ---
 
-## Where the money goes, and why "flush" needed splitting further
+## Where the money goes — and a ladder that now isolates what it names
 
 "The flush" is one word doing two jobs — Reagent re-running every dirtied
 reaction, and React committing the one cell that changed — and telling
-them apart is exactly what the predecessor did not do. Three cell counts
-separate them by construction: the React commit is the same one-cell
-commit at every rung, and only the subscription count moves.
+them apart is exactly what the predecessor did not do.
+
+**The first cut of this ladder did not tell them apart either.** Each rung
+was built by handing the arm a cell count, so a rung changed the app-db
+vector, the mounted component count, the DOM span count, the reaction
+count and the subscription count *together*. The page then said "the React
+commit is the same one-cell commit at every rung, and only the
+subscription count moves". It was not, and it did not. What was measured
+was a compound **fixture-size** ladder, and no figure fitted through it
+could be attributed to layer-1 subscriptions.
+
+Every rung now mounts the **same 300-cell fixture** — 300 cells seeded
+into app-db, 300 `spine-cell` occurrences mounted, 300 spans rendered —
+and the rung's number is how many of those cells actually hold a
+subscription; the rest render an inert dash. Writes target the subscribing
+range, so the React commit really is one cell at every rung, by
+construction rather than by assertion. A gate in the driver refuses to fit
+the ladder unless each rung's subscription count is its own.
 
 | subscriptions | flush ms/write (r1 / r2 / r3) | per subscription | local slope vs the rung below |
 |---|---|---|---|
-| 30 | 0.0154 / 0.0182 / 0.0114 | 0.38–0.61 µs | — |
-| 100 | 0.0932 / 0.0946 / 0.0557 | 0.56–0.95 µs | 0.63–1.11 µs/sub |
-| 300 | 0.5237 / 0.5140 / 0.3892 | 1.30–1.75 µs | 1.67–2.15 µs/sub |
+| 30 | 0.0167 / 0.0136 / 0.0133 | 0.44–0.56 µs | — |
+| 100 | 0.0471 / 0.0586 / 0.0511 | 0.47–0.59 µs | 0.44–0.64 µs/sub |
+| 300 | 0.3204 / 0.3278 / 0.3221 | 1.07–1.09 µs | 1.35–1.37 µs/sub |
 
 **No per-subscription cost is quoted, and that is a finding rather than a
 caution.** A line fitted through the top and bottom rungs has an intercept
-of **−0.031 to −0.041 ms**, and the work that does *not* scale with the
+of **−0.017 to −0.021 ms**, and the work that does *not* scale with the
 subscription count — React's one-cell commit, Reagent's drain overhead —
-cannot cost less than nothing. The two-rung fit was tried first and
-produced a clean-looking "2.27 µs per subscription"; the negative
-intercept is the data refusing that model, and the third rung exists
-because of it. Ten times the subscriptions costs **34.0× / 28.2× / 34.1×**
-the flush — an exponent of **1.53 / 1.45 / 1.53**.
+cannot cost less than nothing. The negative intercept is the data refusing
+the linear model, and the third rung exists because of it. Ten times the
+subscriptions costs **19.2× / 24.1× / 24.2×** the flush — an exponent of
+**1.28 / 1.38 / 1.38**.
 
 So a narrow write's cost on this substrate is **super-linear in the number
-of layer-1 subscriptions in the frame**, and essentially all of it lands
-in Reagent's reaction drain rather than in React.
+of layer-1 subscriptions in the frame**. That sentence is now supported by
+the fixture: with the app-db, the component count, the DOM and the React
+commit all held constant across the rungs, the growth has nowhere else to
+live but the subscription graph — which is Reagent's reaction drain, not
+React's commit.
+
+**What the isolation cost the previous claim.** The superseded ladder read
+an exponent of 1.45–1.53 and an intercept of −0.031 to −0.041 ms. Isolated,
+the same question answers 1.28–1.38 and −0.017 to −0.021. Both ladders are
+super-linear; the first was steeper because it was also growing the app-db
+vector, the fiber tree and the DOM at every rung. **Roughly a third of the
+published super-linearity was fixture size, not subscriptions**, and the
+attribution the earlier page made — that the exponent described layer-1
+subscriptions — was not established by the arms that produced it. It is
+established by these.
 
 What is *not* in doubt is the shape, which is substrate-independent: a
 one-cell write marks **every** layer-1 subscription in the frame dirty and
@@ -142,23 +195,27 @@ on the ratom spine; it does not discover it.
 
 | | mean ms/write (r1 / r2 / r3) | ratio to bare ratom |
 |---|---|---|
-| bare `r/atom` + cursor (no re-frame) | 0.0621 / 0.0494 / 0.0310 | 1.0× |
-| re-frame ratom spine, `replace-app-db!` | 0.5244 / 0.5146 / 0.3903 | **8.4× / 10.4× / 12.6×** |
-| re-frame ratom spine, `dispatch-sync` | 0.5910 / 0.6076 / 0.4653 | 9.5× / 12.3× / 15.0× |
+| bare `r/atom` + cursor (no re-frame) | 0.0272 / 0.0221 / 0.0174 | 1.0× |
+| re-frame ratom spine, `replace-app-db!` | 0.3208 / 0.3287 / 0.3226 | **11.8× / 14.9× / 18.6×** |
+| re-frame ratom spine, `dispatch-sync` | 0.3872 / 0.3757 / 0.3762 | 14.2× / 17.0× / 21.7× |
 
 **Any narrow-update ratio quoted against the bare-ratom column is
 measuring this gap and calling it something else.** A ratio of, say, 15×
 against a bare ratom is not 15× against a re-frame application: on these
-numbers between eight and thirteen of it is already paid by re-frame
-reading its own subscriptions, whatever renders them.
+numbers essentially all of it is already paid by re-frame reading its own
+subscriptions, whatever renders them.
 
-The ratio's own run-to-run spread — 8.4× to 12.6× — is real and is stated
-rather than averaged away. Both arms move with the box, and they do not
-move together, so the ratio is not the stable quantity here; **the
-write-versus-flush split is**, and that is what this bead was asked for.
+The ratio's own run-to-run spread — 11.8× to 18.6× — is real and is stated
+rather than averaged away. It is *wider* than the superseded publication's
+8.4×–12.6×, and the reason is visible in the table: the bare-ratom arm
+drifted from 0.0272 to 0.0174 across the three runs while the spine arm
+held near 0.32. Both arms move with the box and they do not move together,
+so **the ratio is not the stable quantity here; the write-versus-flush
+split is**, and that is what this bead was asked for. The bare-ratom arm
+is also clamp-limited (below), which is a second reason not to lean on it.
 
 The event drain — the difference between the two write doors — is
-**0.067 / 0.093 / 0.075 ms per write**, 11–16% of the total. It is the
+**0.0664 / 0.0469 / 0.0536 ms per write**, 14–17% of the total. It is the
 only part of the cost that shows up in the *write* leg at all:
 `dispatch-sync` is the one arm whose write leg clears the clock grid, and
 it clears it because the drain runs there.
@@ -171,28 +228,44 @@ Every one of these ran before any figure was taken, on every run.
 
 | gate | result |
 |---|---|
-| **Arm-order guard self-test**, replayed from recorded fixtures, run inside the `:advanced` bundle | 8/8 passed |
+| **Arm-order guard self-test**, replayed from recorded fixtures, run inside the `:advanced` bundle | 11/11 passed |
 | **Key-renaming integrity probe** — the bundle writes and reads its own accumulator keys under the renaming it was compiled with | passed; keys `control,write,gap,force,total,span,bad,writes` |
 | **Clock quantum**, measured in-page | 0.100 ms — Chrome's documented clamp, confirmed rather than assumed |
-| **DOM read-back**, every write read back out of the page inside its own window | **0 unverified of 4320**, all three runs |
+| **Ladder isolation** — every rung mounts the same cell/component/span count, so only the subscription count moves | passed, 30/100/300 of 300 |
+| **DOM read-back**, every write read back out of the page inside its own window | **0 unverified of 3600**, all three runs |
 | **Empty-`flushSync` negative control** — the same arm with an empty drain, which must go red | **20 unverified of 20**, all three runs |
 | **Positive control**, predicted vs measured | see below |
 | **Leg identity** — write + gap + force = total, exactly | holds on every arm |
 | **Position completeness** — every sample reached the guard with a finite position | 36 of 36 per arm |
 
+**The denominator is 3,600 and not 4,320.** The `instrument` pseudo-arm
+renders no cell and forces its read-back verdict true, so its 720 windows
+per run were never evidence that anything reached a page. The superseded
+publication folded them in and claimed "0 unverified of 4320; every write
+read out of the DOM", which was true of 83% of the writes it named. Arms
+that cannot be verified are now excluded from the tally and reported on
+their own line.
+
+**Three of these gates now fail the run.** They used to be printed and
+stored and nothing else, so a run could report `VERDICT: reportable`
+beside a column saying some of its writes never reached the page. A
+nonzero unverified count on a real arm, a broken leg identity, and a
+missing sample position are each an exit now.
+
 ### The positive control
 
 A predicted burn inside every measured window, as its own leg, read three
-ways.
+ways. The prediction is fixed in the driver before the run, at 0.3 and
+0.9 ms per write.
 
 | | predicted | measured (p50, run 1 / 2 / 3) |
 |---|---|---|
-| rung 1 | 0.3000 ms/write | 0.3300 / 0.3300 / 0.3250 |
-| rung 2 | 0.9000 ms/write | 0.9600 / 0.9650 / 0.9600 |
-| **slope** | 0.6000 ms | 0.6300 / 0.6350 / 0.6350 — **5.0–5.8% high** |
+| rung 1 | 0.3000 ms/write | 0.3250 / 0.3250 / 0.3250 |
+| rung 2 | 0.9000 ms/write | 0.9650 / 0.9650 / 0.9700 |
+| **slope** | 0.6000 ms | 0.6400 / 0.6400 / 0.6450 — **6.7–7.5% high** |
 
-The direct readings run 0.025–0.065 ms above prediction and the slope runs
-5–6% high; both are the spin loop's own clock-read overhead, which the
+The direct readings run 0.025–0.070 ms above prediction and the slope runs
+6.7–7.5% high; both are the spin loop's own clock-read overhead, which the
 slope reduces but does not remove, since the loop reads the clock at both
 rungs. The control is a *floor* on the instrument's resolution, not a
 correction applied to anything.
@@ -213,19 +286,20 @@ rounded:
   appears anywhere on this page; the split above is taken from the
   **quantisation-unbiased mean**, which recovers a sub-quantum leg because
   `floor(t₁/q)·q − floor(t₀/q)·q` has expectation exactly `t₁ − t₀`.
-- **`bare-ratom` and `spine-30` totals** carry only a few multiples of the
-  quantum per sample. They are reported, and they are not absolute
-  figures — which is one more reason the like-for-like *ratio* is quoted
-  as a range and the *split* is quoted as the finding.
+- **`bare-ratom` and `spine-30` totals** carry only 2–3 multiples of the
+  quantum per sample on these runs — fewer than the superseded ones did,
+  because the box was quieter and the arms therefore faster. They are
+  reported, and they are not absolute figures, which is one more reason
+  the like-for-like *ratio* is quoted as a range and the *split* is quoted
+  as the finding.
 
 ### Warm-up
 
 Each arm is warmed at full window size until the first third of its
 trajectory stops separating from the last third by median, floor 8 windows
-and ceiling 20. **On these three runs several arms reached the ceiling
-still trending** — `bare-ratom` and `spine-dispatch` on all three,
-`spine-replace` on one — and that is stated rather than smoothed, because
-it is the honest account of a box carrying six other agents.
+and ceiling 20. **On these runs several arms reached the ceiling still
+trending** — `bare-ratom` on all three, `spine-30` on the third — and that
+is stated rather than smoothed.
 
 What says the figures are nevertheless usable is not the warm-up rule but
 the guard: its **phase** factor partitions each arm's 36 measured samples
@@ -244,7 +318,7 @@ deciding a site has stopped moving.
 
 ---
 
-## Three faults this harness found in itself
+## Five faults this harness found in itself
 
 Recorded because each produced a plausible, precise, wrong number first.
 
@@ -266,14 +340,56 @@ Recorded because each produced a plausible, precise, wrong number first.
 3. **A two-rung ladder fitted a negative intercept.** Reported above; the
    third rung exists because of it.
 
+4. **The three-rung ladder then varied five things at once.** Found by
+   audit, not by the harness. A rung was a whole smaller fixture, so the
+   slope described fixture size while the page attributed it to
+   subscriptions. Repaired above, and the repair moved the exponent from
+   1.45–1.53 to 1.28–1.38.
+
+5. **The verification denominator counted windows that verified nothing.**
+   Also found by audit. `0 unverified of 4320` included 720 windows of a
+   pseudo-arm that renders no cell and forces its own verdict true.
+
 ---
 
 ## Lane note
 
 This bead adds **no build id**. `implementation/shadow-cljs.edn` is
-hot-zone and `rf2-2rtt6.2` owns the lane's id, so the driver overrides an
-existing `:advanced` `:browser` build's entry point and output directory
-with `--config-merge` — the technique the donor's own `b8_run.cjs` uses.
-It prefers `:hicasso-bench` when the checkout has it and falls back to
-`:freehand-release` otherwise, so the lane's id is picked up with no edit
-once it lands. `HN_BASE_BUILD` overrides both.
+hot-zone and `rf2-2rtt6.2` owns the lane's id, so the driver overrides the
+`:hicasso-bench` build's entry point and output directory with
+`--config-merge` — the technique the donor's own `b8_run.cjs` uses. The
+`:freehand-release` fallback this page used to describe was removed by
+`rf2-uhw11`: that build is cleaned and rebuilt by two other gates, so a
+bench run and a gate run raced one compile cache, and a figure taken
+through the fallback would not have been comparable with one taken through
+the lane.
+
+---
+
+## Superseded
+
+**The publication of 2026-07-30, withdrawn 2026-07-31.** Its rows are on
+`rf2-2rtt6.1`; nothing there has been amended, and this section says why
+the earlier rows should not be quoted.
+
+- **Producing commit as published:** `828d4f1ac0cff850b6fcb44a7fa2d0729fc175d8`
+  — the authored PR commit, which is not on `main`. **The durable landed
+  instrument commit for that publication is `f047011184`**, and the full
+  authored-to-landed mapping is `bf240f3180=2122f7c5d6`,
+  `f74540571e=678afb6759`, `828d4f1ac0=f047011184`, `e229fef1f0=1c03cadd4c`.
+  Recorded here because a page whose SHA cannot be checked out cannot be
+  reproduced, and this page has now been invalidated by a rebase twice.
+- **The ladder rows and their attribution are withdrawn.** 0.0154/0.0182/
+  0.0114 at 30, 0.0932/0.0946/0.0557 at 100, an exponent of 1.45–1.53 and
+  an intercept of −0.031 to −0.041 ms were measured on a ladder whose rungs
+  were whole smaller fixtures. They are real measurements of fixture size
+  and they are not measurements of subscription count.
+- **The verification claim is withdrawn.** "0 unverified of 4320" should
+  have read "0 unverified of 3600, 720 not verifiable".
+- **The headline, the split and the like-for-like correction stand in
+  kind** and were re-measured for this page. The absolute level moved
+  (0.39–0.52 ms then, 0.32–0.33 now) because the box was carrying six
+  sibling agents then and fewer now, and because the page holds 1,500
+  mounted cells under the isolating ladder against 1,030 under the old
+  one. The write share — the figure the bead asked for — did not move at
+  all: 0.1–0.2% on both publications.

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -3,12 +3,28 @@
 Seat: EVIDENCE SPIKE, EP-0038 Wave 0. Bead `rf2-2rtt6.5`; numbers appended to
 the operator-owned standard `rf2-2rtt6.1`.
 
-Measured: 2026-07-30, at commit **`b083b060cb`**, which the rebase onto `main`
-carried forward as **`77ec2aa19a`** — the three instrument files are byte-identical
-across the two (verified by `git hash-object`), and `77ec2aa19a` is the one to
-`git show`. The instrument ships in the same PR as this page. Reagent **2.0.1**, UIx
-**1.4.4**, React **19.2.0**, shadow-cljs **3.4.10**, node **24.13.0**, headless
-**Chromium 147.0.7727.15** via Playwright 1.59.1. Windows 11, single developer
+**Re-measured 2026-07-31 after the audit of PR #7260**, which found that the
+regression included the R=0 anchor the page promised it excluded. Every figure
+below is a fresh reading through the corrected fit; the superseded publication
+is recorded in [§7](#7-superseded) rather than deleted.
+
+Measured at commit **`c0f9121daf914f0009fd5d1e47da9b465d3bd1f6`**. A SHA does
+not survive a rebase — the previous publication was invalidated by exactly
+that — so the instrument is also identified by content hashes, which do:
+
+| file | blob |
+|---|---|
+| `reads_ladder_run.cjs` | `eabd226bcb6fe3877d056145cae496eccd5ab62c` |
+| `reads_ladder.cljs` | `535ee5fd67fb0579854720ff26776c51c7007fd7` |
+| `reads_ladder_app.cljs` | `5b1770a49d4cac50248946b9e80bed726ca4f53d` |
+
+All three live under
+`implementation/freehand/test/re_frame/freehand/bench/`, and
+`git rev-parse HEAD:<path>` answers these at any commit whose tree carries the
+instrument.
+
+Reagent **2.0.1**, UIx **1.4.4**, React **19.2.0**, node **24.13.0**, headless
+**Chromium 147.0.7727.15** via Playwright. Windows 11, single developer
 workstation with other agents running concurrently. Every arm is an
 `:advanced` ClojureScript bundle with `goog.DEBUG false`
 (`:freehand-release`). **Browser numbers**; nothing here is a JVM or Node
@@ -21,7 +37,11 @@ node implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs
 ```
 
 (defaults `LADDER_ROUNDS=6 LADDER_SNAPSHOT=1 LADDER_SUBSTRATES=reagent,uix`;
-exits **2** if the arm-order guard refuses, **3** on an unverified mount.)
+exits **2** if the arm-order guard refuses, **3** on an unverified mount,
+**4** if reader C was requested and did not arrive complete.)
+
+The two substrate pages are independent by construction, so this run took them
+one at a time (`LADDER_SUBSTRATES=reagent`, then `=uix`) at the one commit.
 
 ---
 
@@ -32,49 +52,66 @@ different things, neither of which is what a subscribing boundary costs.**
 
 - **251 B was measuring the INTERCEPT** — the per-boundary shell of a UIx
   boundary that reads *nothing*. This ladder measures that shell directly at
-  **212 B** [207–216] and recovers it as the fitted intercept of the reads
-  curve at **150 B** [146–160].
+  **208 B** [201–213] and recovers it as the fitted intercept of the reads
+  curve at **113 B** [107–124].
 - **516 B was measuring one hook slot in isolation** — `useSyncExternalStore`
   alone, decomposed out of a Freehand boundary by `rf2-oob3g`. It is neither a
   boundary nor a read. It is one component of the slope, and a minority one.
-- **Neither priced a read.** A UIx boundary's *first* re-frame2 subscription
-  read costs **3,550 B** [3,549–3,551] — **6.9× the 516 B hook figure** and
-  **16.7× the 212 B boundary figure**. On Reagent the same read costs **942 B**
-  [941–943].
+- **Neither priced a read.** One more re-frame2 subscription read on a UIx
+  boundary costs **3,552 B** [3,551–3,553] — **6.9× the 516 B hook figure** and
+  **17.1× the 208 B boundary figure**. On Reagent the same read costs **943 B**
+  [935–944].
 
 Put the two figures on one line and they stop arguing. The fitted lines are
-`cost = 150 + 3,550 · R` on UIx and `cost = 406 + 942 · R` on Reagent, with the
-directly measured R=0 rungs — 212 B and 431 B — sitting a couple of hundred
-bytes above each intercept, which is the width of this instrument's zero against
-a 71 KB range. **251 is the first term; 516 is a fraction of the second.** There
-was never a contradiction to resolve — only a category error, and a category
-error is exactly what a ladder cannot make.
+`cost = 113 + 3,552 · R` on UIx and `cost = 397 + 943 · R` on Reagent, with the
+directly measured R=0 rungs — 208 B and 428 B — sitting ninety-five and thirty
+bytes above their intercepts, which is the width of this instrument's zero
+against a 71 KB range. **251 is the first term; 516 is a fraction of the
+second.** There was never a contradiction to resolve — only a category error,
+and a category error is exactly what a ladder cannot make.
+
+### The marginal read and the first read are not the same number
+
+The slope above is a **marginal** cost: what the *next* read costs once a
+boundary already reads. The **first** read costs more, because it also buys
+whatever the shell has to grow to hold a subscription at all, and this page
+previously called the slope "the first read".
+
+| | fitted marginal slope | first-read increment `y(R=1) − y(R=0)` |
+|---|---:|---:|
+| Reagent | **943 B** [935–944] | **1,137 B** [1,125–1,141] |
+| UIx | **3,552 B** [3,551–3,553] | **3,600 B** [3,581–3,601] |
+
+Both are measured, both are quoted, and neither is derived from the other. On
+UIx the two are within 1.4% and the distinction barely matters; on Reagent the
+first read costs **21% more** than the marginal one, which is a real feature of
+that substrate and was invisible while one number stood for both.
 
 Three consequences, and the second is the one the programme has to act on.
 
 1. **On memory, UIx is not the frontier — it inverts.** UIx wins the
-   per-boundary shell (**212 B** against Reagent's **431 B**, 0.49×) and loses
-   the read by **3.77×** (3,550 against 942). The crossover is *below one read*:
+   per-boundary shell (**208 B** against Reagent's **428 B**, 0.49×) and loses
+   the read by **3.77×** (3,552 against 943). The crossover is *below one read*:
    any boundary that subscribes at all is cheaper on Reagent. The census's
-   seven-read archetype costs **24,762 B/boundary on the raw UIx spine against
-   Reagent's 6,580 B**.
+   seven-read archetype costs **24,758 B/boundary on the raw UIx spine against
+   Reagent's 6,587 B**.
 2. **The ~0.4–0.5 KB exclusive-retained budget is a SHELL budget, and nothing
    measured meets it for a boundary that reads once.** Both shells clear it
-   (UIx 212 B, Reagent 431 B). At one read UIx is at **3,811 B** — 7.6× the
-   1 KB paper-fail line — and Reagent at **1,565 B**, 1.6×. The budget row in
+   (UIx 208 B, Reagent 428 B). At one read UIx is at **3,807 B** — 7.6× the
+   1 KB paper-fail line — and Reagent at **1,562 B**, 1.6×. The budget row in
    [validation.md](../validation.md) needs a per-read companion, or it is
    unfalsifiable; see [§5](#5-what-this-hands-the-programme).
 3. **HD-002's tier-1 exclusion now has a price in bytes.** The scalar per-read
    hook spine was excluded as product on hook-rule grounds (N reads = N hooks
    breaks HD-020's ≤2-hook budget). Memory says the same thing independently and
-   louder: the comparator arm allocates **128.5 objects per read** against the
-   Reagent path's **36.2**, at an almost identical **~27 bytes per object**. The
-   spine is not allocating bigger things; it is allocating **3.55× as many of
-   them**.
+   louder: the comparator arm allocates **128.4 objects per read** against the
+   Reagent path's **35.8**, at an almost identical **~26–28 bytes per object**.
+   The spine is not allocating bigger things; it is allocating **3.58× as many
+   of them**.
 
 And a null result worth stating because its absence would have been the worse
 finding: **neither arm retains anything after teardown.** Released heap returns
-to baseline within ±17 B per boundary on every arm, and under ±5 B on almost
+to baseline within ±11 B per boundary on every arm, and under ±6 B on almost
 all of them — HD-002's clause-(d) survival metric, met by both substrates
 ([§4](#4-what-happens-after-teardown)).
 
@@ -101,7 +138,9 @@ read the heap; release, collect, read again.
 **A and B are not independent** — two doors onto one V8 counter — and this page
 does not bank them as if they were. **C** walks the object graph and is the
 reader that makes the table falsifiable. It also carries the object *counts*
-that §1's third consequence rests on.
+that §1's third consequence rests on. **If C is requested and does not arrive
+complete, the driver now exits 4** rather than printing a table on the two
+correlated readers; that refusal is the audit's second repair.
 
 **The in-situ positive control, predicted before anything is measured.** A dense
 JS array of 587,500 doubles, which V8 stores as unboxed 8-byte slots:
@@ -111,17 +150,25 @@ as the arms.
 
 | page | reader | predicted | measured | error |
 |---|---|---:|---:|---:|
-| Reagent | A | 4,700,000 B | 4,700,365 B [4,699,074–4,700,974] | **+0.008%** |
-| Reagent | B | 4,700,000 B | 4,700,358 B | +0.008% |
-| Reagent | C | 4,700,000 B | **4,700,024 B** | **+0.001%** |
-| UIx | A | 4,700,000 B | 4,700,068 B [4,692,128–4,700,910] | **+0.001%** |
-| UIx | B | 4,700,000 B | 4,700,068 B | +0.001% |
-| UIx | C | 4,700,000 B | 4,698,540 B | −0.031% |
+| Reagent | A | 4,700,000 B | 4,700,464 B [4,698,960–4,701,088] | **+0.010%** |
+| Reagent | B | 4,700,000 B | 4,700,463 B | +0.010% |
+| Reagent | C | 4,700,000 B | **4,700,024 B** | **+0.0005%** |
+| UIx | A | 4,700,000 B | 4,700,084 B [4,694,914–4,701,024] | **+0.002%** |
+| UIx | B | 4,700,000 B | 4,700,084 B | +0.002% |
+| UIx | C | 4,700,000 B | 4,693,988 B | **−0.128%** |
 
-**Verification: 0 unverified of 186 mounts.** Every mount counts the boundary
-elements it should have produced and answers the count beside the expectation —
-an arm that silently rendered nothing would otherwise read as the cheapest
-substrate in the table.
+Five of the six readings sit inside ±0.01%. **The sixth does not, and it is
+stated rather than smoothed**: reader C on the UIx page read 6,012 B light on a
+4.7 MB prediction. That page's snapshot pass walks a heap that reaches ~26 MB
+above baseline at the 20-read rung, against ~8 MB on the Reagent page, and a
+full-graph scan of a heap that size drifts more between its two reads. It is a
+bound on reader C's resolution on the *larger* page, and it is two orders of
+magnitude below the 3.77× this page reports.
+
+**Verification: 0 unverified of 186 mounts** (93 per page). Every mount counts
+the boundary elements it should have produced and answers the count beside the
+expectation — an arm that silently rendered nothing would otherwise read as the
+cheapest substrate in the table.
 
 **Order.** Six rounds per page; the schedule rotates *and reflects*, so every arm
 is measured after at least two distinct predecessors and both whole-plan orders
@@ -129,10 +176,10 @@ run. Even rounds forward, odd reversed, reported **separately, never as a mean**
 — the pair exists to show the figure does not move, and by the house rule
 overlapping ranges mean indistinguishable. **Position dominates adjacency**, so
 an unread warm-up pass over every arm precedes round 1. The arm-order guard
-(`order_guard.cjs`, self-tested before the bundle is built) returned **clean on
-both pages**; it refuses on a contaminated *or* an unchecked arm and the driver
-exits 2 when it does. It did exactly that on a one-round trial run, which is how
-the refusal path is known to work here.
+(`order_guard.cjs`, self-tested before the bundle is built — **11 checks, all
+passed**, including the two repairs PR #7267 landed: the k=2 ordering degeneracy
+and the refusal-on-lost-samples) returned **clean on both pages**; it refuses on
+a contaminated *or* an unchecked arm and the driver exits 2 when it does.
 
 **Like-for-like, and why two pages.** Both arms read **re-frame2 subscriptions**
 — the same registrar, the same `[:lad/cell i]` query vectors, one shared frame
@@ -154,6 +201,14 @@ carries the subscription as well as the hook. That is the editing-grid shape
 (use-case A4, and A3's bulk row), and it is the honest worst case: a page where
 many boundaries read *one* shared sub pays the reaction once, not once each.
 
+**The fit is over 1, 3, 7 and 20 — and over nothing else.** `validation.md`
+requires the ladder to be measured directly and never inferred from a sub-free
+rung, and R=0 is a sub-free rung. It rides along as an **anchor**: it is the
+published `storm/uix` 251 B / `storm/reagent` 411 B shape rebuilt in this
+harness, so a reader can see whether this instrument lands where the
+predecessor's did before believing anything it says about reads. It is reported
+everywhere and regressed nowhere.
+
 ---
 
 ## 1. Curve B — fixed boundaries × growing reads
@@ -166,37 +221,41 @@ plan direction; **C** is the independent snapshot pass.
 
 | reads | A (6 rounds) | A, forward | A, reversed | C |
 |---:|---:|---:|---:|---:|
-| 0 *(anchor)* | 431 [420–440] | 421 [420–427] | 436 [436–440] | 428 |
-| **1** | **1,565** [1,552–1,570] | 1,564 [1,553–1,566] | 1,565 [1,552–1,570] | 1,597 |
-| **3** | **3,292** [3,280–3,363] | 3,297 [3,287–3,363] | 3,285 [3,280–3,299] | 3,301 |
-| **7** | **6,580** [6,565–6,616] | 6,582 [6,576–6,616] | 6,578 [6,565–6,585] | 6,577 |
-| **20** | **19,379** [19,368–19,399] | 19,376 [19,368–19,399] | 19,382 [19,368–19,392] | 19,377 |
+| 0 *(anchor — excluded from the fit)* | 428 [421–434] | 422 [421–429] | 432 [427–434] | 429 |
+| **1** | **1,562** [1,552–1,573] | 1,560 [1,555–1,568] | 1,563 [1,552–1,573] | 1,605 |
+| **3** | **3,286** [3,275–3,342] | 3,290 [3,285–3,342] | 3,285 [3,275–3,287] | 3,300 |
+| **7** | **6,587** [6,573–6,606] | 6,596 [6,575–6,606] | 6,579 [6,573–6,595] | 6,578 |
+| **20** | **19,380** [19,215–19,399] | 19,381 [19,367–19,399] | 19,380 [19,215–19,393] | 19,373 |
 
-> **slope = 942 B per read** [941–943] · forward 942 [941–943] · reversed 942
-> [942–942] · **intercept = 406 B** [401–431] · r² 0.99896 [0.99895–0.99905]
+> **marginal slope = 943 B per read** [935–944] · forward 942 [942–944] ·
+> reversed 943 [935–944] · **fitted intercept = 397 B** [393–420] ·
+> **first-read increment 1,137 B** [1,125–1,141] · r² 0.99878 [0.99875–0.99894]
 
 ### UIx on re-frame2 subs
 
 | reads | A (6 rounds) | A, forward | A, reversed | C |
 |---:|---:|---:|---:|---:|
-| 0 *(anchor)* | 212 [207–216] | 214 [207–216] | 211 [210–214] | 212 |
-| **1** | **3,811** [3,799–3,813] | 3,810 [3,799–3,812] | 3,812 [3,809–3,813] | 3,848 |
-| **3** | **10,788** [10,779–10,815] | 10,794 [10,789–10,815] | 10,781 [10,779–10,788] | 10,807 |
-| **7** | **24,762** [24,740–24,772] | 24,770 [24,767–24,772] | 24,752 [24,740–24,757] | 24,792 |
-| **20** | **71,232** [71,206–71,246] | 71,235 [71,230–71,242] | 71,224 [71,206–71,246] | 71,291 |
+| 0 *(anchor — excluded from the fit)* | 208 [201–213] | 207 [201–213] | 209 [206–212] | 211 |
+| **1** | **3,807** [3,794–3,810] | 3,801 [3,794–3,808] | 3,809 [3,806–3,810] | 3,854 |
+| **3** | **10,785** [10,770–10,801] | 10,797 [10,783–10,801] | 10,781 [10,770–10,787] | 10,811 |
+| **7** | **24,758** [24,744–24,770] | 24,767 [24,763–24,770] | 24,748 [24,744–24,754] | 24,799 |
+| **20** | **71,229** [71,216–71,241] | 71,231 [71,228–71,235] | 71,217 [71,216–71,241] | 71,300 |
 
-> **slope = 3,550 B per read** [3,549–3,551] · forward 3,550 [3,550–3,551] ·
-> reversed 3,550 [3,549–3,551] · **intercept = 150 B** [146–160] · r² 0.99998
+> **marginal slope = 3,552 B per read** [3,551–3,553] · forward 3,553
+> [3,552–3,553] · reversed 3,552 [3,551–3,553] · **fitted intercept = 113 B**
+> [107–124] · **first-read increment 3,600 B** [3,581–3,601] · r² 0.99997
 
 **Every rung's forward and reversed ranges overlap**, on both substrates, so by
 this studio's own rule the plan direction is indistinguishable on every figure
 above. The independent reader agrees with A to better than **1.0%** on UIx and
-**2.1%** on Reagent (worst case the R=1 rung, 1,597 against 1,565).
+**2.8%** on Reagent (worst case the R=1 rung, 1,605 against 1,562).
 
-**Both curves are lines.** r² ≥ 0.9989 in every round on both substrates. That
+**Both curves are lines.** r² ≥ 0.9987 in every round on both substrates. That
 matters more than it looks: a per-read cost that grew or shrank with the number
 of reads would mean the slope was not a per-read cost at all, and the fit is
-what forecloses that reading.
+what forecloses that reading. The r² is computed over the four reactive rungs
+only, so it is a statement about 1–20 reads and not about a line drawn through
+a point that reads nothing.
 
 ---
 
@@ -204,64 +263,76 @@ what forecloses that reading.
 
 Three reads throughout; boundaries doubling. `y` is *total* excess over the
 same-size floor, so the slope is bytes per boundary and the intercept is
-whatever the page pays once.
+whatever the page pays once. This curve never had an R=0 rung and is unaffected
+by the fit correction; it is re-measured here because everything else was.
 
 | boundaries | Reagent, fwd | Reagent, rev | UIx, fwd | UIx, rev |
 |---:|---:|---:|---:|---:|
-| 300 | 3,580 [3,574–3,592] | 3,545 [3,538–3,557] | 10,979 [10,959–11,206] | 10,991 [10,978–10,994] |
-| 600 | 3,388 [3,380–3,420] | 3,429 [3,359–3,430] | 10,844 [10,841–10,865] | 10,873 [10,844–10,879] |
-| 1,200 | 3,297 [3,287–3,363] | 3,285 [3,280–3,299] | 10,794 [10,789–10,815] | 10,781 [10,779–10,788] |
-| 2,400 | 3,231 [3,222–3,233] | 3,224 [3,132–3,228] | 10,742 [10,736–10,742] | 10,750 [10,750–10,754] |
+| 300 | 3,568 [3,568–3,574] | 3,524 [3,517–3,552] | 10,979 [10,965–11,177] | 10,971 [10,966–11,018] |
+| 600 | 3,393 [3,384–3,420] | 3,412 [3,337–3,418] | 10,860 [10,840–10,874] | 10,872 [10,844–10,877] |
+| 1,200 | 3,290 [3,285–3,342] | 3,285 [3,275–3,287] | 10,797 [10,783–10,801] | 10,781 [10,770–10,787] |
+| 2,400 | 3,232 [3,227–3,236] | 3,224 [3,216–3,226] | 10,744 [10,738–10,747] | 10,750 [10,750–10,757] |
 
 *(bytes per boundary, so the visible decline down each column is the page
 constant amortising — which is the thing this curve exists to separate out.)*
 
 | | bytes per boundary @ 3 reads | page constant | r² |
 |---|---:|---:|---:|
-| **Reagent** | **3,177** [3,061–3,186] | 136,731 B [115,998–199,589] | 0.99997 |
-| — forward / reversed | 3,182 [3,165–3,186] / 3,174 [3,061–3,180] | | |
-| **UIx** | **10,711** [10,687–10,718] | 89,929 B [76,356–125,879] | 1.00000 |
-| — forward / reversed | 10,700 [10,687–10,710] / 10,718 [10,712–10,718] | | |
+| **Reagent** | **3,178** [3,165–3,188] | 128,760 B [103,249–133,669] | 0.99998 |
+| — forward / reversed | 3,182 [3,173–3,188] / 3,173 [3,165–3,183] | | |
+| **UIx** | **10,710** [10,694–10,724] | 88,122 B [75,507–120,064] | 1.00000 |
+| — forward / reversed | 10,701 [10,694–10,711] / 10,718 [10,710–10,724] | | |
 
 **The two curves agree, and that is the point of separating them.** Curve B's
-fit predicts a three-read boundary at `406 + 3·942 = 3,232 B` on Reagent and
-`150 + 3·3,550 = 10,800 B` on UIx. Curve A, built from four different arms and
-a different regression, answers **3,177 B** and **10,711 B** — within **1.7%**
-and **0.8%**. A per-boundary cost measured by growing the boundaries and a
-per-boundary cost inferred from growing the reads land on the same number, so
-the decomposition into a shell plus a per-read term is not an artefact of either
-fit.
+corrected fit predicts a three-read boundary at `397 + 3·943 = 3,226 B` on
+Reagent and `113 + 3·3,552 = 10,769 B` on UIx. Curve A, built from four
+different arms and a different regression, answers **3,178 B** and **10,710 B**
+— within **1.5%** and **0.6%**. A per-boundary cost measured by growing the
+boundaries and a per-boundary cost inferred from growing the reads land on the
+same number, so the decomposition into a shell plus a per-read term is not an
+artefact of either fit. *(The agreement is slightly tighter than the superseded
+publication's 1.7% / 0.8%, which is a small point in favour of the corrected
+fit and not offered as evidence for it.)*
 
-**The page constant is small and does not carry the result**: 90–137 KB against
-3.4–25.8 MB of boundary term, i.e. **0.3%–4%**. So Curve B's per-boundary
-figures are per-boundary figures, not a page constant divided by 1,200.
+**The page constant is small and does not carry the result.** On the
+1,200-boundary arm that Curve B is built from, it is **0.7% (UIx) to 3.4%
+(Reagent)** of the boundary term. Across all four Curve A arms it ranges from
+0.3% (the 2,400-boundary UIx arm) to 12% (the 300-boundary Reagent arm, the
+smallest and thinnest on the page). So Curve B's per-boundary figures are
+per-boundary figures, not a page constant divided by 1,200.
 
 ---
 
 ## 3. What the reads are made of
 
-Reader C counts nodes as well as bytes.
+Reader C counts nodes as well as bytes. Both columns are **floor-subtracted**,
+which the superseded table's R=0 and R=20 columns were not — the per-read
+figure was unaffected, since the floor cancels in a difference, but the two
+end-point columns read about 13 objects high.
 
-| | objects per boundary, R=0 | per boundary, R=20 | **objects per read** | **bytes per object** |
+| | objects/boundary, R=0 | per boundary, R=20 | **objects per read** | **bytes per object** |
 |---|---:|---:|---:|---:|
-| Reagent | 24.9 | 749.6 | **36.2** | 26.0 |
-| UIx | 18.0 | 2,587.6 | **128.5** | 27.6 |
+| Reagent | 12.1 | 736.8 | **35.8** | 26.3 |
+| UIx | 5.2 | 2,574.8 | **128.4** | 27.7 |
 
 The two substrates allocate objects of **essentially the same size**. The entire
 3.77× is **object count**: the UIx spine's `use-subscribe` — `useSyncExternalStore`
 plus the two `useRef`s, the `useMemo` and the committed-snapshot bookkeeping
-around it, per read — costs 3.55× as many objects as one `deref` of the same
+around it, per read — costs 3.58× as many objects as one `deref` of the same
 subscription under Reagent's capture.
 
 This is where 516 B belongs. `rf2-oob3g` put React's six hooks at 1,171 B for a
 whole boundary and `useSyncExternalStore` alone at 516 B of that. Against
-**3,550 B for one read**, the store hook is **14.5%** — real, and nowhere near
+**3,552 B for one read**, the store hook is **14.5%** — real, and nowhere near
 the whole story. **A read is not a hook.** It is a hook stack *and* a
 subscription: a reaction, a cache entry keyed by `(query-id, args)`, a query
 vector, and a watch registration, all of which the Reagent arm pays too. Reagent's
-942 B is the closest thing this page has to a floor for *the subscription
+943 B is the closest thing this page has to a floor for *the subscription
 itself*, which makes it the number a grouped or collected read mechanism has to
 beat — see §5.
+
+`rf2-2rtt6.12` takes this decomposition further, ablating the spine's own hooks
+to find where the 128 objects go.
 
 ---
 
@@ -273,12 +344,12 @@ unmount, which is a different and worse finding than a large per-boundary figure
 
 Residue after release, bytes per boundary, median of six rounds:
 
-| | worst arm | typical |
+| | worst arm | all reactive arms |
 |---|---:|---:|
-| Reagent | +17.1 (`a-r3-b300`) | 0.1 – 7.5 |
-| UIx | +7.2 (`b-r20-b1200`) | −0.4 – 4.7 |
+| Reagent | +10.5 (`a-r3-b300`) | +0.4 – +10.5 |
+| UIx | +6.0 (`b-r20-b1200`) | −4.0 – +6.0 |
 
-Floors read −3.5 to +1.3, which is the size of this instrument's zero. **Both
+Floors read −3.6 to +0.8, which is the size of this instrument's zero. **Both
 arms return to baseline.** HD-002's clause-(d) survival metric — *zero retained
 per-occurrence objects after commit/teardown* — is met by both substrates, and
 any candidate that misses it is missing something both donors already have.
@@ -289,16 +360,23 @@ any candidate that misses it is missing something both donors already have.
 
 **The red-zones for this witness family.** Under the delegated ruling on
 `rf2-2rtt6.1`, the measured UIx retained-heap figure *is* the red-zone
-threshold, and these are it:
+threshold, and these are it — **re-derived from the corrected fit, superseding
+the values published on 2026-07-30**:
 
-| axis | UIx red-zone |
-|---|---:|
-| per-boundary shell (R=0) | **212 B** [207–216] |
-| per read | **3,550 B** [3,549–3,551] |
-| boundary @ 1 read | **3,811 B** |
-| boundary @ 3 reads | **10,788 B** |
-| boundary @ 7 reads | **24,762 B** |
-| boundary @ 20 reads | **71,232 B** |
+| axis | UIx red-zone | superseded value |
+|---|---:|---:|
+| per-boundary shell (R=0, measured) | **208 B** [201–213] | 212 B |
+| per read (marginal) | **3,552 B** [3,551–3,553] | 3,550 B |
+| first read (increment) | **3,600 B** [3,581–3,601] | *not published* |
+| boundary @ 1 read | **3,807 B** | 3,811 B |
+| boundary @ 3 reads | **10,785 B** | 10,788 B |
+| boundary @ 7 reads | **24,758 B** | 24,762 B |
+| boundary @ 20 reads | **71,229 B** | 71,232 B |
+
+Every threshold moved by less than 0.2%, so no candidate's verdict can turn on
+the correction. They are restated anyway, because a red-zone whose provenance
+is a fit that used a forbidden rung is not a red-zone anyone should have to
+defend.
 
 **One thing the operator should look at before those are applied mechanically.**
 The ruling's rationale is that *UIx is the frontier comparator*. On the clock
@@ -308,7 +386,7 @@ read. A red-zone derived from UIx alone would therefore set a per-read ceiling
 **3.77× looser than the best measured option**, and a candidate could clear it
 comfortably while being worse than the Reagent adapter that already ships. The
 rule as written is still the rule; this page only records that on this axis it
-is not binding, and that **942 B/read is the number a native layer actually has
+is not binding, and that **943 B/read is the number a native layer actually has
 to beat.** Whether to tighten the memory red-zone to the per-axis best rather
 than to UIx is the operator's call, and only the operator's.
 
@@ -316,7 +394,7 @@ than to UIx is the operator's call, and only the operator's.
 receiving the whole query collection — can only remove the *hook* half of a
 read. The subscription half is common to both arms. So the floor a grouped
 mechanism can reach on this witness is bounded below by roughly Reagent's
-**942 B/read**, and the prize for grouping is the difference: **≈2,600 B per
+**943 B/read**, and the prize for grouping is the difference: **≈2,600 B per
 read**, or **≈18 KB on the census's seven-read archetype**. That is a large
 prize and a concrete pre-registered number, which is what HD-002 clause (c) asks
 strategy hypotheses to be counted against.
@@ -326,31 +404,72 @@ per boundary* at ~0.4–0.5 KB target, >1 KB paper-fail. Read as a **shell**
 budget it is exactly right and both donors pass. Read as a *boundary including
 its reads* it is unreachable — the cheapest substrate measured is 1.6× the
 paper-fail line at **one** read. The budget table wants a per-read row beside
-the per-boundary one, and the per-read row's honest anchor is 942 B.
+the per-boundary one, and the per-read row's honest anchor is 943 B.
 
 ---
 
-## Anchors, and one that does not fully reproduce
+## 6. Anchors, and one that does not fully reproduce
 
 The R=0 rung is here to tie this instrument to the published sub-free rows
 before anything it says about reads is believed. **Nothing in §§1–5 is derived
-from it**; every reactive figure above is measured at 1, 3, 7 or 20 reads
-directly.
+from it** — and unlike the superseded publication, that is now true of the fit
+as well as of the prose.
 
 | | published (`freehand-vs-reagent-memory.md` §2) | here, R=0 | |
 |---|---:|---:|---:|
-| Reagent sub-free boundary | 411 / 409 (A), 403 (C) | 431 [420–440] (A), 428 (C) | **+4.9% / +6.2%** |
-| UIx sub-free boundary | 251 / 252 (A), 251 (C) | 212 [207–216] (A), 212 (C) | **−15.5%** |
+| Reagent sub-free boundary | 411 / 409 (A), 403 (C) | 428 [421–434] (A), 429 (C) | **+4.1% / +6.5%** |
+| UIx sub-free boundary | 251 / 252 (A), 251 (C) | 208 [201–213] (A), 211 (C) | **−17.1%** |
 
-The Reagent anchor reproduces. **The UIx anchor reads 15% below the published
+The Reagent anchor reproduces. **The UIx anchor reads 17% below the published
 figure and is not reconciled away here.** The witnesses are not identical —
 `storm` is 10 roots × 300 `span.leaf` boundaries carrying a text child; this is
 1 root × 1,200 `span.cell` boundaries carrying a `data-i` attribute the floor
-also carries — and two differently-built instruments landing 39 B apart on a
+also carries — and two differently-built instruments landing 43 B apart on a
 251 B figure is the size of effect a witness change can produce. It is recorded
 rather than explained, and it is small against the thing the page is for: the
 shell is O(200 B) on either reading, the read is O(3,550 B), and the ratio
 between them is what the ladder was built to measure.
+
+---
+
+## 7. Superseded
+
+**The publication of 2026-07-30, withdrawn 2026-07-31.** Its rows are on
+`rf2-2rtt6.1`; nothing there has been amended, and this section says why the
+earlier rows should not be quoted.
+
+- **Provenance as published.** The page named `77ec2aa19a` as "the one to
+  `git show`". That is the **authored PR commit and is not on `main`**. The
+  durable landed instrument commit is **`9b0759be46`**, and the full
+  authored-to-landed mapping is `6f98cd7cc0=6c6d299664`, `77ec2aa19a=9b0759be46`,
+  `50aa0dfee3=42f4692104`. Recorded because a page whose SHA cannot be checked
+  out cannot be reproduced.
+- **The fits are withdrawn and replaced.** `curves()` regressed
+  `[0, 1, 3, 7, 20]` — including the sub-free anchor the page said in three
+  separate places was excluded — and published **942 B/read + 406 B** on
+  Reagent and **3,550 B/read + 150 B** on UIx. Refitted over 1/3/7/20 alone the
+  same data gives about 943 + 397 and 3,552 + 118, which is how the audit
+  proved the anchor had been used. This re-run measures **943 + 397** and
+  **3,552 + 113** from fresh arms.
+- **The intercept moved most, and it is the figure the anchor most distorted.**
+  On UIx it drops from 150 B to 113 B — a 25% change in a term the page uses to
+  argue that 251 B was "the intercept". The argument survives; the number in it
+  did not.
+- **"The first read costs 3,550 B" is withdrawn as a phrasing.** That is the
+  marginal slope. The first read costs **3,600 B** on UIx and **1,137 B** on
+  Reagent, and on Reagent the difference from the slope is 21%.
+- **The direct rung data stands.** Every A-reader rung on both substrates
+  re-measures within 0.5% of its superseded value, the r² values are unchanged
+  in kind, both curves still agree to better than 2%, and the 3.77× ratio is
+  unchanged to three significant figures. **The finding this page exists for —
+  that 516 and 251 were the slope-fraction and the intercept of one line — is
+  not affected by the correction, and neither is anything the programme has
+  been asked to act on.**
+- **Reader C could fail silently.** A snapshot failure was caught and the run
+  still exited 0, so "reader C agrees" was a claim the instrument could not have
+  refused. It exits 4 now.
+- **§3's R=0 and R=20 object columns were not floor-subtracted** while the rest
+  of the table was. Corrected above; the per-read figures were never affected.
 
 ---
 

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -8,9 +8,10 @@ regression included the R=0 anchor the page promised it excluded. Every figure
 below is a fresh reading through the corrected fit; the superseded publication
 is recorded in [§7](#7-superseded) rather than deleted.
 
-Measured at commit **`c0f9121daf914f0009fd5d1e47da9b465d3bd1f6`**. A SHA does
-not survive a rebase — the previous publication was invalidated by exactly
-that — so the instrument is also identified by content hashes, which do:
+**The instrument is identified by content hash, not by commit SHA.** A SHA does
+not survive a rebase — the previous publication was invalidated by exactly that,
+and this one was rebased onto `main` between its run and its merge, moving every
+SHA again while the three blobs below did not move at all:
 
 | file | blob |
 |---|---|
@@ -18,10 +19,19 @@ that — so the instrument is also identified by content hashes, which do:
 | `reads_ladder.cljs` | `535ee5fd67fb0579854720ff26776c51c7007fd7` |
 | `reads_ladder_app.cljs` | `5b1770a49d4cac50248946b9e80bed726ca4f53d` |
 
-All three live under
-`implementation/freehand/test/re_frame/freehand/bench/`, and
-`git rev-parse HEAD:<path>` answers these at any commit whose tree carries the
-instrument.
+All three live under `implementation/freehand/test/re_frame/freehand/bench/`.
+Authored as `09ec4e6b3c` on `worker/bench-audit-cluster`. **If that SHA does not
+resolve, a rebase moved it and the blobs above are what to trust** — this finds
+a commit carrying them, and confirms it:
+
+```bash
+P=implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs
+git log --oneline --all -- $P
+git rev-parse <candidate>:$P    # must print eabd226bcb6fe3877d056145cae496eccd5ab62c
+```
+
+The reproduction below runs unchanged at any commit whose tree answers those
+three hashes.
 
 Reagent **2.0.1**, UIx **1.4.4**, React **19.2.0**, node **24.13.0**, headless
 **Chromium 147.0.7727.15** via Playwright. Windows 11, single developer

--- a/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
+++ b/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
@@ -10,17 +10,22 @@
 > authored-to-landed mapping for PR #7264 is `bb8fc38173=811f6cec42`,
 > `0cf86fb580=24e8822d7f`, `fa30f51128=27fa21ac4e`, `1f381947ed=86c50a5d83`.
 >
-> **Every figure below was re-measured on 2026-07-31 at
-> `e5ddd0f1c5581f92c3b11f4a18d57f4cbf770965` after the audit repairs, and
-> nothing moved** — see [§ What the audit changed](#what-the-audit-changed).
+> **Every figure below was re-measured on 2026-07-31 after the audit repairs,
+> and nothing moved** — see [§ What the audit changed](#what-the-audit-changed).
 > The repairs are refusals, not calculations, so there was nothing in them that
 > could move a number, and the confirmation run says so rather than assuming it.
 >
 > A SHA does not survive a rebase, which is how the citation above went wrong in
-> the first place. Content hashes do:
+> the first place — and this page's own repair branch was then rebased onto
+> `main` between its confirmation run and its merge, moving every SHA again
+> while the blobs did not move at all. **Content hashes are the identifier:**
 > `spine_ablation.cljs` `c553b2bd25c57d753d41df1915e1ff565b94681f`,
 > `spine_ablation_app.cljs` `a1ae49372b1b6d7d443408446ded9dd19f44ecfb`,
-> `spine_ablation_run.cjs` `6567a4a47783b8a77fdfea340aff8987743f941f`.
+> `spine_ablation_run.cjs` `6567a4a47783b8a77fdfea340aff8987743f941f`. The
+> confirmation run was authored as `fa09c5ad7a` on
+> `worker/bench-audit-cluster`; if that does not resolve,
+> `git log --oneline --all -- <path>` finds a commit carrying the blobs and
+> `git rev-parse <candidate>:<path>` confirms it.
 
 Reproduce:
 
@@ -357,9 +362,9 @@ refusal survives it. Exit 4 is the new code.
 ### The confirmation run
 
 Every repair is a refusal, so none of them can move a number — but that is an
-argument, and this page prefers a measurement. Re-run at
-`e5ddd0f1c5581f92c3b11f4a18d57f4cbf770965`, four rounds and two snapshot rounds
-per page, **exit 0 under all six new gates**:
+argument, and this page prefers a measurement. Re-run on the repaired
+instrument (blobs in the header; authored as `fa09c5ad7a`), four rounds and two
+snapshot rounds per page, **exit 0 under all six new gates**:
 
 | | published | confirmation run |
 |---|---:|---:|

--- a/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
+++ b/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
@@ -1,8 +1,26 @@
 # The UIx spine's per-read allocation, decomposed
 
 **Bead** `rf2-2rtt6.12` · **epic** `rf2-2rtt6` (EP-0038) · **Wave 0**
-**Producing commit** `0cf86fb580` · **measured** 2026-07-31 AUSEST
+**Landed instrument commit `24e8822d7f`** · **measured** 2026-07-31 AUSEST
 **Runtime for every figure on this page: headless Chromium, `:advanced`, `goog.DEBUG false`.**
+
+> This page first cited `0cf86fb580`, which is the **authored PR commit and is
+> not on `main`** — a reader could not check it out and could not run the
+> reproduction at it. The durable landed commit is `24e8822d7f`; the full
+> authored-to-landed mapping for PR #7264 is `bb8fc38173=811f6cec42`,
+> `0cf86fb580=24e8822d7f`, `fa30f51128=27fa21ac4e`, `1f381947ed=86c50a5d83`.
+>
+> **Every figure below was re-measured on 2026-07-31 at
+> `e5ddd0f1c5581f92c3b11f4a18d57f4cbf770965` after the audit repairs, and
+> nothing moved** — see [§ What the audit changed](#what-the-audit-changed).
+> The repairs are refusals, not calculations, so there was nothing in them that
+> could move a number, and the confirmation run says so rather than assuming it.
+>
+> A SHA does not survive a rebase, which is how the citation above went wrong in
+> the first place. Content hashes do:
+> `spine_ablation.cljs` `c553b2bd25c57d753d41df1915e1ff565b94681f`,
+> `spine_ablation_app.cljs` `a1ae49372b1b6d7d443408446ded9dd19f44ecfb`,
+> `spine_ablation_run.cjs` `6567a4a47783b8a77fdfea340aff8987743f941f`.
 
 Reproduce:
 
@@ -240,17 +258,27 @@ Same shape and same size as `rf2-2rtt6.5`'s, so the errors are directly comparab
 | uix | 4,699,971 B, **−0.001%** | 4,699,971 B, −0.001% | 4,700,146 B, +0.003% |
 | reagent | 4,700,796 B, +0.017% | 4,700,751 B, +0.016% | 4,700,014 B, **0.000%** |
 
-**Fidelity control.** An ablation is attributable only if the transcribed-but-
-unablated arm reproduces the shipped hook. Shipped `uix` 3,501 `[3,499–3,503]`;
-transcription `xcript` 3,489 `[3,488–3,492]` — **0.332% apart**, inside the 3%
-band the driver declares before it measures. The band is an order of magnitude
-below the 22% term being resolved, so it cannot manufacture the finding.
+**Fidelity control, on both readers.** An ablation is attributable only if the
+transcribed-but-unablated arm reproduces the shipped hook. Shipped `uix` 3,501
+`[3,499–3,503]`; transcription `xcript` 3,489 `[3,488–3,492]` — **0.332%
+apart**, inside the 3% band the driver declares before it measures. The band is
+an order of magnitude below the 22% term being resolved, so it cannot
+manufacture the finding. **The object count is checked the same way** and lands
+0.045% apart, which matters because the object count is this page's headline and
+bytes are the cross-check.
+
+Note which clause carries it: the two arms' *ranges do not overlap* — at four
+rounds these ranges are a few bytes wide — and it is the pre-declared 3% band
+that passes them. That is the clause's purpose, and it is why the band is
+declared in the driver rather than chosen afterwards.
 
 **Order guard.** `order_guard.schedule` rotates and reflects with the round; even
-rounds forward, odd rounds reversed, both reported separately. Its self-test (8
-checks) runs before the bundle is built. **Verdict: clean on both pages, no
-refusal.** Forward/reversed slopes: uix 3,501/3,501, xcript 3,489/3,490, noretain
-2,710/2,721, hooks 1,036/1,038, reagent 866/866.
+rounds forward, odd rounds reversed, both reported separately. Its self-test (**11
+checks**, including the two repairs PR #7267 landed: the k=2 ordering degeneracy,
+and refusal when samples are silently lost) runs before the bundle is built.
+**Verdict: clean on both pages, no refusal.** Forward/reversed slopes: uix
+3,501/3,501, xcript 3,489/3,490, noretain 2,710/2,721, hooks 1,036/1,038,
+reagent 866/866.
 
 **Verification.** Every mount reads the DOM back against the boundary count the arm
 should have produced: **0 unverified of 154 mounts** across both pages.
@@ -276,17 +304,85 @@ same collector design.
 
 | | this page | `rf2-2rtt6.5` ladder | agreement |
 |---|---:|---:|---|
-| UIx bytes/read | 3,501 | 3,550 | 1.4% |
-| UIx objects/read | 125.8 | 128.5 | 2.1% |
-| Reagent bytes/read | 866 | 942 | 8.1% |
-| Reagent objects/read | 31.5 | 36.2 | 13% |
+| UIx bytes/read | 3,501 | 3,552 | 1.4% |
+| UIx objects/read | 125.8 | 128.4 | 2.0% |
+| Reagent bytes/read | 866 | 943 | 8.2% |
+| Reagent objects/read | 31.5 | 35.8 | 12% |
 | UIx/Reagent ratio | 4.04× | 3.77× | |
-| UIx shell ÷ Reagent shell | 267 ÷ 586 = 0.46× | 0.49× | |
+| UIx shell ÷ Reagent shell | 266 ÷ 589 = 0.45× | 0.49× | |
 
-The UIx arms agree closely; the Reagent arms sit ~8–13% below the ladder's, which
+The ladder column is its **corrected** publication: `rf2-2rtt6.5`'s fit had
+included the sub-free R=0 anchor it promised to exclude, and refitting over
+1/3/7/20 alone moved it from 3,550/942 to 3,552/943 and its object counts from
+128.5/36.2 to 128.4/35.8. Every agreement above holds to within 0.1 percentage
+point of what it was, which is the useful thing to know: **this page never
+depended on the defect in that one.**
+
+The UIx arms agree closely; the Reagent arms sit ~8–12% below the ladder's, which
 is the rung set — dropping R=20 removes the point with the most leverage from a
 line whose r² is 0.997 rather than 0.9999. The ratio is quoted here from
 same-run arms, which is the comparison that carries.
+
+---
+
+## What the audit changed
+
+The audit of PR #7264 found that **an exit-0 rerun of this instrument was not
+self-validating**. The decomposition it published was internally coherent and
+the range-diff of the landed patches was exact; what was wrong was that nothing
+above could have stopped a run from printing.
+
+Five checks were fail-open, and all five are gates now:
+
+| claim | before | now |
+|---|---|---|
+| the witness counts match the N/N/2N and 0/0/N predictions | printed beside the prediction, never compared | compared per offset per counter; a mismatch fails |
+| the ablation is fidelitous | reader-A **bytes** only, and failed nothing | **bytes and the headline object count**; a failure fails the run |
+| reader C answered | a snapshot failure was caught and stepped over | absent or incomplete reader C fails |
+| the positive control hit its 8N prediction | recorded, adjudicated by nobody | must land within **1%**, declared in the driver |
+| the rungs carry a line | r² recorded, adjudicated by nobody | **r² ≥ 0.99** on bytes and on objects |
+
+A sixth was in the page rather than the driver: `release!*` caught every
+unmount exception, removed the container and reported success. The container is
+the DOM half; the half that matters is the committed subscription, its watch on
+the frame and its cache entry, and an unmount that threw part-way can leave all
+three live — after which later arms are no longer the fresh-cache-miss arms this
+page prices, while DOM verification and the process verdict both still pass.
+Cleanup stays best-effort so one bad arm cannot wedge a run; the error is now
+recorded and fails it.
+
+The report is still written to disk before any refusal, so the evidence for a
+refusal survives it. Exit 4 is the new code.
+
+### The confirmation run
+
+Every repair is a refusal, so none of them can move a number — but that is an
+argument, and this page prefers a measurement. Re-run at
+`e5ddd0f1c5581f92c3b11f4a18d57f4cbf770965`, four rounds and two snapshot rounds
+per page, **exit 0 under all six new gates**:
+
+| | published | confirmation run |
+|---|---:|---:|
+| retained render-phase reaction | 769 B `[765–793]` / 23.0 obj | 768 B `[764–770]` / 23.0 obj |
+| one live subscription | 1,684 B `[1,660–1,687]` / 56.7 obj | 1,685 B `[1,683–1,689]` / 56.7 obj |
+| React's six-hook stack | 1,037 B `[1,035–1,039]` / 46.1 obj | 1,037 B `[1,034–1,038]` / 46.1 obj |
+| measured whole (`xcript`) | 3,489 B / 125.8 obj | 3,489 B / 125.8 obj |
+| Reagent, same run | 866 B / 31.5 obj | 866 B / 31.5 obj |
+| the defect's share | 22.0% | 22.0% |
+
+**No object count moved at all, and no byte figure by more than 0.1%.** The
+witness came back exact for the second time — `commits` 1.00N, `rebuilt` 1.00N,
+`bodyRuns` 2.00N on UIx against 0, 0 and 1.00N on Reagent, twice over disjoint
+cells — which is now checked rather than admired. 0 unverified of 154 mounts,
+order guard clean on both pages, controls at −0.003%/+0.003% (uix, readers A/C)
+and +0.017%/0.000% (reagent).
+
+The r² floor is worth one note. Reagent's fits sit at 0.9973 (bytes) and 0.9961
+(objects), so a floor set at the UIx arms' 0.9999 would have refused a run that
+is fine — the Reagent arm is less linear because its R=0 shell is twice UIx's,
+which §*Cross-checks* already explains. 0.99 is the floor below which a slope is
+not a slope, and it was chosen against that reasoning rather than against these
+observations.
 
 ---
 

--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow.cljs
@@ -85,8 +85,16 @@
   never reached the page. So the written cell is read back out of the
   DOM after `t3` — inside the write's own window, not once at the end —
   and the count of failures is published beside every figure as
-  \"N unverified of M\". A sample with any unverified write is still
-  reported; it is the count that is the evidence.
+  \"N unverified of M\".
+
+  **M COUNTS ONLY WRITES THAT COULD HAVE BEEN VERIFIED.** `:instrument`
+  renders no cell and forces `ok` true, so its windows are not evidence of
+  anything having reached a page; folding them into the denominator
+  inflated it from 3,600 to 4,320 and made the headline claim \"every write
+  read out of the DOM\" true of 83% of the writes it named. Skip-verify
+  arms are excluded from the tally and reported on their own line, and a
+  nonzero count on a REAL arm now fails the run rather than being printed
+  beside a `reportable` verdict.
 
   ## Chrome clamps `performance.now()` to 100 microseconds
 
@@ -278,17 +286,21 @@
 ;; frame-provider's React context, and a render-time `subscribe` that
 ;; cannot resolve a frame raises `:rf.error/no-frame-context` (Spec 002
 ;; §Reading the frame from React context).
-(reg-view spine-cell [i]
-  [:span.cell {:data-i i} (str @(rf/subscribe [:hn/cell i]))])
+;; `sub?` is what makes the ladder a SUBSCRIPTION-count ladder rather than a
+;; fixture-size one. A cell renders the same span at the same `data-i` either
+;; way; only the `subscribe` is conditional. See [[ladder-cells]].
+(reg-view spine-cell [i sub?]
+  [:span.cell {:data-i i}
+   (if sub? (str @(rf/subscribe [:hn/cell i])) "-")])
 
-(reg-view spine-grid [n]
+(reg-view spine-grid [n-cells n-subs]
   [:div.ugrid
-   (for [i (range n)]
-     ^{:key i} [spine-cell i])])
+   (for [i (range n-cells)]
+     ^{:key i} [spine-cell i (< i n-subs)])])
 
 (def ladder-cells
-  "The SUBSCRIPTION-COUNT ladder — three rungs, and three rather than two
-  is a repair.
+  "The SUBSCRIPTION-COUNT ladder — three rungs, and every rung mounts the
+  SAME 300-cell fixture.
 
   The headline figure says the flush carries essentially all of a narrow
   write's cost on this substrate. That is one word doing two jobs: the
@@ -296,18 +308,31 @@
   commits the one cell that changed, and a single number cannot say which
   of those the money went to.
 
-  Two rungs looked like enough — the React commit is the same one-cell
-  commit at both, so the slope should be the per-subscription cost and the
-  intercept everything else. Measured, 30 and 300 gave a slope of 2.27 us
-  per subscription and an intercept of MINUS 0.048 ms. A negative
-  intercept is not a small error; it is the two points refusing the linear
-  model they were fitted to, because the flush grows FASTER than the
-  subscription count. A third rung makes that visible instead of hiding it
-  inside a number that reads like a per-unit cost.
+  THE FIRST CUT DID NOT ISOLATE THE THING IT NAMED, and the correction is
+  the reason this reads the way it does. Each rung was built by handing
+  `spine-arm` a cell count, so a rung changed the app-db vector, the
+  mounted component count, the DOM span count, the reaction count AND the
+  subscription count together. The page said \"the React commit is the same
+  one-cell commit at every rung, and only the subscription count moves\";
+  it was not, and a slope fitted through those rungs described a compound
+  FIXTURE-SIZE ladder. The negative intercept and the super-linear
+  exponent were real properties of that ladder, but they could not be
+  attributed to layer-1 subscriptions, which is exactly what the page did.
 
-  30 rather than 1 at the bottom: a one-cell grid changes the shape of
-  both the DOM and the write, and a ladder wants one shape at three
-  sizes."
+  So the rungs now hold everything constant but the subscription. Every
+  rung seeds 300 cells into app-db, mounts 300 `spine-cell` occurrences and
+  renders 300 spans; the rung's number is how many of those cells actually
+  `subscribe`, and the rest render an inert dash. Writes target the
+  SUBSCRIBING range, so the React commit is one cell at every rung by
+  construction rather than by assertion.
+
+  Three rungs rather than two is the earlier repair, kept: two points
+  cannot show a line refusing the model it was fitted to, and 30/300 fitted
+  2.27 us per subscription on an intercept of MINUS 0.048 ms. Work that
+  does not scale with the count cannot cost less than nothing.
+
+  30 rather than 1 at the bottom: one subscription in a 300-cell page is a
+  degenerate graph, and a ladder wants one shape at three sizes."
   [30 100 300])
 
 ;; ---------------------------------------------------------------------------
@@ -354,14 +379,14 @@
   clock reads, one promise, one accumulate. Its read-back is skipped
   because it renders no cell to read back."
   []
-  {:id :instrument :skip-verify? true :cells cells-n
+  {:id :instrument :skip-verify? true :cells cells-n :subs cells-n
    :mount   (fn [container] container)
    :write!  (fn [_ _] nil)
    :force!  (fn [] nil)
    :unmount (fn [_] nil)})
 
 (defn- bare-ratom-arm []
-  {:id :bare-ratom :cells cells-n
+  {:id :bare-ratom :cells cells-n :subs cells-n
    :mount   (fn [container]
               (reset! bare-cells (vec (repeat cells-n 0)))
               (let [root (rdc/create-root container)]
@@ -379,19 +404,30 @@
   donor row's door — the frame write and the signal graph, with no event
   drain) or `:dispatch-sync` (the door an application uses).
 
+  `n-subs` is HOW MANY CELLS SUBSCRIBE, not how big the fixture is. Every
+  arm seeds `cells-n` cells into app-db, mounts `cells-n` `spine-cell`
+  occurrences and renders `cells-n` spans; only the first `n-subs` of them
+  hold a subscription. That is what makes the ladder in [[ladder-cells]] a
+  subscription ladder — the audit's first correction, and the reason
+  `n-subs` is the ONLY thing a rung is allowed to move.
+
+  Writes target `[0, n-subs)` so a narrow write always lands on a
+  SUBSCRIBING cell, which keeps the React commit one cell at every rung by
+  construction.
+
   Each arm owns its OWN frame: frames are isolated contexts and two arms
   sharing one would let each other's writes into the other's graph."
   ([id frame-id write-door] (spine-arm id frame-id write-door cells-n))
-  ([id frame-id write-door n]
-   {:id id :cells n
+  ([id frame-id write-door n-subs]
+   {:id id :cells cells-n :subs n-subs
     :mount
     (fn [container]
       (rf/make-frame {:id frame-id})
-      (rf/with-frame frame-id (rf/dispatch-sync [:hn/seed n]))
+      (rf/with-frame frame-id (rf/dispatch-sync [:hn/seed cells-n]))
       (let [root (rdc/create-root container)]
         (react-dom/flushSync
           (fn [] (rdc/render root [rf/frame-provider {:frame frame-id}
-                                   [spine-grid n]])))
+                                   [spine-grid cells-n n-subs]])))
         root))
     :write!
     (fn [i val]
@@ -401,13 +437,13 @@
           (frame/replace-app-db!
             frame-id
             (if (= i :all)
-              (assoc db :cells (vec (repeat n val)))
+              (assoc db :cells (vec (repeat cells-n val)))
               (update db :cells assoc i val))))
 
         :dispatch-sync
         (rf/with-frame frame-id
           (if (= i :all)
-            (rf/dispatch-sync [:hn/set-all n val])
+            (rf/dispatch-sync [:hn/set-all cells-n val])
             (rf/dispatch-sync [:hn/set-cell i val])))))
     :force!  flush-reagent!
     :unmount (fn [root] (react-dom/flushSync (fn [] (rdc/unmount root))))}))
@@ -437,9 +473,11 @@
          (bare-ratom-arm)
          (spine-arm :spine-replace  :hn/spine-replace  :replace-app-db)
          (spine-arm :spine-dispatch :hn/spine-dispatch :dispatch-sync)]
-        ;; The ladder's rungs BELOW the headline count. The 300-cell rung
-        ;; is `:spine-replace` itself — measuring it twice would price the
-        ;; same arm under two names and invite the two copies to disagree.
+        ;; The ladder's rungs BELOW the headline count. The 300-subscription
+        ;; rung is `:spine-replace` itself — measuring it twice would price
+        ;; the same arm under two names and invite the two copies to
+        ;; disagree. `n` here is a SUBSCRIPTION count; every rung mounts the
+        ;; full `cells-n` fixture.
         (map (fn [n]
                (spine-arm (keyword (str "spine-" n))
                           (keyword "hn" (str "spine-" n))
@@ -527,7 +565,10 @@
   write verified at the DOM in its own window."
   [mnt n]
   (let [acc   (fresh-acc)
-        width (or (:cells (:arm mnt)) cells-n)]
+        ;; The SUBSCRIBING range, not the fixture: a ladder rung mounts 300
+        ;; cells of which `:subs` subscribe, and a write outside that range
+        ;; would commit nothing and verify nothing.
+        width (or (:subs (:arm mnt)) cells-n)]
     (chain acc (range n)
       (fn [a _]
         (let [val (next-gen!)

--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_app.cljs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_app.cljs
@@ -119,6 +119,17 @@
           ;; `cellsN` — the top rung is `:spine-replace` itself rather than
           ;; a fourth mounted copy of it.
           "ladder"        (clj->js hn/ladder-cells)
+          ;; Arms whose windows render no cell, so a DOM read-back on them
+          ;; would be verifying nothing. The driver excludes these from the
+          ;; "N unverified of M" denominator rather than counting a forced
+          ;; `ok` as a verified write.
+          "skipVerify"    (clj->js (into [] (comp (filter :skip-verify?)
+                                                  (map #(name (:id %))))
+                                         arms))
+          ;; How many of each arm's `cellsN` cells actually subscribe. The
+          ;; ladder is fitted through THIS, and the driver prints it so the
+          ;; isolation claim is checkable rather than asserted.
+          "subs"          (clj->js (into {} (map (fn [a] [(name (:id a)) (:subs a)])) arms))
           ;; Run before any measurement: proves this bundle reads the keys
           ;; it writes, under the renaming it was actually compiled with.
           "integrity"     (fn [] (hn/integrity-probe))

--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
@@ -48,7 +48,19 @@
 //      consequence that an arm's total must NOT move when the control's
 //      size does;
 //   6. the read-back gate's non-vacuity control: the same arm with an
-//      EMPTY `flushSync` for its drain, which must go red.
+//      EMPTY `flushSync` for its drain, which must go red;
+//   7. the ladder-isolation gate: every rung mounts the same fixture, so a
+//      rung moves the SUBSCRIPTION count and nothing else.
+//
+// AND THE GATES THAT NOW FAIL THE RUN RATHER THAN DECORATING IT
+// -------------------------------------------------------------
+// The audit of PR #7262 found the three central checks fail-OPEN: a stale
+// write on a real arm was printed and stored, a broken leg identity was
+// printed and stepped over, and the verification denominator counted 720
+// windows of a pseudo-arm that renders no cell and forces `ok` true. So a
+// run could print `VERDICT: reportable` beside a column saying some of its
+// writes never reached the page. All three are exits now, and the
+// denominator counts only arms that could have been verified.
 //
 // EXIT CODES
 //   0  reportable
@@ -312,6 +324,8 @@ async function main() {
   const arms = await page.evaluate(() => window.HN.arms);
   const cellsN = await page.evaluate(() => window.HN.cellsN);
   const ladder = await page.evaluate(() => window.HN.ladder);
+  const skipVerify = await page.evaluate(() => window.HN.skipVerify);
+  const subsOf = await page.evaluate(() => window.HN.subs);
   if (ladder[ladder.length - 1] !== cellsN) {
     throw new Error(
       `the ladder's top rung (${ladder[ladder.length - 1]}) is not the headline cell count ` +
@@ -319,6 +333,35 @@ async function main() {
     );
   }
   console.error(`[hn] arms: ${arms.join(', ')}  (${cellsN} cells, ${WRITES} writes/sample)`);
+  console.error(
+    `[hn] skip-verify arms (excluded from the read-back denominator): ` +
+      `${skipVerify.length ? skipVerify.join(', ') : 'none'}`
+  );
+
+  // --- gate 3b: the ladder isolates SUBSCRIPTIONS, not fixture size -------
+  // The audit's first correction. Every rung must mount the same cell count
+  // so a rung moves the subscription count and nothing else; a rung that
+  // also moved the app-db vector, the component count and the DOM span
+  // count would be a fixture-size ladder wearing a subscription ladder's
+  // label, which is exactly what the first cut published.
+  const rungArmName = (n) => (n === cellsN ? 'spine-replace' : `spine-${n}`);
+  {
+    const wrong = [];
+    for (const n of ladder) {
+      const a = rungArmName(n);
+      if (subsOf[a] !== n) wrong.push(`${a} subscribes ${subsOf[a]}, expected ${n}`);
+    }
+    if (wrong.length) {
+      throw new Error(
+        `the subscription ladder is mis-wired — ${wrong.join('; ')}. ` +
+          `The ladder may not be fitted until each rung's subscription count is its own.`
+      );
+    }
+    console.error(
+      `[hn] gate 3b ok — every ladder rung mounts ${cellsN} cells and ${cellsN} components; ` +
+        `only the subscription count moves (${ladder.join('/')})`
+    );
+  }
 
   // --- gate 4: the read-back gate's non-vacuity control -------------------
   // The same arm with an EMPTY `flushSync` for its drain. An empty flush
@@ -430,6 +473,10 @@ async function main() {
   say('=========================================================================');
   say(`runtime          ${RUNTIME}`);
   say(`fixture          ${cellsN} cells, one layer-1 subscription per cell`);
+  say(
+    `ladder fixture   every rung mounts ${cellsN} cells / ${cellsN} components / ${cellsN} spans; ` +
+      `only ${ladder.join('/')} of them SUBSCRIBE`
+  );
   say(`sample           ${WRITES} narrow writes; per-write = sample / ${WRITES}`);
   say(`plan             ${ROUNDS} rounds x (${IN_ROUND_WARMUP} in-round warmup + ${SAMPLES} samples), arms interleaved`);
   say(`clock quantum    ${num(quantum, 5)} ms (measured in-page)`);
@@ -513,18 +560,27 @@ async function main() {
   // question — the withdrawn predecessor's narrow row was wrong precisely
   // because a framework cost was read as a rendering cost.
   //
-  // Two cell counts separate them by construction. The React commit is the
-  // SAME one-cell commit at both rungs; only the number of layer-1
-  // subscriptions moves. So the slope is the per-subscription recompute and
-  // the intercept is everything else, and neither is inferred from a
-  // sentence.
-  const rungArm = (n) => (n === cellsN ? 'spine-replace' : `spine-${n}`);
+  // The rungs separate them by construction — and "by construction" is now
+  // literal. Every rung mounts the SAME 300-cell fixture: 300 cells in
+  // app-db, 300 mounted components, 300 DOM spans. The rung's number is how
+  // many of those cells hold a subscription, and writes land inside that
+  // range, so the React commit is one cell at every rung. The slope is
+  // therefore the per-subscription recompute and the intercept is
+  // everything else.
+  //
+  // The first cut did NOT do this: a rung was a whole smaller fixture, and
+  // the slope described fixture size. Gate 3b above is what stops that
+  // coming back.
   const rungs = ladder
-    .map((n) => ({ n, arm: rungArm(n), split: split[rungArm(n)] }))
+    .map((n) => ({ n, arm: rungArmName(n), split: split[rungArmName(n)] }))
     .filter((r) => r.split);
   let flushComposition = null;
   if (rungs.length >= 2) {
     say('WHERE THE FLUSH GOES — the subscription-count ladder');
+    say('');
+    say(`  Every rung mounts ${cellsN} cells, ${cellsN} components and ${cellsN} DOM spans. Only the`);
+    say('  number of them that SUBSCRIBE moves, and writes land on a subscribing cell, so the');
+    say('  React commit is the same one-cell commit at every rung.');
     say('');
     say('  subscriptions   flush ms/write   per subscription   local slope vs the rung below');
     for (let i = 0; i < rungs.length; i++) {
@@ -643,18 +699,34 @@ async function main() {
   // --- DOM verification ---------------------------------------------------
   say('DOM READ-BACK — every measured write read out of the page inside its own window');
   say('');
+  // THE DENOMINATOR COUNTS ONLY WRITES THAT COULD HAVE BEEN VERIFIED.
+  // `:instrument` renders no cell and forces `ok` true; folding its windows
+  // in inflated the published denominator from 3,600 to 4,320 and let the
+  // claim "every write read out of the DOM" stand over 720 writes that were
+  // never looked at. Skipped arms get their own line and no credit.
   let badTotal = 0;
   let writeTotal = 0;
+  let skippedTotal = 0;
+  const badByArm = {};
   for (const arm of arms) {
     const rows = byArm(pass1, arm);
     const bad = rows.reduce((a, s) => a + s.bad, 0);
     const n = rows.length * WRITES;
+    badByArm[arm] = bad;
+    if (skipVerify.includes(arm)) {
+      skippedTotal += n;
+      say(`  ${arm.padEnd(17)} ${n} writes NOT VERIFIABLE (renders no cell) — excluded from the tally`);
+      continue;
+    }
     badTotal += bad;
     writeTotal += n;
-    const note = arm === 'instrument' ? '  (pseudo-arm: renders no cell, verification skipped)' : '';
-    say(`  ${arm.padEnd(17)} ${bad} unverified of ${n}${note}`);
+    say(`  ${arm.padEnd(17)} ${bad} unverified of ${n}`);
   }
-  say(`  ${'ALL ARMS'.padEnd(17)} ${badTotal} unverified of ${writeTotal}`);
+  say(`  ${'VERIFIABLE ARMS'.padEnd(17)} ${badTotal} unverified of ${writeTotal}`);
+  say(
+    `  ${'(excluded)'.padEnd(17)} ${skippedTotal} writes on ${skipVerify.join(', ') || 'no arm'} — ` +
+      `a forced ok is not a verified write`
+  );
   say(
     `  negative control  ${neg.bad} unverified of ${neg.writes} — an EMPTY flushSync, which MUST go red`
   );
@@ -760,7 +832,8 @@ async function main() {
     headline,
     split,
     samples: { rung1: pass1, rung2: pass2 },
-    unverified: { bad: badTotal, of: writeTotal },
+    unverified: { bad: badTotal, of: writeTotal, skipped: skippedTotal, byArm: badByArm },
+    legIdentity: identityOk,
     guard: { refuse: report.refuse, contaminated: report.contaminated, unchecked: report.unchecked },
     edn: report.edn,
   };
@@ -791,6 +864,31 @@ async function main() {
   }
   if (leaked) {
     say('VERDICT: FAILED — an arm\'s total moved with the control size. The leg accounting leaks.');
+    process.exitCode = 1;
+    return;
+  }
+  // A stale write on a REAL arm was printed and stored and nothing else: a
+  // run could report `VERDICT: reportable` beside a column saying some of
+  // its writes never reached the page. The read-back gate is the reason the
+  // figures above are about a page rather than about a clock, so it fails
+  // the run.
+  if (badTotal > 0) {
+    const offenders = arms
+      .filter((a) => !skipVerify.includes(a) && badByArm[a] > 0)
+      .map((a) => `${a}:${badByArm[a]}`)
+      .join(' ');
+    say(`VERDICT: FAILED — ${badTotal} of ${writeTotal} measured writes never reached the DOM`);
+    say(`         (${offenders}). A window that did not commit is not a measurement of one.`);
+    process.exitCode = 1;
+    return;
+  }
+  // The three legs are read off the SAME four clock samples the total is, so
+  // they must sum to it exactly. A discrepancy means the accumulator is
+  // mis-wired, and the write-versus-flush SPLIT — the figure this bead
+  // exists to publish — is taken straight from those legs.
+  if (!identityOk) {
+    say('VERDICT: FAILED — write + gap + force does not equal the published total on every arm.');
+    say('         The leg accounting is mis-wired and the write/flush split cannot be quoted.');
     process.exitCode = 1;
     return;
   }

--- a/implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs
@@ -68,6 +68,27 @@
 // there to show the figure does not move, not to average. `verdict` refuses
 // on a contaminated OR an unchecked arm and this driver EXITS 2 on refusal.
 // Repair the arm, not the guard.
+//
+// ## What the audit of PR #7260 corrected
+//
+//   1. THE FIT USED THE ANCHOR. `R=0` is a boundary that reads nothing; the
+//      bead, this header and the studio page all called it "an anchor, not
+//      evidence" and promised no reactive figure was derived from it — and
+//      `curves()` then fitted `[0, 1, 3, 7, 20]`. The fit is now over the
+//      mandated 1/3/7/20 alone. R=0 is reported directly beside it and never
+//      enters a regression, and the FITTED MARGINAL SLOPE is distinguished
+//      from the FIRST-READ INCREMENT `y(R=1) − y(R=0)`, which is the figure
+//      a reader means by "what the first read costs".
+//   2. READER C FAILED OPEN. A snapshot failure was caught into
+//      `{error: ...}` and the run still exited 0, so a reproduction could
+//      degrade to the two CORRELATED readers and print a table anyway.
+//
+// EXIT CODES
+//   0  reportable
+//   1  a gate failed, or the run could not complete
+//   2  THE ARM-ORDER GUARD REFUSED. Repair the arm, never the tolerance.
+//   3  a mount did not verify at the DOM
+//   4  reader C was requested and is incomplete — see (2) above
 
 'use strict';
 
@@ -374,6 +395,7 @@ async function runSubstrate(chromium, substrate) {
   // that reaches ~12 MB above baseline at the 20-read rung) and its job is
   // to falsify the HEADLINE curve, which is the one that prices a read.
   let snapshots = null;
+  let snapshotFailure = null;
   if (WANT_SNAPSHOT) {
     snapshots = {};
     const want = arms.filter((a) => a.curve === 'b' || a.boundaries === plan.curveB.boundaries);
@@ -410,6 +432,30 @@ async function runSubstrate(chromium, substrate) {
     } catch (e) {
       snapshots = { error: String(e && e.message ? e.message : e) };
     }
+
+    // FAIL CLOSED WHEN READER C WAS ASKED FOR AND DID NOT ARRIVE.
+    //
+    // A and B are two doors onto one V8 counter. C is the reader that walks
+    // the object graph, and it is the whole reason this table is falsifiable
+    // rather than self-reported — the object-count conclusion (128.5 UIx
+    // objects per read against 36.2 Reagent) exists nowhere else. The first
+    // cut caught any snapshot failure into `{error: ...}` and the run went on
+    // to exit 0, so a reproduction could silently degrade to the two
+    // CORRELATED readers and still print a table.
+    //
+    // The error is recorded rather than thrown, so the A/B evidence and the
+    // control still reach the artefact — and then the run refuses.
+    const missing = [];
+    if (snapshots.error) {
+      missing.push(`snapshot pass failed: ${snapshots.error}`);
+    } else {
+      if (!snapshots.control) missing.push('reader-C positive control absent');
+      for (const a of want) if (!snapshots[a.id]) missing.push(`reader-C rung ${a.id} absent`);
+    }
+    if (missing.length) {
+      snapshotFailure = missing;
+      for (const m of missing) console.error(`[ladder] ${substrate}: READER C — ${m}`);
+    }
   }
 
   await browser.close();
@@ -421,6 +467,7 @@ async function runSubstrate(chromium, substrate) {
     perRound: rounds,
     orderVerdict: guard.verdict(orderSamples, { tolerance: TOLERANCE }),
     snapshots,
+    snapshotFailure,
     curves: curves(arms, rounds),
   };
 }
@@ -448,11 +495,29 @@ function fit(points) {
   return { slope, intercept, r2: tot === 0 ? 1 : 1 - ss / tot, points };
 }
 
+// THE REACTIVE RUNGS, and the one that is not one.
+//
+// `R=0` is a boundary that reads NOTHING. The bead, this instrument's
+// docstring and the studio page all say the same thing about it — "anchor,
+// not evidence", "no reactive figure is derived from it" — and the first cut
+// then fitted `[0, 1, 3, 7, 20]`, which derived every reactive figure from
+// it. The audit of PR #7260 caught it arithmetically: refitting the
+// published medians over 1/3/7/20 alone gives 943 B/read + 397 B on Reagent
+// and 3,552 B/read + 118 B on UIx, against the shipped 942/406 and
+// 3,550/150. The differences are small and that is not the point — the
+// figures were reached by a route the page promised it had not taken.
+//
+// So the fit is over the MANDATED rungs only. R=0 is carried, reported and
+// compared, and never enters a regression.
+const REACTIVE = (p) => p.x > 0;
+
 function curves(arms, rounds) {
   const subst = arms.find((a) => a.kind !== 'floor').kind;
   const curveB = [];
   const curveA = [];
   const perRung = {};   // arm id -> [excess-bytes-per-boundary per round]
+  const anchorPerRound = [];      // R=0, measured directly, never fitted
+  const firstReadPerRound = [];   // y(R=1) - y(R=0), an INCREMENT, not a slope
   const orders = { forward: { b: [], a: [] }, reversed: { b: [], a: [] } };
 
   for (const r of rounds) {
@@ -463,15 +528,27 @@ function curves(arms, rounds) {
     // Curve B — fixed boundaries, growing reads. y is PER BOUNDARY.
     const bArms = arms.filter((a) => a.kind === subst && a.curve === 'b')
       .sort((p, q) => p.reads - q.reads);
-    const bPts = bArms.map((a) => ({ x: a.reads, y: excess(a) / a.boundaries, arm: a.id }));
+    const bPtsAll = bArms.map((a) => ({ x: a.reads, y: excess(a) / a.boundaries, arm: a.id }));
+    const bPts = bPtsAll.filter(REACTIVE);
+    const anchorPt = bPtsAll.find((p) => p.x === 0) || null;
+    const firstPt = bPtsAll.find((p) => p.x === 1) || null;
     // Curve A — fixed reads, growing boundaries. y is TOTAL excess.
     const aArms = arms.filter((a) => a.kind === subst && (a.curve === 'a' || a.reads === 3))
       .sort((p, q) => p.boundaries - q.boundaries);
     const aPts = aArms.map((a) => ({ x: a.boundaries, y: excess(a), arm: a.id }));
 
-    for (const p of bPts) {
+    // Every rung is REPORTED, including the anchor — it is the comparison
+    // with the published sub-free rows that lets a reader decide whether to
+    // believe this instrument at all. Only the fit excludes it.
+    for (const p of bPtsAll) {
       (perRung[p.arm] = perRung[p.arm] || []).push(p.y);
     }
+    if (anchorPt) anchorPerRound.push(anchorPt.y);
+    // THE FIRST-READ INCREMENT is not the fitted marginal slope, and calling
+    // the slope "the first read" was the other half of the same confusion.
+    // The first read buys the subscription AND whatever the shell has to
+    // grow to hold one; the marginal slope prices the second read onward.
+    if (anchorPt && firstPt) firstReadPerRound.push(firstPt.y - anchorPt.y);
     const bFit = fit(bPts);
     const aFit = fit(aPts);
     curveB.push({ round: r.round, order: r.order, ...bFit });
@@ -483,11 +560,18 @@ function curves(arms, rounds) {
   const sum = (fits, key) => rangeOf(fits.map((f) => f[key]));
   return {
     curveB: {
-      what: 'fixed boundaries x growing reads — SLOPE is bytes per READ, INTERCEPT is bytes per BOUNDARY',
+      what: 'fixed boundaries x growing READS over 1/3/7/20 ONLY — SLOPE is bytes per READ, ' +
+            'INTERCEPT is the FITTED per-boundary shell. R=0 is an anchor and is excluded from the fit.',
+      fittedRungs: (curveB[0] ? curveB[0].points.map((p) => p.x) : []),
       perRound: curveB,
       bytesPerRead: sum(curveB, 'slope'),
       bytesPerBoundaryIntercept: sum(curveB, 'intercept'),
       r2: sum(curveB, 'r2'),
+      // Measured directly at R=0. NOT part of any regression above.
+      anchorMeasured: anchorPerRound.length ? rangeOf(anchorPerRound) : null,
+      // y(R=1) - y(R=0). An increment between two measured rungs, and the
+      // figure a reader means by "what does the first read cost".
+      firstReadIncrement: firstReadPerRound.length ? rangeOf(firstReadPerRound) : null,
       forward: { bytesPerRead: sum(orders.forward.b, 'slope'), intercept: sum(orders.forward.b, 'intercept') },
       reversed: { bytesPerRead: sum(orders.reversed.b, 'slope'), intercept: sum(orders.reversed.b, 'intercept') },
       rungs: Object.fromEntries(Object.entries(perRung).map(([k, v]) => [k, rangeOf(v)])),
@@ -532,17 +616,29 @@ function report(all) {
       L.push(`;;   reader C  measured ${b(s.snapshots.control.measured)} B  error ${pct(s.snapshots.control.error)}`);
     }
     L.push('');
-    L.push(';;   CURVE B — fixed boundaries x growing reads');
+    const cb = s.curves.curveB;
+    L.push(`;;   CURVE B — fixed boundaries x growing reads; FITTED OVER R=${cb.fittedRungs.join('/')} ONLY`);
     for (const [arm, r] of Object.entries(s.curves.curveB.rungs)) {
       const reads = parseArm(arm).reads;
-      L.push(`;;     R=${String(reads).padStart(2)}  ${b(r.p50).padStart(7)} B/boundary  [${b(r.min)}-${b(r.max)}]`);
+      const tag = reads === 0 ? '   <- ANCHOR, excluded from the fit' : '';
+      L.push(`;;     R=${String(reads).padStart(2)}  ${b(r.p50).padStart(7)} B/boundary  [${b(r.min)}-${b(r.max)}]${tag}`);
     }
-    const cb = s.curves.curveB;
     L.push(`;;     => BYTES PER READ      ${b(cb.bytesPerRead.p50)}  [${b(cb.bytesPerRead.min)}-${b(cb.bytesPerRead.max)}]`);
+    L.push(`;;        the fitted MARGINAL slope over ${cb.fittedRungs.join('/')} — what one more read costs.`);
     L.push(`;;        fwd ${b(cb.forward.bytesPerRead.p50)} [${b(cb.forward.bytesPerRead.min)}-${b(cb.forward.bytesPerRead.max)}]  ` +
            `rev ${b(cb.reversed.bytesPerRead.p50)} [${b(cb.reversed.bytesPerRead.min)}-${b(cb.reversed.bytesPerRead.max)}]`);
+    if (cb.firstReadIncrement) {
+      L.push(`;;     => FIRST-READ INCREMENT ${b(cb.firstReadIncrement.p50)}  ` +
+             `[${b(cb.firstReadIncrement.min)}-${b(cb.firstReadIncrement.max)}]`);
+      L.push(`;;        y(R=1) - y(R=0), two MEASURED rungs. This is NOT the slope above, and`);
+      L.push(`;;        calling the slope "the first read" conflates them.`);
+    }
     L.push(`;;     => PER-BOUNDARY INTERCEPT ${b(cb.bytesPerBoundaryIntercept.p50)}  ` +
-           `[${b(cb.bytesPerBoundaryIntercept.min)}-${b(cb.bytesPerBoundaryIntercept.max)}]`);
+           `[${b(cb.bytesPerBoundaryIntercept.min)}-${b(cb.bytesPerBoundaryIntercept.max)}]  (FITTED, extrapolated to R=0)`);
+    if (cb.anchorMeasured) {
+      L.push(`;;     => R=0 MEASURED DIRECTLY  ${b(cb.anchorMeasured.p50)}  ` +
+             `[${b(cb.anchorMeasured.min)}-${b(cb.anchorMeasured.max)}]  (the anchor; nothing is derived from it)`);
+    }
     L.push(`;;        r2 ${cb.r2.p50.toFixed(5)} [${cb.r2.min.toFixed(5)}-${cb.r2.max.toFixed(5)}]`);
     L.push('');
     L.push(';;   CURVE A — fixed reads (3) x growing boundaries');
@@ -625,6 +721,22 @@ function report(all) {
   if (unverified > 0) {
     console.error(`[ladder] ${unverified} UNVERIFIED mounts — the DOM read-back did not match`);
     process.exit(3);
+  }
+  // Reader C was requested and did not arrive. A and B are two doors onto one
+  // V8 counter; without C the object-count conclusion has no source and the
+  // table is self-reported. The artefact above is written first, so the
+  // partial evidence survives the refusal.
+  const cFailed = all.filter((s) => s.snapshotFailure);
+  if (cFailed.length) {
+    for (const s of cFailed) {
+      for (const m of s.snapshotFailure) console.error(`[ladder] ${s.substrate}: READER C — ${m}`);
+    }
+    console.error(
+      '[ladder] READER C WAS REQUESTED AND IS INCOMPLETE — this table may not be published on the ' +
+        'two correlated readers alone. Re-run, or set LADDER_SNAPSHOT=0 and publish nothing that ' +
+        'depends on the object counts.'
+    );
+    process.exit(4);
   }
   if (refused.length) {
     for (const s of refused) {

--- a/implementation/freehand/test/re_frame/freehand/bench/spine_ablation.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/spine_ablation.cljs
@@ -567,13 +567,37 @@
 (defonce ^:private installed (atom nil))
 (defonce ^:private held (atom nil))
 
+(defonce ^:private release-errors
+  ;; A FAILED UNMOUNT IS MEASUREMENT STATE, so it may not be swallowed.
+  ;;
+  ;; This used to be `(catch :default _ nil)` followed by removing the
+  ;; container and reporting success. But the container is the DOM half; the
+  ;; half that matters here is the committed subscription, its watch on the
+  ;; frame and its cache entry, and an unmount that threw part-way can leave
+  ;; all three live. Every later arm is then measured against a page that is
+  ;; no longer the fresh-cache-miss shape this instrument claims to price —
+  ;; and because the DOM read-back and the order guard both still pass, the
+  ;; run reports a clean verdict over arms that are no longer the arms.
+  ;;
+  ;; So: cleanup stays best-effort (the container goes and the slot clears
+  ;; either way, so one bad arm cannot wedge the run), and the ERROR is
+  ;; recorded and surfaced to the driver, which fails on it.
+  (atom []))
+
 (defn- release!* []
   (when-some [{:keys [arm handle container]} @held]
-    (let [{:keys [unmount-one]} (get @installed arm)]
-      (try (unmount-one handle) (catch :default _ nil)))
-    (.remove container)
-    (reset! held nil))
+    (let [{:keys [unmount-one]} (get @installed arm)
+          err (try (unmount-one handle) nil
+                   (catch :default e (str e)))]
+      (when err (swap! release-errors conj {:arm arm :error err}))
+      (.remove container)
+      (reset! held nil)))
   nil)
+
+(defn release-errors-js
+  "Every unmount that threw, in order. Empty is the only publishable state."
+  []
+  (clj->js (mapv (fn [e] {"arm" (str (:arm e)) "error" (:error e)}) @release-errors)))
 
 (defn mount!
   "Mount `arm-id` and KEEP it. Answers `{:elements :expected :ok
@@ -771,7 +795,11 @@
   (reset! installed (arms substrate))
   (set! (.-ABL js/window)
         #js {:mount          (fn [arm] (mount! (keyword arm)))
-             :release        (fn [] (release!*) true)
+             ;; Answers the running unmount-error COUNT, not a bare `true`.
+             ;; A release that threw is measurement state; see
+             ;; [[release-errors]].
+             :release        (fn [] (release!*) (count @release-errors))
+             :releaseErrors  (fn [] (release-errors-js))
              :control        (fn [n] (control! n))
              :controlRelease (fn [] (control-release!))
              :witness        (fn [n offset] (witness! substrate n offset))

--- a/implementation/freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs
@@ -24,11 +24,33 @@
 // is only attributable if the transcribed-but-unablated arm (`xcript`)
 // reproduces the SHIPPED hook (`uix`). If it does not, the transcription
 // prices something else and every difference taken from it is void. This
-// driver computes that check, prints it first, and marks the decomposition
-// NOT ATTRIBUTABLE when the two arms' per-read ranges do not overlap. It
-// does not exit non-zero for it — a failed fidelity check is a finding
-// about the instrument, and suppressing the table would hide the evidence
-// that says so.
+// driver computes that check on BOTH readers — bytes and the headline object
+// count — prints it first, and marks the decomposition NOT ATTRIBUTABLE when
+// either pair of ranges fails. The table is still written to disk, because
+// suppressing it would hide the evidence that says the instrument is wrong;
+// but the RUN then exits 4, because a `VERDICT: 0` printed beside a void
+// decomposition is exactly the fail-open shape the audit of PR #7264 found.
+//
+// ## What else fails the run now, and why each of them was fail-open
+//
+//   * THE WITNESS was printed against its prediction and never compared with
+//     it, so the counting claim this bead exists to make could be falsified
+//     by the run's own probe while the run exited 0.
+//   * READER C was caught into `snapError` and stepped over. C is the
+//     object-COUNT reader and the object count is the headline here, so a
+//     run without it has no source for its central number.
+//   * THE POSITIVE CONTROL and the fits were recorded and adjudicated by
+//     nobody: a control out by any amount, and a "line" with any r2, both
+//     passed.
+//   * A FAILED UNMOUNT was swallowed by the page and reported as success,
+//     which converts a live subscription into measurement state.
+//
+// EXIT CODES
+//   0  reportable
+//   1  a gate failed before measurement, or the run could not complete
+//   2  THE ARM-ORDER GUARD REFUSED. Repair the arm, never the tolerance.
+//   3  a mount did not verify at the DOM
+//   4  a claim this table is published on did not hold — see the list above
 //
 // ## Readers
 //
@@ -108,6 +130,26 @@ const FIDELITY_BAND = Number(process.env.ABL_FIDELITY_BAND || 0.03);
 // percent between rounds, so this sits above that and far below the 2.01x
 // the recorded fault made.
 const TOLERANCE = Number(process.env.ABL_TOLERANCE || 0.25);
+// THE PUBLISHABILITY BANDS, declared here and therefore BEFORE the run.
+//
+// The audit of PR #7264 found the central checks fail-open: the witness
+// counts were printed but never compared with the prediction, fidelity was
+// computed for reader-A bytes only and failed nothing, a reader-C failure was
+// caught and stepped over, and neither a bad control nor a curve that is not a
+// line could stop the run. So `exit 0` could be reached with the counting
+// claim falsified, the ablation non-fidelitous, or reader C absent.
+//
+// `CONTROL_BAND` — the in-situ 8N control must land within 1% of prediction on
+// every reader. The ladder's worst reading on this box was 0.13%, so 1% is
+// loose enough not to fire on drift and tight enough to catch a control that
+// is not measuring what it says: B7's fictional control was out by orders of
+// magnitude, not percent.
+//
+// `R2_FLOOR` — a per-read cost is only a per-read cost if the rungs carry a
+// line. Every fit this instrument has ever published sits above 0.999; 0.99 is
+// the floor below which the slope is not a slope.
+const CONTROL_BAND = Number(process.env.ABL_CONTROL_BAND || 0.01);
+const R2_FLOOR = Number(process.env.ABL_R2_FLOOR || 0.99);
 const INIT_FN = 're-frame.freehand.bench.spine-ablation-app/-main';
 
 // ---------------------------------------------------------------------------
@@ -313,6 +355,35 @@ async function runSubstrate(chromium, substrate) {
     if (!w.ok) { unverifiedWitness++; console.error(`[abl] UNVERIFIED witness ${substrate} offset ${offset}: ${w.elements}/${w.expected}`); }
   }
 
+  // THE PREDICTION, CHECKED. The counts above were printed against the
+  // prediction and never compared with it, so the central claim of this bead
+  // — that a UIx read with no live cache entry builds TWO reactions and keeps
+  // the first — could be falsified by the run's own witness while the run
+  // exited 0. `EXPECTED_WITNESS` is the prediction from the driver header,
+  // stated as multiples of N.
+  const EXPECTED_WITNESS = {
+    uix: { commits: 1, rebuilt: 1, bodyRuns: 2 },
+    reagent: { commits: 0, rebuilt: 0, bodyRuns: 1 },
+  };
+  const witnessFailures = [];
+  const expect = EXPECTED_WITNESS[substrate];
+  if (!expect) {
+    witnessFailures.push(`no witness prediction is recorded for substrate '${substrate}'`);
+  } else {
+    for (const w of witness) {
+      for (const k of ['commits', 'rebuilt', 'bodyRuns']) {
+        const want = expect[k] * w.reads;
+        if (w[k] !== want) {
+          witnessFailures.push(
+            `${substrate} offset ${w.offset}: ${k} = ${w[k]}, predicted ${expect[k]}N = ${want} ` +
+              `for N = ${w.reads} reads`
+          );
+        }
+      }
+    }
+  }
+  for (const f of witnessFailures) console.error(`[abl] WITNESS MISMATCH — ${f}`);
+
   const rounds = [];
   const orderSamples = [];
   let position = 0;
@@ -447,18 +518,77 @@ async function runSubstrate(chromium, substrate) {
     }
   }
 
+  // --- what the page says about its own teardown -------------------------
+  // A swallowed unmount leaves the committed subscription, its watch and its
+  // cache entry live, so every later arm stops being a fresh-cache-miss arm
+  // while the DOM read-back and the guard both still pass.
+  const releaseErrors = await page.evaluate(() => window.ABL.releaseErrors());
+  for (const e of releaseErrors) console.error(`[abl] UNMOUNT FAILED on ${e.arm}: ${e.error}`);
+
   await browser.close();
+
+  // --- the gates that decide whether this table may be published ---------
+  const gateFailures = [...witnessFailures];
+  for (const e of releaseErrors) gateFailures.push(`unmount failed on ${e.arm}: ${e.error}`);
+
+  // Reader C is the object-COUNT reader, and the object count is the whole
+  // finding here — bytes are the cross-check, not the headline. A run that
+  // asked for C and did not get it has no source for its central number.
+  if (SNAP_ROUNDS > 0) {
+    if (snapError) gateFailures.push(`reader C failed: ${snapError}`);
+    else if (snapRounds.length !== SNAP_ROUNDS) {
+      gateFailures.push(`reader C produced ${snapRounds.length} of ${SNAP_ROUNDS} requested rounds`);
+    }
+  }
+
+  // The in-situ control, on every reader that took one.
+  for (const r of rounds) {
+    if (Math.abs(r.control.errorCdp) > CONTROL_BAND) {
+      gateFailures.push(
+        `round ${r.round} reader-A control off by ${(r.control.errorCdp * 100).toFixed(3)}% ` +
+          `(band ${(CONTROL_BAND * 100).toFixed(1)}%)`
+      );
+    }
+  }
+  for (const r of snapRounds) {
+    if (Math.abs(r.control.error) > CONTROL_BAND) {
+      gateFailures.push(
+        `snapshot round ${r.round} reader-C control off by ${(r.control.error * 100).toFixed(3)}% ` +
+          `(band ${(CONTROL_BAND * 100).toFixed(1)}%)`
+      );
+    }
+  }
+
+  const variants = variantCurves(arms, rounds, snapRounds);
+
+  // A slope is only a per-read cost if the rungs carry a line.
+  for (const [v, c] of Object.entries(variants)) {
+    if (Number.isFinite(c.r2.min) && c.r2.min < R2_FLOOR) {
+      gateFailures.push(`variant ${v}: bytes r2 ${c.r2.min.toFixed(5)} below the ${R2_FLOOR} floor`);
+    }
+    if (Number.isFinite(c.objectsR2.min) && c.objectsR2.min < R2_FLOOR) {
+      gateFailures.push(
+        `variant ${v}: objects r2 ${c.objectsR2.min.toFixed(5)} below the ${R2_FLOOR} floor`
+      );
+    }
+  }
+
+  for (const f of gateFailures) console.error(`[abl] GATE — ${f}`);
+
   return {
     substrate,
     plan,
     arms: arms.map((a) => a.id),
     witness,
+    witnessExpected: expect || null,
     verification: { mounts, unverified, unverifiedWitness },
     perRound: rounds,
     orderVerdict: guard.verdict(orderSamples, { tolerance: TOLERANCE }),
     snapRounds,
     snapError,
-    variants: variantCurves(arms, rounds, snapRounds),
+    releaseErrors,
+    gateFailures,
+    variants,
   };
 }
 
@@ -573,6 +703,31 @@ function delta(a, b_) {
 }
 const dstr = (d, f = b) => (d ? `${f(d.p50)}  [${f(d.min)}-${f(d.max)}]` : 'n/a');
 
+// THE FIDELITY CONTROL, on BOTH readers.
+//
+// The whole instrument turns on subtracting one variant from another, and
+// that is only attributable if the transcribed-but-unablated arm (`xcript`)
+// reproduces the SHIPPED hook (`uix`). The first cut checked reader-A BYTES
+// only — and bytes are this bead's cross-check, not its headline. The
+// decomposition is quoted in OBJECTS, so the object count has to pass the
+// same control, and a failure has to stop the table being treated as
+// attributable rather than merely being labelled.
+function fidelityCheck(all) {
+  const byName = Object.fromEntries(all.map((s) => [s.substrate, s]));
+  const U = byName.uix && byName.uix.variants;
+  if (!U || !U.uix || !U.xcript) return { present: false, ok: true, legs: [] };
+  const leg = (name, a, b_) => {
+    const ovl = overlap(a, b_);
+    const rel = Math.abs(b_.p50 / a.p50 - 1);
+    return { name, shipped: a, copy: b_, ovl, rel, ok: ovl || rel <= FIDELITY_BAND };
+  };
+  const legs = [
+    leg('bytes/read', U.uix.bytesPerRead, U.xcript.bytesPerRead),
+    leg('objects/read', U.uix.objectsPerRead, U.xcript.objectsPerRead),
+  ].filter((l) => Number.isFinite(l.shipped.p50) && Number.isFinite(l.copy.p50));
+  return { present: true, legs, ok: legs.length > 0 && legs.every((l) => l.ok) };
+}
+
 function report(all) {
   const L = [];
   const byName = Object.fromEntries(all.map((s) => [s.substrate, s]));
@@ -643,17 +798,18 @@ function report(all) {
   // --- the fidelity check, and only then the decomposition ---------------
   const U = byName.uix && byName.uix.variants;
   const R = byName.reagent && byName.reagent.variants;
-  if (U && U.uix && U.xcript) {
-    const ovl = overlap(U.uix.bytesPerRead, U.xcript.bytesPerRead);
-    const rel = Math.abs(U.xcript.bytesPerRead.p50 / U.uix.bytesPerRead.p50 - 1);
-    const ok = ovl || rel <= FIDELITY_BAND;
+  const fid = fidelityCheck(all);
+  if (fid.present) {
     L.push('');
-    L.push(';; ---- FIDELITY CONTROL --------------------------------------------');
-    L.push(`;;   shipped  uix     ${b(U.uix.bytesPerRead.p50)} B/read  [${b(U.uix.bytesPerRead.min)}-${b(U.uix.bytesPerRead.max)}]`);
-    L.push(`;;   copy     xcript  ${b(U.xcript.bytesPerRead.p50)} B/read  [${b(U.xcript.bytesPerRead.min)}-${b(U.xcript.bytesPerRead.max)}]`);
-    L.push(`;;   ranges ${ovl ? 'OVERLAP' : 'do not overlap'};  medians ${pct(rel)} apart ` +
-           `(band ${pct(FIDELITY_BAND)})`);
-    L.push(`;;   => decomposition is ${ok ? 'ATTRIBUTABLE' : 'NOT ATTRIBUTABLE; every delta below is void'}`);
+    L.push(';; ---- FIDELITY CONTROL — BOTH readers ------------------------------');
+    for (const l of fid.legs) {
+      const f = l.name === 'bytes/read' ? b : n1;
+      L.push(`;;   ${l.name.padEnd(13)} shipped uix ${f(l.shipped.p50)} [${f(l.shipped.min)}-${f(l.shipped.max)}]  ` +
+             `copy xcript ${f(l.copy.p50)} [${f(l.copy.min)}-${f(l.copy.max)}]`);
+      L.push(`;;   ${''.padEnd(13)} ranges ${l.ovl ? 'OVERLAP' : 'do not overlap'};  ` +
+             `medians ${pct(l.rel)} apart (band ${pct(FIDELITY_BAND)})  => ${l.ok ? 'ok' : 'FAIL'}`);
+    }
+    L.push(`;;   => decomposition is ${fid.ok ? 'ATTRIBUTABLE' : 'NOT ATTRIBUTABLE; every delta below is void'}`);
   }
   if (U && U.uix && U.noretain && U.hooks) {
     L.push('');
@@ -738,6 +894,28 @@ function report(all) {
     }
     console.error('[abl] ORDER GUARD REFUSED — repair the arm, not the guard');
     process.exit(2);
+  }
+  // THE CLAIMS THIS TABLE IS PUBLISHED ON. The report above is written to
+  // disk first, so the evidence for a refusal survives the refusal — but the
+  // run does not exit 0 with its own witness falsified, its ablation
+  // non-fidelitous, its control out of band, its curves not lines, reader C
+  // absent, or an unmount silently converted into measurement state.
+  const gateFailures = all.flatMap((s) => s.gateFailures.map((f) => `${s.substrate}: ${f}`));
+  const fid = fidelityCheck(all);
+  if (fid.present && !fid.ok) {
+    for (const l of fid.legs) {
+      if (!l.ok) {
+        gateFailures.push(
+          `fidelity ${l.name}: shipped and transcribed ranges do not overlap and medians are ` +
+            `${pct(l.rel)} apart (band ${pct(FIDELITY_BAND)}) — every delta in the decomposition is void`
+        );
+      }
+    }
+  }
+  if (gateFailures.length) {
+    console.error('[abl] THIS TABLE MAY NOT BE PUBLISHED:');
+    for (const f of gateFailures) console.error(`  - ${f}`);
+    process.exit(4);
   }
   console.error('[abl] done');
 })().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
Discharges the audit riders on three published P0 measurement records. Each
rider asked for narrow repairs and explicitly not a rewrite; none of the three
instruments gained an abstraction, and no production code was touched.

The governing rule throughout: **never silently invalidate a published row.**
Where a repair moved a number the row was re-measured and republished with a
new producing SHA; where it did not, the row stands and the provenance repair
is recorded beside it. Nothing was deleted. `rf2-2rtt6.1` is APPEND-ONLY and
was appended to, three times, amending nothing.

---

## rf2-2rtt6.3 — the ratom-spine narrow-write leg

**Numbers moved. Re-run and republished at `a1934a6403`.**

- **The ladder did not isolate what it named.** Each rung was built by handing
  the arm a cell count, so a rung moved the app-db vector, the mounted
  component count, the DOM span count, the reaction count and the subscription
  count together. Every rung now mounts the same 300-cell fixture and the
  rung's number is how many of those cells subscribe; writes target the
  subscribing range, so the React commit is one cell at every rung by
  construction. A new gate refuses to fit the ladder otherwise.
  **Exponent 1.28/1.38/1.38 against the published 1.45–1.53**, intercept
  −0.017 to −0.021 ms against −0.031 to −0.041. Roughly a third of the
  published super-linearity was fixture size.
- **Three gates stopped failing open.** A nonzero unverified count on a real
  arm, and a broken leg identity, were printed and stored while the run exited
  0 as `VERDICT: reportable`; both now fail. The verification denominator
  excluded the `instrument` pseudo-arm, which renders no cell and forces `ok`
  true — **3,600, not 4,320**.
- **Provenance.** `f047011184` recorded as the landed instrument commit of the
  withdrawn publication, with the full authored-to-landed mapping.

The summed write+flush window is untouched. The write share — what the bead
was asked for — reads 0.1–0.2% on both publications.

## rf2-2rtt6.5 — the 1/3/7/20 reads-per-boundary heap ladder

**Numbers moved. Re-run and republished at `c0f9121daf`.**

- **The fit used the anchor it promised not to.** `curves()` regressed
  `[0,1,3,7,20]` including the sub-free R=0 rung. Refitted over the mandated
  rungs alone: **Reagent 943 B/read on a 397 B intercept** (published 942/406),
  **UIx 3,552 on 113** (published 3,550/150). The audit predicted 943/397 and
  3,552/118 from the published medians and the fresh arms land on it, which is
  what turns "the anchor was probably used" into "it was". The report now also
  separates the fitted **marginal slope** from the **first-read increment**
  `y(R=1) − y(R=0)` — 943 against 1,137 on Reagent, 21% apart.
- **Reader C failed open**: a snapshot error, missing control or missing rung
  was caught while the run exited 0, so a reproduction could degrade to the two
  correlated readers. Exits 4 now.
- **Provenance.** `9b0759be46` recorded as the landed instrument commit.
- Red-zones re-derived on `rf2-2rtt6.1`; every threshold moved by less than
  0.2%, so no candidate's verdict can turn on the correction.

Every A-reader rung re-measures within 0.5% of its superseded value and the
3.77× ratio is unchanged to three significant figures — the finding the page
exists for is unaffected.

## rf2-2rtt6.12 — the UIx spine per-read decomposition

- **The central checks were printed, not checked.** The witness counts were
  never compared with the N/N/2N and 0/0/N predictions; fidelity was computed
  for reader-A bytes only, not the headline object count, and failed nothing; a
  reader-C failure was stepped over; neither a bad control nor a curve that is
  not a line could stop the run. All are gates now — the report is written to
  disk first so the evidence for a refusal survives it, then the run exits 4.
  The two new bands (control within 1%, r² at or above 0.99) are declared in
  the driver, which is to say before the run.
- **A failed unmount was measurement state.** `release!*` swallowed every
  exception and reported success, which can leave the committed subscription,
  its watch and its cache entry live while DOM verification and the verdict
  both still pass. Cleanup stays best-effort; the error is surfaced and fails
  the run.
- **Provenance.** `24e8822d7f` recorded as the landed instrument commit.

---

## Notes for review

- **`lane.cljs` is untouched.** `worker/lane-control-cluster` owns it.
- **`implementation/shadow-cljs.edn` is untouched** — no build id added; the
  drivers `--config-merge` an existing `:advanced` template.
- **The order guard's tolerance is untouched.** Rebased onto PR #7267; the
  self-test runs 11 checks including its k=2 and lost-sample repairs, and every
  arm here passed under the stricter guard.
- Studio pages carry **instrument blob hashes** as well as a SHA. Both of these
  pages had been invalidated by a rebase before, which is the defect the
  provenance riders are about; a blob hash survives one.

## Quality gates

All foreground, to completion, worktree-local logs.

| gate | exit |
|---|---|
| `order_guard.selfTest()` — 11/11 checks, incl. PR #7267's k=2 and lost-sample repairs | **0** |
| `hicasso_narrow_run.cjs` — rf2-2rtt6.3 arm, run 1 (build + 6 rounds) | **0** |
| `hicasso_narrow_run.cjs` — run 2 *(published)* | **0** |
| `hicasso_narrow_run.cjs` — run 3 *(published)* | **0** |
| `hicasso_narrow_run.cjs` — run 4 *(published)* | **0** |
| `reads_ladder_run.cjs LADDER_SUBSTRATES=reagent` — rf2-2rtt6.5 arm | **0** |
| `reads_ladder_run.cjs LADDER_SUBSTRATES=uix` — rf2-2rtt6.5 arm | **0** |
| `spine_ablation_run.cjs` — rf2-2rtt6.12 arm, both pages, under all six new gates | **0** |
| `npm run test:freehand` — 1,399 tests / 7,752 assertions, 0 failures, 0 errors | **0** |
| `npm run test:browser` — 842 tests / 5,469 assertions, 0 failures, 0 errors | **0** |

Instrument gates inside those runs, every time: DOM read-back **0 unverified**
(3,600 verifiable writes per narrow-write run; 186 ladder mounts; 154 ablation
mounts), empty-`flushSync` negative control **20 of 20 red** as required,
arm-order guard **clean/reportable on every arm of every run**, positive
controls predicted before each run and hit (heap: five of six readings inside
±0.01%, the sixth stated on the page).

The two substrate pages of the ladder are independent by construction
(`rf/init!` keeps one adapter per JS context), so they were run one at a time
at the one commit; the ablation runs both pages in one process because its
cross-substrate ratio needs them there.

### The rebase reproduced the fault these riders are about

Rebasing this branch onto `main` moved all six commit SHAs. The nine instrument
blobs moved by nothing — checked, by diffing `git rev-parse` output either side.
So the pages now lead with the blob hash as the identifier and carry the SHA
beside it, plus the incantation that finds a commit carrying the blobs. That is
the last commit on the branch and it changes no figure.

### Reported, not repaired

`rf2-95s5b` (P1, filed): `implementation/core/test/re_frame/bench/p0_run.cjs`
has the same fail-open shape the PR #7262 audit named — the **clock** row's
`unverified` count is accumulated, stored and printed but the exit logic
adjudicates only the heap row's, and the positive control is printed with a
ratio that nothing reads while `lane.cljs` already has `control-verdict` for
exactly that. Outside these three riders, and the control half touches
`control-verdict`'s callers while `rf2-egdaq` is tightening it — **sequence
after that PR merges.** `lane.cljs` was not opened.
