### PR TITLE
bench(hicasso): adjudicate the P0 driver's clock verification and control (rf2-95s5b)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_app.cljs
+++ b/implementation/core/test/re_frame/bench/p0_app.cljs
@@ -49,12 +49,16 @@
 
   `?mode=aggregate` installs `window.P0A`, which folds the driver's
   collected per-round EDN into the published records: ranges across
-  rounds, the red-zone ratios, and the arm-order verdict.
+  rounds, the red-zone ratios, and the arm-order verdict. It answers the
+  row's GATES beside the record — the summed `N unverified of M` and the
+  positive control's verdict — because a figure the driver prints and
+  never exits on is decoration (rf2-95s5b).
 
   Built and driven by `p0_run.cjs` beside this file.
 
   Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
   (:require [cljs.reader :as reader]
+            [re-frame.bench.hicasso.lane :as lane]
             [re-frame.bench.order-guard :as guard]
             [re-frame.bench.p0-arms :as arms]
             [re-frame.bench.p0-fixture :as fx]
@@ -419,6 +423,76 @@
      :refused   (into [] (comp (filter (fn [[_ v]] (refused? v))) (map key)) all)}))
 
 ;; ---------------------------------------------------------------------------
+;; Adjudication — the clock row's own gates, answered where the fold is
+;; ---------------------------------------------------------------------------
+
+(defn- published-rows
+  "Every row the fold publishes, keyed as the driver names them."
+  [agg]
+  (merge (:mount agg)
+         {:bulk-broad (get-in agg [:bulk :broad])
+          :bulk-narrow (get-in agg [:bulk :narrow])}))
+
+(defn- verification-totals
+  "Every published clock row's DOM read-back tally, summed — the
+  `N unverified of M` the whole row stands or falls on.
+
+  ## The positive control is NOT in this denominator, and that is the point
+
+  `control-round!` mounts two arms that build DIFFERENT pages on purpose,
+  so it hands `mount-round!` `nil` as the expectation and there is nothing
+  to read back. An unverifiable window contributes to neither the
+  numerator nor the denominator (see `p0-harness/mount-sample!`): counting
+  it as verified would let the control dilute a real failure, and counting
+  it as unverified would red every run for ever. The control is
+  adjudicated by its own gate instead — [[lane/control-verdict]], below —
+  and the driver reports it beside this figure rather than folding one
+  into the other."
+  [agg]
+  (let [rows (published-rows agg)]
+    {:unverified (reduce + 0 (map #(get-in % [:verification :unverified] 0) (vals rows)))
+     :of         (reduce + 0 (map #(get-in % [:verification :of] 0) (vals rows)))
+     :per-row    (into (sorted-map)
+                       (map (fn [[id r]] [id (:verification r)]))
+                       rows)}))
+
+(defn adjudicate
+  "Fold the per-round EDN into the published record AND answer the gates
+  the driver has to exit on. **The only door onto the fold**, deliberately:
+  a caller that could take the record without the verdicts is the fail-open
+  this replaced (rf2-95s5b) — the clock row's `N unverified of M` was
+  printed inside the record and nothing read it, and the positive control
+  was published as a bare ratio nothing adjudicated.
+
+  The adjudication is the LANE's, not a second copy: [[lane/control-verdict]]
+  is what the freehand P0 arms already publish their controls under, and
+  what it DECIDES is not this namespace's to change (rf2-egdaq, which is
+  open, is the ruling on whether that decision tightens). Read its
+  docstring before quoting `:ok?`: the rule is range OVERLAP, not
+  every-round-inside.
+
+  Answers a flat JS object because a driver reading `verify.ok?` off a
+  `clj->js` map sees `undefined` — every gate green while every gate was
+  unread. That happened on the predecessor's first run."
+  [round-edns slack]
+  (let [agg (aggregate (vec round-edns))
+        vt  (verification-totals agg)
+        ctl (lane/control-verdict (get-in agg [:control :predicted])
+                                  (select-keys (get-in agg [:control :measured])
+                                               [:min :max :mean])
+                                  slack)
+        rec (-> agg
+                (assoc :verification vt)
+                (assoc-in [:control :slack] slack)
+                (assoc-in [:control :verdict] ctl))]
+    #js {:edn        (pr-str rec)
+         :unverified (:unverified vt)
+         :of         (:of vt)
+         :perRow     (pr-str (:per-row vt))
+         :controlOk  (boolean (:ok? ctl))
+         :controlWhy (:why ctl)}))
+
+;; ---------------------------------------------------------------------------
 
 (defn ^:export -main
   []
@@ -446,7 +520,11 @@
 
       "aggregate"
       (do (set! (.-P0A js/window)
-                #js {:aggregate (fn [edns] (pr-str (aggregate (vec edns))))})
+                ;; ONE door, and it hands back the verdicts with the record.
+                ;; A bare `aggregate` beside it would be a way to take the
+                ;; figures without the gates, which is the defect this
+                ;; namespace was carrying (rf2-95s5b).
+                #js {:adjudicate (fn [edns slack] (adjudicate edns slack))})
           (js/console.log ";; P0 aggregator installed")
           (set! (.-P0_READY js/window) true))
 

--- a/implementation/core/test/re_frame/bench/p0_harness.cljs
+++ b/implementation/core/test/re_frame/bench/p0_harness.cljs
@@ -298,7 +298,19 @@
 
   Answers `{:ms … :bad n :total n}` with every mount in the sample
   verified against `expected` — outside the window, since the window
-  closes when the last `flushSync` returns."
+  closes when the last `flushSync` returns.
+
+  **`expected` nil means UNVERIFIABLE, and an unverifiable window is
+  excluded from the denominator rather than counted as verified.** The one
+  caller that passes nil is the positive control, whose two arms build
+  different pages on purpose; there is nothing to read back. Counted into
+  `:total` with `:bad 0` — which is what this answered before rf2-95s5b —
+  those windows would dilute a real failure in whatever tally a caller
+  summed them into, and `N unverified of M` would be quoting an M that
+  nothing had checked. So they contribute to neither, and the control is
+  adjudicated by its own gate instead (`lane/control-verdict`, reached
+  through `p0-app/adjudicate`). No published figure moves: `control-round!`
+  keeps only `:readings` and has always discarded these counts."
   [arm n expected]
   (let [containers (mapv (fn [_] (container!)) (range n))
         handles    (volatile! [])
@@ -315,7 +327,7 @@
       (doseq [hd @handles] ((:unmount arm) hd))
       (doseq [c containers] (.remove c))
       (collect!)
-      {:ms ms :bad bad :total n})))
+      {:ms ms :bad bad :total (if (nil? expected) 0 n)})))
 
 ;; ---------------------------------------------------------------------------
 ;; The schedule, CHOSEN by its measured property rather than assumed

