### PR TITLE
scripts(beads): checkpoint exports must carry the memories under bd v1.1.2 (rf2-fifk0)

### DIFF
--- a/scripts/beads-checkpoint.ps1
+++ b/scripts/beads-checkpoint.ps1
@@ -210,6 +210,11 @@ function Test-SameContent {
 # primary worktree is the first entry of `git worktree list --porcelain`; the
 # same derivation as scripts/git-hooks/lib/check-beads-boundary.sh and
 # scripts/assert-worker-worktree.ps1, with the same RF2_MAYOR_ROOT override.
+#
+# Only the COMMITTING arm is gated. -PrePull is a read-only question -
+# "would clearing .beads discard tracker state?" - that every worktree
+# legitimately asks before its own pull, and it must keep answering from
+# worker worktrees (rf2-fifk0).
 # ---------------------------------------------------------------------------
 function Get-NormalizedPath {
     param([string]$Path)
@@ -219,19 +224,21 @@ function Get-NormalizedPath {
     return ($Path -replace '\\', '/').TrimEnd('/').ToLowerInvariant()
 }
 
-$gitRoot = (& git rev-parse --show-toplevel 2>$null)
-if ($LASTEXITCODE -ne 0 -or -not $gitRoot) {
-    Die 'not inside a git checkout.'
-}
-$primary = $env:RF2_MAYOR_ROOT
-if (-not $primary) {
-    $primary = (& git worktree list --porcelain |
-        Where-Object { $_ -like 'worktree *' } |
-        Select-Object -First 1) -replace '^worktree ', ''
-}
-if ($primary -and
-    (Get-NormalizedPath $gitRoot.Trim()) -ne (Get-NormalizedPath $primary.Trim())) {
-    Die 'this is a linked (worker) worktree; the tracker database is the mayor checkout''s to commit.'
+if (-not $PrePull) {
+    $gitRoot = (& git rev-parse --show-toplevel 2>$null)
+    if ($LASTEXITCODE -ne 0 -or -not $gitRoot) {
+        Die 'not inside a git checkout.'
+    }
+    $primary = $env:RF2_MAYOR_ROOT
+    if (-not $primary) {
+        $primary = (& git worktree list --porcelain |
+            Where-Object { $_ -like 'worktree *' } |
+            Select-Object -First 1) -replace '^worktree ', ''
+    }
+    if ($primary -and
+        (Get-NormalizedPath $gitRoot.Trim()) -ne (Get-NormalizedPath $primary.Trim())) {
+        Die 'this is a linked (worker) worktree; the tracker database is the mayor checkout''s to commit.'
+    }
 }
 
 $tmpExport = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(),
@@ -282,7 +289,12 @@ try {
         Die 'bd is not on PATH; a checkpoint must re-export from the database, so it cannot proceed.'
     }
 
-    $code = Invoke-RawToFile -Exe $bdCmd.Source -Arguments @('export') -OutFile $tmpExport
+    # --include-memories is load-bearing (rf2-fifk0). bd v1.1.2 made the bare
+    # export EXCLUDE the `bd remember` memory rows that v1.0.3 always carried,
+    # so a flagless checkpoint would silently drop every one of them - caught
+    # only because the shrink floor below refused the memory-less export
+    # against HEAD. The tracker commits whole: issues AND memories.
+    $code = Invoke-RawToFile -Exe $bdCmd.Source -Arguments @('export', '--include-memories') -OutFile $tmpExport
     if ($code -ne 0) {
         Die "bd export failed (exit $code); leaving $tracker untouched."
     }

--- a/scripts/beads-checkpoint.sh
+++ b/scripts/beads-checkpoint.sh
@@ -89,9 +89,14 @@ cd "$REPO_ROOT"
 # library so there is one rule in one place. If the library is missing (a
 # partial checkout), skip the check rather than refuse — the pre-commit hook
 # and the CI arm are the enforcement; this is a convenience.
+#
+# Only the COMMITTING arm is gated. --pre-pull is a read-only question —
+# "would clearing `.beads` discard tracker state?" — that every worktree
+# legitimately asks before its own pull, and it must keep answering from
+# worker worktrees (rf2-fifk0).
 # ---------------------------------------------------------------------------
 BOUNDARY_LIB="$REPO_ROOT/scripts/git-hooks/lib/check-beads-boundary.sh"
-if [ -f "$BOUNDARY_LIB" ]; then
+if [ "$MODE" = "checkpoint" ] && [ -f "$BOUNDARY_LIB" ]; then
   # shellcheck source=git-hooks/lib/check-beads-boundary.sh
   . "$BOUNDARY_LIB"
   if ! rf2_beads_in_primary_worktree; then
@@ -218,7 +223,13 @@ command -v bd >/dev/null 2>&1 \
 TMP_EXPORT=$(mktemp "${TMPDIR:-/tmp}/rf2-bdchk-export-XXXXXX")
 # Redirect rather than `bd export -o`: a shell redirection needs no path
 # translation, so this works identically under Git Bash and on Unix.
-bd export > "$TMP_EXPORT" 2>/dev/null \
+#
+# --include-memories is load-bearing (rf2-fifk0). bd v1.1.2 made the bare
+# export EXCLUDE the `bd remember` memory rows that v1.0.3 always carried, so
+# a flagless checkpoint would silently drop every one of them — caught only
+# because the shrink floor below refused the memory-less export against HEAD.
+# The tracker commits whole: issues AND memories.
+bd export --include-memories > "$TMP_EXPORT" 2>/dev/null \
   || die "bd export failed; leaving $TRACKER untouched."
 
 TMP_HEAD=$(mktemp "${TMPDIR:-/tmp}/rf2-bdchk-head-XXXXXX")

--- a/scripts/git-hooks/README.md
+++ b/scripts/git-hooks/README.md
@@ -393,12 +393,16 @@ From rf2-51uz1, on the other side of the same boundary — the checkpoint helper
 (`scripts/beads-checkpoint.sh`), against a stub `bd`:
 
 19. A `bd close` that exists only in the database survives the standard
-    `git checkout HEAD -- .beads` cleanup, because the checkpoint re-exports
+    `git checkout HEAD -- .beads` cleanup, because the checkpoint re-exports —
+    and the committed tracker still carries its memory rows, because the
+    export runs `--include-memories` (bd v1.1.2 drops them bare, rf2-fifk0)
 20. `--pre-pull` refuses while the working export is ahead of HEAD, and is
     silent once it is not
 21. A failed or empty export commits nothing and leaves the tracker untouched
 22. A memory reorder is not a change, so it is not a commit
-23. A worker worktree is refused: the tracker database is the mayor's to commit
+23. A worker worktree is refused the committing arm — the tracker database is
+    the mayor's to commit — while `--pre-pull`, the read-only question, still
+    answers there
 
 From rf2-or8te, driving the floor from the sandbox's **primary** worktree —
 the checkout both incidents came from, and the one every layer above no-ops in:

--- a/scripts/git-hooks/test-pre-commit.sh
+++ b/scripts/git-hooks/test-pre-commit.sh
@@ -1213,6 +1213,12 @@ rm -rf "$RBOX"
 # reorder-ONLY export producing no commit at all; 8h pins the normal case — one
 # real edit commits exactly that edit — and 8i pins the shrink guard that the
 # ordering work must not cost.
+#
+# WHETHER THE MEMORIES RIDE AT ALL is the third (rf2-fifk0). bd v1.1.2 made the
+# bare `bd export` EXCLUDE the `bd remember` rows that v1.0.3 always carried,
+# so the stub models that contract and 8a asserts the committed tracker still
+# carries its memories — a checkpoint that loses --include-memories fails here
+# before it can silently drop every memory on main.
 # ----------------------------------------------------------------------------
 
 printf '\n[8] checkpoint helper: export from the database, never the working file\n'
@@ -1235,13 +1241,21 @@ CBIN="$CBOX/bin"
 mkdir -p "$CBIN" "$CREPO/scripts/git-hooks/lib" "$CREPO/.beads"
 cat > "$CBIN/bd" <<EOF
 #!/usr/bin/env sh
-# Stub bd for the layer-8 checkpoint tests. Prints the "database" on stdout,
-# the way \`bd export\` does; fails when told to.
+# Stub bd for the layer-8 checkpoint tests. Prints the "database" on stdout
+# the way \`bd export\` does under bd v1.1.2: memory rows ride ONLY behind
+# --include-memories (rf2-fifk0 — a bare export silently drops every one).
+# Fails when told to.
 if [ -f "$CBOX/bd-fails" ]; then
   printf 'stub bd: export failed\n' >&2
   exit 1
 fi
-cat "$CBOX/db.jsonl"
+for arg in "\$@"; do
+  if [ "\$arg" = "--include-memories" ]; then
+    cat "$CBOX/db.jsonl"
+    exit 0
+  fi
+done
+grep -v '"_type":"memory"' "$CBOX/db.jsonl" || :
 EOF
 chmod +x "$CBIN/bd"
 
@@ -1298,7 +1312,17 @@ case "$out" in
       *)
         fail "(8a) the close EVAPORATED: the checkpoint committed the reverted file"
         printf '%s\n' "$committed" >&2 ;;
-    esac ;;
+    esac
+    # The memories must ride the same commit (rf2-fifk0). The stub models bd
+    # v1.1.2, where only `bd export --include-memories` carries them — a
+    # checkpoint that goes back to the bare export commits an issues-only
+    # tracker here and this assertion catches it.
+    if [ "$(printf '%s\n' "$committed" | grep -c '"_type":"memory"')" = "2" ]; then
+      pass "(8a) and both memory rows survive: the export runs --include-memories"
+    else
+      fail "(8a) the commit DROPPED memory rows: the export is running bare (rf2-fifk0)"
+      printf '%s\n' "$committed" >&2
+    fi ;;
   *) fail "(8a) checkpoint failed ($out)"; cat "$CERR" >&2 ;;
 esac
 
@@ -1405,6 +1429,19 @@ case "$out" in
       fail "(8g) refused in a worker worktree, but not for the stated reason"
       cat "$CERR" >&2
     fi ;;
+esac
+
+# The READ-ONLY arm is not gated (rf2-fifk0): any worktree may ask whether
+# clearing `.beads` is safe before its own pull. The COMMIT is the mayor's;
+# the question is everyone's. The fresh worktree matches its HEAD, so the
+# answer here is a silent yes.
+out=$(run_checkpoint "$CWORKER" --pre-pull)
+case "$out" in
+  EXIT=0)
+    pass "(8g) but --pre-pull still answers from a worker worktree: read-only is not gated" ;;
+  *)
+    fail "(8g) --pre-pull refused to answer from a worker worktree ($out)"
+    cat "$CERR" >&2 ;;
 esac
 git -C "$CREPO" worktree remove --force "$CWORKER" >/dev/null 2>&1 || true
 


