### PR TITLE
bench: the floor verdict refuses at its own boundary — equality is not collapse (rf2-hydpy)

### DIFF
--- a/implementation/core/test/re_frame/bench/read_attribution_cljs.cljs
+++ b/implementation/core/test/re_frame/bench/read_attribution_cljs.cljs
@@ -1112,11 +1112,14 @@
 ;; arm across window sizes. A REAL per-call cost cannot see the window, so
 ;; its B/call is flat across the ladder; a per-WINDOW quantity divides by
 ;; reps, so across a span-S ladder it falls ~S-fold. [[floor-verdict]] demands
-;; at least HALF the full per-window collapse, so every recorded per-call
-;; signature refuses attribution: rf2-tmzie's C-FRAME drifted 1.09x over a
-;; 62x range (real, stays refused), rf2-ktrvw's closure bimodality is bounded
-;; by 2x — its two modes (real, stays refused) — and the demanded ratio is
-;; span/2 >= 2 at the minimum span of 4. A refused arm whose sweep DOES
+;; STRICTLY MORE than half the full per-window collapse, so every recorded
+;; per-call signature refuses attribution: rf2-tmzie's C-FRAME drifted 1.09x
+;; over a 62x range (real, stays refused), and rf2-ktrvw's closure bimodality
+;; is bounded by 2x — its two modes (real, stays refused). The strictness is
+;; load-bearing at the MINIMUM span: there the demanded ratio is span/2 = 2,
+;; exactly the bimodal class's own bound, and the inclusive comparison this
+;; replaced classified that bound as the floor (MERGED-PR AUDIT #7292).
+;; Equality is not collapse. A refused arm whose sweep DOES
 ;; collapse is CERTIFIED AT THE FLOOR: quotable as the upper bound of its
 ;; worst round, never as a measured p50 — the same quote the floor arms in
 ;; the table above already carry, now with the exit code to match.
@@ -1141,11 +1144,13 @@
   re-measuring the arm at window sizes derived from its own calibrated reps.
 
   Answers `{:status :floor | :per-call | :indeterminate}` plus the numbers.
-  `:floor` needs B/call to fall by at least span/2 from the smallest window
-  to the largest — half the collapse a pure per-window floor shows — over a
-  span of at least 4. Everything else, including an unverified sweep window,
-  a short ladder or a zero-only sweep, is NOT attribution: the refusal
-  stands."
+  `:floor` needs B/call to fall by STRICTLY MORE than span/2 from the
+  smallest window to the largest — more than half the collapse a pure
+  per-window floor shows — over a span of at least 4. Strict, because at the
+  minimum span the threshold is exactly the 2x bimodal class's bound
+  (rf2-ktrvw), and equality is not collapse. Everything else, including an
+  unverified sweep window, a short ladder or a zero-only sweep, is NOT
+  attribution: the refusal stands."
   [points]
   (let [pts   (vec (sort-by :reps points))
         r-lo  (:reps (first pts) 0)
@@ -1177,17 +1182,22 @@
                             (zero? large)    js/Infinity
                             :else            (/ small large))
             threshold (/ span 2.0)
-            floor?    (>= ratio threshold)]
+            ;; STRICT — equality is not collapse. At the minimum span of 4
+            ;; the threshold is exactly 2, which is the rf2-ktrvw bimodal
+            ;; class's own bound; an inclusive comparison classified that
+            ;; bound as :floor (MERGED-PR AUDIT #7292, and the pinned
+            ;; minimum-span fixture in [[floor-self-test]] holds the line).
+            floor?    (> ratio threshold)]
         {:status    (if floor? :floor :per-call)
          :ratio     ratio
          :span      span
          :threshold threshold
          :why       (if floor?
                       (str "B/call falls " (.toFixed ratio 2) "x across a " (.toFixed span 1)
-                           "x ladder (>= span/2 = " (.toFixed threshold 1)
+                           "x ladder (> span/2 = " (.toFixed threshold 1)
                            ") — a per-WINDOW floor, not a per-call cost")
                       (str "B/call moves only " (.toFixed ratio 2) "x across a " (.toFixed span 1)
-                           "x ladder (< span/2 = " (.toFixed threshold 1)
+                           "x ladder (<= span/2 = " (.toFixed threshold 1)
                            ") — a real per-call reading; the refusal stands"))}))))
 
 (defn- floor-self-test
@@ -1215,13 +1225,24 @@
           :points [{:reps 500 :p50 128.0} {:reps 1000 :p50 64.0}
                    {:reps 2000 :p50 32.0} {:reps 4000 :p50 16.0}]}
          ;; rf2-ktrvw's closure bimodality: a REAL 64/128 B per-call cost whose
