### PR TITLE
bench,docs: three audit residuals — stale claims, nil positions, value-unstable (rf2-pq7d8, rf2-ouwh8, rf2-2rtt6.15)

### DIFF
--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -466,14 +466,18 @@ as a replacement. **No figure moved systematically, and nothing published was
 invalidated.** `HD8_ONLY` exists so that a future re-take of one run cannot mint
 a competing set of figures for rows published at another commit.
 
-**Where the general fix belongs, and why it is not here.** The same fixed yield
-lives in the shared `lane/verified-write!`, which every Hicasso arm uses, and
-the general repair — an arm-declared drain slot, additive, today's path
-unchanged when it is absent — is filed as **`rf2-pq7d8`**. It is deliberately
-**not** made here: `lane.cljs` is a shared instrument with sibling arms
-measuring on it, and a shared instrument must not change under a measurement in
-flight. HD-008's own `timed-write!` is a separate copy, which is why this repair
-could land without touching it.
+**Where the general fix belongs, and where it now lives.** The same fixed yield
+lived in the shared `lane/verified-write!`, which every Hicasso arm uses, and
+the general repair — an arm-declared scheduler, additive, today's path unchanged
+when it is absent — is **`rf2-pq7d8`**. It was not made in the same pass as this
+page's, because `lane.cljs` is a shared instrument with sibling arms measuring
+on it and a shared instrument must not change under a measurement in flight;
+HD-008's own `timed-write!` is a separate copy, which is why this repair could
+land first without touching it. **`rf2-pq7d8` has since landed.** The lane now
+takes the same `:scheduler` declaration this page's `window-of` takes and gives
+it the same two shapes — lifted from here rather than invented a second time —
+and an arm that declares no `:scheduler` gets the lane's unchanged window. No
+arm outside HD-008 declares one, so **no published row moved.**
 
 ## Known limitations of this instrument
 
@@ -505,7 +509,8 @@ could land without touching it.
   ten turns at a time** (`rf2-2rtt6.19`), so the whole batched asymmetry is
   beneath this instrument's resolution rather than ten times something beneath it
   — but a future instrument with a finer clock inherits a real asymmetry, not a
-  settled one, and `rf2-pq7d8` is where it gets settled properly.
+  settled one, and `rf2-pq7d8` has since carried both shapes into the shared
+  lane, which inherits that asymmetry rather than settling it.
 - **No retained-heap leg.** The red-zone rule governs clock *and* retained heap;
   this arm measures the clock. The heap ladder is `rf2-2rtt6.5`'s
   ([reads-per-boundary-heap-ladder.md](reads-per-boundary-heap-ladder.md)).

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -38,7 +38,7 @@ as HD-nnn are normative in [decisions.md](decisions.md).
 | Template identity | a stated cache key for any cached shape work |
 | Host boundaries | priced separately (foreign components are census-rare) |
 
-Sub-key identity: `(query-id, args)` under value equality; unstable map args
+Sub-key identity: `(query-id, args)` under value equality; value-unstable map args
 thrash the index — documented, programmer-trusted. A missed invalidation is a P0
 bug class: the staged-stale case is a CI witness for any asynchronous-host
 variant.

--- a/implementation/core/test/re_frame/bench/order_guard.cljc
+++ b/implementation/core/test/re_frame/bench/order_guard.cljc
@@ -99,6 +99,15 @@
   check 11 replays it with deliberately flat values, so nothing but the
   lost positions can be what refuses.
 
+  The excuse belongs to the RUN, not to the sample, and reading it the
+  other way is how the same fault came back: a first repair counted only
+  `NaN`, so a sample carrying `:position nil` — present, unusable, dropped
+  by [[stratify]] exactly as `NaN` is — was excused one at a time, and
+  twenty-four samples with six positions and eighteen nils adjudicated
+  phase over four survivors and answered `[ok]` again. Inside a run that
+  records positions at all, EVERY unusable position is a loss; only a run
+  in which no sample offers one is excused. Check 12 prices both halves.
+
   ## What the `:predecessor` factor can and cannot attribute (rf2-om73r)
 
   Under [[slot-order]] an arm's predecessor is `(a - 1) mod n` on EVEN
