### PR TITLE
hicasso: costing the registry-epoch and node-key axes, and closing both off disposal (rf2-2rtt6.44)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/disposed_cell_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/disposed_cell_cljs_test.cljs
@@ -1,0 +1,287 @@
+(ns re-frame.bench.hicasso.arm1.disposed-cell-cljs-test
+  "THE REGISTRY-EPOCH AND NODE-KEY AXES (rf2-2rtt6.44).
+
+  `generation_fence_coverage_cljs_test` proved that a `:sub`
+  re-registration moves neither term of
+  [[re-frame.bench.hicasso.arm1.runtime/commit-basis]], and stated the
+  same of a same-id frame reincarnation. Both were filed as *design
+  decisions wanting costing*: closing them by giving every key a registry
+  term looked like the only move, and it would have re-rendered every
+  boundary on every re-registration.
+
+  **The costing found the premise wrong, and this file is the
+  measurement.** The axes are not blind spots in an arithmetic. Both
+  events *dispose the reaction a cell holds*:
+
+  - a `:sub` re-registration evicts the query's sub-cache entry and
+    disposes its reaction (`re-frame.subs.cache/invalidate-sub-on-replace!`);
+  - a frame destruction disposes the frame's cached reactions, including
+    when a same-id successor immediately replaces it.
+
+  The spine's derived container clears its own watcher set in `-dispose`,
+  so from that instant the arm's cell is **deaf** — no watch, so no
+  `mark-dirty!`, so no flush, so no notification ever again — and its
+  deref answers the RETIRED computation, or the destroyed incarnation's
+  app-db, for as long as the boundary lives. The four `deliberately-*`
+  rows below pin exactly that failure, and they are the reason a registry
+  term was declined: a moved number buys one extra render, and the extra
+  render reads back through the same dead cell.
+
+  What closes both axes is the substrate's own disposal event, armed once
+  per unique key at `wire-cell!` time. It costs no React hook, no
+  per-boundary object, and nothing at all in the epoch sum — the two
+  rows at the bottom are that bill, checked rather than claimed.
+
+  Everything here runs against Arm 1's own runtime over the React spine's
+  adapter: on an unwatchable host a subscription never notifies and the
+  `notified` half of every row would pass by never firing."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     ;; The rebuild rows resume on a later tick, and `cljs.test` refuses a
+     ;; fn-form fixture for an `async` test — the fn-form's ambient scope is
+     ;; a dynamic binding that would be unwound before the body resumes.
+     :async?        true
+     ;; The carried-invariant chain resolves the dynamic-var frame tier
+     ;; BEFORE React context, so a fixture-installed ambient frame would
+     ;; answer reads for a frame this file never made.
+     :ambient-frame nil
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+;; This file's OWN queries and OWN frames: a re-registration is a global
+;; act, and re-registering a query some other suite reads would be a test
+;; writing on a neighbour.
+(def ^:private q-reg [:disposedcell/reg])
+(def ^:private q-node [:disposedcell/node])
+
+(defn- make-frame! [id db]
+  (live-frame/make-frame {:id id})
+  (frame/replace-app-db! id db)
+  id)
+
+(defn- reader
+  "A boundary whose whole body is one read, so the read set is one key
+  and the snapshot arithmetic is one term."
+  [q seen]
+  (fn [_] (let [v (rt/sub q)] (vreset! seen v) [:li (str v)])))
+
+(defn- settle!
+  "Run the macrotask queue once. `invalidate-cell!`'s rebuild is deferred
+  — it fires inside the registrar's replacement hook and inside frame
+  teardown, and neither is a place to subscribe — so a row that asserts
+  about the REBUILT attachment has to wait for it.
+
+  Callers pair this with `cljs.test/async`. Without that the callback
+  runs after the run has been reported and its assertions are counted by
+  nobody, which is a green that proves nothing — the state this file was
+  in before the assertion count was reconciled against the rows."
+  [k]
+  (js/setTimeout k 0))
+
+;; ---------------------------------------------------------------------------
+;; The registry-epoch axis
+;; ---------------------------------------------------------------------------
+
+(deftest a-re-registered-sub-reaches-a-boundary-that-already-holds-the-key
+  (testing "The predecessor's `:registry-epoch` field, and the axis
+            rf2-2rtt6.42 deliberately left open. A boundary is mounted and
+            holds a cell for the key; the handler behind that query is
+            then REPLACED, which is what an HMR save does. Every later
+            render must compute against the new registration, and every
+            later write must still notify."
+    (rf/reg-sub (first q-reg) (fn [db _] (:v db)))
+    (async done
+    (let [seen (volatile! nil)
+          f    (make-frame! ::registry {:v 1})]
+      (rt/render-body f (reader q-reg seen) {})
+      (let [entry    (rt/last-reads)
+            hits     (volatile! 0)
+            release! (rt/commit-boundary! entry (fn [] (vswap! hits inc)))]
+        (is (= 1 (:cells (rt/stats)))
+            "RETAINED: the commit acquired a cell, so the key's reaction is
+             held for the life of this boundary — which is what makes the
+             warm read a pure deref, and what exposes it to a disposal")
+
+        (testing "the CONTROL — the watch is live before the re-registration"
+          (frame/replace-app-db! f {:v 2})
+          (is (= 1 @hits) "a write notified the boundary")
+          (rt/render-body f (reader q-reg seen) {})
+          (is (= 2 @seen) "and the re-render read the new value"))
+
+        ;; THE RE-REGISTRATION.
+        (rf/reg-sub (first q-reg) (fn [db _] (* 10 (:v db))))
+
+        (testing "the next render computes against the NEW registration"
+          (rt/render-body f (reader q-reg seen) {})
+          (is (= 20 @seen)
+              "20, not 2: the cell's reaction was disposed by the sub-cache
+               eviction, so the read falls through to `subscribe-once`,
+               which resolves the handler that is registered NOW"))
+
+        (settle!
+          (fn []
+            (testing "and the durable attachment is rebuilt, so later writes
+                      notify again"
+              (let [before @hits]
+                (frame/replace-app-db! f {:v 3})
+                (is (pos? (- @hits before))
+                    "the boundary was notified — without the rebuild the cell
+                     is deaf from the disposal onwards, because `-dispose`
+                     cleared the watcher set this arm's `add-watch` was in")))
+            (rt/render-body f (reader q-reg seen) {})
+            (is (= 30 @seen) "and it reads the new handler over the new db")
+            (release!)
+            (done))))))))
+
+(deftest deliberately-a-disposed-cell-derefs-the-retired-computation
+  (testing "the failure the row above repairs, stated as its own
+            assertion so the repair cannot quietly stop being needed. A
+            cell that is NOT invalidated keeps deriving through the
+            container the sub-cache disposed, and that container still
+            computes — with the handler it captured. It is not a stale
+            VALUE (it tracks the db) but a stale COMPUTATION, which is
+            strictly worse: it looks alive."
+    (rf/reg-sub (first q-reg) (fn [db _] (:v db)))
+    (let [f (make-frame! ::registry-retired {:v 1})]
+      (rt/render-body f (reader q-reg (volatile! nil)) {})
+      (let [entry    (rt/last-reads)
+            release! (rt/commit-boundary! entry (fn []))
+            ;; Reach past the repair: hold the reaction the cell held, then
+            ;; re-register. This is exactly the object the cell kept before
+            ;; `invalidate-cell!` existed.
+            held     (rt/cell-reaction [f q-reg])]
+        (is (some? held) "precondition: the cell holds a reaction")
+        (rf/reg-sub (first q-reg) (fn [db _] (* 10 (:v db))))
+        (frame/replace-app-db! f {:v 7})
+        (is (= 7 @held)
+            "the disposed container answers 7 — the RETIRED `(:v db)` over
+             the new db — where the live registration answers 70. A term in
+             `getSnapshot` would have scheduled a re-render that read
+             exactly this")
+        (is (nil? (rt/cell-reaction [f q-reg]))
+            "which is why the cell drops the reference instead: the repair
+             is to stop reading through it, not to re-read it")
+        (release!)))))
+
+;; ---------------------------------------------------------------------------
+;; The node-key axis
+;; ---------------------------------------------------------------------------
+
+(deftest a-same-id-frame-reincarnation-reaches-a-boundary-that-holds-the-key
+  (testing "The predecessor's third field. `frame-commit-epoch` is cleared
+            by `dissoc-frame!`, so a same-id successor restarts at 0 and
+            the basis is monotone only WITHIN one incarnation — which is
+            precisely why Spec 006's observation port carries `:node-key`
+            rather than trusting the two epochs. The arm observes node
+            identity nowhere, and does not need to: the destruction
+            disposes the cell's reaction, and that is the same event the
+            registry axis rides."
+    (rf/reg-sub (first q-node) (fn [db _] (:v db)))
+    (async done
+    (let [seen (volatile! nil)
+          f    (make-frame! ::node {:v 1})]
+      (rt/render-body f (reader q-node seen) {})
+      (let [entry    (rt/last-reads)
+            hits     (volatile! 0)
+            release! (rt/commit-boundary! entry (fn [] (vswap! hits inc)))
+            token-a  (frame/frame-incarnation-token f)
+            basis-a  (rt/commit-basis f)]
+        (is (= 1 @seen) "incarnation A's value")
+
+        ;; THE REINCARNATION.
+        (frame/destroy-frame! f)
+        (make-frame! f {:v 99})
+
+        (testing "the precondition this axis exists for — the basis TIES"
+          (is (not (identical? token-a (frame/frame-incarnation-token f)))
+              "a distinct incarnation, and `frame-incarnation-token` is the
+               public reader that says so")
+          (is (= basis-a (rt/commit-basis f))
+              "and yet the basis is the number it was: the epoch restarted at
+               0 and climbed back to exactly where it stood. A tie, not a
+               near-miss — so no arithmetic over these two terms could have
+               distinguished the incarnations"))
+
+        (testing "the boundary reads the SUCCESSOR's app-db"
+          (rt/render-body f (reader q-node seen) {})
+          (is (= 99 @seen)
+              "99, not 1: the destroyed incarnation's reaction was disposed
+               with its frame, so the read resolves against the frame that is
+               live now"))
+
+        (settle!
+          (fn []
+            (testing "and the rebuilt attachment tracks the successor"
+              (let [before @hits]
+                (frame/replace-app-db! f {:v 100})
+                (is (pos? (- @hits before)) "a write on B notified the boundary"))
+              (rt/render-body f (reader q-node seen) {})
+              (is (= 100 @seen)))
+            (release!)
+            (done))))))))
+
+(deftest deliberately-a-cell-pinned-to-a-destroyed-incarnation-answers-its-db
+  (testing "the reincarnation half of the failure, pinned. The held
+            container is wired to the frame that no longer exists, so it
+            answers that frame's app-db forever — 1, whatever the
+            successor holds — and the epoch sum cannot report it because
+            the basis ties."
+    (rf/reg-sub (first q-node) (fn [db _] (:v db)))
+    (let [f (make-frame! ::node-pinned {:v 1})]
+      (rt/render-body f (reader q-node (volatile! nil)) {})
+      (let [entry    (rt/last-reads)
+            release! (rt/commit-boundary! entry (fn []))
+            held     (rt/cell-reaction [f q-node])]
+        (is (some? held) "precondition: the cell holds a reaction")
+        (frame/destroy-frame! f)
+        (make-frame! f {:v 99})
+        (is (= 1 @held)
+            "the pinned container answers incarnation A's 1 where the live
+             frame holds 99")
+        (is (nil? (rt/cell-reaction [f q-node]))
+            "so the cell drops it")
+        (release!)))))
+
+;; ---------------------------------------------------------------------------
+;; What closing the two axes cost
+;; ---------------------------------------------------------------------------
+
+(deftest closing-the-axes-cost-no-hook-and-nothing-in-the-snapshot
+  (testing "the tripwire. The alternative on the table was a registry term
+            in every key's contribution to `getSnapshot`; what landed is
+            an event armed once per unique key. So the shell is unchanged,
+            the snapshot arithmetic is unchanged, and `subscribe` still
+            closes over the read set alone."
+    (is (= 2 (count rt/shell-hook-ledger))
+        "still two hooks — the disposal hook is not a React hook")
+    (is (= [:use-context/frame :use-sync-external-store/subscription-epoch]
+           rt/shell-hook-ledger)
+        "and the same two, in the same order")
+    (let [inv (rt/retained-inventory)]
+      (is (= #{:use-ref :use-state :view-cell :candidate-ledger}
+             (into #{} (map :token) (:absent inv)))
+          "the enumerated absences are unchanged: no per-boundary object was
+           added, and nothing is keyed by a render or an attempt")))
+
+  (testing "a clean mount is undisturbed — the repair must not become
+            `re-render always`, which is what a registry term would have
+            risked on every boundary in the application"
+    (rf/reg-sub (first q-reg) (fn [db _] (:v db)))
+    (let [f     (make-frame! ::registry-clean {:v 1})
+          _     (rt/render-body f (reader q-reg (volatile! nil)) {})
+          entry (rt/last-reads)
+          at-render (rt/snapshot-of entry)
+          release!  (rt/commit-boundary! entry (fn []))]
+      (is (= at-render (rt/snapshot-of entry))
+          "acquisition still moves nothing: the cell is born at the same
+           basis the staged term reported, and arming a disposal hook is not
+           a term")
+      (release!))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -273,13 +273,27 @@
   component. Those notifications are deferred to a macrotask; the fence
   has already made the *rendering* boundary correct.
 
-  **Two axes the predecessor compared still have no counterpart**, and
-  saying so is the point of writing them down: a `:sub` re-registration
-  (its `:registry-epoch`) and a same-id frame reincarnation (its
-  `:node-key`). Neither is a frame-state install, so neither moves the
-  basis — and `frame-commit-epoch` itself restarts at 0 across a
-  reincarnation, which is precisely why the observation port carries
-  `:node-key` as a third field. rf2-2rtt6.44.
+  ### The other two axes, and why they are not the basis's to carry
+
+  The predecessor compared three things, and the basis answers one of
+  them. The other two — a `:sub` re-registration (its `:registry-epoch`)
+  and a same-id frame reincarnation (its `:node-key`) — move neither
+  term, and rf2-2rtt6.44 established that **adding a term for them would
+  have closed nothing**. Both events dispose the reaction a cell holds:
+  a re-registration through the sub-cache's replacement hook, a
+  reincarnation through frame teardown. A disposed container clears its
+  own watcher set, so the cell is deaf from that instant, and it answers
+  the RETIRED computation (or the destroyed incarnation's db) on every
+  later deref. A number that moved would have bought exactly one extra
+  render, and that render would have read back through the same dead
+  cell.
+
+  So the arm takes the substrate's own event instead of a term:
+  [[invalidate-cell!]] is armed per unique key at [[wire-cell!]] time and
+  fires only when a reaction is actually disposed. It costs no hook, no
+  per-boundary object, nothing in the snapshot arithmetic, and no read of
+  the registry — the epoch-sum `getSnapshot` is untouched. rf2-2rtt6.44
+  records the costing that rejected the alternative.
 
   ## What is deliberately NOT here (the hard fences)
 
@@ -296,6 +310,7 @@
             [re-frame.bench.hicasso.front.sub-index :as index]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.subs :as subs]
             ["react" :as react]))
 
@@ -432,10 +447,16 @@
   advances it, which costs at most one redundant re-render and cannot
   cost a missed one. Pure read; allocates nothing.
 
-  Silent on two axes by construction (rf2-2rtt6.44): a `:sub`
-  re-registration is not a frame-state install, and a same-id frame
-  reincarnation RESTARTS `frame-commit-epoch` at 0 — the case the
-  observation port needs its `:node-key` field for."
+  Silent on two axes, and permanently so — a `:sub` re-registration is
+  not a frame-state install, and a same-id frame reincarnation RESTARTS
+  `frame-commit-epoch` at 0 (measured: A's epoch and B's are both 1, so
+  the basis TIES across the reincarnation), which is the case the
+  observation port needs its `:node-key` field for. **Neither axis is
+  this number's to carry**, and rf2-2rtt6.44 settled why rather than
+  extending it: both events dispose the reaction a cell holds, so a
+  moved number would only buy a re-render that read back through the
+  same dead cell. [[invalidate-cell!]] carries them, off the substrate's
+  own disposal event."
   [frame-kw]
   (+ @!generation (frame/frame-commit-epoch frame-kw)))
 
@@ -464,6 +485,80 @@
                  0)
   nil)
 
+(declare invalidate-cell!)
+
+(defn- wire-cell!
+  "Give `cell` a live subscription: subscribe, establish the baseline,
+  arm the value-change watch, and arm the **disposal** hook. The whole of
+  a cell's attachment to the substrate, in one place, because it is
+  performed twice — once when the cell is born and once when the
+  substrate disposes the reaction out from under it.
+
+  The disposal hook is the arm's counterpart to the two axes
+  `commit-basis` cannot see (rf2-2rtt6.44), and it is deliberately an
+  *event* rather than a term in the epoch sum: the substrate already
+  tells us, exactly and only when it happens, and a term would have to be
+  read by every key on every snapshot to discover the same thing later."
+  [^js cell]
+  (let [frame-kw (.-frameKw cell)
+        query-v  (.-queryV cell)
+        wk       (.-watchKey cell)
+        reaction (subs/subscribe query-v {:frame frame-kw})]
+    (set! (.-reaction cell) reaction)
+    (when (some? reaction)
+      ;; ONE baseline deref, before the watch — see `acquire-cell!`.
+      @reaction
+      (add-watch reaction wk
+                 (fn [_ _ old nu] (when-not (= old nu) (mark-dirty! cell))))
+      (interop/add-on-dispose! reaction (fn [] (invalidate-cell! cell))))
+    cell))
+
+(defn- invalidate-cell!
+  "**The two axes the epoch sum cannot carry, closed by the substrate's own
+  event** (rf2-2rtt6.44). A cell holds its reaction for the life of every
+  boundary that reads the key — that is what makes a warm read a pure
+  deref — and two substrate events dispose that reaction underneath it:
+
+  1. a `:sub` **re-registration**, which evicts the query's sub-cache
+     entry and disposes the reaction (`subs.cache/invalidate-sub-on-replace!`);
+  2. a **frame destruction**, whose teardown disposes the frame's cached
+     reactions — including across a same-id reincarnation.
+
+  Both leave the cell holding a container whose `-dispose` has already
+  run `(reset! watchers {})`, so the watch this arm installed is gone and
+  `mark-dirty!` can never fire for that key again. Measured, before this
+  hook existed: the boundary read the RETIRED computation forever and no
+  later write notified it. That is why neither axis was ever closable by
+  adding a term to `getSnapshot` — the extra render a moved number buys
+  reads back through the same dead cell.
+
+  Two phases, and the split is what keeps this out of both re-entrant
+  windows. **Synchronously** the reaction reference is dropped, which is
+  all a correct read needs: [[read-key!]] treats a cell with no reaction
+  exactly as it treats a key with no cell and goes through
+  `subscribe-once`, so every render from this instant on computes against
+  the new registration and the live frame. **On a macrotask** the durable
+  attachment is rebuilt, so later writes notify again — deferred because
+  this callback runs inside the registrar's replacement hook and inside
+  frame teardown, and neither is a place to subscribe. A frame that did
+  not come back has nothing to rebuild against, and the cell is disposed
+  instead."
+  [^js cell]
+  (when-not (.-disposed cell)
+    (set! (.-reaction cell) nil)
+    (js/setTimeout
+      (fn []
+        (when-not (.-disposed cell)
+          (if (nil? (frame/frame-incarnation-token (.-frameKw cell)))
+            (dispose-cell! cell)
+            (do (wire-cell! cell)
+                ;; Re-stamp and notify: a boundary that painted before the
+                ;; disposal painted the retired computation, and this is the
+                ;; commit that corrects it.
+                (mark-dirty! cell)))))
+      0))
+  nil)
+
 (defn- acquire-cell!
   "**Commit-phase only.** Take (building if necessary) the durable
   reference for `sub-key`, and attach the one watch that turns the sub
@@ -473,13 +568,12 @@
   (let [^js cell (or (get @!cells sub-key)
                  (let [frame-kw (nth sub-key 0)
                        query-v  (nth sub-key 1)
-                       reaction (subs/subscribe query-v {:frame frame-kw})
                        wk       (keyword "rf-hicasso-arm1"
                                          (str "w" (vswap! !watch-counter inc)))
                        ^js fresh #js {"subKey"   sub-key
                                      "frameKw"  frame-kw
                                      "queryV"   query-v
-                                     "reaction" reaction
+                                     "reaction" nil
                                      "watchKey" wk
                                      ;; NOT zero. A key with no cell
                                      ;; contributes the CURRENT
@@ -523,10 +617,12 @@
                    ;; spine can tolerate a notification that did not move,
                    ;; since `useSyncExternalStore` re-compares snapshots
                    ;; after it, and this arm cannot.
-                   (when (some? reaction)
-                     @reaction
-                     (add-watch reaction wk
-                                (fn [_ _ old nu] (when-not (= old nu) (mark-dirty! fresh)))))
+                   ;;
+                   ;; [[wire-cell!]] performs that deref, that watch and the
+                   ;; disposal hook, because a cell is attached to the
+                   ;; substrate twice — here, and again if the substrate
+                   ;; disposes the reaction underneath it.
+                   (wire-cell! fresh)
                    (swap! !cells assoc sub-key fresh)
                    fresh))]
     (set! (.-refs cell) (inc (.-refs cell)))
@@ -610,7 +706,14 @@
   Warm — a committed cell holds the key — is a pure deref: no acquire,
   no release, nothing global touched. Cold is `subscribe-once`, which
   subscribes, derefs and unsubscribes inside this tick and retains
-  nothing, so an abandoned render leaves the world as it found it."
+  nothing, so an abandoned render leaves the world as it found it.
+
+  A cell whose reaction the substrate disposed underneath it takes the
+  cold path too, and that is the whole of what an invalidated read needs
+  to be correct: `subscribe-once` computes against the registration and
+  the frame incarnation that are live NOW, so a render in the window
+  between the disposal and [[invalidate-cell!]]'s rebuild reads the new
+  computation rather than the retired one. rf2-2rtt6.44."
   [query-v]
   (when (nil? (.-frame rstate))
     (fail! :rf.error/hicasso-sub-outside-render
@@ -624,8 +727,8 @@
   (let [frame-kw (.-frame rstate)
         sub-key  [frame-kw query-v]]
     (.push scratch sub-key)
-    (if-some [^js cell (get @!cells sub-key)]
-      (when-some [r (.-reaction cell)] @r)
+    (if-some [^js r (some-> ^js (get @!cells sub-key) (.-reaction))]
+      @r
       (subs/subscribe-once query-v {:frame frame-kw}))))
 
 (defn sub
@@ -1049,6 +1152,17 @@
     {:token :view-cell :what "no per-boundary object graph, reaction, watcher or scheduler"}
     {:token :candidate-ledger
      :what  "one scratch buffer, never two; nothing keyed by render, attempt, lane or generation; no per-read object; no commit-phase deref"}]})
+
+(defn cell-reaction
+  "The subscription `sub-key`'s cell currently derives through, or nil —
+  either because nothing holds the key, or because the substrate disposed
+  the reaction and [[invalidate-cell!]] dropped the reference.
+
+  A witness reader, and the one the rf2-2rtt6.44 rows need: the failure
+  they pin is what a HELD container answers after its disposal, so they
+  have to be able to hold it."
+  [sub-key]
+  (some-> ^js (get @!cells sub-key) (.-reaction)))
 
 (defn stats
   "What the witnesses read: live cells, live boundaries, cached read-set

--- a/implementation/freehand/test/re_frame/bench/hicasso/generation_fence_coverage_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/generation_fence_coverage_cljs_test.cljs
@@ -43,12 +43,23 @@
   RESTARTS at 0 across one, which is precisely why Spec 006's observation
   port carries `:node-key` as a third field.
 
-  Both remaining axes are tracked as **rf2-2rtt6.44**, where the question
-  is a design decision rather than a defect: closing the registry axis for
-  a retained key would mean re-rendering every boundary on every
-  re-registration, and `observation/registry-epoch*` is `^:private` with
-  no public reader, so the arm cannot even observe it without a substrate
-  change.
+  ## The axes are closed; this arithmetic is not what closed them
+
+  **rf2-2rtt6.44 settled both, and the rows below survive it unchanged** —
+  which is the point of keeping this file. The commit basis is still blind
+  to a re-registration, still blind to a reincarnation, and *should be*:
+  the costing found that a registry term would have bought nothing. Both
+  events dispose the reaction the arm's cell holds, so the cell is deaf
+  and derives through a retired computation from that instant; the extra
+  render a moved number scheduled would have read straight back through
+  it. What closes them is the substrate's own disposal event
+  (`arm1.runtime/invalidate-cell!`), armed per unique key, costing nothing
+  in this arithmetic — so `observation/registry-epoch*` stayed `^:private`
+  and no substrate reader was added. `arm1/disposed-cell-cljs-test` is the
+  measurement, both failures pinned and mutation-proved.
+
+  These rows are therefore a **standing statement of scope**: this number
+  answers the version axis and only the version axis.
 
   ## The row carries its own control, and needs to
 
@@ -122,8 +133,10 @@
             move either. Both terms of the basis sit still, and the epoch
             sum React re-checks sits still with them.
 
-            rf2-2rtt6.44 carries this axis, and the `:node-key` axis the
-            same argument covers."
+            That is correct and permanent, not a gap awaiting a term:
+            rf2-2rtt6.44 closed this axis (and the `:node-key` axis the
+            same argument covers) off the substrate's disposal event
+            instead, leaving this arithmetic exactly as it stands."
     (rf/reg-sub (first q) (fn [db _] (:v db)))
     (let [seen (volatile! nil)
           f    (make-frame! ::registry {:v 1})]


### PR DESCRIPTION
rf2-2rtt6.42 closed the staged-read tear on the **version** axis and filed the other two of the predecessor's three compared fields — `:registry-epoch` and `:node-key` — as design decisions wanting costing. This PR is the costing. **It found the premise wrong**, so the term the bead feared was declined and something narrower taken instead.

## What the costing found

Neither axis was ever a blind spot in the epoch sum. Both events **dispose the reaction an Arm 1 cell holds**:

- a `:sub` re-registration evicts the query's sub-cache entry and disposes its reaction (`subs/cache.cljc` `invalidate-sub-on-replace!`);
- a frame destruction disposes the frame's cached reactions, including when a same-id successor immediately replaces it.

The spine's derived container runs `(reset! watchers {})` in `-dispose` (`substrate/spine.cljs:949`), so the arm's `add-watch` goes with it. Measured on the pre-fix runtime:

| | after a `:sub` re-registration | after a same-id reincarnation |
|---|---|---|
| read returns | `2` (live registration answers `20`) | `1` (successor holds `99`) |
| notifications on the next write | **0** | **0** |
| read after that write | `3` (new handler gives `30`) | `1` (frame B holds `100`) |

So the boundary is **permanently deaf** and derives through the **retired computation** — not a stale value that tracks the db, but a stale *computation*, which looks alive. `frame-commit-epoch` for incarnation A is `1`, `0` after `dissoc-frame!`, and `1` again for B: the basis **ties exactly**, so no arithmetic over those two terms could have separated the incarnations.

## Why the registry term was declined

**It corrects nothing.** A moved number buys one extra render, and that render calls `read-key!`, finds the cell, and derefs the disposed reaction — the retired computation. Pinned as an assertion: the held container answers `7` where the live registration answers `70`.

And it is not cheap:

- **Frequency.** `registry-epoch*` bumps on every `:sub` registration, first-time *and* replacement. One HMR save re-registers a whole namespace — 8–15 `reg-sub` forms per namespace in this repo's own example corpus (max 15, `examples/real-apps/realworld_http/comments.cljs`). One save is 8–15 bumps.
- **Blast radius.** The term sits in *every* key's contribution, so every mounted boundary's snapshot moves on every bump.
- **React 19.2.0 mechanics**, read from `react-dom-client.development.js` rather than assumed: `updateSyncExternalStore` (:8162) pushes `updateStoreInstance` when the snapshot moved, and `checkIfSnapshotChanged` (:8250) → `forceStoreRerender` (:8260) re-renders the boundary. Worse, `pushStoreConsistencyCheck` (:8225) is recorded on every non-blocking lane, and `isRenderConsistentWithExternalStores` (:16841) discards the **entire concurrent render pass** if any recorded snapshot moved.

So the broad option costs up to 15 whole-tree concurrent-render invalidations per HMR save, plus a forced re-render per in-flight boundary, in exchange for zero correction. Declined, per the bead's own instruction.

## What was taken instead

The substrate's own disposal event. `wire-cell!` arms `interop/add-on-dispose!` **once per unique key**; `invalidate-cell!` then:

- **synchronously** drops the reaction reference — `read-key!` treats a cell with no reaction exactly as a key with no cell and goes through `subscribe-once`, so every render from that instant computes against the live registration and the live frame;
- **on a macrotask** rebuilds the durable attachment so later writes notify again — deferred because the callback fires inside the registrar's replacement hook and inside frame teardown, and neither is a place to subscribe. A frame that did not come back has nothing to rebuild against and the cell is disposed.

**No substrate change was needed.** `observation/registry-epoch*` stays `^:private`, no public reader was added, and **no spec surface moves**. `frame/frame-incarnation-token` (already public, `frame.cljc:877`) would have been the cheap `:node-key` reader, but the disposal event subsumes it and is strictly better: a token comparison could only have *flagged* the reincarnation, where this also repairs the cell.

## Fences held

- Shell is still **2 hooks** (`:use-context/frame`, `:use-sync-external-store/subscription-epoch`) — asserted, not claimed.
- `subscribe` still closes over the read set alone; `make-subscribe` is untouched.
- The snapshot arithmetic is untouched — the disposal hook is not a term.
- No candidate ledger, no compiler, no analyzer, no dual mode, no ViewCell-class object graph; `retained-inventory`'s enumerated absences are unchanged and asserted.

## The record

`generation_fence_coverage_cljs_test`'s assertions are **unchanged and still pass** — the basis is still blind to both axes, and should be. Its ns docstring now reads as a standing statement of scope rather than an open gap. `commit-basis`'s docstring and the runtime ns docstring were the two places that named this bead; both now state exactly what is true, with every claim in them backed by a passing assertion.

## Quality gates

Surfaces derived from the CI classifier (`.github/scripts/report-changed-surfaces.sh`) on this diff, not from prose: `implementation_jvm=true`, `cljs_node_test=true`, `cljs_browser=true`, `examples_compile=true`, `cljs_prod=true`; `bundle_isolation`, `adapter_testbed_smokes`, `ui_smoke`, `ui_gates`, `freehand_evidence_elision`, `freehand_reachability` all **false** — the change is confined to `implementation/freehand/test/re_frame/bench/hicasso/**` and touches no core substrate, so the transitive adapter/bundle surface is not armed. Per TESTING.md, `test:cljs` + `test:browser` are the lanes that carry these namespaces. No spec page touched, so no `mkdocs build --strict`.

All run foreground on the rebased tree (main moved `arm1/runtime.cljs` under this branch via rf2-2rtt6.46/.47, so the pre-rebase greens were re-earned):

| Gate | Exit |
|---|---|
| `npm run test:cljs` — 12206 tests / 60943 assertions, 0 failures | 0 |
| `npm run test:browser` — 908 tests / 5741 assertions, 0 failures | 0 |
| `npm run test:examples-compile` — 42 example builds, zero warnings | 0 |
| `npm run test:browser-schemas-boundary-prod` — 8 tests / 15 assertions | 0 |
| `npm run test:browser-prod-elision` — `ui mounted production elision: PASS`, 120 tests / 527 assertions | 0 |
| `implementation/freehand` JVM (`clojure -M:test`) — 1288 tests / 8856 assertions | 0 |
| `clj-kondo` 2026.04.15, CI's exact `--lint` roots, `--fail-level error` — **errors: 0** (4526 pre-existing warnings, none in the changed files) | 0 |

One gate needed a second run, and the reason was mine rather than the diff's: `test:browser-prod-elision` first exited 1 while a 627-second `clj-kondo --parallel` sweep was saturating every core, and its failure was the *checker's mutant control build* aborting with `par-compile ... still waiting for` cascades in `re-frame.freehand.react` / `re-frame.http.transport` — namespaces this diff cannot reach, on a gate that had been green pre-rebase. Re-run alone it passes. Recorded rather than quietly re-rolled.

**Mutation-proved.** Removing the single `interop/add-on-dispose!` line reds **8 assertions across all four substantive rows** of `arm1/disposed_cell_cljs_test`, on the rebased tree. The witness also carries both failures as their own `deliberately-*` rows, so the repair cannot quietly stop being needed.

One note on the witness itself: its first green was false. The rebuild assertions ran inside a `setTimeout` under a fn-form fixture, so they resolved after the run was reported and were counted by nobody (18 assertions, all synchronous). It now uses `cljs.test/async` with the fixture's `:async? true` map form, and the count is 22 — the 4 rebuild assertions genuinely gate.
