### PR TITLE
hicasso: a refused character is restored (rf2-n3dxw)

### DIFF
--- a/docs/design/hicasso/architecture.md
+++ b/docs/design/hicasso/architecture.md
@@ -49,7 +49,10 @@ applies the patch** (React elements vs own DOM).
 
 - A boundary is a **real React function component** minted by `defview`
   (invocation semantics: HD-016). React owns identity, reconciliation, context,
-  refs, errors, concurrency, and the controlled-input end-of-event restore.
+  refs, errors, concurrency, and the controlled-input end-of-event restore —
+  the last of these **only while the element is genuinely controlled**, which
+  UIx does not guarantee
+  ([the two implementations](studio/controlled-input-two-implementations.md)).
 - **Hook budget ≤ 2 per boundary** (paper rule), fully consumed by the
   subscription/epoch hook and the frame-context hook (HD-020); refs are callback
   refs, never `useRef` in the shell. A ViewCell-class per-boundary object graph
@@ -148,6 +151,17 @@ notification runs synchronously so React commits the echo in the same turn;
 `flushSync` is the evidence-gated last resort. Rejected/unchanged-model paths
 lean on React's own end-of-event restore; resets are by explicit caller
 revision, never value equality. The 100-cell grid witnesses prove the door.
+
+**Measured 2026-08-01 (rf2-n3dxw), and the lean holds for the value only.**
+React's restore does fire on a rejection, inside the discrete event and with
+nothing re-rendered, so the refused character comes off the screen for free.
+It does not put the caret back: assigning `value` moves the cursor to the end
+of the control, and React restores a selection only around a commit in which
+focus moved. So a mid-string refusal — and every keystroke a normalising model
+rewrites — converges with the caret thrown to the end of the field. The
+matrix, the two implementations UIx chooses between, and a measured option
+that carries both halves in one turn are on
+[the studio page](studio/controlled-input-two-implementations.md).
 
 ## Memoization (HD-006)
 

--- a/docs/design/hicasso/studio/README.md
+++ b/docs/design/hicasso/studio/README.md
@@ -99,6 +99,7 @@ requires nothing from any donor `src/` tree.
 | [The cold-mount double build, priced against the mount red-zone](coldmount-double-build-priced.md) | P0 | What the double build **costs on the clock**, as a fraction of the same-run UIx-minus-Reagent mount excess — the rf2-2rtt6.14 decision input. |
 | [The reagent-slim non-reactive arm — diagnosis](slim-non-reactive-arm-diagnosis.md) | P0 | Why HD-008's reagent-slim arm read `78 unverified of 78`: the **arm's composition**, not the adapter and not the mixed bundle. A single-substrate slim bundle re-renders on every write. |
 | [Arm 1 — lean-React: the mechanism and the dogfood judgement](arm1-lean-react-dogfood-judgement.md) | P1 | How the ≤2-hook shell was reached, the collector against HD-002's four clauses, and the three-rendering ergonomics verdict. **Publishes no bar row** — mechanism, correctness witnesses and preference only. |
+| [A controlled input has two implementations, and the bundle was picking](controlled-input-two-implementations.md) | P1 | Why a refused keystroke appeared to survive on React (rf2-n3dxw): UIx selects between plain React and a port of Reagent's workaround **on what else is on the classpath**. The full value/caret matrix for both, and the priced option that carries every row in one turn. **Publishes no bar row** — correctness only. |
 
 **Clock red-zones live on the converged page.** Where it and the frontier arm
 disagree, the converged row is the operative one: the bar's denominator is