@@ -248,19 +257,27 @@
          vec)))
 
 (defn lost-positions
-  "How many of `samples` CARRY a `:position` that is not a finite number.
+  "How many of `samples` have NO USABLE `:position` — nil, absent, or a
+  non-finite number — in a run that records positions AT ALL.
 
   Not the same question as \"how many have no position\". A harness that
-  records no positions at all is a documented case and is excused the phase
-  contrast; a harness that records `NaN` has LOST them, and the difference
-  between the two is the difference between a question not asked and a
-  question answered over a silently smaller set."
+  offers no position on any sample is a documented case and is excused the
+  phase contrast; a harness that records positions and loses some of them
+  has LOST them, and the difference between the two is the difference
+  between a question not asked and a question answered over a silently
+  smaller set.
+
+  So the excuse is a property of the RUN, not of the sample: only a run in
+  which NO sample offers a position is excused, and inside a run that does
+  record them every unusable position is a loss. `NaN` was the recorded
+  fault and nil is its sibling — [[stratify]] drops both from the phase
+  contrast while [[report-lines]] prints the arm's full count beside it, so
+  a guard that counted only `NaN` would adjudicate 24 samples on four and
+  answer `[ok]` for the second reason having been repaired for the first."
   [samples]
-  (count (filterv (fn [s]
-                    (and (contains? s :position)
-                         (some? (:position s))
-                         (not (finite? (:position s)))))
-                  samples)))
+  (if (not-any? #(some? (:position %)) samples)
+    0
+    (count (remove #(finite? (:position %)) samples))))
 
 (defn adjudicate
   "Adjudicate one arm's strata on one factor.
@@ -341,8 +358,8 @@
                                                 (let [strata (stratify ss f)
                                                       lost   (if (= f :phase) (lost-positions ss) 0)]
                                                   (cond
-                                                    ;; A sample that CARRIES a position
-                                                    ;; and whose position is not a number
+                                                    ;; A sample with no usable position
+                                                    ;; in a run that records positions
                                                     ;; is a HARNESS FAULT, and it is the
                                                     ;; recorded one: a shadowed binding
                                                     ;; made every position `NaN` from
@@ -350,7 +367,9 @@
                                                     ;; them, and the report said
                                                     ;; "24 samples" over a phase
                                                     ;; contrast adjudicated on six —
-                                                    ;; and answered `[ok]`. Silently
+                                                    ;; and answered `[ok]`. nil is the
+                                                    ;; same loss by another route and is
+                                                    ;; counted the same way. Silently
                                                     ;; narrowing the question is the one
                                                     ;; thing this namespace must not do.
                                                     (pos? lost)
@@ -359,10 +378,12 @@
                                                             :status         :unchecked
                                                             :lost-positions lost
                                                             :why (str lost " of " (count ss)
-                                                                      " samples carry a NON-FINITE :position"
-                                                                      " — the harness lost them, so this"
-                                                                      " contrast is over the rest and the"
-                                                                      " sample count above is not it")})
+                                                                      " samples have NO USABLE :position"
+                                                                      " (nil, absent or non-finite) in a run"
+                                                                      " that records them — the harness lost"
+                                                                      " them, so this contrast is over the"
+                                                                      " rest and the sample count above is"
+                                                                      " not it")})
 
                                                     ;; `:phase` is only askable when
                                                     ;; positions were recorded at all; a
@@ -539,6 +560,23 @@
         v-lost (verdict lost {:tolerance 0.10})
         lost-r (one v-lost "A" :phase)
 
+        ;; 12. THE SAME LOSS BY THE OTHER ROUTE. `nil` is dropped from the
+        ;;     phase contrast exactly as `NaN` is, so a guard that counts
+        ;;     only `NaN` adjudicates these 24 samples on FOUR survivors
+        ;;     and answers `[ok]` — the fault of check 11, repaired for one
+        ;;     spelling and live for the other. Only `:phase` is asked, so
+        ;;     nothing but the lost positions can be what refuses; and the
+        ;;     second half pins the excuse it must NOT swallow, a run in
+        ;;     which no sample offers a position at all.
+        nils   (mapv (fn [i] {:arm "A" :predecessor "B"
+                              :position (when (< i 6) i)
+                              :value 1.0})
+                     (range 24))
+        v-nils (verdict nils {:tolerance 0.10 :factors [:phase]})
+        nils-r (one v-nils "A" :phase)
+        none   (mapv (fn [_] {:arm "A" :predecessor "B" :value 1.0}) (range 24))
+        v-none (verdict none {:tolerance 0.10 :factors [:phase]})
+
         checks
         [{:name "the recorded 2.01x is REFUSED"
           :ok   (and (:refuse? v-smi)
@@ -594,7 +632,15 @@
           :ok   (and (:refuse? v-lost)
                      (= :unchecked (:status lost-r))
                      (= 18 (:lost-positions lost-r)))
-          :detail (:why lost-r)}]]
+          :detail (:why lost-r)}
+         {:name "a present-but-NIL :position is the same loss, and recording NONE is still excused"
+          :ok   (and (:refuse? v-nils)
+                     (= :unchecked (:status nils-r))
+                     (= 18 (:lost-positions nils-r))
+                     (not (:refuse? v-none))
+                     (not (contains? (get-in v-none [:arms "A" :factors]) :phase)))
+          :detail (str (:why nils-r)
+                       " — and a run offering no position at all is excused, not refused")}]]
     {:ok?     (every? :ok checks)
      :checks  checks}))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
