### PR TITLE
docs(hicasso): discharge the draft-guide audit rider (rf2-2rtt6.6)

### DIFF
--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -167,21 +167,23 @@ boundary.** Which is often the right design anyway, since it is also where you
 wanted the re-render granularity.
 
 There is a sharper consequence for helpers. **An inlined helper cannot read under the
-grouped surface.** The first cut of this page inferred that from React's hook rules;
-the [HD-002 adjudication](../hd-002-adjudication.md) §5 has since derived it on
-firmer ground and reached the same verdict. The ground is HD-002's own definition —
-grouped is "one fixed hook receiving *the complete query collection before the
-body*", and a helper's queries are not knowable before the body, because the body has
-to run to reach the helper. HD-020's budget agrees from the other side: it is already
-fully consumed by the subscription hook and the frame hook, so a helper calling
-`use-subs` is a third hook in the boundary.
+grouped surface** — and the reason is not the one you would guess. HD-002 defines
+grouped as one fixed hook receiving *the complete query collection before the body*,
+and a helper's queries are not knowable before the body, because the body has to run
+to reach the helper. A reading helper is structurally incompatible with the tier as
+defined. HD-020's budget agrees from the other side: it is already fully consumed by
+the subscription hook and the frame hook, so a helper calling `use-subs` would be a
+third hook in the boundary.
 
-React, notably, is *not* the reason. A helper called unconditionally and exactly once
-per render, itself calling `use-subs` unconditionally, is a custom hook by React's own
-definition and React would allow it. The grouped tier forbids it anyway. Do not reach
-for the hook-rules argument when someone asks you why.
+Both grounds are the [HD-002 adjudication](../hd-002-adjudication.md)'s, which reached
+the verdict after this guide's first pass had reached it from React's hook rules — the
+weaker argument, now withdrawn. React, notably, is *not* the reason. A helper called
+unconditionally and exactly once per render, itself calling `use-subs`
+unconditionally, is a custom hook by React's own definition and React would allow it.
+The grouped tier forbids it anyway. Do not reach for the hook-rules argument when
+someone asks you why.
 
-So there are two shapes for a helper, and the first cut only had one of them.
+So there are two shapes for a helper:
 
 ```clojure
 ;; 1. The helper takes values and reads nothing.
@@ -196,7 +198,7 @@ So there are two shapes for a helper, and the first cut only had one of them.
   (let [{:keys [title badge-count]}
         (use-subs (merge {:title [:cart/title id]}
                          (badge-queries id)))]
-    [:header title (badge id badge-count)]))
+    [:header title (badge {:count badge-count})]))
 ```
 
 The second shape adds nothing to the surface: `use-subs` takes a map and maps merge.
@@ -321,7 +323,7 @@ independently, not because the markup got long.
 | Which read surface ships | **Open by design.** HD-002 is decided by P1 measurement; three outcomes, including null |
 | `use-subs` and `sub` spellings | Pre-declared working names; [authoring.md](../authoring.md) holds all declaration spellings unfrozen until the tournament |
 | Does `use-subs` accept anything but a map — a vector of queries, a single query? | **Not addressed.** Only the map form appears in the record |
-| Can an inlined helper read under Surface A? | **Answered: no.** Not by this guide any more — [hd-002-adjudication.md](../hd-002-adjudication.md) §5 derives it from HD-002's "complete query collection before the body", with HD-020's spent budget as a second ground. The first cut inferred the same verdict from React's hook rules; that ground was the weak one and is withdrawn |
+| Can an inlined helper read under Surface A? | **Answered: no** — and no longer on this guide's authority. [hd-002-adjudication.md](../hd-002-adjudication.md) derives it from HD-002's "complete query collection before the body", with HD-020's spent budget as a second ground. This guide's earlier hook-rules argument reached the same verdict on weaker ground and is withdrawn |
 | Whether query-contributing helpers are the taught idiom or merely legal | The adjudication marks the shape **[INFERRED]** and recommends the dogfood screen exercise it. Nothing rules it in as the taught form |
 | `defview`'s own spelling and whether a props-map argument is required | Working name; the single-props-map body signature is ruled by HD-016 |
 | The dev warning for an unkeyed seq — its id and whether it is dev-only | **Not addressed** beyond "dev warning" |

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -90,6 +90,15 @@ is a cost every render pays whether it helps or not. Narrow updates come from
 **where you put your boundaries**, and `React.memo` is available as an explicit
 opt-out when you have measured a reason.
 
