### PR TITLE
spine,test: observe the render→commit window at the first commit (rf2-2rtt6.13)

### DIFF
--- a/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
+++ b/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
@@ -265,8 +265,8 @@ carried against its copy (pre-fix: 3,501 vs 3,489, 0.33%).
 `re-frame.adapter.uix` (first-class, shipped), `re-frame.freehand.substrate`, and
 `re-frame.ui.substrate`. One change, three beneficiaries.
 
-**Correctness.** The fallback stopped being a live re-read. That window is
-covered, and the covering mechanism is now pinned by a test rather than argued:
+**Correctness.** The fallback stopped being a live re-read. That was measured to
+be a real defect, and it has since been repaired; this section records both.
 
 * React's `useSyncExternalStore` calls `getSnapshot` again after `subscribe`
   returns, and by then `subscribe-fn` has published the committed reaction, so
@@ -276,12 +276,35 @@ covered, and the covering mechanism is now pinned by a test rather than argued:
   `updateStoreInstance`, and passive effects run in push order — and
   `assert-use-subscribe-render-phase-reaction-not-retained` reds if a React
   upgrade ever reorders them.
-* What is given up is narrower than "the live re-read": on a **concurrent** lane
-  the render-phase store-consistency check no longer catches such a write, so the
-  corrective re-render happens one commit later instead of before the commit.
-  Both before and after, the corrective re-render happens.
-* A frozen value satisfies React's "the result of getSnapshot should be cached"
-  rule at least as well as the previous live deref did.
+* **This page originally claimed what was given up was "narrower than the live
+  re-read" — a corrective re-render one commit later rather than before the
+  commit. The merged-PR audit rejected that, and measurement agrees.** A value
+  frozen at render time compares equal to itself, so React's **pre-commit**
+  store-consistency check became a no-op *by construction*: on a concurrent lane
+  the torn render was no longer discarded, it **committed**. Observed at the
+  first commit, on a real browser host, cold, with an unmoved control beside it:
+  first commit `{:dom "g=0", :db 1}` — the DOM carrying the render's value while
+  app-db had already moved. That is a layout-visible, paint-eligible stale
+  commit, not delayed bookkeeping, and it is the shape rf2-so3io / rf2-anmdr
+  price (a panel mounting as a permission drops).
+* **Repaired, still without retaining a handle** (rf2-2rtt6.13, after the audit).
+  The pre-commit read prefers the reaction the hook's unspent **escrow token**
+  is already holding — live by construction, since that +1 is what keeps the
+  entry tenanted for the commit to adopt (rf2-2rtt6.25). Nothing new is
+  retained: the token's hold predates the repair and ends at adoption or at the
+  macrotask horizon, never at the component's lifetime, and the memo slot and
+  `get-snap`'s closure still hold a value and no handle. The same row now reads
+  `{:dom "g=1", :db 1}` — React sees the movement, discards the torn render, and
+  the first commit is fresh. Pinned by
+  `assert-use-subscribe-render-to-commit-window-first-commit`.
+* On a **blocking** lane (`root.render` on the default lane — every shipped
+  consumer's normal configuration) React pushes no pre-commit store-consistency
+  check at all, so the render's value is the committed value whatever
+  `getSnapshot` says. That row is unchanged by any of this and is pinned too, so
+  a React release that starts checking blocking lanes shows up as a failure.
+* Every source `get-snap` can return is `Object.is`-stable across back-to-back
+  calls — a memoised reaction's value or a frozen one — which is what React's
+  "the result of getSnapshot should be cached" rule requires.
 * The key-change path (rf2-naz09e) is unchanged in shape: the memo is keyed on
   `stable-key`, so a key change recomputes the snapshot for the **new** target and
   the key guard still rejects the stale `committed-ref`. If anything it is now
@@ -297,11 +320,14 @@ builds two. Removing the double build is rf2-2rtt6.14, **ruled ADOPT on
 + commit-time adoption), implemented by rf2-2rtt6.25 on these same lines and
 sequenced after this change.
 
-**Rejected alternative.** Making the fallback live *without* retention — having
-`get-snap` call `subs/subscribe-once` on the fallback path — is unsafe. Each call
-builds a fresh reaction with a fresh memo cell, so a sub returning a collection
-yields a fresh, non-`Object.is` value on every `getSnapshot`, which is React's
-documented infinite-render-loop condition.
+**Rejected alternative.** Making the fallback live *without* retention by having
+`get-snap` **re-subscribe** per call — `subs/subscribe-once`, or a balanced
+`subscribe`/`unsubscribe` round trip — is unsafe. On a miss each call builds a
+fresh reaction with a fresh memo cell, so a sub returning a collection yields a
+fresh, non-`Object.is` value on every `getSnapshot`, which is React's documented
+infinite-render-loop condition. The repair above is not that: it *reads a
+reference something else already owns*, so it cannot build anything, and it
+falls back to the frozen value precisely when there is nothing live to read.
 
 **How the change is pinned.** `assert-use-subscribe-render-phase-reaction-not-retained`
 (`implementation/core/test/re_frame/adapter/react_shared_suite.cljs`, run by the

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -210,6 +210,53 @@
     ($ :div {:data-tick tick}
        ($ ProbeKeyChangeChild))))
 
