### PR TITLE
bench(hicasso): the reactive leg gets a second author (rf2-2rtt6.21)

### DIFF
--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -511,6 +511,290 @@ bounds the instrument has ever published rather than one run's.
 | **bulk narrow** — 10 commits a sample | 16.5 – 30 | 41.5 – 66.5 | 48 – 74 | **yes** |
 | ~~bulk narrow — 1 commit a sample (superseded)~~ | ~~2 – 3~~ | ~~4 – 4.5~~ | ~~4.5 – 5~~ | ~~**clamp-limited**~~ |
 
+## The reactive leg, from a second author (rf2-2rtt6.21)
+
+**The one term this page could not corroborate, it now measures.** The section
+above shows that the Reagent-on-subs arm here reproduces rf2-2rtt6.2's
+denominator. What it could not touch was rf2-2rtt6.2's **headline 1** — *reading
+re-frame2 subscriptions rather than a bare cursor costs Reagent ≈1.22× on mount
+and ≈2.01× on a broad commit* — because that figure needs a `:reagent-ratom` arm
+beside the `:reagent-subs` arm, and this page had none. rf2-2rtt6.17 measured the
+leg three times, and all three are re-runs of the **same** arm: three runs bound
+an instrument's noise, and cannot bound a systematic error in how the arm is
+written. Repetition, not replication.
+
+`?ratom=on` puts that arm in the Reagent segment of the `M1` and `broad` rows.
+The leg is then formed **inside one segment of one round** — both terms are
+Reagent arms measured against the same floor, so the floor divides out exactly
+and the segment seam is not in the arithmetic at all.
+
+### What was added, and what deliberately was not
+
+| | |
+|---|---|
+| **the arm** | `:reagent-ratom` — form-2 components minting one `r/cursor` per mounted occurrence over a bare `reagent.core/atom`, mounted through `reagent.dom.client` and drained with `reagent.core/flush` inside one `flushSync`. Everything except **where the value comes from** is held identical to the `:reagent-subs` arm beside it |
+| **the rows** | `M1` mount and `bulk-broad` — the two rows the headline names |
+| **not `M2`** | it is the row whose mount budget already refuses (720 mounts refused four of six), and its leg on the first author's own instrument read **exactly 1.0000 in all five rounds** of the corrected run, because its two Reagent arms returned the same p50 every time on a 4.5-to-11-quantum window. A second author cannot corroborate a number that is the clamp |
+| **not `narrow`** | rf2-2rtt6.2 has no narrow row, so a ratom arm there would mint a new figure rather than corroborate one |
+| **the segment** | the Reagent segment only. Putting a Reagent arm in the UIx segment would buy the leg nothing and would stand Reagent's reaction machinery on the page whose whole point is UIx's |
+| **the default** | **OFF.** With the arm in it the Reagent segment runs four arms against the UIx segment's three, so the interleave and the page's total mount budget both differ from the schedule the ten-run ensemble above was measured under. An unflagged invocation of this driver is still that instrument |
+
+**What "a second author" means here, stated rather than implied.** The two arms
+share `p0_reagent_views.cljs` — `m1-cell-ratom` and `m1-ratom` are the same
+functions on both pages, and that is deliberate: an arm rewritten as well as
+re-scheduled would be a different arm, and a disagreement would not say which
+change caused it. What is independently authored is **everything around the
+components**: a different app namespace, a different round count, a segment
+structure with an adapter destroyed and installed between every pair of
+segments, one row per page instead of three rows in one, a different sampling
+plan, a different aggregation and a different set of gates.
+
+So this corroborates the leg against **harness, schedule and aggregation**
+error, and it cannot corroborate it against an error in the component
+definitions themselves. That limit is real and is left standing as an open item
+below. It also makes the result below stronger rather than weaker: the
+components were held fixed, and the number moved anyway.
+
+### The budget it landed on, and the guard
+
+Adding an arm adds mounts. `M1` runs **840 mounts a page** — 6 rounds × (4
+Reagent-segment arms + 3 UIx-segment arms) × 20 samples — against the 720 every
+clean six-round run of this page has used, and `broad` runs **882 writes**. The
+[dose-response on the M2 row](#3-the-sixth-round-broke-the-m2-row-and-the-lever-was-the-mount-budget)
+says the lever for a phase refusal is the page's total mount budget, so the risk
+was named in the commit before the first sample was taken: *if the guard
+refuses, it will be a last-third-slower phase split, and the repair is the
+budget, never the tolerance.*
+
+**It did not refuse.** Twelve row-runs, `refuse? false`, `contaminated? false`,
+`unchecked? false`, tolerance 0.10, every one. The new arm's own worst factor
+contrast across the six runs is **1.1957× on `M1` and 1.3333× on `broad`, ranges
+overlapping in every case** — the same shape its `:reagent-subs` sibling shows
+(1.2667× and 1.1957×, also overlapping). No budget repair was needed and none
+was taken, so the 840-mount page is what these figures were measured on.
+
+### Predicted before the run, in the commit that added the arm
+
+`bcf80f1979` carries all five, written down before a sample existed:
+
+| prediction | outcome |
+|---|---|
+| positive control, both rows, both segments — 1.9989× on 1801/901 elements, ±25% band [1.4992 – 2.4986] | **24 of 24 pass**, and all 24 pass the *strict* every-round-inside reading as well |
+| `M1` leg — direction *subs slower*, disjoint from 1.0, magnitude **1.10 – 1.35** | direction and disjointness correct; magnitude **1.3353**, at the top edge of the predicted band |
+| `broad` leg — direction *subs slower*, disjoint from 1.0, magnitude **1.8 – 2.3** | direction and disjointness correct; magnitude **2.4957**, **outside the predicted band** |
+| `reagent-ratom ÷ floor` on `M1` — **3.3 – 3.9** | **3.2335** [3.1667 – 3.3375 across run means], just below the band |
+| the guard may refuse `M1` at 840 mounts | it did not |
+
+Two of the five predictions were wrong, both in the same direction, and that is
+the finding rather than a mis-set expectation: the leg is **larger** here than
+the first author's figure, because the ratom arm sits **closer** to the floor
+than predicted while the subs arm sits where this page has always put it.
+
+### `M1` mount — the leg, per run
+
+`reagent-subs ÷ reagent-ratom`, both floor-normalised in the same round of the
+same segment. Six runs, six rounds each, starting segment counterbalanced 3/3.
+
+| run | start | mean | range | per round | Reagent-first stratum | UIx-first stratum | strata |
+|---|---|---|---|---|---|---|---|
+| 1 | reagent | **1.3319** | 1.2778 – 1.3788 | 1.3788 · 1.2963 · 1.3333 · 1.3396 · 1.3654 · 1.2778 | 1.3592 [1.3333 – 1.3788] | 1.3046 [1.2778 – 1.3396] | overlap |
+| 2 | uix | **1.3266** | 1.2692 – 1.4000 | 1.2963 · 1.3137 · 1.2692 · 1.4000 · 1.3469 · 1.3333 | 1.3490 [1.3137 – 1.4000] | 1.3042 [1.2692 – 1.3469] | overlap |
+| 3 | reagent | **1.3497** | 1.3061 – 1.4822 | 1.3621 · 1.3200 · 1.3061 · 1.4822 · 1.3214 · 1.3065 | 1.3299 [1.3061 – 1.3621] | 1.3695 [1.3065 – 1.4822] | overlap |
+| 4 | uix | **1.3378** | 1.2500 – 1.4348 | 1.3725 · 1.3061 · 1.2500 · 1.4348 · 1.3636 · 1.3000 | 1.3470 [1.3000 – 1.4348] | 1.3287 [1.2500 – 1.3725] | overlap |
+| 5 | reagent | **1.3284** | 1.2766 – 1.3750 | 1.3333 · 1.3750 · 1.3043 · 1.3478 · 1.3333 · 1.2766 | 1.3237 [1.3043 – 1.3333] | 1.3331 [1.2766 – 1.3750] | overlap |
+| 6 | uix | **1.3373** | 1.2727 – 1.4039 | 1.3667 · 1.3333 · 1.2727 · 1.4039 · 1.3396 · 1.3077 | 1.3483 [1.3077 – 1.4039] | 1.3263 [1.2727 – 1.3667] | overlap |
+
+**Ensemble 1.3353×**, 95% interval on the mean **1.3265 – 1.3441**, run means
+spanning **1.3266 – 1.3497**. All 36 rounds are above 1.0 and all 12 order strata
+are wholly above it; the strata overlap in **6 of 6** runs, so every run marks
+the row `:claim :magnitude`. The start-group difference is **0.0028** —
+reagent-start 1.3367 against uix-start 1.3339 — so which segment leads does not
+move this figure.
+
+### `bulk-broad` — the leg, per run
+
+| run | start | mean | range | per round | Reagent-first stratum | UIx-first stratum | strata |
+|---|---|---|---|---|---|---|---|
+| 1 | reagent | **2.5504** | 2.4000 – 2.6875 | 2.5909 · 2.4000 · 2.4210 · 2.5556 · 2.6471 · 2.6875 | 2.5530 [2.4210 – 2.6471] | 2.5477 [2.4000 – 2.6875] | overlap |
+| 2 | uix | **2.3613** | 2.1000 – 2.5789 | 2.5789 · 2.3000 · 2.1000 · 2.3000 · 2.5000 · 2.3889 | 2.3297 [2.3000 – 2.3889] | 2.3930 [2.1000 – 2.5789] | overlap |
+| 3 | reagent | **2.4344** | 2.1363 – 2.5833 | 2.5833 · 2.3636 · 2.1363 · 2.5789 · 2.5556 · 2.3889 | 2.4251 [2.1363 – 2.5833] | 2.4438 [2.3636 – 2.5789] | overlap |
+| 4 | uix | **2.4863** | 2.2105 – 2.7858 | 2.5883 · 2.3333 · 2.2105 · 2.5000 · 2.5000 · 2.7858 | 2.5397 [2.3333 – 2.7858] | 2.4329 [2.2105 – 2.5883] | overlap |
+| 5 | reagent | **2.6017** | 2.3889 – 2.7778 | 2.7778 · 2.3889 · 2.5000 · 2.5625 · 2.6667 · 2.7143 | 2.6482 [2.5000 – 2.7778] | 2.5552 [2.3889 – 2.7143] | overlap |
+| 6 | uix | **2.5401** | 2.3889 – 2.8750 | 2.7222 · 2.4210 · 2.4444 · 2.8750 · 2.3889 · 2.3889 | 2.5616 [2.3889 – 2.8750] | 2.5185 [2.3889 – 2.7222] | overlap |
+
+**Ensemble 2.4957×**, 95% interval on the mean **2.4041 – 2.5873**, run means
+spanning **2.3613 – 2.6017**. All 36 rounds above 1.0, all 12 strata wholly
+above, strata overlapping in 6 of 6. Start-group difference **0.066** —
+reagent-start 2.5288 against uix-start 2.4626 — inside this row's run-to-run
+spread.
+
+### Beside the first author: the direction agrees and the magnitude does not
+
+| row | first author (rf2-2rtt6.2 · two re-runs, rf2-2rtt6.17) | second author (this page, six runs) | verdict |
+|---|---|---|---|
+| **M1 mount** | **1.218** [1.122 – 1.310] · **1.216** [1.185 – 1.241] · **1.213** [1.093 – 1.273] | **1.3353** [run means 1.3266 – 1.3497] | **direction agrees, magnitude does not.** Every second-author run mean is above every first-author mean, by 9.5% – 11.1%. The run-mean spreads are **disjoint** |
+| **bulk broad** | **2.008** [1.938 – 2.100] · **1.965** [1.875 – 2.000] · **2.073** [2.000 – 2.167] | **2.4957** [run means 2.3613 – 2.6017] | **direction agrees, magnitude does not.** Every run mean is above every first-author *maximum*, by 14% – 27%. **Disjoint**, and not marginally |
+
+**Both authors say the same thing about the world and a different thing about
+the number.** Reading re-frame2 subscriptions rather than a bare cursor costs
+Reagent something real and it costs it on both rows: 72 of 72 rounds across six
+independent runs sit above 1.0, every order stratum sits above 1.0, and the
+interval on the mean is nowhere near it. That is headline 1's *claim*, and a
+second implementation corroborates it.
+
+**Headline 1's numbers are a different matter.** `≈1.22×` and `≈2.01×` are not
+reproduced: the same witness, the same view components and the same browser, run
+under a second harness, give `1.34×` and `2.50×`. **The leg is not a constant of
+the arm — it is a property of the arm *and its harness*, and the two harnesses
+disagree by 10% on mount and by 24% on a broad commit.** Nothing here says which
+harness is right, and this page does not adjudicate that: a disagreement between
+two internally-clean instruments is the finding, and reconciling it away would
+be inventing an answer neither instrument produced.
+
+### Where the disagreement sits
+
+The leg is a quotient, so it moves when either term does. Both terms are
+published here for exactly that reason:
+
+| row | figure | first author | second author (six-run ensemble) | overlap? |
+|---|---|---|---|---|
+| **M1** | `reagent-subs ÷ floor` | 3.899 [3.447 – 4.300] · 3.973 · 3.513 | **4.3143** [run means 4.1979 – 4.4417, widest round 3.9444 – 4.8824] | yes — and this page already published 4.358 [3.625 – 5.111] on the same figure |
+| **M1** | `reagent-ratom ÷ floor` | 3.224 [2.632 – 3.633] · 3.266 · 2.913 | **3.2335** [run means 3.1667 – 3.3375, widest 2.8889 – 3.6000] | **yes, and closely — the two authors agree on this arm to 0.3% on the mean** |
+| **broad** | `reagent-subs ÷ floor` | 7.064 [6.200 – 7.700] · 7.280 · 7.330 | **7.6959** [run means 7.4167 – 7.9294] | yes — and this page's own ensemble reads 7.630 |
+| **broad** | `reagent-ratom ÷ floor` | 3.519 [3.200 – 3.900] · 3.707 · 3.540 | **3.0948** [run means 2.9722 – 3.2500] | barely — the second author's ratom arm sits **12% closer to the floor** |
+
+**On `M1` the disagreement is entirely in the numerator.** The two authors'
+ratom arms agree to within a third of a percent (3.2335 against 3.224), and the
+subs arm is where the pages differ — which is not new, and is not this bead's
+finding: [the denominator section](#the-denominator-reproduces-rf2-2rtt62) above
+already published `reagent-subs ÷ floor` as 4.358 here against 3.899 there, with
+overlapping ranges and a higher centre. The leg divides one by the other, so a
+centre 11% higher in the numerator and unchanged in the denominator is a leg 11%
+higher, which is what it reads.
+
+**On `broad` both terms move, and they move apart.** The subs arm reads 9%
+higher and the ratom arm 12% lower, and 1.09 ÷ 0.88 is the 24% the leg is out
+by. The ratom arm's absolute window on this page is 0.70 – 1.20 ms against a
+floor of 0.20 – 0.40 — seven to twelve of Chrome's 100 µs quanta against the
+floor's two to four — so it is resolved, but it is the smallest window either
+author measures a leg on.
+
+Absolute p50 milliseconds in the Reagent segment, per round, so the quotients
+above can be checked rather than taken:
+
+| run | `M1` floor / subs / ratom | `broad` floor / subs / ratom |
+|---|---|---|
+| 1 | 1.00/4.55/3.30 · 0.80/3.50/2.70 · 0.80/3.40/2.55 · 0.80/3.55/2.65 · 0.80/3.55/2.60 · 0.75/3.45/2.70 | 0.35/2.85/1.10 · 0.30/2.40/1.00 · 0.30/2.30/0.95 · 0.30/2.30/0.90 · 0.30/2.25/0.85 · 0.25/2.15/0.80 |
+| 2 | 0.80/3.50/2.70 · 0.80/3.35/2.55 · 0.80/3.30/2.60 · 0.80/3.50/2.50 · 0.80/3.30/2.45 · 0.80/3.20/2.40 | 0.30/2.45/0.95 · 0.30/2.30/1.00 · 0.30/2.10/1.00 · 0.30/2.30/1.00 · 0.30/2.25/0.90 · 0.30/2.15/0.90 |
+| 3 | 0.90/3.95/2.90 · 0.80/3.30/2.50 · 0.80/3.20/2.45 · 0.85/4.15/2.80 · 0.90/3.70/2.80 · 0.90/4.05/3.10 | 0.40/3.10/1.20 · 0.30/2.60/1.10 · 0.30/2.35/1.10 · 0.30/2.45/0.95 · 0.30/2.30/0.90 · 0.30/2.15/0.90 |
+| 4 | 0.80/3.50/2.55 · 0.80/3.20/2.45 · 0.70/3.00/2.40 · 0.75/3.30/2.30 · 0.70/3.00/2.20 · 0.70/3.25/2.50 | 0.30/2.20/0.85 · 0.30/2.10/0.90 · 0.30/2.10/0.95 · 0.30/2.00/0.80 · 0.20/2.00/0.80 · 0.30/1.95/0.70 |
+| 5 | 0.90/4.00/3.00 · 0.80/3.30/2.40 · 0.70/3.00/2.30 · 0.70/3.10/2.30 · 0.70/3.00/2.25 · 0.70/3.00/2.35 | 0.35/2.50/0.90 · 0.30/2.15/0.90 · 0.30/2.00/0.80 · 0.20/2.05/0.80 · 0.30/2.00/0.75 · 0.20/1.90/0.70 |
+| 6 | 0.90/4.10/3.00 · 0.90/4.00/3.00 · 0.80/3.50/2.75 · 0.90/3.65/2.60 · 0.90/3.55/2.65 · 0.80/3.40/2.60 | 0.30/2.45/0.90 · 0.30/2.30/0.95 · 0.30/2.20/0.90 · 0.30/2.30/0.80 · 0.30/2.15/0.90 · 0.30/2.15/0.90 |
+
+**The whole page is about twice as fast in absolute terms as rf2-2rtt6.2's
+publication run** — `M1` subs 3.00 – 4.55 ms here against 6.00 – 7.35 there, on
+a floor of 0.70 – 1.00 against 1.50 – 1.90. That is a different session on a
+differently-loaded box and it is exactly why every figure on both pages is a
+*ratio*. It also means the two authors' disagreement cannot be read off the
+absolute numbers: only the quotients are comparable, and the quotients are what
+the tables above compare.
+
+### The control that separates the author from the tree
+
+**A confound has to be excluded before *second author* is the right name for
+this.** Two things differ between rf2-2rtt6.17's re-runs and these six runs: the
+harness, and the tree. `9df5094816` (rf2-2rtt6.13) and `98f6beee8a` (rf2-2rtt6.25)
+both landed changes in `re-frame/substrate/spine.cljs` today, and although the
+`:reagent-ratom` arm touches no re-frame code at all, **the Reagent adapter does
+require the spine** — so a change there could in principle move the *numerator*
+of the leg and produce exactly the shift measured above without any harness
+being involved.
+
+The control is one command: **run the first author's own instrument on this
+tree, in this session.** `npm run bench:hicasso` drives `p0_reagent_app`, which
+publishes its own reactive leg on the same two rows.
+
+**Pre-registered, before it was run:**
+
+- If the first author's instrument still reads near **1.21 – 1.27** on `M1` and
+  **1.96 – 2.17** on `broad` — its published spread — then the tree did not move
+  the leg and the difference above is the **harness**. *Second author* is the
+  right name, and the disagreement stands as measured.
+- If it reads near **1.33** and **2.50** instead, the difference is the **tree or
+  the session**, not the author, the two implementations agree after all, and
+  what has actually been found is that headline 1's published magnitudes are
+  stale at HEAD. That would be a larger finding than the one this bead went
+  looking for, and it would belong to rf2-2rtt6.2's page rather than to this one.
+
+**The control has not been run at the moment this paragraph is committed.**
+It is written here first so that neither branch of it can be chosen after the
+numbers are in.
+
+### Provenance
+
+**Whole-tree anchor: `3a250838a2e3045209ecfc69402bba95ab51de8a`** — `origin/main`,
+plus the two instrument files this bead changed. That is stated as a sum rather
+than as a single SHA because it is the truth: the arm had not landed when it was
+measured, and pretending a branch SHA is a tree anchor is how a placeholder
+becomes a falsehood.
+
+| file | blob |
+|---|---|
+| `implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs` | `a5177d3f0bf764917075d2a247af0ddc4684a719` — **changed by this bead** |
+| `implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` | `82977240c0fcf983b286918105140f40f2a1dbc7` — **changed by this bead** |
+| `implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_views.cljs` | `bf79bf304d62f679be5fca69dd7880360a1a0631` — unchanged; the ratom components are the first author's, by construction |
+| `implementation/freehand/test/re_frame/bench/hicasso/p0_reagent_app.cljs` | `cd8e7c7f3313c08e6b670a3d5acf406a04a7a2e1` — unchanged; the first author's instrument, used as the control above |
+| `implementation/freehand/test/re_frame/bench/hicasso/lane.cljs` | `0642815dc234c1544d1f97bd9e1e4dd24365c027` — unchanged |
+| `implementation/freehand/test/re_frame/bench/hicasso/p0_uix_views.cljs` | `34e0e89d532f2af3b3289525509cf033bb03bc05` — unchanged |
+| `implementation/freehand/test/re_frame/bench/hicasso/lane_cache.cjs` | `dd85cc8bd9133b659718e1f54f286f7314420ffd` — unchanged |
+| `implementation/core/test/re_frame/bench/order_guard.cljc` | `6c4097afff5afa6d64903c3be2f2f4fd6f145050` — unchanged |
+| `implementation/core/src/re_frame/substrate/spine.cljs` | `8d20218fd18282265cce1f931d019ca1f4d88b41` — **carries both of today's spine fixes**, which is the tree the control above exists to price |
+
+```bash
+git merge-base --is-ancestor 3a250838a2 origin/main && echo tree-anchor-on-main
+P=implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+git rev-parse <candidate>:$P   # must print a5177d3f0bf764917075d2a247af0ddc4684a719
+```
+
+| | |
+|---|---|
+| **Authoring commit** | `bcf80f1979170d4d16d6e7679051de0018d410c5` on `worker/ratom2-2rtt6-21` — *the converged witness gets a reagent-ratom arm*. **A rebase-merge will mint a new landed SHA**; the blobs above are what identify the instrument, and a rebase cannot move a blob. The commit is also where the five predictions are written down, before the first sample existed |
+| **Reproduction** | `HICASSO_RATOM=on HICASSO_ONLY=M1,broad HICASSO_START=reagent node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` — and the same with `HICASSO_START=uix`. **Six invocations, exit 0 on all six**, launched one at a time, none re-run and none discarded |
+| **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium via Playwright), `:advanced`, `goog.DEBUG false`, Windows 11 x64, sibling agents live on the box |
+| **Build** | `:hicasso-bench`, one build id, cold — `lane_cache.cjs` clears `.shadow-cljs/builds/hicasso-bench` before every invocation. `implementation/shadow-cljs.edn` untouched |
+| **Schedule** | **6 rounds** × 2 segments × (8 warm-up + 12 samples), one row per page, start counterbalanced 3/3. **Four arms in the Reagent segment** — floor, `reagent-subs`, `reagent-ratom`, `ctl-2x` — and three in the UIx segment |
+| **Budget** | **840 mounts** on the `M1` page, **882 writes** on the `broad` page, per run |
+| **Arm-order guard** | **no refusal on any of the 12 row-runs** — `refuse? false`, `contaminated? false`, `unchecked? false`, tolerance 0.10, every one |
+| **Canonical-DOM parity** | `{:problems [] :ok? true}` on all 12 — in both segments and across the seam. The ratom arm is inside the equality, not exempt from it |
+| **Verification** | **0 unverified of 10,332** — per run 840 `M1` mounts + 882 `broad` writes = 1,722, times six |
+| **Segment-order control** | **no refusal on any row of any run**; `magnitude-resolved? true` on **12 of 12**, `:balanced-design? true` on all 12 — for the leg as well as for the red-zone, because the leg is held to the same rule |
+| **Positive controls** | 2 rows × 2 segments × 6 runs = **24, and 24 passes**, all 24 also inside the *strict* every-round-inside band [1.4992 – 2.4986] |
+
+**The cross-segment red-zone from these six runs is not a threshold and is not
+published as one.** With four arms in the Reagent segment against three in the
+UIx segment the page is not the page the [RED-ZONE
+table](#red-zone--clock-on-rf2-2rtt62s-witnesses) was measured on, and every
+record these runs wrote carries `:ratom-arm? true` and says so. For the record
+and for nothing else, the six runs read `M1` 0.9939 – 1.1184 and `broad`
+0.5808 – 0.6768, which straddle and sit below the published `1.2310` and
+`0.6291` respectively — a difference this design has no standing to interpret.
+
+### Open items from this section
+
+- **The components are shared, so the corroboration is of the harness.**
+  `m1-cell-ratom` and `m1-ratom` are the same functions on both pages. An error
+  inside them would be invisible to both authors, and a third witness written
+  against different components — a `use-syncExternalStore` cursor, or a
+  hand-built Reagent reaction — is what would close that. It is not closed here
+  and is not claimed to be.
+- **The two harnesses disagree and neither is adjudicated the winner.** What is
+  established is that the magnitude moves by 10% – 24% between two internally
+  clean instruments measuring the same witness with the same components. Which
+  number a standard should carry is the operator's, and rf2-2rtt6.1 is
+  size-locked; nothing here amends it.
+- **Six runs, one machine, one session.** The same limit the ten-run ensemble
+  carries. Between-session spread is unmeasured and is the wider of the two.
+
 ## What the convergence changed
 
 Three of rf2-2rtt6.4's four clock verdicts do not survive the move onto

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -585,10 +585,15 @@ was taken, so the 840-mount page is what these figures were measured on.
 | `reagent-ratom ÷ floor` on `M1` — **3.3 – 3.9** | **3.2335** [3.1667 – 3.3375 across run means], just below the band |
 | the guard may refuse `M1` at 840 mounts | it did not |
 
-Two of the five predictions were wrong, both in the same direction, and that is
-the finding rather than a mis-set expectation: the leg is **larger** here than
-the first author's figure, because the ratom arm sits **closer** to the floor
-than predicted while the subs arm sits where this page has always put it.
+**Two of the five were wrong, and they were wrong for the same reason.** Both
+missed on the assumption that the ratom arm would scale with the subs arm — that
+if this page reads `reagent-subs ÷ floor` about 11% above rf2-2rtt6.2's, its
+ratom arm would sit about 11% above rf2-2rtt6.2's too, leaving the leg roughly
+where the first author put it. It did not. **The ratom arm landed on the first
+author's number** (3.2335 against 3.224, a third of a percent apart) while the
+subs arm landed on this page's, and the leg is the quotient of the two, so it
+came out above the band on both rows. That is the shape of the whole result and
+it is set out below.
 
 ### `M1` mount — the leg, per run
 
@@ -645,11 +650,21 @@ second implementation corroborates it.
 **Headline 1's numbers are a different matter.** `≈1.22×` and `≈2.01×` are not
 reproduced: the same witness, the same view components and the same browser, run
 under a second harness, give `1.34×` and `2.50×`. **The leg is not a constant of
-the arm — it is a property of the arm *and its harness*, and the two harnesses
-disagree by 10% on mount and by 24% on a broad commit.** Nothing here says which
-harness is right, and this page does not adjudicate that: a disagreement between
-two internally-clean instruments is the finding, and reconciling it away would
-be inventing an answer neither instrument produced.
+the arm — it is a property of the arm *and its harness*.** Nothing here says
+which harness is right, and this page does not adjudicate that: a disagreement
+between two internally-clean instruments is the finding, and reconciling it
+away would be inventing an answer neither instrument produced.
+
+**Held to one session and one tree, the gap is 8.3% on mount and 16.8% on a
+broad commit.** The control below ran the first author's instrument twice in
+this session, and it read `1.2115` / `1.2550` on `M1` and `2.1410` / `2.1333` on
+`broad` — its own published figures, on the tree the second author measured. So
+the comparison that matters is not against numbers taken on another day:
+
+| row | first author, same session | second author, same session | gap | per-round ranges |
+|---|---|---|---|---|
+| **M1 mount** | 1.2115 · 1.2550 (mean 1.2333) | **1.3353** | **+8.3%** | overlap at the edges — 1.1667 – 1.3175 against 1.2500 – 1.4822 — while the **run means are disjoint** |
+| **bulk broad** | 2.1410 · 2.1333 (mean 2.1372) | **2.4957** | **+16.8%** | overlap at the edges — 2.0000 – 2.2222 against 2.1000 – 2.8750 — while the **run means are disjoint** |
 
 ### Where the disagreement sits
 
@@ -663,21 +678,55 @@ published here for exactly that reason:
 | **broad** | `reagent-subs ÷ floor` | 7.064 [6.200 – 7.700] · 7.280 · 7.330 | **7.6959** [run means 7.4167 – 7.9294] | yes — and this page's own ensemble reads 7.630 |
 | **broad** | `reagent-ratom ÷ floor` | 3.519 [3.200 – 3.900] · 3.707 · 3.540 | **3.0948** [run means 2.9722 – 3.2500] | barely — the second author's ratom arm sits **12% closer to the floor** |
 
-**On `M1` the disagreement is entirely in the numerator.** The two authors'
-ratom arms agree to within a third of a percent (3.2335 against 3.224), and the
-subs arm is where the pages differ — which is not new, and is not this bead's
-finding: [the denominator section](#the-denominator-reproduces-rf2-2rtt62) above
-already published `reagent-subs ÷ floor` as 4.358 here against 3.899 there, with
-overlapping ranges and a higher centre. The leg divides one by the other, so a
-centre 11% higher in the numerator and unchanged in the denominator is a leg 11%
-higher, which is what it reads.
+**The cross-session comparison above is the weaker of the two, and the control
+runs supply the stronger one.** Both authors' instruments ran in the same
+session on the same tree, so their two decompositions can be set beside each
+other with the machine held fixed:
 
-**On `broad` both terms move, and they move apart.** The subs arm reads 9%
-higher and the ratom arm 12% lower, and 1.09 ÷ 0.88 is the 24% the leg is out
-by. The ratom arm's absolute window on this page is 0.70 – 1.20 ms against a
+| row | figure | first author, same session (2 runs) | second author, same session (6 runs) | difference |
+|---|---|---|---|---|
+| **M1** | `reagent-subs ÷ floor` | 3.9287 · 3.9356 | **4.3143** | **+9.7%** |
+| **M1** | `reagent-ratom ÷ floor` | 3.2438 · 3.1411 | **3.2335** | **+1.3% — the two arms agree** |
+| **broad** | `reagent-subs ÷ floor` | 6.5583 · 6.2000 | **7.6959** | **+20.6%** |
+| **broad** | `reagent-ratom ÷ floor` | 3.0667 · 2.9167 | **3.0948** | **+3.4% — the two arms agree** |
+
+**The ratom arm is not where the authors differ. The subs arm is.** Measured in
+one session, the two implementations of `:reagent-ratom` land within 1.3% of
+each other on `M1` and 3.4% on `broad` — well inside either instrument's own
+run-to-run spread. What differs is how expensive the *subscription* arm is
+relative to the floor on each page: 9.7% more here on mount, 20.6% more on a
+broad commit. The leg is the quotient of the two, so it inherits the whole of
+that difference and nothing else.
+
+**And that term was already on this page, in a place where it did not matter.**
+[The denominator section](#the-denominator-reproduces-rf2-2rtt62) publishes
+`reagent-subs ÷ floor` as **4.358 here against rf2-2rtt6.2's 3.899**, with
+overlapping ranges, and calls it a reproduction — correctly, because a range
+that overlaps is what a reproduction looks like. The reactive leg is where a
+higher *centre* on the same term stops being cosmetic: the ranges still
+overlap, but the leg divides by an arm that agrees, so an 8-to-10% offset in
+the numerator's centre becomes an 8-to-17% offset in the leg's, and the leg's
+own spread is tight enough for that to read as disjoint.
+
+**What the mechanism is, this bead does not establish, and it does not guess.**
+The two harnesses differ in several ways that could plausibly price a
+subscription-reading mount differently — the converged page destroys and
+re-installs the adapter and re-creates the frame at every segment entry where
+the first author installs once for the whole run; it runs one row a page
+against three rows chained with settle points; it runs four arms in the
+interleave against four in a different order; and its `M1` page runs 840 mounts
+against 400. **The arm-order guard says none of them shows up as an arm reading
+differently for its position or its predecessor** — `refuse? false` on all
+twelve row-runs here and on both control runs — which is exactly why the
+question needed a second author rather than a tighter tolerance. A guard
+adjudicates an instrument against itself; it cannot adjudicate an instrument
+against another one.
+
+The ratom arm's absolute window on the `broad` row is 0.70 – 1.20 ms against a
 floor of 0.20 – 0.40 — seven to twelve of Chrome's 100 µs quanta against the
 floor's two to four — so it is resolved, but it is the smallest window either
-author measures a leg on.
+author measures a leg on, and it is the row where the two authors' subs arms
+differ most.
 
 Absolute p50 milliseconds in the Reagent segment, per round, so the quotients
 above can be checked rather than taken:
@@ -691,13 +740,24 @@ above can be checked rather than taken:
 | 5 | 0.90/4.00/3.00 · 0.80/3.30/2.40 · 0.70/3.00/2.30 · 0.70/3.10/2.30 · 0.70/3.00/2.25 · 0.70/3.00/2.35 | 0.35/2.50/0.90 · 0.30/2.15/0.90 · 0.30/2.00/0.80 · 0.20/2.05/0.80 · 0.30/2.00/0.75 · 0.20/1.90/0.70 |
 | 6 | 0.90/4.10/3.00 · 0.90/4.00/3.00 · 0.80/3.50/2.75 · 0.90/3.65/2.60 · 0.90/3.55/2.65 · 0.80/3.40/2.60 | 0.30/2.45/0.90 · 0.30/2.30/0.95 · 0.30/2.20/0.90 · 0.30/2.30/0.80 · 0.30/2.15/0.90 · 0.30/2.15/0.90 |
 
-**The whole page is about twice as fast in absolute terms as rf2-2rtt6.2's
-publication run** — `M1` subs 3.00 – 4.55 ms here against 6.00 – 7.35 there, on
-a floor of 0.70 – 1.00 against 1.50 – 1.90. That is a different session on a
-differently-loaded box and it is exactly why every figure on both pages is a
-*ratio*. It also means the two authors' disagreement cannot be read off the
-absolute numbers: only the quotients are comparable, and the quotients are what
-the tables above compare.
+And the same three columns off the first author's instrument, in the same
+session, for the direct comparison:
+
+| control run | `M1` floor / subs / ratom | `broad` floor / subs / ratom |
+|---|---|---|
+| 1 | 0.90/3.90/3.20 · 0.90/3.60/2.90 · 0.90/3.45/2.85 · 0.90/3.50/3.00 · 0.85/3.05/2.50 | 0.30/2.20/1.10 · 0.30/2.00/0.90 · 0.30/2.10/0.95 · 0.40/2.05/1.00 · 0.30/2.00/0.90 |
+| 2 | 1.00/4.15/3.15 · 0.90/3.40/2.75 · 0.80/3.25/2.60 · 0.80/3.15/2.70 · 0.80/3.00/2.30 | 0.30/1.95/0.90 · 0.30/1.90/0.90 · 0.30/1.95/0.90 · 0.40/2.00/0.90 · 0.30/2.00/1.00 |
+
+**The two instruments are measuring the same box, and the numbers say so.** The
+floors match — `M1` 0.80 – 1.00 ms against 0.70 – 1.00, `broad` 0.30 – 0.40
+against 0.20 – 0.40 — and the arms sit in the same absolute band. Both pages
+are about twice as fast in absolute terms as rf2-2rtt6.2's publication run
+(`M1` subs 3.00 – 4.55 ms today against 6.00 – 7.35 then, on a floor of
+0.70 – 1.00 against 1.50 – 1.90), which is a differently-loaded box on a
+different day and exactly why every figure on both pages is a *ratio*. The
+disagreement is therefore not a session artefact and is not visible in the
+absolute numbers at all: it is in what the subs arm costs **relative to its own
+floor**, and only the quotients say it.
 
 ### The control that separates the author from the tree
 
@@ -726,9 +786,25 @@ publishes its own reactive leg on the same two rows.
   stale at HEAD. That would be a larger finding than the one this bead went
   looking for, and it would belong to rf2-2rtt6.2's page rather than to this one.
 
-**The control has not been run at the moment this paragraph is committed.**
-It is written here first so that neither branch of it can be chosen after the
-numbers are in.
+That paragraph was committed in `93062c77d5` **before the control was run**, so
+neither branch of it could be chosen after the numbers were in.
+
+**The control was then run twice, `npm run bench:hicasso`, exit 0 both times,
+guard clean, `0 unverified of 1,220` on each, residue back to
+`{:body-children 2, :sub-entries 0, :sub-ref-count 0, :ratom-watches 0}`:**
+
+| row | first author's instrument, run 1 | run 2 | its published spread | verdict |
+|---|---|---|---|---|
+| **M1 mount** leg | **1.2115** [1.1667 – 1.2414] | **1.2550** [1.1667 – 1.3175] | 1.218 / 1.216 / 1.213 | **reproduces** — both inside the pre-registered 1.21 – 1.27 |
+| **bulk broad** leg | **2.1410** [2.0000 – 2.2222] | **2.1333** [2.0000 – 2.2222] | 2.008 / 1.965 / 2.073 | **reproduces** — both inside the pre-registered 1.96 – 2.17, at the top of it, ranges overlapping the published ones |
+| M2 mount leg *(diagnostic)* | 1.0986 — straddles | 1.0889 — straddles | 1.056, straddles | reproduces, indistinguishable as always |
+
+**The first branch is the one that happened. The tree did not move the leg.**
+`spine.cljs` carries both of today's fixes in this working tree and the first
+author's instrument still reads what it published; the second author's reads
+`1.3353` and `2.4957` **in the same session on the same tree**. The difference
+is the harness, *second author* is the right name for it, and the disagreement
+in the table above stands as measured.
 
 ### Provenance
 
@@ -760,6 +836,7 @@ git rev-parse <candidate>:$P   # must print a5177d3f0bf764917075d2a247af0ddc4684
 |---|---|
 | **Authoring commit** | `bcf80f1979170d4d16d6e7679051de0018d410c5` on `worker/ratom2-2rtt6-21` — *the converged witness gets a reagent-ratom arm*. **A rebase-merge will mint a new landed SHA**; the blobs above are what identify the instrument, and a rebase cannot move a blob. The commit is also where the five predictions are written down, before the first sample existed |
 | **Reproduction** | `HICASSO_RATOM=on HICASSO_ONLY=M1,broad HICASSO_START=reagent node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs` — and the same with `HICASSO_START=uix`. **Six invocations, exit 0 on all six**, launched one at a time, none re-run and none discarded |
+| **The control** | `cd implementation && npm run bench:hicasso` — the first author's instrument, unmodified, on this tree. **Two invocations, exit 0 both**, guard `refuse? false / contaminated? false / unchecked? false`, `0 unverified of 1,220` each, residue back to `{:body-children 2, :sub-entries 0, :sub-ref-count 0, :ratom-watches 0}` after both the parity phase and the bulk row |
 | **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium via Playwright), `:advanced`, `goog.DEBUG false`, Windows 11 x64, sibling agents live on the box |
 | **Build** | `:hicasso-bench`, one build id, cold — `lane_cache.cjs` clears `.shadow-cljs/builds/hicasso-bench` before every invocation. `implementation/shadow-cljs.edn` untouched |
 | **Schedule** | **6 rounds** × 2 segments × (8 warm-up + 12 samples), one row per page, start counterbalanced 3/3. **Four arms in the Reagent segment** — floor, `reagent-subs`, `reagent-ratom`, `ctl-2x` — and three in the UIx segment |
@@ -788,10 +865,18 @@ and for nothing else, the six runs read `M1` 0.9939 – 1.1184 and `broad`
   hand-built Reagent reaction — is what would close that. It is not closed here
   and is not claimed to be.
 - **The two harnesses disagree and neither is adjudicated the winner.** What is
-  established is that the magnitude moves by 10% – 24% between two internally
-  clean instruments measuring the same witness with the same components. Which
-  number a standard should carry is the operator's, and rf2-2rtt6.1 is
-  size-locked; nothing here amends it.
+  established is that the magnitude moves by 8.3% on mount and 16.8% on a broad
+  commit between two internally clean instruments measuring the same witness
+  with the same components, in the same session on the same tree. Which number
+  a standard should carry is the operator's, and rf2-2rtt6.1 is size-locked;
+  nothing here amends it.
+- **The mechanism is not established.** The difference is localised — the ratom
+  arms agree, the subs arms do not — and this page names the candidates without
+  choosing between them: per-round adapter and frame teardown against one
+  install for the run, one row a page against three chained rows, a four-arm
+  interleave, and 840 mounts a page against 400. Isolating it means changing one
+  of those at a time on one of the two harnesses, which is a bead of its own and
+  is not attempted here.
 - **Six runs, one machine, one session.** The same limit the ten-run ensemble
   carries. Between-session spread is unmeasured and is the wider of the two.
 

--- a/docs/design/hicasso/studio/p0-reagent-on-subs-baseline.md
+++ b/docs/design/hicasso/studio/p0-reagent-on-subs-baseline.md
@@ -381,23 +381,45 @@ three quanta. Nothing here installs the strict rule.
 ## What this settles, and what it does not
 
 **Settles.** The bar's denominator exists and is a browser number. Reading
-re-frame2 subscriptions rather than a bare cursor costs Reagent **≈1.22× on
-mount** of the 300-boundary shape and **≈2.01× on a broad commit** — both
-disjoint from 1.0, so both real. That figure was previously argued rather than
-measured, and it is the term that made the predecessor's `13.5×` broad-update row
-an upper bound of unknown content. **It has now been measured three times** — the
+re-frame2 subscriptions rather than a bare cursor costs Reagent **something real
+on mount** of the 300-boundary shape and **something real on a broad commit** —
+disjoint from 1.0 on both, on every run of two independent instruments. That
+cost was previously argued rather than measured, and it is the term that made
+the predecessor's `13.5×` broad-update row an upper bound of unknown content.
+**On this instrument it is ≈1.22× and ≈2.01×, measured three times** — the
 publication run and two independent re-runs at main — and all three agree; see
-[the re-certification](#the-re-certification).
+[the re-certification](#the-re-certification). **A second instrument does not
+reproduce those magnitudes**, and the two figures are therefore stated as this
+page's rather than as the substrate's; see *Does not settle* below.
 
-**Does not settle — one arm, three runs.** Repetition is not replication. The
-reactive leg still comes from *one implementation of one arm*: three runs of it
-bound the instrument's run-to-run noise, and they do not bound a systematic
-error in how `:reagent-ratom` is written. The converged witness set is a genuine
-second implementation of the **denominator** and its `reagent-subs ÷ floor`
-ranges overlap this page's on all three shared rows, but it carries **no
-`reagent-ratom` arm**, so nothing yet corroborates the reactive leg from a
-second author. A second witness for that term remains worth having, and this
-page does not claim otherwise.
+**Does not settle — the leg's DIRECTION is corroborated and its MAGNITUDE is
+contradicted (rf2-2rtt6.21).** Repetition is not replication, and the three runs
+above are three runs of *one implementation of one arm*: they bound this
+instrument's run-to-run noise and cannot bound a systematic error in how
+`:reagent-ratom` is written. The converged witness set has since taken the arm —
+[the reactive leg, from a second
+author](p0-converged-witness-set.md#the-reactive-leg-from-a-second-author-rf2-2rtt621)
+— and the answer is split:
+
+- **The claim reproduces.** Six independent six-round runs put 72 of 72 rounds
+  above 1.0 on both rows, every order stratum above it, intervals nowhere near
+  it. Reading subscriptions rather than a bare cursor costs Reagent something
+  real on mount *and* on a broad commit, and that no longer rests on one arm.
+- **The numbers do not.** The second author reads **1.3353×** on M1 and
+  **2.4957×** on broad where this page reads ≈1.22× and ≈2.01×. That is not a
+  stale-tree artefact: this instrument was re-run twice on the same tree in the
+  same session as those six runs and read **1.2115 / 1.2550** and **2.1410 /
+  2.1333**, its own published figures. The gap is **8.3% on mount and 16.8% on a
+  broad commit**, and it is the harness rather than the arm — the two authors'
+  `reagent-ratom ÷ floor` readings agree to 1.3% and 3.4%, while their
+  `reagent-subs ÷ floor` readings differ by 9.7% and 20.6%.
+
+**So `≈1.22×` and `≈2.01×` are this instrument's figures rather than the
+substrate's**, and a second instrument measuring the same witness with the same
+view components does not reproduce them. Both are internally clean — guard,
+parity, controls and read-back — and neither is adjudicated the winner here.
+What a reader may take from this page is the direction and the fact of a cost;
+the magnitude carries a harness with it.
 
 **Does not settle.** Nothing about a candidate: no Hicasso arm exists, and none is
 quotable against this table until it does. Nothing about UIx (rf2-2rtt6.4 owns the

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
@@ -57,6 +57,35 @@
   | `bulk-broad` | the M1 page, one commit ALL 300 boundaries read | the bar row |
   | `bulk-narrow` | the M1 page, `narrow-batch-k` batched commits, each of which exactly ONE boundary reads, all in one timed window | the converged counterpart of rf2-2rtt6.4's `U-narrow` — the localisation row, and the one row where that arm found UIx materially behind. It has NO counterpart in rf2-2rtt6.2, so it is a NEW row on rf2-2rtt6.2's witness, labelled as such rather than presented as a re-measurement of something |
 
+  ## `?ratom=on` — the reactive leg's SECOND AUTHOR (rf2-2rtt6.21)
+
+  rf2-2rtt6.2's headline 1 is that reading re-frame2 subscriptions rather
+  than a bare cursor costs Reagent ~1.22x on mount and ~2.01x on a broad
+  commit. rf2-2rtt6.17 measured it THREE TIMES — and all three are re-runs
+  of the SAME `:reagent-ratom` arm, which bounds the instrument's
+  run-to-run noise and cannot bound a systematic error in how that arm is
+  written. That is repetition, not replication.
+
+  This page was already a genuine second implementation of the
+  DENOMINATOR — a different app namespace, a different schedule, and
+  `reagent-subs / floor` ranges overlapping rf2-2rtt6.2's on all three
+  shared rows — and it carried no `:reagent-ratom` arm at all, so it could
+  not touch the leg. `?ratom=on` puts that arm in the REAGENT SEGMENT of
+  the two rows the headline names, beside this page's own `:reagent-subs`
+  arm, in the same round of the same run. The leg is then formed a second
+  way, by a second author, on a second page.
+
+  | | |
+  |---|---|
+  | rows | `M1` and `broad`. `M2`'s leg is quantum-limited on the first author's own page (all five rounds read exactly 1.0000 on one run — the quantum wearing a tie's clothes) and `M2` is the one row whose mount budget already refuses; `narrow` has no first-author counterpart to corroborate |
+  | segment | the REAGENT segment only. The leg's two terms are both Reagent arms, so it is formed INSIDE one segment and the seam never enters it; putting a Reagent arm in the UIx segment would buy the leg nothing and would put Reagent's reaction machinery on the page whose whole point is UIx's |
+  | default | OFF. With the arm in the plan the Reagent segment runs FOUR arms against the UIx segment's three, so the page's mount budget and the interleave both differ from the schedule rf2-6i0i2's ten-run ensemble was measured under. Default-off keeps this instrument's published four rows reproducible at their own schedule; `?ratom=on` is a DIFFERENT plan and says so on every record it produces |
+
+  A run with the arm on still publishes its cross-segment red-zone,
+  because it is computed from the same slices and hiding it would be worse
+  than qualifying it — but the record carries `:ratom-arm? true` and a
+  comparability note, and that figure may NOT be quoted as a threshold.
+
   ## Three arms a segment, and why not two
 
   rf2-ouwh8: `lane/slot-order` rotated and then REFLECTED, and at k=2 those
@@ -242,6 +271,19 @@
   (let [s (or (some-> js/window .-location .-search) "")]
     (if (re-find #"start=uix" s) :uix-subs :reagent-subs)))
 
+(defn- query-ratom
+  "Is the second author's `:reagent-ratom` arm in the plan — `?ratom=on`?
+
+  Default OFF, and the default is the point: with the arm in it the
+  Reagent segment runs four arms against the UIx segment's three, which is
+  a different page, a different interleave and a different mount budget
+  from the one rf2-6i0i2's ensemble measured. An unflagged run of this
+  entry is therefore still the instrument those four rows were taken on;
+  a flagged run is a different plan and every record it writes says so."
+  []
+  (let [s (or (some-> js/window .-location .-search) "")]
+    (boolean (re-find #"ratom=on" s))))
+
 (defn- segment-order
   "Two segments admit exactly two orders and every round runs both
   segments; `start` names which one goes FIRST in round 0, and the order
@@ -386,17 +428,27 @@
                              (double (v/m1-elements v/cells-n)))
                :basis     (str "element count: " (v/m1-elements (* 2 v/cells-n)) " / "
                                (v/m1-elements v/cells-n))}
-    :arms-for (fn [segment-id]
-                [(floor-mount-arm :floor v/m1-floor (fn [{:keys [n]}] (zeros n)))
-                 (case segment-id
-                   :reagent-subs (reagent-mount-arm
-                                   :reagent-subs
-                                   (fn [{:keys [n]}] [v/subs-root v/m1-subs n]))
-                   :uix-subs     (uix-mount-arm
-                                   :uix-subs
-                                   (fn [{:keys [n]}] (ux/subs-root ux/m1 n))))
-                 (floor-mount-arm :ctl-2x v/m1-floor
-                                  (fn [{:keys [n]}] (zeros (* 2 n))) 2)])}
+    ;; The `:reagent-ratom` arm sits between the denominator and the
+    ;; control, which is rf2-2rtt6.2's own order — the plan is that arm's
+    ;; plan with the UIx segment's arm swapped in on the other side of the
+    ;; seam, so a reader comparing the two legs is comparing two authors
+    ;; and not two orderings.
+    :arms-for (fn [segment-id ratom?]
+                (-> [(floor-mount-arm :floor v/m1-floor (fn [{:keys [n]}] (zeros n)))]
+                    (into (case segment-id
+                            :reagent-subs
+                            (cond-> [(reagent-mount-arm
+                                       :reagent-subs
+                                       (fn [{:keys [n]}] [v/subs-root v/m1-subs n]))]
+                              ratom? (conj (reagent-mount-arm
+                                             :reagent-ratom
+                                             (fn [{:keys [n]}] [v/m1-ratom n]))))
+                            :uix-subs
+                            [(uix-mount-arm
+                               :uix-subs
+                               (fn [{:keys [n]}] (ux/subs-root ux/m1 n)))]))
+                    (conj (floor-mount-arm :ctl-2x v/m1-floor
+                                           (fn [{:keys [n]}] (zeros (* 2 n))) 2))))}
 
    {:id          :M2
     :grade       :diagnostic
@@ -453,7 +505,17 @@
                              (double (v/m2-elements v/fields-n)))
                :basis     (str "element count: " (v/m2-elements (* 2 v/fields-n)) " / "
                                (v/m2-elements v/fields-n))}
-    :arms-for (fn [segment-id]
+    ;; `ratom?` is IGNORED here, and it is ignored for two reasons rather
+    ;; than for want of a `conj` (rf2-2rtt6.21). This is the one row whose
+    ;; mount budget already refuses — 720 mounts refused four of six, and
+    ;; a fourth arm would put a six-round M2 page at 588 even off the
+    ;; reduced sampling below. And the leg it would measure is one the
+    ;; first author's own instrument cannot resolve: on the corrected-run
+    ;; sweep `M2`'s reactive leg read exactly 1.0000 in ALL FIVE rounds,
+    ;; because its two Reagent arms returned the same p50 every time on a
+    ;; witness whose window is three to six of Chrome's 100 us quanta.
+    ;; A second author cannot corroborate a number that is the clamp.
+    :arms-for (fn [segment-id _ratom?]
                 [(floor-mount-arm :floor v/m2-floor (fn [{:keys [n]}] (zeros n)))
                  (case segment-id
                    :reagent-subs (reagent-mount-arm
@@ -558,12 +620,53 @@
     ;; window in this lane is taken outside it.
     (fn [] (react-dom/flushSync (fn [] nil)))))
 
-(defn- bulk-arms [segment-id]
-  [(floor-bulk-arm :floor v/cells-n)
-   (case segment-id
-     :reagent-subs (reagent-bulk-arm)
-     :uix-subs     (uix-bulk-arm))
-   (floor-bulk-arm :ctl-2x (* 2 v/cells-n) 2)])
+(defn- ratom-bulk-arm
+  "The second author's lower bound on the bulk rows (rf2-2rtt6.21): the
+  same 300-cell page, read through an `r/cursor` over a bare
+  `reagent.core/atom` instead of through a subscription.
+
+  It is NOT built by [[subs-bulk-arm]], and the difference is the whole
+  point of the arm: the write installs into `v/ratom-cells` rather than
+  into the frame's app-db, so this arm pays no subscription graph, no
+  query cache and no frame. Everything else is held identical to the
+  `:reagent-subs` arm beside it — the same mount door
+  (`reagent.dom.client`), the same drain (`reagent.core/flush` inside one
+  `flushSync`), the same page, the same window. `subs / ratom` is then
+  the price of the reactive system and nothing else, which is the term
+  rf2-2rtt6.2's headline 1 turns on.
+
+  The write handles a single cell as well as `:all` because the arm is
+  written to the same contract as its sibling; only the `:broad` row puts
+  it in a plan."
+  []
+  {:id      :reagent-ratom
+   :cells   v/cells-n
+   :mount   (fn [container]
+              (let [root (rdc/create-root container)]
+                (react-dom/flushSync
+                  (fn [] (rdc/render root [v/m1-ratom v/cells-n])))
+                root))
+   :write!  (fn [i val]
+              (if (= i :all)
+                (reset! v/ratom-cells (vec (repeat v/cells-n val)))
+                (swap! v/ratom-cells assoc i val)))
+   :force!  (fn [] (react-dom/flushSync (fn [] (r/flush))))
+   :unmount (fn [root] (react-dom/flushSync (fn [] (rdc/unmount root))))})
+
+(defn- bulk-arms
+  "`:broad` is the bulk row rf2-2rtt6.2 published a reactive leg on, so it
+  is the bulk row the second author's arm joins. `:narrow` has no
+  first-author counterpart at all — rf2-2rtt6.2 has no narrow row — so a
+  ratom arm there would be a new figure rather than a corroboration, and
+  this entry does not mint one while it is answering a different question."
+  [segment-id row-key ratom?]
+  (-> [(floor-bulk-arm :floor v/cells-n)]
+      (into (case segment-id
+              :reagent-subs (cond-> [(reagent-bulk-arm)]
+                              (and ratom? (= row-key :broad))
+                              (conj (ratom-bulk-arm)))
+              :uix-subs     [(uix-bulk-arm)]))
+      (conj (floor-bulk-arm :ctl-2x (* 2 v/cells-n) 2))))
 
 (defn- mount-bulk-arms!
   "Mount every bulk arm once and CHECK THE PAGE IT BUILT, before a clock is
@@ -618,9 +721,9 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- mount-round!
-  [coll t {:keys [id props per-sample arms-for sampling] :as witness} segment-id]
+  [coll t {:keys [id props per-sample arms-for sampling] :as witness} segment-id ratom?]
   (let [{:keys [warmup samples]} (or sampling mount-sampling)
-        arms   (arms-for segment-id)
+        arms   (arms-for segment-id ratom?)
         n      (count arms)
         k      (or per-sample 1)
         expect (into {} (map (juxt :id #(expectation witness %))) arms)
@@ -849,58 +952,78 @@
   rounds the same arithmetic gives 2 of `C(6,3) = 20` — 10%. That is
   why disjointness withdraws the magnitude rather than condemning the
   measurement: it is a statement about what this design can resolve, not a
-  finding that the schedule moved the number."
-  [vs rounds start]
-  (let [lead-even  (if (= start :uix-subs) :uix-first :reagent-first)
-        lead-odd   (if (= lead-even :uix-first) :reagent-first :uix-first)
-        strata     {lead-even (vec (keep-indexed #(when (even? %1) %2) vs))
-                    lead-odd  (vec (keep-indexed #(when (odd? %1) %2) vs))}
-        rf         (range-of (:reagent-first strata))
-        uf         (range-of (:uix-first strata))
-        overlap?   (and (<= (:min rf) (:max uf)) (<= (:min uf) (:max rf)))
-        d-rf       (direction-of rf)
-        d-uf       (direction-of uf)
-        opposed?   (or (and (= d-rf :numerator-slower) (= d-uf :numerator-faster))
-                       (and (= d-rf :numerator-faster) (= d-uf :numerator-slower)))
-        balanced?  (even? rounds)]
-    {:start               start
-     :reagent-first       (assoc rf :direction d-rf :n (count (:reagent-first strata)))
-     :uix-first           (assoc uf :direction d-uf :n (count (:uix-first strata)))
-     :order-balanced-mean (lane/round4 (/ (+ (:mean rf) (:mean uf)) 2.0))
-     :balanced-design?    balanced?
-     :strata-overlap?     overlap?
-     :magnitude-resolved? overlap?
-     :direction-agrees?   (not opposed?)
-     :refuse?             opposed?
-     :why
-     (str "the red-zone's rounds partitioned by which segment ran FIRST "
-          "(round 0 led by " (name start) ", alternating). "
-          "Reagent-first " (.toFixed (:mean rf) 4) "x [" (.toFixed (:min rf) 4) "–"
-          (.toFixed (:max rf) 4) "] over " (count (:reagent-first strata)) " rounds; "
-          "UIx-first " (.toFixed (:mean uf) 4) "x [" (.toFixed (:min uf) 4) "–"
-          (.toFixed (:max uf) 4) "] over " (count (:uix-first strata)) " rounds. "
-          (if opposed?
-            (str "THE TWO STRATA POINT OPPOSITE WAYS, so this row has no direction to "
-                 "publish and no figure in it is reportable.")
-            (if overlap?
-              (str "The strata OVERLAP, so the magnitude survives the partition and the "
-                   "row may publish one.")
-              (str "The strata are DISJOINT, so part of this figure is WHICH SEGMENT "
-                   "RAN FIRST and the mean over them is not a threshold. The row "
-                   "publishes its DIRECTION and the stratum bounds; it may NOT publish a "
-                   "precise magnitude. At " rounds " rounds the split is "
-                   (count (:reagent-first strata)) ":" (count (:uix-first strata))
-                   " and a disjoint partition arises by chance alone in 2 of "
-                   "C(" rounds "," (count (:uix-first strata)) ") assignments, so this "
-                   "withdraws a claim rather than establishing an effect."))))}))
+  finding that the schedule moved the number.
+
+  ## `what`, and the figure that does not cross the seam
+
+  The four-argument arity names the figure under adjudication in `:why`,
+  and it exists because the red-zone is no longer the only thing this
+  verdict judges. rf2-2rtt6.21's REACTIVE LEG — `reagent-subs` over
+  `reagent-ratom` — is formed INSIDE the Reagent segment, so the seam
+  never enters it. The partition is still the right question: the Reagent
+  segment leads half the rounds and follows the other half, and a leg that
+  reads differently for which is a leg that has measured the schedule.
+  What changes is only the name in the sentence, and a verdict that
+  described a within-segment ratio as `the red-zone's` would be a small
+  lie in the one place a reader goes to check the arithmetic."
+  ([vs rounds start] (segment-order-verdict vs rounds start "the red-zone's"))
+  ([vs rounds start what]
+    (let [lead-even  (if (= start :uix-subs) :uix-first :reagent-first)
+          lead-odd   (if (= lead-even :uix-first) :reagent-first :uix-first)
+          strata     {lead-even (vec (keep-indexed #(when (even? %1) %2) vs))
+                      lead-odd  (vec (keep-indexed #(when (odd? %1) %2) vs))}
+          rf         (range-of (:reagent-first strata))
+          uf         (range-of (:uix-first strata))
+          overlap?   (and (<= (:min rf) (:max uf)) (<= (:min uf) (:max rf)))
+          d-rf       (direction-of rf)
+          d-uf       (direction-of uf)
+          opposed?   (or (and (= d-rf :numerator-slower) (= d-uf :numerator-faster))
+                         (and (= d-rf :numerator-faster) (= d-uf :numerator-slower)))
+          balanced?  (even? rounds)]
+      {:start               start
+       :reagent-first       (assoc rf :direction d-rf :n (count (:reagent-first strata)))
+       :uix-first           (assoc uf :direction d-uf :n (count (:uix-first strata)))
+       :order-balanced-mean (lane/round4 (/ (+ (:mean rf) (:mean uf)) 2.0))
+       :balanced-design?    balanced?
+       :strata-overlap?     overlap?
+       :magnitude-resolved? overlap?
+       :direction-agrees?   (not opposed?)
+       :refuse?             opposed?
+       :why
+       (str what " rounds partitioned by which segment ran FIRST "
+            "(round 0 led by " (name start) ", alternating). "
+            "Reagent-first " (.toFixed (:mean rf) 4) "x [" (.toFixed (:min rf) 4) "–"
+            (.toFixed (:max rf) 4) "] over " (count (:reagent-first strata)) " rounds; "
+            "UIx-first " (.toFixed (:mean uf) 4) "x [" (.toFixed (:min uf) 4) "–"
+            (.toFixed (:max uf) 4) "] over " (count (:uix-first strata)) " rounds. "
+            (if opposed?
+              (str "THE TWO STRATA POINT OPPOSITE WAYS, so this row has no direction to "
+                   "publish and no figure in it is reportable.")
+              (if overlap?
+                (str "The strata OVERLAP, so the magnitude survives the partition and the "
+                     "row may publish one.")
+                (str "The strata are DISJOINT, so part of this figure is WHICH SEGMENT "
+                     "RAN FIRST and the mean over them is not a threshold. The row "
+                     "publishes its DIRECTION and the stratum bounds; it may NOT publish a "
+                     "precise magnitude. At " rounds " rounds the split is "
+                     (count (:reagent-first strata)) ":" (count (:uix-first strata))
+                     " and a disjoint partition arises by chance alone in 2 of "
+                     "C(" rounds "," (count (:uix-first strata)) ") assignments, so this "
+                     "withdraws a claim rather than establishing an effect."))))})))
 
 (defn- row-record
   "Turn one row's per-round, per-segment slices into the published record.
 
   `slices` is `[{segment-id {arm-id [ms ...]}} ...]`, one entry per round.
   `start` is the segment that led round 0, and it is published on the
-  record because a reader comparing counterbalanced runs needs it."
-  [{:keys [row doc grade clock-note control note writes-per-sample start]} slices]
+  record because a reader comparing counterbalanced runs needs it.
+
+  `ratom?` says whether the second author's `:reagent-ratom` arm was in
+  this row's plan. When it was, the record carries a REACTIVE LEG — and
+  it also carries the fact that the red-zone beside it came off a
+  four-arm Reagent segment, because a threshold and the plan it was
+  measured under are one fact and not two (rf2-2rtt6.21)."
+  [{:keys [row doc grade clock-note control note writes-per-sample start ratom?]} slices]
   (let [norm       (mapv (fn [by-seg]
                            (into {} (map (fn [[sid rd]] [sid (ratios-of rd)])) by-seg))
                          slices)
@@ -909,6 +1032,20 @@
                          norm)
         rg-floor   (mapv #(get-in % [:reagent-subs :ratio :reagent-subs]) norm)
         ux-floor   (mapv #(get-in % [:uix-subs :ratio :uix-subs]) norm)
+        ;; BOTH TERMS ARE THE REAGENT SEGMENT'S OWN, so the floor divides
+        ;; out exactly and the seam is not in the arithmetic at all. It is
+        ;; formed from the floor-normalised ratios rather than from the
+        ;; raw p50s only because that is the arithmetic `lane/ratio-between`
+        ;; performs on the first author's page, and two authors disagreeing
+        ;; about a division is not a finding anybody wants to chase.
+        leg        (when ratom?
+                     (mapv (fn [m] (/ (get-in m [:reagent-subs :ratio :reagent-subs])
+                                      (get-in m [:reagent-subs :ratio :reagent-ratom])))
+                           norm))
+        ratom-floor (when ratom?
+                      (mapv #(get-in % [:reagent-subs :ratio :reagent-ratom]) norm))
+        leg-order  (when ratom?
+                     (segment-order-verdict leg rounds start "the reactive leg's"))
         seam       (mapv (fn [m] (/ (get-in m [:uix-subs :p50 :floor])
                                     (get-in m [:reagent-subs :p50 :floor])))
                          norm)
@@ -947,8 +1084,44 @@
                           :claim (if (:magnitude-resolved? order)
                                    :magnitude
                                    :direction-only)
-                          :direction (direction-of (range-of rz)))
+                          :direction (direction-of (range-of rz))
+                          :ratom-arm? (boolean ratom?)
+                          :comparability
+                          (when ratom?
+                            (str "NOT the published threshold and not comparable with "
+                                 "it. With :reagent-ratom in the plan the Reagent "
+                                 "segment ran FOUR arms against the UIx segment's "
+                                 "three, so the interleave, the page's total mount "
+                                 "budget and the adjacency structure all differ from "
+                                 "the schedule rf2-6i0i2's ten-run ensemble was "
+                                 "measured under. It is reported because it comes off "
+                                 "the same slices and hiding it would be worse than "
+                                 "qualifying it; it may not be quoted as a red-zone.")))
       :segment-order-control order
+      :ratom-arm?  (boolean ratom?)
+      ;; THE ROW THIS RUN EXISTS FOR when the arm is in the plan. Both
+      ;; terms are Reagent arms measured in the same segment of the same
+      ;; round, which is what makes it a second AUTHOR'S reading of
+      ;; rf2-2rtt6.2's headline 1 rather than a fourth run of the first's.
+      :reactive-leg
+      (when ratom?
+        (assoc (range-of leg)
+               :numerator :reagent-subs
+               :denominator :reagent-ratom
+               :axis :clock
+               :claim (if (:magnitude-resolved? leg-order) :magnitude :direction-only)
+               :direction (direction-of (range-of leg))
+               :why (str "Reagent reading re-frame2 subscriptions over Reagent "
+                         "reading an r/cursor on a bare r/atom, both floor-"
+                         "normalised in the SAME segment of the SAME round, so the "
+                         "floor divides out and the segment seam is not in the "
+                         "arithmetic. This is a SECOND IMPLEMENTATION of the term "
+                         "rf2-2rtt6.2 published as ~1.22x on mount and ~2.01x on a "
+                         "broad commit — a different app namespace, a different "
+                         "schedule, a different round count and a different arm "
+                         "plan (rf2-2rtt6.21).")))
+      :reactive-leg-segment-order leg-order
+      :ratom-over-floor   (when ratom? (range-of ratom-floor))
       :uix-over-floor     (range-of ux-floor)
       :reagent-over-floor (range-of rg-floor)
       :segment-seam-control
@@ -967,8 +1140,9 @@
       :per-round   {:reagent (mapv #(get-in % [:reagent-subs :p50]) norm)
                     :uix     (mapv #(get-in % [:uix-subs :p50]) norm)}
       :status      :evidence}
-     :controls [c-rg c-ux]
-     :order     order}))
+     :controls  [c-rg c-ux]
+     :order     order
+     :leg-order leg-order}))
 
 ;; ---------------------------------------------------------------------------
 ;; Parity — before any clock is read, in EVERY segment and ACROSS the seam
@@ -984,9 +1158,9 @@
   the EQUALITY is not exempt from arithmetic: the control is exempt
   because its page differs, and the size it differs BY is the claim it
   exists to make."
-  [{:keys [id props arms-for] :as witness} segment-id]
+  [{:keys [id props arms-for] :as witness} segment-id ratom?]
   (let [{:keys [mounts agree? disagree reference]}
-        (lane/parity (arms-for segment-id) props)
+        (lane/parity (arms-for segment-id ratom?) props)
         wrong (into {}
                     (comp (map (fn [{:keys [arm container]}]
                                  [(:id arm)
@@ -1015,10 +1189,10 @@
   each other — which is the comparison the red-zone actually makes, and it
   is checked directly rather than inferred from each segment agreeing with
   its own floor."
-  [witness]
+  [witness ratom?]
   (let [by-seg (reduce (fn [acc {:keys [id] :as segment}]
                          (enter-segment! segment)
-                         (assoc acc id (parity-of-segment! witness id)))
+                         (assoc acc id (parity-of-segment! witness id ratom?)))
                        {}
                        segments)
         cross  (when (not= (get-in by-seg [:reagent-subs :reference])
@@ -1067,6 +1241,16 @@
   "And the three-arm plan this entry actually runs must NOT degenerate."
   []
   (> (count (distinct (map #(guard/slot-order 3 %) (range 8)))) 1))
+
+(defn- slot-order-varies-at-4?
+  "Nor the FOUR-arm plan the Reagent segment runs under `?ratom=on`.
+
+  Asserted whether or not the flag is set, for the reason the `k = 2`
+  canary is: the property belongs to the shared rule, and an assertion
+  that only fires on the days it is needed is an assertion nobody
+  maintains. That is precisely how the `k = 2` one rotted."
+  []
+  (> (count (distinct (map #(guard/slot-order 4 %) (range 8)))) 1))
 
 ;; ---------------------------------------------------------------------------
 ;; The run
@@ -1117,7 +1301,7 @@
   "One round of THIS PAGE'S row: both segments, in this round's order —
   `start` leads round 0 and the order alternates from there. Answers a
   promise of `{segment-id readings}`."
-  [{:keys [kind witness] :as _spec} row-key start r coll t legs]
+  [{:keys [kind witness] :as _spec} row-key start ratom? r coll t legs]
   (lane/chain
     {}
     (segment-order start r)
@@ -1129,10 +1313,10 @@
       (assert-teardown-clean! (str "entering segment " (name id)))
       (if (= kind :mount)
         (js/Promise.resolve
-          (let [rd (mount-round! coll t (witness-named witness) id)]
+          (let [rd (mount-round! coll t (witness-named witness) id ratom?)]
             (assert-teardown-clean! (str "mount round, segment " (name id)))
             (assoc acc id rd)))
-        (let [mounts (mount-bulk-arms! (bulk-arms id))]
+        (let [mounts (mount-bulk-arms! (bulk-arms id row-key ratom?))]
           (-> (seed-bulk! mounts t)
               (.then (fn [_] (bulk-round! mounts t legs coll row-key id)))
               (.then (fn [rd]
@@ -1150,9 +1334,10 @@
         legs))
 
 (defn- publish!
-  [{:keys [kind witness row grade doc note control] :as _spec} row-key start slices t legs coll]
+  [{:keys [kind witness row grade doc note control] :as _spec} row-key start ratom?
+   slices t legs coll]
   (let [w   (witness-named witness)
-        {:keys [record controls order]}
+        {:keys [record controls order leg-order]}
         (row-record {:row row
                      :grade grade
                      :doc (or doc (:doc w))
@@ -1160,7 +1345,8 @@
                      :note note
                      :control (or control (:control w))
                      :writes-per-sample (if (= row :bulk-narrow) narrow-batch-k 1)
-                     :start start}
+                     :start start
+                     :ratom? ratom?}
                     slices)]
     (lane/record! (name row) record)
     (lane/record! "verification" {row-key (lane/tally-value t)})
@@ -1191,6 +1377,37 @@
                               "SUPERSEDES the clock threshold rf2-2rtt6.4 published on its "
                               "own witnesses — that figure remains sound as a ratio and is "
                               "simply not comparable with the bar rows.")})
+    (when-let [leg (:reactive-leg record)]
+      (lane/record! "reactive-leg"
+                    {:row row
+                     :axis :clock
+                     :witness-set "rf2-2rtt6.2"
+                     :rounds rounds
+                     :start-segment start
+                     :second-author-of "rf2-2rtt6.2 headline 1 — the price of the reactive system"
+                     :leg (select-keys leg [:mean :min :max :per-round :straddles-1?
+                                            :claim :direction :numerator :denominator])
+                     :reagent-over-floor (:reagent-over-floor record)
+                     :ratom-over-floor   (:ratom-over-floor record)
+                     :segment-order-control leg-order
+                     :publishable
+                     (if (:magnitude-resolved? leg-order)
+                       (str "a MAGNITUDE. The two segment-order strata overlap, so the "
+                            "mean survives the partition.")
+                       (str "a DIRECTION ONLY. The two segment-order strata are DISJOINT, "
+                            "so part of this figure is whether the Reagent segment led "
+                            "its round, and the mean over them is not a magnitude. Quote "
+                            "the direction and the stratum bounds; the order-balanced "
+                            "mean is " (:order-balanced-mean leg-order) "x."))
+                     :first-author
+                     (str "rf2-2rtt6.2 / rf2-2rtt6.17 published this leg three times off ONE "
+                          "implementation of the arm: M1 mount 1.218 [1.122-1.310] / 1.216 "
+                          "[1.185-1.241] / 1.213 [1.093-1.273], bulk broad 2.008 "
+                          "[1.938-2.100] / 1.965 [1.875-2.000] / 2.073 [2.000-2.167]. Three "
+                          "runs of one arm bound the instrument's noise and cannot bound a "
+                          "systematic error in how the arm is written; this row is the "
+                          "second implementation, and agreement or disagreement with those "
+                          "figures is the finding either way.")}))
     (let [vd (lane/guard! (:samples @coll)
                           (str "Hicasso P0 converged — " (name row)))]
       (lane/record! "arm-order-guard"
@@ -1207,6 +1424,13 @@
     ;; fatal for the same reason a failed positive control is: the row's
     ;; only surviving claim would be a measurement of the schedule.
     (when (:refuse? order)
+      (set! (.-HICASSO_ORDER_REFUSED js/window) true))
+    ;; And the reactive leg is held to exactly the same rule. It does not
+    ;; cross the seam, but the Reagent segment still LEADS half the rounds
+    ;; and follows the other half — a leg whose two strata point opposite
+    ;; ways across 1.0 has measured the schedule, and a lower bound that
+    ;; depends on when it was measured is not a lower bound.
+    (when (:refuse? leg-order)
       (set! (.-HICASSO_ORDER_REFUSED js/window) true))
     ;; LAST, so every record above is on the console first. The count was
     ;; published and never adjudicated: this row could read `N unverified of
@@ -1242,14 +1466,33 @@
                            "claim it cannot support"))
           (lane/done!))
 
+      (not (slot-order-varies-at-4?))
+      (do (lane/fail! (str "slot-order emits ONE order at k=4, so the four-arm Reagent "
+                           "segment `?ratom=on` runs would be a single-order plan and the "
+                           "reactive leg could not claim `both orders` either"))
+          (lane/done!))
+
       :else
       (let [row-key (query-row)
             start   (query-start)
+            ratom?  (query-ratom)
             spec    (get row-specs row-key)
             w       (witness-named (:witness spec))
-            {:keys [problems]} (parity! w)]
+            ;; ONCE, at boot, and NOT at every segment entry. The mount
+            ;; arms never write `ratom-cells` and the bulk arms re-seed
+            ;; through their own `write!`, so a per-segment reset would buy
+            ;; nothing and would cost something real: Reagent's disposals
+            ;; sit on a macrotask queue, so a write at the seam can land on
+            ;; reactions whose roots have unmounted but not yet been
+            ;; disposed, and every one of them would re-render. Outside the
+            ;; window, but it is work the page does not need to do.
+            _       (reset! v/ratom-cells (:cells (v/seed-cells v/cells-n 0)))
+            {:keys [problems]} (parity! w ratom?)]
         (js/console.log (str ";; HICASSO row " (name row-key)
-                             " — round 0 led by " (name start) ", alternating"))
+                             " — round 0 led by " (name start) ", alternating"
+                             (when ratom?
+                               (str "; the second author's :reagent-ratom arm is IN the "
+                                    "Reagent segment (rf2-2rtt6.21)"))))
         (lane/record! "parity"
                       {:row row-key :problems problems :ok? (empty? problems)
                        :note (str "canonical DOM with attribute names sorted, inside each "
@@ -1268,10 +1511,10 @@
                 legs (atom {})]
             (-> (lane/chain [] (range rounds)
                             (fn [acc r]
-                              (-> (run-round! spec row-key start r coll t legs)
+                              (-> (run-round! spec row-key start ratom? r coll t legs)
                                   (.then (fn [slice] (conj acc slice))))))
                 (.then (fn [slices]
-                         (publish! spec row-key start slices t legs coll)
+                         (publish! spec row-key start ratom? slices t legs coll)
                          (lane/done!)
                          nil))
                 (.catch (fn [e]

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs
@@ -230,3 +230,85 @@
       (is (= :numerator-faster (:direction (:reagent-first u))))
       (is (true? (:refuse? r)))
       (is (true? (:refuse? u))))))
+
+;; ---------------------------------------------------------------------------
+;; The reactive leg, replayed (rf2-2rtt6.21)
+;; ---------------------------------------------------------------------------
+
+(def ^:private leg
+  "The PUBLISHED per-round `reagent-subs / reagent-ratom` vectors from the
+  studio page's `The reactive leg, from a second author` section — six
+  runs a row, starting segment counterbalanced 3/3.
+
+  These are the second author's, and they are replayed for the reason the
+  red-zone vectors above are: a verdict that has only ever seen the run it
+  shipped with is a verdict nobody can check. The leg does NOT cross the
+  segment seam — both its terms are Reagent arms measured in the same
+  segment of the same round — and it is adjudicated by the same partition
+  anyway, because the Reagent segment leads half the rounds and follows
+  the other half, and a lower bound that reads differently for which is
+  not a lower bound."
+  {:M1    [{:start :reagent-subs :vs [1.3788 1.2963 1.3333 1.3396 1.3654 1.2778]}
+           {:start :uix-subs     :vs [1.2963 1.3137 1.2692 1.4000 1.3469 1.3333]}
+           {:start :reagent-subs :vs [1.3621 1.3200 1.3061 1.4822 1.3214 1.3065]}
+           {:start :uix-subs     :vs [1.3725 1.3061 1.2500 1.4348 1.3636 1.3000]}
+           {:start :reagent-subs :vs [1.3333 1.3750 1.3043 1.3478 1.3333 1.2766]}
+           {:start :uix-subs     :vs [1.3667 1.3333 1.2727 1.4039 1.3396 1.3077]}]
+   :broad [{:start :reagent-subs :vs [2.5909 2.4000 2.4210 2.5556 2.6471 2.6875]}
+           {:start :uix-subs     :vs [2.5789 2.3000 2.1000 2.3000 2.5000 2.3889]}
+           {:start :reagent-subs :vs [2.5833 2.3636 2.1363 2.5789 2.5556 2.3889]}
+           {:start :uix-subs     :vs [2.5883 2.3333 2.2105 2.5000 2.5000 2.7858]}
+           {:start :reagent-subs :vs [2.7778 2.3889 2.5000 2.5625 2.6667 2.7143]}
+           {:start :uix-subs     :vs [2.7222 2.4210 2.4444 2.8750 2.3889 2.3889]}]})
+
+(defn- legs [row] (map (fn [{:keys [vs start]}]
+                         (app/segment-order-verdict vs 6 start "the reactive leg's"))
+                       (get leg row)))
+
+(deftest every-published-leg-run-resolves-a-magnitude
+  (testing "twelve row-runs, twenty-four strata: the strata OVERLAP on all
+           twelve, so every one is entitled to publish a magnitude, and no
+           row-run is reduced to a direction. That is what the studio
+           page's `magnitude-resolved? true on 12 of 12` asserts, derived
+           from the vectors rather than transcribed beside them"
+    (doseq [row [:M1 :broad] r (legs row)]
+      (is (true? (:strata-overlap? r)) (str row " " (:start r)))
+      (is (true? (:magnitude-resolved? r)) (str row " " (:start r)))
+      (is (true? (:balanced-design? r)) "six rounds, so 3:3")
+      (is (= 3 (:n (:reagent-first r))))
+      (is (= 3 (:n (:uix-first r)))))))
+
+(deftest the-leg-is-above-1-in-every-stratum-of-every-run
+  (testing "the DIRECTION is what a second author corroborates, and it is
+           unanimous: both strata of all twelve row-runs sit wholly above
+           1.0, so `subs costs more than a bare cursor` is a verdict no
+           partition of this ensemble touches"
+    (doseq [row [:M1 :broad] r (legs row)]
+      (is (= :numerator-slower (:direction (:reagent-first r))) (str row))
+      (is (= :numerator-slower (:direction (:uix-first r))) (str row))
+      (is (false? (:refuse? r)) (str row)))))
+
+(deftest the-leg-does-not-reproduce-the-first-authors-magnitude
+  (testing "and the MAGNITUDE is not corroborated, which is the finding
+           rf2-2rtt6.21 exists to surface. rf2-2rtt6.2 publishes 1.218 /
+           1.216 / 1.213 on M1 and 2.008 / 1.965 / 2.073 on broad; every
+           one of these run means sits above every one of those, and the
+           lowest M1 round of all six runs still clears the highest of the
+           first author's three means"
+    (let [means (fn [row] (map :order-balanced-mean (legs row)))]
+      (is (every? #(> % 1.30) (means :M1))
+          "every M1 run mean is above 1.30, where the first author's three
+           are 1.213-1.218")
+      (is (every? #(> % 2.30) (means :broad))
+          "every broad run mean is above 2.30, where the first author's
+           three are 1.965-2.073")
+      (is (> (apply min (mapcat :vs (:M1 leg))) 1.24)
+          "and the LOWEST single round across all six M1 runs, 1.2500,
+           still sits above the first author's re-run maxima of 1.241 and
+           1.273 — a disagreement at the round level and not only at the
+           mean")))
+  (testing "the same statement from the other side: replay the first
+           author's own published M1 leg as if it were a six-round vector
+           and it does not reach this ensemble's floor"
+    (is (< 1.218 (apply min (mapcat :vs (:M1 leg))))
+        "1.218 is below every round the second author measured")))

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
@@ -125,6 +125,25 @@ if (!['reagent', 'uix'].includes(START)) {
   process.exit(1);
 }
 
+// `HICASSO_RATOM=on` puts the SECOND AUTHOR'S `:reagent-ratom` arm in the
+// Reagent segment of the `M1` and `broad` rows, so `reagent-subs / ratom` —
+// rf2-2rtt6.2's headline 1, the price of the reactive system — can be formed
+// a second way on a second page (rf2-2rtt6.21). Default OFF, and the default
+// is load-bearing: with the arm in it the Reagent segment runs four arms
+// against the UIx segment's three, which is a different interleave and a
+// bigger mount budget than the schedule rf2-6i0i2's ten-run ensemble was
+// measured under. An unflagged invocation is still that instrument; a flagged
+// one is a different plan and says so on every record it writes.
+//
+// It composes with HICASSO_ONLY rather than implying it: `M2` and `narrow`
+// carry no ratom arm in either mode, so the useful pairing is
+// `HICASSO_RATOM=on HICASSO_ONLY=M1,broad`.
+const RATOM = (process.env.HICASSO_RATOM || 'off').trim();
+if (!['on', 'off'].includes(RATOM)) {
+  console.error(`[converge] HICASSO_RATOM=${RATOM} is not on|off`);
+  process.exit(1);
+}
+
 // A page's own budget. Six rounds of two segments with warm-up is
 // minutes, not seconds, and a loaded workstation is the normal case.
 const SENTINEL_TIMEOUT_MS = 20 * 60 * 1000;
@@ -198,7 +217,7 @@ async function runRow(browser, row) {
     // `'commit'`, not `'load'`. The bundle's `:init-fn` runs inside the
     // `<script>`, so the measurement happens while the document is still
     // loading and `load` cannot fire until it is over.
-    await navigate(page, `http://127.0.0.1:${PORT}/?row=${row.id}&start=${START}`, {
+    await navigate(page, `http://127.0.0.1:${PORT}/?row=${row.id}&start=${START}&ratom=${RATOM}`, {
       waitUntil: 'commit',
       timeoutMs: NAV_TIMEOUT_MS,
       budget: `the ${SENTINEL_TIMEOUT_MS / 60000}-minute wait for window.HICASSO_DONE`,
@@ -260,11 +279,19 @@ async function runRow(browser, row) {
   // bare command: a published figure whose repro command does not reproduce
   // it is a figure nobody can check.
   console.log(
-    `;; reproduce  ${ONLY ? `HICASSO_ONLY=${ONLY} ` : ''}${START !== 'reagent' ? `HICASSO_START=${START} ` : ''}node ` +
+    `;; reproduce  ${ONLY ? `HICASSO_ONLY=${ONLY} ` : ''}${START !== 'reagent' ? `HICASSO_START=${START} ` : ''}` +
+      `${RATOM !== 'off' ? `HICASSO_RATOM=${RATOM} ` : ''}node ` +
       `implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs`
   );
   console.log(`;; rows       ${ROWS.map((r) => r.id).join(', ')}${ONLY ? `  (HICASSO_ONLY=${ONLY})` : ''}`);
   console.log(`;; start      round 0 led by ${START} (HICASSO_START), alternating`);
+  console.log(
+    `;; ratom      ${RATOM} (HICASSO_RATOM)` +
+      (RATOM === 'on'
+        ? ' — the second author\'s :reagent-ratom arm is in the Reagent segment of M1 and broad;' +
+          ' this run\'s cross-segment red-zone is NOT the published threshold'
+        : '')
+  );
   for (const o of outcomes) {
     for (const [k, v] of Object.entries(o.results)) {
       console.log(`;; ==== HICASSO ${o.row.id} / ${k} ====`);


### PR DESCRIPTION
Closes rf2-2rtt6.21.

rf2-2rtt6.2's **headline 1** — *reading re-frame2 subscriptions rather than a
bare cursor costs Reagent ≈1.22× on mount and ≈2.01× on a broad commit* — was
measured three times, and all three are re-runs of the **same** `:reagent-ratom`
arm. That bounds an instrument's run-to-run noise and cannot bound a systematic
error in how the arm is written. Repetition, not replication.

This adds that arm to the **converged witness set**, in the Reagent segment of
the `M1` and `broad` rows, beside that page's own `:reagent-subs` arm, in the
same round of the same run. The leg is formed **inside one segment** — both
terms are Reagent arms normalised to the same floor — so the floor divides out
and the segment seam is not in the arithmetic.

## The verdict: the direction agrees, the magnitude does not

| row | first author (3 runs) | second author (6 runs) | verdict |
|---|---|---|---|
| **M1 mount** | 1.218 · 1.216 · 1.213 | **1.3353** [95% CI 1.3265 – 1.3441, run means 1.3266 – 1.3497] | direction agrees; **run-mean spreads disjoint** |
| **bulk broad** | 2.008 · 1.965 · 2.073 | **2.4957** [95% CI 2.4041 – 2.5873, run means 2.3613 – 2.6017] | direction agrees; **run-mean spreads disjoint** |

**The claim reproduces.** 72 of 72 rounds above 1.0, all 24 order strata wholly
above it, strata overlapping in 12 of 12 row-runs so every one is entitled to a
magnitude. Reading subscriptions rather than a bare cursor costs Reagent
something real, and that no longer rests on one arm.

**The numbers do not reproduce, and that is reported rather than reconciled
away.**

## The confound was pre-registered and then excluded

`spine.cljs` took two fixes today (rf2-2rtt6.13, rf2-2rtt6.25) and the Reagent
adapter requires the spine, so *the tree changed* was a live alternative to *the
harness changed*. Commit `93062c77d5` wrote down both branches and what each
would mean **before the control was run**. The control — the first author's own
instrument, unmodified, twice on this tree in this session — read **1.2115 /
1.2550** on `M1` and **2.1410 / 2.1333** on `broad`: its own published figures,
inside the pre-registered bands. The tree did not move the leg. The difference
is the harness, and held to one session it is **+8.3% on mount and +16.8% on a
broad commit**.

The control also localises it: the two authors' **`reagent-ratom ÷ floor`
readings agree** (+1.3% on `M1`, +3.4% on `broad`) while their **`reagent-subs ÷
floor` readings do not** (+9.7%, +20.6%). The leg inherits the whole of that —
which is the `reagent-subs ÷ floor` difference this page already published as a
reproduction (4.358 here against 3.899 there, ranges overlapping), surfacing in
a quantity where an overlapping range with a higher centre does not cancel. The
mechanism is listed as candidates and chosen between by nobody.

## The arm, and the budget it landed on

- `?ratom=on` / `HICASSO_RATOM=on`, **default OFF** — with the arm in it the
  Reagent segment runs four arms against the UIx segment's three, so an
  unflagged invocation is still the instrument the ten-run ensemble was measured
  on. Every record a flagged run writes carries `:ratom-arm? true` and a
  comparability note forbidding its cross-segment red-zone from being quoted as
  a threshold.
- **840 mounts** on the `M1` page (up from 720) and **882 writes** on `broad`.
  The refusal risk was named in `bcf80f1979` before the first sample; the guard
  did not refuse any of the twelve row-runs, so no budget repair was taken and
  no tolerance was touched.
- `M2` excluded (its budget already refuses, and its leg reads exactly 1.0000 on
  the first author's own instrument — the clamp, not a tie); `narrow` excluded
  (no first-author counterpart to corroborate).
- Fits the balanced design as it now stands: six rounds, counterbalanced start
  3/3, per-run strata, and the leg is adjudicated by `segment-order-verdict` on
  the same fail-closed terms as the red-zone — now four-arity so `:why` names
  the figure it judges instead of calling a within-segment ratio *the
  red-zone's*.

## Also here

- The denominator page's *Does not settle — one arm, three runs* is answered in
  place, and its *Settles* paragraph now states `≈1.22×` / `≈2.01×` as **that
  instrument's** figures rather than the substrate's.
- `p0_converge_order_cljs_test` replays all twelve published leg row-runs, and
  asserts the disagreement at the **round** level. Mutation-proved: flipping one
  threshold reds exactly one test in exactly that namespace.

## Quality gates

Every run foreground to completion, logged to the worktree, exit code echoed.
One build id, cold each time (`lane_cache.cjs` clears
`.shadow-cljs/builds/hicasso-bench` before every invocation).

| gate | command | exit |
|---|---|---|
| compile check | `node node_modules/shadow-cljs/cli/runner.js release hicasso-bench --config-merge …` | **0** (162 files, 107 compiled, 0 warnings) |
| bench run 1 | `HICASSO_RATOM=on HICASSO_ONLY=M1,broad HICASSO_START=reagent node …/p0_converge_run.cjs` | **0** |
| bench run 2 | same, `HICASSO_START=uix` | **0** |
| bench run 3 | same, `HICASSO_START=reagent` | **0** |
| bench run 4 | same, `HICASSO_START=uix` | **0** |
| bench run 5 | same, `HICASSO_START=reagent` | **0** |
| bench run 6 | same, `HICASSO_START=uix` | **0** |
| control 1 | `cd implementation && npm run bench:hicasso` | **0** |
| control 2 | `cd implementation && npm run bench:hicasso` | **0** |
| cljs suite | `cd implementation && npm run test:cljs` | **0** — 11,976 tests, 59,823 assertions, 0 failures, 0 errors |
| cljs suite, **mutation** | same, with one replay threshold flipped | **1** — exactly 1 failure, in `p0-converge-order-cljs-test`, proving the new gate can fail |
| cljs suite, reverted | `cd implementation && npm run test:cljs` | **0** — 11,976 tests, 0 failures |

Six bench runs launched one at a time, none re-run and none discarded. Across
them: **no arm-order refusal on any of the 12 row-runs** (`contaminated? false`,
`unchecked? false`, tolerance 0.10), **canonical-DOM parity clean** in both
segments and across the seam on all 12, **0 unverified of 10,332** mounts and
writes, **24 of 24 positive controls pass** under both the overlap rule and the
strict every-round-inside reading, and **no segment-order refusal** with
`magnitude-resolved? true` on 12 of 12 — for the leg as well as for the
red-zone. The two control runs: guard clean, `0 unverified of 1,220` each,
residue back to `{:body-children 2, :sub-entries 0, :sub-ref-count 0,
:ratom-watches 0}`.

`mkdocs build --strict` does not apply: `design/hicasso/` is in `exclude_docs`.

## Provenance

Whole-tree anchor `3a250838a2e3045209ecfc69402bba95ab51de8a` (`origin/main`) plus
the two instrument files this bead changed. Blob hashes for all nine relevant
files — including `spine.cljs`, which is the tree the control exists to price —
are on the studio page beside the figures.