-         ;; p50 lands in different modes at different ladder points. Its 2x is
-         ;; below span/2 at every accepted span, so it must NOT attribute —
-         ;; this is the planted-bimodal direction, priced as a fixture.
+         ;; p50 lands in different modes at different ladder points. Its 2x
+         ;; never EXCEEDS span/2 at any accepted span — it touches it exactly
+         ;; at span 4 (the pinned fixture below) — so it must NOT attribute.
+         ;; This is the planted-bimodal direction, priced as a fixture.
          {:name   "the bimodal closure step is NOT the floor — the refusal stands"
           :want   :per-call
           :points [{:reps 500 :p50 128.1} {:reps 1000 :p50 128.1}
                    {:reps 2000 :p50 64.0} {:reps 4000 :p50 64.0}]}
+         ;; rf2-hydpy (MERGED-PR AUDIT #7292): the SAME 2x class at the
+         ;; verdict's MINIMUM legal span, where span/2 is exactly the class's
+         ;; own bound — ratio 2.0 against threshold 2.0. The inclusive
+         ;; comparison classified this :floor; equality is not collapse, and
+         ;; the bound refuses. PINNED at the boundary — do not widen the span
+         ;; or nudge a p50 to make it pass.
+         {:name   "the 2x bimodal bound at the minimum span 4 is NOT the floor"
+          :want   :per-call
+          :points [{:reps 1 :p50 128.0} {:reps 2 :p50 128.0}
+                   {:reps 4 :p50 64.0}]}
          ;; the recorded 2.0125x order contamination (rf2-jr76s's fixture in
          ;; the guard's own self-test) is likewise under span/2
          {:name   "a 2x contaminated reading is NOT the floor at span 8"
@@ -1984,8 +2005,8 @@
               (println ";; ==== FLOOR ATTRIBUTION (rf2-hydpy) — is each refused arm reading its subject, or the instrument? ====")
               (println ";;   each refused arm re-measured across window sizes derived from its own reps.")
               (println ";;   a REAL per-call cost is rep-INDEPENDENT in B/call; a per-WINDOW floor falls")
-              (println ";;   as the window grows. attribution demands at least HALF the full per-window")
-              (println ";;   collapse (ratio >= span/2), which no recorded per-call signature reaches.")
+              (println ";;   as the window grows. attribution demands STRICTLY MORE than half the full")
+              (println ";;   per-window collapse (ratio > span/2), which no recorded per-call signature reaches.")
               (if (seq unchecked)
                 (refuse! [(str ";;   FLOOR ATTRIBUTION does not apply: "
                                (str/join ", " unchecked)


### PR DESCRIPTION
## What

MERGED-PR AUDIT #7292 on rf2-hydpy: `floor-verdict` in `implementation/core/test/re_frame/bench/read_attribution_cljs.cljs` was fail-open at its minimum legal boundary. It accepted `ratio >= span/2` over a span of at least 4 — so at span 4 the threshold is exactly 2, and the known rf2-ktrvw 2x closure-bimodality class (the class the sweep explicitly must keep refusing) classified as `:floor`.

## The fix

The comparison is now **strict**: attribution demands strictly more than half the full per-window collapse (`(> ratio threshold)`), and every prose statement of the rule — section comment, docstring, `:why` strings, the `-main` banner — says so.

**Why strict inequality is the smallest honest option:** the 2x class's ratio is bounded by exactly its two modes (128/64), span 4 is the only accepted ladder whose threshold touches that bound (every wider accepted span already clears the class at threshold >= 2.5), and demanding strictly more than half the collapse refuses the bound itself — failing toward refusal.

The audit's exact minimum-span fixture is **pinned** in `floor-self-test`:

```clojure
{:name   "the 2x bimodal bound at the minimum span 4 is NOT the floor"
 :want   :per-call
 :points [{:reps 1 :p50 128.0} {:reps 2 :p50 128.0} {:reps 4 :p50 64.0}]}
```

ratio 2.0 against threshold 2.0 now refuses. `order_guard`, its tolerance and its refusals are untouched; no new measurement framework; one file changed.

## Quality gates

- **`:advanced` ui-bench build** (the file's own run instructions, foreground): exit **0**.
- **Pre-measurement floor-verdict self-test** (`node --expose-gc out/read-attribution-cljs.js`): all **11 checks ok**, including the new pinned fixture (`want per-call, got per-call`). The bounded live run proceeded past both pre-measurement gates through the full plan (0 UNVERIFIED of 188 windows; exit 2 from the order guard's refusal under deliberately under-sampled knobs `RA_SAMPLES=4 RA_ROUNDS=2` — the fail-toward-refusal branch working, and the live floor sweep refusing attribution on non-collapsing sweeps, as it must).
- **Red-capability**: with the pinned fixture's expectation temporarily inverted to `:floor`, the rebuilt harness printed `floor-verdict FAIL the 2x bimodal bound at the minimum span 4 is NOT the floor — want floor, got per-call` and exited **1** pre-measurement ("nothing may be measured"). Plant restored; `git diff` empty.
- **`npm run test:cljs`**: skipped — the bench namespace `re-frame.bench.read-attribution-cljs` does not match the `:node-test` build's `cljs-test$` ns-regexp and no test namespace requires it, so the suite cannot see this surface; the harness's own `:advanced` build + self-test above is the gate TESTING.md maps here.