+;; ---- render→commit window probes (rf2-2rtt6.13) ---------------------------
+;; Three components in one pass. The SUBSCRIBER reads the query. The MUTATOR
+;; renders after it and writes app-db from its own render body, so the write
+;; lands strictly between that read and the commit — deterministic, no timer.
+;; The OBSERVER's layout effect records the FIRST committed, layout-visible
+;; DOM (a render React discards before committing never runs one). The suite
+;; installs the write thunk — nil for the unmoved control — arms the one shot,
+;; and reads the atoms.
+
+(def ^:private gap-write!       (atom nil))
+(def ^:private gap-armed?       (atom false))
+(def ^:private gap-first-commit (atom nil))
+(def ^:private gap-mount-node   (atom nil))
+(def ^:private gap-db-read      (atom nil))
+(def ^:private gap-observed     (atom []))
+
+(defui ProbeGapSubscriber []
+  (let [v (uix-adapter/use-subscribe @refcount-target [:rf.uix-gap/n])]
+    (swap! gap-observed conj v)
+    ($ :div (str "g=" v))))
+
+(defui ProbeGapMutator []
+  ;; ONE-SHOT render-phase write. Disarming BEFORE the write is what lets a
+  ;; corrective re-render converge: React discarding a torn concurrent render
+  ;; re-runs this body, and a second write would keep the store moving forever.
+  (when @gap-armed?
+    (reset! gap-armed? false)
+    (when-let [w @gap-write!] (w)))
+  ($ :span))
+
+(defui ProbeGapObserver []
+  (uix/use-layout-effect
+    (fn []
+      (when (nil? @gap-first-commit)
+        (reset! gap-first-commit
+                {:dom (.-textContent ^js @gap-mount-node)
+                 :db  (when-let [read-db @gap-db-read] (read-db))}))
+      js/undefined)
+    [])
+  ($ :span))
+
+(defui ProbeGapRoot []
+  ($ :div
+     ($ ProbeGapSubscriber)
+     ($ ProbeGapMutator)
+     ($ ProbeGapObserver)))
+
 ;; ---- cfg + forwarded deftests ---------------------------------------------
 
 (def ^:private cfg
@@ -257,6 +304,21 @@
    ;; rf2-2rtt6.13 — its own frame (so its own sub-cache), because the
    ;; assertion is only load-bearing on a COLD read and it says so.
    :nr-frame              :rf.uix-no-retain/probe-frame
+   ;; rf2-2rtt6.13 (audit) — the render→commit window observed at the FIRST
+   ;; commit. Four rows = four frames, because the pre-commit path is only
+   ;; reachable on a COLD read and each row must be one.
+   :probe-gap-element     (fn [] (uix/$ ProbeGapRoot))
+   :gap-write!            gap-write!
+   :gap-armed?            gap-armed?
+   :gap-first-commit      gap-first-commit
+   :gap-mount-node        gap-mount-node
+   :gap-db-read           gap-db-read
+   :gap-observed          gap-observed
+   :gap-query             :rf.uix-gap/n
+   :gap-blocking-frame            :rf.uix-gap/blocking-frame
+   :gap-blocking-control-frame    :rf.uix-gap/blocking-control-frame
+   :gap-concurrent-frame          :rf.uix-gap/concurrent-frame
+   :gap-concurrent-control-frame  :rf.uix-gap/concurrent-control-frame
    ;; rf2-2rtt6.25 — the provisional hand-off's three own frames, for the same
    ;; reason: adoption, the one-shot reaper, the layer-2 horizon cascade and
    ;; the SSR horizon are all COLD-read properties, so each needs a sub-cache
@@ -370,6 +432,16 @@
 ;; getSnapshot call, which is what still catches a render→commit write).
 (deftest use-subscribe-render-phase-reaction-not-retained
   (suite/assert-use-subscribe-render-phase-reaction-not-retained cfg))
