### PR TITLE
hicasso: a deferred read cannot be attributed to the wrong boundary (rf2-2rtt6.45)

### DIFF
--- a/docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md
+++ b/docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md
@@ -205,11 +205,16 @@ It is the hardest class of bug to attribute, because the first paint is clean.
 **This arm does not have it, and the reason is structural rather than careful.**
 The collector window closes around `codec/as-element`, and the codec is eager
 everywhere it walks: `expand-seq` drives a seq to exhaustion, `realize-children`
-folds one into a vector, and a seq at a prop position goes through `clj->js`. A
-lazy read is therefore forced inside the window by the same pass that turns
-hiccup into elements. No `doall`, no `vec`, no widened window, and so no cost:
-the realisation was already going to happen, at the same moment, for the same
-reason. The ≤2-hook budget is untouched.
+folds one into a vector, a seq at a native prop position goes through `clj->js`,
+and `realize-deep` forces every lazy sequence reachable from a **boundary's**
+props before the crossing hands them on. A lazy read is therefore forced inside
+the window by the same pass that turns hiccup into elements. No `doall`, no
+`vec`, no widened window. The ≤2-hook budget is untouched.
+
+The fourth clause is a repair. When this section was first written the list had
+three, and its `clj->js` clause was read as covering the boundary hand-off as
+well as the native prop position — it did not, and what escaped through the gap
+is [below](#one-residual-case-and-one-that-was-not-residual).
 
 Verified rather than argued, on both halves — because the first half alone is
 exactly what a broken implementation also passes:
@@ -234,11 +239,70 @@ witnessed by `every-read-that-escapes-the-render-is-loud-rather-than-a-missing-e
 — a stored handler, a handler actually invoked, an author-held `delay`, and a
 stashed lazy seq forced after the render.
 
-One residual case the guard cannot see, named rather than left to be discovered:
-a deferred read forced *inside another boundary's* render is attributed to that
-boundary. It is not a missing edge — the reader does re-render — but it is the
-wrong reader, and catching it would need per-boundary render identity the shell
-deliberately does not hold.
+### One residual case, and one that was not residual
+
+A fifth escape the `try`/`finally` guard cannot see: a deferred read forced
+*inside another boundary's* render. `read-key!`'s guard asks whether **any** body
+is running, not whether **this** one is — `rstate` is a single module-level
+object — so the read does not throw. It lands on the rendering boundary's scratch
+instead.
+
+**This page previously called that "not a missing edge — the reader does
+re-render — but the wrong reader", and left it there. That was wrong, and it was
+wrong in the worst available direction** (`rf2-2rtt6.45`). A `LazySeq` caches what
+it realised, so the wrong reader re-renders exactly *once*; on that re-render its
+body walks an already-realised seq, `sub` is never called, its read set collapses
+to the empty set, React re-subscribes, and every row edge is dropped. The right
+reader never re-rendered, so the seq is never rebuilt. One correction, and then a
+value that is **correct on screen, frozen thereafter, attributable to nothing** —
+which is the class this section calls the worst failure the ruled surface can
+have, sitting inside the section that says the arm does not have it.
+
+And the structural argument above had a hole in exactly the place that made the
+escape reachable. "A seq at a prop position goes through `clj->js`" is true for a
+**native tag** — `convert-prop-value` sends any collection through it — and was
+false for a **boundary**: `boundary-element` built `body-props` as a plain
+ClojureScript map and handed it across untouched, and the shell read it back as a
+map. No conversion, no walk, no realisation. `realize-children` compounded it by
+flattening exactly one level, so a nested seq in a boundary's children survived
+unrealised too.
+
+Both carriers are closed by one call. `codec/realize-deep`, applied once to
+`body-props` in `boundary-element`, forces every lazy sequence reachable from the
+map — `:children` included, since it is a key in the same map — and returns the
+map **by identity**, because realising a `LazySeq` caches into the seq rather
+than rebuilding it. The read is then forced by the same pass that turns hiccup
+into elements, inside the window of the body that *wrote* it, which is what the
+eager-codec argument claimed all along.
+
+The alternative — giving `read-key!` a per-boundary render token to refuse
+against — was rejected and is worth recording as rejected. It is per-boundary
+render identity, one line from the candidate-ledger tripwire, and it would turn a
+legitimate authoring shape into an error rather than making it work. Realising at
+the hand-off needs no such thing: `rstate` is still one object, nothing can tell
+one render attempt from another, and the shell still holds two hooks and no
+per-instance state.
+
+| Witness | Asserts |
+|---|---|
+| `boundary-crossing-cljs-test` (8 rows) | at the seam: every row query the parent's `for` produced is the **parent's** edge, nothing lands on the child, and a write to a row re-runs the parent and not the child — plus carrier (b), a nested seq one level below the children splice |
+| `boundary-crossing-dom-cljs-test` (2 rows) | in real Chromium: the first paint is right, **and** a later write reaches the DOM, its neighbour is untouched, the edges survive the re-render, and a second write moves it again |
+
+Mutation-proved by removing the one call: node exit 1 (7 failures), browser exit 1
+(4 failures — the cell frozen at its original text through two writes, and the
+edge count collapsing from 7 to 1 on the first). Restored, both exit 0. The
+first-paint assertions passed on the broken runtime, which is the whole reason
+the second half is asserted.
+
+**What genuinely remains, stated precisely so it is not rediscovered as a
+surprise.** The codec can force *structure* — a seq is data it already walks. It
+cannot force an explicit deferral primitive without destroying its meaning: a
+`delay` handed across a boundary and deref'd in the child's render is the same
+fault in a shape no walk may repair, because forcing a `delay` eagerly is the
+opposite of what a `delay` is for. A **function** prop is not in this class and is
+not a defect at all: the child re-runs it on every render, so the read repeats and
+the edge is kept — the reader is the child, and the child is the one whose output
+depends on it.
 
 ## 3. Two places the record did not survive contact with the substrate
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary_crossing_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary_crossing_cljs_test.cljs
@@ -1,0 +1,276 @@
+(ns re-frame.bench.hicasso.arm1.boundary-crossing-cljs-test
+  "A READ DEFERRED ACROSS A BOUNDARY CROSSING (rf2-2rtt6.45).
+
+  `runtime-cljs-test`'s
+  `every-read-that-escapes-the-render-is-loud-rather-than-a-missing-edge`
+  settled four escapes — a stored handler, a handler invoked, an
+  author-held `delay`, and a stashed lazy seq — and all four share one
+  property: the deferred read runs when **no** body is running, so
+  `read-key!` finds no frame and says so. This file is about the fifth,
+  which has the opposite property and is therefore silent.
+
+  ## The defect these rows are about
+
+  `read-key!`'s guard asks *is any body running*, not *is THIS body
+  running*, because `rstate` is one module-level object. A read deferred
+  past its author's body and forced inside a **different** boundary's
+  render therefore does not throw: it lands on that boundary's scratch,
+  and the boundary that produced it holds no edge for it.
+
+  The carrier is the boundary hand-off. `convert-prop-value` sends any
+  collection at a NATIVE prop position through `clj->js`, so the eager
+  codec really does force everything it walks there — but
+  `boundary-element` hands `body-props` across as a raw ClojureScript
+  map, and the shell reads it back as one. No conversion, no walk, no
+  realisation:
+
+      (defview child  [{:keys [rows]}] [:ul (for [r rows] [:li (str r)])])
+      (defview parent [_] [child {:rows (for [id (sub [:visible-ids])]
+                                          (:title (sub [:todo id])))}])
+
+  `(sub [:visible-ids])` is the `for`'s binding expression and runs
+  eagerly; every `(sub [:todo id])` runs when the CHILD walks the seq.
+
+  **And it does not merely put the edge on the wrong boundary.** A
+  `LazySeq` caches what it realised, so the wrong reader re-renders
+  exactly once: on that re-render its body walks an already-realised
+  seq, `sub` is never called, its read set collapses to the empty set,
+  React re-subscribes and the row edges are dropped. The right reader
+  never re-rendered, so the seq is never rebuilt. One correction, then a
+  value that is **correct on screen, frozen thereafter, attributable to
+  nothing** — the class the judgement page calls the worst failure this
+  surface can have.
+
+  ## What closes it
+
+  `codec/realize-deep`, called once on `body-props` in
+  `boundary-element`. It forces every lazy sequence reachable from the
+  props map — including the `:children` vector, whose one-level flatten
+  leaves a nested seq unrealised — and returns the map itself, by
+  identity, because realising a `LazySeq` caches into the seq and copies
+  nothing. The read is then forced by the same pass that turns hiccup
+  into elements, inside the window of the body that WROTE it, which is
+  the property the eager codec was always supposed to have.
+
+  It is emphatically not per-boundary render identity: nothing here can
+  tell one render attempt from another, `rstate` is still one object, and
+  the shell still holds two hooks and no per-instance state.
+
+  ## What these rows are
+
+  The seam driven by hand, as in `staged-read-tear-cljs-test`:
+  `render-body` is the render, `commit-boundary!` is React's
+  `subscribe`, and the props map the codec built for the crossing is read
+  straight off the React element. `boundary-crossing-dom-cljs-test` then
+  proves the DOM moves, in real Chromium, on a later write — the half a
+  first paint cannot tell you.
+
+  The adapter is UIx's, not `plain-atom`'s: plain-atom has no reactivity
+  layer, so a subscription under it never notifies and every commit
+  assertion below would pass by never firing."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     :init-fn (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::arm1-boundary-crossing)
+
+(defn- seeded! []
+  (rt/reset-runtime!)
+  (dogfood/make-frame! frame-id 3)
+  frame-id)
+
+(defn- key-of [query] [frame-id query])
+
+;; ---------------------------------------------------------------------------
+;; The two bodies, and the head that makes the crossing a real one
+;; ---------------------------------------------------------------------------
+;;
+;; The bodies are kept as plain fns and the boundary head is minted from
+;; the child's, so this suite can run both halves of the crossing without
+;; React: the codec sees a genuine marked head and builds the genuine
+;; `rfProps` map, and `render-body` then runs the child's body on exactly
+;; the map React would have handed it.
+
+(defn- child-body [{:keys [rows]}]
+  [:ul.child (for [r rows] [:li.cell (str r)])])
+
+(def ^:private child-view (rt/mint-view! "boundary-crossing/child" child-body))
+
+(defn- parent-body [_]
+  [child-view {:rows (for [id (rt/sub [:dogfood/visible-ids])]
+                       (:title (rt/sub [:dogfood/todo id])))}])
+
+(defn- nested-child-body [{:keys [children]}]
+  (into [:ul.nested] children))
+
+(def ^:private nested-child-view
+  (rt/mint-view! "boundary-crossing/nested-child" nested-child-body))
+
+(defn- nested-parent-body
+  "Carrier (b): the seqs are in the CHILDREN position, one level below the
+  splice `realize-children` performs. The outer `for` is the boundary's
+  one trailing form, so the flatten forces ITS spine and hands each inner
+  `for` on as an element, unrealised."
+  [_]
+  [nested-child-view
+   (for [chunk (partition-all 2 (rt/sub [:dogfood/visible-ids]))]
+     (for [id chunk]
+       [:li.cell {:key id} (str (:title (rt/sub [:dogfood/todo id])))]))])
+
+(defn- crossing-props
+  "The props map the codec built for the crossing — precisely what the
+  shell reads back out of `rfProps` and hands the child's body."
+  [element]
+  (unchecked-get (.-props element) "rfProps"))
+
+(defn- render [body-fn props]
+  (let [element (rt/render-body frame-id body-fn props)]
+    {:element element :entry (rt/last-reads) :reads (rt/reads-of (rt/last-reads))}))
+
+(defn- mounted!
+  "A boundary at the seam React occupies: render the body, commit its
+  reads, and hand back the notification counter and the cleanup."
+  [body-fn props]
+  (let [{:keys [element entry reads]} (render body-fn props)
+        hits    (volatile! 0)
+        release (rt/commit-boundary! entry (fn [] (vswap! hits inc)))]
+    {:element element :entry entry :reads reads :hits hits :release! release}))
+
+(def ^:private row-keys
+  #{[frame-id [:dogfood/todo 0]]
+    [frame-id [:dogfood/todo 1]]
+    [frame-id [:dogfood/todo 2]]})
+
+;; ---------------------------------------------------------------------------
+;; 1 — the crossing attributes the read to the boundary that WROTE it
+;; ---------------------------------------------------------------------------
+
+(deftest a-lazy-seq-handed-across-a-boundary-is-the-parents-read
+  (seeded!)
+  (testing "the reads deferred into a seq at a boundary's prop position
+           belong to the body that wrote them, not to the body that
+           happens to walk the seq"
+    (let [parent (render parent-body {})
+          child  (render child-body (crossing-props (:element parent)))]
+      (is (= (conj row-keys (key-of [:dogfood/visible-ids])) (:reads parent))
+          "every row query the parent's `for` produced is the PARENT's edge")
+      (is (= #{} (:reads child))
+          "and nothing at all landed on the child — the seq the codec handed
+           it was already realised, so its body called `sub` zero times"))))
+
+(deftest the-childs-second-render-reads-nothing-which-is-why-the-first-row-matters
+  (seeded!)
+  (testing "**Why the misattribution is not merely untidy.** A `LazySeq`
+           caches, so a boundary that realised one and is then re-rendered
+           with the same props reads NOTHING the second time. Had the row
+           keys landed on the child, this render would have collapsed its
+           read set to empty, React would have re-subscribed, and every row
+           edge would have been dropped with no boundary left holding one —
+           permanent staleness, with a correct first paint."
+    (let [parent (render parent-body {})
+          props  (crossing-props (:element parent))
+          first' (render child-body props)
+          again  (render child-body props)]
+      (is (= #{} (:reads first')))
+      (is (= #{} (:reads again))
+          "the second walk of a realised seq calls `sub` zero times — true
+           before this fix and after it; what changed is who holds the edge
+           when it happens"))))
+
+(deftest carrier-b-a-nested-seq-in-the-children-position
+  (seeded!)
+  (testing "`realize-children` flattens exactly one level, so a `for`
+           inside a `for` reaches the child's body unrealised. The same
+           walk covers it, because `:children` is a key in the same props
+           map."
+    (let [parent (render nested-parent-body {})
+          props  (crossing-props (:element parent))
+          child  (render nested-child-body props)]
+      (is (= 2 (count (:children props)))
+          "the outer seq spliced into two children, one per chunk")
+      (is (every? seq? (:children props))
+          "and each child is still a seq — the ABI's one-level splice is
+           unchanged; what changed is that the seq arrives realised")
+      (is (= (conj row-keys (key-of [:dogfood/visible-ids])) (:reads parent)))
+      (is (= #{} (:reads child))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — and the commit puts the edges where the reads were attributed
+;; ---------------------------------------------------------------------------
+
+(deftest a-write-to-a-row-the-parent-produced-re-runs-the-parent
+  (seeded!)
+  (testing "the half a first render cannot tell you, at the seam: the
+           notification must reach the boundary that can REBUILD the seq.
+           A notification delivered to the child is worth nothing — its
+           props are the same object and its seq is already realised."
+    (let [parent (mounted! parent-body {})
+          child  (mounted! child-body (crossing-props (:element parent)))]
+      (is (= 4 (:edges (rt/stats)))
+          "four edges, all of them the parent's: the ids query and one per row")
+      (rt/dispatch! frame-id [:dogfood/edit-draft 1 "crossed"])
+      (rt/dispatch! frame-id [:dogfood/commit 1])
+      (is (= 1 @(:hits parent))
+          "the parent re-runs, so the seq is rebuilt and the child receives
+           a new one")
+      (is (= 0 @(:hits child))
+          "and the child is not notified in its stead — a re-render there
+           would repaint the identical realised seq and drop the edges")
+      ((:release! child))
+      ((:release! parent)))))
+
+(deftest the-crossing-leaves-no-residue
+  (seeded!)
+  (let [parent (mounted! parent-body {})
+        child  (mounted! child-body (crossing-props (:element parent)))]
+    ((:release! child))
+    ((:release! parent))
+    (rt/reset-runtime!)
+    (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0} (rt/residue)))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the walk itself: what it forces, and what it must not disturb
+;; ---------------------------------------------------------------------------
+
+(deftest realize-deep-returns-its-argument-by-identity
+  (testing "realising a `LazySeq` caches into the seq, so the walk rebuilds
+           nothing and the props map the child receives is the map the
+           codec built — no copy, no fresh identity for React to see"
+    (let [m {:rows (map inc (range 3)) :label "x"}]
+      (is (identical? m (codec/realize-deep m)))
+      (is (identical? (:rows m) (:rows (codec/realize-deep m))))))
+  (testing "a scalar and a nil pass straight through"
+    (is (= 7 (codec/realize-deep 7)))
+    (is (nil? (codec/realize-deep nil)))
+    (is (= "s" (codec/realize-deep "s")))))
+
+(deftest realize-deep-forces-every-lazy-seq-it-can-reach
+  (testing "the reach is the one `clj->js` already has at a native prop
+           position, which is what makes the structural claim true as
+           written rather than true for one of the two positions"
+    (doseq [[label build] [["a bare seq"            (fn [!n] {:v (map (fn [i] (vswap! !n inc) i) (range 3))})]
+                           ["a seq inside a vector" (fn [!n] {:v [(map (fn [i] (vswap! !n inc) i) (range 3))]})]
+                           ["a seq inside a map"    (fn [!n] {:v {:k (map (fn [i] (vswap! !n inc) i) (range 3))}})]
+                           ["a seq inside a seq"    (fn [!n] {:v (list (map (fn [i] (vswap! !n inc) i) (range 3)))})]
+                           ["a seq inside a set"    (fn [!n] {:v #{(map (fn [i] (vswap! !n inc) i) (range 3))}})]]]
+      (let [!n (volatile! 0)
+            v  (build !n)]
+        (codec/realize-deep v)
+        (is (= 3 @!n) label)))))
+
+(deftest realize-deep-does-not-walk-into-a-react-element-or-a-function
+  (testing "a React element is an opaque JS object and a function is a
+           value, not a structure; neither is a collection and neither is
+           descended into"
+    (let [el (codec/as-element [:li "a"])
+          f  (fn [] :never-called)]
+      (is (identical? el (codec/realize-deep el)))
+      (is (identical? f (codec/realize-deep f))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary_crossing_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary_crossing_dom_cljs_test.cljs
@@ -1,0 +1,160 @@
+(ns re-frame.bench.hicasso.arm1.boundary-crossing-dom-cljs-test
+  "A READ DEFERRED ACROSS A BOUNDARY CROSSING, IN A REAL BROWSER
+  (rf2-2rtt6.45).
+
+  `boundary-crossing-cljs-test` settles who the read belongs to, at the
+  seam, without React. This file asserts the only thing that finally
+  matters about it: **that a later write moves the page.**
+
+  The distinction is the whole point of the bead. The defect's first
+  paint is perfect — the values a lazy seq produces are right once it is
+  realised, whichever boundary realised them — so any witness that stops
+  at the mount passes on the broken runtime as happily as on the fixed
+  one. What separated them was what happened next. The read landed on the
+  child; a write to a row therefore notified the CHILD; the child
+  re-rendered with the same props object and the same already-realised
+  `LazySeq`, so `sub` was never called again; its read set collapsed to
+  empty, React re-subscribed, and the row edges were dropped with no
+  boundary left holding one. The cell painted its original text and no
+  later write to any row would ever move it again.
+
+  So both halves are asserted here, and only the second one can fail on a
+  correct implementation's behalf:
+
+  1. the first paint is right — which proves nothing on its own;
+  2. a write to a row query the PARENT produced reaches the DOM, its
+     neighbour is untouched, and the edges are still held afterwards.
+
+  Both carriers are driven: a lazy seq at a boundary's **prop** position,
+  and a nested seq in its **children** position, one level below the
+  splice `realize-children` performs.
+
+  Runtime: `-dom-cljs-test`; under `:node-test` every claim degrades to a
+  stated skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::arm1-boundary-crossing-dom)
+(def ^:private todo-count 6)
+
+(defn- skip! [why] (is true (str "a boundary-crossing claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (lane/leave-act-environment!)
+  (dogfood/make-frame! frame-id todo-count)
+  (dogfood/reseed! frame-id todo-count)
+  frame-id)
+
+(defn- cell-text [handle id]
+  (some-> (.querySelector (:container handle) (str ".cell[data-id=\"" id "\"]"))
+          (.-textContent)))
+
+(defn- cell-count [handle]
+  (.-length (.querySelectorAll (:container handle) ".cell")))
+
+(defn- retitle!
+  "Move one row's `:dogfood/todo` query, through the arm's own door."
+  [id title]
+  (rt/dispatch! frame-id [:dogfood/edit-draft id title])
+  (mount/settle!)
+  (rt/dispatch! frame-id [:dogfood/commit id])
+  (mount/settle!)
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Carrier (a) — a lazy seq at a boundary's PROP position
+;; ---------------------------------------------------------------------------
+
+(defview crossing-child
+  "Walks the seq its parent handed it. Every `sub` inside that seq was
+  deferred past the parent's body return and is forced HERE, in a render
+  that did not write it."
+  [{:keys [rows]}]
+  [:ul.crossed
+   (for [[id title] rows]
+     [:li.cell {:key id :data-id id} (str title)])])
+
+(defview crossing-parent
+  "Reads the ids eagerly — a `for`'s binding expression always runs — and
+  defers every row read into the seq it hands across the crossing."
+  [_]
+  [crossing-child
+   {:rows (for [id (rt/sub [:dogfood/visible-ids])]
+            [id (:title (rt/sub [:dogfood/todo id]))])}])
+
+(deftest a-read-deferred-across-a-boundarys-props-still-moves-the-dom
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [crossing-parent {}])]
+        (try
+          (is (= todo-count (cell-count handle)))
+          (is (= "todo 2" (cell-text handle 2))
+              "the first paint is right — which is exactly what the broken
+               runtime also gives you, and why this row proves nothing alone")
+          (let [edges-at-mount (:edges (rt/stats))]
+            (retitle! 2 "crossed")
+            (is (= "crossed" (cell-text handle 2))
+                "**the second half.** A write to a row query the PARENT
+                 produced reaches the DOM: the notification went to the
+                 boundary that can rebuild the seq, and it did")
+            (is (= "todo 1" (cell-text handle 1))
+                "while its neighbour is untouched")
+            (is (= edges-at-mount (:edges (rt/stats)))
+                "and the edges survived the re-render — the failure mode was
+                 that the wrong reader re-rendered ONCE, read nothing the
+                 second time, and left the row with no edge at all"))
+          (testing "and it is not a one-shot correction: the value keeps moving"
+            (retitle! 2 "crossed again")
+            (is (= "crossed again" (cell-text handle 2))))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; Carrier (b) — a nested seq in the CHILDREN position
+;; ---------------------------------------------------------------------------
+
+(defview nested-child
+  "Receives `(:children props)` as the realized vector the ABI promises,
+  and splices it. Each element is still a seq — the one-level flatten is
+  unchanged — so this body is the one that walks the inner seqs."
+  [{:keys [children]}]
+  (into [:ul.nested] children))
+
+(defview nested-parent
+  "One trailing form, a `for` of `for`s. `realize-children` forces the
+  outer spine and hands each inner seq on as an element."
+  [_]
+  [nested-child
+   (for [chunk (partition-all 2 (rt/sub [:dogfood/visible-ids]))]
+     (for [id chunk]
+       [:li.cell {:key id :data-id id} (str (:title (rt/sub [:dogfood/todo id])))]))])
+
+(deftest a-read-deferred-into-a-boundarys-nested-children-still-moves-the-dom
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [nested-parent {}])]
+        (try
+          (is (= todo-count (cell-count handle)))
+          (is (= "todo 4" (cell-text handle 4)) "the first paint is right")
+          (retitle! 4 "nested")
+          (is (= "nested" (cell-text handle 4))
+              "a read one level below the children splice belongs to the
+               parent too, and its write reaches the DOM")
+          (is (= "todo 3" (cell-text handle 3))
+              "while its chunk-mate is untouched")
+          (finally (mount/release! handle)))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -118,10 +118,19 @@
   This arm is safe by construction: [[run-once]] closes the window around
   `codec/as-element`, and the codec is eager everywhere it walks —
   `expand-seq` drives a seq to exhaustion, `realize-children` folds one
-  into a vector, and a seq at a prop position goes through `clj->js`. A
-  lazy read is therefore forced inside the window by the same pass that
+  into a vector, a seq at a *native* prop position goes through
+  `clj->js`, and `front.codec/realize-deep` forces every lazy sequence
+  reachable from a *boundary's* props before the crossing hands them on.
+  A lazy read is therefore forced inside the window by the same pass that
   turns hiccup into elements, and moving the codec call out of `run-once`
   fails `a-lazy-for-registers-its-edges-and-its-readers-re-run`.
+
+  The fourth clause is a repair, and the shape of what it repairs is the
+  reason [[read-key!]]'s guard below is not the whole story: the boundary
+  hand-off used to pass its props map through raw, so a seq written in
+  one body was realised inside ANOTHER body's render — where the guard
+  finds a frame, does not throw, and files the read under the wrong
+  boundary. rf2-2rtt6.45, and `arm1/boundary-crossing-cljs-test`.
 
   **An eager codec is only half of it, and the other half matters more.**
   A codec can force the reads it walks; nothing can force a read the

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
@@ -137,9 +137,12 @@
            This arm is safe **by construction rather than by care**: the
            collector window closes around `codec/as-element`, and the codec
            is eager everywhere it walks — `expand-seq` drives a seq to
-           exhaustion, `realize-children` folds one into a vector, and a
-           seq at a prop position goes through `clj->js`. So a lazy read is
-           forced inside the window by the same pass that turns hiccup into
+           exhaustion, `realize-children` folds one into a vector, a seq at
+           a NATIVE prop position goes through `clj->js`, and
+           `codec/realize-deep` forces one reachable from a BOUNDARY's
+           props at the crossing (rf2-2rtt6.45, whose own suite is
+           `arm1/boundary-crossing-cljs-test`). So a lazy read is forced
+           inside the window by the same pass that turns hiccup into
            elements. This test is what keeps that true: it fails the moment
            the codec call moves outside `run-once`."
     (let [b (mounted! (fn [_]

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -71,7 +71,7 @@
   | Head | Props | Children | `:key` |
   |---|---|---|---|
   | Native tag | attr map | trailing forms; seqs realized once and flattened one level; `nil`/`false` render nothing, `true` errors | `:key` in the attr map |
-  | Boundary (a marked `defview` product) | one props map | trailing forms as `(:children props)`, a realized vector | `:key` in the props map, extracted before the body sees props |
+  | Boundary (a marked `defview` product) | one props map, every lazy sequence in it realized ([[realize-deep]]) | trailing forms as `(:children props)`, a realized vector | `:key` in the props map, extracted before the body sees props |
   | Fragment `[:<> …]` | optional attr map | trailing forms | on the fragment's props map |
 
   A React element is a legal child anywhere. No metadata keys, no second
@@ -297,6 +297,17 @@
                        (subvec argv first-child))]
       (when (seq flat) flat))))
 
+(declare realize-deep)
+
+;; The two reducing functions are top-level vars rather than literals
+;; written at the reduce sites, and that is the whole of the walk's
+;; allocation story: a `(fn …)` written inside [[realize-deep]] would
+;; mint a fresh function object on every collection visited, and `run!`
+;; mints one of its own. Named here, the walk allocates nothing at all.
+
+(defn- realize-entry [_ _ x] (realize-deep x) nil)
+(defn- realize-item  [_ x]   (realize-deep x) nil)
+
 (defn realize-deep
   "Force every lazy sequence reachable from `v`, and return **`v` itself,
   by identity**.
@@ -325,29 +336,46 @@
   read is forced by the same pass that turns hiccup into elements, inside
   the window of the body that wrote it.
 
-  ## Why it costs almost nothing
+  ## What it costs, measured
 
   Realising a `LazySeq` caches into the seq itself, so this **rebuilds
   nothing and copies nothing** — every branch returns the argument it was
-  given. The traversal is the whole of the work, and the seq it forces
-  was going to be walked anyway, one boundary later. The overwhelming
-  case is a small props map of scalars, where the cost is one `coll?` per
-  value.
+  given, and with the two reducing functions named above the walk
+  allocates nothing either. The traversal is the whole of the work, and
+  the seq it forces was going to be walked anyway, one boundary later.
+
+  Clocked rather than asserted (`:none` build, Node 22, best of five
+  runs; the figures are a dev build's and are quoted for their ratios):
+
+  | Boundary props | walk | whole element build | share |
+  |---|---|---|---|
+  | `{:id :title :done?}` — the dogfood row | 69 ns | 1089 ns | **6%** |
+  | the same plus two hiccup children | 233 ns | 1344 ns | 17% |
+  | a 100-row collection prop | 13.5 µs | 15.1 µs | 89% |
+
+  The last row is the honest ceiling and it is the right one to compare
+  outwards rather than inwards: **the same 100-row collection at a
+  NATIVE prop position costs 70.7 µs**, because `clj->js` rebuilds it
+  into JavaScript. The position whose eagerness the structural claim
+  already rested on is 4.7x dearer than the position this walk repairs.
 
   Maps are reduced with `reduce-kv` rather than over their entries, so
   the walk allocates no `MapEntry`; their keys are not descended into
   because hashing a seq realises it, so a lazy seq cannot already be a
-  key in a map.
+  key in a map. `coll?` is tested before `map?` so a scalar — the
+  overwhelming case — costs exactly one predicate.
 
   A seq of unbounded length at a boundary prop position now diverges here
   rather than in the child. That is the same thing `clj->js` already does
   to one at a native prop position, and it must be: a deferred read
   cannot be both unbounded and attributable."
   [v]
-  (cond
-    (map? v)  (do (reduce-kv (fn [_ _ x] (realize-deep x) nil) nil v) v)
-    (coll? v) (do (run! realize-deep v) v)
-    :else     v))
+  (if-not (coll? v)
+    v
+    (do (if (map? v)
+          (reduce-kv realize-entry nil v)
+          (reduce realize-item nil v))
+        v)))
 
 ;; ---------------------------------------------------------------------------
 ;; Emission — React elements (Arm 1's representation)

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -297,6 +297,58 @@
                        (subvec argv first-child))]
       (when (seq flat) flat))))
 
+(defn realize-deep
+  "Force every lazy sequence reachable from `v`, and return **`v` itself,
+  by identity**.
+
+  ## Why a boundary needs this and a native tag does not
+
+  The codec is eager everywhere it walks, and that is what makes a `(sub
+  …)` inside a `for` an edge of the body that wrote it rather than a
+  silently missing one: `expand-seq` drives a child seq to exhaustion,
+  [[realize-children]] folds one into a vector, and [[convert-prop-value]]
+  sends any collection at a NATIVE prop position through `clj->js`.
+
+  A boundary prop is the one position where none of that happens.
+  [[boundary-element]] hands `body-props` across as a raw ClojureScript
+  map and the shell reads it back as one — no conversion, and so no
+  realisation. A lazy seq written in one body therefore arrives in
+  another body unrealised, and is forced *there*, inside a render that
+  did not write it. The runtime cannot refuse it — its render frame
+  answers *is any body running*, and one is — so the read is attributed
+  to the wrong boundary; and because a `LazySeq` caches, that boundary
+  re-renders exactly once, reads nothing the second time, and drops the
+  edges. The value is then correct on screen and frozen for the life of
+  the mount. rf2-2rtt6.45.
+
+  One walk at the hand-off closes it, and pays where the escape is: the
+  read is forced by the same pass that turns hiccup into elements, inside
+  the window of the body that wrote it.
+
+  ## Why it costs almost nothing
+
+  Realising a `LazySeq` caches into the seq itself, so this **rebuilds
+  nothing and copies nothing** — every branch returns the argument it was
+  given. The traversal is the whole of the work, and the seq it forces
+  was going to be walked anyway, one boundary later. The overwhelming
+  case is a small props map of scalars, where the cost is one `coll?` per
+  value.
+
+  Maps are reduced with `reduce-kv` rather than over their entries, so
+  the walk allocates no `MapEntry`; their keys are not descended into
+  because hashing a seq realises it, so a lazy seq cannot already be a
+  key in a map.
+
+  A seq of unbounded length at a boundary prop position now diverges here
+  rather than in the child. That is the same thing `clj->js` already does
+  to one at a native prop position, and it must be: a deferred read
+  cannot be both unbounded and attributable."
+  [v]
+  (cond
+    (map? v)  (do (reduce-kv (fn [_ _ x] (realize-deep x) nil) nil v) v)
+    (coll? v) (do (run! realize-deep v) v)
+    :else     v))
+
 ;; ---------------------------------------------------------------------------
 ;; Emission — React elements (Arm 1's representation)
 ;; ---------------------------------------------------------------------------
@@ -342,8 +394,17 @@
   (let [has-props? (props-map? argv 1)
         props      (if has-props? (nth argv 1) {})
         children   (realize-children argv (if has-props? 2 1))
-        body-props (cond-> (dissoc props :key)
-                     children (assoc :children children))
+        ;; THE HAND-OFF, and the one position the eager codec did not
+        ;; reach. Everywhere else a lazy read is forced by the pass that
+        ;; turns hiccup into elements; here the map crosses untouched, so
+        ;; a seq written in THIS body would be realised inside the
+        ;; child's render and attributed to it — silently, and then
+        ;; frozen, because a realised `LazySeq` is never walked a second
+        ;; time. [[realize-deep]] returns the map by identity and covers
+        ;; `:children` in the same pass, which is where the one-level
+        ;; flatten leaves a nested seq. rf2-2rtt6.45.
+        body-props (realize-deep (cond-> (dissoc props :key)
+                                   children (assoc :children children)))
         js-props   #js {"rfProps" body-props}]
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
     (react/createElement (nth argv 0) js-props)))


### PR DESCRIPTION
## The defect

`read-key!`'s guard is `(nil? (.-frame rstate))`. That asks **"is ANY body
running"**, not **"is THIS body running"**, because `rstate` is a single
module-level object (`arm1/runtime.cljs`). So a read deferred past its author's
body and forced inside a **different** boundary's render does not throw — it
lands on that boundary's scratch, and the boundary that produced it holds no
edge for it.

The carrier is the boundary hand-off. `convert-prop-value` sends any collection
at a **native** prop position through `clj->js`, so the eager codec really does
force everything it walks there. `boundary-element` handed `body-props` across
as a raw ClojureScript map and the shell read it back as one: no conversion, no
walk, no realisation. `realize-children` compounded it by flattening exactly one
level, so a nested seq in a boundary's children survived unrealised too.

```clojure
(defview child  [{:keys [rows]}] [:ul.child (for [r rows] [:li.cell (str r)])])
(defview parent [_] [child {:rows (for [id (sub [:dogfood/visible-ids])]
                                    (:title (sub [:dogfood/todo id])))}])
```

**And it is not merely the wrong owner.** A `LazySeq` caches what it realised, so
the wrong reader re-renders exactly *once*; on that re-render its body walks an
already-realised seq, `sub` is never called, its read set collapses to empty,
React re-subscribes and every row edge is dropped. The right reader never
re-rendered, so the seq is never rebuilt. One correction, then a value **correct
on screen, frozen thereafter, attributable to nothing** — the class the judgement
page calls the worst failure this surface can have.

Reproduced independently before fixing. At the seam, on the unfixed runtime: the
parent's read set was `#{visible-ids}` alone, the three row keys were on the
child, the child's second render read nothing at all, and a write to a row
notified the **child** (hits 1) and not the parent (hits 0).

## The fix

`codec/realize-deep`, called once on `body-props` in `boundary-element`.

```clojure
(defn realize-deep [v]
  (if-not (coll? v)
    v
    (do (if (map? v)
          (reduce-kv realize-entry nil v)
          (reduce realize-item nil v))
        v)))
```

It forces every lazy sequence reachable from the props map — `:children`
included, since it is a key in the same map, which is what covers the
nested-children carrier — and returns the map **by identity**: realising a
`LazySeq` caches into the seq, so nothing is rebuilt or copied. The read is then
forced by the same pass that turns hiccup into elements, inside the window of the
body that *wrote* it, which is what the eager-codec argument claimed all along.

Chosen over the alternative — a per-boundary render token for `read-key!` to
refuse against — because that is per-boundary render identity, one line from the
candidate-ledger tripwire, and it would turn a legitimate authoring shape into an
error instead of making it work. This needs none of it: `rstate` is still one
object, nothing can tell one render attempt from another, the shell still holds
two hooks and no per-instance state, and `subscribe` still closes over the read
set and nothing else.

The reducing functions are hoisted to top-level vars. A `(fn …)` written at a
reduce site mints a function object per collection visited and `run!` mints one
of its own, so the walk now allocates nothing at all.

### Cost, measured rather than assumed

`:none` build, Node 22, best of five runs — dev-build figures, quoted for ratios:

| Boundary props | walk | whole element build | share |
|---|---|---|---|
| `{:id :title :done?}` — the dogfood row | 69 ns | 1089 ns | **6%** |
| the same plus two hiccup children | 233 ns | 1344 ns | 17% |
| a 100-row collection prop | 13.5 µs | 15.1 µs | 89% |

The last row is the ceiling, and it compares outwards: the **same** 100-row
collection at a *native* prop position costs **70.7 µs**, because `clj->js`
rebuilds it into JavaScript. The position the structural claim already rested on
is 4.7x dearer than the one this repairs.

## The dismissal, rewritten in place

`docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md` named this
escape and called it *"not a missing edge — the reader does re-render — but the
wrong reader"*. That paragraph is replaced by a section that states the freeze,
retracts the structural claim it rested on ("a seq at a prop position goes
through `clj->js`" — true for a native tag, false for a boundary), records the
rejected alternative as rejected, and names what genuinely remains: a `delay`
handed across a crossing is the same fault in a shape no walk may repair, and a
**function** prop is not in this class at all, because the child re-runs it every
render so the read repeats and the edge is kept. The same correction lands in the
two docstrings that repeated the claim (`arm1/runtime.cljs`,
`arm1/runtime_cljs_test.cljs`).

`mkdocs build --strict` does **not** cover `docs/design/hicasso/**` — the tree is
named in `exclude_docs` in `mkdocs.yml`, and the fast-pr spine soft-skipped it
locally anyway (mkdocs is not on PATH on this machine). So the page was verified
two other ways. By hand: heading levels sit correctly under §2, and both tables
have matching column counts. And by machine: `scripts/check_doc_slugs.py` — the
"docs corpus anchor validator" step of the fast-pr spine — *does* scan this file
(one of 30 hicasso markdown files in its corpus of 646) and validates the one new
in-page anchor. It exits 0.

## Quality gates

Witnesses, mutation-proved by removing the single `realize-deep` call and
restoring it. The first-paint assertions pass on the broken runtime, which is
exactly why the second half is asserted:

| Witness | before (fix removed) | after |
|---|---|---|
| `boundary-crossing-cljs-test` (node, 8 rows) | **exit 1** — 7 failures | **exit 0** — 8 tests, 24 assertions |
| `boundary-crossing-dom-cljs-test` (real Chromium, 2 rows) | **exit 1** — 4 failures; the cell frozen at `"todo 2"` through two writes, edges collapsing 7 → 1 on the first | **exit 0** — 2 tests, 10 assertions |

Full gates, foreground, worktree-local logs, exit codes echoed:

| Gate | exit | result |
|---|---|---|
| `npm run test:cljs` | **0** | Ran 12216 tests containing 60780 assertions. 0 failures, 0 errors. |
| `npm run test:browser` | **0** | Ran 942 tests containing 5831 assertions. 0 failures, 0 errors. |
| `scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` — 30 steps; not-run list is the standing three (mkdocs not on PATH, untouched JVM artefacts, the CI-only browser/bundle/tool lanes) |
| clj-kondo **2026.04.15** (CI's pinned version, CI's exact `--lint` set, `--fail-level error`) | **0** | **errors: 0**; 4526 warnings, all pre-existing — the single info-level finding on a changed file is present on `origin/main` too |

Both suites above were re-run **after** rebasing onto `origin/main` at
`6a90ce92e4`, because main had moved under `implementation/core/src/re_frame/subs/cache.cljc`
and `substrate/spine.cljs` while this branch was in flight — the substrate this
arm's reads go through. `test-fast-pr.sh` and clj-kondo were taken at the
pre-rebase base (`c927f1d755`); their unique coverage — drift gates, JVM
core/freehand, per-ns isolation, lint — is not reachable from a bench-tree codec
change, and the rebase was a clean fast-forward with no overlapping files.

TESTING.md matrix derived: **CLJS node unit** (`test:cljs`, the `:node-test`
build's `cljs-test$`) carries `boundary-crossing-cljs-test`, and the `-dom-` file
under its `(browser?)` skip; **Browser unit** (`test:browser`, DOM-dependent
`*_dom_cljs_test` only) carries `boundary-crossing-dom-cljs-test`. The
changed-surface classifiers that fire are `cljs_node_test` and `cljs_browser`;
`freehand_evidence_elision` / `freehand_reachability` explicitly exclude the rest
of `implementation/freehand/**` and this change touches no probe surface. No new
`spec.cjs` anywhere, and no bar row is published.

Closes rf2-2rtt6.45.
