### PR TITLE
bench,docs(hicasso): correct the HD-008 and converged-page claims, share the cache helper (rf2-2rtt6.7, rf2-zb3qg, rf2-b69lw, rf2-2rtt6.22)

### DIFF
--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -559,9 +559,24 @@ figure is a **lower bound** on the slim arm's cost. Both ends are published; a
 reader gets the interval instead of a point sitting quietly at one end of it.
 
 **No figure on this page moves.** The contract reads the rows; it does not take
-them. Applied to this page's own run it returns `:below-resolution` on both slim
-write rows — the reading was `0.0` in every window — so the ratios above stand
-exactly as published, now with the bound checked rather than asserted.
+them. A full three-run sweep on the branch that added it returns `:not-owed` on
+every `uix` and `reagent` write row and `:below-resolution` on both `slim` write
+rows — the aggregate read `0.0` in all ten of its windows, both at `k = 10` and
+at `k = 1` — so the ratios above stand exactly as published, now with the bound
+checked rather than asserted.
+
+**And the contract has been watched doing the other thing, which is the only
+reason to trust it.** A `slim`-only run on the same branch and the same host
+drew the nonzero reading: the ten-turn aggregate read **`0.0999999 ms` at its
+worst window**, the narrow row came back **`:corrected`**, the bound was
+subtracted from the floor — the sole yield-bearing arm in that row — and the
+ratios were re-formed within each round. The corrected band came out **larger**
+than the unadjusted one, which is the direction the fixed sign predicts, and no
+range crossed `1.0`, so the correction was discharged rather than refused. Its
+figures are not quoted here: that run was `HD8_ONLY=slim` with no `HD8_ROWS`, so
+every row it produced is marked non-publishing, and the point being made is
+about the gate rather than about the numbers. This is the case the old page
+promised to act on and the old driver exited `0` through.
 
 **Second-order, worth stating in the same pass.** The same reasoning applies
 wherever a sub-quantum per-item cost is asserted negligible across a batch.

--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -376,11 +376,18 @@ what an unpaid commit looks like from inside a clock.
 **Two windows do not bill the same wait, so the difference was measured.** The
 `reagent-slim` window omits one harness microtask that the floor's contains.
 `hd8-rows/yield-cost!` prices exactly that turn against the same clock, outside
