### PR TITLE
bench(hicasso): consolidate the donor arm, converge the lanes, batch the clamp-limited row (rf2-f5roa, rf2-uhw11, rf2-zb3qg)

### DIFF
--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -97,6 +97,47 @@ rows do not.
 | **Canonical-DOM parity** | clean under `:advanced` in both segments **and across the seam**, every row — `{:problems [] :ok? true}` |
 | **Verification** | **0 unverified of 2,460** — 600 M1 mounts + 600 M2 mounts + 630 broad writes + 630 narrow writes, each read back out of the DOM inside its own window |
 
+### The bulk-narrow row was re-taken (rf2-zb3qg)
+
+Three of the four rows above stand as measured. **The narrow row does not — it
+was re-run on a batched window** and both its figures and its provenance below
+supersede the ones in the table above.
+
+**The instrument is identified by content hash, not by commit SHA.** A rebase
+moved this branch's SHAs between the run and the merge; the blobs did not move
+at all, and were verified byte-identical afterwards.
+
+| file (`implementation/freehand/test/re_frame/bench/hicasso/`) | blob |
+|---|---|
+| `p0_converge_app.cljs` | `f4b09dc20712e45f44f9ec9339f8dd00ce51e8f7` |
+| `lane.cljs` | `885592cf9fdd79f701d6353fc5d3dae0868d74f1` |
+| `p0_converge_run.cjs` | `253b468a6b3a96b3ca8e1d8e4f6d2ad6299445a1` |
+| `p0_reagent_views.cljs` | `4032e39779ce55fee1e1cd4f7a8e9561237e2cfd` |
+| `p0_uix_views.cljs` | `34e0e89d532f2af3b3289525509cf033bb03bc05` |
+
+| | |
+|---|---|
+| **Producing commit** | `ec30ae12ef` on `worker/bench-tail-cluster`. **If that SHA does not resolve, a rebase moved it and the blobs above are what to trust.** |
+| **Reproduction** | `HICASSO_ONLY=narrow node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` — **run twice at this instrument, exit 0 both times** |
+| **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium via Playwright), Windows 11 x64, 24 logical CPUs |
+| **Schedule** | unchanged — 5 rounds × 2 segments × (8 warm-up + 12 samples), three arms interleaved, **10 writes per timed window** |
+| **Arm-order guard** | **no refusal on either run**, tolerance 0.10, `contaminated? false`, `unchecked? false` |
+| **Verification** | **0 unverified of 6,030 writes, on each run** |
+| **Positive control** | predicted `1801 / 901 = 1.9989×` **before** the run; four measured ranges, all inside ±25%, all inside on **every round** |
+
+`HICASSO_ONLY` re-takes one row rather than four, deliberately: the mount rows
+and the broad row are untouched by the batching — the broad row passes a batch
+of one, which is the pre-batch window exactly — so re-taking them would replace
+sound published numbers with different ones for nothing. It is `hd8_run.cjs`'s
+`HD8_ONLY`, for that driver's reasons.
+
+To confirm a candidate commit carries this instrument:
+
+```bash
+P=implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+git rev-parse <candidate>:$P   # must print f4b09dc20712e45f44f9ec9339f8dd00ce51e8f7
+```
+
 The reproduction command was run **at this commit, on a clean working tree**,
 and the figures below are that run's. A second, independent five-round run of
 the identical instrument is published beside them; where the two disagree, the
@@ -125,8 +166,18 @@ reflects back to `[0 1]`, at every sample index, for ever, so a two-arm plan
 runs in one order and *both orders* is a claim it cannot support. Keeping
 `:ctl-2x` inside the interleave — which is where rf2-2rtt6.2 puts it — means
 this entry never forms a two-arm plan. The property is **asserted at boot**, in
-both directions (degenerate at 2, varied at 3), and the run refuses to measure
-if either assertion fails.
+both directions, and the run refuses to measure if either assertion fails.
+
+**That defect has since been repaired** (PR #7267): at `k = 2` the reflection is
+dropped and the plain rotation alternates, which is every order two arms have.
+The three-arm plan is kept regardless — it is what every row on this page was
+measured under, and the schedule an arm runs is part of its window. The boot
+assertion now checks the *repaired* property as a canary. **It was not updated
+when the repair landed, and the consequence was not cosmetic: the assertion went
+false, `-main` refused to measure, and this page's reproduction command exited 1
+before taking a single sample — from PR #7267 until rf2-zb3qg found it. The
+figures above were unaffected (they predate the repair) but were not
+reproducible at HEAD for that window.**
 
 **`install-adapter!` is once per process** (Spec 006 §Single adapter per
 process), so each round runs two segments — destroy the adapter, install the
@@ -159,7 +210,8 @@ rather than as a winner.
 | **M1 mount** — 901 el, 300 boundaries | **1.2301×** | 1.1099 – 1.3538 | 1.3065 · 1.1417 · 1.2388 · 1.1099 · 1.3538 | **UIx slower**, disjoint from 1.0 |
 | **M2 mount** — 51 el, 12 fields · *diagnostic* | 1.0539× | 0.8572 – 1.4286 | 1.4286 · 0.8572 · 0.8572 · 1.0550 · 1.0714 | **straddles 1.0 — indistinguishable** |
 | **bulk broad** — one commit all 300 read | **0.6239×** | 0.4701 – 0.7857 | 0.7172 · 0.6046 · 0.5417 · 0.7857 · 0.4701 | **UIx faster**, disjoint from 1.0 |
-| **bulk narrow** — one commit exactly one reads | 1.1556× | 1.0417 – 1.2500 | 1.1111 · 1.2500 · 1.2500 · 1.0417 · 1.1250 | UIx slower — **but see the stability note** |
+| **bulk narrow** — 10 commits, each read by exactly one boundary, one window | **1.1540×** | 1.0570 – 1.2053 | 1.2053 · 1.1515 · 1.1860 · 1.0570 · 1.1700 | **UIx slower**, disjoint from 1.0 — *re-taken on a batched window, see below* |
+| ~~bulk narrow, **unbatched window** (superseded)~~ | ~~1.1556×~~ | ~~1.0417 – 1.2500~~ | ~~1.1111 · 1.2500 · 1.2500 · 1.0417 · 1.1250~~ | ~~UIx slower, but did not stably resolve across runs~~ |
 
 Both arms against the floor, for context:
 
@@ -168,7 +220,8 @@ Both arms against the floor, for context:
 | M1 mount | 4.352× [4.063 – 4.625] | 5.343× [4.947 – 5.944] |
 | M2 mount | 2.102× [1.625 – 2.800] | 2.261× [1.714 – 4.000] |
 | bulk broad | 7.443× [7.000 – 8.000] | 4.607× [3.667 – 5.500] |
-| bulk narrow | 1.820× [1.500 – 2.000] | 2.117× [1.667 – 2.500] |
+| bulk narrow *(batched window)* | 1.880× [1.8167 – 1.9259] | 2.168× [2.0357 – 2.2500] |
+| ~~bulk narrow *(unbatched, superseded)*~~ | ~~1.820× [1.500 – 2.000]~~ | ~~2.117× [1.667 – 2.500]~~ |
 
 ### The denominator reproduces rf2-2rtt6.2
 
@@ -199,13 +252,14 @@ same round, touching neither floor — is therefore reported beside it:
 | M1 mount | 1.2301 [1.1099 – 1.3538] | 1.2028 [1.0405 – 1.3538] | yes — same verdict, 2% apart on the mean |
 | M2 mount | 1.0539 [0.8572 – 1.4286] | 0.9989 [0.8571 – 1.1429] | yes — both straddle |
 | bulk broad | 0.6239 [0.4701 – 0.7857] | 0.5582 [0.4483 – 0.6500] | yes — same verdict, both far from 1.0 |
-| bulk narrow | 1.1556 [1.0417 – 1.2500] | 1.1972 [1.1111 – 1.2500] | yes |
+| bulk narrow *(batched window)* | **1.1540** [1.0570 – 1.2053] | **1.1714** [1.0962 – 1.2316] | yes — same verdict, both disjoint from 1.0 |
+| ~~bulk narrow *(unbatched, superseded)*~~ | ~~1.1556 [1.0417 – 1.2500]~~ | ~~1.1972 [1.1111 – 1.2500]~~ | ~~yes~~ |
 
 The two estimators agree on the verdict of every row, which is the evidence that
 the floor normalisation is doing its job rather than injecting the quantisation
 it is exposed to.
 
-### Stability across runs — and the one row that is not stable
+### Stability across runs
 
 The identical instrument was run twice, five rounds each, minutes apart:
 
@@ -214,20 +268,56 @@ The identical instrument was run twice, five rounds each, minutes apart:
 | M1 mount | **1.2301** [1.110 – 1.354] disjoint | 1.2103 [1.021 – 1.316] disjoint | **yes** |
 | M2 mount | 1.0539 [0.857 – 1.429] straddles | 1.1000 [1.000 – 1.458] straddles | **yes** |
 | bulk broad | **0.6239** [0.470 – 0.786] disjoint | 0.5682 [0.444 – 0.691] disjoint | **yes** |
-| bulk narrow | 1.1556 [1.042 – 1.250] disjoint | 1.0405 [0.750 – 1.333] **straddles** | **NO** |
+| **bulk narrow** *(batched window, rf2-zb3qg)* | **1.1540** [1.0570 – 1.2053] disjoint | **1.1656** [1.1091 – 1.2942] disjoint | **yes** |
+| ~~bulk narrow *(unbatched, superseded)*~~ | ~~1.1556 [1.042 – 1.250] disjoint~~ | ~~1.0405 [0.750 – 1.333] **straddles**~~ | ~~**NO**~~ |
 
-**The narrow row does not settle.** Four estimates of it (two runs × two
-estimators) read 1.0405, 1.1556, 1.1738, 1.1972 — the *direction* is the same
-every time and UIx is the slower arm — but whether the range clears 1.0 depends
-on the run, and one of the four has a minimum of exactly `1.0000`, which is the
-clamp's signature and not a tie. Every leg of that row is three to five quanta.
-**The narrow row is therefore published as clamp-limited and NOT as a resolved
-threshold**: read it as *UIx is somewhere between indistinguishable and ~1.2×
-slower on a narrow write*, and do not judge a candidate red on a margin finer
-than that. Lifting it would need a bigger sample per window — batching k writes
-into one clock window, as rf2-2rtt6.4 did for its own clamped rows — which is a
-change to the instrument, not to the witness, and is left as a stated open item
-rather than made silently.
+#### The narrow row was clamp-limited, and now resolves
+
+**As first published it did not settle.** Four estimates (two runs × two
+estimators) read 1.0405, 1.1556, 1.1738, 1.1972 — the *direction* was the same
+every time and UIx was the slower arm — but whether the range cleared 1.0
+depended on the run, and one of the four had a minimum of exactly `1.0000`,
+which is the clamp's signature and not a tie. Every leg of that row was three to
+five quanta. It was therefore published as **clamp-limited and not as a resolved
+threshold**, with the remedy named as an open item: batch *k* writes into one
+clock window, a change to the *instrument* and not to the witness.
+
+**rf2-zb3qg made that change and re-ran the row.** Ten single-cell commits now
+share one clock, each with its own cell and its own value. Every leg is 21 to 65
+quanta instead of 3 to 5, so the quantum is about 2% of a reading rather than
+25% of it. All four estimates now clear 1.0:
+
+| estimate | before (unbatched) | after (10 commits per window) |
+|---|---|---|
+| run 1, floor-normalised | 1.1556 [1.0417 – 1.2500] | **1.1540 [1.0570 – 1.2053]** |
+| run 1, raw cross-segment | 1.1972 [1.1111 – 1.2500] | **1.1714 [1.0962 – 1.2316]** |
+| run 2, floor-normalised | 1.0405 [0.7500 – 1.3330] ← *straddles* | **1.1656 [1.1091 – 1.2942]** |
+| run 2, raw cross-segment | 1.1738 | **1.1447 [1.1091 – 1.1827]** |
+
+**Lowest bound across all four is 1.0570.** The row is now published as a
+resolved threshold: *UIx-on-subs is roughly 1.15× slower than Reagent-on-subs on
+a narrow write, and the two are distinguishable.* The instruction not to judge a
+candidate red on a finer margin than "indistinguishable to ~1.2×" is withdrawn —
+the margin the row now supports is the range above.
+
+**The centre did not move; the noise did.** The batched mean (1.1540 / 1.1656)
+sits inside the spread of the four unbatched estimates, which is the outcome that
+says the batching changed the *resolution* and not the *quantity*. The per-commit
+cost confirms it independently: dividing each batched sample by ten gives floor
+2.1–3.0 quanta, `reagent-subs` 4.75–5.55, `uix-subs` 5.70–6.45 — the same legs
+the unbatched row measured directly (2–3, 4–4.5, 4.5–5).
+
+**What the batch costs, stated rather than assumed.** A batched window verifies
+all ten writes after the clock stops rather than each in its own turn, so an
+early commit gets up to nine extra microtask turns before it is read back. That
+is a difference of degree on a tolerance the instrument already grants — the
+unbatched window tolerates exactly one such turn by construction, because that
+turn *is* the harness yield. It is not a new blind spot: the fault the read-back
+exists to catch is a commit React has parked at the default lane, which is
+scheduled through a `MessageChannel` — a *macrotask* — and no number of
+microtasks lets it land inside the window. A parked commit is still parked when
+the read-backs run, and all ten would read unverified. **0 of 6,030 did, on each
+run.**
 
 ### Clock resolution, per row
 
@@ -239,7 +329,8 @@ Stated rather than smoothed. One sample, p50 milliseconds, expressed in Chrome's
 | M1 mount | 8 – 10 | 33 – 46 | 39 – 54 | yes |
 | M2 mount | 2 – 4 | 6 – 7 | 6 – 8 | **diagnostic only** |
 | bulk broad | 2.5 – 4 | 20 – 29 | 11 – 13 | yes on the substrate legs; the floor is coarse, which is why the raw estimator is published beside the normalised one |
-| bulk narrow | 2 – 3 | 4 – 4.5 | 4.5 – 5 | **clamp-limited** — see above |
+| **bulk narrow** — 10 commits a sample | 21 – 30 | 47.5 – 55.5 | 57 – 64.5 | **yes** |
+| ~~bulk narrow — 1 commit a sample (superseded)~~ | ~~2 – 3~~ | ~~4 – 4.5~~ | ~~4.5 – 5~~ | ~~**clamp-limited**~~ |
 
 ## What the convergence changed
 
@@ -252,7 +343,7 @@ matter*, and it is not small.
 | large-list mount | W1: **1.057×** [0.907 – 1.156] — indistinguishable | M1: **1.2301×** [1.110 – 1.354] — UIx slower, disjoint | **verdict flips**: an indistinguishable row becomes a resolved one |
 | ordinary-form mount | W3: **0.893×** [0.843 – 0.956] — UIx faster, disjoint, published as a threshold | M2: **1.0539×** [0.857 – 1.429] — indistinguishable, graded diagnostic | **verdict flips**, and so does the grade |
 | broad commit | U-broad: **0.838×** [0.760 – 0.953] — UIx faster | bulk broad: **0.6239×** [0.470 – 0.786] — UIx faster | same direction, **much larger margin** |
-| narrow commit | U-narrow: **1.536×** [1.226 – 1.876] — UIx slower, disjoint | bulk narrow: 1.1556× / 1.0405× — direction the same, magnitude far smaller, **does not stably resolve** | **strength collapses** |
+| narrow commit | U-narrow: **1.536×** [1.226 – 1.876] — UIx slower, disjoint | bulk narrow: **1.1540×** [1.0570 – 1.2053] — UIx slower, disjoint | same direction and both resolve, but **the margin roughly halves** |
 
 None of this makes rf2-2rtt6.4 wrong. Each of its ratios is still a ratio
 between two arms measured in one run, on one page, through one sub graph, in
@@ -305,11 +396,21 @@ can honestly be held to it.)
 | M1 mount | 1.9989× | 1.863× [1.750 – 2.000] ✅ | 1.979× [1.895 – 2.000] ✅ | 1801 / 901 elements |
 | M2 mount | 1.9412× | 1.803× [1.600 – 2.000] ✅ | 1.731× [1.333 – 2.000] ✅ | 99 / 51 elements |
 | bulk broad | 1.9989× | 1.817× [1.667 – 2.000] ✅ | 1.923× [1.667 – 2.250] ✅ | 1801 / 901 elements |
