### PR TITLE
hicasso: one canonical structural-slot filter, and a variadic event wrapper (rf2-2rtt6.36, .37, .38, .35)

### DIFF
--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -157,6 +157,12 @@ crosses under the name it was written as. And an element's own classes belong on
 the **tag**, where the shorthand merge composes them with a forwarded `:class`
 rather than one silently replacing the other.
 
+Both halves of the law are enforced on the **slot the key is emitted into**, not on
+the key itself. Prop names reach React through one canonicalisation, so `"key"`,
+`:x/key` and `'key` are all React's key, and `:onInput` is the same handler as an
+owned `:on-input` — a remainder cannot reach either by changing how it spells them
+(HD-023(c′)).
+
 ## The controlled-input door
 
 Controlled text rides the synchronous door: dispatch → drain/commit → re-render

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -453,6 +453,13 @@ rather than passing it to React as an opaque value. That is the whole ruling —
 one refusal branch and one error id. **Not in scope, explicitly:** a behaviors
 registry, a `:timing` option, a commands roster, or any host-ownership subsystem
 in v0.
+The refusal is taken **at the canonical ref slot**, not at the key `:ref`
+(HD-023(c′)): the codec accepts string, symbol and namespaced prop spellings and
+emits them all under React's one `ref`, so a check that reads `(:ref props)` is a
+check `"ref"` and `:x/ref` walk past — carrying the opaque array to React, which
+ignores it in silence, which is the ref-that-never-fires the reservation exists to
+replace. The ref position's exclusion from callback lowering is taken on the same
+slot, for the same reason and at the same cost: the walk has the value already.
 **Rationale.** `:ref` is the one place Hicasso is planned to be *less*
 data-oriented than the substrate it replaces: the predecessor's registered
 behaviors keep the use site as data (`[v/behavior {:use autosize :target … :config
@@ -509,6 +516,20 @@ theming.
 (c) `:key` and `:ref` are **never taken from a `:&` map**. They address the element
 the caller wrote, not the one it is forwarding onto; a remainder is about
 attributes.
+(c′) **Both halves of the law are enforced on the CANONICAL SLOT, never on the map
+key.** The codec accepts a prop key written as a keyword, a string, a symbol or a
+namespaced keyword, in kebab or in camel, and emits them all under one React name —
+so `"key"`, `:x/key` and `'key` are all React's key, and `:onInput` and `:on-input`
+are one handler. A deny written against the raw key denies one spelling and lets the
+rest through: the structural slots become reachable from a remainder, and an owned
+literal shares its slot with an alias that survived the merge as a second map entry,
+leaving *which one React sees* to the order the props map happens to iterate in. An
+unconditional law cannot be map-order-dependent, so the deny set is the two
+structural slots seeded with the slot of every literal the element writes, and the
+resolver is the codec's own emitted prop name (`canonical-slot`) — the thing a deny
+asks is the thing the emitter will do. That resolver must be a pure function of the
+key, which is why a string prop name does not share the prop-name cache with the
+keyword of the same name.
 (d) The **same key and the same law hold at a crossing** (a Hicasso view head, a
 `defhost` head, `[:>]`). `:&` is merged *before* any conversion, and the conversion
 that follows is the position's own — so a forwarded `:className` crosses under the
@@ -568,6 +589,13 @@ the runtime already knows every position it walks:
 A Hicasso **view's** props map is not a position — it is data in transit, exactly
 as an intent vector is. The view puts the value on an element and *that* position
 lowers it.
+**The event wrapper forwards every argument its invoker passes.** A native DOM
+event position calls with one argument and that is the overwhelming case, but the
+same wrapper serves a `defhost` `:callbacks` entry declared `:event`, and a foreign
+component's live invoker calls with whatever its own contract says —
+`(on-change value event)`, `(on-select item index)`. A wrapper fixed at one
+argument would silently drop the rest, or raise an arity error naming nothing the
+author wrote, against a form whose parameter vector is arbitrary by construction.
 **`raw-fn` is NOT v0**, and costs nothing to omit: the codec already passes
 functions to React by identity, deliberately, so that `React.memo` and every
 downstream bail-out comparing handler identity keep working. The behaviour the
@@ -616,7 +644,14 @@ child is in that phase:
 ```
 
 The override wins over the node's own literals (that is what an override is), and
-`:key` and `:ref` are never taken from it — the same law `:&` carries (HD-023).
+`:key` and `:ref` are never taken from it — the same law `:&` carries, through the
+same canonical-slot filter (HD-023(c′)). Sharing that filter is the point rather
+than a convenience: an override carrying `"key"` or `:x/key` survives a raw
+`#{:key :ref}` dissoc and canonicalises onto React's key, which would remount the
+very node presence exists to retain, at the one moment it must not be — mid-exit,
+mid-animation. Retained key identity is therefore pinned by construction: the only
+`:key` in the merged attributes is the one the child is retained under, because
+nothing else can reach that slot in any spelling.
 
 **(2) When the presence child IS a boundary, the phase arrives as an ORDINARY
 PROP** — `[toast-card {:key id :toast t :rf/phase :unmounting}]`. An attribute

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -92,6 +92,12 @@ not the call.
 
 You never pick a form. There is one, and where you put it is the decision.
 
+**Write the parameter vector the caller actually calls with.** A DOM event position
+hands you one argument, so `(h/fn [e] …)` is what you will write almost every time
+— but at a `defhost` callback the declaration named `:event`, the arguments are the
+foreign component's, and it may pass two or three. Take them all: they arrive
+exactly as that library sends them.
+
 One thing the policy defaults above do *not* do: **`h/fn` at `:on-submit` does not
 auto-prevent.** That default exists because an intent vector never sees the event,
 so the runtime has to decide for it. A callback is handed the event, so the event

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -141,6 +141,12 @@ literal `:class` wins outright like any literal — so put your element's own cl
 on the tag (`[:input.form-control {:& attrs}]`) and the shorthand merge combines
 them with whatever the caller brought.
 
+**Spelling it differently does not get round it.** The law is enforced on the prop
+slot React ends up with, not on the key as written, so a remainder carrying
+`"key"`, `:x/ref` or an `:onInput` against your own `:on-input` reaches none of
+them. You do not have to think about this; it is here so you know there is nothing
+to think about.
+
 ## Resets are by revision, never by value
 
 When you need to force a field back to a value — a form reset, a "revert" button, a

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -219,6 +219,11 @@ data spelling of exactly the pattern above — a registered id and a config map,
 with the imperative code in a registry instead of in your view — and v0 claims it
 now so that landing it later is not a breaking change. Today, write the function.
 
+The refusal is on the ref **slot**, so it holds however you spell the key —
+`{"ref" […]}` and `{:x/ref […]}` are refused too, and name the spelling you wrote.
+An unrefused one would have been the worst of both: React ignores an array at
+`ref`, in silence, so you would be debugging a ref that never fires.
+
 **And the honest limit on what that later spelling could ever be.** A React ref
 callback fires on **attach** and on **detach**. It does **not** fire on **config
 change**. There is no third call, and no amount of design gets one: passing a

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence_dom_cljs_test.cljs
@@ -77,6 +77,29 @@
                                                 :aria-hidden true}}
       (:message t)])])
 
