### PR TITLE
docs(hicasso): the component budgets the sweep priced — and the one it refused (rf2-hvl5s)

### DIFF
--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -40,13 +40,52 @@ as HD-nnn are normative in [decisions.md](decisions.md).
 
 The shell budget line is the R=0 boundary shell by ruling (heap red-zone regime
 ruling, delegated by Mike, 2026-07-31; authoritative text on rf2-2rtt6.16,
-transcription on rf2-2rtt6.1): both measured donors comply — Reagent ~418–428 B,
-UIx ~208 B — and a candidate cannot pass the line by amortising subscriptions
-across boundaries, because the distinct-query heap ladder (Q = E) is the
-mandatory worst-case witness and the operative upper-envelope red-zone family.
-Component budget rows (shell / per-edge / per-unique-key) enter this table only
-after rf2-5prok's fan-out sweep verifies the additive heap model and prices the
-terms.
+transcription on rf2-2rtt6.1): a candidate cannot pass the line by amortising
+subscriptions across boundaries, because the distinct-query heap ladder (Q = E)
+is the mandatory worst-case witness and the operative upper-envelope red-zone
+family. The shell is component-shape sensitive at the ~75 B level, so the line
+means nothing without a named boundary shape: the ladder's one-prop boundary
+reads Reagent ~418–428 B and UIx ~208 B; the fan-out sweep's two-prop boundary
+reads Reagent 501–524 B and UIx 221–231 B. Both donors clear the 1 KB paper-fail
+line on either shape, but on the two-prop shape Reagent sits at the *top* of the
+0.4–0.5 KB target band rather than inside it.
+
+### The component budgets
+
+Part 3 of the same ruling would not freeze the shell / per-edge / per-unique-key
+rows from cross-instrument algebra; it gated them on a bench sweep that verified
+the additive heap model and priced the terms on one instrument in one run. That
+sweep has landed — [the fan-out heap sweep](studio/heap-fan-out-sweep.md), commit
+`61dd44950a` (PR #7306): E/Q 1-2-4-8 at ROOTS=4 and ROOTS=1, six rounds each,
+both runs exit 0, arm-order guard reportable, 0 unverified of 126 mounts per run,
+dense-array positive control within 0.007%. It prices two of the three rows on
+both substrates and **refuses** the third on one.
+
+| Component (per boundary, distinct-query witness) | Reagent-on-subs | UIx-on-subs |
+|---|---|---|
+| Boundary shell (R = 0), two-prop boundary | 501–524 B | 221–231 B |
+| Per unique subscription key | ~866 B [823–939] | ~1,590 B [1,525–1,659] |
+| Per edge (consumer attachment) | **refused — measured, not identified** | ~1,345 B [1,327–1,396] |
+
+**The refused row is a result, not an omission.** On UIx the two independent
+identifications of the edge term agree within 3.8% and the surviving model
+predicts a held-out rung it never saw to within 2%. On Reagent they disagree by
+160 B — 80–84 B priced from the contrast against 234–244 B priced from the
+intercept, more than twice the smaller of the two — and the criterion that
+refuses them was written down before the run. What a Reagent boundary pays for
+its *first* read beyond the per-key term is ~234–244 B, and that total is
+quotable; how it splits between an attachment and a per-subscribing-boundary step
+of ~150–163 B, which is neither shell nor edge, is not. Budget against the total.
+Never against either half.
+
+Two caveats ride these rows. Reagent's additive verdict is **marginal**: it
+reaches the four-term model in both runs but by different failing checks — a
+10.44% held-out miss against a 10% threshold in one run, a 163 B step against a
+160 B band in the other — and its per-round verdicts flip. Neither threshold was
+moved after the fact. And separating Reagent's step from its edge wants one rung
+the sweep does not have, R = 3 at fixed Q, which would over-determine the pair;
+the studio page carries that as an Open item. Until it runs, the Reagent per-edge
+row stays refused.
 
 Sub-key identity: `(query-id, args)` under value equality; value-unstable map args
 thrash the index — documented, programmer-trusted. A missed invalidation is a P0


### PR DESCRIPTION
Part 3 of the heap-regime ruling (authoritative text on `rf2-2rtt6.16`,
transcription on `rf2-2rtt6.1`) held `validation.md`'s three component budget
rows — shell / per-edge / per-unique-key — out of the page until a bench sweep
verified the additive heap model and priced the terms, and explicitly **refused**
to freeze them from cross-instrument algebra. That sweep has landed:
[`docs/design/hicasso/studio/heap-fan-out-sweep.md`](https://github.com/day8/re-frame2/blob/main/docs/design/hicasso/studio/heap-fan-out-sweep.md),
commit `61dd44950a` (PR #7306). This PR is the gated edit, and only that edit —
the studio page is the merged source of truth and is not touched, and no figure
here is re-derived or re-measured.

## What the rows now say

| Component (per boundary, distinct-query witness) | Reagent-on-subs | UIx-on-subs |
|---|---|---|
| Boundary shell (R = 0), two-prop boundary | 501–524 B | 221–231 B |
| Per unique subscription key | ~866 B [823–939] | ~1,590 B [1,525–1,659] |
| Per edge (consumer attachment) | **refused — measured, not identified** | ~1,345 B [1,327–1,396] |

## The refusal is the point

A budget table that quietly lacks a row reads as *not applicable*. This one has
to read as *measured, and the instrument refused to identify it* — so the Reagent
per-edge term is recorded as refused rather than omitted, and rather than filled
with the algebraic estimate the ruling already rejected. The page states why: the
two identifications disagree by 160 B (80–84 B from the contrast against
234–244 B from the intercept, more than twice the smaller of the two) against a
criterion written down before the run. What *is* quotable for Reagent is the
~234–244 B first-read total beyond the per-key term; how it splits between an
attachment and the ~150–163 B per-subscribing-boundary step is not. Budget
against the total, never against either half.

## Caveats carried, not smoothed

- Reagent's four-term verdict is **marginal** — it reaches M4 in both runs but by
  different failing checks (a 10.44% held-out miss against a 10% threshold in one
  run, a 163 B step against a 160 B band in the other), and its per-round verdicts
  flip. Neither threshold was moved after the fact.
- Separating Reagent's step from its edge wants a rung the sweep does not have
  (R = 3 at fixed Q). The studio page carries it as an Open item; until it runs,
  the row stays refused.
- The shell paragraph is amended **in place**, not corrected beside: the shell is
  component-shape sensitive at the ~75 B level, so both boundary shapes are named
  with their figures (ladder one-prop: Reagent ~418–428 B, UIx ~208 B; sweep
  two-prop: 501–524 B and 221–231 B), both clear the 1 KB paper-fail line, and
  Reagent's position at the *top* of the 0.4–0.5 KB band on the two-prop shape is
  stated rather than implied by the old blanket "both measured donors comply".

## Out of scope, deliberately

The ruling is not reopened or re-litigated. No component row is added for a term
the sweep did not price. The clock axis, the converged witness set, the red-zone
thresholds, the kill criteria and the `.4`/`.5` family standings are untouched.
The sweep's 9.3% UIx/Reagent ratio drift across E/Q 1→8 refines the ruling's
"a heap ratio is portable across witness shapes" — but `validation.md` never
states that portability rule (it sets red-zones *per witness family*, which is
the opposite claim), so nothing here needed qualifying and nothing was forced in.
The drift stays on the studio page's Open list as the operator's call.

## Quality gates

Prose-only documentation edit — one file, `docs/design/hicasso/validation.md`, no
code, no instrument and no build input changed, so no code gate applies.

| gate | result |
|---|---|
| `python -m mkdocs build --strict` | **exit 0**, foreground, run in this worktree |

Closes rf2-hvl5s.
