### PR TITLE
bench(hicasso): make the z3vlz and retention rigs fail closed (rf2-z3vlz, rf2-flqpd)

### DIFF
--- a/docs/design/hicasso/studio/slim-non-reactive-arm-diagnosis.md
+++ b/docs/design/hicasso/studio/slim-non-reactive-arm-diagnosis.md
@@ -183,3 +183,103 @@ figures the instrument suppressed — reading 0.16–0.50× the floor while chan
 nothing — remain unpublished and unpublishable: they were taken through the
 composition this page identifies as broken, so they price a commit that had not
 happened. They must be re-taken through a corrected arm, not rescued.
+
+## The rig now fails closed (rf2-z3vlz, PR #7266 audit)
+
+Everything above stands unchanged. What follows is about the **instrument**,
+not the finding: the rig that produced this page could print every number on it
+and still exit 0.
+
+`z3vlz_run.cjs` set its failure flag at exactly two places — an uncaught page
+error, and a fatal the probe recorded for itself. It had **no assertion about
+the result at all**. A run in which a mount stopped verifying, in which a slim
+page moved off `0 / 0 / 12`, in which the app-db witness went missing, or in
+which an unmount threw between the two arms, printed a `?` or a different
+number into the summary table and ended `[z3vlz] ok`. That is the same shape as
+the fault this whole page exists to describe: HD-008's arm published
+`156 unverified of 936` and exited 0, and the suppressed figures read 0.16–0.50×
+the floor from a page that never changed.
+
+**Three repairs, each proved by planting the defect it is meant to catch.**
+
+### 1. The six page contracts, in data
+
+Every declared page now carries the row of the matrix above as data, and the
+driver adjudicates the probe's own figures against it. The contract is stated
+per page rather than derived, so a drift has to be **declared** to be accepted:
+
+| contract | `inside-drain` | `drain-immediately` | `yield-then-drain` |
+|---|---|---|---|
+| `SLIM_LATE` — the four reagent-slim pages | `0 of 12`, `sync=12` | `0 of 12`, `sync=12` | `12 of 12`, `macrotask=12` |
+| `STOCK_SYNC` — the two stock-Reagent pages | `0 of 12`, `sync=12` | `0 of 12`, `sync=12` | `0 of 12`, `sync=12` |
+
+**Both arms take the same contract, and that is the finding rather than a
+convenience** — the raw positive control moves in lockstep with the `reg-view`
+arm in every bundle, which is what killed the late-binding hypothesis.
+
+The **escalation ladder is gated too**, and it has to be: `LATE` and `NEVER` are
+different findings and this page's whole conclusion is which one it is. A run
+that moved from `macrotask=12` to `never=12` would be a different result wearing
+the same `12 of 12`.
+
+*Mutation.* Delete the microtask from `:yield-then-drain`, so the rig measures
+an ordering it does not declare. Before the repair this run printed
+`0 unverified of 12` into the table and exited 0 — silently republishing this
+page's conclusion as its **opposite**. It now exits **1** with four named
+refusals, count and rung, on both arms:
+
+```
+[z3vlz] FAILED: … / subs-arm / yield-then-drain: 0 unverified of 12, contract declares 12 of 12
+[z3vlz] FAILED: … / subs-arm / yield-then-drain: escalation ladder reads sync=12, contract
+                declares macrotask=12 — LATE and NEVER are different findings and this rig's
+                conclusion is which one it is
+```
+
+The figures reach the driver through a flat `window.Z3VLZ_GATES` record the
+probe publishes beside its EDN. Scraping the EDN with regexes would be a second
+expression of the same arithmetic, and **a regex that stopped matching would
+report `?` and pass** — the same fail-open.
+
+### 2. `(some pred rs)` over a boolean field is the silent-on-all-false trap
+
+The app-db witness — the slot that attributes a failed read-back to the view leg
+rather than the event leg — was gated on `(some :db-followed? rs)`. That drops
+the field **precisely when every write failed the witness**, which is the one
+case it exists to report. The field went silent exactly when the interesting
+thing had happened, and a reader saw the same absence the raw control shows,
+which legitimately has no app-db at all.
+
+It now tests **key presence**, then asserts the **population** with `every?`,
+and reports the count (`:db-followed-of "12 of 12"`) so the all-false case is
+legible rather than merely false. The driver requires `true` of the arm and
+`null` of the control, so an absent slot is a refusal in its own right and the
+trap cannot return silently.
+
+*Mutation.* Make the witness compare against the wrong value, so all 12 writes
+fail it. Under the old `(some …)` predicate the slot **vanishes** from the
+record; under the repair it reads `:db-followed-all? false, :db-followed-of
+"0 of 12"` and the driver names it. Both now exit **1** — the second by naming
+the population, the first by refusing the absence.
+
+### 3. Teardown is recorded, never swallowed
+
+`(try (unmount handle) (catch :default _ nil))` at both arms. The control runs
+**first** and the arm whose result this page turns on runs after it, on the same
+document — so a swallowed unmount failure meant the arm under test could be
+certified on a page still carrying the control's roots and its ratom's watchers.
+Both sites now record through `lane/teardown-failure!`, the record rides the
+arm, and the driver refuses on it.
+
+*Mutation.* Make the subs-arm unmount throw. Exit **1**, naming the arm and the
+error.
+
+### Every failure is named, and no figure moved
+
+`failed = true` became a `failures` list — `p0_run.cjs`'s shape, where
+`adjudicate` replaced `aggregate` as the only door onto the fold — so a run that
+fails two pages reports two pages instead of one.
+
+**The full six-page run was re-taken with every gate armed and exits 0 with all
+six contracts met.** Every number in the tables above is byte-identical to the
+figures this page published. Nothing here was re-measured, relaxed or moved;
+the gates were fitted around figures that already stood.

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_probe.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_probe.cljs
@@ -294,7 +294,16 @@
 
 (defn- tally
   "`N unverified of M` per ORDER, plus the rung histogram that tells a
-  never-re-rendered apart from a late one."
+  never-re-rendered apart from a late one.
+
+  `:db-followed-all?` is gated on the KEY BEING PRESENT and never on the
+  value being truthy. `(some :db-followed? rs)` — what this did — drops
+  the slot precisely when every write failed the app-db witness, which is
+  the one case it exists to report: the field goes silent exactly when the
+  interesting thing has happened, and a reader sees the same absence it
+  sees for the raw control, which legitimately has no app-db at all. The
+  population is what is asserted (`every?`), not the existence of one
+  member of it."
   [results]
   (into {}
         (map (fn [[order rs]]
@@ -309,8 +318,10 @@
                                                [m {:of (count ms)
                                                    :unverified (count (remove :ok? ms))}]))
                                      (group-by :mechanism rs)))
