### PR TITLE
spine: stop retaining the disposed render-phase reaction (rf2-2rtt6.13)

### DIFF
--- a/docs/design/hicasso/studio/coldmount-double-build-priced.md
+++ b/docs/design/hicasso/studio/coldmount-double-build-priced.md
@@ -231,6 +231,14 @@ the *retention* of the dead reaction, not the rebuild, so these fractions
 survive .13 unchanged in expectation; a post-.13 re-take would be a
 confirmation, not a correction.
 
+**That expectation has since been checked on the counting side.** rf2-2rtt6.13
+landed on 2026-07-31, and the spine ablation's witness re-run against the fixed
+spine reports `commits` 1.00N, `rebuilt` 1.00N, `bodyRuns` 2.00N on UIx against
+0/0/1.00N on Reagent — the same exact integers, twice over disjoint cells
+([the decomposition page](uix-spine-per-read-decomposition.md#the-fix-landed)).
+The double build is untouched by .13, so the fractions on this page stand. Their
+*clock* has not been re-taken post-.13, and this note does not claim it has.
+
 ---
 
 ## Instrument discipline

--- a/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
+++ b/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
@@ -27,6 +27,27 @@
 > `git log --oneline --all -- <path>` finds a commit carrying the blobs and
 > `git rev-parse <candidate>:<path>` confirms it.
 
+> **THE DEFECT THIS PAGE FOUND HAS BEEN FIXED (rf2-2rtt6.13, 2026-07-31).**
+> `re-frame.substrate.spine`'s render-phase `use-memo` now derefs while the
+> reaction is live and returns the **value**, so the disposed reaction is no
+> longer retained. **The shipped UIx read is 3,501 B → 2,734 B and 125.8 → 102.8
+> objects; UIx/Reagent 4.04× → 3.158×.** Every pre-fix figure on this page stands
+> as measured and is now historical; each section says which side of the fix it
+> is on, and [§ The fix, landed](#the-fix-landed) carries the after-run in full.
+>
+> The instrument's arms swapped polarity with it, because `xcript`'s contract is
+> to transcribe the **shipped** hook: `xcript` is now the value-returning shape
+> and the ablation is `retain`, the superseded one. Same two bodies, same single
+> differing expression; the subtraction reads `retain − xcript`.
+>
+> Blobs for the after-run: `spine_ablation.cljs`
+> `ee1ca916bfb02581c32c1a02e4266c7c6d309c76`, `spine_ablation_app.cljs`
+> `a1ae49372b1b6d7d443408446ded9dd19f44ecfb` (unchanged), `spine_ablation_run.cjs`
+> `10c49efbbe731ce02deda6e2ed432b0270d6beb6`, and the fixed spine
+> `implementation/core/src/re_frame/substrate/spine.cljs`
+> `56f7e5480c99330515d525a2bdacf5f86a0db7bd`. Authored as `4367e5d93f` on
+> `worker/spine-2rtt6-13`.
+
 Reproduce:
 
 ```bash
@@ -57,16 +78,18 @@ irreducible, and is any of it a defect?
 
 ## The answer, largest term first
 
-The shipped UIx read costs **3,501 B** and **125.8 objects**. It decomposes into
+*As measured before rf2-2rtt6.13. The third term is the one that is now gone.*
+
+The shipped UIx read cost **3,501 B** and **125.8 objects**. It decomposed into
 three terms that **sum to the whole with no residual**:
 
-| term | bytes/read | objects/read | share |
-|---|---:|---:|---:|
-| **one live subscription**, as the spine represents it | 1,684 `[1,660–1,687]` | 56.7 | 48.1% |
-| **React's six-hook stack** | 1,037 `[1,035–1,039]` | 46.1 | 29.6% |
-| **a second, disposed, unreachable reaction** | 769 `[765–793]` | 23.0 | 22.0% |
-| sum | 3,490 | 125.8 | 99.7% |
-| measured whole (`xcript`) | 3,489 `[3,488–3,492]` | 125.8 | |
+| term | bytes/read | objects/read | share | still paid? |
+|---|---:|---:|---:|---|
+| **one live subscription**, as the spine represents it | 1,684 `[1,660–1,687]` | 56.7 | 48.1% | yes |
+| **React's six-hook stack** | 1,037 `[1,035–1,039]` | 46.1 | 29.6% | yes |
+| **a second, disposed, unreachable reaction** | 769 `[765–793]` | 23.0 | 22.0% | **no — rf2-2rtt6.13** |
+| sum | 3,490 | 125.8 | 99.7% | |
+| measured whole (pre-fix) | 3,489 `[3,488–3,492]` | 125.8 | | |
 
 Reagent, measured in the same run on the same subs and the same page shape, pays
 **866 B / 31.5 objects** for the subscription half. So:
@@ -76,8 +99,10 @@ Reagent, measured in the same run on the same subs and the same page shape, pays
 * The subscription half costs the spine **1,684 B / 56.7 obj** against Reagent's
   **866 B / 31.5 obj** — **1.94×** for the same job, because the two adapters
   build different objects (below).
-* **22% of the read is waste**: a reaction that is built, disposed, and then
+* **22% of the read was waste**: a reaction that is built, disposed, and then
   retained for the lifetime of the component with no verb that can reach it.
+  That term is now zero on the shipped hook — see
+  [§ The fix, landed](#the-fix-landed).
 
 ---
 
@@ -95,10 +120,11 @@ period: the reaction the render phase just built is disposed and its cache slot
 evicted. The commit-phase `subscribe-fn` then misses the cache again and builds a
 **second** reaction.
 
-The first one does not go away. `use-memo` returns it into the fiber's hook slot,
-and `get-snap` closes over it as its pre-commit fallback. So a disposed reaction —
-no source watches, no cache slot, no `-dispose` left to call — is retained for as
-long as the component is mounted.
+The first one did not go away. `use-memo` returned it into the fiber's hook slot,
+and `get-snap` closed over it as its pre-commit fallback. So a disposed reaction —
+no source watches, no cache slot, no `-dispose` left to call — was retained for as
+long as the component stayed mounted. **rf2-2rtt6.13 closed this**; the second
+build is still there and is rf2-2rtt6.14's subject.
 
 **That is not a claim about bytes, so it was not settled with a heap instrument.**
 The page also mounts a small grid through a transcription carrying three counters.
@@ -147,9 +173,10 @@ that collection retained twice.
 
 ### 1,684 B / 56.7 obj — one live subscription, as the spine represents it
 
-`noretain − hooks`. Both arms allocate the query vector, the stable key, both
-refs and all six hooks, so this difference is the reaction, its cache entry, and
-the watch wiring, and nothing else.
+`xcript − hooks` (before the fix, `noretain − hooks` — the same body under its
+old name). Both arms allocate the query vector, the stable key, both refs and all
+six hooks, so this difference is the reaction, its cache entry, and the watch
+wiring, and nothing else.
 
 Reagent's arm pays **866 B / 31.5 obj** for the same job. The two adapters build
 different objects, and the gap is structural rather than accidental:
@@ -191,59 +218,103 @@ reads through hooks does not pay it.
 
 ### 769 B / 23.0 obj — the retained render-phase reaction
 
-`xcript − noretain`, the single-variable ablation described above.
+`retain − xcript` (before the fix, `xcript − noretain` — the same two bodies under
+their old names), the single-variable ablation described above.
 
 ---
 
-## The fix, priced
+## The fix, landed
 
-**Recommendation: land it, in `re-frame.substrate.spine`, as a separate reviewed
-change.** It is a production edit to a first-class shipped adapter and was
-deliberately not made under this bead.
+**Landed 2026-07-31 as rf2-2rtt6.13**, in `re-frame.substrate.spine`, as the
+separate reviewed change this page asked for. It was a production edit to a
+first-class shipped adapter and was deliberately not made under `rf2-2rtt6.12`.
 
-**The change.** The render-phase `use-memo` currently returns the reaction handle;
-have it deref the handle and return the **value**, and have `get-snap`'s pre-commit
-fallback read that value. Roughly six lines. Every `subs/subscribe` /
-`subs/unsubscribe` call, every hook and every watch stays exactly where it is.
+**The change.** The render-phase `use-memo` returned the reaction handle; it now
+derefs the handle **while the reaction is still live** and returns the **value**,
+and `get-snap`'s pre-commit fallback reads that value. Six lines. Every
+`subs/subscribe` / `subs/unsubscribe` call, every hook and every watch stayed
+exactly where it was — so the render is still net-zero and rf2-es09qq's
+no-retention-on-an-abandoned-render property is untouched.
 
-**Measured effect** (this is precisely what the `noretain` arm is):
+**Measured effect**, one run on this branch, four rounds, exit 0 under all six
+gates, the before and after arms measured **in the same run under the same order
+guard**:
 
-| | bytes/read | objects/read | vs Reagent |
+| arm | bytes/read | objects/read | vs Reagent |
 |---|---:|---:|---:|
-| shipped | 3,501 `[3,499–3,503]` | 125.8 | 4.04× |
-| with the fix | 2,720 `[2,698–2,722]` | 102.8 | **3.14×** |
+| `retain` — the superseded shape | 3,489 `[3,488–3,491]` | 125.8 | 4.030× |
+| **`uix` — shipped, after the fix** | **2,734** `[2,731–2,735]` | **102.8** | **3.158×** |
+| `xcript` — transcription of the shipped hook | 2,719 `[2,701–2,721]` | 102.8 | |
+| `hooks` | 1,036 `[1,035–1,040]` | 46.1 | |
+| `reagent` | 866 `[842–866]` | 31.5 | 1× |
 
-−769 B and −23.0 objects per read, −22%.
+−769 B `[767–789]` and −23.0 objects `[23.0–23.1]` per read, −22% — the term
+reproduced to the byte against the 769 B `[765–793]` / 23.0 obj this page
+published pre-fix.
+
+**The term is gone from the shipped hook, and the fidelity control is how you
+know.** `uix − xcript` is now 15 B (0.545%) and 0.05% on objects, both inside the
+pre-declared 3% band; before the fix that same subtraction against the
+value-returning body was the whole 769 B. The prediction this page made — 2,720 B
+`[2,698–2,722]` / 102.8 obj / 3.14× — was the transcription's number, and the
+transcription came back at 2,719 B, inside its own predicted range. The shipped
+arm sits 15 B above it, which is the ~0.5% offset the shipped arm has always
+carried against its copy (pre-fix: 3,501 vs 3,489, 0.33%).
 
 **Blast radius.** `make-react-spine` is shared by three substrates —
 `re-frame.adapter.uix` (first-class, shipped), `re-frame.freehand.substrate`, and
 `re-frame.ui.substrate`. One change, three beneficiaries.
 
-**Correctness.** The fallback stops being a live re-read. That window is covered:
+**Correctness.** The fallback stopped being a live re-read. That window is
+covered, and the covering mechanism is now pinned by a test rather than argued:
 
 * React's `useSyncExternalStore` calls `getSnapshot` again after `subscribe`
   returns, and by then `subscribe-fn` has published the committed reaction, so
   that call reads the **live** one and any app-db write landing between render
-  and commit is detected. This is not inferred from React's source — `bodyRuns =
-  2N` above measures it happening.
+  and commit is detected. It is React's own mount path that guarantees the
+  order — `subscribeToStore` is pushed as a passive effect **before**
+  `updateStoreInstance`, and passive effects run in push order — and
+  `assert-use-subscribe-render-phase-reaction-not-retained` reds if a React
+  upgrade ever reorders them.
+* What is given up is narrower than "the live re-read": on a **concurrent** lane
+  the render-phase store-consistency check no longer catches such a write, so the
+  corrective re-render happens one commit later instead of before the commit.
+  Both before and after, the corrective re-render happens.
 * A frozen value satisfies React's "the result of getSnapshot should be cached"
-  rule at least as well as the current live deref does.
+  rule at least as well as the previous live deref did.
 * The key-change path (rf2-naz09e) is unchanged in shape: the memo is keyed on
   `stable-key`, so a key change recomputes the snapshot for the **new** target and
-  the key guard still rejects the stale `committed-ref`.
+  the key guard still rejects the stale `committed-ref`. If anything it is now
+  *closer* to the Reagent substrate it is defined against, whose render-phase
+  value is likewise read once, in render.
 
-**What it does not fix.** Two reactions are still *built* per read on a first
-mount (`bodyRuns` stays 2N); the fix stops the first being *retained*. Removing the
-double build needs the cache to tolerate a ref-count-0 tenancy so the render-phase
-materialisation survives to be adopted by the commit — which is a change to
-`re-frame.subs` **and** to Spec 006 §Reference counting and disposal's
-no-grace-period rule. That is a ruling, not a patch, and is filed separately.
+**What it does not fix, and the witness says so unchanged.** Two reactions are
+still *built* per read on a first mount — the after-run's witness is `commits`
+1.00N, `rebuilt` 1.00N, `bodyRuns` 2.00N on UIx against 0/0/1.00N on Reagent,
+twice over disjoint cells, exactly as before. Retention was never what made the
+builds two. Removing the double build is rf2-2rtt6.14, **ruled ADOPT on
+2026-07-31** as a hook-scoped provisional hand-off (escrow token + macrotask reap
++ commit-time adoption), implemented by rf2-2rtt6.25 on these same lines and
+sequenced after this change.
 
 **Rejected alternative.** Making the fallback live *without* retention — having
 `get-snap` call `subs/subscribe-once` on the fallback path — is unsafe. Each call
 builds a fresh reaction with a fresh memo cell, so a sub returning a collection
 yields a fresh, non-`Object.is` value on every `getSnapshot`, which is React's
 documented infinite-render-loop condition.
+
+**How the change is pinned.** `assert-use-subscribe-render-phase-reaction-not-retained`
+(`implementation/core/test/re_frame/adapter/react_shared_suite.cljs`, run by the
+UIx DOM suite) asserts the property retention itself cannot expose: **every deref
+the spine performs, at any point in the component's lifetime, targets the reaction
+tenanted in the sub-cache at that moment.** Retention had a cause, and the cause is
+observable — the handle survived because `get-snap` closed over it, which is
+exactly what made the spine deref an evicted reaction. Verified load-bearing
+against the pre-fix spine, where it reds with the deref log
+`[{:gen 1 :tenant? false} {:gen 1 :tenant? false} {:gen 2 :tenant? true}]`: two
+pre-commit reads of the evicted handle, then React's post-subscribe `getSnapshot`
+call landing on the committed one — the ordering the fix depends on, observed on
+the code that predates it.
 
 ---
 
@@ -264,13 +335,20 @@ Same shape and same size as `rf2-2rtt6.5`'s, so the errors are directly comparab
 | reagent | 4,700,796 B, +0.017% | 4,700,751 B, +0.016% | 4,700,014 B, **0.000%** |
 
 **Fidelity control, on both readers.** An ablation is attributable only if the
-transcribed-but-unablated arm reproduces the shipped hook. Shipped `uix` 3,501
-`[3,499–3,503]`; transcription `xcript` 3,489 `[3,488–3,492]` — **0.332%
-apart**, inside the 3% band the driver declares before it measures. The band is
-an order of magnitude below the 22% term being resolved, so it cannot
+transcribed-but-unablated arm reproduces the shipped hook. Pre-fix: shipped `uix`
+3,501 `[3,499–3,503]`; transcription `xcript` 3,489 `[3,488–3,492]` — **0.332%
+apart**, inside the 3% band the driver declares before it measures. After the fix,
+with `xcript` transcribing the new shape: `uix` 2,734 `[2,731–2,735]` against
+`xcript` 2,719 `[2,701–2,721]` — **0.545% apart**, still well inside the band. The
+band is an order of magnitude below the 22% term being resolved, so it cannot
 manufacture the finding. **The object count is checked the same way** and lands
-0.045% apart, which matters because the object count is this page's headline and
-bytes are the cross-check.
+0.045% apart pre-fix, 0.050% after, which matters because the object count is this
+page's headline and bytes are the cross-check.
+
+This control is also what makes the after-run's central claim checkable rather
+than asserted. `uix` reproducing the *value-returning* body to 0.545% is the
+statement "the shipped hook no longer retains the reaction" in the instrument's
+own terms — the same subtraction that carried 769 B before the fix.
 
 Note which clause carries it: the two arms' *ranges do not overlap* — at four
 rounds these ranges are a few bytes wide — and it is the pre-declared 3% band
@@ -281,17 +359,20 @@ declared in the driver rather than chosen afterwards.
 rounds forward, odd rounds reversed, both reported separately. Its self-test (**11
 checks**, including the two repairs PR #7267 landed: the k=2 ordering degeneracy,
 and refusal when samples are silently lost) runs before the bundle is built.
-**Verdict: clean on both pages, no refusal.** Forward/reversed slopes: uix
-3,501/3,501, xcript 3,489/3,490, noretain 2,710/2,721, hooks 1,036/1,038,
-reagent 866/866.
+**Verdict: clean on both pages, no refusal**, before and after the fix.
+Forward/reversed slopes, pre-fix: uix 3,501/3,501, xcript 3,489/3,490, noretain
+2,710/2,721, hooks 1,036/1,038, reagent 866/866. After: uix 2,733/2,734, xcript
+2,711/2,720, retain 3,488/3,490, hooks 1,036/1,038, reagent 866/854.
 
 **Verification.** Every mount reads the DOM back against the boundary count the arm
-should have produced: **0 unverified of 154 mounts** across both pages.
+should have produced: **0 unverified of 154 mounts** across both pages pre-fix,
+**0 unverified of 154** after (119 on the uix page, 35 on the reagent page).
 
 **Linearity.** r² ≥ 0.9999 on all four UIx variants for bytes and for object counts.
 Reagent's is 0.9973 (bytes) / 0.9961 (objects) — visibly less linear, and its R=0
 rung is the reason: a Reagent boundary shell costs 427 B / 12.1 obj against UIx's
-~215 B / 5.2 obj.
+~215 B / 5.2 obj. The after-run reproduces both: UIx arms 0.99996–0.99998, Reagent
+0.99723 / 0.99606.
 
 **Readers.** A = `Runtime.getHeapUsage().usedSize`; B = in-page
 `performance.memory.usedJSHeapSize`; C = a full heap snapshot with every node's
@@ -305,7 +386,8 @@ within 0.1% on every arm (e.g. uix 3,501 vs 3,503; reagent 866 vs 865).
 ## Cross-checks against the ladder
 
 Different rung set (0/1/3/7 here, 0/1/3/7/20 there), different run, same box and
-same collector design.
+same collector design. **Both columns are pre-fix**, which is the only way the
+comparison means anything — the ladder was measured against the retaining spine.
 
 | | this page | `rf2-2rtt6.5` ladder | agreement |
 |---|---:|---:|---|
@@ -393,8 +475,8 @@ observations.
 
 ## What this page does not claim
 
-* It does not claim the 3.14× that remains after the fix is acceptable, or that it
-  is not. That is the P0 bar's question.
+* It does not claim the **3.158×** that remains after the fix is acceptable, or
+  that it is not. That is the P0 bar's question.
 * It does not claim the spine's derived-value representation should be flattened.
   It measures that the representation costs 1.94× Reagent's for the same job and
   stops there.

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -248,6 +248,9 @@
    :probe-refcount-element (fn [] (uix/$ ProbeRefcount))
    :rc-frame              :rf.uix-use-subscribe-test/refcount-frame
    :rc-query              :rf.uix-use-subscribe-test/m
+   ;; rf2-2rtt6.13 — its own frame (so its own sub-cache), because the
+   ;; assertion is only load-bearing on a COLD read and it says so.
+   :nr-frame              :rf.uix-no-retain/probe-frame
    ;; rf2-es09qq — Suspense abort-before-commit probe (reuses :rc-frame /
    ;; :rc-query so the abandoned render and the committed control mount race
    ;; on the SAME (frame, query)).
@@ -347,6 +350,13 @@
 ;; reaction hazard). Object-identity proof; reuses the refcount-probe surface.
 (deftest use-subscribe-getsnapshot-tracks-committed-reaction
   (suite/assert-use-subscribe-getsnapshot-tracks-committed-reaction cfg))
+
+;; rf2-2rtt6.13 — the disposed render-phase reaction must be unreachable: every
+;; deref the spine performs hits the sub-cache's CURRENT tenant, and the cold
+;; mount itself shows a deref of the committed reaction (React's post-subscribe
+;; getSnapshot call, which is what still catches a render→commit write).
+(deftest use-subscribe-render-phase-reaction-not-retained
+  (suite/assert-use-subscribe-render-phase-reaction-not-retained cfg))
 
 ;; rf2-naz09e — a query-v / frame change on a MOUNTED component must render the
 ;; NEW target's value on the change-commit (parity with Reagent's in-render

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -2268,25 +2268,28 @@
         (fn use-subscribe-2 [frame-kw query-v]
           (let [key-ref (React/useRef nil)
                 ;; Holds the DURABLE committed reaction (rf2-sqhjtu). The
-                ;; render-phase `reaction` handle below is a balanced,
-                ;; net-zero subscribe/unsubscribe round-trip whose value
-                ;; equals the committed one but whose IDENTITY can differ on
-                ;; first mount: with no prior cache entry the round-trip's
-                ;; 1 → 0 unsubscribe DISPOSES that handle (evicts it, removes
-                ;; its source watches), and `subscribe-fn` then rebuilds a
-                ;; fresh committed reaction post-commit. A disposed reaction
-                ;; still recomputes on `-deref` (pull-based), so reading it
-                ;; from `get-snap` LOOKS correct for ordinary app-db updates
-                ;; — but it no longer holds source watches and, crucially,
-                ;; still closes over the OLD sub body. On sub re-registration
-                ;; / hot-reload the cache rebuilds the committed reaction with
-                ;; the v2 body while a `get-snap` pinned to the disposed v1
-                ;; handle keeps rendering v1 output. React's
-                ;; `useSyncExternalStore` contract requires `getSnapshot` to
-                ;; read a stable, LIVE source — so `get-snap` reads the
-                ;; committed reaction stored here once `subscribe-fn` has run
-                ;; (post-commit), falling back to the render-phase handle only
-                ;; for the very first pre-commit snapshot.
+                ;; render-phase `use-memo` below takes a balanced, net-zero
+                ;; subscribe/unsubscribe round-trip to READ a snapshot. With
+                ;; no prior cache entry that round-trip's 1 → 0 unsubscribe
+                ;; DISPOSES the reaction it just built (evicts it, removes its
+                ;; source watches) and `subscribe-fn` builds a fresh committed
+                ;; one post-commit — a DIFFERENT object.
+                ;;
+                ;; `get-snap` must never read that disposed handle. A disposed
+                ;; reaction still recomputes on `-deref` (pull-based), so
+                ;; deref-ing it LOOKS correct for ordinary app-db updates —
+                ;; but it holds no source watches and still closes over the
+                ;; OLD sub body. On sub re-registration / hot-reload the cache
+                ;; rebuilds the committed reaction with the v2 body while a
+                ;; `get-snap` pinned to the disposed v1 handle keeps rendering
+                ;; v1 output. React's `useSyncExternalStore` contract requires
+                ;; `getSnapshot` to read a stable, LIVE source — so `get-snap`
+                ;; reads the committed reaction stored here once
+                ;; `subscribe-fn` has run (post-commit), falling back to the
+                ;; render-phase SNAPSHOT VALUE (`render-snapshot` below) only
+                ;; for the pre-commit reads. Since rf2-2rtt6.13 that fallback
+                ;; is a value and not a handle, so the disposed reaction is not
+                ;; merely un-preferred — it is unreachable.
                 ;;
                 ;; rf2-naz09e: the ref stores the committed reaction KEY-TAGGED
                 ;; as `#js [stable-key committed]` (see `subscribe-fn` and
@@ -2330,17 +2333,17 @@
                 ;; doesn't commit, so an abandoned render acquires NOTHING — the
                 ;; leak is gone BY CONSTRUCTION, independent of fiber discard.
                 ;;
-                ;; The render phase still needs a reaction HANDLE to read a
-                ;; snapshot for `useSyncExternalStore`. It obtains one with a
-                ;; BALANCED, net-zero round-trip — `subs/subscribe` immediately
-                ;; followed by `subs/unsubscribe` — so the render contributes ZERO
+                ;; The render phase still needs a SNAPSHOT to hand
+                ;; `useSyncExternalStore`. It reads one with a BALANCED,
+                ;; net-zero round-trip — `subs/subscribe`, deref, then
+                ;; `subs/unsubscribe` — so the render contributes ZERO
                 ;; outstanding ref-count whether or not it commits.
                 ;;
                 ;; In the COMMITTED steady state this round-trip is free of
                 ;; dispose churn: the `subscribe-fn` below holds a durable +1, so
                 ;; the render-phase subscribe bumps to 2 and the immediate
                 ;; unsubscribe drops back to 1 — never crossing the 1 → 0 disposal
-                ;; edge. The handle is the live cached reaction. The ONLY render
+                ;; edge. The reaction deref-ed is the live cached one. The ONLY render
                 ;; with no durable backing is the FIRST mount before commit (and
                 ;; any never-committed render): there the round-trip disposes +
                 ;; rebuilds, but per rf2-cmfln the rebuilt value `=` the disposed
@@ -2356,37 +2359,83 @@
                 ;;     so a discarded+rebuilt memo nets zero regardless of how many
                 ;;     times React re-runs it. No climb.
                 ;; Per Spec 006 §Reference counting and disposal (rf2-cmfln).
-                reaction
+                ;;
+                ;; ---- the memo yields the VALUE, never the handle (rf2-2rtt6.13) ----
+                ;;
+                ;; On a first mount the round trip is 0 → 1 → 0, and 1 → 0 is the
+                ;; disposal edge (`re-frame.subs.cache/unsubscribe!` disposes
+                ;; in-tick, no grace period), so the reaction it built is DEAD
+                ;; before the factory returns: no source watches, no cache slot,
+                ;; no verb that can reach it. Returning that handle RETAINED it
+                ;; for the component's lifetime — `use-memo`'s hook slot held it
+                ;; and `get-snap`'s closure held it — at a measured 769 B
+                ;; `[765–793]` / 23.0 objects per read, 22% of every UIx
+                ;; subscription read (docs/design/hicasso/studio/uix-spine-per-
+                ;; read-decomposition.md; instrument landed 24e8822d7f).
+                ;;
+                ;; So deref INSIDE the round trip — while the reaction is still
+                ;; live — and return the VALUE. Nothing holds the reaction once
+                ;; the factory returns. Every `subs/subscribe` /
+                ;; `subs/unsubscribe` call, every hook and every watch stays
+                ;; exactly where it was, so the render is still net-zero and
+                ;; rf2-es09qq's abandoned-render property is untouched. The
+                ;; double BUILD is untouched too — that is rf2-2rtt6.14's ruling,
+                ;; implemented by rf2-2rtt6.25 on these same lines.
+                render-snapshot
                 (use-memo (fn []
-                            ;; Net-zero render-phase fetch of the reaction handle:
-                            ;; subscribe to read the cached reaction, then release
-                            ;; immediately so the render retains no ref-count. An
-                            ;; abandoned render leaks nothing; a committed render's
-                            ;; durable ref is taken later in `subscribe-fn`.
-                            (let [r (subs/subscribe stable-query-v {:frame stable-frame-kw})]
+                            ;; Net-zero render-phase READ of the snapshot:
+                            ;; subscribe, deref while the reaction is live, then
+                            ;; release immediately so the render retains neither a
+                            ;; ref-count nor a handle. An abandoned render leaks
+                            ;; nothing; a committed render's durable ref is taken
+                            ;; later in `subscribe-fn`.
+                            (let [r (subs/subscribe stable-query-v {:frame stable-frame-kw})
+                                  v (when r @r)]
                               (subs/unsubscribe stable-frame-kw stable-query-v)
-                              r))
+                              v))
                           #js [stable-key])
                 ;; The store-snapshot fn React calls on every render to
                 ;; detect tearing. Pure deref of the LIVE committed reaction.
                 ;;
                 ;; rf2-sqhjtu: prefer the durable committed reaction stored in
                 ;; `committed-ref` by `subscribe-fn` (set post-commit, cleared
-                ;; on teardown). The render-phase `reaction` handle is only the
-                ;; fallback for the FIRST pre-commit snapshot — before React has
-                ;; run `subscribe-fn`, `committed-ref` is still nil and the
-                ;; balanced render-phase handle is the only thing to read. Once
-                ;; committed, `get-snap` tracks the live cached reaction (the
-                ;; one carrying source watches and the current sub body), never
-                ;; a disposed first-render handle. The committed reaction's
-                ;; value `=` the render-phase one (rf2-cmfln), so the source
-                ;; swap is tear-free.
+                ;; on teardown). `render-snapshot` — the VALUE the render-phase
+                ;; round trip read — is only the fallback for the pre-commit
+                ;; snapshot: before React has run `subscribe-fn`,
+                ;; `committed-ref` is still nil and that value is the only
+                ;; thing to read. Once committed, `get-snap` tracks the live
+                ;; cached reaction (the one carrying source watches and the
+                ;; current sub body), never a disposed first-render handle —
+                ;; which since rf2-2rtt6.13 it could not reach anyway. The
+                ;; committed reaction's value `=` the render-phase one
+                ;; (rf2-cmfln), so the source swap is tear-free.
+                ;;
+                ;; rf2-2rtt6.13 — the fallback stops being a LIVE re-read, and
+                ;; the render→commit window stays covered. React's
+                ;; `useSyncExternalStore` mount path pushes its `subscribeToStore`
+                ;; passive effect BEFORE its `updateStoreInstance` one, and
+                ;; passive effects run in push order; `updateStoreInstance` then
+                ;; calls `getSnapshot` again and force-re-renders if the result
+                ;; moved. So by the time that second call runs, `subscribe-fn`
+                ;; has already published the committed reaction and the call
+                ;; reads the LIVE one — an app-db write landing between render
+                ;; and commit is still detected, one commit later than a live
+                ;; fallback would have caught it on a concurrent lane. A frozen
+                ;; value also satisfies React's "the result of getSnapshot
+                ;; should be cached" rule at least as well as a live deref.
+                ;;
+                ;; The rejected alternative — keeping the fallback live WITHOUT
+                ;; retention, by having `get-snap` re-subscribe per call — is
+                ;; unsafe: each call would build a fresh reaction with a fresh
+                ;; memo cell, so a collection-returning sub yields a fresh,
+                ;; non-`Object.is` value on every `getSnapshot`, which is
+                ;; React's documented infinite-render-loop condition.
                 ;;
                 ;; rf2-naz09e — the committed reaction is stored KEY-TAGGED as
                 ;; `#js [stable-key committed]`, and `get-snap` reads it ONLY
                 ;; when the stored key is `identical?` the CURRENT render's
-                ;; `stable-key`; otherwise it falls back to the render-phase
-                ;; handle. This closes the KEY-CHANGE window. When query-v /
+                ;; `stable-key`; otherwise it falls back to `render-snapshot`.
+                ;; This closes the KEY-CHANGE window. When query-v /
                 ;; frame change on a mounted component, `committed-ref`
                 ;; transiently still holds the PREVIOUS target's reaction — the
                 ;; old `subscribe-fn`'s ref-clearing cleanup is a passive effect
@@ -2398,28 +2447,29 @@
                 ;; layout-effect / ref read deterministically observes and which
                 ;; under a transition lane can paint before the passive-phase
                 ;; store-consistency check forces a corrective re-render. The
-                ;; render-phase `reaction` memo is keyed on `#js [stable-key]`,
-                ;; so on a key change it already holds the NEW target: the
+                ;; `render-snapshot` memo is keyed on `#js [stable-key]`, so on
+                ;; a key change it already holds the NEW target's value: the
                 ;; fallback serves the NEW value for that very commit, matching
-                ;; the Reagent substrate's in-render recompute (no tear). The
+                ;; the Reagent substrate's in-render recompute (no tear) — and
+                ;; matching it more closely than before, since Reagent's
+                ;; render-phase value is likewise read once, in render. The
                 ;; earlier claim — "once committed-ref is populated post-commit,
                 ;; get-snap's identity is irrelevant to correctness" — was
                 ;; UNTRUE across a key change: committed-ref points at the WRONG
                 ;; (old) reaction until the passive cleanup runs.
                 ;;
-                ;; Deps include `reaction` so the fallback path always closes
-                ;; over the CURRENT render's handle — both the pre-commit first
-                ;; snapshot AND the key-change render — never a stale
+                ;; Deps include `render-snapshot` so the fallback path always
+                ;; closes over the CURRENT render's value — both the pre-commit
+                ;; first snapshot AND the key-change render — never a stale
                 ;; perf-discarded one.
                 get-snap
                 (use-callback (fn []
-                                (let [stored (.-current committed-ref)
-                                      r (if (and stored
-                                                 (identical? (aget stored 0) stable-key))
-                                          (aget stored 1)
-                                          reaction)]
-                                  (when r @r)))
-                              #js [stable-key reaction])
+                                (let [stored (.-current committed-ref)]
+                                  (if (and stored
+                                           (identical? (aget stored 0) stable-key))
+                                    (let [r (aget stored 1)] (when r @r))
+                                    render-snapshot)))
+                              #js [stable-key render-snapshot])
                 ;; The store-subscribe fn — React's COMMIT-OWNED acquire/release
                 ;; pair. React calls it (once) only AFTER a commit, passing a
                 ;; force-update callback; its returned cleanup runs on unmount,
@@ -2430,13 +2480,13 @@
                 ;; (frame, query) here rather than trust the render-phase handle's
                 ;; ref-count (which was balanced to zero).
                 ;;
-                ;; MEMOIZED ON `[stable-key]`, NOT `[reaction]` (rf2-es09qq). The
-                ;; render-phase handle object can differ from the committed one
-                ;; on first mount (the balanced round-trip may dispose + rebuild
-                ;; the reaction before `subscribe-fn` re-acquires it), so keying
-                ;; on `reaction` would change subscribe-fn identity right after
-                ;; the first commit — forcing React to release (dispose) and
-                ;; re-acquire the durable ref every time the handle churned.
+                ;; MEMOIZED ON `[stable-key]`, NOT on the render-phase memo
+                ;; (rf2-es09qq). The render-phase reaction can differ from the
+                ;; committed one on first mount (the balanced round-trip may
+                ;; dispose + rebuild it before `subscribe-fn` re-acquires), so
+                ;; keying on anything derived from it would change subscribe-fn
+                ;; identity right after the first commit — forcing React to
+                ;; release (dispose) and re-acquire the durable ref on churn.
                 ;; `stable-key` is identity-stable for a fixed (frame, query), so
                 ;; React calls subscribe-fn exactly ONCE per subscription target:
                 ;; one durable acquire, one release, no churn. The watch is added
@@ -2448,8 +2498,8 @@
                   (fn [on-change]
                     ;; Take the durable committed ref now (post-commit). This is
                     ;; the ONLY place a lasting +1 is acquired. The returned
-                    ;; reaction is the live cached one and `=` (often identical)
-                    ;; to the render-phase handle `reaction`.
+                    ;; reaction is the live cached one and its value `=` the
+                    ;; `render-snapshot` the render phase read.
                     (let [committed (subs/subscribe stable-query-v {:frame stable-frame-kw})]
                       ;; rf2-sqhjtu / rf2-naz09e: publish the durable committed
                       ;; reaction KEY-TAGGED with this invocation's `stable-key`

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -4548,6 +4548,157 @@
             (finally
               (try (.unmount root) (catch :default _ nil))))))))))
 