@@ -614,9 +614,12 @@
   carries the evidence, including the positive control (a plain component
   reading a plain `reagent2.core/atom`, no re-frame anywhere on the path)
   that reproduces it in all four bundle compositions. The general form —
-  the same fixed yield in the shared `lane/verified-write!` — is filed as
-  rf2-pq7d8 and is NOT repaired here: `lane.cljs` is a shared instrument
-  with sibling arms measuring on it.
+  the same fixed yield in the shared `lane/verified-write!` — is rf2-pq7d8,
+  and it HAS since been repaired: the lane takes the same `:scheduler`
+  declaration and gives it these same two shapes, lifted from here rather
+  than invented a second time. That repair is additive — an arm that
+  declares no `:scheduler` gets the lane's unchanged window, and none does
+  outside this file — so no published row moved.
 
     `:microtask`  write, then drain, with NOTHING between them. The
                   substrate's queue is filled synchronously by the write and

--- a/implementation/freehand/test/re_frame/freehand/bench/order_guard.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/order_guard.cjs
@@ -133,6 +133,15 @@
 // check 10 replays it with deliberately flat values, so nothing but the
 // lost positions can be what refuses.
 //
+// The excuse belongs to the RUN, not to the sample, and reading it the other
+// way is how the same fault came back: a first repair counted only `NaN`, so
+// a sample carrying `position: null` — present, unusable, dropped by
+// `stratifyArm` exactly as `NaN` is — was excused one at a time, and
+// twenty-four samples with six positions and eighteen nulls adjudicated
+// phase over four survivors and answered `[ok]` again. Inside a run that
+// records positions at all, EVERY unusable position is a loss; only a run in
+// which no sample offers one is excused. Check 11 prices both halves.
+//
 // ## What the `predecessor` factor can and cannot attribute (rf2-om73r)
 //
 // Under [[schedule]] an arm's predecessor is `(a - 1) mod n` on EVEN rounds
@@ -286,18 +295,29 @@ function stratifyArm(samples, factor) {
 }
 
 /**
- * How many of `samples` CARRY a `position` that is not a finite number.
+ * How many of `samples` have NO USABLE `position` — null, absent, or a
+ * non-finite number — in a run that records positions AT ALL.
  *
  * Not the same question as "how many have no position". A harness that
- * records no positions at all is a documented case and is excused the phase
- * contrast; a harness that records `NaN` has LOST them, and the difference
- * between the two is the difference between a question not asked and a
- * question answered over a silently smaller set.
+ * offers no position on any sample is a documented case and is excused the
+ * phase contrast; a harness that records positions and loses some of them
+ * has LOST them, and the difference between the two is the difference
+ * between a question not asked and a question answered over a silently
+ * smaller set.
+ *
+ * So the excuse is a property of the RUN, not of the sample: only a run in
+ * which NO sample offers a position is excused, and inside a run that does
+ * record them every unusable position is a loss. `NaN` was the recorded
+ * fault and null is its sibling — `stratifyArm` drops both from the phase
+ * contrast while `format` prints the arm's full count beside it, so a guard
+ * that counted only `NaN` would adjudicate 24 samples on four and answer
+ * `[ok]` for the second reason having been repaired for the first.
  */
 function lostPositions(samples) {
+  if (!samples.some((s) => s.position !== undefined && s.position !== null)) return 0;
   let n = 0;
   for (const s of samples) {
-    if (s.position !== undefined && s.position !== null && !Number.isFinite(s.position)) n += 1;
+    if (!Number.isFinite(s.position)) n += 1;
   }
   return n;
 }