-| bulk narrow | 1.9989× | 2.013× [1.667 – 2.400] ✅ | 1.867× [1.667 – 2.000] ✅ | 1801 / 901 elements |
+| **bulk narrow** *(batched, run 1)* | 1.9989× | 1.976× [1.917 – 2.038] ✅ | 1.949× [1.821 – 2.000] ✅ | 1801 / 901 elements |
+| **bulk narrow** *(batched, run 2)* | 1.9989× | 1.941× [1.905 – 1.977] ✅ | 1.935× [1.814 – 2.000] ✅ | 1801 / 901 elements |
+| ~~bulk narrow *(unbatched, superseded)*~~ | ~~1.9989×~~ | ~~2.013× [1.667 – 2.400] ✅~~ | ~~1.867× [1.667 – 2.000] ✅~~ | ~~1801 / 901 elements~~ |
 
 Eight controls, eight passes, and seven of the eight sit **below** their
 prediction — the direction a fixed per-root term predicts, and the same
 direction rf2-2rtt6.2 and rf2-2rtt6.4 both recorded.
+
+The narrow row's controls were **predicted before the run** at `1801 / 901 =
+1.9989×` and re-measured on the batched window; all four ranges above sit
+entirely inside the ±25% band `[1.4992 – 2.4986]`. They therefore pass under the
+**strict** every-round-inside reading as well as the overlap rule they were
+adjudicated under — which matters because `lane/control-verdict` implements the
+overlap rule and **rf2-egdaq** is the open question of whether to tighten it.
+Nothing here tightens it; the narrow row simply would not be affected either way.
 
 ## The guard refused this arm, twice, and the arm was repaired
 
@@ -375,11 +476,14 @@ first cut produced looked entirely plausible.
 
 ## Open items — stated, not swept up
 
-- **The narrow row is clamp-limited and does not stably resolve.** Lifting it
-  needs k writes to a clock window. That is a change to the instrument and not
-  to the witness, so it can be made without disturbing the convergence — but it
-  is a change, and rf2-2rtt6.2 has a recorded refusal from batching *mounts*, so
-  the guard must be re-run against it rather than assumed.
+- ~~**The narrow row is clamp-limited and does not stably resolve.**~~
+  **CLOSED by rf2-zb3qg.** Ten writes now share one clock; both independent runs
+  resolve, and **the guard did not refuse either of them** (tolerance 0.10,
+  `contaminated? false`, `unchecked? false`). rf2-2rtt6.2's recorded refusal was
+  from batching *mounts* on the 51-element form, and it was checked rather than
+  assumed: the worst phase stratum across all six arms of the batched narrow row
+  reads 1.038×–1.089× last-third over first-third, ranges overlapping. The
+  tolerance was not touched.
 - **The 51-element form row cannot be lifted the same way here.** rf2-2rtt6.2
   tried batching mounts on this exact witness and the guard refused the whole
   run (exit 2, all four arms 3.2×–5.4× last-third over first-third, ranges

--- a/docs/design/hicasso/studio/p0-ratom-spine-narrow-write.md
+++ b/docs/design/hicasso/studio/p0-ratom-spine-narrow-write.md
@@ -374,6 +374,13 @@ bench run and a gate run raced one compile cache, and a figure taken
 through the fallback would not have been comparable with one taken through
 the lane.
 
+The template is now `:hicasso-bench` unconditionally and **there is no
+environment override**. `HN_BASE_BUILD` went with the fallback; a reader
+working from notes that mention it should know that setting it today does
+nothing. No figure on this page depended on either knob — every row was
+taken through `:hicasso-bench`, which is what the fallback selected once
+the lane's build id existed.
+
 ---
 
 ## Superseded

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
@@ -165,55 +165,78 @@
 
             ;; ---- the positive control, then the lowering check -------------
             (let [pc (record! :positive-control (rows/positive-control! 3 control-sampling))]
-              (when-not (:within? pc)
-                (js/console.warn
-                  (str ";; HD8 WARNING — the positive control missed its prediction "
-                       "(predicted " (:predicted pc) ", measured " (pr-str (:measured pc))
-                       "). Every clock figure in this run is suspect.")))
-              (-> (if (rows/donor-run? which)
-                    (rows/lowering-works! which)
-                    ;; The donor rungs are not in this run's arm set (see
-                    ;; `arm-ids-for`), so there is no lowering here to check
-                    ;; and a check that trivially passed would be worse than
-                    ;; no check at all. Recorded as inapplicable rather than
-                    ;; as green.
-                    (js/Promise.resolve {:lowered? true :applicable? false
-                                         :why (str "the donor arms are not REACTIVE under this "
-                                                   "run's ratom spine, so a lowering check here "
-                                                   "would fail for an unrelated reason; the uix "
-                                                   "run is where this question is asked")}))
-                  (.then
-                    (fn [low]
-                      (record! :lowering-check low)
-                      (if-not (:lowered? low)
-                        (do (fail! (str "rung 2's event-vector lowering did not reach the DOM: "
-                                        (pr-str low) " — the rung-2 clock would be pricing a "
-                                        "lowering that produces a closure nobody can call"))
-                            (done!)
-                            nil)
+              (if-not (:within? pc)
+                ;; FAIL CLOSED. This used to `console.warn` and then measure
+                ;; everything anyway, so a run whose instrument could not see
+                ;; a change its own arithmetic PREDICTS still published a full
+                ;; clock table and still exited 0 — and the warning sat in a
+                ;; console log nobody reads beside numbers that looked fine
+                ;; (rf2-f5roa, from the PR #7263 audit). A control is the row
+                ;; that separates `this arm is cheap` from `the instrument is
+                ;; not running`; if it misses, nothing measured after it is a
+                ;; measurement, so nothing after it runs.
+                (do (fail! (str "the positive control missed its prediction — predicted "
+                                (:predicted pc) "x, measured " (pr-str (:measured pc))
+                                " against a tolerance of " (:tolerance pc)
+                                ". The instrument did not see a change its own arithmetic "
+                                "says it must, so no clock figure in this run would be "
+                                "reportable and none was taken."))
+                    (done!))
+                (-> (if (rows/donor-run? which)
+                      (rows/lowering-works! which)
+                      ;; The donor rungs are not in this run's arm set (see
+                      ;; `arm-ids-for`), so there is no lowering here to check
+                      ;; and a check that trivially passed would be worse than
+                      ;; no check at all. Recorded as inapplicable rather than
+                      ;; as green.
+                      (js/Promise.resolve {:lowered? true :applicable? false
+                                           :why (str "the donor arms are not REACTIVE under this "
+                                                     "run's ratom spine, so a lowering check here "
+                                                     "would fail for an unrelated reason; the uix "
+                                                     "run is where this question is asked")}))
+                    (.then
+                      (fn [low]
+                        (record! :lowering-check low)
+                        (if-not (:lowered? low)
+                          (do (fail! (str "rung 2's event-vector lowering did not reach the DOM: "
+                                          (pr-str low) " — the rung-2 clock would be pricing a "
+                                          "lowering that produces a closure nobody can call"))
+                              (done!)
+                              nil)
 
-                        ;; ---- the clocks ------------------------------------
-                        (do
-                          (doseq [wit rows/witnesses]
-                            (record-row! (keyword (str "mount-" (name (:id wit))))
-                                         (rows/measure-mount! wit arm-ids rounds mount-sampling)))
-                          ;; The harness microtask, priced before the write rows
-                          ;; and outside every one of their windows. A
-                          ;; microtask-scheduled arm's window does not contain
-                          ;; that turn and its rivals' do (rf2-b69lw), so the
-                          ;; size of the asymmetry is published beside the rows
-                          ;; rather than argued about after them.
-                          (-> (rows/yield-cost! write-sampling)
-                              (.then (fn [yc]
-                                       (record! :yield-cost yc)
-                                       (rows/measure-write! write-ids which :narrow rounds write-sampling)))
-                              (.then (fn [r]
-                                       (record-row! :write-narrow r)
-                                       (rows/measure-write! write-ids which :bulk rounds write-sampling)))
-                              (.then (fn [r] (record-row! :write-bulk r) (done!))))))))
-                  (.catch (fn [e]
-                            (fail! (str "the run threw: " (.-message e) "\n" (.-stack e)))
-                            (done!)))))))))))
+                          ;; ---- the clocks ----------------------------------
+                          (do
+                            (doseq [wit rows/witnesses]
+                              (record-row! (keyword (str "mount-" (name (:id wit))))
+                                           (rows/measure-mount! wit arm-ids rounds mount-sampling))
+                              ;; A teardown that threw is checked BETWEEN rows,
+                              ;; not swallowed until the end: an arm whose
+                              ;; unmount failed leaves its watches and its
+                              ;; caches standing, and the next row is then
+                              ;; measured on a page that is carrying them
+                              ;; (rf2-f5roa, from the PR #7263 audit).
+                              (rows/assert-teardown-clean! (str "mount-" (name (:id wit)))))
+                            ;; The harness microtask, priced before the write rows
+                            ;; and outside every one of their windows. A
+                            ;; microtask-scheduled arm's window does not contain
+                            ;; that turn and its rivals' do (rf2-b69lw), so the
+                            ;; size of the asymmetry is published beside the rows
+                            ;; rather than argued about after them.
+                            (-> (rows/yield-cost! write-sampling)
+                                (.then (fn [yc]
+                                         (record! :yield-cost yc)
+                                         (rows/measure-write! write-ids which :narrow rounds write-sampling)))
+                                (.then (fn [r]
+                                         (record-row! :write-narrow r)
+                                         (rows/assert-teardown-clean! "write-narrow")
+                                         (rows/measure-write! write-ids which :bulk rounds write-sampling)))
+                                (.then (fn [r]
+                                         (record-row! :write-bulk r)
+                                         (rows/assert-teardown-clean! "write-bulk")
+                                         (done!))))))))
+                    (.catch (fn [e]
+                              (fail! (str "the run threw: " (.-message e) "\n" (.-stack e)))
+                              (done!))))))))))))
 
 (defn ^:export -main []
   (try

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
@@ -733,8 +733,31 @@
 
 (defn release-write-arms! [mounts]
   (doseq [{:keys [arm handle container]} mounts]
-    (try ((:unmount arm) handle) (catch :default _ nil))
+    (try ((:unmount arm) handle)
+         (catch :default e
+           (lane/teardown-failure! (str "release-write-arms! " (:id arm)) e)))
     (.remove container)))
+
+(defn assert-teardown-clean!
+  "Throw if any teardown has failed since the last check.
+
+  Called BETWEEN rows rather than at the end of the run, because that is
+  where the damage is done: an arm whose unmount threw has left its React
+  root, its watches and its subscription caches standing, and every row
+  measured after it is measured on a page carrying them. The throw lands
+  in `hd8-app`'s existing `.catch`, which records `HD8_ERROR` and exits 1
+  — the same fail-closed path parity and the lowering check already take
+  (rf2-f5roa, from the PR #7263 audit)."
+  [after]
+  (let [fs (lane/drain-teardown-failures!)]
+    (when (seq fs)
+      (throw (ex-info (str "teardown FAILED after " after
+                           " — an arm did not unmount, so its React root, watches and "
+                           "subscription caches are still standing and every row after "
+                           "this one would be measured on a page carrying them: "
+                           (pr-str fs))
+                      {:after after :failures fs})))
+    nil))
 
 (defn timed-write!
   "Run `ops` — a seq of `[i val probes]` — as ONE measured window: each
@@ -1046,7 +1069,8 @@
         root      (react-dom-client/createRoot container)
         cleanup!  (fn []
                     (try (react-dom/flushSync (fn [] (.unmount root)))
-                         (catch :default _ nil))
+                         (catch :default e
+                           (lane/teardown-failure! "lowering-works! cleanup" e)))
                     (.remove container)
                     (reseed! :donor-r2))]
     (react-dom/flushSync

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
@@ -57,6 +57,7 @@ const path = require('node:path');
 // arm-order guard for the repository, never a second copy per lane.
 const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs');
 const guard = require('../../freehand/bench/order_guard.cjs');
+const { watchPage } = require('../../freehand/bench/sentinel.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 const REPO = path.resolve(IMPL, '..');
@@ -100,6 +101,13 @@ if (RUNS.length === 0) {
 // number is NAMED here rather than defaulted, because an unnamed tolerance is
 // the anonymous-ceiling defect wearing a different hat.
 const TOLERANCE = Number(process.env.HD8_TOLERANCE || 0.35);
+
+// The page's own budget, for the case where the page is ALIVE and simply has
+// not finished. Six rounds of every witness across three adapters is minutes,
+// not seconds. It is no longer the budget a page ERROR is reported against —
+// `sentinel.cjs` races this against the page dying, so a throw is reported in
+// the second it happens instead of twenty minutes later (rf2-f5roa).
+const SENTINEL_TIMEOUT_MS = 20 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Build + serve
@@ -170,33 +178,43 @@ async function runOne(chromium, run) {
   // registry state at module scope; reusing a context would carry the
   // previous adapter's installation into the next run's measurement.
   const browser = await chromium.launch();
-  const page = await browser.newPage();
-  const lines = [];
-  page.on('console', (m) => {
-    const t = m.text();
-    if (t.startsWith(';; HD8')) lines.push(t);
-  });
-  page.on('pageerror', (e) => console.error(`[hd8:${run.id}] page error:`, e.message));
-  // `'commit'`, not `'load'` (rf2-p9fa3). `hd8-app/-main` is this bundle's
-  // `:init-fn`, so the parity pass and every mount row run INSIDE the
-  // `<script>` — `load` cannot fire until the benchmark has yielded, which
-  // is exactly what the sentinel below waits for against a budget twenty
-  // times larger.
-  await navigate(page, `http://127.0.0.1:${PORT}/${run.query}`, {
-    waitUntil: 'commit',
-    timeoutMs: NAV_TIMEOUT_MS,
-    budget: 'the 20-minute wait for `window.HD8_DONE`',
-  });
-  await page.waitForFunction('window.HD8_DONE === true || window.HD8_ERROR', null, {
-    timeout: 20 * 60 * 1000,
-  });
-  const err = await page.evaluate('window.HD8_ERROR || null');
-  const results = await page.evaluate('window.HD8_RESULTS || {}');
-  const samples = await page.evaluate('window.HD8_SAMPLES || []');
-  const summary = await page.evaluate('window.HD8_SUMMARY || {}');
-  const userAgent = await page.evaluate('navigator.userAgent');
-  await browser.close();
-  return { id: run.id, why: run.why, err, results, samples, summary, userAgent, lines };
+  try {
+    const page = await browser.newPage();
+    const lines = [];
+    page.on('console', (m) => {
+      const t = m.text();
+      if (t.startsWith(';; HD8')) lines.push(t);
+    });
+    // Watching starts BEFORE the navigation, because the fault this catches
+    // most often — a contaminated Shadow cache throwing out of ReactDOM —
+    // happens during bundle execution, which is inside the navigation. The
+    // driver used to merely log it here and then wait the full twenty minutes
+    // for a sentinel the throw had already made unreachable (rf2-f5roa).
+    const watch = watchPage(page, `hd8:${run.id}`);
+    // `'commit'`, not `'load'` (rf2-p9fa3). `hd8-app/-main` is this bundle's
+    // `:init-fn`, so the parity pass and every mount row run INSIDE the
+    // `<script>` — `load` cannot fire until the benchmark has yielded, which
+    // is exactly what the sentinel below waits for against a budget twenty
+    // times larger.
+    await navigate(page, `http://127.0.0.1:${PORT}/${run.query}`, {
+      waitUntil: 'commit',
+      timeoutMs: NAV_TIMEOUT_MS,
+      budget: 'the 20-minute wait for `window.HD8_DONE`',
+    });
+    await watch.race('window.HD8_DONE === true || window.HD8_ERROR', {
+      timeoutMs: SENTINEL_TIMEOUT_MS,
+      budget: 'the 20-minute wait for `window.HD8_DONE`',
+    });
+    const err = await page.evaluate('window.HD8_ERROR || null');
+    const results = await page.evaluate('window.HD8_RESULTS || {}');
+    const samples = await page.evaluate('window.HD8_SAMPLES || []');
+    const summary = await page.evaluate('window.HD8_SUMMARY || {}');
+    const userAgent = await page.evaluate('navigator.userAgent');
+    watch.dispose();
+    return { id: run.id, why: run.why, err, results, samples, summary, userAgent, lines };
+  } finally {
+    await browser.close();
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -283,9 +301,19 @@ function crossRun(runs) {
   console.log(
     `;;   reproduce   ${ONLY ? `HD8_ONLY=${ONLY} ` : ''}node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs`
   );
-  console.log(`;;   build       shadow-cljs release freehand-release (:advanced, goog.DEBUG false)`);
+  console.log(`;;   build       shadow-cljs release ${BUILD_ID} (:advanced, goog.DEBUG false)`);
   console.log(`;;   node        ${process.version}`);
   console.log(`;;   runs        ${RUNS.map((r) => r.id).join(', ')}${ONLY ? `  (HD8_ONLY=${ONLY})` : ''}`);
+  // THE EFFECTIVE TOLERANCE, on the record beside the figures it adjudicated.
+  // It was not printed, and it does not equal `order_guard`'s own default:
+  // the guard defaults to 0.10 and this driver passes 0.35, for the reason
+  // above. An adjudication whose threshold a reader has to go and find in the
+  // source — or, worse, that an unrecorded `HD8_TOLERANCE=` in someone's shell
+  // moved without trace — is the anonymous-ceiling defect again (rf2-f5roa).
+  console.log(
+    `;;   guard tol   ${TOLERANCE}  (order_guard default 0.10; this driver's stated ` +
+      `choice 0.35${process.env.HD8_TOLERANCE ? `; OVERRIDDEN by HD8_TOLERANCE=${process.env.HD8_TOLERANCE}` : ''})`
+  );
 
   build();
   const server = serve();
@@ -295,7 +323,16 @@ function crossRun(runs) {
     const { chromium } = require('playwright');
     for (const r of RUNS) {
       console.error(`[hd8] run ${r.id} — ${r.why}`);
-      const out = await runOne(chromium, r);
+      let out;
+      try {
+        out = await runOne(chromium, r);
+      } catch (e) {
+        // A page that died is a HARD failure and it stops the sweep: the
+        // remaining runs would each spend their own budget re-discovering a
+        // broken bundle, and no figure from this one is a measurement.
+        hardFail = `${r.id}: ${e.message}`;
+        break;
+      }
       runs.push(out);
       if (out.err) hardFail = `${r.id}: ${out.err}`;
     }

--- a/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
@@ -212,12 +212,55 @@
     {:ms     (- (now-ms) t0)
      :mounts (mapv (fn [c h] {:arm arm :container c :handle h}) containers @handles)}))
 
+;; ---------------------------------------------------------------------------
+;; Teardown, and why a swallowed one is a measurement fault
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private teardown-failures (atom []))
+
+(defn teardown-failure!
+  "Record a release/unmount that threw, and answer nil.
+
+  Every teardown in this lane is wrapped, because a release that throws
+  half way through must still detach the container and must not abort the
+  round. What it must NOT do is vanish, which is what `(catch :default _
+  nil)` did at four sites (rf2-f5roa, from the PR #7263 and #7268 audits).
+
+  An unmount that threw has left the arm's subscriptions, its watches and
+  its React root STANDING. The next row is then measured on a page that is
+  carrying them — more work, attributed to whatever arm happens to be
+  under the clock — and the run reports a precise number for a page that
+  is not the page under test. That is the same class as a write that never
+  reached the DOM, and it gets the same treatment: recorded at the site,
+  adjudicated by the caller, fatal."
+  [where e]
+  (swap! teardown-failures conj
+         {:where (str where)
+          :error (or (some-> e .-message) (str e))})
+  nil)
+
+(defn drain-teardown-failures!
+  "Answer every teardown failure recorded since the last drain, and clear.
+
+  Draining rather than accumulating so a caller can attribute a failure to
+  the row that was running when it happened, instead of to the end of the
+  run."
+  []
+  (let [fs @teardown-failures]
+    (reset! teardown-failures [])
+    fs))
+
 (defn release!
-  "Unmount and detach. Never timed."
+  "Unmount and detach. Never timed.
+
+  A throw is RECORDED ([[teardown-failure!]]) rather than swallowed, and
+  the container is detached either way — the record is what makes it
+  fatal, and detaching is what keeps one bad arm from leaving its DOM
+  behind for every row that follows."
   [{:keys [arm handle container]}]
   (when handle
     (try (react-dom/flushSync (fn [] ((:unmount arm) handle)))
-         (catch :default _ nil)))
+         (catch :default e (teardown-failure! (str "release! " (:id arm)) e))))
   (when container (.remove container))
   nil)
 