+
+;; rf2-2rtt6.13 (merged-PR audit of #7304) — a write landing in the
+;; render→commit gap, observed AT THE FIRST COMMIT (layout-visible, i.e.
+;; paint-eligible) rather than after the dust settles: two lanes, each with an
+;; unmoved control. The blocking row pins React's own no-pre-commit-check
+;; behaviour; the concurrent row pins that our pre-commit snapshot can still
+;; REPORT the movement, so React discards the torn render instead of painting
+;; state the app-db has already revoked.
+(deftest use-subscribe-render-to-commit-window-first-commit
+  (suite/assert-use-subscribe-render-to-commit-window-first-commit cfg))
 
 ;; rf2-2rtt6.25 — the hook-scoped provisional hand-off. A cold mount's commit
 ;; ADOPTS the reaction its render built (one construction, not two); the reaper

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -2226,7 +2226,16 @@
   decrements WITHOUT clearing the holder's ref, so a spent token can be pointing
   at a reaction whose last reference has just gone. Reading only while unspent is
   what keeps the frozen-value fallback as the answer in exactly the cases where
-  there is no live reaction to prefer to it."
+  there is no live reaction to prefer to it.
+
+  What `spent?` does NOT cover, stated rather than glossed: an eviction that
+  takes the entry out from under a still-unspent token — hot reload,
+  `clear-sub-cache!`, `destroy-frame!` — landing INSIDE a single render→commit
+  gap. The release already no-ops for that case (it is identity-guarded), and a
+  deref here would read a pull-based recompute against current sources, so the
+  VALUE stays right; only a sub body re-registered within that same gap could
+  differ. The lifetime-scale version of that hazard is what `committed-ref`
+  exists to close, and it is closed."
   [token]
   (if (and (some? token) (not (aget token 3)))
     @(aget token 0)
@@ -2564,10 +2573,15 @@
                 ;; decomposition.md; instrument landed 24e8822d7f). And on the
                 ;; cold path that handle used to be DEAD before the factory
                 ;; returned. So deref while the reaction is live and return the
-                ;; VALUE; nothing holds the reaction once the factory returns.
-                ;; The escrow above does not walk this back — the token holds a
-                ;; ref-COUNT that the reaper owns, not a handle the component
-                ;; retains.
+                ;; VALUE; no HOOK SLOT holds the reaction once the factory
+                ;; returns. The escrow above does not walk this back. Its token
+                ;; does carry the reaction — that is how the release
+                ;; identity-guards itself — but the token is owned by the reaper
+                ;; and dies at adoption or at the macrotask horizon, so what the
+                ;; component retains for its lifetime is still a value and not a
+                ;; handle. That distinction is what makes the token safe for
+                ;; `get-snap` to READ pre-commit (`provisional-snapshot`) without
+                ;; reopening the 769 B this change closed.
                 render-snapshot
                 (use-memo (fn []
                             (let [stored    (.-current committed-ref)

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -2194,6 +2194,44 @@
     (subs/unsubscribe-if-reaction (aget token 1) (aget token 2) (aget token 0)))
   nil)
 
+(def ^:private no-provisional
+  "Miss sentinel for `provisional-snapshot` — a distinct object identity, so a
+  live escrow whose reaction derefs to `nil`/`false` is still a HIT and is not
+  confused with having no escrow at all."
+  (js-obj))
+
+(defn- provisional-snapshot
+  "The LIVE value of the reaction an UNSPENT escrow token is holding, or
+  `no-provisional` when there is nothing live to read.
+
+  This is what keeps `use-subscribe`'s pre-commit snapshot honest without
+  retaining anything (rf2-2rtt6.13, the audit of PR #7304). The render-phase
+  memo returns a VALUE, so between a render and the commit that owns it the
+  hook has no reaction of its own — and a value frozen at render time compares
+  equal to itself forever, which makes React's pre-commit store-consistency
+  check a no-op BY CONSTRUCTION and lets a write that landed in that gap commit
+  (and paint) stale. Measured: on a concurrent lane the first commit showed the
+  render's value while app-db had already moved.
+
+  But the token ALREADY holds the reaction, and holds it LIVE: that +1 is the
+  whole point of the hand-off (rf2-2rtt6.25), and it is what makes the entry
+  still tenanted when the commit arrives to adopt it. So the pre-commit read has
+  a live source available for free. Nothing new is retained — the retention is
+  the token's, it predates this fn, and it ends at adoption or at the macrotask
+  horizon, never at the component's lifetime. The memo slot and `get-snap`'s
+  closure still hold a value and no handle, which is exactly what rf2-2rtt6.13
+  bought.
+
+  `spent?` (slot 3) is load-bearing, not defensive. The reaper flips it and
+  decrements WITHOUT clearing the holder's ref, so a spent token can be pointing
+  at a reaction whose last reference has just gone. Reading only while unspent is
+  what keeps the frozen-value fallback as the answer in exactly the cases where
+  there is no live reaction to prefer to it."
+  [token]
+  (if (and (some? token) (not (aget token 3)))
+    @(aget token 0)
+    no-provisional))
+
 (defn- make-provisional-escrow
   "Build one spine's provisional-escrow acquirer: `(escrow! reaction frame-kw
   query-v)` mints the token, queues it, arms the reaper, and answers the token.
@@ -2411,12 +2449,15 @@
                 ;; `get-snap` pinned to the disposed v1 handle keeps rendering
                 ;; v1 output. React's `useSyncExternalStore` contract requires
                 ;; `getSnapshot` to read a stable, LIVE source — so `get-snap`
-                ;; reads the committed reaction stored here once
-                ;; `subscribe-fn` has run (post-commit), falling back to the
-                ;; render-phase SNAPSHOT VALUE (`render-snapshot` below) only
-                ;; for the pre-commit reads. Since rf2-2rtt6.13 that fallback
-                ;; is a value and not a handle, so the disposed reaction is not
-                ;; merely un-preferred — it is unreachable.
+                ;; reads the committed reaction stored here once `subscribe-fn`
+                ;; has run (post-commit), and before that reads the reaction the
+                ;; hook's unspent ESCROW TOKEN is holding, which is live by
+                ;; construction (rf2-2rtt6.25's +1 is what keeps it tenanted).
+                ;; The render-phase SNAPSHOT VALUE (`render-snapshot` below) is
+                ;; the last resort, for when neither is live. Since rf2-2rtt6.13
+                ;; nothing here holds a handle for the component's lifetime, so
+                ;; a disposed reaction is not merely un-preferred — it is
+                ;; unreachable.
                 ;;
                 ;; rf2-naz09e: the ref stores the committed reaction KEY-TAGGED
                 ;; as `#js [stable-key committed]` (see `subscribe-fn` and
@@ -2573,26 +2614,55 @@
                 ;; committed reaction's value `=` the render-phase one
                 ;; (rf2-cmfln), so the source swap is tear-free.
                 ;;
-                ;; rf2-2rtt6.13 — the fallback stops being a LIVE re-read, and
-                ;; the render→commit window stays covered. React's
-                ;; `useSyncExternalStore` mount path pushes its `subscribeToStore`
-                ;; passive effect BEFORE its `updateStoreInstance` one, and
-                ;; passive effects run in push order; `updateStoreInstance` then
-                ;; calls `getSnapshot` again and force-re-renders if the result
-                ;; moved. So by the time that second call runs, `subscribe-fn`
-                ;; has already published the committed reaction and the call
-                ;; reads the LIVE one — an app-db write landing between render
-                ;; and commit is still detected, one commit later than a live
-                ;; fallback would have caught it on a concurrent lane. A frozen
-                ;; value also satisfies React's "the result of getSnapshot
-                ;; should be cached" rule at least as well as a live deref.
+                ;; rf2-2rtt6.13 — the pre-commit read is LIVE, and it is live
+                ;; without retaining anything. Three sources, in strict order of
+                ;; how current they are:
                 ;;
-                ;; The rejected alternative — keeping the fallback live WITHOUT
-                ;; retention, by having `get-snap` re-subscribe per call — is
-                ;; unsafe: each call would build a fresh reaction with a fresh
-                ;; memo cell, so a collection-returning sub yields a fresh,
-                ;; non-`Object.is` value on every `getSnapshot`, which is
-                ;; React's documented infinite-render-loop condition.
+                ;;   1. the COMMITTED reaction, once `subscribe-fn` has published
+                ;;      it under this key — the steady state;
+                ;;   2. the reaction the hook's UNSPENT ESCROW TOKEN is holding
+                ;;      (`provisional-snapshot`) — the render→commit window and
+                ;;      the key-change render, the only two moments (1) cannot
+                ;;      answer;
+                ;;   3. `render-snapshot`, the value the render phase read, when
+                ;;      neither of those is live.
+                ;;
+                ;; (2) is what closes the window the audit of PR #7304 opened.
+                ;; The memo returning a VALUE rather than a handle is the whole
+                ;; rf2-2rtt6.13 win and is untouched; but a value frozen at
+                ;; render time compares equal to itself, so with (3) as the only
+                ;; pre-commit answer React's PRE-COMMIT store-consistency check
+                ;; could never fire. On a concurrent lane React re-reads every
+                ;; store's `getSnapshot` before committing a time-sliced render
+                ;; and throws the render away if one moved; a frozen value made
+                ;; that check a no-op by construction, so a write landing in the
+                ;; gap COMMITTED — and could paint — stale, self-healing only one
+                ;; commit later. That is not delayed bookkeeping: a same-commit
+                ;; layout effect or ref read sees it, and the ugly instance is a
+                ;; panel mounting as a permission drops (rf2-so3io / rf2-anmdr).
+                ;; The escrow token already holds that reaction LIVE, so (2) costs
+                ;; a ref read and retains nothing new. See `provisional-snapshot`.
+                ;;
+                ;; On a BLOCKING lane React pushes no pre-commit check at all
+                ;; (`0 !== (renderLanes & 127) || pushStoreConsistencyCheck(…)`),
+                ;; so there the render's value is the committed value whatever
+                ;; `get-snap` says. What still repairs BOTH lanes one commit
+                ;; later is React's mount ordering: the `subscribeToStore`
+                ;; passive effect is pushed BEFORE the `updateStoreInstance` one
+                ;; and passive effects run in push order, so by the second call
+                ;; `subscribe-fn` has published the committed reaction and (1)
+                ;; answers.
+                ;;
+                ;; Every source here is `Object.is`-STABLE across back-to-back
+                ;; calls — each is a memoised reaction's value or a frozen one —
+                ;; which is what React's "the result of getSnapshot should be
+                ;; cached" rule requires. The rejected alternative, having
+                ;; `get-snap` re-SUBSCRIBE per call, is unsafe for exactly that
+                ;; reason: on a miss each call would build a fresh reaction with a
+                ;; fresh memo cell, so a collection-returning sub yields a
+                ;; non-`Object.is` value every time — React's documented
+                ;; infinite-render-loop condition. Reading a reference something
+                ;; else already owns cannot build anything, so it cannot reach it.
                 ;;
                 ;; rf2-naz09e — the committed reaction is stored KEY-TAGGED as
                 ;; `#js [stable-key committed]`, and `get-snap` reads it ONLY
@@ -2631,7 +2701,21 @@
                                   (if (and stored
                                            (identical? (aget stored 0) stable-key))
                                     (let [r (aget stored 1)] (when r @r))
-                                    render-snapshot)))
+                                    ;; Pre-commit / key-change: prefer the LIVE
+                                    ;; reaction the escrow token is holding over
+                                    ;; the frozen render value (rf2-2rtt6.13).
+                                    ;; Key-tagged for the same reason
+                                    ;; `committed-ref` is — across a query-v /
+                                    ;; frame change the ref may still hold the
+                                    ;; PREVIOUS target's token.
+                                    (let [held (.-current provisional-ref)
+                                          v    (if (and held
+                                                        (identical? (aget held 0) stable-key))
+                                                 (provisional-snapshot (aget held 1))
+                                                 no-provisional)]
+                                      (if (identical? v no-provisional)
+                                        render-snapshot
+                                        v)))))
                               #js [stable-key render-snapshot])
                 ;; The store-subscribe fn — React's COMMIT-OWNED acquire/release
                 ;; pair. React calls it (once) only AFTER a commit, passing a

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -4846,6 +4846,196 @@
             (finally
               (try (.unmount root) (catch :default _ nil))))))))))
 