--- a/docs/design/hicasso/studio/controlled-input-two-implementations.md
+++ b/docs/design/hicasso/studio/controlled-input-two-implementations.md
@@ -1,0 +1,199 @@
+# A controlled input has two implementations, and the bundle was picking
+
+**Bead** `rf2-n3dxw` · **epic** `rf2-2rtt6` (EP-0038)
+**Authored commit `14d672b710`** · **witness content hash**
+`13a3569497352cd7d458cc345be339cd3cc66a3b`
+(`implementation/freehand/test/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs`)
+**Measured** 2026-08-01 AUSEST
+
+**Runtime for every row on this page**: headless Chromium via Playwright
+1.59.1, shadow-cljs `:browser-test` (development optimisations, `goog.DEBUG`
+true), react/react-dom **19.2.0**, uix.core **1.4.4**. These are correctness
+rows, not bar rows — no figure here is quotable against the performance bar.
+
+Reproduce:
+
+```bash
+cd implementation
+npx shadow-cljs compile browser-test \
+  --config-merge '{:ns-regexp "controlled-restore-dom-cljs-test$"}'
+node scripts/serve-and-run-browser-tests.cjs
+```
+
+## The headline
+
+`rf2-n3dxw` recorded a P1 against the React path: a keystroke the model
+refuses stays on the screen, so the field and the model disagree
+permanently. **React does not lose the refused character.** It takes it off
+inside the discrete event, with nothing re-rendered. What the bead measured
+was a second implementation that the test bundle had silently selected.
+
+## The selector
+
+UIx decides, per element and at element-creation time, between plain React
+and a port of Reagent's controlled-input workaround.
+`uix.compiler.aot/create-uix-input` branches on
+`uix.compiler.input/should-use-reagent-input?`, and that predicate — with
+`*use-reagent-input-enabled?*` unset, which is the shipped default — answers
+
+> is `reagent.impl.util/*non-reactive*` present, and false?
+
+So the answer is a fact about **what else is on the classpath**, not a
+decision the application makes. Every `:browser-test` bundle in this repo
+carries Reagent, because the Reagent adapter is first-class and ships with
+tests. A UIx-only consumer app gets the other implementation.
+
+The probe that found it read the props React had committed to the DOM node.
+Where the view had written `:value`, the node carried `defaultValue "12"` and
+a `ref` whose source was `function (el){ return (this$.inputEl = el); }` —
+`uix/compiler/input.cljs:110-127`.
+
+## What each implementation does
+
+### `:react` — the element stays controlled
+
+React's own end-of-discrete-event state restore fires, and it fires even when
+nothing re-rendered. In `react-dom@19.2.0`,
+`cjs/react-dom-client.development.js`:
+
+| line | what happens |
+|---|---|
+| `3512-3523` | `createAndAccumulateChangeEvent` records the event target for restoration |
+| `3251-3272` | the `finally` of `batchedUpdates$1` flushes sync work, then calls `restoreStateOfTarget` |
+| `3178-3196` | `restoreStateOfTarget` hands the props React last committed to `updateInput` |
+| `1661-1667` | `updateInput` assigns `element.value` whenever it differs from the prop |
+
+All of that runs before `dispatchEvent` returns. The witness asserts zero
+boundary body runs on the same keystroke, so the write cannot have come from
+a render.
+
+What React does **not** do is put the caret back. Assigning `value` moves the
+text entry cursor to the end of the control (HTML standard, the `value` IDL
+attribute setter), and React restores a selection only around a commit in
+which focus *moved*. Every write React makes therefore throws the caret to
+the end of the field.
+
+### `:uix-reagent-input` — the element is made uncontrolled
+
+`value` is deleted from the props, `defaultValue` is set and a `ref` is
+installed (`uix/compiler/input.cljs:124-127`). React's restore now has
+nothing to restore — `updateInput` skips the write entirely when the `value`
+prop is absent. UIx drives the value itself, and schedules that work on
+`reagent.impl.batching/do-after-render`, a queue drained from
+`requestAnimationFrame` (`reagent/impl/batching.cljs:16-25`, `:57-59`).
+Value and caret both come back correct, by offset from the end of the
+string — Arm 2's algorithm, and Reagent's before it — but **one animation
+frame later, never inside the discrete event.**
+
+## The matrix
+
+Field value and caret, read on the line after `dispatchEvent` returns
+("in-turn") and again after one animation frame ("settled"). The model is
+Arm 2's 100-cell grid, unchanged: cell 11 refuses non-digits, cell 13
+uppercases, cell 17 regroups, cell 7 takes what it is given.
+
+| row | `:react` in-turn | `:react` settled | `:uix-reagent-input` in-turn | `:uix-reagent-input` settled |
+|---|---|---|---|---|
+| refusal at the end — `"12"` + `a` at `[2 2]` | `"12"` `[2 2]` ✅ | unchanged | `"12a"` `[3 3]` ❌ | `"12"` `[2 2]` ✅ |
+| refusal mid-string — `"12345"` + `z` at `[2 2]` | `"12345"` **`[5 5]`** ⚠️ | unchanged | `"12z345"` `[3 3]` ❌ | `"12345"` `[2 2]` ✅ |
+| uppercasing mid-string — `"ABCD"` + `x` at `[2 2]` | `"ABXCD"` **`[5 5]`** ⚠️ | unchanged | `"ABXCD"` `[3 3]` ✅ | `[3 3]` ✅ |
+| regrouping at the end — `"1,234"` + `5` at `[5 5]` | `"12,345"` `[6 6]` ✅ | unchanged | `[6 6]` ✅ | `[6 6]` ✅ |
+| accepted keystroke mid-string — `"abcd"` + `X` at `[2 2]` | `"abXcd"` `[3 3]` ✅ | unchanged | `[3 3]` ✅ | `[3 3]` ✅ |
+| a range `[1 4]` across a converge that WRITES | `"Xabcdef"` `[7 7]` | unchanged | `[2 2]` | unchanged |
+
+Read the table as one sentence: **React converges in the same turn and puts
+the caret in the wrong place; UIx's port puts the caret in the right place
+one frame late.** Neither gives both.
+
+The regrouping row is green on React only because the edit was at the *end*
+of the field, which is where React's write leaves the caret anyway. It is not
+evidence that React preserves a caret across a length change.
+
+### The range row
+
+Arm 2 restored both ends of a selection by distance from the end of the
+string and required `[2 5]`. Neither shipped implementation does, and neither
+is close: React resets the cursor to the end of the value it wrote, and the
+port writes one offset into both `selectionStart` and `selectionEnd`
+(`uix/compiler/input.cljs:68-69`), so a range collapses **by construction**.
+`[2 2]`, the value the bead recorded, is the port's — correct as a cursor,
+never a range. This is not a defect to be fixed in passing; restoring a range
+means restoring two offsets, which is a different algorithm from the one both
+implementations run.
+
+### IME composition
+
+Still not established, and still not asserted. Synthetic `Event`s named
+`compositionstart`/`compositionend` do not exercise React's composition path,
+and there are now **two** implementations to establish a fence against rather
+than one — React's `SyntheticCompositionEvent` plumbing on the controlled
+path, and the port's write-owning path, which never consults composition
+state at all. A fence asserted without being demonstrated is worse than no
+fence. It needs a real `CompositionEvent` harness against both.
+
+## The options, and what they cost
+
+### A — do nothing
+
+The refused character already comes off the screen in the same turn on the
+React path, for free. **Gap**: the caret is thrown to the end of the field on
+every mid-string refusal, and on every keystroke a normalising model rewrites.
+That is React's own long-standing controlled-input caret jump, not something
+re-frame2 introduced.
+
+### B — converge at the end of the change handler
+
+Measured, green, and committed as
+`a-same-turn-converge-can-have-both-halves-at-a-stated-price`. At the end of
+the change handler, still inside the discrete event and still ahead of
+React's own restore:
+
+1. `flushSync` so the synchronous door's commit lands now rather than in the
+   `finally` of `batchedUpdates$1`;
+2. if the field still disagrees with what the element renders, write the
+   rendered value — which also makes React's later `updateInput` a no-op,
+   because it only assigns when the two differ;
+3. put the caret back by offset from the end of the string.
+
+Every row of the family, in one turn, including the mid-string refusal that
+neither shipped path gets right.
+
+**Price, stated rather than hidden.** One `flushSync` per keystroke on a
+controlled element. A per-instance record of the value that element last
+rendered — the handler's own closure carries the value from the render that
+*minted* it, which is stale after a re-render, and `(= (.-value node)
+dom-value)` alone cannot tell a refusal from a keystroke the model took
+verbatim. The synchronous door only: `dispatch` drains on a macrotask, so at
+the end of the handler the model has not moved and there is nothing to
+converge to.
+
+**What it does not cost.** No user-visible ceremony — the view still writes
+an ordinary `:value`/`:on-change` pair, with no ref, no effect and no escape
+hatch. No hook in the boundary shell, so the ≤2-hook budget (HD-020) is
+untouched. UIx's own answer to the same problem costs a wrapper *component*
+per input with three hooks in it (`uix/compiler/input.cljs:132-143`); this
+one costs none, because it lives in the element path rather than in a
+component.
+
+Where it would live is the open question: neither Hicasso nor the shipped
+UIx adapter mints its own `:input` element today — UIx does — so the
+prototype sits in the witness's view, labelled as a measurement rather than
+an authoring pattern.
+
+### C — pin the selector
+
+Independent of A and B, and cheap: decide which implementation a re-frame2
+UIx app gets, instead of inheriting whatever the bundle implies. One `set!`
+of `uix.compiler.input/*use-reagent-input-enabled?*` at adapter load. The
+cost is not implementation, it is the ruling — the two implementations have
+materially different behaviour, and today a consumer's choice of a *second*
+adapter silently changes the first one's inputs.
+
+## What this changes in the record
+
+- `architecture.md`'s "React owns ... the controlled-input end-of-event
+  restore" is **confirmed**, with the qualification that it holds only while
+  the element is actually controlled, which UIx does not guarantee.
+- HD-019's "rejected/unchanged-model paths lean on React's own end-of-event
+  restore" is **confirmed for the value and refuted for the caret**.
+- `rf2-n3dxw` stays open on the residue: no shipped path gives both halves.

--- a/docs/design/hicasso/studio/controlled-input-two-implementations.md
+++ b/docs/design/hicasso/studio/controlled-input-two-implementations.md
@@ -1,9 +1,12 @@
 # A controlled input has two implementations, and the bundle was picking
 
 **Bead** `rf2-n3dxw` · **epic** `rf2-2rtt6` (EP-0038)