+One corollary is worth stating outright, because the opposite is the thing people
+worry about. Reading a subscription high in the tree and passing the value down as a
+prop does **not** lose an update. The boundary that reads is the boundary that
+invalidates; it re-renders with the new value, passes it down, and — precisely
+because nothing is memoized by default — every descendant re-renders with it. The
+value arrives. What you have bought yourself is invalidation that is **too coarse**,
+never invalidation that is missing. Moving the read down is a granularity fix, not a
+correctness fix, and if you go looking for a lost update you will not find one.
+
 ## The fork: how a view reads a subscription
 
 HD-002 ranks three tiers. One of them is not a product surface at all — **scalar
@@ -157,16 +166,45 @@ The second move is the one to internalise: **a conditional read is a conditional
 boundary.** Which is often the right design anyway, since it is also where you
 wanted the re-render granularity.
 
-There is a sharper consequence for helpers. An inlined helper cannot call `use-subs`
-— it would be a hook in a function called conditionally, which React forbids. So
-under Surface A, helpers take values as arguments and read nothing:
+There is a sharper consequence for helpers. **An inlined helper cannot read under the
+grouped surface.** The first cut of this page inferred that from React's hook rules;
+the [HD-002 adjudication](../hd-002-adjudication.md) §5 has since derived it on
+firmer ground and reached the same verdict. The ground is HD-002's own definition —
+grouped is "one fixed hook receiving *the complete query collection before the
+body*", and a helper's queries are not knowable before the body, because the body has
+to run to reach the helper. HD-020's budget agrees from the other side: it is already
+fully consumed by the subscription hook and the frame hook, so a helper calling
+`use-subs` is a third hook in the boundary.
+
+React, notably, is *not* the reason. A helper called unconditionally and exactly once
+per render, itself calling `use-subs` unconditionally, is a custom hook by React's own
+definition and React would allow it. The grouped tier forbids it anyway. Do not reach
+for the hook-rules argument when someone asks you why.
+
+So there are two shapes for a helper, and the first cut only had one of them.
 
 ```clojure
-(defn- badge [{:keys [count]}]         ;; plain fn, plain args, no reads
+;; 1. The helper takes values and reads nothing.
+(defn- badge [{:keys [count]}]
   [:span.badge count])
+
+;; 2. The helper contributes QUERIES, which compose into the one hook.
+(defn- badge-queries [id]
+  {:badge-count [:cart/count id]})
+
+(defview cart-header [{:keys [id]}]
+  (let [{:keys [title badge-count]}
+        (use-subs (merge {:title [:cart/title id]}
+                         (badge-queries id)))]
+    [:header title (badge id badge-count)]))
 ```
 
-That inference is this guide's, not a ruling; see **Not settled yet**.
+The second shape adds nothing to the surface: `use-subs` takes a map and maps merge.
+Hook count fixed, order fixed, the complete collection still assembled before the
+body. It matters beyond ergonomics — the adjudication's recommendation is that the
+dogfood screen's grouped rendering exercise query-contributing helpers explicitly, so
+that the ergonomic half of the HD-002 verdict is not scored against a grouped
+rendering written with one hand tied.
 
 ### Surface B — the ambient collector (the challenger)
 
@@ -206,7 +244,13 @@ Loops can read. You write the obvious thing.
 
 ### How this gets decided
 
-Four adjudication clauses are pinned before any P1 code is written:
+Four adjudication clauses are pinned before any P1 code is written, and they now have
+a written adjudication of their own — [hd-002-adjudication.md](../hd-002-adjudication.md),
+a delegated advisory the operator may overturn. Read it before you form an opinion
+about the fork. It settles what the collector may do and what kills it; it does
+**not** decide which surface ships, and neither does this page.
+
+The four clauses:
 
 1. a render/commit **ownership state machine** — how a candidate read survives a
    winning render and disappears after an abandoned render, a replay, or a teardown;
@@ -236,9 +280,18 @@ Whichever surface wins:
 - **Framework subscriptions read identically to your own** — machine tags, resource
   and mutation state, route identity. They are 27% of the census's read traffic, so
   the index serves them first-class rather than as a special case.
