### PR TITLE
hicasso: Wave-1 Arm 1 — lean-React (rf2-2rtt6.9)

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -105,6 +105,17 @@
   ;; a Var, optional docstring + body expression analysed).
   re-frame.core/defmachine          clojure.core/def
 
+  ;; Hicasso Arm 1's `defview` (rf2-2rtt6.9) is
+  ;; `(defview sym [doc] [props] body+)` — a `defn`-shaped wrapper that
+  ;; introduces a Var holding the React function component the runtime
+  ;; minted. `clojure.core/defn` is the right shape: the name resolves as
+  ;; a Var, the optional docstring is accepted, and the props vector gets
+  ;; ordinary lexical-binding analysis so a destructured key is neither
+  ;; unresolved nor unused. It lives in the bench/test tree on a spike
+  ;; branch (HD-017), so this entry retires with the arm if the P2 ruling
+  ;; does not graduate it.
+  re-frame.bench.hicasso.arm1.lang/defview clojure.core/defn
+
   ;; `reg-view` is `(reg-view sym [args] body)` — defn-shape, but the
   ;; macro auto-injects `dispatch` / `subscribe` into the body. Handled
   ;; by the dedicated hook in `.clj-kondo/hooks/re_frame/core.clj` —

--- a/docs/design/hicasso/studio/README.md
+++ b/docs/design/hicasso/studio/README.md
@@ -97,6 +97,7 @@ requires nothing from any donor `src/` tree.
 | [The UIx spine's per-read allocation, decomposed](uix-spine-per-read-decomposition.md) | P0 | Where a UIx-on-subs read's bytes go. |
 | [The cold-mount double build, priced against the mount red-zone](coldmount-double-build-priced.md) | P0 | What the double build **costs on the clock**, as a fraction of the same-run UIx-minus-Reagent mount excess — the rf2-2rtt6.14 decision input. |
 | [The reagent-slim non-reactive arm — diagnosis](slim-non-reactive-arm-diagnosis.md) | P0 | Why HD-008's reagent-slim arm read `78 unverified of 78`: the **arm's composition**, not the adapter and not the mixed bundle. A single-substrate slim bundle re-renders on every write. |
+| [Arm 1 — lean-React: the mechanism and the dogfood judgement](arm1-lean-react-dogfood-judgement.md) | P1 | How the ≤2-hook shell was reached, the collector against HD-002's four clauses, and the three-rendering ergonomics verdict. **Publishes no bar row** — mechanism, correctness witnesses and preference only. |
 
 **Clock red-zones live on the converged page.** Where it and the frontier arm
 disagree, the converged row is the operative one: the bar's denominator is

--- a/docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md
+++ b/docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md
@@ -1,0 +1,381 @@
+# Arm 1 — lean-React: the mechanism, and the three-rendering dogfood judgement
+
+**Bead:** `rf2-2rtt6.9` · **Arm:** Hicasso lean-React
+([architecture.md](../architecture.md) Arm 1) · **Branch:** `worker/arm1-2rtt6-9`
+
+> **This page publishes no bar row.** The clock gate lines are being re-taken
+> (`rf2-b0tz5`), and this arm's candidate rows are scored against the restated
+> bar when it is ready. Everything below is either a *mechanism* description, a
+> *correctness* witness, or an *ergonomics* judgement — none of it is a clock or
+> a retained-heap figure quoted against a red-zone.
+
+The runtime skeleton stays **off main**, on the spike branch, per HD-017. What is
+on this page is the record the P2 ruling reads.
+
+---
+
+## 1. The shell, and how the ≤2-hook budget was actually reached
+
+HD-020(b) makes the budget a hard line: two hooks, and `useRef` banned in the
+shell. The obstacle is not the third hook — it is that React offers a function
+component **no per-instance storage except a hook cell**, so a shell that wants
+one has already spent a third hook before it starts. Every real
+`useSyncExternalStore` wrapper in the wild, including this repository's own
+spine, holds three `useRef`s.
+
+The way out is to notice what the two closures need to close over.
+
+| Closure | Closes over | Consequence |
+|---|---|---|
+| `subscribe` | the render's sub-key **set**, and nothing else | a pure function of a value, so it is cached by that value and **shared** by every boundary reading the same set |
+| `getSnapshot` | the same set | returns the sum of those keys' epochs — monotone, so `Object.is` on one number is a correct change test with no memo |
+
+Because `subscribe` is identity-stable exactly while the read set is unchanged,
+React's own re-subscribe condition (`prevSubscribe !== subscribe`) becomes
+"the read set changed" — which is the *only* thing that should trigger edge
+maintenance. React then calls that shared closure once per **fiber**, handing it
+that fiber's own `onStoreChange`; the registration minted inside is therefore
+per-boundary, durable for the mount, and commit-owned. It is the boundary id the
+index keys on, and a render that never commits registers nothing.
+
+So the shell is:
+
+```clojure
+(let [frame-kw (react/useContext adapter-context/frame-context)   ; hook 1
+      element  (render-body frame-kw body-fn props)               ; not a hook
+      entry    (.-entry rstate)]
+  (react/useSyncExternalStore (.-subscribe entry) (.-snapshot entry) …) ; hook 2
+  element)
+```
+
+The body runs *between* the hooks. That is legal because what React fixes is
+hook **order and count**, not the position of ordinary code around them — and it
+is what lets the subscription hook close over the reads the body just made.
+
+### The budget is measured, not declared
+
+`arm1_hook_ledger_dom_cljs_test` replaces React's shared-internals dispatcher
+slot with a counting `Proxy` and reads back what React was actually asked for.
+
+| Boundary | Reads | Hooks React was asked for |
+|---|---:|---|
+| Hicasso shell | 1 | `["useContext" "useSyncExternalStore"]` |
+| Hicasso shell | 7 | 2 |
+| Hicasso shell | 20 | 2 |
+| Raw UIx (`use-subscribe` ×1) | 1 | strictly more than the whole Hicasso shell |
+| Raw UIx (`use-subscribe` ×3) | 3 | more again — the count rises **with** the read count |
+
+No `useRef`, no `useState`, no `useMemo`, no `useCallback` in the shell. The
+probe counts what the *body* calls: `useSyncExternalStore` is one dispatcher
+call, and React's internal machinery for it does not go back through the slot.
+When React's internals slot cannot be found the witness records **UNWITNESSED
+and fails** — it never reads as a pass.
+
+---
+
+## 2. The collector, against HD-002's four clauses
+
+The operator ruled on 2026-07-31 that the ambient collector (Surface B) is the
+only read surface acceptable on ergonomics, and that grouped `use-subs` is below
+the usability bar. The collector is therefore the surface this arm engineers for.
+That inverts which tier is *defended*; it waives none of the correctness gates,
+and [the adjudication](../hd-002-adjudication.md)'s tripwire still overrides the
+clock.
+
+### (a) The ownership state machine
+
+One sentence carries it, and it is the positive form of the tripwire:
+
+> **No render-phase code mutates the index or a subscription ref-count. The only
+> global mutation is the commit's.**
+
+| State | What holds |
+|---|---|
+| `RENDERING` | reads append to **one** module-level scratch array, reset by overwrite at the top of every body |
+| `PENDING` | the body returned; the scratch has resolved to a cached read-set entry; the index is untouched |
+| `COMMITTED` | React called the entry's `subscribe`: the registration exists, edges are installed, cells acquired |
+| `UNMOUNTED` | React called the cleanup; edges and references released |
+
+An abandoned render is `PENDING → RENDERING` and needs **no cleanup**, because it
+never did anything that would need cleaning. StrictMode's double-invoke is
+correct for the same reason: the reset is unconditional, so two runs replace
+rather than concatenate.
+
+Witnesses: `a-render-mutates-neither-the-index-nor-a-reference`,
+`a-re-render-before-the-commit-destroys-the-previous-candidate-by-overwrite`,
+`a-body-that-throws-leaves-nothing-behind`,
+`a-render-that-never-commits-leaves-nothing-behind`.
+
+### (b) The allowed edge-diff operation
+
+A boundary's edge set is **replaced wholesale, once, at commit** — the shared
+front half's `record-reads` set difference — and only when the read set actually
+changed, because an unchanged set leaves `subscribe` identical and React does not
+call it again. **The unchanged case is detected without building anything:** the
+scratch array is compared pairwise against the cached entry's key array, so
+steady-state allocation for edge maintenance is zero bytes.
+
+The ordered compare is a **false-negative device, never a wrong answer** — two
+renders reading the same keys in a different order miss the compare, take a
+second entry with the same set, and React replaces a set with itself. It is
+deliberately not repaired with a content hash, whose failure mode would be a
+silently missing edge.
+
+Against the forbidden list: no per-read object; one scratch and never two;
+nothing keyed by render, attempt, lane or generation; no registry of in-flight
+renders; **no commit-phase re-read of subscription values**.
+
+Witnesses: `an-unchanged-read-set-is-detected-without-building-anything`,
+`a-changed-read-set-takes-a-different-subscribe-identity`,
+`a-boundary-holds-exactly-the-edges-its-latest-commit-installed`,
+`reading-one-key-twice-is-one-edge`,
+`a-warm-read-performs-no-new-attach-or-release`.
+
+### (c) The two pre-registered hypotheses — one consumed as *implemented*, neither yet as *benchmarked*
+
+The counting rule is explicit: a hypothesis is consumed when a commit implements
+it **and** a bench row on the standard witness set cites that commit SHA and its
+reproduction command. Both halves, or it is not consumed. **No bench row exists
+yet**, so on the rule as written **neither swing has been spent.** What is
+recorded here is the implementation half, so the later bench row has something to
+cite.
+
+- **H1 — commit-side ordered compare.** Implemented, in the form the mechanism
+  above describes. It differs from the adjudication's sketch in *where* the
+  compare sits: the page imagines a commit-phase pass over the scratch, and this
+  arm does the compare when the scratch resolves to its entry, which lets the
+  commit do **no work at all** in the unchanged case rather than a cheap pass.
+  That is strictly inside the allowed operation and strictly less work; it is
+  recorded here because a reader comparing code to page should not have to
+  wonder.
+- **H2 — render-side positional verification.** Not implemented. Not abandoned
+  either: it is untried, and the record says an unrecorded abandonment is how two
+  swings quietly become five.
+
+### (d) The survival metric
+
+Two halves. **Zero retained per-occurrence objects after commit/teardown** is
+witnessed now — `arm1_runtime_cljs_test` asserts `{:cells 0 :cell-refs 0
+:boundaries 0 :edges 0 :entries 0}` after release, and every DOM suite asserts
+the same after its mount. **The steady-state allocation slope across warm
+1/3/7/20 reads** needs the bench and is not taken here.
+
+### The tripwire did not fire
+
+No construct in this arm needs to survive from one render attempt to a different
+render attempt of the same boundary, or to be told apart from another attempt's
+version of itself. The nearest approach — and it is worth naming, because it is
+one line from the fence — is the **read-set entry cache**. It is keyed by read-set
+*content*, never by a render or an attempt; it is a cache whose eviction is a
+macrotask reaper rather than a record of anything to undo; and dropping an entry
+early costs one re-subscribe and no correctness. That is the allowed
+"per-boundary reused scratch buffer" generalised to one buffer for the runtime,
+not a second candidate slot.
+
+---
+
+### Laziness — a Surface B property, checked and refuted here
+
+Arm 2 hit this in Chromium and flagged it across the tournament: **`for` returns
+a lazy sequence**, so every `(sub …)` inside one runs when something walks the
+seq, not when the body returns. A collector that closed at the body's return
+would register *no edge for any row*, and would look perfectly correct on the
+first render — the values are right once realised — while never updating again.
+It is the hardest class of bug to attribute, because the first paint is clean.
+
+**This arm does not have it, and the reason is structural rather than careful.**
+The collector window closes around `codec/as-element`, and the codec is eager
+everywhere it walks: `expand-seq` drives a seq to exhaustion, `realize-children`
+folds one into a vector, and a seq at a prop position goes through `clj->js`. A
+lazy read is therefore forced inside the window by the same pass that turns
+hiccup into elements. No `doall`, no `vec`, no widened window, and so no cost:
+the realisation was already going to happen, at the same moment, for the same
+reason. The ≤2-hook budget is untouched.
+
+Verified rather than argued, on both halves — because the first half alone is
+exactly what a broken implementation also passes:
+
+| Witness | Asserts |
+|---|---|
+| `a-lazy-for-registers-its-edges-and-its-readers-re-run` | all four edges (the ids query + one per row) are installed by the commit, **and** a write to a row query the `for` produced re-runs the boundary |
+| `a-lazy-seq-returned-as-the-body-root-registers-its-edges-too` | the same at the root position, where no enclosing vector forces the walk |
+| `reads-inside-a-lazy-for-update-the-dom-on-a-later-write` | through a real React commit: the first paint is right, **and** a later write reaches the DOM while the neighbouring row is untouched |
+
+The tests are what keep the property true: moving the codec call outside
+`run-once` fails the first of them.
+
+## 3. Two places the record did not survive contact with the substrate
+
+Both are findings rather than complaints, and both are recorded because the next
+arm will meet them.
+
+### 3.1 "Acquire without deref" is not implementable here
+
+The adjudication sketches commit-phase acquisition as *acquire without deref: the
+value is already known from the render*. Against this substrate that is not
+implementable, and the failure is silent. A derived value starts at an `unset`
+baseline that is never `rf=` a real value, and the render's own read went through
+`subscribe-once`, which built a **different** reaction and disposed it. So a
+freshly acquired reaction reports movement on the first later commit whatever
+that commit did — **every newly mounted boundary re-rendering once for nothing.**
+
+The fix is one baseline deref per *new unique key*, on a path that has to compute
+anyway; it never runs again for the life of the cell, and it is not the forbidden
+per-read-per-commit tear check. The narrow-write witness is what caught it, which
+is the argument for writing the witness before trusting the sketch.
+
+### 3.2 The ambient frame outranks React context, and it is invisible
+
+The three-rendering parity gate initially failed with the raw-UIx rendering
+showing an empty app-db while `use-current-frame` reported the *right* frame in
+the same component. The frame probe separated the two read forms: the
+explicitly-framed `use-subscribe` saw the seeded db, the ambient one did not.
+
+The cause is the test fixture's default ambient frame. The carried-invariant
+chain resolves the **dynamic-var tier before React context**, so an ambient read
+answers for the ambient frame while `use-current-frame` — a raw context read —
+reports the provider's. The two disagree silently, and the symptom presents as a
+*rendering* difference. `:ambient-frame nil` is now set in every DOM fixture in
+this arm, and the probe asserts the two read forms agree so a regression names
+the plumbing rather than the rendering.
+
+Worth knowing for the product: this arm's shell reads the context **directly**
+and so is unaffected by an ambient stamp. Whether that is the right resolution
+policy for a product boundary is a question for the P2 phase, not this bead.
+
+---
+
+## 4. The dogfood screen, in three renderings
+
+One list, one controlled field per editable thing, on **one** shared state layer
+and **one** shared intent set (`front/dogfood`), so the comparison is about the
+reading surface and nothing else. All three build the identical canonical DOM
+(attribute names sorted), with a control proving the comparison can answer false.
+
+**Mounting this screen started the six-week K7 clock (HD-014).** The operator is
+on record accepting that (`rf2-2rtt6`, 2026-07-31). K7 is never extended
+silently.
+
+### The diff, at the four sites where it exists
+
+**The row — the conditional read.** A completed row is not editable, so its draft
+subscription is not needed.
+
+```clojure
+;; collector — the read is where the value is used
+(when-not (:done? todo)
+  [:input.draft {:value (sub [:dogfood/draft id]) …}])
+
+;; grouped — the query is declared before the body, so the branch that is
+;; not taken still costs its edge
+(let [{:keys [todo draft]} (use-subs {:todo  [:dogfood/todo id]
+                                      :draft [:dogfood/draft id]})]
+  … (when-not (:done? todo) [:input.draft {:value draft …}]))
+
+;; raw UIx — same as grouped, and NOT by choice: a hook may not sit in a `when`
+(let [todo  (uixa/use-subscribe [:dogfood/todo id])
+      draft (uixa/use-subscribe [:dogfood/draft id])] …)
+```
+
+This is measured, not asserted: `arm1_dogfood_dom_cljs_test` toggles two rows and
+reads the index's edge count, and the collector rendering holds **fewer edges
+than the declaration on the same page**. The ruled grouped alternative — a
+conditional *child boundary* owning the draft — buys the edge back at the cost of
+a second `defview` and a second boundary per editable row; it is not what a
+working author writes, which is why the grouped rendering here does not pretend
+otherwise.
+
+**The helper — the donated read.** `filter-button` needs the current filter.
+
+```clojure
+;; collector — a plain function call inlines into the enclosing boundary,
+;; so its read belongs to that boundary and needs no argument
+(defn- filter-button [id label]
+  [:button.filter {:data-current (str (= id (sub [:dogfood/filter]))) …} label])
+
+;; grouped and raw UIx — the value is threaded down as an argument, because a
+;; helper has no fixed hook site for a read to occupy
+(defn- filter-button [id label current] …)
+```
+
+The adjudication's §5 offers grouped a second move — a helper that contributes
+*queries* into the single `use-subs` map rather than reading. It is real and it
+composes; it is also a second concept (query-contributing helpers) that the
+collector does not need, and on a screen this size it reads as ceremony. Recorded
+so the comparison is not run with one hand tied.
+
+**The loop.** Under the collector a read inside `for` is ordinary code. Under the
+other two it is illegal, so the read has to move up to a fixed site and the loop
+consumes a value it was handed. On this screen that is a one-line difference; on
+a screen where the loop's body decides *which* query it needs, it is a
+restructuring.
+
+**The event position.** Both Hicasso renderings hand the shared
+`front.dogfood/row-intents` vectors straight to the props map. The raw UIx
+rendering writes seven closures, each reaching into the event for `.-value` and
+each re-implementing the IME composition gate. Every one of them is a place the
+wrong event id can be written with nothing to notice.
+
+### The preference
+
+**Surface B (the collector) is preferred, and the reason is not brevity.** Line
+counts are close — the collector rendering is a handful of lines shorter than
+grouped, which would not on its own decide anything. What decides it is that the
+collector is the only surface where **the read is at the value's point of use**,
+so the question "what does this boundary depend on?" is answered by reading the
+body rather than by cross-referencing a declaration against it. Grouped's
+declaration and its body can drift: a query left in the map after its use is
+deleted is an edge nobody notices, and the compiler-free runtime has no way to
+say so. On the collector that drift is not expressible.
+
+The raw-UIx rendering is the control and it loses on ergonomics decisively — not
+because of the `$` spelling, which is a matter of taste, but because it cannot
+express the conditional read, cannot let a helper read, and turns every event
+position into hand-written imperative code.
+
+The honest cost on the other side: the collector's edge set is a function of what
+the body *did*, so a body whose control flow depends on a value read late can
+change its edge set from render to render, and each change is a re-subscribe. The
+mechanism makes that cheap (an identity change and one replacement) and the
+witnesses prove it is correct, but it is a real difference from a surface whose
+edges are static, and it is the thing to watch on the bulk rows when they are
+taken.
+
+---
+
+## 5. What this arm has not done
+
+Named so the P2 ruling is not misled by silence.
+
+- **No bar row.** No clock, no retained-heap figure, no ratio. Deferred to the
+  restated bar (`rf2-b0tz5`).
+- **H2 untried.** Untried, not abandoned.
+- **The survival metric's allocation-slope half** is unmeasured; its
+  zero-retained half is witnessed.
+- **The 100-cell controlled grid** (HD-019's full witness — caret, selection, IME
+  composition, unchanged-model rejection, async normalisation) is not built. The
+  same-turn echo and the explicit-revision reset are witnessed on the dogfood
+  screen's own controlled field; the rest of K4's row is outstanding.
+- **StrictMode, HMR body swap and a real error boundary** (`h/boundary`,
+  HD-020(c)) are not witnessed. The abandoned-render and teardown halves of that
+  row are.
+- **The foreign-component / `defhost` door** (HD-011) is untouched; the codec
+  passes a React element through as a child, which is the whole of the interop
+  this arm exercises.
+
+## Reproduction
+
+```bash
+cd implementation
+
+# the runtime, the read surfaces, the state machine, the allowed edge-diff
+# operation, the fence algebra and the residue — no browser needed
+npx shadow-cljs compile node-test && node out/node-test.js
+
+# the hook ledger at React's dispatcher, the staged-stale fence, and the
+# dogfood screen's three renderings against a real React DOM
+npx shadow-cljs compile browser-test && node scripts/serve-and-run-browser-tests.cjs
+```
+
+Both are diagnostic and correctness runs. Neither is a bar measurement, and
+neither may be quoted as one.

--- a/docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md
+++ b/docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md
@@ -3,6 +3,25 @@
 **Bead:** `rf2-2rtt6.9` · **Arm:** Hicasso lean-React
 ([architecture.md](../architecture.md) Arm 1) · **Branch:** `worker/arm1-2rtt6-9`
 
+> **Status, 2026-07-31: this is no longer a tournament arm — it is the product
+> line.** The operator ruled that Hicasso is "an adaptor for React that is
+> optimised for re-frame2, user ergonomics and performance", and dropped Arm 2
+> (PATCH) on product direction rather than on measurement — it had met its hard
+> gate. The competitive framing below (parity gates against a rival, the
+> like-for-like fences) was written before that ruling and is left standing
+> because the evidence is unaffected: a canonical-DOM parity gate against the
+> raw-UIx control is worth exactly as much when the control is a comparator as
+> when it was a rival.
+>
+> Two consequences the ruling makes sharper rather than softer. **Surface B is
+> the only acceptable read surface**, so if the collector cannot be made correct
+> the answer is NULL — grouped is not a fallback. And **HD-002(a)'s ownership
+> state machine is fully live here**: React owns the render phase in this
+> architecture, so every read is a candidate until a commit adopts it, and the
+> candidate-ledger tripwire is a real kill signal rather than a formality. §2
+> below is that clause discharged, and §2's closing paragraph names the nearest
+> approach to the fence.
+
 > **This page publishes no bar row.** The clock gate lines are being re-taken
 > (`rf2-b0tz5`), and this arm's candidate rows are scored against the restated
 > bar when it is ready. Everything below is either a *mechanism* description, a
@@ -203,6 +222,23 @@ exactly what a broken implementation also passes:
 
 The tests are what keep the property true: moving the codec call outside
 `run-once` fails the first of them.
+
+**And the eager codec is only half of it.** A codec forces the reads it *walks*;
+nothing can force a read the author deferred past the render — a handler closure,
+a `delay`, a lazy seq stashed rather than returned. Each of those would otherwise
+be a **silent** missing edge, which is the worst failure mode the ruled surface
+can have: correct on screen, frozen thereafter, attributable to nothing. The
+render frame is therefore set in a `try` and cleared in the matching `finally`,
+and a read that finds none **fails loudly, naming the query**. Four escapes are
+witnessed by `every-read-that-escapes-the-render-is-loud-rather-than-a-missing-edge`
+— a stored handler, a handler actually invoked, an author-held `delay`, and a
+stashed lazy seq forced after the render.
+
+One residual case the guard cannot see, named rather than left to be discovered:
+a deferred read forced *inside another boundary's* render is attributed to that
+boundary. It is not a missing edge — the reader does re-render — but it is the
+wrong reader, and catching it would need per-boundary render identity the shell
+deliberately does not hold.
 
 ## 3. Two places the record did not survive contact with the substrate
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_collector.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_collector.cljs
@@ -1,0 +1,83 @@
+(ns re-frame.bench.hicasso.arm1.dogfood-collector
+  "THE DOGFOOD SCREEN — RENDERING 1 OF 3: the ambient collector (HD-002
+  tier 3, the challenger).
+
+  One list, one controlled field per editable thing, and subscription
+  reads written wherever the value is used: in a `let`, inside a `when`,
+  inside a helper. That is the whole of the tier's authoring claim, and
+  the row below is where it earns or loses its place — the draft
+  subscription is read **only when the row is editable**, so a completed
+  row holds one edge and an editable row holds two. No other tier in the
+  tournament can write that.
+
+  The state layer is the shared front half's
+  (`re-frame.bench.hicasso.front.dogfood`) and the intents are its
+  `row-intents` / `new-item-intents`, so the three renderings cannot
+  drift on events while claiming to differ only on the view. What differs
+  between the three files is the reading surface and nothing else; the
+  DOM is asserted identical by `arm1_dogfood_dom_cljs_test`.
+
+  Mounted by `arm1_dogfood_dom_cljs_test` — and mounting it is what
+  started the six-week K7 clock (HD-014)."
+  (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.bench.hicasso.front.dogfood :as d])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(defview head [_]
+  (let [remaining (sub [:dogfood/remaining])]
+    [:header.head
+     [:h1.title "todos"]
+     [:span.remaining {:data-remaining remaining} (str remaining " left")]]))
+
+(defview new-item [_]
+  (let [{:keys [on-input on-submit on-key-down]} (d/new-item-intents)]
+    [:form.new {:on-submit on-submit}
+     [:input.new-input {:type      "text"
+                        :value     (sub [:dogfood/draft d/new-draft-key])
+                        :on-input  on-input
+                        :on-key-down on-key-down}]
+     [:button.add {:type "submit"} "Add"]]))
+
+(defn- filter-button
+  "A plain function call — it inlines into the enclosing boundary and
+  mints no boundary of its own (HD-016). The `sub` it donates is the
+  collector-contingent case authoring.md names: legal here, and only
+  here, because this tier tracks reads wherever they happen."
+  [id label]
+  [:button.filter {:type      "button"
+                   :data-filter (name id)
+                   :data-current (str (= id (sub [:dogfood/filter])))
+                   :on-click  [:dogfood/set-filter id]}
+   label])
+
+(defview filters [_]
+  [:nav.filters
+   (filter-button :all "All")
+   (filter-button :active "Active")
+   (filter-button :done "Done")])
+
+(defview row [{:keys [id]}]
+  (let [todo (sub [:dogfood/todo id])
+        {:keys [on-click-toggle on-click-remove on-input-title on-key-down]}
+        (d/row-intents id)]
+    [:li.row {:data-id id :data-done (str (boolean (:done? todo)))}
+     [:button.toggle {:type "button" :on-click on-click-toggle} "✓"]
+     [:span.label (:title todo)]
+     (when-not (:done? todo)
+       [:input.draft {:type        "text"
+                      :value       (sub [:dogfood/draft id])
+                      :on-input    on-input-title
+                      :on-key-down on-key-down}])
+     [:button.remove {:type "button" :on-click on-click-remove} "x"]]))
+
+(defview todo-list [_]
+  [:ul.list {:role "list"}
+   (for [id (sub [:dogfood/visible-ids])]
+     [row {:key id :id id}])])
+
+(defview screen [_]
+  [:div.dogfood
+   [head {}]
+   [new-item {}]
+   [filters {}]
+   [todo-list {}]])

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_dom_cljs_test.cljs
@@ -1,0 +1,314 @@
+(ns re-frame.bench.hicasso.arm1.dogfood-dom-cljs-test
+  "THE DOGFOOD SCREEN, MOUNTED — AND THE SIX-WEEK CLOCK (rf2-2rtt6.9).
+
+  **HD-014 starts the K7 clock at the first Hicasso-arm commit that
+  mounts the dogfood screen. This is that mount.** The operator is on
+  record accepting it (rf2-2rtt6, 2026-07-31); K7 is never extended
+  silently.
+
+  validation.md asks for one list, one controlled field and subscription
+  reads, written in three renderings — the collector surface, the grouped
+  `use-subs` surface, and raw UIx — \"judged on diff and preference by
+  its authors\". The written judgement is
+  `docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md`. What
+  is asserted here is the half a judgement cannot supply: that the three
+  renderings build **the same page**, so the comparison is about the
+  reading surface and nothing else.
+
+  Three claims:
+
+  1. **Canonical-DOM parity** across all three, with attribute names
+     sorted, and a control that proves the comparison can answer false.
+  2. **The narrow write touches one row.** A toggle re-renders the row it
+     names and no other, on both Hicasso renderings — which is the index
+     doing its job through React rather than a claim about it.
+  3. **The controlled field echoes in the caller's turn** (HD-019's
+     synchronous door), and the collector's conditional read means a
+     completed row holds one edge where the grouped rendering holds two.
+
+  No clock is read and no bar row is published: the clock gate lines are
+  being re-taken (rf2-b0tz5) and this arm's rows are scored against the
+  restated bar later.
+
+  Runtime: `-dom-cljs-test`; under `:node-test` every claim degrades to a
+  stated skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.dogfood-collector :as collector]
+            [re-frame.bench.hicasso.arm1.dogfood-grouped :as grouped]
+            [re-frame.bench.hicasso.arm1.dogfood-uix :as raw-uix]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]
+            [uix.core :refer [$ defui]]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     ;; `:ambient-frame nil` is load-bearing, not tidiness. The fixture's
+     ;; default leaves a dynamic-var frame stamp in scope, and the
+     ;; carried-invariant chain resolves that tier BEFORE React context —
+     ;; so the comparator's ambient `use-subscribe` would read the
+     ;; ambient frame's app-db while `use-current-frame` reported the
+     ;; provider's, and a parity miss would look like a rendering
+     ;; difference. Caught by the frame probe below, which is why the
+     ;; probe stays.
+     :ambient-frame nil
+     :init-fn (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::arm1-dogfood)
+(def ^:private todo-count 6)
+
+(defn- skip! [why] (is true (str "the dogfood screen needs a real React DOM — " why)))
+
+(defn- fresh!
+  "A frame holding exactly the seeded page, whatever a previous mount in
+  this test did to it. Both halves are needed and neither is redundant:
+  `make-frame!` is idempotent, so it will NOT replay its initial events
+  for an id that already exists, and `reseed!` is the front half's own
+  door for returning a live frame to its seeded state."
+  []
+  (lane/leave-act-environment!)
+  (dogfood/make-frame! frame-id todo-count)
+  (dogfood/reseed! frame-id todo-count)
+  frame-id)
+
+;; ---------------------------------------------------------------------------
+;; The three mounts
+;; ---------------------------------------------------------------------------
+
+(defn- hicasso-mount!
+  "Either Hicasso rendering, on the arm's own root."
+  [screen]
+  (mount/root! (mount/fresh-container!) frame-id [screen {}]))
+
+(defn- uix-mount!
+  "The comparator, on its own React root and its own `frame-provider`.
+  Deliberately NOT the arm's root: the control must not borrow the
+  candidate's plumbing, or a plumbing bug would hide inside the parity
+  gate it is supposed to expose."
+  []
+  (let [container (mount/fresh-container!)
+        root      (react-dom-client/createRoot container)]
+    (react-dom/flushSync (fn [] (.render root (raw-uix/root frame-id))))
+    {:root root :container container :uix? true}))
+
+(defn- release-uix! [handle]
+  (react-dom/flushSync (fn [] (.unmount (:root handle))))
+  (when-some [p (.-parentNode (:container handle))] (.removeChild p (:container handle)))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; 0 — the comparator resolves the same frame this test seeded
+;; ---------------------------------------------------------------------------
+;;
+;; A parity miss between a candidate and its control is only informative
+;; if the control was reading the same app-db. This asks that question on
+;; its own, so a failure names the plumbing rather than the rendering.
+
+(defui frame-probe [_props]
+  ($ :div.probe {:data-frame (str (uix-adapter/use-current-frame))
+                 :data-ambient (str (uix-adapter/use-subscribe [:dogfood/remaining]))
+                 :data-explicit (str (uix-adapter/use-subscribe frame-id [:dogfood/remaining]))}))
+
+(deftest the-comparator-reads-the-frame-this-test-seeded
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (is (= todo-count (rf/with-frame frame-id (deref (rf/subscribe [:dogfood/remaining]))))
+          "the frame itself is seeded")
+      (let [container (mount/fresh-container!)
+            root      (react-dom-client/createRoot container)]
+        (react-dom/flushSync
+          (fn [] (.render root ($ uix-adapter/frame-provider {:frame frame-id}
+                                  ($ frame-probe)))))
+        (let [probe (.querySelector container ".probe")]
+          (is (= (str frame-id) (.getAttribute probe "data-frame"))
+              "the comparator's provider scopes the frame this test seeded")
+          (is (= (str todo-count) (.getAttribute probe "data-explicit"))
+              "an explicitly-framed read sees that frame's app-db")
+          (is (= (str todo-count) (.getAttribute probe "data-ambient"))
+              "and so does the ambient read the comparator is written with"))
+        (react-dom/flushSync (fn [] (.unmount root)))
+        (when-some [pn (.-parentNode container)] (.removeChild pn container))))))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the same page, three ways
+;; ---------------------------------------------------------------------------
+
+(deftest the-three-renderings-build-the-same-page
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    ;; The comparator goes FIRST, on the freshest possible frame. If it
+    ;; went last, a parity miss could be read either as a rendering
+    ;; difference or as residue from the two mounts before it, and the
+    ;; gate would not be able to tell a reader which.
+    (let [_ (fresh!)
+          c (uix-mount!)
+          c-dom (lane/canonical (:container c))
+          _ (release-uix! c)
+          _ (fresh!)
+          a (hicasso-mount! collector/screen)
+          a-dom (lane/canonical (:container a))
+          _ (mount/release! a)
+          _ (fresh!)
+          b (hicasso-mount! grouped/screen)
+          b-dom (lane/canonical (:container b))
+          _ (mount/release! b)]
+      (is (= a-dom b-dom) "collector and grouped build the same page")
+      (is (= a-dom c-dom) "and so does raw UIx")
+      (testing "the comparison can answer false, so it is not passing vacuously"
+        (fresh!)
+        (let [d     (hicasso-mount! collector/screen)
+              _     (mount/dispatch! d [:dogfood/toggle 0])
+              moved (lane/canonical (:container d))]
+          (mount/release! d)
+          (is (not= a-dom moved))))
+      (testing "and the page is the screen validation.md asked for — a list
+               and a controlled field"
+        (is (re-find #"<ul class=\"list\"" a-dom))
+        (is (re-find #"class=\"new-input\"" a-dom))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the narrow write touches one row
+;; ---------------------------------------------------------------------------
+
+(defn- row-text [handle id]
+  (some-> (.querySelector (:container handle) (str "[data-id=\"" id "\"] .label"))
+          (.-textContent)))
+
+(defn- row-done [handle id]
+  (some-> (.querySelector (:container handle) (str "[data-id=\"" id "\"]"))
+          (.getAttribute "data-done")))
+
+(deftest a-toggle-moves-exactly-the-row-it-names
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (doseq [[label screen] [["collector" collector/screen] ["grouped" grouped/screen]]]
+      (fresh!)
+      (let [handle (hicasso-mount! screen)]
+        (try
+          (is (= "false" (row-done handle 1)) label)
+          (mount/dispatch! handle [:dogfood/toggle 1])
+          (is (= "true" (row-done handle 1)) (str label ": the named row moved"))
+          (is (= "false" (row-done handle 0)) (str label ": and its neighbour did not"))
+          (is (= "false" (row-done handle 2)) (str label ": nor the one after"))
+          (finally (mount/release! handle)))))))
+
+(deftest a-broad-write-rebuilds-the-list
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (hicasso-mount! collector/screen)]
+        (try
+          (mount/dispatch! handle [:dogfood/toggle 1])
+          (is (= todo-count (.-length (.querySelectorAll (:container handle) ".row"))))
+          (mount/dispatch! handle [:dogfood/set-filter :done])
+          (is (= 1 (.-length (.querySelectorAll (:container handle) ".row")))
+              "the filter is a broad write: the visible-ids subscription
+               moved and the list rebuilt")
+          (is (= "todo 1" (row-text handle 1)))
+          (finally (mount/release! handle)))))))
+
+(deftest keyed-rows-keep-their-identity-across-a-reorder
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (hicasso-mount! collector/screen)]
+        (try
+          (let [node-before (.querySelector (:container handle) "[data-id=\"3\"]")]
+            (mount/dispatch! handle [:dogfood/move 3 0])
+            (let [rows (array-seq (.querySelectorAll (:container handle) ".row"))]
+              (is (= "3" (.getAttribute (first rows) "data-id"))
+                  "the moved row is first")
+              (is (identical? node-before (.querySelector (:container handle) "[data-id=\"3\"]"))
+                  "and it is the SAME node — identity follows the key")))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the controlled field, and what the collector's conditional read buys
+;; ---------------------------------------------------------------------------
+
+(defn- new-input [handle] (.querySelector (:container handle) ".new-input"))
+
+(deftest the-controlled-field-echoes-in-the-callers-turn
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (hicasso-mount! collector/screen)]
+        (try
+          (let [input (new-input handle)]
+            (is (= "" (.-value input)))
+            ;; The intent's own path: dispatch through the arm's
+            ;; synchronous door, exactly as the lowered `:on-input`
+            ;; closure does, and read the DOM on the next line.
+            (rt/dispatch! frame-id [:dogfood/edit-draft dogfood/new-draft-key "milk"])
+            (mount/settle!)
+            (is (= "milk" (.-value (new-input handle)))
+                "the echo landed without waiting for a later turn"))
+          (finally (mount/release! handle)))))))
+
+(deftest the-submit-intent-creates-and-clears-the-draft
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (hicasso-mount! collector/screen)]
+        (try
+          (rt/dispatch! frame-id [:dogfood/edit-draft dogfood/new-draft-key "milk"])
+          (mount/settle!)
+          (rt/dispatch! frame-id [:dogfood/create])
+          (mount/settle!)
+          (is (= (inc todo-count) (.-length (.querySelectorAll (:container handle) ".row"))))
+          (is (= "milk" (row-text handle todo-count)))
+          (is (= "" (.-value (new-input handle)))
+              "and the draft cleared by explicit caller revision, never by
+               value equality")
+          (finally (mount/release! handle)))))))
+
+(deftest the-collectors-conditional-read-costs-fewer-edges-than-the-declaration
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [collector-edges (let [h (hicasso-mount! collector/screen)]
+                              (mount/dispatch! h [:dogfood/toggle 0])
+                              (mount/dispatch! h [:dogfood/toggle 1])
+                              (let [e (:edges (rt/stats))] (mount/release! h) e))
+            _ (fresh!)
+            grouped-edges   (let [h (hicasso-mount! grouped/screen)]
+                              (mount/dispatch! h [:dogfood/toggle 0])
+                              (mount/dispatch! h [:dogfood/toggle 1])
+                              (let [e (:edges (rt/stats))] (mount/release! h) e))]
+        (is (< collector-edges grouped-edges)
+            (str "two completed rows drop their draft edge under the collector "
+                 "and keep it under the declaration (" collector-edges " vs "
+                 grouped-edges ") — the same page, two edge counts, which is "
+                 "the surface difference stated as a number rather than a "
+                 "preference"))))))
+
+;; ---------------------------------------------------------------------------
+;; Teardown
+;; ---------------------------------------------------------------------------
+
+(deftest the-screen-leaves-no-residue
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (doseq [[label screen] [["collector" collector/screen] ["grouped" grouped/screen]]]
+      (fresh!)
+      (let [handle (hicasso-mount! screen)]
+        (mount/dispatch! handle [:dogfood/toggle 0])
+        (mount/dispatch! handle [:dogfood/set-filter :all])
+        (mount/release! handle)
+        (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+               (rt/residue))
+            (str label ": zero leaked subscription ref-counts after teardown"))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_dom_cljs_test.cljs
@@ -45,7 +45,8 @@
             [re-frame.test-support :as test-support]
             [uix.core :refer [$ defui]]
             ["react-dom" :as react-dom]
-            ["react-dom/client" :as react-dom-client]))
+            ["react-dom/client" :as react-dom-client])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -174,6 +175,46 @@
                and a controlled field"
         (is (re-find #"<ul class=\"list\"" a-dom))
         (is (re-find #"class=\"new-input\"" a-dom))))))
+
+;; ---------------------------------------------------------------------------
+;; 1b — the lazy `for`, through a real React commit
+;; ---------------------------------------------------------------------------
+;;
+;; A Surface B property (see the node suite for the argument). `for` is
+;; lazy, so a collector that closed at the body's return would register no
+;; row edges and the DOM would freeze after the first paint while looking
+;; correct. Here it is asserted where it actually matters — after a real
+;; commit, against real nodes.
+
+(defview lazy-rows
+  "Every read is inside the lazy seq. Nothing outside it reads a row."
+  [_]
+  [:ul.lazy
+   (for [id (rt/sub [:dogfood/visible-ids])]
+     [:li.lazy-row {:key id :data-id id}
+      (str (:title (rt/sub [:dogfood/todo id])))])])
+
+(deftest reads-inside-a-lazy-for-update-the-dom-on-a-later-write
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [lazy-rows {}])]
+        (try
+          (let [cell (fn [id] (some-> (.querySelector (:container handle)
+                                                      (str ".lazy-row[data-id=\"" id "\"]"))
+                                      (.-textContent)))]
+            (is (= todo-count (.-length (.querySelectorAll (:container handle) ".lazy-row"))))
+            (is (= "todo 2" (cell 2)) "the first paint is right — which proves nothing on its own")
+            (rt/dispatch! frame-id [:dogfood/edit-draft 2 "ignored"])
+            (mount/settle!)
+            (rt/dispatch! frame-id [:dogfood/commit 2])
+            (mount/settle!)
+            (is (= "ignored" (cell 2))
+                "and a later write to a query the lazy seq produced reaches the
+                 DOM — the half a first render cannot tell you")
+            (is (= "todo 1" (cell 1)) "while its neighbour is untouched"))
+          (finally (mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — the narrow write touches one row

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_grouped.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_grouped.cljs
@@ -1,0 +1,93 @@
+(ns re-frame.bench.hicasso.arm1.dogfood-grouped
+  "THE DOGFOOD SCREEN — RENDERING 2 OF 3: grouped `use-subs` (HD-002 tier
+  2, the product default).
+
+  The same screen, the same state layer, the same intents. One fixed
+  site per boundary receives the complete query collection and the body
+  destructures the snapshot; the hook count does not move with the
+  collection's size, which is the whole reason this tier — and not the
+  scalar spine — is the default.
+
+  Two differences from the collector rendering are visible in the source
+  and are the substance of the diff judgement:
+
+  1. **[[row]] declares both queries and reads the draft
+     unconditionally**, where the collector rendering reads it only for
+     an editable row. A completed row therefore holds two edges here and
+     one there. The ruled alternative — a conditional *child boundary*
+     owning the draft — buys the edge back and costs a second `defview`;
+     the judgement page prices both, and this file takes the spelling a
+     working author actually writes.
+  2. **[[filters]] cannot delegate its read to the helper**, because a
+     helper's read has no fixed site to belong to. The current filter is
+     read once at the boundary's own site and passed down as an ordinary
+     argument, which is how *every* helper-donated read is written under
+     this tier.
+
+  Nothing else moves. The DOM is asserted identical to the other two
+  renderings by `arm1_dogfood_dom_cljs_test`."
+  (:require [re-frame.bench.hicasso.arm1.runtime :refer [use-subs]]
+            [re-frame.bench.hicasso.front.dogfood :as d])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(defview head [_]
+  (let [{:keys [remaining]} (use-subs {:remaining [:dogfood/remaining]})]
+    [:header.head
+     [:h1.title "todos"]
+     [:span.remaining {:data-remaining remaining} (str remaining " left")]]))
+
+(defview new-item [_]
+  (let [{:keys [draft]} (use-subs {:draft [:dogfood/draft d/new-draft-key]})
+        {:keys [on-input on-submit on-key-down]} (d/new-item-intents)]
+    [:form.new {:on-submit on-submit}
+     [:input.new-input {:type        "text"
+                        :value       draft
+                        :on-input    on-input
+                        :on-key-down on-key-down}]
+     [:button.add {:type "submit"} "Add"]]))
+
+(defn- filter-button
+  "The read moved out: a helper under this tier takes the value it needs
+  as an argument, because there is no fixed hook site inside a helper for
+  a read to occupy."
+  [id label current]
+  [:button.filter {:type         "button"
+                   :data-filter  (name id)
+                   :data-current (str (= id current))
+                   :on-click     [:dogfood/set-filter id]}
+   label])
+
+(defview filters [_]
+  (let [{:keys [current]} (use-subs {:current [:dogfood/filter]})]
+    [:nav.filters
+     (filter-button :all "All" current)
+     (filter-button :active "Active" current)
+     (filter-button :done "Done" current)]))
+
+(defview row [{:keys [id]}]
+  (let [{:keys [todo draft]} (use-subs {:todo  [:dogfood/todo id]
+                                        :draft [:dogfood/draft id]})
+        {:keys [on-click-toggle on-click-remove on-input-title on-key-down]}
+        (d/row-intents id)]
+    [:li.row {:data-id id :data-done (str (boolean (:done? todo)))}
+     [:button.toggle {:type "button" :on-click on-click-toggle} "✓"]
+     [:span.label (:title todo)]
+     (when-not (:done? todo)
+       [:input.draft {:type        "text"
+                      :value       draft
+                      :on-input    on-input-title
+                      :on-key-down on-key-down}])
+     [:button.remove {:type "button" :on-click on-click-remove} "x"]]))
+
+(defview todo-list [_]
+  (let [{:keys [ids]} (use-subs {:ids [:dogfood/visible-ids]})]
+    [:ul.list {:role "list"}
+     (for [id ids]
+       [row {:key id :id id}])]))
+
+(defview screen [_]
+  [:div.dogfood
+   [head {}]
+   [new-item {}]
+   [filters {}]
+   [todo-list {}]])

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_uix.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_uix.cljs
@@ -37,13 +37,13 @@
             [re-frame.bench.hicasso.front.dogfood :as d]
             [uix.core :refer [$ defui]]))
 
-(defui head []
+(defui head [_props]
   (let [remaining (uixa/use-subscribe [:dogfood/remaining])]
     ($ :header.head
        ($ :h1.title "todos")
        ($ :span.remaining {:data-remaining remaining} (str remaining " left")))))
 
-(defui new-item []
+(defui new-item [_props]
   (let [draft              (uixa/use-subscribe [:dogfood/draft d/new-draft-key])
         {:keys [dispatch]} (uixa/use-frame)]
     ($ :form.new {:on-submit (fn [e]
@@ -70,7 +70,7 @@
                      :on-click     (fn [_] (dispatch [:dogfood/set-filter id]))}
      label))
 
-(defui filters []
+(defui filters [_props]
   (let [current            (uixa/use-subscribe [:dogfood/filter])
         {:keys [dispatch]} (uixa/use-frame)]
     ($ :nav.filters
@@ -103,18 +103,18 @@
                           :on-click (fn [_] (dispatch [:dogfood/remove id]))}
           "x"))))
 
-(defui todo-list []
+(defui todo-list [_props]
   (let [ids (uixa/use-subscribe [:dogfood/visible-ids])]
     ($ :ul.list {:role "list"}
        (for [id ids]
          ($ row {:key id :id id})))))
 
-(defui screen []
+(defui screen [_props]
   ($ :div.dogfood
-     ($ head)
-     ($ new-item)
-     ($ filters)
-     ($ todo-list)))
+     ($ head {})
+     ($ new-item {})
+     ($ filters {})
+     ($ todo-list {})))
 
 (defn root
   "`frame-provider` SCOPES an already-created frame and renders no DOM of
@@ -122,4 +122,4 @@
   renderings is unaffected."
   [frame-kw]
   ($ uixa/frame-provider {:frame frame-kw}
-     ($ screen)))
+     ($ screen {})))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_uix.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_uix.cljs
@@ -1,0 +1,125 @@
+(ns re-frame.bench.hicasso.arm1.dogfood-uix
+  "THE DOGFOOD SCREEN — RENDERING 3 OF 3: raw UIx (HD-002 tier 1, the
+  comparator).
+
+  The same screen on the shipping UIx spine: `$` instead of hiccup,
+  `use-subscribe` per read, `use-frame` for dispatch, and every event
+  position a hand-written closure. This is the control, and the point of
+  writing it out in full is that a comparator quoted from memory is not a
+  comparator.
+
+  Three things this rendering cannot do, and they are the finding rather
+  than a complaint:
+
+  1. **No conditional read.** `row` reads the draft on every render
+     including a completed row's, because a hook may not sit inside a
+     `when`. The collector rendering reads it only when the row is
+     editable.
+  2. **No helper-donated read.** `filter-button` takes the current filter
+     as an argument for the same reason the grouped rendering's does — a
+     hook may not run inside a plain function called from a body.
+  3. **No intent as data.** Every handler is a fresh closure that reaches
+     into the event to pull `.-value`, and each one is a place the wrong
+     event id can be written without anything noticing. The other two
+     renderings hand the same vectors to the shared
+     `front.dogfood/row-intents`.
+
+  What it *does* have is three hooks in `row` where the two Hicasso
+  renderings have two in the shell — and the shell's two do not grow with
+  the read count, while these do (HD-020's budget, and why the scalar
+  tier is exempt from it as a control rather than admitted to it as a
+  product).
+
+  Not a third runtime: the grouped rendering rides this same comparator
+  spine's substrate, and the DOM all three build is asserted identical by
+  `arm1_dogfood_dom_cljs_test`."
+  (:require [re-frame.adapter.uix :as uixa]
+            [re-frame.bench.hicasso.front.dogfood :as d]
+            [uix.core :refer [$ defui]]))
+
+(defui head []
+  (let [remaining (uixa/use-subscribe [:dogfood/remaining])]
+    ($ :header.head
+       ($ :h1.title "todos")
+       ($ :span.remaining {:data-remaining remaining} (str remaining " left")))))
+
+(defui new-item []
+  (let [draft              (uixa/use-subscribe [:dogfood/draft d/new-draft-key])
+        {:keys [dispatch]} (uixa/use-frame)]
+    ($ :form.new {:on-submit (fn [e]
+                               (.preventDefault e)
+                               (dispatch [:dogfood/create]))}
+       ($ :input.new-input
+          {:type      "text"
+           :value     draft
+           :on-input  (fn [e] (dispatch [:dogfood/edit-draft d/new-draft-key
+                                         (.. e -target -value)]))
+           :on-key-down (fn [e]
+                          (when-not (or (true? (.-isComposing e))
+                                        (identical? 229 (.-keyCode e)))
+                            (case (.-key e)
+                              "Enter"  (dispatch [:dogfood/create])
+                              "Escape" (dispatch [:dogfood/cancel d/new-draft-key])
+                              nil)))})
+       ($ :button.add {:type "submit"} "Add"))))
+
+(defn- filter-button [id label current dispatch]
+  ($ :button.filter {:type         "button"
+                     :data-filter  (name id)
+                     :data-current (str (= id current))
+                     :on-click     (fn [_] (dispatch [:dogfood/set-filter id]))}
+     label))
+
+(defui filters []
+  (let [current            (uixa/use-subscribe [:dogfood/filter])
+        {:keys [dispatch]} (uixa/use-frame)]
+    ($ :nav.filters
+       (filter-button :all "All" current dispatch)
+       (filter-button :active "Active" current dispatch)
+       (filter-button :done "Done" current dispatch))))
+
+(defui row [{:keys [id]}]
+  (let [todo               (uixa/use-subscribe [:dogfood/todo id])
+        draft              (uixa/use-subscribe [:dogfood/draft id])
+        {:keys [dispatch]} (uixa/use-frame)]
+    ($ :li.row {:data-id id :data-done (str (boolean (:done? todo)))}
+       ($ :button.toggle {:type     "button"
+                          :on-click (fn [_] (dispatch [:dogfood/toggle id]))}
+          "✓")
+       ($ :span.label (:title todo))
+       (when-not (:done? todo)
+         ($ :input.draft
+            {:type      "text"
+             :value     draft
+             :on-input  (fn [e] (dispatch [:dogfood/edit-draft id (.. e -target -value)]))
+             :on-key-down (fn [e]
+                            (when-not (or (true? (.-isComposing e))
+                                          (identical? 229 (.-keyCode e)))
+                              (case (.-key e)
+                                "Enter"  (dispatch [:dogfood/commit id])
+                                "Escape" (dispatch [:dogfood/cancel id])
+                                nil)))}))
+       ($ :button.remove {:type     "button"
+                          :on-click (fn [_] (dispatch [:dogfood/remove id]))}
+          "x"))))
+
+(defui todo-list []
+  (let [ids (uixa/use-subscribe [:dogfood/visible-ids])]
+    ($ :ul.list {:role "list"}
+       (for [id ids]
+         ($ row {:key id :id id})))))
+
+(defui screen []
+  ($ :div.dogfood
+     ($ head)
+     ($ new-item)
+     ($ filters)
+     ($ todo-list)))
+
+(defn root
+  "`frame-provider` SCOPES an already-created frame and renders no DOM of
+  its own, so the canonical-DOM comparison against the two Hicasso
+  renderings is unaffected."
+  [frame-kw]
+  ($ uixa/frame-provider {:frame frame-kw}
+     ($ screen)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/generation_fence_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/generation_fence_dom_cljs_test.cljs
@@ -1,0 +1,167 @@
+(ns re-frame.bench.hicasso.arm1.generation-fence-dom-cljs-test
+  "THE GENERATION FENCE, AND ITS STAGED-STALE WITNESS (rf2-2rtt6.9).
+
+  architecture.md gives Arm 1 one line on this and it is the load-bearing
+  one: \"A generation fence keeps all reads within one render pass on one
+  commit (invariant-5 preservation; the staged-stale CI witness guards
+  it).\" validation.md adds the stakes — \"a missed invalidation is a P0
+  bug class: the staged-stale case is a CI witness for any asynchronous-
+  host variant.\"
+
+  ## What the fence replaces, and why that matters
+
+  The predecessor preserved the same invariant by **re-reading every
+  subscription at commit** — a second deref of every read, after the
+  render had already read it, measured at 1.19 ms of a 4.0 ms write for
+  300 reads against Reagent's entire layout-effect phase of 1.4
+  microseconds. HD-002's adjudication makes that re-read a *forbidden*
+  construct for this arm, which leaves the fence carrying the invariant
+  on its own: one comparison per boundary, O(1), instead of one deref per
+  read, O(reads).
+
+  A fence that has never been watched refuse is not evidence, so these
+  tests stage the case rather than describing it.
+
+  ## The two staged cases
+
+  1. **A commit lands inside a body.** The boundary reads, a write is
+     staged mid-body, and the body reads again. Without the fence its two
+     reads straddle two commits and the DOM publishes a value that was
+     never simultaneously true. With it, the body re-runs and the
+     committed DOM is the winning render's.
+  2. **A commit lands between a body and its React commit** — the case
+     hd-002-adjudication.md §6.1 leaves open, and the one the record does
+     not demonstrate. It is staged here against a real React root, and
+     the assertion is the honest one: the committed DOM is not stale.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every claim degrades to a stated skip.
+  The fence's own algebra is proved without a browser in
+  `arm1/runtime_cljs_test`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     ;; `:ambient-frame nil` is load-bearing, not tidiness. The fixture's
+     ;; default leaves a dynamic-var frame stamp in scope, and the
+     ;; carried-invariant chain resolves that tier BEFORE React context —
+     ;; so the comparator's ambient `use-subscribe` would read the
+     ;; ambient frame's app-db while `use-current-frame` reported the
+     ;; provider's, and a parity miss would look like a rendering
+     ;; difference. Caught by the frame probe below, which is why the
+     ;; probe stays.
+     :ambient-frame nil
+     :init-fn (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::arm1-fence)
+
+(defonce ^:private !runs (atom 0))
+(defonce ^:private !stage (atom nil))
+
+(defview staged-row
+  "A boundary that reads, may stage a commit, and reads again. The stage
+  is a fn in an atom rather than a prop so the test can arm it for
+  exactly one run — a body that writes on every run is a write loop, and
+  the fence fails that loudly rather than spinning (proved in the node
+  suite)."
+  [{:keys [id]}]
+  ;; The filter read is what lets the test make React re-render this
+  ;; boundary WITHOUT touching the subscription the body is about to
+  ;; write — a boundary re-rendered by the very write it stages would not
+  ;; separate the fence from ordinary invalidation. The read set is the
+  ;; same on both runs, so the entry (and React's `subscribe`) is stable
+  ;; across the re-run.
+  (let [_filter (rt/sub [:dogfood/filter])
+        before  (rt/sub [:dogfood/done? id])]
+    (when-some [stage @!stage] (reset! !stage nil) (stage))
+    (let [after (rt/sub [:dogfood/done? id])]
+      (swap! !runs inc)
+      [:li.row {:data-id id
+                :data-before (str before)
+                :data-after (str after)}
+       (str after)])))
+
+(defn- skip! [why] (is true (str "a staged-stale claim needs a real React DOM — " why)))
+
+(defn- mounted! []
+  (reset! !runs 0)
+  (reset! !stage nil)
+  (lane/leave-act-environment!)
+  (dogfood/make-frame! frame-id 3)
+  (dogfood/reseed! frame-id 3)
+  (let [container (mount/fresh-container!)]
+    (mount/root! container frame-id [staged-row {:id 0}])))
+
+(defn- read-back [handle k]
+  (some-> (.querySelector (:container handle) ".row") (.getAttribute k)))
+
+;; ---------------------------------------------------------------------------
+;; Case 1 — a commit lands inside the body
+;; ---------------------------------------------------------------------------
+
+(deftest a-commit-staged-inside-a-body-never-publishes-a-straddled-read
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (let [handle (mounted!)]
+      (try
+        (is (= "false" (read-back handle "data-after")) "the seeded value is on screen")
+        (let [runs-before @!runs]
+          ;; Arm the stage, then make React re-render this boundary. The
+          ;; body will write to the very subscription it is reading.
+          (reset! !stage (fn [] (rt/dispatch! frame-id [:dogfood/toggle 0])))
+          (mount/dispatch! handle [:dogfood/set-filter :done])
+          (is (> @!runs runs-before) "the body ran"))
+        (testing "the two reads of the winning run agree, so the DOM never
+                 carries a value that was not simultaneously true"
+          (is (= (read-back handle "data-before") (read-back handle "data-after"))))
+        (testing "and the committed DOM is the POST-write value, not the
+                 pre-write one the abandoned run started from"
+          (is (= "true" (read-back handle "data-after"))))
+        (finally (mount/release! handle))))))
+
+;; ---------------------------------------------------------------------------
+;; Case 2 — a commit lands between the body and React's commit (§6.1)
+;; ---------------------------------------------------------------------------
+
+(deftest a-commit-landing-after-the-body-does-not-leave-the-dom-stale
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (let [handle (mounted!)]
+      (try
+        (is (= "false" (read-back handle "data-after")))
+        ;; hd-002-adjudication.md §6.1 leaves open whether one epoch
+        ;; comparison covers what the predecessor's three compared fields
+        ;; covered. This is the adversarial half it names: move the value
+        ;; AFTER the body has returned. The fence cannot see this one — its
+        ;; window has closed — so what must catch it is the ordinary
+        ;; invalidation path, and the claim is that between the two the DOM
+        ;; is never left stale.
+        (mount/dispatch! handle [:dogfood/toggle 0])
+        (mount/settle!)
+        (is (= "true" (read-back handle "data-after"))
+            "the committed DOM caught up without a commit-phase re-read of
+             every subscription")
+        (is (= (read-back handle "data-before") (read-back handle "data-after")))
+        (finally (mount/release! handle))))))
+
+;; ---------------------------------------------------------------------------
+;; Teardown
+;; ---------------------------------------------------------------------------
+
+(deftest the-fenced-boundary-leaves-no-residue
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (let [handle (mounted!)]
+      (mount/dispatch! handle [:dogfood/toggle 0])
+      (mount/release! handle)
+      (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+             (rt/residue))
+          "zero leaked subscription ref-counts after teardown"))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/hook_ledger_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/hook_ledger_dom_cljs_test.cljs
@@ -1,0 +1,173 @@
+(ns re-frame.bench.hicasso.arm1.hook-ledger-dom-cljs-test
+  "THE ≤2-HOOK BUDGET, COUNTED AT REACT'S DISPATCHER (rf2-2rtt6.9).
+
+  HD-020(b): \"the ≤2 budget is fully consumed by the subscription/epoch
+  hook and the frame-context hook; boundary shells use callback refs,
+  never `useRef` — a third hook in the shell is a budget breach.\"
+
+  Three claims, and the third is the one that matters:
+
+  1. a boundary's shell calls exactly two hooks;
+  2. neither is `useRef` and neither is `useState`;
+  3. **the count does not move with the read count.** One read, seven
+     reads, twenty reads — the census archetype and the stress rung — all
+     cost two. That is the whole argument for why the scalar per-read
+     spine is a comparator and not a product: N reads = N hooks cannot
+     satisfy this budget on any rung.
+
+  The comparator is measured in the same run, on the same page, by the
+  same probe, so the contrast is a reading rather than a recollection.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every claim degrades to a stated skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.hook-probe :as probe]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.test-support :as test-support]
+            [uix.core :refer [$ defui]])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     ;; `:ambient-frame nil` is load-bearing, not tidiness. The fixture's
+     ;; default leaves a dynamic-var frame stamp in scope, and the
+     ;; carried-invariant chain resolves that tier BEFORE React context —
+     ;; so the comparator's ambient `use-subscribe` would read the
+     ;; ambient frame's app-db while `use-current-frame` reported the
+     ;; provider's, and a parity miss would look like a rendering
+     ;; difference. Caught by the frame probe below, which is why the
+     ;; probe stays.
+     :ambient-frame nil
+     :init-fn (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::arm1-hooks)
+
+;; ---------------------------------------------------------------------------
+;; The boundaries under the probe — one shape, three read counts
+;; ---------------------------------------------------------------------------
+
+(defview reader
+  "One Hicasso boundary reading `n` subscriptions through the collector.
+  The reads sit in a `for`, which no hook-shaped surface can do, and
+  which is exactly why the count below is interesting."
+  [{:keys [n]}]
+  [:ul.reads
+   (for [i (range n)]
+     [:li.read {:key i} (str (rt/sub [:dogfood/todo i]))])])
+
+(defui uix-one [{:keys [i]}]
+  ($ :li.read (str (uix-adapter/use-subscribe [:dogfood/todo i]))))
+
+(defui uix-three [{:keys [i]}]
+  ;; Three reads, three hooks, spelled out — a loop is illegal here, and
+  ;; that illegality is the finding rather than an inconvenience.
+  (let [a (uix-adapter/use-subscribe [:dogfood/todo i])
+        b (uix-adapter/use-subscribe [:dogfood/todo (inc i)])
+        c (uix-adapter/use-subscribe [:dogfood/todo (+ i 2)])]
+    ($ :li.read (str a b c))))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- skip! [why] (is true (str "a dispatcher-level hook count needs a real React DOM — " why)))
+
+(defn- unwitnessed! []
+  (is false (str "React's internals slot was not found, so the ≤2-hook budget is "
+                 "UNWITNESSED on this build. A gate nobody has watched fire is not "
+                 "evidence — fix " (pr-str 're-frame.bench.hicasso.arm1.hook-probe)
+                 " rather than reading this as a pass.")))
+
+(defn- mount-and-count
+  "Mount `hiccup` through the arm's own root and answer the hook names
+  React was asked for while it mounted. The root, the page and the frame
+  are identical for every caller, so the only thing that varies between
+  readings is the component."
+  [hiccup]
+  (lane/leave-act-environment!)
+  (dogfood/make-frame! frame-id 32)
+  (dogfood/reseed! frame-id 32)
+  (let [container (mount/fresh-container!)
+        handle    (volatile! nil)
+        names     (probe/record!
+                    (fn [] (vreset! handle (mount/root! container frame-id hiccup))))]
+    (mount/release! @handle)
+    names))
+
+(defn- hicasso-hooks
+  "The hook names for ONE Hicasso boundary reading `n` subscriptions."
+  [n]
+  (mount-and-count [reader {:n n}]))
+
+;; ---------------------------------------------------------------------------
+;; The claims
+;; ---------------------------------------------------------------------------
+
+(deftest the-shell-calls-exactly-two-hooks
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (if-not (probe/install!)
+      (unwitnessed!)
+      (testing "one boundary, one read: the frame hook and the
+               subscription/epoch hook, and nothing else"
+        (let [names (hicasso-hooks 1)]
+          (is (= 2 (count names)) (str "hooks React was asked for: " (pr-str names)))
+          (is (= ["useContext" "useSyncExternalStore"] names)
+              "in the order shell-hook-ledger declares")
+          (is (= (count rt/shell-hook-ledger) (count names))
+              "and the declared ledger is the measured one"))))))
+
+(deftest the-count-does-not-move-with-the-read-count
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (if-not (probe/install!)
+      (unwitnessed!)
+      (testing "1, 7 and 20 reads — the first rung, the census archetype
+               and the stress rung — all cost two hooks"
+        (doseq [n [1 7 20]]
+          (let [names (hicasso-hooks n)]
+            (is (= 2 (count names))
+                (str n " reads still cost two hooks: " (pr-str names)))))))))
+
+(deftest no-use-ref-and-no-use-state-in-the-shell
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (if-not (probe/install!)
+      (unwitnessed!)
+      (let [names (set (hicasso-hooks 7))]
+        (is (not (contains? names "useRef")) "HD-020(b) bans useRef in the shell")
+        (is (not (contains? names "useState"))
+            "and this arm holds no per-instance render-phase state at all")
+        (is (not (contains? names "useMemo")))
+        (is (not (contains? names "useCallback")))))))
+
+(deftest the-scalar-comparator-pays-per-read-and-is-measured-saying-so
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (if-not (probe/install!)
+      (unwitnessed!)
+      (testing "the raw UIx spine's per-read hooks, counted by the same
+               probe on the same page — a comparator read rather than
+               recalled. No bar row is published from this: it is a hook
+               count, not a clock or a heap figure."
+        (let [host-1 (rt/mint-view! "uix-host-1" (fn [_] ($ uix-one {:i 0})))
+              host-3 (rt/mint-view! "uix-host-3" (fn [_] ($ uix-three {:i 0})))
+              base   (count (hicasso-hooks 1))
+              one    (count (mount-and-count [host-1 {}]))
+              three  (count (mount-and-count [host-3 {}]))]
+          ;; The host boundary contributes the shell's two; everything above
+          ;; that is the comparator's own per-read cost.
+          (is (> one base)
+              (str "one UIx read already costs more than the whole Hicasso "
+                   "shell (" one " vs " base ")"))
+          (is (> three one)
+              (str "and three reads cost more again — the count moves WITH the "
+                   "read count, which is the property the product budget "
+                   "forbids (" three " vs " one ")"))
+          (is (= 2 base)
+              "while the Hicasso shell stays at two on every rung"))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/hook_probe.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/hook_probe.cljs
@@ -1,0 +1,92 @@
+(ns re-frame.bench.hicasso.arm1.hook-probe
+  "COUNTING HOOKS AT REACT'S OWN DISPATCHER (rf2-2rtt6.9).
+
+  HD-020(b) makes the ≤2-hook budget a hard line, and a budget a runtime
+  reports about itself is not a witness. This counts the calls React
+  actually receives.
+
+  ## How
+
+  React routes every hook call through one mutable slot on its shared
+  internals — `H`, the current dispatcher, reassigned as React enters and
+  leaves each render. [[install!]] replaces that slot with an accessor
+  whose getter wraps whatever React last assigned in a counting `Proxy`,
+  so a read of `H.useRef` is recorded and then forwarded untouched. React
+  never sees a different function; it sees the same one, one property
+  read later.
+
+  Two properties make this the right instrument rather than a clever one:
+
+  - **It counts what the component body calls, not what React implements
+    with.** `useSyncExternalStore` is ONE dispatcher call; React's
+    internal machinery for it does not go back through `H`. So the shell's
+    two hooks read as two, and a comparator's `use-subscribe` reads as the
+    hooks *it* calls — which is the comparison the budget is about.
+  - **It cannot be satisfied by a runtime that reports on itself.** The
+    numbers come from React.
+
+  ## When it cannot answer
+
+  The internals slot is a private React implementation detail and its
+  name is version-bound. [[install!]] returns `false` when it is not
+  found, and every witness that uses it must then record the claim as
+  **unwitnessed** — never as passed. A gate nobody has watched fire is
+  not evidence."
+  (:require ["react" :as react]))
+
+(def ^:private internals-key
+  "React 19's client-internals export. Version-bound by construction; the
+  witness degrades to `unwitnessed` rather than to green if it moves."
+  "__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE")
+
+(defonce ^:private !log (atom []))
+(defonce ^:private !counting (atom false))
+(defonce ^:private !installed (atom false))
+
+(defn- hook-name?
+  "A dispatcher property that is a hook. React reads a few non-hook keys
+  off the same object, and counting those would inflate every arm."
+  [prop]
+  (and (string? prop)
+       (> (count prop) 3)
+       (= "use" (subs prop 0 3))
+       (let [c (subs prop 3 4)] (= c (.toUpperCase c)))))
+
+(defn- counting-proxy [dispatcher]
+  (if (nil? dispatcher)
+    dispatcher
+    (js/Proxy. dispatcher
+               #js {"get" (fn [target prop receiver]
+                            (when (and @!counting (hook-name? prop))
+                              (swap! !log conj prop))
+                            (js/Reflect.get target prop receiver))})))
+
+(defn install!
+  "Arm the probe. Idempotent; returns true when the dispatcher slot was
+  found and wrapped, false when React's internals are not where this
+  version expects them."
+  []
+  (if @!installed
+    true
+    (if-some [internals (unchecked-get react internals-key)]
+      (let [raw (volatile! (unchecked-get internals "H"))]
+        (js/Object.defineProperty
+          internals "H"
+          #js {"configurable" true
+               "get" (fn [] (counting-proxy @raw))
+               "set" (fn [v] (vreset! raw v))})
+        (reset! !installed true)
+        true)
+      false)))
+
+(defn installed? [] @!installed)
+
+(defn record!
+  "Run `thunk` with counting on, and answer the hook names React was asked
+  for while it ran, in call order."
+  [thunk]
+  (reset! !log [])
+  (reset! !counting true)
+  (try (thunk)
+       (finally (reset! !counting false)))
+  @!log)

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj
@@ -1,0 +1,47 @@
+(ns re-frame.bench.hicasso.arm1.lang
+  "`defview` — the one macro Arm 1 has (rf2-2rtt6.9).
+
+  It exists because the authoring surface is a *deliverable*: HD-002 has
+  the dogfood screen written in three renderings and judged on diff and
+  preference, and a judgement taken against `(def todo-row (mint-view!
+  \"todo-row\" (fn [props] …)))` would be judging the absence of a macro
+  rather than the design.
+
+  ## It is not a compiler, and the distinction is load-bearing
+
+  The charter's hard fence is a compiler or an analyzer. This expands to
+  a `def` and a `fn`: it reads no body form, rewrites no hiccup, resolves
+  no subscription, plans no holes, and emits no code that depends on what
+  the body contains. Everything the body does — hiccup interpretation,
+  subscription reads, intent lowering — happens at runtime in
+  `re-frame.bench.hicasso.arm1.runtime`, on forms the macro never
+  inspected. The only thing it captures at expansion time is the view's
+  *name*, for `displayName`.
+
+      (defview todo-row [{:keys [id]}] …)
+      ;; =>
+      (def todo-row
+        (runtime/mint-view! \"my.ns/todo-row\" (fn todo-row-body [{:keys [id]}] …)))
+
+  ## Why it is a `.clj` and not a `.cljc`
+
+  Macros only. The runtime it names is CLJS-only (it requires React), and
+  a `.cljc` would invite a JVM-side implementation this arm does not have
+  — HD-020(d) puts SSR out of v0 explicitly.")
+
+(defmacro defview
+  "Mint a boundary — a real React function component (HD-016).
+
+  `argv` is the ordinary one-props-map argument vector, so destructuring
+  reads as it does in any Clojure fn. In hiccup the resulting var is a
+  legal head: `[todo-row {:key id :id id}]`. A plain function in head
+  position is a loud error rather than a silent embedding, which is what
+  makes the head's identity stable by construction and leaves the codec's
+  stable-component-head cache with nothing to do."
+  [sym argv & body]
+  (let [view-name (str (ns-name *ns*) "/" sym)
+        body-name (symbol (str sym "-body"))]
+    `(def ~sym
+       (re-frame.bench.hicasso.arm1.runtime/mint-view!
+         ~view-name
+         (fn ~body-name ~argv ~@body)))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj
@@ -38,10 +38,12 @@
   position is a loud error rather than a silent embedding, which is what
   makes the head's identity stable by construction and leaves the codec's
   stable-component-head cache with nothing to do."
-  [sym argv & body]
-  (let [view-name (str (ns-name *ns*) "/" sym)
+  [sym & more]
+  (let [doc       (when (string? (first more)) (first more))
+        [argv & body] (if doc (rest more) more)
+        view-name (str (ns-name *ns*) "/" sym)
         body-name (symbol (str sym "-body"))]
-    `(def ~sym
+    `(def ~(if doc (vary-meta sym assoc :doc doc) sym)
        (re-frame.bench.hicasso.arm1.runtime/mint-view!
          ~view-name
          (fn ~body-name ~argv ~@body)))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/mount.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/mount.cljs
@@ -1,0 +1,98 @@
+(ns re-frame.bench.hicasso.arm1.mount
+  "ARM 1's ROOT — one operation, an idempotent teardown (HD-021(b)).
+
+  `root!` associates a DOM node, a frame, and a hiccup tree, and returns
+  the handle `release!` takes. That is the whole execution contract this
+  arm needs; the names stay unfrozen (HD-021 pins the semantics, not the
+  spelling) and nothing here is a public API.
+
+  The frame reaches the tree through the substrate's single internal
+  React context — the same object every React-shaped adapter reads
+  (`re-frame.adapter.context/frame-context`), so a Hicasso subtree and a
+  UIx subtree under one provider resolve the same frame. That is what
+  lets the dogfood screen's three renderings sit side by side in one page
+  and be compared on authoring rather than on plumbing.
+
+  ## Why the flushes are explicit
+
+  React 19 renders a root concurrently, and a `useSyncExternalStore`
+  notification schedules at the SYNC lane rather than committing inline.
+  Witnesses assert the DOM, so every door here commits before it returns:
+  `render!` renders inside `flushSync`, and [[settle!]] is the empty
+  `flushSync` that lets an already-scheduled sync-lane notification land.
+  Neither is `act` — `act` diverts work to a queue that is not the
+  browser's, which is the right tool for an effect-ordering test and the
+  wrong one for a witness that reads the page."
+  (:require [re-frame.adapter.context :as adapter-context]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            ["react" :as react]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]))
+
+(defn provider
+  "Scope `frame-kw` for a subtree. Renders no DOM of its own, so it cannot
+  move a canonical-DOM parity comparison."
+  [frame-kw child]
+  (react/createElement (.-Provider adapter-context/frame-context)
+                       #js {:value frame-kw}
+                       child))
+
+(defn settle!
+  "Let an already-scheduled sync-lane notification commit. The empty
+  `flushSync` — no work of its own, and the reason a witness may read the
+  DOM on the line after a dispatch."
+  []
+  (react-dom/flushSync (fn [] nil))
+  nil)
+
+(defn render!
+  "Render `hiccup` into an existing root, synchronously."
+  [handle hiccup]
+  (react-dom/flushSync
+    (fn [] (.render (:root handle) (provider (:frame handle) (codec/as-element hiccup)))))
+  handle)
+
+(defn root!
+  "Associate `container`, `frame-kw` and `hiccup`. Returns the handle."
+  [container frame-kw hiccup]
+  (let [handle {:root      (react-dom-client/createRoot container)
+                :frame     frame-kw
+                :container container}]
+    (render! handle hiccup)
+    handle))
+
+(defn release!
+  "Unmount the root and drop every edge, cell and cached closure the arm
+  held. Idempotent: releasing twice is not an error, because a teardown
+  door that throws on the second call is a teardown door test fixtures
+  route around."
+  [handle]
+  (when-some [r (:root handle)]
+    (react-dom/flushSync (fn [] (.unmount r))))
+  (rt/reset-runtime!)
+  (when-some [c (:container handle)]
+    (when-some [p (.-parentNode c)] (.removeChild p c)))
+  nil)
+
+(defn dispatch!
+  "Dispatch through the arm's synchronous door and commit the echo. The
+  witness door; an intent written in a view reaches
+  `runtime/dispatch!` on its own."
+  [handle event]
+  (rt/dispatch! (:frame handle) event)
+  (settle!)
+  nil)
+
+(defn fresh-container!
+  "A detached-then-attached container, appended to the document body."
+  []
+  (let [c (js/document.createElement "div")]
+    (.appendChild js/document.body c)
+    c))
+
+(defn browser?
+  "Is there a real DOM here? `:node-test` has none, and every DOM claim in
+  this arm degrades to a stated skip there rather than a false green."
+  []
+  (and (exists? js/document) (some? (.-createElement js/document))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -28,27 +28,100 @@
   to close over.
 
   - `subscribe` closes over **the render's sub-key set and nothing
-    else**, so it is a pure function of a *value*. It is therefore
-    cached by that value ([[closure-for]]) and shared by every boundary
-    reading the same set — which makes its identity stable across a
-    re-render whose reads did not change, which is exactly the condition
-    React uses to decide whether to re-subscribe. An unchanged hot read
-    performs no new attach and no new release, by construction.
+    else**, so it is a pure function of a value. It lives on a
+    [[read-set entry|entry-for]] cached by that value, shared by every
+    boundary reading the same set, and therefore identity-stable across
+    a re-render whose reads did not change — which is exactly the
+    condition React uses to decide whether to re-subscribe. **An
+    unchanged hot read performs no new attach and no new release, and
+    the commit does no work at all**, because React never calls the
+    closure again.
   - React calls that shared `subscribe` once per *fiber*, handing it that
     fiber's own `onStoreChange`. The registration minted inside is
     therefore per-boundary, durable for the mount, and commit-owned — so
     it is the boundary id the index keys on, and a render that never
-    commits registers nothing at all. The abandoned-render leak class is
-    closed by construction rather than by bookkeeping.
-  - `getSnapshot` closes over the same key set and returns the **sum of
-    those keys' epochs**. Epochs only ever increase, so the sum is
-    strictly monotone: `Object.is` on one number is a correct change
-    test, and React's own \"getSnapshot should be cached\" rule is
-    satisfied without a memo.
+    commits registers nothing.
+  - `getSnapshot` also lives on the entry and returns the **sum of the
+    set's epochs**. Epochs only ever increase, so the sum is monotone:
+    `Object.is` on one number is a correct change test, and React's own
+    \"getSnapshot should be cached\" rule is satisfied without a memo.
 
   The hook budget is not self-reported — `arm1_hook_ledger_dom_cljs_test`
-  counts hook calls at React's own dispatcher, which sees every call the
-  shell makes.
+  counts hook calls at React's own dispatcher.
+
+  ## The collector is the surface being made to work
+
+  The operator ruled on 2026-07-31 that the ambient collector — `sub` as
+  an ordinary function call, legal inside a `when`, inside a `for`, and
+  inside an inlined helper — is the only read surface acceptable on
+  ergonomics, and that grouped `use-subs` sits below the usability bar.
+  So [[sub]] is the surface this arm engineers for and [[use-subs]] is
+  kept as the control it is measured against. That inverts which tier is
+  defended; it waives none of HD-002's correctness gates, and the
+  tripwire still overrides the clock.
+
+  ### The ownership state machine (clause (a))
+
+  One sentence carries it, and it is the positive form of the tripwire:
+
+  > **No render-phase code mutates the index or a subscription
+  > ref-count. The only global mutation is the commit's.**
+
+      RENDERING   the body runs; reads append to ONE module-level scratch
+                  array, reset unconditionally at the top of every body
+      PENDING     the body returned; the scratch has been resolved to a
+                  cached read-set entry; the index is untouched
+      COMMITTED   React called the entry's `subscribe`; the registration
+                  exists, the edges are installed, the cells are acquired
+      UNMOUNTED   React called the cleanup; edges and references released
+
+  An abandoned render is `PENDING → RENDERING`, and it needs no cleanup
+  because it never did anything that would need cleaning. The scratch is
+  reset by overwrite, not by bookkeeping, which is also why StrictMode's
+  double-invoke is correct rather than additive.
+
+  ### The allowed edge-diff operation (clause (b))
+
+  A boundary's edge set is **replaced wholesale, once, at commit** —
+  `front.sub-index/record-reads`'s set difference — and only when the
+  read set actually changed, because an unchanged set leaves the
+  `subscribe` closure identical and React does not call it again. The
+  unchanged case is detected **without building anything**: the scratch
+  array is compared pairwise against the cached entry's key array, so
+  steady-state allocation for edge maintenance is zero bytes and the
+  allocation slope across warm 1/3/7/20 reads is flat.
+
+  The ordered compare is a false-negative device and never a wrong
+  answer: two renders that read the same keys in a different order miss
+  the compare, take a second entry with the same set, and React replaces
+  a set with itself — slower, still correct. It is deliberately not
+  repaired with a content hash, whose failure mode would be a silently
+  missing edge.
+
+  **No per-read object, no second candidate slot, nothing keyed by a
+  render or an attempt, and no commit-phase deref.** The commit consults
+  sub-keys only; the generation fence, not a re-read, is what preserves
+  invariant 5.
+
+  ### The cold read, and what it costs (clause (a) consequence)
+
+  A render-phase read is a **pure deref** when the key already has a
+  committed cell — the overwhelming case, and the one validation.md's
+  \"an unchanged hot read performs no new attach/release\" describes. A
+  read of a key nothing holds yet computes through `subscribe-once`,
+  which subscribes, derefs and unsubscribes inside the calling tick and
+  retains nothing, so an abandoned render leaves the world exactly as it
+  found it. Acquisition happens at commit, without a deref.
+
+  That costs a cold key its computation twice — once discarded at render,
+  once when the commit acquires. The shipping React spine avoids the same
+  double build with a render-phase escrow (rf2-2rtt6.25), and this arm
+  deliberately does **not** copy it: an escrow is a render-phase
+  ref-count mutation, which is the one thing the state machine above
+  forbids. It is also not a collector charge — `useSyncExternalStore` has
+  the identical render/commit shape, so grouped and the scalar comparator
+  inherit it — and it belongs to the shared front half rather than to
+  this arm.
 
   ## The re-render path
 
@@ -60,15 +133,10 @@
         -> bodies re-run -> hiccup -> front.codec -> React reconciles
 
   The dirty *sub-key* set is push-cheap: a key is marked only when the
-  sub layer's own equality cutoff let a change through, so a commit that
-  moves one subscription costs one mark and one index lookup, never a
-  sweep of every live key. The dirty *boundary* set is the shared front
-  half's index, unmodified — this arm calls `mount!`, `record-reads!`,
-  `unmount!` and `commit!`, and edits nothing.
-
-  Notifications are batched by [[with-commit]], which the arm's
-  frame-locked dispatch wraps around every intent, so one user action is
-  one flush however many subscriptions it moved.
+  sub layer's own equality cutoff let a change through. Notifications are
+  batched by [[with-commit]], which the arm's frame-locked dispatch wraps
+  around every intent, so one user action is one flush however many
+  subscriptions it moved.
 
   ## The generation fence
 
@@ -76,33 +144,23 @@
   which captures the generation before the body and checks it after: if a
   commit landed *during* the body, its reads straddle two commits and the
   body is re-run against the newer one. That is invariant-5 preservation
-  written as a loop rather than as a comment, and
-  `arm1_generation_fence_dom_cljs_test` stages exactly that commit from
-  inside a rendering body.
+  written as a loop rather than as a comment, and one comparison per
+  boundary rather than one deref per read.
 
-  A flush that happens while a body is running must not call React's
+  A flush raised while a body is running must not call React's
   `onStoreChange` — that is a render-phase update on somebody else's
   component. Those notifications are deferred to a macrotask; the fence
-  has already made the *rendering* boundary correct, so the deferral only
-  reaches boundaries that were not rendering.
+  has already made the *rendering* boundary correct.
 
   ## What is deliberately NOT here (the hard fences)
 
   No compiler and no analyzer: bodies are ordinary functions and hiccup
   is interpreted by the shared codec at runtime. No dual mode: one shell,
-  one index, one read path — the two HD-002 product tiers ([[use-subs]]
-  and [[sub]]) differ in *where the author writes the read* and in the
-  provenance the index records, not in the machinery underneath. No
-  ViewCell-class object graph: a boundary's exclusive retention is one
-  registration, its index memberships, and React's own two hook cells —
-  the inventory is [[retained-inventory]], and it is a witness rather
-  than a claim. No candidate ledger: an edge set is *replaced* wholesale
-  at commit — the registration's identity changes with the key set, so
-  React's own subscribe/cleanup pair performs the diff — and no per-read
-  record survives the commit that consumed it.
-
-  Codec caching is the only accelerant (HD-004). Nothing here holds a
-  node reference, plans a hole, or writes the DOM; those are Arm 2's."
+  one index, one read path — the two HD-002 tiers differ in *where the
+  author writes the read*, not in the machinery underneath. No
+  ViewCell-class object graph. No candidate ledger. Codec caching is the
+  only accelerant (HD-004); nothing here holds a node reference, plans a
+  hole, or writes the DOM."
   (:require [re-frame.adapter.context :as adapter-context]
             [re-frame.bench.hicasso.front.codec :as codec]
             [re-frame.bench.hicasso.front.intent :as intent]
@@ -122,26 +180,46 @@
                          extra))))
 
 ;; ---------------------------------------------------------------------------
-;; The render context — ambient for one body's dynamic extent (HD-020(a))
+;; The render context
 ;; ---------------------------------------------------------------------------
+;;
+;; Module-level rather than per-render objects, and legal for one reason:
+;; **boundary bodies do not nest**. A body returns hiccup; the codec turns
+;; a child boundary into a React *element*, and React runs that child's
+;; body later, after this one has returned. A plain helper called from a
+;; body does run inside it — and its reads belong to the enclosing
+;; boundary, which is exactly the collector's helper-donated read.
 
-(def ^:dynamic ^:private *render*
-  "The rendering boundary's context: the resolved frame keyword and the
-  read provenance. nil outside a render, which is what makes `(sub …)`
-  outside a boundary a loud error rather than a silent read of whichever
-  frame happened to be ambient."
-  nil)
+(def ^:private rstate
+  "The render slots: the frame the running body resolved (nil outside a
+  render, which is what makes `(sub …)` outside a boundary a loud error
+  rather than a silent read of whichever frame happened to be ambient),
+  the two read-surface provenance flags, and the entry the last body
+  resolved. One JS object for the whole runtime — not one per render."
+  #js {"frame" nil "collector" false "grouped" false "entry" nil})
+
+(def ^:private scratch
+  "**The one scratch buffer**, reused by every body and reset by
+  overwrite at the top of each. One render's reads, in read order,
+  nothing else, and no allocation: `(set! (.-length scratch) 0)` is the
+  whole of the reset. There is exactly one of it, which is the point —
+  a second would mean telling two render attempts apart, and that is the
+  ledger."
+  #js [])
 
 (defn rendering?
   "Is a boundary body running right now?"
   []
-  (some? *render*))
+  (some? (.-frame rstate)))
 
 ;; ---------------------------------------------------------------------------
 ;; Frame-locked ops, resolved once per frame and not once per boundary
 ;; ---------------------------------------------------------------------------
 
 (defonce ^:private !frame-ops (atom {}))
+(defonce ^:private !frame-dispatch (atom {}))
+
+(declare dispatch!)
 
 (defn frame-ops
   "The frame-locked op bundle for `frame-kw` — `rf/capture-frame`'s
@@ -157,15 +235,26 @@
         (swap! !frame-ops assoc frame-kw ops)
         ops)))
 
+(defn- frame-dispatch
+  "The ambient dispatch a boundary binds for its render's dynamic extent
+  (HD-020(a)), memoised per frame so binding it allocates nothing."
+  [frame-kw]
+  (or (get @!frame-dispatch frame-kw)
+      (let [f (fn dispatch-for-frame [event] (dispatch! frame-kw event))]
+        (swap! !frame-dispatch assoc frame-kw f)
+        f)))
+
 (defn forget-frame-ops!
-  "Drop the memoised bundle for `frame-kw` (or all of them). A destroyed
-  and re-created frame is a new incarnation, and a captured bundle is
-  pinned to the old one."
-  ([] (reset! !frame-ops {}) nil)
-  ([frame-kw] (swap! !frame-ops dissoc frame-kw) nil))
+  "Drop the memoised bundles. A destroyed and re-created frame is a new
+  incarnation, and a captured bundle is pinned to the old one."
+  ([] (reset! !frame-ops {}) (reset! !frame-dispatch {}) nil)
+  ([frame-kw] (swap! !frame-ops dissoc frame-kw)
+              (swap! !frame-dispatch dissoc frame-kw)
+              nil))
 
 ;; ---------------------------------------------------------------------------
-;; Key cells — one per unique (frame, query), shared by every reader
+;; Key cells — one per unique (frame, query), shared by every reader,
+;; created and acquired ONLY at commit
 ;; ---------------------------------------------------------------------------
 ;;
 ;; The sub-key the index sees is `[frame-kw query-v]`. validation.md pins
@@ -207,61 +296,75 @@
   nil)
 
 (defn- arm-cell-reaper!
-  "A cell with no committed reader is reaped one macrotask later.
-
-  Two callers, one rule. A cell built by a render that never commits has
-  no reader and no owner — the reaper is what releases its `+1`, which is
-  why an abandoned render leaks nothing even though acquisition is
-  commit-owned. A cell whose last reader unmounts is given the same
-  macrotask of grace, so a keyed reorder that unmounts and remounts a row
-  within one turn reuses the reaction instead of rebuilding it."
+  "A cell whose last reader unmounts is given one macrotask of grace, so
+  a keyed reorder that unmounts and remounts a row within one turn reuses
+  the reaction instead of rebuilding it."
   [cell]
   (js/setTimeout (fn [] (when (and (zero? (.-refs cell)) (not (.-disposed cell)))
                           (dispose-cell! cell)))
                  0)
   nil)
 
-(defn- cell-for!
-  "The cell for `[frame-kw query-v]`, built on first read. Building takes
-  the durable `+1` on the sub-cache entry and attaches the one watch that
-  turns the sub layer's equality cutoff into this arm's dirty set."
-  [frame-kw query-v]
-  (let [sub-key [frame-kw query-v]]
-    (or (get @!cells sub-key)
-        (let [reaction (subs/subscribe query-v {:frame frame-kw})
-              wk       (keyword "rf-hicasso-arm1"
-                                (str "w" (vswap! !watch-counter inc)))
-              cell     #js {"subKey"   sub-key
-                            "frameKw"  frame-kw
-                            "queryV"   query-v
-                            "reaction" reaction
-                            "watchKey" wk
-                            "epoch"    0
-                            "refs"     0
-                            "disposed" false}]
-          (when (some? reaction)
-            (add-watch reaction wk (fn [_ _ _ _] (mark-dirty! cell))))
-          (swap! !cells assoc sub-key cell)
-          (arm-cell-reaper! cell)
-          cell))))
+(defn- acquire-cell!
+  "**Commit-phase only.** Take (building if necessary) the durable
+  reference for `sub-key`, and attach the one watch that turns the sub
+  layer's equality cutoff into this arm's dirty set. Acquire without
+  deref: the render already knows the value."
+  [sub-key]
+  (let [cell (or (get @!cells sub-key)
+                 (let [frame-kw (nth sub-key 0)
+                       query-v  (nth sub-key 1)
+                       reaction (subs/subscribe query-v {:frame frame-kw})
+                       wk       (keyword "rf-hicasso-arm1"
+                                         (str "w" (vswap! !watch-counter inc)))
+                       fresh    #js {"subKey"   sub-key
+                                     "frameKw"  frame-kw
+                                     "queryV"   query-v
+                                     "reaction" reaction
+                                     "watchKey" wk
+                                     "epoch"    0
+                                     "refs"     0
+                                     "disposed" false}]
+                   ;; ONE baseline deref, at construction, before the watch.
+                   ;;
+                   ;; HD-002's adjudication sketches commit-phase
+                   ;; acquisition as "acquire without deref: the value is
+                   ;; already known from the render". Against this
+                   ;; substrate that is not implementable, and the failure
+                   ;; is silent: a derived value starts at an `unset`
+                   ;; baseline that is never `rf=` a real value, and the
+                   ;; render's own read went through `subscribe-once`,
+                   ;; which built a DIFFERENT reaction and disposed it. So
+                   ;; a freshly acquired reaction whose baseline is still
+                   ;; `unset` reports movement on the FIRST later commit
+                   ;; whatever the commit did — every newly mounted
+                   ;; boundary re-rendering once for nothing. Establishing
+                   ;; the baseline here costs one compute per *new unique
+                   ;; key*, on a path that has to compute anyway. It is
+                   ;; emphatically not the forbidden commit-phase re-read:
+                   ;; that one is per read per commit and is a tear check;
+                   ;; this one never runs again for the life of the cell.
+                   ;;
+                   ;; The watch then hands us old and new, so the movement
+                   ;; test is free. It is made here rather than trusted to
+                   ;; the layer below because this arm uses the
+                   ;; notification ITSELF as the dirty signal: the shipping
+                   ;; spine can tolerate a notification that did not move,
+                   ;; since `useSyncExternalStore` re-compares snapshots
+                   ;; after it, and this arm cannot.
+                   (when (some? reaction)
+                     @reaction
+                     (add-watch reaction wk
+                                (fn [_ _ old nu] (when-not (= old nu) (mark-dirty! fresh)))))
+                   (swap! !cells assoc sub-key fresh)
+                   fresh))]
+    (set! (.-refs cell) (inc (.-refs cell)))
+    cell))
 
-(defn- acquire! [cell]
-  (set! (.-refs cell) (inc (.-refs cell)))
-  cell)
-
-(defn- release! [cell]
+(defn- release-cell! [cell]
   (set! (.-refs cell) (dec (.-refs cell)))
   (when (<= (.-refs cell) 0) (arm-cell-reaper! cell))
   nil)
-
-(defn- epoch-sum
-  "The snapshot React compares. Epochs are monotone, so the sum is
-  monotone, so `Object.is` on it is a correct change test."
-  [sub-keys]
-  (let [cells @!cells]
-    (reduce (fn [acc k] (if-some [c (get cells k)] (+ acc (.-epoch c)) acc))
-            0
-            sub-keys)))
 
 ;; ---------------------------------------------------------------------------
 ;; The commit — the only door through which a write becomes re-render work
@@ -321,124 +424,179 @@
   nil)
 
 ;; ---------------------------------------------------------------------------
-;; The two product read tiers (HD-002)
+;; The two read tiers (HD-002) — the render phase mutates nothing global
 ;; ---------------------------------------------------------------------------
 
 (defn- read-key!
-  "Read one query for the rendering boundary: the value from the shared
-  cell, the edge into this render's collector."
+  "One read: append the sub-key to the scratch, and return the value.
+
+  Warm — a committed cell holds the key — is a pure deref: no acquire,
+  no release, nothing global touched. Cold is `subscribe-once`, which
+  subscribes, derefs and unsubscribes inside this tick and retains
+  nothing, so an abandoned render leaves the world as it found it."
   [query-v]
-  (let [r *render*]
-    (when (nil? r)
-      (fail! :rf.error/hicasso-sub-outside-render
-             're-frame.bench.hicasso.arm1.runtime/read-key!
-             (str "A subscription read " (pr-str query-v)
-                  " happened outside a boundary render. `sub` and `use-subs` "
-                  "are legal only inside a defview body; `subscribe-once` is "
-                  "the sanctioned snapshot for handler and utility code.")
-             :read-inside-a-boundary-body
-             {:query-v query-v}))
-    (let [cell (cell-for! (.-frame r) query-v)]
-      (index/read! (.-subKey cell))
-      (when-some [reaction (.-reaction cell)] @reaction))))
+  (when (nil? (.-frame rstate))
+    (fail! :rf.error/hicasso-sub-outside-render
+           're-frame.bench.hicasso.arm1.runtime/read-key!
+           (str "A subscription read " (pr-str query-v)
+                " happened outside a boundary render. `sub` and `use-subs` "
+                "are legal only inside a defview body; `subscribe-once` is "
+                "the sanctioned snapshot for handler and utility code.")
+           :read-inside-a-boundary-body
+           {:query-v query-v}))
+  (let [frame-kw (.-frame rstate)
+        sub-key  [frame-kw query-v]]
+    (.push scratch sub-key)
+    (if-some [cell (get @!cells sub-key)]
+      (when-some [r (.-reaction cell)] @r)
+      (subs/subscribe-once query-v {:frame frame-kw}))))
 
 (defn sub
-  "**Tier 3, the ambient collector** — the challenger, ridden hardest. A
-  plain tracked read, legal anywhere in a body: conditionals, loops,
-  helpers. The edge is *recorded* by the collector rather than declared,
-  and the recorded set is what the commit installs."
+  "**The ambient collector** — the surface the operator ruled the only
+  acceptable one (2026-07-31). A plain function call, legal anywhere in a
+  body: inside a `when`, inside a `for`, inside an inlined helper. The
+  edge is *recorded* where the read happens, and the recorded set is what
+  the commit installs — so a branch not taken contributes no edge."
   [query-v]
-  (when-some [r *render*] (set! (.-collectorTier r) true))
+  (set! (.-collector rstate) true)
   (read-key! query-v))
 
 (defn use-subs
-  "**Tier 2, grouped — the product default.** One fixed site receiving the
-  complete query collection, returning the snapshot the body destructures.
-  The edges are *declared*: they are the map's values, so a boundary's
-  edge set is a function of its declaration and not of its control flow.
+  "**Grouped — the control.** One fixed site receiving the complete query
+  collection, returning the snapshot the body destructures. Its edges are
+  *declared*: they are the map's values, so a boundary's edge set is a
+  function of its declaration and not of its control flow, and a branch
+  not taken still costs its edge.
 
       (let [{:keys [todo editing?]}
             (use-subs {:todo     [:todo/by-id id]
                        :editing? [:todo.ui/editing? id]})]
         …)
 
-  The hook count does not move with the collection's size — which is the
-  whole of why this tier is the default and the scalar per-read spine is
-  a comparator only."
+  Kept, and kept working, because the three-rendering dogfood judgement
+  needs it and because it is the surface the collector is measured
+  against — not because it is being defended. The operator ruled it below
+  the ergonomics bar."
   [query-map]
-  (when-some [r *render*] (set! (.-groupedTier r) true))
+  (set! (.-grouped rstate) true)
   (reduce-kv (fn [m alias query-v] (assoc m alias (read-key! query-v)))
              {}
              query-map))
 
 ;; ---------------------------------------------------------------------------
-;; The shell's subscribe closure, cached by the value it closes over
+;; Read-set entries — the cached subscribe/getSnapshot pair, and the
+;; zero-allocation detection of the unchanged case
 ;; ---------------------------------------------------------------------------
 
-(defonce ^:private !closures (atom {}))
+(defonce ^:private !entries
+  ;; first-sub-key -> vector of entries. Bucketing on a value the scratch
+  ;; already holds keeps the steady-state lookup allocation-free; the
+  ;; distinct-query witness puts one entry in each bucket.
+  (atom {}))
 
-(defn- reap-closures! [sub-keys]
-  (js/setTimeout (fn []
-                   (when-some [c (get @!closures sub-keys)]
-                     (when (zero? (.-refs c)) (swap! !closures dissoc sub-keys))))
-                 0)
+(def ^:private empty-bucket-key ::no-reads)
+
+(defn- drop-entry! [entry]
+  (let [bucket-key (.-bucketKey entry)]
+    (swap! !entries
+           (fn [m]
+             (let [left (vec (remove #(identical? % entry) (get m bucket-key)))]
+               (if (seq left) (assoc m bucket-key left) (dissoc m bucket-key)))))
+    nil))
+
+(defn- arm-entry-reaper!
+  "An entry with no committed boundary is dropped one macrotask later.
+  Two callers, one rule: an entry a discarded render minted was never
+  claimed, and an entry whose last boundary unmounted is no longer
+  anybody's. Both are cache eviction and neither is a record of something
+  to undo."
+  [entry]
+  (js/setTimeout (fn [] (when (zero? (.-refs entry)) (drop-entry! entry))) 0)
   nil)
+
+(defn- entry-matches?
+  "Ordered pairwise compare of an entry's key array against the scratch.
+  Allocates nothing. A false negative — same set, different order — costs
+  a second entry and a symmetric difference that removes and re-adds the
+  same edges; it is never a wrong answer, which is why this is not a
+  content hash."
+  [entry]
+  (let [ks (.-keys entry)
+        n  (alength ks)]
+    (and (== n (alength scratch))
+         (loop [i 0]
+           (cond
+             (== i n)                          true
+             (= (aget ks i) (aget scratch i))  (recur (inc i))
+             :else                             false)))))
+
+(declare make-subscribe make-snapshot)
+
+(defn- entry-for
+  "The read-set entry for the scratch's current contents — the cached
+  `subscribe` / `getSnapshot` pair React sees. A hit allocates nothing and
+  keeps `subscribe`'s identity, so React does not re-subscribe and the
+  commit does no work; a miss materialises the key array, the key set and
+  the two closures **once**, for every boundary that will ever read that
+  set."
+  []
+  (let [bucket-key (if (zero? (alength scratch)) empty-bucket-key (aget scratch 0))
+        bucket     (get @!entries bucket-key)]
+    (or (some (fn [e] (when (entry-matches? e) e)) bucket)
+        (let [ks    (.slice scratch)
+              entry #js {"keys"      ks
+                         "set"       (into #{} ks)
+                         "refs"      0
+                         "bucketKey" bucket-key}]
+          (unchecked-set entry "subscribe" (make-subscribe entry))
+          (unchecked-set entry "snapshot" (make-snapshot entry))
+          (swap! !entries update bucket-key (fnil conj []) entry)
+          (arm-entry-reaper! entry)
+          entry))))
+
+(defn- make-snapshot
+  "React's `getSnapshot`: the sum of the set's epochs. Monotone, so
+  `Object.is` on it is a correct change test; cached on the entry, so a
+  render allocates no closure for it."
+  [entry]
+  (fn snapshot []
+    (let [cells @!cells
+          ks    (.-keys entry)
+          n     (alength ks)]
+      (loop [i 0 acc 0]
+        (if (== i n)
+          acc
+          (recur (inc i)
+                 (if-some [c (get cells (aget ks i))] (+ acc (.-epoch c)) acc)))))))
 
 (defn- make-subscribe
   "React's `subscribe`, as a pure function of the read set.
 
-  Everything commit-owned lives in here: the boundary's registration is
-  minted from React's own `onStoreChange`, the index learns the boundary
-  and its edges, and each key cell takes its committed reference. The
-  returned cleanup is the exact inverse and is the only place edges and
-  references are released, so teardown is symmetric with mount whatever
-  React did with the renders in between.
+  **The only global mutation in the state machine.** The boundary's
+  registration is minted from React's own `onStoreChange`, the index
+  learns the boundary and its edges, and each key takes its committed
+  reference. The returned cleanup is the exact inverse and is the only
+  place edges and references are released, so teardown is symmetric with
+  mount whatever React did with the renders in between.
 
-  The cells are re-resolved here rather than carried from the render: a
-  cell the render built may have been reaped in the window before the
-  commit, and the committed reference must be taken on the cell that is
-  actually live. The registration then holds exactly the cells it
-  acquired, so its cleanup cannot release a successor's."
-  [sub-keys]
+  The registration holds exactly the cells it acquired, so its cleanup
+  cannot release a successor's after a reap and rebuild."
+  [entry]
   (fn subscribe [on-store-change]
-    (let [reg   #js {"subKeys" sub-keys "notify" on-store-change}
-          cells (mapv (fn [k] (acquire! (cell-for! (nth k 0) (nth k 1)))) sub-keys)]
+    (let [reads (.-set entry)
+          reg   #js {"reads" reads "notify" on-store-change}
+          cells (mapv acquire-cell! reads)]
       (unchecked-set reg "cells" cells)
       (index/mount! reg)
-      (index/record-reads! reg sub-keys)
-      (when-some [c (get @!closures sub-keys)]
-        (set! (.-refs c) (inc (.-refs c)))
-        (set! (.-acquired c) true))
+      (index/record-reads! reg reads)
+      (set! (.-refs entry) (inc (.-refs entry)))
       (fn unsubscribe []
         (set! (.-notify reg) nil)
         (index/unmount! reg)
-        (doseq [cell cells] (release! cell))
-        (when-some [c (get @!closures sub-keys)]
-          (set! (.-refs c) (dec (.-refs c)))
-          (when (<= (.-refs c) 0) (reap-closures! sub-keys)))
+        (doseq [cell cells] (release-cell! cell))
+        (set! (.-refs entry) (dec (.-refs entry)))
+        (when (<= (.-refs entry) 0) (arm-entry-reaper! entry))
         nil))))
-
-(defn- closure-for
-  "The cached `subscribe` for this read set. Identity-stable while the set
-  is unchanged, which is what stops React re-subscribing on an ordinary
-  re-render — and different the moment the set changes, which is what
-  makes React's own subscribe/cleanup pair perform the edge-set diff.
-
-  Entries are ref-counted by *committed* registrations, never by renders:
-  a render increments nothing, so a body that runs ten times before its
-  first commit leaves the count at zero, and the creation reaper drops an
-  entry no commit ever claimed."
-  [sub-keys]
-  (if-some [c (get @!closures sub-keys)]
-    (.-subscribe c)
-    (let [fresh #js {"subscribe" (make-subscribe sub-keys) "refs" 0 "acquired" false}]
-      (swap! !closures assoc sub-keys fresh)
-      (js/setTimeout (fn []
-                       (when-some [c (get @!closures sub-keys)]
-                         (when (and (zero? (.-refs c)) (not (.-acquired c)))
-                           (swap! !closures dissoc sub-keys))))
-                     0)
-      (.-subscribe fresh))))
 
 (defn commit-boundary!
   "**The seam React occupies.** Hand a boundary's read set and a notifier
@@ -447,12 +605,12 @@
 
   It exists because the commit path, the index wiring and the
   zero-leaked-reference assertion are the parts of this arm most worth
-  proving cheaply and deterministically — and every one of them is
+  proving cheaply and deterministically, and every one of them is
   answerable without a browser, a root, or a render. The DOM suites then
-  prove that React drives *this* seam, rather than re-proving what the
+  prove that React drives *this* seam rather than re-proving what the
   seam does."
-  [reads notify]
-  ((closure-for reads) notify))
+  [entry notify]
+  ((.-subscribe entry) notify))
 
 ;; ---------------------------------------------------------------------------
 ;; The body run, and the generation fence
@@ -465,32 +623,40 @@
   spinning."
   3)
 
-(defn- run-once [frame-kw body-fn props]
-  (let [collector (volatile! #{})
-        ctx       #js {"frame" frame-kw "collectorTier" false "groupedTier" false}]
-    (binding [*render*          ctx
-              index/*collector* collector]
-      (let [element (intent/with-frame
-                      (fn [event] (dispatch! frame-kw event))
-                      (fn [] (codec/as-element (body-fn props))))]
-        #js [element @collector (.-collectorTier ctx) (.-groupedTier ctx)]))))
+(defn- run-once
+  "One body run. The scratch and both provenance flags are reset
+  **unconditionally** — a reset guarded by \"if empty\" would concatenate
+  two renders' reads, which is precisely what makes StrictMode's
+  double-invoke correct here rather than additive."
+  [frame-kw body-fn props]
+  (set! (.-length scratch) 0)
+  (set! (.-collector rstate) false)
+  (set! (.-grouped rstate) false)
+  (set! (.-frame rstate) frame-kw)
+  (try
+    (intent/with-frame (frame-dispatch frame-kw)
+      (fn [] (codec/as-element (body-fn props))))
+    (finally (set! (.-frame rstate) nil))))
 
 (defn render-body
-  "Run a boundary body under the generation fence. Returns
-  `#js [element read-set collector? grouped?]`.
+  "Run a boundary body under the generation fence and return its element;
+  [[last-reads]] carries the read-set entry.
 
   The fence is the loop: capture the generation, run the body, and if a
   commit landed while it ran, run it again against the newer commit. All
-  of a pass's reads therefore observe one commit — the invariant-5
-  preservation architecture.md asks of this arm, and the thing the
-  staged-stale witness stages."
+  of a pass's reads therefore observe one commit — invariant-5
+  preservation as one comparison per boundary, not one deref per read."
   [frame-kw body-fn props]
   (loop [attempt 0]
-    (let [before (generation)
-          out    (run-once frame-kw body-fn props)]
+    (let [before  (generation)
+          element (run-once frame-kw body-fn props)]
       (cond
-        (= before (generation))       out
-        (< attempt max-fence-retries) (recur (inc attempt))
+        (= before (generation))
+        (do (set! (.-entry rstate) (entry-for)) element)
+
+        (< attempt max-fence-retries)
+        (recur (inc attempt))
+
         :else
         (fail! :rf.error/hicasso-generation-fence-exhausted
                're-frame.bench.hicasso.arm1.runtime/render-body
@@ -500,6 +666,23 @@
                     "out of the render.")
                :move-the-write-out-of-the-render
                {:frame frame-kw :generation (generation)})))))
+
+(defn last-reads
+  "The read-set entry the most recent [[render-body]] resolved."
+  []
+  (.-entry rstate))
+
+(defn reads-of
+  "An entry's sub-key set."
+  [entry]
+  (.-set entry))
+
+(defn last-tiers
+  "Which read surfaces the most recent body used. The instrument's input,
+  and the reason a rendering's tier is a measured property rather than a
+  claim in a docstring."
+  []
+  {:collector? (.-collector rstate) :grouped? (.-grouped rstate)})
 
 ;; ---------------------------------------------------------------------------
 ;; The shell — exactly two React hooks, and no useRef
@@ -529,11 +712,10 @@
   [body-fn js-props]
   (let [frame-kw (resolve-frame! (react/useContext adapter-context/frame-context))
         props    (or (unchecked-get js-props "rfProps") {})
-        out      (render-body frame-kw body-fn props)
-        reads    (aget out 1)
-        snapshot (fn [] (epoch-sum reads))]
-    (react/useSyncExternalStore (closure-for reads) snapshot snapshot)
-    (aget out 0)))
+        element  (render-body frame-kw body-fn props)
+        entry    (.-entry rstate)]
+    (react/useSyncExternalStore (.-subscribe entry) (.-snapshot entry) (.-snapshot entry))
+    element))
 
 (defn mint-view!
   "Turn a body fn into a boundary: a React function component, marked as a
@@ -558,7 +740,7 @@
   []
   {:per-boundary
    [{:token :registration
-     :what  "one JS object: the sub-key set (shared with the closure cache), React's onStoreChange, and the acquired cell vector"}
+     :what  "one JS object: the read set (shared with its entry), React's onStoreChange, and the acquired cell vector"}
     {:token :index/live
      :what  "one membership in the index's :live set"}
     {:token :index/b->subs
@@ -572,10 +754,12 @@
    :shared
    [{:token :key-cell
      :what  "one cell + one sub-cache reaction per unique (frame, query), however many boundaries read it"}
-    {:token :subscribe-closure
-     :what  "one subscribe closure per distinct read SET, shared by every boundary with that set, ref-counted and reaped"}
+    {:token :read-set-entry
+     :what  "one key array, key set, subscribe and getSnapshot per distinct read SET, shared by every boundary with that set"}
+    {:token :scratch
+     :what  "ONE module-level array for the whole runtime, reset by overwrite; its capacity is the high-water read count"}
     {:token :frame-ops
-     :what  "one capture-frame bundle per frame"}
+     :what  "one capture-frame bundle and one ambient dispatch per frame"}
     {:token :codec-cache
      :what  "the codec's tag and prop caches, per distinct literal in the build"}]
    :absent
@@ -583,18 +767,18 @@
     {:token :use-state :what "no per-instance render-phase state of any kind"}
     {:token :view-cell :what "no per-boundary object graph, reaction, watcher or scheduler"}
     {:token :candidate-ledger
-     :what  "no per-read record survives the commit that consumed it"}]})
+     :what  "one scratch buffer, never two; nothing keyed by render, attempt, lane or generation; no per-read object; no commit-phase deref"}]})
 
 (defn stats
-  "What the witnesses read: live cells, live boundaries, cached closures,
-  the generation, and the codec caches."
+  "What the witnesses read: live cells, live boundaries, cached read-set
+  entries, the generation, and the codec caches."
   []
   (let [idx (index/snapshot)]
     {:cells      (count @!cells)
      :cell-refs  (reduce + 0 (map (fn [[_ c]] (.-refs c)) @!cells))
      :boundaries (count (:live idx))
      :edges      (reduce + 0 (map (fn [[_ v]] (count v)) (:b->subs idx)))
-     :closures   (count @!closures)
+     :entries    (reduce + 0 (map (fn [[_ v]] (count v)) @!entries))
      :generation (generation)
      :frames     (count @!frame-ops)
      :codec      (codec/cache-sizes)}))