-                        (some :db-followed? rs)
-                        (assoc :db-followed-all? (every? :db-followed? rs)))]))
+                        (some #(contains? % :db-followed?) rs)
+                        (assoc :db-followed-all? (every? :db-followed? rs)
+                               :db-followed-of   (str (count (filter :db-followed? rs))
+                                                      " of " (count rs))))]))
         (group-by :order results)))
 
 (defn- writes-over-orders!
@@ -339,11 +350,21 @@
                                (let [mech (if (odd? v) :replace-app-db :dispatch-sync)]
                                  [mech (write-fn fid v mech)])))
         (.then (fn [results]
-                 (try (unmount handle) (catch :default _ nil))
+                 ;; RECORDED, never swallowed. This arm runs BEFORE nothing
+                 ;; and AFTER the raw control, in one page, against one
+                 ;; document — an unmount that threw leaves this arm's React
+                 ;; root, its `reg-view` boundaries and their subscriptions
+                 ;; standing, and the next page's arms would be certified on
+                 ;; a contaminated document. The container is detached either
+                 ;; way; the record is what makes it fatal.
+                 (try (unmount handle)
+                      (catch :default e
+                        (lane/teardown-failure! "z3vlz subs-arm unmount" e)))
                  (.remove container)
-                 {:mount  {:ok? mount-ok? :cells mount-cells}
-                  :orders (tally results)
-                  :failed (vec (take 3 (remove :ok? results)))})))))
+                 {:mount    {:ok? mount-ok? :cells mount-cells}
+                  :orders   (tally results)
+                  :teardown (lane/drain-teardown-failures!)
+                  :failed   (vec (take 3 (remove :ok? results)))})))))
 
 (defn- run-raw-control!
   "THE POSITIVE CONTROL, in the same bundle and the same harness: a plain
@@ -365,10 +386,65 @@
     (-> (writes-over-orders! substrate container nil
                              (fn [v] [nil (fn [] (raw-write! v))]))
         (.then (fn [results]
-                 (try (unmount handle) (catch :default _ nil))
+                 ;; The control runs FIRST and the arm under test follows it
+                 ;; on the same document, so a swallowed failure here is the
+                 ;; worse of the two: the arm whose result the bead turns on
+                 ;; would be measured on a page still carrying the control's
+                 ;; roots and its ratom's watchers.
+                 (try (unmount handle)
+                      (catch :default e
+                        (lane/teardown-failure! "z3vlz raw-control unmount" e)))
                  (.remove container)
-                 {:mount  {:ok? mount-ok?}
-                  :orders (tally results)})))))
+                 {:mount    {:ok? mount-ok?}
+                  :orders   (tally results)
+                  :teardown (lane/drain-teardown-failures!)})))))
+
+;; ---------------------------------------------------------------------------
+;; The gate payload — the same figures, in a shape a driver can ADJUDICATE
+;; ---------------------------------------------------------------------------
+;;
+;; `lane/record!` parks EDN strings, which are for a reader. A driver that
+;; had to scrape them with regexes would be a second, drifting expression
+;; of the same arithmetic — and a regex that stopped matching would report
+;; `?` and pass, which is the fail-open shape this rig is being repaired
+;; for. So the probe publishes its own figures once more as a flat JS
+;; record with no `?` in any key.
+;;
+;; A LITERAL `#js` object, deliberately: `clj->js` renders `:ok?` as the
+;; key `"ok?"`, and `p0-heap/mount!`'s docstring records the run where a
+;; driver reading `verify.ok` saw `undefined` and reported every mount
+;; unverified while every mount was fine. `:by-rung`'s keys carry no `?`
+;; and are converted.
+
+(defn- order-gate
+  "One order's figures. `dbFollowedAll` is `null` when the arm has no
+  app-db to witness (the raw control) and a BOOLEAN otherwise — so the
+  driver can require `true` of the subs arm and `null` of the control, and
+  a slot that went missing reads as a refusal rather than as a pass."
+  [orders k]
+  (let [o (get orders k)]
+    #js {"of"            (:of o)
+         "unverified"    (:unverified o)
+         "rungs"         (clj->js (:by-rung o))
+         "dbFollowedAll" (:db-followed-all? o)}))
+
+(defn- arm-gate [arm]
+  #js {"mountOk"  (boolean (:ok? (:mount arm)))
+       "teardown" (clj->js (mapv (fn [f] (str (:where f) ": " (:error f)))
+                                 (:teardown arm)))
+       "orders"   #js {"inside-drain"      (order-gate (:orders arm) :inside-drain)
+                       "drain-immediately" (order-gate (:orders arm) :drain-immediately)
+                       "yield-then-drain"  (order-gate (:orders arm) :yield-then-drain)}})
+
+(defn- publish-gates!
+  "Park the adjudicable record on `window.Z3VLZ_GATES`. Absent means the
+  probe did not get this far, and the driver treats that as a failure —
+  a page that produced no gates cannot have its contract checked, and an
+  unchecked contract is the thing being repaired."
+  [control subs]
+  (set! (.-Z3VLZ_GATES js/window)
+        #js {"raw" (arm-gate control) "subs" (arm-gate subs)})
+  nil)
 
 ;; ---------------------------------------------------------------------------
 ;; The run
@@ -379,9 +455,11 @@
   (-> (run-raw-control! substrate)
       (.then (fn [control]
                (lane/record! :raw-control control)
-               (run-subs-arm! substrate fid)))
-      (.then (fn [subs]
+               (-> (run-subs-arm! substrate fid)
+                   (.then (fn [subs] [control subs])))))
+      (.then (fn [[control subs]]
                (lane/record! :subs-arm subs)
+               (publish-gates! control subs)
                (let [o (:orders subs)
                      un (fn [k] (get-in o [k :summary]))]
                  (lane/record! :verdict

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs
@@ -27,10 +27,47 @@
 // probe that threw and kept going reports on a page that is not the page
 // under test.
 //
+// ## EVERY FIGURE THIS DRIVER PRINTS, IT EXITS ON
+//
+// It did not. Until this repair the only exit-bearing checks were the
+// build, the bundle-composition check and a page error — so a run in
+// which a mount did not verify, in which a slim page stopped reading
+// `0/0/12`, in which the app-db witness went missing, or in which an
+// unmount threw between the two arms, printed a `?` or a different number
+// beside `[z3vlz] ok` and exited 0. A count that is DISPLAYED but not
+// GATED is decoration, and this rig exists because an ungated count in
+// HD-008 nearly published `reagent-slim narrow write is 2-6x faster than
+// a top-down re-render` off a page that never changed.
+//
+// So every page now carries a CONTRACT in data — `PAGE_CONTRACT` below —
+// and the driver adjudicates the probe's own figures against it. The
+// contract is exactly the matrix this rig published
+// (`docs/design/hicasso/studio/slim-non-reactive-arm-diagnosis.md`), and
+// it is stated per page rather than derived, so a drift has to be
+// declared to be accepted.
+//
+// The figures come from `window.Z3VLZ_GATES`, which the probe publishes
+// as a flat JS record beside its EDN. Scraping the EDN with regexes would
+// be a second expression of the same arithmetic, and a regex that stopped
+// matching would report `?` and PASS — the same fail-open shape.
+//
+// EVERY failed gate is named, never the last one: `failures` is a list,
+// not a slot, because a run that failed two things must not report one.
+// That is `p0_run.cjs`'s shape and this is the same rule.
+//
+// THE CONTRACT IS ENFORCED IN THE `Z3VLZ_OPT=none` AID TOO. The aid is a
+// rig-debugging build and never a source of a finding, so a divergence
+// there is a finding ABOUT THE AID and the driver names it rather than
+// quietly exempting it. There is no knob to relax the contract: the
+// repair for a refusal is the arm or the declared contract, never the
+// gate.
+//
 // EXIT CODES
-//   0  every declared bundle matched, every page ran, every record printed
+//   0  every declared bundle matched, every page ran, and every page met
+//      its declared contract
 //   1  a build failed, a bundle did not match its declared composition, a
-//      page threw, or the probe recorded a fatal
+//      page threw, the probe recorded a fatal, a page published no gate
+//      record, or a page's figures drifted from its declared contract
 //
 // The arm-order guard owns exit 2 on the timed lanes. It is NOT ENGAGED
 // here and the run says so in its own record: this driver publishes no
@@ -51,15 +88,57 @@ const BUILD_ID = 'hicasso-bench';
 const PORT = Number(process.env.Z3VLZ_PORT || 8171);
 const SENTINEL_TIMEOUT_MS = 5 * 60 * 1000;
 
+// ---------------------------------------------------------------------------
+// THE DECLARED PAGE CONTRACTS
+// ---------------------------------------------------------------------------
+//
+// One row of the published matrix, as data. `of` is the probe's
+// `writes-n`; `unverified` is how many of those writes the DOM did not
+// follow inside the write's own window; `rungs` is the escalation-ladder
+// histogram, and it is gated because LATE and NEVER are different
+// findings and the whole conclusion turns on which one this is. A run
+// whose slim page moved from `macrotask=12` to `never=12` would be a
+// different result wearing the same `12 of 12`.
+const SYNC12 = { of: 12, unverified: 0, rungs: { sync: 12 } };
+const LATE12 = { of: 12, unverified: 12, rungs: { macrotask: 12 } };
+
+// reagent-slim installed: the DOM follows every write under the adapter's
+// own drain contract and under an immediate drain, and is one macrotask
+// late when the harness yields first. Stock Reagent installed: all three
+// orders commit at `:sync`, because its queue is rAF-scheduled and a
+// microtask has not emptied it.
+const SLIM_LATE = {
+  'inside-drain': SYNC12,
+  'drain-immediately': SYNC12,
+  'yield-then-drain': LATE12,
+};
+const STOCK_SYNC = {
+  'inside-drain': SYNC12,
+  'drain-immediately': SYNC12,
+  'yield-then-drain': SYNC12,
+};
+
+// BOTH ARMS TAKE THE SAME CONTRACT, and that is the finding rather than a
+// convenience: the raw positive control — a plain substrate component
+// reading a plain substrate atom, no frame, no `subscribe`, no
+// `:adapter/*` hook — moves in lockstep with the `reg-view` arm in every
+// bundle. That is what killed the late-binding hypothesis, so it is what
+// the contract asserts.
+const ORDERS = ['inside-drain', 'drain-immediately', 'yield-then-drain'];
+
 // Each rung adds ONE namespace to the one above it. The `expect` map is
-// checked against the build's own source map before the page is driven.
+// checked against the build's own source map before the page is driven;
+// each page's `contract` is checked against the probe's own figures after
+// it has run.
 const VARIANTS = [
   {
     name: 'slim-only',
     initFn: 're-frame.bench.hicasso.z3vlz-slim-only/-main',
     outDir: 'out/z3vlz-slim-only',
     expect: { reagent: false, reagent2: true, uix: false },
-    pages: [{ label: 'slim-only / install=reagent-slim', query: '' }],
+    pages: [
+      { label: 'slim-only / install=reagent-slim', query: '', contract: SLIM_LATE },
+    ],
   },
   {
     name: 'slim+reagent',
@@ -67,8 +146,12 @@ const VARIANTS = [
     outDir: 'out/z3vlz-slim-reagent',
     expect: { reagent: true, reagent2: true, uix: false },
     pages: [
-      { label: 'slim+reagent / install=reagent-slim', query: '' },
-      { label: 'slim+reagent / install=reagent (control)', query: '?install=reagent' },
+      { label: 'slim+reagent / install=reagent-slim', query: '', contract: SLIM_LATE },
+      {
+        label: 'slim+reagent / install=reagent (control)',
+        query: '?install=reagent',
+        contract: STOCK_SYNC,
+      },
     ],
   },
   {
@@ -76,7 +159,9 @@ const VARIANTS = [
     initFn: 're-frame.bench.hicasso.z3vlz-slim-uix/-main',
     outDir: 'out/z3vlz-slim-uix',
     expect: { reagent: false, reagent2: true, uix: true },
-    pages: [{ label: 'slim+uix / install=reagent-slim', query: '' }],
+    pages: [
+      { label: 'slim+uix / install=reagent-slim', query: '', contract: SLIM_LATE },
+    ],
   },
   {
     name: 'mixed',
@@ -84,8 +169,12 @@ const VARIANTS = [
     outDir: 'out/z3vlz-mixed',
     expect: { reagent: true, reagent2: true, uix: true },
     pages: [
-      { label: 'mixed / install=reagent-slim', query: '' },
-      { label: 'mixed / install=reagent (control)', query: '?install=reagent' },
+      { label: 'mixed / install=reagent-slim', query: '', contract: SLIM_LATE },
+      {
+        label: 'mixed / install=reagent (control)',
+        query: '?install=reagent',
+        contract: STOCK_SYNC,
+      },
     ],
   },
 ];
@@ -279,6 +368,7 @@ async function drive(page, url) {
   ]);
   const err = await page.evaluate('window.HICASSO_ERROR || null');
   const results = await page.evaluate('window.HICASSO_RESULTS || {}');
+  const gates = await page.evaluate('window.Z3VLZ_GATES || null');
   const uncaught = await page.evaluate('window.Z3VLZ_UNCAUGHT || null');
   if (uncaught) {
     console.error('[z3vlz] UNCAUGHT (page-side capture):');
@@ -288,7 +378,104 @@ async function drive(page, url) {
     console.error(`  stack:    ${uncaught.stack}`);
   }
   page.off('pageerror', onError);
-  return { err, results, pageErrors, uncaught };
+  return { err, results, gates, pageErrors, uncaught };
+}
+
+// ---------------------------------------------------------------------------
+// ADJUDICATION — the declared contract against the figures the page produced
+// ---------------------------------------------------------------------------
+
+// A histogram as one canonical, order-independent string, so `{sync: 12}`
+// compares as a whole rather than key by key. A rung that appeared and
+// one that vanished are both drift and both have to be named.
+const rungs = (h) =>
+  Object.keys(h || {})
+    .sort()
+    .map((k) => `${k}=${h[k]}`)
+    .join(',') || '(none)';
+
+// `wantDb` is `true` for the arm that has an app-db behind it and `null`
+// for the raw control, which legitimately has none. Requiring `null`
+// rather than ignoring it is deliberate: `:db-followed-all?` used to be
+// gated on `(some :db-followed? rs)`, so it VANISHED on the all-false
+// case — the arm looked exactly like the control precisely when every
+// write had failed the app-db witness. The driver now refuses an absent
+// slot on the arm and an unexpectedly present one on the control, so the
+// trap cannot come back silently.
+function checkArm(label, armName, got, contract, wantDb, failures) {
+  const at = `${label} / ${armName}`;
+  if (!got) {
+    failures.push(`${at}: the page published no gate record for this arm`);
+    return;
+  }
+  if (!got.mountOk) {
+    failures.push(
+      `${at}: the MOUNT did not verify at the DOM — every write figure below it ` +
+        `was taken against a page that had not rendered correctly to begin with`
+    );
+  }
+  if (got.teardown && got.teardown.length) {
+    failures.push(
+      `${at}: ${got.teardown.length} teardown failure(s) — the arm's roots, its ` +
+        `boundaries and their subscriptions are still standing, so whatever ran ` +
+        `next on this document was measured on a contaminated page: ` +
+        got.teardown.join('; ')
+    );
+  }
+  for (const order of ORDERS) {
+    const want = contract[order];
+    const g = (got.orders || {})[order];
+    if (!g) {
+      failures.push(`${at} / ${order}: no figures published for this order`);
+      continue;
+    }
+    if (g.of !== want.of) {
+      failures.push(`${at} / ${order}: ${g.of} writes, contract declares ${want.of}`);
+    }
+    if (g.unverified !== want.unverified) {
+      failures.push(
+        `${at} / ${order}: ${g.unverified} unverified of ${g.of}, contract declares ` +
+          `${want.unverified} of ${want.of}`
+      );
+    }
+    const gotRungs = rungs(g.rungs);
+    const wantRungs = rungs(want.rungs);
+    if (gotRungs !== wantRungs) {
+      failures.push(
+        `${at} / ${order}: escalation ladder reads ${gotRungs}, contract declares ` +
+          `${wantRungs} — LATE and NEVER are different findings and this rig's ` +
+          `conclusion is which one it is`
+      );
+    }
+    if (wantDb === null && g.dbFollowedAll !== null) {
+      failures.push(
+        `${at} / ${order}: the raw control published an app-db witness ` +
+          `(${g.dbFollowedAll}) and it has no app-db to witness`
+      );
+    } else if (wantDb === true && g.dbFollowedAll !== true) {
+      failures.push(
+        `${at} / ${order}: app-db witness is ${g.dbFollowedAll} — ` +
+          (g.dbFollowedAll === null
+            ? 'the slot is ABSENT, which is what the `(some :db-followed? rs)` trap did ' +
+              'on the all-false case and is never a pass'
+            : 'app-db did not take the new value on every write, so a failed read-back ' +
+              'can no longer be attributed to the view leg')
+      );
+    }
+  }
+}
+
+function checkPage(label, contract, gates, failures) {
+  if (!gates) {
+    failures.push(
+      `${label}: the page published no window.Z3VLZ_GATES — its declared contract ` +
+        `could not be checked, and an unchecked contract is exactly the fail-open ` +
+        `this driver was repaired for`
+    );
+    return;
+  }
+  checkArm(label, 'subs-arm', gates.subs, contract, true, failures);
+  checkArm(label, 'raw-control', gates.raw, contract, null, failures);
 }
 
 (async () => {
@@ -297,7 +484,10 @@ async function drive(page, url) {
   const browser = await chromium.launch();
   const version = browser.version();
   const rows = [];
-  let failed = false;
+  // EVERY failed gate, not the last one and not a bare boolean. A run that
+  // failed two pages must name two pages: `p0_run.cjs` carries the same
+  // list for the same reason.
+  const failures = [];
 
   for (const variant of variants) {
     build(variant);
@@ -317,17 +507,18 @@ async function drive(page, url) {
           console.log(`;; ---- ${p.label} :${k}\n${v}`);
         }
         if (outcome.pageErrors.length) {
-          console.error(
-            `[z3vlz] FAILED: ${outcome.pageErrors.length} uncaught page error(s) on ` +
+          failures.push(
+            `${outcome.pageErrors.length} uncaught page error(s) on ` +
               `${p.label} — every figure above was taken on a page that had already ` +
               `thrown:\n  ${outcome.pageErrors.map((e) => e.stack || e.message).join('\n  ')}`
           );
-          failed = true;
         }
         if (outcome.err) {
-          console.error(`[z3vlz] FAILED: ${p.label}: ${outcome.err}`);
-          failed = true;
+          failures.push(`${p.label}: ${outcome.err}`);
         }
+        // THE DECLARED CONTRACT. Checked even when the page reported a
+        // fatal: a page that failed two ways must say so.
+        checkPage(p.label, p.contract, outcome.gates, failures);
         rows.push({ page: p.label, comp, verdict: outcome.results.verdict || null });
       }
     } finally {
@@ -362,7 +553,14 @@ async function drive(page, url) {
     `;; arm-order guard: NOT ENGAGED — no timed figure and no arm-to-arm ratio is ` +
       `published by this driver, so there is nothing to adjudicate.`
   );
+  console.log(
+    `;; page contracts: ${rows.length} page(s) adjudicated against the declared ` +
+      `matrix — ${failures.length === 0 ? 'all met' : `${failures.length} refusal(s)`}`
+  );
 
-  if (failed) process.exit(1);
+  if (failures.length) {
+    for (const f of failures) console.error(`[z3vlz] FAILED: ${f}`);
+    process.exit(1);
+  }
   console.error('[z3vlz] ok');
 })();


### PR DESCRIPTION
Two beads, one defect shape: a driver that prints a failure and exits 0.

Both are **diagnostic rigs, not published arms**, so no figure should move — and none did. The gates were fitted around figures that already stood.

## rf2-z3vlz — the reagent-slim discriminator rig

`z3vlz_run.cjs` set its failure flag at exactly two places, an uncaught page error and a fatal the probe recorded for itself. It had **no assertion about the result at all**: a changed verdict, a failed mount, a missing app-db witness or a thrown unmount printed a `?` or a different number into the summary table and ended `[z3vlz] ok`.

1. **The six page contracts, in data.** Each declared page carries its row of the published matrix; the driver adjudicates counts, denominators and the **escalation-ladder histogram** against it — `LATE` and `NEVER` are different findings and this rig's conclusion is which one it is. Both arms take the same contract, which is the finding rather than a convenience. Figures reach the driver via a flat `window.Z3VLZ_GATES` record, not by scraping EDN with regexes — a regex that stopped matching would report `?` and **pass**.
2. **`(some :db-followed? rs)` is the silent-on-all-false trap.** It dropped the app-db witness precisely when every write failed it. Now tests **key presence**, then asserts the **population** with `every?`, and reports the count. The driver requires `true` of the arm and `null` of the control, so an absent slot is a refusal in its own right.
3. **Teardown recorded, never swallowed**, at both arms, through `lane/teardown-failure!`.

`failed = true` became a `failures` list — `p0_run.cjs`'s shape.

## rf2-flqpd — the retention rig

1. **`p0_arms/enter-segment!` caught and discarded** `destroy-frame!` and `destroy-adapter!` — while this bead's argument rejects H2 *from those exact transitions*. It now raises with the failing phase named, so every caller fails closed without having to remember to ask.
2. **SERIES C's page loop overwrote `last`** and returned only the final cycle's verdict: 49 of 50 cycles could render nothing and the row still printed `ok`. It now folds every cycle, counting failures and keeping the **first**.
3. **The validity gates were prints.** A failed census positive control printed `[FAIL] the census cannot see a live subscription` and then `[ret] ok`; an absent heap column printed `n/a`; a `:no-frame` census printed the token; and in `repro` mode an early `return` skipped the page-error and unverified-cycle gates entirely. All now exit 1 in one named `failures` list. The empty-`SERIES B` case is reported as a **narrowed scope** rather than compared as `0 of 0`, which would have printed `[ok]` for a control that never ran.

The reaction-**watchers** column is deliberately still not a gate: blind under `:advanced`, it carries no information in either direction. **Exit 0 still means the probe ran and its readings are valid — never that the heap is clean.** Rows stay operator-owned (rf2-2rtt6.1).

## Mutation proofs

Each defect was planted, shown to exit non-zero **naming what failed**, then restored.

| gate | planted defect | result |
|---|---|---|
| z3vlz page contract | drop the microtask from `:yield-then-drain` | **exit 1**, 4 refusals: count *and* rung, both arms. Before the repair: `0 unverified of 12`, exit 0 — the conclusion republished as its opposite |
| z3vlz app-db witness | witness compares wrong value, all 12 writes fail | under old `some`: slot **vanishes**, driver refuses the absence. Under repair: `false` / `"0 of 12"`, driver names the population. Both **exit 1** |
| z3vlz teardown | subs-arm unmount throws | **exit 1**, naming arm and error |
| flqpd teardown | `destroy-frame!` throws | **exit 1** — `P0 segment teardown FAILED at destroy-frame! … Cause: PLANTED destroy-frame! failure` |
| flqpd multi-cycle fold | fail **cycle 0 only**, last cycle good | **exit 1**, `row 1: 1 of 4 cycles … first #0 0/1200`. The old `last`-overwrite returned the final cycle's `ok` and exited 0 |
| flqpd census control | blind the sub-cache census | the audit's exact scenario: `[FAIL] the census cannot see a live subscription` now **exit 1** instead of `[ret] ok` |

### Two things the mutation proofs caught in my own repairs

- **The first cut of the teardown raise used `ex-info`.** It failed closed on `page.evaluate: aj` — under `:advanced`, Closure renames the constructor of any `Error` subclass, so the phase name never reached the operator. Stopping the instrument without saying what stopped it is not the repair that was asked for; it is now a plain `js/Error` with the phase in the **message**.
- **The first cut of the census-readability gate refused the baseline.** `SERIES A` row 0 is taken before the first `prepare`, so `:no-frame` is the *truthful* answer there. The gate is now keyed on whether a segment has actually been entered (`framed`), not on a row index — the same token after a segment entry still refuses.

## No published figure moved

- **z3vlz** — the full six-page run exits 0 with all six contracts met, byte-identical to the published matrix.
- **flqpd** — the full run at published settings exits 0. The COLLECTED column reproduces the published series to 0.01 MB and totals the same **0.90 MB** climb across six segments; UNCOLLECTED sawtooths as published; the census control reads 6 of 6. Every SERIES C row now verifies **all 50** cycles rather than one.

No gate was relaxed and nothing was re-measured to fit.

## Studio

`rf2-2rtt6.1` is size-locked (`rf2-0znkn`), so the record went to the studio pages instead — see the final section of `slim-non-reactive-arm-diagnosis.md` and the settled first *Open item* on `p0-uix-on-subs-frontier-arm.md`.

## Quality gates

All foreground to completion, run in the worker worktree, logs kept locally with exit codes echoed. None piped through `tail`/`grep`.

| Gate | Exit |
|---|---|
| `node …/hicasso/z3vlz_run.cjs` (all 4 bundles, 6 pages) | **0** |
| `node …/hicasso/retention_run.cjs` (published settings) | **0** |
| order-guard `self-test` (11 checks, all ok) | **0** |
| `clojure -M:test` — core JVM suite, 2193 tests / 11318 assertions | **0** |
| `npm run test:browser` — 851 tests / 5503 assertions | **0** |

## Fence

Six files, all inside the fence. `p0_run.cjs` was read as the reference implementation and **not modified**; `control-verdict`, `order_guard.*` tolerance, `shadow-cljs.edn`, `spec/**` and the frozen design docs were not touched. No new build id — both rigs still ride `:hicasso-bench` via `--config-merge`. No `.beads` path is on this branch.
