### PR TITLE
bench,test(hicasso): pin run-mean separation, not a false round-level claim (rf2-2rtt6.21)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_app.cljs
@@ -86,6 +86,14 @@
   than qualifying it — but the record carries `:ratom-arm? true` and a
   comparability note, and that figure may NOT be quoted as a threshold.
 
+  THE FLAG IS GLOBAL AND THE ARM IS NOT. `?ratom=on` with no row
+  restriction reaches `M2` and `narrow` as well, and those two rows keep
+  their published three-arm plan whatever the flag says. So every fact
+  downstream of the arm — the leg, the ratom floor, `:ratom-arm?`, the
+  comparability note — is derived from the SLICE by [[ratom-leg]] and
+  never from the flag. A row that did not run the arm publishes no leg,
+  rather than dividing by a denominator nobody measured.
+
   ## Three arms a segment, and why not two
 
   rf2-ouwh8: `lane/slot-order` rotated and then REFLECTED, and at k=2 those
@@ -882,10 +890,11 @@
 (defn segment-order-verdict
   "Adjudicate a cross-segment figure BY WHICH SEGMENT RAN FIRST.
 
-  Public, and the only public fn in this entry besides `-main`, because
-  `p0_converge_order_cljs_test` replays the PUBLISHED per-round vectors
-  through it: a verdict that has only ever seen the run it shipped with is
-  a verdict nobody can check.
+  Public because `p0_converge_order_cljs_test` replays the PUBLISHED
+  per-round vectors through it: a verdict that has only ever seen the run
+  it shipped with is a verdict nobody can check. That is the only reason
+  anything in this entry is public, and it is the reason for the other
+  three — [[ratom-leg]], [[row-record]] and [[reagent-segment-arm-ids]].
 
   ## What the arm-order guard cannot see, and why this exists
 
@@ -1011,19 +1020,63 @@
                      "C(" rounds "," (count (:uix-first strata)) ") assignments, so this "
                      "withdraws a claim rather than establishing an effect."))))})))
 
