### PR TITLE
docs(hicasso): the heap red-zone regime lands on the pages — B/E/Q stamps, fan-out relabel, shell-only paper line (rf2-5e84f)

### DIFF
--- a/docs/design/hicasso/studio/README.md
+++ b/docs/design/hicasso/studio/README.md
@@ -89,9 +89,9 @@ requires nothing from any donor `src/` tree.
 |---|---|---|
 | [P0 — Reagent-on-subs baseline (mount + bulk)](p0-reagent-on-subs-baseline.md) | P0 | The ship bar's **denominator**: mount and bulk view work for Reagent reading re-frame2 subscriptions. |
 | [P0 — ratom-spine narrow write](p0-ratom-spine-narrow-write.md) | P0 | What a narrow write on the ratom spine costs, and the write-versus-flush split. |
-| [P0 — the UIx-on-subs frontier arm](p0-uix-on-subs-frontier-arm.md) | P0 | The frontier against the denominator, on the arm's own witnesses. Its **retained-heap** red-zones stand; its clock rows are superseded by the converged page. |
+| [P0 — the UIx-on-subs frontier arm](p0-uix-on-subs-frontier-arm.md) | P0 | The frontier against the denominator, on the arm's own witnesses. Its retained-heap absolutes are **shared-query fan-out evidence** (rf2-2rtt6.16), its ratios the cross-regime check; its clock rows are superseded by the converged page. |
 | [P0 — the converged witness set, and the red-zones re-derived on it](p0-converged-witness-set.md) | P0 | The **clock red-zones** on the denominator's own witnesses, and how far the earlier per-arm witness sets moved the verdicts. |
-| [P0 — the reads-per-boundary heap ladder](reads-per-boundary-heap-ladder.md) | P0 | Retained heap per subscribing boundary across the 1/3/7/20 reads ladder, both donors. |
+| [P0 — the reads-per-boundary heap ladder](reads-per-boundary-heap-ladder.md) | P0 | Retained heap per subscribing boundary across the 1/3/7/20 reads ladder, both donors — the **operative** distinct-query (Q = E) red-zone family. |
 | [HD-008 — the composed donor arm](hd8-composed-donor-arm.md) | donor gate | What the composed donor arm costs against both Reagent paths and against the frontier. |
 | [The UIx spine's per-read allocation, decomposed](uix-spine-per-read-decomposition.md) | P0 | Where a UIx-on-subs read's bytes go. |
 | [The reagent-slim non-reactive arm — diagnosis](slim-non-reactive-arm-diagnosis.md) | P0 | Why HD-008's reagent-slim arm read `78 unverified of 78`: the **arm's composition**, not the adapter and not the mixed bundle. A single-substrate slim bundle re-renders on every write. |
@@ -102,9 +102,19 @@ Reagent-on-subs, so the denominator's witness set defines the comparison by
 construction, and a threshold measured on a different witness is a threshold on
 a different question.
 
-**Retained-heap red-zones are not superseded.** They live on the heap ladder and
-on the frontier arm's own record, and stand as published. Three shapes spanning
-a 4× range in markup density agree within 8% — because retained bytes per
-subscribing boundary is a property of the boundary. The clock is not: element
-count decides what fraction of the window is React's own work, which is why the
-clock rows had to move to the denominator's pages and the heap rows did not.
+**Retained-heap red-zones are regime-matched** (heap red-zone regime ruling,
+delegated by Mike, 2026-07-31; authoritative text on rf2-2rtt6.16,
+transcription on rf2-2rtt6.1). Cache cardinality is part of the witness, so
+every heap red-zone row stamps **B** (boundaries), **E** (boundary-query edges)
+and **Q** (unique live query keys). The
+[heap ladder](reads-per-boundary-heap-ladder.md)'s distinct-query rows (Q = E)
+are the mandatory worst-case witness and the operative upper-envelope red-zone
+family; the frontier arm's absolute heap rows are fan-out 4 (amortised ×4)
+shared-query witness evidence, not comparable to distinct-query rows, and its
+ratios stay published as the cross-regime check — the 8% agreement across
+shapes is *ratio* agreement, common-mode across both arms, so the ratio ports
+and the quantity does not. A candidate heap row is judged only against donor
+rows measured under the same regime on the same witness, and reports both
+regime-matched gates: UIx 3,552 B/read (worse is RED, operator waiver
+required) and Reagent 943 B/read (worse with no named paper path down is K3
+territory; between the two is "UIx-rule cleared, K3 open", never plain green).

--- a/docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md
+++ b/docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md
@@ -9,8 +9,9 @@ explicit *"accept your recommendation and proceed"*) says it mechanically:
 > RED. A red row needs an explicit operator waiver naming the dogfood benefit.
 > Silence is still not a pass.
 