--- a/implementation/core/test/re_frame/bench/p0_heap.cljs
+++ b/implementation/core/test/re_frame/bench/p0_heap.cljs
@@ -56,6 +56,7 @@
   Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
   (:require ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]
+            [re-frame.bench.hicasso.lane :as lane]
             [re-frame.bench.order-guard :as guard]
             [re-frame.bench.p0-arms :as arms]
             [re-frame.bench.p0-fixture :as fx]
@@ -247,6 +248,30 @@
              :verdict        (fn [samples tolerance]
                                (pr-str (guard/verdict (js->clj samples :keywordize-keys true)
                                                       {:tolerance tolerance})))
+             ;; ONE expression of the positive-control rule too, and it is
+             ;; the LANE's. The driver owns the collector, so it is the
+             ;; driver that reads `predicted` against the measured range —
+             ;; and until rf2-95s5b it printed that pair as a bare ratio
+             ;; nothing adjudicated. `lane/control-verdict` is what the
+             ;; freehand P0 arms already publish their controls under; what
+             ;; it DECIDES is not this namespace's to change (rf2-egdaq),
+             ;; and its docstring states the rule it applies — range
+             ;; OVERLAP, not every-round-inside.
+             ;;
+             ;; A flat literal `#js` answer, never `clj->js`: that would
+             ;; render `:ok?` as the key `"ok?"` and a driver reading
+             ;; `v.ok` would see `undefined` — the control green for ever
+             ;; because nothing could read it. The same trap `mount!`
+             ;; already carries the scar from.
+             :controlVerdict (fn [predicted measured slack]
+                               (let [m (js->clj measured :keywordize-keys true)
+                                     v (lane/control-verdict
+                                         predicted
+                                         (select-keys m [:min :max :mean])
+                                         slack)]
+                                 #js {:ok    (boolean (:ok? v))
+                                      :why   (:why v)
+                                      :slack (:slack v)}))
              :guardSelfTest  (fn [] (pr-str (guard/self-test)))
              :boundariesPerRoot #js {:list rows-per-root :grid per-root}})
   nil)

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -49,6 +49,38 @@
 // bench, and a third would be a third place for it to drift. Its
 // self-test runs before anything is measured, in both modes. **A refusal
 // exits 2, and the repair is to the ARM, never to the guard.**
