### PR TITLE
hicasso: a staged read no longer tears — the fence reaches the render→commit gap (rf2-2rtt6.42)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/generation_fence_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/generation_fence_dom_cljs_test.cljs
@@ -153,6 +153,66 @@
         (finally (mount/release! handle))))))
 
 ;; ---------------------------------------------------------------------------
+;; Case 3 — a STAGED read moves in the render->commit gap (rf2-2rtt6.42)
+;; ---------------------------------------------------------------------------
+;;
+;; Case 2 above is LABELLED as §6.1's case and is not it: it dispatches
+;; after the mount has settled, so the key is already RETAINED — some
+;; commit installed its watch before the move, and the ordinary
+;; invalidation path carries it. The case §6.1 actually asks for is a key
+;; **nothing holds yet**, moving before the commit that would acquire it.
+;; Nothing marks, nothing bumps, and the boundary has already painted.
+;;
+;; Staged here the way the reachability argument says it happens in an
+;; application: a SIBLING boundary writes during the same React render
+;; pass, after the reading boundary's fence has closed. That needs no
+;; guess about when React runs a passive effect — the write is strictly
+;; inside the render, and `subscribe` runs strictly after it.
+
+(defonce ^:private !sibling-writes (atom 0))
+
+(defview staged-reader
+  "Renders FIRST, and reads a key nothing else holds."
+  [{:keys [id]}]
+  (let [v (rt/sub [:dogfood/done? id])]
+    [:li.row {:data-id id :data-after (str v) :data-before (str v)} (str v)]))
+
+(defview sibling-writer
+  "Renders SECOND, in the same pass, and writes to the key its sibling
+  just read. Once — a body that writes on every run is a write loop, and
+  the fence fails that loudly rather than spinning."
+  [{:keys [id]}]
+  ;; A read of its own, so this is an ordinary boundary rather than a
+  ;; contrivance with no edges.
+  (rt/sub [:dogfood/filter])
+  (when (zero? @!sibling-writes)
+    (swap! !sibling-writes inc)
+    (rt/dispatch! frame-id [:dogfood/toggle id]))
+  [:li.writer])
+
+(deftest a-staged-read-that-moves-before-the-commit-is-corrected-in-the-dom
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (reset! !sibling-writes 0)
+      (lane/leave-act-environment!)
+      (dogfood/make-frame! frame-id 3)
+      (dogfood/reseed! frame-id 3)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id
+                                [:ul [staged-reader {:id 0}] [sibling-writer {:id 0}]])]
+        (try
+          (is (= 1 @!sibling-writes) "the sibling wrote, exactly once")
+          (mount/settle!)
+          (mount/settle!)
+          (testing "the reader's key had no cell, no watch and no epoch when
+                   it moved, so nothing was marked and the generation did
+                   not move — and the DOM must still not be stale"
+            (is (= "true" (read-back handle "data-after"))
+                "the boundary was corrected: React re-read the store after
+                 `subscribe` and found a number that had moved"))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
 ;; Teardown
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -42,7 +42,9 @@
     it is the boundary id the index keys on, and a render that never
     commits registers nothing.
   - `getSnapshot` also lives on the entry and returns the **sum of the
-    set's epochs**. Epochs only ever increase, so the sum is monotone:
+    set's epochs**, where a key nothing holds yet contributes the
+    [[commit-basis]] rather than nothing (see *the render→commit gap*
+    below). Every term only ever increases, so the sum is monotone:
     `Object.is` on one number is a correct change test, and React's own
     \"getSnapshot should be cached\" rule is satisfied without a memo.
 
@@ -166,19 +168,72 @@
   around every intent, so one user action is one flush however many
   subscriptions it moved.
 
-  ## The generation fence
+  ## The commit basis, the fence, and the render→commit gap
 
-  [[generation]] counts flushes. A body runs inside [[render-body]],
-  which captures the generation before the body and checks it after: if a
-  commit landed *during* the body, its reads straddle two commits and the
-  body is re-run against the newer one. That is invariant-5 preservation
-  written as a loop rather than as a comment, and one comparison per
-  boundary rather than one deref per read.
+  Invariant 5 has two windows, and they are not the same window. One is
+  *inside a body* — a commit landing between two of one render's reads.
+  The other is the **render→commit gap** — a commit landing after the
+  body returned and before React runs the effect that acquires its
+  edges. The predecessor guarded the second by re-reading every
+  subscription at commit; this arm may not (HD-002), so it needs
+  something else there.
+
+  Both windows are judged against one number, [[commit-basis]]:
+
+      commit-basis(frame) = this runtime's flush generation
+                          + that frame's own physical-install epoch
+
+  [[generation]] counts flushes. `frame-commit-epoch` is the substrate's
+  own counter, bumped once per physical frame-state install at both
+  write chokepoints, and Spec 006's observation port already uses it for
+  exactly this question — *did the frame's durable state move in the
+  render→commit gap?* — because it answers without watching anything.
+  That second term is what the runtime was missing, and it is why the
+  basis is not just the generation:
+
+  > The generation only moves when `flush!` bumps it, `flush!` only runs
+  > from `mark-dirty!`, and `mark-dirty!`'s only caller is the
+  > value-change watch [[acquire-cell!]] installs **at commit**. So a
+  > key nothing holds yet — no cell, no watch, no epoch — could move
+  > without moving the generation by so much as one.
+
+  The two windows then use the basis in the two places they can:
+
+  1. **Inside a body.** [[render-body]] captures the basis before the
+     body and checks it after; a commit that landed during the run makes
+     the body re-run against the newer one. One comparison per boundary
+     rather than one deref per read.
+  2. **The render→commit gap.** A key with no cell contributes the
+     current basis to [[make-snapshot]], and a cell records the basis it
+     was *created* at. So a staged key's number is `basis@render` while
+     the boundary renders and `basis@commit` once the commit acquires
+     it — equal when nothing moved, different when something did. React
+     re-reads `getSnapshot` immediately after calling `subscribe`
+     (`updateStoreInstance` runs as the next passive effect) and
+     compares it against the snapshot **that fiber** captured at render,
+     so the comparison is per boundary, costs one number, and needs no
+     record of what any read returned. **A staged read that moves in the
+     gap now heals.** rf2-2rtt6.42.
+
+  It is conservative in the safe direction and only there: an install
+  that moved nothing this boundary read still moves the basis, so a
+  boundary mounting exactly as an unrelated write lands re-renders once.
+  A MISSED move would be the P0. Nothing pays for this in steady state —
+  a mounted boundary holds a reference to every key it reads, so its
+  snapshot has no staged term in it at all.
 
   A flush raised while a body is running must not call React's
   `onStoreChange` — that is a render-phase update on somebody else's
   component. Those notifications are deferred to a macrotask; the fence
   has already made the *rendering* boundary correct.
+
+  **Two axes the predecessor compared still have no counterpart**, and
+  saying so is the point of writing them down: a `:sub` re-registration
+  (its `:registry-epoch`) and a same-id frame reincarnation (its
+  `:node-key`). Neither is a frame-state install, so neither moves the
+  basis — and `frame-commit-epoch` itself restarts at 0 across a
+  reincarnation, which is precisely why the observation port carries
+  `:node-key` as a third field. rf2-2rtt6.44.
 
   ## What is deliberately NOT here (the hard fences)
 
@@ -194,6 +249,7 @@
             [re-frame.bench.hicasso.front.intent :as intent]
             [re-frame.bench.hicasso.front.sub-index :as index]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.subs :as subs]
             ["react" :as react]))
 