-So every number in the two "red-zone" tables below *is* a threshold, not a
-supporting figure. **Red is not fail** — the ship bar (HD-012: mount AND bulk
+So every number in the two "red-zone" tables below was set as a threshold, not
+a supporting figure — and both tables have since been qualified, each by the
+banner below. **Red is not fail** — the ship bar (HD-012: mount AND bulk
 ≤ 1.0× Reagent, like-for-like, clock only) is independent, and a row can clear
 the bar and still be red. That tension is intended.
 
@@ -28,13 +29,21 @@ the bar, the budgets, the kill criteria, or these thresholds.
 > a different question. This page's own *Open items* anticipated the move; quote
 > the converged table.
 >
-> **The retained-heap table is NOT superseded, and stands as published.** It was
-> deliberately not re-run: three shapes spanning a 4× range in markup density
-> agree within 8% — this page's list at 2.262×, its grid at 2.254×, and the heap
-> ladder's 2.435× — because retained bytes per subscribing boundary is a property
-> of *the boundary*. The clock is not, since element count decides what fraction
-> of the window is React's own work. That asymmetry is why the clock rows had to
-> move onto the denominator's pages and these did not.
+> **The retained-heap table is regime-qualified — the heap red-zone regime
+> ruling (delegated by Mike, 2026-07-31; authoritative text on rf2-2rtt6.16,
+> transcription on rf2-2rtt6.1).** Cache cardinality is part of the witness:
+> this arm's four held roots render the *same* 300 query vectors against one
+> frame, so one subscription cache serves all 1,200 boundaries and the
+> per-boundary figures amortise the subscription half of every read across four
+> consumers. The absolute rows below therefore stand as **fan-out 4 (amortised
+> ×4), shared-query witness evidence — not comparable to distinct-query rows** —
+> and the operative upper-envelope red-zone family is the
+> [heap ladder](reads-per-boundary-heap-ladder.md)'s distinct-query rows
+> (Q = E). The ratios stay published as the cross-regime check: the 8% agreement
+> across shapes — this page's list at 2.262×, its grid at 2.254×, the ladder's
+> 2.435× — is *ratio* agreement, because the amortisation is common-mode across
+> both arms and cancels in the ratio. Portability of the ratio is real;
+> portability of the quantity is not.
 
 ## Provenance
 
@@ -60,12 +69,13 @@ housekeeping.
 this page says so rather than leaving a reader to discover it.** The three arm
 definitions and both fixtures are byte-identical on main; the driver, the heap
 probe, the app shell, the harness and the guard are not. The heap rows are
-**not** re-run on that account, and the reason is the one this page and [the
-converged set](p0-converged-witness-set.md) both give: retained bytes per
-subscribing boundary is a property of *the boundary*, and the axis already
-rests on three shapes spanning a 4× range in markup density agreeing within 8%
-— this page's list at 2.262×, its grid at 2.254×, and [the heap
-ladder](reads-per-boundary-heap-ladder.md)'s 2.435×. **The ladder was itself
+**not** re-run on that account: under the heap-regime ruling (rf2-2rtt6.16)
+they stand as shared-query fan-out evidence rather than as the operative
+red-zone family, and the sweep that prices the regimes against each other is
+rf2-5prok's, not a re-take of this arm. The cross-regime check — this page's
+list at 2.262×, its grid at 2.254×, and [the heap
+ladder](reads-per-boundary-heap-ladder.md)'s 2.435× — agrees within 8% because
+the amortisation cancels in the ratio. **The ladder was itself
 re-run under the repaired guard and every threshold moved by less than 0.2%**,
 which is the best available evidence that #7267's guard change is inert. A
 reader who wants the stronger check has the blob table above and the command
