### PR TITLE
bench(hicasso): a corrected band inherits its original's publication mask (rf2-b69lw)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_app.cljs
@@ -129,7 +129,15 @@
   this export used to carry the verdict and not the corrected bands, so a
   `:corrected` run announced that both bands publish while the copyable
   table could print only the unadjusted one (rf2-b69lw, from the PR #7282
-  audit)."
+  audit).
+
+  The corrected bands arrive here already wearing the original row's
+  publication mask (`hd8-rows`'s `inherit-publication-mask`): an arm the
+  DOM read-back unpublished carries its `:unpublished` marker in the
+  corrected summary too, and [[pack-bands]] exports the marker exactly as
+  it does for the unadjusted band — one reader, one shape, no numeric
+  band for a figure the read-back refused (rf2-b69lw, from the PR #7295
+  audit). The driver's table holds the same line from its own side."
   [row-name v]
   (let [acc (or (.-HD8_CORRECTION js/window) #js {})
         o   #js {"verdict" (name (:verdict v))

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_rows.cljs
@@ -892,6 +892,39 @@
                                                       :predecessor (some-> (:prev a) name)
                                                       :position    p}))))))))))))))
 
+(defn- mask-failed-read-backs
+  "Apply the DOM-read-back publication mask to one write row's published
+  surfaces, and answer the row.
+
+  AN ARM WHOSE WRITES DID NOT REACH THE DOM HAS NO FIGURE. Its clock
+  readings are real milliseconds and they are measuring a page that never
+  changed — which is the cheapest possible way to be fast and the exact
+  fault the read-back exists to catch. So `:summary` carries
+  `:unpublished` in that arm's place rather than a number a reader could
+  quote, and every head-to-head pair touching it is dropped.
+
+  Named rather than inlined in [[measure-write!]] so the self-test's
+  fixture rows are masked by the instrument's own rule, never by a
+  hand-written approximation that could drift from it (rf2-b69lw, from
+  the PR #7295 audit)."
+  [{:keys [unverified writes] :as row}]
+  (let [bad (into #{} (comp (filter (fn [[_ n]] (pos? n))) (map key)) unverified)]
+    (-> row
+        (update :summary
+                (fn [m]
+                  (reduce (fn [acc arm]
+                            (assoc acc arm {:unpublished :failed-dom-read-back
+                                            :unverified  (get unverified arm)
+                                            :of          (get writes arm)}))
+                          m
+                          bad)))
+        (update :head-to-head
+                (fn [m]
+                  (into {}
+                        (remove (fn [[k _]]
+                                  (some #(re-find (re-pattern (name %)) (name k)) bad)))
+                        m))))))
+
 (defn measure-write!
   "`rounds` interleaved rounds of the write clock, `kind` ∈ `#{:narrow
   :bulk}`. Answers a promise of the published record."
@@ -910,46 +943,29 @@
                                :position   (:position r)})))))
         (.then (fn [acc]
                  (release-write-arms! mounts)
-                 (let [bad (into #{} (comp (filter (fn [[_ n]] (pos? n))) (map key))
-                                 (:unverified acc))
-                       publishable (fn [m]
-                                     (reduce (fn [acc' arm]
-                                               (assoc acc' arm
-                                                      {:unpublished :failed-dom-read-back
-                                                       :unverified  (get (:unverified acc) arm)
-                                                       :of          (get (:total acc) arm)}))
-                                             m
-                                             bad))]
-                 {:witness    (keyword (str "U-" (name kind)))
-                  :doc        (if (= kind :bulk)
-                                "all 300 cells written in ONE commit — bulk view work"
-                                (str narrow-batch-k " single-cell writes into a 300-cell "
-                                     "grid, each its own commit, all inside ONE timed "
-                                     "window — the narrow-write path. The per-write "
-                                     "figure is the sample divided by " narrow-batch-k))
-                  ;; Stated on the row, because a reader comparing this
-                  ;; against the pre-rf2-9zysg numbers is comparing two
-                  ;; different windows and has to be told so.
-                  :writes-per-sample (if (= kind :bulk) 1 narrow-batch-k)
-                  :arms       (vec arm-ids)
-                  :per-round  (:rounds-out acc)
-                  ;; AN ARM WHOSE WRITES DID NOT REACH THE DOM HAS NO FIGURE.
-                  ;; Its clock readings are real milliseconds and they are
-                  ;; measuring a page that never changed — which is the
-                  ;; cheapest possible way to be fast and the exact fault the
-                  ;; read-back exists to catch. So the summary carries
-                  ;; `:unpublished` in that arm's place rather than a number a
-                  ;; reader could quote, and every head-to-head pair touching
-                  ;; it is dropped.
-                  :summary    (publishable (lane/across-rounds (mapv :ratio (:rounds-out acc))))
-                  :head-to-head (into {}
-                                      (remove (fn [[k _]]
-                                                (some #(re-find (re-pattern (name %)) (name k))
-                                                      bad)))
-                                      (head-to-head (:rounds-out acc)))
-                  :unverified (:unverified acc)
-                  :writes     (:total acc)
-                  :samples    (:samples acc)})))
+                 ;; The publication mask — an arm whose writes did not reach
+                 ;; the DOM has NO figure — is [[mask-failed-read-backs]]'s,
+                 ;; applied over the raw summary and head-to-head, so the rule
+                 ;; the self-test's fixtures replay is the rule this row ships.
+                 (mask-failed-read-backs
+                  {:witness    (keyword (str "U-" (name kind)))
+                   :doc        (if (= kind :bulk)
+                                 "all 300 cells written in ONE commit — bulk view work"
+                                 (str narrow-batch-k " single-cell writes into a 300-cell "
+                                      "grid, each its own commit, all inside ONE timed "
+                                      "window — the narrow-write path. The per-write "
+                                      "figure is the sample divided by " narrow-batch-k))
+                   ;; Stated on the row, because a reader comparing this
+                   ;; against the pre-rf2-9zysg numbers is comparing two
+                   ;; different windows and has to be told so.
+                   :writes-per-sample (if (= kind :bulk) 1 narrow-batch-k)
+                   :arms       (vec arm-ids)
+                   :per-round  (:rounds-out acc)
+                   :summary    (lane/across-rounds (mapv :ratio (:rounds-out acc)))
+                   :head-to-head (head-to-head (:rounds-out acc))
+                   :unverified (:unverified acc)
+                   :writes     (:total acc)
+                   :samples    (:samples acc)})))
         (.catch (fn [e] (release-write-arms! mounts) (throw e))))))
 
 ;; ===========================================================================
@@ -1123,6 +1139,27 @@
     (< (:max v) 1.0)  :below
     :else             :above))
 
+(defn- inherit-publication-mask
+  "The corrected band for an arm the row's own summary marked
+  `:unpublished` is that marker, never a number (rf2-b69lw, from the
+  PR #7295 audit).
+
+  The correction rebuilds its bands from `:per-round`, which retains
+  every arm's raw timings — including an arm whose writes failed their
+  DOM read-back, whose milliseconds are real and are measuring a page
+  that never changed. Without this, the corrected-band path printed
+  `1.200 – 1.300 [CORRECTED]` directly beneath `UNPUBLISHED (1/78
+  unverified)` for the SAME arm, which defeats the rule that a failed
+  read-back has no publishable timing. The mask is INHERITED from the
+  original summary rather than recomputed, so the two bands cannot
+  disagree about which arms have a figure."
+  [corrected original]
+  (into {}
+        (map (fn [[id v]]
+               (let [o (get original id)]
+                 [id (if (:unpublished o) o v)])))
+        corrected))
+
 (defn yield-correction
   "Adjudicate one write row against the harness-microtask asymmetry, and
   answer a verdict rather than an observation (rf2-b69lw).
@@ -1192,6 +1229,18 @@
   Refusal is not this function's to soften and not the caller's to widen.
   `hd8-app` fails the run on one, exactly as it does on a positive control
   that missed its prediction.
+
+  ## The publication mask survives the correction
+
+  A `:corrected` verdict's bands are rebuilt from `:per-round`, which
+  retains raw timings for EVERY arm — including one whose writes failed
+  their DOM read-back and whose `:summary` entry is therefore the
+  `:unpublished` marker rather than a band. The corrected bands INHERIT
+  that mask ([[inherit-publication-mask]]): the marker stays in the
+  masked arm's place, and a head-to-head pair the mask dropped stays
+  dropped. A correction adjusts a figure the row was entitled to publish;
+  it must never mint one the read-back refused (rf2-b69lw, from the
+  PR #7295 audit).
 
   ## Which reading is subtracted
 
@@ -1268,8 +1317,17 @@
                                 "the harness's turns rather than the arm, so no ratio taken "
                                 "against it may be published — and a corrected value that "
                                 "survives only by a rounding error is not a denominator"))
-          (let [summary'  (lane/across-rounds (mapv :ratio corrected))
-                h2h'      (head-to-head corrected)
+          (let [;; BOTH corrected bands inherit the original row's publication
+                ;; mask ([[inherit-publication-mask]]): an arm UNPUBLISHED for
+                ;; a failed DOM read-back keeps its marker in the corrected
+                ;; summary, and a head-to-head pair the mask dropped stays
+                ;; dropped — the corrected map carries exactly the pairs the
+                ;; original published, never one it withheld.
+                summary'  (inherit-publication-mask
+                            (lane/across-rounds (mapv :ratio corrected))
+                            (:summary row))
+                h2h'      (select-keys (head-to-head corrected)
+                                       (keys (:head-to-head row)))
                 ;; [[side-of-1]] on both ends, and ANY change of state is a
                 ;; crossing. Comparing the `:straddles-1?` booleans is not
                 ;; the same test: a band that leaps the line WHOLE never
@@ -1342,7 +1400,13 @@
   that repair cannot silently come undone. Fixture 7 is not invented
   either: it is the PR #7282 audit's counterexample, the band that crossed
   1.0 WHOLE without flipping `:straddles-1?` at either end, published as
-  0.95x unadjusted and 1.0556x corrected — kept here for the same reason."
+  0.95x unadjusted and 1.0556x corrected — kept here for the same reason.
+  Neither is fixture 8: it is the PR #7295 audit's polarity, an arm
+  UNPUBLISHED for a failed DOM read-back (1 of 78) whose corrected band
+  was rebuilt numeric from the retained `:per-round` timings and printed
+  `1.200 – 1.300 [CORRECTED]` beneath the marker — masked by
+  [[mask-failed-read-backs]] itself, the instrument's own rule, so the
+  fixture cannot drift from what [[measure-write!]] actually applies."
   []
   (let [zero-yc    {:p50 0 :min 0 :max 0 :n 10
                     :batched {:k narrow-batch-k :window-p50 0 :window-max 0 :n 10}}
@@ -1423,7 +1487,40 @@
            {:name "a band that crosses 1.0 WHOLE (no straddle at either end) is REFUSED"
             :ok   (and (= :refused (:verdict v))
                        (= :correction-changes-the-verdict (:reason v)))
-            :detail (str (name (:verdict v)) "/" (some-> (:reason v) name))})]]
+            :detail (str (name (:verdict v)) "/" (some-> (:reason v) name))})
+
+         ;; 8. THE PUBLICATION MASK SURVIVES THE CORRECTION (PR #7295
+         ;;    audit). An arm whose writes failed their DOM read-back is
+         ;;    UNPUBLISHED in the original summary, but its raw timings are
+         ;;    retained in :per-round — and the corrected band, rebuilt from
+         ;;    exactly those timings, printed a number the read-back had
+         ;;    refused: `UNPUBLISHED (1/78 unverified) [UNADJUSTED]` then
+         ;;    `1.200 – 1.300 [CORRECTED]` for the SAME arm. The corrected
+         ;;    summary must carry the marker in that arm's place, the
+         ;;    dropped head-to-head pairs must stay dropped, and a
+         ;;    PUBLISHED arm's corrected band must still be numeric — the
+         ;;    row is masked by [[mask-failed-read-backs]], the rule
+         ;;    [[measure-write!]] itself applies.
+         (let [row  (-> (fixture-row :U-narrow narrow-batch-k
+                                     [:floor :reagent-slim :donor-r1 :donor-r2]
+                                     [{:floor 1.0 :reagent-slim 5.0 :donor-r1 2.0 :donor-r2 3.0}
+                                      {:floor 1.2 :reagent-slim 6.0 :donor-r1 2.4 :donor-r2 3.6}])
+                        (assoc :unverified {:floor 0 :reagent-slim 1 :donor-r1 0 :donor-r2 0}
+                               :writes     {:floor 78 :reagent-slim 78 :donor-r1 78 :donor-r2 78})
+                        mask-failed-read-backs)
+               v    (verdict-of row :slim live-yc)
+               slim (get-in v [:summary-corrected :reagent-slim])
+               d1   (get-in v [:summary-corrected :donor-r1])]
+           {:name "a corrected band inherits its original's publication mask (failed DOM read-back)"
+            :ok   (and (= :corrected (:verdict v))
+                       (= :failed-dom-read-back (:unpublished slim))
+                       (nil? (:min slim))
+                       (number? (:min d1))
+                       (contains? (:head-to-head-corrected v) :donor-r2-over-donor-r1)
+                       (not (contains? (:head-to-head-corrected v) :donor-r1-over-reagent-slim)))
+            :detail (str (name (:verdict v))
+                         " reagent-slim-corrected=" (pr-str slim)
+                         " h2h-corrected=" (pr-str (vec (keys (:head-to-head-corrected v)))))})]]
     {:ok?    (every? :ok checks)
      :checks (mapv (fn [c] (update c :ok boolean)) checks)}))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
@@ -376,9 +376,21 @@ function crossRun(runs) {
       // figure cannot leave the table without the name of its band.
       const cSummary = c && c.verdict === 'corrected' ? c.summaryCorrected || {} : {};
       const cH2h = c && c.verdict === 'corrected' ? c.headToHeadCorrected || {} : {};
+      // AN UNPUBLISHED ORIGINAL HAS NO CORRECTED BAND, and the table holds
+      // that line itself rather than trusting the export: the correction
+      // rebuilds its bands from per-round timings that are retained even for
+      // an arm whose writes failed their DOM read-back, and this table
+      // printed `1.200 – 1.300 [CORRECTED]` directly beneath `UNPUBLISHED
+      // (1/78 unverified)` for the SAME arm (rf2-b69lw, from the PR #7295
+      // audit). A failed read-back has NO publishable timing — corrected or
+      // not — so the original's publication mask decides both lines. A
+      // marker arriving in the corrected band itself is refused the same
+      // way: `band(marker)` would print UNPUBLISHED twice, and twice is not
+      // a figure either.
+      const correctedBand = (v, cv) => (v.unpublished || !cv || cv.unpublished ? null : cv);
       for (const [arm, v] of Object.entries(s.vsFloor)) {
         if (arm === 'floor') continue;
-        const cv = cSummary[arm];
+        const cv = correctedBand(v, cSummary[arm]);
         out.push(
           `;;     [${run.id.padEnd(7)}] ${arm.padEnd(14)} vs floor   ${band(v)}${cv ? '  [UNADJUSTED]' : ''}${mark}`
         );
@@ -387,7 +399,7 @@ function crossRun(runs) {
         }
       }
       for (const [pair, v] of Object.entries(s.headToHead)) {
-        const cv = cH2h[pair];
+        const cv = correctedBand(v, cH2h[pair]);
         out.push(
           `;;     [${run.id.padEnd(7)}] ${pair.padEnd(26)}  ${band(v)}${cv ? '  [UNADJUSTED]' : ''}${mark}`
         );
@@ -398,6 +410,62 @@ function crossRun(runs) {
     }
   }
   return out;
+}
+
+// The corrected-table fixture (rf2-b69lw, from the PR #7295 audit) — the
+// EXACT REACHABLE SHAPE, replayed through the live `crossRun` before
+// anything is measured, the same argument as `guard.selfTest()`: a refusal
+// nobody has watched fire is not a refusal, and this polarity fires only
+// when a run both fails a read-back AND resolves a yield correction, which
+// no live run can be relied on to do. The fixture's export deliberately
+// carries a numeric corrected band for the unpublished arm — the very
+// shape the pre-repair pipeline produced — so the check pins the TABLE's
+// own refusal, independent of the CLJS-side mask upstream of it.
+function tableSelfTest() {
+  const runs = [
+    {
+      id: 'slim',
+      summary: {
+        'write-narrow': {
+          vsFloor: {
+            floor: { min: 1.0, max: 1.0, straddles1: true },
+            'reagent-slim': { unpublished: 'failed-dom-read-back', unverified: 1, of: 78 },
+            'donor-r1': { min: 2.0, max: 2.0, straddles1: false },
+          },
+          headToHead: {},
+        },
+      },
+      correction: {
+        'write-narrow': {
+          verdict: 'corrected',
+          reason: null,
+          bound: 0.1,
+          why: 'fixture — the PR #7295 audit shape',
+          summaryCorrected: {
+            'reagent-slim': { min: 1.2, max: 1.3, straddles1: false },
+            'donor-r1': { min: 2.2, max: 2.3, straddles1: false },
+          },
+          headToHeadCorrected: {},
+        },
+      },
+    },
+  ];
+  const out = crossRun(runs).join('\n');
+  const checks = [
+    {
+      name: 'an UNPUBLISHED original grows neither a [CORRECTED] band nor an [UNADJUSTED] label',
+      ok: !/reagent-slim.*\[CORRECTED\]/.test(out) && !/reagent-slim.*\[UNADJUSTED\]/.test(out),
+    },
+    {
+      name: 'the UNPUBLISHED marker itself still prints, with its counts',
+      ok: /reagent-slim\s+vs floor\s+UNPUBLISHED \(1\/78 unverified\)/.test(out),
+    },
+    {
+      name: 'a published arm still prints BOTH labelled bands',
+      ok: /donor-r1.*2\.000 – 2\.000.*\[UNADJUSTED\]/.test(out) && /donor-r1.*2\.200 – 2\.300.*\[CORRECTED\]/.test(out),
+    },
+  ];
+  return { ok: checks.every((c) => c.ok), checks };
 }
 
 // ---------------------------------------------------------------------------
@@ -415,6 +483,22 @@ function crossRun(runs) {
   }
   if (!st.ok) {
     console.error('[hd8] the arm-order guard failed its own self-test; nothing was measured');
+    process.exit(1);
+  }
+
+  // The corrected-table fixture, enforced with the same standing: a table
+  // that would let a corrected band leave without its original's
+  // publication mask may print nothing at all.
+  const ts = tableSelfTest();
+  console.log(';; ==== HD8 CORRECTED-TABLE SELF-TEST ====');
+  for (const c of ts.checks) {
+    console.log(`;;   ${c.ok ? 'ok  ' : 'FAIL'}  ${c.name}`);
+  }
+  if (!ts.ok) {
+    console.error(
+      '[hd8] the cross-run table failed its own corrected-band fixture — a figure the DOM ' +
+        'read-back unpublished could leave the table as [CORRECTED]; nothing was measured'
+    );
     process.exit(1);
   }
 


### PR DESCRIPTION
## What

The #7295 audit-reopen remainder of rf2-b69lw: the newly copyable corrected-band path could publish a number the DOM-read-back contract explicitly marked UNPUBLISHED. At landed `a3d18c7991`, `measure-write!` replaces a failed-read-back arm only in `:summary` with the `{:unpublished :failed-dom-read-back ...}` marker while retaining numeric `:per-round`; `yield-correction` rebuilt numeric `:summary-corrected` from exactly those per-round timings; `correction!` exported every corrected entry; and `crossRun` printed the corrected band without checking the original's marker. The table printed `UNPUBLISHED (1/78 unverified)  [UNADJUSTED]` then `1.200 – 1.300  [CORRECTED]` for the SAME arm — a failed DOM read-back has no publishable timing, corrected or not.

## How

The original publication mask now survives the correction at every seam, and both ends of the pipeline hold the line independently:

- **`hd8_rows.cljs` / `mask-failed-read-backs`** — the read-back mask extracted from `measure-write!` into a named rule (marker into `:summary`, pairs dropped from `:head-to-head`), so the self-test fixture is masked by the instrument's own rule rather than a hand-written approximation that could drift from it.
- **`hd8_rows.cljs` / `inherit-publication-mask`** — a `:corrected` verdict's `:summary-corrected` carries the original's `:unpublished` marker in the masked arm's place, and `:head-to-head-corrected` keeps exactly the pairs the original published (`select-keys`). A correction adjusts a figure the row was entitled to publish; it never mints one the read-back refused.
- **`hd8_app.cljs` / `correction!`** — no code change needed: the bands arrive already masked and `pack-bands` exports the marker with the same reader as the unadjusted band. Docstring states the contract.
- **`hd8_run.cjs` / `crossRun`** — the table refuses a `[CORRECTED]` band (and the `[UNADJUSTED]` label) for an unpublished original from its own side, independent of the export.
- **Deterministic fixtures, both layers**: fixture 8 in `yield-correction-self-test` (in-bundle gate 0, fatal on disagreement) replays the audit's exact polarity — 1 unverified of 78 — masked by the live rule; and a corrected-table self-test in the driver replays the exact reachable export shape (numeric corrected band beside an unpublished original) through the live `crossRun`, enforced before the build with the same standing as the arm-order guard's self-test.

No measurement or lifecycle machinery changed; no published figure moved. The live slim run's verdicts remain `:below-resolution` on both write rows.

## Quality gates

All foreground, exit codes echoed.

**Red-then-green, driver fixture** (plant: `correctedBand` reverted to pre-fix pass-through in `crossRun`):

```
;; ==== HD8 CORRECTED-TABLE SELF-TEST ====
;;   FAIL  an UNPUBLISHED original grows neither a [CORRECTED] band nor an [UNADJUSTED] label
;;   ok    the UNPUBLISHED marker itself still prints, with its counts
;;   ok    a published arm still prints BOTH labelled bands
[hd8] the cross-run table failed its own corrected-band fixture — ... nothing was measured
EXIT=1   (before the build — nothing measured)
```

Plant restored via `git checkout --`; `git status --porcelain` empty.

**Red-then-green, in-bundle fixture 8** (plant: `yield-correction` formation reverted to pre-fix, no mask inheritance; `HD8_ONLY=uix node .../hd8_run.cjs`):

```
;;   ok  ... (fixtures 1-7)
{:name "a corrected band inherits its original's publication mask (failed DOM read-back)", :ok false,
 :detail "corrected reagent-slim-corrected={:mean 5.5051, :min 5.4545, :max 5.5556, ...}
          h2h-corrected=[:donor-r1-over-reagent-slim :donor-r2-over-reagent-slim :donor-r2-over-donor-r1]"}
;; HD8 FAILED — the yield-correction contract failed its own self-test — ... nothing may be measured
EXIT=1   (gate 0 threw before any clock)
```

Plant restored via `git checkout --`; `git status --porcelain` empty.

**Green** — light clean driver run at this branch (`HD8_ONLY=slim HD8_ROWS=write-narrow,write-bulk node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs`): **exit 0**. Arm-order guard self-test 12/12 ok; corrected-table self-test 3/3 ok; in-bundle yield-correction self-test **8/8 ok** — fixture 8's detail shows the inherited marker `{:unpublished :failed-dom-read-back, :unverified 1, :of 78}` and `h2h-corrected=[:donor-r2-over-donor-r1]` only; live slim verdicts `:below-resolution` on both write rows (aggregate max 0.0); `[hd8] ok — measured, and no arm reads differently for its position in the plan`. This run also carries the focused compile gate for the touched build: `shadow-cljs release hicasso-bench` (`:advanced`, `goog.DEBUG false`) compiled clean inside the driver.

**Full three-adapter sweep not re-run**: this is a publication-mask contract fix — no measured window, sampling plan, or published figure changed — and the light clean slim run above exercises the whole gate chain live. The coldmount worker's bench processes were checked before the browser runs (none live, so the run did not collide with it).

`npm run test:script-policy`: **exit 0**.
