### PR TITLE
hicasso: an honest residue gate, a correct classification, and a diff that never runs (rf2-2rtt6.46, rf2-2rtt6.47, rf2-2rtt6.48)

### DIFF
--- a/docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md
+++ b/docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md
@@ -127,18 +127,48 @@ Witnesses: `a-render-mutates-neither-the-index-nor-a-reference`,
 
 ### (b) The allowed edge-diff operation
 
-A boundary's edge set is **replaced wholesale, once, at commit** — the shared
-front half's `record-reads` set difference — and only when the read set actually
-changed, because an unchanged set leaves `subscribe` identical and React does not
-call it again. **The unchanged case is detected without building anything:** the
-scratch array is compared pairwise against the cached entry's key array, so
-steady-state allocation for edge maintenance is zero bytes.
+A boundary's edge set is **replaced wholesale, once, at commit** — and only when
+the read set actually changed, because an unchanged set leaves `subscribe`
+identical and React does not call it again. **The unchanged case is detected
+without building anything:** the scratch array is compared pairwise against the
+cached entry's key array, so steady-state allocation for edge maintenance is zero
+bytes.
+
+**The replacement is `unmount-all` + `mount-all`, and this page used to say it
+was `record-reads`'s set difference.** That was wrong about the running path
+(rf2-2rtt6.47). A boundary id here is the registration object React mints inside
+`subscribe`, so a changed read set means a new entry, a new `subscribe` and a new
+id; the index installs `#{}` for it, and the `record-reads` that follows sees
+`held = #{}` — `added` is the whole read set and `dropped` is always empty. The
+narrowing is the *previous* registration's cleanup calling `unmount`, which drops
+every edge outright. The difference is proved in
+`front/sub_index_laws_cljs_test`, and on this wiring it is delivered by the
+`unmount`/`mount` pair; `the-wired-path-never-takes-the-diffs-dropping-half`
+pins that, so the two stop diverging.
+
+The cost follows and is not the "identity change and one replacement" §4 of this
+page priced it as. For an `n`-read boundary with one key changed: `n` releases
+(including the `n-1` that did not change), up to `n` armed reapers, an entry miss
+that builds a key array, a key set and two closures, `n` re-acquisitions, and two
+whole-map rebuilds of `:sub->bs`. **There is no cheap route for "19 of 20 keys
+unchanged."**
+
+A durable per-boundary id would make the difference live. It is unavailable at
+this arm's fences rather than merely unbuilt: it must survive a re-subscribe, so
+it cannot live on the registration; the shell has no per-instance storage that is
+not a hook, and a third hook breaks the HD-020 budget the ledger witness
+enforces; and threading one into `subscribe` would end `subscribe`'s property of
+closing over the read set and nothing else, which is what makes it shared and
+identity-stable. Buying the diff costs the two properties the arm exists to
+demonstrate, so it is not bought — and the finding is recorded here rather than
+left as an unexplained absence.
 
 The ordered compare is a **false-negative device, never a wrong answer** — two
 renders reading the same keys in a different order miss the compare, take a
-second entry with the same set, and React replaces a set with itself. It is
-deliberately not repaired with a content hash, whose failure mode would be a
-silently missing edge.
+second entry with the same set, and React replaces a set with itself. The compare
+is deliberately not *replaced* by a content hash, whose failure mode would be a
+silently missing edge; a hash does choose which entries the compare runs against
+(rf2-2rtt6.46), where a collision costs a second entry and never a wrong one.
 
 Against the forbidden list: no per-read object; one scratch and never two;
 nothing keyed by render, attempt, lane or generation; no registry of in-flight
@@ -147,6 +177,8 @@ renders; **no commit-phase re-read of subscription values**.
 Witnesses: `an-unchanged-read-set-is-detected-without-building-anything`,
 `a-changed-read-set-takes-a-different-subscribe-identity`,
 `a-boundary-holds-exactly-the-edges-its-latest-commit-installed`,
+`the-wired-path-never-takes-the-diffs-dropping-half`,
+`the-bucket-scan-does-not-grow-with-the-number-of-boundaries`,
 `reading-one-key-twice-is-one-edge`,
 `a-warm-read-performs-no-new-attach-or-release`.
 
@@ -174,10 +206,25 @@ cite.
 ### (d) The survival metric
 
 Two halves. **Zero retained per-occurrence objects after commit/teardown** is
-witnessed now — `arm1_runtime_cljs_test` asserts `{:cells 0 :cell-refs 0
-:boundaries 0 :edges 0 :entries 0}` after release, and every DOM suite asserts
-the same after its mount. **The steady-state allocation slope across warm
-1/3/7/20 reads** needs the bench and is not taken here.
+witnessed now, at both seams and in both directions:
+
+- at the **node seam**, `arm1_runtime_cljs_test` drives `commit-boundary!`'s own
+  cleanup and asserts `{:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}`
+  past the reapers' macrotask horizon;
+- at the **React seam**, `arm1_dogfood_dom_cljs_test` and
+  `arm1_generation_fence_dom_cljs_test` unmount the root and take the same
+  reading — with the runtime untouched, so what they read is what React's own
+  cleanup left.
+
+The second bullet is a correction. Until rf2-2rtt6.48 those DOM gates asserted
+after `mount/release!`, which resets the runtime *before* the reading: they
+answered zero however teardown had gone, and no suite witnessed React-driven
+release at all. `release!` now splits into `unmount!` + reset, the gates read
+between the two, and `the-residue-reading-can-answer-false` mounts two roots and
+unmounts one to show the repaired reading is live at the point the gates take it.
+
+**The steady-state allocation slope across warm 1/3/7/20 reads** needs the bench
+and is not taken here.
 
 ### The tripwire did not fire
 
@@ -436,10 +483,12 @@ position into hand-written imperative code.
 The honest cost on the other side: the collector's edge set is a function of what
 the body *did*, so a body whose control flow depends on a value read late can
 change its edge set from render to render, and each change is a re-subscribe. The
