### PR TITLE
docs(migration): teach the author-supplied :git/sha route post-cancellation; lock the drift (rf2-snjn5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Well, beyond the novel parts, re-frame2 comes with SOTA batteries in various dim
 
 Pre-alpha. I'm still preserving optionality.
 
-We are building apps against the ClojureScript reference implementation, however out of an abundance of caution I have not yet published artifacts to Clojars and NPM. Soon.
+We are building apps against the ClojureScript reference implementation, however out of an abundance of caution I have not yet published artifacts to Clojars and NPM — and no release is scheduled yet.
 
 You should absolutely not use it yet — there could be dragons and there is still a chance of change. If you are a daredevil, add as a `:git/sha` coordinate in `deps.edn` and hold on for dear life. And use the Skills, Luke: [re-frame-migration](skills/re-frame-migration/) for you-know-what, then [re-frame2-pair](skills/re-frame2-pair/) for coding. Finally, use [re-frame2-pair-retro](skills/re-frame2-pair-retro/) to do a session retrospective and file an issue if you find friction.
 

--- a/migration/from-re-frame-v1/README.md
+++ b/migration/from-re-frame-v1/README.md
@@ -43,9 +43,9 @@ These are the changes that **must** be applied if the codebase trips them.
 
 ### M-0. Bump the dependency coordinate to `day8/re-frame2`
 
-**Type A** (mechanical). The target coord is unambiguous; apply without asking.
+**Type A** (mechanical). The target coord is unambiguous; apply without asking. The *pin* — which commit or version to consume — is the author's to supply; never invent one.
 
-Before applying any other migration rule, inspect the target project's dependency files and replace the re-frame coordinate with the latest released version of `day8/re-frame2`. Every other rule below assumes the project is already pointing at the v2 artefact — without this step the agent has nothing to verify against.
+Before applying any other migration rule, inspect the target project's dependency files and replace the re-frame coordinate with `day8/re-frame2` (plus its substrate adapter), at the consumption route chosen below. Every other rule below assumes the project is already pointing at the v2 artefact — without this step the agent has nothing to verify against.
 
 **Files to inspect** (whichever exist at the project root):
 
@@ -62,25 +62,28 @@ re-frame          {:mvn/version "1.x.x"}     ;; deps.edn / shadow-cljs.edn — o
 [re-frame "1.x.x"]                            ;; project.clj — Lein vector form
 ```
 
-**Replacement.** Swap the entire coord (not just the version) — the artefact name changes — AND add a substrate-adapter artefact alongside the core. v1 was a single `re-frame/re-frame` artefact; v2 ships core and adapter as siblings, so a Reagent app needs both:
+**Replacement.** Swap the entire coord (not just the version) — the artefact name changes — AND add a substrate-adapter artefact alongside the core. v1 was a single `re-frame/re-frame` artefact; v2 ships core and adapter as siblings, so a Reagent app needs both.
+
+The coordinate *shape* is a publication-state decision, and today nothing is published: no `day8/re-frame2*` artefact resolves from Clojars or Maven Central, and no release is scheduled. For a tools.deps project (`deps.edn` / `shadow-cljs.edn` / `bb.edn`) the route is therefore a **pinned `:git/url` + `:git/sha` coordinate per artefact — every artefact at the same commit** — each selecting its own monorepo subdirectory via `:deps/root`:
 
 ```clojure
-;; deps.edn / shadow-cljs.edn / bb.edn
-day8/re-frame2         {:mvn/version "<latest>"}
-day8/re-frame2-reagent {:mvn/version "<latest>"}    ;; ← new in v2
-
-;; project.clj
-[day8/re-frame2         "<latest>"]
-[day8/re-frame2-reagent "<latest>"]
+;; deps.edn / shadow-cljs.edn / bb.edn — every day8/re-frame2* coord pinned to
+;; ONE author-supplied, pushed <SHA>; :deps/root selects the artefact's subdir
+day8/re-frame2         {:git/url "https://github.com/day8/re-frame2.git" :git/sha "<SHA>" :deps/root "implementation/core"}
+day8/re-frame2-reagent {:git/url "https://github.com/day8/re-frame2.git" :git/sha "<SHA>" :deps/root "implementation/adapters/reagent"}   ;; ← new in v2
 ```
 
-`<latest>` is the latest released version of `day8/re-frame2` (look it up — Clojars / Maven Central). Adapter artefacts are versioned in lock-step with core. The `re-frame.core` and `re-frame.adapter.reagent` namespaces and `:require` lines are unchanged; only the dep coord moves.
+The author supplies `<SHA>` (a reviewed, pushed commit) — never invent a pin, and never guess "latest". The copy-pasteable recipe — per-artefact `:deps/root` sub-paths, the lockstep same-SHA rule, and the alternatives — is maintained in one place, the setup skill's [`deps-versions.md` §Choosing the coordinate](../../skills/re-frame2-setup/references/deps-versions.md#choosing-the-coordinate-publication-state-decides-the-shape). A `{:local/root "../re-frame2/implementation/<subdir>"}` coordinate ([`deps-versions.md` §The `:local/root` sibling-checkout dev route](../../skills/re-frame2-setup/references/deps-versions.md#the-localroot-sibling-checkout-dev-route-pre-publish)) is the local-development-only equivalent: it names a path on the author's own disk, so it is not CI-portable, and it must be repinned to a pushed `:git/sha` before the migration is called done. If and when re-frame2 artefacts are published to a Maven registry, published coordinates — under whatever group id they ship with — take a `{:mvn/version "…"}` shape instead; check the registry itself before writing one.
+
+The `re-frame.core` and `re-frame.adapter.reagent` namespaces and `:require` lines are unchanged; only the dep coord moves. Adapter artefacts are versioned in lock-step with core.
 
 **Pick the adapter artefact by current substrate.** v1 codebases use Reagent universally, so the migration adds `day8/re-frame2-reagent`. Codebases that have already switched to UIx (rare; usually post-migration) get `day8/re-frame2-uix` instead. Per [Conventions §Adapter shipping convention](../../spec/Conventions.md#adapter-shipping-convention).
 
-**If no released v2 version is available yet** (pre-publication): leave the dep alone, do not apply any other migration rules, and flag the situation in the migration report — the user must update the coord manually once a release lands, then re-run the migration.
+**`project.clj` / Leiningen is a separate case — treat it honestly.** Leiningen cannot resolve tools.deps git coordinates — there is no `:git/sha` equivalent for a `:dependencies` vector — and Leiningen *checkouts* supplement an already-resolvable dependency; they never replace one. A Leiningen project picks one of three routes and records the choice in the migration report: migrate dependency management to tools.deps (the shape this guide's examples assume, and the recommended move); build and install the artefacts into the local Maven repository for explicitly-local experimentation (like `:local/root`, not CI-portable); or pause this build tool's dep edit pending publication. Do not write a `[day8/re-frame2 "…"]` vector that no registry can satisfy.
 
-**Report.** Include the before/after coord pair in the migration report's preamble (e.g. `re-frame/re-frame 1.4.5 → day8/re-frame2 2.0.0`).
+**Choose and record the route, then continue the migration.** The route decision is made once, here at M-0, and every later artefact rule (M-27 through M-33) inherits it — one publication-state decision governs the whole guide. Record it in the migration report, then keep going: a first release is not a precondition for any other rule in this file.
+
+**Report.** Include the before/after coord pair in the migration report's preamble (e.g. `re-frame/re-frame 1.4.5 → day8/re-frame2 {:git/sha "abc1234…"}`).
 
 **Why:** v1 (`re-frame/re-frame`) and v2 (`day8/re-frame2`) share the `re-frame.core` namespace and cannot coexist on the same classpath; migration is necessarily atomic per project. Shipping v2 under a new artefact label (rather than as `re-frame/re-frame 2.x`) makes the redesign visible to ops and deps tooling and lets the v1 line continue under its own coord for maintenance releases. The artefact name change is deliberate: the public `re-frame.core` namespace is unchanged, but the Maven coord moves to `day8/re-frame2` so v1 and v2 can ship as siblings without classpath conflict.
 
@@ -1322,14 +1325,7 @@ As the first per-feature artefact split (Strategy B), Spec 010's schema-attachme
 - A direct `(:require [re-frame.schemas])` clause.
 - Use of the `:rf.error/schema-validation-failure` trace op (i.e. the app reads the validation outcome).
 
-**What to do.** Add the schemas artefact alongside the core dep:
-
-```clojure
-;; deps.edn for an app that uses Spec 010 schemas
-{:deps {day8/re-frame2         {:mvn/version "<latest>"}
-        day8/re-frame2-reagent {:mvn/version "<latest>"}
-        day8/re-frame2-schemas {:mvn/version "<latest>"}}}  ;; ← new in v2
-```
+**What to do.** Add `day8/re-frame2-schemas` alongside the core and adapter coords, at the coordinate kind and pin chosen at [M-0](#m-0-bump-the-dependency-coordinate-to-day8re-frame2) — one route, one pin, one commit across every `day8/re-frame2*` artefact; the per-artefact paths live in the setup skill's [`deps-versions.md` §Choosing the coordinate](../../skills/re-frame2-setup/references/deps-versions.md#choosing-the-coordinate-publication-state-decides-the-shape).
 
 CLJS apps additionally require `re-frame.schemas.malli` somewhere in their boot path so the default validator delegates to Malli. The adapter namespace publishes `malli.core/validate` and `malli.core/explain` into the framework's late-bind hook table on ns-load; the schemas artefact's default validator consults the hook on every call. Absent the require, the default validator soft-passes per Spec 010 §Recommended soft-pass (CLJS has no runtime `resolve`, so a previous-generation `(resolve 'malli.core/validate)` approach silently no-op'd even when Malli was on the classpath). The schemas artefact carries Malli as a `:deps` entry so the namespace is available without an explicit `:require`; the app's `:require [re-frame.schemas.malli]` is what wires the runtime fns into the framework.
 
@@ -1351,14 +1347,7 @@ As the second per-feature artefact split (Strategy B), Spec 005's state-machine 
 - Any subscription to the framework-shipped `:rf/machine` reg-sub (e.g. `(rf/subscribe [:rf/machine machine-id])`).
 - A direct `(:require [re-frame.machines])` clause.
 
-**What to do.** Add the machines artefact alongside the core dep:
-
-```clojure
-;; deps.edn for an app that uses Spec 005 state machines
-{:deps {day8/re-frame2          {:mvn/version "<latest>"}
-        day8/re-frame2-reagent  {:mvn/version "<latest>"}
-        day8/re-frame2-machines {:mvn/version "<latest>"}}}  ;; ← new in v2
-```
+**What to do.** Add `day8/re-frame2-machines` alongside the core and adapter coords, at the coordinate kind and pin chosen at [M-0](#m-0-bump-the-dependency-coordinate-to-day8re-frame2) — one route, one pin, one commit across every `day8/re-frame2*` artefact; the per-artefact paths live in the setup skill's [`deps-versions.md` §Choosing the coordinate](../../skills/re-frame2-setup/references/deps-versions.md#choosing-the-coordinate-publication-state-decides-the-shape).
 
 Every namespace that calls `rf/reg-machine` / `rf/make-machine-handler` / `rf/machine-transition` (or relies on the `:rf/machine` framework sub registration) MUST `(:require [re-frame.machines])` so the namespace's load-time hook registrations fire before the call site runs. Without the require, the late-bind hook table is empty at the moment the call resolves and the wrapper raises `:rf.error/machines-artefact-missing` with a clear "add the machines artefact" message.
 
@@ -1381,14 +1370,7 @@ As the third per-feature artefact split (Strategy B), Spec 012's routing surface
 - Any subscription to `:rf/route` or `:rf.route/{id,params,query,transition,error}`.
 - A direct `(:require [re-frame.routing])` clause.
 
-**What to do.** Add the routing artefact alongside the core dep:
-
-```clojure
-;; deps.edn for an app that uses Spec 012 routing
-{:deps {day8/re-frame2         {:mvn/version "<latest>"}
-        day8/re-frame2-reagent {:mvn/version "<latest>"}
-        day8/re-frame2-routing {:mvn/version "<latest>"}}}  ;; ← new in v2
-```
+**What to do.** Add `day8/re-frame2-routing` alongside the core and adapter coords, at the coordinate kind and pin chosen at [M-0](#m-0-bump-the-dependency-coordinate-to-day8re-frame2) — one route, one pin, one commit across every `day8/re-frame2*` artefact; the per-artefact paths live in the setup skill's [`deps-versions.md` §Choosing the coordinate](../../skills/re-frame2-setup/references/deps-versions.md#choosing-the-coordinate-publication-state-decides-the-shape).
 
 Every namespace that calls `rf/reg-route` (or dispatches the `:rf.route/*` events / subscribes to the `:rf/route` family) MUST `(:require [re-frame.routing])` so the namespace's load-time hook registrations and `:rf.route/*` reg-event + reg-sub installations fire before the call site runs. Without the require, the late-bind hook table is empty at the moment `rf/reg-route` resolves and the wrapper raises `:rf.error/routing-artefact-missing` with a clear "add the routing artefact" message; without the framework events the dispatches resolve to `:rf.error/no-such-handler`.
 
@@ -1410,14 +1392,7 @@ As the fourth per-feature artefact split (Strategy B), Spec 013's flows surface 
 - Any `:rf.fx/reg-flow` / `:rf.fx/clear-flow` entry inside an `:fx` vector or effect map.
 - A direct `(:require [re-frame.flows])` clause.
 
-**What to do.** Add the flows artefact alongside the core dep:
-
-```clojure
-;; deps.edn for an app that uses Spec 013 flows
-{:deps {day8/re-frame2         {:mvn/version "<latest>"}
-        day8/re-frame2-reagent {:mvn/version "<latest>"}
-        day8/re-frame2-flows   {:mvn/version "<latest>"}}}  ;; ← new in v2
-```
+**What to do.** Add `day8/re-frame2-flows` alongside the core and adapter coords, at the coordinate kind and pin chosen at [M-0](#m-0-bump-the-dependency-coordinate-to-day8re-frame2) — one route, one pin, one commit across every `day8/re-frame2*` artefact; the per-artefact paths live in the setup skill's [`deps-versions.md` §Choosing the coordinate](../../skills/re-frame2-setup/references/deps-versions.md#choosing-the-coordinate-publication-state-decides-the-shape).
 
 Every namespace that calls `rf/reg-flow` (or uses the `:rf.fx/reg-flow` / `:rf.fx/clear-flow` runtime fxs) MUST `(:require [re-frame.flows])` so the namespace's load-time hook registrations fire before the call site runs. Without the require, the late-bind hook table is empty at the moment `rf/reg-flow` resolves and the wrapper raises `:rf.error/flows-artefact-missing` with a clear "add the flows artefact" message; without the load-time hooks the `:rf.fx/reg-flow` runtime fx silently no-ops.
 
@@ -1441,14 +1416,7 @@ As the fifth per-feature artefact split (Strategy B), Spec 014's managed-HTTP su
 - A direct `(:require [re-frame.http.managed])` clause.
 - Any `:rf.http/decode-schemas` registration metadata key.
 
-**What to do.** Add the http artefact alongside the core dep:
-
-```clojure
-;; deps.edn for an app that uses Spec 014 managed HTTP
-{:deps {day8/re-frame2         {:mvn/version "<latest>"}
-        day8/re-frame2-reagent {:mvn/version "<latest>"}
-        day8/re-frame2-http    {:mvn/version "<latest>"}}}  ;; ← new in v2
-```
+**What to do.** Add `day8/re-frame2-http` alongside the core and adapter coords, at the coordinate kind and pin chosen at [M-0](#m-0-bump-the-dependency-coordinate-to-day8re-frame2) — one route, one pin, one commit across every `day8/re-frame2*` artefact; the per-artefact paths live in the setup skill's [`deps-versions.md` §Choosing the coordinate](../../skills/re-frame2-setup/references/deps-versions.md#choosing-the-coordinate-publication-state-decides-the-shape).
 
 Every namespace that dispatches `:rf.http/managed` (or uses the canned-stub fxs / `with-managed-request-stubs` helper / `:rf.http/decode-schemas` registration metadata) MUST `(:require [re-frame.http.managed])` so the namespace's load-time fx registrations and late-bind hook publications fire before the call site runs. Without the require, the four `:rf.http/*` fxs are not registered at the moment a `[:rf.http/managed ...]` entry hits the drain and the `:fx` runner raises `:rf.error/no-such-fx`; the test-helper wrappers in `re-frame.core` raise `:rf.error/http-artefact-missing` with a clear "add the http artefact" message.
 
@@ -1542,14 +1510,7 @@ As the sixth per-feature artefact split (Strategy B), Spec 011's server-side ren
 - A direct `(:require [re-frame.ssr])` clause.
 - Any reference to the `:rf/render-hash` / `:rf/app-db` payload keys consumed by SSR hosts, or to the per-request response accumulator (read via `re-frame.ssr/get-response` — a framework-private side-channel atom keyed by frame-id, NOT a payload key on `app-db`).
 
-**What to do.** Add the ssr artefact alongside the core dep:
-
-```clojure
-;; deps.edn for an app that uses Spec 011 SSR
-{:deps {day8/re-frame2         {:mvn/version "<latest>"}
-        day8/re-frame2-reagent {:mvn/version "<latest>"}
-        day8/re-frame2-ssr     {:mvn/version "<latest>"}}}  ;; ← new in v2
-```
+**What to do.** Add `day8/re-frame2-ssr` alongside the core and adapter coords, at the coordinate kind and pin chosen at [M-0](#m-0-bump-the-dependency-coordinate-to-day8re-frame2) — one route, one pin, one commit across every `day8/re-frame2*` artefact; the per-artefact paths live in the setup skill's [`deps-versions.md` §Choosing the coordinate](../../skills/re-frame2-setup/references/deps-versions.md#choosing-the-coordinate-publication-state-decides-the-shape).
 
 Every namespace that calls `rf/render-to-string` / `rf/render-tree-hash` / `rf/reg-error-projector` / `rf/project-error`, dispatches `:rf/hydrate`, or registers a `:rf.server/*` fx call site MUST `(:require [re-frame.ssr])` so the namespace's load-time fx registrations and late-bind hook publications fire before the call site runs. Without the require, the four core re-exports raise `:rf.error/ssr-artefact-missing` with a clear "add the ssr artefact" message; the `:rf/hydrate` event resolves to no handler.
 
@@ -1572,14 +1533,7 @@ As the seventh and final per-feature artefact split (Strategy B), the [Tool-Pair
 - A direct `(:require [re-frame.epoch])` clause.
 - Any reference to `:rf.epoch/*` trace ops in custom listeners.
 
-**What to do.** Add the epoch artefact alongside the core dep:
-
-```clojure
-;; deps.edn for an app that uses Tool-Pair time-travel / pair-tool surfaces
-{:deps {day8/re-frame2         {:mvn/version "<latest>"}
-        day8/re-frame2-reagent {:mvn/version "<latest>"}
-        day8/re-frame2-epoch   {:mvn/version "<latest>"}}}  ;; ← new in v2
-```
+**What to do.** Add `day8/re-frame2-epoch` alongside the core and adapter coords, at the coordinate kind and pin chosen at [M-0](#m-0-bump-the-dependency-coordinate-to-day8re-frame2) — one route, one pin, one commit across every `day8/re-frame2*` artefact; the per-artefact paths live in the setup skill's [`deps-versions.md` §Choosing the coordinate](../../skills/re-frame2-setup/references/deps-versions.md#choosing-the-coordinate-publication-state-decides-the-shape).
 
 Every namespace that calls `rf/epoch-history` / `rf/restore-epoch!`, the `:epoch` stream of `rf/register-listener!` / `rf/unregister-listener!`, or `(rf/configure! {:epoch-history ...})` SHOULD `(:require [re-frame.epoch])` at boot so the namespace's load-time hook publications fire before the call sites run. Without the artefact on the classpath the four core re-exports degrade silently — `epoch-history` returns `[]`, `restore-epoch!` returns `false`, the listener register / remove return `nil`, the configure call is a no-op — because the surface is dev-tier and a release build that omits the artefact must not raise from a leftover dev-time call site. (Compare M-32: SSR raises `:rf.error/ssr-artefact-missing` because rendering server-side is a production behaviour; epoch is dev-only and degrades silently.)
 

--- a/scripts/check_skill_migration_contract_drift.py
+++ b/scripts/check_skill_migration_contract_drift.py
@@ -124,6 +124,19 @@ Two contract facts, each pinned against the shipped spec:
     "confirm the boot machine via `get-path`/`snapshot {path:}` on
     `[:rf.runtime/machines :snapshots]`" / "`snapshot {path: [:rf.db/runtime]}`".
 
+  * **M-0 publication-route lock (rf2-snjn5) — the migration guide teaches the
+    author-supplied pinned consumption route, never an invented "latest".** The
+    event that flips install prose is OFF-REPO (an operator release decision),
+    so no code change reds it naturally, and the guide has lied in both
+    polarities. Three narrow assertions over MIGRATION_MD only: no `"<latest>"`
+    version placeholder in a dependency coordinate; no leave-the-dep-alone /
+    wait-for-a-release stop instruction (the migration is fully doable — a
+    first release is not a precondition, per the skill's setup.md); and M-0
+    links the canonical deps-versions.md §Choosing the coordinate recipe so one
+    publication-state decision governs the whole guide. Same class as the setup
+    skill's Lock 9. Retire deliberately at a real first publish. See
+    `m0_publication_route_problems`.
+
 All of these rules are written to fire ONLY on the stale ASSERTION / bad-command
 shape, never on the corrected wording that states the negation — and never on the
 unrelated, still-live `:on-error` *surfaces* (a machine `:spawn :on-error`
@@ -1549,6 +1562,113 @@ def form3_capture_once_retarget_problems() -> list[str]:
     return problems
 
 
+# ---------------------------------------------------------------------------
+# Rule 6 — M-0 publication-route lock (rf2-snjn5).
+#
+# The migration guide's M-0 (and the seven artefact rules that inherit it) is
+# install documentation, and the event that flips its truth is OFF-REPO — an
+# operator release decision — so no code change ever reds stale route prose
+# naturally. It has now lied in both polarities: with nothing published, the
+# guide taught `{:mvn/version "<latest>"}` ("look it up — Clojars / Maven
+# Central"), a coordinate that fails resolution, and M-0's pre-publication
+# branch ordered the author to leave the dep alone and apply no other
+# migration rules until a release lands — a stop-ALL-work dead end that
+# directly contradicts the skill this guide fronts for (references/setup.md:
+# the migration is fully doable; a first release is NOT a precondition; never
+# invent a version — the author supplies the pin/route). Three narrow
+# assertions over MIGRATION_MD, the same publication-state drift class as the
+# setup skill's Lock 9 (skills/re-frame2-setup/tests/setup_drift_test.clj):
+#
+#   * M0-LATEST-MAVEN — no `"<latest>"` version placeholder in a dependency
+#     coordinate (the deps.edn `:mvn/version "<latest>"` map form and the Lein
+#     `[... "<latest>"]` vector form both carry the quoted token). The one
+#     labelled if/when-published `:mvn/version` sentence stays legal: it names
+#     no version at all.
+#   * M0-STOP-AND-WAIT — no leave-the-dep-alone / hold-everything-for-a-release
+#     instruction. Narrow by design: an honestly-labelled per-build-tool option
+#     (the Leiningen paragraph pausing ITS OWN dep edit pending publication)
+#     carries neither shape and stays legal.
+#   * M0-RECIPE-DELEGATION — M-0 links the canonical coordinate recipe
+#     (re-frame2-setup references/deps-versions.md §Choosing the coordinate),
+#     so ONE publication-state decision governs the whole guide instead of
+#     eight independently drifting copies.
+#
+# Retire this lock deliberately at a real first publish — it pins the
+# pre-publish polarity.
+# ---------------------------------------------------------------------------
+
+M0_LATEST_PLACEHOLDER_RE = re.compile(r'"<latest>"')
+M0_STOP_AND_WAIT_RE = re.compile(
+    r"leave\s+the\s+dep(?:endency)?\s+alone"
+    r"|do\s+not\s+apply\s+any\s+other\s+migration\s+rules"
+    r"|(?:stop|wait)[^.\n]{0,80}?(?:until|once)\s+a\s+release\s+lands",
+    re.IGNORECASE,
+)
+# A prefix of the canonical anchor, so a future anchor shortening
+# (…#choosing-the-coordinate) still satisfies it while a dropped delegation
+# does not.
+M0_DELEGATION_ANCHOR = "deps-versions.md#choosing-the-coordinate"
+
+M0_LATEST_PROBLEM = (
+    "M0-LATEST-MAVEN: the migration guide carries a `\"<latest>\"` version "
+    "placeholder in a dependency coordinate. Nothing is published, so every "
+    "such coordinate fails resolution — and \"latest\" is never a pin the "
+    "guide may invent (the author supplies the pin). Teach the "
+    "author-supplied route chosen at M-0 and delegate the recipe to "
+    "deps-versions.md §Choosing the coordinate. (rf2-snjn5.)"
+)
+M0_STOP_PROBLEM = (
+    "M0-STOP-AND-WAIT: the migration guide orders the author to leave the dep "
+    "alone / hold the migration for a release. A first release is NOT a "
+    "precondition — the author chooses a consumption route (pinned `:git/sha`; "
+    "`:local/root` for local dev only), records it in the migration report, "
+    "and the migration CONTINUES (skills/re-frame-migration/references/"
+    "setup.md §Discovering the current VERSION). (rf2-snjn5.)"
+)
+M0_DELEGATION_PROBLEM = (
+    "M0-RECIPE-DELEGATION-MISSING: the guide no longer links the canonical "
+    "coordinate recipe (re-frame2-setup references/deps-versions.md "
+    "§Choosing the coordinate). One publication-state decision must govern "
+    "the whole guide — restated per-rule recipes are how eight copies drifted "
+    "independently. (rf2-snjn5.)"
+)
+
+
+def _m0_publication_route_problems(text: str) -> list[tuple[int, str, str]]:
+    """Rule-6 drift in the migration guide's text. `(lineno, label, excerpt)`;
+    the whole-text delegation check reports lineno 0 with an empty excerpt.
+    Text-pure so the self-test can exercise it against fixtures."""
+    problems: list[tuple[int, str, str]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if M0_LATEST_PLACEHOLDER_RE.search(line):
+            problems.append((lineno, M0_LATEST_PROBLEM, line.strip()))
+        if M0_STOP_AND_WAIT_RE.search(line):
+            problems.append((lineno, M0_STOP_PROBLEM, line.strip()))
+    if M0_DELEGATION_ANCHOR not in text:
+        problems.append((0, M0_DELEGATION_PROBLEM, ""))
+    return problems
+
+
+def m0_publication_route_problems() -> list[str]:
+    """Run the Rule-6 M-0 publication-route lock over MIGRATION_MD only —
+    the corrected setup.md wording legitimately QUOTES the banned instruction
+    in negated form ("Do not leave the dep alone"), so the skill leaves are
+    deliberately out of this rule's scan surface."""
+    if not MIGRATION_MD.is_file():
+        return [
+            f"SETUP: migration corpus missing: {MIGRATION_MD.relative_to(REPO_ROOT)}"
+            " — the M-0 publication-route lock cannot run."
+        ]
+    rel = MIGRATION_MD.relative_to(REPO_ROOT)
+    out: list[str] = []
+    for lineno, label, excerpt in _m0_publication_route_problems(_slurp(MIGRATION_MD)):
+        if lineno:
+            out.append(f"{rel}:{lineno}: {label}\n    {excerpt}")
+        else:
+            out.append(f"{rel}: {label}")
+    return out
+
+
 def find_drift(files: list[Path]) -> tuple[list[str], int]:
     problems: list[str] = []
     lines_checked = 0
@@ -1590,6 +1710,7 @@ def run(*, verbose: bool, ci: bool) -> int:
     problems.extend(m1_classifier_problems())
     problems.extend(m1_anchor_problems())
     problems.extend(form3_capture_once_retarget_problems())
+    problems.extend(m0_publication_route_problems())
 
     if verbose:
         print(
@@ -1607,7 +1728,8 @@ def run(*, verbose: bool, ci: bool) -> int:
                 "partition-mismatch (Rule 4), Form-3 bare-lifecycle targeting "
                 "(Rule 5), Form-3 captured-subscribe acquisition (Rule 5b — "
                 "rf2-v84zn), Form-3 capture-once retarget-invariance drift "
-                "(rf2-aalo4n), or M-1 classifier / kickoff-anchor drift found."
+                "(rf2-aalo4n), M-0 publication-route drift (Rule 6 — "
+                "rf2-snjn5), or M-1 classifier / kickoff-anchor drift found."
             )
         return 0
 
@@ -1622,9 +1744,11 @@ def run(*, verbose: bool, ci: bool) -> int:
         "`get-path`/`snapshot {path:}` CANNOT read runtime-db; use "
         "`read-sub [:rf/machine <id>]`), and the M-1 classifier (public "
         "destinations exempt, private internals flagged) / kickoff anchors, plus "
-        "Form-3 lifecycle explicit-frame targeting and the Form-3 capture-once "
+        "Form-3 lifecycle explicit-frame targeting, the Form-3 capture-once "
         "retarget invariance (FORM-3.md + guided-handlers-state.md §M-11 aligned "
-        "— rf2-aalo4n), to the shipped contract."
+        "— rf2-aalo4n), and the M-0 publication-route lock (author-supplied "
+        "pinned route, no `\"<latest>\"`, no stop-and-wait — rf2-snjn5), to the "
+        "shipped contract."
     )
     return 1
 
@@ -2638,6 +2762,81 @@ def _self_test() -> int:
         K10_ADAPTIVE_REMEDY_OK, K_CANON, dirty=False,
         label="K10 route-1 adaptive-remedy prose is clean",
     )
+
+    # --- Rule 6 fixtures — M-0 publication-route lock (rf2-snjn5) ---------------
+    # The FAIL fixtures are the exact pre-fix shapes (M-0 :69-77 / :81 and the
+    # seven artefact-rule `<latest>` recipes); the PASS fixture is the corrected
+    # author-supplied-route wording, including the two sentences that must stay
+    # legal: the labelled if/when-published `:mvn/version` destination and the
+    # honestly-scoped Leiningen pause option.
+    def expect_m0(text: str, *, dirty: bool, label: str) -> None:
+        nonlocal failures
+        got = bool(_m0_publication_route_problems(text))
+        if got != dirty:
+            print(
+                f"SELF-TEST FAIL ({label}): expected dirty={dirty}, got {got} "
+                f"for M-0 route text: {text!r}"
+            )
+            failures += 1
+
+    M0_CLEAN = (
+        'day8/re-frame2 {:git/url "https://github.com/day8/re-frame2.git" '
+        ':git/sha "<SHA>" :deps/root "implementation/core"}\n'
+        "The recipe is maintained in one place, the setup skill's "
+        "[`deps-versions.md` §Choosing the coordinate](../../skills/"
+        "re-frame2-setup/references/deps-versions.md"
+        "#choosing-the-coordinate-publication-state-decides-the-shape).\n"
+        "Choose and record the route, then continue the migration.\n"
+        "If and when re-frame2 artefacts are published to a Maven registry, "
+        'published coordinates take a `{:mvn/version "…"}` shape instead.\n'
+        "Leiningen may instead pause this build tool's dep edit pending "
+        "publication."
+    )
+    expect_m0(M0_CLEAN, dirty=False, label="M0-1 corrected route text is clean")
+    expect_m0(
+        M0_CLEAN + '\nday8/re-frame2 {:mvn/version "<latest>"}',
+        dirty=True, label="M0-2 mvn <latest> map coord is dirty",
+    )
+    expect_m0(
+        M0_CLEAN + '\n[day8/re-frame2 "<latest>"]',
+        dirty=True, label="M0-3 Lein <latest> vector coord is dirty",
+    )
+    expect_m0(
+        M0_CLEAN + "\nleave the dep alone, do not apply any other migration "
+        "rules, and flag the situation in the migration report",
+        dirty=True, label="M0-4 leave-the-dep-alone stop instruction is dirty",
+    )
+    expect_m0(
+        M0_CLEAN + "\nthe author should wait until a release lands, then "
+        "re-run the migration",
+        dirty=True, label="M0-5 wait-for-a-release instruction is dirty",
+    )
+    expect_m0(
+        M0_CLEAN.replace(
+            "deps-versions.md"
+            "#choosing-the-coordinate-publication-state-decides-the-shape",
+            "deps-versions.md",
+        ),
+        dirty=True, label="M0-6 dropped delegation anchor is dirty",
+    )
+
+    # Live red-proof teeth: the lock must have BITE against the exact pre-fix
+    # M-0 text — the `<latest>` recipe and the stop instruction verbatim from
+    # the guide as it stood before rf2-snjn5.
+    PRE_FIX_M0 = (
+        M0_CLEAN
+        + '\nday8/re-frame2         {:mvn/version "<latest>"}\n'
+        + "**If no released v2 version is available yet** (pre-publication): "
+        "leave the dep alone, do not apply any other migration rules, and flag "
+        "the situation in the migration report — the user must update the "
+        "coord manually once a release lands, then re-run the migration."
+    )
+    if len(_m0_publication_route_problems(PRE_FIX_M0)) < 2:
+        print(
+            "SELF-TEST FAIL (M0-red-proof): the exact pre-fix M-0 text does "
+            "not trip both the <latest> and stop-and-wait assertions."
+        )
+        failures += 1
 
     # Live-corpus teeth: the SHIPPED owners must both carry the invariant, and a
     # mutation that drops the A→B sentence from either owner must be caught — so a


### PR DESCRIPTION
## What

The alpha release was cancelled (rf2-vxgfnd.99 close, 2026-07-30), which made the v1 migration guide the lying half of the install corpus: following its text today either fails dependency resolution or halts a migration the repo already knows how to perform. This PR is the bounded documentation correction the re-scoped rf2-snjn5 ruling ordered, plus the narrow drift lock that keeps it honest.

**Preflight (publication state, verified live before editing):** Clojars returns 404 for `day8/re-frame2`, `day8/re-frame2-reagent`, and `day8/re-frame2-uix` (the `day8` group carries no re-frame2 artifacts); the repo has zero `v*` tags locally and on origin; the GitHub releases list is empty. State unchanged from the bead — the rewrite applies.

Per the bead's seven items:

1. **M-0 is now an author-supplied consumption route, not "latest".** The default tools.deps route is a pinned `:git/url` + `:git/sha` per artefact — all at ONE commit — each with its own `:deps/root "implementation/<subdir>"`. `:local/root` is labelled local-development-only (names a path on the author's own disk; not CI-portable; repin before done). The copy-pasteable recipe is delegated to the setup skill's `deps-versions.md` (§Choosing the coordinate + §The `:local/root` sibling-checkout dev route — both anchors verified present on main), the same delegation the migration skill already uses. The stop-instruction at :81 is replaced with choose-and-record-the-route, then continue — now agreeing with `skills/re-frame-migration/references/setup.md:260`.
2. **The seven artefact rules (M-27 through M-33) drop their `<latest>` recipes** and inherit M-0's coordinate kind + pin by delegation — one publication-state decision governs the whole guide, and eight copies stop drifting independently.
3. **Leiningen is treated honestly as a separate case:** checkouts supplement, never replace, a resolvable dependency; the guide no longer implies tools.deps git coordinates work in `project.clj`. Three recorded options: migrate dep management to tools.deps, local-install for explicitly-local experimentation, or pause that build tool's dep edit pending publication.
4. **README.md:97 no longer promises "Soon."** — the (true) not-published claim stays; the sentence now states that no release is scheduled.
5. **Narrow drift lock** (Rule 6) added to the existing `scripts/check_skill_migration_contract_drift.py`, same class as `setup_drift_test.clj` Lock 9: no `"<latest>"` version placeholder in a dependency coordinate, no leave-the-dep-alone / wait-for-a-release instruction, and the guide must link the canonical `deps-versions.md#choosing-the-coordinate` recipe. Scans the migration README only (setup.md legitimately quotes the banned instruction in negated form). Self-test fixtures include the exact pre-fix shapes. Retire deliberately at a real first publish.
6. **`:mvn/version` survives as one labelled if/when-published sentence, group-agnostic** ("published coordinates — under whatever group id they ship with — take a `{:mvn/version "…"}` shape instead; check the registry itself before writing one").
7. **Coordinate names and every `### M-NN.` heading are untouched** (`check_skill_migration_cites.py` keys on the headings — green below).

## Quality gates

All run foreground, unpiped, to completion, from the worktree:

| Gate | Exit code |
|---|---|
| `python -m mkdocs build --strict` | 0 |
| `python scripts/check_skill_migration_cites.py` | 0 |
| `python scripts/check_skill_migration_contract_drift.py` (incl. the new Rule-6 lock) | 0 |
| `python scripts/check_skill_migration_contract_drift.py --self-test` | 0 |
| `python scripts/check_skill_migration_o1617_router_drift.py` | 0 |
| `python scripts/check_doc_slugs.py` | 0 |
| `python scripts/check_readme_links.py` | 0 |

**Red-then-green proof for the lock:** the lock was committed first (3d496b181f) and run against the pre-fix guide — **exit 1 with 27 Rule-6 violations** (all 25 `"<latest>"` coordinate lines across M-0 + the seven artefact rules, the M-0 :81 stop-and-wait line, and the missing delegation link). After the guide correction (bae1243064) the same scan is **exit 0**. The self-test additionally carries a live red-proof tooth: the exact pre-fix M-0 text must trip both the `<latest>` and stop-and-wait assertions, or the self-test fails.

Closes rf2-snjn5 on merge.
