### PR TITLE
bench(hicasso): make successful arm release observable; prove it by mutation (rf2-2rtt6.2)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
@@ -251,17 +251,51 @@
     (reset! teardown-failures [])
     fs))
 
+(defn container-released!
+  "Record a teardown failure unless `container` is EMPTY; answer whether it
+  was. Called after an unmount RETURNED NORMALLY, and BEFORE the container
+  is detached.
+
+  Every mount door in this lane is a React root, and a root's `unmount`
+  deletes its tree from its container synchronously — so a container still
+  holding nodes names the fault a thrown exception cannot: an unmount that
+  returned without releasing. Detach the container without looking and
+  that root lives on, standing on a DETACHED tree no later census can see
+  — [[residue]]'s body-children count sees only attached elements, its
+  sub-cache census only frame subscriptions, and a ratom arm's reactions
+  are rooted in a namespace-level atom outside both, still consuming every
+  later write. The rf2-2rtt6.2 second audit proved the gap by mutation: a
+  no-op'd bulk ratom unmount sailed through `residue-after-bulk`. This one
+  read, taken while the container is still in hand, is where a SUCCESSFUL
+  release is observable per arm, whatever family the arm belongs to."
+  [where container]
+  (let [n (.-length (.-childNodes container))]
+    (if (zero? n)
+      true
+      (teardown-failure!
+        where
+        (str "the unmount RETURNED NORMALLY but its container still holds " n
+             " node(s) — the root was never released, and it would stay live "
+             "on a detached tree, consuming every later write")))))
+
 (defn release!
   "Unmount and detach. Never timed.
 
   A throw is RECORDED ([[teardown-failure!]]) rather than swallowed, and
   the container is detached either way — the record is what makes it
   fatal, and detaching is what keeps one bad arm from leaving its DOM
-  behind for every row that follows."
+  behind for every row that follows. An unmount that returns NORMALLY is
+  not taken at its word either: [[container-released!]] reads the
+  container before it goes, because a root that survives its own unmount
+  does so on a detached tree that no census downstream can see."
   [{:keys [arm handle container]}]
   (when handle
-    (try (react-dom/flushSync (fn [] ((:unmount arm) handle)))
-         (catch :default e (teardown-failure! (str "release! " (:id arm)) e))))
+    (when (try (react-dom/flushSync (fn [] ((:unmount arm) handle)))
+               true
+               (catch :default e
+                 (teardown-failure! (str "release! " (:id arm)) e)))
+      (when container
+        (container-released! (str "release! " (:id arm)) container))))
   (when container (.remove container))
   nil)
 