-**Authored commit `14d672b710`** · **witness content hash**
-`13a3569497352cd7d458cc345be339cd3cc66a3b`
-(`implementation/freehand/test/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs`)
+**Witness content hash** `966e6d8390ecc9945193417bb221b6c574c9681f`
+(`implementation/freehand/test/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs`;
+authored on `worker/reject-n3dxw`). A SHA does not survive a rebase and this
+branch was rebased once already — the content hash is the identifier, and
+`git log --oneline --all -- <path>` plus `git rev-parse <candidate>:<path>`
+finds a commit carrying the blob.
 **Measured** 2026-08-01 AUSEST
 
 **Runtime for every row on this page**: headless Chromium via Playwright

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -305,7 +305,13 @@ identical witnesses; challengers time-boxed to 1–3 days:
   Hicasso is a React adapter — on direction, not on measurement, the arm having
   met that gate. Its tree is retired (`rf2-m6if4`); the controlled grid it was
   gated on now lives at
-  `bench/hicasso/controlled_restore_dom_cljs_test.cljs`, re-taken on React.
+  `bench/hicasso/controlled_restore_dom_cljs_test.cljs`, re-taken on React —
+  and re-taken **twice**, because UIx selects between plain React and a port
+  of Reagent's controlled-input workaround on what else is on the classpath.
+  The grid pins the implementation it measures rather than inheriting one; the
+  matrix is on
+  [the studio page](studio/controlled-input-two-implementations.md)
+  (`rf2-n3dxw`).
 - A root-pull arm may run as a non-product assumption-challenge that leaves no
   API behind.
 - **The dogfood screen**: one list + one controlled field + sub reads, written
@@ -319,7 +325,8 @@ identical witnesses; challengers time-boxed to 1–3 days:
 **Witness set**: the 300-boundary shapes; 1/3/7/20 reads-per-boundary as two
 separated scaling curves (fixed reads × growing boundaries; fixed boundaries ×
 growing reads); the 100-cell controlled grid (same-turn echo, mid-string caret,
-selection, IME composition, unchanged-model rejection, async normalisation);
+selection, unchanged-model rejection, async normalisation — IME composition is
+named here but **not asserted**, and `rf2-n3dxw` says why);
 keyed insert/delete/reorder; changing query identity through an abandoned render;
 a foreign hook/context/ref component and a real error boundary (the runtime's
 `h/boundary` class component, HD-020); StrictMode, abandoned first mount, root

--- a/implementation/freehand/test/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs
@@ -106,11 +106,14 @@
   as a no-op change and nothing under test ever runs.
 
   Every synchronous assertion below runs on the line after
-  `dispatchEvent` returns. There is no `act()` anywhere in this file;
-  `flushSync` appears only in the mount/teardown door and in
-  [[settle!]], which lets an already-scheduled sync-lane
-  `useSyncExternalStore` notification land after an OUT-OF-BAND
-  dispatch — never inside the discrete-event path an assertion reads.
+  `dispatchEvent` returns. There is no `act()` anywhere in this file.
+  `flushSync` appears in the mount/teardown door and in [[settle!]],
+  which lets an already-scheduled sync-lane `useSyncExternalStore`
+  notification land after an OUT-OF-BAND dispatch — never inside the
+  discrete-event path an assertion reads. The one exception is
+  [[converge!]], where a `flushSync` inside the discrete event is not
+  scaffolding but the mechanism being measured, and it is used by that
+  row alone.
 
   ## What is still not asserted, and why
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs
@@ -1,19 +1,13 @@
 (ns re-frame.bench.hicasso.controlled-restore-dom-cljs-test
-  "WHAT CORRECT MEANS FOR A CONTROLLED INPUT, on React (rf2-m6if4).
+  "WHAT CORRECT MEANS FOR A CONTROLLED INPUT, on React (rf2-m6if4,
+  rf2-n3dxw).
 
   Arm 2 (the PATCH renderer) is retired — Mike ruled on 2026-07-31 that
   Hicasso is an adapter for React — and this file is what its hard gate
   left behind. Arm 2's `:controlled/grid-100` witness was the clearest
   statement in the repo of what a store-backed controlled input has to
   do, and the statement is worth keeping even though the renderer that
-  provoked it is not. The assertions below are **moved** here, not
-  copied: the arm2 tree goes in the same change.
-
-  ## Why the grid moved instead of being deleted
-
-  Arm 2 owned the end-of-event restore because it had no React. The
-  reflex is to say React makes the whole family free. **It does not**,
-  and this file is the measurement rather than the reflex.
+  provoked it is not.
 
   The model is Arm 2's, unchanged, because the model was never the
   renderer's business: 100 cells, one event, one subscription, and a
@@ -26,7 +20,72 @@
   | `:upper`  | normalises it to upper case |
   | `:group`  | normalises `12345` to `12,345` — the length changes |
 
