### PR TITLE
bench(hicasso): the cold-mount double build priced against the mount red-zone (rf2-2rtt6.15)

### DIFF
--- a/docs/design/hicasso/studio/README.md
+++ b/docs/design/hicasso/studio/README.md
@@ -94,6 +94,7 @@ requires nothing from any donor `src/` tree.
 | [P0 — the reads-per-boundary heap ladder](reads-per-boundary-heap-ladder.md) | P0 | Retained heap per subscribing boundary across the 1/3/7/20 reads ladder, both donors — the **operative** distinct-query (Q = E) red-zone family. |
 | [HD-008 — the composed donor arm](hd8-composed-donor-arm.md) | donor gate | What the composed donor arm costs against both Reagent paths and against the frontier. |
 | [The UIx spine's per-read allocation, decomposed](uix-spine-per-read-decomposition.md) | P0 | Where a UIx-on-subs read's bytes go. |
+| [The cold-mount double build, priced against the mount red-zone](coldmount-double-build-priced.md) | P0 | What the double build **costs on the clock**, as a fraction of the same-run UIx-minus-Reagent mount excess — the rf2-2rtt6.14 decision input. |
 | [The reagent-slim non-reactive arm — diagnosis](slim-non-reactive-arm-diagnosis.md) | P0 | Why HD-008's reagent-slim arm read `78 unverified of 78`: the **arm's composition**, not the adapter and not the mixed bundle. A single-substrate slim bundle re-renders on every write. |
 
 **Clock red-zones live on the converged page.** Where it and the frontier arm

--- a/docs/design/hicasso/studio/coldmount-double-build-priced.md
+++ b/docs/design/hicasso/studio/coldmount-double-build-priced.md
@@ -1,0 +1,285 @@
+# The cold-mount double build, priced against the mount red-zone
+
+**Bead** `rf2-2rtt6.15` · **epic** `rf2-2rtt6` (EP-0038) · decision input for the
+**rf2-2rtt6.14** ruling
+**Measured** 2026-07-31 AUSEST · **Runtime for every figure on this page:
+HeadlessChrome 147.0.7727.15 (Chromium via Playwright), `:advanced`,
+`goog.DEBUG false`, Windows 11 x64.**
+
+> **The instrument is identified by content hash, not by commit SHA** — a rebase
+> moves SHAs and leaves blobs alone, which is how two earlier pages' citations
+> went stale. Authored at `0b482f385e` on `worker/coldmount-2rtt6-15`; if that
+> does not resolve, these blobs are what to trust
+> (`git rev-parse <candidate>:implementation/freehand/test/re_frame/bench/hicasso/<file>`):
+>
+> | file | blob |
+> |---|---|
+> | `coldmount_views.cljs` | `335a37bb09233121e83ca2dc9f6a0a9ef88e037c` |
+> | `coldmount_app.cljs`   | `8cc9a9b5ec82dccc4a09321d2b08c440b580dc8f` |
+> | `coldmount_run.cjs`    | `d37fd07688f6e9a47f18938117ba776cb8d098e9` |
+
+Reproduce (each row is one page and one driver invocation; the plain command
+runs all five over the same gates):
+
+```bash
+node implementation/freehand/test/re_frame/bench/hicasso/coldmount_run.cjs
+COLDMOUNT_ONLY=M1L1 node implementation/freehand/test/re_frame/bench/hicasso/coldmount_run.cjs
+```
+
+The five published rows were taken one row per invocation — fresh build (the
+lane cache cleared per rf2-2rtt6.20, so the bundle is byte-deterministic),
+fresh browser per row — with the machine checked quiet first: the sibling
+`test:cljs` runs live on this box were waited out before the first published
+round. **Exit 0 on all five.**
+
+---
+
+## The question
+
+rf2-2rtt6.12 proved by counting that every cold subscription read on the
+React-hook spine constructs **two** reactions: `use-subscribe`'s render-phase
+balanced round trip takes an empty-cache entry `0 → 1 → 0`, Spec 006's
+no-grace-period rule makes `1 → 0` an in-tick dispose + evict, and the
+commit-owned `subscribe-fn` then misses the cache and rebuilds
+(`bodyRuns = 2.00N` against Reagent's `1.00N`, twice over disjoint cells —
+[the decomposition page](uix-spine-per-read-decomposition.md)). That page
+priced what the first, dead reaction *retains*. It deliberately did not price
+what the second construction *costs on the clock*.
+
+rf2-2rtt6.14 pre-registered the rule that consumes that clock:
+
+> fraction < 20% of the mount red-zone, or unresolvable from round-to-round
+> spread → rf2-2rtt6.14 closes as "take rf2-2rtt6.13 alone; Spec 006
+> no-grace-period stands". fraction ≥ 20% on representative layer-1 AND
+> layer-2/3 mounts → rf2-2rtt6.14 reopens for a design pass scoped to a
+> hook-scoped provisional hand-off ONLY.
+
+The denominator — the UIx-minus-Reagent mount-clock excess — is measured **in
+the same runs**: M1's published red-zone magnitude is withdrawn (direction
+only, ≈1.11–1.35×), so nothing here quotes it; every excess below comes from
+this page's own rounds.
+
+---
+
+## The instrument — one variable, and the counts that pin it
+
+Two transcriptions of the shipped hook run beside the shipped arm and the
+converged Reagent denominator, on the converged witnesses, on the
+`:hicasso-bench` lane. They differ in exactly one property — how many
+reactions a cold read constructs:
+
+| arm | render phase | commit phase | constructions | cache-API calls/read |
+|---|---|---|---:|---:|
+| `uix-xcript` | subscribe + unsubscribe (build #1, dispose #1) | subscribe — miss, **build #2** | **2** | 4 |
+| `uix-handoff` | subscribe (+1 held provisionally) | subscribe — **hit** — then unsubscribe (2 → 1) | **1** | 4 |
+
+Both make two `subs/subscribe` and two `subs/unsubscribe` calls per mounted
+read; both install the same watch, the same refs, the same six hooks; the
+canonical-DOM gate proves they build the identical page. `xcript − handoff` is
+therefore the build/dispose/rebuild churn alone — the clock a commit-phase
+adoption of the render-phase materialisation would recover, which is the
+rf2-2rtt6.14 question in arm form. **`handoff` is a measurement arm, not a
+patch**: its provisional +1 leaks if a render is abandoned before commit, and
+the reaping policy a real hand-off needs is exactly what the ruling's design
+pass would have to produce. Nothing here edits production code.
+
+**The construction counts are adjudicated, not assumed.** Before any clock, a
+counter-instrumented copy of each transcription reads a counter-instrumented
+sub chain, predictions written in the driver first. Every call, every page,
+came back exact — `failures []` on all five rows:
+
+| variant, for N = 300 reads at page layer L | commits | rebuilt | bodyRuns per layer ≤ L |
+|---|---:|---:|---:|
+| `xcript` — predicted and measured | 300 | **300** | **600 (2N)** |
+| `handoff` — predicted and measured | 300 | **0** | 300 (1N) |
+| Reagent — predicted and measured | 0 | 0 | 300 (1N) |
+
+`rebuilt = 300` on `xcript` re-confirms the double build **on this spine at
+this commit**; `rebuilt = 0` on `handoff` proves the commit adopts the
+render-phase reaction `identical?`-ly, which is what makes the subtraction
+single-variable. At layers 2 and 3 the *whole chain* doubles (`body1` and
+`body2` both 2N at L2; all three at L3) — the render-phase dispose cascades
+down the `:<-` inputs and the commit rebuild reconstructs every node, which is
+why materiality was expected to show at layer 2+ first.
+
+The layered subs are identity chains over the converged witness's own sub
+(`[:cm/l2 i] :<- [:p0/cell i]`, `[:cm/l3 i] :<- [:cm/l2 i]`, parametric
+`input-fn` form), so the bodies stay near-zero and the ladder isolates the
+per-hop `:<-` machinery rather than user compute.
+
+Two deliberate departures from the converged mount rows, both stated: **four
+rounds, even** — the converged page measured a systematic segment-order effect
+and named an even round count as the arm-level repair; 2:2 makes the raw mean
+and the order-balanced mean coincide by construction — and **a residue gate**
+per segment-round (`lane/residue` back to baseline after a settle, equality,
+no tolerance), because a `handoff` leak would silently convert later samples
+into warm-cache mounts. It never fired.
+
+---
+
+## The answer
+
+**The double build is not a minor term of the mount red-zone. It is most of
+it — and at layer 1 it is all of it.** Per round, p50 milliseconds per mount;
+the fraction is `(xcript − handoff) / (uix-subs − reagent-subs)` in the same
+round, raw and seam-adjusted (UIx-segment terms divided by that round's
+floor-vs-floor seam):
+
+| row | double build, ms | red-zone excess, ms (raw) | **fraction, raw** | fraction, seam-adjusted | verdict vs 20% |
+|---|---|---|---|---|---|
+| **M1L1** — 901 el / 300 boundaries, layer 1 | 0.81 `[0.75–0.85]` | 0.63 `[0.35–0.85]` | **1.49 `[0.94–2.14]`** | 1.31 `[0.93–2.00]` | **≥ 20% in every round, both estimators** |
+| **M1L2** — one `:<-` hop | 2.39 `[2.35–2.45]` | 3.61 `[3.15–3.90]` | **0.66 `[0.63–0.75]`** | 0.67 `[0.61–0.71]` | **≥ 20% in every round, both estimators** |
+| **M1L3** — two `:<-` hops | 3.83 `[3.30–5.15]` | 7.50 `[6.35–9.95]` | **0.53 `[0.35–0.78]`** | 0.57 `[0.41–0.84]` | **≥ 20% in every round, both estimators** |
+| M2L1 — 51-el form, layer 1 · *diagnostic* | 0.10 `[0.10–0.10]` | −0.04 `[−0.15–0.00]` | not resolved | not resolved | **unresolvable** — the excess sits on the clamp |
+| M2L2 — the form, one hop · *diagnostic* | 0.13 `[0.10–0.20]` | 0.26 `[0.05–0.45]` | 0.82 `[0.22–2.00]` | not resolved | **unresolvable** — one seam-adjusted round ≤ 0 |
+
+Per-round fractions, stated rather than smoothed:
+
+| row | raw, per round | seam-adjusted, per round |
+|---|---|---|
+| M1L1 | 1.8889 · 1.0000 · 2.1429 · 0.9412 | 1.2911 · 1.0000 · 0.9302 · 2.0000 |
+| M1L2 | 0.6528 · 0.6316 · 0.6282 · 0.7460 | 0.6960 · 0.7085 · 0.6655 · 0.6075 |
+| M1L3 | 0.4718 · 0.5197 · 0.7803 · 0.3518 | 0.4487 · 0.5593 · 0.8423 · 0.4130 |
+
+**One honesty note on M1L1's magnitude.** Its fraction's two segment-order
+strata are disjoint (Reagent-first 1.89–2.14, UIx-first 0.94–1.00), so the
+point value 1.49 is not a threshold — the same discipline that withdrew
+`1.2301`. What the decision rule consumes survives the partition untouched:
+**every round of every estimator in every stratum sits at 0.93 or above**,
+more than four times the 20% boundary. M1L2's and M1L3's strata overlap and
+their magnitudes stand as quoted.
+
+The raw per-arm milliseconds behind the table, p50 per round:
+
+| row | floor (R / U segment) | reagent-subs | uix-subs | uix-xcript | uix-handoff |
+|---|---|---|---|---|---|
+| M1L1 | 0.9·0.8·0.8·0.7 / 0.85·0.8·0.7·0.8 | 3.75·3.30·3.65·3.15 | 4.20·4.15·4.00·4.00 | 4.20·4.05·3.90·4.00 | **3.35·3.20·3.15·3.20** |
+| M1L2 | 0.85·0.8·0.8·0.95 / 0.9·0.9·0.85·0.8 | 3.80·3.30·3.50·4.55 | 7.40·7.10·7.40·7.70 | 7.40·7.10·7.25·7.00 | 5.05·4.70·4.80·4.65 |
+| M1L3 | 0.9·0.7·0.7·0.6 / 0.8·0.8·0.8·0.9 | 3.30·3.15·3.40·2.95 | 10.40·9.50·10.00·12.90 | 9.60·9.40·11.40·11.70 | 6.25·6.10·6.25·8.20 |
+| M2L1 | 0.2·0.3·0.3·0.2 / 0.2·0.2·0.2·0.15 | 0.50·0.50·0.55·0.40 | 0.50·0.50·0.40·0.40 | 0.50·0.50·0.40·0.40 | 0.40·0.40·0.30·0.30 |
+| M2L2 | 0.2·0.3·0.1·0.35 / 0.25·0.4·0.2·0.2 | 0.50·0.50·0.30·0.55 | 0.75·0.95·0.60·0.60 | 0.70·0.70·0.60·0.60 | 0.60·0.60·0.40·0.50 |
+
+### The split by layer — where the second construction's clock goes
+
+Per cold read (dividing each row's double-build delta by its 300 reads):
+
+| depth | second construction, µs/read | increment |
+|---|---|---|
+| layer 1 — no `:<-` chain | **2.5–2.8** | the reaction allocation + dispose + cache round trip itself |
+| layer 2 — one hop | 7.8–8.2 | **+5.2–5.5 µs for the first `:<-` hop** (input reaction rebuild + input re-deref + wiring) |
+| layer 3 — two hops | 11.0–17.2 | +3.0–9.0 µs for the second hop |
+
+The sub bodies here are near-zero (`nth` on a vector, identity chains), so the
+second sub-body run's own compute is a negligible slice of these numbers — the
+clock is dominated by the reaction allocation and, from layer 2, by rebuilding
+and re-dereffing the input chain. Each `:<-` hop roughly *doubles-and-more* the
+per-read churn, which is the shape the counting witness predicts: at depth L
+the double build reconstructs L reactions, not one.
+
+### Two observations beside the fraction, reported not ruled
+
+* **The single-build hook mount lands at or below the Reagent denominator on
+  M1L1.** `uix-handoff` read 3.15–3.35 ms against `reagent-subs`' 3.15–3.75 ms
+  in the same rounds. On this page's witness, removing the double build takes
+  the UIx mount out of the red zone entirely — an observation about the
+  ceiling of the hand-off design, not a bar row.
+* **The layered mounts widen the gap sharply** — `uix-subs / reagent-subs`
+  reads 1.84–2.01× at layer 2 and 2.57–3.55× at layer 3 against layer 1's
+  1.11–1.26× (which sits inside the converged page's ≈1.11–1.35 direction
+  range, the external-consistency check this page owes). These layered ratios
+  are **context, not red-zones** — no layered row exists in the converged set,
+  and only the operator amends the standard. One method note applies to the
+  denominator at depth: Reagent's released subscriptions dispose on a
+  *macrotask* (measured in `lane/settle!`'s docstring), so within a
+  synchronous sampling round its later mounts re-acquire live cache entries,
+  while the hook spine's in-tick disposal makes every UIx mount cold. That
+  asymmetry is shipped behaviour on both sides — it is the no-grace-period
+  rule seen from the other end — and it is part of what these ratios measure.
+
+---
+
+## The decision rule, applied
+
+The rule, verbatim from rf2-2rtt6.14 (pre-registered; applied, not
+re-litigated):
+
+> * fraction < 20% of the mount red-zone, or unresolvable from round-to-round
+>   spread → rf2-2rtt6.14 closes as "take rf2-2rtt6.13 alone; Spec 006
+>   no-grace-period stands".
+> * fraction ≥ 20% on representative layer-1 AND layer-2/3 mounts →
+>   rf2-2rtt6.14 reopens for a design pass scoped to a hook-scoped provisional
+>   hand-off ONLY (never a general ref-count-0 cache tenancy), subject to the
+>   correctness protocol recorded on rf2-2rtt6.14.
+
+**The measurement satisfies the second branch.** On the representative M1
+mount the fraction is ≥ 20% in every round of every estimator at layer 1
+(lowest estimate 0.93) and at layers 2 and 3 (lowest estimates 0.61 and
+0.35). The two diagnostic M2 rows are unresolvable at the clamp, exactly as
+their bar-row counterpart's grading predicts, and the rule does not condition
+on them.
+
+**Implied verdict: rf2-2rtt6.14 reopens for a hook-scoped provisional
+hand-off design pass only.** This page implies the verdict and stops; opening
+and closing the ruling bead is the mayor's reconciliation, not this
+instrument's.
+
+**Which spine was measured: the shipped one.** rf2-2rtt6.13's retention fix
+is NOT landed at the measured commit — the render-phase `use-memo` still
+returns the reaction handle — and the counting witness re-confirmed
+`rebuilt = 1.00N` live. Per that bead's own sequencing note the fix removes
+the *retention* of the dead reaction, not the rebuild, so these fractions
+survive .13 unchanged in expectation; a post-.13 re-take would be a
+confirmation, not a correction.
+
+---
+
+## Instrument discipline
+
+* **Fidelity, adjudicated.** The transcription must reproduce the shipped
+  hook on the clock or every delta is void: per-round p50 ranges overlap or
+  medians within the pre-declared 3% band. All five rows passed on the
+  range-overlap clause; medians sat 1.2% (M1L1), 3.0% (M1L2), 2.9% (M1L3),
+  6.3% / 4.2% (M2, quantised) apart. The shipped arm reads through the
+  ambient 1-arg `use-subscribe` (the converged arm, unchanged, under
+  `frame-provider`); the transcriptions pin the frame explicitly as the
+  2-arg spine path does — one context read per boundary of difference, far
+  below the quantum, and the control adjudicates it rather than a comment.
+* **Positive control.** `:ctl-2x` at exactly twice the elements, predicted
+  1.9989× (M1) / 1.9412× (M2) before the run, measured inside the interleave
+  in both segments of every row — **ten controls, ten passes** under the
+  overlap rule (`lane/control-verdict`, slack 25%), every mean below the
+  prediction, the direction a fixed per-root term predicts.
+* **Verification.** Every mount read back at the arm's own arithmetic —
+  element count plus both ends of the page, the 2× control at its own far
+  probe: **0 unverified of 640, on each of the five rows** (3,200 mounts
+  total), and `unverified > 0` throws.
+* **Arm-order guard.** `lane/slot-order` rotates and reflects; the self-test
+  runs before anything is measured, plan sizes 2/3/5 asserted non-degenerate
+  at boot. **Verdict: clean on all five rows** — `refuse? false`,
+  `contaminated? false`, `unchecked? false`, tolerance 0.10 untouched.
+* **Segment-order verdict** (`p0-converge-app/segment-order-verdict`,
+  required, not copied) on every row's cross-seam ratio: no refusal anywhere;
+  M1 rows publish magnitudes (strata overlap), M2 rows are direction-only —
+  and the M1L1 *fraction*'s strata are disjoint, which is why its point value
+  is not quoted as one (above).
+* **Residue gate.** After every segment-round, one macrotask settle then
+  `lane/residue` compared to the segment's baseline by equality —
+  `sub-entries`, `sub-ref-count`, attached containers. Never fired: the
+  provisional +1 balanced in all 3,200 mounts.
+* **The report survives refusal.** Every record prints before any gate exits;
+  a witness mismatch or fidelity failure exits 4 with the table already on
+  stdout (the rf2-2rtt6.12 audit's fail-closed discipline).
+
+---
+
+## What this page does not claim
+
+* It does not claim a new red-zone. The layered ratios are context; the bar
+  and the red-zones are rf2-2rtt6.1's, and only the operator amends them.
+* It does not claim `uix-handoff` is shippable. It is the hand-off *shape*
+  with the reaping question deliberately unanswered — the design pass the
+  verdict feeds is where that question lives, under the correctness protocol
+  on rf2-2rtt6.14.
+* It does not re-price retention. The 769 B / 23.0 obj term is
+  [the decomposition page](uix-spine-per-read-decomposition.md)'s and is
+  untouched; no red-zone value moves, so rf2-2rtt6.1 gets nothing from here.

--- a/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
+++ b/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
@@ -398,4 +398,7 @@ observations.
 * It does not claim the spine's derived-value representation should be flattened.
   It measures that the representation costs 1.94× Reagent's for the same job and
   stops there.
-* It does not price the CPU of the double build, only its retention.
+* It does not price the CPU of the double build, only its retention. The CPU
+  is now priced by rf2-2rtt6.15 on
+  [its own page](coldmount-double-build-priced.md), against the mount
+  red-zone, in the same runs.

--- a/implementation/freehand/test/re_frame/bench/hicasso/coldmount_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/coldmount_app.cljs
@@ -1,0 +1,717 @@
+(ns re-frame.bench.hicasso.coldmount-app
+  "THE COLD-MOUNT DOUBLE BUILD, PRICED AGAINST THE MOUNT RED-ZONE — the
+  run (rf2-2rtt6.15; decision input for the rf2-2rtt6.14 ruling).
+
+  ## The question, and the two numbers it needs from ONE run
+
+  rf2-2rtt6.12 proved by counting that every cold subscription read on the
+  React-hook spine constructs TWO reactions (`bodyRuns = 2.00N` against
+  Reagent's `1.00N`) and priced the RETENTION of the first. The CLOCK of
+  the second construction was left unmeasured, and the rf2-2rtt6.14
+  decision rule consumes it as a FRACTION OF THE MOUNT RED-ZONE — the
+  UIx-minus-Reagent mount-clock excess — measured in the SAME runs (M1's
+  published red-zone magnitude is withdrawn, so the excess is re-derived
+  from this run's own rounds and no published number is quoted into the
+  denominator).
+
+  So every row here carries, per round, in one page:
+
+      numerator    xcript − handoff          (UIx segment; the single-
+                                              variable ablation of the
+                                              build/dispose/rebuild churn)
+      denominator  uix-subs − reagent-subs   (the mount red-zone excess,
+                                              cross-seam, same round)
+
+  and the published figure is their ratio, per round, with ranges — raw
+  and seam-adjusted (the UIx-segment terms divided by that round's
+  floor-vs-floor seam ratio) as two estimators that must agree.
+
+  ## The rows
+
+  One row per page (the converged arm's repair, kept):
+
+      M1L1  the converged M1 mount (901 el / 300 boundaries), layer-1 —
+            the PRIMARY witness, rf2-2rtt6.2's page exactly
+      M1L2  the same page reading through one `:<-` hop
+      M1L3  the same page reading through two `:<-` hops
+      M2L1  the converged M2 form (51 el / 12 fields) — DIAGNOSTIC,
+            per rf2-2rtt6.2's own grading (clamp-quantised)
+      M2L2  the form through one `:<-` hop — DIAGNOSTIC
+
+  The `:<-` input-chain re-deref lives at layer 2+, so the layer ladder is
+  the split that attributes the double-build clock between the reaction
+  allocation itself (visible at layer 1, where there is no chain) and the
+  per-hop input rebuild + re-deref (the L2−L1 and L3−L2 increments).
+
+  ## Method, inherited rather than restated
+
+  The converged arm's method, on its witnesses, on its lane: three-plus
+  arms a segment interleaved under `lane/slot-order` (rotating AND
+  reflecting), two segments a round with the floor in both, segment order
+  alternating with the round, canonical-DOM parity before any clock,
+  every mount read back at the arm's own arithmetic, `:ctl-2x` predicted
+  before the run, the arm-order guard owning exit 2, and the
+  segment-order verdict on every cross-seam figure
+  (`p0-converge-app/segment-order-verdict`, required from the converged
+  arm rather than copied — a second copy of an adjudication rule is a
+  second authority).
+
+  TWO deliberate differences from the converged mount rows, both stated:
+
+    * ROUNDS = 4, EVEN. The converged page measured a systematic
+      segment-order effect (11 of 12 row-runs read higher Reagent-first,
+      p = 0.0032) and named an even round count as the arm-level repair —
+      the 3:2 design over-weights one order. A balanced 2:2 design makes
+      the raw mean and the order-balanced mean coincide by construction.
+      This entry takes that repair; it re-derives its own denominator, so
+      no published row moves.
+    * A RESIDUE GATE per segment-round (`lane/residue` back to baseline
+      after a settle). The `handoff` arm holds a provisional +1 between
+      render and commit; a plan in which every render commits must drive
+      the census back to zero, and a leak here would silently convert
+      later samples into warm-cache mounts. Equality, no tolerance.
+
+  ## What fails the run
+
+  The counting witness adjudicated per page BEFORE any clock (predicted
+  commits / rebuilt / per-layer bodyRuns, exact); the clock fidelity
+  control (`uix-subs` vs `xcript` — ranges overlap or medians within the
+  pre-declared 3% band, else every delta is void); the positive controls;
+  the DOM read-backs; the residue gate; the arm-order guard (exit 2); the
+  segment-order direction refusal. The records are written to the console
+  before any refusal, so the evidence survives it.
+
+  Driven by `coldmount_run.cjs` on the `:hicasso-bench` build id through
+  `--config-merge` — no new build id, no `implementation/shadow-cljs.edn`
+  edit."
+  (:require ["react-dom/client" :as react-dom-client]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.coldmount-views :as cmv]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.p0-converge-app :as converge]
+            [re-frame.bench.hicasso.p0-reagent-views :as v]
+            [re-frame.bench.order-guard :as guard]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [reagent.dom.client :as rdc]
+            [uix.dom :as uix-dom]))
+
+(def ^:private rounds
+  "EVEN, deliberately — see the namespace docstring. 4 rounds = 2 rounds
+  per segment order, so the raw mean over rounds IS the order-balanced
+  mean."
+  4)
+
+(def ^:private mount-sampling {:warmup 8 :samples 12})
+
+(def ^:private control-slack 0.25)
+
+(def ^:private fidelity-band
+  "The clock fidelity control passes when the shipped arm's and the
+  transcription's per-round p50 RANGES overlap, or — declared here,
+  before the run — their medians are within 3%. The second clause exists
+  because ranges at low round counts can be narrow; 3% is the same band
+  rf2-2rtt6.12 declared on the heap axis, and it sits well below the
+  effects the ablation resolves."
+  0.03)
+
+(def ^:private witness-boundaries
+  "Boundaries per counting-witness mount; 3 reads each, so N = 300 reads
+  per call — the same N as a timed M1 mount."
+  100)
+
+;; ---------------------------------------------------------------------------
+;; Segments
+;; ---------------------------------------------------------------------------
+
+(def ^:private segments
+  [{:id :reagent-subs :adapter reagent-adapter/adapter :name "Reagent-on-subs"}
+   {:id :uix-subs     :adapter uix-adapter/adapter     :name "UIx-on-subs"}])
+
+(defn- segment-order [r]
+  (if (even? r) (vec segments) (vec (rseq (vec segments)))))
+
+(defn- enter-segment!
+  "The converged arm's seam, unchanged: tear down, install this segment's
+  adapter, re-register the sub graph (`cmv/register!` — the converged
+  layer-1 sub plus the `:<-` chain and the witness chain) and stand the
+  frame back up seeded. All outside every measured window; a teardown
+  that throws is recorded and adjudicated, never swallowed."
+  [{:keys [adapter]}]
+  (try (rf/destroy-frame! v/subs-frame)
+       (catch :default e (lane/teardown-failure! "enter-segment! destroy-frame!" e)))
+  (when (rf/current-adapter)
+    (try (rf/destroy-adapter!)
+         (catch :default e (lane/teardown-failure! "enter-segment! destroy-adapter!" e))))
+  (rf/init! adapter)
+  (cmv/register!)
+  (rf/make-frame {:id v/subs-frame})
+  (frame/replace-app-db! v/subs-frame (v/seed-cells v/cells-n 0))
+  (lane/leave-act-environment!)
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Mount arms — the converged arm's constructors
+;; ---------------------------------------------------------------------------
+
+(defn- zeros [n] (vec (repeat n 0)))
+
+(defn- floor-mount-arm
+  [id element-of cells-of & [scale]]
+  (let [scale (or scale 1)]
+    {:id             id
+     :scale          scale
+     :parity-exempt? (not= 1 scale)
+     :mount          (fn [container props _n]
+                       (let [root (react-dom-client/createRoot container)]
+                         (.render root (element-of (cells-of props)))
+                         root))
+     :unmount        (fn [root] (.unmount root))}))
+
+(defn- reagent-mount-arm
+  [id form-of]
+  {:id      id
+   :mount   (fn [container props _n]
+              (let [root (rdc/create-root container)]
+                (rdc/render root (form-of props))
+                root))
+   :unmount (fn [root] (rdc/unmount root))})
+
+(defn- uix-mount-arm
+  [id element-of]
+  {:id      id
+   :mount   (fn [container props _n]
+              (let [root (uix-dom/create-root container)]
+                (uix-dom/render-root (element-of props) root)
+                root))
+   :unmount (fn [root] (uix-dom/unmount-root root))})
+
+(defn- input-value [container sel]
+  (some-> (.querySelector container sel) (.-value)))
+
+(defn- verify-m1 [n]
+  (fn [container]
+    (and (= "0" (lane/text-at container 0))
+         (= "0" (lane/text-at container (dec n))))))
+
+(defn- verify-m2 [n]
+  (fn [container]
+    (and (= (v/field-value 0 0) (input-value container "#f0"))
+         (= (v/field-value (dec n) 0)
+            (input-value container (str "#f" (dec n)))))))
+
+;; ---------------------------------------------------------------------------
+;; The rows
+;; ---------------------------------------------------------------------------
+
+(def ^:private shapes
+  {:M1 {:elements-of v/m1-elements
+        :verify-of   verify-m1
+        :props       {:n v/cells-n}
+        :grid        cmv/m1-grid
+        :uix-cells   cmv/uix-m1-cells
+        :reagent     cmv/reagent-m1-views
+        :floor       v/m1-floor
+        :control     {:predicted (/ (double (v/m1-elements (* 2 v/cells-n)))
+                                    (double (v/m1-elements v/cells-n)))
+                      :basis     (str "element count: " (v/m1-elements (* 2 v/cells-n))
+                                      " / " (v/m1-elements v/cells-n))}}
+   :M2 {:elements-of v/m2-elements
+        :verify-of   verify-m2
+        :props       {:n v/fields-n}
+        :grid        cmv/m2-grid
+        :uix-cells   cmv/uix-m2-cells
+        :reagent     cmv/reagent-m2-views
+        :floor       v/m2-floor
+        :control     {:predicted (/ (double (v/m2-elements (* 2 v/fields-n)))
+                                    (double (v/m2-elements v/fields-n)))
+                      :basis     (str "element count: " (v/m2-elements (* 2 v/fields-n))
+                                      " / " (v/m2-elements v/fields-n))}}})
+
+(defn- arms-for [shape layer segment-id]
+  (let [{:keys [floor grid uix-cells reagent]} (get shapes shape)]
+    (-> [(floor-mount-arm :floor floor (fn [{:keys [n]}] (zeros n)))]
+        (into (case segment-id
+                :reagent-subs
+                [(reagent-mount-arm :reagent-subs
+                   (fn [{:keys [n]}] [v/subs-root (get reagent layer) n]))]
+                :uix-subs
+                [(uix-mount-arm :uix-subs
+                   (fn [{:keys [n]}]
+                     (cmv/uix-root grid (get-in uix-cells [:uix-subs layer]) n)))
+                 (uix-mount-arm :uix-xcript
+                   (fn [{:keys [n]}]
+                     (cmv/uix-root grid (get-in uix-cells [:uix-xcript layer]) n)))
+                 (uix-mount-arm :uix-handoff
+                   (fn [{:keys [n]}]
+                     (cmv/uix-root grid (get-in uix-cells [:uix-handoff layer]) n)))]))
+        (conj (floor-mount-arm :ctl-2x floor
+                               (fn [{:keys [n]}] (zeros (* 2 n))) 2)))))
+
+(def ^:private row-specs
+  {:M1L1 {:shape :M1 :layer 1 :grade :primary
+          :doc "the converged M1 mount (901 el / 300 boundaries), layer-1 subs — the primary witness"}
+   :M1L2 {:shape :M1 :layer 2 :grade :primary
+          :doc "the M1 mount through one :<- hop ([:cm/l2 i] :<- [:p0/cell i])"}
+   :M1L3 {:shape :M1 :layer 3 :grade :primary
+          :doc "the M1 mount through two :<- hops ([:cm/l3 i] :<- [:cm/l2 i] :<- [:p0/cell i])"}
+   :M2L1 {:shape :M2 :layer 1 :grade :diagnostic
+          :doc "the converged M2 form (51 el / 12 fields), layer-1 subs — DIAGNOSTIC, clamp-quantised per rf2-2rtt6.2"}
+   :M2L2 {:shape :M2 :layer 2 :grade :diagnostic
+          :doc "the M2 form through one :<- hop — DIAGNOSTIC"}})
+
+(defn- row-spec [row-key]
+  (let [{:keys [shape layer] :as spec} (get row-specs row-key)
+        sh (get shapes shape)]
+    (merge sh spec
+           {:row-key  row-key
+            :arms-for (fn [segment-id] (arms-for shape layer segment-id))})))
+
+(defn- query-row []
+  (let [s (or (some-> js/window .-location .-search) "")]
+    (or (some (fn [k] (when (re-find (re-pattern (str "row=" (name k) "(&|$)")) s) k))
+              (keys row-specs))
+        :M1L1)))
+
+;; ---------------------------------------------------------------------------
+;; Expectation and parity — the converged arm's, over these arms
+;; ---------------------------------------------------------------------------
+
+(defn- expectation
+  [{:keys [elements-of verify-of props]} arm]
+  (let [n (* (or (:scale arm) 1) (:n props))]
+    {:elements (elements-of n)
+     :verify   (verify-of n)}))
+
+(defn- base-elements [{:keys [elements-of props]}] (elements-of (:n props)))
+
+(defn- parity-of-segment!
+  [{:keys [row-key props arms-for] :as spec} segment-id]
+  (let [{:keys [mounts agree? disagree reference]}
+        (lane/parity (arms-for segment-id) props)
+        wrong (into {}
+                    (comp (map (fn [{:keys [arm container]}]
+                                 [(:id arm)
+                                  {:expected (:elements (expectation spec arm))
+                                   :got      (lane/element-count container)}]))
+                          (remove (fn [[_ {:keys [expected got]}]] (= expected got))))
+                    mounts)]
+    (try
+      {:reference reference
+       :problems  (cond-> []
+                    (not agree?)
+                    (conj {:segment segment-id :row row-key
+                           :problem :canonical-dom-disagreement :arms disagree})
+
+                    (seq wrong)
+                    (conj {:segment segment-id :row row-key
+                           :problem :element-count :arms wrong}))}
+      (finally (doseq [m mounts] (lane/release! m))))))
+
+(defn- parity! [spec]
+  (let [by-seg (reduce (fn [acc {:keys [id] :as segment}]
+                         (enter-segment! segment)
+                         (assoc acc id (parity-of-segment! spec id)))
+                       {}
+                       segments)
+        cross  (when (not= (get-in by-seg [:reagent-subs :reference])
+                           (get-in by-seg [:uix-subs :reference]))
+                 [{:problem :cross-segment-disagreement :row (:row-key spec)}])]
+    {:problems (into (vec (mapcat (comp :problems val) by-seg)) cross)}))
+
+;; ---------------------------------------------------------------------------
+;; THE COUNTING WITNESS — adjudicated before any clock
+;; ---------------------------------------------------------------------------
+
+(defn- witness-sweep!
+  "Per segment: the counter-instrumented witness mounts, over disjoint
+  cell ranges per call. Answers `{segment-id [result …]}`."
+  [{:keys [layer]}]
+  (reduce (fn [acc {:keys [id] :as segment}]
+            (enter-segment! segment)
+            (assoc acc id
+                   (case id
+                     :reagent-subs
+                     [(cmv/witness! :reagent layer witness-boundaries 0)
+                      (cmv/witness! :reagent layer witness-boundaries 900)]
+                     :uix-subs
+                     [(cmv/witness! :xcript  layer witness-boundaries 0)
+                      (cmv/witness! :xcript  layer witness-boundaries 900)
+                      (cmv/witness! :handoff layer witness-boundaries 1800)
+                      (cmv/witness! :handoff layer witness-boundaries 2700)])))
+          {}
+          segments))
+
+(defn- witness-failures
+  "Compare every witness result against the prediction, exactly. For N
+  reads at page layer L:
+
+      xcript    commits N   rebuilt N   bodyRuns 2N at every layer <= L
+      handoff   commits N   rebuilt 0   bodyRuns  N at every layer <= L
+      reagent   commits 0   rebuilt 0   bodyRuns  N at every layer <= L
+
+  Layers above L must read 0 — a non-zero there means the chain is not
+  the chain this page claims to price."
+  [by-seg layer]
+  (vec
+    (for [[seg ws] by-seg
+          {:keys [variant reads offset] :as w} ws
+          :let [n      reads
+                factor (case variant :xcript 2 :handoff 1 :reagent 1)
+                exp    (merge
+                         (case variant
+                           :xcript  {:commits n :rebuilt n}
+                           :handoff {:commits n :rebuilt 0}
+                           :reagent {:commits 0 :rebuilt 0})
+                         {:body1 (if (<= 1 layer) (* factor n) 0)
+                          :body2 (if (<= 2 layer) (* factor n) 0)
+                          :body3 (if (<= 3 layer) (* factor n) 0)})
+                bad    (into {}
+                             (keep (fn [[k want]]
+                                     (when (not= (get w k) want)
+                                       [k {:predicted want :measured (get w k)}])))
+                             exp)]
+          :when (or (seq bad) (not (:ok? w)))]
+      {:segment seg :variant variant :layer layer :offset offset :reads n
+       :dom-ok? (:ok? w) :mismatches bad})))
+
+;; ---------------------------------------------------------------------------
+;; One round of this page's row in one segment
+;; ---------------------------------------------------------------------------
+
+(defn- mark-predecessor! [coll id]
+  (swap! coll assoc :prev id)
+  nil)
+
+(defn- mount-round!
+  [coll t {:keys [row-key props arms-for] :as spec} segment-id]
+  (let [arms   (arms-for segment-id)
+        n      (count arms)
+        expect (into {} (map (juxt :id #(expectation spec %))) arms)
+        acc    (atom (zipmap (map :id arms) (repeat [])))]
+    (dotimes [s (+ (:warmup mount-sampling) (:samples mount-sampling))]
+      (doseq [j (lane/slot-order n s)]
+        (let [arm (nth arms j)
+              {:keys [ms mounts]} (lane/mount-batch! arm props 1)
+              {exp-elements :elements verify :verify} (get expect (:id arm))]
+          (doseq [m mounts]
+            (let [ok? (and (= exp-elements (lane/element-count (:container m)))
+                           (verify (:container m)))]
+              (swap! t (fn [{:keys [of bad]}]
+                         {:of (inc of) :bad (if ok? bad (inc bad))}))))
+          (doseq [m mounts] (lane/release! m))
+          (let [label (str (name row-key) "/" (name segment-id) "/" (name (:id arm)))]
+            (if (>= s (:warmup mount-sampling))
+              (do (lane/collect! coll label ms)
+                  (swap! acc update (:id arm) conj ms))
+              (mark-predecessor! coll label))))))
+    @acc))
+
+(defn- run-round!
+  "One round: both segments in this round's order, each with the residue
+  gate around its mount round. Answers a promise of
+  `{segment-id {arm-id [ms …]}}`."
+  [spec r coll t]
+  (lane/chain
+    {}
+    (segment-order r)
+    (fn [acc {:keys [id] :as segment}]
+      (enter-segment! segment)
+      (lane/assert-teardown-clean! (str "entering segment " (name id)))
+      (-> (lane/settle!)
+          (.then
+            (fn [_]
+              (let [baseline (lane/residue v/subs-frame)
+                    rd       (mount-round! coll t spec id)]
+                (-> (lane/settle!)
+                    (.then
+                      (fn [_]
+                        (lane/assert-residue!
+                          baseline v/subs-frame
+                          (str "mount round, row " (name (:row-key spec))
+                               ", segment " (name id)))
+                        (lane/assert-teardown-clean!
+                          (str "mount round, segment " (name id)))
+                        (assoc acc id rd)))))))))))
+
+;; ---------------------------------------------------------------------------
+;; Aggregation — the two numbers, per round, and their ratio
+;; ---------------------------------------------------------------------------
+
+(defn- p50-of [xs] (:p50 (lane/summarise xs)))
+
+(defn- range-of [vs]
+  {:mean (lane/round4 (/ (reduce + 0.0 vs) (count vs)))
+   :min  (lane/round4 (apply min vs))
+   :max  (lane/round4 (apply max vs))
+   :per-round (mapv lane/round4 vs)})
+
+(defn- strata-of
+  "The per-round vector split by which segment ran first. Even rounds are
+  Reagent-first (see [[segment-order]]); at 4 rounds the split is 2:2 and
+  the design is balanced."
+  [vs]
+  (let [rf-v (vec (keep-indexed #(when (even? %1) %2) vs))
+        uf-v (vec (keep-indexed #(when (odd? %1) %2) vs))]
+    {:reagent-first (range-of rf-v)
+     :uix-first     (range-of uf-v)
+     :strata-overlap? (and (<= (apply min rf-v) (apply max uf-v))
+                           (<= (apply min uf-v) (apply max rf-v)))}))
+
+(defn- round-quantities
+  "Everything one round yields, from its two segments' p50s."
+  [slice]
+  (let [rg      (get slice :reagent-subs)
+        ux      (get slice :uix-subs)
+        floor-r (p50-of (:floor rg))
+        floor-u (p50-of (:floor ux))
+        reagent (p50-of (:reagent-subs rg))
+        uix     (p50-of (:uix-subs ux))
+        xcript  (p50-of (:uix-xcript ux))
+        handoff (p50-of (:uix-handoff ux))
+        seam    (/ floor-u floor-r)
+        delta   (- xcript handoff)
+        excess  (- uix reagent)
+        excess-seam (- (/ uix seam) reagent)]
+    {:floor-reagent floor-r
+     :floor-uix     floor-u
+     :reagent       reagent
+     :uix           uix
+     :xcript        xcript
+     :handoff       handoff
+     :ctl-ratio-reagent (/ (p50-of (:ctl-2x rg)) floor-r)
+     :ctl-ratio-uix     (/ (p50-of (:ctl-2x ux)) floor-u)
+     :seam          seam
+     :rz            (/ (/ uix floor-u) (/ reagent floor-r))
+     :delta         delta
+     :excess        excess
+     :excess-seam   excess-seam
+     :fraction      (when (pos? excess) (/ delta excess))
+     :fraction-seam (when (pos? excess-seam) (/ (/ delta seam) excess-seam))}))
+
+(defn- fidelity-of
+  "The clock fidelity control: the transcription must reproduce the
+  shipped hook. Both readers here are the same clock, so the legs are the
+  per-round p50 ranges and the medians."
+  [uix-vec xcript-vec]
+  (let [a   (range-of uix-vec)
+        b   (range-of xcript-vec)
+        ovl (and (<= (:min a) (:max b)) (<= (:min b) (:max a)))
+        rel (js/Math.abs (dec (/ (p50-of xcript-vec) (p50-of uix-vec))))]
+    {:shipped-uix    a
+     :copy-xcript    b
+     :ranges-overlap? ovl
+     :medians-apart  (lane/round4 rel)
+     :band           fidelity-band
+     :ok?            (and (js/isFinite rel) (or ovl (<= rel fidelity-band)))}))
+
+(defn- rule-verdict
+  "The pre-registered rf2-2rtt6.14 decision rule, mechanised for ONE row.
+  BOTH estimators (raw and seam-adjusted), ALL rounds:
+
+    :below-20        every estimate resolves and sits under 0.20
+    :at-or-above-20  every estimate resolves and sits at/over 0.20
+    :unresolvable    a round's excess did not resolve above zero, or the
+                     estimates straddle 0.20
+
+  The rule itself lives on rf2-2rtt6.14 and is applied, not re-litigated:
+  `< 20% or unresolvable` feeds the close; `>= 20%` must hold on
+  representative layer-1 AND layer-2/3 mounts to feed the reopen."
+  [fractions fractions-seam]
+  (let [all (into (vec fractions) fractions-seam)]
+    (cond
+      (some nil? all)             :unresolvable
+      (every? #(< % 0.20) all)    :below-20
+      (every? #(>= % 0.20) all)   :at-or-above-20
+      :else                       :unresolvable)))
+
+;; ---------------------------------------------------------------------------
+;; Publication
+;; ---------------------------------------------------------------------------
+
+(defn- publish!
+  [{:keys [row-key grade layer doc control] :as _spec} slices t coll witness-results wfails]
+  (let [qs        (mapv round-quantities slices)
+        pick      (fn [k] (mapv k qs))
+        fractions      (pick :fraction)
+        fractions-seam (pick :fraction-seam)
+        resolved? (fn [vs] (not-any? nil? vs))
+        fid       (fidelity-of (pick :uix) (pick :xcript))
+        rz        (pick :rz)
+        order     (converge/segment-order-verdict rz rounds)
+        c-rg      (lane/control-verdict (:predicted control)
+                                        (select-keys (range-of (pick :ctl-ratio-reagent))
+                                                     [:min :max :mean])
+                                        control-slack)
+        c-ux      (lane/control-verdict (:predicted control)
+                                        (select-keys (range-of (pick :ctl-ratio-uix))
+                                                     [:min :max :mean])
+                                        control-slack)
+        verdict   (rule-verdict fractions fractions-seam)]
+    (lane/record! (name row-key)
+                  {:benchmark   (keyword "hicasso.coldmount" (name row-key))
+                   :bead        "rf2-2rtt6.15"
+                   :doc         doc
+                   :grade       grade
+                   :layer       layer
+                   :witness-set "rf2-2rtt6.2 (converged; p0-converged-witness-set.md)"
+                   :spine       (str "the SHIPPED re-frame.substrate.spine/use-subscribe — "
+                                     "rf2-2rtt6.13's retention fix NOT landed; the balanced "
+                                     "render round trip and the commit-phase rebuild are the "
+                                     "shipped behaviour under measurement")
+                   :rounds      rounds
+                   :balanced-design? (even? rounds)
+                   :per-round   {:floor-reagent (mapv lane/round4 (pick :floor-reagent))
+                                 :floor-uix     (mapv lane/round4 (pick :floor-uix))
+                                 :reagent-subs  (mapv lane/round4 (pick :reagent))
+                                 :uix-subs      (mapv lane/round4 (pick :uix))
+                                 :uix-xcript    (mapv lane/round4 (pick :xcript))
+                                 :uix-handoff   (mapv lane/round4 (pick :handoff))}
+                   :double-build-ms {:doc "xcript − handoff, per round (ms, UIx segment): the build/dispose/rebuild churn of the cold-mount double build over the row's N cold reads"
+                                     :summary (range-of (pick :delta))}
+                   :red-zone-excess-ms {:doc "uix-subs − reagent-subs, per round (ms, cross-seam, same run): the mount red-zone excess this row's fraction is priced against"
+                                        :raw (range-of (pick :excess))
+                                        :seam-adjusted (range-of (pick :excess-seam))
+                                        :resolved-above-zero? (and (resolved? fractions)
+                                                                   (resolved? fractions-seam))}
+                   :seam        (range-of (pick :seam))
+                   :rz-ratio    (assoc (range-of rz)
+                                       :numerator :uix-subs :denominator :reagent-subs
+                                       :claim (if (:magnitude-resolved? order)
+                                                :magnitude :direction-only))
+                   :segment-order-control order
+                   :status      :evidence})
+    (lane/record! "coldmount-fraction"
+                  {:row row-key
+                   :layer layer
+                   :grade grade
+                   :fraction-of-red-zone
+                   {:raw           (when (resolved? fractions) (range-of fractions))
+                    :seam-adjusted (when (resolved? fractions-seam) (range-of fractions-seam))
+                    :per-round-raw fractions
+                    :per-round-seam-adjusted fractions-seam
+                    :strata (when (resolved? fractions) (strata-of fractions))}
+                   :rule (str "pre-registered on rf2-2rtt6.14: fraction < 20% of the mount "
+                              "red-zone, or unresolvable from round-to-round spread -> close "
+                              "as 'take rf2-2rtt6.13 alone; Spec 006 no-grace-period stands'; "
+                              ">= 20% on representative layer-1 AND layer-2/3 mounts -> "
+                              "reopen for a hook-scoped provisional hand-off design pass only")
+                   :row-verdict verdict})
+    (lane/record! "fidelity" (assoc fid :row row-key))
+    (lane/record! "witness-counts"
+                  {:row row-key :layer layer
+                   :predictions {:xcript  "commits N, rebuilt N, bodyRuns 2N at every layer <= L"
+                                 :handoff "commits N, rebuilt 0, bodyRuns N at every layer <= L"
+                                 :reagent "commits 0, rebuilt 0, bodyRuns N at every layer <= L"}
+                   :results witness-results
+                   :failures wfails})
+    (lane/record! "positive-control"
+                  {:row row-key
+                   :predicted (:predicted control)
+                   :basis     (:basis control)
+                   :reagent-segment c-rg
+                   :uix-segment     c-ux})
+    (lane/record! "verification" {row-key (lane/tally-value t)})
+    (let [vd (lane/guard! (:samples @coll)
+                          (str "Hicasso cold-mount double build — " (name row-key)))]
+      (lane/record! "arm-order-guard"
+                    {:row row-key
+                     :tolerance (:tolerance vd)
+                     :contaminated? (:contaminated? vd)
+                     :unchecked? (:unchecked? vd)
+                     :refuse? (:refuse? vd)
+                     :arms (:arms vd)})
+      (when (:refuse? vd) (set! (.-HICASSO_GUARD_REFUSED js/window) true)))
+    (when (some (complement :ok?) [c-rg c-ux])
+      (set! (.-HICASSO_CONTROL_FAILED js/window) true))
+    (when (:refuse? order)
+      (set! (.-HICASSO_ORDER_REFUSED js/window) true))
+    ;; The claims this table is published on: the counting witness and the
+    ;; clock fidelity control. A mismatch or a non-fidelitous transcription
+    ;; voids every delta; the records above are already on the console, and
+    ;; the driver exits 4.
+    (when (or (seq wfails) (not (:ok? fid)))
+      (set! (.-HICASSO_CLAIM_FAILED js/window) true))
+    (lane/assert-verified! t (str "row " (name row-key)))
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; The schedule's preconditions
+;; ---------------------------------------------------------------------------
+
+(defn- slot-order-varies-at?
+  "The plan sizes this entry runs (3 arms Reagent-side, 5 UIx-side) plus
+  the k=2 canary the converged arm keeps — each must emit more than one
+  order across sample indices, or `both orders` is a claim the schedule
+  cannot support."
+  [k]
+  (> (count (distinct (map #(guard/slot-order k %) (range 8)))) 1))
+
+;; ---------------------------------------------------------------------------
+;; The run
+;; ---------------------------------------------------------------------------
+
+(defn ^:export -main
+  []
+  (try
+    (lane/leave-act-environment!)
+    (cond
+      (not (lane/self-test!))
+      (do (lane/fail! (str "the arm-order guard's SELF-TEST failed — this copy of the rule "
+                           "no longer behaves like the one the .cjs drivers use, so nothing "
+                           "was measured"))
+          (lane/done!))
+
+      (not (every? slot-order-varies-at? [2 3 5]))
+      (do (lane/fail! (str "lane/slot-order emits ONE order at a plan size this entry runs "
+                           "(or at the k=2 canary) — the rf2-ouwh8 degeneracy class. Nothing "
+                           "is measured until the schedule is repaired; the repair belongs "
+                           "to the schedule, never to the tolerance"))
+          (lane/done!))
+
+      :else
+      (let [row-key (query-row)
+            spec    (row-spec row-key)
+            {:keys [problems]} (parity! spec)]
+        (js/console.log (str ";; HICASSO coldmount row " (name row-key)))
+        (lane/record! "parity"
+                      {:row row-key :problems problems :ok? (empty? problems)
+                       :note (str "canonical DOM with attribute names sorted, inside each "
+                                  "segment AND across the seam, over the judged arms "
+                                  "(floor, reagent-subs / uix-subs, uix-xcript, uix-handoff); "
+                                  "element counts checked against written arithmetic — "
+                                  (base-elements spec) " for " (name row-key)
+                                  ", and the arm's OWN scale for the 2x control")})
+        (if (seq problems)
+          (do (lane/fail! (str "the arms do not build the same page under :advanced — "
+                               (pr-str problems)))
+              (lane/done!))
+          (let [wit    (witness-sweep! spec)
+                wfails (witness-failures wit (:layer spec))]
+            (if (seq wfails)
+              (do (lane/record! "witness-counts"
+                                {:row row-key :layer (:layer spec)
+                                 :results wit :failures wfails})
+                  (set! (.-HICASSO_CLAIM_FAILED js/window) true)
+                  (lane/fail! (str "THE COUNTING WITNESS FALSIFIED A PREDICTION — the "
+                                   "construction counts this ablation is built on did not "
+                                   "hold, so no clock taken over these arms is attributable: "
+                                   (pr-str wfails)))
+                  (lane/done!))
+              (let [coll (lane/sample-collector)
+                    t    (lane/tally)]
+                (-> (lane/chain [] (range rounds)
+                                (fn [acc r]
+                                  (-> (run-round! spec r coll t)
+                                      (.then (fn [slice] (conj acc slice))))))
+                    (.then (fn [slices]
+                             (publish! spec slices t coll wit wfails)
+                             (lane/done!)
+                             nil))
+                    (.catch (fn [e]
+                              (lane/fail! (str "the run rejected: " e))
+                              (lane/done!))))))))))
+    (catch :default e
+      (lane/fail! (str "the run threw: " e))
+      (lane/done!))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/coldmount_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/coldmount_run.cjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+// THE COLD-MOUNT DOUBLE BUILD, PRICED AGAINST THE MOUNT RED-ZONE — driver
+// (rf2-2rtt6.15; decision input for the rf2-2rtt6.14 ruling).
+//
+//   node implementation/freehand/test/re_frame/bench/hicasso/coldmount_run.cjs
+//   COLDMOUNT_ONLY=M1L1,M1L2 node .../coldmount_run.cjs      # a subset of rows
+//
+// Build once, serve once, load the page ONE ROW AT A TIME, and refuse a
+// figure that moves with its position in the plan. The method is the
+// converged arm's (`p0_converge_run.cjs`), on its witnesses, on its lane;
+// what is new is the pair of transcription arms whose difference is the
+// cold-mount double build, and the fraction their delta makes of the
+// UIx-minus-Reagent mount excess measured in the SAME page loads.
+//
+// ## No new build id
+//
+// `implementation/shadow-cljs.edn` is not touched. This rides
+// `:hicasso-bench` with an output directory and an `:init-fn` merged in at
+// the CLI — HD-017's seam, the same one every driver in this directory
+// uses. The lane's one cache rule runs first (`lane_cache.cjs`,
+// rf2-2rtt6.20): one build id means one build cache, so it is cleared
+// before the build and the bundle starts cold.
+//
+// ## Exit codes
+//
+//   0  measured; guard clean; controls, witness counts and fidelity all held
+//   1  the run failed (build, page error, a fatal the page recorded, a
+//      positive control that did not see what it predicted, a
+//      SEGMENT-ORDER control whose two strata point opposite ways)
+//   2  THE ARM-ORDER GUARD REFUSED. A figure whose value depends on where
+//      in the plan it was measured is not a figure. Repair the ARM —
+//      more warm-up, fewer arms per page, a longer window — never the
+//      guard's tolerance.
+//   4  A CLAIM THIS TABLE IS PUBLISHED ON DID NOT HOLD — the counting
+//      witness falsified a construction-count prediction, or the
+//      transcription failed the clock fidelity control against the
+//      shipped hook. The records are on stdout before the refusal, so
+//      the evidence survives it; the deltas are void and must not be
+//      quoted (the rf2-2rtt6.12 audit's fail-closed discipline).
+//
+// A Chromium `pageerror` is FATAL: a benchmark that threw and kept going
+// publishes a precise number for a page that is not the page under test.
+
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+// The directory's ONE navigation, with its ceiling named (rf2-p9fa3).
+const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs');
+// The directory's ONE sentinel wait, raced against the page dying (rf2-f5roa).
+const { watchPage } = require('../../freehand/bench/sentinel.cjs');
+// One build id, N programs, so nothing may cache between them (rf2-2rtt6.20).
+const { resetLaneBuildCache } = require('./lane_cache.cjs');
+
+const IMPL = path.resolve(__dirname, '../../../../..');
+
+const BUILD_ID = 'hicasso-bench';
+const OUT_DIR = process.env.COLDMOUNT_OUT_DIR || 'out/hicasso-coldmount';
+const INIT_FN = 're-frame.bench.hicasso.coldmount-app/-main';
+const OUT = path.join(IMPL, OUT_DIR);
+const PORT = Number(process.env.COLDMOUNT_PORT || 8143);
+
+// One row, one page, one fresh heap. M1 is the primary witness; M2 is
+// DIAGNOSTIC per rf2-2rtt6.2's own grading and stays diagnostic here. The
+// layer ladder is the split that attributes the double-build clock between
+// the reaction allocation (layer 1, no `:<-` chain) and the per-hop input
+// rebuild + re-deref (the L2−L1 / L3−L2 increments).
+const ALL_ROWS = [
+  { id: 'M1L1', why: 'mount, 901 el / 300 boundaries, layer-1 subs — PRIMARY' },
+  { id: 'M1L2', why: 'the M1 mount through one :<- hop — PRIMARY (layer-2/3 coverage)' },
+  { id: 'M1L3', why: 'the M1 mount through two :<- hops — PRIMARY (layer-2/3 coverage)' },
+  { id: 'M2L1', why: 'mount, 51 el / 12 fields, layer-1 — DIAGNOSTIC, clamp-quantised' },
+  { id: 'M2L2', why: 'the M2 form through one :<- hop — DIAGNOSTIC' },
+];
+
+// `COLDMOUNT_ONLY=M1L2` re-takes a subset over the SAME bundle and the same
+// gates — `p0_converge_run.cjs`'s `HICASSO_ONLY`, for that driver's reasons.
+const ONLY = (process.env.COLDMOUNT_ONLY || '').trim();
+const ROWS = ONLY ? ALL_ROWS.filter((r) => ONLY.split(',').includes(r.id)) : ALL_ROWS;
+if (ROWS.length === 0) {
+  console.error(
+    `[coldmount] COLDMOUNT_ONLY=${ONLY} selects no row; known ids: ${ALL_ROWS.map((r) => r.id).join(', ')}`
+  );
+  process.exit(1);
+}
+
+// A page's own budget. Four rounds of two segments with warm-up, plus the
+// parity and counting-witness phases, is minutes on a loaded workstation.
+const SENTINEL_TIMEOUT_MS = 20 * 60 * 1000;
+
+// ONE LINE, deliberately: shadow-cljs's CLI re-splits `--config-merge` on
+// whitespace when the EDN contains a newline.
+const CONFIG_MERGE =
+  `{:output-dir "${OUT_DIR}" :asset-path "." ` +
+  `:modules {:main {:init-fn ${INIT_FN}}}}`;
+
+function build() {
+  if (resetLaneBuildCache(IMPL, BUILD_ID)) {
+    console.error(`[coldmount] cleared .shadow-cljs/builds/${BUILD_ID} — one build id, N arms (rf2-2rtt6.20)`);
+  }
+  console.error(`[coldmount] building :advanced bundle — ${INIT_FN} -> ${OUT_DIR}`);
+  const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+  const r = spawnSync(
+    process.execPath,
+    [runner, 'release', BUILD_ID, '--config-merge', CONFIG_MERGE],
+    { cwd: IMPL, stdio: ['ignore', 'inherit', 'inherit'] }
+  );
+  if (r.status !== 0) {
+    console.error(`[coldmount] build failed with status ${r.status}`);
+    process.exit(1);
+  }
+}
+
+const MIME = { '.js': 'text/javascript', '.html': 'text/html', '.map': 'application/json' };
+
+function serve() {
+  fs.writeFileSync(
+    path.join(OUT, 'index.html'),
+    '<!doctype html><html><head><meta charset="utf-8"><title>Hicasso cold-mount double build</title></head>' +
+      '<body><div id="app"></div><script src="main.js"></script></body></html>'
+  );
+  return http
+    .createServer((req, res) => {
+      const rel = decodeURIComponent(req.url.split('?')[0]);
+      const file = path.join(OUT, rel === '/' ? 'index.html' : rel);
+      if (!file.startsWith(OUT) || !fs.existsSync(file)) {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      fs.createReadStream(file).pipe(res);
+    })
+    .listen(PORT);
+}
+
+async function runRow(browser, row) {
+  // A FRESH PAGE per row: the fault this lane's drivers were rebuilt
+  // around is a page that gets slower the longer it runs, and a reused
+  // page carries whatever caused that across the row boundary.
+  const page = await browser.newPage();
+  page.on('console', (msg) => {
+    const t = msg.text();
+    if (t.startsWith(';; ') || t.startsWith('[coldmount]')) console.log(t);
+  });
+  // Watching starts BEFORE the navigation (rf2-f5roa): a throw before the
+  // sentinel must not cost the full budget before the driver looks.
+  const watch = watchPage(page, `coldmount:${row.id}`);
+
+  try {
+    await navigate(page, `http://127.0.0.1:${PORT}/?row=${row.id}`, {
+      waitUntil: 'commit',
+      timeoutMs: NAV_TIMEOUT_MS,
+      budget: `the ${SENTINEL_TIMEOUT_MS / 60000}-minute wait for window.HICASSO_DONE`,
+    });
+    await watch.race('window.HICASSO_DONE === true || window.HICASSO_ERROR', {
+      timeoutMs: SENTINEL_TIMEOUT_MS,
+      budget: `the ${SENTINEL_TIMEOUT_MS / 60000}-minute wait for window.HICASSO_DONE`,
+    });
+
+    const err = await page.evaluate('window.HICASSO_ERROR || null');
+    const refused = await page.evaluate('window.HICASSO_GUARD_REFUSED === true');
+    const controlFailed = await page.evaluate('window.HICASSO_CONTROL_FAILED === true');
+    const orderRefused = await page.evaluate('window.HICASSO_ORDER_REFUSED === true');
+    const claimFailed = await page.evaluate('window.HICASSO_CLAIM_FAILED === true');
+    const results = await page.evaluate('window.HICASSO_RESULTS || {}');
+    return {
+      row, err, refused, controlFailed, orderRefused, claimFailed, results,
+      pageErrors: watch.failures.map((f) => `${f.kind}: ${f.detail}`),
+    };
+  } finally {
+    watch.dispose();
+    await page.close();
+  }
+}
+
+(async () => {
+  build();
+  const server = serve();
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch();
+  const version = browser.version();
+  const outcomes = [];
+  let died = null;
+  try {
+    for (const row of ROWS) {
+      console.error(`[coldmount] row ${row.id} — ${row.why}`);
+      try {
+        outcomes.push(await runRow(browser, row));
+      } catch (e) {
+        died = `${row.id}: ${e.message}`;
+        break;
+      }
+    }
+  } finally {
+    await browser.close();
+    server.close();
+  }
+
+  if (died) {
+    console.error(`[coldmount] FAILED: ${died}`);
+    process.exit(1);
+  }
+
+  console.log(`;; ==== HICASSO RUNTIME ====`);
+  console.log(`;; chromium ${version} (playwright), :advanced, goog.DEBUG false`);
+  console.log(`;; one row per page; ${ROWS.length} pages; 4 rounds (balanced 2:2 segment order)`);
+  console.log(
+    `;; reproduce  ${ONLY ? `COLDMOUNT_ONLY=${ONLY} ` : ''}node ` +
+      `implementation/freehand/test/re_frame/bench/hicasso/coldmount_run.cjs`
+  );
+  console.log(`;; rows       ${ROWS.map((r) => r.id).join(', ')}${ONLY ? `  (COLDMOUNT_ONLY=${ONLY})` : ''}`);
+  for (const o of outcomes) {
+    for (const [k, v] of Object.entries(o.results)) {
+      console.log(`;; ==== HICASSO ${o.row.id} / ${k} ====`);
+      console.log(v);
+    }
+  }
+
+  const errored = outcomes.filter((o) => o.pageErrors.length > 0);
+  if (errored.length > 0) {
+    console.error(
+      `[coldmount] FAILED: uncaught page error(s) — every figure above was taken on a ` +
+        `page that had already thrown:\n  ` +
+        errored.map((o) => `${o.row.id}: ${o.pageErrors.join(' | ')}`).join('\n  ')
+    );
+    process.exit(1);
+  }
+  const refused = outcomes.filter((o) => o.refused);
+  if (refused.length > 0) {
+    console.error(
+      `[coldmount] ARM-ORDER GUARD REFUSED (exit 2) on: ${refused
+        .map((o) => o.row.id)
+        .join(', ')}. At least one arm reads differently for WHERE IN THE PLAN it was ` +
+        `measured, so no figure in that row is reportable. Repair the ARM; the guard ` +
+        `tolerance is not yours to move.`
+    );
+    process.exit(2);
+  }
+  const ctlFailed = outcomes.filter((o) => o.controlFailed);
+  if (ctlFailed.length > 0) {
+    console.error(
+      `[coldmount] FAILED: the positive control did not see the change its own ` +
+        `arithmetic predicts on: ${ctlFailed.map((o) => o.row.id).join(', ')}. An ` +
+        `instrument that cannot see a predicted change cannot be trusted with an ` +
+        `unpredicted one.`
+    );
+    process.exit(1);
+  }
+  const orderRefused = outcomes.filter((o) => o.orderRefused);
+  if (orderRefused.length > 0) {
+    console.error(
+      `[coldmount] FAILED: the SEGMENT-ORDER control refused on: ${orderRefused
+        .map((o) => o.row.id)
+        .join(', ')}. The row's two order strata point OPPOSITE WAYS across 1.0, so the ` +
+        `row has no direction to publish and the figure is a measurement of the schedule.`
+    );
+    process.exit(1);
+  }
+  const failed = outcomes.filter((o) => o.err);
+  if (failed.length > 0) {
+    console.error(
+      `[coldmount] FAILED:\n  ` + failed.map((o) => `${o.row.id}: ${o.err}`).join('\n  ')
+    );
+    process.exit(1);
+  }
+  // LAST among the gates, so every more specific failure names itself
+  // first. Exit 4 is the fail-closed refusal the rf2-2rtt6.12 audit
+  // established: the table was written, and it may not be published.
+  const claimFailed = outcomes.filter((o) => o.claimFailed);
+  if (claimFailed.length > 0) {
+    console.error(
+      `[coldmount] THIS TABLE MAY NOT BE PUBLISHED — a claim it rests on did not hold ` +
+        `on: ${claimFailed.map((o) => o.row.id).join(', ')}. Either the counting witness ` +
+        `falsified a construction-count prediction (see the witness-counts record) or ` +
+        `the transcription failed the clock fidelity control against the shipped hook ` +
+        `(see the fidelity record). Every delta in those rows is void.`
+    );
+    process.exit(4);
+  }
+  console.error('[coldmount] ok');
+})();

--- a/implementation/freehand/test/re_frame/bench/hicasso/coldmount_views.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/coldmount_views.cljs
@@ -1,0 +1,724 @@
+(ns re-frame.bench.hicasso.coldmount-views
+  "THE COLD-MOUNT DOUBLE BUILD, PRICED ON THE CLOCK — the views, the sub
+  layers, the hook transcriptions and the counting witnesses
+  (rf2-2rtt6.15, epic rf2-2rtt6 / EP-0038; decision input for the
+  rf2-2rtt6.14 ruling).
+
+  ## The term being priced
+
+  `re-frame.substrate.spine/use-subscribe` takes a BALANCED render-phase
+  round trip — `subs/subscribe` immediately followed by `subs/unsubscribe`
+  (spine.cljs, the rf2-es09qq net-zero rule) — so a render that never
+  commits retains no ref-count. For a query with NO live cache entry that
+  is `0 -> 1 -> 0`, and `1 -> 0` is the disposal edge:
+  `re-frame.subs.cache/unsubscribe!` disposes in-tick with no grace
+  period. The commit-owned `subscribe-fn` then misses the cache and
+  REBUILDS. Two reactions are built per cold read; the COUNT is exact and
+  landed (`bodyRuns = 2.00N` vs Reagent's `1.00N`, rf2-2rtt6.12,
+  `docs/design/hicasso/studio/uix-spine-per-read-decomposition.md`).
+  This instrument prices the CLOCK of the second construction — the
+  second sub-body run, the `:<-` input-chain re-deref, and the reaction
+  allocation on the commit-phase rebuild.
+
+  ## The single-variable ablation
+
+  Two transcriptions of the shipped hook, differing in exactly one
+  property — HOW MANY reactions a cold read constructs:
+
+  | arm | render phase | commit phase | constructions |
+  |---|---|---|---|
+  | `xcript`  | subscribe + unsubscribe (build #1, dispose #1) | subscribe (build #2) | **2** |
+  | `handoff` | subscribe (build #1, +1 held provisionally)    | subscribe (hit) + unsubscribe (2 -> 1) | **1** |
+
+  Both make exactly TWO `subs/subscribe` and TWO `subs/unsubscribe` calls
+  per mounted read (render, commit, unmount); both install the same
+  watch, the same refs, the same six hooks. `xcript - handoff` is
+  therefore the build/dispose/rebuild churn ALONE — the clock a
+  commit-phase adoption of the render-phase materialisation would
+  recover, which is precisely the question rf2-2rtt6.14 holds open.
+
+  `handoff` is a MEASUREMENT ARM, not a proposed patch: its provisional
+  +1 leaks if a render is abandoned before commit, and the reaping policy
+  a real hand-off needs is exactly what the rf2-2rtt6.14 design pass
+  would have to produce. Nothing here edits production code.
+
+  ## The sub layers
+
+  The `:<-` input-chain re-deref lives at layer 2+, so the witnesses run
+  at three depths over the converged witness set's own layer-1 sub:
+
+      layer 1   [:p0/cell i]                  (rf2-2rtt6.2's, unchanged)
+      layer 2   [:cm/l2 i]  :<-  [:p0/cell i]  (parametric input-fn)
+      layer 3   [:cm/l3 i]  :<-  [:cm/l2 i]
+
+  The chain fns are identity, deliberately: the sub BODIES here are the
+  witness set's near-zero bodies, so the layer ladder isolates the
+  per-hop `:<-` machinery (input subscribe, input reaction construction,
+  input re-deref) rather than user compute.
+
+  ## The counting witnesses
+
+  A displayed count that is not adjudicated is decoration, so the
+  construction counts are PREDICTED and CHECKED per page before any clock
+  is read: counter-instrumented sub chains (`:cm/w1` / `:cm/w2` /
+  `:cm/w3`) behind counter-instrumented copies of both transcriptions.
+  For N reads at page layer L:
+
+      xcript    commits N   rebuilt N   bodyRuns 2N at every layer <= L
+      handoff   commits N   rebuilt 0   bodyRuns  N at every layer <= L
+      reagent   commits 0   rebuilt 0   bodyRuns  N at every layer <= L
+
+  `rebuilt = 0` on `handoff` is what makes the ablation single-variable:
+  the commit-phase acquire hands back the IDENTICAL reaction the render
+  built. The witness components never appear in a timed window and the
+  timed arms never touch a counter.
+
+  Driven by `coldmount_app.cljs` / `coldmount_run.cjs` on the
+  `:hicasso-bench` lane. Markup is byte-for-byte the converged set's
+  (`p0_reagent_views.cljs` / `p0_uix_views.cljs`); the canonical-DOM
+  parity gate proves it rather than this docstring."
+  (:require ["react" :as react]
+            [re-frame.adapter.uix :as uixa]
+            [re-frame.bench.hicasso.p0-reagent-views :as v]
+            [re-frame.core :as rf]
+            [re-frame.subs :as subs]
+            [reagent.dom.client :as rdc]
+            [uix.core :refer [$ defui]]
+            [uix.dom :as uix-dom]
+            [uix.hooks.alpha :as uix-hooks]
+            ["react-dom" :as react-dom])
+  (:require-macros [re-frame.core :refer [reg-view]]))
+
+;; ---------------------------------------------------------------------------
+;; The witness counters
+;; ---------------------------------------------------------------------------
+
+(def witness-counters
+  "Plain counters for the adjudicated counting witness.
+
+    body1/2/3 — sub-body invocations per layer of the witness chain
+    commits   — commit-phase `subscribe-fn` calls (reads that mounted)
+    rebuilt   — commit-phase acquisitions whose reaction is NOT
+                `identical?` to the render-phase handle the fiber holds"
+  (js-obj "body1" 0 "body2" 0 "body3" 0 "commits" 0 "rebuilt" 0))
+
+(defn- reset-witness-counters! []
+  (doseq [k ["body1" "body2" "body3" "commits" "rebuilt"]]
+    (aset witness-counters k 0)))
+
+;; ---------------------------------------------------------------------------
+;; The layered subs the TIMED arms read
+;; ---------------------------------------------------------------------------
+
+(defn register!
+  "The full sub graph for one segment: the converged set's layer-1
+  `:p0/cell` (via `v/register!`, unchanged), the identity `:<-` chain the
+  layer-2/3 rows read, and the counter-instrumented witness chain.
+  Re-registering overwrites with identical handlers, so the per-segment
+  re-register is idempotent (the converged arm's own pattern)."
+  []
+  (v/register!)
+  ;; Parametric `:<-` producers — the index rides the query vector, which
+  ;; the static literal `:<-` form cannot express. A parametric single
+  ;; input is delivered as `[value]` (Spec 006 §Single input contract).
+  (rf/reg-sub :cm/l2
+    (fn [qv] [[:p0/cell (second qv)]])
+    (fn [[cell] _] cell))
+  (rf/reg-sub :cm/l3
+    (fn [qv] [[:cm/l2 (second qv)]])
+    (fn [[cell] _] cell))
+  ;; -- the witness chain: identical shape, plus one counter per body ------
+  (rf/reg-sub :cm/w1
+    (fn [db [_ i]]
+      (aset witness-counters "body1" (inc (aget witness-counters "body1")))
+      (nth (:cells db) (mod i v/cells-n))))
+  (rf/reg-sub :cm/w2
+    (fn [qv] [[:cm/w1 (second qv)]])
+    (fn [[cell] _]
+      (aset witness-counters "body2" (inc (aget witness-counters "body2")))
+      cell))
+  (rf/reg-sub :cm/w3
+    (fn [qv] [[:cm/w2 (second qv)]])
+    (fn [[cell] _]
+      (aset witness-counters "body3" (inc (aget witness-counters "body3")))
+      cell))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; The two transcriptions
+;; ---------------------------------------------------------------------------
+;;
+;; `use-sub-xcript` is `re-frame.substrate.spine`'s `use-subscribe-2` body,
+;; copied — the same transcription rf2-2rtt6.12 published and validated
+;; (its heap fidelity landed 0.332% from the shipped hook). The only
+;; cosmetic differences are the ones that arm recorded: hooks named
+;; directly (`uix.hooks.alpha/use-memo`, which is exactly what the UIx
+;; adapter passes into `make-react-spine`) and the watch-key namespace
+;; spelled here. The CLOCK fidelity control in `coldmount_app.cljs` is
+;; what ties it to the shipped arm on this axis.
+
+(def ^:private watch-ns "rf-cm-use-sub")
+
+(defn- stable-key-of
+  "The `useRef` + `=` memo-by-value from the spine (rf2-mwft2), shared by
+  every transcribed arm so the stable-key term cancels in the ablation."
+  [key-ref frame-kw query-v]
+  (let [prev    (.-current key-ref)
+        new-key #js [frame-kw query-v]]
+    (if (and prev
+             (= (aget prev 0) frame-kw)
+             (= (aget prev 1) query-v))
+      prev
+      (do (set! (.-current key-ref) new-key)
+          new-key))))
+
+(defn- use-sub-xcript [frame-kw query-v]
+  (let [key-ref       (react/useRef nil)
+        committed-ref (react/useRef nil)
+        stable-key      (stable-key-of key-ref frame-kw query-v)
+        stable-frame-kw (aget stable-key 0)
+        stable-query-v  (aget stable-key 1)
+        ;; The shipped BALANCED round trip: for a cold query this is
+        ;; 0 -> 1 -> 0 — build, then dispose + evict, inside the render.
+        reaction
+        (uix-hooks/use-memo
+          (fn []
+            (let [r (subs/subscribe stable-query-v {:frame stable-frame-kw})]
+              (subs/unsubscribe stable-frame-kw stable-query-v)
+              r))
+          #js [stable-key])
+        get-snap
+        (uix-hooks/use-callback
+          (fn []
+            (let [stored (.-current committed-ref)
+                  r      (if (and stored
+                                  (identical? (aget stored 0) stable-key))
+                           (aget stored 1)
+                           reaction)]
+              (when r @r)))
+          #js [stable-key reaction])
+        subscribe-fn
+        (uix-hooks/use-callback
+          (fn [on-change]
+            ;; Cold cache (the render round trip disposed the entry), so
+            ;; this MISSES and constructs the SECOND reaction.
+            (let [committed (subs/subscribe stable-query-v
+                                            {:frame stable-frame-kw})]
+              (set! (.-current committed-ref) #js [stable-key committed])
+              (let [k (keyword watch-ns (str (gensym "watch-")))]
+                (when committed
+                  (add-watch committed k (fn [_ _ _ _] (on-change))))
+                (fn unsubscribe []
+                  (when committed (remove-watch committed k))
+                  (let [stored (.-current committed-ref)]
+                    (when (and stored (identical? (aget stored 1) committed))
+                      (set! (.-current committed-ref) nil)))
+                  (subs/unsubscribe stable-frame-kw stable-query-v)))))
+          #js [stable-key])]
+    (react/useSyncExternalStore subscribe-fn get-snap get-snap)))
+
+;; ONE property differs from `xcript`: the render-phase acquire is NOT
+;; balanced in-render. The +1 is held PROVISIONALLY; the commit-phase
+;; `subscribe-fn` takes its own durable +1 (a cache HIT — the entry is
+;; still live at ref-count 1) and then releases the provisional one,
+;; 2 -> 1, never crossing the disposal edge. One construction per read,
+;; the same four cache-API calls per read as `xcript`, everything else
+;; character-for-character identical.
+;;
+;; This is the hook-scoped provisional hand-off SHAPE, as a measurement
+;; arm. It is deliberately not safe to ship: a render abandoned before
+;; commit strands the provisional +1 (nothing ever balances it), which is
+;; exactly the reaping question the rf2-2rtt6.14 ruling owns. The
+;; instrument's residue gate (`lane/residue` back to baseline after every
+;; round) is what proves the arm balanced in THIS plan, where every
+;; render commits.
+
+(defn- use-sub-handoff [frame-kw query-v]
+  (let [key-ref       (react/useRef nil)
+        committed-ref (react/useRef nil)
+        stable-key      (stable-key-of key-ref frame-kw query-v)
+        stable-frame-kw (aget stable-key 0)
+        stable-query-v  (aget stable-key 1)
+        reaction
+        (uix-hooks/use-memo
+          (fn [] (subs/subscribe stable-query-v {:frame stable-frame-kw}))
+          #js [stable-key])
+        get-snap
+        (uix-hooks/use-callback
+          (fn []
+            (let [stored (.-current committed-ref)
+                  r      (if (and stored
+                                  (identical? (aget stored 0) stable-key))
+                           (aget stored 1)
+                           reaction)]
+              (when r @r)))
+          #js [stable-key reaction])
+        subscribe-fn
+        (uix-hooks/use-callback
+          (fn [on-change]
+            ;; Live entry at ref-count 1, so this HITS: `committed` is
+            ;; `identical?` the render-phase handle. Adopt, then release
+            ;; the provisional +1 (2 -> 1).
+            (let [committed (subs/subscribe stable-query-v
+                                            {:frame stable-frame-kw})]
+              (set! (.-current committed-ref) #js [stable-key committed])
+              (subs/unsubscribe stable-frame-kw stable-query-v)
+              (let [k (keyword watch-ns (str (gensym "watch-")))]
+                (when committed
+                  (add-watch committed k (fn [_ _ _ _] (on-change))))
+                (fn unsubscribe []
+                  (when committed (remove-watch committed k))
+                  (let [stored (.-current committed-ref)]
+                    (when (and stored (identical? (aget stored 1) committed))
+                      (set! (.-current committed-ref) nil)))
+                  (subs/unsubscribe stable-frame-kw stable-query-v)))))
+          #js [stable-key])]
+    (react/useSyncExternalStore subscribe-fn get-snap get-snap)))
+
+;; ---------------------------------------------------------------------------
+;; The timed M1 cells — 3 variants x 3 layers, unrolled
+;; ---------------------------------------------------------------------------
+;;
+;; Unrolled per variant per layer for the ladder's reason: these are hooks,
+;; the call sequence must be identical on every render by construction,
+;; and a reader pricing hook calls should be able to count them. Markup is
+;; `p0_uix_views/m1-cell`'s, byte for byte; the parity gate checks it.
+;;
+;; The SHIPPED arms read through the ambient 1-arg `use-subscribe` under
+;; `frame-provider` — exactly the converged M1 arm, because they carry the
+;; red-zone denominator role. The transcriptions pin the frame explicitly,
+;; as `use-subscribe-2` (which the ambient form resolves into) does; the
+;; per-boundary difference is one context read, far below the clock
+;; quantum, and the fidelity control adjudicates it rather than this
+;; comment.
+
+(defui s-m1-l1 [{:keys [i]}]
+  (let [cell (uixa/use-subscribe [:p0/cell i])]
+    ($ :li.row
+       ($ :span.lbl "cell ")
+       ($ :span.cell {:data-i i} (str cell)))))
+
+(defui s-m1-l2 [{:keys [i]}]
+  (let [cell (uixa/use-subscribe [:cm/l2 i])]
+    ($ :li.row
+       ($ :span.lbl "cell ")
+       ($ :span.cell {:data-i i} (str cell)))))
+
+(defui s-m1-l3 [{:keys [i]}]
+  (let [cell (uixa/use-subscribe [:cm/l3 i])]
+    ($ :li.row
+       ($ :span.lbl "cell ")
+       ($ :span.cell {:data-i i} (str cell)))))
+
+(defui x-m1-l1 [{:keys [i]}]
+  (let [cell (use-sub-xcript v/subs-frame [:p0/cell i])]
+    ($ :li.row
+       ($ :span.lbl "cell ")
+       ($ :span.cell {:data-i i} (str cell)))))
+
+(defui x-m1-l2 [{:keys [i]}]
+  (let [cell (use-sub-xcript v/subs-frame [:cm/l2 i])]
+    ($ :li.row
+       ($ :span.lbl "cell ")
+       ($ :span.cell {:data-i i} (str cell)))))
+
+(defui x-m1-l3 [{:keys [i]}]
+  (let [cell (use-sub-xcript v/subs-frame [:cm/l3 i])]
+    ($ :li.row
+       ($ :span.lbl "cell ")
+       ($ :span.cell {:data-i i} (str cell)))))
+
+(defui h-m1-l1 [{:keys [i]}]
+  (let [cell (use-sub-handoff v/subs-frame [:p0/cell i])]
+    ($ :li.row
+       ($ :span.lbl "cell ")
+       ($ :span.cell {:data-i i} (str cell)))))
+
+(defui h-m1-l2 [{:keys [i]}]
+  (let [cell (use-sub-handoff v/subs-frame [:cm/l2 i])]
+    ($ :li.row
+       ($ :span.lbl "cell ")
+       ($ :span.cell {:data-i i} (str cell)))))
+
+(defui h-m1-l3 [{:keys [i]}]
+  (let [cell (use-sub-handoff v/subs-frame [:cm/l3 i])]
+    ($ :li.row
+       ($ :span.lbl "cell ")
+       ($ :span.cell {:data-i i} (str cell)))))
+
+;; ---------------------------------------------------------------------------
+;; The timed M2 fields — 3 variants x 2 layers
+;; ---------------------------------------------------------------------------
+
+(defui s-m2-l1 [{:keys [i]}]
+  (let [cell (uixa/use-subscribe [:p0/cell i])]
+    ($ :div.field
+       ($ :label.lbl {:for (str "f" i)} (str "Field " i))
+       ($ :input.inp {:id        (str "f" i)
+                      :name      (str "f" i)
+                      :type      "text"
+                      :value     (v/field-value i cell)
+                      :read-only true})
+       ($ :p.err (v/field-error i)))))
+
+(defui s-m2-l2 [{:keys [i]}]
+  (let [cell (uixa/use-subscribe [:cm/l2 i])]
+    ($ :div.field
+       ($ :label.lbl {:for (str "f" i)} (str "Field " i))
+       ($ :input.inp {:id        (str "f" i)
+                      :name      (str "f" i)
+                      :type      "text"
+                      :value     (v/field-value i cell)
+                      :read-only true})
+       ($ :p.err (v/field-error i)))))
+
+(defui x-m2-l1 [{:keys [i]}]
+  (let [cell (use-sub-xcript v/subs-frame [:p0/cell i])]
+    ($ :div.field
+       ($ :label.lbl {:for (str "f" i)} (str "Field " i))
+       ($ :input.inp {:id        (str "f" i)
+                      :name      (str "f" i)
+                      :type      "text"
+                      :value     (v/field-value i cell)
+                      :read-only true})
+       ($ :p.err (v/field-error i)))))
+
+(defui x-m2-l2 [{:keys [i]}]
+  (let [cell (use-sub-xcript v/subs-frame [:cm/l2 i])]
+    ($ :div.field
+       ($ :label.lbl {:for (str "f" i)} (str "Field " i))
+       ($ :input.inp {:id        (str "f" i)
+                      :name      (str "f" i)
+                      :type      "text"
+                      :value     (v/field-value i cell)
+                      :read-only true})
+       ($ :p.err (v/field-error i)))))
+
+(defui h-m2-l1 [{:keys [i]}]
+  (let [cell (use-sub-handoff v/subs-frame [:p0/cell i])]
+    ($ :div.field
+       ($ :label.lbl {:for (str "f" i)} (str "Field " i))
+       ($ :input.inp {:id        (str "f" i)
+                      :name      (str "f" i)
+                      :type      "text"
+                      :value     (v/field-value i cell)
+                      :read-only true})
+       ($ :p.err (v/field-error i)))))
+
+(defui h-m2-l2 [{:keys [i]}]
+  (let [cell (use-sub-handoff v/subs-frame [:cm/l2 i])]
+    ($ :div.field
+       ($ :label.lbl {:for (str "f" i)} (str "Field " i))
+       ($ :input.inp {:id        (str "f" i)
+                      :name      (str "f" i)
+                      :type      "text"
+                      :value     (v/field-value i cell)
+                      :read-only true})
+       ($ :p.err (v/field-error i)))))
+
+;; ---------------------------------------------------------------------------
+;; The UIx grids and root
+;; ---------------------------------------------------------------------------
+
+(defui m1-grid [{:keys [cell n]}]
+  ($ :ul.grid {:role "list"}
+     (for [i (range n)]
+       ($ cell {:key i :i i}))))
+
+(defui m2-grid [{:keys [cell n]}]
+  ($ :form.p0form
+     ($ :fieldset.fields
+        (for [i (range n)]
+          ($ cell {:key i :i i})))
+     ($ :button.submit {:type "submit" :disabled true} "Submit")))
+
+(defn uix-root
+  "One root for every UIx arm: `frame-provider` scopes the segment's frame
+  (the ambient shipped arms resolve through it; the pinned transcriptions
+  ignore it) and renders no DOM of its own, so it cannot move the parity
+  gate."
+  [grid cell n]
+  ($ uixa/frame-provider {:frame v/subs-frame}
+     ($ grid {:cell cell :n n})))
+
+(def uix-m1-cells
+  {:uix-subs    {1 s-m1-l1 2 s-m1-l2 3 s-m1-l3}
+   :uix-xcript  {1 x-m1-l1 2 x-m1-l2 3 x-m1-l3}
+   :uix-handoff {1 h-m1-l1 2 h-m1-l2 3 h-m1-l3}})
+
+(def uix-m2-cells
+  {:uix-subs    {1 s-m2-l1 2 s-m2-l2}
+   :uix-xcript  {1 x-m2-l1 2 x-m2-l2}
+   :uix-handoff {1 h-m2-l1 2 h-m2-l2}})
+
+;; ---------------------------------------------------------------------------
+;; The Reagent layer-2/3 counterparts
+;; ---------------------------------------------------------------------------
+;;
+;; Layer 1 is `p0_reagent_views`' own `m1-subs` / `m2-subs`, untouched.
+;; These are the same markup over the layered queries.
+
+(reg-view ^{:rf/id :cm/m1-cell-l2} rg-m1-cell-l2
+  [i]
+  (let [cell @(rf/subscribe [:cm/l2 i])]
+    [:li.row
+     [:span.lbl "cell "]
+     [:span.cell {:data-i i} (str cell)]]))
+
+(reg-view ^{:rf/id :cm/m1-l2} rg-m1-l2
+  [n]
+  [:ul.grid {:role "list"}
+   (for [i (range n)]
+     ^{:key i} [rg-m1-cell-l2 i])])
+
+(reg-view ^{:rf/id :cm/m1-cell-l3} rg-m1-cell-l3
+  [i]
+  (let [cell @(rf/subscribe [:cm/l3 i])]
+    [:li.row
+     [:span.lbl "cell "]
+     [:span.cell {:data-i i} (str cell)]]))
+
+(reg-view ^{:rf/id :cm/m1-l3} rg-m1-l3
+  [n]
+  [:ul.grid {:role "list"}
+   (for [i (range n)]
+     ^{:key i} [rg-m1-cell-l3 i])])
+
+(reg-view ^{:rf/id :cm/m2-field-l2} rg-m2-field-l2
+  [i]
+  (let [cell @(rf/subscribe [:cm/l2 i])]
+    [:div.field
+     [:label.lbl {:for (str "f" i)} (str "Field " i)]
+     [:input.inp {:id        (str "f" i)
+                  :name      (str "f" i)
+                  :type      "text"
+                  :value     (v/field-value i cell)
+                  :read-only true}]
+     [:p.err (v/field-error i)]]))
+
+(reg-view ^{:rf/id :cm/m2-l2} rg-m2-l2
+  [fields]
+  [:form.p0form
+   [:fieldset.fields
+    (for [i (range fields)]
+      ^{:key i} [rg-m2-field-l2 i])]
+   [:button.submit {:type "submit" :disabled true} "Submit"]])
+
+(def reagent-m1-views {1 v/m1-subs 2 rg-m1-l2 3 rg-m1-l3})
+(def reagent-m2-views {1 v/m2-subs 2 rg-m2-l2})
+
+;; ---------------------------------------------------------------------------
+;; THE COUNTING WITNESS — the same claim, settled exactly
+;; ---------------------------------------------------------------------------
+;;
+;; Counter-instrumented copies of BOTH transcriptions (the counters are
+;; the only additions), read against the counter-instrumented `:cm/w*`
+;; chain, mounted OUTSIDE every timed window over disjoint cell ranges,
+;; and adjudicated against the predictions in the namespace docstring.
+;; A `rebuilt` of 0 on `xcript` or of N on `handoff` falsifies the
+;; ablation outright, and the run refuses to publish.
+
+(defn- use-sub-witness-xcript [frame-kw query-v]
+  (let [key-ref       (react/useRef nil)
+        committed-ref (react/useRef nil)
+        stable-key      (stable-key-of key-ref frame-kw query-v)
+        stable-frame-kw (aget stable-key 0)
+        stable-query-v  (aget stable-key 1)
+        reaction
+        (uix-hooks/use-memo
+          (fn []
+            (let [r (subs/subscribe stable-query-v {:frame stable-frame-kw})]
+              (subs/unsubscribe stable-frame-kw stable-query-v)
+              r))
+          #js [stable-key])
+        get-snap
+        (uix-hooks/use-callback
+          (fn []
+            (let [stored (.-current committed-ref)
+                  r      (if (and stored
+                                  (identical? (aget stored 0) stable-key))
+                           (aget stored 1)
+                           reaction)]
+              (when r @r)))
+          #js [stable-key reaction])
+        subscribe-fn
+        (uix-hooks/use-callback
+          (fn [on-change]
+            (let [committed (subs/subscribe stable-query-v
+                                            {:frame stable-frame-kw})]
+              (aset witness-counters "commits"
+                    (inc (aget witness-counters "commits")))
+              ;; `reaction` is the render-phase handle the fiber holds;
+              ;; `committed` is what the commit-phase acquire returned.
+              ;; Not `identical?` means the render-phase one was disposed
+              ;; and a SECOND was constructed between the two calls.
+              (when-not (identical? committed reaction)
+                (aset witness-counters "rebuilt"
+                      (inc (aget witness-counters "rebuilt"))))
+              (set! (.-current committed-ref) #js [stable-key committed])
+              (let [k (keyword watch-ns (str (gensym "watch-")))]
+                (when committed
+                  (add-watch committed k (fn [_ _ _ _] (on-change))))
+                (fn unsubscribe []
+                  (when committed (remove-watch committed k))
+                  (let [stored (.-current committed-ref)]
+                    (when (and stored (identical? (aget stored 1) committed))
+                      (set! (.-current committed-ref) nil)))
+                  (subs/unsubscribe stable-frame-kw stable-query-v)))))
+          #js [stable-key reaction])]
+    (react/useSyncExternalStore subscribe-fn get-snap get-snap)))
+
+(defn- use-sub-witness-handoff [frame-kw query-v]
+  (let [key-ref       (react/useRef nil)
+        committed-ref (react/useRef nil)
+        stable-key      (stable-key-of key-ref frame-kw query-v)
+        stable-frame-kw (aget stable-key 0)
+        stable-query-v  (aget stable-key 1)
+        reaction
+        (uix-hooks/use-memo
+          (fn [] (subs/subscribe stable-query-v {:frame stable-frame-kw}))
+          #js [stable-key])
+        get-snap
+        (uix-hooks/use-callback
+          (fn []
+            (let [stored (.-current committed-ref)
+                  r      (if (and stored
+                                  (identical? (aget stored 0) stable-key))
+                           (aget stored 1)
+                           reaction)]
+              (when r @r)))
+          #js [stable-key reaction])
+        subscribe-fn
+        (uix-hooks/use-callback
+          (fn [on-change]
+            (let [committed (subs/subscribe stable-query-v
+                                            {:frame stable-frame-kw})]
+              (aset witness-counters "commits"
+                    (inc (aget witness-counters "commits")))
+              (when-not (identical? committed reaction)
+                (aset witness-counters "rebuilt"
+                      (inc (aget witness-counters "rebuilt"))))
+              (set! (.-current committed-ref) #js [stable-key committed])
+              (subs/unsubscribe stable-frame-kw stable-query-v)
+              (let [k (keyword watch-ns (str (gensym "watch-")))]
+                (when committed
+                  (add-watch committed k (fn [_ _ _ _] (on-change))))
+                (fn unsubscribe []
+                  (when committed (remove-watch committed k))
+                  (let [stored (.-current committed-ref)]
+                    (when (and stored (identical? (aget stored 1) committed))
+                      (set! (.-current committed-ref) nil)))
+                  (subs/unsubscribe stable-frame-kw stable-query-v)))))
+          #js [stable-key reaction])]
+    (react/useSyncExternalStore subscribe-fn get-snap get-snap)))
+
+;; -- witness cells: 3 reads each, per variant per layer, unrolled -----------
+
+(defn- wq [layer i] [(case layer 1 :cm/w1 2 :cm/w2 3 :cm/w3) i])
+
+(defui wx-cell-1 [{:keys [base]}]
+  (let [a (use-sub-witness-xcript v/subs-frame (wq 1 (+ base 0)))
+        b (use-sub-witness-xcript v/subs-frame (wq 1 (+ base 1)))
+        c (use-sub-witness-xcript v/subs-frame (wq 1 (+ base 2)))]
+    ($ :span.wcell {:data-i base} (str (+ a b c)))))
+
+(defui wx-cell-2 [{:keys [base]}]
+  (let [a (use-sub-witness-xcript v/subs-frame (wq 2 (+ base 0)))
+        b (use-sub-witness-xcript v/subs-frame (wq 2 (+ base 1)))
+        c (use-sub-witness-xcript v/subs-frame (wq 2 (+ base 2)))]
+    ($ :span.wcell {:data-i base} (str (+ a b c)))))
+
+(defui wx-cell-3 [{:keys [base]}]
+  (let [a (use-sub-witness-xcript v/subs-frame (wq 3 (+ base 0)))
+        b (use-sub-witness-xcript v/subs-frame (wq 3 (+ base 1)))
+        c (use-sub-witness-xcript v/subs-frame (wq 3 (+ base 2)))]
+    ($ :span.wcell {:data-i base} (str (+ a b c)))))
+
+(defui wh-cell-1 [{:keys [base]}]
+  (let [a (use-sub-witness-handoff v/subs-frame (wq 1 (+ base 0)))
+        b (use-sub-witness-handoff v/subs-frame (wq 1 (+ base 1)))
+        c (use-sub-witness-handoff v/subs-frame (wq 1 (+ base 2)))]
+    ($ :span.wcell {:data-i base} (str (+ a b c)))))
+
+(defui wh-cell-2 [{:keys [base]}]
+  (let [a (use-sub-witness-handoff v/subs-frame (wq 2 (+ base 0)))
+        b (use-sub-witness-handoff v/subs-frame (wq 2 (+ base 1)))
+        c (use-sub-witness-handoff v/subs-frame (wq 2 (+ base 2)))]
+    ($ :span.wcell {:data-i base} (str (+ a b c)))))
+
+(defui wh-cell-3 [{:keys [base]}]
+  (let [a (use-sub-witness-handoff v/subs-frame (wq 3 (+ base 0)))
+        b (use-sub-witness-handoff v/subs-frame (wq 3 (+ base 1)))
+        c (use-sub-witness-handoff v/subs-frame (wq 3 (+ base 2)))]
+    ($ :span.wcell {:data-i base} (str (+ a b c)))))
+
+(def ^:private uix-witness-cells
+  {:xcript  {1 wx-cell-1 2 wx-cell-2 3 wx-cell-3}
+   :handoff {1 wh-cell-1 2 wh-cell-2 3 wh-cell-3}})
+
+(defui w-grid [{:keys [cell n offset]}]
+  ($ :div.wab
+     (for [i (range n)]
+       ($ cell {:key i :base (+ offset (* i 3))}))))
+
+;; -- the Reagent witness ----------------------------------------------------
+
+(defn- w-rg-cell [layer base]
+  (let [total (loop [k 0 acc 0]
+                (if (< k 3)
+                  (recur (inc k)
+                         (+ acc @(rf/subscribe (wq layer (+ base k))
+                                               {:frame v/subs-frame})))
+                  acc))]
+    [:span.wcell {:data-i base} (str total)]))
+
+(defn- w-rg-grid [layer n offset]
+  (into [:div.wab]
+        (map (fn [i] ^{:key i} [w-rg-cell layer (+ offset (* i 3))]))
+        (range n)))
+
+(defn witness!
+  "Mount `n` witness boundaries of 3 reads each — `variant` in
+  `#{:xcript :handoff :reagent}` at `layer` — read the counters back,
+  unmount, and answer them beside the read count N they are adjudicated
+  against. Fresh counters per call; a fresh subtree of cells per call
+  (`offset`) so no call can be served by another's cache entries; never
+  inside a timed window. The caller adjudicates."
+  [variant layer n offset]
+  (reset-witness-counters!)
+  (let [container (js/document.createElement "div")
+        _         (.appendChild js/document.body container)
+        root      (case variant
+                    :reagent
+                    (let [rt (rdc/create-root container)]
+                      (react-dom/flushSync
+                        (fn [] (rdc/render rt [w-rg-grid layer n offset])))
+                      rt)
+                    ;; :xcript / :handoff
+                    (let [rt (uix-dom/create-root container)]
+                      (react-dom/flushSync
+                        (fn []
+                          (uix-dom/render-root
+                            ($ w-grid {:cell (get-in uix-witness-cells [variant layer])
+                                       :n n :offset offset})
+                            rt)))
+                      rt))
+        elements  (.-length (.querySelectorAll container ".wcell"))
+        out       {:variant  variant
+                   :layer    layer
+                   :offset   offset
+                   :reads    (* n 3)
+                   :elements elements
+                   :expected n
+                   :ok?      (= elements n)
+                   :commits  (aget witness-counters "commits")
+                   :rebuilt  (aget witness-counters "rebuilt")
+                   :body1    (aget witness-counters "body1")
+                   :body2    (aget witness-counters "body2")
+                   :body3    (aget witness-counters "body3")}]
+    (react-dom/flushSync
+      (fn [] (case variant
+               :reagent (rdc/unmount root)
+               (uix-dom/unmount-root root))))
+    (.remove container)
+    out))


### PR DESCRIPTION
Decision input for the rf2-2rtt6.14 ruling. rf2-2rtt6.12 counted the cold-mount double build exactly (bodyRuns = 2.00N vs Reagent 1.00N); this prices its CLOCK, as a fraction of the UIx-minus-Reagent mount excess measured in the SAME runs on the converged M1/M2 witnesses.

**Instrument** (`implementation/freehand/test/re_frame/bench/hicasso/coldmount_{views,app}.cljs` + `coldmount_run.cjs`, riding `:hicasso-bench` via `--config-merge`, no build id, no shadow-cljs.edn edit): two transcriptions of the shipped `use-subscribe` differing in exactly one property — constructions per cold read (`xcript` 2, `handoff` 1; identical cache-API call counts, identical markup, canonical-DOM parity gated). `xcript − handoff` is the build/dispose/rebuild churn; the same rounds' `uix-subs − reagent-subs` is the red-zone excess. Sub layers 1/2/3 (`:<-` chains) cover the input-chain re-deref. Counting witness adjudicated per page before any clock (commits/rebuilt/per-layer bodyRuns, exact — `failures []` on all five rows); clock fidelity control (pre-declared 3% band / range overlap); residue gate (the handoff arm's provisional +1 must balance — equality, never fired); positive controls 10/10; 0 unverified of 3,200 mounts; arm-order guard clean everywhere; segment-order verdict on every cross-seam figure; exit 4 when a published claim fails.

**Result** (`docs/design/hicasso/studio/coldmount-double-build-priced.md`): the double-build clock is **0.94–2.14× the M1 layer-1 mount excess** (every round of every estimator ≥ 0.93), **0.61–0.75× at layer 2**, **0.35–0.84× at layer 3**. M2 rows diagnostic and unresolvable at the clamp, as their bar-row grading predicts. The single-build `handoff` arm's M1 mount lands at/below the Reagent denominator (3.15–3.35 vs 3.15–3.75 ms). Spine measured: the SHIPPED one — rf2-2rtt6.13 not landed; `rebuilt = 1.00N` re-confirmed live.

**Rule applied** (verbatim from rf2-2rtt6.14, pre-registered): fraction < 20% or unresolvable → close as "take rf2-2rtt6.13 alone; Spec 006 no-grace-period stands"; ≥ 20% on representative layer-1 AND layer-2/3 mounts → reopen for a hook-scoped provisional hand-off design pass only. The measurement satisfies the second branch on every round of every estimator. **Implied verdict: rf2-2rtt6.14 reopens for the hook-scoped design pass** — the mayor reconciles the bead; nothing here opens or closes it. rf2-2rtt6.1 is untouched (no red-zone value moves; the layered ratios are context, not thresholds).

## Quality gates

All runs foreground to completion, worktree-local logs, machine checked quiet (sibling `test:cljs` runs waited out) before the five published rows.

| run | exit |
|---|---|
| `shadow-cljs release hicasso-bench --config-merge …coldmount-app…` (`:advanced`, 164 files, 0 warnings) | 0 |
| `COLDMOUNT_ONLY=M2L1 node …/coldmount_run.cjs` (pipeline smoke) | 0 |
| `COLDMOUNT_ONLY=M2L2 node …/coldmount_run.cjs` (layer-2 chain smoke) | 0 |
| `COLDMOUNT_ONLY=M1L1 node …/coldmount_run.cjs` (published row, fresh cold-cache build) | 0 |
| `COLDMOUNT_ONLY=M1L2 node …/coldmount_run.cjs` (published row) | 0 |
| `COLDMOUNT_ONLY=M1L3 node …/coldmount_run.cjs` (published row) | 0 |
| `COLDMOUNT_ONLY=M2L1 node …/coldmount_run.cjs` (published row) | 0 |
| `COLDMOUNT_ONLY=M2L2 node …/coldmount_run.cjs` (published row) | 0 |
| `python -m mkdocs build --strict` | 0 |

Bead: rf2-2rtt6.15 (epic rf2-2rtt6 / EP-0038). Bench/test + studio docs only; no production edits, no hot-zone files, `lane.cljs` untouched.