### PR TITLE
bench(hicasso): the segment-order question asked properly — balanced rounds, independent runs (rf2-6i0i2)

### DIFF
--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -6,9 +6,10 @@ page re-measures the frontier arm — UIx reading re-frame2 subscriptions — on
 bar's rows and the red-zone thresholds a candidate is judged against can be
 read down one column.
 
-Bead **rf2-a4x1o**. The rows are appended to the operator-owned standard bead
-**rf2-2rtt6.1**; only the operator amends the bar, the budgets, the kill
-criteria or the red-zones. Nothing here amends any of them.
+Bead **rf2-a4x1o**, re-published under a balanced design by **rf2-6i0i2**. The
+rows are appended to the operator-owned standard bead **rf2-2rtt6.1**; only the
+operator amends the bar, the budgets, the kill criteria or the red-zones.
+Nothing here amends any of them.
 
 ## The extent of the mismatch, measured rather than feared
 
@@ -177,10 +178,14 @@ the blur such a block exists to prevent.
 | M1 mount · M2 mount · bulk broad | the **earlier** instrument — `p0_converge_app.cljs` blob `9b5c0d63db5528d8b9790111f9bc53cda052106f`, at `4c3f7189c4` | the original five-round sweep in [Provenance](#provenance) above. Re-**checked** against the current instrument by [the rf2-rjfz1 sweep](#all-four-rows-reproduce-against-the-revived-driver-rf2-rjfz1); not re-taken |
 | **bulk narrow** *(batched)* | `f4b09dc20712e45f44f9ec9339f8dd00ce51e8f7` — the blob table immediately above | run **twice** at this instrument, and both runs are published |
 
-A second, independent five-round run of the identical instrument is published
-beside the **narrow** row; where the two disagree, the page says so rather than
-picking one. The other three rows have one run each and a reproduction check,
-which is a weaker warrant and is labelled as one wherever it appears.
+**Everything in this section is the provenance of the five-round rows, which
+rf2-6i0i2 has since superseded.** It is kept because the five-round figures are
+still quoted on the page as the values that were replaced, and a struck number
+with no provenance is not a record of anything. The live rows come off **one
+instrument and ten runs** — [the balanced ensemble's
+provenance](#the-balanced-ensembles-provenance-rf2-6i0i2) — which retires the
+partitioned table above: no row is now published off a different instrument from
+any other, and no row rests on a single run.
 
 All bar numbers are browser numbers. No JVM or Node figure appears on this page.
 
@@ -332,11 +337,13 @@ They have now been. One full four-row sweep at main `32cb224d6e`:
 node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs   # exit 0
 ```
 
-**This is a reproduction check, not a re-publication. No figure on this page
-moves.** Ranges are min–max across the five rounds; overlap with the published
-range and an unchanged verdict is the test.
+**This is a reproduction check, not a re-publication.** Ranges are min–max
+across the five rounds; overlap with the published range and an unchanged verdict
+is the test. The *published* column is the five-round table, which rf2-6i0i2 has
+since superseded — this check is kept as the record that the three unmoved rows
+were reproducible before they were re-taken.
 
-| row | published | reproduction sweep | overlap | verdict |
+| row | published *(five-round, superseded)* | reproduction sweep | overlap | verdict |
 |---|---|---|---|---|
 | **M1 mount** | 1.2301 [1.1099 – 1.3538] disjoint | 1.2887 [1.1462 – 1.4242] disjoint | 1.1462 – 1.3538 | **reproduces**, UIx slower both times |
 | **M2 mount** *(diagnostic)* | 1.0539 [0.8572 – 1.4286] straddles | 1.0327 [0.8000 – 1.2727] straddles | 0.8572 – 1.2727 | **reproduces**, indistinguishable both times |
@@ -360,7 +367,7 @@ has never been.
 | **Position completeness** | **zero lost positions on every arm of every row**; each phase contrast adjudicated on a full 20-against-20 of 60 |
 | **Canonical-DOM parity** | clean in both segments and across the seam, every row — `{:problems [] :ok? true}` |
 | **Verification** | **0 unverified of 7,860** — 600 M1 mounts + 600 M2 mounts + 630 broad writes + 6,030 narrow writes |
-| **Positive controls** | **this sweep's** four rows × two segments = eight, **eight passes** under the overlap rule; see below for the strict reading. Not the page's live count — the [positive-control table](#the-positive-controls) carries ten entries, because the narrow row is published from two runs and the superseded one is struck |
+| **Positive controls** | **this sweep's** four rows × two segments = eight, **eight passes** under the overlap rule; see below for the strict reading. Not the page's live count — the [positive-control table](#the-positive-controls) carries the ensemble's **eighty** |
 
 **The M2 control that rf2-egdaq holds open reads differently on this sweep,
 and the ruling is still the operator's.** The published M2 control range
@@ -370,7 +377,11 @@ every-round-inside reading. **This sweep's M2 controls are `[1.500 – 2.000]`
 (Reagent segment) and `[1.600 – 2.000]` (UIx segment) — both wholly inside the
 band, so both pass under *either* reading.** That is reported, not used: a
 re-run producing a friendlier control is not an argument for a rule, and
-rf2-egdaq is not settled here. The broad row's controls on this sweep, `[1.600
+rf2-egdaq is not settled here. **Eighty controls have since been measured on the
+balanced ensemble and they say something this one sweep could not** — the strict
+reading fails 7 of 20 M2 controls, with a worst round 19.9% below the band floor;
+[the breakdown](#the-strict-reading-over-eighty-controls-rf2-egdaq) is under the
+positive controls. The broad row's controls on this sweep, `[1.600
 – 2.500]` and `[1.667 – 2.500]`, miss the strict reading by `0.0014` — the
 lattice point above a `2.4986` ceiling on a floor of two to three quanta, the
 same quantisation artefact the denominator page records.
@@ -382,11 +393,11 @@ against the same witnesses in a different app namespace and run in a different
 schedule. Its `reagent-subs ÷ floor` ranges **overlap that arm's published
 ranges on all three shared rows**:
 
-| row | rf2-2rtt6.2, published | here | overlap |
+| row | rf2-2rtt6.2, published | here, over the ten-run ensemble | overlap |
 |---|---|---|---|
-| M1 mount | 3.899× [3.447 – 4.300] | 4.352× [4.063 – 4.625] | yes, 4.063 – 4.300 |
-| M2 mount | 1.874× [1.750 – 2.050] | 2.102× [1.625 – 2.800] | yes |
-| bulk broad | 7.064× [6.200 – 7.700] | 7.443× [7.000 – 8.000] | yes, 7.000 – 7.700 |
+| M1 mount | 3.899× [3.447 – 4.300] | 4.358× [3.625 – 5.111] | yes, 3.625 – 4.300 |
+| M2 mount | 1.874× [1.750 – 2.050] | 2.241× [1.250 – 4.500] | yes, wholly containing |
+| bulk broad | 7.064× [6.200 – 7.700] | 7.630× [6.167 – 10.000] | yes, 6.200 – 7.700 |
 
 That is the check that says the convergence moved the *frontier* arm onto the
 denominator's pages without moving the denominator.
@@ -525,27 +536,30 @@ thing a narrow write is compared against — is three times as much work.
 
 ## Where the time goes, per leg
 
-p50 milliseconds, split at the microtask boundary. This is the same
-decomposition rf2-2rtt6.4 published on its narrow row, reproduced on the
-converged witness:
+p50 milliseconds, split at the microtask boundary, min–max over the ten-run
+ensemble. This is the same decomposition rf2-2rtt6.4 published on its narrow row,
+reproduced on the converged witness. **The narrow legs are per timed window,
+which is ten commits** — divide by ten for a per-commit figure, and the earlier
+one-commit table read `0.40` on exactly the legs that now read 4.2–6.35:
 
 | row / arm | write | microtask gap | forced drain |
 |---|---|---|---|
-| broad / `reagent-subs` | 0.0 | 0.0 | **2.10** |
-| broad / `uix-subs` | **0.40** | **0.80** | 0.0 |
-| narrow / `reagent-subs` | 0.0 | 0.0 | **0.40** |
-| narrow / `uix-subs` | **0.40** | 0.10 | 0.0 |
-| both / `floor` | 0.0 | 0.0 | 0.20 – 0.30 |
+| broad / `reagent-subs` | 0.0 | 0.0 | **1.8 – 2.6** |
+| broad / `uix-subs` | **0.3 – 0.5** | **0.7 – 1.1** | 0.0 |
+| narrow / `reagent-subs` *(10 commits)* | 0.0 – 0.1 | 0.0 | **4.2 – 6.15** |
+| narrow / `uix-subs` *(10 commits)* | **4.6 – 6.35** | 0.4 – 0.7 | 0.0 |
+| broad / `floor` | 0.0 | 0.0 | 0.2 – 0.3 |
+| narrow / `floor` *(10 commits)* | 0.0 | 0.0 | 1.7 – 2.6 |
 
 The two substrates put their cost in different legs and the split is total. On
 Reagent everything is the drain — `reagent.core/flush`, the reaction walk. On
 UIx nothing is the drain: the cost is in the **write leg and the microtask that
 follows it**, before React is involved at all — the `useSyncExternalStore`
 notification fanning out across 300 subscribed boundaries. On the narrow row the
-UIx write leg *alone* (0.40 ms) is the whole of Reagent's window (0.40 ms) for
-the same operation, which is the structural claim a native view layer has on
-that row, and it is a claim about the React-hook spine's invalidation rather
-than about UIx's rendering.
+UIx write leg *alone* (4.6 – 6.35 ms) is the whole of Reagent's window
+(4.2 – 6.15 ms) for the same operation, which is the structural claim a native
+view layer has on that row, and it is a claim about the React-hook spine's
+invalidation rather than about UIx's rendering.
 
 ## The positive controls
 
@@ -711,10 +725,18 @@ ensemble is ten runs and not sixteen.
 
 ## Method
 
-- **Both orders.** Arms rotate *and reflect* on the sample index; segment order
-  alternates with the round. Three arms a segment, never two, because at two the
-  rotation and the reflection cancel (rf2-ouwh8) — asserted at boot in both
-  directions, and the run refuses to measure if the assertion fails.
+- **Both orders, and an even number of rounds.** Arms rotate *and reflect* on
+  the sample index; segment order alternates with the round, over **six** rounds
+  so the alternation splits 3:3 and the raw mean is design-unbiased. Three arms a
+  segment, never two, because at two the rotation and the reflection cancel
+  (rf2-ouwh8) — asserted at boot in both directions, and the run refuses to
+  measure if the assertion fails.
+- **A counterbalanced start, across independently launched runs.** Which segment
+  leads round 0 is a per-run parameter (`?start=reagent` / `?start=uix`,
+  `HICASSO_START`). Inside one run, *Reagent led* and *the even rounds* are the
+  same set of rounds however many rounds there are, so an order effect and a
+  temporal drift are the same partition and no single run can separate them. Half
+  the runs start each way, and the inference is made **across** runs.
 - **Position before adjacency.** Every sample carries its position in the whole
   page and the guard partitions on first-third against last-third as well as on
   predecessor. Warm-up matters more than interleaving, and warm-up samples are
@@ -736,7 +758,7 @@ ensemble is ten runs and not sixteen.
   seam — the two substrate arms are compared with each other directly, not
   merely each with its own floor.
 
-## The segment-order warrant — and why `1.2301` does not have one
+## The segment-order warrant
 
 Bead **rf2-a4x1o**, reopened by the PR #7268 audit: *"the operative 1.2301
 threshold magnitude does not yet have its stated fail-closed warrant."*
@@ -755,100 +777,211 @@ separately:
 | **direction** — *UIx slower / faster / indistinguishable* | **FAIL-CLOSED.** Two strata pointing opposite ways across 1.0 sets `HICASSO_ORDER_REFUSED`; `p0_converge_run.cjs` exits **1** | the row has no direction to publish, and the figure is a measurement of the schedule |
 | **magnitude** — the single number a candidate is judged against | reportable **only** when the two strata **overlap**. `:magnitude-resolved?` starts false and the overlap has to earn it | a disjoint split publishes `:claim :direction-only`; silence is not a pass |
 
-### The partition, confirmed
+### The partition, and what one run's split can and cannot say
 
-The audit's M1 reading reproduces **exactly** from the published per-round
-vector. Rounds 0, 2, 4 are Reagent-first; rounds 1, 3 are UIx-first.
+The strata are keyed by **which segment actually led the round**, not by round
+parity, so they stay meaningful when the start flips. Under the balanced design
+each stratum holds three rounds. The pre-registered run of the ensemble reads:
 
-| row | Reagent-first (3 rounds) | UIx-first (2 rounds) | strata | raw mean | **order-balanced** |
-|---|---|---|---|---|---|
-| **M1 mount** | **1.2997** [1.2388 – 1.3538] | **1.1258** [1.1099 – 1.1417] | **DISJOINT** | 1.2301 | **1.2128** |
-| M2 mount | 1.1191 [0.8572 – 1.4286] | 0.9561 [0.8572 – 1.0550] | overlap | 1.0539 | 1.0376 |
-| bulk broad | 0.5763 [0.4701 – 0.7172] | 0.6951 [0.6046 – 0.7857] | overlap | 0.6239 | 0.6357 |
-| **bulk narrow** *(batched — the published row)* | **1.1871** [1.1700 – 1.2053] | **1.1042** [1.0570 – 1.1515] | **DISJOINT** | 1.1540 | 1.1457 |
-| ~~bulk narrow *(unbatched, superseded)*~~ | ~~1.1620 [1.1111 – 1.2500]~~ | ~~1.1459 [1.0417 – 1.2500]~~ | ~~overlap~~ | ~~1.1556~~ | ~~1.1539~~ |
-
-**One correction to the audit's reading, stated because it changes a row's
-status.** The audit reported M2, broad *and* narrow as overlapping. Two of the
-three reproduce; **the current batched narrow row's strata are disjoint too**
-([1.1700 – 1.2053] against [1.0570 – 1.1515]). Only the **superseded unbatched**
-narrow row overlaps. So the exposure was never bounded to M1: `1.1540` is in the
-same position as `1.2301`. This partition is pinned in
-`p0_converge_order_cljs_test.cljs`, which replays these exact vectors.
-
-### Disjointness is not the evidence — the SIGN is
-
-**A disjoint 3:2 split is weak evidence on its own.** Under the null — no order
-effect, the five rounds exchangeable — the 2-round stratum is one of
-`C(5,2) = 10` equally likely subsets and exactly two of them separate the
-strata. **A disjoint partition therefore arises 20% of the time per row with no
-order effect at all**, and *which* row splits is not stable: M1 and narrow split
-in the published run, **broad** splits in the rf2-rjfz1 sweep, and **no row
-splits in both**. Three disjoint rows out of eight row-runs is what chance looks
-like.
-
-**The sign is a different matter, and it is decisive.** Across **three
-independent five-round runs** — the published run, the rf2-rjfz1 reproduction
-sweep, and the corrected-instrument run below — the cross-segment figure reads
-**higher when the Reagent segment ran first in 11 of 12 row-runs**. One-sided
-binomial, **p = 0.0032**.
-
-| run | M1 | M2 | broad | narrow |
+| row | Reagent-first (3 rounds) | UIx-first (3 rounds) | strata | mean |
 |---|---|---|---|---|
-| published | R 1.2997 > U 1.1258 | R 1.1191 > U 0.9561 | R 0.5763 **<** U 0.6951 | R 1.1871 > U 1.1042 |
-| rf2-rjfz1 sweep | R 1.3253 > U 1.2338 | R 1.0909 > U 0.9455 | R 0.6426 > U 0.5410 | R 1.1790 > U 1.1549 |
-| corrected instrument | R 1.2183 > U 1.0217 | R 0.9345 > U 0.9025 | R 0.6139 > U 0.5466 | R 1.2236 > U 1.1692 |
+| M1 mount | 1.2782 [1.1378 – 1.4286] | 1.1536 [0.9529 – 1.2892] | overlap | 1.2159 |
+| M2 mount | 1.0027 [0.8571 – 1.0794] | 1.0912 [0.8889 – 1.3846] | overlap | 1.0469 |
+| bulk broad | 0.6940 [0.6144 – 0.8485] | 0.6384 [0.5532 – 0.7292] | overlap | 0.6662 |
+| bulk narrow | 1.1381 [1.0568 – 1.2575] | 1.1703 [1.0346 – 1.3602] | overlap | 1.1542 |
 
-**There is a systematic segment-order effect.** It is small — one to nineteen
-percent between strata — and it is real. The per-row disjointness test could not
-see it because it has no power at 3:2; the sign test across rows and runs can.
+Across the whole ensemble the strata **overlap in 37 of 40 row-runs**: M1, M2 and
+narrow each go disjoint once, broad never. The three disjoint splits fall in two
+runs, and no row is disjoint twice.
 
-**Two consequences, and the first is arithmetic.** Five rounds cannot balance
-two orders: the split is 3:2, so the raw mean **over-weights whichever order got
-the extra round**, and with a real effect present that bias has a sign. Every
-published threshold on this page is a 3:2 **Reagent-first-heavy** mean of a
-quantity that reads high Reagent-first, so **every one of them is biased upward
-by roughly one to two percent.** The design-unbiased estimator under an
-alternating schedule is the mean of the two stratum means, and it is now
-published on every row as `:order-balanced-mean`. An **even** round count would
-make the two coincide by construction; it is named as the arm-level repair
-rather than taken here, because it would move four published rows without
-deciding the question.
+**A disjoint split is a statement about resolution, not a finding.** Under the
+null — no order effect, the six rounds exchangeable — the three-round stratum is
+one of `C(6,3) = 20` equally likely subsets and exactly two of them separate the
+strata, so **a disjoint partition arises 10% of the time per row with no order
+effect at all**. Three in forty is 7.5%. That is what chance looks like, and it
+is the reason a disjoint split withdraws the magnitude rather than condemning
+the measurement. (At five rounds the same arithmetic gave 2 of `C(5,2) = 10` —
+**20%**, twice as often — which is half of why the round count is now even.)
 
-### The verdict on `1.2301` — the hold stands
+The five-round partition that broke `1.2301` is preserved in
+`p0_converge_order_cljs_test.cljs`, which replays those exact vectors with the
+start stated rather than defaulted.
 
-**rf2-2rtt6.1's hold — *do not use 1.2301 as a precise red-zone threshold* — is
-NOT lifted.** Three measured reasons, in order of weight:
+### The segment-order question, asked properly
 
-1. **It is biased by a design the effect exploits.** 3:2 Reagent-first on a
-   quantity that reads high Reagent-first. The order-balanced estimate on the
-   published rounds is **1.2128**, not 1.2301.
-2. **Its two strata do not meet.** [1.2388 – 1.3538] against [1.1099 – 1.1417].
-   A mean over a split whose halves are disjoint is not a threshold, and
-   `:magnitude-resolved?` is false for that row.
-3. **Four independent estimates do not agree to better than ±6%, and the newest
-   does not resolve at all:** 1.2301, 1.2103 (same-instrument stability run),
-   1.2887 (rf2-rjfz1 sweep), and **1.1397 [0.9130 – 1.3201] — straddling 1.0 —**
-   on the corrected instrument below. A figure quoted to four decimal places on
-   that spread was never a threshold.
+**The claim under test.** Three five-round runs of this page were read as saying
+that the cross-segment figure comes out **higher when the Reagent segment ran
+first**, in 11 of 12 row-runs, one-sided binomial **p = 0.0032**, and the page
+called that *systematic* and *real*. **That warrant was wrong, and it was wrong
+in two separable ways.**
 
-**What IS warranted, and it is not nothing.** UIx-on-subs is slower than
-Reagent-on-subs on the M1 mount witness in **three of four runs**, and every
-Reagent-first stratum of every run is disjoint above 1.0. The defensible
-statement is a **direction with a range — *UIx slower on M1 mount, roughly
-1.11× to 1.35× across the runs that resolve, with one run of four
-indistinguishable*** — not a point. **A candidate row is red on M1 if it is
-worse than that range; inside it, the answer is `not resolved` and not a pass.**
+**First, the twelve were not twelve.** Four rows measured inside one browser
+process share a machine, a heap and a collector; they are four correlated
+readings of one run, not four Bernoulli trials. The honest unit is the **run**,
+which made the sample n = 3, and no arrangement of three observations reaches
+p = 0.0032.
 
-**`0.6239×` broad is in better shape, and its magnitude carries the same 1–2%
-caveat.** Its **direction survives everywhere**: all six order strata across the
-three runs sit wholly below 1.0, and all four run means (0.6239 / 0.5682 /
-0.6020 / 0.5870) are disjoint from 1.0. Its strata overlap in the published run
-and in the corrected run, and are disjoint in the sweep — so it passes the test
-that broke M1's magnitude twice out of three, and its order-balanced published
-value is **0.6357**. The narrow row is the same shape as M1: direction resolved
-in every run, magnitude disjoint on the published rounds, balanced value
-**1.1457**.
+**Second, the design could not tell an order effect from a clock.** Every one of
+those runs started with Reagent, so *Reagent led* and *rounds 0, 2, 4* named the
+same set of rounds in every run. A page that simply gets slower as it runs — and
+[this one does](#3-the-sixth-round-broke-the-m2-row-and-the-lever-was-the-mount-budget)
+— produces exactly the same partition. Adding same-start runs cannot separate
+them, because each new run reproduces the same confound.
+
+**The repair is the design, not the arithmetic.** Ten runs, launched
+independently, six rounds each, **five starting with Reagent and five with UIx**.
+The statistic is one number per run per row,
+
+> `d = ln( mean of the Reagent-first stratum ÷ mean of the UIx-first stratum )`,
+
+positive when the figure reads higher Reagent-first, which is the direction the
+original claim asserted. Counterbalancing then splits `d` into two components
+that a fixed start had welded together. In a Reagent-start run the Reagent-first
+rounds are the even ones; in a UIx-start run they are the odd ones. So
+
+- **the average of the two start groups isolates the ORDER effect** — the
+  temporal term enters with opposite signs and cancels;
+- **half their difference isolates the TEMPORAL term** — the order effect enters
+  with the same sign and cancels.
+
+Two views follow, and the page publishes both because they answer different
+questions and are powered differently.
+
+#### View 1 — between runs, one observation per run
+
+The assumption-free test: take the run's published threshold mean, compare the
+five Reagent-start runs against the five UIx-start runs, and use an **exact
+permutation test** over all `C(10,5) = 252` relabellings. Nothing about the
+inside of a run is assumed.
+
+| row | Reagent-start mean | UIx-start mean | difference | exact two-sided *p* | smallest difference this test could have seen |
+|---|---|---|---|---|---|
+| M1 mount | 1.2276 | 1.2344 | −0.0068 | 0.770 | 0.043 |
+| M2 mount | 1.0461 | 1.0740 | −0.0280 | 0.611 | 0.122 |
+| bulk broad | 0.6295 | 0.6288 | +0.0007 | 0.984 | 0.063 |
+| bulk narrow | 1.1754 | 1.1755 | −0.0001 | 0.992 | 0.037 |
+
+**Which segment starts a run does not detectably move the number that run
+publishes.** On the narrow row the two groups agree to one part in ten thousand.
+That is the practically important result: **the four rows above may be quoted
+without asking which segment led**, which was not true of the five-round design.
+
+#### View 2 — within run, the paired strata
+
+The higher-powered test, and the direct successor to the discredited 11-of-12.
+Because a six-round run now carries **both** strata by construction, `d` is a
+*paired* contrast: it differences two numbers measured minutes apart in the same
+process, so run-to-run variance cancels instead of being absorbed. Ten runs, one
+`d` per run per row, an exact **sign-flip randomisation test** over all
+`2¹⁰ = 1024` sign assignments, one-sided in the direction the original claim
+named.
+
+| row | order effect (mean `d`) | as a ratio | 95% interval | sign-flip *p* | positive |
+|---|---|---|---|---|---|
+| M1 mount | +0.0357 | 1.036× | 0.979× – 1.097× | 0.084 | 7 of 10 |
+| M2 mount | −0.0837 | 0.920× | 0.795× – 1.065× | 0.889 | 4 of 10 |
+| bulk broad | −0.0388 | 0.962× | 0.887× – 1.044× | 0.856 | 5 of 10 |
+| bulk narrow | +0.0070 | 1.007× | 0.977× – 1.038× | 0.302 | 7 of 10 |
+| **run-level composite** *(the pre-registered statistic: mean over the four rows)* | **−0.0200** | **0.980×** | **0.934× – 1.029×** | **0.823** | **6 of 10** |
+
+**The pre-registered hypothesis fails, and it fails on the wrong side of zero.**
+The composite was fixed in advance as one-sided positive; the ensemble puts it at
+**−0.0200**, a 2% effect in the *opposite* direction, with 6 of 10 runs positive.
+Two rows lean the claimed way and two lean against it. Nothing here is
+significant at any conventional level, and the largest of them, M1's +3.6% at
+p = 0.084, is one row of four and would not survive being asked for four times.
+
+And the temporal component the confound hid is no better resolved:
+
+| row | order component | temporal component | exact *p* on the start-group difference |
+|---|---|---|---|
+| M1 mount | +0.0357 | −0.0212 | 0.421 |
+| M2 mount | −0.0837 | +0.0632 | 0.318 |
+| bulk broad | −0.0388 | −0.0011 | 1.000 |
+| bulk narrow | +0.0070 | −0.0063 | 0.698 |
+| composite | −0.0200 | +0.0086 | 0.810 |
+
+**And the discredited statistic itself does not survive.** Counted the way the
+page counted it — 40 row-runs treated as if independent, which they are not —
+the Reagent-first stratum is higher in **23 of 40**, p = 0.21. The 11-of-12 was
+not a small effect measured well; on the balanced design it is not there at the
+strength it was quoted.
+
+#### Why the two views can disagree, and what n = 5 vs 5 cannot settle
+
+They did not disagree here — both say *not resolved* — but they can, and a reader
+should know which to believe about what.
+
+View 1 is between runs and therefore **cannot see a pure order effect at all**
+once the design is balanced: a six-round run averages both orders equally, so an
+order effect is inside the run mean, not between the start groups. What View 1
+tests is whether the *start* biases the published number, and its answer is no.
+View 2 is paired, so it can see an order effect at a fraction of the size, but
+its unit is a within-run difference and its four rows are correlated — which is
+precisely the error the original 11-of-12 made. The rows are therefore reported
+separately and pooled only through the pre-registered composite, never as four
+trials.
+
+**What n = 5 versus n = 5 cannot do is prove an absence, and this page does not
+claim one.** The start-group contrast can only resolve a difference of about
+0.04 on the narrow and M1 rows and about 0.12 on M2 — the last column of View 1's
+table is that limit, computed rather than asserted. On the composite, the
+interval admits an order effect anywhere from **6.6% against the claim to 2.9%
+for it**. So:
+
+- **An order effect of the size the page previously asserted — one to nineteen
+  percent between strata, systematic — is excluded on every row.**
+- **An order effect of one or two percent is not excluded, and would not be
+  detectable at ten runs.** It would also not matter: it is smaller than the
+  spread between two consecutive runs of the same design.
+
+The right conclusion is the modest one. **The segment-order effect is not
+established, and the design no longer needs it to be.** With an even round count
+the raw mean is design-unbiased whatever the truth is, and with a counterbalanced
+start the published figures are demonstrably insensitive to the schedule. The
+per-row fail-closed rule stays exactly as it is — it costs nothing when the
+strata overlap, and it is the thing that would catch an order effect if one
+appeared on a future witness.
+
+### The verdict on M1's magnitude
+
+**The three measured reasons `1.2301` was withdrawn have all been answered**,
+and each was answered by the design rather than by a friendlier run:
+
+1. ~~*It is biased by a design the effect exploits* — 3:2 Reagent-first on a
+   quantity that reads high Reagent-first.~~ **Gone by construction.** At six
+   rounds the split is 3:3 and the raw mean *is* the order-balanced mean; the two
+   differ on 7 of 40 row-runs of the ensemble and only ever in the fourth
+   decimal, where they are rounded independently.
+2. ~~*Its two strata do not meet* — [1.2388 – 1.3538] against
+   [1.1099 – 1.1417].~~ **The strata overlap in 9 of the 10 runs**, and the
+   instrument marks the row `:claim :magnitude` in those nine.
+3. ~~*Four independent estimates do not agree to better than ±6%, and the newest
+   does not resolve at all.*~~ **Ten independent estimates now span
+   1.1989 – 1.2931**, a spread of ±3.8% about their mean, none of them
+   straddling 1.0, and 59 of the 60 rounds behind them read above 1.0.
+
+**What is published is a magnitude with an interval: 1.2310×, 95% interval
+1.2105 – 1.2514 on the mean, single runs landing anywhere in 1.199 – 1.293.**
+That is the form the measurement supports. A bare four-decimal point never was —
+not because the point was wrong (`1.2301` sits inside the new interval, which is
+its own small vindication) but because a point carries no statement of how far a
+fresh run may legitimately land from it.
+
+**rf2-2rtt6.1's hold is not lifted here, and cannot be.** That bead is the
+operator's, `1.2301` is its number, and this page supersedes that number rather
+than rehabilitating it. What a worker may say is what the measurement now
+supports, and that is [written out below](#what-would-have-been-appended-to-rf2-2rtt61-had-it-not-been-size-locked)
+in the form the standard would take.
+
+**The other three rows.** `0.6291×` **broad** is the strongest row on the page:
+all 60 rounds below 1.0, all 20 order strata wholly below it, strata overlapping
+in every run. `1.1754×` **narrow** is now its mirror: all 60 rounds above 1.0,
+all 20 strata wholly above. **M2** resolves nothing and is not meant to — every
+one of its ten runs straddles 1.0, and its interval `[1.0017 – 1.1185]` sits
+barely clear of parity only because it is an interval on a *mean*; three of the
+ten runs read below 1.0 outright. On legs of 4.5 to 11 quanta that is not a
+direction, and the row stays **diagnostic**.
 
 ### The corrected instrument's own run
 
@@ -856,9 +989,9 @@ Four rows, five rounds, both segments, at this branch's instrument.
 `node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` —
 **exit 0**.
 
-| row | published | corrected instrument | overlap | verdict |
+| row | the five-round publication *(superseded)* | corrected instrument | overlap | verdict |
 |---|---|---|---|---|
-| **M1 mount** | 1.2301 [1.1099 – 1.3538] disjoint | **1.1397 [0.9130 – 1.3201] — straddles 1.0** | 1.1099 – 1.3201 | **does NOT reproduce as resolved** — see above |
+| **M1 mount** | 1.2301 [1.1099 – 1.3538] disjoint | **1.1397 [0.9130 – 1.3201] — straddles 1.0** | 1.1099 – 1.3201 | **does NOT reproduce as resolved** — see below |
 | M2 mount *(diagnostic)* | 1.0539 [0.8572 – 1.4286] straddles | 0.9217 [0.8572 – 1.0000] straddles | 0.8572 – 1.0000 | **reproduces**, indistinguishable both |
 | **bulk broad** | 0.6239 [0.4701 – 0.7857] disjoint | 0.5870 [0.4762 – 0.8372] disjoint | wholly overlapping | **reproduces**, UIx faster both |
 | **bulk narrow** | 1.1540 [1.0570 – 1.2053] disjoint | 1.2018 [1.1344 – 1.3395] disjoint | 1.1344 – 1.2053 | **reproduces**, UIx slower both |
@@ -872,20 +1005,46 @@ control arm in **both** segments identically, and the red-zone divides
 `uix-subs` by `reagent-subs` — neither of which is the control — so it cannot
 bias the ratio directionally. The arm-order guard agrees: `refuse? false`,
 `contaminated? false`, `unchecked? false` on all four rows, with no arm reading
-differently for its position. The reading that fits is the one the four
-estimates already showed: **M1's red-zone is a noisy quantity that was published
-as a precise one.**
+differently for its position.
 
-**No published figure on this page is deleted or rewritten.** The rows above
-stand as measured; what changes is what may be **quoted** from them, and that is
-now decided by the instrument (`:claim :magnitude` vs `:claim :direction-only`)
-rather than by whoever writes the page.
+**The ten-run ensemble now bounds how much of this was noise, and it does not
+account for all of it.** Ten runs of the balanced design span 1.1989 – 1.2931 on
+M1; this run's `1.1397` sits *below* that spread. The ten were launched within
+about eight minutes of one another on one machine, so their interval measures
+**within-session** run-to-run variation; the corrected run is a different session
+on a different instrument, and it reads lower than any of them. **A candidate
+should therefore be judged against the run-mean spread rather than the interval
+on the mean, and a figure taken in a different session may legitimately land
+outside even that.** The interval this page publishes is not a claim about
+next week's machine.
 
 ### The corrected run's provenance
 
+**The landed SHA is `9737ed5cf815817d856c49eefb6824856df51668`.** This block said
+*"the landed SHA follows the merge"* for as long as the merge had not happened,
+and then went on saying it afterwards, which is how a placeholder becomes a
+falsehood. The merge has happened; the SHA is on `origin/main`; and because a
+rebase can move a SHA but cannot move a blob, the instrument is pinned by content
+below as well.
+
+| file | blob at `9737ed5cf8` |
+|---|---|
+| `implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs` | `7d62bb6f4c4ce90a930bef94060ecc89772f42f1` |
+| `implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` | `f9c8c36ca58ccf2986f9946aee62a4666297924e` |
+| `implementation/freehand/test/re_frame/bench/hicasso/lane.cljs` | `73b382cbfc17acf767e744313e60ec33c35fe6e5` |
+| `implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_views.cljs` | `4032e39779ce55fee1e1cd4f7a8e9561237e2cfd` |
+| `implementation/freehand/test/re_frame/bench/hicasso/p0_uix_views.cljs` | `34e0e89d532f2af3b3289525509cf033bb03bc05` |
+| `implementation/core/test/re_frame/bench/order_guard.cljc` | `6c4097afff5afa6d64903c3be2f2f4fd6f145050` |
+
+```bash
+git merge-base --is-ancestor 9737ed5cf815817d856c49eefb6824856df51668 origin/main && echo on-main
+P=implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+git rev-parse 9737ed5cf8:$P   # 7d62bb6f4c4ce90a930bef94060ecc89772f42f1
+```
+
 | | |
 |---|---|
-| **Branch** | `worker/control-verify` (rf2-2rtt6.2 / rf2-a4x1o) — the landed SHA follows the merge |
+| **Producing commit** | `9737ed5cf815817d856c49eefb6824856df51668` — *bench(hicasso): warrant the segment-order threshold, verify the doubled control (rf2-a4x1o)*, on `origin/main`. Measured on `worker/control-verify` before the merge; the rebase rewrote the id and left every blob above untouched |
 | **Reproduction** | `node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` — **exit 0** |
 | **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium via Playwright), Windows 11 x64, 24 logical CPUs |
 | **Arm-order guard** | **no refusal on any of the four rows** — `refuse? false`, `contaminated? false`, `unchecked? false`, tolerance 0.10 |
@@ -894,6 +1053,51 @@ rather than by whoever writes the page.
 | **Segment-order control** | **no refusal on any row**; `magnitude-resolved? true` on all four of this run's rows, and the published M1 and narrow rounds are the ones it marks unresolved |
 | **Positive controls** | eight, eight passes — and, for the first time, **adjudicated against the doubled page they claim**: 1,801 elements with a probe at index 599, 99 with a probe at field 23 |
 
+### The balanced ensemble's provenance (rf2-6i0i2)
+
+**Ten runs, launched one at a time, none of them re-run and none of them
+discarded.** Five started with the Reagent segment and five with UIx, in
+alternation; every one exited 0 and every one is in the numbers above. A run that
+had been dropped for reading badly would make the ensemble worthless, so the
+count is stated as the whole record: **ten launched, ten published.**
+
+| | |
+|---|---|
+| **Authored anchor** | `2a97274c0fd50dd3145ba60a33f73f663bec94b9` on `worker/balance-6i0i2` — the last commit that touches the instrument. **A rebase-merge will mint a new landed SHA for it**, and this line is deliberately not rewritten to that SHA later: the blobs below are what identify the instrument, and a rebase cannot move a blob. An audit mapping this page to `main` should expect the anchor to resolve to a commit that is *not* an ancestor of `main`, and should check the blobs |
+| **Reproduction** | `HICASSO_START=reagent node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` — and the same with `HICASSO_START=uix`. **Ten invocations, exit 0 on all ten** |
+| **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium via Playwright), `:advanced`, `goog.DEBUG false`, Windows 11 x64, 24 logical CPUs, sibling agents live on the box |
+| **Schedule** | **6 rounds** × 2 segments × 3 arms interleaved, **one row per page**, start counterbalanced 5/5 across the ten launches. Sampling 8 warm-up + 12 samples on M1, broad and narrow; **4 + 10 on M2** ([why](#3-the-sixth-round-broke-the-m2-row-and-the-lever-was-the-mount-budget)) |
+| **Arm-order guard** | **no refusal on any of the 40 row-runs** — `refuse? false`, `contaminated? false`, `unchecked? false`, tolerance 0.10, every one |
+| **Canonical-DOM parity** | `{:problems [] :ok? true}` on all 40 — in both segments and across the seam |
+| **Verification** | **0 unverified of 92,160** — per run 720 M1 mounts + 504 M2 mounts + 756 broad writes + 7,236 narrow writes = 9,216, times ten |
+| **Segment-order control** | **no refusal on any row of any run**; `magnitude-resolved? true` on **37 of 40**, and `:balanced-design? true` on all 40 |
+| **Positive controls** | **80, and 80 passes** under `lane/control-verdict`'s overlap rule; 64 of 80 under the strict every-round-inside reading — [the breakdown](#the-strict-reading-over-eighty-controls-rf2-egdaq) |
+
+The instrument, by content hash. These are the blobs every one of the ten runs
+was measured at:
+
+| file | blob |
+|---|---|
+| `implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs` | `5a727706fcd3268027b1d1b640658ca0be7ab86f` |
+| `implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` | `9542c1167435e06727a28bb8af89c055bb4e4682` |
+| `implementation/freehand/test/re_frame/bench/hicasso/lane.cljs` | `0642815dc234c1544d1f97bd9e1e4dd24365c027` |
+| `implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_views.cljs` | `bf79bf304d62f679be5fca69dd7880360a1a0631` |
+| `implementation/freehand/test/re_frame/bench/hicasso/p0_uix_views.cljs` | `34e0e89d532f2af3b3289525509cf033bb03bc05` |
+| `implementation/core/test/re_frame/bench/order_guard.cljc` | `6c4097afff5afa6d64903c3be2f2f4fd6f145050` |
+
+```bash
+P=implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+git rev-parse <candidate>:$P   # must print 5a727706fcd3268027b1d1b640658ca0be7ab86f
+```
+
+**What this ensemble does not establish.** All ten ran on one machine inside one
+eight-minute window, so it bounds run-to-run variation *within a session* and
+says nothing about a different machine, a different Chromium or a different day —
+and the corrected run's `1.1397` on M1, from another session, is the standing
+demonstration that between-session spread is wider. Ten runs also cannot prove an
+absence: see [what n = 5 versus n = 5 cannot
+settle](#why-the-two-views-can-disagree-and-what-n--5-vs-5-cannot-settle).
+
 ### What would have been appended to rf2-2rtt6.1, had it not been size-locked
 
 **rf2-2rtt6.1 is size-locked (rf2-0znkn, the operator's) and cannot accept an
@@ -901,25 +1105,33 @@ append**, so this is what a worker would have added to the governance record's
 P0 table, verbatim. **Only the operator may amend the standard**; this is a
 statement of what the measurement supports, not an amendment.
 
-> **CLOCK RED-ZONES — amendment under RULING 1.** RULING 1 makes the red-zone
-> threshold *the measured UIx ratio for that witness family*. On two of the four
-> converged rows that ratio is **not resolved to a magnitude**, so the rule needs
-> its consequence stated rather than a number substituted:
+> **CLOCK RED-ZONES — amendment under RULING 1, restated on the balanced
+> design.** RULING 1 makes the red-zone threshold *the measured UIx ratio for
+> that witness family*. Ten independently launched six-round runs with the
+> starting segment counterbalanced 5/5 now stand behind each row, so each is a
+> **magnitude with an interval** rather than a point or a bare direction:
 >
-> - **M1 mount — the magnitude `1.2301×` is withdrawn.** Its two segment-order
->   strata are disjoint, the 3:2 design biases it upward on a quantity now shown
->   to carry a systematic order effect (11 of 12 row-runs, p = 0.0032), and four
->   independent estimates read 1.2301 / 1.2103 / 1.2887 / 1.1397 with the last
->   straddling 1.0. The red-zone this row supports is **a direction and a range:
->   UIx slower, ≈1.11 – 1.35×**. A candidate worse than 1.35× is RED; inside the
->   range the answer is **not resolved**, which under the standard is still not a
->   pass.
-> - **bulk narrow — the magnitude `1.1540×` is withdrawn** on the same test;
->   direction (UIx slower) resolves in every run. Order-balanced value 1.1457.
-> - **bulk broad — `0.6239×` stands as a threshold**, with the order-balanced
->   value **0.6357** recorded beside it. Direction survives in all six strata of
->   all three runs.
-> - **M2 mount — unchanged and still diagnostic.** Balanced value 1.0376.
+> - **M1 mount — `1.2310×`, 95% interval `1.2105 – 1.2514` on the mean, single
+>   runs landing in `1.199 – 1.293`.** This **supersedes `1.2301×`**, which was
+>   withdrawn as a magnitude and is not reinstated: the number the standard holds
+>   was measured on a 3:2 design whose bias has since been removed by
+>   construction, and it is replaced rather than restored. A candidate worse than
+>   the run-mean spread is RED; inside it, the honest answer is where in the
+>   spread it sits.
+> - **bulk narrow — `1.1754×`, interval `1.1579 – 1.1930`, runs `1.139 – 1.219`.**
+>   **Supersedes `1.1540×`**, also withdrawn. Its direction is now as strong as
+>   any row on the page: all 60 rounds above 1.0, all 20 order strata wholly
+>   above.
+> - **bulk broad — `0.6291×`, interval `0.5996 – 0.6587`, runs `0.579 – 0.699`.**
+>   Supersedes `0.6239×`, which stood. All 60 rounds and all 20 strata below 1.0.
+> - **M2 mount — `1.0601×` and still diagnostic and still indistinguishable.**
+>   All ten runs straddle 1.0 and three read below it outright. Not quotable
+>   against the bar, exactly as before.
+> - **The segment-order finding this table previously cited is withdrawn.** The
+>   *11 of 12 row-runs, p = 0.0032* was four correlated rows inside each of three
+>   runs, not twelve trials, and its design could not separate segment order from
+>   time. On the counterbalanced ensemble the effect is not established on any
+>   row, and the same statistic counted the old way reads 23 of 40.
 > - **The heap red-zones are untouched.** Nothing here measures heap.
 
 ### The control on this page was never checked either
@@ -956,8 +1168,21 @@ mutation evidence is on
   rather than rewritten. Its **heap** rows are not superseded by anything here —
   this entry measures no heap, and retained bytes per boundary is a property of
   the boundary rather than of the page.
-- **The per-page accumulation is still unexplained.** One row per page makes it
-  harmless to these figures; it does not make it fixed.
+- **The per-page accumulation is still unexplained — but it now has a measured
+  dose-response and a named lever.** rf2-6i0i2's six-round M2 refusals put
+  numbers on it: 600 mounts a page clean, 720 refused 4 of 6, 1,296 refused 3 of
+  3, 504 clean over 40 row-runs, every refusal *last*-third-slower. So the page
+  degrades in proportion to the mounts it has run, and the budget is the control
+  knob. rf2-flqpd has tied the same shape to collector debt on the retention
+  page. What is still missing is the mechanism on *this* page and a fix that does
+  not cost samples; one row per page plus a per-witness budget makes it harmless
+  to these figures, and neither makes it fixed.
+- **The segment-order effect is not established, and one machine-session is
+  what stands behind that.** rf2-6i0i2's ten counterbalanced runs exclude an
+  effect of the size this page once asserted and cannot exclude one of a percent
+  or two. They also all ran inside one eight-minute window on one box; a run from
+  another session read below the whole ensemble's spread on M1. **Between-session
+  variation is unmeasured and is the wider of the two.**
 - ~~**`p0_converge_app.cljs`'s own row table still describes the pre-batch
   narrow window, and this page cannot fix it.**~~ **CLOSED by rf2-95m11
   (PR #7288).** The sibling worker finished, and the correction was the one

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -289,9 +289,12 @@ has cleared the threshold.
 **The pre-registered single run, printed because the design named it before it
 ran.** The commit that balanced the design nominated run 1 — reagent-start, the
 historic schedule — as the re-publication run *in advance*, so that the row
-payloads could not be chosen after the fact. It is printed here beside the
-ensemble; on every row it sits inside the ten-run spread, and the ensemble mean
-is the better-founded estimate of the same quantity.
+payloads could not be chosen after the fact. It is one of the ten, so it is
+inside their spread by construction; what it is worth printing for is **where it
+falls in that spread**, which is all over it — 4th lowest of ten on M1, 5th on
+M2, **2nd lowest on narrow and 2nd highest on broad**. A single pre-designated
+run is honest but arbitrary, and that is the case for publishing the ensemble
+rather than any one member of it.
 
 | witness | run 1 (pre-registered) | range | per round |
 |---|---|---|---|
@@ -306,7 +309,7 @@ replace:
 
 | witness | `reagent-subs ÷ floor` | `uix-subs ÷ floor` |
 |---|---|---|
-| M1 mount | ~~4.352×~~ → 4.358× [3.625 – 5.111] | ~~5.343×~~ → 5.343× [4.611 – 6.500] |
+| M1 mount | ~~4.352×~~ → 4.358× [3.625 – 5.111] | **5.343×** [4.611 – 6.500] — the mean is unchanged to four figures |
 | M2 mount | ~~2.102×~~ → 2.241× [1.250 – 4.500] | ~~2.261×~~ → 2.335× [1.375 – 4.000] |
 | bulk broad | ~~7.443×~~ → 7.630× [6.167 – 10.000] | ~~4.607×~~ → 4.728× [3.333 – 6.000] |
 | bulk narrow *(batched window)* | ~~1.880×~~ → 2.416× [1.965 – 2.682] | ~~2.168×~~ → 2.831× [2.618 – 3.059] |
@@ -854,12 +857,16 @@ five Reagent-start runs against the five UIx-start runs, and use an **exact
 permutation test** over all `C(10,5) = 252` relabellings. Nothing about the
 inside of a run is assumed.
 
-| row | Reagent-start mean | UIx-start mean | difference | exact two-sided *p* | smallest difference this test could have seen |
+| row | Reagent-start mean | UIx-start mean | difference | exact two-sided *p* | resolution limit |
 |---|---|---|---|---|---|
-| M1 mount | 1.2276 | 1.2344 | −0.0068 | 0.770 | 0.043 |
-| M2 mount | 1.0461 | 1.0740 | −0.0280 | 0.611 | 0.122 |
-| bulk broad | 0.6295 | 0.6288 | +0.0007 | 0.984 | 0.063 |
-| bulk narrow | 1.1754 | 1.1755 | −0.0001 | 0.992 | 0.037 |
+| M1 mount | 1.2276 | 1.2344 | −0.0068 | 0.770 | ±0.043 |
+| M2 mount | 1.0461 | 1.0740 | −0.0280 | 0.611 | ±0.122 |
+| bulk broad | 0.6295 | 0.6288 | +0.0007 | 0.984 | ±0.063 |
+| bulk narrow | 1.1754 | 1.1755 | −0.0001 | 0.992 | ±0.037 |
+
+The **resolution limit** is the half-width of the 95% interval on the difference
+— what a start-group effect would have had to exceed for five against five to
+see it. It is printed because a null result without one is not a result.
 
 **Which segment starts a run does not detectably move the number that run
 publishes.** On the narrow row the two groups agree to one part in ten thousand.
@@ -927,13 +934,16 @@ claim one.** The start-group contrast can only resolve a difference of about
 0.04 on the narrow and M1 rows and about 0.12 on M2 — the last column of View 1's
 table is that limit, computed rather than asserted. On the composite, the
 interval admits an order effect anywhere from **6.6% against the claim to 2.9%
-for it**. So:
+for it**. Stated as bounds rather than as a verdict:
 
-- **An order effect of the size the page previously asserted — one to nineteen
-  percent between strata, systematic — is excluded on every row.**
-- **An order effect of one or two percent is not excluded, and would not be
-  detectable at ten runs.** It would also not matter: it is smaller than the
-  spread between two consecutive runs of the same design.
+- **An effect at the top of the range the page previously asserted is excluded
+  on every row.** The upper end of View 2's interval — the end that would favour
+  the claim — is +9.7% on M1, +6.5% on M2, +4.4% on broad and +3.8% on narrow.
+  The *"one to nineteen percent between strata, systematic"* the page used to
+  assert cannot be true of the top of its own range on any row.
+- **An effect of one or two percent is not excluded, and ten runs could not have
+  detected one.** It would also not matter: it is smaller than the gap between
+  two consecutive runs of the same design.
 
 The right conclusion is the modest one. **The segment-order effect is not
 established, and the design no longer needs it to be.** With an even round count

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -227,50 +227,93 @@ re-frame state and is untouched by which adapter is installed, so a
 UIx-over-Reagent figure is a ratio of two floor-normalised ratios and the seam
 cancels. **That cancellation is published, not assumed:**
 
-| row | floor(UIx segment) ÷ floor(Reagent segment), per round | verdict |
-|---|---|---|
-| mount M1 | 0.900 · 1.056 · 1.000 · 0.938 · 1.000 | straddles 1.0 |
-| mount M2 | 0.800 · 1.000 · 1.167 · 0.875 · 1.000 | straddles 1.0 |
-| bulk broad | 0.625 · 1.000 · 1.200 · 0.667 · 1.200 | straddles 1.0 |
-| bulk narrow | 1.000 · 1.000 · 1.000 · 1.200 · 1.000 | straddles 1.0 |
+| row | floor(UIx segment) ÷ floor(Reagent segment), run 1 per round | over the ten runs | verdict |
+|---|---|---|---|
+| mount M1 | 1.000 · 1.105 · 1.125 · 0.900 · 1.118 · 1.000 | mean 1.029, run means 1.000 – 1.085 | straddles 1.0 in **10 of 10** |
+| mount M2 | 1.167 · 1.000 · 1.000 · 1.000 · 1.125 · 1.000 | mean 1.019, run means 0.903 – 1.103 | straddles 1.0 in **10 of 10** |
+| bulk broad | 1.000 · 0.857 · 1.143 · 1.000 · 0.857 · 0.857 | mean 0.971, run means 0.856 – 1.078 | straddles 1.0 in **10 of 10** |
+| bulk narrow | 0.900 · 0.962 · 0.943 · 0.965 · 1.020 · 1.122 | mean 1.003, run means 0.957 – 1.029 | straddles 1.0 in **10 of 10** |
 
-The seam is indistinguishable from unity on every row — a materially quieter
-seam than the one rf2-2rtt6.4 published, which moved by up to 1.8×.
+The seam is indistinguishable from unity on every row of every run — a
+materially quieter seam than the one rf2-2rtt6.4 published, which moved by up to
+1.8×. Forty independent chances to catch a drifting seam, and it did not drift.
 **A single-segment absolute millisecond from this page is still not a quotable
 figure.**
 
 ## RED-ZONE — clock, on rf2-2rtt6.2's witnesses
 
 **UIx-on-subs ÷ Reagent-on-subs**, both floor-normalised in the same round and
-the same segment. Ranges are min–max across the five rounds. A range that
-includes 1.0 means the two are **indistinguishable** and is reported as such
-rather than as a winner.
+the same segment. A range that includes 1.0 means the two are
+**indistinguishable** and is reported as such rather than as a winner.
 
-| witness | **threshold (mean)** | range | per round | verdict |
+**These four rows are the balanced re-publication (rf2-6i0i2)**, and the
+five-round figures they replace are struck in place. Every row below is the
+mean over **ten independently launched six-round runs** whose starting segment
+is counterbalanced five and five — the design [the segment-order
+question](#the-segment-order-question-asked-properly) describes. At six rounds
+the alternation splits 3:3, so the raw mean and the order-balanced mean are the
+**same number by construction**; there is no longer a corrected value to print
+beside a biased one.
+
+| witness | **threshold** | 95% interval on the mean | run means (10) | verdict |
 |---|---|---|---|---|
-| **M1 mount** — 901 el, 300 boundaries | ~~**1.2301×**~~ **MAGNITUDE WITHDRAWN** — direction only, ≈1.11 – 1.35 | 1.1099 – 1.3538 | 1.3065 · 1.1417 · 1.2388 · 1.1099 · 1.3538 | **UIx slower** here and in 2 of the 3 other runs; **see [the segment-order warrant](#the-segment-order-warrant--and-why-12301-does-not-have-one)** |
-| **M2 mount** — 51 el, 12 fields · *diagnostic* | 1.0539× | 0.8572 – 1.4286 | 1.4286 · 0.8572 · 0.8572 · 1.0550 · 1.0714 | **straddles 1.0 — indistinguishable** |
-| **bulk broad** — one commit all 300 read | **0.6239×** | 0.4701 – 0.7857 | 0.7172 · 0.6046 · 0.5417 · 0.7857 · 0.4701 | **UIx faster**, disjoint from 1.0 |
-| **bulk narrow** — 10 commits, each read by exactly one boundary, one window | ~~**1.1540×**~~ **MAGNITUDE WITHDRAWN** — direction only; balanced 1.1457 | 1.0570 – 1.2053 | 1.2053 · 1.1515 · 1.1860 · 1.0570 · 1.1700 | **UIx slower**, disjoint from 1.0 in every run — *but its order strata are disjoint too; see [the segment-order warrant](#the-segment-order-warrant--and-why-12301-does-not-have-one)* |
-| ~~bulk narrow, **unbatched window** (superseded)~~ | ~~1.1556×~~ | ~~1.0417 – 1.2500~~ | ~~1.1111 · 1.2500 · 1.2500 · 1.0417 · 1.1250~~ | ~~UIx slower, but did not stably resolve across runs~~ |
+| **M1 mount** — 901 el, 300 boundaries | ~~1.2301×~~ → **1.2310×** | 1.2105 – 1.2514 | 1.1989 – 1.2931 | **UIx slower.** 59 of 60 rounds above 1.0; 19 of 20 order strata wholly above it |
+| **M2 mount** — 51 el, 12 fields · *diagnostic* | ~~1.0539×~~ → **1.0601×** | 1.0017 – 1.1185 | 0.9561 – 1.1923 | **straddles 1.0 — indistinguishable**, in all ten runs |
+| **bulk broad** — one commit all 300 read | ~~0.6239×~~ → **0.6291×** | 0.5996 – 0.6587 | 0.5792 – 0.6987 | **UIx faster.** All 60 rounds below 1.0; all 20 strata wholly below it |
+| **bulk narrow** — 10 commits, each read by exactly one boundary, one window | ~~1.1540×~~ → **1.1754×** | 1.1579 – 1.1930 | 1.1390 – 1.2186 | **UIx slower.** All 60 rounds above 1.0; all 20 strata wholly above it |
+| ~~bulk narrow, **unbatched window** (superseded twice over)~~ | ~~1.1556×~~ | — | — | ~~UIx slower, but did not stably resolve across runs~~ |
 
-> **Two magnitudes are withdrawn and no number is deleted.** Every figure above
-> is exactly as measured; what changed is what may be **quoted** from it, and it
-> is now the instrument that decides ([the segment-order
-> warrant](#the-segment-order-warrant--and-why-12301-does-not-have-one)).
-> The two rows whose order strata OVERLAP keep their magnitudes, with the
-> order-balanced value beside the raw one: **M2 1.0539 → 1.0376** (diagnostic
-> either way), **bulk broad 0.6239 → 0.6357**.
+**The interval is on the mean, not on a run.** It is a Student-t interval over
+the ten run means, so it says how well ten runs pin the centre; the *run means*
+column is the spread a single fresh run should be expected to land in, and it is
+two to four times wider. Quote the interval when comparing a candidate against
+the centre; quote the run-mean spread when asking whether one run of a candidate
+has cleared the threshold.
 
-Both arms against the floor, for context:
+> **The two withdrawn magnitudes are restored, and no number is deleted.** M1's
+> `1.2301` and narrow's `1.1540` were withdrawn because a 3:2 design biased them,
+> their order strata were disjoint, and four estimates disagreed by ±6%. The
+> balanced ensemble answers all three: the design is even, the strata **overlap
+> in 9 of 10 runs on both rows**, and ten estimates now agree to ±4%. What is
+> published is a magnitude **with an interval**, which is what the measurement
+> supports; a bare four-decimal point never was. **rf2-2rtt6.1's operator hold on
+> quoting `1.2301` is not lifted here** — that bead's number is superseded rather
+> than rehabilitated, and only the operator amends the standard. See [the verdict
+> on M1's magnitude](#the-verdict-on-m1s-magnitude).
+
+**The pre-registered single run, printed because the design named it before it
+ran.** The commit that balanced the design nominated run 1 — reagent-start, the
+historic schedule — as the re-publication run *in advance*, so that the row
+payloads could not be chosen after the fact. It is printed here beside the
+ensemble; on every row it sits inside the ten-run spread, and the ensemble mean
+is the better-founded estimate of the same quantity.
+
+| witness | run 1 (pre-registered) | range | per round |
+|---|---|---|---|
+| M1 mount | 1.2159× | 0.9529 – 1.4286 | 1.4286 · 0.9529 · 1.2681 · 1.2186 · 1.1378 · 1.2892 |
+| M2 mount | 1.0469× | 0.8571 – 1.3846 | 0.8571 · 1.3846 · 1.0714 · 1.0000 · 1.0794 · 0.8889 |
+| bulk broad | 0.6662× | 0.5532 – 0.8485 | 0.6190 · 0.6328 · 0.6144 · 0.5532 · 0.8485 · 0.7292 |
+| bulk narrow | 1.1542× | 1.0346 – 1.3602 | 1.2575 · 1.1161 · 1.0999 · 1.3602 · 1.0568 · 1.0346 |
+
+Both arms against the floor, over the ensemble. Ranges are min–max across all
+sixty rounds, which is why they are wider than the five-round ranges they
+replace:
 
 | witness | `reagent-subs ÷ floor` | `uix-subs ÷ floor` |
 |---|---|---|
-| M1 mount | 4.352× [4.063 – 4.625] | 5.343× [4.947 – 5.944] |
-| M2 mount | 2.102× [1.625 – 2.800] | 2.261× [1.714 – 4.000] |
-| bulk broad | 7.443× [7.000 – 8.000] | 4.607× [3.667 – 5.500] |
-| bulk narrow *(batched window)* | 1.880× [1.8167 – 1.9259] | 2.168× [2.0357 – 2.2500] |
+| M1 mount | ~~4.352×~~ → 4.358× [3.625 – 5.111] | ~~5.343×~~ → 5.343× [4.611 – 6.500] |
+| M2 mount | ~~2.102×~~ → 2.241× [1.250 – 4.500] | ~~2.261×~~ → 2.335× [1.375 – 4.000] |
+| bulk broad | ~~7.443×~~ → 7.630× [6.167 – 10.000] | ~~4.607×~~ → 4.728× [3.333 – 6.000] |
+| bulk narrow *(batched window)* | ~~1.880×~~ → 2.416× [1.965 – 2.682] | ~~2.168×~~ → 2.831× [2.618 – 3.059] |
 | ~~bulk narrow *(unbatched, superseded)*~~ | ~~1.820× [1.500 – 2.000]~~ | ~~2.117× [1.667 – 2.500]~~ |
+
+**The narrow row's floor-relative figures move a long way and the reason is the
+floor, not the arms.** Both legs rise by almost the same factor — Reagent ×1.29,
+UIx ×1.31 — because the narrow floor reads *faster* on this ensemble than it did
+on the five-round run (16.5–30 quanta against 21–30). A common factor in both
+numerators cancels out of a ratio of two floor-normalised ratios, which is why
+the threshold itself barely moves: 2.831 ÷ 2.416 = 1.172, against the 1.1754 the
+row publishes. That agreement is the floor normalisation working as designed.
 
 ### All four rows reproduce against the revived driver (rf2-rjfz1)
 
@@ -356,19 +399,29 @@ of Chrome's 100 µs quanta, which is coarse enough to be worth checking. The
 **raw** cross-segment estimator — `uix-subs` p50 over `reagent-subs` p50 in the
 same round, touching neither floor — is therefore reported beside it:
 
+Both columns are now over the ten-run ensemble; the bracket is the spread of the
+ten run means.
+
 | row | floor-normalised | raw cross-segment | agree? |
 |---|---|---|---|
-| M1 mount | 1.2301 [1.1099 – 1.3538] | 1.2028 [1.0405 – 1.3538] | yes — same verdict, 2% apart on the mean |
-| M2 mount | 1.0539 [0.8572 – 1.4286] | 0.9989 [0.8571 – 1.1429] | yes — both straddle |
-| bulk broad | 0.6239 [0.4701 – 0.7857] | 0.5582 [0.4483 – 0.6500] | yes — same verdict, both far from 1.0 |
-| bulk narrow *(batched window)* | **1.1540** [1.0570 – 1.2053] | **1.1714** [1.0962 – 1.2316] | yes — same verdict, both disjoint from 1.0 |
+| M1 mount | ~~1.2301~~ → **1.2310** [1.1989 – 1.2931] | ~~1.2028~~ → **1.2608** [1.2119 – 1.3607] | yes — same verdict, 2.4% apart on the mean |
+| M2 mount | ~~1.0539~~ → **1.0601** [0.9561 – 1.1923] | ~~0.9989~~ → **1.0489** [0.9958 – 1.1111] | yes — both straddle |
+| bulk broad | ~~0.6239~~ → **0.6291** [0.5792 – 0.6987] | ~~0.5582~~ → **0.5939** [0.5712 – 0.6282] | yes — same verdict, both far from 1.0 |
+| bulk narrow *(batched window)* | ~~1.1540~~ → **1.1754** [1.1390 – 1.2186] | ~~1.1714~~ → **1.1761** [1.1323 – 1.2267] | yes — same verdict, both disjoint from 1.0 |
 | ~~bulk narrow *(unbatched, superseded)*~~ | ~~1.1556 [1.0417 – 1.2500]~~ | ~~1.1972 [1.1111 – 1.2500]~~ | ~~yes~~ |
 
 The two estimators agree on the verdict of every row, which is the evidence that
 the floor normalisation is doing its job rather than injecting the quantisation
-it is exposed to.
+it is exposed to. On the narrow row they now agree to **0.06%**, which is the
+tightest the two have ever been on this page.
 
 ### Stability across runs
+
+**Superseded as the stability evidence by the ten-run ensemble** — ten runs give
+a spread and an interval where two give only an anecdote, and the numbers are in
+the [RED-ZONE table](#red-zone--clock-on-rf2-2rtt62s-witnesses) above. The pair
+below is kept because it is what the page had at the time and because the
+narrow row's story turns on it.
 
 The identical instrument was run twice, five rounds each, minutes apart:
 
@@ -433,12 +486,15 @@ run.**
 Stated rather than smoothed. One sample, p50 milliseconds, expressed in Chrome's
 100 µs quanta:
 
+Over the whole ensemble — 120 segment-rounds a row, so these are the widest
+bounds the instrument has ever published rather than one run's.
+
 | row | floor | `reagent-subs` | `uix-subs` | usable? |
 |---|---|---|---|---|
-| M1 mount | 8 – 10 | 33 – 46 | 39 – 54 | yes |
-| M2 mount | 2 – 4 | 6 – 7 | 6 – 8 | **diagnostic only** |
-| bulk broad | 2.5 – 4 | 20 – 29 | 11 – 13 | yes on the substrate legs; the floor is coarse, which is why the raw estimator is published beside the normalised one |
-| **bulk narrow** — 10 commits a sample | 21 – 30 | 47.5 – 55.5 | 57 – 64.5 | **yes** |
+| M1 mount | 6 – 11 | 27 – 47 | 35 – 65 | yes |
+| M2 mount | 2 – 5 | 4.5 – 11 | 4.5 – 11 | **diagnostic only** — and the reason is right here: a single 100 µs quantum is up to 22% of a reading |
+| bulk broad | 2 – 4 | 17 – 31.5 | 9 – 19.5 | yes on the substrate legs; the floor is coarse, which is why the raw estimator is published beside the normalised one |
+| **bulk narrow** — 10 commits a sample | 16.5 – 30 | 41.5 – 66.5 | 48 – 74 | **yes** |
 | ~~bulk narrow — 1 commit a sample (superseded)~~ | ~~2 – 3~~ | ~~4 – 4.5~~ | ~~4.5 – 5~~ | ~~**clamp-limited**~~ |
 
 ## What the convergence changed
@@ -449,10 +505,10 @@ matter*, and it is not small.
 
 | question | rf2-2rtt6.4, on its own witnesses | converged, on rf2-2rtt6.2's | change |
 |---|---|---|---|
-| large-list mount | W1: **1.057×** [0.907 – 1.156] — indistinguishable | M1: **1.2301×** [1.110 – 1.354] — UIx slower, disjoint | **verdict flips**: an indistinguishable row becomes a resolved one |
-| ordinary-form mount | W3: **0.893×** [0.843 – 0.956] — UIx faster, disjoint, published as a threshold | M2: **1.0539×** [0.857 – 1.429] — indistinguishable, graded diagnostic | **verdict flips**, and so does the grade |
-| broad commit | U-broad: **0.838×** [0.760 – 0.953] — UIx faster | bulk broad: **0.6239×** [0.470 – 0.786] — UIx faster | same direction, **much larger margin** |
-| narrow commit | U-narrow: **1.536×** [1.226 – 1.876] — UIx slower, disjoint | bulk narrow: **1.1540×** [1.0570 – 1.2053] — UIx slower, disjoint | same direction and both resolve, but **the margin roughly halves** |
+| large-list mount | W1: **1.057×** [0.907 – 1.156] — indistinguishable | M1: **1.2310×** [1.199 – 1.293 across ten runs] — UIx slower | **verdict flips**: an indistinguishable row becomes a resolved one |
+| ordinary-form mount | W3: **0.893×** [0.843 – 0.956] — UIx faster, disjoint, published as a threshold | M2: **1.0601×** [0.956 – 1.192] — indistinguishable, graded diagnostic | **verdict flips**, and so does the grade |
+| broad commit | U-broad: **0.838×** [0.760 – 0.953] — UIx faster | bulk broad: **0.6291×** [0.579 – 0.699] — UIx faster | same direction, **much larger margin** |
+| narrow commit | U-narrow: **1.536×** [1.226 – 1.876] — UIx slower, disjoint | bulk narrow: **1.1754×** [1.139 – 1.219] — UIx slower | same direction and both resolve, but **the margin over parity falls to about a third** — 0.18 against 0.54 |
 
 None of this makes rf2-2rtt6.4 wrong. Each of its ratios is still a ratio
 between two arms measured in one run, on one page, through one sub graph, in
@@ -500,42 +556,66 @@ is exact*. (The ±0.001% standard this wave set belongs to the **heap** control,
 where the predicted quantity is a known retained byte count; no clock control
 can honestly be held to it.)
 
+**The live count is the ensemble's: 4 rows × 2 segments × 10 runs = 80
+controls, and 80 passes** under the overlap rule `lane/control-verdict`
+implements. Each cell is the mean of the ten run means, with the widest bound any
+of the ten reached:
+
 | row | predicted | Reagent segment | UIx segment | basis |
 |---|---|---|---|---|
-| M1 mount | 1.9989× | 1.863× [1.750 – 2.000] ✅ | 1.979× [1.895 – 2.000] ✅ | 1801 / 901 elements |
-| M2 mount | 1.9412× | 1.803× [1.600 – 2.000] ✅ | 1.731× [1.333 – 2.000] ✅ | 99 / 51 elements |
-| bulk broad | 1.9989× | 1.817× [1.667 – 2.000] ✅ | 1.923× [1.667 – 2.250] ✅ | 1801 / 901 elements |
-| **bulk narrow** *(batched, run 1)* | 1.9989× | 1.976× [1.917 – 2.038] ✅ | 1.949× [1.821 – 2.000] ✅ | 1801 / 901 elements |
-| **bulk narrow** *(batched, run 2)* | 1.9989× | 1.941× [1.905 – 1.977] ✅ | 1.935× [1.814 – 2.000] ✅ | 1801 / 901 elements |
+| M1 mount | 1.9989× | 1.918× [1.714 – 2.167] ✅ | 1.917× [1.688 – 2.167] ✅ | 1801 / 901 elements |
+| M2 mount | 1.9412× | 1.783× [1.167 – 2.500] ✅ | 1.778× [1.333 – 2.333] ✅ | 99 / 51 elements |
+| bulk broad | 1.9989× | 1.905× [1.500 – 2.500] ✅ | 2.013× [1.333 – 2.500] ✅ | 1801 / 901 elements |
+| **bulk narrow** | 1.9989× | 1.979× [1.754 – 2.294] ✅ | 1.965× [1.796 – 2.194] ✅ | 1801 / 901 elements |
 | ~~bulk narrow *(unbatched, superseded)*~~ | ~~1.9989×~~ | ~~2.013× [1.667 – 2.400] ✅~~ | ~~1.867× [1.667 – 2.000] ✅~~ | ~~1801 / 901 elements~~ |
 
-**Ten controls, ten passes, and all ten sit below their prediction** — the
-direction a fixed per-root term predicts, and the same direction rf2-2rtt6.2
-and rf2-2rtt6.4 both recorded.
+**Sixty-seven of the eighty sit below their prediction** — the direction a fixed
+per-root term predicts, and the same direction rf2-2rtt6.2 and rf2-2rtt6.4 both
+recorded. The thirteen that sit above are concentrated on the two rows whose
+control legs are coarsest: seven on bulk broad, four on narrow, one each on M1
+and M2. **The earlier summary said the direction was *unanimous*, which was true
+of ten controls and is not true of eighty.** Ten measurements were never enough
+to establish a unanimity; eighty are enough to say the tendency is real and not
+universal, which is the more useful statement anyway.
 
-**This summary read *"Eight controls, eight passes, and seven of the eight sit
-below"*, and the table it described no longer exists.** It was right when the
-table held M1, M2, broad and the unbatched narrow row — four entries across two
-segments, of which exactly one, the narrow Reagent segment's `2.013×`, sat above
-its prediction. The batched re-take struck that row and added two batched runs
-in its place, so the live table is **five entries × two segments = ten**, the
-one entry that sat above prediction is the superseded one, and the direction is
-now unanimous. Counting the struck row would be counting a figure this page has
-withdrawn.
+### The strict reading, over eighty controls (rf2-egdaq)
 
-The narrow row's controls were **predicted before the run** at `1801 / 901 =
-1.9989×` and re-measured on the batched window; all four ranges above sit
-entirely inside the ±25% band `[1.4992 – 2.4986]`. They therefore pass under the
-**strict** every-round-inside reading as well as the overlap rule they were
-adjudicated under — which matters because `lane/control-verdict` implements the
-overlap rule and **rf2-egdaq** is the open question of whether to tighten it.
-Nothing here tightens it; the narrow row simply would not be affected either way.
+`lane/control-verdict` adjudicates a control by **overlap** with the ±25% band;
+**rf2-egdaq** holds open the question of whether to require **every round**
+inside it. The ensemble is the first sample large enough to say what that choice
+would cost, so it is stated here as an observation. **The ruling is the
+operator's and nothing below decides it.**
 
-## The guard refused this arm, twice, and the arm was repaired
+| row | band | strict passes | worst single round |
+|---|---|---|---|
+| M1 mount | [1.4992 – 2.4986] | **20 of 20** | 1.6875 — inside |
+| M2 mount | [1.4559 – 2.4265] | **13 of 20** — Reagent 6/10, UIx 7/10 | **1.1667**, 19.9% below the floor (Reagent segment); **1.3333**, 8.4% below (UIx segment) |
+| bulk broad | [1.4992 – 2.4986] | **11 of 20** — Reagent 7/10, UIx 4/10 | **1.3333**, 11.1% below the floor |
+| bulk narrow | [1.4992 – 2.4986] | **20 of 20** | 1.7544 — inside |
+
+**64 of 80 pass strict; 2 of the 10 runs pass strict on all eight of their
+controls.** The failures are not spread evenly — they land entirely on the two
+rows whose control leg is a handful of 100 µs quanta, and every one of them is a
+*low* outlier of exactly the shape a quantised floor produces. The rows measured
+on 20-plus quanta legs, M1 and narrow, pass strict 40 times out of 40.
+
+Two things follow, and only the first is a finding. **A strict rule would refuse
+the M2 row in 6 runs of 10 and the broad row in 6 of 10, on a page where every
+other gate is green** — the guard clean on all forty row-runs, parity clean,
+zero unverified of 92,160. And the number rf2-egdaq holds on reproduces exactly:
+its worst M2 round, `1.3333` against a floor of `1.4559`, is **8.4% below**, and
+this ensemble's worst M2 UIx round is the same `1.3333` — the same lattice
+point, not a coincidence but the arithmetic of a ratio built from two-to-five
+quantum readings. What the ensemble adds is that the Reagent segment reaches
+`1.1667`, **19.9% below the floor**, which is more than twice the excursion the
+held ruling was weighing.
+
+## The guard refused this arm three times, and the arm was repaired each time
 
 The first cut ran all four rows in one page. **The arm-order guard refused it,
 exit 2**, on two independent faults. Both were the arm's; the tolerance was not
-touched.
+touched. The third refusal came much later, when the sixth round was added, and
+it has its own section below.
 
 **1. Phase — the page degraded as it ran.** `M1/uix-subs/floor` — an arm that
 hand-builds React elements and *cannot change* — read
@@ -571,6 +651,63 @@ predecessor; and one row per page leaves no cross-row adjacency to mislabel.
 A refusal is not a broken script. It is the instrument saying that a figure it
 produced depends on where in the plan it was measured — and every figure the
 first cut produced looked entirely plausible.
+
+### 3. The sixth round broke the M2 row, and the lever was the mount budget
+
+**This one changes how an M2 row on this page is read, so it is written up in
+full.** Adding the sixth round moved the M2 page from 600 measured mounts to
+720, and the guard refused **four of the first six six-round invocations** —
+every refusal on M2's *phase* factor, every one a **last-third-slower** disjoint
+split of 2.0000× / 2.2857× / 2.5000×, on readings of one to three of Chrome's
+100 µs quanta. No other row refused, in any of them.
+
+**The first diagnosis was wrong and the guard said so.** The obvious reading of
+a phase split is a cold page — the knee — and the guard's own repair list begins
+with *more warm-up*. That repair was taken first: 24 discarded mounts a
+segment-round instead of 8. It made things **worse**, and unambiguously:
+1,296 mounts a page, refused **three of three**, with the split widened to
+2.6×–4.0×.
+
+The direction was the tell. A cold page reads **first**-third-slower; every one
+of these refusals was **last**-third-slower. The page is not warming, it is
+**degrading as it runs** — the per-page accumulation rf2-2rtt6.4 recorded and
+could not explain, which rf2-flqpd has since tied to collector debt (a scavenge
+inside a timed window measures the collector, and the floor it measured drifted
+3.4 → 7.0 ms under 30–80 MB of uncollected rubbish). Deeper warm-up *feeds* that
+accumulation, because a warm-up mount is a mount. The lever is the page's
+**total mount budget**, and the dose-response was measured rather than argued:
+
+| M2 page budget | how it arises | verdict |
+|---|---|---|
+| **600 mounts** | 5 rounds × 2 segments × 3 arms × (8 + 12) | clean — every five-round run on this page |
+| **720 mounts** | 6 rounds, same sampling | **refused 4 of 6**, splits 2.0×–2.5× |
+| **1,296 mounts** | 6 rounds, warm-up deepened to 24 | **refused 3 of 3**, splits 2.6×–4.0× |
+| **504 mounts** | 6 rounds, sampling 4 + 10 — *the repair* | clean — **40 of 40 row-runs of the ensemble** |
+
+**The repair is a smaller sampling budget on this witness only:** `:sampling
+{:warmup 4 :samples 10}`, carried on the M2 witness map rather than the page
+default, which puts a six-round M2 page at 504 mounts — under the budget every
+clean run ever ran at. **The measured window is untouched** (one mount a sample,
+exactly as rf2-2rtt6.2 publishes it) and **the tolerance is untouched** (0.10).
+Less warm-up is safe *here* precisely because the failure is the tail rather
+than the knee: a cold early sample pulls the first third **up**, against the
+climb, so it costs sensitivity in the direction that is not failing. M1 keeps
+the page default — its readings are 30–50 quanta, where the same absolute drift
+is comfortably inside tolerance.
+
+**What this means for reading an M2 row.** The M2 row of this ensemble is
+sampled **10 deep off a 4-mount warm-up**, where the other three rows are 12 deep
+off 8 and where every five-round M2 row on this page was also 12 off 8.
+Comparing an M2 figure across the two publications compares two sampling depths
+as well as two designs. It is still the same witness, the same window and the
+same tolerance — but the row now carries an instrument parameter the others do
+not, and the reason is that this witness is the only one whose readings are
+small enough for the page's own decay to show up as a refusal.
+
+**Six invocations were run at the pre-repair instrument and none of them is
+published.** They diagnosed a defect and were spent doing it; the counterbalanced
+ensemble restarted from scratch at the repaired instrument, which is why the
+ensemble is ten runs and not sixteen.
 
 ## Method
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/coldmount_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/coldmount_app.cljs
@@ -132,6 +132,14 @@
 (defn- segment-order [r]
   (if (even? r) (vec segments) (vec (rseq (vec segments)))))
 
+(def ^:private start-segment
+  "Which segment leads round 0, and therefore how `segment-order-verdict`
+  labels the even and odd strata. This entry's [[segment-order]] takes no
+  counterbalanced start — round 0 is even, so Reagent leads it in every
+  coldmount run — and the value is derived from the schedule rather than
+  restated beside it, so the label and the order cannot drift apart."
+  (:id (first (segment-order 0))))
+
 (defn- enter-segment!
   "The converged arm's seam, unchanged: tear down, install this segment's
   adapter, re-register the sub graph (`cmv/register!` — the converged
@@ -539,7 +547,7 @@
         resolved? (fn [vs] (not-any? nil? vs))
         fid       (fidelity-of (pick :uix) (pick :xcript))
         rz        (pick :rz)
-        order     (converge/segment-order-verdict rz rounds)
+        order     (converge/segment-order-verdict rz rounds start-segment)
         c-rg      (lane/control-verdict (:predicted control)
                                         (select-keys (range-of (pick :ctl-ratio-reagent))
                                                      [:min :max :mean])

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
@@ -92,7 +92,14 @@
 
   Segment order alternates with the round, so the cross-segment figure is
   a both-orders result rather than a single-order one however many rounds
-  it averages.
+  it averages. WHICH segment starts round 0 is a per-run parameter
+  (`?start=reagent` or `?start=uix`, default reagent — the schedule every
+  five-round run used), because rf2-6i0i2's audit is right that a fixed
+  start confounds segment order with temporal position: in every earlier
+  run the Reagent-first rounds were also rounds 0, 2 and 4. Independently
+  launched runs counterbalance the start, and the inference about the
+  order effect is made ACROSS those runs, never by pooling one run's four
+  correlated rows as if they were independent trials.
 
   ## And the order is ADJUDICATED, not merely run (rf2-a4x1o)
 
@@ -115,7 +122,10 @@
   orders, so the raw mean over-weights whichever order got the extra round
   — which is why `:order-balanced-mean`, the mean of the two stratum
   means, is published on every row beside it. The studio page carries the
-  table and the consequence for `1.2301`.
+  table and the consequence for `1.2301`. rf2-6i0i2 then took both
+  repairs: [[rounds]] is even, and the start is a counterbalanced per-run
+  parameter, so the order question is answered across independently
+  launched runs rather than inside one.
 
   ## One row per page
 
@@ -163,7 +173,16 @@
             [reagent.dom.client :as rdc]
             [uix.dom :as uix-dom]))
 
-(def ^:private rounds 5)
+(def ^:private rounds
+  "SIX, and EVEN on purpose (rf2-6i0i2). Five rounds cannot balance two
+  segment orders: the alternation split 3:2, the raw mean over-weighted
+  whichever order got the extra round, and the per-row disjointness test
+  ran at a 20% null rate (2 of C(5,2) = 10 exchangeable assignments). At
+  six the split is 3:3, the raw mean and `:order-balanced-mean` coincide
+  BY CONSTRUCTION, and the null rate halves to 10% (2 of C(6,3) = 20).
+  The four five-round rows this moves are re-published under the balanced
+  design and marked superseded IN PLACE on the studio page."
+  6)
 (def ^:private mount-sampling {:warmup 8 :samples 12})
 (def ^:private bulk-sampling {:warmup 8 :samples 12})
 
@@ -209,12 +228,31 @@
   [{:id :reagent-subs :adapter reagent-adapter/adapter :name "Reagent-on-subs"}
    {:id :uix-subs     :adapter uix-adapter/adapter     :name "UIx-on-subs"}])
 
+(defn- query-start
+  "Which segment runs FIRST in round 0 — `?start=uix` or `?start=reagent`.
+
+  Defaults to `:reagent-subs`, which is the only schedule any run before
+  rf2-6i0i2 ever had. That fixed start is exactly what the audit contested:
+  with alternation from a constant start, `Reagent first` and `rounds 0, 2,
+  4` are the same set in every run, so an order effect and a temporal one
+  are indistinguishable BY DESIGN however many runs agree. The parameter
+  exists so that independently launched runs can counterbalance the start
+  and pull those two apart; the driver passes it and reports it."
+  []
+  (let [s (or (some-> js/window .-location .-search) "")]
+    (if (re-find #"start=uix" s) :uix-subs :reagent-subs)))
+
 (defn- segment-order
-  "Two segments admit exactly two orders and this runs both. A
-  cross-segment figure taken in one order only is a single-order result
-  however many rounds it averages."
-  [r]
-  (if (even? r) (vec segments) (vec (rseq (vec segments)))))
+  "Two segments admit exactly two orders and every round runs both
+  segments; `start` names which one goes FIRST in round 0, and the order
+  alternates with the round from there. A cross-segment figure taken in
+  one order only is a single-order result however many rounds it
+  averages."
+  [start r]
+  (let [base (if (= start (:id (first segments)))
+               (vec segments)
+               (vec (rseq (vec segments))))]
+    (if (even? r) base (vec (rseq base)))))
 
 (defn- enter-segment!
   "Tear down whatever adapter is installed, install this segment's,
@@ -748,7 +786,7 @@
   and its stratum bounds, and NOT a precise magnitude. Silence is not a
   pass: `:magnitude-resolved?` starts false and the overlap has to earn it.
 
-  ## `:order-balanced-mean`, and the 3:2 design
+  ## `:order-balanced-mean`, and why the design is now EVEN
 
   With `rounds` odd the alternation is UNBALANCED — three rounds in one
   order, two in the other — so the arithmetic mean over rounds
@@ -756,10 +794,25 @@
   under an alternating design is the MEAN OF THE TWO STRATUM MEANS, and
   that is `:order-balanced-mean`, published beside the raw one whatever
   the parity of `rounds`. `:balanced-design?` says whether they can
-  differ. An EVEN round count would make them identical by construction
-  and is the arm-level repair available to whoever next re-takes the
-  table; it is not taken here, because it would move four published rows
-  without deciding the question the disjointness raises.
+  differ. The five-round design could not take the even count without
+  moving four published rows; rf2-6i0i2 took it AS a re-publication, so
+  [[rounds]] is now 6 and the two estimators coincide by construction on
+  every row this entry measures. The odd-round arithmetic stays because
+  this fn is PUBLIC and replays the published five-round vectors.
+
+  ## `start`, and what one run's partition can and cannot say
+
+  `start` is the segment that ran first in round 0, and the strata are
+  keyed by the segment that actually led each round — `:reagent-first` is
+  the rounds Reagent's segment led wherever they fell in the schedule.
+  Before rf2-6i0i2 the start was constant, so `Reagent first` and `rounds
+  0, 2, 4` were the same set in every run: a temporal drift and an order
+  effect produce identical partitions under that design, and no number of
+  same-start runs can tell them apart. Counterbalancing the start across
+  INDEPENDENTLY LAUNCHED runs is what breaks the tie — an order effect
+  keeps its sign when the start flips, a temporal one reverses it — and
+  the inference belongs at the run level, one statistic per launched run,
+  never four correlated rows of one run counted as four trials.
 
   ## What a disjoint split is and is not EVIDENCE of
 
@@ -767,13 +820,16 @@
   the five rounds exchangeable — the 2-element stratum is one of
   `C(5,2) = 10` equally likely subsets, and exactly TWO of them (the two
   smallest, the two largest) separate the strata. So a disjoint split
-  arises **20% of the time with no order effect at all**, per row. That is
+  arises **20% of the time with no order effect at all**, per row. At 6
+  rounds the same arithmetic gives 2 of `C(6,3) = 20` — 10%. That is
   why disjointness withdraws the magnitude rather than condemning the
   measurement: it is a statement about what this design can resolve, not a
   finding that the schedule moved the number."
-  [vs rounds]
-  (let [strata     {:reagent-first (vec (keep-indexed #(when (even? %1) %2) vs))
-                    :uix-first     (vec (keep-indexed #(when (odd? %1) %2) vs))}
+  [vs rounds start]
+  (let [lead-even  (if (= start :uix-subs) :uix-first :reagent-first)
+        lead-odd   (if (= lead-even :uix-first) :reagent-first :uix-first)
+        strata     {lead-even (vec (keep-indexed #(when (even? %1) %2) vs))
+                    lead-odd  (vec (keep-indexed #(when (odd? %1) %2) vs))}
         rf         (range-of (:reagent-first strata))
         uf         (range-of (:uix-first strata))
         overlap?   (and (<= (:min rf) (:max uf)) (<= (:min uf) (:max rf)))
@@ -782,7 +838,8 @@
         opposed?   (or (and (= d-rf :numerator-slower) (= d-uf :numerator-faster))
                        (and (= d-rf :numerator-faster) (= d-uf :numerator-slower)))
         balanced?  (even? rounds)]
-    {:reagent-first       (assoc rf :direction d-rf :n (count (:reagent-first strata)))
+    {:start               start
+     :reagent-first       (assoc rf :direction d-rf :n (count (:reagent-first strata)))
      :uix-first           (assoc uf :direction d-uf :n (count (:uix-first strata)))
      :order-balanced-mean (lane/round4 (/ (+ (:mean rf) (:mean uf)) 2.0))
      :balanced-design?    balanced?
@@ -791,7 +848,8 @@
      :direction-agrees?   (not opposed?)
      :refuse?             opposed?
      :why
-     (str "the red-zone's rounds partitioned by which segment ran FIRST. "
+     (str "the red-zone's rounds partitioned by which segment ran FIRST "
+          "(round 0 led by " (name start) ", alternating). "
           "Reagent-first " (.toFixed (:mean rf) 4) "x [" (.toFixed (:min rf) 4) "–"
           (.toFixed (:max rf) 4) "] over " (count (:reagent-first strata)) " rounds; "
           "UIx-first " (.toFixed (:mean uf) 4) "x [" (.toFixed (:min uf) 4) "–"
@@ -814,8 +872,10 @@
 (defn- row-record
   "Turn one row's per-round, per-segment slices into the published record.
 
-  `slices` is `[{segment-id {arm-id [ms ...]}} ...]`, one entry per round."
-  [{:keys [row doc grade clock-note control note writes-per-sample]} slices]
+  `slices` is `[{segment-id {arm-id [ms ...]}} ...]`, one entry per round.
+  `start` is the segment that led round 0, and it is published on the
+  record because a reader comparing counterbalanced runs needs it."
+  [{:keys [row doc grade clock-note control note writes-per-sample start]} slices]
   (let [norm       (mapv (fn [by-seg]
                            (into {} (map (fn [[sid rd]] [sid (ratios-of rd)])) by-seg))
                          slices)
@@ -834,15 +894,17 @@
                                                   control-slack))
         c-rg       (verdict-of ctl-rg)
         c-ux       (verdict-of ctl-ux)
-        order      (segment-order-verdict rz rounds)]
+        order      (segment-order-verdict rz rounds start)]
     {:record
      {:benchmark   (keyword "hicasso.P0.converged" (name row))
       :doc         doc
-      :bead        "rf2-a4x1o"
+      :bead        "rf2-6i0i2"
       :grade       grade
       :clock-note  clock-note
       :note        note
       :witness-set "rf2-2rtt6.2"
+      :rounds      rounds
+      :start-segment start
       ;; STATED ON THE ROW, because a reader comparing this against the
       ;; pre-rf2-zb3qg numbers is comparing two different windows and has to
       ;; be told so. 1 means the sample IS the operation.
@@ -1027,12 +1089,13 @@
         :M1)))
 
 (defn- run-round!
-  "One round of THIS PAGE'S row: both segments, in this round's order.
-  Answers a promise of `{segment-id readings}`."
-  [{:keys [kind witness] :as _spec} row-key r coll t legs]
+  "One round of THIS PAGE'S row: both segments, in this round's order —
+  `start` leads round 0 and the order alternates from there. Answers a
+  promise of `{segment-id readings}`."
+  [{:keys [kind witness] :as _spec} row-key start r coll t legs]
   (lane/chain
     {}
-    (segment-order r)
+    (segment-order start r)
     (fn [acc {:keys [id] :as segment}]
       (enter-segment! segment)
       ;; Checked immediately after the seam and before a single sample: a
@@ -1062,7 +1125,7 @@
         legs))
 
 (defn- publish!
-  [{:keys [kind witness row grade doc note control] :as _spec} row-key slices t legs coll]
+  [{:keys [kind witness row grade doc note control] :as _spec} row-key start slices t legs coll]
   (let [w   (witness-named witness)
         {:keys [record controls order]}
         (row-record {:row row
@@ -1071,7 +1134,8 @@
                      :clock-note (when (= kind :mount) (:clock-note w))
                      :note note
                      :control (or control (:control w))
-                     :writes-per-sample (if (= row :bulk-narrow) narrow-batch-k 1)}
+                     :writes-per-sample (if (= row :bulk-narrow) narrow-batch-k 1)
+                     :start start}
                     slices)]
     (lane/record! (name row) record)
     (lane/record! "verification" {row-key (lane/tally-value t)})
@@ -1080,6 +1144,8 @@
                   {:row row
                    :axis :clock
                    :witness-set "rf2-2rtt6.2"
+                   :rounds rounds
+                   :start-segment start
                    :threshold (select-keys (:red-zone record)
                                            [:mean :min :max :per-round :straddles-1?
                                             :claim :direction])
@@ -1153,10 +1219,12 @@
 
       :else
       (let [row-key (query-row)
+            start   (query-start)
             spec    (get row-specs row-key)
             w       (witness-named (:witness spec))
             {:keys [problems]} (parity! w)]
-        (js/console.log (str ";; HICASSO row " (name row-key)))
+        (js/console.log (str ";; HICASSO row " (name row-key)
+                             " — round 0 led by " (name start) ", alternating"))
         (lane/record! "parity"
                       {:row row-key :problems problems :ok? (empty? problems)
                        :note (str "canonical DOM with attribute names sorted, inside each "
@@ -1175,10 +1243,10 @@
                 legs (atom {})]
             (-> (lane/chain [] (range rounds)
                             (fn [acc r]
-                              (-> (run-round! spec row-key r coll t legs)
+                              (-> (run-round! spec row-key start r coll t legs)
                                   (.then (fn [slice] (conj acc slice))))))
                 (.then (fn [slices]
-                         (publish! spec row-key slices t legs coll)
+                         (publish! spec row-key start slices t legs coll)
                          (lane/done!)
                          nil))
                 (.catch (fn [e]

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
@@ -402,6 +402,22 @@
     :grade       :diagnostic
     :verify-of   verify-m2
     :elements-of v/m2-elements
+    ;; DEEPER WARM-UP THAN THE PAGE DEFAULT, and only here (rf2-6i0i2).
+    ;; This witness's readings are one to three of Chrome's 100 us quanta,
+    ;; so a one-quantum p50 step between the page's first and last thirds
+    ;; reads as a 2.0x-2.5x DISJOINT phase split and the arm-order guard
+    ;; refuses the run — which it did on four of the first six six-round
+    ;; invocations (uix-subs and both segments' floors, steps 2.0000x /
+    ;; 2.2857x / 2.5000x, every one exactly the page warming across a
+    ;; lattice point). The guard's own repair list starts with `more
+    ;; warm-up`, and that is the repair taken: 24 discarded mounts per
+    ;; segment-round put the first RECORDED sample past the knee. The
+    ;; measured window (one mount) is untouched; M1's readings are 30-50
+    ;; quanta where a one-quantum step is inside tolerance, so the page
+    ;; default stays at 8 there. Batching this row's mounts instead was
+    ;; REFUSED by the guard when rf2-2rtt6.2 tried it and is not
+    ;; re-litigated (see the clock-note below).
+    :sampling    {:warmup 24 :samples 12}
     ;; ONE mount per sample, exactly as rf2-2rtt6.2 publishes it. That arm
     ;; TRIED the batch that would lift this witness clear of Chrome's
     ;; 100 us clamp — eight 51-element roots in one flushSync — and THE
@@ -594,13 +610,14 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- mount-round!
-  [coll t {:keys [id props per-sample arms-for] :as witness} segment-id]
-  (let [arms   (arms-for segment-id)
+  [coll t {:keys [id props per-sample arms-for sampling] :as witness} segment-id]
+  (let [{:keys [warmup samples]} (or sampling mount-sampling)
+        arms   (arms-for segment-id)
         n      (count arms)
         k      (or per-sample 1)
         expect (into {} (map (juxt :id #(expectation witness %))) arms)
         acc    (atom (zipmap (map :id arms) (repeat [])))]
-    (dotimes [s (+ (:warmup mount-sampling) (:samples mount-sampling))]
+    (dotimes [s (+ warmup samples)]
       (doseq [j (lane/slot-order n s)]
         (let [arm (nth arms j)
               {:keys [ms mounts]} (lane/mount-batch! arm props k)
@@ -618,7 +635,7 @@
                          {:of (inc of) :bad (if ok? bad (inc bad))}))))
           (doseq [m mounts] (lane/release! m))
           (let [label (str (name id) "/" (name segment-id) "/" (name (:id arm)))]
-            (if (>= s (:warmup mount-sampling))
+            (if (>= s warmup)
               (do (lane/collect! coll label ms)
                   (swap! acc update (:id arm) conj ms))
               ;; A warm-up sample is DISCARDED but it still ran, so it is

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
@@ -402,22 +402,30 @@
     :grade       :diagnostic
     :verify-of   verify-m2
     :elements-of v/m2-elements
-    ;; DEEPER WARM-UP THAN THE PAGE DEFAULT, and only here (rf2-6i0i2).
-    ;; This witness's readings are one to three of Chrome's 100 us quanta,
-    ;; so a one-quantum p50 step between the page's first and last thirds
-    ;; reads as a 2.0x-2.5x DISJOINT phase split and the arm-order guard
-    ;; refuses the run — which it did on four of the first six six-round
-    ;; invocations (uix-subs and both segments' floors, steps 2.0000x /
-    ;; 2.2857x / 2.5000x, every one exactly the page warming across a
-    ;; lattice point). The guard's own repair list starts with `more
-    ;; warm-up`, and that is the repair taken: 24 discarded mounts per
-    ;; segment-round put the first RECORDED sample past the knee. The
-    ;; measured window (one mount) is untouched; M1's readings are 30-50
-    ;; quanta where a one-quantum step is inside tolerance, so the page
-    ;; default stays at 8 there. Batching this row's mounts instead was
-    ;; REFUSED by the guard when rf2-2rtt6.2 tried it and is not
-    ;; re-litigated (see the clock-note below).
-    :sampling    {:warmup 24 :samples 12}
+    ;; A SMALLER MOUNT BUDGET THAN THE PAGE DEFAULT, and only here
+    ;; (rf2-6i0i2). The sixth round pushed this page over the arm-order
+    ;; guard's phase gate: at the default 8+12 sampling a six-round M2
+    ;; page runs 720 mounts and FOUR OF SIX invocations were refused,
+    ;; every refusal a LAST-third-slower disjoint split (2.0x-2.5x) on
+    ;; readings of one to three 100 us quanta. The direction matters —
+    ;; the page DEGRADES as it runs, which is the per-page accumulation
+    ;; rf2-2rtt6.4 recorded and rf2-flqpd tied to collector debt, and the
+    ;; dose-response was measured rather than guessed: 600 mounts a page
+    ;; (the five-round budget) ran clean, 720 refused four of six, and a
+    ;; misdiagnosed `deeper warm-up` repair — 1,296 mounts — refused
+    ;; three of three with the split widened to 2.6x-4.0x. Warm-up depth
+    ;; FEEDS the accumulation; the lever is the page's TOTAL mount
+    ;; budget. So: 4 warm-up + 10 samples = 504 mounts a page at six
+    ;; rounds, back under the budget every clean run ran at, with the
+    ;; measured window (one mount) untouched and the tolerance untouched.
+    ;; Less warm-up is safe HERE because the failure is the tail, not the
+    ;; knee — a cold early sample pulls the FIRST third up, against the
+    ;; climb. M1's readings are 30-50 quanta on the same budget, where
+    ;; the same absolute drift is inside tolerance; it keeps the page
+    ;; default. Batching this row's mounts instead was REFUSED by the
+    ;; guard when rf2-2rtt6.2 tried it and is not re-litigated (see the
+    ;; clock-note below).
+    :sampling    {:warmup 4 :samples 10}
     ;; ONE mount per sample, exactly as rf2-2rtt6.2 publishes it. That arm
     ;; TRIED the batch that would lift this witness clear of Chrome's
     ;; 100 us clamp — eight 51-element roots in one flushSync — and THE

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs
@@ -12,10 +12,11 @@
   `docs/design/hicasso/studio/p0-converged-witness-set.md`, replayed:
   the run the red-zone table was taken from, and the independent
   four-row reproduction sweep (rf2-rjfz1) taken at main `32cb224d6e`.
-  Both are on the page, both are five rounds, and
-  `p0-converge-app/segment-order` alternates on the round index — so
-  rounds 0, 2, 4 are Reagent-first and rounds 1, 3 are UIx-first, in
-  both.
+  Both are on the page, both are five rounds, and both ran the only
+  schedule that existed before rf2-6i0i2 — round 0 led by the Reagent
+  segment, alternating — so rounds 0, 2, 4 are Reagent-first and rounds
+  1, 3 are UIx-first, in both, and every replay below says so with an
+  explicit `:reagent-subs` start.
 
   What the replay establishes, and it is the whole of rf2-a4x1o's second
   item:
@@ -68,7 +69,11 @@
    :broad  [0.5750 0.5263 0.6176 0.5556 0.7353]
    :narrow [1.2528 1.1591 1.1705 1.1507 1.1136]})
 
-(defn- v [vs] (app/segment-order-verdict vs 5))
+(defn- v
+  "Replay a PUBLISHED five-round vector. Every published five-round run
+  was Reagent-start, and the start is stated rather than defaulted."
+  [vs]
+  (app/segment-order-verdict vs 5 :reagent-subs))
 
 (defn- close? [a b] (< (js/Math.abs (- a b)) 0.0002))
 
@@ -164,7 +169,7 @@
            UIx-first rounds reading 0.7 is a figure that says `slower`
            when one segment leads and `faster` when the other does — no
            direction to publish, and the run must not"
-    (let [r (app/segment-order-verdict [1.40 0.70 1.45 0.72 1.38] 5)]
+    (let [r (app/segment-order-verdict [1.40 0.70 1.45 0.72 1.38] 5 :reagent-subs)]
       (is (= :numerator-slower (:direction (:reagent-first r))))
       (is (= :numerator-faster (:direction (:uix-first r))))
       (is (false? (:direction-agrees? r)))
@@ -183,10 +188,45 @@
       (is (= 3 (:n (:reagent-first r))))
       (is (= 2 (:n (:uix-first r))))))
   (testing "at an EVEN round count the two estimators coincide by
-           construction, which is the arm-level repair available to
-           whoever re-takes the table"
+           construction — the repair rf2-6i0i2 took, and the design the
+           entry now runs"
     (let [vs [1.10 1.20 1.30 1.40 1.50 1.60]
-          r  (app/segment-order-verdict vs 6)]
+          r  (app/segment-order-verdict vs 6 :reagent-subs)]
       (is (true? (:balanced-design? r)))
+      (is (= 3 (:n (:reagent-first r))))
+      (is (= 3 (:n (:uix-first r))))
       (is (close? 1.35 (:order-balanced-mean r))
           "= the raw mean of the six rounds, because 3:3 is balanced"))))
+
+;; ---------------------------------------------------------------------------
+;; The start is a parameter, and the strata follow the schedule that ran
+;; ---------------------------------------------------------------------------
+
+(deftest the-strata-are-keyed-by-the-segment-that-actually-led
+  (testing "flipping the start swaps which index-parity lands in which
+           stratum: a UIx-start run's even rounds ARE its UIx-first
+           rounds. Before rf2-6i0i2 the start was constant, so `Reagent
+           first` and `rounds 0, 2, 4` were the same set in every run —
+           which is exactly the confound the counterbalanced runs exist
+           to break"
+    (let [vs [1.30 1.10 1.25 1.12 1.35 1.11]
+          r  (app/segment-order-verdict vs 6 :reagent-subs)
+          u  (app/segment-order-verdict vs 6 :uix-subs)]
+      (is (= :reagent-subs (:start r)))
+      (is (= :uix-subs (:start u)))
+      (is (= [1.30 1.25 1.35] (:per-round (:reagent-first r))))
+      (is (= [1.10 1.12 1.11] (:per-round (:uix-first r))))
+      (is (= (:per-round (:reagent-first r)) (:per-round (:uix-first u)))
+          "the same readings land in the OPPOSITE stratum under the
+           flipped schedule")
+      (is (= (:per-round (:uix-first r)) (:per-round (:reagent-first u))))))
+  (testing "the refusal logic follows the strata, not the index parity: a
+           vector that refuses under one start refuses under the other
+           with the directions exchanged"
+    (let [vs [1.40 0.70 1.45 0.72 1.38 0.69]
+          r  (app/segment-order-verdict vs 6 :reagent-subs)
+          u  (app/segment-order-verdict vs 6 :uix-subs)]
+      (is (= :numerator-slower (:direction (:reagent-first r))))
+      (is (= :numerator-faster (:direction (:reagent-first u))))
+      (is (true? (:refuse? r)))
+      (is (true? (:refuse? u))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
@@ -111,7 +111,21 @@ if (ROWS.length === 0) {
   process.exit(1);
 }
 
-// A page's own budget. Five rounds of two segments with warm-up is
+// `HICASSO_START=reagent|uix` names the segment that leads round 0; the
+// order alternates from there. Default reagent — the only schedule any run
+// before rf2-6i0i2 had. A fixed start confounds segment order with temporal
+// position (Reagent-first was always rounds 0/2/4), so the segment-order
+// question is answered by COUNTERBALANCING the start across independently
+// launched runs — separate invocations of this driver, half each way — and
+// adjudicating at the run level. One invocation, whatever its start, is one
+// run and is never more than one trial.
+const START = (process.env.HICASSO_START || 'reagent').trim();
+if (!['reagent', 'uix'].includes(START)) {
+  console.error(`[converge] HICASSO_START=${START} is not a segment; known starts: reagent, uix`);
+  process.exit(1);
+}
+
+// A page's own budget. Six rounds of two segments with warm-up is
 // minutes, not seconds, and a loaded workstation is the normal case.
 const SENTINEL_TIMEOUT_MS = 20 * 60 * 1000;
 
@@ -184,7 +198,7 @@ async function runRow(browser, row) {
     // `'commit'`, not `'load'`. The bundle's `:init-fn` runs inside the
     // `<script>`, so the measurement happens while the document is still
     // loading and `load` cannot fire until it is over.
-    await navigate(page, `http://127.0.0.1:${PORT}/?row=${row.id}`, {
+    await navigate(page, `http://127.0.0.1:${PORT}/?row=${row.id}&start=${START}`, {
       waitUntil: 'commit',
       timeoutMs: NAV_TIMEOUT_MS,
       budget: `the ${SENTINEL_TIMEOUT_MS / 60000}-minute wait for window.HICASSO_DONE`,
@@ -246,10 +260,11 @@ async function runRow(browser, row) {
   // bare command: a published figure whose repro command does not reproduce
   // it is a figure nobody can check.
   console.log(
-    `;; reproduce  ${ONLY ? `HICASSO_ONLY=${ONLY} ` : ''}node ` +
+    `;; reproduce  ${ONLY ? `HICASSO_ONLY=${ONLY} ` : ''}${START !== 'reagent' ? `HICASSO_START=${START} ` : ''}node ` +
       `implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs`
   );
   console.log(`;; rows       ${ROWS.map((r) => r.id).join(', ')}${ONLY ? `  (HICASSO_ONLY=${ONLY})` : ''}`);
+  console.log(`;; start      round 0 led by ${START} (HICASSO_START), alternating`);
   for (const o of outcomes) {
     for (const [k, v] of Object.entries(o.results)) {
       console.log(`;; ==== HICASSO ${o.row.id} / ${k} ====`);


### PR DESCRIPTION
Closes **rf2-6i0i2**.

The page asserted a systematic segment-order effect on the strength of *11 of 12
row-runs, one-sided binomial p = 0.0032*. The PR #7283 audit was right that the
warrant did not exist, and this PR replaces the design that produced it rather
than re-arguing the arithmetic.

## What was wrong, and it was two things

**The twelve were not twelve.** Four rows measured inside one browser process
share a machine, a heap and a collector. They are four correlated readings of one
run, not four Bernoulli trials, so the honest sample was **n = 3** — and three
observations cannot reach p = 0.0032 under any arrangement.

**The design could not tell an order effect from a clock.** Every one of those
runs started with Reagent, so *Reagent led* and *rounds 0, 2, 4* named the same
set of rounds in every run. A page that gets slower as it runs produces the
identical partition — and this page does get slower as it runs, which the M2
finding below measures. Adding same-start runs cannot separate the two, because
each new run reproduces the same confound.

## The repair is the design

`rounds` 5 → 6, so the alternation splits 3:3, the raw mean and
`:order-balanced-mean` coincide **by construction**, and the per-row disjointness
null rate halves from 20% (2 of `C(5,2)`) to 10% (2 of `C(6,3)`). Which segment
leads round 0 becomes a per-run parameter (`?start=`, `HICASSO_START`), and the
strata are keyed by the segment that *actually led* rather than by round parity,
so they stay meaningful when the start flips.

Then **ten independently launched runs, counterbalanced five Reagent-start and
five UIx-start**, with the analysis pre-registered in the commit that balanced
the design — before any run — down to the statistic, the one-sided direction and
the designation of run 1 as the re-publication run.

## The inference, at the run level

`d = ln(Reagent-first stratum mean ÷ UIx-first stratum mean)`, one per run per
row, positive in the direction the original claim asserted. Counterbalancing
splits `d` into two components a fixed start had welded together: **the average
of the two start groups isolates the ORDER effect** (the temporal term cancels),
**half their difference isolates the TEMPORAL one** (the order effect cancels).

**View 1 — between runs, exact permutation over `C(10,5) = 252`.** No assumption
about the inside of a run. Which segment starts a run does not detectably move
the number that run publishes: p = 0.77 / 0.61 / 0.98 / 0.99 across the four
rows, with the narrow row's two groups agreeing to one part in ten thousand.

**View 2 — within run, the paired strata, exact sign-flip over `2¹⁰ = 1024`.**
The higher-powered view and the direct successor to the 11-of-12. The
pre-registered composite comes out at **−0.0200 — 2% on the *wrong* side of
zero** — 6 of 10 runs positive, p = 0.82. Two rows lean the claimed way and two
lean against it; the largest, M1's +3.6%, is p = 0.084 on one row of four.
Counted the old way, the sign is Reagent-first-higher in **23 of 40**, p = 0.21.

**What n = 5 vs 5 cannot do is prove an absence, and the page does not claim
one.** The resolution limits are printed beside the null results — ±0.04 on M1
and narrow, ±0.12 on M2 — and the honest bound is stated: an effect at the top of
the range previously asserted is excluded on every row (+9.7% / +6.5% / +4.4% /
+3.8% at the favourable end of each interval), while an effect of one or two
percent is *not* excluded and would not have been detectable at ten runs. It
would also not matter — it is smaller than the gap between two consecutive runs.

## The four rows, re-published

Superseded values are rewritten **in place**, not corrected beside.

| row | was | now | 95% interval on the mean | ten run means |
|---|---|---|---|---|
| M1 mount | ~~1.2301×~~ | **1.2310×** | 1.2105 – 1.2514 | 1.1989 – 1.2931 |
| M2 mount *(diagnostic)* | ~~1.0539×~~ | **1.0601×** | 1.0017 – 1.1185 | 0.9561 – 1.1923 |
| bulk broad | ~~0.6239×~~ | **0.6291×** | 0.5996 – 0.6587 | 0.5792 – 0.6987 |
| bulk narrow | ~~1.1540×~~ | **1.1754×** | 1.1579 – 1.1930 | 1.1390 – 1.2186 |

**The two withdrawn magnitudes are restored as intervals, and the conservative
holds are preserved where the ensemble does not resolve them.** M1's and narrow's
magnitudes were withdrawn on three grounds; all three are answered by the design
rather than by a friendlier run — the 3:2 bias is gone by construction, the
strata overlap in **9 of 10** runs on both rows, and ten estimates agree to ±4%
where four disagreed by ±6%. **M2 keeps its hold**: all ten runs straddle 1.0,
three read below it outright, and on legs of 4.5 to 11 quanta that is not a
direction. It stays diagnostic. **rf2-2rtt6.1's operator hold on `1.2301` is not
lifted** — that number is superseded rather than rehabilitated, and only the
operator amends the standard.

## The M2 finding — the lever is the mount budget, not warm-up depth

Adding the sixth round moved the M2 page from 600 mounts to 720 and the guard
refused **four of the first six invocations**, every one on M2's phase factor and
every one a *last*-third-slower disjoint split of 2.0×–2.5×. The first repair
taken was the obvious one — more warm-up — and it made things **worse**: 1,296
mounts a page, refused **three of three**, split widened to 2.6×–4.0×.

The direction was the tell. A cold page reads *first*-third-slower; these were
all *last*-third-slower. The page is not warming, it is **degrading as it runs** —
the per-page accumulation rf2-2rtt6.4 recorded and rf2-flqpd tied to collector
debt — and a warm-up mount is still a mount. The dose-response was measured:
600 clean, 720 refused 4 of 6, 1,296 refused 3 of 3, **504 clean over all 40
row-runs of the ensemble**. So M2 alone now carries `:sampling {:warmup 4
:samples 10}`, with the measured window and the tolerance both untouched.

**It changes how an M2 row is read**, which is why it is on the page: the M2 row
is sampled 10 deep off a 4-mount warm-up where every other row, and every
five-round M2 row, is 12 off 8. The six pre-repair invocations are not published.

## Provenance

- **The corrected run's placeholder is retired.** *"the landed SHA follows the
  merge"* is replaced with **`9737ed5cf815817d856c49eefb6824856df51668`**,
  verified on `origin/main`, with all six instrument blob hashes and the one-line
  check.
- **The ensemble records its own.** Authored anchor **`2a97274c0f`**, stated
  explicitly as an anchor that **a rebase-merge will replace with a new landed
  SHA** — so an audit mapping this page to `main` should expect it not to resolve
  as an ancestor and should check the blobs, which are pinned because a rebase
  cannot move a blob.

## Also observed, and reported rather than decided

**rf2-egdaq.** The ensemble yields **80 positive controls** — the first sample
large enough to price the strict-vs-overlap question that bead holds. All 80 pass
the overlap rule; **64 of 80** pass the strict every-round-inside reading, and the
failures fall *entirely* on the two rows whose control leg is a handful of
100 µs quanta. The number the ruling holds on reproduces exactly (worst M2 UIx
round `1.3333`, 8.4% below the band floor) — but the Reagent segment reaches
`1.1667`, **19.9% below**, more than twice the excursion being weighed. Recorded
as a `bd note` on rf2-egdaq; **the ruling is untouched**. A compact
pointer naming the superseded rows is on rf2-2rtt6.1.

## Quality gates

**The ten runs of the ensemble — every one foreground, every one `[converge] ok`
(exit 0), none re-run, none discarded:**

| run | start | exit | | run | start | exit |
|---|---|---|---|---|---|---|
| B1 | reagent | **0** | | B6 | uix | **0** |
| B2 | uix | **0** | | B7 | reagent | **0** |
| B3 | reagent | **0** | | B8 | uix | **0** |
| B4 | uix | **0** | | B9 | reagent | **0** |
| B5 | reagent | **0** | | B10 | uix | **0** |

Across those forty row-runs: arm-order guard `refuse? false`,
`contaminated? false`, `unchecked? false`, tolerance 0.10 — **all 40**;
canonical-DOM parity `{:problems [] :ok? true}` — **all 40**; segment-order
control no refusal on any row, `:balanced-design? true` on all 40; **0 unverified
of 92,160** writes; 80 of 80 positive controls pass.

| gate | result |
|---|---|
| `python -m mkdocs build --strict` | **exit 0**, zero warnings (bare `mkdocs` is not on PATH here) |
| internal anchor check on the rewritten page | **0 broken** of 34 headings |
| `npm run test:cljs` | **exit 0** — `Ran 11968 tests containing 59715 assertions. 0 failures, 0 errors.` |

**One flake, disclosed rather than buried.** The first `test:cljs` invocation
aborted the par-compile with no source error (the aborted resources were
`zprint`, `sci` and `tools/xray` namespaces, none of them reachable from this
diff) because a `mkdocs` build was running against the same box. The second
invocation compiled clean and failed four assertions in
`re-frame.test-quiet-shadow-node-cljs-test/real-shadow-node-green-run-is-quiet`
— all four downstream of one `spawnSync … ETIMEDOUT` on the nested runner it
shells out to, on a machine that had just finished ten browser benchmark sweeps.
The third invocation, on an idle box, is the green one recorded above. Nothing in
this diff can reach that namespace.

### The clj-kondo repair — a mutually-invalidating pair, not a defect in either half

`clj-kondo (fail on errors, warnings informational)` went red on
[run 30597398528](https://github.com/day8/re-frame2/actions/runs/30597398528/job/91053115299)
with `errors: 1`:

```
coldmount_app.cljs:542:19: error:
  p0-converge-app/segment-order-verdict is called with 2 args but expects 3
```

Neither half was wrong on its own. This branch gave `segment-order-verdict` a
third argument — the segment that leads round 0, which is what the strata are
keyed by once the start is counterbalanced instead of constant. PR #7300
(rf2-2rtt6.15) added `coldmount_app` against the two-argument signature while
this branch was open. Each was green alone; only their merge was not, and #7300
merged first, so the caller update belongs here.

The fix is at the call site and is semantic, not a silencing. Cold-mount's
`segment-order` takes no counterbalanced start — round 0 is even, so Reagent
leads it in every run of that entry — so `:reagent-subs` is the value the
verdict must receive, and it is derived from `segment-order` itself rather than
restated, which stops the stratum label and the schedule drifting apart. It
reproduces the partition cold-mount's own `strata-of` already documented
("Even rounds are Reagent-first"), so no published figure moves and the ten
measured runs above stand untouched. The branch was rebased onto `main` to pick
up #7300, which is where the two signatures first meet.

| gate | result |
|---|---|
| `clj-kondo` **v2026.04.15** (the CI-pinned binary), full CI argument list | **exit 0** — `errors: 0, warnings: 4526` |
| `shadow-cljs release hicasso-bench --config-merge …coldmount-app/-main` | **exit 0** — `164 files, 36 compiled, 0 warnings` |

The 4,526 warnings are the pre-existing informational baseline — the same count
CI reported — and were deliberately left alone; the gate fails on errors only.
No kondo configuration was weakened, suppressed or reconfigured.

No production code is touched. The files in this PR are the Hicasso bench
instrument, its order test, its driver, the studio page, and the one-call-site
arity repair in the cold-mount entry.