@@ -380,19 +400,21 @@ function verdict(samples, opts = {}) {
       const strata = stratifyArm(ss, f);
       const lost = f === 'phase' ? lostPositions(ss) : 0;
       if (lost > 0) {
-        // A sample that CARRIES a position and whose position is not a
-        // number is a HARNESS FAULT, and it is the recorded one: a shadowed
+        // A sample with no usable position in a run that records positions
+        // is a HARNESS FAULT, and it is the recorded one: a shadowed
         // binding made every position `NaN` from round 2 on, `stratifyArm`
         // dropped them, and the report said "24 samples" over a phase
-        // contrast adjudicated on six — and answered `[ok]`. Silently
+        // contrast adjudicated on six — and answered `[ok]`. null is the
+        // same loss by another route and is counted the same way. Silently
         // narrowing the question is the one thing this module must not do.
         per[f] = {
           strata,
           status: 'unchecked',
           lostPositions: lost,
           why:
-            `${lost} of ${ss.length} samples carry a NON-FINITE position — the harness ` +
-            'lost them, so this contrast is over the rest and the sample count above is not it',
+            `${lost} of ${ss.length} samples have NO USABLE position (null, absent or ` +
+            'non-finite) in a run that records them — the harness lost them, so this ' +
+            'contrast is over the rest and the sample count above is not it',
         };
         unchecked = true;
         continue;
@@ -635,6 +657,33 @@ function selfTest() {
     'samples whose position went NON-FINITE refuse instead of narrowing the question',
     vLost.refuse && lostR.status === 'unchecked' && lostR.lostPositions === 18,
     lostR.why
+  );
+
+  // 11. THE SAME LOSS BY THE OTHER ROUTE. `null` is dropped from the phase
+  //     contrast exactly as `NaN` is, so a guard that counts only `NaN`
+  //     adjudicates these 24 samples on FOUR survivors and answers `[ok]` —
+  //     the fault of check 10, repaired for one spelling and live for the
+  //     other. Only `phase` is asked, so nothing but the lost positions can
+  //     be what refuses; and the second half pins the excuse it must NOT
+  //     swallow, a run in which no sample offers a position at all.
+  const nullSamples = Array.from({ length: 24 }, (_, i) => ({
+    arm: 'A',
+    predecessor: 'B',
+    position: i < 6 ? i : null,
+    value: 1.0,
+  }));
+  const vNull = verdict(nullSamples, { tolerance: 0.1, factors: ['phase'] });
+  const nullR = one(vNull, 'A', 'phase');
+  const noneSamples = Array.from({ length: 24 }, () => ({ arm: 'A', predecessor: 'B', value: 1.0 }));
+  const vNone = verdict(noneSamples, { tolerance: 0.1, factors: ['phase'] });
+  check(
+    'a present-but-NULL position is the same loss, and recording NONE is still excused',
+    vNull.refuse &&
+      nullR.status === 'unchecked' &&
+      nullR.lostPositions === 18 &&
+      !vNone.refuse &&
+      vNone.arms.A.factors.phase === undefined,
+    `${nullR.why} — and a run offering no position at all is excused, not refused`
   );
 
   return { ok: checks.every((c) => c.ok), checks };


### PR DESCRIPTION
Three audit residuals, one commit each. Two are prose corrections to claims that
the engineering has already overtaken; the third is one predicate, in the two
copies of the arm-order guard.

## `rf2-pq7d8` — the repair landed; two sentences said it had not

`86188c93fa` made `lane/verified-write!` scheduler-aware: an arm declares
`:scheduler`, `:microtask` gets write-then-drain with nothing between them and
`:gap-ms 0.0`, anything else — or the key absent — gets today's window,
unchanged. Verified in place at `lane.cljs:499-520` (the two shapes) and
`:563-577` (the docstring that states them).

Two claims written before that survived saying the opposite, and both are now
false:

| site | said |
|---|---|
| `hd8_rows.cljs` `window-of` | *"The general form … is filed as rf2-pq7d8 and is **NOT repaired here**"* |
| `hd8-composed-donor-arm.md` | *"It is deliberately **not** made here"* |

Both corrected to describe what landed, keeping the reason it was not made in
the same pass — `lane.cljs` is a shared instrument and sibling arms were
measuring on it — because that is still why HD-008's own `window-of` exists.

Also corrected: the page's **"Known limitations"** bullet, which forward-referenced
`rf2-pq7d8` as where the two-shape asymmetry *"gets settled properly"*. It landed
and did not settle it — it carried **both** shapes into the lane, so the lane
inherits the asymmetry and `hd8-rows/yield-cost!` is still what prices it. Same
false status, forty lines down the same page; flagged here because it is one
clause beyond the two the bead enumerates.

**No re-engineering.** Prose only.

## `rf2-ouwh8` — a present-but-nil `:position` is a LOST one

Item 1 of the audit is already discharged on main (`p0_converge_app.cljs:905`
fails if slot-order *has* degenerated). Item 2 was live in **both** guard copies.

`#7267`'s lost-position gate separated *"records no positions"* (documented,
excused) from *"records and LOSES them"* (refuses, naming the count) — but only
for `NaN`. It asked `contains?` + `some?` (`order_guard.cljc:261`) and
`s.position !== null` (`order_guard.cjs:300`) before testing finiteness, so a
sample carrying a present-but-nil position fell through the first branch and was
excused **one at a time**.

The audit's witness, run against the landed code before and after:

```
24 flat samples, six finite positions, eighteen null
  before   refuse=false  status=clean      lostPositions=undefined
           phase adjudicated over FOUR survivors, report prints "24 samples"
  after    refuse=true   status=unchecked  lostPositions=18
           "18 of 24 samples have NO USABLE position (null, absent or
            non-finite) in a run that records them — the harness lost them …"
```

which is the fifteenth-fault shape exactly: a precise wrong number over a
silently narrowed population.

**The excuse belongs to the RUN, not to the sample.** That is the whole repair
and it is one predicate in each copy — stating it once subsumes both spellings
instead of bolting a second special case beside the first:

```clojure
(if (not-any? #(some? (:position %)) samples)
  0
  (count (remove #(finite? (:position %)) samples)))
```

If no sample offers a position the run is excused exactly as before; inside a run
that records them at all, **every** unusable position — nil, absent or
non-finite — is a loss. The `.cjs` copy is the same three lines through
`Number.isFinite`, and both self-tests gained the same check (cljc 12, cjs 11)
carrying the audit's 24-sample witness plus, in its second half, the excuse it
must **not** swallow: a run offering no position at all stays reportable with no
phase key at all. Only `:phase` is asked in that check, so nothing but the
positions can be what refuses.

**Proved by mutation**, on a three-arm plan with every reading flat at `1.0`:

```
clean plan, all positions finite   refuse=false
ONE position planted null          refuse=true, lostPositions=1, "1 of 6 samples …"
restored                           verdict byte-identical to the pre-plant one: true
```

**The tolerance is untouched**, and so is `adjudicate`. This changes which samples
the phase contrast will *accept*, never how far it lets them drift.

## `rf2-2rtt6.15` — one word

`validation.md`: *"unstable map args thrash the index"* → **"value-unstable map
args"**. Sub-key identity is `(query-id, args)` under *value* equality, so a
freshly allocated but `=`-equal map is one cache key — allocation is free, and
bare "unstable" reads as reference-unstable and tells a programmer to hoist or
memoize something that costs nothing. Only a value-unstable argument churns: a
re-sorted seq, a folded-in timestamp, a JS object or a function.

One line, one word. The draft guide's note that it is reporting a sibling page's
wording it does not own now has no reason to exist; the guide is outside this
change's fence, so deleting that note is a separate one-line follow-up.

## No number moves

None of the three touches a table, a figure or a range.

- **`rf2-pq7d8`** — prose only, and no arm outside HD-008 declares `:scheduler`,
  so every published row is the window it was measured in.
- **`rf2-ouwh8`** — every live emitter (`p0_harness`, `p0_arms`, `p0_app`,
  `hd8_rows`, `hicasso_narrow`, `b7_run`, `b8_run`, `reads_ladder_run`,
  `spine_ablation_run`, `read_attribution`, `write_attribution`) derives
  `:position` from an integer counter, so `lost-positions` answers `0` for every
  published run exactly as it did before. The studio's *"zero lost positions on
  every arm"* rows are unaffected.
- **`rf2-2rtt6.15`** — one word in a prose sentence beside the budget table.

So nothing was owed to `rf2-2rtt6.1`, which is size-locked and cannot accept an
append (`rf2-0znkn`).

## Quality gates

Run foreground to completion in this worktree, logs local, exit codes as echoed.

| gate | exit | result |
|---|---|---|
| `node …/freehand/bench/order_guard.cjs` (cjs self-test) | `0` | 12/12 checks ok |
| `re-frame.bench.order-guard/print-self-test!` on the JVM (cljc self-test) | `0` | 12/12 checks ok |
| `npm run test:freehand` | `0` | Ran 1399 tests containing 7752 assertions. 0 failures, 0 errors. |
| `npm run test:browser` | `0` | Ran 851 tests containing 5503 assertions. 0 failures, 0 errors. |
| `clojure -M:test` in `implementation/core` | `0` | Ran 2193 tests containing 11318 assertions. 0 failures, 0 errors. |

`test:freehand` carries `order-schedule-cljs-test`, which runs `guard/self-test`
in the ClojureScript runtime — so the shared fixture set is green in all three
runtimes the two copies live in, which is what holds them in step.

`mkdocs build --strict` is not a gate for either page: `design/hicasso/` is in
`exclude_docs` in `mkdocs.yml`, and neither edit adds or moves a link.
