### PR TITLE
bench(hicasso): one lane-cache helper, in the shared bench-helper directory (rf2-9smjn)

### DIFF
--- a/docs/design/hicasso/studio/README.md
+++ b/docs/design/hicasso/studio/README.md
@@ -75,7 +75,7 @@ have: two cleared-cache builds of an arm are byte-identical, where before the
 fix the bundle depended on which arm had built last. The clear sits inside the
 run-to-run noise, because the time is JVM start, classpath and the Closure
 `:advanced` pass rather than the CLJS compile the cache holds.
-`freehand/test/re_frame/bench/hicasso/lane_cache.cjs` carries the isolation, the
+`freehand/test/re_frame/freehand/bench/lane_cache.cjs` carries the isolation, the
 measurement and the alternatives that were rejected.
 
 The instrument is

--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -737,7 +737,7 @@ reader was that HD-008 was broken on main. It was not.
 Every driver in the lane now clears the shared entry before it builds, so
 **this page's reproduction command runs from a cold or a warm cache, in any
 order.** The clear is inside the run-to-run noise;
-`freehand/test/re_frame/bench/hicasso/lane_cache.cjs` carries the measurement
+`freehand/test/re_frame/freehand/bench/lane_cache.cjs` carries the measurement
 and the alternatives that were rejected.
 
 ## Known limitations of this instrument

--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
@@ -97,12 +97,11 @@ const PORT = Number(process.env.HN_PORT || 8141);
 // and for the same reason: ONE helper for the repository, never a second copy
 // per lane. Unlike `loadNavigate`, this require has NO FALLBACK — a fallback
 // here would silently re-arm the trap, and a driver that cannot find the
-// cache rule must fail loudly rather than measure without it. (The helper's
-// home is the hicasso lane it was written for; hoisting it beside
-// `navigate.cjs` now that a second tree needs it is rf2-2rtt6.22's recorded
-// recommendation and is left to the owner of those five drivers.)
+// cache rule must fail loudly rather than measure without it. (The helper
+// now sits beside `navigate.cjs` in the shared bench-helper directory,
+// hoisted there by rf2-9smjn once a second tree needed it.)
 const { resetLaneBuildCache } = require(
-  path.join(IMPL, 'freehand/test/re_frame/bench/hicasso/lane_cache.cjs')
+  path.join(IMPL, 'freehand/test/re_frame/freehand/bench/lane_cache.cjs')
 );
 
 // --- the plan ---------------------------------------------------------------

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -101,7 +101,7 @@ const http = require('node:http');
 const path = require('node:path');
 
 // One build id, N programs, so nothing may cache between them (rf2-2rtt6.20).
-const { resetLaneBuildCache } = require('../../../../freehand/test/re_frame/bench/hicasso/lane_cache.cjs');
+const { resetLaneBuildCache } = require('../../../../freehand/test/re_frame/freehand/bench/lane_cache.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../..');
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/coldmount_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/coldmount_run.cjs
@@ -53,7 +53,7 @@ const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs'
 // The directory's ONE sentinel wait, raced against the page dying (rf2-f5roa).
 const { watchPage } = require('../../freehand/bench/sentinel.cjs');
 // One build id, N programs, so nothing may cache between them (rf2-2rtt6.20).