+;; ---- the render→commit window, observed AT THE FIRST COMMIT (rf2-2rtt6.13 audit) ----
+;;
+;; WHY THIS EXISTS. The assertion above pins an ORDERING — React calls
+;; `getSnapshot` again after `subscribe` returns — and an ordering cannot
+;; answer the question the audit of PR #7304 actually asked. When a write lands
+;; between a render and the commit that owns it, WHAT DOES THE FIRST COMMIT
+;; SHOW? A repair that arrives one commit later is compatible with both
+;; answers, so nothing that only reads the settled DOM can discriminate. This
+;; row observes the first commit itself.
+;;
+;; DETERMINISM, NOT TIMING. The write is issued from the RENDER BODY of a
+;; sibling that renders after the subscriber in the same pass. React cannot
+;; distinguish that from a write delivered by a browser event while a
+;; time-sliced render is parked: in both cases app-db moves after the
+;; subscriber's `getSnapshot` and before the commit. There is no timer and no
+;; race — the ordering is the render order of two siblings. The write is
+;; ONE-SHOT, so a corrective re-render is not written over again and the retry
+;; can converge.
+;;
+;; WHAT "THE FIRST COMMIT" MEANS. A layout effect runs in the commit's layout
+;; phase: after the whole tree's DOM mutation, before the browser can paint. A
+;; render React discards before committing never runs one. So the FIRST firing
+;; of the observer's layout effect is exactly the first committed,
+;; paint-eligible value — the thing a user could see and a same-commit ref /
+;; layout read does see.
+;;
+;; THE UNMOVED CONTROL. Each lane runs twice — once with the write, once
+;; without — each on its OWN frame, hence its own sub-cache, so every row is
+;; genuinely COLD (the only state in which `get-snap` takes the pre-commit
+;; path at all). Without the control a "nothing stale" reading would be
+;; indistinguishable from a probe that never fired.
+;;
+;; THE TWO LANES ARE DIFFERENT QUESTIONS, and only measurement separates them.
+;; React pushes its pre-commit store-consistency check ONLY on a non-blocking
+;; lane (`react-dom-client`: `0 !== (renderLanes & 127) ||
+;; pushStoreConsistencyCheck(…)`) and consults it only when the render
+;; actually time-sliced (`renderWasConcurrent && !isRenderConsistentWith
+;; ExternalStores(…)`). So:
+;;
+;;   BLOCKING (`root.render` on the default lane — every shipped consumer's
+;;   normal configuration) — React performs NO pre-commit re-read. The value
+;;   the render produced is the value that commits, and no `getSnapshot`
+;;   implementation can change that. Pinned here so a React release that
+;;   starts checking blocking lanes is caught rather than assumed.
+;;
+;;   CONCURRENT (`startTransition`, `useDeferredValue` — opt-in, and per
+;;   rf2-so3io reachable at any time because we mount through `createRoot`) —
+;;   React DOES re-read every store's `getSnapshot` before committing and
+;;   throws the render away if any moved. Whether that check can SEE the
+;;   movement is decided entirely by what `get-snap` returns pre-commit, and
+;;   that is the seam PR #7304 changed.
+
+(def ^:private gap-idle-element
+  "A substrate-free placeholder so the probe arrives as an UPDATE on both
+  lanes and the two arms differ in exactly one thing: the lane."
+  (when (and (exists? js/document) (some? (.-createElement js/document)))
+    (React/createElement "span" nil "idle")))
+
+(defn- run-render-to-commit-window-row!
+  "Mount the gap probe once, COLD, on `frame`, on `lane`, with (`:move? true`)
+  or without the render-phase write, and answer what the FIRST commit showed
+  alongside the settled state."
+  [act-fn
+   {:keys [probe-gap-element gap-write! gap-armed? gap-first-commit
+           gap-mount-node gap-db-read gap-observed gap-query refcount-target]}
+   {:keys [frame lane move?]}]
+  (rf/make-frame {:id frame :doc "rf2-2rtt6.13 render→commit window row"})
+  (rf/dispatch-sync [::gap-seed] {:frame frame})
+  (reset! refcount-target frame)
+  (let [cache      (:sub-cache (frame/frame frame))
+        mount-node (make-mount-node!)
+        root       (react-dom-client/createRoot mount-node)]
+    (reset! gap-mount-node mount-node)
+    (reset! gap-db-read (fn [] (:n (rf/app-db-value frame))))
+    (reset! gap-first-commit nil)
+    (reset! gap-observed [])
+    (reset! gap-armed? false)
+    (reset! gap-write! (when move?
+                         (fn [] (rf/dispatch-sync [::gap-set 1] {:frame frame}))))
+    (try
+      (act-fn (fn [] (.render root gap-idle-element)))
+      (let [cold? (nil? (get @cache [gap-query]))]
+        ;; Arm only now — the placeholder render must not consume the one shot.
+        (reset! gap-armed? true)
+        (if (= lane :concurrent)
+          (act-fn (fn [] (React/startTransition
+                           (fn [] (.render root (probe-gap-element))))))
+          (act-fn (fn [] (.render root (probe-gap-element)))))
+        {:lane         lane
+         :moved?       move?
+         :cold?        cold?
+         :first-commit @gap-first-commit
+         :settled      {:dom (.-textContent mount-node)
+                        :db  (:n (rf/app-db-value frame))}
+         :observed     @gap-observed})
+      (finally
+        (try (act-fn (fn [] (.unmount root))) (catch :default _ nil))))))
+
+(defn assert-use-subscribe-render-to-commit-window-first-commit
+  "rf2-2rtt6.13 (merged-PR audit of #7304): an app-db write landing in the
+  render→commit gap, observed AT THE FIRST COMMIT rather than after the dust
+  settles, on both a blocking and a concurrent lane, each beside an unmoved
+  control.
+
+  cfg keys:
+    :probe-gap-element  — 0-arg fn returning the probe root element
+                          (subscriber + one-shot render-phase mutator +
+                          layout-effect observer)
+    :gap-write! :gap-armed? :gap-first-commit :gap-mount-node :gap-db-read
+    :gap-observed       — the probe's side-channel atoms
+    :gap-query          — the probe's query id
+    :gap-blocking-frame / :gap-blocking-control-frame /
+    :gap-concurrent-frame / :gap-concurrent-control-frame — one frame per row,
+                          so every row is a genuinely COLD read"
+  [{:keys [name gap-query gap-blocking-frame gap-blocking-control-frame
+           gap-concurrent-frame gap-concurrent-control-frame]
+    :as   cfg}]
+  (testing (str name " — a write in the render→commit gap, observed at the FIRST commit (rf2-2rtt6.13)")
+    (with-browser-act
+     (fn [act-fn]
+      (rf/reg-event ::gap-seed (fn [_ _] {:db {:n 0}}))
+      (rf/reg-event ::gap-set  (fn [_ [_ v]] {:db {:n v}}))
+      (rf/reg-sub gap-query (fn [db _] (:n db)))
+      (let [blocking-control   (run-render-to-commit-window-row!
+                                 act-fn cfg {:frame gap-blocking-control-frame
+                                             :lane  :blocking :move? false})
+            blocking-moved     (run-render-to-commit-window-row!
+                                 act-fn cfg {:frame gap-blocking-frame
+                                             :lane  :blocking :move? true})
+            concurrent-control (run-render-to-commit-window-row!
+                                 act-fn cfg {:frame gap-concurrent-control-frame
+                                             :lane  :concurrent :move? false})
+            concurrent-moved   (run-render-to-commit-window-row!
+                                 act-fn cfg {:frame gap-concurrent-frame
+                                             :lane  :concurrent :move? true})]
+        ;; ---- the probe is sound before anything is concluded from it ------
+        (doseq [[label row] [[:blocking-control blocking-control]
+                             [:blocking-moved blocking-moved]
+                             [:concurrent-control concurrent-control]
+                             [:concurrent-moved concurrent-moved]]]
+          (is (:cold? row)
+              (str label ": the probe mounted COLD — `get-snap`'s pre-commit "
+                   "path is only reachable with no live cache entry. Row " row))
+          (is (some? (:first-commit row))
+              (str label ": the observer's layout effect fired, so there IS a "
+                   "first commit to read. Row " row)))
+        ;; ---- THE UNMOVED CONTROLS ----------------------------------------
+        (is (= {:dom "g=0" :db 0} (:first-commit blocking-control))
+            (str "blocking control: nothing moved, so the first commit shows "
+                 "the seeded value and agrees with app-db. Row " blocking-control))
+        (is (= {:dom "g=0" :db 0} (:first-commit concurrent-control))
+            (str "concurrent control: nothing moved, so the first commit shows "
+                 "the seeded value and agrees with app-db. Row " concurrent-control))
+        ;; ---- the injection really landed INSIDE the gap -------------------
+        (is (= 1 (:db (:first-commit blocking-moved)))
+            (str "blocking moved: app-db had already moved to 1 by the first "
+                 "commit — the write landed in the gap, not after it. Row "
+                 blocking-moved))
+        (is (= 1 (:db (:first-commit concurrent-moved)))
+            (str "concurrent moved: app-db had already moved to 1 by the first "
+                 "commit — the write landed in the gap, not after it. Row "
+                 concurrent-moved))
+        ;; ---- BLOCKING lane: React performs no pre-commit re-read ----------
+        ;; NOT a property of this spine and NOT changed by PR #7304: on a
+        ;; blocking lane React pushes no store-consistency check at all, so the
+        ;; render's value is the committed value whatever `get-snap` would say.
+        ;; Pinned so a React release that starts checking blocking lanes shows
+        ;; up here as a failure rather than as a silent improvement nobody
+        ;; noticed.
+        (is (= "g=0" (:dom (:first-commit blocking-moved)))
+            (str "blocking moved: React pushes NO pre-commit store-consistency "
+                 "check on a blocking lane, so the first commit carries the "
+                 "render's value. Row " blocking-moved))
+        ;; ---- CONCURRENT lane: THE LOAD-BEARING ROW ------------------------
+        ;; React DOES re-read `getSnapshot` before committing a time-sliced
+        ;; render and discards the render if a store moved. The pre-commit
+        ;; fallback must therefore be able to REPORT the movement — a value
+        ;; frozen at render time compares equal to itself and makes the check
+        ;; a no-op by construction, committing (and allowing paint of) state
+        ;; the app-db has already revoked.
+        (is (= "g=1" (:dom (:first-commit concurrent-moved)))
+            (str "concurrent moved: the pre-commit re-read SAW the write, so "
+                 "React discarded the torn render and the FIRST commit is "
+                 "fresh — no stale paint. Row " concurrent-moved))
+        ;; ---- both moved rows settle fresh --------------------------------
+        (is (= {:dom "g=1" :db 1} (:settled blocking-moved))
+            (str "blocking moved settles fresh. Row " blocking-moved))
+        (is (= {:dom "g=1" :db 1} (:settled concurrent-moved))
+            (str "concurrent moved settles fresh. Row " concurrent-moved)))))))
+
 ;; ---- the commit adopts the render-phase build (rf2-2rtt6.25) --------------
 ;;
 ;; THE TERM DELETED. A React render and the commit that owns it are two


