### PR TITLE
bench,docs(hicasso): the clock gate lines restated on the post-.25 tree (rf2-b0tz5)

### DIFF
--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -23,6 +23,16 @@ Bead **`rf2-2rtt6.7`**. Decision **[HD-008](../decisions.md)**. The standard is
 > thresholds it is judged against (*the measured UIx ratios per witness family,
 > on clock and on retained heap*) are set when P0 publishes. This page is
 > measurement. There is no verdict in it and there must not be.
+>
+> **The advisory has since been issued — 2026-07-31, recorded on `rf2-2rtt6.1`
+> and `rf2-2rtt6.7`, and summarised in
+> [validation.md](../validation.md#p1-gate--the-composed-donor-arm-hd-008).**
+> It found the stop rule **not met as written**, so continuation is an operator
+> override of a pre-registered gate rather than a passing grade. That verdict
+> still is not this page's, and this page still holds no verdict; the line above
+> is what it is, and this note only stops a reader concluding the gate is
+> outstanding. **Read the verdict together with the spine stamp below** — it was
+> issued against these pre-landing donor columns.
 
 ---
 
@@ -58,6 +68,51 @@ not stated](#the-correction-contract-is-enforced-not-stated). Neither touched an
 arm's window, so no figure on this page moves; but a run at the tip is a run of
 a *later* instrument over the same plan, and only a run at the landed commit in
 the row's own line reproduces that row's instrument exactly.
+
+### Spine stamp — three of the six arms read a spine that no longer ships
+
+**Every producing commit in the table above carries `spine.cljs` blob
+`befd8469d932d6ee381e80e724cfbc98c0861814`**, which is the spine as it stood
+*before* both of this week's production landings. Verified by blob rather than by
+date, at all four of `172244521e`, `c7e4c70ac0`, `0cba8181a7` and `5cd819c5bf`:
+
+```bash
+S=implementation/core/src/re_frame/substrate/spine.cljs
+git rev-parse 172244521e:$S   # befd8469d932d6ee381e80e724cfbc98c0861814
+git rev-parse 9df5094816:$S   # 56f7e5480c99330515d525a2bdacf5f86a0db7bd  (.13)
+git rev-parse f784ab0adb:$S   # 086d08e94089002c19e6b30cc901d03324b0f4cc  (.25)
+```
+
+The two landings are `rf2-2rtt6.13` (PR #7304, **`9df5094816`**) — stopped
+retaining the disposed render-phase reaction — and `rf2-2rtt6.25` (PR #7305,
+**`f784ab0adb`**) — the hook-scoped provisional hand-off, so a cold read builds
+one reaction instead of two, which is a **mount-path** change. Both are ancestors
+of `main`.
+
+**Which columns are pre-landing, and which are not.** `hd8_witnesses.cljs` routes
+exactly three arms through `re-frame.adapter.uix/use-subscribe`:
+
+| arm | spine | status |
+|---|---|---|
+| `uix` | React `use-subscribe` | **PRE-LANDING — reads a spine that no longer exists** |
+| `donor-r1` | React `use-subscribe` | **PRE-LANDING** |
+| `donor-r2` | React `use-subscribe` | **PRE-LANDING** |
+| `reagent` | ratom | unaffected — neither landing goes near the ratom path |
+| `reagent-slim` | ratom | unaffected |
+| `floor` | none | unaffected |
+
+**So every donor-vs-Reagent ratio on this page has a numerator measured on a
+spine term that has since been removed, and a denominator that has not moved.**
+`.25` cuts the cold read's double build, which lands on the **mount** rows; the
+independent coldmount re-derivation of the layer-1 mount witness post-`.25`
+closed that red zone outright. The direction is therefore known — the donor and
+`uix` mount columns are **pessimistic** as published — while the magnitude is
+not, because this page has not been re-run since. **No figure here is amended by
+this stamp and none is deleted:** the rows stand as measured, under the stamp,
+and a post-landing candidate is judged against a re-taken donor row rather than
+against these. The clock counterpart of this restatement, on the converged
+witness, is
+[the converged witness set](p0-converged-witness-set.md#red-zone--clock-on-rf2-2rtt62s-witnesses).
 
 Every figure below is a **browser** figure, which is what HD-012 requires of
 anything quotable against the bar.

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -333,11 +333,12 @@ beside a biased one.
 >
 > Not one row was post-landing, so the whole table needed re-taking rather than
 > just the mount row. **The re-take is [below](#the-re-take-on-the-post-25-tree-rf2-b0tz5)**
-> and it moves exactly one line: **M1 mount, `1.2310×` → indistinguishable from
-> parity.** The other three reproduce inside their published run-mean spreads and
-> are NOT restated. Mike's ruling of 2026-07-31 (option (a), on `rf2-2rtt6.1`)
-> required the re-take to happen on THIS instrument rather than by carrying the
-> coldmount page's post-`.25` figure across, and that is what was done.
+> and it moves exactly one line: **M1 mount, `1.2310×` → `1.0243×`
+> [0.9937 – 1.0549], indistinguishable from parity.** The other three are not
+> distinguishable from their published values at four runs and are **NOT
+> restated**. Mike's ruling of 2026-07-31 (option (a), on `rf2-2rtt6.1`) required
+> the re-take to happen on THIS instrument rather than by carrying the coldmount
+> page's post-`.25` figure across, and that is what was done.
 
 | witness | **threshold** | 95% interval on the mean | run means (10) | verdict |
 |---|---|---|---|---|
@@ -460,14 +461,19 @@ below was launched into a measured-quiet window** — the `java`/`node` toolchai
 sampled under 30% of one core for three consecutive samples immediately before
 launch — and the pre- and post-run readings are recorded per run.
 
-**One run was refused and is reported rather than quietly dropped.** A run
-launched at 101% of a core exited **2** on the `narrow` row: the arm-order
-guard found phase strata **1.37×–1.55×** last-third over first-third across the
-narrow arms, which is the signature of a box that degraded mid-run (the post-run
-reading was 310%). It was **re-taken under quiet, not excused, and the guard's
-tolerance was not touched.** A separate `M1`-only pilot taken under load is
-likewise excluded from every figure here. That refusal is the evidence that the
-quiet bar is doing work rather than being asserted.
+**Three runs did not produce a published row, and all three are reported rather
+than quietly dropped.** None was excused and no tolerance was touched:
+
+| run | outcome | why |
+|---|---|---|
+| launched at **101%** of a core | **exit 2** — arm-order guard, `narrow` | phase strata **1.37×–1.55×** last-third over first-third across the narrow arms — the signature of a box that degraded mid-run (post-run reading 310%). **Re-taken under quiet** |
+| launched at **0%** | **exit 2** — arm-order guard, `M2` | the *mount-budget* fragility this page already documents — 720 mounts a page refused 4 of 6 for `rf2-6i0i2` too. Not contention, and not new |
+| launched at **0%** | **exit 1** — segment-order control, `M1` | the strata point opposite ways across 1.0 — [discussed below](#the-row-now-sits-so-close-to-parity-that-one-run-could-not-be-given-a-direction), where it is treated as a finding rather than a fault |
+
+A separate `M1`-only pilot taken under load is likewise excluded from every
+figure here. **The first refusal is the evidence that the quiet bar is doing work
+rather than being asserted**, and the second is the evidence that this
+instrument's known M2 fragility is unchanged by the landings.
 
 #### What moved, and the control that says the denominator did not
 
@@ -475,32 +481,47 @@ The restatement rests on a comparison the `rf2-2rtt6.21` finding demands: **the
 bar's own denominator is held fixed and shown to be fixed.** On `M1`, same
 instrument and same author:
 
-| `M1` mount leg | published ensemble *(pre-`.13`/`.25`)* | this re-take *(post-`.25`)* | change |
+| `M1` mount leg | published ensemble *(pre-`.13`/`.25`, 10 runs)* | this re-take *(post-`.25`, 4 runs)* | change |
 |---|---:|---:|---|
-| `reagent-subs ÷ floor` — **the denominator** | **4.358×** | **4.316×** | **−1.0% — unmoved** |
-| `uix-subs ÷ floor` — the frontier numerator | **5.343×** | **4.391×** | **−17.8%** |
-| **ratio** | 5.343 ÷ 4.358 = **1.226** *(published 1.2310)* | 4.391 ÷ 4.316 = **1.017** | **the line moves ~21 points** |
+| `reagent-subs ÷ floor` — **the denominator** | **4.358×** | **4.380×** | **+0.5% — unmoved** |
+| `uix-subs ÷ floor` — the frontier numerator | **5.343×** | **4.479×** | **−16.2%** |
+| **ratio** | 5.343 ÷ 4.358 = **1.226** *(published 1.2310)* | 4.479 ÷ 4.380 = **1.023** | **the line moves ≈21 points** |
+
+Per run, the denominator leg reads `4.2853 · 4.3457 · 4.5731 · 4.3144` and the
+numerator leg `4.2723 · 4.5089 · 4.6673 · 4.4687`.
 
 **The arithmetic is explicit and it closes.** The published threshold is the
 quotient of two floor-normalised legs; the denominator leg reproduces to within
-1.0% while the numerator leg falls 17.8%, and 4.391 ÷ 4.316 = 1.017 against the
-1.0185 the runs actually report — the small residue being that each run's ratio
-is formed per round and per segment before averaging, not from the two means.
-**So the ~21-point tightening is a property of the UIx arm, not of a drifting
-baseline** — which is precisely the failure mode a cross-author bridge could not
-have excluded.
-
-*(Numbers in this section are the ensemble as it stands; the run count and the
-interval are stated with the rows below and are updated as runs land.)*
+**0.5%** while the numerator leg falls **16.2%**, and 4.479 ÷ 4.380 = 1.023
+against the **1.0243** the runs actually report — the small residue being that
+each run's ratio is formed per round and per segment before averaging, not from
+the two means. **So the ≈21-point tightening is a property of the UIx arm, not of
+a drifting baseline** — precisely the failure mode a cross-author bridge could not
+have excluded, and the reason the ruling required a same-instrument re-take.
 
 #### The restated lines — INSTRUMENT STAMP: converged `p0_converge_app` instrument, `rf2-2rtt6.2` witness family, post-`.25` spine `8d20218fd1`
 
-| witness | published *(pre-landing)* | **re-take, post-`.25`** | verdict |
-|---|---|---|---|
-| **M1 mount** — 901 el, 300 boundaries · *bar row* | ~~**1.2310×**~~ [1.1989 – 1.2931] | **≈1.02×** — see rows below | **RESTATED. The mount red zone has closed:** UIx and Reagent are now **indistinguishable** on the bar's mount row |
-| **M2 mount** — 51 el, 12 fields · *diagnostic* | 1.0601× [0.9561 – 1.1923] | reproduces inside its spread | **NOT restated** — still indistinguishable, still diagnostic |
-| **bulk broad** — one commit all 300 read · *bar row* | 0.6291× [0.5792 – 0.6987] | reproduces inside its spread | **NOT restated** — UIx still faster, direction unchanged |
-| **bulk narrow** — 10 commits, one window | 1.1754× [1.1390 – 1.2186] | reproduces inside its spread | **NOT restated** — UIx still slower, direction unchanged |
+**Four independently launched six-round runs, start counterbalanced two and
+two**, every one launched into a measured-quiet window, every one exiting 0.
+**0 unverified of 36,864** verified operations; arm-order guard `refuse? false`
+on all 24 row-verdicts; canonical-DOM parity `ok? true` on all 16; every positive
+control inside ±25%. The interval is a Student-t 95% interval on the mean of the
+run means. **This is four runs against the published line's ten, and the interval
+is correspondingly wider — it is stated as measured, not padded.**
+
+| witness | published *(pre-landing, 10 runs)* | **re-take, post-`.25` (4 runs)** | 95% CI on the mean | run means | verdict |
+|---|---|---|---|---|---|
+| **M1 mount** — 901 el, 300 bnd · *bar row* | ~~**1.2310×**~~ [1.1989 – 1.2931] | **1.0243×** | **0.9937 – 1.0549** | 0.9980 · 1.0391 · 1.0219 · 1.0382 | **RESTATED — the L1 mount red zone has CLOSED.** The interval contains 1.0 and every run reads `:direction :indistinguishable`. The run-mean spread is **wholly disjoint** from the published one |
+| **M2 mount** — 51 el, 12 fields · *diagnostic* | 1.0601× [0.9561 – 1.1923] | 1.0071× | 0.8978 – 1.1165 | 0.9685 – 1.0714 | **NOT restated** — indistinguishable then, indistinguishable now, still diagnostic |
+| **bulk broad** — one commit all 300 read · *bar row* | 0.6291× [0.5792 – 0.6987] | 0.5598× | 0.4781 – 0.6415 | 0.5102 – 0.6316 | **NOT restated** — the CI contains the published value; UIx faster, all 24 rounds and all 8 strata below 1.0 |
+| **bulk narrow** — 10 commits, one window | 1.1754× [1.1390 – 1.2186] | 1.2233× | 1.1238 – 1.3228 | 1.1767 – 1.3090 | **NOT restated** — the CI contains the published value; UIx slower, all 24 rounds and all 8 strata above 1.0 |
+
+**Only M1 is restated, and the three that are not are held to the conservative
+reading deliberately.** On `broad` and `narrow` the re-take's interval contains
+the published magnitude, so the honest statement is *direction unchanged, magnitude
+not distinguishable at n = 4* — not a new number. Publishing `0.5598×` as a
+threshold on four runs against a ten-run line it does not contradict would be
+minting precision the measurement does not carry.
 
 **Only the mount row moved, and that is the mechanism agreeing with the
 measurement rather than a coincidence.** `rf2-2rtt6.25` landed the hook-scoped
@@ -517,15 +538,36 @@ The advisory recorded that
 [the coldmount page](coldmount-double-build-priced.md) independently re-derived
 the same 901-element / 300-boundary mount witness post-`.25` at **`1.0054×`
 [0.917 – 1.143]**, excess mean 0.00 ms, on **its own instrument**. This re-take,
-on the **converged** instrument, reads the same witness at **≈1.02×**.
+on the **converged** instrument, reads the same witness at **`1.0243×`
+[0.9937 – 1.0549]**.
 
-**Two different instruments, two different drivers, two different authors, the
-same answer to within about two points** — against a published line of `1.2310×`
-that both now contradict by roughly twenty. The disagreement that `rf2-2rtt6.21`
-found in the denominator between two authors (+9.7% mount) is larger than the
-gap between these two post-`.25` mount readings, so the agreement is not an
-artefact of a shared harness. **The tightening is real, and it is the correct
-outcome rather than a problem to be softened.**
+**Two instruments, two drivers, two authors — `1.0054×` against `1.0243×`, 1.9
+points apart, each interval containing the other's point estimate** — against a
+published line of `1.2310×` that both now contradict by roughly twenty. The
+disagreement `rf2-2rtt6.21` found in the denominator between two authors (+9.7%
+on mount) is **larger than the gap between these two post-`.25` mount readings**,
+so the agreement is not an artefact of a shared harness. **The tightening is real,
+and it is the correct outcome rather than a problem to be softened.**
+
+#### The row now sits so close to parity that one run could not be given a direction
+
+**A third piece of evidence, and it arrived as a failure.** One run exited **1**
+because the driver's segment-order control refused `M1` outright:
+
+> *the row's two order strata — rounds where Reagent's segment ran first, rounds
+> where UIx's did — point OPPOSITE WAYS across 1.0, so the row has no direction
+> to publish and the figure is a measurement of the schedule.*
+
+That control was written when this row sat at `1.23×`, comfortably disjoint from
+1.0, where two strata pointing opposite ways can only mean the schedule is
+leaking in. **A row centred ON 1.0 trips it for the opposite reason**: the strata
+straddle parity because there is no effect left to have a direction. The refusal
+is reported here as evidence rather than repaired, because repairing it would
+mean asserting a direction the measurement declines to give — and *"the row has
+no direction"* is the strongest available statement that the mount red zone has
+closed. Under Ruling 1 the red-zone **is** the measured UIx ratio, so the
+restated `M1` line is now **at parity**, and candidates between `1.0243` and the
+old `1.2310` that would have been scored red-free are **now RED**.
 
 ### All four rows reproduce against the revived driver (rf2-rjfz1)
 

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -506,8 +506,11 @@ two**, every one launched into a measured-quiet window, every one exiting 0.
 **0 unverified of 36,864** verified operations; arm-order guard `refuse? false`
 on all 24 row-verdicts; canonical-DOM parity `ok? true` on all 16; every positive
 control inside ±25%. The interval is a Student-t 95% interval on the mean of the
-run means. **This is four runs against the published line's ten, and the interval
-is correspondingly wider — it is stated as measured, not padded.**
+run means — one-sample, so `n − 1 =` **three** degrees of freedom and
+`t = 3.1824`, the distinction the ensemble's own intervals got wrong and which is
+worked through [below](#the-intervals-are-2-too-wide-and-the-cause-is-an-off-by-one-in-the-degrees-of-freedom).
+**This is four runs against the published line's ten, and the interval is
+correspondingly wider — it is stated as measured, not padded.**
 
 | witness | published *(pre-landing, 10 runs)* | **re-take, post-`.25` (4 runs)** | 95% CI on the mean | run means | verdict |
 |---|---|---|---|---|---|
@@ -1685,11 +1688,11 @@ rounded strata against `877/1024 = 0.8564` from the readings, and 877 is the
 This is the one disagreement between the recovered data and what this page
 published, and it is reported rather than quietly fixed in either direction.
 
-**Every interval on this page — View 2's on `d`, and the RED-ZONE table's on the
-threshold — is about 2% wider than the ten runs support.** An interval on the
-mean of **ten** run means is a one-sample Student-t interval with `n − 1 =`
-**nine** degrees of freedom, `t = 2.2622`. The multiplier actually used is
-`≈ 2.306`, which is `t` at **eight** degrees of freedom.
+**Every interval this ensemble published — View 2's on `d`, and the RED-ZONE
+table's on the threshold — is about 2% wider than the ten runs support.** An
+interval on the mean of **ten** run means is a one-sample Student-t interval with
+`n − 1 =` **nine** degrees of freedom, `t = 2.2622`. The multiplier actually used
+is `≈ 2.306`, which is `t` at **eight** degrees of freedom.
 
 The mistake is identifiable rather than merely detectable. Eight *is* the right
 number for the `resolution limit` column standing beside it — that column is a
@@ -1721,6 +1724,17 @@ narrow stay wholly clear of 1.0; M2 still only just clears parity on the mean
 and stays diagnostic for the reason it always was, that three of its ten runs
 read below 1.0 outright. The suite recomputes all four corrected intervals and
 asserts each of those readings.
+
+**The one other set of intervals on this page — the [rf2-b0tz5
+re-take](#the-re-take-on-the-post-25-tree-rf2-b0tz5)'s — does not carry the
+defect, and that is checked rather than assumed.** Those are one-sample intervals
+on the mean of **four** run means, so `n − 1 =` **three** and `t = 3.1824`, and
+that is the multiplier they use: `1.0243 ± 3.1824 × 0.009616` reproduces `M1`'s
+published `0.9937 – 1.0549` to four decimals from the four run means printed
+beside it. The rule is the same rule; only the ensemble misapplied it. It is
+load-bearing there rather than bookkeeping — at `t = 2.2622` the same four runs
+would read `1.0025 – 1.0461`, which **excludes** 1.0 and would have contradicted
+the *indistinguishable from parity* verdict every one of those runs reports.
 
 **The old figures are struck, not deleted**, in the same style as every other
 correction here — and the *p* values, the point estimates and the thresholds are

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -310,9 +310,38 @@ the alternation splits 3:3, so the raw mean and the order-balanced mean are the
 **same number by construction**; there is no longer a corrected value to print
 beside a biased one.
 
+> ## SUPERSEDED IN PLACE — every row below was measured on a spine that no longer ships
+>
+> **All four rows come off one anchor, `4e4a68fa1f`, whose `spine.cljs` blob is
+> `befd8469d932d6ee381e80e724cfbc98c0861814` — byte-identical to the spine as it
+> stood BEFORE both of this week's production landings.** Established by blob
+> rather than by date, and the check is three commands:
+>
+> ```bash
+> S=implementation/core/src/re_frame/substrate/spine.cljs
+> git rev-parse 4e4a68fa1f:$S   # befd8469d9…  the ensemble's tree
+> git rev-parse 9df5094816^:$S  # befd8469d9…  identical — so the run is PRE-.13
+> git rev-parse f784ab0adb:$S   # 086d08e940…  .25, a different spine again
+> ```
+>
+> | converged row | landed anchor | spine blob | vs `.13` `9df5094816` | vs `.25` `f784ab0adb` |
+> |---|---|---|---|---|
+> | M1 mount | `4e4a68fa1f` | `befd8469d9` | **PRE** | **PRE** |
+> | M2 mount | `4e4a68fa1f` | `befd8469d9` | **PRE** | **PRE** |
+> | bulk broad | `4e4a68fa1f` | `befd8469d9` | **PRE** | **PRE** |
+> | bulk narrow | `4e4a68fa1f` | `befd8469d9` | **PRE** | **PRE** |
+>
+> Not one row was post-landing, so the whole table needed re-taking rather than
+> just the mount row. **The re-take is [below](#the-re-take-on-the-post-25-tree-rf2-b0tz5)**
+> and it moves exactly one line: **M1 mount, `1.2310×` → indistinguishable from
+> parity.** The other three reproduce inside their published run-mean spreads and
+> are NOT restated. Mike's ruling of 2026-07-31 (option (a), on `rf2-2rtt6.1`)
+> required the re-take to happen on THIS instrument rather than by carrying the
+> coldmount page's post-`.25` figure across, and that is what was done.
+
 | witness | **threshold** | 95% interval on the mean | run means (10) | verdict |
 |---|---|---|---|---|
-| **M1 mount** — 901 el, 300 boundaries | ~~1.2301×~~ → **1.2310×** | ~~1.2105 – 1.2514~~ → **1.2109 – 1.2510** | 1.1989 – 1.2931 | **UIx slower.** 59 of 60 rounds above 1.0; 19 of 20 order strata wholly above it |
+| **M1 mount** — 901 el, 300 boundaries | ~~1.2301×~~ ~~1.2310×~~ → **SUPERSEDED, see [the re-take](#the-re-take-on-the-post-25-tree-rf2-b0tz5)** | ~~1.2105 – 1.2514~~ → ~~1.2109 – 1.2510~~ *(9-df corrected, then superseded with the row)* | ~~1.1989 – 1.2931~~ | ~~UIx slower~~ — **measured on the pre-`.13`/`.25` spine; the mount red zone has since closed** |
 | **M2 mount** — 51 el, 12 fields · *diagnostic* | ~~1.0539×~~ → **1.0601×** | ~~1.0017 – 1.1185~~ → **1.0028 – 1.1173** | 0.9561 – 1.1923 | **straddles 1.0 — indistinguishable**, in all ten runs |
 | **bulk broad** — one commit all 300 read | ~~0.6239×~~ → **0.6291×** | ~~0.5996 – 0.6587~~ → **0.6001 – 0.6581** | 0.5792 – 0.6987 | **UIx faster.** All 60 rounds below 1.0; all 20 strata wholly below it |
 | **bulk narrow** — 10 commits, each read by exactly one boundary, one window | ~~1.1540×~~ → **1.1754×** | ~~1.1579 – 1.1930~~ → **1.1582 – 1.1926** | 1.1390 – 1.2186 | **UIx slower.** All 60 rounds above 1.0; all 20 strata wholly above it |
@@ -382,6 +411,121 @@ on the five-round run (16.5–30 quanta against 21–30). A common factor in bot
 numerators cancels out of a ratio of two floor-normalised ratios, which is why
 the threshold itself barely moves: 2.831 ÷ 2.416 = 1.172, against the 1.1754 the
 row publishes. That agreement is the floor normalisation working as designed.
+
+### The re-take on the post-`.25` tree (rf2-b0tz5)
+
+**Mike ruled option (a) on 2026-07-31: re-take on the CONVERGED instrument and
+restate from same-instrument data.** Bridging the coldmount page's post-`.25`
+figure onto this page's line was explicitly rejected, and the reason is on this
+page — `rf2-2rtt6.21` measured the bar's own denominator, `reagent-subs ÷ floor`,
+differing **+9.7% on mount and +20.6% on broad between two authors in the same
+session**. A ~22-point restatement carried across a bridge worth up to 20 points
+is not a restatement.
+
+#### The instrument is the same one, and the default-off arm is why
+
+`p0_converge_app.cljs` moved between the published ensemble
+(`5a727706fc…`) and this re-take (`a5177d3f0b…`), because PR #7310 added the
+`:reagent-ratom` arm. **That arm is default OFF and the default is plan-identity,
+not politeness.** With `HICASSO_RATOM` unset the driver appends `&ratom=off`, the
+page's `query-ratom` returns false, and `arms-for` builds
+`[floor, <segment arm>, ctl-2x]` — the same three arms in the same order the
+ensemble ran. This is confirmed empirically rather than by reading the diff: the
+arm-order guard in every run below enumerates exactly
+`M1/reagent-subs/{floor, reagent-subs, ctl-2x}` and
+`M1/uix-subs/{floor, uix-subs, ctl-2x}`, with **no `reagent-ratom` arm present.**
+The other five instrument files are **byte-identical** to the ensemble's:
+
+| file | ensemble `4e4a68fa1f` | this re-take | |
+|---|---|---|---|
+| `p0_converge_app.cljs` | `5a727706fc…` | `a5177d3f0b…` | moved — additive, default-off (#7310) |
+| `p0_converge_run.cjs` | `9542c11674…` | `a846d1da11…` | moved — `lane_cache` path + `&ratom=` (#7310) |
+| `lane.cljs` | `0642815dc2…` | `0642815dc2…` | **identical** |
+| `p0_reagent_views.cljs` | `bf79bf304d…` | `bf79bf304d…` | **identical** |
+| `p0_uix_views.cljs` | `34e0e89d53…` | `34e0e89d53…` | **identical** |
+| `order_guard.cljc` | `6c4097afff…` | `6c4097afff…` | **identical** |
+
+| | |
+|---|---|
+| **Whole-tree anchor** | `7f54c67d5a6f25d5bdd2d74e71e4e61ab966b663` — `origin/main`. All eight instrument and spine blobs at the measuring tree are byte-identical to it, checked by `git rev-parse` |
+| **Spine under test** | `8d20218fd18282265cce1f931d019ca1f4d88b41` — **post-`.13` (`9df5094816`) and post-`.25` (`f784ab0adb`)**, both verified ancestors |
+| **Reproduction** | `HICASSO_START=reagent node implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs`, and the same with `HICASSO_START=uix` |
+| **Schedule** | unchanged — 6 rounds × 2 segments × 3 arms interleaved, one row per page, start counterbalanced across independently launched runs |
+| **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium via Playwright), `:advanced`, `goog.DEBUG false`, Windows 11 x64, 24 logical CPUs |
+
+#### The quiet discipline, and the one run the guard refused
+
+Three sibling workers were live on this box throughout. **Every published run
+below was launched into a measured-quiet window** — the `java`/`node` toolchain
+sampled under 30% of one core for three consecutive samples immediately before
+launch — and the pre- and post-run readings are recorded per run.
+
+**One run was refused and is reported rather than quietly dropped.** A run
+launched at 101% of a core exited **2** on the `narrow` row: the arm-order
+guard found phase strata **1.37×–1.55×** last-third over first-third across the
+narrow arms, which is the signature of a box that degraded mid-run (the post-run
+reading was 310%). It was **re-taken under quiet, not excused, and the guard's
+tolerance was not touched.** A separate `M1`-only pilot taken under load is
+likewise excluded from every figure here. That refusal is the evidence that the
+quiet bar is doing work rather than being asserted.
+
+#### What moved, and the control that says the denominator did not
+
+The restatement rests on a comparison the `rf2-2rtt6.21` finding demands: **the
+bar's own denominator is held fixed and shown to be fixed.** On `M1`, same
+instrument and same author:
+
+| `M1` mount leg | published ensemble *(pre-`.13`/`.25`)* | this re-take *(post-`.25`)* | change |
+|---|---:|---:|---|
+| `reagent-subs ÷ floor` — **the denominator** | **4.358×** | **4.316×** | **−1.0% — unmoved** |
+| `uix-subs ÷ floor` — the frontier numerator | **5.343×** | **4.391×** | **−17.8%** |
+| **ratio** | 5.343 ÷ 4.358 = **1.226** *(published 1.2310)* | 4.391 ÷ 4.316 = **1.017** | **the line moves ~21 points** |
+
+**The arithmetic is explicit and it closes.** The published threshold is the
+quotient of two floor-normalised legs; the denominator leg reproduces to within
+1.0% while the numerator leg falls 17.8%, and 4.391 ÷ 4.316 = 1.017 against the
+1.0185 the runs actually report — the small residue being that each run's ratio
+is formed per round and per segment before averaging, not from the two means.
+**So the ~21-point tightening is a property of the UIx arm, not of a drifting
+baseline** — which is precisely the failure mode a cross-author bridge could not
+have excluded.
+
+*(Numbers in this section are the ensemble as it stands; the run count and the
+interval are stated with the rows below and are updated as runs land.)*
+
+#### The restated lines — INSTRUMENT STAMP: converged `p0_converge_app` instrument, `rf2-2rtt6.2` witness family, post-`.25` spine `8d20218fd1`
+
+| witness | published *(pre-landing)* | **re-take, post-`.25`** | verdict |
+|---|---|---|---|
+| **M1 mount** — 901 el, 300 boundaries · *bar row* | ~~**1.2310×**~~ [1.1989 – 1.2931] | **≈1.02×** — see rows below | **RESTATED. The mount red zone has closed:** UIx and Reagent are now **indistinguishable** on the bar's mount row |
+| **M2 mount** — 51 el, 12 fields · *diagnostic* | 1.0601× [0.9561 – 1.1923] | reproduces inside its spread | **NOT restated** — still indistinguishable, still diagnostic |
+| **bulk broad** — one commit all 300 read · *bar row* | 0.6291× [0.5792 – 0.6987] | reproduces inside its spread | **NOT restated** — UIx still faster, direction unchanged |
+| **bulk narrow** — 10 commits, one window | 1.1754× [1.1390 – 1.2186] | reproduces inside its spread | **NOT restated** — UIx still slower, direction unchanged |
+
+**Only the mount row moved, and that is the mechanism agreeing with the
+measurement rather than a coincidence.** `rf2-2rtt6.25` landed the hook-scoped
+provisional hand-off so that a cold read builds **one reaction instead of two** —
+a **mount-path** cost. `M1` is the 300-boundary mount row and it moves ~21
+points. `broad` and `narrow` are commit-path rows and do not move. `M2` is also a
+mount row and does not resolve a move, which is expected rather than awkward: its
+window is three to six of Chrome's 100 µs quanta, so an 18% shift on one arm sits
+under its resolution — which is exactly why that row is graded diagnostic.
+
+#### The converged instrument AGREES with coldmount
+
+The advisory recorded that
+[the coldmount page](coldmount-double-build-priced.md) independently re-derived
+the same 901-element / 300-boundary mount witness post-`.25` at **`1.0054×`
+[0.917 – 1.143]**, excess mean 0.00 ms, on **its own instrument**. This re-take,
+on the **converged** instrument, reads the same witness at **≈1.02×**.
+
+**Two different instruments, two different drivers, two different authors, the
+same answer to within about two points** — against a published line of `1.2310×`
+that both now contradict by roughly twenty. The disagreement that `rf2-2rtt6.21`
+found in the denominator between two authors (+9.7% mount) is larger than the
+gap between these two post-`.25` mount readings, so the agreement is not an
+artefact of a shared harness. **The tightening is real, and it is the correct
+outcome rather than a problem to be softened.**
 
 ### All four rows reproduce against the revived driver (rf2-rjfz1)
 

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -42,26 +42,76 @@ genuinely incomparable and is re-measured below. The heap axis was not.
 
 ## What did not need re-running, and why
 
-Retained heap. The red-zones on that axis already rest on **two independent
-witness families measured by two independent instruments**, and they agree:
+Retained heap — **and the reason given below has since been corrected, twice.**
+The rows are kept because they are what the convergence decision was actually
+made on; the justification is rewritten in place because it was wrong.
 
-| source | witness | UIx ÷ Reagent, exclusive retained per boundary |
-|---|---|---|
-| rf2-2rtt6.4 | list, 1,203-el page, 300 boundaries | **2.262×** [2.196 – 2.335] |
-| rf2-2rtt6.4 | grid, 301-el page, 300 boundaries | **2.254×** [2.217 – 2.288] |
-| [rf2-2rtt6.5](reads-per-boundary-heap-ladder.md) | 1,200 boundaries × 1 read | **2.435×** (3,811 B ÷ 1,565 B above a component-free React floor) |
+> **REGIME STAMP, and the two corrections (`rf2-2rtt6.16`).** Cache cardinality
+> is part of the witness, so a heap row is meaningless without **B**
+> (boundaries), **E** (boundary-query edges) and **Q** (unique live query keys).
+> The heap red-zone regime ruling — delegated by Mike, 2026-07-31, authoritative
+> text on `rf2-2rtt6.16`, transcribed on `rf2-2rtt6.1` — makes the
+> **distinct-query ladder (Q = E)** the mandatory worst-case witness and the
+> operative upper-envelope red-zone family, and **relabels `rf2-2rtt6.4`'s rows
+> "fan-out 4 (amortised ×4), shared-query witness evidence — not comparable to
+> distinct-query rows."** Its four roots render the same 300 query vectors
+> against one frame, so 300 reactions at refcount 4 are divided over 1,200
+> boundaries and each "exclusive retained per boundary" **amortises the
+> subscription half of every read across four boundaries.** A candidate row is
+> judged only against same-regime, same-witness donor rows.
+
+| source | regime | witness | UIx ÷ Reagent, exclusive retained per boundary |
+|---|---|---|---|
+| rf2-2rtt6.4 | **shared-query, fan-out 4** (B = 1,200, Q = 300, amortised ×4) | list, 1,203-el page, 300 boundaries | **2.262×** [2.196 – 2.335] |
+| rf2-2rtt6.4 | **shared-query, fan-out 4** (B = 1,200, Q = 300, amortised ×4) | grid, 301-el page, 300 boundaries | **2.254×** [2.217 – 2.288] |
+| [rf2-2rtt6.5](reads-per-boundary-heap-ladder.md) | **distinct-query, Q = E** — the operative family | 1,200 boundaries × 1 read | ~~**2.435×** (3,811 B ÷ 1,565 B)~~ → **≈1.945×** (3,038 B ÷ 1,562 B) — see below |
+
+**The ladder row is restated in place, on two counts.** The `2.435×` above was
+computed from `3,811 B ÷ 1,565 B`, and **both of those values are superseded**:
+the tracked ladder's corrected fit reads **3,807 B** and **1,562 B** at one read
+(`2.437×`), because `rf2-2rtt6.5`'s original regression had included the sub-free
+R = 0 anchor it promised to exclude. More consequentially, **both are readings of
+a spine that no longer ships.** `rf2-2rtt6.13` (PR #7304, `9df5094816`) stopped
+retaining the disposed render-phase reaction — 769 B per unique query key, and so
+769 B *per read* where Q = E — and `rf2-2rtt6.25` (PR #7305, `f784ab0adb`) landed
+the hook-scoped provisional hand-off. On the shipping spine the ladder's UIx
+boundary at one read is **≈3,038 B** against Reagent's **1,562 B**, which neither
+landing touches, giving **≈1.945×**. **`2.435×` must not be quoted.**
+
+**`rf2-2rtt6.4`'s two rows are pre-`.13`/`.25` as well**, and their UIx numerators
+fall while their Reagent denominators do not, so both ratios move down by an
+amount this page has not measured. They are left as measured, under the regime
+label above, and **no post-landing magnitude is minted for them here.**
 
 Those three shapes differ in markup density by 4× and in boundary count by 4×,
-and the answers sit within 8% of each other. **Retained bytes per subscribing
-boundary is a property of the boundary.** The clock is not: a page's element
-count decides what fraction of the measured window is React's own work, which
-is precisely the term that moves a substrate ratio toward or away from 1.0.
+and their *ratios* sit within 8% of each other. That agreement was originally
+read as portability, and the conclusion drawn from it — **"retained bytes per
+subscribing boundary is a property of the boundary"** — **is falsified.** The
+mayor recorded the correction on `rf2-2rtt6.1` on 2026-07-31, and it is narrower
+than the claim it replaces:
 
-That asymmetry is the reason exactly one arm is re-run here, and it is stated as
-a claim the operator can reject rather than assumed. The three figures come from
-two different instruments and are not a replication in the strict sense; what
-they are is three independent shapes agreeing on an axis where the clock's four
-rows do not.
+- **A heap ABSOLUTE is not portable across witness shapes**, because it depends
+  on how many boundaries share a query. Hold markup density and boundary count
+  constant — `.4`'s grid (1 el/boundary, 4 × 300) against the ladder (1
+  el/boundary, 1,200) — and the answers still differ: Reagent 947 B against
+  1,565 B (1.65×), UIx 2,134 B against 3,811 B (1.79×). The sharing model
+  *solves*: a Reagent subscription half of ≈824 B against `rf2-2rtt6.12`'s
+  independently measured 866 B, and a UIx half of ≈2,236 B against its 2,453 B.
+  Three instruments, one arithmetic.
+- **A heap RATIO is portable only approximately** — 9.3% drift across fan-out
+  E/Q 1 → 8, 5.5% at ROOTS = 1.
+- **The 8% agreement survived only because the bias is common-mode.** Both arms
+  amortise identically, so the ratio is preserved while both absolutes are
+  wrong. That is precisely the shape a ratio-only check cannot see.
+
+The clock is not portable either, and for its own reason: a page's element count
+decides what fraction of the measured window is React's own work, which is the
+term that moves a substrate ratio toward or away from 1.0. **So the asymmetry
+that justified re-running exactly one arm here does not hold as stated** — the
+honest version is that the clock axis was *incomparable* across these witnesses
+while the heap axis was *comparably biased*, which is a weaker claim and the one
+the evidence supports. The three heap figures come from two different instruments
+and are not a replication in the strict sense.
 
 ## Which witness set, and why that one
 
@@ -1790,8 +1840,15 @@ mutation evidence is on
   clock rows remain sound as ratios and are superseded as *thresholds* by the
   table above; [its page](p0-uix-on-subs-frontier-arm.md) is marked accordingly
   rather than rewritten. Its **heap** rows are not superseded by anything here —
-  this entry measures no heap, and retained bytes per boundary is a property of
-  the boundary rather than of the page.
+  this entry measures no heap — but the reason this bullet used to give for
+  leaving them alone, *"retained bytes per boundary is a property of the boundary
+  rather than of the page"*, **is falsified and has been rewritten** at [What did
+  not need re-running](#what-did-not-need-re-running-and-why). A heap **absolute**
+  is not portable across witness shapes, because it depends on how many
+  boundaries share a query; a heap **ratio** ports only approximately (9.3% drift
+  across fan-out E/Q 1 → 8). `rf2-2rtt6.4`'s rows are **shared-query, fan-out 4**
+  and are not comparable to the distinct-query ladder as absolutes, per
+  `rf2-2rtt6.16`'s regime ruling.
 - **The per-page accumulation is still unexplained — but it now has a measured
   dose-response and a named lever.** rf2-6i0i2's six-round M2 refusals put
   numbers on it: 600 mounts a page clean, 720 refused 4 of 6, 1,296 refused 3 of

--- a/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
+++ b/docs/design/hicasso/studio/uix-spine-per-read-decomposition.md
@@ -48,6 +48,20 @@
 > `56f7e5480c99330515d525a2bdacf5f86a0db7bd`. Authored as `4367e5d93f` on
 > `worker/spine-2rtt6-13`.
 
+> **SPINE STAMP — this page's after-run is POST-`rf2-2rtt6.13` and
+> PRE-`rf2-2rtt6.25`.** The landed `.13` commit is **`9df5094816`**, whose
+> `spine.cljs` blob is the `56f7e5480c99…` named above — so the `2,734 B/read`
+> reading and everything under [§ The fix, landed](#the-fix-landed) sit on that
+> tree exactly. **A third landing has happened since:** `rf2-2rtt6.25`
+> (PR #7305, **`f784ab0adb`**, spine blob `086d08e94089…`) landed the
+> hook-scoped provisional hand-off, so a cold read builds one reaction instead
+> of two. That change is a **cold-read/mount-time** effect and this page's
+> steady-state per-read slope is not re-measured against it; the figures below
+> are therefore stamped `.13`, not "current tree". The live per-read gate lines
+> are on [validation.md](../validation.md#the-per-read-gates), and the clock
+> consequences of `.25` are on
+> [the converged witness set](p0-converged-witness-set.md).
+
 Reproduce:
 
 ```bash
@@ -413,23 +427,52 @@ within 0.1% on every arm (e.g. uix 3,501 vs 3,503; reagent 866 vs 865).
 
 Different rung set (0/1/3/7 here, 0/1/3/7/20 there), different run, same box and
 same collector design. **Both columns are pre-fix**, which is the only way the
-comparison means anything — the ladder was measured against the retaining spine.
+comparison means anything — the ladder was measured against the retaining spine,
+and so was this page's `retain` arm.
+
+> **`3,552 B/read` IS NOT A LIVE GATE LINE, here or anywhere.** It is the
+> ladder's reading of a spine that **no longer ships**, and it appears in this
+> section only because a pre-fix figure is the correct partner for a pre-fix
+> figure. Two production landings postdate both columns: `rf2-2rtt6.13`
+> (PR #7304, `9df5094816`) stopped retaining the disposed render-phase reaction,
+> worth **−769 B per unique query key** and so −769 B *per read* in the ladder's
+> distinct-query regime; `rf2-2rtt6.25` (PR #7305, `f784ab0adb`) landed the
+> hook-scoped provisional hand-off, so a cold read builds one reaction instead
+> of two. **The live UIx per-read red-zone is `2,935 B/read` [2,852–3,055] on
+> the P0 bench instrument** (Mike's option (a) ruling of 2026-07-31, executed by
+> `rf2-e3flf`), stated in
+> [validation.md](../validation.md#the-per-read-gates); the same tree reads
+> **`2,783 B/read` on the ladder's instrument**, and the ~5% between the two
+> harnesses is unexplained, so **a margin under 5% is instrument-limited rather
+> than cleared**.
 
 | | this page | `rf2-2rtt6.5` ladder | agreement |
 |---|---:|---:|---|
-| UIx bytes/read | 3,501 | 3,552 | 1.4% |
-| UIx objects/read | 125.8 | 128.4 | 2.0% |
-| Reagent bytes/read | 866 | 943 | 8.2% |
+| UIx bytes/read — **pre-fix spine, superseded as a gate** | 3,501 | 3,552 | 1.4% |
+| UIx objects/read — pre-fix spine | 125.8 | 128.4 | 2.0% |
+| Reagent bytes/read *(neither landing goes near the ratom path)* | 866 | 943 | 8.2% |
 | Reagent objects/read | 31.5 | 35.8 | 12% |
-| UIx/Reagent ratio | 4.04× | 3.77× | |
+| UIx/Reagent ratio — pre-fix spine | 4.04× | 3.77× | |
 | UIx shell ÷ Reagent shell | 266 ÷ 589 = 0.45× | 0.49× | |
+
+**The same cross-check on the shipping spine, and it holds.** This page's
+post-fix `uix` arm measured **2,734 B/read** [2,731–2,735]; the ladder's
+corresponding figure is its own slope less `.13`'s per-read term,
+`3,552 − 769 = 2,783 B`. The two sit **49 B apart — 1.8%**, against the 1.4%
+the pre-fix pair agreed to. **The agreement survives the landing**, which is
+what a cross-check between two instruments is for:
+
+| | this page *(measured post-fix)* | `rf2-2rtt6.5` ladder *(derived)* | agreement |
+|---|---:|---:|---|
+| UIx bytes/read, **shipping spine** | **2,734** | **2,783** | 1.8% |
 
 The ladder column is its **corrected** publication: `rf2-2rtt6.5`'s fit had
 included the sub-free R=0 anchor it promised to exclude, and refitting over
 1/3/7/20 alone moved it from 3,550/942 to 3,552/943 and its object counts from
-128.5/36.2 to 128.4/35.8. Every agreement above holds to within 0.1 percentage
-point of what it was, which is the useful thing to know: **this page never
-depended on the defect in that one.**
+128.5/36.2 to 128.4/35.8 — **all four of those figures being readings of the
+pre-`.13` spine.** Every agreement above holds to within 0.1 percentage point of
+what it was, which is the useful thing to know: **this page never depended on
+the defect in that one.**
 
 The UIx arms agree closely; the Reagent arms sit ~8–12% below the ladder's, which
 is the rung set — dropping R=20 removes the point with the most leverage from a

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -25,7 +25,9 @@ as HD-nnn are normative in [decisions.md](decisions.md).
   gate.
 - The bar's numbers come from P0. Until the like-for-like arms exist, no spike
   figure is quotable against the bar — and the donor-arm stop ruling (HD-008) is
-  issued only against the published P0 baseline table.
+  issued only against the published P0 baseline table. **That ruling was issued
+  on 2026-07-31** against the published table; the verdict and its win conditions
+  are under [the P1 gate](#p1-gate--the-composed-donor-arm-hd-008).
 
 ## The budgets (paper before code)
 
@@ -171,6 +173,40 @@ existing UIx `use-subscribe` spine already compose the central hypothesis
 **Stop rule**: if this composed arm cannot clearly beat both Reagent paths and
 stay acceptably close to direct UIx on the witness shapes, the programme stops
 before an API is designed. Adapters + sugar is the recorded successful outcome.
+
+**The stop rule has been consumed. The advisory was issued on 2026-07-31** as a
+delegated advisory ruling under HD-013, against the published P0 baseline table,
+and the outcome is recorded on `rf2-2rtt6.1` and `rf2-2rtt6.7`. This section no
+longer describes a gate awaiting its ruling.
+
+**Verdict: the stop rule was NOT met as written.** The composed arm beat neither
+Reagent path on mount — 1.333–1.473× stock Reagent on the `M` page, 1.448–1.542×
+on `U`, and indistinguishable from `reagent-slim` on both — and beat both on bulk
+only on the weaker cross-run warrant. **Continuation is therefore an operator
+override of a pre-registered gate, not a passing grade**, and the record says so
+in those words. What the gate did establish is worth more than the verdict it
+missed: the product shell is free (rung 2 indistinguishable from rung 1 on six of
+eight rows), and rung 1 *is* `reagent-slim` — so the residual mount deficit is the
+hiccup interpreter rather than the spine.
+
+Given continuation, the win conditions are (1) mount ≤ 1.0× Reagent-on-subs, same
+run and same instrument, with the codec inside 1.10× of direct UIx `$` on `M1`;
+(2) bulk broad ≤ 1.0× Reagent, red below UIx's measured broad ratio, K2 at 1.5×;
+(3) narrow as a **law** rather than a ratio — commit-side dirty-set flat in `B`
+across 300/600/1,200/2,400 mounted subscribing boundaries, and ≤ 1.0× Reagent,
+materially below UIx's measured narrow ratio; (4) grouped per-read retained heap
+≤ ≈2,000 B/read on the bench instrument, with a named paper path toward 943 B;
+and (5) a measured ergonomic preference over **Adapter-Prime**, never over the
+floor. The nine pre-registered kill signals are on `rf2-2rtt6.7`.
+
+**The advisory named one precondition, and it is now met.** The clock gate lines
+carried no post-landing restatement when the advisory was issued — the M1 mount
+red-zone was measured on the pre-`rf2-2rtt6.25` spine — so a candidate mount row
+judged against it was scored against a line the tree no longer justified. Mike
+ruled option (a) on 2026-07-31: re-take on the converged instrument and restate
+from same-instrument data. That re-take is `rf2-b0tz5`; the restated clock lines
+and their instrument stamps are on
+[the converged witness set](studio/p0-converged-witness-set.md#red-zone--clock-on-rf2-2rtt62s-witnesses).
 
 ### P1 — the tournament (the six-week clock starts at the first Hicasso-arm commit that mounts the dogfood screen — HD-014)
 

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -204,9 +204,40 @@ carried no post-landing restatement when the advisory was issued — the M1 moun
 red-zone was measured on the pre-`rf2-2rtt6.25` spine — so a candidate mount row
 judged against it was scored against a line the tree no longer justified. Mike
 ruled option (a) on 2026-07-31: re-take on the converged instrument and restate
-from same-instrument data. That re-take is `rf2-b0tz5`; the restated clock lines
-and their instrument stamps are on
-[the converged witness set](studio/p0-converged-witness-set.md#red-zone--clock-on-rf2-2rtt62s-witnesses).
+from same-instrument data. That re-take is `rf2-b0tz5`.
+
+### The clock gates, restated on the post-`.25` tree
+
+**INSTRUMENT STAMP: the converged `p0_converge_app` instrument, `rf2-2rtt6.2`'s
+witness family, post-`.25` spine `8d20218fd1`, whole-tree anchor `7f54c67d5a`.**
+All four published converged rows were measured on anchor `4e4a68fa1f`, whose
+`spine.cljs` blob is byte-identical to the **pre-`rf2-2rtt6.13`** spine — so all
+four were stale, not just the mount row. Four counterbalanced six-round runs,
+every gate clean, 0 unverified of 36,864:
+
+| bar row | published *(pre-landing)* | **restated, post-`.25`** | disposition |
+|---|---|---|---|
+| **M1 mount** | ~~1.2310×~~ | **1.0243×** [0.9937 – 1.0549] | **RESTATED — the L1 mount red zone has CLOSED.** Under Ruling 1 the red-zone *is* the measured UIx ratio, so the mount line now sits at parity |
+| **bulk broad** | 0.6291× | not distinguishable at n = 4 | **stands** — direction unchanged, UIx faster |
+| **bulk narrow** | 1.1754× | not distinguishable at n = 4 | **stands** — direction unchanged, UIx slower |
+| M2 mount *(diagnostic)* | 1.0601× | not distinguishable at n = 4 | **stands**, still not quotable against the bar |
+
+**The arithmetic.** The threshold is a quotient of two floor-normalised legs. The
+denominator, `reagent-subs ÷ floor`, reads **4.380×** against the published
+**4.358×** — unmoved within 0.5%. The numerator, `uix-subs ÷ floor`, falls
+**5.343× → 4.479×**, −16.2%. `4.479 ÷ 4.380 = 1.023`. **The tightening is a
+property of the UIx arm, not of a drifting baseline** — the check `rf2-2rtt6.21`
+made necessary by measuring that same denominator differing +9.7% between two
+authors.
+
+**A candidate at 1.15× Reagent on mount was red-free yesterday and is RED
+today.** Every candidate mount row between `1.0243` and the old `1.2310` flips,
+and that tightening is the intended consequence rather than a problem to soften.
+The converged instrument independently agrees with
+[the coldmount page](studio/coldmount-double-build-priced.md)'s `1.0054×` on the
+same witness — 1.9 points apart, from two instruments and two authors. Full
+record, including the three runs that did not publish and why:
+[the re-take](studio/p0-converged-witness-set.md#the-re-take-on-the-post-25-tree-rf2-b0tz5).
 
 ### P1 — the tournament (the six-week clock starts at the first Hicasso-arm commit that mounts the dogfood screen — HD-014)
 


### PR DESCRIPTION
Implements `rf2-b0tz5`. Restates the CLOCK gate lines on the post-`.25` tree from
same-instrument data, per Mike's option (a) ruling of 2026-07-31, and clears the
five stale-figure sites the `rf2-2rtt6.7` donor-gate advisory found.

Nothing here amends the bar, the budgets, the kill criteria or any red-zone the
operator set. Ruling 1's rule is applied, not changed.

## Provenance — all four converged rows were stale, settled by blob not by date

The bead asked which of the four converged rows were pre- or post-`rf2-2rtt6.13`
(`9df5094816`) and `rf2-2rtt6.25` (`f784ab0adb`). The answer is **all four, on
both counts** — they come off one anchor whose spine blob is byte-identical to
the pre-`.13` spine:

| converged row | landed anchor | `spine.cljs` blob | vs `.13` | vs `.25` |
|---|---|---|---|---|
| M1 mount | `4e4a68fa1f` | `befd8469d9` | **PRE** | **PRE** |
| M2 mount | `4e4a68fa1f` | `befd8469d9` | **PRE** | **PRE** |
| bulk broad | `4e4a68fa1f` | `befd8469d9` | **PRE** | **PRE** |
| bulk narrow | `4e4a68fa1f` | `befd8469d9` | **PRE** | **PRE** |

```bash
S=implementation/core/src/re_frame/substrate/spine.cljs
git rev-parse 4e4a68fa1f:$S    # befd8469d9...
git rev-parse 9df5094816^:$S   # befd8469d9...  identical -> the run is PRE-.13
git rev-parse f784ab0adb:$S    # 086d08e940...
```

So the whole table needed re-taking, not just the mount row.

## The restated lines

**INSTRUMENT STAMP: converged `p0_converge_app` instrument, `rf2-2rtt6.2` witness
family, post-`.25` spine `8d20218fd1`, whole-tree anchor `7f54c67d5a`** (all eight
instrument and spine blobs byte-identical to `origin/main`).

Four independently launched six-round runs, start counterbalanced 2/2, each into
a measured-quiet window. **0 unverified of 36,864**; arm-order guard
`refuse? false` on all 24 row-verdicts; parity `ok? true` on all 16; every
positive control inside +/-25%.

| bar row | published (pre-landing, 10 runs) | restated (post-`.25`, 4 runs) | 95% CI | disposition |
|---|---|---|---|---|
| **M1 mount** | ~~1.2310x~~ [1.1989-1.2931] | **1.0243x** | 0.9937 - 1.0549 | **RESTATED — L1 mount red zone CLOSED** |
| bulk broad | 0.6291x | 0.5598x | 0.4781 - 0.6415 | **stands** — CI contains the published value |
| bulk narrow | 1.1754x | 1.2233x | 1.1238 - 1.3228 | **stands** — CI contains the published value |
| M2 mount *(diagnostic)* | 1.0601x | 1.0071x | 0.8978 - 1.1165 | **stands**, not quotable against the bar |

**The arithmetic, explicit.** The threshold is a quotient of two floor-normalised
legs, and stating it this way isolates which leg moved:

- denominator `reagent-subs / floor`: **4.358x -> 4.380x** — unmoved within **0.5%**
- numerator `uix-subs / floor`: **5.343x -> 4.479x** — **-16.2%**
- `4.479 / 4.380 = 1.023`, against the **1.0243** the runs report (each run forms
  its ratio per round and per segment before averaging, hence the small residue)

**The ~21-point tightening is a property of the UIx arm, not of a drifting
baseline.** That is exactly the check `rf2-2rtt6.21` made necessary by measuring
the same denominator differing +9.7% between two authors — and it is why the
ruling required a same-instrument re-take rather than a bridge.

Only M1 is restated. On the other three the re-take's interval **contains** the
published magnitude, so the conservative reading is kept: direction unchanged,
magnitude not distinguishable at n = 4. Publishing `0.5598x` as a threshold on
four runs against a ten-run line it does not contradict would mint precision the
measurement does not carry.

**The converged instrument AGREES with coldmount:** `1.0054x` on its instrument
against `1.0243x` on this one — 1.9 points apart, each interval containing the
other's point estimate. The cross-author denominator disagreement (+9.7%) is
larger than the gap between the two post-`.25` readings, so the agreement is not
a shared-harness artefact.

Under Ruling 1 the red-zone **is** the measured UIx ratio, so **a candidate at
1.15x Reagent on mount was red-free yesterday and is RED today.**

## Items 2-6 — the stale-figure sites

2. **`uix-spine-per-read-decomposition.md`** — the two `3,552 B/read` sites had no
   restated counterpart. The cross-check section stays **pre-fix on both sides**
   (a pre-fix figure is the correct partner for a pre-fix figure) but now says so,
   and names the live line: `2,935 B/read` on the bench instrument, `2,783` on the
   ladder's, with the ~5% harness offset stated so a sub-5% margin is not read as
   a pass. Adds the same cross-check on the shipping spine — this page's measured
   `2,734` against the ladder's derived `2,783`, **1.8% apart** against the pre-fix
   pair's 1.4%, so the agreement is shown to survive the landing. Also gains the
   spine stamp it lacked: its after-run is **post-`.13`, pre-`.25`**, which its own
   recorded spine blob `56f7e5480c99` proves.
3. **`p0-converged-witness-set.md`** — the ladder row cited `2.435x` from
   `3,811/1,565`. Both values are superseded (the corrected fit reads
   `3,807/1,562`) **and** both read a spine that no longer ships. Restated **in
   place** to **~1.945x** (`3,038 B / 1,562 B`).
4. **Both sites** asserting *"retained bytes per subscribing boundary is a property
   of the boundary"* are **rewritten, not annotated**. The claim is falsified: a
   heap **absolute** is not portable across witness shapes because it depends on
   how many boundaries share a query, and the 8% ratio agreement survived only
   because the amortisation bias is common-mode. Replaced with the narrower true
   claim (a ratio ports approximately — 9.3% drift across E/Q 1->8) plus
   `rf2-2rtt6.16`'s regime stamp (B/E/Q) and a pointer to its ruling.
5. **`hd8-composed-donor-arm.md`** — stamped. Every producing commit carries spine
   blob `befd8469d9`, verified by blob rather than by date. `uix`, `donor-r1` and
   `donor-r2` route through `use-subscribe` and are **pre-landing**; `reagent`,
   `reagent-slim` and `floor` are on the ratom path and unaffected. So every
   donor-vs-Reagent ratio on the gate's own page has a numerator term that no
   longer exists. Direction is stated (the mount columns are pessimistic); no
   post-landing magnitude is minted, because this page was not re-run.
6. **`validation.md`** — HD-008's stop rule is no longer described as outstanding.
   The advisory issued 2026-07-31: **not met as written**, so continuation is an
   operator override of a pre-registered gate, in those words, with the five win
   conditions and a pointer to the nine kill signals on `rf2-2rtt6.7`.

## Refusals — reported, not excused

Three runs did not publish. None was excused and no guard tolerance was touched:

| launched at | outcome | why |
|---|---|---|
| 101% of a core | **exit 2** — guard, `narrow` | phase strata 1.37x-1.55x last-third over first-third; the box degraded mid-run (post-run reading 310%). **Re-taken under quiet** |
| 0% | **exit 2** — guard, `M2` | the mount-budget fragility this page already documents (720 mounts a page refused 4 of 6 for `rf2-6i0i2` too). Not contention, not new |
| 0% | **exit 1** — segment-order control, `M1` | the two order strata point **opposite ways across 1.0**. Reported as a finding: that control was written when the row sat at 1.23x, and a row centred **on** 1.0 trips it because there is no effect left to have a direction |

An `M1`-only pilot taken under load is excluded from every published figure.

## Rebased onto `main` — and the conflict was two correct edits, not one stale one

The branch was **not mergeable**: `main` had advanced and PR #7312 (`rf2-6i0i2`)
had edited the same page. Rebased onto `447dc6ad09` and force-pushed. **One
conflicting hunk, in `p0-converged-witness-set.md`: the RED-ZONE table.** Both
sides were right, so neither was taken wholesale.

* **#7312's intent.** It recovered the ensemble's 10x4 observation table from a
  backup and, recomputing from it, found every 95% interval on the page was
  about 2% too wide — a `t` multiplier for **eight** degrees of freedom where a
  one-sample interval on the mean of ten run means needs **nine**. Eight is
  correct for the two-sample 5-v-5 `resolution limit` column beside it, and the
  same `t` had been reused. Ten sites struck and corrected, three tests pinning
  the arithmetic.
* **This branch's intent.** M1 mount `1.2310x` -> `1.0243x` [0.9937 - 1.0549]
  on the post-`.25` tree, the L1 mount red zone **closed**; M2, broad and narrow
  deliberately **not** restated because each re-take's CI contains the published
  value.

**How both were kept.** M2, broad and narrow take #7312's corrected intervals
unchanged — this branch never restated those rows. The M1 row carries **both**:
the original interval struck, #7312's 9-df correction struck beside it, and a
gloss naming the order (`9-df corrected, then superseded with the row`), so the
corrected figure stays on the page for a reader who arrives looking for it while
the row still points at the re-take. No `--ours`, no `--theirs`.

### The 8-df/9-df interaction — this branch's intervals did NOT need correcting

Checked rather than assumed, because it is load-bearing. The re-take's intervals
are one-sample intervals on the mean of **four** run means, so `n - 1 = 3` and
`t = 3.1824` — and that is the multiplier they use:

```
run means  0.9980  1.0391  1.0219  1.0382     (the four printed beside the row)
mean 1.0243   sd 0.019233   se 0.009616
1.0243 +/- 3.1824 x 0.009616 = [0.9937 - 1.0549]   <- the published M1 interval, exactly
```

**Same rule, applied correctly.** #7312's defect was reusing a *two-sample*
multiplier for a *one-sample* interval; this branch used `n - 1` for its own `n`.
It is not bookkeeping: at `t = 2.2622` the same four runs would read
`1.0025 - 1.0461`, which **excludes** 1.0 and would contradict the
indistinguishable-from-parity verdict every one of those runs reports.

One sentence of #7312's was scoped rather than left to over-reach — *"every
interval on this page"* became *"every interval this ensemble published"*, since
the re-take adds four intervals that do not carry the defect — and the page now
states the re-take's degrees of freedom at both sites.

## Quality gates

| gate | command | exit |
|---|---|---|
| **#7312's interval suite, post-rebase** | `node out/node-test.js --test=re-frame.bench.hicasso.p0-converge-order-cljs-test` — **29 tests, 368 assertions, 0 failures** | **0** |
| CLJS suite, post-rebase | `npm run test:cljs` — 12,057 tests / 60,412 assertions; 30 failures, **all 30 in `test_quiet_shadow_node_cljs_test.cljs`** (see below) | **1** |
| docs build, post-rebase | `python -m mkdocs build --strict` | **0** |
| in-page anchors, by hand | 30 links / 57 headings on the converged page — all resolve | **0** |
| table column counts, by hand | 85 tables across the four touched pages — 0 ragged rows | **0** |
| converged run 1 (reagent-start) | `HICASSO_START=reagent node .../p0_converge_run.cjs` | **0** |
| converged run 2 (uix-start) | `HICASSO_START=uix node .../p0_converge_run.cjs` | **0** |
| converged run 3 (reagent-start) | `HICASSO_START=reagent node .../p0_converge_run.cjs` | **0** |
| converged run 6 (uix-start) | `HICASSO_START=uix node .../p0_converge_run.cjs` | **0** |
| converged run — refused on `narrow` | `HICASSO_START=uix node .../p0_converge_run.cjs` | **2** (re-taken) |
| converged run — refused on `M2` | `HICASSO_START=uix node .../p0_converge_run.cjs` | **2** (recorded) |
| converged run — segment-order, `M1` | `HICASSO_START=reagent node .../p0_converge_run.cjs` | **1** (recorded as a finding) |
| worktree `node_modules` repair | `npm ci --no-audit --no-fund` | **0** |

**The suite's exit 1 is a local box artefact and is reported rather than
rounded off.** All 30 failures are in one namespace,
`re_frame/test_quiet_shadow_node_cljs_test.cljs`, across all six of its
nested-spawn tests, with **18 `spawnSync … ETIMEDOUT`** among them. That
namespace measures the real runner's wall-clock spawn behaviour, and it was run
while `mkdocs build --strict` (144 s of CPU) and three sibling worker builds were
live on the same box. **`p0_converge_order_cljs_test.cljs` — the namespace
carrying #7312's three interval assertions — is green in that same run and green
again when run focused**, which is the gate that actually covers this merge. Two
attempts at an uncontended re-run aborted in `par-compile` under the sibling
load, each naming *different* resources and reporting **0 test failures**, so
they carry no verdict either way.

**No code file is touched on this branch at all** — `git diff --name-only
origin/main..HEAD` is four `.md` paths — so no conflict could reach a code file
and **no clj-kondo run is claimed here**. CI agrees: *Detect lint surface* and
*Detect changed test surfaces* both resolve to no code surface, every JVM and
CLJS job reports `skipping`, and *Lint required* / *All required checks passed*
are green.

**`mkdocs build --strict` does not cover this surface, and is not cited as
though it did.** `design/hicasso/` is in `exclude_docs` in `mkdocs.yml`, and the
build confirms it — zero mentions of the page in the log and no
`site/design/hicasso/` produced. The strict build is reported for the rest of
the site only. **The converged page's internal anchors and table shapes were
therefore checked by hand**, against the page's own slug convention
(`pymdownx.slugs.slugify`, `case: lower`, which is what makes this page's
existing `#red-zone--clock-...` double-hyphen anchors correct): 30 in-page links
against 57 headings across the converged page all resolve, and 85 tables across
the four touched pages have no ragged row. Read by eye as well — no duplicated
section, no orphaned supersession pointer, the 10x4 observation table intact at
all forty cells with both group-mean rows and the threshold row, the restated M1
line intact, and all 63 struck spans on the page still paired with a replacement
or an explicit in-line supersession.

## Note for the mayor — one pre-existing tension, deliberately not touched

*The verdict on M1's magnitude* and the size-locked-`rf2-2rtt6.1` appendix both
still read *"what is published is a magnitude with an interval: `1.2310×`"*,
which sits oddly beside a RED-ZONE row now marked SUPERSEDED. **That is not a
merge artefact** — it reads identically in this branch's pre-rebase commit
`5d49ce064c`, which is the state the PR was reviewed green in; the rebase only
moved the interval figure there from `1.2105 – 1.2514` to `1.2109 – 1.2510`,
which is #7312's correction landing correctly. Left alone rather than folded
into a conflict resolution, because rewriting the operator-facing verdict text
is a content decision rather than a merge one. Flagged so it is a choice on the
record and not an oversight.

## Note for the mayor — `node_modules` incident, not caused by this branch

Mid-task every build on this box began failing with
`Cannot find module .../implementation/node_modules/shadow-cljs/cli/runner.js`.
**The mayor checkout's real `implementation/node_modules` had been emptied to 0
entries** — the documented hazard where `git worktree remove` follows a worktree's
`node_modules` junction into the mayor's real directory. `wave1-2rtt6-8` no longer
has a `node_modules` at all, which is consistent with that worktree having been
reaped through its junction.

This branch did **not** cause it and did **not** repair the mayor checkout (out of
bounds for a worker). It unblocked itself by removing its own junction with
`cmd /c rmdir` (link only — the target was verified still present afterwards) and
running `npm ci` locally, so **this worktree now holds a REAL `node_modules` and
leaves no junction for the mayor to clean up.** `benchfix-6i0i2` and
`concurrent-2rtt6-13` also hold real trees; `pr-audit-20260730` still has a
dangling junction into the empty directory. **The mayor's own checkout still needs
`npm ci`.**

