### PR TITLE
bench(hicasso): verify the doubled control, fail cleanup loudly, warrant the order threshold (rf2-2rtt6.2, rf2-a4x1o)

### DIFF
--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -235,11 +235,19 @@ rather than as a winner.
 
 | witness | **threshold (mean)** | range | per round | verdict |
 |---|---|---|---|---|
-| **M1 mount** — 901 el, 300 boundaries | **1.2301×** | 1.1099 – 1.3538 | 1.3065 · 1.1417 · 1.2388 · 1.1099 · 1.3538 | **UIx slower**, disjoint from 1.0 |
+| **M1 mount** — 901 el, 300 boundaries | ~~**1.2301×**~~ **MAGNITUDE WITHDRAWN** — direction only, ≈1.11 – 1.35 | 1.1099 – 1.3538 | 1.3065 · 1.1417 · 1.2388 · 1.1099 · 1.3538 | **UIx slower** here and in 2 of the 3 other runs; **see [the segment-order warrant](#the-segment-order-warrant--and-why-12301-does-not-have-one)** |
 | **M2 mount** — 51 el, 12 fields · *diagnostic* | 1.0539× | 0.8572 – 1.4286 | 1.4286 · 0.8572 · 0.8572 · 1.0550 · 1.0714 | **straddles 1.0 — indistinguishable** |
 | **bulk broad** — one commit all 300 read | **0.6239×** | 0.4701 – 0.7857 | 0.7172 · 0.6046 · 0.5417 · 0.7857 · 0.4701 | **UIx faster**, disjoint from 1.0 |
-| **bulk narrow** — 10 commits, each read by exactly one boundary, one window | **1.1540×** | 1.0570 – 1.2053 | 1.2053 · 1.1515 · 1.1860 · 1.0570 · 1.1700 | **UIx slower**, disjoint from 1.0 — *re-taken on a batched window, see below* |
+| **bulk narrow** — 10 commits, each read by exactly one boundary, one window | ~~**1.1540×**~~ **MAGNITUDE WITHDRAWN** — direction only; balanced 1.1457 | 1.0570 – 1.2053 | 1.2053 · 1.1515 · 1.1860 · 1.0570 · 1.1700 | **UIx slower**, disjoint from 1.0 in every run — *but its order strata are disjoint too; see [the segment-order warrant](#the-segment-order-warrant--and-why-12301-does-not-have-one)* |
 | ~~bulk narrow, **unbatched window** (superseded)~~ | ~~1.1556×~~ | ~~1.0417 – 1.2500~~ | ~~1.1111 · 1.2500 · 1.2500 · 1.0417 · 1.1250~~ | ~~UIx slower, but did not stably resolve across runs~~ |
+
+> **Two magnitudes are withdrawn and no number is deleted.** Every figure above
+> is exactly as measured; what changed is what may be **quoted** from it, and it
+> is now the instrument that decides ([the segment-order
+> warrant](#the-segment-order-warrant--and-why-12301-does-not-have-one)).
+> The two rows whose order strata OVERLAP keep their magnitudes, with the
+> order-balanced value beside the raw one: **M2 1.0539 → 1.0376** (diagnostic
+> either way), **bulk broad 0.6239 → 0.6357**.
 
 Both arms against the floor, for context:
 
@@ -554,13 +562,217 @@ first cut produced looked entirely plausible.
 - **Ranges, never a mean alone.** Overlapping ranges mean indistinguishable and
   the page says so.
 - **Every measured mount and every measured write is read back out of the DOM
-  inside its own window**, and the count is published as `N unverified of M`.
-  Mounts are checked against a *written* element count (901, 51) as well as
-  their content, so the gate can answer false for an arm that rendered nothing.
+  inside its own window**, and the count is published as `N unverified of M` —
+  and **`unverified > 0` fails the run**, which it did not until rf2-a4x1o.
+  Mounts are checked against a *written* element count at **the arm's own
+  scale** (901/51 for the measured arms, **1,801/99 for the control**, probed at
+  **its own** far end), so the gate answers false both for an arm that rendered
+  nothing and for a 2× control that rendered only its base prefix.
 - **A positive control with predicted vs measured, every run, per segment.**
+- **A segment-order verdict on every cross-segment figure.** The red-zone's
+  rounds are partitioned by which segment ran first; opposite directions refuse
+  the row, and a magnitude may be published only when the two strata overlap.
 - **Canonical-DOM parity before any clock**, inside each segment and across the
   seam — the two substrate arms are compared with each other directly, not
   merely each with its own floor.
+
+## The segment-order warrant — and why `1.2301` does not have one
+
+Bead **rf2-a4x1o**, reopened by the PR #7268 audit: *"the operative 1.2301
+threshold magnitude does not yet have its stated fail-closed warrant."*
+`lane/guard!` adjudicates arms **inside** a segment; the red-zone is a ratio
+**across the seam**, and `:segment-seam-control` above only *records* the floor's
+drift. Nothing asked whether the threshold itself moved with which segment ran
+first — even though `segment-order` alternates, so every round is already
+labelled with the answer.
+
+It now does. `segment-order-verdict` partitions every cross-segment figure by
+segment order and adjudicates two claims separately, because they fail
+separately:
+
+| claim | rule | consequence |
+|---|---|---|
+| **direction** — *UIx slower / faster / indistinguishable* | **FAIL-CLOSED.** Two strata pointing opposite ways across 1.0 sets `HICASSO_ORDER_REFUSED`; `p0_converge_run.cjs` exits **1** | the row has no direction to publish, and the figure is a measurement of the schedule |
+| **magnitude** — the single number a candidate is judged against | reportable **only** when the two strata **overlap**. `:magnitude-resolved?` starts false and the overlap has to earn it | a disjoint split publishes `:claim :direction-only`; silence is not a pass |
+
+### The partition, confirmed
+
+The audit's M1 reading reproduces **exactly** from the published per-round
+vector. Rounds 0, 2, 4 are Reagent-first; rounds 1, 3 are UIx-first.
+
+| row | Reagent-first (3 rounds) | UIx-first (2 rounds) | strata | raw mean | **order-balanced** |
+|---|---|---|---|---|---|
+| **M1 mount** | **1.2997** [1.2388 – 1.3538] | **1.1258** [1.1099 – 1.1417] | **DISJOINT** | 1.2301 | **1.2128** |
+| M2 mount | 1.1191 [0.8572 – 1.4286] | 0.9561 [0.8572 – 1.0550] | overlap | 1.0539 | 1.0376 |
+| bulk broad | 0.5763 [0.4701 – 0.7172] | 0.6951 [0.6046 – 0.7857] | overlap | 0.6239 | 0.6357 |
+| **bulk narrow** *(batched — the published row)* | **1.1871** [1.1700 – 1.2053] | **1.1042** [1.0570 – 1.1515] | **DISJOINT** | 1.1540 | 1.1457 |
+| ~~bulk narrow *(unbatched, superseded)*~~ | ~~1.1620 [1.1111 – 1.2500]~~ | ~~1.1459 [1.0417 – 1.2500]~~ | ~~overlap~~ | ~~1.1556~~ | ~~1.1539~~ |
+
+**One correction to the audit's reading, stated because it changes a row's
+status.** The audit reported M2, broad *and* narrow as overlapping. Two of the
+three reproduce; **the current batched narrow row's strata are disjoint too**
+([1.1700 – 1.2053] against [1.0570 – 1.1515]). Only the **superseded unbatched**
+narrow row overlaps. So the exposure was never bounded to M1: `1.1540` is in the
+same position as `1.2301`. This partition is pinned in
+`p0_converge_order_cljs_test.cljs`, which replays these exact vectors.
+
+### Disjointness is not the evidence — the SIGN is
+
+**A disjoint 3:2 split is weak evidence on its own.** Under the null — no order
+effect, the five rounds exchangeable — the 2-round stratum is one of
+`C(5,2) = 10` equally likely subsets and exactly two of them separate the
+strata. **A disjoint partition therefore arises 20% of the time per row with no
+order effect at all**, and *which* row splits is not stable: M1 and narrow split
+in the published run, **broad** splits in the rf2-rjfz1 sweep, and **no row
+splits in both**. Three disjoint rows out of eight row-runs is what chance looks
+like.
+
+**The sign is a different matter, and it is decisive.** Across **three
+independent five-round runs** — the published run, the rf2-rjfz1 reproduction
+sweep, and the corrected-instrument run below — the cross-segment figure reads
+**higher when the Reagent segment ran first in 11 of 12 row-runs**. One-sided
+binomial, **p = 0.0032**.
+
+| run | M1 | M2 | broad | narrow |
+|---|---|---|---|---|
+| published | R 1.2997 > U 1.1258 | R 1.1191 > U 0.9561 | R 0.5763 **<** U 0.6951 | R 1.1871 > U 1.1042 |
+| rf2-rjfz1 sweep | R 1.3253 > U 1.2338 | R 1.0909 > U 0.9455 | R 0.6426 > U 0.5410 | R 1.1790 > U 1.1549 |
+| corrected instrument | R 1.2183 > U 1.0217 | R 0.9345 > U 0.9025 | R 0.6139 > U 0.5466 | R 1.2236 > U 1.1692 |
+
+**There is a systematic segment-order effect.** It is small — one to nineteen
+percent between strata — and it is real. The per-row disjointness test could not
+see it because it has no power at 3:2; the sign test across rows and runs can.
+
+**Two consequences, and the first is arithmetic.** Five rounds cannot balance
+two orders: the split is 3:2, so the raw mean **over-weights whichever order got
+the extra round**, and with a real effect present that bias has a sign. Every
+published threshold on this page is a 3:2 **Reagent-first-heavy** mean of a
+quantity that reads high Reagent-first, so **every one of them is biased upward
+by roughly one to two percent.** The design-unbiased estimator under an
+alternating schedule is the mean of the two stratum means, and it is now
+published on every row as `:order-balanced-mean`. An **even** round count would
+make the two coincide by construction; it is named as the arm-level repair
+rather than taken here, because it would move four published rows without
+deciding the question.
+
+### The verdict on `1.2301` — the hold stands
+
+**rf2-2rtt6.1's hold — *do not use 1.2301 as a precise red-zone threshold* — is
+NOT lifted.** Three measured reasons, in order of weight:
+
+1. **It is biased by a design the effect exploits.** 3:2 Reagent-first on a
+   quantity that reads high Reagent-first. The order-balanced estimate on the
+   published rounds is **1.2128**, not 1.2301.
+2. **Its two strata do not meet.** [1.2388 – 1.3538] against [1.1099 – 1.1417].
+   A mean over a split whose halves are disjoint is not a threshold, and
+   `:magnitude-resolved?` is false for that row.
+3. **Four independent estimates do not agree to better than ±6%, and the newest
+   does not resolve at all:** 1.2301, 1.2103 (same-instrument stability run),
+   1.2887 (rf2-rjfz1 sweep), and **1.1397 [0.9130 – 1.3201] — straddling 1.0 —**
+   on the corrected instrument below. A figure quoted to four decimal places on
+   that spread was never a threshold.
+
+**What IS warranted, and it is not nothing.** UIx-on-subs is slower than
+Reagent-on-subs on the M1 mount witness in **three of four runs**, and every
+Reagent-first stratum of every run is disjoint above 1.0. The defensible
+statement is a **direction with a range — *UIx slower on M1 mount, roughly
+1.11× to 1.35× across the runs that resolve, with one run of four
+indistinguishable*** — not a point. **A candidate row is red on M1 if it is
+worse than that range; inside it, the answer is `not resolved` and not a pass.**
+
+**`0.6239×` broad is in better shape, and its magnitude carries the same 1–2%
+caveat.** Its **direction survives everywhere**: all six order strata across the
+three runs sit wholly below 1.0, and all four run means (0.6239 / 0.5682 /
+0.6020 / 0.5870) are disjoint from 1.0. Its strata overlap in the published run
+and in the corrected run, and are disjoint in the sweep — so it passes the test
+that broke M1's magnitude twice out of three, and its order-balanced published
+value is **0.6357**. The narrow row is the same shape as M1: direction resolved
+in every run, magnitude disjoint on the published rounds, balanced value
+**1.1457**.
+
+### The corrected instrument's own run
+
+Four rows, five rounds, both segments, at this branch's instrument.
+`node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` —
+**exit 0**.
+
+| row | published | corrected instrument | overlap | verdict |
+|---|---|---|---|---|
+| **M1 mount** | 1.2301 [1.1099 – 1.3538] disjoint | **1.1397 [0.9130 – 1.3201] — straddles 1.0** | 1.1099 – 1.3201 | **does NOT reproduce as resolved** — see above |
+| M2 mount *(diagnostic)* | 1.0539 [0.8572 – 1.4286] straddles | 0.9217 [0.8572 – 1.0000] straddles | 0.8572 – 1.0000 | **reproduces**, indistinguishable both |
+| **bulk broad** | 0.6239 [0.4701 – 0.7857] disjoint | 0.5870 [0.4762 – 0.8372] disjoint | wholly overlapping | **reproduces**, UIx faster both |
+| **bulk narrow** | 1.1540 [1.0570 – 1.2053] disjoint | 1.2018 [1.1344 – 1.3395] disjoint | 1.1344 – 1.2053 | **reproduces**, UIx slower both |
+
+**The M1 non-reproduction is reported, not explained away, and the comparison is
+reflected.** This run's instrument differs from the published one in one way
+that touches the measured page: the `:ctl-2x` control's element count is now
+checked on **every** mount, which is a `querySelectorAll` over an 1,801-element
+container between samples. It is **outside every timed window**, it falls on the
+control arm in **both** segments identically, and the red-zone divides
+`uix-subs` by `reagent-subs` — neither of which is the control — so it cannot
+bias the ratio directionally. The arm-order guard agrees: `refuse? false`,
+`contaminated? false`, `unchecked? false` on all four rows, with no arm reading
+differently for its position. The reading that fits is the one the four
+estimates already showed: **M1's red-zone is a noisy quantity that was published
+as a precise one.**
+
+**No published figure on this page is deleted or rewritten.** The rows above
+stand as measured; what changes is what may be **quoted** from them, and that is
+now decided by the instrument (`:claim :magnitude` vs `:claim :direction-only`)
+rather than by whoever writes the page.
+
+### The corrected run's provenance
+
+| | |
+|---|---|
+| **Branch** | `worker/control-verify` (rf2-2rtt6.2 / rf2-a4x1o) — the landed SHA follows the merge |
+| **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` — **exit 0** |
+| **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium via Playwright), Windows 11 x64, 24 logical CPUs |
+| **Arm-order guard** | **no refusal on any of the four rows** — `refuse? false`, `contaminated? false`, `unchecked? false`, tolerance 0.10 |
+| **Canonical-DOM parity** | clean in both segments and across the seam, every row — `{:problems [] :ok? true}` |
+| **Verification** | **0 unverified of 7,860** — 600 M1 mounts + 600 M2 mounts + 630 broad writes + 6,030 narrow writes, and `unverified > 0` now **fails the run** |
+| **Segment-order control** | **no refusal on any row**; `magnitude-resolved? true` on all four of this run's rows, and the published M1 and narrow rounds are the ones it marks unresolved |
+| **Positive controls** | eight, eight passes — and, for the first time, **adjudicated against the doubled page they claim**: 1,801 elements with a probe at index 599, 99 with a probe at field 23 |
+
+### What would have been appended to rf2-2rtt6.1, had it not been size-locked
+
+**rf2-2rtt6.1 is size-locked (rf2-0znkn, the operator's) and cannot accept an
+append**, so this is what a worker would have added to the governance record's
+P0 table, verbatim. **Only the operator may amend the standard**; this is a
+statement of what the measurement supports, not an amendment.
+
+> **CLOCK RED-ZONES — amendment under RULING 1.** RULING 1 makes the red-zone
+> threshold *the measured UIx ratio for that witness family*. On two of the four
+> converged rows that ratio is **not resolved to a magnitude**, so the rule needs
+> its consequence stated rather than a number substituted:
+>
+> - **M1 mount — the magnitude `1.2301×` is withdrawn.** Its two segment-order
+>   strata are disjoint, the 3:2 design biases it upward on a quantity now shown
+>   to carry a systematic order effect (11 of 12 row-runs, p = 0.0032), and four
+>   independent estimates read 1.2301 / 1.2103 / 1.2887 / 1.1397 with the last
+>   straddling 1.0. The red-zone this row supports is **a direction and a range:
+>   UIx slower, ≈1.11 – 1.35×**. A candidate worse than 1.35× is RED; inside the
+>   range the answer is **not resolved**, which under the standard is still not a
+>   pass.
+> - **bulk narrow — the magnitude `1.1540×` is withdrawn** on the same test;
+>   direction (UIx slower) resolves in every run. Order-balanced value 1.1457.
+> - **bulk broad — `0.6239×` stands as a threshold**, with the order-balanced
+>   value **0.6357** recorded beside it. Direction survives in all six strata of
+>   all three runs.
+> - **M2 mount — unchanged and still diagnostic.** Balanced value 1.0376.
+> - **The heap red-zones are untouched.** Nothing here measures heap.
+
+### The control on this page was never checked either
+
+The same defect rf2-2rtt6.2 carried. `mount-round!` read
+`expected (if (:parity-exempt? arm) nil elements)`; `verify-m1` probed indices 0
+and 299 and `verify-m2` the shared 12-field prefix, both of which exist in the
+doubled page; and `parity-of-segment!` compared counts over `lane/parity`'s map,
+which excludes parity-exempt arms by construction. **Every red-zone on this page
+rests on a control whose 2× claim nothing tested.** It is now held to its own
+arithmetic — 1,801 / 99 elements, far probe at index 599 / field 23 — and the
+mutation evidence is on
+[the denominator page](p0-reagent-on-subs-baseline.md#mutation-proved-a-base-prefix-control-now-fails-three-ways).
 
 ## Open items — stated, not swept up
 

--- a/docs/design/hicasso/studio/p0-reagent-on-subs-baseline.md
+++ b/docs/design/hicasso/studio/p0-reagent-on-subs-baseline.md
@@ -236,6 +236,148 @@ tightening: **a strict rule would retroactively fail a control this page already
 published as passing**, on a quantisation artefact rather than on a loss of
 signal. Nothing here installs it.
 
+## The control that could not fail, and the teardown that said nothing
+
+Bead **rf2-2rtt6.2**, reopened by the PR #7259 audit. Two load-bearing controls
+were missing rather than wrong, and **no figure on this page moves** — the
+corrected instrument was run and every row reproduces. What changed is what the
+instrument is now able to refuse.
+
+### The `:ctl-2x` arm was the one arm whose page was never checked
+
+The positive control's whole claim is *this is exactly twice the page*. Nothing
+tested it. Three independent gates each excused it, and the third is the one
+that makes the first two matter:
+
+| gate | what it did | why the control slipped through |
+|---|---|---|
+| the per-mount element count | `expected (if (:parity-exempt? arm) nil elements)` | `nil` for every parity-exempt arm, so the control's count was compared with nothing |
+| the per-mount content probe | `verify-m1` read indices `0` and `299`; `verify-m2` read fields `0` and `11` | both exist in a **600-row** page and in a **300-row** one, so the probe could not tell them apart |
+| the canonical-DOM parity gate | compared counts over `lane/parity`'s `counts` map | that map **excludes parity-exempt arms by construction** |
+
+So a `:ctl-2x` arm that rendered only its base prefix passed every gate, and all
+**200 measured control mounts** (100 M1 + 100 M2) contributed to `0 unverified
+of 1,220` without the doubling being tested anywhere. The `2×` was **asserted,
+not verified** — and the row's whole warrant is *"a control that renders only
+the base prefix must fail before any figure is reportable"*.
+
+**The repair is arithmetic, not a new gate.** `:parity-exempt?` is now *derived*
+from a new `:scale`, so an arm's size and its exemption are one fact rather than
+two that can drift apart. Every arm — the control included — is held to the
+witness's own arithmetic applied to *its own* scale:
+
+| arm | element count checked against | far probe |
+|---|---|---|
+| M1 `:floor` / `:reagent-subs` / `:reagent-ratom` | **901** | index 299 |
+| **M1 `:ctl-2x`** | **1,801** | **index 599** |
+| M2 `:floor` / `:reagent-subs` / `:reagent-ratom` | **51** | field 11 |
+| **M2 `:ctl-2x`** | **99** | **field 23** |
+| **bulk `:ctl-2x`** | **1,801**, at mount, from its own `:cells` | index 599 (already, via `lane/bulk-probes`) |
+
+Exempt from the canonical-DOM **equality** is not exempt from **arithmetic**:
+the control is exempt because its page differs, and the size it differs *by* is
+the claim it exists to make. The per-arm expectations are published on every row
+as `:expected-elements`.
+
+### And `unverified > 0` now fails the run
+
+The third finding, and the one that made the other two possible. **The tally was
+published and never adjudicated.** `N unverified of M` reached the record, the
+record reached the console, and nothing between the tally and the exit code ever
+read `:unverified` — a row could report `400 unverified of 400` and the driver
+would still exit 0. `lane/assert-verified!` closes that, after the row's record
+is published so the evidence is on screen before the run dies on it.
+
+### Mutation-proved: a base-prefix control now fails, three ways
+
+Each mutation was run against this instrument, at this commit, with nothing else
+changed.
+
+| mutation | what the run did | exit |
+|---|---|---|
+| M1 `:ctl-2x` renders `(zeros n)` instead of `(zeros (* 2 n))` | refused at the **parity gate, before any clock**: `{:witness :M1, :problem :element-count, :arms {:ctl-2x {:expected 1801, :got 901}}}` | **1** |
+| the same control shrinks **only after parity** (so parity passes: `{:problems [] :ok? true}`) | refused at the **measured path**: `mount row M1: 100 UNVERIFIED of 400` — exactly the 100 control mounts | **1** |
+| the **bulk** `:ctl-2x` renders only its base 300 cells while still declaring 600 | refused at mount, before the row's first write: `the bulk arm :ctl-2x built 901 elements where its own 600 cells make 1801` | **1** |
+
+The second is the one that matters, because parity alone would have been a gate
+that fires before the measurement rather than on it. The control is now checked
+**per mount, on every sample**, and the count it produces is fatal.
+
+### Teardown: recorded, adjudicated, and proved
+
+`release-bulk-arms!` read `(try ((:unmount arm) handle) (catch :default _ nil))`
+and there was no residue assertion anywhere. The bulk arms stand for a whole
+row, so an unmount that threw would leave three hundred subscribing boundaries
+watching the app-db while every later sample was measured on top of them.
+
+Two halves, because there are two ways a release fails:
+
+- **A release that THREW** is recorded by `lane/teardown-failure!` and
+  adjudicated by `lane/assert-teardown-clean!` between every pair of rows.
+  Fatal.
+- **A release that returned normally and did not release** is caught by
+  `lane/residue` — three integers, all read outside every timed window:
+  attached containers under `document.body`, sub-cache entries, and the sum of
+  their ref-counts. re-frame2 evicts a cache entry the moment its ref-count
+  reaches zero, with no grace period, so a fully released row leaves an **empty
+  cache** and the comparison is equality rather than a threshold.
+
+### What that assertion found on its first run — and it is not a leak
+
+It went red immediately. After the parity phase released every arm of both
+witnesses, the frame's sub-cache still held **300 entries, ref-count 312** — M1's
+300 `[:p0/cell i]` subscriptions plus M2's 12, all still live after
+`root.unmount()` inside a `flushSync`.
+
+Reading the same census at three points settled what it was:
+
+| when | `:sub-entries` | `:sub-ref-count` |
+|---|---|---|
+| immediately after `lane/release!` | **300** | **312** |
+| after `reagent.core/flush` — Reagent's own *synchronous* render drain | **300** | **312** |
+| after ONE `setTimeout` | **0** | **0** |
+
+**Nothing is leaking.** Reagent's disposals sit on `reagent.impl.batching`'s
+next-tick queue, which is a *macrotask*; a synchronous drain cannot reach them
+and one turn of the event loop can.
+
+**It is not cosmetic, and this is the part worth keeping.** A mount row is
+wholly synchronous — `lane/rounds!` is `dotimes` inside `doseq` inside `mapv` —
+so **an entire row of a hundred mount-and-release cycles ran in one macrotask
+and not one disposal happened inside it.** Without a settle point, the M2 row
+began on a page whose 300 cached subscriptions still carried every consumer
+reaction the M1 row had mounted, and the bulk row began carrying both. The rows
+are now **chained with a settle between them**, which is as much the repair as
+the assertion is. `residue-baseline` and `residue-after-bulk` are published on
+every run: both read `{:body-children 2, :sub-entries 0, :sub-ref-count 0}`.
+
+### The corrected instrument, re-run — and nothing moves
+
+`cd implementation && npm run bench:hicasso` — **exit 0**, guard `refuse? false /
+contaminated? false / unchecked? false`, tolerance 0.10, `0 unverified of 1,220`.
+
+| row | figure | published | corrected instrument | overlap | verdict |
+|---|---|---|---|---|---|
+| **M1 mount** | `reagent-subs ÷ floor` | 3.899 [3.447 – 4.300] | 4.029 [3.429 – 4.733] | 3.447 – 4.300 | **reproduces** |
+| | **reactive leg** | **1.218 [1.122 – 1.310]** | **1.271 [1.200 – 1.326]** | 1.200 – 1.310 | **reproduces**, disjoint from 1.0 both |
+| **M2 mount** *(diagnostic)* | `reagent-subs ÷ floor` | 1.874 [1.750 – 2.050] | 1.867 [1.333 – 3.000] | wholly inside | reproduces |
+| | **reactive leg** | 1.056 [0.960 – 1.242] | 1.000 [1.000 – 1.000] | — | **same verdict — straddles 1.0**, and see below |
+| **bulk broad** | `reagent-subs ÷ floor` | 7.064 [6.200 – 7.700] | 7.230 [5.000 – 10.250] | wholly inside | **reproduces** |
+| | **reactive leg** | **2.008 [1.938 – 2.100]** | **2.170 [2.000 – 2.286]** | 2.000 – 2.100 | **reproduces**, disjoint from 1.0 both |
+
+**M2's reactive leg read exactly 1.0000 in all five rounds**, because its two
+Reagent arms returned the *same p50* in every round — which on a witness whose
+absolute p50 is two to four of Chrome's 100 µs quanta is the quantum, not a tie.
+It is the same signature the converged page records on its own M2 row, it agrees
+with the published verdict (*indistinguishable*), and it is exactly why **this
+row is graded diagnostic and must not be quoted against the bar.**
+
+Controls under both readings of rf2-egdaq's open question: M1 `1.963×
+[1.857 – 2.357]` and M2 `1.733× [1.500 – 2.000]` pass under **either** rule;
+bulk `2.000× [1.500 – 2.500]` passes the overlap rule and misses the strict one
+by **0.0014** — the same lattice artefact recorded above, on a floor of two to
+three quanta. Nothing here installs the strict rule.
+
 ## What this settles, and what it does not
 
 **Settles.** The bar's denominator exists and is a browser number. Reading

--- a/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
@@ -76,7 +76,8 @@
      of them repaired the ARM. The tolerance is not the arm's to move."
   (:require ["react-dom" :as react-dom]
             [clojure.string :as str]
-            [re-frame.bench.order-guard :as guard]))
+            [re-frame.bench.order-guard :as guard]
+            [re-frame.frame :as frame]))
 
 ;; ---------------------------------------------------------------------------
 ;; Clock and summary — eleven lines, so the lane owes the donor tree nothing
@@ -264,6 +265,115 @@
   (when container (.remove container))
   nil)
 
+(defn assert-teardown-clean!
+  "Throw if any teardown has failed since the last check.
+
+  Checked BETWEEN rows, segments and rounds, which is where the damage is
+  done: a React root or a frame that did not tear down is still holding
+  its watches and its caches when the next row is measured, and that row
+  then reports a precise number for a page that is not the page under
+  test. The throw lands in the caller's fatal path, which records
+  `HICASSO_ERROR`, and the driver exits 1.
+
+  This is the ADJUDICATION half of [[teardown-failure!]]. Recording a
+  failure and never asking about it is the same silence
+  `(catch :default _ nil)` produced, one indirection further out."
+  [after]
+  (let [fs (drain-teardown-failures!)]
+    (when (seq fs)
+      (throw (ex-info (str "teardown FAILED after " after
+                           " — an arm or a frame did not tear down, so its caches and "
+                           "watches are still standing and every row after this one "
+                           "would be measured on a page carrying them: " (pr-str fs))
+                      {:after after :failures fs})))
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; Residue — the proof that the teardown that did not throw also worked
+;; ---------------------------------------------------------------------------
+
+(defn residue
+  "The live-reference census a fully released row must return to.
+
+  Three integers, all read OUTSIDE every timed window:
+
+    `:body-children`  attached elements under `document.body`. Every
+                      container this lane mints is attached there and
+                      detached by [[release!]], so a container whose arm
+                      survived its unmount shows up here as a page the
+                      NEXT row is measured on top of.
+    `:sub-entries`    slots in the frame's sub-cache.
+    `:sub-ref-count`  the sum of those slots' ref-counts.
+
+  Both subscription numbers return to their starting value by
+  construction rather than by hope: `re-frame.subs.cache/unsubscribe!`
+  EVICTS an entry the moment its ref-count reaches zero, with no grace
+  period, so a row whose every boundary unmounted leaves an EMPTY cache.
+  A row that left three hundred `[:p0/cell i]` reactions watching the
+  app-db is therefore visible as a non-zero count and not merely as a
+  slower page.
+
+  A teardown that THREW is caught by [[teardown-failure!]]. This is the
+  other half: a teardown that returned normally and did not actually
+  release. Neither is a leak detector and neither is a lifecycle
+  framework — this answers one question, `did the release this row just
+  performed actually happen`, in three integers."
+  [frame-id]
+  (let [cache (some-> (frame/frame frame-id) :sub-cache deref)]
+    {:body-children (.-childElementCount js/document.body)
+     :sub-entries   (count cache)
+     :sub-ref-count (reduce + 0 (map #(or (:ref-count %) 0) (vals cache)))}))
+
+(defn settle!
+  "Yield ONE MACROTASK, so a substrate that schedules its disposals there
+  has run them. Answers a promise. Never inside a timed window.
+
+  ## Reagent's unmount does not release its subscriptions synchronously
+
+  Measured, not assumed. Reading [[residue]] at three points after the
+  parity phase releases every arm of both witnesses:
+
+      immediately after `release!`   {:sub-entries 300 :sub-ref-count 312}
+      after `reagent.core/flush`     {:sub-entries 300 :sub-ref-count 312}
+      after ONE `setTimeout`         {:sub-entries   0 :sub-ref-count   0}
+
+  `root.unmount()` inside a `flushSync` returns with the frame's sub-cache
+  still holding every entry the page was reading, and Reagent's own
+  SYNCHRONOUS render drain does not move them either — the disposals are
+  on `reagent.impl.batching`'s next-tick queue, which is a macrotask. One
+  turn later they are gone. Nothing is leaking.
+
+  It is not cosmetic, and this is why a settle point belongs BETWEEN ROWS
+  rather than only in front of the assertion. A mount row is fully
+  synchronous — `rounds!` is `dotimes` inside `doseq` inside `mapv` — so
+  an entire row of a hundred mount-and-release cycles runs in ONE
+  macrotask and NOT ONE disposal happens inside it. Without a settle the
+  next row begins on a page whose cached subscriptions still carry every
+  consumer reaction the previous row mounted, and the row after that
+  carries both. Yielding here is what makes each row's first sample and
+  its last sample the same experiment."
+  []
+  (js/Promise. (fn [resolve] (js/setTimeout (fn [] (resolve nil)) 0))))
+
+(defn assert-residue!
+  "Throw unless the residue is back at `baseline`. Answers the reading.
+
+  Called between rows and never inside a window, and always AFTER
+  [[settle!]] — the claim is `the release happened`, not `the release
+  happened synchronously`, and Reagent's does not. The comparison is
+  EQUALITY, not a threshold: the quantities are counts of live references
+  that a correct teardown drives to exactly where they started, and a
+  tolerance on them would only make room for the fault."
+  [baseline frame-id after]
+  (let [now (residue frame-id)]
+    (when (not= baseline now)
+      (throw (ex-info (str "RESIDUE after " after " — the teardown returned without "
+                           "throwing but did not release: expected " (pr-str baseline)
+                           ", found " (pr-str now) ". Every later sample would be "
+                           "measured on a page still carrying it")
+                      {:after after :baseline baseline :residue now})))
+    now))
+
 ;; ---------------------------------------------------------------------------
 ;; Parity — run before any clock is read
 ;; ---------------------------------------------------------------------------
@@ -418,6 +528,29 @@
   (atom {:of 0 :bad 0}))
 
 (defn tally-value [t] (let [{:keys [of bad]} @t] {:writes of :unverified bad}))
+
+(defn assert-verified!
+  "Throw unless the tally reads `0 unverified of M`. Answers the tally.
+
+  The count was PUBLISHED and never ADJUDICATED, on both P0 entries: a row
+  could report `400 unverified of 400` and the driver would still exit 0,
+  because nothing between the tally and the exit code ever looked at
+  `:unverified`. Every read-back this lane performs — the written cell, the
+  mount's element count, the far end of the page — banks here, so this one
+  line is what makes ALL of them load-bearing rather than decorative.
+
+  Called AFTER the row's record is published, so the evidence a reader
+  needs is on the console before the run dies on it, and never inside a
+  timed window."
+  [t where]
+  (let [{:keys [writes unverified] :as v} (tally-value t)]
+    (when (pos? unverified)
+      (throw (ex-info (str where ": " unverified " UNVERIFIED of " writes
+                           " — a measured operation did not produce the page it claims. "
+                           "Every figure in this row is a clock reading over a page that "
+                           "was not checked, so none of them is reportable")
+                      {:where where :verification v})))
+    v))
 
 (defn verified-writes!
   "Run `ops` — a seq of `[i val probes]` — as ONE measured window: each

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
@@ -94,6 +94,29 @@
   a both-orders result rather than a single-order one however many rounds
   it averages.
 
+  ## And the order is ADJUDICATED, not merely run (rf2-a4x1o)
+
+  Running both orders is not the same as testing whether the answer
+  depends on them. `lane/guard!` adjudicates arms INSIDE a segment; the
+  red-zone is a ratio ACROSS the seam and no guard on this page ever
+  looked at it by segment order, while `:segment-seam-control` recorded
+  the floor's drift and stopped there. [[segment-order-verdict]] asks the
+  question the labels were already carrying, and splits the answer in two
+  because the two halves fail separately: DIRECTION is fail-closed (two
+  strata pointing opposite ways across 1.0 refuse the row), and MAGNITUDE
+  is publishable only when the strata OVERLAP.
+
+  It found something. Across three independent five-round runs the
+  cross-segment figure reads HIGHER when the Reagent segment ran first in
+  11 of 12 row-runs — one-sided binomial p = 0.0032. The per-row
+  disjointness test cannot see that (at 3:2 a disjoint split arises 20% of
+  the time under the null, and which row splits is not stable across
+  runs); the sign across rows and runs can. Five rounds cannot balance two
+  orders, so the raw mean over-weights whichever order got the extra round
+  — which is why `:order-balanced-mean`, the mean of the two stratum
+  means, is published on every row beside it. The studio page carries the
+  table and the consequence for `1.2301`.
+
   ## One row per page
 
   The first cut ran all four rows in one page and THE ARM-ORDER GUARD
@@ -226,14 +249,21 @@
 (defn- zeros [n] (vec (repeat n 0)))
 
 (defn- floor-mount-arm
-  [id element-of cells-of & [exempt?]]
-  {:id             id
-   :parity-exempt? (boolean exempt?)
-   :mount          (fn [container props _n]
-                     (let [root (react-dom-client/createRoot container)]
-                       (.render root (element-of (cells-of props)))
-                       root))
-   :unmount        (fn [root] (.unmount root))})
+  "`scale` is how many times the witness's own page this arm builds, and
+  `:parity-exempt?` is DERIVED from it: an arm that builds a different page
+  is exactly the arm the canonical-DOM gate must exempt. They used to be
+  independent facts and the control carried only the exemption, which is
+  how its doubled page went unchecked."
+  [id element-of cells-of & [scale]]
+  (let [scale (or scale 1)]
+    {:id             id
+     :scale          scale
+     :parity-exempt? (not= 1 scale)
+     :mount          (fn [container props _n]
+                       (let [root (react-dom-client/createRoot container)]
+                         (.render root (element-of (cells-of props)))
+                         root))
+     :unmount        (fn [root] (.unmount root))}))
 
 (defn- reagent-mount-arm
   "Reagent's own mount door — what a Reagent application calls."
@@ -264,30 +294,56 @@
   (some-> (.querySelector container sel) (.-value)))
 
 (defn- verify-m1
-  "Both ends of the list. A page that committed only its head would pass a
-  single-probe check at index 0."
-  [container]
-  (and (= "0" (lane/text-at container 0))
-       (= "0" (lane/text-at container (dec v/cells-n)))))
+  "Both ends of the list AT THE ARM'S OWN SIZE — `n` rows, so the far probe
+  is index `n - 1`.
+
+  A page that committed only its head would pass a single-probe check at
+  index 0; a CONTROL that rendered only its base prefix would pass a check
+  at index 299, which is what this was for every arm. The one arm whose
+  whole purpose is to be twice the page was the one arm nothing checked
+  past its first half."
+  [n]
+  (fn [container]
+    (and (= "0" (lane/text-at container 0))
+         (= "0" (lane/text-at container (dec n))))))
 
 (defn- verify-m2
-  "The first and last field of the SHARED prefix — the control arm has
-  twice the fields, so a probe past `fields-n` would not exist in every
-  arm."
-  [container]
-  (and (= (v/field-value 0 0) (input-value container "#f0"))
-       (= (v/field-value (dec v/fields-n) 0)
-          (input-value container (str "#f" (dec v/fields-n))))))
+  "The first and last field AT THE ARM'S OWN SIZE. Fixed at the witness's
+  `fields-n` it read the SHARED PREFIX and could not tell a doubled form
+  from a base one."
+  [n]
+  (fn [container]
+    (and (= (v/field-value 0 0) (input-value container "#f0"))
+         (= (v/field-value (dec n) 0)
+            (input-value container (str "#f" (dec n)))))))
+
+(defn- expectation
+  "What THIS arm's page must contain: the witness's own arithmetic applied
+  to the arm's `:scale`, as `{:elements n :verify f}`.
+
+  There is no exemption. `mount-round!` used to read
+  `(if (:parity-exempt? arm) nil elements)` and skip the element count for
+  the control, while the probes read indices that exist in the base page —
+  so the `:ctl-2x` arm was the ONE arm in the plan whose page was never
+  checked, and a control that rendered only its base prefix passed. Every
+  red-zone on this page rests on that control having seen the change its
+  own arithmetic predicts."
+  [{:keys [elements-of verify-of props]} arm]
+  (let [n (* (or (:scale arm) 1) (:n props))]
+    {:elements (elements-of n)
+     :verify   (verify-of n)}))
+
+(defn- base-elements [{:keys [elements-of props]}] (elements-of (:n props)))
 
 (def ^:private mount-witnesses
-  [{:id       :M1
-    :grade    :bar
-    :verify   verify-m1
+  [{:id          :M1
+    :grade       :bar
+    :verify-of   verify-m1
+    :elements-of v/m1-elements
     :doc      (str "the 300-boundary sub-reading list — the bulk shape's mount "
                    "counterpart, one subscription read per boundary. "
                    "rf2-2rtt6.2's M1, unchanged")
     :props    {:n v/cells-n}
-    :elements (v/m1-elements v/cells-n)
     :control  {:predicted (/ (double (v/m1-elements (* 2 v/cells-n)))
                              (double (v/m1-elements v/cells-n)))
                :basis     (str "element count: " (v/m1-elements (* 2 v/cells-n)) " / "
@@ -302,11 +358,12 @@
                                    :uix-subs
                                    (fn [{:keys [n]}] (ux/subs-root ux/m1 n))))
                  (floor-mount-arm :ctl-2x v/m1-floor
-                                  (fn [{:keys [n]}] (zeros (* 2 n))) true)])}
+                                  (fn [{:keys [n]}] (zeros (* 2 n))) 2)])}
 
-   {:id         :M2
-    :grade      :diagnostic
-    :verify     verify-m2
+   {:id          :M2
+    :grade       :diagnostic
+    :verify-of   verify-m2
+    :elements-of v/m2-elements
     ;; ONE mount per sample, exactly as rf2-2rtt6.2 publishes it. That arm
     ;; TRIED the batch that would lift this witness clear of Chrome's
     ;; 100 us clamp — eight 51-element roots in one flushSync — and THE
@@ -330,7 +387,6 @@
     :doc      (str "the ordinary 12-field form on subs — the shape most "
                    "applications are made of. rf2-2rtt6.2's M2, unchanged")
     :props    {:n v/fields-n}
-    :elements (v/m2-elements v/fields-n)
     :control  {:predicted (/ (double (v/m2-elements (* 2 v/fields-n)))
                              (double (v/m2-elements v/fields-n)))
                :basis     (str "element count: " (v/m2-elements (* 2 v/fields-n)) " / "
@@ -345,7 +401,7 @@
                                    :uix-subs
                                    (fn [{:keys [n]}] (ux/subs-root ux/m2 n))))
                  (floor-mount-arm :ctl-2x v/m2-floor
-                                  (fn [{:keys [n]}] (zeros (* 2 n))) true)])}])
+                                  (fn [{:keys [n]}] (zeros (* 2 n))) 2)])}])
 
 (defn- witness-named [id] (first (filter #(= id (:id %)) mount-witnesses)))
 
@@ -360,11 +416,12 @@
   lane, so a floor arm that rendered in `write!` would have its commit
   land outside the measured window entirely — the recorded fault is 80 of
   320 floor samples ending on a cell that still held its old value."
-  [id n & [exempt?]]
+  [id n & [scale]]
   (let [state (atom (zeros n))
         rt    (volatile! nil)]
     {:id             id
-     :parity-exempt? (boolean exempt?)
+     :scale          (or scale 1)
+     :parity-exempt? (not= 1 (or scale 1))
      :cells          n
      :mount          (fn [container]
                        (let [root (react-dom-client/createRoot container)]
@@ -444,12 +501,31 @@
    (case segment-id
      :reagent-subs (reagent-bulk-arm)
      :uix-subs     (uix-bulk-arm))
-   (floor-bulk-arm :ctl-2x (* 2 v/cells-n) true)])
+   (floor-bulk-arm :ctl-2x (* 2 v/cells-n) 2)])
 
-(defn- mount-bulk-arms! [arms]
+(defn- mount-bulk-arms!
+  "Mount every bulk arm once and CHECK THE PAGE IT BUILT, before a clock is
+  read.
+
+  Every bulk arm declares `:cells` and `v/m1-elements` turns that into an
+  element count by written arithmetic, so this is what makes the bulk
+  `:ctl-2x` arm's doubled page load-bearing. Its far-end read-back already
+  derives from `:cells` (`lane/bulk-probes` probes index `cells - 1`), so a
+  control shrunk to the base 300 cells would still have probed a cell it
+  owns; the COUNT is the check a smaller page cannot satisfy. Outside every
+  timed window — the arms are mounted once and written to thereafter."
+  [arms]
   (mapv (fn [a]
-          (let [c (lane/fresh-container!)]
-            {:arm a :container c :handle ((:mount a) c)}))
+          (let [c        (lane/fresh-container!)
+                handle   ((:mount a) c)
+                expected (v/m1-elements (:cells a))
+                got      (lane/element-count c)]
+            (when-not (= expected got)
+              (throw (ex-info (str "the bulk arm " (:id a) " built " got
+                                   " elements where its own " (:cells a)
+                                   " cells make " expected)
+                              {:arm (:id a) :expected expected :got got})))
+            {:arm a :container c :handle handle}))
         arms))
 
 (defn- release-bulk-arms! [mounts]
@@ -459,48 +535,38 @@
            (lane/teardown-failure! (str "release-bulk-arms! " (:id arm)) e)))
     (.remove container)))
 
-(defn- assert-teardown-clean!
-  "Throw if any teardown has failed since the last check.
-
-  Checked BETWEEN rows and segments, which is where the damage is done: a
-  React root or a frame that did not tear down is still holding its
-  watches and its caches when the next row is measured, and that row then
-  reports a precise number for a page that is not the page under test.
-  The throw lands in `-main`'s existing `.catch`, which records
-  `HICASSO_ERROR` and exits 1."
-  [after]
-  (let [fs (lane/drain-teardown-failures!)]
-    (when (seq fs)
-      (throw (ex-info (str "teardown FAILED after " after
-                           " — an arm or a frame did not tear down, so its caches and "
-                           "watches are still standing and every row after this one "
-                           "would be measured on a page carrying them: " (pr-str fs))
-                      {:after after :failures fs})))
-    nil))
+(def ^:private assert-teardown-clean!
+  "Lifted into `lane.cljs` (rf2-2rtt6.2), because the Reagent baseline arm
+  needs the same adjudication and a second copy of a fatal rule is a second
+  authority with nothing holding it in step. Aliased rather than inlined at
+  the call sites so this entry's four `assert-teardown-clean!` calls still
+  read as the sentences they are."
+  lane/assert-teardown-clean!)
 
 ;; ---------------------------------------------------------------------------
 ;; One round of one mount witness in one segment
 ;; ---------------------------------------------------------------------------
 
 (defn- mount-round!
-  [coll t {:keys [id verify elements props per-sample arms-for]} segment-id]
-  (let [arms (arms-for segment-id)
-        n    (count arms)
-        k    (or per-sample 1)
-        acc  (atom (zipmap (map :id arms) (repeat [])))]
+  [coll t {:keys [id props per-sample arms-for] :as witness} segment-id]
+  (let [arms   (arms-for segment-id)
+        n      (count arms)
+        k      (or per-sample 1)
+        expect (into {} (map (juxt :id #(expectation witness %))) arms)
+        acc    (atom (zipmap (map :id arms) (repeat [])))]
     (dotimes [s (+ (:warmup mount-sampling) (:samples mount-sampling))]
       (doseq [j (lane/slot-order n s)]
         (let [arm (nth arms j)
               {:keys [ms mounts]} (lane/mount-batch! arm props k)
-              expected (if (:parity-exempt? arm) nil elements)]
-          ;; EVERY mount is read back out of the document — the element
-          ;; count against WRITTEN arithmetic, and the witness's own probe
-          ;; at both ends of the page. An arm that rendered an empty page
-          ;; is the cheapest arm in any table and this is the line that
-          ;; catches it.
+              {exp-elements :elements verify :verify} (get expect (:id arm))]
+          ;; EVERY mount is read back out of the document against THIS
+          ;; ARM'S OWN arithmetic — its exact element count, and both ends
+          ;; of the page it claims to build. An arm that rendered an empty
+          ;; page is the cheapest arm in any table, and a CONTROL that
+          ;; rendered only its base prefix is the cheapest 2x arm; this is
+          ;; the line that catches both.
           (doseq [m mounts]
-            (let [ok? (and (or (nil? expected)
-                               (= expected (lane/element-count (:container m))))
+            (let [ok? (and (= exp-elements (lane/element-count (:container m)))
                            (verify (:container m)))]
               (swap! t (fn [{:keys [of bad]}]
                          {:of (inc of) :bad (if ok? bad (inc bad))}))))
@@ -628,6 +694,115 @@
    :per-round (mapv lane/round4 vs)
    :straddles-1? (and (<= (apply min vs) 1.0) (>= (apply max vs) 1.0))})
 
+;; ---------------------------------------------------------------------------
+;; The segment-order verdict — the gate the cross-segment figure never had
+;; ---------------------------------------------------------------------------
+
+(defn- direction-of
+  "Where a range sits relative to 1.0, as a verdict rather than a number."
+  [{:keys [min max]}]
+  (cond (> min 1.0) :numerator-slower
+        (< max 1.0) :numerator-faster
+        :else       :indistinguishable))
+
+(defn segment-order-verdict
+  "Adjudicate a cross-segment figure BY WHICH SEGMENT RAN FIRST.
+
+  Public, and the only public fn in this entry besides `-main`, because
+  `p0_converge_order_cljs_test` replays the PUBLISHED per-round vectors
+  through it: a verdict that has only ever seen the run it shipped with is
+  a verdict nobody can check.
+
+  ## What the arm-order guard cannot see, and why this exists
+
+  `lane/guard!` adjudicates arms INSIDE a segment: it asks whether an arm
+  reads differently for where in the plan it was measured. The red-zone is
+  not an arm — it is a ratio of one segment's floor-normalised arm to the
+  OTHER segment's, and no guard on this page ever looked at it by segment
+  order. [[segment-order]] alternates, so every round is already labelled
+  with the answer; nothing was asking the question. The seam control
+  records the floor's own drift and stops there (rf2-a4x1o, from the PR
+  #7265 and #7268 audits).
+
+  ## Two claims, adjudicated separately, because they fail separately
+
+  DIRECTION — `UIx slower` / `UIx faster` / `indistinguishable`. This is
+  what the bar and the red-zone rule actually consume. It is FAIL-CLOSED:
+  a row whose two order strata point OPPOSITE WAYS has no direction to
+  publish, `:refuse?` is true, and the driver exits non-zero. A figure
+  that says `slower` when Reagent went first and `faster` when UIx did is
+  a measurement of the schedule.
+
+  MAGNITUDE — the single number a candidate would be judged against. It is
+  reportable only when the two strata OVERLAP. Disjoint strata mean the
+  figure has a component that is the segment order, and a mean over a
+  bimodal split is not a threshold; the row then publishes its direction
+  and its stratum bounds, and NOT a precise magnitude. Silence is not a
+  pass: `:magnitude-resolved?` starts false and the overlap has to earn it.
+
+  ## `:order-balanced-mean`, and the 3:2 design
+
+  With `rounds` odd the alternation is UNBALANCED — three rounds in one
+  order, two in the other — so the arithmetic mean over rounds
+  over-weights whichever order got the extra round. The unbiased estimator
+  under an alternating design is the MEAN OF THE TWO STRATUM MEANS, and
+  that is `:order-balanced-mean`, published beside the raw one whatever
+  the parity of `rounds`. `:balanced-design?` says whether they can
+  differ. An EVEN round count would make them identical by construction
+  and is the arm-level repair available to whoever next re-takes the
+  table; it is not taken here, because it would move four published rows
+  without deciding the question the disjointness raises.
+
+  ## What a disjoint split is and is not EVIDENCE of
+
+  At `rounds` 5 the strata are 3 and 2. Under the null — no order effect,
+  the five rounds exchangeable — the 2-element stratum is one of
+  `C(5,2) = 10` equally likely subsets, and exactly TWO of them (the two
+  smallest, the two largest) separate the strata. So a disjoint split
+  arises **20% of the time with no order effect at all**, per row. That is
+  why disjointness withdraws the magnitude rather than condemning the
+  measurement: it is a statement about what this design can resolve, not a
+  finding that the schedule moved the number."
+  [vs rounds]
+  (let [strata     {:reagent-first (vec (keep-indexed #(when (even? %1) %2) vs))
+                    :uix-first     (vec (keep-indexed #(when (odd? %1) %2) vs))}
+        rf         (range-of (:reagent-first strata))
+        uf         (range-of (:uix-first strata))
+        overlap?   (and (<= (:min rf) (:max uf)) (<= (:min uf) (:max rf)))
+        d-rf       (direction-of rf)
+        d-uf       (direction-of uf)
+        opposed?   (or (and (= d-rf :numerator-slower) (= d-uf :numerator-faster))
+                       (and (= d-rf :numerator-faster) (= d-uf :numerator-slower)))
+        balanced?  (even? rounds)]
+    {:reagent-first       (assoc rf :direction d-rf :n (count (:reagent-first strata)))
+     :uix-first           (assoc uf :direction d-uf :n (count (:uix-first strata)))
+     :order-balanced-mean (lane/round4 (/ (+ (:mean rf) (:mean uf)) 2.0))
+     :balanced-design?    balanced?
+     :strata-overlap?     overlap?
+     :magnitude-resolved? overlap?
+     :direction-agrees?   (not opposed?)
+     :refuse?             opposed?
+     :why
+     (str "the red-zone's rounds partitioned by which segment ran FIRST. "
+          "Reagent-first " (.toFixed (:mean rf) 4) "x [" (.toFixed (:min rf) 4) "–"
+          (.toFixed (:max rf) 4) "] over " (count (:reagent-first strata)) " rounds; "
+          "UIx-first " (.toFixed (:mean uf) 4) "x [" (.toFixed (:min uf) 4) "–"
+          (.toFixed (:max uf) 4) "] over " (count (:uix-first strata)) " rounds. "
+          (if opposed?
+            (str "THE TWO STRATA POINT OPPOSITE WAYS, so this row has no direction to "
+                 "publish and no figure in it is reportable.")
+            (if overlap?
+              (str "The strata OVERLAP, so the magnitude survives the partition and the "
+                   "row may publish one.")
+              (str "The strata are DISJOINT, so part of this figure is WHICH SEGMENT "
+                   "RAN FIRST and the mean over them is not a threshold. The row "
+                   "publishes its DIRECTION and the stratum bounds; it may NOT publish a "
+                   "precise magnitude. At " rounds " rounds the split is "
+                   (count (:reagent-first strata)) ":" (count (:uix-first strata))
+                   " and a disjoint partition arises by chance alone in 2 of "
+                   "C(" rounds "," (count (:uix-first strata)) ") assignments, so this "
+                   "withdraws a claim rather than establishing an effect."))))}))
+
 (defn- row-record
   "Turn one row's per-round, per-segment slices into the published record.
 
@@ -650,7 +825,8 @@
                                                   (select-keys (range-of vs) [:min :max :mean])
                                                   control-slack))
         c-rg       (verdict-of ctl-rg)
-        c-ux       (verdict-of ctl-ux)]
+        c-ux       (verdict-of ctl-ux)
+        order      (segment-order-verdict rz rounds)]
     {:record
      {:benchmark   (keyword "hicasso.P0.converged" (name row))
       :doc         doc
@@ -666,7 +842,18 @@
       :red-zone    (assoc (range-of rz)
                           :numerator :uix-subs
                           :denominator :reagent-subs
-                          :axis :clock)
+                          :axis :clock
+                          ;; What this row is ENTITLED to publish, decided by
+                          ;; the segment-order verdict rather than by whoever
+                          ;; writes the studio page. `:direction-only` means
+                          ;; the mean above is an average over a split the
+                          ;; schedule explains part of, and must not be quoted
+                          ;; as a threshold.
+                          :claim (if (:magnitude-resolved? order)
+                                   :magnitude
+                                   :direction-only)
+                          :direction (direction-of (range-of rz)))
+      :segment-order-control order
       :uix-over-floor     (range-of ux-floor)
       :reagent-over-floor (range-of rg-floor)
       :segment-seam-control
@@ -685,16 +872,33 @@
       :per-round   {:reagent (mapv #(get-in % [:reagent-subs :p50]) norm)
                     :uix     (mapv #(get-in % [:uix-subs :p50]) norm)}
       :status      :evidence}
-     :controls [c-rg c-ux]}))
+     :controls [c-rg c-ux]
+     :order     order}))
 
 ;; ---------------------------------------------------------------------------
 ;; Parity — before any clock is read, in EVERY segment and ACROSS the seam
 ;; ---------------------------------------------------------------------------
 
 (defn- parity-of-segment!
-  [{:keys [id props elements arms-for]} segment-id]
-  (let [{:keys [mounts agree? counts disagree reference]}
-        (lane/parity (arms-for segment-id) props)]
+  "Canonical-DOM equality across the judged arms, and the element count of
+  EVERY arm — the control included — against its own arithmetic.
+
+  The count used to be checked over `lane/parity`'s `counts` map, which
+  excludes the parity-exempt arms by design, so the one arm building a
+  deliberately different page had that page checked nowhere. Exempt from
+  the EQUALITY is not exempt from arithmetic: the control is exempt
+  because its page differs, and the size it differs BY is the claim it
+  exists to make."
+  [{:keys [id props arms-for] :as witness} segment-id]
+  (let [{:keys [mounts agree? disagree reference]}
+        (lane/parity (arms-for segment-id) props)
+        wrong (into {}
+                    (comp (map (fn [{:keys [arm container]}]
+                                 [(:id arm)
+                                  {:expected (:elements (expectation witness arm))
+                                   :got      (lane/element-count container)}]))
+                          (remove (fn [[_ {:keys [expected got]}]] (= expected got))))
+                    mounts)]
     (try
       {:reference reference
        :problems  (cond-> []
@@ -702,9 +906,9 @@
                     (conj {:segment segment-id :witness id
                            :problem :canonical-dom-disagreement :arms disagree})
 
-                    (not (every? #(= elements %) (vals counts)))
+                    (seq wrong)
                     (conj {:segment segment-id :witness id :problem :element-count
-                           :expected elements :got counts}))}
+                           :arms wrong}))}
       (finally (doseq [m mounts] (lane/release! m))))))
 
 (defn- parity!
@@ -852,7 +1056,7 @@
 (defn- publish!
   [{:keys [kind witness row grade doc note control] :as _spec} row-key slices t legs coll]
   (let [w   (witness-named witness)
-        {:keys [record controls]}
+        {:keys [record controls order]}
         (row-record {:row row
                      :grade grade
                      :doc (or doc (:doc w))
@@ -869,7 +1073,18 @@
                    :axis :clock
                    :witness-set "rf2-2rtt6.2"
                    :threshold (select-keys (:red-zone record)
-                                           [:mean :min :max :per-round :straddles-1?])
+                                           [:mean :min :max :per-round :straddles-1?
+                                            :claim :direction])
+                   :segment-order-control order
+                   :publishable (if (:magnitude-resolved? order)
+                                  (str "a MAGNITUDE. The two segment-order strata overlap, "
+                                       "so the mean survives the partition.")
+                                  (str "a DIRECTION ONLY. The two segment-order strata are "
+                                       "DISJOINT, so part of this figure is which segment "
+                                       "ran first and the mean over them is not a "
+                                       "threshold. Quote the direction and the stratum "
+                                       "bounds; the order-balanced mean is "
+                                       (:order-balanced-mean order) "x."))
                    :rule (str "RULING 1 on rf2-2rtt6.1: the red-zone threshold IS the "
                               "measured UIx ratio for that witness family. A candidate row "
                               "worse than it is RED and needs an explicit operator waiver "
@@ -889,6 +1104,17 @@
       (when (:refuse? vd) (set! (.-HICASSO_GUARD_REFUSED js/window) true)))
     (when (some (complement :ok?) controls)
       (set! (.-HICASSO_CONTROL_FAILED js/window) true))
+    ;; The segment-order refusal is DIRECTIONAL disagreement, and it is
+    ;; fatal for the same reason a failed positive control is: the row's
+    ;; only surviving claim would be a measurement of the schedule.
+    (when (:refuse? order)
+      (set! (.-HICASSO_ORDER_REFUSED js/window) true))
+    ;; LAST, so every record above is on the console first. The count was
+    ;; published and never adjudicated: this row could read `N unverified of
+    ;; M` with N > 0 and the driver would still exit 0, which is what left
+    ;; every read-back in this entry — the written cell, the mount's element
+    ;; count, the far end of the page — decorative.
+    (lane/assert-verified! t (str "row " (name row)))
     nil))
 
 (defn ^:export -main
@@ -927,9 +1153,11 @@
                       {:row row-key :problems problems :ok? (empty? problems)
                        :note (str "canonical DOM with attribute names sorted, inside each "
                                   "segment AND across the seam. The element count is checked "
-                                  "against written arithmetic — " (:elements w) " for "
-                                  (name (:id w)) " — so the gate can answer false for an arm "
-                                  "that rendered nothing.")})
+                                  "against written arithmetic — " (base-elements w) " for "
+                                  (name (:id w)) ", and the arm's OWN scale for the "
+                                  "control — so the gate can answer false for an arm that "
+                                  "rendered nothing, and for a 2x control that rendered "
+                                  "only its base prefix.")})
         (if (seq problems)
           (do (lane/fail! (str "the arms do not build the same page under :advanced — "
                                (pr-str problems)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs
@@ -1,0 +1,192 @@
+(ns re-frame.bench.hicasso.p0-converge-order-cljs-test
+  "THE SEGMENT-ORDER VERDICT, replayed against the numbers it was built to
+  judge (rf2-a4x1o).
+
+  `p0-converge-app/segment-order-verdict` partitions a cross-segment
+  figure by which segment ran FIRST in each round — the question
+  `lane/guard!` cannot ask, because the guard adjudicates arms INSIDE a
+  segment and the red-zone is a ratio ACROSS the seam.
+
+  A gate whose only evidence is the run it shipped with has not been
+  tested. These are the PUBLISHED per-round vectors from
+  `docs/design/hicasso/studio/p0-converged-witness-set.md`, replayed:
+  the run the red-zone table was taken from, and the independent
+  four-row reproduction sweep (rf2-rjfz1) taken at main `32cb224d6e`.
+  Both are on the page, both are five rounds, and
+  `p0-converge-app/segment-order` alternates on the round index — so
+  rounds 0, 2, 4 are Reagent-first and rounds 1, 3 are UIx-first, in
+  both.
+
+  What the replay establishes, and it is the whole of rf2-a4x1o's second
+  item:
+
+  1. The M1 partition the PR #7268 audit reported is REPRODUCED exactly
+     from the published vector — the strata are disjoint, so the
+     operative `1.2301` is a mean over a split whose two halves do not
+     meet.
+  2. The same partition applied to the other three published rows agrees
+     with the audit on M2 and broad, and DISAGREES on narrow: the
+     CURRENT (batched) narrow row's strata are disjoint too. Only the
+     SUPERSEDED unbatched narrow row overlaps.
+  3. Across the two runs, WHICH rows split disjointly MOVES — M1 and
+     narrow in the published run, broad in the sweep, and no row in
+     both. At a 3:2 split a disjoint partition arises in 2 of the
+     `C(5,2) = 10` exchangeable assignments, so 3 disjoint rows out of 8
+     row-runs is what no order effect at all looks like.
+  4. DIRECTION survives everywhere. Every stratum of every row-run
+     agrees with its sibling about which side of 1.0 it is on, which is
+     what the fail-closed half of the verdict tests — and it never
+     fires on any published row.
+
+  Pure arithmetic over recorded vectors: no DOM, no clock, no browser,
+  so this runs on every runtime."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.set :as set]
+            [re-frame.bench.hicasso.p0-converge-app :as app]))
+
+;; ---------------------------------------------------------------------------
+;; The published vectors
+;; ---------------------------------------------------------------------------
+
+(def ^:private published
+  "Per-round `uix-subs ÷ reagent-subs`, both floor-normalised in the same
+  round and segment — the RED-ZONE column of the studio page's table."
+  {:M1     [1.3065 1.1417 1.2388 1.1099 1.3538]
+   :M2     [1.4286 0.8572 0.8572 1.0550 1.0714]
+   :broad  [0.7172 0.6046 0.5417 0.7857 0.4701]
+   :narrow [1.2053 1.1515 1.1860 1.0570 1.1700]})
+
+(def ^:private superseded-narrow
+  "The unbatched narrow row, struck through on the page and kept here
+  because it is the row the audit's `narrow overlaps` reading came from."
+  [1.1111 1.2500 1.2500 1.0417 1.1250])
+
+(def ^:private sweep
+  "rf2-rjfz1's independent four-row reproduction sweep at `32cb224d6e`."
+  {:M1     [1.4242 1.1462 1.3611 1.3214 1.1905]
+   :M2     [1.2727 0.8000 1.0000 1.0909 1.0000]
+   :broad  [0.5750 0.5263 0.6176 0.5556 0.7353]
+   :narrow [1.2528 1.1591 1.1705 1.1507 1.1136]})
+
+(defn- v [vs] (app/segment-order-verdict vs 5))
+
+(defn- close? [a b] (< (js/Math.abs (- a b)) 0.0002))
+
+;; ---------------------------------------------------------------------------
+;; 1. The audit's M1 partition, reproduced from the published vector
+;; ---------------------------------------------------------------------------
+
+(deftest the-published-m1-partition-is-the-one-the-audit-reported
+  (testing "PR #7268's audit read the M1 red-zone rounds as Reagent-first
+           [1.3065 1.2388 1.3538] against UIx-first [1.1417 1.1099],
+           disjoint. The verdict must derive exactly that from the
+           published vector and nothing else"
+    (let [r (v (:M1 published))]
+      (is (= [1.3065 1.2388 1.3538] (:per-round (:reagent-first r))))
+      (is (= [1.1417 1.1099] (:per-round (:uix-first r))))
+      (is (false? (:strata-overlap? r)) "disjoint, as the audit reported")
+      (is (close? 1.2997 (:mean (:reagent-first r))))
+      (is (close? 1.1258 (:mean (:uix-first r)))
+          "the audit's p50 1.1258 for the UIx-first stratum")
+      (is (false? (:magnitude-resolved? r))
+          "so the row may NOT publish 1.2301 as a threshold")
+      (is (close? 1.2128 (:order-balanced-mean r))
+          "and the design-unbiased estimator is 1.2128, not 1.2301"))))
+
+(deftest the-m1-direction-survives-the-partition
+  (testing "both M1 strata sit wholly above 1.0, so UIx-slower is a
+           verdict the partition does not touch — the fail-closed half
+           does not fire"
+    (let [r (v (:M1 published))]
+      (is (= :numerator-slower (:direction (:reagent-first r))))
+      (is (= :numerator-slower (:direction (:uix-first r))))
+      (is (true? (:direction-agrees? r)))
+      (is (false? (:refuse? r))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. The same partition on the other three published rows
+;; ---------------------------------------------------------------------------
+
+(deftest m2-and-broad-overlap-and-the-current-narrow-row-does-not
+  (testing "the audit reported M2, broad AND narrow as overlapping. Two of
+           the three reproduce; the CURRENT narrow row is disjoint, and
+           only the SUPERSEDED unbatched one overlaps"
+    (is (true?  (:strata-overlap? (v (:M2 published)))))
+    (is (true?  (:strata-overlap? (v (:broad published)))))
+    (is (false? (:strata-overlap? (v (:narrow published))))
+        "the batched narrow row's strata are [1.1700-1.2053] against
+         [1.0570-1.1515] — DISJOINT, so its 1.1540 is not a threshold
+         either")
+    (is (true?  (:strata-overlap? (v superseded-narrow)))
+        "the superseded unbatched row is the one that overlaps")))
+
+;; ---------------------------------------------------------------------------
+;; 3. Which row splits disjointly is not stable across runs
+;; ---------------------------------------------------------------------------
+
+(deftest no-row-is-disjoint-in-both-runs
+  (testing "if the segment order moved a row's figure, the SAME row would
+           split in both runs. None does: M1 and narrow split in the
+           published run, broad splits in the sweep, and the intersection
+           is empty — which is what a 20%-per-row chance rate looks like"
+    (let [disjoint (fn [m] (into #{} (remove #(:strata-overlap? (v (get m %))))
+                                 [:M1 :M2 :broad :narrow]))]
+      (is (= #{:M1 :narrow} (disjoint published)))
+      (is (= #{:broad}      (disjoint sweep)))
+      (is (empty? (set/intersection (disjoint published)
+                                            (disjoint sweep)))))))
+
+(deftest the-sweep-does-not-reproduce-the-m1-split
+  (testing "the reproduction sweep's M1 strata OVERLAP — 1.3253
+           [1.1905-1.4242] against 1.2338 [1.1462-1.3214] — so the
+           disjointness the published run showed is not a property of the
+           M1 row"
+    (let [r (v (:M1 sweep))]
+      (is (true? (:strata-overlap? r)))
+      (is (true? (:magnitude-resolved? r))))))
+
+;; ---------------------------------------------------------------------------
+;; 4. Direction is the fail-closed half, and it never fires on real data
+;; ---------------------------------------------------------------------------
+
+(deftest direction-agrees-on-every-published-row-of-both-runs
+  (testing "eight row-runs, sixteen strata, and no row whose two halves
+           point opposite ways across 1.0. The gate is fail-closed and it
+           is closed"
+    (doseq [[label m] [["published" published] ["sweep" sweep]]
+            row       [:M1 :M2 :broad :narrow]]
+      (let [r (v (get m row))]
+        (is (true? (:direction-agrees? r)) (str label " " row))
+        (is (false? (:refuse? r)) (str label " " row))))))
+
+(deftest a-row-whose-halves-point-opposite-ways-is-refused
+  (testing "the gate can go red. Reagent-first rounds reading 1.4 and
+           UIx-first rounds reading 0.7 is a figure that says `slower`
+           when one segment leads and `faster` when the other does — no
+           direction to publish, and the run must not"
+    (let [r (app/segment-order-verdict [1.40 0.70 1.45 0.72 1.38] 5)]
+      (is (= :numerator-slower (:direction (:reagent-first r))))
+      (is (= :numerator-faster (:direction (:uix-first r))))
+      (is (false? (:direction-agrees? r)))
+      (is (true? (:refuse? r))))))
+
+;; ---------------------------------------------------------------------------
+;; The design, and the estimator that survives it
+;; ---------------------------------------------------------------------------
+
+(deftest five-rounds-cannot-balance-two-orders
+  (testing "an odd round count splits 3:2, so the raw mean over-weights
+           whichever order got the extra round. The verdict says so, and
+           publishes the mean of the two stratum means beside it"
+    (let [r (v (:M1 published))]
+      (is (false? (:balanced-design? r)))
+      (is (= 3 (:n (:reagent-first r))))
+      (is (= 2 (:n (:uix-first r))))))
+  (testing "at an EVEN round count the two estimators coincide by
+           construction, which is the arm-level repair available to
+           whoever re-takes the table"
+    (let [vs [1.10 1.20 1.30 1.40 1.50 1.60]
+          r  (app/segment-order-verdict vs 6)]
+      (is (true? (:balanced-design? r)))
+      (is (close? 1.35 (:order-balanced-mean r))
+          "= the raw mean of the six rounds, because 3:3 is balanced"))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
@@ -49,7 +49,8 @@
 //
 //   0  measured, guard clean, controls passed
 //   1  the run failed (build, page error, a fatal the page recorded, a
-//      positive control that did not see what it predicted)
+//      positive control that did not see what it predicted, a SEGMENT-ORDER
+//      control whose two strata point opposite ways across 1.0)
 //   2  THE ARM-ORDER GUARD REFUSED. A figure whose value depends on where
 //      in the plan it was measured is not a figure. The repair is the ARM
 //      — more warm-up, fewer arms per page, a longer window — never the
@@ -196,10 +197,11 @@ async function runRow(browser, row) {
     const err = await page.evaluate('window.HICASSO_ERROR || null');
     const refused = await page.evaluate('window.HICASSO_GUARD_REFUSED === true');
     const controlFailed = await page.evaluate('window.HICASSO_CONTROL_FAILED === true');
+    const orderRefused = await page.evaluate('window.HICASSO_ORDER_REFUSED === true');
     const results = await page.evaluate('window.HICASSO_RESULTS || {}');
     // Kept as a BACKSTOP for an error arriving in the same tick as the
     // sentinel, which the race cannot order.
-    return { row, err, refused, controlFailed, results, pageErrors: watch.failures.map((f) => `${f.kind}: ${f.detail}`) };
+    return { row, err, refused, controlFailed, orderRefused, results, pageErrors: watch.failures.map((f) => `${f.kind}: ${f.detail}`) };
   } finally {
     watch.dispose();
     await page.close();
@@ -283,6 +285,18 @@ async function runRow(browser, row) {
         `arithmetic predicts on: ${ctlFailed.map((o) => o.row.id).join(', ')}. An ` +
         `instrument that cannot see a predicted change cannot be trusted with an ` +
         `unpredicted one.`
+    );
+    process.exit(1);
+  }
+  const orderRefused = outcomes.filter((o) => o.orderRefused);
+  if (orderRefused.length > 0) {
+    console.error(
+      `[converge] FAILED: the SEGMENT-ORDER control refused on: ${orderRefused
+        .map((o) => o.row.id)
+        .join(', ')}. The row's two order strata — rounds where Reagent's segment ran ` +
+        `first, rounds where UIx's did — point OPPOSITE WAYS across 1.0, so the row has ` +
+        `no direction to publish and the figure is a measurement of the schedule. The ` +
+        `repair is the ARM: more rounds, a balanced (even) round count, a longer window.`
     );
     process.exit(1);
   }

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_app.cljs
@@ -23,7 +23,15 @@
      though it is a deterministic property, because a parity that held
      under `:none` and failed under `:advanced` would be a renaming bug
      silently deciding the comparison.
-  3. **The mount rows**, then the bulk row.
+  3. **The mount rows**, then the bulk row, with a SETTLE POINT between
+     every pair. A release that threw is fatal, and so is a release that
+     returned normally without releasing: `lane/residue` reads the
+     attached-container count and the frame's subscription ref-counts back
+     to the empty-page baseline. The settle is not politeness to the
+     assertion — a mount row is wholly synchronous and Reagent's disposals
+     are queued on a macrotask, so without it row N+1 begins on a page
+     still carrying every consumer reaction row N mounted
+     (`lane/settle!` carries the three-point measurement).
   4. **The positive control's verdict**, then the guard's.
 
   Nothing publishes until the guard has spoken. `run.cjs` prints the
@@ -66,14 +74,22 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- floor-mount-arm
-  [id element-of cells-of & [exempt?]]
-  {:id             id
-   :parity-exempt? (boolean exempt?)
-   :mount          (fn [container props _n]
-                     (let [root (react-dom-client/createRoot container)]
-                       (.render root (element-of (cells-of props)))
-                       root))
-   :unmount        (fn [root] (.unmount root))})
+  "`scale` is how many times the witness's own page this arm builds, and it
+  is ONE fact rather than two: an arm that builds a different page is
+  exactly the arm the canonical-DOM gate must exempt, so
+  `:parity-exempt?` is DERIVED from it. The two used to be independent
+  and the control was the arm that carried `exempt?` without anything
+  carrying the size — which is how its doubled page went unchecked."
+  [id element-of cells-of & [scale]]
+  (let [scale (or scale 1)]
+    {:id             id
+     :scale          scale
+     :parity-exempt? (not= 1 scale)
+     :mount          (fn [container props _n]
+                       (let [root (react-dom-client/createRoot container)]
+                         (.render root (element-of (cells-of props)))
+                         root))
+     :unmount        (fn [root] (.unmount root))}))
 
 (defn- reagent-mount-arm
   "Reagent's own mount door — `reagent.dom.client/create-root` and
@@ -96,28 +112,55 @@
   (some-> (.querySelector container sel) (.-value)))
 
 (defn- verify-m1
-  "Both ends of the list. A page that committed only its head would pass a
-  single-probe check at index 0."
-  [container]
-  (and (= "0" (lane/text-at container 0))
-       (= "0" (lane/text-at container (dec v/cells-n)))))
+  "Both ends of the list AT THE ARM'S OWN SIZE — `n` rows, so the far
+  probe is index `n - 1`.
+
+  A page that committed only its head would pass a single-probe check at
+  index 0. A CONTROL that rendered only its base prefix would pass a check
+  at index 299 — which is what the probe was, fixed at the witness's
+  `cells-n` for every arm, so the one arm whose whole purpose is to be
+  twice the page was the one arm nothing checked past its first half."
+  [n]
+  (fn [container]
+    (and (= "0" (lane/text-at container 0))
+         (= "0" (lane/text-at container (dec n))))))
 
 (defn- verify-m2
-  "The first and last field of the SHARED prefix — the control arm has
-  twice the fields, so a probe past `fields-n` would not exist in every
-  arm."
-  [container]
-  (and (= (v/field-value 0 0) (input-value container "#f0"))
-       (= (v/field-value (dec v/fields-n) 0)
-          (input-value container (str "#f" (dec v/fields-n))))))
+  "The first and last field AT THE ARM'S OWN SIZE — `n` fields, so the far
+  probe is `#f(n-1)`. Fixed at the witness's `fields-n` it read the SHARED
+  PREFIX and could not tell a doubled form from a base one."
+  [n]
+  (fn [container]
+    (and (= (v/field-value 0 0) (input-value container "#f0"))
+         (= (v/field-value (dec n) 0)
+            (input-value container (str "#f" (dec n)))))))
+
+(defn- expectation
+  "What THIS arm's page must contain: the witness's own arithmetic applied
+  to the arm's `:scale`, as `{:elements n :verify f}`.
+
+  There is no exemption. `measure-mount!` used to read
+  `(if (:parity-exempt? arm) nil elements)` and skip the element count for
+  the control, while the probes read indices that exist in the base page —
+  so the `:ctl-2x` arm was the ONE arm in the plan whose page was never
+  checked, and a control that rendered only its base prefix passed. The
+  control's whole claim is that it is exactly twice the page; scaling both
+  the count and the far probe is what makes that claim load-bearing rather
+  than asserted."
+  [{:keys [elements-of verify-of props]} arm]
+  (let [n (* (or (:scale arm) 1) (:n props))]
+    {:elements (elements-of n)
+     :verify   (verify-of n)}))
+
+(defn- base-elements [{:keys [elements-of props]}] (elements-of (:n props)))
 
 (def ^:private mount-witnesses
-  [{:id       :M1
-    :verify   verify-m1
+  [{:id          :M1
+    :verify-of   verify-m1
+    :elements-of v/m1-elements
     :doc      (str "the 300-boundary sub-reading list — the bulk shape's mount "
                    "counterpart, one subscription read per boundary")
     :props    {:n v/cells-n}
-    :elements (v/m1-elements v/cells-n)
     :control  {:predicted (/ (double (v/m1-elements (* 2 v/cells-n)))
                              (double (v/m1-elements v/cells-n)))
                :basis     (str "element count: " (v/m1-elements (* 2 v/cells-n)) " / "
@@ -126,10 +169,11 @@
            (reagent-mount-arm :reagent-subs
                               (fn [{:keys [n]}] [v/subs-root v/m1-subs n]))
            (reagent-mount-arm :reagent-ratom (fn [{:keys [n]}] [v/m1-ratom n]))
-           (floor-mount-arm :ctl-2x v/m1-floor (fn [{:keys [n]}] (zeros (* 2 n))) true)]}
+           (floor-mount-arm :ctl-2x v/m1-floor (fn [{:keys [n]}] (zeros (* 2 n))) 2)]}
 
-   {:id         :M2
-    :verify     verify-m2
+   {:id          :M2
+    :verify-of   verify-m2
+    :elements-of v/m2-elements
     ;; ONE mount per sample, and the batching that would have lifted this
     ;; witness clear of Chrome's 100 µs clamp is NOT USED. It was tried —
     ;; eight mounts in one `flushSync` — and THE ARM-ORDER GUARD REFUSED
@@ -158,7 +202,6 @@
     :doc      (str "the ordinary 12-field form on subs — the shape most "
                    "applications are made of")
     :props    {:n v/fields-n}
-    :elements (v/m2-elements v/fields-n)
     :control  {:predicted (/ (double (v/m2-elements (* 2 v/fields-n)))
                              (double (v/m2-elements v/fields-n)))
                :basis     (str "element count: " (v/m2-elements (* 2 v/fields-n)) " / "
@@ -167,18 +210,19 @@
            (reagent-mount-arm :reagent-subs
                               (fn [{:keys [n]}] [v/subs-root v/m2-subs n]))
            (reagent-mount-arm :reagent-ratom (fn [{:keys [n]}] [v/m2-ratom n]))
-           (floor-mount-arm :ctl-2x v/m2-floor (fn [{:keys [n]}] (zeros (* 2 n))) true)]}])
+           (floor-mount-arm :ctl-2x v/m2-floor (fn [{:keys [n]}] (zeros (* 2 n))) 2)]}])
 
 ;; ---------------------------------------------------------------------------
 ;; Bulk arms — mounted once, then written to
 ;; ---------------------------------------------------------------------------
 
 (defn- floor-bulk-arm
-  [id n & [exempt?]]
+  [id n & [scale]]
   (let [state (atom (zeros n))
         rt    (volatile! nil)]
     {:id             id
-     :parity-exempt? (boolean exempt?)
+     :scale          (or scale 1)
+     :parity-exempt? (not= 1 (or scale 1))
      :cells          n
      :mount          (fn [container]
                        (let [root (react-dom-client/createRoot container)]
@@ -230,17 +274,48 @@
   [(floor-bulk-arm :floor v/cells-n)
    (subs-bulk-arm)
    (ratom-bulk-arm)
-   (floor-bulk-arm :ctl-2x (* 2 v/cells-n) true)])
+   (floor-bulk-arm :ctl-2x (* 2 v/cells-n) 2)])
 
-(defn- mount-bulk-arms! [arms]
+(defn- mount-bulk-arms!
+  "Mount every bulk arm once and CHECK THE PAGE IT BUILT, before a clock is
+  read.
+
+  Every bulk arm declares `:cells`, and `v/m1-elements` turns that into an
+  element count by written arithmetic — so this one line is what makes the
+  bulk `:ctl-2x` arm's doubled page load-bearing. Its far-end read-back
+  already derives from `:cells` (`lane/bulk-probes` probes index
+  `cells - 1`), so a control shrunk to the base 300 cells would still have
+  probed a cell it owns; the count is the check that cannot be satisfied by
+  a smaller page. Outside every timed window: the arms are mounted once and
+  written to thereafter."
+  [arms]
   (mapv (fn [a]
-          (let [c (lane/fresh-container!)]
-            {:arm a :container c :handle ((:mount a) c)}))
+          (let [c        (lane/fresh-container!)
+                handle   ((:mount a) c)
+                expected (v/m1-elements (:cells a))
+                got      (lane/element-count c)]
+            (when-not (= expected got)
+              (throw (ex-info (str "the bulk arm " (:id a) " built " got
+                                   " elements where its own " (:cells a)
+                                   " cells make " expected)
+                              {:arm (:id a) :expected expected :got got})))
+            {:arm a :container c :handle handle}))
         arms))
 
-(defn- release-bulk-arms! [mounts]
+(defn- release-bulk-arms!
+  "Release every bulk arm. A throw is RECORDED, never swallowed.
+
+  `(catch :default _ nil)` was here, and the arm it hid is the one that
+  matters most: the bulk arms stand for a whole row, so an unmount that
+  threw leaves three hundred subscribing boundaries watching the app-db
+  while every later sample is measured on top of them. The caller
+  adjudicates with `lane/assert-teardown-clean!` and proves the release
+  with `lane/assert-residue!`."
+  [mounts]
   (doseq [{:keys [arm handle container]} mounts]
-    (try ((:unmount arm) handle) (catch :default _ nil))
+    (try ((:unmount arm) handle)
+         (catch :default e
+           (lane/teardown-failure! (str "release-bulk-arms! " (:id arm)) e)))
     (.remove container)))
 
 ;; ---------------------------------------------------------------------------
@@ -262,32 +337,39 @@
                            "frame. (subs - ratom) is the price of the reactive system")
    :control-note      (str "the :ctl-2x arm is the same floor page at exactly twice the "
                            "boundaries. Its prediction is arithmetic on the element count "
-                           "and is written down before the run; it is parity-exempt "
-                           "because it builds a different page on purpose")})
+                           "and is written down before the run; it is exempt from the "
+                           "canonical-DOM EQUALITY because it builds a different page on "
+                           "purpose, and NOT exempt from arithmetic — every one of its "
+                           "mounts is checked against its own doubled element count and "
+                           "probed at its own far end, so a control that rendered only "
+                           "the base prefix fails before any figure is reportable")})
 
 ;; ---------------------------------------------------------------------------
 ;; Mount
 ;; ---------------------------------------------------------------------------
 
 (defn- measure-mount!
-  [{:keys [id doc props arms elements control verify per-sample clock-note]}]
-  (let [k     (or per-sample 1)
-        t     (lane/tally)
+  [{:keys [id doc props arms control per-sample clock-note] :as witness}]
+  (let [k        (or per-sample 1)
+        t        (lane/tally)
+        elements (base-elements witness)
+        expect   (into {} (map (juxt :id #(expectation witness %))) arms)
         one!  (fn [arm]
                 (let [{:keys [ms mounts]} (lane/mount-batch! arm props k)
-                      expected (if (:parity-exempt? arm) nil elements)]
+                      {exp-elements :elements verify :verify} (get expect (:id arm))]
                   ;; EVERY mount in the batch is read back out of the
-                  ;; document. `verify` is PER WITNESS because the probe has
-                  ;; to exist in the witness — the first cut of this
-                  ;; instrument read a `data-i` cell in both witnesses, the
-                  ;; form has no such attribute, and the M2 row published
-                  ;; `400 unverified of 400` while the page was in fact
-                  ;; perfectly correct. A read-back that cannot pass is worse
-                  ;; than none: it manufactures a defect and would hide a real
-                  ;; one behind it.
+                  ;; document, against THIS ARM'S OWN arithmetic. `verify` is
+                  ;; per witness because the probe has to exist in the witness
+                  ;; — the first cut of this instrument read a `data-i` cell in
+                  ;; both witnesses, the form has no such attribute, and the M2
+                  ;; row published `400 unverified of 400` while the page was in
+                  ;; fact perfectly correct. A read-back that cannot pass is
+                  ;; worse than none: it manufactures a defect and would hide a
+                  ;; real one behind it. It is per ARM because the control is
+                  ;; twice the page and a probe fixed at the witness's size
+                  ;; cannot tell it from the base one.
                   (doseq [m mounts]
-                    (let [ok? (and (or (nil? expected)
-                                       (= expected (lane/element-count (:container m))))
+                    (let [ok? (and (= exp-elements (lane/element-count (:container m)))
                                    (verify (:container m)))]
                       (swap! t (fn [{:keys [of bad]}]
                                  {:of (inc of) :bad (if ok? bad (inc bad))}))))
@@ -313,6 +395,11 @@
                                    :props    props
                                    :elements elements
                                    :arms     (mapv :id arms)
+                                   ;; PER ARM, so a reader can see that the
+                                   ;; control was held to 1,801/99 and not to
+                                   ;; the base page's 901/51.
+                                   :expected-elements
+                                   (into {} (map (fn [[k' e]] [k' (:elements e)])) expect)
                                    :mounts-per-sample k
                                    :measurement-method
                                    (str "a SAMPLE is " k " mount(s) inside ONE "
@@ -331,8 +418,12 @@
                                         "not vary adjacency at all); " rounds " rounds of "
                                         (:warmup mount-sampling) " warm-up + "
                                         (:samples mount-sampling) " samples per arm per "
-                                        "round; every measured mount's element count and "
-                                        "first cell read back out of the DOM")})
+                                        "round; every measured mount read back out of the "
+                                        "DOM against THAT ARM'S OWN arithmetic — its exact "
+                                        "element count, and both ends of the page it "
+                                        "claims to build, so the doubled control is "
+                                        "checked at its own far end and not at the base "
+                                        "page's")})
          :sampling         mount-sampling
          :verification     (lane/tally-value t)
          :positive-control (assoc ctl :basis (:basis control))
@@ -342,6 +433,7 @@
          :reactive-leg     (lane/ratio-between ratios :reagent-subs :reagent-ratom)
          :status           :evidence}]
     (lane/record! (str "mount-" (name id)) record)
+    (lane/assert-verified! t (str "mount row " (name id)))
     {:id id :record record :samples samples :control ctl}))
 
 ;; ---------------------------------------------------------------------------
@@ -463,23 +555,41 @@
                    :reactive-leg     (lane/ratio-between ratios :reagent-subs :reagent-ratom)
                    :status           :evidence}]
               (lane/record! "bulk-broad" record)
+              (lane/assert-verified! t "the bulk row")
               {:record record :samples (:samples @coll) :control ctl}))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Parity
 ;; ---------------------------------------------------------------------------
 
