### PR TITLE
hicasso: one callback form, one merge spelling, presence as data (rf2-2rtt6.35, .36, .37, .38, .43)

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -116,6 +116,14 @@
   ;; does not graduate it.
   re-frame.bench.hicasso.arm1.lang/defview clojure.core/defn
 
+  ;; Hicasso's one callback form (rf2-2rtt6.35, HD-024). `(hfn [e] body+)`
+  ;; expands to `(intent/callback (fn [e] body+))` and nothing else, so
+  ;; `clojure.core/fn` is exactly its shape: the argument vector gets
+  ;; ordinary lexical-binding analysis, which is what stops every `hfn`
+  ;; parameter reading as an unresolved symbol. Retires with the arm on
+  ;; the same terms as `defview` above.
+  re-frame.bench.hicasso.arm1.lang/hfn     clojure.core/fn
+
   ;; `reg-view` is `(reg-view sym [args] body)` — defn-shape, but the
   ;; macro auto-injects `dispatch` / `subscribe` into the body. Handled
   ;; by the dedicated hook in `.clj-kondo/hooks/re_frame/core.clj` —

--- a/docs/design/hicasso/README.md
+++ b/docs/design/hicasso/README.md
@@ -8,7 +8,7 @@ by [EP-0038](../../EP/EP-0038-the-hicasso-view-layer-programme.md).
 | Document | Contents |
 |---|---|
 | [charter.md](charter.md) | Product identity, evidence base, goals, constraints, use-case roster, known losses |
-| [decisions.md](decisions.md) | HD-001…HD-021 — every design decision, resolved, with rationale and reopen conditions |
+| [decisions.md](decisions.md) | HD-001…HD-025 — every design decision, resolved, with rationale and reopen conditions |
 | [hd-002-adjudication.md](hd-002-adjudication.md) | HD-002 adjudicated — the tripwire, the boundary, ownership, and the hypotheses under test |
 | [architecture.md](architecture.md) | The architecture space, the two spike arms, the shared front half, inside-React feasibility, the sub-read mechanism ladder |
 | [validation.md](validation.md) | The bar, the budgets, the P0→P1→P2 plan, witnesses, tournament and measurement discipline, kill criteria |

--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -101,6 +101,34 @@ steady-state change belongs on an effect, not on the ref.
   per boundary from the substrate's single internal context) so they remain valid
   when the browser invokes them after render scope unwinds.
 
+### When a vector is not enough: one form, and the position decides (HD-024)
+
+There is **one** callback form, `h/fn`, and it is an **ordinary function**:
+
+```clojure
+[:input {:type "file"
+         :on-change (h/fn [e] [:upload/picked (js/Array.from (.. e -target -files))])}]
+```
+
+| Position | Contract |
+|---|---|
+| a native `:on-*` prop | **event** — a returned vector is dispatched; any other return is ignored |
+| a `defhost` `:callbacks` entry | as **declared** (`:event` or `:handler`) |
+| any other walked prop position (a slot, a foreign render prop) | **render** — pure; the return is output, and dispatching from inside is a loud error **naming the position** |
+| `:ref` | React's own contract; not lowered |
+| anywhere Hicasso does not walk | a plain function; it runs, and its return is ignored |
+
+A view's props map is not a position — it is data in transit, exactly as an intent
+vector is; the value is lowered where it finally lands. Ordinary functions remain
+untouched at every position, which is why there is no separate identity-passthrough
+form: the codec already hands functions to React by identity so `React.memo` and
+handler-identity bail-outs keep working.
+
+The point of the collapse is the last row. In the predecessor the roster forms are
+carriers — marker objects — so one handed to a raw `#js` prop is not callable and
+the failure is the engine's own `TypeError`, naming nothing the author wrote. A
+form that is a function cannot fail that way.
+
 ## Forwarding attributes — one merge, spelled `:&` (HD-023)
 
 There is **one** attribute merge and it is a reserved key in the attribute map, not

--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -211,6 +211,38 @@ of them context:
 3. **App-db + `sub` for the theme choice only** — user-picked, per-frame,
    time-travelling.
 
+## Presence — phase as data (HD-025)
+
+`h/presence` retains exiting keyed children for `:timeout-ms`. A child says what it
+looks like in each phase, **in its own attribute map**:
+
+```clojure
+(h/presence {:timeout-ms 300}
+  (for [t (sub [:toasts/visible])]
+    [:div.toast {:key (:id t)
+                 ::h/unmounting {:class "toast toast--exit"
+                                 :inert true :aria-hidden true}}
+     (:message t)]))
+```
+
+No child view, no ambient read. When the child *is* a boundary, the phase arrives
+as an ordinary prop — `[toast-card {:key id :toast t :rf/phase :unmounting}]` — so
+it cannot be read from the wrong render scope, it appears in a structural test's
+props map, and a headless test supplies it with no clock. There is no
+`presence-phase`.
+
+An override wins over the node's own literals (that is what an override is) and can
+never reach `:key` or `:ref`, the same law `:&` carries. Writing one on a **view**
+head is a loud error naming `:rf/phase`, because the boundary cannot see inside an
+opaque child. `:timeout-ms` is mandatory and is both the retention length and the
+hard terminal bound; re-entry cancels exit; every dynamic child needs a `:key`;
+presence never dispatches domain mount/unmount events.
+
+**Enter is the weak half.** A `:mounting` → `:present` class flip can lose the race
+to paint. `::h/mounting` exists, but the reliable spelling for enter is an
+animation on insertion (or `@starting-style`); exit is the phase that transitions
+happily, because the node is already painted.
+
 ## Ephemeral state (HD-009)
 
 There is no `local`/ratom-equivalent, and no `useState` for app state. In order:

--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -101,6 +101,34 @@ steady-state change belongs on an effect, not on the ref.
   per boundary from the substrate's single internal context) so they remain valid
   when the browser invokes them after render scope unwinds.
 
+## Forwarding attributes — one merge, spelled `:&` (HD-023)
+
+There is **one** attribute merge and it is a reserved key in the attribute map, not
+a call:
+
+```clojure
+(defview field [{:keys [id busy?] :as attrs}]
+  [:input.form-control {:& (dissoc attrs :id :busy?)
+                        :value    (sub [:editor/field id])
+                        :disabled busy?
+                        :on-input [:editor/edit-field id ::h/value]}])
+```
+
+**The law is unconditional: the literal keys written in the map always win over
+`:&`.** That is HD-010(a)'s owned-literal law applied to every merge rather than
+only under theming, and it is what makes the controlled-input door
+non-forfeitable — a merge cannot reach an owned literal, so there is no wrong
+choice of syntax to make. The case where a caller override *should* win is spelled
+by not writing the literal.
+
+Three details. `:key` and `:ref` are never taken from a `:&` map (they address the
+element the caller wrote). The same key and the same law hold at a crossing — a
+view head, a `defhost` head, `[:>]` — because `:&` is merged before any conversion
+and the conversion that follows is the position's own, so a forwarded `:className`
+crosses under the name it was written as. And an element's own classes belong on
+the **tag**, where the shorthand merge composes them with a forwarded `:class`
+rather than one silently replacing the other.
+
 ## The controlled-input door
 
 Controlled text rides the synchronous door: dispatch → drain/commit → re-render

--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -80,6 +80,14 @@ the default surface is scored from day one, not discovered mid-clock:
 An existing React element is a legal child anywhere (pass-through). A view may
 return `nil`, one root, or a fragment.
 
+`:ref` takes a **function** in v0. A **vector** is the reserved value-space for the
+later data spelling (`{:ref [registered-id config]}`) and is refused loudly —
+`:rf.error/hicasso-ref-vector-reserved` (HD-022). The reservation is one branch and
+one error id; it exists so the imperative escape can become data without minting a
+second attribute name, and it carries one honest limit that shapes what you write
+today: a ref callback fires on attach and detach and **never on config change**, so
+steady-state change belongs on an effect, not on the ref.
+
 ## Event intent as data
 
 - A literal vector at an event position is the intent; `::h/value` is the value

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1,4 +1,4 @@
-# Hicasso — decisions (HD-001 … HD-021)
+# Hicasso — decisions (HD-001 … HD-025)
 
 Every design decision for the Hicasso programme, resolved. Each record carries the
 ruling, the decisive rationale, and the condition under which it reopens. These
@@ -431,3 +431,60 @@ touches; leaving them to taste mid-spike is how boot ceremony and leak classes
 creep in. The harness measured ~30 lines of boot ceremony per app as the
 baseline to beat.
 **Reopens** at product phase (public API naming, richer HMR) by ordinary ruling.