+//
+// ## Every figure this driver prints as a check, it EXITS on (rf2-95s5b)
+//
+// It did not. The clock row's `N unverified of M` and BOTH positive
+// controls were printed and only the heap row's read-back count was
+// adjudicated, so a run in which no write reached the page, or in which
+// the instrument could not see a change its own arithmetic predicted,
+// printed the count beside `VERDICT: reportable` and exited 0. A count
+// that is displayed and not gated is decoration. The four exit-bearing
+// checks are now, in the order they are taken:
+//
+//   1. the arm-order guard's self-test, in the page, before anything is
+//      measured — exit 1 (clock) / the page refuses to install (heap);
+//   2. `N unverified of M` — clock and heap, exit 1 on any nonzero count;
+//   3. the positive control — clock and heap, adjudicated by
+//      `lane/control-verdict` and exit 1 when it is not `ok`;
+//   4. the arm-order verdict over the samples — exit 2, figures not
+//      quotable.
+//
+// The positive controls are UNVERIFIABLE BY CONSTRUCTION — the clock's
+// two control arms build different pages on purpose, and the heap's is a
+// dense array with no DOM at all — so their windows are excluded from
+// (2)'s denominator rather than counted as verified, and (3) is the gate
+// they answer to instead. See `p0-harness/mount-sample!`.
+//
+// `lane/control-verdict` is the lane's shared rule and WHAT IT DECIDES IS
+// NOT THIS DRIVER'S TO CHANGE: rf2-egdaq is the open ruling on whether it
+// tightens from range-overlap to every-round-inside. Read its docstring
+// before quoting `:ok?`. Both of this driver's controls pass under either
+// reading — heap 4,700,317 B [4,699,074–4,700,974] against a predicted
+// 4,700,000 B, clock 1.8381x [1.8182–1.8548] against a predicted 1.9975x
+// with ±25% slack — so wiring them in changed no published figure.
 
 'use strict';
 
@@ -74,6 +106,11 @@ const CONTROL_DOUBLES = Number(process.env.P0_CONTROL_DOUBLES || 587500);
 const CONTROL_PREDICTED = CONTROL_DOUBLES * 8;
 const HEAP_TOLERANCE = Number(process.env.P0_HEAP_TOLERANCE || 0.25);
 const CLOCK_TIMEOUT_MS = Number(process.env.P0_CLOCK_TIMEOUT_MS || 30 * 60 * 1000);
