### PR TITLE
bench(hicasso): the retention rig refuses a misspelt collector; P0_BUILD rides the landed lane id (rf2-flqpd, rf2-etmyc)

### DIFF
--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -22,15 +22,20 @@
 // ## No shadow-cljs.edn change, deliberately
 //
 // The epic's SEQUENCING LAW makes `implementation/shadow-cljs.edn`
-// build-id touches hot-zone sequenced, and rf2-2rtt6.2 owns that file for
-// this wave. So this driver does what `b6_prod_run.cjs` and `b7_run.cjs`
-// already do: it merges an output directory and an `:init-fn` into an
-// EXISTING `:advanced` `:browser` build id, which contributes nothing but
-// its compiler settings — `:target :browser`, `:optimizations :advanced`,
-// `:infer-externs :auto`, `goog.DEBUG false`. The module's entry, and
-// therefore everything that ends up in the bundle, is this arm's.
-// `P0_BUILD` overrides the donor id: when rf2-2rtt6.2's measurement-lane
-// build id lands, point this at it and delete this paragraph.
+// build-id touches hot-zone sequenced. So this driver does what
+// `b6_prod_run.cjs` and `b7_run.cjs` already do: it merges an output
+// directory and an `:init-fn` into an EXISTING `:advanced` `:browser`
+// build id, which contributes nothing but its compiler settings —
+// `:target :browser`, `:optimizations :advanced`, `:infer-externs :auto`,
+// `goog.DEBUG false`. The module's entry, and therefore everything that
+// ends up in the bundle, is this arm's. The default id is rf2-2rtt6.2's
+// measurement lane, `:hicasso-bench` — the id the lane landed for exactly
+// this ride — and `P0_BUILD` overrides it. One id serves N programs, so
+// the driven id's cache entry is cleared before every build
+// (`lane_cache.cjs`, rf2-2rtt6.20): a sibling arm's stale `shadow-js/`
+// index compiles clean and dies at runtime under `:advanced`, and the
+// trap is the ride itself — a foreign `:init-fn` merged onto an existing
+// id — not any one donor.
 //
 // ## The heap row runs HERE and the clock row runs in the page
 //
@@ -89,9 +94,12 @@ const fs = require('node:fs');
 const http = require('node:http');
 const path = require('node:path');
 
+// One build id, N programs, so nothing may cache between them (rf2-2rtt6.20).
+const { resetLaneBuildCache } = require('../../../../freehand/test/re_frame/bench/hicasso/lane_cache.cjs');
+
 const IMPL = path.resolve(__dirname, '../../../..');
 
-const BUILD = process.env.P0_BUILD || 'freehand-release';
+const BUILD = process.env.P0_BUILD || 'hicasso-bench';
 const OUT_DIR = process.env.P0_OUT_DIR || 'out/p0-hicasso';
 const OUT = path.join(IMPL, OUT_DIR);
 const INIT_FN = process.env.P0_INIT_FN || 're-frame.bench.p0-app/-main';