### PR DESCRIPTION
The AUDIT-REOPEN remainder of **rf2-2rtt6.13**. The audit of merged PR #7304 charged
that the retention repair's prose concession — "on a concurrent lane a write in the
render→commit gap is repaired one commit later" — describes **a real stale commit and
possible paint, not delayed bookkeeping**, and that the test landed with it could not
validate the claim because it injects no write in the gap and never asserts the first
committed value.

**The audit is right, it is measured, and the window is now closed.** No operator ruling
is required: nothing here accepts a stale window.

## What the evidence measures

`assert-use-subscribe-render-to-commit-window-first-commit`
(`implementation/core/test/re_frame/adapter/react_shared_suite.cljs`, driven by the UIx
DOM suite) mounts a **cold** subscription and writes `app-db` from the **render body of a
sibling that renders after the subscriber in the same pass**. React cannot tell that apart
from a write delivered by a browser event while a time-sliced render is parked: in both
cases app-db moves after the subscriber's `getSnapshot` and before the commit. There is no
timer and no race — the ordering is the render order of two siblings, and the write is
one-shot so a corrective re-render can converge.

It observes the **first commit**, from a `useLayoutEffect`: the layout phase runs after the
whole tree's DOM mutation and before the browser can paint, and a render React discards
before committing never runs one. So the observer's first firing is exactly the first
committed, paint-eligible value.