+// How far a positive control's measured range may sit from the prediction
+// its own arithmetic made and still count as THE INSTRUMENT HAS SIGNAL.
+// Generous on purpose — the claim being gated is not that the model is
+// exact. `lane/control-verdict` applies it; this driver only carries it.
+const CONTROL_SLACK = Number(process.env.P0_CONTROL_SLACK || 0.25);
 
 const ONLY = (() => {
   const i = process.argv.indexOf('--only');
@@ -203,18 +240,29 @@ async function clockRow(chromium) {
   if (err) return { err, results: null };
   if (!roundEdns.length) return { err: 'no round produced a record', results: null };
 
-  // The fold runs in a page too, so the ranges, the red-zone ratios and
-  // the arm-order verdict are computed by `re-frame.bench.order-guard`
-  // and `p0-harness` — the same code the rounds ran under — rather than
-  // by a second, drifting expression of the same arithmetic in JavaScript.
+  // The fold runs in a page too, so the ranges, the red-zone ratios, the
+  // arm-order verdict, the summed read-back tally and the positive
+  // control's verdict are computed by `re-frame.bench.order-guard`,
+  // `p0-harness` and `hicasso.lane` — the same code the rounds ran under —
+  // rather than by a second, drifting expression of the same arithmetic in
+  // JavaScript. `adjudicate` is the ONLY door onto the fold: a driver that
+  // could take the record without the verdicts is the hole this closed.
   console.error('[p0] aggregating ...');
   const { browser, page } = await newPage(chromium, '?mode=aggregate');
   await page.waitForFunction('window.P0_READY === true || window.P0_ERROR', null, {
     timeout: 180000,
   });
-  const edn = await page.evaluate((e) => window.P0A.aggregate(e), roundEdns);
+  const adj = await page.evaluate(
+    ([e, s]) => window.P0A.adjudicate(e, s),
+    [roundEdns, CONTROL_SLACK]
+  );
   await browser.close();
-  return { err: null, results: edn };
+  return {
+    err: null,
+    results: adj.edn,
+    verification: { unverified: adj.unverified, of: adj.of, perRow: adj.perRow },
+    control: { ok: adj.controlOk, why: adj.controlWhy, slack: CONTROL_SLACK },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -363,6 +411,19 @@ async function heapRow(chromium) {
     ([s, t]) => window.P0H.verdict(s, t),
     [orderSamples, HEAP_TOLERANCE]
   );
+
+  // THE CONTROL IS ADJUDICATED, not printed. `predicted` is 8 bytes a
+  // double, fixed before the run; the measured range is this row's own
+  // per-round readings. The rule is `lane/control-verdict`'s, the same one
+  // the freehand P0 arms publish under — this driver states the pair and
+  // reads the answer, and it does so HERE because the page has to still be
+  // open for the rule to be the lane's rather than a JavaScript copy of it.
+  const ctlStat = stat(rounds.map((r) => r.control.measuredCdp));
+  const controlVerdict = await page.evaluate(
+    ([p, m, s]) => window.P0H.controlVerdict(p, m, s),
+    [CONTROL_PREDICTED, { min: ctlStat.min, max: ctlStat.max, mean: ctlStat.mean }, CONTROL_SLACK]
+  );
+
   await browser.close();
 
   return {
@@ -383,6 +444,9 @@ async function heapRow(chromium) {
       shape: 'dense JS array of doubles',
       doubles: CONTROL_DOUBLES,
       predictedBytes: CONTROL_PREDICTED,
+      measured: ctlStat,
+      slack: CONTROL_SLACK,
+      verdict: controlVerdict,
     },
     verification: { mounts, unverified },
     perRound: rounds,
@@ -401,13 +465,35 @@ const stat = (xs) => {
   return { mean, min: s[0], max: s[s.length - 1] };
 };
 
+// The clock row's two gates, stated where a reader will look for them
+// rather than buried inside the record's EDN. Both were printed and
+// neither was adjudicated until rf2-95s5b; the exit logic below reads
+// exactly these figures.
+function summariseClock(c) {
+  console.log(';;');
+  console.log(';; ==== P0 CLOCK — VERIFICATION AND POSITIVE CONTROL ====');
+  console.log(`;;   verification: ${c.verification.unverified} unverified of ${c.verification.of} windows`);
+  console.log(`;;                 ${c.verification.perRow}`);
+  console.log(';;   The positive control is NOT in that denominator and cannot be: its two');
+  console.log(';;   arms build DIFFERENT pages on purpose, so no window of it has anything to');
+  console.log(';;   read back. It is reported and adjudicated separately, here:');
+  console.log(
+    `;;   positive control (slack ±${(c.control.slack * 100).toFixed(0)}%): ` +
+      `${c.control.ok ? 'OK' : 'FAILED'} — ${c.control.why}`
+  );
+}
+
 function summariseHeap(row) {
   console.log('\n;; ==== P0 RETAINED HEAP — bytes per boundary ====');
   console.log(`;; ${row.roots} roots held per arm; list=${row.perRoot.list} rows, grid=${row.perRoot.grid} cells`);
-  const ctlA = stat(row.perRound.map((r) => r.control.measuredCdp));
+  const ctlA = row.control.measured;
   console.log(
     `;; positive control: predicted ${CONTROL_PREDICTED} B  |  measured ${Math.round(ctlA.mean)} B ` +
       `[${Math.round(ctlA.min)}–${Math.round(ctlA.max)}]  (ratio ${(ctlA.mean / CONTROL_PREDICTED).toFixed(4)})`
+  );
+  console.log(
+    `;;   VERDICT (lane/control-verdict, slack ±${(row.control.slack * 100).toFixed(0)}%): ` +
+      `${row.control.verdict.ok ? 'OK' : 'FAILED'} — ${row.control.verdict.why}`
   );
   console.log(`;; verification: ${row.verification.unverified} unverified of ${row.verification.mounts} mounts`);
   console.log(';;');
@@ -463,7 +549,10 @@ function summariseHeap(row) {
   const server = serve();
   const { chromium } = require('playwright');
   const out = { generatedAt: new Date().toISOString(), build: BUILD, initFn: INIT_FN };
-  let failed = null;
+  // EVERY failed gate, not the last one. A single `failed` slot let a
+  // later gate's silence overwrite an earlier gate's refusal, and a run
+  // that failed two things would name one of them.
+  const failures = [];
   let refused = false;
   try {
     if (ONLY !== 'heap') {
@@ -471,10 +560,22 @@ function summariseHeap(row) {
       const c = await clockRow(chromium);
       out.clock = c.results;
       if (c.err) {
-        failed = `clock: ${c.err}`;
+        failures.push(`clock: ${c.err}`);
       } else {
+        out.clockGates = { verification: c.verification, control: c.control };
         console.log(';; ==== P0 CLOCK ====');
         console.log(c.results);
+        summariseClock(c);
+        // A row whose writes never reached the page is the cheapest row in
+        // any table. The count was printed inside the record from the
+        // first run; nothing exited on it until rf2-95s5b.
+        if (c.verification.unverified > 0) {
+          failures.push(
+            `clock: ${c.verification.unverified} unverified of ${c.verification.of} windows ` +
+              `— ${c.verification.perRow}`
+          );
+        }
+        if (!c.control.ok) failures.push(`clock: positive control — ${c.control.why}`);
         const m = /:refused \[([^\]]*)\]/.exec(c.results);
         if (m && m[1].trim()) {
           refused = true;
@@ -489,12 +590,15 @@ function summariseHeap(row) {
       out.heap = await heapRow(chromium);
       summariseHeap(out.heap);
       if (out.heap.verification.unverified > 0) {
-        failed = `heap: ${out.heap.verification.unverified} unverified mounts`;
+        failures.push(`heap: ${out.heap.verification.unverified} unverified mounts`);
+      }
+      if (!out.heap.control.verdict.ok) {
+        failures.push(`heap: positive control — ${out.heap.control.verdict.why}`);
       }
       refused = refused || out.heap.orderRefused;
     }
   } catch (e) {
-    failed = String(e && e.stack ? e.stack : e);
+    failures.push(String(e && e.stack ? e.stack : e));
   } finally {
     server.close();
   }
@@ -504,8 +608,8 @@ function summariseHeap(row) {
     fs.writeFileSync(raw, JSON.stringify(out, null, 2));
     console.error(`[p0] raw data -> ${raw}`);
   }
-  if (failed) {
-    console.error(`[p0] FAILED: ${failed}`);
+  if (failures.length) {
+    for (const f of failures) console.error(`[p0] FAILED: ${f}`);
     process.exit(1);
   }
   // A run whose figures the arm-order guard refused is not a green run.

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -493,8 +493,10 @@ function summariseHeap(row) {
   );
   console.log(
     `;;   VERDICT (lane/control-verdict, slack ±${(row.control.slack * 100).toFixed(0)}%): ` +
-      `${row.control.verdict.ok ? 'OK' : 'FAILED'} — ${row.control.verdict.why}`
+      `${row.control.verdict.ok ? 'OK' : 'FAILED'}`
   );
+  console.log(`;;     ${row.control.verdict.why}`);
+  console.log(';;     (the shared rule words its figures with an "x"; this control\'s unit is BYTES)');
   console.log(`;; verification: ${row.verification.unverified} unverified of ${row.verification.mounts} mounts`);
   console.log(';;');
   console.log(';; arm                              B/boundary (mean) [min-max]     residue B');


### PR DESCRIPTION
Closes **rf2-95s5b** (P1).

The P0 lane driver printed four checks and exited on one. `p0_run.cjs` accumulated the clock row's `N unverified of M`, printed it inside the record, and never read it back; both positive controls were published as a bare predicted-vs-measured ratio that nothing adjudicated. Only the heap row's read-back count reached the exit logic. **A count that is displayed and not gated is decoration** — an arm could print `156 unverified of 936` beside `VERDICT: reportable` and still exit 0.

## What is wired

| Gate | Where it is decided | Exit |
|---|---|---|
| clock `N unverified of M` | `p0-app/adjudicate`, summed across every published row | **1** |
| clock positive control | `lane/control-verdict`, in-page | **1** |
| heap positive control | `lane/control-verdict` via `P0H.controlVerdict` | **1** |
| heap `N unverified of M` | unchanged, already gated | 1 |

- **`p0-app/adjudicate` replaces `aggregate` as the only door onto the fold**, and hands back the summed tally and the control's verdict with the record. A caller that could take the figures without the gates was the hole; there is now no such caller.
- **The adjudication is the lane's, not a second copy.** `lane/control-verdict` is what the freehand P0 arms already publish their controls under. **What it decides is untouched** — the overlap-versus-strict question is `rf2-egdaq`, still open and the operator's. Both new call sites point at its docstring so `:ok?` is not mistaken for the strict answer.
- **The driver names every failed gate, not the last one.** A single `failed` slot let a later gate's silence overwrite an earlier gate's refusal.
- **An unverifiable window is excluded from the denominator** rather than counted as verified. `p0-harness/mount-sample!` answered `{:bad 0 :total n}` when handed `nil` as the expectation — the shape that lets a skip-verify arm dilute a real failure. It now contributes to neither, and the one caller that passes `nil` (the positive control, whose two arms build different pages on purpose) is adjudicated by `control-verdict` instead and **reported separately** in the printout. `control-round!` has always discarded these counts, so no figure moves.

## No published number moves

`docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md` publishes **`0 unverified of 6,600` (clock)** and **`0 unverified of 48 mounts` (heap)**, a heap control of **4,700,317 B [4,699,074 – 4,700,974]** against a predicted 4,700,000 B, and a clock control of **1.8381× [1.8182 – 1.8548]** against a predicted 1.9975×. A clean run at the published sizes reproduces the denominator row by row:

```
;;   verification: 0 unverified of 6600 windows
;;                 {:W1-list {:unverified 0, :of 200}, :W3-form {:unverified 0, :of 1600},
;;                  :bulk-broad {:unverified 0, :of 800}, :bulk-narrow {:unverified 0, :of 4000}}
```

— which is the page's own `200 mounts W1 + 1,600 mounts W3 + 800 broad writes + 4,000 narrow writes`, arrived at independently. **No published row would have failed a newly wired gate.** Both published controls sit *inside* the ±25% band rather than merely overlapping it, so neither reading of `rf2-egdaq` changes the answer for these two rows. No file under `docs/` is touched.

## Proof by mutation

Each gate was shown passing on a good run, then planted with the defect it exists to catch, then restored.

| # | Mutation — a real arm defect, never the gate | Result |
|---|---|---|
| 1 | floor bulk arm's `force!` → no-op, so the commit never lands inside the window | `[p0] FAILED: clock: 96 unverified of 264 windows — {… :bulk-broad {:unverified 16, :of 32}, :bulk-narrow {:unverified 80, :of 160}}` → **exit 1** |
| 2 | `control-2x` builds the *same* page as `control-1x`, so the instrument has no signal | `positive control: FAILED — predicted 1.998x, measured 1.210x [1.210–1.210] — DISJOINT from ±25%` → **exit 1** |
| 3 | `P0H.control` allocates a tenth of the doubles — the "reads as 6 KB" fiction its own docstring warns of | `measured 470610 B (ratio 0.1001) … VERDICT: FAILED` → **exit 1** |

Mutation 2 left `verification: 0 unverified of 264` untouched: the two gates are independent, and the control's own windows are confirmed absent from the denominator. Mutation 3 exited 1 while the arm-order guard was concurrently refusing — the intended precedence, since a failed gate is worse than an unquotable figure.

**Restored byte-identical.** `implementation/core/test/re_frame/bench/p0_arms.cljs` is blob `89d26f8b9853d4fd06abfbdd99e6c7ac8a4cc060` on this branch and on `origin/main`; `p0_heap.cljs`'s committed `control!` reads `(js/Array. n)`.

## Anchors

Rebased onto `origin/main` after #7272 and #7273 landed; no overlap in `implementation/core/test/re_frame/bench/`. Commit `2fd3a362176e9a01b42dad5992e16817bdb5d1d5`, and by blob hash, since rebase and merge both rewrite the SHA:

| blob | file |
|---|---|
| `eec62f5a727ede52897c2472b823140dd0334d24` | `implementation/core/test/re_frame/bench/p0_run.cjs` |
| `095731f2880cf1fca4f08272a80a5dd7303bbed8` | `implementation/core/test/re_frame/bench/p0_app.cljs` |
| `d4dcb3f6e4a4f782cf0ed41953cc15cfecb8f113` | `implementation/core/test/re_frame/bench/p0_heap.cljs` |
| `74672756f712ab1b1282e943bbb1904635dd19e5` | `implementation/core/test/re_frame/bench/p0_harness.cljs` |

## Quality gates

Foreground, to completion, never piped; exit codes echoed.

| Gate | Command | Exit |
|---|---|---|
| P0 driver, published sizes, both rows, post-rebase | `P0_ROUNDS=5 P0_SAMPLES=10 P0_WARMUPS=4 node implementation/core/test/re_frame/bench/p0_run.cjs` | **0** |
| arm-order guard self-test | in-page, before anything is measured — 11 checks `ok` in every page of the run above | **0** |
| mutation 1 — clock verification | `P0_ROUNDS=1 P0_SAMPLES=2 … --only clock` | **1**, expected |
| mutation 2 — clock control | `P0_ROUNDS=1 P0_SAMPLES=2 … --only clock` | **1**, expected |
| mutation 3 — heap control | `P0_ROUNDS=1 … --only heap` | **1**, expected |
| browser suite | `npm run test:browser` — 847 tests, 5,489 assertions, 0 failures | **0** |
| CLJS suite | `npm run test:cljs` — 11,951 tests, 59,640 assertions, 0 failures | **0** |

## Fence

`control-verdict`'s decision logic, `order_guard.*` tolerances, `implementation/shadow-cljs.edn`, all of `implementation/*/src/**`, `docs/**` and `spec/**` are untouched. The diff is four files under `implementation/core/test/re_frame/bench/`.