-mechanism makes that cheap (an identity change and one replacement) and the
-witnesses prove it is correct, but it is a real difference from a surface whose
-edges are static, and it is the thing to watch on the bulk rows when they are
-taken.
+witnesses prove it is correct. **It is not cheap** — §3(b) prices it: a
+re-subscribe releases and re-acquires every key the boundary reads, not the one
+that changed, and arms a reaper for each. This paragraph read "an identity change
+and one replacement" until rf2-2rtt6.47 corrected it. It is a real difference
+from a surface whose edges are static, and it is the thing to watch on the bulk
+rows when they are taken.
 
 ---
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_dom_cljs_test.cljs
@@ -32,7 +32,7 @@
 
   Runtime: `-dom-cljs-test`; under `:node-test` every claim degrades to a
   stated skip."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.bench.hicasso.arm1.dogfood-collector :as collector]
             [re-frame.bench.hicasso.arm1.dogfood-grouped :as grouped]
@@ -60,6 +60,10 @@
      ;; difference. Caught by the frame probe below, which is why the
      ;; probe stays.
      :ambient-frame nil
+     ;; The map shape, because the teardown claims are `async`: the cell
+     ;; and entry reapers are macrotasks, so the residue a React unmount
+     ;; leaves is not readable inside one synchronous test body.
+     :async?  true
      :init-fn (fn [] (rt/reset-runtime!))}))
 
 (def ^:private frame-id ::arm1-dogfood)
@@ -338,18 +342,78 @@
                  "preference"))))))
 
 ;; ---------------------------------------------------------------------------
-;; Teardown
+;; Teardown — **React's** teardown, read while the runtime still holds it
 ;; ---------------------------------------------------------------------------
+;;
+;; The reading is taken between the root unmount and any reset, because
+;; `mount/release!` resets the runtime and a reading taken after that is a
+;; reading of an emptied table — zero however badly teardown went. That
+;; ordering is what made these two gates unable to fail (rf2-2rtt6.48),
+;; and `the-residue-reading-can-answer-false` below is the demonstration
+;; that the repaired reading is live at the point the gates take it.
+;;
+;; The macrotask wait is not slack: a cell whose last reader unmounts and
+;; an entry whose last boundary unmounts are both reaped one macrotask
+;; later, deliberately, so a keyed reorder reuses them.
 
-(deftest the-screen-leaves-no-residue
+(def ^:private reaper-horizon-ms
+  "One macrotask, with room — `arm1/runtime` arms both reapers at 0 ms."
+  8)
+
+(def ^:private nothing-retained
+  {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0})
+
+(defn- assert-react-teardown-releases-everything!
+  "Mount `screen`, drive it, and let **React** tear it down. What survives
+  the reaper horizon is what React's own cleanup failed to release."
+  [label screen done]
+  (fresh!)
+  (let [handle (hicasso-mount! screen)]
+    (mount/dispatch! handle [:dogfood/toggle 0])
+    (mount/dispatch! handle [:dogfood/set-filter :all])
+    (is (pos? (:cell-refs (rt/stats)))
+        (str label ": the mounted screen holds references, so the reading "
+             "below is a reading of something"))
+    (mount/unmount! handle)
+    (js/setTimeout (fn []
+                     (is (= nothing-retained (rt/residue))
+                         (str label ": React's own cleanup released every edge, "
+                              "reference and cached entry"))
+                     (rt/reset-runtime!)
+                     (done))
+                   reaper-horizon-ms)))
+
+(deftest the-collector-screen-leaves-no-residue
   (if-not (mount/browser?)
     (skip! ":node-test has no DOM")
-    (doseq [[label screen] [["collector" collector/screen] ["grouped" grouped/screen]]]
-      (fresh!)
-      (let [handle (hicasso-mount! screen)]
-        (mount/dispatch! handle [:dogfood/toggle 0])
-        (mount/dispatch! handle [:dogfood/set-filter :all])
-        (mount/release! handle)
-        (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-               (rt/residue))
-            (str label ": zero leaked subscription ref-counts after teardown"))))))
+    (async done (assert-react-teardown-releases-everything!
+                  "collector" collector/screen done))))
+
+(deftest the-grouped-screen-leaves-no-residue
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (async done (assert-react-teardown-releases-everything!
+                  "grouped" grouped/screen done))))
+
+(deftest the-residue-reading-can-answer-false
+  (testing "two roots, one unmounted: the reading the gates above take is
+           NOT zero, because the other root's boundaries are still holding
+           what they acquired. This is the property the pre-repair gates
+           lacked — `release!` resets the runtime, so it would report zero
+           here too, with a whole screen still mounted"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (async done
+        (fresh!)
+        (let [survivor (hicasso-mount! collector/screen)
+              doomed   (hicasso-mount! collector/screen)]
+          (mount/unmount! doomed)
+          (js/setTimeout (fn []
+                           (is (not= nothing-retained (rt/residue))
+                               "a live screen is visible to the residue reading")
+                           (is (pos? (:cell-refs (rt/residue)))
+                               "and it is visible as held references, which is
+                                the quantity the gates assert to be zero")
+                           (mount/release! survivor)
+                           (done))
+                         reaper-horizon-ms))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/generation_fence_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/generation_fence_dom_cljs_test.cljs
@@ -38,7 +38,7 @@
   React DOM; under `:node-test` every claim degrades to a stated skip.
   The fence's own algebra is proved without a browser in
   `arm1/runtime_cljs_test`."
-  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.bench.hicasso.arm1.mount :as mount]
             [re-frame.bench.hicasso.arm1.runtime :as rt]
@@ -59,6 +59,10 @@
      ;; difference. Caught by the frame probe below, which is why the
      ;; probe stays.
      :ambient-frame nil
+     ;; The map shape, because the teardown claim is `async`: the cell and
+     ;; entry reapers are macrotasks, so the residue a React unmount leaves
+     ;; is not readable inside one synchronous test body.
+     :async?  true
      :init-fn (fn [] (rt/reset-runtime!))}))
 
 (def ^:private frame-id ::arm1-fence)