-  ## The door is the variable, not the renderer
+  ## There are TWO input implementations, and the BUNDLE used to pick
+
+  UIx chooses, per element and at element-creation time, between plain
+  React and a port of Reagent's controlled-input workaround —
+  `uix.compiler.aot/create-uix-input` branches on
+  `uix.compiler.input/should-use-reagent-input?` (uix.core 1.4.4). That
+  selector is not a decision the application makes. Left unset, it
+  answers *\"is Reagent loaded, and not in `*non-reactive*` mode?\"*
+  (`uix/compiler/input.cljs:15-21`). So a UIx-only app and a UIx app that
+  also carries Reagent get **different input implementations, with
+  different timing and a different caret** — and every bundle in this
+  repo's `:browser-test` carries Reagent, because the Reagent adapter is
+  first-class and ships with tests.
+
+  Every row below therefore **pins** the implementation it measures
+  rather than inheriting whichever one the bundle happened to select.
+  Both are witnessed, because the difference between them IS the finding.
+
+  ### `:react` — the element stays controlled
+
+  React's own end-of-discrete-event state restore fires, and it fires
+  even when nothing re-rendered. Reading react-dom 19.2.0's
+  `cjs/react-dom-client.development.js`:
+  `createAndAccumulateChangeEvent` records the event target for
+  restoration (`:3512-3523`); the `finally` of `batchedUpdates$1`
+  (`:3251-3272`) flushes sync work and then calls `restoreStateOfTarget`
+  (`:3178`), which hands the props React last committed to `updateInput`
+  (`:1644`); `updateInput` assigns `element.value` whenever it differs
+  from the prop (`:1661-1667`). **So a refused character comes off the
+  screen inside the discrete event, with nothing re-rendered** — measured
+  below beside a body-run count of zero.
+
+  What React does not do is put the caret back. Assigning `value` moves
+  the text entry cursor to the end of the control (HTML standard, the
+  `value` IDL attribute setter), and React restores a selection only
+  around a commit in which focus MOVED. So every write React makes —
+  a rejection, an uppercasing, a regrouping — lands the caret at the end
+  of the string.
+
+  ### `:uix-reagent-input` — the element is made uncontrolled
+
+  `value` is deleted from the props, `defaultValue` is set and a `ref` is
+  installed (`uix/compiler/input.cljs:124-127`), so React's restore has
+  nothing to restore: `updateInput` skips the write entirely when the
+  `value` prop is absent. UIx drives the value itself, and it schedules
+  that work on `reagent.impl.batching/do-after-render`, a queue drained
+  from `requestAnimationFrame` (`reagent/impl/batching.cljs:16-25`,
+  `:57-59`). Value and caret both come back correct — by offset from the
+  END of the string, which is the algorithm Arm 2 used — but **one
+  animation frame later, never inside the discrete event.**
+
+  ## What rf2-n3dxw actually is
+
+  The bead recorded `:unchanged-model-rejection` as a React defect: the
+  refused character stayed on the screen. **It is not React's.** The row
+  was measured in the full `:browser-test` bundle, which carries Reagent,
+  so what it measured was `:uix-reagent-input`'s one-frame lag. On React
+  the character is gone before `dispatchEvent` returns, and that is now
+  asserted.
+
+  The bead stays open for the half that is real: **neither implementation
+  gives both same-turn convergence and a caret at the position before the
+  refused character.** React converges in-turn and puts the caret at the
+  end; UIx's port puts the caret in the right place a frame late.
+
+  ## The door is a variable too
 
   `re-frame.core/dispatch` is asynchronous by design: the router's drain
   rides `interop/next-tick`, a **macrotask** (Spec 002 §Drain
@@ -34,9 +93,7 @@
   cannot echo inside the discrete event — the model is still the old one
   when the event returns. The synchronous door (`dispatch-sync`, which
   `use-frame` publishes beside `dispatch`) is what buys the same-turn
-  echo. Both are witnessed here, and the contrast is the finding: **on
-  React the controlled-input question is a question about the dispatch
-  door, not about the differ.**
+  echo. Both are witnessed here.
 
   ## Typing is simulated the way the browser does it
 
@@ -55,21 +112,15 @@
   `useSyncExternalStore` notification land after an OUT-OF-BAND
   dispatch — never inside the discrete-event path an assertion reads.
 
-  ## What was dropped, and why
-
-  Three of Arm 2's rows are not here.
+  ## What is still not asserted, and why
 
   - `:ime-composition-commits-nothing` — **not established, not
     asserted.** Arm 2 owned a composition fence because it owned the
-    writes. Whether React's own path leaves a composing field alone and
-    then converges at `compositionend` could not be settled with
-    synthetic `Event`s of those two names, and a fence that is asserted
-    without being demonstrated is worse than no assertion. Open on
-    rf2-n3dxw.
-  - `:selection-preserved` across a converge **that writes** — measured
-    `[2 2]` where Arm 2 required `[2 5]`; a range does not survive as a
-    range. Also on rf2-n3dxw. The half that does hold — an unchanged
-    model leaves another field's selection alone — is asserted below.
+    writes. Synthetic `Event`s named `compositionstart`/`compositionend`
+    do not exercise React's composition path, and there are now two
+    implementations to establish it against rather than one. A fence
+    asserted without being demonstrated is worse than no assertion.
+    Still open on rf2-n3dxw.
   - `teardown-leaves-no-boundary-and-no-edge` — dropped as a duplicate.
     Arm 1's dogfood suite already asserts zero residue after unmount
     (`:cells :cell-refs :boundaries :edges :entries` all 0), and one
@@ -80,6 +131,12 @@
             [re-frame.core :as rf]
             [re-frame.test-support :as test-support]
             [uix.core :refer [$ defui]]
+            [uix.compiler.input]
+            ;; Required so `:uix-reagent-input` can be SELECTED rather
+            ;; than merely inherited: UIx's port reaches Reagent's
+            ;; after-render queue through the `reagent.impl.batching`
+            ;; global, which only exists once that namespace is loaded.
+            [reagent.impl.batching]
             ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]))
 
@@ -144,21 +201,86 @@
   here rather than asserted about."
   (atom 0))
 
-(defui cell-view [{:keys [i door]}]
+(def ^:private !rendered
+  "Cell index → the value that cell's LAST render put on the element. It
+  stands in for the per-instance storage the [[converge!]] prototype
+  below would need, and naming it is half of that option's price."
+  (atom {}))
+
+(defn- converge!
+  "THE PROPOSED THIRD BEHAVIOUR, PROTOTYPED FOR MEASUREMENT ONLY.
+
+  Not an authoring pattern and not a proposed API: in a real adapter this
+  is the element path's business, wrapping `:on-change` where the user
+  never sees it. It sits in the view here only because neither Hicasso
+  nor the UIx adapter mints its own `:input` element today — UIx does.
+
+  Run at the end of the change handler, i.e. still inside the discrete
+  event and still ahead of React's own end-of-event restore:
+
+  1. `flushSync` so the synchronous door's commit lands NOW rather than
+     in the `finally` of React's `batchedUpdates$1`;
+  2. if the field still disagrees with what the element renders, write
+     the rendered value — which also makes React's later `updateInput`
+     a no-op, because it only assigns when the two differ;
+  3. put the caret back by offset from the END of the string.
+
+  Step 2 needs to know what the element renders NOW, which is why
+  [[!rendered]] exists: the handler's own closure carries the value from
+  the render that MINTED it, and after a re-render that value is stale —
+  the trap that makes `(= (.-value node) dom-value)` alone insufficient,
+  because it cannot tell a refusal from a keystroke the model took
+  verbatim."
+  [i e]
+  (let [node      (.-target e)
+        dom-value (.-value node)
+        caret-was (.-selectionStart node)]
+    (react-dom/flushSync (fn [] nil))
+    (let [rendered (get @!rendered i "")]
+      (when-not (= (.-value node) rendered)
+        (set! (.-value node) rendered))
+      (let [offset (- (count dom-value) caret-was)
+            c      (max 0 (- (count (.-value node)) offset))]
+        (.setSelectionRange node c c)))))
+
+(defui cell-view [{:keys [i door converge?]}]
   (swap! !body-runs inc)
   (let [v                                (uixa/use-subscribe [:cgrid/cell i])
         {:keys [dispatch dispatch-sync]} (uixa/use-frame)
         send                             (if (= :queued door) dispatch dispatch-sync)]
+    (swap! !rendered assoc i v)
     ($ :div.cell
        ($ :input.inp {:id        (str "c" i)
                       :type      "text"
                       :value     v
-                      :on-change (fn [e] (send [:cgrid/edit i (.. e -target -value)]))}))))
+                      :on-change (fn [e]
+                                   (send [:cgrid/edit i (.. e -target -value)])
+                                   (when converge? (converge! i e)))}))))
 