### PR DESCRIPTION
## What

rf2-fwij4 migrated the tracker to bd v1.1.2, whose bare `bd export` EXCLUDES the 565 `bd remember` memory rows that v1.0.3 always included. Both checkpoint siblings called the bare export, so every future checkpoint would have silently dropped every memory from `.beads/issues.jsonl` — caught only because the shrink floor refused the 1997-row export against HEAD's 2561.

- `scripts/beads-checkpoint.sh` and `scripts/beads-checkpoint.ps1` now run `bd export --include-memories`. The shrink floor is untouched — it just proved its worth.
- The layer-8 test stub `bd` in `scripts/git-hooks/test-pre-commit.sh` now models the v1.1.2 export contract (memory rows ride only behind `--include-memories`), and 8a asserts the committed tracker still carries its memory rows. Negative control: with the flag stripped from the checkpoint script, 8a/8f/8h fail — the pin bites.
- The mayor-only boundary in both siblings now gates only the COMMITTING arm. `--pre-pull` / `-PrePull` is a read-only question — "would clearing `.beads` discard tracker state?" — that every worktree legitimately asks before its own pull, and it previously refused to answer from a worker worktree at all. A new 8g case pins that split; the committing arm is still refused there (existing 8g).
- `scripts/git-hooks/README.md` coverage list (items 19 and 23) updated to match.

