### PR TITLE
docs(hicasso): the fan-out warrant stated honestly; .25 removed from heap causality (rf2-5prok, rf2-e3flf, rf2-hvl5s)

### DIFF
--- a/docs/design/hicasso/studio/README.md
+++ b/docs/design/hicasso/studio/README.md
@@ -126,19 +126,25 @@ required) and Reagent **943 B/read** (worse with no named paper path down is K3
 territory; between the two is "UIx-rule cleared, K3 open", never plain green).
 
 **Heap absolutes published before 2026-07-31 predate two spine landings, and
-the UIx gate line has been restated on the post-landing tree.**
-`rf2-2rtt6.13` (`9df5094816`) stopped retaining a disposed render-phase
-reaction — **−769 B per unique query key** on the UIx spine — and
-`rf2-2rtt6.25` (`f784ab0adb`) landed the hook-scoped provisional hand-off, so a
-cold read now builds one reaction rather than two. Every UIx heap absolute on
-the ladder and on the frontier arm was measured before both. The
-[fan-out sweep](heap-fan-out-sweep.md) is the first heap page measured after
-them, and it prices the difference: at fan-out 1 the UIx/Reagent retained-heap
-ratio moves from ~2.44× to **~1.97×**. On Mike's ruling of 2026-07-31 (option
-(a), `rf2-e3flf`) the UIx per-read gate line was restated from **3,552 B/read**
-to **2,935 B/read** rather than stamped historical — a line measured on a spine
-that no longer ships is looser than the tree warrants, and loose is the unsafe
-direction for a gate. The arithmetic and its three cross-checks are in
+the UIx gate line has been restated on the post-landing tree.** The landing that
+moves retained heap is `rf2-2rtt6.13` (`9df5094816`), which stopped retaining a
+disposed render-phase reaction — **−769 B per unique query key** on the UIx
+spine. `rf2-2rtt6.25` (`f784ab0adb`) landed the hook-scoped provisional hand-off
+in the same window and is a **tree stamp rather than a heap cause**: its single
+build holds under a forced synchronous commit, while the audit of PR #7305
+measured 2N on the shipped bare `createRoot().render` path, so no retained-heap
+delta from it is established and none is attributed. That is open on
+`rf2-2rtt6.25`. Every UIx heap absolute on the ladder and on the frontier arm
+was measured before both. The [fan-out sweep](heap-fan-out-sweep.md) is the
+first heap page measured after them, and it prices `.13`'s difference: at
+fan-out 1 the UIx/Reagent retained-heap ratio moves from ~2.44× to **~1.97×**.
+On Mike's ruling of 2026-07-31 (option (a), `rf2-e3flf`) the UIx per-read gate
+line was restated from **3,552 B/read** to **2,935 B/read** rather than stamped
+historical — a line measured on a spine that no longer ships is looser than the
+tree warrants, and loose is the unsafe direction for a gate. **That line rests
+on a direct two-point contrast at Q = E, not on an independent triangulation**;
+the arithmetic, and an explicit account of which readings are independent of
+each other, are in
 [the ladder's §5](reads-per-boundary-heap-ladder.md#5-what-this-hands-the-programme).
 Reagent's 943 B/read is unmoved: neither landing goes near the ratom path.
 Compare heap absolutes across that line only with the correction stated.

--- a/docs/design/hicasso/studio/heap-fan-out-sweep.md
+++ b/docs/design/hicasso/studio/heap-fan-out-sweep.md
@@ -11,6 +11,22 @@ budget rows — the shell / per-edge / per-unique-key numbers that may not enter
 prices the terms. [§6](#6-what-this-unblocks) says which rows are unblocked and
 which one is refused.
 
+**Warrant correction, 2026-07-31 — the held-out claim is withdrawn.** This
+page's first revision advertised `R2Q2B` as a rung *held out of every
+identification* and presented the model as validated by predicting it. The audit
+of PR #7306 found that the adjudicator gives `R2Q2B` a second job: its measured
+value is half of the `key-2` estimate, which feeds `key-gap`, which feeds
+`key-ok?` — a **mandatory** input to model selection. The rung is an input to
+the verdict, not a witness withheld from it, and the residual it returns is
+arithmetically the other checks recombined. **The independence claim is
+retracted here and everywhere it was carried downstream.** The rows, the
+contrasts and the component magnitudes below are unchanged and unedited;
+[§4](#4-the-additive-model) states, with the identity written out, exactly what
+they now rest on and what they do not. No new measurement was taken: the
+operator deferred further heap measurement on 2026-07-31, and
+[§7](#7-open) records what an independent adjudication would require if one is
+ever run.
+
 ---
 
 ## The answer, first
@@ -41,14 +57,19 @@ two substrates sit **+5.2% and +5.2%** above the ladder, the same common-mode
 offset between two instruments. **Part 1 is not reopened.**
 [§3](#3-the-prediction-adjudicated) shows the working.
 
-**The additive model holds on UIx and needs a fourth term on Reagent.** The
-per-unique-key axis is a straight line on both substrates in every round of both
-runs (r² 0.9973–0.9999), so a per-unique-key price exists and is priced twice
-over from disjoint subsets of the sweep. The *per-edge* term is another matter:
-on UIx the two ways of pricing it agree within 3.8% and the held-out rung is
-predicted within 2%, and on Reagent they disagree by 160 B — **more than twice
-the smaller of the two** — which is a real finding about where Reagent spends
-and a refusal to publish a per-edge byte count for it.
+**The additive model *fits* UIx with three terms and Reagent with four — and
+"fits" is the strongest word this sweep has earned.** The per-unique-key axis is
+a straight line on both substrates in every round of both runs (r²
+0.9973–0.9999), so a per-unique-key price exists and is priced twice over from
+genuinely disjoint rung sets: the R = 1 family's slope, and the R = 2 pair. The
+*per-edge* term is another matter: on UIx the two routes to it land within 3.8%
+of each other, and on Reagent they disagree by 160 B — **more than twice the
+smaller of the two** — which is a real finding about where Reagent spends, and
+the page refuses to publish a per-edge byte count for it. What this page does
+**not** claim is an out-of-sample validation. `R2Q2B` is an input to the
+model's admissibility gate, not a rung withheld from it, and the residual it
+returns is identically the other two checks recombined —
+[§4](#4-the-additive-model) writes that identity out.
 
 ---
 
@@ -76,13 +97,25 @@ git rev-parse <candidate>:$P   # must print 29a5d1087c2a78d3bc025657d414af2131d3
 ```
 
 **The spine measured.** Both of today's spine landings are ancestors of the
-anchor, and both move per-read heap, so this page's absolutes are **not**
-comparable to any P0 heap figure published before them:
+anchor. **One of them is known to move retained heap**, and it is the reason this
+page's UIx absolutes are **not** comparable to any P0 heap figure published
+before it:
 
-| landing | commit | what it did |
-|---|---|---|
-| `rf2-2rtt6.13` (PR #7304) | `9df5094816` | stopped retaining the disposed render-phase reaction — **−769 B / −23.0 objects per unique key** on UIx |
-| `rf2-2rtt6.25` (PR #7305) | `f784ab0adb` | hook-scoped provisional hand-off; the cold read builds **one** reaction, not two (`bodyRuns` 2.00N → 1.00N) |
+| landing | commit | what it did | retained heap |
+|---|---|---|---|
+| `rf2-2rtt6.13` (PR #7304) | `9df5094816` | stopped retaining the disposed render-phase reaction — **−769 B / −23.0 objects per unique key** on UIx | **moves it** — measured there, and priced again in [§3](#3-the-prediction-adjudicated) |
+| `rf2-2rtt6.25` (PR #7305) | `f784ab0adb` | hook-scoped provisional hand-off | **no established delta** — see below |
+
+**`rf2-2rtt6.25` is named here as a tree stamp, not as a cause.** Under a forced
+synchronous commit — which is what this harness does, mounting every arm inside
+`react-dom/flushSync` — the hand-off lets a cold read build one reaction rather
+than two. The audit of PR #7305 then drove the shipped public path (bare
+`createRoot().render`, no `act`, no `flushSync`) and measured **2N** body
+constructions at N = 1, 300, 3,000 and 10,000: the reaper's macrotask wins before
+React's passive subscribe, so the provisional is disposed and the commit
+rebuilds. **No durable retained-heap delta from `.25` is established**, this page
+attributes none to it, and every correction below is `.13`'s alone. The public
+schedule is open under `rf2-2rtt6.25`.
 
 **Versions.** Reagent **2.0.1**, UIx **1.4.4**, React **19.2.0**, node
 **24.13.0**, headless **Chromium 147.0.7727.15** via Playwright 1.59.1. Windows
@@ -161,7 +194,7 @@ round.
 | `R1Q2` | 1 | B/2 | fan-out 2 |
 | `R1Q4` | 1 | B/4 | fan-out 4 — at ROOTS=4, exactly `rf2-2rtt6.4`'s regime |
 | `R1Q8` | 1 | B/8 | fan-out 8 |
-| `R2Q2B` | 2 | 2B | **held out of every identification** |
+| `R2Q2B` | 2 | 2B | **prices no term — and gates the model** ([§4](#4-the-additive-model)) |
 | `R2QB2` | 2 | B/2 | identifies the per-edge term against `R1Q2` |
 | `anchor` | 1 | 300 | the published `grid/<substrate>` arm, **unchanged** |
 
@@ -311,11 +344,12 @@ guard reportable, 0 unverified of 56 mounts):
 | `grid` exclusive ratio | 2.254× | **2.104×** [2.056–2.138] |
 
 The Reagent denominator is the published figure **to the byte**. The UIx
-numerator has moved, by `.13`, and the ratio with it — which is the second
-independent statement of the same thing, on the instrument that published the
-original. Those mounts also passed the new **Q** read-back, so the `.4` grid
-arm's E/Q = 4 is now checked every time that row is taken and not only when this
-sweep runs.
+numerator has moved, by `.13`, and the ratio with it — a second statement of the
+same thing, from a separate run of the very arm that published the original.
+Same instrument, different arm, different run: corroboration within one
+harness, not a second harness. Those mounts also passed the new **Q**
+read-back, so the `.4` grid arm's E/Q = 4 is now checked every time that row is
+taken and not only when this sweep runs.
 
 ### P2 and P3 — see [§4](#4-the-additive-model) and [§5](#5-the-terms)
 
@@ -353,10 +387,11 @@ M4    y = shell + [E>0]·step + (E/B)·edge + (Q/B)·key
 - `step` — what is left of the `R1*` intercept once `shell` and `edge` are taken
   out. M3 says this is zero.
 
-`R2Q2B` is **held out of all of that** and predicted by both models. It is the
-only rung whose value nothing above depends on.
+`R2Q2B` prices none of those four terms. **It is not, however, held out of the
+adjudication** — and the first revision of this page said it was. Correcting
+that is what the rest of this section does.
 
-**The refusal criterion, stated before the run and not moved after it.** Written
+**The model criterion, stated before the run and not moved after it.** Written
 into `p0-heap/additive-criterion`, applied by `p0-heap/additive-fit`, and
 adjudicated per round as well as on the round means:
 
@@ -365,49 +400,112 @@ adjudicated per round as well as on the round means:
 | the `R1*` family is a line in Q/B | r² ≥ **0.98** |
 | the key term from the R=2 **pair** agrees with the R=1 slope | within **15%** |
 | M3 — edge priced from the intercept equals edge priced from the contrast | `\|step\|` ≤ **10%** of the fan-out-1 boundary |
-| the model predicts the held-out `R2Q2B` rung | within **10%** |
+| the model reproduces the `R2Q2B` rung | within **10%** |
 
-If the first two fail, no component price is quotable at all. Otherwise the
-model that survives its own held-out check carries the prices, and if neither
-does, the page publishes the rows and refuses the prices.
+If the first two fail, no component price is quotable at all. Otherwise the model
+that clears the fourth row carries the prices, and if neither does, the page
+publishes the rows and refuses the prices.
+
+### `R2Q2B` has one role, and it is not the one advertised
+
+The second row of that table is the one that matters. `key-2` is
+`(R2Q2B − R2QB2) / Δ(Q/B)`; `key-gap` compares it to the R = 1 slope; `key-ok?`
+is that comparison thresholded — and `key-ok?` is a **mandatory** input to model
+selection, because `(not (and linear? key-ok?))` returns *no model and no
+prices*. `R2Q2B`'s measured value therefore decides whether any price is
+quotable at all. That is its one role: **an admissibility gate, not a held-out
+witness.**
+
+The fourth row is then not a fifth piece of evidence but the second and third
+rows recombined. Write `dx` for the gap in `Q/B` between the two R = 2 rungs
+(2.0 − 0.5 = **1.5** here) and `ρ` for the R = 1 regression's residual at
+`R1Q2` — its fitted value minus its measured one. The algebra is exact, not
+approximate:
+
+```
+M4 predicted − R2Q2B measured  =         ρ  +  dx·(key − key₂)
+M3 predicted − R2Q2B measured  =  step + ρ  +  dx·(key − key₂)
+```
+
+`key − key₂` is precisely what `key-gap` thresholds; `step` is precisely what
+the M3 row thresholds. On the ROOTS=4 Reagent arm `step` = 150 B, `ρ` = −28 B,
+and `dx·(key − key₂)` = 1.5 × (919 − 824) = +143 B — so 150 − 28 + 143 =
+**+265 B**, against a measured M3 miss of 2,806 − 2,541 = **+265 B**; drop
+`step` and M4's is **+115 B** against a measured **+115 B**. The "held-out"
+residual carries no information the two checks above it do not already carry.
+
+**So the model was not validated out of sample. It was fitted, and checked for
+self-consistency.** Everything below that says the model *reproduces* `R2Q2B`
+is true and worth reporting — a model whose recombined checks land within 2% is
+in better shape than one whose land at 10% — but it is a consistency reading,
+and this page no longer offers it as independent evidence. What that costs the
+downstream budget rows is stated in [§6](#6-what-this-unblocks); what would buy
+the independence back is in [§7](#7-open).
 
 **The adjudicator's own positive control.** Three synthetic pages, built by
 arithmetic and never measured, run before the sweep does: an exact M3 page that
-must be priced back to its three terms and predict its held-out rung *to the
-byte*; an M4 page carrying a 400 B step, whose R=1 family is a **perfect** line
-(r² = 1.000000) and which M3 still misses by 12.90% on the held-out rung; and a
-page with a quadratic key term that both models must refuse. **That middle page
-is the whole argument for the R=2 rungs existing** — a page that is not M3 can
-fit the R=1 family perfectly, and nothing inside that family can tell.
+must be priced back to its three terms and reproduce `R2Q2B` *to the byte*; an M4
+page carrying a 400 B step, whose R=1 family is a **perfect** line
+(r² = 1.000000) and which M3 still misses by 12.90%; and a page with a quadratic
+key term that both models must refuse. **That middle page is the whole argument
+for the R = 2 rungs existing** — a page that is not M3 can fit the R = 1 family
+perfectly, and nothing inside that family can tell. On it the identity above
+reduces to `miss = step` exactly, which is the point: the R = 2 rungs are what
+make `step` observable at all. **`R2QB2` is the rung that supplies it.** `R2Q2B`
+supplies the key cross-check from a rung set disjoint from the R = 1 family —
+genuinely useful, and not a held-out test.
 
 ### The verdicts
 
-| | model | r² | held-out `R2Q2B` | rounds agreeing |
+| | model | r² | `R2Q2B` reproduced | rounds agreeing |
 |---|---|---:|---|---:|
 | Reagent, ROOTS=4 | **M4** | 0.99732 | M3 +10.44% *(fail)* · M4 +4.55% | 5 of 6 |
 | Reagent, ROOTS=1 | **M4** | 0.99862 | M3 +0.51% · M4 −5.63% | 2 of 6 |
 | UIx, ROOTS=4 | **M3** | 0.99989 | M3 +1.95% · M4 +1.34% | **6 of 6** |
 | UIx, ROOTS=1 | **M3** | 0.99994 | M3 −0.20% · M4 −1.04% | **6 of 6** |
 
-**UIx is M3, unambiguously.** Both runs, every round, r² ≥ 0.9999, the two edge
-identifications within 3.8% of each other, and the held-out rung predicted
-within 2% by a model that never saw it.
+**UIx is M3, unambiguously.** Both runs, every round, r² ≥ 0.9999; the two routes
+to the edge term within 3.8% of each other; `R2Q2B` reproduced within 2%. Those
+two routes are **not data-independent** — the intercept is fitted through the
+whole R = 1 family and the contrast subtracts `R1Q2`, a member of it, from
+`R2QB2` — so 3.8% is internal agreement, not corroboration by a second
+experiment. What they jointly support is narrower and still worth having: UIx's
+non-per-key cost of reading is 1,327–1,396 B however it is sliced, and its `step`
+is 38–52 B, so the model's freedom to move bytes between `edge` and `step` is
+bounded at about **50 B** on UIx.
 
 **Reagent reaches M4 in both runs and does not reach it stably.** Look at what
 actually happens: at ROOTS=4 the step (150 B) sits *inside* its 165 B band while
-M3 misses the held-out rung by 10.44% against a 10% threshold; at ROOTS=1 the
-step (163 B) sits *outside* its 160 B band while M3 predicts the held-out rung
-to **0.51%** — better than M4's −5.63%. Both runs land on M4 by the rule, by
-different failing checks, and the per-round verdicts flip (M3, M4, refused, M3,
-refused, M4).
+M3 misses `R2Q2B` by 10.44% against a 10% threshold; at ROOTS=1 the step (163 B)
+sits *outside* its 160 B band while M3 reproduces `R2Q2B` to **0.51%** — better
+than M4's −5.63%. Both runs land on M4 by the rule, by different failing checks,
+and the per-round verdicts flip (M3, M4, refused, M3, refused, M4).
 
 **That instability is the result, not noise to be averaged away.** Reagent's
 non-per-key cost of reading is ~234–244 B at one read, and this sweep can say
-that number confidently. What it cannot say is how to split it: the two
-identifications of `edge` give **84 B** and **234 B** — the disagreement is
-larger than twice the smaller term. On UIx the same disagreement is 38 B against
-a 1,344 B term. **The Reagent per-edge price is refused, and the criterion that
-refuses it is the one written down before the run.**
+that number confidently. What it cannot say is how to split it: the two routes to
+`edge` give **84 B** and **234 B** — a disagreement larger than twice the smaller
+term. On UIx the same disagreement is 38 B against a 1,344 B term.
+
+**The Reagent per-edge price is refused — and the refusal is this page's
+judgement, not the precommitted rule's.** The first revision of this page ran the
+two together; they are different things and the difference is worth spelling out.
+
+- **What the precommitted criterion did.** It selected **M4** on both Reagent
+  runs, and `additive-fit` reports `:edge` as the *contrast* value under M4. The
+  rule as written would therefore have handed out **84 B / 80 B** as Reagent's
+  per-edge price. No "twice the smaller term" threshold appears anywhere in
+  `additive-criterion`, and no threshold in it was moved after the run.
+- **What the criterion did put on the record, before any prose was written.** The
+  two runs reach M4 by *different* failing checks; the step sits inside its band
+  in one run and outside it in the other; the per-round verdicts flip 5-of-6 and
+  2-of-6. That is the precommitted machinery reporting an unstable
+  identification, and it is in the table above.
+- **What this page then decided.** That an 84 B number carrying a 234 B
+  alternative is not a number to freeze into a budget, and that the honest form
+  is the ~234–244 B total with the split marked unresolved. That is a
+  **conservative post-run editorial call**, made in the safe direction, and it is
+  offered as one — not as the output of a rule written down in advance.
 
 ---
 
@@ -436,14 +534,20 @@ not move.
 | **per-edge**, from the contrast | **1,344** [1,327–1,365] | **1,345** [1,339–1,352] | from the intercept 1,382 / 1,396 — **3.8% apart** |
 | step | 38 [24–54] | 52 [26–72] | inside its band in every round |
 
-**Four instruments now agree on the subscription term.** Reagent: this sweep's
-four estimates span **823–939 B** and `rf2-2rtt6.12`'s direct ablation reads
-**866 B**, dead centre; the ruling's own cross-family algebra solved 820–824 B,
-at the bottom of the range. UIx: this sweep reads **1,525–1,659 B** against
-`.12`'s 1,684 B once the 769 B `.13` removed is taken out — 1.5% above the top
-of the range. The algebra the ruling refused to freeze budgets from turns out to
-have been right; it was right for a reason it could not demonstrate, and now one
-run demonstrates it.
+**The subscription term is priced four times inside this sweep and agrees with
+two readings taken outside it.** Inside: two runs × two disjoint rung sets (the
+R = 1 slope, and the R = 2 pair) — same instrument, so four estimates rather than
+four instruments. Outside: `rf2-2rtt6.12`'s direct ablation, a different
+experiment on a different page, and the ruling's cross-family algebra over the
+two published families. Reagent — this sweep's four estimates span **823–939 B**,
+`.12`'s ablation reads **866 B**, dead centre, and the algebra solved 820–824 B,
+at the bottom of the range. UIx — this sweep reads **1,525–1,659 B** against
+`.12`'s 1,684 B once the 769 B `.13` removed is taken out, 1.5% above the top of
+the range. The algebra the ruling refused to freeze budgets from turns out to
+have been right; it was right for a reason it could not demonstrate, and this run
+demonstrates it. **This is the one term on the page with genuinely external
+corroboration**, and it is why [§6](#6-what-this-unblocks) treats it differently
+from the rest.
 
 **Where the two substrates actually spend.** UIx wins the shell by 2.27×
 (221 B against 501 B) and loses everything else: its per-edge term is
@@ -470,11 +574,33 @@ the 0.4–0.5 KB target band rather than inside it.
 Part 3 of the ruling gated three component budget rows on this sweep. The sweep
 answers for two of them on both substrates, and refuses one.
 
-| row | Reagent | UIx |
-|---|---|---|
-| **shell** (R=0 boundary) | **UNBLOCKED** — 501–524 B, *stated for a named boundary shape* | **UNBLOCKED** — 221–231 B |
-| **per-unique-subscription-key** | **UNBLOCKED** — **~866 B** [823–939] | **UNBLOCKED** — **~1,590 B** [1,525–1,659] |
-| **per-edge** (consumer attachment) | **REFUSED** — the two identifications differ by more than twice the smaller term | **UNBLOCKED** — **~1,345 B** [1,327–1,396] |
+| row | Reagent | UIx | what it rests on |
+|---|---|---|---|
+| **shell** (R=0 boundary) | **UNBLOCKED** — 501–524 B, *stated for a named boundary shape* | **UNBLOCKED** — 221–231 B | a **measured rung**, `R0`, read directly. No model, no fit |
+| **per-unique-subscription-key** | **UNBLOCKED** — **~866 B** [823–939] | **UNBLOCKED** — **~1,590 B** [1,525–1,659] | a **direct slope** at pinned E/B, priced twice from disjoint rungs, and corroborated **outside this sweep** by `.12`'s ablation |
+| **per-edge** (consumer attachment) | **REFUSED** — the two routes differ by more than twice the smaller term | **UNBLOCKED, PROVISIONAL** — **~1,345 B** [1,327–1,396] | a **direct two-rung contrast** at fixed Q; the *label* is model-dependent within ~50 B |
+
+**Read that fourth column before quoting the third.** With the held-out claim
+withdrawn, the rows no longer rest on a model that survived an out-of-sample
+test — so each one is stated for what it individually is:
+
+- **The shell is a measurement.** `R0` is a rung that was mounted and read. The
+  additive model plays no part in it, and nothing in this correction touches it
+  beyond the component-shape caveat it already carried.
+- **The per-unique-key term is the sweep's strongest number.** It is the slope of
+  four rungs whose E/B is pinned, it is r² ≥ 0.9973 in every round of both runs,
+  it is re-priced from the disjoint R = 2 pair, and `rf2-2rtt6.12`'s ablation —
+  which is not this instrument and not this run — lands inside the range on
+  Reagent and 1.5% outside it on UIx. It stands.
+- **The UIx per-edge term is a direct contrast, and its *name* is provisional.**
+  `R2QB2 − R1Q2` measures what one more edge costs at fixed Q, and that
+  measurement is 1,344/1,345 B whichever model is selected. What the model
+  decides is only whether a further 38–52 B is called `edge` or `step`. Quote
+  ~1,345 B as the cost of an attachment and treat the last ~50 B as unallocated,
+  rather than reading the number as a validated decomposition.
+- **The Reagent per-edge row stays refused**, on the conservative post-run
+  judgement set out in [§4](#4-the-additive-model) — which is a judgement, not
+  the precommitted rule's output, and is labelled that way there.
 
 And it adds one row Part 3 did not name:
 
@@ -498,6 +624,27 @@ measured rather than inferred.
 
 ## 7. Open
 
+- **An independent adjudication of the additive model has not been run, and this
+  is what one would take.** The defect is structural, not arithmetic: every rung
+  this sweep measured is consumed by identification or by admissibility, so no
+  rearrangement of the existing data recovers a held-out test. It needs **one
+  more rung, precommitted as untouchable, and a criterion that never reads it**.
+  Concretely: (1) add a rung outside both the R = 1 family and the R = 2 pair —
+  `R3` at fixed Q is the obvious one, since the Reagent step/edge item below
+  wants exactly that rung anyway; (2) drop `key-ok?`'s dependence on it, or price
+  the key cross-check from a different pair, so the validation rung feeds *no*
+  admissibility check; (3) state the prediction for it before the run, as this
+  page did for P1–P4; (4) re-adjudicate the component rows against it. Until that
+  runs, [§6](#6-what-this-unblocks)'s fourth column is the warrant. **New
+  measurement is deferred by operator direction (Mike, 2026-07-31)** — the
+  tournament arms have the box — so this is a recorded requirement, not a queued
+  task.
+- **The instrument's own comments still say `R2Q2B` is held out.** The blobs in
+  [Provenance](#provenance) are pinned to the revision that produced these rows
+  and are deliberately not edited, so `p0_heap.cljs`'s "Falsification — one rung
+  is held out" block and `p0_run.cjs`'s banner remain as they were when the
+  numbers were taken. This page supersedes them. Whichever revision next touches
+  the adjudicator should correct the wording there and re-stamp the blobs.
 - **The 9.3% ratio drift across fan-out** ([§2](#2-the-rows)) refines Part 1's
   "the ratio survives regimes". It survives approximately. Whether a donor gate
   should carry a band rather than a point is the operator's call, not this

--- a/docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md
+++ b/docs/design/hicasso/studio/p0-uix-on-subs-frontier-arm.md
@@ -271,13 +271,18 @@ worse with no named paper path down is K3 territory; between the two is
 
 **The UIx line was restated on 2026-07-31** (Mike's ruling, option (a),
 `rf2-e3flf`). It read 3,552 B/read while it was sourced from the ladder's
-pre-`rf2-2rtt6.13` / pre-`rf2-2rtt6.25` spine; the sweep's post-landing
-decomposition prices it at per-edge 1,345 B + per-unique-key 1,590 B, and the
-[ladder](reads-per-boundary-heap-ladder.md)'s §5 carries the arithmetic and its
-three cross-checks. Reagent's line did not move — neither landing touches the
-ratom path. **This page's own UIx heap absolutes also predate both landings**
-and are ~769/4 B per boundary high at E/Q = 4 on that account: the sweep re-ran
-this grid arm unchanged and read 1,996 B against the 2,134 B below.
+pre-`rf2-2rtt6.13` spine; the sweep's post-landing rungs read the same quantity
+directly — `R2Q2B − R1Q1`, two rungs at Q = E one read apart — and its
+decomposition explains it as per-edge 1,345 B + per-unique-key 1,590 B. The
+[ladder](reads-per-boundary-heap-ladder.md)'s §5 carries the arithmetic and
+says plainly which of its readings are independent of each other and which are
+one run stated twice. Reagent's line did not move — neither landing touches the
+ratom path. `rf2-2rtt6.25` (`f784ab0adb`) is also an ancestor of the sweep's
+tree, but no retained-heap delta from it is established and none is claimed
+here; it is open on its own bead. **This page's own UIx heap absolutes predate
+both landings** and are ~769/4 B per boundary high at E/Q = 4 on `.13`'s
+account: the sweep re-ran this grid arm unchanged and read 1,996 B against the
+2,134 B below.
 
 DOM nodes live in Blink's C++ heap, not V8's, so none of these figures contain
 the elements themselves. Every arm builds the identical DOM — the canonical-DOM

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -9,15 +9,20 @@ below is a fresh reading through the corrected fit; the superseded publication
 is recorded in [§7](#7-superseded) rather than deleted.
 
 **Spine stamp — every UIx rung below was measured on a spine that no longer
-ships.** Two production landings postdate this run and both cut UIx retained
-heap: `rf2-2rtt6.13` (PR #7304, `9df5094816`) stopped retaining the disposed
-render-phase reaction — **−769 B / −23.0 objects per unique query key**, which
-on this ladder's distinct-query regime is 769 B *per read* — and
-`rf2-2rtt6.25` (PR #7305, `f784ab0adb`) landed the hook-scoped provisional
-hand-off, so a cold read builds one reaction instead of two. The **measured
-rows are left exactly as measured**, because a measurement record edited to
-match a later tree stops being a record. What is restated, in place, is
-everything this page *hands the programme* as a live number:
+ships.** Two production landings postdate this run. **One of them cuts UIx
+retained heap**: `rf2-2rtt6.13` (PR #7304, `9df5094816`) stopped retaining the
+disposed render-phase reaction — **−769 B / −23.0 objects per unique query
+key**, which on this ladder's distinct-query regime is 769 B *per read*. The
+other, `rf2-2rtt6.25` (PR #7305, `f784ab0adb`), landed the hook-scoped
+provisional hand-off; it is named here as a **tree stamp, not as a cause**,
+because no retained-heap delta from it has been established — the audit of
+PR #7305 drove the shipped bare `createRoot().render` path and measured 2N body
+constructions at N = 1, 300, 3,000 and 10,000, the reaper winning before
+React's passive subscribe. That schedule question is open under
+`rf2-2rtt6.25`; every correction on this page is `.13`'s. The **measured rows
+are left exactly as measured**, because a measurement record edited to match a
+later tree stops being a record. What is restated, in place, is everything this
+page *hands the programme* as a live number:
 [§5](#5-what-this-hands-the-programme) carries the gate lines on the
 post-landing tree, with the arithmetic written out. Reagent's rows are
 untouched by both landings — neither goes near the ratom path.
@@ -456,10 +461,31 @@ stamped with the instrument it was taken on, because the two instruments in
 play differ by a measured common-mode offset that no gate should silently
 absorb.
 
+**It stands on a direct two-point contrast, not on an independent
+triangulation** — this section said the latter when it was first written, and
+the audit of PR #7306 was right to refuse it. The number is unchanged, and so
+is the band; what changes is the account of why either is trustworthy, which is
+below.
+
 The derivation is desk work over landed, gated data: no new campaign was run
 for it. The [fan-out sweep](heap-fan-out-sweep.md) is the first heap page
 measured *after* both landings, and its UIx arm is **M3 in both runs and every
-round** (r² ≥ 0.9999, held-out rung predicted within 2%):
+round** (r² ≥ 0.9999).
+
+**The primary source is a direct contrast, and it needs no model at all.** Two
+of the sweep's rungs sit at Q = E — this witness family's own regime — and
+differ by exactly one read and one unique key per boundary. Subtracting them
+measures the gate's quantity outright:
+
+```
+R2Q2B − R1Q1 = 6,122 − 3,235 = 2,887 B/read   at B = 1,200
+             = 6,155 − 3,185 = 2,970 B/read   at B = 300
+                                mean  2,929 B/read
+```
+
+**The model decomposition says the same thing and explains it.** Under M3 with
+Q = E the per-read slope is the sum of two terms, and the sum lands 0.2% from
+the direct reading above:
 
 ```
 M3          y = shell + (E/B)·edge + (Q/B)·key
@@ -472,25 +498,48 @@ marginal per read = edge + key
                   = 2,935 B  [2,852–3,055]
 ```
 
-**Three checks, none of which the derivation used.**
+**What these two are, and what they are not.** They are *not* two independent
+readings. They come from one run on one instrument; they share the `R1Q1`
+observation — it is a member of the R = 1 family the key slope is fitted
+through — and the sweep's model verdict itself depends on `R2Q2B` through the
+mandatory `key-ok?` admissibility check, so nothing here was held out of
+anything. The corrected warrant is on
+[the sweep's §4](heap-fan-out-sweep.md#4-the-additive-model). What they are is
+one measured quantity stated two ways, agreeing to 0.2%, with the second way
+telling you where the bytes go.
 
-1. **A direct two-point reading on a held-out rung.** The sweep's `R2Q2B` rung
-   is two reads at E/Q = 1 and is held out of *every* identification, so
-   `R2Q2B − R1Q1` measures this slope without touching the terms above:
-   `6,122 − 3,235 = 2,887 B` at B = 1,200 and `6,155 − 3,185 = 2,970 B` at
-   B = 300, mean **2,929 B** — 0.2% from the derived value.
-2. **This ladder's own slope, corrected.** `3,552 − 769 = 2,783 B/read`. That
-   is +5.5% below the sweep's figure, and +5.2% is exactly the common-mode
+**Two readings that do come from elsewhere.** Both are on the *other*
+instrument, so they corroborate the magnitude and not the bench number:
+
+1. **This ladder's own slope, corrected.** `3,552 − 769 = 2,783 B/read`. That
+   is 5.5% below the sweep's figure, and +5.2% is exactly the common-mode
    offset the sweep measured twice between the two harnesses (Reagent +5.19%,
    UIx +5.17%) — a difference in boundary-component shape, not in the spine.
-3. **A third instrument, measured after the fix.**
+2. **A third instrument, measured after the fix.**
    [The spine decomposition](uix-spine-per-read-decomposition.md) reads the
    shipped UIx spine at **2,734 B/read** [2,731–2,735] post-`.13`. It sits 1.4%
    below this ladder pre-fix (3,501 against 3,552); scaled onto this ladder's
-   instrument that is 2,774 B/read — **0.4%** from check 2.
+   instrument that is 2,774 B/read — **0.4%** from the reading above it.
 
-Four readings, three instruments, one arithmetic: ~2,780 B/read on this page's
-instrument, ~2,935 B/read on the bench's.
+So: **one quantity measured directly on the bench instrument and decomposed
+there, plus two same-direction readings on two other instruments** — ~2,780
+B/read on this page's instrument, ~2,935 B/read on the bench's. That is the
+whole warrant, and it is a weaker claim than the "four readings, three
+instruments" this section carried when it was first written, which counted the
+sweep's overlapping arithmetics as separate evidence.
+
+**What survives the correction, and what does not.** The line's *number* and
+its *band* both survive, and the reason is that neither ever needed the
+withdrawn claim: the two direct readings are 2,887 and 2,970 B/read, 2.9% apart
+and both inside `[2,852–3,055]`, so the band is a fair statement of the spread
+whether or not the additive model was validated out of sample. What does not
+survive is the decomposition's standing as *independent* support. Treat
+`1,345 + 1,590` as an explanation of the line rather than a second proof of it,
+and treat the split itself as provisional to within the ~50 B the sweep's model
+is free to move between `edge` and `step` — [its §6](heap-fan-out-sweep.md#6-what-this-unblocks)
+says so row by row. **Nothing here is re-measured**: the operator deferred new
+heap measurement on 2026-07-31, and this restatement is desk work over landed
+data exactly as the ruling directed.
 
 **Provenance of the restatement.** Whole-tree anchor **`61dd44950a`** — the
 landed sweep commit, with `9df5094816` (`.13`) and `f784ab0adb` (`.25`) both

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -511,8 +511,8 @@ telling you where the bytes go.
 **Two readings that do come from elsewhere.** Both are on the *other*
 instrument, so they corroborate the magnitude and not the bench number:
 
-1. **This ladder's own slope, corrected.** `3,552 − 769 = 2,783 B/read`. That
-   is 5.5% below the sweep's figure, and +5.2% is exactly the common-mode
+1. **This ladder's own slope, corrected.** `3,552 − 769 = 2,783 B/read`. The
+   sweep's figure sits 5.5% above it, and +5.2% is exactly the common-mode
    offset the sweep measured twice between the two harnesses (Reagent +5.19%,
    UIx +5.17%) — a difference in boundary-component shape, not in the spine.
 2. **A third instrument, measured after the fix.**

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -112,18 +112,36 @@ layer actually has to beat.**
 
 **The UIx line was restated on 2026-07-31** (Mike's ruling, option (a),
 `rf2-e3flf`). It stood at 3,552 B/read while it was sourced from the reads
-ladder, which measured a spine two production landings ago: `rf2-2rtt6.13`
-(`9df5094816`) stopped retaining a disposed render-phase reaction, worth 769 B
-per unique query key and so 769 B per read where Q = E, and `rf2-2rtt6.25`
-(`f784ab0adb`) removed the cold read's double build. A gate measured on a spine
-that no longer ships is looser than the tree warrants, which is the unsafe
-direction for a gate, so the line was restated rather than stamped historical.
-It is now the sum of the two terms the fan-out sweep priced after both landings
-— per-edge 1,345 B [1,327–1,396] plus per-unique-key 1,590 B [1,525–1,659] —
-and three checks the derivation did not use agree with it: the sweep's held-out
-two-point rung, the ladder's own slope less `.13`'s term, and the spine
-decomposition's post-fix reading. The working is in
+ladder, which measured a spine one heap-moving production landing ago:
+`rf2-2rtt6.13` (`9df5094816`) stopped retaining a disposed render-phase
+reaction, worth 769 B per unique query key and so 769 B per read where Q = E.
+A gate measured on a spine that no longer ships is looser than the tree
+warrants, which is the unsafe direction for a gate, so the line was restated
+rather than stamped historical.
+
+**What the restated line rests on.** Its primary source is a **direct two-point
+contrast** on the fan-out sweep, taken in this gate's own Q = E regime:
+`R2Q2B − R1Q1` reads 2,887 B/read at B = 1,200 and 2,970 B/read at B = 300,
+mean 2,929 B — no model required. The sweep's additive decomposition (per-edge
+1,345 B [1,327–1,396] plus per-unique-key 1,590 B [1,525–1,659] = 2,935 B) lands
+0.2% away and is what makes the line *interpretable*. **The two are not
+independent evidence**: they come from one run on one instrument and share the
+`R1Q1` observation, and the sweep's model verdict itself depends on `R2Q2B`
+through a mandatory admissibility check, so no rung was held out of anything.
+Two readings from *other* instruments agree in the same direction — the ladder's
+own slope less `.13`'s term (2,783 B/read) and the spine decomposition's
+post-fix reading (2,774 B/read scaled) — and the ~5% between the instruments is
+the offset the next paragraph governs. The working, and the withdrawn
+independence claim, are in
 [the reads ladder](studio/reads-per-boundary-heap-ladder.md#5-what-this-hands-the-programme).
+
+**`rf2-2rtt6.25` is not part of this.** It landed in the same window
+(`f784ab0adb`) and is an ancestor of the sweep's tree, but its single-build
+benefit was measured under a forced synchronous commit; the audit of PR #7305
+drove the shipped bare `createRoot().render` path and measured 2N. **No
+retained-heap delta from it is established**, so no gate line here is
+attributed to it and the public-schedule question stays with its open owner,
+`rf2-2rtt6.25`.
 
 **Reagent's line did not move.** Neither landing goes near the ratom path, and
 the sweep's own post-landing reading of the Reagent slope straddles the

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -55,39 +55,69 @@ line on either shape, but on the two-prop shape Reagent sits at the *top* of the
 ### The component budgets
 
 Part 3 of the same ruling would not freeze the shell / per-edge / per-unique-key
-rows from cross-instrument algebra; it gated them on a bench sweep that verified
-the additive heap model and priced the terms on one instrument in one run. That
-sweep has landed — [the fan-out heap sweep](studio/heap-fan-out-sweep.md), commit
-`61dd44950a` (PR #7306): E/Q 1-2-4-8 at ROOTS=4 and ROOTS=1, six rounds each,
-both runs exit 0, arm-order guard reportable, 0 unverified of 126 mounts per run,
-dense-array positive control within 0.007%. It prices two of the three rows on
-both substrates and **refuses** the third on one.
+rows from cross-instrument algebra; it gated them on a bench sweep that would
+verify the additive heap model and price the terms on one instrument in one run.
+That sweep has landed — [the fan-out heap sweep](studio/heap-fan-out-sweep.md),
+commit `61dd44950a` (PR #7306): E/Q 1-2-4-8 at ROOTS=4 and ROOTS=1, six rounds
+each, both runs exit 0, arm-order guard reportable, 0 unverified of 126 mounts
+per run, dense-array positive control within 0.007%. It prices two of the three
+rows on both substrates and **refuses** the third on one. It **fits** the
+additive model rather than validating it out of sample: the warrant column below
+says what each row therefore rests on, and the paragraphs under it say why the
+stronger claim was withdrawn.
 
-| Component (per boundary, distinct-query witness) | Reagent-on-subs | UIx-on-subs |
-|---|---|---|
-| Boundary shell (R = 0), two-prop boundary | 501–524 B | 221–231 B |
-| Per unique subscription key | ~866 B [823–939] | ~1,590 B [1,525–1,659] |
-| Per edge (consumer attachment) | **refused — measured, not identified** | ~1,345 B [1,327–1,396] |
+| Component (per boundary, distinct-query witness) | Reagent-on-subs | UIx-on-subs | Warrant |
+|---|---|---|---|
+| Boundary shell (R = 0), two-prop boundary | 501–524 B | 221–231 B | a measured rung, read directly — no model |
+| Per unique subscription key | ~866 B [823–939] | ~1,590 B [1,525–1,659] | a direct slope, plus corroboration from outside the sweep |
+| Per edge (consumer attachment) | **refused — measured, not identified** | ~1,345 B [1,327–1,396], **provisional** | a direct contrast; the *split* is model-dependent within ~50 B |
 
-**The refused row is a result, not an omission.** On UIx the two independent
-identifications of the edge term agree within 3.8% and the surviving model
-predicts a held-out rung it never saw to within 2%. On Reagent they disagree by
-160 B — 80–84 B priced from the contrast against 234–244 B priced from the
-intercept, more than twice the smaller of the two — and the criterion that
-refuses them was written down before the run. What a Reagent boundary pays for
-its *first* read beyond the per-key term is ~234–244 B, and that total is
-quotable; how it splits between an attachment and a per-subscribing-boundary step
-of ~150–163 B, which is neither shell nor edge, is not. Budget against the total.
-Never against either half.
+**Read the warrant column with the numbers.** The sweep's first publication
+offered these rows as validated by a model that predicted a rung held out of
+every identification. The audit of PR #7306 established that no rung was held
+out — the rung in question feeds a mandatory model-admissibility check — so
+**that warrant is withdrawn and each row now stands on its own evidence**
+([the sweep's §4 and §6](studio/heap-fan-out-sweep.md#4-the-additive-model)).
+The magnitudes are unchanged; none was re-measured, because the operator
+deferred new heap measurement on 2026-07-31.
 
-Two caveats ride these rows. Reagent's additive verdict is **marginal**: it
-reaches the four-term model in both runs but by different failing checks — a
-10.44% held-out miss against a 10% threshold in one run, a 163 B step against a
-160 B band in the other — and its per-round verdicts flip. Neither threshold was
-moved after the fact. And separating Reagent's step from its edge wants one rung
-the sweep does not have, R = 3 at fixed Q, which would over-determine the pair;
-the studio page carries that as an Open item. Until it runs, the Reagent per-edge
-row stays refused.
+- **The shell is a measurement**, not a fit: `R0` is a rung that was mounted and
+  read. Nothing in the correction touches it.
+- **The per-unique-key row is the strongest of the three.** It is the slope of
+  four rungs with edges pinned, r² ≥ 0.9973 in every round of both runs,
+  re-priced from a disjoint rung pair, and matched from *outside* the sweep by
+  `rf2-2rtt6.12`'s direct ablation — 866 B on Reagent, dead centre of the range;
+  1,684 B on UIx once `.13`'s 769 B is taken out, 1.5% above the top of it.
+- **The UIx per-edge row is a direct contrast and its label is provisional.**
+  Two rungs at the same Q, one read apart, price an attachment at 1,344–1,345 B
+  whichever model is selected; what the model decides is only whether a further
+  38–52 B is called *edge* or *step*. Budget against ~1,345 B and treat the last
+  ~50 B as unallocated — not as a validated decomposition.
+
+**The refused row is a result, not an omission** — and the refusal is a
+judgement, stated as one. On Reagent the two routes to the edge term disagree by
+160 B: 80–84 B priced from the contrast against 234–244 B priced from the
+intercept, more than twice the smaller of the two. The **precommitted** criterion
+(r² floor, key agreement within 15%, step ≤ 10% of the fan-out-1 boundary,
+model reproduces the R = 2 rung within 10%) selected the four-term model on both
+runs and would have published the 84 B figure; no "twice the smaller term"
+threshold appears in it, and no threshold in it was moved after the run. What the
+precommitted machinery *did* record is the instability: the two runs reach the
+four-term model by different failing checks, the step sits inside its band in one
+and outside it in the other, and the per-round verdicts flip 5-of-6 and 2-of-6.
+**The refusal itself is the studio page's post-run editorial call** on that
+record — conservative, in the safe direction, and left standing here, but not
+the output of a rule written in advance. What a Reagent
+boundary pays for its *first* read beyond the per-key term is ~234–244 B, and
+that total is quotable; how it splits between an attachment and a
+per-subscribing-boundary step of ~150–163 B, which is neither shell nor edge, is
+not. Budget against the total. Never against either half.
+
+One more caveat rides these rows. Separating Reagent's step from its edge wants
+one rung the sweep does not have, R = 3 at fixed Q, which would over-determine
+the pair; the studio page carries that as an Open item, alongside what an
+adjudication genuinely independent of the model would require. Until that runs,
+the Reagent per-edge row stays refused.
 
 Sub-key identity: `(query-id, args)` under value equality; value-unstable map args
 thrash the index — documented, programmer-trusted. A missed invalidation is a P0


### PR DESCRIPTION
Three audit-reopened beads, one defect: the heap fan-out sweep (PR #7306) published its result as independently triangulated on a held-out rung `R2Q2B`, and `R2Q2B` was never held out. Everything downstream that leaned on that warrant inherited it.

Operator direction (Mike, 2026-07-31) defers new heap measurement — hicasso proceeds full throttle, measuring comes later — so this takes **route (ii)**: retract the overclaim, state the real warrant, mark what is provisional. **No new run was taken. No row, contrast, magnitude or gate number is edited.** Every stale claim is rewritten in place; nothing is appended beside a correction.

## The dataflow, exactly

In `p0-heap/additive-fit`, `R2Q2B` is the high-Q half of the R = 2 pair, so its measured value is half of

```
key-2  = (R2Q2B − R2QB2) / Δ(Q/B)
key-gap = (key-2 − key) / key
key-ok? = |key-gap| ≤ 15%
```

and `key-ok?` is a **mandatory** input to model selection — `(not (and linear? key-ok?))` returns no model and no prices. The rung decides whether any price is quotable at all. That is its **one role**, and the pages now say so.

The "held-out prediction" is not a second role but the other checks recombined, as an exact identity (`dx` = the R = 2 rungs' gap in Q/B, `ρ` = the R = 1 regression's residual at `R1Q2`):

```
M4 predicted − R2Q2B measured  =         ρ  +  dx·(key − key₂)
M3 predicted − R2Q2B measured  =  step + ρ  +  dx·(key − key₂)
```

Checked to the byte on the ROOTS=4 Reagent arm: `150 − 28 + 143 = +265 B` against a measured M3 miss of `2,806 − 2,541 = +265 B`; drop `step` and M4's is `+115 B` against `+115 B`. The residual carries no information the key check and the step check do not already carry.

Two further dependences are stated where they were previously called independent: the UIx edge term's "two independent identifications" share the whole R = 1 family (the intercept is fitted through it; the contrast subtracts `R1Q2`, a member of it), and the ladder's direct `R2Q2B − R1Q1` check shares `R1Q1` with the regression that supplies the key term.

## What each figure now rests on

| figure | stands on | status |
|---|---|---|
| UIx **2,935 B/read** [2,852–3,055] | the model-free direct Q = E contrast: `R2Q2B − R1Q1` = 2,887 B (B=1,200) and 2,970 B (B=300), mean 2,929 — 0.2% from the decomposition | **unchanged**, re-sourced |
| Reagent **943 B/read** [935–944] | untouched by both landings | **unchanged** |
| shell 501–524 B / 221–231 B | a measured `R0` rung. No model | stands |
| per-unique-key ~866 B / ~1,590 B | a direct slope at pinned edges, r² ≥ 0.9973 every round, re-priced from a disjoint pair, matched from **outside** the sweep by `rf2-2rtt6.12`'s ablation | stands — the strongest row |
| UIx per-edge ~1,345 B | a direct two-rung contrast; 1,344–1,345 B whichever model wins | **provisional** — ~50 B free to move between `edge` and `step` |
| Reagent per-edge | — | **stays refused**, provenance corrected |

The gate line's *band* survives too, and for a reason that never needed the withdrawn claim: the two direct readings are 2.9% apart and both sit inside `[2,852–3,055]`.

## The precommitted rule vs. the post-run judgement

`validation.md` said the criterion that refuses Reagent's per-edge price "was written down before the run". Two different things:

- **The precommitted criterion** (r² ≥ 0.98; key agreement within 15%; `|step|` ≤ 10% of the fan-out-1 boundary; the model reproduces `R2Q2B` within 10%) selected **M4** on both Reagent runs, and `additive-fit` reports `:edge` as the contrast value under M4 — so the rule as written would have **published 84 B / 80 B**. No "twice the smaller term" threshold appears anywhere in `additive-criterion`, and no threshold in it was moved after the run.
- **What the criterion did record**, before any prose: the two runs reach M4 by different failing checks, the step sits inside its band in one and outside it in the other, and the per-round verdicts flip 5-of-6 and 2-of-6.
- **The refusal itself** is the studio page's conservative post-run editorial call on that record. It is kept — it is the right call in the safe direction — and it is now labelled as a judgement rather than a rule's output.

## `rf2-2rtt6.25` removed from retained-heap causality

`.25` has not been shown to deliver a retained-heap benefit. Its single-build behaviour holds under the forced `flushSync` this harness uses; the audit of PR #7305 drove the shipped bare `createRoot().render` path and measured **2N** body constructions at N = 1, 300, 3,000 and 10,000. It is now a **tree stamp, not a cause**, on all five pages, and the public-schedule claim points at its **open** owner `rf2-2rtt6.25` instead of asserting a benefit. `rf2-2rtt6.13`'s retained-reaction term is untouched and remains supported — the explicit `3,552 − 769 = 2,783` correction is entirely `.13`'s.

## What an independent adjudication would require

Recorded on `rf2-5prok` and in the sweep's §7. The defect is structural: every rung the sweep measured is consumed by identification or by admissibility, so no rearrangement of existing data recovers a held-out test. It needs one more rung precommitted as untouchable (`R3` at fixed Q — which the Reagent step/edge split wants anyway), `key-ok?` re-sourced so the validation rung feeds no admissibility check, a prediction stated for it before the run, and the component rows re-adjudicated against it.

A compact pointer note is on `rf2-2rtt6.1` — the normative line's number did not change, its warrant did.

## Quality gates

| gate | result |
|---|---|
| `python -m mkdocs build --strict` | **exit 0**, 64.1 s |
| — coverage of this diff | **none.** `docs/design/hicasso/` is in `mkdocs.yml`'s `exclude_docs`; the build log mentions `design/hicasso` **0 times**. Cited for the rest of the site only |
| internal links + anchors, by hand | **68 checked across the 5 touched pages, 0 broken** |
| markdown tables, by hand | **43 tables / 198 body rows across the 5 touched pages, 0 ragged** |
| figures quoted two ways | cross-grepped 2,935 · 2,929 · 2,887 · 2,970 · 943 · 1,345 · 1,590 · 866 · 2,783 · 2,774 · 769 across all of `docs/design/hicasso/` — consistent everywhere. One relative-direction slip repaired (the sweep sits 5.5% **above** the corrected ladder slope; the page read "+5.5% below" it) |
| benchmarks | **not run, deliberately.** Two tournament arms have the box, and this PR measures nothing |

Docs only: 5 files, no code, no `.beads`, nothing under `ai/`.

Beads: `rf2-5prok` · `rf2-e3flf` · `rf2-hvl5s`.
