### PR TITLE
subs,spine: a movement witness retires the wasted layer-1 compare (rf2-gncxk.1)

### DIFF
--- a/implementation/core/src/re_frame/movement.cljc
+++ b/implementation/core/src/re_frame/movement.cljc
@@ -1,0 +1,122 @@
+(ns re-frame.movement
+  "Re-frame-owned MOVEMENT-WITNESS protocol — an OPTIONAL capability a
+  substrate's derived container may publish so core can PROVE, without
+  walking the value, that its input moved.
+
+  Sibling in spirit to `re-frame.disposable` (rf2-jicu2): a re-frame-owned
+  protocol reified by the substrate spine's derived container and consulted
+  by core, with no dependency on any adapter artefact in either direction.
+
+  ## The problem it solves (rf2-gncxk)
+
+  `re-frame.subs.memo`'s fixed-arity-1 memo wrappers guard the user's sub
+  body with `(= @last-seen new-value)`. That guard is NOT dead code — the
+  spine's derived value is PULL-based (`-deref` recomputes every time), so
+  the guard is the only thing stopping a view render from re-running every
+  sub body. It earns its keep on the READ path.
+
+  On the WRITE path it is overwhelmingly wasted: a full structural
+  comparison of the changed app-db subtree, measured at 147.0 B/sub —
+  17.6% of the per-subscription slope — whose TIME cost scales with the
+  shape of the changed subtree rather than with the sub.
+
+  It cannot simply be skipped \"when flushing\", because the flush path is
+  not the same question. The substrate establishes \"the source moved since
+  the source's PREVIOUS NOTIFY\"; the guard asks \"did the input move since
+  THE WRAPPER LAST RAN\", and two reachable interleavings separate them —
+  a deref between `mark-dirty` and the epoch drain, and a single-epoch
+  `A -> B -> A'` return-to-equal that coalesces into one flush. In BOTH the
+  guard correctly HITS on the flush path. So the signal must be an exact
+  fact about the SOURCE, not about the caller.
+
+  ## The signal
+
+  A container that gates its own propagation on `rf=` already knows the
+  value its most recent COMPLETED movement departed FROM. Publishing that
+  value lets a consumer holding the same object decide by POINTER
+  COMPARISON — nothing is walked, nothing is allocated:
+
+    let S be the source, L the value the consumer last saw, V = @S.
+    If `(identical? (-moved-from S) L)` then `(not (= L V))`.
+
+    Proof. W1 + W2 below give `(not (rf= f V))` for the returned `f`, and
+    `rf=` subsumes `=`, so `(not (= f V))`. `f` is `identical?` to `L`, so
+    `(not (= L V))`. QED.
+
+  The source OWNS the signal (movement is its own notion, defined by its
+  own `rf=` gate) and core PULLS it. So `make-derived-value`'s pinned
+  `(source-containers compute-fn)` signature is untouched, and so is
+  `compute-fn`'s pinned one-arg-per-source shape (Spec 006
+  §`make-derived-value`).
+
+  ## Publishing is optional
+
+  Exactly the posture Spec 006 already takes for `:adapter/derived-
+  container?` and `:adapter/activate-derived-value!`. A container that
+  publishes nothing is not deficient: it is simply one the consumer cannot
+  short-circuit, and the consumer's fall-back is the comparison it would
+  have performed anyway. Absence is answered by `no-witness`, which every
+  consumer must treat as \"no information\".
+
+  In this repo exactly ONE implementor exists — the React-hook spine's
+  `make-derived-value` reify (`re-frame.substrate.spine`), whose `notify`
+  is `rf=`-gated. The Reagent / reagent-slim `Reaction`, the plain-atom
+  derived value (JVM and CLJS), test-react's derived value, and every raw
+  `cljs.core/Atom` / `clojure.lang.Atom` publish nothing.
+
+  See Spec 006 §Movement witness (optional).")
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(def no-witness
+  "The \"no information\" answer to `-moved-from`.
+
+  A DISTINCT object identity, so it is never `identical?` (nor `=`) to any
+  real container value, to `nil`/`false`, or to `re-frame.subs.memo`'s
+  `::unset` sentinel. A consumer therefore needs no special-casing: an
+  `identical?` test against it simply fails, and the consumer falls through
+  to the comparison it would otherwise have made.
+
+  Also the correct answer for a consumer that holds NO witnessing source at
+  all — the fixed-arity-1 memo wrappers substitute it for the protocol call
+  when their source does not implement `IMovementWitness`, which keeps the
+  hot path one closed-over truthiness test plus one pointer compare."
+  #?(:clj (Object.) :cljs (js-obj)))
+
+(defprotocol IMovementWitness
+  "OPTIONAL capability of a derived container that gates its own
+  propagation on `rf=`: publish the value its most recent completed
+  movement departed FROM, so a consumer holding that same object can prove
+  by pointer comparison that the container's live value differs from it.
+
+  Two obligations bind an implementor. They are the whole normative
+  content of this protocol:
+
+  **(W1) FRESHNESS.** Answer `no-witness` unless the container's own value
+  has completed a movement AND no input change has been observed since.
+  Without W1 a PULL-based container's live value can run ahead of its last
+  movement — its sources changed, it has not recomputed-and-notified yet,
+  and a witness from the previous movement would then say nothing true
+  about what a `-deref` returns now.
+
+  **(W2) SOUNDNESS.** Whenever it answers `f` other than `no-witness`,
+  reading the container at that instant yields `v` with `(not (rf= f v))`
+  — in particular `(not (= f v))`, since `rf=` subsumes `=`.
+
+  And one binds a consumer:
+
+  **(C1) VERDICT-PRESERVING.** Use the witness ONLY to skip a comparison
+  whose answer it determines. Never let it change an observable outcome.
+  The set of verdicts a consumer reaches must be bit-identical with and
+  without the witness — this is a comparison ELIMINATION, not a behaviour
+  change, and any divergence in body-run counts or in the Spec 009
+  `:rf.sub/run` / `:rf.sub/skip` stream is a defect, never a new baseline.
+
+  Method naming follows the `re-frame.disposable` precedent: a
+  single-leading-dash internal protocol method, reached by re-frame's own
+  layers rather than by users."
+  (-moved-from [this]
+    "The value THIS container's most recent COMPLETED movement departed
+     FROM, or `no-witness` when the container cannot presently answer (W1).
+     Must be cheap — consumers call it on the hottest path in the
+     artefact — and must never recompute the container or notify anyone."))

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -1259,9 +1259,21 @@
                         ;; frame-state value `{:rf.db/app … :rf.db/runtime …}`.
                         ;; `container-fn` is exactly the single-source membership
                         ;; (its map keys ARE `single-source-input-kinds`).
+                        ;;
+                        ;; The trailing `(first inputs)` is the reaction's
+                        ;; LONE signal source, handed over so the wrapper can
+                        ;; resolve its MOVEMENT WITNESS once at construction
+                        ;; (rf2-gncxk.1). For `:db` / `:runtime-db` that is an
+                        ;; `rf=`-gated partition projection, which publishes
+                        ;; one; for `:frame-state` it is the raw physical
+                        ;; container, which cannot — so that kind keeps its
+                        ;; genuine flush-path memo hit structurally. See
+                        ;; `re-frame.subs.memo` §The movement-witness
+                        ;; short-circuit.
                         container-fn
                         (subs-memo/make-layer-1-memoised-body
-                          body-fn query-id query-v frame-id sub-meta)
+                          body-fn query-id query-v frame-id sub-meta
+                          (first inputs))
 
                         ;; PARAMETRIC subs (any realized input count,
                         ;; including 1) deliver a VECTOR of input values to
@@ -1279,9 +1291,13 @@
                         ;; shape; specialise to fixed-arity-1 for
                         ;; parity with layer-1. Delivers the bare
                         ;; value (the v1 `:<-` single-input convention).
+                        ;; `(first inputs)` — the lone upstream reaction, for
+                        ;; the same movement-witness resolution as layer-1
+                        ;; (rf2-gncxk.1).
                         (= 1 (count input-qs))
                         (subs-memo/make-layer-n-single-input-memoised-body
-                          body-fn query-id query-v frame-id input-qs sub-meta)
+                          body-fn query-id query-v frame-id input-qs sub-meta
+                          (first inputs))
                         :else
                         (subs-memo/make-layer-n-memoised-body
                           body-fn query-id query-v frame-id input-qs sub-meta))

--- a/implementation/core/src/re_frame/subs/memo.cljc
+++ b/implementation/core/src/re_frame/subs/memo.cljc
@@ -35,6 +35,7 @@
   (:require [re-frame.error :as error]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.movement :as movement]
             [re-frame.performance :as performance
              #?@(:cljs [:include-macros true])]
             [re-frame.trace :as trace
@@ -491,6 +492,70 @@
                     :rf.sub/reason                :input-value-equal
                     :rf.sub/input-paths-unchanged input-paths-unchanged}))))
 