-(defn- parity-problems []
+(defn- parity-problems
+  "Canonical-DOM equality across the judged arms, and the element count of
+  EVERY arm — the control included — against its own arithmetic.
+
+  The count used to be checked only over `lane/parity`'s `counts` map,
+  which excludes the parity-exempt arms by design, so the one arm building
+  a deliberately different page had that page checked nowhere. Exempt from
+  the EQUALITY is not exempt from arithmetic: the control is exempt
+  because its page differs, and the size it differs BY is the claim it
+  exists to make."
+  []
   (reduce
-    (fn [problems {:keys [id props arms elements]}]
-      (let [{:keys [mounts agree? counts disagree]} (lane/parity arms props)]
+    (fn [problems {:keys [id props arms] :as witness}]
+      (let [{:keys [mounts agree? disagree]} (lane/parity arms props)
+            wrong (into {}
+                        (comp (map (fn [{:keys [arm container]}]
+                                     [(:id arm)
+                                      {:expected (:elements (expectation witness arm))
+                                       :got      (lane/element-count container)}]))
+                              (remove (fn [[_ {:keys [expected got]}]] (= expected got))))
+                        mounts)]
         (try
           (cond-> problems
             (not agree?)
             (conj {:witness id :problem :canonical-dom-disagreement :arms disagree})
 
-            (not (every? #(= elements %) (vals counts)))
-            (conj {:witness id :problem :element-count :expected elements :got counts}))
+            (seq wrong)
+            (conj {:witness id :problem :element-count :arms wrong}))
           (finally (doseq [m mounts] (lane/release! m))))))
     []
     mount-witnesses))
@@ -487,6 +597,22 @@
 ;; ---------------------------------------------------------------------------
 ;; The run
 ;; ---------------------------------------------------------------------------
+
+(defn- settled!
+  "Let the substrate's disposal queue run, then adjudicate the two things a
+  released row owes: that nothing threw on the way out, and that the
+  release actually happened. Answers a promise of the residue reading.
+
+  Between rows, never inside a window. A row measured on top of the
+  previous row's un-released boundaries is the same class of fault as a
+  write that never reached the page, and this is where it is caught — see
+  [[lane/settle!]] for why the yield is load-bearing rather than a
+  courtesy to the assertion."
+  [baseline after]
+  (-> (lane/settle!)
+      (.then (fn [_]
+               (lane/assert-teardown-clean! after)
+               (lane/assert-residue! baseline v/subs-frame after)))))
 
 (defn- finish!
   [{:keys [samples controls]}]
@@ -516,25 +642,53 @@
                            "rule no longer behaves like the one the .cjs drivers use, "
                            "so nothing was measured"))
           (lane/done!))
-      (let [problems (parity-problems)]
+      ;; The residue this run must return to after every row. Taken before
+      ;; the first mount of the run, so it is the empty-page, empty-cache
+      ;; reading and not a reading of whatever the previous row left.
+      (let [baseline (lane/residue v/subs-frame)
+            problems (parity-problems)]
         (lane/record! "parity" {:problems problems :ok? (empty? problems)})
+        (lane/record! "residue-baseline" baseline)
         (if (seq problems)
           (do (lane/fail! (str "the arms do not build the same page under :advanced — "
                                (pr-str problems)))
               (lane/done!))
-          (let [mounted (mapv measure-mount! mount-witnesses)
-                bulk    (mount-bulk-arms! (make-bulk-arms))]
-            (-> (measure-bulk! bulk)
-                (.then (fn [b]
-                         (release-bulk-arms! bulk)
-                         (finish! {:samples  (into (vec (mapcat :samples mounted))
-                                                   (:samples b))
-                                   :controls (conj (mapv :control mounted) (:control b))})
-                         nil))
-                (.catch (fn [e]
-                          (release-bulk-arms! bulk)
-                          (lane/fail! (str "the bulk row rejected: " e))
-                          (lane/done!))))))))
+          ;; The rows are CHAINED rather than folded, so a settle point sits
+          ;; between every pair of them. See `lane/settle!`: a mount row is
+          ;; wholly synchronous, Reagent's disposals are on a macrotask
+          ;; queue, and without the yield row N+1 begins on a page still
+          ;; carrying every consumer reaction row N mounted.
+          (-> (settled! baseline "parity")
+              (.then (fn [_]
+                       (lane/chain []
+                                   mount-witnesses
+                                   (fn [acc w]
+                                     (let [r (measure-mount! w)]
+                                       (-> (settled! baseline
+                                                     (str "mount row " (name (:id w))))
+                                           (.then (fn [_] (conj acc r)))))))))
+              (.then (fn [mounted]
+                       (let [bulk (mount-bulk-arms! (make-bulk-arms))]
+                         (-> (measure-bulk! bulk)
+                             (.then (fn [b]
+                                      (release-bulk-arms! bulk)
+                                      (-> (settled! baseline "the bulk row")
+                                          (.then (fn [res]
+                                                   (lane/record! "residue-after-bulk" res)
+                                                   (finish!
+                                                     {:samples
+                                                      (into (vec (mapcat :samples mounted))
+                                                            (:samples b))
+                                                      :controls
+                                                      (conj (mapv :control mounted)
+                                                            (:control b))})
+                                                   nil)))))
+                             (.catch (fn [e]
+                                       (release-bulk-arms! bulk)
+                                       (throw e)))))))
+              (.catch (fn [e]
+                        (lane/fail! (str "the run rejected: " e))
+                        (lane/done!)))))))
     (catch :default e
       (lane/fail! (str "the run threw: " e))
       (lane/done!))))