@@ -213,15 +217,30 @@
           (finally (mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Teardown
+;; Teardown — **React's** teardown, read while the runtime still holds it
 ;; ---------------------------------------------------------------------------
+;;
+;; `mount/unmount!` rather than `mount/release!`, because `release!` resets
+;; the runtime and a reading taken after that reset answers zero whatever
+;; teardown did — the ordering that made this gate unable to fail
+;; (rf2-2rtt6.48). The macrotask wait is the cell and entry reapers'
+;; deliberate grace period, not slack.
 
 (deftest the-fenced-boundary-leaves-no-residue
   (if-not (mount/browser?)
     (skip! ":node-test has no DOM")
-    (let [handle (mounted!)]
-      (mount/dispatch! handle [:dogfood/toggle 0])
-      (mount/release! handle)
-      (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-             (rt/residue))
-          "zero leaked subscription ref-counts after teardown"))))
+    (async done
+      (let [handle (mounted!)]
+        (mount/dispatch! handle [:dogfood/toggle 0])
+        (is (pos? (:cell-refs (rt/stats)))
+            "the mounted boundary holds references, so the reading below is
+             a reading of something")
+        (mount/unmount! handle)
+        (js/setTimeout (fn []
+                         (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                                (rt/residue))
+                             "React's own cleanup released every edge and every
+                              subscription reference")
+                         (rt/reset-runtime!)
+                         (done))
+                       8)))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/mount.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/mount.cljs
@@ -62,17 +62,37 @@
     (render! handle hiccup)
     handle))
 