-(defui grid-view [{:keys [n door]}]
+(defui grid-view [{:keys [n door converge?]}]
   ($ :div.grid {:role "group"}
      (for [i (range n)]
-       ($ cell-view {:key i :i i :door door}))))
+       ($ cell-view {:key i :i i :door door :converge? converge?}))))
+
+;; ---------------------------------------------------------------------------
+;; Pinning the input implementation
+;; ---------------------------------------------------------------------------
+
+(def input-implementations
+  "The two things `uix.compiler.aot/create-uix-input` can build, and the
+  value of `uix.compiler.input/*use-reagent-input-enabled?*` that selects
+  each. `nil` — the shipped default — is not a third option; it is
+  *whichever of these two the bundle's contents imply*, which is what
+  this file exists to stop measuring by accident."
+  {:react             false
+   :uix-reagent-input true})
+
+(defn- pin-input-implementation! [impl]
+  (set! uix.compiler.input/*use-reagent-input-enabled?*
+        (get input-implementations impl)))
+
+(defn- unpin-input-implementation! []
+  (set! uix.compiler.input/*use-reagent-input-enabled?* nil))
 
 ;; ---------------------------------------------------------------------------
 ;; The harness
@@ -179,36 +301,47 @@
   (react-dom/flushSync (fn [] nil))
   nil)
 
+(defn- after-a-frame
+  "Give Reagent's after-render queue the animation frame it is scheduled
+  on, then a macrotask for anything that frame scheduled in turn."
+  [f]
+  (js/requestAnimationFrame (fn [] (js/setTimeout f 0))))
+
 (defn- container! []
   (let [c (js/document.createElement "div")]
     (.appendChild js/document.body c)
     c))
 
 (defn- mount!
-  ([container n] (mount! container n :sync))
-  ([container n door]
+  ([container n] (mount! container n {}))
+  ([container n {:keys [door converge?]}]
    (rf/make-frame {:id frame-id :initial-events [[:cgrid/seed n]]})
+   (reset! !rendered {})
    (let [root (react-dom-client/createRoot container)]
      (react-dom/flushSync
       (fn [] (.render root ($ uixa/frame-provider {:frame frame-id}
-                              ($ grid-view {:n n :door door})))))
+                              ($ grid-view {:n n :door door :converge? converge?})))))
      root)))
 
 (defn- release! [root c]
   (react-dom/flushSync (fn [] (.unmount root)))
   (.remove c)
+  (unpin-input-implementation!)
   nil)
 
 (defn- with-grid
-  "Mount the grid, run `f` with the container, and tear it down whatever
-  happens. Synchronous tests only — an async body returns before its
-  timer fires, and a grid torn down under a pending callback dispatches
-  into a frame that is gone."
-  [f]
-  (let [c    (container!)
-        root (mount! c cells)]
-    (try (f c)
-         (finally (release! root c)))))
+  "Mount the grid with `impl` PINNED, run `f` with the container, and tear
+  it down whatever happens. Synchronous tests only — an async body
+  returns before its timer fires, and a grid torn down under a pending
+  callback dispatches into a frame that is gone."
+  {:arglists '([impl f] [impl opts f])}
+  ([impl f] (with-grid impl {} f))
+  ([impl opts f]
+   (pin-input-implementation! impl)
+   (let [c    (container!)
+         root (mount! c cells opts)]
+     (try (f c)
+          (finally (release! root c))))))
 
 (defn- cell-input [container i] (.querySelector container (str "#c" i)))
 
@@ -256,6 +389,27 @@
                      {:adapter uixa/adapter :ambient-frame nil :async? true}))
 
 ;; ---------------------------------------------------------------------------
+;; The selector itself — the reason every row below names an implementation
+;; ---------------------------------------------------------------------------
+
+(deftest the-input-implementation-is-chosen-by-the-bundle-not-the-app
+  (testing "UIx's default answer is a fact about the classpath, and this
+           bundle carries Reagent, so the shipped default here is the port
+           rather than plain React"
+    (is (some? reagent.impl.batching/do-after-render)
+        "Reagent's after-render queue is in this bundle — which is exactly
+         what makes UIx's default answer `true`")
+    (unpin-input-implementation!)
+    (is (true? (uix.compiler.input/should-use-reagent-input?))
+        "with nothing pinned, a UIx `:input` in THIS bundle is not a plain
+         React controlled input at all")
+    (pin-input-implementation! :react)
+    (is (false? (uix.compiler.input/should-use-reagent-input?)))
+    (pin-input-implementation! :uix-reagent-input)
+    (is (true? (uix.compiler.input/should-use-reagent-input?)))
+    (unpin-input-implementation!)))
+
+;; ---------------------------------------------------------------------------
 ;; :same-turn-echo — and the per-keystroke budget
 ;; ---------------------------------------------------------------------------
 
@@ -264,7 +418,7 @@
            discrete event — no act, no flushSync, no yield"
     (if-not (browser?)
       (is true off-browser)
-      (with-grid
+      (with-grid :react
         (fn [c]
           (let [n (cell-input c 7)]
             (.focus n)
@@ -278,7 +432,7 @@
   (testing "the per-keystroke budget: a keystroke in cell 7 re-runs cell 7"
     (if-not (browser?)
       (is true off-browser)
-      (with-grid
+      (with-grid :react
         (fn [c]
           (let [n (cell-input c 7)]
             (.focus n)
@@ -294,7 +448,7 @@
 (deftest editing-mid-string-leaves-the-caret-where-the-typing-put-it
   (if-not (browser?)
     (is true off-browser)
-    (with-grid
+    (with-grid :react
       (fn [c]
         (let [n (cell-input c 7)]
           (set-model! 7 "abcd")
@@ -308,31 +462,55 @@
                field, so React wrote nothing"))))))
 
 ;; ---------------------------------------------------------------------------
-;; Normalisation — the length-preserving and the length-changing case
+;; Normalisation — where the two implementations part company
 ;; ---------------------------------------------------------------------------
 
-(deftest an-uppercasing-model-keeps-the-caret-mid-string
-  (if-not (browser?)
-    (is true off-browser)
-    (with-grid
-      (fn [c]
-        (let [n (cell-input c 13)]
-          (set-model! 13 "ABCD")
-          (.focus n)
-          (.setSelectionRange n 2 2)
-          (type-into! n "x")
-          (is (= "ABXCD" (model-value 13)) "the model normalised the case")
-          (is (= "ABXCD" (.-value n)) "and the field followed")
-          (is (= [3 3] (caret n))
-              "the caret is still after the character just typed — React saves
-               and restores the selection around a commit that writes"))))))
+(deftest a-normalising-model-moves-the-caret-to-the-end-on-react
+  (testing "the model uppercases what was typed, so React WRITES, and every
+           write React makes lands the caret at the end of the string —
+           the classic controlled-input caret jump, not a re-frame2 defect"
+    (if-not (browser?)
+      (is true off-browser)
+      (with-grid :react
+        (fn [c]
+          (let [n (cell-input c 13)]
+            (set-model! 13 "ABCD")
+            (.focus n)
+            (.setSelectionRange n 2 2)
+            (type-into! n "x")
+            (is (= "ABXCD" (model-value 13)) "the model normalised the case")
+            (is (= "ABXCD" (.-value n)) "and the field followed, in the same turn")
+            (is (= [5 5] (caret n))
+                "but the caret is at the END, not after the character just
+                 typed — React restores a selection only around a commit in
+                 which focus MOVED, and focus did not move")))))))
+
+(deftest the-uix-port-keeps-the-caret-mid-string-through-a-normalisation
+  (testing "the same keystroke on the other implementation: UIx's port owns
+           the write, and restores the caret by offset from the END of the
+           string — Arm 2's algorithm, and Reagent's before it"
+    (if-not (browser?)
+      (is true off-browser)
+      (with-grid :uix-reagent-input
+        (fn [c]
+          (let [n (cell-input c 13)]
+            (set-model! 13 "ABCD")
+            (.focus n)
+            (.setSelectionRange n 2 2)
+            (type-into! n "x")
+            (is (= "ABXCD" (model-value 13)))
+            (is (= "ABXCD" (.-value n)))
+            (is (= [3 3] (caret n))
+                "still after the character just typed")))))))
 
 (deftest a-grouping-model-keeps-the-caret-after-the-digit-just-typed
   (testing "1,234 + \"5\" becomes 12,345 — one character longer than what the
-           user typed, which is the case an absolute caret offset gets wrong"
+           user typed. The caret survives on React here only because the
+           edit was at the END of the field, which is where React's write
+           puts it anyway"
     (if-not (browser?)
       (is true off-browser)
-      (with-grid
+      (with-grid :react
         (fn [c]
           (let [n (cell-input c 17)]
             (set-model! 17 "1,234")
@@ -345,7 +523,7 @@
                 "the caret is still after the 5")))))))
 
 ;; ---------------------------------------------------------------------------
-;; :selection-preserved — the half that holds
+;; :selection-preserved
 ;; ---------------------------------------------------------------------------
 
 (deftest a-converge-elsewhere-leaves-this-fields-selection-alone
@@ -353,7 +531,7 @@
            nothing here moves"
     (if-not (browser?)
       (is true off-browser)
-      (with-grid
+      (with-grid :react
         (fn [c]
           (let [n (cell-input c 7)]
             (set-model! 7 "abcdef")
@@ -362,8 +540,41 @@
             (set-model! 23 "elsewhere")
             (is (= [1 4] (caret n)))))))))
 
+(deftest a-range-does-not-survive-a-converge-that-writes-on-either-implementation
+  (testing "Arm 2 restored both ends of a selection by distance from the end
+           of the string and required [2 5]. Neither shipped implementation
+           does: React resets the cursor to the end of the new value, and
+           UIx's port restores ONE offset into both `selectionStart` and
+           `selectionEnd` by construction (uix/compiler/input.cljs:68-69).
+           A range collapses. rf2-n3dxw records it; nothing here pretends
+           otherwise"
+    (if-not (browser?)
+      (is true off-browser)
+      (do
+        (with-grid :react
+          (fn [c]
+            (let [n (cell-input c 7)]
+              (set-model! 7 "abcdef")
+              (.focus n)
+              (.setSelectionRange n 1 4)
+              (set-model! 7 "Xabcdef")
+              (is (= "Xabcdef" (.-value n)))
+              (is (= [7 7] (caret n))
+                  "React put the cursor at the end of the value it wrote"))))
+        (with-grid :uix-reagent-input
+          (fn [c]
+            (let [n (cell-input c 7)]
+              (set-model! 7 "abcdef")
+              (.focus n)
+              (.setSelectionRange n 1 4)
+              (set-model! 7 "Xabcdef")
+              (is (= "Xabcdef" (.-value n)))
+              (is (= [2 2] (caret n))
+                  "the port kept the offset from the end — as a cursor, not
+                   as a range"))))))))
+
 ;; ---------------------------------------------------------------------------
-;; :unchanged-model-rejection — the row Arm 2 called decisive
+;; :unchanged-model-rejection — the row Arm 2 called decisive (rf2-n3dxw)
 ;; ---------------------------------------------------------------------------
 
 (deftest a-refused-keystroke-moves-no-model-and-re-runs-no-boundary
@@ -371,7 +582,7 @@
            letter; the model does not move, so NOTHING re-renders"
     (if-not (browser?)
       (is true off-browser)
-      (with-grid
+      (with-grid :react
         (fn [c]
           (let [n (cell-input c 11)]
             (set-model! 11 "12")
@@ -384,34 +595,169 @@
                 "and no boundary body ran at all — the value the model holds
                  did not change, so there was nothing for React to re-render")))))))
 
-(deftest recorded-a-refused-keystroke-is-not-taken-off-the-screen
-  (testing "RECORDED BEHAVIOUR, NOT DESIRED BEHAVIOUR (rf2-n3dxw).
+(deftest a-refused-keystroke-is-taken-off-the-screen-inside-the-event
+  (testing "THE ROW rf2-n3dxw WAS OPENED FOR, and React meets it.
 
-           This is the row Arm 2 met and the React path does not. Arm 2
-           converged the focused node at the end of every commit, so the
-           refused character came off the screen with the caret intact.
-           Here nothing re-renders — see the test above — and React's own
-           end-of-discrete-event state restore does not put the field
-           back either, so the field and the model disagree and every
-           later edit compounds it.
+           Nothing re-rendered — the test above counts zero body runs on
+           this exact keystroke — so the write below cannot have come from
+           a render. It comes from React's own controlled-state restore:
+           the change event enqueued this node
+           (`react-dom-client.development.js:3512-3523`), and the `finally`
+           of `batchedUpdates$1` (`:3251-3272`) handed the committed props
+           to `updateInput` (`:1644`), which assigned `value` because it
+           differed (`:1661-1667`). All of it before `dispatchEvent`
+           returned.
 
-           The assertion is written to the MEASURED value deliberately:
-           it is a tripwire. The day the adapter takes the character off
-           the screen this test goes red, and whoever makes it go red is
-           exactly the person who should be reading rf2-n3dxw."
+           The caret lands at 2 because that is where React's write leaves
+           it — the end of the string — which happens to be the position
+           before the refused character when the edit was AT the end. The
+           test below shows what that costs mid-string."
     (if-not (browser?)
       (is true off-browser)
-      (with-grid
+      (with-grid :react
         (fn [c]
           (let [n (cell-input c 11)]
             (set-model! 11 "12")
             (.focus n)
             (.setSelectionRange n 2 2)
+            (reset! !body-runs 0)
             (type-into! n "a")
-            (is (= "12a" (.-value n))
-                "the refused character is still on screen")
+            (is (= "12" (.-value n))
+                "the refused character is off the screen, on the next line")
             (is (= "12" (model-value 11))
-                "while the model says it was never accepted")))))))
+                "and the field and the model agree")
+            (is (zero? @!body-runs)
+                "with nothing re-rendered to do it")
+            (is (= [2 2] (caret n))
+                "caret at the position before the refused character")))))))
+
+(deftest a-refused-keystroke-mid-string-converges-with-the-caret-at-the-end
+  (testing "RECORDED BEHAVIOUR, NOT DESIRED BEHAVIOUR (rf2-n3dxw).
+
+           This is the residue after the headline row was corrected. The
+           refused character IS removed, in the same turn — but React's
+           write moves the cursor to the end of the control, so a user
+           editing mid-string is thrown to the end of the field on every
+           refused keystroke. The assertion is written to the MEASURED
+           value deliberately: the day something puts the caret back at 2
+           this goes red, and whoever makes it go red is exactly the person
+           who should be reading rf2-n3dxw."
+    (if-not (browser?)
+      (is true off-browser)
+      (with-grid :react
+        (fn [c]
+          (let [n (cell-input c 11)]
+            (set-model! 11 "12345")
+            (.focus n)
+            (.setSelectionRange n 2 2)
+            (type-into! n "z")
+            (is (= "12345" (.-value n))
+                "the refused character is gone")
+            (is (= "12345" (model-value 11)))
+            (is (= [5 5] (caret n))
+                "but the caret is at the end of the field, not at 2")))))))
+
+(deftest the-uix-port-takes-the-refused-character-off-one-frame-late
+  (testing "RECORDED BEHAVIOUR, NOT DESIRED BEHAVIOUR (rf2-n3dxw).
+
+           The other implementation gets the caret right and the timing
+           wrong. Its convergence rides `do-after-render`, whose queue is
+           drained from `requestAnimationFrame`, so on the line after
+           `dispatchEvent` the refused character is still on the screen —
+           which is what the bead originally recorded, and attributed to
+           React."
+    (if-not (browser?)
+      (is true off-browser)
+      (async done
+        (pin-input-implementation! :uix-reagent-input)
+        (let [c    (container!)
+              root (mount! c cells)
+              n    (cell-input c 11)]
+          (set-model! 11 "12345")
+          (.focus n)
+          (.setSelectionRange n 2 2)
+          (type-into! n "z")
+          (is (= "12z345" (.-value n))
+              "still on the screen when the discrete event returns")
+          (is (= "12345" (model-value 11)) "though the model refused it")
+          (after-a-frame
+           (fn []
+             (try
+               (is (= "12345" (.-value n))
+                   "one animation frame later the port has converged")
+               (is (= [2 2] (caret n))
+                   "and the caret is at the position before the refused
+                    character — the half React does not give")
+               (catch :default e
+                 (is false (str "the deferred converge threw: " (ex-message e)))))
+             (release! root c)
+             (done))))))))
+
+;; ---------------------------------------------------------------------------
+;; The priced option — both halves, in one turn (rf2-n3dxw)
+;; ---------------------------------------------------------------------------
+
+(deftest a-same-turn-converge-can-have-both-halves-at-a-stated-price
+  (testing "MEASUREMENT OF A PROPOSAL, not of anything that ships.
+
+           Neither implementation above gives same-turn convergence AND a
+           caret at the position before the refused character. [[converge!]]
+           does, on every row of the family at once, on the synchronous
+           door. What it costs is stated rather than hidden: one
+           `flushSync` per keystroke on a controlled element, and a
+           per-instance record of the value that element last rendered
+           ([[!rendered]] here). It costs no user-visible ceremony — no
+           ref, no effect, nothing in the view but the ordinary
+           `:value`/`:on-change` pair — and no hook in the boundary shell.
+
+           The one thing it cannot do is the queued door: `dispatch`
+           drains on a macrotask, so at the end of the change handler the
+           model has not moved yet and there is nothing to converge to."
+    (if-not (browser?)
+      (is true off-browser)
+      (with-grid :react {:converge? true}
+        (fn [c]
+          (let [reject (cell-input c 11)
+                upper  (cell-input c 13)
+                group  (cell-input c 17)
+                plain  (cell-input c 7)]
+            (testing "a refused keystroke at the end of the field"
+              (set-model! 11 "12")
+              (.focus reject)
+              (.setSelectionRange reject 2 2)
+              (type-into! reject "a")
+              (is (= "12" (.-value reject)))
+              (is (= [2 2] (caret reject))))
+            (testing "a refused keystroke MID-STRING — the row React alone loses"
+              (set-model! 11 "12345")
+              (.focus reject)
+              (.setSelectionRange reject 2 2)
+              (type-into! reject "z")
+              (is (= "12345" (.-value reject)))
+              (is (= [2 2] (caret reject))
+                  "the caret is at the position before the refused character,
+                   in the same turn"))
+            (testing "a length-preserving normalisation"
+              (set-model! 13 "ABCD")
+              (.focus upper)
+              (.setSelectionRange upper 2 2)
+              (type-into! upper "x")
+              (is (= "ABXCD" (.-value upper)))
+              (is (= [3 3] (caret upper))))
+            (testing "a length-CHANGING normalisation"
+              (set-model! 17 "1,234")
+              (.focus group)
+              (.setSelectionRange group 5 5)
+              (type-into! group "5")
+              (is (= "12,345" (.-value group)))
+              (is (= [6 6] (caret group))))
+            (testing "and an ordinary accepted keystroke is not disturbed"
+              (set-model! 7 "abcd")
+              (.focus plain)
+              (.setSelectionRange plain 2 2)
+              (type-into! plain "X")
+              (is (= "abXcd" (.-value plain)))
+              (is (= [3 3] (caret plain))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; :async-normalisation, and the queued door
@@ -425,6 +771,7 @@
       (async done
         ;; NOT `with-grid`: its `finally` runs the moment the body returns,
         ;; and the body of an async test returns before its timer fires.
+        (pin-input-implementation! :react)
         (let [c    (container!)
               root (mount! c cells)
               n    (cell-input c 17)]
@@ -453,8 +800,9 @@
     (if-not (browser?)
       (is true off-browser)
       (async done
+        (pin-input-implementation! :react)
         (let [c    (container!)
-              root (mount! c cells :queued)
+              root (mount! c cells {:door :queued})
               n    (cell-input c 3)]
           (.focus n)
           (type-into! n "ab")


### PR DESCRIPTION
#7327, which added the witness file this PR corrects, merged while this work
was in flight; the branch has been rebased onto `main` and the diff is the
correction alone.

`rf2-n3dxw` recorded a P1 against Hicasso's React path: a keystroke the model
refuses stays on the screen, the field and the model disagree permanently, and
every later edit compounds it. Measured against the react-dom in this repo, in
real Chromium, **that is not what happens, and React is not what was being
measured.**

## What the row actually measured

UIx chooses, per element and at element-creation time, between plain React and a
port of Reagent's controlled-input workaround.
`uix.compiler.aot/create-uix-input` branches on
`uix.compiler.input/should-use-reagent-input?`, and that predicate — with
`*use-reagent-input-enabled?*` unset, which is the shipped default — answers
*"is `reagent.impl.util/*non-reactive*` present, and false?"* (uix.core 1.4.4,
`uix/compiler/input.cljs:15-21`). It is a fact about the classpath, not a
decision the application makes, and every `:browser-test` bundle here carries
Reagent because the Reagent adapter is first-class and ships with tests.

So the witness measured the port and attributed the port's behaviour to React.
The probe that found it read the props React had committed to the DOM node:
where the view had written `:value`, the node carried `defaultValue "12"` and a
`ref` whose source is `function (el){ return (this$.inputEl = el); }`. Narrowing
the build to that one namespace — no Reagent — flipped the row green on the
spot.

## What React does

Read out of `react-dom@19.2.0`, `cjs/react-dom-client.development.js`:

| line | what happens |
|---|---|
| `3512-3523` | `createAndAccumulateChangeEvent` records the event target for restoration |
| `3251-3272` | the `finally` of `batchedUpdates$1` flushes sync work, then calls `restoreStateOfTarget` |
| `3178-3196` | `restoreStateOfTarget` hands the props React last committed to `updateInput` |
| `1661-1667` | `updateInput` assigns `element.value` whenever it differs from the prop |

All of it before `dispatchEvent` returns, and with **nothing re-rendered** — the
same keystroke counts zero boundary body runs, asserted beside the value, so the
write cannot have come from a render. Measured: field `"12"`, caret `[2 2]`,
model `"12"`.

What React does **not** do is put the caret back. Assigning `value` moves the
cursor to the end of the control, and React restores a selection only around a
commit in which focus *moved*.

## The residue, which is why the bead stays open

**Neither shipped implementation gives both same-turn convergence and a caret at
the position before the refused character.**

| row | `:react` in-turn | `:uix-reagent-input` in-turn | `:uix-reagent-input` after a frame |
|---|---|---|---|
| refusal at the end — `"12"` + `a` | `"12"` `[2 2]` OK | `"12a"` `[3 3]` WRONG | `"12"` `[2 2]` OK |
| refusal mid-string — `"12345"` + `z` at `[2 2]` | `"12345"` **`[5 5]`** caret wrong | `"12z345"` `[3 3]` WRONG | `"12345"` `[2 2]` OK |
| uppercasing mid-string | `"ABXCD"` **`[5 5]`** caret wrong | `"ABXCD"` `[3 3]` OK | OK |
| a range `[1 4]` across a converge that writes | `[7 7]` | `[2 2]` | unchanged |

React converges in-turn with the caret in the wrong place; the port puts the
caret in the right place one `requestAnimationFrame` late. The full matrix and
three priced options are on
`docs/design/hicasso/studio/controlled-input-two-implementations.md`.

## What this PR changes

- **The witness pins the implementation it measures** instead of inheriting
  whichever one the bundle implies, and measures both, because the difference is
  the finding. The tripwire flips: `"12a"` becomes `"12"`.
- **Two rows that were quietly green on the port are corrected to React's real
  behaviour** — a normalisation moves the caret to the end (`[5 5]`, not
  `[3 3]`), and a range converge lands at `[7 7]`, not `[2 2]`. The port keeps
  its own rows beside them.
- **The range row is answered and scoped, not fixed.** Arm 2 required `[2 5]`;
  a range collapses **by construction** on both paths — React resets the cursor
  to the end of the value it wrote, and the port writes one offset into both
  `selectionStart` and `selectionEnd` (`uix/compiler/input.cljs:68-69`).
  Asserted on both, with the reason.
- **IME stays dropped**, with a stronger reason: there are now two
  implementations to establish a fence against, and they face composition
  differently. Split out as `rf2-o27h3` with the harness that would settle it.
  `validation.md` stops listing it as an asserted row of the controlled grid.
- **The option is priced by measurement, not by assertion.** `converge!` runs at
  the end of the change handler — `flushSync`, write the rendered value if the
  field still disagrees, restore the caret by offset from the end — and carries
  every row of the family in one turn, including the mid-string refusal neither
  shipped path gets right. Its price is stated: one `flushSync` per keystroke, a
  per-instance record of the value last rendered, and the synchronous door only.
  It costs no user-visible ceremony and **no hook in the boundary shell**, so
  the HD-020 two-hook budget is untouched. It is prototyped in the witness's
  view because neither Hicasso nor the UIx adapter mints its own `:input`
  element today — UIx does.
- **The record is corrected on the same evidence.** `architecture.md`'s "React
  owns the controlled-input end-of-event restore" is confirmed, with the
  qualification that it holds only while the element is genuinely controlled;
  HD-019's "rejected/unchanged-model paths lean on React's own end-of-event
  restore" is confirmed for the value and refuted for the caret.

No production source changed. Which implementation a re-frame2 UIx consumer
should get is a ruling, not a worker's call — filed as `rf2-heqwo` (P1) with the
one-line action it implies. The in-turn converge is `rf2-fki5d` (P2).

**`rf2-n3dxw` stays OPEN** on the residue above.

## Mutation proof

The flipped assertion is proved, not asserted. Neutering the pin — so the file
goes back to inheriting whatever the bundle implies — reds it:

```
FAIL in (a-refused-keystroke-is-taken-off-the-screen-inside-the-event)
expected: (= "12" (.-value n))
  actual: (not (= "12" "12a"))
```

| state | exit |
|---|---|
| pin neutered (`(when false ...)`) | **1** — 7 assertions red, including the flipped one |
| pin restored | **0** — 16 tests, 52 assertions, 0 failures |

## Quality gates

Every gate ran in the worktree, in the foreground, to completion, with the exit
code echoed. No output was piped through `tail` or `grep` before the exit code
was taken.

| gate | exit | result |
|---|---|---|
| `npm run test:browser` (compile) | 0 | `:browser-test` build completed, 1080 files, 0 warnings |
| `npm run test:browser` (run, headless Chromium) | 0 | Ran 905 tests containing 5730 assertions. 0 failures, 0 errors. |
| `npm run test:cljs` | 0 | Ran 12135 tests containing 60630 assertions. 0 failures, 0 errors. |
| `scripts/test-fast-pr.sh` | 0 | `PASS fast PR spine`; per-ns isolation 17/17 standalone |
| clj-kondo **2026.04.15** (CI's pinned version, CI's exact `--lint` set, `--fail-level error`) | 0 | **errors: 0**, warnings 4526 (all pre-existing; none in the changed file) |
| `mkdocs build --strict` | 0 | Documentation built in 21.91 seconds |

`npm run test:browser` was re-run at the rebased tip, on top of the merged
#7327, so its numbers are this branch's final ones. `npm run test:cljs`,
`scripts/test-fast-pr.sh`, clj-kondo and `mkdocs build --strict` ran on the same
tree content before the rebase; the rebase replayed the three commits unchanged
onto a `main` whose only additions since were that merge plus two docs commits
and a beads checkpoint, and the one commit made after them touches a single
Markdown provenance block.

**TESTING.md matrix derived for this change.** The changed surfaces are one
`*_dom_cljs_test.cljs` under `implementation/freehand/test/` and four Markdown
files under `docs/design/hicasso/`. That selects the CLJS lanes — `:browser-test`
(the `-dom-cljs-test$` selector matches this file, and it is not under
`re-frame.freehand.bench.`, so it is not in the excluded bench partition) and
`:node-test` (whose `cljs-test$` selector matches it too, where it short-circuits
off-browser) — plus the lint lane and the docs lane. It selects no JVM artefact
lane, and no bundle-isolation, perf-bundle, adapter-smoke, Xray-feature-gate or
mcp-conformance lane, because it touches no production source, no `deps.edn`, no
`shadow-cljs.edn` build id, no adapter and no example. `scripts/test-fast-pr.sh`
was run anyway as the repo's pre-checkin spine, and independently agreed: it
named the JVM artefact suites and the browser/bundle/adapter/tooling lanes as
NOT RUN because the diff did not touch them.

**`mkdocs build --strict` does not cover the pages this PR touches.**
`design/hicasso/` is in `exclude_docs` in `mkdocs.yml`, so the strict build never
reads `architecture.md`, `validation.md`, `studio/README.md` or the new studio
page. Every relative link added to them was resolved **by hand** against the
checkout: the three inbound links to
`studio/controlled-input-two-implementations.md` all resolve, and the new page
adds no relative links of its own. The strict build was run regardless and is
green.