### PR DESCRIPTION
Two beads, one defect and one open question.

## 1. The control that could not fail (rf2-2rtt6.2 item 1, rf2-a4x1o item 1)

The `:ctl-2x` positive control's whole claim is *this is exactly twice the page*. **Nothing tested it.** Three gates each excused it, on both P0 entries:

| gate | what it did | why the control slipped through |
|---|---|---|
| per-mount element count | `expected (if (:parity-exempt? arm) nil elements)` | `nil` for every exempt arm |
| per-mount content probe | `verify-m1` read indices 0 / 299; `verify-m2` the shared 12-field prefix | both exist in a 600-row page **and** a 300-row one |
| canonical-DOM parity | compared counts over `lane/parity`'s `counts` map | that map **excludes parity-exempt arms by construction** |

So 200 measured control mounts contributed to `0 unverified of 1,220` without the doubling being checked anywhere.

**Repair.** `:parity-exempt?` is now *derived* from a new `:scale`, so an arm's size and its exemption are one fact. `expectation` holds every arm — control included — to the witness's arithmetic at *its own* scale: **1,801 / 99 elements, far probe at index 599 / field 23**. Bulk arms are element-counted at mount from their own `:cells`. Exempt from the canonical-DOM *equality* is not exempt from *arithmetic*.

