### PR TITLE
bench(hicasso): drain inside the boundary — retake the slim writes; siblings adopt container-released! (rf2-b69lw, rf2-jk3vj, rf2-z3vlz)

### DIFF
--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -523,7 +523,7 @@ verdicts, and they are the whole of it:
 |---|---|---|
 | `:not-owed` | every arm in the row shares one window shape | published unchanged — the harness turns are in numerator and denominator alike |
 | `:below-resolution` | the row mixes shapes and the **aggregate** yield window's max is `0.0` across every sample | published unadjusted, with the bound on the record rather than assumed |
-| `:corrected` | mixed shapes, aggregate nonzero | the subtraction is **applied**; the corrected band is published beside the unadjusted one |
+| `:corrected` | mixed shapes, aggregate nonzero | the subtraction is **applied**; both bands publish, labelled `[UNADJUSTED]` and `[CORRECTED]` in the cross-run table itself |
 | `:refused` | the correction cannot be discharged | **nothing in the row may be published**, and the run exits non-zero |
 
 **Which rows owe anything: the `slim` run's, and no others.** A row owes only
@@ -534,11 +534,21 @@ harness turns, so there is nothing asymmetric to correct.
 **Two ways to be refused, and neither has a tolerance of its own.**
 
 * **The correction changes the verdict.** If subtracting the bound moves any
-  published range across `1.0` — indistinguishable becoming a finding, or the
-  reverse — then what the row reports is the asymmetry rather than the arms. The
-  test is the instrument's **own house rule** (`:straddles-1?`), deliberately:
-  a contract that decides whether a row may be published is not entitled to
-  invent a threshold for doing so.
+  published range across `1.0` — indistinguishable becoming a finding, the
+  reverse, or a band crossing the line *whole* — then what the row reports is
+  the asymmetry rather than the arms. The test is **three-state**
+  (`hd8-rows/side-of-1`: below, straddles, above — any change of state is a
+  crossing), and it earned its third state from the PR #7282 audit: the first
+  cut compared the `:straddles-1?` boolean at both ends, and a band wholly
+  below `1.0` that lands wholly above it never straddles at either end —
+  `false → false`, a complete direction reversal accepted as `:corrected`. The
+  audit's live-rule counterexample is two slim-row rounds at floor `1.0` /
+  `reagent-slim` `0.95` under a `0.1 ms` bound: `0.95×` unadjusted, `1.0556×`
+  corrected, the bearer survives, and neither band straddles. The
+  classification is still the instrument's **own house rule** extended to
+  which side of the line a decided band sits on, deliberately: a contract
+  that decides whether a row may be published is not entitled to invent a
+  threshold for doing so.
 * **The correction exceeds the window** — a yield-bearing arm for which what
   *remains* after the subtraction does not exceed what was *removed*. That
   window was measuring the harness's turns rather than the arm.
@@ -577,16 +587,24 @@ So the contract has a **self-test**, replayed from recorded fixtures through the
 live rule, run inside the bundle **before any clock**, and fatal when it
 disagrees: `hd8-app` throws, `hd8_run.cjs` prints every check and exits `1`. It
 is `order_guard.cjs`'s technique and `parity-can-fail?`'s argument, applied to
-the newest gate rather than only the oldest ones. Six fixtures: one per verdict,
-and one per refusal reason. **Fixture 4 is the `15,518,934×` row**, kept so that
-repair cannot silently come undone.
+the newest gate rather than only the oldest ones. Seven fixtures: one per
+verdict, one per refusal reason, and one per repaired hole in the rule itself.
+**Fixture 4 is the `15,518,934×` row** and **fixture 7 is the whole-band
+crossing** — the `0.95× → 1.0556×` reversal the boolean test accepted — each
+kept so its repair cannot silently come undone.
 
 **No figure on this page moves.** The contract reads the rows; it does not take
 them. A full three-run sweep on the branch that added it returns `:not-owed` on
 every `uix` and `reagent` write row and `:below-resolution` on both `slim` write
 rows — the aggregate read `0.0` in all ten of its windows, both at `k = 10` and
 at `k = 1` — so the ratios above stand exactly as published, now with the bound
