### PR TITLE
docs,bench(hicasso): the restated clock lines become checkable from the repository (rf2-b0tz5)

### DIFF
--- a/docs/design/hicasso/studio/hd8-freehand-codec-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-freehand-codec-donor-arm.md
@@ -23,10 +23,10 @@ Bead **`rf2-2rtt6.29`**. Decision **[HD-008](../decisions.md)**. The standard is
 > **NO BAR VERDICT IS ISSUED HERE, AND NONE MAY BE READ OUT OF THIS PAGE.**
 > The mount win condition is suspended as a gate pending an operator amendment:
 > post-`rf2-2rtt6.25`, UIx and Reagent are at parity on the converged mount
-> witness (1.0243×), which makes *"mount ≤ 1.0× Reagent"* arithmetically require
+> witness (1.0150×), which makes *"mount ≤ 1.0× Reagent"* arithmetically require
 > a free-or-negative interpreter and puts it in contradiction with the
 > *"codec inside 1.10× of direct UIx"* condition beside it
-> (1.0243 × 1.10 = 1.127). Every figure below is therefore reported **against
+> (1.0150 × 1.10 = 1.117). Every figure below is therefore reported **against
 > raw UIx and against the existing donor arms**, and the bar is applied later by
 > whoever holds it. This page measures. It issues no ruling and it must not
 > learn to.