@@ -187,11 +197,25 @@ notification path fanning out across 300 subscribed boundaries. That is a
 statement about the React-hook spine's invalidation, not about UIx's rendering,
 and it is the row a native view layer has the clearest structural claim on.
 
-## RED-ZONE — retained heap
+## Retained heap — shared-query fan-out evidence, and the cross-regime check
 
-**Not superseded.** These are the operative retained-heap thresholds; the
-convergence re-ran the clock axis only, for the reason given at the top of the
-page.
+**Regime-qualified, not operative as absolutes** — the heap red-zone regime
+ruling (rf2-2rtt6.16; transcription on rf2-2rtt6.1). The operative
+upper-envelope red-zone family is the
+[heap ladder](reads-per-boundary-heap-ladder.md)'s distinct-query rows (Q = E);
+this section's ratios stay published as the cross-regime check, and its
+absolute rows stand as **fan-out 4 (amortised ×4), shared-query witness
+evidence — not comparable to distinct-query rows**. A candidate row is judged
+only against donor rows measured under the same regime on the same witness.
+
+**Witness stamp — B/E/Q.** Four held roots render the *same* 300 query vectors
+against one frame, so one subscription cache serves every root: **B = 1,200**
+boundaries (300 × 4 roots), **E = 1,200** boundary-query edges (one read per
+boundary, E/B = 1), **Q = 300** unique live query keys — **mean fan-out
+E/Q = 4**. The production cache key is the query vector itself, so four
+consumers of one `(frame, query-vector)` retain one reaction plus four
+attachments, and dividing the held delta by 1,200 boundaries amortises the
+subscription half of every read across four of them.
 
 Retention, never allocation: V8's sampling heap profiler drops the samples of
 collected objects, and on the predecessor's instrument the same 80,000 objects
@@ -200,16 +224,18 @@ driver forces a collection, reads, asks the page to mount 4 roots and keep them,
 collects, reads again, releases, collects, reads a third time.
 
 **Exclusive** = `arm − floor` in the same segment: the substrate's own standing
-cost, and the axis [validation.md](../validation.md) states the budget on
-(~0.4–0.5 KB per boundary target, > 1 KB fails on paper).
+cost. [validation.md](../validation.md)'s budget on this axis — ~0.4–0.5 KB per
+boundary target, > 1 KB fails on paper — is the **R = 0 boundary shell**, not a
+boundary including its reads (heap-regime ruling, rf2-2rtt6.16, Part 3).
 
-| family | **threshold — exclusive (mean)** | range | absolute (mean) | range |
+| family | **cross-regime check — exclusive (mean)** | range | absolute (mean) | range |
 |---|---|---|---|---|
 | **list** (300 sub-reading rows) | **2.262×** | 2.196 – 2.335 | 1.580× | 1.564 – 1.603 |
 | **grid** (300 sub-reading cells) | **2.254×** | 2.217 – 2.288 | 1.989× | 1.968 – 2.002 |
 
-Bytes per boundary, CDP `Runtime.getHeapUsage` after a forced collection, 4 roots
-held:
+Bytes per boundary — **fan-out 4 (amortised ×4), shared-query witness evidence,
+not comparable to distinct-query rows**. CDP `Runtime.getHeapUsage` after a
+forced collection, 4 roots held:
 
 | arm | B/boundary (mean) | range |
 |---|---|---|
@@ -222,14 +248,22 @@ held:
 | `uix-subs \| grid/floor` | 244 | 239 – 247 |
 | `uix-subs \| grid/uix` | **2,378** | 2,372 – 2,388 |
 
