### PR TITLE
docs(hicasso): the M1 verdict follows its own table; no gate covers docs/design (rf2-ij36z, rf2-x5dvk)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,8 @@ Per-artefact tests run from each artefact directory via `clojure -M:test` (see e
 
 Docs build from repo root with `mkdocs build --strict` (config in `mkdocs.yml`).
 
+**`mkdocs build --strict` does not cover `docs/design/**`** — `mkdocs.yml`'s `exclude_docs` block deliberately keeps `design/freehand/` and `design/hicasso/` out of the site (they are working design records, not user-facing documentation), so never nominate it as the gate for an edit confined to that tree. `scripts/check_doc_slugs.py` *does* validate the tree's markdown link targets and heading anchors (it runs in the fast-PR spine and in `docs.yml`); nothing validates its tables, rendering or nav, so **the worker verifies anchors and table column counts by hand and says so in the PR body**.
+
 ## Architecture Overview
 
 **The spec is the artefact; the code is downstream.** The normative description of re-frame2 lives in [`spec/`](spec/) (~22K lines across 35+ documents); [`implementation/`](implementation/) is a CLJS reference that validates the spec end-to-end. See the repo-root [`README.md`](README.md) for the marketing-voice introduction and the project-layout map, and [`spec/README.md`](spec/README.md) for the spec index.

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -365,16 +365,21 @@ two to four times wider. Quote the interval when comparing a candidate against
 the centre; quote the run-mean spread when asking whether one run of a candidate
 has cleared the threshold.
 
-> **The two withdrawn magnitudes are restored, and no number is deleted.** M1's
-> `1.2301` and narrow's `1.1540` were withdrawn because a 3:2 design biased them,
-> their order strata were disjoint, and four estimates disagreed by ±6%. The
-> balanced ensemble answers all three: the design is even, the strata **overlap
-> in 9 of 10 runs on both rows**, and ten estimates now agree to ±4%. What is
-> published is a magnitude **with an interval**, which is what the measurement
-> supports; a bare four-decimal point never was. **rf2-2rtt6.1's operator hold on
-> quoting `1.2301` is not lifted here** — that bead's number is superseded rather
-> than rehabilitated, and only the operator amends the standard. See [the verdict
-> on M1's magnitude](#the-verdict-on-m1s-magnitude).
+> **No number is deleted — and one of the two restorations has itself been
+> overtaken.** M1's `1.2301` and narrow's `1.1540` were withdrawn because a 3:2
+> design biased them, their order strata were disjoint, and four estimates
+> disagreed by ±6%. The balanced ensemble answered all three: the design is even,
+> the strata **overlap in 9 of 10 runs on both rows**, and ten estimates agreed
+> to ±4%. That restored **narrow**, which still stands at `1.1754×`. It also
+> restored **M1**, at `1.2310×` — and [the post-`.25`
+> re-take](#the-re-take-on-the-post-25-tree-rf2-b0tz5) has since superseded that
+> in turn at **`1.0243×` [0.9937 – 1.0549]**, which contains 1.0 and so publishes
+> no direction at all. What is published either way is a magnitude **with an
+> interval**, which is what the measurement supports; a bare four-decimal point
+> never was. **rf2-2rtt6.1's operator hold on quoting `1.2301` is not lifted
+> here** — that bead's number is superseded rather than rehabilitated, and only
+> the operator amends the standard. See [the verdict on M1's
+> magnitude](#the-verdict-on-m1s-magnitude).
 
 **The pre-registered single run, printed because the design named it before it
 ran.** The commit that balanced the design nominated run 1 — reagent-start, the
@@ -1102,8 +1107,11 @@ UIx segment the page is not the page the [RED-ZONE
 table](#red-zone--clock-on-rf2-2rtt62s-witnesses) was measured on, and every
 record these runs wrote carries `:ratom-arm? true` and says so. For the record
 and for nothing else, the six runs read `M1` 0.9939 – 1.1184 and `broad`
-0.5808 – 0.6768, which straddle and sit below the published `1.2310` and
-`0.6291` respectively — a difference this design has no standing to interpret.
+0.5808 – 0.6768, which straddle and sit below the lines published at the time —
+~~`1.2310`~~ (since [superseded by the post-`.25`
+re-take](#the-re-take-on-the-post-25-tree-rf2-b0tz5) at `1.0243`, which this
+straddling range also contains) and `0.6291` respectively — a difference this
+design has no standing to interpret.
 
 ### Open items from this section
 
@@ -1131,13 +1139,16 @@ and for nothing else, the six runs read `M1` 0.9939 – 1.1184 and `broad`
 
 ## What the convergence changed
 
-Three of rf2-2rtt6.4's four clock verdicts do not survive the move onto
-rf2-2rtt6.2's witnesses. That is the answer to *how much did the mismatch
-matter*, and it is not small.
+rf2-2rtt6.4's clock verdicts largely do not survive the move onto rf2-2rtt6.2's
+witnesses: two of the four flipped outright, and the two that kept their
+direction moved their margin by a factor. That is the answer to *how much did
+the mismatch matter*, and it is not small. **One of those two flips has since
+been undone — by the landings rather than by the witness** — and the table
+records that in place.
 
 | question | rf2-2rtt6.4, on its own witnesses | converged, on rf2-2rtt6.2's | change |
 |---|---|---|---|
-| large-list mount | W1: **1.057×** [0.907 – 1.156] — indistinguishable | M1: **1.2310×** [1.199 – 1.293 across ten runs] — UIx slower | **verdict flips**: an indistinguishable row becomes a resolved one |
+| large-list mount | W1: **1.057×** [0.907 – 1.156] — indistinguishable | M1: ~~**1.2310×**~~ [1.199 – 1.293 across ten runs] → **1.0243×** [0.9937 – 1.0549] post-`.25` — indistinguishable | ~~**verdict flips**~~ — **the flip did not outlive the spine.** The converged row read `1.2310×` on the pre-`.13`/`.25` tree; [the re-take](#the-re-take-on-the-post-25-tree-rf2-b0tz5) returns it to parity, which is where `W1` sat all along |
 | ordinary-form mount | W3: **0.893×** [0.843 – 0.956] — UIx faster, disjoint, published as a threshold | M2: **1.0601×** [0.956 – 1.192] — indistinguishable, graded diagnostic | **verdict flips**, and so does the grade |
 | broad commit | U-broad: **0.838×** [0.760 – 0.953] — UIx faster | bulk broad: **0.6291×** [0.579 – 0.699] — UIx faster | same direction, **much larger margin** |
 | narrow commit | U-narrow: **1.536×** [1.226 – 1.876] — UIx slower, disjoint | bulk narrow: **1.1754×** [1.139 – 1.219] — UIx slower | same direction and both resolve, but **the margin over parity falls to about a third** — 0.18 against 0.54 |
@@ -1791,8 +1802,40 @@ appeared on a future witness.
 
 ### The verdict on M1's magnitude
 
-**The three measured reasons `1.2301` was withdrawn have all been answered**,
-and each was answered by the design rather than by a friendlier run:
+**What is published is `1.0243×`, 95% interval `0.9937 – 1.0549` on the mean,
+single runs landing in `0.998 – 1.039` — and because that interval contains 1.0,
+the row is INDISTINGUISHABLE FROM PARITY.** The magnitude is [the re-take on the
+post-`.25` tree](#the-re-take-on-the-post-25-tree-rf2-b0tz5): the converged
+`p0_converge_app` instrument, four independently launched six-round runs, each
+into a measured-quiet window, on a spine carrying both `rf2-2rtt6.13` and
+`rf2-2rtt6.25`. **`1.2310×` [1.2109 – 1.2510] is SUPERSEDED** — it was measured
+before those two landed, its ten run means are wholly disjoint from the
+re-take's four, and the L1 mount red zone it stood behind has **closed**.
+
+**A second instrument reaches the same place independently.** [The coldmount
+page](coldmount-double-build-priced.md) re-derived the same 901-element /
+300-boundary witness post-`.25` at **`1.0054×` [0.917 – 1.143]** on its own
+driver, under a different author. That is 1.9 points from `1.0243×`, with each
+interval containing the other's point estimate — a smaller gap than the +9.7%
+mount disagreement `rf2-2rtt6.21` measured between the same two authors'
+denominators — so [the parity reading is not an artefact of one
+harness](#the-converged-instrument-agrees-with-coldmount).
+
+**The interval's shape is load-bearing, so it is stated exactly.** Four run
+means — `0.9980 · 1.0391 · 1.0219 · 1.0382` — give a one-sample Student-t
+interval with `n − 1 =` **three** degrees of freedom and `t = 3.1824`, and
+`1.0243 ± 3.1824 × 0.009616` reproduces `0.9937 – 1.0549`. The **nine**-df
+correction [applied to the ten-run ensemble's
+intervals](#the-intervals-are-2-too-wide-and-the-cause-is-an-off-by-one-in-the-degrees-of-freedom)
+is a correction to a different quantity and does not belong here: at
+`t = 2.2622` these four runs would read `1.0025 – 1.0461`, which **excludes** 1.0
+and would invert the verdict every one of the four runs actually reports.
+
+**The three measured reasons `1.2301` was withdrawn were all answered — by the
+ten-run ensemble that has itself since been superseded.** Nothing in that record
+is retracted; it is kept because it is the line the re-take had to be measured
+against, and each objection was answered by the design rather than by a
+friendlier run:
 
 1. ~~*It is biased by a design the effect exploits* — 3:2 Reagent-first on a
    quantity that reads high Reagent-first.~~ **Gone by construction.** At six
@@ -1800,24 +1843,32 @@ and each was answered by the design rather than by a friendlier run:
    differ on 7 of 40 row-runs of the ensemble and only ever in the fourth
    decimal, where they are rounded independently.
 2. ~~*Its two strata do not meet* — [1.2388 – 1.3538] against
-   [1.1099 – 1.1417].~~ **The strata overlap in 9 of the 10 runs**, and the
-   instrument marks the row `:claim :magnitude` in those nine.
+   [1.1099 – 1.1417].~~ **The strata overlapped in 9 of the 10 runs**, and the
+   instrument marked the row `:claim :magnitude` in those nine.
 3. ~~*Four independent estimates do not agree to better than ±6%, and the newest
-   does not resolve at all.*~~ **Ten independent estimates now span
+   does not resolve at all.*~~ **Ten independent estimates spanned
    1.1989 – 1.2931**, a spread of ±3.8% about their mean, none of them
    straddling 1.0, and 59 of the 60 rounds behind them read above 1.0.
 
-**What is published is a magnitude with an interval: 1.2310×, 95% interval
-1.2109 – 1.2510 on the mean, single runs landing anywhere in 1.199 – 1.293.**
-That is the form the measurement supports. A bare four-decimal point never was —
-not because the point was wrong (`1.2301` sits inside the new interval, which is
-its own small vindication) but because a point carries no statement of how far a
-fresh run may legitimately land from it.
+**What moved was the spine, not the instrument, and that is measured rather than
+inferred.** `rf2-2rtt6.25` made a cold read build one reaction instead of two —
+a mount-path cost — and on the re-take [the bar's own denominator is held fixed
+and shown to be
+fixed](#what-moved-and-the-control-that-says-the-denominator-did-not): the
+`reagent-subs` leg reproduces to within 0.5% while the `uix-subs` leg falls
+16.2%. The ≈21-point tightening is a property of the UIx arm.
+
+**A magnitude still has to be published with an interval, and that is the one
+thing this section never had wrong.** A bare four-decimal point — `1.2301`,
+`1.2310` and `1.0243` alike — carries no statement of how far a fresh run may
+legitimately land from it. On this row the honest form of the answer is now a
+range that includes parity.
 
 **rf2-2rtt6.1's hold is not lifted here, and cannot be.** That bead is the
 operator's, `1.2301` is its number, and this page supersedes that number rather
-than rehabilitating it. What a worker may say is what the measurement now
-supports, and that is [written out below](#what-would-have-been-appended-to-rf2-2rtt61-had-it-not-been-size-locked)
+than rehabilitating it — and the re-take has now carried the row past it in the
+other direction. What a worker may say is what the measurement now supports, and
+that is [written out below](#what-would-have-been-appended-to-rf2-2rtt61-had-it-not-been-size-locked)
 in the form the standard would take.
 
 **The other three rows.** `0.6291×` **broad** is the strongest row on the page:
@@ -1980,18 +2031,28 @@ P0 table, verbatim. **Only the operator may amend the standard**; this is a
 statement of what the measurement supports, not an amendment.
 
 > **CLOCK RED-ZONES — amendment under RULING 1, restated on the balanced
-> design.** RULING 1 makes the red-zone threshold *the measured UIx ratio for
-> that witness family*. Ten independently launched six-round runs with the
-> starting segment counterbalanced 5/5 now stand behind each row, so each is a
-> **magnitude with an interval** rather than a point or a bare direction:
+> design and then on the post-`.25` spine.** RULING 1 makes the red-zone
+> threshold *the measured UIx ratio for that witness family*. Ten independently
+> launched six-round runs with the starting segment counterbalanced 5/5 stand
+> behind the three rows the post-`.25` re-take did not move; **M1 stands on the
+> four-run re-take instead**, because that is the only row the landings changed.
+> Either way each is a **magnitude with an interval** rather than a point or a
+> bare direction:
 >
-> - **M1 mount — `1.2310×`, 95% interval `1.2109 – 1.2510` on the mean, single
->   runs landing in `1.199 – 1.293`.** This **supersedes `1.2301×`**, which was
->   withdrawn as a magnitude and is not reinstated: the number the standard holds
->   was measured on a 3:2 design whose bias has since been removed by
->   construction, and it is replaced rather than restored. A candidate worse than
->   the run-mean spread is RED; inside it, the honest answer is where in the
->   spread it sits.
+> - **M1 mount — `1.0243×`, 95% interval `0.9937 – 1.0549` on the mean, single
+>   runs landing in `0.998 – 1.039`. The interval contains 1.0, so the row is
+>   INDISTINGUISHABLE FROM PARITY and the L1 mount red zone is CLOSED.**
+>   ~~`1.2310×` [1.2109 – 1.2510]~~ is **SUPERSEDED**: it was measured before
+>   `rf2-2rtt6.13` and `rf2-2rtt6.25` landed, and the [re-take on the post-`.25`
+>   tree](#the-re-take-on-the-post-25-tree-rf2-b0tz5) reads the same witness on
+>   the same instrument at parity — four runs, all four reporting
+>   `:direction :indistinguishable`, corroborated to 1.9 points by [the coldmount
+>   page](coldmount-double-build-priced.md)'s independent `1.0054×`. `1.2301×` is
+>   not reinstated either: it was withdrawn as a magnitude, and the row has since
+>   moved past it in the other direction. Because the threshold IS the measured
+>   ratio, **a candidate anywhere between `1.0243` and the old `1.2310` is now
+>   RED** where it would once have scored clear; inside the run-mean spread the
+>   honest answer is where in the spread it sits.
 > - **bulk narrow — `1.1754×`, interval `1.1582 – 1.1926`, runs `1.139 – 1.219`.**
 >   **Supersedes `1.1540×`**, also withdrawn. Its direction is now as strong as
 >   any row on the page: all 60 rounds above 1.0, all 20 order strata wholly

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -78,6 +78,14 @@ Two hard-won rules:
 - **Local-green ≠ CI.** "Green locally" usually means the subset the worker ran;
   the red gate is one it skipped (integration/live, a linter, a drift-check). The
   merge decision is CI's, not the worker's hand-off.
+- **Never nominate a gate that does not cover the surface being edited.** Site
+  builds, linters and test runners all carry exclusion lists, and a gate run over
+  an excluded path exits green having verified nothing — the same fail-open defect
+  worth hunting anywhere else, except it is now the brief telling the worker to
+  trust it. Read the exclusion config before naming the gate. Where a surface
+  genuinely has no automated coverage, the honest brief says *no automated gate
+  covers this surface; the worker verifies it by hand and says so in the PR body* —
+  and the PR body then reports what was checked and the counts.
 
 A skipped gate needs a one-line PR-body reason (e.g. "tool not installed locally;
 relying on CI"). A silent skip fails review.


### PR DESCRIPTION
Two beads, one theme: a claim that outlived its evidence, and a gate that never covered its surface.

## rf2-ij36z — the M1 verdict follows its own table

`docs/design/hicasso/studio/p0-converged-witness-set.md` carried the re-taken M1 row in its tables — mount **1.0243× [0.9937 – 1.0549]** on the post-`.25` spine, superseding 1.2310×, L1 mount red zone **CLOSED** — while its verdict prose and the `rf2-2rtt6.1` appendix block one screen away still published *"a magnitude with an interval: 1.2310×"*. A page that says one thing in its table and another in its verdict has no position at all.

**What is published now.** M1 mount is `1.0243×`, 95% interval `0.9937 – 1.0549` on the mean of four run means, converged instrument, post-`.25` spine. The interval **contains 1.0**, so the row is indistinguishable from parity and publishes no direction. `1.2310×` is struck **in place**, never appended beside; `1.2301×` is not reinstated either, and rf2-2rtt6.1's operator hold on it is untouched.

**The degrees of freedom are three, and that is load-bearing.** The re-take's interval is one-sample on four run means (`0.9980 · 1.0391 · 1.0219 · 1.0382`), so `n − 1 = 3` and `t = 3.1824`. Recomputed from the printed run means rather than trusted:

| quantity | value |
|---|---|
| mean | 1.024300 |
| se | 0.009616 |
| `t(3) = 3.1824` | **[0.9937, 1.0549]** — contains 1.0, matches the page |
| `t(9) = 2.2622` | [1.0025, 1.0461] — **excludes 1.0**, would invert the verdict |

The 9-df correction PR #7312 applied to the **ten-run ensemble's** intervals is a correction to a different quantity and does not belong here. The page states `three` and `t = 3.1824` in both places it mentions them (the re-take stamp and the off-by-one section) — confirmed, not 8 or 9 — and the verdict section now says so explicitly, with the counterfactual spelled out.

**Cross-checked against coldmount.** The coldmount page's independent `1.0054× [0.917 – 1.143]`, its own driver under a different author, is 1.9 points from `1.0243×` with each interval containing the other's estimate — a smaller gap than the +9.7% denominator disagreement `rf2-2rtt6.21` measured between the same two authors. Now stated in the verdict section, which previously did not mention it.

**Three further stale-as-current claims found while there**, all corrected in place rather than deleted:

| where | was | now |
|---|---|---|
| The *"two withdrawn magnitudes are restored"* callout — sitting one screen under the RED-ZONE table that already marks M1 superseded | both restorations stand | narrow's restoration stands at `1.1754×`; M1's has itself been overtaken at `1.0243×` |
| *"What the convergence changed"* table, large-list mount row | `M1: 1.2310× — UIx slower`, **verdict flips** to a resolved row | `1.2310×` struck → `1.0243×` post-`.25`, indistinguishable; the flip did not outlive the spine, and W1 sat at parity all along |
| The six-run ratom section | *"sit below the published `1.2310`"* | `1.2310` struck as superseded, with the note that the same range also contains `1.0243` |

The lead sentence of *What the convergence changed* said *"three of four verdicts do not survive"*; with M1's flip undone it is restated to what the table itself shows — two flipped, two kept direction with margins moving by a factor.

**Untouched on purpose:** the ensemble's own arithmetic (the observation table, View 1 / View 2, the two-estimator comparison, the `threshold (10)` row). It was a sound measurement of the spine it ran on and is what the re-take had to be measured against. The other three rows are likewise untouched — the re-take explicitly does **not** restate them, so `0.6291×`, `1.1754×` and `1.0601×` remain current. No test file was touched.

## rf2-x5dvk — no site gate covers `docs/design`

`mkdocs.yml`'s `exclude_docs` block lists `design/freehand/` and `design/hicasso/`, so `mkdocs build --strict` validates nothing under `docs/design/**`. Many Hicasso docs PRs this session cited it as *the* gate for edits confined to that tree.

**The exclusion is deliberate and stays** (operator, 2026-07-31): these are working design records, not user-facing documentation. Publishing them was never on the table. The defect is in the briefs, not the config, so the fix is guidance — no new script, no new CI job, per the operator's downward revision of the original recommendation.

Added in the two places dispatch guidance actually lives:

- **`CLAUDE.md`**, beside the existing mkdocs line, where a worker looks up the docs gate and where it would otherwise read as covering everything under `docs/`.
- **`docs/the-mayor-method/dispatch-prompt-template.md`**, as a third rule under *Quality gates — the discipline*, stated project-agnostically: read the exclusion config before naming a gate; where a surface has no automated coverage, say *no automated gate covers this surface; the worker verifies it by hand and says so in the PR body* — and have the PR body report the counts.

**The cheap half needed no change, because it is already done.** `scripts/check_doc_slugs.py` takes `docs` as a scan root and excludes only `docs/spec`, `docs/migration` and a handful of directory *names* (`findings`, `node_modules`, `site`, `.git`, `.beads`, `ai`, `__pycache__`) — none of which match `design/`. It therefore already walks `docs/design/**`: **64 of its 644 scanned files live there**, including every page in the Hicasso studio tree. It runs in `scripts/test-fast-pr.sh` and in `docs.yml`, whose `docs/**` path filter a design-tree PR trips.

Verified by **mutation**, not by reading the source. A deliberate broken same-page anchor appended to the page under edit:

```
1 broken anchor link(s) found:
  BROKEN ANCHOR: docs\design\hicasso\studio\p0-converged-witness-set.md:2152 -> #no-such-anchor-on-this-page
```

exit **1**, naming the file and line; exit **0** again once reverted. So link targets and heading anchors in that tree **are** gated. What is not gated is table shape, rendering and nav — which is exactly what the new guidance tells the worker to check by hand.

`check_readme_links.py` needs no change either: it deliberately skips READMEs under the roots `check_doc_slugs.py` already walks, `docs/` among them, to avoid double coverage.

## Quality gates

**`python -m mkdocs build --strict` — exit 0. It does NOT cover the hicasso page this PR edits.** That is not an inference; the gate's own log says so, for the sibling excluded tree:

```
INFO - Doc file 'spec/004-Views.md' contains a link to
       'design/freehand/decisions/D010-...md' which is excluded from the built site.
```

It is run and reported here only because this PR also touches `CLAUDE.md` and `docs/the-mayor-method/`, and to prove the rest of the site still builds.

| gate | scope | exit |
|---|---|---|
| `python -m mkdocs build --strict` | whole site **minus `docs/design/**`** | **0** |
| `python scripts/check_doc_slugs.py --verbose` | 644 files **including** `docs/design/**` — the real gate on the edited page | **0** (`no broken links`) |
| `python scripts/check_readme_links.py --ci` | README corpus | **0** |
| mutation check on `check_doc_slugs.py` | teeth, on the edited page itself | **1** when mutated, **0** reverted |

**By-hand verification of `p0-converged-witness-set.md`**, since no site gate covers it — counts as measured on the final file:

| property | count | result |
|---|---|---|
| rendered fragment ids on the page | 57 | — |
| same-page `#anchor` links | 38 | **38 / 38 resolve** |
| cross-page `file.md#anchor` links | 1 | **1 / 1 resolves** |
| markdown tables | 57 | **0 ragged** — every body and delimiter row matches its header's column count |

Not run: `npm run test:script-policy` — neither checker script was modified, and no script was added.