@@ -317,12 +351,26 @@
   other half: a teardown that returned normally and did not actually
   release. Neither is a leak detector and neither is a lifecycle
   framework — this answers one question, `did the release this row just
-  performed actually happen`, in three integers."
-  [frame-id]
-  (let [cache (some-> (frame/frame frame-id) :sub-cache deref)]
-    {:body-children (.-childElementCount js/document.body)
-     :sub-entries   (count cache)
-     :sub-ref-count (reduce + 0 (map #(or (:ref-count %) 0) (vals cache)))}))
+  performed actually happen`, in three integers.
+
+  `counters` is the caller's own additions to the census — `{key thunk}`,
+  each thunk answering an integer — for an arm family whose live
+  references are rooted where NEITHER built-in counter can see them. The
+  P0 ratom arms are the recorded case (rf2-2rtt6.2, second audit): their
+  cursor reactions watch a namespace-level `reagent.core/atom`, not the
+  frame's sub-cache, and a surviving root's tree is detached, not under
+  `document.body`, so a release that never happened was invisible to all
+  three integers while the detached tree consumed every later write. One
+  map of counts per run, compared by the same equality — the caller names
+  where its arms' references live, and nothing more general than that."
+  ([frame-id] (residue frame-id nil))
+  ([frame-id counters]
+   (let [cache (some-> (frame/frame frame-id) :sub-cache deref)]
+     (into {:body-children (.-childElementCount js/document.body)
+            :sub-entries   (count cache)
+            :sub-ref-count (reduce + 0 (map #(or (:ref-count %) 0) (vals cache)))}
+           (map (fn [[k f]] [k (f)]))
+           counters))))
 
 (defn settle!
   "Yield ONE MACROTASK, so a substrate that schedules its disposals there
@@ -363,16 +411,21 @@
   happened synchronously`, and Reagent's does not. The comparison is
   EQUALITY, not a threshold: the quantities are counts of live references
   that a correct teardown drives to exactly where they started, and a
-  tolerance on them would only make room for the fault."
-  [baseline frame-id after]
-  (let [now (residue frame-id)]
-    (when (not= baseline now)
-      (throw (ex-info (str "RESIDUE after " after " — the teardown returned without "
-                           "throwing but did not release: expected " (pr-str baseline)
-                           ", found " (pr-str now) ". Every later sample would be "
-                           "measured on a page still carrying it")
-                      {:after after :baseline baseline :residue now})))
-    now))
+  tolerance on them would only make room for the fault.
+
+  `counters` is [[residue]]'s: the caller that took its baseline with an
+  extra census must assert with the same one, or the comparison silently
+  narrows to the counters a surviving root does not touch."
+  ([baseline frame-id after] (assert-residue! baseline frame-id after nil))
+  ([baseline frame-id after counters]
+   (let [now (residue frame-id counters)]
+     (when (not= baseline now)
+       (throw (ex-info (str "RESIDUE after " after " — the teardown returned without "
+                            "throwing but did not release: expected " (pr-str baseline)
+                            ", found " (pr-str now) ". Every later sample would be "
+                            "measured on a page still carrying it")
+                       {:after after :baseline baseline :residue now})))
+     now)))
 
 ;; ---------------------------------------------------------------------------
 ;; Parity — run before any clock is read

--- a/implementation/freehand/test/re_frame/bench/hicasso/lane_release_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/lane_release_dom_cljs_test.cljs
@@ -1,0 +1,103 @@
+(ns re-frame.bench.hicasso.lane-release-dom-cljs-test
+  "`lane/release!`'s claim that a NORMAL RETURN is not proof of release,
+  and the census extension that lets a family count its own references
+  (rf2-2rtt6.2, second audit).
+
+  The recorded fault: an arm's `:unmount` returns normally without
+  unmounting its React root. The container is removed regardless, so the
+  root lives on, standing on a DETACHED tree — outside the body-children
+  count, and (for a ratom arm) outside the frame's sub-cache census too,
+  because its cursor reactions watch a namespace-level atom. The landed
+  instrument passed `residue-after-bulk` with exactly this fault planted.
+
+  These are correctness tests of the instrument, not benchmarks: no clock
+  is read for a figure. The real-arm, end-to-end proof is the bounded
+  mutation run recorded on the bead; what is pinned here is the two
+  mechanisms' behaviour, cheaply and deterministically, in the build every
+  PR runs.
+
+  Runtime: these are DOM claims. The file carries the `-dom-cljs-test`
+  suffix so `:browser-test` runs it for real, and every test degrades to
+  a stated skip under `:node-test`, which is the posture the other `*-dom`
+  suites keep."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.bench.hicasso.lane :as lane]))
+
+(def ^:private off-browser
+  "no DOM on this runtime — the claim is a DOM read taken at release, and
+  :browser-test is where it is asked")
+
+(defn- populated-mount
+  "A mount whose container holds a page, with the arm's unmount under the
+  test's control: `unmount!` receives the container and decides whether
+  the release actually happens — which is the whole variable under test."
+  [unmount!]
+  (let [c (js/document.createElement "div")]
+    (set! (.-innerHTML c) "<ul><li>live</li></ul>")
+    (.appendChild js/document.body c)
+    {:arm       {:id :under-test :unmount (fn [_handle] (unmount! c))}
+     :handle    ::root
+     :container c}))
+
+;; ---------------------------------------------------------------------------
+;; The normal-return non-release — recorded, and fatal at adjudication
+;; ---------------------------------------------------------------------------
+
+(deftest a-normally-returning-non-release-is-recorded-and-fatal
+  (testing "an unmount that returns normally leaving its page standing is
+           recorded at the site and adjudicated as a teardown failure —
+           the exact shape the second audit planted and watched pass"
+    (if-not (lane/browser?)
+      (is true off-browser)
+      (do (lane/drain-teardown-failures!) ;; a clean slate for the claim
+          (lane/release! (populated-mount (fn [_c] nil)))
+          (is (thrown-with-msg? js/Error #"teardown FAILED"
+                (lane/assert-teardown-clean! "the no-op release"))
+              "a normal return must not pass for a release")))))
+
+(deftest a-release-that-emptied-its-container-is-clean
+  (testing "the same path records nothing when the unmount actually
+           releases — the check reads the page, not the promise"
+    (if-not (lane/browser?)
+      (is true off-browser)
+      (do (lane/drain-teardown-failures!)
+          (lane/release! (populated-mount (fn [c] (.replaceChildren c))))
+          (is (nil? (lane/assert-teardown-clean! "the real release"))
+              "an emptied container is the release, observed")))))
+
+(deftest a-throwing-unmount-is-recorded-once
+  (testing "a throw is already the record — the container read does not
+           stack a second failure onto the same release"
+    (if-not (lane/browser?)
+      (is true off-browser)
+      (do (lane/drain-teardown-failures!)
+          (lane/release! (populated-mount (fn [_c] (throw (js/Error. "boom")))))
+          (let [fs (lane/drain-teardown-failures!)]
+            (is (= 1 (count fs)) "one release, one record")
+            (is (= "boom" (:error (first fs)))
+                "and the record carries the throw, not the container count"))))))
+
+;; ---------------------------------------------------------------------------
+;; The census extension — a family's own counter is held to the equality
+;; ---------------------------------------------------------------------------
+
+(deftest the-census-counts-what-the-caller-names
+  (testing "a family whose references live outside the frame cache and the
+           body supplies its own counter, and the residue assertion
+           refuses on it by the same equality"
+    (if-not (lane/browser?)
+      (is true off-browser)
+      (let [live     (atom 0)
+            counters {:family-refs (fn [] @live)}
+            baseline (lane/residue ::no-such-frame counters)]
+        (is (= 0 (:family-refs baseline))
+            "the caller's counter is part of the reading")
+        (swap! live inc) ;; the surviving root's reference
+        (is (thrown-with-msg? js/Error #"RESIDUE"
+              (lane/assert-residue! baseline ::no-such-frame
+                                    "the row" counters))
+            "one live reference outside both built-in counters must refuse")
+        (reset! live 0)
+        (is (= baseline (lane/assert-residue! baseline ::no-such-frame
+                                              "the row" counters))
+            "and back at baseline the same census passes")))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_app.cljs
@@ -25,9 +25,15 @@
      silently deciding the comparison.
   3. **The mount rows**, then the bulk row, with a SETTLE POINT between
      every pair. A release that threw is fatal, and so is a release that
-     returned normally without releasing: `lane/residue` reads the
-     attached-container count and the frame's subscription ref-counts back
-     to the empty-page baseline. The settle is not politeness to the
+     returned normally without releasing — observed twice over: every
+     unmount's container is read BEFORE it is detached
+     (`lane/container-released!` — a React root's unmount empties its
+     container synchronously, so a populated one is a root that was never
+     released), and `lane/residue` reads the attached-container count, the
+     frame's subscription ref-counts AND the watch count on
+     `v/ratom-cells` back to the empty-page baseline, because the ratom
+     arms' live references sit on that namespace-level atom where neither
+     built-in counter can see them. The settle is not politeness to the
      assertion — a mount row is wholly synchronous and Reagent's disposals
      are queued on a macrotask, so without it row N+1 begins on a page
      still carrying every consumer reaction row N mounted
@@ -303,19 +309,28 @@
         arms))
 
 (defn- release-bulk-arms!
-  "Release every bulk arm. A throw is RECORDED, never swallowed.
+  "Release every bulk arm. A throw is RECORDED, never swallowed — and a
+  normal return is not taken at its word.
 
   `(catch :default _ nil)` was here, and the arm it hid is the one that
   matters most: the bulk arms stand for a whole row, so an unmount that
   threw leaves three hundred subscribing boundaries watching the app-db
-  while every later sample is measured on top of them. The caller
-  adjudicates with `lane/assert-teardown-clean!` and proves the release
-  with `lane/assert-residue!`."
+  while every later sample is measured on top of them. The second audit
+  then proved the remaining half by mutation: an unmount that RETURNED
+  NORMALLY without releasing left the ratom arm's root standing on a
+  detached tree, rooted in `v/ratom-cells` where neither the body census
+  nor the frame's sub-cache could see it — so `lane/container-released!`
+  now reads each container before it is removed, exactly as
+  `lane/release!` does. The caller adjudicates with
+  `lane/assert-teardown-clean!` and proves the reference census with
+  `lane/assert-residue!`."
   [mounts]
   (doseq [{:keys [arm handle container]} mounts]
-    (try ((:unmount arm) handle)
-         (catch :default e
-           (lane/teardown-failure! (str "release-bulk-arms! " (:id arm)) e)))
+    (when (try ((:unmount arm) handle)
+               true
+               (catch :default e
+                 (lane/teardown-failure! (str "release-bulk-arms! " (:id arm)) e)))
+      (lane/container-released! (str "release-bulk-arms! " (:id arm)) container))
     (.remove container)))
 
 ;; ---------------------------------------------------------------------------
@@ -598,6 +613,15 @@
 ;; The run
 ;; ---------------------------------------------------------------------------
 
+(def ^:private census
+  "This run's additions to `lane/residue` — the places its own arms' live
+  references sit that the built-in counters cannot see. One entry: the
+  ratom arms' cursor reactions are watches on `v/ratom-cells`, not frame
+  subscriptions and not attached DOM, so without this count a ratom root
+  that survived its unmount was invisible to the whole census
+  (`v/ratom-watch-count` carries the mechanics)."
+  {:ratom-watches v/ratom-watch-count})
+
 (defn- settled!
   "Let the substrate's disposal queue run, then adjudicate the two things a
   released row owes: that nothing threw on the way out, and that the
@@ -607,12 +631,14 @@
   previous row's un-released boundaries is the same class of fault as a
   write that never reached the page, and this is where it is caught — see
   [[lane/settle!]] for why the yield is load-bearing rather than a
-  courtesy to the assertion."
+  courtesy to the assertion. The [[census]] rides both the baseline and
+  every assertion, so the ratom family is held to the same equality as
+  the subs family."
   [baseline after]
   (-> (lane/settle!)
       (.then (fn [_]
                (lane/assert-teardown-clean! after)
-               (lane/assert-residue! baseline v/subs-frame after)))))
+               (lane/assert-residue! baseline v/subs-frame after census)))))
 
 (defn- finish!
   [{:keys [samples controls]}]
@@ -645,7 +671,7 @@
       ;; The residue this run must return to after every row. Taken before
       ;; the first mount of the run, so it is the empty-page, empty-cache
       ;; reading and not a reading of whatever the previous row left.
-      (let [baseline (lane/residue v/subs-frame)
+      (let [baseline (lane/residue v/subs-frame census)
             problems (parity-problems)]
         (lane/record! "parity" {:problems problems :ok? (empty? problems)})
         (lane/record! "residue-baseline" baseline)

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_views.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_views.cljs
@@ -150,6 +150,25 @@
 
 (defonce ratom-cells (r/atom []))
 
+(defn ratom-watch-count
+  "How many reactions are watching [[ratom-cells]] right now — the ratom
+  family's live-reference census, and the count neither of the lane's
+  built-in residue counters can supply.
+
+  Every mounted [[m1-cell-ratom]] / [[m2-field-ratom]] occurrence derefs an
+  `r/cursor` over [[ratom-cells]]. Reagent backs each cursor with a cached
+  Reaction that adds itself to the atom's watch map while anything reads it
+  and removes itself when its last watcher is disposed, so a ratom arm
+  whose unmount returned normally WITHOUT releasing its root shows up here
+  as a count that never came back down: rooted in this namespace-level
+  atom — outside the frame's sub-cache and off `document.body` — its
+  detached tree would re-render on every later bulk write. `^clj` because
+  [[ratom-cells]] is a ClojureScript deftype instance: the hint keeps
+  `:advanced` treating this access exactly like Reagent's own
+  `add-w`/`remove-w` instead of minting an extern for it."
+  []
+  (count (.-watches ^clj ratom-cells)))
+
 (defn m1-cell-ratom
   "A FORM-2 component: the outer call mints a `cursor` once per mounted
   occurrence and the returned render fn dereferences only that cursor.


### PR DESCRIPTION
Audit remainder of **rf2-2rtt6.2** (second reopen, AUDIT PR #7283): the claimed proof of a normally-returning non-release was incomplete. `lane/release!` and `release-bulk-arms!` called an arm's `:unmount` and unconditionally removed its container; `lane/residue` saw only body child count plus the frame's sub-cache census. So a root that survived its own unmount stood on a **detached** tree — and the ratom arm's cursor reactions are rooted in the namespace-level `v/ratom-cells`, outside both counters — consuming every later write. The audit proved it by mutation on landed `9737ed5cf8`: a no-op'd bulk ratom unmount reached and **passed** `residue-after-bulk`.

## Two observables, both outside every timed window

1. **`lane/container-released!`** — after an unmount **returns normally**, the container is read **before** it is detached, at both release sites (`lane/release!`, `release-bulk-arms!`). A React root's `unmount` empties its container synchronously, so a populated container is a root that was never released — recorded as a teardown failure, adjudicated fatally at the next settle point, for **every arm family** (floor, ctl, subs, ratom alike). This is where a *successful* release is observable per arm.
2. **`lane/residue` census extension** — `residue`/`assert-residue!` take an optional `{key thunk}` counter map for a family whose live references sit where neither built-in counter can see. The P0 run adds `:ratom-watches` (`v/ratom-watch-count`: the watch map on `v/ratom-cells`), riding the baseline and every settle-point assertion under the same equality. `residue-baseline` and `residue-after-bulk` now publish `{:body-children 2, :sub-entries 0, :sub-ref-count 0, :ratom-watches 0}`.

No timed window changes; no generalized lifecycle machinery — one read per release and one map of counts per run. `lane_release_dom_cljs_test.cljs` (4 tests, `:browser-test`) pins both mechanisms deterministically: the normal-return non-release is recorded and fatal, a real release is clean, a throw is recorded once not twice, and a caller-named census counter refuses by equality.

## Mutation-proved, three ways (plants never committed; `git diff` empty after each)

| mutation | outcome | exit |
|---|---|---|
| **A** — the audit's exact plant: bulk ratom `:unmount` → normal no-op | refused at the bulk release: `teardown FAILED after the bulk row — release-bulk-arms! :reagent-ratom … RETURNED NORMALLY but its container still holds 1 node(s)`. Deterministic, at cleanup — not the independent stochastic exit-2 the audit's run died on | **1** (intended) |
| **B** — second family: floor mount `:unmount` → normal no-op | refused at **parity, before any clock**: `release! :floor` and `release! :ctl-2x` recorded on both witnesses | **1** (intended) |
| **C** — bulk ratom `:unmount` scrubs the container's DOM but keeps the root | container check passes, body census passes, sub-cache passes — **only the new counter refuses**: `RESIDUE after the bulk row — expected {… :ratom-watches 0}, found {… :ratom-watches 300}`. Proves `:ratom-watches` is load-bearing under `:advanced` | **1** (intended) |

## No published figure moves

Clean reproduction (machine quiet, no sibling bench processes): every row's range overlaps its published counterpart — M1 bar-row 4.000 [3.778–4.167] vs 3.899 [3.447–4.300]; M2 (diagnostic) 1.662 [1.429–2.000] vs 1.874 [1.750–2.050]; bulk 6.650 [5.750–8.000] vs 7.064 [6.200–7.700]; reactive legs 1.230 [1.136–1.283] vs 1.218 [1.122–1.310] and 2.153 [2.080–2.190] vs 2.008 [1.938–2.100]. The studio page and the journal bead are deliberately untouched.

A first clean take exited **2** on the recorded stochastic arm-order class (`M2/ctl-2x` phase stratum disjoint, 1.60x, on the clock-coarse diagnostic witness — 4–9 quanta readings); its figures are not reportable by definition and the run was re-taken, not excused. Its cleanup side was clean (`residue-after-bulk` at baseline, 0 unverified of 1,220, 8/8 controls).

Follow-up filed: **rf2-jk3vj** — the two sibling *own*-release bulk paths (`p0_converge_app`, `hd8_rows`) should adopt `lane/container-released!`; their mount-row releases already inherit it via `lane/release!`.

## Quality gates

| gate | exit |
|---|---|
| `npm run bench:hicasso` — clean reproduction, machine quiet: guard `refuse? false / contaminated? false / unchecked? false`, 8/8 positive controls, canonical parity clean, **0 unverified of 1,220**, residue census clean at baseline and after bulk | **0** |
| `npm run bench:hicasso` — first take, stochastic arm-order refusal on the diagnostic M2 control (recorded class; re-taken) | 2 |
| `node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` — the sibling instrument on the modified lane: all rows, all guards clean, 16 controls ok | **0** |
| `npm run test:browser` — 855 tests / 5,510 assertions (includes the 4 new release tests) | **0** |
| `npm run test:script-policy` (incl. the browser-dom lane partition over the new test file) | **0** |
| mutation A — bulk ratom unmount → normal no-op | **1** (intended) |
| mutation B — floor mount unmount → normal no-op | **1** (intended) |
| mutation C — bulk ratom unmount scrubs DOM, keeps root | **1** (intended) |
| `git diff` after removing each plant | empty |

Closes rf2-2rtt6.2.