-**Exclusive per boundary**: Reagent-on-subs ≈ **954 B** (list) and **947 B**
-(grid); UIx-on-subs ≈ **2,156 B** (list) and **2,134 B** (grid).
+**Exclusive per boundary, fan-out 4 (amortised ×4)**: Reagent-on-subs ≈
+**954 B** (list) and **947 B** (grid); UIx-on-subs ≈ **2,156 B** (list) and
+**2,134 B** (grid). Their distinct-query counterparts on the
+[ladder](reads-per-boundary-heap-ladder.md) read ≈ **1,562 B** and ≈ **3,807 B**
+at one read — the same boundaries, carrying the full subscription instead of a
+quarter of it.
 
-Against the paper budget that is a finding in its own right, and it belongs to
-K3 rather than to the ship number: **the frontier comparator is itself over the
-1 KB paper-fail line, by more than 2×, and the Reagent denominator is close to
-it.** A candidate is red above 2.26×; it is over budget above ~0.5 KB. The two
-lines are far apart and a candidate can sit between them.
+Against the paper budget these figures decide nothing:
+[validation.md](../validation.md)'s ~0.4–0.5 KB target / > 1 KB paper-fail line
+is the **R = 0 boundary shell**, which both measured arms comply with (Reagent
+~418–428 B, UIx ~208 B), and a boundary *including its read* — amortised or not
+— is judged on the per-read axis instead, under the ruling's regime-matched
+gates: UIx **3,552 B/read** [3,551–3,553], worse is RED and needs an explicit
+operator waiver; Reagent **943 B/read** [935–944], worse with no named paper
+path down is K3 territory; between the two is "UIx-rule cleared, K3 open",
+never plain green.
 
 DOM nodes live in Blink's C++ heap, not V8's, so none of these figures contain
 the elements themselves. Every arm builds the identical DOM — the canonical-DOM
@@ -401,8 +435,10 @@ precise wrong number first. They are recorded because the next arm will meet the
   witnesses and re-derived the clock red-zones there; three of the four verdicts
   moved, and U-broad's margin widened from 0.838× to 0.624×. See
   [the converged witness set](p0-converged-witness-set.md). The clock rows above