@@ -604,21 +788,24 @@
   zero-leaked-subscription-ref-counts assertion; `:boundaries` and
   `:edges` are the index's half of it."
   []
-  (select-keys (stats) [:cells :cell-refs :boundaries :edges :closures]))
+  (select-keys (stats) [:cells :cell-refs :boundaries :edges :entries]))
 
 (defn reset-runtime!
-  "Drop every cell, every edge, every cached closure and every frame
-  bundle. The root-teardown and test-fixture door; disposing each cell
-  releases its sub-cache reference, so this is the leak check's reset
-  rather than a way to hide one."
+  "Drop every cell, every edge, every cached entry and every frame bundle.
+  The root-teardown and test-fixture door; disposing each cell releases
+  its sub-cache reference, so this is the leak check's reset rather than
+  a way to hide one."
   []
   (doseq [[_ cell] @!cells] (dispose-cell! cell))
   (reset! !cells {})
-  (reset! !closures {})
+  (reset! !entries {})
   (vreset! !dirty #{})
   (vreset! !deferred #{})
   (vreset! !batching false)
   (vreset! !generation 0)
+  (set! (.-entry rstate) nil)
+  (set! (.-frame rstate) nil)
+  (set! (.-length scratch) 0)
   (index/reset-index!)
   (forget-frame-ops!)
   nil)

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -190,7 +190,7 @@
 ;; body does run inside it — and its reads belong to the enclosing
 ;; boundary, which is exactly the collector's helper-donated read.
 
-(def ^:private rstate
+(def ^:private ^js rstate
   "The render slots: the frame the running body resolved (nil outside a
   render, which is what makes `(sub …)` outside a boundary a loud error
   rather than a silent read of whichever frame happened to be ambient),
@@ -198,7 +198,7 @@
   resolved. One JS object for the whole runtime — not one per render."
   #js {"frame" nil "collector" false "grouped" false "entry" nil})
 
-(def ^:private scratch
+(def ^:private ^js scratch
   "**The one scratch buffer**, reused by every body and reset by
   overwrite at the top of each. One render's reads, in read order,
   nothing else, and no allocation: `(set! (.-length scratch) 0)` is the
@@ -282,12 +282,12 @@
 
 (declare flush!)
 
-(defn- mark-dirty! [cell]
+(defn- mark-dirty! [^js cell]
   (when-not (.-disposed cell)
     (vswap! !dirty conj cell)
     (when-not @!batching (flush!))))
 
-(defn- dispose-cell! [cell]
+(defn- dispose-cell! [^js cell]
   (when-not (.-disposed cell)
     (set! (.-disposed cell) true)
     (when-some [r (.-reaction cell)] (remove-watch r (.-watchKey cell)))
@@ -299,7 +299,7 @@
   "A cell whose last reader unmounts is given one macrotask of grace, so
   a keyed reorder that unmounts and remounts a row within one turn reuses
   the reaction instead of rebuilding it."
-  [cell]
+  [^js cell]
   (js/setTimeout (fn [] (when (and (zero? (.-refs cell)) (not (.-disposed cell)))
                           (dispose-cell! cell)))
                  0)
@@ -311,13 +311,13 @@
   layer's equality cutoff into this arm's dirty set. Acquire without
   deref: the render already knows the value."
   [sub-key]
-  (let [cell (or (get @!cells sub-key)
+  (let [^js cell (or (get @!cells sub-key)
                  (let [frame-kw (nth sub-key 0)
                        query-v  (nth sub-key 1)
                        reaction (subs/subscribe query-v {:frame frame-kw})
                        wk       (keyword "rf-hicasso-arm1"
                                          (str "w" (vswap! !watch-counter inc)))
-                       fresh    #js {"subKey"   sub-key
+                       ^js fresh #js {"subKey"   sub-key
                                      "frameKw"  frame-kw
                                      "queryV"   query-v
                                      "reaction" reaction
@@ -361,7 +361,7 @@
     (set! (.-refs cell) (inc (.-refs cell)))
     cell))
 
-(defn- release-cell! [cell]
+(defn- release-cell! [^js cell]
   (set! (.-refs cell) (dec (.-refs cell)))
   (when (<= (.-refs cell) 0) (arm-cell-reaper! cell))
   nil)
@@ -371,7 +371,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- notify! [registrations]
-  (doseq [r registrations]
+  (doseq [^js r registrations]
     (when-some [n (.-notify r)] (n))))
 
 (defn flush!
@@ -389,8 +389,8 @@
     (when (seq dirty)
       (vreset! !dirty #{})
       (vswap! !generation inc)
-      (doseq [c dirty] (set! (.-epoch c) (inc (.-epoch c))))
-      (let [boundaries (index/commit! (into #{} (map #(.-subKey %)) dirty))]
+      (doseq [^js c dirty] (set! (.-epoch c) (inc (.-epoch c))))
+      (let [boundaries (index/commit! (into #{} (map (fn [^js c] (.-subKey c))) dirty))]
         (if (rendering?)
           (do (vswap! !deferred into boundaries)
               (js/setTimeout (fn []
@@ -447,7 +447,7 @@
   (let [frame-kw (.-frame rstate)
         sub-key  [frame-kw query-v]]
     (.push scratch sub-key)
-    (if-some [cell (get @!cells sub-key)]
+    (if-some [^js cell (get @!cells sub-key)]
       (when-some [r (.-reaction cell)] @r)
       (subs/subscribe-once query-v {:frame frame-kw}))))
 
@@ -496,7 +496,7 @@
 
 (def ^:private empty-bucket-key ::no-reads)
 
-(defn- drop-entry! [entry]
+(defn- drop-entry! [^js entry]
   (let [bucket-key (.-bucketKey entry)]
     (swap! !entries
            (fn [m]
@@ -510,7 +510,7 @@
   claimed, and an entry whose last boundary unmounted is no longer
   anybody's. Both are cache eviction and neither is a record of something
   to undo."
-  [entry]
+  [^js entry]
   (js/setTimeout (fn [] (when (zero? (.-refs entry)) (drop-entry! entry))) 0)
   nil)
 
@@ -520,7 +520,7 @@
   a second entry and a symmetric difference that removes and re-adds the
   same edges; it is never a wrong answer, which is why this is not a
   content hash."
-  [entry]
+  [^js entry]
   (let [ks (.-keys entry)
         n  (alength ks)]
     (and (== n (alength scratch))
@@ -542,9 +542,9 @@
   []
   (let [bucket-key (if (zero? (alength scratch)) empty-bucket-key (aget scratch 0))
         bucket     (get @!entries bucket-key)]
-    (or (some (fn [e] (when (entry-matches? e) e)) bucket)
+    (or (some (fn [^js e] (when (entry-matches? e) e)) bucket)
         (let [ks    (.slice scratch)
-              entry #js {"keys"      ks
+              ^js entry #js {"keys"      ks
                          "set"       (into #{} ks)
                          "refs"      0
                          "bucketKey" bucket-key}]
@@ -558,7 +558,7 @@
   "React's `getSnapshot`: the sum of the set's epochs. Monotone, so
   `Object.is` on it is a correct change test; cached on the entry, so a
   render allocates no closure for it."
-  [entry]
+  [^js entry]
   (fn snapshot []
     (let [cells @!cells
           ks    (.-keys entry)
@@ -567,7 +567,7 @@
         (if (== i n)
           acc
           (recur (inc i)
-                 (if-some [c (get cells (aget ks i))] (+ acc (.-epoch c)) acc)))))))
+                 (if-some [^js c (get cells (aget ks i))] (+ acc (.-epoch c)) acc)))))))
 
 (defn- make-subscribe
   "React's `subscribe`, as a pure function of the read set.
@@ -581,10 +581,10 @@
 
   The registration holds exactly the cells it acquired, so its cleanup
   cannot release a successor's after a reap and rebuild."
-  [entry]
+  [^js entry]
   (fn subscribe [on-store-change]
     (let [reads (.-set entry)
-          reg   #js {"reads" reads "notify" on-store-change}
+          ^js reg #js {"reads" reads "notify" on-store-change}
           cells (mapv acquire-cell! reads)]
       (unchecked-set reg "cells" cells)
       (index/mount! reg)
@@ -609,7 +609,7 @@
   answerable without a browser, a root, or a render. The DOM suites then
   prove that React drives *this* seam rather than re-proving what the
   seam does."
-  [entry notify]
+  [^js entry notify]
   ((.-subscribe entry) notify))
 
 ;; ---------------------------------------------------------------------------
@@ -674,7 +674,7 @@
 
 (defn reads-of
   "An entry's sub-key set."
-  [entry]
+  [^js entry]
   (.-set entry))
 
 (defn last-tiers
@@ -713,7 +713,7 @@
   (let [frame-kw (resolve-frame! (react/useContext adapter-context/frame-context))
         props    (or (unchecked-get js-props "rfProps") {})
         element  (render-body frame-kw body-fn props)
-        entry    (.-entry rstate)]
+        ^js entry (.-entry rstate)]
     (react/useSyncExternalStore (.-subscribe entry) (.-snapshot entry) (.-snapshot entry))
     element))
 
@@ -775,7 +775,7 @@
   []
   (let [idx (index/snapshot)]
     {:cells      (count @!cells)
-     :cell-refs  (reduce + 0 (map (fn [[_ c]] (.-refs c)) @!cells))
+     :cell-refs  (reduce-kv (fn [acc _ ^js c] (+ acc (.-refs c))) 0 @!cells)
      :boundaries (count (:live idx))
      :edges      (reduce + 0 (map (fn [[_ v]] (count v)) (:b->subs idx)))
      :entries    (reduce + 0 (map (fn [[_ v]] (count v)) @!entries))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -121,6 +121,16 @@
   turns hiccup into elements, and moving the codec call out of `run-once`
   fails `a-lazy-for-registers-its-edges-and-its-readers-re-run`.
 
+  **An eager codec is only half of it, and the other half matters more.**
+  A codec can force the reads it walks; nothing can force a read the
+  author deferred past the render — a handler closure, a `delay`, a lazy
+  seq stashed rather than returned. Each of those would otherwise be a
+  *silent* missing edge: correct on screen, frozen thereafter,
+  attributable to nothing. So the render frame is set in a `try` and
+  cleared in the matching `finally`, and [[read-key!]] fails loudly when
+  it finds none. Every escape becomes an error naming the query rather
+  than an edge that was quietly not recorded.
+
   ### The cold read, and what it costs (clause (a) consequence)
 
   A render-phase read is a **pure deref** when the key already has a

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -103,6 +103,24 @@
   sub-keys only; the generation fence, not a re-read, is what preserves
   invariant 5.
 
+  ### Laziness, and why the collector window closes around the codec
+
+  A Surface B property worth stating in the runtime rather than only in a
+  test, because a host language with lazy seqs can lose it silently. `for`
+  returns a **lazy sequence**, so every `(sub …)` inside one runs when
+  something walks the seq — not when the body returns. A collector closed
+  at the body's return would register **no edge for any row**, and would
+  look perfectly correct on the first render, because the values are right
+  once realised; it would simply never update again.
+
+  This arm is safe by construction: [[run-once]] closes the window around
+  `codec/as-element`, and the codec is eager everywhere it walks —
+  `expand-seq` drives a seq to exhaustion, `realize-children` folds one
+  into a vector, and a seq at a prop position goes through `clj->js`. A
+  lazy read is therefore forced inside the window by the same pass that
+  turns hiccup into elements, and moving the codec call out of `run-once`
+  fails `a-lazy-for-registers-its-edges-and-its-readers-re-run`.
+
   ### The cold read, and what it costs (clause (a) consequence)
 
   A render-phase read is a **pure deref** when the key already has a

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -1,0 +1,624 @@
+(ns re-frame.bench.hicasso.arm1.runtime
+  "HICASSO ARM 1 — LEAN-REACT. The runtime skeleton (rf2-2rtt6.9).
+
+  A boundary is a real React function component minted by `defview`
+  (`re-frame.bench.hicasso.arm1.lang`). React owns identity,
+  reconciliation, context, refs, errors, concurrency and the
+  controlled-input end-of-event restore; this namespace owns exactly
+  three things React does not: *which* boundaries a commit must re-run,
+  *how* a boundary's body reaches subscription values, and *the fence*
+  that keeps one render pass on one commit.
+
+  Residence: the bench/test tree, off every production source path
+  (HD-017). Nothing under `implementation/*/src` requires this.
+
+  ## The shell, and the ≤2-hook budget (HD-020)
+
+  The whole shell is two React hook calls and no `useRef`:
+
+      1. `useContext(frame-context)`         the frame hook
+      2. `useSyncExternalStore(sub, snap)`   the subscription/epoch hook
+
+  There is no third hook, and — this is the part that took the design —
+  **no per-instance render-phase state at all**. That is not a saving,
+  it is what makes the budget reachable: React offers a function
+  component no per-instance storage except a hook cell, so a shell that
+  wants one has spent a third hook (`useRef`/`useState`) before it
+  starts. The way out is to notice what the two closures actually need
+  to close over.
+
+  - `subscribe` closes over **the render's sub-key set and nothing
+    else**, so it is a pure function of a *value*. It is therefore
+    cached by that value ([[closure-for]]) and shared by every boundary
+    reading the same set — which makes its identity stable across a
+    re-render whose reads did not change, which is exactly the condition
+    React uses to decide whether to re-subscribe. An unchanged hot read
+    performs no new attach and no new release, by construction.
+  - React calls that shared `subscribe` once per *fiber*, handing it that
+    fiber's own `onStoreChange`. The registration minted inside is
+    therefore per-boundary, durable for the mount, and commit-owned — so
+    it is the boundary id the index keys on, and a render that never
+    commits registers nothing at all. The abandoned-render leak class is
+    closed by construction rather than by bookkeeping.
+  - `getSnapshot` closes over the same key set and returns the **sum of
+    those keys' epochs**. Epochs only ever increase, so the sum is
+    strictly monotone: `Object.is` on one number is a correct change
+    test, and React's own \"getSnapshot should be cached\" rule is
+    satisfied without a memo.
+
+  The hook budget is not self-reported — `arm1_hook_ledger_dom_cljs_test`
+  counts hook calls at React's own dispatcher, which sees every call the
+  shell makes.
+
+  ## The re-render path
+
+      write -> the sub layer's equality cutoff -> key-cell watch -> dirty set
+        -> flush: epoch bump + generation bump
+        -> front.sub-index/commit! -> dirty boundary set
+        -> registration notify (React's onStoreChange)
+        -> React re-renders exactly those boundaries
+        -> bodies re-run -> hiccup -> front.codec -> React reconciles
+
+  The dirty *sub-key* set is push-cheap: a key is marked only when the
+  sub layer's own equality cutoff let a change through, so a commit that
+  moves one subscription costs one mark and one index lookup, never a
+  sweep of every live key. The dirty *boundary* set is the shared front
+  half's index, unmodified — this arm calls `mount!`, `record-reads!`,
+  `unmount!` and `commit!`, and edits nothing.
+
+  Notifications are batched by [[with-commit]], which the arm's
+  frame-locked dispatch wraps around every intent, so one user action is
+  one flush however many subscriptions it moved.
+
+  ## The generation fence
+
+  [[generation]] counts flushes. A body runs inside [[render-body]],
+  which captures the generation before the body and checks it after: if a
+  commit landed *during* the body, its reads straddle two commits and the
+  body is re-run against the newer one. That is invariant-5 preservation
+  written as a loop rather than as a comment, and
+  `arm1_generation_fence_dom_cljs_test` stages exactly that commit from
+  inside a rendering body.
+
+  A flush that happens while a body is running must not call React's
+  `onStoreChange` — that is a render-phase update on somebody else's
+  component. Those notifications are deferred to a macrotask; the fence
+  has already made the *rendering* boundary correct, so the deferral only
+  reaches boundaries that were not rendering.
+
+  ## What is deliberately NOT here (the hard fences)
+
+  No compiler and no analyzer: bodies are ordinary functions and hiccup
+  is interpreted by the shared codec at runtime. No dual mode: one shell,
+  one index, one read path — the two HD-002 product tiers ([[use-subs]]
+  and [[sub]]) differ in *where the author writes the read* and in the
+  provenance the index records, not in the machinery underneath. No
+  ViewCell-class object graph: a boundary's exclusive retention is one
+  registration, its index memberships, and React's own two hook cells —
+  the inventory is [[retained-inventory]], and it is a witness rather
+  than a claim. No candidate ledger: an edge set is *replaced* wholesale
+  at commit — the registration's identity changes with the key set, so
+  React's own subscribe/cleanup pair performs the diff — and no per-read
+  record survives the commit that consumed it.
+
+  Codec caching is the only accelerant (HD-004). Nothing here holds a
+  node reference, plans a hole, or writes the DOM; those are Arm 2's."
+  (:require [re-frame.adapter.context :as adapter-context]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.bench.hicasso.front.sub-index :as index]
+            [re-frame.core :as rf]
+            [re-frame.subs :as subs]
+            ["react" :as react]))
+
+;; ---------------------------------------------------------------------------
+;; Errors
+;; ---------------------------------------------------------------------------
+
+(defn- fail! [id where reason recovery extra]
+  (throw (ex-info (str reason " [" id "]")
+                  (merge {:rf.error/id id :where where
+                          :reason reason :recovery recovery}
+                         extra))))
+
+;; ---------------------------------------------------------------------------
+;; The render context — ambient for one body's dynamic extent (HD-020(a))
+;; ---------------------------------------------------------------------------
+
+(def ^:dynamic ^:private *render*
+  "The rendering boundary's context: the resolved frame keyword and the
+  read provenance. nil outside a render, which is what makes `(sub …)`
+  outside a boundary a loud error rather than a silent read of whichever
+  frame happened to be ambient."
+  nil)
+
+(defn rendering?
+  "Is a boundary body running right now?"
+  []
+  (some? *render*))
+
+;; ---------------------------------------------------------------------------
+;; Frame-locked ops, resolved once per frame and not once per boundary
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !frame-ops (atom {}))
+
+(defn frame-ops
+  "The frame-locked op bundle for `frame-kw` — `rf/capture-frame`'s
+  `{:frame :dispatch :dispatch-sync :subscribe}` — memoised per frame.
+
+  HD-020(a) has each boundary read the frame *once* from the substrate's
+  single internal context; it does not ask each boundary to rebuild the
+  bundle. `capture-frame` pins a frame incarnation and is not free, so
+  the shell's cost here is one map lookup per render and no allocation."
+  [frame-kw]
+  (or (get @!frame-ops frame-kw)
+      (let [ops (rf/capture-frame frame-kw)]
+        (swap! !frame-ops assoc frame-kw ops)
+        ops)))
+
+(defn forget-frame-ops!
+  "Drop the memoised bundle for `frame-kw` (or all of them). A destroyed
+  and re-created frame is a new incarnation, and a captured bundle is
+  pinned to the old one."
+  ([] (reset! !frame-ops {}) nil)
+  ([frame-kw] (swap! !frame-ops dissoc frame-kw) nil))
+
+;; ---------------------------------------------------------------------------
+;; Key cells — one per unique (frame, query), shared by every reader
+;; ---------------------------------------------------------------------------
+;;
+;; The sub-key the index sees is `[frame-kw query-v]`. validation.md pins
+;; sub-key identity as `(query-id, args)` under value equality; qualifying
+;; it by frame is strictly finer, and it is the honest key for a runtime
+;; in which two frames are isolated contexts holding two different
+;; app-dbs. The pair is a value, so every index law reads it exactly as it
+;; reads a bare query vector.
+;;
+;; Cells are plain JS objects rather than a deftype on purpose: this is
+;; the object the heap ladder prices per unique key, and a deftype would
+;; add a constructor and a prototype to a structure with no behaviour.
+
+(defonce ^:private !cells (atom {}))
+(defonce ^:private !dirty (volatile! #{}))
+(defonce ^:private !batching (volatile! false))
+(defonce ^:private !generation (volatile! 0))
+(defonce ^:private !deferred (volatile! #{}))
+(defonce ^:private !watch-counter (volatile! 0))
+
+(defn generation
+  "The commit generation. Bumped once per flush that moved something."
+  []
+  @!generation)
+
+(declare flush!)
+
+(defn- mark-dirty! [cell]
+  (when-not (.-disposed cell)
+    (vswap! !dirty conj cell)
+    (when-not @!batching (flush!))))
+
+(defn- dispose-cell! [cell]
+  (when-not (.-disposed cell)
+    (set! (.-disposed cell) true)
+    (when-some [r (.-reaction cell)] (remove-watch r (.-watchKey cell)))
+    (swap! !cells dissoc (.-subKey cell))
+    (subs/unsubscribe (.-frameKw cell) (.-queryV cell)))
+  nil)
+
+(defn- arm-cell-reaper!
+  "A cell with no committed reader is reaped one macrotask later.
+
+  Two callers, one rule. A cell built by a render that never commits has
+  no reader and no owner — the reaper is what releases its `+1`, which is
+  why an abandoned render leaks nothing even though acquisition is
+  commit-owned. A cell whose last reader unmounts is given the same
+  macrotask of grace, so a keyed reorder that unmounts and remounts a row
+  within one turn reuses the reaction instead of rebuilding it."
+  [cell]
+  (js/setTimeout (fn [] (when (and (zero? (.-refs cell)) (not (.-disposed cell)))
+                          (dispose-cell! cell)))
+                 0)
+  nil)
+
+(defn- cell-for!
+  "The cell for `[frame-kw query-v]`, built on first read. Building takes
+  the durable `+1` on the sub-cache entry and attaches the one watch that
+  turns the sub layer's equality cutoff into this arm's dirty set."
+  [frame-kw query-v]
+  (let [sub-key [frame-kw query-v]]
+    (or (get @!cells sub-key)
+        (let [reaction (subs/subscribe query-v {:frame frame-kw})
+              wk       (keyword "rf-hicasso-arm1"
+                                (str "w" (vswap! !watch-counter inc)))
+              cell     #js {"subKey"   sub-key
+                            "frameKw"  frame-kw
+                            "queryV"   query-v
+                            "reaction" reaction
+                            "watchKey" wk
+                            "epoch"    0
+                            "refs"     0
+                            "disposed" false}]
+          (when (some? reaction)
+            (add-watch reaction wk (fn [_ _ _ _] (mark-dirty! cell))))
+          (swap! !cells assoc sub-key cell)
+          (arm-cell-reaper! cell)
+          cell))))
+
+(defn- acquire! [cell]
+  (set! (.-refs cell) (inc (.-refs cell)))
+  cell)
+
+(defn- release! [cell]
+  (set! (.-refs cell) (dec (.-refs cell)))
+  (when (<= (.-refs cell) 0) (arm-cell-reaper! cell))
+  nil)
+
+(defn- epoch-sum
+  "The snapshot React compares. Epochs are monotone, so the sum is
+  monotone, so `Object.is` on it is a correct change test."
+  [sub-keys]
+  (let [cells @!cells]
+    (reduce (fn [acc k] (if-some [c (get cells k)] (+ acc (.-epoch c)) acc))
+            0
+            sub-keys)))
+
+;; ---------------------------------------------------------------------------
+;; The commit — the only door through which a write becomes re-render work
+;; ---------------------------------------------------------------------------
+
+(defn- notify! [registrations]
+  (doseq [r registrations]
+    (when-some [n (.-notify r)] (n))))
+
+(defn flush!
+  "Turn the dirty sub-key set into re-render work: bump each dirty key's
+  epoch, bump the generation, ask the index which boundaries read those
+  keys, and hand each one React's own `onStoreChange`.
+
+  Notifications are deferred to a macrotask when a body is running: an
+  `onStoreChange` fired from inside somebody's render is a render-phase
+  update on another component, which React rejects — and which the
+  generation fence has already made unnecessary for the *rendering*
+  boundary."
+  []
+  (let [dirty @!dirty]
+    (when (seq dirty)
+      (vreset! !dirty #{})
+      (vswap! !generation inc)
+      (doseq [c dirty] (set! (.-epoch c) (inc (.-epoch c))))
+      (let [boundaries (index/commit! (into #{} (map #(.-subKey %)) dirty))]
+        (if (rendering?)
+          (do (vswap! !deferred into boundaries)
+              (js/setTimeout (fn []
+                               (let [d @!deferred]
+                                 (vreset! !deferred #{})
+                                 (notify! d)))
+                             0))
+          (notify! boundaries)))))
+  nil)
+
+(defn with-commit
+  "Run `f` inside one commit window: every subscription the writes inside
+  it move is collected, and the boundaries that read them are notified
+  once, after `f` returns. Re-entrant — a nested window joins the
+  enclosing one rather than flushing early."
+  [f]
+  (if @!batching
+    (f)
+    (do (vreset! !batching true)
+        (try (f)
+             (finally (vreset! !batching false)
+                      (flush!))))))
+
+(defn dispatch!
+  "The arm's frame-locked dispatch — HD-019's synchronous door. The event
+  drains synchronously inside the caller's turn (the discrete browser
+  event, for an intent) and the store notification runs before that turn
+  ends, so React commits the echo in the same turn."
+  [frame-kw event]
+  (with-commit (fn [] ((:dispatch-sync (frame-ops frame-kw)) event)))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; The two product read tiers (HD-002)
+;; ---------------------------------------------------------------------------
+
+(defn- read-key!
+  "Read one query for the rendering boundary: the value from the shared
+  cell, the edge into this render's collector."
+  [query-v]
+  (let [r *render*]
+    (when (nil? r)
+      (fail! :rf.error/hicasso-sub-outside-render
+             're-frame.bench.hicasso.arm1.runtime/read-key!
+             (str "A subscription read " (pr-str query-v)
+                  " happened outside a boundary render. `sub` and `use-subs` "
+                  "are legal only inside a defview body; `subscribe-once` is "
+                  "the sanctioned snapshot for handler and utility code.")
+             :read-inside-a-boundary-body
+             {:query-v query-v}))
+    (let [cell (cell-for! (.-frame r) query-v)]
+      (index/read! (.-subKey cell))
+      (when-some [reaction (.-reaction cell)] @reaction))))
+
+(defn sub
+  "**Tier 3, the ambient collector** — the challenger, ridden hardest. A
+  plain tracked read, legal anywhere in a body: conditionals, loops,
+  helpers. The edge is *recorded* by the collector rather than declared,
+  and the recorded set is what the commit installs."
+  [query-v]
+  (when-some [r *render*] (set! (.-collectorTier r) true))
+  (read-key! query-v))
+
+(defn use-subs
+  "**Tier 2, grouped — the product default.** One fixed site receiving the
+  complete query collection, returning the snapshot the body destructures.
+  The edges are *declared*: they are the map's values, so a boundary's
+  edge set is a function of its declaration and not of its control flow.
+
+      (let [{:keys [todo editing?]}
+            (use-subs {:todo     [:todo/by-id id]
+                       :editing? [:todo.ui/editing? id]})]
+        …)
+
+  The hook count does not move with the collection's size — which is the
+  whole of why this tier is the default and the scalar per-read spine is
+  a comparator only."
+  [query-map]
+  (when-some [r *render*] (set! (.-groupedTier r) true))
+  (reduce-kv (fn [m alias query-v] (assoc m alias (read-key! query-v)))
+             {}
+             query-map))
+
+;; ---------------------------------------------------------------------------
+;; The shell's subscribe closure, cached by the value it closes over
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !closures (atom {}))
+
+(defn- reap-closures! [sub-keys]
+  (js/setTimeout (fn []
+                   (when-some [c (get @!closures sub-keys)]
+                     (when (zero? (.-refs c)) (swap! !closures dissoc sub-keys))))
+                 0)
+  nil)
+
+(defn- make-subscribe
+  "React's `subscribe`, as a pure function of the read set.
+
+  Everything commit-owned lives in here: the boundary's registration is
+  minted from React's own `onStoreChange`, the index learns the boundary
+  and its edges, and each key cell takes its committed reference. The
+  returned cleanup is the exact inverse and is the only place edges and
+  references are released, so teardown is symmetric with mount whatever
+  React did with the renders in between.
+
+  The cells are re-resolved here rather than carried from the render: a
+  cell the render built may have been reaped in the window before the
+  commit, and the committed reference must be taken on the cell that is
+  actually live. The registration then holds exactly the cells it
+  acquired, so its cleanup cannot release a successor's."
+  [sub-keys]
+  (fn subscribe [on-store-change]
+    (let [reg   #js {"subKeys" sub-keys "notify" on-store-change}
+          cells (mapv (fn [k] (acquire! (cell-for! (nth k 0) (nth k 1)))) sub-keys)]
+      (unchecked-set reg "cells" cells)
+      (index/mount! reg)
+      (index/record-reads! reg sub-keys)
+      (when-some [c (get @!closures sub-keys)]
+        (set! (.-refs c) (inc (.-refs c)))
+        (set! (.-acquired c) true))
+      (fn unsubscribe []
+        (set! (.-notify reg) nil)
+        (index/unmount! reg)
+        (doseq [cell cells] (release! cell))
+        (when-some [c (get @!closures sub-keys)]
+          (set! (.-refs c) (dec (.-refs c)))
+          (when (<= (.-refs c) 0) (reap-closures! sub-keys)))
+        nil))))
+
+(defn- closure-for
+  "The cached `subscribe` for this read set. Identity-stable while the set
+  is unchanged, which is what stops React re-subscribing on an ordinary
+  re-render — and different the moment the set changes, which is what
+  makes React's own subscribe/cleanup pair perform the edge-set diff.
+
+  Entries are ref-counted by *committed* registrations, never by renders:
+  a render increments nothing, so a body that runs ten times before its
+  first commit leaves the count at zero, and the creation reaper drops an
+  entry no commit ever claimed."
+  [sub-keys]
+  (if-some [c (get @!closures sub-keys)]
+    (.-subscribe c)
+    (let [fresh #js {"subscribe" (make-subscribe sub-keys) "refs" 0 "acquired" false}]
+      (swap! !closures assoc sub-keys fresh)
+      (js/setTimeout (fn []
+                       (when-some [c (get @!closures sub-keys)]
+                         (when (and (zero? (.-refs c)) (not (.-acquired c)))
+                           (swap! !closures dissoc sub-keys))))
+                     0)
+      (.-subscribe fresh))))
+
+(defn commit-boundary!
+  "**The seam React occupies.** Hand a boundary's read set and a notifier
+  to the same `subscribe` closure `useSyncExternalStore` would call, and
+  get back the same cleanup React would hold.
+
+  It exists because the commit path, the index wiring and the
+  zero-leaked-reference assertion are the parts of this arm most worth
+  proving cheaply and deterministically — and every one of them is
+  answerable without a browser, a root, or a render. The DOM suites then
+  prove that React drives *this* seam, rather than re-proving what the
+  seam does."
+  [reads notify]
+  ((closure-for reads) notify))
+
+;; ---------------------------------------------------------------------------
+;; The body run, and the generation fence
+;; ---------------------------------------------------------------------------
+
+(def ^:private max-fence-retries
+  "A body is re-run once per commit that landed inside it. Three is a
+  ceiling, not a budget: a fourth commit arriving inside three
+  consecutive body runs is a write loop, and failing loudly beats
+  spinning."
+  3)
+
+(defn- run-once [frame-kw body-fn props]
+  (let [collector (volatile! #{})
+        ctx       #js {"frame" frame-kw "collectorTier" false "groupedTier" false}]
+    (binding [*render*          ctx
+              index/*collector* collector]
+      (let [element (intent/with-frame
+                      (fn [event] (dispatch! frame-kw event))
+                      (fn [] (codec/as-element (body-fn props))))]
+        #js [element @collector (.-collectorTier ctx) (.-groupedTier ctx)]))))
+
+(defn render-body
+  "Run a boundary body under the generation fence. Returns
+  `#js [element read-set collector? grouped?]`.
+
+  The fence is the loop: capture the generation, run the body, and if a
+  commit landed while it ran, run it again against the newer commit. All
+  of a pass's reads therefore observe one commit — the invariant-5
+  preservation architecture.md asks of this arm, and the thing the
+  staged-stale witness stages."
+  [frame-kw body-fn props]
+  (loop [attempt 0]
+    (let [before (generation)
+          out    (run-once frame-kw body-fn props)]
+      (cond
+        (= before (generation))       out
+        (< attempt max-fence-retries) (recur (inc attempt))
+        :else
+        (fail! :rf.error/hicasso-generation-fence-exhausted
+               're-frame.bench.hicasso.arm1.runtime/render-body
+               (str "A boundary body observed a new commit on each of "
+                    (inc max-fence-retries) " consecutive runs. A body that "
+                    "writes on every render cannot be fenced; move the write "
+                    "out of the render.")
+               :move-the-write-out-of-the-render
+               {:frame frame-kw :generation (generation)})))))
+
+;; ---------------------------------------------------------------------------
+;; The shell — exactly two React hooks, and no useRef
+;; ---------------------------------------------------------------------------
+
+(def shell-hook-ledger
+  "The shell's declared hook calls, in call order. The dispatcher-level
+  witness counts against this, so a third hook appearing in the shell
+  fails a test rather than a review."
+  [:use-context/frame :use-sync-external-store/subscription-epoch])
+
+(defn- resolve-frame! [frame-kw]
+  (if (or (nil? frame-kw) (= adapter-context/no-provider-sentinel frame-kw))
+    (fail! :rf.error/no-frame-context
+           're-frame.bench.hicasso.arm1.runtime/shell
+           (str "A Hicasso boundary rendered with no frame in scope. Mount the "
+                "tree under a frame boundary — `arm1.mount/root!` installs one.")
+           :mount-under-a-frame
+           {})
+    frame-kw))
+
+(defn shell
+  "The boundary shell. Two hooks, with the body between them — which is
+  legal because what React fixes is hook *order and count*, not the
+  position of ordinary code around them, and it is what lets the
+  subscription hook close over the reads the body just made."
+  [body-fn js-props]
+  (let [frame-kw (resolve-frame! (react/useContext adapter-context/frame-context))
+        props    (or (unchecked-get js-props "rfProps") {})
+        out      (render-body frame-kw body-fn props)
+        reads    (aget out 1)
+        snapshot (fn [] (epoch-sum reads))]
+    (react/useSyncExternalStore (closure-for reads) snapshot snapshot)
+    (aget out 0)))
+
+(defn mint-view!
+  "Turn a body fn into a boundary: a React function component, marked as a
+  legal hiccup head. Minted once, at definition — which is why the codec's
+  third HD-004 cache (stable component heads) has nothing to do in this
+  arm, and why HD-016 can make a plain function in head position a loud
+  error instead of auto-wrapping it."
+  [view-name body-fn]
+  (let [component (fn hicasso-boundary [js-props] (shell body-fn js-props))]
+    (unchecked-set component "displayName" view-name)
+    (codec/mark-boundary! component)))
+
+;; ---------------------------------------------------------------------------
+;; Retained inventory — honest accounting, not a claimed absence
+;; ---------------------------------------------------------------------------
+
+(defn retained-inventory
+  "Every boundary-exclusive token this arm retains, enumerated rather than
+  asserted (architecture.md, Arm 1). `:shared` names what is emphatically
+  *not* per boundary, because that is the half a heap ladder reads wrong
+  if nobody writes it down."
+  []
+  {:per-boundary
+   [{:token :registration
+     :what  "one JS object: the sub-key set (shared with the closure cache), React's onStoreChange, and the acquired cell vector"}
+    {:token :index/live
+     :what  "one membership in the index's :live set"}
+    {:token :index/b->subs
+     :what  "one map entry holding this boundary's read set"}
+    {:token :index/sub->bs
+     :what  "one membership per edge in each read key's reader set"}
+    {:token :react/use-sync-external-store
+     :what  "React's own hook cell for the one subscription hook"}
+    {:token :react/use-context
+     :what  "React's own hook cell for the frame hook"}]
+   :shared
+   [{:token :key-cell
+     :what  "one cell + one sub-cache reaction per unique (frame, query), however many boundaries read it"}
+    {:token :subscribe-closure
+     :what  "one subscribe closure per distinct read SET, shared by every boundary with that set, ref-counted and reaped"}
+    {:token :frame-ops
+     :what  "one capture-frame bundle per frame"}
+    {:token :codec-cache
+     :what  "the codec's tag and prop caches, per distinct literal in the build"}]
+   :absent
+   [{:token :use-ref   :what "no useRef anywhere in the shell (HD-020(b))"}
+    {:token :use-state :what "no per-instance render-phase state of any kind"}
+    {:token :view-cell :what "no per-boundary object graph, reaction, watcher or scheduler"}
+    {:token :candidate-ledger
+     :what  "no per-read record survives the commit that consumed it"}]})
+
+(defn stats
+  "What the witnesses read: live cells, live boundaries, cached closures,
+  the generation, and the codec caches."
+  []
+  (let [idx (index/snapshot)]
+    {:cells      (count @!cells)
+     :cell-refs  (reduce + 0 (map (fn [[_ c]] (.-refs c)) @!cells))
+     :boundaries (count (:live idx))
+     :edges      (reduce + 0 (map (fn [[_ v]] (count v)) (:b->subs idx)))
+     :closures   (count @!closures)
+     :generation (generation)
+     :frames     (count @!frame-ops)
+     :codec      (codec/cache-sizes)}))
+
+(defn residue
+  "What must be zero after a clean teardown. `:cell-refs` is the standing
+  zero-leaked-subscription-ref-counts assertion; `:boundaries` and
+  `:edges` are the index's half of it."
+  []
+  (select-keys (stats) [:cells :cell-refs :boundaries :edges :closures]))
+
+(defn reset-runtime!
+  "Drop every cell, every edge, every cached closure and every frame
+  bundle. The root-teardown and test-fixture door; disposing each cell
+  releases its sub-cache reference, so this is the leak check's reset
+  rather than a way to hide one."
+  []
+  (doseq [[_ cell] @!cells] (dispose-cell! cell))
+  (reset! !cells {})
+  (reset! !closures {})
+  (vreset! !dirty #{})
+  (vreset! !deferred #{})
+  (vreset! !batching false)
+  (vreset! !generation 0)
+  (index/reset-index!)
+  (forget-frame-ops!)
+  nil)

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
@@ -80,6 +80,15 @@
 ;; The two read surfaces (HD-002; the collector is the one being made to work)
 ;; ---------------------------------------------------------------------------
 
+(defn- mounted!
+  "A boundary at the seam React occupies: render its body, commit the
+  reads, and hand back `{:hits :release!}`."
+  [body-fn]
+  (let [entry   (render body-fn)
+        hits    (volatile! 0)
+        release (rt/commit-boundary! entry (fn [] (vswap! hits inc)))]
+    {:entry entry :hits hits :release! release}))
+
 (deftest a-read-outside-a-render-is-a-loud-error
   (seeded!)
   (testing "`sub` outside a boundary is an error, never a silent read of
@@ -295,15 +304,6 @@
 ;; The commit path: write -> dirty keys -> index -> dirty boundaries
 ;; ---------------------------------------------------------------------------
 
-(defn- mounted!
-  "A boundary at the seam React occupies: render its body, commit the
-  reads, and hand back `{:hits :release!}`."
-  [body-fn]
-  (let [entry   (render body-fn)
-        hits    (volatile! 0)
-        release (rt/commit-boundary! entry (fn [] (vswap! hits inc)))]
-    {:entry entry :hits hits :release! release}))
-
 (deftest a-narrow-write-notifies-exactly-the-boundary-that-read-it
   (seeded! 3)
   (let [a (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
@@ -373,25 +373,25 @@
 
 (deftest a-commit-landing-inside-a-body-re-runs-that-body
   (seeded! 3)
+  ;; The boundary must already hold the key for a mid-body write to be
+  ;; observable at all — a key nothing holds has no watch to fire.
   (let [runs       (volatile! 0)
         first-read (volatile! nil)
-        seen       (volatile! nil)]
-    ;; The boundary must already hold the key for a mid-body write to be
-    ;; observable at all — a key nothing holds has no watch to fire.
-    (let [warm (mounted! (fn [_] [:li (str (rt/sub [:dogfood/done? 0]))]))
-          entry (render (fn [_]
+        seen       (volatile! nil)
+        warm       (mounted! (fn [_] [:li (str (rt/sub [:dogfood/done? 0]))]))
+        entry      (render (fn [_]
                           (vswap! runs inc)
                           (vreset! first-read (rt/sub [:dogfood/done? 0]))
                           (when (= 1 @runs)
                             (rt/dispatch! frame-id [:dogfood/toggle 0]))
                           (vreset! seen (rt/sub [:dogfood/done? 0]))
                           [:li (str @seen)]))]
-      (is (= 2 @runs) "the fence re-ran the body against the newer commit")
-      (is (true? @seen) "and the winning run read the committed value")
-      (is (true? @first-read) "both of the winning run's reads are on one commit")
-      (is (= #{(key-of [:dogfood/done? 0])} (reads-of entry))
-          "the index sees the winning render's reads, not the abandoned one's")
-      ((:release! warm)))))
+    (is (= 2 @runs) "the fence re-ran the body against the newer commit")
+    (is (true? @seen) "and the winning run read the committed value")
+    (is (true? @first-read) "both of the winning run's reads are on one commit")
+    (is (= #{(key-of [:dogfood/done? 0])} (reads-of entry))
+        "the index sees the winning render's reads, not the abandoned one's")
+    ((:release! warm))))
 
 (deftest a-body-that-writes-on-every-run-fails-loudly
   (seeded! 3)

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
@@ -167,6 +167,38 @@
                                   [:li {:key id} (str (rt/sub [:dogfood/todo id]))])))]
       (is (= 4 (count (reads-of entry)))))))
 
+(deftest every-read-that-escapes-the-render-is-loud-rather-than-a-missing-edge
+  (seeded! 3)
+  (testing "**The complement of the eager codec, and the more important half.**
+           An eager codec forces the reads it walks; it cannot force a read
+           the author deferred past the render — a handler closure, a
+           `delay`, a lazy seq stashed and forced later. Every one of those
+           would otherwise be a SILENT missing edge, which is the worst
+           failure mode the ruled surface can have: correct on screen,
+           frozen thereafter, attributable to nothing.
+
+           One guard covers all of them, and it is the same guard that
+           makes a read outside any boundary an error: the render frame is
+           set in a `try` and cleared in the matching `finally`, so a read
+           that runs after the body returned finds nothing and says so. The
+           escape is converted into a loud error, never into an edge that
+           was quietly not recorded."
+    (let [escaped (volatile! nil)]
+      ;; 1. a handler closure — the browser invokes it long after render
+      (render (fn [_] [:button {:on-click (fn [] (vreset! escaped (fn [] (rt/sub [:dogfood/remaining]))))}]))
+      ;; 2. an author-held delay
+      (let [d (volatile! nil)]
+        (render (fn [_] (vreset! d (delay (rt/sub [:dogfood/remaining]))) [:li]))
+        (is (thrown-with-msg? js/Error #"outside a boundary render" @@d)))
+      ;; 3. a lazy seq the body stashed rather than returned
+      (let [s (volatile! nil)]
+        (render (fn [_] (vreset! s (map (fn [id] (rt/sub [:dogfood/todo id])) (range 3))) [:li]))
+        (is (thrown-with-msg? js/Error #"outside a boundary render" (doall @s))))
+      ;; 4. the handler, actually called
+      (let [h (volatile! nil)]
+        (render (fn [_] (vreset! h (fn [] (rt/sub [:dogfood/remaining]))) [:li]))
+        (is (thrown-with-msg? js/Error #"outside a boundary render" (@h)))))))
+
 (deftest a-conditional-read-is-an-edge-the-collector-simply-does-not-have
   (seeded! 3)
   (testing "law 4 at the authoring surface: the branch that is not taken

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
@@ -114,6 +114,50 @@
                  (key-of [:dogfood/todo 2])}
                (reads-of entry)))))))
 
+(deftest a-lazy-for-registers-its-edges-and-its-readers-re-run
+  (seeded! 3)
+  (testing "**A Surface B property, and the one a lazy host language can lose
+           silently.** `for` returns a LAZY SEQUENCE, so every `(sub …)`
+           inside it runs when something walks the seq — not when the body
+           returns. A collector closed at the body's return would collect
+           ZERO edges for every row, register no dependency, and look
+           perfectly correct on the first render (the values ARE right once
+           realised) while never updating again. Arm 2 hit exactly that in
+           Chromium and flagged it across the tournament.
+
+           This arm is safe **by construction rather than by care**: the
+           collector window closes around `codec/as-element`, and the codec
+           is eager everywhere it walks — `expand-seq` drives a seq to
+           exhaustion, `realize-children` folds one into a vector, and a
+           seq at a prop position goes through `clj->js`. So a lazy read is
+           forced inside the window by the same pass that turns hiccup into
+           elements. This test is what keeps that true: it fails the moment
+           the codec call moves outside `run-once`."
+    (let [b (mounted! (fn [_]
+                        [:ul (for [id (rt/sub [:dogfood/visible-ids])]
+                               [:li {:key id} (str (rt/sub [:dogfood/todo id]))])]))]
+      (is (= #{(key-of [:dogfood/visible-ids])
+               (key-of [:dogfood/todo 0])
+               (key-of [:dogfood/todo 1])
+               (key-of [:dogfood/todo 2])}
+             (reads-of (:entry b)))
+          "every row query the lazy seq produced is an edge")
+      (is (= 4 (:edges (rt/stats)))
+          "and the commit installed all four, not just the eager one")
+      (rt/dispatch! frame-id [:dogfood/toggle 1])
+      (is (= 1 @(:hits b))
+          "a write to a row query the `for` produced re-runs the boundary —
+           the half a first render cannot tell you")
+      ((:release! b)))))
+
+(deftest a-lazy-seq-returned-as-the-body-root-registers-its-edges-too
+  (seeded! 3)
+  (testing "the same property at the root position, where there is no
+           enclosing vector to force the walk"
+    (let [entry (render (fn [_] (for [id (rt/sub [:dogfood/visible-ids])]
+                                  [:li {:key id} (str (rt/sub [:dogfood/todo id]))])))]
+      (is (= 4 (count (reads-of entry)))))))
+
 (deftest a-conditional-read-is-an-edge-the-collector-simply-does-not-have
   (seeded! 3)
   (testing "law 4 at the authoring surface: the branch that is not taken

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
@@ -1,0 +1,304 @@
+(ns re-frame.bench.hicasso.arm1.runtime-cljs-test
+  "ARM 1's RUNTIME, proved without a browser (rf2-2rtt6.9).
+
+  Everything this arm does that is not React's is answerable here: the
+  read tiers, the commit path, the index wiring, the generation fence,
+  and the standing zero-leaked-subscription-ref-counts assertion. The
+  `-dom` suites then prove that React drives *this* seam — they do not
+  re-prove what the seam does.
+
+  The adapter is UIx's, not `plain-atom`'s, and that is load-bearing:
+  plain-atom has no reactivity layer at all (\"no caching, no
+  listeners\"), so a subscription under it never notifies and every
+  commit assertion below would pass vacuously by never firing. The React
+  spine's derived values coalesce their source watches through an epoch
+  that closes *inside* the synchronous dispatch, which is both what makes
+  the watch land in the caller's turn (HD-019's door) and what lets these
+  tests read the result on the next line."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.front.sub-index :as idx]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     :init-fn (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::arm1-runtime)
+
+(defn- seeded!
+  ([] (seeded! 3))
+  ([n] (rt/reset-runtime!) (dogfood/make-frame! frame-id n) frame-id))
+
+(defn- render
+  "Run a body through the shell's own fence, exactly as [[rt/shell]]
+  does — minus React, which contributes nothing to what is asserted."
+  ([body-fn] (render body-fn {}))
+  ([body-fn props] (rt/render-body frame-id body-fn props)))
+
+(defn- reads-of [out] (aget out 1))
+(defn- element-of [out] (aget out 0))
+(defn- collector? [out] (aget out 2))
+(defn- grouped? [out] (aget out 3))
+
+(defn- key-of [query] [frame-id query])
+
+;; ---------------------------------------------------------------------------
+;; The hook ledger and the retained inventory (HD-020(b))
+;; ---------------------------------------------------------------------------
+
+(deftest the-shell-declares-exactly-two-hooks
+  (testing "the ≤2 budget is fully consumed by the subscription/epoch hook
+           and the frame-context hook, and there is no room left"
+    (is (= 2 (count rt/shell-hook-ledger)))
+    (is (= [:use-context/frame :use-sync-external-store/subscription-epoch]
+           rt/shell-hook-ledger))))
+
+(deftest the-shell-retains-no-use-ref-and-no-use-state
+  (testing "HD-020(b) bans useRef in the shell; this arm bans per-instance
+           render-phase state outright, because that is what makes two
+           hooks reachable rather than three"
+    (let [inv    (rt/retained-inventory)
+          tokens (into #{} (map :token) (:per-boundary inv))]
+      (is (not (contains? tokens :react/use-ref)))
+      (is (not (contains? tokens :react/use-state)))
+      (is (contains? tokens :react/use-sync-external-store))
+      (is (contains? tokens :react/use-context))
+      (is (= #{:use-ref :use-state :view-cell :candidate-ledger}
+             (into #{} (map :token) (:absent inv)))
+          "the absences are enumerated, so a regression that adds one
+           has to delete a line rather than merely appear"))))
+
+;; ---------------------------------------------------------------------------
+;; The two read tiers (HD-002)
+;; ---------------------------------------------------------------------------
+
+(deftest a-read-outside-a-render-is-a-loud-error
+  (seeded!)
+  (testing "`sub` outside a boundary is an error, never a silent read of
+           whichever frame happened to be ambient"
+    (is (thrown-with-msg? js/Error #"outside a boundary render"
+          (rt/sub [:dogfood/remaining])))
+    (is (thrown-with-msg? js/Error #"outside a boundary render"
+          (rt/use-subs {:r [:dogfood/remaining]})))))
+
+(deftest the-collector-records-the-reads-the-body-actually-made
+  (seeded! 3)
+  (let [out (render (fn [_]
+                      (let [ids (rt/sub [:dogfood/visible-ids])]
+                        [:ul (when (seq ids) [:li (str (rt/sub [:dogfood/todo (first ids)]))])])))]
+    (is (collector? out))
+    (is (not (grouped? out)))
+    (is (= #{(key-of [:dogfood/visible-ids]) (key-of [:dogfood/todo 0])}
+           (reads-of out)))))
+
+(deftest a-conditional-read-is-an-edge-the-collector-simply-does-not-have
+  (seeded! 3)
+  (testing "law 4 at the authoring surface: the branch that is not taken
+           contributes no edge, which is the collector's whole claim"
+    (let [taken     (render (fn [{:keys [editable?]}]
+                              [:li (when editable? (rt/sub [:dogfood/draft 1]))])
+                            {:editable? true})
+          not-taken (render (fn [{:keys [editable?]}]
+                              [:li (when editable? (rt/sub [:dogfood/draft 1]))])
+                            {:editable? false})]
+      (is (= #{(key-of [:dogfood/draft 1])} (reads-of taken)))
+      (is (= #{} (reads-of not-taken))))))
+
+(deftest grouped-declares-its-edges-whatever-the-body-then-does
+  (seeded! 3)
+  (testing "the same branch under the product default: the declaration is
+           the edge set, so the untaken branch still costs its edge —
+           the honest price of a fixed read site"
+    (let [out (render (fn [_]
+                        (let [{:keys [todo draft]}
+                              (rt/use-subs {:todo  [:dogfood/todo 1]
+                                            :draft [:dogfood/draft 1]})]
+                          [:li (:title todo) (when (:done? todo) draft)])))]
+      (is (grouped? out))
+      (is (not (collector? out)))
+      (is (= #{(key-of [:dogfood/todo 1]) (key-of [:dogfood/draft 1])}
+             (reads-of out))))))
+
+(deftest grouped-returns-the-snapshot-the-body-destructures
+  (seeded! 3)
+  (let [captured (volatile! nil)]
+    (render (fn [_] (vreset! captured (rt/use-subs {:todo      [:dogfood/todo 1]
+                                                    :remaining [:dogfood/remaining]}))
+              [:li]))
+    (is (= {:id 1 :title "todo 1" :done? false} (:todo @captured)))
+    (is (= 3 (:remaining @captured)))))
+
+;; ---------------------------------------------------------------------------
+;; The commit path: write -> dirty keys -> index -> dirty boundaries
+;; ---------------------------------------------------------------------------
+
+(defn- mounted!
+  "A boundary at the seam React occupies: render its body, commit the
+  reads, and hand back `{:notified :release! :reads}`."
+  [body-fn]
+  (let [out    (render body-fn)
+        reads  (reads-of out)
+        hits   (volatile! 0)
+        release (rt/commit-boundary! reads (fn [] (vswap! hits inc)))]
+    {:reads reads :hits hits :release! release}))
+
+(deftest a-narrow-write-notifies-exactly-the-boundary-that-read-it
+  (seeded! 3)
+  (let [a (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
+        b (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 1]))]))]
+    (rt/dispatch! frame-id [:dogfood/toggle 0])
+    (is (= 1 @(:hits a)) "the reader of the moved subscription re-runs")
+    (is (= 0 @(:hits b)) "and nothing else does")
+    ((:release! a))
+    ((:release! b))))
+
+(deftest two-boundaries-sharing-a-subscription-both-run
+  (seeded! 3)
+  (let [a (mounted! (fn [_] [:span (str (rt/sub [:dogfood/remaining]))]))
+        b (mounted! (fn [_] [:span (str (rt/sub [:dogfood/remaining]))]))]
+    (rt/dispatch! frame-id [:dogfood/toggle 0])
+    (is (= 1 @(:hits a)))
+    (is (= 1 @(:hits b)))
+    ((:release! a))
+    ((:release! b))))
+
+(deftest an-unmounted-boundary-is-never-notified-again
+  (seeded! 3)
+  (let [a (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))]
+    ((:release! a))
+    (rt/dispatch! frame-id [:dogfood/toggle 0])
+    (is (= 0 @(:hits a)))))
+
+(deftest a-write-that-moves-nothing-notifies-nobody
+  (seeded! 3)
+  (let [a (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
+        g (rt/generation)]
+    ;; `:dogfood/commit` on a row with no draft is a no-op by construction.
+    (rt/dispatch! frame-id [:dogfood/commit 0])
+    (is (= 0 @(:hits a)))
+    (is (= g (rt/generation)) "and does not move the generation")
+    ((:release! a))))
+
+(deftest one-commit-window-is-one-flush-however-many-subscriptions-moved
+  (seeded! 3)
+  (let [a (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
+                             (str (rt/sub [:dogfood/remaining]))]))
+        g (rt/generation)]
+    (rt/with-commit (fn []
+                      (rf/with-frame frame-id (rf/dispatch-sync [:dogfood/toggle 0]))
+                      (rf/with-frame frame-id (rf/dispatch-sync [:dogfood/toggle 1]))))
+    (is (= 1 @(:hits a)) "one notification, not one per moved subscription")
+    (is (= (inc g) (rt/generation)) "and one generation, not two")
+    ((:release! a))))
+
+;; ---------------------------------------------------------------------------
+;; The edge-set diff — a replacement, never a ledger
+;; ---------------------------------------------------------------------------
+
+(deftest a-changed-read-set-replaces-the-edges-rather-than-accumulating-them
+  (seeded! 3)
+  (let [wide   (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
+                                  (str (rt/sub [:dogfood/todo 1]))]))
+        _      ((:release! wide))
+        narrow (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
+        b      (first (:live (idx/snapshot)))]
+    (is (= 1 (count (idx/edges-of (idx/snapshot) b)))
+        "the boundary holds exactly the edges its latest commit installed")
+    (is (empty? (idx/readers-of (idx/snapshot) (key-of [:dogfood/todo 1])))
+        "and the dropped key has no reader left behind")
+    ((:release! narrow))))
+
+;; ---------------------------------------------------------------------------
+;; The generation fence
+;; ---------------------------------------------------------------------------
+
+(deftest a-commit-landing-inside-a-body-re-runs-that-body
+  (seeded! 3)
+  (let [runs (volatile! 0)
+        seen (volatile! nil)
+        out  (render (fn [_]
+                       (vswap! runs inc)
+                       ;; Stage the stale read: the first run writes, so its
+                       ;; own reads straddle two commits.
+                       (when (= 1 @runs)
+                         (rt/dispatch! frame-id [:dogfood/toggle 0]))
+                       (vreset! seen (rt/sub [:dogfood/done? 0]))
+                       [:li (str @seen)]))]
+    (is (= 2 @runs) "the fence re-ran the body against the newer commit")
+    (is (true? @seen) "and the winning run read the committed value")
+    (is (= #{(key-of [:dogfood/done? 0])} (reads-of out))
+        "the index sees the winning render's reads, not the abandoned one's")))
+
+(deftest a-body-that-writes-on-every-run-fails-loudly
+  (seeded! 3)
+  (testing "the fence is a ceiling, not a budget — an unfenceable body is
+           a write loop and says so"
+    (is (thrown-with-msg? js/Error #"generation-fence-exhausted"
+          (render (fn [_]
+                    (rt/dispatch! frame-id [:dogfood/toggle 0])
+                    [:li (str (rt/sub [:dogfood/done? 0]))]))))))
+
+(deftest a-body-that-reads-without-writing-never-moves-the-generation
+  (seeded! 3)
+  (let [g (rt/generation)]
+    (render (fn [_] [:li (str (rt/sub [:dogfood/remaining]))]))
+    (is (= g (rt/generation)))))
+
+;; ---------------------------------------------------------------------------
+;; Boundaries, heads, and the ABI
+;; ---------------------------------------------------------------------------
+
+(deftest a-minted-view-is-a-legal-hiccup-head
+  (let [v (rt/mint-view! "test/probe" (fn [_] [:li]))]
+    (is (fn? v))
+    (is (= "test/probe" (.-displayName v)))
+    (is (true? (unchecked-get v "hicassoBoundary"))
+        "the codec's own boundary marker, so a view is a head by
+         construction and the stable-head cache has nothing to do")))
+
+;; ---------------------------------------------------------------------------
+;; Residue — the standing zero-leaked-refcounts assertion
+;; ---------------------------------------------------------------------------
+
+(deftest a-released-boundary-leaves-no-edge-and-no-reference
+  (async done
+    (seeded! 3)
+    (let [a (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
+                               (str (rt/sub [:dogfood/remaining]))]))]
+      (is (= 1 (:boundaries (rt/stats))))
+      (is (= 2 (:edges (rt/stats))))
+      (is (= 2 (:cell-refs (rt/stats))))
+      ((:release! a))
+      (is (= 0 (:boundaries (rt/stats))))
+      (is (= 0 (:edges (rt/stats))))
+      (is (= 0 (:cell-refs (rt/stats))))
+      ;; The cells and the cached closure are reaped one macrotask later —
+      ;; the grace that lets a keyed reorder reuse a reaction instead of
+      ;; rebuilding it.
+      (js/setTimeout (fn []
+                       (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :closures 0}
+                              (rt/residue))
+                           "nothing survives the macrotask horizon")
+                       (done))
+                     4))))
+
+(deftest a-render-that-never-commits-leaves-nothing-behind
+  (async done
+    (seeded! 3)
+    ;; The abandoned-render class: a body runs, builds its cells, and its
+    ;; commit never happens. Acquisition is commit-owned, so there is
+    ;; nothing to unwind — the reaper is what releases the render's `+1`.
+    (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
+                     (str (rt/sub [:dogfood/todo 1]))]))
+    (is (= 0 (:boundaries (rt/stats))) "no boundary was ever registered")
+    (is (= 0 (:cell-refs (rt/stats))) "and no reference was ever taken")
+    (js/setTimeout (fn []
+                     (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :closures 0}
+                            (rt/residue)))
+                     (done))
+                   4)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
@@ -2,10 +2,11 @@
   "ARM 1's RUNTIME, proved without a browser (rf2-2rtt6.9).
 
   Everything this arm does that is not React's is answerable here: the
-  read tiers, the commit path, the index wiring, the generation fence,
-  and the standing zero-leaked-subscription-ref-counts assertion. The
-  `-dom` suites then prove that React drives *this* seam — they do not
-  re-prove what the seam does.
+  read surfaces, the commit path, the index wiring, the generation fence,
+  HD-002's ownership state machine and allowed edge-diff operation, and
+  the standing zero-leaked-subscription-ref-counts assertion. The `-dom`
+  suites then prove that React drives *this* seam — they do not re-prove
+  what the seam does.
 
   The adapter is UIx's, not `plain-atom`'s, and that is load-bearing:
   plain-atom has no reactivity layer at all (\"no caching, no
@@ -26,6 +27,9 @@
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
     {:adapter uix-adapter/adapter
+     ;; The map shape, because the residue claims are `async` — a reaper
+     ;; horizon is not observable inside one synchronous test body.
+     :async?  true
      :init-fn (fn [] (rt/reset-runtime!))}))
 
 (def ^:private frame-id ::arm1-runtime)
@@ -35,15 +39,14 @@
   ([n] (rt/reset-runtime!) (dogfood/make-frame! frame-id n) frame-id))
 
 (defn- render
-  "Run a body through the shell's own fence, exactly as [[rt/shell]]
-  does — minus React, which contributes nothing to what is asserted."
+  "Run a body through the shell's own fence, exactly as `rt/shell` does —
+  minus React, which contributes nothing to what is asserted. Returns the
+  read-set entry; the element is discarded because no assertion here is
+  about markup."
   ([body-fn] (render body-fn {}))
-  ([body-fn props] (rt/render-body frame-id body-fn props)))
+  ([body-fn props] (rt/render-body frame-id body-fn props) (rt/last-reads)))
 
-(defn- reads-of [out] (aget out 1))
-(defn- element-of [out] (aget out 0))
-(defn- collector? [out] (aget out 2))
-(defn- grouped? [out] (aget out 3))
+(defn- reads-of [entry] (rt/reads-of entry))
 
 (defn- key-of [query] [frame-id query])
 
@@ -70,11 +73,11 @@
       (is (contains? tokens :react/use-context))
       (is (= #{:use-ref :use-state :view-cell :candidate-ledger}
              (into #{} (map :token) (:absent inv)))
-          "the absences are enumerated, so a regression that adds one
-           has to delete a line rather than merely appear"))))
+          "the absences are enumerated, so a regression that adds one has
+           to delete a line rather than merely appear"))))
 
 ;; ---------------------------------------------------------------------------
-;; The two read tiers (HD-002)
+;; The two read surfaces (HD-002; the collector is the one being made to work)
 ;; ---------------------------------------------------------------------------
 
 (deftest a-read-outside-a-render-is-a-loud-error
@@ -88,13 +91,28 @@
 
 (deftest the-collector-records-the-reads-the-body-actually-made
   (seeded! 3)
-  (let [out (render (fn [_]
-                      (let [ids (rt/sub [:dogfood/visible-ids])]
-                        [:ul (when (seq ids) [:li (str (rt/sub [:dogfood/todo (first ids)]))])])))]
-    (is (collector? out))
-    (is (not (grouped? out)))
+  (let [entry (render (fn [_]
+                        (let [ids (rt/sub [:dogfood/visible-ids])]
+                          [:ul (when (seq ids)
+                                 [:li (str (rt/sub [:dogfood/todo (first ids)]))])])))]
+    (is (:collector? (rt/last-tiers)))
+    (is (not (:grouped? (rt/last-tiers))))
     (is (= #{(key-of [:dogfood/visible-ids]) (key-of [:dogfood/todo 0])}
-           (reads-of out)))))
+           (reads-of entry)))))
+
+(deftest the-collector-reads-inside-a-for-and-inside-an-inlined-helper
+  (seeded! 3)
+  (testing "the surface the operator ruled the only acceptable one: a read
+           in a loop and a read donated by a plain helper, both landing on
+           the enclosing boundary's edge set"
+    (letfn [(label [id] [:span (str (rt/sub [:dogfood/todo id]))])]
+      (let [entry (render (fn [_] [:ul (for [id (rt/sub [:dogfood/visible-ids])]
+                                         [:li (label id)])]))]
+        (is (= #{(key-of [:dogfood/visible-ids])
+                 (key-of [:dogfood/todo 0])
+                 (key-of [:dogfood/todo 1])
+                 (key-of [:dogfood/todo 2])}
+               (reads-of entry)))))))
 
 (deftest a-conditional-read-is-an-edge-the-collector-simply-does-not-have
   (seeded! 3)
@@ -111,18 +129,17 @@
 
 (deftest grouped-declares-its-edges-whatever-the-body-then-does
   (seeded! 3)
-  (testing "the same branch under the product default: the declaration is
-           the edge set, so the untaken branch still costs its edge —
-           the honest price of a fixed read site"
-    (let [out (render (fn [_]
-                        (let [{:keys [todo draft]}
-                              (rt/use-subs {:todo  [:dogfood/todo 1]
-                                            :draft [:dogfood/draft 1]})]
-                          [:li (:title todo) (when (:done? todo) draft)])))]
-      (is (grouped? out))
-      (is (not (collector? out)))
+  (testing "the control: the declaration is the edge set, so the untaken
+           branch still costs its edge"
+    (let [entry (render (fn [_]
+                          (let [{:keys [todo draft]}
+                                (rt/use-subs {:todo  [:dogfood/todo 1]
+                                              :draft [:dogfood/draft 1]})]
+                            [:li (:title todo) (when (:done? todo) draft)])))]
+      (is (:grouped? (rt/last-tiers)))
+      (is (not (:collector? (rt/last-tiers))))
       (is (= #{(key-of [:dogfood/todo 1]) (key-of [:dogfood/draft 1])}
-             (reads-of out))))))
+             (reads-of entry))))))
 
 (deftest grouped-returns-the-snapshot-the-body-destructures
   (seeded! 3)
@@ -134,23 +151,123 @@
     (is (= 3 (:remaining @captured)))))
 
 ;; ---------------------------------------------------------------------------
+;; HD-002 clause (a) — the ownership state machine
+;; ---------------------------------------------------------------------------
+
+(deftest a-render-mutates-neither-the-index-nor-a-reference
+  (seeded! 3)
+  (testing "the invariant the whole state machine reduces to: no
+           render-phase code mutates the index or a subscription
+           ref-count, so an abandoned render needs no cleanup because it
+           never did anything that would need cleaning"
+    (let [before (rt/stats)]
+      (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
+                       (str (rt/sub [:dogfood/remaining]))]))
+      (let [after (rt/stats)]
+        (is (= (:boundaries before) (:boundaries after)) "no boundary registered")
+        (is (= (:edges before) (:edges after)) "no edge added")
+        (is (= (:cells before) (:cells after)) "no cell built")
+        (is (= (:cell-refs before) (:cell-refs after)) "no reference taken")))))
+
+(deftest a-re-render-before-the-commit-destroys-the-previous-candidate-by-overwrite
+  (seeded! 3)
+  (testing "PENDING -> RENDERING, which is the abandoned render: there is
+           one scratch and never two, so the second run's reads replace
+           the first's rather than joining them"
+    (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
+                     (str (rt/sub [:dogfood/todo 1]))]))
+    (let [entry (render (fn [_] [:li (str (rt/sub [:dogfood/todo 2]))]))]
+      (is (= #{(key-of [:dogfood/todo 2])} (reads-of entry))))))
+
+(deftest a-body-that-throws-leaves-nothing-behind
+  (seeded! 3)
+  (let [before (rt/stats)]
+    (is (thrown? js/Error
+          (render (fn [_] (rt/sub [:dogfood/todo 0]) (throw (js/Error. "body"))))))
+    (is (= (select-keys before [:boundaries :edges :cell-refs])
+           (select-keys (rt/stats) [:boundaries :edges :cell-refs])))
+    (testing "and the next render starts from a clean scratch rather than
+             concatenating the throwing run's reads"
+      (let [entry (render (fn [_] [:li (str (rt/sub [:dogfood/remaining]))]))]
+        (is (= #{(key-of [:dogfood/remaining])} (reads-of entry)))))))
+
+;; ---------------------------------------------------------------------------
+;; HD-002 clause (b) — the allowed edge-diff operation, and its cost law
+;; ---------------------------------------------------------------------------
+
+(deftest an-unchanged-read-set-is-detected-without-building-anything
+  (seeded! 3)
+  (testing "the same reads twice resolve to the SAME entry, so React's
+           `subscribe` identity does not move, so React does not
+           re-subscribe and the commit does no work at all — which is the
+           survival metric's flat slope seen from the mechanism's side"
+    (let [body  (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
+                         (str (rt/sub [:dogfood/todo 1]))
+                         (str (rt/sub [:dogfood/remaining]))])
+          a     (render body)
+          b     (render body)]
+      (is (identical? a b) "one entry, not two")
+      (is (identical? (.-subscribe a) (.-subscribe b))
+          "and therefore one `subscribe` identity")
+      (is (= 1 (:entries (rt/stats)))))))
+
+(deftest a-changed-read-set-takes-a-different-subscribe-identity
+  (seeded! 3)
+  (testing "which is what makes React's own subscribe/cleanup pair perform
+           the edge-set replacement — the whole of the allowed operation"
+    (let [wide   (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
+                                  (str (rt/sub [:dogfood/todo 1]))]))
+          narrow (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))]
+      (is (not (identical? wide narrow)))
+      (is (not (identical? (.-subscribe wide) (.-subscribe narrow)))))))
+
+(deftest a-boundary-holds-exactly-the-edges-its-latest-commit-installed
+  (seeded! 3)
+  (let [wide    (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
+                                 (str (rt/sub [:dogfood/todo 1]))]))
+        release (rt/commit-boundary! wide (fn []))]
+    (is (= 2 (:edges (rt/stats))))
+    (release)
+    (let [narrow  (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
+          release (rt/commit-boundary! narrow (fn []))
+          b       (first (:live (idx/snapshot)))]
+      (is (= 1 (count (idx/edges-of (idx/snapshot) b))))
+      (is (empty? (idx/readers-of (idx/snapshot) (key-of [:dogfood/todo 1])))
+          "and the dropped key has no reader left behind")
+      (release))))
+
+(deftest reading-one-key-twice-is-one-edge
+  (seeded! 3)
+  (testing "the buffer is a sequence and the index edge is set-valued; the
+           diff collapses them"
+    (let [entry   (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
+                                   (str (rt/sub [:dogfood/todo 0]))]))
+          release (rt/commit-boundary! entry (fn []))]
+      (is (= 1 (count (reads-of entry))))
+      (is (= 1 (:edges (rt/stats))))
+      (release))))
+
+;; ---------------------------------------------------------------------------
 ;; The commit path: write -> dirty keys -> index -> dirty boundaries
 ;; ---------------------------------------------------------------------------
 
 (defn- mounted!
   "A boundary at the seam React occupies: render its body, commit the
-  reads, and hand back `{:notified :release! :reads}`."
+  reads, and hand back `{:hits :release!}`."
   [body-fn]
-  (let [out    (render body-fn)
-        reads  (reads-of out)
-        hits   (volatile! 0)
-        release (rt/commit-boundary! reads (fn [] (vswap! hits inc)))]
-    {:reads reads :hits hits :release! release}))
+  (let [entry   (render body-fn)
+        hits    (volatile! 0)
+        release (rt/commit-boundary! entry (fn [] (vswap! hits inc)))]
+    {:entry entry :hits hits :release! release}))
 
 (deftest a-narrow-write-notifies-exactly-the-boundary-that-read-it
   (seeded! 3)
   (let [a (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
         b (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 1]))]))]
+    (is (= #{(key-of [:dogfood/todo 0])} (reads-of (:entry a))))
+    (is (= #{(key-of [:dogfood/todo 1])} (reads-of (:entry b))))
+    (is (= 1 (count (idx/readers-of (idx/snapshot) (key-of [:dogfood/todo 0])))))
+    (is (= 1 (count (idx/readers-of (idx/snapshot) (key-of [:dogfood/todo 1])))))
     (rt/dispatch! frame-id [:dogfood/toggle 0])
     (is (= 1 @(:hits a)) "the reader of the moved subscription re-runs")
     (is (= 0 @(:hits b)) "and nothing else does")
@@ -196,22 +313,15 @@
     (is (= (inc g) (rt/generation)) "and one generation, not two")
     ((:release! a))))
 
-;; ---------------------------------------------------------------------------
-;; The edge-set diff — a replacement, never a ledger
-;; ---------------------------------------------------------------------------
-
-(deftest a-changed-read-set-replaces-the-edges-rather-than-accumulating-them
+(deftest a-warm-read-performs-no-new-attach-or-release
   (seeded! 3)
-  (let [wide   (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
-                                  (str (rt/sub [:dogfood/todo 1]))]))
-        _      ((:release! wide))
-        narrow (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
-        b      (first (:live (idx/snapshot)))]
-    (is (= 1 (count (idx/edges-of (idx/snapshot) b)))
-        "the boundary holds exactly the edges its latest commit installed")
-    (is (empty? (idx/readers-of (idx/snapshot) (key-of [:dogfood/todo 1])))
-        "and the dropped key has no reader left behind")
-    ((:release! narrow))))
+  (testing "validation.md's standing assertion, stated as a reference
+           count that does not move across a re-render"
+    (let [a      (mounted! (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
+          before (:cell-refs (rt/stats))]
+      (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
+      (is (= before (:cell-refs (rt/stats))))
+      ((:release! a)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The generation fence
@@ -219,29 +329,37 @@
 
 (deftest a-commit-landing-inside-a-body-re-runs-that-body
   (seeded! 3)
-  (let [runs (volatile! 0)
-        seen (volatile! nil)
-        out  (render (fn [_]
-                       (vswap! runs inc)
-                       ;; Stage the stale read: the first run writes, so its
-                       ;; own reads straddle two commits.
-                       (when (= 1 @runs)
-                         (rt/dispatch! frame-id [:dogfood/toggle 0]))
-                       (vreset! seen (rt/sub [:dogfood/done? 0]))
-                       [:li (str @seen)]))]
-    (is (= 2 @runs) "the fence re-ran the body against the newer commit")
-    (is (true? @seen) "and the winning run read the committed value")
-    (is (= #{(key-of [:dogfood/done? 0])} (reads-of out))
-        "the index sees the winning render's reads, not the abandoned one's")))
+  (let [runs       (volatile! 0)
+        first-read (volatile! nil)
+        seen       (volatile! nil)]
+    ;; The boundary must already hold the key for a mid-body write to be
+    ;; observable at all — a key nothing holds has no watch to fire.
+    (let [warm (mounted! (fn [_] [:li (str (rt/sub [:dogfood/done? 0]))]))
+          entry (render (fn [_]
+                          (vswap! runs inc)
+                          (vreset! first-read (rt/sub [:dogfood/done? 0]))
+                          (when (= 1 @runs)
+                            (rt/dispatch! frame-id [:dogfood/toggle 0]))
+                          (vreset! seen (rt/sub [:dogfood/done? 0]))
+                          [:li (str @seen)]))]
+      (is (= 2 @runs) "the fence re-ran the body against the newer commit")
+      (is (true? @seen) "and the winning run read the committed value")
+      (is (true? @first-read) "both of the winning run's reads are on one commit")
+      (is (= #{(key-of [:dogfood/done? 0])} (reads-of entry))
+          "the index sees the winning render's reads, not the abandoned one's")
+      ((:release! warm)))))
 
 (deftest a-body-that-writes-on-every-run-fails-loudly
   (seeded! 3)
   (testing "the fence is a ceiling, not a budget — an unfenceable body is
            a write loop and says so"
-    (is (thrown-with-msg? js/Error #"generation-fence-exhausted"
-          (render (fn [_]
-                    (rt/dispatch! frame-id [:dogfood/toggle 0])
-                    [:li (str (rt/sub [:dogfood/done? 0]))]))))))
+    (let [warm (mounted! (fn [_] [:li (str (rt/sub [:dogfood/done? 0]))]))]
+      (is (thrown-with-msg? js/Error #"generation-fence-exhausted"
+            (render (fn [_]
+                      (rt/sub [:dogfood/done? 0])
+                      (rt/dispatch! frame-id [:dogfood/toggle 0])
+                      [:li (str (rt/sub [:dogfood/done? 0]))]))))
+      ((:release! warm)))))
 
 (deftest a-body-that-reads-without-writing-never-moves-the-generation
   (seeded! 3)
@@ -277,28 +395,29 @@
       (is (= 0 (:boundaries (rt/stats))))
       (is (= 0 (:edges (rt/stats))))
       (is (= 0 (:cell-refs (rt/stats))))
-      ;; The cells and the cached closure are reaped one macrotask later —
+      ;; The cells and the cached entry are reaped one macrotask later —
       ;; the grace that lets a keyed reorder reuse a reaction instead of
       ;; rebuilding it.
       (js/setTimeout (fn []
-                       (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :closures 0}
+                       (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
                               (rt/residue))
                            "nothing survives the macrotask horizon")
                        (done))
-                     4))))
+                     8))))
 
 (deftest a-render-that-never-commits-leaves-nothing-behind
   (async done
     (seeded! 3)
-    ;; The abandoned-render class: a body runs, builds its cells, and its
-    ;; commit never happens. Acquisition is commit-owned, so there is
-    ;; nothing to unwind — the reaper is what releases the render's `+1`.
+    ;; The abandoned-render class. Acquisition is commit-owned, so there is
+    ;; nothing to unwind — and the cached entry a discarded render minted is
+    ;; a cache, dropped at the macrotask horizon rather than undone.
     (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
                      (str (rt/sub [:dogfood/todo 1]))]))
     (is (= 0 (:boundaries (rt/stats))) "no boundary was ever registered")
     (is (= 0 (:cell-refs (rt/stats))) "and no reference was ever taken")
+    (is (= 0 (:cells (rt/stats))) "and no cell was ever built")
     (js/setTimeout (fn []
-                     (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :closures 0}
+                     (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
                             (rt/residue)))
                      (done))
-                   4)))
+                   8)))


### PR DESCRIPTION
Hicasso's lean-React arm: React function components minted by `defview`, a two-hook shell with no `useRef`, the ambient collector as the read surface, a generation fence with a staged-stale witness, and the dogfood screen in three renderings.

**Dispatched under the operator's full-throttle direction** (Mike, 2026-07-31): *"I want hicasso to proceed full throttle. Let's do our measuring later."* Building was explicitly not gated on the in-flight instrument work, so this ran **in parallel with instrumenting** and publishes **no candidate bar row** — the clock gate lines are being re-taken (`rf2-b0tz5`) and this arm's rows are scored against the restated bar later.

**Mounting the dogfood screen starts the six-week K7 clock (HD-014).** This PR mounts it, in `arm1_dogfood_dom_cljs_test`. The operator is on record accepting that consequence (`rf2-2rtt6`). K7 is never extended silently.

Later rulings landed mid-build and are honoured: Surface B (the ambient collector) is the only acceptable read surface, so grouped `use-subs` is kept as the control it is measured against rather than the thing being defended; and Arm 2 is dropped, making this the product line. Residence is unchanged — the runtime lives in the bench/test lane under `implementation/freehand/test/re_frame/bench/hicasso/arm1/`, off every production source path (HD-017).

## The shell, and how ≤2 hooks was actually reached

The obstacle is not the third hook — it is that React gives a function component **no per-instance storage except a hook cell**, so a shell that wants one has spent a third hook (`useRef`/`useState`) before it starts. Every real `useSyncExternalStore` wrapper in the wild, including this repo's own spine, holds three `useRef`s.

The way out is what the two closures close over. `subscribe` closes over the render's sub-key **set** and nothing else, so it is a pure function of a value: cached by that value, shared by every boundary reading the same set, and identity-stable exactly while the read set is unchanged — which is precisely React's own re-subscribe condition. React then calls that shared closure once per **fiber** and hands it that fiber's `onStoreChange`, so the registration minted inside is per-boundary, durable, and commit-owned. `getSnapshot` returns the sum of the set's epochs; epochs are monotone, so `Object.is` on one number is a correct change test with no memo.

The body runs *between* the two hooks, which is legal because React fixes hook **order and count**, not the position of code around them — and it is what lets the subscription hook close over the reads the body just made.

**Counted at React's dispatcher, not self-reported.** `hook_probe` wraps the shared-internals dispatcher slot in a counting `Proxy`. Measured: `["useContext" "useSyncExternalStore"]`, and **2 hooks at 1, 7 and 20 reads**. No `useRef`, `useState`, `useMemo` or `useCallback`. The raw-UIx comparator is counted by the same probe on the same page and its count rises with the read count. If React's internals slot cannot be found the witness records **UNWITNESSED and fails** — it never reads as a pass.

## The collector, against HD-002's clauses

**(a) Ownership state machine.** No render-phase code mutates the index or a subscription ref-count; the only global mutation is the commit's. Reads append to **one** module-level scratch array, reset by overwrite at the top of every body. An abandoned render is `PENDING → RENDERING` and needs no cleanup, because it never did anything that would need cleaning; StrictMode's double-invoke is correct for the same reason.

**(b) The allowed edge-diff operation.** The edge set is replaced wholesale, once, at commit — and only when it changed, because an unchanged set leaves `subscribe` identical and React does not call it again. The unchanged case is detected **without building anything** (an ordered pairwise compare against the cached key array), so steady-state edge-maintenance allocation is zero bytes. The ordered compare is a false-negative device, never a wrong answer, and is deliberately not a content hash — a hash's failure mode is a silently missing edge.

**(c) Hypotheses.** H1 implemented; H2 untried (not abandoned). On the counting rule as written **neither swing is spent**, because no bench row exists yet to cite a SHA.

**(d) Survival metric.** The zero-retained half is witnessed; the allocation-slope half needs the bench.

**The tripwire did not fire.** No construct needs to survive from one render attempt to a different attempt of the same boundary. The nearest approach to the fence is named in the studio page rather than left for a reviewer to find.

## Laziness — the cross-arm finding, checked and refuted

`for` is lazy, so a collector closed at the body's return registers **no edge for any row** and looks perfectly correct on the first render while never updating again. This arm does not have it, structurally: the collector window closes around `codec/as-element`, and the codec is eager everywhere it walks. No `doall`, no widened window, no cost, hook budget untouched. Three witnesses, and the second half of each is the load-bearing one because a broken implementation passes the first.

**And the eager codec is only half of it.** A codec forces the reads it *walks*; nothing forces a read deferred past the render. Four escapes — a stored handler, an invoked handler, an author-held `delay`, a stashed lazy seq — are witnessed converting into a **loud error naming the query**, never a silent missing edge.

## Two places the record did not survive contact with the substrate

**"Acquire without deref" is not implementable here.** A derived value starts at an `unset` baseline never `rf=` a real value, and the render's own read went through `subscribe-once`, which built a *different* reaction and disposed it. A freshly acquired reaction therefore reports movement on the first later commit whatever that commit did — every newly mounted boundary re-rendering once for nothing. One baseline deref per *new unique key* closes it. The narrow-write witness is what caught it.

**The ambient frame outranks React context, invisibly.** The parity gate first failed with the comparator rendering an empty app-db while `use-current-frame` reported the right frame in the same component. The carried-invariant chain resolves the dynamic-var tier **before** React context, so an ambient read answers for a different frame while the context says otherwise — and it presents as a *rendering* difference. `:ambient-frame nil` is now set in every DOM fixture here, and the probe asserts the two read forms agree so a regression names the plumbing.

## The dogfood screen, three renderings

One list, one controlled field, on one shared state layer and one shared intent set. All three build the identical canonical DOM (attribute names sorted), with a control proving the comparison can answer false. **Verdict: Surface B preferred**, and not for brevity — it is the only surface where the read sits at the value's point of use, so "what does this boundary depend on?" is answered by reading the body. Grouped's declaration and its body can drift; on the collector that drift is not expressible. The collector's conditional read is measured holding **fewer edges** than the declaration on the same page.

Judgement, mechanism and open items: `docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md`.

## Quality gates

| Gate | Result |
|---|---|
| `npm run test:cljs` (`:node-test`) | **PASS** — 12,104 tests / 60,508 assertions / 0 failures, 0 errors (exit 0) |
| `npm run test:browser` (`:browser-test`, real Chromium) | **PASS** — 878 tests / 5,617 assertions / 0 failures, 0 errors (exit 0) |
| `scripts/test-fast-pr.sh` | **PASS fast PR spine** (exit 0) — tiers `docs=false jvm=true node=true`; the not-run list is printed by the script itself (mkdocs soft-skip, untouched JVM artefacts, CI-only browser/bundle/perf lanes) |
| clj-kondo, reproduced as `.github/workflows/lint.yml` runs it, on the **CI-pinned 2026.04.15** (the local binary is 2025.10.23, and the version matters) | **PASS — errors: 0** (exit 0), and zero warnings from this arm's files |
| `mkdocs build --strict` | **does not cover this change** — `docs/design/hicasso/**` is excluded in `mkdocs.yml`. The studio page's links, anchors and tables were checked by hand and the new row in `studio/README.md` resolves. Stated rather than cited as a gate that passed. |

**TESTING.md matrix derived for the touched trees.** The diff touches `implementation/freehand/test/**` and `.clj-kondo/config.edn`. Per TESTING.md that arms **CLJS unit** (`test:cljs` — every `*_cljs_test.cljs`, the consolidated default gate) and **Browser unit** (`test:browser` — `*_dom_cljs_test.cljs` only; the `:browser-test` `:ns-regexp` excludes `re-frame.freehand.bench.*`, and these namespaces are `re-frame.bench.hicasso.arm1.*`, so they ride the ordinary browser lane rather than `bench:freehand-browser`). Both were run to completion, in the foreground, with exit codes echoed. No production source path is touched, so no elision, bundle-isolation, adapter-probe or perf gate is in scope; no build id or `:dev-http` port is added, so `implementation/shadow-cljs.edn` is untouched and this PR takes no hot-zone lock.

## Fences

No compiler and no analyzer — `defview` expands to a `def` and a `fn`, reads no body form, and rewrites no hiccup. No dual mode. No ViewCell-class object graph. No candidate ledger. Codec caching only; no template extraction, no hole plan, no node reference, no DOM write. No third interpreter was authored: the shared front half's codec is consumed unmodified.