-(defn release!
-  "Unmount the root and drop every edge, cell and cached closure the arm
-  held. Idempotent: releasing twice is not an error, because a teardown
-  door that throws on the second call is a teardown door test fixtures
-  route around."
+(defn unmount!
+  "Unmount the root and detach its container, and **touch nothing the
+  runtime holds**. Whatever edges, cells and cached closures survive are
+  the ones React's own cleanup failed to release.
+
+  This is the half a residue gate has to be able to read. [[release!]]
+  also resets the runtime, and a reading taken after that reset is a
+  reading of an emptied table: it answers `0` whether teardown worked or
+  not, which is a gate that cannot go red (rf2-2rtt6.48). A witness that
+  wants to assert on teardown therefore calls this, waits one macrotask
+  for the cell and entry reapers, asserts, and resets afterwards.
+
+  Idempotent, for the same reason [[release!]] is."
   [handle]
   (when-some [r (:root handle)]
     (react-dom/flushSync (fn [] (.unmount r))))
-  (rt/reset-runtime!)
   (when-some [c (:container handle)]
     (when-some [p (.-parentNode c)] (.removeChild p c)))
+  nil)
+
+(defn release!
+  "Unmount the root and drop every edge, cell and cached closure the arm
+  held. The fixture door: it ends with a runtime that holds nothing,
+  whatever this test left behind. Idempotent: releasing twice is not an
+  error, because a teardown door that throws on the second call is a
+  teardown door test fixtures route around.
+
+  **Not the door a residue assertion takes** — see [[unmount!]]."
+  [handle]
+  (unmount! handle)
+  (rt/reset-runtime!)
   nil)
 
 (defn dispatch!

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -84,21 +84,58 @@
 
   ### The allowed edge-diff operation (clause (b))
 
-  A boundary's edge set is **replaced wholesale, once, at commit** —
-  `front.sub-index/record-reads`'s set difference — and only when the
-  read set actually changed, because an unchanged set leaves the
-  `subscribe` closure identical and React does not call it again. The
-  unchanged case is detected **without building anything**: the scratch
-  array is compared pairwise against the cached entry's key array, so
-  steady-state allocation for edge maintenance is zero bytes and the
-  allocation slope across warm 1/3/7/20 reads is flat.
+  A boundary's edge set is **replaced wholesale, once, at commit**, and
+  only when the read set actually changed, because an unchanged set
+  leaves the `subscribe` closure identical and React does not call it
+  again. The unchanged case is detected **without building anything**:
+  the scratch array is compared pairwise against the cached entry's key
+  array, so steady-state allocation for edge maintenance is zero bytes
+  and the allocation slope across warm 1/3/7/20 reads is flat.
+
+  **The replacement is `unmount-all` + `mount-all`, not a set difference,
+  and it is worth being exact about that (rf2-2rtt6.47).** The clause
+  used to be discharged against `front.sub-index/record-reads`'s
+  difference — the operation `front/sub_index_laws_cljs_test` proves law
+  4 for. This wiring never takes its dropping half. A boundary id here is
+  the registration object minted inside [[make-subscribe]], so a changed
+  read set means a new entry, a new `subscribe`, a new registration and
+  therefore a new id; `index/mount!` installs `#{}` for it, and the
+  `record-reads!` that follows sees `held = #{}`, `added = the whole read
+  set`, `dropped = #{}` every single time. The narrowing is done by the
+  *previous* registration's cleanup calling `index/unmount!`, which drops
+  every edge outright. `the-wired-path-never-takes-the-diffs-dropping-half`
+  asserts that, so the claim is checkable rather than argued.
+
+  What the changed case therefore costs, for an `n`-read boundary with
+  one key different: `n` `release-cell!`s and up to `n` armed reapers,
+  one entry miss (a `.slice`, an `(into #{} ks)` and two closures), `n`
+  `acquire-cell!`s, one `mount!` and one `record-reads!` — two whole-map
+  rebuilds of `:sub->bs`. There is **no cheap route for \"19 of 20 keys
+  unchanged\"**, and a page whose rows change read set on a data change
+  pays it per row. That is the honest price and the thing to watch on the
+  bulk rows.
+
+  A durable per-boundary id would make the difference live, and it is
+  **unavailable at this arm's fences rather than merely unbuilt**. It has
+  to survive a re-subscribe, so it cannot live on the registration; the
+  shell has no per-instance storage that is not a hook, and a third hook
+  breaks the HD-020 budget the ledger witness enforces; and threading one
+  into `subscribe` would mean `subscribe` closing over something other
+  than the read set, which is what makes it a shared, identity-stable
+  pure function of a value in the first place. Buying the diff costs the
+  two properties this arm exists to demonstrate, so it is not bought.
+  The difference stays in the shared front half — general, proved, and
+  driven in its degenerate form from here.
 
   The ordered compare is a false-negative device and never a wrong
   answer: two renders that read the same keys in a different order miss
   the compare, take a second entry with the same set, and React replaces
-  a set with itself — slower, still correct. It is deliberately not
-  repaired with a content hash, whose failure mode would be a silently
-  missing edge.
+  a set with itself — slower, still correct. The compare is what decides
+  a match, and it is deliberately not *replaced* by a content hash, whose
+  failure mode would be a silently missing edge. A hash does choose which
+  entries the compare is run against ([[scratch-bucket-key]]), which is a
+  different job with a different failure mode — a collision costs a
+  second entry, never a wrong one.
 
   **No per-read object, no second candidate slot, nothing keyed by a
   render or an attempt, and no commit-phase deref.** The commit consults
@@ -629,12 +666,52 @@
 ;; ---------------------------------------------------------------------------
 
 (defonce ^:private !entries
-  ;; first-sub-key -> vector of entries. Bucketing on a value the scratch
-  ;; already holds keeps the steady-state lookup allocation-free; the
-  ;; distinct-query witness puts one entry in each bucket.
+  ;; read-sequence hash -> vector of entries. See [[scratch-bucket-key]]
+  ;; for why the key is a hash of the WHOLE sequence and not, as it once
+  ;; was, the first sub-key.
   (atom {}))
 
-(def ^:private empty-bucket-key ::no-reads)
+(defn- scratch-bucket-key
+  "The bucket the scratch's current read sequence belongs to: an
+  **order-sensitive hash of the whole sequence**.
+
+  It selects a bucket and is never an equality test — [[entry-matches?]]
+  still compares every key pairwise before an entry is reused. That
+  division is the whole safety argument, and it is why this is not the
+  content hash the design record rejected: a hash *instead of* the
+  compare could hand back an entry for a different read set, which is a
+  silently missing edge; a hash *in front of* the compare can only send
+  two different sequences to one bucket, where the compare rejects one of
+  them and the caller mints a second entry. False negatives only, in both
+  directions.
+
+  It costs nothing measurable. Every sub-key on the scratch has already
+  been hashed this render — [[read-key!]] looks it up in `!cells` before
+  it returns — so this is `n` cached-hash reads and `n` integer ops, with
+  no allocation, which is what keeps the steady-state hit path at zero
+  bytes.
+
+  **Why the first sub-key was not enough (rf2-2rtt6.46).** Bucketing on
+  `(aget scratch 0)` made the scan's cost a function of how an author
+  ordered their `let` bindings. A row body reading its per-row key first
+  put one entry in each bucket; the same body reading a page-wide key
+  first — one line moved — put every live row's entry in ONE bucket, and
+  every probe then passed the length test and the index-0 test and failed
+  only at the last key. Mounting N such rows cost `sum(i)` probes, and
+  N = 300 is a rung this programme benchmarks. Same page, same edges,
+  same DOM, ~150x the entry-lookup work. Hashing the whole sequence makes
+  the bucket a function of the read set rather than of its first element,
+  and `the-bucket-scan-does-not-grow-with-the-number-of-boundaries`
+  holds it there."
+  []
+  (let [n (alength scratch)]
+    (loop [i 0 h 1]
+      (if (== i n)
+        h
+        (recur (inc i)
+               ;; h*31 + hash(k), truncated to int32 — order-sensitive,
+               ;; allocation-free, and the arithmetic is JS-exact.
+               (bit-or 0 (+ (bit-shift-left h 5) (- h) (hash (aget scratch i)))))))))
 
 (defn- drop-entry! [^js entry]
   (let [bucket-key (.-bucketKey entry)]
@@ -658,8 +735,8 @@
   "Ordered pairwise compare of an entry's key array against the scratch.
   Allocates nothing. A false negative — same set, different order — costs
   a second entry and a symmetric difference that removes and re-adds the
-  same edges; it is never a wrong answer, which is why this is not a
-  content hash."
+  same edges; it is never a wrong answer, which is why the hash in
+  [[scratch-bucket-key]] chooses the bucket and this decides the match."
   [^js entry]
   (let [ks (.-keys entry)
         n  (alength ks)]
@@ -678,9 +755,15 @@
   keeps `subscribe`'s identity, so React does not re-subscribe and the
   commit does no work; a miss materialises the key array, the key set and
   the two closures **once**, for every boundary that will ever read that
-  set."
+  set.
+
+  The bucket is [[scratch-bucket-key]]'s hash of the whole read sequence,
+  so what a lookup scans is the set of read sequences that COLLIDE — not,
+  as it once was, the set of live boundaries that happen to share a first
+  key. `drop-entry!`'s rebuild of the bucket vector is O(1) for the same
+  reason."
   []
-  (let [bucket-key (if (zero? (alength scratch)) empty-bucket-key (aget scratch 0))
+  (let [bucket-key (scratch-bucket-key)
         bucket     (get @!entries bucket-key)]
     (or (some (fn [^js e] (when (entry-matches? e) e)) bucket)
         (let [ks    (.slice scratch)
@@ -742,7 +825,15 @@
   mount whatever React did with the renders in between.
 
   The registration holds exactly the cells it acquired, so its cleanup
-  cannot release a successor's after a reap and rebuild."
+  cannot release a successor's after a reap and rebuild.
+
+  **The registration is also the boundary id, and that is what makes the
+  index's edge diff degenerate here** — a fresh id every time, so
+  `record-reads!` always adds the whole read set against an empty held
+  set and never drops anything. A read-set change is this cleanup
+  followed by a fresh call to a different entry's `subscribe`: the
+  edge-set replacement in full, done by the pair rather than by a
+  difference. See the ns docstring, clause (b)."
   [^js entry]
   (fn subscribe [on-store-change]
     (let [reads (.-set entry)
@@ -914,7 +1005,19 @@
   "Every boundary-exclusive token this arm retains, enumerated rather than
   asserted (architecture.md, Arm 1). `:shared` names what is emphatically
   *not* per boundary, because that is the half a heap ladder reads wrong
-  if nobody writes it down."
+  if nobody writes it down.
+
+  **The classification is the ladder's input, so where a token sits is a
+  measurement and not a filing convenience (rf2-2rtt6.46).** The read-set
+  entry sat under `:shared` and does not belong there: an entry is shared
+  only between boundaries whose read SEQUENCES are identical, and the
+  shape the per-read heap ladder is taken on (rf2-2rtt6.34) is the
+  distinct-query one — every row reading its own key, so every row a read
+  sequence of its own and an entry of its own. Filed as `:shared` it
+  under-counted per-boundary retention by one entry per boundary, on
+  exactly the rung being measured, in the direction that flatters this
+  arm. Filed here it over-counts in the coincident-sequence case, which
+  is the direction a candidate's own instrument should err in."
   []
   {:per-boundary
    [{:token :registration
@@ -928,12 +1031,12 @@
     {:token :react/use-sync-external-store
      :what  "React's own hook cell for the one subscription hook"}
     {:token :react/use-context
-     :what  "React's own hook cell for the frame hook"}]
+     :what  "React's own hook cell for the frame hook"}
+    {:token :read-set-entry
+     :what  "one key array, key SET, subscribe and getSnapshot per distinct read SEQUENCE — shared ONLY with boundaries whose sequence is identical, so on the distinct-query rung the ladder is taken on there is one per boundary"}]
    :shared
    [{:token :key-cell
      :what  "one cell + one sub-cache reaction per unique (frame, query), however many boundaries read it"}
-    {:token :read-set-entry
-     :what  "one key array, key set, subscribe and getSnapshot per distinct read SET, shared by every boundary with that set"}
     {:token :scratch
      :what  "ONE module-level array for the whole runtime, reset by overwrite; its capacity is the high-water read count"}
     {:token :frame-ops
@@ -960,6 +1063,19 @@
      :generation (generation)
      :frames     (count @!frame-ops)
      :codec      (codec/cache-sizes)}))
+
+(defn entry-buckets
+  "The read-set entry cache's bucket occupancy — `{:buckets n :max-bucket
+  m}`, where `:max-bucket` is the number of entries a lookup compares
+  against in the worst case.
+
+  The scan's cost is `:max-bucket`, and the point of hashing the whole
+  read sequence is that it stays put while the number of live boundaries
+  grows. Computed on demand from the cache, so nothing on the hot path
+  counts anything. rf2-2rtt6.46."
+  []
+  (let [sizes (map (fn [[_ v]] (count v)) @!entries)]
+    {:buckets (count sizes) :max-bucket (reduce max 0 sizes)}))
 
 (defn residue
   "What must be zero after a clean teardown. `:cell-refs` is the standing

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
@@ -324,6 +324,46 @@
           "and the dropped key has no reader left behind")
       (release))))
 
+(deftest the-wired-path-never-takes-the-diffs-dropping-half
+  (seeded! 3)
+  (testing "rf2-2rtt6.47. HD-002(b) used to be discharged against
+           `record-reads`'s set difference, and this wiring never runs its
+           dropping half: the boundary id is the registration React mints
+           per `subscribe`, so a changed read set arrives as a FRESH id
+           with an empty held set. Every `:edges-changed` the index emits
+           on this path therefore adds everything and drops nothing —
+           asserted, so the docstring's claim is checkable"
+    (let [seen (atom [])]
+      (idx/set-evidence-sink!
+        (fn [e] (when (= :edges-changed (:event e)) (swap! seen conj e))))
+      (try
+        (let [wide  (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
+                                     (str (rt/sub [:dogfood/todo 1]))]))
+              stop  (rt/commit-boundary! wide (fn []))]
+          (is (= 2 (:cell-refs (rt/stats))))
+          ;; React's own sequence when `subscribe` identity moves: the
+          ;; previous cleanup, THEN the new entry's subscribe.
+          (stop)
+          (is (= 0 (:cell-refs (rt/stats)))
+              "every reference is dropped, including the key that did not
+               change — there is no cheap route for `n-1 of n unchanged`")
+          (let [narrow (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
+                stop2  (rt/commit-boundary! narrow (fn []))
+                b      (first (:live (idx/snapshot)))]
+            (is (= 1 (:cell-refs (rt/stats))) "and re-acquired from nothing")
+            (is (= #{(key-of [:dogfood/todo 0])} (idx/edges-of (idx/snapshot) b))
+                "the narrowing landed")
+            (is (empty? (idx/readers-of (idx/snapshot) (key-of [:dogfood/todo 1])))
+                "and it landed through `unmount`'s drop-everything, not
+                 through the difference")
+            (stop2)))
+        (finally (idx/set-evidence-sink! nil)))
+      (is (= 2 (count @seen)) "two commits, two edge-change records")
+      (is (every? (comp empty? :dropped) @seen)
+          (str "and neither dropped anything: " (pr-str (mapv :dropped @seen))))
+      (is (= [2 1] (mapv (comp count :added) @seen))
+          "each one added its whole read set"))))
+
 (deftest reading-one-key-twice-is-one-edge
   (seeded! 3)
   (testing "the buffer is a sequence and the index edge is set-valued; the
@@ -334,6 +374,82 @@
       (is (= 1 (count (reads-of entry))))
       (is (= 1 (:edges (rt/stats))))
       (release))))
+
+;; ---------------------------------------------------------------------------
+;; The read-set entry cache: what a lookup scans, and who an entry belongs to
+;; ---------------------------------------------------------------------------
+
+(defn- render-shared-first-key!
+  "`n` bodies in the shape that used to collapse the whole cache into one
+  bucket: a page-wide key read FIRST, then a per-row key. One `let`
+  binding moved is all it takes for a bulk list to be written this way."
+  [n]
+  (dotimes [i n]
+    (render (fn [_] [:li (str (rt/sub [:dogfood/remaining]))
+                     (str (rt/sub [:dogfood/todo i]))]))))
+
+(deftest the-bucket-scan-does-not-grow-with-the-number-of-boundaries
+  (seeded! 3)
+  (testing "an entry lookup compares against the read sequences that
+           COLLIDE, not against every live boundary that happens to share
+           a first key. Bucketing on `(aget scratch 0)` made an 8-row list
+           an 8-deep scan and a 64-row list a 64-deep one — the whole
+           quadratic in rf2-2rtt6.46 — so the claim is that the depth does
+           not move between the two"
+    (render-shared-first-key! 8)
+    (let [small (rt/entry-buckets)]
+      (is (= 8 (:entries (rt/stats))) "eight distinct read sequences, eight entries")
+      (seeded! 3)
+      (render-shared-first-key! 64)
+      (let [large (rt/entry-buckets)]
+        (is (= 64 (:entries (rt/stats))))
+        (is (= 1 (:max-bucket small)))
+        (is (= (:max-bucket small) (:max-bucket large))
+            (str "the scan is " (:max-bucket large) " deep at 64 rows and "
+                 (:max-bucket small) " deep at 8 — flat in N, which is the "
+                 "acceptance"))
+        (is (= 64 (:buckets large))
+            "and the entries are spread across buckets rather than stacked
+             in one")))))
+
+(deftest a-read-set-entry-belongs-to-its-read-sequence-and-not-to-a-boundary
+  (seeded! 3)
+  (testing "the sharing rule the retained inventory now states: an entry
+           is shared with a boundary whose read sequence is IDENTICAL, and
+           with no other. Two rows reading a per-row key have distinct
+           sequences and therefore an entry each — which is why the entry
+           is filed per-boundary for the heap ladder (rf2-2rtt6.34)"
+    (let [a (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
+          b (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
+          c (render (fn [_] [:li (str (rt/sub [:dogfood/todo 1]))]))]
+      (is (identical? a b) "an identical sequence shares one entry")
+      (is (not (identical? a c)) "a per-row key does not")
+      (is (= 2 (:entries (rt/stats))))))
+  (testing "and the ordered compare is a false negative, never a wrong
+           answer: the same SET read in a different ORDER takes a second
+           entry with the same key set"
+    (seeded! 3)
+    (let [ab (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))
+                              (str (rt/sub [:dogfood/remaining]))]))
+          ba (render (fn [_] [:li (str (rt/sub [:dogfood/remaining]))
+                              (str (rt/sub [:dogfood/todo 0]))]))]
+      (is (not (identical? ab ba)))
+      (is (= (reads-of ab) (reads-of ba)) "same edges, so the answer is right")
+      (is (= 2 (:entries (rt/stats))) "and the cost is one extra entry"))))
+
+(deftest the-retained-inventory-files-the-entry-where-a-heap-ladder-must-count-it
+  (testing "rf2-2rtt6.46: `:read-set-entry` under `:shared` under-counted
+           per-boundary retention by one entry per boundary on exactly the
+           distinct-query rung rf2-2rtt6.34 is taken on"
+    (let [inv    (rt/retained-inventory)
+          per-b  (into #{} (map :token) (:per-boundary inv))
+          shared (into #{} (map :token) (:shared inv))]
+      (is (contains? per-b :read-set-entry))
+      (is (not (contains? shared :read-set-entry)))
+      (is (contains? shared :key-cell)
+          "the key cell IS shared — one per unique (frame, query) however
+           many boundaries read it — so this is a classification and not a
+           blanket move"))))
 
 ;; ---------------------------------------------------------------------------
 ;; The commit path: write -> dirty keys -> index -> dirty boundaries

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index.cljs
@@ -139,7 +139,20 @@
   conditional read) an edge-set diff rather than a bookkeeping ledger.
 
   A boundary that is not live is ignored. See the namespace docstring:
-  an abandoned render must not resurrect an unmounted boundary's edges."
+  an abandoned render must not resurrect an unmounted boundary's edges.
+
+  **Which half of the difference a caller exercises depends on how
+  durable its boundary ids are, and that is worth knowing before reading
+  a discharge against this function (rf2-2rtt6.47).** A caller that
+  re-runs a body under a STABLE id drives both halves. Arm 1's id is the
+  registration object React mints per `subscribe`, so a changed read set
+  arrives here as a fresh id with `held = #{}`: `added` is the whole read
+  set, `dropped` is always empty, and the narrowing is [[unmount]]'s
+  drop-everything on the previous registration. Law 4 is therefore proved
+  here and, on that wiring, delivered by the `unmount`/`mount` pair. The
+  general form stays because this is the shared front half and because
+  narrowing it to one caller's wiring would make a second `record-reads`
+  for the same id leak edges silently."
   [idx boundary-id read-sub-keys]
   (if-not (contains? (:live idx) boundary-id)
     idx


### PR DESCRIPTION
Three findings from the adversarial review of the landed Arm 1 code. Surface B
only; no candidate ledger, no compiler, no analyzer, no dual mode, no
ViewCell-class object graph. The shell is untouched — still `useContext` +
`useSyncExternalStore`, still `subscribe` closing over the read set and nothing
else. Rebased onto #7327 and #7329.

## rf2-2rtt6.48 — a residue gate that can go red

`mount/release!` called `rt/reset-runtime!` and the two DOM residue gates
asserted `{:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}` on the line
after — against a table the reset had just emptied. They answered zero however
teardown had gone, and **no suite witnessed React's own cleanup releasing
anything**, which is the path production runs and the path a re-subscribe
exercises on every read-set change.

`release!` splits. `unmount!` unmounts the root and detaches its container and
touches nothing the runtime holds; `release!` is that plus the reset, so every
fixture caller is unchanged. The gates now take `unmount!`, wait one macrotask
for the cell and entry reapers (that grace period is deliberate, not slack),
assert, and reset afterwards. Both suites move to the map-form fixture, because
a reaper horizon is not observable inside a synchronous test body.

`the-residue-reading-can-answer-false` stays in the suite: two roots, one
unmounted, and the reading is **not** zero — the property the old ordering
lacked, since `release!` would have reported zero there with a whole screen
still mounted.

The node-seam witness through `commit-boundary!` (`runtime_cljs_test`) is
untouched. It was always real; it just is not React.

## rf2-2rtt6.46 — the entry cache, and a misfiled token

**The scan.** The read-set entry cache bucketed on `(aget scratch 0)`. A row
body reading a page-wide key before its per-row key — one `let` binding moved —
put every live row's entry in ONE bucket, where every probe passed the length
test and the index-0 test and failed only at the last key. The bucket is now an
order-sensitive hash of the whole read sequence. It **selects the bucket and
never decides a match**: `entry-matches?` still compares every key pairwise, so
a collision costs a second entry and never a missing edge — which is the
property the design record rejected a content hash to protect, and the reason
that rejection does not apply to a hash sitting in *front* of the compare. Every
sub-key on the scratch has already been hashed this render by the `!cells`
lookup, so the fold is cached-hash reads and integer ops with no allocation;
the steady-state hit path still allocates zero bytes. `drop-entry!`'s bucket
rebuild collapses to O(1) for the same reason.

**The classification.** `:read-set-entry` sat under `:shared` and does not
belong there. An entry is shared only between boundaries whose read *sequences*
are identical, and the per-read heap ladder (rf2-2rtt6.34) is taken on the
distinct-query rung, where every boundary has one of its own. Filed as
`:shared` it under-counted per-boundary retention by one entry per boundary, on
exactly the rung being measured, in the direction that flatters this arm. It is
now `:per-boundary`, which over-counts in the coincident-sequence case — the
direction a candidate's own instrument should err in. `:key-cell` stays
`:shared`; this is a classification, not a blanket move.

## rf2-2rtt6.47 — the discharge, restated against the path that runs

HD-002(b) was discharged against `front.sub-index/record-reads`'s set
difference. **This wiring never takes its dropping half.** The boundary id is
the registration object React mints inside `subscribe`, so a changed read set
means a new entry, a new `subscribe`, a new registration and therefore a new
id; `index/mount!` installs `#{}` for it, and the `record-reads!` that follows
sees `held = #{}` every time. The narrowing is the *previous* registration's
cleanup calling `index/unmount!`.

Verdict: **the diff is not dead code and is not deleted.** Its adding half runs
on every commit; only the dropping half is unreachable from here. `record-reads`
is the shared front half's general, law-bearing operation, and narrowing it to
one caller's wiring would make a second `record-reads` for the same id leak
edges silently. What is corrected is the *discharge*: clause (b) is now stated
against the `unmount-all` + `mount-all` pair that runs, and priced honestly. For
an `n`-read boundary with one key changed that is `n` releases (including the
`n-1` that did not change), up to `n` armed reapers, an entry miss, `n`
re-acquisitions and two whole-map rebuilds of `:sub->bs`. **There is no cheap
route for "19 of 20 keys unchanged."** The judgement page's "an identity change
and one replacement" is corrected to say so.

A durable per-boundary id would make the difference live. It is **unavailable at
this arm's fences rather than merely unbuilt**, and that is the finding rather
than a deferral: it has to survive a re-subscribe, so it cannot live on the
registration; the shell has no per-instance storage that is not a hook, and a
third hook breaks the HD-020 budget the ledger witness enforces; and threading
one into `subscribe` would end `subscribe`'s property of closing over the read
set and nothing else. Buying the diff costs the two properties the arm exists to
demonstrate.

`the-wired-path-never-takes-the-diffs-dropping-half` pins the claim through the
runtime's own wiring — every `:edges-changed` the index emits on this path adds
its whole read set and drops nothing — and asserts the price at the reference
level (`cell-refs` 2 → 0 → 1 across a one-key narrowing). `front/sub_index.cljs`
now says which half a caller exercises and why, so the tested algebra and the
running path stop diverging.

## Quality gates

Every gate foreground, to completion, worktree-local logs, exit codes echoed.
The suite numbers under **The suites** are taken at this PR's head, after the
rebase onto `00bb0c82e5`. The three mutation runs below predate that rebase and
are labelled where they do — the rebase pulled main's additions to
`controlled_restore_dom_cljs_test.cljs`, which is why the browser lane now
counts 907 tests where run C counted 901.

### The one CI red — `JVM core`, and why nothing here changed to clear it

Run 30655577476, job 91239771476, one failure in 2198 tests:

```
FAIL in (jvm-provenance-entry-is-weak-and-expunged-when-its-throwable-dies)
     (observation_port_cljs_test.cljc:3515)
"the cleared entry was expunged — private storage returned to baseline"
actual: false
```

**It cannot be this PR.** The diff is six `.cljs` files under
`implementation/freehand/test/re_frame/bench/hicasso/**` plus one `.md`.
`implementation/core`'s `:test` alias puts `src`, `test`, eight `examples/*`
roots and seven sibling artefacts on the classpath — never
`implementation/freehand` — and a JVM Clojure runner cannot load `.cljs`
regardless. There is no path from the diff to that suite.

**Nor a collision with main.** `origin/main` advanced 30 commits since the
branch point, and the entire delta is `.beads/issues.jsonl`, three
`docs/design/hicasso/` pages and `controlled_restore_dom_cljs_test.cljs`.
Nothing under `implementation/core`. Rebased onto `00bb0c82e5`, conflict-free.

**It is a flake — the mechanism, not the label.** The failing assertion polls a
*process-wide* count for strict equality:

```clojure
(cond (= baseline (.size m)) true
      (>= i 40)              false
      :else (do (System/gc) (System/runFinalization) (recur (inc i))))
```

`m` is the shared `java.util.HashMap` at
`(:by-throwable @#'obs/provenance-storage)`, keyed by weak identity keys and
reclaimed only when `expunge-stale-provenance!` polls its `ReferenceQueue`.
`baseline` is `.size` sampled after ONE `System.gc()` and one drain. But a
Reference is *cleared* during GC and *enqueued* afterwards, asynchronously, by
the ReferenceHandler thread — so `baseline` over-counts by whatever backlog is
still pending, and that backlog grows with machine load. Nothing inside the loop
ever adds an entry (`source-covered-always-on?` only reads and drains), so
`.size` is monotonically non-increasing: the instant a pending sibling lands,
`.size` falls *below* `baseline`, the equality can never hold again, and the
loop times out into `false`. The test reddens *because* unrelated collection
succeeded.

Note what did **not** fail on that same red run: the preceding
`(is (gc-until-cleared? t-ref))` passed, so the referent was collected and
storage retained it via neither key nor value. The property the test is named
for held; only the global-count equality broke.

Evidence it is non-deterministic, at this head:

| Execution | Result |
|---|---|
| `clojure -M:test` in `implementation/core`, full suite | green ×4 — 2198 tests, 11341 assertions, exit 0 each |
| `clojure -M:test -n re-frame.observation-port-cljs-test`, 8 JVMs **concurrently**, to starve the ReferenceHandler | green ×8 — 94 tests, 666 assertions, exit 0 each |

Instrumented (temporarily; reverted, and the tree is clean), `baseline` reads 0
and the pre-loop size 1 on every local run — an idle box carries no pending
backlog, which is precisely why it cannot reproduce here and does on a shared
runner.

**Nothing was weakened to clear this.** No tolerance widened, no assertion
deleted, no test skipped, no `--admin`. This branch does not touch the core test
at all: it is a different artefact, and `implementation/core/test/**` is a
surface the audit loop works actively. The defect is filed as **rf2-8vvdo**,
carrying the diagnosis above and a fix that is *stronger* rather than weaker —
`.size` is `baseline+1` at attestation and can only decrease, so
`(<= (.size m) baseline)` states exactly "the new entry was expunged" without
coupling the claim to unrelated entries.

### rf2-2rtt6.48 — the mutation proof

The fault: delete `(doseq [cell cells] (release-cell! cell))` from the cleanup
`make-subscribe` returns, so React's own teardown releases no subscription
reference.

| Run | Fault | Gates | `npm run test:browser` | Result |
|---|---|---|---|---|
| A | planted | repaired | **EXIT=1** | 3 failures — `the-collector-screen-leaves-no-residue`, `the-grouped-screen-leaves-no-residue`, `the-fenced-boundary-leaves-no-residue` |
| B | planted | pre-repair (`release!` before the assertion) | **EXIT=0** | 899 tests, 5700 assertions, 0 failures — **the old gate cannot fail** |
| C | reverted | repaired | **EXIT=0** | 901 tests, 5705 assertions, 0 failures |

Run B is the point: the same defect, the same suite, green. That is what "a gate
nobody has watched fire is not evidence" looks like in exit codes.

(Runs A/B/C were measured before the rebase, hence the 899/901 counts against
the post-rebase 907. The mutation was re-planted only for the experiment and is
not in the branch; run C is the reverted state, and the post-rebase browser lane
in **The suites** below is the current standing evidence.)

### rf2-2rtt6.46 — the scan, measured

Same discipline. Planting the pre-fix first-sub-key bucketing against the new
witness reds `the-bucket-scan-does-not-grow-with-the-number-of-boundaries`
(`npm run test:cljs`, **EXIT=1**, 3 failures), and the failure output carries the
measurement:

```
expected: (= 1 (:max-bucket small))                      actual: (not (= 1 8))
the scan is 64 deep at 64 rows and 8 deep at 8 — flat in N, which is the acceptance
expected: (= (:max-bucket small) (:max-bucket large))    actual: (not (= 8 64))
expected: (= 64 (:buckets large))                        actual: (not (= 64 1))
```

64 read sequences, **one** bucket, a 64-deep scan — linear in the number of live
boundaries, so mounting N rows costs `sum(i)` probes (44,850 at the K=300 rung
this programme benchmarks). With the fix: 64 buckets, `:max-bucket` 1 at both 8
and 64 rows. So the scan was not optimised on principle — it was measured first,
and the measurement is now a test that reds if the fix is undone.

### The suites

| Gate | Command | Exit |
|---|---|---|
| JVM core (the gate CI reddened) | `clojure -M:test` in `implementation/core` | **0** — 2198 tests, 11341 assertions, 0 failures, 0 errors |
| CLJS node | `npm run test:cljs` | **0** — 12195 tests, 60843 assertions, 0 failures, 0 errors |
| CLJS browser | `npm run test:browser` | **0** — 907 tests, 5735 assertions, 0 failures, 0 errors |
| clj-kondo, at CI's pin | `clj-kondo --parallel --fail-level error --lint …` at **v2026.04.15** (fetched — the local npm binary is v2025.10.23) | **0** — `errors: 0, warnings: 4526`. The one hicasso finding is a pre-existing `info` line in `front/codec.cljs`, untouched here |
| fast-PR spine | `scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine` |
| doc slugs | `python scripts/check_doc_slugs.py` | **0** |

### The TESTING.md matrix I derived

The diff is `implementation/freehand/test/re_frame/bench/hicasso/**` (six CLJS
files) plus one page under `docs/design/hicasso/studio/`.

- **`cljs_node_test`** — a `:node-test` surface changed, and `-dom-cljs-test`
  also matches the `cljs-test$` regexp, so both DOM suites run there too as
  stated skips. Run.
- **`cljs_browser`** — a `:browser-test` surface changed, and .48 is a real-DOM
  question. Run, three times over (the mutation table).
- **lint** — `implementation/**` changed. clj-kondo run at CI's pin, errors 0.
  Splint is not installed locally and is CI's arm; the diff adds no new
  top-level form shapes, only fn/deftest bodies and docstrings.
- **`jvm-freehand`** — the changed files are `.cljs` and unloadable by the JVM
  lane, but the spine's JVM tier still selected `implementation/freehand`'s
  suite because the diff touched that tree, and it ran green (the spine's
  "NOT RUN" line names the untouched artefacts; freehand is not among them).
- **`cljs_prod`** — armed by `implementation/freehand/**`, so CI will run it.
  The changed tree is bench/test code no production build requires (HD-017 keeps
  it off every `implementation/*/src` path), so it has no release-probe surface.
- **`freehand_evidence_elision` / `freehand_reachability`** — explicitly *not*
  armed by the rest of `implementation/freehand/**`. Correctly out of scope.

### Docs coverage, stated exactly

`mkdocs build --strict` does **not** cover `docs/design/**` — `mkdocs.yml`'s
`exclude_docs` keeps `design/hicasso/` off the site — so it is not the gate for
this edit and is not claimed as one. (The spine soft-skipped it anyway: mkdocs is
not on this machine's PATH.) `scripts/check_doc_slugs.py` **does** validate that
tree's markdown link targets and heading anchors; it runs in the fast-PR spine as
the "docs corpus anchor validator" and in `docs.yml`, and it is green. What it
does not cover I checked by hand:

- **Tables** — the edit adds and removes **zero** table rows
  (`git diff origin/main HEAD -- <page> | grep -c '^+.*|'` → 0). The page's five
  tables are untouched and internally consistent: 3 columns at L47–50 and
  L79–85, 2 columns at L111–116, L269–273 and L333–336, each header, separator
  and row at the same count.
- **Headings and nav** — no heading added, removed or renamed, so no anchor
  moved, and there is no nav entry to update because the tree is excluded from
  the site.

### The fences held

- **Hook budget** — the shell is not touched. `shell-hook-ledger` still declares
  two, and `arm1_hook_ledger_dom_cljs_test` counts them at React's own
  dispatcher at 1/7/20 reads. Green in run C.
- **`subscribe` closes over the read set and nothing else** — unchanged, and it
  is precisely why rf2-2rtt6.47 lands as a finding rather than as a durable-id
  implementation.
- **The tripwire** — nothing added is keyed by a render, an attempt, a lane or a
  generation. The entry cache is keyed by read-set content, now more literally
  than before: the bucket is a hash *of that content*.

