### PR TITLE
bench(hicasso): the heap fan-out sweep — E/Q 1-2-4-8 and the additive model (rf2-5prok)

### DIFF
--- a/docs/design/hicasso/studio/README.md
+++ b/docs/design/hicasso/studio/README.md
@@ -92,6 +92,7 @@ requires nothing from any donor `src/` tree.
 | [P0 — the UIx-on-subs frontier arm](p0-uix-on-subs-frontier-arm.md) | P0 | The frontier against the denominator, on the arm's own witnesses. Its retained-heap absolutes are **shared-query fan-out evidence** (rf2-2rtt6.16), its ratios the cross-regime check; its clock rows are superseded by the converged page. |
 | [P0 — the converged witness set, and the red-zones re-derived on it](p0-converged-witness-set.md) | P0 | The **clock red-zones** on the denominator's own witnesses, and how far the earlier per-arm witness sets moved the verdicts. |
 | [P0 — the reads-per-boundary heap ladder](reads-per-boundary-heap-ladder.md) | P0 | Retained heap per subscribing boundary across the 1/3/7/20 reads ladder, both donors — the **operative** distinct-query (Q = E) red-zone family. |
+| [P0 — the heap fan-out sweep](heap-fan-out-sweep.md) | P0 | What sharing a subscription is worth: E/Q at 1, 2, 4 and 8 on one instrument, with B and reads/boundary pinned. Confirms the ruling's fan-out-1 prediction, reproduces the `.4` grid arm to 0.3%, and prices the shell and per-unique-key terms — **refusing** the Reagent per-edge one. |
 | [HD-008 — the composed donor arm](hd8-composed-donor-arm.md) | donor gate | What the composed donor arm costs against both Reagent paths and against the frontier. |
 | [The UIx spine's per-read allocation, decomposed](uix-spine-per-read-decomposition.md) | P0 | Where a UIx-on-subs read's bytes go. |
 | [The cold-mount double build, priced against the mount red-zone](coldmount-double-build-priced.md) | P0 | What the double build **costs on the clock**, as a fraction of the same-run UIx-minus-Reagent mount excess — the rf2-2rtt6.14 decision input. |
@@ -119,3 +120,14 @@ rows measured under the same regime on the same witness, and reports both
 regime-matched gates: UIx 3,552 B/read (worse is RED, operator waiver
 required) and Reagent 943 B/read (worse with no named paper path down is K3
 territory; between the two is "UIx-rule cleared, K3 open", never plain green).
+
+**Heap absolutes published before 2026-07-31 predate two spine landings.**
+`rf2-2rtt6.13` (`9df5094816`) stopped retaining a disposed render-phase
+reaction — **−769 B per unique query key** on the UIx spine — and
+`rf2-2rtt6.25` (`f784ab0adb`) landed the hook-scoped provisional hand-off, so a
+cold read now builds one reaction rather than two. Every UIx heap absolute on
+the ladder and on the frontier arm was measured before both. The
+[fan-out sweep](heap-fan-out-sweep.md) is the first heap page measured after
+them, and it prices the difference: at fan-out 1 the UIx/Reagent retained-heap
+ratio moves from ~2.44× to **~1.97×**. Compare heap absolutes across that line
+only with the correction stated.

--- a/docs/design/hicasso/studio/heap-fan-out-sweep.md
+++ b/docs/design/hicasso/studio/heap-fan-out-sweep.md
@@ -8,60 +8,483 @@ heap-regime ruling (authoritative text on `rf2-2rtt6.16`; transcription on
 regardless of what is below. It is **gating** for freezing Part 3's component
 budget rows — the shell / per-edge / per-unique-key numbers that may not enter
 [validation.md](../validation.md) until a sweep verifies the additive model and
-prices the terms.
+prices the terms. [§6](#6-what-this-unblocks) says which rows are unblocked and
+which one is refused.
+
+---
+
+## The answer, first
+
+**Cache cardinality is worth more than a factor of two, and it is now measured
+on one instrument in one run instead of inferred across two.** Holding
+boundaries, elements, text and reads-per-boundary all fixed and moving *only*
+the number of unique live query keys, a Reagent boundary's exclusive retained
+heap runs **1,643 B at fan-out 1 down to 842 B at fan-out 8**, and a UIx
+boundary **3,235 B down to 1,813 B**. Nothing else in either page changed.
+
+**The `rf2-2rtt6.4` grid arm reproduces to 0.3%.** Its published Reagent row is
+947 B/boundary; run here unchanged, as a rung of this sweep, it reads
+**950 B [939–958]** — and this sweep can now say *why* that is not the same
+quantity as the ladder's 1,562 B, because it holds both regimes in one table.
+The instrument counts **Q off the frame's own sub-cache on every mount** and
+refuses a mount whose count is not the one the plan asked for, so the ruling's
+central mechanical claim — four roots rendering one frame's query vectors hold
+**300** reactions, not 1,200 — stopped being a reading of the source and became
+a number 252 mounts had to answer.
+
+**The ruling's prediction holds, once the spine landings that postdate the
+ladder are accounted for.** Reagent's fan-out-1 rung lands within **1.8–5.2%**
+of the predicted 1,562 B. UIx's misses by **15–16%** — and `rf2-2rtt6.13`, which
+removed a retained disposed reaction worth 769 B per unique key and landed
+*after* the ladder was published, accounts for it: add that term back and the
+two substrates sit **+5.2% and +5.2%** above the ladder, the same common-mode
+offset between two instruments. **Part 1 is not reopened.**
+[§3](#3-the-prediction-adjudicated) shows the working.
+
+**The additive model holds on UIx and needs a fourth term on Reagent.** The
+per-unique-key axis is a straight line on both substrates in every round of both
+runs (r² 0.9973–0.9999), so a per-unique-key price exists and is priced twice
+over from disjoint subsets of the sweep. The *per-edge* term is another matter:
+on UIx the two ways of pricing it agree within 3.8% and the held-out rung is
+predicted within 2%, and on Reagent they disagree by 160 B — **more than twice
+the smaller of the two** — which is a real finding about where Reagent spends
+and a refusal to publish a per-edge byte count for it.
+
+---
+
+## Provenance
+
+**Instrument.** Whole-tree anchor `cd99cded8227816848499b989a9981f194ac656e` on
+`worker/fanout-5prok`. A SHA does not survive a rebase, so the content checks
+are beside it:
+
+| file | blob |
+|---|---|
+| `p0_heap.cljs` | `29a5d1087c2a78d3bc025657d414af2131d358fe` |
+| `p0_run.cjs` | `c8c1756dde30a49042c197d6582702efb995d0c9` |
+| `p0_reagent.cljs` | `49633402a26d17188987746b2f8f5f0e42213a27` |
+| `p0_uix.cljs` | `d19b07697ecf11ce5640bf12f1c5438f6e5eb1da` |
+| `p0_fixture.cljc` | `867ad5838ab64ac6aa7afbf8317d8fb305f53619` |
+
+All five live under `implementation/core/test/re_frame/bench/`. If the SHA does
+not resolve, a rebase moved it and the blobs are what to trust:
+
+```bash
+P=implementation/core/test/re_frame/bench/p0_heap.cljs
+git log --oneline --all -- $P
+git rev-parse <candidate>:$P   # must print 29a5d1087c2a78d3bc025657d414af2131d358fe
+```
+
+**The spine measured.** Both of today's spine landings are ancestors of the
+anchor, and both move per-read heap, so this page's absolutes are **not**
+comparable to any P0 heap figure published before them:
+
+| landing | commit | what it did |
+|---|---|---|
+| `rf2-2rtt6.13` (PR #7304) | `9df5094816` | stopped retaining the disposed render-phase reaction — **−769 B / −23.0 objects per unique key** on UIx |
+| `rf2-2rtt6.25` (PR #7305) | `f784ab0adb` | hook-scoped provisional hand-off; the cold read builds **one** reaction, not two (`bodyRuns` 2.00N → 1.00N) |
+
+**Versions.** Reagent **2.0.1**, UIx **1.4.4**, React **19.2.0**, node
+**24.13.0**, headless **Chromium 147.0.7727.15** via Playwright 1.59.1. Windows
+11, single developer workstation; no other agent or bench process was running
+(checked before the published rungs). Every arm is an `:advanced` ClojureScript
+bundle with `goog.DEBUG false`, riding the `:hicasso-bench` build id whose cache
+entry is cleared before every build (`lane_cache.cjs`, `rf2-2rtt6.20`), so both
+runs started cold.
+
+**Reproduce** — foreground, to completion, and the exit code is the verdict:
+
+```bash
+P0_ROOTS=4 P0_FAN_ROUNDS=6 node implementation/core/test/re_frame/bench/p0_run.cjs --only fanout
+P0_ROOTS=1 P0_FAN_ROUNDS=6 node implementation/core/test/re_frame/bench/p0_run.cjs --only fanout
+```
+
+Both **exited 0**. Exit 1 is an unverified mount or a failed positive control;
+exit 2 is the arm-order guard refusing, and the repair for that is to the arm,
+never to the guard.
 
 ---
 
 ## The prediction, on record, before the run
 
-Written and committed before the published rungs were measured. The ruling put
-one prediction on record and this page adds the rest, because a page that only
-records the predictions it got right is not recording predictions.
+Committed as `cd99cded82` — this page's first revision — **before** the
+published rungs were measured, so this page is not a record of only the
+predictions that came true. `git show cd99cded82` is the receipt.
+[§3](#3-the-prediction-adjudicated) marks each one.
 
-**P1 — the fan-out-1 rung lands on the ladder's distinct-query family** (the
-ruling's own falsifiable claim): Reagent ~**1,562 B**, UIx ~**3,807 B** at one
-read, ratio 2.25–2.44×. *A material miss reopens Part 1 of the ruling.*
-
-**P1′ — but the ladder's absolutes predate two spine landings, and this sweep
-measures the tree after both.** `rf2-2rtt6.13` (PR #7304) removed a retained,
-disposed, unreachable reaction worth **769 B / 23.0 objects per UIx read**;
-`rf2-2rtt6.25` (PR #7305) landed the hook-scoped provisional hand-off, taking
-the cold read from two reaction constructions to one. The dead reaction was
-built once per *cache miss*, so it belongs to the per-unique-key term, not the
-per-edge one. So the corrected prediction is:
-
-| rung | ladder, as published | predicted here (post-.13/.25) |
-|---|---:|---:|
-| Reagent, fan-out 1, R=1 | 1,562 B | **~1,562 B** (unchanged — the fix is UIx-side) |
-| UIx, fan-out 1, R=1 | 3,807 B | **~3,038 B** (3,807 − 769) |
-| UIx, fan-out 4, R=1 | 2,134 B (the `.4` grid) | **~1,942 B** (2,134 − 769/4) |
-
-**P2 — the terms.** Reagent shell ~428 B, per-unique-key ~866 B
-(`rf2-2rtt6.12`'s ablation), per-edge ~270 B by difference. UIx shell ~208 B,
-per-unique-key ~1,684 B (the 2,453 B ablation less the 769 B the fix removed),
-per-edge ~1,146 B.
-
-**P3 — the model may not be three terms.** The reads ladder's own Reagent curve
-fits `397 + 943·R` at r² 0.9988 while its measured R=0 shell reads 428 B and its
-R=1 rung reads 1,562 B — a first read that costs **224 B more than the line**,
-invisible in an r² taken against a 19 KB range. If that step is real and is a
-per-*subscribing-boundary* cost rather than a per-edge one, the three-term
-budget the ruling named would misprice every page whose fan-out is not 1. The
-sweep therefore adjudicates **two** models and holds a rung back to tell them
-apart. Predicted: **M4 on Reagent, M3 on UIx.**
-
-**P4 — the instrument's own controls**, predicted before the run:
-
-- the dense-array positive control reads **4,700,000 B** (587,500 unboxed
-  doubles × 8) on every round;
-- the adjudicator's self-test passes 6 of 6, and its synthetic quadratic page
-  clears the r² floor at **≈0.997** and is refused only out of sample;
-- **Q, counted off the frame's sub-cache**, reads exactly 300 on the published
-  `grid/*` arms at *every* ROOTS setting. That is the ruling's central
-  mechanical claim — four roots rendering one frame's query vectors hold 300
-  reactions, not 1,200 — and this sweep turns it from a reading of the source
-  into a number the instrument refuses to proceed without.
+- **P1** *(the ruling's own falsifiable claim)* — the fan-out-1 rung lands on
+  the ladder's distinct-query family: Reagent ~1,562 B, UIx ~3,807 B at one
+  read, ratio 2.25–2.44×. *A material miss reopens Part 1.*
+- **P1′** — but the ladder predates `.13`/`.25`. The dead reaction was built
+  once per **cache miss**, so it belongs to the per-unique-key term: corrected,
+  Reagent ~1,562 B (unchanged, the fix is UIx-side), UIx ~**3,038 B**
+  (3,807 − 769), and the `.4` grid's UIx row ~**1,942 B** (2,134 − 769/4).
+- **P2** — Reagent shell ~428 B, key ~866 B (`rf2-2rtt6.12`'s ablation), edge
+  ~270 B by difference. UIx shell ~208 B, key ~1,684 B, edge ~1,146 B.
+- **P3** — the model may not be three terms. The ladder's own Reagent curve fits
+  `397 + 943·R` at r² 0.9988 while its R=0 shell reads 428 B and its R=1 rung
+  1,562 B: a first read costing **224 B more than the line**, invisible in an r²
+  taken against a 19 KB range. Predicted **M4 on Reagent, M3 on UIx**.
+- **P4** — the controls: the dense array reads 4,700,000 B; the adjudicator's
+  self-test passes 6 of 6 and its synthetic quadratic page clears the r² floor
+  at ≈0.997 and is refused only out of sample; Q reads exactly 300 on the
+  published `grid/*` arms at every ROOTS setting.
 
 ---
 
-*(Results follow once the published rungs are measured.)*
+## 1. The design, and what is held fixed
+
+One page, one frame, one subscription cache, `K` React roots kept standing. A
+boundary's query index is `(n·R + j) mod Q`, where `n` is its index in the
+**global** numbering across all roots. That single rule sets the whole witness
+stamp from three numbers the driver chooses:
+
+- **B** — boundaries, `K × 300`. Read back off the DOM on every mount.
+- **E** — boundary-query edges, `B × R`.
+- **Q** — unique live query keys, the modulus. **Counted**, on every mount, off
+  the frame's `:sub-cache`; a count that is not the one the plan asked for is an
+  unverified mount and the driver exits 1.
+
+Every rung renders **identical DOM** — one `span.cell` per boundary whose text
+is `0`, because every seeded cell is `0` and a two-read cell shows their sum —
+so a rung differs from its neighbours in cache cardinality and in nothing a
+floor subtraction could confuse for it. The floor is the same plain-React
+`createElement` walk the published grid rows are differenced against: same
+elements, same classes, same text, **no component per boundary and no
+reactivity at all**. Every `y` below is `arm − floor`, within one segment of one
+round.
+
+| rung | reads/boundary | Q | what it is for |
+|---|---:|---:|---|
+| `R0` | 0 | 0 | the boundary **shell** |
+| `R1Q1` | 1 | B | fan-out 1 — the distinct-query worst case |
+| `R1Q2` | 1 | B/2 | fan-out 2 |
+| `R1Q4` | 1 | B/4 | fan-out 4 — at ROOTS=4, exactly `rf2-2rtt6.4`'s regime |
+| `R1Q8` | 1 | B/8 | fan-out 8 |
+| `R2Q2B` | 2 | 2B | **held out of every identification** |
+| `R2QB2` | 2 | B/2 | identifies the per-edge term against `R1Q2` |
+| `anchor` | 1 | 300 | the published `grid/<substrate>` arm, **unchanged** |
+
+**Method** is the published heap row's, unchanged and shared with it through one
+measurement engine: retention never allocation (mount and *keep*, force a full
+collection, read, release, collect, read again); CDP
+`Runtime.getHeapUsage().usedSize` after 3× `HeapProfiler.collectGarbage`, with
+in-page `performance.memory` alongside and *not* banked as independent; one
+unread warm-up pass over every arm before round 1; two adapter segments per
+round with the order alternating; the slot order rotating **and reflecting** so
+every arm is measured after at least two distinct predecessors.
+
+**Verification: 0 unverified of 126 mounts on each run**, on both read-backs.
+
+**The in-situ positive control**, predicted before anything was measured: a
+dense JS array of 587,500 doubles, which V8 stores as unboxed 8-byte slots —
+**4,700,000 B, known in advance**. It rides every round.
+
+| run | predicted | measured | error |
+|---|---:|---:|---:|
+| ROOTS=4 | 4,700,000 B | 4,700,330 B [4,699,074–4,700,974] | **+0.007%** |
+| ROOTS=1 | 4,700,000 B | 4,700,337 B [4,699,074–4,700,974] | **+0.007%** |
+
+**The arm-order guard returned `reportable` on both runs.** Its own self-test —
+twelve checks replayed from recorded live fixtures — passed before either run
+measured anything.
+
+---
+
+## 2. The rows
+
+`y` is exclusive retained bytes per boundary (arm − floor), six rounds, reader A.
+
+### ROOTS = 4 · B = 1,200
+
+| rung | E/B | Q | E/Q | Reagent | UIx | UIx/Reagent |
+|---|---:|---:|---:|---:|---:|---:|
+| floor *(absolute)* | 0 | 0 | — | 253 [248–260] | 254 [251–257] | — |
+| `R0` shell | 0 | 0 | — | **501** [496–506] | **221** [218–224] | 0.441× |
+| `R1Q1` | 1 | 1,200 | **1** | **1,643** [1,634–1,654] | **3,235** [3,221–3,257] | 1.969× |
+| `R1Q2` | 1 | 600 | **2** | **1,222** [1,212–1,239] | **2,409** [2,405–2,413] | 1.971× |
+| `R1Q4` | 1 | 300 | **4** | **954** [941–964] | **2,009** [2,000–2,015] | 2.106× |
+| `R1Q8` | 1 | 150 | **8** | **842** [831–867] | **1,813** [1,804–1,824] | 2.153× |
+| `R2Q2B` | 2 | 2,400 | 1 | 2,541 [2,534–2,561] | 6,122 [6,101–6,135] | 2.409× |
+| `R2QB2` | 2 | 600 | 4 | 1,305 [1,293–1,315] | 3,752 [3,740–3,773] | 2.875× |
+| **`anchor`** (`.4`'s grid arm) | 1 | 300 | **4** | **950** [939–958] | **1,996** [1,991–2,003] | 2.101× |
+
+### ROOTS = 1 · B = 300
+
+| rung | E/B | Q | E/Q | Reagent | UIx | UIx/Reagent |
+|---|---:|---:|---:|---:|---:|---:|
+| floor *(absolute)* | 0 | 0 | — | 270 [259–278] | 270 [255–285] | — |
+| `R0` shell | 0 | 0 | — | **524** [510–545] | **231** [215–255] | 0.441× |
+| `R1Q1` | 1 | 300 | **1** | **1,590** [1,549–1,625] | **3,185** [3,158–3,256] | 2.003× |
+| `R1Q2` | 1 | 150 | **2** | **1,198** [1,188–1,214] | **2,408** [2,377–2,457] | 2.010× |
+| `R1Q4` | 1 | 75 | **4** | **977** [965–991] | **2,022** [1,998–2,050] | 2.070× |
+| `R1Q8` | 1 | 38 | **7.89** | **861** [840–886] | **1,819** [1,810–1,836] | 2.113× |
+| `R2Q2B` | 2 | 600 | 1 | 2,658 [2,609–2,727] | 6,155 [6,134–6,181] | 2.316× |
+| `R2QB2` | 2 | 150 | 4 | 1,278 [1,255–1,331] | 3,753 [3,718–3,808] | 2.937× |
+| **`anchor`** (`.4`'s grid arm) | 1 | 300 | **1** | **1,563** [1,542–1,596] | **3,183** [3,165–3,198] | 2.036× |
+
+Three things fall straight out of the pair.
+
+**Fan-out is worth 1.6–1.9×, on one instrument.** From E/Q = 1 to E/Q = 8, with
+B, E, elements and text all pinned: Reagent 1,643 → 842 B (**1.95×**), UIx
+3,235 → 1,813 B (**1.78×**). From E/Q 1 to 4 — the two published families'
+regimes — Reagent **1.72×** and UIx **1.61×**, against the 1.65× / 1.79× the
+ruling computed across two instruments. *The incomparability the ruling priced
+is real, and this is the direct measurement of it.*
+
+**Per-boundary cost does not depend on B.** Every rung agrees between B = 300
+and B = 1,200 to within **4.0% on Reagent and 1.5% on UIx** — most within 1%.
+Whatever a page pays once is not showing up in these denominators.
+
+**The `:p0/fan` substitution is not doing any work.** At identical B/E/Q the fan
+rung and the published `grid` arm — different query ids, otherwise the same page
+— read within **0.4% and 0.7%** (ROOTS=4, fan-out 4) and **1.7% and 0.06%**
+(ROOTS=1, fan-out 1).
+
+### A refinement the ruling will want: the ratio is *approximately* regime-free
+
+Part 1 keeps `.4`'s ratios as "the cross-regime check that survives regimes".
+Measured directly here, the UIx/Reagent ratio at one read moves from **1.969×**
+at fan-out 1 to **2.153×** at fan-out 8 — a **9.3% drift** across the axis, in
+one run, on one instrument, and reproduced at ROOTS=1 (2.003× → 2.113×, 5.5%).
+The ratio is far more portable than the absolutes, which was the point; it is
+not *constant*, and a cross-regime check quoted to three decimal places is
+quoting drift.
+
+---
+
+## 3. The prediction, adjudicated
+
+### P1 — the fan-out-1 rung against the ladder
+
+| | ladder, R=1 | sweep, ROOTS=4 | ROOTS=1 | miss |
+|---|---:|---:|---:|---:|
+| Reagent | 1,562 B | 1,643 B | 1,590 B | **+5.2% / +1.8%** |
+| UIx | 3,807 B | 3,235 B | 3,185 B | **−15.0% / −16.3%** |
+
+Reagent lands. **UIx misses materially, and the miss is fully accounted for by a
+landing that postdates the ladder.** `rf2-2rtt6.13` removed a second, disposed,
+unreachable reaction worth 769 B — built once per *cache miss*, so once per
+unique key, so 769 B per boundary at fan-out 1. Add it back:
+
+| | ladder | sweep + 769 B | miss |
+|---|---:|---:|---:|
+| Reagent (no correction — the fix is UIx-side) | 1,562 B | 1,643 B | **+5.19%** |
+| UIx | 3,807 B | 4,004 B | **+5.17%** |
+
+Two substrates, two independent numbers, the same **+5.2%** offset between this
+instrument and the ladder's — which is what a common-mode difference between two
+harnesses with different boundary components looks like, and which the ratio
+cancels. **P1 is confirmed; Part 1 of the ruling is not reopened.** P1′, the
+corrected prediction, was 3,038 B against a measured 3,235 B (+6.5%) — closer
+than P1 by a factor of two, and the residual is the same common-mode offset.
+
+The ratio half of P1 goes the same way: predicted 2.25–2.44×, measured
+**1.969×** — outside the band, and outside it *because* of `.13`. Adding the
+term back recovers **2.437×** (ROOTS=4) and **2.487×** (ROOTS=1), inside the
+band at its top. **The measured drop from ~2.44× to ~1.97× is the retained-heap
+benefit of `rf2-2rtt6.13`, priced on the fan-out-1 witness.**
+
+### P1′ at fan-out 4 — the `.4` grid arm, re-run unchanged
+
+| | `.4` as published | sweep `anchor` | miss | after adding back 769/4 |
+|---|---:|---:|---:|---:|
+| Reagent | 947 B | **950 B** | **+0.3%** | — |
+| UIx | 2,134 B | **1,996 B** | **−6.5%** | 2,188 B (+2.5%) |
+
+The Reagent arm reproduces to three parts in a thousand across two months, two
+trees and a re-run. The UIx arm moves down by what `.13` predicts, to within
+2.5%.
+
+### P2 and P3 — see [§4](#4-the-additive-model) and [§5](#5-the-terms)
+
+P3 called it: **M4 on Reagent, M3 on UIx**, and the mechanism is the one the
+ladder's 224 B first-read excess pointed at.
+
+### P4 — the controls
+
+All four held. The dense array read within 0.007% of its predicted 4,700,000 B
+on both runs. The adjudicator's self-test passed 6 of 6, and its synthetic
+quadratic page returned r² **0.99696** — hand-computed at 0.99694 before it ran
+— clearing the 0.98 floor and refused only out of sample. **Q read exactly 300
+on the published `grid/*` arms at both ROOTS settings**, which at ROOTS=4 with
+B=1,200 is E/Q = 4 exactly: the ruling's mechanical claim, measured.
+
+---
+
+## 4. The additive model
+
+Two models were adjudicated, because assuming the ruling's shape and reporting
+its terms would have been assuming the answer:
+
+```
+M3    y = shell +              (E/B)·edge + (Q/B)·key      the ruling's shape
+M4    y = shell + [E>0]·step + (E/B)·edge + (Q/B)·key
+```
+
+**Each term comes from one contrast, not from one fit.**
+
+- `shell` — the `R0` rung, alone.
+- `key` — the **slope** of the `R1*` family in Q/B. E/B is pinned at 1 across
+  those four rungs; nothing but the number of unique keys moves.
+- `edge` — `R2QB2 − R1Q2`: two rungs at the **same Q**, differing by one read
+  per boundary. One extra edge each, no extra keys, nothing else.
+- `step` — what is left of the `R1*` intercept once `shell` and `edge` are taken
+  out. M3 says this is zero.
+
+`R2Q2B` is **held out of all of that** and predicted by both models. It is the
+only rung whose value nothing above depends on.
+
+**The refusal criterion, stated before the run and not moved after it.** Written
+into `p0-heap/additive-criterion`, applied by `p0-heap/additive-fit`, and
+adjudicated per round as well as on the round means:
+
+| check | threshold |
+|---|---|
+| the `R1*` family is a line in Q/B | r² ≥ **0.98** |
+| the key term from the R=2 **pair** agrees with the R=1 slope | within **15%** |
+| M3 — edge priced from the intercept equals edge priced from the contrast | `\|step\|` ≤ **10%** of the fan-out-1 boundary |
+| the model predicts the held-out `R2Q2B` rung | within **10%** |
+
+If the first two fail, no component price is quotable at all. Otherwise the
+model that survives its own held-out check carries the prices, and if neither
+does, the page publishes the rows and refuses the prices.
+
+**The adjudicator's own positive control.** Three synthetic pages, built by
+arithmetic and never measured, run before the sweep does: an exact M3 page that
+must be priced back to its three terms and predict its held-out rung *to the
+byte*; an M4 page carrying a 400 B step, whose R=1 family is a **perfect** line
+(r² = 1.000000) and which M3 still misses by 12.90% on the held-out rung; and a
+page with a quadratic key term that both models must refuse. **That middle page
+is the whole argument for the R=2 rungs existing** — a page that is not M3 can
+fit the R=1 family perfectly, and nothing inside that family can tell.
+
+### The verdicts
+
+| | model | r² | held-out `R2Q2B` | rounds agreeing |
+|---|---|---:|---|---:|
+| Reagent, ROOTS=4 | **M4** | 0.99732 | M3 +10.44% *(fail)* · M4 +4.55% | 5 of 6 |
+| Reagent, ROOTS=1 | **M4** | 0.99862 | M3 +0.51% · M4 −5.63% | 2 of 6 |
+| UIx, ROOTS=4 | **M3** | 0.99989 | M3 +1.95% · M4 +1.34% | **6 of 6** |
+| UIx, ROOTS=1 | **M3** | 0.99994 | M3 −0.20% · M4 −1.04% | **6 of 6** |
+
+**UIx is M3, unambiguously.** Both runs, every round, r² ≥ 0.9999, the two edge
+identifications within 3.8% of each other, and the held-out rung predicted
+within 2% by a model that never saw it.
+
+**Reagent reaches M4 in both runs and does not reach it stably.** Look at what
+actually happens: at ROOTS=4 the step (150 B) sits *inside* its 165 B band while
+M3 misses the held-out rung by 10.44% against a 10% threshold; at ROOTS=1 the
+step (163 B) sits *outside* its 160 B band while M3 predicts the held-out rung
+to **0.51%** — better than M4's −5.63%. Both runs land on M4 by the rule, by
+different failing checks, and the per-round verdicts flip (M3, M4, refused, M3,
+refused, M4).
+
+**That instability is the result, not noise to be averaged away.** Reagent's
+non-per-key cost of reading is ~234–244 B at one read, and this sweep can say
+that number confidently. What it cannot say is how to split it: the two
+identifications of `edge` give **84 B** and **234 B** — the disagreement is
+larger than twice the smaller term. On UIx the same disagreement is 38 B against
+a 1,344 B term. **The Reagent per-edge price is refused, and the criterion that
+refuses it is the one written down before the run.**
+
+---
+
+## 5. The terms
+
+Ranges are across the six rounds of each run; the two runs are reported
+separately and never as a mean, because the pair exists to show the figures do
+not move.
+
+### Reagent on re-frame2 subs
+
+| term | ROOTS=4 | ROOTS=1 | cross-check |
+|---|---:|---:|---|
+| **shell** (R=0) | **501** [496–506] | **524** [510–545] | ladder R=0 428 B *(different boundary component — see below)* |
+| **per-unique-key** (R=1 slope) | **919** [901–939] | **830** [785–864] | from the R=2 pair: **823** / **919** · `rf2-2rtt6.12` ablation **866** |
+| per-edge, from the contrast | 84 [76–98] | 80 [59–117] | — |
+| per-edge, from the intercept | 234 | 244 | **the two disagree by 160 B — refused** |
+| step (M4's fourth term) | 150 [123–173] | 163 [122–187] | ladder's first-read excess **224 B** |
+
+### UIx on re-frame2 subs
+
+| term | ROOTS=4 | ROOTS=1 | cross-check |
+|---|---:|---:|---|
+| **shell** (R=0) | **221** [218–224] | **231** [215–255] | ladder R=0 208 B |
+| **per-unique-key** (R=1 slope) | **1,628** [1,613–1,659] | **1,559** [1,525–1,658] | from the R=2 pair: **1,580** / **1,601** · `.12` ablation less the removed term **1,684** |
+| **per-edge**, from the contrast | **1,344** [1,327–1,365] | **1,345** [1,339–1,352] | from the intercept 1,382 / 1,396 — **3.8% apart** |
+| step | 38 [24–54] | 52 [26–72] | inside its band in every round |
+
+**Four instruments now agree on the subscription term.** Reagent: this sweep's
+four estimates span **823–939 B** and `rf2-2rtt6.12`'s direct ablation reads
+**866 B**, dead centre; the ruling's own cross-family algebra solved 820–824 B,
+at the bottom of the range. UIx: this sweep reads **1,525–1,659 B** against
+`.12`'s 1,684 B once the 769 B `.13` removed is taken out — 1.5% above the top
+of the range. The algebra the ruling refused to freeze budgets from turns out to
+have been right; it was right for a reason it could not demonstrate, and now one
+run demonstrates it.
+
+**Where the two substrates actually spend.** UIx wins the shell by 2.3×
+(221 B against 501 B) and loses everything else: its per-edge term is
+**1,344 B against Reagent's 84–234 B**, which is the hook spine — one
+`useSyncExternalStore` slot, its store object, its subscribe closure — paid per
+*attachment*, and its per-unique-key term is 1.8× Reagent's. That is the same
+story `uix-spine-per-read-decomposition.md` tells by ablation, arrived at from
+the opposite direction.
+
+**A caveat on the shell, and it is this page's own.** The `R0` rung here reads
+501–524 B on Reagent against the ladder's 428 B, because this sweep's boundary
+component carries two props (its DOM index and its global index) where the
+ladder's carries one, and both are held uniform across every rung so that the
+shell rung is not measuring one fewer prop slot than the rungs it anchors. The
+**shell is component-shape sensitive at the ~75 B level**, and a shell budget
+should therefore name the boundary shape it is stated for. It clears the 1 KB
+paper-fail line on both substrates either way; on Reagent it sits at the top of
+the 0.4–0.5 KB target band rather than inside it.
+
+---
+
+## 6. What this unblocks
+
+Part 3 of the ruling gated three component budget rows on this sweep. The sweep
+answers for two of them on both substrates, and refuses one.
+
+| row | Reagent | UIx |
+|---|---|---|
+| **shell** (R=0 boundary) | **UNBLOCKED** — 501–524 B, *stated for a named boundary shape* | **UNBLOCKED** — 221–231 B |
+| **per-unique-subscription-key** | **UNBLOCKED** — **~866 B** [823–939] | **UNBLOCKED** — **~1,590 B** [1,525–1,659] |
+| **per-edge** (consumer attachment) | **REFUSED** — the two identifications differ by more than twice the smaller term | **UNBLOCKED** — **~1,345 B** [1,327–1,396] |
+
+And it adds one row Part 3 did not name:
+
+- **a per-subscribing-boundary step on Reagent, ~150–163 B**, which is neither
+  shell nor per-edge. Its existence is established (the ladder's 224 B first-read
+  excess, this sweep's M4 verdict in both runs); its exact split against the
+  per-edge term is not. The honest form for validation.md is a **single
+  first-read term of ~234–244 B for Reagent** with the step/edge split marked
+  unresolved, rather than two numbers of which one is wrong by 3×.
+
+The edit to `validation.md` is not made from this seat — that file is normative.
+It is filed as its own bead, carrying this page's numbers and this section's
+refusals.
+
+**What the sweep does *not* touch.** The clock axis, the converged witness set,
+the red-zone thresholds, the kill criteria, and the `.4`/`.5` family standings.
+Part 1 stands as ruled, now with its prediction confirmed and its mechanism
+measured rather than inferred.
+
+---
+
+## 7. Open
+
+- **The 9.3% ratio drift across fan-out** ([§2](#2-the-rows)) refines Part 1's
+  "the ratio survives regimes". It survives approximately. Whether a donor gate
+  should carry a band rather than a point is the operator's call, not this
+  page's.
+- **The Reagent step/edge split** wants a rung this sweep does not have: R=3 at
+  fixed Q would over-determine the pair and separate them. It is one more rung
+  on the same instrument and would take one more run.
+- **The `+5.2%` common-mode offset** between this instrument and the reads
+  ladder is measured twice ([§3](#3-the-prediction-adjudicated)) and unexplained.
+  The most likely cause is the boundary component's prop count, the same ~75 B
+  the shell caveat names; nothing here establishes that.

--- a/docs/design/hicasso/studio/heap-fan-out-sweep.md
+++ b/docs/design/hicasso/studio/heap-fan-out-sweep.md
@@ -299,6 +299,24 @@ The Reagent arm reproduces to three parts in a thousand across two months, two
 trees and a re-run. The UIx arm moves down by what `.13` predicts, to within
 2.5%.
 
+**And the published heap ROW — not a rung of this sweep, the `--only heap` row
+itself, untouched — says the same thing.** Run on this tree at the same
+`P0_ROOTS=4` as a regression check that this PR did not disturb it (exit 0,
+guard reportable, 0 unverified of 56 mounts):
+
+| | published `.4` | this tree |
+|---|---:|---:|
+| `grid` Reagent exclusive | 947 B | 1,198 − 251 = **947 B** |
+| `grid` UIx exclusive | 2,134 B | 2,236 − 244 = **1,992 B** |
+| `grid` exclusive ratio | 2.254× | **2.104×** [2.056–2.138] |
+
+The Reagent denominator is the published figure **to the byte**. The UIx
+numerator has moved, by `.13`, and the ratio with it — which is the second
+independent statement of the same thing, on the instrument that published the
+original. Those mounts also passed the new **Q** read-back, so the `.4` grid
+arm's E/Q = 4 is now checked every time that row is taken and not only when this
+sweep runs.
+
 ### P2 and P3 — see [§4](#4-the-additive-model) and [§5](#5-the-terms)
 
 P3 called it: **M4 on Reagent, M3 on UIx**, and the mechanism is the one the

--- a/docs/design/hicasso/studio/heap-fan-out-sweep.md
+++ b/docs/design/hicasso/studio/heap-fan-out-sweep.md
@@ -1,0 +1,67 @@
+# What does sharing a subscription do to a boundary's retained heap?
+
+Seat: EVIDENCE SPIKE, EP-0038. Bead `rf2-5prok`, adopted as *Codex rec 4* by the
+heap-regime ruling (authoritative text on `rf2-2rtt6.16`; transcription on
+`rf2-2rtt6.1`).
+
+**Standing.** This sweep is **non-gating** for that ruling, which stands
+regardless of what is below. It is **gating** for freezing Part 3's component
+budget rows — the shell / per-edge / per-unique-key numbers that may not enter
+[validation.md](../validation.md) until a sweep verifies the additive model and
+prices the terms.
+
+---
+
+## The prediction, on record, before the run
+
+Written and committed before the published rungs were measured. The ruling put
+one prediction on record and this page adds the rest, because a page that only
+records the predictions it got right is not recording predictions.
+
+**P1 — the fan-out-1 rung lands on the ladder's distinct-query family** (the
+ruling's own falsifiable claim): Reagent ~**1,562 B**, UIx ~**3,807 B** at one
+read, ratio 2.25–2.44×. *A material miss reopens Part 1 of the ruling.*
+
+**P1′ — but the ladder's absolutes predate two spine landings, and this sweep
+measures the tree after both.** `rf2-2rtt6.13` (PR #7304) removed a retained,
+disposed, unreachable reaction worth **769 B / 23.0 objects per UIx read**;
+`rf2-2rtt6.25` (PR #7305) landed the hook-scoped provisional hand-off, taking
+the cold read from two reaction constructions to one. The dead reaction was
+built once per *cache miss*, so it belongs to the per-unique-key term, not the
+per-edge one. So the corrected prediction is:
+
+| rung | ladder, as published | predicted here (post-.13/.25) |
+|---|---:|---:|
+| Reagent, fan-out 1, R=1 | 1,562 B | **~1,562 B** (unchanged — the fix is UIx-side) |
+| UIx, fan-out 1, R=1 | 3,807 B | **~3,038 B** (3,807 − 769) |
+| UIx, fan-out 4, R=1 | 2,134 B (the `.4` grid) | **~1,942 B** (2,134 − 769/4) |
+
+**P2 — the terms.** Reagent shell ~428 B, per-unique-key ~866 B
+(`rf2-2rtt6.12`'s ablation), per-edge ~270 B by difference. UIx shell ~208 B,
+per-unique-key ~1,684 B (the 2,453 B ablation less the 769 B the fix removed),
+per-edge ~1,146 B.
+
+**P3 — the model may not be three terms.** The reads ladder's own Reagent curve
+fits `397 + 943·R` at r² 0.9988 while its measured R=0 shell reads 428 B and its
+R=1 rung reads 1,562 B — a first read that costs **224 B more than the line**,
+invisible in an r² taken against a 19 KB range. If that step is real and is a
+per-*subscribing-boundary* cost rather than a per-edge one, the three-term
+budget the ruling named would misprice every page whose fan-out is not 1. The
+sweep therefore adjudicates **two** models and holds a rung back to tell them
+apart. Predicted: **M4 on Reagent, M3 on UIx.**
+
+**P4 — the instrument's own controls**, predicted before the run:
+
+- the dense-array positive control reads **4,700,000 B** (587,500 unboxed
+  doubles × 8) on every round;
+- the adjudicator's self-test passes 6 of 6, and its synthetic quadratic page
+  clears the r² floor at **≈0.997** and is refused only out of sample;
+- **Q, counted off the frame's sub-cache**, reads exactly 300 on the published
+  `grid/*` arms at *every* ROOTS setting. That is the ruling's central
+  mechanical claim — four roots rendering one frame's query vectors hold 300
+  reactions, not 1,200 — and this sweep turns it from a reading of the source
+  into a number the instrument refuses to proceed without.
+
+---
+
+*(Results follow once the published rungs are measured.)*

--- a/docs/design/hicasso/studio/heap-fan-out-sweep.md
+++ b/docs/design/hicasso/studio/heap-fan-out-sweep.md
@@ -233,8 +233,11 @@ ruling computed across two instruments. *The incomparability the ruling priced
 is real, and this is the direct measurement of it.*
 
 **Per-boundary cost does not depend on B.** Every rung agrees between B = 300
-and B = 1,200 to within **4.0% on Reagent and 1.5% on UIx** — most within 1%.
-Whatever a page pays once is not showing up in these denominators.
+and B = 1,200 to within **4.6% on both substrates**, over a fourfold change in
+B. On UIx the *only* rung above 1.6% is the R=0 shell (221 against 231 B, where
+ten bytes is 4.5%) — every rung above 1 KB agrees to **1.6% or better**, five of
+the six to under 0.7%. On Reagent the spread is 2.0–4.6% throughout. Whatever a
+page pays once is not showing up in these denominators.
 
 **The `:p0/fan` substitution is not doing any work.** At identical B/E/Q the fan
 rung and the published `grid` arm — different query ids, otherwise the same page
@@ -424,7 +427,7 @@ of the range. The algebra the ruling refused to freeze budgets from turns out to
 have been right; it was right for a reason it could not demonstrate, and now one
 run demonstrates it.
 
-**Where the two substrates actually spend.** UIx wins the shell by 2.3×
+**Where the two substrates actually spend.** UIx wins the shell by 2.27×
 (221 B against 501 B) and loses everything else: its per-edge term is
 **1,344 B against Reagent's 84–234 B**, which is the hook spine — one
 `useSyncExternalStore` slot, its store object, its subscribe closure — paid per

--- a/implementation/core/test/re_frame/bench/p0_fixture.cljc
+++ b/implementation/core/test/re_frame/bench/p0_fixture.cljc
@@ -39,6 +39,16 @@
   make the NARROW row unmeasurable by construction — the row that prices
   localisation would price nothing.
 
+  ## The fan-out key space (rf2-5prok)
+
+  `:p0/fan` is a fourth layer-1 subscription that exists so a heap arm can
+  set the number of UNIQUE live query keys INDEPENDENTLY of the number of
+  boundaries and the number of reads. It answers the same cell values
+  `:p0/cell` answers, folded round the seeded range, so a rung holding
+  2,400 keys renders exactly the DOM a rung holding 150 does and the
+  difference between them is cache cardinality and nothing else. See
+  [[fan-key]].
+
   ## Sub-key identity
 
   `(query-id, args)` under value equality, args a bare long. A map would
@@ -87,6 +97,44 @@
   (+ 1 n))
 
 ;; ---------------------------------------------------------------------------
+;; The fan-out key space — B, E and Q as three numbers, not three shapes
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private fan-q
+  ;; Q for the arm currently mounted. A `volatile!` and not an `atom`: it is
+  ;; set ONCE per arm, outside every measured window, and nothing derefs it
+  ;; reactively — a ratom here would put a watchable in the middle of the
+  ;; thing being weighed.
+  (volatile! 1))
+
+(defn set-fan-keys!
+  "Set Q — the number of UNIQUE live query keys the arm about to mount will
+  hold — before mounting it. The heap driver states B, E/B and Q; this is
+  the only one of the three the page cannot read off the DOM, which is why
+  `p0-heap/mount!` asks the sub-cache to prove it afterwards."
+  [q]
+  (vreset! fan-q (max 1 (long q)))
+  nil)
+
+(defn fan-key
+  "The query INDEX that boundary `n` reads at slot `j` of its `r` reads:
+  `(n·r + j) mod Q`.
+
+  ONE rule, so the whole witness stamp falls out of three numbers the
+  driver chose. B boundaries × r reads is E; the modulus is Q; mean fan-out
+  is E/Q. Every key in `0 … Q-1` is used whenever `B·r >= Q`, which every
+  rung of the published sweep satisfies, so `Q` is the exact live
+  cardinality and not an upper bound on it.
+
+  `n` is the GLOBAL boundary index — root index × boundaries-per-root plus
+  the cell's own index — because the roots of one arm share one frame and
+  therefore one subscription cache. That sharing is the mechanism the whole
+  sweep is about (rf2-2rtt6.16): four roots rendering the same query
+  vectors hold one reaction at ref-count 4, not four reactions."
+  [n r j]
+  (mod (+ (* n r) j) @fan-q))
+
+;; ---------------------------------------------------------------------------
 ;; The data
 ;; ---------------------------------------------------------------------------
 
@@ -123,6 +171,12 @@
   (rf/reg-sub :p0/row   (fn [db [_ i]] (get-in db [:rows i])))
   (rf/reg-sub :p0/field (fn [db [_ i]] (get-in db [:fields i])))
   (rf/reg-sub :p0/cell  (fn [db [_ i]] (get-in db [:cells i])))
+  ;; The fan-out arm's key space. The index is folded back into the seeded
+  ;; range, so EVERY key — 0 or 2,399 — answers the same `0` the `:p0/cell`
+  ;; grid answers and every rung of the sweep renders identical DOM. A rung
+  ;; whose text differed with Q would be moving the floor it is differenced
+  ;; against while claiming to move only the cache.
+  (rf/reg-sub :p0/fan   (fn [db [_ i]] (get-in db [:cells (mod i cells-n)])))
   (rf/reg-event :p0/seed (fn [_ _] {:db (seed-db)}))
   ;; The two BULK writes, as ordinary re-frame events. Both arms drive
   ;; their bulk row through `dispatch-sync` on these, because in re-frame2

--- a/implementation/core/test/re_frame/bench/p0_heap.cljs
+++ b/implementation/core/test/re_frame/bench/p0_heap.cljs
@@ -334,26 +334,48 @@
 ;; It also REFUSES to freeze those numbers from cross-instrument algebra,
 ;; because the paired rows came from different instruments and runs — and
 ;; it makes this sweep the gate. So the sweep has to do two things a fit
-;; alone does not: identify the terms from CONTRASTS that move one factor
-;; at a time, and then try to BREAK the model on rungs it was not fitted
-;; to.
+;; alone does not: identify each term from a CONTRAST that moves one
+;; factor at a time, and then try to BREAK the model on a rung it was not
+;; fitted to.
 ;;
-;; Identification. The R=1 family holds E/B = 1 and walks Q/B, so a
-;; straight line through it has slope `key` and intercept `shell + edge`;
-;; the R=0 rung measures `shell` on its own; `edge` is the difference. All
-;; three come out of one page, one round, one reader.
+;; ## Two models, because the published ladder already doubts the first
 ;;
-;; Falsification. Two R=2 rungs are then measured and PREDICTED FROM
-;; NOTHING BUT THE ABOVE. They are not in the fit. If the cost of a read
-;; depended on how many reads a boundary already had, or if a shared key
-;; were cheaper per consumer than an exclusive one, the R=1 family would
-;; still be a line and the R=2 predictions would miss. The self-test below
-;; proves that is not a hypothetical: a synthetic page with a quadratic
-;; key term passes the r² floor at 0.997 and is caught only here.
+;; **M3** is the ruling's shape exactly, three terms. **M4** adds one:
 ;;
-;; The verdict this returns is not an instrument fault and does not stop a
-;; run. It decides whether the numbers may be QUOTED as component prices,
-;; which is the thing the ruling gated.
+;;     y = shell + [E>0]·step + (E/B)·edge + (Q/B)·key
+;;
+;; where `step` is what a boundary pays for SUBSCRIBING AT ALL, over and
+;; above what it pays per read. There is already evidence for it: the
+;; reads ladder's Reagent curve fits `397 + 943·R` at r² 0.9988 while its
+;; measured R=0 shell reads 428 and its R=1 rung reads 1,562 — a first
+;; read that costs 224 B more than the line, invisible in an r² taken
+;; against a 19 KB range. M3 says that number is zero. Deciding between
+;; them is this sweep's job; assuming M3 and reporting its terms would be
+;; assuming the answer.
+;;
+;; ## Identification — each term from one contrast
+;;
+;;   shell  the R=0 rung, on its own.
+;;   key    the SLOPE of the R=1 family in Q/B. E/B is pinned at 1 across
+;;          those four rungs, so nothing but the number of unique keys is
+;;          moving.
+;;   edge   `R2QB2 − R1Q2`: two rungs at the SAME Q, differing by one read
+;;          per boundary. One extra edge each, no extra keys, nothing else.
+;;   step   `(intercept − shell) − edge`. The intercept of the R=1 family
+;;          is everything a reading boundary pays that is not per-key; the
+;;          contrast says how much of that is per-EDGE; the remainder is
+;;          the term M3 says does not exist.
+;;
+;; ## Falsification — one rung is held out
+;;
+;; `R2Q2B` (two reads, every one of them distinct) is measured and never
+;; used to identify anything. Both models predict it from the terms above
+;; and the page publishes both predictions. A model that survives that is
+;; a model that priced a rung it had never seen.
+;;
+;; The verdict is not an instrument fault and does not stop a run. It
+;; decides whether the numbers may be QUOTED as component prices, and
+;; under which shape — which is exactly what the ruling gated.
 
 (def additive-criterion
   "The thresholds, fixed before the sweep ran and not moved after it.
@@ -361,17 +383,25 @@
   `:min-r2` — the R=1 family must be a line in Q/B. 0.98 over four rungs
   is well inside what this instrument has shown it can resolve (the reads
   ladder returned r² ≥ 0.9987 on both substrates) and far outside what a
-  page with a real interaction term would return.
+  page whose shared reactions were priced differently from its exclusive
+  ones would return. This one gates everything: without it there is no
+  per-unique-key price to argue about.
 
-  `:max-oos-error` — each R=2 rung's prediction must land within 10% of
-  the measured value. The rungs sit at 3–13 KB per boundary and this
-  instrument's per-arm ranges are well under 1% wide, so 10% is a margin
-  for the model, not for the reader.
+  `:max-oos-error` — the held-out rung must be predicted within 10%. It
+  sits at 3–13 KB per boundary and this instrument's per-arm ranges are
+  well under 1% wide, so 10% is a margin for the MODEL, not for the
+  reader.
 
-  `:max-key-disagreement` — the per-key term solved from the R=2 PAIR
+  `:max-key-disagreement` — the per-key term solved from the R=2 pair
   alone must agree with the R=1 slope within 15%. Two disjoint subsets of
-  the sweep, one arithmetic."
-  {:min-r2 0.98 :max-oos-error 0.10 :max-key-disagreement 0.15})
+  the sweep, one arithmetic.
+
+  `:max-step-frac` — how big `step` may be, as a fraction of the whole
+  fan-out-1 boundary, and still be called zero. 10%: a term that moves a
+  distinct-query boundary by a tenth is not a rounding error, and a
+  budget that named it `edge` would misprice every page whose fan-out is
+  not 1."
+  {:min-r2 0.98 :max-oos-error 0.10 :max-key-disagreement 0.15 :max-step-frac 0.10})
 
 (defn- ols
   "Ordinary least squares of `[x y]` pairs. Answers `{:slope :intercept
@@ -396,139 +426,200 @@
 (defn- pct [x] (str (.toFixed (* 100.0 x) 2) "%"))
 
 (defn additive-fit
-  "Price `shell`, `edge` and `key` from one substrate's rungs, and
-  adjudicate whether they may be quoted.
+  "Price the terms from one substrate's rungs and adjudicate which model —
+  if either — may carry them into a budget.
 
   `rungs` is a seq of `{:rung :reads :keys :boundaries :y}`, where `y` is
   exclusive retained bytes per boundary (arm − floor). Answers a map whose
-  `:ok?` is the ruling's refusal rule: false means the page publishes the
-  rows and NOT the prices, and says which check failed."
-  [rungs {:keys [min-r2 max-oos-error max-key-disagreement]}]
+  `:model` is `\"M3\"`, `\"M4\"` or `nil`; `nil` means the page publishes
+  the ROWS and not the PRICES, and says which check refused."
+  [rungs {:keys [min-r2 max-oos-error max-key-disagreement max-step-frac]}]
   (let [xof      (fn [{:keys [keys boundaries]}] (/ (double keys) (double boundaries)))
         of-reads (fn [r] (vec (sort-by xof (filterv #(= r (long (:reads %))) rungs))))
         zero     (first (of-reads 0))
         ones     (of-reads 1)
-        twos     (of-reads 2)]
+        twos     (of-reads 2)
+        pair     (fn [xs x] (first (filter #(< (js/Math.abs (- (xof %) x)) 1e-9) xs)))]
     (if (or (nil? zero) (< (count ones) 3) (< (count twos) 2))
-      {:ok?  false
-       :why  (str "the sweep is missing a rung the model needs — R=0 ×"
-                  (if zero 1 0) ", R=1 ×" (count ones) ", R=2 ×" (count twos)
-                  " (need 1, ≥3, 2)")
+      {:ok?    false
+       :model  nil
+       :why    (str "the sweep is missing a rung the model needs — R=0 ×"
+                    (if zero 1 0) ", R=1 ×" (count ones) ", R=2 ×" (count twos)
+                    " (need 1, ≥3, 2)")
        :checks []}
       (let [{:keys [slope intercept r2]} (ols (mapv (fn [g] [(xof g) (:y g)]) ones))
             shell    (:y zero)
             key-term slope
-            edge     (- intercept shell)
-            predict  (fn [g] (+ shell (* 2.0 edge) (* (xof g) key-term)))
-            oos      (mapv (fn [g]
-                             (let [p (predict g)]
-                               {:rung     (:rung g)
-                                :q-over-b (xof g)
-                                :measured (:y g)
-                                :predicted p
-                                :error    (/ (- p (:y g)) (:y g))}))
-                           twos)
+            ;; The identification pair: the LOWER-Q of the two R=2 rungs
+            ;; and the R=1 rung at the same Q. One extra edge per boundary
+            ;; and nothing else moved.
             lo       (first twos)
             hi       (peek twos)
+            twin     (pair ones (xof lo))
+            edge-c   (when twin (- (:y lo) (:y twin)))
+            edge-i   (- intercept shell)
+            step     (when edge-c (- edge-i edge-c))
+            ;; The HELD-OUT rung: never used above, predicted by both.
+            m3       (+ shell (* 2.0 edge-i) (* (xof hi) key-term))
+            m4       (when step
+                       (+ shell step (* 2.0 edge-c) (* (xof hi) key-term)))
+            err      (fn [p] (when p (/ (- p (:y hi)) (:y hi))))
+            m3-err   (err m3)
+            m4-err   (err m4)
             dx       (- (xof hi) (xof lo))
             key-2    (when-not (zero? dx) (/ (- (:y hi) (:y lo)) dx))
             key-gap  (when (and key-2 (not (zero? key-term)))
                        (/ (- key-2 key-term) key-term))
-            twin     (first (filter #(< (js/Math.abs (- (xof %) (xof lo))) 1e-9) ones))
-            edge-2   (when twin (- (:y lo) (:y twin)))
+            fan1     (+ intercept key-term)          ; the whole Q/B = 1 boundary
+            step-lim (* max-step-frac (js/Math.abs fan1))
+            linear?  (>= r2 min-r2)
+            key-ok?  (boolean (and key-gap (<= (js/Math.abs key-gap) max-key-disagreement)))
+            step-0?  (boolean (and step (<= (js/Math.abs step) step-lim)))
+            m3-ok?   (boolean (and m3-err (<= (js/Math.abs m3-err) max-oos-error)))
+            m4-ok?   (boolean (and m4-err (<= (js/Math.abs m4-err) max-oos-error)))
+            model    (cond
+                       (not (and linear? key-ok?)) nil
+                       (and step-0? m3-ok?)        "M3"
+                       m4-ok?                      "M4"
+                       :else                       nil)
             checks
-            [{:name "the R=1 family is a LINE in Q/B"
-              :ok   (>= r2 min-r2)
+            [{:name "the R=1 family is a LINE in Q/B — the per-unique-key price exists"
+              :ok   linear?
               :detail (str "r² " (.toFixed r2 5) " over " (count ones)
                            " rungs (floor " min-r2 ")")}
-             {:name "the two R=2 rungs are predicted OUT OF SAMPLE"
-              :ok   (every? #(<= (js/Math.abs (:error %)) max-oos-error) oos)
-              :detail (str/join
-                        " · "
-                        (map (fn [o]
-                               (str (:rung o) " predicted " (.toFixed (:predicted o) 0)
-                                    " B, measured " (.toFixed (:measured o) 0)
-                                    " B, " (pct (:error o))))
-                             oos))}
              {:name "the per-key term from the R=2 PAIR agrees with the R=1 slope"
-              :ok   (boolean (and key-gap
-                                  (<= (js/Math.abs key-gap) max-key-disagreement)))
+              :ok   key-ok?
               :detail (if key-gap
                         (str "R=2 pair " (.toFixed key-2 0) " B vs R=1 slope "
                              (.toFixed key-term 0) " B — " (pct key-gap))
-                        "the two R=2 rungs share a Q/B; the pair cannot price a slope")}]]
-        {:ok?        (every? :ok checks)
-         :checks     checks
-         :shell      shell
-         :edge       edge
-         :key        key-term
-         :edge-alt   edge-2
-         :key-alt    key-2
-         :intercept  intercept
-         :r2         r2
-         :oos        oos
-         :criterion  {:min-r2 min-r2
-                      :max-oos-error max-oos-error
-                      :max-key-disagreement max-key-disagreement}
-         :why        (if (every? :ok checks)
-                       "additive — component prices may be quoted"
-                       (str "REFUSED: "
-                            (str/join "; " (map :name (remove :ok checks)))))}))))
+                        "the two R=2 rungs share a Q/B; the pair cannot price a slope")}
+             {:name "M3 — the per-edge term is the same priced from the intercept and from the contrast"
+              :ok   step-0?
+              :detail (if step
+                        (str "intercept − shell = " (.toFixed edge-i 0)
+                             " B, R2QB2 − R1Q2 = " (.toFixed edge-c 0)
+                             " B, so step = " (.toFixed step 0) " B against a "
+                             (.toFixed step-lim 0) " B band ("
+                             (.toFixed (* 100.0 max-step-frac) 0) "% of the Q/B=1 boundary)")
+                        "no R=1 rung shares a Q with an R=2 rung — the contrast is unavailable")}
+             {:name "M3 predicts the HELD-OUT R2Q2B rung"
+              :ok   m3-ok?
+              :detail (str "predicted " (.toFixed m3 0) " B, measured "
+                           (.toFixed (:y hi) 0) " B — " (pct m3-err))}
+             {:name "M4 (M3 + a per-subscribing-boundary step) predicts the HELD-OUT R2Q2B rung"
+              :ok   m4-ok?
+              :detail (if m4
+                        (str "predicted " (.toFixed m4 0) " B, measured "
+                             (.toFixed (:y hi) 0) " B — " (pct m4-err))
+                        "step unavailable, so M4 is unidentified")}]]
+        {:ok?            (some? model)
+         :model          model
+         :checks         checks
+         :shell          shell
+         :key            key-term
+         :key-alt        key-2
+         :edge-intercept edge-i
+         :edge-contrast  edge-c
+         :edge           (if (= model "M3") edge-i edge-c)
+         :step           step
+         :intercept      intercept
+         :r2             r2
+         :held-out       {:rung (:rung hi) :measured (:y hi)
+                          :m3 m3 :m3-error m3-err :m4 m4 :m4-error m4-err}
+         :criterion      {:min-r2 min-r2
+                          :max-oos-error max-oos-error
+                          :max-key-disagreement max-key-disagreement
+                          :max-step-frac max-step-frac}
+         :why            (case model
+                           "M3" "ADDITIVE (M3) — shell / per-edge / per-unique-key may be quoted"
+                           "M4" (str "ADDITIVE ONLY WITH A FOURTH TERM (M4) — a subscribing "
+                                     "boundary pays a step of " (.toFixed step 0)
+                                     " B that is neither shell nor per-edge; the three-term "
+                                     "budget would misprice every page whose fan-out is not 1")
+                           (str "REFUSED: "
+                                (str/join "; " (map :name (remove :ok checks)))))}))))
 
 (defn fan-self-test
   "The adjudicator's own positive control, PREDICTED before it is run.
 
-  Two synthetic pages, both built by arithmetic rather than measured:
+  Three synthetic pages, all built by arithmetic and none measured, each
+  one a shape the sweep must tell apart from the others:
 
-  **A** is the model exactly — shell 400, edge 250, key 900 over B = 1,200
-  — and must be priced back to those three numbers and accepted.
+  **A** is M3 exactly — shell 400, edge 250, key 900 over B = 1,200. It
+  must come back `M3` with those three numbers and a held-out rung
+  predicted to the byte.
 
-  **B** adds a QUADRATIC key term (`+300·(Q/B)²`), which is what a page
-  whose shared reactions were cheaper per consumer than its exclusive ones
-  would look like. It must be REFUSED — and the interesting part is where:
-  its R=1 family still fits a line at r² ≈ 0.997, comfortably past the
-  0.98 floor, so the linearity check passes and only the out-of-sample
-  R=2 rungs catch it. That is the whole reason the R=2 rungs exist, and a
-  self-test that did not price it would leave them looking like padding.
+  **B** is M4 — the same, plus a 400 B step every subscribing boundary
+  pays. Its R=1 family is a PERFECT line (r² = 1) and its held-out rung is
+  still missed by M3, because M3 has nowhere to put the step but the
+  per-edge term and then charges it twice. It must come back `M4`, with
+  the step recovered at 400 B.
 
-  A rule that cannot fail has not adjudicated anything."
+  **C** carries a quadratic key term (`+300·(Q/B)²`) — what a page whose
+  shared reactions were priced differently from its exclusive ones would
+  look like. Both models must REFUSE it. Its R=1 family still fits a line
+  at r² ≈ 0.997, comfortably past the 0.98 floor, so the linearity check
+  is not what catches it.
+
+  B and C are the reason the R=2 rungs are in the sweep at all: a page
+  that is not M3 can fit the R=1 family perfectly, and nothing inside that
+  family can tell. A rule that cannot fail has not adjudicated anything."
   []
   (let [b     1200.0
         mk    (fn [f] (mapv (fn [[id r q]] {:rung id :reads r :keys q :boundaries b
-                                            :y (f r (/ (double q) b))})
+                                            :y (f (double r) (/ (double q) b))})
                             [["R0" 0 0] ["R1Q1" 1 1200] ["R1Q2" 1 600]
                              ["R1Q4" 1 300] ["R1Q8" 1 150]
                              ["R2Q2B" 2 2400] ["R2QB2" 2 600]]))
-        exact (mk (fn [r x] (if (zero? r) 400.0 (+ 400.0 (* r 250.0) (* x 900.0)))))
+        m3*   (mk (fn [r x] (if (zero? r) 400.0 (+ 400.0 (* r 250.0) (* x 900.0)))))
+        m4*   (mk (fn [r x] (if (zero? r)
+                              400.0
+                              (+ 400.0 400.0 (* r 250.0) (* x 900.0)))))
         curvy (mk (fn [r x] (if (zero? r)
                               400.0
                               (+ 400.0 (* r 250.0) (* x 900.0) (* x x 300.0)))))
-        fa    (additive-fit exact additive-criterion)
-        fb    (additive-fit curvy additive-criterion)
-        near? (fn [a b tol] (< (js/Math.abs (- a b)) tol))
-        chk   [{:name "the exact additive page is priced back to its own three terms"
-                :ok   (and (:ok? fa)
+        fa    (additive-fit m3* additive-criterion)
+        fb    (additive-fit m4* additive-criterion)
+        fc    (additive-fit curvy additive-criterion)
+        near? (fn [a b tol] (and (number? a) (< (js/Math.abs (- a b)) tol)))
+        held  (fn [f k] (get-in f [:held-out k]))
+        chk   [{:name "A — the exact M3 page comes back M3, priced to its own three terms"
+                :ok   (and (= "M3" (:model fa))
                            (near? (:shell fa) 400.0 0.5)
                            (near? (:edge fa) 250.0 0.5)
-                           (near? (:key fa) 900.0 0.5))
+                           (near? (:key fa) 900.0 0.5)
+                           (near? (:step fa) 0.0 0.5))
                 :detail (str "shell " (.toFixed (:shell fa) 1)
                              " · edge " (.toFixed (:edge fa) 1)
-                             " · key " (.toFixed (:key fa) 1))}
-               {:name "the exact page's R=2 rungs are predicted to the byte"
-                :ok   (every? #(< (js/Math.abs (:error %)) 1e-9) (:oos fa))
-                :detail (str/join " · " (map #(str (:rung %) " " (pct (:error %)))
-                                             (:oos fa)))}
-               {:name "a QUADRATIC key term is refused"
-                :ok   (not (:ok? fb))
-                :detail (:why fb)}
-               {:name "…and it is refused OUT OF SAMPLE, not by the r² floor"
-                :ok   (and (>= (:r2 fb) (:min-r2 additive-criterion))
-                           (not (:ok (second (:checks fb)))))
-                :detail (str "r² " (.toFixed (:r2 fb) 5)
-                             " passes the " (:min-r2 additive-criterion)
-                             " floor; the R=2 rungs miss by "
-                             (str/join " and "
-                                       (map #(pct (:error %)) (:oos fb))))}]]
+                             " · key " (.toFixed (:key fa) 1)
+                             " · step " (.toFixed (:step fa) 1))}
+               {:name "A — its HELD-OUT rung is predicted to the byte"
+                :ok   (near? (held fa :m3-error) 0.0 1e-9)
+                :detail (str "R2Q2B predicted " (.toFixed (held fa :m3) 1)
+                             " B against " (.toFixed (held fa :measured) 1) " B")}
+               {:name "B — a per-subscribing-boundary STEP is caught, and M4 carries it"
+                :ok   (and (= "M4" (:model fb))
+                           (near? (:step fb) 400.0 0.5)
+                           (near? (:edge fb) 250.0 0.5)
+                           (near? (:key fb) 900.0 0.5)
+                           (near? (held fb :m4-error) 0.0 1e-9))
+                :detail (str "step " (.toFixed (:step fb) 1)
+                             " B; M3 misses the held-out rung by "
+                             (pct (held fb :m3-error))
+                             ", M4 lands on it")}
+               {:name "B — and its R=1 family is a PERFECT line, so nothing inside it could tell"
+                :ok   (near? (:r2 fb) 1.0 1e-9)
+                :detail (str "r² " (.toFixed (:r2 fb) 6)
+                             " — the R=2 rungs are the only reason B and A are distinguishable")}
+               {:name "C — a QUADRATIC key term is refused by BOTH models"
+                :ok   (and (nil? (:model fc)) (not (:ok? fc)))
+                :detail (:why fc)}
+               {:name "C — …and not by the r² floor, which it clears"
+                :ok   (>= (:r2 fc) (:min-r2 additive-criterion))
+                :detail (str "r² " (.toFixed (:r2 fc) 5) " ≥ "
+                             (:min-r2 additive-criterion)
+                             "; the held-out rung misses by " (pct (held fc :m3-error))
+                             " (M3) and " (pct (held fc :m4-error)) " (M4)")}]]
     {:ok? (every? :ok chk) :checks chk}))
 
 ;; ---------------------------------------------------------------------------
@@ -609,13 +700,22 @@
                                          (js->clj rungs :keywordize-keys true)
                                          additive-criterion)]
                                  #js {:ok       (boolean (:ok? v))
+                                      :model    (:model v)
                                       :why      (:why v)
                                       :shell    (:shell v)
                                       :edge     (:edge v)
+                                      :edgeIntercept (:edge-intercept v)
+                                      :edgeContrast  (:edge-contrast v)
+                                      :step     (:step v)
                                       :key      (:key v)
-                                      :edgeAlt  (:edge-alt v)
                                       :keyAlt   (:key-alt v)
                                       :r2       (:r2 v)
+                                      :heldOut  #js {:rung     (get-in v [:held-out :rung])
+                                                     :measured (get-in v [:held-out :measured])
+                                                     :m3       (get-in v [:held-out :m3])
+                                                     :m3Error  (get-in v [:held-out :m3-error])
+                                                     :m4       (get-in v [:held-out :m4])
+                                                     :m4Error  (get-in v [:held-out :m4-error])}
                                       :checks   (into-array
                                                   (map (fn [c]
                                                          #js {:ok     (boolean (:ok c))

--- a/implementation/core/test/re_frame/bench/p0_heap.cljs
+++ b/implementation/core/test/re_frame/bench/p0_heap.cljs
@@ -53,9 +53,23 @@
   red-zone is set from. The absolute column is a JS-heap figure and is
   labelled as one.
 
-  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4."
+  ## Cache cardinality is part of the witness (rf2-2rtt6.16, rf2-5prok)
+
+  A retained-bytes-per-boundary figure is only defined relative to how
+  many boundaries share a subscription, so every reading here stamps **B**
+  (boundaries), **E** (boundary-query edges) and **Q** (unique live query
+  keys). B is read back off the DOM and E follows from B and the arm's
+  read count; Q is the one a page cannot see from the outside, so
+  [[mount!]] asks the frame's own sub-cache how many entries it is
+  holding and the driver refuses a mount whose answer is not the Q the
+  plan asked for. A Q that is asserted rather than counted is the same
+  class of decoration as a mount count that is printed and not gated.
+
+  Owner: rf2-2rtt6.1 (standard); this arm rf2-2rtt6.4; the fan-out family
+  and the additive model rf2-5prok."
   (:require ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]
+            [clojure.string :as str]
             [re-frame.bench.hicasso.lane :as lane]
             [re-frame.bench.order-guard :as guard]
             [re-frame.bench.p0-arms :as arms]
@@ -64,6 +78,7 @@
             [re-frame.bench.p0-harness :as h]
             [re-frame.bench.p0-reagent :as rg]
             [re-frame.bench.p0-uix :as ux]
+            [re-frame.frame :as frame]
             [reagent.dom.client :as rdc]
             [uix.dom :as uix-dom]))
 
@@ -79,67 +94,122 @@
 ;; Arms — keyed `family/substrate`, the same naming the driver schedules on
 ;; ---------------------------------------------------------------------------
 
+;; `element-of` / `form-of` take the ROOT INDEX. The published arms ignore
+;; it — four roots of `grid/uix` are four copies of one page, which is the
+;; shape that produced the fan-out finding in the first place — but the
+;; fan-out family needs it, because a root's boundaries are numbered from
+;; its own base in a GLOBAL numbering and that base is the only thing
+;; separating "four roots sharing every key" from "four roots sharing
+;; none".
+
 (defn- react-root-arm [element-of selector expected]
   {:selector    selector
    :expected    expected
-   :mount-one   (fn [c _i]
+   :mount-one   (fn [c i]
                   (let [r (react-dom-client/createRoot c)]
-                    (react-dom/flushSync (fn [] (.render r (element-of))))
+                    (react-dom/flushSync (fn [] (.render r (element-of i))))
                     r))
    :unmount-one (fn [r] (.unmount r))})
 
 (defn- reagent-root-arm [form-of selector expected]
   {:selector    selector
    :expected    expected
-   :mount-one   (fn [c _i]
+   :mount-one   (fn [c i]
                   (let [rt (rdc/create-root c)]
-                    (react-dom/flushSync (fn [] (rdc/render rt (form-of))))
+                    (react-dom/flushSync (fn [] (rdc/render rt (form-of i))))
                     rt))
    :unmount-one (fn [rt] (rdc/unmount rt))})
 
 (defn- uix-root-arm [element-of selector expected]
   {:selector    selector
    :expected    expected
-   :mount-one   (fn [c _i]
+   :mount-one   (fn [c i]
                   (let [rt (uix-dom/create-root c)]
-                    (react-dom/flushSync (fn [] (uix-dom/render-root (element-of) rt)))
+                    (react-dom/flushSync (fn [] (uix-dom/render-root (element-of i) rt)))
                     rt))
    :unmount-one (fn [rt] (uix-dom/unmount-root rt))})
 
 (def arm-table
-  "`arm-id -> {:segment :selector :expected :mount-one :unmount-one}`.
+  "`arm-id -> {:segment :selector :expected :keys-expected :mount-one
+  :unmount-one}`.
 
   `:segment` is which adapter the arm needs; the driver calls `prepare!`
   with it before taking the baseline of the pair. A floor arm names the
   segment it is being measured IN, because the floor is the calibrator and
-  has to be read on both sides of the seam."
+  has to be read on both sides of the seam.
+
+  `:keys-expected` is **Q**, and it is written down here rather than
+  derived, because the published arms are exactly the ones whose Q the
+  ruling had to reconstruct by reading the source: every root of
+  `grid/uix` renders the same `[:p0/cell 0…299]` vectors against the same
+  frame, so four roots hold **300** reactions and not 1,200. That claim is
+  now a number this instrument checks on every mount instead of an
+  argument about a file."
   {:list/floor
-   (assoc (react-root-arm #(floor/w1 (mapv fx/row-value (range rows-per-root)))
+   (assoc (react-root-arm (fn [_] (floor/w1 (mapv fx/row-value (range rows-per-root))))
                           ".row" rows-per-root)
-          :segment nil)
+          :segment nil :keys-expected 0)
 
    :list/reagent
-   (assoc (reagent-root-arm #(rg/w1-root arms/frame-id rows-per-root)
+   (assoc (reagent-root-arm (fn [_] (rg/w1-root arms/frame-id rows-per-root))
                             ".row" rows-per-root)
-          :segment :reagent-subs)
+          :segment :reagent-subs :keys-expected rows-per-root)
 
    :list/uix
-   (assoc (uix-root-arm #(ux/w1-root arms/frame-id rows-per-root)
+   (assoc (uix-root-arm (fn [_] (ux/w1-root arms/frame-id rows-per-root))
                         ".row" rows-per-root)
-          :segment :uix-subs)
+          :segment :uix-subs :keys-expected rows-per-root)
 
    :grid/floor
-   (assoc (react-root-arm #(floor/u-grid (vec (repeat per-root 0)))
+   (assoc (react-root-arm (fn [_] (floor/u-grid (vec (repeat per-root 0))))
                           ".cell" per-root)
-          :segment nil)
+          :segment nil :keys-expected 0)
 
    :grid/reagent
-   (assoc (reagent-root-arm #(rg/u-root arms/frame-id) ".cell" per-root)
-          :segment :reagent-subs)
+   (assoc (reagent-root-arm (fn [_] (rg/u-root arms/frame-id)) ".cell" per-root)
+          :segment :reagent-subs :keys-expected per-root)
 
    :grid/uix
-   (assoc (uix-root-arm #(ux/u-root arms/frame-id) ".cell" per-root)
-          :segment :uix-subs)})
+   (assoc (uix-root-arm (fn [_] (ux/u-root arms/frame-id)) ".cell" per-root)
+          :segment :uix-subs :keys-expected per-root)})
+
+;; ---------------------------------------------------------------------------
+;; The fan-out family — B, E and Q moved independently (rf2-5prok)
+;; ---------------------------------------------------------------------------
+
+(defn- fan-arm
+  "One rung of the fan-out sweep: `reads` subscription reads on each of the
+  same `.cell` boundaries the `grid` family holds, drawn from `q` unique
+  query keys across the whole page.
+
+  Constructed per mount rather than tabled, because the rung IS the
+  parameters. B is `ROOTS × per-root` and does not move; E is `B × reads`;
+  Q is `q`. Mean fan-out E/Q therefore falls out of the plan and is not a
+  property of a hand-written page."
+  [substrate reads q]
+  (let [root-of (case substrate
+                  :reagent (fn [r] (rg/fan-root arms/frame-id (* r per-root) per-root reads))
+                  :uix     (fn [r] (ux/fan-root arms/frame-id (* r per-root) per-root reads)))
+        base    (case substrate
+                  :reagent (reagent-root-arm root-of ".cell" per-root)
+                  :uix     (uix-root-arm root-of ".cell" per-root))]
+    (assoc base
+           :segment       (case substrate :reagent :reagent-subs :uix :uix-subs)
+           :reads         reads
+           ;; A boundary that reads NOTHING holds no cache entry, so the
+           ;; R=0 rung's Q is 0 whatever `q` says. Stating it here keeps
+           ;; the driver from having to special-case its own shell rung.
+           :keys-expected (if (zero? (long reads)) 0 (long q)))))
+
+(defn- arm-for
+  "Resolve `arm-id` to an arm map. `:fan/*` is parameterised by `opts`
+  (`{:reads r :keys q}`); everything else is the published table."
+  [arm-id opts]
+  (or (get arm-table arm-id)
+      (case arm-id
+        :fan/reagent (fan-arm :reagent (:reads opts) (:keys opts))
+        :fan/uix     (fan-arm :uix     (:reads opts) (:keys opts))
+        nil)))
 
 ;; ---------------------------------------------------------------------------
 ;; Segment preparation — always OUTSIDE the baseline read
@@ -165,31 +235,61 @@
 
 (defn- release!*
   []
-  (when-some [{:keys [arm handles containers]} @held]
-    (let [{:keys [unmount-one]} (get arm-table arm)]
-      (doseq [hd (reverse handles)]
-        (unmount-one hd)))
+  (when-some [{:keys [unmount-one handles containers]} @held]
+    (doseq [hd (reverse handles)]
+      (unmount-one hd))
     (doseq [c containers] (.remove c))
     (reset! held nil))
   nil)
 
+(defn- live-key-count
+  "How many UNIQUE query keys the frame's subscription cache is holding —
+  **Q**, counted rather than asserted.
+
+  The production cache is `{query-vector {:reaction … :ref-count n}}` per
+  frame and an entry is evicted in-tick when its last derefer drops
+  (`re-frame.subs.cache`), so between arms this reads 0 and during an arm
+  it reads exactly the number of distinct query vectors the mounted page
+  holds — independently of how many boundaries hold each one. That is the
+  quantity the two published heap families disagreed about, and it is
+  cheaper to count it than to argue about it."
+  []
+  (if-some [f (frame/frame arms/frame-id)]
+    (count @(:sub-cache f))
+    0))
+
 (defn mount!
   "Mount `k` roots of `arm-id` and KEEP them. Answers the DOM read-back
-  over the boundary class the arm should have produced.
+  over the boundary class the arm should have produced, AND the sub-cache
+  read-back over the unique query keys the plan said it would hold.
+
+  `opts` carries the fan-out rung — `{:reads r :keys q}` — and is ignored
+  by the published arms. Q is set on the fixture BEFORE the first root
+  mounts and once for the whole arm, because the roots of an arm share one
+  frame and therefore one key space.
 
   A literal `#js` object rather than `clj->js`: `clj->js` would render
   `:ok?` as the key `\"ok?\"` and a driver reading `verify.ok` would see
   `undefined` — every mount reported unverified while every mount was
   fine. That happened, on the predecessor's first run."
-  [arm-id k]
+  [arm-id k opts]
   (release!*)
-  (let [{:keys [mount-one selector expected]} (get arm-table (keyword arm-id))
+  (let [opts       (js->clj opts :keywordize-keys true)
+        arm        (arm-for (keyword arm-id) opts)
+        {:keys [mount-one unmount-one selector expected keys-expected]} arm
+        _          (when-some [q (:keys opts)] (fx/set-fan-keys! q))
         containers (mapv (fn [_] (h/container!)) (range k))
         handles    (into [] (map-indexed (fn [i c] (mount-one c i))) containers)
         elements   (.-length (.querySelectorAll js/document selector))
-        want       (* k expected)]
-    (reset! held {:arm (keyword arm-id) :handles handles :containers containers})
-    #js {:elements elements :expected want :ok (= elements want)}))
+        want       (* k expected)
+        live       (live-key-count)]
+    (reset! held {:arm (keyword arm-id) :unmount-one unmount-one
+                  :handles handles :containers containers})
+    #js {:elements     elements
+         :expected     want
+         :keys         live
+         :keysExpected keys-expected
+         :ok           (and (= elements want) (= live keys-expected))}))
 
 ;; ---------------------------------------------------------------------------
 ;; The positive control
@@ -221,6 +321,217 @@
 (defn control-release! [] (reset! control-cell nil) 0)
 
 ;; ---------------------------------------------------------------------------
+;; THE ADDITIVE MODEL — and the rule that decides whether it may be priced
+;; ---------------------------------------------------------------------------
+;;
+;; The heap-regime ruling (rf2-2rtt6.16 Part 3) adopts a target shape for
+;; the budget: a boundary's retained cost decomposes into a SHELL, a
+;; per-EDGE term (one boundary's attachment to one query) and a per-unique
+;; -KEY term (one cached reaction, however many boundaries hold it).
+;;
+;;     y  =  shell  +  (E/B)·edge  +  (Q/B)·key
+;;
+;; It also REFUSES to freeze those numbers from cross-instrument algebra,
+;; because the paired rows came from different instruments and runs — and
+;; it makes this sweep the gate. So the sweep has to do two things a fit
+;; alone does not: identify the terms from CONTRASTS that move one factor
+;; at a time, and then try to BREAK the model on rungs it was not fitted
+;; to.
+;;
+;; Identification. The R=1 family holds E/B = 1 and walks Q/B, so a
+;; straight line through it has slope `key` and intercept `shell + edge`;
+;; the R=0 rung measures `shell` on its own; `edge` is the difference. All
+;; three come out of one page, one round, one reader.
+;;
+;; Falsification. Two R=2 rungs are then measured and PREDICTED FROM
+;; NOTHING BUT THE ABOVE. They are not in the fit. If the cost of a read
+;; depended on how many reads a boundary already had, or if a shared key
+;; were cheaper per consumer than an exclusive one, the R=1 family would
+;; still be a line and the R=2 predictions would miss. The self-test below
+;; proves that is not a hypothetical: a synthetic page with a quadratic
+;; key term passes the r² floor at 0.997 and is caught only here.
+;;
+;; The verdict this returns is not an instrument fault and does not stop a
+;; run. It decides whether the numbers may be QUOTED as component prices,
+;; which is the thing the ruling gated.
+
+(def additive-criterion
+  "The thresholds, fixed before the sweep ran and not moved after it.
+
+  `:min-r2` — the R=1 family must be a line in Q/B. 0.98 over four rungs
+  is well inside what this instrument has shown it can resolve (the reads
+  ladder returned r² ≥ 0.9987 on both substrates) and far outside what a
+  page with a real interaction term would return.
+
+  `:max-oos-error` — each R=2 rung's prediction must land within 10% of
+  the measured value. The rungs sit at 3–13 KB per boundary and this
+  instrument's per-arm ranges are well under 1% wide, so 10% is a margin
+  for the model, not for the reader.
+
+  `:max-key-disagreement` — the per-key term solved from the R=2 PAIR
+  alone must agree with the R=1 slope within 15%. Two disjoint subsets of
+  the sweep, one arithmetic."
+  {:min-r2 0.98 :max-oos-error 0.10 :max-key-disagreement 0.15})
+
+(defn- ols
+  "Ordinary least squares of `[x y]` pairs. Answers `{:slope :intercept
+  :r2 :n}`. `:r2` is 1.0 for a degenerate y — a family that does not vary
+  is perfectly explained by a flat line, and calling that 0 would refuse
+  the one case where the model is trivially exact."
+  [pts]
+  (let [n   (count pts)
+        xs  (mapv first pts)
+        ys  (mapv second pts)
+        mx  (/ (reduce + xs) n)
+        my  (/ (reduce + ys) n)
+        sxx (reduce + (map (fn [x] (let [d (- x mx)] (* d d))) xs))
+        sxy (reduce + (map (fn [x y] (* (- x mx) (- y my))) xs ys))
+        slope (if (zero? sxx) 0.0 (/ sxy sxx))
+        b0  (- my (* slope mx))
+        syy (reduce + (map (fn [y] (let [d (- y my)] (* d d))) ys))
+        ssr (reduce + (map (fn [x y] (let [e (- y (+ b0 (* slope x)))] (* e e))) xs ys))]
+    {:slope slope :intercept b0 :n n
+     :r2 (if (zero? syy) 1.0 (- 1.0 (/ ssr syy)))}))
+
+(defn- pct [x] (str (.toFixed (* 100.0 x) 2) "%"))
+
+(defn additive-fit
+  "Price `shell`, `edge` and `key` from one substrate's rungs, and
+  adjudicate whether they may be quoted.
+
+  `rungs` is a seq of `{:rung :reads :keys :boundaries :y}`, where `y` is
+  exclusive retained bytes per boundary (arm − floor). Answers a map whose
+  `:ok?` is the ruling's refusal rule: false means the page publishes the
+  rows and NOT the prices, and says which check failed."
+  [rungs {:keys [min-r2 max-oos-error max-key-disagreement]}]
+  (let [xof      (fn [{:keys [keys boundaries]}] (/ (double keys) (double boundaries)))
+        of-reads (fn [r] (vec (sort-by xof (filterv #(= r (long (:reads %))) rungs))))
+        zero     (first (of-reads 0))
+        ones     (of-reads 1)
+        twos     (of-reads 2)]
+    (if (or (nil? zero) (< (count ones) 3) (< (count twos) 2))
+      {:ok?  false
+       :why  (str "the sweep is missing a rung the model needs — R=0 ×"
+                  (if zero 1 0) ", R=1 ×" (count ones) ", R=2 ×" (count twos)
+                  " (need 1, ≥3, 2)")
+       :checks []}
+      (let [{:keys [slope intercept r2]} (ols (mapv (fn [g] [(xof g) (:y g)]) ones))
+            shell    (:y zero)
+            key-term slope
+            edge     (- intercept shell)
+            predict  (fn [g] (+ shell (* 2.0 edge) (* (xof g) key-term)))
+            oos      (mapv (fn [g]
+                             (let [p (predict g)]
+                               {:rung     (:rung g)
+                                :q-over-b (xof g)
+                                :measured (:y g)
+                                :predicted p
+                                :error    (/ (- p (:y g)) (:y g))}))
+                           twos)
+            lo       (first twos)
+            hi       (peek twos)
+            dx       (- (xof hi) (xof lo))
+            key-2    (when-not (zero? dx) (/ (- (:y hi) (:y lo)) dx))
+            key-gap  (when (and key-2 (not (zero? key-term)))
+                       (/ (- key-2 key-term) key-term))
+            twin     (first (filter #(< (js/Math.abs (- (xof %) (xof lo))) 1e-9) ones))
+            edge-2   (when twin (- (:y lo) (:y twin)))
+            checks
+            [{:name "the R=1 family is a LINE in Q/B"
+              :ok   (>= r2 min-r2)
+              :detail (str "r² " (.toFixed r2 5) " over " (count ones)
+                           " rungs (floor " min-r2 ")")}
+             {:name "the two R=2 rungs are predicted OUT OF SAMPLE"
+              :ok   (every? #(<= (js/Math.abs (:error %)) max-oos-error) oos)
+              :detail (str/join
+                        " · "
+                        (map (fn [o]
+                               (str (:rung o) " predicted " (.toFixed (:predicted o) 0)
+                                    " B, measured " (.toFixed (:measured o) 0)
+                                    " B, " (pct (:error o))))
+                             oos))}
+             {:name "the per-key term from the R=2 PAIR agrees with the R=1 slope"
+              :ok   (boolean (and key-gap
+                                  (<= (js/Math.abs key-gap) max-key-disagreement)))
+              :detail (if key-gap
+                        (str "R=2 pair " (.toFixed key-2 0) " B vs R=1 slope "
+                             (.toFixed key-term 0) " B — " (pct key-gap))
+                        "the two R=2 rungs share a Q/B; the pair cannot price a slope")}]]
+        {:ok?        (every? :ok checks)
+         :checks     checks
+         :shell      shell
+         :edge       edge
+         :key        key-term
+         :edge-alt   edge-2
+         :key-alt    key-2
+         :intercept  intercept
+         :r2         r2
+         :oos        oos
+         :criterion  {:min-r2 min-r2
+                      :max-oos-error max-oos-error
+                      :max-key-disagreement max-key-disagreement}
+         :why        (if (every? :ok checks)
+                       "additive — component prices may be quoted"
+                       (str "REFUSED: "
+                            (str/join "; " (map :name (remove :ok checks)))))}))))
+
+(defn fan-self-test
+  "The adjudicator's own positive control, PREDICTED before it is run.
+
+  Two synthetic pages, both built by arithmetic rather than measured:
+
+  **A** is the model exactly — shell 400, edge 250, key 900 over B = 1,200
+  — and must be priced back to those three numbers and accepted.
+
+  **B** adds a QUADRATIC key term (`+300·(Q/B)²`), which is what a page
+  whose shared reactions were cheaper per consumer than its exclusive ones
+  would look like. It must be REFUSED — and the interesting part is where:
+  its R=1 family still fits a line at r² ≈ 0.997, comfortably past the
+  0.98 floor, so the linearity check passes and only the out-of-sample
+  R=2 rungs catch it. That is the whole reason the R=2 rungs exist, and a
+  self-test that did not price it would leave them looking like padding.
+
+  A rule that cannot fail has not adjudicated anything."
+  []
+  (let [b     1200.0
+        mk    (fn [f] (mapv (fn [[id r q]] {:rung id :reads r :keys q :boundaries b
+                                            :y (f r (/ (double q) b))})
+                            [["R0" 0 0] ["R1Q1" 1 1200] ["R1Q2" 1 600]
+                             ["R1Q4" 1 300] ["R1Q8" 1 150]
+                             ["R2Q2B" 2 2400] ["R2QB2" 2 600]]))
+        exact (mk (fn [r x] (if (zero? r) 400.0 (+ 400.0 (* r 250.0) (* x 900.0)))))
+        curvy (mk (fn [r x] (if (zero? r)
+                              400.0
+                              (+ 400.0 (* r 250.0) (* x 900.0) (* x x 300.0)))))
+        fa    (additive-fit exact additive-criterion)
+        fb    (additive-fit curvy additive-criterion)
+        near? (fn [a b tol] (< (js/Math.abs (- a b)) tol))
+        chk   [{:name "the exact additive page is priced back to its own three terms"
+                :ok   (and (:ok? fa)
+                           (near? (:shell fa) 400.0 0.5)
+                           (near? (:edge fa) 250.0 0.5)
+                           (near? (:key fa) 900.0 0.5))
+                :detail (str "shell " (.toFixed (:shell fa) 1)
+                             " · edge " (.toFixed (:edge fa) 1)
+                             " · key " (.toFixed (:key fa) 1))}
+               {:name "the exact page's R=2 rungs are predicted to the byte"
+                :ok   (every? #(< (js/Math.abs (:error %)) 1e-9) (:oos fa))
+                :detail (str/join " · " (map #(str (:rung %) " " (pct (:error %)))
+                                             (:oos fa)))}
+               {:name "a QUADRATIC key term is refused"
+                :ok   (not (:ok? fb))
+                :detail (:why fb)}
+               {:name "…and it is refused OUT OF SAMPLE, not by the r² floor"
+                :ok   (and (>= (:r2 fb) (:min-r2 additive-criterion))
+                           (not (:ok (second (:checks fb)))))
+                :detail (str "r² " (.toFixed (:r2 fb) 5)
+                             " passes the " (:min-r2 additive-criterion)
+                             " floor; the R=2 rungs miss by "
+                             (str/join " and "
+                                       (map #(pct (:error %)) (:oos fb))))}]]
+    {:ok? (every? :ok chk) :checks chk}))
+
+;; ---------------------------------------------------------------------------
 ;; The page-side door
 ;; ---------------------------------------------------------------------------
 
@@ -230,7 +541,7 @@
   []
   (set! (.-P0H js/window)
         #js {:prepare        (fn [seg] (prepare! (when seg (keyword seg))))
-             :mount          (fn [arm k] (mount! arm k))
+             :mount          (fn [arm k opts] (mount! arm k opts))
              :release        (fn [] (release!*) true)
              :control        (fn [n] (control! n))
              :controlRelease (fn [] (control-release!))
@@ -273,5 +584,44 @@
                                       :why   (:why v)
                                       :slack (:slack v)}))
              :guardSelfTest  (fn [] (pr-str (guard/self-test)))
+             ;; The fan-out sweep's two doors, and both of them are RULES
+             ;; rather than arithmetic, so both live here rather than in a
+             ;; JavaScript restatement the driver would own alone. The
+             ;; self-test runs before the sweep measures anything, exactly
+             ;; as the arm-order guard's does.
+             ;;
+             ;; Flat `#js` answers, never `clj->js`, for the reason
+             ;; `mount!` carries the scar from: `clj->js` renders `:ok?`
+             ;; as the key `"ok?"` and a driver reading `v.ok` sees
+             ;; `undefined` — a gate green for ever because nothing could
+             ;; read it. The EDN rides along whole, for the record file.
+             :fanSelfTest    (fn []
+                               (let [st (fan-self-test)]
+                                 #js {:ok     (boolean (:ok? st))
+                                      :checks (into-array
+                                                (map (fn [c]
+                                                       #js {:ok     (boolean (:ok c))
+                                                            :name   (:name c)
+                                                            :detail (:detail c)})
+                                                     (:checks st)))}))
+             :fanVerdict     (fn [rungs]
+                               (let [v (additive-fit
+                                         (js->clj rungs :keywordize-keys true)
+                                         additive-criterion)]
+                                 #js {:ok       (boolean (:ok? v))
+                                      :why      (:why v)
+                                      :shell    (:shell v)
+                                      :edge     (:edge v)
+                                      :key      (:key v)
+                                      :edgeAlt  (:edge-alt v)
+                                      :keyAlt   (:key-alt v)
+                                      :r2       (:r2 v)
+                                      :checks   (into-array
+                                                  (map (fn [c]
+                                                         #js {:ok     (boolean (:ok c))
+                                                              :name   (:name c)
+                                                              :detail (:detail c)})
+                                                       (:checks v)))
+                                      :edn      (pr-str v)}))
              :boundariesPerRoot #js {:list rows-per-root :grid per-root}})
   nil)

--- a/implementation/core/test/re_frame/bench/p0_reagent.cljs
+++ b/implementation/core/test/re_frame/bench/p0_reagent.cljs
@@ -88,8 +88,57 @@
      ^{:key i} [u-cell i])])
 
 ;; ---------------------------------------------------------------------------
+;; FAN — the fan-out family (rf2-5prok)
+;; ---------------------------------------------------------------------------
+;;
+;; The same `.cell` boundary as `u-cell`, with two things lifted into
+;; parameters: how many subscriptions a boundary READS (`reads`), and how
+;; many UNIQUE query keys the whole page holds (Q, set on the fixture
+;; before the mount). Boundary count, element count and text are held
+;; fixed across every rung — all cells are `0`, and a two-read cell shows
+;; their SUM, which is also `0` — so a rung differs from its neighbours in
+;; cache cardinality and in nothing a floor subtraction could confuse for
+;; it.
+;;
+;; THREE CELLS RATHER THAN ONE WITH A LOOP. A boundary's read count has to
+;; be fixed per component: a `for` over `reads` inside one cell would be a
+;; different question on Reagent and a hook-linter error on the UIx
+;; counterpart, and the two arms have to be written the same way.
+;;
+;; The `_n` arg on the zero-read cell is deliberate: every rung's cell
+;; takes the SAME two arguments, so the argv a fiber retains is the same
+;; shape at R=0, R=1 and R=2 and the shell rung is not measuring one fewer
+;; prop slot than the rungs it anchors.
+
+(reg-view fan-cell-0 [j _n]
+  [:span.cell {:data-i j} "0"])
+
+(reg-view fan-cell-1 [j n]
+  (let [a @(subscribe [:p0/fan (fx/fan-key n 1 0)])]
+    [:span.cell {:data-i j} (str a)]))
+
+(reg-view fan-cell-2 [j n]
+  (let [a @(subscribe [:p0/fan (fx/fan-key n 2 0)])
+        b @(subscribe [:p0/fan (fx/fan-key n 2 1)])]
+    [:span.cell {:data-i j} (str (+ a b))]))
+
+(reg-view fan-grid [offset n-cells reads]
+  [:div.ugrid
+   (case (long reads)
+     0 (for [j (range n-cells)] ^{:key j} [fan-cell-0 j (+ offset j)])
+     1 (for [j (range n-cells)] ^{:key j} [fan-cell-1 j (+ offset j)])
+     2 (for [j (range n-cells)] ^{:key j} [fan-cell-2 j (+ offset j)]))])
+
+;; ---------------------------------------------------------------------------
 ;; Roots
 ;; ---------------------------------------------------------------------------
+
+(defn fan-root
+  "One root of the fan-out arm. `offset` is this root's base in the GLOBAL
+  boundary numbering, which is what lets four roots of one frame either
+  share every key or share none."
+  [frame-id offset n-cells reads]
+  [rf/frame-provider {:frame frame-id} [fan-grid offset n-cells reads]])
 
 (defn w1-root [frame-id rows]
   [rf/frame-provider {:frame frame-id} [w1 rows]])

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -5,7 +5,13 @@
 //   node implementation/core/test/re_frame/bench/p0_run.cjs
 //   node implementation/core/test/re_frame/bench/p0_run.cjs --only clock
 //   node implementation/core/test/re_frame/bench/p0_run.cjs --only heap
+//   node implementation/core/test/re_frame/bench/p0_run.cjs --only fanout
 //   P0_ROUNDS=6 P0_SAMPLES=12 node .../p0_run.cjs
+//
+// `--only fanout` is the CACHE-CARDINALITY row (rf2-5prok): the same page,
+// readers, collector and guard as the heap row, with B and reads/boundary
+// held fixed while the number of UNIQUE live query keys moves. It is
+// opt-in, runs nothing else, and takes `P0_ROOTS` and `P0_FAN_ROUNDS`.
 //
 // ## Why the numbers have to come from here
 //
@@ -134,6 +140,99 @@ const HEAP_SEGMENTS = [
   { segment: 'reagent-subs', arms: ['list/floor', 'list/reagent', 'grid/floor', 'grid/reagent'] },
   { segment: 'uix-subs', arms: ['list/floor', 'list/uix', 'grid/floor', 'grid/uix'] },
 ];
+
+// ---------------------------------------------------------------------------
+// The fan-out sweep (rf2-5prok)
+// ---------------------------------------------------------------------------
+//
+// The heap-regime ruling (rf2-2rtt6.16) made cache cardinality part of the
+// witness: a retained-bytes-per-boundary figure is defined only relative to
+// how many boundaries share a subscription. `--only fanout` is the row that
+// walks that axis and nothing else — the same page, the same readers, the
+// same collector, the same guard, and B and E/B held fixed while Q moves.
+//
+// The rungs, per substrate, at whatever `P0_ROOTS` sets B to:
+//
+//   R0      0 reads          — the boundary SHELL, Q = 0
+//   R1Q1    1 read,  Q = B   — fan-out 1, the distinct-query worst case
+//   R1Q2    1 read,  Q = B/2 — fan-out 2
+//   R1Q4    1 read,  Q = B/4 — fan-out 4, which at ROOTS=4 is exactly the
+//                              regime rf2-2rtt6.4's published grid rows were
+//                              measured in
+//   R1Q8    1 read,  Q = B/8 — fan-out 8
+//   R2Q2B   2 reads, Q = 2B  — held out of the fit
+//   R2QB2   2 reads, Q = B/2 — held out of the fit
+//
+// and the published `grid/<substrate>` arm rides along unchanged as the
+// REPRODUCTION ANCHOR: at ROOTS=4 it is the same B, E and Q as R1Q4 through
+// a different query id, so the two agreeing is a same-run check that the
+// fan family is measuring the published family's quantity.
+//
+// Why two R=2 rungs. They are the only rungs the model is not fitted to,
+// and they are what turns a curve fit into a test: `R2QB2 − R1Q2` is one
+// extra edge per boundary at IDENTICAL Q, which is the per-edge term with
+// nothing else moving, and the R=2 pair prices the per-key term a second
+// time from samples the R=1 slope never saw.
+const FAN_ROUNDS = Number(process.env.P0_FAN_ROUNDS || 6);
+
+function fanRungs(boundaries) {
+  const B = boundaries;
+  return [
+    { rung: 'R0', reads: 0, keys: 0 },
+    { rung: 'R1Q1', reads: 1, keys: B },
+    { rung: 'R1Q2', reads: 1, keys: Math.round(B / 2) },
+    { rung: 'R1Q4', reads: 1, keys: Math.round(B / 4) },
+    { rung: 'R1Q8', reads: 1, keys: Math.round(B / 8) },
+    { rung: 'R2Q2B', reads: 2, keys: 2 * B },
+    { rung: 'R2QB2', reads: 2, keys: Math.round(B / 2) },
+  ];
+}
+
+const FAN_SUBSTRATE = { 'reagent-subs': 'reagent', 'uix-subs': 'uix' };
+
+function fanPlan(perRoot, roots) {
+  const B = roots * perRoot.grid;
+  return Object.keys(FAN_SUBSTRATE).map((segment) => {
+    const sub = FAN_SUBSTRATE[segment];
+    const arms = [
+      { arm: 'grid/floor', key: `${segment}|grid/floor`, boundaries: B, opts: null, rung: 'floor' },
+    ];
+    for (const r of fanRungs(B)) {
+      arms.push({
+        arm: `fan/${sub}`,
+        key: `${segment}|fan/${sub}#${r.rung}`,
+        boundaries: B,
+        opts: { reads: r.reads, keys: r.keys },
+        rung: r.rung,
+        reads: r.reads,
+        keys: r.keys,
+      });
+    }
+    arms.push({
+      arm: `grid/${sub}`,
+      key: `${segment}|grid/${sub}`,
+      boundaries: B,
+      opts: null,
+      rung: 'anchor',
+      reads: 1,
+      keys: perRoot.grid,
+    });
+    return { segment, arms };
+  });
+}
+
+function legacyPlan(perRoot, roots) {
+  return HEAP_SEGMENTS.map(({ segment, arms }) => ({
+    segment,
+    arms: arms.map((arm) => ({
+      arm,
+      key: `${segment}|${arm}`,
+      boundaries: roots * perRoot[arm.split('/')[0]],
+      opts: null,
+      rung: arm,
+    })),
+  }));
+}
 
 // ---------------------------------------------------------------------------
 // Build and serve
@@ -311,7 +410,17 @@ async function makeReaders(page) {
 // The heap row
 // ---------------------------------------------------------------------------
 
-async function heapRow(chromium) {
+// ONE measurement engine, two plans. The heap row's plan is the published
+// four-arm one; the fan-out row's walks cache cardinality. Everything
+// between them — the warm-up pass, the collector, the in-situ control, the
+// slot order, the read-back gates, the arm-order verdict — is shared, so
+// the two rows cannot drift into being two instruments wearing one name.
+// `analyse` runs with the page STILL OPEN, because the rules it reaches
+// live in ClojureScript.
+async function heapPass(
+  chromium,
+  { benchmark, bead, plan: planOf, roots, rounds: nRounds, preflight, analyse }
+) {
   const { browser, page } = await newPage(chromium, '?mode=heap');
   await page.waitForFunction('window.P0_READY === true || window.P0_ERROR', null, {
     timeout: 180000,
@@ -321,16 +430,39 @@ async function heapRow(chromium) {
     await browser.close();
     throw new Error(`heap page failed to initialise: ${err}`);
   }
+  if (preflight) {
+    try {
+      await preflight(page);
+    } catch (e) {
+      await browser.close();
+      throw e;
+    }
+  }
   const perRoot = await page.evaluate(() => window.P0H.boundariesPerRoot);
+  const plan = planOf(perRoot, roots);
   const { gc, read } = await makeReaders(page);
-
-  const boundariesOf = (arm) => ROOTS * perRoot[arm.split('/')[0]];
 
   let unverified = 0;
   let mounts = 0;
+  const unverifiedDetail = [];
   const orderSamples = [];
   let position = 0;
   let previous = null;
+
+  const mountOne = async (entry) => {
+    const v = await page.evaluate(
+      ([a, k, o]) => window.P0H.mount(a, k, o),
+      [entry.arm, roots, entry.opts]
+    );
+    mounts++;
+    if (!v.ok) {
+      unverified++;
+      unverifiedDetail.push(
+        `${entry.key}: elements ${v.elements}/${v.expected}, keys ${v.keys}/${v.keysExpected}`
+      );
+    }
+    return v;
+  };
 
   // A WARM-UP PASS, mounted and released once per arm and never read. The
   // first mount of any arm allocates things that are not the page and
@@ -338,12 +470,10 @@ async function heapRow(chromium) {
   // caches, interned keywords, one-time module state. Charged to round 1
   // they read as retention per boundary, and they are not.
   console.error('[p0] heap warm-up pass ...');
-  for (const { segment, arms } of HEAP_SEGMENTS) {
+  for (const { segment, arms } of plan) {
     await page.evaluate((s) => window.P0H.prepare(s), segment);
-    for (const arm of arms) {
-      const v = await page.evaluate(([a, k]) => window.P0H.mount(a, k), [arm, ROOTS]);
-      mounts++;
-      if (!v.ok) unverified++;
+    for (const entry of arms) {
+      await mountOne(entry);
       await page.evaluate(() => window.P0H.release());
     }
   }
@@ -351,8 +481,8 @@ async function heapRow(chromium) {
   await page.evaluate(() => window.P0H.controlRelease());
 
   const rounds = [];
-  for (let round = 0; round < ROUNDS; round++) {
-    console.error(`[p0] heap round ${round + 1}/${ROUNDS}`);
+  for (let round = 0; round < nRounds; round++) {
+    console.error(`[p0] heap round ${round + 1}/${nRounds}`);
 
     // --- the positive control, in situ, before this round's arms --------
     await gc();
@@ -375,7 +505,7 @@ async function heapRow(chromium) {
     // Segment order alternates with the round for the same reason the
     // clock row's does: two segments admit two orders, and a single-order
     // result has not been checked.
-    const segs = round % 2 === 0 ? HEAP_SEGMENTS : [...HEAP_SEGMENTS].slice().reverse();
+    const segs = round % 2 === 0 ? plan : [...plan].slice().reverse();
     const armsOut = {};
     for (const { segment, arms } of segs) {
       // `prepare` BEFORE the baseline read, so the adapter swap's own
@@ -386,22 +516,22 @@ async function heapRow(chromium) {
         [arms.length, round]
       );
       for (const j of order) {
-        const arm = arms[j];
+        const entry = arms[j];
         await gc();
         const pre = await read();
-        const verify = await page.evaluate(([a, k]) => window.P0H.mount(a, k), [arm, ROOTS]);
-        mounts++;
-        if (!verify.ok) unverified++;
+        const verify = await mountOne(entry);
         await gc();
         const held = await read();
         await page.evaluate(() => window.P0H.release());
         await gc();
         const post = await read();
-        const boundaries = boundariesOf(arm);
-        const key = `${segment}|${arm}`;
-        armsOut[key] = {
+        const boundaries = entry.boundaries;
+        armsOut[entry.key] = {
           segment,
-          arm,
+          arm: entry.arm,
+          rung: entry.rung,
+          reads: entry.reads,
+          keys: entry.keys,
           verify,
           boundaries,
           retainedCdp: held.cdp - pre.cdp,
@@ -411,12 +541,12 @@ async function heapRow(chromium) {
           bytesPerBoundaryPerf: (held.perf - pre.perf) / boundaries,
         };
         orderSamples.push({
-          arm: key,
-          value: armsOut[key].bytesPerBoundaryCdp,
+          arm: entry.key,
+          value: armsOut[entry.key].bytesPerBoundaryCdp,
           predecessor: previous,
           position: position++,
         });
-        previous = key;
+        previous = entry.key;
       }
     }
     rounds.push({ round, control, arms: armsOut });
@@ -439,35 +569,138 @@ async function heapRow(chromium) {
     [CONTROL_PREDICTED, { min: ctlStat.min, max: ctlStat.max, mean: ctlStat.mean }, CONTROL_SLACK]
   );
 
+  const extra = analyse ? await analyse(page, rounds, plan) : {};
+
   await browser.close();
 
-  return {
+  return Object.assign(
+    {
+      benchmark,
+      bead,
+      roots,
+      perRoot,
+      rounds: nRounds,
+      plan: plan.map((p) => ({
+        segment: p.segment,
+        arms: p.arms.map((a) => ({
+          key: a.key,
+          arm: a.arm,
+          rung: a.rung,
+          boundaries: a.boundaries,
+          reads: a.reads,
+          keys: a.keys,
+        })),
+      })),
+      instruments: {
+        A: 'CDP Runtime.getHeapUsage().usedSize after 3x HeapProfiler.collectGarbage',
+        B: 'in-page performance.memory.usedJSHeapSize, same moment, --enable-precise-memory-info',
+        note:
+          'A and B are two doors onto one V8 counter and are NOT independent — on the ' +
+          'predecessor instrument, pointed at 80,000 held objects, they returned 3868954 both.',
+      },
+      control: {
+        shape: 'dense JS array of doubles',
+        doubles: CONTROL_DOUBLES,
+        predictedBytes: CONTROL_PREDICTED,
+        measured: ctlStat,
+        slack: CONTROL_SLACK,
+        verdict: controlVerdict,
+      },
+      verification: { mounts, unverified, detail: unverifiedDetail },
+      perRound: rounds,
+      orderVerdictEdn: verdictEdn,
+      orderRefused: /:refuse\? true/.test(verdictEdn),
+    },
+    extra
+  );
+}
+
+async function heapRow(chromium) {
+  const row = await heapPass(chromium, {
     benchmark: 'P0:retained-heap-per-boundary',
     bead: 'rf2-2rtt6.4',
+    plan: legacyPlan,
     roots: ROOTS,
-    perRoot,
     rounds: ROUNDS,
-    segments: HEAP_SEGMENTS,
-    instruments: {
-      A: 'CDP Runtime.getHeapUsage().usedSize after 3x HeapProfiler.collectGarbage',
-      B: 'in-page performance.memory.usedJSHeapSize, same moment, --enable-precise-memory-info',
-      note:
-        'A and B are two doors onto one V8 counter and are NOT independent — on the ' +
-        'predecessor instrument, pointed at 80,000 held objects, they returned 3868954 both.',
+  });
+  row.segments = HEAP_SEGMENTS;
+  return row;
+}
+
+// ---------------------------------------------------------------------------
+// The fan-out row
+// ---------------------------------------------------------------------------
+
+async function fanoutRow(chromium) {
+  return heapPass(chromium, {
+    benchmark: 'P0:retained-heap-fan-out-sweep',
+    bead: 'rf2-5prok',
+    plan: fanPlan,
+    roots: ROOTS,
+    rounds: FAN_ROUNDS,
+    // The adjudicator's own self-test, BEFORE anything is measured, on the
+    // same footing as the arm-order guard's: two synthetic pages built by
+    // arithmetic, one exactly additive and one carrying a quadratic key
+    // term. The first has to be priced back to its own three terms and the
+    // second has to be REFUSED — and refused out of sample, since its r²
+    // clears the linearity floor. A fit rule that cannot fail would make
+    // every price below unfalsifiable.
+    preflight: async (page) => {
+      const st = await page.evaluate(() => window.P0H.fanSelfTest());
+      for (const c of st.checks) {
+        console.log(`;; P0 fan-fit ${c.ok ? 'ok  ' : 'FAIL'} ${c.name}  — ${c.detail}`);
+      }
+      if (!st.ok) {
+        throw new Error(
+          'the additive-model self-test FAILED — no fan-out figure may be priced'
+        );
+      }
     },
-    control: {
-      shape: 'dense JS array of doubles',
-      doubles: CONTROL_DOUBLES,
-      predictedBytes: CONTROL_PREDICTED,
-      measured: ctlStat,
-      slack: CONTROL_SLACK,
-      verdict: controlVerdict,
+    // The fit and its refusal rule are ClojureScript
+    // (`p0-heap/additive-fit`), reached through the page while it is still
+    // open, for the same reason the arm-order verdict and the control
+    // verdict are: a JavaScript restatement would be a second place for the
+    // rule to drift, and this one decides whether a component price may be
+    // quoted at all.
+    analyse: async (page, rounds) => {
+      const substrates = Object.keys(FAN_SUBSTRATE);
+      const perRoundFits = {};
+      const meanFits = {};
+      for (const segment of substrates) {
+        const sub = FAN_SUBSTRATE[segment];
+        const rungsOf = (r) => {
+          const floor = r.arms[`${segment}|grid/floor`];
+          return fanRungs(floor.boundaries).map((g) => {
+            const a = r.arms[`${segment}|fan/${sub}#${g.rung}`];
+            return {
+              rung: g.rung,
+              reads: g.reads,
+              keys: g.keys,
+              boundaries: a.boundaries,
+              y: a.bytesPerBoundaryCdp - floor.bytesPerBoundaryCdp,
+            };
+          });
+        };
+        perRoundFits[segment] = [];
+        for (const r of rounds) {
+          perRoundFits[segment].push(
+            await page.evaluate((rs) => window.P0H.fanVerdict(rs), rungsOf(r))
+          );
+        }
+        // The headline fit, over the per-rung MEANS. Reported beside the
+        // per-round fits and never instead of them: a criterion applied
+        // only to a mean is a criterion a single bad round can hide from.
+        const all = rounds.map(rungsOf);
+        const meanRungs = all[0].map((g, i) => ({
+          ...g,
+          y: all.reduce((acc, rr) => acc + rr[i].y, 0) / all.length,
+        }));
+        meanFits[segment] = await page.evaluate((rs) => window.P0H.fanVerdict(rs), meanRungs);
+        meanFits[segment].rungs = meanRungs;
+      }
+      return { fanFits: { perRound: perRoundFits, mean: meanFits } };
     },
-    verification: { mounts, unverified },
-    perRound: rounds,
-    orderVerdictEdn: verdictEdn,
-    orderRefused: /:refuse\? true/.test(verdictEdn),
-  };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -513,6 +746,9 @@ function summariseHeap(row) {
   console.log(`;;     ${row.control.verdict.why}`);
   console.log(';;     (the shared rule words its figures with an "x"; this control\'s unit is BYTES)');
   console.log(`;; verification: ${row.verification.unverified} unverified of ${row.verification.mounts} mounts`);
+  console.log(';;   (a mount is verified on TWO read-backs: the boundary elements it produced,');
+  console.log(";;    and the unique query keys the frame's sub-cache is holding — B and Q)");
+  for (const d of row.verification.detail || []) console.log(`;;   UNVERIFIED ${d}`);
   console.log(';;');
   console.log(';; arm                              B/boundary (mean) [min-max]     residue B');
   const keys = Object.keys(row.perRound[0].arms);
@@ -561,6 +797,115 @@ function summariseHeap(row) {
 
 // ---------------------------------------------------------------------------
 
+const n0 = (x) => String(Math.round(x));
+
+function summariseFanout(row) {
+  const B = row.plan[0].arms[0].boundaries;
+  console.log('\n;; ==== P0 RETAINED HEAP — THE FAN-OUT SWEEP (rf2-5prok) ====');
+  console.log(
+    `;; ${row.roots} root(s) held per arm, ${row.perRoot.grid} cells each — B = ${B} boundaries, ` +
+      `held FIXED across every rung`
+  );
+  console.log(`;; ${row.rounds} rounds. Q is COUNTED off the frame's own sub-cache on every mount,`);
+  console.log(';; not asserted by the plan — an unstamped or mis-stamped rung is an unverified mount.');
+  const ctlA = row.control.measured;
+  console.log(
+    `;; positive control: predicted ${CONTROL_PREDICTED} B  |  measured ${Math.round(ctlA.mean)} B ` +
+      `[${Math.round(ctlA.min)}–${Math.round(ctlA.max)}]  (ratio ${(ctlA.mean / CONTROL_PREDICTED).toFixed(4)})`
+  );
+  console.log(
+    `;;   VERDICT (lane/control-verdict, slack ±${(row.control.slack * 100).toFixed(0)}%): ` +
+      `${row.control.verdict.ok ? 'OK' : 'FAILED'}`
+  );
+  console.log(`;;     ${row.control.verdict.why}`);
+  console.log(`;; verification: ${row.verification.unverified} unverified of ${row.verification.mounts} mounts`);
+  for (const d of row.verification.detail || []) console.log(`;;   UNVERIFIED ${d}`);
+
+  for (const segment of Object.keys(FAN_SUBSTRATE)) {
+    const sub = FAN_SUBSTRATE[segment];
+    console.log(';;');
+    console.log(`;; ---- ${segment} ----`);
+    console.log(
+      ';; rung    reads    B      E      Q     E/B    E/Q    exclusive B/boundary [min–max]   residue'
+    );
+    const floorKey = `${segment}|grid/floor`;
+    const line = (label, key, reads, keys) => {
+      const excl = stat(
+        row.perRound.map((r) => r.arms[key].bytesPerBoundaryCdp - r.arms[floorKey].bytesPerBoundaryCdp)
+      );
+      const res = stat(row.perRound.map((r) => r.arms[key].residueCdp));
+      const E = B * reads;
+      console.log(
+        `;; ${label.padEnd(8)}${String(reads).padStart(3)}  ${String(B).padStart(6)} ` +
+          `${String(E).padStart(6)} ${String(keys).padStart(6)} ` +
+          `${reads.toFixed(2).padStart(5)}  ${(keys ? (E / keys).toFixed(2) : '—').padStart(5)}   ` +
+          `${n0(excl.mean).padStart(8)} [${n0(excl.min)}–${n0(excl.max)}]`.padEnd(24) +
+          `${n0(res.mean).padStart(9)}`
+      );
+    };
+    const floorStat = stat(row.perRound.map((r) => r.arms[floorKey].bytesPerBoundaryCdp));
+    console.log(
+      `;; floor     0  ${String(B).padStart(6)} ${String(0).padStart(6)} ${String(0).padStart(6)} ` +
+        ` 0.00      —   ${n0(floorStat.mean).padStart(8)} [${n0(floorStat.min)}–${n0(floorStat.max)}]` +
+        '   (absolute, the calibrator)'
+    );
+    for (const g of fanRungs(B)) line(g.rung, `${segment}|fan/${sub}#${g.rung}`, g.reads, g.keys);
+    line('anchor', `${segment}|grid/${sub}`, 1, row.perRoot.grid);
+    console.log(
+      `;;   'anchor' is the PUBLISHED rf2-2rtt6.4 ${sub} grid arm, unchanged — same B/E/Q as ` +
+        `R1Q${Math.round(B / row.perRoot.grid)} at these roots, through :p0/cell instead of :p0/fan.`
+    );
+  }
+
+  // --- the additive model -------------------------------------------------
+  console.log(';;');
+  console.log(';; ==== THE ADDITIVE MODEL — y = shell + (E/B)·edge + (Q/B)·key ====');
+  console.log(';;   The R=1 family identifies it (slope = key, intercept = shell + edge, and the');
+  console.log(';;   R=0 rung measures shell on its own). The two R=2 rungs are HELD OUT and');
+  console.log(";;   predicted from those three numbers alone. The rule is p0-heap/additive-fit's;");
+  console.log(';;   this driver states the rungs and reads the answer.');
+  const fits = row.fanFits;
+  for (const segment of Object.keys(FAN_SUBSTRATE)) {
+    const m = fits.mean[segment];
+    const per = fits.perRound[segment];
+    const rng = (f) => {
+      const xs = per.map(f).filter((x) => typeof x === 'number' && isFinite(x));
+      return xs.length ? `[${n0(Math.min(...xs))}–${n0(Math.max(...xs))}]` : '[—]';
+    };
+    console.log(';;');
+    console.log(
+      `;;   ${segment}:  shell ${n0(m.shell)} B ${rng((f) => f.shell)}` +
+        `   edge ${n0(m.edge)} B ${rng((f) => f.edge)}` +
+        `   key ${n0(m.key)} B ${rng((f) => f.key)}`
+    );
+    console.log(
+      `;;     r² ${m.r2.toFixed(5)}   ·   edge re-measured as R2QB2 − R1Q2 = ${n0(m.edgeAlt)} B` +
+        `   ·   key re-measured from the R=2 pair = ${n0(m.keyAlt)} B`
+    );
+    for (const c of m.checks) {
+      console.log(`;;     [${c.ok ? 'ok  ' : 'FAIL'}] ${c.name}`);
+      console.log(`;;              ${c.detail}`);
+    }
+    const badRounds = per.filter((f) => !f.ok).length;
+    console.log(
+      `;;     per-round: ${per.length - badRounds} of ${per.length} rounds additive on the same criterion`
+    );
+    console.log(
+      `;;     VERDICT: ${m.ok && badRounds === 0 ? 'ADDITIVE — component prices may be quoted' : 'REFUSED — ' + m.why}`
+    );
+    row.fanFits.mean[segment].allRoundsOk = badRounds === 0;
+  }
+
+  console.log(';;');
+  console.log(';; ==== ARM-ORDER GUARD (fan-out) ====');
+  console.log(
+    `;;   ${row.orderRefused ? 'VERDICT: REFUSE — no figure above may be published as measured' : 'VERDICT: reportable'}`
+  );
+  if (row.orderRefused) console.log(`;;   ${row.orderVerdictEdn}`);
+}
+
+// ---------------------------------------------------------------------------
+
 (async () => {
   build();
   const server = serve();
@@ -571,8 +916,19 @@ function summariseHeap(row) {
   // that failed two things would name one of them.
   const failures = [];
   let refused = false;
+  // `--only fanout` is opt-in and runs NOTHING ELSE. It is 5x the arms of
+  // the published heap row and it answers a different question, so folding
+  // it into a default run would both cost every run five times over and
+  // change the sample stream the heap row's arm-order guard adjudicates.
+  const wantClock = ONLY === null || ONLY === 'clock';
+  const wantHeap = ONLY === null || ONLY === 'heap';
+  const wantFanout = ONLY === 'fanout';
+  if (ONLY !== null && !wantClock && !wantHeap && !wantFanout) {
+    console.error(`[p0] unknown --only ${ONLY} (clock | heap | fanout)`);
+    process.exit(1);
+  }
   try {
-    if (ONLY !== 'heap') {
+    if (wantClock) {
       console.error('[p0] clock row ...');
       const c = await clockRow(chromium);
       out.clock = c.results;
@@ -602,7 +958,7 @@ function summariseHeap(row) {
         }
       }
     }
-    if (ONLY !== 'clock') {
+    if (wantHeap) {
       console.error('[p0] heap row ...');
       out.heap = await heapRow(chromium);
       summariseHeap(out.heap);
@@ -613,6 +969,27 @@ function summariseHeap(row) {
         failures.push(`heap: positive control — ${out.heap.control.verdict.why}`);
       }
       refused = refused || out.heap.orderRefused;
+    }
+    if (wantFanout) {
+      console.error('[p0] fan-out sweep ...');
+      out.fanout = await fanoutRow(chromium);
+      summariseFanout(out.fanout);
+      if (out.fanout.verification.unverified > 0) {
+        failures.push(
+          `fanout: ${out.fanout.verification.unverified} unverified mounts — ` +
+            out.fanout.verification.detail.join(' | ')
+        );
+      }
+      if (!out.fanout.control.verdict.ok) {
+        failures.push(`fanout: positive control — ${out.fanout.control.verdict.why}`);
+      }
+      refused = refused || out.fanout.orderRefused;
+      // The additive verdict is NOT an exit code. A model that does not
+      // hold is a finding about the substrate, not a fault in the
+      // instrument that measured it — the rows stay quotable and only the
+      // component PRICES do not. It is adjudicated, printed as a verdict
+      // and carried in the raw record; what it gates is what may be
+      // written into validation.md.
     }
   } catch (e) {
     failures.push(String(e && e.stack ? e.stack : e));

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -797,7 +797,7 @@ function summariseHeap(row) {
 
 // ---------------------------------------------------------------------------
 
-const n0 = (x) => String(Math.round(x));
+const n0 = (x) => (typeof x === 'number' && isFinite(x) ? String(Math.round(x)) : '—');
 
 function summariseFanout(row) {
   const B = row.plan[0].arms[0].boundaries;
@@ -859,11 +859,14 @@ function summariseFanout(row) {
 
   // --- the additive model -------------------------------------------------
   console.log(';;');
-  console.log(';; ==== THE ADDITIVE MODEL — y = shell + (E/B)·edge + (Q/B)·key ====');
-  console.log(';;   The R=1 family identifies it (slope = key, intercept = shell + edge, and the');
-  console.log(';;   R=0 rung measures shell on its own). The two R=2 rungs are HELD OUT and');
-  console.log(";;   predicted from those three numbers alone. The rule is p0-heap/additive-fit's;");
-  console.log(';;   this driver states the rungs and reads the answer.');
+  console.log(';; ==== THE ADDITIVE MODEL ====');
+  console.log(';;   M3   y = shell + (E/B)·edge + (Q/B)·key            (the ruling\'s shape)');
+  console.log(';;   M4   y = shell + [E>0]·step + (E/B)·edge + (Q/B)·key');
+  console.log(';;   Each term from one contrast: shell is the R=0 rung; key is the R=1 slope in');
+  console.log(';;   Q/B; edge is R2QB2 − R1Q2 (same Q, one more read); step is what is left of');
+  console.log(';;   the R=1 intercept. R2Q2B is HELD OUT of all of that and predicted by both.');
+  console.log(";;   The rule is p0-heap/additive-fit's — this driver states the rungs and reads");
+  console.log(';;   the answer. It is a verdict about what may be PRICED, not an instrument gate.');
   const fits = row.fanFits;
   for (const segment of Object.keys(FAN_SUBSTRATE)) {
     const m = fits.mean[segment];
@@ -875,25 +878,32 @@ function summariseFanout(row) {
     console.log(';;');
     console.log(
       `;;   ${segment}:  shell ${n0(m.shell)} B ${rng((f) => f.shell)}` +
-        `   edge ${n0(m.edge)} B ${rng((f) => f.edge)}` +
+        `   step ${n0(m.step)} B ${rng((f) => f.step)}` +
+        `   edge ${n0(m.edgeContrast)} B ${rng((f) => f.edgeContrast)}` +
         `   key ${n0(m.key)} B ${rng((f) => f.key)}`
     );
     console.log(
-      `;;     r² ${m.r2.toFixed(5)}   ·   edge re-measured as R2QB2 − R1Q2 = ${n0(m.edgeAlt)} B` +
-        `   ·   key re-measured from the R=2 pair = ${n0(m.keyAlt)} B`
+      `;;     r² ${m.r2.toFixed(5)}  ·  edge from the intercept ${n0(m.edgeIntercept)} B` +
+        `  ·  key from the R=2 pair ${n0(m.keyAlt)} B`
+    );
+    console.log(
+      `;;     held out ${m.heldOut.rung} = ${n0(m.heldOut.measured)} B  ·  M3 says ${n0(m.heldOut.m3)} B ` +
+        `(${(100 * m.heldOut.m3Error).toFixed(2)}%)  ·  M4 says ${n0(m.heldOut.m4)} B ` +
+        `(${(100 * m.heldOut.m4Error).toFixed(2)}%)`
     );
     for (const c of m.checks) {
       console.log(`;;     [${c.ok ? 'ok  ' : 'FAIL'}] ${c.name}`);
       console.log(`;;              ${c.detail}`);
     }
-    const badRounds = per.filter((f) => !f.ok).length;
+    const models = per.map((f) => f.model);
+    const agreed = models.filter((x) => x === m.model).length;
     console.log(
-      `;;     per-round: ${per.length - badRounds} of ${per.length} rounds additive on the same criterion`
+      `;;     per-round: ${agreed} of ${per.length} rounds reach the same verdict ` +
+        `(${models.map((x) => x || 'refused').join(', ')})`
     );
-    console.log(
-      `;;     VERDICT: ${m.ok && badRounds === 0 ? 'ADDITIVE — component prices may be quoted' : 'REFUSED — ' + m.why}`
-    );
-    row.fanFits.mean[segment].allRoundsOk = badRounds === 0;
+    console.log(`;;     VERDICT: ${m.why}`);
+    row.fanFits.mean[segment].roundsAgreeing = agreed;
+    row.fanFits.mean[segment].roundModels = models;
   }
 
   console.log(';;');

--- a/implementation/core/test/re_frame/bench/p0_uix.cljs
+++ b/implementation/core/test/re_frame/bench/p0_uix.cljs
@@ -91,6 +91,36 @@
        ($ u-cell {:key i :i i}))))
 
 ;; ---------------------------------------------------------------------------
+;; FAN — the fan-out family (rf2-5prok)
+;; ---------------------------------------------------------------------------
+;;
+;; The UIx counterpart of `p0-reagent`'s fan family, written the same way
+;; for the same reasons: one `defui` per read count (a `for` over the read
+;; count inside one component is a hook-linter error and would be a
+;; different question anyway), identical props at every rung so the shell
+;; rung is not measuring one fewer prop slot, and identical DOM at every
+;; rung so the floor subtraction stays honest.
+
+(defui fan-cell-0 [{:keys [j]}]
+  ($ :span.cell {:data-i j} "0"))
+
+(defui fan-cell-1 [{:keys [j n]}]
+  (let [a (uix-adapter/use-subscribe [:p0/fan (fx/fan-key n 1 0)])]
+    ($ :span.cell {:data-i j} (str a))))
+
+(defui fan-cell-2 [{:keys [j n]}]
+  (let [a (uix-adapter/use-subscribe [:p0/fan (fx/fan-key n 2 0)])
+        b (uix-adapter/use-subscribe [:p0/fan (fx/fan-key n 2 1)])]
+    ($ :span.cell {:data-i j} (str (+ a b)))))
+
+(defui fan-grid [{:keys [offset n-cells reads]}]
+  ($ :div.ugrid
+     (case (long reads)
+       0 (for [j (range n-cells)] ($ fan-cell-0 {:key j :j j :n (+ offset j)}))
+       1 (for [j (range n-cells)] ($ fan-cell-1 {:key j :j j :n (+ offset j)}))
+       2 (for [j (range n-cells)] ($ fan-cell-2 {:key j :j j :n (+ offset j)})))))
+
+;; ---------------------------------------------------------------------------
 ;; Roots — the frame scope every read resolves through
 ;; ---------------------------------------------------------------------------
 ;;
@@ -111,3 +141,11 @@
 (defn u-root [frame-id]
   ($ uix-adapter/frame-provider {:frame frame-id}
      ($ u-grid {:n fx/cells-n})))
+
+(defn fan-root
+  "One root of the fan-out arm. `offset` is this root's base in the GLOBAL
+  boundary numbering, which is what lets four roots of one frame either
+  share every key or share none."
+  [frame-id offset n-cells reads]
+  ($ uix-adapter/frame-provider {:frame frame-id}
+     ($ fan-grid {:offset offset :n-cells n-cells :reads reads})))


### PR DESCRIPTION
Closes rf2-5prok — the P0 heap fan-out sweep, adopted as *Codex rec 4* by the
heap-regime ruling (`rf2-2rtt6.16`). Non-gating for that ruling; gating for
freezing Part 3's component budget rows.

## What this is

E/Q at **1, 2, 4 and 8** on the existing P0 heap arm — not a second instrument —
with **B, E/B, elements and text all pinned** and only the number of unique live
query keys moving. Run at **ROOTS=4** (B = 1,200) and **ROOTS=1** (B = 300), six
rounds each.

Studio page: `docs/design/hicasso/studio/heap-fan-out-sweep.md`.

## What it found

**Cache cardinality is worth 1.6–1.9×, measured on one instrument in one run.**
Reagent runs 1,643 → 842 B/boundary from fan-out 1 to 8; UIx 3,235 → 1,813 B.
Nothing else in either page changed.

**The ruling's prediction holds and Part 1 is not reopened.** Reagent's
fan-out-1 rung lands within **1.8–5.2%** of the predicted 1,562 B. UIx's misses
by **15–16%** — and `rf2-2rtt6.13` (`9df5094816`), which landed *after* the
reads ladder was published and removed a retained disposed reaction worth 769 B
per unique key, accounts for all of it: add the term back and **both** substrates
sit **+5.2%** above the ladder, which is what a common-mode offset between two
harnesses looks like. The ratio prediction (2.25–2.44×) recovers the same way;
the measured **1.97×** is the retained-heap *benefit* of that landing, priced on
the fan-out-1 witness.

**The `rf2-2rtt6.4` grid arm reproduces to 0.3%.** Re-run unchanged as a rung of
this sweep, its published 947 B/boundary reads **950 B [939–958]** — and the
instrument now **counts Q off the frame's own sub-cache on every mount** and
refuses a mount whose count is not the plan's, so the ruling's central
mechanical claim (four roots holding 300 reactions over 1,200 boundaries, not
1,200 reactions) stopped being a reading of the source and became a number 252
mounts had to answer.

**The additive model holds on UIx and needs a fourth term on Reagent.** The
per-unique-key axis is a line in every round of both runs (r² 0.9973–0.9999).
The per-edge term is another matter: on UIx the two identifications agree within
3.8% and the held-out rung is predicted within 2%; on Reagent they differ by
160 B — more than twice the smaller — and a per-subscribing-boundary step of
~150–163 B is what sits between them. **Shell and per-unique-key are unblocked
for `validation.md` on both substrates; the Reagent per-edge row is refused**, by
a criterion written down before the run. `validation.md` is normative and is not
touched here — that edit is filed as **rf2-hvl5s**.

## Instrument changes

- `p0_fixture.cljc` — `:p0/fan` and `fan-key`: one rule, `(n·r + j) mod Q`, so
  B, E and Q are three numbers the driver states rather than three hand-written
  pages. Every key answers the same `0`, so every rung renders identical DOM.
- `p0_reagent.cljs` / `p0_uix.cljs` — the fan family, one component per read
  count (a loop over the read count would be a different question on Reagent and
  a hook-linter error on UIx), with **identical props at every rung** so the
  shell rung is not measuring one fewer prop slot than the rungs it anchors.
- `p0_heap.cljs` — `mount!` verifies **Q as well as B**; the published arms carry
  their Q too. `additive-fit` adjudicates two models and holds one rung out of
  every identification. Its self-test runs three synthetic pages before the sweep
  measures anything: an exact M3 page priced back to the byte, an M4 page whose
  R=1 family is a **perfect** line and which M3 still misses by 12.90% on the
  held-out rung, and a quadratic page both models must refuse.
- `p0_run.cjs` — `--only fanout`, opt-in, sharing one measurement engine with the
  published heap row so the two cannot drift into two instruments wearing one
  name.

The published `--only heap` row's arms, keys, plan and output are unchanged.

## Quality gates

| # | command | exit |
|---|---|---|
| 1 | `sh scripts/assert-worker-worktree.sh` | **0** |
| 2 | `node --check implementation/core/test/re_frame/bench/p0_run.cjs` | **0** |
| 3 | `P0_FAN_ROUNDS=1 P0_ROOTS=1 node .../p0_run.cjs --only fanout` *(smoke, 1 round — not published)* | **2** — the arm-order guard refusing a single-order result, correctly. Re-taken at 6 rounds rather than excused. |
| 4 | `P0_ROOTS=4 P0_FAN_ROUNDS=6 node .../p0_run.cjs --only fanout` *(published)* | **0** |
| 5 | `P0_ROOTS=1 P0_FAN_ROUNDS=6 node .../p0_run.cjs --only fanout` *(published)* | **0** |
| 6 | `P0_ROUNDS=6 node .../p0_run.cjs --only heap` *(regression: the published row, unchanged)* | **0** — Reagent grid exclusive 947 B, the published figure to the byte; 0 unverified of 56 mounts, now including the new Q read-back |
| 7 | `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine` (docs+jvm+node tiers; mkdocs soft-skipped, not on PATH) |

Both published runs: arm-order guard **reportable**, **0 unverified of 126
mounts**, dense-array positive control within **0.007%** of its predicted
4,700,000 B, adjudicator self-test **6 of 6**. Runs were foreground to
completion, logs worktree-local, no other bench process on the box.