## Other bare-export sites inspected

- `scripts/check-beads-pr-boundary.sh`: no `bd export` invocation or assumption — it classifies PR diff paths only. Clean.
- `scripts/git-hooks/pre-commit` + `lib/check-beads-boundary.sh` (truncation floor): compares staged row count against HEAD's — content-agnostic, no export assumption. Clean, unchanged.
- Repo-wide `git grep 'bd export'`: the only remaining mentions are prose (CLAUDE.md's Beads durability section still describes the checkpoint as running `bd export`; left alone — mayor-owned file with uncommitted edits in the mayor checkout) and bead/memory text inside the tracker itself.

## Quality gates

All run foreground from the worker worktree `C:/Users/miket/code/re-frame2-worktrees/ckpt-fifk0`, logs under the worktree's gitignored `ai/findings/`:

- `sh scripts/git-hooks/test-pre-commit.sh` — 68 passed, 0 failed, exit 0 (includes the new 8a memory-survival and 8g pre-pull assertions)
- Negative control: flag stripped via sed, suite exit 1 with `FAIL (8a)/(8f)/(8h-seed)/(8h)`, then restored
- `sh scripts/beads-checkpoint.sh --pre-pull` from the worker worktree — exit 0
- `powershell -ExecutionPolicy Bypass -File scripts/beads-checkpoint.ps1 -PrePull` from the worker worktree — exit 0
- Export-shape probe, same invocation the scripts now use, written to a gitignored temp file and deleted: `bd export --include-memories` exit 0, 2563 total rows = 1998 issue rows (matches `bd info` Issue Count: 1998) + 565 memory rows (the exact count the bead names)

The committing checkpoint was deliberately NOT run from this worktree: worker branches never carry `.beads/issues.jsonl`; the tracker database is the mayor's to commit. The first mayor-side `sh scripts/beads-checkpoint.sh` after merge is the end-to-end confirmation.