### PR TITLE
hicasso: an explicitly deferred read is loud, not silent (rf2-2rtt6.32)

### DIFF
--- a/docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md
+++ b/docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md
@@ -341,15 +341,61 @@ edge count collapsing from 7 to 1 on the first). Restored, both exit 0. The
 first-paint assertions passed on the broken runtime, which is the whole reason
 the second half is asserted.
 
-**What genuinely remains, stated precisely so it is not rediscovered as a
-surprise.** The codec can force *structure* — a seq is data it already walks. It
-cannot force an explicit deferral primitive without destroying its meaning: a
-`delay` handed across a boundary and deref'd in the child's render is the same
-fault in a shape no walk may repair, because forcing a `delay` eagerly is the
-opposite of what a `delay` is for. A **function** prop is not in this class and is
-not a defect at all: the child re-runs it on every render, so the read repeats and
-the edge is kept — the reader is the child, and the child is the one whose output
-depends on it.
+**And the deferral no walk may repair is refused instead** (`rf2-2rtt6.32`). The
+codec can force *structure* — a seq is data it already walks, and forcing it
+changes nothing an author could observe, because the seq was going to be walked
+one boundary later regardless. A `delay` is not structure. It is an explicit
+deferral whose whole content is *not now*, so forcing it at the hand-off would
+change the meaning of the author's program in order to protect a property the
+author was never told about — a silent repair of a different kind, and no better
+than the silent staleness it replaces. `realize-deep` therefore **refuses** an
+unforced `delay` it reaches, and refuses it *inside the render of the body that
+wrote the crossing*, so the stack lands on the author's own call site. That is the
+attribution a query name would have bought, obtained without forcing anything to
+learn the name. Only an unforced one is refused: a `delay` the author already
+deref'd in their own body carries a computed value, derefs to it without calling
+anything, and passes through untouched. The cost is one `instanceof` on the branch
+that already existed for scalars, and the refusal needs no render identity — the
+check is on the value's shape, made inside the producing body's own window.
+
+The fault it replaces is asserted rather than described, driven around the codec
+because the codec now refuses to build it: the parent's read set is **empty**, the
+child's first render holds the row query, and the child's second render holds
+nothing. The edge is dropped with no boundary left holding one, and the only
+boundary that could rebuild the delay never re-rendered.
+
+A **function** prop is not in this class and is not a defect at all — now verified
+rather than argued. The child calls it on every render, so the read repeats, the
+edge is kept, and the holder is the child, which is the boundary whose output
+depends on it. The render-prop-that-is-not-re-run has only two ends and both were
+already settled: called in the render it keeps its edge; called anywhere else it
+finds no frame and raises the error `read-key!` has raised from the start. A body
+that *stops* calling a render prop simply holds no edge — that is law 4 rather
+than a defect, and no framework can tell it from a branch not taken.
+
+**What genuinely remains, and it is a boundary of the mechanism rather than a gap
+in it.** The crossing walk descends into data structures; a **mutable reference**
+is not one. A deferral an author parks in an atom — at a prop position, or in a
+module-level var the codec never sees at all — reaches its reader unrepaired and
+unrefused, and behaves exactly like the fault above. Opening it is not an option
+in either direction: a walk that deref'd a reactive reference would mint a
+dependency it has no business holding, and one that deref'd a `delay` would be
+the forcing this whole section declines. The author has routed state around the
+ruled surface, and no view framework detects that — React with hooks has the
+identical hole. It is asserted rather than described, so that it is a stated
+property of Surface B and not a later discovery.
+
+| Witness | Asserts |
+|---|---|
+| `deferred-read-cljs-test` (10 rows) | the unforced `delay` is refused at the crossing, with the id, the refusing position and the recovery; at every position the walk reaches — bare prop, vector, nested map, list, lazy seq, set, and the children slot; a realised `delay` crosses untouched and the read stays the parent's; the refused render installs nothing |
+| the same file, classification rows | the fault the refusal replaces, driven around the codec; a function prop keeping its edge across two renders; a function prop invoked outside a render raising the existing error; a body that stops calling one holding no edge; and the mutable-reference limit, asserted unrepaired |
+
+Mutation-proved by deleting the guard from `realize-deep`: node exit 1, 12
+failures and 1 error. Restored, node exit 0. There is no browser row and that is
+deliberate — the refusal is a pure codec verdict reached before any element is
+built, so a Chromium mount would re-prove what the node rows already prove. The
+DOM half was earned for `rf2-2rtt6.45` because *that* claim was about liveness,
+which a first paint cannot tell you; this one is not.
 
 ## 3. Two places the record did not survive contact with the substrate
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/deferred_read_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/deferred_read_cljs_test.cljs
@@ -1,0 +1,299 @@
+(ns re-frame.bench.hicasso.arm1.deferred-read-cljs-test
+  "AN EXPLICITLY DEFERRED READ IS LOUD, NOT SILENT (rf2-2rtt6.32).
+
+  The last shape in the read-outside-the-render family, and the only one
+  the two existing guards cannot see between them.
+
+  ## Where this sits
+
+  `runtime-cljs-test`'s
+  `every-read-that-escapes-the-render-is-loud-rather-than-a-missing-edge`
+  settles four escapes — a stored handler, a handler invoked, an
+  author-held `delay`, and a stashed lazy seq — all of which run when
+  **no** body is running, so `read-key!` finds no frame and throws.
+  `boundary-crossing-cljs-test` settles the fifth — a lazy seq handed
+  across a boundary and realised in the child's render, where a frame IS
+  bound and the guard is satisfied — by forcing it at the crossing,
+  inside the window of the body that wrote it.
+
+  Both of those repair or refuse **structure**. This file is about what
+  is left: an **explicit deferral**, handed across a boundary and forced
+  there. A `delay` is the canonical spelling, and it is the one carrier
+  the crossing walk may not repair, because repairing it means forcing
+  it, and *not now* is the entire content of what a `delay` says.
+
+  ## The fault, and why it is the worst one available
+
+      (defview child  [{:keys [d]}] [:li (str @d)])
+      (defview parent [_] [child {:d (delay (:title (sub [:todo 1])))}])
+
+  Measured on the runtime before this change (the probe is preserved as
+  `the-fault-the-refusal-replaces` below): the parent's read set is
+  **empty**, the child's first render holds `[:todo 1]`, and the child's
+  second render holds **nothing** — a `Delay` caches, so the second walk
+  calls `sub` zero times, the read set collapses, React re-subscribes and
+  the edge is dropped. The parent never held an edge, so it never
+  re-renders and the delay is never rebuilt. Correct on screen, frozen
+  thereafter, attributable to nothing.
+
+  ## What this change does, and what it deliberately does not
+
+  `codec/realize-deep` — already the one walk at the crossing — refuses
+  an **unforced** `delay` it reaches, and refuses it *inside the render
+  of the body that wrote it*, so the stack lands on the author's own call
+  site. It does not force the delay: that would change the meaning of the
+  program to protect a property the author was never told about, which is
+  a silent repair of a different kind. The right answer for a deferred
+  read is a diagnostic.
+
+  A **function** prop is not in this class and is not a defect at all —
+  the rows below verify rather than assert it — because the child calls
+  it on every render, so the read repeats, the edge is the child's, and
+  the child is the boundary whose output depends on it.
+
+  ## The declared limit, recorded rather than discovered
+
+  The walk descends into data structures. A **mutable reference** is not
+  one, and a deferral parked inside an atom — or in a module-level var
+  the codec never sees at all — is outside what any structural pass can
+  reach. Those rows are here, asserting the unrepaired behaviour, so the
+  limit is a written-down property of Surface B and not a surprise.
+
+  The adapter is UIx's, matching `boundary-crossing-cljs-test`:
+  `plain-atom` has no reactivity layer, so a subscription under it never
+  notifies and every commit assertion would pass by never firing."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     :init-fn (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::arm1-deferred-read)
+
+(defn- seeded! []
+  (rt/reset-runtime!)
+  (dogfood/make-frame! frame-id 3)
+  frame-id)
+
+(defn- key-of [query] [frame-id query])
+
+(defn- crossing-props
+  "The props map the codec built for the crossing — what the shell reads
+  back out of `rfProps` and hands the child's body."
+  [element]
+  (unchecked-get (.-props element) "rfProps"))
+
+(defn- render [body-fn props]
+  (let [element (rt/render-body frame-id body-fn props)]
+    {:element element :entry (rt/last-reads) :reads (rt/reads-of (rt/last-reads))}))
+
+;; ---------------------------------------------------------------------------
+;; The bodies
+;; ---------------------------------------------------------------------------
+
+(defn- child-derefs-body [{:keys [d]}] [:li.deref (str @d)])
+(def ^:private child-derefs (rt/mint-view! "deferred/child-derefs" child-derefs-body))
+
+(defn- parent-delay-body
+  "The crossing this file exists for: an explicit deferral written by one
+  body and forced by another."
+  [_]
+  [child-derefs {:d (delay (:title (rt/sub [:dogfood/todo 1])))}])
+
+(defn- child-calls-body [{:keys [f]}] [:li.call (str (f))])
+(def ^:private child-calls (rt/mint-view! "deferred/child-calls" child-calls-body))
+
+(defn- parent-fn-body
+  "The shape that is NOT in the class: the child re-runs it every render."
+  [_]
+  [child-calls {:f (fn [] (:title (rt/sub [:dogfood/todo 1])))}])
+
+;; ---------------------------------------------------------------------------
+;; 1 — the refusal, at the crossing, in the writing body's render
+;; ---------------------------------------------------------------------------
+
+(deftest an-unforced-delay-crossing-a-boundary-is-refused
+  (seeded!)
+  (testing "the refusal fires while the PARENT is rendering — the codec
+           runs inside `run-once`, so the throw lands on the call site
+           that wrote the crossing rather than on the child that would
+           otherwise have been blamed for the read"
+    (let [e (try (render parent-delay-body {}) nil (catch :default e e))]
+      (is (some? e) "the crossing refuses")
+      (is (= :rf.error/hicasso-deferred-read-at-boundary (:rf.error/id (ex-data e))))
+      (is (= 'front.codec/boundary-element (:where (ex-data e)))
+          "the position that refused is the crossing, not the child")
+      (is (= :hand-a-function-or-deref-it-in-this-body (:recovery (ex-data e))))
+      (is (re-find #"unforced `delay` reached a boundary's props" (ex-message e))))))
+
+(deftest the-refused-crossing-installs-nothing
+  (seeded!)
+  (testing "a render that threw is an abandoned render, and an abandoned
+           render mutates neither the index nor a reference — the
+           refusal is a diagnostic, not a half-built boundary"
+    (let [before (rt/residue)]
+      (try (render parent-delay-body {}) (catch :default _ nil))
+      (is (= before (rt/residue))))))
+
+(deftest the-refusal-reaches-wherever-the-walk-reaches
+  (testing "the delay is refused at every position the crossing walk
+           descends into, which is the same reach the seq realisation
+           already had — a bare prop, inside a vector, inside a map,
+           inside a seq, and inside a realised lazy seq"
+    (doseq [[label v] [["a bare prop"            {:d (delay 1)}]
+                       ["inside a vector"        {:d [(delay 1)]}]
+                       ["inside a nested map"    {:d {:k (delay 1)}}]
+                       ["inside a list"          {:d (list (delay 1))}]
+                       ["inside a lazy seq"      {:d (map (fn [_] (delay 1)) (range 1))}]
+                       ["inside a set"           {:d #{(delay 1)}}]]]
+      (is (thrown-with-msg? js/Error #"unforced `delay` reached a boundary's props"
+                            (codec/realize-deep v))
+          label))))
+
+(deftest a-delay-in-the-children-position-is-refused-too
+  (seeded!)
+  (testing "`:children` is a key in the same props map, so the one walk
+           covers the children position without a second pass — the
+           property `realize-children`'s one-level flatten made necessary
+           for seqs holds identically for a deferral"
+    (is (thrown-with-msg? js/Error #"unforced `delay` reached a boundary's props"
+                          (render (fn [_] [child-derefs (delay (rt/sub [:dogfood/remaining]))]) {})))))
+
+(deftest a-delay-the-author-already-forced-crosses-untouched
+  (seeded!)
+  (testing "only an UNFORCED delay is refused. One the author deref'd in
+           their own body carries a computed value, derefs to it without
+           calling anything, and is harmless wherever it goes — so the
+           refusal costs the legitimate spelling nothing"
+    (let [parent (render (fn [_]
+                           (let [d (delay (:title (rt/sub [:dogfood/todo 1])))]
+                             @d
+                             [child-derefs {:d d}]))
+                         {})
+          props  (crossing-props (:element parent))]
+      (is (= #{(key-of [:dogfood/todo 1])} (:reads parent))
+          "the read is the parent's, because the parent forced it")
+      (is (realized? (:d props)))
+      (is (= #{} (:reads (render child-derefs-body props)))
+          "and the child reads nothing, which is correct: it is not the reader"))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the fault the refusal replaces, kept as a witness
+;; ---------------------------------------------------------------------------
+
+(deftest the-fault-the-refusal-replaces
+  (seeded!)
+  (testing "driven around the codec, because the codec now refuses to
+           build it: a delay forced inside the child's render is the
+           child's edge on the first render and NOBODY's edge on the
+           second, because a `Delay` caches. The parent holds no edge at
+           any point, so nothing ever rebuilds the delay. This is the
+           mechanism the refusal exists to prevent, and it is asserted
+           rather than described so that removing the refusal cannot
+           quietly restore it."
+    (let [d      (delay (:title (rt/sub [:dogfood/todo 1])))
+          first' (render child-derefs-body {:d d})
+          again  (render child-derefs-body {:d d})]
+      (is (= #{(key-of [:dogfood/todo 1])} (:reads first'))
+          "the first walk files the read under whoever forced it")
+      (is (= #{} (:reads again))
+          "and the second walk calls `sub` zero times, so the read set
+           collapses, React re-subscribes, and the edge is dropped"))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the shapes that are NOT in the class, verified rather than argued
+;; ---------------------------------------------------------------------------
+
+(deftest a-function-prop-keeps-its-edge-because-the-child-re-runs-it
+  (seeded!)
+  (testing "the render prop is the sanctioned deferral across a crossing.
+           Its read repeats on every render, so the edge is kept; and the
+           holder is the CHILD, which is correct — the child is the
+           boundary whose output depends on it"
+    (let [parent (render parent-fn-body {})
+          props  (crossing-props (:element parent))
+          first' (render child-calls-body props)
+          again  (render child-calls-body props)]
+      (is (= #{} (:reads parent))
+          "the parent read nothing: it wrote a function, it did not read")
+      (is (= #{(key-of [:dogfood/todo 1])} (:reads first')))
+      (is (= #{(key-of [:dogfood/todo 1])} (:reads again))
+          "and again on the next render, which is the whole difference
+           from a delay"))))
+
+(deftest a-function-prop-not-called-in-the-render-is-already-loud
+  (seeded!)
+  (testing "the render-prop-that-is-not-re-run has only two ends, and
+           both are already settled: called in the render it keeps its
+           edge (above); called anywhere else it finds no frame and is
+           the error `read-key!` has raised since the beginning"
+    (let [parent (render parent-fn-body {})
+          props  (crossing-props (:element parent))
+          stashed (volatile! nil)]
+      (render (fn [{:keys [f]}] (vreset! stashed f) [:li]) props)
+      (is (thrown-with-msg? js/Error #"outside a boundary render" (@stashed))))))
+
+(deftest a-body-that-stops-calling-a-render-prop-simply-holds-no-edge
+  (seeded!)
+  (testing "not a defect, and worth the row so it is not filed as one:
+           the collector's read set is a function of control flow (law
+           4), so a body that stops calling its render prop correctly
+           stops depending on it. A framework cannot tell that from a
+           branch not taken, and must not try."
+    (let [parent (render parent-fn-body {})
+          props  (crossing-props (:element parent))
+          calls  (render (fn [{:keys [f]}] [:li (str (f))]) props)
+          skips  (render (fn [_] [:li "static"]) props)]
+      (is (= #{(key-of [:dogfood/todo 1])} (:reads calls)))
+      (is (= #{} (:reads skips))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — the declared limit
+;; ---------------------------------------------------------------------------
+
+(def ^:private !parked (atom nil))
+
+(deftest a-deferral-parked-in-a-mutable-reference-is-outside-the-walk
+  (seeded!)
+  (testing "**A real limit of the Surface B ruling, written down.** The
+           crossing walk descends into data structures; an atom is not
+           one, and descending into a mutable reference is neither a
+           structural pass nor safe (a reactive reference deref'd by a
+           walk would mint a dependency the walk has no business
+           holding). So a deferral parked in one — at a prop position or
+           in a module-level var the codec never sees at all — reaches
+           the child unrepaired and unrefused, and behaves exactly like
+           the fault above.
+
+           This is the boundary of the mechanism, not a gap in it: the
+           author has routed state around the ruled surface, and no view
+           framework detects that. React with hooks has the identical
+           hole. It is recorded here so it is a stated property rather
+           than a discovery."
+    (let [parent  (render (fn [_]
+                            (reset! !parked
+                                    (map (fn [id] (:title (rt/sub [:dogfood/todo id]))) (range 3)))
+                            [:li])
+                          {})
+          reader  (render (fn [_] [:li (str (doall @!parked))]) {})]
+      (is (= #{} (:reads parent))
+          "the writing body reads nothing — the seq is unrealised when it returns")
+      (is (= #{(key-of [:dogfood/todo 0])
+               (key-of [:dogfood/todo 1])
+               (key-of [:dogfood/todo 2])}
+             (:reads reader))
+          "and every row lands on whichever body happened to force it")))
+  (testing "the same, one step nearer: the reference is at a boundary
+           prop, so the codec SEES it and still may not open it"
+    (let [box    (atom (map (fn [id] (:title (rt/sub [:dogfood/todo id]))) (range 3)))
+          parent (render (fn [_] [child-derefs {:d box}]) {})
+          props  (crossing-props (:element parent))
+          child  (render (fn [{:keys [d]}] [:li (str (doall @d))]) props)]
+      (is (= #{} (:reads parent)))
+      (is (= 3 (count (:reads child)))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -179,6 +179,14 @@
   it finds none. Every escape becomes an error naming the query rather
   than an edge that was quietly not recorded.
 
+  The one escape that guard cannot see is a deferral forced inside
+  ANOTHER body's render, where a frame is bound and [[read-key!]] is
+  satisfied. Structure is repaired there — `realize-deep` forces it at
+  the crossing — and an explicit deferral is REFUSED there, by the same
+  walk, because forcing a `delay` would change what the author wrote.
+  `front.codec/refuse-deferred!`, and `arm1/deferred-read-cljs-test`.
+  rf2-2rtt6.32.
+
   ### The cold read, and what it costs (clause (a) consequence)
 
   A render-phase read is a **pure deref** when the key already has a

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -71,7 +71,7 @@
   | Head | Props | Children | `:key` |
   |---|---|---|---|
   | Native tag | attr map | trailing forms; seqs realized once and flattened one level; `nil`/`false` render nothing, `true` errors | `:key` in the attr map |
-  | Boundary (a marked `defview` product) | one props map, every lazy sequence in it realized ([[realize-deep]]) | trailing forms as `(:children props)`, a realized vector | `:key` in the props map, extracted before the body sees props |
+  | Boundary (a marked `defview` product) | one props map, every lazy sequence in it realized and every unforced `delay` in it refused ([[realize-deep]]) | trailing forms as `(:children props)`, a realized vector | `:key` in the props map, extracted before the body sees props |
   | Fragment `[:<> …]` | optional attr map | trailing forms | on the fragment's props map |
 
   A React element is a legal child anywhere. No metadata keys, no second
@@ -543,9 +543,42 @@
 (defn- realize-entry [_ _ x] (realize-deep x) nil)
 (defn- realize-item  [_ x]   (realize-deep x) nil)
 
+(defn- refuse-deferred!
+  "The one thing the crossing walk **refuses** rather than repairs.
+
+  A `delay` is an author's explicit statement that a computation happens
+  *later*, and the codec may not overrule it: forcing it at the hand-off
+  would be the opposite of what a `delay` is for, and would change the
+  meaning of the author's program to protect a property the author has
+  not been told about. Refusing costs nothing and states the problem.
+
+  The refusal is raised **inside the render of the body that wrote the
+  `delay`**, because [[realize-deep]] runs at the crossing — so the stack
+  lands on the author's own call site rather than on the child that would
+  otherwise have been blamed. That is the attribution a query name would
+  have bought, obtained without forcing anything to learn the name.
+
+  Only an **unforced** delay is refused. One the author already deref'd
+  in their own body carries a computed value, derefs to it without
+  calling anything, and is harmless wherever it goes."
+  [v]
+  (fail! :rf.error/hicasso-deferred-read-at-boundary
+         'front.codec/boundary-element
+         (str "An unforced `delay` reached a boundary's props. It would be "
+              "forced inside the CHILD's render, so any subscription it reads "
+              "becomes the child's edge, is cached by the delay, and is then "
+              "dropped the next time the child renders — a value correct on "
+              "screen, frozen thereafter, and attributable to nothing. Hicasso "
+              "will not force it for you: that would change what your `delay` "
+              "means. Hand a FUNCTION instead — the child calls it on every "
+              "render, so its reads are the child's edges and are kept — or "
+              "deref the delay in the body that wrote it.")
+         :hand-a-function-or-deref-it-in-this-body
+         {:value v}))
+
 (defn realize-deep
-  "Force every lazy sequence reachable from `v`, and return **`v` itself,
-  by identity**.
+  "Force every lazy sequence reachable from `v`, refuse any unforced
+  `delay` reachable from it, and return **`v` itself, by identity**.
 
   ## Why a boundary needs this and a native tag does not
 
@@ -603,10 +636,36 @@
   A seq of unbounded length at a boundary prop position now diverges here
   rather than in the child. That is the same thing `clj->js` already does
   to one at a native prop position, and it must be: a deferred read
-  cannot be both unbounded and attributable."
+  cannot be both unbounded and attributable.
+
+  ## What it forces, and the one thing it refuses
+
+  A lazy sequence is **structure**, and structure is what a codec walk is
+  entitled to force: forcing it changes nothing an author could observe,
+  because the seq was going to be walked one boundary later regardless.
+  A `delay` is not structure. It is an explicit deferral, and the whole
+  of its meaning is *not now* — so the walk may not force it, and
+  [[refuse-deferred!]] says so instead. That is the entire difference
+  between the two carriers, and the reason one is repaired silently and
+  the other cannot be.
+
+  The check costs one `instanceof` per non-collection node, on the branch
+  that already exists for scalars, and it is never reached for anything
+  the walk descends into. `realized?` narrows it further: a `delay` the
+  author already deref'd in their own body is a computed value and passes
+  through.
+
+  **Its reach is the walk's reach, and no further.** The walk descends
+  into data structures; a *mutable reference* is not one, and is not
+  descended into. A deferral an author parks in an atom — or in a
+  module-level var the codec never sees — is outside what any structural
+  pass can reach, and is a declared limit rather than a repair this
+  function withheld."
   [v]
   (if-not (coll? v)
-    v
+    (if (and (delay? v) (not (realized? v)))
+      (refuse-deferred! v)
+      v)
     (do (if (map? v)
           (reduce-kv realize-entry nil v)
           (reduce realize-item nil v))
@@ -679,6 +738,12 @@
         ;; time. [[realize-deep]] returns the map by identity and covers
         ;; `:children` in the same pass, which is where the one-level
         ;; flatten leaves a nested seq. rf2-2rtt6.45.
+        ;;
+        ;; The same pass refuses the one carrier it may not repair — an
+        ;; unforced `delay`, whose meaning is precisely that it is not
+        ;; forced here. The refusal fires inside THIS body's render, so
+        ;; the author who wrote the crossing is the one who sees it.
+        ;; rf2-2rtt6.32.
         body-props (realize-deep (cond-> (dissoc props :key)
                                    children (assoc :children children)))
         js-props   #js {"rfProps" body-props}]


### PR DESCRIPTION
An unforced `delay` handed across a boundary was the last **silent** member of
the read-outside-the-render family, and this closes it — by refusing it, not by
forcing it.

## The shape, and why it was silent

`read-key!`'s guard asks *is any body running*, not *is THIS body running*. A
`delay` written in one body and deref'd in the child's render therefore finds a
frame and does **not** throw. Verified by writing the case rather than reasoning
about it (the probe is preserved as `the-fault-the-refusal-replaces`):

| | reads |
|---|---|
| parent | `#{}` |
| child, first render | `#{[:dogfood/todo 1]}` |
| child, second render | `#{}` |

A `Delay` caches, so the child's second render calls `sub` zero times, its read
set collapses, React re-subscribes, and the edge is dropped with no boundary
left holding one. The parent never held an edge, so it never re-renders and the
delay is never rebuilt. **Correct on screen, frozen thereafter, attributable to
nothing** — the worst failure this surface has.

## The fix: a diagnostic, not a repair

`codec/realize-deep` — already the one walk at the crossing — refuses an
**unforced** `delay` it reaches.

**It does not force it, and that is the point.** A lazy seq is *structure*, and
forcing structure changes nothing an author could observe: the seq was going to
be walked one boundary later regardless. A `delay` is not structure. Its whole
content is *not now*, so forcing it at the hand-off would change the meaning of
the author's program to protect a property the author was never told about —
a silent repair of a different kind, no better than the silent staleness. The
right answer for an explicit deferral is a diagnostic, and the design record now
says so in those words.

The refusal fires **inside the render of the body that wrote the crossing**, so
the stack lands on the author's own call site. That is the attribution a query
name would have bought, obtained without forcing anything to learn the name — a
`delay` cannot name its query without being forced, which is exactly what may
not happen.

Only an unforced one is refused. A `delay` the author already deref'd in their
own body carries a computed value, derefs to it without calling anything, and
passes through untouched (`a-delay-the-author-already-forced-crosses-untouched`).

## Fences

- **No render identity.** The check is on the value's shape, made inside the
  producing body's own window. `rstate` is still one module-level object and
  nothing can tell one render attempt from another. The per-boundary render
  token rejected in #7329 is not built here and is not needed.
- **Hook budget untouched**: 2 hooks at 1/7/20 reads, `subscribe` still closes
  over the read set alone. `arm1-hook-ledger-dom-cljs-test` green.
- Surface B only. No candidate ledger, no post-render reconciliation, no
  compiler, no analyzer, no dual mode, no ViewCell-class graph.
- One `instanceof` on the branch that already existed for scalars, plus
  `realized?` on the exceptional path only. Not re-clocked: the bench lane was
  in use by `rf2-2rtt6.34`, and the walk's shape is unchanged.
- The canonical structural-slot filter merged in #7332 was read first; this
  change touches no slot rule and duplicates nothing — it extends the crossing
  walk only.

## Every deferred shape, enumerated and classified by writing it

| Shape | Verdict |
|---|---|
| `delay` at a boundary prop, deref'd in the child | **was silent, now LOUD** (`:rf.error/hicasso-deferred-read-at-boundary`) |
| `delay` nested in a vector / map / list / lazy seq / set in the props | **LOUD** — the refusal's reach is the walk's reach |
| `delay` in the children slot | **LOUD** — `:children` is a key in the same map |
| `delay` already forced by its author | **fine**, and passes through untouched |
| `delay` created and forced inside one body | **fine** — right owner, rebuilt every render |
| `delay` deref'd outside any render | already LOUD (`hicasso-sub-outside-render`) |
| function prop, called in the child's render | **fine** — verified, not argued: the read repeats and the edge is the child's |
| function prop, called outside a render | already LOUD |
| render prop the body stops calling | **fine** — law 4, and no framework can tell it from a branch not taken |
| a deferral parked in a **mutable reference** (atom prop, or a module var) | **declared limit** — asserted unrepaired |

The declared limit is a boundary of the mechanism rather than a gap in it: the
walk descends into data structures and a mutable reference is not one. Opening
it fails in both directions — a walk that deref'd a reactive reference would
mint a dependency it has no business holding, and one that deref'd a `delay`
would be the forcing this change declines. The author has routed state around
the ruled surface; React with hooks has the identical hole. It is asserted in
`a-deferral-parked-in-a-mutable-reference-is-outside-the-walk` so it is a stated
property of Surface B rather than a later discovery.

## Docs

`docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md` — the
"One residual case, and one that was not residual" subsection is corrected
**in place**. Its closing "What genuinely remains" paragraph said the `delay`
was a fault no walk may repair and left it there; it now records the refusal,
the reason a `delay` is not forced, the function-prop verdict as verified rather
than asserted, and the mutable-reference limit as the only thing that genuinely
remains. No second statement was added beside it and no heading was renamed, so
the in-page anchor is unchanged.

## Quality gates

All run on the rebased tree (main moved under this branch mid-flight; every
figure below is post-rebase, foreground, worktree-local logs).

| Gate | Exit | Result |
|---|---|---|
| `npm run test:cljs` | **0** | 12211 tests, 60949 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **0** | 908 tests, 5741 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` | **0** | PASS fast PR spine (includes `scripts/check_doc_slugs.py`) |
| `scripts/check_doc_slugs.py` (direct) | **0** | link targets and heading anchors clean |
| clj-kondo **2026.04.15**, CI's exact args | **0** | **errors: 0**, warnings 4526 (unchanged baseline) |

clj-kondo was fetched at CI's pinned version — the npm package tops out at
2025.10.23, so the GitHub release binary was used, `clj-kondo v2026.04.15`
verified before the run. The only finding on a touched file is a pre-existing
`info: Single argument to str already is a string` in `codec.cljs`, present on
`main` and not error level.

### Mutation proof

Guard deleted from `realize-deep` (`(if (and (delay? v) (not (realized? v))) ...)`
becomes `v`), everything else untouched:

| | Exit |
|---|---|
| guard removed | **1** — 12 failures, 1 error |
| guard restored | **0** — 10 tests, 28 assertions, 0 failures |

The refusal rows fall silent without it, and `the-fault-the-refusal-replaces`
is what makes the silence legible: it asserts the dropped edge directly, driven
around the codec, so removing the guard cannot quietly restore the fault
unnoticed.

### TESTING.md matrix

`arm1/deferred_read_cljs_test.cljs` carries the plain `-cljs-test` suffix, so it
is selected by `:node-test` only and runs in the `npm run test:cljs` PR lane. It
needs no browser: the refusal is a pure codec verdict reached before any element
is built, so a Chromium mount would re-prove what the node rows already prove.
The DOM half was earned for `rf2-2rtt6.45` because that claim was about
*liveness*, which a first paint cannot tell you; this one is not. `test:browser`
was run in full regardless and is green. Everything else is CI's per TESTING.md
(prod-elision, bundle-isolation, perf, Xray feature matrix, mcp-conformance,
tool JVM suites). `mkdocs --strict` is not on PATH locally and CI runs it; it
does not reach `docs/design/**` in any case, and the gate that does —
`check_doc_slugs.py` — is green above. Table column counts in the edited
subsection were checked by hand: the one added table is 2 columns across header,
separator and both rows, matching the two tables already in the section.