Four rows — two lanes, each with an **unmoved control** on its own frame (hence its own
sub-cache, so every row is a genuinely cold read, the only state in which the pre-commit
path is reachable at all). Without the control a "nothing stale" reading would be
indistinguishable from a probe that never fired.

## The measurement

| row | first commit | reading |
|---|---|---|
| blocking, control | `{:dom "g=0", :db 0}` | consistent — the probe works |
| blocking, moved | `{:dom "g=0", :db 1}` | stale, and it is React's own (see below) |
| concurrent, control | `{:dom "g=0", :db 0}` | consistent — the probe works |
| **concurrent, moved** | **`{:dom "g=0", :db 1}`** | **STALE FIRST COMMIT — the defect** |

Both moved rows settled at `{:dom "g=1", :db 1}`, i.e. the passive-effect repair does
arrive — one commit late, after the stale value was committed and paint-eligible.

## Characterisation

**Reachable? Yes, deterministically. Does it paint? It is layout-visible, so yes — and a
same-commit layout effect or ref read observes it without any paint at all.**

**Which lanes, and why.** React pushes its pre-commit store-consistency check **only on a
non-blocking lane** (`react-dom-client`: `0 !== (renderLanes & 127) ||
pushStoreConsistencyCheck(…)`) and consults it only when the render actually time-sliced
(`renderWasConcurrent && !isRenderConsistentWithExternalStores(…)`). So the two lanes are
two different findings:

