### PR TITLE
core,test: the expunge proof states its own property, not a process-wide count (rf2-8vvdo)

### DIFF
--- a/implementation/core/test/re_frame/observation_port_cljs_test.cljc
+++ b/implementation/core/test/re_frame/observation_port_cljs_test.cljc
@@ -3490,20 +3490,45 @@
    (deftest jvm-provenance-entry-is-weak-and-expunged-when-its-throwable-dies
      ;; acceptance 3 (the weak-lifecycle PROOF): release the throwable, retain only a
      ;; WeakReference, force bounded GC + a later map access, and prove the referent
-     ;; CLEARS (the storage retains it via NEITHER key NOR value) and the private
-     ;; storage returns to baseline (the cleared entry is expunged). A strong-map
-     ;; mutation — retaining the referent by key OR value — reddens gc-until-cleared?.
-     (let [prov @#'obs/provenance-both-channels
-           m    (:by-throwable @#'obs/provenance-storage)]
-       ;; Reach a stable baseline: drain any prior stale entries first.
-       (System/gc) (System/runFinalization)
-       (#'obs/source-covered-always-on? (ex-info "baseline drain" {}))
-       (let [baseline (.size ^java.util.Map m)
-             t-box    (volatile! (ex-info "weak-lifecycle boom" {}))
-             t-ref    (java.lang.ref.WeakReference. ^Object @t-box)]
-         (#'obs/attest-provenance! @t-box prov)
-         (is (= (inc baseline) (.size ^java.util.Map m))
-             "the attestation bound exactly one entry")
+     ;; CLEARS (the storage retains it via NEITHER key NOR value) and THIS entry is
+     ;; expunged from the private storage. A strong-map mutation — retaining the
+     ;; referent by key OR value — reddens gc-until-cleared?; a mutation that leaks
+     ;; the entry (never enqueued, never removed) reddens the expunge poll below.
+     ;;
+     ;; BOTH map assertions name THIS ONE ENTRY, never the map's total size
+     ;; (rf2-8vvdo). `provenance-storage` is PROCESS-WIDE and shrinks asynchronously:
+     ;; a Reference is CLEARED during GC but ENQUEUED afterwards by the
+     ;; ReferenceHandler thread, so any `baseline` sampled after a drain over-counts
+     ;; by whatever backlog is still pending — and that backlog grows with machine
+     ;; load. The size-based form this replaced therefore reddened BECAUSE UNRELATED
+     ;; COLLECTION SUCCEEDED: nothing here adds an entry after the attestation, so the
+     ;; size only falls, and a sibling landing mid-poll drops it BELOW the sampled
+     ;; baseline, after which `(= baseline (.size m))` can never hold again and the
+     ;; bounded loop times out into false. Relaxing that to `(<= (.size m) baseline)`
+     ;; would cure the false red at the cost of a false GREEN under the very same
+     ;; load: a sibling expunging in our entry's place satisfies it while our entry is
+     ;; still leaked. Asking the map about OUR OWN KEY is immune to both, and says
+     ;; exactly what the test is named for.
+     (let [prov  @#'obs/provenance-both-channels
+           m     ^java.util.Map (:by-throwable @#'obs/provenance-storage)
+           t-box (volatile! (ex-info "weak-lifecycle boom" {}))
+           t-ref (java.lang.ref.WeakReference. ^Object @t-box)]
+       (#'obs/attest-provenance! @t-box prov)
+       ;; The STORED key objects for this throwable, found by identity over the live
+       ;; key set. A key is a WeakReference subclass, so holding one strongly retains
+       ;; the KEY and never its referent — the entry stays free to be cleared,
+       ;; enqueued and expunged exactly as in production (the HashMap holds its keys
+       ;; strongly anyway). Its `hashCode` is the identityHashCode captured at
+       ;; construction and its `equals` short-circuits on `identical? this o`, so
+       ;; `.containsKey` answers about THIS entry alone — before or after clearing,
+       ;; and without ever dereferencing a dead referent.
+       (let [our-keys (locking m
+                        (into [] (filter #(identical? @t-box
+                                                      (.get ^java.lang.ref.WeakReference %)))
+                              (.keySet m)))
+             our-key  (first our-keys)]
+         (is (= 1 (count our-keys))
+             "the attestation bound EXACTLY one entry, keyed by this throwable")
          (is (true? (#'obs/source-covered-always-on? @t-box))
              "the bound throwable reads covered")
          (vreset! t-box nil) ;; drop the last strong ref — only t-ref (weak) remains
@@ -3515,10 +3540,11 @@
          (is (loop [i 0]
                (#'obs/source-covered-always-on? (ex-info "post-gc access" {}))
                (cond
-                 (= baseline (.size ^java.util.Map m)) true
-                 (>= i 40)                             false
+                 (not (.containsKey m our-key)) true
+                 (>= i 40)                      false
                  :else (do (System/gc) (System/runFinalization) (recur (inc i)))))
-             "the cleared entry was expunged — private storage returned to baseline")))))
+             (str "the cleared entry was expunged — THIS key is gone from the private "
+                  "storage"))))))
 
 ;; ===========================================================================
 ;; rf2-kia9st — the JVM provenance is TRULY reload-safe: a REAL namespace reload


### PR DESCRIPTION
Closes rf2-8vvdo.

`jvm-provenance-entry-is-weak-and-expunged-when-its-throwable-dies` proved
*"the cleared entry was expunged"* by pinning the `.size` of a **process-wide**
`HashMap` to a sampled `baseline` with `=`. It reddened on CI under load for a
reason with nothing to do with the property it claims to prove.

## The defect

`m` is the shared `java.util.HashMap` at `(:by-throwable @#'obs/provenance-storage)`
— keyed by weak identity keys, reclaimed only when `expunge-stale-provenance!`
polls its `ReferenceQueue`. A `Reference` is **cleared during GC but enqueued
afterwards**, asynchronously, by the ReferenceHandler thread, so a `baseline`
sampled after one `System.gc()` and one drain **over-counts** by whatever
backlog is still pending — and that backlog grows with machine load.

Nothing in the poll loop ever *adds* an entry (`source-covered-always-on?` only
reads and drains), so `.size` is monotonically non-increasing. The moment a
pending sibling landed, `.size` fell **below** `baseline`, `=` could never hold
again, and the bounded loop timed out into `false`. **The test reddened because
unrelated collection succeeded.** On the observed red run the preceding
`(is (gc-until-cleared? t-ref))` *passed* — the named property held; only the
global-count equality broke.

## Verifying the diagnosis, and three corrections

The bead's analysis was checked against
`implementation/core/src/re_frame/substrate/observation.cljc` rather than taken
on trust. The mechanism holds exactly as described. Three corrections:

**1. The prescribed `(<= (.size m) baseline)` is not safe.** It cures the false
red at the cost of a **false green** under exactly the same load: a sibling
expunging *in our entry's place* satisfies it while our entry is still leaked.
This is not hypothetical — it is measured below (`PROBE`), where `<=` held with
our entry demonstrably still in the map, before the throwable had even been
released. Since an assertion that stops the flake but can no longer catch the
bug is worse than the flake, `<=` was rejected. The bead's own alternative —
*"better still, track that entry's own absence"* — is what landed.

**2. The bead diagnosed only the poll loop; the sibling assertion carried the
identical defect.** `(= (inc baseline) (.size m))` — *"the attestation bound
exactly one entry"* — reds whenever the attest's own drain reclaims a pending
sibling before the `.put`. Left alone it would have kept the test
load-sensitive after the loop was repaired. It is measured red below (`OLD-A`),
and is fixed too.

**3. Path.** The bead names
`implementation/core/test/re_frame/substrate/observation_port_cljs_test.cljc`;
the file is `implementation/core/test/re_frame/observation_port_cljs_test.cljc`
(no `substrate/` segment). Line 3515 was correct.

## The fix

Both map assertions now name **this one entry** and never the map's total size.
The stored key is located by referent identity over the live key set and held
strongly — it is a `WeakReference` subclass, so that retains the **key** and
never its referent, and the `HashMap` holds its keys strongly in production
anyway, so nothing about the lifecycle under test changes. `.containsKey`
discriminates it by the `identityHashCode` captured at construction plus an
`identical? this o` short-circuit, so it answers about this entry alone, before
or after clearing, without ever dereferencing a dead referent.

```clojure
;; before
(is (= (inc baseline) (.size ^java.util.Map m))
    "the attestation bound exactly one entry")
...
  (= baseline (.size ^java.util.Map m)) true

;; after
(is (= 1 (count our-keys))
    "the attestation bound EXACTLY one entry, keyed by this throwable")
...
  (not (.containsKey m our-key)) true
```

The diff is confined to that one `deftest`; the surrounding namespace is
untouched, and no production code changed.

## Quality gates

All foreground, worktree-local logs, no piping through `tail`/`grep`.

### Mutation proof — the repaired assertion still catches the defect

The fault the test exists to detect was planted in production code:
`expunge-stale-provenance!` was changed to poll the queue but **never remove**,
so a cleared key leaks in the map forever. The referent still clears, which
isolates the leak from every other assertion.

| | exit | result |
|---|---|---|
| Mutation planted (`expunge-stale-provenance!` never removes) | **1** | **RED** — 1 failure of 4 |
| Mutation reverted (`git diff` empty) | **0** | **GREEN** — 0 failures of 4 |

Under the mutation, `gc-until-cleared?` and the "exactly one entry"
precondition **both still passed** — only the expunge proof reddened, which is
precisely the required isolation:

```
FAIL in (jvm-provenance-entry-is-weak-and-expunged-when-its-throwable-dies)
the cleared entry was expunged — THIS key is gone from the private storage
  actual: false
Ran 1 tests containing 4 assertions.
1 failures, 0 errors.
```

Run twice — once before a mid-task API outage and once after, on a since-idle
box — with identical exit codes. An idle box is the condition under which the
*old* assertion passes, so a green alone proves nothing here; the mutation is
what settles it.

### The old failure mode, reproduced deterministically

Cheap, so it was done rather than asserted. A scratch test (temporary; reverted,
not committed) seeded exactly the backlog the async enqueue produces on a loaded
runner — a sibling entry that is **cleared and still counted** when `baseline`
is sampled — then ran the OLD and NEW assertions over the *same* run:

```
SCRATCH baseline= 1 size-after-attest= 1
FAIL  OLD-A: the attestation bound exactly one entry   actual: (not (= 2 1))
FAIL  OLD-B: private storage returned to baseline      actual: false
SCRATCH final size= 0 baseline= 1
Ran 1 tests containing 7 assertions.  2 failures, 0 errors.
```

Both OLD forms red; both NEW forms green, in the same run, 3/3 runs, exit 1 each
time. `final size= 0` against `baseline= 1` is the bead's mechanism made
visible: the size fell **below** the sampled baseline, so `=` could never hold.

The seventh assertion is the `PROBE` that rejects `<=`. It is a **passing**
assertion of `(and (<= (.size m) baseline) (.containsKey m our-key))` — i.e. the
proposed relaxation already held *while our entry was still in the map*, before
the throwable was released. That is the false green, measured.

### Suites

| gate | exit |
|---|---|
| `clojure -M:test` in `implementation/core` — the gate that reddened | **0** — 2198 tests, 11341 assertions, 0 failures 0 errors |
| `scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine` |
| clj-kondo **2026.04.15** (CI's pinned version, CI's exact `--lint` invocation) | **0** — `errors: 0` |

The spine's own `JVM implementation/core` leg reported the same 2198 / 11341 / 0
/ 0, and it ran while sibling workers were active on the box — i.e. under load,
the condition that reddened the old assertion on CI.

clj-kondo reports three findings in the touched file — lines 2467, 2895, 2908 —
all pre-existing and none inside the edited region (3490–3547). The local npm
binary is v2025.10.23, so the pinned 2026.04.15 release was fetched and used.

**TESTING.md matrix derived for this surface.** The diff is one file under
`implementation/core/test/**` and no production code. Per TESTING.md the fast-PR
spine's JVM tier is `implementation/core` **plus every artefact whose own tree
the diff touched** — here only `implementation/core`, confirmed by
`scripts/test-fast-pr.sh --plan`:

```
PLAN docs=false jvm=true node=true
PLAN-JVM implementation/core
```

`scripts/test-jvm-implementation.sh` is **not** mapped for this surface —
TESTING.md scopes it to a broad refactor reaching artefacts the fast-PR tier
does not select, which this diff is not. The wider fan-out
(`.github/scripts/report-changed-surfaces.sh` lights `implementation_jvm`,
`cljs_node_test`, `ui_gates`, `cljs_browser`, `bundle_isolation`, the tool-JVM
lanes and `mcp_conformance` for any `implementation/core/**` path) runs in CI,
which is where TESTING.md places it.