**And a third finding that made the first two possible: `unverified > 0` never failed the run.** The tally was published and never adjudicated — a row could report `400 unverified of 400` and the driver still exit 0. `lane/assert-verified!` closes it.

### Mutation-proved, three ways

| mutation | outcome | exit |
|---|---|---|
| M1 `:ctl-2x` renders `(zeros n)` | refused at **parity, before any clock** — `{:ctl-2x {:expected 1801, :got 901}}` | **1** |
| the same control shrinks **only after parity** (parity passes: `{:problems [] :ok? true}`) | refused on the **measured path** — `mount row M1: 100 UNVERIFIED of 400`, exactly the 100 control mounts | **1** |
| **bulk** `:ctl-2x` renders its base 300 cells while declaring 600 | `the bulk arm :ctl-2x built 901 elements where its own 600 cells make 1801` | **1** |

## 2. Teardown: loud, and proved (rf2-2rtt6.2 item 2)

`release-bulk-arms!` was `(try ((:unmount arm) handle) (catch :default _ nil))` with no residue assertion. Now: throws are recorded (`lane/teardown-failure!`) and adjudicated between rows (`lane/assert-teardown-clean!`, lifted out of `p0_converge_app`), and a release that returned *without releasing* is caught by `lane/residue` — attached containers, sub-cache entries, summed ref-counts, compared by **equality**.