-- **Sub-key identity is `(query-id, args)` under value equality.** Building a fresh
-  map as a query argument on every render will thrash the index. Documented,
-  programmer-trusted, not policed.
+- **Sub-key identity is `(query-id, args)` under value equality.** Note what that
+  buys you: a *freshly allocated* map or vector is not a problem. Two structurally
+  equal persistent values are one cache key, so rebuilding `{:scope :all}` inside the
+  query on every render hits the same entry every time, and you do not have to hoist
+  it into a `def` or memoize it to be safe. What thrashes the index is an argument
+  whose **value** changes when nothing meaningful did — a re-sorted seq, a timestamp
+  folded into the query, a JS object or a function, which carry reference identity
+  rather than value identity. Documented, programmer-trusted, not policed.
+
+  (Read [validation.md](../validation.md)'s shorthand — "unstable map args thrash the
+  index" — as *value*-unstable. A guide does not own that page's wording; the reading
+  is the one Spec 006's cache identity forces.)
 
 ## Troubleshooting
 
@@ -248,9 +301,9 @@ No Hicasso error ids exist yet; this table names mechanisms.
 |---|---|---|
 | A child re-renders whenever its parent does | Expected — there is no default memoization (HD-006) | Move the boundary, or apply `React.memo` where you measured a reason |
 | One cell changes and 300 boundaries re-render | The read lives too high in the tree | Push the read down into the boundary that displays it |
-| Nothing re-renders when app-db changes | The value was passed down as a prop instead of read where it is used | Read at the point of use |
-| Hook-order error in a helper | Surface A only: a hook in a conditionally-called function | Helpers take values as arguments; keep `use-subs` in view bodies |
-| Index thrash, subscriptions constantly re-created | Unstable query args — a fresh map or vector each render | Pass values with stable identity under `=` |
+| One value changes and a whole subtree re-renders with it | The value is read in an ancestor and passed down as a prop. Nothing is *lost* — the reading ancestor re-renders with the new value and, there being no default memoization, so does everything under it. Coarse invalidation, not missed invalidation | Read at the point of use, so the boundary that displays the value is the boundary that invalidates |
+| A helper wants to read, under Surface A | Grouped takes the complete query collection *before* the body, so a helper's queries are out of reach — HD-002's definition, not React's hook rules | Pass the value in, or have the helper return queries that `merge` into the one `use-subs` call |
+| Index thrash, subscriptions constantly re-created | Query args that are not *value*-stable — a re-sorted seq, a folded-in timestamp, a JS object or a function | Allocation is fine; two equal persistent values are one key. Make the args equal under `=` between renders |
 | A body's side effect fires twice | StrictMode double-invoke | Bodies are pure; move the effect out |
 
 ## When not to use a boundary
@@ -268,6 +321,7 @@ independently, not because the markup got long.
 | Which read surface ships | **Open by design.** HD-002 is decided by P1 measurement; three outcomes, including null |
 | `use-subs` and `sub` spellings | Pre-declared working names; [authoring.md](../authoring.md) holds all declaration spellings unfrozen until the tournament |
 | Does `use-subs` accept anything but a map — a vector of queries, a single query? | **Not addressed.** Only the map form appears in the record |
-| Can an inlined helper read under Surface A? | **This guide's inference is no** (React hook rules), and helpers therefore take values as arguments. The record states the consequence only for the collector case — HD-016 calls helper-donated reads "collector-contingent" — and never spells out the grouped-surface answer |
+| Can an inlined helper read under Surface A? | **Answered: no.** Not by this guide any more — [hd-002-adjudication.md](../hd-002-adjudication.md) §5 derives it from HD-002's "complete query collection before the body", with HD-020's spent budget as a second ground. The first cut inferred the same verdict from React's hook rules; that ground was the weak one and is withdrawn |
+| Whether query-contributing helpers are the taught idiom or merely legal | The adjudication marks the shape **[INFERRED]** and recommends the dogfood screen exercise it. Nothing rules it in as the taught form |
 | `defview`'s own spelling and whether a props-map argument is required | Working name; the single-props-map body signature is ruled by HD-016 |
 | The dev warning for an unkeyed seq — its id and whether it is dev-only | **Not addressed** beyond "dev warning" |

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -29,6 +29,11 @@ Then use it anywhere, and it is indistinguishable from a native view:
 
 ## Why a declaration instead of `[:>]`
 
+HD-011's Ruling settles the hierarchy in a sentence: **`defhost` is the door, and the
+only form taught**; `[:>]` "survives only as the explicitly secondary raw escape …
+for the cases a static declaration cannot express." Both forms are legal. Only one is
+taught. This page is written in that order for that reason.
+
 `[:> DatePicker {...}]` puts a raw JavaScript value inside your data tree. Three
 things break at that node, all of them quietly:
 
@@ -97,8 +102,19 @@ invocation are not in the record.
 
 A mapping SDK, a chart library that wants a DOM node, anything that hands you a
 handle and expects you to feed it — that is **not** an interop-door problem. It is
-ordinary host-edge React (HD-003): a callback ref, an effect, and a cleanup, written
-in a `.cljs` namespace at the edge of your app.
+ordinary host-edge React (HD-003): a callback ref, written in a `.cljs` namespace at
+the edge of your app.
+
+There is no Hicasso concept for this, deliberately. "Behaviors" — a predecessor
+product concept for imperative host ownership — is **not v0 vocabulary**. A richer
+host-ownership pattern is a product-phase question; the v0 answer is React, used
+honestly, at the edge.
+
+Used honestly means **the attach and the teardown are written as one thing.** An SDK
+that mounts and never tears down is the most common bug on this seam, and it is not
+subtle — you get two maps, two resize observers, and a leak per remount. React 19's
+callback ref makes the pairing structural: **whatever the ref function returns is its
+cleanup**, so you cannot write the attach without deciding what undoes it.
 
 ```clojure
 ;; Sketch only — host-edge React inside a defview body, in a .cljs namespace.
@@ -109,19 +125,88 @@ in a `.cljs` namespace at the edge of your app.
 
 (defview map-panel [_]
   (let [attach (react/useCallback
-                 (fn [node] (when node (sdk/mount node)))
-                 #js [])]
+                 (fn [node]
+                   ;; One attach, one handle, one teardown. The handle lives in
+                   ;; this closure and nowhere else.
+                   (let [handle (sdk/mount node)
+                         done?  (volatile! false)]
+                     (fn cleanup []
+                       (when-not @done?
+                         (vreset! done? true)
+                         (sdk/destroy handle)))))
+                 #js [])]                    ;; stable identity — see below
     [:div.map {:ref attach}]))
 ```
 
-There is no Hicasso concept for this, deliberately. "Behaviors" — a predecessor
-product concept for imperative host ownership — is **not v0 vocabulary**. A richer
-host-ownership pattern is a product-phase question; the v0 answer is React, used
-honestly, at the edge.
+Four properties, and each one is load-bearing.
 
-Note the two hook-budget consequences: this body now has hooks in it, so it is
-outside the headless testing scope ([Testing](08-testing.md)) and you have taken on
-React's hook rules yourself. Both are fine. Both are on you.
+**The handle is per-attach, not per-namespace.** It is created by the attach and
+captured by the cleanup that attach returned. Two attaches produce two handles and
+two cleanups, correctly paired. The moment you hoist that handle into a `defonce`
+atom or a module-level var, a second attach overwrites the first and the first
+instance leaks — which is the actual mechanism behind every "it mounted twice" report
+on this seam.
+
+**The teardown is idempotent.** The `done?` latch makes a second call a no-op. React
+calls each cleanup exactly once, so strictly this is belt and braces — but SDK
+`destroy` methods that throw on a dead handle are common enough that the three lines
+are worth it, and the alternative is finding out in production. This is the same
+idempotence the root teardown has ([Getting started](01-getting-started.md)); the
+discipline does not change because the object is foreign.
+
+**Returning a cleanup and handling a `nil` node are exclusive.** When a ref callback
+returns a function, React calls that function on detach *instead of* invoking the
+callback again with `nil`. Write both and you will have written a `nil` branch that
+never runs — a dead path that reads like a teardown and is not one. Pick the return.
+
+**`useCallback` with an empty dependency array is what makes any of this
+deterministic.** A ref function with a fresh identity every render is detached and
+re-attached on every render, so the SDK is destroyed and rebuilt on every keystroke
+elsewhere in the tree. The stable identity is the difference between one mount and
+one mount per render.
+
+### Under StrictMode
+
+StrictMode double-invokes the mount in development: attach, cleanup, attach. The
+shape above survives it, and the reason is the first property, not the second. The
+first attach's handle is destroyed by the cleanup that attach returned, and the
+second attach builds a fresh one. You end with exactly one live handle, which is what
+you would have had in production.
+
+What does *not* survive is a handle stored outside the closure, or a cleanup that
+tears down less than the attach built — a listener left on `window`, an observer left
+connected. Then the second attach genuinely doubles, and the symptom is two of
+everything in dev and one leak per remount in production. **The rule is that the
+cleanup returns the world to the state the attach found it in**; there is no runtime
+that can check that for you.
+
+### If the runtime does not target React 19
+
+The cleanup-returning ref is a React 19 contract. The record does not pin a React
+version (see **Not settled yet**), so the older shape is worth knowing: the callback
+is invoked with the node on attach and with `nil` on detach, and the handle needs a
+home that outlives one invocation.
+
+```clojure
+(let [handle (react/useRef nil)
+      attach (react/useCallback
+               (fn [node]
+                 (if node
+                   (set! (.-current handle) (sdk/mount node))
+                   (when-let [h (.-current handle)]
+                     (set! (.-current handle) nil)   ;; clear first — idempotent
+                     (sdk/destroy h))))
+               #js [])]
+  [:div.map {:ref attach}])
+```
+
+Same discipline, one more moving part. That the handle now needs a home outside the
+closure is exactly what the React 19 contract removes, which is why it is the shape
+taught above.
+
+Note the two consequences of putting hooks in a body at all: it is outside the
+headless testing scope ([Testing](08-testing.md)), and you have taken on React's hook
+rules yourself. Both are fine. Both are on you.
 
 ## Troubleshooting
 
@@ -133,7 +218,10 @@ No Hicasso error ids exist yet; this table names mechanisms.
 | A namespace stops loading on the JVM | A JS require reached a `.cljc` file | Quarantine the require in a `.cljs` host namespace |
 | Structural test can't match a node | It's a `[:>]` node — reduced structural identity, by design | Declare it with `defhost`, or assert around it |
 | Provider from a library needs to wrap the tree | Hosted like anything else | `defhost` the provider; it is a component |
-| The SDK mounts twice in dev | StrictMode double-invoke of effects | Make attach and cleanup idempotent — the same discipline React requires of any JS app |
+| The SDK mounts twice in dev and you end with two live handles | StrictMode double-invoke, plus a handle stored outside the attach's closure — so the second attach overwrote the first instead of replacing it | One attach, one handle, one cleanup, all in one closure; return the cleanup from the ref |
+| The SDK is destroyed and rebuilt on every unrelated render | The ref function has a fresh identity each render, so React detaches and re-attaches | `useCallback` with `#js []` — a stable ref identity |
+| A `nil`-node branch in a ref never runs | The callback returns a cleanup, so React calls that instead of re-invoking with `nil` | Pick one contract; with React 19, pick the return |
+| A listener or observer survives unmount | The cleanup tears down less than the attach built | The cleanup returns the world to the state the attach found it in — nothing checks this for you |
 
 ## When not to reach for the door
 
@@ -150,6 +238,7 @@ two or three genuinely hard widgets.
 |---|---|
 | `defhost`'s option keys | **Not addressed.** "Policy overrides live on the declaration" is as far as the record goes |
 | The codemod's name and invocation | **Not addressed** |
+| Which React version the runtime targets | **Not addressed by the design record.** The cleanup-returning callback ref taught above is a React 19 contract; this repo's implementation currently pins React 19.2, but that is a fact about today's tree, not a Hicasso ruling. If v0 lands on 18, the fallback shape above is the one to teach |
 | Whether `::h/value` works across a host crossing | **Not addressed.** The example above assumes it does; a foreign `onChange` may hand you something other than a DOM event |
 | The SSR placeholder's shape | Declared policy, inert in v0 |
 | Whether a hosted component can be a `defview`'s child via `(:children props)` | The ABI says an existing React element is a legal child anywhere, which implies yes; not stated for the host case specifically |

--- a/docs/design/hicasso/draft-guide/06-theming.md
+++ b/docs/design/hicasso/draft-guide/06-theming.md
@@ -42,9 +42,16 @@ it is platform-native.
 }
 ```
 
-Switching theme is one attribute flip on one element. **Zero React work** — no
-re-render, no hook, no diff. Nothing in your component tree knows it happened, which
-is exactly right, because nothing in your component tree needed to.
+Switching theme is one attribute flip on one element, and **restyling from there
+costs zero React work** — no re-render, no hook, no diff. The cascade recomputes and
+your component tree is never consulted, which is exactly right, because nothing in it
+needed to be.
+
+Read that claim precisely, because layer 3 depends on where its edge is. HD-010's
+"one attribute flip, zero React work" describes what happens *after* the attribute
+changes. It says nothing about what flips it. See
+[Layer 3 and the DOM](#layer-3-and-the-dom) — the one place this page has to report a
+hole rather than teach around it.
 
 ## Layer 2 — parts as data addresses
 
@@ -89,6 +96,97 @@ Xray visibility for free.
 App-db holds the *choice*. It does not hold the tokens, and it does not hold the
 part maps.
 
+## Layer 3 and the DOM
+
+Here is the part the record does not join up, and the reason this section exists
+rather than a paragraph of confident prose.
+
+**That event is a no-op as far as the browser is concerned.** It moves a keyword into
+app-db. Layer 1's cascade keys off a `data-theme` attribute on a DOM element. Nothing
+in HD-010 says how the first becomes the second — it rules "app-db + `sub` for the
+theme choice only" and, separately, "a theme switch is one attribute flip, zero React
+work", and never writes the line between them. A guide that skipped the gap would be
+telling you to write an event that visibly does nothing.
+
+Two bridges close it. Neither needs a new API, and the record picks neither.
+
+### Bridge A — a scope view reads the choice
+
+The obvious one: one view reads `:theme/current` and puts it on its own element.
+
+```clojure
+(defview theme-scope [{:keys [children]}]
+  [:div {:data-theme (name (sub [:theme/current]))}   ;; collector spelling
+   children])
+
+;; At the root:
+[theme-scope {} [app {}]]
+```
+
+**Its true cost.** The boundary that reads the theme re-renders on every switch —
+that much is certain and it is one boundary. What is *not* certain is whether the
+subtree comes with it. If `theme-scope` takes its content through `(:children props)`,
+those children are elements its parent already created, and the parent did not
+re-render (it does not read the theme), so React's ordinary bailout on referentially
+identical children should skip them. If instead the scope view renders its content
+directly, the whole app re-renders on a theme switch, because
+[there is no default memoization](02-views-and-reads.md).
+
+That first "should" is doing real work and this guide will not launder it. Whether an
+*interpreted* hiccup runtime preserves element identity for children a boundary
+merely passes through is a runtime property nobody has measured. The ABI says
+children arrive realized and an existing React element is a legal child anywhere; it
+does not say identity survives a re-render of the receiving boundary. **If it does,
+bridge A costs one boundary. If it does not, bridge A costs the app, and "zero React
+work" is off by the size of your tree.**
+
+### Bridge B — an effect writes the attribute
+
+The other one: nothing reads the theme at all. The event that records the choice also
+returns an effect, and the effect does the flip.
+
+```clojure
+(rf/reg-fx :theme/apply!
+  (fn [theme]
+    (.setAttribute (.-documentElement js/document) "data-theme" (name theme))))
+
+(rf/reg-event :theme/choose
+  (fn [{:keys [db]} [_ theme]]
+    {:db          (assoc db :theme/current theme)
+     :theme/apply! theme}))
+```
+
+**Its true cost.** Zero React work, literally rather than approximately: no
+subscription, no boundary, no render. HD-010's claim is exactly true under this
+bridge.
+
+**What you pay for it.** Three things, and they are real:
+
+- **The DOM is no longer derived from state.** Rewind app-db in Xray and the
+  attribute does not follow, because no event ran. Any path that replaces app-db
+  without going through `:theme/choose` — time travel, a test fixture, a restored
+  snapshot — leaves the document showing the old theme while app-db says otherwise.
+- **Boot needs its own hand.** The initial theme is applied by an initial event that
+  carries the same effect, or the first paint is unthemed.
+- **It is not frame-isolated.** `document.documentElement` is one element and two
+  frames on one page share it, which contradicts the "frame isolation for free" that
+  layer 3 otherwise gets. Targeting each root's own node instead would need the
+  effect to reach that node, and nothing in the record says an effect can.
+
+### Unresolved, and deliberately so
+
+**Which bridge is the taught one is not settled**, and this guide is not the place to
+settle it — naming one would be designing the missing half rather than reporting it.
+The shape of the choice is clear enough to state, though: bridge A keeps the DOM
+derived from state at a render cost nobody has measured; bridge B has no render cost
+and gives up the derivation. It is the ordinary trade between rendering a fact and
+imperatively asserting it, and it is a design decision with a witness attached.
+
+What would settle it: a measurement of bridge A on the multi-frame witness — does a
+theme flip re-render one boundary or the tree — and a ruling on whether the theme
+attribute is per-root or per-document. The first is a P1 instrument. The second is a
+sentence somebody has to write.
+
 ## The two laws
 
 Layers 1 and 2 would be a footgun without these. Both are ruled in HD-010.
@@ -114,8 +212,9 @@ The three halves of that, spelled out:
 - If it changes while the app runs — light and dark, density, brand — it is a CSS
   variable.
 - A part-to-class map is fixed at boot. Changing one is an app rebuild, **by
-  design**. The "theme switch is zero React work" claim holds for the token layer,
-  and this is the price.
+  design**. The "theme switch is zero React work" claim holds for the token layer —
+  for the restyle, and for the flip itself only under bridge B — and this is the
+  price of it.
 - If you want a different *structure* — a custom menu row, a replaced icon — that is
   a child or a slot. Parts address the pieces a control renders; they do not replace
   them.
@@ -144,7 +243,9 @@ No Hicasso error ids exist yet; this table names mechanisms.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| Theme switch re-renders the whole app | The switch went through app-db into a prop that every view reads | Switch a CSS variable scope instead — the token layer is the runtime-switchable one |
+| The theme keyword changes in app-db and nothing on screen changes | No bridge is wired — app-db holds the choice, and the cascade keys off a DOM attribute | Wire one of the two bridges above; the event alone does nothing to the document |
+| Theme switch re-renders the whole app | Bridge A, with the themed content rendered directly by the scope view rather than passed through as children — so there is no bailout and no memoization (HD-006) to stop it | Pass the content through as children, or use bridge B |
+| A time-travel rewind shows the old theme | Bridge B — the attribute was asserted by an effect, so it is not derived from the state you rewound | Expected under bridge B; it is the price named above |
 | A controlled input's value gets clobbered by a theme | Should be impossible — law (a) | A runtime bug, not a usage error |
 | A part override doesn't take effect | Merge order: instance props beat app theme beat base | Check which layer you set it in |
 | Theme change needs a rebuild | Expected, if you changed a part-to-class map — law (b) | Move the switchable part into a CSS variable |
@@ -164,6 +265,9 @@ order to remember, in exchange for a flexibility nobody is going to use.
 
 | Question | Status |
 |---|---|
+| **How the app-db choice reaches the `data-theme` scope** | **Unresolved, and the largest hole on this page.** HD-010 rules the choice into app-db and rules the switch to be one attribute flip, and never joins them. [Layer 3 and the DOM](#layer-3-and-the-dom) names both candidate bridges and prices them; picking one is a design decision, not a writing decision |
+| Whether a boundary that only passes children through re-renders them | **Not addressed**, and bridge A's whole cost turns on it. The ABI says children arrive realized; it does not say element identity survives a re-render of the receiving boundary. A P1 instrument, not a paper question |
+| Whether the theme attribute is per-root or per-document | **Not addressed.** Layer 3 promises frame isolation; a document-level attribute does not have it |
 | How a control declares a part | **Not addressed.** "Controls emit keyword-tagged parts" is the whole of the record; the attribute or macro that does it is unnamed |
 | How an app installs a theme | **Not addressed.** The merge order `base < app-theme < instance-props` is ruled; the mechanism that supplies the app-theme layer is not. Since there is no context, it is presumably passed or registered — the record does not say which |
 | The part-address shape | This guide writes `[:typeahead :root]` by analogy with the record's "part address" language; the actual shape is unstated |

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -76,5 +76,7 @@ plausible ones would be the single most damaging thing this draft could do.
 [decisions.md](../decisions.md) governs; [validation.md](../validation.md) is next.
 [authoring.md](../authoring.md) holds the canonical spellings that do exist, and
 where this guide shows a symbol that authoring.md does not, the symbol is invented
-here and marked. The programme is sequenced by
+here and marked. [hd-002-adjudication.md](../hd-002-adjudication.md) is a delegated
+advisory on the read fork — it settles what the collector may do and what kills it,
+and explicitly does **not** decide which surface ships. The programme is sequenced by
 [EP-0038](../../../EP/EP-0038-the-hicasso-view-layer-programme.md).


### PR DESCRIPTION
Discharges the audit rider reopened on `rf2-2rtt6.6` against
`docs/design/hicasso/draft-guide/`. Every defect was a place where the guide
promised something its own examples did not deliver.

This stays a documentation reconciliation, per the rider's own closing
constraint: no API freeze, no new context/state system, no generalized lifecycle
abstraction. Where the record does not settle a question, the guide now says so.

## Rider item 1 — the invalidation claim (`02-views-and-reads.md`)

The troubleshooting table said passing a subscribed value down as a prop means
"nothing re-renders". Under the same page's no-default-memoization semantics
(HD-006) that is backwards: the subscribing ancestor re-renders and passes the new
value, and every descendant re-renders with it. The value arrives.

Fixed as a description, not as a framework change. The "There is no automatic
memoization" section now states the corollary outright — **coarse invalidation,
never missed invalidation; moving the read down is a granularity fix, not a
correctness fix** — and the table row was rewritten to match.

## Rider item 2 — the imperative-SDK teardown (`05-interop.md`)

The sketch attached an SDK to a node and never detached it, while the surrounding
prose promised cleanup and the page's own troubleshooting table warned about
StrictMode double attachment.

The sketch now shows a deterministic, idempotent mount/teardown, on the React 19
**callback-ref return contract** — whatever the ref returns is its cleanup. Four
properties are spelled out because each is load-bearing:

- the handle lives in the attach's own closure, never a module var or `defonce`
  atom (that hoist is the actual mechanism behind "it mounted twice");
- the teardown latches, so a second call is a no-op;
- returning a cleanup and handling a `nil` node are **exclusive** — write both and
  the `nil` branch is dead code that reads like a teardown;
- `useCallback` with an empty dependency array is what stops a fresh ref identity
  detaching and re-attaching on every unrelated render.

An **Under StrictMode** section walks attach, cleanup, attach and says why the
shape survives it (one live handle, same as production) and what does not — a
hoisted handle, or a cleanup that tears down less than the attach built. The
pre-19 `nil`-node shape is shown as the fallback, and **which React version the
runtime targets is recorded as unsettled**: the design record does not pin one.

Also cites HD-011's Ruling directly for the `defhost` / raw-escape hierarchy
rather than reconstructing it from two paragraphs, per the reconciliation in
#7271. No "no raw-escape form" line was re-imported; the page already taught the
reconciled shape and nothing was reversed.

## Rider item 3 — theming's DOM bridge (`06-theming.md`)

The page put the chosen theme in app-db, said to read it with `sub`, promised zero
React work, and never connected any of that to the `data-theme` scope — leaving the
event a no-op with respect to the document.

A new **Layer 3 and the DOM** section names both bridges and prices each honestly:

- **Bridge A**, a scope view that reads the choice. One boundary re-renders for
  certain; whether the subtree comes with it turns on whether an interpreted hiccup
  runtime preserves element identity for children a boundary merely passes through
  — which nobody has measured, and the guide refuses to launder the "should".
- **Bridge B**, a `reg-fx` that writes the attribute. Zero React work, literally.
  Priced with its three real costs: the DOM stops being derived from state (a
  time-travel rewind leaves it stale), boot needs its own hand, and a
  document-level attribute is not frame-isolated.

**The choice between them is marked unresolved**, with what would settle it (a
measurement on the multi-frame witness, and a ruling on per-root vs per-document).
Naming one would be designing the missing half rather than reporting it. Layer 1's
"zero React work" claim is now scoped to the restyle rather than the flip, which is
what HD-010 actually says.

## Rider item 4 — the fresh-map cache-identity claim (`02-views-and-reads.md`)

The page defined sub-key identity under value equality and then said a freshly
allocated map argument thrashes the index. Equal persistent values are one cache
key (Spec 006), so allocation is free; only **value**-unstable args churn — a
re-sorted seq, a folded-in timestamp, a JS object or function. Corrected in both
the prose bullet and the troubleshooting row.

## HD-002: not resolved, and now better cited

The fork stays open. Both surfaces keep equal weight, both status paragraphs
stand, and the page still closes on "HD-002 is a measurement and the measurement
has not run."

What changed is the citation. `hd-002-adjudication.md` is now linked as the
delegated advisory it is, explicitly noted as settling what the collector may do
and what kills it while deciding nothing about which surface ships. Two
consequences flow into the guide:

- **The grouped-surface helper-read verdict is no longer this guide's inference.**
  It is derived from HD-002's own "complete query collection before the body", with
  HD-020's spent budget as a second ground. The guide's earlier hook-rules argument
  reached the same verdict on weaker ground and is withdrawn — with a note that
  React would in fact permit an unconditionally-called custom hook, so nobody
  reaches for that argument again.
- **Query-contributing helpers** are shown as the second helper shape, marked as
  the advisory's `[INFERRED]` recommendation rather than a taught idiom, because the
  ergonomic half of the HD-002 verdict should not be scored against a grouped
  rendering written with one hand tied.

## Draft properties preserved

All three still hold, and were checked rather than assumed:

- the pre-implementation banner is on all **9** pages;
- every unfrozen spelling is still marked (`[unfrozen]` present on all 9);
- `design/hicasso/` is still in `exclude_docs`, and the built site contains
  **zero** pages under `design/` — the only `hicasso` paths in `site/` are the
  EP page, which lives elsewhere.

## Left for the mayor — one fenced residual

The bead's acceptance criteria also ask for `docs/design/hicasso/validation.md`
to be reconciled where it repeats the claim. **That file is outside this worker's
fence** (normative, read-and-cite only), so it is untouched. Its wording —
"unstable map args thrash the index" — is ambiguous rather than wrong, and needs a
one-word reconciliation to "value-unstable". The guide states the correct reading
and flags it as a sibling-page wording issue it does not own. Filed as a
follow-up bead.

## Quality gates

Run foreground to completion in the worker worktree, exit codes echoed:

| Gate | Command | Exit |
|---|---|---|
| Doc links + anchors | `python scripts/check_doc_slugs.py --verbose` | **0** — 642 markdown files scanned, "no broken links" |
| Docs build | `python -m mkdocs build --strict` | **0** — built in 23.44s; the only INFO lines are the pre-existing `spec/API.md` anchor notes, untouched by this PR |
| Exclusion still holds | `find site -ipath '*hicasso*'` | **0** — 2 hits, both the `EP/EP-0038-...` page; `site/design/` does not exist, so `design/hicasso/` produces no pages |

Note the trap this surface carries: a green `mkdocs build --strict` is **not**
evidence these pages are well-formed, because the build never sees them. The
three changed pages were read end-to-end by hand for that reason.
