### PR TITLE
hicasso: the Wave-1 shared front half — codec, index laws, intent lowering (rf2-2rtt6.8)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -1,0 +1,437 @@
+(ns re-frame.bench.hicasso.front.codec
+  "THE HICCUP CODEC — deliverable 1 of the Wave-1 shared front half
+  (rf2-2rtt6.8). Runtime interpretation of arbitrary hiccup into React
+  elements, built by extracting reagent-slim's *measured* tag/prop/child
+  plumbing.
+
+  ## What was taken, and what was deliberately left
+
+  Taken from `reagent2.impl.template`, because it is the plumbing the P0
+  and HD-008 instruments actually clocked: the `#id.class` tag regex and
+  its parse; the kebab→camel prop-name rule with its `aria`/`data`
+  exemptions, its `--custom-property` passthrough and its three seeded
+  entries; the `:style` map→JS-object conversion; the class coercion and
+  the shorthand merge; the single-pass sequence expansion that does not
+  truncate on an interior `nil`; and the 0/1/N `createElement` arms with
+  the `.apply` path for long child lists.
+
+  **Left behind, by ruling and on purpose**: the component protocol, the
+  ratoms, the argv-equality memoization, and the scheduler. None of them
+  is here, none of them is reachable from here, and the codec requires
+  nothing from a donor. Reagent's equality semantics in particular are
+  not recreated (HD-006): every default comparison is a cost every render
+  pays, and narrow updates in this design come from boundary placement.
+
+  Also absent, and worth naming so their absence reads as a decision
+  rather than an omission: the `:r>` raw-props path, the class-component
+  `__rfArgv` crossing, `defhost`/`[:>]` interop (HD-011 — its own
+  surface), and the adapters' reserved-head and keyword-prop diagnostics
+  (public-boundary policy for a shipped adapter; this codec has no public
+  boundary, and the pre-alpha stance is to trust the programmer).
+
+  ## Codec-work caching only (HD-004)
+
+  Two caches, both keyed by the author's literal and both plain JS
+  objects with an own-property guard so a hiccup tag or prop literally
+  named `__proto__` cannot poison them:
+
+    tag-cache    \"div#main.wide\" -> ParsedTag
+    prop-cache   \"on-click\"      -> \"onClick\"
+
+  That is the whole of the accelerant HD-004 permits in the lean arm.
+  There is **no template extraction, no hole plan, no node reference, and
+  no direct DOM write** — any of those *is* the PATCH strategy and has to
+  say so. There is no memoization of converted props objects and no
+  memoization of elements: `convert-props` mints a fresh object per
+  element per render, exactly as the measured donor does, so the clock
+  this codec is compared on is the clock that was measured.
+
+  **The third cache HD-004 names — cached stable component heads — costs
+  nothing here, and that is the interesting part.** reagent-slim needs
+  one because `:f>` takes a *plain* function and must not mint a fresh
+  React type per render. Hicasso's `defview` mints the function component
+  once, at definition, and [[mark-boundary!]] records that on the fn
+  itself; the head is then identity-stable by construction and the cache
+  has nothing to do. This is also why HD-016 makes a plain function in
+  head position a loud error rather than auto-wrapping it: auto-wrapping
+  is precisely the thing that would need the cache back.
+
+  ## The arm boundary
+
+  Analysis — tag parse, prop names, class merge, child realization, head
+  classification — is arm-neutral and is what both tournament arms share.
+  **Emission is not**, and this file emits React elements, i.e. Arm 1's
+  representation. Hicasso/PATCH (rf2-2rtt6.10) reuses the analysis and
+  brings its own emitter; that is the honest shape of \"the arm's element
+  representation\" in architecture.md, and it is the reason the two are
+  kept visibly apart below rather than interleaved.
+
+  ## The component ABI (HD-016)
+
+  | Head | Props | Children | `:key` |
+  |---|---|---|---|
+  | Native tag | attr map | trailing forms; seqs realized once and flattened one level; `nil`/`false` render nothing, `true` errors | `:key` in the attr map |
+  | Boundary (a marked `defview` product) | one props map | trailing forms as `(:children props)`, a realized vector | `:key` in the props map, extracted before the body sees props |
+  | Fragment `[:<> …]` | optional attr map | trailing forms | on the fragment's props map |
+
+  A React element is a legal child anywhere. No metadata keys, no second
+  calling convention, and a plain function in head position is a loud
+  error."
+  (:require [clojure.string :as str]
+            [re-frame.bench.hicasso.front.intent :as intent]
+            ["react" :as react]))
+
+(declare as-element)
+
+;; ---------------------------------------------------------------------------
+;; Cache hygiene — the own-property guard both caches share
+;; ---------------------------------------------------------------------------
+
+(def ^:private reserved-cache-keys
+  "Never read from or written to a JS-object cache: a hiccup literal with
+  one of these names would otherwise reach the object's prototype."
+  #{"__proto__" "prototype" "constructor"})
+
+(def ^:private has-own (.-hasOwnProperty (.-prototype js/Object)))
+
+(defn- own-key?
+  "`hasOwnProperty`, called off the prototype, so an object carrying its
+  own `hasOwnProperty` property cannot shadow the check."
+  [o k]
+  (.call has-own o k))
+
+;; ---------------------------------------------------------------------------
+;; Tag parsing and its cache
+;; ---------------------------------------------------------------------------
+
+(def ^:private re-tag
+  "`tag`, optional `#id`, optional `.class.class`. The `#id` must precede
+  the classes, as in the donor and in stock Reagent."
+  #"([^\s\.#]+)(?:#([^\s\.#]+))?(?:\.([^\s#]+))?")
+
+(deftype ParsedTag [tag id className])
+
+(defn parse-tag
+  "Parse `:div#main.wide.tall` into its tag, id and class string."
+  [hiccup-tag]
+  (let [[_ tag id classes] (re-matches re-tag (name hiccup-tag))]
+    (->ParsedTag tag id (when classes (str/replace classes #"\." " ")))))
+
+(def ^:private tag-cache #js {})
+
+(defn- cache-key [k]
+  (if-let [ns' (namespace k)] (str ns' "/" (name k)) (name k)))
+
+(defn cached-parse
+  "[[parse-tag]] behind the codec-work cache (HD-004). One entry per
+  distinct tag literal the build ever renders."
+  [hiccup-tag]
+  (let [k (cache-key hiccup-tag)]
+    (if (reserved-cache-keys k)
+      (parse-tag hiccup-tag)
+      (if (own-key? tag-cache k)
+        (unchecked-get tag-cache k)
+        (let [parsed (parse-tag hiccup-tag)]
+          (unchecked-set tag-cache k parsed)
+          parsed)))))
+
+;; ---------------------------------------------------------------------------
+;; Prop names and their cache
+;; ---------------------------------------------------------------------------
+
+(def ^:private dont-camel-case
+  "`aria-*` and `data-*` are HTML attribute names in React too, and
+  camelCasing them would break them."
+  #{"aria" "data"})
+
+(defn- capitalize [s]
+  (if (< (count s) 2) (str/upper-case s) (str (str/upper-case (subs s 0 1)) (subs s 1))))
+
+(defn prop-name
+  "The React prop name for a hiccup prop key. `:on-click` → `\"onClick\"`;
+  `:aria-label` and `:data-index` pass through; a `--custom-property` is
+  preserved verbatim."
+  [k]
+  (if (string? k)
+    k
+    (let [n (name k)]
+      (if (str/starts-with? n "--")
+        n
+        (let [[start & parts] (str/split n #"-")]
+          (if (dont-camel-case start)
+            n
+            (apply str start (map capitalize parts))))))))
+
+(def ^:private prop-cache
+  (doto #js {}
+    (unchecked-set "class" "className")
+    (unchecked-set "for" "htmlFor")
+    (unchecked-set "charset" "charSet")))
+
+(defn cached-prop-name
+  "[[prop-name]] behind the codec-work cache (HD-004)."
+  [k]
+  (if-not (or (keyword? k) (symbol? k) (string? k))
+    k
+    (let [n (name k)]
+      (if (reserved-cache-keys n)
+        (prop-name k)
+        (if (own-key? prop-cache n)
+          (unchecked-get prop-cache n)
+          (let [converted (prop-name k)]
+            (unchecked-set prop-cache n converted)
+            converted))))))
+
+;; ---------------------------------------------------------------------------
+;; Classes and the shorthand merge
+;; ---------------------------------------------------------------------------
+
+(defn class-names
+  "Coerce a `:class` value — a string, a keyword, a symbol, or a
+  collection of those, with nils dropped — to one space-joined string, or
+  nil when nothing survives."
+  ([] nil)
+  ([class]
+   (cond
+     (nil? class)     nil
+     (string? class)  (when (seq class) class)
+     (or (keyword? class) (symbol? class)) (name class)
+     (coll? class)    (let [joined (->> class (keep class-names) (str/join " "))]
+                        (when (seq joined) joined))
+     :else            (str class)))
+  ([a b]
+   (let [a (class-names a) b (class-names b)]
+     (cond (nil? a) b (nil? b) a :else (str a " " b)))))
+
+(defn- merge-shorthand
+  "Fold the tag's `#id`/`.class` shorthand into the props map. An explicit
+  `:id` wins over the shorthand; the shorthand class is *prepended* to an
+  explicit class, so `[:div.a {:class \"b\"}]` is `\"a b\"`."
+  [props ^ParsedTag parsed]
+  (let [id        (.-id parsed)
+        shorthand (.-className parsed)
+        props     (if (and id (not (contains? props :id))) (assoc props :id id) props)
+        declared  (or (:class props) (:className props))
+        merged    (class-names shorthand declared)]
+    (cond-> (dissoc props :className :class)
+      merged (assoc :class merged))))
+
+;; ---------------------------------------------------------------------------
+;; Prop values
+;; ---------------------------------------------------------------------------
+
+(declare convert-prop-value)
+
+(defn- nested-map->js
+  "A nested map — `:style` and its kin — with camelCased keys."
+  [m]
+  (reduce-kv (fn [o k v] (unchecked-set o (cached-prop-name k) (convert-prop-value v)) o)
+             #js {}
+             m))
+
+(defn convert-prop-value
+  "A prop value in the shape React wants. Functions pass through **by
+  identity**, deliberately: rewrapping them would defeat `React.memo` and
+  every downstream bail-out that compares handler identity."
+  [v]
+  (cond
+    (fn? v)                  v
+    (map? v)                 (nested-map->js v)
+    (or (keyword? v) (symbol? v)) (name v)
+    (coll? v)                (clj->js v)
+    :else                    v))
+
+(defn convert-props
+  "One pass over the attribute map: fold the tag shorthand, drop `:key`
+  (React's own contract — it is not an attribute), lower every intent,
+  and set each converted value under its React prop name.
+
+  Note the order: intent lowering happens *inside* this single walk, so
+  the codec does not traverse the props map a second time to find the
+  event positions."
+  [props ^ParsedTag parsed]
+  (let [props (-> props (merge-shorthand parsed) (dissoc :key))]
+    (reduce-kv (fn [o k v]
+                 (let [n (cached-prop-name k)]
+                   (when-not (reserved-cache-keys n)
+                     (unchecked-set o n (convert-prop-value (intent/lower-prop k v))))
+                   o))
+               #js {}
+               props)))
+
+;; ---------------------------------------------------------------------------
+;; Boundary heads (HD-016 / HD-004)
+;; ---------------------------------------------------------------------------
+
+(defn mark-boundary!
+  "Record that `f` — a React function component an arm's `defview` minted
+  — is a legal hiccup head. Returns `f`, so a `defview` can end with it."
+  [f]
+  (unchecked-set f "hicassoBoundary" true)
+  f)
+
+(defn boundary-head?
+  "Is `f` a marked boundary? One own-property read; no registry, no map."
+  [f]
+  (and (fn? f) (true? (unchecked-get f "hicassoBoundary"))))
+
+;; ---------------------------------------------------------------------------
+;; Hiccup shape
+;; ---------------------------------------------------------------------------
+
+(defn- props-map?
+  "Slot `i` of a hiccup vector is the props map when it is a map. A seq
+  there is a child, as is a string, as is another hiccup vector."
+  [argv i]
+  (map? (nth argv i nil)))
+
+(defn realize-children
+  "The trailing forms of `argv` from `first-child`, realized once into a
+  vector and flattened exactly one level — a nested seq splices, a nested
+  *vector* does not, because a vector is hiccup. Returns nil when there
+  are none, so `(:children props)` is absent rather than empty."
+  [argv first-child]
+  (when (< first-child (count argv))
+    (let [flat (reduce (fn [acc c] (if (seq? c) (into acc c) (conj acc c)))
+                       []
+                       (subvec argv first-child))]
+      (when (seq flat) flat))))
+
+;; ---------------------------------------------------------------------------
+;; Emission — React elements (Arm 1's representation)
+;; ---------------------------------------------------------------------------
+
+(defn- expand-seq
+  "A seq of children as a JS array of elements. One pass, driven by the
+  seq's own exhaustion rather than by each child's truthiness, so an
+  interior `nil` — the `(for [x xs] (when pred [:li …]))` shape — does not
+  truncate the list."
+  [s]
+  (let [a #js []]
+    (loop [items (seq s)]
+      (when items
+        (.push a (as-element (first items)))
+        (recur (next items))))
+    a))
+
+(defn- make-element
+  "`createElement` with the donor's three arms: no children, one child,
+  and the `.apply` path that builds an argument array for the rest. The
+  loop is deliberate — a long keyed list is the hot case."
+  [component js-props argv first-child]
+  (let [n (count argv)]
+    (case (- n first-child)
+      0 (react/createElement component js-props)
+      1 (react/createElement component js-props (as-element (nth argv first-child)))
+      (let [args #js [component js-props]]
+        (loop [i first-child]
+          (when (< i n)
+            (.push args (as-element (nth argv i)))
+            (recur (inc i))))
+        (.apply (.-createElement react) nil args)))))
+
+(defn- native-element [argv]
+  (let [parsed      (cached-parse (nth argv 0))
+        has-props?  (props-map? argv 1)
+        props       (if has-props? (nth argv 1) nil)
+        js-props    (convert-props (or props {}) parsed)]
+    (when-some [k (:key props)] (unchecked-set js-props "key" k))
+    (make-element (.-tag parsed) js-props argv (if has-props? 2 1))))
+
+(defn- boundary-element [argv]
+  (let [has-props? (props-map? argv 1)
+        props      (if has-props? (nth argv 1) {})
+        children   (realize-children argv (if has-props? 2 1))
+        body-props (cond-> (dissoc props :key)
+                     children (assoc :children children))
+        js-props   #js {"rfProps" body-props}]
+    (when-some [k (:key props)] (unchecked-set js-props "key" k))
+    (react/createElement (nth argv 0) js-props)))
+
+(defn- fragment-element [argv]
+  (let [has-props? (props-map? argv 1)
+        props      (if has-props? (nth argv 1) nil)
+        js-props   #js {}]
+    (when-some [k (:key props)] (unchecked-set js-props "key" k))
+    (make-element (.-Fragment react) js-props argv (if has-props? 2 1))))
+
+(defn- fragment-head?
+  "Is this the fragment spelling? Compared with `=`, never `identical?`:
+  ClojureScript keyword literals are shared constants only when the build
+  interns them, so an identity comparison here works under `:advanced`
+  and silently routes every fragment into the native-tag path everywhere
+  else."
+  [head]
+  (= :<> head))
+
+(defn- hiccup-tag? [head]
+  (and (or (keyword? head) (symbol? head) (string? head))
+       (not (fragment-head? head))))
+
+(defn vec->element
+  "Interpret one hiccup vector."
+  [argv]
+  (when (zero? (count argv))
+    (throw (ex-info (str "Empty hiccup vector. [:rf.error/hicasso-empty-vector]")
+                    {:rf.error/id :rf.error/hicasso-empty-vector
+                     :where       'front.codec/vec->element
+                     :reason      "A hiccup vector must have a head."
+                     :recovery    :supply-a-hiccup-head})))
+  (let [head (nth argv 0)]
+    (cond
+      (fragment-head? head)   (fragment-element argv)
+      (hiccup-tag? head)      (native-element argv)
+      (boundary-head? head)   (boundary-element argv)
+      :else
+      (throw (ex-info (str "Hiccup head " (pr-str head) " is not a valid element head; "
+                           "use a tag keyword, :<>, or a view minted by defview. "
+                           "A plain function in head position is never a silent "
+                           "embedding — call it, or make it a view. "
+                           "[:rf.error/hicasso-bad-head]")
+                      {:rf.error/id :rf.error/hicasso-bad-head
+                       :where       'front.codec/vec->element
+                       :reason      (if (fn? head)
+                                      "A plain function in head position is a loud error (HD-016)."
+                                      "Hiccup head must be a tag keyword, :<>, or a defview product.")
+                       :recovery    (if (fn? head) :call-it-or-make-it-a-view :supply-a-valid-hiccup-head)})))))
+
+(defn as-element
+  "Interpret any hiccup form. `nil` and `false` render nothing; `true` is
+  an error (HD-016); an existing React element passes through."
+  [x]
+  (cond
+    (nil? x)         nil
+    (false? x)       nil
+    (vector? x)      (vec->element x)
+    (string? x)      x
+    (number? x)      x
+    (seq? x)         (expand-seq x)
+    (true? x)        (throw (ex-info (str "`true` is not a renderable child. "
+                                          "[:rf.error/hicasso-true-child]")
+                                     {:rf.error/id :rf.error/hicasso-true-child
+                                      :where       'front.codec/as-element
+                                      :reason      "nil and false render nothing; true is an error (HD-016)."
+                                      :recovery    :use-nil-or-false}))
+    (react/isValidElement x) x
+    (keyword? x)     (name x)
+    (symbol? x)      (name x)
+    :else            x))
+
+;; ---------------------------------------------------------------------------
+;; Cache observation — for the tests and the bench, never for the runtime
+;; ---------------------------------------------------------------------------
+
+(defn cache-sizes []
+  {:tags  (count (js/Object.keys tag-cache))
+   :props (count (js/Object.keys prop-cache))})
+
+(defn reset-caches!
+  "Empty both codec caches. The prop cache keeps its three seeded entries,
+  because those are the rule and not a memo of one."
+  []
+  (doseq [k (js/Object.keys tag-cache)] (js-delete tag-cache k))
+  (doseq [k (js/Object.keys prop-cache)] (js-delete prop-cache k))
+  (unchecked-set prop-cache "class" "className")
+  (unchecked-set prop-cache "for" "htmlFor")
+  (unchecked-set prop-cache "charset" "charSet")
+  nil)

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
@@ -1,0 +1,270 @@
+(ns re-frame.bench.hicasso.front.codec-cljs-test
+  "THE HICCUP CODEC, tested at the element (rf2-2rtt6.8).
+
+  Every assertion here reads a React element's `type`, `props` and `key`
+  rather than rendered DOM. That is the right altitude for a codec and it
+  is also the cheap one: the question this file answers is *what did the
+  codec build*, and a mounted tree would answer it through two more
+  layers that have their own opinions. What React then does with these
+  elements is the arms' browser witness set, not this file's."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.intent :as intent]
+            ["react" :as react]))
+
+(use-fixtures :each {:before (fn [] (codec/reset-caches!))})
+
+;; ---------------------------------------------------------------------------
+;; Reading an element
+;; ---------------------------------------------------------------------------
+
+(defn- el-type [e] (.-type e))
+(defn- el-key [e] (.-key e))
+(defn- prop [e k] (aget (.-props e) k))
+(defn- prop-names [e] (vec (sort (js/Object.keys (.-props e)))))
+(defn- children [e] (prop e "children"))
+(defn- child-vec [e] (let [c (children e)] (if (array? c) (vec c) [c])))
+
+;; ---------------------------------------------------------------------------
+;; Tags
+;; ---------------------------------------------------------------------------
+
+(deftest a-bare-tag-becomes-an-element-of-that-type
+  (let [e (codec/as-element [:div])]
+    (is (= "div" (el-type e)))
+    (is (= [] (prop-names e)))))
+
+(deftest the-id-and-class-shorthand-is-parsed-and-folded-into-the-props
+  (testing "id alone"
+    (is (= "main" (prop (codec/as-element [:div#main]) "id"))))
+  (testing "classes alone, dot-separated"
+    (is (= "wide tall" (prop (codec/as-element [:div.wide.tall]) "className"))))
+  (testing "id then classes, in the one spelling the donor supports"
+    (let [e (codec/as-element [:section#main.wide.tall])]
+      (is (= "section" (el-type e)))
+      (is (= "main" (prop e "id")))
+      (is (= "wide tall" (prop e "className")))))
+  (testing "an explicit :id wins over the shorthand"
+    (is (= "explicit" (prop (codec/as-element [:div#short {:id "explicit"}]) "id"))))
+  (testing "the shorthand class is prepended to an explicit one"
+    (is (= "short explicit" (prop (codec/as-element [:div.short {:class "explicit"}]) "className"))))
+  (testing "a collection class value joins, dropping nils"
+    (is (= "a b" (prop (codec/as-element [:div {:class ["a" nil :b]}]) "className")))))
+
+(deftest the-tag-cache-holds-one-entry-per-distinct-literal
+  (is (= 0 (:tags (codec/cache-sizes))))
+  (codec/as-element [:div.row])
+  (codec/as-element [:div.row])
+  (codec/as-element [:div.row])
+  (is (= 1 (:tags (codec/cache-sizes))) "three renders of one literal, one entry")
+  (codec/as-element [:span])
+  (is (= 2 (:tags (codec/cache-sizes))))
+  (testing "a cached parse produces the same element a fresh parse does"
+    (is (= "row" (prop (codec/as-element [:div.row]) "className")))))
+
+(deftest the-caches-refuse-the-prototype-poisoning-keys
+  (testing "a tag named __proto__ parses without being cached"
+    (is (= "__proto__" (el-type (codec/as-element [:__proto__]))))
+    (is (= 0 (:tags (codec/cache-sizes)))))
+  (testing "a prop named __proto__ is neither cached nor set"
+    (let [e (codec/as-element [:div {:__proto__ "nope"}])]
+      (is (= [] (prop-names e))))))
+
+;; ---------------------------------------------------------------------------
+;; Prop names
+;; ---------------------------------------------------------------------------
+
+(deftest prop-names-follow-the-donors-kebab-to-camel-rule
+  (is (= "onClick" (codec/prop-name :on-click)))
+  (is (= "tabIndex" (codec/prop-name :tab-index)))
+  (is (= "className" (codec/cached-prop-name :class)))
+  (is (= "htmlFor" (codec/cached-prop-name :for)))
+  (is (= "charSet" (codec/cached-prop-name :charset)))
+  (testing "aria and data are HTML attribute names in React too"
+    (is (= "aria-label" (codec/prop-name :aria-label)))
+    (is (= "data-index" (codec/prop-name :data-index))))
+  (testing "a CSS custom property is preserved verbatim"
+    (is (= "--gap" (codec/prop-name :--gap))))
+  (testing "the three seeded entries are the rule, not a memo of one"
+    (is (= 3 (:props (codec/cache-sizes))))
+    (codec/cached-prop-name :on-click)
+    (codec/cached-prop-name :on-click)
+    (is (= 4 (:props (codec/cache-sizes))))))
+
+(deftest prop-values-are-converted-in-the-shapes-react-wants
+  (testing "a style map becomes a JS object with camelCased keys"
+    (let [style (prop (codec/as-element [:div {:style {:font-size "12px" :color :red}}]) "style")]
+      (is (= "12px" (aget style "fontSize")))
+      (is (= "red" (aget style "color")) "a keyword value stringifies")))
+  (testing "a CSS custom property survives inside style"
+    (let [style (prop (codec/as-element [:div {:style {:--gap "4px"}}]) "style")]
+      (is (= "4px" (aget style "--gap")))))
+  (testing "a function passes through BY IDENTITY, so downstream bail-outs still work"
+    (let [f (fn [_])]
+      (is (identical? f (prop (codec/as-element [:div {:on-click f}]) "onClick")))))
+  (testing "a ref is an ordinary prop — callback refs are legal on native tags"
+    (let [r (fn [_node])]
+      (is (identical? r (prop (codec/as-element [:div {:ref r}]) "ref")))))
+  (testing "scalars are left alone"
+    (let [e (codec/as-element [:input {:value "x" :disabled true :tab-index 3}])]
+      (is (= "x" (prop e "value")))
+      (is (= true (prop e "disabled")))
+      (is (= 3 (prop e "tabIndex"))))))
+
+;; ---------------------------------------------------------------------------
+;; Keys — `:key` in the props position, never metadata (HD-016)
+;; ---------------------------------------------------------------------------
+
+(deftest a-native-elements-key-is-key-in-the-props-map-and-is-not-an-attribute
+  (let [e (codec/as-element [:li {:key 7 :class "row"}])]
+    (is (= "7" (el-key e)) "React stringifies keys")
+    (is (= ["className"] (prop-names e)) ":key never reaches the DOM props")))
+
+;; ---------------------------------------------------------------------------
+;; Children
+;; ---------------------------------------------------------------------------
+
+(deftest children-are-realized-once-and-flattened-one-level
+  (testing "one child arrives as the single child, not an array"
+    (let [e (codec/as-element [:p "text"])]
+      (is (= "text" (children e)))))
+  (testing "several children arrive in order"
+    (let [e (codec/as-element [:p "a" "b" "c"])]
+      (is (= ["a" "b" "c"] (child-vec e)))))
+  (testing "a seq is expanded, and an interior nil does NOT truncate it"
+    (let [e (codec/as-element [:ul (for [i (range 4)] (when (odd? i) [:li {:key i} i]))])
+          expanded (vec (children e))]
+      (is (= 4 (count expanded)) "all four slots survive the single pass")
+      (is (nil? (nth expanded 0)))
+      (is (= "li" (el-type (nth expanded 1))))
+      (is (nil? (nth expanded 2)))
+      (is (= "li" (el-type (nth expanded 3))))))
+  (testing "nil and false render nothing"
+    (is (nil? (codec/as-element nil)))
+    (is (nil? (codec/as-element false)))
+    (is (= [nil nil "x"] (child-vec (codec/as-element [:p nil false "x"])))))
+  (testing "true is an error"
+    (is (thrown-with-msg? js/Error #"not a renderable child" (codec/as-element true)))
+    (try
+      (codec/as-element true)
+      (is false "should have thrown")
+      (catch :default e
+        (is (= :rf.error/hicasso-true-child (:rf.error/id (ex-data e)))))))
+  (testing "an existing React element is a legal child anywhere"
+    (let [foreign (react/createElement "b" nil "bold")
+          e       (codec/as-element [:p foreign])]
+      (is (identical? foreign (children e))))))
+
+(deftest a-map-in-the-first-slot-is-props-and-anything-else-is-a-child
+  (testing "a map is props"
+    (is (= "row" (prop (codec/as-element [:div {:class "row"}]) "className"))))
+  (testing "a string in the first slot is a child, not props"
+    (is (= "hello" (children (codec/as-element [:div "hello"])))))
+  (testing "a vector in the first slot is a child"
+    (is (= "b" (el-type (children (codec/as-element [:div [:b]])))))))
+
+;; ---------------------------------------------------------------------------
+;; Fragments
+;; ---------------------------------------------------------------------------
+
+(deftest the-fragment-spelling-is-a-fragment
+  (let [e (codec/as-element [:<> [:li "a"] [:li "b"]])]
+    (is (identical? (.-Fragment react) (el-type e)))
+    (is (= 2 (count (child-vec e)))))
+  (testing "a keyed fragment carries its key"
+    (is (= "k" (el-key (codec/as-element [:<> {:key "k"} [:li "a"]]))))))
+
+;; ---------------------------------------------------------------------------
+;; Boundaries — the HD-016 head rules
+;; ---------------------------------------------------------------------------
+
+(defn- a-view
+  "Stands in for a `defview` product: an arm mints the function component
+  once, at definition, and marks it. The codec never wraps it, which is
+  why HD-004's cached-component-head has nothing to do here."
+  [_js-props]
+  nil)
+
+(codec/mark-boundary! a-view)
+
+(deftest a-marked-view-in-head-position-is-a-boundary-child
+  (let [e (codec/as-element [a-view {:id 7}])]
+    (is (identical? a-view (el-type e)))
+    (is (= {:id 7} (prop e "rfProps")) "the body receives one CLJS props map")))
+
+(deftest a-boundarys-key-is-extracted-before-the-body-sees-props
+  (let [e (codec/as-element [a-view {:key 3 :id 7}])]
+    (is (= "3" (el-key e)))
+    (is (= {:id 7} (prop e "rfProps")) ":key is React's contract, not the body's")))
+
+(deftest a-boundarys-children-arrive-as-a-realized-vector-of-hiccup
+  (testing "trailing forms become (:children props)"
+    (let [e (codec/as-element [a-view {:id 7} [:li "a"] [:li "b"]])]
+      (is (= {:id 7 :children [[:li "a"] [:li "b"]]} (prop e "rfProps")))))
+  (testing "a seq child is realized once and flattened exactly one level"
+    (let [e (codec/as-element [a-view {} (for [i (range 2)] [:li i])])]
+      (is (= [[:li 0] [:li 1]] (:children (prop e "rfProps"))))))
+  (testing "with no trailing forms there is no :children key at all"
+    (is (= {:id 7} (prop (codec/as-element [a-view {:id 7}]) "rfProps"))))
+  (testing "a boundary with no props map still works"
+    (is (= {} (prop (codec/as-element [a-view]) "rfProps")))))
+
+(deftest a-plain-function-in-head-position-is-a-loud-error
+  (let [helper (fn [_] [:div])]
+    (is (false? (codec/boundary-head? helper)))
+    (is (thrown-with-msg? js/Error #"never a silent" (codec/as-element [helper {}])))
+    (try
+      (codec/as-element [helper {}])
+      (is false "should have thrown")
+      (catch :default e
+        (is (= :rf.error/hicasso-bad-head (:rf.error/id (ex-data e))))
+        (is (= :call-it-or-make-it-a-view (:recovery (ex-data e))))))))
+
+(deftest an-empty-hiccup-vector-and-a-nonsense-head-are-loud-errors
+  (is (thrown-with-msg? js/Error #"Empty hiccup vector" (codec/as-element [])))
+  (is (thrown-with-msg? js/Error #"not a valid element head" (codec/as-element [42 {}]))))
+
+;; ---------------------------------------------------------------------------
+;; The codec's one policy call — intent lowering happens inside the walk
+;; ---------------------------------------------------------------------------
+
+(deftest event-vectors-in-attributes-lower-during-prop-conversion
+  (let [!seen (atom [])
+        e     (intent/with-frame (fn [ev] (swap! !seen conj ev))
+                                 (fn [] (codec/as-element
+                                         [:button {:on-click [:todo/toggle 7] :class "btn"}
+                                          "done"])))]
+    (is (= "btn" (prop e "className")))
+    (is (fn? (prop e "onClick")))
+    (is (= [] @!seen))
+    ((prop e "onClick") #js {:target #js {}})
+    (is (= [[:todo/toggle 7]] @!seen))))
+
+(deftest a-controlled-field-lowers-its-marker-through-the-codec
+  (let [!seen (atom [])
+        e     (intent/with-frame (fn [ev] (swap! !seen conj ev))
+                                 (fn [] (codec/as-element
+                                         [:input {:value "milk"
+                                                  :on-input [:todo.ui/edit 7 :re-frame.hicasso/value]}])))]
+    (is (= "milk" (prop e "value")))
+    ((prop e "onInput") #js {:target #js {:value "bread"}})
+    (is (= [[:todo.ui/edit 7 "bread"]] @!seen))))
+
+;; ---------------------------------------------------------------------------
+;; What the codec must NOT be
+;; ---------------------------------------------------------------------------
+
+(deftest the-codec-mints-a-fresh-props-object-per-element-and-memoizes-no-element
+  (testing "two renders of the same hiccup are two elements with two props objects"
+    (let [hiccup [:div {:class "row"} "x"]
+          a      (codec/as-element hiccup)
+          b      (codec/as-element hiccup)]
+      (is (not (identical? a b)) "no element memoization — HD-006 stands")
+      (is (not (identical? (.-props a) (.-props b))) "no props-object cache")
+      (is (= (prop-names a) (prop-names b)))))
+  (testing "only the two codec-work caches grow — tags and prop names (HD-004)"
+    (codec/reset-caches!)
+    (dotimes [i 20] (codec/as-element [:div.row {:class (str "c" i)} i]))
+    (is (= {:tags 1 :props 3} (codec/cache-sizes))
+        "one tag literal; `:class` is one of the three seeded prop names, so
+         twenty renders with twenty distinct class VALUES add nothing")))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/dogfood.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/dogfood.cljs
@@ -1,0 +1,191 @@
+(ns re-frame.bench.hicasso.front.dogfood
+  "THE DOGFOOD SCREEN'S SHARED APP AND STATE (rf2-2rtt6.8) — the state
+  layer only.
+
+  **There is no screen in this namespace, and mounting one is not this
+  bead's work.** HD-014 starts the six-week clock at the first
+  Hicasso-arm commit that mounts the dogfood screen; the arms
+  (rf2-2rtt6.9 and rf2-2rtt6.10) own that commit. What is here is
+  everything the screen will sit on: the app-db shape, the events, the
+  subscriptions, and the frame lifecycle. Nothing renders, nothing
+  imports React, and no root is created.
+
+  ## Why the state layer is shared rather than written three times
+
+  HD-002 says the dogfood screen is written in **three renderings** — the
+  collector surface, the grouped `use-subs` surface, and raw UIx — and
+  judged on diff and preference by its authors. That verdict is only
+  about the view layer if the three renderings sit on one identical set
+  of events and subscriptions. Three hand-written state layers would put
+  a second variable into an ergonomics comparison whose whole value is
+  that it has one.
+
+  ## The screen, described
+
+  One list and one controlled field, which is validation.md's whole
+  specification for it. Concretely: a to-do list with a header count, a
+  filter, a per-row toggle and delete, a keyed reorder, and one draft
+  field per editable thing.
+
+  ## Where the drafts live, and why that is the interesting part
+
+  HD-009 admits no component-local reactive cell — no `local`, no
+  ratom-equivalent, no `useState` for application state. The draft of a
+  half-typed to-do is exactly the state a Reagent author would reach for
+  `r/atom` to hold, so it is the honest test of the ruling rather than a
+  place to quietly make an exception. It lives in app-db under `:drafts`,
+  keyed, with **one parametric subscription and one named event serving
+  every instance** — which is HD-009's claim that the tax is per-concern
+  and not per-instance, stated as code that either is or is not one
+  declaration per concern.
+
+  The reset law is kept as HD-019 keeps it: a draft is cleared **by
+  explicit caller revision**, never by value equality. `:dogfood/commit`
+  and `:dogfood/cancel` say so by name.
+
+  ## The write shapes, which are also the bulk witnesses
+
+  `:dogfood/toggle` is the narrow write — one row's subscription dirties,
+  and under a correct index exactly one boundary re-runs.
+  `:dogfood/set-filter` is the broad write — the visible-ids
+  subscription changes and the list rebuilds. The two are here rather
+  than in a bench file because the same pair drives both the dogfood
+  screen and the bulk witness rows, and they must be the same events in
+  both or the ergonomics screen is not the thing being measured."
+  (:require [re-frame.core :as rf]))
+
+;; ---------------------------------------------------------------------------
+;; The app-db shape
+;; ---------------------------------------------------------------------------
+
+(defn seed-db
+  "`n` to-dos, no drafts, no filter. The one place the shape is written
+  out; every assertion about the shape reads it from here."
+  [n]
+  {:todos  (into {} (map (fn [i] [i {:id i :title (str "todo " i) :done? false}])) (range n))
+   :order  (vec (range n))
+   :drafts {}
+   :filter :all
+   :next-id n})
+
+(def new-draft-key
+  "The draft key for the not-yet-created to-do. A to-do being edited uses
+  its own id, so one parametric subscription serves both."
+  ::new)
+
+;; ---------------------------------------------------------------------------
+;; Subscriptions — what a boundary reads
+;; ---------------------------------------------------------------------------
+
+(rf/reg-sub :dogfood/filter (fn [db _] (:filter db)))
+
+(rf/reg-sub :dogfood/todo (fn [db [_ id]] (get-in db [:todos id])))
+
+(rf/reg-sub :dogfood/done? (fn [db [_ id]] (get-in db [:todos id :done?])))
+
+(rf/reg-sub :dogfood/draft (fn [db [_ k]] (get-in db [:drafts k] "")))
+
+(rf/reg-sub :dogfood/visible-ids
+  (fn [db _]
+    (let [f (:filter db)]
+      (if (= :all f)
+        (:order db)
+        (let [want (= :done f)]
+          (filterv #(= want (boolean (get-in db [:todos % :done?]))) (:order db)))))))
+
+(rf/reg-sub :dogfood/remaining
+  (fn [db _] (count (remove #(get-in db [:todos % :done?]) (:order db)))))
+
+;; ---------------------------------------------------------------------------
+;; Events — what an intent dispatches
+;; ---------------------------------------------------------------------------
+
+(rf/reg-event :dogfood/seed
+  (fn [_ [_ n]] {:db (seed-db n)}))
+
+(rf/reg-event :dogfood/edit-draft
+  (fn [{:keys [db]} [_ k v]] {:db (assoc-in db [:drafts k] v)}))
+
+(rf/reg-event :dogfood/cancel
+  (fn [{:keys [db]} [_ k]] {:db (update db :drafts dissoc k)}))
+
+(rf/reg-event :dogfood/create
+  (fn [{:keys [db]} _]
+    (let [title (get-in db [:drafts new-draft-key] "")]
+      (if (= "" title)
+        {:db db}
+        (let [id (:next-id db)]
+          {:db (-> db
+                   (assoc-in [:todos id] {:id id :title title :done? false})
+                   (update :order conj id)
+                   (update :drafts dissoc new-draft-key)
+                   (assoc :next-id (inc id)))})))))
+
+(rf/reg-event :dogfood/commit
+  (fn [{:keys [db]} [_ id]]
+    (let [title (get-in db [:drafts id])]
+      (if (or (nil? title) (= "" title))
+        {:db db}
+        {:db (-> db (assoc-in [:todos id :title] title) (update :drafts dissoc id))}))))
+
+(rf/reg-event :dogfood/toggle
+  (fn [{:keys [db]} [_ id]] {:db (update-in db [:todos id :done?] not)}))
+
+(rf/reg-event :dogfood/remove
+  (fn [{:keys [db]} [_ id]]
+    {:db (-> db
+             (update :todos dissoc id)
+             (update :order (fn [o] (filterv #(not= id %) o)))
+             (update :drafts dissoc id))}))
+
+(rf/reg-event :dogfood/set-filter
+  (fn [{:keys [db]} [_ f]] {:db (assoc db :filter f)}))
+
+(rf/reg-event :dogfood/move
+  (fn [{:keys [db]} [_ id to]]
+    (let [without (filterv #(not= id %) (:order db))
+          to      (max 0 (min to (count without)))]
+      {:db (assoc db :order (into (conj (subvec without 0 to) id) (subvec without to)))})))
+
+;; ---------------------------------------------------------------------------
+;; The frame lifecycle
+;; ---------------------------------------------------------------------------
+
+(defn make-frame!
+  "Create (or idempotently replace) `frame-id`'s frame, seeded with `n`
+  to-dos. Runs outside any measured window."
+  [frame-id n]
+  (rf/make-frame {:id frame-id :initial-events [[:dogfood/seed n]]})
+  frame-id)
+
+(defn reseed!
+  "Return the frame to its seeded state, so one witness never measures a
+  page a previous one already mutated."
+  [frame-id n]
+  (rf/with-frame frame-id (rf/dispatch-sync [:dogfood/seed n]))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; The intents the three renderings all write
+;; ---------------------------------------------------------------------------
+
+(defn row-intents
+  "The event vectors a to-do row's markup carries, in the one spelling
+  all three renderings use. Returned as data so the three renderings
+  cannot drift on the events while claiming to differ only on the view."
+  [id]
+  {:on-click-toggle [:dogfood/toggle id]
+   :on-click-remove [:dogfood/remove id]
+   :on-input-title  [:dogfood/edit-draft id :re-frame.hicasso/value]
+   :on-key-down     {"Enter"  [:dogfood/commit id]
+                     "Escape" [:dogfood/cancel id]}})
+
+(defn new-item-intents
+  "The same, for the one controlled field at the head of the screen. The
+  submit intent carries no explicit prevent metadata, so it takes the
+  position's census-weighted default."
+  []
+  {:on-input    [:dogfood/edit-draft new-draft-key :re-frame.hicasso/value]
+   :on-submit   [:dogfood/create]
+   :on-key-down {"Enter"  [:dogfood/create]
+                 "Escape" [:dogfood/cancel new-draft-key]}})

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/dogfood_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/dogfood_cljs_test.cljs
@@ -1,0 +1,234 @@
+(ns re-frame.bench.hicasso.front.dogfood-cljs-test
+  "THE DOGFOOD STATE LAYER, and the front half composed end to end
+  (rf2-2rtt6.8).
+
+  Two things are being proved. First, that the events and subscriptions
+  the three renderings will share behave — which is worth its own tests
+  precisely because all three renderings depend on them and none of them
+  owns them. Second, and the reason this file is not merely a state
+  test: that the front half **composes**. An intent written in the
+  authoring spelling, lowered by the intent module through the codec's
+  prop walk, invoked as the browser would invoke it, reaches a real
+  re-frame2 event handler and moves a real app-db — and the index says
+  which boundary that write dirtied.
+
+  Nothing here mounts a screen. HD-014 starts the six-week clock at the
+  first Hicasso-arm commit that mounts the dogfood screen, and that
+  commit belongs to rf2-2rtt6.9 / rf2-2rtt6.10, not to this bead."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.bench.hicasso.front.sub-index :as idx]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private frame-id ::dogfood)
+
+(defn- seeded!
+  "A frame with `n` to-dos, and the index reset alongside it."
+  ([] (seeded! 3))
+  ([n]
+   (idx/reset-index!)
+   (dogfood/make-frame! frame-id n)
+   frame-id))
+
+(defn- read-sub [query]
+  (rf/with-frame frame-id (deref (rf/subscribe query))))
+
+(defn- send! [event]
+  (rf/with-frame frame-id (rf/dispatch-sync event))
+  nil)
+
+(defn- frame-dispatch
+  "The frame-locked dispatch a boundary would resolve once, from the
+  substrate's single internal context, and bind ambiently."
+  []
+  (fn [event] (send! event)))
+
+;; ---------------------------------------------------------------------------
+;; The shape
+;; ---------------------------------------------------------------------------
+
+(deftest the-seeded-shape-is-the-one-the-screen-is-written-against
+  (let [db (dogfood/seed-db 3)]
+    (is (= [0 1 2] (:order db)))
+    (is (= 3 (count (:todos db))))
+    (is (= {:id 1 :title "todo 1" :done? false} (get-in db [:todos 1])))
+    (is (= {} (:drafts db)))
+    (is (= :all (:filter db)))
+    (is (= 3 (:next-id db)))))
+
+(deftest the-subscriptions-read-what-the-screen-needs
+  (seeded! 3)
+  (is (= [0 1 2] (read-sub [:dogfood/visible-ids])))
+  (is (= 3 (read-sub [:dogfood/remaining])))
+  (is (= "todo 1" (:title (read-sub [:dogfood/todo 1]))))
+  (is (false? (read-sub [:dogfood/done? 1])))
+  (is (= "" (read-sub [:dogfood/draft 1])) "an untouched draft reads as empty, not nil")
+  (is (= :all (read-sub [:dogfood/filter]))))
+
+;; ---------------------------------------------------------------------------
+;; The write shapes that are also the bulk witnesses
+;; ---------------------------------------------------------------------------
+
+(deftest the-narrow-write-touches-one-row-and-the-header
+  (seeded! 3)
+  (send! [:dogfood/toggle 1])
+  (is (true? (read-sub [:dogfood/done? 1])))
+  (is (false? (read-sub [:dogfood/done? 0])))
+  (is (false? (read-sub [:dogfood/done? 2])))
+  (is (= 2 (read-sub [:dogfood/remaining])))
+  (is (= [0 1 2] (read-sub [:dogfood/visible-ids])) "under :all the list is unchanged"))
+
+(deftest the-broad-write-rebuilds-the-list
+  (seeded! 3)
+  (send! [:dogfood/toggle 1])
+  (send! [:dogfood/set-filter :active])
+  (is (= [0 2] (read-sub [:dogfood/visible-ids])))
+  (send! [:dogfood/set-filter :done])
+  (is (= [1] (read-sub [:dogfood/visible-ids])))
+  (send! [:dogfood/set-filter :all])
+  (is (= [0 1 2] (read-sub [:dogfood/visible-ids]))))
+
+(deftest keyed-insert-delete-and-reorder-move-the-order-and-nothing-else
+  (seeded! 3)
+  (testing "insert appends and mints the next id"
+    (send! [:dogfood/edit-draft dogfood/new-draft-key "milk"])
+    (send! [:dogfood/create])
+    (is (= [0 1 2 3] (read-sub [:dogfood/visible-ids])))
+    (is (= "milk" (:title (read-sub [:dogfood/todo 3])))))
+  (testing "delete removes the row and its draft"
+    (send! [:dogfood/edit-draft 1 "half-typed"])
+    (send! [:dogfood/remove 1])
+    (is (= [0 2 3] (read-sub [:dogfood/visible-ids])))
+    (is (nil? (read-sub [:dogfood/todo 1])))
+    (is (= "" (read-sub [:dogfood/draft 1]))))
+  (testing "reorder moves one id and preserves every other position"
+    (send! [:dogfood/move 3 0])
+    (is (= [3 0 2] (read-sub [:dogfood/visible-ids])))
+    (send! [:dogfood/move 3 2])
+    (is (= [0 2 3] (read-sub [:dogfood/visible-ids])))
+    (testing "an out-of-range target clamps rather than corrupting the list"
+      (send! [:dogfood/move 0 99])
+      (is (= [2 3 0] (read-sub [:dogfood/visible-ids]))))))
+
+;; ---------------------------------------------------------------------------
+;; Drafts — HD-009's claim, as code
+;; ---------------------------------------------------------------------------
+
+(deftest one-parametric-sub-and-named-events-serve-every-draft-instance
+  (seeded! 3)
+  (send! [:dogfood/edit-draft 0 "zero"])
+  (send! [:dogfood/edit-draft 2 "two"])
+  (send! [:dogfood/edit-draft dogfood/new-draft-key "new"])
+  (testing "three instances, one subscription"
+    (is (= "zero" (read-sub [:dogfood/draft 0])))
+    (is (= "two" (read-sub [:dogfood/draft 2])))
+    (is (= "new" (read-sub [:dogfood/draft dogfood/new-draft-key])))
+    (is (= "" (read-sub [:dogfood/draft 1])) "an instance nobody typed into"))
+  (testing "commit is by explicit caller revision, never by value equality"
+    (send! [:dogfood/commit 0])
+    (is (= "zero" (:title (read-sub [:dogfood/todo 0]))))
+    (is (= "" (read-sub [:dogfood/draft 0])) "and only then is the draft cleared"))
+  (testing "cancel discards without touching the to-do"
+    (send! [:dogfood/cancel 2])
+    (is (= "" (read-sub [:dogfood/draft 2])))
+    (is (= "todo 2" (:title (read-sub [:dogfood/todo 2]))))))
+
+(deftest an-empty-draft-creates-and-commits-nothing
+  (seeded! 3)
+  (send! [:dogfood/create])
+  (is (= [0 1 2] (read-sub [:dogfood/visible-ids])))
+  (send! [:dogfood/commit 1])
+  (is (= "todo 1" (:title (read-sub [:dogfood/todo 1])))))
+
+;; ---------------------------------------------------------------------------
+;; The front half, composed: authoring spelling → codec → browser → app-db
+;; ---------------------------------------------------------------------------
+
+(deftest a-lowered-intent-reaches-a-real-event-handler
+  (seeded! 3)
+  (let [row (dogfood/row-intents 1)
+        el  (intent/with-frame (frame-dispatch)
+                               (fn [] (codec/as-element
+                                       [:button {:on-click (:on-click-toggle row)} "toggle"])))
+        on-click (aget (.-props el) "onClick")]
+    (is (false? (read-sub [:dogfood/done? 1])))
+    (on-click #js {:target #js {}})
+    (is (true? (read-sub [:dogfood/done? 1])) "the click moved app-db")
+    (is (= 2 (read-sub [:dogfood/remaining])))))
+
+(deftest the-controlled-field-carries-its-value-through-the-marker
+  (seeded! 3)
+  (let [el (intent/with-frame (frame-dispatch)
+                              (fn [] (codec/as-element
+                                      [:input {:value (read-sub [:dogfood/draft dogfood/new-draft-key])
+                                               :on-input (:on-input (dogfood/new-item-intents))}])))
+        on-input (aget (.-props el) "onInput")]
+    (is (= "" (aget (.-props el) "value")))
+    (on-input #js {:target #js {:value "mi"}})
+    (is (= "mi" (read-sub [:dogfood/draft dogfood/new-draft-key])))
+    (on-input #js {:target #js {:value "milk"}})
+    (is (= "milk" (read-sub [:dogfood/draft dogfood/new-draft-key])))))
+
+(deftest the-form-submits-once-and-prevents-the-browsers-navigation
+  (seeded! 3)
+  (send! [:dogfood/edit-draft dogfood/new-draft-key "milk"])
+  (let [!prevented (atom false)
+        el (intent/with-frame (frame-dispatch)
+                              (fn [] (codec/as-element
+                                      [:form {:on-submit (:on-submit (dogfood/new-item-intents))}])))
+        on-submit (aget (.-props el) "onSubmit")]
+    (on-submit #js {:target #js {} :preventDefault (fn [] (reset! !prevented true))})
+    (is (true? @!prevented))
+    (is (= [0 1 2 3] (read-sub [:dogfood/visible-ids])))
+    (is (= "milk" (:title (read-sub [:dogfood/todo 3]))))
+    (is (= "" (read-sub [:dogfood/draft dogfood/new-draft-key])))))
+
+(deftest the-key-map-commits-on-enter-cancels-on-escape-and-is-silent-mid-composition
+  (seeded! 3)
+  (send! [:dogfood/edit-draft 1 "renamed"])
+  (let [el (intent/with-frame (frame-dispatch)
+                              (fn [] (codec/as-element
+                                      [:input {:on-key-down (:on-key-down (dogfood/row-intents 1))}])))
+        on-key-down (aget (.-props el) "onKeyDown")]
+    (testing "a composing Enter commits nothing"
+      (on-key-down #js {:key "Enter" :isComposing true :target #js {}})
+      (is (= "todo 1" (:title (read-sub [:dogfood/todo 1]))))
+      (is (= "renamed" (read-sub [:dogfood/draft 1])) "and the draft survives"))
+    (testing "a settled Enter commits"
+      (on-key-down #js {:key "Enter" :target #js {}})
+      (is (= "renamed" (:title (read-sub [:dogfood/todo 1])))))
+    (testing "Escape discards the next draft"
+      (send! [:dogfood/edit-draft 1 "second thoughts"])
+      (on-key-down #js {:key "Escape" :target #js {}})
+      (is (= "" (read-sub [:dogfood/draft 1])))
+      (is (= "renamed" (:title (read-sub [:dogfood/todo 1])))))))
+
+;; ---------------------------------------------------------------------------
+;; The index over the real screen's reads
+;; ---------------------------------------------------------------------------
+
+(deftest the-index-answers-the-screens-own-narrow-and-broad-writes
+  (seeded! 3)
+  (idx/mount! :header)
+  (idx/mount! :row-0)
+  (idx/mount! :row-1)
+  (idx/record-reads! :header #{[:dogfood/remaining] [:dogfood/visible-ids]})
+  (idx/record-reads! :row-0 #{[:dogfood/todo 0] [:dogfood/done? 0]})
+  (idx/record-reads! :row-1 #{[:dogfood/todo 1] [:dogfood/done? 1]})
+  (testing "the narrow write dirties the one row and the header that counts it"
+    (is (= #{:row-1 :header}
+           (idx/commit! #{[:dogfood/done? 1] [:dogfood/remaining]}))))
+  (testing "the broad write dirties every reader of the list"
+    (is (= #{:header} (idx/commit! #{[:dogfood/visible-ids]}))))
+  (testing "a to-do nobody has mounted a row for dirties nothing"
+    (is (= #{} (idx/commit! #{[:dogfood/todo 2]}))))
+  (testing "unmounting a row takes its edges with it"
+    (idx/unmount! :row-1)
+    (is (= #{} (idx/commit! #{[:dogfood/done? 1]})))
+    (is (= #{:header} (idx/commit! #{[:dogfood/remaining]})))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -1,0 +1,252 @@
+(ns re-frame.bench.hicasso.front.intent
+  "INTENT LOWERING — deliverable 3 of the Wave-1 shared front half
+  (rf2-2rtt6.8). Ergonomics-as-data: the author writes what should
+  happen, and the front half, not the author, turns it into the closure
+  the browser calls.
+
+      [:button {:on-click [:todo/toggle id]} \"done\"]
+      [:input  {:on-input [:todo.ui/edit id ::h/value]}]
+      [:form   {:on-submit [:todo/create]}]
+      [:input  {:on-key-down {\"Enter\"  [:todo/commit id]
+                              \"Escape\" [:todo.ui/cancel id]}}]
+
+  authoring.md's whole event surface, and nothing beyond it. Four
+  behaviours, dispatched on the *shape* of the value at an `on-*` prop
+  so that there is no roster of blessed prop names to keep in step with
+  the DOM:
+
+  | value      | lowered to |
+  |------------|------------|
+  | vector     | a closure dispatching that intent |
+  | map        | a composition-gated key-map |
+  | fn         | passed through untouched — ordinary functions stay legal |
+  | anything else | passed through untouched |
+
+  ## The frame, and why the closure closes over it
+
+  HD-020(a): a boundary resolves its frame **once**, from the substrate's
+  single internal context, and binds it ambiently for the render's
+  dynamic extent so inlined helpers and generated callbacks resolve it
+  without hooks of their own. [[*dispatch*]] is that ambient binding —
+  the frame-locked `dispatch` the substrate hands back for this
+  boundary's frame.
+
+  Lowering reads it **at lowering time**, during the render, and the
+  generated closure closes over the value. That is the load-bearing part:
+  the browser invokes these callbacks long after the render's dynamic
+  extent has unwound, and a closure that read an ambient binding *when
+  the click happened* would find nothing there. Reading it eagerly is
+  also the cheaper of the two — one read per lowered props map instead of
+  one per event.
+
+  A vector at an event position with no ambient frame is a loud error,
+  never a silently inert handler.
+
+  ## The marker roster and its one pure materializer
+
+  Two markers, both of which the ruled surface names:
+  `:re-frame.hicasso/value` (authoring.md's `::h/value`) and
+  `:re-frame.hicasso/checked` — the controlled pair HD-010's owned-literal
+  merge law and HD-019's controlled door both speak of. They are ordinary
+  qualified keywords; the namespace segment names the product namespace
+  HD-017 forbids *creating* before P2, which costs a keyword nothing.
+
+  [[materialize]] is the one pure materializer: it substitutes markers at
+  the intent vector's top level, which is the shape the corpus writes
+  (`[:todo.ui/edit id ::h/value]`), and does not walk nested structure —
+  a per-event deep walk to serve a shape nobody writes would be paid on
+  every keystroke of every controlled field.
+
+  **The static/dynamic split is decided once, at lowering time.** An
+  intent carrying no marker lowers to a closure that dispatches a vector
+  it already holds; only a marker-carrying intent pays a materialization
+  per event. Deciding this per render rather than per event is why the
+  controlled path costs one allocation per keystroke and the ordinary
+  button path costs none.
+
+  ## The policy defaults
+
+  - **`:on-submit` auto-prevents** (authoring.md, census-weighted). The
+    opt-out is metadata on the intent — `^{::h/prevent? false} [:ev]` —
+    which costs no new prop, no new spelling, and no second calling
+    convention. The same metadata opts *in* at any other event position,
+    so there is one mechanism rather than a default and an override.
+  - **The key-map is composition-gated, centrally.** A key event arriving
+    mid-composition commits nothing: `isComposing`, or the legacy
+    keyCode-229 signal that is all some IMEs on some browsers ever send.
+    authoring.md pins the case that must not fire — a composing Enter —
+    and the gate is written over the whole map rather than that one key,
+    because during composition every keystroke belongs to the IME and a
+    per-key exception list is a second place for the law to rot.
+  - Each key-map branch is lowered **once per render** into a plain map
+    of key-string → handler, so an event is one `.-key` lookup and no
+    allocation.
+
+  This namespace deliberately does not implement `route-link` (routing-
+  coupled, and outside this bead's three deliverables), `defhost`/`[:>]`
+  interop (HD-011, its own surface), or any controlled-value restore
+  (HD-019's door belongs to the arm that owns the DOM).")
+
+;; ---------------------------------------------------------------------------
+;; The ambient frame (HD-020(a))
+;; ---------------------------------------------------------------------------
+
+(def ^:dynamic *dispatch*
+  "The frame-locked `dispatch` for the boundary currently rendering,
+  bound for the render's dynamic extent. `nil` outside a render, which is
+  what makes an intent lowered outside a boundary a loud error."
+  nil)
+
+(defn with-frame
+  "Run `body-fn` with `dispatch` — the frame-locked dispatch resolved once
+  for this boundary — bound ambiently. An arm's boundary shell calls this
+  around the body."
+  [dispatch body-fn]
+  (binding [*dispatch* dispatch] (body-fn)))
+
+(defn- require-dispatch [intent]
+  (or *dispatch*
+      (throw (ex-info (str "Intent " (pr-str intent) " was lowered with no ambient frame; "
+                           "event vectors are only legal inside a boundary's render. "
+                           "[:rf.error/hicasso-intent-outside-boundary]")
+                      {:rf.error/id :rf.error/hicasso-intent-outside-boundary
+                       :where       'front.intent/lower-prop
+                       :reason      "No frame-locked dispatch is bound for this render."
+                       :recovery    :lower-intents-inside-a-boundary-render
+                       :intent      intent}))))
+
+;; ---------------------------------------------------------------------------
+;; The marker roster and its one pure materializer
+;; ---------------------------------------------------------------------------
+
+(def value-marker
+  "authoring.md's `::h/value` — the event target's current value."
+  :re-frame.hicasso/value)
+
+(def checked-marker
+  "`::h/checked` — the event target's current checked state."
+  :re-frame.hicasso/checked)
+
+(def prevent-key
+  "`::h/prevent?` — metadata on an intent vector, opting `.preventDefault`
+  in or out against the position's default."
+  :re-frame.hicasso/prevent?)
+
+(def ^:private marker-readers
+  "The roster, as marker → the reader that pulls its value off the event
+  target. A map rather than a chain of comparisons, because it is both
+  the roster and the dispatch — and because `identical?` is the wrong
+  test for keywords in ClojureScript: literals are shared constants only
+  when the build interns them, so an identity comparison that works under
+  `:advanced` silently fails in the test build."
+  {value-marker   (fn [target] (.-value target))
+   checked-marker (fn [target] (.-checked target))})
+
+(defn markers?
+  "Does this intent carry a marker at its top level? Answered once, at
+  lowering time, so the per-event path never asks."
+  [intent]
+  (boolean (some marker-readers intent)))
+
+(defn materialize
+  "THE ONE PURE MATERIALIZER. Substitute the markers in `intent` with
+  values pulled from the DOM event's target. Top level only — see the
+  namespace docstring."
+  [intent e]
+  (let [target (.-target e)]
+    (mapv (fn [x] (if-some [read-value (marker-readers x)] (read-value target) x))
+          intent)))
+
+;; ---------------------------------------------------------------------------
+;; The composition gate
+;; ---------------------------------------------------------------------------
+
+(defn composing?
+  "Is this key event part of an in-flight IME composition? `isComposing`
+  where the browser sets it, and the legacy keyCode-229 signal where it
+  is all the browser sends."
+  [e]
+  (or (true? (.-isComposing e))
+      (identical? 229 (.-keyCode e))))
+
+;; ---------------------------------------------------------------------------
+;; Lowering
+;; ---------------------------------------------------------------------------
+
+(def ^:private re-event-prop
+  "`:on-click` (the taught kebab spelling) or `:onClick` (the camel one a
+  migrating author writes). Two shapes, one rule, no roster of DOM event
+  names to maintain."
+  #"^on-[a-z]|^on[A-Z]")
+
+(defn event-prop?
+  "Is `k` an event position?"
+  [k]
+  (boolean (and (or (keyword? k) (string? k))
+                (re-find re-event-prop (name k)))))
+
+(defn- prevent-by-default? [k]
+  (let [n (name k)]
+    (or (= n "on-submit") (= n "onSubmit"))))
+
+(defn- prevent?
+  "Does the intent at `k` prevent the default action? The position's
+  default, overridden either way by `^{::h/prevent? …}` on the intent."
+  [k intent]
+  (let [m (meta intent)]
+    (if (contains? m prevent-key)
+      (boolean (get m prevent-key))
+      (prevent-by-default? k))))
+
+(defn- intent-handler
+  "Lower one intent vector into the closure the browser will call. The
+  three axes — prevent, markers, dispatch — are all resolved here, so the
+  event path is the shortest one this intent can have."
+  [k intent]
+  (let [dispatch (require-dispatch intent)
+        prevent  (prevent? k intent)
+        dynamic  (markers? intent)]
+    (cond
+      (and prevent dynamic)       (fn [e] (.preventDefault e) (dispatch (materialize intent e)))
+      prevent                     (fn [e] (.preventDefault e) (dispatch intent))
+      dynamic                     (fn [e] (dispatch (materialize intent e)))
+      :else                       (fn [_e] (dispatch intent)))))
+
+(defn- key-map-handler
+  "Lower a data key-map into one closure over a plain map of key-string →
+  handler. The map is built once per render; an event costs one
+  composition test and one lookup."
+  [k key-map]
+  (let [lowered (reduce-kv (fn [m key-name v]
+                             (assoc m key-name (cond
+                                                 (vector? v) (intent-handler k v)
+                                                 (fn? v)     v
+                                                 :else       nil)))
+                           {}
+                           key-map)]
+    (fn [e]
+      (when-not (composing? e)
+        (when-some [h (get lowered (.-key e))]
+          (h e))))))
+
+(defn lower-prop
+  "Lower one prop. Values at non-event positions, and non-lowerable values
+  at event positions, come back untouched — this is the identity function
+  for everything the surface does not claim."
+  [k v]
+  (if-not (event-prop? k)
+    v
+    (cond
+      (vector? v) (intent-handler k v)
+      (map? v)    (key-map-handler k v)
+      :else       v)))
+
+(defn lower-props
+  "Walk a props map once, lowering every event position. Returns the map
+  unchanged, by identity, when it holds nothing to lower — the ordinary
+  case for the great majority of elements on a page, and worth not
+  allocating for."
+  [props]
+  (if-not (some (fn [[k v]] (and (event-prop? k) (or (vector? v) (map? v)))) props)
+    props
+    (reduce-kv (fn [m k v] (assoc m k (lower-prop k v))) {} props)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent_cljs_test.cljs
@@ -1,0 +1,273 @@
+(ns re-frame.bench.hicasso.front.intent-cljs-test
+  "INTENT LOWERING, tested against the surface authoring.md declares
+  (rf2-2rtt6.8).
+
+  Every test drives the lowered closure with a stand-in event rather than
+  a real DOM one. That is not a shortcut: the closures take exactly three
+  things off an event — `preventDefault`, `.-target`, and the key/
+  composition signals — and a stand-in makes each of those observable,
+  which a real browser event does not. The browser's own behaviour on the
+  same closures is the arms' witness (validation.md's 100-cell grid), not
+  this file's."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.bench.hicasso.front.intent :as intent]))
+
+;; ---------------------------------------------------------------------------
+;; A recording dispatch, and stand-in events
+;; ---------------------------------------------------------------------------
+
+(defn- recorder [] (atom []))
+
+(defn- dispatching [!seen] (fn [event] (swap! !seen conj event) nil))
+
+(defn- ev
+  "A stand-in DOM event. `:value`/`:checked` become the target's fields;
+  `:key`, `:isComposing` and `:keyCode` sit on the event itself; the
+  `:prevented` atom records `preventDefault`."
+  [{:keys [value checked key composing? key-code prevented]}]
+  #js {:target        #js {:value value :checked checked}
+       :key           key
+       :isComposing   composing?
+       :keyCode       key-code
+       :preventDefault (fn [] (when prevented (reset! prevented true)) nil)})
+
+(defn- lowered
+  "Lower one prop with `dispatch` bound as the boundary's frame, and
+  return the closure — deliberately *outside* the binding, so every test
+  below exercises a callback the browser invokes after the render's
+  dynamic extent has unwound."
+  [dispatch k v]
+  (intent/with-frame dispatch (fn [] (intent/lower-prop k v))))
+
+;; ---------------------------------------------------------------------------
+;; Event vectors
+;; ---------------------------------------------------------------------------
+
+(deftest a-vector-at-an-event-position-becomes-a-dispatching-closure
+  (let [!seen (recorder)
+        h     (lowered (dispatching !seen) :on-click [:todo/toggle 7])]
+    (is (fn? h))
+    (is (= [] @!seen) "lowering dispatches nothing by itself")
+    (h (ev {}))
+    (is (= [[:todo/toggle 7]] @!seen))
+    (testing "the same closure is reusable and dispatches the same intent"
+      (h (ev {}))
+      (is (= [[:todo/toggle 7] [:todo/toggle 7]] @!seen)))))
+
+(deftest the-closure-closes-over-the-boundarys-frame
+  (testing "two boundaries lower the same intent to two different frames"
+    (let [!a (recorder)
+          !b (recorder)
+          ha (lowered (dispatching !a) :on-click [:ping])
+          hb (lowered (dispatching !b) :on-click [:ping])]
+      (ha (ev {}))
+      (hb (ev {}))
+      (is (= [[:ping]] @!a))
+      (is (= [[:ping]] @!b))))
+  (testing "and it still works with no ambient frame bound — the browser
+            calls it long after the render unwound"
+    (let [!seen (recorder)
+          h     (lowered (dispatching !seen) :on-click [:ping])]
+      (is (nil? intent/*dispatch*))
+      (h (ev {}))
+      (is (= [[:ping]] @!seen)))))
+
+(deftest an-intent-lowered-outside-a-boundary-is-a-loud-error
+  (is (nil? intent/*dispatch*))
+  (is (thrown-with-msg? js/Error #"no ambient frame"
+                        (intent/lower-prop :on-click [:ping])))
+  (testing "the error carries its id"
+    (try
+      (intent/lower-prop :on-click [:ping])
+      (is false "should have thrown")
+      (catch :default e
+        (is (= :rf.error/hicasso-intent-outside-boundary (:rf.error/id (ex-data e))))))))
+
+(deftest non-event-positions-and-non-intent-values-pass-through-untouched
+  (let [d (dispatching (recorder))]
+    (testing "a vector at a non-event position is data, not an intent"
+      (is (= [:a :b] (lowered d :data-path [:a :b]))))
+    (testing "an ordinary function at an event position stays legal"
+      (let [f (fn [_e] :called)]
+        (is (identical? f (lowered d :on-click f)))))
+    (testing "a string, a number and nil are left alone"
+      (is (= "x" (lowered d :on-click "x")))
+      (is (= 3 (lowered d :on-click 3)))
+      (is (nil? (lowered d :on-click nil))))))
+
+(deftest both-event-prop-spellings-are-recognised-and-nothing-else-is
+  (is (true? (intent/event-prop? :on-click)))
+  (is (true? (intent/event-prop? :on-key-down)))
+  (is (true? (intent/event-prop? :onClick)))
+  (is (false? (intent/event-prop? :online)) "a kebab-less word starting with `on`")
+  (is (false? (intent/event-prop? :class)))
+  (is (false? (intent/event-prop? :data-on-click)))
+  (is (false? (intent/event-prop? nil))))
+
+;; ---------------------------------------------------------------------------
+;; The value placeholder and the one pure materializer
+;; ---------------------------------------------------------------------------
+
+(deftest the-value-marker-is-replaced-with-the-targets-value
+  (let [!seen (recorder)
+        h     (lowered (dispatching !seen) :on-input
+                       [:todo.ui/edit 7 :re-frame.hicasso/value])]
+    (h (ev {:value "milk"}))
+    (h (ev {:value "bread"}))
+    (is (= [[:todo.ui/edit 7 "milk"] [:todo.ui/edit 7 "bread"]] @!seen)
+        "one intent, materialized fresh per event")))
+
+(deftest the-checked-marker-is-replaced-with-the-targets-checked-state
+  (let [!seen (recorder)
+        h     (lowered (dispatching !seen) :on-change
+                       [:todo/set-done 7 :re-frame.hicasso/checked])]
+    (h (ev {:checked true}))
+    (h (ev {:checked false}))
+    (is (= [[:todo/set-done 7 true] [:todo/set-done 7 false]] @!seen))))
+
+(deftest the-materializer-is-pure-and-positional
+  (testing "several markers in one intent all materialize"
+    (let [e (ev {:value "v" :checked true})]
+      (is (= [:e "v" true :tail]
+             (intent/materialize [:e :re-frame.hicasso/value :re-frame.hicasso/checked :tail] e)))))
+  (testing "an intent with no marker comes back with the same elements"
+    (let [e (ev {:value "v"})]
+      (is (= [:e 1 "two"] (intent/materialize [:e 1 "two"] e)))))
+  (testing "markers are substituted at the top level only — the documented shape"
+    (let [e (ev {:value "v"})]
+      (is (= [:e {:v :re-frame.hicasso/value}]
+             (intent/materialize [:e {:v :re-frame.hicasso/value}] e)))))
+  (testing "the static/dynamic split is decidable before any event exists"
+    (is (true? (intent/markers? [:e :re-frame.hicasso/value])))
+    (is (true? (intent/markers? [:e :re-frame.hicasso/checked])))
+    (is (false? (intent/markers? [:e 1 "two"])))))
+
+;; ---------------------------------------------------------------------------
+;; Submit auto-prevent, and the one metadata mechanism that overrides it
+;; ---------------------------------------------------------------------------
+
+(deftest on-submit-auto-prevents
+  (let [!seen (recorder)
+        !prevented (atom false)
+        h     (lowered (dispatching !seen) :on-submit [:todo/create])]
+    (h (ev {:prevented !prevented}))
+    (is (true? @!prevented) "the browser's navigation is prevented")
+    (is (= [[:todo/create]] @!seen) "and the intent still dispatches")))
+
+(deftest no-other-event-position-prevents-by-default
+  (let [!prevented (atom false)]
+    ((lowered (dispatching (recorder)) :on-click [:ping]) (ev {:prevented !prevented}))
+    (is (false? @!prevented))))
+
+(deftest prevent-metadata-overrides-the-positions-default-in-both-directions
+  (testing "opting out of the submit default"
+    (let [!seen (recorder)
+          !prevented (atom false)
+          h (lowered (dispatching !seen) :on-submit
+                     (with-meta [:todo/create] {:re-frame.hicasso/prevent? false}))]
+      (h (ev {:prevented !prevented}))
+      (is (false? @!prevented))
+      (is (= [[:todo/create]] @!seen))))
+  (testing "opting in anywhere else"
+    (let [!prevented (atom false)
+          h (lowered (dispatching (recorder)) :on-click
+                     (with-meta [:ping] {:re-frame.hicasso/prevent? true}))]
+      (h (ev {:prevented !prevented}))
+      (is (true? @!prevented))))
+  (testing "auto-prevent composes with the value marker"
+    (let [!seen (recorder)
+          !prevented (atom false)
+          h (lowered (dispatching !seen) :on-submit
+                     [:todo/create :re-frame.hicasso/value])]
+      (h (ev {:value "milk" :prevented !prevented}))
+      (is (true? @!prevented))
+      (is (= [[:todo/create "milk"]] @!seen)))))
+
+;; ---------------------------------------------------------------------------
+;; The composition-gated key-map
+;; ---------------------------------------------------------------------------
+
+(deftest a-map-at-an-event-position-becomes-a-key-map
+  (let [!seen (recorder)
+        h     (lowered (dispatching !seen) :on-key-down
+                       {"Enter"  [:todo/commit 7]
+                        "Escape" [:todo.ui/cancel 7]})]
+    (h (ev {:key "Enter"}))
+    (is (= [[:todo/commit 7]] @!seen))
+    (h (ev {:key "Escape"}))
+    (is (= [[:todo/commit 7] [:todo.ui/cancel 7]] @!seen))
+    (testing "an unlisted key commits nothing"
+      (h (ev {:key "a"}))
+      (h (ev {:key "Tab"}))
+      (is (= [[:todo/commit 7] [:todo.ui/cancel 7]] @!seen)))))
+
+(deftest a-composing-enter-commits-nothing
+  (testing "the isComposing signal"
+    (let [!seen (recorder)
+          h     (lowered (dispatching !seen) :on-key-down {"Enter" [:todo/commit 7]})]
+      (h (ev {:key "Enter" :composing? true}))
+      (is (= [] @!seen))
+      (h (ev {:key "Enter" :composing? false}))
+      (is (= [[:todo/commit 7]] @!seen) "and the same closure commits once composition ends")))
+  (testing "the legacy keyCode-229 signal, which is all some IMEs send"
+    (let [!seen (recorder)
+          h     (lowered (dispatching !seen) :on-key-down {"Enter" [:todo/commit 7]})]
+      (h (ev {:key "Enter" :key-code 229}))
+      (is (= [] @!seen))
+      (h (ev {:key "Enter" :key-code 13}))
+      (is (= [[:todo/commit 7]] @!seen))))
+  (testing "the gate is centralised over the whole map, not written per key"
+    (let [!seen (recorder)
+          h     (lowered (dispatching !seen) :on-key-down
+                         {"Enter" [:commit] "Escape" [:cancel]})]
+      (h (ev {:key "Escape" :composing? true}))
+      (is (= [] @!seen)))))
+
+(deftest key-map-branches-carry-the-full-intent-surface
+  (testing "a marker inside a key-map branch materializes"
+    (let [!seen (recorder)
+          h     (lowered (dispatching !seen) :on-key-down
+                         {"Enter" [:todo/commit :re-frame.hicasso/value]})]
+      (h (ev {:key "Enter" :value "milk"}))
+      (is (= [[:todo/commit "milk"]] @!seen))))
+  (testing "prevent metadata works inside a branch, and is off by default"
+    (let [!a (atom false)
+          !b (atom false)
+          h  (lowered (dispatching (recorder)) :on-key-down
+                      {"Enter"  (with-meta [:commit] {:re-frame.hicasso/prevent? true})
+                       "Escape" [:cancel]})]
+      (h (ev {:key "Enter" :prevented !a}))
+      (h (ev {:key "Escape" :prevented !b}))
+      (is (true? @!a))
+      (is (false? @!b))))
+  (testing "an ordinary function is a legal branch"
+    (let [!called (atom false)
+          h (lowered (dispatching (recorder)) :on-key-down
+                     {"Enter" (fn [_e] (reset! !called true))})]
+      (h (ev {:key "Enter"}))
+      (is (true? @!called)))))
+
+(deftest the-composition-predicate-reads-both-signals
+  (is (true? (intent/composing? (ev {:composing? true}))))
+  (is (true? (intent/composing? (ev {:key-code 229}))))
+  (is (false? (intent/composing? (ev {:key-code 13}))))
+  (is (false? (intent/composing? (ev {})))))
+
+;; ---------------------------------------------------------------------------
+;; The whole-map door
+;; ---------------------------------------------------------------------------
+
+(deftest lower-props-walks-a-map-once-and-does-not-allocate-when-there-is-nothing-to-do
+  (let [!seen (recorder)]
+    (testing "a props map with nothing to lower comes back by identity"
+      (let [props {:class "row" :data-index 3 :on-click (fn [_])}]
+        (is (identical? props (intent/with-frame (dispatching !seen)
+                                                 (fn [] (intent/lower-props props)))))))
+    (testing "a props map with an intent comes back lowered, everything else intact"
+      (let [props    {:class "row" :data-index 3 :on-click [:touch 3]}
+            lowered' (intent/with-frame (dispatching !seen) (fn [] (intent/lower-props props)))]
+        (is (= "row" (:class lowered')))
+        (is (= 3 (:data-index lowered')))
+        (is (fn? (:on-click lowered')))
+        ((:on-click lowered') (ev {}))
+        (is (= [[:touch 3]] @!seen))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index.cljs
@@ -1,0 +1,256 @@
+(ns re-frame.bench.hicasso.front.sub-index
+  "THE SUBSCRIPTION→BOUNDARY INDEX — deliverable 2 of the Wave-1 shared
+  front half (rf2-2rtt6.8), graduated out of the local `spike-01` pure
+  model into the tracked bench/test tree as HD-017 directs.
+
+  ## What it is
+
+  One question, answered in one place: *given the set of subscription
+  keys a commit dirtied, which boundaries must re-run?* Everything else
+  in this namespace exists to keep that answer correct as boundaries
+  mount, read, re-run with a different read set, and unmount.
+
+  The index is **global maps, not reactions**. Two maps and a set live in
+  a single atom:
+
+      :sub->bs   sub-key      -> #{boundary-id}    the reverse edges
+      :b->subs   boundary-id  -> #{sub-key}        the forward edges
+      :live      #{boundary-id}                    mounted boundaries
+
+  Shared structure, not per-boundary object fan-out. A boundary's
+  membership in the index is one entry in `:b->subs`, one entry in
+  `:live`, and one membership per edge in `:sub->bs` — there is no
+  per-boundary reaction, watcher, or cell here, and a ViewCell-class
+  object graph appearing in this file is the explicit failure marker for
+  the whole programme (architecture.md, Arm 1).
+
+  **Nothing in here is reactive.** The index does not watch, subscribe,
+  schedule, or notify. It is a pure function of the edges it has been
+  told about, and *only the commit applies the dirty set* — [[commit!]]
+  is the single door through which a dirty sub-key set becomes a dirty
+  boundary set.
+
+  ## The six laws
+
+  architecture.md restates the six laws the spike-01 model proved, and
+  they are the acceptance criteria for this namespace. Each has a test
+  of its own in `sub_index_laws_cljs_test.cljs`, named for its number:
+
+    1. after mount+read, a commit of that sub dirties that boundary only;
+    2. two boundaries sharing a sub both dirty;
+    3. unmount removes edges;
+    4. a re-run with fewer reads drops edges (the conditional read);
+    5. the broad dirty set is the union of all readers of any dirty sub;
+    6. an unknown dirty sub yields the empty set — no phantom boundaries.
+
+  ## Two things this adds to the spike model, and why
+
+  The spike was a paper proof of the algebra and threaded its state by
+  hand. Two behaviours a runtime needs were therefore never expressed,
+  and both are leak classes rather than conveniences:
+
+  - **[[record-reads]] ignores a boundary that is not live.** React can
+    abandon a render, and an abandoned render's reads must not resurrect
+    the edges [[unmount]] just removed. Without the guard law 3 holds
+    only until the next stale body run, which is exactly the class
+    HD-002's adjudication clause (a) asks a read mechanism to answer for.
+    With it, unmount is final.
+  - **[[mount]] is idempotent.** StrictMode mounts twice and HMR
+    remounts; neither may clear the edges an already-live boundary has
+    recorded. (The spike had this right already; it is restated here
+    because it is load-bearing and one `contains?` away from being lost.)
+
+  ## Sub-key identity
+
+  A sub-key is the query vector itself — `(query-id, args)` under
+  ordinary value equality, so `[:todo/by-id 7]` and `[:todo/by-id 7]`
+  are one key and `[:todo/by-id 8]` is another. Framework-shaped keys
+  with map args work by the same rule and are tested. Value-unstable map
+  args thrash the index; that is documented and programmer-trusted
+  (validation.md), not defended against here.
+
+  ## The evidence sink (HD-005)
+
+  Three lines — a holder, a setter, and a nil-checked emit — so dev
+  tooling can attach to the dependency index later with no redesign.
+  Detached cost is one deref and one nil test at each of the two tap
+  points. **No evidence subsystem ships**: there is no manifest, no
+  registry, no buffering, and the sink is nil until something sets it."
+  (:require [clojure.set :as set]))
+
+;; ---------------------------------------------------------------------------
+;; The evidence sink seam (HD-005)
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !evidence-sink (atom nil))
+(defn set-evidence-sink! "Attach (or with nil, detach) the evidence sink." [f] (reset! !evidence-sink f) nil)
+(defn- evidence! [event] (when-some [sink @!evidence-sink] (sink event)) nil)
+
+;; ---------------------------------------------------------------------------
+;; The pure algebra — an index is a value; every op returns the next value
+;; ---------------------------------------------------------------------------
+
+(defn empty-index
+  "A fresh, empty index value."
+  []
+  {:sub->bs {}
+   :b->subs {}
+   :live    #{}})
+
+(defn mount
+  "Register `boundary-id` as live. Idempotent: a boundary already in the
+  index keeps the edges it has recorded, because StrictMode mounts a
+  boundary twice and HMR remounts it, and neither event means its reads
+  went away."
+  [idx boundary-id]
+  (cond-> (update idx :live conj boundary-id)
+    (not (contains? (:b->subs idx) boundary-id))
+    (assoc-in [:b->subs boundary-id] #{})))
+
+(defn- drop-edges
+  "Remove `boundary-id` from the reverse edges of every key in `sub-keys`,
+  dropping a key entirely once its reader set empties — an index that
+  retained empty sets would grow without bound across a long session."
+  [sub->bs boundary-id sub-keys]
+  (reduce (fn [m sub-key]
+            (let [readers (disj (get m sub-key #{}) boundary-id)]
+              (if (seq readers)
+                (assoc m sub-key readers)
+                (dissoc m sub-key))))
+          sub->bs
+          sub-keys))
+
+(defn unmount
+  "Drop `boundary-id` and every edge it holds. After this the boundary is
+  not live, holds no forward edges, and appears in no key's reader set —
+  law 3, and the standing zero-leaked-refcounts assertion depends on it."
+  [idx boundary-id]
+  (-> idx
+      (update :sub->bs drop-edges boundary-id (get-in idx [:b->subs boundary-id] #{}))
+      (update :b->subs dissoc boundary-id)
+      (update :live disj boundary-id)))
+
+(defn record-reads
+  "Replace `boundary-id`'s edge set with the sub-keys its body just read.
+
+  This is the whole of the edge maintenance: the difference against the
+  previous set is added, the difference the other way is dropped, and an
+  unchanged read set touches nothing — which is what makes law 4 (the
+  conditional read) an edge-set diff rather than a bookkeeping ledger.
+
+  A boundary that is not live is ignored. See the namespace docstring:
+  an abandoned render must not resurrect an unmounted boundary's edges."
+  [idx boundary-id read-sub-keys]
+  (if-not (contains? (:live idx) boundary-id)
+    idx
+    (let [reads   (set read-sub-keys)
+          held    (get-in idx [:b->subs boundary-id] #{})
+          dropped (set/difference held reads)
+          added   (set/difference reads held)]
+      (-> idx
+          (update :sub->bs drop-edges boundary-id dropped)
+          (update :sub->bs
+                  (fn [m] (reduce (fn [m sub-key] (update m sub-key (fnil conj #{}) boundary-id))
+                                  m
+                                  added)))
+          (assoc-in [:b->subs boundary-id] reads)))))
+
+(defn dirty-boundaries
+  "The set of boundaries that must re-run, given the sub-keys a commit
+  dirtied. The union of every dirty key's reader set — law 5 — and an
+  unknown key contributes nothing, so the answer for a key nobody reads
+  is the empty set and never a phantom boundary (law 6)."
+  [idx dirty-sub-keys]
+  (reduce (fn [acc sub-key] (into acc (get (:sub->bs idx) sub-key)))
+          #{}
+          dirty-sub-keys))
+
+(defn edges-of
+  "The sub-keys `boundary-id` currently reads."
+  [idx boundary-id]
+  (get-in idx [:b->subs boundary-id] #{}))
+
+(defn readers-of
+  "The boundaries currently reading `sub-key`."
+  [idx sub-key]
+  (get (:sub->bs idx) sub-key #{}))
+
+(defn live?
+  "Is `boundary-id` mounted?"
+  [idx boundary-id]
+  (contains? (:live idx) boundary-id))
+
+;; ---------------------------------------------------------------------------
+;; The global index — one atom, the runtime's door
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !index (atom (empty-index)))
+
+(defn snapshot
+  "The current index value. For tests and for the evidence seam's
+  consumers; the runtime never reads it."
+  []
+  @!index)
+
+(defn reset-index!
+  "Drop every boundary and every edge. Test-fixture and root-teardown door."
+  []
+  (reset! !index (empty-index))
+  nil)
+
+(defn mount! [boundary-id] (swap! !index mount boundary-id) nil)
+
+(defn unmount! [boundary-id] (swap! !index unmount boundary-id) nil)
+
+(defn record-reads!
+  "Apply this render's read set for `boundary-id` and emit the edge
+  change on the evidence seam."
+  [boundary-id read-sub-keys]
+  (let [before (:b->subs @!index)
+        after  (:b->subs (swap! !index record-reads boundary-id read-sub-keys))
+        held   (get before boundary-id #{})
+        reads  (get after boundary-id #{})]
+    (when (not= held reads)
+      (evidence! {:event   :edges-changed
+                  :boundary boundary-id
+                  :added   (set/difference reads held)
+                  :dropped (set/difference held reads)}))
+    nil))
+
+(defn commit!
+  "**The only door through which a commit becomes re-render work.** Given
+  the sub-keys this commit dirtied, return the set of boundaries to
+  re-run. Reads the index; never mutates it."
+  [dirty-sub-keys]
+  (let [dirty (dirty-boundaries @!index dirty-sub-keys)]
+    (evidence! {:event :commit :dirty-subs (set dirty-sub-keys) :dirty-boundaries dirty})
+    dirty))
+
+;; ---------------------------------------------------------------------------
+;; The read collector — how a body's reads reach [[record-reads!]]
+;; ---------------------------------------------------------------------------
+
+(def ^:dynamic *collector*
+  "Bound to a transient-free mutable set for the dynamic extent of one
+  boundary body. `nil` outside a render, which is what makes a read
+  outside a render detectable rather than silently indexed."
+  nil)
+
+(defn read!
+  "Record that the running body read `sub-key`. The value is the sub
+  layer's business; this records the edge only."
+  [sub-key]
+  (when-some [c *collector*] (vswap! c conj sub-key))
+  nil)
+
+(defn with-reads
+  "Run `body-fn` with a fresh collector bound, apply the reads it made to
+  `boundary-id`, and return `[result reads]`. This is the front half's
+  read-collection shape; an arm's boundary shell calls it once per
+  render."
+  [boundary-id body-fn]
+  (let [c (volatile! #{})
+        result (binding [*collector* c] (body-fn))
+        reads @c]
+    (record-reads! boundary-id reads)
+    [result reads]))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index_laws_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index_laws_cljs_test.cljs
@@ -1,0 +1,269 @@
+(ns re-frame.bench.hicasso.front.sub-index-laws-cljs-test
+  "THE SIX INDEX LAWS, as tests (rf2-2rtt6.8).
+
+  architecture.md restates six laws the local `spike-01` pure model
+  proved, and HD-017 says the model graduates into the tracked bench/test
+  tree *with its six-law algebra as the index's unit tests*. This file is
+  that graduation. Each law gets one `deftest` named for its number, and
+  each is written so that breaking the mechanism it names turns that test
+  red and — as far as the algebra allows — leaves its five siblings
+  green, because a law whose failure is indistinguishable from another
+  law's failure is not being tested separately.
+
+  The laws, verbatim from architecture.md:
+
+    1. after mount+read, a commit of that sub dirties that boundary only;
+    2. two boundaries sharing a sub both dirty;
+    3. unmount removes edges;
+    4. a re-run with fewer reads drops edges (conditional read);
+    5. the broad dirty set is the union of all readers of any dirty sub;
+    6. an unknown dirty sub yields the empty set — no phantom boundaries.
+
+  Below the six sit the tests for what a runtime needs beyond the paper
+  algebra: sub-key identity under value equality, the abandoned-render
+  guard, mount idempotence, the global-atom door, and the HD-005 evidence
+  seam. Those are not laws and do not pretend to be; they are the
+  obligations the laws would silently lose without them.
+
+  Everything here is a pure-value test against the algebra in
+  [[re-frame.bench.hicasso.front.sub-index]] except the last two groups,
+  which drive the global atom and are wrapped in a fixture that resets
+  it — the index is process-global by design (global maps, not
+  reactions), and a consolidated node-test bundle shares one process."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.bench.hicasso.front.sub-index :as idx]))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures and fixtures-free helpers
+;; ---------------------------------------------------------------------------
+
+(use-fixtures :each
+  {:before (fn [] (idx/reset-index!) (idx/set-evidence-sink! nil))
+   :after  (fn [] (idx/reset-index!) (idx/set-evidence-sink! nil))})
+
+(defn- run
+  "Mount `boundary-id` if it is not already live, then apply one body run
+  that read `sub-keys`. The pure-value counterpart of one render."
+  [index boundary-id & sub-keys]
+  (-> index
+      (idx/mount boundary-id)
+      (idx/record-reads boundary-id (set sub-keys))))
+
+;; ===========================================================================
+;; LAW 1 — after mount+read, a commit of that sub dirties that boundary only
+;; ===========================================================================
+
+(deftest law-1-a-committed-sub-dirties-its-own-reader-only
+  (let [index (-> (idx/empty-index)
+                  (run :row-1 [:todo/by-id 1] [:todo.ui/editing? 1])
+                  (run :row-2 [:todo/by-id 2])
+                  (run :header [:cart/count]))]
+    (testing "the reader of the dirty sub is dirty"
+      (is (= #{:row-1} (idx/dirty-boundaries index #{[:todo/by-id 1]}))))
+    (testing "and nobody else is — not the sibling row, not the header"
+      (is (= #{:row-2} (idx/dirty-boundaries index #{[:todo/by-id 2]})))
+      (is (= #{:header} (idx/dirty-boundaries index #{[:cart/count]}))))
+    (testing "a boundary's second read is an independent edge, not a merge"
+      (is (= #{:row-1} (idx/dirty-boundaries index #{[:todo.ui/editing? 1]}))))))
+
+;; ===========================================================================
+;; LAW 2 — two boundaries sharing a sub both dirty
+;; ===========================================================================
+
+(deftest law-2-a-shared-sub-dirties-every-sharer
+  (let [index (-> (idx/empty-index)
+                  (run :a [:cart/count])
+                  (run :b [:cart/count])
+                  (run :c [:cart/count] [:user/name]))]
+    (testing "every reader of the shared key, and only them"
+      (is (= #{:a :b :c} (idx/dirty-boundaries index #{[:cart/count]})))
+      (is (= #{:a :b :c} (idx/readers-of index [:cart/count]))))
+    (testing "a key one of them additionally reads dirties only that one"
+      (is (= #{:c} (idx/dirty-boundaries index #{[:user/name]}))))))
+
+;; ===========================================================================
+;; LAW 3 — unmount removes edges
+;; ===========================================================================
+
+(deftest law-3-unmount-removes-every-edge-the-boundary-held
+  (let [index (-> (idx/empty-index)
+                  (run :gone [:x] [:y])
+                  (run :stay [:x]))
+        after (idx/unmount index :gone)]
+    (testing "the shared key keeps the survivor and loses the departed"
+      (is (= #{:stay} (idx/dirty-boundaries after #{[:x]}))))
+    (testing "the key only the departed read is gone from the index entirely"
+      (is (= #{} (idx/dirty-boundaries after #{[:y]})))
+      (is (not (contains? (:sub->bs after) [:y]))
+          "an emptied reader set is dropped, not retained as an empty set"))
+    (testing "the departed holds no forward edges and is not live"
+      (is (= #{} (idx/edges-of after :gone)))
+      (is (false? (idx/live? after :gone)))
+      (is (true? (idx/live? after :stay))))))
+
+;; ===========================================================================
+;; LAW 4 — a re-run with fewer reads drops edges (the conditional read)
+;; ===========================================================================
+
+(deftest law-4-a-rerun-with-fewer-reads-drops-the-edges-it-stopped-reading
+  (let [index  (-> (idx/empty-index) (run :b [:a] [:b]))
+        narrow (idx/record-reads index :b #{[:a]})]
+    (testing "the edge the second run did not read is dropped"
+      (is (= #{[:a]} (idx/edges-of narrow :b)))
+      (is (= #{} (idx/dirty-boundaries narrow #{[:b]}))))
+    (testing "the edge it did read survives untouched"
+      (is (= #{:b} (idx/dirty-boundaries narrow #{[:a]}))))
+    (testing "and a third run that reads it again restores the edge"
+      (let [wide (idx/record-reads narrow :b #{[:a] [:b]})]
+        (is (= #{[:a] [:b]} (idx/edges-of wide :b)))
+        (is (= #{:b} (idx/dirty-boundaries wide #{[:b]})))))
+    (testing "a re-run that reads nothing leaves the boundary live with no edges"
+      (let [silent (idx/record-reads index :b #{})]
+        (is (= #{} (idx/edges-of silent :b)))
+        (is (true? (idx/live? silent :b)))
+        (is (= #{} (idx/dirty-boundaries silent #{[:a] [:b]})))))))
+
+;; ===========================================================================
+;; LAW 5 — the broad dirty set is the union of all readers of any dirty sub
+;; ===========================================================================
+
+(deftest law-5-the-broad-dirty-set-is-the-union-of-the-readers
+  (let [index (-> (idx/empty-index)
+                  (run :r1 [:todo/by-id 1] [:cart/count])
+                  (run :r2 [:todo/by-id 2])
+                  (run :hdr [:cart/count]))]
+    (testing "the union across three keys, counted once each"
+      (is (= #{:r1 :r2 :hdr}
+             (idx/dirty-boundaries index #{[:todo/by-id 1] [:todo/by-id 2] [:cart/count]}))))
+    (testing "a two-key commit is the union of exactly those two reader sets"
+      (is (= #{:r1 :hdr} (idx/dirty-boundaries index #{[:cart/count]})))
+      (is (= #{:r1 :r2} (idx/dirty-boundaries index #{[:todo/by-id 1] [:todo/by-id 2]}))))
+    (testing "an overlapping commit does not double-count its overlap"
+      (is (= #{:r1 :hdr} (idx/dirty-boundaries index #{[:todo/by-id 1] [:cart/count]}))))
+    (testing "the empty commit dirties nothing"
+      (is (= #{} (idx/dirty-boundaries index #{}))))))
+
+;; ===========================================================================
+;; LAW 6 — an unknown dirty sub yields the empty set; no phantom boundaries
+;; ===========================================================================
+
+(deftest law-6-an-unknown-dirty-sub-yields-the-empty-set
+  (let [index (-> (idx/empty-index) (run :row-1 [:todo/by-id 1]))]
+    (testing "a key nobody reads contributes nothing"
+      (is (= #{} (idx/dirty-boundaries index #{[:todo/by-id 99]})))
+      (is (= #{} (idx/readers-of index [:todo/by-id 99]))))
+    (testing "an unknown key mixed into a known commit adds no phantom"
+      (is (= #{:row-1} (idx/dirty-boundaries index #{[:todo/by-id 1] [:todo/by-id 99]}))))
+    (testing "a commit made entirely of unknown keys is empty, not everything"
+      (is (= #{} (idx/dirty-boundaries index #{[:nope] [:also/nope] [:never]}))))
+    (testing "and the unknown key is not interned into the index by asking"
+      (idx/dirty-boundaries index #{[:todo/by-id 99]})
+      (is (not (contains? (:sub->bs index) [:todo/by-id 99]))))))
+
+;; ===========================================================================
+;; Beyond the six — the obligations the laws would silently lose
+;; ===========================================================================
+
+(deftest sub-key-identity-is-value-equality-over-query-and-args
+  (testing "same query-id, same args — one key, however it was constructed"
+    (let [index (-> (idx/empty-index) (run :row-7 [:todo/by-id 7]))]
+      (is (= #{:row-7} (idx/dirty-boundaries index #{(vec [:todo/by-id (+ 3 4)])})))))
+  (testing "same query-id, different args — different keys"
+    (let [index (-> (idx/empty-index) (run :row-7 [:todo/by-id 7]))]
+      (is (= #{} (idx/dirty-boundaries index #{[:todo/by-id 8]})))))
+  (testing "framework-shaped keys with map args obey the same rule"
+    (let [index (-> (idx/empty-index) (run :fav [:rf/mutation {:instance [:fav "slug"]}]))]
+      (is (= #{:fav} (idx/dirty-boundaries index #{[:rf/mutation {:instance [:fav "slug"]}]})))
+      (is (= #{} (idx/dirty-boundaries index #{[:rf/mutation {:instance [:fav "other"]}]}))))))
+
+(deftest an-abandoned-renders-reads-do-not-resurrect-an-unmounted-boundary
+  (testing "record-reads on a boundary that is not live is a no-op"
+    (let [index (-> (idx/empty-index) (run :b [:x]) (idx/unmount :b))
+          stale (idx/record-reads index :b #{[:x] [:y]})]
+      (is (= index stale) "the index value is untouched")
+      (is (= #{} (idx/dirty-boundaries stale #{[:x] [:y]})))
+      (is (false? (idx/live? stale :b)))))
+  (testing "a boundary never mounted at all cannot record edges either"
+    (let [index (idx/record-reads (idx/empty-index) :never-mounted #{[:x]})]
+      (is (= #{} (idx/dirty-boundaries index #{[:x]}))))))
+
+(deftest mount-is-idempotent-and-does-not-clear-recorded-edges
+  (testing "StrictMode's second mount keeps the first mount's reads"
+    (let [index (-> (idx/empty-index) (run :b [:x]) (idx/mount :b))]
+      (is (= #{[:x]} (idx/edges-of index :b)))
+      (is (= #{:b} (idx/dirty-boundaries index #{[:x]})))))
+  (testing "a remount after unmount starts clean"
+    (let [index (-> (idx/empty-index) (run :b [:x]) (idx/unmount :b) (idx/mount :b))]
+      (is (= #{} (idx/edges-of index :b)))
+      (is (true? (idx/live? index :b))))))
+
+(deftest the-global-index-is-one-atom-and-commit-is-its-only-door
+  (idx/mount! :a)
+  (idx/mount! :b)
+  (idx/record-reads! :a #{[:shared] [:only-a]})
+  (idx/record-reads! :b #{[:shared]})
+  (testing "commit! answers the same question the pure algebra does"
+    (is (= #{:a :b} (idx/commit! #{[:shared]})))
+    (is (= #{:a} (idx/commit! #{[:only-a]})))
+    (is (= #{} (idx/commit! #{[:unknown]}))))
+  (testing "commit! reads the index and never mutates it"
+    (let [before (idx/snapshot)]
+      (idx/commit! #{[:shared] [:unknown]})
+      (is (= before (idx/snapshot)))))
+  (testing "unmount! through the global door drops the edges too"
+    (idx/unmount! :a)
+    (is (= #{:b} (idx/commit! #{[:shared]})))
+    (is (= #{} (idx/commit! #{[:only-a]})))))
+
+(deftest with-reads-collects-a-bodys-reads-and-applies-them
+  (idx/mount! :b)
+  (testing "the body's return value comes back, and its reads become edges"
+    (let [[result reads] (idx/with-reads :b (fn []
+                                              (idx/read! [:a])
+                                              (idx/read! [:b])
+                                              :hiccup))]
+      (is (= :hiccup result))
+      (is (= #{[:a] [:b]} reads))
+      (is (= #{:b} (idx/commit! #{[:a]})))))
+  (testing "a second body run with fewer reads drops the edge — law 4, live"
+    (idx/with-reads :b (fn [] (idx/read! [:a])))
+    (is (= #{} (idx/commit! #{[:b]})))
+    (is (= #{:b} (idx/commit! #{[:a]}))))
+  (testing "outside a body the collector is nil and a read indexes nothing"
+    (is (nil? idx/*collector*))
+    (idx/read! [:stray])
+    (is (= #{} (idx/commit! #{[:stray]})))))
+
+;; ---------------------------------------------------------------------------
+;; HD-005 — the evidence seam is three lines, nil by default, and silent
+;; ---------------------------------------------------------------------------
+
+(deftest the-evidence-seam-is-detached-by-default-and-attachable-without-redesign
+  (testing "with no sink attached the index does its work and says nothing"
+    (idx/mount! :a)
+    (idx/record-reads! :a #{[:x]})
+    (is (= #{:a} (idx/commit! #{[:x]}))))
+  (testing "an attached sink sees the edge change and the commit"
+    (let [seen (atom [])]
+      (idx/set-evidence-sink! (fn [ev] (swap! seen conj ev)))
+      (idx/mount! :b)
+      (idx/record-reads! :b #{[:x] [:y]})
+      (idx/commit! #{[:x]})
+      (is (= [{:event :edges-changed :boundary :b :added #{[:x] [:y]} :dropped #{}}
+              {:event :commit :dirty-subs #{[:x]} :dirty-boundaries #{:a :b}}]
+             @seen))))
+  (testing "an unchanged read set emits nothing — the seam reports change, not traffic"
+    (let [seen (atom [])]
+      (idx/mount! :c)
+      (idx/record-reads! :c #{[:z]})
+      (idx/set-evidence-sink! (fn [ev] (swap! seen conj ev)))
+      (idx/record-reads! :c #{[:z]})
+      (is (= [] @seen))))
+  (testing "detaching restores silence"
+    (let [seen (atom [])]
+      (idx/set-evidence-sink! (fn [ev] (swap! seen conj ev)))
+      (idx/set-evidence-sink! nil)
+      (idx/mount! :d)
+      (idx/record-reads! :d #{[:q]})
+      (idx/commit! #{[:q]})
+      (is (= [] @seen)))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/witnesses.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/witnesses.cljs
@@ -1,0 +1,172 @@
+(ns re-frame.bench.hicasso.front.witnesses
+  "THE WITNESS SET, as data (rf2-2rtt6.8).
+
+  validation.md §P1 pins one measurement discipline above all others:
+  *same React version, build settings, tree, frame, queries, writes, and
+  data across arms*. Two arms enumerating the witness set from two
+  hand-written lists satisfies that on the day it is written and stops
+  satisfying it the first time one list gains a row. So the set is
+  declared once, here, as data — and each arm reads the roster rather
+  than restating it.
+
+  This namespace holds **no runtime and mounts nothing**. It is the
+  roster, the two scaling curves computed from their stated bounds, and
+  the shape parameters an arm needs to build a page. What each arm does
+  with a row is the arm's business; *which rows exist* is not.
+
+  ## The families
+
+  Each row names the family it belongs to, because the red-zone ratios
+  are set per family, before candidate results are opened (validation.md
+  §The bar), and a row whose family is implicit is a row whose gate is
+  implicit.
+
+  ## Reading a row
+
+      :id        the stable identifier an arm's result rows cite
+      :family    the red-zone family this row is gated under
+      :what      one sentence, in the voice a result table can print
+      :shape     the parameters an arm needs to build the page
+      :asserts   what must be true regardless of the clock
+      :gates     the budget or kill-criterion rows this witness feeds
+
+  `:asserts` is the half that does not depend on a number, and it is
+  first-class here for the reason validation.md gives: a candidate that
+  is fast and wrong has failed, and the assertions are what say so."
+  (:require [clojure.set :as set]))
+
+;; ---------------------------------------------------------------------------
+;; The two scaling curves, separated (validation.md §Witness set)
+;; ---------------------------------------------------------------------------
+
+(def reads-per-boundary
+  "The 1/3/7/20 ladder. Seven is the census's archetype and the number
+  HD-020's ≤2-hook budget is argued against; twenty is the stress rung."
+  [1 3 7 20])
+
+(def boundary-counts
+  "The bulk sizes validation.md names — 100 and 300 — plus the small rung
+  that makes a mount figure legible next to them."
+  [10 100 300])
+
+(def fixed-reads-curve
+  "**Fixed reads × growing boundaries.** One read per boundary, the
+  boundary count growing. Isolates the per-boundary cost."
+  (mapv (fn [n] {:boundaries n :reads 1}) boundary-counts))
+
+(def fixed-boundaries-curve
+  "**Fixed boundaries × growing reads.** One hundred boundaries, the read
+  count growing across the ladder. Isolates the per-read cost.
+
+  The heap ladder is measured with **distinct queries per boundary**
+  (Q = E), which rf2-2rtt6.16 established as the mandatory worst case:
+  a candidate must not be able to pass the shell budget by amortising one
+  subscription set across four roots."
+  (mapv (fn [r] {:boundaries 100 :reads r :distinct-queries? true}) reads-per-boundary))
+
+;; ---------------------------------------------------------------------------
+;; The roster
+;; ---------------------------------------------------------------------------
+
+(def witnesses
+  "Every witness validation.md §Witness set names, in declaration order."
+  [{:id      :bulk/one-commit
+    :family  :bulk
+    :what    "300 boundaries, one commit, the whole page dirty"
+    :shape   {:boundaries 300 :reads 1 :write :broad}
+    :asserts [:every-boundary-re-ran :dom-matches-the-model]
+    :gates   [:K2 :ship-bar-clock]}
+
+   {:id      :bulk/narrow-write
+    :family  :bulk
+    :what    "300 boundaries, one commit dirtying one subscription"
+    :shape   {:boundaries 300 :reads 1 :write :narrow}
+    :asserts [:exactly-one-boundary-re-ran :dom-matches-the-model]
+    :gates   [:K2 :ship-bar-clock]}
+
+   {:id      :mount/list-and-form
+    :family  :mount
+    :what    "cold mount of the reference list + form"
+    :shape   {:boundaries 300 :reads 1 :cold? true}
+    :asserts [:dom-matches-the-model]
+    :gates   [:K1 :ship-bar-clock]}
+
+   {:id      :scaling/fixed-reads
+    :family  :heap
+    :what    "fixed reads, growing boundaries — the per-boundary curve"
+    :shape   {:curve fixed-reads-curve}
+    :asserts [:no-retained-per-occurrence-objects-after-teardown]
+    :gates   [:K3 :shell-budget]}
+
+   {:id      :scaling/fixed-boundaries
+    :family  :heap
+    :what    "fixed boundaries, growing reads — the per-read curve, distinct queries"
+    :shape   {:curve fixed-boundaries-curve}
+    :asserts [:no-retained-per-occurrence-objects-after-teardown]
+    :gates   [:K3 :per-read-budget]}
+
+   {:id      :controlled/grid-100
+    :family  :controlled
+    :what    "the 100-cell controlled grid — the synchronous door (HD-019)"
+    :shape   {:cells 100 :controlled? true}
+    :asserts [:same-turn-echo
+              :mid-string-caret
+              :selection-preserved
+              :ime-composition-commits-nothing
+              :unchanged-model-rejection
+              :async-normalisation]
+    :gates   [:K4 :per-keystroke-budget]}
+
+   {:id      :keyed/insert-delete-reorder
+    :family  :correctness
+    :what    "keyed insert, delete and reorder against one list"
+    :shape   {:boundaries 100 :keyed? true}
+    :asserts [:identity-follows-the-key :no-node-recreated-on-reorder]
+    :gates   [:component-abi]}
+
+   {:id      :abandoned/query-identity
+    :family  :correctness
+    :what    "a boundary's query identity changes through an abandoned render"
+    :shape   {:boundaries 1 :abandon-render? true}
+    :asserts [:no-edge-from-the-abandoned-render :index-matches-the-winning-render]
+    :gates   [:index-laws :HD-002-ownership]}
+
+   {:id      :foreign/host-and-error-boundary
+    :family  :correctness
+    :what    "a foreign hook/context/ref component beside a real error boundary"
+    :shape   {:foreign? true :error-boundary? true}
+    :asserts [:foreign-component-renders :error-boundary-catches-and-resets]
+    :gates   [:HD-020-error-boundary :host-boundary-budget]}
+
+   {:id      :lifecycle/strict-abandoned-teardown-hmr
+    :family  :correctness
+    :what    "StrictMode, an abandoned first mount, root teardown, an HMR body swap"
+    :shape   {:strict-mode? true :hmr? true}
+    :asserts [:zero-leaked-subscription-refcounts-after-teardown
+              :unchanged-hot-read-performs-no-new-attach-or-release
+              :hmr-preserves-root-frame-and-app-db]
+    :gates   [:HD-021-execution-contract]}])
+
+;; ---------------------------------------------------------------------------
+;; Reading the roster
+;; ---------------------------------------------------------------------------
+
+(def by-id (into {} (map (juxt :id identity)) witnesses))
+
+(defn of-family [family] (filterv #(= family (:family %)) witnesses))
+
+(def families (into #{} (map :family) witnesses))
+
+(defn gates
+  "Every gate any witness feeds. An arm that reports fewer rows than this
+  has left a gate unwitnessed."
+  []
+  (into #{} (mapcat :gates) witnesses))
+
+(defn missing
+  "The witness ids an arm has NOT reported, given the ids it has. The one
+  function the arms actually call: `(missing (map :id my-rows))` is the
+  partial-run banner's input, and an empty result is the only thing that
+  licenses a complete-run claim."
+  [reported-ids]
+  (set/difference (into #{} (map :id) witnesses) (set reported-ids)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/witnesses_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/witnesses_cljs_test.cljs
@@ -1,0 +1,77 @@
+(ns re-frame.bench.hicasso.front.witnesses-cljs-test
+  "THE WITNESS ROSTER (rf2-2rtt6.8).
+
+  A roster whose only reader is the arm that wrote it proves nothing, so
+  these tests assert the two properties that make it worth being data:
+  that it covers what validation.md §Witness set enumerates, and that
+  [[re-frame.bench.hicasso.front.witnesses/missing]] — the function an
+  arm's partial-run banner is built on — actually reports an incomplete
+  run rather than flattering it."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.bench.hicasso.front.witnesses :as w]))
+
+(deftest the-roster-covers-what-validation-enumerates
+  (testing "every family the red-zone ratios are set per"
+    (is (= #{:bulk :mount :heap :controlled :correctness} w/families)))
+  (testing "the bulk pair, the mount row, and the two separated curves"
+    (is (contains? w/by-id :bulk/one-commit))
+    (is (contains? w/by-id :bulk/narrow-write))
+    (is (contains? w/by-id :mount/list-and-form))
+    (is (contains? w/by-id :scaling/fixed-reads))
+    (is (contains? w/by-id :scaling/fixed-boundaries)))
+  (testing "the controlled door's six proofs are named, not summarised"
+    (is (= [:same-turn-echo
+            :mid-string-caret
+            :selection-preserved
+            :ime-composition-commits-nothing
+            :unchanged-model-rejection
+            :async-normalisation]
+           (:asserts (w/by-id :controlled/grid-100)))))
+  (testing "the lifecycle row carries the standing teardown assertions"
+    (is (contains? (set (:asserts (w/by-id :lifecycle/strict-abandoned-teardown-hmr)))
+                   :zero-leaked-subscription-refcounts-after-teardown))
+    (is (contains? (set (:asserts (w/by-id :lifecycle/strict-abandoned-teardown-hmr)))
+                   :unchanged-hot-read-performs-no-new-attach-or-release)))
+  (testing "every kill criterion the witness set is supposed to feed has a witness"
+    (is (every? (w/gates) [:K1 :K2 :K3 :K4]))))
+
+(deftest every-row-is-completely-declared
+  (doseq [row w/witnesses]
+    (testing (str (:id row))
+      (is (keyword? (:id row)))
+      (is (contains? w/families (:family row)))
+      (is (string? (:what row)))
+      (is (map? (:shape row)))
+      (is (seq (:asserts row)) "a row with no assertion is a clock with no correctness")
+      (is (seq (:gates row)))))
+  (testing "the ids are unique"
+    (is (= (count w/witnesses) (count w/by-id)))))
+
+(deftest the-two-scaling-curves-are-separated
+  (testing "fixed reads, growing boundaries"
+    (is (= [1 1 1] (mapv :reads w/fixed-reads-curve)))
+    (is (= [10 100 300] (mapv :boundaries w/fixed-reads-curve))))
+  (testing "fixed boundaries, growing reads across the 1/3/7/20 ladder"
+    (is (= [100 100 100 100] (mapv :boundaries w/fixed-boundaries-curve)))
+    (is (= [1 3 7 20] (mapv :reads w/fixed-boundaries-curve))))
+  (testing "the per-read curve is measured with distinct queries — rf2-2rtt6.16's worst case"
+    (is (every? :distinct-queries? w/fixed-boundaries-curve))))
+
+(deftest missing-reports-an-incomplete-run-rather-than-flattering-it
+  (testing "a run that reported nothing is missing everything"
+    (is (= (count w/witnesses) (count (w/missing [])))))
+  (testing "a run missing one row names that row"
+    (let [reported (remove #{:controlled/grid-100} (map :id w/witnesses))]
+      (is (= #{:controlled/grid-100} (w/missing reported)))))
+  (testing "only a complete run reports nothing missing"
+    (is (= #{} (w/missing (map :id w/witnesses)))))
+  (testing "an id nobody declared does not count toward coverage"
+    (is (= #{:controlled/grid-100}
+           (w/missing (conj (vec (remove #{:controlled/grid-100} (map :id w/witnesses)))
+                            :invented/row))))))
+
+(deftest of-family-partitions-the-roster
+  (is (= (count w/witnesses)
+         (reduce + (map #(count (w/of-family %)) w/families))))
+  (is (= 2 (count (w/of-family :bulk))))
+  (is (= 2 (count (w/of-family :heap)))))


### PR DESCRIPTION
Wave-1's shared front half for EP-0038 (Hicasso) — the part built once and
consumed by both tournament arms. All three deliverables landed, plus the
witness-set build and the dogfood screen's shared state.

**Authority.** The operator's "full steam ahead with hicasso" direction (Mike,
2026-07-31, recorded on `rf2-2rtt6`, `rf2-2rtt6.7` and `rf2-2rtt6.8`)
**discharges this bead's "Blocked by the donor gate" line**: `.8` serves both
arms and is required under either tournament outcome. **The six-week clock is
not started** — per HD-014 and rf2-2rtt6.9/.10 it starts at the first
Hicasso-arm commit that mounts the dogfood screen, and no screen is mounted
here. This PR contains no view, no root, and no React mount.

**Residence.** Everything lands in the tracked bench/test tree at
`implementation/freehand/test/re_frame/bench/hicasso/front/`, as HD-017
directs. Nothing is on a production source path; no production build requires
any of it; `implementation/shadow-cljs.edn` is untouched (the new namespaces
end in `-cljs-test` and ride the existing `cljs-test$` selector, so no build id
and no hot-zone edit was needed).

## What landed

**1. The hiccup codec** (`codec.cljs`) — reagent-slim's measured tag/prop/child
plumbing, extracted: the `#id.class` regex and its parse, the kebab-to-camel
prop rule with its `aria`/`data` exemptions and `--custom-property`
passthrough, the `:style` map-to-object conversion, the class coercion and
shorthand merge, the single-pass sequence expansion that does not truncate on
an interior `nil`, and the 0/1/N `createElement` arms. None of the component
protocol, ratoms, argv-equality memoization or scheduler came with it, and the
codec requires nothing from a donor.

Caching is **codec-work only** (HD-004): one tag cache and one prop-name cache,
both plain JS objects behind an own-property guard so a hiccup literal named
`__proto__` cannot poison them. No props objects and no elements are memoized —
a test asserts both, because HD-006 says Reagent's equality semantics are not
to be recreated from taste. HD-004's third cache, stable component heads, turns
out to cost nothing: `defview` mints its function component once at definition
and the codec only records the mark. That is also why HD-016 makes a plain
function in head position a loud error instead of auto-wrapping it —
auto-wrapping is precisely what would need the cache back.

**2. The subscription→boundary index** (`sub_index.cljs`) — the local
`spike-01` pure model graduated into tracked code, **with its six laws as unit
tests** (HD-017). Global maps, not reactions: two maps and a live set in one
atom, shared structure rather than per-boundary object fan-out, and `commit!`
is the only door through which a dirty sub-key set becomes a dirty boundary
set. The HD-005 evidence sink is three lines — a holder, a setter, a
nil-checked emit — tapped at the edge change and at the commit, nil until
something attaches, with the silence asserted as well as the traffic.

Two behaviours the paper model never had to express are added, both leak
classes rather than conveniences: `record-reads` ignores a boundary that is not
live, so an abandoned render's reads cannot resurrect the edges `unmount` just
removed; and `mount` is idempotent, because StrictMode mounts twice and HMR
remounts.

**3. Intent lowering** (`intent.cljs`) — dispatch on the *shape* of the value
at an `on-*` prop, so there is no roster of blessed DOM event names to keep in
step: a vector is an intent, a map is a composition-gated key-map, a function
stays legal, everything else passes through. The frame is read at lowering
time, during the render, and the closure closes over it — the browser calls
these back long after the render's dynamic extent has unwound. The
static/dynamic split is decided once per render too, so an ordinary button
costs no per-event allocation and only a marker-carrying intent materializes.
`::h/prevent?` metadata on the intent is the single mechanism for both the
submit auto-prevent's opt-out and the opt-in anywhere else. The composition
gate reads both signals (`isComposing` and the legacy keyCode-229) and is
written over the whole key-map rather than the one key authoring.md names,
because during composition every keystroke belongs to the IME.

**4. The witness set** (`witnesses.cljs`) — declared once, as data. Each row
carries its red-zone family, its shape, the gates it feeds, and — first class,
because a candidate that is fast and wrong has failed — what must be true
regardless of the clock. The two scaling curves are separated as validation.md
requires, and the per-read curve carries rf2-2rtt6.16's distinct-queries worst
case. `missing` is the partial-run banner's input and is tested for reporting
an incomplete run rather than flattering it.

**5. The dogfood screen's shared app/state** (`dogfood.cljs`) — app-db shape,
events, subscriptions, frame lifecycle. **No screen.** HD-002 has the screen
written in three renderings and judged on preference, which is only a verdict
about the view layer if all three sit on one identical state layer. Drafts are
where HD-009 is tested rather than asserted: a half-typed to-do is exactly what
a Reagent author reaches for `r/atom` to hold, so it lives in app-db behind one
parametric subscription and named events, cleared by explicit caller revision
and never by value equality.

## The six index laws, as tests

Each law from architecture.md gets one `deftest` named for its number in
`sub_index_laws_cljs_test.cljs`:

| Law | Test |
|---|---|
| 1 — a commit of that sub dirties that boundary only | `law-1-a-committed-sub-dirties-its-own-reader-only` |
| 2 — two boundaries sharing a sub both dirty | `law-2-a-shared-sub-dirties-every-sharer` |
| 3 — unmount removes edges | `law-3-unmount-removes-every-edge-the-boundary-held` |
| 4 — a re-run with fewer reads drops edges | `law-4-a-rerun-with-fewer-reads-drops-the-edges-it-stopped-reading` |
| 5 — the broad dirty set is the union of the readers | `law-5-the-broad-dirty-set-is-the-union-of-the-readers` |
| 6 — an unknown dirty sub yields the empty set | `law-6-an-unknown-dirty-sub-yields-the-empty-set` |

Below the six sit the obligations the laws would silently lose: sub-key
identity under value equality, the abandoned-render guard, mount idempotence,
the global-atom door, and the evidence seam.

## Two real bugs the tests caught

Both are ClojureScript keyword-identity errors, and both are worth recording
because `identical?` on keyword literals **works under `:advanced`** (where
constants are interned) and fails everywhere else — a green release build over
a broken dev one. One had made *every* event position auto-prevent; the other
had routed *every* fragment into the native-tag path. Both are now `=` or a map
lookup, with the reason written down at each site.

## Hard fences

No compiler. No analyzer. No dual mode. No ViewCell-class object graph — the
index is two maps and a set in one atom, and the docstring names the graph as
the programme's failure marker. No candidate ledger — `record-reads` is a
set-difference against the previously held edge set, computed and applied in
one call, with nothing retained per occurrence. Nothing came close.

## Quality gates

| Gate | Result | Exit |
|---|---|---|
| `npm run test:cljs` (full consolidated node-test) | 12036 tests, 60100 assertions, 0 failures, 0 errors | **0** |
| `--test=…front.sub-index-laws-cljs-test` (standalone process) | 12 tests, 60 assertions, 0 failures, 0 errors | **0** |
| `--test=…front.codec-cljs-test` (standalone process) | 18 tests, 80 assertions, 0 failures, 0 errors | **0** |
| `--test=…front.intent-cljs-test` (standalone process) | 16 tests, 60 assertions, 0 failures, 0 errors | **0** |
| `--test=…front.dogfood-cljs-test` (standalone process) | 12 tests, 58 assertions, 0 failures, 0 errors | **0** |
| `--test=…front.witnesses-cljs-test` (standalone process) | 5 tests, 83 assertions, 0 failures, 0 errors | **0** |
| `shadow-cljs compile node-test` | 2071 files, 0 warnings | **0** |
| clj-kondo **v2026.04.15** (the CI-pinned version, downloaded to match), CI's exact `--parallel --fail-level error --lint …` invocation | **errors: 0**, warnings 4526 (the informational pre-existing baseline), **0 findings in the new files** | **0** |
| Splint, CI's exact `clojure -M:splint --fail-on-errors ../implementation ../tools ../examples ../testbeds` | 2877 files, 4945 style warnings (informational baseline), **0 findings in the new files** | **0** |
| `scripts/test-fast-pr.sh` | first run exited **1** on a **local host OOM**, re-running — see the note below | **1**, re-running |
| `python -m mkdocs build --strict` | not run — **no docs touched** (deliberate: `docs/design/hicasso/validation.md` and the studio pages are in flight on `worker/gateline-e3flf` and PR #7308) | n/a |

**On the `test-fast-pr.sh` exit 1.** Its three static steps passed — test-lane
bijection (1735 test-defining files, 46 lanes, every file selected and every
selector reached), the JVM roster self-test (9/9), and the JVM roster↔CI
bijection (31 rostered artefacts). It then failed in `JVM implementation/core`
on a **host memory exhaustion, not an assertion**:

```
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x…, 2684354560, 0) failed;
error='The paging file is too small for this operation to complete' (DOS error/errno=1455)
# There is insufficient memory for the Java Runtime Environment to continue.
# Native memory allocation (mmap) failed to map 2684354560 bytes. Error detail: G1 virtual space
```

The box had 5.1 GB physical and 6.2 GB virtual free against a 2.5 GB G1
reservation, with several sibling worker JVM/Node processes resident. The
change cannot be the cause and this is checkable rather than asserted:
`implementation/core/deps.edn` contains **zero** references to `freehand`, so
`implementation/freehand/test/**` is not on the core JVM classpath — and every
file in this PR is `.cljs`, which the JVM lane does not compile at all. CI runs
this lane on its own runner.

**Matrix derivation (TESTING.md).** The touched tree is
`implementation/freehand/test/re_frame/bench/hicasso/front/**` — CLJS test-tree
files only. That puts the change in the **node unit** tier (`test:cljs`,
always-on, `cljs-test$` selector) and the **lint** tier, and in no other. It is
*not* in the browser DOM lane: no file ends in `_dom_cljs_test`, which is what
`_browser-dom-lane-partition.test.cjs` partitions on. It is *not* in
`test:freehand` / `node-test-freehand`, whose `ns-regexp` is
`^re-frame\.freehand\..+-cljs-test$` and does not match
`re-frame.bench.hicasso.front.*` — the same is already true of every existing
hicasso bench suite. It is *not* in the JVM tier (no `.clj`/`.cljc`), nor the
prod-elision, bundle-isolation, perf-bundle, adapter-smoke, Xray or
mcp-conformance lanes (no production source, no build config, no example). Each
new suite was additionally run **standalone in a fresh process**, which is the
property `test:cljs-isolation` guards — the `dogfood` suite installs its own
`plain-atom` adapter via `make-reset-runtime-fixture` and does not lean on
bundle pollution.

## Mutation proofs

A law asserted but never watched failing is decoration, so three were planted,
watched red, and reverted to an empty `git diff`. Each mutation reds its own
law and leaves the others alone, except where the algebra makes that impossible
— noted below.

**Mutation 1 — law 3.** `unmount` stopped dropping the reverse edges (keeping
the `:b->subs` dissoc and the `:live` disj). Exit **1**, 6 failures: 3 in
`law-3-…`, plus the abandoned-render guard and the global-door test that depend
on it. Laws 1, 2, 4, 5, 6 stayed green. Reverted; `git diff --stat` empty.

**Mutation 2 — law 4.** `record-reads` stopped computing the dropped set
(`dropped #{}`) and accumulated the forward edges (`(into held reads)`) — the
classic "never drops" bug. Exit **1**, 5 failures: 4 in `law-4-…` plus its live
counterpart in `with-reads`. Laws 1, 2, 3, 5, 6 stayed green. Reverted;
`git diff --stat` empty.

**Mutation 3 — law 6.** `dirty-boundaries` fell back to every live boundary for
an unknown key (`(get (:sub->bs idx) sub-key (:live idx))`) — a phantom
boundary. Exit **1**, 11 failures: 2 in `law-6-…`, and — this is the point of
law 6 — every *negative* assertion in laws 3 and 4, in sub-key identity, and in
the global door. Law 6 is what keeps the other laws' empty-set assertions
meaningful, so the blast radius is the evidence for that rather than a defect
in the separation. Laws 1, 2, 5 stayed green. Reverted; `git diff --stat`
empty.

The green baseline before and after every mutation was identical: 12 tests, 60
assertions, 0 failures, exit **0**.

## What is not here, and why

Deliberate omissions, each a decision rather than an oversight, so a later
reader need not guess: `route-link` (routing-coupled, and not among this bead's
three deliverables); `defhost` / `[:>]` interop (HD-011, its own surface); the
controlled-value restore (HD-019's door belongs to the arm that owns the DOM);
the `:r>` raw-props path and the class-component `__rfArgv` crossing; and the
adapters' reserved-head and keyword-prop diagnostics, which are
public-boundary policy for a shipped adapter where this codec has no public
boundary. The PATCH arm's emitter is likewise absent by design — the codec's
analysis half is arm-neutral and shared, the emission half is Arm 1's, and
rf2-2rtt6.10 brings its own.