-  are superseded as thresholds by that page; the heap rows are not, and were
-  deliberately not re-run.
+  are superseded as thresholds by that page; the heap rows were deliberately not
+  re-run, and have since been regime-qualified as shared-query fan-out evidence
+  by the heap-regime ruling (rf2-2rtt6.16), with the operative family on
+  [the ladder](reads-per-boundary-heap-ladder.md).
 - **This arm rides `:freehand-release` for its compiler settings** because the
   epic's sequencing law gives `implementation/shadow-cljs.edn` to rf2-2rtt6.2 and
   that arm had not merged. `P0_BUILD` points the driver at another build id;

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -8,6 +8,20 @@ regression included the R=0 anchor the page promised it excluded. Every figure
 below is a fresh reading through the corrected fit; the superseded publication
 is recorded in [§7](#7-superseded) rather than deleted.
 
+**Regime stamp — distinct-query (Q = E), mandatory worst-case witness,
+operative upper-envelope family.** The heap red-zone regime ruling (delegated
+by Mike, 2026-07-31; authoritative text on rf2-2rtt6.16, transcription on
+rf2-2rtt6.1) makes cache cardinality part of the witness: every heap red-zone
+row stamps **B** (boundaries), **E** (boundary-query edges) and **Q** (unique
+live query keys). On this ladder every read is a distinct query, so **Q = E**
+and the fan-out E/Q is 1 on every rung — Curve B holds B = 1,200 with
+E = 1,200·R, Curve A holds R = 3 with E = 3·B. These rows are the **operative
+upper-envelope red-zone family**: where governance needs one conservative
+number, the distinct-query row is used and labelled an *upper-envelope capacity
+budget*, never "retained bytes per boundary" unqualified. The frontier arm's
+shared-query grid (E/Q = 4) is fan-out witness evidence, not comparable to
+these rows; its ratios remain the cross-regime check.
+
 **The instrument is identified by content hash, not by commit SHA.** A SHA does
 not survive a rebase — the previous publication was invalidated by exactly that,
 and this one was rebased onto `main` between its run and its merge, moving every
@@ -109,8 +123,10 @@ Three consequences, and the second is the one the programme has to act on.
    measured meets it for a boundary that reads once.** Both shells clear it
    (UIx 208 B, Reagent 428 B). At one read UIx is at **3,807 B** — 7.6× the
    1 KB paper-fail line — and Reagent at **1,562 B**, 1.6×. The budget row in
-   [validation.md](../validation.md) needs a per-read companion, or it is
-   unfalsifiable; see [§5](#5-what-this-hands-the-programme).
+   [validation.md](../validation.md) now says so explicitly: the target/fail
+   line is the **R = 0 boundary shell**, and the per-read axis is judged
+   separately under the ruling's regime-matched gates; see
+   [§5](#5-what-this-hands-the-programme).
 3. **HD-002's tier-1 exclusion now has a price in bytes.** The scalar per-read
    hook spine was excluded as product on hook-rule grounds (N reads = N hooks
    breaks HD-020's ≤2-hook budget). Memory says the same thing independently and
@@ -210,6 +226,10 @@ to be compared with the published sub-free rows.
 carries the subscription as well as the hook. That is the editing-grid shape
 (use-case A4, and A3's bulk row), and it is the honest worst case: a page where
 many boundaries read *one* shared sub pays the reaction once, not once each.
+The heap-regime ruling (rf2-2rtt6.16) makes that property normative —
+**distinct-query (Q = E), mandatory worst-case witness, operative
+upper-envelope family** — and a candidate row is judged only against donor rows
+measured under the same regime on the same witness.
 
 **The fit is over 1, 3, 7 and 20 — and over nothing else.** `validation.md`
 requires the ladder to be measured directly and never inferred from a sub-free
@@ -224,7 +244,8 @@ everywhere and regressed nowhere.
 ## 1. Curve B — fixed boundaries × growing reads
 
 1,200 boundaries, reads varying. `y` is retained bytes per boundary above the
-1,200-boundary floor. **A** is six rounds; **fwd**/**rev** split those six by
+1,200-boundary floor. Witness stamp: **B = 1,200 · E = 1,200·R · Q = E**
+(fan-out 1). **A** is six rounds; **fwd**/**rev** split those six by
 plan direction; **C** is the independent snapshot pass.
 
 ### Reagent on re-frame2 subs
@@ -273,7 +294,8 @@ a point that reads nothing.
 
 Three reads throughout; boundaries doubling. `y` is *total* excess over the
 same-size floor, so the slope is bytes per boundary and the intercept is
-whatever the page pays once. This curve never had an R=0 rung and is unaffected
+whatever the page pays once. Witness stamp: **B = 300–2,400 · E = 3·B ·
+Q = E** (fan-out 1). This curve never had an R=0 rung and is unaffected
 by the fit correction; it is re-measured here because everything else was.
 
 | boundaries | Reagent, fwd | Reagent, rev | UIx, fwd | UIx, rev |
@@ -368,10 +390,12 @@ any candidate that misses it is missing something both donors already have.
 
 ## 5. What this hands the programme
 
-**The red-zones for this witness family.** Under the delegated ruling on
-`rf2-2rtt6.1`, the measured UIx retained-heap figure *is* the red-zone
-threshold, and these are it — **re-derived from the corrected fit, superseding
-the values published on 2026-07-30**:
+**The red-zones for this witness family — distinct-query (Q = E), the
+operative upper-envelope family.** Under the delegated ruling on `rf2-2rtt6.1`
+as regime-qualified by the heap-regime ruling (rf2-2rtt6.16), the measured UIx
+retained-heap figure on this witness *is* the red-zone threshold, and these are
+it — witness stamp B = 1,200 · E = 1,200·R · Q = E, **re-derived from the
+corrected fit, superseding the values published on 2026-07-30**:
 
 | axis | UIx red-zone | superseded value |
 |---|---:|---:|
@@ -388,17 +412,17 @@ the correction. They are restated anyway, because a red-zone whose provenance
 is a fit that used a forbidden rung is not a red-zone anyone should have to
 defend.
 
-**One thing the operator should look at before those are applied mechanically.**
-The ruling's rationale is that *UIx is the frontier comparator*. On the clock
-that is the recorded position. **On retained heap, in this family, it is not**:
-UIx is 3.77× worse than Reagent per read, and the crossover sits below a single
-read. A red-zone derived from UIx alone would therefore set a per-read ceiling
-**3.77× looser than the best measured option**, and a candidate could clear it
-comfortably while being worse than the Reagent adapter that already ships. The
-rule as written is still the rule; this page only records that on this axis it
-is not binding, and that **943 B/read is the number a native layer actually has
-to beat.** Whether to tighten the memory red-zone to the per-axis best rather
-than to UIx is the operator's call, and only the operator's.
+**The inversion this page surfaced has been ruled on** (rf2-2rtt6.16, delegated
+by Mike, 2026-07-31; transcription on rf2-2rtt6.1). On retained heap UIx is
+3.77× worse than Reagent per read and the crossover sits below a single read,
+so a UIx-only ceiling is 3.77× looser than the best measured option. The ruling
+keeps **both lines, regime-matched**, rather than re-sourcing the red-zone: the
+red-zone stays UIx-sourced at **3,552 B/read** [3,551–3,553] — worse than that
+is RED and needs an explicit operator waiver naming the dogfood benefit — and
+Reagent's **943 B/read** [935–944] governs through K3 — worse than it with no
+named paper path down is K3 territory. Between the two lines a candidate is
+**"UIx-rule cleared, K3 open until a path down is named"**, never plain green.
+**943 B/read remains the number a native layer actually has to beat.**
 
 **A target for HD-002's grouped tier.** Grouped `use-subs` — one fixed hook
 receiving the whole query collection — can only remove the *hook* half of a
@@ -409,12 +433,20 @@ read**, or **≈18 KB on the census's seven-read archetype**. That is a large
 prize and a concrete pre-registered number, which is what HD-002 clause (c) asks
 strategy hypotheses to be counted against.
 
-**A budget that needs a second row.** `validation.md` sets *exclusive retained
-per boundary* at ~0.4–0.5 KB target, >1 KB paper-fail. Read as a **shell**
-budget it is exactly right and both donors pass. Read as a *boundary including
-its reads* it is unreachable — the cheapest substrate measured is 1.6× the
-paper-fail line at **one** read. The budget table wants a per-read row beside
-the per-boundary one, and the per-read row's honest anchor is 943 B.
+**The budget row is now split, shell from read.**
+[validation.md](../validation.md) sets *exclusive retained per boundary* at
+~0.4–0.5 KB target, >1 KB paper-fail, and per the heap-regime ruling
+(rf2-2rtt6.16, Part 3) that line is explicitly the **R = 0 boundary shell** —
+both donors comply (Reagent ~418–428 B, UIx ~208 B). The per-read axis is
+judged separately under the regime-matched gates above, so the shipped Reagent
+adapter is not retroactively K3-failed: its ~1,562 B at one read is shell
+(~428 B) plus first-read increment (~1,137 B), each judged on its own axis —
+and a candidate cannot pass the paper line by amortising subscriptions across
+boundaries. Component budget rows (shell / per-edge / per-unique-key) enter
+validation.md only after rf2-5prok's fan-out sweep verifies the additive heap
+model and prices the terms; in this witness (Q = E) the 943 B slope is the
+*sum* of the per-edge and per-unique-key terms — a valid total marginal cost in
+this regime only, not a pure view-layer per-read price.
 
 ---
 

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -32,11 +32,21 @@ as HD-nnn are normative in [decisions.md](decisions.md).
 | Budget | Rule |
 |---|---|
 | Runtime/shell hooks per product boundary | ≤ 2 (the subscription/epoch hook + the frame hook, HD-020); a ViewCell-class object graph = failed spike. The scalar *comparator* arm is exempt — it is priced by the 1/3/7/20 heap ladder, not this row |
-| Exclusive retained per boundary | target ~0.4–0.5 KB; > 1 KB fails on paper |
+| Exclusive retained per boundary (**the R=0 boundary shell**) | target ~0.4–0.5 KB; > 1 KB fails on paper. Shell only — a boundary's *reads* are priced on the per-read axis, against the regime-matched red-zone gates (rf2-2rtt6.16) |
 | Per-read | tier-3 survival metric (HD-002): steady-state allocation slope across warm 1/3/7/20 reads, zero retained per-occurrence objects after commit/teardown |
 | Per-keystroke | stated path for a 4-field form and a 100-cell grid; requires sub-recompute localization (which subs recompute, not merely which boundaries re-run) |
 | Template identity | a stated cache key for any cached shape work |
 | Host boundaries | priced separately (foreign components are census-rare) |
+
+The shell budget line is the R=0 boundary shell by ruling (heap red-zone regime
+ruling, delegated by Mike, 2026-07-31; authoritative text on rf2-2rtt6.16,
+transcription on rf2-2rtt6.1): both measured donors comply — Reagent ~418–428 B,
+UIx ~208 B — and a candidate cannot pass the line by amortising subscriptions
+across boundaries, because the distinct-query heap ladder (Q = E) is the
+mandatory worst-case witness and the operative upper-envelope red-zone family.
+Component budget rows (shell / per-edge / per-unique-key) enter this table only
+after rf2-5prok's fan-out sweep verifies the additive heap model and prices the
+terms.
 
 Sub-key identity: `(query-id, args)` under value equality; value-unstable map args
 thrash the index — documented, programmer-trusted. A missed invalidation is a P0


### PR DESCRIPTION
Doc follow-through for the heap red-zone regime ruling (rf2-2rtt6.16, delegated by Mike, 2026-07-31; compact transcription on rf2-2rtt6.1). Four bounded prose edits, each citing the ruling in place — stale claims rewritten, not annotated. Bead: rf2-5e84f.

- **`docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md`** — the retained-heap absolutes are relabelled "fan-out 4 (amortised ×4), shared-query witness evidence — not comparable to distinct-query rows"; the section carries its B/E/Q witness stamp (B = 1,200, E = 1,200, Q = 300, E/Q = 4); the ratios (list 2.262×, grid 2.254×) stay published as the cross-regime check; the operative upper-envelope family points at the ladder. The "property of the boundary" justification is rewritten as what the ruling found it to be: ratio agreement from a common-mode bias that cancels in the ratio. The paper-budget paragraph now reads validation.md's line as the R=0 boundary shell, with the per-read axis judged under the regime-matched gates (UIx 3,552 B/read [3,551–3,553] RED beyond; Reagent 943 B/read [935–944] K3 territory beyond; between = "UIx-rule cleared, K3 open", never plain green).
- **`docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md`** — stamped "distinct-query (Q = E), mandatory worst-case witness, operative upper-envelope family", with B/E/Q on both curves and on the red-zone table; the operator-inversion paragraph now records the ruling's resolution (red-zone stays UIx-sourced, Reagent governs through K3, three-state verdict); the budget paragraph records the shell/read split, the 943 B slope as the per-edge + per-unique-key sum valid in this regime only, and component rows deferred to rf2-5prok.
- **`docs/design/hicasso/validation.md`** — the "exclusive retained per boundary" budget row is explicitly the R=0 boundary shell (both measured donors comply: Reagent ~418–428 B, UIx ~208 B); a candidate cannot pass it by amortising subscriptions across boundaries; component budget rows (shell / per-edge / per-unique-key) enter only after rf2-5prok's sweep verifies the additive model.
- **`docs/design/hicasso/studio/README.md`** — the "retained-heap red-zones are not superseded" banner is replaced with the regime-matched statement, and the two Pages-table blurbs (frontier arm, ladder) now say which family governs.

## Quality gates

- `python -m mkdocs build --strict` — **exit 0** (log captured worktree-local as `mkdocs-gate.log`; the residual INFO lines are pre-existing `spec/API.md` anchor notes untouched by this PR).
- Prose-only edits under `docs/design/hicasso/` — no code, no bench instrument, no build surface touched, so no code gate runs.