* **Blocking (default lane — every shipped consumer's normal `root.render` configuration).**
  React performs **no** pre-commit re-read at all. The render's value is the committed
  value whatever `getSnapshot` says. This row is **not a #7304 regression** — it is
  identical before and after, it is React's semantics, and no `getSnapshot` implementation
  can change it. It is now pinned so a React release that starts checking blocking lanes
  shows up as a failure rather than as an unnoticed improvement.
* **Concurrent (`startTransition` / `useDeferredValue` — opt-in, but per rf2-so3io
  reachable at any time because we mount through `createRoot`).** React **does** re-read
  every store's `getSnapshot` before committing and discards the render if one moved.
  #7304 made a value frozen at render time the only pre-commit answer, and a frozen value
  compares equal to itself — so the check became **a no-op by construction** and the torn
  render committed. **This half is a genuine #7304 regression.**

**Does it reach rf2-so3io / rf2-anmdr's class?** In *shape*, yes and by the same route: the
pre-commit fallback is reached exactly on a **first mount** of a subscription and on a
**query-v / frame change** — which is rf2-anmdr's "staged site" scenario verbatim, a panel
mounting while a permission drops, a user switches, a record is redacted. In *severity*,
no: rf2-anmdr's staged+ablated case is stale **forever** (no watch was ever installed);
this window always self-heals at the next passive flush. It is the transient-paint half of
that class, not the permanent half.

## The repair, and why it is bounded

`get-snap` now reads, in strict order of currency:

1. the **committed** reaction, once `subscribe-fn` has published it under this key;
2. the reaction the hook's **unspent escrow token** is holding (`provisional-snapshot`) —
   the render→commit window and the key-change render, the only two moments (1) cannot
   answer;
3. `render-snapshot`, the frozen render value, when neither is live.

(2) is live **by construction**: that +1 is what keeps the entry tenanted for the commit to
adopt (rf2-2rtt6.25). Crucially it **retains nothing new** — the token's hold on the
reaction predates this change (it is how `unsubscribe-if-reaction` identity-guards its
release) and ends at adoption or at the macrotask horizon, never at the component's
lifetime. The memo still returns a **value**, so rf2-2rtt6.13's 769 B / 23.0 objects per
read stays bought and no handle survives the factory. `spent?` is load-bearing rather than
defensive: the reaper flips it and decrements *without* clearing the holder's ref, so a
spent token can point at a reaction whose last reference has gone; reading only while
unspent is what keeps the frozen value the answer exactly when there is nothing live to
prefer to it.

**Not the rejected alternative.** Making the fallback live by having `get-snap` *re-subscribe*
per call is unsafe — on a miss each call builds a fresh reaction with a fresh memo cell, so
a collection-returning sub yields a non-`Object.is` value every time, React's documented
infinite-render-loop condition. This **reads a reference something else already owns**, so
it cannot build anything and cannot reach that condition. Every source it can return is
`Object.is`-stable across back-to-back calls, which is what React's "the result of
getSnapshot should be cached" rule requires.

**Red → green, both exit codes below.** The concurrent row fails before the repair and
passes after; nothing else in the 861-test browser suite moves. rf2-es09qq's Suspense-abort
witness and rf2-2rtt6.25's adoption / horizon / SSR witnesses are untouched.

`spec/006` needs no change: it already sanctions the provisional reference as "an ordinary
reference held by an ordinary owner — the entry it keeps alive is at ref-count ≥ 1
throughout", which is precisely what makes source (2) live. The stale-window concession in
`docs/design/hicasso/studio/uix-spine-per-read-decomposition.md` is corrected in place with
the measurement that overturned it.

## Quality gates

All foreground, all logged worktree-locally, every exit code echoed.

| gate | exit | result |
|---|---|---|
| `npm run test:browser` — **BEFORE** the repair | **1** | 861 tests / 5562 assertions, **1 failure**: the concurrent-moved row, `{:dom "g=0", :db 1}` |
| `npm run test:browser` — **AFTER** the repair | **0** | 861 tests / 5562 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | 0 | 11974 tests / 59724 assertions, 0 failures, 0 errors |
| `npm run test:adapter-smokes` (Reagent + UIx + re-frame.ui) | 0 | 3 specs, 0 failures |
| `npm run test:freehand` (spine consumer 2) | 0 | 1399 tests / 7752 assertions, 0 failures |
| `npm run test:ui` (spine consumer 3) | 0 | 801 tests / 4057 assertions, 0 failures |
| clj-kondo, CI-pinned `2026.04.15`, CI's exact `--lint` set + `--fail-level error` | 0 | **errors: 0** (4526 warnings, pre-existing) |
| `python -m mkdocs build --strict` | 0 | built in 32.9 s |
| `scripts/test-fast-pr.sh` | 0 | `PASS fast PR spine` — includes JVM `implementation/core` 2198 tests / 11341 assertions, JVM `implementation/adapters/uix`, the CLJS node integration, the JS harness self-tests, and per-ns isolation across all 17 curated namespaces |

Two notes on the gate log, so a green is not over-read:

* The spine **soft-skipped its own `mkdocs --strict` step** ("mkdocs not on PATH") — the
  known false-green vector. It is covered by the standalone `python -m mkdocs build
  --strict` row above, exit 0.
* `npm run test:cljs` failed once on its first invocation with two `spawnSync …
  ETIMEDOUT` assertions in `re_frame/test_quiet_shadow_node_cljs_test.cljs` — a
  nested-runner spawn timeout while several other workers were loading this machine, no
  relation to this diff. Two subsequent clean runs (before and after the final
  comment-only commit) are the row above.

**TESTING.md matrix derived.** The diff touches `implementation/core/src` (the shared React
spine, blast radius: `re-frame.adapter.uix`, `re-frame.freehand.substrate`,
`re-frame.ui.substrate`), `implementation/core/test`, `implementation/adapters/uix/test`,
and one `docs/**` page. That selects the **cljs node** tier (`test:cljs` + isolation), the
**browser** tier (the only tier that can execute `useSyncExternalStore` against a real
React root — where this change lives), the **adapter smokes** for the three spine
consumers, the **implementation JVM** tier via the fast-PR spine's classifier, the
**documentation** tier (`mkdocs build --strict`), and **lint**. Not run, and out of tier for
this diff: the production-elision / bundle-isolation / perf-bundle gates, the Xray feature
matrix, mcp-conformance, and the tool JVM suites — none of which the changed surface
reaches.