-checked rather than asserted.
+checked rather than asserted. A full sweep at the three-state repair (authored
+`79de836f35`; the landed SHA is the merge's to mint) answers the same, exit
+`0`: `:not-owed` on all four
+`uix`/`reagent` write rows, `:below-resolution` on both `slim` rows with every
+aggregate window at `0.0`, every read-back `0` unverified, and every slim write
+range overlapping the published one — the repair moves gate logic and table
+labelling, not a number.
 
 **And the contract has been watched doing the other thing, which is the only
 reason to trust it.** A `slim`-only run on the same branch and the same host
@@ -600,6 +618,17 @@ figures are not quoted here: that run was `HD8_ONLY=slim` with no `HD8_ROWS`, so
 every row it produced is marked non-publishing, and the point being made is
 about the gate rather than about the numbers. This is the case the old page
 promised to act on and the old driver exited `0` through.
+
+**The `:corrected` verdict carried a second hole, found by the same audit: its
+bands were published in the EDN record and nowhere else.** `yield-correction`
+computed `:summary-corrected` and `:head-to-head-corrected`, but the export
+carried only verdict, reason, bound and why, and the cross-run table — the
+thing a reader copies a figure out of — printed the unadjusted endpoints alone.
+So a `:corrected` run announced that both bands publish while exposing exactly
+one of them. The export now carries both bands on a `:corrected` verdict, and
+the table prints each governed figure twice, labelled `[UNADJUSTED]` and
+`[CORRECTED]`, so a figure cannot leave the table without the name of its
+band.
 
 **Second-order, worth stating in the same pass.** The same reasoning applies
 wherever a sub-quantum per-item cost is asserted negligible across a batch.

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
@@ -79,6 +79,25 @@
     (set! (.-HD8_SAMPLES js/window) acc)
     nil))
 
+(defn- pack-bands
+  "A per-figure RANGE map packed as plain JS for the driver.
+
+  Shared by [[summary!]] and [[correction!]] rather than private to the
+  first: a `:corrected` verdict's bands ride the exact shape the unadjusted
+  ones do, so the driver reads both with ONE reader and the cross-run table
+  cannot end up labelling one band in a format the other lacks."
+  [m]
+  (clj->js
+    (into {} (map (fn [[k v]]
+                    [(name k)
+                     (if (:unpublished v)
+                       {"unpublished" (name (:unpublished v))
+                        "unverified"  (:unverified v)
+                        "of"          (:of v)}
+                       {"min" (:min v) "max" (:max v)
+                        "straddles1" (boolean (:straddles-1? v))})]))
+          m)))
+
 (defn- summary!
   "Park one row's floor-normalised RANGE per arm, plus its head-to-head
   ranges, in a shape the driver can read without an EDN reader.
@@ -87,21 +106,10 @@
   overlapping ranges mean indistinguishable, and a table of means invites
   exactly the reading the rule forbids."
   [row-name r]
-  (let [acc (or (.-HD8_SUMMARY js/window) #js {})
-        pack (fn [m]
-               (clj->js
-                 (into {} (map (fn [[k v]]
-                                 [(name k)
-                                  (if (:unpublished v)
-                                    {"unpublished" (name (:unpublished v))
-                                     "unverified"  (:unverified v)
-                                     "of"          (:of v)}
-                                    {"min" (:min v) "max" (:max v)
-                                     "straddles1" (boolean (:straddles-1? v))})]))
-                       m)))]
+  (let [acc (or (.-HD8_SUMMARY js/window) #js {})]
     (aset acc (name row-name)
-          #js {"vsFloor" (pack (:summary r))
-               "headToHead" (pack (:head-to-head r))})
+          #js {"vsFloor" (pack-bands (:summary r))
+               "headToHead" (pack-bands (:head-to-head r))})
     (set! (.-HD8_SUMMARY js/window) acc)
     nil))
 
@@ -111,19 +119,27 @@
   (record! k (dissoc r :samples)))
 
 (defn- correction!
-  "Park one write row's yield-correction VERDICT where the driver can read
-  it without an EDN reader, so the cross-run table can stamp the row.
+  "Park one write row's yield-correction VERDICT — and, on `:corrected`,
+  BOTH of its bands — where the driver can read them without an EDN
+  reader, so the cross-run table can stamp the row.
 
   A corrected row that appears in the table looking uncorrected is the
   exact fault this contract exists to prevent, and the table is what a
-  reader copies a figure out of."
+  reader copies a figure out of. That argument covers the ENDPOINTS too:
+  this export used to carry the verdict and not the corrected bands, so a
+  `:corrected` run announced that both bands publish while the copyable
+  table could print only the unadjusted one (rf2-b69lw, from the PR #7282
+  audit)."
   [row-name v]
-  (let [acc (or (.-HD8_CORRECTION js/window) #js {})]
-    (aset acc (name row-name)
-          #js {"verdict" (name (:verdict v))
-               "reason"  (some-> (:reason v) name)
-               "bound"   (:bound v)
-               "why"     (:why v)})
+  (let [acc (or (.-HD8_CORRECTION js/window) #js {})
+        o   #js {"verdict" (name (:verdict v))
+                 "reason"  (some-> (:reason v) name)
+                 "bound"   (:bound v)
+                 "why"     (:why v)}]
+    (when (= :corrected (:verdict v))
+      (aset o "summaryCorrected" (pack-bands (:summary-corrected v)))
+      (aset o "headToHeadCorrected" (pack-bands (:head-to-head-corrected v))))
+    (aset acc (name row-name) o)
     (set! (.-HD8_CORRECTION js/window) acc)
     nil))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
@@ -735,11 +735,19 @@
             {:arm a :container c :handle ((:mount a) c)}))
         arm-ids))
 