+(def ^:private !ref-fired
+  "Every node a ref written in a phase override was handed. It must stay
+  empty: a ref addresses node identity, and a phase override is about
+  appearance."
+  (atom []))
+
+(defview hostile-tray
+  "The same tray, with an unmounting override that reaches for both
+  structural slots in spellings a raw `#{:key :ref}` dissoc does not see.
+  `\"ref\"` and `:x/key` are the codec's own accepted spellings — it takes
+  string, symbol and namespaced prop keys and emits them all under one
+  React name — so this is the shape the deny has to be written against."
+  [_]
+  [presence {:timeout-ms timeout-ms}
+   (for [t (rt/sub [:toasts/visible])]
+     [:div.toast {:key (:id t)
+                  :data-id (:id t)
+                  :re-frame.hicasso/unmounting
+                  {:class "toast--exit"
+                   "ref"  (fn [node] (swap! !ref-fired conj node))
+                   :x/key (str "stolen-" (:id t))}}
+      (:message t)])])
+
 (def ^:private two [{:id 1 :message "Saved"} {:id 2 :message "Copied"}])
 (def ^:private one [{:id 1 :message "Saved"}])
 
@@ -127,6 +150,39 @@
               (is (nil? (.getAttribute back "aria-hidden")))
               (is (not (.contains (.-classList back) "toast--exit")))
               (is (= 2 (toast-count handle)))))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 1b — a hostile override reaches neither structural slot on the real node