+;; ---- the disposed render-phase reaction is unreachable (rf2-2rtt6.13) -----
+;;
+;; THE DEFECT. `use-subscribe`'s render-phase `use-memo` used to return the
+;; reaction HANDLE its balanced round trip had just built. On a cold read that
+;; round trip is 0 → 1 → 0 and 1 → 0 is the disposal edge, so the handle it
+;; returned was already dead — no source watches, no cache slot, no verb that
+;; can reach it — and `use-memo`'s hook slot plus `get-snap`'s closure then held
+;; it for the component's lifetime. Measured at 769 B [765–793] / 23.0 objects
+;; per read, 22% of every UIx subscription read
+;; (docs/design/hicasso/studio/uix-spine-per-read-decomposition.md). The memo now
+;; derefs INSIDE the round trip, while the reaction is still live, and returns
+;; the VALUE.
+;;
+;; WHY THIS SHAPE OF PROOF. Retention is not directly assertable — there is no
+;; deterministic GC to ask. But retention had a CAUSE that is assertable: the
+;; handle survived because `get-snap` closed over it, and `get-snap` closing over
+;; it is precisely what made the spine deref a DISPOSED reaction on the
+;; pre-commit snapshot. So the property pinned here is the sharper, observable
+;; one, and it implies the other:
+;;
+;;   EVERY deref the spine performs, at any point in the component's lifetime,
+;;   targets the reaction TENANTED in the sub-cache slot at that moment.
+;;
+;; A `subs/subscribe` spy wraps each returned reaction in a proxy that records,
+;; per deref, the reaction's generation AND whether it was the cache's tenant at
+;; that instant. Pre-fix the pre-commit `getSnapshot` deref lands on the evicted
+;; handle and the tenancy flag is false on the very first mount.
+;;
+;; AND THE PROPERTY THE FIX LEANS ON. The pre-commit fallback stops being a live
+;; re-read, so a write landing between render and commit is no longer caught by
+;; the render-phase store-consistency check. It is still caught, one step later,
+;; because React's `useSyncExternalStore` mount path pushes its `subscribeToStore`
+;; passive effect BEFORE its `updateStoreInstance` one and passive effects run in
+;; push order: `updateStoreInstance` calls `getSnapshot` AGAIN — after
+;; `subscribe-fn` has published the committed reaction — and force-re-renders if
+;; the value moved. That ordering is React's, not ours, so it is pinned here: a
+;; cold mount MUST show at least one deref of the COMMITTED reaction. If a React
+;; upgrade ever reorders those two effects, the frozen fallback becomes the last
+;; word and this assertion is what says so.
+;;
+;; The rf2-es09qq ref-count property is unchanged by construction (no
+;; subscribe/unsubscribe call moved) and is re-asserted here as a control.
+
+(defn assert-use-subscribe-render-phase-reaction-not-retained
+  "rf2-2rtt6.13: the spine must never deref a disposed reaction — the
+  render-phase handle is deref-ed once, while it is still the sub-cache's
+  tenant, and is unreachable thereafter (it is not retained by the memo slot or
+  by `get-snap`). Proven by object identity plus a per-deref tenancy check. Also
+  pins the ordering the frozen fallback depends on: React calls `getSnapshot`
+  again AFTER `subscribe` returns, so the committed reaction is deref-ed during
+  the cold mount itself.
+
+  cfg keys: reuses the refcount-probe surface, on its own frame
+    :probe-refcount-element / :refcount-target / :rc-query / :nr-frame"
+  [{:keys [name probe-refcount-element refcount-target rc-query nr-frame]}]
+  (testing (str name " — use-subscribe never derefs a disposed reaction; the render-phase handle is not retained (rf2-2rtt6.13)")
+    (with-browser-act
+     (fn [act-fn]
+      (reset! refcount-target nr-frame)
+      (rf/make-frame {:id nr-frame :doc "rf2-2rtt6.13 no-retention probe frame"})
+      (rf/reg-event ::nr-seed (fn [_ _] {:db {:m 0}}))
+      (rf/dispatch-sync [::nr-seed] {:frame nr-frame})
+      (rf/reg-event ::nr-inc (fn [{:keys [db]} _] {:db {:m (inc (:m db))}}))
+      (rf/reg-sub rc-query (fn [db _] (:m db)))
+      (let [cache-key-v    [rc-query]
+            cache          (:sub-cache (frame/frame nr-frame))
+            real-subscribe subs/subscribe
+            gen-counter    (atom 0)
+            real->gen      (atom {})
+            ;; One entry per deref, in order: the reaction's generation, and
+            ;; whether that reaction was the cache slot's tenant AT THAT MOMENT.
+            deref-log      (atom [])
+            gen-of         (fn [real]
+                             (or (get @real->gen real)
+                                 (let [g (swap! gen-counter inc)]
+                                   (swap! real->gen assoc real g)
+                                   g)))
+            tenant?        (fn [real]
+                             (identical? real (get-in @cache [cache-key-v :reaction])))
+            wrap           (fn [real]
+                             (let [g (gen-of real)]
+                               (reify
+                                 IDeref
+                                 (-deref [_]
+                                   (swap! deref-log conj {:gen g :tenant? (tenant? real)})
+                                   @real)
+                                 IWatchable
+                                 (-add-watch [this k f]
+                                   (add-watch real k (fn [_ _ old nu] (f k this old nu)))
+                                   this)
+                                 (-remove-watch [_ k] (remove-watch real k) nil)
+                                 (-notify-watches [_ _o _n] nil))))
+            mount-node     (make-mount-node!)
+            root           (react-dom-client/createRoot mount-node)]
+        ;; The whole point is a COLD read — a live cache entry would make the
+        ;; render-phase round trip a hit (n → n+1 → n), never cross the disposal
+        ;; edge, and prove nothing. Say so rather than pass vacuously.
+        (is (nil? (get @cache cache-key-v))
+            "precondition: no live cache entry, so the mount is genuinely COLD")
+        (with-redefs [subs/subscribe
+                      (fn spy-subscribe
+                        ([query-v]
+                         (wrap (real-subscribe query-v {:frame (frame/resolve-current-frame)})))
+                        ([query-v opts]
+                         (wrap (real-subscribe query-v opts))))]
+          (try
+            (act-fn (fn [] (.render root (probe-refcount-element))))
+            (let [committed-real (get-in @cache [cache-key-v :reaction])
+                  committed-gen  (get @real->gen committed-real)]
+              (is (= 1 (or (get-in @cache [cache-key-v :ref-count]) 0))
+                  "after mount exactly one durable committed ref is pinned (rf2-es09qq, unchanged)")
+              (is (some? committed-gen)
+                  "the committed cached reaction was seen through the subscribe spy")
+              (is (seq @deref-log)
+                  "the cold mount drove at least one deref")
+              ;; THE LOAD-BEARING ASSERTION. Pre-fix, `get-snap`'s pre-commit
+              ;; fallback derefs the render-phase handle AFTER the round trip
+              ;; evicted it — tenancy false, on the very first mount.
+              (is (every? :tenant? @deref-log)
+                  (str "every deref during the cold mount hit the reaction tenanted "
+                       "in the sub-cache at that moment — never a disposed, evicted "
+                       "handle. Observed " @deref-log))
+              ;; THE ORDERING THE FROZEN FALLBACK DEPENDS ON.
+              (is (some #(= committed-gen (:gen %)) @deref-log)
+                  (str "React called getSnapshot again AFTER subscribe-fn published "
+                       "the committed reaction (gen " committed-gen "), so a write "
+                       "landing between render and commit is still detected. "
+                       "Observed " @deref-log))
+              ;; The property holds for the whole lifetime, not just the mount:
+              ;; a forced re-render and a dispatch-driven update both read the
+              ;; live committed reaction and nothing else.
+              (reset! deref-log [])
+              (act-fn (fn [] (.render root (probe-refcount-element))))
+              (act-fn (fn [] (rf/dispatch-sync [::nr-inc] {:frame nr-frame})))
+              (is (= "m=1" (.-textContent mount-node))
+                  "post-dispatch the snapshot reflects the new value")
+              (is (seq @deref-log)
+                  "the re-render + dispatch drove at least one deref")
+              (is (every? :tenant? @deref-log)
+                  (str "post-mount every deref still hit the cache's tenant. Observed "
+                       @deref-log))
+              (is (every? #(= committed-gen (:gen %)) @deref-log)
+                  (str "post-mount every deref hit the COMMITTED reaction (gen "
+                       committed-gen "). Observed " @deref-log)))
+            (act-fn (fn [] (.unmount root)))
+            (is (or (nil? (get @cache cache-key-v))
+                    (zero? (or (get-in @cache [cache-key-v :ref-count]) 0)))
+                "post-unmount the committed ref is released (no leak from the proxy path)")
+            (finally
+              (try (.unmount root) (catch :default _ nil))))))))))
+
 ;; ---- key-change serves the NEW target (rf2-naz09e) ------------------------
 ;;
 ;; THE BUG (UIx shared spine only — Reagent recomputes in-render and

--- a/implementation/freehand/test/re_frame/freehand/bench/spine_ablation.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/spine_ablation.cljs
@@ -15,7 +15,7 @@
   `useMemo` and two `useCallback`s do not come to 128 objects, so the
   spine is holding something the hook stack does not account for.
 
-  Reading `re-frame.substrate.spine/use-subscribe` says what. The render
+  Reading `re-frame.substrate.spine/use-subscribe` said what. The render
   phase takes a BALANCED round trip — `subs/subscribe` immediately
   followed by `subs/unsubscribe` — so that a render which never commits
   retains no ref-count (rf2-es09qq). For a query with no prior cache
@@ -24,25 +24,30 @@
   evicted (`re-frame.subs.cache/unsubscribe!`, no grace period). The
   commit-phase `subscribe-fn` then misses the cache again and builds a
   SECOND reaction. Two reactions are built per read — and the first one
-  does not go away, because `use-memo` returns it into the fiber's hook
-  slot and the `get-snap` callback closes over it as its pre-commit
-  fallback. A disposed, unreachable-by-any-verb reaction is retained for
+  did not go away, because `use-memo` returned it into the fiber's hook
+  slot and the `get-snap` callback closed over it as its pre-commit
+  fallback. A disposed, unreachable-by-any-verb reaction was retained for
   the lifetime of the component.
 
-  That is a hypothesis about retained bytes, so it is settled by a
-  retention measurement and not by reading.
+  That was a hypothesis about retained bytes, so it was settled by a
+  retention measurement and not by reading — 769 B `[765-793]` / 23.0
+  objects per read, 22% of the read. rf2-2rtt6.13 then landed the fix
+  (the memo derefs while live and returns the VALUE), which is why the
+  arms below read as they now do; see THE POLARITY FLIPPED, at the foot
+  of this docstring. The DOUBLE BUILD is untouched and is rf2-2rtt6.14's
+  subject — the witness at the end of this file still counts it.
 
   ## The ablation
 
   Four UIx arms, differing by ONE term each, all reading the same
   `[:abl/cell i]` subs in the same frame at 1,200 boundaries:
 
-  | arm        | what it is                                                  |
-  |------------|-------------------------------------------------------------|
-  | `uix`      | the SHIPPED `re-frame.adapter.uix/use-subscribe`             |
-  | `xcript`   | a transcription of the shipped hook, term for term           |
-  | `noretain` | the transcription with the render-phase reaction NOT held    |
-  | `hooks`    | the same six hooks over a trivial JS store — no re-frame     |
+  | arm       | what it is                                                   |
+  |-----------|--------------------------------------------------------------|
+  | `uix`     | the SHIPPED `re-frame.adapter.uix/use-subscribe`              |
+  | `xcript`  | a transcription of the shipped hook, term for term            |
+  | `retain`  | the transcription WITH the render-phase reaction held         |
+  | `hooks`   | the same six hooks over a trivial JS store — no re-frame      |
 
   `xcript` is the FIDELITY CONTROL and it is the reason the other two
   mean anything: an ablation is only attributable if the unablated
@@ -53,20 +58,30 @@
 
   The differences then read off directly:
 
-      uix - noretain   the retained render-phase reaction
-      noretain - hooks one live subscription as the spine pays for it
+      retain - xcript  the retained render-phase reaction
+      xcript - hooks   one live subscription as the spine pays for it
       hooks  - floor   React's own six-hook stack, per read
       reagent          the subscription half BOTH substrates pay
 
-  `noretain` differs from `xcript` in exactly one expression: its
-  render-phase `use-memo` derefs the reaction and returns the VALUE
-  rather than the reaction itself, and `get-snap`'s pre-commit fallback
-  reads that value. Every `subs/subscribe` / `subs/unsubscribe` call, every
-  hook, every deps array and every watch is otherwise identical — so the
-  build/dispose/rebuild CHURN is still paid on both sides and the delta
-  isolates RETENTION alone. `noretain` is a MEASUREMENT ARM, not a
-  proposed patch: it drops the live-reread property of the current
-  fallback (see the studio page).
+  `retain` differs from `xcript` in exactly one expression: its
+  render-phase `use-memo` returns the reaction itself rather than
+  deref-ing it for the VALUE, and `get-snap`'s pre-commit fallback then
+  closes over that handle. Every `subs/subscribe` / `subs/unsubscribe`
+  call, every hook, every deps array and every watch is otherwise
+  identical — so the build/dispose/rebuild CHURN is still paid on both
+  sides and the delta isolates RETENTION alone.
+
+  ## THE POLARITY FLIPPED WHEN THE FIX LANDED (rf2-2rtt6.13)
+
+  This instrument was written against a shipped hook that RETAINED the
+  disposed render-phase reaction, so `xcript` transcribed that and
+  `retain` was the ablation. rf2-2rtt6.13 landed the fix in
+  `re-frame.substrate.spine`, so `xcript` — whose whole contract is to
+  reproduce the SHIPPED hook — now transcribes the value-returning shape,
+  and the ablation is `retain`, the superseded one. Same two bodies, same
+  single differing expression, same subtraction magnitude; only the sign
+  of the story changed. Leaving `xcript` on the old shape would have made
+  the fidelity control fail by construction and voided the whole table.
 
   ## What this namespace does NOT do
 
@@ -235,10 +250,75 @@
         stable-key      (stable-key-of key-ref frame-kw query-v)
         stable-frame-kw (aget stable-key 0)
         stable-query-v  (aget stable-key 1)
-        ;; Balanced, net-zero render-phase fetch of the reaction HANDLE
-        ;; (rf2-es09qq). For a query with no live cache entry this is
-        ;; 0 -> 1 -> 0: build, then dispose + evict. The handle is
-        ;; returned, so React's hook slot keeps it.
+        ;; Balanced, net-zero render-phase READ (rf2-es09qq). For a query
+        ;; with no live cache entry this is 0 -> 1 -> 0: build, deref while
+        ;; live, then dispose + evict. Only the VALUE is returned, so
+        ;; nothing holds the disposed reaction (rf2-2rtt6.13).
+        snapshot
+        (uix-hooks/use-memo
+          (fn []
+            (let [r (subs/subscribe stable-query-v {:frame stable-frame-kw})
+                  v (when r @r)]
+              (subs/unsubscribe stable-frame-kw stable-query-v)
+              v))
+          #js [stable-key])
+        get-snap
+        (uix-hooks/use-callback
+          (fn []
+            (let [stored (.-current committed-ref)]
+              (if (and stored (identical? (aget stored 0) stable-key))
+                (let [r (aget stored 1)] (when r @r))
+                snapshot)))
+          #js [stable-key snapshot])
+        subscribe-fn
+        (uix-hooks/use-callback
+          (fn [on-change]
+            (let [committed (subs/subscribe stable-query-v
+                                            {:frame stable-frame-kw})]
+              (set! (.-current committed-ref) #js [stable-key committed])
+              (let [k (keyword watch-ns (str (gensym "watch-")))]
+                (when committed
+                  (add-watch committed k (fn [_ _ _ _] (on-change))))
+                (fn unsubscribe []
+                  (when committed (remove-watch committed k))
+                  (let [stored (.-current committed-ref)]
+                    (when (and stored (identical? (aget stored 1) committed))
+                      (set! (.-current committed-ref) nil)))
+                  (subs/unsubscribe stable-frame-kw stable-query-v)))))
+          #js [stable-key])]
+    (react/useSyncExternalStore subscribe-fn get-snap get-snap)))
+
+;; ---------------------------------------------------------------------------
+;; ARM 3 — `retain`: the transcription, plus the retained reaction
+;; ---------------------------------------------------------------------------
+;;
+;; THE SUPERSEDED SHAPE, kept as the ablation. Until rf2-2rtt6.13 this WAS
+;; the shipped hook, and `xcript` was its transcription; the fix landed and
+;; the roles swapped. Keeping the old shape here is what keeps the change's
+;; justification reproducible — delete this arm and the 22% claim becomes
+;; something you have to take on faith.
+;;
+;; ONE expression differs from `xcript`. The render-phase `use-memo` performs
+;; the identical balanced round trip — same `subs/subscribe`, same
+;; `subs/unsubscribe`, same build + dispose + commit-phase rebuild — but it
+;; returns the HANDLE rather than deref-ing it for the VALUE, so React's hook
+;; slot and `get-snap`'s closure retain a disposed, unreachable reaction for
+;; the component's lifetime.
+;;
+;; Everything else — both refs, the stable key, both `use-callback`s, the
+;; watch, `useSyncExternalStore` — is character-for-character `xcript`. The
+;; CHURN is therefore on both sides of the subtraction and only RETENTION
+;; is isolated.
+
+(defn- use-sub-retain [frame-kw query-v]
+  (let [key-ref       (react/useRef nil)
+        committed-ref (react/useRef nil)
+        stable-key      (stable-key-of key-ref frame-kw query-v)
+        stable-frame-kw (aget stable-key 0)
+        stable-query-v  (aget stable-key 1)
+        ;; The one differing expression: the memo returns the reaction
+        ;; HANDLE, so React's hook slot and `get-snap`'s closure keep the
+        ;; disposed object alive for the component's lifetime.
         reaction
         (uix-hooks/use-memo
           (fn []
@@ -275,75 +355,11 @@
     (react/useSyncExternalStore subscribe-fn get-snap get-snap)))
 
 ;; ---------------------------------------------------------------------------
-;; ARM 3 — `noretain`: the transcription, minus the retained reaction
-;; ---------------------------------------------------------------------------
-;;
-;; ONE expression differs from `xcript`. The render-phase `use-memo` still
-;; performs the identical balanced round trip — same `subs/subscribe`, same
-;; `subs/unsubscribe`, same build + dispose + commit-phase rebuild — but it
-;; DEREFS the handle and returns the VALUE, so nothing holds the disposed
-;; reaction once the factory returns. `get-snap`'s pre-commit fallback reads
-;; that value.
-;;
-;; Everything else — both refs, the stable key, both `use-callback`s, the
-;; watch, `useSyncExternalStore` — is character-for-character `xcript`. The
-;; CHURN is therefore on both sides of the subtraction and only RETENTION
-;; is isolated.
-;;
-;; This is a measurement arm and not a proposed patch. Freezing the fallback
-;; snapshot gives up one property the live handle has: today's fallback
-;; `@r` on the disposed reaction still recomputes (the derived value is
-;; pull-based), so an app-db write landing between render and the
-;; commit-phase watch install is observed by React's store-consistency
-;; check. A frozen value is not. The studio page prices the fix that keeps
-;; that property; this arm exists to price the term, not to ship it.
-
-(defn- use-sub-noretain [frame-kw query-v]
-  (let [key-ref       (react/useRef nil)
-        committed-ref (react/useRef nil)
-        stable-key      (stable-key-of key-ref frame-kw query-v)
-        stable-frame-kw (aget stable-key 0)
-        stable-query-v  (aget stable-key 1)
-        snapshot
-        (uix-hooks/use-memo
-          (fn []
-            (let [r (subs/subscribe stable-query-v {:frame stable-frame-kw})
-                  v (when r @r)]
-              (subs/unsubscribe stable-frame-kw stable-query-v)
-              v))
-          #js [stable-key])
-        get-snap
-        (uix-hooks/use-callback
-          (fn []
-            (let [stored (.-current committed-ref)]
-              (if (and stored (identical? (aget stored 0) stable-key))
-                (let [r (aget stored 1)] (when r @r))
-                snapshot)))
-          #js [stable-key snapshot])
-        subscribe-fn
-        (uix-hooks/use-callback
-          (fn [on-change]
-            (let [committed (subs/subscribe stable-query-v
-                                            {:frame stable-frame-kw})]
-              (set! (.-current committed-ref) #js [stable-key committed])
-              (let [k (keyword watch-ns (str (gensym "watch-")))]
-                (when committed
-                  (add-watch committed k (fn [_ _ _ _] (on-change))))
-                (fn unsubscribe []
-                  (when committed (remove-watch committed k))
-                  (let [stored (.-current committed-ref)]
-                    (when (and stored (identical? (aget stored 1) committed))
-                      (set! (.-current committed-ref) nil)))
-                  (subs/unsubscribe stable-frame-kw stable-query-v)))))
-          #js [stable-key])]
-    (react/useSyncExternalStore subscribe-fn get-snap get-snap)))
-
-;; ---------------------------------------------------------------------------
 ;; ARM 4 — `hooks`: the same six hooks, no re-frame at all
 ;; ---------------------------------------------------------------------------
 ;;
 ;; Two `useRef`s, the stable-key derivation (INCLUDING the `[:abl/cell i]`
-;; query vector, so the query-v allocation cancels in `noretain - hooks`
+;; query vector, so the query-v allocation cancels in `retain - hooks`
 ;; and that difference is the subscription machinery alone), one `useMemo`,
 ;; two `useCallback`s and `useSyncExternalStore` over a trivial JS store.
 ;; No `subs/subscribe`, no reaction, no cache entry.
@@ -381,7 +397,7 @@
 
 (defn- r-uix      [i] (uix-adapter/use-subscribe frame-id [:abl/cell i]))
 (defn- r-xcript   [i] (use-sub-xcript   frame-id [:abl/cell i]))
-(defn- r-noretain [i] (use-sub-noretain frame-id [:abl/cell i]))
+(defn- r-retain [i] (use-sub-retain frame-id [:abl/cell i]))
 (defn- r-hooks    [i] (use-sub-hooks    frame-id [:abl/cell i]))
 
 ;; ---------------------------------------------------------------------------
@@ -428,22 +444,22 @@
              (r-xcript (+ base 6)))]
     ($ :span.cell {:data-i base} (str v))))
 
-(defui c-noretain-0 [{:keys [base]}] ($ :span.cell {:data-i base} "0"))
+(defui c-retain-0 [{:keys [base]}] ($ :span.cell {:data-i base} "0"))
 
-(defui c-noretain-1 [{:keys [base]}]
-  (let [v (r-noretain (+ base 0))]
+(defui c-retain-1 [{:keys [base]}]
+  (let [v (r-retain (+ base 0))]
     ($ :span.cell {:data-i base} (str v))))
 
-(defui c-noretain-3 [{:keys [base]}]
-  (let [v (+ (r-noretain (+ base 0)) (r-noretain (+ base 1))
-             (r-noretain (+ base 2)))]
+(defui c-retain-3 [{:keys [base]}]
+  (let [v (+ (r-retain (+ base 0)) (r-retain (+ base 1))
+             (r-retain (+ base 2)))]
     ($ :span.cell {:data-i base} (str v))))
 
-(defui c-noretain-7 [{:keys [base]}]
-  (let [v (+ (r-noretain (+ base 0)) (r-noretain (+ base 1))
-             (r-noretain (+ base 2)) (r-noretain (+ base 3))
-             (r-noretain (+ base 4)) (r-noretain (+ base 5))
-             (r-noretain (+ base 6)))]
+(defui c-retain-7 [{:keys [base]}]
+  (let [v (+ (r-retain (+ base 0)) (r-retain (+ base 1))
+             (r-retain (+ base 2)) (r-retain (+ base 3))
+             (r-retain (+ base 4)) (r-retain (+ base 5))
+             (r-retain (+ base 6)))]
     ($ :span.cell {:data-i base} (str v))))
 
 (defui c-hooks-0 [{:keys [base]}] ($ :span.cell {:data-i base} "0"))
@@ -465,7 +481,7 @@
 (def ^:private component-table
   {:uix      {0 c-uix-0      1 c-uix-1      3 c-uix-3      7 c-uix-7}
    :xcript   {0 c-xcript-0   1 c-xcript-1   3 c-xcript-3   7 c-xcript-7}
-   :noretain {0 c-noretain-0 1 c-noretain-1 3 c-noretain-3 7 c-noretain-7}
+   :retain {0 c-retain-0 1 c-retain-1 3 c-retain-3 7 c-retain-7}
    :hooks    {0 c-hooks-0    1 c-hooks-1    3 c-hooks-3    7 c-hooks-7}})
 
 (defui uix-grid [{:keys [variant n r]}]
@@ -539,7 +555,7 @@
 
 (def uix-variants
   "The four UIx-page arms, in decomposition order."
-  [:uix :xcript :noretain :hooks])
+  [:uix :xcript :retain :hooks])
 
 (defn- arm-id [variant r n]
   (keyword (str (name variant) "/r" r "-b" n)))
@@ -626,16 +642,24 @@
 ;;
 ;; Everything above is a heap measurement, and a heap measurement on this
 ;; surface is guilty until it has produced a control. The central claim —
-;; that a UIx read with no live cache entry BUILDS TWO REACTIONS and keeps
-;; the first — is not really a claim about bytes at all. It is a claim about
-;; COUNTS, and counts can be read exactly.
+;; that a UIx read with no live cache entry BUILDS TWO REACTIONS — is not
+;; really a claim about bytes at all. It is a claim about COUNTS, and counts
+;; can be read exactly.
 ;;
 ;; So: mount a small grid whose reads go through a transcription that is
-;; `use-sub-xcript` PLUS three counter increments, and read the counters
+;; `use-sub-retain` PLUS three counter increments, and read the counters
 ;; back. The witness components never appear in the heap table (a sub body
 ;; with a side effect has no business on a page pricing retention) and the
 ;; heap arms never touch the witness sub. The two halves of this file check
 ;; each other and share nothing but the frame.
+;;
+;; WHY THE WITNESS KEEPS THE HANDLE, WHEN THE SHIPPED HOOK NO LONGER DOES.
+;; Its whole mechanism is an `identical?` between the render-phase reaction
+;; and the commit-phase one, which requires holding the former. That is an
+;; INSTRUMENT REQUIREMENT, not a transcription of shipped behaviour: since
+;; rf2-2rtt6.13 the shipped hook keeps only the value. The counting claim is
+;; unaffected — the two BUILDS happen either way; retention was never what
+;; made them two — and the double build remains rf2-2rtt6.14's subject.
 ;;
 ;; PREDICTED BEFORE THE RUN, for `n` boundaries x `r` reads = N reads:
 ;;
@@ -644,9 +668,9 @@
 ;;
 ;; `rebuilt = N` is the whole finding: EVERY read's commit-phase acquire
 ;; hands back a DIFFERENT reaction object from the one the render phase
-;; already built and the fiber is still holding. `bodyRuns = 2N` is its
-;; shadow — the second reaction's first deref re-runs the user's sub body.
-;; A `rebuilt` of 0 would falsify the finding outright.
+;; already built. `bodyRuns = 2N` is its shadow — the second reaction's
+;; first deref re-runs the user's sub body. A `rebuilt` of 0 would falsify
+;; the finding outright.
 
 (defn- use-sub-witness [frame-kw query-v]
   (let [key-ref       (react/useRef nil)

--- a/implementation/freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs
@@ -318,7 +318,7 @@ function snapshotTotal(cdp) {
 // Arm naming — the plan is derived from the page, never assumed here
 // ---------------------------------------------------------------------------
 
-// `floor/r0-b1200`, `uix/r7-b1200`, `noretain/r3-b1200`. The driver PARSES
+// `floor/r0-b1200`, `uix/r7-b1200`, `retain/r3-b1200`. The driver PARSES
 // rather than reconstructs, so a rename in the CLJS cannot silently
 // desynchronise the two halves of the instrument.
 function parseArm(id) {
@@ -848,13 +848,14 @@ function report(all) {
     }
     L.push(`;;   => decomposition is ${fid.ok ? 'ATTRIBUTABLE' : 'NOT ATTRIBUTABLE; every delta below is void'}`);
   }
-  if (U && U.uix && U.noretain && U.hooks) {
+  if (U && U.uix && U.retain && U.hooks) {
     L.push('');
     L.push(';; ---- DECOMPOSITION of the shipped per-read cost --------------------');
-    L.push(`;;   retained render-phase reaction   xcript - noretain   ${dstr(delta(U.xcript.bytesPerRead, U.noretain.bytesPerRead))} B`);
-    L.push(`;;                                                        ${dstr(delta(U.xcript.objectsPerRead, U.noretain.objectsPerRead), n1)} obj`);
-    L.push(`;;   one live subscription            noretain - hooks    ${dstr(delta(U.noretain.bytesPerRead, U.hooks.bytesPerRead))} B`);
-    L.push(`;;                                                        ${dstr(delta(U.noretain.objectsPerRead, U.hooks.objectsPerRead), n1)} obj`);
+    L.push(`;;   retained render-phase reaction   retain - xcript   ${dstr(delta(U.retain.bytesPerRead, U.xcript.bytesPerRead))} B`);
+    L.push(`;;   (SUPERSEDED by rf2-2rtt6.13;                          ${dstr(delta(U.retain.objectsPerRead, U.xcript.objectsPerRead), n1)} obj`);
+    L.push(`;;    the shipped hook no longer pays it)`);
+    L.push(`;;   one live subscription            xcript - hooks    ${dstr(delta(U.xcript.bytesPerRead, U.hooks.bytesPerRead))} B`);
+    L.push(`;;                                                        ${dstr(delta(U.xcript.objectsPerRead, U.hooks.objectsPerRead), n1)} obj`);
     L.push(`;;   React's six-hook stack           hooks               ${b(U.hooks.bytesPerRead.p50)}  [${b(U.hooks.bytesPerRead.min)}-${b(U.hooks.bytesPerRead.max)}] B`);
     L.push(`;;                                                        ${n1(U.hooks.objectsPerRead.p50)}  [${n1(U.hooks.objectsPerRead.min)}-${n1(U.hooks.objectsPerRead.max)}] obj`);
     if (R && R.reagent) {
@@ -862,7 +863,7 @@ function report(all) {
       L.push(`;;   Reagent, same subs, same page shape                  ${b(R.reagent.bytesPerRead.p50)}  [${b(R.reagent.bytesPerRead.min)}-${b(R.reagent.bytesPerRead.max)}] B`);
       L.push(`;;                                                        ${n1(R.reagent.objectsPerRead.p50)}  [${n1(R.reagent.objectsPerRead.min)}-${n1(R.reagent.objectsPerRead.max)}] obj`);
       L.push(`;;   shipped UIx / Reagent ratio                          ${(U.uix.bytesPerRead.p50 / R.reagent.bytesPerRead.p50).toFixed(3)}x`);
-      L.push(`;;   noretain  / Reagent ratio                            ${(U.noretain.bytesPerRead.p50 / R.reagent.bytesPerRead.p50).toFixed(3)}x`);
+      L.push(`;;   superseded retaining shape / Reagent ratio            ${(U.retain.bytesPerRead.p50 / R.reagent.bytesPerRead.p50).toFixed(3)}x`);
     }
   }
   return L.join('\n');


### PR DESCRIPTION
Closes `rf2-2rtt6.13` (epic `rf2-2rtt6`, EP-0038 Hicasso).

## The defect

`re-frame.substrate.spine/use-subscribe` takes a balanced render-phase round trip —
`subs/subscribe` then `subs/unsubscribe` — so a render that never commits retains no
ref-count. That property is `rf2-es09qq`'s and it is preserved here untouched.

For a query with **no live cache entry** the trip is `0 → 1 → 0`, and `1 → 0` is the
disposal edge: `re-frame.subs.cache/unsubscribe!` disposes in-tick with no grace period.
So the reaction the memo factory just built is dead before the factory returns — no source
watches, no cache slot, no verb that can reach it — and the factory **returned it anyway**.
`use-memo`'s hook slot and `get-snap`'s closure then held that corpse for the component's
whole lifetime.

Measured at **769 B `[765–793]` / 23.0 objects per read — 22% of every UIx subscription
read** (`docs/design/hicasso/studio/uix-spine-per-read-decomposition.md`; landed instrument
commit `24e8822d7f`).

## The change

Six lines. The render-phase `use-memo` now derefs the handle **inside** the round trip,
while the reaction is still live, and returns the **value**; `get-snap`'s pre-commit
fallback reads that value.

```clj
(let [r (subs/subscribe stable-query-v {:frame stable-frame-kw})
      v (when r @r)]                          ;; deref while live
  (subs/unsubscribe stable-frame-kw stable-query-v)
  v)                                          ;; the VALUE, not the handle
```

Every `subs/subscribe` / `subs/unsubscribe` call, every hook, every deps array and every
watch stays exactly where it was. `make-react-spine` is shared by three substrates —
`re-frame.adapter.uix` (first-class, shipped), `re-frame.freehand.substrate` and
`re-frame.ui.substrate` — so one change, three beneficiaries.

**rf2-es09qq is preserved by construction.** No subscribe/unsubscribe call moved, so the
render is still net-zero on ref-count and an abandoned render still acquires nothing. The
Suspense abort-before-commit witness and the `useMemo` perf-discard witness both pass
unchanged, and the new test re-asserts ref-count 1 after mount / released after unmount as
a control.

### Correctness: the window the frozen fallback gives up, and what still covers it

The fallback stops being a live re-read. React's `useSyncExternalStore` **mount path pushes
`subscribeToStore` as a passive effect BEFORE `updateStoreInstance`**, and passive effects
run in push order, so `updateStoreInstance` calls `getSnapshot` again *after* `subscribe-fn`
has published the committed reaction — that call reads the **live** one and force-re-renders
if a write landed between render and commit. Verified against React 19.2.0's actual source
(the pinned version) and, better, **observed**: the new test's pre-fix control run records
the deref log `[{:gen 1 :tenant? false} {:gen 1 :tenant? false} {:gen 2 :tenant? true}]` —
two pre-commit reads of the evicted handle, then the post-subscribe call landing on the
committed reaction.

What is genuinely given up is narrower than "the live re-read": on a **concurrent** lane the
render-phase store-consistency check no longer catches such a write, so the corrective
re-render happens one commit later rather than before the commit. Both before and after, the
corrective re-render happens.

The key-change path (`rf2-naz09e`) is unchanged in shape and arguably closer to the Reagent
substrate it is defined against, whose render-phase value is likewise read once, in render.

## What this does NOT do

Two reactions are still **built** per read on a cold mount — the witness is `rebuilt` 1.00N /
`bodyRuns` 2.00N, unchanged. Retention was never what made the builds two. **`rf2-2rtt6.25`
(the hook-scoped provisional hand-off adopted under `rf2-2rtt6.14` on 2026-07-31 — escrow
token + macrotask reap + commit-time adoption) follows on these same lines**, and that
ruling sequences it after this PR.

## The test

`assert-use-subscribe-render-phase-reaction-not-retained` pins the property retention itself
cannot expose. Retention had a *cause* that is observable: the handle survived because
`get-snap` closed over it, and `get-snap` closing over it is exactly what made the spine
deref an evicted reaction. So the assertion is the sharper statement —

> every deref the spine performs, at any point in the component's lifetime, targets the
> reaction **tenanted in the sub-cache at that moment**

— proven by a `subs/subscribe` spy recording generation *and* tenancy per deref. It also pins
React's effect ordering, so a future React upgrade that reorders those two passive effects
reds here rather than silently making the frozen fallback the last word.

**Verified load-bearing**: reverted to the pre-fix shape, the full browser suite goes red with
exactly this one failure (exit 1), on the tenancy assertion, at the first mount.

## Bench: the instrument's polarity flipped with the fix

`xcript`'s contract is to transcribe the **shipped** hook — it is the fidelity control, and
the driver voids the whole decomposition when it fails. Leaving it on the handle-returning
shape would have failed that control by construction and exited 4 on a healthy tree. So the
two bodies swap roles: `xcript` is now the value-returning transcription and the ablation is
`retain` (formerly `noretain`), the superseded shape, kept because deleting it would leave the
22% claim resting on faith. Same two bodies, same single differing expression, same
subtraction magnitude. **No gate, band or tolerance is touched.**

The witness deliberately keeps the handle: its mechanism is an `identical?` between the
render-phase and commit-phase reactions, which requires holding the former. That is an
instrument requirement, not shipped behaviour, and it is now labelled as such.

## Pricing, before and after

One run on this branch, lane started cold, 4 rounds / 2 snapshot rounds per page, **exit 0
under all six fail-closed gates**. Before and after arms measured **in the same run under the
same order guard**:

| arm | bytes/read | objects/read | vs Reagent |
|---|---:|---:|---:|
| `retain` — the superseded (pre-fix) shipped shape | 3,489 `[3,488–3,491]` | 125.8 | 4.030× |
| **`uix` — shipped, after this PR** | **2,734** `[2,731–2,735]` | **102.8** | **3.158×** |
| `xcript` — transcription of the shipped hook | 2,719 `[2,701–2,721]` | 102.8 | |
| `hooks` | 1,036 `[1,035–1,040]` | 46.1 | |
| `reagent` | 866 `[842–866]` | 31.5 | 1× |

* **−769 B `[767–789]` / −23.0 obj `[23.0–23.1]` per read, −22%** — the term reproduced to
  the byte against the published 769 B `[765–793]` / 23.0 obj.
* **The term is zero on the shipped hook.** `uix − xcript` is now 15 B (0.545%) on bytes and
  0.050% on objects, both inside the pre-declared 3% fidelity band; before the fix that same
  subtraction against the value-returning body was the whole 769 B.
* The page priced the fix at 2,720 B `[2,698–2,722]` / 102.8 obj / 3.14×. That was the
  transcription's number and the transcription came back at **2,719 B — inside its own
  predicted range**. The shipped arm sits 15 B above it, the same ~0.5% offset the shipped
  arm has always carried against its copy (pre-fix: 3,501 vs 3,489, 0.33%).
* Witness, unchanged as expected: `commits` 1.00N, `rebuilt` 1.00N, `bodyRuns` 2.00N on UIx
  against 0/0/1.00N on Reagent, twice over disjoint cells.
* Instrument gates: 0 unverified of 154 mounts; in-situ 8N positive control at −0.002% /
  −0.002% / +0.003% (uix page readers A/B/C) and +0.017% / +0.016% / 0.000% (reagent page),
  all inside the 1% band; order guard **clean** on both pages; r² 0.99996–0.99998 on the UIx
  arms, 0.99723 / 0.99606 on Reagent, all above the 0.99 floor; fidelity **ATTRIBUTABLE**.

## Quality gates

Derived from `TESTING.md`. This is a public-surface change in a shipped adapter's shared
spine, so the matrix gates the **transitive** surface — the three `make-react-spine`
consumers and the production bundles they compile into — not just the changed file.

| gate | why it is in the matrix | result | exit |
|---|---|---|---|
| `npm run test:cljs` | the consolidated CLJS node lane across `implementation/*` + `tools/*` | **11967 tests / 59703 assertions, 0 failures, 0 errors** | `0` |
| `npm run test:browser` | where every `use-subscribe` DOM assertion actually executes (real React mounts), incl. the new one | **856 tests / 5521 assertions, 0 failures, 0 errors** | `0` |
| `npm run test:browser` — **pre-fix control** | proves the new assertion is load-bearing | **exactly 1 failure, the new assertion** | `1` (expected) |
| `npm run test:adapter-smokes` | the two adapter testbeds (Reagent, UIx) + the `re-frame.ui` substrate smoke — mount + dispatch + assert across all three spine consumers | **3 adapter-smoke specs, 0 failures** | `0` |
| `npm run test:bundle-isolation` | `:advanced` release compile of the changed spine through the shipped UIx/Reagent bundles; UIx stays Reagent-free | **4 checkers PASS** (self-test 23 artefacts / 39 mutations; isolation; uix-reagent-free; login) | `0` |
| `npm run test:browser-prod-elision` | the third consumer (`re-frame.ui.substrate`) mounted under `:advanced` + `goog.DEBUG=false` | **120 tests / 527 assertions, 0 failures, 0 errors** | `0` |
| `bash scripts/test-fast-pr.sh` | the canonical pre-checkin spine — static/drift, docs-content tier (both edited pages), JVM core + freehand, node tier | **PASS** — JVM core 2194 tests / 11323 assertions, freehand 1288 tests / 8856 assertions, all 0 failures | `0` |
| `python -m mkdocs build --strict` | the spine soft-skips it locally (`mkdocs` not on PATH); run explicitly because this PR edits two published pages | **built in 25.77s, no warnings promoted** | `0` |
| ablation driver (`spine_ablation_run.cjs`) | re-verify the pricing on the landed instrument, lane started cold | **exit 0 under all six fail-closed gates** | `0` |

Not run locally, and why: the nightly / expensive lanes `TESTING.md` puts outside the PR
gate — Story and Xray full sweeps, mcp-conformance live, template emitted-app. None of them
reach `re-frame.substrate.spine`; CI owns them.

## Changed files

* `implementation/core/src/re_frame/substrate/spine.cljs` — the fix
* `implementation/core/test/re_frame/adapter/react_shared_suite.cljs` — the new assertion
* `implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs` — wires it, on its own frame
* `implementation/freehand/test/re_frame/freehand/bench/spine_ablation.cljs` — arm polarity
* `implementation/freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs` — report labels
* `docs/design/hicasso/studio/uix-spine-per-read-decomposition.md` — landed anchor, blob hashes, the after-run
* `docs/design/hicasso/studio/coldmount-double-build-priced.md` — the confirmation its provenance note predicted