**It went red on its first run, and the finding is not a leak.** After parity the cache held **300 entries / ref-count 312** immediately *and* after `reagent.core/flush`, and **0 / 0** one macrotask later — Reagent's disposals are on `reagent.impl.batching`'s next-tick queue. But a mount row is wholly synchronous, so **a hundred mount-and-release cycles ran with not one disposal inside them**, and each row began on a page carrying the previous row's consumer reactions. The rows are now **chained with a settle point between them** — that is as much the repair as the assertion.

## 3. The order warrant (rf2-a4x1o item 2) — **1.2301 is NOT warranted; the hold stands**

`lane/guard!` adjudicates arms *inside* a segment; the red-zone is a ratio *across* the seam. `segment-order-verdict` now partitions it by which segment ran first and splits the answer, because the halves fail separately: **direction is fail-closed** (opposite strata → `HICASSO_ORDER_REFUSED`, exit 1); **magnitude is publishable only when the strata overlap**, starting from false.

- The audit's M1 partition **reproduces exactly**: Reagent-first `1.2997 [1.2388–1.3538]` vs UIx-first `1.1258 [1.1099–1.1417]`, **disjoint**.
- **One correction to the audit's reading:** the *current batched* narrow row is disjoint too (`[1.1700–1.2053]` vs `[1.0570–1.1515]`). Only the **superseded unbatched** row overlaps. The exposure was never bounded to M1.
- **Per-row disjointness is weak evidence** — at 3:2 it arises **20% of the time under the null**, and no row is disjoint in two runs. **The sign is not:** across three independent five-round runs the figure reads higher Reagent-first in **11 of 12 row-runs, p = 0.0032.** There *is* a systematic segment-order effect, and the 3:2 Reagent-first-heavy design biases every published threshold upward 1–2%. `:order-balanced-mean` is now published on every row.