-every arm's window, and read **p50 0.0 ms, min 0.0, max 0.0 over 10 samples in
-all three runs** — the harness microtask is below the 100 µs quantum, so the
-asymmetry is beneath this instrument's resolution and nothing has to be
-subtracted before the ratios above are read. Had it read anything else, this
-page would owe the reader a subtraction.
+every arm's window. **On the run that produced the rows above** it read
+**p50 0.0 ms, min 0.0, max 0.0 over 10 samples in all three runs** — below
+Chrome's 100 µs quantum, so on that run there was nothing to subtract before the
+ratios above are read.
+
+**That is a reading, not a property of the instrument, and this page used to
+blur the two.** It said the asymmetry *"is beneath this instrument's
+resolution"*, full stop. A later run of the same source on the same host read
+`{:p50 0 :min 0 :max 0.1 :n 10}` on the `slim` run — nonzero, and therefore
+exactly the case the next sentence named. So the reading has to be taken and
+adjudicated **every run**, which is what it now is; see
+[The correction contract is enforced, not stated](#the-correction-contract-is-enforced-not-stated).
 
 **And since the narrow window now holds ten of those turns rather than one, ten
 of them are priced under one clock as well** (`rf2-2rtt6.19`). That reading is
@@ -435,15 +442,73 @@ per turn at `< 10 µs`. Against the narrow row's 3.8–7.6 ms samples that is **
 most 2.6% of the smallest sample and 1.3% of the largest**, where the sentence
 this replaces left a reader facing up to 26%.
 
-**Nothing is subtracted, and now that is a finding rather than an assumption.**
-The bound is ten times tighter than the one it replaces, and it is the bound the
-batched window actually needs. Had the ten-turn window read anything above the
-clamp, this page would have owed the reader the subtraction the old sentence
-quietly assumed away.
+**Nothing is subtracted on this run, and that is a finding rather than an
+assumption.** The bound is ten times tighter than the one it replaces, and it is
+the bound the batched window actually needs. Had the ten-turn window read
+anything above the clamp, this page would have owed the reader the subtraction
+the old sentence quietly assumed away.
 
 **No published row moves.** The control is measured outside every arm's window,
 the one-turn reading is unchanged and still reported, and no arm's window was
 touched — so the ratios above are the ratios above.
+
+### The correction contract is enforced, not stated
+
+**The sentence above — *"had it read anything else, this page would owe the
+reader a subtraction"* — was a promise nothing kept.** `yield-cost!` was
+recorded beside the write rows and read by nobody. The audit of `#7269` ran the
+exact landed source and measured `{:p50 0 :min 0 :max 0.1 :n 10}` on the `slim`
+run: nonzero, the case the promise names, and the driver exited `0` and emitted
+unadjusted ratios anyway. A contract nothing evaluates is a sentence.
+
+`hd8-rows/yield-correction` is that contract as code, run against **both write
+rows of every run**, and `hd8-app` fails the run on a refusal — the same
+fail-closed path a positive control that missed its prediction takes. Four
+verdicts, and they are the whole of it:
+
+| verdict | when | what happens to the row |
+|---|---|---|
+| `:not-owed` | every arm in the row shares one window shape | published unchanged — the harness turns are in numerator and denominator alike |
+| `:below-resolution` | the row mixes shapes and the **aggregate** yield window's max is `0.0` across every sample | published unadjusted, with the bound on the record rather than assumed |
+| `:corrected` | mixed shapes, aggregate nonzero | the subtraction is **applied**; the corrected band is published beside the unadjusted one |
+| `:refused` | the correction cannot be discharged | **nothing in the row may be published**, and the run exits non-zero |
+
+**Which rows owe anything: the `slim` run's, and no others.** A row owes only
+when it mixes the two window shapes, and only `reagent-slim` is
+microtask-scheduled. In the `reagent` and `uix` runs every arm carries the
+harness turns, so there is nothing asymmetric to correct.
+
+**Two ways to be refused, and neither has a tolerance of its own.**
+
+* **The correction changes the verdict.** If subtracting the bound moves any
+  published range across `1.0` — indistinguishable becoming a finding, or the
+  reverse — then what the row reports is the asymmetry rather than the arms. The
+  test is the instrument's **own house rule** (`:straddles-1?`), deliberately:
+  a contract that decides whether a row may be published is not entitled to
+  invent a threshold for doing so.
+* **The correction exceeds the window.** A yield-bearing arm whose reading does
+  not survive the subtraction was not measuring its arm.
+
+**Which number is subtracted, and why the max.** The aggregate measured for
+*this row's* `k` — the ten-turn window for narrow, the one-turn reading for bulk
+— never a per-turn figure multiplied up, which is the argument that batched the
+writes in the first place. A row whose `k` has no measured aggregate is refused
+as **unevaluable** rather than corrected with the nearest available number. The
+bound subtracted is the aggregate's **max**: the p50 would be the central
+estimate of a correction, but a gate has to be evaluated at the end that could
+change the answer.
+
+**The direction is fixed and it is why a correction is publishable rather than
+alarming.** The turns sit in the bearers' windows only, so removing them makes
+the bearers *smaller*. On the `slim` run the floor is the bearer, so a corrected
+`reagent-slim / floor` is **larger** than the published one — the unadjusted
+figure is a **lower bound** on the slim arm's cost. Both ends are published; a
+reader gets the interval instead of a point sitting quietly at one end of it.
+
+**No figure on this page moves.** The contract reads the rows; it does not take
+them. Applied to this page's own run it returns `:below-resolution` on both slim
+write rows — the reading was `0.0` in every window — so the ratios above stand
+exactly as published, now with the bound checked rather than asserted.
 
 **Second-order, worth stating in the same pass.** The same reasoning applies
 wherever a sub-quantum per-item cost is asserted negligible across a batch.
@@ -463,8 +528,33 @@ overlaps it (narrow `donor-r1` `4.000 – 8.000` ⊃ `5.000 – 8.000`; narrow
 `8.750 – 17.000`). The re-take's write ranges are **wider** — four sibling
 workers were live on the host — which is why they are cited as a check and not
 as a replacement. **No figure moved systematically, and nothing published was
-invalidated.** `HD8_ONLY` exists so that a future re-take of one run cannot mint
-a competing set of figures for rows published at another commit.
+invalidated.**
+
+**`HD8_ONLY` did not do what this page said it did.** The sentence here read
+*"`HD8_ONLY` exists so that a future re-take of one run cannot mint a competing
+set of figures for rows published at another commit"*. It selects **adapters**.
+Each selected run still executed the bundle's whole row set, so `HD8_ONLY=slim`
+emitted `mount-M`, `mount-U`, `write-narrow` and `write-bulk` — four rows, where
+a re-take needed one or two — and nothing marked the other three as anything but
+figures. The competing set it was supposed to prevent was one copy-and-paste
+away (`rf2-b69lw`, from the `#7269` audit).
+
+**The declaration is explicit now, and the default is the safe one.**
+`HD8_ROWS` names what a partial run publishes; every other row it emits is
+stamped `NON-PUBLISHING` on its heading and on every figure under it, in the
+cross-run table a reader actually copies from, and the run states which rows it
+may publish in its provenance block.
+
+| invocation | publishes |
+|---|---|
+| `HD8_ONLY` unset | every row — the full three-run sweep, which is the published shape |
+| `HD8_ONLY=slim` | **nothing.** The driver cannot know which re-take was intended, so every row is marked |
+| `HD8_ONLY=slim HD8_ROWS=write-narrow,write-bulk` | those two; the mount rows are marked |
+
+Marked rather than suppressed: parity, the positive control, the lowering check,
+the read-back and the arm-order guard all still run over the whole set, and a row
+withheld from the log is a row nobody can diagnose. What a partial run must never
+do is emit a figure that *looks* like the published one.
 
 **Where the general fix belongs, and where it now lives.** The same fixed yield
 lived in the shared `lane/verified-write!`, which every Hicasso arm uses, and
@@ -557,11 +647,15 @@ and the alternatives that were rejected.
   that reading rests on.
 - **Two window shapes now exist**, and only one of them contains the harness
   microtask. Measured at 0.0 ms against a 100 µs quantum **one turn at a time and
-  ten turns at a time** (`rf2-2rtt6.19`), so the whole batched asymmetry is
-  beneath this instrument's resolution rather than ten times something beneath it
-  — but a future instrument with a finer clock inherits a real asymmetry, not a
-  settled one, and `rf2-pq7d8` has since carried both shapes into the shared
-  lane, which inherits that asymmetry rather than settling it.
+  ten turns at a time** (`rf2-2rtt6.19`) **on the run that produced these rows**,
+  so that run's whole batched asymmetry is beneath this instrument's resolution
+  rather than ten times something beneath it. **A later run of the same source on
+  the same host read `max 0.1 ms`, so this is a per-run reading and not a settled
+  property**, which is why `hd8-rows/yield-correction` now adjudicates it every
+  run and refuses a row it cannot discharge ([the contract](#the-correction-contract-is-enforced-not-stated)).
+  A future instrument with a finer clock inherits a real asymmetry, and
+  `rf2-pq7d8` has since carried both shapes into the shared lane, which inherits
+  that asymmetry rather than settling it.
 - **No retained-heap leg.** The red-zone rule governs clock *and* retained heap;
   this arm measures the clock. The heap ladder is `rf2-2rtt6.5`'s
   ([reads-per-boundary-heap-ladder.md](reads-per-boundary-heap-ladder.md)).

--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -28,34 +28,63 @@ Bead **`rf2-2rtt6.7`**. Decision **[HD-008](../decisions.md)**. The standard is
 
 ## Provenance
 
+Three producing commits, each re-taking only the rows whose window it changed.
+**The SHA in the left column is the one that LANDED on `main`** — the commit a
+reader can check out. The authored SHA beside it is what the run actually
+executed, kept because it is what the run's own artefacts recorded, and because
+a mapping a reader can verify is worth more than a rewritten SHA presented as if
+it had always been the one.
+
+| rows | landed on `main` | authored (rewritten by rebase) | instrument at the landed commit |
+|---|---|---|---|
+| every row except the `reagent-slim` and narrow write rows | **`172244521eb780a3ba38ccd057cad3430017bf1f`** | `d46ede4fb05a8f4c5af9900f0a010772f0b0883a` | `hd8_rows.cljs` `edec4ba86f543f0f0f4b9566b322c3c1021b360e` · `hd8_witnesses.cljs` `87b8624adefc502f127ddef27ef3e768ecae618c` · `lane.cljs` `d32312d9c562f0b6aa7d7f84538eb81ffc18e61c` |
+| the `reagent-slim` write rows (`rf2-b69lw`) | **`c7e4c70ac067d1ace58720a63804d268dad3df3a`** | `b943c7ed20d63d66fade4775059dad9fcf0012a7` | `hd8_rows.cljs` `ab4e7dab4e072123120e0f825f5e2befd8a62452` · `hd8_witnesses.cljs` `87b8624adefc502f127ddef27ef3e768ecae618c` · `lane.cljs` `d32312d9c562f0b6aa7d7f84538eb81ffc18e61c` |
+| the **narrow** write rows, on a batched window (`rf2-9zysg`) | **`0cba8181a7293f4aca4d9bd397cdbfc94b2c850a`** | `d3f1c2fff6305235216dc1e4cd9ac1cdf4519d9d` | `hd8_rows.cljs` `e6bca24420b7fc4c9de2c6137f5b2f7144ad243d` · `hd8_witnesses.cljs` `87b8624adefc502f127ddef27ef3e768ecae618c` · `lane.cljs` `671756751ecdb25c4c3d81e164c3204b022e93ae` |
+
+`5cd819c5bffc665fce4fae06abb144dbca1a92db` (authored `7aa55a2433`) is where this
+page's final `rf2-b69lw` record landed; it moved no figure.
+
 | | |
 |---|---|
-| **Producing commit** | `d46ede4fb05a8f4c5af9900f0a010772f0b0883a` — every row except the `reagent-slim` write rows |
-| **Producing commit, re-take** | `b943c7ed20d63d66fade4775059dad9fcf0012a7` — the `reagent-slim` write rows only (`rf2-b69lw`) |
-| **Producing commit, re-take** | `d3f1c2fff6` on `worker/lane-control-cluster` — the **narrow write rows** only, on a batched window (`rf2-9zysg`) |
-| **Producing instrument** | `hd8_rows.cljs` blob `e6bca24420b7fc4c9de2c6137f5b2f7144ad243d`, `lane.cljs` blob `671756751ecdb25c4c3d81e164c3204b022e93ae` |
-| **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs` — runs at every commit above, and **from a cold or a warm cache in any order** since `rf2-2rtt6.20` ([why](#the-lanes-shared-build-cache-made-this-page-look-broken-rf2-2rtt620)) |
+| **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs` — runs at each **landed** commit above, and **from a cold or a warm cache in any order** since `rf2-2rtt6.20` ([why](#the-lanes-shared-build-cache-made-this-page-look-broken-rf2-2rtt620)) |
 | **Build** | `:hicasso-bench` (rf2-2rtt6.2's lane) — `:advanced`, `goog.DEBUG false` |
 | **Runtime** | Chromium `HeadlessChrome/147.0.7727.15` (Windows NT 10.0 x64), React 19.2.0, node v24.13.0 |
 | **Rounds** | 6 · mount `{:warmup 4 :samples 12}` · write `{:warmup 3 :samples 10}` |
 
+**The instrument at `main`'s tip is no longer any of the three.** `ba0c215a73`
+batched the yield-cost control (`rf2-2rtt6.19`), and `rf2-b69lw` has since turned
+that control into an enforced gate — see [The correction contract is enforced,
+not stated](#the-correction-contract-is-enforced-not-stated). Neither touched an
+arm's window, so no figure on this page moves; but a run at the tip is a run of
+a *later* instrument over the same plan, and only a run at the landed commit in
+the row's own line reproduces that row's instrument exactly.
+
 Every figure below is a **browser** figure, which is what HD-012 requires of
 anything quotable against the bar.
 
-**The narrow rows are anchored by BLOB HASH as well as by commit, and that is
-not belt-and-braces.** The run was executed at `1c7c963e`; rebasing onto a main
-that had moved rewrote it to `d3f1c2fff6`, and merging this branch will rewrite
-it again. `git diff 1c7c963e d3f1c2fff6 -- implementation/` is empty, so the
-instrument did not change — but a reader handed only a rewritten SHA cannot
-check that. The two blob hashes above identify the exact instrument these
-figures came off regardless of how the commit carrying it is rebased, and
-`git rev-parse HEAD:implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs`
-is how a reader confirms the checkout in front of them is the one that produced
-this row.
+**Why both columns, and what each one is actually good for.** A producing SHA is
+rewritten by rebase *and* by merge. Every authored SHA in the middle column above
+is now unreachable — `d46ede4f`, `b943c7ed` and `d3f1c2ff` are on no branch, so a
+reader handed one of them can check out nothing and run nothing. That is what the
+landed column is for, and it is the **whole-tree anchor**: the bundle these
+figures came off depends on `re-frame.core`, on the three adapters, on
+`deps.edn`, `package-lock.json` and the React version, and only a commit pins all
+of them.
 
-**Three producing commits, and each later one re-took only the rows whose
-window it changed.** The narrow write rows are the batched re-take's and are marked as
-such in [their own section](#write--narrow-one-cell-in-a-300-cell-grid), where
+**The blob hashes pin the files they name and nothing else, which is a real but
+narrower guarantee.** `git rev-parse HEAD:implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs`
+tells a reader whether the instrument file in front of them is the one that took
+the row — useful precisely because it survives a rebase. It does **not** tell
+them the rest of the tree matches, and this page used to claim it did. The
+sibling P0 page has a concrete witness that the claim is false: its narrow row's
+authored and landed commits carry the *same* three pinned instrument blobs while
+the imported `lane.cljs` changed underneath them. So the two are recorded side by
+side and neither substitutes for the other — the commit says *which tree*, the
+blob says *which instrument*.
+
+**Each later producing commit re-took only the rows whose window it changed.**
+The narrow write rows are the batched re-take's and are marked as such in
+[their own section](#write--narrow-one-cell-in-a-300-cell-grid), where
 the superseded unbatched ranges are kept rather than deleted; `rf2-9zysg`
 batched ten writes under one clock and left every other window alone, so no
 other row moved. Before that:
@@ -72,19 +101,43 @@ changed and the reproduction check that says the change was inert for them.
 ## The arms
 
 Every arm reads **re-frame2 subscriptions** — the bar's like-for-like
-condition. No arm reads a bare ratom. Every arm resolves its dispatch fn the
-same way (one map lookup, primed outside render), so an arm that minted a fresh
-ops map per render would not be carrying an allocation its rivals escape; the
-frontier comparator in particular is never strawmanned.
+condition. No arm reads a bare ratom.
 
-| arm | hooks | markup | handler |
-|---|---|---|---|
-| `floor` | 0 | hand-written `createElement` | inert |
-| `reagent` | 0 | Reagent hiccup (`reg-view`) | author closure |
-| `reagent-slim` | 0 | slim hiccup (`reg-view`) | author closure |
-| `uix` | 2 | `$` macro — resolved at compile time | author closure |
-| `donor-r1` | 1 | slim hiccup + `:f>` | author closure |
-| `donor-r2` | 2 | slim hiccup + `:f>` | **codec-lowered** |
+| arm | hooks | markup | handler | how it resolves `dispatch` |
+|---|---|---|---|---|
+| `floor` | 0 | hand-written `createElement` | inert | **nothing** — one hoisted `(fn [_] nil)`, shared by every element |
+| `reagent` | 0 | Reagent hiccup (`reg-view`) | author closure | the **lexical** `dispatch` `reg-view` injects, bound to the surrounding frame |
+| `reagent-slim` | 0 | slim hiccup (`reg-view`) | author closure | the same lexical `dispatch` — one source, the other engine |
+| `uix` | 2 | `$` macro — resolved at compile time | author closure | `dispatch-for` — a **deref + lookup** in the shared `frame-dispatch` atom, in render |
+| `donor-r1` | 1 | slim hiccup + `:f>` | author closure | `dispatch-for`, as above |
+| `donor-r2` | 2 | slim hiccup + `:f>` | **codec-lowered** | `dispatch-for`, as above, then lowered by `lower-events` |
+
+**The arms do NOT all resolve dispatch the same way, and this page used to say
+they did.** The sentence here read *"every arm resolves its dispatch fn the same
+way — one map lookup, primed outside render"*. Three mechanisms are in the
+instrument, not one, and the column above is what the source does:
+
+* `prime-frame!` runs outside every measured window and puts each frame's
+  `dispatch` in a shared atom. That much of the old sentence is true, and it is
+  what stops any arm paying to *construct* a dispatch fn during a render.
+* But only the three React-spine arms go through it, and the **lookup** —
+  `(dispatch-for frame)`, a deref of the atom plus a `get` — happens **inside**
+  each boundary's render, 300 times a mount. "Primed outside render" described
+  the value; it did not describe the read.
+* The two Reagent paths never touch that atom at all. `reg-view` injects a
+  lexical `dispatch` already bound to the frame from context, which is what a
+  Reagent application actually contains.
+* The floor resolves nothing. Its handler is a single hoisted no-op shared by all
+  300 elements, which is correct — it is the calibrator, not a rival — but it is
+  a third thing again.
+
+**What the sentence was defending is still true, and worth keeping.** No arm
+mints a fresh **ops map** per render; every mechanism above is one indirection or
+fewer; and the frontier comparator is not strawmanned. **The direction of what
+remains is stated rather than waved away:** the deref-plus-`get` is paid by
+`uix`, `donor-r1` and `donor-r2` and *not* by the two Reagent paths, so the
+residual asymmetry runs **against** the arms HD-008 is arguing for. It cannot
+have flattered the donor rungs in the ship comparison.
 
 So `donor-r2 / donor-r1` is the product shell's price and nothing else's;
 `donor-r2 / uix` holds hooks and dispatch fixed and varies **the codec**;
@@ -656,6 +709,12 @@ and the alternatives that were rejected.
   A future instrument with a finer clock inherits a real asymmetry, and
   `rf2-pq7d8` has since carried both shapes into the shared lane, which inherits
   that asymmetry rather than settling it.
+- **The arms resolve `dispatch` three ways, not one** — see
+  [The arms](#the-arms). `:uix` and both donor rungs read the shared
+  `frame-dispatch` atom inside each boundary's render; the two Reagent paths take
+  `reg-view`'s lexical `dispatch`; the floor's handler is inert. The residual runs
+  against the donor rungs, so it cannot have flattered them, but the arms are not
+  levelled on this axis and this page claimed they were.
 - **No retained-heap leg.** The red-zone rule governs clock *and* retained heap;
   this arm measures the clock. The heap ladder is `rf2-2rtt6.5`'s
   ([reads-per-boundary-heap-ladder.md](reads-per-boundary-heap-ladder.md)).

--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -539,8 +539,19 @@ harness turns, so there is nothing asymmetric to correct.
   test is the instrument's **own house rule** (`:straddles-1?`), deliberately:
   a contract that decides whether a row may be published is not entitled to
   invent a threshold for doing so.
-* **The correction exceeds the window.** A yield-bearing arm whose reading does
-  not survive the subtraction was not measuring its arm.
+* **The correction exceeds the window** — a yield-bearing arm for which what
+  *remains* after the subtraction does not exceed what was *removed*. That
+  window was measuring the harness's turns rather than the arm.
+
+  **This test began as `pos?`, and the gate run caught it publishing a precise
+  wrong number**, which is worth recording because it is the same shape of fault
+  the whole instrument is built against. On a `slim` run where the one-turn
+  aggregate resolved at `0.0999999 ms`, the **bulk** row's floor — whose p50 is
+  about *one clock quantum* — survived the subtraction at `~1e-8 ms`, still
+  positive, and the corrected `reagent-slim / floor` came out at
+  **`15,518,934×`**. A denominator that survives by a rounding error is not a
+  denominator. The rule is now the comparison between two measured quantities
+  with no constant between them, and that row refuses.
 
 **Which number is subtracted, and why the max.** The aggregate measured for
 *this row's* `k` — the ten-turn window for narrow, the one-turn reading for bulk
@@ -557,6 +568,18 @@ the bearers *smaller*. On the `slim` run the floor is the bearer, so a corrected
 `reagent-slim / floor` is **larger** than the published one — the unadjusted
 figure is a **lower bound** on the slim arm's cost. Both ends are published; a
 reader gets the interval instead of a point sitting quietly at one end of it.
+
+**A gate nobody has watched refuse is not a gate, and this one refuses
+rarely.** The harness asymmetry reads `0.0` on most runs of this host and
+resolves only intermittently, so a live run cannot be relied on to exercise the
+branch that matters — which is the branch that stops a figure being published.
+So the contract has a **self-test**, replayed from recorded fixtures through the
+live rule, run inside the bundle **before any clock**, and fatal when it
+disagrees: `hd8-app` throws, `hd8_run.cjs` prints every check and exits `1`. It
+is `order_guard.cjs`'s technique and `parity-can-fail?`'s argument, applied to
+the newest gate rather than only the oldest ones. Six fixtures: one per verdict,
+and one per refusal reason. **Fixture 4 is the `15,518,934×` row**, kept so that
+repair cannot silently come undone.
 
 **No figure on this page moves.** The contract reads the rows; it does not take
 them. A full three-run sweep on the branch that added it returns `:not-owed` on
@@ -708,6 +731,17 @@ and the alternatives that were rejected.
   `< 1.0 ms`, which is up to ~26% of a 3.8–7.6 ms sample.
 - **The bulk write verifies one probe cell**, where the shared lane verifies a
   seq including the far end of the grid. Same bead.
+- **The bulk row's FLOOR sits on the clock clamp**, at a p50 of about one 100 µs
+  quantum, and that is a harder limit than it looks. The published row was taken
+  on a run whose harness-microtask aggregate read `0.0`, so nothing was owed and
+  the figure stands. But on a run where that aggregate *resolves* — and it does,
+  intermittently, at `0.1 ms` on this host — the correction is the whole of the
+  bulk floor, and [the contract](#the-correction-contract-is-enforced-not-stated)
+  refuses the row rather than quoting a ratio against a denominator that is
+  mostly harness. Lifting it needs the same repair the narrow row got: **batch
+  the bulk window** so the floor clears the clamp. Not done here — that changes a
+  measured window and therefore obliges a re-take of the row, which is a
+  re-publication and not this bead's to make.
 - **The write rows' donor-vs-Reagent comparison is cross-run**, floor-normalised.
   The mount rows' is not. **The `reagent-slim` write column is normalised through
   the floor of a run taken at a different commit** from the donor and `reagent`

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -164,10 +164,23 @@ P=implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
 git rev-parse <candidate>:$P   # must print f4b09dc20712e45f44f9ec9339f8dd00ce51e8f7
 ```
 
-The reproduction command was run **at this commit, on a clean working tree**,
-and the figures below are that run's. A second, independent five-round run of
-the identical instrument is published beside them; where the two disagree, the
-page says so rather than picking one.
+**The reproduction command was run at this instrument, on a clean working tree
+— and it produced the NARROW row and nothing else.** This paragraph used to say
+*"the figures below are that run's"*, unqualified, which is not what happened:
+`HICASSO_ONLY=narrow` re-took one row of four, exactly as the paragraph above
+says it should. Three of the four rows below therefore come off a **different
+instrument**, and a provenance block that does not partition its own table is
+the blur such a block exists to prevent.
+
+| rows | instrument | which run |
+|---|---|---|
+| M1 mount · M2 mount · bulk broad | the **earlier** instrument — `p0_converge_app.cljs` blob `9b5c0d63db5528d8b9790111f9bc53cda052106f`, at `4c3f7189c4` | the original five-round sweep in [Provenance](#provenance) above. Re-**checked** against the current instrument by [the rf2-rjfz1 sweep](#all-four-rows-reproduce-against-the-revived-driver-rf2-rjfz1); not re-taken |
+| **bulk narrow** *(batched)* | `f4b09dc20712e45f44f9ec9339f8dd00ce51e8f7` — the blob table immediately above | run **twice** at this instrument, and both runs are published |
+
+A second, independent five-round run of the identical instrument is published
+beside the **narrow** row; where the two disagree, the page says so rather than
+picking one. The other three rows have one run each and a reproduction check,
+which is a weaker warrant and is labelled as one wherever it appears.
 
 All bar numbers are browser numbers. No JVM or Node figure appears on this page.
 
@@ -296,7 +309,7 @@ has never been.
 | **Position completeness** | **zero lost positions on every arm of every row**; each phase contrast adjudicated on a full 20-against-20 of 60 |
 | **Canonical-DOM parity** | clean in both segments and across the seam, every row — `{:problems [] :ok? true}` |
 | **Verification** | **0 unverified of 7,860** — 600 M1 mounts + 600 M2 mounts + 630 broad writes + 6,030 narrow writes |
-| **Positive controls** | eight, **eight passes** under the overlap rule; see below for the strict reading |
+| **Positive controls** | **this sweep's** four rows × two segments = eight, **eight passes** under the overlap rule; see below for the strict reading. Not the page's live count — the [positive-control table](#the-positive-controls) carries ten entries, because the narrow row is published from two runs and the superseded one is struck |
 
 **The M2 control that rf2-egdaq holds open reads differently on this sweep,
 and the ruling is still the operator's.** The published M2 control range
@@ -488,9 +501,19 @@ can honestly be held to it.)
 | **bulk narrow** *(batched, run 2)* | 1.9989× | 1.941× [1.905 – 1.977] ✅ | 1.935× [1.814 – 2.000] ✅ | 1801 / 901 elements |
 | ~~bulk narrow *(unbatched, superseded)*~~ | ~~1.9989×~~ | ~~2.013× [1.667 – 2.400] ✅~~ | ~~1.867× [1.667 – 2.000] ✅~~ | ~~1801 / 901 elements~~ |
 
-Eight controls, eight passes, and seven of the eight sit **below** their
-prediction — the direction a fixed per-root term predicts, and the same
-direction rf2-2rtt6.2 and rf2-2rtt6.4 both recorded.
+**Ten controls, ten passes, and all ten sit below their prediction** — the
+direction a fixed per-root term predicts, and the same direction rf2-2rtt6.2
+and rf2-2rtt6.4 both recorded.
+
+**This summary read *"Eight controls, eight passes, and seven of the eight sit
+below"*, and the table it described no longer exists.** It was right when the
+table held M1, M2, broad and the unbatched narrow row — four entries across two
+segments, of which exactly one, the narrow Reagent segment's `2.013×`, sat above
+its prediction. The batched re-take struck that row and added two batched runs
+in its place, so the live table is **five entries × two segments = ten**, the
+one entry that sat above prediction is the superseded one, and the direction is
+now unanimous. Counting the struck row would be counting a figure this page has
+withdrawn.
 
 The narrow row's controls were **predicted before the run** at `1801 / 901 =
 1.9989×` and re-measured on the batched window; all four ranges above sit
@@ -586,3 +609,15 @@ first cut produced looked entirely plausible.
   the boundary rather than of the page.
 - **The per-page accumulation is still unexplained.** One row per page makes it
   harmless to these figures; it does not make it fixed.
+- **`p0_converge_app.cljs`'s own row table still describes the pre-batch narrow
+  window, and this page cannot fix it.** Its namespace docstring reads
+  *"`bulk-narrow` | the M1 page, one commit exactly ONE boundary reads"*, which
+  was true before `rf2-zb3qg` and is not true of the landed row: `narrow-batch-k`
+  commits share one timed window, and the `:doc` on the entry itself — ~730 lines
+  further down the same file — already says so. So the file contradicts itself,
+  and a reader who stops at the summary table reads a window that no longer
+  exists. **Marked rather than corrected**: a sibling worker holds 362
+  uncommitted lines in that file at the time of writing, its earliest hunk at
+  line 229, and a one-line docstring fix landed into a live working surface buys
+  a conflict on a hot file for nothing. The correction belongs to whoever
+  finishes there, and it is one line.

--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
@@ -82,6 +82,29 @@ const REPO = path.resolve(IMPL, '..');
 const OUT = path.join(IMPL, 'out', 'hicasso-narrow');
 const PORT = Number(process.env.HN_PORT || 8141);
 
+// THE LANE'S ONE CACHE RULE (rf2-2rtt6.20, applied here by rf2-2rtt6.22).
+//
+// This driver is the SIXTH program riding `:hicasso-bench`, and shadow-cljs
+// derives the build cache directory from the build id alone — before any
+// `--config-merge` is applied — so all six share one cache entry. The five
+// drivers in `freehand/test/re_frame/bench/hicasso/` clear it before they
+// build, which is why this one can no longer poison THEM; nothing was
+// clearing it on this driver's behalf, so it could still be handed a cache
+// poisoned by whichever arm ran before it. `lane_cache.cjs` carries the
+// mechanism, the isolation evidence and the measured cost.
+//
+// Reached by path across the test trees, exactly as `navigate.cjs` is below
+// and for the same reason: ONE helper for the repository, never a second copy
+// per lane. Unlike `loadNavigate`, this require has NO FALLBACK — a fallback
+// here would silently re-arm the trap, and a driver that cannot find the
+// cache rule must fail loudly rather than measure without it. (The helper's
+// home is the hicasso lane it was written for; hoisting it beside
+// `navigate.cjs` now that a second tree needs it is rf2-2rtt6.22's recorded
+// recommendation and is left to the owner of those five drivers.)
+const { resetLaneBuildCache } = require(
+  path.join(IMPL, 'freehand/test/re_frame/bench/hicasso/lane_cache.cjs')
+);
+
 // --- the plan ---------------------------------------------------------------
 //
 // Four rounds of six measured samples is 24 samples an arm, which is what
@@ -163,6 +186,10 @@ const CONFIG_MERGE =
   ':modules {:main {:init-fn re-frame.bench.hicasso-narrow-app/-main}}}';
 
 function build() {
+  // Before anything reads the cache — see the note beside the require.
+  if (resetLaneBuildCache(IMPL, BASE_BUILD)) {
+    console.error(`[hn] cleared .shadow-cljs/builds/${BASE_BUILD} — one build id, N arms (rf2-2rtt6.20)`);
+  }
   console.error(`[hn] building :advanced bundle from template :${BASE_BUILD} ...`);
   const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
   const r = spawnSync(

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
@@ -110,6 +110,23 @@
   (summary! k r)
   (record! k (dissoc r :samples)))
 
+(defn- correction!
+  "Park one write row's yield-correction VERDICT where the driver can read
+  it without an EDN reader, so the cross-run table can stamp the row.
+
+  A corrected row that appears in the table looking uncorrected is the
+  exact fault this contract exists to prevent, and the table is what a
+  reader copies a figure out of."
+  [row-name v]
+  (let [acc (or (.-HD8_CORRECTION js/window) #js {})]
+    (aset acc (name row-name)
+          #js {"verdict" (name (:verdict v))
+               "reason"  (some-> (:reason v) name)
+               "bound"   (:bound v)
+               "why"     (:why v)})
+    (set! (.-HD8_CORRECTION js/window) acc)
+    nil))
+
 (defn- done! [] (set! (.-HD8_DONE js/window) true))
 
 ;; ---------------------------------------------------------------------------
@@ -221,19 +238,52 @@
                             ;; microtask-scheduled arm's window does not contain
                             ;; that turn and its rivals' do (rf2-b69lw), so the
                             ;; size of the asymmetry is published beside the rows
-                            ;; rather than argued about after them.
-                            (-> (rows/yield-cost! write-sampling)
-                                (.then (fn [yc]
-                                         (record! :yield-cost yc)
-                                         (rows/measure-write! write-ids which :narrow rounds write-sampling)))
-                                (.then (fn [r]
-                                         (record-row! :write-narrow r)
-                                         (rows/assert-teardown-clean! "write-narrow")
-                                         (rows/measure-write! write-ids which :bulk rounds write-sampling)))
-                                (.then (fn [r]
-                                         (record-row! :write-bulk r)
-                                         (rows/assert-teardown-clean! "write-bulk")
-                                         (done!))))))))
+                            ;; — and, since this bead, ADJUDICATED against them
+                            ;; rather than left beside them as an observation.
+                            (let [yc* (volatile! nil)]
+                              (-> (rows/yield-cost! write-sampling)
+                                  (.then (fn [yc]
+                                           (record! :yield-cost yc)
+                                           (vreset! yc* yc)
+                                           (rows/measure-write! write-ids which :narrow rounds write-sampling)))
+                                  (.then (fn [r]
+                                           (record-row! :write-narrow r)
+                                           (rows/assert-teardown-clean! "write-narrow")
+                                           (-> (rows/measure-write! write-ids which :bulk rounds write-sampling)
+                                               (.then (fn [b] #js [r b])))))
+                                  (.then
+                                    (fn [pair]
+                                      (let [narrow (aget pair 0)
+                                            bulk   (aget pair 1)]
+                                        (record-row! :write-bulk bulk)
+                                        (rows/assert-teardown-clean! "write-bulk")
+                                        ;; ---- THE CORRECTION-OR-REFUSAL CONTRACT ----
+                                        ;; The asymmetry between the two window shapes
+                                        ;; used to be recorded here and nothing else:
+                                        ;; the run exited 0 and emitted unadjusted
+                                        ;; ratios over a slim run whose aggregate had
+                                        ;; read nonzero, while the studio record said
+                                        ;; any nonzero reading owes the reader a
+                                        ;; subtraction (rf2-b69lw, from the PR #7269
+                                        ;; audit). It is adjudicated now, and a row
+                                        ;; whose correction cannot be discharged FAILS
+                                        ;; the run — the same fail-closed path the
+                                        ;; positive control takes, for the same reason:
+                                        ;; a figure the instrument cannot stand behind
+                                        ;; is not a measurement.
+                                        (let [verdicts {:write-narrow (rows/yield-correction narrow which @yc*)
+                                                        :write-bulk   (rows/yield-correction bulk which @yc*)}
+                                              refused  (into {} (filter (fn [[_ v]] (= :refused (:verdict v)))) verdicts)]
+                                          (record! :yield-correction verdicts)
+                                          (doseq [[k v] verdicts] (correction! k v))
+                                          (when (seq refused)
+                                            (fail! (str "the harness-microtask correction could not be discharged on "
+                                                        (pr-str (vec (keys refused))) " — "
+                                                        (pr-str (into {} (map (fn [[k v]] [k (:why v)])) refused))
+                                                        ". Those rows mix window shapes, so one arm is billed for "
+                                                        "turns its rival escapes, and a ratio published over that "
+                                                        "is a comparison of the harness.")))
+                                          (done!)))))))))))
                     (.catch (fn [e]
                               (fail! (str "the run threw: " (.-message e) "\n" (.-stack e)))
                               (done!))))))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
@@ -162,6 +162,35 @@
     (doseq [id arm-ids] (rows/ensure-frame! id))
     (record! :method (rows/method-record which arm-ids write-ids rounds mount-sampling write-sampling))
 
+    ;; ---- gate 0: the correction contract's own self-test -------------------
+    ;; Before anything is measured, because a harness that gets `false` here
+    ;; may measure nothing — the same placement, and the same argument, as
+    ;; the arm-order guard's self-test in `hd8_run.cjs`.
+    ;;
+    ;; It exists because THE BRANCH THAT MATTERS ALMOST NEVER FIRES LIVE: the
+    ;; harness asymmetry reads 0.0 on most runs of this host, so a run cannot
+    ;; be relied on to exercise a refusal, and a gate nobody has watched
+    ;; refuse is not evidence. Fixtures replayed through the live rule are.
+    ;;
+    ;; It THROWS rather than recording a failure and reading on: `-main`'s
+    ;; `catch` is the fail-closed path (`assert-teardown-clean!` uses it for
+    ;; the same reason), and a `when-not` here would print the failure and
+    ;; then measure the whole plan anyway.
+    (let [st (rows/yield-correction-self-test)]
+      (record! :yield-correction-self-test st)
+      ;; Also on a JS-readable channel, so the driver can fail on it instead
+      ;; of parsing EDN it has no reader for.
+      (set! (.-HD8_CORRECTION_SELFTEST js/window)
+            (clj->js {"ok" (boolean (:ok? st))
+                      "checks" (mapv (fn [c] {"name" (:name c) "ok" (:ok c) "detail" (:detail c)})
+                                     (:checks st))}))
+      (when-not (:ok? st)
+        (throw (ex-info (str "the yield-correction contract failed its own self-test — the gate "
+                             "that decides whether a write row may be published does not agree "
+                             "with its recorded fixtures, so nothing may be measured: "
+                             (pr-str (remove :ok (:checks st))))
+                        {:checks (:checks st)}))))
+
     ;; ---- the fairness gate, before any clock ------------------------------
     (let [problems (rows/parity-problems arm-ids)]
       (if (seq problems)

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
@@ -1075,10 +1075,24 @@
   [{:keys [p50]} bearers bound]
   (let [adj   (into {} (map (fn [[id v]] [id (if (contains? bearers id) (- v bound) v)])) p50)
         floor (get adj :floor)]
-    ;; Only the BEARERS are checked for survival, because only they were
-    ;; subtracted from. An exempt arm reading zero is a clamp problem this
-    ;; contract did not create and must not claim to have found.
-    (when (and (pos? floor) (every? pos? (vals (select-keys adj bearers))))
+    ;; SURVIVAL: WHAT REMAINS MUST EXCEED WHAT WAS REMOVED.
+    ;;
+    ;; Only the BEARERS are checked, because only they were subtracted from —
+    ;; an exempt arm reading zero is a clamp problem this contract did not
+    ;; create and must not claim to have found.
+    ;;
+    ;; The test is not `pos?`, and finding that out cost a wrong number rather
+    ;; than an argument. `pos?` passed a bulk row whose floor read one clock
+    ;; quantum against a bound of one clock quantum: the corrected floor came
+    ;; out at ~1e-8 ms, still positive, and the row published a corrected
+    ;; `reagent-slim / floor` of 15,518,934x. A denominator that survives
+    ;; subtraction by a rounding error is not a denominator.
+    ;;
+    ;; So a bearer survives only when the correction is the SMALLER part of its
+    ;; window. That is not a threshold invented here — it is what makes a
+    ;; correction a correction rather than the measurement, and it compares two
+    ;; MEASURED quantities with no constant between them.
+    (when (every? (fn [[_ v]] (> v bound)) (select-keys adj bearers))
       {:p50   adj
        :ratio (into {} (map (fn [[id v]] [id (round4 (/ v floor))])) adj)})))
 
@@ -1133,8 +1147,13 @@
         invented here, which is deliberate: this contract is not entitled
         to a tolerance of its own.
 
-    (b) THE CORRECTION EXCEEDS THE WINDOW. A bearer whose reading does not
-        survive the subtraction was not measuring its arm.
+    (b) THE CORRECTION EXCEEDS THE WINDOW — a bearer for which what REMAINS
+        after the subtraction does not exceed what was REMOVED. That window
+        was measuring the harness's turns, not the arm. `pos?` is not the
+        test and the difference is not academic: it passed a bulk row whose
+        floor read one clock quantum against a bound of one clock quantum,
+        left a corrected floor of ~1e-8 ms, and published a corrected ratio
+        of 15,518,934x. See [[correct-round]].
 
   Refusal is not this function's to soften and not the caller's to widen.
   `hd8-app` fails the run on one, exactly as it does on a positive control
@@ -1207,10 +1226,14 @@
       (let [bound     (:max agg)
             corrected (mapv #(correct-round % bearers bound) (:per-round row))]
         (if (some nil? corrected)
-          (assoc base :verdict :refused :reason :correction-exceeds-window :aggregate agg
-                      :why (str "subtracting the " (:k agg) "-turn aggregate bound of " bound
-                                " ms leaves a bearer arm at or below zero in at least one round: "
-                                "that window was measuring the harness's turns, not the arm"))
+          (assoc base :verdict :refused :reason :correction-exceeds-window
+                      :aggregate agg :bound bound
+                      :why (str "in at least one round a yield-bearing arm has LESS LEFT after "
+                                "subtracting the " (:k agg) "-turn aggregate bound of " bound
+                                " ms than the subtraction removed. That window was measuring "
+                                "the harness's turns rather than the arm, so no ratio taken "
+                                "against it may be published — and a corrected value that "
+                                "survives only by a rounding error is not a denominator"))
           (let [summary'  (lane/across-rounds (mapv :ratio corrected))
                 h2h'      (head-to-head corrected)
                 flipped   (into []
@@ -1247,6 +1270,111 @@
                                     "bearer smaller — so the published unadjusted figure and "
                                     "the corrected one bracket the answer, and no range "
                                     "crossed 1.0 between them")))))))))
+
+(defn- fixture-row
+  "A synthetic write row built from per-round p50 maps, so a fixture is a
+  handful of milliseconds rather than a hand-written summary that could
+  disagree with its own rounds."
+  [witness k arms rounds]
+  (let [per-round (mapv (fn [p50]
+                          (let [floor (get p50 :floor)]
+                            {:p50   p50
+                             :ratio (into {} (map (fn [[id v]] [id (round4 (/ v floor))])) p50)}))
+                        rounds)]
+    {:witness           witness
+     :arms              arms
+     :writes-per-sample k
+     :per-round         per-round
+     :summary           (lane/across-rounds (mapv :ratio per-round))
+     :head-to-head      (head-to-head per-round)}))
+
+(defn yield-correction-self-test
+  "Replay [[yield-correction]] over recorded fixtures, and answer
+  `{:ok? :checks}`.
+
+  **A gate nobody has watched refuse is not a gate**, and this one refuses
+  rarely by design: the harness asymmetry reads `0.0` on most runs of this
+  host and resolves only intermittently, so a live run cannot be relied on
+  to exercise the branch that matters. `parity-can-fail?` makes exactly
+  this argument about the parity gate and `hd8_run.cjs`'s gate 4 makes it
+  about the DOM read-back. This is the same argument for the correction
+  contract, and the technique is `order_guard.cjs`'s: fixtures replayed
+  through the live rule, before anything is measured, deterministic, and
+  fatal when they disagree.
+
+  Fixture 4 is not invented. It is the row that made the survival test
+  `pos?` publish a corrected ratio of 15,518,934x — a bulk floor of one
+  clock quantum against a bound of one clock quantum — and it is here so
+  that repair cannot silently come undone."
+  []
+  (let [zero-yc    {:p50 0 :min 0 :max 0 :n 10
+                    :batched {:k narrow-batch-k :window-p50 0 :window-max 0 :n 10}}
+        live-yc    {:p50 0 :min 0 :max 0.1 :n 10
+                    :batched {:k narrow-batch-k :window-p50 0 :window-max 0.1 :n 10}}
+        no-agg-yc  {:p50 0 :min 0 :max 0.1 :n 10}
+        verdict-of (fn [row adapter yc] (yield-correction row adapter yc))
+        checks
+        [;; 1. Both arms carry the harness turns, so nothing is asymmetric.
+         (let [v (verdict-of (fixture-row :U-narrow narrow-batch-k [:floor :reagent]
+                                          [{:floor 1.0 :reagent 5.0} {:floor 1.0 :reagent 5.0}])
+                             :reagent zero-yc)]
+           {:name "one window shape in the row is NOT-OWED"
+            :ok   (= :not-owed (:verdict v))
+            :detail (name (:verdict v))})
+
+         ;; 2. Mixed shapes, aggregate flat zero across every window.
+         (let [v (verdict-of (fixture-row :U-narrow narrow-batch-k [:floor :reagent-slim]
+                                          [{:floor 1.0 :reagent-slim 5.0} {:floor 1.2 :reagent-slim 6.0}])
+                             :slim zero-yc)]
+           {:name "mixed shapes with a 0.0 aggregate is BELOW-RESOLUTION"
+            :ok   (= :below-resolution (:verdict v))
+            :detail (name (:verdict v))})
+
+         ;; 3. Mixed shapes, aggregate resolves, the bearer survives and no
+         ;;    range crosses 1.0 — so the subtraction is applied and the
+         ;;    corrected ratio is LARGER, which is the fixed direction.
+         (let [v (verdict-of (fixture-row :U-narrow narrow-batch-k [:floor :reagent-slim]
+                                          [{:floor 1.0 :reagent-slim 5.0} {:floor 1.2 :reagent-slim 6.0}])
+                             :slim live-yc)
+               was  (get-in (fixture-row :U-narrow narrow-batch-k [:floor :reagent-slim]
+                                         [{:floor 1.0 :reagent-slim 5.0} {:floor 1.2 :reagent-slim 6.0}])
+                            [:summary :reagent-slim :min])
+               now  (get-in v [:summary-corrected :reagent-slim :min])]
+           {:name "a resolving aggregate is CORRECTED, and the corrected ratio is larger"
+            :ok   (and (= :corrected (:verdict v)) (number? now) (> now was))
+            :detail (str (name (:verdict v)) " " was " -> " now)})
+
+         ;; 4. THE 15,518,934x ROW. A bulk floor of one quantum against a
+         ;;    bound of one quantum: `pos?` passed it, this must not.
+         (let [v (verdict-of (fixture-row :U-bulk 1 [:floor :reagent-slim]
+                                          [{:floor 0.1 :reagent-slim 1.5} {:floor 0.1 :reagent-slim 1.6}])
+                             :slim live-yc)]
+           {:name "a bearer with less left than was removed is REFUSED (the 15,518,934x row)"
+            :ok   (and (= :refused (:verdict v))
+                       (= :correction-exceeds-window (:reason v)))
+            :detail (str (name (:verdict v)) "/" (some-> (:reason v) name))})
+
+         ;; 5. The correction moves a range across 1.0, so the row is
+         ;;    reporting the asymmetry rather than the arms.
+         (let [v (verdict-of (fixture-row :U-narrow narrow-batch-k [:floor :reagent-slim]
+                                          [{:floor 1.0 :reagent-slim 0.9} {:floor 1.0 :reagent-slim 1.1}])
+                             :slim {:p50 0 :min 0 :max 0.3 :n 10
+                                    :batched {:k narrow-batch-k :window-p50 0 :window-max 0.3 :n 10}})]
+           {:name "a correction that moves a range across 1.0 is REFUSED"
+            :ok   (and (= :refused (:verdict v))
+                       (= :correction-changes-the-verdict (:reason v)))
+            :detail (str (name (:verdict v)) "/" (some-> (:reason v) name))})
+
+         ;; 6. No measured aggregate for this row's k. Refused as
+         ;;    unevaluable, never corrected with the nearest number to hand.
+         (let [v (verdict-of (fixture-row :U-narrow narrow-batch-k [:floor :reagent-slim]
+                                          [{:floor 1.0 :reagent-slim 5.0} {:floor 1.2 :reagent-slim 6.0}])
+                             :slim no-agg-yc)]
+           {:name "no aggregate measured for this row's k is REFUSED as unevaluable"
+            :ok   (and (= :refused (:verdict v)) (= :unevaluable (:reason v)))
+            :detail (str (name (:verdict v)) "/" (some-> (:reason v) name))})]]
+    {:ok?    (every? :ok checks)
+     :checks (mapv (fn [c] (update c :ok boolean)) checks)}))
 
 ;; ===========================================================================
 ;; The positive control — predicted against measured, every run

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
@@ -101,6 +101,7 @@
   `rf2-2rtt6.1` and `docs/design/hicasso/studio/`."
   (:require ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]
+            [clojure.string :as str]
             [re-frame.adapter.uix :as uixa]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -1051,6 +1052,201 @@
                                "clamp; it does NOT bound " narrow-batch-k
                                " of them, and this window measures them instead "
                                "of multiplying (rf2-2rtt6.19)")}}))))))))
+
+;; ===========================================================================
+;; THE CORRECTION-OR-REFUSAL CONTRACT — the asymmetry adjudicated, not noted
+;; ===========================================================================
+
+(defn- window-shape
+  "`:write-then-drain` (no harness microtask in the window) or
+  `:write-yield-drain` (`k` of them), for `arm-id` under `adapter`."
+  [arm-id adapter]
+  (if (= (arm-scheduler arm-id adapter) :microtask)
+    :write-then-drain
+    :write-yield-drain))
+
+(defn- correct-round
+  "One round's p50 map with `bound` ms subtracted from every arm in
+  `bearers`, and the floor ratios re-formed from the corrected p50s.
+
+  Re-formed and not rescaled: the ratios are within-round by construction
+  and the correction moves the DENOMINATOR whenever the floor is a bearer,
+  which no rescaling of the published ratio can express."
+  [{:keys [p50]} bearers bound]
+  (let [adj   (into {} (map (fn [[id v]] [id (if (contains? bearers id) (- v bound) v)])) p50)
+        floor (get adj :floor)]
+    ;; Only the BEARERS are checked for survival, because only they were
+    ;; subtracted from. An exempt arm reading zero is a clamp problem this
+    ;; contract did not create and must not claim to have found.
+    (when (and (pos? floor) (every? pos? (vals (select-keys adj bearers))))
+      {:p50   adj
+       :ratio (into {} (map (fn [[id v]] [id (round4 (/ v floor))])) adj)})))
+
+(defn yield-correction
+  "Adjudicate one write row against the harness-microtask asymmetry, and
+  answer a verdict rather than an observation (rf2-b69lw).
+
+  ## What is owed, and why
+
+  [[window-of]] gives a `:microtask`-scheduled arm a window with NOTHING
+  between its write and its drain, and every other arm a window holding
+  `k` harness microtasks. So on a row that mixes the two shapes, the
+  yield-bearing arms are billed for turns their rival is not, and the
+  studio record says plainly that any nonzero reading of that turn owes
+  the reader a subtraction. It said so and nothing acted on it: the
+  driver recorded [[yield-cost!]] beside the row, exited 0, and published
+  unadjusted ratios over a slim run that had measured
+  `{:p50 0 :max 0.1 :n 10}`. A contract nothing enforces is a sentence,
+  not a contract.
+
+  ## The four verdicts
+
+  `:not-owed` — every arm in the row shares one window shape, so the turns
+  are in the numerator and the denominator alike. Only a row that MIXES
+  shapes owes anything, and today that is the `slim` run's write rows and
+  no others.
+
+  `:below-resolution` — the row owes, and the aggregate yield window's MAX
+  is zero across every sample. Chrome clamps `performance.now()` to 100 µs;
+  a max of zero over `n` windows is the instrument saying it could not
+  resolve the asymmetry in any of them. There is nothing to subtract, and
+  the row publishes unadjusted with the bound on the record.
+
+  `:corrected` — the row owes, the aggregate reads nonzero, and the
+  subtraction is APPLIED. Its direction is fixed and known: the turns sit
+  in the bearers' windows only, so removing them makes the bearers
+  smaller. Where the floor is a bearer — which it is on the slim run — the
+  corrected ratio is LARGER, and the published unadjusted figure is
+  therefore a LOWER BOUND on the exempt arm's cost. Both ends are
+  published; a reader is given the interval rather than a point that
+  quietly sits at one end of it.
+
+  `:refused` — the row owes and the correction cannot be discharged. Two
+  ways, and both mean the same thing: the window is substantially the
+  harness's own turns rather than the arm's work.
+
+    (a) THE CORRECTION CHANGES THE VERDICT. If subtracting the bound moves
+        any published range across 1.0 — indistinguishable becoming a
+        finding, or a finding becoming indistinguishable — then what the
+        row reports is an artefact of the asymmetry. The test is the
+        instrument's OWN house rule (`:straddles-1?`), not a threshold
+        invented here, which is deliberate: this contract is not entitled
+        to a tolerance of its own.
+
+    (b) THE CORRECTION EXCEEDS THE WINDOW. A bearer whose reading does not
+        survive the subtraction was not measuring its arm.
+
+  Refusal is not this function's to soften and not the caller's to widen.
+  `hd8-app` fails the run on one, exactly as it does on a positive control
+  that missed its prediction.
+
+  ## Which reading is subtracted
+
+  The aggregate measured for THIS row's `k`, never a per-turn figure
+  multiplied up — `10 x below-resolution` is not below resolution, which is
+  the same argument that batched the writes in the first place. The narrow
+  row's `k` is [[narrow-batch-k]] and takes `yield-cost!`'s `:batched`
+  window; the bulk row's `k` is 1 and takes the one-turn reading. A row
+  whose `k` has no measured aggregate is `:refused` as unevaluable rather
+  than corrected with the nearest available number.
+
+  The bound subtracted is the aggregate's MAX. The p50 would be the central
+  estimate of a correction; the max is the largest the correction can
+  honestly be, and a contract that decides whether a row may be published
+  has to be evaluated at the end that could change the answer."
+  [row adapter yc]
+  (let [k        (:writes-per-sample row)
+        arms     (:arms row)
+        shapes   (into {} (map (fn [id] [id (window-shape id adapter)])) arms)
+        bearers  (into #{} (keep (fn [[id s]] (when (= s :write-yield-drain) id))) shapes)
+        exempt   (into #{} (keep (fn [[id s]] (when (= s :write-then-drain) id))) shapes)
+        base     {:row (:witness row) :k k :windows shapes
+                  :bearers (vec bearers) :exempt (vec exempt)}
+        agg      (cond
+                   (= k narrow-batch-k) (let [b (:batched yc)]
+                                          (when b {:source :batched-aggregate
+                                                   :k      (:k b)
+                                                   :p50    (:window-p50 b)
+                                                   :max    (:window-max b)
+                                                   :n      (:n b)}))
+                   (= k 1)              {:source :one-turn
+                                         :k      1
+                                         :p50    (:p50 yc)
+                                         :max    (:max yc)
+                                         :n      (:n yc)}
+                   :else                nil)]
+    (cond
+      (or (empty? bearers) (empty? exempt))
+      (assoc base :verdict :not-owed
+                  :why (str "every arm in this row was measured through the same window shape ("
+                            (name (or (first (vals shapes)) :none))
+                            "), so the harness turns are in the numerator and the denominator "
+                            "alike and no arm is billed for a turn its rival escapes"))
+
+      (nil? agg)
+      (assoc base :verdict :refused
+                  :reason :unevaluable
+                  :why (str "this row batches " k " writes to a window and yield-cost! measured no "
+                            "aggregate for that k, so the asymmetry it owes cannot be priced. "
+                            "Measure " k " turns under one clock — never multiply the one-turn "
+                            "reading, which bounds one turn and not " k " of them"))
+
+      (not (and (number? (:max agg)) (>= (:max agg) 0)))
+      (assoc base :verdict :refused :reason :unevaluable :aggregate agg
+                  :why "the aggregate yield window is not a number")
+
+      (zero? (:max agg))
+      (assoc base :verdict :below-resolution :aggregate agg
+                  :why (str "the " (:k agg) "-turn aggregate read 0.0 ms in every one of its "
+                            (:n agg) " windows, so the asymmetry is below this instrument's "
+                            "own resolution (Chrome clamps performance.now() to 100 µs). "
+                            "Nothing to subtract; the row publishes unadjusted and the bound "
+                            "is on the record rather than assumed"))
+
+      :else
+      (let [bound     (:max agg)
+            corrected (mapv #(correct-round % bearers bound) (:per-round row))]
+        (if (some nil? corrected)
+          (assoc base :verdict :refused :reason :correction-exceeds-window :aggregate agg
+                      :why (str "subtracting the " (:k agg) "-turn aggregate bound of " bound
+                                " ms leaves a bearer arm at or below zero in at least one round: "
+                                "that window was measuring the harness's turns, not the arm"))
+          (let [summary'  (lane/across-rounds (mapv :ratio corrected))
+                h2h'      (head-to-head corrected)
+                flipped   (into []
+                                (keep (fn [[id v]]
+                                        (let [v' (get summary' id)]
+                                          (when (and v' (not (:unpublished v))
+                                                     (not= (boolean (:straddles-1? v))
+                                                           (boolean (:straddles-1? v'))))
+                                            {:figure id :was v :corrected v'}))))
+                                (:summary row))
+                flipped   (into flipped
+                                (keep (fn [[id v]]
+                                        (let [v' (get h2h' id)]
+                                          (when (and v' (not= (boolean (:straddles-1? v))
+                                                              (boolean (:straddles-1? v'))))
+                                            {:figure id :was v :corrected v'}))))
+                                (:head-to-head row))]
+            (if (seq flipped)
+              (assoc base :verdict :refused :reason :correction-changes-the-verdict
+                          :aggregate agg :bound bound :flipped flipped
+                          :why (str "subtracting the measured " (:k agg) "-turn asymmetry ("
+                                    bound " ms) moves " (count flipped) " published range(s) "
+                                    "across 1.0. What this row reports is the asymmetry and "
+                                    "not the arms; no figure in it may be published"))
+              (assoc base :verdict :corrected
+                          :aggregate agg :bound bound
+                          :summary-corrected summary'
+                          :head-to-head-corrected h2h'
+                          :why (str "the " (:k agg) "-turn aggregate read " bound
+                                    " ms at its worst window; it is subtracted from every "
+                                    "yield-bearing arm (" (str/join ", " (map name bearers))
+                                    ") and the ratios re-formed within each round. The "
+                                    "correction's direction is fixed — removing turns makes a "
+                                    "bearer smaller — so the published unadjusted figure and "
+                                    "the corrected one bracket the answer, and no range "
+                                    "crossed 1.0 between them")))))))))
 
 ;; ===========================================================================
 ;; The positive control — predicted against measured, every run

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
@@ -280,9 +280,18 @@ async function runOne(chromium, run) {
     // a corrected row that appears there looking uncorrected is the fault the
     // contract exists to prevent.
     const correction = await page.evaluate('window.HD8_CORRECTION || {}');
+    // The contract's own self-test result, on a JS-readable channel so the
+    // driver can FAIL on it rather than leaving it in an EDN blob nobody
+    // parses — which is the exact fault the contract itself was filed for.
+    const contractSelfTest = await page.evaluate(
+      'window.HD8_CORRECTION_SELFTEST === undefined ? null : window.HD8_CORRECTION_SELFTEST'
+    );
     const userAgent = await page.evaluate('navigator.userAgent');
     watch.dispose();
-    return { id: run.id, why: run.why, err, results, samples, summary, correction, userAgent, lines };
+    return {
+      id: run.id, why: run.why, err, results, samples, summary,
+      correction, contractSelfTest, userAgent, lines,
+    };
   } finally {
     await browser.close();
   }
@@ -448,6 +457,24 @@ function crossRun(runs) {
     server.close();
   }
 
+  // The correction contract's self-test, printed and ENFORCED. It runs in the
+  // bundle before any clock; a run that reached the far side without it is a
+  // run whose publication gate was never checked against its own fixtures.
+  let contractFailed = null;
+  for (const run of runs) {
+    const st = run.contractSelfTest;
+    console.log(`\n;; ==== HD8 YIELD-CORRECTION CONTRACT SELF-TEST — ${run.id} ====`);
+    if (!st) {
+      contractFailed = `${run.id}: the run recorded no contract self-test at all`;
+      console.log(';;   MISSING — the run recorded no result');
+      continue;
+    }
+    for (const c of st.checks) {
+      console.log(`;;   ${c.ok ? 'ok  ' : 'FAIL'}  ${c.name}${c.detail ? '  — ' + c.detail : ''}`);
+    }
+    if (!st.ok) contractFailed = `${run.id}: the yield-correction contract failed its own fixtures`;
+  }
+
   let refused = false;
   for (const run of runs) {
     console.log(`\n;; ==== HD8 RUN ${run.id} — ${run.why} ====`);
@@ -474,6 +501,13 @@ function crossRun(runs) {
 
   if (hardFail) {
     console.error(`[hd8] FAILED: ${hardFail}`);
+    process.exit(1);
+  }
+  if (contractFailed) {
+    console.error(
+      `[hd8] FAILED: ${contractFailed}. The gate that decides whether a write row may be ` +
+        'published does not agree with its recorded fixtures, so no figure above may be reported.'
+    );
     process.exit(1);
   }
   if (refused) {

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
@@ -329,13 +329,13 @@ function crossRun(runs) {
   if (PARTIAL) {
     out.push(';;');
     out.push(`;;   PARTIAL RUN — HD8_ONLY=${ONLY}. This is not the published shape.`);
-    out.push(
-      DECLARED_ROWS
-        ? `;;   Publishing: ${[...DECLARED_ROWS].join(', ')}. Every other row below is a` +
-          ';;   by-product of the adapter selection and is marked NON-PUBLISHING.'
-        : ';;   HD8_ROWS was not set, so NO row below publishes. Re-run with HD8_ROWS naming' +
-          ';;   the row this re-take is for.'
-    );
+    if (DECLARED_ROWS) {
+      out.push(`;;   Publishing: ${[...DECLARED_ROWS].join(', ')}. Every other row below is a`);
+      out.push(';;   by-product of the adapter selection and is marked NON-PUBLISHING.');
+    } else {
+      out.push(';;   HD8_ROWS was not set, so NO row below publishes. Re-run with HD8_ROWS');
+      out.push(';;   naming the row this re-take is for.');
+    }
   }
   for (const row of rows) {
     const pub = publishing(row);

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
@@ -98,6 +98,62 @@ if (RUNS.length === 0) {
   process.exit(1);
 }
 
+// ...AND `HD8_ONLY` ALONE DOES NOT DELIVER WHAT THE PARAGRAPH ABOVE PROMISES.
+//
+// It selects ADAPTERS. Every selected run still executes the bundle's whole
+// row set, so `HD8_ONLY=slim` emits `mount-M`, `mount-U`, `write-narrow` and
+// `write-bulk` — four rows, of which a re-take needed one or two. Nothing
+// mechanically stopped the other three being read as figures beside the rows
+// published from the full three-run sweep, which is exactly the competing set
+// the comment said it prevented (rf2-b69lw, from the PR #7269 audit).
+//
+// So the declaration is made EXPLICIT and the default is the safe one:
+//
+//   HD8_ONLY unset          the full three-run sweep — the published shape;
+//                           every row publishes.
+//   HD8_ONLY set, no ROWS   a PARTIAL run. The driver cannot know which
+//                           re-take was intended, so NO row publishes and
+//                           every one is stamped NON-PUBLISHING.
+//   HD8_ONLY + HD8_ROWS     the named rows publish; every other row the run
+//                           emits is stamped NON-PUBLISHING.
+//
+// Marked rather than suppressed: the gates that qualify a row (parity, the
+// positive control, the lowering check, the read-back, the arm-order guard)
+// run over the whole set either way, and a row withheld from the log is a row
+// nobody can diagnose. What a partial run must never do is emit a figure that
+// LOOKS like the published one.
+const KNOWN_ROWS = ['mount-M', 'mount-U', 'write-narrow', 'write-bulk'];
+const ROWS = (process.env.HD8_ROWS || '').trim();
+const DECLARED_ROWS = ROWS
+  ? new Set(
+      ROWS.split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    )
+  : null;
+if (DECLARED_ROWS) {
+  const unknown = [...DECLARED_ROWS].filter((r) => !KNOWN_ROWS.includes(r));
+  if (unknown.length) {
+    console.error(
+      `[hd8] HD8_ROWS names ${unknown.join(', ')}, which this instrument does not emit; ` +
+        `known rows: ${KNOWN_ROWS.join(', ')}. A typo here would silently mark every row ` +
+        `non-publishing, so it is an error instead.`
+    );
+    process.exit(1);
+  }
+  if (!ONLY) {
+    console.error(
+      '[hd8] HD8_ROWS is set without HD8_ONLY. A full sweep IS the published shape and ' +
+        'publishes every row; narrowing what publishes without narrowing what ran would ' +
+        'describe a run that did not happen.'
+    );
+    process.exit(1);
+  }
+}
+const PARTIAL = Boolean(ONLY);
+// A row publishes only from the full sweep, or when a partial run NAMED it.
+const publishing = (row) => (!PARTIAL ? true : DECLARED_ROWS ? DECLARED_ROWS.has(row) : false);
+
 // The guard's tolerance. `order_guard.cjs` defends the choice: 0.10 sits far
 // below the 2.01x the recorded fault produced and far above the 0.4% the same
 // study's uncontaminated arms reproduced to. A browser mount clock is noisier
@@ -218,9 +274,15 @@ async function runOne(chromium, run) {
     const results = await page.evaluate('window.HD8_RESULTS || {}');
     const samples = await page.evaluate('window.HD8_SAMPLES || []');
     const summary = await page.evaluate('window.HD8_SUMMARY || {}');
+    // The harness-microtask correction's VERDICT per write row (rf2-b69lw).
+    // On a JS-readable channel rather than only inside the EDN record,
+    // because the cross-run table is what a reader copies a figure out of and
+    // a corrected row that appears there looking uncorrected is the fault the
+    // contract exists to prevent.
+    const correction = await page.evaluate('window.HD8_CORRECTION || {}');
     const userAgent = await page.evaluate('navigator.userAgent');
     watch.dispose();
-    return { id: run.id, why: run.why, err, results, samples, summary, userAgent, lines };
+    return { id: run.id, why: run.why, err, results, samples, summary, correction, userAgent, lines };
   } finally {
     await browser.close();
   }
@@ -264,18 +326,44 @@ function crossRun(runs) {
   out.push(';; ==== HD8 CROSS-RUN TABLE — every figure a RANGE over 6 rounds, ratio to the ====');
   out.push(';; ==== floor measured in the SAME round. The floor is identical code in an   ====');
   out.push(';; ==== identical bundle; only the installed adapter differs between runs.    ====');
+  if (PARTIAL) {
+    out.push(';;');
+    out.push(`;;   PARTIAL RUN — HD8_ONLY=${ONLY}. This is not the published shape.`);
+    out.push(
+      DECLARED_ROWS
+        ? `;;   Publishing: ${[...DECLARED_ROWS].join(', ')}. Every other row below is a` +
+          ';;   by-product of the adapter selection and is marked NON-PUBLISHING.'
+        : ';;   HD8_ROWS was not set, so NO row below publishes. Re-run with HD8_ROWS naming' +
+          ';;   the row this re-take is for.'
+    );
+  }
   for (const row of rows) {
+    const pub = publishing(row);
     out.push(`;;`);
-    out.push(`;;   ${row}`);
+    // The stamp goes on the row HEADING, so a reader who copies a figure out of
+    // the table cannot get it without the label that says it may not be quoted.
+    out.push(`;;   ${row}${pub ? '' : '   *** NON-PUBLISHING — a partial run\'s by-product ***'}`);
     for (const run of runs) {
       const s = run.summary[row];
       if (!s) continue;
+      const mark = pub ? '' : ' [NON-PUBLISHING]';
+      // The harness-microtask correction, stamped on the figures it governs.
+      // `:not-owed` is the common case and says nothing; the other three all
+      // change what a reader may do with the numbers on the line below.
+      const c = (run.correction || {})[row];
+      if (c && c.verdict !== 'not-owed') {
+        out.push(
+          `;;     [${run.id.padEnd(7)}] YIELD CORRECTION: ${c.verdict.toUpperCase()}` +
+            `${c.reason ? ` (${c.reason})` : ''}${c.bound != null ? ` — bound ${c.bound} ms` : ''}`
+        );
+        out.push(`;;                 ${c.why}`);
+      }
       for (const [arm, v] of Object.entries(s.vsFloor)) {
         if (arm === 'floor') continue;
-        out.push(`;;     [${run.id.padEnd(7)}] ${arm.padEnd(14)} vs floor   ${band(v)}`);
+        out.push(`;;     [${run.id.padEnd(7)}] ${arm.padEnd(14)} vs floor   ${band(v)}${mark}`);
       }
       for (const [pair, v] of Object.entries(s.headToHead)) {
-        out.push(`;;     [${run.id.padEnd(7)}] ${pair.padEnd(26)}  ${band(v)}`);
+        out.push(`;;     [${run.id.padEnd(7)}] ${pair.padEnd(26)}  ${band(v)}${mark}`);
       }
     }
   }
@@ -308,11 +396,22 @@ function crossRun(runs) {
   // bare command: a published figure whose repro command does not reproduce it
   // is a figure nobody can check.
   console.log(
-    `;;   reproduce   ${ONLY ? `HD8_ONLY=${ONLY} ` : ''}node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs`
+    `;;   reproduce   ${ONLY ? `HD8_ONLY=${ONLY} ` : ''}${ROWS ? `HD8_ROWS=${ROWS} ` : ''}node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs`
   );
   console.log(`;;   build       shadow-cljs release ${BUILD_ID} (:advanced, goog.DEBUG false)`);
   console.log(`;;   node        ${process.version}`);
   console.log(`;;   runs        ${RUNS.map((r) => r.id).join(', ')}${ONLY ? `  (HD8_ONLY=${ONLY})` : ''}`);
+  // WHICH ROWS THIS RUN MAY PUBLISH, printed with the provenance and not left
+  // to be inferred from the absence of a warning (rf2-b69lw).
+  console.log(
+    `;;   publishes   ${
+      !PARTIAL
+        ? 'every row — this is the full three-run sweep, the published shape'
+        : DECLARED_ROWS
+          ? `${[...DECLARED_ROWS].join(', ')} only (HD8_ROWS); every other row emitted is marked NON-PUBLISHING`
+          : 'NOTHING — a partial run with no HD8_ROWS declaration; every row emitted is marked NON-PUBLISHING'
+    }`
+  );
   // THE EFFECTIVE TOLERANCE, on the record beside the figures it adjudicated.
   // It was not printed, and it does not equal `order_guard`'s own default:
   // the guard defaults to 0.10 and this driver passes 0.35, for the reason

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_witnesses.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_witnesses.cljs
@@ -33,25 +33,40 @@
 
   ## The hook ladder, and why it is the readable variable
 
-  Every arm below resolves its dispatch fn the SAME way — one map lookup
-  keyed by frame, from [[frame-dispatch]], primed once outside render.
-  That is deliberate levelling: an arm that minted a fresh ops map per
-  render would be carrying an allocation none of its rivals pay, and the
-  frontier comparator in particular must never be strawmanned. What is
-  left varying is the thing under test:
+  THREE dispatch mechanisms live here, not one, and this docstring used to
+  claim otherwise — *\"every arm below resolves its dispatch fn the SAME way
+  — one map lookup keyed by frame\"*. What the source does:
 
-      arm            hooks  markup                     handler
-      :floor           0    hand createElement         inert
-      :reagent         0    Reagent hiccup (reg-view)  author closure
-      :reagent-slim    0    slim hiccup (reg-view)     author closure
-      :uix             2    `$` macro (compile-time)   author closure
-      :donor-r1        1    slim hiccup + `:f>`        author closure
-      :donor-r2        2    slim hiccup + `:f>`        CODEC-LOWERED
+      arm            hooks  markup                     handler        dispatch
+      :floor           0    hand createElement         inert          none — one hoisted no-op, shared
+      :reagent         0    Reagent hiccup (reg-view)  author closure LEXICAL, injected by reg-view
+      :reagent-slim    0    slim hiccup (reg-view)     author closure LEXICAL, injected by reg-view
+      :uix             2    `$` macro (compile-time)   author closure [[dispatch-for]] — deref + get, IN RENDER
+      :donor-r1        1    slim hiccup + `:f>`        author closure [[dispatch-for]]
+      :donor-r2        2    slim hiccup + `:f>`        CODEC-LOWERED  [[dispatch-for]], then [[lower-events]]
 
-  So `donor-r2 / donor-r1` is the product shell's price and nothing
-  else's; `donor-r2 / uix` holds the hooks and the dispatch mechanism
-  fixed and varies the CODEC; `donor-r* / reagent*` is HD-008's ship
-  comparison.
+  [[prime-frame!]] does run outside every measured window, so no arm pays
+  to CONSTRUCT a dispatch fn during a render — that part of the old claim
+  holds and is the point of the levelling. But only the three React-spine
+  arms read [[frame-dispatch]], and they read it INSIDE each boundary's
+  render, 300 times a mount; the two Reagent paths never touch it, because
+  `reg-view` hands them a `dispatch` already bound to the frame from
+  context, which is what a Reagent application contains; and the floor
+  resolves nothing at all.
+
+  What the old sentence was defending is still true and still matters: no
+  arm mints a fresh OPS MAP per render, every mechanism above is one
+  indirection or fewer, and the frontier comparator is never strawmanned.
+  And the residual runs in the safe direction — the deref-plus-`get` is
+  paid by `:uix` and both donor rungs and NOT by the Reagent paths, so it
+  cannot have flattered the arms HD-008 is arguing for.
+
+  What is left varying is the thing under test. `donor-r2 / donor-r1` is
+  the product shell's price and nothing else's; `donor-r2 / uix` holds the
+  hooks and the dispatch mechanism fixed — both go through
+  [[dispatch-for]] — and varies the CODEC; `donor-r* / reagent*` is
+  HD-008's ship comparison, and is the one pair the mechanisms differ
+  across.
 
   ## Why every arm is written out longhand
 
@@ -134,13 +149,20 @@
 (defn u-elements [n] (+ 1 n))
 
 ;; ===========================================================================
-;; The levelled dispatch lookup
+;; The dispatch lookup the React-spine arms share
 ;; ===========================================================================
 
 (defonce ^:private frame-dispatch
   ;; frame keyword -> the frame-locked `dispatch` fn. Primed by
   ;; [[prime-frame!]] at arm construction, outside every measured window,
-  ;; so no arm pays for capturing it and every arm pays the same lookup.
+  ;; so no arm pays to CONSTRUCT a dispatch fn during a render.
+  ;;
+  ;; It does NOT make every arm pay the same lookup, and the comment here
+  ;; used to say it did. Its readers are `:uix`, `:donor-r1` and
+  ;; `:donor-r2`, which call [[dispatch-for]] inside each boundary's
+  ;; render; the two Reagent arms take `reg-view`'s lexical `dispatch` and
+  ;; never come here, and the floor's handler is [[inert]]. See the ns
+  ;; docstring for the three mechanisms and which way the residual runs.
   (atom {}))
 
 (defn prime-frame! [frame-kw]


### PR DESCRIPTION
Four beads, all of them a published measurement page saying something the code no longer does. **No published measurement moves in this PR.** Every change either corrects a claim to match the source, or makes an already-stated contract mechanical.

## The false claims, and what they now say

**`rf2-2rtt6.7` — "every arm resolves its dispatch fn the same way (one map lookup, primed outside render)".** Three mechanisms are in the instrument, not one:

| arm | how it resolves `dispatch` |
|---|---|
| `floor` | nothing — one hoisted `inert` no-op shared by all 300 elements |
| `reagent`, `reagent-slim` | `reg-view`'s **lexical** `dispatch`, bound to the frame from context; they never touch `frame-dispatch` |
| `uix`, `donor-r1`, `donor-r2` | `dispatch-for` — a deref of the shared `frame-dispatch` atom plus a `get`, **inside** each boundary's render, 300 times a mount |

`prime-frame!` does run outside every window, so no arm pays to *construct* a dispatch fn during a render — that much held, and it is what "primed outside render" described. It described the value, not the read. What the sentence was defending is kept because it is still true (no arm mints a fresh ops map per render; every mechanism is one indirection or fewer; the frontier comparator is not strawmanned), and the direction of the residual is now stated: the deref-plus-`get` is paid by `uix` and **both donor rungs** and not by the Reagent paths, so it runs *against* the arms HD-008 argues for. The arms were not levelled and retaken, for that reason. The same claim lived in `hd8_witnesses.cljs`'s ns docstring and in `frame-dispatch`'s own comment; both corrected, no behaviour changed.

**`rf2-2rtt6.7` — the provenance cited SHAs a reader cannot check out.** Line 35 named `d3f1c2fff6` on `worker/lane-control-cluster`; that branch is gone, and `d46ede4f` and `b943c7ed` are on no branch either (verified with `git branch --contains`: empty for all three). All three rows now lead with the **landed** commit — `172244521e`, `c7e4c70ac0`, `0cba8181a7` — with the authored SHA beside it as a verifiable mapping rather than a deletion, and `5cd819c5bf` recorded as where the final `rf2-b69lw` record landed. Each row also carries **the instrument at its own landed commit**: one "Producing instrument" line served three producing commits while describing only the narrow re-take's.

The page's claim that blob hashes identify the instrument *"regardless of how the commit carrying it is rebased"* is corrected — they pin the files they name and nothing else, and the sibling P0 page has a witness where the same three pinned blobs sit over a changed imported `lane.cljs`. Commit and blob now sit side by side with what each is good for: the commit says which tree, the blob says which instrument.

**`rf2-b69lw` — "had it read anything else, this page would owe the reader a subtraction"** was a promise nothing kept. `yield-cost!` was recorded and read by nobody; the #7269 audit ran the exact landed source, measured `{:p50 0 :min 0 :max 0.1 :n 10}` on the slim run, and the driver exited 0 with unadjusted ratios.

**`rf2-b69lw` — "HD8_ONLY exists so that a future re-take of one run cannot mint a competing set of figures".** It selects **adapters**; every selected run still emitted the whole row set.

**`rf2-zb3qg` — "the figures below are that run's".** The narrow re-take ran `HICASSO_ONLY=narrow`, one row of four. M1 mount, M2 mount and bulk broad come off the **earlier** instrument (blob `9b5c0d63db`, at `4c3f7189c4`); only the narrow row came off `f4b09dc207`. Now a partition table, with the "second independent run" scoped to the only row that has one.

**`rf2-zb3qg` — "Eight controls, eight passes, and seven of the eight sit below".** Right when the table held M1, M2, broad and the *unbatched* narrow row — four entries across two segments, of which exactly one (narrow Reagent, `2.013x`) sat above prediction. The batched re-take struck that row and added two runs, so the live table is **five entries across two segments = ten, ten passes, all ten below**, verified entry by entry. The `rf2-rjfz1` sweep's own "eight, eight passes" is correct for *that* sweep and is left at eight, scoped explicitly rather than renumbered.

## How the correction contract is enforced rather than stated

`hd8-rows/yield-correction` adjudicates both write rows of every run; `hd8-app` fails the run on a refusal — the same fail-closed path the positive control takes.

| verdict | when |
|---|---|
| `:not-owed` | every arm shares one window shape (the `reagent` and `uix` runs) |
| `:below-resolution` | mixed shapes, aggregate max `0.0` — nothing to subtract, bound recorded rather than assumed |
| `:corrected` | mixed shapes, aggregate nonzero — subtraction **applied**, corrected band published beside the unadjusted one |
| `:refused` | undischargeable — nothing in the row publishes, run exits non-zero |

**Refusal has no tolerance of its own.** A row is refused when subtracting the bound moves a published range across `1.0` — the instrument's **own** house rule, `:straddles-1?` — or when a bearer has **less left than was removed**, or when the row's `k` has no measured aggregate (unevaluable rather than corrected with the nearest number to hand). The bound is the aggregate's **max**, because a gate is evaluated at the end that could change the answer. The direction is fixed — removing turns makes a bearer smaller — so on the slim run the unadjusted figure is a **lower bound**, and both ends publish.

**The gate caught itself publishing a precise wrong number, which is worth the whole exercise.** The survival test began as `pos?`. On a slim run where the one-turn aggregate resolved at `0.0999999 ms`, the **bulk** row's floor — p50 about one 100us clock quantum — survived the subtraction at `~1e-8 ms`, still positive, and the row published a corrected `reagent-slim / floor` of **`15,518,934x`**. A denominator that survives by a rounding error is not a denominator. The rule is now a comparison between two measured quantities with no constant between them.

**A gate nobody has watched refuse is not a gate, and this one refuses rarely.** The asymmetry reads `0.0` on most runs of this host and resolves only intermittently, so a live run cannot be relied on to exercise the branch that stops a figure being published. The contract therefore carries a **self-test** — six fixtures replayed through the live rule, one per verdict and one per refusal reason, run in the bundle **before any clock**, throwing in `hd8-app` and exiting `1` in `hd8_run.cjs`. `order_guard.cjs`'s technique and `parity-can-fail?`'s argument, applied to the newest gate. **Fixture 4 is the `15,518,934x` row**, so the repair cannot silently come undone.

```
;; ==== HD8 YIELD-CORRECTION CONTRACT SELF-TEST — uix ====
;;   ok    one window shape in the row is NOT-OWED  — not-owed
;;   ok    mixed shapes with a 0.0 aggregate is BELOW-RESOLUTION  — below-resolution
;;   ok    a resolving aggregate is CORRECTED, and the corrected ratio is larger  — corrected 5 -> 5.4545
;;   ok    a bearer with less left than was removed is REFUSED (the 15,518,934x row)  — refused/correction-exceeds-window
;;   ok    a correction that moves a range across 1.0 is REFUSED  — refused/correction-changes-the-verdict
;;   ok    no aggregate measured for this row's k is REFUSED as unevaluable  — refused/unevaluable
```

**Observed live.** The full three-run sweep returns `:not-owed` on every `uix` and `reagent` write row and `:below-resolution` on both `slim` rows (aggregate `0.0` in all ten windows, at `k = 10` and `k = 1`), so no published figure moves. A `slim`-only run on the same host drew the nonzero reading and came back `:corrected`, larger, discharged — the exact case the old driver exited `0` through. Its figures are not quoted: that run was `HD8_ONLY` without `HD8_ROWS`, so by this branch's own rule every row it produced is non-publishing.

## How HD8_ONLY marks non-publishing rows

`HD8_ROWS` names what a partial run publishes:

| invocation | publishes |
|---|---|
| `HD8_ONLY` unset | every row — the full three-run sweep, the published shape |
| `HD8_ONLY=slim` | **nothing** — the driver cannot know which re-take was intended |
| `HD8_ONLY=slim HD8_ROWS=write-narrow,write-bulk` | those two; the mount rows are marked |

Non-publishing rows are stamped on the row heading **and on every figure beneath it** in the cross-run table (which is what a reader copies from), and the provenance block prints what the run may publish. An `HD8_ROWS` naming a row the instrument does not emit is exit `1`, because a typo would otherwise silently mark everything. Marked rather than suppressed: every gate still runs over the whole set, and a row withheld from the log is a row nobody can diagnose. All three invocations verified live.

## The sixth driver on the shared build id (`rf2-2rtt6.22`)

`hicasso_narrow_run.cjs` now clears `.shadow-cljs/builds/hicasso-bench` before it builds. It could no longer poison the five fixed drivers, but nothing cleared the entry on **its** behalf. `lane_cache.cjs` is reached by path across the test trees, exactly as `navigate.cjs` already is in that file — one helper for the repository, never a second copy per lane — with **no fallback**, because a fallback would silently re-arm the trap. Hoisting the helper beside `navigate.cjs` (the bead's recommendation) touches five drivers outside this branch's fence; it is recorded in the new comment and left to their owner.

## What was marked rather than edited

`p0_converge_app.cljs`'s row table still calls `bulk-narrow` *"one commit exactly ONE boundary reads"* while the entry's own `:doc` roughly 730 lines below says `narrow-batch-k` commits share one window. **A sibling worker holds 362 uncommitted lines in that file** (earliest hunk at line 229), so the one-line docstring fix is recorded under the converged page's Open items rather than landed into a live working surface.

Also newly recorded, under the HD-008 page's Known limitations: the **bulk row's floor sits on the clock clamp** at about one quantum. The published row was taken on a run whose aggregate read `0.0`, so nothing was owed and the figure stands — but on a run where it resolves, the correction is the whole of the bulk floor and the row refuses. Lifting it needs the batched window the narrow row got, which changes a measured window and obliges a re-take. Not made here.

`rf2-2rtt6.1` could not accept an append (`rf2-0znkn`), so these records are on the studio pages, which is what that bead's instruction says to do.

## Quality gates

| gate | exit |
|---|---|
| `node .../hicasso/hd8_run.cjs` — full three-run sweep, to completion | ``0`` |
| `node .../bench/hicasso_narrow_run.cjs` | `0` |
| `HD8_ONLY=slim node .../hd8_run.cjs` — undeclared partial, everything marked | `0` |
| `HD8_ONLY=slim HD8_ROWS=write-narrow,write-bulk node .../hd8_run.cjs` | `0` |
| `HD8_ROWS=bogus node .../hd8_run.cjs` — rejects an unknown row name | `1` (expected) |
| yield-correction contract self-test — 6 fixtures, all ok, in-bundle | `0` |
| `order_guard.cjs` self-test — 12 checks, all ok | `0` |
| `npm run test:script-policy` | `0` |
| `npm run test:browser` | `0` |
| `python -m mkdocs build --strict` — no warning on either changed page | `0` |
| `shadow-cljs release hicasso-bench` — `:advanced`, 169 files, 0 warnings | `0` |