+;; ---------------------------------------------------------------------------
+
+(deftest a-hostile-override-reaches-neither-structural-slot-on-the-retained-node
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (reset! !ref-fired [])
+      (fresh! two)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [hostile-tray {}])]
+        (try
+          (let [before (node handle 2)]
+            (is (some? before))
+            (is (= [] @!ref-fired) "nothing attached while the toast was present")
+            (mount/dispatch! handle [:toasts/set one])
+            (is (= 2 (toast-count handle)) "retained, as ever")
+            (let [during (node handle 2)]
+              (is (.contains (.-classList during) "toast--exit")
+                  "the appearance half of the override still lands — this is a
+                   deny on two slots, not a rejection of the override")
+              (is (= [] @!ref-fired)
+                  "and no ref was handed the retained node. React invokes a ref
+                   in the commit phase, so an override that reaches this slot
+                   hands a live DOM node to code the boundary never inspected —
+                   the exact thing `:ref` is excluded from a merge for")
+              (is (identical? before during)
+                  "the retained node is the SAME element. Its identity is the
+                   key the machine retains it under, and nothing in an override
+                   can move that in any spelling — a remount here would restart
+                   the exit of a node that is mid-animation")))
           (finally (mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -87,7 +87,19 @@
 
   Both are attribute *keys*, not forms — so the merge survives into a
   structural test and into tooling, and neither adds a public concept in
-  the K5 sense."
+  the K5 sense.
+
+  ## One canonical slot, and every rule asks it
+
+  This codec accepts a prop key written as a keyword, a string, a symbol
+  or a namespaced keyword, in kebab or in camel, and emits them all under
+  **one** React name. So every rule about *which* attribute a value is —
+  the owned-literal deny, the two structural exclusions, the `:ref`
+  reservation, and the ref position's exclusion from intent lowering —
+  is asked of [[canonical-slot]], the slot the value will actually be
+  emitted into, and never of the key it happened to be written as. A rule
+  written against the raw key is a rule that `\"key\"`, `:x/ref` and
+  `:onInput` walk straight past."
   (:require [clojure.string :as str]
             [re-frame.bench.hicasso.front.intent :as intent]
             ["react" :as react]))
@@ -171,20 +183,33 @@
 (defn- capitalize [s]
   (if (< (count s) 2) (str/upper-case s) (str (str/upper-case (subs s 0 1)) (subs s 1))))
 
+(def ^:private react-renames
+  "The three attribute names React spells differently from HTML. They are
+  the RULE rather than a memo of one, so they hold for every spelling of
+  the same attribute: `:class`, `:className`, `\"class\"` and `:x/class`
+  all name the one slot React calls `className`."
+  {"class" "className" "for" "htmlFor" "charset" "charSet"})
+
 (defn prop-name
-  "The React prop name for a hiccup prop key. `:on-click` → `\"onClick\"`;
-  `:aria-label` and `:data-index` pass through; a `--custom-property` is
-  preserved verbatim."
+  "The React prop name for a hiccup prop key — which, because it is the
+  name the codec emits the value under, is that key's CANONICAL SLOT.
+  `:on-click` → `\"onClick\"`; `:aria-label` and `:data-index` pass
+  through; a `--custom-property` is preserved verbatim; a string is
+  already a React name and is taken verbatim apart from the three renames
+  above.
+
+  **A pure function of the key**, which is what [[canonical-slot]] rests
+  on. A slot that depended on what the build happened to have converted
+  earlier would make the owned-literal law depend on render order."
   [k]
-  (if (string? k)
-    k
-    (let [n (name k)]
-      (if (str/starts-with? n "--")
-        n
-        (let [[start & parts] (str/split n #"-")]
-          (if (dont-camel-case start)
-            n
-            (apply str start (map capitalize parts))))))))
+  (let [n (name k)]
+    (or (react-renames n)
+        (if (or (string? k) (str/starts-with? n "--"))
+          n
+          (let [[start & parts] (str/split n #"-")]
+            (if (dont-camel-case start)
+              n
+              (apply str start (map capitalize parts))))))))
 
 (def ^:private prop-cache
   (doto #js {}
@@ -193,10 +218,23 @@
     (unchecked-set "charset" "charSet")))
 
 (defn cached-prop-name
-  "[[prop-name]] behind the codec-work cache (HD-004)."
+  "[[prop-name]] behind the codec-work cache (HD-004).
+
+  **Only a keyword or a symbol is cached**, which is the donor's shape and
+  is load-bearing here. The cache is keyed by `(name k)` while
+  [[prop-name]] answers a STRING differently from the keyword of the same
+  name — a string is already a React name, so `\"on-input\"` stays
+  `\"on-input\"` where `:on-input` becomes `\"onInput\"`. Sharing one cache
+  entry between them lets either poison the other: the first
+  `{\"on-input\" f}` rendered anywhere would answer every later
+  `:on-input` with `\"on-input\"` for the life of the build, silently
+  emitting every handler written the taught way into a slot React ignores
+  — and, worse, would make [[canonical-slot]] answer differently
+  depending on what had rendered first, which is exactly the order
+  dependence the owned-literal law exists to remove."
   [k]
-  (if-not (or (keyword? k) (symbol? k) (string? k))
-    k
+  (if-not (or (keyword? k) (symbol? k))
+    (if (string? k) (prop-name k) k)
     (let [n (name k)]
       (if (reserved-cache-keys n)
         (prop-name k)
@@ -205,6 +243,64 @@
           (let [converted (prop-name k)]
             (unchecked-set prop-cache n converted)
             converted))))))
+
+;; ---------------------------------------------------------------------------
+;; The canonical structural-slot filter (rf2-2rtt6.36)
+;; ---------------------------------------------------------------------------
+
+(def canonical-slot
+  "**The one slot resolver.** The React prop slot a hiccup attribute key
+  actually emits into — which is [[cached-prop-name]] itself, and that
+  identity is the whole mechanism: the thing a deny asks is the thing the
+  emitter will do.
+
+  A props map reaches React through exactly one canonicalisation, so a
+  rule written against the RAW map key is a rule that any other spelling
+  of the same slot walks straight past. `\"key\"`, `:x/key` and `'key` are
+  all React's key; `:on-input` and `:onInput` are one handler; `:class`,
+  `:className` and `\"class\"` are one `className`. Every deny, every
+  dissoc and every check in this codec and in
+  [[re-frame.bench.hicasso.front.presence]] asks THIS, and never the key
+  it was written as."
+  cached-prop-name)
+
+(def structural-slots
+  "The two React slots that address the ELEMENT rather than its
+  attributes. `key` is React's own identity contract and `ref` is
+  HD-016's node handle; neither is an attribute, and neither is ever
+  taken from a map that is *about* attributes — a `:&` remainder
+  ([[merge-caller]]) or a presence phase override
+  ([[re-frame.bench.hicasso.front.presence/with-phase]]).
+
+  Held as canonical SLOTS rather than as keys, because the spelling is
+  exactly what a hostile or careless map would vary."
+  #{"key" "ref"})
+
+(def ^:private ref-slot "ref")
+
+(defn structural-slot?
+  "Does `k` — in any spelling — land on `key` or `ref`?"
+  [k]
+  (contains? structural-slots (canonical-slot k)))
+
+(defn- without-slots
+  "`m` minus every key whose canonical slot is in `denied`. Returns `m`
+  itself, by identity, when nothing is denied — which is the ordinary
+  case, so the filter allocates nothing on a map that was already legal."
+  [m denied]
+  (reduce-kv (fn [acc k _] (if (denied (canonical-slot k)) (dissoc acc k) acc)) m m))
+
+(defn without-structural
+  "`m` with every structural slot removed, in every spelling."
+  [m]
+  (without-slots m structural-slots))
+
+(defn- denied-slots
+  "The slots a `:&` remainder may not reach: the two structural ones, plus
+  the slot of every literal the element wrote. One set, so one rule states
+  both halves of the owned-literal law ([[merge-caller]])."
+  [owned]
+  (reduce-kv (fn [denied k _] (conj denied (canonical-slot k))) structural-slots owned))
 
 ;; ---------------------------------------------------------------------------
 ;; Classes and the shorthand merge
@@ -276,14 +372,6 @@
   tooling; and it cannot collide with a real DOM attribute."
   :&)
 
-(def merge-structural-keys
-  "Never taken from a `:&` map. `:key` and `:ref` address the ELEMENT the
-  caller wrote, not the one it is forwarding onto — React's key contract
-  and HD-016's ref rule are both about node identity, and a remainder map
-  is about attributes. Dropping them is what makes a hostile or careless
-  remainder unable to reach either."
-  #{:key :ref})
-
 (defn merge-caller
   "Fold a `:&` remainder into the attribute map, under **the owned-literal
   law, unconditionally**: the literal keys written in the map ALWAYS win.
@@ -302,9 +390,21 @@
   the literal**, which is the honest way round: the dangerous default is
   the other one.
 
+  **The law is enforced on the CANONICAL SLOT, never on the map key.**
+  The deny set is [[structural-slots]] seeded with the slot of every
+  literal the element writes, so one rule says both halves of the law:
+  nothing in a remainder may reach `key` or `ref`, and nothing in a
+  remainder may reach a slot an owned literal already claims — however
+  either is spelled. Without that, `:onInput` against an owned
+  `:on-input` survives the merge as a distinct map key, both land on
+  React's one `onInput` slot, and which handler wins is decided by the
+  order the props map happens to iterate in. An unconditional law cannot
+  be map-order-dependent, so the check is the emitted slot
+  ([[canonical-slot]]) or it is not a law.
+
   Absent — the overwhelming case — this is one `contains?` and the map
-  comes back by identity, allocating nothing. Present, it is one `merge`
-  in the direction that makes the law true by construction."
+  comes back by identity, allocating nothing. Present, it is one filter
+  and one `merge` that, the filter having run, is a plain union."
   [props]
   (if-not (contains? props merge-key)
     props
@@ -312,7 +412,7 @@
           owned  (dissoc props merge-key)]
       (cond
         (nil? caller) owned
-        (map? caller) (merge (apply dissoc caller merge-structural-keys) owned)
+        (map? caller) (merge (without-slots caller (denied-slots owned)) owned)
         :else
         (fail! :rf.error/hicasso-merge-not-a-map
                'front.codec/merge-caller
@@ -336,19 +436,26 @@
   value-space is claimed *now*, so the imperative escape can become data
   later without minting a second attribute name — and so that an author
   who writes tomorrow's spelling today learns it from a diagnostic rather
-  than from a ref that never fires."
-  [props]
-  (when (vector? (:ref props))
+  than from a ref that never fires.
+
+  Called from inside [[convert-props]]'s single walk, at the position
+  whose CANONICAL SLOT is `ref` — not at the key `:ref`. This codec
+  deliberately accepts string, symbol and namespaced prop spellings and
+  emits them all under one React name, so a check that reads `(:ref
+  props)` is a check `\"ref\"` and `:x/ref` walk past, on their way to
+  React with the opaque value the reservation exists to stop."
+  [k v]
+  (when (vector? v)
     (fail! :rf.error/hicasso-ref-vector-reserved
            'front.codec/convert-props
-           (str "A vector at :ref is RESERVED and is not a v0 surface. "
+           (str "A vector at " (pr-str k) " is RESERVED and is not a v0 surface. "
                 "`{:ref [registered-id config]}` is the reserved spelling for "
                 "registered node ownership; v0 accepts a callback ref (a "
                 "function) only. Write the function, or move the mechanic to "
                 "an event and an effect.")
            :use-a-callback-ref-or-an-effect
-           {:ref (:ref props)}))
-  props)
+           {:ref v :position k}))
+  v)
 
 (defn convert-props
   "One pass over the attribute map: fold a `:&` remainder under the
@@ -367,13 +474,22 @@
   `:class` on the way through and hands the wrong name onward. It also
   puts a forwarded `:class` into the shorthand merge, so
   `[:input.form-control {:& caller}]` composes `\"form-control\"` with the
-  caller's classes instead of one silently replacing the other."
+  caller's classes instead of one silently replacing the other.
+
+  The `:ref` reservation and the ref position's exclusion from intent
+  lowering are both taken on the CANONICAL SLOT the walk has just
+  computed, rather than on the key — which is what makes them hold for
+  `\"ref\"` and `:x/ref` as well as for `:ref`, and costs the walk one
+  comparison it already had the value for."
   [props ^ParsedTag parsed]
-  (let [props (-> props merge-caller check-ref! (merge-shorthand parsed) (dissoc :key))]
+  (let [props (-> props merge-caller (merge-shorthand parsed) (dissoc :key))]
     (reduce-kv (fn [o k v]
                  (let [n (cached-prop-name k)]
                    (when-not (reserved-cache-keys n)
-                     (unchecked-set o n (convert-prop-value (intent/lower-prop k v))))
+                     (unchecked-set o n (convert-prop-value
+                                          (if (= ref-slot n)
+                                            (check-ref! k v)
+                                            (intent/lower-prop k v)))))
                    o))
                #js {}
                props)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
@@ -91,6 +91,28 @@
     (codec/cached-prop-name :on-click)
     (is (= 4 (:props (codec/cache-sizes))))))
 
+(deftest the-slot-is-a-pure-function-of-the-key-and-a-string-cannot-poison-it
+  (testing "a string prop name is already a React name and is taken verbatim,
+            so `\"on-input\"` and `:on-input` are DIFFERENT slots. They share
+            a cache entry if the cache is keyed by name alone, and then the
+            first string spelling rendered anywhere answers every later
+            keyword — emitting every handler written the taught way into a
+            slot React ignores, and making the canonical slot depend on what
+            the page happened to render first."
+    (is (= "on-input" (codec/cached-prop-name "on-input")))
+    (is (= "onInput" (codec/cached-prop-name :on-input))
+        "the keyword still camelCases, whatever was asked before it")
+    (is (= "on-input" (codec/cached-prop-name "on-input"))
+        "and the string is still itself, whatever was asked before IT"))
+  (testing "the other way round, from a cold cache"
+    (codec/reset-caches!)
+    (is (= "onInput" (codec/cached-prop-name :on-input)))
+    (is (= "on-input" (codec/cached-prop-name "on-input"))))
+  (testing "the three React renames are the rule, so they hold for every
+            spelling of the one attribute"
+    (doseq [k [:class :className "class" :x/class 'class]]
+      (is (= "className" (codec/canonical-slot k)) (str "spelled " (pr-str k))))))
+
 (deftest prop-values-are-converted-in-the-shapes-react-wants
   (testing "a style map becomes a JS object with camelCased keys"
     (let [style (prop (codec/as-element [:div {:style {:font-size "12px" :color :red}}]) "style")]
@@ -323,6 +345,90 @@
         (is (= :rf.error/hicasso-merge-not-a-map (:rf.error/id (ex-data e))))))))
 
 ;; ---------------------------------------------------------------------------
+;; The canonical structural-slot filter (rf2-2rtt6.36)
+;; ---------------------------------------------------------------------------
+
+(deftest a-structural-slot-is-recognised-in-every-spelling-the-codec-accepts
+  (testing "the mechanism the whole of this bead's repair rests on: the slot
+            a key EMITS INTO, not the key it was written as. React's key and
+            ref are reachable as a keyword, a string, a symbol and a
+            namespaced keyword, and a rule that names `#{:key :ref}` sees
+            exactly one of the four."
+    (doseq [k [:key "key" 'key :x/key :re-frame.hicasso/key]]
+      (is (true? (codec/structural-slot? k)) (str "key, spelled " (pr-str k))))
+    (doseq [k [:ref "ref" 'ref :x/ref]]
+      (is (true? (codec/structural-slot? k)) (str "ref, spelled " (pr-str k))))
+    (doseq [k [:id :class :on-click :data-key "aria-ref" :keyboard]]
+      (is (false? (codec/structural-slot? k))
+          (str "and nothing else is structural: " (pr-str k)))))
+  (testing "the filter drops every one of them and returns the map by
+            identity when there is nothing to drop"
+    (is (= {:class "x"} (codec/without-structural
+                          {:class "x" :key 1 "key" 2 :x/key 3 :ref (fn [_]) "ref" 4 :x/ref 5})))
+    (let [clean {:class "x" :id "y"}]
+      (is (identical? clean (codec/without-structural clean))))))
+
+(deftest an-alternate-spelling-in-a-remainder-reaches-neither-structural-slot
+  (testing "the hole this repair closes. A remainder is about ATTRIBUTES;
+            `key` and `ref` are about node identity. Denying `:key` and
+            `:ref` by map-key identity denies one spelling of each and lets
+            three through — and with no literal at that slot to overwrite it
+            afterwards, the caller's value is simply what React gets."
+    (doseq [spelling ["key" 'key :x/key]]
+      (let [e (codec/as-element [:li {:& {spelling "hostile"} :class "row"}])]
+        (is (nil? (el-key e)) (str "a remainder's " (pr-str spelling) " is not the element's key"))
+        (is (= ["className"] (prop-names e))
+            "and it does not land as an attribute either")))
+    (doseq [spelling ["ref" 'ref :x/ref]]
+      (let [!fired (atom false)
+            e      (codec/as-element [:div {:& {spelling (fn [_] (reset! !fired true))}}])]
+        (is (nil? (prop e "ref")) (str "a remainder's " (pr-str spelling) " is not a ref"))
+        (is (= [] (prop-names e)))
+        (is (false? @!fired)))))
+  (testing "and the element's OWN literal is untouched by the filter — the
+            law is about what a remainder may reach, not about what an
+            author may write on their own node"
+    (let [f (fn [_node])
+          e (codec/as-element [:li {:key 7 :ref f :& {:title "caller"}}])]
+      (is (= "7" (el-key e)))
+      (is (identical? f (prop e "ref")))
+      (is (= "caller" (prop e "title"))))))
+
+(deftest an-alias-cannot-defeat-an-owned-literal-at-the-slot-they-share
+  (testing "the second half of the same hole. `:onInput` and `:on-input` are
+            two map keys and ONE React slot, so a raw-key merge leaves both
+            in the map and lets whichever the map iterates last decide —
+            which is a law that holds by luck of map ordering rather than by
+            construction. The deny is on the slot, so the alias never
+            reaches the map at all."
+    (is (= {:on-input [:owned/edit]}
+           (codec/merge-caller {:& {:onInput [:hostile/edit]} :on-input [:owned/edit]})))
+    (is (= {:on-input [:owned/edit]}
+           (codec/merge-caller {:& {"onInput" [:hostile/edit]} :on-input [:owned/edit]}))
+        "including the string spelling of the same React name"))
+  (testing "at a crossing the map is handed over UNRENAMED, so the alias is
+            visible in the props a structural test reads — and the law is
+            the same one rule at both positions (HD-023(d))"
+    (let [e (codec/as-element [a-view {:& {:onInput [:hostile/edit] :title "kept"}
+                                       :on-input [:owned/edit]}])]
+      (is (= {:on-input [:owned/edit] :title "kept"} (prop e "rfProps")))))
+  (testing "and the owned handler is the one React calls"
+    (let [!seen (atom [])
+          e (intent/with-frame (fn [ev] (swap! !seen conj ev))
+                               (fn [] (codec/as-element
+                                       [:input {:& {:onInput [:hostile/edit]
+                                                    :onFocus  [:hostile/focus]}
+                                                :on-input [:todo.ui/edit 7]}])))]
+      ((prop e "onInput") #js {:target #js {}})
+      (is (= [[:todo.ui/edit 7]] @!seen))
+      (is (fn? (prop e "onFocus"))
+          "an alias the element does NOT write still lands — the deny is the
+           slot the literal claimed, never the shape of the spelling")))
+  (testing "the same for the controlled pair spelled with a namespace"
+    (let [e (codec/as-element [:input {:& {:x/value "HOSTILE"} :value "owned"}])]
+      (is (= "owned" (prop e "value"))))))
+
+;; ---------------------------------------------------------------------------
 ;; The reserved `:ref` value-space (HD-022, rf2-2rtt6.38)
 ;; ---------------------------------------------------------------------------
 
@@ -353,6 +459,39 @@
           (is (= [::autosize {:max-rows 8}] (:ref d))
               "the refusal carries the value it refused, so a later
                migration can find its own call sites"))))))
+
+(deftest the-reservation-holds-at-the-ref-slot-however-the-ref-is-spelled
+  (testing "the hole. This codec deliberately accepts string, symbol and
+            namespaced prop spellings and emits them all under one React
+            name, so a reservation that reads `(:ref props)` is a
+            reservation `\"ref\"` and `:x/ref` walk straight past — on their
+            way to React with the opaque array the reservation exists to
+            stop, which is the silent ref-that-never-fires it was written to
+            replace."
+    (doseq [spelling ["ref" 'ref :x/ref :re-frame.hicasso/ref]]
+      (try
+        (codec/as-element [:textarea.composer {spelling [::autosize {:max-rows 8}]}])
+        (is false (str "should have thrown for " (pr-str spelling)))
+        (catch :default e
+          (let [d (ex-data e)]
+            (is (= :rf.error/hicasso-ref-vector-reserved (:rf.error/id d))
+                (str "refused, spelled " (pr-str spelling)))
+            (is (= spelling (:position d))
+                "and the diagnostic names the spelling that was written")
+            (is (= [::autosize {:max-rows 8}] (:ref d))))))))
+  (testing "and a callback ref under an alternate spelling still reaches
+            React's ref slot BY IDENTITY — the reservation is the VECTOR
+            arm, not a claim on the spelling, and the ref position is
+            excluded from callback lowering at the slot rather than at the
+            key. Wrapping it would both forbid a dispatch that is legitimate
+            there and change the identity React uses to decide whether to
+            re-attach the node."
+    (let [f (intent/callback (fn [_node]))]
+      (is (identical? f (prop (codec/as-element [:div {"ref" f}]) "ref")))
+      (is (identical? f (prop (codec/as-element [:div {:x/ref f}]) "ref")))))
+  (testing "a vector anywhere else is still an ordinary prop value"
+    (is (= "a b" (prop (codec/as-element [:div {:class ["a" "b"]}]) "className")))
+    (is (some? (prop (codec/as-element [:div {:data-refs [1 2]}]) "data-refs")))))
 
 (deftest the-reservation-costs-one-branch-and-claims-nothing-else
   (testing "no other :ref value moves. A string ref, a nil ref and a map at

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -219,11 +219,21 @@
   A callback is handed the event, so the event is the callback's — it
   calls `.preventDefault` itself, and the runtime does not reach in after
   the body has run to second-guess it. One rule: whoever holds the event
-  owns it."
+  owns it.
+
+  **Every argument the invoker passes reaches the body**, the same way
+  [[render-callback]] forwards them. A native DOM event position calls
+  with one argument and that is the overwhelming case, but this is also
+  the wrapper a `defhost` `:callbacks` entry declared `:event` gets, and
+  a foreign component's live invoker calls with whatever its own contract
+  says — `(on-change value event)`, `(on-select item index)`. Accepting
+  exactly `[e]` would silently drop everything after the first, or raise
+  an arity error naming nothing the author wrote, against a form whose
+  parameter vector is arbitrary by construction."
   [k f]
   (let [dispatch *dispatch*]
-    (fn hicasso-event-callback [e]
-      (let [result (f e)]
+    (fn hicasso-event-callback [& args]
+      (let [result (apply f args)]
         (when (vector? result)
           (if dispatch
             (dispatch result)

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent_cljs_test.cljs
@@ -383,6 +383,20 @@
                                    (fn [] (intent/lower-declared-prop :onValueChange cb :event)))]
           (h 7)
           (is (= [[:host/changed 7]] @!seen))))
+      (testing "and it forwards EVERY argument the invoker passes. A native
+                DOM event position calls with one argument, but this is also
+                the wrapper a declaration gives a foreign component's own
+                live invoker — `(on-change value event)`, `(on-select item
+                index)` — and the form's parameter vector is arbitrary by
+                construction. A wrapper that accepted exactly `[e]` would
+                silently drop everything after the first, or raise an arity
+                error naming nothing the author wrote."
+        (reset! !seen [])
+        (let [pair (intent/callback (fn [value e] [:host/changed value (.-key e)]))
+              h    (intent/with-frame (dispatching !seen)
+                                      (fn [] (intent/lower-declared-prop :onValueChange pair :event)))]
+          (h "typed" (ev {:key "Enter"}))
+          (is (= [[:host/changed "typed" "Enter"]] @!seen))))
       (testing ":handler ignores the return, and the function passes through
                 by identity so a library memoising on it is not defeated"
         (reset! !seen [])

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/presence.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/presence.cljs
@@ -178,9 +178,21 @@
 
   A **native node** takes the phase's attribute-override map merged over
   its own attributes — the override WINS, because that is what an
-  override is — with `:key` and `:ref` never taken from it, the same law
-  `:&` carries (HD-023). The two override keys are always removed, so an
-  override never reaches the DOM as an attribute.
+  override is — with the two structural slots never taken from it, the
+  same law `:&` carries (HD-023). The two override keys are always
+  removed, so an override never reaches the DOM as an attribute.
+
+  **The exclusion is on the canonical SLOT, through the filter
+  [[re-frame.bench.hicasso.front.codec/without-structural]] that `:&`
+  uses.** It has to be: an override carrying `\"key\"` or `:x/key`
+  survives a raw `#{:key :ref}` dissoc and canonicalises straight onto
+  React's key, which would remount the very node presence exists to
+  retain — the child would restart its exit, or vanish and come back,
+  precisely while it is being animated out. A `\"ref\"` or `:x/ref`
+  likewise reaches the retained node. Retained key identity is therefore
+  pinned by construction: the only `:key` in the merged map is the one
+  the child was retained under, because nothing else can reach that slot
+  in any spelling.
 
   A **boundary child** takes `:rf/phase` as an ordinary prop instead, and
   an override written there is a loud error: the boundary cannot see
@@ -204,8 +216,7 @@
             base     (when props (apply dissoc props override-keys))]
         (cond
           (map? override)
-          (with-props child (merge base (apply dissoc override
-                                               codec/merge-structural-keys)))
+          (with-props child (merge base (codec/without-structural override)))
 
           ;; Nothing to strip and nothing to merge: the child is already
           ;; exactly what it should render as, so it comes back untouched

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/presence_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/presence_cljs_test.cljs
@@ -171,6 +171,30 @@
                                {:key "stolen" :ref (fn [_]) :class "x"}}]]
       (is (= [:div.toast {:key 1 :class "x"}]
              (presence/with-phase hostile :unmounting)))))
+  (testing "and it cannot reach them under ANY spelling, which is the whole
+            of the repair. `\"key\"` and `:x/key` survive a raw `#{:key
+            :ref}` dissoc and canonicalise onto React's key — after the
+            child's own `:key` has been merged, and at the one moment the
+            node must NOT be remounted, because it is being animated out.
+            The exclusion is taken on the canonical SLOT, through the very
+            filter `:&` uses."
+    (doseq [spelling ["key" 'key :x/key]]
+      (let [hostile [:div.toast {:key 1
+                                 :re-frame.hicasso/unmounting
+                                 {spelling "stolen" :class "x"}}]
+            out     (presence/with-phase hostile :unmounting)]
+        (is (= [:div.toast {:key 1 :class "x"}] out)
+            (str "key, spelled " (pr-str spelling)))
+        (is (= 1 (presence/child-key out))
+            "the retained node's identity is the key the machine retains it
+             under, and nothing in an override can move it")))
+    (doseq [spelling ["ref" 'ref :x/ref]]
+      (let [hostile [:div.toast {:key 1
+                                 :re-frame.hicasso/unmounting
+                                 {spelling (fn [_]) :class "x"}}]]
+        (is (= [:div.toast {:key 1 :class "x"}]
+               (presence/with-phase hostile :unmounting))
+            (str "ref, spelled " (pr-str spelling))))))
   (testing "a child that carries no override comes back UNTOUCHED, by
             identity — the transform costs nothing on a node that does not
             use it"


### PR DESCRIPTION
The merged-PR audit of #7328 reopened four beads. Three of them are one defect
seen from three sides, and this is one repair for all three; the fourth is
independent and small.

## The one defect

The codec accepts a prop key written as a keyword, a string, a symbol or a
namespaced keyword, in kebab or in camel, and emits them all under **one** React
name. Three rules were written against the RAW map key, so every other spelling
of the same slot walked straight past them.

| Bead | The face |
|---|---|
| **rf2-2rtt6.36** | a `:&` remainder carrying `"key"`, `:x/key`, `"ref"` or `:x/ref` reached React's structural slots; and an alias such as `:onInput` against an owned `:on-input` survived the merge as a *second map entry*, leaving the promised **unconditional** owned-literal law to be decided by whichever of the two the props map happened to iterate last |
| **rf2-2rtt6.37** | presence reused the same raw `#{:key :ref}` dissoc for phase overrides, so an unmounting override could reach the key and the ref of the very node presence exists to retain |
| **rf2-2rtt6.38** | `check-ref!` read `(:ref props)`, so a reserved vector under `"ref"` or `:x/ref` bypassed `:rf.error/hicasso-ref-vector-reserved` and reached React as the opaque value that bead exists to stop |

## One filter, three consumers

`canonical-slot` **is** `cached-prop-name` — the slot the emitter will actually
use — and that identity is the mechanism: the thing a deny asks is the thing the
emitter will do. Every deny, dissoc and check now consults it.

- `structural-slots` is `#{"key" "ref"}`, held as slots rather than as keys,
  because the spelling is exactly what a hostile or careless map would vary.
- `merge-caller`'s deny set is `structural-slots` **seeded with the slot of every
  literal the element writes** — one set, so one rule states both halves of
  HD-023's law.
- presence's `with-phase` filters its override through the same
  `without-structural`. Retained key identity is then pinned by construction: the
  only `:key` in the merged attributes is the one the child is retained under,
  because nothing else can reach that slot in any spelling.
- the `:ref` reservation, and the ref position's exclusion from callback
  lowering, are both taken on the slot `convert-props` has *already computed* in
  its single walk — no extra traversal, and no second spelling-check.

**One supporting change the law needs.** The resolver has to be a pure function
of the key or the law is order-dependent again, so a string prop name no longer
shares the prop-name cache with the keyword of the same name (this restores the
donor's shape). The cache is keyed by `(name k)` while `prop-name` answers a
string differently from the keyword — so one `{"on-input" f}` rendered anywhere
would otherwise have answered every later `:on-input` with `"on-input"` for the
life of the build, silently emitting every handler written the taught way into a
slot React ignores. The three React renames (`class`/`for`/`charset`) move into
`prop-name` itself, where they hold for every spelling of the one attribute.

## rf2-2rtt6.35 — the event wrapper's arity

Separate defect, bounded exactly as the audit scoped it. `event-callback`
accepted `[e]` and invoked `(f e)`, so a `defhost` `:event` callback silently
dropped every argument after the first — against a form whose parameter vector is
arbitrary by construction. It is now variadic and applies the marked function, as
`render-callback` already did. **No new callback form, no ABI change.** The
one-argument native path and the no-frame diagnostic are unchanged and still
covered.

## Fences honoured

Surface B only. No candidate ledger, no compiler, no analyzer, no dual mode, no
ViewCell-class object graph. Hicasso authors no codec — this changes Hicasso's
prop handling around reagent-slim's, not the donor's own walk (`template.cljs` is
untouched). The ≤2-hook shell is untouched: `arm1/runtime.cljs` and
`arm1/mount.cljs` are not in this diff, and `hook-ledger-dom-cljs-test` — which
asserts exactly `["useContext" "useSyncExternalStore"]` at 1/7/20 reads — ran
green in the browser lane.

## Witnesses

Every witness is in the **alternate** spelling, because every earlier test passed
while using the canonical one.

- **.36** — `structural-slot?` over `:key "key" 'key :x/key ::h/key` and
  `:ref "ref" 'ref :x/ref`, with six near-misses that must stay false; a `:&`
  remainder's `"key"`/`'key`/`:x/key` reaching neither the element's key nor its
  attributes; the same three ref spellings reaching neither `ref` nor a fired
  callback; the element's OWN literal `:key`/`:ref` untouched; `:onInput` and
  `"onInput"` denied against an owned `:on-input` both at the merge and, visibly,
  in the props a crossing hands over unrenamed; `:x/value` denied against an
  owned `:value`.
- **.37** — an unmounting override carrying `"key"`, `'key` or `:x/key` leaves
  the child's props exactly as it found them and `child-key` still answers the
  retention key; the same for `"ref"`, `'ref`, `:x/ref`; and in a real browser, a
  hostile override on a retained toast hands **no node** to its `"ref"` while the
  appearance half of the override still lands, and the retained node is the same
  DOM element instance across the exit.
- **.38** — `[:textarea.composer {<spelling> [::autosize {:max-rows 8}]}]` is
  refused with `:rf.error/hicasso-ref-vector-reserved` for `"ref"`, `'ref`,
  `:x/ref` and `::h/ref`, and the diagnostic names the spelling that was written;
  a callback ref under an alternate spelling still reaches React's `ref` **by
  identity** (it is not wrapped as a render-position callback on the way).
- **.35** — a declared `:event` callback taking **two** arguments receives both
  and dispatches its return.

## Quality gates

Every gate run foreground, to completion, logs kept worktree-local, never piped
through `tail`/`grep`.

| Gate | Exit |
|---|---|
| `npm run test:cljs` (`:node-test`) — 12195 tests / 60897 assertions, 0 failures, 0 errors | **0** |
| `npm run test:browser` (`:browser-test`) — 906 tests / 5736 assertions, 0 failures, 0 errors | **0** |
| `scripts/test-fast-pr.sh` (docs + JVM `core`+`freehand` + node tiers) | **0** |
| `clj-kondo` **v2026.04.15** (the CI pin, fetched — local npm carries 2025.10.23), CI's exact `--lint` set + `--fail-level error` → **errors: 0**, warnings 4526 (pre-existing) | **0** |
| `python scripts/check_doc_slugs.py` | **0** |

### Mutation proof

Each mutation reverts one mechanism and leaves every witness in place.

| Mutation | Suite | What went red |
|---|---|---|
| **A** — `canonical-slot` → `identity`, `structural-slots` → `#{:key :ref}`, and the prop-name cache shared with strings again (i.e. *remove the canonical filter*) | node: **exit 1**, 33 failures | `a-structural-slot-is-recognised-in-every-spelling-…`, `an-alternate-spelling-in-a-remainder-reaches-neither-structural-slot`, `an-alias-cannot-defeat-an-owned-literal-at-the-slot-they-share`, `the-slot-is-a-pure-function-of-the-key-…` (.36) and `a-native-child-takes-the-phases-override-map-and-nothing-else` (.37) |
| **B** — the ref check + lowering exclusion back to the raw key `:ref` | node: **exit 1**, 5 failures | `the-reservation-holds-at-the-ref-slot-however-the-ref-is-spelled` (.38) |
| **C** — the event wrapper back to `[e]` / `(f e)` | node: **exit 1**, 1 error | `a-declaration-can-name-the-contract-instead-of-the-position` (.35) — `TypeError: Cannot read properties of undefined (reading 'key')`, which is the audit's "or raises an arity error", verbatim |
| **A**, again | browser: **exit 1**, 1 failure | `a-hostile-override-reaches-neither-structural-slot-on-the-retained-node` — `actual: (not (= [] [#object[HTMLDivElement]]))`. The override's `"ref"` was handed the live retained node (.37) |

Restored after each; the green table above is the restored tree, and
`git grep MUTATION` is empty.

**One honest note on .37's key face.** Its mutation red is at the transform, not
in the DOM, and that is not an accident of the witness. `native-element` writes
`js-props.key` from the child's own `:key` *after* prop conversion, so before this
PR a hostile `"key"` in a presence override was already being overwritten at the
emitter for a child that has a `:key` — and a presence child always has one. The
face that was live in the DOM is the ref, and that is where the browser mutation
bites. The key face is live wherever there is no owned literal to overwrite it,
which is `:&` on an unkeyed element — witnessed under .36, on the shared filter,
and red under mutation A. The alias face has the same shape: `merge-caller`
returned `(merge caller owned)`, so for an array map the owned literal happened to
emit last, and it is a hash map (>8 entries) where that stops being luck. That is
precisely the audit's "map-order-dependent", and it is why the deny is now on the
slot rather than on the direction of a merge.

## Docs coverage, stated correctly

`mkdocs build --strict` does **not** reach `docs/design/**` (`mkdocs.yml`'s
`exclude_docs` keeps `design/hicasso/` off the site), so it is not the gate for
this diff. `scripts/check_doc_slugs.py` **does** validate that tree's markdown
link targets and heading anchors, it runs in the fast-PR spine, and it exits 0
here.

Only table column counts, rendering and nav are ungated, so those are verified by
hand: **no heading and no table was added or altered** in any documentation file.
The four touched records (`decisions.md` HD-022 / HD-023 / HD-024 / HD-025) and
the three guide pages (`03-events-as-data.md`, `04-controlled-inputs.md`,
`05-interop.md`) gain prose paragraphs only; every existing table in those files
is byte-identical (the doc diff adds no `|` line at all), and
`docs/design/hicasso/` is not in the nav.

## The TESTING.md matrix this diff derives

`.github/scripts/report-changed-surfaces.sh` classifies the diff as
`cljs_node_test` + `cljs_browser` + `implementation_jvm`, plus the documentation
tier and the lint surface, giving:

- **CLJS unit** (`test:cljs`) — every `*_cljs_test.cljs`; owns the codec, intent
  and presence witnesses. Run.
- **Browser unit** (`test:browser`) — `*_dom_cljs_test.cljs` only; owns the
  presence remount + ref-delivery witness, which is a real-DOM question. Run.
- **JVM tier** — `implementation/core` plus the artefacts the diff touches
  (`implementation/freehand`). Run, via the spine.
- **Documentation gates** — the doc-content checkers; `mkdocs build --strict`
  soft-skips locally and does not cover this tree in any case (above).
- **Lint** — clj-kondo at the CI pin. Run.

Not in any tier for this diff, and left to CI: the prod-elision / bundle-isolation
/ perf-bundle probes, the adapter smokes, Xray, Story and mcp-conformance. The
`cljs_prod` arm does fire on `implementation/freehand/**`, but this tree is
test-only and reaches no release build.

Closes rf2-2rtt6.36, rf2-2rtt6.37, rf2-2rtt6.38, rf2-2rtt6.35.