--- a/docs/design/hicasso/studio/p0-converged-witness-set.md
+++ b/docs/design/hicasso/studio/p0-converged-witness-set.md
@@ -333,9 +333,9 @@ beside a biased one.
 >
 > Not one row was post-landing, so the whole table needed re-taking rather than
 > just the mount row. **The re-take is [below](#the-re-take-on-the-post-25-tree-rf2-b0tz5)**
-> and it moves exactly one line: **M1 mount, `1.2310×` → `1.0243×`
-> [0.9937 – 1.0549], indistinguishable from parity.** The other three are not
-> distinguishable from their published values at four runs and are **NOT
+> and it moves exactly one line: **M1 mount, `1.2310×` → `1.0150×`
+> [0.9820 – 1.0480], indistinguishable from parity.** The other three are not
+> distinguishable from their published values at five runs and are **NOT
 > restated**. Mike's ruling of 2026-07-31 (option (a), on `rf2-2rtt6.1`) required
 > the re-take to happen on THIS instrument rather than by carrying the coldmount
 > page's post-`.25` figure across, and that is what was done.
@@ -373,7 +373,7 @@ has cleared the threshold.
 > to ±4%. That restored **narrow**, which still stands at `1.1754×`. It also
 > restored **M1**, at `1.2310×` — and [the post-`.25`
 > re-take](#the-re-take-on-the-post-25-tree-rf2-b0tz5) has since superseded that
-> in turn at **`1.0243×` [0.9937 – 1.0549]**, which contains 1.0 and so publishes
+> in turn at **`1.0150×` [0.9820 – 1.0480]**, which contains 1.0 and so publishes
 > no direction at all. What is published either way is a magnitude **with an
 > interval**, which is what the measurement supports; a bare four-decimal point
 > never was. **rf2-2rtt6.1's operator hold on quoting `1.2301` is not lifted
@@ -459,26 +459,102 @@ The other five instrument files are **byte-identical** to the ensemble's:
 | **Schedule** | unchanged — 6 rounds × 2 segments × 3 arms interleaved, one row per page, start counterbalanced across independently launched runs |
 | **Runtime** | HeadlessChrome **147.0.7727.15** (Chromium via Playwright), `:advanced`, `goog.DEBUG false`, Windows 11 x64, 24 logical CPUs |
 
-#### The quiet discipline, and the one run the guard refused
+#### The quiet discipline, and the launch set in full
 
-Three sibling workers were live on this box throughout. **Every published run
-below was launched into a measured-quiet window** — the `java`/`node` toolchain
-sampled under 30% of one core for three consecutive samples immediately before
-launch — and the pre- and post-run readings are recorded per run.
+Three sibling workers were live on this box throughout. **Every run below was
+launched into a measured-quiet window** — the `java`/`node` toolchain sampled
+under 30% of one core for three consecutive samples immediately before launch —
+and the pre- and post-run readings are recorded per run.
 
-**Three runs did not produce a published row, and all three are reported rather
-than quietly dropped.** None was excused and no tolerance was touched:
+**Seven launches, and the table names all seven.** None was excused and no
+tolerance was touched:
 
-| run | outcome | why |
-|---|---|---|
-| launched at **101%** of a core | **exit 2** — arm-order guard, `narrow` | phase strata **1.37×–1.55×** last-third over first-third across the narrow arms — the signature of a box that degraded mid-run (post-run reading 310%). **Re-taken under quiet** |
-| launched at **0%** | **exit 2** — arm-order guard, `M2` | the *mount-budget* fragility this page already documents — 720 mounts a page refused 4 of 6 for `rf2-6i0i2` too. Not contention, and not new |
-| launched at **0%** | **exit 1** — segment-order control, `M1` | the strata point opposite ways across 1.0 — [discussed below](#the-row-now-sits-so-close-to-parity-that-one-run-could-not-be-given-a-direction), where it is treated as a finding rather than a fault |
+| launch | start | outcome | disposition |
+|---|---|---|---|
+| run 1 | reagent | **exit 0**, launched at 2% | **in the ensemble** |
+| run 2, first attempt | uix | **exit 2** — arm-order guard, `narrow`; launched at **101%** of a core | **out.** Phase strata **1.37×–1.55×** last-third over first-third across the narrow arms — the signature of a box that degraded mid-run (post-run reading 310%). **Re-taken under quiet** |
+| run 2, re-take | uix | **exit 0**, launched at 0% | **in the ensemble** |
+| run 3 | reagent | **exit 0**, launched at 0% | **in the ensemble** |
+| run 4 | uix | **exit 2** — arm-order guard, `M2`; launched at **0%** | **out.** The *mount-budget* fragility this page already documents — 720 mounts a page refused 4 of 6 for `rf2-6i0i2` too. Not contention, and not new |
+| run 5 | reagent | **exit 1** — segment-order control, `M1`; launched at **0%** | **IN the ensemble**, and PR #7315 had it out. All four rows completed; see [below](#the-row-now-sits-so-close-to-parity-that-one-run-could-not-be-given-a-direction) |
+| run 6 | uix | **exit 0**, launched at 0% | **in the ensemble** |
 
-A separate `M1`-only pilot taken under load is likewise excluded from every
-figure here. **The first refusal is the evidence that the quiet bar is doing work
-rather than being asserted**, and the second is the evidence that this
-instrument's known M2 fragility is unchanged by the landings.
+A separate `M1`-only pilot taken under load is excluded from every figure here.
+**The 101% refusal is the evidence that the quiet bar is doing work rather than
+being asserted**, and the `M2` refusal is the evidence that this instrument's
+known mount-budget fragility is unchanged by the landings.
+
+**The inclusion rule, stated because the two refusal kinds are not the same
+kind.** The arm-order guard reads *arm timings by plan position* — whether an arm
+reads differently for where in the plan it was measured. That verdict never looks
+at the `uix ÷ reagent` ratio, so excluding a run for it selects on the
+**instrument's validity**. The segment-order control adjudicates *the ratio's own
+strata*, and refuses when they point opposite ways across 1.0 — so excluding a
+run for it selects on **the result**. Under [the aggregate
+rule](#the-partition-and-what-one-runs-split-can-and-cannot-say) the ensemble
+takes every launched run whose validity gates passed, whatever its strata did.
+**Two launches are out, one is in, and which is which is decided by what the gate
+was looking at.**
+
+#### The observation table
+
+**PR #7315 published only summaries.** It printed a point estimate, a 95%
+interval and a run-mean range per row, plus M1's four run means — and committed
+nothing behind them, which is the gap `rf2-6i0i2` had closed for the ten-run
+ensemble one section above and this section reopened. The intervals that decided
+*not restated* on `M2`, `broad` and `narrow` could not be recomputed from the
+repository.
+
+**The table is below.** Every ensemble figure in this section is now derived from
+it by
+`implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs`
+rather than asserted here — both the four-run figures PR #7315 published and the
+five-run figures that replace them.
+
+!!! warning "Provenance — recovered, not re-run, and only down to the run mean"
+
+    **Nothing here was measured again.** No browser was opened; measurement is
+    deferred while the adapter is built and five sibling workers were on the box.
+    The producing worktree (`worker/clockline-b0tz5`) was reaped with its
+    `ai/bench-logs/` inside it, so the run logs themselves are gone. What
+    survives is the **producing agent's own transcript**, which captured the
+    driver's console output and the analysis run over those logs verbatim; the
+    cells below are transcribed from it.
+
+    **The unit that survived is the run mean.** The six per-round readings behind
+    each accepted run's mean did **not** survive — except run 5's, which did in
+    full, because the diagnosis of its refusal was captured whole. So every
+    *ensemble*-level figure below is derivable, and the *per-round* counts this
+    section used to print (`14 of 24 rounds above 1.0`, `1 of 8 strata wholly
+    above`) are **not**. They are marked where they appear, and they are not
+    reconstructed.
+
+Each cell is that run's `red-zone :mean` for the row — its six per-round
+`uix-subs ÷ reagent-subs` readings averaged, each reading floor-normalised in its
+own round and segment. **†** marks the run PR #7315 dropped.
+
+| run | start | M1 | M2 | broad | narrow | `M1` legs — `reagent ÷ floor` · `uix ÷ floor` |
+|---|---|---|---|---|---|---|
+| 1 | reagent | 0.9980 | 1.0584 | 0.6316 | 1.2306 | 4.2853 · 4.2723 |
+| 2 | uix | 1.0391 | 0.9685 | 0.5437 | 1.1767 | 4.3457 · 4.5089 |
+| 3 | reagent | 1.0219 | 1.0714 | 0.5538 | 1.3090 | 4.5731 · 4.6673 |
+| 5 **†** | reagent | 0.9780 | 0.9242 | 0.6135 | 1.1291 | 4.6045 · 4.4573 |
+| 6 | uix | 1.0382 | 0.9302 | 0.5102 | 1.1769 | 4.3144 · 4.4687 |
+
+Run 5's four per-round vectors are in the suite too, because its refusal is the
+one thing here that has to be **re-derived rather than quoted**:
+
+| run 5, six rounds | per-round `uix ÷ reagent` |
+|---|---|
+| `M1` | 1.0345 · 0.9749 · 1.0792 · 0.9279 · 1.0459 · 0.8055 |
+| `M2` | 0.8000 · 1.1053 · 0.9584 · 0.7727 · 1.0000 · 0.9091 |
+| `broad` | 0.5938 · 0.6667 · 0.6667 · 0.4675 · 0.5400 · 0.7467 |
+| `narrow` | 1.1780 · 1.1033 · 1.1584 · 1.1559 · 1.1510 · 1.0282 |
+
+The two launches that are **out** produced no ensemble observation and their row
+figures did not survive the reaping. They are **not reconstructed**; what the
+exclusion rests on is the exit code, the refusing row and the load either side,
+and those are in the launch table above.
 
 #### What moved, and the control that says the denominator did not
 
@@ -486,50 +562,83 @@ The restatement rests on a comparison the `rf2-2rtt6.21` finding demands: **the
 bar's own denominator is held fixed and shown to be fixed.** On `M1`, same
 instrument and same author:
 
-| `M1` mount leg | published ensemble *(pre-`.13`/`.25`, 10 runs)* | this re-take *(post-`.25`, 4 runs)* | change |
-|---|---:|---:|---|
-| `reagent-subs ÷ floor` — **the denominator** | **4.358×** | **4.380×** | **+0.5% — unmoved** |
-| `uix-subs ÷ floor` — the frontier numerator | **5.343×** | **4.479×** | **−16.2%** |
-| **ratio** | 5.343 ÷ 4.358 = **1.226** *(published 1.2310)* | 4.479 ÷ 4.380 = **1.023** | **the line moves ≈21 points** |
+| `M1` mount leg | published ensemble *(pre-`.13`/`.25`, 10 runs)* | this re-take *(post-`.25`, 5 runs)* | ~~*4 runs, as PR #7315 had it*~~ | change |
+|---|---:|---:|---:|---|
+| `reagent-subs ÷ floor` — **the denominator** | **4.358×** | **4.425×** | ~~4.380×~~ | **+1.5% — unmoved** |
+| `uix-subs ÷ floor` — the frontier numerator | **5.343×** | **4.475×** | ~~4.479×~~ | **−16.2%** |
+| **ratio** | 5.343 ÷ 4.358 = **1.226** *(published 1.2310)* | 4.475 ÷ 4.425 = **1.011** | ~~4.479 ÷ 4.380 = 1.023~~ | **the line moves ≈21 points** |
 
-Per run, the denominator leg reads `4.2853 · 4.3457 · 4.5731 · 4.3144` and the
-numerator leg `4.2723 · 4.5089 · 4.6673 · 4.4687`.
+Both legs are the mean of the per-run legs in [the observation
+table](#the-observation-table) above, and the suite computes them from it.
 
 **The arithmetic is explicit and it closes.** The published threshold is the
 quotient of two floor-normalised legs; the denominator leg reproduces to within
-**0.5%** while the numerator leg falls **16.2%**, and 4.479 ÷ 4.380 = 1.023
-against the **1.0243** the runs actually report — the small residue being that
-each run's ratio is formed per round and per segment before averaging, not from
-the two means. **So the ≈21-point tightening is a property of the UIx arm, not of
-a drifting baseline** — precisely the failure mode a cross-author bridge could not
-have excluded, and the reason the ruling required a same-instrument re-take.
+**1.5%** while the numerator leg falls **16.2%** — an order of magnitude larger,
+which is the whole point — and 4.475 ÷ 4.425 = 1.011 against the **1.0150** the
+runs actually report, the small residue being that each run's ratio is formed per
+round and per segment before averaging, not from the two means. **So the
+≈21-point tightening is a property of the UIx arm, not of a drifting baseline** —
+precisely the failure mode a cross-author bridge could not have excluded, and the
+reason the ruling required a same-instrument re-take.
 
 #### The restated lines — INSTRUMENT STAMP: converged `p0_converge_app` instrument, `rf2-2rtt6.2` witness family, post-`.25` spine `8d20218fd1`
 
-**Four independently launched six-round runs, start counterbalanced two and
-two**, every one launched into a measured-quiet window, every one exiting 0.
-**0 unverified of 36,864** verified operations; arm-order guard `refuse? false`
-on all 24 row-verdicts; canonical-DOM parity `ok? true` on all 16; every positive
-control inside ±25%. The interval is a Student-t 95% interval on the mean of the
-run means — one-sample, so `n − 1 =` **three** degrees of freedom and
-`t = 3.1824`, the distinction the ensemble's own intervals got wrong and which is
-worked through [below](#the-intervals-are-2-too-wide-and-the-cause-is-an-off-by-one-in-the-degrees-of-freedom).
-**This is four runs against the published line's ten, and the interval is
+**Five independently launched six-round runs**, every one launched into a
+measured-quiet window, every one clearing every validity gate. Across the four
+that exited 0: **0 unverified of 36,864** verified operations, arm-order guard
+`refuse? false` and canonical-DOM parity `ok? true` on all sixteen row-runs,
+every positive control inside ±25%. **Run 5 cleared the same gates, and its exit
+code proves it**: the driver checks page errors, then the arm-order guard (exit
+**2**), then the positive control (exit **1**, a different message), and only
+then the segment-order control. An exit 1 carrying the segment-order message
+means every earlier gate passed on every row. *(Its verification count is one of
+the figures that did not survive the reaping, so it is not quoted.)* The interval
+is a Student-t 95% interval on the mean of the run means — one-sample, so
+`n − 1 =` **four** degrees of freedom and `t = 2.7764`, the distinction the
+ensemble's own intervals got wrong and which is worked through
+[below](#the-intervals-are-2-too-wide-and-the-cause-is-an-off-by-one-in-the-degrees-of-freedom).
+**This is five runs against the published line's ten, and the interval is
 correspondingly wider — it is stated as measured, not padded.**
 
-| witness | published *(pre-landing, 10 runs)* | **re-take, post-`.25` (4 runs)** | 95% CI on the mean | run means | verdict |
-|---|---|---|---|---|---|
-| **M1 mount** — 901 el, 300 bnd · *bar row* | ~~**1.2310×**~~ [1.1989 – 1.2931] | **1.0243×** | **0.9937 – 1.0549** | 0.9980 · 1.0391 · 1.0219 · 1.0382 | **RESTATED — the L1 mount red zone has CLOSED.** The interval contains 1.0 and every run reads `:direction :indistinguishable`. The run-mean spread is **wholly disjoint** from the published one |
-| **M2 mount** — 51 el, 12 fields · *diagnostic* | 1.0601× [0.9561 – 1.1923] | 1.0071× | 0.8978 – 1.1165 | 0.9685 – 1.0714 | **NOT restated** — indistinguishable then, indistinguishable now, still diagnostic |
-| **bulk broad** — one commit all 300 read · *bar row* | 0.6291× [0.5792 – 0.6987] | 0.5598× | 0.4781 – 0.6415 | 0.5102 – 0.6316 | **NOT restated** — the CI contains the published value; UIx faster, all 24 rounds and all 8 strata below 1.0 |
-| **bulk narrow** — 10 commits, one window | 1.1754× [1.1390 – 1.2186] | 1.2233× | 1.1238 – 1.3228 | 1.1767 – 1.3090 | **NOT restated** — the CI contains the published value; UIx slower, all 24 rounds and all 8 strata above 1.0 |
+!!! note "Superseded in place — the four-run figures are the same measurement, differently selected"
+
+    PR #7315 published this table over **four** runs. Its fifth — run 5, launched
+    at measured 0% load, all four rows completed, every validity gate clean —
+    was dropped because the driver exits 1 when a row's two segment-order strata
+    point opposite ways across 1.0. **That is a selection on the result**, and
+    [the aggregate rule](#the-partition-and-what-one-runs-split-can-and-cannot-say)
+    this page already carries says a row-run whose strata split is still one
+    observation. Run 5 is back in; the four-run figures are struck beside the
+    five-run ones rather than deleted; **no verdict moves.**
+
+| witness | published *(pre-landing, 10 runs)* | **re-take, post-`.25` (5 runs)** | 95% CI on the mean | run means | ~~*4 runs, as PR #7315 had it*~~ | verdict |
+|---|---|---|---|---|---|---|
+| **M1 mount** — 901 el, 300 bnd · *bar row* | ~~**1.2310×**~~ [1.1989 – 1.2931] | **1.0150×** | **0.9820 – 1.0480** | 0.9980 · 1.0391 · 1.0219 · 0.9780 · 1.0382 | ~~1.0243× [0.9937 – 1.0549]~~ | **RESTATED — the L1 mount red zone has CLOSED.** The interval contains 1.0. The run-mean spread is **wholly disjoint** from the published one |
+| **M2 mount** — 51 el, 12 fields · *diagnostic* | 1.0601× [0.9561 – 1.1923] | 0.9905× | 0.9035 – 1.0776 | 0.9242 – 1.0714 | ~~1.0071× [0.8978 – 1.1165]~~ | **NOT restated** — indistinguishable then, indistinguishable now, still diagnostic |
+| **bulk broad** — one commit all 300 read · *bar row* | 0.6291× [0.5792 – 0.6987] | 0.5706× | 0.5078 – 0.6333 | 0.5102 – 0.6316 | ~~0.5598× [0.4781 – 0.6415]~~ | **NOT restated** — the CI contains the published value; UIx faster, every run mean below 1.0 |
+| **bulk narrow** — 10 commits, one window | 1.1754× [1.1390 – 1.2186] | 1.2045× | 1.1193 – 1.2896 | 1.1291 – 1.3090 | ~~1.2233× [1.1238 – 1.3228]~~ | **NOT restated** — the CI contains the published value; UIx slower, every run mean above 1.0 |
 
 **Only M1 is restated, and the three that are not are held to the conservative
 reading deliberately.** On `broad` and `narrow` the re-take's interval contains
 the published magnitude, so the honest statement is *direction unchanged, magnitude
-not distinguishable at n = 4* — not a new number. Publishing `0.5598×` as a
-threshold on four runs against a ten-run line it does not contradict would be
-minting precision the measurement does not carry.
+not distinguishable at n = 5* — not a new number. Publishing `0.5706×` as a
+threshold on five runs against a ten-run line it does not contradict would be
+minting precision the measurement does not carry. **Every one of those
+containments is now arithmetic** — the suite recomputes each interval from the
+observation table and asserts that it brackets the published value, on the
+four-run set and on the five-run set alike.
+
+**The start counterbalance is 3:2 rather than 2:2, and that is a consequence of
+not choosing the launch set by outcome.** It does not carry the M1 result: the
+reagent-start group reads **0.9993×** over three runs, the uix-start group
+**1.0387×** over two, and the start-balanced estimate — the mean of the two group
+means, which is what an alternating design's unbiased estimator is — is
+**1.0190×**, inside the published interval.
+
+*Two counts this section used to print — `14 of 24 rounds above 1.0` and the
+per-stratum tallies — rest on per-round vectors that did not survive the
+producing worktree, and are **not** restated over five runs. See the [provenance
+note](#the-observation-table).*
 
 **Only the mount row moved, and that is the mechanism agreeing with the
 measurement rather than a coincidence.** `rf2-2rtt6.25` landed the hook-scoped
@@ -551,11 +660,11 @@ The advisory recorded that
 [the coldmount page](coldmount-double-build-priced.md) independently re-derived
 the same 901-element / 300-boundary mount witness post-`.25` at **`1.0054×`
 [0.917 – 1.143]**, excess mean 0.00 ms, on **its own instrument**. This re-take,
-on the **converged** instrument, reads the same witness at **`1.0243×`
-[0.9937 – 1.0549]**.
+on the **converged** instrument, reads the same witness at **`1.0150×`
+[0.9820 – 1.0480]**.
 
-**Two instruments, two drivers, two authors — `1.0054×` against `1.0243×`, 1.9
-points apart, each interval containing the other's point estimate** — against a
+**Two instruments, two drivers, two authors — `1.0054×` against `1.0150×`, 1.0
+point apart, each interval containing the other's point estimate** — against a
 published line of `1.2310×` that both now contradict by roughly twenty. The
 disagreement `rf2-2rtt6.21` found in the denominator between two authors (+9.7%
 on mount) is **larger than the gap between these two post-`.25` mount readings**,
@@ -564,23 +673,50 @@ and it is the correct outcome rather than a problem to be softened.**
 
 #### The row now sits so close to parity that one run could not be given a direction
 
-**A third piece of evidence, and it arrived as a failure.** One run exited **1**
+**A third piece of evidence, and it arrived as a failure.** Run 5 exited **1**
 because the driver's segment-order control refused `M1` outright:
 
 > *the row's two order strata — rounds where Reagent's segment ran first, rounds
 > where UIx's did — point OPPOSITE WAYS across 1.0, so the row has no direction
 > to publish and the figure is a measurement of the schedule.*
 
+Its `M1` vector is in [the observation table](#the-observation-table) and the
+suite replays it through `segment-order-verdict` rather than quoting the driver:
+Reagent-first **1.0532×** [1.0345 – 1.0792] over three rounds, UIx-first
+**0.9028×** [0.8055 – 0.9749] over three. **The driver was right to refuse** —
+those two point opposite ways, and a row that reads *slower* when Reagent leads
+and *faster* when UIx does has, on its own, measured the schedule.
+
 That control was written when this row sat at `1.23×`, comfortably disjoint from
 1.0, where two strata pointing opposite ways can only mean the schedule is
 leaking in. **A row centred ON 1.0 trips it for the opposite reason**: the strata
-straddle parity because there is no effect left to have a direction. The refusal
-is reported here as evidence rather than repaired, because repairing it would
-mean asserting a direction the measurement declines to give — and *"the row has
-no direction"* is the strongest available statement that the mount red zone has
-closed. Under Ruling 1 the red-zone **is** the measured UIx ratio, so the
-restated `M1` line is now **at parity**, and candidates between `1.0243` and the
-old `1.2310` that would have been scored red-free are **now RED**.
+straddle parity because there is no effect left to have a direction. Repairing it
+would mean asserting a direction the measurement declines to give — and *"the row
+has no direction"* is the strongest available statement that the mount red zone
+has closed.
+
+**But the refusal governs what run 5 may publish ALONE, and PR #7315 read it as
+governing whether run 5 exists at all.** It does not, and this page had already
+said so for the ten-run ensemble: `:magnitude-resolved?` decides whether one
+run's mean may be quoted as a threshold; `:in-an-ensemble` answers the other
+question, and it answers **one observation, whatever `:publishable` says** —
+because a split *is* the extreme partition, so dropping it shrinks the spread and
+moves the very estimate it would be used to compute. It moved it here, and in the
+direction that flatters the restatement: with run 5 out the row reads
+~~`1.0243×`~~ and with it in **`1.0150×`**, nine tenths of a point closer to
+parity, on an interval that is *wider* rather than narrower. Nothing about the
+verdict changes — the interval still contains 1.0, still excludes `1.2310`, and
+the run-mean spreads still do not meet — which is why the row is **corrected
+rather than re-measured**.
+
+*(The instrument now says this where the refusal is printed:
+`p0_converge_run.cjs`'s exit-1 message names the ensemble rule, so the next
+reader of a refused run is told to bank the log rather than left to infer that
+exit 1 means discard.)*
+
+Under Ruling 1 the red-zone **is** the measured UIx ratio, so the restated `M1`
+line is now **at parity**, and candidates between `1.0150` and the old `1.2310`
+that would have been scored red-free are **now RED**.
 
 ### All four rows reproduce against the revived driver (rf2-rjfz1)
 
@@ -1114,7 +1250,7 @@ record these runs wrote carries `:ratom-arm? true` and says so. For the record
 and for nothing else, the six runs read `M1` 0.9939 – 1.1184 and `broad`
 0.5808 – 0.6768, which straddle and sit below the lines published at the time —
 ~~`1.2310`~~ (since [superseded by the post-`.25`
-re-take](#the-re-take-on-the-post-25-tree-rf2-b0tz5) at `1.0243`, which this
+re-take](#the-re-take-on-the-post-25-tree-rf2-b0tz5) at `1.0150`, which this
 straddling range also contains) and `0.6291` respectively — a difference this
 design has no standing to interpret.
 
@@ -1153,7 +1289,7 @@ records that in place.
 
 | question | rf2-2rtt6.4, on its own witnesses | converged, on rf2-2rtt6.2's | change |
 |---|---|---|---|
-| large-list mount | W1: **1.057×** [0.907 – 1.156] — indistinguishable | M1: ~~**1.2310×**~~ [1.199 – 1.293 across ten runs] → **1.0243×** [0.9937 – 1.0549] post-`.25` — indistinguishable | ~~**verdict flips**~~ — **the flip did not outlive the spine.** The converged row read `1.2310×` on the pre-`.13`/`.25` tree; [the re-take](#the-re-take-on-the-post-25-tree-rf2-b0tz5) returns it to parity, which is where `W1` sat all along |
+| large-list mount | W1: **1.057×** [0.907 – 1.156] — indistinguishable | M1: ~~**1.2310×**~~ [1.199 – 1.293 across ten runs] → **1.0150×** [0.9820 – 1.0480] post-`.25` — indistinguishable | ~~**verdict flips**~~ — **the flip did not outlive the spine.** The converged row read `1.2310×` on the pre-`.13`/`.25` tree; [the re-take](#the-re-take-on-the-post-25-tree-rf2-b0tz5) returns it to parity, which is where `W1` sat all along |
 | ordinary-form mount | W3: **0.893×** [0.843 – 0.956] — UIx faster, disjoint, published as a threshold | M2: **1.0601×** [0.956 – 1.192] — indistinguishable, graded diagnostic | **verdict flips**, and so does the grade |
 | broad commit | U-broad: **0.838×** [0.760 – 0.953] — UIx faster | bulk broad: **0.6291×** [0.579 – 0.699] — UIx faster | same direction, **much larger margin** |
 | narrow commit | U-narrow: **1.536×** [1.226 – 1.876] — UIx slower, disjoint | bulk narrow: **1.1754×** [1.139 – 1.219] — UIx slower | same direction and both resolve, but **the margin over parity falls to about a third** — 0.18 against 0.54 |
@@ -1744,13 +1880,21 @@ asserts each of those readings.
 **The one other set of intervals on this page — the [rf2-b0tz5
 re-take](#the-re-take-on-the-post-25-tree-rf2-b0tz5)'s — does not carry the
 defect, and that is checked rather than assumed.** Those are one-sample intervals
-on the mean of **four** run means, so `n − 1 =` **three** and `t = 3.1824`, and
-that is the multiplier they use: `1.0243 ± 3.1824 × 0.009616` reproduces `M1`'s
-published `0.9937 – 1.0549` to four decimals from the four run means printed
-beside it. The rule is the same rule; only the ensemble misapplied it. It is
-load-bearing there rather than bookkeeping — at `t = 2.2622` the same four runs
-would read `1.0025 – 1.0461`, which **excludes** 1.0 and would have contradicted
-the *indistinguishable from parity* verdict every one of those runs reports.
+on the mean of the re-take's run means, so the degrees of freedom follow the run
+count: `1.0150 ± 2.7764 × 0.011884` reproduces `M1`'s published
+`0.9820 – 1.0480` from the **five** cells in [the observation
+table](#the-observation-table), and `1.0243 ± 3.1824 × 0.009616` reproduces the
+struck four-run `0.9937 – 1.0549` from four of them. The suite computes both. The
+rule is the same rule; only the ensemble misapplied it.
+
+**On the four-run set the distinction was load-bearing and on the five-run set it
+is not, which is worth saying rather than leaving to be discovered.** At
+`t = 2.2622` the four runs would have read `1.0025 – 1.0461`, **excluding** 1.0
+and contradicting the *indistinguishable from parity* verdict every one of them
+reports; the same multiplier on the five reads `0.9882 – 1.0419`, which contains
+parity anyway. The corrected estimate sits closer to 1.0 on a wider interval, so
+the verdict now survives even the wrong multiplier. That is a fact about this
+row, not a licence — the multiplier is still `n − 1`.
 
 **The old figures are struck, not deleted**, in the same style as every other
 correction here — and the *p* values, the point estimates and the thresholds are
@@ -1807,34 +1951,36 @@ appeared on a future witness.
 
 ### The verdict on M1's magnitude
 
-**What is published is `1.0243×`, 95% interval `0.9937 – 1.0549` on the mean,
-single runs landing in `0.998 – 1.039` — and because that interval contains 1.0,
+**What is published is `1.0150×`, 95% interval `0.9820 – 1.0480` on the mean,
+single runs landing in `0.978 – 1.039` — and because that interval contains 1.0,
 the row is INDISTINGUISHABLE FROM PARITY.** The magnitude is [the re-take on the
 post-`.25` tree](#the-re-take-on-the-post-25-tree-rf2-b0tz5): the converged
-`p0_converge_app` instrument, four independently launched six-round runs, each
+`p0_converge_app` instrument, five independently launched six-round runs, each
 into a measured-quiet window, on a spine carrying both `rf2-2rtt6.13` and
 `rf2-2rtt6.25`. **`1.2310×` [1.2109 – 1.2510] is SUPERSEDED** — it was measured
 before those two landed, its ten run means are wholly disjoint from the
-re-take's four, and the L1 mount red zone it stood behind has **closed**.
+re-take's five, and the L1 mount red zone it stood behind has **closed**.
+*(~~`1.0243×` [0.9937 – 1.0549]~~ was the same measurement over four of the five;
+[the fifth is back in](#the-row-now-sits-so-close-to-parity-that-one-run-could-not-be-given-a-direction).)*
 
 **A second instrument reaches the same place independently.** [The coldmount
 page](coldmount-double-build-priced.md) re-derived the same 901-element /
 300-boundary witness post-`.25` at **`1.0054×` [0.917 – 1.143]** on its own
-driver, under a different author. That is 1.9 points from `1.0243×`, with each
+driver, under a different author. That is 1.0 point from `1.0150×`, with each
 interval containing the other's point estimate — a smaller gap than the +9.7%
 mount disagreement `rf2-2rtt6.21` measured between the same two authors'
 denominators — so [the parity reading is not an artefact of one
 harness](#the-converged-instrument-agrees-with-coldmount).
 
-**The interval's shape is load-bearing, so it is stated exactly.** Four run
-means — `0.9980 · 1.0391 · 1.0219 · 1.0382` — give a one-sample Student-t
-interval with `n − 1 =` **three** degrees of freedom and `t = 3.1824`, and
-`1.0243 ± 3.1824 × 0.009616` reproduces `0.9937 – 1.0549`. The **nine**-df
+**The interval's shape is load-bearing, so it is stated exactly.** Five run
+means — `0.9980 · 1.0391 · 1.0219 · 0.9780 · 1.0382` — give a one-sample
+Student-t interval with `n − 1 =` **four** degrees of freedom and `t = 2.7764`,
+and `1.0150 ± 2.7764 × 0.011884` reproduces `0.9820 – 1.0480`. The **nine**-df
 correction [applied to the ten-run ensemble's
 intervals](#the-intervals-are-2-too-wide-and-the-cause-is-an-off-by-one-in-the-degrees-of-freedom)
-is a correction to a different quantity and does not belong here: at
-`t = 2.2622` these four runs would read `1.0025 – 1.0461`, which **excludes** 1.0
-and would invert the verdict every one of the four runs actually reports.
+is a correction to a different quantity and does not belong here. Both intervals
+are recomputed from [the observation table](#the-observation-table) by the suite,
+which also holds the struck four-run pair.
 
 **The three measured reasons `1.2301` was withdrawn were all answered — by the
 ten-run ensemble that has itself since been superseded.** Nothing in that record
@@ -1863,12 +2009,12 @@ the attribution is to this harness's schedule and is open on `rf2-2rtt6.25` —
 and on the re-take [the bar's own denominator is held fixed
 and shown to be
 fixed](#what-moved-and-the-control-that-says-the-denominator-did-not): the
-`reagent-subs` leg reproduces to within 0.5% while the `uix-subs` leg falls
+`reagent-subs` leg reproduces to within 1.5% while the `uix-subs` leg falls
 16.2%. The ≈21-point tightening is a property of the UIx arm.
 
 **A magnitude still has to be published with an interval, and that is the one
 thing this section never had wrong.** A bare four-decimal point — `1.2301`,
-`1.2310` and `1.0243` alike — carries no statement of how far a fresh run may
+`1.2310` and `1.0150` alike — carries no statement of how far a fresh run may
 legitimately land from it. On this row the honest form of the answer is now a
 range that includes parity.
 
@@ -2043,24 +2189,25 @@ statement of what the measurement supports, not an amendment.
 > threshold *the measured UIx ratio for that witness family*. Ten independently
 > launched six-round runs with the starting segment counterbalanced 5/5 stand
 > behind the three rows the post-`.25` re-take did not move; **M1 stands on the
-> four-run re-take instead**, because that is the only row the landings changed.
+> five-run re-take instead**, because that is the only row the landings changed.
 > Either way each is a **magnitude with an interval** rather than a point or a
 > bare direction:
 >
-> - **M1 mount — `1.0243×`, 95% interval `0.9937 – 1.0549` on the mean, single
->   runs landing in `0.998 – 1.039`. The interval contains 1.0, so the row is
+> - **M1 mount — `1.0150×`, 95% interval `0.9820 – 1.0480` on the mean, single
+>   runs landing in `0.978 – 1.039`. The interval contains 1.0, so the row is
 >   INDISTINGUISHABLE FROM PARITY and the L1 mount red zone is CLOSED.**
 >   ~~`1.2310×` [1.2109 – 1.2510]~~ is **SUPERSEDED**: it was measured before
 >   `rf2-2rtt6.13` and `rf2-2rtt6.25` landed, and the [re-take on the post-`.25`
 >   tree](#the-re-take-on-the-post-25-tree-rf2-b0tz5) reads the same witness on
->   the same instrument at parity — four runs, all four reporting
->   `:direction :indistinguishable`, corroborated to 1.9 points by [the coldmount
->   page](coldmount-double-build-priced.md)'s independent `1.0054×`. `1.2301×` is
->   not reinstated either: it was withdrawn as a magnitude, and the row has since
->   moved past it in the other direction. Because the threshold IS the measured
->   ratio, **a candidate anywhere between `1.0243` and the old `1.2310` is now
->   RED** where it would once have scored clear; inside the run-mean spread the
->   honest answer is where in the spread it sits.
+>   the same instrument at parity — five runs, corroborated to 1.0 point by [the
+>   coldmount page](coldmount-double-build-priced.md)'s independent `1.0054×`.
+>   ~~`1.0243×` [0.9937 – 1.0549]~~ is the same re-take over four of those five
+>   and is superseded in turn. `1.2301×` is not reinstated either: it was
+>   withdrawn as a magnitude, and the row has since moved past it in the other
+>   direction. Because the threshold IS the measured ratio, **a candidate
+>   anywhere between `1.0150` and the old `1.2310` is now RED** where it would
+>   once have scored clear; inside the run-mean spread the honest answer is where
+>   in the spread it sits.
 > - **bulk narrow — `1.1754×`, interval `1.1582 – 1.1926`, runs `1.139 – 1.219`.**
 >   **Supersedes `1.1540×`**, also withdrawn. Its direction is now as strong as
 >   any row on the page: all 60 rounds above 1.0, all 20 order strata wholly

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -260,31 +260,34 @@ from same-instrument data. That re-take is `rf2-b0tz5`.
 witness family, post-`.25` spine `8d20218fd1`, whole-tree anchor `7f54c67d5a`.**
 All four published converged rows were measured on anchor `4e4a68fa1f`, whose
 `spine.cljs` blob is byte-identical to the **pre-`rf2-2rtt6.13`** spine — so all
-four were stale, not just the mount row. Four counterbalanced six-round runs,
-every gate clean, 0 unverified of 36,864:
+four were stale, not just the mount row. Five six-round runs, every validity gate
+clean:
 
 | bar row | published *(pre-landing)* | **restated, post-`.25`** | disposition |
 |---|---|---|---|
-| **M1 mount** | ~~1.2310×~~ | **1.0243×** [0.9937 – 1.0549] | **RESTATED — the L1 mount red zone has CLOSED.** Under Ruling 1 the red-zone *is* the measured UIx ratio, so the mount line now sits at parity |
-| **bulk broad** | 0.6291× | not distinguishable at n = 4 | **stands** — direction unchanged, UIx faster |
-| **bulk narrow** | 1.1754× | not distinguishable at n = 4 | **stands** — direction unchanged, UIx slower |
-| M2 mount *(diagnostic)* | 1.0601× | not distinguishable at n = 4 | **stands**, still not quotable against the bar |
+| **M1 mount** | ~~1.2310×~~ | **1.0150×** [0.9820 – 1.0480] | **RESTATED — the L1 mount red zone has CLOSED.** Under Ruling 1 the red-zone *is* the measured UIx ratio, so the mount line now sits at parity |
+| **bulk broad** | 0.6291× | not distinguishable at n = 5 | **stands** — direction unchanged, UIx faster |
+| **bulk narrow** | 1.1754× | not distinguishable at n = 5 | **stands** — direction unchanged, UIx slower |
+| M2 mount *(diagnostic)* | 1.0601× | not distinguishable at n = 5 | **stands**, still not quotable against the bar |
 
 **The arithmetic.** The threshold is a quotient of two floor-normalised legs. The
-denominator, `reagent-subs ÷ floor`, reads **4.380×** against the published
-**4.358×** — unmoved within 0.5%. The numerator, `uix-subs ÷ floor`, falls
-**5.343× → 4.479×**, −16.2%. `4.479 ÷ 4.380 = 1.023`. **The tightening is a
-property of the UIx arm, not of a drifting baseline** — the check `rf2-2rtt6.21`
-made necessary by measuring that same denominator differing +9.7% between two
-authors.
+denominator, `reagent-subs ÷ floor`, reads **4.425×** against the published
+**4.358×** — unmoved within 1.5%. The numerator, `uix-subs ÷ floor`, falls
+**5.343× → 4.475×**, −16.2%, an order of magnitude further. `4.475 ÷ 4.425 =
+1.011`. **The tightening is a property of the UIx arm, not of a drifting
+baseline** — the check `rf2-2rtt6.21` made necessary by measuring that same
+denominator differing +9.7% between two authors.
 
 **A candidate at 1.15× Reagent on mount was red-free yesterday and is RED
-today.** Every candidate mount row between `1.0243` and the old `1.2310` flips,
+today.** Every candidate mount row between `1.0150` and the old `1.2310` flips,
 and that tightening is the intended consequence rather than a problem to soften.
 The converged instrument independently agrees with
 [the coldmount page](studio/coldmount-double-build-priced.md)'s `1.0054×` on the
-same witness — 1.9 points apart, from two instruments and two authors. Full
-record, including the three runs that did not publish and why:
+same witness — 1.0 point apart, from two instruments and two authors. *(PR #7315
+first published this row at ~~`1.0243×`~~ over four of the five runs; the fifth
+was dropped for the way its order strata split, which is a selection on the
+result, and it is back in. No disposition changed.)* Full record, the launch set
+in full, and the committed observation table every figure is derived from:
 [the re-take](studio/p0-converged-witness-set.md#the-re-take-on-the-post-25-tree-rf2-b0tz5).
 
 ### P1 — the tournament (the six-week clock starts at the first Hicasso-arm commit that mounts the dogfood screen — HD-014)

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_order_cljs_test.cljs
@@ -922,6 +922,355 @@
            three of the ten read below 1.0 outright"))))
 
 ;; ---------------------------------------------------------------------------
+;; THE POST-.25 RE-TAKE'S OBSERVATION TABLE (rf2-b0tz5)
+;; ---------------------------------------------------------------------------
+;;
+;; PR #7315 restated the M1 mount line on the post-`.25` tree and published,
+;; for the four runs it accepted, a point estimate, a 95% interval and a
+;; min–max range per row — plus M1's four run means and nothing else. The
+;; merged-PR audit found that this repeats the gap #7312 had just closed one
+;; section above: the intervals that decided *not restated* on M2, broad and
+;; narrow could not be recomputed from the repository, because the numbers
+;; they are computed FROM had never reached it.
+;;
+;; [[retake]] is that table. Every figure the studio page prints about the
+;; re-take is derived below from these twenty cells and checked against the
+;; page's own claims, which live in [[retake-published]] so that the
+;; derivation has something to be checked against.
+;;
+;; PROVENANCE, and it is NOT the same as the ensemble's. Nothing here was
+;; measured for this fixture and no browser was opened: the operator has
+;; deferred measurement while the adapter is built, and five sibling workers
+;; were on the box. The producing worktree (`worker/clockline-b0tz5`) was
+;; reaped with its `ai/bench-logs/` inside it, so the run logs themselves are
+;; gone. What survives is the producing agent's own transcript, which
+;; captured the driver's console output and the analysis run over those logs
+;; verbatim; the cells below are transcribed from it. Two consequences,
+;; stated rather than glossed:
+;;
+;;   * The unit that survives is the RUN MEAN — each row's `red-zone :mean`
+;;     for that run. The six per-round vectors behind each accepted run's
+;;     mean did NOT survive, except for run 5, whose four vectors are in
+;;     [[run-5-per-round]] because the diagnosis of its refusal was
+;;     captured in full. So every ENSEMBLE-level figure is derivable here;
+;;     the page's per-round counts (`14 of 24 rounds above 1.0`, `1 of 8
+;;     strata wholly above`) are NOT, and the page now says so.
+;;   * A run mean transcribed at four decimals is the instrument's own
+;;     rounded output, so a mean re-derived from these cells can differ from
+;;     the instrument's in the fourth decimal. It never did on any figure
+;;     below, and the tolerances say so.
+;;
+;; THE SECOND FINDING, which changes a published number. The four-run set was
+;; not the launch set: a fifth run completed all four rows at measured 0%
+;; load and was dropped because the driver exits 1 when a row's two
+;; segment-order strata point OPPOSITE WAYS across 1.0. That condition is a
+;; function of the result — and the aggregate rule this file pinned for the
+;; ensemble one section above says exactly what to do with it. See
+;; [[the-fifth-run-was-dropped-for-the-way-its-strata-split]].
+
+(def ^:private retake
+  "THE 5 × 4 OBSERVATION TABLE of the post-`.25` re-take, complete.
+
+  One entry per run that completed all four rows on the converged
+  instrument at whole-tree anchor `7f54c67d5a`. Each cell is that run's
+  `red-zone :mean` for the row — its six per-round `uix-subs ÷
+  reagent-subs` readings averaged, each reading floor-normalised in its
+  own round and segment. `:start` is the segment that led round 0.
+
+  `:exit` is the driver's exit code and `:in-ensemble?` is whether the
+  run is one observation of the ensemble. They are not the same
+  question, which is the whole of
+  [[the-fifth-run-was-dropped-for-the-way-its-strata-split]].
+
+  `:M1-legs` is the same run's `M1` mount leg pair — `reagent-subs ÷
+  floor` and `uix-subs ÷ floor`, the denominator and numerator the page
+  decomposes the threshold into."
+  [{:run 1 :start :reagent-subs :exit 0 :in-ensemble? true
+    :M1 0.9980 :M2 1.0584 :broad 0.6316 :narrow 1.2306
+    :M1-legs {:reagent 4.2853 :uix 4.2723}}
+   {:run 2 :start :uix-subs :exit 0 :in-ensemble? true
+    :M1 1.0391 :M2 0.9685 :broad 0.5437 :narrow 1.1767
+    :M1-legs {:reagent 4.3457 :uix 4.5089}}
+   {:run 3 :start :reagent-subs :exit 0 :in-ensemble? true
+    :M1 1.0219 :M2 1.0714 :broad 0.5538 :narrow 1.3090
+    :M1-legs {:reagent 4.5731 :uix 4.6673}}
+   {:run 6 :start :uix-subs :exit 0 :in-ensemble? true
+    :M1 1.0382 :M2 0.9302 :broad 0.5102 :narrow 1.1769
+    :M1-legs {:reagent 4.3144 :uix 4.4687}}
+   {:run 5 :start :reagent-subs :exit 1 :in-ensemble? true
+    :M1 0.9780 :M2 0.9242 :broad 0.6135 :narrow 1.1291
+    :M1-legs {:reagent 4.6045 :uix 4.4573}}])
+
+(def ^:private retake-refused
+  "The launches that produced no ensemble observation, kept here because a
+  launch set with the failures left out is not a launch set.
+
+  Both are ARM-ORDER GUARD refusals — `p0_converge_run.cjs` exit **2**,
+  the guard reporting that an arm reads differently for WHERE IN THE PLAN
+  it was measured. That verdict is computed from arm timings by plan
+  position and never looks at the `uix ÷ reagent` ratio, so excluding
+  these two selects on the INSTRUMENT's validity and not on the result —
+  which is the distinction run 5 fails and they pass.
+
+  Their row figures did not survive the reaping and are NOT reconstructed;
+  what survives is the exit code, the refusing row and the load either
+  side, which is what the exclusion rests on anyway."
+  [{:run 2 :attempt 1 :start :uix-subs :exit 2 :refused-row :narrow
+    :pre-cpu 101 :post-cpu 310 :why "phase strata 1.37×–1.55× last-third over
+                                     first-third; the box degraded mid-run. Re-taken under quiet"}
+   {:run 4 :start :uix-subs :exit 2 :refused-row :M2
+    :pre-cpu 0 :post-cpu 0 :why "the mount-budget fragility this instrument already
+                                 documents — 720 mounts a page refused 4 of 6 for
+                                 rf2-6i0i2 too. Not contention, and not new"}])
+
+(def ^:private run-5-per-round
+  "Run 5's four per-round vectors, the only per-round record of the
+  re-take that survived. Six rounds, round 0 led by the Reagent segment.
+
+  They are here because run 5's refusal is the one thing on the page that
+  has to be re-derived rather than quoted: whether the driver was right to
+  refuse, and whether the ensemble was right to drop the run, are
+  different questions with different answers."
+  {:M1     [1.0345 0.9749 1.0792 0.9279 1.0459 0.8055]
+   :M2     [0.8    1.1053 0.9584 0.7727 1.0    0.9091]
+   :broad  [0.5938 0.6667 0.6667 0.4675 0.54   0.7467]
+   :narrow [1.178  1.1033 1.1584 1.1559 1.151  1.0282]})
+
+(def ^:private retake-published
+  "What PR #7315 printed for the FOUR accepted runs — the figures the audit
+  said could not be recomputed. Transcribed so the derivation can be
+  checked against them, and superseded on the page by the five-run
+  figures below."
+  {:M1     {:threshold 1.0243 :lo 0.9937 :hi 1.0549 :run-min 0.9980 :run-max 1.0391}
+   :M2     {:threshold 1.0071 :lo 0.8978 :hi 1.1165 :run-min 0.9302 :run-max 1.0714}
+   :broad  {:threshold 0.5598 :lo 0.4781 :hi 0.6415 :run-min 0.5102 :run-max 0.6316}
+   :narrow {:threshold 1.2233 :lo 1.1238 :hi 1.3228 :run-min 1.1767 :run-max 1.3090}})
+
+(def ^:private retake-corrected
+  "What the page publishes now: the same four rows over the FIVE runs the
+  ensemble actually holds, run 5 included."
+  {:M1     {:threshold 1.0150 :lo 0.9820 :hi 1.0480 :run-min 0.9780 :run-max 1.0391}
+   :M2     {:threshold 0.9905 :lo 0.9035 :hi 1.0776 :run-min 0.9242 :run-max 1.0714}
+   :broad  {:threshold 0.5706 :lo 0.5078 :hi 0.6333 :run-min 0.5102 :run-max 0.6316}
+   :narrow {:threshold 1.2045 :lo 1.1193 :hi 1.2896 :run-min 1.1291 :run-max 1.3090}})
+
+(def ^:private t-3
+  "Student's t, 0.975, THREE degrees of freedom — a 95% interval on the
+  mean of FOUR run means."
+  3.182446)
+
+(def ^:private t-4
+  "Student's t, 0.975, FOUR degrees of freedom — a 95% interval on the
+  mean of FIVE."
+  2.776445)
+
+(defn- accepted-only
+  "The four runs PR #7315 published: exit 0."
+  []
+  (filterv #(zero? (:exit %)) retake))
+
+(defn- retake-ci
+  "Point estimate, sample sd and one-sample Student-t 95% interval on the
+  mean of `runs`' means for `row`. `n − 1` degrees of freedom, which is
+  the rule the ensemble misapplied and this section applies correctly for
+  both n = 4 and n = 5."
+  [runs row]
+  (let [xs (mapv #(get % row) runs)
+        m  (mean xs)
+        sd (sample-sd xs)
+        t  (case (count xs) 4 t-3 5 t-4)
+        h  (* t (/ sd (js/Math.sqrt (count xs))))]
+    {:mean m :sd sd :lo (- m h) :hi (+ m h) :half h
+     :run-min (apply min xs) :run-max (apply max xs)}))
+
+(deftest the-retake-table-is-the-launch-set-not-a-selection
+  (testing "five completed runs and two guard-refused launches — seven
+           launches, and the table names all seven rather than only the
+           ones that published"
+    (is (= 5 (count retake)))
+    (is (= 2 (count retake-refused)))
+    (is (= [1 2 3 6 5] (mapv :run retake)))
+    (is (every? #(contains? % :in-ensemble?) retake)))
+  (testing "the four PR #7315 published are the four that exited 0, and
+           the fifth is the one that exited 1"
+    (is (= [1 2 3 6] (mapv :run (accepted-only))))
+    (is (= [5] (mapv :run (remove #(zero? (:exit %)) retake)))))
+  (testing "the accepted four are counterbalanced two and two, and the
+           five-run set is 3:2 — an imbalance that is a CONSEQUENCE of
+           not choosing the launch set by outcome, not a defect of it"
+    (is (= 2 (count (filter #(= :reagent-subs (:start %)) (accepted-only)))))
+    (is (= 2 (count (filter #(= :uix-subs (:start %)) (accepted-only)))))
+    (is (= 3 (count (filter #(= :reagent-subs (:start %)) retake))))
+    (is (= 2 (count (filter #(= :uix-subs (:start %)) retake))))))
+
+(deftest every-figure-pr-7315-published-reproduces-from-the-four-cells
+  (testing "the point estimates, the intervals the audit said could not be
+           recomputed, and the run-mean ranges — all four rows, from the
+           table and nothing else"
+    (doseq [row rows]
+      (let [{:keys [mean lo hi run-min run-max]} (retake-ci (accepted-only) row)
+            p (get retake-published row)]
+        (is (close? mean (:threshold p)) (str (name row) " — threshold"))
+        (is (close? lo (:lo p))          (str (name row) " — interval low"))
+        (is (close? hi (:hi p))          (str (name row) " — interval high"))
+        (is (close? run-min (:run-min p)) (str (name row) " — run-mean min"))
+        (is (close? run-max (:run-max p)) (str (name row) " — run-mean max")))))
+  (testing "M1's published sd, which is the only one the page prints"
+    (is (close-to? (:sd (retake-ci (accepted-only) :M1)) 0.0192 0.0001)))
+  (testing "the multiplier is t at THREE degrees of freedom — the page
+           states `1.0243 ± 3.1824 × 0.009616` and that is what these four
+           run means give"
+    (let [{:keys [sd half]} (retake-ci (accepted-only) :M1)]
+      (is (close-to? (/ sd 2.0) 0.009616 0.000002) "the standard error")
+      (is (close-to? half (* t-3 0.009616) 0.00001) "half-width = t(3) × se"))))
+
+(deftest the-not-restated-dispositions-are-arithmetic-not-assertion
+  (testing "M2, broad and narrow were held at their published values
+           because the re-take's interval CONTAINS the published
+           magnitude. That is now checked rather than stated — on the
+           four-run set the audit questioned, and on the five-run set that
+           replaces it"
+    (doseq [runs [(accepted-only) retake]]
+      (doseq [row [:M2 :broad :narrow]]
+        (let [{:keys [lo hi]} (retake-ci runs row)
+              pub (:threshold (get published-threshold row))]
+          (is (and (<= lo pub) (<= pub hi))
+              (str (name row) " — the interval contains the published " pub
+                   " over " (count runs) " runs, so the row is NOT restated"))))))
+  (testing "M1 is the one row restated, and for the opposite reason: the
+           published 1.2310 lies outside the interval on either set, and
+           the run-mean spreads do not even meet"
+    (doseq [runs [(accepted-only) retake]]
+      (let [{:keys [lo hi run-max]} (retake-ci runs :M1)
+            {:keys [threshold run-min]} (get published-threshold :M1)]
+        (is (not (and (<= lo threshold) (<= threshold hi)))
+            (str "M1 over " (count runs) " runs — 1.2310 is outside the interval"))
+        (is (< run-max run-min)
+            (str "M1 over " (count runs)
+                 " runs — the run-mean spread is wholly disjoint from the published one"))))))
+
+(deftest the-leg-decomposition-is-the-mean-of-the-per-run-legs
+  (testing "the page decomposes the threshold into two floor-normalised
+           legs and reports 4.380 ÷ 4.479 over the four accepted runs. Both
+           are means of the per-run legs in the table"
+    (let [runs (accepted-only)
+          den  (mean (mapv #(get-in % [:M1-legs :reagent]) runs))
+          num  (mean (mapv #(get-in % [:M1-legs :uix]) runs))]
+      (is (close-to? den 4.380 0.0005) "denominator leg")
+      (is (close-to? num 4.479 0.0005) "numerator leg")
+      (is (close-to? (/ num den) 1.023 0.0005)
+          "and their quotient, 1.023 against the 1.0243 the runs report —
+           the residue being that each run forms its ratio per round and per
+           segment before averaging, never from the two means")))
+  (testing "the leg comparison is what carries the restatement, so it is
+           also stated over the five-run set. The denominator moves further
+           from the published 4.358 — +1.5% rather than +0.5% — and the
+           conclusion is unchanged, because the numerator's fall is an
+           order of magnitude larger either way"
+    (let [den (mean (mapv #(get-in % [:M1-legs :reagent]) retake))
+          num (mean (mapv #(get-in % [:M1-legs :uix]) retake))]
+      (is (close-to? den 4.425 0.0005) "denominator leg, five runs")
+      (is (close-to? num 4.475 0.0005) "numerator leg, five runs")
+      (is (< (js/Math.abs (- (/ den 4.358) 1.0)) 0.02) "denominator within 2% of published")
+      (is (< (/ num 5.343) 0.85) "numerator down more than 15% from published")
+      (is (close-to? (/ num den) 1.011 0.0005) "quotient, five runs"))))
+
+(deftest the-fifth-run-was-dropped-for-the-way-its-strata-split
+  (testing "run 5's M1 refusal is REPRODUCED from its per-round vector
+           rather than quoted: the two order strata point opposite ways
+           across 1.0, so `segment-order-verdict` refuses and the driver
+           exits 1. The driver was right"
+    (let [vd (app/segment-order-verdict (:M1 run-5-per-round) 6 :reagent-subs)]
+      (is (true? (:refuse? vd)))
+      (is (false? (:direction-agrees? vd)))
+      (is (false? (:magnitude-resolved? vd)))
+      (is (close? 1.0532 (:mean (:reagent-first vd))) "Reagent-first stratum, above 1.0")
+      (is (close? 0.9028 (:mean (:uix-first vd)))     "UIx-first stratum, below 1.0")
+      (is (close? 0.9780 (mean (:M1 run-5-per-round)))
+          "and its row mean is the cell in the table")))
+  (testing "the OTHER three rows of run 5 refuse nothing — their strata
+           overlap and every one resolves a magnitude. Run 5 is not a bad
+           run; it is a run whose M1 sat on parity"
+    (doseq [row [:M2 :broad :narrow]]
+      (let [vd (app/segment-order-verdict (get run-5-per-round row) 6 :reagent-subs)]
+        (is (false? (:refuse? vd)) (str (name row) " — no refusal"))
+        (is (true? (:magnitude-resolved? vd)) (str (name row) " — magnitude resolved"))
+        (is (close? (get (nth retake 4) row) (mean (get run-5-per-round row)))
+            (str (name row) " — the vector's mean is the cell in the table")))))
+  (testing "the exit code proves the rest of the run was clean. The driver
+           checks page errors, then the ARM-ORDER guard (exit 2), then the
+           positive control (exit 1, different message), and only then the
+           segment-order control. An exit 1 carrying the segment-order
+           message means every earlier gate passed on every row — so the
+           ONLY thing wrong with run 5 was the direction its M1 strata took"
+    (is (= 1 (:exit (nth retake 4))))
+    (is (every? #(= 2 (:exit %)) retake-refused)
+        "and the two launches that ARE excluded were excluded by the
+         arm-order guard, which never looks at the ratio"))
+  (testing "dropping it is the outcome-based selection this file already
+           forbade for the ensemble one section above: `:in-an-ensemble`
+           says a row-run whose strata split is still ONE OBSERVATION,
+           because a split IS the extreme partition and excluding it moves
+           the estimate. It moved it here — away from parity, which is the
+           direction that flatters the restatement"
+    (let [four (retake-ci (accepted-only) :M1)
+          five (retake-ci retake :M1)]
+      (is (< (:mean five) (:mean four))
+          "the dropped run pulled the estimate toward 1.0, so dropping it pushed it away")
+      (is (close-to? (- (:mean four) (:mean five)) 0.0093 0.0002)
+          "by 0.9 points")
+      (is (< (:half four) (:half five))
+          "and narrowed the interval, which is the second half of the same error")))
+  (testing "and it changes no verdict, which is why the row is corrected
+           rather than re-run: the five-run interval still contains 1.0,
+           still excludes the published 1.2310, and the row is still
+           indistinguishable from parity"
+    (let [{:keys [lo hi]} (retake-ci retake :M1)]
+      (is (and (< lo 1.0) (> hi 1.0)) "contains parity")
+      (is (< hi 1.1989) "and does not reach the published run-mean spread"))))
+
+(deftest the-corrected-five-run-figures-are-what-the-page-publishes
+  (testing "every figure in the page's corrected table, derived from the
+           five cells"
+    (doseq [row rows]
+      (let [{:keys [mean lo hi run-min run-max]} (retake-ci retake row)
+            c (get retake-corrected row)]
+        (is (close? mean (:threshold c)) (str (name row) " — threshold"))
+        (is (close? lo (:lo c))          (str (name row) " — interval low"))
+        (is (close? hi (:hi c))          (str (name row) " — interval high"))
+        (is (close? run-min (:run-min c)) (str (name row) " — run-mean min"))
+        (is (close? run-max (:run-max c)) (str (name row) " — run-mean max")))))
+  (testing "the 3:2 start imbalance does not carry the M1 result: the
+           start-balanced estimate — the mean of the two start-group means,
+           which is what an alternating design's unbiased estimator is —
+           lands inside the interval"
+    (let [by  (group-by :start retake)
+          rg  (mean (mapv :M1 (:reagent-subs by)))
+          ux  (mean (mapv :M1 (:uix-subs by)))
+          bal (/ (+ rg ux) 2.0)
+          {:keys [lo hi]} (retake-ci retake :M1)]
+      (is (close-to? rg 0.9993 0.0002) "reagent-start group, three runs")
+      (is (close-to? ux 1.0387 0.0002) "uix-start group, two runs")
+      (is (close-to? bal 1.0190 0.0002) "start-balanced")
+      (is (and (< lo bal) (< bal hi)) "inside the published interval"))))
+
+(deftest what-the-retake-table-cannot-check-is-said-rather-than-implied
+  (testing "the per-round vectors of the four accepted runs did not
+           survive, so the page's per-round and per-stratum counts are
+           reported by the instrument and NOT re-derivable here. Only run
+           5 carries vectors, and this test pins which cells the fixture
+           does and does not hold, so a later reader cannot mistake the
+           table for something it is not"
+    (is (= 20 (count (for [r retake row rows] (get r row))))
+        "twenty run means — every accepted and every completed run, all four rows")
+    (is (= #{:M1 :M2 :broad :narrow} (set (keys run-5-per-round)))
+        "and per-round vectors for exactly one run")
+    (is (every? #(= 6 (count %)) (vals run-5-per-round))
+        "six rounds each, the balanced design")
+    (is (empty? (filter :per-round retake))
+        "no run in the table claims a per-round vector it does not have")))
+
+;; ---------------------------------------------------------------------------
 ;; The flag is global and the arm is not (rf2-2rtt6.21)
 ;; ---------------------------------------------------------------------------
 ;;

--- a/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/p0_converge_run.cjs
@@ -330,6 +330,14 @@ async function runRow(browser, row) {
     );
     process.exit(1);
   }
+  // EXIT 1 HERE MEANS "THIS RUN MAY NOT PUBLISH ALONE", NOT "DISCARD THIS RUN".
+  // The two are different questions and the row records above already answer
+  // both — `:publishable` governs the run quoted by itself, `:in-an-ensemble`
+  // governs whether it is one observation of many, and it says it always is.
+  // rf2-b0tz5's re-take dropped a whole run on this exit code, which moved the
+  // published estimate away from parity by nine tenths of a point and narrowed
+  // its interval: refusing on the way the strata split IS a selection on the
+  // result. So the message says so, because a bare exit 1 does not.
   const orderRefused = outcomes.filter((o) => o.orderRefused);
   if (orderRefused.length > 0) {
     console.error(
@@ -338,7 +346,15 @@ async function runRow(browser, row) {
         .join(', ')}. The row's two order strata — rounds where Reagent's segment ran ` +
         `first, rounds where UIx's did — point OPPOSITE WAYS across 1.0, so the row has ` +
         `no direction to publish and the figure is a measurement of the schedule. The ` +
-        `repair is the ARM: more rounds, a balanced (even) round count, a longer window.`
+        `repair is the ARM: more rounds, a balanced (even) round count, a longer window.\n` +
+        `[converge] BANK THIS LOG. Exit 1 here bars THIS RUN from publishing a figure ` +
+        `ALONE; it does NOT drop the run from an ensemble. Every row record above ` +
+        `carries :in-an-ensemble, and it reads ONE OBSERVATION whatever :publishable ` +
+        `says — dropping a run for the way its strata happened to split selects on the ` +
+        `result, and it moves the estimate it would be used to compute (rf2-6i0i2, ` +
+        `rf2-b0tz5). Everything before this line passed: the arm-order guard owns exit 2 ` +
+        `and the positive control prints a different exit 1, so reaching here means both ` +
+        `cleared on every row.`
     );
     process.exit(1);
   }


### PR DESCRIPTION
The AUDIT-REOPEN remainder of **rf2-b0tz5** — the merged-PR audit of #7315.

**No measurement anywhere in this PR.** The operator has deferred measurement while the adapter is built, and sibling workers were on the box; no bench driver was run and no browser was opened. The job was to make the re-take's inference checkable from the repository.

## The audit made two charges. Both are discharged.

### 1. DURABILITY — *"no compact post-`.25` observation fixture or executable derivation lands"*

**The observation table is now committed, complete.** Five runs × four rows, each run's `M1` leg pair, run 5's four per-round vectors, and the whole launch set — seven launches, refusals included — in `p0_converge_order_cljs_test.cljs`, beside the ten-run ensemble table #7312 landed one section above.

Every figure the studio page prints about the re-take is now **derived** rather than asserted, including the ones the audit named specifically:

| what the audit said could not be recomputed | now |
|---|---|
| M2 / broad / narrow point estimates | **reproduce** |
| **the intervals used to decide "not restated"** on all three | **reproduce**, and each is asserted to bracket the published magnitude |
| the run-mean ranges — all eight endpoints | **reproduce** |
| M1's point, interval and sd — `1.0243 ± 3.1824 × 0.009616` | **reproduces** to four decimals |
| the M1 leg decomposition `4.479 ÷ 4.380 = 1.023` | **reproduces**, as the mean of the per-run legs |
| run 5's refusal | **re-derived** through `segment-order-verdict`, not quoted |

**What is NOT checkable is said so, not papered over.** The per-round vectors behind the four accepted runs did not survive; run 5's did. So ensemble-level figures are derivable and the section's per-round counts (`14 of 24 rounds above 1.0`, the per-stratum tallies) are **not** — they are marked as not restated and are **not reconstructed**. A test pins which cells the fixture holds, so a later reader cannot mistake the table for something it is not.

**Provenance is stated as recovery, not measurement.** The producing worktree `worker/clockline-b0tz5` was reaped with its `ai/bench-logs/` inside it, so the run logs are gone. The cells come from the **producing agent's own transcript**, which captured the driver's console output and the analysis run over those logs verbatim. `ai/findings/` and the scratchpad were searched first; the only bench backup there is #7312's ten-run ensemble, which is a different ensemble.

### 2. CORRECTNESS — *"include the quiet M1 direction refusal … and recompute the exact red-zone point/CI"*

**The raw record was recoverable, so the audit's primary instruction applied rather than its fallback.** Run 5 — launched at measured 0% load, all four rows completed — survives in full: four row means, four per-round vectors, its `M1` leg pair, and its `segment-order-control` map.

It was dropped because the driver exits 1 when a row's two segment-order strata point opposite ways across 1.0. **That condition is a function of the result**, and this page's own aggregate rule — added by #7312 and carried in the instrument as `:in-an-ensemble` — already answers it: `:magnitude-resolved?` governs what one run may publish **alone**; whether it is one observation of many is the other question, and the answer is *ONE OBSERVATION, whatever `:publishable` says*.

So run 5 is back in, and the rows are **corrected in place**:

| | 4 runs (PR #7315) | **5 runs (this PR)** |
|---|---|---|
| **M1 mount** | ~~1.0243× [0.9937 – 1.0549]~~ | **1.0150× [0.9820 – 1.0480]** |
| M2 mount | ~~1.0071× [0.8978 – 1.1165]~~ | 0.9905× [0.9035 – 1.0776] |
| bulk broad | ~~0.5598× [0.4781 – 0.6415]~~ | 0.5706× [0.5078 – 0.6333] |
| bulk narrow | ~~1.2233× [1.1238 – 1.3228]~~ | 1.2045× [1.1193 – 1.2896] |

**The verdict does not move, and that is the point.** M1's interval still contains 1.0, still excludes the published `1.2310`, and the run-mean spreads still do not meet — **the L1 mount red zone is still CLOSED**, and every "not restated" disposition on the other three rows survives unchanged. What moved is a magnitude, by nine tenths of a point, in the direction the drop had flattered: dropping run 5 pushed the estimate **away** from parity *and narrowed the interval*, which is exactly the two-part error the aggregate law describes.

**The refusal itself is upheld.** The suite replays run 5's `M1` vector through `segment-order-verdict`: Reagent-first `1.0532×` against UIx-first `0.9028×`, pointing opposite ways — **the driver was right to refuse**. Its other three rows resolve magnitudes cleanly, and the driver's gate ordering proves the rest of the run was clean: the arm-order guard owns exit **2** and the positive control prints a different exit **1**, so reaching the segment-order check means both passed on every row. The only thing wrong with run 5 was the direction its `M1` strata took.

**The inclusion rule is now written down**, because the two refusal kinds are not the same kind. The arm-order guard reads *arm timings by plan position* and never looks at the ratio — so the two exit-2 launches stay **out**, on instrument validity, exactly as the audit asked ("preserve genuine predeclared validity refusals"). Two out, one in, and which is which is decided by what the gate was looking at.

**And the instrument now says it, so this cannot recur silently.** `p0_converge_run.cjs`'s exit-1 message tells the reader to bank the log: exit 1 bars *this run* from publishing alone and does **not** drop it from an ensemble. That is the cause rather than the symptom — a bare exit code is what routed around a rule the row records already carried. Message text only; no behaviour change.

## Three honest consequences, recorded rather than smoothed

- **The denominator leg reads +1.5% over five runs** where four gave +0.5%. The conclusion is unchanged because the numerator falls **16.2%**, an order of magnitude further — but the page now says 1.5%, not 0.5%.
- **The degrees-of-freedom distinction was load-bearing on four runs and is not on five.** At `t(9) = 2.2622` the four runs would have read `1.0025 – 1.0461`, excluding 1.0 and inverting the verdict; the same multiplier on five reads `0.9882 – 1.0419`, which contains parity anyway. Stated as a fact about this row, not as a licence — the multiplier is still `n − 1`.
- **The start counterbalance is 3:2, not 2:2** — a consequence of not choosing the launch set by outcome. Answered rather than hidden: reagent-start `0.9993×` over three, uix-start `1.0387×` over two, start-balanced `1.0190×`, inside the interval.

## Sites corrected

Every site quoting the four-run figures, superseded **in place** and never appended beside: eleven on `p0-converged-witness-set.md`, plus `validation.md`'s P0 bar-row table and `hd8-freehand-codec-donor-arm.md`'s HD-008 suspension banner (whose `1.0243 × 1.10 = 1.127` arithmetic becomes `1.0150 × 1.10 = 1.117`).

## For the mayor — one thing to be aware of

My dispatch brief said *"1.0243× stands; this is about the durability of its evidence"*, while the bead's audit note — which the brief states **governs** — directs recomputation with run 5 included, with the fallback applying only *"if the raw record is unavailable"*. It was available. I followed the bead. **The verdict is not weakened in any respect**; only the magnitude moved. If you would rather `1.0243×` remain the published line, the fixture holds and derives **both** sets, so reverting the page to the four-run figures is mechanical — but it would leave standing the outcome-based drop the audit charged.

## Quality gates

Every gate foreground to completion, worktree-local logs under `.gate-logs/`, exit codes echoed. **All gates were re-run from scratch after an API outage killed this task mid-sweep** — no pre-outage green is relied on.

| gate | result |
|---|---|
| `npm run test:cljs` (the `node-test` build) | **12,196 tests / 60,920 assertions. 9 failures, ALL in `implementation/test-quiet/test/**` — zero elsewhere, zero in the namespace this PR touches.** A pre-existing load flake, not this branch; the evidence is below |
| negative control on the new tests | mutated one fixture constant → **exit 1**, `FAIL in (the-corrected-five-run-figures-are-what-the-page-publishes)`; reverted and re-run green. The new tests demonstrably execute rather than being silently skipped |
| `python scripts/check_doc_slugs.py` | **exit 0** |
| negative control on the doc gate | broke one anchor on the edited page → **exit 1**, `BROKEN ANCHOR: docs\design\hicasso\studio\p0-converged-witness-set.md`; reverted and re-run green. The gate demonstrably reaches this tree |
| `python -m mkdocs build --strict` | **exit 0** — see the caveat below |
| `node --check p0_converge_run.cjs` | **exit 0** |
| table column counts, by hand | **76 tables checked across the three edited files, 0 mismatches** |

**Gate coverage, stated correctly.** `mkdocs build --strict` **does not reach `docs/design/**`** — `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site, so the strict build proves only that the rest of the site still builds. **`scripts/check_doc_slugs.py` DOES validate this tree's link targets and heading anchors**, and it runs in the fast-PR spine and in `docs.yml`; the negative control above proves it reaches the edited page. Only **table column counts, rendering and nav** are ungated, so those were checked by hand:

| table | columns × rows |
|---|---|
| the launch set (new) | 4 × 7 |
| the observation table (new) | 7 × 5 |
| run 5's per-round vectors (new) | 2 × 4 |
| the `M1` leg decomposition (edited) | 5 × 3 |
| the restated lines (edited) | 7 × 4 |
| `validation.md`'s bar rows (edited) | 4 × 4 |

### The `test:cljs` failures are a pre-existing load flake, and I am not claiming otherwise

I did not get a clean green on the full suite, so I am reporting what I got rather than a number I would like. **Every failure is in `implementation/test-quiet/test/**`, which this branch does not touch, and every root cause is `spawnSync … ETIMEDOUT`** — a nested runner killed at its 60,000 ms ceiling with **both child streams empty**, i.e. the child never ran.

Four full-suite runs on this one unchanged tree:

| run | box | result |
|---|---|---|
| before an API outage killed this task | siblings dead, box quiet | **exit 0** — 12,196 tests, 60,920 assertions, **0 failures** |
| re-run 1 | siblings restarted | exit 1 — **9** failures, all `test_quiet_shadow_node_cljs_test.cljs`, all `ETIMEDOUT` |
| re-run 2 | two siblings running browser suites | exit 1 — **18** failures, same file, all `ETIMEDOUT` |
| re-run 3 | — | compile abort — **my own fault**, see below |
| re-run 4, clean cache | siblings still live | exit 1 — **9** failures, `test-quiet/test/**` only, `ETIMEDOUT` |

**Why it cannot be this branch.** `git diff --name-only <base> | grep test_quiet` is empty. The only non-documentation files this PR changes are one pure-arithmetic CLJS test namespace and a `.cjs` bench driver that the `node-test` build never compiles (shadow-cljs compiles `.cljs`/`.cljc`; the driver is invoked by `node` directly). Neither can affect a subprocess spawn timeout. **The failure count tracks box load on an identical tree — 0 → 9 → 18 → 9** — which is what a wall-clock flake looks like and is not what a regression looks like. Two sibling worktrees (`witness-2rtt6-41`, `axes-2rtt6-44`) were confirmed running browser tests and shadow-cljs compiles throughout.

**And this PR's own tests are green in isolation:** a focused `node-test` build of just `p0-converge-order-cljs-test` — **41 tests, 526 assertions, 0 failures, exit 0**.

Filed as **rf2-hofhx** (P2) with the diagnosis and three candidate remedies.

**One thing I got wrong, recorded rather than buried.** I tried to isolate the flaky namespace by compiling it alone with `--config-merge '{:ns-regexp …}'`. That was **confounded** — those tests spawn `out/node-test.js` itself, so a focused build changes the very artifact under test, and its 14/15 failures prove nothing. Worse, a focused compile shares the `node-test` build id, so it left the cache mixed and re-run 3 died with `aborted par-compile` and no root error. Clearing `.shadow-cljs/builds/node-test` fixed it (the same "one build id, N configs → clear the cache" rule this repo's own `lane_cache.cjs` implements). Both facts are in rf2-hofhx. I discarded the isolation run as evidence rather than citing it.