-const { resetLaneBuildCache } = require('./lane_cache.cjs');
+const { resetLaneBuildCache } = require('../../freehand/bench/lane_cache.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs
@@ -61,7 +61,7 @@ const { watchPage } = require('../../freehand/bench/sentinel.cjs');
 // One build id, N programs, so nothing may cache between them (rf2-2rtt6.20).
 // This driver is where the fault was found: run the P0 lane, then run HD-008,
 // and the page died before taking a sample.
-const { resetLaneBuildCache } = require('./lane_cache.cjs');
+const { resetLaneBuildCache } = require('../../freehand/bench/lane_cache.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 const REPO = path.resolve(IMPL, '..');

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
@@ -71,7 +71,7 @@ const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs'
 // The directory's ONE sentinel wait, raced against the page dying (rf2-f5roa).
 const { watchPage } = require('../../freehand/bench/sentinel.cjs');
 // One build id, N programs, so nothing may cache between them (rf2-2rtt6.20).
-const { resetLaneBuildCache } = require('./lane_cache.cjs');
+const { resetLaneBuildCache } = require('../../freehand/bench/lane_cache.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/retention_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/retention_run.cjs
@@ -80,7 +80,7 @@ const path = require('node:path');
 
 const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs');
 // One build id, N programs, so nothing may cache between them (rf2-2rtt6.20).
-const { resetLaneBuildCache } = require('./lane_cache.cjs');
+const { resetLaneBuildCache } = require('../../freehand/bench/lane_cache.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/run.cjs
@@ -47,7 +47,7 @@ const path = require('node:path');
 // line reads exactly like the bench timeout it is not.
 const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs');
 // One build id, N programs, so nothing may cache between them (rf2-2rtt6.20).
-const { resetLaneBuildCache } = require('./lane_cache.cjs');
+const { resetLaneBuildCache } = require('../../freehand/bench/lane_cache.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/z3vlz_run.cjs
@@ -86,7 +86,7 @@ const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs'
 // This driver needs it MOST: it builds four different variants back to back in
 // a single run, so it was poisoning its own later rungs with its earlier ones
 // without any second driver being involved.
-const { resetLaneBuildCache } = require('./lane_cache.cjs');
+const { resetLaneBuildCache } = require('../../freehand/bench/lane_cache.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 const BUILD_ID = 'hicasso-bench';

--- a/implementation/freehand/test/re_frame/freehand/bench/lane_cache.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/lane_cache.cjs
@@ -3,7 +3,7 @@
 //
 // HD-017 gives the whole P0 lane a SINGLE build id, `:hicasso-bench`, because
 // `implementation/shadow-cljs.edn` is hot-zone and a build id per arm would be
-// a sequenced dispatch per arm. Every driver in this directory therefore rides
+// a sequenced dispatch per arm. Every driver in the lane therefore rides
 // that one id and supplies its own `:init-fn` and `:output-dir` through
 // `--config-merge`. That design is good and this file does not change it.
 //


### PR DESCRIPTION
Closes rf2-9smjn.

`lane_cache.cjs` is the hicasso lane's one cache rule. `:hicasso-bench` is a
single build id serving N different programs, shadow-cljs derives the build
cache directory from the build id alone — before any `--config-merge` is
applied — so a sibling arm's stale `shadow-js/` npm-conversion index compiles
clean and then dies at runtime under `:advanced`. Every driver on that id
clears the whole entry before it builds.

The helper lived in `implementation/freehand/test/re_frame/bench/hicasso/`,
the lane it was written for, while serving **three test trees**: the six
drivers in that directory, plus `core/test/re_frame/bench/p0_run.cjs` and
`adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs`, both of which
reached it by path across the trees. That works and it is not a copy — but the
rule it exists to serve is *one helper for the repository, never a second copy
per lane*, and the repository already has the place for exactly that:
`implementation/freehand/test/re_frame/freehand/bench/`, where `navigate.cjs`,
`order_guard.cjs` and `sentinel.cjs` live and where the hicasso drivers
already reach for all three.

So it moves there (`git mv`, history preserved) and **all eight** requires
follow it. `grep` on current `main`, not the count in the bead: the tree has
moved since the bead was filed — `coldmount_run.cjs` is a sixth in-lane driver
and `core/.../p0_run.cjs` was retargeted to `:hicasso-bench` by rf2-etmyc.

| driver | tree | require after |
|---|---|---|
| `bench/hicasso/run.cjs` | freehand | `require('../../freehand/bench/lane_cache.cjs')` |
| `bench/hicasso/hd8_run.cjs` | freehand | same |
| `bench/hicasso/p0_converge_run.cjs` | freehand | same |
| `bench/hicasso/retention_run.cjs` | freehand | same |
| `bench/hicasso/z3vlz_run.cjs` | freehand | same |
| `bench/hicasso/coldmount_run.cjs` | freehand | same |
| `core/test/re_frame/bench/p0_run.cjs` | core | `require('../../../../freehand/test/re_frame/freehand/bench/lane_cache.cjs')` |
| `adapters/reagent/.../hicasso_narrow_run.cjs` | adapters | `path.join(IMPL, 'freehand/test/re_frame/freehand/bench/lane_cache.cjs')` |

The six in-lane drivers now use the same `../../freehand/bench/…` spelling
they already use for `navigate.cjs`; the two out-of-tree drivers keep the path
form they had.

No behaviour change. The helper's mechanism, isolation evidence, rejected
alternatives and measured cost are its own and move with it unedited, save one
line whose "every driver in this directory" no longer described the directory
the file now sits in. Three other lines that were falsified by the move are
reconciled: `hicasso_narrow_run.cjs`'s parenthetical saying the hoist "is left
to the owner of those five drivers", and the two studio pages that cited the
helper by full path.

## Quality gates

Run on Windows 11, from a worktree with **no `.shadow-cljs` directory at all**
— the trap self-heals once the npm-conversion index has accumulated every
arm's modules, so a warm start proves nothing. Foreground, to completion, each
exit code echoed, each run captured to its own log.

**A moved require that resolves is not proof the helper still does its job**,
so the invariant was run rather than asserted: two programs on one build id,
the second needing `react/jsx-runtime` that the first does not pull.

| # | run | exit | what it shows |
|---|---|---|---|
| 1 | `node freehand/test/re_frame/bench/hicasso/run.cjs` (cold) | **2** | Reagent-only arms, 94 compiled. Built and ran to completion; exit 2 is the arm-order guard refusing `M2/ctl-2x` on phase (`LAST-THIRD reads 1.8000x FIRST-THIRD`) — a measurement verdict on a loaded box, and categorically not the runtime death below. The same driver exited 0 twice later in this sequence. |
| 2 | `HD8_ONLY=uix node .../hd8_run.cjs` | **0** | `[hd8] cleared .shadow-cljs/builds/hicasso-bench`, 114 compiled, all four rows measured, `[hd8] ok`. |
| 3 | `node .../hicasso/run.cjs` (re-poison) | **0** | `cleared …`, 94 compiled — a fresh Reagent-only index, the control condition. |
| 4 | `HD8_ONLY=uix` hd8_run **with `resetLaneBuildCache` neutralised** | **1** | `Build completed. (169 files, 30 compiled)` — compiled clean over the poisoned index — then `[hd8:uix] PAGE PAGEERROR: Cannot read properties of undefined (reading 'd')`. The documented fault, reproduced. |
| 5 | `node .../hicasso/run.cjs` (re-poison, identical state) | **0** | `cleared …`, 94 compiled. |
| 6 | `HD8_ONLY=uix node .../hd8_run.cjs` (unmodified) | **0** | `cleared …`, 114 compiled, all four rows measured, `[hd8] ok`. |
| 7 | `node adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs` | **0** | The **adapters** tree's `path.join` require, over hd8's UIx cache: `[hn] cleared …`, gates 1–4 ok, 6 rounds, 0 unverified. |
| 8 | `P0_ROUNDS=2 P0_SAMPLES=6 node core/test/re_frame/bench/p0_run.cjs --only heap` | **0** | The **core** tree's relative cross-tree require: `[p0] cleared …`, 120 compiled, `[p0] done`. |

**Runs 3→4 and 5→6 are the paired A/B**, and they differ in nothing but
whether the helper ran. The control was produced without editing the
repository: a wrapper pre-seeded `require.cache` with a no-op
`resetLaneBuildCache`, so the driver's own require found the stub and every
other byte of the run was identical.

Runs 1, 2, 6, 7 and 8 exercise **all three require forms** live — in-lane
relative, cross-tree relative, and `path.join(IMPL, …)`. The four in-lane
drivers not run here (`p0_converge_run`, `retention_run`, `z3vlz_run`,
`coldmount_run`) carry a require line byte-identical to runs 1 and 2's. All
eight were additionally resolved programmatically from each driver's own
`createRequire`, every one landing on the single hoisted file, and all eight
pass `node --check`.

`git grep` for `lane_cache` and `resetLaneBuildCache` over tracked files now
returns no reference to the old path anywhere outside the bead's own record.
