### PR TITLE
docs(hicasso): clear the discharged witness-set Open item; record the retention enum gate (rf2-t8e7i, rf2-94z57)

### DIFF
--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -821,15 +821,11 @@ mutation evidence is on
   the boundary rather than of the page.
 - **The per-page accumulation is still unexplained.** One row per page makes it
   harmless to these figures; it does not make it fixed.
-- **`p0_converge_app.cljs`'s own row table still describes the pre-batch narrow
-  window, and this page cannot fix it.** Its namespace docstring reads
-  *"`bulk-narrow` | the M1 page, one commit exactly ONE boundary reads"*, which
-  was true before `rf2-zb3qg` and is not true of the landed row: `narrow-batch-k`
-  commits share one timed window, and the `:doc` on the entry itself — ~730 lines
-  further down the same file — already says so. So the file contradicts itself,
-  and a reader who stops at the summary table reads a window that no longer
-  exists. **Marked rather than corrected**: a sibling worker holds 362
-  uncommitted lines in that file at the time of writing, its earliest hunk at
-  line 229, and a one-line docstring fix landed into a live working surface buys
-  a conflict on a hot file for nothing. The correction belongs to whoever
-  finishes there, and it is one line.
+- ~~**`p0_converge_app.cljs`'s own row table still describes the pre-batch
+  narrow window, and this page cannot fix it.**~~ **CLOSED by rf2-95m11
+  (PR #7288).** The sibling worker finished, and the correction was the one
+  line predicted: the namespace docstring's `bulk-narrow` row now reads
+  *"`narrow-batch-k` batched commits, each of which exactly ONE boundary
+  reads, all in one timed window"*, matching the `:doc` on the entry itself.
+  The file agrees with itself, and the summary table a reader stops at is the
+  window that ran.

--- a/docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md
+++ b/docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md
@@ -366,6 +366,19 @@ precise wrong number first. They are recorded because the next arm will meet the
       now exit 1, in one named `failures` list. The empty-`SERIES B` case is
       reported as a **narrowed scope** rather than compared as `0 of 0`, which
       would have printed `[ok]` for a control that never ran.
+    - `retention_run`'s **`RETENTION_COLLECT` and `RETENTION_ONLY` were
+      matched, never validated** — `collect()` silently did nothing on an
+      unrecognised value, so `RETENTION_COLLECT=bogus` forced no collection
+      while the header still printed it as the collector forcing every
+      COLLECTED reading, and the run exited 0: a typo certifying uncollected
+      heap as collected. A misspelt `RETENTION_ONLY` was the same trap one
+      door over, silently narrowing the run to `repro`. Both enums now refuse
+      **before anything is built or measured**, with the value and the legal
+      set named; `none` stays legal, because asking for no collector is a
+      question this probe exists to compare. *Mutation:* the audit's exact
+      one-cycle bogus-collector repro; it exited 0 at the landed head and now
+      refuses up front, exit 1 (merged-PR audit #7281; PR #7285, landed
+      `a36272fa3e`).
 
     The reaction-**watchers** column is deliberately still not a gate: it is
     blind under `:advanced` and carries no information in either direction, so


### PR DESCRIPTION
## What this is

Two bounded prose edits to Hicasso studio pages, one commit per bead. Both record on the studio surface what already landed on main; neither re-measures nor re-litigates anything.

**rf2-t8e7i** — `p0-converged-witness-set.md`'s Open item recorded that `p0_converge_app.cljs`'s namespace-docstring row table still described the pre-batch narrow window, and deliberately deferred the one-line fix to whoever finished in that file (a sibling worker held 362 uncommitted lines there at the time). PR #7288 (rf2-95m11) landed exactly that one line: the `bulk-narrow` row now reads the batched window, matching the entry's own `:doc`. The bullet is closed in the list's own register — struck headline, `CLOSED by rf2-95m11 (PR #7288)`, and the landed row quoted — the same shape as the sibling rf2-zb3qg closure directly above it.

**rf2-94z57** — `p0-uix-on-subs-frontier-arm.md`'s fail-closed list gains the one bullet the retention worker deferred (PR #7285 explicitly left it out because this page was an in-flight worker's surface at the time). It records the `RETENTION_COLLECT`/`RETENTION_ONLY` enum gate: `collect()` silently did nothing on an unrecognised value, so a misspelt collector forced no collection while the header printed it as the forcing collector — exit 0, a typo certifying uncollected heap as collected. Both enums now refuse before anything is built or measured; `none` stays legal. Same register as the existing three bullets, including the *Mutation:* clause (the audit's one-cycle bogus repro: exit 0 at the landed head, exit 1 up front now). Provenance cited as merged-PR audit #7281 and PR #7285's landed commit `a36272fa3e` (verified on main, sole file `retention_run.cjs`).

Dispatch-order notes honoured: rf2-t8e7i dispatched after #7288 merged; rf2-94z57 sequenced behind the docs-cluster worker that held the frontier-arm page.

## Quality gates

These are prose-only docs edits — no code, config, or build surface is touched, so no code gate runs. The docs gate ran foreground to completion from the worktree root:

- `python -m mkdocs build --strict` — exit 0 ("Documentation built in 25.90 seconds"; the INFO anchor notes are pre-existing on main and unrelated to these pages).