### PR TITLE
bench(hicasso): stop the shared build id poisoning the P0 lane cache (rf2-2rtt6.20)

### DIFF
--- a/docs/design/hicasso/studio/README.md
+++ b/docs/design/hicasso/studio/README.md
@@ -69,11 +69,14 @@ npm-conversion cache: its index is invalidated on shadow's own cache key, never
 on the set of npm modules the build actually needs, so the UIx arm's
 `react/jsx-runtime` was linked against whole-build state established for the
 Reagent arms' fourteen modules. **Every reproduction command on these pages
-therefore runs from a cold or a warm cache, in any order.** The clear sits
-inside the run-to-run noise — the time is JVM start, classpath and the Closure
-`:advanced` pass, not the CLJS compile the cache holds —
-and `freehand/test/re_frame/bench/hicasso/lane_cache.cjs` carries the isolation,
-the measurement and the alternatives that were rejected.
+therefore runs from a cold or a warm cache, in any order** — and emits the same
+bundle either way, which a reproduction command needs and did not previously
+have: two cleared-cache builds of an arm are byte-identical, where before the
+fix the bundle depended on which arm had built last. The clear sits inside the
+run-to-run noise, because the time is JVM start, classpath and the Closure
+`:advanced` pass rather than the CLJS compile the cache holds.
+`freehand/test/re_frame/bench/hicasso/lane_cache.cjs` carries the isolation, the
+measurement and the alternatives that were rejected.
 
 The instrument is
 `implementation/freehand/test/re_frame/bench/hicasso/lane.cljs`; it lives in the

--- a/docs/design/hicasso/studio/README.md
+++ b/docs/design/hicasso/studio/README.md
@@ -57,6 +57,24 @@ Exit codes: `0` measured and clean, `1` the run failed, **`2` the arm-order
 guard refused** — a figure that moves with its position in the plan is not a
 figure, and the repair is the arm, never the tolerance.
 
+**One build id also means one build cache, and each driver now clears it before
+building** (`rf2-2rtt6.20`). shadow-cljs derives the cache directory from the
+build id alone, and fixes it before any `--config-merge` data is applied — so
+the arm is invisible to the cache key and every arm above shared one cache
+entry. Running the commands in this section in sequence used to leave a cache
+that compiled cleanly and then produced an `:advanced` bundle that **died on its
+first execution**, `Cannot read properties of undefined (reading 'd')`, which
+made a sound arm look broken at HEAD. The carrier was the `shadow-js/`
+npm-conversion cache: its index is invalidated on shadow's own cache key, never
+on the set of npm modules the build actually needs, so the UIx arm's
+`react/jsx-runtime` was linked against whole-build state established for the
+Reagent arms' fourteen modules. **Every reproduction command on these pages
+therefore runs from a cold or a warm cache, in any order.** The clear sits
+inside the run-to-run noise — the time is JVM start, classpath and the Closure
+`:advanced` pass, not the CLJS compile the cache holds —
+and `freehand/test/re_frame/bench/hicasso/lane_cache.cjs` carries the isolation,
+the measurement and the alternatives that were rejected.
+
 The instrument is
 `implementation/freehand/test/re_frame/bench/hicasso/lane.cljs`; it lives in the
 bench/test measurement lane HD-017 carves out of the donor freeze, and it

--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -34,7 +34,7 @@ Bead **`rf2-2rtt6.7`**. Decision **[HD-008](../decisions.md)**. The standard is
 | **Producing commit, re-take** | `b943c7ed20d63d66fade4775059dad9fcf0012a7` — the `reagent-slim` write rows only (`rf2-b69lw`) |
 | **Producing commit, re-take** | `d3f1c2fff6` on `worker/lane-control-cluster` — the **narrow write rows** only, on a batched window (`rf2-9zysg`) |
 | **Producing instrument** | `hd8_rows.cljs` blob `e6bca24420b7fc4c9de2c6137f5b2f7144ad243d`, `lane.cljs` blob `671756751ecdb25c4c3d81e164c3204b022e93ae` |