@@ -308,6 +364,35 @@
   []
   @!generation)
 
+(defn commit-basis
+  "**The number both invariant-5 windows are judged against** — this
+  runtime's flush [[generation]] plus `frame`'s own physical-install
+  epoch (`re-frame.frame/frame-commit-epoch`, the substrate's
+  observation-port evidence counter, bumped once per frame-state install
+  at both write chokepoints).
+
+  The generation alone cannot carry it, and the reason is structural
+  rather than a matter of degree: the generation moves only through
+  `mark-dirty!`, whose only caller is the value-change watch
+  [[acquire-cell!]] installs **at commit**, so a key nothing holds yet
+  can move without moving it. The frame's install epoch has no such
+  dependency — it is a counter read, not a watch — which is exactly why
+  Spec 006's observation port uses it to ask whether durable state moved
+  in the render→commit gap.
+
+  Both terms are monotone within a frame incarnation, so the basis is,
+  and so is any sum of bases and cell epochs. Deliberately
+  install-counting rather than `=`-counting: a value-equal install still
+  advances it, which costs at most one redundant re-render and cannot
+  cost a missed one. Pure read; allocates nothing.
+
+  Silent on two axes by construction (rf2-2rtt6.44): a `:sub`
+  re-registration is not a frame-state install, and a same-id frame
+  reincarnation RESTARTS `frame-commit-epoch` at 0 — the case the
+  observation port needs its `:node-key` field for."
+  [frame-kw]
+  (+ @!generation (frame/frame-commit-epoch frame-kw)))
+
 (declare flush!)
 
 (defn- mark-dirty! [^js cell]
@@ -350,7 +435,19 @@
                                      "queryV"   query-v
                                      "reaction" reaction
                                      "watchKey" wk
-                                     "epoch"    0
+                                     ;; NOT zero. A key with no cell
+                                     ;; contributes the CURRENT
+                                     ;; `commit-basis` to `getSnapshot`,
+                                     ;; so a cell born at the same basis
+                                     ;; contributes the same number and
+                                     ;; a mount that raced nothing
+                                     ;; re-renders for nothing. Born at a
+                                     ;; LATER basis — something installed
+                                     ;; in the gap — it contributes a
+                                     ;; different one, and React's
+                                     ;; post-subscribe re-check corrects
+                                     ;; the boundary. rf2-2rtt6.42.
+                                     "epoch"    (commit-basis frame-kw)
                                      "refs"     0
                                      "disposed" false}]
                    ;; ONE baseline deref, at construction, before the watch.