@@ -138,6 +146,13 @@ const CONFIG_MERGE =
   `{:output-dir "${OUT_DIR}" :asset-path "." :modules {:main {:init-fn ${INIT_FN}}}}`;
 
 function build() {
+  // The lane's cache rule, before anything reads the cache: this driver
+  // merges its own `:init-fn` onto `BUILD`, so `BUILD`'s cache entry was
+  // written by a different program. `lane_cache.cjs` carries the measured
+  // fault and the rejected alternatives (rf2-2rtt6.20).
+  if (resetLaneBuildCache(IMPL, BUILD)) {
+    console.error(`[p0] cleared .shadow-cljs/builds/${BUILD} — one build id, N arms (rf2-2rtt6.20)`);
+  }
   console.error(`[p0] building :advanced bundle (donor build id: ${BUILD}) ...`);
   // `node cli/runner.js` rather than the `.cmd` shim: spawning a shim on
   // Windows needs `shell: true`, and a shell concatenates argv, which is

--- a/implementation/freehand/test/re_frame/bench/hicasso/retention_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/retention_run.cjs
@@ -52,7 +52,9 @@
 //      scope rather than quietly passing a vacuous `0 of 0`;
 //   4. every reading is a reading — a numeric sub-cache count, a heap
 //      figure, and `window.gc` present whenever `RETENTION_COLLECT` asks
-//      the PAGE to collect;
+//      the PAGE to collect — and `RETENTION_COLLECT` itself names a real
+//      collector, refused up front on a typo, because a misspelt one
+//      forces no collection and certifies uncollected heap as collected;
 //   5. the probe completed at all — `P0H.prepare` now RAISES with the
 //      failing teardown phase named, instead of swallowing it.
 //
@@ -119,6 +121,33 @@ const COLLECT = process.env.RETENTION_COLLECT || 'both';
 // `all` (default) | repro — the two cheap series are worth running once,
 // not on every variant of the collector question.
 const ONLY = process.env.RETENTION_ONLY || 'all';
+
+// THE ENUMS REFUSE A TYPO, before anything is built or measured. `collect()`
+// matches these strings and silently does NOTHING on any other, so an
+// unvalidated `RETENTION_COLLECT=bogus` performed no forced collection at
+// all while the header still printed it as the collector forcing every
+// COLLECTED reading — and the run exited 0, certifying UNCOLLECTED heap as
+// collected. Proven at the landed head with the one-cycle `repro` shape
+// (rf2-flqpd, merged-PR audit #7281). `none` stays a legal answer: asking
+// for no collector is a question this probe exists to compare, and is
+// nothing like failing to name one. `RETENTION_ONLY` is the same trap one
+// door over — a typo there silently narrows the run to `repro` — so it is
+// held to the same rule.
+for (const [name, value, legal] of [
+  ['RETENTION_COLLECT', COLLECT, ['both', 'page', 'cdp', 'none']],
+  ['RETENTION_ONLY', ONLY, ['all', 'repro']],
+]) {
+  if (!legal.includes(value)) {
+    console.error(
+      `[ret] FAILED: ${name}=${JSON.stringify(value)} is not one of ` +
+        `${legal.join(' | ')} — refusing before anything is measured. Without ` +
+        `this gate an unrecognised value does not stop the run: a misspelt ` +
+        `collector forces NO collection and certifies uncollected heap as ` +
+        `COLLECTED; a misspelt scope silently narrows the run to repro.`
+    );
+    process.exit(1);
+  }
+}
 
 const CONFIG_MERGE =
   `{:output-dir "${OUT_DIR}" :asset-path "." :modules {:main {:init-fn ${INIT_FN}}}}`;


### PR DESCRIPTION
## What this is

Two bounded edits to the P0 lane's instruments, one per bead.

**rf2-flqpd** — merged-PR audit #7281 kept this owner open for one proven fail-open door: `retention_run.cjs`'s `collect()` matches the `RETENTION_COLLECT` enum strings and silently does NOTHING on any other, so `RETENTION_COLLECT=bogus` performed no forced collection while the header still printed it as the collector forcing every COLLECTED reading — and the run exited 0, a typo certifying uncollected heap as collected. The enum is now validated **before anything is built or measured**; the audit's exact one-cycle repro refuses with the value and the legal set named. `RETENTION_ONLY` is the same trap one door over (a typo silently narrowed the run to `repro`) and is held to the same rule. `none` stays legal — asking for no collector is a question the probe exists to compare, nothing like failing to name one.

**rf2-etmyc** — `p0_run.cjs` still instructed "when rf2-2rtt6.2's measurement-lane build id lands, point this at it and delete this paragraph". The lane id landed, so the default donor is now `:hicasso-bench` and the paragraph is gone. Because one id serves N programs, the driven id's cache entry is cleared before every build (`lane_cache.cjs`, rf2-2rtt6.20) — without that, retargeting would have armed the exact stale-`shadow-js/` trap that bead closed for the lane's other three drivers. rf2-2rtt6.1 keeps this driver as the reproduction path for rf2-2rtt6.4's OPERATIVE retained-heap thresholds, so the bead's condition — verify the heap rows still reproduce at the new target before retargeting — was met before landing (gates below): the operative list 2.262x and grid 2.254x both sit inside the ranges measured at the new default.

The studio bullet recording the new gate on `p0-uix-on-subs-frontier-arm.md` is deliberately **not** in this PR — that page is an in-flight worker's surface right now; a follow-up bead carries it.

## Quality gates

No CI gate consumes these two drivers (checked `.github/workflows/` and `implementation/package.json`); the drivers' own runs are the gates, all foreground to completion:

- `node --check` on both drivers — pass, exit 0.
- Audit #7281's exact repro, `RETENTION_COLLECT=bogus RETENTION_ONLY=repro RETENTION_REPRO_SEGMENTS=1 RETENTION_REPRO_CYCLES=1 RETENTION_REPRO_ROOTS=1 node .../retention_run.cjs --no-build` — now REFUSES before measurement, exit 1 (was exit 0 at the landed head).
- `RETENTION_ONLY=all-series ... --no-build` — refuses, exit 1.
- `RETENTION_COLLECT=none` one-cycle repro, `--no-build` — still runs, exit 0.
- Full default retention run (cold cache, `:advanced` build + SERIES A/B/C): exit 0, every validity gate green, census positive control 6 of 6, and the landed finding reproduced — collected column climbs 0.89 MB total across six segments, uncollected sawtooths 17.9/85.3/30.8/83.1/30.5/82.5 MB.
- `node implementation/core/test/re_frame/bench/p0_run.cjs --only heap` at the new default (full 6-round shape): exit 0, positive control ratio 1.0001, 0 unverified of 56 mounts, arm-order guard reportable, EXCLUSIVE list 2.2658x [2.1894–2.3408] and grid 2.2460x [2.2185–2.2867] against the operative 2.262x / 2.254x.