### PR TITLE
bench,docs(hicasso): make the balanced-design inference checkable; correct the lane-cache counts (rf2-6i0i2, rf2-veu0q)

### DIFF
--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -262,11 +262,21 @@ beside a biased one.
 
 | witness | **threshold** | 95% interval on the mean | run means (10) | verdict |
 |---|---|---|---|---|
-| **M1 mount** — 901 el, 300 boundaries | ~~1.2301×~~ → **1.2310×** | 1.2105 – 1.2514 | 1.1989 – 1.2931 | **UIx slower.** 59 of 60 rounds above 1.0; 19 of 20 order strata wholly above it |
-| **M2 mount** — 51 el, 12 fields · *diagnostic* | ~~1.0539×~~ → **1.0601×** | 1.0017 – 1.1185 | 0.9561 – 1.1923 | **straddles 1.0 — indistinguishable**, in all ten runs |
-| **bulk broad** — one commit all 300 read | ~~0.6239×~~ → **0.6291×** | 0.5996 – 0.6587 | 0.5792 – 0.6987 | **UIx faster.** All 60 rounds below 1.0; all 20 strata wholly below it |
-| **bulk narrow** — 10 commits, each read by exactly one boundary, one window | ~~1.1540×~~ → **1.1754×** | 1.1579 – 1.1930 | 1.1390 – 1.2186 | **UIx slower.** All 60 rounds above 1.0; all 20 strata wholly above it |
+| **M1 mount** — 901 el, 300 boundaries | ~~1.2301×~~ → **1.2310×** | ~~1.2105 – 1.2514~~ → **1.2109 – 1.2510** | 1.1989 – 1.2931 | **UIx slower.** 59 of 60 rounds above 1.0; 19 of 20 order strata wholly above it |
+| **M2 mount** — 51 el, 12 fields · *diagnostic* | ~~1.0539×~~ → **1.0601×** | ~~1.0017 – 1.1185~~ → **1.0028 – 1.1173** | 0.9561 – 1.1923 | **straddles 1.0 — indistinguishable**, in all ten runs |
+| **bulk broad** — one commit all 300 read | ~~0.6239×~~ → **0.6291×** | ~~0.5996 – 0.6587~~ → **0.6001 – 0.6581** | 0.5792 – 0.6987 | **UIx faster.** All 60 rounds below 1.0; all 20 strata wholly below it |
+| **bulk narrow** — 10 commits, each read by exactly one boundary, one window | ~~1.1540×~~ → **1.1754×** | ~~1.1579 – 1.1930~~ → **1.1582 – 1.1926** | 1.1390 – 1.2186 | **UIx slower.** All 60 rounds above 1.0; all 20 strata wholly above it |
 | ~~bulk narrow, **unbatched window** (superseded twice over)~~ | ~~1.1556×~~ | — | — | ~~UIx slower, but did not stably resolve across runs~~ |