-(defn- row-record
+(defn ratom-leg
+  "This row's REACTIVE LEG — `reagent-subs` over `reagent-ratom`, per
+  round, both floor-normalised in the SAME segment of the SAME round — or
+  `nil` when this row's Reagent segment did not run the `:reagent-ratom`
+  arm.
+
+  BOTH TERMS ARE THE REAGENT SEGMENT'S OWN, so the floor divides out
+  exactly and the seam is not in the arithmetic at all. The leg is formed
+  from the floor-normalised ratios rather than from the raw p50s only
+  because that is the arithmetic `lane/ratio-between` performs on the
+  first author's page, and two authors disagreeing about a division is
+  not a finding anybody wants to chase.
+
+  DECIDED BY THE SLICE, and that is the whole of the function
+  (rf2-2rtt6.21). `?ratom=on` is a page-global flag while arm presence is
+  ROW-SPECIFIC: the `M2` witness ignores the flag outright and
+  [[bulk-arms]] admits the arm only on `:broad`. A record that read the
+  FLAG instead of the MEASUREMENT therefore divided by a ratio those two
+  rows never produced — `subs / nil`, which JavaScript answers `Infinity`
+  rather than refusing — formed a ratom floor of nothing, ran the leg
+  verdict over it and labelled the row as carrying an arm it was never
+  given. The natural flagged invocation, `HICASSO_RATOM=on` with no
+  `HICASSO_ONLY`, is exactly the one that selects those rows; the
+  published runs escaped it only by always pairing the flag with
+  `HICASSO_ONLY=M1,broad`.
+
+  A PARTIAL arm is treated as no arm. Every round must carry a finite,
+  positive ratom ratio, because a leg formed over some rounds and not
+  others is a different figure from the one this page publishes, and a
+  figure that quietly changes what it averages over is worse than one
+  that is absent."
+  [norm]
+  (let [ratom (mapv #(get-in % [:reagent-subs :ratio :reagent-ratom]) norm)]
+    (when (and (seq ratom)
+               (every? #(and (number? %) (js/isFinite %) (pos? %)) ratom))
+      (mapv (fn [m r] (/ (get-in m [:reagent-subs :ratio :reagent-subs]) r))
+            norm ratom))))
+
+(defn row-record
   "Turn one row's per-round, per-segment slices into the published record.
 
   `slices` is `[{segment-id {arm-id [ms ...]}} ...]`, one entry per round.
   `start` is the segment that led round 0, and it is published on the
   record because a reader comparing counterbalanced runs needs it.
 
-  `ratom?` says whether the second author's `:reagent-ratom` arm was in
-  this row's plan. When it was, the record carries a REACTIVE LEG — and
-  it also carries the fact that the red-zone beside it came off a
-  four-arm Reagent segment, because a threshold and the plan it was
-  measured under are one fact and not two (rf2-2rtt6.21)."
-  [{:keys [row doc grade clock-note control note writes-per-sample start ratom?]} slices]
+  Whether the second author's `:reagent-ratom` arm was in this row's plan
+  is not passed in: it is read off the slices by [[ratom-leg]], because
+  the flag that requests the arm is global and the plan that runs it is
+  per-row. When the arm ran, the record carries a REACTIVE LEG — and it
+  also carries the fact that the red-zone beside it came off a four-arm
+  Reagent segment, because a threshold and the plan it was measured under
+  are one fact and not two (rf2-2rtt6.21).
+
+  Public for `p0_converge_order_cljs_test`, which feeds it one round of
+  each row's actual arm set and holds the flagged default selection to
+  that contract without a browser."
+  [{:keys [row doc grade clock-note control note writes-per-sample start]} slices]
   (let [norm       (mapv (fn [by-seg]
                            (into {} (map (fn [[sid rd]] [sid (ratios-of rd)])) by-seg))
                          slices)
@@ -1032,19 +1085,11 @@
                          norm)
         rg-floor   (mapv #(get-in % [:reagent-subs :ratio :reagent-subs]) norm)
         ux-floor   (mapv #(get-in % [:uix-subs :ratio :uix-subs]) norm)
-        ;; BOTH TERMS ARE THE REAGENT SEGMENT'S OWN, so the floor divides
-        ;; out exactly and the seam is not in the arithmetic at all. It is
-        ;; formed from the floor-normalised ratios rather than from the
-        ;; raw p50s only because that is the arithmetic `lane/ratio-between`
-        ;; performs on the first author's page, and two authors disagreeing
-        ;; about a division is not a finding anybody wants to chase.
-        leg        (when ratom?
-                     (mapv (fn [m] (/ (get-in m [:reagent-subs :ratio :reagent-subs])
-                                      (get-in m [:reagent-subs :ratio :reagent-ratom])))
-                           norm))
-        ratom-floor (when ratom?
+        leg        (ratom-leg norm)
+        arm?       (some? leg)
+        ratom-floor (when arm?
                       (mapv #(get-in % [:reagent-subs :ratio :reagent-ratom]) norm))
-        leg-order  (when ratom?
+        leg-order  (when arm?
                      (segment-order-verdict leg rounds start "the reactive leg's"))
         seam       (mapv (fn [m] (/ (get-in m [:uix-subs :p50 :floor])
                                     (get-in m [:reagent-subs :p50 :floor])))
@@ -1085,9 +1130,9 @@
                                    :magnitude
                                    :direction-only)
                           :direction (direction-of (range-of rz))
-                          :ratom-arm? (boolean ratom?)
+                          :ratom-arm? arm?
                           :comparability
-                          (when ratom?
+                          (when arm?
                             (str "NOT the published threshold and not comparable with "
                                  "it. With :reagent-ratom in the plan the Reagent "
                                  "segment ran FOUR arms against the UIx segment's "
@@ -1098,13 +1143,13 @@
                                  "the same slices and hiding it would be worse than "
                                  "qualifying it; it may not be quoted as a red-zone.")))
       :segment-order-control order
-      :ratom-arm?  (boolean ratom?)
+      :ratom-arm?  arm?
       ;; THE ROW THIS RUN EXISTS FOR when the arm is in the plan. Both
       ;; terms are Reagent arms measured in the same segment of the same
       ;; round, which is what makes it a second AUTHOR'S reading of
       ;; rf2-2rtt6.2's headline 1 rather than a fourth run of the first's.
       :reactive-leg
-      (when ratom?
+      (when arm?
         (assoc (range-of leg)
                :numerator :reagent-subs
                :denominator :reagent-ratom
@@ -1121,7 +1166,7 @@
                          "schedule, a different round count and a different arm "
                          "plan (rf2-2rtt6.21).")))
       :reactive-leg-segment-order leg-order
-      :ratom-over-floor   (when ratom? (range-of ratom-floor))
+      :ratom-over-floor   (when arm? (range-of ratom-floor))
       :uix-over-floor     (range-of ux-floor)
       :reagent-over-floor (range-of rg-floor)
       :segment-seam-control
@@ -1288,6 +1333,21 @@
                        "row here uses.")
             :control bulk-control}})
 
+(defn reagent-segment-arm-ids
+  "The arm ids THIS row's Reagent segment runs under `ratom?` — asked of
+  the plan itself rather than restated beside it.
+
+  Public because `?ratom=on` is a page-global flag while arm presence is
+  row-specific, and until rf2-2rtt6.21 that distinction lived in two
+  `cond->`s no test without a browser could reach. `M1` takes the arm from
+  its witness's `:arms-for` and `:broad` from [[bulk-arms]]; `M2` ignores
+  the flag and `:narrow` is never offered it."
+  [row-key ratom?]
+  (let [{:keys [kind witness]} (get row-specs row-key)]
+    (mapv :id (if (= kind :mount)
+                ((:arms-for (witness-named witness)) :reagent-subs ratom?)
+                (bulk-arms :reagent-subs row-key ratom?)))))
+
 (defn- query-row
   "Which row this page runs. One row per page (see [[row-specs]]); the
   driver loads the page once per row."
@@ -1334,7 +1394,7 @@
         legs))
 
 (defn- publish!
-  [{:keys [kind witness row grade doc note control] :as _spec} row-key start ratom?
+  [{:keys [kind witness row grade doc note control] :as _spec} row-key start
    slices t legs coll]
   (let [w   (witness-named witness)
         {:keys [record controls order leg-order]}
@@ -1345,8 +1405,7 @@
                      :note note
                      :control (or control (:control w))
                      :writes-per-sample (if (= row :bulk-narrow) narrow-batch-k 1)
-                     :start start
-                     :ratom? ratom?}
+                     :start start}
                     slices)]
     (lane/record! (name row) record)
     (lane/record! "verification" {row-key (lane/tally-value t)})
@@ -1512,8 +1571,10 @@
         (js/console.log (str ";; HICASSO row " (name row-key)
                              " — round 0 led by " (name start) ", alternating"
                              (when ratom?
-                               (str "; the second author's :reagent-ratom arm is IN the "
-                                    "Reagent segment (rf2-2rtt6.21)"))))
+                               (str "; :reagent-ratom REQUESTED — this row's Reagent "
+                                    "segment runs "
+                                    (pr-str (reagent-segment-arm-ids row-key true))
+                                    " (rf2-2rtt6.21)"))))
         (lane/record! "parity"
                       {:row row-key :problems problems :ok? (empty? problems)
                        :note (str "canonical DOM with attribute names sorted, inside each "
@@ -1535,7 +1596,7 @@
                               (-> (run-round! spec row-key start ratom? r coll t legs)
                                   (.then (fn [slice] (conj acc slice))))))
                 (.then (fn [slices]
-                         (publish! spec row-key start ratom? slices t legs coll)
+                         (publish! spec row-key start slices t legs coll)
                          (lane/done!)
                          nil))
                 (.catch (fn [e]

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs
@@ -76,6 +76,7 @@
   so this runs on every runtime."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.set :as set]
+            [clojure.walk :as walk]
             [re-frame.bench.hicasso.p0-converge-app :as app]))
 
 ;; ---------------------------------------------------------------------------
@@ -331,13 +332,28 @@
       (is (= :numerator-slower (:direction (:uix-first r))) (str row))
       (is (false? (:refuse? r)) (str row)))))
 
+(def ^:private first-author
+  "rf2-2rtt6.2's publication run and rf2-2rtt6.17's two re-runs of its OWN
+  `:reagent-ratom` arm — the run mean and the per-round range of each,
+  exactly as the studio page tabulates them beside this ensemble.
+
+  Kept as DATA rather than as constants inside an assertion, so that what
+  the tests below compare is two published sets against each other and
+  not a number somebody typed into a threshold."
+  {:M1    [{:mean 1.218 :min 1.122 :max 1.310}
+           {:mean 1.216 :min 1.185 :max 1.241}
+           {:mean 1.213 :min 1.093 :max 1.273}]
+   :broad [{:mean 2.008 :min 1.938 :max 2.100}
+           {:mean 1.965 :min 1.875 :max 2.000}
+           {:mean 2.073 :min 2.000 :max 2.167}]})
+
 (deftest the-leg-does-not-reproduce-the-first-authors-magnitude
   (testing "and the MAGNITUDE is not corroborated, which is the finding
            rf2-2rtt6.21 exists to surface. rf2-2rtt6.2 publishes 1.218 /
-           1.216 / 1.213 on M1 and 2.008 / 1.965 / 2.073 on broad; every
-           one of these run means sits above every one of those, and the
-           lowest M1 round of all six runs still clears the highest of the
-           first author's three means"
+           1.216 / 1.213 on M1 and 2.008 / 1.965 / 2.073 on broad, and
+           every one of these RUN MEANS sits above every one of those.
+           That is the separation the studio page claims, and it is
+           claimed at the run level because that is the level it holds at"
     (let [means (fn [row] (map :order-balanced-mean (legs row)))]
       (is (every? #(> % 1.30) (means :M1))
           "every M1 run mean is above 1.30, where the first author's three
@@ -345,16 +361,34 @@
       (is (every? #(> % 2.30) (means :broad))
           "every broad run mean is above 2.30, where the first author's
            three are 1.965-2.073")
-      (is (> (apply min (mapcat :vs (:M1 leg))) 1.24)
-          "and the LOWEST single round across all six M1 runs, 1.2500,
-           still sits above the first author's re-run maxima of 1.241 and
-           1.273 — a disagreement at the round level and not only at the
-           mean")))
-  (testing "the same statement from the other side: replay the first
-           author's own published M1 leg as if it were a six-round vector
-           and it does not reach this ensemble's floor"
-    (is (< 1.218 (apply min (mapcat :vs (:M1 leg))))
-        "1.218 is below every round the second author measured")))
+      (doseq [row [:M1 :broad]]
+        (is (> (apply min (means row))
+               (apply max (map :mean (get first-author row))))
+            (str row ": the LOWEST of the second author's six run means "
+                 "must clear the HIGHEST of the first author's three"))))))
+
+(deftest the-round-ranges-overlap-so-the-separation-is-not-a-round-level-claim
+  (testing "THE CORRECTION the PR #7310 audit required (rf2-2rtt6.21). The
+           replay above used to carry a third assertion —
+           `min(second-author round) > 1.24` — under a message reading
+           `1.2500 still sits above the first author's re-run maxima of
+           1.241 AND 1.273`. It does not: 1.2500 is below 1.273, so the
+           message made a FALSE round-level claim look pinned by a test
+           that was only ever pinning 1.24.
+
+           The round ranges OVERLAP, which is what the studio page has
+           always said — `overlap at the edges, 1.1667 - 1.3175 against
+           1.2500 - 1.4822, while the run means are disjoint`. So the
+           round-level reading is pinned FALSE here rather than merely
+           deleted: a later hand that reinstates it reds this test"
+    (doseq [row [:M1 :broad]]
+      (let [lowest-second (apply min (mapcat :vs (get leg row)))
+            highest-first (apply max (map :max (get first-author row)))]
+        (is (< lowest-second highest-first)
+            (str row ": the lowest single round of the second author's six "
+                 "runs sits BELOW the highest round the first author "
+                 "published, so the two ensembles are NOT separated round "
+                 "by round — only run mean by run mean"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; THE BALANCED ENSEMBLE'S OBSERVATION TABLE (rf2-6i0i2, the PR #7303 audit)
@@ -886,3 +920,152 @@
           "M2's interval on the MEAN clears parity — barely, and it stays
            a diagnostic row precisely because its individual runs do not:
            three of the ten read below 1.0 outright"))))
+
+;; ---------------------------------------------------------------------------
+;; The flag is global and the arm is not (rf2-2rtt6.21)
+;; ---------------------------------------------------------------------------
+;;
+;; `HICASSO_RATOM=on` is a page-global request; arm presence is decided per
+;; row. With no `HICASSO_ONLY` the driver selects ALL FOUR rows, and `M2`
+;; and `narrow` deliberately carry no `:reagent-ratom` arm — `M2`'s witness
+;; ignores the flag and `bulk-arms` admits the arm only on `:broad`. Until
+;; this section the record still read the FLAG: it divided by a ratio those
+;; rows never produced, formed a ratom floor of nothing, ran the leg verdict
+;; over the result and labelled the row as carrying the arm. The published
+;; runs escaped it only by always pairing the flag with
+;; `HICASSO_ONLY=M1,broad`, so neither CI nor the quality gates ever ran the
+;; natural flagged invocation.
+;;
+;; Three facts, in the order the run establishes them: which arms the row's
+;; PLAN plants, what [[app/ratom-leg]] DECIDES from a round, and what the
+;; RECORD then publishes. Pure arithmetic over constants — no DOM, no clock,
+;; no browser, like everything else in this namespace.
+
+(def ^:private flagged-rows
+  "What `HICASSO_RATOM=on` with no `HICASSO_ONLY` selects: the driver's
+  default row list, all four of them."
+  [:M1 :M2 :broad :narrow])
+
+(def ^:private rows-carrying-the-arm
+  "And the two of those four whose plan admits the arm."
+  #{:M1 :broad})
+
+(deftest the-flagged-default-selection-plants-the-arm-on-two-rows-of-four
+  (testing "with the flag ON, M1 and broad run a FOUR-arm Reagent segment
+           and M2 and narrow run their published three. This is the fact
+           every assertion below rests on, and it is asked of the entry's
+           own plan rather than restated beside it"
+    (doseq [row flagged-rows]
+      (let [ids (set (app/reagent-segment-arm-ids row true))]
+        (is (contains? ids :reagent-subs) (str row " must always run the denominator"))
+        (is (= (contains? rows-carrying-the-arm row)
+               (contains? ids :reagent-ratom))
+            (str row " under HICASSO_RATOM=on")))))
+  (testing "and with the flag OFF no row runs it, which is what keeps an
+           unflagged invocation the instrument the four published rows
+           were measured on"
+    (doseq [row flagged-rows]
+      (is (not (contains? (set (app/reagent-segment-arm-ids row false)) :reagent-ratom))
+          (str row " under HICASSO_RATOM=off")))))
+
+(deftest the-leg-is-formed-only-when-every-round-measured-the-arm
+  (let [round (fn [ratom] {:reagent-subs
+                           {:ratio (cond-> {:reagent-subs 4.0}
+                                     ratom (assoc :reagent-ratom ratom))}})]
+    (testing "six rounds that all measured the arm: the leg is 4.0 / 3.0,
+             once per round"
+      (let [l (app/ratom-leg (mapv round (repeat 6 3.0)))]
+        (is (= 6 (count l)))
+        (is (every? #(close? 1.3333 %) l))))
+    (testing "no round measured it — nil, and NOT a quotient over a
+             denominator that was never taken. This is the M2 and narrow
+             case, and `subs / nil` is `Infinity` in JavaScript rather
+             than an error, so nothing downstream would have complained"
+      (is (nil? (app/ratom-leg (mapv round (repeat 6 nil))))))
+    (testing "a PARTIAL arm is no arm: one round short and the leg is nil,
+             because a figure that quietly changes what it averages over
+             is worse than one that is absent"
+      (is (nil? (app/ratom-leg (mapv round [3.0 3.0 3.0 3.0 3.0 nil])))))
+    (testing "and a zero denominator divides to Infinity, so it is refused
+             at the same door"
+      (is (nil? (app/ratom-leg (mapv round (repeat 6 0.0))))))))
+
+(def ^:private synthetic-ms
+  "One reading vector per arm id, constant, so every ratio the record
+  computes is exact: the floor is 1.0, the denominator arm 4.0, the ratom
+  arm 3.0, and the 2x control 2.0 — which is the control's own
+  prediction, so it passes."
+  {:floor [1.0 1.0 1.0]
+   :reagent-subs [4.0 4.0 4.0]
+   :reagent-ratom [3.0 3.0 3.0]
+   :uix-subs [5.0 5.0 5.0]
+   :ctl-2x [2.0 2.0 2.0]})
+
+(defn- flagged-record
+  "The published record for `row` under `HICASSO_RATOM=on`, over six rounds
+  of that row's ACTUAL flagged arm set. The Reagent segment's arms come
+  from the entry's own plan, so no premise is transcribed here."
+  [row]
+  (let [reagent-arms (select-keys synthetic-ms (app/reagent-segment-arm-ids row true))
+        uix-arms     (select-keys synthetic-ms [:floor :uix-subs :ctl-2x])]
+    (:record (app/row-record
+               {:row row
+                :grade :bar
+                :doc "a contract fixture, not a measurement"
+                :control {:predicted 2.0 :basis "the 2x control reads twice the floor"}
+                :writes-per-sample 1
+                :start :reagent-subs}
+               (vec (repeat 6 {:reagent-subs reagent-arms :uix-subs uix-arms}))))))
+
+(defn- non-finite
+  "Every number anywhere in `x` that is not finite — NaN, Infinity,
+  -Infinity. A record is a tree of maps and vectors, so the whole of it is
+  checked rather than the two or three keys somebody remembered."
+  [x]
+  (let [found (atom [])]
+    (walk/postwalk (fn [v]
+                     (when (and (number? v) (not (js/isFinite v)))
+                       (swap! found conj v))
+                     v)
+                   x)
+    @found))
+
+(deftest the-flagged-default-selection-publishes-a-leg-only-where-the-arm-ran
+  (testing "HICASSO_RATOM=on with the default four rows. M1 and broad
+           publish a leg of 4.0 / 3.0 and say they carry the arm; M2 and
+           narrow publish no leg, no ratom floor, no leg verdict and no
+           comparability note, and say they carry no arm — and no row
+           emits a non-finite number anywhere in its record"
+    (doseq [row flagged-rows]
+      (let [rec (flagged-record row)]
+        (if (contains? rows-carrying-the-arm row)
+          (do (is (true? (:ratom-arm? rec)) (str row))
+              (is (true? (:ratom-arm? (:red-zone rec))) (str row))
+              (is (string? (:comparability (:red-zone rec))) (str row))
+              (is (close? 1.3333 (:mean (:reactive-leg rec))) (str row))
+              (is (= :magnitude (:claim (:reactive-leg rec))) (str row))
+              (is (some? (:ratom-over-floor rec)) (str row))
+              (is (some? (:reactive-leg-segment-order rec)) (str row)))
+          (do (is (false? (:ratom-arm? rec)) (str row))
+              (is (false? (:ratom-arm? (:red-zone rec))) (str row))
+              (is (nil? (:comparability (:red-zone rec))) (str row))
+              (is (nil? (:reactive-leg rec)) (str row))
+              (is (nil? (:ratom-over-floor rec)) (str row))
+              (is (nil? (:reactive-leg-segment-order rec)) (str row))))
+        (is (empty? (non-finite rec))
+            (str row " emitted non-finite numbers: " (pr-str (non-finite rec))))))))
+
+(deftest an-m2-or-narrow-only-flagged-selection-emits-no-leg-and-no-infinity
+  (testing "`HICASSO_RATOM=on HICASSO_ONLY=M2,narrow` — the selection
+           nobody published from, CI never ran and the quality gates never
+           exercised, which is precisely why it was the broken one. Both
+           rows must answer with no leg at all rather than with a division
+           by a denominator they never measured"
+    (doseq [row [:M2 :narrow]]
+      (let [rec (flagged-record row)]
+        (is (nil? (:reactive-leg rec)) (str row " must publish no leg"))
+        (is (false? (:ratom-arm? rec)) (str row " must not claim the arm"))
+        (is (empty? (non-finite rec))
+            (str row " emitted non-finite numbers: " (pr-str (non-finite rec))))
+        (is (some? (:red-zone rec))
+            (str row " still publishes its ordinary red-zone"))))))


### PR DESCRIPTION
Closes rf2-2rtt6.21 (the AUDIT-REOPEN remainder).

The merged-PR audit of #7310 found two implementation gaps under this owner.
Both are repaired here. **No measurement is re-run** — the audit says the
published `M1` / `broad` figures need not be for either repair, and none is
re-derived, moved, or given a wider tolerance.

## 1. The replay pinned a claim that is not true

`the-leg-does-not-reproduce-the-first-authors-magnitude` asserted

```clojure
(is (> (apply min (mapcat :vs (:M1 leg))) 1.24)
    "and the LOWEST single round across all six M1 runs, 1.2500, still sits
     above the first author's re-run maxima of 1.241 and 1.273 …")
```

**1.2500 does not sit above 1.273.** The threshold was `1.24` and the sentence
claimed `1.273`, so a false ROUND-level finding read as pinned by a test that
was only ever pinning the weaker number.

**Option taken: rewrite the assertion to pin RUN-MEAN separation** — the claim
the studio page actually makes, at the level it holds at — *and* pin the
round-level reading FALSE rather than merely deleting it.

- Both authors' published figures are now carried as data (`first-author`: the
  run mean and per-round range of each of rf2-2rtt6.2's / rf2-2rtt6.17's three
  runs), so the comparison is two published sets against each other rather than
  a constant typed into a threshold.
- `the-leg-does-not-reproduce-the-first-authors-magnitude` now asserts, per
  row, that the **lowest** of the second author's six run means clears the
  **highest** of the first author's three — which is exactly *every
  second-author run mean exceeds every first-author run mean*.
- `the-round-ranges-overlap-so-the-separation-is-not-a-round-level-claim`
  asserts the complement: the lowest single round the second author measured
  sits **below** the highest round the first author published, on both rows.
  That is what the studio page has always said — *overlap at the edges,
  1.1667 – 1.3175 against 1.2500 – 1.4822, while the run means are disjoint* —
  so a later hand that reinstates the round-level claim reds a test.

The two pre-existing run-mean assertions are untouched and no tolerance is
widened. One further assertion is retracted: `(< 1.218 (apply min …rounds))`
compared a first-author *mean* against second-author *rounds*, the same
category confusion in the other direction.

**The studio page needed no change.** It reports the round-level overlap
correctly; the page was right and the test message was wrong.

## 2. Leg presence was decided by a global flag, per-row

`?ratom=on` / `HICASSO_RATOM=on` is a **page-global** request; arm presence is
**row-specific**. The `M2` witness ignores the flag outright and `bulk-arms`
admits the arm only on `:broad` — but `row-record` still read the FLAG to
divide by `[:reagent-subs :ratio :reagent-ratom]`, form the ratom floor, run
the leg verdict and label the row as carrying the arm.

On `M2` and `narrow` that ratio does not exist, and `subs / nil` is `Infinity`
in JavaScript rather than an error. The natural flagged invocation —
`HICASSO_RATOM=on` with no `HICASSO_ONLY`, which selects all four rows — would
therefore have published this:

```
:order-balanced-mean ##Inf
"the reactive leg's rounds partitioned by which segment ran FIRST … Reagent-first
 Infinityx [Infinity–Infinity] over 3 rounds; UIx-first Infinityx
 [Infinity–Infinity] over 3 rounds. The strata OVERLAP, so the magnitude
 survives the partition and the row may publish one."
```

That is a verbatim capture from red proof **D** below, which restores the
pre-repair arithmetic. The published runs escaped it only by always pairing the
flag with `HICASSO_ONLY=M1,broad`; neither CI nor the quality gates ever ran
the default flagged invocation.

**Option taken: decide leg presence from the actual row/slice.** A new
`ratom-leg` answers the per-round `reagent-subs ÷ reagent-ratom` quotient when
every round carries a finite, positive ratom ratio, and `nil` otherwise.
`row-record` derives `:ratom-arm?` (on the record and on the red-zone), the
comparability note, `:ratom-over-floor`, `:reactive-leg` and the leg verdict
from that one answer, and **no longer takes the flag at all** — nor does
`publish!`. A partial arm is treated as no arm: a leg that quietly changes what
it averages over is worse than one that is absent. The boot console line now
names the arms the row's own plan plants instead of asserting the arm is there.

Rejected: refusing flagged selections containing `M2` / `narrow`. That would
make the audit's *natural flagged default* an error rather than a correct run,
and it leaves the flag as a second authority over a fact the measurement
already carries.

## The contract test the flagged default never had

Three deftests in `p0_converge_order_cljs_test` — pure arithmetic over
constants, no DOM, no clock, no browser, like the rest of that namespace:

- **the plan** — `the-flagged-default-selection-plants-the-arm-on-two-rows-of-four`.
  With the flag ON, `M1` and `broad` run a four-arm Reagent segment while `M2`
  and `narrow` run their published three; with it OFF no row runs it. Asked of
  the entry's own plan through the new `reagent-segment-arm-ids`, so the
  premise is derived rather than transcribed.
- **the decision** — `the-leg-is-formed-only-when-every-round-measured-the-arm`.
  `ratom-leg` forms a leg when six rounds carry the arm; `nil` for none, `nil`
  for a partial arm, `nil` for a zero denominator.
- **the record** — `the-flagged-default-selection-publishes-a-leg-only-where-the-arm-ran`
  builds each of the four default rows' record from that row's *actual* arm
  set: `M1` and `broad` publish a leg of `4.0/3.0`, claim `:magnitude` and
  carry the ratom floor, the leg verdict and the comparability note; `M2` and
  `narrow` publish none of it and say `:ratom-arm? false`. A `postwalk` of the
  **whole** record finds no non-finite number in any of the four.
  `an-m2-or-narrow-only-flagged-selection-emits-no-leg-and-no-infinity` asserts
  the `HICASSO_ONLY=M2,narrow` selection by name.

`ratom-leg`, `row-record` and `reagent-segment-arm-ids` become public for the
reason `segment-order-verdict` already was: a rule whose only evidence is the
run it shipped with has not been tested.

## Quality gates

Every run foreground to completion, logged to the worktree, exit code echoed —
nothing piped through `tail` or `grep`. clj-kondo is the **CI-pinned
v2026.04.15** binary from `.github/workflows/lint.yml`, invoked with CI's exact
`--lint` surface (an older local binary emits spurious errors).

| gate | command | exit |
|---|---|---|
| cljs suite | `cd implementation && npm run test:cljs` | **0** — 12,062 tests, 60,469 assertions, 0 failures, 0 errors |
| clj-kondo | `clj-kondo --parallel --fail-level error --lint implementation --lint examples --lint testbeds --lint tools/…` | **0** — **errors: 0**, warnings 4526 (unchanged), and **no finding in either changed file** |

`mkdocs build --strict` not run: no file under `docs/` is touched.

### Red proofs — every changed assertion watched failing

Each condition planted, the **full** suite run, the exit code echoed, then
reverted with `git status` clean. All four re-run after the rebase onto
`origin/main`, which carried rf2-6i0i2's observation table into the same file.

| # | condition planted | suite exit | what went red |
|---|---|---|---|
| **A** | a first-author run mean raised to `1.400`, above the second author's lowest | **1** | 1 failure — `the-leg-does-not-reproduce-the-first-authors-magnitude` |
| **B** | the first author's round maxima lowered below every second-author round (i.e. the ensembles *are* separated round by round) | **1** | 2 failures — `the-round-ranges-overlap-so-the-separation-is-not-a-round-level-claim`, both rows |
| **C** | `bulk-arms` plants the ratom arm on `:narrow` as well as `:broad` | **1** | 9 failures — the plan test, the record test, the M2/narrow-only test |
| **D** | `ratom-leg`'s finiteness guard removed — **the pre-repair defect restored** | **1** | 23 failures across the decision test, the record test and the M2/narrow-only test, with `##Inf` printed in the actual-value output (quoted above). The 8 further failures in that run are the `test-quiet` meta-tests, which assert the suite is green and therefore red whenever it is not |

Reverted after each; the suite is green again at **exit 0**, 12,062 tests,
0 failures, 0 errors.