@@ -417,7 +514,13 @@
     (when (seq dirty)
       (vreset! !dirty #{})
       (vswap! !generation inc)
-      (doseq [^js c dirty] (set! (.-epoch c) (inc (.-epoch c))))
+      ;; Re-STAMP rather than increment, so a cell's epoch is always a
+      ;; `commit-basis` reading and never drifts into a private
+      ;; numbering the staged term could not be compared against. It
+      ;; still strictly increases: the generation was just bumped and
+      ;; the frame's install epoch never falls, so the new stamp is
+      ;; above the one this cell last carried.
+      (doseq [^js c dirty] (set! (.-epoch c) (commit-basis (.-frameKw c))))
       (let [boundaries (index/commit! (into #{} (map (fn [^js c] (.-subKey c))) dirty))]
         (if (rendering?)
           (do (vswap! !deferred into boundaries)
@@ -583,9 +686,28 @@
           entry))))
 
 (defn- make-snapshot
-  "React's `getSnapshot`: the sum of the set's epochs. Monotone, so
-  `Object.is` on it is a correct change test; cached on the entry, so a
-  render allocates no closure for it."
+  "React's `getSnapshot`: the sum of the set's epochs, where a key **no
+  cell holds yet** contributes its frame's current [[commit-basis]]
+  instead of nothing. Monotone, so `Object.is` on it is a correct change
+  test; cached on the entry, so a render allocates no closure for it.
+
+  That one term is what reaches the render→commit gap. A staged key
+  contributes `basis@render` while the boundary renders and, once the
+  commit has created its cell, `basis@commit` — the same number when
+  nothing installed in between and a different one when something did.
+  React re-reads this closure immediately after `subscribe` returns
+  (`updateStoreInstance` is the next passive effect) and compares
+  against the value **that fiber** captured at render, so the tear check
+  is per boundary, is one number, and holds no record of what any read
+  returned. Returning 0 there — which is what a key with no epoch used
+  to contribute — meant a staged key answered the same number before and
+  after the commit however far its value had moved, so React saw no tear
+  and scheduled no re-render, and nothing ever corrected the boundary.
+  rf2-2rtt6.42.
+
+  Steady state pays nothing for it: a mounted boundary holds a reference
+  to every key it reads, so every term is a cell epoch and the staged
+  branch is never taken."
   [^js entry]
   (fn snapshot []
     (let [cells @!cells
@@ -594,8 +716,11 @@
       (loop [i 0 acc 0]
         (if (== i n)
           acc
-          (recur (inc i)
-                 (if-some [^js c (get cells (aget ks i))] (+ acc (.-epoch c)) acc)))))))
+          (let [k (aget ks i)]
+            (recur (inc i)
+                   (if-some [^js c (get cells k)]
+                     (+ acc (.-epoch c))
+                     (+ acc (commit-basis (nth k 0)))))))))))
 
 (defn- make-subscribe
   "React's `subscribe`, as a pure function of the read set.
@@ -670,16 +795,24 @@
   "Run a boundary body under the generation fence and return its element;
   [[last-reads]] carries the read-set entry.
 
-  The fence is the loop: capture the generation, run the body, and if a
-  commit landed while it ran, run it again against the newer commit. All
-  of a pass's reads therefore observe one commit — invariant-5
-  preservation as one comparison per boundary, not one deref per read."
+  The fence is the loop: capture the [[commit-basis]], run the body, and
+  if a commit landed while it ran, run it again against the newer
+  commit. All of a pass's reads therefore observe one commit —
+  invariant-5 preservation as one comparison per boundary, not one deref
+  per read.
+
+  It compares the basis rather than the generation alone because the
+  generation cannot see a mid-body move of a key nothing holds: no cell,
+  so no watch, so no `mark-dirty!`, so no bump. A body that read a
+  staged key, dispatched, and read again could straddle two commits with
+  the generation sitting perfectly still. The frame's install epoch
+  moves for that write, so the basis does. rf2-2rtt6.42."
   [frame-kw body-fn props]
   (loop [attempt 0]
-    (let [before  (generation)
+    (let [before  (commit-basis frame-kw)
           element (run-once frame-kw body-fn props)]
       (cond
-        (= before (generation))
+        (= before (commit-basis frame-kw))
         (do (set! (.-entry rstate) (entry-for)) element)
 
         (< attempt max-fence-retries)
@@ -704,6 +837,14 @@
   "An entry's sub-key set."
   [^js entry]
   (.-set entry))
+
+(defn snapshot-of
+  "The number React stores for a boundary with this read set, and the
+  one it re-reads after `subscribe` to decide whether the store moved
+  under the render. Reading it is the witness's way of performing
+  React's own `checkIfSnapshotChanged` without a browser."
+  [^js entry]
+  ((.-snapshot entry)))
 
 (defn last-tiers
   "Which read surfaces the most recent body used. The instrument's input,

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/staged_read_tear_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/staged_read_tear_cljs_test.cljs
@@ -188,12 +188,12 @@
            in the application pays a second render."
     (seeded!)
     (let [entry     (render (done-row (volatile! nil)))
-          at-render (rt/snapshot-of entry)]
-      (let [release! (rt/commit-boundary! entry (fn []))]
-        (is (= at-render (rt/snapshot-of entry))
-            "acquisition alone moves nothing: the cell is born at the same
-             basis the staged term reported")
-        (release!)))))
+          at-render (rt/snapshot-of entry)
+          release!  (rt/commit-boundary! entry (fn []))]
+      (is (= at-render (rt/snapshot-of entry))
+          "acquisition alone moves nothing: the cell is born at the same
+           basis the staged term reported")
+      (release!))))
 
 (deftest a-retained-key-moving-in-the-gap-is-still-corrected
   (testing "the path that already worked, kept working. A key some

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/staged_read_tear_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/staged_read_tear_cljs_test.cljs
@@ -1,0 +1,277 @@
+(ns re-frame.bench.hicasso.arm1.staged-read-tear-cljs-test
+  "A STAGED READ THAT MOVES BEFORE THE COMMIT (rf2-2rtt6.42).
+
+  `generation_fence_coverage_cljs_test` settled what the generation
+  fence covers and found the hole; this file is the hole closed, over
+  Arm 1's OWN runtime rather than a transcription of it.
+
+  ## The defect these rows are about
+
+  Two windows, and the arm only ever guarded one of them:
+
+      predecessor   render probes a site … COMMIT re-reads that site
+                    |<------- the render->commit gap ------->|
+
+      the fence     capture … BODY RUNS … compare … RETURN
+                    |<---- one body run ---->|
+
+  `render-body` compares and returns; the commit that follows — React
+  calling the read-set entry's `subscribe`, where `acquire-cell!`
+  installs the edge and the watch — compares nothing, by design (`no
+  commit-phase deref`). What reached the gap instead was the epoch-sum
+  `getSnapshot` plus React's own post-`subscribe` re-check, and that is
+  real — but it was driven by ONE counter. An epoch moved only when
+  `flush!` bumped it, `flush!` ran only from `mark-dirty!`, and
+  `mark-dirty!` has exactly one caller: the value-change watch
+  `acquire-cell!` installs AT COMMIT. So for a key nothing holds yet —
+  no cell, no watch, no epoch — a move in the gap marked nothing, bumped
+  nothing, and left `getSnapshot` answering the same number before and
+  after the commit. The boundary painted the old value and, because the
+  watch's baseline was already the new one, **no later notification was
+  coming for a change that had already happened**. Spec 006 invariant
+  5's stronger half, executed: *a staged site publishes stale and
+  nothing ever corrects it.*
+
+  A baseline deref at acquire — which this arm already performs, and
+  which is the right fix for a DIFFERENT problem (a fresh reaction whose
+  `unset` baseline is never `rf=` a real value reports movement on the
+  first later commit whatever it did) — cannot close this one. It gives
+  the cell a correct baseline and no COMPARISON: it silently adopts the
+  moved value as though it had always been that. Row `the-baseline-deref-
+  alone-cannot-see-the-move` states that as an assertion rather than as
+  a paragraph.
+
+  ## What closes it
+
+  One term, in the one place React already looks. A key with no cell
+  contributes its frame's `commit-basis` to `getSnapshot` instead of
+  nothing, and a cell records the basis it was CREATED at:
+
+      commit-basis(frame) = the runtime's flush generation
+                          + `re-frame.frame/frame-commit-epoch`
+
+  The second term is the substrate's own observation-port evidence
+  counter — one bump per physical frame-state install, at both write
+  chokepoints — and Spec 006 already uses it to answer exactly this
+  question without watching anything. So a staged key's number is
+  `basis@render` while the boundary renders and `basis@commit` once the
+  commit acquires it: equal when nothing installed in the gap, different
+  when something did. React stores each fiber's render-time snapshot and
+  re-reads `getSnapshot` immediately after `subscribe` returns
+  (`updateStoreInstance` is the very next passive effect), so the
+  comparison is per boundary, is one number, and holds **no record of
+  what any read returned**.
+
+  ## What these rows are, and what they are not
+
+  They are the seam React occupies, driven by hand: `render-body` is the
+  render, `snapshot-of` is `useSyncExternalStore`'s capture and React's
+  `checkIfSnapshotChanged`, `commit-boundary!` is `subscribe`. Nothing
+  here mocks the sub layer, the frames or the watches — the adapter is
+  the React spine's, because under `plain-atom` a subscription never
+  notifies and every one of these assertions would pass by never firing.
+  `arm1/generation_fence_dom_cljs_test`'s staged row then proves REACT
+  drives this seam, in a real browser, against the real DOM.
+
+  Two rows fail on the pre-fix runtime and pass on it —
+  `a-staged-read-that-moves-in-the-gap-is-corrected` and
+  `the-fence-sees-a-mid-body-move-of-a-key-nothing-holds` — and the
+  remaining rows are what stops the repair from being \"re-render
+  always\": a clean mount must ask React for nothing."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.frame :as frame]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     :init-fn (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::arm1-staged-tear)
+
+(defn- seeded! []
+  (rt/reset-runtime!)
+  (dogfood/make-frame! frame-id 3)
+  frame-id)
+
+(defn- render
+  "One render pass for `body-fn`, through the shell's own fence. Returns
+  the read-set entry — the object React's `subscribe` and `getSnapshot`
+  hang off."
+  [body-fn]
+  (rt/render-body frame-id body-fn {})
+  (rt/last-reads))
+
+(defn- done-row
+  "A boundary reading one row's done? flag, and recording what it read.
+  The read is the whole body, so the boundary's read set is one key and
+  the arithmetic below is one term."
+  [seen]
+  (fn [_] (let [v (rt/sub [:dogfood/done? 0])] (vreset! seen v) [:li (str v)])))
+
+;; ---------------------------------------------------------------------------
+;; The tear, and its repair
+;; ---------------------------------------------------------------------------
+
+(deftest a-staged-read-that-moves-in-the-gap-is-corrected
+  (testing "hd-002-adjudication.md §6.1's adversarial witness, executed
+           against Arm 1's own runtime. The value moves after the body
+           returned and before React's commit acquires the key, and it
+           moves WITHIN ONE GENERATION — because for a key nothing holds
+           the generation cannot move. The number React re-checks must
+           move anyway, or the boundary paints stale forever."
+    (seeded!)
+    (let [seen  (volatile! nil)
+          entry (render (done-row seen))]
+      (is (false? @seen) "the render read, and this is what it put on screen")
+      (is (zero? (:cells (rt/stats)))
+          "STAGED, not retained: nothing holds this key, so there is no
+           cell, no watch and no epoch — `commit-boundary!` below is the
+           first acquisition")
+      (let [at-render  (rt/snapshot-of entry)
+            generation (rt/generation)
+            frame-e    (frame/frame-commit-epoch frame-id)]
+        ;; THE GAP.
+        (rt/dispatch! frame-id [:dogfood/toggle 0])
+        (is (= generation (rt/generation))
+            "the generation did NOT move — there was no watch to fire, so
+             the change happened within one generation, which is precisely
+             the witness §6.1 asks for")
+        (is (> (frame/frame-commit-epoch frame-id) frame-e)
+            "but the frame's own physical-install epoch did, and it moved
+             without anybody watching anything")
+        ;; THE COMMIT: React calls the entry's `subscribe`.
+        (let [release! (rt/commit-boundary! entry (fn []))]
+          (is (not= at-render (rt/snapshot-of entry))
+              "so the number React stored at render is not the number it
+               re-reads after `subscribe` — `updateStoreInstance` finds a
+               moved store and schedules the boundary")
+          (testing "and the re-render React schedules reads the value that
+                   is now true, so the correction actually corrects"
+            (render (done-row seen))
+            (is (true? @seen)))
+          (release!))))))
+
+(deftest the-baseline-deref-alone-cannot-see-the-move
+  (testing "why the arm's existing acquire-time baseline deref is not the
+           fix. It gives a fresh cell a correct baseline — which is worth
+           having, and is what stops every newly mounted boundary
+           re-rendering once for nothing — but it performs no COMPARISON,
+           so on its own it adopts the moved value as though it had
+           always been that. The proof is that after the commit the dirty
+           set is empty: no notification is coming for a change that
+           already happened, and the only thing left that can correct the
+           boundary is the number React re-checks."
+    (seeded!)
+    (let [seen  (volatile! nil)
+          entry (render (done-row seen))]
+      (rt/dispatch! frame-id [:dogfood/toggle 0])
+      (let [hits     (volatile! 0)
+            release! (rt/commit-boundary! entry (fn [] (vswap! hits inc)))]
+        (is (= 0 @hits)
+            "the commit notified nobody — the watch was armed one move too
+             late to have reported it")
+        (rt/dispatch! frame-id [:dogfood/commit 0])
+        (is (= 0 @hits)
+            "and a later write that moves nothing brings no correction
+             either: the ordinary invalidation path is done with this
+             change")
+        (release!)))))
+
+(deftest a-clean-mount-asks-react-for-nothing
+  (testing "the half that stops the repair from being `re-render always`.
+           A staged key whose value did NOT move in the gap must leave
+           the snapshot exactly where the render left it, or every mount
+           in the application pays a second render."
+    (seeded!)
+    (let [entry     (render (done-row (volatile! nil)))
+          at-render (rt/snapshot-of entry)]
+      (let [release! (rt/commit-boundary! entry (fn []))]
+        (is (= at-render (rt/snapshot-of entry))
+            "acquisition alone moves nothing: the cell is born at the same
+             basis the staged term reported")
+        (release!)))))
+
+(deftest a-retained-key-moving-in-the-gap-is-still-corrected
+  (testing "the path that already worked, kept working. A key some
+           earlier boundary committed has a cell whose watch PRE-DATES
+           the move, so the ordinary invalidation path reaches it. The
+           repair must not disturb that — and the epoch it stamps is now
+           a `commit-basis` reading rather than a private count, so this
+           row is also the check that re-stamping still strictly
+           increases."
+    (seeded!)
+    (let [warm  (render (done-row (volatile! nil)))
+          hold! (rt/commit-boundary! warm (fn []))]
+      (is (= 1 (:cells (rt/stats))) "RETAINED: an earlier commit holds the key")
+      (let [entry      (render (done-row (volatile! nil)))
+            at-render  (rt/snapshot-of entry)
+            generation (rt/generation)]
+        (rt/dispatch! frame-id [:dogfood/toggle 0])
+        (is (= (inc generation) (rt/generation))
+            "the pre-existing watch fired, so the generation moved here")
+        (is (not= at-render (rt/snapshot-of entry))
+            "and the epoch sum moved with it")
+        (hold!)))))
+
+;; ---------------------------------------------------------------------------
+;; The same blind spot, inside the fence's own window
+;; ---------------------------------------------------------------------------
+
+(deftest the-fence-sees-a-mid-body-move-of-a-key-nothing-holds
+  (testing "the sibling hole, and the reason the fence compares the basis
+           rather than the generation alone. A body reads a key nothing
+           holds, writes, and reads again. No cell means no watch means
+           no `mark-dirty!` means no generation bump — so a fence
+           comparing the generation saw one still number across a body
+           whose two reads straddled two commits. The frame's install
+           epoch moves for that write, so the basis does, and the body
+           re-runs against the newer commit."
+    (seeded!)
+    (let [runs   (volatile! 0)
+          first- (volatile! nil)
+          then-  (volatile! nil)]
+      (render (fn [_]
+                (vswap! runs inc)
+                (vreset! first- (rt/sub [:dogfood/done? 0]))
+                (when (= 1 @runs)
+                  (rt/dispatch! frame-id [:dogfood/toggle 0]))
+                (vreset! then- (rt/sub [:dogfood/done? 0]))
+                [:li (str @then-)]))
+      (is (= 2 @runs) "the fence re-ran the body against the newer commit")
+      (is (= @first- @then-)
+          "so the winning run's two reads are on ONE commit — the DOM never
+           carries a pair of values that were not simultaneously true")
+      (is (true? @then-) "and the winning run read the committed value"))))
+
+;; ---------------------------------------------------------------------------
+;; The cost of the repair, stated as assertions
+;; ---------------------------------------------------------------------------
+
+(deftest the-repair-costs-no-hook-no-object-and-no-record-of-a-read
+  (testing "the tripwire, checked rather than claimed. Closing the gap
+           added one integer term to a number that was already being
+           summed — no second scratch, nothing keyed by a render or an
+           attempt, no per-read object, and no commit-phase deref of a
+           subscription value."
+    (is (= 2 (count rt/shell-hook-ledger))
+        "still two hooks; the repair rides `useSyncExternalStore`'s own
+         snapshot re-check rather than buying a third")
+    (let [inv (rt/retained-inventory)]
+      (is (= #{:use-ref :use-state :view-cell :candidate-ledger}
+             (into #{} (map :token) (:absent inv)))
+          "the enumerated absences are unchanged")))
+  (testing "and a render still mutates neither the index nor a reference,
+           which is the clause the repair had to stay inside: the staged
+           term is READ from the frame, never recorded by the render"
+    (seeded!)
+    (let [before (rt/stats)]
+      (render (done-row (volatile! nil)))
+      (let [after (rt/stats)]
+        (is (= (:cells before) (:cells after)) "no cell built")
+        (is (= (:cell-refs before) (:cell-refs after)) "no reference taken")
+        (is (= (:boundaries before) (:boundaries after)) "no boundary registered")
+        (is (= (:edges before) (:edges after)) "no edge added")))))


### PR DESCRIPTION
Closes the P0 in **rf2-2rtt6.42**: a boundary's first read of a key nothing else holds could move between the render and the commit, and nothing ever corrected it.

## The defect

The bead settled it precisely and this PR does not re-litigate it. The predecessor's commit-side re-read and Hicasso's generation fence guard **different windows**:

```
predecessor   render probes a site .. COMMIT re-reads that site   (the render→commit gap)
the fence     capture .. BODY RUNS .. compare .. RETURN           (one body run)
```

`render-body` compares and returns. The commit that follows — React calling the read-set entry's `subscribe`, where `acquire-cell!` installs the edge and the watch — compares nothing, by design. What *did* reach the gap was the epoch-sum `getSnapshot` plus React's own post-`subscribe` snapshot re-check, and that channel is real. But it was driven by **one counter**: an epoch moved only when `flush!` bumped it, `flush!` ran only from `mark-dirty!`, and `mark-dirty!` has exactly one caller — the value-change watch `acquire-cell!` installs **at commit**.

So for a **staged** key — no cell, no watch, no epoch — a move in the gap marked nothing, bumped nothing, and left `getSnapshot` answering the *same number* before and after the commit. React saw no tear, scheduled no re-render, and the watch's baseline was already the new value, so no later notification was coming for a change that had already happened. Spec 006 invariant 5's stronger half, and a P0 by `validation.md`'s own words. Every mount of a new row, panel or route is a candidate.

**The baseline deref is not the fix.** Arm 1's "one baseline deref per new unique key" (already in `acquire-cell!`) is the right repair for a *different* problem — a fresh reaction whose `unset` baseline is never `rf=` a real value reports movement on the first later commit whatever it did, so every newly mounted boundary re-rendered once for nothing. It gives the cell a correct baseline and **no comparison**: it silently adopts the moved value as though it had always been that, which is exactly why the tear never healed. The witness states that as an assertion (`the-baseline-deref-alone-cannot-see-the-move`) rather than as a paragraph.

## The fix

One term, in the one place React already looks. A key **with no cell** contributes its frame's `commit-basis` to `getSnapshot` instead of nothing, and a cell records the basis it was *created* at:

```clojure
(defn commit-basis [frame-kw]
  (+ @!generation (frame/frame-commit-epoch frame-kw)))
```

`re-frame.frame/frame-commit-epoch` is the **substrate's own observation-port evidence counter** — bumped once per physical frame-state install at both write chokepoints — and Spec 006 already uses it to answer exactly this question, in these words: *"the commit-side evidence comparison can detect 'the frame's durable state moved in the render→commit gap' without watching anything — a pure counter read, no watch, no allocation on the read side."* The arm was missing the one field the substrate had already built. It is not a watch, so it has none of the generation's dependency on a cell existing.

A staged key therefore reads `basis@render` while the boundary renders and `basis@commit` once the commit acquires it: the same number when nothing installed in the gap, a different one when something did. **React stores each fiber's render-time snapshot and re-reads `getSnapshot` immediately after `subscribe` returns** — `mountSyncExternalStore` pushes `subscribeToStore` as a passive effect and `updateStoreInstance` as the *next* one, and `updateStoreInstance` is a `checkIfSnapshotChanged` + `forceStoreRerender` (React 19.2, verified in `react-dom-client`). So the comparison is per boundary, is one number, and **holds no record of what any read returned**.

`flush!` re-stamps a dirty cell's epoch with the basis rather than incrementing it, so every term is a basis reading and the sum stays monotone; it still strictly increases, because the generation was just bumped and the install epoch never falls.

The fence compares the basis too, for the same reason on a shorter window: a body that read a staged key, dispatched, and read again could straddle two commits with the generation sitting perfectly still. That is a second row in the witness.

**Executable change: six lines**, plus `commit-basis` and a `snapshot-of` accessor for the witness.

### Cost

| | |
|---|---|
| Hooks | **unchanged, 2** (`useContext` + `useSyncExternalStore`). The repair rides `useSyncExternalStore`'s own re-check rather than buying a third; asserted in the witness. |
| `subscribe` closure | **unchanged** — still closes over the read set and nothing else. `getSnapshot` likewise. |
| Allocation | **zero**. One integer add and one map lookup, only for a key with no cell. |
| Steady state | **nothing**. A mounted boundary holds a reference to every key it reads, so its snapshot has no staged term in it at all — the branch is never taken. |
| Re-renders | conservative in the safe direction and only there: an install that moved nothing this boundary read still moves the basis, so a boundary mounting *exactly as* an unrelated write lands re-renders once. A clean mount re-renders zero times, which is its own witness row (`a-clean-mount-asks-react-for-nothing`). |

### The tripwire did not fire

No candidate ledger and no generic post-render reconciliation. No second scratch, nothing keyed by a render, an attempt, a lane or a generation, no per-read object, and **no commit-phase deref** — the repair deliberately does *not* take the bead's candidate (a) shape ("compare what the render read against what is live now"), because that needs somewhere to keep what the render read, and the only ledger-free place to keep it is a second render-populated buffer the commit reconciles. Comparing *bases* instead needs no such record: React is already holding the per-boundary render-time value. `hd-002-adjudication.md` checklist item 4 stays unfired, and now for a mechanical reason rather than an argued one.

Hard fences unchanged: no compiler, no analyzer, no dual mode, no ViewCell-class object graph.

## Scoped out, deliberately — **rf2-2rtt6.44** filed

Two of the predecessor's three fields still have no counterpart, and the record should say so rather than imply otherwise:

- **`:registry-epoch`** — a `:sub` re-registration is not a frame-state install, so it does not move the basis. Closing it *for a retained key* means adding a registry term to **every** key's contribution, i.e. re-rendering every boundary on every re-registration — a design decision (the bead's candidate (b)), not a defect fix. It is also blocked: `observation/registry-epoch*` is `^:private` with no public reader, so the arm cannot read it without a substrate change. HMR/dev-time reachability.
- **`:node-key`** (a same-id frame reincarnation) — `frame/dissoc-frame!` clears the destroyed frame's commit-epoch entry, so a same-id successor **restarts at 0**; `observation_port_cljs_test` asserts exactly that. `commit-basis` is monotone only *within* one incarnation, which is precisely why the observation port carries `:node-key` as a third field.

Both are named in `commit-basis`'s docstring and in the ns docstring, with the bead id.

## The witness

`arm1/staged_read_tear_cljs_test.cljs` — new, six rows, against Arm 1's **own runtime** (not a transcription), over the real sub layer, real frames and real watches on the React-spine host. `arm1/generation_fence_dom_cljs_test.cljs` gains **Case 3**, which stages the same defect in real Chromium the way the reachability argument says it happens in an application: a **sibling boundary writes during the same React render pass**, after the reading boundary's fence has already closed. That needs no guess about when React runs a passive effect — the write is strictly inside the render and `subscribe` runs strictly after it.

Case 2 in that file is *labelled* as §6.1's case and is not it: it dispatches after the mount has settled, so the key is already **retained**. Noted in the file.

Two rows fail before the fix and pass after; four are controls that pass both ways and are what stop the repair from being "re-render always".

## Quality gates

All foreground, worktree-local logs, exit codes echoed. Matrix derived from `TESTING.md`: the diff touches only `implementation/freehand/test/re_frame/bench/hicasso/arm1/**`, which is the `cljs_node_test` surface (→ `test:cljs`, the consolidated `cljs` job), the `cljs_browser` surface (a new `*_dom_cljs_test` row → `test:browser`, the Playwright `cljs-browser` job), and the lint surface (`implementation/**` → clj-kondo + Splint + the api-manifest drift-check; no public var changes, and the bench lane is not on the manifest classpath). `test-fast-pr.sh` additionally selects the `implementation/freehand` JVM suite because the diff touches that tree. No docs tier: **no page under `docs/design/hicasso/**` was touched**, so the standing "mkdocs `--strict` does not cover that tree, verify by hand" caveat applies to nothing here.

### The witness, before and after

| gate | before the fix (mutation) | after |
|---|---|---|
| `npm run test:cljs` | **exit 1** — 12,196 tests / 60,717 assertions, **3 failures**, all in `arm1.staged-read-tear-cljs-test` and nowhere else in the suite | **exit 0** — 12,196 tests / 60,717 assertions / 0 failures |
| `npm run test:browser` | **exit 1** — 938 tests / 5,800 assertions, **1 failure**: `a-staged-read-that-moves-before-the-commit-is-corrected-in-the-dom` | **exit 0** — 938 tests / 5,800 assertions / 0 failures |

The mutation is the fix reverted with the witness left in place — `epoch` back to `0` at creation, `flush!` back to `inc`, the staged term back to `acc`, and the fence back to `(generation)`. The failures read:

```
FAIL in (a-staged-read-that-moves-in-the-gap-is-corrected)
  so the number React stored at render is not the number it re-reads after `subscribe`
  expected: (not= at-render (rt/snapshot-of entry))
    actual: (not (not= 0 0))                       ← the bead's sentence, executed

FAIL in (the-fence-sees-a-mid-body-move-of-a-key-nothing-holds)
  the fence re-ran the body against the newer commit
  expected: (= 2 @runs)
    actual: (not (= 2 1))

FAIL in (a-staged-read-that-moves-before-the-commit-is-corrected-in-the-dom)
  the boundary was corrected: React re-read the store after `subscribe`
  expected: (= "true" (read-back handle "data-after"))
    actual: (not (= "true" "false"))               ← the real DOM, painting stale forever
```

### The rest

| gate | result |
|---|---|
| `npm run test:cljs` | **exit 0** — 12,196 tests / 60,717 assertions / 0 failures |
| `npm run test:browser` | **exit 0** — 938 tests / 5,800 assertions / 0 failures |
| `scripts/test-fast-pr.sh` | **PASS fast PR spine** — exit 0 |
| clj-kondo, CI-pinned **2026.04.15** (`.github/workflows/lint.yml`; the local npm binary is 2025.10.23, so the pinned release was fetched) — full CI `--lint` path set, `--parallel --fail-level error` | **exit 0**, **errors: 0**. Re-linted `arm1/`: **errors: 0, warnings: 0** |

## Follow-ups

- **rf2-2rtt6.44** (filed) — the registry-epoch and node-key axes, above.
- **rf2-2rtt6.43** (annotated) — `generation_fence_coverage_cljs_test.cljs` in #7323 **transcribes** the three functions this PR changes, so once #7323 lands its row 2 asserts a defect the arm no longer has. That bead already owns re-pointing the rows at the arm's own runtime; it now carries the note that row 2's verdict has moved and that this PR's witness already covers the same case against the real runtime. Rows 1 and 3 are unchanged in verdict, and row 3's axis is rf2-2rtt6.44.