-(defn release-write-arms! [mounts]
+(defn release-write-arms!
+  "Release every write arm. A throw is RECORDED, never swallowed — and a
+  normal return is not taken at its word: `lane/container-released!` reads
+  each container before it is removed, exactly as `lane/release!` does,
+  because a root that survives its own unmount does so on a DETACHED tree
+  no later census can see (rf2-jk3vj)."
+  [mounts]
   (doseq [{:keys [arm handle container]} mounts]
-    (try ((:unmount arm) handle)
-         (catch :default e
-           (lane/teardown-failure! (str "release-write-arms! " (:id arm)) e)))
+    (when (try ((:unmount arm) handle)
+               true
+               (catch :default e
+                 (lane/teardown-failure! (str "release-write-arms! " (:id arm)) e)))
+      (lane/container-released! (str "release-write-arms! " (:id arm)) container))
     (.remove container)))
 
 (defn assert-teardown-clean!

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
@@ -1104,6 +1104,25 @@
       {:p50   adj
        :ratio (into {} (map (fn [[id v]] [id (round4 (/ v floor))])) adj)})))
 
+(defn- side-of-1
+  "Which side of 1.0 a published range sits on — `:below`, `:straddles` or
+  `:above`.
+
+  Three states rather than the `:straddles-1?` boolean, because the boolean
+  cannot see a COMPLETE crossing: a band wholly below 1.0 that lands wholly
+  above it after correction is `false -> false`, no straddle at either end,
+  and the PR #7282 audit built a live-rule counterexample that published
+  exactly that — 0.95x unadjusted, 1.0556x corrected, a full direction
+  reversal accepted as `:corrected`. The classification is still the
+  instrument's own house rule extended to which side of the line a DECIDED
+  band sits on: `:straddles-1?` names the indistinguishable state, and the
+  other two are the only places a decided band can be."
+  [v]
+  (cond
+    (:straddles-1? v) :straddles
+    (< (:max v) 1.0)  :below
+    :else             :above))
+
 (defn yield-correction
   "Adjudicate one write row against the harness-microtask asymmetry, and
   answer a verdict rather than an observation (rf2-b69lw).
@@ -1149,11 +1168,18 @@
 
     (a) THE CORRECTION CHANGES THE VERDICT. If subtracting the bound moves
         any published range across 1.0 — indistinguishable becoming a
-        finding, or a finding becoming indistinguishable — then what the
-        row reports is an artefact of the asymmetry. The test is the
-        instrument's OWN house rule (`:straddles-1?`), not a threshold
-        invented here, which is deliberate: this contract is not entitled
-        to a tolerance of its own.
+        finding, a finding becoming indistinguishable, or a band leaping
+        the line WHOLE, wholly below 1.0 before the correction and wholly
+        above it after — then what the row reports is an artefact of the
+        asymmetry. The test is three-state ([[side-of-1]]): a band is
+        below, straddling, or above, and ANY change of state is a
+        crossing. It began as a comparison of the `:straddles-1?` boolean
+        alone, and a complete reversal never flips that boolean — the PR
+        #7282 audit's counterexample published 0.95x unadjusted as 1.0556x
+        corrected through exactly that hole. The classification is still
+        the instrument's OWN house rule extended to which side of the line
+        a decided band sits on, not a threshold invented here: this
+        contract remains not entitled to a tolerance of its own.
 
     (b) THE CORRECTION EXCEEDS THE WINDOW — a bearer for which what REMAINS
         after the subtraction does not exceed what was REMOVED. That window
@@ -1244,20 +1270,20 @@
                                 "survives only by a rounding error is not a denominator"))
           (let [summary'  (lane/across-rounds (mapv :ratio corrected))
                 h2h'      (head-to-head corrected)
+                ;; [[side-of-1]] on both ends, and ANY change of state is a
+                ;; crossing. Comparing the `:straddles-1?` booleans is not
+                ;; the same test: a band that leaps the line WHOLE never
+                ;; straddles at either end (PR #7282 audit).
+                crossed   (fn [id v v']
+                            (when (and v' (not (:unpublished v))
+                                       (not= (side-of-1 v) (side-of-1 v')))
+                              {:figure id :was v :corrected v'
+                               :was-side (side-of-1 v) :now-side (side-of-1 v')}))
                 flipped   (into []
-                                (keep (fn [[id v]]
-                                        (let [v' (get summary' id)]
-                                          (when (and v' (not (:unpublished v))
-                                                     (not= (boolean (:straddles-1? v))
-                                                           (boolean (:straddles-1? v'))))
-                                            {:figure id :was v :corrected v'}))))
+                                (keep (fn [[id v]] (crossed id v (get summary' id))))
                                 (:summary row))
                 flipped   (into flipped
-                                (keep (fn [[id v]]
-                                        (let [v' (get h2h' id)]
-                                          (when (and v' (not= (boolean (:straddles-1? v))
-                                                              (boolean (:straddles-1? v'))))
-                                            {:figure id :was v :corrected v'}))))
+                                (keep (fn [[id v]] (crossed id v (get h2h' id))))
                                 (:head-to-head row))]
             (if (seq flipped)
               (assoc base :verdict :refused :reason :correction-changes-the-verdict
@@ -1313,7 +1339,10 @@
   Fixture 4 is not invented. It is the row that made the survival test
   `pos?` publish a corrected ratio of 15,518,934x — a bulk floor of one
   clock quantum against a bound of one clock quantum — and it is here so
-  that repair cannot silently come undone."
+  that repair cannot silently come undone. Fixture 7 is not invented
+  either: it is the PR #7282 audit's counterexample, the band that crossed
+  1.0 WHOLE without flipping `:straddles-1?` at either end, published as
+  0.95x unadjusted and 1.0556x corrected — kept here for the same reason."
   []
   (let [zero-yc    {:p50 0 :min 0 :max 0 :n 10
                     :batched {:k narrow-batch-k :window-p50 0 :window-max 0 :n 10}}
@@ -1380,6 +1409,20 @@
                              :slim no-agg-yc)]
            {:name "no aggregate measured for this row's k is REFUSED as unevaluable"
             :ok   (and (= :refused (:verdict v)) (= :unevaluable (:reason v)))
+            :detail (str (name (:verdict v)) "/" (some-> (:reason v) name))})
+
+         ;; 7. THE WHOLE-BAND CROSSING (PR #7282 audit). A band wholly below
+         ;;    1.0 that lands wholly above it after correction never flips
+         ;;    `:straddles-1?` — false -> false at both ends — and the
+         ;;    boolean test published exactly this complete direction
+         ;;    reversal as :corrected: 0.95x unadjusted, 1.0556x corrected.
+         ;;    [[side-of-1]] is three-state so that it cannot.
+         (let [v (verdict-of (fixture-row :U-narrow narrow-batch-k [:floor :reagent-slim]
+                                          [{:floor 1.0 :reagent-slim 0.95} {:floor 1.0 :reagent-slim 0.95}])
+                             :slim live-yc)]
+           {:name "a band that crosses 1.0 WHOLE (no straddle at either end) is REFUSED"
+            :ok   (and (= :refused (:verdict v))
+                       (= :correction-changes-the-verdict (:reason v)))
             :detail (str (name (:verdict v)) "/" (some-> (:reason v) name))})]]
     {:ok?    (every? :ok checks)
      :checks (mapv (fn [c] (update c :ok boolean)) checks)}))

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
@@ -274,11 +274,12 @@ async function runOne(chromium, run) {
     const results = await page.evaluate('window.HD8_RESULTS || {}');
     const samples = await page.evaluate('window.HD8_SAMPLES || []');
     const summary = await page.evaluate('window.HD8_SUMMARY || {}');
-    // The harness-microtask correction's VERDICT per write row (rf2-b69lw).
-    // On a JS-readable channel rather than only inside the EDN record,
-    // because the cross-run table is what a reader copies a figure out of and
-    // a corrected row that appears there looking uncorrected is the fault the
-    // contract exists to prevent.
+    // The harness-microtask correction's VERDICT per write row — and, on a
+    // `:corrected` row, BOTH of its bands (rf2-b69lw). On a JS-readable
+    // channel rather than only inside the EDN record, because the cross-run
+    // table is what a reader copies a figure out of and a corrected row that
+    // appears there looking uncorrected — or whose corrected endpoints the
+    // table cannot print — is the fault the contract exists to prevent.
     const correction = await page.evaluate('window.HD8_CORRECTION || {}');
     // The contract's own self-test result, on a JS-readable channel so the
     // driver can FAIL on it rather than leaving it in an EDN blob nobody
@@ -367,12 +368,32 @@ function crossRun(runs) {
         );
         out.push(`;;                 ${c.why}`);
       }
+      // A `:corrected` verdict publishes BOTH bands, so BOTH must be in the
+      // table a reader copies from. The EDN record carried the corrected
+      // endpoints while this table printed only the unadjusted ones — a
+      // corrected row whose correction a reader cannot copy (rf2-b69lw,
+      // from the PR #7282 audit). Each line carries its own label, so a
+      // figure cannot leave the table without the name of its band.
+      const cSummary = c && c.verdict === 'corrected' ? c.summaryCorrected || {} : {};
+      const cH2h = c && c.verdict === 'corrected' ? c.headToHeadCorrected || {} : {};
       for (const [arm, v] of Object.entries(s.vsFloor)) {
         if (arm === 'floor') continue;
-        out.push(`;;     [${run.id.padEnd(7)}] ${arm.padEnd(14)} vs floor   ${band(v)}${mark}`);
+        const cv = cSummary[arm];
+        out.push(
+          `;;     [${run.id.padEnd(7)}] ${arm.padEnd(14)} vs floor   ${band(v)}${cv ? '  [UNADJUSTED]' : ''}${mark}`
+        );
+        if (cv) {
+          out.push(`;;     [${run.id.padEnd(7)}] ${arm.padEnd(14)} vs floor   ${band(cv)}  [CORRECTED]${mark}`);
+        }
       }
       for (const [pair, v] of Object.entries(s.headToHead)) {
-        out.push(`;;     [${run.id.padEnd(7)}] ${pair.padEnd(26)}  ${band(v)}${mark}`);
+        const cv = cH2h[pair];
+        out.push(
+          `;;     [${run.id.padEnd(7)}] ${pair.padEnd(26)}  ${band(v)}${cv ? '  [UNADJUSTED]' : ''}${mark}`
+        );
+        if (cv) {
+          out.push(`;;     [${run.id.padEnd(7)}] ${pair.padEnd(26)}  ${band(cv)}  [CORRECTED]${mark}`);
+        }
       }
     }
   }

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
@@ -528,11 +528,19 @@
             {:arm a :container c :handle handle}))
         arms))
 
-(defn- release-bulk-arms! [mounts]
+(defn- release-bulk-arms!
+  "Release every bulk arm. A throw is RECORDED, never swallowed — and a
+  normal return is not taken at its word: `lane/container-released!` reads
+  each container before it is removed, exactly as `lane/release!` and
+  `p0_reagent_app`'s sibling do, because a root that survives its own
+  unmount does so on a DETACHED tree no later census can see (rf2-jk3vj)."
+  [mounts]
   (doseq [{:keys [arm handle container]} mounts]
-    (try ((:unmount arm) handle)
-         (catch :default e
-           (lane/teardown-failure! (str "release-bulk-arms! " (:id arm)) e)))
+    (when (try ((:unmount arm) handle)
+               true
+               (catch :default e
+                 (lane/teardown-failure! (str "release-bulk-arms! " (:id arm)) e)))
+      (lane/container-released! (str "release-bulk-arms! " (:id arm)) container))
     (.remove container)))
 
 (def ^:private assert-teardown-clean!

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_probe.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_probe.cljs
@@ -356,10 +356,15 @@
                  ;; root, its `reg-view` boundaries and their subscriptions
                  ;; standing, and the next page's arms would be certified on
                  ;; a contaminated document. The container is detached either
-                 ;; way; the record is what makes it fatal.
-                 (try (unmount handle)
-                      (catch :default e
-                        (lane/teardown-failure! "z3vlz subs-arm unmount" e)))
+                 ;; way; the record is what makes it fatal. A NORMAL return is
+                 ;; not taken at its word either (rf2-z3vlz, from the PR #7291
+                 ;; audit): `lane/container-released!` reads the container
+                 ;; before it goes, exactly as `lane/release!` does.
+                 (when (try (unmount handle)
+                            true
+                            (catch :default e
+                              (lane/teardown-failure! "z3vlz subs-arm unmount" e)))
+                   (lane/container-released! "z3vlz subs-arm unmount" container))
                  (.remove container)
                  {:mount    {:ok? mount-ok? :cells mount-cells}
                   :orders   (tally results)
@@ -390,10 +395,15 @@
                  ;; on the same document, so a swallowed failure here is the
                  ;; worse of the two: the arm whose result the bead turns on
                  ;; would be measured on a page still carrying the control's
-                 ;; roots and its ratom's watchers.
-                 (try (unmount handle)
-                      (catch :default e
-                        (lane/teardown-failure! "z3vlz raw-control unmount" e)))
+                 ;; roots and its ratom's watchers. A NORMAL return is not
+                 ;; taken at its word either (rf2-z3vlz, from the PR #7291
+                 ;; audit): `lane/container-released!` reads the container
+                 ;; before it goes, exactly as `lane/release!` does.
+                 (when (try (unmount handle)
+                            true
+                            (catch :default e
+                              (lane/teardown-failure! "z3vlz raw-control unmount" e)))
+                   (lane/container-released! "z3vlz raw-control unmount" container))
                  (.remove container)
                  {:mount    {:ok? mount-ok?}
                   :orders   (tally results)


### PR DESCRIPTION
## What this does

Three beads, one surface (the HD-008 / z3vlz measurement lane).

**rf2-b69lw — the PR #7282 audit's two holes in the yield-correction publication contract.**

1. *A crossing is three-state.* The refusal \"the correction moves a published range across 1.0\" compared the `:straddles-1?` boolean at both ends, and a band that leaps the line WHOLE never flips it — `false -> false`, a complete direction reversal accepted as `:corrected` (the audit's live-rule counterexample: 0.95x unadjusted published as 1.0556x corrected). `side-of-1` now classifies each band below / straddles / above and ANY change of state is a crossing; the refusal record carries both sides. Fixture 7 is that counterexample, replayed through the live rule before any clock in every run.
2. *Both bands reach the table.* `yield-correction` computed `:summary-corrected` / `:head-to-head-corrected` but `hd8_app/correction!` exported only verdict/reason/bound/why and the cross-run table printed `run.summary` alone — a `:corrected` run announced two bands while the copyable table could print one. The export now carries both bands on a `:corrected` verdict (packed by the same reader `summary!` uses) and the table prints each governed figure twice, labelled `[UNADJUSTED]` / `[CORRECTED]`.

The full three-run sweep at the repair verifies the published figures rather than moving them: exit 0, verdicts `:not-owed` on all four uix/reagent write rows and `:below-resolution` on both slim rows (every aggregate window 0.0), every DOM read-back 0 unverified (780+78 per write row per run), arm-order guard clean, and every slim write range overlapping the published one (narrow 4.278–5.944 inside the published 2.667–6.000; bulk 9.500–19.000 overlapping 11.000–13.667). No published figure moves; the studio page records the repair and the sweep. An earlier slim-only run at the same source drew the resolved-aggregate reading and the BULK row refused (`:correction-exceeds-window`, bound 0.1 ms) — the contract failing closed on the known clock-clamp limitation that is rf2-d2tzk's, whose re-take authority is not this PR's.

**rf2-jk3vj — the two sibling bulk own-release paths adopt `lane/container-released!`.** `p0_converge_app.cljs` `release-bulk-arms!` and `hd8_rows.cljs` `release-write-arms!` removed the container unchecked after a normal unmount return; both now read it first, exactly as `lane/release!` and `p0_reagent_app` do. Observability, not a live fault: every arm is a real React root today. Mutation-proved on `hd8_rows` (below).

**rf2-z3vlz (reopened by the PR #7291 audit) — the z3vlz rig's two own release sites adopt the same check.** The audit's reproduction: nil the raw-control unmount at landed `d6352dc8d7`, run `Z3VLZ_ONLY=slim-only`, and the rig reported `:teardown []`, all page contracts met, exit 0. Both sites (subs arm, raw control) now perform `lane/container-released!` after a normal return and before the `.remove`; the record lands in `:teardown`, which the driver already adjudicates as a page-contract refusal. The same plant now exits 1 naming the site. Diagnostic-local; no lifecycle machinery.

Out of scope, deliberately: rf2-d2tzk's bulk-window batching (its re-take authority sits with rf2-2rtt6.7's owner); the bulk window is untouched here.

## Quality gates

Every run foreground to completion; logs worktree-local; machine checked quiet (no active java/node/bench processes) before measurement runs.

| gate | exit | notes |
|---|---|---|
| `npm run test:cljs` (node-test) | 0 | 11,967 tests / 59,699 assertions, 0 failures — compiles `p0_converge_app` with the adoption |
| `HD8_ONLY=slim hd8_run.cjs` (baseline at the repair) | 1 | **contract refusal, working as designed**: slim one-turn aggregate resolved at 0.1 ms, bulk row `:refused (correction-exceeds-window)` — the known rf2-d2tzk clamp limitation; partial run, every row marked NON-PUBLISHING; self-test 7/7 ok; write read-backs 0 unverified of 780 / 78 |
| **Mutation (rf2-b69lw)**: `crossed` reverted to the boolean `:straddles-1?` compare | 1 | gate-0 self-test refuses: `FAIL a band that crosses 1.0 WHOLE... — corrected/`; nothing measured; plant reverted, `git diff` empty |
| **Mutation (rf2-jk3vj)**: `write-arm` unmount planted as normal no-op | 1 | `release-write-arms! :floor` and `:reagent-slim` both refused: \"the unmount RETURNED NORMALLY but its container still holds 1 node(s)\"; fatal at write-narrow; plant reverted, `git diff` empty |
| Full three-run `hd8_run.cjs` sweep (final, machine quiet) | 0 | verdicts 4x `:not-owed` + 2x `:below-resolution`; yield-correction self-test 7/7 ok in all three runs; arm-order guard clean; 0 unverified everywhere; provenance commit `79de836f35` |
| `Z3VLZ_ONLY=slim-only z3vlz_run.cjs` (clean, at the adoption) | 0 | all declared page contracts met |
| **Mutation (rf2-z3vlz)**: raw-control unmount call replaced with nil | 1 | `[z3vlz] FAILED: slim-only / install=reagent-slim / raw-control: 1 teardown failure(s)... RETURNED NORMALLY but its container still holds 1 node(s)` — the reproduction that exits 0 at landed main; plant reverted, `git diff` empty |
| `npm run test:script-policy` | 0 | `hd8_run.cjs` changed |
| `npm run test:browser` | 0 | 855 tests / 5,510 assertions, 0 failures (includes the lane release DOM suite) |
| `python -m mkdocs build --strict` | 0 | no warning on the changed page |