### PR TITLE
hicasso: Wave-1 Arm 2 — PATCH own renderer (rf2-2rtt6.10)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/collector_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/collector_dom_cljs_test.cljs
@@ -94,23 +94,35 @@
                 "and nothing is left reading the key the body stopped reading")))))))
 
 (deftest a-read-inside-a-loop-is-legal-and-indexed
-  (if-not (browser?)
-    (is true off-browser)
-    (let [v (rt/view ::loop-view
-                     (fn [_]
-                       [:ul.loop
-                        (for [id (rt/sub [:dogfood/visible-ids])]
-                          [:li {:key id} (:title (rt/sub [:dogfood/todo id]))])]))]
-      (with-mounted [v {}]
-        (fn [c]
-          (is (= 5 (.-length (.querySelectorAll c "li"))))
-          (is (= (into #{[:dogfood/visible-ids]} (map (fn [i] [:dogfood/todo i])) (range 5))
-                 (edges-of-only-boundary))
-              "one edge per iteration, collected as the loop ran")
-          (testing "a shorter list drops the edges the loop stopped visiting"
-            (rt/dispatch! [:dogfood/remove 4])
-            (is (= (into #{[:dogfood/visible-ids]} (map (fn [i] [:dogfood/todo i])) (range 4))
-                   (edges-of-only-boundary)))))))))
+  (testing "the regression this file was written for: hiccup is LAZY, so a
+           `for`'s reads happen when the differ walks the children, not when
+           the body returns. A collector closed at the body's return records
+           the list query and loses every row query — and the arm then
+           silently stops re-running on a row write. See
+           `runtime/with-collected-reads`."
+    (if-not (browser?)
+      (is true off-browser)
+      (let [v (rt/view ::loop-view
+                       (fn [_]
+                         [:ul.loop
+                          (for [id (rt/sub [:dogfood/visible-ids])]
+                            [:li {:key id} (:title (rt/sub [:dogfood/todo id]))])]))]
+        (with-mounted [v {}]
+          (fn [c]
+            (is (= 5 (.-length (.querySelectorAll c "li"))))
+            (is (= (into #{[:dogfood/visible-ids]} (map (fn [i] [:dogfood/todo i])) (range 5))
+                   (edges-of-only-boundary))
+                "one edge per iteration, collected as the loop ran")
+            (testing "a shorter list drops the edges the loop stopped visiting"
+              (rt/dispatch! [:dogfood/remove 4])
+              (is (= (into #{[:dogfood/visible-ids]} (map (fn [i] [:dogfood/todo i])) (range 4))
+                     (edges-of-only-boundary))))
+            (testing "and a write to a row the LOOP read re-runs the boundary —
+                     the behaviour the lost edges would have broken"
+              (rt/dispatch! [:dogfood/edit-draft 2 "renamed"])
+              (rt/dispatch! [:dogfood/commit 2])
+              (is (= "renamed" (.-textContent (.item (.querySelectorAll c "li") 2)))
+                  "the row's title followed a write nothing else pointed at"))))))))
 
 (deftest a-read-inside-an-inlined-helper-is-legal-and-indexed
   (testing "the helper is an ordinary function with no runtime privileges —

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/collector_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/collector_dom_cljs_test.cljs
@@ -1,0 +1,223 @@
+(ns re-frame.bench.hicasso.arm2.collector-dom-cljs-test
+  "SURFACE B UNDER A COMMIT-TIME RE-RUN MODEL (rf2-2rtt6.10).
+
+  Operator ruling, 2026-07-31: only the **ambient collector** surface
+  clears the ergonomics bar — `sub` as an ordinary function call, legal
+  in a conditional, in a loop, and inside an inlined helper, with the
+  runtime diffing the edge set after the body returns. Grouped `use-subs`
+  is out.
+
+  Arm 2 re-runs dirty boundaries *inside the commit* rather than through
+  React, so the surface has to be shown working under that model
+  specifically. This file shows it, one shape at a time, and then shows
+  the two things the ruling did **not** waive:
+
+  - **the conditional read is an edge-set diff, not a ledger** — a body
+    that stops reading a key drops exactly that edge and nothing else,
+    and a body that starts reading one adds exactly that edge;
+  - **no candidate ledger exists to kill** — the whole post-body
+    reconciliation is two set differences, and the index's own state is
+    the only place a read is recorded.
+
+  ## Why this is easier here than under React, stated as a test
+
+  [[a-body-run-is-never-abandoned]] is the assertion that carries the
+  tournament finding: in this arm a body runs because the commit ran it,
+  and the patch lands in the same synchronous extent. There is no
+  scheduler that can discard the run, so there is no window in which a
+  read is a *candidate* rather than a fact. The front half still carries
+  the abandoned-render guard — it is written for the arm that needs it —
+  and this arm exercises it only from the teardown direction."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.bench.hicasso.arm2.runtime :as rt]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.front.sub-index :as idx]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private off-browser "no DOM on this runtime — the collector is exercised through a mounted body")
+
+(defn- browser? []
+  (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
+
+(defn- container! []
+  (let [c (js/document.createElement "div")]
+    (.appendChild js/document.body c)
+    c))
+
+(def ^:private frame-id ::collector)
+
+(defn- with-mounted
+  "Seed a dogfood frame, mount `element`, run `f` with the container."
+  [element f]
+  (rt/reset-runtime!)
+  (dogfood/make-frame! frame-id 5)
+  (let [c (container!)
+        teardown (rt/mount-root! {:container c :frame frame-id :element element})]
+    (try (f c) (finally (teardown) (.remove c) (rt/reset-runtime!)))))
+
+(defn- edges-of-only-boundary
+  "The one mounted boundary's edge set."
+  []
+  (let [snap (idx/snapshot)]
+    (first (vals (:b->subs snap)))))
+
+;; ---------------------------------------------------------------------------
+;; The three shapes the surface exists for
+;; ---------------------------------------------------------------------------
+
+(deftest a-read-inside-a-conditional-is-legal-and-indexed
+  (if-not (browser?)
+    (is true off-browser)
+    (let [v (rt/view ::cond-view
+                     (fn [_]
+                       (let [f (rt/sub [:dogfood/filter])]
+                         [:div.cond
+                          (when (= :done f)
+                            [:span.extra (str (rt/sub [:dogfood/remaining]))])])))]
+      (with-mounted [v {}]
+        (fn [c]
+          (testing "the branch is not taken, so its read never happened"
+            (is (= #{[:dogfood/filter]} (edges-of-only-boundary)))
+            (is (nil? (.querySelector c "span.extra"))))
+          (testing "taking the branch adds exactly that edge"
+            (rt/dispatch! [:dogfood/set-filter :done])
+            (is (= #{[:dogfood/filter] [:dogfood/remaining]} (edges-of-only-boundary)))
+            (is (some? (.querySelector c "span.extra"))))
+          (testing "leaving it drops exactly that edge — law 4, through a real re-run"
+            (rt/dispatch! [:dogfood/set-filter :all])
+            (is (= #{[:dogfood/filter]} (edges-of-only-boundary)))
+            (is (empty? (idx/readers-of (idx/snapshot) [:dogfood/remaining]))
+                "and nothing is left reading the key the body stopped reading")))))))
+
+(deftest a-read-inside-a-loop-is-legal-and-indexed
+  (if-not (browser?)
+    (is true off-browser)
+    (let [v (rt/view ::loop-view
+                     (fn [_]
+                       [:ul.loop
+                        (for [id (rt/sub [:dogfood/visible-ids])]
+                          [:li {:key id} (:title (rt/sub [:dogfood/todo id]))])]))]
+      (with-mounted [v {}]
+        (fn [c]
+          (is (= 5 (.-length (.querySelectorAll c "li"))))
+          (is (= (into #{[:dogfood/visible-ids]} (map (fn [i] [:dogfood/todo i])) (range 5))
+                 (edges-of-only-boundary))
+              "one edge per iteration, collected as the loop ran")
+          (testing "a shorter list drops the edges the loop stopped visiting"
+            (rt/dispatch! [:dogfood/remove 4])
+            (is (= (into #{[:dogfood/visible-ids]} (map (fn [i] [:dogfood/todo i])) (range 4))
+                   (edges-of-only-boundary)))))))))
+
+(deftest a-read-inside-an-inlined-helper-is-legal-and-indexed
+  (testing "the helper is an ordinary function with no runtime privileges —
+           it is not a hook, not a boundary, and takes no context"
+    (if-not (browser?)
+      (is true off-browser)
+      (let [title-of (fn [id] (:title (rt/sub [:dogfood/todo id])))
+            v (rt/view ::helper-view
+                       (fn [_] [:div.helper (title-of 2) (title-of 3)]))]
+        (with-mounted [v {}]
+          (fn [c]
+            (is (= "todo 2todo 3" (.-textContent (.querySelector c "div.helper"))))
+            (is (= #{[:dogfood/todo 2] [:dogfood/todo 3]} (edges-of-only-boundary))
+                "both helper reads reached the index")))))))
+
+;; ---------------------------------------------------------------------------
+;; What the ruling did not waive
+;; ---------------------------------------------------------------------------
+
+(deftest the-reconciliation-is-two-set-differences-and-nothing-else
+  (testing "HD-002(b): the allowed edge-diff operation, not the forbidden ledger"
+    (if-not (browser?)
+      (is true off-browser)
+      (let [!reads (atom [[:dogfood/filter]])
+            v (rt/view ::switching
+                       (fn [_] [:div.sw (str (mapv rt/sub @!reads))]))]
+        (with-mounted [v {}]
+          (fn [_c]
+            (is (= #{[:dogfood/filter]} (edges-of-only-boundary)))
+            ;; Swap the read set wholesale and force a re-run.
+            (reset! !reads [[:dogfood/remaining] [:dogfood/visible-ids]])
+            (rt/dispatch! [:dogfood/set-filter :done])
+            (is (= #{[:dogfood/remaining] [:dogfood/visible-ids]} (edges-of-only-boundary))
+                "the new set replaced the old one in one diff")
+            (is (empty? (idx/readers-of (idx/snapshot) [:dogfood/filter]))
+                "the dropped key has no reader left — no residue, no ledger entry")))))))
+
+(deftest a-body-run-is-never-abandoned
+  (testing "the tournament finding: there is no window in which a read is a
+           CANDIDATE rather than a fact, because the commit runs the body and
+           patches the DOM in one synchronous extent"
+    (if-not (browser?)
+      (is true off-browser)
+      (let [runs   (atom 0)
+            v      (rt/view ::counting
+                            (fn [_]
+                              (swap! runs inc)
+                              [:div.count (str (rt/sub [:dogfood/remaining]))]))]
+        (with-mounted [v {}]
+          (fn [c]
+            (is (= 1 @runs) "one run at mount")
+            (is (= "5" (.-textContent (.querySelector c "div.count")))
+                "and the DOM already carries its result")
+            (rt/dispatch! [:dogfood/toggle 0])
+            (is (= 2 @runs) "one run per commit that dirties it — never a discarded extra")
+            (is (= "4" (.-textContent (.querySelector c "div.count")))
+                "and the patch landed in the same extent as the run")))))))
+
+(deftest a-read-for-an-unmounted-boundary-records-nothing
+  (testing "the one direction from which this arm can reach the front half's
+           abandoned-render guard: teardown"
+    (if-not (browser?)
+      (is true off-browser)
+      (let [v (rt/view ::doomed (fn [_] [:div.doomed (str (rt/sub [:dogfood/remaining]))]))]
+        (rt/reset-runtime!)
+        (dogfood/make-frame! frame-id 5)
+        (let [c        (container!)
+              teardown (rt/mount-root! {:container c :frame frame-id :element [v {}]})
+              id       (first (keys (:b->subs (idx/snapshot))))]
+          (teardown)
+          (idx/record-reads! id #{[:dogfood/remaining]})
+          (is (empty? (idx/readers-of (idx/snapshot) [:dogfood/remaining]))
+              "a read arriving after unmount is ignored, so unmount is final")
+          (.remove c)
+          (rt/reset-runtime!))))))
+
+;; ---------------------------------------------------------------------------
+;; The surface, at a glance
+;; ---------------------------------------------------------------------------
+
+(deftest the-surface-needs-no-declaration-before-the-body
+  (testing "there is no query collection to hand over, no hook to keep in a
+           fixed position, and no rule about where a read may appear"
+    (if-not (browser?)
+      (is true off-browser)
+      (let [v (rt/view ::free
+                       (fn [{:keys [n]}]
+                         [:div.free
+                          (when (pos? n) [:i (str (rt/sub [:dogfood/remaining]))])
+                          (for [id (range n)]
+                            [:b {:key id} (:title (rt/sub [:dogfood/todo id]))])
+                          [:em (name (rt/sub [:dogfood/filter]))]]))]
+        (with-mounted [v {:n 3}]
+          (fn [c]
+            (is (= 3 (.-length (.querySelectorAll c "b"))))
+            (is (= "all" (.-textContent (.querySelector c "em"))))
+            (is (= 5 (count (edges-of-only-boundary)))
+                "five reads from three syntactic positions, all indexed")))))))
+
+(deftest reading-through-the-frame-and-reading-through-the-collector-agree
+  (if-not (browser?)
+    (is true off-browser)
+    (let [v (rt/view ::agree (fn [_] [:div.agree (str (rt/sub [:dogfood/remaining]))]))]
+      (with-mounted [v {}]
+        (fn [c]
+          (rt/dispatch! [:dogfood/toggle 2])
+          (is (= (str (count (remove (fn [i] (get-in (rf/app-db-value frame-id) [:todos i :done?]))
+                                     (:order (rf/app-db-value frame-id)))))
+                 (.-textContent (.querySelector c "div.agree")))
+              "the collector's value is the frame's value, not a stale copy"))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/controlled.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/controlled.cljs
@@ -1,0 +1,256 @@
+(ns re-frame.bench.hicasso.arm2.controlled
+  "THE CONTROLLED-RESTORE OBLIGATION — Arm 2's hard gate (rf2-2rtt6.10).
+
+  architecture.md states it without hedging: *off React's discrete-event
+  path there is no free end-of-event value restore; the renderer must
+  converge controlled `value`/`checked` against the live node after every
+  controlled dispatch, caret preserved, composition fenced. Any PATCH
+  spike that cannot demonstrate the controlled-restore on the 100-cell
+  grid witness has failed regardless of its clock numbers.*
+
+  This namespace is that obligation, discharged. It is small on purpose —
+  the obligation is not large, it is *load-bearing*, and the reason arms
+  fail it is that the four rules below interact.
+
+  ## What React actually does, and what therefore has to be replaced
+
+  React's controlled input is not a diffing trick. At the end of a
+  **discrete** event React re-asserts the value it last rendered onto the
+  DOM node, whether or not its own render produced a change. That is what
+  makes `onChange` able to *reject* a keystroke: the browser has already
+  put the character in the field, the model refuses it, React's restore
+  puts the field back. A renderer that only writes what changed has no
+  such moment, and its rejected keystroke stays on screen — the field and
+  the model disagree, permanently, and every later edit compounds it.
+
+  Arm 2 has no React on this path, so it owns the moment. It is
+  [[converge-focused!]], run by the runtime at the end of every commit.
+
+  ## The four rules
+
+  1. **Write only on disagreement.** `(set! (.-value node) v)` is not a
+     no-op when `v` is what is already there: per HTML, setting `value`
+     moves the text entry cursor to the end. Every write is guarded by an
+     inequality, which is what makes an *unchanged* model free.
+
+  2. **Preserve the caret from the END of the string.** When a write is
+     genuinely needed — normalisation, rejection, an async correction —
+     the caret is restored at the same distance from the end, not the
+     same absolute offset. Distance-from-end is the measure that survives
+     the cases that actually happen: uppercasing (unchanged), digit
+     grouping `1234 → 1,234` (caret stays after the same digit), and
+     rejection (the refused character disappears and the caret lands
+     where it was before it). Absolute offset gets grouping wrong every
+     time.
+
+  3. **Fence composition.** Between `compositionstart` and
+     `compositionend` the field belongs to the IME, and writing `value`
+     destroys the in-flight composition — on some IMEs it commits
+     garbage, on others it cancels silently. So convergence is suppressed
+     while composing and **replayed at `compositionend`**, which is the
+     part that is easy to leave out and impossible to notice on a Latin
+     keyboard. The front half's key-map gate already refuses to
+     *dispatch* mid-composition (`isComposing` / keyCode 229); this is
+     the other half — refusing to *write*.
+
+  4. **Restore selections, not just carets.** A range selection has two
+     ends; both are restored from the end of the string, so a converge
+     that fires while text is selected does not collapse the selection.
+
+  ## Where the model value lives
+
+  On the node, as one own property (`__hicassoValue` / `__hicassoChecked`),
+  written whenever the renderer sets a controlled prop. The convergence
+  needs the model value at a moment when no hiccup is in hand — the
+  commit has finished patching, and the only node that can disagree is
+  the focused one. Reaching back into the boundary tree for it would mean
+  retaining a map from node to hiccup; one expando per controlled node is
+  smaller and cannot go stale, because it is written by the same code
+  path that writes the DOM.
+
+  Resets are **by explicit caller revision, never value equality**
+  (HD-019, keeping the predecessor's ruled reset law). Nothing here
+  clears a field because a value looked empty."
+  (:require [clojure.string :as str]))
+
+(def ^:private value-key    "__hicassoValue")
+(def ^:private checked-key  "__hicassoChecked")
+(def ^:private composing-key "__hicassoComposing")
+(def ^:private fenced-key   "__hicassoFenced")
+
+;; ---------------------------------------------------------------------------
+;; Composition fencing
+;; ---------------------------------------------------------------------------
+
+(defn composing?
+  "Is this node inside an IME composition the renderer must not disturb?"
+  [node]
+  (true? (unchecked-get node composing-key)))
+
+(declare converge!)
+
+(defn- fence!
+  "Install the composition listeners once per controlled node. The
+  `compositionend` handler replays the convergence that was suppressed
+  while the IME held the field."
+  [node]
+  (when-not (true? (unchecked-get node fenced-key))
+    (unchecked-set node fenced-key true)
+    (.addEventListener node "compositionstart" (fn [_] (unchecked-set node composing-key true)))
+    (.addEventListener node "compositionend"
+                       (fn [_]
+                         (unchecked-set node composing-key false)
+                         (converge! node)))
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; Caret arithmetic
+;; ---------------------------------------------------------------------------
+
+(defn- caret-capable?
+  "Does this element expose a text entry cursor? `selectionStart` throws
+  on `number`, `email`, `color` and friends in several browsers, so the
+  question is asked by reading it defensively rather than by keeping a
+  roster of input types."
+  [node]
+  (try (some? (.-selectionStart node)) (catch :default _ false)))
+
+(defn- focused? [node]
+  (and (some? js/document) (identical? node (.-activeElement js/document))))
+
+(defn- restore-caret!
+  "Put the caret (or the selection) back at the same distance from the
+  end of the string it held before the write."
+  [node start-from-end end-from-end]
+  (let [n (.-length (.-value node))
+        s (max 0 (- n start-from-end))
+        e (max 0 (- n end-from-end))]
+    (try (.setSelectionRange node (min s e) (max s e))
+         (catch :default _ nil))
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; The writes
+;; ---------------------------------------------------------------------------
+
+(defn write-value!
+  "Set a controlled `value`, obeying all four rules. Called by the
+  emitter for every `:value` prop — mount and patch alike — so there is
+  exactly one code path that ever writes a controlled value."
+  [node v]
+  (let [v (if (nil? v) "" (str v))]
+    (unchecked-set node value-key v)
+    (fence! node)
+    (when-not (composing? node)
+      (let [live (.-value node)]
+        (when-not (= live v)
+          (if (and (focused? node) (caret-capable? node))
+            (let [len (.-length live)
+                  s   (- len (or (.-selectionStart node) len))
+                  e   (- len (or (.-selectionEnd node) len))]
+              (set! (.-value node) v)
+              (restore-caret! node s e))
+            (set! (.-value node) v))))))
+  nil)
+
+(defn write-checked!
+  "Set a controlled `checked`. No caret, but the same
+  write-only-on-disagreement rule: assigning `checked` fires no event but
+  does reset an `indeterminate` flag, so an unconditional write is not
+  free."
+  [node v]
+  (let [b (boolean v)]
+    (unchecked-set node checked-key b)
+    (when-not (= (.-checked node) b) (set! (.-checked node) b)))
+  nil)
+
+(defn controlled?
+  "Has the renderer ever written a controlled prop to this node?"
+  [node]
+  (or (some? (unchecked-get node value-key))
+      (some? (unchecked-get node checked-key))))
+
+;; ---------------------------------------------------------------------------
+;; The end-of-event restore
+;; ---------------------------------------------------------------------------
+
+(defn converge!
+  "Re-assert the model value on one node. This is the moment React
+  supplies for free and Arm 2 has to name: after the commit, the field
+  must read what the model says, whatever the browser put there."
+  [node]
+  (when (and (some? node) (not (composing? node)))
+    (when-some [v (unchecked-get node value-key)]
+      (let [live (.-value node)]
+        (when-not (= live v)
+          (if (and (focused? node) (caret-capable? node))
+            (let [len (.-length live)
+                  s   (- len (or (.-selectionStart node) len))
+                  e   (- len (or (.-selectionEnd node) len))]
+              (set! (.-value node) v)
+              (restore-caret! node s e))
+            (set! (.-value node) v)))))
+    (when-some [c (unchecked-get node checked-key)]
+      (when-not (= (.-checked node) c) (set! (.-checked node) c))))
+  nil)
+
+(defn converge-focused!
+  "The end-of-commit restore. **Only the focused element can disagree**
+  with the model: every other controlled node was last written by the
+  renderer and nothing but user input moves a field. So the whole
+  obligation costs one `document.activeElement` read and — on the one
+  node that can have diverged — one comparison.
+
+  That is the cost claim the 100-cell grid witness exists to check: a
+  keystroke in cell 7 converges cell 7, and does not walk the other 99."
+  []
+  (when (some? js/document)
+    (let [node (.-activeElement js/document)]
+      (when (and (some? node) (controlled? node)) (converge! node))))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Observation — for the witnesses
+;; ---------------------------------------------------------------------------
+
+(defn model-value
+  "The value the renderer last told this node to hold."
+  [node]
+  (unchecked-get node value-key))
+
+(defn agreement
+  "`{:model … :live … :agree? …}` for one node — the witness's readable
+  form of \"the field and the model agree\"."
+  [node]
+  (let [m (unchecked-get node value-key)
+        l (.-value node)]
+    {:model m :live l :agree? (= m l)}))
+
+(defn disagreements
+  "Every controlled descendant of `root` whose live value differs from
+  its model value. The grid witness asserts this is empty after every
+  keystroke; a non-empty result names the cells."
+  [root]
+  (let [out (volatile! [])]
+    (letfn [(walk [n]
+              (when (and (identical? 1 (.-nodeType n)) (controlled? n))
+                (let [a (agreement n)]
+                  (when-not (:agree? a) (vswap! out conj (assoc a :id (.getAttribute n "id"))))))
+              (loop [c (.-firstChild n)]
+                (when c (walk c) (recur (.-nextSibling c)))))]
+      (walk root))
+    @out))
+
+(defn caret
+  "`[start end]` for a caret-capable node, or nil."
+  [node]
+  (when (caret-capable? node)
+    [(.-selectionStart node) (.-selectionEnd node)]))
+
+(defn describe
+  "One-line readable state of a controlled node, for failure output."
+  [node]
+  (str/join " " [(str "value=" (pr-str (.-value node)))
+                 (str "model=" (pr-str (unchecked-get node value-key)))
+                 (str "caret=" (pr-str (caret node)))
+                 (str "composing=" (composing? node))]))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/controlled_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/controlled_dom_cljs_test.cljs
@@ -1,0 +1,342 @@
+(ns re-frame.bench.hicasso.arm2.controlled-dom-cljs-test
+  "THE HARD GATE — the controlled-restore obligation on the 100-cell grid
+  (rf2-2rtt6.10; witness `:controlled/grid-100`).
+
+  architecture.md: *any PATCH spike that cannot demonstrate the
+  controlled-restore on the 100-cell grid witness has failed regardless
+  of its clock numbers.* This file is that demonstration, and it is
+  written to be readable as evidence rather than as coverage: one
+  `deftest` per named assertion in the witness set, each asserting the
+  DOM the user would see and the caret they would find.
+
+  ## The typing simulation is the browser's own order
+
+  [[type-into!]] mutates the field **first** and fires `input`
+  **second**, because that is what a browser does and it is the whole
+  difficulty: by the time any handler runs, the character is already on
+  screen. An arm that only writes what its model changed has, at that
+  moment, nothing to write — which is why `:unchanged-model-rejection`
+  is the assertion that decides this gate.
+
+  ## Same turn means same turn
+
+  Every assertion below runs on the line after `dispatchEvent` returns.
+  There is no `act()`, no `flushSync`, no microtask yield and no
+  animation frame anywhere in this file. If the arm's door were not
+  synchronous, every one of these tests would fail on its first
+  assertion rather than flake.
+
+  Runtime: these are DOM claims, so the file carries the
+  `-dom-cljs-test` suffix and `:browser-test` runs it for real; under
+  `:node-test` each test degrades to a stated skip, which is the posture
+  the other `*-dom` suites keep."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.bench.hicasso.arm2.controlled :as controlled]
+            [re-frame.bench.hicasso.arm2.grid-witness :as grid]
+            [re-frame.bench.hicasso.arm2.runtime :as rt]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private off-browser
+  "no DOM on this runtime — the claim is a caret in a real text field,
+  and :browser-test is where it is asked")
+
+(defn- browser? []
+  (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
+
+;; ---------------------------------------------------------------------------
+;; The page
+;; ---------------------------------------------------------------------------
+
+(defn- container! []
+  (let [c (js/document.createElement "div")]
+    (.appendChild js/document.body c)
+    c))
+
+(defn- with-grid
+  "Mount the 100-cell grid, run `f` with `[container teardown]`, and tear
+  it down whatever happens."
+  [f]
+  (rt/reset-runtime!)
+  (let [c (container!)
+        teardown (grid/mount! c)]
+    (try (f c)
+         (finally (teardown) (.remove c) (rt/reset-runtime!)))))
+
+(defn- type-into!
+  "Type `text` at the caret, the way a browser does it: the field changes
+  first, the `input` event fires second."
+  [node text]
+  (let [start (.-selectionStart node)
+        end   (.-selectionEnd node)
+        v     (.-value node)]
+    (set! (.-value node) (str (subs v 0 start) text (subs v end)))
+    (let [caret (+ start (count text))]
+      (.setSelectionRange node caret caret))
+    (.dispatchEvent node (js/Event. "input" #js {:bubbles true}))
+    nil))
+
+(defn- set-model!
+  "Put a value in the model out of band — the setup door, and also the
+  `:async-normalisation` door."
+  [i v]
+  (rt/dispatch! [:grid/set i v]))
+
+(defn- compose! [node kind]
+  (.dispatchEvent node (js/Event. kind #js {:bubbles true})))
+
+;; ---------------------------------------------------------------------------
+;; :same-turn-echo
+;; ---------------------------------------------------------------------------
+
+(deftest the-field-and-the-model-agree-before-the-event-returns
+  (testing "a keystroke reaches app-db and comes back to the DOM inside the
+           discrete event — no act, no flushSync, no yield"
+    (if-not (browser?)
+      (is true off-browser)
+      (with-grid
+        (fn [c]
+          (let [n (grid/cell-input c 7)]
+            (.focus n)
+            (type-into! n "hello")
+            (is (= "hello" (grid/model-value 7)) "the model took the keystroke")
+            (is (= "hello" (.-value n)) "and the field shows it, on the next line")
+            (is (= [] (controlled/disagreements c))
+                "no cell in the grid disagrees with its model")))))))
+
+(deftest the-echo-is-one-body-run-not-one-hundred
+  (testing "the per-keystroke budget: a keystroke in cell 7 re-runs cell 7"
+    (if-not (browser?)
+      (is true off-browser)
+      (with-grid
+        (fn [c]
+          (let [n (grid/cell-input c 7)]
+            (.focus n)
+            (rt/reset-stats!)
+            (type-into! n "x")
+            (is (= 1 (:body-runs @rt/stats))
+                (str "one boundary body ran, not " grid/cells))
+            (is (= 1 (:dirty-boundaries @rt/stats))
+                "and the index named exactly one dirty boundary")))))))
+
+;; ---------------------------------------------------------------------------
+;; :mid-string-caret
+;; ---------------------------------------------------------------------------
+
+(deftest editing-mid-string-leaves-the-caret-where-the-typing-put-it
+  (if-not (browser?)
+    (is true off-browser)
+    (with-grid
+      (fn [c]
+        (let [n (grid/cell-input c 7)]
+          (set-model! 7 "abcd")
+          (.focus n)
+          (.setSelectionRange n 2 2)
+          (type-into! n "X")
+          (is (= "abXcd" (grid/model-value 7)))
+          (is (= "abXcd" (.-value n)))
+          (is (= [3 3] (controlled/caret n))
+              "the caret did not jump to the end — the model agreed, so nothing was written"))))))
+
+;; ---------------------------------------------------------------------------
+;; :unchanged-model-rejection — the assertion that decides the gate
+;; ---------------------------------------------------------------------------
+
+(deftest a-refused-keystroke-disappears-from-the-field
+  (testing "cell 11 takes digits only. The browser has already shown the
+           letter; the model does not move; NOTHING re-renders — and the
+           field must still come back to the model"
+    (if-not (browser?)
+      (is true off-browser)
+      (with-grid
+        (fn [c]
+          (let [n (grid/cell-input c 11)]
+            (set-model! 11 "12")
+            (.focus n)
+            (.setSelectionRange n 2 2)
+            (rt/reset-stats!)
+            (type-into! n "a")
+            (is (= "12" (grid/model-value 11)) "the model refused the letter")
+            (is (= "12" (.-value n))
+                "and the renderer took it off the screen — this is the obligation")
+            (is (= [2 2] (controlled/caret n))
+                "the caret sits where it was before the refused character")
+            (is (zero? (:dirty-boundaries @rt/stats))
+                "and the restore happened with NO boundary re-run at all — a
+                 renderer that only writes what changed would have written nothing")))))))
+
+(deftest a-refusal-mid-string-does-not-drag-the-caret-to-the-end
+  (if-not (browser?)
+    (is true off-browser)
+    (with-grid
+      (fn [c]
+        (let [n (grid/cell-input c 11)]
+          (set-model! 11 "12345")
+          (.focus n)
+          (.setSelectionRange n 2 2)
+          (type-into! n "z")
+          (is (= "12345" (.-value n)))
+          (is (= [2 2] (controlled/caret n))))))))
+
+;; ---------------------------------------------------------------------------
+;; Normalisation — the length-preserving and length-changing cases
+;; ---------------------------------------------------------------------------
+
+(deftest an-uppercasing-model-keeps-the-caret-mid-string
+  (if-not (browser?)
+    (is true off-browser)
+    (with-grid
+      (fn [c]
+        (let [n (grid/cell-input c 13)]
+          (set-model! 13 "ABCD")
+          (.focus n)
+          (.setSelectionRange n 2 2)
+          (type-into! n "x")
+          (is (= "ABXCD" (grid/model-value 13)) "the model normalised the case")
+          (is (= "ABXCD" (.-value n)) "and the field followed")
+          (is (= [3 3] (controlled/caret n))
+              "the caret is still after the character just typed"))))))
+
+(deftest a-grouping-model-keeps-the-caret-at-the-same-distance-from-the-end
+  (testing "1,234 + \"5\" becomes 12,345 — one character longer than what the
+           user typed, which is exactly the case an absolute caret offset
+           gets wrong"
+    (if-not (browser?)
+      (is true off-browser)
+      (with-grid
+        (fn [c]
+          (let [n (grid/cell-input c 17)]
+            (set-model! 17 "1,234")
+            (.focus n)
+            (.setSelectionRange n 5 5)
+            (type-into! n "5")
+            (is (= "12,345" (grid/model-value 17)))
+            (is (= "12,345" (.-value n)))
+            (is (= [6 6] (controlled/caret n))
+                "the caret is still after the 5")))))))
+
+;; ---------------------------------------------------------------------------
+;; :selection-preserved
+;; ---------------------------------------------------------------------------
+
+(deftest a-converge-does-not-collapse-a-selection
+  (testing "both ends ride the distance from the end of the string"
+    (if-not (browser?)
+      (is true off-browser)
+      (with-grid
+        (fn [c]
+          (let [n (grid/cell-input c 7)]
+            (set-model! 7 "abcdef")
+            (.focus n)
+            (.setSelectionRange n 1 4)
+            (set-model! 7 "Xabcdef")
+            (is (= "Xabcdef" (.-value n)))
+            (let [[s e] (controlled/caret n)]
+              (is (not= s e) "the selection was not collapsed to a caret")
+              (is (= [2 5] [s e])
+                  "and it still spans the same characters"))))))))
+
+(deftest an-unchanged-model-leaves-the-selection-exactly-alone
+  (if-not (browser?)
+    (is true off-browser)
+    (with-grid
+      (fn [c]
+        (let [n (grid/cell-input c 7)]
+          (set-model! 7 "abcdef")
+          (.focus n)
+          (.setSelectionRange n 1 4)
+          ;; a commit that changes a DIFFERENT cell
+          (set-model! 23 "elsewhere")
+          (is (= [1 4] (controlled/caret n))
+              "nothing was written to this node, so nothing moved"))))))
+
+;; ---------------------------------------------------------------------------
+;; :ime-composition-commits-nothing
+;; ---------------------------------------------------------------------------
+
+(deftest the-renderer-does-not-write-a-composing-field
+  (testing "between compositionstart and compositionend the field belongs to
+           the IME; writing value there destroys the composition"
+    (if-not (browser?)
+      (is true off-browser)
+      (with-grid
+        (fn [c]
+          (let [n (grid/cell-input c 7)]
+            (set-model! 7 "base")
+            (.focus n)
+            (compose! n "compositionstart")
+            (is (true? (controlled/composing? n)) "the fence is up")
+            ;; the IME puts provisional text in the field
+            (set! (.-value n) "baseあ")
+            ;; and an out-of-band correction arrives mid-composition
+            (set-model! 7 "OTHER")
+            (is (= "baseあ" (.-value n))
+                "the renderer must not have touched the composing field")
+            (compose! n "compositionend")
+            (is (false? (controlled/composing? n)) "the fence is down")
+            (is (= "OTHER" (.-value n))
+                "and the suppressed convergence was replayed at compositionend")))))))
+
+;; ---------------------------------------------------------------------------
+;; :async-normalisation
+;; ---------------------------------------------------------------------------
+
+(deftest a-correction-that-arrives-later-still-converges
+  (testing "the same restore, driven by a timer instead of a keystroke —
+           the shape a server normalisation or a debounced validation takes"
+    (if-not (browser?)
+      (is true off-browser)
+      (async done
+        (with-grid
+          (fn [c]
+            (let [n (grid/cell-input c 17)]
+              (set-model! 17 "1234")
+              (.focus n)
+              (.setSelectionRange n 4 4)
+              (js/setTimeout
+               (fn []
+                 (set-model! 17 (grid/group-digits "1234"))
+                 (is (= "1,234" (.-value n)) "the late correction reached the field")
+                 (is (= [5 5] (controlled/caret n))
+                     "and the caret is still at the same distance from the end")
+                 (done))
+               0))))))))
+
+;; ---------------------------------------------------------------------------
+;; The gate, stated once
+;; ---------------------------------------------------------------------------
+
+(deftest the-whole-grid-agrees-with-the-model-after-a-mixed-edit-session
+  (testing "the obligation is not one field's behaviour; it is that no field
+           in a hundred can be left disagreeing"
+    (if-not (browser?)
+      (is true off-browser)
+      (with-grid
+        (fn [c]
+          (doseq [[i text] [[3 "three"] [11 "99"] [11 "x"] [13 "mixed"] [17 "9876"] [42 "forty two"]]]
+            (let [n (grid/cell-input c i)]
+              (.focus n)
+              (.setSelectionRange n (.-length (.-value n)) (.-length (.-value n)))
+              (type-into! n text)))
+          (is (= [] (controlled/disagreements c))
+              "every controlled cell reads what its model says")
+          (is (= grid/cells (rt/boundary-count))
+              "and the grid still holds exactly its cells"))))))
+
+(deftest teardown-leaves-no-boundary-and-no-edge
+  (if-not (browser?)
+    (is true off-browser)
+    (do (rt/reset-runtime!)
+        (let [c (container!)
+              teardown (grid/mount! c)]
+          (is (= grid/cells (rt/boundary-count)))
+          (teardown)
+          (is (zero? (rt/boundary-count)) "no boundary survives the teardown")
+          (is (empty? (rt/watched-keys)) "and no subscription value is retained")
+          (teardown)
+          (is (zero? (rt/boundary-count)) "the teardown is idempotent")
+          (.remove c)
+          (rt/reset-runtime!)))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/controlled_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/controlled_dom_cljs_test.cljs
@@ -73,15 +73,27 @@
 
 (defn- type-into!
   "Type `text` at the caret, the way a browser does it: the field changes
-  first, the `input` event fires second."
+  first, the `input` event fires second.
+
+  `dispatchEvent` does **not** rethrow a listener's exception — it reports
+  it to `window` and returns normally — so a throw on the arm's dispatch
+  path would otherwise be invisible here and fatal to the bundle. The
+  error listener turns it into a failure of the test that caused it."
   [node text]
   (let [start (.-selectionStart node)
         end   (.-selectionEnd node)
-        v     (.-value node)]
+        v     (.-value node)
+        !err  (atom nil)
+        on-error (fn [e] (reset! !err (or (.-message e) (str e))))]
     (set! (.-value node) (str (subs v 0 start) text (subs v end)))
     (let [caret (+ start (count text))]
       (.setSelectionRange node caret caret))
-    (.dispatchEvent node (js/Event. "input" #js {:bubbles true}))
+    (.addEventListener js/window "error" on-error)
+    (try
+      (.dispatchEvent node (js/Event. "input" #js {:bubbles true}))
+      (finally (.removeEventListener js/window "error" on-error)))
+    (when-some [msg @!err]
+      (is false (str "the input handler threw: " msg)))
     nil))
 
 (defn- set-model!
@@ -295,20 +307,33 @@
     (if-not (browser?)
       (is true off-browser)
       (async done
-        (with-grid
-          (fn [c]
-            (let [n (grid/cell-input c 17)]
-              (set-model! 17 "1234")
-              (.focus n)
-              (.setSelectionRange n 4 4)
-              (js/setTimeout
-               (fn []
+        ;; NOT `with-grid`: its `finally` runs the moment the body returns,
+        ;; and the body of an async test returns before its timer fires. A
+        ;; grid torn down under a pending callback leaves the callback
+        ;; dispatching into a runtime with no frame — which throws inside a
+        ;; timer, escapes every `try`, and aborts the whole browser bundle
+        ;; as an uncaught page error rather than failing one test. The
+        ;; lifecycle is therefore driven from inside the callback.
+        (do
+          (rt/reset-runtime!)
+          (let [c        (container!)
+                teardown (grid/mount! c)
+                n        (grid/cell-input c 17)
+                finish   (fn [] (teardown) (.remove c) (rt/reset-runtime!) (done))]
+            (set-model! 17 "1234")
+            (.focus n)
+            (.setSelectionRange n 4 4)
+            (js/setTimeout
+             (fn []
+               (try
                  (set-model! 17 (grid/group-digits "1234"))
                  (is (= "1,234" (.-value n)) "the late correction reached the field")
                  (is (= [5 5] (controlled/caret n))
                      "and the caret is still at the same distance from the end")
-                 (done))
-               0))))))))
+                 (catch :default e
+                   (is false (str "the late correction threw: " (ex-message e)))))
+               (finish))
+             0)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The gate, stated once

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/controlled_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/controlled_dom_cljs_test.cljs
@@ -34,7 +34,6 @@
             [re-frame.bench.hicasso.arm2.controlled :as controlled]
             [re-frame.bench.hicasso.arm2.grid-witness :as grid]
             [re-frame.bench.hicasso.arm2.runtime :as rt]
-            [re-frame.core :as rf]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
 
@@ -117,9 +116,9 @@
             (.focus n)
             (rt/reset-stats!)
             (type-into! n "x")
-            (is (= 1 (:body-runs @rt/stats))
+            (is (= 1 (:body-runs (rt/stats)))
                 (str "one boundary body ran, not " grid/cells))
-            (is (= 1 (:dirty-boundaries @rt/stats))
+            (is (= 1 (:dirty-boundaries (rt/stats)))
                 "and the index named exactly one dirty boundary")))))))
 
 ;; ---------------------------------------------------------------------------
@@ -164,7 +163,7 @@
                 "and the renderer took it off the screen — this is the obligation")
             (is (= [2 2] (controlled/caret n))
                 "the caret sits where it was before the refused character")
-            (is (zero? (:dirty-boundaries @rt/stats))
+            (is (zero? (:dirty-boundaries (rt/stats)))
                 "and the restore happened with NO boundary re-run at all — a
                  renderer that only writes what changed would have written nothing")))))))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/controlled_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/controlled_dom_cljs_test.cljs
@@ -353,7 +353,7 @@
               (type-into! n text)))
           (is (= [] (controlled/disagreements c))
               "every controlled cell reads what its model says")
-          (is (= grid/cells (rt/boundary-count))
+          (is (= (inc grid/cells) (rt/boundary-count))
               "and the grid still holds exactly its cells"))))))
 
 (deftest teardown-leaves-no-boundary-and-no-edge
@@ -362,7 +362,7 @@
     (do (rt/reset-runtime!)
         (let [c (container!)
               teardown (grid/mount! c)]
-          (is (= grid/cells (rt/boundary-count)))
+          (is (= (inc grid/cells) (rt/boundary-count)))
           (teardown)
           (is (zero? (rt/boundary-count)) "no boundary survives the teardown")
           (is (empty? (rt/watched-keys)) "and no subscription value is retained")

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/controlled_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/controlled_dom_cljs_test.cljs
@@ -37,7 +37,13 @@
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
 
-(use-fixtures :each (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+;; `:async? true` — the map-form fixture. `cljs.test` hard-errors on a
+;; fn-form fixture in a suite carrying an `(async done …)` test, and this
+;; suite carries one: `:async-normalisation` is the witness for a
+;; correction that arrives on a LATER tick, which is not a shape a
+;; synchronous test can pretend to have.
+(use-fixtures :each (test-support/make-reset-runtime-fixture
+                     {:adapter plain-atom/adapter :async? true}))
 
 (def ^:private off-browser
   "no DOM on this runtime — the claim is a caret in a real text field,

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/dogfood_screen.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/dogfood_screen.cljs
@@ -34,8 +34,7 @@
   costs one more element per row and removes a class of bug that the
   predecessor's controls work spent a decision on."
   (:require [re-frame.bench.hicasso.arm2.runtime :as rt]
-            [re-frame.bench.hicasso.front.dogfood :as dogfood]
-            [re-frame.core :as rf]))
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]))
 
 ;; ---------------------------------------------------------------------------
 ;; The row — one boundary, three reads

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/dogfood_screen.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/dogfood_screen.cljs
@@ -1,0 +1,142 @@
+(ns re-frame.bench.hicasso.arm2.dogfood-screen
+  "THE DOGFOOD SCREEN, RENDERED BY THE PATCH RUNTIME (rf2-2rtt6.10).
+
+  **Mounting this screen starts the six-week clock** (HD-014; K7). The
+  operator is on record accepting that, and the clock is never extended
+  silently.
+
+  validation.md's specification for the screen is *one list + one
+  controlled field + sub reads*. The state it sits on —
+  [[re-frame.bench.hicasso.front.dogfood]] — is the shared front half and
+  is **read-only to this arm**: every event, every subscription and the
+  intent spellings come from there unchanged, so the two arms' dogfood
+  screens differ in the view layer and in nothing else. That is the whole
+  point of the state layer having been built once.
+
+  ## What this rendering is, and what it is not
+
+  This is the **PATCH runtime's** rendering. HD-002's three renderings —
+  the collector surface, the grouped `use-subs` surface, and raw UIx —
+  are an *ergonomics* comparison ridden on the comparator spine, and they
+  belong to Arm 1. Arm 2's job with this screen is the runtime half: that
+  an own renderer can carry a real screen with a controlled field in it,
+  that a narrow write re-runs one row, and that a keyed reorder moves
+  nodes instead of rebuilding them.
+
+  ## Drafts are not a fallback
+
+  A row shows its title as text and carries its own draft field, bound
+  directly to `[:dogfood/draft id]` — there is no
+  `(if (= \"\" draft) title draft)` anywhere. That spelling would be a
+  reset **by value equality**, which HD-019 rules out: a draft is cleared
+  by explicit caller revision (`:dogfood/commit`, `:dogfood/cancel`) and
+  never because a value looked empty. Writing the screen the ruled way
+  costs one more element per row and removes a class of bug that the
+  predecessor's controls work spent a decision on."
+  (:require [re-frame.bench.hicasso.arm2.runtime :as rt]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.core :as rf]))
+
+;; ---------------------------------------------------------------------------
+;; The row — one boundary, three reads
+;; ---------------------------------------------------------------------------
+
+(def row-view
+  (rt/view ::row
+           (fn [{:keys [id]}]
+             (let [todo  (rt/sub [:dogfood/todo id])
+                   done? (rt/sub [:dogfood/done? id])
+                   draft (rt/sub [:dogfood/draft id])
+                   {:keys [on-click-toggle on-click-remove on-input-title on-key-down]}
+                   (dogfood/row-intents id)]
+               [:li.todo {:class (when done? "done") :data-id id}
+                [:input.toggle {:id        (str "toggle-" id)
+                                :type      "checkbox"
+                                :checked   (boolean done?)
+                                :on-change on-click-toggle}]
+                [:span.title {:id (str "title-" id)} (:title todo)]
+                [:input.draft {:id          (str "draft-" id)
+                               :type        "text"
+                               :value       draft
+                               :placeholder "edit…"
+                               :on-input    on-input-title
+                               :on-key-down on-key-down}]
+                [:button.up {:id (str "up-" id) :on-click [:dogfood/move id 0]} "↑"]
+                [:button.remove {:id (str "remove-" id) :on-click on-click-remove} "×"]]))))
+
+;; ---------------------------------------------------------------------------
+;; The header — the broad write's boundary
+;; ---------------------------------------------------------------------------
+
+(def header-view
+  (rt/view ::header
+           (fn [_]
+             (let [remaining (rt/sub [:dogfood/remaining])
+                   filter'   (rt/sub [:dogfood/filter])]
+               [:header.head
+                [:h1.count {:id "remaining"} (str remaining " left")]
+                [:nav.filters
+                 (for [f [:all :active :done]]
+                   [:button.filter {:key      f
+                                    :id       (str "filter-" (name f))
+                                    :class    (when (= f filter') "selected")
+                                    :on-click [:dogfood/set-filter f]}
+                    (name f)])]]))))
+
+;; ---------------------------------------------------------------------------
+;; The one controlled field at the head of the screen
+;; ---------------------------------------------------------------------------
+
+(def new-item-view
+  (rt/view ::new-item
+           (fn [_]
+             (let [draft (rt/sub [:dogfood/draft dogfood/new-draft-key])
+                   {:keys [on-input on-submit on-key-down]} (dogfood/new-item-intents)]
+               [:form.new {:on-submit on-submit}
+                [:input.new-todo {:id          "new-todo"
+                                  :type        "text"
+                                  :value       draft
+                                  :placeholder "What needs doing?"
+                                  :on-input    on-input
+                                  :on-key-down on-key-down}]]))))
+
+;; ---------------------------------------------------------------------------
+;; The list — the keyed witness
+;; ---------------------------------------------------------------------------
+
+(def list-view
+  (rt/view ::list
+           (fn [_]
+             (let [ids (rt/sub [:dogfood/visible-ids])]
+               [:ul.todos {:role "list"}
+                (for [id ids]
+                  [row-view {:key id :id id}])]))))
+
+(def screen-view
+  (rt/view ::screen
+           (fn [_]
+             [:main.dogfood
+              [header-view {}]
+              [new-item-view {}]
+              [list-view {}]])))
+
+;; ---------------------------------------------------------------------------
+;; Mounting
+;; ---------------------------------------------------------------------------
+
+(def frame-id ::dogfood)
+
+(defn mount!
+  "Create the frame, seed `n` to-dos, and mount the screen into
+  `container`. Returns the teardown.
+
+  **This is the call HD-014 hangs the six-week clock on.**"
+  ([container] (mount! container 20))
+  ([container n]
+   (dogfood/make-frame! frame-id n)
+   (rt/mount-root! {:container container :frame frame-id :element [screen-view {}]})))
+
+(defn row-nodes [container] (vec (array-seq (.querySelectorAll container "li.todo"))))
+
+(defn row-ids [container]
+  (mapv (fn [n] (js/parseInt (.getAttribute n "data-id") 10)) (row-nodes container)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/dom.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/dom.cljs
@@ -1,0 +1,346 @@
+(ns re-frame.bench.hicasso.arm2.dom
+  "THE OWN EMITTER — hiccup analysis in, real DOM out (rf2-2rtt6.10).
+
+  The shared front half's codec ends its docstring with the honest
+  statement of where the two tournament arms part: *analysis — tag parse,
+  prop names, class merge, child realization, head classification — is
+  arm-neutral; emission is not.* Arm 1 emits React elements. This file is
+  Arm 2's emitter, and it emits `Element`, `Text` and `Comment`.
+
+  It reuses the codec's analysis by requiring it ([[codec/cached-parse]],
+  [[codec/class-names]], [[codec/boundary-head?]]) so the two arms parse
+  `:div#main.wide` with one regex and one cache, and a tournament result
+  cannot turn on one arm having a cheaper tag parser.
+
+  ## Names: attributes are not React props
+
+  The codec's kebab→camel rule is React's. The DOM's rule is different
+  and simpler, and getting this wrong is silent — `setAttribute
+  \"readOnly\"` happens to work (HTML attribute names are
+  case-insensitive) while `setAttribute \"read-only\"` silently does
+  nothing. One rule, no roster:
+
+  | prop | attribute |
+  |---|---|
+  | `:data-i`, `:aria-label`, `--custom` | verbatim |
+  | `:read-only`, `:tab-index`, `:col-span` | dashes stripped, lowercased |
+  | `:readOnly`, `:tabIndex` | lowercased |
+  | `:className`, `:htmlFor` | `class`, `for` (the two seeded aliases) |
+
+  Every multi-word HTML attribute is squashed (`readonly`, `tabindex`,
+  `colspan`, `maxlength`, `contenteditable`, `novalidate`, `crossorigin`,
+  `datetime`), which is why the strip-and-lowercase rule needs no table:
+  the exceptions are `aria-*`/`data-*`, and those are exactly the ones
+  React exempts too.
+
+  ## Properties, not attributes, for the controlled pair
+
+  `value`, `checked`, `selected`, `indeterminate` and `muted` are set as
+  **DOM properties**. `setAttribute(\"value\", …)` writes the *default*
+  value and does not move a live input; a renderer that sets the
+  attribute has no controlled input at all. This is the first half of the
+  controlled-restore obligation and the reason
+  [[re-frame.bench.hicasso.arm2.controlled]] can do its work at all.
+
+  ## The event trampoline
+
+  A lowered intent is a fresh closure per render (the front half's
+  `intent/lower-prop` builds it). Naively that is one `removeEventListener`
+  plus one `addEventListener` per prop per render — on the 100-cell grid,
+  200 listener mutations per keystroke.
+
+  Instead each node carries one own-property register, `__hicassoOn`, and
+  the *first* handler at a type installs one permanent listener that
+  reads the register at dispatch time. Re-renders overwrite a slot. The
+  cost of a re-render is one property write; the cost of an event is one
+  own-property read. Retention is one small JS object per node that has
+  any handler at all, and it dies with the node.
+
+  This is deliberately **not** root delegation. Delegation is the bigger
+  win and it is also where a renderer inherits a synthetic event system —
+  retargeting, non-bubbling types (`focus`, `blur`), portal semantics, and
+  a `stopPropagation` story that differs from the platform's. HD-019's
+  door needs the *real* discrete event, so the arm keeps real listeners on
+  real nodes and states delegation as an unexplored optimization rather
+  than paying for a synthetic layer to get it.
+
+  ## The 1:1 law
+
+  **Every hiccup child occupies exactly one DOM node.** A string or number
+  is a `Text`; `nil` and `false` are a `<!--h-->` comment anchor; a vector
+  is one element or one boundary root. Seqs and fragments are spliced
+  into the parent's child vector *before* diffing, so they contribute
+  children rather than nodes of their own.
+
+  The comment anchor is what makes a conditional child free of index
+  arithmetic: `[:div (when x [:b])]` keeps one child slot whether or not
+  `x` holds, so the differ never has to decide whether child 2 of the old
+  tree is child 1 or child 2 of the new one. The cost is one comment node
+  per absent child, which is the trade every anchor-based renderer makes
+  and it is worth naming rather than discovering in a diff."
+  (:require [clojure.string :as str]
+            [re-frame.bench.hicasso.arm2.controlled :as controlled]
+            [re-frame.bench.hicasso.front.codec :as codec]))
+
+;; ---------------------------------------------------------------------------
+;; Own-property hygiene — the same guard the codec's caches use
+;; ---------------------------------------------------------------------------
+
+(def ^:private has-own (.-hasOwnProperty (.-prototype js/Object)))
+
+(defn- own-key? [o k] (.call has-own o k))
+
+(def ^:private reserved-cache-keys #{"__proto__" "prototype" "constructor"})
+
+;; ---------------------------------------------------------------------------
+;; Attribute names
+;; ---------------------------------------------------------------------------
+
+(defn attr-name
+  "The DOM attribute name for a hiccup prop key. See the namespace
+  docstring's table — one rule and two seeded aliases."
+  [k]
+  (if (string? k)
+    k
+    (let [n (name k)]
+      (cond
+        (str/starts-with? n "--")     n
+        (str/starts-with? n "aria-")  n
+        (str/starts-with? n "data-")  n
+        (= n "className")             "class"
+        (= n "htmlFor")               "for"
+        :else                         (str/lower-case (str/replace n "-" ""))))))
+
+(def ^:private attr-cache #js {})
+
+(defn cached-attr-name
+  "[[attr-name]] behind a codec-work cache (HD-004). One entry per
+  distinct prop literal the build ever renders."
+  [k]
+  (if-not (or (keyword? k) (symbol? k) (string? k))
+    (attr-name k)
+    (let [n (name k)]
+      (if (reserved-cache-keys n)
+        (attr-name k)
+        (if (own-key? attr-cache n)
+          (unchecked-get attr-cache n)
+          (let [converted (attr-name k)]
+            (unchecked-set attr-cache n converted)
+            converted))))))
+
+(def ^:private dom-properties
+  "Written as properties, never attributes. The controlled pair plus the
+  three other live-state properties whose attribute is only a default."
+  #{"value" "checked" "selected" "indeterminate" "muted"})
+
+(defn property-prop?
+  "Does this prop address live element state rather than markup?"
+  [k]
+  (contains? dom-properties (cached-attr-name k)))
+
+;; ---------------------------------------------------------------------------
+;; Events
+;; ---------------------------------------------------------------------------
+
+(def ^:private event-prop-re #"^on-[a-z]|^on[A-Z]")
+
+(defn event-prop?
+  "Is `k` an event position? The same two spellings the front half's
+  intent lowering accepts, so a prop it lowered is a prop this emitter
+  binds."
+  [k]
+  (boolean (and (or (keyword? k) (string? k))
+                (re-find event-prop-re (name k)))))
+
+(defn event-type
+  "`:on-click` → `\"click\"`, `:onKeyDown` → `\"keydown\"`. Dashes
+  stripped and lowercased, which is the DOM's own naming for every type
+  the census writes."
+  [k]
+  (-> (name k) (subs 2) (str/replace "-" "") str/lower-case))
+
+(def ^:private on-key "__hicassoOn")
+
+(defn- handler-register
+  "The node's handler register, created on first use."
+  [node]
+  (or (unchecked-get node on-key)
+      (let [o #js {}] (unchecked-set node on-key o) o)))
+
+(defn set-handler!
+  "Install (or with `nil`, clear) the handler at `type` on `node`. The
+  first handler at a type installs one permanent listener that reads the
+  register; later renders only write the slot."
+  [node type f]
+  (let [reg (handler-register node)]
+    (when-not (own-key? reg type)
+      (.addEventListener node type
+                         (fn [e] (when-some [h (unchecked-get reg type)] (h e)))))
+    (unchecked-set reg type f)
+    nil))
+
+(defn handler-at
+  "The handler currently bound at `type`, or nil. For the witnesses."
+  [node type]
+  (when-some [reg (unchecked-get node on-key)]
+    (unchecked-get reg type)))
+
+;; ---------------------------------------------------------------------------
+;; Style
+;; ---------------------------------------------------------------------------
+
+(defn- css-name
+  "`:font-size` → `\"font-size\"`, `:fontSize` → `\"font-size\"`, a custom
+  property verbatim. `setProperty` wants the CSS spelling, not the
+  camelCase one the `style` object exposes."
+  [k]
+  (let [n (name k)]
+    (if (str/starts-with? n "--")
+      n
+      (str/lower-case (str/replace n #"([a-z0-9])([A-Z])" "$1-$2")))))
+
+(defn- apply-style!
+  "Set the declarations in `new-style` that differ from `old-style`, and
+  remove the ones that went away. Numbers are stringified as-is: this
+  renderer appends no implicit `px` — an implicit unit is a rule the
+  author has to learn and a value the author cannot express."
+  [node old-style new-style]
+  (let [style (.-style node)]
+    (doseq [[k v] new-style]
+      (when-not (= v (get old-style k))
+        (if (nil? v)
+          (.removeProperty style (css-name k))
+          (.setProperty style (css-name k) (str v)))))
+    (doseq [[k _] old-style]
+      (when-not (contains? new-style k)
+        (.removeProperty style (css-name k))))
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; One prop
+;; ---------------------------------------------------------------------------
+
+(defn set-prop!
+  "Apply one already-lowered prop to `node`. `old` is the value the
+  previous render set at this key, used only by `:style` (which patches
+  declaration-wise) — every other kind writes unconditionally, because
+  the caller has already established that the value changed."
+  [node k v old]
+  (let [n (cached-attr-name k)]
+    (cond
+      (event-prop? k)          (set-handler! node (event-type k) (when (fn? v) v))
+      (= "style" n)            (apply-style! node (when (map? old) old) (when (map? v) v))
+      ;; The controlled pair goes through the one code path that owns the
+      ;; caret and the composition fence — never a bare property write.
+      (= "value" n)            (controlled/write-value! node v)
+      (= "checked" n)          (controlled/write-checked! node v)
+      (dom-properties n)       (unchecked-set node n (if (nil? v) "" v))
+      (or (nil? v) (false? v)) (.removeAttribute node n)
+      (true? v)                (.setAttribute node n "")
+      (keyword? v)             (.setAttribute node n (name v))
+      :else                    (.setAttribute node n (str v)))
+    nil))
+
+(defn clear-prop!
+  "Undo a prop that the new render does not carry."
+  [node k]
+  (let [n (cached-attr-name k)]
+    (cond
+      (event-prop? k)    (set-handler! node (event-type k) nil)
+      (= "style" n)      (apply-style! node nil nil)
+      (= "value" n)      (controlled/write-value! node "")
+      (= "checked" n)    (controlled/write-checked! node false)
+      (dom-properties n) (unchecked-set node n "")
+      :else              (.removeAttribute node n))
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; Props maps
+;; ---------------------------------------------------------------------------
+
+(defn merge-shorthand
+  "Fold a parsed tag's `#id`/`.class` shorthand into the props map, drop
+  `:key` (identity, not an attribute), and normalize `:className` onto
+  `:class`. The codec's private counterpart, restated here because the
+  emitter needs the *merged map itself* — the codec's version is fused
+  into its React props walk."
+  [props parsed]
+  (let [id        (.-id parsed)
+        shorthand (.-className parsed)
+        declared  (or (:class props) (:className props))
+        merged    (codec/class-names shorthand declared)]
+    (cond-> (dissoc props :key :className :class)
+      (and id (not (contains? props :id))) (assoc :id id)
+      merged                               (assoc :class merged))))
+
+(defn apply-props!
+  "Write every prop in `props` onto a freshly created `node`."
+  [node props]
+  (reduce-kv (fn [_ k v] (set-prop! node k v nil) nil) nil props)
+  nil)
+
+(defn diff-props!
+  "Patch `node` from `old-props` to `new-props`. Only the keys whose
+  values are not `=` are written, and only the keys that went away are
+  cleared — the ordinary re-render of an unchanged element touches the
+  DOM zero times.
+
+  Event positions are the deliberate exception: a lowered intent is a
+  fresh closure every render and is never `=` to the last one, so its
+  slot is rewritten. That write is one property assignment on the node's
+  handler register (see the namespace docstring), not a listener
+  mutation."
+  [node old-props new-props]
+  (when-not (identical? old-props new-props)
+    (reduce-kv (fn [_ k v]
+                 (let [o (get old-props k ::absent)]
+                   (when-not (= o v) (set-prop! node k v (when (not= o ::absent) o))))
+                 nil)
+               nil
+               new-props)
+    (reduce-kv (fn [_ k _]
+                 (when-not (contains? new-props k) (clear-prop! node k))
+                 nil)
+               nil
+               old-props))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Node construction
+;; ---------------------------------------------------------------------------
+
+(defn create-anchor
+  "The comment node standing in for a `nil` or `false` child — the 1:1
+  law's placeholder."
+  []
+  (js/document.createComment "h"))
+
+(defn create-text [x] (js/document.createTextNode (str x)))
+
+(defn anchor?  [node] (identical? 8 (.-nodeType node)))
+(defn text?    [node] (identical? 3 (.-nodeType node)))
+(defn element? [node] (identical? 1 (.-nodeType node)))
+
+(defn create-element
+  "Create the element for a parsed tag and write its merged props."
+  [parsed props]
+  (let [node (js/document.createElement (.-tag parsed))]
+    (apply-props! node props)
+    node))
+
+;; ---------------------------------------------------------------------------
+;; Placement
+;; ---------------------------------------------------------------------------
+
+(defn insert!
+  "Put `node` into `parent` before `anchor` (or at the end when `anchor`
+  is nil). The one placement primitive the differ uses — `appendChild` is
+  `insertBefore` with a nil anchor, and having one call site is what
+  keeps the reorder path honest."
+  [parent node anchor]
+  (.insertBefore parent node (or anchor nil))
+  nil)
+
+(defn remove! [parent node] (.removeChild parent node) nil)
+
+(defn replace! [parent old-node new-node] (.replaceChild parent new-node old-node) nil)

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/grid_witness.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/grid_witness.cljs
@@ -1,0 +1,143 @@
+(ns re-frame.bench.hicasso.arm2.grid-witness
+  "THE 100-CELL CONTROLLED GRID, on the PATCH runtime — the witness the
+  hard gate is judged on (rf2-2rtt6.10; witness `:controlled/grid-100`,
+  family `:controlled`, gates `K4` and the per-keystroke budget).
+
+  The witness set names six assertions for this row, and the six are the
+  cases where a store-backed controlled input actually breaks:
+
+      :same-turn-echo                  the field shows the model before the event returns
+      :mid-string-caret                editing in the middle does not jump to the end
+      :selection-preserved             a converge does not collapse a selection
+      :ime-composition-commits-nothing the renderer does not touch a composing field
+      :unchanged-model-rejection       a refused keystroke disappears from the field
+      :async-normalisation             a later correction converges, caret intact
+
+  ## One event, one subscription, a per-cell policy in app-db
+
+  Rejection and normalisation are not special *code paths* in a
+  controlled input; they are ordinary model behaviour that the renderer
+  has to survive. So the grid has exactly one event and one
+  subscription, and each cell carries a policy in app-db:
+
+  | policy | what the model does with the typed value |
+  |---|---|
+  | `:plain` | takes it |
+  | `:digits` | **refuses** it unless it is all digits — the model does not move |
+  | `:upper`  | normalises it to upper case |
+  | `:group`  | normalises `12345` to `12,345` — the length changes |
+
+  `:digits` is the one that fails an arm outright: the model is unchanged,
+  so **nothing re-renders**, so a renderer that only writes what changed
+  never writes at all, and the refused character stays on screen forever.
+  `:group` is the one that catches a caret restored by absolute offset
+  instead of distance-from-the-end.
+
+  ## The shape
+
+  100 boundaries, one controlled `<input>` each, one read each. That is
+  also the per-keystroke budget's witness: a keystroke in cell 7 must run
+  one body, not one hundred, and [[re-frame.bench.hicasso.arm2.runtime/stats]]
+  is where that is counted rather than asserted."
+  (:require [clojure.string :as str]
+            [re-frame.bench.hicasso.arm2.runtime :as rt]
+            [re-frame.core :as rf]))
+
+(def cells
+  "The witness size validation.md names."
+  100)
+
+;; ---------------------------------------------------------------------------
+;; The model
+;; ---------------------------------------------------------------------------
+
+(defn group-digits
+  "`\"12345\"` → `\"12,345\"`. Non-digits are dropped, which is what makes
+  this a normalisation rather than a rejection."
+  [s]
+  (let [ds (str/replace (str s) #"[^0-9]" "")
+        n  (count ds)]
+    (if (<= n 3)
+      ds
+      (str/join "," (reverse (map str/join (partition-all 3 (reverse ds))))))))
+
+(defn apply-policy
+  "What the model does with a typed value. `old` is what it holds now,
+  which is the whole of a rejection: the model returns itself."
+  [policy old v]
+  (case policy
+    :digits (if (re-matches #"[0-9]*" v) v old)
+    :upper  (str/upper-case v)
+    :group  (group-digits v)
+    v))
+
+(defn seed-db
+  "`n` empty cells, with the four policies placed on named cells so the
+  witness can address them by index rather than by setting up state."
+  [n]
+  {:cells    (into {} (map (fn [i] [i ""])) (range n))
+   :policies {11 :digits 13 :upper 17 :group}})
+
+(rf/reg-sub :grid/cell (fn [db [_ i]] (get-in db [:cells i] "")))
+
+(rf/reg-event :grid/seed
+  (fn [_ [_ n]] {:db (seed-db n)}))
+
+(rf/reg-event :grid/edit
+  (fn [{:keys [db]} [_ i v]]
+    (let [policy (get-in db [:policies i] :plain)
+          old    (get-in db [:cells i] "")]
+      {:db (assoc-in db [:cells i] (apply-policy policy old v))})))
+
+;; The door an out-of-band correction arrives through — a server
+;; normalisation, a debounce, a validation that resolves late. It is a
+;; plain event; what makes it the `:async-normalisation` witness is that
+;; the witness dispatches it from a timer rather than from the field.
+(rf/reg-event :grid/set
+  (fn [{:keys [db]} [_ i v]] {:db (assoc-in db [:cells i] v)}))
+
+;; ---------------------------------------------------------------------------
+;; The views
+;; ---------------------------------------------------------------------------
+
+(def cell-view
+  (rt/view ::cell
+           (fn [{:keys [i]}]
+             (let [v (rt/sub [:grid/cell i])]
+               [:div.cell
+                [:input.inp {:id       (str "c" i)
+                             :type     "text"
+                             :value    v
+                             :on-input [:grid/edit i :re-frame.hicasso/value]}]]))))
+
+(def grid-view
+  (rt/view ::grid
+           (fn [{:keys [n]}]
+             [:div.grid {:role "group"}
+              (for [i (range n)]
+                [cell-view {:key i :i i}])])))
+
+;; ---------------------------------------------------------------------------
+;; Mounting the witness
+;; ---------------------------------------------------------------------------
+
+(def frame-id ::grid)
+
+(defn mount!
+  "Create the frame, seed it, and mount the grid into `container`.
+  Returns the teardown."
+  ([container] (mount! container cells))
+  ([container n]
+   (rf/make-frame {:id frame-id :initial-events [[:grid/seed n]]})
+   (rt/mount-root! {:container container :frame frame-id :element [grid-view {:n n}]})))
+
+(defn cell-input
+  "The `<input>` for cell `i` inside `container`."
+  [container i]
+  (.querySelector container (str "#c" i)))
+
+(defn model-value
+  "What app-db says cell `i` holds — the other half of every agreement
+  assertion, read from the frame rather than from the renderer."
+  [i]
+  (get-in (rf/app-db-value frame-id) [:cells i] ""))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/grid_witness.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/grid_witness.cljs
@@ -59,7 +59,11 @@
         n  (count ds)]
     (if (<= n 3)
       ds
-      (str/join "," (reverse (map str/join (partition-all 3 (reverse ds))))))))
+      (->> (reverse ds)
+           (partition-all 3)
+           (map (comp str/join reverse))
+           reverse
+           (str/join ",")))))
 
 (defn apply-policy
   "What the model does with a typed value. `old` is what it holds now,

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/patch.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/patch.cljs
@@ -1,0 +1,352 @@
+(ns re-frame.bench.hicasso.arm2.patch
+  "THE DIFFER — hiccup against hiccup, patch against the live DOM
+  (rf2-2rtt6.10, architecture.md Arm 2).
+
+  ## The previous tree is the previous hiccup
+
+  This renderer keeps **no virtual DOM of its own**. The tree it diffs
+  against is the hiccup the last render produced — the author's own data,
+  retained as-is — and the nodes it patches are the real ones, reached by
+  walking the live DOM in step with the two hiccup trees. There is no
+  intermediate node object, no `VNode` record, no per-element instance
+  cell. That is not an economy measure; it is the whole reason a PATCH
+  arm can be lighter than a React arm rather than merely different, and
+  it is why the retained-size question for this arm is *the boundary
+  record and the index edges*, with nothing per element.
+
+  The parallel walk is sound because of the emitter's 1:1 law (see
+  [[re-frame.bench.hicasso.arm2.dom]]): every hiccup child occupies
+  exactly one DOM node, `nil` included. Old child *i* is therefore
+  `parent.childNodes[i]`, always, with no bookkeeping to keep in step.
+
+  ## The three tiers, and what each covers
+
+  | tier | entered when | what it costs |
+  |---|---|---|
+  | **1 — hole plan** | old and new share a static shape ([[re-frame.bench.hicasso.arm2.template]]) | one structural verify + one pass over the holes; no map walk, no name conversion, no recursion |
+  | **2 — equality cutoff** | `identical?`, then `=`, on any subtree | one comparison, then nothing |
+  | **3 — keyed diff** | everything else | props diff + [[re-frame.bench.hicasso.arm2.reconcile]]'s plan |
+
+  Tier 2 is checked first at every child slot, because it is the cheapest
+  and — with ClojureScript's structural sharing — the most often taken:
+  an author's `for` over an unchanged collection returns hiccup whose
+  unchanged rows are `identical?` to last render's, so a 300-row list
+  where one row changed compares 300 pointers and patches one row.
+
+  **Tier 2 is sound at a boundary child too**, and that is worth stating
+  plainly because it looks like the memoization HD-006 refuses. It is
+  not. HD-006 refuses *guessing* that equal arguments imply an equal
+  rendering — true under React, where a boundary's data arrives through
+  props. Here a boundary's data arrives through the index: a boundary
+  whose subscriptions changed is in this commit's dirty set and re-runs
+  from [[re-frame.bench.hicasso.arm2.runtime/commit!]] on its own,
+  whether or not an ancestor reached it. Skipping an unchanged boundary
+  element therefore skips *nothing that would have happened*; it is the
+  index paying for itself, not a memo.
+
+  ## Sequences and fragments splice; they are not nodes
+
+  [[flatten-children]] realizes seqs and `[:<>]` fragments into the
+  parent's own child vector before any diffing. A `for` inside a `for`
+  splices twice; a fragment contributes its children. This is what lets
+  the keyed reconciler see one flat list — the list an author thinks
+  they wrote — instead of a tree of grouping nodes with their own
+  identity rules.
+
+  ## Raw hiccup in, lowering at the last moment
+
+  The retained previous tree holds the author's **raw** props, not
+  lowered ones. An event intent is a value (`[:dogfood/toggle 3]`), so an
+  unchanged handler compares `=` and is never lowered at all: no closure
+  allocated, no register written, nothing touched. Only a *changed*
+  intent pays [[intent/lower-prop]]. A renderer that lowered before
+  diffing would allocate a fresh closure per event prop per render and
+  then discover it could not compare them."
+  (:require [re-frame.bench.hicasso.arm2.dom :as dom]
+            [re-frame.bench.hicasso.arm2.reconcile :as reconcile]
+            [re-frame.bench.hicasso.arm2.template :as template]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.intent :as intent]))
+
+(declare mount-child patch-child! patch-element-slow!)
+
+;; ---------------------------------------------------------------------------
+;; The boundary seam
+;; ---------------------------------------------------------------------------
+;;
+;; The differ knows that a marked `defview` product is a legal head and
+;; that it occupies one node. It knows nothing else about boundaries —
+;; not the index, not the sub layer, not the commit. The runtime installs
+;; three functions here, in the same shape as the front half's evidence
+;; sink: a holder, a setter, and a nil-checked call.
+
+(defonce ^:private !boundary-ops (atom nil))
+
+(defn set-boundary-ops!
+  "Install the runtime's boundary operations:
+
+      {:mount   (fn [hiccup] node)
+       :patch   (fn [node old-hiccup new-hiccup] node)
+       :unmount (fn [subtree-root-node] nil)}"
+  [ops]
+  (reset! !boundary-ops ops)
+  nil)
+
+(defn- boundary-ops []
+  (or @!boundary-ops
+      (throw (ex-info (str "A boundary element was rendered with no runtime installed. "
+                           "[:rf.error/hicasso-patch-no-runtime]")
+                      {:rf.error/id :rf.error/hicasso-patch-no-runtime
+                       :where       'arm2.patch/boundary-ops
+                       :reason      "set-boundary-ops! has not been called."
+                       :recovery    :mount-through-the-runtime}))))
+
+(defn unmount-subtree!
+  "Tell the runtime that `node` and everything under it is leaving the
+  document, so the boundaries inside it unmount and their index edges
+  drop. Called before every removal and every replacement — the standing
+  `zero-leaked-subscription-refcounts-after-teardown` assertion is this
+  call being unconditional."
+  [node]
+  (when-some [ops @!boundary-ops] ((:unmount ops) node))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Hiccup shape
+;; ---------------------------------------------------------------------------
+
+(defn- fragment? [form]
+  (and (vector? form) (pos? (count form)) (= :<> (nth form 0))))
+
+(defn props-of
+  "The props map of a hiccup vector, or nil. Slot 1 is props when it is a
+  map — the codec's rule, restated for the emitter's own walk."
+  [argv]
+  (let [p (nth argv 1 nil)] (when (map? p) p)))
+
+(defn first-child-index [argv] (if (map? (nth argv 1 nil)) 2 1))
+
+(defn- splice!
+  "Append one child form to the transient accumulator, splicing a seq or
+  a fragment into it rather than treating it as a node."
+  [acc c]
+  (cond
+    (seq? c)      (reduce splice! acc c)
+    (fragment? c) (let [n (count c)]
+                    (loop [i (first-child-index c) a acc]
+                      (if (< i n) (recur (inc i) (splice! a (nth c i))) a)))
+    :else         (conj! acc c)))
+
+(defn flatten-children
+  "The trailing forms of `argv`, with seqs and fragments spliced
+  recursively, as one flat vector. Returns `[]` when there are none."
+  [argv from]
+  (let [n (count argv)]
+    (loop [i from acc (transient [])]
+      (if (>= i n)
+        (persistent! acc)
+        (recur (inc i) (splice! acc (nth argv i)))))))
+
+(defn child-key
+  "The `:key` a child declares, or nil. Read off the props map, which is
+  the only place the component ABI (HD-016) puts it."
+  [form]
+  (when (vector? form)
+    (when-some [p (props-of form)] (:key p))))
+
+(defn- scalar? [x] (or (string? x) (number? x)))
+
+(defn- same-type?
+  "Can the node at this slot be patched in place, or must it be replaced?
+  Same head under `=`, which covers both a tag keyword and a boundary
+  function identity."
+  [old new]
+  (and (vector? old) (vector? new) (= (nth old 0) (nth new 0))))
+
+;; ---------------------------------------------------------------------------
+;; Props
+;; ---------------------------------------------------------------------------
+
+(defn- lower [k v] (if (dom/event-prop? k) (intent/lower-prop k v) v))
+
+(defn- apply-raw-props!
+  "Write a merged, still-raw props map onto a fresh node, lowering only
+  at the event positions."
+  [node props]
+  (reduce-kv (fn [_ k v] (dom/set-prop! node k (lower k v) nil) nil) nil props)
+  nil)
+
+(defn- diff-raw-props!
+  "Patch a node's props from one raw merged map to the next. The `=`
+  comparison happens on the *author's values*, so an unchanged intent
+  never becomes a closure."
+  [node old-props new-props]
+  (when-not (identical? old-props new-props)
+    (reduce-kv (fn [_ k v]
+                 (let [o (get old-props k ::absent)]
+                   (when-not (= o v)
+                     (dom/set-prop! node k (lower k v) (when (not= o ::absent) o))))
+                 nil)
+               nil
+               new-props)
+    (reduce-kv (fn [_ k _] (when-not (contains? new-props k) (dom/clear-prop! node k)) nil)
+               nil
+               old-props))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Mounting
+;; ---------------------------------------------------------------------------
+
+(defn- mount-element
+  "Build one native element and its children. Tier 1 takes this path
+  whenever the shape has a plan: the plan's template is cloned in one
+  native call and only the holes are written."
+  [argv]
+  (if-some [plan (template/plan-for argv)]
+    (template/mount-from-plan! plan argv lower)
+    (let [parsed (codec/cached-parse (nth argv 0))
+          props  (dom/merge-shorthand (or (props-of argv) {}) parsed)
+          node   (js/document.createElement (.-tag parsed))]
+      (apply-raw-props! node props)
+      (doseq [c (flatten-children argv (first-child-index argv))]
+        (.appendChild node (mount-child c)))
+      node)))
+
+(defn mount-child
+  "Build the one node this child form occupies."
+  [form]
+  (cond
+    (nil? form)     (dom/create-anchor)
+    (false? form)   (dom/create-anchor)
+    (scalar? form)  (dom/create-text form)
+    (vector? form)  (let [head (nth form 0 nil)]
+                      (cond
+                        (codec/boundary-head? head) ((:mount (boundary-ops)) form)
+                        (or (keyword? head) (string? head) (symbol? head)) (mount-element form)
+                        :else
+                        (throw (ex-info (str "Hiccup head " (pr-str head) " is not a valid element head. "
+                                             "[:rf.error/hicasso-bad-head]")
+                                        {:rf.error/id :rf.error/hicasso-bad-head
+                                         :where       'arm2.patch/mount-child
+                                         :reason      "Head must be a tag keyword or a view minted by defview."
+                                         :recovery    :supply-a-valid-hiccup-head}))))
+    (true? form)    (throw (ex-info (str "`true` is not a renderable child. "
+                                         "[:rf.error/hicasso-true-child]")
+                                    {:rf.error/id :rf.error/hicasso-true-child
+                                     :where       'arm2.patch/mount-child
+                                     :reason      "nil and false render nothing; true is an error (HD-016)."
+                                     :recovery    :use-nil-or-false}))
+    :else           (dom/create-text form)))
+
+;; ---------------------------------------------------------------------------
+;; Children
+;; ---------------------------------------------------------------------------
+
+(defn- patch-children!
+  "Reconcile one parent's children. The ordering decisions are all
+  [[reconcile/plan]]'s; this function only applies them, carrying one
+  anchor as it walks the placements backwards."
+  [parent old-forms new-forms]
+  (let [old-nodes (let [cs (.-childNodes parent)
+                        n  (.-length cs)]
+                    (loop [i 0 acc (transient [])]
+                      (if (< i n) (recur (inc i) (conj! acc (.item cs i))) (persistent! acc))))
+        {:keys [removes places]} (reconcile/plan (mapv child-key old-forms) (mapv child-key new-forms))]
+    (doseq [i removes]
+      (let [node (nth old-nodes i)]
+        (unmount-subtree! node)
+        (dom/remove! parent node)))
+    (loop [ps (seq places) anchor nil]
+      (when ps
+        (let [{:keys [op new old]} (first ps)
+              node (case op
+                     :mount (let [n (mount-child (nth new-forms new))]
+                              (dom/insert! parent n anchor)
+                              n)
+                     :keep  (patch-child! parent (nth old-nodes old) (nth old-forms old) (nth new-forms new))
+                     :move  (let [n (patch-child! parent (nth old-nodes old) (nth old-forms old) (nth new-forms new))]
+                              (dom/insert! parent n anchor)
+                              n))]
+          (recur (next ps) node))))
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; One child slot
+;; ---------------------------------------------------------------------------
+
+(defn- patch-element!
+  "Patch a native element in place. Tier 1 when the node's stamp says it
+  was last rendered from exactly this shape; tier 3 otherwise, after
+  which the node is re-stamped so the *next* render can take tier 1."
+  [node old new]
+  (let [plan (template/plan-for new)]
+    (if (template/fits? plan node)
+      (template/patch-from-plan! plan node old new lower)
+      (do (patch-element-slow! node old new)
+          (template/stamp! node (:sig plan)))))
+  node)
+
+(defn patch-element-slow!
+  "Tier 3 on one element: a raw props diff and a keyed children plan."
+  [node old new]
+  (let [parsed (codec/cached-parse (nth new 0))]
+    (diff-raw-props! node
+                     (dom/merge-shorthand (or (props-of old) {}) parsed)
+                     (dom/merge-shorthand (or (props-of new) {}) parsed))
+    (patch-children! node
+                     (flatten-children old (first-child-index old))
+                     (flatten-children new (first-child-index new)))
+    nil))
+
+(defn- replace-child!
+  "Build the new node, swap it in, and unmount everything the old one
+  held."
+  [parent node new]
+  (let [fresh (mount-child new)]
+    (dom/replace! parent node fresh)
+    (unmount-subtree! node)
+    fresh))
+
+(defn patch-child!
+  "Bring the node occupying one child slot from `old` to `new`, and
+  return the node now occupying it (the same node whenever the slot was
+  patched in place).
+
+  Tier 2 is the first two lines, and the ones that carry the bulk
+  witness."
+  [parent node old new]
+  (cond
+    (identical? old new) node
+    (= old new)          node
+
+    (and (scalar? old) (scalar? new))
+    (do (set! (.-nodeValue node) (str new)) node)
+
+    (and (or (nil? old) (false? old)) (or (nil? new) (false? new)))
+    node
+
+    (same-type? old new)
+    (if (codec/boundary-head? (nth new 0))
+      ((:patch (boundary-ops)) node old new)
+      (patch-element! node old new))
+
+    :else
+    (replace-child! parent node new)))
+
+;; ---------------------------------------------------------------------------
+;; Root
+;; ---------------------------------------------------------------------------
+
+(defn render-root!
+  "Render `new` into `container`, against the `old` hiccup the container
+  last held (nil on a cold mount). Returns the node the root occupies.
+
+  The container is the renderer's own: it owns every child of it, which
+  is what makes the parallel walk legal from the very first slot."
+  [container old new]
+  (if (nil? old)
+    (let [node (mount-child new)]
+      (.appendChild container node)
+      node)
+    (patch-child! container (.-firstChild container) old new)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/patch_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/patch_dom_cljs_test.cljs
@@ -143,13 +143,16 @@
 
 (deftest an-equal-but-fresh-subtree-is-also-cut
   (testing "structural sharing is a bonus, not the mechanism — a rebuilt but
-           `=` subtree bails just the same"
+           `=` subtree bails just the same. The seq child keeps the parent
+           out of tier 1, so the `=` this test takes is tier 2's."
     (if-not (browser?)
       (is true off-browser)
-      (let [[c patch!] (render! [:div [:span {:class "a"} "same"]])
+      (let [[c patch!] (render! [:div (list [:span {:class "a"} "same"])])
             span       (.-firstChild (.-firstChild c))
             text       (.-firstChild span)]
-        (patch! [:div [:span {:class (str "a")} (str "same")]])
+        ;; `subs` mints strings that are `=` but not `identical?` to the
+        ;; literals above — which is the point of this test.
+        (patch! [:div (list [:span {:class (subs "za" 1)} (subs "xsame" 1)])])
         (is (identical? span (.-firstChild (.-firstChild c))))
         (is (identical? text (.-firstChild span)))
         (.remove c)))))
@@ -165,8 +168,10 @@
       (template/reset-plans!)
       (let [[c] (render! [:ul (for [i (range 50)]
                                 [:li.row {:key i :data-i i} [:span.cell (str i)]])])]
-        (is (= 2 (template/plan-count))
-            "one plan for the row and one for the cell — not one per instance")
+        (is (= 1 (template/plan-count))
+            "ONE plan for fifty rows — and the row's plan covers its span, so
+             the nested element does not get a plan of its own; the `:ul`
+             refuses one because its child list is a seq")
         (is (= 50 (count (kids (.-firstChild c)))))
         (.remove c)))))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/patch_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/patch_dom_cljs_test.cljs
@@ -1,0 +1,301 @@
+(ns re-frame.bench.hicasso.arm2.patch-dom-cljs-test
+  "THE DIFFER AGAINST A REAL DOM (rf2-2rtt6.10).
+
+  [[re-frame.bench.hicasso.arm2.reconcile-cljs-test]] proves the keyed
+  decisions as values; this file proves that the applier does what the
+  plan says — and that the two other tiers do what they claim.
+
+  The assertions are mostly about **node identity**: the interesting
+  claims of a renderer are not what the markup reads afterwards (any
+  renderer that rebuilds everything gets that right) but which nodes
+  survived. So `identical?` on captured node references is the tool
+  throughout.
+
+  No boundaries here. This file exercises the differ on plain elements,
+  with no runtime, no frame and no subscriptions — which is the layering
+  the arm is built on: the differ knows nothing about them."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.bench.hicasso.arm2.controlled :as controlled]
+            [re-frame.bench.hicasso.arm2.dom :as dom]
+            [re-frame.bench.hicasso.arm2.patch :as patch]
+            [re-frame.bench.hicasso.arm2.template :as template]))
+
+(def ^:private off-browser
+  "no DOM on this runtime — every claim here is a claim about nodes")
+
+(defn- browser? []
+  (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
+
+(defn- container! []
+  (let [c (js/document.createElement "div")]
+    (.appendChild js/document.body c)
+    c))
+
+(defn- render!
+  "Render a sequence of hiccup trees into a fresh container, returning
+  `[container render-fn]` where `render-fn` patches the next one."
+  [initial]
+  (let [c    (container!)
+        !old (atom initial)]
+    (patch/render-root! c nil initial)
+    [c (fn [next] (patch/render-root! c @!old next) (reset! !old next) nil)]))
+
+(defn- kids [node]
+  (let [cs (.-childNodes node) n (.-length cs)]
+    (mapv (fn [i] (.item cs i)) (range n))))
+
+(defn- texts [node] (mapv #(.-textContent %) (kids node)))
+
+;; ---------------------------------------------------------------------------
+;; Mounting
+;; ---------------------------------------------------------------------------
+
+(deftest a-cold-mount-builds-the-markup-the-hiccup-describes
+  (if-not (browser?)
+    (is true off-browser)
+    (let [[c] (render! [:ul.grid {:role "list"}
+                        [:li.row {:data-i 0} [:span.lbl "cell "] [:span.cell "7"]]])]
+      (let [ul (.-firstChild c)]
+        (is (= "UL" (.-tagName ul)))
+        (is (= "grid" (.getAttribute ul "class")) "the tag shorthand became the class")
+        (is (= "list" (.getAttribute ul "role")))
+        (is (= "<li class=\"row\" data-i=\"0\"><span class=\"lbl\">cell </span><span class=\"cell\">7</span></li>"
+               (.-innerHTML ul))))
+      (.remove c))))
+
+(deftest attribute-names-follow-the-doms-rule-not-reacts
+  (if-not (browser?)
+    (is true off-browser)
+    (let [[c] (render! [:input {:read-only true :tab-index 3 :data-i 9
+                                :aria-label "Cell" :for "x" :className "k"}])]
+      (let [n (.-firstChild c)]
+        (is (true? (.-readOnly n)) "read-only reached the element as readonly")
+        (is (= "3" (.getAttribute n "tabindex")))
+        (is (= "9" (.getAttribute n "data-i")) "data- keeps its dash")
+        (is (= "Cell" (.getAttribute n "aria-label")) "aria- keeps its dash")
+        (is (= "x" (.getAttribute n "for")))
+        (is (= "k" (.getAttribute n "class")) "className is the seeded alias for class"))
+      (.remove c))))
+
+(deftest the-controlled-pair-is-a-property-not-an-attribute
+  (if-not (browser?)
+    (is true off-browser)
+    (let [[c] (render! [:input {:type "text" :value "hello"}])]
+      (let [n (.-firstChild c)]
+        (is (= "hello" (.-value n)) "the live value moved")
+        (is (nil? (.getAttribute n "value"))
+            "and no value ATTRIBUTE was written — that would only set a default")
+        (is (controlled/controlled? n) "the node is known to the restore path"))
+      (.remove c))))
+
+;; ---------------------------------------------------------------------------
+;; The 1:1 law
+;; ---------------------------------------------------------------------------
+
+(deftest a-nil-child-occupies-one-comment-anchor
+  (if-not (browser?)
+    (is true off-browser)
+    (let [[c patch!] (render! [:div [:b "a"] nil [:i "c"]])]
+      (let [d (.-firstChild c)]
+        (is (= 3 (count (kids d))) "three slots, one of them absent")
+        (is (dom/anchor? (nth (kids d) 1)))
+        (testing "the absent child can appear without disturbing its neighbours"
+          (let [before (nth (kids d) 2)]
+            (patch! [:div [:b "a"] [:em "B"] [:i "c"]])
+            (is (= 3 (count (kids d))))
+            (is (= "EM" (.-tagName (nth (kids d) 1))))
+            (is (identical? before (nth (kids d) 2))
+                "the following sibling is the same node — no index shifted"))))
+      (.remove c))))
+
+(deftest a-seq-child-splices-into-the-parents-children
+  (if-not (browser?)
+    (is true off-browser)
+    (let [[c] (render! [:ul (for [i (range 3)] [:li {:key i} (str i)])])]
+      (is (= ["0" "1" "2"] (texts (.-firstChild c))))
+      (.remove c))))
+
+(deftest a-fragment-child-splices-too
+  (if-not (browser?)
+    (is true off-browser)
+    (let [[c] (render! [:div [:b "a"] [:<> [:i "b"] [:em "c"]]])]
+      (is (= ["B" "I" "EM"] (mapv #(.-tagName %) (kids (.-firstChild c)))))
+      (.remove c))))
+
+;; ---------------------------------------------------------------------------
+;; Tier 2 — the equality cutoff
+;; ---------------------------------------------------------------------------
+
+(deftest an-identical-subtree-is-not-walked
+  (if-not (browser?)
+    (is true off-browser)
+    (let [row        [:li.row {:data-i 0} "unchanged"]
+          [c patch!] (render! [:ul row [:li "x"]])
+          ul         (.-firstChild c)
+          first-li   (nth (kids ul) 0)
+          text-node  (.-firstChild first-li)]
+      (patch! [:ul row [:li "y"]])
+      (is (identical? first-li (nth (kids ul) 0)))
+      (is (identical? text-node (.-firstChild first-li))
+          "the identical row's own text node was never replaced")
+      (is (= "y" (.-textContent (nth (kids ul) 1))) "and the changed sibling did change")
+      (.remove c))))
+
+(deftest an-equal-but-fresh-subtree-is-also-cut
+  (testing "structural sharing is a bonus, not the mechanism — a rebuilt but
+           `=` subtree bails just the same"
+    (if-not (browser?)
+      (is true off-browser)
+      (let [[c patch!] (render! [:div [:span {:class "a"} "same"]])
+            span       (.-firstChild (.-firstChild c))
+            text       (.-firstChild span)]
+        (patch! [:div [:span {:class (str "a")} (str "same")]])
+        (is (identical? span (.-firstChild (.-firstChild c))))
+        (is (identical? text (.-firstChild span)))
+        (.remove c)))))
+
+;; ---------------------------------------------------------------------------
+;; Tier 1 — the hole plan
+;; ---------------------------------------------------------------------------
+
+(deftest one-plan-serves-every-instance-of-a-shape
+  (if-not (browser?)
+    (is true off-browser)
+    (do
+      (template/reset-plans!)
+      (let [[c] (render! [:ul (for [i (range 50)]
+                                [:li.row {:key i :data-i i} [:span.cell (str i)]])])]
+        (is (= 2 (template/plan-count))
+            "one plan for the row and one for the cell — not one per instance")
+        (is (= 50 (count (kids (.-firstChild c)))))
+        (.remove c)))))
+
+(deftest a-templated-patch-writes-only-the-hole
+  (if-not (browser?)
+    (is true off-browser)
+    (let [[c patch!] (render! [:li.row {:data-i 0} [:span.lbl "cell "] [:span.cell "7"]])
+          li         (.-firstChild c)
+          lbl        (.-firstChild li)
+          cell       (.-lastChild li)
+          cell-text  (.-firstChild cell)]
+      (patch! [:li.row {:data-i 0} [:span.lbl "cell "] [:span.cell "8"]])
+      (is (identical? lbl (.-firstChild li)) "the untouched sibling is the same node")
+      (is (identical? cell-text (.-firstChild cell))
+          "and the changed text is the SAME Text node with a new value")
+      (is (= "8" (.-textContent cell)))
+      (.remove c))))
+
+(deftest a-shape-change-falls-out-of-tier-1-and-back-in
+  (if-not (browser?)
+    (is true off-browser)
+    (let [[c patch!] (render! [:div [:span "a"]])
+          div        (.-firstChild c)]
+      (patch! [:div [:span "a"] [:span "b"]])
+      (is (= 2 (count (kids div))) "the slow path handled the shape change")
+      (patch! [:div [:span "a"] [:span "c"]])
+      (is (= ["a" "c"] (texts div)) "and the next render is templated again")
+      (.remove c))))
+
+;; ---------------------------------------------------------------------------
+;; Tier 3 — keyed children against real nodes
+;; ---------------------------------------------------------------------------
+
+(defn- keyed [ks] (into [:ul] (map (fn [k] [:li {:key k} (name k)])) ks))
+
+(deftest a-reorder-recreates-no-node
+  (if-not (browser?)
+    (is true off-browser)
+    (let [[c patch!] (render! (keyed [:a :b :c]))
+          ul         (.-firstChild c)
+          [a b d]    (kids ul)]
+      (patch! (keyed [:c :a :b]))
+      (is (= ["c" "a" "b"] (texts ul)) "the order followed the keys")
+      (is (identical? d (nth (kids ul) 0)))
+      (is (identical? a (nth (kids ul) 1)))
+      (is (identical? b (nth (kids ul) 2)))
+      (.remove c))))
+
+(deftest an-insert-at-the-head-moves-nothing
+  (if-not (browser?)
+    (is true off-browser)
+    (let [[c patch!] (render! (keyed [:a :b :c]))
+          ul         (.-firstChild c)
+          before     (kids ul)]
+      (patch! (keyed [:z :a :b :c]))
+      (is (= ["z" "a" "b" "c"] (texts ul)))
+      (is (= before (subvec (kids ul) 1)) "the three survivors are the same nodes")
+      (.remove c))))
+
+(deftest a-delete-removes-exactly-one-node
+  (if-not (browser?)
+    (is true off-browser)
+    (let [[c patch!] (render! (keyed [:a :b :c]))
+          ul         (.-firstChild c)
+          [a _ d]    (kids ul)]
+      (patch! (keyed [:a :c]))
+      (is (= ["a" "c"] (texts ul)))
+      (is (identical? a (nth (kids ul) 0)))
+      (is (identical? d (nth (kids ul) 1)))
+      (.remove c))))
+
+(deftest a-hundred-row-rotation-keeps-every-node
+  (if-not (browser?)
+    (is true off-browser)
+    (let [ks         (mapv #(keyword (str "k" %)) (range 100))
+          [c patch!] (render! (keyed ks))
+          ul         (.-firstChild c)
+          before     (into #{} (kids ul))]
+      (patch! (keyed (into [(last ks)] (butlast ks))))
+      (is (= 100 (count (kids ul))))
+      (is (= before (into #{} (kids ul))) "every node survived the rotation")
+      (is (= "k99" (.-textContent (nth (kids ul) 0))))
+      (.remove c))))
+
+;; ---------------------------------------------------------------------------
+;; Props and the event trampoline
+;; ---------------------------------------------------------------------------
+
+(deftest a-changed-prop-is-written-and-a-vanished-one-cleared
+  (if-not (browser?)
+    (is true off-browser)
+    (let [[c patch!] (render! [:div {:title "a" :data-x "1"}])
+          n          (.-firstChild c)]
+      (patch! [:div {:title "b"}])
+      (is (= "b" (.getAttribute n "title")))
+      (is (nil? (.getAttribute n "data-x")) "the vanished prop was cleared")
+      (.remove c))))
+
+(deftest a-handler-is-replaced-without-touching-the-listener
+  (if-not (browser?)
+    (is true off-browser)
+    (let [seen       (atom [])
+          [c patch!] (render! [:button {:on-click (fn [_] (swap! seen conj :first))} "go"])
+          n          (.-firstChild c)]
+      (.click n)
+      (patch! [:button {:on-click (fn [_] (swap! seen conj :second))} "go"])
+      (.click n)
+      (is (= [:first :second] @seen) "the latest handler runs, and only it")
+      (is (some? (dom/handler-at n "click")) "the register holds the current handler")
+      (.remove c))))
+
+(deftest a-style-map-patches-declaration-by-declaration
+  (if-not (browser?)
+    (is true off-browser)
+    (let [[c patch!] (render! [:div {:style {:color "red" :font-size "12px"}}])
+          n          (.-firstChild c)]
+      (is (= "red" (.-color (.-style n))))
+      (is (= "12px" (.-fontSize (.-style n))))
+      (patch! [:div {:style {:color "blue"}}])
+      (is (= "blue" (.-color (.-style n))))
+      (is (= "" (.-fontSize (.-style n))) "the dropped declaration was removed")
+      (.remove c))))
+
+(deftest a-changed-head-replaces-the-node
+  (if-not (browser?)
+    (is true off-browser)
+    (let [[c patch!] (render! [:div [:span "x"]])
+          span       (.-firstChild (.-firstChild c))]
+      (patch! [:div [:b "x"]])
+      (is (= "B" (.-tagName (.-firstChild (.-firstChild c)))))
+      (is (not (identical? span (.-firstChild (.-firstChild c)))))
+      (.remove c))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/reconcile.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/reconcile.cljs
@@ -1,0 +1,175 @@
+(ns re-frame.bench.hicasso.arm2.reconcile
+  "KEYED RECONCILIATION AS PURE DATA — the floor tier of the PATCH
+  differ (rf2-2rtt6.10, architecture.md Arm 2).
+
+  architecture.md gives Arm 2 three differ tiers under one grammar:
+  template extraction with data-encoded hole plans as the static fast
+  path, a value-equality cutoff as the fallback, and **a full keyed diff
+  as the floor**. This namespace is that floor's decision half, and it is
+  deliberately separated from the DOM half.
+
+  ## Why the plan is data
+
+  A keyed reconciler is where renderers get their reputation for being
+  untestable: the algorithm and the mutation are usually the same loop,
+  so the only way to ask *which* nodes moved is to mount a page and
+  compare pointers. Here the algorithm answers that question on its own,
+  as a value:
+
+      (plan [:a :b :c] [:c :a :b])
+      ;; => {:removes [] :places [ … ]}
+
+  so `no-node-recreated-on-reorder` — one of the witness set's assertions
+  for `:keyed/insert-delete-reorder` — is a claim about a returned map
+  that a node runtime can check, not a DOM forensics exercise. The DOM
+  applier ([[re-frame.bench.hicasso.arm2.patch]]) contains no reordering
+  decisions at all; it walks this plan.
+
+  ## The plan's shape, and why `:places` runs backwards
+
+      {:removes [old-index …]                    ;; apply first
+       :places  [{:op :keep|:move|:mount, :new j, :old i-or-nil} …]}
+
+  `:places` is emitted in **descending `:new` order** because that is the
+  order in which an `insertBefore` applier needs it. Walking the new
+  children from the end, the node placed at `j+1` is the anchor for `j`,
+  so the applier carries exactly one variable — the last node it touched —
+  and never computes a live child index. Index arithmetic against a
+  parent that is being mutated is the classic source of off-by-one
+  reorder bugs; this plan removes the arithmetic rather than getting it
+  right.
+
+  `:keep` means *already in the right relative position* — the applier
+  patches it in place and moves no node. `:move` means the same node,
+  relocated with one `insertBefore`. `:mount` is the only op that builds.
+
+  ## Minimal moves, by construction
+
+  The stable set is a **longest increasing subsequence** of the reused old
+  indices (the algorithm Inferno and Vue 3 both settled on). That is what
+  makes a rotation of 100 rows cost one move rather than 99, and it is
+  why `:keep` is a distinct op rather than a `:move` that happens to be a
+  no-op: a reader can count the moves in the plan.
+
+  ## Unkeyed children
+
+  With no keys on either side the plan is positional — pair by index,
+  mount the surplus, remove the deficit. This is not a fallback that
+  loses correctness: an unkeyed list has told the renderer that position
+  *is* the identity. HD-006's no-default-memoization posture applies here
+  too; nothing guesses at identity from content."
+  (:refer-clojure :exclude [key]))
+
+;; ---------------------------------------------------------------------------
+;; Longest increasing subsequence
+;; ---------------------------------------------------------------------------
+
+(defn lis-positions
+  "The set of **positions in `xs`** forming one longest strictly
+  increasing subsequence of `xs`, where a `nil` entry is skipped (it is a
+  position with no old node — a mount — and cannot be part of a stable
+  run).
+
+  Patience sorting with a predecessor chain: O(n log n), one binary
+  search per entry. Public because it is the part of the algorithm worth
+  testing on its own."
+  [xs]
+  (let [n     (count xs)
+        prev  (js/Array. n)
+        tails #js []]
+    (dotimes [i n]
+      (when-some [v (nth xs i)]
+        (let [lo (loop [lo 0 hi (alength tails)]
+                   (if (< lo hi)
+                     (let [mid (bit-shift-right (+ lo hi) 1)]
+                       (if (< (nth xs (aget tails mid)) v)
+                         (recur (inc mid) hi)
+                         (recur lo mid)))
+                     lo))]
+          (aset prev i (when (pos? lo) (aget tails (dec lo))))
+          (if (< lo (alength tails))
+            (aset tails lo i)
+            (.push tails i)))))
+    (loop [acc #{}
+           i   (when (pos? (alength tails)) (aget tails (dec (alength tails))))]
+      (if (nil? i)
+        acc
+        (recur (conj acc i) (aget prev i))))))
+
+;; ---------------------------------------------------------------------------
+;; The plan
+;; ---------------------------------------------------------------------------
+
+(defn- positional-plan
+  "Pair by index. The unkeyed contract: position is identity."
+  [old-n new-n]
+  {:removes (vec (range new-n old-n))
+   :places  (into []
+                  (map (fn [j] (if (< j old-n)
+                                 {:op :keep :new j :old j}
+                                 {:op :mount :new j :old nil})))
+                  (reverse (range new-n)))})
+
+(defn- index-by-key
+  "key → first old position carrying it. First wins on a duplicate, which
+  makes a duplicated key degrade to *one* reused node and one fresh
+  mount rather than to two children fighting over one node."
+  [old-keys]
+  (persistent!
+   (reduce (fn [m i]
+             (let [k (nth old-keys i)]
+               (if (or (nil? k) (contains? m k)) m (assoc! m k i))))
+           (transient {})
+           (range (count old-keys)))))
+
+(defn plan
+  "Reconcile `old-keys` against `new-keys` — two vectors of child keys,
+  `nil` at an unkeyed position — into the plan described in the namespace
+  docstring.
+
+  When neither side carries a single key the plan is positional. As soon
+  as one key appears anywhere the keyed path runs: a `nil`-keyed child in
+  a keyed list matches nothing and mounts, which is the same rule React
+  and Reagent apply and the reason a partially-keyed list is a mistake
+  worth making visible in the plan."
+  [old-keys new-keys]
+  (let [old-n (count old-keys)
+        new-n (count new-keys)]
+    (if (and (not-any? some? old-keys) (not-any? some? new-keys))
+      (positional-plan old-n new-n)
+      (let [by-key   (index-by-key old-keys)
+            ;; reused[j] = the old position new child j reuses, or nil.
+            reused   (mapv (fn [k] (when (some? k) (get by-key k))) new-keys)
+            taken    (into #{} (keep identity) reused)
+            removes  (into [] (remove taken) (range old-n))
+            stable   (lis-positions reused)
+            places   (into []
+                           (map (fn [j]
+                                  (let [i (nth reused j)]
+                                    (cond
+                                      (nil? i)        {:op :mount :new j :old nil}
+                                      (stable j)      {:op :keep  :new j :old i}
+                                      :else           {:op :move  :new j :old i}))))
+                           (reverse (range new-n)))]
+        {:removes removes :places places}))))
+
+;; ---------------------------------------------------------------------------
+;; Reading a plan — for tests, and for the witness assertions
+;; ---------------------------------------------------------------------------
+
+(defn move-count
+  "How many nodes this plan relocates. The number
+  `:no-node-recreated-on-reorder` is really about: a reorder that mounts
+  nothing and moves few."
+  [{:keys [places]}]
+  (count (filter #(= :move (:op %)) places)))
+
+(defn mount-count
+  "How many nodes this plan builds."
+  [{:keys [places]}]
+  (count (filter #(= :mount (:op %)) places)))
+
+(defn reuse-count
+  "How many nodes this plan carries over — kept or moved."
+  [{:keys [places]}]
+  (count (remove #(= :mount (:op %)) places)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/reconcile.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/reconcile.cljs
@@ -139,7 +139,17 @@
       (positional-plan old-n new-n)
       (let [by-key   (index-by-key old-keys)
             ;; reused[j] = the old position new child j reuses, or nil.
-            reused   (mapv (fn [k] (when (some? k) (get by-key k))) new-keys)
+            ;; An old position is consumed at most ONCE: a key duplicated on
+            ;; the new side would otherwise have two children claiming one
+            ;; node, which is the same fight `index-by-key` settles on the
+            ;; old side.
+            reused   (loop [j 0 acc (transient []) used #{}]
+                       (if (>= j new-n)
+                         (persistent! acc)
+                         (let [k (nth new-keys j)
+                               i (when (some? k) (get by-key k))
+                               i (when (and (some? i) (not (used i))) i)]
+                           (recur (inc j) (conj! acc i) (if i (conj used i) used)))))
             taken    (into #{} (keep identity) reused)
             removes  (into [] (remove taken) (range old-n))
             stable   (lis-positions reused)

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/reconcile_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/reconcile_cljs_test.cljs
@@ -24,7 +24,7 @@
 (deftest lis-finds-a-longest-run
   (is (= #{0 1 2} (rc/lis-positions [0 1 2])))
   (is (= 1 (count (rc/lis-positions [2 1 0]))) "a full reversal has no run longer than one")
-  (is (= 4 (count (rc/lis-positions [0 8 1 2 3 9]))))
+  (is (= 5 (count (rc/lis-positions [0 8 1 2 3 9]))) "0 1 2 3 9 — the 8 is the odd one out")
   (is (= #{} (rc/lis-positions [])))
   (is (= #{} (rc/lis-positions [nil nil])) "a mount is never part of a stable run")
   (is (= #{1 3} (rc/lis-positions [nil 0 nil 5]))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/reconcile_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/reconcile_cljs_test.cljs
@@ -1,0 +1,125 @@
+(ns re-frame.bench.hicasso.arm2.reconcile-cljs-test
+  "The keyed reconciler's decisions, asserted as values (rf2-2rtt6.10).
+
+  `:keyed/insert-delete-reorder` in the witness set asserts
+  `identity-follows-the-key` and `no-node-recreated-on-reorder`. Both are
+  properties of the plan, so both are checked here — on a runtime with no
+  DOM at all, in milliseconds, on every PR — rather than only in the
+  browser suite where they would be visible as a pointer comparison and
+  nowhere else."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.bench.hicasso.arm2.reconcile :as rc]))
+
+(defn- ops
+  "The plan's placements in ascending new-index order, which reads the
+  way a person thinks about a list even though the applier wants them
+  backwards."
+  [plan]
+  (vec (reverse (:places plan))))
+
+;; ---------------------------------------------------------------------------
+;; The longest increasing subsequence
+;; ---------------------------------------------------------------------------
+
+(deftest lis-finds-a-longest-run
+  (is (= #{0 1 2} (rc/lis-positions [0 1 2])))
+  (is (= 1 (count (rc/lis-positions [2 1 0]))) "a full reversal has no run longer than one")
+  (is (= 4 (count (rc/lis-positions [0 8 1 2 3 9]))))
+  (is (= #{} (rc/lis-positions [])))
+  (is (= #{} (rc/lis-positions [nil nil])) "a mount is never part of a stable run")
+  (is (= #{1 3} (rc/lis-positions [nil 0 nil 5]))))
+
+;; ---------------------------------------------------------------------------
+;; Unkeyed children
+;; ---------------------------------------------------------------------------
+
+(deftest unkeyed-children-pair-by-position
+  (testing "same length — every slot is patched in place"
+    (let [p (rc/plan [nil nil nil] [nil nil nil])]
+      (is (= [] (:removes p)))
+      (is (= 3 (rc/reuse-count p)))
+      (is (= 0 (rc/mount-count p)))))
+  (testing "growing — the surplus mounts at the end"
+    (let [p (rc/plan [nil nil] [nil nil nil])]
+      (is (= [] (:removes p)))
+      (is (= [{:op :keep :new 0 :old 0}
+              {:op :keep :new 1 :old 1}
+              {:op :mount :new 2 :old nil}]
+             (ops p)))))
+  (testing "shrinking — the deficit is removed"
+    (let [p (rc/plan [nil nil nil] [nil])]
+      (is (= [1 2] (:removes p)))
+      (is (= [{:op :keep :new 0 :old 0}] (ops p))))))
+
+;; ---------------------------------------------------------------------------
+;; Keyed children
+;; ---------------------------------------------------------------------------
+
+(deftest an-unchanged-keyed-list-moves-nothing
+  (let [p (rc/plan [:a :b :c] [:a :b :c])]
+    (is (= [] (:removes p)))
+    (is (= 0 (rc/move-count p)))
+    (is (= 0 (rc/mount-count p)))
+    (is (= 3 (rc/reuse-count p)))))
+
+(deftest insertion-at-the-head-mounts-one-and-moves-none
+  (let [p (rc/plan [:a :b :c] [:z :a :b :c])]
+    (is (= [] (:removes p)))
+    (is (= 1 (rc/mount-count p)))
+    (is (= 0 (rc/move-count p)) "the three survivors keep their relative order")
+    (is (= {:op :mount :new 0 :old nil} (first (ops p))))))
+
+(deftest deletion-removes-exactly-the-missing-key
+  (let [p (rc/plan [:a :b :c] [:a :c])]
+    (is (= [1] (:removes p)))
+    (is (= 0 (rc/mount-count p)))
+    (is (= [{:op :keep :new 0 :old 0} {:op :keep :new 1 :old 2}] (ops p)))))
+
+(deftest a-reorder-recreates-nothing
+  (testing "identity follows the key, and the plan says so"
+    (let [p (rc/plan [:a :b :c] [:c :a :b])]
+      (is (= [] (:removes p)))
+      (is (= 0 (rc/mount-count p)) "no node is recreated on reorder")
+      (is (= 3 (rc/reuse-count p)))
+      (is (= 1 (rc/move-count p)) "one insertBefore, not two")))
+  (testing "a swap of the two ends"
+    (let [p (rc/plan [:a :b :c :d] [:d :b :c :a])]
+      (is (= 0 (rc/mount-count p)))
+      (is (= 2 (rc/move-count p))))))
+
+(deftest a-full-reversal-is-linear-in-moves-not-quadratic
+  (let [ks (vec (range 100))
+        p  (rc/plan ks (vec (reverse ks)))]
+    (is (= 0 (rc/mount-count p)))
+    (is (= 100 (rc/reuse-count p)))
+    (is (= 99 (rc/move-count p)) "a reversal is the worst case and it is n-1")))
+
+(deftest a-rotation-of-a-hundred-rows-costs-one-move
+  (let [ks (vec (range 100))
+        p  (rc/plan ks (into [99] (subvec ks 0 99)))]
+    (is (= 0 (rc/mount-count p)))
+    (is (= 1 (rc/move-count p))
+        "the whole point of the longest-increasing-subsequence stable set")))
+
+(deftest mixed-insert-delete-and-reorder
+  (let [p (rc/plan [:a :b :c :d :e] [:e :b :x :a])]
+    (is (= [2 3] (:removes p)) "c and d")
+    (is (= 1 (rc/mount-count p)) "x is new")
+    (is (= 3 (rc/reuse-count p)) "e, b and a survive")))
+
+(deftest a-nil-key-in-a-keyed-list-matches-nothing
+  (testing "it mounts rather than pairing by position — the same rule React applies"
+    (let [p (rc/plan [:a nil :c] [:a nil :c])]
+      (is (= 1 (rc/mount-count p)))
+      (is (= [1] (:removes p))))))
+
+(deftest a-duplicated-key-degrades-to-one-reuse
+  (testing "first wins, so two children never fight over one node"
+    (let [p (rc/plan [:a :a] [:a :a])]
+      (is (= 1 (rc/mount-count p)))
+      (is (= [1] (:removes p))))))
+
+(deftest places-run-backwards-so-the-applier-carries-one-anchor
+  (let [p (rc/plan [:a :b :c] [:c :b :a])]
+    (is (= [0 1 2] (mapv :new (reverse (:places p))))
+        "ascending when reversed — i.e. descending as emitted")))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/retention_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/retention_dom_cljs_test.cljs
@@ -1,0 +1,171 @@
+(ns re-frame.bench.hicasso.arm2.retention-dom-cljs-test
+  "BOUNDARY-EXCLUSIVE RETENTION, INVENTORIED (rf2-2rtt6.10).
+
+  validation.md is explicit that an arm does not get to claim an absence:
+  *before an arm is admitted, every boundary-exclusive token, callback,
+  hook cell, epoch, map entry, and edge membership is inventoried in the
+  1/3/7/20 heap ladder against the 0.4–0.5 KB target — honest
+  accounting, not a claimed absence.*
+
+  This file is the **census half** of that obligation, and it is
+  deliberately not a byte figure. It asserts what a boundary *is*, by
+  counting what mounting one adds and what unmounting one removes, so
+  that the term list a heap figure would be attributed to is established
+  independently of any instrument. The byte half needs the browser heap
+  instrument and is stated as remaining work rather than estimated here;
+  a number nobody measured is worth less than a term list nobody can
+  dispute.
+
+  ## The complete term list for one Arm 2 boundary, at R reads
+
+  | term | count | where it lives |
+  |---|---|---|
+  | boundary record | 1 map, 5 entries | `runtime/!boundaries` |
+  | id → record entry | 1 | `runtime/!boundaries` |
+  | forward edge set | 1 set of R keys | index `:b->subs` |
+  | reverse edge membership | R | index `:sub->bs` |
+  | live membership | 1 | index `:live` |
+  | node → id entry | 1 | `runtime`'s `WeakMap` |
+  | React hook cells | **0** | — |
+  | reactions / ref-counts | **0** | — |
+  | per-element instance objects | **0** | the previous hiccup *is* the previous tree |
+  | epoch / generation counters | **0** | invariant 5 is constructive |
+
+  The three zeros are the arm's whole architectural bet, and each is
+  asserted below rather than asserted in prose: a mounted boundary must
+  add **no** own-property expando to its element beyond the ones the
+  emitter's own contracts require (the shape stamp, the handler register,
+  the controlled model value), and those are *element* terms shared by
+  every renderer that patches DOM, not per-boundary ones.
+
+  Value-cache terms are per **unique subscription key**, not per
+  boundary, and are asserted here too, because a per-boundary reading of
+  them would flatter the arm exactly the way rf2-2rtt6.16 warned about."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.bench.hicasso.arm2.grid-witness :as grid]
+            [re-frame.bench.hicasso.arm2.runtime :as rt]
+            [re-frame.bench.hicasso.front.sub-index :as idx]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private off-browser "no DOM on this runtime — the census counts mounted boundaries")
+
+(defn- browser? []
+  (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
+
+(defn- container! []
+  (let [c (js/document.createElement "div")]
+    (.appendChild js/document.body c)
+    c))
+
+(defn- with-grid [n f]
+  (rt/reset-runtime!)
+  (let [c (container!)
+        teardown (grid/mount! c n)]
+    (try (f c) (finally (teardown) (.remove c) (rt/reset-runtime!)))))
+
+;; ---------------------------------------------------------------------------
+;; The census
+;; ---------------------------------------------------------------------------
+
+(deftest a-boundary-costs-exactly-the-terms-in-the-inventory
+  (if-not (browser?)
+    (is true off-browser)
+    (with-grid 10
+      (fn [_c]
+        (let [snap (idx/snapshot)]
+          (testing "one record and one live membership per boundary"
+            (is (= 11 (rt/boundary-count)) "ten cells plus the grid boundary")
+            (is (= 11 (count (:live snap)))))
+          (testing "one forward edge set per boundary"
+            (is (= 11 (count (:b->subs snap)))))
+          (testing "R reverse-edge memberships, R = 1 for a cell"
+            (is (= 10 (count (:sub->bs snap))) "ten distinct keys, one per cell")
+            (is (every? (fn [[_k readers]] (= 1 (count readers))) (:sub->bs snap))
+                "and one reader each — no amortisation across boundaries"))
+          (testing "the grid boundary reads nothing, and that is visible"
+            (is (some (fn [[_id ks]] (empty? ks)) (:b->subs snap)))))))))
+
+(deftest the-value-cache-is-per-unique-key-not-per-boundary
+  (testing "rf2-2rtt6.16's mandatory worst case: distinct queries, Q = E"
+    (if-not (browser?)
+      (is true off-browser)
+      (with-grid 10
+        (fn [_c]
+          (is (= 10 (count (rt/watched-keys)))
+              "ten cached values for ten distinct keys")
+          (is (= (into #{} (map (fn [i] [:grid/cell i])) (range 10))
+                 (rt/watched-keys))))))))
+
+(deftest a-boundary-holds-no-hook-cell-no-reaction-and-no-epoch
+  (testing "the three zeros — asserted as the shape of the record, because a
+           field that does not exist cannot be measured later"
+    (if-not (browser?)
+      (is true off-browser)
+      (with-grid 3
+        (fn [c]
+          (let [node (grid/cell-input c 1)
+                cell (.-parentNode node)
+                rec  (rt/boundary-of cell)]
+            (is (some? rec) "the cell's root node maps back to its boundary")
+            (is (= #{:id :view :props :hiccup :node} (set (keys rec)))
+                "five fields, and no sixth — no hook cell, no epoch, no reaction")))))))
+
+(deftest an-element-carries-only-the-emitters-own-expandos
+  (testing "there is no per-element instance object: the previous hiccup is
+           the previous tree, so a patched element holds only what the DOM
+           contracts need"
+    (if-not (browser?)
+      (is true off-browser)
+      (with-grid 3
+        (fn [c]
+          (let [input   (grid/cell-input c 1)
+                own     (set (js->clj (js/Object.keys input)))
+                ours    (into #{} (filter #(re-find #"^__hicasso" %)) own)
+                allowed #{"__hicassoOn" "__hicassoValue" "__hicassoChecked"
+                          "__hicassoFenced" "__hicassoComposing" "__hicassoSig"}]
+            (is (contains? ours "__hicassoOn") "the handler register")
+            (is (contains? ours "__hicassoValue") "the controlled model value")
+            (is (contains? ours "__hicassoFenced") "the composition fence")
+            (is (empty? (remove allowed ours))
+                (str "and nothing else the renderer put there: " (pr-str ours)))
+            (is (not-any? #(re-find #"[Ff]iber|[Rr]eact" %) own)
+                "and nothing React put there — React is not on this path")))))))
+
+;; ---------------------------------------------------------------------------
+;; Unmount removes exactly what mount added
+;; ---------------------------------------------------------------------------
+
+(deftest unmounting-returns-every-term
+  (if-not (browser?)
+    (is true off-browser)
+    (do (rt/reset-runtime!)
+        (let [c (container!)
+              teardown (grid/mount! c 10)
+              snap-before (idx/snapshot)]
+          (is (= 11 (count (:live snap-before))))
+          (teardown)
+          (let [snap (idx/snapshot)]
+            (is (zero? (rt/boundary-count)) "no record")
+            (is (empty? (:live snap)) "no live membership")
+            (is (empty? (:b->subs snap)) "no forward edge set")
+            (is (empty? (:sub->bs snap)) "no reverse edge membership")
+            (is (empty? (rt/watched-keys)) "no cached value")
+            (is (nil? (.-firstChild c)) "and no node"))
+          (.remove c)
+          (rt/reset-runtime!)))))
+
+(deftest the-shape-of-the-ladder-is-linear-in-boundaries
+  (testing "the census's own scaling check: the term counts a heap figure
+           would be divided by"
+    (if-not (browser?)
+      (is true off-browser)
+      (doseq [n [1 10 50]]
+        (with-grid n
+          (fn [_c]
+            (let [snap (idx/snapshot)]
+              (is (= (inc n) (count (:live snap))))
+              (is (= n (count (:sub->bs snap))))
+              (is (= n (count (rt/watched-keys)))))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/runtime.cljs
@@ -59,6 +59,45 @@
   they differ is a deep derived graph, and that is a measurement this arm
   owes rather than a claim it makes.
 
+  ## The read surface is the ambient collector (Surface B), and only that
+
+  Operator ruling, 2026-07-31: *\"Only surface B is acceptable from an
+  ergonomics point of view\"* — the grouped `use-subs` surface is below
+  the usability bar. This arm has no other surface to withdraw: [[sub]]
+  is an ordinary function call, legal inside a `when`, inside a `for`,
+  inside an inlined helper, anywhere the body reaches. There is no hook,
+  no fixed query collection, and nothing that has to be declared before
+  the body runs.
+
+  **The ownership state machine HD-002(a) asks for is trivial here, and
+  that is a tournament finding rather than a convenience.** The clause
+  asks how candidate reads survive a winning render and disappear after
+  an abandoned render, replay, or teardown. Under Arm 2 the question
+  mostly does not arise:
+
+  - There is **no abandoned render**. A body runs because [[commit!]] ran
+    it, synchronously, inside the commit; the patch follows in the same
+    extent and the DOM is updated before the call returns. There is no
+    scheduler that can throw the run away, no concurrent rendering, no
+    StrictMode double-invoke on the render path — React is not on this
+    path at all. Every body run is the winning one, by construction.
+  - So there is **no candidate set to arbitrate**, and therefore no
+    candidate ledger. The whole mechanism is: one mutable set is bound
+    for the body's dynamic extent, and when the body returns, the front
+    half's `record-reads` takes two set differences against the edges the
+    boundary already held. That is HD-002(b)'s *allowed edge-diff
+    operation*, and it is the entire post-body reconciliation — not a
+    generic dependency reconciler, not a per-read ledger, not a graph
+    walk.
+  - **Teardown** removes the edges outright ([[unmount-subtree!]] →
+    `idx/unmount!`), and a read arriving for a boundary that is no longer
+    live is ignored by the front half's own guard.
+
+  Lean-React must answer the same clause against a render model that
+  *can* abandon a render and *can* replay one. If Surface B turns out to
+  cost more there than here, that difference is architectural and belongs
+  in the P2 comparison rather than in a footnote.
+
   ## The boundary record
 
   One CLJS map per live boundary in one global map:
@@ -104,13 +143,37 @@
 (defonce ^:private !committing (atom false))
 (defonce ^:private !again      (atom false))
 
-(defonce stats
-  (atom {:commits 0 :body-runs 0 :sub-reads 0 :sub-computes 0
-         :dirty-boundaries 0 :snapshots-per-commit 0}))
+;; The counters are a plain JS object incremented in place, not an atom
+;; `swap!`ed. A `swap!` per subscription read would put a CAS loop and a
+;; map assoc on the hottest path this arm has, and an instrument that
+;; changes what it measures is the bench harness's first recorded fault
+;; class.
+(defonce ^:private counters
+  #js {:commits 0 :bodyRuns 0 :subReads 0 :subComputes 0
+       :dirtyBoundaries 0 :snapshotsPerCommit 0 :deferredCommits 0})
 
-(defn reset-stats! [] (swap! stats merge {:commits 0 :body-runs 0 :sub-reads 0
-                                          :sub-computes 0 :dirty-boundaries 0
-                                          :snapshots-per-commit 0}) nil)
+(defn- bump! [k] (unchecked-set counters k (inc (unchecked-get counters k))) nil)
+
+(defn stats
+  "The runtime's counters, as a map. Read by the witnesses; never by the
+  runtime."
+  []
+  {:commits             (unchecked-get counters "commits")
+   :body-runs           (unchecked-get counters "bodyRuns")
+   :sub-reads           (unchecked-get counters "subReads")
+   :sub-computes        (unchecked-get counters "subComputes")
+   :dirty-boundaries    (unchecked-get counters "dirtyBoundaries")
+   :snapshots-per-commit (unchecked-get counters "snapshotsPerCommit")
+   ;; How many times a dispatch arrived DURING a commit and was deferred to
+   ;; the commit loop's next turn instead of opening a nested commit. Fact
+   ;; (3) of the invariant-5 argument, counted rather than argued.
+   :deferred-commits    (unchecked-get counters "deferredCommits")})
+
+(defn reset-stats! []
+  (doseq [k ["commits" "bodyRuns" "subReads" "subComputes" "dirtyBoundaries"
+             "snapshotsPerCommit" "deferredCommits"]]
+    (unchecked-set counters k 0))
+  nil)
 
 (def ^:dynamic *snapshot*
   "The committed app-db this commit's reads resolve against. Nil outside
@@ -119,7 +182,13 @@
   nil)
 
 (def ^:private ^:dynamic *ran* nil)
-(def ^:private ^:dynamic *seen* nil)
+
+(def ^:private ^:dynamic *seen*
+  "A JS array of the snapshot values this commit's reads actually
+  resolved against, compared by **identity**. Value equality would hash
+  the whole app-db on every read, which is an instrument that changes
+  what it measures; identity is both cheaper and the stronger claim."
+  nil)
 
 (defn current-snapshot [] *snapshot*)
 
@@ -147,13 +216,13 @@
   computes once, against the same snapshot."
   [query-v]
   (idx/read! query-v)
-  (swap! stats update :sub-reads inc)
+  (bump! "subReads")
   (let [db (snapshot)
         v  (get @!values query-v miss)]
-    (when (some? *seen*) (vswap! *seen* conj db))
+    (when (and (some? *seen*) (not (.includes *seen* db))) (.push *seen* db))
     (if (identical? v miss)
       (let [computed (rf/compute-sub query-v db)]
-        (swap! stats update :sub-computes inc)
+        (bump! "subComputes")
         (swap! !values assoc query-v computed)
         computed)
       v)))
@@ -172,7 +241,7 @@
         (let [k (first ks)
               v (rf/compute-sub k db)
               o (get old k miss)]
-          (swap! stats update :sub-computes inc)
+          (bump! "subComputes")
           (recur (next ks)
                  (assoc! acc k v)
                  (if (or (identical? o miss) (not= o v)) (conj! dirty k) dirty)))))))
@@ -211,7 +280,7 @@
   event prop is lowered at the moment it is written, and it needs the
   same frame the body resolved."
   [id view props]
-  (swap! stats update :body-runs inc)
+  (bump! "bodyRuns")
   (first (idx/with-reads id (fn [] (view props)))))
 
 (defn- mount-boundary!
@@ -294,10 +363,11 @@
   (let [db (rf/app-db-value @!frame)]
     (binding [*snapshot* db
               *ran*      (volatile! #{})
-              *seen*     (volatile! #{})]
+              *seen*     #js []]
       (let [dirty (recompute-watched db)
             bs    (if (seq dirty) (idx/commit! dirty) #{})]
-        (swap! stats update :dirty-boundaries + (count bs))
+        (unchecked-set counters "dirtyBoundaries"
+                       (+ (unchecked-get counters "dirtyBoundaries") (count bs)))
         ;; Ascending id order is ancestor-first for a tree built top down,
         ;; and `*ran*` makes the order an optimization rather than a
         ;; correctness condition: a boundary an ancestor already re-ran is
@@ -305,8 +375,8 @@
         (doseq [id (sort bs)]
           (when (and (contains? @!boundaries id) (not (contains? @*ran* id)))
             (re-run! id nil)))
-        (swap! stats assoc :snapshots-per-commit (count @*seen*))))
-    (swap! stats update :commits inc))
+        (unchecked-set counters "snapshotsPerCommit" (alength *seen*))))
+    (bump! "commits"))
   nil)
 
 (defn commit!
@@ -319,7 +389,7 @@
   controlled input cannot observe a half-applied commit."
   []
   (if @!committing
-    (do (reset! !again true) nil)
+    (do (bump! "deferredCommits") (reset! !again true) nil)
     (do (reset! !committing true)
         (try
           (loop []
@@ -358,7 +428,7 @@
   (install!)
   (reset! !frame frame)
   (let [db   (rf/app-db-value frame)
-        node (binding [*snapshot* db *seen* (volatile! #{})]
+        node (binding [*snapshot* db *seen* #js []]
                (let [n (patch/mount-child element)]
                  (.appendChild container n)
                  n))
@@ -402,7 +472,7 @@
   (reset! (unchecked-get view "hicassoBody") new-body)
   (let [ids (->> @!boundaries vals (filter #(identical? view (:view %))) (map :id) sort)
         db  (rf/app-db-value @!frame)]
-    (binding [*snapshot* db *ran* (volatile! #{}) *seen* (volatile! #{})]
+    (binding [*snapshot* db *ran* (volatile! #{}) *seen* #js []]
       (doseq [id ids] (re-run! id nil))))
   nil)
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/runtime.cljs
@@ -98,6 +98,13 @@
   cost more there than here, that difference is architectural and belongs
   in the P2 comparison rather than in a footnote.
 
+  **The one real cost Surface B does impose here, and it is not obvious**:
+  the collector must stay open until the body's hiccup has been
+  *consumed*, not merely returned, because hiccup is lazy and a `for`'s
+  reads happen when the differ walks the children. See
+  [[with-collected-reads]] — the browser suite caught this, and it
+  applies to any renderer collecting ambient reads.
+
   ## The boundary record
 
   One CLJS map per live boundary in one global map:
@@ -273,15 +280,41 @@
     (cond-> (dissoc p :key)
       (seq children) (assoc :children children))))
 
-(defn- run-body
-  "Run one boundary body with the frame bound ambiently and the read
-  collector open. The frame binding spans the *patch* as well as the
-  body, because intent lowering happens during the patch — a changed
-  event prop is lowered at the moment it is written, and it needs the
-  same frame the body resolved."
-  [id view props]
-  (bump! "bodyRuns")
-  (first (idx/with-reads id (fn [] (view props)))))
+(defn- with-collected-reads
+  "Bind the front half's read collector for `f` — **the body AND the
+  patch that consumes its output** — and then apply the collected reads
+  to `id`'s edges.
+
+  ## Why the collector cannot close at the body's `return`
+
+  Hiccup is lazy. `(for [id ids] [:li (sub [:todo id])])` returns a lazy
+  seq, and its element expressions do not run when the body returns —
+  they run when something walks the children, which is the differ, a
+  moment later. A collector bound only for the body's own call therefore
+  records the reads in the `let` and **loses every read inside a `for`**:
+  the boundary's edge set comes out holding the list query and none of
+  the row queries, and the arm silently stops re-running on a row write.
+
+  The browser suite caught exactly that
+  (`collector_dom_cljs_test/a-read-inside-a-loop-is-legal-and-indexed`),
+  which is why the shape is written out here rather than assumed. It is a
+  **Surface B finding, not an Arm 2 one**: any renderer collecting
+  ambient reads has to keep the collector open until the hiccup has been
+  consumed, or forbid laziness — and forbidding laziness would forbid
+  `for`, which is the surface the operator ruled for.
+
+  Keeping it open is safe because a child boundary reached during the
+  patch opens its own binding for its own extent, so its reads go to it
+  and the parent's binding is restored on the way out.
+
+  This uses the front half's public seams (`idx/*collector*`,
+  `idx/record-reads!`) rather than `idx/with-reads`, which closes at the
+  body's return by design. Nothing in the shared front half is edited."
+  [id f]
+  (let [c      (volatile! #{})
+        result (binding [idx/*collector* c] (f))]
+    (idx/record-reads! id @c)
+    result))
 
 (defn- mount-boundary!
   "Mount one boundary element and return the single node it occupies."
@@ -292,11 +325,14 @@
     (idx/mount! id)
     (intent/with-frame dispatch!
       (fn []
-        (let [hiccup (run-body id view props)
-              node   (patch/mount-child hiccup)]
-          (.set node->boundary node id)
-          (swap! !boundaries assoc id {:id id :view view :props props :hiccup hiccup :node node})
-          node)))))
+        (with-collected-reads id
+          (fn []
+            (bump! "bodyRuns")
+            (let [hiccup (view props)
+                  node   (patch/mount-child hiccup)]
+              (.set node->boundary node id)
+              (swap! !boundaries assoc id {:id id :view view :props props :hiccup hiccup :node node})
+              node)))))))
 
 (defn- patch-boundary!
   "A parent re-rendered and reached this boundary with (possibly) new
@@ -334,13 +370,16 @@
       (when (some? *ran*) (vswap! *ran* conj id))
       (intent/with-frame dispatch!
         (fn []
-          (let [new-hiccup (run-body id view props)
-                node'      (patch/patch-child! parent node hiccup new-hiccup)]
-            (when-not (identical? node' node)
-              (.delete node->boundary node)
-              (.set node->boundary node' id))
-            (swap! !boundaries update id merge {:props props :hiccup new-hiccup :node node'})
-            node'))))
+          (with-collected-reads id
+            (fn []
+              (bump! "bodyRuns")
+              (let [new-hiccup (view props)
+                    node'      (patch/patch-child! parent node hiccup new-hiccup)]
+                (when-not (identical? node' node)
+                  (.delete node->boundary node)
+                  (.set node->boundary node' id))
+                (swap! !boundaries update id merge {:props props :hiccup new-hiccup :node node'})
+                node'))))))
     nil))
 
 (defn install!

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/runtime.cljs
@@ -1,0 +1,428 @@
+(ns re-frame.bench.hicasso.arm2.runtime
+  "THE PATCH RUNTIME — boundaries, the sub layer, and the commit
+  (rf2-2rtt6.10, architecture.md Arm 2).
+
+  Arm 2's one-sentence definition is *dirty boundaries re-run **inside
+  the commit** against the committed snapshot; an own keyed hiccup differ
+  applies the patch; React exists only at `defhost` islands.* This
+  namespace is the first and third clauses; [[patch]] is the second.
+
+  ## Invariant 5, by construction — the whole argument
+
+  The invariant is that every read in one update sees one snapshot. Arm 1
+  has to *build* that: React schedules renders, so a generation fence
+  keeps all reads within one render pass on one commit, and a
+  staged-stale CI witness guards the fence. Arm 2 has no fence, because
+  it has nothing to fence — the property falls out of three facts a
+  reader can check in this file:
+
+  1. **[[sub]] cannot read without a bound snapshot.** `*snapshot*` is
+     nil outside a commit and a read there is a loud error, not a fall
+     back to \"whatever the frame holds now\". There is no ambient
+     current-db path in this runtime at all.
+  2. **`*snapshot*` is bound in exactly two places** — [[mount-root!]]
+     and [[commit!]] — each binding it once, to one value, read once.
+  3. **[[commit!]] is non-reentrant.** A dispatch that arrives while a
+     commit is running does not nest: it raises a flag and the commit
+     loop takes another turn *after* the current one finishes. So no
+     second binding can appear inside the extent of the first.
+
+  Together: every read taken during one commit resolves against the same
+  value, and the property has no runtime cost — no generation counter,
+  no per-read staleness check, no fence to get wrong. The
+  `snapshots-per-commit` counter in [[stats]] is evidence, not
+  machinery: it is what the witness reads, and it is 1 because 1 is the
+  only value the three facts allow.
+
+  ## The sub layer: recompute at commit, cut on equality
+
+  Arm 2 subscribes to nothing. It has no reactions, no ref-counts, and no
+  reactive substrate on the view path: a commit recomputes each **watched
+  key** (a key some live boundary reads — the index's own domain) with
+  `rf/compute-sub` against the committed db and compares the result with
+  `=`. The keys whose values changed are the dirty set.
+
+  That is architecture.md's fourth front-half item taken literally
+  (*equality cutoff on subscription values at the existing sub layer;
+  unchanged hot reads perform no new attach/release*), and it is the
+  reason `zero-leaked-subscription-refcounts-after-teardown` is
+  structural for this arm rather than a test that passes: there is no
+  ref-count to leak. The value cache is rebuilt from the index's domain
+  every commit, so a key nobody reads any more is gone by construction
+  too.
+
+  The cost is honest and worth stating: **O(watched keys) recomputes per
+  commit**, where a reactive arm pays O(dirty subgraph). For layer-2 subs
+  reading `:db` — the census's overwhelming majority — the two are the
+  same set, because every db write invalidates every db-reading reaction
+  and Reagent recomputes them all before its own equality cutoff. Where
+  they differ is a deep derived graph, and that is a measurement this arm
+  owes rather than a claim it makes.
+
+  ## The boundary record
+
+  One CLJS map per live boundary in one global map:
+
+      {:id 7 :view <fn> :props {…} :hiccup […] :node <Element>}
+
+  Five fields, shared structure, no object graph. There is no hook cell,
+  no epoch, no subscription cell, no fiber, and — because the differ
+  keeps the previous hiccup as the previous tree — nothing per element
+  either. A boundary's whole exclusive retention is this map, its entry
+  in the index's two edge maps, and one `WeakMap` entry pointing its DOM
+  node back at its id. That inventory is what the heap ladder prices
+  against the 0.4–0.5 KB shell target.
+
+  ## `defview` is a function here, deliberately
+
+  [[view]] mints a boundary from a plain body function rather than
+  through a macro. The spike is measuring a runtime, not an authoring
+  surface: HD-002's three-rendering ergonomics verdict rides the grouped
+  and collector *surfaces*, which are Arm 1's dogfood work, and adding a
+  macro here would put a second uncompared authoring spelling into a
+  tournament whose whole value is that the arms differ in one place."
+  (:require [re-frame.bench.hicasso.arm2.controlled :as controlled]
+            [re-frame.bench.hicasso.arm2.patch :as patch]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.bench.hicasso.front.sub-index :as idx]
+            [re-frame.core :as rf]))
+
+(declare dispatch! commit! re-run!)
+
+;; ---------------------------------------------------------------------------
+;; State
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !frame      (atom nil))
+(defonce ^:private !boundaries (atom {}))
+(defonce ^:private !next-id    (atom 0))
+(defonce ^:private !values     (atom {}))
+(defonce ^:private !root       (atom nil))
+(defonce ^:private node->boundary (js/WeakMap.))
+
+(defonce ^:private !committing (atom false))
+(defonce ^:private !again      (atom false))
+
+(defonce stats
+  (atom {:commits 0 :body-runs 0 :sub-reads 0 :sub-computes 0
+         :dirty-boundaries 0 :snapshots-per-commit 0}))
+
+(defn reset-stats! [] (swap! stats merge {:commits 0 :body-runs 0 :sub-reads 0
+                                          :sub-computes 0 :dirty-boundaries 0
+                                          :snapshots-per-commit 0}) nil)
+
+(def ^:dynamic *snapshot*
+  "The committed app-db this commit's reads resolve against. Nil outside
+  a commit, which is what makes a read outside one a loud error rather
+  than a silently different answer."
+  nil)
+
+(def ^:private ^:dynamic *ran* nil)
+(def ^:private ^:dynamic *seen* nil)
+
+(defn current-snapshot [] *snapshot*)
+
+;; ---------------------------------------------------------------------------
+;; The sub layer
+;; ---------------------------------------------------------------------------
+
+(def ^:private miss #js {})
+
+(defn- snapshot []
+  (or *snapshot*
+      (throw (ex-info (str "A subscription was read outside a commit. "
+                           "[:rf.error/hicasso-read-outside-commit]")
+                      {:rf.error/id :rf.error/hicasso-read-outside-commit
+                       :where       'arm2.runtime/sub
+                       :reason      "There is no ambient current-db in this runtime — invariant 5 holds because a read without a bound snapshot is impossible."
+                       :recovery    :read-inside-a-boundary-body}))))
+
+(defn sub
+  "Read `query-v` from inside a boundary body. Records the edge on the
+  index and returns the value this commit's snapshot computes.
+
+  The read is a map lookup in the steady state: the commit has already
+  recomputed every watched key. A key this body is the first to read
+  computes once, against the same snapshot."
+  [query-v]
+  (idx/read! query-v)
+  (swap! stats update :sub-reads inc)
+  (let [db (snapshot)
+        v  (get @!values query-v miss)]
+    (when (some? *seen*) (vswap! *seen* conj db))
+    (if (identical? v miss)
+      (let [computed (rf/compute-sub query-v db)]
+        (swap! stats update :sub-computes inc)
+        (swap! !values assoc query-v computed)
+        computed)
+      v)))
+
+(defn- recompute-watched
+  "Rebuild the value cache from the index's own domain and return the set
+  of keys whose value changed. Rebuilding rather than updating is what
+  drops the keys nobody reads any more — the cache cannot outlive the
+  edges."
+  [db]
+  (let [watched (keys (:sub->bs (idx/snapshot)))
+        old     @!values]
+    (loop [ks (seq watched) acc (transient {}) dirty (transient #{})]
+      (if-not ks
+        (do (reset! !values (persistent! acc)) (persistent! dirty))
+        (let [k (first ks)
+              v (rf/compute-sub k db)
+              o (get old k miss)]
+          (swap! stats update :sub-computes inc)
+          (recur (next ks)
+                 (assoc! acc k v)
+                 (if (or (identical? o miss) (not= o v)) (conj! dirty k) dirty)))))))
+
+;; ---------------------------------------------------------------------------
+;; Boundaries
+;; ---------------------------------------------------------------------------
+
+(defn view
+  "Mint a boundary from a body function. The returned function is the
+  hiccup head; it carries its own body in a holder so an HMR swap can
+  replace the body without changing the identity the tree was built
+  from."
+  [view-id body-fn]
+  (let [!body (atom body-fn)
+        f     (fn [props] (@!body props))]
+    (unchecked-set f "hicassoBody" !body)
+    (unchecked-set f "hicassoViewId" (str view-id))
+    (codec/mark-boundary! f)))
+
+(defn view-id [view] (unchecked-get view "hicassoViewId"))
+
+(defn- boundary-props
+  "The props a boundary body sees: the element's props map without
+  `:key`, plus `:children` when the element carries any (HD-016)."
+  [form]
+  (let [p        (or (patch/props-of form) {})
+        children (patch/flatten-children form (patch/first-child-index form))]
+    (cond-> (dissoc p :key)
+      (seq children) (assoc :children children))))
+
+(defn- run-body
+  "Run one boundary body with the frame bound ambiently and the read
+  collector open. The frame binding spans the *patch* as well as the
+  body, because intent lowering happens during the patch — a changed
+  event prop is lowered at the moment it is written, and it needs the
+  same frame the body resolved."
+  [id view props]
+  (swap! stats update :body-runs inc)
+  (first (idx/with-reads id (fn [] (view props)))))
+
+(defn- mount-boundary!
+  "Mount one boundary element and return the single node it occupies."
+  [form]
+  (let [view  (nth form 0)
+        id    (swap! !next-id inc)
+        props (boundary-props form)]
+    (idx/mount! id)
+    (intent/with-frame dispatch!
+      (fn []
+        (let [hiccup (run-body id view props)
+              node   (patch/mount-child hiccup)]
+          (.set node->boundary node id)
+          (swap! !boundaries assoc id {:id id :view view :props props :hiccup hiccup :node node})
+          node)))))
+
+(defn- patch-boundary!
+  "A parent re-rendered and reached this boundary with (possibly) new
+  props. Re-running is the right default — HD-006 keeps React's
+  semantics, and the differ's tier 2 has already established that the
+  element is not `=` to last render's."
+  [node _old-form new-form]
+  (if-some [id (.get node->boundary node)]
+    (re-run! id (boundary-props new-form))
+    node))
+
+(defn unmount-subtree!
+  "Unmount every boundary at or under `node`. Unconditional on every
+  removal and every replacement, which is what makes the standing
+  teardown assertion structural."
+  [node]
+  (when-some [id (.get node->boundary node)]
+    (idx/unmount! id)
+    (swap! !boundaries dissoc id)
+    (.delete node->boundary node))
+  (loop [c (.-firstChild node)]
+    (when c
+      (let [next (.-nextSibling c)]
+        (unmount-subtree! c)
+        (recur next))))
+  nil)
+
+(defn- re-run!
+  "Re-run one boundary and patch its subtree in place. Returns the node
+  it now occupies."
+  [id props]
+  (if-some [{:keys [view node hiccup] :as b} (get @!boundaries id)]
+    (let [props  (or props (:props b))
+          parent (.-parentNode node)]
+      (when (some? *ran*) (vswap! *ran* conj id))
+      (intent/with-frame dispatch!
+        (fn []
+          (let [new-hiccup (run-body id view props)
+                node'      (patch/patch-child! parent node hiccup new-hiccup)]
+            (when-not (identical? node' node)
+              (.delete node->boundary node)
+              (.set node->boundary node' id))
+            (swap! !boundaries update id merge {:props props :hiccup new-hiccup :node node'})
+            node'))))
+    nil))
+
+(defn install!
+  "Hand the differ its three boundary operations. Idempotent."
+  []
+  (patch/set-boundary-ops! {:mount   mount-boundary!
+                            :patch   patch-boundary!
+                            :unmount unmount-subtree!})
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; The commit
+;; ---------------------------------------------------------------------------
+
+(defn- run-commit!
+  "One turn of the commit: recompute the watched keys against the
+  committed db, ask the index which boundaries that dirties, and re-run
+  them **here**, inside this extent, against this snapshot."
+  []
+  (let [db (rf/app-db-value @!frame)]
+    (binding [*snapshot* db
+              *ran*      (volatile! #{})
+              *seen*     (volatile! #{})]
+      (let [dirty (recompute-watched db)
+            bs    (if (seq dirty) (idx/commit! dirty) #{})]
+        (swap! stats update :dirty-boundaries + (count bs))
+        ;; Ascending id order is ancestor-first for a tree built top down,
+        ;; and `*ran*` makes the order an optimization rather than a
+        ;; correctness condition: a boundary an ancestor already re-ran is
+        ;; skipped, and one the ancestor's tier-2 cutoff skipped still runs.
+        (doseq [id (sort bs)]
+          (when (and (contains? @!boundaries id) (not (contains? @*ran* id)))
+            (re-run! id nil)))
+        (swap! stats assoc :snapshots-per-commit (count @*seen*))))
+    (swap! stats update :commits inc))
+  nil)
+
+(defn commit!
+  "Apply the committed state to the DOM.
+
+  Non-reentrant by design: a dispatch raised from inside a body, an
+  event handler, or a patch does not open a second commit inside the
+  first — it raises a flag and this loop takes another turn. That is
+  fact (3) of the invariant-5 argument, and it is also the reason a
+  controlled input cannot observe a half-applied commit."
+  []
+  (if @!committing
+    (do (reset! !again true) nil)
+    (do (reset! !committing true)
+        (try
+          (loop []
+            (reset! !again false)
+            (run-commit!)
+            (when @!again (recur)))
+          ;; The end-of-event restore. After this line the focused field
+          ;; reads what the model says — see arm2.controlled.
+          (controlled/converge-focused!)
+          (finally (reset! !committing false)))
+        nil)))
+
+(defn dispatch!
+  "**The synchronous door** (HD-019, transferred to the renderer). The
+  event drains, the commit recomputes, the dirty boundaries re-run, the
+  DOM is patched and the controlled fields converge — all inside the
+  browser's discrete event, before it returns.
+
+  This is the function [[intent/with-frame]] binds ambiently, so every
+  lowered event vector in the tree calls exactly this."
+  [event]
+  (rf/with-frame @!frame (rf/dispatch-sync event))
+  (commit!)
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; The root (HD-021(b))
+;; ---------------------------------------------------------------------------
+
+(defn mount-root!
+  "Associate a DOM node, a frame and a root element; render; return an
+  **idempotent teardown**.
+
+      (mount-root! {:container node :frame :app :element [my-view {}]})"
+  [{:keys [container frame element]}]
+  (install!)
+  (reset! !frame frame)
+  (let [db   (rf/app-db-value frame)
+        node (binding [*snapshot* db *seen* (volatile! #{})]
+               (let [n (patch/mount-child element)]
+                 (.appendChild container n)
+                 n))
+        torn (volatile! false)]
+    (reset! !root {:container container :node node})
+    (fn teardown []
+      (when-not @torn
+        (vreset! torn true)
+        (unmount-subtree! node)
+        (when (identical? container (.-parentNode node)) (.removeChild container node))
+        (reset! !values {})
+        (reset! !root nil))
+      nil)))
+
+(defn root-node [] (:node @!root))
+
+(defn reset-runtime!
+  "Drop every boundary, edge, cached value and root. The test fixture's
+  door; also what a root teardown leaves behind when a page holds one
+  root."
+  []
+  (reset! !boundaries {})
+  (reset! !values {})
+  (reset! !root nil)
+  (reset! !frame nil)
+  (reset! !committing false)
+  (reset! !again false)
+  (idx/reset-index!)
+  (reset-stats!)
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; HMR (HD-021(c))
+;; ---------------------------------------------------------------------------
+
+(defn swap-body!
+  "Replace a view's body without changing the identity the tree was built
+  from: the root, the frame and app-db survive, the new body is used, and
+  no subscription leaks because the boundary never unmounted."
+  [view new-body]
+  (reset! (unchecked-get view "hicassoBody") new-body)
+  (let [ids (->> @!boundaries vals (filter #(identical? view (:view %))) (map :id) sort)
+        db  (rf/app-db-value @!frame)]
+    (binding [*snapshot* db *ran* (volatile! #{}) *seen* (volatile! #{})]
+      (doseq [id ids] (re-run! id nil))))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Observation — for the witnesses
+;; ---------------------------------------------------------------------------
+
+(defn boundary-count [] (count @!boundaries))
+
+(defn watched-keys [] (set (keys @!values)))
+
+(defn boundary-ids [] (set (keys @!boundaries)))
+
+(defn boundary-of
+  "The boundary record whose node is `node`, or nil."
+  [node]
+  (when-some [id (.get node->boundary node)] (get @!boundaries id)))
+
+(defn force-commit!
+  "Run a commit without dispatching — the door a witness uses to apply a
+  write it made through some other path."
+  []
+  (commit!))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/runtime_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/runtime_dom_cljs_test.cljs
@@ -111,8 +111,10 @@
             (rt/dispatch! [:dogfood/toggle 1])
             (is (pos? (:deferred-commits (rt/stats)))
                 "the re-entrant commit was deferred, not nested")
-            (is (= 1 (:snapshots-per-commit (rt/stats)))
-                "and every read of the turn that ran still saw one snapshot")
+            (is (>= 1 (:snapshots-per-commit (rt/stats)))
+                "and no turn ever observed a second snapshot — the counter is
+                 the LAST turn's, and the deferred turn dirtied nothing, so
+                 0 and 1 are both the shape the claim allows and 2 is not")
             (is (true? (get-in (rf/app-db-value screen/frame-id) [:todos 1 :done?]))
                 "the write landed")
             (finally (teardown) (screen-t) (.remove c) (.remove screen-c)

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/runtime_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/runtime_dom_cljs_test.cljs
@@ -57,7 +57,7 @@
         (is (some? (.querySelector c "#new-todo")) "one controlled field")
         (is (= "20 left" (.-textContent (.querySelector c "#remaining"))))
         (is (= (vec (range 20)) (screen/row-ids c)))
-        (is (pos? (:sub-reads @rt/stats)) "and the boundaries read subscriptions")))))
+        (is (pos? (:sub-reads (rt/stats))) "and the boundaries read subscriptions")))))
 
 ;; ---------------------------------------------------------------------------
 ;; Invariant 5, by construction
@@ -75,25 +75,48 @@
         (rt/reset-stats!)
         (rf/with-frame screen/frame-id (rf/dispatch-sync [:dogfood/set-filter :done]))
         (rt/force-commit!)
-        (is (= 1 (:snapshots-per-commit @rt/stats))
+        (is (= 1 (:snapshots-per-commit (rt/stats)))
             "one distinct snapshot was observed across every read of the commit")
-        (is (pos? (:sub-reads @rt/stats)) "and there were reads to observe")))))
+        (is (pos? (:sub-reads (rt/stats))) "and there were reads to observe")))))
 
 (deftest a-dispatch-raised-inside-a-commit-does-not-nest
-  (testing "fact 3: the commit loop takes another turn instead of opening a
-           second binding inside the first"
+  (testing "fact 3: a dispatch that arrives while a commit is running is
+           DEFERRED to the loop's next turn — no second snapshot binding
+           appears inside the extent of the first"
     (if-not (browser?)
       (is true off-browser)
-      (with-screen 5
-        (fn [c]
-          ;; A row's toggle handler dispatches; the commit that applies it
-          ;; runs its own commit! — which must not nest.
-          (let [toggle (.querySelector c "#toggle-2")]
+      (do
+        (rt/reset-runtime!)
+        (let [armed (atom false)
+              ;; A body that re-enters the commit door from inside the commit
+              ;; that is running it. Contrived on purpose: reaching the
+              ;; reentrant door deliberately is the only way to assert what it
+              ;; does, and `dispatch!` reaches the very same door.
+              probe (rt/view ::probe
+                             (fn [_]
+                               (let [n (rt/sub [:dogfood/remaining])]
+                                 (when @armed
+                                   (reset! armed false)
+                                   (rt/force-commit!))
+                                 [:span.probe (str n)])))
+              c        (container!)
+              screen-c (container!)
+              screen-t (screen/mount! screen-c 5)
+              teardown (rt/mount-root! {:container c
+                                        :frame     screen/frame-id
+                                        :element   [probe {}]})]
+          (try
             (rt/reset-stats!)
-            (.click toggle)
-            (is (= 1 (:snapshots-per-commit @rt/stats)))
-            (is (true? (get-in (rf/app-db-value screen/frame-id) [:todos 2 :done?]))
-                "and the write landed")))))))
+            (reset! armed true)
+            (rt/dispatch! [:dogfood/toggle 1])
+            (is (pos? (:deferred-commits (rt/stats)))
+                "the re-entrant commit was deferred, not nested")
+            (is (= 1 (:snapshots-per-commit (rt/stats)))
+                "and every read of the turn that ran still saw one snapshot")
+            (is (true? (get-in (rf/app-db-value screen/frame-id) [:todos 1 :done?]))
+                "the write landed")
+            (finally (teardown) (screen-t) (.remove c) (.remove screen-c)
+                     (rt/reset-runtime!))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; :bulk/narrow-write
@@ -106,9 +129,9 @@
       (fn [_c]
         (rt/reset-stats!)
         (rt/dispatch! [:dogfood/edit-draft 42 "x"])
-        (is (= 1 (:dirty-boundaries @rt/stats))
+        (is (= 1 (:dirty-boundaries (rt/stats)))
             "one row's draft changed, so one row is dirty out of a hundred")
-        (is (= 1 (:body-runs @rt/stats)))))))
+        (is (= 1 (:body-runs (rt/stats))))))))
 
 (deftest a-broad-write-rebuilds-the-list-and-nothing-else
   (if-not (browser?)

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/runtime_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/runtime_dom_cljs_test.cljs
@@ -1,0 +1,229 @@
+(ns re-frame.bench.hicasso.arm2.runtime-dom-cljs-test
+  "THE COMMIT, THE INDEX AND THE LIFECYCLE — the runtime's own claims
+  (rf2-2rtt6.10).
+
+  Three witnesses from the roster land here:
+
+  - `:bulk/narrow-write` — `:exactly-one-boundary-re-ran`;
+  - `:abandoned/query-identity` — `:no-edge-from-the-abandoned-render`,
+    `:index-matches-the-winning-render`;
+  - `:lifecycle/strict-abandoned-teardown-hmr` —
+    `:zero-leaked-subscription-refcounts-after-teardown`,
+    `:unchanged-hot-read-performs-no-new-attach-or-release`,
+    `:hmr-preserves-root-frame-and-app-db`.
+
+  Plus the one claim that is Arm 2's alone: **invariant 5 holds by
+  construction**. The three facts the runtime's docstring names are each
+  asserted below — a read without a snapshot is an error, a commit's
+  reads all resolve against one value, and a dispatch raised inside a
+  commit does not open a second one."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.bench.hicasso.arm2.dogfood-screen :as screen]
+            [re-frame.bench.hicasso.arm2.runtime :as rt]
+            [re-frame.bench.hicasso.front.sub-index :as idx]
+            [re-frame.core :as rf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private off-browser "no DOM on this runtime — the runtime patches real nodes")
+
+(defn- browser? []
+  (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
+
+(defn- container! []
+  (let [c (js/document.createElement "div")]
+    (.appendChild js/document.body c)
+    c))
+
+(defn- with-screen [n f]
+  (rt/reset-runtime!)
+  (let [c (container!)
+        teardown (screen/mount! c n)]
+    (try (f c)
+         (finally (teardown) (.remove c) (rt/reset-runtime!)))))
+
+;; ---------------------------------------------------------------------------
+;; The screen mounts — the commit HD-014 starts the clock on
+;; ---------------------------------------------------------------------------
+
+(deftest the-dogfood-screen-mounts-a-list-a-controlled-field-and-its-reads
+  (if-not (browser?)
+    (is true off-browser)
+    (with-screen 20
+      (fn [c]
+        (is (= 20 (count (screen/row-nodes c))) "one list, twenty rows")
+        (is (some? (.querySelector c "#new-todo")) "one controlled field")
+        (is (= "20 left" (.-textContent (.querySelector c "#remaining"))))
+        (is (= (vec (range 20)) (screen/row-ids c)))
+        (is (pos? (:sub-reads @rt/stats)) "and the boundaries read subscriptions")))))
+
+;; ---------------------------------------------------------------------------
+;; Invariant 5, by construction
+;; ---------------------------------------------------------------------------
+
+(deftest a-read-without-a-snapshot-is-a-loud-error
+  (testing "fact 1: there is no ambient current-db path in this runtime"
+    (is (thrown-with-msg? js/Error #"outside a commit" (rt/sub [:dogfood/filter])))))
+
+(deftest every-read-in-one-commit-resolves-against-one-snapshot
+  (if-not (browser?)
+    (is true off-browser)
+    (with-screen 20
+      (fn [_c]
+        (rt/reset-stats!)
+        (rf/with-frame screen/frame-id (rf/dispatch-sync [:dogfood/set-filter :done]))
+        (rt/force-commit!)
+        (is (= 1 (:snapshots-per-commit @rt/stats))
+            "one distinct snapshot was observed across every read of the commit")
+        (is (pos? (:sub-reads @rt/stats)) "and there were reads to observe")))))
+
+(deftest a-dispatch-raised-inside-a-commit-does-not-nest
+  (testing "fact 3: the commit loop takes another turn instead of opening a
+           second binding inside the first"
+    (if-not (browser?)
+      (is true off-browser)
+      (with-screen 5
+        (fn [c]
+          ;; A row's toggle handler dispatches; the commit that applies it
+          ;; runs its own commit! — which must not nest.
+          (let [toggle (.querySelector c "#toggle-2")]
+            (rt/reset-stats!)
+            (.click toggle)
+            (is (= 1 (:snapshots-per-commit @rt/stats)))
+            (is (true? (get-in (rf/app-db-value screen/frame-id) [:todos 2 :done?]))
+                "and the write landed")))))))
+
+;; ---------------------------------------------------------------------------
+;; :bulk/narrow-write
+;; ---------------------------------------------------------------------------
+
+(deftest a-narrow-write-re-runs-exactly-one-boundary
+  (if-not (browser?)
+    (is true off-browser)
+    (with-screen 100
+      (fn [_c]
+        (rt/reset-stats!)
+        (rt/dispatch! [:dogfood/edit-draft 42 "x"])
+        (is (= 1 (:dirty-boundaries @rt/stats))
+            "one row's draft changed, so one row is dirty out of a hundred")
+        (is (= 1 (:body-runs @rt/stats)))))))
+
+(deftest a-broad-write-rebuilds-the-list-and-nothing-else
+  (if-not (browser?)
+    (is true off-browser)
+    (with-screen 20
+      (fn [c]
+        (rt/dispatch! [:dogfood/toggle 1])
+        (rt/reset-stats!)
+        (rt/dispatch! [:dogfood/set-filter :done])
+        (is (= 1 (count (screen/row-nodes c))) "one done to-do survives the filter")
+        (is (= [1] (screen/row-ids c)))))))
+
+;; ---------------------------------------------------------------------------
+;; The keyed witness, through the runtime
+;; ---------------------------------------------------------------------------
+
+(deftest a-reorder-through-the-screen-moves-nodes-rather-than-rebuilding-them
+  (if-not (browser?)
+    (is true off-browser)
+    (with-screen 10
+      (fn [c]
+        (let [before (into #{} (screen/row-nodes c))
+              row-7  (nth (screen/row-nodes c) 7)]
+          (rt/dispatch! [:dogfood/move 7 0])
+          (is (= 7 (first (screen/row-ids c))) "row 7 is now first")
+          (is (identical? row-7 (first (screen/row-nodes c))) "and it is the same node")
+          (is (= before (into #{} (screen/row-nodes c))) "no row was recreated"))))))
+
+(deftest removing-a-row-unmounts-its-boundary-and-drops-its-edges
+  (if-not (browser?)
+    (is true off-browser)
+    (with-screen 10
+      (fn [c]
+        (let [before (rt/boundary-count)]
+          (rt/dispatch! [:dogfood/remove 3])
+          (is (= 9 (count (screen/row-nodes c))))
+          (is (= (dec before) (rt/boundary-count)) "exactly one boundary left")
+          (is (empty? (idx/readers-of (idx/snapshot) [:dogfood/todo 3]))
+              "and nothing still reads the gone row's subscription"))))))
+
+;; ---------------------------------------------------------------------------
+;; :abandoned/query-identity
+;; ---------------------------------------------------------------------------
+
+(deftest an-unmounted-boundarys-edges-do-not-come-back
+  (testing "the front half's record-reads guard, exercised through the runtime:
+           a body run for a boundary that is gone records nothing"
+    (if-not (browser?)
+      (is true off-browser)
+      (with-screen 5
+        (fn [_c]
+          (rt/dispatch! [:dogfood/remove 2])
+          (idx/record-reads! 999 #{[:dogfood/todo 2]})
+          (is (empty? (idx/readers-of (idx/snapshot) [:dogfood/todo 2]))
+              "an abandoned render cannot resurrect an unmounted boundary's edges"))))))
+
+(deftest a-boundarys-query-identity-follows-its-props
+  (if-not (browser?)
+    (is true off-browser)
+    (with-screen 5
+      (fn [_c]
+        (let [snap (idx/snapshot)]
+          (is (seq (idx/readers-of snap [:dogfood/todo 3]))
+              "the index matches the winning render, key by key")
+          (is (empty? (idx/readers-of snap [:dogfood/todo 99]))
+              "and an unread key has no reader — no phantom boundary"))))))
+
+;; ---------------------------------------------------------------------------
+;; :lifecycle
+;; ---------------------------------------------------------------------------
+
+(deftest an-unchanged-hot-read-performs-no-new-attach-or-release
+  (testing "there is nothing to attach: this arm holds no reaction and no
+           ref-count, so the claim is that the edge set is untouched"
+    (if-not (browser?)
+      (is true off-browser)
+      (with-screen 10
+        (fn [_c]
+          (let [edges-before (:sub->bs (idx/snapshot))]
+            (rt/dispatch! [:dogfood/toggle 4])
+            (is (= edges-before (:sub->bs (idx/snapshot)))
+                "a hot re-run reading the same keys changed no edge")))))))
+
+(deftest teardown-leaves-nothing-behind
+  (if-not (browser?)
+    (is true off-browser)
+    (do (rt/reset-runtime!)
+        (let [c (container!)
+              teardown (screen/mount! c 10)]
+          (is (pos? (rt/boundary-count)))
+          (teardown)
+          (is (zero? (rt/boundary-count)))
+          (is (empty? (:sub->bs (idx/snapshot))) "no edge survives")
+          (is (empty? (:live (idx/snapshot))) "no boundary is live")
+          (is (empty? (rt/watched-keys)) "no subscription value is retained")
+          (is (nil? (.-firstChild c)) "and the container is empty")
+          (.remove c)
+          (rt/reset-runtime!)))))
+
+(deftest an-hmr-body-swap-keeps-the-root-the-frame-and-app-db
+  (if-not (browser?)
+    (is true off-browser)
+    (with-screen 5
+      (fn [c]
+        (let [db-before (rf/app-db-value screen/frame-id)
+              root      (rt/root-node)
+              original  @(unchecked-get screen/row-view "hicassoBody")]
+          (rt/swap-body! screen/row-view
+                         (fn [{:keys [id]}]
+                           (let [todo (rt/sub [:dogfood/todo id])]
+                             [:li.todo {:data-id id} [:b.swapped (:title todo)]])))
+          (is (= 5 (count (screen/row-nodes c))) "the list survived")
+          (is (some? (.querySelector c "b.swapped")) "the changed body is in use")
+          (is (identical? root (rt/root-node)) "the root node is the same")
+          (is (= db-before (rf/app-db-value screen/frame-id)) "app-db is untouched")
+          (is (seq (:sub->bs (idx/snapshot))) "and no subscription leaked")
+          ;; leave the view as we found it, since it is a def
+          (rt/swap-body! screen/row-view original))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/template.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/template.cljs
@@ -54,7 +54,12 @@
   - a `nil`/`false` child, whose presence is data even though the 1:1
     law gives it a stable slot — a conditional child changes what kind
     of node the slot holds, and a plan that assumed otherwise would
-    write text into a comment.
+    write text into a comment;
+  - a child declaring a **`:key`**, because a key says *position is not
+    identity* and a hole plan is positional. Patching slot 0's text
+    rather than moving the node that owns the key reads correctly and is
+    wrong: every piece of DOM state a row holds — focus, scroll, a
+    controlled field's live value — would end up on the wrong row.
 
   The refusal is per shape, not per tree: a `for` over rows refuses at
   the `<ul>` and every row inside it still runs tier 1.
@@ -102,6 +107,12 @@
 
 (defn- props-at [argv] (let [p (nth argv 1 nil)] (when (map? p) p)))
 
+(defn- keyed-child?
+  "Does this child declare a `:key`? See the refusal in [[sig-of!]]."
+  [c]
+  (and (vector? c)
+       (when-some [p (props-at c)] (contains? p :key))))
+
 (defn- sig-of!
   "Append `form`'s signature to `out`, or return `false` to refuse the
   whole shape. Recursive, depth-first, in the order the DOM will hold."
@@ -116,6 +127,18 @@
         (let [props (props-at form)
               from  (if props 2 1)
               n     (count form)]
+          ;; A CHILD that declares `:key` refuses the parent's shape. A key
+          ;; says *position is not identity*, and a hole plan is positional
+          ;; by construction: it would patch the text of slot 0 rather than
+          ;; move the node that owns that key, and every piece of DOM state
+          ;; a row holds — focus, scroll, a controlled field's live value —
+          ;; would end up on the wrong row. The keyed reconciler exists for
+          ;; exactly this, so the plan stands aside for it.
+          ;;
+          ;; The common keyed shape is a seq, which already refuses; this
+          ;; catches the literal keyed list, which is rarer and was wrong
+          ;; in silence until `patch_dom_cljs_test/a-reorder-recreates-no-node`
+          ;; asked which nodes survived rather than what the markup read.
           (.push out "(")
           (.push out (name head))
           (when props
@@ -124,7 +147,9 @@
             (if (>= i n)
               (do (.push out ")") true)
               (let [c (nth form i)]
-                (if (sig-of! out c) (recur (inc i)) false)))))))
+                (if (keyed-child? c)
+                  false
+                  (if (sig-of! out c) (recur (inc i)) false))))))))
 
     :else false))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/template.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/template.cljs
@@ -1,0 +1,289 @@
+(ns re-frame.bench.hicasso.arm2.template
+  "TIER 1 — TEMPLATE EXTRACTION WITH DATA-ENCODED HOLE PLANS
+  (rf2-2rtt6.10, architecture.md Arm 2: *template extraction with
+  data-encoded hole plans as the static-shape fast path, CSP-safe, no
+  `new Function`*).
+
+  ## What a plan is
+
+  A plan is what the renderer learns the *first* time it meets a static
+  hiccup shape, so that every later meeting is cheap:
+
+      {:sig      \"(li.row|(span.lbl|#)(span.cell|data-i|#))\"
+       :template <a detached DOM subtree, built once>
+       :holes    [{:kind :prop  :prop :data-i :props-path [2 1] :dom-path #js [1]}
+                  {:kind :text  :hiccup-path [1 1]              :dom-path #js [0 0]}
+                  …]}
+
+  Everything in it is **data** — vectors, keywords, small JS index
+  arrays, and one detached node. Nothing is compiled, nothing is
+  `eval`ed, no `new Function` is called, and the plan survives a strict
+  Content-Security-Policy because it is not code. Hicasso's fence is
+  explicit that a *compiler* would kill the programme (K6); template
+  extraction at runtime is the thing that gets a compiler's constant
+  factor without one, which is exactly why architecture.md puts it in
+  Arm 2's scope and out of Arm 1's.
+
+  ## Why the signature is the entry, and why it is stamped on the node
+
+  A hole plan is only usable when the renderer knows the shape did not
+  change. Computing that from scratch on both sides would cost two
+  structural walks per patch, which is the work the plan is trying to
+  avoid.
+
+  So the walk happens once — on the **new** tree, producing a signature
+  string — and the *old* side answers in O(1): the node was stamped with
+  the signature it was last rendered from ([[stamp!]]). A patch is tier 1
+  when the new signature is `=` to the node's stamp. One string compare.
+
+  The signature is deliberately cheap: it reads tag literals and prop
+  **keys**, never prop values, never children's values. It is therefore
+  linear in the shape and independent of the data — which is what makes
+  it affordable to compute on every render of every element.
+
+  ## What the plan refuses
+
+  A shape is templatable only when its structure cannot vary with data.
+  [[signature]] returns `nil` — and the differ falls to tier 3 — for:
+
+  - a **seq** child, whose length is data (this is the `for` case, and it
+    is the whole reason a keyed reconciler exists);
+  - a **fragment** child, which splices and therefore has no fixed slot
+    count;
+  - a **boundary** head, which owns its own subtree and its own commit;
+  - a `nil`/`false` child, whose presence is data even though the 1:1
+    law gives it a stable slot — a conditional child changes what kind
+    of node the slot holds, and a plan that assumed otherwise would
+    write text into a comment.
+
+  The refusal is per shape, not per tree: a `for` over rows refuses at
+  the `<ul>` and every row inside it still runs tier 1.
+
+  ## The two static positions
+
+  `:id` and `:class` are the only props the tag literal can contribute
+  to (`:div#main.wide`). When the author writes no `:id`/`:class` prop,
+  the shorthand is **baked into the template** and is not a hole at all.
+  When they do, the hole carries the shorthand so the merge happens
+  without the map allocation `merge-shorthand` would cost per element per
+  render. That allocation — one fresh map per element per render — is the
+  single biggest thing tier 1 removes from the steady-state path."
+  (:require [clojure.string :as str]
+            [re-frame.bench.hicasso.arm2.dom :as dom]
+            [re-frame.bench.hicasso.front.codec :as codec]))
+
+;; ---------------------------------------------------------------------------
+;; The stamp
+;; ---------------------------------------------------------------------------
+
+(def ^:private sig-key "__hicassoSig")
+
+(defn stamp!
+  "Record on `node` the signature it now matches (or clear it with nil)."
+  [node sig]
+  (unchecked-set node sig-key sig)
+  nil)
+
+(defn stamped [node] (unchecked-get node sig-key))
+
+(defn fits?
+  "Was `node` last rendered from this exact plan's shape? One string
+  comparison — the whole point of the stamp."
+  [plan node]
+  (and (some? plan) (= (:sig plan) (unchecked-get node sig-key))))
+
+;; ---------------------------------------------------------------------------
+;; The signature
+;; ---------------------------------------------------------------------------
+
+(defn- scalar? [x] (or (string? x) (number? x)))
+
+(defn- tag-head? [head] (and (or (keyword? head) (string? head) (symbol? head)) (not= :<> head)))
+
+(defn- props-at [argv] (let [p (nth argv 1 nil)] (when (map? p) p)))
+
+(defn- sig-of!
+  "Append `form`'s signature to `out`, or return `false` to refuse the
+  whole shape. Recursive, depth-first, in the order the DOM will hold."
+  [out form]
+  (cond
+    (scalar? form) (do (.push out "#") true)
+
+    (vector? form)
+    (let [head (nth form 0 nil)]
+      (if-not (tag-head? head)
+        false
+        (let [props (props-at form)
+              from  (if props 2 1)
+              n     (count form)]
+          (.push out "(")
+          (.push out (name head))
+          (when props
+            (reduce-kv (fn [_ k _] (when-not (= :key k) (.push out "|") (.push out (name k))) nil) nil props))
+          (loop [i from]
+            (if (>= i n)
+              (do (.push out ")") true)
+              (let [c (nth form i)]
+                (if (sig-of! out c) (recur (inc i)) false)))))))
+
+    :else false))
+
+(defn signature
+  "The shape signature of one hiccup element, or nil when the shape is
+  not templatable. See the namespace docstring for the refusal list."
+  [form]
+  (let [out #js []]
+    (when (sig-of! out form)
+      (.join out ""))))
+
+;; ---------------------------------------------------------------------------
+;; Building a plan
+;; ---------------------------------------------------------------------------
+
+(defn- shorthand-class
+  "The class string the tag literal contributes, or nil."
+  [parsed]
+  (.-className parsed))
+
+(defn- collect!
+  "Walk `form`, appending holes to `holes` and building the template
+  subtree. `elem-path` is the hiccup path to this form; `dom-path` is the
+  JS index array addressing the node inside the template."
+  [form elem-path dom-path holes]
+  (cond
+    (scalar? form)
+    (do (.push holes {:kind :text :hiccup-path elem-path :dom-path dom-path})
+        (js/document.createTextNode ""))
+
+    :else
+    (let [parsed     (codec/cached-parse (nth form 0))
+          props      (props-at form)
+          props-path (conj elem-path 1)
+          from       (if props 2 1)
+          node       (js/document.createElement (.-tag parsed))
+          shorthand  (shorthand-class parsed)
+          declared?  (and props (or (contains? props :class) (contains? props :className)))]
+      ;; The two static positions.
+      (when-some [id (.-id parsed)]
+        (when-not (and props (contains? props :id)) (.setAttribute node "id" id)))
+      (when (and shorthand (not declared?)) (.setAttribute node "class" shorthand))
+      (when declared?
+        (.push holes {:kind :class :props-path props-path :shorthand shorthand :dom-path dom-path}))
+      (when props
+        (reduce-kv (fn [_ k _]
+                     (when-not (or (= :key k) (= :class k) (= :className k))
+                       (.push holes {:kind :prop :prop k :props-path props-path :dom-path dom-path}))
+                     nil)
+                   nil
+                   props))
+      (loop [i from j 0]
+        (when (< i (count form))
+          (.appendChild node (collect! (nth form i) (conj elem-path i) (.concat dom-path #js [j]) holes))
+          (recur (inc i) (inc j))))
+      node)))
+
+(defn- build-plan [sig form]
+  (let [holes #js []
+        tmpl  (collect! form [] #js [] holes)]
+    {:sig sig :template tmpl :holes (vec holes)}))
+
+(defonce ^:private !plans (atom {}))
+
+(defn plan-for
+  "The plan for `form`'s shape, building it on first sight. Returns nil
+  when the shape is not templatable."
+  [form]
+  (when-some [sig (signature form)]
+    (or (get @!plans sig)
+        (let [plan (build-plan sig form)]
+          (swap! !plans assoc sig plan)
+          plan))))
+
+(defn plan-count "How many distinct shapes the cache holds. For the witnesses." [] (count @!plans))
+
+(defn reset-plans! "Empty the plan cache. Test fixture door." [] (reset! !plans {}) nil)
+
+;; ---------------------------------------------------------------------------
+;; Reading a hole's value
+;; ---------------------------------------------------------------------------
+
+(defn- node-at
+  "Walk `root` down a precomputed index path."
+  [root path]
+  (let [n (alength path)]
+    (loop [node root i 0]
+      (if (>= i n)
+        node
+        (recur (loop [c (.-firstChild node) k 0]
+                 (if (< k (aget path i)) (recur (.-nextSibling c) (inc k)) c))
+               (inc i))))))
+
+(defn- hole-value [hole form]
+  (case (:kind hole)
+    :text  (get-in form (:hiccup-path hole))
+    :class (let [props (get-in form (:props-path hole))]
+             (codec/class-names (:shorthand hole) (or (:class props) (:className props))))
+    :prop  (get (get-in form (:props-path hole)) (:prop hole))))
+
+(defn- write-hole!
+  [hole node value old-value lower]
+  (case (:kind hole)
+    :text  (set! (.-nodeValue node) (if (nil? value) "" (str value)))
+    :class (if (nil? value) (.removeAttribute node "class") (.setAttribute node "class" value))
+    :prop  (let [k (:prop hole)]
+             (dom/set-prop! node k (lower k value) old-value)))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Mount and patch
+;; ---------------------------------------------------------------------------
+
+(defn mount-from-plan!
+  "Clone the plan's template and write this instance's holes. One native
+  `cloneNode(true)` replaces the whole element/attribute construction
+  walk; only the holes are touched in JavaScript."
+  [plan form lower]
+  (let [root (.cloneNode (:template plan) true)]
+    (doseq [hole (:holes plan)]
+      (let [v (hole-value hole form)]
+        (when (some? v) (write-hole! hole (node-at root (:dom-path hole)) v nil lower))))
+    (stamp! root (:sig plan))
+    root))
+
+(defn patch-from-plan!
+  "Patch `node` from `old` to `new` through the plan: one pass over the
+  holes, comparing the author's own values, writing only where they
+  differ. No map is allocated, no prop name is converted, no child list
+  is realized, and nothing recurses."
+  [plan node old new lower]
+  (doseq [hole (:holes plan)]
+    (let [o (hole-value hole old)
+          v (hole-value hole new)]
+      (when-not (= o v)
+        (write-hole! hole (node-at node (:dom-path hole)) v o lower))))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Observation — for the tests and the witnesses, never for the runtime
+;; ---------------------------------------------------------------------------
+
+(defn hole-count [plan] (count (:holes plan)))
+
+(defn describe
+  "A plan, as printable data. Used by the tests to assert the extraction
+  rather than its effects."
+  [plan]
+  (when plan
+    {:sig   (:sig plan)
+     :holes (mapv (fn [h] (-> h (dissoc :dom-path) (assoc :dom-path (vec (:dom-path h))))) (:holes plan))}))
+
+(defn templatable?
+  "Does this shape get a plan at all? The refusal list, as a predicate."
+  [form]
+  (some? (signature form)))
+
+(defn sig-parts
+  "The signature split on its element boundaries — a legibility helper
+  for test failure output, not a runtime path."
+  [sig]
+  (when sig (str/split sig #"(?=\()")))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/template_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/template_cljs_test.cljs
@@ -1,0 +1,89 @@
+(ns re-frame.bench.hicasso.arm2.template-cljs-test
+  "TIER 1's ENTRY CONDITION — the shape signature and what it refuses
+  (rf2-2rtt6.10).
+
+  The signature is the only thing standing between a hole plan and a
+  wrong patch: a shape that says it matches when it does not will write
+  text into the wrong node, and it will do so *silently*, because tier 1
+  never looks at the tree it is patching. So the refusals are asserted
+  here, on a runtime with no DOM, and the plan's behaviour is asserted in
+  the browser suite.
+
+  Nothing in this file builds a plan — [[template/plan-for]] creates DOM
+  nodes. That split is deliberate: the decision half is testable
+  everywhere, the emission half is testable where DOM is."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.bench.hicasso.arm2.template :as t]))
+
+;; ---------------------------------------------------------------------------
+;; What the signature reads
+;; ---------------------------------------------------------------------------
+
+(deftest a-signature-reads-shape-and-never-data
+  (testing "two instances of one shape share a signature"
+    (is (= (t/signature [:li.row {:data-i 1} [:span "a"]])
+           (t/signature [:li.row {:data-i 2} [:span "b"]]))))
+  (testing "a different tag is a different shape"
+    (is (not= (t/signature [:li.row {:data-i 1}])
+              (t/signature [:ul.row {:data-i 1}]))))
+  (testing "a different prop KEY is a different shape"
+    (is (not= (t/signature [:li {:data-i 1}])
+              (t/signature [:li {:data-j 1}]))))
+  (testing "a different child count is a different shape"
+    (is (not= (t/signature [:div "a"])
+              (t/signature [:div "a" "b"]))))
+  (testing "the tag's own shorthand is part of the shape"
+    (is (not= (t/signature [:div.a "x"]) (t/signature [:div.b "x"])))))
+
+(deftest key-is-identity-not-shape
+  (testing "two rows differing only in :key share one plan"
+    (is (= (t/signature [:li {:key 1 :data-i 1}])
+           (t/signature [:li {:key 2 :data-i 1}])))))
+
+;; ---------------------------------------------------------------------------
+;; What the signature refuses
+;; ---------------------------------------------------------------------------
+
+(deftest a-seq-child-refuses-the-shape
+  (testing "a for-expansion's length is data, which is exactly what a plan may not assume"
+    (is (nil? (t/signature [:ul (list [:li "a"] [:li "b"])])))
+    (is (false? (t/templatable? [:ul (for [i (range 3)] [:li i])])))))
+
+(deftest a-conditional-child-refuses-the-shape
+  (testing "nil is a stable SLOT under the 1:1 law but not a stable KIND"
+    (is (nil? (t/signature [:div nil])))
+    (is (nil? (t/signature [:div [:b "x"] false])))))
+
+(deftest a-fragment-child-refuses-the-shape
+  (is (nil? (t/signature [:div [:<> [:b "x"]]]))))
+
+(deftest a-boundary-head-refuses-the-shape
+  (let [boundary (fn [_props] [:i "x"])]
+    (is (nil? (t/signature [:div [boundary {}]]))
+        "a boundary owns its own subtree and its own commit")
+    (is (nil? (t/signature [boundary {}])))))
+
+(deftest refusal-is-per-shape-not-per-tree
+  (testing "a list refuses; its rows do not"
+    (is (nil? (t/signature [:ul (list [:li.row {:data-i 0} "a"])])))
+    (is (some? (t/signature [:li.row {:data-i 0} "a"])))))
+
+;; ---------------------------------------------------------------------------
+;; Shapes that DO get a plan
+;; ---------------------------------------------------------------------------
+
+(deftest the-witness-shapes-are-templatable
+  (testing "the P0 list row"
+    (is (t/templatable? [:li.row [:span.lbl "cell "] [:span.cell {:data-i 3} "7"]])))
+  (testing "the controlled grid cell"
+    (is (t/templatable? [:div.cell
+                         [:label.lbl {:for "f3"} "Field 3"]
+                         [:input.inp {:id "f3" :type "text" :value "abc"
+                                      :on-input [:grid/edit 3 :re-frame.hicasso/value]}]])))
+  (testing "a deeply nested static shape"
+    (is (t/templatable? [:div [:div [:div [:span {:class "x"} "leaf"]]]]))))
+
+(deftest signature-parts-are-legible
+  (let [sig (t/signature [:li.row {:data-i 1} [:span "a"]])]
+    (is (string? sig))
+    (is (= 2 (count (t/sig-parts sig))) "one part per element")))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm2/template_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm2/template_cljs_test.cljs
@@ -36,9 +36,15 @@
     (is (not= (t/signature [:div.a "x"]) (t/signature [:div.b "x"])))))
 
 (deftest key-is-identity-not-shape
-  (testing "two rows differing only in :key share one plan"
+  (testing "a row's OWN :key is identity, not shape — two rows differing only
+           in :key share one plan"
     (is (= (t/signature [:li {:key 1 :data-i 1}])
-           (t/signature [:li {:key 2 :data-i 1}])))))
+           (t/signature [:li {:key 2 :data-i 1}]))))
+  (testing "but a keyed CHILD refuses the parent, because a hole plan is
+           positional and a key says position is not identity"
+    (is (nil? (t/signature [:ul [:li {:key :a} "a"] [:li {:key :b} "b"]])))
+    (is (some? (t/signature [:ul [:li "a"] [:li "b"]]))
+        "the same list without keys is positional by the author's own statement")))
 
 ;; ---------------------------------------------------------------------------
 ;; What the signature refuses


### PR DESCRIPTION
Three audit-reopened beads, one defect: the heap fan-out sweep (PR #7306) published its result as independently triangulated on a held-out rung `R2Q2B`, and `R2Q2B` was never held out. Everything downstream that leaned on that warrant inherited it.

Operator direction (Mike, 2026-07-31) defers new heap measurement — hicasso proceeds full throttle, measuring comes later — so this takes **route (ii)**: retract the overclaim, state the real warrant, mark what is provisional. **No new run was taken. No row, contrast, magnitude or gate number is edited.** Every stale claim is rewritten in place; nothing is appended beside a correction.

## The dataflow, exactly

In `p0-heap/additive-fit`, `R2Q2B` is the high-Q half of the R = 2 pair, so its measured value is half of

```
key-2  = (R2Q2B − R2QB2) / Δ(Q/B)
key-gap = (key-2 − key) / key
key-ok? = |key-gap| ≤ 15%
```

and `key-ok?` is a **mandatory** input to model selection — `(not (and linear? key-ok?))` returns no model and no prices. The rung decides whether any price is quotable at all. That is its **one role**, and the pages now say so.

The "held-out prediction" is not a second role but the other checks recombined, as an exact identity (`dx` = the R = 2 rungs' gap in Q/B, `ρ` = the R = 1 regression's residual at `R1Q2`):

```
M4 predicted − R2Q2B measured  =         ρ  +  dx·(key − key₂)
M3 predicted − R2Q2B measured  =  step + ρ  +  dx·(key − key₂)
```

Checked to the byte on the ROOTS=4 Reagent arm: `150 − 28 + 143 = +265 B` against a measured M3 miss of `2,806 − 2,541 = +265 B`; drop `step` and M4's is `+115 B` against `+115 B`. The residual carries no information the key check and the step check do not already carry.

Two further dependences are stated where they were previously called independent: the UIx edge term's "two independent identifications" share the whole R = 1 family (the intercept is fitted through it; the contrast subtracts `R1Q2`, a member of it), and the ladder's direct `R2Q2B − R1Q1` check shares `R1Q1` with the regression that supplies the key term.

## What each figure now rests on

| figure | stands on | status |
|---|---|---|
| UIx **2,935 B/read** [2,852–3,055] | the model-free direct Q = E contrast: `R2Q2B − R1Q1` = 2,887 B (B=1,200) and 2,970 B (B=300), mean 2,929 — 0.2% from the decomposition | **unchanged**, re-sourced |
| Reagent **943 B/read** [935–944] | untouched by both landings | **unchanged** |
| shell 501–524 B / 221–231 B | a measured `R0` rung. No model | stands |
| per-unique-key ~866 B / ~1,590 B | a direct slope at pinned edges, r² ≥ 0.9973 every round, re-priced from a disjoint pair, matched from **outside** the sweep by `rf2-2rtt6.12`'s ablation | stands — the strongest row |
| UIx per-edge ~1,345 B | a direct two-rung contrast; 1,344–1,345 B whichever model wins | **provisional** — ~50 B free to move between `edge` and `step` |
| Reagent per-edge | — | **stays refused**, provenance corrected |

The gate line's *band* survives too, and for a reason that never needed the withdrawn claim: the two direct readings are 2.9% apart and both sit inside `[2,852–3,055]`.

## The precommitted rule vs. the post-run judgement

`validation.md` said the criterion that refuses Reagent's per-edge price "was written down before the run". Two different things:

- **The precommitted criterion** (r² ≥ 0.98; key agreement within 15%; `|step|` ≤ 10% of the fan-out-1 boundary; the model reproduces `R2Q2B` within 10%) selected **M4** on both Reagent runs, and `additive-fit` reports `:edge` as the contrast value under M4 — so the rule as written would have **published 84 B / 80 B**. No "twice the smaller term" threshold appears anywhere in `additive-criterion`, and no threshold in it was moved after the run.
- **What the criterion did record**, before any prose: the two runs reach M4 by different failing checks, the step sits inside its band in one and outside it in the other, and the per-round verdicts flip 5-of-6 and 2-of-6.
- **The refusal itself** is the studio page's conservative post-run editorial call on that record. It is kept — it is the right call in the safe direction — and it is now labelled as a judgement rather than a rule's output.

## `rf2-2rtt6.25` removed from retained-heap causality

`.25` has not been shown to deliver a retained-heap benefit. Its single-build behaviour holds under the forced `flushSync` this harness uses; the audit of PR #7305 drove the shipped bare `createRoot().render` path and measured **2N** body constructions at N = 1, 300, 3,000 and 10,000. It is now a **tree stamp, not a cause**, on all five pages, and the public-schedule claim points at its **open** owner `rf2-2rtt6.25` instead of asserting a benefit. `rf2-2rtt6.13`'s retained-reaction term is untouched and remains supported — the explicit `3,552 − 769 = 2,783` correction is entirely `.13`'s.

## What an independent adjudication would require

Recorded on `rf2-5prok` and in the sweep's §7. The defect is structural: every rung the sweep measured is consumed by identification or by admissibility, so no rearrangement of existing data recovers a held-out test. It needs one more rung precommitted as untouchable (`R3` at fixed Q — which the Reagent step/edge split wants anyway), `key-ok?` re-sourced so the validation rung feeds no admissibility check, a prediction stated for it before the run, and the component rows re-adjudicated against it.

A compact pointer note is on `rf2-2rtt6.1` — the normative line's number did not change, its warrant did.

## Quality gates

| gate | result |
|---|---|
| `python -m mkdocs build --strict` | **exit 0**, 64.1 s |
| — coverage of this diff | **none.** `docs/design/hicasso/` is in `mkdocs.yml`'s `exclude_docs`; the build log mentions `design/hicasso` **0 times**. Cited for the rest of the site only |
| internal links + anchors, by hand | **68 checked across the 5 touched pages, 0 broken** |
| markdown tables, by hand | **43 tables / 198 body rows across the 5 touched pages, 0 ragged** |
| figures quoted two ways | cross-grepped 2,935 · 2,929 · 2,887 · 2,970 · 943 · 1,345 · 1,590 · 866 · 2,783 · 2,774 · 769 across all of `docs/design/hicasso/` — consistent everywhere. One relative-direction slip repaired (the sweep sits 5.5% **above** the corrected ladder slope; the page read "+5.5% below" it) |
| benchmarks | **not run, deliberately.** Two tournament arms have the box, and this PR measures nothing |

Docs only: 5 files, no code, no `.beads`, nothing under `ai/`.

Beads: `rf2-5prok` · `rf2-e3flf` · `rf2-hvl5s`.

## What remains

Three follow-up beads are filed under the epic, and this arm's bead stays open until the first two
land:

- **`rf2-2rtt6.26`** — the **islands bridge** (`defhost`, HD-011) and the runtime's own **error
  boundary** (HD-020(c)). This is the one witness-set row Arm 2 does not report:
  `:foreign/host-and-error-boundary`. Everything else in the roster is either witnessed here or is a
  clock/heap row.
- **`rf2-2rtt6.27`** — **the witness rows against the restated bar**. No clock row and no heap row is
  published here, deliberately and on two standing instructions. The retention *term list* those
  bytes will attach to is already established and asserted.
- **`rf2-2rtt6.28`** — the own renderer's **SSR / hydration story** (a design obligation; HD-020(d)
  puts SSR out of v0).

Two roster notes worth stating rather than leaving to inference. `:lifecycle/…`'s **StrictMode** rung
is not applicable to this arm in the form Arm 1 will meet it — there is no React on the render path to
double-invoke — so what is witnessed instead is the teardown and HMR halves, which are the ones with
teeth. And `:mount/list-and-form`, `:bulk/*` and `:scaling/*` are witnessed here for **correctness**
(what re-ran, which nodes survived, which edges exist) and not for their clocks, which belong to
`rf2-2rtt6.27`.


## Quality gates

Run from the worktree `C:/Users/miket/code/re-frame2-worktrees/arm2-2rtt6-10`, foreground, worktree-local
logs, nothing piped through `tail`/`grep` before its exit code was taken.

| gate | command | exit | result |
|---|---|---:|---|
| CLJS node unit | `npm run test:cljs` | 0 | Ran 12137 tests / 60542 assertions. **Every arm2 namespace green.** 4 failures, all in `re-frame.test-quiet-shadow-node-cljs-test` — see the note below |
| Browser DOM (the lane the hard gate lives in) | `npm run test:browser` | **0** | **Ran 920 tests containing 5743 assertions. 0 failures, 0 errors.** |
| Fast pre-checkin spine | `bash scripts/test-fast-pr.sh` | 1 | Static/drift checks **PASS**; test-lane bijection **PASS**; JVM roster↔CI bijection **PASS**; JVM `implementation/core` 2198 tests / 11341 assertions **0 failures**; JVM `implementation/freehand` 1288 tests / 8856 assertions **0 failures**; node tier 5 failures, again **only** in the self-spawn suite — see the note below |
| clj-kondo, CI invocation | the twelve `--lint` paths from `.github/workflows/lint.yml`, `--parallel --fail-level error` | — | **arm2 tree: errors 0, warnings 0.** Repo-wide: 10 errors, **none in this branch's diff** — see the note below |

### The TESTING.md matrix this diff derives

The diff is fifteen `.cljs` files under `implementation/freehand/test/re_frame/bench/hicasso/arm2/`.
Per `TESTING.md`:

- **CLJS node unit (`test:cljs`)** — the `:node-test` build's `cljs-test$` selector matches every
  `*_cljs_test.cljs` here, including the `*_dom_cljs_test.cljs` files, which degrade to a stated skip
  off a browser (the posture the other `*-dom` suites keep).
- **Browser unit (`test:browser`)** — the `:browser-test` build's
  `^(?!re-frame\.freehand\.bench\.).*-dom-cljs-test$` selector claims the five DOM suites. These
  namespaces are `re-frame.bench.hicasso.arm2.*`, so the negative lookahead does not exclude them and
  they ride the **PR-blocking correctness lane**, not the Freehand bench lane. `test-fast-pr.sh`'s
  test-lane bijection confirms it: *1742 test-defining files, 46 lanes, every file selected and every
  selector reached* — so neither an orphan nor a double-run is possible in silence.
- **JVM tier** — `implementation/freehand` is a rostered artefact, so its JVM suite runs alongside
  `implementation/core`.
- **Not in any tier of this diff**: bundle-isolation, production-elision, perf-bundle, adapter smokes,
  the Xray matrix, mcp-conformance — nothing here is on a production source path, adds a build id, or
  touches a bundle.

`mkdocs build --strict` is **not** cited: `docs/design/hicasso/**` is excluded in `mkdocs.yml`, so it
would validate nothing here. It is moot anyway — **this branch edits no documentation at all.**

### Note — every red assertion in both node runs is one flaky suite, and it is not this branch

All of them are `spawnSync … ETIMEDOUT` inside
`re-frame.test-quiet-shadow-node-cljs-test`. That suite re-spawns `out/node-test.js` as a child
process **from inside the running suite**, under a 60 s ceiling whose own docstring says *a correctly
exiting child returns in well under a second*; on this box the child exceeds it while 12 137 tests run
around it. Three separate runs failed **three different members** of that suite —
`unknown-arg-is-fatal-not-false-green` + `red-run-replays-buffered-console-warn`, then
`real-shadow-node-green-run-is-quiet`, then `large-red-replay-is-not-truncated` — which is a
load-dependent ceiling, not a break. Run on its own, every time:

```
node out/node-test.js --test=re-frame.test-quiet-shadow-node-cljs-test
Ran 15 tests containing 101 assertions.
0 failures, 0 errors.                                            exit 0
```

**Every `re-frame.bench.hicasso.arm2.*` namespace is green in both node runs and in the browser run.**

### Note — the ten repo-wide clj-kondo errors are not this branch

Every one is `Expected: throwable, received: …` in `implementation/epoch/…` and `implementation/ui/…`
test files. `git diff --name-only origin/main...HEAD` touches none of them. The local binary is
**clj-kondo v2025.10.23**; CI pins **2026.04.15**, and the pinned build is distributed from GitHub
releases rather than npm (npm's newest is the local one), so the CI version could not be reproduced
here — stated rather than glossed, because the brief asks for the pinned version and this is the
closest honest substitute. Linted on its own, **the arm2 tree is errors 0, warnings 0** on both the
subtree invocation and inside the repo-wide one.