-| **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs` — runs at every commit above |
+| **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs` — runs at every commit above, and **from a cold or a warm cache in any order** since `rf2-2rtt6.20` ([why](#the-lanes-shared-build-cache-made-this-page-look-broken-rf2-2rtt620)) |
 | **Build** | `:hicasso-bench` (rf2-2rtt6.2's lane) — `:advanced`, `goog.DEBUG false` |
 | **Runtime** | Chromium `HeadlessChrome/147.0.7727.15` (Windows NT 10.0 x64), React 19.2.0, node v24.13.0 |
 | **Rounds** | 6 · mount `{:warmup 4 :samples 12}` · write `{:warmup 3 :samples 10}` |
@@ -474,6 +474,57 @@ unchanged when it is absent — is filed as **`rf2-pq7d8`**. It is deliberately
 measuring on it, and a shared instrument must not change under a measurement in
 flight. HD-008's own `timed-write!` is a separate copy, which is why this repair
 could land without touching it.
+
+## The lane's shared build cache made this page look broken (`rf2-2rtt6.20`)
+
+**No figure on this page moves, and none of them ever depended on this.** It is
+recorded because the symptom pointed squarely at HD-008 and the cause was not
+here at all.
+
+Found by `rf2-2rtt6.19` while re-reading the yield-cost control: after the
+natural sequence — run the P0 lane, then run HD-008 — `hd8_run.cjs` **exited 1
+before taking a single sample**, with
+
+```
+pageerror: Cannot read properties of undefined (reading 'd')
+```
+
+It reproduced at *unmodified* HEAD, which is how it was localised, and it
+cleared completely with `rm -rf implementation/.shadow-cljs/builds/hicasso-bench`.
+
+**The cause is the lane's one build id, not this arm.** HD-017 gives the whole
+programme a single `:hicasso-bench` so that no arm costs a hot-zone edit of
+`implementation/shadow-cljs.edn`; shadow-cljs derives the build cache directory
+from the build id alone, and fixes it *before* any `--config-merge` data is
+applied. The arm is therefore invisible to the cache key, and several different
+programs shared one cache entry.
+
+The carrier was isolated rather than assumed, each trial from a cold cache
+replaying the same poisoning history — the trap self-heals once the cache has
+accumulated every arm's modules, so a warm trial proves nothing:
+
+| trial | result |
+|---|---|
+| control — poison, remove nothing | **DEAD**, `reading 'd'` |
+| remove `shadow-js/` only | **ALIVE** |
+| remove `closure.property.map` + `closure.variable.map` only | **DEAD** — the first suspect, and not the carrier |
+
+`shadow-js/` is the npm-conversion cache. Its index is invalidated on shadow's
+own cache key and never on the set of npm modules the build actually needs, so
+the Reagent arms' fourteen modules — which do not include `react/jsx-runtime` —
+left an index that this page's UIx arm was then linked against. That produces a
+bundle which compiles cleanly and is wrong in a way only execution can show.
+
+**The driver's fail-closed logic behaved correctly throughout.** It refused to
+publish anything from a page that had thrown (`rf2-f5roa`), which is exactly
+right; what it could not do was say *why*, and the likeliest conclusion for a
+reader was that HD-008 was broken on main. It was not.
+
+Every driver in the lane now clears the shared entry before it builds, so
+**this page's reproduction command runs from a cold or a warm cache, in any
+order.** The clear is inside the run-to-run noise;
+`freehand/test/re_frame/bench/hicasso/lane_cache.cjs` carries the measurement
+and the alternatives that were rejected.
 
 ## Known limitations of this instrument
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
@@ -58,6 +58,10 @@ const path = require('node:path');
 const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs');
 const guard = require('../../freehand/bench/order_guard.cjs');
 const { watchPage } = require('../../freehand/bench/sentinel.cjs');
+// One build id, N programs, so nothing may cache between them (rf2-2rtt6.20).
+// This driver is where the fault was found: run the P0 lane, then run HD-008,
+// and the page died before taking a sample.
+const { resetLaneBuildCache } = require('./lane_cache.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 const REPO = path.resolve(IMPL, '..');
@@ -130,6 +134,11 @@ function revision() {
 }
 
 function build() {
+  // The lane's cache rule, before anything reads the cache. `lane_cache.cjs`
+  // carries the measurement and the rejected alternatives.
+  if (resetLaneBuildCache(IMPL, BUILD_ID)) {
+    console.error(`[hd8] cleared .shadow-cljs/builds/${BUILD_ID} — one build id, N arms (rf2-2rtt6.20)`);
+  }
   console.error('[hd8] building :advanced bundle (goog.DEBUG false) ...');
   // `node cli/runner.js` rather than the `.cmd` shim: spawning a shim on
   // Windows needs `shell: true`, and a shell concatenates argv, which is the

--- a/implementation/freehand/test/re_frame/bench/hicasso/lane_cache.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/lane_cache.cjs
@@ -60,6 +60,15 @@
 // not the CLJS compile the cache holds. Against a driver run measured in
 // minutes it is not a cost at all.
 //
+// And it buys something beyond not crashing: **the build becomes
+// deterministic.** Two cleared-cache builds of the same arm emit a
+// byte-identical `main.js` (sha256 `a1d14753ef818fcd…`, measured both ways),
+// where before the fix the bundle depended on which arm had built last —
+// Closure's renaming for a build compiled fresh differs from the same build
+// compiled with a sibling warm, which `hicasso_narrow_run.cjs` measured at
+// 4,075 bytes. A reproduction command a studio page publishes should not emit
+// a different bundle depending on what the reader ran an hour ago.
+//
 // Rejected, with reasons, so the next reader does not re-litigate them:
 //
 //   * A build id per arm. Six hot-zone, sequenced edits to

--- a/implementation/freehand/test/re_frame/bench/hicasso/lane_cache.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/lane_cache.cjs
@@ -1,0 +1,91 @@
+'use strict';
+// THE HICASSO LANE'S ONE CACHE RULE — rf2-2rtt6.20.
+//
+// HD-017 gives the whole P0 lane a SINGLE build id, `:hicasso-bench`, because
+// `implementation/shadow-cljs.edn` is hot-zone and a build id per arm would be
+// a sequenced dispatch per arm. Every driver in this directory therefore rides
+// that one id and supplies its own `:init-fn` and `:output-dir` through
+// `--config-merge`. That design is good and this file does not change it.
+//
+// What it costs is stated here once: **one build id means one build cache**,
+// and shadow-cljs derives the cache directory from the build id alone —
+// `<cache-root>/builds/<build-id>/<mode>` (`shadow.cljs.devtools.config/
+// make-cache-dir`), fixed in `new-build` BEFORE any `--config-merge` data is
+// applied (`shadow.build/configure`). So the arm is invisible to the cache
+// key, and N different programs share one cache entry.
+//
+// ## The fault that makes this a rule rather than a note
+//
+// Running one arm after another left a cache that COMPILED CLEANLY and then
+// produced an `:advanced` bundle that DIED ON ITS FIRST EXECUTION:
+//
+//     pageerror: Cannot read properties of undefined (reading 'd')
+//
+// MEASURED, at unmodified main `6509d8e5c5`: from a cold cache, two
+// `run.cjs` builds (`p0-reagent-app`) and one `p0_converge_run.cjs` build
+// (`p0-converge-app`), then `hd8_run.cjs` — which exits 1 before taking a
+// single sample. `rm -rf .shadow-cljs/builds/hicasso-bench` clears it
+// completely.
+//
+// THE CARRIER IS `shadow-js/`, the npm-conversion cache, and it was isolated
+// rather than assumed. `shadow.build.closure/convert-sources-simple` keeps
+// `shadow-js/index.json.transit` — the converted-module index plus the build's
+// `:injected-libs` — and invalidates it only on `SHADOW-CACHE-KEY` or
+// `cache-affecting-options`, NEVER on the set of modules the build actually
+// needs. The Reagent arms pull 14 npm modules and no `react/jsx-runtime`; the
+// UIx arm needs it. Building the UIx arm over the Reagent arms' index links
+// the newcomer against whole-build state established for a different module
+// set, and the bundle is wrong in a way only execution can show.
+//
+// The isolation, each trial from a COLD cache and each replaying the same
+// poisoning history (the trap is self-healing once the index has accumulated
+// every arm's modules, so a warm trial proves nothing):
+//
+//     control, remove nothing   -> DEAD  (reading 'd')
+//     remove shadow-js/ only    -> ALIVE
+//
+// The two Closure name-stability maps were the first suspect and are NOT the
+// carrier: removing `closure.property.map` and `closure.variable.map` from a
+// poisoned cache leaves it dead. That failed guess is why this file clears the
+// WHOLE entry instead of the one directory now known to carry it — the
+// invariant "N programs, one id, so nothing may cache between them" holds
+// whatever shadow-cljs caches next, and a surgical clear is a standing bet on
+// internals that has already been lost once.
+//
+// ## What it costs, measured, because that was the objection
+//
+// Nothing that registers. Rebuilding `hd8-app` on this box, alternating:
+// warm 34s, 26s; cleared 33s, 37s. The clear is inside the run-to-run noise,
+// because the time is JVM start, classpath and the Closure `:advanced` pass —
+// not the CLJS compile the cache holds. Against a driver run measured in
+// minutes it is not a cost at all.
+//
+// Rejected, with reasons, so the next reader does not re-litigate them:
+//
+//   * A build id per arm. Six hot-zone, sequenced edits to
+//     `implementation/shadow-cljs.edn` to buy back three seconds, and it
+//     discards the one thing HD-017 built this lane to avoid.
+//   * A cache root per arm (`SHADOW_CLJS='{:cache-root ...}'`, the only lever
+//     that reaches `:cache-root`, since `--config-merge` cannot). It would
+//     keep a warm cache per arm — but it also duplicates the 22 MB
+//     `jar-manifest` and the classpath cache per arm, and the node side still
+//     discovers a server through `.shadow-cljs`, so the override can silently
+//     fail to apply. A silent non-fix for the silent-failure bug.
+//   * Only improving the error message (the bead's fallback). It leaves the
+//     trap armed.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Clears the shared build cache entry for `buildId`, both modes. Returns the
+// directory if one was there, else null. `maxRetries` because this is Windows
+// and a scanner or a just-exited JVM can still hold a handle for a moment —
+// the same guard `package.json`'s `clean:freehand-*` scripts use.
+function resetLaneBuildCache(implDir, buildId) {
+  const dir = path.join(implDir, '.shadow-cljs', 'builds', buildId);
+  if (!fs.existsSync(dir)) return null;
+  fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  return dir;
+}
+
+module.exports = { resetLaneBuildCache };

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
@@ -69,6 +69,8 @@ const path = require('node:path');
 const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs');
 // The directory's ONE sentinel wait, raced against the page dying (rf2-f5roa).
 const { watchPage } = require('../../freehand/bench/sentinel.cjs');
+// One build id, N programs, so nothing may cache between them (rf2-2rtt6.20).
+const { resetLaneBuildCache } = require('./lane_cache.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 
@@ -119,6 +121,11 @@ const CONFIG_MERGE =
   `:modules {:main {:init-fn ${INIT_FN}}}}`;
 
 function build() {
+  // The lane's cache rule, before anything reads the cache. `lane_cache.cjs`
+  // carries the measurement and the rejected alternatives.
+  if (resetLaneBuildCache(IMPL, BUILD_ID)) {
+    console.error(`[converge] cleared .shadow-cljs/builds/${BUILD_ID} — one build id, N arms (rf2-2rtt6.20)`);
+  }
   console.error(`[converge] building :advanced bundle — ${INIT_FN} -> ${OUT_DIR}`);
   const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
   const r = spawnSync(

--- a/implementation/freehand/test/re_frame/bench/hicasso/retention_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/retention_run.cjs
@@ -47,6 +47,8 @@ const http = require('node:http');
 const path = require('node:path');
 
 const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs');
+// One build id, N programs, so nothing may cache between them (rf2-2rtt6.20).
+const { resetLaneBuildCache } = require('./lane_cache.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 
@@ -92,6 +94,11 @@ const CONFIG_MERGE =
   `{:output-dir "${OUT_DIR}" :asset-path "." :modules {:main {:init-fn ${INIT_FN}}}}`;
 
 function build() {
+  // The lane's cache rule, before anything reads the cache. `lane_cache.cjs`
+  // carries the measurement and the rejected alternatives.
+  if (resetLaneBuildCache(IMPL, BUILD_ID)) {
+    console.error(`[ret] cleared .shadow-cljs/builds/${BUILD_ID} — one build id, N arms (rf2-2rtt6.20)`);
+  }
   console.error(`[ret] building :advanced bundle — ${INIT_FN} -> ${OUT_DIR}`);
   // `node cli/runner.js` rather than the `.cmd` shim: spawning a shim on
   // Windows needs `shell: true`, and a shell concatenates argv, which is

--- a/implementation/freehand/test/re_frame/bench/hicasso/run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/run.cjs
@@ -46,6 +46,8 @@ const path = require('node:path');
 // budget this driver's own 20-minute sentinel cannot reach, whose failure
 // line reads exactly like the bench timeout it is not.
 const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs');
+// One build id, N programs, so nothing may cache between them (rf2-2rtt6.20).
+const { resetLaneBuildCache } = require('./lane_cache.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 
@@ -67,6 +69,11 @@ const CONFIG_MERGE =
   `:modules {:main {:init-fn ${INIT_FN}}}}`;
 
 function build() {
+  // The lane's cache rule, before anything reads the cache. `lane_cache.cjs`
+  // carries the measurement and the rejected alternatives.
+  if (resetLaneBuildCache(IMPL, BUILD_ID)) {
+    console.error(`[hicasso] cleared .shadow-cljs/builds/${BUILD_ID} — one build id, N arms (rf2-2rtt6.20)`);
+  }
   console.error(`[hicasso] building :advanced bundle — ${INIT_FN} -> ${OUT_DIR}`);
   // `node cli/runner.js` rather than the `.cmd` shim: spawning a shim on
   // Windows needs `shell: true`, a shell concatenates argv, and a

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs
@@ -45,6 +45,11 @@ const http = require('node:http');
 const path = require('node:path');
 
 const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs');
+// One build id, N programs, so nothing may cache between them (rf2-2rtt6.20).
+// This driver needs it MOST: it builds four different variants back to back in
+// a single run, so it was poisoning its own later rungs with its earlier ones
+// without any second driver being involved.
+const { resetLaneBuildCache } = require('./lane_cache.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 const BUILD_ID = 'hicasso-bench';
@@ -103,6 +108,12 @@ function selected() {
 }
 
 function build(variant) {
+  // The lane's cache rule, before anything reads the cache — and PER VARIANT,
+  // because each of the four is a different program. `lane_cache.cjs` carries
+  // the measurement and the rejected alternatives.
+  if (resetLaneBuildCache(IMPL, BUILD_ID)) {
+    console.error(`[z3vlz] cleared .shadow-cljs/builds/${BUILD_ID} — one build id, N variants (rf2-2rtt6.20)`);
+  }
   console.error(`[z3vlz] building :advanced — ${variant.name} -> ${variant.outDir}`);
   // ONE LINE, deliberately: shadow-cljs's CLI re-splits `--config-merge` on
   // whitespace when the EDN contains a newline and then reports `EOF while


### PR DESCRIPTION
Closes **rf2-2rtt6.20**.

## The sequence that reproduces it, at unmodified HEAD

From a cold cache at `6509d8e5c5`, `origin/main`, clean tree:

```bash
cd implementation
rm -rf .shadow-cljs/builds/hicasso-bench
R=node_modules/shadow-cljs/cli/runner.js
# run.cjs's build, twice — the bead ran run.cjs twice
node $R release hicasso-bench --config-merge '{:output-dir "out/hicasso-bench" :asset-path "." :modules {:main {:init-fn re-frame.bench.hicasso.p0-reagent-app/-main}}}'
node $R release hicasso-bench --config-merge '{:output-dir "out/hicasso-bench" :asset-path "." :modules {:main {:init-fn re-frame.bench.hicasso.p0-reagent-app/-main}}}'
# p0_converge_run.cjs's build
node $R release hicasso-bench --config-merge '{:output-dir "out/hicasso-converge" :asset-path "." :modules {:main {:init-fn re-frame.bench.hicasso.p0-converge-app/-main}}}'
# then the driver, unmodified
HD8_ONLY=uix node freehand/test/re_frame/bench/hicasso/hd8_run.cjs
```

Every build exits 0. The three builds are the poisoning history — a driver's
measurement phase never touches the build cache, only its build step does, so
replaying the build steps reproduces the fault without paying for the P0 lane's
measurement time.

**Before — `[:hicasso-bench] Build completed. (169 files, 20 compiled, 0 warnings)` and then:**

```
[hd8:uix] PAGE PAGEERROR: Cannot read properties of undefined (reading 'd')
[hd8] FAILED: uix: THE PAGE DIED BEFORE IT FINISHED
HD8_EXIT=1
```

**After — the identical script, unmodified, on this branch:**

```
[hd8] cleared .shadow-cljs/builds/hicasso-bench — one build id, N arms (rf2-2rtt6.20)
[hd8] ok — measured, and no arm reads differently for its position in the plan
HD8_EXIT=0
```

Note that the poisoning steps in that script are still raw `shadow-cljs`
invocations, so this also shows the fix holds against a **non-cooperating**
poisoner rather than only against its fixed siblings.

**And the same thing from a WARM cache**, which is the bead's own gate. Nothing
cleared, the cache left in whatever state the preceding gates put it (`z3vlz`'s
four variants ran last, 14 npm modules cached), then both P0 arms build over it
and HD-008 runs:

```
cache state before (NOT cleared): ana  closure.property.map  closure.variable.map
                                  externs.shadow.js  shadow-js (14 modules)
warm poison A (p0-reagent)  exit=0
warm poison B (p0-converge) exit=0
[hd8] cleared .shadow-cljs/builds/hicasso-bench — one build id, N arms (rf2-2rtt6.20)
[:hicasso-bench] Build completed. (169 files, 114 compiled, 0 warnings, 24.42s)
[hd8] ok — measured, and no arm reads differently for its position in the plan
GATE_WARM_HD8_EXIT=0
```

## The cause

HD-017 gives the whole P0 lane one build id, `:hicasso-bench`, because
`implementation/shadow-cljs.edn` is hot-zone and a build id per arm would be a
sequenced dispatch per arm. shadow-cljs derives the build cache directory from
the build id alone — `<cache-root>/builds/<build-id>/<mode>`, fixed in
`new-build` **before** any `--config-merge` data is applied. The arm is
therefore invisible to the cache key, and N different programs share one entry.
`--config-merge` cannot reach `:cache-root`; it merges into the *build* config,
which is applied later.

**The carrier was isolated, not assumed.** Each trial ran from a cold cache and
replayed the same poisoning history — the trap self-heals once the cache has
accumulated every arm's npm modules, so a warm trial proves nothing (the first
attempt at this control came back ALIVE for exactly that reason and had to be
thrown away):

| trial | result |
|---|---|
| control — poison, remove nothing | **DEAD**, `reading 'd'` |
| remove `shadow-js/` only | **ALIVE** |
| remove `closure.property.map` + `closure.variable.map` only | **DEAD** |

`shadow-js/` is the npm-conversion cache. `shadow.build.closure/convert-sources-simple`
invalidates its index on `SHADOW-CACHE-KEY` or `cache-affecting-options` and
**never on the set of modules the build actually needs**. The Reagent arms pull
14 npm modules and no `react/jsx-runtime`; the UIx arm needs it, and building it
over the Reagent arms' index links it against whole-build state established for
a different module set. The result compiles cleanly and is wrong in a way only
execution shows.

## The fix, and what was rejected

Each driver clears the shared entry before it builds, through one helper —
`lane_cache.cjs` — that states the invariant once: **one build id hosts N
programs, so nothing may cache between them.**

Clearing the *whole* entry rather than the one directory now known to carry it
is deliberate. The Closure name-stability maps were the obvious first suspect
and are **not** the carrier; that lost bet is the reason a surgical clear is not
worth making a standing wager on shadow-cljs internals.

**The cost objection does not survive measurement.** Rebuilding `hd8-app`,
alternating: warm 34s, 26s; cleared 33s, 37s. The clear is inside the
run-to-run noise, because the time is JVM start, classpath and the Closure
`:advanced` pass — not the CLJS compile the cache holds. Against a driver run
measured in minutes it is not a cost.

Rejected:

* **A build id per arm** — six hot-zone, sequenced edits to
  `implementation/shadow-cljs.edn` to buy back seconds, discarding the one thing
  HD-017 built this lane to avoid.
* **A cache root per arm** (`SHADOW_CLJS='{:cache-root ...}'`, the only lever
  that reaches `:cache-root`). It would keep a warm cache per arm, but it
  duplicates the 22 MB `jar-manifest` and the classpath cache per arm, and the
  node side still discovers a server through `.shadow-cljs`, so the override can
  silently fail to apply — a silent non-fix for a silent-failure bug.
* **Only improving the error message** (the bead's own fallback `(c)`) — it
  leaves the trap armed. Not needed once the cause is gone.

## `z3vlz_run.cjs` was poisoning itself

It builds four different variants back to back **in a single run**, so it hit
this with no second driver involved. It now clears per variant.

## No measured window moves

This is a build-step change only. No schedule, arm, witness, timed region,
tolerance or guard is touched, and `control-verdict` and `order_guard.*` are not
edited. `implementation/shadow-cljs.edn` was **not** touched — the whole point
of the fix is that it does not need to be.

Instrument blob hashes for the five drivers do move, since the drivers are
edited. The studio provenance tables are anchored to *named* commits
(`32cb224d6e` and friends), so none of them is falsified by this.

## Studio pages

`rf2-2rtt6.1` is size-locked (`rf2-0znkn`), so the record is published to the
studio instead:

* `studio/README.md` — the lane's cache rule, beside the exit codes, in the
  section that prints the very sequence that used to trigger the trap.
* `studio/hd8-composed-donor-arm.md` — the incident, and the reproduction row
  now states that the command runs from a cold or a warm cache in any order.

No reproduction *command* needed changing: making them order-independent is the
fix.

## A build that is now deterministic, which is the point of a repro command

Two cleared-cache builds of the same arm emit a **byte-identical** `main.js`
(sha256 `a1d14753ef818fcd…`, both ways). Before the fix the bundle depended on
which arm built last — the same effect `hicasso_narrow_run.cjs` already recorded
at 4,075 bytes between a fresh build and one compiled with a sibling warm.

## Quality gates

| gate | exit |
|---|---|
| reproduction at unmodified HEAD `6509d8e5c5` (**must fail**) | `1` — reproduced |
| same script, this branch, `HD8_ONLY=uix` | **`0`** |
| `node run.cjs` — P0 baseline, warm cache | **`0`** |
| `node p0_converge_run.cjs` — full 4-row sweep, warm cache | `2` — guard refused on M2, see below |
| `node hd8_run.cjs` — all three adapters, warm cache | `1` — slim positive control, see below |
| `node z3vlz_run.cjs` — four variants in one run | **`0`** — all four per-variant clears observed |
| arm-order guard self-test (`order_guard.cjs`, standalone) | **`0`** — 11/11 |
| cleared-cache build determinism (gate G) | **`0`** — byte-identical |
| `npm run test:browser` | **`0`** — 851 tests, 5,503 assertions, 0 failures, 0 errors |
| warm-cache proof: two P0 arms build over a warm cache, then HD-008 | **`0`** |
| `scripts/check-beads-pr-boundary.sh origin/main` | **`0`** — no beads paths |

### The two red gates are measurement noise on a loaded box, not the cache fault

**Neither is a boot or cache failure.** Both pages booted, rendered, passed
canonical-DOM parity, tabulated normally and read **0 unverified** on every arm.
A poisoned bundle *dies*; it does not measure cleanly and miss a control by a
hair.

* `p0_converge_run.cjs` refused **M2** — the row the page itself marks
  DIAGNOSTIC — on the phase factor of `M2/uix-subs/ctl-2x`: FIRST-THIRD p50
  `0.40` `[0.30–0.50]` against LAST-THIRD `0.70` `[0.60–0.80]`, disjoint. These
  are sub-millisecond readings against Chrome's 100 µs clamp.
* `hd8_run.cjs`'s **slim** run missed its positive control on one round of
  three: `1.3529` against a floor of `1.395` (predicted `1.9934`, tolerance
  `0.3`). The `uix` run's control passed in the same session.

**The guard's tolerance was not touched and the arm was not "repaired"** —
repairing the arm would move a measured window, which this PR must not do, and
the arm is outside this bead's fence.

Isolation, with main's own drivers extracted byte-for-byte from `origin/main`
and run on the same box. **Note the harness clears the cache before every rep,
so `resetLaneBuildCache` finds nothing and is a literal no-op: both sides
compile the same program from the same state and gate G shows the bundles are
byte-identical. Any difference here is the row's own variance by construction.**

`HD8_ONLY=slim` from a cleared cache: main `0`, **branch `0`** — the
sequence-gate control failure did not reproduce.

For M2, the first comparison ran all of main's reps before all of the branch's.
That confounds the variable with box load drifting over the hour — the same
block-versus-interleave fault `order_guard` exists to catch, and it had no
business being in the experiment used to exonerate a branch. Blocked, it read
main `0 0 0` against branch `2 0 0`, which flatters the wrong conclusion. Re-run
with the order **reflected** (`MAIN,BRANCH` then `BRANCH,MAIN`, so each side
takes both positions equally):

| round | order | main | branch |
|---|---|---|---|
| 1 | MAIN first | **`2`** | `0` |
| 1 | BRANCH first | `0` | `0` |
| 2 | MAIN first | `0` | `0` |
| 2 | BRANCH first | **`2`** | `0` |

**Reflected, main refuses 2 of 4 and the branch 0 of 4** — the reverse of the
blocked reading. Over every M2 run taken in this investigation the rate is
**2 refusals in 8 on each side**. M2 refuses intermittently on both, and the box
was running **32 concurrent java/node processes** from sibling agents
throughout.

Instrument discipline on the HD-008 proof run: **0 unverified on every arm of
both write witnesses** (`{:floor 0, :uix 0, :donor-r1 0, :donor-r2 0}`), over
3,120 narrow-write and 312 bulk-write read-backs; positive control
`:predicted 1.9934`, `:measured {:min 1.6667, :max 2}`, `:within? true`,
predicted from the witness arithmetic before any clock was read; arm-order guard
reportable with no refusal; every figure a per-round range, not a mean.