+
+**The intervals are struck and corrected**, and the reason is worth a sentence
+here rather than only where it is worked out: the originals were computed with a
+`t` multiplier for **eight** degrees of freedom where a mean of ten run means
+needs **nine**, which made every one of them about 2% too wide. The error was
+found by recovering the ensemble's [observation
+table](#the-observation-table-in-full) and recomputing from it; it is
+conservative, so no verdict changes, and the thresholds, *p* values and ranges
+were all correct. [The full account, with the
+diagnosis](#the-intervals-are-2-too-wide-and-the-cause-is-an-off-by-one-in-the-degrees-of-freedom).
 
 **The interval is on the mean, not on a run.** It is a Student-t interval over
 the ten run means, so it says how well ten runs pin the centre; the *run means*
@@ -1302,11 +1312,11 @@ these numbers. Read them as descriptive.
 
 | row | order effect (mean `d`) | as a ratio | 95% interval | sign-flip *p* | positive |
 |---|---|---|---|---|---|
-| M1 mount | +0.0357 | 1.036× | 0.979× – 1.097× | 0.084 | 7 of 10 |
-| M2 mount | −0.0837 | 0.920× | 0.795× – 1.065× | 0.889 | 4 of 10 |
-| bulk broad | −0.0388 | 0.962× | 0.887× – 1.044× | 0.856 | 5 of 10 |
-| bulk narrow | +0.0070 | 1.007× | 0.977× – 1.038× | 0.302 | 7 of 10 |
-| **run-level composite** *(the pre-registered statistic: mean over the four rows)* | **−0.0200** | **0.980×** | **0.934× – 1.029×** | **0.823** | **6 of 10** |
+| M1 mount | +0.0357 | 1.036× | ~~0.979× – 1.097×~~ → 0.980× – 1.095× | 0.084 | 7 of 10 |
+| M2 mount | −0.0837 | 0.920× | ~~0.795× – 1.065×~~ → 0.797× – 1.062× | 0.889 | 4 of 10 |
+| bulk broad | −0.0388 | 0.962× | ~~0.887× – 1.044×~~ → 0.888× – 1.042× | 0.856 | 5 of 10 |
+| bulk narrow | +0.0070 | 1.007× | ~~0.977× – 1.038×~~ → 0.978× – 1.037× | 0.302 | 7 of 10 |
+| **run-level composite** *(the pre-registered statistic: mean over the four rows)* | **−0.0200** | **0.980×** | ~~**0.934× – 1.029×**~~ → **0.935× – 1.028×** | **0.823** | **6 of 10** |
 
 **The pre-registered hypothesis fails, and it fails on the wrong side of zero.**
 The composite was fixed in advance as one-sided positive; the ensemble puts it at
@@ -1331,87 +1341,164 @@ the Reagent-first stratum is higher in **23 of 40**, p = 0.21. The 11-of-12 was
 not a small effect measured well; on the balanced design it is not there at the
 strength it was quoted.
 
-#### The observation table, and the nine rows of it that were not kept
+#### The observation table, in full
 
-**Both views above are computed from a 10 × 4 table of per-run figures, and that
-table was never committed.** What landed was group means, intervals, ranges and
-*p* values — summaries, with nothing behind them a reader can reach. The PR
-#7303 audit found it, and it is a defect of the record rather than of the
-measurement: no number in either view can be recomputed from this repository.
+**Both views above are computed from a 10 × 4 table of per-run figures, and the
+PR #7303 audit's finding was that the table itself was never committed** — what
+landed was group means, intervals, ranges and *p* values, summaries with nothing
+behind them a reader could reach. **The table is below, all forty cells**, and
+every figure in both views is now derived from it by
+`implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs`
+rather than asserted here.
 
-It is also only partly repairable. The worktree that produced the ensemble is
-gone and nine runs' readings went with it. So this section publishes what the
-repository *does* hold, marks the hole rather than filling it with a
-reconstruction, and pins the derivation of everything that can still be checked.
-The fixture is
-`implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs`.
+!!! warning "Provenance — recovered, not re-run"
+
+    These are the **console logs of the ten runs themselves**, taken at the
+    ensemble's landed anchor and recovered from an out-of-tree backup made
+    before the producing worktree was reaped. **Nothing was measured again.**
+    No browser was opened, the machine has since moved, and a re-run would be a
+    different ensemble, not this one. Each cell is that run's
+    `:threshold :per-round` vector, transcribed by script rather than by hand.
+    The pilot runs that share the backup directory are **not** this ensemble
+    and are excluded.
+
+    The identification is checked rather than assumed: run 1's four vectors in
+    the backup are exactly the four this page already printed for the
+    pre-registered run, which is what ties the backup to *this* ensemble. The
+    suite asserts it.
+
+Each cell is that run's threshold mean over its six rounds. **†** marks a
+row-run whose order strata came out disjoint, so that run was individually
+barred from publishing a magnitude — [and stayed in the ensemble
+anyway](#the-partition-and-what-one-runs-split-can-and-cannot-say), which is
+the aggregate rule.
 
 | run | start | M1 | M2 | broad | narrow |
 |---|---|---|---|---|---|
-| **1** *(pre-registered)* | reagent | **1.2159** | **1.0469** | **0.6662** | **1.1542** |
-| 2 | uix | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
-| 3 | reagent | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
-| 4 | uix | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
-| 5 | reagent | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
-| 6 | uix | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
-| 7 | reagent | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
-| 8 | uix | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
-| 9 | reagent | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
-| 10 | uix | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
+| **1** *(pre-registered)* | reagent | 1.2159 | 1.0469 | 0.6662 | 1.1542 |
+| 2 | uix | 1.1989 | 0.9857 | 0.6153 | 1.1817 |
+| 3 | reagent | 1.2463 | 1.0155 | 0.6550 | 1.1972 |
+| 4 | uix | 1.2359 | 0.9561 | 0.5898 | 1.1390 |
+| 5 | reagent | 1.2056 | 1.1290 | 0.5867 | 1.1728 **†** |
+| 6 | uix | 1.2214 | 1.1923 | 0.6609 | 1.1714 |
+| 7 | reagent | 1.2145 | 0.9609 | 0.6384 | 1.1546 |
+| 8 | uix | 1.2931 | 1.1111 | 0.5792 | 1.1667 |
+| 9 | reagent | 1.2556 **†** | 1.0781 **†** | 0.6011 | 1.1981 |
+| 10 | uix | 1.2225 | 1.1250 | 0.6987 | 1.2186 |
 | **group mean — reagent-start (5)** | | 1.2276 | 1.0461 | 0.6295 | 1.1754 |
 | **group mean — uix-start (5)** | | 1.2344 | 1.0740 | 0.6288 | 1.1755 |
-| **threshold (10)** | | 1.2310 | 1.0601 | 0.6291 | 1.1754 |
-| **run-mean range (10)** | | 1.1989 – 1.2931 | 0.9561 – 1.1923 | 0.5792 – 0.6987 | 1.1390 – 1.2186 |
+| **threshold (10)** | | **1.2310** | **1.0601** | **0.6291** | **1.1754** |
 
-**Run 1's four cells are derived, not transcribed.** The fixture replays its
-six-round vectors — the ones printed under the [RED-ZONE
-table](#red-zone--clock-on-rf2-2rtt62s-witnesses) above — through
-`segment-order-verdict`, and checks the run means, the whole stratum table, and
-run 1's four `d` values against what this page prints. Those `d` values are
-`+0.1026` on M1, `−0.0846` on M2, `+0.0835` on broad and `−0.0279` on narrow:
-**one tenth of View 2's input, and on broad it is opposite in sign to the
-ensemble mean** — which is the case for publishing ten runs rather than one,
-made from the one run that survives.
+And the ten `d` values each row of View 2 averages, derived from the strata of
+the same vectors — `d = ln(Reagent-first mean ÷ UIx-first mean)`, positive when
+the figure reads higher with Reagent leading:
 
-Rows 2 through 10 are explicit `nil`s in the fixture. That is the honest shape:
-not zero, not missing at random, and **not recoverable** — six published
-constraints per column (two group means, the threshold, the range, the interval,
-the resolution limit) do not invert to nine unknowns, and any table that
-satisfied them would be an invention that happened to fit.
+| run | start | M1 | M2 | broad | narrow | composite |
+|---|---|---|---|---|---|---|
+| 1 | reagent | +0.1026 | −0.0846 | +0.0835 | −0.0279 | +0.0184 |
+| 2 | uix | −0.0691 | −0.1515 | −0.1796 | +0.0137 | −0.0966 |
+| 3 | reagent | −0.0055 | −0.3707 | −0.1234 | −0.0769 | −0.1441 |
+| 4 | uix | +0.1106 | −0.1729 | +0.0493 | +0.0099 | −0.0008 |
+| 5 | reagent | +0.0451 | +0.1359 | −0.1302 | +0.0604 | +0.0278 |
+| 6 | uix | +0.0446 | −0.4182 | +0.0171 | −0.0330 | −0.0974 |
+| 7 | reagent | +0.0454 | +0.0660 | −0.1243 | +0.0233 | +0.0026 |
+| 8 | uix | +0.0897 | −0.0801 | +0.0761 | +0.0467 | +0.0331 |
+| 9 | reagent | −0.1151 | +0.1508 | +0.0950 | +0.0245 | +0.0388 |
+| 10 | uix | +0.1088 | +0.0883 | −0.1518 | +0.0294 | +0.0187 |
+| **mean** | | **+0.0357** | **−0.0837** | **−0.0388** | **+0.0070** | **−0.0200** |
 
-**The derivation, stated once and now executed by the suite.**
+**Read the columns before the means.** M2 swings from −0.42 to +0.15 — an order
+effect of ±35% would be needed to show through that, and none of these rows is
+one run repeating another. On broad, run 1 reads `+0.0835` where the ensemble
+mean is `−0.0388`: opposite in sign, from the very run the design had
+pre-registered. That single fact is the case for publishing ten runs rather than
+the one the design nominated, and it is why the earlier *11 of 12* was never
+evidence.
 
-1. Per run per row, `d = ln( mean of the Reagent-first stratum ÷ mean of the
-   UIx-first stratum )`, the strata taken from `segment-order-verdict` itself so
-   the statistic and the published partition cannot drift apart. **Checked** on
-   run 1.
-2. A run's published figure is the arithmetic mean of its six rounds.
-   **Checked** on run 1, all four rows.
-3. A group mean is the mean of that start group's five runs; the threshold is
-   the mean of all ten. The counterbalance being 5/5, the threshold **is** the
-   average of the two group means — so the RED-ZONE table and View 1 are one
-   table, and a transcription slip in either shows up. **Checked**, all four
-   rows.
-4. View 1's `difference` column is the reagent-start group mean minus the
-   uix-start one. **Checked** (M2 misses by 0.0001 because the page differenced
-   the unrounded means).
-5. View 2's `as a ratio` column is `exp(mean d)`, and the 95% interval is
-   computed on `d` and printed as ratios — so the midpoint of its two logarithms
-   is the mean `d` itself. **Checked**, four rows and the composite.
-6. The composite is the mean over the four rows, for `d` and for both
-   components, never four trials pooled. **Checked** on both component columns.
-7. The *p* values — View 1's 252 relabellings, View 2's 1024 sign flips — are
-   functions of the ten per-run numbers. **Not checkable, and not checkable
-   later**: nine of the ten are gone.
+##### What reproduces, and it now includes both *p* columns
 
-**So the arithmetic between the published summaries is checkable from the
-repository, and the step from ten runs to those summaries is not.** That is a
-smaller claim than *the inference can be independently recomputed*, and it is
-the true one. The rule it leaves behind is cheap and general: **an ensemble
-publishes its table, not only its summaries.** Ten launches produced ten
-records; committing forty numbers would have cost nothing and would have made
-every *p* on this page reproducible. The next ensemble on this lane commits
-them.
+Every point estimate on this page falls out of the forty cells, and so do the
+two *p* columns the audit correctly said could not be checked from the
+repository. All of it is asserted by the suite, not by this paragraph.
+
+| quantity | reproduces? |
+|---|---|
+| the four run-mean ranges — all eight endpoints | **yes** |
+| threshold, and its identity with the average of the two start-group means | **yes** |
+| View 1's group means and `difference` column | **yes** |
+| **View 1's permutation *p*** — all `C(10,5) = 252` relabellings enumerated | **yes** — 0.770 / 0.611 / 0.984 / 0.992 |
+| the `resolution limit` column | **yes** |
+| mean `d`, the `as a ratio` column, the `positive` counts | **yes** |
+| **View 2's sign-flip *p*** — all `2¹⁰ = 1024` assignments enumerated | **yes** — 0.084 / 0.889 / 0.856 / 0.302 |
+| the order and temporal components, and their permutation *p* | **yes** |
+| the composite, computed per run and never as four pooled trials | **yes** — including its 0.823 |
+| the prose counts: 37 of 40 strata overlapping, 23 of 40 Reagent-first-higher, 59 of 60 M1 rounds above 1.0, all 60 / all 20 on broad and narrow | **yes** |
+| **the 95% intervals** | **NO — see below** |
+
+One derivation detail is worth stating because it decides a published digit.
+`d` takes its **partition** from `segment-order-verdict` but averages the
+readings itself, because the verdict rounds its stratum means to four decimals
+for display. On the broad row that rounding is load-bearing: a sign-flip *p*
+moves in steps of `1/1024 = 0.00098`, and the fourth decimal carries exactly one
+of the 1024 assignments across the observed mean — `878/1024 = 0.8574` from
+rounded strata against `877/1024 = 0.8564` from the readings, and 877 is the
+`0.856` this page publishes. **A displayed number is not an input.**
+
+##### The intervals are 2% too wide, and the cause is an off-by-one in the degrees of freedom
+
+This is the one disagreement between the recovered data and what this page
+published, and it is reported rather than quietly fixed in either direction.
+
+**Every interval on this page — View 2's on `d`, and the RED-ZONE table's on the
+threshold — is about 2% wider than the ten runs support.** An interval on the
+mean of **ten** run means is a one-sample Student-t interval with `n − 1 =`
+**nine** degrees of freedom, `t = 2.2622`. The multiplier actually used is
+`≈ 2.306`, which is `t` at **eight** degrees of freedom.
+
+The mistake is identifiable rather than merely detectable. Eight *is* the right
+number for the `resolution limit` column standing beside it — that column is a
+genuine two-sample five-against-five contrast, its degrees of freedom are
+`5 + 5 − 2 = 8`, and it reproduces **exactly**. The same `t` was then reused for
+the one-sample intervals, where it does not belong.
+
+| row | published interval on the mean | corrected (9 df) |
+|---|---|---|
+| M1 mount | ~~1.2105 – 1.2514~~ | **1.2109 – 1.2510** |
+| M2 mount | ~~1.0017 – 1.1185~~ | **1.0028 – 1.1173** |
+| bulk broad | ~~0.5996 – 0.6587~~ | **0.6001 – 0.6581** |
+| bulk narrow | ~~1.1579 – 1.1930~~ | **1.1582 – 1.1926** |
+
+View 2's intervals move the same way — M1's `0.979 – 1.097` becomes
+`0.980 – 1.095`, M2's `0.795 – 1.065` becomes `0.797 – 1.062`, broad's
+`0.887 – 1.044` becomes `0.888 – 1.042`, narrow's `0.977 – 1.038` becomes
+`0.978 – 1.037`, and the composite's `0.934 – 1.029` becomes `0.935 – 1.028`.
+So *"the interval admits an order effect anywhere from 6.6% against the claim to
+2.9% for it"* is properly **6.5% against to 2.8% for**, and the upper ends
+quoted [above](#why-the-two-views-can-disagree-and-what-n--5-vs-5-cannot-settle)
+are `+9.5%`, `+6.2%`, `+4.2%` and `+3.7%` rather than `+9.7%`, `+6.5%`, `+4.4%`
+and `+3.8%`.
+
+**No verdict on this page turns on it, and that is checked rather than asserted.**
+The error is conservative — the published intervals were too *wide*, so every
+claim made inside them survives being made inside narrower ones. M1, broad and
+narrow stay wholly clear of 1.0; M2 still only just clears parity on the mean
+and stays diagnostic for the reason it always was, that three of its ten runs
+read below 1.0 outright. The suite recomputes all four corrected intervals and
+asserts each of those readings.
+
+**The old figures are struck, not deleted**, in the same style as every other
+correction here — and the *p* values, the point estimates and the thresholds are
+all untouched, because they were right.
+
+##### What the table changes about the audit's finding
+
+The audit said the central statistics could not be independently recomputed from
+the repository. **They can now**, and the finding closes properly rather than
+being downgraded to *checkable in part*. What remains true is the lesson: an
+ensemble that publishes only summaries is one reaped worktree away from being
+unverifiable, and this one survived on a backup rather than by design. **The rule
+is that an ensemble publishes its table.** Forty numbers, and they would have
+cost nothing.
 
 #### Why the two views can disagree, and what n = 5 vs 5 cannot settle
 
@@ -1432,12 +1519,12 @@ trials.
 claim one.** The start-group contrast can only resolve a difference of about
 0.04 on the narrow and M1 rows and about 0.12 on M2 — the last column of View 1's
 table is that limit, computed rather than asserted. On the composite, the
-interval admits an order effect anywhere from **6.6% against the claim to 2.9%
+interval admits an order effect anywhere from **6.5% against the claim to 2.8%
 for it**. Stated as bounds rather than as a verdict:
 
 - **An effect at the top of the range the page previously asserted is excluded
   on every row.** The upper end of View 2's interval — the end that would favour
-  the claim — is +9.7% on M1, +6.5% on M2, +4.4% on broad and +3.8% on narrow.
+  the claim — is +9.5% on M1, +6.2% on M2, +4.2% on broad and +3.7% on narrow.
   The *"one to nineteen percent between strata, systematic"* the page used to
   assert cannot be true of the top of its own range on any row.
 - **An effect of one or two percent is not excluded, and ten runs could not have
@@ -1471,7 +1558,7 @@ and each was answered by the design rather than by a friendlier run:
    straddling 1.0, and 59 of the 60 rounds behind them read above 1.0.
 
 **What is published is a magnitude with an interval: 1.2310×, 95% interval
-1.2105 – 1.2514 on the mean, single runs landing anywhere in 1.199 – 1.293.**
+1.2109 – 1.2510 on the mean, single runs landing anywhere in 1.199 – 1.293.**
 That is the form the measurement supports. A bare four-decimal point never was —
 not because the point was wrong (`1.2301` sits inside the new interval, which is
 its own small vindication) but because a point carries no statement of how far a
@@ -1487,7 +1574,7 @@ in the form the standard would take.
 all 60 rounds below 1.0, all 20 order strata wholly below it, strata overlapping
 in every run. `1.1754×` **narrow** is now its mirror: all 60 rounds above 1.0,
 all 20 strata wholly above. **M2** resolves nothing and is not meant to — every
-one of its ten runs straddles 1.0, and its interval `[1.0017 – 1.1185]` sits
+one of its ten runs straddles 1.0, and its interval `[1.0028 – 1.1173]` sits
 barely clear of parity only because it is an interval on a *mean*; three of the
 ten runs read below 1.0 outright. On legs of 4.5 to 11 quanta that is not a
 direction, and the row stays **diagnostic**.
@@ -1570,6 +1657,12 @@ alternation; every one exited 0 and every one is in the numbers above. A run tha
 had been dropped for reading badly would make the ensemble worthless, so the
 count is stated as the whole record: **ten launched, ten published.**
 
+**Their per-run readings are now committed** — see [the observation table in
+full](#the-observation-table-in-full), recovered from an out-of-tree backup of
+the ten runs' console logs after the producing worktree was reaped, and
+**not re-measured**. That is what makes every figure on this page derivable
+from the repository rather than merely stated by it.
+
 | | |
 |---|---|
 | **Authored anchor** | `2a97274c0fd50dd3145ba60a33f73f663bec94b9` on `worker/balance-6i0i2` — the last commit that touches the instrument. **A rebase-merge will mint a new landed SHA for it**, and this line is deliberately not rewritten to that SHA later: the blobs below are what identify the instrument, and a rebase cannot move a blob. An audit mapping this page to `main` should expect the anchor to resolve to a commit that is *not* an ancestor of `main`, and should check the blobs |
@@ -1642,18 +1735,18 @@ statement of what the measurement supports, not an amendment.
 > starting segment counterbalanced 5/5 now stand behind each row, so each is a
 > **magnitude with an interval** rather than a point or a bare direction:
 >
-> - **M1 mount — `1.2310×`, 95% interval `1.2105 – 1.2514` on the mean, single
+> - **M1 mount — `1.2310×`, 95% interval `1.2109 – 1.2510` on the mean, single
 >   runs landing in `1.199 – 1.293`.** This **supersedes `1.2301×`**, which was
 >   withdrawn as a magnitude and is not reinstated: the number the standard holds
 >   was measured on a 3:2 design whose bias has since been removed by
 >   construction, and it is replaced rather than restored. A candidate worse than
 >   the run-mean spread is RED; inside it, the honest answer is where in the
 >   spread it sits.
-> - **bulk narrow — `1.1754×`, interval `1.1579 – 1.1930`, runs `1.139 – 1.219`.**
+> - **bulk narrow — `1.1754×`, interval `1.1582 – 1.1926`, runs `1.139 – 1.219`.**
 >   **Supersedes `1.1540×`**, also withdrawn. Its direction is now as strong as
 >   any row on the page: all 60 rounds above 1.0, all 20 order strata wholly
 >   above.
-> - **bulk broad — `0.6291×`, interval `0.5996 – 0.6587`, runs `0.579 – 0.699`.**
+> - **bulk broad — `0.6291×`, interval `0.6001 – 0.6581`, runs `0.579 – 0.699`.**
 >   Supersedes `0.6239×`, which stood. All 60 rounds and all 20 strata below 1.0.
 > - **M2 mount — `1.0601×` and still diagnostic and still indistinguishable.**
 >   All ten runs straddle 1.0 and three read below it outright. Not quotable
@@ -1708,15 +1801,17 @@ mutation evidence is on
   page. What is still missing is the mechanism on *this* page and a fix that does
   not cost samples; one row per page plus a per-witness budget makes it harmless
   to these figures, and neither makes it fixed.
-- **Nine tenths of the ensemble's observation table is gone, and no later work
-  recovers it.** The ten-run ensemble published summaries and discarded the
-  readings behind them; only run 1's four vectors reached a committed file, and
-  the producing worktree no longer exists. [The observation
-  table](#the-observation-table-and-the-nine-rows-of-it-that-were-not-kept)
-  publishes what remains and the fixture derives every identity that survives —
-  but the two *p* columns cannot be recomputed by anyone, now or later. **Only a
-  fresh ensemble that commits its table closes this**, and the rule that would
-  have prevented it costs forty numbers.
+- ~~**Nine tenths of the ensemble's observation table is gone, and no later work
+  recovers it.**~~ **CLOSED — the logs survived.** The ten runs' console output
+  had been backed up out of tree before the producing worktree was reaped, so
+  [the observation table](#the-observation-table-in-full) is published complete
+  and every figure in both views — **including the two *p* columns this entry
+  had written off as permanently uncheckable** — is now derived from the forty
+  cells by the suite. Recovering it also found the one thing summaries had
+  hidden: the intervals used the wrong degrees of freedom. **What does not close
+  is the practice.** This ensemble was verifiable by luck, not by design; an
+  ensemble that publishes only summaries is one reaped worktree away from being
+  unverifiable, and the fix costs forty numbers.
 - **The segment-order effect is not established, and one machine-session is
   what stands behind that.** rf2-6i0i2's ten counterbalanced runs exclude an
   effect of the size this page once asserted and cannot exclude one of a percent

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -1166,6 +1166,25 @@ Across the whole ensemble the strata **overlap in 37 of 40 row-runs**: M1, M2 an
 narrow each go disjoint once, broad never. The three disjoint splits fall in two
 runs, and no row is disjoint twice.
 
+**All forty row-runs feed the ensemble, the three unresolved ones included — and
+that is a rule, not an oversight.** It has to be said out loud, because the
+per-run gate is fail-closed and the ensemble looks like it walked straight past
+it: three row-runs were individually barred from publishing a magnitude, and
+their run means went into a threshold quoted to four decimals anyway. The two
+rules govern different quantities. `:magnitude-resolved?` decides whether **one
+run's mean may be quoted alone as a threshold**; it says nothing about whether
+that run may be **one observation among ten**. Dropping the three would select
+on the outcome — a disjoint split is precisely the extreme partition, so
+excluding it shrinks the spread and narrows the very interval the ensemble
+exists to compute. The ensemble's warrant is instead the launch count, **ten
+launched, ten published**, and a run discarded for how it read would forfeit it.
+
+The rule is pinned in the instrument as well as here: every row's `red-zone`
+record now carries an `:in-an-ensemble` line beside its `:publishable` one, so a
+`:direction-only` row-run states what it may be used for rather than entering an
+aggregate in silence. (The three fall one each on M1, M2 and narrow; broad never
+split.)
+
 **A disjoint split is a statement about resolution, not a finding.** Under the
 null — no order effect, the six rounds exchangeable — the three-round stratum is
 one of `C(6,3) = 20` equally likely subsets and exactly two of them separate the
@@ -1221,12 +1240,34 @@ questions and are powered differently.
 
 #### View 1 — between runs, one observation per run
 
-The assumption-free test: take the run's published threshold mean, compare the
-five Reagent-start runs against the five UIx-start runs, and use an **exact
-permutation test** over all `C(10,5) = 252` relabellings. Nothing about the
-inside of a run is assumed.
+Take the run's published threshold mean, compare the five Reagent-start runs
+against the five UIx-start runs, and enumerate all `C(10,5) = 252` relabellings.
+Nothing about the inside of a run enters it.
 
-| row | Reagent-start mean | UIx-start mean | difference | exact two-sided *p* | resolution limit |
+**What that enumeration assumes, because the labels were not randomised.** The
+ten starts were **alternated** — run 1 Reagent, run 2 UIx, and so on to run 10 —
+not drawn at random. Enumerating the 252 relabellings is therefore *not* a
+randomisation distribution justified by the assignment mechanism, which is what
+this page called it when it wrote *assumption-free*. It is a permutation test
+whose *p* is exact **only if the ten runs are exchangeable under the null** —
+only if what a run reads does not depend on where in the session it was
+launched. Alternation makes the failure mode concrete rather than theoretical:
+`Reagent-start` and `odd-numbered launch` name **the same five runs**, so a drift
+across the session and a start effect produce the identical partition. That is
+the five-round design's confound — segment order welded to round parity — moved
+up to the run level, and the design that actually ran cannot separate them
+either.
+
+**What survives the correction is the direction of the result.** A confound can
+manufacture an effect; it cannot manufacture a null. Every row below reads null,
+so what these numbers support is *no start effect detectable at this
+resolution, under exchangeability* — and a genuinely randomised assignment is
+what it would take to say more. The counterbalance still does the job it was
+taken for, which was to stop the raw mean being biased by the schedule; it is
+the **inference** about order that rests on an assumption, not the four
+published thresholds.
+
+| row | Reagent-start mean | UIx-start mean | difference | two-sided permutation *p* | resolution limit |
 |---|---|---|---|---|---|
 | M1 mount | 1.2276 | 1.2344 | −0.0068 | 0.770 | ±0.043 |
 | M2 mount | 1.0461 | 1.0740 | −0.0280 | 0.611 | ±0.122 |
@@ -1248,9 +1289,16 @@ The higher-powered test, and the direct successor to the discredited 11-of-12.
 Because a six-round run now carries **both** strata by construction, `d` is a
 *paired* contrast: it differences two numbers measured minutes apart in the same
 process, so run-to-run variance cancels instead of being absorbed. Ten runs, one
-`d` per run per row, an exact **sign-flip randomisation test** over all
-`2¹⁰ = 1024` sign assignments, one-sided in the direction the original claim
-named.
+`d` per run per row, a **sign-flip test** over all `2¹⁰ = 1024` sign
+assignments, one-sided in the direction the original claim named.
+
+**The same caveat, in this view's form.** A sign-flip test is a *randomisation*
+test when the starts were randomised, because flipping a run's start flips the
+sign of its `d` and the 1024 assignments are then exactly the experiments that
+could have happened. These starts were alternated, so they are not. The *p*
+below is exact **only under sign symmetry — each run's `d` symmetric about zero
+under the null** — an assumption this page did not state when it first published
+these numbers. Read them as descriptive.
 
 | row | order effect (mean `d`) | as a ratio | 95% interval | sign-flip *p* | positive |
 |---|---|---|---|---|---|
@@ -1269,7 +1317,7 @@ p = 0.084, is one row of four and would not survive being asked for four times.
 
 And the temporal component the confound hid is no better resolved:
 
-| row | order component | temporal component | exact *p* on the start-group difference |
+| row | order component | temporal component | permutation *p* on the start-group difference |
 |---|---|---|---|
 | M1 mount | +0.0357 | −0.0212 | 0.421 |
 | M2 mount | −0.0837 | +0.0632 | 0.318 |
@@ -1282,6 +1330,88 @@ page counted it — 40 row-runs treated as if independent, which they are not �
 the Reagent-first stratum is higher in **23 of 40**, p = 0.21. The 11-of-12 was
 not a small effect measured well; on the balanced design it is not there at the
 strength it was quoted.
+
+#### The observation table, and the nine rows of it that were not kept
+
+**Both views above are computed from a 10 × 4 table of per-run figures, and that
+table was never committed.** What landed was group means, intervals, ranges and
+*p* values — summaries, with nothing behind them a reader can reach. The PR
+#7303 audit found it, and it is a defect of the record rather than of the
+measurement: no number in either view can be recomputed from this repository.
+
+It is also only partly repairable. The worktree that produced the ensemble is
+gone and nine runs' readings went with it. So this section publishes what the
+repository *does* hold, marks the hole rather than filling it with a
+reconstruction, and pins the derivation of everything that can still be checked.
+The fixture is
+`implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs`.
+
+| run | start | M1 | M2 | broad | narrow |
+|---|---|---|---|---|---|
+| **1** *(pre-registered)* | reagent | **1.2159** | **1.0469** | **0.6662** | **1.1542** |
+| 2 | uix | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
+| 3 | reagent | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
+| 4 | uix | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
+| 5 | reagent | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
+| 6 | uix | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
+| 7 | reagent | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
+| 8 | uix | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
+| 9 | reagent | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
+| 10 | uix | *not recorded* | *not recorded* | *not recorded* | *not recorded* |
+| **group mean — reagent-start (5)** | | 1.2276 | 1.0461 | 0.6295 | 1.1754 |
+| **group mean — uix-start (5)** | | 1.2344 | 1.0740 | 0.6288 | 1.1755 |
+| **threshold (10)** | | 1.2310 | 1.0601 | 0.6291 | 1.1754 |
+| **run-mean range (10)** | | 1.1989 – 1.2931 | 0.9561 – 1.1923 | 0.5792 – 0.6987 | 1.1390 – 1.2186 |
+
+**Run 1's four cells are derived, not transcribed.** The fixture replays its
+six-round vectors — the ones printed under the [RED-ZONE
+table](#red-zone--clock-on-rf2-2rtt62s-witnesses) above — through
+`segment-order-verdict`, and checks the run means, the whole stratum table, and
+run 1's four `d` values against what this page prints. Those `d` values are
+`+0.1026` on M1, `−0.0846` on M2, `+0.0835` on broad and `−0.0279` on narrow:
+**one tenth of View 2's input, and on broad it is opposite in sign to the
+ensemble mean** — which is the case for publishing ten runs rather than one,
+made from the one run that survives.
+
+Rows 2 through 10 are explicit `nil`s in the fixture. That is the honest shape:
+not zero, not missing at random, and **not recoverable** — six published
+constraints per column (two group means, the threshold, the range, the interval,
+the resolution limit) do not invert to nine unknowns, and any table that
+satisfied them would be an invention that happened to fit.
+
+**The derivation, stated once and now executed by the suite.**
+
+1. Per run per row, `d = ln( mean of the Reagent-first stratum ÷ mean of the
+   UIx-first stratum )`, the strata taken from `segment-order-verdict` itself so
+   the statistic and the published partition cannot drift apart. **Checked** on
+   run 1.
+2. A run's published figure is the arithmetic mean of its six rounds.
+   **Checked** on run 1, all four rows.
+3. A group mean is the mean of that start group's five runs; the threshold is
+   the mean of all ten. The counterbalance being 5/5, the threshold **is** the
+   average of the two group means — so the RED-ZONE table and View 1 are one
+   table, and a transcription slip in either shows up. **Checked**, all four
+   rows.
+4. View 1's `difference` column is the reagent-start group mean minus the
+   uix-start one. **Checked** (M2 misses by 0.0001 because the page differenced
+   the unrounded means).
+5. View 2's `as a ratio` column is `exp(mean d)`, and the 95% interval is
+   computed on `d` and printed as ratios — so the midpoint of its two logarithms
+   is the mean `d` itself. **Checked**, four rows and the composite.
+6. The composite is the mean over the four rows, for `d` and for both
+   components, never four trials pooled. **Checked** on both component columns.
+7. The *p* values — View 1's 252 relabellings, View 2's 1024 sign flips — are
+   functions of the ten per-run numbers. **Not checkable, and not checkable
+   later**: nine of the ten are gone.
+
+**So the arithmetic between the published summaries is checkable from the
+repository, and the step from ten runs to those summaries is not.** That is a
+smaller claim than *the inference can be independently recomputed*, and it is
+the true one. The rule it leaves behind is cheap and general: **an ensemble
+publishes its table, not only its summaries.** Ten launches produced ten
+records; committing forty numbers would have cost nothing and would have made
+every *p* on this page reproducible. The next ensemble on this lane commits
+them.
 
 #### Why the two views can disagree, and what n = 5 vs 5 cannot settle
 
@@ -1388,8 +1518,8 @@ differently for its position.
 
 **The ten-run ensemble now bounds how much of this was noise, and it does not
 account for all of it.** Ten runs of the balanced design span 1.1989 – 1.2931 on
-M1; this run's `1.1397` sits *below* that spread. The ten were launched within
-about eight minutes of one another on one machine, so their interval measures
+M1; this run's `1.1397` sits *below* that spread. The ten were launched serially
+on one machine, each after the previous had exited, so their interval measures
 **within-session** run-to-run variation; the corrected run is a different session
 on a different instrument, and it reads lower than any of them. **A candidate
 should therefore be judged against the run-mean spread rather than the interval
@@ -1469,13 +1599,35 @@ P=implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
 git rev-parse <candidate>:$P   # must print 5a727706fcd3268027b1d1b640658ca0be7ab86f
 ```
 
-**What this ensemble does not establish.** All ten ran on one machine inside one
-eight-minute window, so it bounds run-to-run variation *within a session* and
-says nothing about a different machine, a different Chromium or a different day —
-and the corrected run's `1.1397` on M1, from another session, is the standing
-demonstration that between-session spread is wider. Ten runs also cannot prove an
-absence: see [what n = 5 versus n = 5 cannot
+**That blob has since moved twice, and both moves are recorded here rather than
+left to ambush a reader.** rf2-2rtt6.21 added the `:reagent-ratom` arm (its own
+provenance block names the blob it landed), and rf2-6i0i2's follow-up then added
+the `:in-an-ensemble` line to the red-zone record — a constant string published
+*after* every sample of a row is taken, on no measured path. So a checkout at
+HEAD no longer answers `5a727706fc`, and will not again. The hash above
+identifies the instrument **as it stood when the ten runs ran**, which is the
+whole point of pinning it; it was never a claim that the file would stop
+changing. Reproduce against the blob, not against HEAD.
+
+**What this ensemble does not establish.** All ten ran on one machine in one
+session, launched one at a time with each waiting for the previous to exit, so it
+bounds run-to-run variation *within a session* and says nothing about a different
+machine, a different Chromium or a different day — and the corrected run's
+`1.1397` on M1, from another session, is the standing demonstration that
+between-session spread is wider. Ten runs also cannot prove an absence: see [what
+n = 5 versus n = 5 cannot
 settle](#why-the-two-views-can-disagree-and-what-n--5-vs-5-cannot-settle).
+
+> **"One eight-minute window" was not true, and it is corrected rather than
+> quietly deleted.** A single run of this design is minutes, not seconds —
+> `p0_converge_run.cjs` says exactly that where it sets its own twenty-minute
+> sentinel budget — so ten serial runs cannot share an eight-minute window. About
+> eight minutes was the **spacing between launches**, which is a different claim
+> and a session an order of magnitude longer. **The wall-clock span itself was
+> never recorded**, and nothing here reconstructs it. What *is* recorded is that
+> the ten ran serially, on one box, in one sitting — which is the only property
+> the within-session reading ever needed, and the reason the conclusion is
+> unchanged.
 
 ### What would have been appended to rf2-2rtt6.1, had it not been size-locked
 
@@ -1556,12 +1708,25 @@ mutation evidence is on
   page. What is still missing is the mechanism on *this* page and a fix that does
   not cost samples; one row per page plus a per-witness budget makes it harmless
   to these figures, and neither makes it fixed.
+- **Nine tenths of the ensemble's observation table is gone, and no later work
+  recovers it.** The ten-run ensemble published summaries and discarded the
+  readings behind them; only run 1's four vectors reached a committed file, and
+  the producing worktree no longer exists. [The observation
+  table](#the-observation-table-and-the-nine-rows-of-it-that-were-not-kept)
+  publishes what remains and the fixture derives every identity that survives —
+  but the two *p* columns cannot be recomputed by anyone, now or later. **Only a
+  fresh ensemble that commits its table closes this**, and the rule that would
+  have prevented it costs forty numbers.
 - **The segment-order effect is not established, and one machine-session is
   what stands behind that.** rf2-6i0i2's ten counterbalanced runs exclude an
   effect of the size this page once asserted and cannot exclude one of a percent
-  or two. They also all ran inside one eight-minute window on one box; a run from
-  another session read below the whole ensemble's spread on M1. **Between-session
-  variation is unmeasured and is the wider of the two.**
+  or two. They also all ran serially in one session on one box — the span was
+  never recorded, and *"one eight-minute window"* was this page's own error about
+  it; a run from another session read below the whole ensemble's spread on M1.
+  **Between-session variation is unmeasured and is the wider of the two.** And
+  the ten start labels were alternated rather than randomised, so both views'
+  *p* values are exact only under an exchangeability assumption that the design
+  cannot check — the null they report is a weaker warrant than it looked.
 - ~~**`p0_converge_app.cljs`'s own row table still describes the pre-batch
   narrow window, and this page cannot fix it.**~~ **CLOSED by rf2-95m11
   (PR #7288).** The sibling worker finished, and the correction was the one

--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
@@ -84,13 +84,16 @@ const PORT = Number(process.env.HN_PORT || 8141);
 
 // THE LANE'S ONE CACHE RULE (rf2-2rtt6.20, applied here by rf2-2rtt6.22).
 //
-// This driver is the SIXTH program riding `:hicasso-bench`, and shadow-cljs
+// This driver is one of the programs riding `:hicasso-bench`, and shadow-cljs
 // derives the build cache directory from the build id alone — before any
-// `--config-merge` is applied — so all six share one cache entry. The five
-// drivers in `freehand/test/re_frame/bench/hicasso/` clear it before they
-// build, which is why this one can no longer poison THEM; nothing was
-// clearing it on this driver's behalf, so it could still be handed a cache
-// poisoned by whichever arm ran before it. `lane_cache.cjs` carries the
+// `--config-merge` is applied — so every program on the id shares ONE cache
+// entry. There is deliberately no count here: a number goes stale the moment
+// the next lane driver lands, and `git grep -l resetLaneBuildCache` names the
+// current set exactly. The rule is that EVERY driver on the id clears the
+// entry before it builds. The others already did, which is why this one could
+// no longer poison THEM; nothing was clearing it on this driver's behalf, so
+// it could still be handed a cache poisoned by whichever arm ran before it —
+// until rf2-2rtt6.22 added the clear below. `lane_cache.cjs` carries the
 // mechanism, the isolation evidence and the measured cost.
 //
 // Reached by path across the test trees, exactly as `navigate.cjs` is below

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
@@ -1370,6 +1370,27 @@
                                        "threshold. Quote the direction and the stratum "
                                        "bounds; the order-balanced mean is "
                                        (:order-balanced-mean order) "x."))
+                   ;; THE AGGREGATE RULE, stated on every row because the
+                   ;; alternative is that it is assumed (rf2-6i0i2, the PR
+                   ;; #7303 audit). `:publishable` above governs THIS run's
+                   ;; mean quoted ALONE. It says nothing about ensembles, and
+                   ;; the ten-run ensemble on the studio page averaged three
+                   ;; `:direction-only` row-runs of forty into precise
+                   ;; thresholds — correctly, but silently, which is the part
+                   ;; that was wrong. So the row now answers both questions.
+                   :in-an-ensemble
+                   (str "ONE OBSERVATION, whatever `:publishable` says. An "
+                        "ensemble mean takes EVERY launched run — the "
+                        "`:direction-only` ones included — because dropping a "
+                        "run for the way its strata happened to split selects "
+                        "on the outcome: a disjoint split IS the extreme "
+                        "partition, so excluding it shrinks the spread and "
+                        "narrows the very interval it would be used to "
+                        "compute. The ensemble's warrant is the LAUNCH COUNT, "
+                        "stated as `N launched, N published`, and a run "
+                        "dropped for reading badly makes the whole ensemble "
+                        "worthless. What an ensemble may NOT do is inherit "
+                        "this row's per-run gate as if it had passed it.")
                    :rule (str "RULING 1 on rf2-2rtt6.1: the red-zone threshold IS the "
                               "measured UIx ratio for that witness family. A candidate row "
                               "worse than it is RED and needs an explicit operator waiver "

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs
@@ -39,34 +39,38 @@
      what the fail-closed half of the verdict tests — and it never
      fires on any published row.
 
-  ## The balanced ensemble's table, and the hole in it (rf2-6i0i2)
+  ## The balanced ensemble's observation table (rf2-6i0i2)
 
   The PR #7303 audit found that the ten-run counterbalanced ensemble
   published only GROUP MEANS, intervals, ranges and p-values: the ten
   per-run threshold means and the ten per-run `d` values reached no
   committed file, so the central statistics could not be recomputed
-  from the repository. This namespace now carries what the repository
-  actually has, and it says which is which:
+  from the repository.
 
-  * RECORDED — run 1, the pre-registered run, whose four six-round
-    per-round vectors the studio page prints in full. Its four run
-    means and its four `d` values are DERIVED here from those vectors
-    rather than copied, so the page's numbers are checked rather than
-    restated.
-  * NOT RECORDED — runs 2 through 10. Their per-round vectors were
-    never committed and the worktree that produced them is gone, so
-    they cannot be recovered. [[ensemble-run-means]] holds them as
-    explicit `nil`s rather than pretending the table is whole.
+  [[ensemble]] is that table, whole — all forty cells, recovered from
+  the ten runs' own console logs (see its docstring for the provenance,
+  which matters: recovered, not re-run). Everything the studio page
+  publishes about the ensemble is now DERIVED here from those forty
+  cells and checked against the page's claims, which are transcribed
+  into [[view-1]], [[view-1-p]], [[view-2]], [[components]] and
+  [[published-threshold]] purely so that the derivation has something
+  to be checked against.
 
-  What that leaves checkable is the arithmetic BETWEEN the published
-  summaries, and it is not nothing: the 5/5 counterbalance forces the
-  threshold to be the mean of the two start-group means, the View 1
-  difference to be their difference, and every View 2 ratio and
-  interval to be the exponential of a log-scale quantity centred on the
-  mean `d`. Those identities are derived below and they hold. What
-  cannot be checked without the missing rows is the step from ten runs
-  to the group means, and no arrangement of the published summaries
-  recovers it — see [[recorded-runs]].
+  WHAT REPRODUCES: every point estimate — run means and their spread,
+  both start-group means, the difference, the threshold, mean `d`, the
+  ratio, the order and temporal components, the composite — and BOTH
+  p columns, the 252-relabelling permutation test and the 1024-assignment
+  sign-flip test, which the audit correctly said could not be checked
+  and now can. So do the prose counts: 37 of 40 strata overlapping, 23
+  of 40 Reagent-first-higher, 59 of 60 M1 rounds above 1.0.
+
+  WHAT DOES NOT: the INTERVALS. Every one of them is about 2% wider
+  than the data supports, because a t multiplier for EIGHT degrees of
+  freedom was used where a mean of ten needs NINE. The error is
+  conservative and changes no verdict, but it is real and it is
+  reported rather than absorbed — see
+  [[the-published-intervals-used-eight-degrees-of-freedom-where-nine-is-right]]
+  and [[the-corrected-nine-degree-intervals-change-no-verdict]].
 
   Pure arithmetic over recorded vectors: no DOM, no clock, no browser,
   so this runs on every runtime."
@@ -356,62 +360,92 @@
 ;; THE BALANCED ENSEMBLE'S OBSERVATION TABLE (rf2-6i0i2, the PR #7303 audit)
 ;;
 ;; Ten independently launched six-round runs, the starting segment
-;; counterbalanced five and five, one statistic per run per row. The studio
-;; page publishes the SUMMARIES of that table; the table itself was never
-;; committed. What follows is the table as far as the repository has it,
-;; the derivation of every summary that can be recomputed from what IS
-;; there, and an explicit `nil` everywhere it cannot.
+;; counterbalanced five and five. The studio page published the SUMMARIES of
+;; this table and committed nothing behind them, which is what the audit
+;; found. The table itself is below — all forty cells — so every figure in
+;; both views is now derived here rather than asserted there.
+;;
+;; PROVENANCE, because recovered data is not the same as measured data and
+;; must not be passed off as it. These are the CONSOLE LOGS OF THE TEN RUNS
+;; THEMSELVES, taken at the ensemble's landed anchor and recovered from an
+;; out-of-tree backup after the producing worktree was reaped. They are NOT a
+;; re-run: nothing here was measured again, no browser was opened, and the
+;; machine has since moved. Each cell is the `:threshold :per-round` vector
+;; of that run's `red-zone` record, transcribed by script rather than by
+;; hand. The pilot runs that share the backup directory (`run1..run6`,
+;; `runA1..runA3`) are NOT this ensemble and are deliberately absent.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private rows [:M1 :M2 :broad :narrow])
 
-(def ^:private run-1
-  "RUN 1's per-round `uix-subs ÷ reagent-subs` vectors, six rounds,
-  Reagent-start — the one run of the ten whose readings reached a
-  committed file. The commit that balanced the design nominated it as
-  the re-publication run BEFORE the ensemble ran, which is why its
-  vectors are on the page at all; the other nine were summarised and
-  discarded."
-  {:M1     [1.4286 0.9529 1.2681 1.2186 1.1378 1.2892]
-   :M2     [0.8571 1.3846 1.0714 1.0000 1.0794 0.8889]
-   :broad  [0.6190 0.6328 0.6144 0.5532 0.8485 0.7292]
-   :narrow [1.2575 1.1161 1.0999 1.3602 1.0568 1.0346]})
+(def ^:private ensemble
+  "THE 10x4 OBSERVATION TABLE, complete. One entry per launched run, one
+  vector per witness: that run's six per-round `uix-subs ÷ reagent-subs`
+  readings, each floor-normalised in its own round and segment. `:start`
+  is the segment that led round 0.
 
-(def ^:private recorded-runs
-  "How many of the ten runs have their per-run figures in the
-  repository. ONE. This is the audit's finding stated as a number the
-  suite reads: nine tenths of the ensemble's observations exist only in
-  logs that were never committed, on a worktree that no longer exists.
+  Everything the studio page publishes about the ensemble is derived
+  from exactly these numbers — run means, group means, thresholds, `d`,
+  both *p* columns, the components and the composite. Nothing is
+  transcribed from the page except the page's own claims, which live in
+  [[view-1]], [[view-2]] and [[components]] so that the derivation can
+  be checked AGAINST them.
 
-  Raise this — and fill [[ensemble-run-means]] — when an ensemble
-  records its table. It is deliberately asserted below so that the gap
-  is a thing the suite states rather than a thing a reader has to
-  notice."
-  1)
-
-(def ^:private ensemble-run-means
-  "THE 10x4 OBSERVATION TABLE. One row per launched run, one column per
-  witness, each cell that run's six per-round readings — the vector its
-  threshold mean and its `d` are both derived from. `:start` is the
-  segment that led round 0; the ten alternate, so the odd-numbered
-  launches are the Reagent-start group.
-
-  `nil` means NOT RECORDED — not zero, not missing at random, and not
-  reconstructible: nine sets of six-round vectors were summarised into
-  the group means the page prints and then lost. The published group
-  means, threshold, interval and range are the only trace they left,
-  and those are six constraints on nine unknowns per column."
-  [{:run 1  :start :reagent-subs :M1 (:M1 run-1) :M2 (:M2 run-1)
-    :broad (:broad run-1) :narrow (:narrow run-1)}
-   {:run 2  :start :uix-subs     :M1 nil :M2 nil :broad nil :narrow nil}
-   {:run 3  :start :reagent-subs :M1 nil :M2 nil :broad nil :narrow nil}
-   {:run 4  :start :uix-subs     :M1 nil :M2 nil :broad nil :narrow nil}
-   {:run 5  :start :reagent-subs :M1 nil :M2 nil :broad nil :narrow nil}
-   {:run 6  :start :uix-subs     :M1 nil :M2 nil :broad nil :narrow nil}
-   {:run 7  :start :reagent-subs :M1 nil :M2 nil :broad nil :narrow nil}
-   {:run 8  :start :uix-subs     :M1 nil :M2 nil :broad nil :narrow nil}
-   {:run 9  :start :reagent-subs :M1 nil :M2 nil :broad nil :narrow nil}
-   {:run 10 :start :uix-subs     :M1 nil :M2 nil :broad nil :narrow nil}])
+  The vectors are the instrument's four-decimal output. The instrument
+  rounds a mean from UNROUNDED readings while rounding each round
+  separately for display, so a mean re-derived from these vectors can
+  differ from the instrument's own in the fourth decimal. It never
+  exceeded 0.0006 on any figure below, and the tolerances say so."
+  [{:run  1 :start :reagent-subs
+    :M1     [1.4286 0.9529 1.2681 1.2186 1.1378 1.2892]
+    :M2     [0.8571 1.3846 1.0714 1.0000 1.0794 0.8889]
+    :broad  [0.6190 0.6328 0.6144 0.5532 0.8485 0.7292]
+    :narrow [1.2575 1.1161 1.0999 1.3602 1.0568 1.0346]}
+   {:run  2 :start :uix-subs
+    :M1     [1.3375 1.1299 1.2017 1.1522 1.1818 1.1905]
+    :M2     [0.9722 1.0000 1.3333 0.9333 0.8750 0.8000]
+    :broad  [0.4857 0.5769 0.8974 0.5385 0.6282 0.5652]
+    :narrow [1.2584 1.0789 1.0710 1.4104 1.1913 1.0800]}
+   {:run  3 :start :reagent-subs
+    :M1     [1.2466 1.1178 1.2121 1.2286 1.2698 1.4026]
+    :M2     [0.6667 1.6250 1.0714 1.0000 0.7500 0.9796]
+    :broad  [0.5556 0.6500 0.6667 0.8571 0.6216 0.5789]
+    :narrow [1.1959 1.2648 1.1483 1.2884 1.1095 1.1764]}
+   {:run  4 :start :uix-subs
+    :M1     [1.1190 1.3897 1.3231 1.2500 1.0606 1.2727]
+    :M2     [1.3500 0.6667 0.7656 1.0208 1.0000 0.9333]
+    :broad  [0.5314 0.6667 0.6364 0.5556 0.5581 0.5909]
+    :narrow [1.1539 1.1550 1.0691 1.1420 1.1771 1.1368]}
+   {:run  5 :start :reagent-subs
+    :M1     [1.2418 1.1719 1.2308 1.2343 1.2258 1.1290]
+    :M2     [1.2500 1.2000 1.1667 1.1000 1.2000 0.8571]
+    :broad  [0.6222 0.4632 0.4444 0.6875 0.5790 0.7237]
+    :narrow [1.2316 1.1444 1.1786 1.1111 1.2143 1.1566]}
+   {:run  6 :start :uix-subs
+    :M1     [1.1975 1.2418 1.0867 1.2500 1.2983 1.2542]
+    :M2     [1.7143 0.9167 1.0000 1.0000 1.6000 0.9231]
+    :broad  [0.5159 0.6500 0.6250 0.7857 0.8250 0.5641]
+    :narrow [1.2182 1.1334 1.1258 1.1809 1.2282 1.1420]}
+   {:run  7 :start :reagent-subs
+    :M1     [1.1192 1.1426 1.1875 1.3393 1.4194 1.0788]
+    :M2     [0.7778 1.0000 1.2000 1.1000 1.0000 0.6875]
+    :broad  [0.6383 0.7895 0.6316 0.5500 0.5263 0.6944]
+    :narrow [1.1667 1.0947 1.1905 1.1265 1.1470 1.2024]}
+   {:run  8 :start :uix-subs
+    :M1     [1.1004 1.2167 1.2091 1.3241 1.3960 1.5124]
+    :M2     [1.1667 1.2000 1.2000 1.0000 1.1000 1.0000]
+    :broad  [0.4211 0.4259 0.7639 0.7895 0.4865 0.5882]
+    :narrow [1.2055 1.1698 1.1183 1.2355 1.0947 1.1765]}
+   {:run  9 :start :reagent-subs
+    :M1     [1.1549 1.3103 1.1057 1.3158 1.2895 1.3572]
+    :M2     [1.1667 0.9000 1.2000 1.0000 1.1111 1.0909]
+    :broad  [0.7250 0.6000 0.6111 0.5000 0.5526 0.6176]
+    :narrow [1.3105 1.1465 1.1315 1.2145 1.1964 1.1893]}
+   {:run 10 :start :uix-subs
+    :M1     [1.1291 1.3929 1.1008 1.1118 1.2381 1.3621]
+    :M2     [1.1429 1.6364 0.8000 1.2000 1.2833 0.6875]
+    :broad  [0.5814 0.5750 0.7733 0.6571 0.9000 0.7051]
+    :narrow [1.2226 1.1715 1.2373 1.3892 1.1422 1.1487]}])
 
 (def ^:private view-1
   "The page's View 1 table: the two start-group means over five runs
@@ -421,26 +455,66 @@
    :broad  {:reagent-start 0.6295 :uix-start 0.6288 :difference +0.0007 :threshold 0.6291}
    :narrow {:reagent-start 1.1754 :uix-start 1.1755 :difference -0.0001 :threshold 1.1754}})
 
+(def ^:private view-1-p
+  "The page's View 1 permutation *p* on the start-group difference of the
+  threshold means, and its `resolution limit` — the half-width of the 95%
+  interval on that difference."
+  {:M1 {:p 0.770 :limit 0.043} :M2 {:p 0.611 :limit 0.122}
+   :broad {:p 0.984 :limit 0.063} :narrow {:p 0.992 :limit 0.037}})
+
 (def ^:private view-2
   "The page's View 2 table: the mean of the ten per-run `d` values, the
-  same figure as a ratio, and the 95% interval printed as ratios."
-  {:M1        {:mean-d +0.0357 :ratio 1.036 :lo 0.979 :hi 1.097}
-   :M2        {:mean-d -0.0837 :ratio 0.920 :lo 0.795 :hi 1.065}
-   :broad     {:mean-d -0.0388 :ratio 0.962 :lo 0.887 :hi 1.044}
-   :narrow    {:mean-d +0.0070 :ratio 1.007 :lo 0.977 :hi 1.038}
-   :composite {:mean-d -0.0200 :ratio 0.980 :lo 0.934 :hi 1.029}})
+  same figure as a ratio, the 95% interval printed as ratios, the
+  one-sided sign-flip *p*, and how many of the ten `d` are positive."
+  {:M1        {:mean-d +0.0357 :ratio 1.036 :lo 0.979 :hi 1.097 :p 0.084 :positive 7}
+   :M2        {:mean-d -0.0837 :ratio 0.920 :lo 0.795 :hi 1.065 :p 0.889 :positive 4}
+   :broad     {:mean-d -0.0388 :ratio 0.962 :lo 0.887 :hi 1.044 :p 0.856 :positive 5}
+   :narrow    {:mean-d +0.0070 :ratio 1.007 :lo 0.977 :hi 1.038 :p 0.302 :positive 7}
+   :composite {:mean-d -0.0200 :ratio 0.980 :lo 0.934 :hi 1.029 :p 0.823 :positive 6}})
 
 (def ^:private components
-  "The page's order/temporal decomposition. Under a counterbalanced
-  start the average of the two start groups isolates the ORDER term and
-  half their difference isolates the TEMPORAL one."
-  {:M1        {:order +0.0357 :temporal -0.0212}
-   :M2        {:order -0.0837 :temporal +0.0632}
-   :broad     {:order -0.0388 :temporal -0.0011}
-   :narrow    {:order +0.0070 :temporal -0.0063}
-   :composite {:order -0.0200 :temporal +0.0086}})
+  "The page's order/temporal decomposition and the permutation *p* on the
+  start-group difference of `d`. Under a counterbalanced start the
+  average of the two start groups isolates the ORDER term and half their
+  difference isolates the TEMPORAL one."
+  {:M1        {:order +0.0357 :temporal -0.0212 :p 0.421}
+   :M2        {:order -0.0837 :temporal +0.0632 :p 0.318}
+   :broad     {:order -0.0388 :temporal -0.0011 :p 1.000}
+   :narrow    {:order +0.0070 :temporal -0.0063 :p 0.698}
+   :composite {:order -0.0200 :temporal +0.0086 :p 0.810}})
+
+(def ^:private published-threshold
+  "The RED-ZONE table: the threshold, the 95% interval on the mean, and
+  the observed spread of the ten run means."
+  {:M1     {:threshold 1.2310 :lo 1.2105 :hi 1.2514 :run-min 1.1989 :run-max 1.2931}
+   :M2     {:threshold 1.0601 :lo 1.0017 :hi 1.1185 :run-min 0.9561 :run-max 1.1923}
+   :broad  {:threshold 0.6291 :lo 0.5996 :hi 0.6587 :run-min 0.5792 :run-max 0.6987}
+   :narrow {:threshold 1.1754 :lo 1.1579 :hi 1.1930 :run-min 1.1390 :run-max 1.2186}})
+
+;; --- the derivation, in the smallest form that computes the published table ---
 
 (defn- mean [xs] (/ (reduce + 0.0 xs) (count xs)))
+
+(defn- sample-sd [xs]
+  (let [m (mean xs)]
+    (js/Math.sqrt (/ (reduce + 0.0 (map #(* (- % m) (- % m)) xs))
+                     (dec (count xs))))))
+
+(def ^:private t-9
+  "Student's t, 0.975, NINE degrees of freedom — the multiplier for a 95%
+  interval on the mean of TEN run means (`n − 1`)."
+  2.262157)
+
+(def ^:private t-8
+  "Student's t, 0.975, EIGHT degrees of freedom. Correct for the
+  two-sample five-against-five contrast the `resolution limit` column
+  reports, and — see
+  [[the-published-intervals-used-eight-degrees-of-freedom-where-nine-is-right]]
+  — the multiplier the page also used for its one-sample intervals,
+  which is an error."
+  2.306004)
+
+(defn- run-mean [run row] (mean (get run row)))
 
 (defn- d-of
   "THE PER-RUN STATISTIC, defined once and derived nowhere else:
@@ -448,30 +522,98 @@
       d = ln( mean of the Reagent-first stratum / mean of the UIx-first stratum )
 
   positive when the figure reads higher with the Reagent segment
-  leading, which is the direction the withdrawn claim asserted. The
-  strata come from the verdict itself, so this and the published
-  partition cannot drift apart."
+  leading, which is the direction the withdrawn claim asserted.
+
+  The PARTITION comes from `segment-order-verdict`, so this and the
+  published strata cannot drift apart — but the two stratum means are
+  averaged HERE, from the readings, rather than taken from the verdict's
+  own `:mean`. The verdict rounds its means to four decimals for
+  display, and on the broad row that rounding is load-bearing: a
+  sign-flip *p* moves in steps of 1/1024 = 0.00098, and the fourth
+  decimal is enough to carry exactly one of the 1024 assignments across
+  the observed mean. Rounded strata give broad 878/1024 = 0.8574; the
+  readings give 877/1024 = 0.8564, which is the 0.856 the page
+  publishes. A displayed number is not an input."
   [vs start]
   (let [r (app/segment-order-verdict vs 6 start)]
-    (js/Math.log (/ (:mean (:reagent-first r)) (:mean (:uix-first r))))))
+    (js/Math.log (/ (mean (:per-round (:reagent-first r)))
+                    (mean (:per-round (:uix-first r)))))))
+
+(defn- reagent-start? [run] (= :reagent-subs (:start run)))
+
+(defn- by-start
+  "Split ten per-run values into [reagent-start-five uix-start-five],
+  keyed on the run that produced each."
+  [values]
+  [(keep-indexed #(when (reagent-start? (nth ensemble %1)) %2) values)
+   (keep-indexed #(when-not (reagent-start? (nth ensemble %1)) %2) values)])
+
+(defn- thresholds [row] (mapv #(run-mean % row) ensemble))
+(defn- d-values  [row] (mapv #(d-of (get % row) (:start %)) ensemble))
+
+(defn- combinations-from
+  "Every way to choose `k` indices from `[start, n)`, ascending. Called
+  once, as C(10,5) = 252, and deliberately nothing more general."
+  [start n k]
+  (if (zero? k)
+    [[]]
+    (mapcat (fn [i] (map #(cons i %) (combinations-from (inc i) n (dec k))))
+            (range start (inc (- n k))))))
+
+(defn- permutation-p
+  "EXACT two-sided permutation *p* on the difference between the two
+  start groups: enumerate all C(10,5) = 252 relabellings and count those
+  whose |difference| is at least the observed one.
+
+  Exact GIVEN the relabelling set — which is not the same as exact by
+  randomisation, because the ten starts were alternated rather than
+  drawn. The studio page states that assumption; this only computes the
+  number."
+  [values]
+  (let [[a b] (by-start values)
+        obs   (js/Math.abs (- (mean a) (mean b)))
+        combs (combinations-from 0 10 5)
+        hits  (count (filter (fn [c]
+                               (let [s (set c)
+                                     x (keep-indexed #(when (s %1) %2) values)
+                                     y (keep-indexed #(when-not (s %1) %2) values)]
+                                 (>= (js/Math.abs (- (mean x) (mean y))) (- obs 1e-12))))
+                             combs))]
+    (/ hits (double (count combs)))))
+
+(defn- sign-flip-p
+  "EXACT one-sided sign-flip *p* over all 2^10 = 1024 sign assignments,
+  in the positive direction the withdrawn claim named. Exact only under
+  sign symmetry of `d` under the null — again an assumption, stated on
+  the page, not established by the design."
+  [ds]
+  (let [obs (mean ds)
+        hits (count (filter (fn [m]
+                              (>= (mean (map-indexed
+                                          (fn [i d] (if (bit-test m i) (- d) d))
+                                          ds))
+                                  (- obs 1e-12)))
+                            (range 1024)))]
+    (/ hits 1024.0)))
+
 
 ;; ---------------------------------------------------------------------------
-;; What the repository holds of the table, stated rather than implied
+;; The table is whole, and it is the ensemble the page describes
 ;; ---------------------------------------------------------------------------
 
-(deftest nine-of-the-ten-runs-were-never-recorded
-  (testing "the audit's completeness finding, as arithmetic the suite
-           reads. One run of ten has its readings in a committed file;
-           the other nine exist only as the group means they were
-           folded into. Filling them needs a fresh ensemble that commits
-           its table, never a reconstruction from the summaries"
-    (let [recorded (filter #(some? (:M1 %)) ensemble-run-means)]
-      (is (= 10 (count ensemble-run-means)) "ten launched, ten in the table")
-      (is (= recorded-runs (count recorded)))
-      (is (= [1] (mapv :run recorded)) "and it is the pre-registered run")
-      (is (= 5 (count (filter #(= :reagent-subs (:start %)) ensemble-run-means)))
-          "the start is counterbalanced 5/5 across the ten launches")
-      (is (= 5 (count (filter #(= :uix-subs (:start %)) ensemble-run-means)))))))
+(deftest the-observation-table-is-complete-and-counterbalanced
+  (testing "forty cells, ten runs, six rounds each, and the start
+           counterbalanced five and five — the design the page claims,
+           checked against the data rather than asserted beside it"
+    (is (= 10 (count ensemble)) "ten launched, ten in the table")
+    (is (= (range 1 11) (map :run ensemble)))
+    (is (= 5 (count (filter reagent-start? ensemble))))
+    (is (= 5 (count (remove reagent-start? ensemble))))
+    (doseq [run ensemble row rows]
+      (is (= 6 (count (get run row)))
+          (str "run " (:run run) " " (name row) " has six rounds"))
+      (is (every? pos? (get run row))
+          (str "run " (:run run) " " (name row) " is all positive ratios")))))
 
 (deftest the-start-label-is-the-launch-parity-and-that-is-a-confound
   (testing "the ten labels were ALTERNATED, not drawn at random, so
@@ -479,120 +621,268 @@
            runs. A drift across the session would therefore reproduce a
            start effect exactly — the same confound the five-round
            design had between segment order and round parity, moved up
-           to the run level. It is why the page's permutation p-values
-           are exact only under an assumption, and the assumption is
-           stated there rather than left to the reader"
-    (is (= (mapv :run (filter #(= :reagent-subs (:start %)) ensemble-run-means))
-           (filterv odd? (mapv :run ensemble-run-means))))))
+           to the run level. It is why the permutation and sign-flip
+           p-values below are exact only under an assumption, and the
+           page states the assumption rather than leaving it to the
+           reader"
+    (is (= (mapv :run (filter reagent-start? ensemble))
+           (filterv odd? (mapv :run ensemble))))))
 
-;; ---------------------------------------------------------------------------
-;; Run 1 is derived from its vectors, not copied from the page
-;; ---------------------------------------------------------------------------
-
-(deftest run-1s-published-means-are-derivable-from-its-vectors
-  (testing "the four run means the page prints for the pre-registered
-           run fall out of the six-round vectors it prints beside them"
+(deftest run-1-is-the-pre-registered-run-the-page-prints
+  (testing "the page prints one run's vectors in full — the run the
+           design nominated in advance — and they are this table's first
+           entry. That is the join between the recovered logs and what
+           was already published, and it is what identifies the backup
+           as THIS ensemble rather than one of the pilots beside it"
+    (let [r1 (first ensemble)]
+      (is (= 1 (:run r1)))
+      (is (= :reagent-subs (:start r1)))
+      (is (= [1.4286 0.9529 1.2681 1.2186 1.1378 1.2892] (:M1 r1)))
+      (is (= [0.8571 1.3846 1.0714 1.0000 1.0794 0.8889] (:M2 r1)))
+      (is (= [0.6190 0.6328 0.6144 0.5532 0.8485 0.7292] (:broad r1)))
+      (is (= [1.2575 1.1161 1.0999 1.3602 1.0568 1.0346] (:narrow r1))))
     (doseq [[row published] [[:M1 1.2159] [:M2 1.0469] [:broad 0.6662] [:narrow 1.1542]]]
-      (is (close? published (mean (get run-1 row))) (name row)))))
-
-(deftest run-1s-partition-is-the-one-the-page-publishes
-  (testing "the stratum table the page prints for the pre-registered run
-           — Reagent-first mean [min–max] against UIx-first — is what
-           the verdict derives from the same vectors, and all four rows
-           overlap, so all four were entitled to publish a magnitude"
-    (doseq [[row rf-mean rf-min rf-max uf-mean uf-min uf-max]
-            [[:M1     1.2782 1.1378 1.4286 1.1536 0.9529 1.2892]
-             [:M2     1.0027 0.8571 1.0794 1.0912 0.8889 1.3846]
-             [:broad  0.6940 0.6144 0.8485 0.6384 0.5532 0.7292]
-             [:narrow 1.1381 1.0568 1.2575 1.1703 1.0346 1.3602]]]
-      (let [r  (app/segment-order-verdict (get run-1 row) 6 :reagent-subs)
-            rf (:reagent-first r)
-            uf (:uix-first r)]
-        (is (true? (:balanced-design? r)) (name row))
-        (is (= 3 (:n rf)) (name row))
-        (is (= 3 (:n uf)) (name row))
-        ;; M2's Reagent-first mean is the one page figure that misses at
-        ;; the fourth decimal: 1.0027 there against 1.00263 from the
-        ;; four-decimal vector, because the page rounded from the raw
-        ;; readings. Recorded here rather than papered over.
-        (is (close-to? rf-mean (:mean rf) 0.0002) (name row))
-        (is (close? rf-min (:min rf)) (name row))
-        (is (close? rf-max (:max rf)) (name row))
-        (is (close-to? uf-mean (:mean uf) 0.0002) (name row))
-        (is (close? uf-min (:min uf)) (name row))
-        (is (close? uf-max (:max uf)) (name row))
-        (is (true? (:strata-overlap? r)) (name row))
-        (is (true? (:magnitude-resolved? r)) (name row))))))
-
-(deftest run-1s-d-values-are-one-tenth-of-view-2s-input
-  (testing "the four `d` values of run 1, derived from its vectors. They
-           are ONE of the ten rows View 2 averages, and they are printed
-           here because a mean whose summands are nowhere in the
-           repository is not a checkable mean — one summand is better
-           than none, and it is also the demonstration that a single run
-           says very little: run 1's broad `d` is +0.0835 where the
-           ensemble mean is −0.0388, opposite in sign"
-    (doseq [[row expected] [[:M1 +0.1026] [:M2 -0.0846] [:broad +0.0835] [:narrow -0.0279]]]
-      (is (close-to? expected (d-of (get run-1 row) :reagent-subs) 0.0002) (name row)))))
+      (is (close? published (run-mean (first ensemble) row)) (name row)))))
 
 ;; ---------------------------------------------------------------------------
-;; The identities the 5/5 counterbalance forces, which ARE checkable
+;; Every published figure, re-derived from the forty cells
 ;; ---------------------------------------------------------------------------
 
-(deftest the-threshold-is-the-mean-of-the-two-start-group-means
-  (testing "five runs each side means the grand mean over ten IS the
-           average of the two group means — so the threshold column and
-           the View 1 columns are one table, and a typo in either shows
-           up here"
+(deftest the-run-mean-spread-reproduces
+  (testing "the RED-ZONE table's `run means (10)` column is the min and
+           max of this table's ten run means, per row. Four ranges, eight
+           endpoints, all from the data"
     (doseq [row rows]
-      (let [{:keys [reagent-start uix-start threshold]} (get view-1 row)]
-        (is (close? threshold (/ (+ reagent-start uix-start) 2.0)) (name row))))))
+      (let [t (thresholds row)
+            {:keys [run-min run-max]} (get published-threshold row)]
+        (is (close? run-min (apply min t)) (name row))
+        (is (close? run-max (apply max t)) (name row))))))
 
-(deftest view-1s-difference-column-is-the-difference
-  (testing "the start-group contrast, recomputed. M2 misses by 0.0001
-           because the page differenced the unrounded group means"
+(deftest the-threshold-is-the-mean-of-the-ten-run-means
+  (testing "and, because the counterbalance is 5/5, equally the average
+           of the two start-group means — so the RED-ZONE table and View
+           1 are one table and cannot drift apart"
     (doseq [row rows]
-      (let [{:keys [reagent-start uix-start difference]} (get view-1 row)]
-        (is (close-to? difference (- reagent-start uix-start) 0.0002) (name row))))))
+      (let [t (thresholds row)
+            [rs us] (by-start t)
+            {:keys [threshold]} (get published-threshold row)]
+        (is (close? threshold (mean t)) (name row))
+        (is (close? threshold (/ (+ (mean rs) (mean us)) 2.0)) (name row))))))
 
-(deftest view-2s-ratio-column-is-the-exponential-of-mean-d
-  (testing "`d` is a log ratio, so the `as a ratio` column is exp(mean
-           d) and nothing else. Three decimals on the page, so 0.001"
-    (doseq [[row {:keys [mean-d ratio]}] view-2]
-      (is (close-to? ratio (js/Math.exp mean-d) 0.001) (name row)))))
+(deftest view-1s-group-means-and-difference-reproduce
+  (testing "the five Reagent-start runs against the five UIx-start runs,
+           and the difference column that contrasts them"
+    (doseq [row rows]
+      (let [[rs us] (by-start (thresholds row))
+            {:keys [reagent-start uix-start difference]} (get view-1 row)]
+        (is (close? reagent-start (mean rs)) (name row))
+        (is (close? uix-start (mean us)) (name row))
+        (is (close? difference (- (mean rs) (mean us))) (name row))))))
 
-(deftest view-2s-interval-is-centred-on-mean-d-in-log-space
-  (testing "the 95% interval is printed as ratios but computed on `d`,
-           so the midpoint of its two logarithms must be the mean `d`
-           itself. This is the check that catches an interval pasted
-           against the wrong row"
-    (doseq [[row {:keys [mean-d lo hi]}] view-2]
-      (is (close-to? mean-d
-                     (/ (+ (js/Math.log lo) (js/Math.log hi)) 2.0)
-                     0.0006)
+(deftest view-1s-permutation-p-reproduces
+  (testing "THE FIRST OF THE TWO p COLUMNS THE AUDIT COULD NOT CHECK.
+           All 252 relabellings of the ten runs into two fives,
+           enumerated, counting those whose group difference is at least
+           the observed one in absolute value. The page publishes 0.770 /
+           0.611 / 0.984 / 0.992 and the data yields them"
+    (doseq [row rows]
+      (is (close-to? (:p (get view-1-p row)) (permutation-p (thresholds row)) 0.0006)
           (name row)))))
 
-(deftest the-composite-is-the-mean-over-the-four-rows
-  (testing "the pre-registered statistic was fixed in advance as the
-           mean over the four rows — never as four trials — and both
-           components obey it"
-    (is (close-to? (:order (:composite components))
-                   (mean (map #(:order (get components %)) rows))
-                   0.0002))
-    (is (close-to? (:temporal (:composite components))
-                   (mean (map #(:temporal (get components %)) rows))
-                   0.0002))
-    (is (close-to? (:mean-d (:composite view-2))
-                   (mean (map #(:mean-d (get view-2 %)) rows))
-                   0.0002)
-        "and View 2's composite row is the same mean of the same four
-         numbers, so the two tables cannot disagree in silence")))
+(deftest view-1s-resolution-limit-reproduces
+  (testing "the half-width of the 95% interval on the start-group
+           difference — a genuine two-sample five-against-five contrast,
+           so EIGHT degrees of freedom is correct here. It reproduces
+           exactly, which is what makes the one-sample intervals'
+           multiplier diagnosable below"
+    (doseq [row rows]
+      (let [[rs us] (by-start (thresholds row))
+            pooled  (js/Math.sqrt (/ (+ (* 4 (js/Math.pow (sample-sd rs) 2))
+                                        (* 4 (js/Math.pow (sample-sd us) 2)))
+                                     8))
+            limit   (* t-8 pooled (js/Math.sqrt (/ 2.0 5)))]
+        (is (close-to? (:limit (get view-1-p row)) limit 0.0006) (name row))))))
+
+(deftest view-2s-mean-d-ratio-and-counts-reproduce
+  (testing "one `d` per run per row, averaged; the `as a ratio` column is
+           exp of it; and the `positive` column counts the runs whose `d`
+           is above zero"
+    (doseq [row rows]
+      (let [d (d-values row)
+            {:keys [mean-d ratio positive]} (get view-2 row)]
+        (is (close? mean-d (mean d)) (name row))
+        (is (close-to? ratio (js/Math.exp (mean d)) 0.0006) (name row))
+        (is (= positive (count (filter pos? d))) (name row))))))
+
+(deftest view-2s-sign-flip-p-reproduces
+  (testing "THE SECOND p COLUMN THE AUDIT COULD NOT CHECK. All 1024 sign
+           assignments, one-sided in the direction the withdrawn claim
+           named. The page publishes 0.084 / 0.889 / 0.856 / 0.302 and
+           the data yields them — including M1's 0.084, the largest lean
+           on the page and still not significant"
+    (doseq [row rows]
+      (is (close-to? (:p (get view-2 row)) (sign-flip-p (d-values row)) 0.0006)
+          (name row)))))
+
+(deftest the-components-and-their-permutation-p-reproduce
+  (testing "averaging the two start groups of `d` isolates the ORDER
+           term; half their difference isolates the TEMPORAL one; and
+           the last column is the same 252-relabelling test applied to
+           `d` rather than to the threshold means"
+    (doseq [row rows]
+      (let [d (d-values row)
+            [rs us] (by-start d)
+            {:keys [order temporal p]} (get components row)]
+        (is (close? order (/ (+ (mean rs) (mean us)) 2.0)) (name row))
+        (is (close? temporal (/ (- (mean rs) (mean us)) 2.0)) (name row))
+        (is (close-to? p (permutation-p d) 0.0006) (name row))))))
+
+(deftest the-composite-is-the-per-run-mean-over-the-four-rows
+  (testing "the pre-registered statistic: per RUN, the mean of that run's
+           four `d` values — never four trials pooled. Its mean, its
+           ratio, its sign-flip p, its positive count and both components
+           all reproduce"
+    (let [ds   (into {} (map (fn [r] [r (d-values r)])) rows)
+          comp (mapv (fn [i] (mean (map #(nth (get ds %) i) rows))) (range 10))
+          [rs us] (by-start comp)
+          {:keys [mean-d ratio p positive]} (:composite view-2)
+          {:keys [order temporal] cp :p} (:composite components)]
+      (is (close? mean-d (mean comp)))
+      (is (close-to? ratio (js/Math.exp (mean comp)) 0.0006))
+      (is (= positive (count (filter pos? comp))))
+      (is (close-to? p (sign-flip-p comp) 0.0006))
+      (is (close? order (/ (+ (mean rs) (mean us)) 2.0)))
+      (is (close? temporal (/ (- (mean rs) (mean us)) 2.0)))
+      (is (close-to? cp (permutation-p comp) 0.0006))))
+  (testing "and the mean of the four ROW means equals the mean of the ten
+           per-run composites, which is why the page may print either and
+           get the same number"
+    (is (close? (:mean-d (:composite view-2))
+                (mean (map #(mean (d-values %)) rows))))))
 
 (deftest the-order-component-is-view-2s-mean-d
   (testing "the decomposition's ORDER column is not a second estimate:
            averaging the two start groups is what the paired `d` already
-           does once the start is counterbalanced, so the two columns
-           are the same number and the page prints both only because
-           they answer differently-worded questions"
+           does once the start is counterbalanced, so the two columns are
+           the same number and the page prints both only because they
+           answer differently-worded questions"
     (doseq [row rows]
       (is (close? (:mean-d (get view-2 row)) (:order (get components row))) (name row)))))
+
+;; ---------------------------------------------------------------------------
+;; The counts the page quotes in prose
+;; ---------------------------------------------------------------------------
+
+(defn- strata-of [row]
+  (mapcat (fn [run]
+            (let [v (app/segment-order-verdict (get run row) 6 (:start run))]
+              [(:reagent-first v) (:uix-first v)]))
+          ensemble))
+
+(defn- rounds-of [row] (mapcat #(get % row) ensemble))
+
+(deftest the-per-row-round-and-stratum-counts-reproduce
+  (testing "`59 of 60 rounds above 1.0; 19 of 20 order strata wholly
+           above it` on M1, and `all 60 / all 20` below on broad and
+           above on narrow — the sentences the RED-ZONE table's verdict
+           column carries, counted from the forty cells"
+    (is (= 59 (count (filter #(> % 1.0) (rounds-of :M1)))))
+    (is (= 19 (count (filter #(> (:min %) 1.0) (strata-of :M1)))))
+    (is (= 60 (count (filter #(< % 1.0) (rounds-of :broad)))))
+    (is (= 20 (count (filter #(< (:max %) 1.0) (strata-of :broad)))))
+    (is (= 60 (count (filter #(> % 1.0) (rounds-of :narrow)))))
+    (is (= 20 (count (filter #(> (:min %) 1.0) (strata-of :narrow)))))))
+
+(deftest the-magnitude-resolution-and-the-discredited-statistic-reproduce
+  (testing "`the strata overlap in 37 of 40 row-runs`, the three
+           unresolved ones falling one each on M1, M2 and narrow and
+           never on broad, and `no row is disjoint twice`. Those three
+           are the individually-unpublishable points the aggregate rule
+           deliberately keeps in the ensemble"
+    (let [verdicts (for [run ensemble row rows]
+                     [(:run run) row (app/segment-order-verdict (get run row) 6 (:start run))])
+          unresolved (remove #(:magnitude-resolved? (nth % 2)) verdicts)]
+      (is (= 37 (count (filter #(:magnitude-resolved? (nth % 2)) verdicts))))
+      (is (= 3 (count unresolved)))
+      (is (= #{:M1 :M2 :narrow} (set (map second unresolved))) "broad never splits")
+      (is (= 2 (count (set (map first unresolved))))
+          "the three fall in two runs, so no row is disjoint twice")
+      (is (every? #(false? (:refuse? (nth % 2))) verdicts)
+          "and the fail-closed DIRECTION half never fires on any of the forty")))
+  (testing "`counted the way the page counted it — 40 row-runs treated as
+           if independent — the Reagent-first stratum is higher in 23 of
+           40`, which is the discredited 11-of-12 restated on the
+           balanced design and no longer an effect"
+    (is (= 23 (count (for [run ensemble row rows
+                           :let [v (app/segment-order-verdict (get run row) 6 (:start run))]
+                           :when (> (:mean (:reagent-first v)) (:mean (:uix-first v)))]
+                       [(:run run) row]))))))
+
+;; ---------------------------------------------------------------------------
+;; THE ONE DISAGREEMENT, pinned rather than conformed away
+;; ---------------------------------------------------------------------------
+
+(deftest the-published-intervals-used-eight-degrees-of-freedom-where-nine-is-right
+  (testing "EVERY point estimate and both p columns reproduce. The
+           INTERVALS do not, and they miss the same way on every row:
+           the page's are about 2% wider than the data supports.
+
+           The cause is identifiable rather than guessed. An interval on
+           the mean of TEN run means is a one-sample Student-t interval
+           with n − 1 = NINE degrees of freedom, t = 2.2622. The
+           multiplier the page actually used is ~2.306 — t at EIGHT
+           degrees of freedom, which is the CORRECT multiplier for the
+           two-sample five-against-five `resolution limit` column
+           standing beside it, and which reproduces exactly there. The
+           same t was reused for the one-sample case.
+
+           This test asserts the diagnosis both ways: the published
+           half-width is NOT t-9 times the standard error, and IS t-8
+           times it. The studio page states the disagreement and prints
+           both intervals; nothing is silently conformed"
+    (doseq [row rows]
+      (let [t    (thresholds row)
+            se   (/ (sample-sd t) (js/Math.sqrt 10))
+            {:keys [lo hi]} (get published-threshold row)
+            half (/ (- hi lo) 2.0)]
+        (is (not (close-to? half (* t-9 se) 0.0002))
+            (str (name row) " — the published interval is NOT the 9-df one"))
+        (is (close-to? half (* t-8 se) 0.0006)
+            (str (name row) " — it IS the 8-df one")))))
+  (testing "the same reuse in View 2's intervals on `d`, where the page
+           prints ratios to three decimals, so the multiplier can only be
+           recovered to about ±0.02 — enough to exclude 2.2622 and to
+           include 2.3060"
+    (doseq [row rows]
+      (let [d    (d-values row)
+            se   (/ (sample-sd d) (js/Math.sqrt 10))
+            {:keys [lo hi]} (get view-2 row)
+            half (/ (- (js/Math.log hi) (js/Math.log lo)) 2.0)
+            mult (/ half se)]
+        (is (> mult 2.28) (str (name row) " — above the 9-df multiplier 2.2622"))
+        (is (< mult 2.34) (str (name row) " — consistent with the 8-df 2.3060"))))))
+
+(deftest the-corrected-nine-degree-intervals-change-no-verdict
+  (testing "the error is CONSERVATIVE — the published intervals are too
+           WIDE — so every verdict on the page survives it. Recomputed
+           here so that the claim is arithmetic rather than reassurance"
+    (doseq [[row lo hi] [[:M1 1.2109 1.2510] [:M2 1.0028 1.1173]
+                         [:broad 0.6001 0.6581] [:narrow 1.1582 1.1926]]]
+      (let [t  (thresholds row)
+            se (/ (sample-sd t) (js/Math.sqrt 10))
+            m  (mean t)]
+        (is (close? lo (- m (* t-9 se))) (name row))
+        (is (close? hi (+ m (* t-9 se))) (name row)))))
+  (testing "M1, broad and narrow stay clear of 1.0 on the corrected
+           interval and M2 still only just clears parity, exactly as
+           published"
+    (let [ci (fn [row]
+               (let [t (thresholds row) se (/ (sample-sd t) (js/Math.sqrt 10))]
+                 [(- (mean t) (* t-9 se)) (+ (mean t) (* t-9 se))]))]
+      (is (> (first (ci :M1)) 1.0) "M1 wholly above 1.0")
+      (is (< (second (ci :broad)) 1.0) "broad wholly below 1.0")
+      (is (> (first (ci :narrow)) 1.0) "narrow wholly above 1.0")
+      (is (> (first (ci :M2)) 1.0)
+          "M2's interval on the MEAN clears parity — barely, and it stays
+           a diagnostic row precisely because its individual runs do not:
+           three of the ten read below 1.0 outright"))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs
@@ -39,6 +39,35 @@
      what the fail-closed half of the verdict tests — and it never
      fires on any published row.
 
+  ## The balanced ensemble's table, and the hole in it (rf2-6i0i2)
+
+  The PR #7303 audit found that the ten-run counterbalanced ensemble
+  published only GROUP MEANS, intervals, ranges and p-values: the ten
+  per-run threshold means and the ten per-run `d` values reached no
+  committed file, so the central statistics could not be recomputed
+  from the repository. This namespace now carries what the repository
+  actually has, and it says which is which:
+
+  * RECORDED — run 1, the pre-registered run, whose four six-round
+    per-round vectors the studio page prints in full. Its four run
+    means and its four `d` values are DERIVED here from those vectors
+    rather than copied, so the page's numbers are checked rather than
+    restated.
+  * NOT RECORDED — runs 2 through 10. Their per-round vectors were
+    never committed and the worktree that produced them is gone, so
+    they cannot be recovered. [[ensemble-run-means]] holds them as
+    explicit `nil`s rather than pretending the table is whole.
+
+  What that leaves checkable is the arithmetic BETWEEN the published
+  summaries, and it is not nothing: the 5/5 counterbalance forces the
+  threshold to be the mean of the two start-group means, the View 1
+  difference to be their difference, and every View 2 ratio and
+  interval to be the exponential of a log-scale quantity centred on the
+  mean `d`. Those identities are derived below and they hold. What
+  cannot be checked without the missing rows is the step from ten runs
+  to the group means, and no arrangement of the published summaries
+  recovers it — see [[recorded-runs]].
+
   Pure arithmetic over recorded vectors: no DOM, no clock, no browser,
   so this runs on every runtime."
   (:require [cljs.test :refer-macros [deftest is testing]]
@@ -75,7 +104,17 @@
   [vs]
   (app/segment-order-verdict vs 5 :reagent-subs))
 
-(defn- close? [a b] (< (js/Math.abs (- a b)) 0.0002))
+(defn- close-to?
+  "Within `tol`. Every figure below is quoted from the studio page at
+  four decimals, and several of the page's own numbers were rounded
+  from unrounded readings rather than from the four-decimal vectors it
+  prints — so an identity that holds exactly on the raw data can miss
+  by a unit in the last place here. `tol` is stated at each call site
+  for that reason, never widened silently."
+  [a b tol]
+  (< (js/Math.abs (- a b)) tol))
+
+(defn- close? [a b] (close-to? a b 0.0002))
 
 ;; ---------------------------------------------------------------------------
 ;; 1. The audit's M1 partition, reproduced from the published vector
@@ -312,3 +351,248 @@
            and it does not reach this ensemble's floor"
     (is (< 1.218 (apply min (mapcat :vs (:M1 leg))))
         "1.218 is below every round the second author measured")))
+
+;; ---------------------------------------------------------------------------
+;; THE BALANCED ENSEMBLE'S OBSERVATION TABLE (rf2-6i0i2, the PR #7303 audit)
+;;
+;; Ten independently launched six-round runs, the starting segment
+;; counterbalanced five and five, one statistic per run per row. The studio
+;; page publishes the SUMMARIES of that table; the table itself was never
+;; committed. What follows is the table as far as the repository has it,
+;; the derivation of every summary that can be recomputed from what IS
+;; there, and an explicit `nil` everywhere it cannot.
+;; ---------------------------------------------------------------------------
+
+(def ^:private rows [:M1 :M2 :broad :narrow])
+
+(def ^:private run-1
+  "RUN 1's per-round `uix-subs ÷ reagent-subs` vectors, six rounds,
+  Reagent-start — the one run of the ten whose readings reached a
+  committed file. The commit that balanced the design nominated it as
+  the re-publication run BEFORE the ensemble ran, which is why its
+  vectors are on the page at all; the other nine were summarised and
+  discarded."
+  {:M1     [1.4286 0.9529 1.2681 1.2186 1.1378 1.2892]
+   :M2     [0.8571 1.3846 1.0714 1.0000 1.0794 0.8889]
+   :broad  [0.6190 0.6328 0.6144 0.5532 0.8485 0.7292]
+   :narrow [1.2575 1.1161 1.0999 1.3602 1.0568 1.0346]})
+
+(def ^:private recorded-runs
+  "How many of the ten runs have their per-run figures in the
+  repository. ONE. This is the audit's finding stated as a number the
+  suite reads: nine tenths of the ensemble's observations exist only in
+  logs that were never committed, on a worktree that no longer exists.
+
+  Raise this — and fill [[ensemble-run-means]] — when an ensemble
+  records its table. It is deliberately asserted below so that the gap
+  is a thing the suite states rather than a thing a reader has to
+  notice."
+  1)
+
+(def ^:private ensemble-run-means
+  "THE 10x4 OBSERVATION TABLE. One row per launched run, one column per
+  witness, each cell that run's six per-round readings — the vector its
+  threshold mean and its `d` are both derived from. `:start` is the
+  segment that led round 0; the ten alternate, so the odd-numbered
+  launches are the Reagent-start group.
+
+  `nil` means NOT RECORDED — not zero, not missing at random, and not
+  reconstructible: nine sets of six-round vectors were summarised into
+  the group means the page prints and then lost. The published group
+  means, threshold, interval and range are the only trace they left,
+  and those are six constraints on nine unknowns per column."
+  [{:run 1  :start :reagent-subs :M1 (:M1 run-1) :M2 (:M2 run-1)
+    :broad (:broad run-1) :narrow (:narrow run-1)}
+   {:run 2  :start :uix-subs     :M1 nil :M2 nil :broad nil :narrow nil}
+   {:run 3  :start :reagent-subs :M1 nil :M2 nil :broad nil :narrow nil}
+   {:run 4  :start :uix-subs     :M1 nil :M2 nil :broad nil :narrow nil}
+   {:run 5  :start :reagent-subs :M1 nil :M2 nil :broad nil :narrow nil}
+   {:run 6  :start :uix-subs     :M1 nil :M2 nil :broad nil :narrow nil}
+   {:run 7  :start :reagent-subs :M1 nil :M2 nil :broad nil :narrow nil}
+   {:run 8  :start :uix-subs     :M1 nil :M2 nil :broad nil :narrow nil}
+   {:run 9  :start :reagent-subs :M1 nil :M2 nil :broad nil :narrow nil}
+   {:run 10 :start :uix-subs     :M1 nil :M2 nil :broad nil :narrow nil}])
+
+(def ^:private view-1
+  "The page's View 1 table: the two start-group means over five runs
+  each, their difference, and the threshold the row publishes."
+  {:M1     {:reagent-start 1.2276 :uix-start 1.2344 :difference -0.0068 :threshold 1.2310}
+   :M2     {:reagent-start 1.0461 :uix-start 1.0740 :difference -0.0280 :threshold 1.0601}
+   :broad  {:reagent-start 0.6295 :uix-start 0.6288 :difference +0.0007 :threshold 0.6291}
+   :narrow {:reagent-start 1.1754 :uix-start 1.1755 :difference -0.0001 :threshold 1.1754}})
+
+(def ^:private view-2
+  "The page's View 2 table: the mean of the ten per-run `d` values, the
+  same figure as a ratio, and the 95% interval printed as ratios."
+  {:M1        {:mean-d +0.0357 :ratio 1.036 :lo 0.979 :hi 1.097}
+   :M2        {:mean-d -0.0837 :ratio 0.920 :lo 0.795 :hi 1.065}
+   :broad     {:mean-d -0.0388 :ratio 0.962 :lo 0.887 :hi 1.044}
+   :narrow    {:mean-d +0.0070 :ratio 1.007 :lo 0.977 :hi 1.038}
+   :composite {:mean-d -0.0200 :ratio 0.980 :lo 0.934 :hi 1.029}})
+
+(def ^:private components
+  "The page's order/temporal decomposition. Under a counterbalanced
+  start the average of the two start groups isolates the ORDER term and
+  half their difference isolates the TEMPORAL one."
+  {:M1        {:order +0.0357 :temporal -0.0212}
+   :M2        {:order -0.0837 :temporal +0.0632}
+   :broad     {:order -0.0388 :temporal -0.0011}
+   :narrow    {:order +0.0070 :temporal -0.0063}
+   :composite {:order -0.0200 :temporal +0.0086}})
+
+(defn- mean [xs] (/ (reduce + 0.0 xs) (count xs)))
+
+(defn- d-of
+  "THE PER-RUN STATISTIC, defined once and derived nowhere else:
+
+      d = ln( mean of the Reagent-first stratum / mean of the UIx-first stratum )
+
+  positive when the figure reads higher with the Reagent segment
+  leading, which is the direction the withdrawn claim asserted. The
+  strata come from the verdict itself, so this and the published
+  partition cannot drift apart."
+  [vs start]
+  (let [r (app/segment-order-verdict vs 6 start)]
+    (js/Math.log (/ (:mean (:reagent-first r)) (:mean (:uix-first r))))))
+
+;; ---------------------------------------------------------------------------
+;; What the repository holds of the table, stated rather than implied
+;; ---------------------------------------------------------------------------
+
+(deftest nine-of-the-ten-runs-were-never-recorded
+  (testing "the audit's completeness finding, as arithmetic the suite
+           reads. One run of ten has its readings in a committed file;
+           the other nine exist only as the group means they were
+           folded into. Filling them needs a fresh ensemble that commits
+           its table, never a reconstruction from the summaries"
+    (let [recorded (filter #(some? (:M1 %)) ensemble-run-means)]
+      (is (= 10 (count ensemble-run-means)) "ten launched, ten in the table")
+      (is (= recorded-runs (count recorded)))
+      (is (= [1] (mapv :run recorded)) "and it is the pre-registered run")
+      (is (= 5 (count (filter #(= :reagent-subs (:start %)) ensemble-run-means)))
+          "the start is counterbalanced 5/5 across the ten launches")
+      (is (= 5 (count (filter #(= :uix-subs (:start %)) ensemble-run-means)))))))
+
+(deftest the-start-label-is-the-launch-parity-and-that-is-a-confound
+  (testing "the ten labels were ALTERNATED, not drawn at random, so
+           `Reagent-start` and `odd-numbered launch` name the same five
+           runs. A drift across the session would therefore reproduce a
+           start effect exactly — the same confound the five-round
+           design had between segment order and round parity, moved up
+           to the run level. It is why the page's permutation p-values
+           are exact only under an assumption, and the assumption is
+           stated there rather than left to the reader"
+    (is (= (mapv :run (filter #(= :reagent-subs (:start %)) ensemble-run-means))
+           (filterv odd? (mapv :run ensemble-run-means))))))
+
+;; ---------------------------------------------------------------------------
+;; Run 1 is derived from its vectors, not copied from the page
+;; ---------------------------------------------------------------------------
+
+(deftest run-1s-published-means-are-derivable-from-its-vectors
+  (testing "the four run means the page prints for the pre-registered
+           run fall out of the six-round vectors it prints beside them"
+    (doseq [[row published] [[:M1 1.2159] [:M2 1.0469] [:broad 0.6662] [:narrow 1.1542]]]
+      (is (close? published (mean (get run-1 row))) (name row)))))
+
+(deftest run-1s-partition-is-the-one-the-page-publishes
+  (testing "the stratum table the page prints for the pre-registered run
+           — Reagent-first mean [min–max] against UIx-first — is what
+           the verdict derives from the same vectors, and all four rows
+           overlap, so all four were entitled to publish a magnitude"
+    (doseq [[row rf-mean rf-min rf-max uf-mean uf-min uf-max]
+            [[:M1     1.2782 1.1378 1.4286 1.1536 0.9529 1.2892]
+             [:M2     1.0027 0.8571 1.0794 1.0912 0.8889 1.3846]
+             [:broad  0.6940 0.6144 0.8485 0.6384 0.5532 0.7292]
+             [:narrow 1.1381 1.0568 1.2575 1.1703 1.0346 1.3602]]]
+      (let [r  (app/segment-order-verdict (get run-1 row) 6 :reagent-subs)
+            rf (:reagent-first r)
+            uf (:uix-first r)]
+        (is (true? (:balanced-design? r)) (name row))
+        (is (= 3 (:n rf)) (name row))
+        (is (= 3 (:n uf)) (name row))
+        ;; M2's Reagent-first mean is the one page figure that misses at
+        ;; the fourth decimal: 1.0027 there against 1.00263 from the
+        ;; four-decimal vector, because the page rounded from the raw
+        ;; readings. Recorded here rather than papered over.
+        (is (close-to? rf-mean (:mean rf) 0.0002) (name row))
+        (is (close? rf-min (:min rf)) (name row))
+        (is (close? rf-max (:max rf)) (name row))
+        (is (close-to? uf-mean (:mean uf) 0.0002) (name row))
+        (is (close? uf-min (:min uf)) (name row))
+        (is (close? uf-max (:max uf)) (name row))
+        (is (true? (:strata-overlap? r)) (name row))
+        (is (true? (:magnitude-resolved? r)) (name row))))))
+
+(deftest run-1s-d-values-are-one-tenth-of-view-2s-input
+  (testing "the four `d` values of run 1, derived from its vectors. They
+           are ONE of the ten rows View 2 averages, and they are printed
+           here because a mean whose summands are nowhere in the
+           repository is not a checkable mean — one summand is better
+           than none, and it is also the demonstration that a single run
+           says very little: run 1's broad `d` is +0.0835 where the
+           ensemble mean is −0.0388, opposite in sign"
+    (doseq [[row expected] [[:M1 +0.1026] [:M2 -0.0846] [:broad +0.0835] [:narrow -0.0279]]]
+      (is (close-to? expected (d-of (get run-1 row) :reagent-subs) 0.0002) (name row)))))
+
+;; ---------------------------------------------------------------------------
+;; The identities the 5/5 counterbalance forces, which ARE checkable
+;; ---------------------------------------------------------------------------
+
+(deftest the-threshold-is-the-mean-of-the-two-start-group-means
+  (testing "five runs each side means the grand mean over ten IS the
+           average of the two group means — so the threshold column and
+           the View 1 columns are one table, and a typo in either shows
+           up here"
+    (doseq [row rows]
+      (let [{:keys [reagent-start uix-start threshold]} (get view-1 row)]
+        (is (close? threshold (/ (+ reagent-start uix-start) 2.0)) (name row))))))
+
+(deftest view-1s-difference-column-is-the-difference
+  (testing "the start-group contrast, recomputed. M2 misses by 0.0001
+           because the page differenced the unrounded group means"
+    (doseq [row rows]
+      (let [{:keys [reagent-start uix-start difference]} (get view-1 row)]
+        (is (close-to? difference (- reagent-start uix-start) 0.0002) (name row))))))
+
+(deftest view-2s-ratio-column-is-the-exponential-of-mean-d
+  (testing "`d` is a log ratio, so the `as a ratio` column is exp(mean
+           d) and nothing else. Three decimals on the page, so 0.001"
+    (doseq [[row {:keys [mean-d ratio]}] view-2]
+      (is (close-to? ratio (js/Math.exp mean-d) 0.001) (name row)))))
+
+(deftest view-2s-interval-is-centred-on-mean-d-in-log-space
+  (testing "the 95% interval is printed as ratios but computed on `d`,
+           so the midpoint of its two logarithms must be the mean `d`
+           itself. This is the check that catches an interval pasted
+           against the wrong row"
+    (doseq [[row {:keys [mean-d lo hi]}] view-2]
+      (is (close-to? mean-d
+                     (/ (+ (js/Math.log lo) (js/Math.log hi)) 2.0)
+                     0.0006)
+          (name row)))))
+
+(deftest the-composite-is-the-mean-over-the-four-rows
+  (testing "the pre-registered statistic was fixed in advance as the
+           mean over the four rows — never as four trials — and both
+           components obey it"
+    (is (close-to? (:order (:composite components))
+                   (mean (map #(:order (get components %)) rows))
+                   0.0002))
+    (is (close-to? (:temporal (:composite components))
+                   (mean (map #(:temporal (get components %)) rows))
+                   0.0002))
+    (is (close-to? (:mean-d (:composite view-2))
+                   (mean (map #(:mean-d (get view-2 %)) rows))
+                   0.0002)
+        "and View 2's composite row is the same mean of the same four
+         numbers, so the two tables cannot disagree in silence")))
+
+(deftest the-order-component-is-view-2s-mean-d
+  (testing "the decomposition's ORDER column is not a second estimate:
+           averaging the two start groups is what the paired `d` already
+           does once the start is counterbalanced, so the two columns
+           are the same number and the page prints both only because
+           they answer differently-worded questions"
+    (doseq [row rows]
+      (is (close? (:mean-d (get view-2 row)) (:order (get components row))) (name row)))))


### PR DESCRIPTION
Two beads: the audit-reopen remainder of **rf2-6i0i2** (P2) and **rf2-veu0q** (P4).

No re-measurement anywhere in this PR. The ten-run ensemble is complete and its numbers are published; the job was to make the inference checkable from the repository.

## rf2-6i0i2 — the PR #7303 audit

The audit found that the ten-run counterbalanced ensemble published only group means, intervals, ranges and *p* values, so none of its central statistics could be recomputed from the repository.

**The 10 × 4 observation table is now committed, complete.** I first concluded it was unrecoverable — the producing worktree had been reaped. It was not: the ten runs' console logs had been backed up out of tree, and all forty cells are now in the fixture and on the page.

**Provenance is stated as recovery, not measurement.** These are the ten runs' logs at the ensemble's landed anchor, recovered from an out-of-tree backup. Nothing was re-measured, no browser was opened, and the machine has since moved. The identification is checked rather than assumed: run 1's four vectors in the backup are exactly the four the page already printed for the pre-registered run, which is what ties the backup to *this* ensemble rather than to one of the pilot runs beside it. A test asserts it, and the pilots are excluded.

### What reproduces

Every point estimate, **and both *p* columns the audit said could not be checked**:

| quantity | result |
|---|---|
| the four run-mean ranges — all eight endpoints | reproduces |
| threshold, and its identity with the average of the two start-group means | reproduces |
| View 1's group means and `difference` column | reproduces |
| **View 1's permutation *p*** — all `C(10,5) = 252` relabellings | **0.770 / 0.611 / 0.984 / 0.992** |
| the `resolution limit` column | reproduces |
| mean `d`, the ratio column, the `positive` counts | reproduces |
| **View 2's sign-flip *p*** — all `2¹⁰ = 1024` assignments | **0.084 / 0.889 / 0.856 / 0.302** |
| order and temporal components, and their permutation *p* | reproduces |
| the composite, per-run and never four pooled trials | reproduces, including its 0.823 |
| prose counts: 37 of 40 strata overlapping, 23 of 40 Reagent-first-higher, 59 of 60 M1 rounds above 1.0, all 60 / all 20 on broad and narrow | reproduces |

### What does not reproduce — a finding, reported in neither direction

**Every 95% interval on the page is about 2% too wide.** An interval on the mean of *ten* run means is a one-sample Student-t interval with `n − 1 =` **nine** degrees of freedom, `t = 2.2622`. The multiplier actually used is `≈ 2.306` — `t` at **eight**.

The mistake is nameable, not merely detectable: eight *is* correct for the two-sample five-against-five `resolution limit` column standing beside it (`5 + 5 − 2`), and that column reproduces **exactly**. The same `t` was then reused for the one-sample case.

I did not conform the table to the page or quietly conform the page to the table. The old intervals are **struck in place** with the corrected ones beside them, at all ten sites that quoted one, and three tests pin the diagnosis: the published half-width is *not* the 9-df one, it *is* the 8-df one, and the corrected intervals change no verdict (the error is conservative — too wide — so every claim made inside them survives narrower ones). Thresholds, *p* values, ranges and counts were all correct and are untouched.

One derivation detail decides a published digit: `d` takes its **partition** from `segment-order-verdict` but averages the readings itself, because the verdict rounds stratum means for display. On broad that rounding is load-bearing — a sign-flip *p* moves in steps of `1/1024`, and the fourth decimal carries exactly one assignment across the observed mean (`878/1024` rounded vs `877/1024` from the readings; 877 is the published `0.856`). A displayed number is not an input.

### The audit's other two findings

**CORRECTNESS.** *"The assumption-free test"* was wrong: the starts were **alternated**, not randomised, so enumerating `C(10,5)` is not a randomisation distribution justified by the assignment mechanism — it is exact only under exchangeability, and alternation makes `Reagent-start` and `odd-numbered launch` the same five runs, so a session drift and a start effect give the identical partition. The `2¹⁰` sign-flip is exact only under sign symmetry. Both assumptions are now stated, the table headers read `permutation p` rather than `exact p`, and the conclusion survives because it is a null: a confound can manufacture an effect, not an absence.

**THE UNPUBLISHABLE POINT.** Three of forty row-runs were barred from publishing a magnitude yet fed four-decimal thresholds. That is correct — dropping them selects on the outcome, since a disjoint split *is* the extreme partition — but it was nowhere stated. The rule is now on the page and pinned in the instrument: every `red-zone` record carries `:in-an-ensemble` beside `:publishable`. The recovered table confirms the three fall one each on M1, M2 and narrow, in two runs, and broad never splits.

**The false wording.** *"One eight-minute window"* was not true — a single run of this design is minutes, as `p0_converge_run.cjs` says where it sets a twenty-minute sentinel. Eight minutes was launch spacing; the span was never recorded and is **not** reconstructed here.

No general statistics framework: two enumerations sized to this one table (252 and 1024), a mean, a sample sd, and two `t` constants.

## rf2-veu0q — the lane-cache counts

`hicasso_narrow_run.cjs` called itself *"the SIXTH program riding `:hicasso-bench`"* and credited *"the five drivers"* with clearing the shared entry. Verified by grep: **eight** programs ride the id and all eight require and call `resetLaneBuildCache` — six in `freehand/test/re_frame/bench/hicasso/`, plus `core/test/re_frame/bench/p0_run.cjs` (retargeted by rf2-etmyc), plus this driver. Rather than swap six for eight and wait for the next driver, the comment now states the invariant **without a count** and points at `git grep -l resetLaneBuildCache` — how `lane_cache.cjs` itself puts it, and what the bead asked for.

## Note for the reviewer

Rebased onto **#7310** (rf2-2rtt6.21) after it merged mid-flight. It had already moved the `p0_converge_app.cljs` blob the ensemble's provenance pins, so the provenance note records **both** moves rather than attributing the change to this PR alone.

## Quality gates

| gate | result |
|---|---|
| `npm run test:cljs` (the `node-test` build — the lane TESTING.md maps `*_cljs_test.cljs` under `implementation/` to) | **exit 0** — 11,993 tests / 60,034 assertions, 0 failures, 0 errors |
| negative control on the new tests | deliberately broke one assertion → **exit 1**, `FAIL in (…)`; reverted and re-run green. The new tests demonstrably execute rather than being silently skipped |
| `clj-kondo` 2026.04.15 (CI-pinned, via `-Sdeps`, over `lint.yml`'s exact `--lint` surface, `--fail-level error`) | **exit 0** — `errors: 0`; zero findings in any touched file |
| `node --check` on `hicasso_narrow_run.cjs` | **exit 0** — the comment-only change still gets a compile check |
| `python -m mkdocs build --strict` | **exit 0**, zero warnings — **but see the caveat below** |
| studio-page checks (because mkdocs does not cover it) | all 15 internal anchors resolve to real headings; no table has inconsistent column counts |

**Gate caveat, stated rather than glossed:** `mkdocs build --strict` **does not validate the file this PR's doc change touches.** `mkdocs.yml` excludes `docs/design/hicasso/` from the scan, so the strict build proves only that the rest of the site still builds. The page was therefore checked directly, by resolving every internal anchor against the heading slugs and verifying table column counts. (One duplicate heading slug, `provenance`, predates this branch on `main`; the single link to it resolves to the intended section.)

Every gate was run in the foreground to completion.
