### PR TITLE
bench(hicasso): every taken control and fidelity leg now gates the ablation exit (rf2-2rtt6.12)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs
@@ -44,6 +44,15 @@
 //     passed.
 //   * A FAILED UNMOUNT was swallowed by the page and reported as success,
 //     which converts a live subscription into measurement state.
+//   * AND THE FIRST CUT OF THESE GATES was itself fail-open at the edges
+//     (PR #7272 audit): reader B's control error was printed and never
+//     adjudicated; `Number.isFinite(x) && x < FLOOR` waved a NaN control or
+//     fit through the band tests; and a fidelity leg the run failed to
+//     measure was filtered out rather than failed, so with both legs absent
+//     main iterated an empty failure list and exited 0. Now every TAKEN
+//     A/B/C control must be finite and in band, both required fidelity legs
+//     must be present and finite, and every required r2 must be finite and
+//     at or above the floor.
 //
 // EXIT CODES
 //   0  reportable
@@ -541,36 +550,47 @@ async function runSubstrate(chromium, substrate) {
     }
   }
 
-  // The in-situ control, on every reader that took one.
-  for (const r of rounds) {
-    if (Math.abs(r.control.errorCdp) > CONTROL_BAND) {
+  // The in-situ control, on EVERY reader that took one — A and B each round,
+  // C each snapshot round. The first cut adjudicated A and C only, so reader
+  // B's error was printed in the report and never gated exit 0; and a band
+  // test alone is a bypass for a control that came back NaN, because
+  // `Math.abs(NaN) > band` is false. A control that did not produce a finite
+  // number has not controlled anything.
+  const controlGate = (label, err) => {
+    if (!Number.isFinite(err)) {
+      gateFailures.push(`${label} control is not finite (${err})`);
+    } else if (Math.abs(err) > CONTROL_BAND) {
       gateFailures.push(
-        `round ${r.round} reader-A control off by ${(r.control.errorCdp * 100).toFixed(3)}% ` +
+        `${label} control off by ${(err * 100).toFixed(3)}% ` +
           `(band ${(CONTROL_BAND * 100).toFixed(1)}%)`
       );
     }
+  };
+  for (const r of rounds) {
+    controlGate(`round ${r.round} reader-A`, r.control.errorCdp);
+    controlGate(`round ${r.round} reader-B`, r.control.errorPerf);
   }
   for (const r of snapRounds) {
-    if (Math.abs(r.control.error) > CONTROL_BAND) {
-      gateFailures.push(
-        `snapshot round ${r.round} reader-C control off by ${(r.control.error * 100).toFixed(3)}% ` +
-          `(band ${(CONTROL_BAND * 100).toFixed(1)}%)`
-      );
-    }
+    controlGate(`snapshot round ${r.round} reader-C`, r.control.error);
   }
 
   const variants = variantCurves(arms, rounds, snapRounds);
 
-  // A slope is only a per-read cost if the rungs carry a line.
+  // A slope is only a per-read cost if the rungs carry a line — and a fit
+  // that came back NaN is not a line above the floor, it is no line at all.
+  // The first cut tested `Number.isFinite(x) && x < FLOOR`, which waves a
+  // non-finite fit through. Bytes r2 comes from the main rounds and is always
+  // required; objects r2 exists only when reader C was asked for.
+  const r2Gate = (label, r2min) => {
+    if (!Number.isFinite(r2min)) {
+      gateFailures.push(`${label} is not finite (${r2min}) — no line was fitted`);
+    } else if (r2min < R2_FLOOR) {
+      gateFailures.push(`${label} ${r2min.toFixed(5)} below the ${R2_FLOOR} floor`);
+    }
+  };
   for (const [v, c] of Object.entries(variants)) {
-    if (Number.isFinite(c.r2.min) && c.r2.min < R2_FLOOR) {
-      gateFailures.push(`variant ${v}: bytes r2 ${c.r2.min.toFixed(5)} below the ${R2_FLOOR} floor`);
-    }
-    if (Number.isFinite(c.objectsR2.min) && c.objectsR2.min < R2_FLOOR) {
-      gateFailures.push(
-        `variant ${v}: objects r2 ${c.objectsR2.min.toFixed(5)} below the ${R2_FLOOR} floor`
-      );
-    }
+    r2Gate(`variant ${v}: bytes r2`, c.r2.min);
+    if (SNAP_ROUNDS > 0) r2Gate(`variant ${v}: objects r2`, c.objectsR2.min);
   }
 
   for (const f of gateFailures) console.error(`[abl] GATE — ${f}`);
@@ -712,20 +732,37 @@ const dstr = (d, f = b) => (d ? `${f(d.p50)}  [${f(d.min)}-${f(d.max)}]` : 'n/a'
 // decomposition is quoted in OBJECTS, so the object count has to pass the
 // same control, and a failure has to stop the table being treated as
 // attributable rather than merely being labelled.
+// EVERY REQUIRED LEG, PRESENT AND FINITE. The previous cut filtered
+// non-finite legs out and accepted any one survivor, so a leg the run
+// failed to measure EXEMPTED itself from the control it exists to be — and
+// with both legs absent the list was empty, `ok` was false, and main's loop
+// over the legs had no failure to add, so the run still exited 0. Now the
+// bytes leg is always required, the objects leg is required whenever reader
+// C was asked for (it is C's numbers the leg compares), and a required leg
+// that is absent or non-finite FAILS rather than vanishing.
 function fidelityCheck(all) {
   const byName = Object.fromEntries(all.map((s) => [s.substrate, s]));
-  const U = byName.uix && byName.uix.variants;
-  if (!U || !U.uix || !U.xcript) return { present: false, ok: true, legs: [] };
+  if (!byName.uix) return { present: false, ok: true, legs: [] };
+  const U = byName.uix.variants;
+  if (!U.uix || !U.xcript) {
+    // The uix page ran but a whole side of the comparison is missing: there
+    // is nothing to check, which is a failure, not an exemption.
+    return {
+      present: true, ok: false, legs: [],
+      missing: 'the uix page ran without both a uix and an xcript variant — no fidelity legs exist',
+    };
+  }
   const leg = (name, a, b_) => {
+    const finite = Number.isFinite(a.p50) && Number.isFinite(b_.p50);
     const ovl = overlap(a, b_);
     const rel = Math.abs(b_.p50 / a.p50 - 1);
-    return { name, shipped: a, copy: b_, ovl, rel, ok: ovl || rel <= FIDELITY_BAND };
+    return { name, shipped: a, copy: b_, finite, ovl, rel, ok: finite && (ovl || rel <= FIDELITY_BAND) };
   };
-  const legs = [
-    leg('bytes/read', U.uix.bytesPerRead, U.xcript.bytesPerRead),
-    leg('objects/read', U.uix.objectsPerRead, U.xcript.objectsPerRead),
-  ].filter((l) => Number.isFinite(l.shipped.p50) && Number.isFinite(l.copy.p50));
-  return { present: true, legs, ok: legs.length > 0 && legs.every((l) => l.ok) };
+  const legs = [leg('bytes/read', U.uix.bytesPerRead, U.xcript.bytesPerRead)];
+  if (SNAP_ROUNDS > 0) {
+    legs.push(leg('objects/read', U.uix.objectsPerRead, U.xcript.objectsPerRead));
+  }
+  return { present: true, legs, ok: legs.every((l) => l.ok) };
 }
 
 function report(all) {
@@ -901,15 +938,23 @@ function report(all) {
   // non-fidelitous, its control out of band, its curves not lines, reader C
   // absent, or an unmount silently converted into measurement state.
   const gateFailures = all.flatMap((s) => s.gateFailures.map((f) => `${s.substrate}: ${f}`));
+  // `!fid.ok` always names its failure here: a missing side pushes one, and
+  // every not-ok leg pushes one — the previous cut could reach `!fid.ok` with
+  // an EMPTY leg list (both legs filtered as non-finite) and fall through
+  // this loop without adding anything, which is an exit 0 on a run whose
+  // fidelity control never happened.
   const fid = fidelityCheck(all);
   if (fid.present && !fid.ok) {
+    if (fid.missing) gateFailures.push(`fidelity: ${fid.missing}`);
     for (const l of fid.legs) {
-      if (!l.ok) {
-        gateFailures.push(
-          `fidelity ${l.name}: shipped and transcribed ranges do not overlap and medians are ` +
-            `${pct(l.rel)} apart (band ${pct(FIDELITY_BAND)}) — every delta in the decomposition is void`
-        );
-      }
+      if (l.ok) continue;
+      gateFailures.push(
+        !l.finite
+          ? `fidelity ${l.name}: leg is absent or non-finite (shipped p50 ${l.shipped.p50}, ` +
+              `copy p50 ${l.copy.p50}) — the control this table needs never ran`
+          : `fidelity ${l.name}: shipped and transcribed ranges do not overlap and medians are ` +
+              `${pct(l.rel)} apart (band ${pct(FIDELITY_BAND)}) — every delta in the decomposition is void`
+      );
     }
   }
   if (gateFailures.length) {


### PR DESCRIPTION
Discharges the operator audit comment on rf2-2rtt6.12 (Mike Thompson, 2026-07-30 17:20, on PR #7272's landed tip `7d78c04773`): the in-situ control claimed to be gated on every reader but adjudicated only readers A and C — reader B's `errorPerf` was printed and never gated exit 0; `fidelityCheck` filtered non-finite legs and accepted any one survivor, and with both legs absent `main` iterated an empty failure list and added nothing; and the `Number.isFinite(x) && x < FLOOR` pattern waved a NaN control or r2 through the band tests.

All repairs are small driver assertions in `implementation/freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs` — no framework, no production or adapter code, and rf2-2rtt6.13's spine fix is untouched:

- **Every taken A/B/C control must be finite and in band.** One `controlGate` adjudicates reader A and reader B each round and reader C each snapshot round; non-finite fails before the band test, because `Math.abs(NaN) > band` is false.
- **Both required fidelity legs must be present and finite.** No filtering: the bytes leg is always required, the objects leg whenever reader C was asked for (`SNAP_ROUNDS > 0`), and a leg that is absent or non-finite fails instead of exempting itself. A uix page missing its `uix` or `xcript` variant refuses outright instead of returning `present: false`. `main`'s refusal block now always names the failure — the empty-failure-list fall-through is structurally closed.
- **Every required r2 must be finite and at or above the floor.** `r2Gate` refuses a non-finite fit ("no line was fitted") as well as one below 0.99; objects r2 is required whenever reader C was asked for.

The file's repairing predicate holds throughout: the report is written to disk before any refusal, and exit 4 remains the refusal code. Both mutation runs below confirm the table landed on disk before the non-zero exit.

## Quality gates

- **Mutation refusal 1 — planted non-finite reader-B control** (`control.errorPerf = NaN` after the round control; `ABL_SUBSTRATES=uix ABL_ROUNDS=2 ABL_SNAP_ROUNDS=0`): **exit 4**, failures `round 0 reader-B control is not finite (NaN)` and `round 1 reader-B control is not finite (NaN)`. (That reduced run's round-1 reader-A also drifted out of band at −1.945% and was listed independently — the reader-B lines fire on their own.) Plant removed; `git diff` empty against the committed repair before the next run.
- **Mutation refusal 2 — planted missing fidelity leg** (`U.xcript.objectsPerRead = rangeOf([])` inside `fidelityCheck`; `ABL_SUBSTRATES=uix ABL_ROUNDS=2 ABL_SNAP_ROUNDS=1`): **exit 4**, sole failure `fidelity objects/read: leg is absent or non-finite (shipped p50 125.84…, copy p50 NaN) — the control this table needs never ran`. Under the previous cut this leg was filtered out and the run passed on the bytes leg alone. Plant removed; `git diff` empty.
- **Clean foreground gate** — `node freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs` at defaults (4 rounds, 2 snapshot rounds, uix + reagent), lane started cold (fresh worktree, no `.shadow-cljs`), run to completion, log captured: **exit 0**. 0 unverified of 154 mounts (119 uix + 35 reagent); order guard clean on both pages; witness exact for the third time (uix 1.00N/1.00N/2.00N, reagent 0/0/1.00N, both offsets); controls all finite and in band — uix A −0.001% / **B −0.001%** / C +0.003%, reagent A +0.017% / **B +0.016%** / C −0.000% — with reader B now adjudicated for the first time; fidelity legs both present and finite (bytes 0.347% apart, objects 0.043% apart, band 3%).
- `node --check` clean on the driver after every edit.

**No figure moved**, as expected — every repair is a refusal, not a calculation. The clean run reproduces the studio page's decomposition to the digit: retained render-phase reaction 768 B / 23.0 obj, one live subscription 1,684 B / 56.7 obj, hook stack 1,037 B / 46.1 obj, whole 3,489 B / 125.8 obj, Reagent 866 B (objects 31.3 [31.1–31.5] against the published 31.5 — overlapping ranges, the same run-to-run noise the page already documents). `docs/design/hicasso/studio/uix-spine-per-read-decomposition.md` therefore stands unamended.

One measurement note recorded on rf2-2rtt6.12 rather than rf2-2rtt6.1 (its append path is broken — rf2-0znkn): on a reduced `ABL_ROUNDS=2` run an honest reader-A control breached the 1% band at −1.945%, so the band is calibrated for the default four-round rhythm and reduced-round reruns can refuse honestly — a refusal on a shortened run is evidence about the configuration before it is evidence about the instrument.