@@ -376,6 +419,125 @@
 
 (defn tally-value [t] (let [{:keys [of bad]} @t] {:writes of :unverified bad}))
 
+(defn verified-writes!
+  "Run `ops` — a seq of `[i val probes]` — as ONE measured window: each
+  writes, waits the way THIS ARM'S SCHEDULER requires and forces the arm's
+  own synchronous drain; the clock stops after the last of them; THEN every
+  `probes` cell of every op is read back out of the DOM.
+
+  Answers a promise of `{:ms :write-ms :gap-ms :force-ms :ok? :oks}`. `:ms`
+  is the WHOLE window; the three legs are sums across the `k` ops, so a
+  per-operation figure is any of them divided by `k`. `:oks` is one flag
+  per op and `:ok?` is all of them; the tally banks `k` writes.
+
+  ## ONE CLOCK OVER k OPERATIONS
+
+  Chrome clamps `performance.now()` to 100 µs. A witness whose window is
+  four quanta wide publishes a range that is mostly quantisation — the P0
+  converged bulk-narrow row read four estimates of 1.0405 / 1.1556 /
+  1.1738 / 1.1972 with one minimum of exactly 1.0000, which is the quantum
+  wearing a null result's clothes rather than a tie (rf2-zb3qg). Timing `k`
+  operations as ONE sample lifts the window clear of the clamp, and it is
+  NOT the same as summing `k` separately-clamped readings, which quantises
+  `k` times and adds the errors. [[mount-batch!]] does this for mounts and
+  `hd8-rows/window-of` proved it for HD-008's narrow write (rf2-9zysg);
+  this is that shape lifted into the shared lane rather than a third copy
+  of it.
+
+  ## WHY THE READ-BACK SURVIVES THE BATCHING
+
+  A batched window cannot verify each write in the turn its own drain ran
+  in, because there is only one clock. It verifies all `k` after the clock
+  stops — and that is not the weakening it looks like:
+
+    NO MACROTASK RUNS INSIDE THE WINDOW. Every turn between the first
+    write and the last drain is a MICROTASK. The fault this read-back
+    exists to catch is a commit React has PARKED at the default lane,
+    which is scheduled through the Scheduler's `MessageChannel` — a
+    MACROTASK — so it cannot land inside the window however many
+    microtasks pass. A parked commit is still parked when the read-backs
+    run, and all `k` read UNVERIFIED.
+
+  What the batch relaxes is microtask-scale lateness: an early op gets up
+  to `k - 1` extra microtask turns before it is read back. The unbatched
+  window already tolerates exactly one such turn by construction — that IS
+  the yield — so this is a difference of degree on a tolerance the
+  instrument already grants, not a new blind spot. It belongs in the row's
+  stated method, and every caller that batches states it.
+
+  Each op must therefore carry its OWN value and its OWN cell, so that no
+  read-back can be satisfied by a neighbour's commit. That is the caller's
+  obligation and it is why `ops` carries `val` per op rather than one
+  value for the batch.
+
+  ## THE WAIT BELONGS TO THE ARM'S SCHEDULER, NOT TO THE HARNESS
+
+  See [[verified-write!]]. In the yielding shape the yield is preserved PER
+  OPERATION and never batched away: the next write starts in the turn the
+  previous drain finished in, so a `k`-op window holds exactly `k` harness
+  turns rather than `2k`."
+  [t {:keys [arm container]} ops]
+  (let [ops        (vec ops)
+        verify-all (fn []
+                     (mapv (fn [[_ val probes]]
+                             (every? #(= (str val) (text-at container %)) probes))
+                           ops))
+        bank!      (fn [oks]
+                     (swap! t (fn [{:keys [of bad]}]
+                                {:of  (+ of (count oks))
+                                 :bad (+ bad (count (remove identity oks)))}))
+                     oks)
+        answer     (fn [ms write-ms gap-ms force-ms]
+                     (let [oks (verify-all)]
+                       (bank! oks)
+                       {:ms       ms
+                        :write-ms write-ms
+                        :gap-ms   gap-ms
+                        :force-ms force-ms
+                        :ok?      (every? identity oks)
+                        :oks      oks}))]
+    (if (= (:scheduler arm) :microtask)
+      ;; Write, then drain, with nothing between them: the substrate's queue
+      ;; is filled synchronously by the write and is still there when the
+      ;; drain opens its boundary, so the commit lands INSIDE the window.
+      ;; The whole batch is one synchronous run, so not even a microtask
+      ;; separates a drain from the next write.
+      ;;
+      ;; `:prev` starts at the window's own `t0` and every leg boundary IS a
+      ;; clock read the unbatched window already took — at k = 1 this is
+      ;; three `now-ms` calls in the same three places, which is what makes
+      ;; the general form exactly the special one.
+      (let [t0 (now-ms)
+            {:keys [prev write force]}
+            (reduce (fn [{:keys [prev write force]} [i val _]]
+                      ((:write! arm) i val)
+                      (let [w (now-ms)]
+                        ((:force! arm))
+                        (let [f (now-ms)]
+                          {:prev f :write (+ write (- w prev)) :force (+ force (- f w))})))
+                    {:prev t0 :write 0.0 :force 0.0}
+                    ops)]
+        (js/Promise.resolve (answer (- prev t0) write 0.0 force)))
+      (let [t0 (now-ms)]
+        (letfn [(run [remaining {:keys [prev write gap force] :as acc}]
+                  (if (empty? remaining)
+                    (js/Promise.resolve (answer (- prev t0) write gap force))
+                    (let [[i val _] (first remaining)]
+                      ((:write! arm) i val)
+                      (let [w (now-ms)]
+                        (-> (js/Promise.resolve nil)
+                            (.then (fn [_]
+                                     (let [g (now-ms)]
+                                       ((:force! arm))
+                                       (let [f (now-ms)]
+                                         (run (next remaining)
+                                              (assoc acc
+                                                     :prev  f
+                                                     :write (+ write (- w prev))
+                                                     :gap   (+ gap (- g w))
+                                                     :force (+ force (- f g)))))))))))))]
+          (run (seq ops) {:prev t0 :write 0.0 :gap 0.0 :force 0.0}))))))
+
 (defn verified-write!
   "Write, wait the way THIS ARM'S SCHEDULER requires, force the arm's own
   synchronous drain, stop the clock — THEN read the written cell back out
@@ -435,44 +597,19 @@
   verifies almost nothing: the recorded fault is a commit that landed
   outside the window, and a stale page can still have one fresh cell in
   it from the previous write. The rotating probe plus the far end of the
-  grid is the cheapest read that a partial commit cannot satisfy."
-  [t {:keys [arm container]} i val probes]
-  (let [verify! (fn [] (every? #(= (str val) (text-at container %)) probes))
-        bank!   (fn [ok?]
-                  (swap! t (fn [{:keys [of bad]}]
-                             {:of (inc of) :bad (if ok? bad (inc bad))}))
-                  ok?)]
-    (if (= (:scheduler arm) :microtask)
-      ;; Write, then drain, with nothing between them: the substrate's queue
-      ;; is filled synchronously by the write and is still there when the
-      ;; drain opens its boundary, so the commit lands INSIDE the window.
-      (let [t0 (now-ms)]
-        ((:write! arm) i val)
-        (let [t1 (now-ms)]
-          ((:force! arm))
-          (let [t2  (now-ms)
-                ok? (verify!)]
-            (bank! ok?)
-            (js/Promise.resolve {:ms       (- t2 t0)
-                                 :write-ms (- t1 t0)
-                                 :gap-ms   0.0
-                                 :force-ms (- t2 t1)
-                                 :ok?      ok?}))))
-      (let [t0 (now-ms)]
-        ((:write! arm) i val)
-        (let [t1 (now-ms)]
-          (-> (js/Promise.resolve nil)
-              (.then (fn [_]
-                       (let [t2 (now-ms)]
-                         ((:force! arm))
-                         (let [t3  (now-ms)
-                               ok? (verify!)]
-                           (bank! ok?)
-                           {:ms       (- t3 t0)
-                            :write-ms (- t1 t0)
-                            :gap-ms   (- t2 t1)
-                            :force-ms (- t3 t2)
-                            :ok?      ok?}))))))))))
+  grid is the cheapest read that a partial commit cannot satisfy.
+
+  ## `k` OPERATIONS UNDER ONE CLOCK, AND WHY THE READ-BACK SURVIVES IT
+
+  [[verified-writes!]] is the general form and this is its `k = 1` case,
+  byte-for-byte: the same clock reads at the same boundaries, the same one
+  microtask between write and drain, the same read-back after the clock
+  stops. Chrome's 100 µs clamp is why the general form exists — a witness
+  whose window is 4 quanta wide publishes a range that is mostly quantum —
+  and `lane/mount-batch!` has done exactly this for mounts since the lane
+  landed."
+  [t mnt i val probes]
+  (verified-writes! t mnt [[i val probes]]))
 
 (defn bulk-probes
   "The probe seq for a BROAD write over `n` cells: a cell that ROTATES with

--- a/implementation/freehand/test/re_frame/bench/hicasso/lane_window_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/lane_window_dom_cljs_test.cljs
@@ -66,11 +66,22 @@
     (.appendChild js/document.body c)
     c))
 
+(defn- grid-container!
+  "A container holding `n` cells, all reading `\"old\"` — the smallest page
+  a BATCHED window can write `k` distinct cells into."
+  [n]
+  (let [c (js/document.createElement "div")]
+    (set! (.-innerHTML c)
+          (apply str (map (fn [i] (str "<span data-i=\"" i "\">old</span>")) (range n))))
+    (.appendChild js/document.body c)
+    c))
+
 (defn- commit!
   "Put `v` on the page. The ONLY way anything here reaches the DOM, so a
   window that does not reach it leaves the cell reading `\"old\"`."
-  [container v]
-  (set! (.-textContent (.querySelector container "[data-i=\"0\"]")) (str v)))
+  ([container v] (commit! container 0 v))
+  ([container i v]
+   (set! (.-textContent (.querySelector container (str "[data-i=\"" i "\"]"))) (str v))))
 
 ;; ---------------------------------------------------------------------------
 ;; The two scheduler families, as fakes
@@ -251,6 +262,137 @@
                        ;; asymmetry against the microtask window is a NUMBER
                        ;; rather than an assurance.
                        (is (number? (:gap-ms r)) ":gap-ms is measured, not asserted")
+                       (.remove c)
+                       (done)))
+              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+
+;; ---------------------------------------------------------------------------
+;; The batched window — k operations, ONE clock (rf2-zb3qg)
+;; ---------------------------------------------------------------------------
+
+(defn- recording-arm
+  "An arm that writes straight to the page and records the ORDER of its
+  turns, so a test can assert how many harness microtasks a window holds.
+
+  The write queues a microtask that records the fact; if the window yields
+  before draining, that microtask has run by the time `force!` is called."
+  [container seen]
+  {:id     :recording
+   :write! (fn [i v]
+             (.then (js/Promise.resolve nil) (fn [_] (swap! seen conj :microtask-ran)))
+             (swap! seen conj :wrote)
+             (commit! container i v)
+             nil)
+   :force! (fn [] (swap! seen conj :forced))})
+
+(defn- ops-for
+  "`k` ops, each its OWN cell and its OWN value — the caller obligation
+  `lane/verified-writes!` states, so no read-back can be satisfied by a
+  neighbour's commit."
+  [k]
+  (mapv (fn [i] [i (str "v" i) [i]]) (range k)))
+
+(deftest batched-yielding-window-holds-exactly-one-yield-per-operation
+  (testing "k ops under one clock keep the fixed yield PER OPERATION — the
+           window holds k harness turns, never 2k and never one for the
+           whole batch, which is what makes a batched figure comparable
+           with the unbatched one it supersedes"
+    (async done
+      (if-not (lane/browser?)
+        (do (is true off-browser) (done))
+        (let [k    3
+              c    (grid-container! k)
+              seen (atom [])
+              t    (lane/tally)]
+          (-> (lane/verified-writes! t {:arm (recording-arm c seen) :container c} (ops-for k))
+              (.then (fn [r]
+                       (is (= [:wrote :microtask-ran :forced
+                               :wrote :microtask-ran :forced
+                               :wrote :microtask-ran :forced]
+                              @seen)
+                           "exactly one microtask sits between each write and its own drain")
+                       (is (true? (:ok? r)))
+                       (is (= [true true true] (:oks r)) "one flag per op")
+                       ;; The tally counts OPERATIONS, not samples: a batched
+                       ;; row that banked one write per window would publish
+                       ;; `N unverified of M` with an M a tenth of the truth.
+                       (is (= {:writes k :unverified 0} (lane/tally-value t))
+                           "the tally banks every op in the batch")
+                       (.remove c)
+                       (done)))
+              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+
+(deftest a-batch-of-one-is-the-unbatched-window-exactly
+  (testing "k = 1 is the pre-batch window, turn for turn — this is what lets
+           the BROAD row pass a batch of one and not move, while the narrow
+           row batches"
+    (async done
+      (if-not (lane/browser?)
+        (do (is true off-browser) (done))
+        (let [c    (grid-container! 1)
+              seen (atom [])
+              t    (lane/tally)]
+          (-> (lane/verified-writes! t {:arm (recording-arm c seen) :container c} (ops-for 1))
+              (.then (fn [r]
+                       (is (= [:wrote :microtask-ran :forced] @seen)
+                           "one write, one yield, one drain — the unbatched shape")
+                       (is (true? (:ok? r)))
+                       (is (= {:writes 1 :unverified 0} (lane/tally-value t)))
+                       (.remove c)
+                       (done)))
+              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+
+(deftest a-batched-microtask-arm-puts-nothing-between-write-and-drain
+  (testing "the microtask family's batched window is one synchronous run —
+           not even a microtask separates a drain from the next write"
+    (async done
+      (if-not (lane/browser?)
+        (do (is true off-browser) (done))
+        (let [k    3
+              c    (grid-container! k)
+              seen (atom [])
+              t    (lane/tally)
+              arm  (assoc (recording-arm c seen) :scheduler :microtask)]
+          (-> (lane/verified-writes! t {:arm arm :container c} (ops-for k))
+              (.then (fn [r]
+                       ;; The first 2k entries are the WINDOW, and they are
+                       ;; write/drain/write/drain with nothing in between. The
+                       ;; arm's own queued microtasks appear only AFTER all of
+                       ;; them, which is the claim stated from the other side:
+                       ;; the batch is one synchronous run, so no microtask —
+                       ;; not even one the arm queued itself — can interleave
+                       ;; with it. Under the yielding shape those same three
+                       ;; turns land INSIDE the window, one per operation.
+                       (is (= [:wrote :forced :wrote :forced :wrote :forced]
+                              (vec (take (* 2 k) @seen)))
+                           "no turn of any kind between a write and its drain")
+                       (is (= [:microtask-ran :microtask-ran :microtask-ran]
+                              (vec (drop (* 2 k) @seen)))
+                           "and the arm's own microtasks ran only once the window had closed")
+                       (is (zero? (:gap-ms r)) ":gap-ms must be 0.0, not merely small")
+                       (is (= {:writes k :unverified 0} (lane/tally-value t)))
+                       (.remove c)
+                       (done)))
+              (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))
+
+(deftest a-batch-reports-every-op-that-missed-the-dom
+  (testing "an arm whose commits never land reads `k unverified of k`, not
+           one — the count a published row quotes is per OPERATION"
+    (async done
+      (if-not (lane/browser?)
+        (do (is true off-browser) (done))
+        (let [k   3
+              c   (grid-container! k)
+              t   (lane/tally)
+              ;; Writes nothing to the page at all: the window's milliseconds
+              ;; are real and they measure nothing.
+              arm {:id :never-commits :write! (fn [_i _v] nil) :force! (fn [] nil)}]
+          (-> (lane/verified-writes! t {:arm arm :container c} (ops-for k))
+              (.then (fn [r]
+                       (is (false? (:ok? r)))
+                       (is (= [false false false] (:oks r)))
+                       (is (= {:writes k :unverified k} (lane/tally-value t))
+                           "k unverified of k")
                        (.remove c)
                        (done)))
               (.catch (fn [e] (.remove c) (is false (str e)) (done)))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
@@ -59,15 +59,22 @@
 
   ## Three arms a segment, and why not two
 
-  rf2-ouwh8: `lane/slot-order` rotates and then REFLECTS, and at k=2 those
-  two operations cancel — `[0 1]` rotates to `[1 0]` and reflects back to
-  `[0 1]`, at every sample index, for ever. A two-arm plan therefore runs
-  in ONE order and `both orders` is a claim it cannot support. This entry
-  never forms a two-arm plan: `:ctl-2x` is measured INSIDE the interleave
-  as rf2-2rtt6.2 measures it, so every segment carries three arms and the
-  reflection does what the guard's self-test says it does. The property is
-  asserted at boot ([[slot-order-degenerates-at-2?]]) rather than trusted,
-  and the run refuses to measure if the assertion does not hold.
+  rf2-ouwh8: `lane/slot-order` rotated and then REFLECTED, and at k=2 those
+  two operations cancelled — `[0 1]` rotates to `[1 0]` and reflects back
+  to `[0 1]`, at every sample index, for ever. A two-arm plan therefore ran
+  in ONE order and `both orders` was a claim it could not support. This
+  entry was designed around that and never forms a two-arm plan: `:ctl-2x`
+  is measured INSIDE the interleave as rf2-2rtt6.2 measures it, so every
+  segment carries three arms.
+
+  THE DEFECT HAS SINCE BEEN REPAIRED (PR #7267): at k=2 the reflection is
+  dropped, and the plain rotation alternates, which is every order two arms
+  have. The three-arm plan is KEPT anyway — it is what every published row
+  on this page was measured under, and the schedule an arm runs is part of
+  its window. The boot assertion therefore checks the REPAIRED property
+  rather than the defect ([[slot-order-varies-at-2?]], which records what
+  went wrong when that distinction was missed), and the run still refuses
+  to measure if it does not hold.
 
   ## Two segments, and what makes the seam legitimate
 
@@ -724,14 +731,38 @@
 ;; The schedule's own precondition (rf2-ouwh8)
 ;; ---------------------------------------------------------------------------
 
-(defn- slot-order-degenerates-at-2?
-  "Does `slot-order` emit the SAME order at every sample index when there
-  are two arms? rf2-ouwh8 says yes — rotate `[0 1]` to `[1 0]`, reflect
-  back to `[0 1]` — and three copies of the rule carry it. Asserted here
-  rather than trusted, because this entry's whole `both orders` claim
-  rests on never forming a two-arm plan."
+(defn- slot-order-varies-at-2?
+  "Does `slot-order` emit MORE THAN ONE order at `k = 2`?
+
+  It does now, and that is a REVERSAL of what this function used to assert.
+  rf2-ouwh8 found that composing rotate-then-reflect at `k = 2` returns
+  `[0 1]` at every index — reversing a pair IS rotating it by one, so the
+  two operations cancel and a two-arm plan ran in ONE ORDER FOR EVER. This
+  entry was designed around that defect: it puts THREE arms in every
+  segment so it never forms a two-arm plan, and it asserted the degeneracy
+  at boot so the justification could not rot.
+
+  The defect was then REPAIRED (`e176fed976`, PR #7267): at `k = 2` the
+  reflection is dropped and the plain rotation alternates `[0 1]` and
+  `[1 0]`, which is every order two arms have. The assertion did rot — in
+  the other direction. It went on asserting the pre-repair behaviour, went
+  false the moment the repair landed, and this entry's `-main` refused to
+  measure anything from then until rf2-zb3qg found it. Every row of
+  `docs/design/hicasso/studio/p0-converged-witness-set.md` was
+  unreproducible at HEAD for that whole window: the repro command exited 1
+  before taking a sample.
+
+  So it asserts the REPAIRED property instead, as a canary — if `k = 2`
+  ever silently degenerates again, this entry says so at boot rather than
+  in a table.
+
+  THE THREE-ARM PLAN IS KEPT, and not because a two-arm plan would still
+  be single-order. It would not. It is kept because three arms is what
+  every published row on this page was measured under, and the schedule an
+  arm runs is part of its window: changing it would move numbers that
+  nothing here is re-running."
   []
-  (apply = (map #(guard/slot-order 2 %) (range 8))))
+  (> (count (distinct (map #(guard/slot-order 2 %) (range 8)))) 1))
 
 (defn- slot-order-varies-at-3?
   "And the three-arm plan this entry actually runs must NOT degenerate."
@@ -871,11 +902,13 @@
                            "was measured"))
           (lane/done!))
 
-      (not (slot-order-degenerates-at-2?))
-      (do (lane/fail! (str "slot-order no longer degenerates at k=2. rf2-ouwh8 is the reason "
-                           "this entry puts three arms in every segment; if the rule has "
-                           "changed, the schedule's justification has to be re-derived before "
-                           "anything here is measured"))
+      (not (slot-order-varies-at-2?))
+      (do (lane/fail! (str "slot-order has DEGENERATED at k=2 — it emits one order at every "
+                           "sample index, which is the rf2-ouwh8 defect returning. This entry "
+                           "runs three arms and is not itself affected, but the shared rule it "
+                           "takes its schedule from is, so nothing here is measured until the "
+                           "rule is repaired. The repair belongs to the schedule, never to the "
+                           "tolerance"))
           (lane/done!))
 
       (not (slot-order-varies-at-3?))

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
@@ -190,11 +190,21 @@
   "Tear down whatever adapter is installed, install this segment's,
   re-register the sub graph and stand the frame back up seeded.
 
-  All of it OUTSIDE every measured window."
+  All of it OUTSIDE every measured window.
+
+  A destroy that throws is RECORDED rather than swallowed. This is the
+  segment SEAM, so it is the worst place in the run to lose one: a frame
+  that did not tear down keeps its subscription caches and its watches,
+  and the very next thing that happens is the OTHER adapter being
+  installed over the top of them — after which every figure in the
+  segment is a figure for a page carrying the previous segment's
+  reactive graph (rf2-f5roa, from the PR #7268 audit)."
   [{:keys [adapter]}]
-  (try (rf/destroy-frame! v/subs-frame) (catch :default _ nil))
+  (try (rf/destroy-frame! v/subs-frame)
+       (catch :default e (lane/teardown-failure! "enter-segment! destroy-frame!" e)))
   (when (rf/current-adapter)
-    (try (rf/destroy-adapter!) (catch :default _ nil)))
+    (try (rf/destroy-adapter!)
+         (catch :default e (lane/teardown-failure! "enter-segment! destroy-adapter!" e))))
   (rf/init! adapter)
   (v/register!)
   (rf/make-frame {:id v/subs-frame})
@@ -437,8 +447,29 @@
 
 (defn- release-bulk-arms! [mounts]
   (doseq [{:keys [arm handle container]} mounts]
-    (try ((:unmount arm) handle) (catch :default _ nil))
+    (try ((:unmount arm) handle)
+         (catch :default e
+           (lane/teardown-failure! (str "release-bulk-arms! " (:id arm)) e)))
     (.remove container)))
+
+(defn- assert-teardown-clean!
+  "Throw if any teardown has failed since the last check.
+
+  Checked BETWEEN rows and segments, which is where the damage is done: a
+  React root or a frame that did not tear down is still holding its
+  watches and its caches when the next row is measured, and that row then
+  reports a precise number for a page that is not the page under test.
+  The throw lands in `-main`'s existing `.catch`, which records
+  `HICASSO_ERROR` and exits 1."
+  [after]
+  (let [fs (lane/drain-teardown-failures!)]
+    (when (seq fs)
+      (throw (ex-info (str "teardown FAILED after " after
+                           " — an arm or a frame did not tear down, so its caches and "
+                           "watches are still standing and every row after this one "
+                           "would be measured on a page carrying them: " (pr-str fs))
+                      {:after after :failures fs})))
+    nil))
 
 ;; ---------------------------------------------------------------------------
 ;; One round of one mount witness in one segment
@@ -480,26 +511,66 @@
 ;; One round of one bulk kind in one segment
 ;; ---------------------------------------------------------------------------
 
+(def ^:private narrow-batch-k
+  "How many narrow writes share ONE clock (rf2-zb3qg).
+
+  Chrome clamps `performance.now()` to 100 µs and the unbatched narrow row
+  sat one to one-and-a-half quanta above its own floor: every leg was 3–5
+  quanta (floor 2–3, reagent-subs 4–4.5, uix-subs 4.5–5), so its four
+  published estimates read 1.0405 / 1.1556 / 1.1738 / 1.1972 — the same
+  DIRECTION every time, but whether the range cleared 1.0 depended on the
+  run, and one estimate had a minimum of exactly 1.0000. That is the
+  quantum, not a tie. The row was published as CLAMP-LIMITED rather than as
+  a resolved threshold precisely because that was the honest reading.
+
+  Ten writes per window puts the sample 30–50 quanta up, where the quantum
+  is ~2–3% of the reading instead of 20–33% of it.
+
+  Ten and not more, for `hd8-rows/narrow-batch-k`'s reasons, which this
+  deliberately copies rather than re-derives: the batch's cells must be
+  DISTINCT (they are `(mod (* 7 o) 300)` over consecutive `o`, and 7 is
+  coprime with 300, so any run of ten is ten different cells), and the
+  microtask-scale tolerance an early op receives grows with `k`
+  ([[lane/verified-writes!]]). Ten buys the clamp headroom and keeps that
+  tolerance at nine turns.
+
+  THE BROAD ROW DOES NOT USE THIS. It passes a batch of ONE — the pre-batch
+  window exactly — because its readings are already far above the clamp,
+  and because it is a published bar row that nothing here may move."
+  10)
+
+(defonce ^:private op-seq (atom 0))
+(defn- next-op! [] (swap! op-seq inc))
+
 (defn- bulk-write!
-  "One write on one arm, timed as one sample and verified at the DOM
-  inside its own window.
+  "One SAMPLE on one arm, timed as one window and verified at the DOM after
+  the clock stops.
 
-  BROAD changes every cell, so the probe rotates with the value AND the
-  far end of the grid is checked: a stale page can still carry one fresh
-  cell from the previous write and a single fixed probe would accept it.
+  BROAD is one write of every cell, and it is a batch of one: the probe
+  rotates with the value AND the far end of the grid is checked, because a
+  stale page can still carry one fresh cell from the previous write and a
+  single fixed probe would accept it.
 
-  NARROW changes exactly one cell, so there is nothing else in the page
-  to check — the strength of the read-back comes from the value being
-  fresh on every write, which means a stale page holds the PREVIOUS value
-  at the probed cell and fails. The cell also rotates, so no index is
-  special."
-  [t mnt kind s]
-  (let [n   (:cells (:arm mnt))
-        val (next-gen!)]
+  NARROW is [[narrow-batch-k]] writes, each changing exactly ONE cell, all
+  under one clock. Each op gets its OWN value and its OWN cell, so no
+  read-back can be satisfied by a neighbour's commit; and a narrow write
+  changes one cell, so one probe is that op's whole page's worth of
+  verification — the strength comes from the value being fresh on every
+  write, which means a stale page holds the PREVIOUS value at the probed
+  cell and fails."
+  [t mnt kind _s]
+  (let [n (:cells (:arm mnt))]
     (if (= kind :broad)
-      (lane/verified-write! t mnt :all val [(mod val n) (dec n) 0])
-      (let [i (mod (* 7 s) n)]
-        (lane/verified-write! t mnt i val [i])))))
+      (let [val (next-gen!)]
+        (lane/verified-writes! t mnt [[:all val (lane/bulk-probes val n)]]))
+      (lane/verified-writes!
+        t mnt
+        (mapv (fn [_]
+                (let [o    (next-op!)
+                      cell (mod (* 7 o) n)
+                      val  (next-gen!)]
+                  [cell val [cell]]))
+              (range narrow-batch-k))))))
 
 (defn- seed-bulk!
   [mounts t]
@@ -554,7 +625,7 @@
   "Turn one row's per-round, per-segment slices into the published record.
 
   `slices` is `[{segment-id {arm-id [ms ...]}} ...]`, one entry per round."
-  [{:keys [row doc grade clock-note control note]} slices]
+  [{:keys [row doc grade clock-note control note writes-per-sample]} slices]
   (let [norm       (mapv (fn [by-seg]
                            (into {} (map (fn [[sid rd]] [sid (ratios-of rd)])) by-seg))
                          slices)
@@ -581,6 +652,10 @@
       :clock-note  clock-note
       :note        note
       :witness-set "rf2-2rtt6.2"
+      ;; STATED ON THE ROW, because a reader comparing this against the
+      ;; pre-rf2-zb3qg numbers is comparing two different windows and has to
+      ;; be told so. 1 means the sample IS the operation.
+      :writes-per-sample (or writes-per-sample 1)
       :red-zone    (assoc (range-of rz)
                           :numerator :uix-subs
                           :denominator :reagent-subs
@@ -687,8 +762,10 @@
                       "rf2-2rtt6.2's M1 page — the make-or-break row")
             :control bulk-control}
    :narrow {:kind :bulk  :witness :M1 :row :bulk-narrow :grade :bar
-            :doc (str "one commit that exactly ONE of " v/cells-n
-                      " sub-reading boundaries reads — the localisation row")
+            :doc (str narrow-batch-k " commits, each of which exactly ONE of " v/cells-n
+                      " sub-reading boundaries reads, all inside ONE timed window — the "
+                      "localisation row. The per-commit figure is the sample divided by "
+                      narrow-batch-k)
             :note (str "NEW ROW. rf2-2rtt6.2 has no narrow counterpart, so this is not a "
                        "re-measurement of a published figure: it is rf2-2rtt6.4's U-narrow "
                        "question asked on rf2-2rtt6.2's witness. The two numbers are NOT "
@@ -715,14 +792,21 @@
     (segment-order r)
     (fn [acc {:keys [id] :as segment}]
       (enter-segment! segment)
+      ;; Checked immediately after the seam and before a single sample: a
+      ;; segment entered over a frame that would not destroy is measuring
+      ;; the previous segment's reactive graph.
+      (assert-teardown-clean! (str "entering segment " (name id)))
       (if (= kind :mount)
         (js/Promise.resolve
-          (assoc acc id (mount-round! coll t (witness-named witness) id)))
+          (let [rd (mount-round! coll t (witness-named witness) id)]
+            (assert-teardown-clean! (str "mount round, segment " (name id)))
+            (assoc acc id rd)))
         (let [mounts (mount-bulk-arms! (bulk-arms id))]
           (-> (seed-bulk! mounts t)
               (.then (fn [_] (bulk-round! mounts t legs coll row-key id)))
               (.then (fn [rd]
                        (release-bulk-arms! mounts)
+                       (assert-teardown-clean! (str "bulk round, segment " (name id)))
                        (assoc acc id (:readings rd))))
               (.catch (fn [e] (release-bulk-arms! mounts) (throw e)))))))))
 
@@ -743,7 +827,8 @@
                      :doc (or doc (:doc w))
                      :clock-note (when (= kind :mount) (:clock-note w))
                      :note note
-                     :control (or control (:control w))}
+                     :control (or control (:control w))
+                     :writes-per-sample (if (= row :bulk-narrow) narrow-batch-k 1)}
                     slices)]
     (lane/record! (name row) record)
     (lane/record! "verification" {row-key (lane/tally-value t)})

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
@@ -67,6 +67,8 @@ const path = require('node:path');
 
 // The directory's ONE navigation, with its ceiling named (rf2-p9fa3).
 const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs');
+// The directory's ONE sentinel wait, raced against the page dying (rf2-f5roa).
+const { watchPage } = require('../../freehand/bench/sentinel.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 
@@ -78,12 +80,33 @@ const PORT = Number(process.env.HICASSO_PORT || 8134);
 
 // One row, one page, one fresh heap. The order is the order the studio
 // page reports them in; each is self-contained, so it is not load-bearing.
-const ROWS = [
+const ALL_ROWS = [
   { id: 'M1', why: 'mount, 901 elements, 300 sub-reading boundaries — a bar row' },
   { id: 'M2', why: 'mount, 51 elements, 12 fields — DIAGNOSTIC, per rf2-2rtt6.2' },
   { id: 'broad', why: 'one commit all 300 boundaries read — a bar row' },
-  { id: 'narrow', why: 'one commit exactly one boundary reads — localisation' },
+  { id: 'narrow', why: 'k commits each read by exactly one boundary — localisation' },
 ];
+
+// `HICASSO_ONLY=narrow` drives one row instead of four, over the SAME bundle
+// and the same gates. Not a shortcut, and it is `hd8_run.cjs`'s `HD8_ONLY`
+// for the same reason that one has it: re-taking ONE row whose window moved
+// must not re-take the three whose windows did not, because that would mint a
+// competing set of figures for rows already published at another SHA and
+// leave a reader unable to tell which table is current. rf2-zb3qg batched the
+// narrow window and nothing else; the mount rows and the broad row are
+// untouched by it — the broad row passes a batch of one, which is the
+// pre-batch window exactly — so re-taking them would be replacing sound
+// published numbers with different ones for no reason.
+//
+// Unset is all four, so the published shape is the default.
+const ONLY = (process.env.HICASSO_ONLY || '').trim();
+const ROWS = ONLY ? ALL_ROWS.filter((r) => ONLY.split(',').includes(r.id)) : ALL_ROWS;
+if (ROWS.length === 0) {
+  console.error(
+    `[converge] HICASSO_ONLY=${ONLY} selects no row; known ids: ${ALL_ROWS.map((r) => r.id).join(', ')}`
+  );
+  process.exit(1);
+}
 
 // A page's own budget. Five rounds of two segments with warm-up is
 // minutes, not seconds, and a loaded workstation is the normal case.
@@ -137,34 +160,43 @@ async function runRow(browser, row) {
   // longer it runs, and a reused page carries whatever caused that across
   // the row boundary.
   const page = await browser.newPage();
-  const pageErrors = [];
-  page.on('pageerror', (e) => {
-    pageErrors.push(e.message);
-    console.error(`[converge] PAGE ERROR (${row.id}):`, e.message);
-  });
   page.on('console', (msg) => {
     const t = msg.text();
     if (t.startsWith(';; ') || t.startsWith('[converge]')) console.log(t);
   });
+  // Watching starts BEFORE the navigation. `pageerror` used to be pushed onto
+  // an array that nothing read until after the sentinel wait, so a throw
+  // before HICASSO_DONE — which is every throw, since a page that threw never
+  // reaches its own `done!` — cost the FULL twenty-minute budget before the
+  // driver looked at the answer it had held all along (rf2-f5roa, from the PR
+  // #7268 audit).
+  const watch = watchPage(page, `converge:${row.id}`);
 
-  // `'commit'`, not `'load'`. The bundle's `:init-fn` runs inside the
-  // `<script>`, so the measurement happens while the document is still
-  // loading and `load` cannot fire until it is over.
-  await navigate(page, `http://127.0.0.1:${PORT}/?row=${row.id}`, {
-    waitUntil: 'commit',
-    timeoutMs: NAV_TIMEOUT_MS,
-    budget: `the ${SENTINEL_TIMEOUT_MS / 60000}-minute wait for window.HICASSO_DONE`,
-  });
-  await page.waitForFunction('window.HICASSO_DONE === true || window.HICASSO_ERROR', null, {
-    timeout: SENTINEL_TIMEOUT_MS,
-  });
+  try {
+    // `'commit'`, not `'load'`. The bundle's `:init-fn` runs inside the
+    // `<script>`, so the measurement happens while the document is still
+    // loading and `load` cannot fire until it is over.
+    await navigate(page, `http://127.0.0.1:${PORT}/?row=${row.id}`, {
+      waitUntil: 'commit',
+      timeoutMs: NAV_TIMEOUT_MS,
+      budget: `the ${SENTINEL_TIMEOUT_MS / 60000}-minute wait for window.HICASSO_DONE`,
+    });
+    await watch.race('window.HICASSO_DONE === true || window.HICASSO_ERROR', {
+      timeoutMs: SENTINEL_TIMEOUT_MS,
+      budget: `the ${SENTINEL_TIMEOUT_MS / 60000}-minute wait for window.HICASSO_DONE`,
+    });
 
-  const err = await page.evaluate('window.HICASSO_ERROR || null');
-  const refused = await page.evaluate('window.HICASSO_GUARD_REFUSED === true');
-  const controlFailed = await page.evaluate('window.HICASSO_CONTROL_FAILED === true');
-  const results = await page.evaluate('window.HICASSO_RESULTS || {}');
-  await page.close();
-  return { row, err, refused, controlFailed, results, pageErrors };
+    const err = await page.evaluate('window.HICASSO_ERROR || null');
+    const refused = await page.evaluate('window.HICASSO_GUARD_REFUSED === true');
+    const controlFailed = await page.evaluate('window.HICASSO_CONTROL_FAILED === true');
+    const results = await page.evaluate('window.HICASSO_RESULTS || {}');
+    // Kept as a BACKSTOP for an error arriving in the same tick as the
+    // sentinel, which the race cannot order.
+    return { row, err, refused, controlFailed, results, pageErrors: watch.failures.map((f) => `${f.kind}: ${f.detail}`) };
+  } finally {
+    watch.dispose();
+    await page.close();
+  }
 }
 
 (async () => {
@@ -174,19 +206,41 @@ async function runRow(browser, row) {
   const browser = await chromium.launch();
   const version = browser.version();
   const outcomes = [];
+  let died = null;
   try {
     for (const row of ROWS) {
       console.error(`[converge] row ${row.id} — ${row.why}`);
-      outcomes.push(await runRow(browser, row));
+      try {
+        outcomes.push(await runRow(browser, row));
+      } catch (e) {
+        // The sweep STOPS. The remaining rows would each spend their own
+        // budget re-discovering the same broken bundle, and nothing this row
+        // recorded is a measurement.
+        died = `${row.id}: ${e.message}`;
+        break;
+      }
     }
   } finally {
     await browser.close();
     server.close();
   }
 
+  if (died) {
+    console.error(`[converge] FAILED: ${died}`);
+    process.exit(1);
+  }
+
   console.log(`;; ==== HICASSO RUNTIME ====`);
   console.log(`;; chromium ${version} (playwright), :advanced, goog.DEBUG false`);
   console.log(`;; one row per page; ${ROWS.length} pages`);
+  // The repro line carries the environment it was actually run with, not the
+  // bare command: a published figure whose repro command does not reproduce
+  // it is a figure nobody can check.
+  console.log(
+    `;; reproduce  ${ONLY ? `HICASSO_ONLY=${ONLY} ` : ''}node ` +
+      `implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs`
+  );
+  console.log(`;; rows       ${ROWS.map((r) => r.id).join(', ')}${ONLY ? `  (HICASSO_ONLY=${ONLY})` : ''}`);
   for (const o of outcomes) {
     for (const [k, v] of Object.entries(o.results)) {
       console.log(`;; ==== HICASSO ${o.row.id} / ${k} ====`);

--- a/implementation/freehand/test/re_frame/freehand/bench/sentinel.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/sentinel.cjs
@@ -1,0 +1,179 @@
+'use strict';
+
+/*
+ * The bench drivers' ONE sentinel wait, raced against the page dying
+ * (rf2-f5roa, from the PR #7268 and #7269 audits).
+ *
+ * THE DEFECT
+ * ----------
+ * Every driver in this directory ends its page's work the same way:
+ *
+ *     page.on('pageerror', (e) => { errors.push(e.message); });
+ *     await page.waitForFunction('window.X_DONE === true || window.X_ERROR',
+ *                                null, { timeout: 20 * 60 * 1000 });
+ *     if (errors.length) { ...fail... }
+ *
+ * Read the order. A benchmark that THROWS never reaches its `done!`, so the
+ * sentinel never becomes true, so the wait runs its budget out — TWENTY
+ * MINUTES — and only then does the driver look at the array that has held
+ * the answer since the first second. The failure is instantaneous and the
+ * report of it is twenty minutes late.
+ *
+ * That is not a slow gate, it is the anonymous-ceiling defect `navigate.cjs`
+ * documents, wearing its other hat. There the budget was too small and
+ * absorbed a fault it was never meant to bound; here it is enormous and
+ * absorbs one it already knows about. Both end the same way: a log line that
+ * says `Timeout 1200000ms exceeded` when what happened was a ReferenceError
+ * at page-load, and an afternoon spent enlarging a budget that was never the
+ * problem.
+ *
+ * RECORDED, not hypothetical. A contaminated Shadow cache produced a
+ * ReactDOM `pageerror` under `hd8_run.cjs`; the driver logged it and then
+ * waited the full twenty minutes for `HD8_DONE` before timing out. The
+ * source was clean — rebuilding fixed it — which is exactly why this
+ * matters: the *common* cause of a page error here is environmental, so it
+ * is the case a driver meets most often and the one it handles worst.
+ *
+ * WHY A FILE AND NOT A PATCH IN EACH DRIVER
+ * -----------------------------------------
+ * `navigate.cjs`'s reasoning, unchanged: `b10_prod_run.cjs` was already
+ * given the right navigation by hand while its four siblings kept the
+ * defect, so the directory drifted. Two drivers carry this sentinel today
+ * and both had the same fault. Per-file drift is the failure mode; the
+ * directory gets one sentinel.
+ *
+ * WHAT COUNTS AS THE PAGE DYING
+ * -----------------------------
+ * Three things, and deliberately not a fourth:
+ *
+ *   `pageerror`     an uncaught exception. A benchmark that threw and kept
+ *                   going publishes a precise number for a page that is not
+ *                   the page under test.
+ *   `crash`         the renderer is gone; nothing will ever set the sentinel.
+ *   `requestfailed` for a DOCUMENT or SCRIPT only. These drivers serve the
+ *                   bundle from a loopback `http.createServer`, so a script
+ *                   that fails at the network level means the benchmark was
+ *                   never loaded and the sentinel is unreachable by
+ *                   construction. Other resource types are NOT fatal: an
+ *                   image or a favicon that fails has nothing to do with the
+ *                   measurement, and a gate that goes red for one is a gate
+ *                   that gets disabled.
+ *
+ * WHAT THIS DOES NOT DO
+ * ---------------------
+ * It does not adjudicate anything. A driver still reads its own
+ * `window.*_ERROR`, its own guard verdict and its own control after the wait
+ * returns; this only guarantees that the wait RETURNS — promptly, and saying
+ * which of the two things happened.
+ */
+
+/**
+ * Start watching `page` for the ways it can die. Call this as early as the
+ * page exists — BEFORE navigation — because the fault this exists to catch
+ * most often happens during bundle execution, which is inside the
+ * navigation.
+ *
+ * @param page   Playwright page.
+ * @param label  How this page is named in a failure line (e.g. `'hd8:slim'`).
+ * @returns {{failures: Array, race: Function, dispose: Function}}
+ */
+function watchPage(page, label) {
+  const failures = [];
+  // Resolvers for a currently-pending `race`. A failure that arrives while
+  // nothing is waiting is still RECORDED — `race` checks the array before it
+  // waits, so an error thrown during navigation fails the very next wait
+  // rather than being missed for having been early.
+  const waiters = [];
+
+  const record = (kind, detail) => {
+    failures.push({ kind, detail });
+    console.error(`[${label}] PAGE ${kind.toUpperCase()}: ${detail}`);
+    while (waiters.length) waiters.pop()();
+  };
+
+  const onPageError = (e) => record('pageerror', e && e.message ? e.message : String(e));
+  const onCrash = () => record('crash', 'the renderer process crashed');
+  const onRequestFailed = (req) => {
+    const type = typeof req.resourceType === 'function' ? req.resourceType() : '';
+    if (type !== 'document' && type !== 'script') return;
+    const why = req.failure && req.failure() ? req.failure().errorText : 'unknown';
+    record('requestfailed', `${type} ${req.url()} — ${why}`);
+  };
+
+  page.on('pageerror', onPageError);
+  page.on('crash', onCrash);
+  page.on('requestfailed', onRequestFailed);
+
+  return {
+    failures,
+
+    /**
+     * Wait for `predicate` to become true in the page, OR for the page to
+     * die — whichever happens first.
+     *
+     * @param predicate  A JS expression string, as `page.waitForFunction` takes.
+     * @param timeoutMs  REQUIRED. The sentinel's own budget, for the case where
+     *                   the page is alive and simply has not finished.
+     * @param budget     What that budget IS, in words, for the failure line.
+     * @throws           If the page died, or the budget ran out.
+     */
+    async race(predicate, { timeoutMs, budget } = {}) {
+      if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+        throw new Error(
+          `sentinel.race: timeoutMs is REQUIRED and must be a positive number ` +
+            `(got ${JSON.stringify(timeoutMs)}). An unnamed sentinel budget is the ` +
+            `anonymous-ceiling defect (rf2-p9fa3).`
+        );
+      }
+      const died = new Promise((resolve) => {
+        if (failures.length > 0) resolve();
+        else waiters.push(resolve);
+      }).then(() => 'died');
+
+      // The LOSER of this race is abandoned but not cancelled: when the page
+      // dies, `waitForFunction` stays pending and rejects later — at its own
+      // timeout, or at once when the page closes. An abandoned rejection with
+      // no handler is an unhandled rejection, which Node turns into a process
+      // abort, and it would kill the driver BEFORE it printed the diagnosis
+      // this whole file exists to print. So the rejection is folded into a
+      // value here rather than left to escape.
+      let waitError = null;
+      const finished = page.waitForFunction(predicate, null, { timeout: timeoutMs }).then(
+        () => 'finished',
+        (e) => {
+          waitError = e;
+          return 'wait-failed';
+        }
+      );
+
+      const outcome = await Promise.race([died, finished]);
+
+      if (outcome === 'died' || failures.length > 0) {
+        throw new Error(
+          `[${label}] THE PAGE DIED BEFORE IT FINISHED — the benchmark did not ` +
+            `reach its own completion sentinel, so nothing it may have recorded is ` +
+            `a measurement. This is reported now rather than after ${budget}, ` +
+            `which had not yet run out and would have said only that time passed ` +
+            `(rf2-f5roa). What happened:\n  ` +
+            failures.map((f) => `${f.kind}: ${f.detail}`).join('\n  ')
+        );
+      }
+      if (outcome === 'wait-failed') {
+        throw new Error(
+          `[${label}] ${budget} RAN OUT — the page was still alive and had not ` +
+            `thrown, so this is the benchmark genuinely not finishing rather than ` +
+            `a fault being reported late. Underlying: ${waitError && waitError.message}`
+        );
+      }
+      return outcome;
+    },
+
+    dispose() {
+      page.off('pageerror', onPageError);
+      page.off('crash', onCrash);
+      page.off('requestfailed', onRequestFailed);
+    },
+  };
+}
+
+module.exports = { watchPage };


### PR DESCRIPTION
Three small instrument beads. **Two were mostly discharged already** — the pre-flight is most of the work — and the third moves a published number, which is expected and authorised. Rebased onto current `origin/main` (through #7274); one studio-page conflict resolved by **merging both intents**, never `--ours`/`--theirs`.

## Per bead: what remained versus what was already done

**`rf2-uhw11` — converge the two P0 lanes.** Resolved in #7267, which converged the *method* and removed the narrow driver's build-template fallback. Reopened by that PR's audit for one thing: the studio page still told a reproduction reader the driver "falls back to `:freehand-release`" and that "`HN_BASE_BUILD` overrides both". **While this was in flight, #7272 rewrote that Lane note itself** — so the rebase conflict was resolved by keeping #7272's rewrite *and* its whole new Superseded section, and adding only what was still missing: that `HN_BASE_BUILD` is gone too and setting it today does nothing. No figure moves.

**`rf2-f5roa` — consolidate the HD-008 donor arm.** The consolidation is on main (#7267, and #7270 as `rf2-9zysg`). What remained is the residue three merged-PR audits reopened it for, all one shape — *a gate that reports rather than refuses*:

1. **The positive control only warned** (#7263) and then published a full clock table anyway. Now fails closed.
2. **The effective guard tolerance was invisible** (#7263): the driver passes `0.35` while `order_guard` defaults to `0.10`, and `HD8_TOLERANCE` could move it without trace. Both now in provenance. The same block also claimed the build was `freehand-release`; it is `hicasso-bench`.
3. **A page error cost twenty minutes** (#7269, #7268). `pageerror` went onto an array nothing read until *after* the sentinel wait — and a page that throws never reaches its own `done!`, so the wait always ran its full budget first. New shared `sentinel.cjs` races the sentinel against the page dying, on `navigate.cjs`'s one-helper-for-the-directory reasoning.
4. **Teardown failures were swallowed** at four sites (#7263, #7268). Recorded at the site, adjudicated *between* rows, fatal.

**No measured window moves in any of it**, so nothing is invalidated and nothing was re-run.

**`rf2-zb3qg` — the clamp-limited bulk-narrow row. IT NOW RESOLVES.**

| estimate | before (unbatched) | after (10 commits per window) |
|---|---|---|
| run 1, floor-normalised | 1.1556 [1.0417 – 1.2500] | **1.1540 [1.0570 – 1.2053]** |
| run 1, raw cross-segment | 1.1972 [1.1111 – 1.2500] | **1.1714 [1.0962 – 1.2316]** |
| run 2, floor-normalised | 1.0405 [0.7500 – 1.3330] ← *straddled 1.0* | **1.1656 [1.1091 – 1.2942]** |
| run 2, raw cross-segment | 1.1738 | **1.1447 [1.1091 – 1.1827]** |

Lowest bound across all four is **1.0570** — disjoint from 1.0 on every estimate. Every leg went from 3–5 quanta to 21–65. **The centre did not move, the noise did:** the batched mean sits inside the spread of the four unbatched estimates, and dividing each sample by ten recovers the unbatched per-commit legs.

**The guard did not refuse** either run (tolerance `0.10`, `contaminated? false`, `unchecked? false`). `rf2-2rtt6.2`'s recorded refusal was from batching *mounts*, and it was checked rather than assumed — worst phase stratum across all six arms reads 1.038×–1.089×. The tolerance was not touched.

`lane/verified-writes!` is #7270's shape lifted, not a second one: `verified-write!` is now its `k = 1` case **byte-for-byte**, which is what lets the broad row pass a batch of one and *not move*. Four new DOM contract tests pin that.

### And the driver had been dead

`p0_converge_app` asserts at boot that `slot-order` **degenerates** at `k=2`. #7267 *repaired* that defect in six files and did not touch this one, so the assertion went false the moment the repair landed and `p0_converge_run.cjs` has **exited 1 before taking a single sample ever since**. Every row of `p0-converged-witness-set.md` was unreproducible at HEAD for that window. Fixed here; the assertion now checks the repaired property as a canary.

### Two things the operator needs to see

- **`rf2-2rtt6.1` can no longer accept ANY append** — a one-word note fails identically to a 4 KB one, because the failing write is the audit *event*, which serialises the whole issue. The governance record whose stated purpose is "workers append measurements" is append-never. Filed as **`rf2-0znkn` (P1)**; **not worked around**, since every remedy touches an operator-owned record. This measurement's full record went to the studio page with blob-hash provenance instead.
- Only the narrow row was re-taken, so the other three converged rows have still never been reproduced against a driver that runs. Filed as **`rf2-rjfz1` (P2)**.

Nothing touched `p0_run.cjs`, `control-verdict`, `order_guard` tolerance, `shadow-cljs.edn`, or any `src/`. `rf2-egdaq` stays the operator's — the narrow row's controls pass its stricter rule anyway, so it would not be affected either way.

## Provenance

Anchored by **blob hash**, because a rebase moved the SHA between the run and the merge — and the blobs were re-verified byte-identical afterwards.

| file (`implementation/freehand/test/re_frame/bench/hicasso/`) | blob |
|---|---|
| `p0_converge_app.cljs` | `f4b09dc20712e45f44f9ec9339f8dd00ce51e8f7` |
| `lane.cljs` | `885592cf9fdd79f701d6353fc5d3dae0868d74f1` |
| `p0_converge_run.cjs` | `253b468a6b3a96b3ca8e1d8e4f6d2ad6299445a1` |

Repro, verified to run at this instrument (exit 0, twice):
`HICASSO_ONLY=narrow node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs`

## Quality gates

All run **after** the rebase onto current `origin/main`, foreground to completion.

| gate | result | exit |
|---|---|---|
| `npm run test:browser` | 851 tests, 5,503 assertions, **0 failures, 0 errors** | **0** |
| `npm run test:freehand` | 1,399 tests, 7,752 assertions, **0 failures, 0 errors** | **0** |
| order-guard self-test (`order_guard.cjs`) | 11/11 checks ok | **0** |
| `node --check` on `sentinel.cjs`, `hd8_run.cjs`, `p0_converge_run.cjs` | syntax ok | **0** |
| measurement run 1 — `HICASSO_ONLY=narrow` | guard clean, control passed, **0 unverified of 6,030** | **0** |
| measurement run 2 — `HICASSO_ONLY=narrow` (independent) | guard clean, control passed, **0 unverified of 6,030** | **0** |

**Instrument discipline.** `0 unverified of 6,030` on each run. Positive control **predicted before the run** at `1801 / 901 = 1.9989×`; measured [1.917–2.038] and [1.821–2.000] (run 1), [1.905–1.977] and [1.814–2.000] (run 2) — every round inside the ±25% band. Both orders run; ranges published, never a mean alone.