**Verdict.** `1.2301` is biased by the design, sits between two strata that do not meet, and has four estimates — `1.2301 / 1.2103 / 1.2887 / 1.1397` — the last of which **straddles 1.0** on this branch's own run. The row supports **a direction and a range: UIx slower on M1 mount, ≈1.11–1.35×**. Narrow's magnitude is withdrawn on the same test. **`0.6239×` broad stands** — direction survives in all six strata of all three runs — balanced `0.6357`.

**No published figure is deleted or rewritten.** Two magnitudes are marked withdrawn in place; the studio page carries what would have been appended to the size-locked `rf2-2rtt6.1` (`rf2-0znkn`).

`rf2-egdaq`'s strict control rule is **not** installed. The order-guard tolerance is untouched.

## Quality gates

| gate | exit |
|---|---|
| `node implementation/freehand/test/re_frame/bench/hicasso/run.cjs` (Reagent baseline arm, full) | **0** |
| `node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` (converged, 4 rows) | **0** |
| arm-order guard self-test (inside both runs) | **0** — 8/8, `refuse? false / contaminated? false / unchecked? false` |
| `npm run test:cljs` — 11,963 tests / 59,695 assertions | **0** |
| `npm run test:browser` — 851 tests / 5,503 assertions | **0** |
| `npm run test:freehand` — 1,399 tests / 7,752 assertions | **0** |
| `npm run test:script-policy` | **0** |
| `python -m mkdocs build --strict` | **0** |
| mutation A — mount control renders base prefix | **1** (intended) |
| mutation B — bulk control renders base prefix | **1** (intended) |
| mutation C — control shrinks after parity | **1** (intended) |

**Verification: `0 unverified of 1,220`** (Reagent arm) and **`0 unverified of 7,860`** (converged) — and `unverified > 0` now fails the run.

Reagent arm rows all reproduce: M1 bar-row `4.029 [3.429–4.733]` vs published `3.899 [3.447–4.300]`; reactive leg `1.271 [1.200–1.326]` vs `1.218 [1.122–1.310]`; bulk leg `2.170 [2.000–2.286]` vs `2.008 [1.938–2.100]`.

Closes rf2-2rtt6.2, rf2-a4x1o.
