### PR TITLE
bench(hicasso): re-certify the bar's denominator and anchor the operative red-zone pages (rf2-2rtt6.17, rf2-rjfz1, rf2-2rtt6.18, rf2-2rtt6.19)

### DIFF
--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -382,6 +382,75 @@ asymmetry is beneath this instrument's resolution and nothing has to be
 subtracted before the ratios above are read. Had it read anything else, this
 page would owe the reader a subtraction.
 
+**And since the narrow window now holds ten of those turns rather than one, ten
+of them are priced under one clock as well** (`rf2-2rtt6.19`). That reading is
+also **0.0 ms**, which bounds the whole ten-turn asymmetry at `< 100 µs` instead
+of at ten times a sub-quantum reading — see [The ten-turn asymmetry is measured,
+not multiplied](#the-ten-turn-asymmetry-is-measured-not-multiplied).
+
+### The ten-turn asymmetry is measured, not multiplied
+
+**The arithmetic that was wrong.** After the batched re-take, this page bounded
+its own microtask asymmetry as *"ten times a quantity below the instrument's own
+resolution"*. That does not follow, and it is the same argument the batch was
+adopted to make: `hd8-rows/yield-cost!` read `p50 0.0, min 0.0, max 0.0` over
+`n = 10`, which against Chrome's 100 µs clamp bounds **one** turn at `< 100 µs`.
+It bounds **ten** turns at `< 1.0 ms` — up to **~26%** of a 3.8–7.6 ms batched
+narrow sample. And the term is present in three columns and absent from the
+fourth:
+
+| arm | batched narrow, × floor | harness microtasks in the window |
+|---|---|---|
+| `reagent-slim` | 4.222 – 5.944 | **zero** |
+| `donor-r1` | 5.182 – 6.790 | ten |
+| `donor-r2` | 5.400 – 6.579 | ten |
+| `reagent` | 4.130 – 6.947 | ten |
+
+An unpriced term present in three columns and absent from the one they are read
+against is exactly the shape of thing that decides whether `reagent-slim` reads
+faster than the donor rungs — and HD-008 is the donor gate, so that comparison
+is the point of the row.
+
+**The repair is this page's own technique, applied to the control.**
+`yield-cost!` now prices **ten harness microtasks inside one clock window**, the
+way the narrow row prices ten writes, and reports the per-turn figure as the
+sample divided by ten. The recursion mirrors `window-of`'s non-microtask branch
+exactly — `(js/Promise.resolve nil)` with the continuation inside the `.then`,
+so the next turn begins in the turn the previous one finished in — because
+threading the turns through a promise-returning `.then` would add two resolution
+ticks per step and price a window no arm runs. The two readings are taken
+**sequentially, never through `Promise.all`**: two microtask chains in flight on
+one queue would each be timing the other's turns.
+
+**The measurement, all three runs:**
+
+| reading | window | per turn | n |
+|---|---|---|---|
+| one turn (unchanged, as published) | **0.0 ms** | 0.0 ms | 10 |
+| **ten turns under one clock** | **0.0 ms** | **0.0 ms** | 10 |
+
+**Ten turns together still measure 0.0 ms against a 100 µs quantum.** So the
+asymmetry is bounded at `< 100 µs` for the whole batch — not at `< 1.0 ms` — and
+per turn at `< 10 µs`. Against the narrow row's 3.8–7.6 ms samples that is **at
+most 2.6% of the smallest sample and 1.3% of the largest**, where the sentence
+this replaces left a reader facing up to 26%.
+
+**Nothing is subtracted, and now that is a finding rather than an assumption.**
+The bound is ten times tighter than the one it replaces, and it is the bound the
+batched window actually needs. Had the ten-turn window read anything above the
+clamp, this page would have owed the reader the subtraction the old sentence
+quietly assumed away.
+
+**No published row moves.** The control is measured outside every arm's window,
+the one-turn reading is unchanged and still reported, and no arm's window was
+touched — so the ratios above are the ratios above.
+
+**Second-order, worth stating in the same pass.** The same reasoning applies
+wherever a sub-quantum per-item cost is asserted negligible across a batch.
+`lane/verified-write!`'s `:gap-ms` is priced per window; if a future arm batches
+*k* operations under one clock on the shared lane, the same multiplication
+reappears there and wants the same treatment.
+
 **Reproduction check — NOT a republication.** The re-take ran all three
 adapters, so the rows published at `d46ede4f` were measured again by a driver
 carrying the change. Every one of them reproduced: on the mount rows, which are
@@ -417,8 +486,13 @@ could land without touching it.
   lane needs a *macrotask*, which never occurs inside the window, so the
   read-back's actual target is unaffected. The batched window also contains ten
   harness microtasks for every arm except the microtask-scheduled one, which
-  contains none; each such turn measures 0.0 ms against this clock, so the
-  asymmetry is ten times a quantity below the instrument's own resolution.
+  contains none. ~~Each such turn measures 0.0 ms against this clock, so the
+  asymmetry is ten times a quantity below the instrument's own resolution.~~
+  **That sentence was wrong, and `rf2-2rtt6.19` replaced the multiplication with
+  a measurement — see [The ten-turn asymmetry is measured, not
+  multiplied](#the-ten-turn-asymmetry-is-measured-not-multiplied).** Ten times a
+  quantity below resolution is *not* below resolution: it bounds ten turns at
+  `< 1.0 ms`, which is up to ~26% of a 3.8–7.6 ms sample.
 - **The bulk write verifies one probe cell**, where the shared lane verifies a
   seq including the far end of the grid. Same bead.
 - **The write rows' donor-vs-Reagent comparison is cross-run**, floor-normalised.
@@ -427,10 +501,11 @@ could land without touching it.
   columns beside it, which is weaker again; the reproduction check above is what
   that reading rests on.
 - **Two window shapes now exist**, and only one of them contains the harness
-  microtask. Measured at 0.0 ms against a 100 µs quantum, so it is beneath this
-  instrument's resolution — but a future instrument with a finer clock inherits
-  a real asymmetry, not a settled one, and `rf2-pq7d8` is where it gets settled
-  properly.
+  microtask. Measured at 0.0 ms against a 100 µs quantum **one turn at a time and
+  ten turns at a time** (`rf2-2rtt6.19`), so the whole batched asymmetry is
+  beneath this instrument's resolution rather than ten times something beneath it
+  — but a future instrument with a finer clock inherits a real asymmetry, not a
+  settled one, and `rf2-pq7d8` is where it gets settled properly.
 - **No retained-heap leg.** The red-zone rule governs clock *and* retained heap;
   this arm measures the clock. The heap ladder is `rf2-2rtt6.5`'s
   ([reads-per-boundary-heap-ladder.md](reads-per-boundary-heap-ladder.md)).

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -177,7 +177,9 @@ when the repair landed, and the consequence was not cosmetic: the assertion went
 false, `-main` refused to measure, and this page's reproduction command exited 1
 before taking a single sample — from PR #7267 until rf2-zb3qg found it. The
 figures above were unaffected (they predate the repair) but were not
-reproducible at HEAD for that window.**
+reproducible at HEAD for that window.** **rf2-rjfz1 has since run the full
+four-row sweep against the revived driver and every row reproduces — see
+[All four rows reproduce](#all-four-rows-reproduce-against-the-revived-driver-rf2-rjfz1).**
 
 **`install-adapter!` is once per process** (Spec 006 §Single adapter per
 process), so each round runs two segments — destroy the adapter, install the
@@ -222,6 +224,66 @@ Both arms against the floor, for context:
 | bulk broad | 7.443× [7.000 – 8.000] | 4.607× [3.667 – 5.500] |
 | bulk narrow *(batched window)* | 1.880× [1.8167 – 1.9259] | 2.168× [2.0357 – 2.2500] |
 | ~~bulk narrow *(unbatched, superseded)*~~ | ~~1.820× [1.500 – 2.000]~~ | ~~2.117× [1.667 – 2.500]~~ |
+
+### All four rows reproduce against the revived driver (rf2-rjfz1)
+
+**Why this check exists.** `p0_converge_app` asserted at boot that
+`lane/slot-order` *degenerates* at `k = 2`. PR #7267 repaired that degeneracy
+and did not touch this file, so the assertion went false the moment the repair
+landed: `p0_converge_run.cjs` **exited 1 before taking a single sample**, and
+every row on this page was unreproducible at HEAD until rf2-zb3qg found it.
+rf2-zb3qg re-ran only the narrow row, because only the narrow row's window had
+moved — the right call, but it left **the M1 mount, M2 mount and broad rows
+never once reproduced against a driver that runs.**
+
+They have now been. One full four-row sweep at main `32cb224d6e`:
+
+```bash
+node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs   # exit 0
+```
+
+**This is a reproduction check, not a re-publication. No figure on this page
+moves.** Ranges are min–max across the five rounds; overlap with the published
+range and an unchanged verdict is the test.
+
+| row | published | reproduction sweep | overlap | verdict |
+|---|---|---|---|---|
+| **M1 mount** | 1.2301 [1.1099 – 1.3538] disjoint | 1.2887 [1.1462 – 1.4242] disjoint | 1.1462 – 1.3538 | **reproduces**, UIx slower both times |
+| **M2 mount** *(diagnostic)* | 1.0539 [0.8572 – 1.4286] straddles | 1.0327 [0.8000 – 1.2727] straddles | 0.8572 – 1.2727 | **reproduces**, indistinguishable both times |
+| **bulk broad** | 0.6239 [0.4701 – 0.7857] disjoint | 0.6020 [0.5263 – 0.7353] disjoint | wholly inside | **reproduces**, UIx faster both times |
+| bulk narrow *(rf2-zb3qg's re-take, checked again here)* | 1.1540 [1.0570 – 1.2053] disjoint | 1.1693 [1.1136 – 1.2528] disjoint | 1.1136 – 1.2053 | **reproduces** |
+
+Per round, the sweep read M1 `1.4242 · 1.1462 · 1.3611 · 1.3214 · 1.1905` ·
+M2 `1.2727 · 0.8000 · 1.0000 · 1.0909 · 1.0000` · broad `0.5750 · 0.5263 ·
+0.6176 · 0.5556 · 0.7353` · narrow `1.2528 · 1.1591 · 1.1705 · 1.1507 ·
+1.1136`.
+
+**Every operative clock red-zone in the table above is therefore now a
+threshold that a reader can reproduce**, which for the three unmoved rows it
+has never been.
+
+| | |
+|---|---|
+| **Commit measured at** | `32cb224d6e5dde730d1e7ddc99c062656cb68155` — `origin/main`, clean tree |
+| **Instrument** | unchanged from the rf2-zb3qg blob table above — `p0_converge_app.cljs` `f4b09dc2…`, `lane.cljs` `885592cf…`, `p0_converge_run.cjs` `253b468a…`, `p0_reagent_views.cljs` `4032e397…`, `p0_uix_views.cljs` `34e0e89d…`, all five **byte-identical on main** |
+| **Arm-order guard** | **no refusal on any of the four rows** — `refuse? false`, `contaminated? false`, `unchecked? false`, tolerance 0.10 |
+| **Position completeness** | **zero lost positions on every arm of every row**; each phase contrast adjudicated on a full 20-against-20 of 60 |
+| **Canonical-DOM parity** | clean in both segments and across the seam, every row — `{:problems [] :ok? true}` |
+| **Verification** | **0 unverified of 7,860** — 600 M1 mounts + 600 M2 mounts + 630 broad writes + 6,030 narrow writes |
+| **Positive controls** | eight, **eight passes** under the overlap rule; see below for the strict reading |
+
+**The M2 control that rf2-egdaq holds open reads differently on this sweep,
+and the ruling is still the operator's.** The published M2 control range
+`[1.333 – 2.000]` sits against a ±25% band whose floor is `1.4559`: it passes
+the overlap rule `lane/control-verdict` implements and fails a strict
+every-round-inside reading. **This sweep's M2 controls are `[1.500 – 2.000]`
+(Reagent segment) and `[1.600 – 2.000]` (UIx segment) — both wholly inside the
+band, so both pass under *either* reading.** That is reported, not used: a
+re-run producing a friendlier control is not an argument for a rule, and
+rf2-egdaq is not settled here. The broad row's controls on this sweep, `[1.600
+– 2.500]` and `[1.667 – 2.500]`, miss the strict reading by `0.0014` — the
+lattice point above a `2.4986` ceiling on a floor of two to three quanta, the
+same quantisation artefact the denominator page records.
 
 ### The denominator reproduces rf2-2rtt6.2
 

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -85,10 +85,36 @@ rows do not.
 
 ## Provenance
 
+**The hashes this page previously asserted but did not print.** The claim below
+was *"the four bench files are byte-identical (same blob hashes) at the rebased
+commit"* — asserted without the hashes, so a reader could not perform the check
+that was the whole point of making it. Here they are, with the landed commit
+the rebase produced:
+
+| file (`implementation/freehand/test/re_frame/bench/hicasso/`) | blob at `44900cd4fd` **and** `4c3f7189c4` | on main `32cb224d6e` |
+|---|---|---|
+| `p0_converge_app.cljs` | `9b5c0d63db5528d8b9790111f9bc53cda052106f` | `f4b09dc20712…` — **moved** (#7275) |
+| `p0_converge_run.cjs` | `9e620cdeb3a7643c74c321a358cdadaabf186465` | `253b468a6b3a…` — **moved** (#7270) |
+| `lane.cljs` | `d32312d9c562f0b6aa7d7f84538eb81ffc18e61c` | `885592cf9fdd…` — **moved** (#7267, #7270) |
+| `p0_reagent_views.cljs` | `4032e39779ce55fee1e1cd4f7a8e9561237e2cfd` | **unchanged** |
+| `p0_uix_views.cljs` | `34e0e89d532f2af3b3289525509cf033bb03bc05` | **unchanged** |
+| `order_guard.cljc` *(`implementation/core/test/re_frame/bench/`)* | `adf59ca03cfe8e2639de97c031c138838f2d34b7` | `e42450ef1c77…` — **moved** (#7267) |
+
+```bash
+P=implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+git rev-parse 4c3f7189c4:$P   # 9b5c0d63db5528d8b9790111f9bc53cda052106f
+git merge-base --is-ancestor 4c3f7189c4 origin/main && echo on-main
+```
+
+Four of the six have moved since — which is exactly why the rows above were
+re-run rather than merely re-anchored; see [All four rows
+reproduce](#all-four-rows-reproduce-against-the-revived-driver-rf2-rjfz1),
+where the instrument is the **current** one and every published range is met.
+
 | | |
 |---|---|
-| **Producing commit** | `44900cd4fd35815b3e2462ae7752242efcb296b9` — the branch was later rebased onto PR #7265, which **rewrote that commit's id without touching the instrument**: the four bench files are byte-identical (same blob hashes) at the rebased commit, so the reproduction command is unaffected. Nothing was re-measured. |
-| **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` |
+| **Producing commit** | `44900cd4fd35815b3e2462ae7752242efcb296b9` — **off main.** Its landed equivalent is **`4c3f7189c4`**, whose instrument tree is byte-identical (the table above prints the hashes); this page landed as **`a987caca26`**. The rebase onto PR #7265 **rewrote the id without touching the instrument**, so the reproduction command was unaffected. Nothing was re-measured at the time. |
+| **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` — **verified to run at main `32cb224d6e`, exit 0.** It did not, for the window between PR #7267 and PR #7275; that is recorded below and is now closed |
 | **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium via Playwright), Windows 11 x64, sibling agents live on the box |
 | **Build** | `:hicasso-bench` — `:browser`, `:advanced`, `goog.DEBUG false`. **No new build id; `implementation/shadow-cljs.edn` untouched** |
 | **Adapters** | `:rf.adapter/reagent` and `:rf.adapter/uix`, one per segment. Reagent 2.0.1 · UIx 1.4.4 · React 19.2.0 |

--- a/docs/design/hicasso/studio/p0-reagent-on-subs-baseline.md
+++ b/docs/design/hicasso/studio/p0-reagent-on-subs-baseline.md
@@ -15,7 +15,7 @@ or the red-zones.
 > **Re-certified on main, 2026-07-31 — the rows below reproduce.** This page was
 > the last P0 arm whose producing SHA was not on main, whose instruments carried
 > no blob anchor, and which had never been re-run under the repaired arm-order
-> guard. All three are closed by **[the re-certification below](#the-re-certification-rf2-2rtt6.17)**:
+> guard. All three are closed by **[the re-certification below](#the-re-certification)**:
 > the landed instrument commit is recovered and byte-identical, the blobs are
 > printed, and two independent five-round runs at `32cb224d6e` reproduce every
 > row. **No published figure below is superseded.** The rows stand as measured.
@@ -24,13 +24,13 @@ or the red-zones.
 
 | | |
 |---|---|
-| **Producing commit** | `19401ad083e895b19d55151157f37a59551cb5e2` — **off main.** Its landed equivalent is **`f03960a8da`** (see [the re-certification](#the-re-certification-rf2-2rtt6.17)); the rebase rewrote the id and moved no instrument byte |
+| **Producing commit** | `19401ad083e895b19d55151157f37a59551cb5e2` — **off main.** Its landed equivalent is **`f03960a8da`** (see [the re-certification](#the-re-certification)); the rebase rewrote the id and moved no instrument byte |
 | **Reproduction** | `cd implementation && npm run bench:hicasso` |
 | **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium, via Playwright), Windows x64 |
 | **Build** | `:hicasso-bench` — `:advanced`, `goog.DEBUG false` |
 | **Adapter** | `:rf.adapter/reagent`; Reagent 2.0.1 |
 | **Schedule** | 5 rounds × (8 warm-up + 12 samples) per arm per round, arms interleaved at the sample level, order rotating **and reflecting** on the sample index |
-| **Arm-order guard** | **reportable** — no arm reads differently for its position in the plan. Self-test 8/8 before anything was measured. *This was the pre-#7267 guard; the same verdict has since been re-taken under the repaired one with **zero lost positions on every arm** — see [the re-certification](#the-re-certification-rf2-2rtt6.17)* |
+| **Arm-order guard** | **reportable** — no arm reads differently for its position in the plan. Self-test 8/8 before anything was measured. *This was the pre-#7267 guard; the same verdict has since been re-taken under the repaired one with **zero lost positions on every arm** — see [the re-certification](#the-re-certification)* |
 | **Canonical-DOM parity** | clean under `:advanced` — `{:problems [] :ok? true}` |
 | **Verification** | **0 unverified of 1220** (400 mounts M1 + 400 mounts M2 + 420 writes bulk) |
 
@@ -123,9 +123,9 @@ not perfectly linear in element count, because the root, the commit and the diff
 walk do not double. Every measured control sits **below** its prediction, which
 is the direction that fixed per-root overhead predicts.
 
-## The re-certification (rf2-2rtt6.17)
+## The re-certification
 
-The audit's cold read found this page carried the wave's **least-anchored**
+Bead **rf2-2rtt6.17**. The audit's cold read found this page carried the wave's **least-anchored**
 measurement and its **first headline**: a producing SHA not on main, no blob
 anchor, four of five instrument blobs moved since, and no re-run under the
 guard repair that stopped a verdict reading `[ok]` while adjudicating on a
@@ -245,7 +245,7 @@ disjoint from 1.0, so both real. That figure was previously argued rather than
 measured, and it is the term that made the predecessor's `13.5×` broad-update row
 an upper bound of unknown content. **It has now been measured three times** — the
 publication run and two independent re-runs at main — and all three agree; see
-[the re-certification](#the-re-certification-rf2-2rtt6.17).
+[the re-certification](#the-re-certification).
 
 **Does not settle — one arm, three runs.** Repetition is not replication. The
 reactive leg still comes from *one implementation of one arm*: three runs of it

--- a/docs/design/hicasso/studio/p0-reagent-on-subs-baseline.md
+++ b/docs/design/hicasso/studio/p0-reagent-on-subs-baseline.md
@@ -12,17 +12,25 @@ Bead **rf2-2rtt6.2**. The rows are appended to the operator-owned standard bead
 **rf2-2rtt6.1**; only the operator amends the bar, the budgets, the kill criteria
 or the red-zones.
 
+> **Re-certified on main, 2026-07-31 — the rows below reproduce.** This page was
+> the last P0 arm whose producing SHA was not on main, whose instruments carried
+> no blob anchor, and which had never been re-run under the repaired arm-order
+> guard. All three are closed by **[the re-certification below](#the-re-certification-rf2-2rtt6.17)**:
+> the landed instrument commit is recovered and byte-identical, the blobs are
+> printed, and two independent five-round runs at `32cb224d6e` reproduce every
+> row. **No published figure below is superseded.** The rows stand as measured.
+
 ## Provenance
 
 | | |
 |---|---|
-| **Producing commit** | `19401ad083e895b19d55151157f37a59551cb5e2` |
+| **Producing commit** | `19401ad083e895b19d55151157f37a59551cb5e2` — **off main.** Its landed equivalent is **`f03960a8da`** (see [the re-certification](#the-re-certification-rf2-2rtt6.17)); the rebase rewrote the id and moved no instrument byte |
 | **Reproduction** | `cd implementation && npm run bench:hicasso` |
 | **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium, via Playwright), Windows x64 |
 | **Build** | `:hicasso-bench` — `:advanced`, `goog.DEBUG false` |
 | **Adapter** | `:rf.adapter/reagent`; Reagent 2.0.1 |
 | **Schedule** | 5 rounds × (8 warm-up + 12 samples) per arm per round, arms interleaved at the sample level, order rotating **and reflecting** on the sample index |
-| **Arm-order guard** | **reportable** — no arm reads differently for its position in the plan. Self-test 8/8 before anything was measured |
+| **Arm-order guard** | **reportable** — no arm reads differently for its position in the plan. Self-test 8/8 before anything was measured. *This was the pre-#7267 guard; the same verdict has since been re-taken under the repaired one with **zero lost positions on every arm** — see [the re-certification](#the-re-certification-rf2-2rtt6.17)* |
 | **Canonical-DOM parity** | clean under `:advanced` — `{:problems [] :ok? true}` |
 | **Verification** | **0 unverified of 1220** (400 mounts M1 + 400 mounts M2 + 420 writes bulk) |
 
@@ -115,6 +123,119 @@ not perfectly linear in element count, because the root, the commit and the diff
 walk do not double. Every measured control sits **below** its prediction, which
 is the direction that fixed per-root overhead predicts.
 
+## The re-certification (rf2-2rtt6.17)
+
+The audit's cold read found this page carried the wave's **least-anchored**
+measurement and its **first headline**: a producing SHA not on main, no blob
+anchor, four of five instrument blobs moved since, and no re-run under the
+guard repair that stopped a verdict reading `[ok]` while adjudicating on a
+fraction of its samples. Headline 1 — the reactive leg — rested on it alone,
+because the converged arm reproduces `reagent-subs ÷ floor` but carries no
+`reagent-ratom` arm.
+
+**The instrument commit is recovered, and it is byte-identical.** The rebase
+that took `19401ad083` onto main produced **`f03960a8da`**, which *is* an
+ancestor of main. Every instrument file matches at the byte:
+
+| file | blob at `19401ad083` **and** `f03960a8da` | on main `32cb224d6e` |
+|---|---|---|
+| `…/hicasso/lane.cljs` | `d32312d9c562f0b6aa7d7f84538eb81ffc18e61c` | `885592cf9fdd…` — **moved** (#7267, #7270) |
+| `…/hicasso/p0_reagent_app.cljs` | `a4aefdd825fef83cc1810b05926a488eee69613d` | `b7dfb2452b8a…` — **moved** (#7267) |
+| `…/hicasso/p0_reagent_views.cljs` | `6daefef0479e0a7247e0deda6f2c574d9c04bd93` | `4032e39779ce…` — **moved** |
+| `…/hicasso/run.cjs` | `3dc92c316191b8f52ab04bfced399192203cf95d` | `3dc92c316191…` — **unchanged** |
+| `…/bench/order_guard.cljc` | `adf59ca03cfe8e2639de97c031c138838f2d34b7` | `e42450ef1c77…` — **moved** (#7267) |
+
+```bash
+P=implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_app.cljs
+git rev-parse f03960a8da:$P   # a4aefdd825fef83cc1810b05926a488eee69613d
+git merge-base --is-ancestor f03960a8da origin/main && echo on-main
+```
+
+**Four blobs have moved, so the wave's rule applies: re-run or mark superseded.
+It was re-run.** Twice, five rounds each, at main `32cb224d6e`, under the
+repaired guard — `npm run bench:hicasso`, **exit 0 both times**.
+
+### Every row reproduces
+
+Published against both re-runs. Overlap of the min–max ranges is the test; a
+verdict flip would be the finding.
+
+| row | figure | published (`f03960a8da`) | re-run 1 (`32cb224d6e`) | re-run 2 (`32cb224d6e`) | verdict |
+|---|---|---|---|---|---|
+| **M1 mount** | `reagent-subs ÷ floor` | 3.899 [3.447 – 4.300] | 3.973 [3.556 – 4.571] | 3.513 [3.313 – 3.688] | **reproduces**, all disjoint from 1.0 |
+| | `reagent-ratom ÷ floor` | 3.224 [2.632 – 3.633] | 3.266 [3.000 – 3.714] | 2.913 [2.625 – 3.375] | **reproduces** |
+| | **reactive leg** | **1.218 [1.122 – 1.310]** | **1.216 [1.185 – 1.241]** | **1.213 [1.093 – 1.273]** | **reproduces — disjoint from 1.0 on all three** |
+| **M2 mount** *(diagnostic)* | `reagent-subs ÷ floor` | 1.874 [1.750 – 2.050] | 1.650 [1.500 – 2.000] | 1.700 [1.333 – 2.000] | reproduces |
+| | `reagent-ratom ÷ floor` | 1.785 [1.625 – 2.083] | 1.433 [1.333 – 1.500] | 1.633 [1.333 – 2.000] | run 2 overlaps; **run 1 does not** — see below |
+| | **reactive leg** | 1.056 [0.960 – 1.242] | 1.150 [1.000 – 1.333] | 1.050 [1.000 – 1.250] | **same verdict — straddles 1.0 on all three** |
+| **bulk broad** | `reagent-subs ÷ floor` | 7.064 [6.200 – 7.700] | 7.280 [6.400 – 8.000] | 7.330 [6.400 – 8.500] | **reproduces**, all disjoint |
+| | `reagent-ratom ÷ floor` | 3.519 [3.200 – 3.900] | 3.707 [3.200 – 4.000] | 3.540 [3.000 – 4.000] | **reproduces** |
+| | **reactive leg** | **2.008 [1.938 – 2.100]** | **1.965 [1.875 – 2.000]** | **2.073 [2.000 – 2.167]** | **reproduces — disjoint from 1.0 on all three** |
+
+**Headline 1 is corroborated for the first time.** *Reading re-frame2
+subscriptions rather than a bare cursor costs Reagent ≈1.22× on mount and
+≈2.01× on a broad commit.* Both legs now rest on three independent five-round
+runs instead of one. The mount leg's three means sit inside 0.5% of each other
+(1.218 / 1.216 / 1.213); the broad leg's three all clear 1.0 with their whole
+range, and the widest spread across them is 1.875 – 2.167.
+
+**The one range that does not overlap, stated rather than smoothed.** Run 1's
+`M2/reagent-ratom ÷ floor` reads [1.333 – 1.500] against a published [1.625 –
+2.083]. It is on **the row this page already grades diagnostic and forbids
+quoting against the bar**, whose absolute p50 is two to four of Chrome's 100 µs
+quanta — the ratio's denominator moves by a whole quantum between adjacent
+rounds. Run 2 overlaps the published range on the same figure ([1.333 – 2.000]),
+and the **leg** that row actually reports straddles 1.0 on all three runs, which
+is the verdict. Nothing here changes; the row's grading is what already said it.
+
+### The re-certification's own provenance
+
+| | |
+|---|---|
+| **Commit measured at** | `32cb224d6e5dde730d1e7ddc99c062656cb68155` — `origin/main`, clean tree |
+| **Reproduction** | `cd implementation && npm run bench:hicasso` — **run twice at this instrument, exit 0 both times** |
+| **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium via Playwright), Windows 11 x64, 24 logical CPUs, sibling agents live on the box |
+| **Instrument** | `lane.cljs` `885592cf9fdd79f701d6353fc5d3dae0868d74f1` · `p0_reagent_app.cljs` `b7dfb2452b8a7984237e0c2db5e117dc72001638` · `p0_reagent_views.cljs` `4032e39779ce55fee1e1cd4f7a8e9561237e2cfd` · `run.cjs` `3dc92c316191b8f52ab04bfced399192203cf95d` · `order_guard.cljc` `e42450ef1c7759b51feca6a3d1bae2c0eb8ab323` |
+| **Arm-order guard** | **no refusal on either run** — `refuse? false`, `contaminated? false`, `unchecked? false`, tolerance 0.10 |
+| **Position completeness** | **60 of 60 per arm, on all 12 arms, both runs** — zero `:lost-positions`, every phase contrast adjudicated on a full 20-against-20 |
+| **Canonical-DOM parity** | clean under `:advanced` — `{:problems [] :ok? true}` |
+| **Verification** | **0 unverified of 1,220 on each run** (400 M1 mounts + 400 M2 mounts + 420 bulk writes) |
+
+**The guard repair is inert to this arm, and that is now measured rather than
+assumed.** The audit's third finding was that this page's whole warrant against
+position effects came from the *pre-repair* guard — the one that could drop a
+sample carrying a non-finite `:position` from the phase contrast while printing
+the arm's full count. Both re-runs report `unchecked? false` with **zero lost
+positions on every arm**, so each phase contrast was adjudicated on the full
+first-third-against-last-third split (20 against 20 of 60) rather than on a
+silently smaller set. The verdict *reportable* is the same verdict, now taken
+under an instrument that cannot narrow the question without saying so.
+
+### The controls, under both readings of the rule
+
+`lane/control-verdict` implements the **overlap** rule; HD-008 states a
+**strict** every-round-inside rule; **rf2-egdaq** is the open operator question
+of which governs. Both readings are reported here rather than adjudicated:
+
+| run | row | predicted | measured range | ±25% band | overlap rule | strict rule |
+|---|---|---|---|---|---|---|
+| 1 | M1 | 1.9989× | 1.778 – 2.071 | 1.499 – 2.499 | ✅ | ✅ |
+| 1 | M2 | 1.9412× | 1.500 – 2.000 | 1.456 – 2.427 | ✅ | ✅ |
+| 1 | bulk | 1.9989× | 1.600 – **2.500** | 1.499 – **2.499** | ✅ | ❌ by 0.0014 |
+| 2 | M1 | 1.9989× | 1.750 – 1.938 | 1.499 – 2.499 | ✅ | ✅ |
+| 2 | M2 | 1.9412× | 1.500 – 2.000 | 1.456 – 2.427 | ✅ | ✅ |
+| 2 | bulk | 1.9989× | 1.833 – **2.500** | 1.499 – **2.499** | ✅ | ❌ by 0.0014 |
+
+**Six controls, six passes under the rule actually installed.** The two that
+would fail a strict reading fail it by **0.0014**, and they fail it for a reason
+that is arithmetic rather than instrumental: the bulk floor's p50 is two to
+three of Chrome's 100 µs quanta, so the control's ratio can only land on a
+coarse lattice, and `2.5` is the lattice point immediately above a ceiling of
+`2.4986`. That is the shape of evidence rf2-egdaq needs and it points against
+tightening: **a strict rule would retroactively fail a control this page already
+published as passing**, on a quantisation artefact rather than on a loss of
+signal. Nothing here installs it.
+
 ## What this settles, and what it does not
 
 **Settles.** The bar's denominator exists and is a browser number. Reading
@@ -122,7 +243,19 @@ re-frame2 subscriptions rather than a bare cursor costs Reagent **≈1.22× on
 mount** of the 300-boundary shape and **≈2.01× on a broad commit** — both
 disjoint from 1.0, so both real. That figure was previously argued rather than
 measured, and it is the term that made the predecessor's `13.5×` broad-update row
-an upper bound of unknown content.
+an upper bound of unknown content. **It has now been measured three times** — the
+publication run and two independent re-runs at main — and all three agree; see
+[the re-certification](#the-re-certification-rf2-2rtt6.17).
+
+**Does not settle — one arm, three runs.** Repetition is not replication. The
+reactive leg still comes from *one implementation of one arm*: three runs of it
+bound the instrument's run-to-run noise, and they do not bound a systematic
+error in how `:reagent-ratom` is written. The converged witness set is a genuine
+second implementation of the **denominator** and its `reagent-subs ÷ floor`
+ranges overlap this page's on all three shared rows, but it carries **no
+`reagent-ratom` arm**, so nothing yet corroborates the reactive leg from a
+second author. A second witness for that term remains worth having, and this
+page does not claim otherwise.
 
 **Does not settle.** Nothing about a candidate: no Hicasso arm exists, and none is
 quotable against this table until it does. Nothing about UIx (rf2-2rtt6.4 owns the

--- a/docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md
+++ b/docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md
@@ -38,9 +38,48 @@ the bar, the budgets, the kill criteria, or these thresholds.
 
 ## Provenance
 
+**The instrument is identified by content hash, not by commit SHA** — a blob
+survives the rebase and the merge that rewrite a SHA, and this page's rows are
+the **retained-heap red-zone thresholds**, which are operative and not
+housekeeping.
+
+| file (`implementation/core/test/re_frame/bench/`) | blob at `bc5f38f10a` **and** `1415d9f7af` | on main `32cb224d6e` |
+|---|---|---|
+| `p0_run.cjs` | `e2d6eb6c722ad142123c34b99f9292328ddb11be` | `eec62f5a727e…` — **moved** |
+| `p0_heap.cljs` | `28caa45a31e4cb27b3305b1abf63d97dcc2c1a5e` | `d4dcb3f6e4a4…` — **moved** |
+| `p0_app.cljs` | `047ff2c0fdb1faaa4554778873e5f7f715befaf9` | `095731f2880c…` — **moved** |
+| `p0_harness.cljs` | `f33cb6449743c9e7e830c373683f40038d6bd132` | `74672756f712…` — **moved** |
+| `order_guard.cljc` | `adf59ca03cfe8e2639de97c031c138838f2d34b7` | `e42450ef1c77…` — **moved** (#7267) |
+| `p0_arms.cljs` | `89d26f8b9853d4fd06abfbdd99e6c7ac8a4cc060` | **unchanged** |
+| `p0_uix.cljs` | `45654d01eaefed42e61d4520ed48be0cebb08057` | **unchanged** |
+| `p0_reagent.cljs` | `f13d7e9cf0e59c498eae3358a14d239cf5338b35` | **unchanged** |
+| `p0_fixture.cljc` | `f5f615972f29c5c1418c0a788ffc8d84945d865a` | **unchanged** |
+| `p0_floor.cljs` | `66016daefb3c5dcf7e9601bc7a7ea6e8f68b8678` | **unchanged** |
+
+**Five of the ten instrument blobs have moved since these rows were taken, and
+this page says so rather than leaving a reader to discover it.** The three arm
+definitions and both fixtures are byte-identical on main; the driver, the heap
+probe, the app shell, the harness and the guard are not. The heap rows are
+**not** re-run on that account, and the reason is the one this page and [the
+converged set](p0-converged-witness-set.md) both give: retained bytes per
+subscribing boundary is a property of *the boundary*, and the axis already
+rests on three shapes spanning a 4× range in markup density agreeing within 8%
+— this page's list at 2.262×, its grid at 2.254×, and [the heap
+ladder](reads-per-boundary-heap-ladder.md)'s 2.435×. **The ladder was itself
+re-run under the repaired guard and every threshold moved by less than 0.2%**,
+which is the best available evidence that #7267's guard change is inert. A
+reader who wants the stronger check has the blob table above and the command
+below.
+
+```bash
+P=implementation/core/test/re_frame/bench/p0_heap.cljs
+git rev-parse 1415d9f7af:$P   # 28caa45a31e4cb27b3305b1abf63d97dcc2c1a5e
+git merge-base --is-ancestor 1415d9f7af origin/main && echo on-main
+```
+
 | | |
 |---|---|
-| **Producing commit** | `bc5f38f10a` |
+| **Producing commit** | `bc5f38f10a` — **off main.** Its landed equivalent is **`1415d9f7af`**, whose instrument tree is **byte-identical** (every blob in the table above matches); this page landed as **`462bcbffd4`**. The rebase rewrote the ids and moved no instrument byte |
 | **Reproduction (clock)** | `P0_ROUNDS=5 P0_SAMPLES=10 P0_WARMUPS=4 node implementation/core/test/re_frame/bench/p0_run.cjs --only clock` |
 | **Reproduction (heap)** | `P0_ROUNDS=5 P0_ROOTS=4 node implementation/core/test/re_frame/bench/p0_run.cjs --only heap` |
 | **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium via Playwright), Windows x64 |

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
@@ -944,9 +944,29 @@
 ;; What the two window shapes cost differently
 ;; ===========================================================================
 
+(defn- yield-window!
+  "Price `k` consecutive harness microtasks inside ONE clock window.
+
+  `now-ms`, `k` yields, `now-ms`, and nothing else in between.
+
+  The recursion mirrors [[window-of]]'s non-microtask branch EXACTLY —
+  `(js/Promise.resolve nil)` with the continuation inside the `.then`, so
+  the next turn begins in the turn the previous one finished in. That
+  matters: threading these through a promise-returning `.then` instead
+  would add two resolution ticks per step and price a window the arms
+  never run. At `k = 1` this is the original one-turn reading exactly."
+  [k]
+  (let [t0 (lane/now-ms)]
+    (letfn [(run [n]
+              (if (zero? n)
+                (js/Promise.resolve (- (lane/now-ms) t0))
+                (-> (js/Promise.resolve nil)
+                    (.then (fn [_] (run (dec n)))))))]
+      (run k))))
+
 (defn yield-cost!
-  "Price ONE harness microtask against the same clock the write rows use:
-  `now-ms`, a resolved-promise turn, `now-ms`, and nothing else in between.
+  "Price the harness microtask against the same clock the write rows use —
+  ONE turn per window, and `narrow-batch-k` turns per window.
 
   [[window-of]] gives a microtask-scheduled arm a window that does NOT
   contain this turn while every other arm's does, and that asymmetry has to
@@ -957,30 +977,77 @@
   its own resolution; anything else has to be subtracted before a ratio is
   quoted, and the report must say which happened.
 
+  WHY THE SECOND WINDOW EXISTS (rf2-2rtt6.19). The narrow row now batches
+  `narrow-batch-k` writes under one clock, so its window contains that many
+  harness microtasks rather than one — for every arm except the
+  microtask-scheduled one, which contains none. The one-turn reading bounds
+  the asymmetry at `< 100 µs` for ONE turn; multiplying it by ten does NOT
+  bound ten turns at `< 100 µs`, it bounds them at `< 1.0 ms`, which is up
+  to ~26% of a 3.8–7.6 ms batched sample. `10 × below-resolution` is not
+  below resolution, and that is the same argument that justified batching
+  the writes in the first place: timing k operations as ONE window lifts
+  the sample clear of the clamp, and is not the same as summing k
+  separately-clamped readings.
+
+  So the control is batched the way the row is. Ten turns share one clock,
+  the per-turn figure is that sample divided by ten, and the asymmetry
+  becomes a measurement instead of a multiplication.
+
   Measured OUTSIDE every arm's window, in its own turns, so it perturbs no
   published figure. Warmed like every other row, because a first promise
   turn is not a representative one."
   [{:keys [warmup samples]}]
-  (-> (chain []
-             (range (+ warmup samples))
-             (fn [acc s]
-               (let [t0 (lane/now-ms)]
-                 (-> (js/Promise.resolve nil)
-                     (.then (fn [_]
-                              (let [ms (- (lane/now-ms) t0)]
-                                (cond-> acc (>= s warmup) (conj ms)))))))))
-      (.then (fn [xs]
-               (let [s (lane/summarise xs)]
-                 {:control :harness-microtask-yield
-                  :p50     (:p50 s)
-                  :min     (:min s)
-                  :max     (:max s)
-                  :n       (:n s)
-                  :clamp   "Chrome clamps performance.now() to 100 µs"
-                  :note    (str "the turn every non-microtask-scheduled arm's write "
-                                "window contains and the reagent-slim arm's does not "
-                                "(rf2-b69lw); 0.0 means the asymmetry is below this "
-                                "instrument's resolution")})))))
+  (let [run (fn [k]
+              (chain []
+                     (range (+ warmup samples))
+                     (fn [acc s]
+                       (-> (yield-window! k)
+                           (.then (fn [ms] (cond-> acc (>= s warmup) (conj ms))))))))]
+    ;; SEQUENTIALLY, never `Promise.all`: two microtask chains in flight at
+    ;; once interleave on the one queue, and each would then be timing the
+    ;; other's turns as well as its own. The second run nests inside the
+    ;; first's `.then` and closes over its samples.
+    (-> (run 1)
+        (.then
+          (fn [xs1]
+            (.then
+              (run narrow-batch-k)
+              (fn [xsk]
+                (let [s1  (lane/summarise xs1)
+                      sk  (lane/summarise xsk)
+                      per (fn [v] (when (number? v) (/ v narrow-batch-k)))]
+                  {:control :harness-microtask-yield
+                   ;; The original one-turn reading, unchanged, so nothing
+                   ;; published against it moves.
+                   :p50     (:p50 s1)
+                   :min     (:min s1)
+                   :max     (:max s1)
+                   :n       (:n s1)
+                   :clamp   "Chrome clamps performance.now() to 100 µs"
+                   :note    (str "the turn every non-microtask-scheduled arm's write "
+                                 "window contains and the reagent-slim arm's does not "
+                                 "(rf2-b69lw); 0.0 means ONE such turn is below this "
+                                 "instrument's resolution")
+                   ;; The batched reading — the one the batched narrow row
+                   ;; actually needs, because its window holds k of these.
+                   :batched
+                   {:k            narrow-batch-k
+                    :window-p50   (:p50 sk)
+                    :window-min   (:min sk)
+                    :window-max   (:max sk)
+                    :n            (:n sk)
+                    :per-turn-p50 (per (:p50 sk))
+                    :per-turn-min (per (:min sk))
+                    :per-turn-max (per (:max sk))
+                    :note (str narrow-batch-k " harness microtasks under ONE clock, "
+                               "the same technique the narrow row uses for its "
+                               "writes. This is the quantity the batched narrow "
+                               "window's asymmetry actually is — present in every "
+                               "arm except the microtask-scheduled one. The "
+                               "one-turn reading above bounds ONE turn below the "
+                               "clamp; it does NOT bound " narrow-batch-k
+                               " of them, and this window measures them instead "
+                               "of multiplying (rf2-2rtt6.19)")}}))))))))
 
 ;; ===========================================================================
 ;; The positive control — predicted against measured, every run


### PR DESCRIPTION
Four beads on one surface: the provenance and reproducibility of the P0 baseline
wave's published numbers. A cold-read audit found their weakest property was not
their values but where they came from.

**The headline: the bar's denominator reproduces.** Every ratio in the programme
is measured against `p0-reagent-on-subs-baseline.md`, and it was the least
anchored measurement in the wave. It is now re-run, re-anchored, and corroborated
for the first time.

Nothing in this PR amends the bar, the budgets, the kill criteria, the red-zones
or the clock. No published figure is deleted; one wrong sentence is struck
through in place.

## rf2-2rtt6.17 — the bar's denominator, re-certified

The audit's four findings, each closed:

1. **The producing SHA was not on main.** Its landed equivalent is recovered:
   `19401ad083` → **`f03960a8da`**, an ancestor of main, whose instrument tree is
   **byte-identical** across all five files.
2. **There was no blob anchor.** All five blobs are now printed on the page — at
   the producing commit and on main — so a reader can tell drift from identity.
3. **Four of five instrument blobs had moved, and the row was neither re-run nor
   marked superseded.** It was re-run: twice, five rounds each, at main
   `32cb224d6e`, `npm run bench:hicasso`, **exit 0 both times**.
4. **It had never been re-certified under the repaired arm-order guard.** Both
   re-runs report `unchecked? false` with **zero lost positions on all 12 arms**,
   so every phase contrast was adjudicated on a full 20-against-20 of 60 rather
   than the silently smaller set the pre-repair guard could produce.

**Every row reproduces. Nothing is superseded.**

| row | figure | published | re-run 1 | re-run 2 |
|---|---|---|---|---|
| M1 mount | `reagent-subs ÷ floor` | 3.899 [3.447–4.300] | 3.973 [3.556–4.571] | 3.513 [3.313–3.688] |
| M1 mount | **reactive leg** | **1.218 [1.122–1.310]** | **1.216 [1.185–1.241]** | **1.213 [1.093–1.273]** |
| M2 mount | reactive leg | 1.056 [0.960–1.242] straddles | 1.150 [1.000–1.333] straddles | 1.050 [1.000–1.250] straddles |
| bulk broad | `reagent-subs ÷ floor` | 7.064 [6.200–7.700] | 7.280 [6.400–8.000] | 7.330 [6.400–8.500] |
| bulk broad | **reactive leg** | **2.008 [1.938–2.100]** | **1.965 [1.875–2.000]** | **2.073 [2.000–2.167]** |

**Headline 1 is corroborated for the first time.** The mount leg's three means sit
inside 0.5% of each other; both legs are disjoint from 1.0 on all three runs.

One range does not overlap, and the page says so rather than smoothing it: run 1's
`M2/reagent-ratom ÷ floor` reads [1.333–1.500] against a published [1.625–2.083],
on the row already graded diagnostic, at two to four of Chrome's 100 µs quanta.
Run 2 overlaps, and the leg that row reports straddles 1.0 on all three runs.

Adds the **Does-not-settle** clause the audit asked for: three runs of one arm
bound run-to-run noise, not a systematic error, and the converged arm still
carries no `reagent-ratom` arm to corroborate the reactive leg from a second
author.

## rf2-rjfz1 — the three unmoved converged rows reproduce

`p0_converge_app` asserted at boot that `slot-order` *degenerates* at `k=2`;
PR #7267 repaired that degeneracy and missed the assertion, so the driver exited 1
before taking a sample until PR #7275. PR #7275 re-ran only the narrow row, which
left three rows never once reproduced against a driver that runs.

One full four-row sweep at main, **exit 0**. All four reproduce:

| row | published | sweep |
|---|---|---|
| M1 mount | 1.2301 [1.1099–1.3538] disjoint | 1.2887 [1.1462–1.4242] disjoint |
| M2 mount | 1.0539 [0.8572–1.4286] straddles | 1.0327 [0.8000–1.2727] straddles |
| bulk broad | 0.6239 [0.4701–0.7857] disjoint | 0.6020 [0.5263–0.7353] disjoint |
| bulk narrow | 1.1540 [1.0570–1.2053] disjoint | 1.1693 [1.1136–1.2528] disjoint |

A reproduction check, not a re-publication: **no figure on the page moves.**
0 unverified of 7,860. Guard clean on all four rows, zero lost positions.

## rf2-2rtt6.18 — the two operative red-zone pages, anchored

Both pages cited an off-main SHA with no blob anchor. Both now carry the landed
commit and the printed hashes.

- **Frontier arm (heap red-zones):** producing `bc5f38f10a` → landed
  **`1415d9f7af`** (page `462bcbffd4`), tree byte-identical across all ten files.
  All ten blobs printed. **Five of the ten have moved on main** and the page says
  so; the heap rows are not re-run on that account, and the page states why.
- **Converged set (clock red-zones):** the page asserted *"the four bench files
  are byte-identical (same blob hashes)"* **and printed no hashes**, so the check
  it was making could not be performed. Producing `44900cd4fd` → landed
  **`4c3f7189c4`** (page `a987caca26`). Six blobs printed, four moved since.

Also corrects a provenance claim that has expired: the bead recorded that the
converged reproduction command exits 1 on main. **It no longer does** — verified
to exit 0 at `32cb224d6e` by rf2-rjfz1's sweep in this branch.

Deliberately **not** touched: the converged page's Method bullet still asserts the
`k=2` cancellation `slot-order` no longer has. That text is `rf2-ouwh8`'s by the
bead's own no-duplicate note and `rf2-ouwh8` is open; the page body already
carries a paragraph explaining the repair.

## rf2-2rtt6.19 — the microtask asymmetry, measured instead of multiplied

HD-008's limitations section bounded its batched narrow window's asymmetry as
*"ten times a quantity below the instrument's own resolution"*. Ten × unresolved
is not unresolved: it bounds ten turns at `< 1.0 ms`, up to ~26% of a 3.8–7.6 ms
sample — present in three columns and absent from `reagent-slim`'s, which is the
comparison the donor gate turns on.

`hd8-rows/yield-cost!` now applies **the page's own batching technique to the
control**: ten harness microtasks under one clock, per-turn reported as sample ÷ 10.

Two details decide whether the number means anything, and both are in the code:

- The recursion mirrors `window-of`'s non-microtask branch **exactly** —
  `(js/Promise.resolve nil)` with the continuation inside the `.then` — because
  threading the turns through a promise-returning `.then` would add two
  resolution ticks per step and price a window no arm runs.
- The two readings run **sequentially, never through `Promise.all`**: two
  microtask chains in flight on one queue would each time the other's turns.

**Measured, all three runs: ten turns under one clock read 0.0 ms**, window and
per-turn, `n = 10`. The asymmetry is therefore bounded at `< 100 µs` for the whole
batch rather than `< 1.0 ms` — **at most 2.6% of the smallest batched narrow
sample and 1.3% of the largest**, where the sentence it replaces left a reader
facing up to 26%. Ten times tighter, and nothing is subtracted — now as a finding
rather than an assumption.

No published row moves: the control is measured outside every arm's window, the
one-turn reading is unchanged and still reported, and no arm's window was touched.

## Controls, under both readings of the rule (rf2-egdaq)

`rf2-egdaq` is open and the operator's, and **nothing here installs the strict
rule**. Both readings are reported on every run this PR took:

- **All 14 controls pass the overlap rule** that `lane/control-verdict` implements.
- **10 of 14 also pass a strict every-round-inside reading.** The 4 that do not
  are all the bulk-broad control, and they miss by **0.0014** — measured max
  `2.500` against a ceiling of `2.4986`, on a floor of two to three of Chrome's
  100 µs quanta, so `2.5` is the lattice point immediately above the ceiling.
- Evidence *against* tightening: a strict rule would retroactively fail a control
  the denominator page already published as passing, on a quantisation artefact
  rather than on lost signal.
- Reported but **not** used to settle it: the converged M2 control the operator
  holds open reads `[1.500–2.000]` and `[1.600–2.000]` on this sweep — both wholly
  inside the band, so both pass under either reading, where the published
  `[1.333–2.000]` passes the overlap rule and fails the strict one. A re-run
  producing a friendlier control is not an argument for a rule.

## Instrument discipline

- **`unverified > 0` fails the run.** Across every run in this PR: **0 unverified
  of 12,520** — denominator 1,220 × 2 runs, converged 7,860, HD-008's own gates on
  top. No arm skipped verification.
- **Positive controls predicted before each run**, from element-count arithmetic,
  published pass or fail.
- **Both orders, ranges across rounds, never a mean alone.** Every range that
  includes 1.0 is reported as indistinguishable.
- **Arm-order guard**: `refuse? false`, `contaminated? false`, `unchecked? false`
  on every run; self-test **11/11** including the two repaired cases (`k=2`
  alternation, and non-finite `:position` refusing rather than narrowing).
  **The tolerance was not touched.**
- Blob hashes lead the provenance; SHAs are cited beside them.

## An instrument hazard found on the way, not a defect in main

`run.cjs`, `p0_converge_run.cjs` and `hd8_run.cjs` all drive build id
`hicasso-bench` with a different `:init-fn` through `--config-merge`. Running one
after another leaves a `.shadow-cljs/builds/hicasso-bench` cache that compiles
cleanly and then **dies at runtime under `:advanced`** — `hd8_run.cjs` exited 1
with `pageerror: Cannot read properties of undefined (reading 'd')` before taking
a sample. It reproduces at **unmodified `HEAD`** and clears completely with
`rm -rf implementation/.shadow-cljs/builds/hicasso-bench`. Worth a bead: the P0
lane's one-build-id design (HD-017) means "run the lane, then run HD-008" silently
produces a dead page, and the driver's own failure message correctly refuses to
publish but cannot say why.

## Quality gates

All gates run **foreground to completion**, never piped through `tail`/`grep`,
with worktree-local logs and exit codes echoed.

| gate | exit | result |
|---|---|---|
| `npm run bench:hicasso` — denominator, run 1 | **0** | all 3 rows measured; guard clean; 0 unverified of 1,220 |
| `npm run bench:hicasso` — denominator, run 2 | **0** | all 3 rows measured; guard clean; 0 unverified of 1,220 |
| `node …/p0_converge_run.cjs` — converged 4-row sweep | **0** | all 4 rows measured; guard clean; 0 unverified of 7,860 |
| `node …/hd8_run.cjs` — all three adapter runs | **0** | batched control measured; no arm reads differently for its position |
| arm-order guard self-test | **11/11** | in every driver run above, including the two repaired cases |
| `npm run test:freehand` | **0** | Ran 1399 tests containing 7752 assertions. 0 failures, 0 errors. |
| `npm run test:browser` | **0** | Ran 851 tests containing 5503 assertions. 0 failures, 0 errors. |
| `mkdocs build --strict` | **not run** | `mkdocs` is not on PATH in this worktree (exit 127, command not found) — **CI owns this gate**. Docs changes are prose, tables and one intra-page anchor rename. |

**Anchor note.** A heading containing `rf2-2rtt6.17` slugifies with the dot
removed, which would have broken every intra-page link to it. The heading is now
`## The re-certification` (dotless, matching the repo's existing
`#the-re-take-rf2-b69lw` convention) with the bead id in the first line.

## Fence

Touched: `implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs` and
four studio pages. **No production code, no `order_guard` tolerance, no
`control-verdict` decision logic, no `implementation/shadow-cljs.edn`, no
`spec/**`.** `rf2-2rtt6.13`'s priced six-line spine fix remains deliberately
unlanded.

## Beads filed

- **rf2-2rtt6.20** (P2, bug) — the shared-build-id cache hazard above.
- **rf2-2rtt6.21** (P3) — give the reactive leg a second author: a
  `reagent-ratom` arm on the converged witness set, so headline 1's leg can be
  formed a second way. One arm on an existing instrument, not a new page.