+
+---
+
+The four records below (HD-022 … HD-025) come from one adversarial design review
+of the shipped predecessor's authoring surface, taken under the operator's
+2026-07-31 direction to spend the programme's effort on *"adversarial design
+reviews and performance improvement"* and to *"look at their data oriented
+structure. Improve upon that."* Each one is a **deletion with a data
+replacement**, because the unsolved problem the review found is
+[K5](validation.md) — concept count — and K5 is a count. Each is demonstrated on
+a census-real screen rather than argued; where the diff did not come out better,
+the record says so.
+
+## HD-022 — `:ref`'s vector value-space is reserved now, and refused loudly in v0
+
+**Ruling.** `:ref` accepts **a function** — HD-003's escape hatch and HD-016's
+callback-refs-only rule, both unchanged. A **vector** (`{:ref [registered-id
+config]}`) is **RESERVED**: v0 refuses it with `:rf.error/hicasso-ref-vector-reserved`
+rather than passing it to React as an opaque value. That is the whole ruling —
+one refusal branch and one error id. **Not in scope, explicitly:** a behaviors
+registry, a `:timing` option, a commands roster, or any host-ownership subsystem
+in v0.
+**Rationale.** `:ref` is the one place Hicasso is planned to be *less*
+data-oriented than the substrate it replaces: the predecessor's registered
+behaviors keep the use site as data (`[v/behavior {:use autosize :target … :config
+{…}}]`) and put the code in a registry, with `:config` refusing a callback, a
+node, a ref or a host instance. Reserving the value-space costs one branch and
+keeps `{:ref [::autosize {:max-rows 8}]}` reachable without minting a second
+attribute name later. The census pays for the reservation and not for the
+subsystem: **one `:ref` in 85 idiomatic files**, and charter.md defers the
+component-library tier past v0.
+**Why the later spelling is mechanically sound** (react.dev,
+`react-dom/components/common`, verified 2026-07-31): React 19 added cleanup
+functions for ref callbacks; the callback is called with the DOM node on attach
+and its returned cleanup on detach; React calls the callback again whenever a
+*different* callback is passed; StrictMode runs one extra development-only
+setup+cleanup cycle. So a runtime-minted ref callback is a complete attach/detach
+pair, with the node, in the commit phase, and no ref object or effect ever
+appears in user code. Three obligations follow and must be recorded when the
+later bead lands: the minted callback's identity must be **stable per site** or
+React detaches and reattaches every render; connect/disconnect must be
+**idempotent** because StrictMode adds a cycle; and timing is
+**commit-before-paint only**, so the predecessor's `:passive` (after paint) has
+no ref-callback equivalent.
+**And the real gap, stated so nobody rediscovers it.** A ref callback fires on
+**attach** and **detach**, never on **config change**. The predecessor's
+`:update` — "only when the committed `:config` moves by `rf=`, receiving
+`:prev-config` alongside" — has no equivalent without either changing the
+callback identity (which detaches and reattaches the node's owner: wrong for a
+map or chart instance) or spending an effect. The recommended later shape is
+therefore **attach/detach only, config immutable for the connection's life, and
+steady-state change routed through a command effect**, which is already data.
+This limit is taught in the guide
+([Interop](draft-guide/05-interop.md#the-reserved-vector-and-the-gap-it-does-not-close))
+rather than left to be discovered.
+**Reopens** when the component-library tier is chartered — the reservation exists
+to make that reopening non-breaking.

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -550,3 +550,50 @@ such additions be measured rather than assumed. Structurally this one is a singl
 absent, so it allocates nothing on an element that does not use it — but its clock
 cost is **unmeasured** and is named here rather than claimed away.
 **Reopens** if a witness shows a merge the law cannot express without an escape.
+
+## HD-024 — One callback form; the position selects the contract
+
+**Ruling.** Hicasso ships **one** callback form — `h/fn` (spelling unfrozen) — and
+it is **an ordinary function**. The contract comes from the **position**, because
+the runtime already knows every position it walks:
+
+| Position | Contract |
+|---|---|
+| a native `:on-*` prop | **event** — a returned VECTOR is dispatched; any other return is ignored |
+| a `defhost` `:callbacks` entry | as **declared** (`:event` or `:handler`), never inferred from an `on*` name |
+| any other walked prop position (a slot, a foreign render prop) | **render** — pure; the return is render output and is not dispatched, and dispatching from inside is `:rf.error/hicasso-dispatch-in-render-position`, **naming the position** |
+| `:ref` | React's own: commit phase, node in, cleanup out. Excluded from lowering |
+| anywhere Hicasso does not walk (a raw `#js` prop) | it is a plain function; it runs, and its return is ignored |
+
+A Hicasso **view's** props map is not a position — it is data in transit, exactly
+as an intent vector is. The view puts the value on an element and *that* position
+lowers it.
+**`raw-fn` is NOT v0**, and costs nothing to omit: the codec already passes
+functions to React by identity, deliberately, so that `React.memo` and every
+downstream bail-out comparing handler identity keep working. The behaviour the
+predecessor spells as a fourth roster form is the default here.
+
+**Rationale.** The predecessor requires an author who cannot use a bare event
+vector to pick from a roster of **four** forms with four different contracts —
+`v/event` returns one vector or nil, `v/handler`'s "return is ignored",
+`v/render-fn` is pure and runs during a foreign render, `v/raw-fn` passes identity
+through — and then adds a **fifth** rule about *where the roster reaches*. Outside
+that reach the failure is not even the library's: a roster carrier handed to a raw
+`createElement` `#js` prop is a non-callable marker object, so the author gets the
+engine's own `TypeError` — `props.onPing is not a function` — "naming nothing you
+wrote". Making the one form an ordinary function deletes the fifth rule outright,
+because there is nothing that can fail to be callable; making the position select
+the contract deletes the other three, because the role is already declared exactly
+once per crossing and Hicasso already walks the position. Four concepts collapse to
+one: **half the K5 budget back**. The census supports the trade — keyboard-condition
+handlers appear 3 times in 85 idiomatic files, `stopPropagation` 0 times, and
+foreign React components 0 times, so the roster is priced for a component-library
+tier charter.md defers past v0.
+**Diagnostics name the position, never the form** — under one form the form can
+never be the answer to "what did I get wrong?". The render-position refusal is
+enforced by poisoning the ambient dispatch for the call's dynamic extent, so an
+intent lowered inside the call and a direct dispatch land on the same error id.
+**Fence.** This is a **runtime classification at positions the codec already
+walks**, not a build-time pass over body forms. No compiler, no analyzer.
+**Reopens** if the component-library tier finds a contract the four rows cannot
+express — in which case it is a new row, not a new form.

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -597,3 +597,85 @@ intent lowered inside the call and a direct dispatch land on the same error id.
 walks**, not a build-time pass over body forms. No compiler, no analyzer.
 **Reopens** if the component-library tier finds a contract the four rows cannot
 express — in which case it is a new row, not a new form.
+
+## HD-025 — Presence: phase as a prop, and `::h/mounting` / `::h/unmounting` as data
+
+**Ruling.** Two changes, both of them data.
+
+**(1) `::h/mounting` and `::h/unmounting` are attribute OVERRIDE MAPS on a native
+node.** The presence boundary merges them into that node's attributes while the
+child is in that phase:
+
+```clojure
+(h/presence {:timeout-ms 300}
+  (for [t (sub [:toasts/visible])]
+    [:div.toast {:key (:id t)
+                 ::h/unmounting {:class "toast toast--exit"
+                                 :inert true :aria-hidden true}}
+     (:message t)]))
+```
+
+The override wins over the node's own literals (that is what an override is), and
+`:key` and `:ref` are never taken from it — the same law `:&` carries (HD-023).
+
+**(2) When the presence child IS a boundary, the phase arrives as an ORDINARY
+PROP** — `[toast-card {:key id :toast t :rf/phase :unmounting}]`. An attribute
+override written on a view head is `:rf.error/hicasso-presence-override-on-a-view`,
+naming `:rf/phase`, because the boundary cannot see inside an opaque child and a
+silently dropped override map is the class of failure this ruling exists to delete.
+
+**Consequence: `presence-phase` has no Hicasso equivalent — one fewer public
+concept against K5.**
+
+**Rationale.** The predecessor exposes phase as an AMBIENT READ, and its own guide
+records the cost verbatim: *"Read the phase inside a DECLARED, KEYED CHILD VIEW…
+Reading it in markup written inline in the parent is a trap: those props are
+evaluated during the PARENT'S render, so the phase you get is the parent's, not the
+per-child one you meant."* So a fading toast **cannot be written inline**: it must
+be extracted into a view purely so a dynamic var resolves against the right child,
+and getting it wrong yields the wrong phase silently. The a11y obligation then
+costs three separate `(when exiting? …)` attributes on that child. A prop cannot be
+read from the wrong render scope, appears in a structural test's props map, and can
+be supplied by a headless test with no clock.
+**Why the predecessor's rejection does not apply.** It rejected attribute overrides
+and gave a reason — *"A boundary that stamped attributes would have to guess at a
+node it never sees."* That is sound for a boundary stamping **by itself**. It does
+not survive the AUTHOR writing the override on the node: the boundary already owns
+the retained-children list (that is what retention *is*), so applying an override
+the author wrote is a hiccup→hiccup transform performed before the codec runs.
+React sees an ordinary element whose props changed — no wrapper node, no stamped
+`data-*`, no ref, no effect and no ambient read in the merge.
+**Only the attribute half of Replicant's mechanism is taken.** Replicant has two
+(verified 2026-07-31, replicant.fun): `:replicant/mounting` / `:replicant/unmounting`
+attribute overrides — *"allows you to specify overrides for any attributes during
+mounting and unmounting… declaratively transition elements on mount and unmount"* —
+and separately `:replicant/on-mount` / `:replicant/on-unmount` **callbacks**. The
+callback half is less data-oriented than the predecessor's registered behaviors and
+is **rejected**.
+**Honest limits, recorded rather than discovered.** The override applies to a node
+the boundary can SEE; an override inside an opaque child view is invisible to it,
+which is what (2) is for. And **enter is the weak half** — the predecessor already
+says why: *"driving enter purely as a `:mounting` → `:present` class flip can race
+paint… An ANIMATION ON INSERTION (or modern `@starting-style`) is more reliable."*
+`::h/mounting` ships; the guide teaches the CSS answer for enter.
+**Inherited unchanged:** `:timeout-ms` is MANDATORY, and is both the retention
+length and the hard terminal bound; re-entry cancels exit; keys are required on
+every dynamic child; presence never dispatches domain mount/unmount events.
+**Cost, stated.** The phase transform and the retention machine are **pure**
+(`front/presence`), which is what makes the whole thing assertable with no clock.
+The React component that drives them (`arm1/presence`) spends **two hooks —
+`useState` and `useEffect` — in its own component**. That is not a shell-budget
+breach: HD-020(b)'s ≤2 is the *boundary shell's*, and presence reads no
+subscription, mounts no registration and takes no cell; the dispatcher-level ledger
+still counts exactly two in `runtime/shell`. The hooks are legitimate under
+HD-003's placement rule rather than in spite of it — animation lifecycle is
+component mechanics by that rule's own list — and they are a library mechanic paid
+once, not an application one paid per view. The machine is adjusted **during
+render** rather than in an effect (`step` is idempotent, so the comparison
+converges), because an effect there would cost a paint with the wrong tree in it.
+**Demonstrated, not asserted.** The predecessor's own worked toast tray is ported
+both ways in `front/presence_cljs_test` with the rendered attributes asserted
+identical, and driven through React and a real DOM in
+`arm1/presence_dom_cljs_test`.
+**Reopens** if a witness needs a phase on a node the boundary genuinely cannot see
+and `:rf/phase` cannot reach.

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -488,3 +488,65 @@ This limit is taught in the guide
 rather than left to be discovered.
 **Reopens** when the component-library tier is chartered — the reservation exists
 to make that reopening non-breaking.
+
+## HD-023 — One attribute merge: a reserved `:&` key, owned-literal law unconditional
+
+**Ruling.** Hicasso has **one** attribute merge, spelled as data in the attribute
+map, with one unconditional law.
+
+```clojure
+[:input      {:& caller-attrs :value v :on-input ev}]
+[:div        {:& base :class "own"}]
+[date-picker {:& caller-attrs :selected d}]
+```
+
+(a) `:&` is a **reserved attribute key carrying a runtime map**. It is data, not a
+call, so a forwarded remainder survives into a structural test and into tooling,
+and it cannot collide with a real DOM attribute.
+(b) **The law: the literal keys written in the map always win over `:&`.** This is
+HD-010(a)'s owned-literal merge law applied to *every* merge rather than only under
+theming.
+(c) `:key` and `:ref` are **never taken from a `:&` map**. They address the element
+the caller wrote, not the one it is forwarding onto; a remainder is about
+attributes.
+(d) The **same key and the same law hold at a crossing** (a Hicasso view head, a
+`defhost` head, `[:>]`). `:&` is merged *before* any conversion, and the conversion
+that follows is the position's own — so a forwarded `:className` crosses under the
+name it was written as. One rule covers both positions.
+(e) A non-map at `:&` is `:rf.error/hicasso-merge-not-a-map`.
+**Consequence:** two public concepts (the predecessor's `spread` and `spread-safe`)
+become **zero**. An attribute key is not a concept in the K5 sense.
+
+**Rationale.** The predecessor makes an author choose between three merge forms
+depending on where the target is, and the penalty for choosing wrong is **silent**:
+`spread-safe` "preserves the controlled-input door", `spread` "does not claim the
+door", and neither is legal onto a declared foreign head (a spread canonicalises
+`:className` into the `:class` slot, so the component never sees the prop it
+reads). The cost is recorded twice as a wall with no error attached — "Dynamic map
+on controlled input without `spread-safe` | forfeits door proof" — and re-frame.ui
+carries the same split and admits it: "General (`ui/spread` base overrides) remains
+the visible-cost escape and **still forfeits the sync door**." Making the law
+unconditional deletes the whole class: the controlled-input door cannot be
+forfeited by a merge at all, because a merge cannot reach an owned literal. The
+case where a caller override *should* win is spelled by **not writing the literal**,
+which is the honest way round — the dangerous default is the other one. Spelling
+precedent: UIx already uses `:&` for exactly this in this repo
+(`examples/substrates/uix/login/core.cljs:148`).
+**Class composition needs no exception.** An element's own classes are written on
+the **tag** (`[:input.form-control {:& caller}]`), which is not a literal attribute
+key, so the shorthand merge composes them with whatever the remainder brought. A
+literal `:class` still wins outright, because it is a literal.
+**Demonstrated, not asserted.** The RealWorld article editor's four form fields
+(`examples/real-apps/realworld_resources/article_editor.cljs:496-522`) are ported
+both ways in `front/census_article_editor_cljs_test`, with the produced elements
+and the dispatched intents asserted identical between the renderings. The
+authoring result: four repeated attribute maps become one `field` helper and four
+call sites, and — the part that matters — the helper does not have to defend
+itself against what a caller forwards.
+**Cost, stated.** `:&` is an addition to the codec this programme took from
+reagent-slim, and the ruling that Hicasso authors no codec carries a caveat that
+such additions be measured rather than assumed. Structurally this one is a single
+`contains?` per attribute map, returning the map by identity when the key is
+absent, so it allocates nothing on an element that does not use it — but its clock
+cost is **unmeasured** and is named here rather than claimed away.
+**Reopens** if a witness shows a merge the law cannot express without an escape.

--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -4,7 +4,7 @@
 > *designed* surface so it can be read before it is built. Spellings marked
 > **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
 > is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+> source: [decisions.md](../decisions.md) (HD-001…HD-025).
 
 Booting a re-frame2 app today takes about thirty lines: create a React root, install
 an adapter, render a `frame-root` inside it, remember the root across hot reloads so

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -4,7 +4,7 @@
 > *designed* surface so it can be read before it is built. Spellings marked
 > **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
 > is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+> source: [decisions.md](../decisions.md) (HD-001…HD-025).
 
 A Hicasso view is a function from a props map to hiccup, which reads whatever
 subscriptions it needs along the way. That much is settled and has been since the

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -92,6 +92,11 @@ not the call.
 
 You never pick a form. There is one, and where you put it is the decision.
 
+One thing the policy defaults above do *not* do: **`h/fn` at `:on-submit` does not
+auto-prevent.** That default exists because an intent vector never sees the event,
+so the runtime has to decide for it. A callback is handed the event, so the event
+is yours — call `.preventDefault` in the body. Whoever holds the event owns it.
+
 ## Policy defaults the runtime owns
 
 Two things a form does every single time, and every codebase reimplements badly.

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -51,6 +51,47 @@ Use one when you genuinely need the event object — geometry, pointer capture, 
 imperative call. The intent vector is the taught default because it covers almost
 everything, not because functions are forbidden.
 
+## When you need the event *and* an intent: `h/fn`
+
+Sometimes the event has to be read before you know what to dispatch — a file list,
+a drag delta, a filtered key. For that there is **one** callback form, and it is an
+ordinary function:
+
+```clojure
+[:input {:type "file"
+         :on-change (h/fn [e] [:upload/picked (js/Array.from (.. e -target -files))])}]
+```
+
+**The position decides what the return means.** At an `:on-*` prop, a returned
+vector is dispatched and anything else — including `nil` — is ignored, so a
+conditional dispatch is an ordinary `when`:
+
+```clojure
+[:div {:on-drop (h/fn [e]
+                  (.preventDefault e)
+                  (when-let [f (aget (.. e -dataTransfer -files) 0)]
+                    [:upload/dropped (.-name f)]))}]
+```
+
+| Where you wrote it | What it means |
+|---|---|
+| a native `:on-*` prop | a returned vector is dispatched; any other return is ignored |
+| a `defhost` callback the declaration named | whatever the declaration said — `:event` or `:handler` |
+| a slot or a foreign render prop | it runs during a render, so it must be pure. The return is output, not an intent, and dispatching from inside it is an error that **names the prop** |
+| `:ref` | React's own contract — the node on attach, your return as the cleanup |
+| a raw `#js` prop you built yourself | nothing at all. It is a function; it runs |
+
+That last row is the one worth knowing about, because of what it is not. In the
+predecessor there are four callback forms plus a rule about where they reach, and
+the forms are *carriers* — marker objects, not functions. Hand one to a raw `#js`
+prop and the library calls `props.onPing(…)` on something that is not callable, so
+what you get is the JavaScript engine's own `TypeError`, worded after whatever
+expression it tripped on, naming nothing you wrote. `h/fn` is a function
+everywhere. Put it somewhere the runtime does not walk and you lose the contract,
+not the call.
+
+You never pick a form. There is one, and where you put it is the decision.
+
 ## Policy defaults the runtime owns
 
 Two things a form does every single time, and every codebase reimplements badly.
@@ -123,7 +164,8 @@ When you need the event object itself. Pointer coordinates, `dataTransfer`,
 `stopPropagation`, anything measuring the DOM — those are functions, and reaching
 for one is not a failure. The census puts these at roughly 3% of handler sites,
 which is the right size for an escape hatch: too small to design the syntax around,
-too real to pretend away.
+too real to pretend away. Reach for `h/fn` when you want to read the event *and*
+dispatch, and a plain `(fn …)` when you want to read it and do something else.
 
 ## Not settled yet
 

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -4,7 +4,7 @@
 > *designed* surface so it can be read before it is built. Spellings marked
 > **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
 > is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+> source: [decisions.md](../decisions.md) (HD-001…HD-025).
 
 Handler attributes are where a data-oriented view layer usually gives up. You have
 been writing pure data all the way down the tree, and then `:on-click` needs a

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -102,6 +102,45 @@ dispatch, caret preserved, composition fenced — a hard gate in
 [architecture.md](../architecture.md). A PATCH spike that cannot demonstrate that on
 the 100-cell grid has failed regardless of its clock numbers.
 
+## Forwarding attributes onto a controlled input
+
+Sooner or later you write a `field` wrapper: one place that owns the controlled
+contract, and call sites that still need to pass a placeholder, a `name`, a test id.
+The remainder rides in one reserved key, `:&`:
+
+```clojure
+(defview field [{:keys [id busy?] :as attrs}]
+  [:input.form-control {:& (dissoc attrs :id :busy?)   ;; whatever the caller sent
+                        :value    (sub [:editor/field id])
+                        :disabled busy?
+                        :on-input [:editor/edit-field id ::h/value]}])
+
+[field {:id :title :busy? busy? :type "text" :placeholder "Article Title"}]
+```
+
+**The literal keys you write always win.** Not "usually", not "if you pick the right
+merge form" — always. So a caller who forwards a whole props map, a theme that
+supplies part attributes, or a genuinely hostile remainder carrying `:value` and
+`:on-input` all reach nothing that matters. Your `:value` is your `:value`.
+
+That is the whole design, and it exists because of the thing it deletes. In the
+predecessor there are **three** merge forms and the wrong one is silent: pick the
+general spread on a controlled input and caret and IME protection stop, with no
+error raised anywhere. Correctness by choice of syntax is the worst kind, because
+the code looks fine.
+
+Two consequences worth knowing.
+
+**Say it by not saying it.** When you *want* the caller's value to win, leave the
+literal out. `[:input {:& attrs}]` takes everything the caller sent. The default is
+the safe direction and the override is the explicit one, which is the way round you
+want when the thing being defended is a caret.
+
+**Classes compose on the tag.** `:key` and `:ref` are never taken from `:&`, and a
+literal `:class` wins outright like any literal — so put your element's own classes
+on the tag (`[:input.form-control {:& attrs}]`) and the shorthand merge combines
+them with whatever the caller brought.
+
 ## Resets are by revision, never by value
 
 When you need to force a field back to a value — a form reset, a "revert" button, a

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -4,7 +4,7 @@
 > *designed* surface so it can be read before it is built. Spellings marked
 > **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
 > is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+> source: [decisions.md](../decisions.md) (HD-001…HD-025).
 
 A controlled text input is the hardest correctness problem a view layer has, and
 almost none of the difficulty is visible in the code you write.

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -4,7 +4,7 @@
 > *designed* surface so it can be read before it is built. Spellings marked
 > **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
 > is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+> source: [decisions.md](../decisions.md) (HD-001…HD-025).
 
 You want a date picker from npm. In Reagent you write `[:> DatePicker {...}]` and
 move on. Hicasso asks you to write one line first:
@@ -208,6 +208,37 @@ Note the two consequences of putting hooks in a body at all: it is outside the
 headless testing scope ([Testing](08-testing.md)), and you have taken on React's hook
 rules yourself. Both are fine. Both are on you.
 
+### The reserved vector — and the gap it does not close
+
+One thing about `:ref` is worth knowing before you write your first one, because it
+changes what you should put in the closure.
+
+**A vector at `:ref` is refused.** `{:ref [::autosize {:max-rows 8}]}` raises
+`:rf.error/hicasso-ref-vector-reserved`. That value-space is reserved for a later
+data spelling of exactly the pattern above — a registered id and a config map,
+with the imperative code in a registry instead of in your view — and v0 claims it
+now so that landing it later is not a breaking change. Today, write the function.
+
+**And the honest limit on what that later spelling could ever be.** A React ref
+callback fires on **attach** and on **detach**. It does **not** fire on **config
+change**. There is no third call, and no amount of design gets one: passing a
+*different* callback is the only way to make React invoke it again, and doing that
+detaches and re-attaches the node — which destroys and rebuilds your map instance,
+which is precisely the thing you were trying to avoid.
+
+So the shape to write, now and later, is:
+
+- **attach and detach only**, in one closure, as above;
+- **config immutable for the connection's life** — whatever the SDK needs at
+  `mount` time is decided once;
+- **steady-state change routed through an effect**, dispatched as an ordinary
+  event: `{:map/fly-to {:instance id :center [lat lng]}}`. That is already data,
+  it is already in the event log, and it is already testable.
+
+If you find yourself wanting the ref to notice that a prop changed, that is the
+signal to move the change onto the effect path. Nothing in the reserved vector
+will rescue it later.
+
 ## Troubleshooting
 
 No Hicasso error ids exist yet; this table names mechanisms.
@@ -238,6 +269,7 @@ two or three genuinely hard widgets.
 |---|---|
 | `defhost`'s option keys | **Not addressed.** "Policy overrides live on the declaration" is as far as the record goes |
 | The codemod's name and invocation | **Not addressed** |
+| When the reserved `{:ref [id config]}` spelling lands, and what registers an id | **Reserved, not designed.** HD-022 rules the refusal and the value-space; the registry, the timings and the commands roster are explicitly out of v0 |
 | Which React version the runtime targets | **Not addressed by the design record.** The cleanup-returning callback ref taught above is a React 19 contract; this repo's implementation currently pins React 19.2, but that is a fact about today's tree, not a Hicasso ruling. If v0 lands on 18, the fallback shape above is the one to teach |
 | Whether `::h/value` works across a host crossing | **Not addressed.** The example above assumes it does; a foreign `onChange` may hand you something other than a DOM event |
 | The SSR placeholder's shape | Declared policy, inert in v0 |

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -208,7 +208,7 @@ Note the two consequences of putting hooks in a body at all: it is outside the
 headless testing scope ([Testing](08-testing.md)), and you have taken on React's hook
 rules yourself. Both are fine. Both are on you.
 
-### The reserved vector — and the gap it does not close
+### The reserved vector, and the gap it does not close
 
 One thing about `:ref` is worth knowing before you write your first one, because it
 changes what you should put in the closure.

--- a/docs/design/hicasso/draft-guide/06-theming.md
+++ b/docs/design/hicasso/draft-guide/06-theming.md
@@ -201,6 +201,14 @@ Without this law, a stylesheet-shaped piece of data could reach in and clobber t
 `:value` of a controlled input — and you would debug that as an input bug for a day
 before you thought to look at the theme.
 
+**The law is not theming-specific.** HD-023 makes it unconditional: there is one
+attribute merge, spelled `:&`, and the literal keys written in the map always win
+over it — whether what arrives is a theme's part attributes, a caller's forwarded
+remainder, or anything else. So a control that emits parts and a control that
+forwards props are the same code, defended by the same rule, and there is no second
+merge form to choose between. See
+[Controlled inputs](04-controlled-inputs.md#forwarding-attributes-onto-a-controlled-input).
+
 ### (b) The static-map law
 
 **Anything runtime-switchable lives in CSS variables. Part-to-class maps are

--- a/docs/design/hicasso/draft-guide/06-theming.md
+++ b/docs/design/hicasso/draft-guide/06-theming.md
@@ -4,7 +4,7 @@
 > *designed* surface so it can be read before it is built. Spellings marked
 > **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
 > is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+> source: [decisions.md](../decisions.md) (HD-001…HD-025).
 
 Every React component library reaches for context to theme itself. Hicasso doesn't
 ship a context API at all, and its theming uses none.

--- a/docs/design/hicasso/draft-guide/07-ephemeral-state.md
+++ b/docs/design/hicasso/draft-guide/07-ephemeral-state.md
@@ -127,6 +127,77 @@ The no-`local` core stands.
 So: a v0 complaint about state ceremony is **expected signal**, not a verdict. It
 triggers the sugar iteration, not a kill.
 
+## The state you cannot put in app-db: "it left, but it is still on screen"
+
+There is one piece of view state app-db genuinely cannot hold, and it is worth
+knowing where it lives before you go looking for a `local` to put it in.
+
+A toast is dismissed. It is gone from app-db — that write already happened, and it
+was correct. But it should fade out over 300ms, which means the node has to outlive
+the data by 300ms. Nothing in app-db can express that, because app-db is about what
+is *true*, and this is about what is still *painted*.
+
+That is what `h/presence` is for. It retains keyed children that have left the
+source data, for `:timeout-ms`, and it lets each child say what it looks like on
+the way out — **in its own attribute map**:
+
+```clojure
+(defview toast-tray [_]
+  [h/presence {:timeout-ms 300}
+   (for [t (sub [:toasts/visible])]
+     [:div.toast {:key (:id t)
+                  ::h/unmounting {:class "toast toast--exit"
+                                  :inert true :aria-hidden true}}
+      (:message t)])])
+```
+
+Three things about that block.
+
+**There is no child view.** The whole tray is written inline, in the parent. In the
+predecessor this is not possible: the phase is an ambient read, so reading it in
+markup written inline in the parent silently gives you the *parent's* phase, and
+the guide says so outright. The fix there is to extract the toast into a declared
+keyed view — a view whose only reason to exist is that a dynamic variable needs
+somewhere to resolve.
+
+**The a11y attributes are one map, not three conditionals.** A retained node is
+still in the document: it can take focus and clicks until you say otherwise. That
+obligation is `:inert`, `:aria-hidden` and an exit class, and here they arrive
+together, as data, in the phase they belong to.
+
+**When the child is a view, the phase is an ordinary prop.**
+
+```clojure
+[toast-card {:key (:id t) :toast t}]   ;; receives :rf/phase :unmounting
+```
+
+Which means a test can pass `:rf/phase :unmounting` and assert the exit rendering
+with no timers, no browser and no clock at all.
+
+### What presence does not do
+
+`:timeout-ms` is mandatory, and it is both the retention length and a hard terminal
+bound — presence is a clock, not a `transitionend` listener, so the node leaves on
+time whether or not your CSS ran, or was disabled, or was overridden by
+`prefers-reduced-motion`. Re-entry cancels exit: a toast that comes back before the
+timeout returns to `:present` rather than finishing its exit and remounting. And
+presence never dispatches anything — a node lingering on screen is not a reason for
+anything in app-db to linger with it.
+
+**Enter is the weak half, and this guide will not pretend otherwise.**
+`::h/mounting` exists, but driving an entrance as a `:mounting` → `:present` class
+flip can lose the race to the browser's first paint, and then nothing animates. For
+enter, use an animation on insertion or `@starting-style`:
+
+```css
+.toast { animation: toast-in 200ms ease-out; }
+@keyframes toast-in { from { opacity: 0; translate: 0 8px; } }
+.toast--exit { opacity: 0; translate: 0 8px; transition: opacity 250ms, translate 250ms; }
+@media (prefers-reduced-motion: reduce) { .toast { animation: none; transition: none; } }
+```
+
+Exit is the phase that transitions happily, because the node is already painted.
+
 ## Troubleshooting
 
 No Hicasso error ids exist yet; this table names mechanisms.
@@ -134,6 +205,9 @@ No Hicasso error ids exist yet; this table names mechanisms.
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | Reaching for `useState` to hold "is this open?" | That's semantic state | app-db, or CSS if the platform tracks it |
+| A dismissed item disappears instantly with no exit animation | The node left with the data | `h/presence` with a `:timeout-ms` at least as long as the exit transition |
+| A retained node still takes focus or clicks while fading | The exit override does not carry `:inert` / `:aria-hidden` | Put all three in the `::h/unmounting` map |
+| An exit override on a child view does nothing | Presence merges overrides into nodes it can see; a view is opaque to it | The view receives `:rf/phase` — branch or style on that |
 | Every panel in a list opens at once | The state isn't parameterised by instance | Key the app-db path by the widget's id |
 | A hook body can't be tested headlessly | Hooks put a body outside headless scope, by design | Move the semantic half to app-db; mount-test the mechanics |
 | Hook-order error after a conditional early-return | React's rules, now yours | Hooks at the top of the body, unconditionally |
@@ -163,4 +237,5 @@ that edge needs to know it exists.
 | The controls kit (drafts, revisions) | **Post-v0** |
 | The overlay top layer that would own open and dismiss | **Post-v0** |
 | The reusable-widget instance-key convention | **Post-v0**, named as a resolved design debt in HD-009's sugar |
+| Whether presence order can follow a live re-sort | **No, by design, inherited.** Presence freezes first-appearance slots so an exiting child does not jump mid-animation; a continuously re-sorting list orders at the data layer |
 | Where the line falls between "mechanics" and "semantic" in hard cases | **Judgment, by design.** HD-003 makes it a taught rule with no enforcement, and reopens if dogfooding shows it confusing in practice |

--- a/docs/design/hicasso/draft-guide/07-ephemeral-state.md
+++ b/docs/design/hicasso/draft-guide/07-ephemeral-state.md
@@ -4,7 +4,7 @@
 > *designed* surface so it can be read before it is built. Spellings marked
 > **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
 > is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+> source: [decisions.md](../decisions.md) (HD-001…HD-025).
 
 Is this dropdown open? Is this row hovered? Is this panel expanded?
 

--- a/docs/design/hicasso/draft-guide/08-testing.md
+++ b/docs/design/hicasso/draft-guide/08-testing.md
@@ -4,7 +4,7 @@
 > *designed* surface so it can be read before it is built. Spellings marked
 > **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
 > is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+> source: [decisions.md](../decisions.md) (HD-001…HD-025).
 
 There are two doors into a Hicasso view under test, and knowing which one you are
 allowed through is most of the skill.

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -4,7 +4,7 @@
 > *designed* surface so it can be read before it is built. Spellings marked
 > **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
 > is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-021).
+> source: [decisions.md](../decisions.md) (HD-001…HD-025).
 
 Hicasso is re-frame2's native view layer: interpreted Hiccup on a React
 function-component host, optimised for re-frame2. The

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -25,7 +25,7 @@ compiled, run, or measured.
 | [Controlled inputs](04-controlled-inputs.md) | Type into a text field whose value round-trips through app-db, and keep your caret |
 | [Interop](05-interop.md) | Use a React component from npm |
 | [Theming](06-theming.md) | Style a component library without a context API |
-| [Ephemeral state](07-ephemeral-state.md) | Decide where "is this dropdown open?" lives, given there is no `local` |
+| [Ephemeral state](07-ephemeral-state.md) | Decide where "is this dropdown open?" lives, given there is no `local` — and where "it left but is still fading out" lives, given app-db cannot hold it |
 | [Testing](08-testing.md) | Assert a view's output without a browser, and know when you still need one |
 
 Eight pages is not an accident. K5 in [validation.md](../validation.md) kills the

--- a/docs/design/hicasso/hd-002-adjudication.md
+++ b/docs/design/hicasso/hd-002-adjudication.md
@@ -6,7 +6,7 @@
 > rather than an operator gate, on the pattern HD-013 already uses for the donor
 > gate: produced by a worker, adversarially reviewed, recorded on the standard
 > bead. **The operator may overturn any part of it.** Normative source:
-> [decisions.md](decisions.md) (HD-001…HD-021).
+> [decisions.md](decisions.md) (HD-001…HD-025).
 
 HD-002 is a measurement and the measurement has not run. This page does not argue
 about whether the ambient collector should be the product mechanism. It makes the

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/callback_form_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/callback_form_dom_cljs_test.cljs
@@ -1,0 +1,156 @@
+(ns re-frame.bench.hicasso.arm1.callback-form-dom-cljs-test
+  "THE ONE CALLBACK FORM, DRIVEN BY A REAL BROWSER EVENT
+  (rf2-2rtt6.35, HD-024).
+
+  `front/intent_cljs_test` proves the position table's algebra against
+  stand-in events, which is the right altitude for it — a stand-in makes
+  `preventDefault`, the target and the composition signals observable in
+  a way a real event does not. What a stand-in cannot show is that React
+  routes a genuine click to a closure this runtime minted, that the
+  intent it returns drains through the arm's synchronous door, and that
+  the echo is on screen. That is this file.
+
+  Three rows, and each one is a row of the position table:
+
+  1. **Event position.** `(hfn [e] …)` at `:on-click`, clicked for real;
+     its returned VECTOR reaches app-db and the DOM re-paints in the same
+     turn.
+  2. **Event position, no intent.** The same form whose body returns
+     something that is not a vector: the body runs and nothing is
+     dispatched. In the predecessor this is a SECOND form (`v/handler`)
+     with its own contract; here it is the same form at the same
+     position, and the return value is the only difference.
+  3. **Outside every walked position.** The form handed straight into a
+     raw `#js` props object and called the way a JavaScript library calls
+     it. This is the row that deletes the predecessor's fifth rule: there,
+     a roster carrier in that position is a marker OBJECT, so the call
+     raises the engine's own `TypeError` \"naming nothing you wrote\".
+     Here it is a function, so it simply runs.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every DOM claim degrades to a stated
+  skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview hfn]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::arm1-callback-form)
+
+(defonce ^:private !ran (atom 0))
+
+(defn- skip! [why] (is true (str "a callback-form claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (reset! !ran 0)
+  (lane/leave-act-environment!)
+  (dogfood/make-frame! frame-id 3)
+  (dogfood/reseed! frame-id 3)
+  frame-id)
+
+;; ---------------------------------------------------------------------------
+;; The screen — one form at one position, three times
+;; ---------------------------------------------------------------------------
+
+(defview toggle-row
+  "The row a real click lands on. `hfn` is the ONE form; `:on-click` is
+  the position; the returned vector is the contract that position
+  imposes. Nothing here names a form: the author wrote a function and
+  returned data."
+  [{:keys [id]}]
+  (let [done? (rt/sub [:dogfood/done? id])]
+    [:li.row {:data-id id :data-done (str done?)}
+     [:button.toggle
+      {:on-click (hfn [e]
+                   (swap! !ran inc)
+                   ;; A live event: the same form the predecessor would
+                   ;; need `v/event` for, reading the DOM event and
+                   ;; returning ONE intent.
+                   (when (= "toggle" (.. e -target -dataset -role))
+                     [:dogfood/toggle id]))
+       :data-role "toggle"}
+      "toggle"]
+     [:button.silent
+      ;; The same form, same position, whose body returns something that
+      ;; is not a vector. The predecessor spells this `v/handler`.
+      {:on-click (hfn [_] (swap! !ran inc) :nothing-to-dispatch)}
+      "silent"]]))
+
+(defn- query [handle sel] (.querySelector (:container handle) sel))
+
+;; ---------------------------------------------------------------------------
+;; 1 — event position: a returned vector reaches app-db and the DOM
+;; ---------------------------------------------------------------------------
+
+(deftest a-real-click-on-the-one-form-dispatches-what-it-returned
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [toggle-row {:id 1}])]
+        (try
+          (is (= "false" (.getAttribute (query handle ".row") "data-done")))
+          (.click (query handle ".toggle"))
+          (mount/settle!)
+          (is (= 1 @!ran) "React routed the click to the closure the runtime minted")
+          (is (= "true" (.getAttribute (query handle ".row") "data-done"))
+              "and the intent it RETURNED drained through the arm's
+               synchronous door, so the echo is on screen in the same turn")
+          (.click (query handle ".toggle"))
+          (mount/settle!)
+          (is (= "false" (.getAttribute (query handle ".row") "data-done"))
+              "and again, so this is a working handler and not a one-shot")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — event position: a return that is not a vector dispatches nothing
+;; ---------------------------------------------------------------------------
+
+(deftest the-same-form-at-the-same-position-can-return-nothing
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [toggle-row {:id 1}])]
+        (try
+          (.click (query handle ".silent"))
+          (mount/settle!)
+          (is (= 1 @!ran) "the body ran")
+          (is (= "false" (.getAttribute (query handle ".row") "data-done"))
+              "and nothing was dispatched — in the predecessor this is a
+               different FORM with a different contract; here it is the same
+               form, and the return value is the whole of the difference")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — outside every walked position, it is a function
+;; ---------------------------------------------------------------------------
+
+(deftest a-javascript-library-calling-it-natively-gets-a-real-call
+  (testing "the predecessor's fifth rule, deleted. Its roster forms are
+            site-owned, and a carrier that reaches a raw `#js` prop is a
+            marker object rather than a function — so `props.onPing(…)`
+            raises the engine's own TypeError, worded after whatever
+            expression it tripped on and naming nothing the author wrote.
+            The one form is a function everywhere, so a position Hicasso
+            never walks costs the CONTRACT and nothing else."
+    (let [cb       (hfn [x] (swap! !ran inc) [:would-have-dispatched x])
+          js-props #js {:onPing cb}]
+      (reset! !ran 0)
+      (is (fn? (.-onPing js-props)))
+      (is (= [:would-have-dispatched 3] ((.-onPing js-props) 3)))
+      (is (= 1 @!ran))
+      (is (true? (intent/callback? cb))
+          "and it is still the marked form, so a position that DOES walk it
+           would impose that position's contract on the same value"))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj
@@ -1,5 +1,6 @@
 (ns re-frame.bench.hicasso.arm1.lang
-  "`defview` — the one macro Arm 1 has (rf2-2rtt6.9).
+  "`defview` and `hfn` — the two macros Arm 1 has (rf2-2rtt6.9,
+  rf2-2rtt6.35).
 
   It exists because the authoring surface is a *deliverable*: HD-002 has
   the dogfood screen written in three renderings and judged on diff and
@@ -47,3 +48,22 @@
        (re-frame.bench.hicasso.arm1.runtime/mint-view!
          ~view-name
          (fn ~body-name ~argv ~@body)))))
+
+(defmacro hfn
+  "**The one callback form** (HD-024). `h/fn` in the authoring surface;
+  spelled `hfn` here because `h/fn` is qualified in the product and a
+  bare `fn` would shadow `cljs.core/fn` on a `:refer`.
+
+  Expands to nothing but a marked `fn`:
+
+      (hfn [e] (js/Array.from (.. e -target -files)) …)
+      ;; =>
+      (re-frame.bench.hicasso.front.intent/callback (fn [e] …))
+
+  The value is an ORDINARY FUNCTION — that is the point of the ruling.
+  The contract comes from the position it is written at, so there is
+  nothing to choose between and nothing that can fail to be callable
+  where Hicasso does not walk. See
+  [[re-frame.bench.hicasso.front.intent]] for the position table."
+  [argv & body]
+  `(re-frame.bench.hicasso.front.intent/callback (fn ~argv ~@body)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence.cljs
@@ -1,0 +1,90 @@
+(ns re-frame.bench.hicasso.arm1.presence
+  "PRESENCE, DRIVEN BY REACT (rf2-2rtt6.37, HD-025). The impure half:
+  a component that owns the retained-children list and a clock. The
+  machine and the phase transform are
+  `re-frame.bench.hicasso.front.presence`, and they are pure.
+
+  ## What this costs, stated rather than buried
+
+  **Two React hooks — `useState` and `useEffect` — in THIS component.**
+  The ≤2-hook budget HD-020(b) polices is the *boundary shell's*, and
+  this is not a boundary shell: it reads no subscription, mounts no
+  registration and takes no cell. `runtime/shell` is untouched and the
+  dispatcher-level ledger still counts exactly two there.
+
+  The hooks are legitimate under HD-003's placement rule rather than in
+  spite of it: presence is animation lifecycle, which is component
+  mechanics by that rule's own list, and it is a *library* mechanic paid
+  once rather than an application one paid per view. The alternative
+  — keeping retention in a module-level registry keyed by instance —
+  would be a second reactivity system, which is the top item on the
+  anti-regression fence.
+
+  ## Why the machine is adjusted during render and not in an effect
+
+  Retention has to survive a render or the deadline is re-derived on
+  every pass and the terminal bound stops being terminal. But a value
+  derived from props does not need an effect to store it: React's own
+  guidance is to adjust state *while rendering* when a prop changes, and
+  that is what happens here — [[front.presence/step]] is idempotent, so
+  the comparison converges after one extra pass and never loops. An
+  effect would cost a paint with the wrong tree in it.
+
+  The effect that remains does the two things only a clock can: it flips
+  `:mounting` to `:present` after paint, and it arms **one** timer at the
+  earliest deadline. Deadlines are absolute instants, so a timer re-armed
+  because some *other* key changed cannot extend a child's retention."
+  (:require [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.presence :as presence]
+            ["react" :as react]))
+
+(defn- now [] (js/Date.now))
+
+(defn- presence-body [js-props]
+  (let [props      (or (unchecked-get js-props "rfProps") {})
+        timeout-ms (presence/check-timeout! (:timeout-ms props))
+        children   (:children props)
+        hook       (react/useState presence/initial)
+        state      (aget hook 0)
+        set-state  (aget hook 1)
+        next       (presence/step state children (now) timeout-ms)]
+    ;; Adjusting state while rendering — React's own answer to "a value
+    ;; derived from props that must persist". `step` is idempotent, so the
+    ;; equality test converges rather than looping.
+    (when-not (= next state) (set-state next))
+    (react/useEffect
+      (fn []
+        (let [expiry (when-some [d (presence/next-deadline next)]
+                       (js/setTimeout
+                         (fn [] (set-state (fn [s] (presence/expire s (now)))))
+                         (max 0 (- d (now)))))
+              ;; The enter flip lands on a macrotask rather than a layout
+              ;; effect: a class flip that beats the browser's first paint
+              ;; of the mounting styles animates nothing, and this is the
+              ;; weak half the guide teaches around.
+              enter  (when (presence/mounting? next)
+                       (js/setTimeout (fn [] (set-state presence/settle)) 0))]
+          (fn []
+            (when expiry (js/clearTimeout expiry))
+            (when enter (js/clearTimeout enter)))))
+      #js [(presence/pending-signature next)])
+    (codec/as-element (into [:<>] (presence/render next)))))
+
+(def presence
+  "`h/presence` — a boundary that retains exiting keyed children for
+  `:timeout-ms`, and applies each child's own `::h/mounting` /
+  `::h/unmounting` attribute overrides while it is in that phase.
+
+      [presence {:timeout-ms 300}
+       (for [t (rt/sub [:toasts/visible])]
+         [:div.toast {:key (:id t)
+                      ::h/unmounting {:class \"toast toast--exit\"
+                                      :inert true :aria-hidden true}}
+          (:message t)])]
+
+  A legal hiccup head, marked the same way a `defview` product is —
+  though it is not a Hicasso *reactive* boundary: it reads no
+  subscription and holds no cell. It inserts no wrapper node and stamps
+  no `data-*`; every child it renders is the author's own node with the
+  author's own attributes merged."
+  (codec/mark-boundary! (doto presence-body (aset "displayName" "hicasso/presence"))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence_dom_cljs_test.cljs
@@ -1,0 +1,182 @@
+(ns re-frame.bench.hicasso.arm1.presence-dom-cljs-test
+  "PRESENCE, MOUNTED — the toast tray written INLINE (rf2-2rtt6.37,
+  HD-025).
+
+  `front/presence_cljs_test` proves the machine and the phase transform
+  with no clock, which is itself one of the ruling's claims. This file
+  proves the part only a browser can: that React drives that machine,
+  that the exit attributes reach the real DOM on the real node, that
+  re-entry takes them off again, and that the node is gone after
+  `:timeout-ms` with nothing retained behind it.
+
+  **The whole point is that there is no child view here.** The
+  predecessor's guide requires one — `[:div.toast …]` extracted into a
+  declared, keyed `defview` purely so a dynamic var resolves against the
+  right child, with reading the phase inline in the parent recorded as a
+  trap that silently yields the parent's phase. The tray below is written
+  inline, in the parent, in one form.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every DOM claim degrades to a stated
+  skip."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.presence :refer [presence]]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(def ^:private frame-id ::arm1-presence)
+(def ^:private timeout-ms 60)
+
+;; Registered ABOVE `use-fixtures`, deliberately. The reset fixture captures
+;; its source-store baseline when the `use-fixtures` form is EVALUATED and
+;; restores that baseline before every test — so a `reg-sub` written below it
+;; is erased before the first row runs, and the screen renders nothing.
+
+(rf/reg-sub :toasts/visible (fn [db _] (:toasts db)))
+
+(rf/reg-event :toasts/set (fn [{:keys [db]} [_ ts]] {:db (assoc db :toasts ts)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     ;; `:timeout-ms` means two rows here wait on a real clock, and
+     ;; `cljs.test` hard-errors on a fn-form fixture in a suite with an
+     ;; `(async done …)` test.
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(defn- skip! [why] (is true (str "a presence claim needs a real React DOM — " why)))
+
+(defn- fresh! [ts]
+  (lane/leave-act-environment!)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:toasts/set ts]))
+  frame-id)
+
+;; ---------------------------------------------------------------------------
+;; The screen — one view, no child view, one override map
+;; ---------------------------------------------------------------------------
+
+(defview toast-tray
+  "The census-real shape, ported. Compare the predecessor's: two views, an
+  ambient `presence-phase` read, and three separate `(when exiting? …)`
+  attributes on the extracted child."
+  [_]
+  [presence {:timeout-ms timeout-ms}
+   (for [t (rt/sub [:toasts/visible])]
+     [:div.toast {:key (:id t)
+                  :data-id (:id t)
+                  :re-frame.hicasso/unmounting {:class       "toast--exit"
+                                                :inert       true
+                                                :aria-hidden true}}
+      (:message t)])])
+
+(def ^:private two [{:id 1 :message "Saved"} {:id 2 :message "Copied"}])
+(def ^:private one [{:id 1 :message "Saved"}])
+
+(defn- node [handle id]
+  (.querySelector (:container handle) (str ".toast[data-id=\"" id "\"]")))
+
+(defn- toast-count [handle]
+  (.-length (.querySelectorAll (:container handle) ".toast")))
+
+(defn- settled!
+  "Let the enter flip's macrotask land, then let React commit it."
+  []
+  (js/Promise. (fn [resolve]
+                 (js/setTimeout (fn [] (mount/settle!) (resolve true)) 0))))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the inline toast gets its exit attributes, and loses them on re-entry
+;; ---------------------------------------------------------------------------
+
+(deftest an-inline-toast-gets-the-exit-attributes-while-unmounting
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! two)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
+        (try
+          (is (= 2 (toast-count handle)) "both toasts are on screen")
+          (is (nil? (.getAttribute (node handle 2) "inert"))
+              "and neither is exiting")
+          (mount/dispatch! handle [:toasts/set one])
+          (is (= 2 (toast-count handle))
+              "the removed toast is RETAINED — it is gone from app-db and
+               still in the document, which is the whole of presence")
+          (let [exiting (node handle 2)]
+            (is (some? (.getAttribute exiting "inert"))
+                "the override reached the real node")
+            (is (= "true" (.getAttribute exiting "aria-hidden")))
+            (is (.contains (.-classList exiting) "toast--exit"))
+            (is (.contains (.-classList exiting) "toast")
+                "and the tag's own class is still there — the override merged
+                 onto the node rather than replacing it"))
+          (is (nil? (.getAttribute (node handle 1) "inert"))
+              "while its neighbour is untouched")
+          (testing "and re-entry cancels the exit rather than finishing it"
+            (mount/dispatch! handle [:toasts/set two])
+            (let [back (node handle 2)]
+              (is (nil? (.getAttribute back "inert")))
+              (is (nil? (.getAttribute back "aria-hidden")))
+              (is (not (.contains (.-classList back) "toast--exit")))
+              (is (= 2 (toast-count handle)))))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the node is gone after :timeout-ms, and nothing leaks
+;; ---------------------------------------------------------------------------
+
+(deftest the-retained-node-leaves-on-the-timeout
+  (if-not (mount/browser?)
+    (do (skip! ":node-test has no DOM") (async done (done)))
+    (async done
+      (fresh! two)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
+        (mount/dispatch! handle [:toasts/set one])
+        (is (= 2 (toast-count handle)) "retained, for now")
+        (js/setTimeout
+          (fn []
+            (mount/settle!)
+            (try
+              (is (= 1 (toast-count handle))
+                  "removal is terminal: :timeout-ms is a clock, not a
+                   transitionend listener, so the node leaves whether or not
+                   any CSS ran")
+              (is (nil? (node handle 2)))
+              (is (some? (node handle 1))
+                  "and the toast that never left is still there, so this is
+                   removal and not a teardown")
+              (finally (mount/release! handle) (done))))
+          (* 4 timeout-ms))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the enter phase, and the honest limit on it
+;; ---------------------------------------------------------------------------
+
+(deftest a-mounting-child-flips-to-present-after-paint
+  (if-not (mount/browser?)
+    (do (skip! ":node-test has no DOM") (async done (done)))
+    (async done
+      (fresh! [])
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
+        (mount/dispatch! handle [:toasts/set one])
+        (is (= 1 (toast-count handle)))
+        (-> (settled!)
+            (.then (fn [_]
+                     (try
+                       (is (nil? (.getAttribute (node handle 1) "inert"))
+                           "the child settled to :present — the enter override,
+                            if it had one, would be off by now. This is the
+                            weak half: a class flip can lose the race to
+                            paint, which is why the guide teaches an
+                            animation on insertion for enter and keeps the
+                            override for exit")
+                       (finally (mount/release! handle) (done)))))
+            (.catch (fn [e] (is false (str e)) (done))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence_dom_cljs_test.cljs
@@ -134,49 +134,54 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-retained-node-leaves-on-the-timeout
-  (if-not (mount/browser?)
-    (do (skip! ":node-test has no DOM") (async done (done)))
-    (async done
-      (fresh! two)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
-        (mount/dispatch! handle [:toasts/set one])
-        (is (= 2 (toast-count handle)) "retained, for now")
-        (js/setTimeout
-          (fn []
-            (mount/settle!)
-            (try
-              (is (= 1 (toast-count handle))
-                  "removal is terminal: :timeout-ms is a clock, not a
-                   transitionend listener, so the node leaves whether or not
-                   any CSS ran")
-              (is (nil? (node handle 2)))
-              (is (some? (node handle 1))
-                  "and the toast that never left is still there, so this is
-                   removal and not a teardown")
-              (finally (mount/release! handle) (done))))
-          (* 4 timeout-ms))))))
+  ;; ONE `async` block covering both branches: `cljs.test` runs only the
+  ;; first async block of a `deftest`, so a skip branch with its own block
+  ;; would be a test that silently stopped running in the browser.
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
+        (fresh! two)
+        (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
+          (mount/dispatch! handle [:toasts/set one])
+          (is (= 2 (toast-count handle)) "retained, for now")
+          (js/setTimeout
+            (fn []
+              (mount/settle!)
+              (try
+                (is (= 1 (toast-count handle))
+                    "removal is terminal: :timeout-ms is a clock, not a
+                     transitionend listener, so the node leaves whether or not
+                     any CSS ran")
+                (is (nil? (node handle 2)))
+                (is (some? (node handle 1))
+                    "and the toast that never left is still there, so this is
+                     removal and not a teardown")
+                (finally (mount/release! handle) (done))))
+            (* 4 timeout-ms)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — the enter phase, and the honest limit on it
 ;; ---------------------------------------------------------------------------
 
 (deftest a-mounting-child-flips-to-present-after-paint
-  (if-not (mount/browser?)
-    (do (skip! ":node-test has no DOM") (async done (done)))
-    (async done
-      (fresh! [])
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
-        (mount/dispatch! handle [:toasts/set one])
-        (is (= 1 (toast-count handle)))
-        (-> (settled!)
-            (.then (fn [_]
-                     (try
-                       (is (nil? (.getAttribute (node handle 1) "inert"))
-                           "the child settled to :present — the enter override,
-                            if it had one, would be off by now. This is the
-                            weak half: a class flip can lose the race to
-                            paint, which is why the guide teaches an
-                            animation on insertion for enter and keeps the
-                            override for exit")
-                       (finally (mount/release! handle) (done)))))
-            (.catch (fn [e] (is false (str e)) (done))))))))
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
+        (fresh! [])
+        (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
+          (mount/dispatch! handle [:toasts/set one])
+          (is (= 1 (toast-count handle)))
+          (-> (settled!)
+              (.then (fn [_]
+                       (try
+                         (is (nil? (.getAttribute (node handle 1) "inert"))
+                             "the child settled to :present — the enter override,
+                              if it had one, would be off by now. This is the
+                              weak half: a class flip can lose the race to
+                              paint, which is why the guide teaches an
+                              animation on insertion for enter and keeps the
+                              override for exit")
+                         (finally (mount/release! handle) (done)))))
+              (.catch (fn [e] (is false (str e)) (done)))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/census_article_editor_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/census_article_editor_cljs_test.cljs
@@ -1,0 +1,238 @@
+(ns re-frame.bench.hicasso.front.census-article-editor-cljs-test
+  "THE `:&` MERGE, DEMONSTRATED ON A CENSUS-REAL SCREEN (rf2-2rtt6.36).
+
+  The design review that produced HD-023 carried its own stated risk, and
+  it is worth repeating rather than softening: *all four proposals are
+  taste rulings dressed as deletions, and the instrument that would
+  falsify them lost its control arm.* Its mitigation is this file. The
+  claim 'one merge spelling is better' is not asserted here; a real
+  screen is ported and the two renderings are put side by side, with the
+  DOM they produce asserted identical so the comparison is about
+  authoring and nothing else.
+
+  ## The screen
+
+  `examples/real-apps/realworld_resources/article_editor.cljs:496-522` —
+  the RealWorld article editor's four form fields, which the fitness
+  harness names in five separate rows (R-A5 validation-display gating,
+  R-A10 busy discipline, census row 3a event-value extraction, 3b
+  `preventDefault` handlers, 1b parameterised reads). Four fields, each
+  controlled, each disabled off the same in-flight write, each with its
+  own error slot. Verbatim, one field of four:
+
+      [:input.form-control
+       {:type \"text\" :name \"description\" :placeholder \"What's this article about?\"
+        :data-testid \"editor-description\"
+        :value (:description draft) :disabled busy?
+        :on-blur #(dispatch [:editor/blur-field :description])
+        :on-change #(dispatch [:editor/edit-field :description (.. % -target -value)])}]
+
+  Four of those, differing in **three tokens each** — the field key, the
+  placeholder, and the test id — and repeating the controlled contract,
+  the busy rule and both handlers at every site. That repetition is the
+  thing a wrapper deletes, and it is the reason the corpus has it: the
+  wrapper is not free to write.
+
+  ## Why the predecessor cannot write the wrapper cheaply
+
+  Forwarding a caller's remainder onto an internal controlled `input`
+  needs the door-preserving spread form, and choosing the ordinary one
+  instead is a **silent** loss of caret and IME protection — recorded
+  twice in the predecessor's own docs as a wall with no error attached
+  ('Dynamic map on controlled input without spread-safe | forfeits door
+  proof'). So the author must know that a third form exists, know which
+  of three applies here, and get it right with nothing checking. A
+  wrapper whose correctness depends on the caller picking the right merge
+  syntax is a wrapper most authors correctly decline to write.
+
+  ## What is asserted
+
+  Both renderings are built and their elements compared attribute by
+  attribute, and both handlers are fired and their dispatched intents
+  compared. If the ported screen were not the same screen, the diff in
+  the PR would be measuring two different things."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.intent :as intent]))
+
+(use-fixtures :each {:before (fn [] (codec/reset-caches!))})
+
+(def ^:private draft
+  {:title "A title" :description "A description" :body "A body" :tagList "a,b"})
+
+(def ^:private errors
+  {:title nil :description "can't be blank" :body nil :tagList nil})
+
+;; ---------------------------------------------------------------------------
+;; BEFORE — the census's own shape, transliterated
+;; ---------------------------------------------------------------------------
+;;
+;; Intent vectors replace the four `#(dispatch …)` closures, because that
+;; substitution is rf2-2rtt6.8's and is not what this file is measuring. Everything
+;; else is the corpus's shape: one attribute map per field, written out per field.
+
+(defn- inline-fieldset [busy?]
+  [:fieldset
+   [:fieldset.form-group
+    [:input.form-control.form-control-lg
+     {:type "text" :name "title" :placeholder "Article Title" :data-testid "editor-title"
+      :value (:title draft) :disabled busy?
+      :on-blur  [:editor/blur-field :title]
+      :on-input [:editor/edit-field :title :re-frame.hicasso/value]}]
+    (when (:title errors) [:div.error-messages (:title errors)])]
+   [:fieldset.form-group
+    [:input.form-control
+     {:type "text" :name "description" :placeholder "What's this article about?"
+      :data-testid "editor-description"
+      :value (:description draft) :disabled busy?
+      :on-blur  [:editor/blur-field :description]
+      :on-input [:editor/edit-field :description :re-frame.hicasso/value]}]
+    (when (:description errors) [:div.error-messages (:description errors)])]
+   [:fieldset.form-group
+    [:input.form-control
+     {:type "text" :name "body" :placeholder "Write your article (in markdown)"
+      :data-testid "editor-body"
+      :value (:body draft) :disabled busy?
+      :on-blur  [:editor/blur-field :body]
+      :on-input [:editor/edit-field :body :re-frame.hicasso/value]}]
+    (when (:body errors) [:div.error-messages (:body errors)])]
+   [:fieldset.form-group
+    [:input.form-control
+     {:type "text" :name "tags" :placeholder "Enter tags (comma-separated)"
+      :data-testid "editor-tags"
+      :value (:tagList draft) :disabled busy?
+      :on-blur  [:editor/blur-field :tagList]
+      :on-input [:editor/edit-field :tagList :re-frame.hicasso/value]}]
+    (when (:tagList errors) [:div.error-messages (:tagList errors)])]])
+
+;; ---------------------------------------------------------------------------
+;; AFTER — one helper that owns the contract, `:&` carrying the remainder
+;; ---------------------------------------------------------------------------
+;;
+;; `field` owns exactly the things that must not vary: the controlled pair, the
+;; busy rule, the blur intent and the error slot. Everything a call site still
+;; needs to say rides through `:&` as ONE key, and the owned-literal law means the
+;; helper does not have to defend itself against what arrives there.
+
+(defn- field [{:keys [id busy?] :as attrs}]
+  [:fieldset.form-group
+   [:input.form-control {:& (dissoc attrs :id :busy?)
+                         :value    (get draft id)
+                         :disabled busy?
+                         :on-blur  [:editor/blur-field id]
+                         :on-input [:editor/edit-field id :re-frame.hicasso/value]}]
+   (when-some [e (get errors id)] [:div.error-messages e])])
+
+(defn- merged-fieldset [busy?]
+  [:fieldset
+   (field {:id :title :busy? busy? :class "form-control-lg"
+           :type "text" :name "title" :placeholder "Article Title"
+           :data-testid "editor-title"})
+   (field {:id :description :busy? busy?
+           :type "text" :name "description" :placeholder "What's this article about?"
+           :data-testid "editor-description"})
+   (field {:id :body :busy? busy?
+           :type "text" :name "body" :placeholder "Write your article (in markdown)"
+           :data-testid "editor-body"})
+   (field {:id :tagList :busy? busy?
+           :type "text" :name "tags" :placeholder "Enter tags (comma-separated)"
+           :data-testid "editor-tags"})])
+
+;; ---------------------------------------------------------------------------
+;; Reading elements back
+;; ---------------------------------------------------------------------------
+
+(defn- children-of [e]
+  (let [c (aget (.-props e) "children")]
+    (cond (array? c) (vec c) (nil? c) [] :else [c])))
+
+(defn- inputs
+  "Every `<input>` element in a rendered fieldset, in document order."
+  [e]
+  (into [] (mapcat (fn [group] (filter #(and (some? %) (= "input" (.-type %)))
+                                       (children-of group))))
+        (children-of e)))
+
+(defn- static-attrs
+  "An element's props with the handlers removed — the half that is comparable
+  by value. The handlers are compared separately, by what they dispatch."
+  [e]
+  (into (sorted-map)
+        (remove (fn [[_ v]] (fn? v)))
+        (js->clj (.-props e))))
+
+(defn- render [hiccup dispatched]
+  (intent/with-frame (fn [ev] (swap! dispatched conj ev))
+                     (fn [] (codec/as-element hiccup))))
+
+;; ---------------------------------------------------------------------------
+;; The port is the same screen
+;; ---------------------------------------------------------------------------
+
+(deftest the-two-renderings-produce-the-same-four-controlled-inputs
+  (doseq [busy? [false true]]
+    (testing (str "busy? = " busy?)
+      (let [seen   (atom [])
+            before (inputs (render (inline-fieldset busy?) seen))
+            after  (inputs (render (merged-fieldset busy?) seen))]
+        (is (= 4 (count before) (count after)))
+        (doseq [[b a] (map vector before after)]
+          (is (= (static-attrs b) (static-attrs a))
+              "every static attribute, including the class the tag shorthand
+               composed and the busy rule, is identical"))))))
+
+(deftest the-two-renderings-dispatch-the-same-intents
+  (let [seen-b (atom [])
+        seen-a (atom [])
+        before (inputs (render (inline-fieldset false) seen-b))
+        after  (inputs (render (merged-fieldset false) seen-a))]
+    (doseq [e before] ((aget (.-props e) "onInput") #js {:target #js {:value "typed"}}))
+    (doseq [e before] ((aget (.-props e) "onBlur") #js {:target #js {}}))
+    (doseq [e after] ((aget (.-props e) "onInput") #js {:target #js {:value "typed"}}))
+    (doseq [e after] ((aget (.-props e) "onBlur") #js {:target #js {}}))
+    (is (= @seen-b @seen-a))
+    (is (= [[:editor/edit-field :title "typed"]
+            [:editor/edit-field :description "typed"]
+            [:editor/edit-field :body "typed"]
+            [:editor/edit-field :tagList "typed"]
+            [:editor/blur-field :title]
+            [:editor/blur-field :description]
+            [:editor/blur-field :body]
+            [:editor/blur-field :tagList]]
+           @seen-a))))
+
+(deftest the-error-slot-still-appears-for-exactly-the-field-that-has-one
+  (let [seen  (atom [])
+        after (children-of (render (merged-fieldset false) seen))
+        errs  (into [] (mapcat (fn [g] (filter #(and (some? %)
+                                                     (= "div" (.-type %)))
+                                               (children-of g))))
+                    after)]
+    (is (= 1 (count errs)) "R-A5: one field is in error, so one slot renders")
+    (is (= "can't be blank" (aget (.-props (first errs)) "children")))))
+
+;; ---------------------------------------------------------------------------
+;; The property the predecessor's wrapper cannot have
+;; ---------------------------------------------------------------------------
+
+(deftest the-helper-does-not-have-to-defend-itself
+  (testing "the reason this wrapper is writable at all. A call site that
+            forwards a whole remainder — a props map it received, a theme's
+            part attrs, anything dynamic — cannot reach the controlled
+            contract, because the law is unconditional and the helper wrote
+            those keys as literals. There is no third form to pick, and no
+            silent forfeit for picking wrong."
+    (let [seen (atom [])
+          e    (first (inputs (render [:fieldset
+                                       (field {:id :title :busy? false
+                                               :value      "CLOBBER"
+                                               :disabled   true
+                                               :on-input   [:hostile/edit]
+                                               :data-testid "editor-title"})]
+                                      seen)))]
+      (is (= "A title" (aget (.-props e) "value")))
+      (is (false? (aget (.-props e) "disabled")))
+      (is (= "editor-title" (aget (.-props e) "data-testid"))
+          "and everything the caller was entitled to still arrives")
+      ((aget (.-props e) "onInput") #js {:target #js {:value "typed"}})
+      (is (= [[:editor/edit-field :title "typed"]] @seen)))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -76,7 +76,18 @@
 
   A React element is a legal child anywhere. No metadata keys, no second
   calling convention, and a plain function in head position is a loud
-  error."
+  error.
+
+  ## Two reserved attribute keys, and nothing else
+
+  | Key | Meaning |
+  |---|---|
+  | `:&` | the caller's remainder map. One merge, one law: **the literal keys written in the map always win** (HD-023, [[merge-caller]]) |
+  | `:ref` | a callback ref in v0; a **vector** is the reserved data spelling and is refused loudly (HD-022, [[check-ref!]]) |
+
+  Both are attribute *keys*, not forms — so the merge survives into a
+  structural test and into tooling, and neither adds a public concept in
+  the K5 sense."
   (:require [clojure.string :as str]
             [re-frame.bench.hicasso.front.intent :as intent]
             ["react" :as react]))
@@ -255,6 +266,62 @@
     :else                    v))
 
 ;; ---------------------------------------------------------------------------
+;; `:&` — the one attribute merge, and the owned-literal law (HD-023)
+;; ---------------------------------------------------------------------------
+
+(def merge-key
+  "`:&` — the reserved attribute key carrying a caller's remainder map.
+  There is exactly one merge in Hicasso and this is it. It is DATA, not a
+  call, so a forwarded remainder survives into a structural test and into
+  tooling; and it cannot collide with a real DOM attribute."
+  :&)
+
+(def merge-structural-keys
+  "Never taken from a `:&` map. `:key` and `:ref` address the ELEMENT the
+  caller wrote, not the one it is forwarding onto — React's key contract
+  and HD-016's ref rule are both about node identity, and a remainder map
+  is about attributes. Dropping them is what makes a hostile or careless
+  remainder unable to reach either."
+  #{:key :ref})
+
+(defn merge-caller
+  "Fold a `:&` remainder into the attribute map, under **the owned-literal
+  law, unconditionally**: the literal keys written in the map ALWAYS win.
+
+  This is HD-010(a)'s law — `:key`, `:ref`, controlled `:value`/`:checked`
+  and owned event handlers are unoverridable — applied to *every* merge
+  rather than only under theming, and it is the whole point of the
+  ruling. The predecessor needs the author to choose between three merge
+  forms depending on where the target is, and the penalty for choosing
+  wrong is SILENT: caret and IME protection simply stop, with no
+  diagnostic anywhere. Making the law unconditional deletes that class —
+  the controlled-input door cannot be forfeited by a merge at all,
+  because a merge cannot reach an owned literal.
+
+  The case where a caller override SHOULD win is spelled by **not writing
+  the literal**, which is the honest way round: the dangerous default is
+  the other one.
+
+  Absent — the overwhelming case — this is one `contains?` and the map
+  comes back by identity, allocating nothing. Present, it is one `merge`
+  in the direction that makes the law true by construction."
+  [props]
+  (if-not (contains? props merge-key)
+    props
+    (let [caller (get props merge-key)
+          owned  (dissoc props merge-key)]
+      (cond
+        (nil? caller) owned
+        (map? caller) (merge (apply dissoc caller merge-structural-keys) owned)
+        :else
+        (fail! :rf.error/hicasso-merge-not-a-map
+               'front.codec/merge-caller
+               (str ":& carries a caller's attribute map and nothing else. It was "
+                    "given " (pr-str (type caller)) ". Forward a map, or drop the key.")
+               :forward-a-map-at-the-merge-key
+               {:value caller})))))
+
+;; ---------------------------------------------------------------------------
 ;; The reserved `:ref` value-space (HD-022)
 ;; ---------------------------------------------------------------------------
 
@@ -284,16 +351,25 @@
   props)
 
 (defn convert-props
-  "One pass over the attribute map: refuse a reserved `:ref` value, fold
-  the tag shorthand, drop `:key` (React's own contract — it is not an
-  attribute), lower every intent, and set each converted value under its
-  React prop name.
+  "One pass over the attribute map: fold a `:&` remainder under the
+  owned-literal law, refuse a reserved `:ref` value, fold the tag
+  shorthand, drop `:key` (React's own contract — it is not an attribute),
+  lower every intent, and set each converted value under its React prop
+  name.
 
-  Note the order: intent lowering happens *inside* this single walk, so
-  the codec does not traverse the props map a second time to find the
-  event positions."
+  Two things about the order. Intent lowering happens *inside* the single
+  walk, so the codec does not traverse the props map a second time to
+  find the event positions. And [[merge-caller]] runs FIRST — before the
+  tag shorthand and before any prop-name conversion — which is what lets
+  one rule cover the class the predecessor needs a third form for. A
+  forwarded `:className` is merged as the key it was written as and then
+  converted by *this position's* grammar; nothing canonicalises it into
+  `:class` on the way through and hands the wrong name onward. It also
+  puts a forwarded `:class` into the shorthand merge, so
+  `[:input.form-control {:& caller}]` composes `\"form-control\"` with the
+  caller's classes instead of one silently replacing the other."
   [props ^ParsedTag parsed]
-  (let [props (-> props check-ref! (merge-shorthand parsed) (dissoc :key))]
+  (let [props (-> props merge-caller check-ref! (merge-shorthand parsed) (dissoc :key))]
     (reduce-kv (fn [o k v]
                  (let [n (cached-prop-name k)]
                    (when-not (reserved-cache-keys n)
@@ -383,7 +459,20 @@
 
 (defn- boundary-element [argv]
   (let [has-props? (props-map? argv 1)
-        props      (if has-props? (nth argv 1) {})
+        ;; The SAME merge, at the crossing. This is the case the
+        ;; predecessor needs a third rule for: its spread forms are
+        ;; element forms whose content is the attribute grammar, so
+        ;; sending a remainder through one on the way to a declared
+        ;; foreign head rewrites `:className` into the `:class` slot and
+        ;; the component never sees the prop it reads — which is why
+        ;; "neither spread form is legal there" and an ordinary `merge`
+        ;; is prescribed instead. `:&` has no such problem because it is
+        ;; not a spread: it is a key in the props map, merged before any
+        ;; conversion, and the conversion that follows is the POSITION's
+        ;; own — a props map handed to a boundary or a declared foreign
+        ;; head is passed through unrenamed. One rule, both positions,
+        ;; and the owned-literal law holds identically at each.
+        props      (merge-caller (if has-props? (nth argv 1) {}))
         children   (realize-children argv (if has-props? 2 1))
         body-props (cond-> (dissoc props :key)
                      children (assoc :children children))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -84,6 +84,19 @@
 (declare as-element)
 
 ;; ---------------------------------------------------------------------------
+;; Errors
+;; ---------------------------------------------------------------------------
+
+(defn- fail!
+  "The codec's one refusal shape, matching the arm runtime's: an id a test
+  can assert on, the position that refused, why, and what to do instead."
+  [id where reason recovery extra]
+  (throw (ex-info (str reason " [" id "]")
+                  (merge {:rf.error/id id :where where
+                          :reason reason :recovery recovery}
+                         extra))))
+
+;; ---------------------------------------------------------------------------
 ;; Cache hygiene — the own-property guard both caches share
 ;; ---------------------------------------------------------------------------
 
@@ -241,16 +254,46 @@
     (coll? v)                (clj->js v)
     :else                    v))
 
+;; ---------------------------------------------------------------------------
+;; The reserved `:ref` value-space (HD-022)
+;; ---------------------------------------------------------------------------
+
+(defn- check-ref!
+  "`:ref` takes a **function** in v0 — HD-003's honest escape hatch, and
+  HD-016's callback-refs-only rule, both unchanged. A **vector** is the
+  reserved spelling for the later data form, `{:ref [::autosize {:max-rows
+  8}]}`, and v0 refuses it here rather than handing React an opaque array
+  it would ignore in silence.
+
+  One branch and one error id. The point is not the branch: it is that the
+  value-space is claimed *now*, so the imperative escape can become data
+  later without minting a second attribute name — and so that an author
+  who writes tomorrow's spelling today learns it from a diagnostic rather
+  than from a ref that never fires."
+  [props]
+  (when (vector? (:ref props))
+    (fail! :rf.error/hicasso-ref-vector-reserved
+           'front.codec/convert-props
+           (str "A vector at :ref is RESERVED and is not a v0 surface. "
+                "`{:ref [registered-id config]}` is the reserved spelling for "
+                "registered node ownership; v0 accepts a callback ref (a "
+                "function) only. Write the function, or move the mechanic to "
+                "an event and an effect.")
+           :use-a-callback-ref-or-an-effect
+           {:ref (:ref props)}))
+  props)
+
 (defn convert-props
-  "One pass over the attribute map: fold the tag shorthand, drop `:key`
-  (React's own contract — it is not an attribute), lower every intent,
-  and set each converted value under its React prop name.
+  "One pass over the attribute map: refuse a reserved `:ref` value, fold
+  the tag shorthand, drop `:key` (React's own contract — it is not an
+  attribute), lower every intent, and set each converted value under its
+  React prop name.
 
   Note the order: intent lowering happens *inside* this single walk, so
   the codec does not traverse the props map a second time to find the
   event positions."
   [props ^ParsedTag parsed]
-  (let [props (-> props (merge-shorthand parsed) (dissoc :key))]
+  (let [props (-> props check-ref! (merge-shorthand parsed) (dissoc :key))]
     (reduce-kv (fn [o k v]
                  (let [n (cached-prop-name k)]
                    (when-not (reserved-cache-keys n)

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
@@ -225,6 +225,49 @@
   (is (thrown-with-msg? js/Error #"not a valid element head" (codec/as-element [42 {}]))))
 
 ;; ---------------------------------------------------------------------------
+;; The reserved `:ref` value-space (HD-022, rf2-2rtt6.38)
+;; ---------------------------------------------------------------------------
+
+(deftest a-callback-ref-is-the-v0-surface-and-reaches-react-by-identity
+  (testing "HD-003's escape hatch and HD-016's callback-refs-only rule are
+            unchanged by the reservation: a function at :ref is the v0
+            spelling, and it arrives at React as the same function object —
+            rewrapping it would detach and reattach the node every render."
+    (let [f (fn [_node] nil)
+          e (codec/as-element [:div {:ref f}])]
+      (is (identical? f (prop e "ref"))))))
+
+(deftest a-vector-at-ref-is-reserved-and-refused-loudly
+  (testing "the whole of rf2-2rtt6.38. `{:ref [registered-id config]}` is the
+            spelling the later data form wants, so v0 claims the value-space
+            now and refuses it with a diagnostic naming the reservation —
+            rather than handing React an opaque array, which it would ignore
+            in silence and which would look like a ref that never fires."
+    (is (thrown-with-msg? js/Error #"RESERVED"
+                          (codec/as-element [:div {:ref [::autosize {:max-rows 8}]}])))
+    (try
+      (codec/as-element [:textarea.composer {:ref [::autosize {:max-rows 8}]}])
+      (is false "should have thrown")
+      (catch :default e
+        (let [d (ex-data e)]
+          (is (= :rf.error/hicasso-ref-vector-reserved (:rf.error/id d)))
+          (is (= :use-a-callback-ref-or-an-effect (:recovery d)))
+          (is (= [::autosize {:max-rows 8}] (:ref d))
+              "the refusal carries the value it refused, so a later
+               migration can find its own call sites"))))))
+
+(deftest the-reservation-costs-one-branch-and-claims-nothing-else
+  (testing "no other :ref value moves. A string ref, a nil ref and a map at
+            :ref all pass through the ordinary conversion — the reservation
+            is the VECTOR arm and nothing wider, because a wider claim would
+            be designing the later surface rather than reserving room for it."
+    (is (nil? (prop (codec/as-element [:div {:ref nil}]) "ref")))
+    (is (= "legacy" (prop (codec/as-element [:div {:ref "legacy"}]) "ref")))
+    (is (some? (prop (codec/as-element [:div {:ref {:a 1}}]) "ref"))))
+  (testing "and :ref is not an event position, so intent lowering never sees it"
+    (is (false? (intent/event-prop? :ref)))))
+
+;; ---------------------------------------------------------------------------
 ;; The codec's one policy call — intent lowering happens inside the walk
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
@@ -225,6 +225,104 @@
   (is (thrown-with-msg? js/Error #"not a valid element head" (codec/as-element [42 {}]))))
 
 ;; ---------------------------------------------------------------------------
+;; `:&` — one merge, and the owned-literal law unconditional
+;; (HD-023, rf2-2rtt6.36)
+;; ---------------------------------------------------------------------------
+
+(deftest a-caller-remainder-merges-under-the-literals-that-are-written
+  (testing "the law, in its plainest form: keys the caller supplies and the
+            element does not, land; keys the element writes are not
+            reachable from `:&` at all."
+    (let [e (codec/as-element [:div {:& {:title "from caller" :id "caller"}
+                                     :id "owned"}])]
+      (is (= "from caller" (prop e "title")) "an unclaimed key lands")
+      (is (= "owned" (prop e "id")) "a written literal always wins")
+      (is (not (contains? (set (prop-names e)) "&"))
+          ":& is a reserved key, never an attribute")))
+  (testing "the whole point of the direction: a caller override is spelled by
+            NOT writing the literal, because the dangerous default is the
+            other way round"
+    (is (= "caller" (prop (codec/as-element [:div {:& {:id "caller"}}]) "id")))))
+
+(deftest a-hostile-remainder-cannot-forfeit-the-controlled-input-door
+  (testing "the predecessor's silent failure, deleted. There, a dynamic map
+            merged onto a controlled input WITHOUT the door-preserving spread
+            form forfeits caret and IME protection, and no diagnostic is
+            raised anywhere — the choice of syntax is the choice of
+            correctness. Here there is one merge and the law is
+            unconditional, so a remainder carrying the whole controlled
+            contract reaches none of it."
+    (let [!seen (atom [])
+          caller {:value      "HOSTILE"
+                  :on-input   [:hostile/edit]
+                  :key        "hostile"
+                  :ref        (fn [_] (swap! !seen conj :ref-fired))
+                  :class      "from-caller"
+                  :aria-label "kept"}
+          e (intent/with-frame (fn [ev] (swap! !seen conj ev))
+                               (fn [] (codec/as-element
+                                       [:input {:& caller
+                                                :value    "owned"
+                                                :on-input [:todo.ui/edit 7 :re-frame.hicasso/value]}])))]
+      (is (= "owned" (prop e "value")) "the controlled value survives")
+      (is (nil? (el-key e)) ":key is never taken from a remainder")
+      (is (nil? (prop e "ref")) ":ref is never taken from a remainder")
+      (is (= "from-caller" (prop e "className")) "an unclaimed key still lands")
+      (is (= "kept" (prop e "aria-label")))
+      ((prop e "onInput") #js {:target #js {:value "typed"}})
+      (is (= [[:todo.ui/edit 7 "typed"]] @!seen)
+          "and the owned handler is the one that fired — the caller's intent
+           never reached the element"))))
+
+(deftest an-owned-class-composes-through-the-tag-shorthand
+  (testing "the one place a caller's value and an owned value both survive,
+            and it needs no exception to the law: the element's own classes
+            are written on the TAG, which is not a literal attribute key, so
+            the shorthand merge composes them with whatever the remainder
+            brought."
+    (let [e (codec/as-element [:input.form-control {:& {:class "form-control-lg"}}])]
+      (is (= "form-control form-control-lg" (prop e "className"))))
+    (testing "and a literal :class still wins outright, because it is a literal"
+      (let [e (codec/as-element [:input.base {:& {:class "from-caller"} :class "owned"}])]
+        (is (= "base owned" (prop e "className")))))))
+
+(deftest the-same-merge-and-the-same-law-hold-at-a-crossing
+  (testing "the case the predecessor needs a THIRD rule for. Its spread forms
+            are element forms, so forwarding a remainder through one onto a
+            declared foreign head rewrites `:className` into the `:class`
+            slot and the component never sees the prop it reads — hence
+            'neither spread form is legal there' and an ordinary `merge`
+            instead. `:&` is not a spread: it is a key in the props map,
+            merged before any conversion, and the conversion that follows is
+            the position's own."
+    (let [e (codec/as-element [a-view {:& {:className "react-name" :selected "caller"}
+                                       :selected "owned"}])]
+      (is (= {:className "react-name" :selected "owned"} (prop e "rfProps"))
+          ":className crosses under the name it was written as, and the
+           owned literal still wins")))
+  (testing "a remainder's :key cannot become the crossing's key either"
+    (let [e (codec/as-element [a-view {:& {:key "hostile"} :id 7}])]
+      (is (nil? (el-key e)))
+      (is (= {:id 7} (prop e "rfProps"))))))
+
+(deftest the-merge-costs-one-lookup-when-it-is-absent
+  (testing "the overwhelming case. No `:&` means the map comes back by
+            identity — the feature allocates nothing on an element that does
+            not use it."
+    (let [props {:id "x" :class "y"}]
+      (is (identical? props (codec/merge-caller props)))))
+  (testing "an explicit nil remainder is a no-op that still removes the key"
+    (is (= {:id "x"} (codec/merge-caller {:& nil :id "x"}))))
+  (testing "a non-map remainder is a loud error rather than a silent drop"
+    (is (thrown-with-msg? js/Error #"carries a caller's attribute map"
+                          (codec/as-element [:div {:& [:not :a :map]}])))
+    (try
+      (codec/as-element [:div {:& "nope"}])
+      (is false "should have thrown")
+      (catch :default e
+        (is (= :rf.error/hicasso-merge-not-a-map (:rf.error/id (ex-data e))))))))
+
+;; ---------------------------------------------------------------------------
 ;; The reserved `:ref` value-space (HD-022, rf2-2rtt6.38)
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -19,8 +19,54 @@
   |------------|------------|
   | vector     | a closure dispatching that intent |
   | map        | a composition-gated key-map |
+  | [[callback]] | one form; the POSITION selects its contract — see below |
   | fn         | passed through untouched — ordinary functions stay legal |
   | anything else | passed through untouched |
+
+  ## ONE callback form, and the position selects the contract (HD-024)
+
+  When a vector is not enough, the predecessor asks the author to pick
+  from a roster of FOUR forms, each with a different contract — one
+  returning an event vector, one whose return is ignored, one that is
+  pure and runs during a foreign render, one that passes a function
+  through by identity — and then adds a FIFTH rule about *where the
+  roster reaches*. Outside that reach the failure is not even the
+  library's: a roster carrier handed to a raw `#js` prop is a marker
+  object rather than a function, so the author gets the engine's own
+  `TypeError`, \"naming nothing you wrote\".
+
+  Hicasso ships **one** form, [[callback]] (`h/fn`), and it is an
+  ORDINARY FUNCTION. The contract comes from the position, because the
+  runtime already knows every position it walks:
+
+  | Position | How it is recognised | Contract |
+  |---|---|---|
+  | a native `:on-*` prop | [[event-prop?]] — the same two-shape rule as an intent vector | **event**: a returned VECTOR is dispatched; any other return is ignored |
+  | a `defhost` `:callbacks` entry | the declaration already says `:event` or `:handler` — never inferred from an `on*` name | as declared; `:handler` is the return-ignored contract |
+  | any other prop position (a slot, a render prop) | not an event position | **render**: pure. The return is the render output and is NOT dispatched; dispatching *from inside the call* is a loud error naming the position |
+  | `:ref` | [[ref-position?]] | React's own: commit phase, the node as the argument, the return as the detach cleanup. Excluded from lowering entirely |
+  | anywhere Hicasso does not walk — a raw `#js` prop, a value handed to a foreign API | it is not a position | it is a plain function and it simply runs; the return is ignored |
+
+  That last row is the deletion. There is no carrier object, so there is
+  nothing that can fail to be callable, so the fifth rule has nothing to
+  govern.
+
+  **A Hicasso view's own props map is not a position — it is data in
+  transit.** An intent vector handed to a view is not lowered there
+  either; the view puts it on an element and *that* position lowers it.
+  A callback travels the same way, and a callback a view simply *calls*
+  is ordinary Clojure with no foreign ABI in between, so there is nothing
+  to protect. Which is also why the render row is not free-floating
+  policy: it bites exactly where something other than Hicasso invokes the
+  callback.
+
+  **`raw-fn`'s identity passthrough is not v0, and costs nothing to
+  omit**: [[re-frame.bench.hicasso.front.codec/convert-prop-value]]
+  already passes functions to React by identity, deliberately, so that
+  `React.memo` and every downstream bail-out that compares handler
+  identity keep working. The behaviour the predecessor spells as a fourth
+  roster form is the default here. The census agrees with the omission —
+  zero foreign components across 85 idiomatic files.
 
   ## The frame, and why the closure closes over it
 
@@ -104,6 +150,12 @@
   [dispatch body-fn]
   (binding [*dispatch* dispatch] (body-fn)))
 
+(defn- fail! [id where reason recovery extra]
+  (throw (ex-info (str reason " [" id "]")
+                  (merge {:rf.error/id id :where where
+                          :reason reason :recovery recovery}
+                         extra))))
+
 (defn- require-dispatch [intent]
   (or *dispatch*
       (throw (ex-info (str "Intent " (pr-str intent) " was lowered with no ambient frame; "
@@ -114,6 +166,112 @@
                        :reason      "No frame-locked dispatch is bound for this render."
                        :recovery    :lower-intents-inside-a-boundary-render
                        :intent      intent}))))
+
+;; ---------------------------------------------------------------------------
+;; The one callback form (HD-024)
+;; ---------------------------------------------------------------------------
+
+(def ^:private callback-marker "hicassoFn")
+
+(defn callback
+  "**The one callback form.** Marks `f` so the position it is written at
+  can impose a contract on it — and returns `f` ITSELF, an ordinary
+  function, which is the whole of the deletion.
+
+  The predecessor's roster carriers are marker OBJECTS, so handing one to
+  a position the library does not walk produces the engine's own
+  `TypeError` naming nothing the author wrote. There is nothing here that
+  can fail to be callable: outside every walked position this value is a
+  plain function whose return is ignored, which is a defensible contract
+  rather than a crash.
+
+  `h/fn` in the authoring surface; see
+  [[re-frame.bench.hicasso.arm1.lang/hfn]]. Marking mutates the function
+  object, which is safe because a callback written in a body is minted
+  fresh per render — and it is one own-property read to test, with no
+  registry and no map."
+  [f]
+  (unchecked-set f callback-marker true)
+  f)
+
+(defn callback?
+  "Is `v` the one callback form? One own-property read behind a `fn?`
+  guard, so a string or a number at a prop position costs one type test."
+  [v]
+  (and (fn? v) (true? (unchecked-get v callback-marker))))
+
+(defn- event-callback
+  "**Event position.** A returned VECTOR is dispatched; anything else is
+  ignored, so the same form serves the live-event case (files, geometry,
+  filters) and the imperative one without the author choosing between two
+  spellings.
+
+  The ambient dispatch is captured at LOWERING time, as everywhere else
+  in this namespace — the browser invokes the callback long after the
+  render's dynamic extent has unwound. It is captured rather than
+  *required*, so a callback that never returns an intent is legal with no
+  frame in scope; returning one there is the loud error, and it names the
+  position."
+  [k f]
+  (let [dispatch *dispatch*]
+    (fn hicasso-event-callback [e]
+      (let [result (f e)]
+        (when (vector? result)
+          (if dispatch
+            (dispatch result)
+            (fail! :rf.error/hicasso-intent-outside-boundary
+                   'front.intent/lower-prop
+                   (str "A callback at " (pr-str k) " returned the intent "
+                        (pr-str result) " with no frame-locked dispatch in scope. "
+                        "Callbacks that dispatch are only legal at a position "
+                        "lowered inside a boundary's render.")
+                   :lower-intents-inside-a-boundary-render
+                   {:position k :intent result})))
+        nil))))
+
+(defn- render-callback
+  "**Render position.** The callback is invoked by whatever holds it —
+  a slot, a foreign component's render prop — DURING a render, so its
+  return is the render output and is emphatically not an intent. What is
+  forbidden is dispatching from inside it, and the diagnostic names the
+  POSITION rather than the form the author chose, because under one form
+  the form is never the answer to \"what did I get wrong?\".
+
+  Enforced by poisoning the ambient dispatch for the call's dynamic
+  extent: an intent lowered inside, or a direct call, both land on the
+  same error id. `.preventDefault`-style side effects are untouched."
+  [k f]
+  (fn hicasso-render-callback [& args]
+    (binding [*dispatch*
+              (fn [event]
+                (fail! :rf.error/hicasso-dispatch-in-render-position
+                       'front.intent/lower-prop
+                       (str "A callback at " (pr-str k) " dispatched " (pr-str event)
+                            " while it was running. " (pr-str k) " is a RENDER "
+                            "position: it is invoked during a render, so it must be "
+                            "pure. Move the dispatch to an event position, or to an "
+                            "event handler that owns the work.")
+                       :dispatch-from-an-event-position
+                       {:position k :event event}))]
+      (apply f args))))
+
+(defn- declared-callback
+  "**A `defhost` `:callbacks` entry.** The declaration already carries the
+  contract — `:event` or `:handler`, never inferred from an `on*` name —
+  so this is the position table's third row and it needs no new
+  machinery. `:handler` is the return-ignored contract, which for a form
+  that is already an ordinary function is the function itself."
+  [k f contract]
+  (case contract
+    :event   (event-callback k f)
+    :handler f
+    :render  (render-callback k f)
+    (fail! :rf.error/hicasso-unknown-callback-contract
+           'front.intent/lower-declared-prop
+           (str "A declaration gave " (pr-str k) " the callback contract "
+                (pr-str contract) ". The contracts are :event, :handler and :render.")
+           :declare-event-handler-or-render
+           {:position k :contract contract})))
 
 ;; ---------------------------------------------------------------------------
 ;; The marker roster and its one pure materializer
@@ -229,24 +387,70 @@
         (when-some [h (get lowered (.-key e))]
           (h e))))))
 
+(defn ref-position?
+  "`:ref` is the one prop position whose contract is neither Hicasso's to
+  select nor the same for both phases: React invokes it in the COMMIT
+  phase with the node, and whatever it returns is the detach cleanup. So
+  it is excluded from callback lowering entirely and keeps its own
+  declared contract (HD-016 callback refs, HD-022's reserved vector) —
+  wrapping it would forbid a dispatch that is legitimate there and would
+  change the identity React uses to decide whether to re-attach."
+  [k]
+  (or (= :ref k) (= "ref" k)))
+
+(defn position-contract
+  "The contract a prop position imposes on the one callback form. An
+  event position is the only one the attribute grammar can name by
+  itself; everything else Hicasso walks is a render position, and a
+  `defhost` declaration overrides this by saying so
+  ([[lower-declared-prop]])."
+  [k]
+  (cond
+    (ref-position? k) :ref
+    (event-prop? k)   :event
+    :else             :render))
+
 (defn lower-prop
   "Lower one prop. Values at non-event positions, and non-lowerable values
   at event positions, come back untouched — this is the identity function
-  for everything the surface does not claim."
+  for everything the surface does not claim.
+
+  The one callback form is claimed at EVERY position, because that is
+  what makes the position the thing that selects the contract."
   [k v]
-  (if-not (event-prop? k)
-    v
+  (if (event-prop? k)
     (cond
-      (vector? v) (intent-handler k v)
-      (map? v)    (key-map-handler k v)
-      :else       v)))
+      (vector? v)   (intent-handler k v)
+      (map? v)      (key-map-handler k v)
+      (callback? v) (event-callback k v)
+      :else         v)
+    (if (and (callback? v) (not (ref-position? k)))
+      (render-callback k v)
+      v)))
+
+(defn lower-declared-prop
+  "Lower one prop whose contract a `defhost` declaration named — the
+  position table's second row. Kept separate from [[lower-prop]] so the
+  declaration is what decides, rather than the prop's spelling: the
+  predecessor's own rule is that a host's callback contract is 'a finite
+  map from EXACT prop names to `:event` or `:handler`; never inferred
+  from an `on*` name', and that rule survives here because the position,
+  not the value, carries the contract."
+  [k v contract]
+  (cond
+    (callback? v) (declared-callback k v contract)
+    (vector? v)   (intent-handler k v)
+    (map? v)      (key-map-handler k v)
+    :else         v))
 
 (defn lower-props
-  "Walk a props map once, lowering every event position. Returns the map
-  unchanged, by identity, when it holds nothing to lower — the ordinary
-  case for the great majority of elements on a page, and worth not
-  allocating for."
+  "Walk a props map once, lowering every position that carries something
+  to lower. Returns the map unchanged, by identity, when it holds nothing
+  — the ordinary case for the great majority of elements on a page, and
+  worth not allocating for."
   [props]
-  (if-not (some (fn [[k v]] (and (event-prop? k) (or (vector? v) (map? v)))) props)
+  (if-not (some (fn [[k v]] (or (callback? v)
+                                (and (event-prop? k) (or (vector? v) (map? v)))))
+                props)
     props
     (reduce-kv (fn [m k v] (assoc m k (lower-prop k v))) {} props)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -211,7 +211,15 @@
   render's dynamic extent has unwound. It is captured rather than
   *required*, so a callback that never returns an intent is legal with no
   frame in scope; returning one there is the loud error, and it names the
-  position."
+  position.
+
+  **The census-weighted policy defaults do NOT apply here, deliberately.**
+  `:on-submit`'s auto-prevent is a property of the *data* spelling: an
+  intent vector never sees the event, so the runtime must decide for it.
+  A callback is handed the event, so the event is the callback's — it
+  calls `.preventDefault` itself, and the runtime does not reach in after
+  the body has run to second-guess it. One rule: whoever holds the event
+  owns it."
   [k f]
   (let [dispatch *dispatch*]
     (fn hicasso-event-callback [e]

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent_cljs_test.cljs
@@ -319,6 +319,29 @@
       (h (ev {}))
       (is (= [] @!seen)))))
 
+(deftest the-policy-defaults-belong-to-the-data-spelling-not-to-the-callback
+  (testing "`:on-submit` auto-prevents an INTENT VECTOR because a vector never
+            sees the event, so the runtime must decide for it. A callback IS
+            handed the event, so the event is the callback's — the runtime
+            does not reach in after the body has run to second-guess it.
+            One rule: whoever holds the event owns it."
+    (let [!seen (recorder)]
+      (testing "the vector at :on-submit prevents, as it always has"
+        (let [prevented (atom false)
+              h (lowered (dispatching !seen) :on-submit [:signup/submit])]
+          (h (ev {:prevented prevented}))
+          (is (true? @prevented))
+          (is (= [[:signup/submit]] @!seen))))
+      (testing "the callback at the same position does not, and its returned
+                intent still dispatches"
+        (reset! !seen [])
+        (let [prevented (atom false)
+              h (lowered (dispatching !seen) :on-submit
+                         (intent/callback (fn [_] [:signup/submit])))]
+          (h (ev {:prevented prevented}))
+          (is (false? @prevented) "the runtime left the event alone")
+          (is (= [[:signup/submit]] @!seen)))))))
+
 (deftest at-a-render-position-the-return-is-output-and-dispatching-is-a-loud-error
   (testing "the contract the predecessor spells `v/render-fn`. A slot or a
             foreign render prop is invoked DURING a render, so its return is

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent_cljs_test.cljs
@@ -271,3 +271,165 @@
         (is (fn? (:on-click lowered')))
         ((:on-click lowered') (ev {}))
         (is (= [[:touch 3]] @!seen))))))
+
+;; ---------------------------------------------------------------------------
+;; ONE callback form, and the POSITION selects the contract
+;; (HD-024, rf2-2rtt6.35)
+;; ---------------------------------------------------------------------------
+;;
+;; One test per position, plus the row that deletes the predecessor's fifth
+;; rule, plus the diagnostic that must name the POSITION rather than the form.
+
+(deftest the-one-form-is-an-ordinary-function
+  (testing "the deletion, stated as an assertion. The predecessor's roster
+            carriers are marker OBJECTS, so the same value handed to a
+            position the library does not walk is not callable and the author
+            gets the engine's own TypeError naming nothing they wrote. There
+            is nothing here that can fail to be callable."
+    (let [f  (fn [_] :ran)
+          cb (intent/callback f)]
+      (is (identical? f cb) "`callback` marks and returns the SAME function")
+      (is (fn? cb))
+      (is (true? (intent/callback? cb)))
+      (is (false? (intent/callback? (fn [_]))) "an ordinary fn is not the form")
+      (is (false? (intent/callback? [:an :intent])))
+      (is (false? (intent/callback? "on-click"))))))
+
+(deftest at-an-event-position-a-returned-vector-is-dispatched
+  (testing "the contract the predecessor spells `v/event`"
+    (let [!seen (recorder)
+          h     (lowered (dispatching !seen) :on-change
+                         (intent/callback (fn [e] [:files/picked (.. e -target -value)])))]
+      (h (ev {:value "a.png"}))
+      (is (= [[:files/picked "a.png"]] @!seen))))
+  (testing "and a return that is not a vector is ignored — which is the
+            contract the predecessor needs a SECOND form (`v/handler`) for"
+    (let [!seen (recorder)
+          !ran  (atom 0)
+          h     (lowered (dispatching !seen) :on-click
+                         (intent/callback (fn [_] (swap! !ran inc) :not-an-intent)))]
+      (h (ev {}))
+      (is (= 1 @!ran) "the body ran")
+      (is (= [] @!seen) "and nothing was dispatched")))
+  (testing "nil is likewise ignored, so a conditional dispatch is written as
+            an ordinary conditional returning nil"
+    (let [!seen (recorder)
+          h     (lowered (dispatching !seen) :on-click
+                         (intent/callback (fn [_] nil)))]
+      (h (ev {}))
+      (is (= [] @!seen)))))
+
+(deftest at-a-render-position-the-return-is-output-and-dispatching-is-a-loud-error
+  (testing "the contract the predecessor spells `v/render-fn`. A slot or a
+            foreign render prop is invoked DURING a render, so its return is
+            markup — which is itself a vector, and is exactly why the shape
+            of the value cannot select the contract and the position must."
+    (let [!seen (recorder)
+          h     (lowered (dispatching !seen) :row-renderer
+                         (intent/callback (fn [row] [:li (:title row)])))]
+      (is (= [:li "milk"] (h {:title "milk"}))
+          "the hiccup came back to the caller and was NOT dispatched")
+      (is (= [] @!seen))))
+  (testing "and a dispatch from inside one is refused, naming the POSITION"
+    (let [!seen (recorder)
+          h     (lowered (dispatching !seen) :row-renderer
+                         (intent/callback
+                           (fn [_] ((intent/lower-prop :on-click [:oops]) (ev {})) [:li])))]
+      (try
+        (h {})
+        (is false "should have thrown")
+        (catch :default e
+          (let [d (ex-data e)]
+            (is (= :rf.error/hicasso-dispatch-in-render-position (:rf.error/id d)))
+            (is (= :row-renderer (:position d))
+                "the diagnostic names the POSITION — under one form, the form
+                 is never the answer to the question of what went wrong")
+            (is (re-find #":row-renderer" (ex-message e))))))
+      (is (= [] @!seen) "and nothing reached the frame"))))
+
+(deftest a-declaration-can-name-the-contract-instead-of-the-position
+  (testing "the position table's second row. A `defhost` declaration carries
+            `:event` or `:handler` per EXACT prop name and never infers it
+            from an `on*` spelling, so the contract travels with the
+            declaration rather than with the value."
+    (let [!seen (recorder)
+          cb    (intent/callback (fn [x] [:host/changed x]))]
+      (testing ":event dispatches the return even though :onValueChange is
+                not a position the attribute grammar would call an event"
+        (let [h (intent/with-frame (dispatching !seen)
+                                   (fn [] (intent/lower-declared-prop :onValueChange cb :event)))]
+          (h 7)
+          (is (= [[:host/changed 7]] @!seen))))
+      (testing ":handler ignores the return, and the function passes through
+                by identity so a library memoising on it is not defeated"
+        (reset! !seen [])
+        (let [h (intent/with-frame (dispatching !seen)
+                                   (fn [] (intent/lower-declared-prop :onValueChange cb :handler)))]
+          (is (identical? cb h))
+          (is (= [:host/changed 7] (h 7)) "the caller sees the return")
+          (is (= [] @!seen))))
+      (testing "an unknown contract is a loud error rather than a guess"
+        (try
+          (intent/lower-declared-prop :onValueChange cb :whatever)
+          (is false "should have thrown")
+          (catch :default e
+            (is (= :rf.error/hicasso-unknown-callback-contract
+                   (:rf.error/id (ex-data e))))))))))
+
+(deftest outside-every-walked-position-the-form-is-just-a-function
+  (testing "the row that deletes the predecessor's FIFTH rule. There, the
+            roster is site-owned and a carrier handed to a raw #js prop is a
+            marker object, so a native call on it raises the host's own
+            TypeError naming nothing the author wrote. Here the value was
+            never anything but a function, so the position not being walked
+            costs the contract and nothing else."
+    (let [!ran     (atom 0)
+          cb       (intent/callback (fn [x] (swap! !ran inc) [:would-have-dispatched x]))
+          js-props #js {:onPing cb}]
+      (is (fn? (.-onPing js-props)))
+      (is (= [:would-have-dispatched 3] ((.-onPing js-props) 3))
+          "a JavaScript library calling it natively gets a real call and a
+           real return — the return is simply not an intent here, because
+           this is not a position anything could have lowered")
+      (is (= 1 @!ran)))))
+
+(deftest an-intent-returned-with-no-frame-in-scope-names-the-position
+  (testing "the form is legal with no frame — a callback that never returns
+            an intent has nothing to dispatch. Returning one there is the
+            loud error, and it names the position rather than the form."
+    (let [h (intent/lower-prop :on-click (intent/callback (fn [_] [:too/late])))]
+      (try
+        (h (ev {}))
+        (is false "should have thrown")
+        (catch :default e
+          (is (= :rf.error/hicasso-intent-outside-boundary (:rf.error/id (ex-data e))))
+          (is (= :on-click (:position (ex-data e)))))))
+    (testing "while the same callback returning nothing is fine"
+      (let [!ran (atom 0)
+            h    (intent/lower-prop :on-click (intent/callback (fn [_] (swap! !ran inc) nil)))]
+        (h (ev {}))
+        (is (= 1 @!ran))))))
+
+(deftest ref-keeps-reacts-own-contract-and-is-not-lowered
+  (testing ":ref is the one position whose contract is neither Hicasso's to
+            select nor the same in both phases — React invokes it in the
+            COMMIT phase with the node, and its return is the detach
+            cleanup. Wrapping it would forbid a legitimate dispatch there and
+            would change the identity React re-attaches on."
+    (is (= :ref (intent/position-contract :ref)))
+    (is (= :event (intent/position-contract :on-click)))
+    (is (= :render (intent/position-contract :row-renderer)))
+    (let [cb (intent/callback (fn [_node] :cleanup))]
+      (is (identical? cb (intent/lower-prop :ref cb)))
+      (is (identical? cb (intent/lower-prop "ref" cb))))))
+
+(deftest an-ordinary-function-is-untouched-everywhere
+  (testing "`raw-fn`'s identity passthrough is not v0 because it is already
+            the default: an ordinary function is claimed by no position, and
+            the codec hands functions to React by identity so `React.memo`
+            and every downstream bail-out that compares handler identity keep
+            working. One fewer form for nothing given up."
+    (let [f (fn [_] :whatever)]
+      (is (identical? f (intent/lower-prop :on-click f)))
+      (is (identical? f (intent/lower-prop :row-renderer f)))
+      (is (identical? f (intent/lower-prop :ref f))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/presence.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/presence.cljs
@@ -1,0 +1,352 @@
+(ns re-frame.bench.hicasso.front.presence
+  "PRESENCE AS DATA — the retention machine and the phase transform
+  (rf2-2rtt6.37, HD-025). The **pure half**: a value in, a value out, no
+  React, no clock, no ambient read. The React component that drives it is
+  `re-frame.bench.hicasso.arm1.presence`.
+
+  ## The trap this deletes
+
+  The shipped predecessor exposes a keyed child's phase as an AMBIENT
+  READ, and its own guide records what that costs, verbatim:
+
+  > Read the phase inside a DECLARED, KEYED CHILD VIEW, as above. Reading
+  > it in markup written inline in the parent is a trap: those props are
+  > evaluated during the PARENT'S render, so the phase you get is the
+  > parent's, not the per-child one you meant.
+
+  So a fading toast cannot be written inline. It must be extracted into a
+  child view purely so a dynamic var resolves against the right child,
+  and getting it wrong yields the wrong phase SILENTLY. The a11y
+  obligation then costs three separate `(when exiting? …)` attributes on
+  that child.
+
+  ## The two changes
+
+  **(1) `::h/mounting` and `::h/unmounting` are attribute OVERRIDE MAPS
+  on a native node.** The boundary merges them into that node's attrs
+  while the child is in that phase:
+
+      (h/presence {:timeout-ms 300}
+        (for [t (sub [:toasts/visible])]
+          [:div.toast {:key (:id t)
+                       ::h/unmounting {:class \"toast toast--exit\"
+                                       :inert true :aria-hidden true}}
+           (:message t)]))
+
+  The child view has disappeared and the three `(when exiting? …)`
+  attributes are one map.
+
+  **(2) When the child IS a boundary, the phase arrives as an ORDINARY
+  PROP** — `[toast-card {:key id :toast t :rf/phase :unmounting}]`. That
+  deletes the trap by construction: a prop cannot be read from the wrong
+  render scope, it appears in a structural test's props map, and a
+  headless test can supply it with no clock.
+
+  The consequence worth recording: `presence-phase` has no Hicasso
+  equivalent. One fewer public concept against K5.
+
+  ## Why the predecessor's rejection does not apply
+
+  It rejected exactly this, and gave a reason: *\"A boundary that stamped
+  attributes would have to guess at a node it never sees.\"* That is
+  sound for a boundary stamping **by itself**. It does not survive the
+  AUTHOR writing the override on the node. The boundary already owns the
+  retained-children list — that is what retention IS — so applying an
+  override the author wrote is a hiccup→hiccup transform performed before
+  the codec runs. React then sees an ordinary element whose props
+  changed: no wrapper node, no stamped `data-*`, **no ref, no effect, no
+  hook and no ambient read** in the merge itself.
+
+  ## Honest limits
+
+  - **The override applies to a node the boundary can SEE.** An override
+    written inside an opaque child view is invisible to it; change (2) is
+    what that case is for, and an override written on a boundary child is
+    a loud error naming `:rf/phase` rather than a silently dropped map.
+  - **ENTER is the weak half**, and the predecessor already says why:
+    driving enter purely as a `:mounting` → `:present` class flip can race
+    paint. `::h/mounting` ships, and the guide teaches the CSS answer —
+    an animation on insertion, or `@starting-style`.
+
+  ## Inherited unchanged
+
+  `:timeout-ms` is MANDATORY, and is both the retention length and the
+  hard terminal bound; re-entry cancels exit; keys are required on every
+  dynamic child; presence never dispatches domain mount/unmount events.
+
+  ## The machine
+
+  A state value is `{:order [key …] :entries {key {:child … :phase …
+  :deadline …}}}`. [[step]] is the whole transition and is **idempotent**
+  — `(step (step s cs t1 ms) cs t2 ms)` equals `(step s cs t1 ms)` — which
+  is what lets the React half adjust its state during render rather than
+  spend an effect on it. Deadlines are absolute instants stored when a
+  key starts exiting, so a timer re-armed for an unrelated reason cannot
+  extend a child's retention past its terminal bound."
+  (:require [re-frame.bench.hicasso.front.codec :as codec]))
+
+;; ---------------------------------------------------------------------------
+;; The reserved keys
+;; ---------------------------------------------------------------------------
+
+(def mounting-key
+  "`::h/mounting` — the attribute overrides applied while a child is
+  entering."
+  :re-frame.hicasso/mounting)
+
+(def unmounting-key
+  "`::h/unmounting` — the attribute overrides applied while a child is
+  being retained on its way out."
+  :re-frame.hicasso/unmounting)
+
+(def override-keys #{mounting-key unmounting-key})
+
+(def phase-prop
+  "`:rf/phase` — how a BOUNDARY child receives its phase. An ordinary
+  prop, so it cannot be read from the wrong render scope, it appears in a
+  structural test's props map, and a headless test supplies it with no
+  clock."
+  :rf/phase)
+
+(def initial {:order [] :entries {}})
+
+;; ---------------------------------------------------------------------------
+;; Errors
+;; ---------------------------------------------------------------------------
+
+(defn- fail! [id where reason recovery extra]
+  (throw (ex-info (str reason " [" id "]")
+                  (merge {:rf.error/id id :where where
+                          :reason reason :recovery recovery}
+                         extra))))
+
+;; ---------------------------------------------------------------------------
+;; Reading a child
+;; ---------------------------------------------------------------------------
+
+(defn renderable?
+  "`nil` and `false` children render nothing, so they are not entries.
+  Everything else must be a keyed hiccup vector."
+  [child]
+  (and (some? child) (not (false? child))))
+
+(defn- props-of [child] (let [p (nth child 1 nil)] (when (map? p) p)))
+
+(defn- with-props
+  "Put `props` on a hiccup vector, inserting the map when the vector had
+  none."
+  [child props]
+  (if (map? (nth child 1 nil))
+    (assoc child 1 props)
+    (into [(nth child 0) props] (subvec child 1))))
+
+(defn child-key
+  "A child's `:key`, from the props map where HD-016 puts it. Required on
+  every dynamic child, because the key IS the identity the state machine
+  runs on — an unkeyed child has no way to be the same child next render."
+  [child]
+  (when-not (vector? child)
+    (fail! :rf.error/hicasso-presence-child-not-hiccup
+           'front.presence/child-key
+           (str "A presence child must be a keyed hiccup vector; it was "
+                (pr-str child) ".")
+           :give-every-presence-child-a-keyed-hiccup-vector
+           {:child child}))
+  (let [k (:key (props-of child))]
+    (when (nil? k)
+      (fail! :rf.error/hicasso-presence-child-unkeyed
+             'front.presence/child-key
+             (str "A presence child has no :key. Presence retains children by "
+                  "key, so an unkeyed child cannot be recognised across a "
+                  "render and cannot be animated out.")
+             :put-a-key-in-the-child-props-map
+             {:child child}))
+    k))
+
+;; ---------------------------------------------------------------------------
+;; The phase transform — hiccup in, hiccup out
+;; ---------------------------------------------------------------------------
+
+(defn- override-for [props phase]
+  (case phase
+    :mounting   (get props mounting-key)
+    :unmounting (get props unmounting-key)
+    nil))
+
+(defn with-phase
+  "Apply `phase` to one child, as data.
+
+  A **native node** takes the phase's attribute-override map merged over
+  its own attributes — the override WINS, because that is what an
+  override is — with `:key` and `:ref` never taken from it, the same law
+  `:&` carries (HD-023). The two override keys are always removed, so an
+  override never reaches the DOM as an attribute.
+
+  A **boundary child** takes `:rf/phase` as an ordinary prop instead, and
+  an override written there is a loud error: the boundary cannot see
+  inside an opaque view, and silently dropping the map is the class of
+  failure this whole ruling exists to delete."
+  [child phase]
+  (let [props (props-of child)]
+    (if (codec/boundary-head? (nth child 0))
+      (do
+        (when (some #(contains? props %) override-keys)
+          (fail! :rf.error/hicasso-presence-override-on-a-view
+                 'front.presence/with-phase
+                 (str "A presence attribute override was written on a VIEW head. "
+                      "Presence merges overrides into nodes it can see; a view is "
+                      "opaque to it. The view receives " (pr-str phase-prop)
+                      " as an ordinary prop — branch or style on that instead.")
+                 :read-the-phase-prop-inside-the-view
+                 {:child child :phase phase}))
+        (with-props child (assoc props phase-prop phase)))
+      (let [override (override-for props phase)
+            base     (when props (apply dissoc props override-keys))]
+        (cond
+          (map? override)
+          (with-props child (merge base (apply dissoc override
+                                               codec/merge-structural-keys)))
+
+          ;; Nothing to strip and nothing to merge: the child is already
+          ;; exactly what it should render as, so it comes back untouched
+          ;; and this phase costs no allocation at all.
+          (= base props) child
+
+          (some? base) (with-props child base)
+          :else        child)))))
+
+;; ---------------------------------------------------------------------------
+;; The machine
+;; ---------------------------------------------------------------------------
+
+(defn step
+  "The whole transition: fold `children` (as they are now) into `state`,
+  starting an exit for every key that has gone and cancelling one for
+  every key that has come back.
+
+  **Idempotent**, which is the property the React half rides: a second
+  application with the same children changes nothing, whatever `now` is,
+  because a `:mounting` entry stays `:mounting` and an exiting entry
+  keeps the deadline it was given. `now + timeout-ms` is stored as an
+  absolute instant precisely so that re-deriving cannot extend it."
+  [state children now timeout-ms]
+  (let [live      (filterv renderable? children)
+        live-keys (mapv child-key live)
+        live-set  (set live-keys)
+        by-key    (zipmap live-keys live)
+        prev      (:entries state)
+        entries   (reduce (fn [acc k]
+                            (let [p     (get prev k)
+                                  child (get by-key k)]
+                              (assoc acc k
+                                     (cond
+                                       (nil? p)
+                                       {:child child :phase :mounting}
+
+                                       ;; Re-entry cancels exit — the child
+                                       ;; returns to :present rather than
+                                       ;; finishing its exit and remounting.
+                                       (= :unmounting (:phase p))
+                                       {:child child :phase :present}
+
+                                       :else
+                                       (assoc p :child child)))))
+                          {}
+                          live-keys)
+        entries   (reduce-kv (fn [acc k p]
+                               (if (contains? live-set k)
+                                 acc
+                                 (assoc acc k
+                                        (if (= :unmounting (:phase p))
+                                          p
+                                          (assoc p :phase    :unmounting
+                                                   :deadline (+ now timeout-ms))))))
+                             entries
+                             prev)
+        ;; First-appearance slots are frozen, so an exiting child does not
+        ;; jump mid-animation: surviving keys keep their order and genuinely
+        ;; new keys are appended in the order the source produced them.
+        kept      (filterv #(contains? entries %) (:order state))]
+    {:order   (into kept (remove (set kept)) live-keys)
+     :entries entries}))
+
+(defn settle
+  "Flip every `:mounting` entry to `:present`. The React half calls this
+  after paint; a headless test calls it directly."
+  [state]
+  (let [entries (reduce-kv (fn [m k e]
+                             (assoc m k (if (= :mounting (:phase e))
+                                          (assoc e :phase :present)
+                                          e)))
+                           {}
+                           (:entries state))]
+    (if (= entries (:entries state)) state (assoc state :entries entries))))
+
+(defn expire
+  "Drop every retained child whose deadline has passed. Removal is
+  terminal: `:timeout-ms` is a clock, not a transition listener, so a
+  child leaves on time whether or not any CSS ran."
+  [state now]
+  (let [dead (into #{}
+                   (keep (fn [[k e]]
+                           (when (and (= :unmounting (:phase e))
+                                      (<= (:deadline e) now))
+                             k)))
+                   (:entries state))]
+    (if (empty? dead)
+      state
+      {:order   (filterv (complement dead) (:order state))
+       :entries (apply dissoc (:entries state) dead)})))
+
+(defn next-deadline
+  "The earliest instant at which something must leave, or `nil`. One
+  timer serves every exiting child."
+  [state]
+  (when-some [ds (seq (keep (comp :deadline val) (:entries state)))]
+    (reduce min ds)))
+
+(defn mounting?
+  "Is anything waiting for its enter flip?"
+  [state]
+  (boolean (some (fn [[_ e]] (= :mounting (:phase e))) (:entries state))))
+
+(defn pending-signature
+  "What the React half's effect depends on: the work outstanding, as a
+  value it can compare. Deliberately a printed value rather than a hash —
+  a collision here would drop a timer, and dropping a timer means a node
+  that never leaves."
+  [state]
+  (pr-str [(next-deadline state) (mounting? state)
+           (filterv (fn [k] (= :unmounting (:phase (get (:entries state) k))))
+                    (:order state))]))
+
+(defn phases
+  "`key -> phase`, in order. The headless assertion surface."
+  [state]
+  (into {} (map (fn [k] [k (:phase (get (:entries state) k))])) (:order state)))
+
+(defn render
+  "The children to hand the codec: every retained and live child, in
+  frozen order, each with its phase already applied as data."
+  [state]
+  (mapv (fn [k]
+          (let [e (get (:entries state) k)]
+            (with-phase (:child e) (:phase e))))
+        (:order state)))
+
+(defn check-timeout!
+  "`:timeout-ms` is MANDATORY and positive, inherited unchanged. It is the
+  retention length AND the hard terminal bound, so a boundary without one
+  is a boundary whose children can be stuck on screen forever if CSS
+  fails or is disabled."
+  [timeout-ms]
+  (when-not (and (number? timeout-ms) (pos? timeout-ms))
+    (fail! :rf.error/hicasso-presence-timeout-required
+           'front.presence/check-timeout!
+           (str "presence needs a positive :timeout-ms; it was "
+                (pr-str timeout-ms) ". It is the retention length and the hard "
+                "terminal bound — presence does not wait on transitionend, so "
+                "without it a child could be retained forever.")
+           :give-presence-a-positive-timeout-ms
+           {:timeout-ms timeout-ms}))
+  timeout-ms)

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/presence_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/presence_cljs_test.cljs
@@ -1,0 +1,299 @@
+(ns re-frame.bench.hicasso.front.presence-cljs-test
+  "PRESENCE AS DATA, HEADLESSLY — the machine, the transform, and the
+  census-real toast tray ported both ways (rf2-2rtt6.37, HD-025).
+
+  Every row here runs with **no React, no browser and no clock**: `step`
+  and `expire` take `now` as an argument, which is itself one of the
+  ruling's claims — a phase that is data can be asserted without a
+  timeline. `arm1/presence_dom_cljs_test` then proves React drives this
+  machine against a real DOM.
+
+  ## The screen, and the diff this file exists to make honest
+
+  The predecessor's own guide worked example, verbatim
+  (`docs/core/freehand/host/presence.md`) — a fading toast, with the
+  a11y obligation its Accessibility section spells out:
+
+      (v/defview toast-card [{:keys [toast]}]
+        (let [exiting? (= :unmounting (v/presence-phase))]
+          [:div.toast {:class       (when exiting? \"toast--exit\")
+                       :inert       (when exiting? true)
+                       :aria-hidden (when exiting? true)}
+           (:message toast)]))
+
+      (v/defview toast-tray [_]
+        (v/presence {:timeout-ms 300}
+          (for [t (v/sub [:toasts/visible])]
+            [toast-card {:key (:id t) :toast t}])))
+
+  Two views, an ambient read, and three `(when exiting? …)` attributes —
+  and the child view exists **only** so a dynamic var resolves against
+  the right child, because that guide records that reading the phase in
+  markup written inline in the parent silently yields the parent's phase.
+
+  Both Hicasso spellings are built below and their rendered attributes
+  asserted **identical**, so the diff in the pull request is about
+  authoring and not about behaviour. The design review that produced
+  HD-025 stated its own risk plainly — that all four of its proposals are
+  taste rulings dressed as deletions — and this is the instrument that
+  answers it for this one."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.presence :as presence]))
+
+(use-fixtures :each {:before (fn [] (codec/reset-caches!))})
+
+(def ^:private timeout-ms 300)
+
+(defn- toast [id message]
+  [:div.toast {:key id
+               :re-frame.hicasso/unmounting {:class       "toast--exit"
+                                             :inert       true
+                                             :aria-hidden true}}
+   message])
+
+(defn- state-of
+  "Fold a sequence of child-lists into the machine, one render per list,
+  with an explicit clock."
+  [renders]
+  (reduce (fn [s [children now]] (presence/step s children now timeout-ms))
+          presence/initial
+          renders))
+
+;; ---------------------------------------------------------------------------
+;; The machine
+;; ---------------------------------------------------------------------------
+
+(deftest a-child-enters-mounting-then-settles-present
+  (let [s (presence/step presence/initial [(toast 1 "a")] 0 timeout-ms)]
+    (is (= {1 :mounting} (presence/phases s)))
+    (is (true? (presence/mounting? s)))
+    (let [s (presence/settle s)]
+      (is (= {1 :present} (presence/phases s)))
+      (is (false? (presence/mounting? s)))
+      (testing "and a later render with the same child leaves it alone"
+        (is (= {1 :present} (presence/phases
+                              (presence/step s [(toast 1 "a")] 50 timeout-ms))))))))
+
+(deftest a-child-that-leaves-the-source-is-retained-as-unmounting
+  (let [s (-> (state-of [[[(toast 1 "a") (toast 2 "b")] 0]])
+              presence/settle
+              (presence/step [(toast 1 "a")] 100 timeout-ms))]
+    (is (= {1 :present 2 :unmounting} (presence/phases s))
+        "the child is gone from the data and still on screen")
+    (is (= 400 (presence/next-deadline s)) "100 + :timeout-ms, as an instant")
+    (testing "and it leaves exactly on time, not before"
+      (is (= {1 :present 2 :unmounting} (presence/phases (presence/expire s 399))))
+      (is (= {1 :present} (presence/phases (presence/expire s 400)))))))
+
+(deftest re-entry-cancels-exit
+  (let [s (-> (state-of [[[(toast 1 "a")] 0]])
+              presence/settle
+              (presence/step [] 100 timeout-ms))]
+    (is (= {1 :unmounting} (presence/phases s)))
+    (let [back (presence/step s [(toast 1 "a")] 150 timeout-ms)]
+      (is (= {1 :present} (presence/phases back))
+          "the exit is cancelled rather than finished-and-remounted")
+      (is (nil? (presence/next-deadline back)) "and its deadline is gone with it")
+      (is (= "a" (nth (first (presence/render back)) 2))))))
+
+(deftest the-deadline-is-a-terminal-bound-and-re-deriving-cannot-extend-it
+  (testing "the property `:timeout-ms` is FOR. Deadlines are absolute
+            instants stored once, so any number of later renders — a
+            neighbour arriving, a neighbour leaving, React re-running the
+            body — leave a retained child leaving at the instant it was
+            always going to."
+    (let [s (-> (state-of [[[(toast 1 "a")] 0]]) presence/settle
+                (presence/step [] 100 timeout-ms))]
+      (is (= 400 (presence/next-deadline s)))
+      (let [busy (-> s
+                     (presence/step [(toast 2 "b")] 150 timeout-ms)
+                     (presence/step [(toast 2 "b") (toast 3 "c")] 200 timeout-ms)
+                     (presence/step [(toast 3 "c")] 250 timeout-ms))]
+        (is (= 400 (:deadline (get (:entries busy) 1)))
+            "still 400 — not 550, which is what re-deriving would give")))))
+
+(deftest step-is-idempotent-which-is-what-lets-react-adjust-state-in-render
+  (testing "the property the React half rides. A second application with
+            the same children changes nothing, whatever the clock says —
+            so the component's `(when-not (= next state) (set-state next))`
+            converges after one extra pass and cannot loop."
+    (let [children [(toast 1 "a") (toast 2 "b")]
+          once     (presence/step presence/initial children 0 timeout-ms)
+          twice    (presence/step once children 99 timeout-ms)]
+      (is (= once twice)))
+    (let [s     (-> (state-of [[[(toast 1 "a")] 0]]) presence/settle)
+          once  (presence/step s [] 100 timeout-ms)
+          twice (presence/step once [] 500 timeout-ms)]
+      (is (= once twice) "including for a retained child, whose deadline holds"))))
+
+(deftest first-appearance-slots-are-frozen-so-an-exiting-child-does-not-jump
+  (let [s (-> (state-of [[[(toast 1 "a") (toast 2 "b") (toast 3 "c")] 0]])
+              presence/settle
+              (presence/step [(toast 1 "a") (toast 3 "c")] 100 timeout-ms))]
+    (is (= [1 2 3] (:order s)) "the middle child holds its slot while it exits")
+    (let [s (presence/step s [(toast 1 "a") (toast 3 "c") (toast 4 "d")] 120 timeout-ms)]
+      (is (= [1 2 3 4] (:order s)) "and a genuinely new child is appended"))))
+
+(deftest nil-children-are-not-entries-and-unkeyed-children-are-a-loud-error
+  (is (= {1 :mounting}
+         (presence/phases (presence/step presence/initial
+                                         [(toast 1 "a") nil false]
+                                         0 timeout-ms))))
+  (is (thrown-with-msg? js/Error #"no :key"
+                        (presence/step presence/initial [[:div.toast "x"]] 0 timeout-ms)))
+  (is (thrown-with-msg? js/Error #"keyed hiccup vector"
+                        (presence/step presence/initial ["a string"] 0 timeout-ms))))
+
+(deftest timeout-ms-is-mandatory-and-positive
+  (is (= 300 (presence/check-timeout! 300)))
+  (doseq [bad [nil 0 -1 "300"]]
+    (is (thrown-with-msg? js/Error #"positive :timeout-ms"
+                          (presence/check-timeout! bad))
+        (str "refused: " (pr-str bad)))))
+
+;; ---------------------------------------------------------------------------
+;; The phase transform
+;; ---------------------------------------------------------------------------
+
+(deftest a-native-child-takes-the-phases-override-map-and-nothing-else
+  (testing ":present — the overrides are stripped and never reach the DOM"
+    (is (= [:div.toast {:key 1} "a"] (presence/with-phase (toast 1 "a") :present))))
+  (testing ":unmounting — the map is merged, and it WINS, because that is
+            what an override is"
+    (is (= [:div.toast {:key 1 :class "toast--exit" :inert true :aria-hidden true} "a"]
+           (presence/with-phase (toast 1 "a") :unmounting))))
+  (testing "an override still cannot reach :key or :ref — the same law :&
+            carries, for the same reason: those address node identity, not
+            appearance"
+    (let [hostile [:div.toast {:key 1
+                               :re-frame.hicasso/unmounting
+                               {:key "stolen" :ref (fn [_]) :class "x"}}]]
+      (is (= [:div.toast {:key 1 :class "x"}]
+             (presence/with-phase hostile :unmounting)))))
+  (testing "a child that carries no override comes back UNTOUCHED, by
+            identity — the transform costs nothing on a node that does not
+            use it"
+    (let [plain [:div.toast {:key 1} "a"]]
+      (is (identical? plain (presence/with-phase plain :unmounting))))
+    (is (= [:div.toast] (presence/with-phase [:div.toast] :present))
+        "including a node with no props map, which is not given one")))
+
+(deftest a-boundary-child-takes-the-phase-as-an-ordinary-prop
+  (let [card (codec/mark-boundary! (fn [_] nil))]
+    (is (= [card {:key 1 :toast {:id 1} :rf/phase :unmounting}]
+           (presence/with-phase [card {:key 1 :toast {:id 1}}] :unmounting))
+        "it appears in a structural test's props map, it cannot be read from
+         the wrong render scope, and a headless test can supply it")
+    (testing "and an attribute override written on a VIEW head is a loud
+              error naming the prop, because the boundary cannot see inside
+              an opaque child and dropping the map silently is the class of
+              failure this ruling deletes"
+      (is (thrown-with-msg?
+            js/Error #":rf/phase"
+            (presence/with-phase [card {:key 1 :re-frame.hicasso/unmounting {:class "x"}}]
+                                 :unmounting))))))
+
+;; ---------------------------------------------------------------------------
+;; The census-real screen, ported both ways
+;; ---------------------------------------------------------------------------
+
+(defn- toast-card-body
+  "BEFORE — the predecessor's shape, minus its trap. The child view exists
+  only so a per-child phase can be read; here the phase at least arrives
+  as a prop rather than as an ambient read, so this rendering is already
+  strictly safer than the one the guide teaches. The three
+  `(when exiting? …)` attributes are the part HD-025 is about."
+  [{:keys [message] phase :rf/phase}]
+  (let [exiting? (= :unmounting phase)]
+    [:div.toast {:class       (when exiting? "toast--exit")
+                 :inert       (when exiting? true)
+                 :aria-hidden (when exiting? true)}
+     message]))
+
+(def ^:private toast-card (codec/mark-boundary! toast-card-body))
+
+(defn- child-view-tray
+  "BEFORE — a keyed child view per toast."
+  [toasts]
+  (mapv (fn [t] [toast-card {:key (:id t) :message (:message t)}]) toasts))
+
+(defn- inline-tray
+  "AFTER — no child view at all, and the three attributes are one map."
+  [toasts]
+  (mapv (fn [t]
+          [:div.toast {:key (:id t)
+                       :re-frame.hicasso/unmounting {:class       "toast--exit"
+                                                     :inert       true
+                                                     :aria-hidden true}}
+           (:message t)])
+        toasts))
+
+(defn- attrs
+  "An element's props with nil-valued entries dropped — `nil` and absent
+  are the same attribute to React, and the two renderings differ on
+  exactly that: `(when exiting? …)` writes the key with a nil value where
+  an override simply does not write the key."
+  [e]
+  (into (sorted-map)
+        (remove (fn [[_ v]] (nil? v)))
+        (dissoc (js->clj (.-props e)) "children")))
+
+(defn- rendered
+  "Drive one tray through the machine to `phase`, then through the codec,
+  and read the toast elements back."
+  [tray toasts phase]
+  (let [seeded (presence/settle (presence/step presence/initial (tray toasts) 0 timeout-ms))
+        state  (if (= :unmounting phase)
+                 (presence/step seeded (tray []) 100 timeout-ms)
+                 seeded)
+        hiccup (presence/render state)]
+    ;; A boundary child renders through its body; a native child is already
+    ;; the node. Both end at the codec, which is where the comparison is
+    ;; taken, because that is the last point before React.
+    (mapv (fn [child]
+            (codec/as-element
+              (if (codec/boundary-head? (nth child 0))
+                (toast-card-body (nth child 1))
+                child)))
+          hiccup)))
+
+(def ^:private toasts [{:id 1 :message "Saved"} {:id 2 :message "Copied"}])
+
+(deftest the-inline-tray-renders-what-the-child-view-tray-renders
+  (doseq [phase [:present :unmounting]]
+    (testing (str "phase " phase)
+      (let [before (rendered child-view-tray toasts phase)
+            after  (rendered inline-tray toasts phase)]
+        (is (= 2 (count before) (count after)))
+        (doseq [[b a] (map vector before after)]
+          (is (= "div" (.-type b) (.-type a)))
+          (is (= (attrs b) (attrs a))))))))
+
+(deftest the-exit-attributes-arrive-while-unmounting-and-go-on-re-entry
+  (testing "witness 1: a toast written INLINE — no child view — gets the exit
+            attributes while unmounting, and loses them when it comes back."
+    (let [seeded (presence/settle
+                   (presence/step presence/initial (inline-tray toasts) 0 timeout-ms))
+          gone   (presence/step seeded (inline-tray [(first toasts)]) 100 timeout-ms)
+          back   (presence/step gone (inline-tray toasts) 150 timeout-ms)]
+      (is (= {1 :present 2 :unmounting} (presence/phases gone)))
+      (let [exiting (attrs (codec/as-element (second (presence/render gone))))]
+        (is (= "toast toast--exit" (get exiting "className")))
+        (is (true? (get exiting "inert")))
+        (is (true? (get exiting "aria-hidden"))))
+      (is (= {1 :present 2 :present} (presence/phases back)))
+      (let [restored (attrs (codec/as-element (second (presence/render back))))]
+        (is (= "toast" (get restored "className")))
+        (is (nil? (get restored "inert")))
+        (is (nil? (get restored "aria-hidden"))))))
+  (testing "witness 3, headlessly: the child is gone after :timeout-ms and
+            the machine retains nothing"
+    (let [seeded (presence/settle
+                   (presence/step presence/initial (inline-tray toasts) 0 timeout-ms))
+          gone   (presence/step seeded (inline-tray [(first toasts)]) 100 timeout-ms)
+          done   (presence/expire gone 400)]
+      (is (= {1 :present} (presence/phases done)))
+      (is (= [1] (:order done)))
+      (is (= 1 (count (:entries done))))
+      (is (nil? (presence/next-deadline done))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/generation_fence_coverage_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/generation_fence_coverage_cljs_test.cljs
@@ -1,338 +1,163 @@
 (ns re-frame.bench.hicasso.generation-fence-coverage-cljs-test
-  "WHAT THE GENERATION FENCE COVERS, AND WHAT ESCAPES IT (rf2-2rtt6.33).
+  "WHAT THE COMMIT BASIS STILL DOES NOT SEE (rf2-2rtt6.33, re-pointed by
+  rf2-2rtt6.43).
 
-  `docs/design/hicasso/hd-002-adjudication.md` §6.1 leaves one question
-  **[OPEN]**, and calls it the substitution everything else in §2 rests
-  on: the predecessor's commit-side re-read compared **three** things —
-  node identity (`:node-key`), version, and the frame/registry epochs —
-  between the render that produced an element and the commit about to
-  publish it; Hicasso replaces the whole of it with one generation
-  comparison per boundary. Nobody had shown that the one covers the
-  three.
+  `hd-002-adjudication.md` §6.1 asked whether ONE generation comparison
+  per boundary could stand in for the predecessor's commit-side re-read,
+  which compared **three** things between the render that produced an
+  element and the commit about to publish it: node identity
+  (`:node-key`), version, and the frame/registry epochs. This file was
+  the answer, and the answer was *no* on all three.
 
-  This file settles it, and the answer is **no**. It is not a near miss
-  and it is not an arithmetic gap — the fence and the re-read do not
-  guard the same window, so the question 'which of the three does it
-  cover' has the same answer for all three. **The defect row 2 stages is
-  open as `rf2-2rtt6.42`**; these rows are green because they assert the
-  coverage boundary as it stands, so the day that boundary moves they go
-  red and the finding cannot be quietly lost.
+  **Two of the three have since been closed** — rf2-2rtt6.42 replaced the
+  bare generation with [[re-frame.bench.hicasso.arm1.runtime/commit-basis]]
+  (the flush generation PLUS the frame's own physical-install epoch), and
+  the version axis now heals in both windows. Those rows have moved to
+  `arm1/staged_read_tear_cljs_test`, against the arm's own runtime,
+  mutation-proved both ways, with a real-Chromium counterpart in
+  `arm1/generation_fence_dom_cljs_test`. Keeping a second copy here would
+  give one assertion two homes, so this file no longer carries them.
 
-  ## The two windows
+  What is left is the axis nothing closed, and it is the whole of this
+  file: **a `:sub` re-registration moves neither term of the basis.**
 
-      predecessor    render probes a site … COMMIT re-reads that site
-                     |<-------- the render->commit gap -------->|
+  ## Why the basis cannot see it
 
-      generation     capture gen … BODY RUNS … compare gen
-      fence          |<---- one body run ---->|      … then the body returns
+      commit-basis(frame) = flush generation + frame-commit-epoch(frame)
 
-  `render-body` (Arm 1's `arm1/runtime.cljs`, the `loop` at its
-  `(let [before (generation)] …)`) captures the generation, runs the
-  body, compares, and — on a match — RETURNS. Nothing compares anything
-  again. The commit that follows (React calling the read-set entry's
-  `subscribe`, which is where `acquire-cell!` installs the edge and the
-  watch) performs no comparison at all, by design: `#no commit-phase
-  deref` is the arm's stated fence.
+  The first term moves only through `flush!`, whose only caller is
+  `mark-dirty!`, whose only caller is the per-cell value-change watch
+  `acquire-cell!` installs. A re-registration changes the *computation*
+  behind a query; it does not push a new value through an acquired
+  reaction, so it reaches none of them. The second term is bumped once
+  per physical frame-state install at the substrate's two write
+  chokepoints — and a registry write is not a frame-state install. So
+  both terms sit still, and React's post-`subscribe` `getSnapshot`
+  re-check is equally blind: the number is the sum of the same epochs it
+  was before.
 
-  So the fence covers a hazard the predecessor's three fields never
-  addressed — a commit landing BETWEEN TWO READS OF ONE BODY, which the
-  predecessor got for free because it probed per site and re-read per
-  site — and it does not reach the render->commit gap, which is the only
-  window the three fields were ever about. One-for-one on a different
-  axis, not one-for-three.
+  The `:node-key` axis is silent for the same reason and is stated rather
+  than staged, because a second row would re-prove this one's arithmetic
+  with a longer fixture: a same-id frame reincarnation is not a value
+  change on an acquired reaction either — and `frame-commit-epoch`
+  RESTARTS at 0 across one, which is precisely why Spec 006's observation
+  port carries `:node-key` as a third field.
 
-  ## What does reach the gap, and how far
+  Both remaining axes are tracked as **rf2-2rtt6.44**, where the question
+  is a design decision rather than a defect: closing the registry axis for
+  a retained key would mean re-rendering every boundary on every
+  re-registration, and `observation/registry-epoch*` is `^:private` with
+  no public reader, so the arm cannot even observe it without a substrate
+  change.
 
-  Arm 1 is not defenceless there. Its shell hands
-  `useSyncExternalStore` a `getSnapshot` that returns the **sum of the
-  read set's epochs**, and React's own commit-time snapshot re-check
-  forces a re-render when that number moves. That is a real second
-  channel and this file's first row proves it works. But it is driven by
-  the same counter the fence is: an epoch moves only when `flush!`
-  bumps it, `flush!` runs only from `mark-dirty!`, and `mark-dirty!` has
-  exactly one caller — the value-change watch that `acquire-cell!`
-  installs **at commit**. Therefore:
+  ## The row carries its own control, and needs to
 
-  - **version axis** — covered for a **retained** key (some boundary
-    already committed it, so the watch pre-dates the move). NOT covered
-    for a **staged** key: a key nothing holds yet has no cell, no watch
-    and no epoch, so a move in the gap marks nothing, bumps nothing, and
-    leaves `getSnapshot` returning the same number before and after the
-    commit. Row 2.
-  - **frame/registry-epoch axis** — no counterpart at all. A registry
-    epoch move is not a value change on an acquired reaction, so it
-    cannot reach `mark-dirty!`. Row 3.
-  - **node-key axis** — no counterpart at all, by the same argument:
-    nothing in the runtime observes node identity, and the sole writer of
-    the generation is the value watch. Stated rather than staged, because
-    a third row would re-prove row 3's arithmetic with a longer fixture.
+  The assertion is that a number does NOT move, and a still number is
+  trivially still on a broken fixture. So the row first makes a real
+  frame-state install and watches the basis and the snapshot move — same
+  frame, same boundary, same read set, same instruments, one line apart —
+  and only then re-registers and reads them still. Without the positive
+  half on the board this row would pass against a runtime that had no
+  counters at all.
 
-  Spec 006 §The six frozen invariants, invariant 5 already names the
-  staged case as the worse one, in the same words: 'a **staged** site
-  publishes stale and **nothing ever corrects it**, because a
-  dependency's *first* render has no earlier channel to heal through.'
-  Row 2 is that sentence, executed against Arm 1's counter.
+  ## Everything here runs against Arm 1's own runtime
 
-  ## Why this file transcribes rather than requires
-
-  Arm 1's runtime is on a spike branch (HD-017 keeps runtime skeletons
-  off main until the P2 ruling), and the arm owns that surface. The
-  three functions the answer turns on are therefore **transcribed** here
-  — `flush!`/`mark-dirty!` (the generation and the epoch bump),
-  `acquire-cell!` (commit-only acquisition, baseline deref, watch), and
-  the epoch-sum `getSnapshot` — over the REAL sub layer, the REAL frames
-  and REAL watches. What is deliberately dropped is everything that
-  cannot change the answer: the index, the read-set entry cache, the
-  scratch array, React. Each transcribed function names its original in
-  a comment; `rf2-2rtt6.43` re-points these rows at the arm's own
-  runtime once it is on main.
-
-  The host is the React spine (`re-frame.adapter.uix`), not the
-  plain-atom substrate, and that is load-bearing for the same reason
-  `shell_tear_dom_cljs_test.cljs` gives: on an unwatchable host row 2's
-  clean counter is trivially clean and says nothing. Row 1 establishes
-  that this host really does notify a committed key, and only then does
-  row 2 read a still counter as evidence."
+  This file used to TRANSCRIBE `flush!`, `mark-dirty!`, `acquire-cell!`
+  and the epoch-sum `getSnapshot`, because HD-017 kept runtime skeletons
+  off main. They are on main now, so the transcription is gone: the row
+  drives `render-body` (the render), `snapshot-of` (React's
+  `useSyncExternalStore` capture and its `checkIfSnapshotChanged`) and
+  `commit-boundary!` (React's `subscribe`) directly. The host is the
+  React spine's adapter rather than the plain-atom substrate, and that is
+  load-bearing: on an unwatchable host a subscription never notifies and
+  the control half would be as still as the axis it is controlling for."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [re-frame.adapter.uix :as react-substrate]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.live-frame :as live-frame]
-            [re-frame.subs :as subs]
             [re-frame.test-support :as test-support]))
-
-;; ---------------------------------------------------------------------------
-;; The transcribed generation machinery
-;; ---------------------------------------------------------------------------
-;;
-;; Arm 1 keeps these on JS objects because they are what its heap ladder
-;; prices. Nothing here measures heap, so they are ordinary atoms — the
-;; algebra is identical and the file carries no externs risk.
-
-(defonce ^:private !cells
-  ;; sub-key -> {:reaction r :watch-key k}. Arm 1's `!cells`: one cell per
-  ;; unique (frame, query), created and acquired ONLY at commit.
-  (atom {}))
-
-(defonce ^:private !epochs
-  ;; sub-key -> int. Arm 1 keeps this on the cell as `.-epoch`; a key with
-  ;; no cell has no epoch, which is the whole of row 2.
-  (atom {}))
-
-(defonce ^:private !dirty (atom #{}))
-(defonce ^:private !generation (atom 0))
-(defonce ^:private !watch-counter (atom 0))
-
-(defn- flush!
-  "Arm 1's `flush!`: bump each dirty key's epoch and bump the generation.
-  The ONLY writer of the generation, and it does nothing when the dirty
-  set is empty."
-  []
-  (let [dirty @!dirty]
-    (when (seq dirty)
-      (reset! !dirty #{})
-      (swap! !generation inc)
-      (swap! !epochs (fn [m] (reduce (fn [m k] (update m k (fnil inc 0))) m dirty)))))
-  nil)
-
-(defn- mark-dirty!
-  "Arm 1's `mark-dirty!`. Its ONLY caller is the value-change watch below,
-  which is the fact rows 2 and 3 turn on."
-  [sub-key]
-  (swap! !dirty conj sub-key)
-  (flush!)
-  nil)
-
-(defn- render-read!
-  "Arm 1's `read-key!`, render phase. Warm — a committed cell holds the key
-  — is a pure deref. Cold is `subscribe-once`, which subscribes, derefs and
-  unsubscribes inside this tick and retains nothing, so an abandoned render
-  leaves the world as it found it."
-  [frame-kw query-v]
-  (let [sub-key [frame-kw query-v]]
-    (if-some [cell (get @!cells sub-key)]
-      @(:reaction cell)
-      (subs/subscribe-once query-v {:frame frame-kw}))))
-
-(defn- commit-acquire!
-  "Arm 1's `acquire-cell!` — **commit-phase only**, and the seam React
-  reaches through the read-set entry's `subscribe`. One baseline deref at
-  construction, then the watch that turns the sub layer's equality cutoff
-  into the dirty set. No tear check: the arm acquires without comparing
-  what it read against what the render read."
-  [frame-kw query-v]
-  (let [sub-key [frame-kw query-v]]
-    (or (get @!cells sub-key)
-        (let [reaction (subs/subscribe query-v {:frame frame-kw})
-              watch-key (keyword "rf-genfence-witness" (str "w" (swap! !watch-counter inc)))]
-          @reaction
-          (add-watch reaction watch-key
-                     (fn [_ _ old nu] (when-not (= old nu) (mark-dirty! sub-key))))
-          (swap! !epochs assoc sub-key 0)
-          (swap! !cells assoc sub-key {:reaction reaction :watch-key watch-key})
-          (get @!cells sub-key)))))
-
-(defn- get-snapshot
-  "Arm 1's `getSnapshot` — the sum of the read set's epochs. Monotone, so
-  React's `Object.is` on it is a correct change test; a key with no cell
-  contributes nothing, which is exactly what row 2 exploits."
-  [sub-keys]
-  (reduce (fn [acc k] (+ acc (get @!epochs k 0))) 0 sub-keys))
-
-(defn- reset-model! []
-  (doseq [[sub-key cell] @!cells]
-    (remove-watch (:reaction cell) (:watch-key cell))
-    (subs/unsubscribe (nth sub-key 0) (nth sub-key 1)))
-  (reset! !cells {})
-  (reset! !epochs {})
-  (reset! !dirty #{})
-  (reset! !generation 0)
-  nil)
-
-;; ---------------------------------------------------------------------------
-;; Fixture and seams
-;; ---------------------------------------------------------------------------
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
-    {:adapter       react-substrate/adapter
+    {:adapter       uix-adapter/adapter
+     ;; The carried-invariant chain resolves the dynamic-var frame tier
+     ;; BEFORE React context, so a fixture-installed ambient frame would
+     ;; answer reads for a frame this row never made.
      :ambient-frame nil
-     :init-fn       reset-model!}))
+     :init-fn       (fn [] (rt/reset-runtime!))}))
 
 (def ^:private q [:genfence/v])
 
 (defn- make-frame!
-  "Each row builds its OWN frame: two rows sharing one frame id share its
-  app-db and so share each other's order."
+  "This row's OWN frame and OWN query: a re-registration is a global act,
+  and re-registering a query some other suite reads would be a test
+  writing on a neighbour."
   [id db]
   (live-frame/make-frame {:id id})
   (frame/replace-app-db! id db)
   id)
 
+(defn- reader
+  "A boundary whose whole body is one read, so the entry's read set is one
+  key and the snapshot arithmetic is one term."
+  [seen]
+  (fn [_] (let [v (rt/sub q)] (vreset! seen v) [:li (str v)])))
+
 ;; ---------------------------------------------------------------------------
-;; Row 1 — host honesty. A RETAINED key moving in the gap does move the counter
+;; The registry-epoch axis has no counterpart in the commit basis
 ;; ---------------------------------------------------------------------------
 
-(deftest a-retained-key-moving-in-the-gap-moves-the-generation-and-the-epoch-sum
-  (testing "The precondition for row 2, and the honest half of the answer.
-            A key some earlier boundary already committed has a cell, and
-            that cell's watch was installed by that EARLIER commit — before
-            the move. So a move in this boundary's render->commit gap does
-            reach `mark-dirty!`, does bump the generation and the key's
-            epoch, and therefore does move the number React re-checks at
-            commit. The version axis IS covered here.
+(deftest the-commit-basis-has-no-registry-epoch-axis
+  (testing "The predecessor's third field, and the one rf2-2rtt6.42 did not
+            close. `obs/read` reports the registry epoch on every live node
+            and `moved?` compares it, so a handler re-registration between a
+            render and its commit corrects before paint there.
 
-            Without this row on the board, row 2's still counter would be
-            trivially still and would say nothing at all."
+            Here there is nothing to compare it against. A re-registration
+            is not a frame-state install, so `frame-commit-epoch` does not
+            move; and it is not a value change on an acquired reaction, so
+            it cannot reach `mark-dirty!` and the flush generation does not
+            move either. Both terms of the basis sit still, and the epoch
+            sum React re-checks sits still with them.
+
+            rf2-2rtt6.44 carries this axis, and the `:node-key` axis the
+            same argument covers."
     (rf/reg-sub (first q) (fn [db _] (:v db)))
-    (let [f       (make-frame! ::retained {:v 1})
-          sub-key [f q]]
-      ;; An earlier boundary's commit. This is the whole difference from row 2.
-      (commit-acquire! f q)
-      (let [published   (render-read! f q)
-            gen-before  @!generation
-            snap-before (get-snapshot [sub-key])]
-        (is (= 1 published) "the render read the value that was true when it ran")
-        ;; THE GAP: the source moves after this render read it and before the
-        ;; commit that would install its edge.
-        (frame/replace-app-db! f {:v 2})
-        (is (= (inc gen-before) @!generation)
-            "the generation moved — the watch this key's EARLIER commit
-             installed fired, so this host notifies")
-        (is (not= snap-before (get-snapshot [sub-key]))
-            "and the epoch sum moved with it, so React's own commit-time
-             getSnapshot re-check sees a changed store and re-renders")
-        (is (= 2 (render-read! f q))
-            "a re-run therefore reads the value that is now true")))))
+    (let [seen (volatile! nil)
+          f    (make-frame! ::registry {:v 1})]
+      (rt/render-body f (reader seen) {})
+      (let [entry    (rt/last-reads)
+            release! (rt/commit-boundary! entry (fn []))]
+        (is (= 1 @seen) "the render read the value that was true when it ran")
 
-;; ---------------------------------------------------------------------------
-;; Row 2 — the tear. A STAGED key moving in the gap moves NOTHING
-;; ---------------------------------------------------------------------------
+        (testing "the CONTROL — the instruments are live on this frame, this
+                  boundary and this read set. A real frame-state install
+                  moves the basis and moves the number React re-checks."
+          (let [basis    (rt/commit-basis f)
+                snapshot (rt/snapshot-of entry)]
+            (frame/replace-app-db! f {:v 2})
+            (is (> (rt/commit-basis f) basis)
+                "a physical frame-state install bumps `frame-commit-epoch`,
+                 so the basis moves")
+            (is (not= snapshot (rt/snapshot-of entry))
+                "and the retained key's watch fired, so the epoch sum moved
+                 too — this is what a MOVE looks like on these instruments")))
 
-(deftest invariant-5-a-staged-key-moving-in-the-gap-moves-neither-the-generation-nor-the-epoch-sum
-  (testing "hd-002-adjudication.md §6.1's adversarial witness, and the
-            answer to it. The subscription's VALUE changes between a
-            boundary's render and its commit, and it changes WITHIN ONE
-            GENERATION — because the generation cannot move.
-
-            The key is STAGED: nothing holds it yet, so there is no cell,
-            no watch and no epoch. The move therefore marks nothing. The
-            commit then acquires, and installs the watch one move too late
-            to have reported it. Both counters read exactly what they read
-            at render, before and after the commit, so neither the fence
-            nor React's own getSnapshot re-check has anything to see — and
-            the value the render published is not the value that is true.
-
-            Spec 006 invariant 5 names this as the case with no second
-            channel. This row is that case, executed."
-    (rf/reg-sub (first q) (fn [db _] (:v db)))
-    (let [f       (make-frame! ::staged {:v 1})
-          sub-key [f q]]
-      (is (nil? (get @!cells sub-key))
-          "STAGED, not retained: nothing holds this key, so `commit-acquire!`
-           must run inside the commit below")
-      (let [published   (render-read! f q)
-            gen-before  @!generation
-            snap-before (get-snapshot [sub-key])]
-        (is (= 1 published) "the render read, and this is what it put on screen")
-        (is (zero? snap-before) "a key with no cell contributes no epoch")
-        ;; THE GAP.
-        (frame/replace-app-db! f {:v 2})
-        (is (empty? @!dirty)
-            "the move marked NOTHING — there was no watch yet to fire, so the
-             ordinary invalidation path is not going to correct this")
-        (is (= gen-before @!generation)
-            "so the generation did not move: the change happened WITHIN ONE
-             GENERATION, which is precisely the witness §6.1 asks for")
-        (is (= snap-before (get-snapshot [sub-key]))
-            "and the epoch sum did not move either")
-        ;; THE COMMIT: React calls `subscribe`, the edge is installed, the
-        ;; watch is armed — after the move it would have reported.
-        (commit-acquire! f q)
-        (is (= gen-before @!generation)
-            "the commit compares nothing, so the generation is still the
-             render's")
-        (is (= snap-before (get-snapshot [sub-key]))
-            "and getSnapshot answers the SAME number it answered at render, so
-             React's commit-time re-check finds no tear and schedules no
-             re-render")
-        (is (= 2 (render-read! f q))
-            "meanwhile the value that is true has moved")
-        (is (not= published (render-read! f q))
-            "so `published` — what this boundary put on screen — is STALE")
-        (is (empty? @!dirty)
-            "and nothing is pending: the watch's baseline is the NEW value, so
-             no later notification is coming for a change that already
-             happened. Invariant 5's 'nothing ever corrects it'.")))))
-
-;; ---------------------------------------------------------------------------
-;; Row 3 — the epoch axis has no counterpart in the generation at all
-;; ---------------------------------------------------------------------------
-
-(deftest the-generation-has-no-registry-epoch-axis
-  (testing "The predecessor's third field. `obs/read` reports the registry
-            epoch on every live node and `moved?` compares it, so a handler
-            re-registration between a render and its commit corrects before
-            paint there.
-
-            Here there is nothing to compare it against. The sole writer of
-            the generation is `flush!`, its sole caller is `mark-dirty!`,
-            and `mark-dirty!`'s sole caller is the per-cell VALUE watch. A
-            registry epoch move is not a value change on an acquired
-            reaction, so it cannot reach any of them — and the same
-            argument, unchanged, covers the `:node-key` axis, whose mover
-            (a same-id frame reincarnation) is likewise not a value change
-            on an acquired reaction."
-    (rf/reg-sub (first q) (fn [db _] (:v db)))
-    (let [f (make-frame! ::registry {:v 1})]
-      (commit-acquire! f q)
-      (let [published  (render-read! f q)
-            gen-before @!generation]
-        (is (= 1 published))
-        ;; A registry-epoch move: the same query, a different computation.
-        (rf/reg-sub (first q) (fn [db _] (* 10 (:v db))))
-        (is (= gen-before @!generation)
-            "the generation did not move — it has no registry-epoch axis, and
-             no epoch bumped, so React's getSnapshot re-check is equally blind")
-        (is (empty? @!dirty)
-            "and nothing was marked dirty either")))))
+        (testing "and the axis: the same query, a different computation"
+          (let [basis      (rt/commit-basis f)
+                snapshot   (rt/snapshot-of entry)
+                generation (rt/generation)]
+            (rf/reg-sub (first q) (fn [db _] (* 10 (:v db))))
+            (is (= generation (rt/generation))
+                "the flush generation did not move — a re-registration is not
+                 a value change on an acquired reaction, so it never reaches
+                 `mark-dirty!`")
+            (is (= basis (rt/commit-basis f))
+                "and neither did the basis — a registry write is not a
+                 frame-state install, so `frame-commit-epoch` is untouched")
+            (is (= snapshot (rt/snapshot-of entry))
+                "so React's post-`subscribe` `getSnapshot` re-check is blind
+                 to it: the number is exactly the number it was")))
+        (release!)))))


### PR DESCRIPTION
Five beads from one adversarial design review of the shipped predecessor's
authoring surface, taken under the operator's direction to spend this
programme's effort on *"adversarial design reviews and performance
improvement"* and to *"look at their data oriented structure. Improve upon
that."*

The review found the unsolved problem is **concept count** — and K5 is a count.
So all four ergonomics beads are **deletions with a data replacement**, not
additions. Four new decision records land: HD-022 … HD-025.

The review also stated its own risk, and it is binding rather than decorative:

> All four proposals are taste rulings dressed as deletions, and the instrument
> that would falsify them lost its control arm when grouped `use-subs` was ruled
> below the usability bar.

Its mitigation was to **port a census-real screen and diff it**. Two are ported
below, both with the rendered output asserted identical between the renderings,
so each diff is about authoring and nothing else. Nothing here is asserted to be
better; it is shown, or it is not claimed.

---

## rf2-2rtt6.35 — one callback form; the position selects the contract (HD-024)

The predecessor asks an author who cannot use a bare event vector to pick from a
roster of **four** forms with four contracts — `v/event` returns one vector or
nil, `v/handler`'s "return is ignored", `v/render-fn` is pure and runs during a
foreign render, `v/raw-fn` passes identity through — and then adds a **fifth**
rule about *where the roster reaches*. Outside that reach the failure is not
even the library's: a carrier handed to a raw `#js` prop is a non-callable
marker object, so the author gets the engine's own `TypeError`,
`props.onPing is not a function`, "naming nothing you wrote".

```clojure
;; BEFORE — four forms, and a fifth rule about where they reach
[:input {:type "file" :on-change (v/event     [e]   [:upload/picked (files-of e)])}]
[:div                 {:on-drop  (v/handler   [e]   (measure! e))}]
[grid                 {:cell     (v/render-fn [row] [:td (:x row)])}]
(react/createElement Widget #js {:onPing (v/event [] [:ping])})
;;                                        ^ TypeError at call time, naming nothing you wrote

;; AFTER — one form. Where you put it is the decision.
[:input {:type "file" :on-change (h/fn [e]   [:upload/picked (files-of e)])}]
[:div                 {:on-drop  (h/fn [e]   (measure! e) nil)}]
[grid                 {:cell     (h/fn [row] [:td (:x row)])}]
(react/createElement Widget #js {:onPing (h/fn [] [:ping])})
;;                                        ^ it is a function; it runs, return ignored
```

| Position | Contract |
|---|---|
| native `:on-*` prop | **event** — a returned VECTOR is dispatched; any other return ignored |
| `defhost` `:callbacks` entry | as **declared** (`:event` / `:handler`), never inferred from an `on*` name |
| any other walked position (slot, foreign render prop) | **render** — pure; dispatching from inside is a loud error **naming the position** |
| `:ref` | React's own contract; excluded from lowering |
| anywhere Hicasso does not walk | a plain function; it runs, return ignored |

**Demonstrated.** The last row is the deletion, and it has a witness in both
suites: `outside-every-walked-position-the-form-is-just-a-function` (node) and
`a-javascript-library-calling-it-natively-gets-a-real-call` (real Chromium).
`raw-fn` is **not v0** and costs nothing to omit — the codec already hands
functions to React by identity so `React.memo` and handler-identity bail-outs
keep working. A view's props map is not a position either: it is data in
transit, exactly as an intent vector is.

Four concepts collapse to one — half the K5 budget back. Runtime classification
at positions the codec already walks; **no compiler, no analyzer**.

---

## rf2-2rtt6.36 — one attribute merge, spelled `:&` (HD-023)

The predecessor makes an author choose between **three** merge forms depending
on where the target is, and the penalty for choosing wrong is **silent**:
`spread-safe` "preserves the controlled-input door", `spread` "does not claim
the door", and neither is legal onto a declared foreign head (a spread
canonicalises `:className` into the `:class` slot, so the component never sees
the prop it reads). The cost is recorded twice as a wall with no error attached
— *"Dynamic map on controlled input without spread-safe | forfeits door proof"*
— and re-frame.ui carries the same split and admits it. Caret and IME
protection simply stop.

### The census-real diff — the RealWorld article editor's four fields

`examples/real-apps/realworld_resources/article_editor.cljs:496-522`. Four
fields, each controlled, each disabled off the same in-flight write, each with
its own error slot — differing in **three tokens each**.

```clojure
;; BEFORE — one attribute map per field, written out per field, x4
[:fieldset.form-group
 [:input.form-control
  {:type "text" :name "description" :placeholder "What's this article about?"
   :data-testid "editor-description"
   :value (:description draft) :disabled busy?
   :on-blur  [:editor/blur-field :description]
   :on-input [:editor/edit-field :description ::h/value]}]
 (when desc-err [:div.error-messages desc-err])]
;; … and three more just like it

;; AFTER — one helper that owns the contract, and `:&` carrying the remainder
(defview field [{:keys [id busy?] :as attrs}]
  [:fieldset.form-group
   [:input.form-control {:& (dissoc attrs :id :busy?)
                         :value    (sub [:editor/field id])
                         :disabled busy?
                         :on-blur  [:editor/blur-field id]
                         :on-input [:editor/edit-field id ::h/value]}]
   (when-some [e (sub [:editor/field-error id])] [:div.error-messages e])])

[field {:id :title       :busy? busy? :class "form-control-lg"
        :type "text" :name "title" :placeholder "Article Title"
        :data-testid "editor-title"}]
[field {:id :description :busy? busy?
        :type "text" :name "description" :placeholder "What's this article about?"
        :data-testid "editor-description"}]
[field {:id :body        :busy? busy? …}]
[field {:id :tagList     :busy? busy? …}]
```

**The diff is not the line count — it is that this wrapper is writable at all.**
In the predecessor a `field` helper's correctness depends on the *caller*
picking the right merge syntax, with nothing checking and no diagnostic when
they don't. Here the law is unconditional: **the literal keys written in the map
always win**, so the helper does not have to defend itself, and the
controlled-input door cannot be forfeited by a merge because a merge cannot
reach an owned literal. The case where a caller override *should* win is spelled
by **not writing the literal** — the dangerous default is the other one.

Both renderings are built in `front/census_article_editor_cljs_test` and their
produced elements **and** dispatched intents asserted identical, so the diff
above is about authoring and not about behaviour.

Three details that fall out rather than needing rules: `:key` and `:ref` are
never taken from a `:&` map; the same key and law hold at a crossing, because
`:&` is merged *before* any conversion and the conversion that follows is the
position's own (so a forwarded `:className` crosses under the name it was
written as — that is the predecessor's third rule, absorbed); and class
composition needs no exception because an element's own classes live on the
**tag**, which is not a literal attribute key.

**Two public concepts become zero.** An attribute key is not a concept in the K5
sense.

---

## rf2-2rtt6.37 — presence as data (HD-025)

The predecessor exposes phase as an AMBIENT READ, and its own guide records what
that costs, verbatim:

> Read the phase inside a DECLARED, KEYED CHILD VIEW, as above. Reading it in
> markup written inline in the parent is a trap: those props are evaluated
> during the PARENT'S render, so the phase you get is the parent's, not the
> per-child one you meant.

### The census-real diff — the predecessor's own worked toast tray

```clojure
;; BEFORE — verbatim from docs/core/freehand/host/presence.md
(v/defview toast-card [{:keys [toast]}]
  (let [exiting? (= :unmounting (v/presence-phase))]
    [:div.toast {:class       (when exiting? "toast--exit")
                 :inert       (when exiting? true)
                 :aria-hidden (when exiting? true)}
     (:message toast)]))

(v/defview toast-tray [_]
  (v/presence {:timeout-ms 300}
    (for [t (v/sub [:toasts/visible])]
      [toast-card {:key (:id t) :toast t}])))

;; AFTER
(defview toast-tray [_]
  [h/presence {:timeout-ms 300}
   (for [t (sub [:toasts/visible])]
     [:div.toast {:key (:id t)
                  ::h/unmounting {:class "toast--exit"
                                  :inert true :aria-hidden true}}
      (:message t)])])
```

The child view has disappeared — and it existed **only** so a dynamic variable
could resolve against the right child — and the three `(when exiting? …)`
attributes are one map. When the child genuinely *is* a boundary, the phase
arrives as an ordinary prop, `:rf/phase`, which deletes the trap by
construction: a prop cannot be read from the wrong render scope, it appears in a
structural test's props map, and a headless test supplies it with no clock.

`presence-phase` therefore has **no Hicasso equivalent** — one fewer public
concept.

The predecessor rejected exactly this, and its reason — *"A boundary that
stamped attributes would have to guess at a node it never sees"* — is sound for
a boundary stamping **by itself** and does not survive the author writing the
override on the node. The boundary already owns the retained-children list; the
merge is hiccup→hiccup, before the codec, and React sees an ordinary element
whose props changed.

Only the attribute half of Replicant's mechanism is taken (verified from
replicant.fun, 2026-07-31); its `on-mount` / `on-unmount` **callbacks** are less
data-oriented than registered behaviors and are **rejected**.

**Both renderings are asserted to produce identical attributes**
(`front/presence_cljs_test`), and the whole thing is driven through React and a
real DOM in `arm1/presence_dom_cljs_test`.

Honest limits written into the guide rather than left to be discovered: an
override inside an opaque child view is invisible to the boundary (which is what
`:rf/phase` is for, and writing one there is a loud error naming it), and
**enter is the weak half** — a `:mounting` → `:present` class flip can lose the
race to paint, so the guide teaches the animation-on-insertion answer and keeps
the override for exit.

---

## rf2-2rtt6.38 — reserve `:ref`'s vector value-space (HD-022)

```clojure
[:textarea.composer {:ref attach}]                       ;; v0, unchanged
[:textarea.composer {:ref [::autosize {:max-rows 8}]}]   ;; RESERVED
;; => :rf.error/hicasso-ref-vector-reserved
```

One refusal branch and one error id. `:ref` is the one place Hicasso was planned
to be *less* data-oriented than the substrate it replaces; the census pays for
the reservation and not for the subsystem (**one `:ref` in 85 idiomatic files**).
Explicitly out of scope: a behaviors registry, a `:timing` option, a commands
roster, any host-ownership subsystem.

**The honest limit, now in the guide.** A React ref callback fires on **attach**
and **detach** and **never on config change** — passing a different callback is
the only way to make React invoke it again, and that detaches and reattaches the
node's owner. So v0 ships attach/detach only, config is immutable for the
connection's life, and steady-state change routes through a command **effect**,
which is already data. Nothing in the reserved vector will rescue a design that
wants the ref to notice a prop changed.

---

## rf2-2rtt6.43 — re-point the generation-fence witness

`generation_fence_coverage_cljs_test` **transcribed** `flush!`, `mark-dirty!`,
`acquire-cell!` and the epoch-sum `getSnapshot` from `arm1/runtime.cljs`, because
HD-017 kept runtime skeletons off main when rf2-2rtt6.33 wrote it. They are on
main now, and #7324 changed all three — so the copy had drifted and **row 2
asserted a defect the arm no longer has**.

Re-pointed, not repaired. Two rows **deleted** rather than kept in a second home:

- **Row 1** (a retained key moving in the gap moves the counters) is
  `arm1/staged_read_tear_cljs_test`'s
  `a-retained-key-moving-in-the-gap-is-still-corrected`, against the arm's own
  runtime.
- **Row 2** (a staged key moving in the gap moves nothing) had its verdict
  inverted by #7324 — `commit-basis` now moves for exactly that case. The same
  case is `a-staged-read-that-moves-in-the-gap-is-corrected`, mutation-proved
  both ways, with a real-Chromium counterpart in
  `arm1/generation_fence_dom_cljs_test`.
- **Row 3** (the registry-epoch axis has no counterpart) survives, because
  nothing closed it — rf2-2rtt6.44 carries it and the `:node-key` axis.

The surviving row now carries **its own control**: its claim is that a number
does *not* move, and a still number is trivially still on a broken fixture, so
it first makes a real frame-state install and watches `commit-basis` and
`snapshot-of` move on the same frame, boundary and read set.

---

## Fences held

- **Surface B only.** No compiler, no analyzer, no dual mode, no ViewCell-class
  object graph, **no candidate ledger**. Every classification here happens at a
  position the codec already walks, on a value, at runtime.
- **The ≤2-hook shell is untouched.** `runtime/shell` is not modified;
  `rt/shell-hook-ledger` is still `[:use-context/frame
  :use-sync-external-store/subscription-epoch]`, and
  `arm1_hook_ledger_dom_cljs_test` counts **at React's own dispatcher** —
  `["useContext" "useSyncExternalStore"]`, exactly 2 at 1/7/20 reads, no
  `useRef`/`useState` — green in this branch's browser run. `subscribe` still
  closes over the read set and nothing else.
- **A cost is reported, not spent.** Presence's React driver spends **two hooks
  in its own component** (`useState` + `useEffect`). That is not a shell-budget
  breach — presence reads no subscription, mounts no registration and takes no
  cell — and it is legitimate under HD-003 (animation lifecycle is component
  mechanics), paid once as a library mechanic rather than per view. It is named
  in HD-025 rather than buried. The machine and the phase transform are **pure**,
  which is what makes the whole surface assertable with no clock.
- **Hicasso authors no codec.** `:&` and the `:ref` refusal are two additions to
  the codec taken from reagent-slim, each one branch, each returning by identity
  when absent. HD-023 records that their **clock cost is unmeasured** rather than
  claiming it away — the ruling's own caveat says such additions must be
  measured, and this PR does not measure them. No candidate-bar rows are
  published here.

## Quality gates

All four run **after** a rebase onto current `main` (clean — zero file overlap with
anything that landed since this branch started, including #7325's spine/subs
work), except the spine, which ran immediately before it and whose tiers are
unaffected by that rebase (its JVM tier tests `main`'s code, not this diff's —
this diff contains no JVM-lane source at all).

| Gate | Command | Exit |
|---|---|---|
| CLJS node suite | `npm run test:cljs` | **0** — Ran 12243 tests / 60898 assertions, 0 failures, 0 errors |
| Browser suite (real Chromium) | `npm run test:browser` | **0** — Ran 946 tests / 5849 assertions, 0 failures, 0 errors |
| Fast PR spine | `scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine`; JVM core 2198 tests, JVM freehand 1288 tests, CLJS node 12236, per-ns isolation 17/17, all 0 failures |
| clj-kondo, CI-pinned **2026.04.15** | the exact `--lint` list from `.github/workflows/lint.yml`, `--fail-level error` | **0** — `errors: 0, warnings: 4526` (4531 before; the 5 this branch introduced are fixed) |

The local npm-resolved clj-kondo is 2025.10.23, so the **CI-pinned 2026.04.15**
release was fetched and run instead — that is the version whose findings block
the merge.

**TESTING.md matrix derived for this diff.** The changed surface is
`implementation/freehand/test/**` (bench/test tree only — no `src/` in any
artefact), `docs/design/hicasso/**`, and `.clj-kondo/config.edn`. That lights
the **cljs node** tier (`npm run test:cljs`, which is where every new
`*_cljs_test` ns runs), the **browser** tier (the two new `*_dom_cljs_test`
namespaces — `re-frame.bench.hicasso.*` is not excluded by `:browser-test`'s
`ns-regexp`, unlike `re-frame.freehand.bench.*`), the **lint** tier
(`.clj-kondo/config.edn` is in the lint surface), and the **docs** tier. It does
**not** light the JVM artefact suites beyond `implementation/core` (which the
spine runs unconditionally), the adapter smokes, bundle-isolation, the
perf-bundle gate, or mcp-conformance — nothing here is reachable from a
production build, and the Hicasso tree has no JVM lane.

**`mkdocs build --strict` does not cover `docs/design/hicasso/**`** —
`design/hicasso/` is in `exclude_docs` in `mkdocs.yml`, and the spine soft-skips
mkdocs locally anyway (not on PATH). What *does* cover the tree is the spine's
**docs corpus anchor validator** (`scripts/check_doc_slugs.py`), which walks it:
it caught a genuine break — HD-022's link into the interop guide, where the em
dash in the heading does not survive slugification — and that heading was
reworded rather than the link fudged. Table **column counts** are not checked by
any gate, so every table in the tree was verified separately: the 9 mismatches
in the corpus are all pre-existing rows under `docs/design/hicasso/studio/`
(untouched here); every table added or edited by this PR is consistent.

`test_quiet_shadow_node_cljs_test` did not fail in any run.