+;; ---- the movement-witness short-circuit (rf2-gncxk.1) --------------------
+;;
+;; The two FIXED-ARITY-1 wrappers below guard the user's body with a
+;; structural `(= last-seen new-value)`. That guard is NOT dead code — the
+;; spine's derived value is PULL-based, so it is the only thing stopping a
+;; render from re-running every sub body — but on the WRITE path it is
+;; overwhelmingly wasted: a full walk of the changed app-db subtree,
+;; measured at 147.0 B/sub, 17.6% of the per-subscription slope, whose TIME
+;; cost scales with the shape of that subtree rather than with the sub.
+;;
+;; It cannot be skipped by asking "am I on the flush path?" — that is a
+;; different question, and two reachable interleavings make the guard
+;; correctly HIT there even for `:db` (a deref between `mark-dirty` and the
+;; epoch drain; and a single-epoch `A -> B -> A'` return-to-equal coalescing
+;; into one flush). So we key on an exact fact about the SOURCE instead: a
+;; source that gates its own propagation on `rf=` publishes, through
+;; `re-frame.movement/IMovementWitness`, the value its most recent completed
+;; movement departed FROM. When that witness is `identical?` to the value
+;; this wrapper last saw, the source's live value is provably not `rf=` to
+;; it — hence not `=` — and the walk can be skipped. See `re-frame.movement`
+;; for the two implementor obligations and the proof.
+;;
+;; This is a comparison ELIMINATION. The set of {hit, miss} verdicts is
+;; bit-identical on every path on every adapter, so body-run counts and the
+;; Spec 009 `:rf.sub/run` / `:rf.sub/skip` stream (including
+;; `:reason :input-value-equal`, which stays exactly true — the wrapper
+;; never skips when the values ARE `=`) do not move. A trace-count diff is
+;; the failure signal, not a thing to re-baseline.
+;;
+;; It also cannot weaken the READ-path guard, structurally rather than by
+;; care. After any invocation `last-seen` holds the value just seen while
+;; the witness holds its PREDECESSOR, so the proof cannot fire twice running
+;; on the same value: a render that derefs 300 subs three times each still
+;; memo-hits 900 times, with `=` short-circuiting on `identical?`. The only
+;; deref that gets the proof is the FIRST one after a movement — where the
+;; guard would have missed anyway.
+
+(defn- witnessing-source
+  "The lone `source-container` if it publishes
+  `re-frame.movement/IMovementWitness`, else nil. Resolved ONCE per cache
+  entry, at wrapper construction, so the hot path pays one closed-over
+  truthiness test and one pointer compare — never a protocol lookup on a
+  container that cannot answer.
+
+  nil is the answer for every source that is not an `rf=`-gated derived
+  container, and that is the mechanism (not a courtesy) by which
+  `:frame-state` keeps its genuine flush-path memo hit: its source is the
+  frame's ONE physical container — a `cljs.core/Atom` under the React-hook
+  spine, an `r/atom` under Reagent — whose fan-out is not movement-gated
+  and which therefore cannot implement the protocol. With nil here the
+  guard expression below is byte-for-byte the one that shipped. Reagent /
+  reagent-slim `Reaction`s, the plain-atom derived value (JVM and CLJS) and
+  test-react's derived value likewise answer nil, so those substrates see
+  no behavioural change at all — two extra pointer compares per recompute,
+  zero allocation.
+
+  Nil-tolerant: the parametric input-error recovery path constructs no
+  fixed-arity-1 wrapper, but a caller with no resolved source may pass nil
+  and simply forgoes the short-circuit."
+  [source-container]
+  (when (and (some? source-container)
+             (satisfies? movement/IMovementWitness source-container))
+    source-container))
+
 ;; ---- memoisation wrappers ------------------------------------------------
 
 (defn make-layer-1-memoised-body
@@ -504,14 +569,29 @@
   every call without touching the memo cells.
 
   The `::unset` sentinel guarantees the first invocation always
-  recomputes (the sentinel is never `=` to any db value)."
-  [body-fn query-id query-v frame-id sub-meta]
+  recomputes (the sentinel is never `=` to any db value).
+
+  `source-container` is the reaction's LONE signal source (the app-db /
+  runtime-db projection, or the whole frame-state container). It is used
+  for one thing: to resolve the movement witness once at construction — see
+  §The movement-witness short-circuit above. Pre-alpha posture, so it is a
+  plain positional parameter with no compatibility arity."
+  [body-fn query-id query-v frame-id sub-meta source-container]
   (let [last-db     (volatile! ::unset)
         last-result (volatile! nil)
-        sub-scope   (trace/handler-scope-from-meta :sub query-id sub-meta)]
+        sub-scope   (trace/handler-scope-from-meta :sub query-id sub-meta)
+        witness-src (witnessing-source source-container)]
     (fn [db]
       (when body-fn
-        (if (= @last-db db)
+        ;; `seen` is read once — the recompute branch below wants the same
+        ;; value, and re-`deref`ing a volatile nothing has written in
+        ;; between only costs field reads.
+        (if (let [seen @last-db]
+              (and (not (identical? (if witness-src
+                                      (movement/-moved-from witness-src)
+                                      movement/no-witness)
+                                    seen))
+                   (= seen db)))
           ;; Memo hit — input value-equal to last-seen, the user body
           ;; does NOT re-run. Emit `:rf.sub/skip` so tools
           ;; can show the "considered, no recompute" branch of the
@@ -563,14 +643,25 @@
   `validate-and-trace` receives `in-vals` as a singleton list — the
   same shape the varargs wrapper would have produced for arity-1 —
   preserving the `(body-fn (first in-vals) query-v)` invocation path
-  inside the validate/trace bracket."
-  [body-fn query-id query-v frame-id input-signals sub-meta]
+  inside the validate/trace bracket.
+
+  `source-container` is the reaction's LONE signal source — here the
+  upstream sub's own derived container — used only to resolve the movement
+  witness once at construction (§The movement-witness short-circuit above).
+  Pre-alpha posture: a plain positional parameter, no compatibility arity."
+  [body-fn query-id query-v frame-id input-signals sub-meta source-container]
   (let [last-v0     (volatile! ::unset)
         last-result (volatile! nil)
-        sub-scope   (trace/handler-scope-from-meta :sub query-id sub-meta)]
+        sub-scope   (trace/handler-scope-from-meta :sub query-id sub-meta)
+        witness-src (witnessing-source source-container)]
     (fn [v0]
       (when body-fn
-        (if (= @last-v0 v0)
+        (if (let [seen @last-v0]
+              (and (not (identical? (if witness-src
+                                      (movement/-moved-from witness-src)
+                                      movement/no-witness)
+                                    seen))
+                   (= seen v0)))
           ;; Memo hit — see `make-layer-1-memoised-body` for the
           ;; `:rf.sub/skip` rationale. `:input-paths-unchanged`
           ;; carries the upstream sub query-vector(s) whose values were

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -12,7 +12,9 @@
     * `make-derived-value` (one watch per source, coalesced through a
       shared per-adapter epoch scheduler so a multi-input derived value
       recomputes glitch-free and notifies once per coherent input epoch;
-      reifies the re-frame-owned `re-frame.disposable/IDisposable`).
+      reifies the re-frame-owned `re-frame.disposable/IDisposable`, and —
+      because its fan-out is `rf=`-gated — the optional re-frame-owned
+      `re-frame.movement/IMovementWitness`).
     * React 18+ root renderer (createRoot + render, hydrateRoot for
       hydrate).
     * Late-bind hiccup-emitter atom + `render-to-string` thrower.
@@ -43,6 +45,7 @@
             [re-frame.frame      :as frame]
             [re-frame.interop    :as interop]
             [re-frame.late-bind  :as late-bind]
+            [re-frame.movement   :as movement]
             [re-frame.subs       :as subs]
             [re-frame.trace      :as trace]
             [re-frame.substrate.adapter :as substrate-adapter]
@@ -646,6 +649,44 @@
           ;; loop, never escapes this closure — `volatile!` is the right
           ;; primitive (matches `prev-state` / `dirty?` above).
           disposed?      (volatile! false)
+          ;; The MOVEMENT WITNESS this container publishes (rf2-gncxk.1) —
+          ;; the value its most recent COMPLETED movement departed FROM, or
+          ;; `movement/no-witness` when it cannot presently answer. Read by
+          ;; `re-frame.subs.memo`'s fixed-arity-1 wrappers to skip a
+          ;; structural `=` walk whose answer the witness already
+          ;; determines; see `re-frame.movement` for the protocol, its two
+          ;; implementor obligations, and the proof.
+          ;;
+          ;; Written in exactly two places, both of which already exist:
+          ;;
+          ;;   W2 SOUNDNESS — armed inside `notify`'s `rf=` gate, which is
+          ;;     precisely the instant movement is ESTABLISHED: `prev-state`
+          ;;     already holds `nu` (flush! writes it before notifying), and
+          ;;     the gate has just proven `(not (rf= prev nu))`.
+          ;;   W1 FRESHNESS — cleared on `mark-dirty!`'s 0->1 transition.
+          ;;     This container is PULL-based (`deref-derived` recomputes on
+          ;;     every `-deref`), so once an input change is observed its
+          ;;     live value may run ahead of its last notify and it must
+          ;;     stop answering. `flush!` clears `dirty?` BEFORE it
+          ;;     recomputes and notifies, so the witness re-arms in the
+          ;;     right order with no extra bookkeeping.
+          ;;
+          ;; W1 is stated in terms of an OBSERVED input change, which is
+          ;; what a watch-driven container can honour: a source's own write
+          ;; lands a tick before this container's `mark-dirty!` runs, and
+          ;; nothing on the single-threaded event loop is interposed there
+          ;; (a CLJS `reset!` sets the state and immediately fans its
+          ;; watches out; the raw-atom coordinator marks every dependent
+          ;; before the enclosing epoch closes).
+          ;;
+          ;; MEMORY, the one real cost: this retains ONE predecessor derived
+          ;; value per derived container while the container is clean. For
+          ;; the app-db projection that is one extra app-db generation held
+          ;; between writes — and structural sharing means the true delta is
+          ;; only the nodes the last write replaced. Not a new class of
+          ;; retention: every layer-1 memo cell already holds a full app-db
+          ;; in its `last-db`.
+          last-moved-from (volatile! movement/no-witness)
           ;; Movement-gated, failure-contained fan-out (rf2-vxgfnd.203).
           ;; Two disciplines at this one boundary:
           ;;
@@ -687,6 +728,14 @@
           ;;      the capture volatile + `run!` closure.
           notify         (fn [prev nu]
                            (when-not (rf= prev nu)
+                             ;; W2 — record the departure at the exact instant
+                             ;; movement is established, BEFORE fan-out, so a
+                             ;; subscriber that reads this container from
+                             ;; inside the fan-out already sees the armed
+                             ;; witness (rf2-gncxk.1). One volatile write; no
+                             ;; allocation; on the no-move path (the gate
+                             ;; above) not reached at all.
+                             (vreset! last-moved-from prev)
                              (let [ws @watchers]
                                (case (count ws)
                                  0 nil
@@ -796,6 +845,13 @@
           mark-dirty!    (fn mark-dirty! []
                            (when-not @dirty?
                              (vreset! dirty? true)
+                             ;; W1 — an input change has been observed, so
+                             ;; this container's live value may now run ahead
+                             ;; of its last completed movement. Stop
+                             ;; answering until the next `notify` re-arms
+                             ;; (rf2-gncxk.1). Inside the 0->1 branch, so a
+                             ;; re-mark within the same epoch costs nothing.
+                             (vreset! last-moved-from movement/no-witness)
                              (schedule-flush! scheduler flush!)))]
       ;; Wire this derived value to each source so a source change MARKS it
       ;; dirty — the actual recompute + notify is deferred to the scheduler
@@ -855,6 +911,19 @@
         (-remove-watch [_this k]
           (swap! watchers dissoc k)
           nil)
+        ;; Re-frame-owned OPTIONAL movement witness (rf2-gncxk.1). This
+        ;; container gates its own propagation on `rf=` (see `notify`
+        ;; above), which is exactly the precondition `re-frame.movement`'s
+        ;; W2 requires, so it can publish. A raw `cljs.core/Atom` source, a
+        ;; Reagent `Reaction`, the plain-atom derived value and test-react's
+        ;; derived value all publish NOTHING — and that is the correct
+        ;; answer for them, not an omission: their propagation is not
+        ;; `rf=`-gated (the raw-atom coordinator fans out on every `reset!`)
+        ;; or they have no notify step at all. Consumers resolve the
+        ;; capability once, by `satisfies?`, and fall back to the
+        ;; comparison they would have made anyway.
+        movement/IMovementWitness
+        (-moved-from [_] @last-moved-from)
         ;; Re-frame-owned IDisposable — `interop/add-on-dispose!` /
         ;; `interop/dispose!` route into this protocol via the
         ;; adapter's `:adapter/add-on-dispose!` / `:adapter/dispose!`
@@ -878,6 +947,13 @@
               (release-source-wire! scheduler s k))
             (reset! own-keys [])
             (reset! watchers {})
+            ;; Stop witnessing and RELEASE the retained predecessor value
+            ;; (rf2-gncxk.1). A disposed container answers `no-witness`
+            ;; forever, which is both correct (it will never complete
+            ;; another movement) and the hygienic answer — the one extra
+            ;; generation it held is dropped here rather than pinned for
+            ;; the lifetime of whatever still references the reify.
+            (vreset! last-moved-from movement/no-witness)
             ;; Snapshot-and-clear callbacks before firing: a callback that
             ;; re-enters `interop/dispose!` on this same object hits the
             ;; guard above (no-op) and never sees the callbacks again, so

--- a/implementation/core/test/re_frame/bench/write_attribution.cljs
+++ b/implementation/core/test/re_frame/bench/write_attribution.cljs
@@ -138,6 +138,11 @@
               partition projections recomputing and fanning out
     RFWRITE-N + N held layer-1 subscriptions, each with one watcher, the
               shape a mounted application has
+    FSWRITE-N the SAME write against a frame holding N `:frame-state` subs
+              instead — the same fixed-arity-1 memo wrapper, but reading the
+              frame's RAW physical container rather than the `rf=`-gated
+              app-db projection. It is the control for `RFWRITE-N`
+              (rf2-gncxk.1)
 
   `RFWRITE-N` is measured at four values of N and the SLOPE between them is
   the per-subscription cost — the number the bead is about. A slope cancels
@@ -154,6 +159,9 @@
     P-BODY    the user's sub body — `(get-in db [:cells k])`
     P-EQDB    the memo wrapper's guard — `(= last-db db)` against the REAL
               app-db value, which is what decides whether the body runs
+    P-EQDBF   the same guard at the OTHER input that reaches it — two
+              `=`-but-not-`identical?` app-db values, where the walk runs to
+              completion and finds no difference (rf2-gncxk.1)
     P-SCOPE   `trace/with-handler-scope` + `handler-scope-from-meta`, which
               bracket every recompute and are NOT dev-gated
     P-EMIT    `trace/emit!` on its production path with the tag map the
@@ -161,6 +169,18 @@
     P-MEMO    the whole shipped memo wrapper
               (`subs.memo/make-layer-1-memoised-body`) invoked with a
               CHANGED db — the sum of the four above plus its own frame
+    P-MEMOW   the same wrapper over a source that publishes a MOVEMENT
+              WITNESS, driven in the flush-path shape, so the guard's `=`
+              walk is proved unnecessary and skipped (rf2-gncxk.1)
+    P-MEMOWC  its matched control — identical scaffolding, identical inputs,
+              a source that publishes nothing. `P-MEMOWC − P-MEMOW` is the
+              `=` term and nothing else
+    P-MEMOF   the same wrapper over a RAW ATOM source (the `:frame-state`
+              shape) at an `=`-but-not-`identical?` db: the memo HIT the
+              witness must NOT be allowed to touch
+    P-MEMOFI  its matched control — the same wrapper objects at an
+              `identical?` db, where `=` short-circuits and walks nothing.
+              `P-MEMOF − P-MEMOFI` is the `=` walk still being paid
     Q-SCHED   the epoch scheduler's queue bookkeeping in its RETIRED
               spelling — N `conj` onto a PersistentHashSet + a
               PersistentVector, then N `disj` as the drain consumes them
@@ -433,6 +453,16 @@
 (defonce ^:private rig (volatile! nil))
 (defonce ^:private gen (volatile! 1000))
 
+;; rf2-gncxk.1 — one flip cell per movement-witness arm. These arms need their
+;; input to ALTERNATE strictly, because their whole shape is "the value the
+;; wrappers last saw is the value the source just departed from"; handing an
+;; arm the same value twice would put it on the memo-HIT branch and measure
+;; something else. The shared `gen` cannot promise that (a neighbouring arm may
+;; leave it advanced by an odd count between windows), so each arm flips its
+;; own boolean. `not` on a boolean allocates nothing.
+(defonce ^:private w-flip  (volatile! false))
+(defonce ^:private wc-flip (volatile! false))
+
 (defn- next-gen! [] (vswap! gen inc))
 
 (def ^:private fid
@@ -487,6 +517,26 @@
   [k]
   (let [{:keys [cells-n frames]} @rig
         f (nth frames k)
+        v (next-gen!)
+        i (mod v cells-n)]
+    (frame/replace-app-db! f (update (frame/frame-app-db-value f) :cells assoc i v))
+    nil))
+
+(defn- arm-fswrite
+  "rf2-gncxk.1 — the SAME write as `arm-rfwrite`, against a frame whose held
+  subscriptions are `:frame-state` subs instead of `:db` subs.
+
+  Both kinds route to `subs.memo`'s fixed-arity-1 wrapper, but they differ in
+  the ONE fact the movement witness keys on: a `:db` sub's source is the
+  app-db PROJECTION (a derived container whose fan-out is `rf=`-gated, so it
+  publishes a witness), while a `:frame-state` sub's source is the frame's ONE
+  physical container — a raw atom, which cannot. So this ladder's slope must be
+  UNCHANGED by the witness while the `RFWRITE-N` slope falls by the `=` term,
+  and the pair of slopes is the ladder-level statement of the same two-sided
+  claim the `P-MEMOW` / `P-MEMOF` arms make at the wrapper level."
+  [k]
+  (let [{:keys [cells-n fs-frames]} @rig
+        f (nth fs-frames k)
         v (next-gen!)
         i (mod v cells-n)]
     (frame/replace-app-db! f (update (frame/frame-app-db-value f) :cells assoc i v))
@@ -878,6 +928,99 @@
     (next-gen!)
     nil))
 
+;; ---- rf2-gncxk.1 — the MOVEMENT WITNESS, both halves ----------------------
+;;
+;; `P-EQDB` above prices the memo wrapper's `(= last-db db)` guard at 147.0
+;; B/sub, and rf2-gncxk.1 retires it — but only where it is provably wasted.
+;; The guard is NOT dead code: the spine's derived value is pull-based, so it
+;; is the only thing stopping a render from re-running every sub body, and on
+;; a `:frame-state` sub it genuinely HITS on the flush path. So the change is
+;; two-sided by construction, and so is the measurement. Neither half is
+;; optional; a one-sided result does not discharge the claim.
+;;
+;; THE `:db` HALF — a strict paired control, the `RC-ATTACH` / `RC-CAND`
+;; discipline. Two arms, identical in every respect but ONE:
+;;
+;;   P-MEMOW   the shipped wrapper over a WITNESSING source — a real spine
+;;             derived container, which publishes
+;;             `re-frame.movement/IMovementWitness` because its fan-out is
+;;             `rf=`-gated — driven in the FLUSH-PATH shape.
+;;   P-MEMOWC  the shipped wrapper over the RAW ATOM under that same derived
+;;             container, so `witness-src` resolves nil and the guard
+;;             expression is byte-for-byte the one that shipped.
+;;
+;; Both arms move their source once per call and then invoke 300 wrappers, so
+;; the scaffolding — one `replace-container!`, one epoch, one drain, one
+;; recompute-and-notify — is IDENTICAL and cancels in the difference.
+;; `P-MEMOWC − P-MEMOW` is therefore the `=` term and nothing else, and it
+;; must equal `P-EQDB`. `P-MEMOWC` is separately checked against `P-MEMO` to
+;; show the scaffolding is not carrying the result.
+;;
+;; The flush-path shape is set up rather than simulated. Each call moves the
+;; source to `cur`, which arms its witness with `prev` — the very object the
+;; 300 wrappers each hold in `last-db` from the previous call — and then hands
+;; every wrapper `cur`. `(identical? (-moved-from S) @last-db)` is exactly the
+;; precondition the proof needs, and the wrapper then recomputes without
+;; walking. Each arm alternates on its OWN flip cell rather than the shared
+;; `gen`, so a neighbouring arm's odd call count cannot silently hand it the
+;; same value twice and put it on the memo-hit branch instead.
+;;
+;; THE `:frame-state` HALF — the same wrapper, over a RAW ATOM (which is what
+;; `subs/single-source-container-for` maps `:frame-state` to: the frame's ONE
+;; physical container, whose fan-out is not movement-gated and which therefore
+;; cannot implement the protocol). Two arms over the SAME wrapper objects,
+;; both landing on the memo-HIT branch — the real `:frame-state` flush-path
+;; shape, the one PR #7233 pins — differing only in the identity of the
+;; argument:
+;;
+;;   P-MEMOF   invoked with an `=`-but-NOT-`identical?` db, so `=` walks the
+;;             whole structure and finds no difference.
+;;   P-MEMOFI  invoked with the IDENTICAL db object, so `=` short-circuits on
+;;             `identical?` and walks nothing.
+;;
+;; `P-MEMOF − P-MEMOFI` is the full `=` walk at that input, and it must equal
+;; `P-EQDBF` — the bare `(= db-a db-a2)` measured on its own. That is the
+;; "still paid where it earns its keep" half, and it is a genuine pair: same
+;; wrapper set, same source, same memo cells, one object identity different.
+;; (Both arms take the hit branch, so neither mutates `last-db` — the pairing
+;; is stable across any number of calls in any order.)
+
+(defn- arm-p-eqdb-f []
+  (let [{:keys [n db-a db-a2]} @rig]
+    (dotimes [_ n]
+      (keep! (= db-a db-a2)))))
+
+(defn- arm-p-memo-w []
+  (let [{:keys [n memos-w w-src db-a db-b]} @rig
+        cur (if (vswap! w-flip not) db-a db-b)]
+    ;; Move the witnessing source: `notify`'s `rf=` gate arms its witness
+    ;; with the value the 300 wrappers below each hold in `last-db`.
+    (adapter/replace-container! w-src cur)
+    (dotimes [k n]
+      (keep! ((nth memos-w k) cur)))
+    nil))
+
+(defn- arm-p-memo-wc []
+  (let [{:keys [n memos-wc wc-src db-a db-b]} @rig
+        cur (if (vswap! wc-flip not) db-a db-b)]
+    ;; Byte-for-byte `arm-p-memo-w`'s scaffolding — the same container shape
+    ;; carrying the same lone derived dependent — so the only thing left in
+    ;; the difference is whether the wrapper's source publishes a witness.
+    (adapter/replace-container! wc-src cur)
+    (dotimes [k n]
+      (keep! ((nth memos-wc k) cur)))
+    nil))
+
+(defn- arm-p-memo-f []
+  (let [{:keys [n memos-f db-a2]} @rig]
+    (dotimes [k n]
+      (keep! ((nth memos-f k) db-a2)))))
+
+(defn- arm-p-memo-fi []
+  (let [{:keys [n memos-f db-a]} @rig]
+    (dotimes [k n]
+      (keep! ((nth memos-f k) db-a)))))
+
 ;; The scheduler's queue bookkeeping, in BOTH spellings, in one process on the
 ;; same 300 thunks — the paired-control discipline `read-attribution`'s
 ;; `RC-ATTACH` / `RC-CAND` established. `Q-SCHED` is the RETIRED form (a
@@ -1028,6 +1171,18 @@
       (if coords?
         (rf/reg-sub qid prod-sub-meta body)
         (rf/reg-sub qid body))))
+  ;; rf2-gncxk.1 — the `:frame-state` ladder's subs. Same fixed-arity-1 memo
+  ;; wrapper as the `:db` ladder's, same registration shape; the ONE difference
+  ;; is the signal source the reactive build resolves — the frame's raw
+  ;; physical container rather than the `rf=`-gated app-db projection. That is
+  ;; the fact the movement witness keys on, so this ladder's slope is the
+  ;; control for the `RFWRITE-N` ladder's.
+  (doseq [i (range cells-n)]
+    (let [body (fn [fs _] (get-in fs [frame/app-partition-key :cells i]))
+          qid  (keyword "wa" (str "fscell" i))]
+      (if coords?
+        (subs/reg-frame-state-sub qid prod-sub-meta body)
+        (subs/reg-frame-state-sub qid body))))
   (let [qids  (mapv #(keyword "wa" (str "cell" %)) (range cells-n))
         qvs   (mapv vector qids)
         ;; One frame per subscription count, each with its OWN held
@@ -1055,8 +1210,35 @@
                                    r))
                                (subvec qvs 0 cnt))))
                      frames ns-per-frame)
+        ;; rf2-gncxk.1 — the `:frame-state` ladder: one frame per subscription
+        ;; count, each holding `cnt` `:frame-state` subs, wired exactly as the
+        ;; `:db` ladder's frames are (one watcher per reaction, one deref to
+        ;; establish the memo baseline). Written by `arm-fswrite` with the same
+        ;; narrow `assoc`-one-cell write.
+        fs-qvs (mapv (fn [i] [(keyword "wa" (str "fscell" i))]) (range cells-n))
+        fs-frames (mapv (fn [k]
+                          (let [f (keyword "wa" (str "fsframe" k))]
+                            (live-frame/make-frame {:id f})
+                            (frame/replace-app-db! f (db-of cells-n 0))
+                            f))
+                        (range (count ns-per-frame)))
+        fs-holds (mapv (fn [f cnt]
+                         (binding [frame/*current-frame* f]
+                           (mapv (fn [q]
+                                   (let [r (subs/subscribe q)]
+                                     (adapter/subscribe-container r (fn [_ _] nil))
+                                     (deref r)
+                                     r))
+                                 (subvec fs-qvs 0 cnt))))
+                       fs-frames ns-per-frame)
         db-a  (db-of cells-n 7)
         db-b  (update (db-of cells-n 7) :cells assoc (dec cells-n) 8)
+        ;; rf2-gncxk.1 — a FRESH map `=` to `db-a` but not `identical?` to it:
+        ;; the input at which the `=` walk runs to completion and finds no
+        ;; difference. That is the `:frame-state` flush-path shape PR #7233
+        ;; pins — a value-equal commit that reaches the wrapper and memo-HITS —
+        ;; and `P-EQDBF` / `P-MEMOF` / `P-MEMOFI` are all priced at it.
+        db-a2 (db-of cells-n 7)
         ;; rf2-78ejq — the two frame-state values a commit alternates between,
         ;; PRE-BUILT so the SPINE0B / SPINE0P arms measure the container write
         ;; and the projections alone, with no value construction folded in.
@@ -1069,7 +1251,51 @@
         bare-fs-container (adapter/make-state-container fs-a)
         proj-fs-container (adapter/make-state-container fs-a)
         _proj (mapv (fn [k] (adapter/make-derived-value [proj-fs-container] k))
-                    [frame/app-partition-key frame/runtime-partition-key])]
+                    [frame/app-partition-key frame/runtime-partition-key])
+        ;; rf2-gncxk.1 — the movement-witness pair's rigs. TWO structurally
+        ;; identical stacks (a raw container carrying one derived dependent),
+        ;; differing only in which of the two the 300 memo wrappers are handed
+        ;; as their lone source:
+        ;;
+        ;;   w-*   wrappers over the DERIVED container, which publishes
+        ;;         `IMovementWitness` (its fan-out is `rf=`-gated)
+        ;;   wc-*  wrappers over the RAW container underneath it, which cannot
+        ;;
+        ;; so `P-MEMOWC − P-MEMOW` isolates the guard and nothing else.
+        w-src      (adapter/make-state-container db-a)
+        w-derived  (adapter/make-derived-value [w-src] identity)
+        wc-src     (adapter/make-state-container db-a)
+        wc-derived (adapter/make-derived-value [wc-src] identity)
+        ;; The `:frame-state` half's source: a raw container, exactly what
+        ;; `subs/single-source-container-for` hands a `:frame-state` sub.
+        f-src      (adapter/make-state-container db-a)
+        mk-memos   (fn [source]
+                     (mapv (fn [i]
+                             (subs-memo/make-layer-1-memoised-body
+                               (fn [db _] (get-in db [:cells i]))
+                               (nth qids i) (nth qvs i) fid {} source))
+                           (range n)))
+        memos-w    (mk-memos w-derived)
+        memos-wc   (mk-memos wc-src)
+        memos-f    (mk-memos f-src)]
+    ;; Seed each derived container's baseline BEFORE moving it, so the first
+    ;; movement's `notify` arms the witness with a REAL predecessor rather than
+    ;; the spine's construction sentinel.
+    (deref w-derived)
+    (deref wc-derived)
+    ;; Put both stacks — and every wrapper over them — into the state the
+    ;; measured arms assume on entry: source at `db-b`, `last-db` at `db-b`.
+    ;; `w-flip` / `wc-flip` start false, so the first measured call flips to
+    ;; true and drives `db-b -> db-a`, arming the witness with the very object
+    ;; the wrappers hold.
+    (adapter/replace-container! w-src db-b)
+    (adapter/replace-container! wc-src db-b)
+    (dotimes [k n]
+      ((nth memos-w k) db-b)
+      ((nth memos-wc k) db-b)
+      ;; `memos-f` is primed at `db-a` and never moves off it: both of its arms
+      ;; take the memo-HIT branch, which does not write `last-db`.
+      ((nth memos-f k) db-a))
     (vreset! rig
              {:n        n
               :cells-n  cells-n
@@ -1077,11 +1303,24 @@
               :qvs      qvs
               :frames   frames
               :holds    holds
+              ;; rf2-gncxk.1 — the `:frame-state` ladder
+              :fs-frames fs-frames
+              :fs-holds  fs-holds
               :db-cell  (atom (db-of cells-n 0))
               :bare     (atom (db-of cells-n 0))
               :spine-container (adapter/make-state-container (db-of cells-n 0))
               :db-a     db-a
               :db-b     db-b
+              ;; rf2-gncxk.1 — the movement-witness pair
+              :db-a2      db-a2
+              :w-src      w-src
+              :w-derived  w-derived
+              :wc-src     wc-src
+              :wc-derived wc-derived
+              :f-src      f-src
+              :memos-w    memos-w
+              :memos-wc   memos-wc
+              :memos-f    memos-f
               :fs-a     fs-a
               :fs-b     fs-b
               :bare-fs-container bare-fs-container
@@ -1096,12 +1335,12 @@
                                   qids)
               :parent-scope (trace/handler-scope-from-meta
                               :event :wa/parent prod-sub-meta)
-              ;; the shipped memo wrapper, one per subscription
-              :memos    (mapv (fn [i]
-                                (subs-memo/make-layer-1-memoised-body
-                                  (fn [db _] (get-in db [:cells i]))
-                                  (nth qids i) (nth qvs i) fid {}))
-                              (range n))
+              ;; the shipped memo wrapper, one per subscription. The trailing
+              ;; source is the RAW container (rf2-gncxk.1) — a source that
+              ;; publishes no movement witness, so `P-MEMO` keeps measuring
+              ;; exactly the expression it always measured, its published
+              ;; figure intact and comparable.
+              :memos    (mk-memos f-src)
               ;; distinct fn identities, the way the scheduler's queue holds
               ;; one flush thunk per dirty derived value
               :thunks    (mapv (fn [i] (fn [] i)) (range n))
@@ -1238,8 +1477,21 @@
                               (fn [k cnt]
                                 [(str "RFWRITE-" cnt) (fn [] (arm-rfwrite k)) 1])
                               ns-per-frame))
+                 ;; rf2-gncxk.1 — the same ladder over `:frame-state` subs,
+                 ;; whose source cannot publish a movement witness. Its slope
+                 ;; is the control for `RFWRITE-N`'s.
+                 true (into (map-indexed
+                              (fn [k cnt]
+                                [(str "FSWRITE-" cnt) (fn [] (arm-fswrite k)) 1])
+                              ns-per-frame))
                  true (into [["P-BODY"  arm-p-body  n]
                              ["P-EQDB"  arm-p-eqdb  n]
+                             ;; rf2-gncxk.1 paired controls, both halves
+                             ["P-EQDBF"   arm-p-eqdb-f   n]
+                             ["P-MEMOW"   arm-p-memo-w   n]
+                             ["P-MEMOWC"  arm-p-memo-wc  n]
+                             ["P-MEMOF"   arm-p-memo-f   n]
+                             ["P-MEMOFI"  arm-p-memo-fi  n]
                              ["P-SCOPE" arm-p-scope n]
                              ;; rf2-zxv06 paired controls
                              ["P-SCOPEM"  arm-p-scope-m n]
@@ -1391,15 +1643,23 @@
         (println (gstring/format ";;   %-46s %10s B"
                          (str "RFWRITE-" cnt "  frame/replace-app-db!, " cnt " subs")
                          (fmt (b (str "RFWRITE-" cnt))))))
+      (doseq [cnt ns-per-frame]
+        (println (gstring/format ";;   %-46s %10s B"
+                         (str "FSWRITE-" cnt "  same write, " cnt " :frame-state subs")
+                         (fmt (b (str "FSWRITE-" cnt))))))
       (println ";;")
       (let [lo (first ns-per-frame) hi (last ns-per-frame)
-            slope (/ (- (b (str "RFWRITE-" hi)) (b (str "RFWRITE-" lo))) (- hi lo))]
-        (println (gstring/format ";;   PER-SUBSCRIPTION SLOPE  %s B / sub / write" (fmt slope)))
+            slope (/ (- (b (str "RFWRITE-" hi)) (b (str "RFWRITE-" lo))) (- hi lo))
+            fs-slope (/ (- (b (str "FSWRITE-" hi)) (b (str "FSWRITE-" lo))) (- hi lo))]
+        (println (gstring/format ";;   PER-SUBSCRIPTION SLOPE  %s B / sub / write   (:db subs)" (fmt slope)))
+        (println (gstring/format ";;   PER-SUBSCRIPTION SLOPE  %s B / sub / write   (:frame-state subs — rf2-gncxk.1 control)"
+                         (fmt fs-slope)))
         (println ";;")
         (println ";; WHERE THE PER-SUBSCRIPTION BYTES GO (each arm × n, reported per sub)")
         (println ";;   P-SCOPE is the COORD-LESS control; P-SCOPEM is the production shape")
-        (doseq [l ["P-BODY" "P-EQDB" "P-SCOPE" "P-SCOPEM" "P-SCOPEH" "P-INHER" "P-INHERH"
-                   "P-EMIT" "P-MEMO" "Q-SCHED" "Q-SCHEDJS" "P-VALS" "P-RKV"]]
+        (doseq [l ["P-BODY" "P-EQDB" "P-EQDBF" "P-SCOPE" "P-SCOPEM" "P-SCOPEH" "P-INHER" "P-INHERH"
+                   "P-EMIT" "P-MEMO" "P-MEMOW" "P-MEMOWC" "P-MEMOF" "P-MEMOFI"
+                   "Q-SCHED" "Q-SCHEDJS" "P-VALS" "P-RKV"]]
           (let [v (/ (b l) n)]
             (println (gstring/format ";;   %-10s %10s B/sub   %5.1f%% of the slope"
                              l (fmt v) (* 100.0 (/ v slope))))))
@@ -1421,7 +1681,34 @@
                    ";;   P-INHERH (shipped inherit)      %10s B/sub" (fmt (/ (b "P-INHERH") n))))
         (println (gstring/format
                    ";;   -> inherit predicts             %10s B/sub saved  (ONLY under a bound parent — a real app's write; NOT visible in the ladder above)"
-                   (fmt (/ (- (b "P-INHER") (b "P-INHERH")) n)))))
+                   (fmt (/ (- (b "P-INHER") (b "P-INHERH")) n))))
+        ;; rf2-gncxk.1 — BOTH halves, quoted as the two paired differences the
+        ;; change stands or falls on. Neither is optional: the first says the
+        ;; `=` term is GONE where the source publishes a movement witness, the
+        ;; second says it is STILL PAID where it does not — which is the
+        ;; `:frame-state` shape PR #7233 pins.
+        (println ";;")
+        (println ";; rf2-gncxk.1 — THE MOVEMENT WITNESS, PAIRED, BOTH HALVES")
+        (println ";;   [:db half] same wrapper, same inputs, same scaffolding; witnessing vs not")
+        (println (gstring/format
+                   ";;   P-MEMOWC (raw-atom source, no witness) %10s B/sub" (fmt (/ (b "P-MEMOWC") n))))
+        (println (gstring/format
+                   ";;   P-MEMOW  (witnessing source, proof fires) %7s B/sub" (fmt (/ (b "P-MEMOW") n))))
+        (println (gstring/format
+                   ";;   -> witness retires                     %10s B/sub   (must equal P-EQDB %s)"
+                   (fmt (/ (- (b "P-MEMOWC") (b "P-MEMOW")) n)) (fmt (/ (b "P-EQDB") n))))
+        (println (gstring/format
+                   ";;   (cross-check) P-MEMO                   %10s B/sub   — P-MEMOWC's scaffolding is not carrying the result"
+                   (fmt (/ (b "P-MEMO") n))))
+        (println ";;   [:frame-state half] same wrapper objects, same source, same memo cells;")
+        (println ";;     only the ARGUMENT's identity differs — both land on the memo-HIT branch")
+        (println (gstring/format
+                   ";;   P-MEMOF  (=-but-not-identical? db)     %10s B/sub" (fmt (/ (b "P-MEMOF") n))))
+        (println (gstring/format
+                   ";;   P-MEMOFI (identical? db, = short-circuits) %6s B/sub" (fmt (/ (b "P-MEMOFI") n))))
+        (println (gstring/format
+                   ";;   -> = walk STILL PAID                   %10s B/sub   (must equal P-EQDBF %s)"
+                   (fmt (/ (- (b "P-MEMOF") (b "P-MEMOFI")) n)) (fmt (/ (b "P-EQDBF") n)))))
       (println ";;")
       (println ";; rf2-78ejq — WHERE RFWRITE-0's CONSTANT GOES")
       (let [rf0    (b "RFWRITE-0")

--- a/implementation/core/test/re_frame/movement_witness_cljs_test.cljs
+++ b/implementation/core/test/re_frame/movement_witness_cljs_test.cljs
@@ -1,0 +1,132 @@
+(ns re-frame.movement-witness-cljs-test
+  "rf2-gncxk.1 — the `re-frame.movement/IMovementWitness` contract, pinned on
+  the ONE implementor in this repo: the React-hook spine's derived container.
+
+  Spec 006 §Movement witness (optional) states three obligations. Two bind an
+  implementor and are what these tests pin:
+
+    W1 FRESHNESS  answer `no-witness` unless the container's own value has
+                  completed a movement AND no input change has been observed
+                  since. Without it, a PULL-based container's live value can
+                  run ahead of its last movement.
+    W2 SOUNDNESS  whenever it answers `f` other than `no-witness`, reading the
+                  container at that instant yields `v` with `(not (rf= f v))`
+                  — and therefore `(not (= f v))`.
+
+  The third (C1, verdict-preserving) binds the CONSUMER, and its pins live
+  where the consumer does: `sub_memo_flush_path_cljs_test.cljs` (both arms),
+  `sub_memo_layer_1_test.clj`, and the body-run counts asserted throughout the
+  subscription suite.
+
+  Also pinned here: the structural fact `:frame-state` depends on. A raw
+  physical container does NOT implement the protocol, so
+  `subs.memo`'s `witness-src` resolves nil for a `:frame-state` sub and its
+  guard expression is byte-for-byte the one that shipped. That is a property
+  of the container, not a courtesy of the consumer, and it is what keeps the
+  `:frame-state` flush-path memo hit alive.
+
+  ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.disposable :as rf-disposable]
+            [re-frame.movement :as movement]
+            [re-frame.substrate.spine :as spine]))
+
+;; A bare spine adapter — nothing is mounted and no frame is registered; these
+;; tests drive `make-state-container` / `make-derived-value` /
+;; `replace-container!` directly, which is the whole surface under test.
+(def ^:private adapter
+  (spine/make-react-adapter
+    (spine/make-react-spine
+      {:substrate-name        "movement-witness"
+       :gensym-prefix-sub     "mw-sub-"
+       :gensym-prefix-derived "mw-derived-"
+       :gensym-prefix-use-sub "mw-use-sub-"
+       :use-memo              (fn [t _] (t))
+       :use-callback          (fn [t _] t)
+       :use-context           (fn [_] nil)})
+    {:kind :rf.adapter/movement-witness :frame-provider nil}))
+
+(defn- make-state-container [v] ((:make-state-container adapter) v))
+(defn- make-derived-value [sources f] ((:make-derived-value adapter) sources f))
+(defn- replace-container! [c v] ((:replace-container! adapter) c v))
+
+(deftest a-fresh-derived-container-answers-no-witness
+  (testing "W1 — nothing has moved yet, so there is no departure value to
+            publish and the container must say so"
+    (let [src     (make-state-container {:n 1})
+          derived (make-derived-value [src] :n)]
+      (is (satisfies? movement/IMovementWitness derived)
+          "the spine's derived container publishes the capability — its
+           fan-out is `rf=`-gated, which is W2's precondition")
+      (is (identical? movement/no-witness (movement/-moved-from derived))
+          "before any movement, `no-witness`")
+      ;; A deref establishes the baseline but is NOT a movement.
+      (is (= 1 @derived))
+      (is (identical? movement/no-witness (movement/-moved-from derived))
+          "a read is not a movement"))))
+
+(deftest a-completed-movement-publishes-its-departure-value
+  (testing "W2 — after a movement the witness is the value departed FROM, by
+            IDENTITY, and the live value is not `=` to it"
+    (let [v0      {:n 1}
+          src     (make-state-container v0)
+          derived (make-derived-value [src] identity)]
+      (is (= v0 @derived))                      ;; seed the baseline
+      (replace-container! src {:n 2})
+      (let [f (movement/-moved-from derived)]
+        (is (identical? v0 f)
+            "the witness IS the predecessor object — the consumer's whole
+             short-circuit is an `identical?` test against it")
+        (is (not (= f @derived))
+            "W2: reading the container yields a value that is not `=` to the
+             witness. This is the inference the memo wrapper skips its
+             structural walk on.")))))
+
+(deftest an-observed-input-change-retracts-the-witness
+  (testing "W1 — a no-move flush leaves the container silent. `mark-dirty!`
+            clears the witness on its 0->1 transition (the container's live
+            value may now run ahead of its last notify), and a `rf=`-equal
+            recompute does not re-arm it, so nothing stale is published."
+    (let [v0      {:n 1}
+          src     (make-state-container v0)
+          ;; The projection shape: a change to `:other` moves the SOURCE but
+          ;; leaves this derived value `rf=`-equal, so it must not notify.
+          derived (make-derived-value [src] :n)]
+      (is (= 1 @derived))
+      (replace-container! src {:n 2 :other :a})
+      (is (= 1 (movement/-moved-from derived))
+          "the real move arms the witness with the value DEPARTED FROM")
+      ;; A source change that leaves THIS container's value `rf=`-equal.
+      (replace-container! src {:n 2 :other :b})
+      (is (identical? movement/no-witness (movement/-moved-from derived))
+          "the input change was OBSERVED (mark-dirty) so the witness was
+           retracted, and the `rf=` gate then declined to re-arm it — the
+           container correctly publishes nothing rather than a stale claim")
+      (is (= 2 @derived) "and its value genuinely did not move"))))
+
+(deftest dispose-retracts-the-witness-and-releases-the-predecessor
+  (testing "hygiene + the one memory cost. A disposed container will never
+            complete another movement, so `no-witness` is the only correct
+            answer — and dropping the reference releases the single
+            predecessor generation the witness retained."
+    (let [v0      {:n 1}
+          src     (make-state-container v0)
+          derived (make-derived-value [src] identity)]
+      (is (= v0 @derived))
+      (replace-container! src {:n 2})
+      (is (identical? v0 (movement/-moved-from derived)))
+      (rf-disposable/-dispose derived)
+      (is (identical? movement/no-witness (movement/-moved-from derived))
+          "disposed containers stop answering, and the retained predecessor
+           is released with them"))))
+
+(deftest a-raw-physical-container-publishes-nothing
+  (testing "the STRUCTURAL fact `:frame-state` rests on. Its signal source is
+            the frame's one physical container, whose fan-out is not
+            movement-gated — so it cannot satisfy W2 and does not implement
+            the protocol. `subs.memo`'s `witness-src` is therefore nil there
+            and the guard is unchanged."
+    (let [src (make-state-container {:n 1})]
+      (is (not (satisfies? movement/IMovementWitness src))
+          "a raw base container publishes no witness — absence is the correct
+           answer for it, not an omission"))))

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -217,6 +217,23 @@ CLJS-Reagent: a Reagent `reaction` — memoising; re-runs only when an input der
 
 Together these make **frame construction** failure-atomic. The core acquires the `app-db` and `runtime-db` projections into locals, and if the second throws it `interop/dispose!`s the first in reverse acquisition order before re-raising the original error, so a frame that never installs strands no watch (the physical frame-state container is left to GC per [§`make-state-container`](#make-state-container-initial-value--container) above). In the reference adapters the obligation is met three ways: the React-hook spine (`re-frame.ui` / UIx) reifies the re-frame-owned `re-frame.disposable/IDisposable` and its `-dispose` removes every source watch; the Reagent family returns a disposable `Reaction`; and the plain-atom, SSR, and headless test adapters recompute on `read-container` and own no source watch to strand (the plain-atom value additionally reifies `IDisposable` to carry the sub-cache's on-dispose callbacks — [§Reference counting and disposal](#reference-counting-and-disposal)).
 
+#### Movement witness (optional)
+
+A derived container that gates its own propagation on `rf=` already knows something the core cannot cheaply re-derive: **the value its most recent completed movement departed from**. Such a container **MAY** publish that value through the re-frame-owned protocol `re-frame.movement/IMovementWitness`, whose single method `(-moved-from container)` answers either that departure value or the distinguished `re-frame.movement/no-witness` sentinel. Publishing is **optional** — the same posture this spec already takes for `:adapter/derived-container?` and `:adapter/activate-derived-value!` above — and a container that publishes nothing is not deficient. It is simply one a consumer cannot short-circuit, and the consumer's fall-back is the comparison it would have performed anyway. Absence is the correct answer for a container whose propagation is not `rf=`-gated at all, such as a raw base container fanning out on every write.
+
+Two obligations bind an implementor, and they are the whole normative content:
+
+- **(W1) Freshness.** Answer `no-witness` unless the container's own value has completed a movement **and** no input change has been observed since. Without W1 a *pull-based* container's live value can run ahead of its last movement — its sources changed, it has not yet recomputed and notified, and a witness from the previous movement would then say nothing true about what a `read-container` returns now.
+- **(W2) Soundness.** Whenever it answers some `f` other than `no-witness`, reading the container at that instant yields `v` with `(not (rf= f v))` — and therefore `(not (= f v))`, since `rf=` subsumes `=` ([§`rf=`](#rf--the-runtime-value-equality-relation)).
+
+And one binds a consumer:
+
+- **(C1) Verdict-preserving.** Use the witness **only** to skip a comparison whose answer it already determines, never to change an observable outcome. The set of verdicts a consumer reaches must be identical with and without the witness. This is a comparison *elimination*; a divergence in body-run counts or in the [Spec 009](009-Instrumentation.md#op-type-vocabulary) `:rf.sub/run` / `:rf.sub/skip` stream is a defect, never a new baseline.
+
+Together W1 + W2 license exactly one inference, by pointer comparison and nothing else. Let `S` be a source, `L` the value a consumer last saw from it, and `v = (read-container S)`: if `(identical? (-moved-from S) L)` then `(not (= L v))`. That is what lets `re-frame.subs.memo`'s fixed-arity-1 wrappers skip the structural `=` walk of a changed `app-db` subtree on the write path, where it is guaranteed to fail — while keeping it on the read path, where a pull-based derived value depends on it to stop a render re-running every sub body.
+
+The signal is **pulled by the core from the source, never pushed into the compute-fn**, which is why this capability changes neither `make-derived-value`'s `(source-containers compute-fn)` signature nor the one-argument-per-source shape of `compute-fn` pinned above. In the CLJS reference exactly one implementor exists: the React-hook spine's derived container, whose fan-out is `rf=`-gated. The Reagent and reagent-slim `Reaction`, the plain-atom derived value on both hosts, the headless test adapter's derived value, and every raw base container publish nothing — so on those substrates the consumer's guard is unchanged.
+
 ### `(render render-tree mount-point opts) → unmount-fn`
 
 Renders the render-tree onto the substrate's surface and returns a function that unmounts.
@@ -928,6 +945,8 @@ Three load-bearing properties:
 3. **Topological cascade.** Layer-2 subs see the new layer-1 values when they recompute. Layer-3 subs see new layer-2 values. The cascade respects the static `:<-` topology recorded during registration.
 
 Reagent realises this automatically: each `Reaction` re-runs only when its derefs change by `=`; the reactive graph is built from the `:<-` chain. Non-CLJS implementations (or the plain-atom adapter) must satisfy the contract explicitly — Phase 1 / Phase 2 / Phase 3 above is the fallback algorithm.
+
+The `=` test in Phase 1 and Phase 2 is a contract on the *verdict*, not a mandate to walk the structure every time. A single-source consumer whose source publishes a [movement witness](#movement-witness-optional) may reach the same verdict by pointer comparison when the witness determines it, and must reach it by the `=` walk otherwise — obligation C1 there makes the two indistinguishable from outside.
 
 **First-run discriminator on the cache-miss path.** The cache lookup step above splits cleanly into two cases: a hit (existing slot, ref-count bump) and a miss (fresh slot, body's first run). The memo wrapper threads that discrimination through to the trace stream as a `:rf.sub/first-run?` boolean on every `:rf.sub/run` emit (`true` on the run that allocated the slot, `false` on every subsequent recompute). Consumers (Xray's SUBSCRIPTIONS leaf-scalar renderer) need the discriminator to render a fresh-cache-entry run (the sub is now alive — `:added` chrome, no "was") distinctly from a recompute whose prior value happened to be `nil` (the value really changed `nil → X` — `← was nil` annotation). Both shapes report `:rf.sub/value-changed? true` and `:rf.sub/prev-value nil`; the `:first-run?` flag is the only signal that distinguishes them. See [Spec 009 §`:op-type` vocabulary](009-Instrumentation.md#op-type-vocabulary) for the full `:rf.sub/run` tag-map shape.
 


### PR DESCRIPTION
Implements the movement-witness design **adopted by the acting mayor on 2026-07-31** under authority delegated by Mike (full ruling on `rf2-gncxk`; the "HELD for operator sign-off" gate on `rf2-gncxk.1` is discharged). **Operator-overturnable.**

## What was wrong

`subs.memo`'s fixed-arity-1 memo wrappers guard the user's sub body with `(= last-seen new-value)`. On the write path that walk is overwhelmingly wasted — a full structural comparison of the changed app-db subtree, **147.0 B/sub, 17.6% of the per-subscription slope**, whose *time* cost scales with the shape of that subtree rather than with the sub.

It is **not dead code**. The spine's derived value is pull-based (`-deref` recomputes every time), so this same guard is the only thing stopping a view render from re-running every sub body. It earns its keep on the read path and cannot pay on the write path.

And it cannot be retired by asking *"am I on the flush path?"* — the design pass falsified that premise. Two reachable interleavings make the guard correctly **HIT** on the flush path even for `:db`: a deref between `mark-dirty` and the epoch drain, and a single-epoch `A -> B -> A'` return-to-equal that coalesces into one flush. So the signal has to key on an exact fact about the **source**.

## What this does

A derived container that gates its own propagation on `rf=` publishes, through the new optional re-frame-owned protocol `re-frame.movement/IMovementWitness`, **the value its most recent completed movement departed from**. One volatile in `make-derived-value-fn`:

- **armed** inside `notify`'s existing `rf=` gate, before fan-out — the exact instant movement is established (**W2 soundness**);
- **retracted** on `mark-dirty!`'s 0->1 transition, so a pull-based container stops answering once its live value may run ahead of its last notify (**W1 freshness**);
- released on `-dispose`.

The wrappers hold their lone source and skip the `=` walk exactly when that witness is `identical?` to the value they last saw. That is a **proof**, not a heuristic: W1+W2 guarantee the live value is not `rf=` — hence not `=` — to the witness. The source owns the signal and core *pulls* it, so `make-derived-value`'s pinned `(sources compute-fn)` signature and `compute-fn`'s pinned one-arg-per-source shape are both untouched.

It cannot weaken the read-path guard **structurally**, not by care: after any invocation `last-seen` holds the value just seen while the witness holds its predecessor, so the proof cannot fire twice running on the same value. A render that derefs 300 subs three times each still memo-hits 900 times.

**`:frame-state` keeps its genuine flush-path hit structurally.** Its source is `frame/frame-state-container` — the frame's ONE physical container, a `cljs.core/Atom` under the spine — whose fan-out is not movement-gated and which therefore cannot implement the protocol. `witness-src` resolves nil and the guard expression there is byte-for-byte today's. Verified rather than assumed: `movement_witness_cljs_test.cljs` pins `(not (satisfies? IMovementWitness raw-container))`, and the mutation proof below reds the #7233 pin the moment that stops being true.

Reagent / reagent-slim `Reaction`s, the plain-atom derived value (JVM + CLJS) and test-react's derived value publish nothing either — two extra pointer compares per recompute, zero allocation, no behavioural change.

**Memory — the one real cost.** `last-moved-from` retains ONE predecessor derived value per derived container while that container is clean (cleared on the next `mark-dirty!`, released on `-dispose`). For the app-db projection that is one extra app-db generation held between writes; structural sharing means the true delta is only the nodes the last write replaced. Not a new class of retention — every layer-1 memo cell already holds a full app-db in `last-db`.

## Quality gates

Node 24.13.0 / V8 13.6.233.17-node.37, `:advanced`, `goog.DEBUG false`, pointer compression **OFF**, `n=300`, 40 samples over 6 rotating-and-reflecting rounds. Arm-order guard: **VERDICT reportable** on all five published bench runs (8/8 self-tests, 70/70 strata). Ranges are quoted; overlapping ranges mean INDISTINGUISHABLE.

Baseline = `e5cf5facda` (this branch's parent), built and run on the same machine in a detached read-only worktree. The `:frame-state` ladder was backported into the *baseline harness only, as an instrument* (a test file, never committed) so both ladders have a genuine before/after.

### The two-sided measurement

**1. Baseline reproduced.** `P-EQDB` = **148.0** B/sub forward `[44050.6 - 44725.4]` B/call, **147.0** reversed `[44054.0 - 44498.8]` — overlapping, indistinguishable, and exactly the 147.0 recorded on the bead.

**2. THE PAIRED ARMS — one process, same objects** (the harness's own `RC-ATTACH` / `RC-CAND` discipline).

*The `:db` half.* `P-MEMOW` and `P-MEMOWC` are the same wrapper, the same inputs, the same scaffolding (one `replace-container!` + epoch + drain + recompute-and-notify per call). The ONE difference is whether the source publishes a witness.

| arm | forward | reversed |
|---|---|---|
| `P-MEMOWC` raw-atom source, no witness | 640.2 B/sub `[188601.5 - 194347.6]` B/call | 642.5 `[191920.8 - 194253.6]` |
| `P-MEMOW` witnessing source, proof fires | 485.1 B/sub `[145020.0 - 147325.1]` | 484.8 `[145092.0 - 147084.0]` |
| **-> witness retires** | **155.1 B/sub** | **157.6 B/sub** |
| `P-EQDB` (the `=` term alone) | 147.9 | 147.3 |
| `P-MEMO` (cross-check: the scaffolding is not carrying the result) | 639.5 | 638.8 |

**The `=` term is GONE** — the saving is at least the full term in both orders. It reads ~7-10 B/sub *larger* than `P-EQDB` measures in isolation, and that excess is reported rather than explained away: the plausible cause is that the wrapper's `=` call site is less monomorphic than the bare arm's, so the same walk allocates slightly more there. It is folded into no headline figure; the ladder below is the independent check, and it brackets both readings.

*The `:frame-state` half.* `P-MEMOF` and `P-MEMOFI` are the SAME wrapper objects over the SAME raw-atom source with the SAME memo cells, both landing on the memo-**HIT** branch — the real `:frame-state` flush-path shape #7233 pins. Only the argument's identity differs.

| arm | forward | reversed |
|---|---|---|
| `P-MEMOF` `=`-but-not-`identical?` db | 147.4 B/sub | 147.0 |
| `P-MEMOFI` `identical?` db (`=` short-circuits) | 0.2 B/sub | 0.2 |
| **-> `=` walk STILL PAID** | **147.2 B/sub** | **146.9** |
| `P-EQDBF` (the equal-input walk alone) | 147.4 | 147.2 |

**Still paid where it earns its keep**, to within 0.2 B/sub.

**3. THE LADDER — both, before and after.**

| per-subscription slope | baseline fwd | baseline rev | branch fwd | branch rev | delta |
|---|---|---|---|---|---|
| `RFWRITE-N` (`:db` subs) | 833.0 | 834.9 | **681.5** | **682.2** | **-151.5 / -152.7 (-18.2% / -18.3%)** |
| `FSWRITE-N` (`:frame-state` subs) | 905.0 | 906.0 | **905.9** | **906.7** | +0.9 / +0.7 (+0.1%) — indistinguishable |

The `:db` slope falls by the `=` term; the `:frame-state` slope does not move. Same process, same write, same wrapper — only the source kind differs.

**4. BEHAVIOURAL WITNESSES, UNMODIFIED (this discharges C1).** `sub_memo_flush_path_cljs_test.cljs` (PR #7233, **both arms, not one character changed**) and `sub_memo_layer_1_test.clj` (including the `=`-not-`identical?` pin at `:84`) pass as they stand. Those suites assert body-run counts throughout; no `:rf.sub/run` or `:rf.sub/skip` count moved.

**5. MUTATION PROOFS, BOTH DIRECTIONS.**

*(i) Forcing the `:frame-state` wrapper to behave as though its source published a witness must RED the #7233 pin.* The guard's nil branch was changed from `movement/no-witness` to `seen` — precisely what a (wrongly) witnessing `:frame-state` source would publish. Result: **exit 1, 3 failures**, all in `frame-state-sub-guard-does-hit-on-the-flush-path`:

```
expected: (pos? flush-skips)          actual: (not (pos? 0))
expected: (= before @runs)            actual: (not (= 1 2))
expected: (= 2 @runs)                 actual: (not (= 2 5))
```

The `:db` arm stayed green. Reverted -> **exit 0, 0 failures**.

*(ii) Deleting the `identical?` proof term must RESTORE the 147 B in `P-MEMOW`.* With the term removed, on a rebuilt `:advanced` bench, guard verdict reportable, exit 0:

```
P-MEMOWC   642.3 B/sub
P-MEMOW    642.0 B/sub
-> witness retires   0.3 B/sub        (was 155.1)
:db slope            832.2 B/sub      (was 681.5; baseline 833.0)
:frame-state slope   905.9 B/sub      (unmoved, as it must be)
```

The whole saving comes back, the `:db` slope returns to baseline, and the `:frame-state` side is untouched — it never depended on the term. Reverted.

**6. RETENTION — NOT discharged here, deliberately.** The bead's `hicasso retention_run.cjs` obligation was **not run**: that harness lives under `implementation/freehand/test/re_frame/bench/hicasso/`, the tree `worker/tear-2rtt6-42` is actively editing, and it is a heavy CDP-driven browser bench. A reading taken against a half-edited tree would not be evidence. What *is* pinned instead: `movement_witness_cljs_test.cljs` asserts that `mark-dirty!` retracts the witness and that `-dispose` releases the retained predecessor, which bounds retention at the one generation described above. Worth a follow-up run once that worktree lands.

### The gate matrix

Derived from `.github/scripts/report-changed-surfaces.sh` over this diff: `implementation_jvm=true cljs_node_test=true ui_gates=true adapter_diagnostic=true cljs_browser=true cljs_prod=true bundle_isolation=true`. `adapter_testbed_smokes` and `ui_smoke` classify **false** for a core-only change; they were run anyway, since all three consumers of `make-derived-value-fn` ride this code.

| gate | result |
|---|---|
| `npm run test:cljs` | **12194 tests / 60712 assertions, 0 failures, 0 errors** — exit 0. Before the contract pin was added the same suite read 12189 / 60695; the delta is exactly the five new tests and their seventeen assertions, and every other count is unchanged |
| `scripts/test-fast-pr.sh` (static + drift + docs tier + JVM core + JVM touched artefacts + node tier + per-ns isolation) | `PASS fast PR spine` — exit 0. Run before the contract pin landed; that file touches only the CLJS node tier, which was re-run standalone (above), and the per-ns isolation gate scans an explicit curated list the new ns is not on |
| `scripts/test-jvm-implementation.sh` (every implementation JVM artefact) | `PASS implementation JVM artefacts` — exit 0 |
| `npm run test:browser` | 937 tests / 5798 assertions, 0 failures, 0 errors — exit 0 |
| `npm run test:browser-prod-elision` | `ui mounted production elision: PASS`; 120 tests / 527 assertions, 0 failures — exit 0 |
| `npm run test:adapter-smokes` (Reagent, UIx, re-frame.ui) | `Ran 3 adapter-smoke specs. 0 failures.` — exit 0 |
| `npm run test:bundle-isolation` | `PASS bundle-isolation` (23 artefacts, 39 sentinels), `PASS uix-reagent-free`, `PASS login-bundle-isolation` — exit 0 |
| `npm run test:perf-bundle` | `PASS perf-bundle: off-count=0; on-count=8` — exit 0 |
| clj-kondo **v2026.04.15** — the CI-pinned release, fetched (the local npm binary is older); CI's exact `--lint` set and `--fail-level error` | **errors: 0** (4526 pre-existing warnings) — exit 0. Zero findings on `movement.cljc`; every finding on the other changed files predates this diff |
| `python -m mkdocs build --strict` | 0 warnings — exit 0 (the fast-PR spine soft-skips it: mkdocs is not on PATH here) |

**Bundle delta**, `:advanced` release, baseline vs branch — one sentinel, one `defprotocol`, and the guard's extra terms:

| bundle | baseline | branch | delta | gzipped delta |
|---|---|---|---|---|
| `examples/counter` (Reagent) | 626,893 B | 627,266 B | +373 B (+0.06%) | +147 B |
| `examples/counter-uix` (spine) | 613,610 B | 614,127 B | +517 B (+0.08%) | +211 B |

A protocol call on a `reify` is a direct method dispatch under `:advanced`; the UIx bundle is the larger of the two because it also carries the spine's implementation.

## Scope

New `re_frame/movement.cljc`; `spine.cljs`'s `make-derived-value-fn`; the two fixed-arity-1 wrappers in `subs/memo.cljc`; two call sites in `subs.cljc`; the paired bench arms + `:frame-state` ladder in `write_attribution.cljs`; one Spec 006 subsection (**hot-zone** — no other Spec 006 work was in flight); and a contract pin for the new normative surface.

**No adapter files.** `make-layer-n-memoised-body` (varargs, >=2 inputs, all parametric subs) is deliberately out of scope — the measured 147 B is the fixed-arity-1 path, and the varargs cost is dominated by its seq. Spec 009 needs no change: `:rf.sub/skip`'s "input value was `=` to last-seen" stays exactly true, because the design never skips when the values *are* `=`. Pre-alpha posture: a positional parameter, no compatibility arity.

The two adjacent candidates the design pass declined — memoising `deref-derived` while clean, and movement-gating the raw-atom fan-out coordinator — stay out, per the ruling. Neither rode along.

Composes with the landed `rf2-2rtt6.13` (#7304) and `rf2-2rtt6.25` (#7305); `.25`'s commit adoption makes the proof's precondition (`last-db` `identical?` to the witness) hold **more** often, not less, since the memo cells now survive render -> commit instead of being thrown away with a discarded double build.

Closes rf2-gncxk.1.
