### PR TITLE
hicasso: the controlled grid, StrictMode, HMR and a real error boundary (rf2-2rtt6.41)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary.cljs
@@ -42,15 +42,23 @@
   surface, no telemetry: each of those is an application's decision, and
   `:on-error` is the door it makes them behind.
 
-  ## Once per failure, and why that needs a flag
+  ## Once per failure, and why that needs NO flag — measured, not assumed
 
-  React's commit runs `componentDidCatch` as an update-queue callback, and
-  under StrictMode the render that threw runs twice. `:on-error` must
-  still fire once, so the report is gated on an instance flag cleared only
-  by a `:reset-key` change. The freehand boundary
-  (`re-frame.freehand.error-react`) reaches the same conclusion through a
-  generation counter in a shared law; this arm needs one boolean, and
-  says so rather than importing the law.
+  `:on-error` fires from `componentDidCatch` and from nowhere else, so it
+  fires exactly as often as React catches. Under StrictMode the render
+  that threw runs **twice** and `componentDidCatch` is still called
+  **once**, which is the whole of the once-per-failure guarantee:
+  `arm1_lifecycle_dom_cljs_test/the-boundary-reports-once-under-strictmode`
+  mounts the failing tree in StrictMode and reads one record.
+
+  This started life with an instance flag gating the report, on the
+  reasoning the freehand boundary uses for its generation counter
+  (`re-frame.freehand.error-react`, whose `componentDidUpdate` promotes
+  too and therefore genuinely needs one). Removing the flag changed no
+  witness — **the mutation went green**, which is the definition of a
+  line nothing observes — so it is gone. The freehand law is not being
+  contradicted; it is being told apart, and the difference is that this
+  boundary reports from one lifecycle rather than three.
 
   The frame reaches the class through `contextType` — the substrate's one
   internal React context, the same object `runtime/shell` reads with
@@ -84,19 +92,19 @@
   (adapter-context/context-value->current-frame (.-context this)))
 
 (defn- report!
-  "Fire `:on-error` once for the failure now held. A vector is an intent
-  and is dispatched with the error appended; a function is called with it.
-  The flag is what makes StrictMode's second render, and every later
-  commit of the fallback, a no-op."
+  "Fire `:on-error` for the failure React just caught. A vector is an
+  intent and is dispatched, with the error appended, into the frame the
+  boundary is mounted under; a function is called with the error.
+
+  **Called from `componentDidCatch` and from nowhere else**, which is what
+  makes it once per failure without a flag to make it so."
   [^js this error]
-  (when-not (.-reported this)
-    (set! (.-reported this) true)
-    (let [on-error (:on-error (props-of this))]
-      (cond
-        (vector? on-error) (when-some [frame-kw (frame-of this)]
-                             (rt/dispatch! frame-kw (conj on-error error)))
-        (fn? on-error)     (on-error error)
-        :else              nil)))
+  (let [on-error (:on-error (props-of this))]
+    (cond
+      (vector? on-error) (when-some [frame-kw (frame-of this)]
+                           (rt/dispatch! frame-kw (conj on-error error)))
+      (fn? on-error)     (on-error error)
+      :else              nil))
   nil)
 
 (def boundary
@@ -110,7 +118,6 @@
                 (this-as ^js this
                   (.call ^js react/Component this props)
                   (set! (.-state this) #js {"error" nil})
-                  (set! (.-reported this) false)
                   (set! (.-resetKey this)
                         (:reset-key (or (unchecked-get props "rfProps") {})))
                   this))
@@ -138,11 +145,6 @@
               (let [k (:reset-key (props-of this))]
                 (when (not= k (.-resetKey this))
                   (set! (.-resetKey this) k)
-                  (set! (.-reported this) false)
-                  ;; Unconditional: a reset that only fired while a
-                  ;; failure was held would leave the flag armed after a
-                  ;; clean pass, and the NEXT failure would report
-                  ;; nothing.
                   (when (some? (unchecked-get (.-state this) "error"))
                     (.setState this #js {"error" nil})))))))
     (set! (.-render proto)

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary.cljs
@@ -1,0 +1,156 @@
+(ns re-frame.bench.hicasso.arm1.boundary
+  "`h/boundary` — THE RUNTIME'S OWN ERROR BOUNDARY (HD-020(c),
+  rf2-2rtt6.41).
+
+  HD-020(c) rules that \"the runtime ships one internal class-based
+  boundary exposed as `h/boundary` (`:fallback`/`:reset-key`/`:on-error`);
+  it is the P1 witness's *real error boundary*\". validation.md's
+  `:foreign/host-and-error-boundary` row names it by that description.
+  This is it, and it is deliberately the smallest thing that satisfies
+  the three keys.
+
+      [boundary {:fallback  [:p.oops \"that did not work\"]
+                 :reset-key attempt
+                 :on-error  [:app/record-failure]}
+       [risky-view {}]]
+
+  ## Why a class, and what that buys the hook budget
+
+  React catches a render-phase throw at a **class** component and nowhere
+  else: `getDerivedStateFromError` is the render-phase marker React 19
+  requires for the boundary to catch at all, and `componentDidCatch` is
+  the commit-phase callback where a side effect is safe. There is no hook
+  form of either, which is the whole reason HD-020(c) says \"class-based\"
+  rather than leaving it to taste.
+
+  **A class component calls no hooks, so this costs the ≤2-hook shell
+  budget exactly nothing** — the boundary is not a boundary *shell*, it
+  reads no subscription, mints no registration and takes no cell.
+  `arm1_lifecycle_dom_cljs_test` counts that at React's own dispatcher
+  rather than asserting it here: a page wrapping a Hicasso boundary in
+  one of these still reads two.
+
+  ## The three keys
+
+  | key | shape | meaning |
+  |---|---|---|
+  | `:fallback` | hiccup, or `(fn [error] hiccup)` | what renders instead of the children once something below has thrown |
+  | `:reset-key` | any value, compared with `=` | a change clears the caught failure and re-mounts the children, so the retry is the CALLER's to schedule and never the boundary's to guess |
+  | `:on-error` | an intent vector, or a plain function | fired **once per caught failure**. A vector is dispatched with the error appended, through the frame the boundary is mounted under; a function is called with the error |
+
+  Nothing else. No error classification, no retry policy, no logging
+  surface, no telemetry: each of those is an application's decision, and
+  `:on-error` is the door it makes them behind.
+
+  ## Once per failure, and why that needs a flag
+
+  React's commit runs `componentDidCatch` as an update-queue callback, and
+  under StrictMode the render that threw runs twice. `:on-error` must
+  still fire once, so the report is gated on an instance flag cleared only
+  by a `:reset-key` change. The freehand boundary
+  (`re-frame.freehand.error-react`) reaches the same conclusion through a
+  generation counter in a shared law; this arm needs one boolean, and
+  says so rather than importing the law.
+
+  The frame reaches the class through `contextType` — the substrate's one
+  internal React context, the same object `runtime/shell` reads with
+  `useContext` — so `:on-error`'s intent lands in the frame the boundary
+  was mounted under rather than in whatever happened to be ambient when
+  the throw arrived.
+
+  ## What it does NOT catch, stated because a boundary that quietly does
+  ## not catch is worse than none
+
+  React error boundaries catch throws from **render, and from the
+  lifecycle and effects of the tree below**. They do not catch a throw
+  from an event handler, from a `setTimeout`, or from anything the
+  browser calls outside React's own work loop — an intent handler that
+  throws lands in the browser's error channel, not here. That is React's
+  boundary, not this arm's, and the arm inherits it exactly."
+  (:require [re-frame.adapter.context :as adapter-context]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            ["react" :as react]))
+
+(defn- props-of
+  "The ClojureScript props map the codec's boundary hand-off stashed under
+  `rfProps` — the same crossing every `defview` product reads."
+  [^js this]
+  (or (unchecked-get (.-props this) "rfProps") {}))
+
+(defn- frame-of
+  "The frame this boundary is mounted under, read through `contextType`."
+  [^js this]
+  (adapter-context/context-value->current-frame (.-context this)))
+
+(defn- report!
+  "Fire `:on-error` once for the failure now held. A vector is an intent
+  and is dispatched with the error appended; a function is called with it.
+  The flag is what makes StrictMode's second render, and every later
+  commit of the fallback, a no-op."
+  [^js this error]
+  (when-not (.-reported this)
+    (set! (.-reported this) true)
+    (let [on-error (:on-error (props-of this))]
+      (cond
+        (vector? on-error) (when-some [frame-kw (frame-of this)]
+                             (rt/dispatch! frame-kw (conj on-error error)))
+        (fn? on-error)     (on-error error)
+        :else              nil)))
+  nil)
+
+(def boundary
+  "`h/boundary` — a legal hiccup head, marked the way a `defview` product
+  is, and a React **class** so React will hand it a render-phase throw
+  from anything below.
+
+  It is not a Hicasso *reactive* boundary: it reads no subscription,
+  holds no cell and spends no hook."
+  (let [ctor  (fn hicasso-boundary-ctor [props]
+                (this-as ^js this
+                  (.call ^js react/Component this props)
+                  (set! (.-state this) #js {"error" nil})
+                  (set! (.-reported this) false)
+                  (set! (.-resetKey this)
+                        (:reset-key (or (unchecked-get props "rfProps") {})))
+                  this))
+        ;; Bound once and `^js`-tagged so the React lifecycle names below
+        ;; are inferred externs — the same discipline
+        ;; `re-frame.freehand.error-react` uses, for the same reason: a
+        ;; `(.. ctor -prototype -X)` chain cannot infer them, and an
+        ;; `:advanced` build that munged `componentDidCatch` would give a
+        ;; boundary that silently never catches.
+        proto ^js (js/Object.create (.-prototype ^js react/Component))]
+    (set! (.-prototype ^js ctor) proto)
+    (set! (.-constructor proto) ctor)
+    (set! (.-displayName ^js ctor) "hicasso/boundary")
+    (set! (.-contextType ^js ctor) adapter-context/frame-context)
+    ;; React 19 requires the static marker for the boundary to catch at
+    ;; all. It cannot reach the instance, so it only flips the render
+    ;; marker; everything with a side effect is the commit's.
+    (set! (.-getDerivedStateFromError ^js ctor) (fn [error] #js {"error" error}))
+    (set! (.-componentDidCatch proto)
+          (fn [error _info]
+            (this-as ^js this (report! this error))))
+    (set! (.-componentDidUpdate proto)
+          (fn [_prev-props _prev-state _snapshot]
+            (this-as ^js this
+              (let [k (:reset-key (props-of this))]
+                (when (not= k (.-resetKey this))
+                  (set! (.-resetKey this) k)
+                  (set! (.-reported this) false)
+                  ;; Unconditional: a reset that only fired while a
+                  ;; failure was held would leave the flag armed after a
+                  ;; clean pass, and the NEXT failure would report
+                  ;; nothing.
+                  (when (some? (unchecked-get (.-state this) "error"))
+                    (.setState this #js {"error" nil})))))))
+    (set! (.-render proto)
+          (fn []
+            (this-as ^js this
+              (let [{:keys [fallback children]} (props-of this)
+                    error (unchecked-get (.-state this) "error")]
+                (if (some? error)
+                  (codec/as-element (if (fn? fallback) (fallback error) fallback))
+                  (codec/as-element (into [:<>] children)))))))
+    (codec/mark-boundary! ctor)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
@@ -684,7 +684,21 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-grid-leaves-no-residue
-  (testing "one hundred controlled boundaries, typed into, then released"
+  (testing "one hundred controlled boundaries, typed into, then unmounted.
+
+           **The census is read after React's unmount and BEFORE the arm's
+           teardown door**, and that ordering is the whole of it.
+           `mount/release!` calls `runtime/reset-runtime!`, which disposes
+           every cell and empties the index by fiat, so a residue reading
+           taken after it is all zeros whatever the teardown released —
+           measured, by deleting `make-subscribe`'s cleanup
+           `release-cell!`: the reading below goes red, and the same
+           reading taken after `release!` stays green.
+
+           Three counts, because those three are exact the instant the
+           unmount returns; `:cells` and `:entries` are the reaper's, one
+           macrotask later, and asserting them here would assert a
+           schedule rather than a release."
     (if-not (mount/browser?)
       (skip! ":node-test has no DOM")
       (do
@@ -695,8 +709,14 @@
           (.focus n)
           (type-into! n "abc")
           (is (= "abc" (model-value 7)))
-          (mount/release! handle)
-          (unpin!)
-          (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
-                 (rt/residue))
-              "zero leaked subscription ref-counts after teardown"))))))
+          (is (= (inc grid/cells) (:boundaries (rt/stats)))
+              "a hundred cell registrations and the grid's own are really
+               standing before the teardown — the enclosing `grid` is a
+               `defview` too, so it is a boundary like any other")
+          (react-dom/flushSync (fn [] (.unmount (:root handle))))
+          (let [census (select-keys (rt/residue) [:cell-refs :boundaries :edges])]
+            (mount/release! (assoc handle :root nil))
+            (unpin!)
+            (is (= {:cell-refs 0 :boundaries 0 :edges 0} census)
+                "zero leaked subscription ref-counts, zero boundaries and zero
+                 edges the moment React's unmount returned")))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
@@ -1,0 +1,702 @@
+(ns re-frame.bench.hicasso.arm1.controlled-grid-dom-cljs-test
+  "THE 100-CELL CONTROLLED GRID, ON ARM 1 (K4, HD-019's full door —
+  rf2-2rtt6.41).
+
+  rf2-2rtt6.9 witnessed two of validation.md's six `:controlled/grid-100`
+  claims, on the dogfood screen's own single field: the same-turn echo and
+  the explicit-revision reset. The other four are here, at the witness's
+  stated size, on the arm's own element path —
+  **`:mid-string-caret`, `:selection-preserved`,
+  `:ime-composition-commits-nothing`, `:unchanged-model-rejection`** and
+  **`:async-normalisation`**.
+
+  Every synchronous assertion runs on the line after `dispatchEvent`
+  returns. There is **no `act` anywhere in this file**, and no `flushSync`
+  inside a discrete-event path an assertion reads: `mount/settle!` appears
+  only after an OUT-OF-BAND dispatch, which is the setup door and never
+  the claim.
+
+  ## THE THING THIS FILE EXISTS TO NOT MEASURE BY ACCIDENT
+
+  UIx picks its controlled-input implementation **from the classpath**:
+  `uix.compiler.aot/create-uix-input` branches on
+  `uix.compiler.input/should-use-reagent-input?`, which — left alone —
+  answers *\"is Reagent loaded?\"*. Every `:browser-test` bundle in this
+  repo carries Reagent, so a UIx `:input` here is **not** a plain React
+  controlled input: it is a port of Reagent's workaround that makes the
+  element uncontrolled and drives it from a `requestAnimationFrame`
+  queue, one frame late. Two rows were once green while measuring that
+  port and reading it as React (rf2-n3dxw), which is the whole reason
+  `*use-reagent-input-enabled?*` exists to pin with.
+
+  **Arm 1 does not go through UIx at all**, and the first row below proves
+  it rather than asserting it. `front.codec` emits `[:input …]` with
+  `react/createElement` against the tag string, so the selector has
+  nothing to select: pinned either way, in the same bundle, in the same
+  turn, the arm's cell behaves identically — while a UIx cell mounted
+  beside it on the same frame changes behaviour with the pin. That is the
+  measurement that licenses every row after it to say \"React\" and mean it.
+
+  ## What React's own restore does, and what it does not
+
+  React's end-of-discrete-event state restore fires even when nothing
+  re-rendered: the change plugin records the target
+  (`react-dom-client.development.js`, `createAndAccumulateChangeEvent`
+  banks `restoreTarget` **before** it looks for an `onChange` listener, so
+  an `:on-input`-only element is restored too), and the `finally` of
+  `batchedUpdates$1` hands the committed props to `updateInput`, which
+  assigns `element.value` whenever it differs. **So a refused character
+  comes off the screen inside the discrete event, with nothing
+  re-rendered.**
+
+  What it does not do is put the caret back. Assigning `value` moves the
+  cursor to the end of the control (the HTML `value` IDL setter), and
+  React restores a selection only around a commit in which focus MOVED.
+  So every write React makes lands the caret at the end. Neither shipped
+  implementation gives both same-turn convergence and the caret where the
+  edit left it — React converges in-turn and throws the caret to the end,
+  UIx's port gets the caret right a frame late. rf2-n3dxw records it and
+  rf2-fki5d prices the third behaviour that would have both. **The rows
+  below assert the MEASURED value, not the desired one**: the day
+  something puts the caret back, they go red, and whoever makes them red
+  is exactly the person who should be reading those two beads.
+
+  ## Typing is simulated the way the browser does it
+
+  [[type-into!]] mutates the field **first** and fires `input` **second**,
+  because that is the whole difficulty: by the time any handler runs, the
+  character is already on screen. It writes through
+  `HTMLInputElement.prototype`'s own `value` setter, because React patches
+  the *instance* setter to maintain its change tracker and a plain `set!`
+  would update the tracker too — after which React discards the `input`
+  event as a no-op change and nothing under test ever runs.
+
+  Runtime: `-dom-cljs-test`; under `:node-test` every claim degrades to a
+  stated skip."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.grid :as grid]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]
+            [uix.core :refer [$ defui]]
+            [uix.compiler.input]
+            ;; Required so `:uix-reagent-input` can be SELECTED rather than
+            ;; merely inherited: UIx's port reaches Reagent's after-render
+            ;; queue through the `reagent.impl.batching` global, which only
+            ;; exists once that namespace is loaded.
+            [reagent.impl.batching]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview hfn]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     ;; `:ambient-frame nil` is load-bearing: the fixture's default leaves
+     ;; a dynamic-var frame stamp in scope and the carried-invariant chain
+     ;; resolves that tier BEFORE React context, so the UIx comparator
+     ;; would read the ambient frame's app-db while the arm read the
+     ;; provider's.
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::arm1-grid)
+
+(defn- skip! [why]
+  (is true (str "a caret in a real text field needs a real DOM — " why)))
+
+;; ---------------------------------------------------------------------------
+;; Pinning the input implementation
+;; ---------------------------------------------------------------------------
+
+(def input-implementations
+  "The two things `uix.compiler.aot/create-uix-input` can build, and the
+  value of `uix.compiler.input/*use-reagent-input-enabled?*` that selects
+  each. `nil` — the shipped default — is not a third option; it is
+  *whichever of these two the bundle's contents imply*."
+  {:react false :uix-reagent-input true})
+
+(defn- pin! [impl]
+  (set! uix.compiler.input/*use-reagent-input-enabled?*
+        (get input-implementations impl)))
+
+(defn- unpin! [] (set! uix.compiler.input/*use-reagent-input-enabled?* nil))
+
+;; ---------------------------------------------------------------------------
+;; The harness
+;; ---------------------------------------------------------------------------
+
+(defn- fresh!
+  "A frame holding exactly the seeded grid. Both halves are needed:
+  `make-frame!` is idempotent and will not replay its initial events for
+  an id that already exists, and `reseed!` is the model's own door for
+  returning a live frame to its seeded state."
+  []
+  (lane/leave-act-environment!)
+  (grid/make-frame! frame-id grid/cells)
+  (grid/reseed! frame-id grid/cells)
+  frame-id)
+
+(defn- arm-mount!
+  "The arm's grid, on the arm's own root."
+  []
+  (mount/root! (mount/fresh-container!) frame-id [grid/grid {:n grid/cells}]))
+
+(defn- cell-input [handle i] (.querySelector (:container handle) (str "#c" i)))
+
+(defn- model-value
+  "What app-db says cell `i` holds — the other half of every agreement
+  assertion, read from the frame rather than from the renderer."
+  [i]
+  (get-in (rf/app-db-value frame-id) [:cells i] ""))
+
+(defn- committed-value [i] (get-in (rf/app-db-value frame-id) [:committed i]))
+
+(defn- caret [node] [(.-selectionStart node) (.-selectionEnd node)])
+
+(defn- set-native-value!
+  "Write `v` through `HTMLInputElement.prototype`'s OWN `value` setter,
+  bypassing React's per-instance change tracker. See the ns docstring."
+  [node v]
+  (let [d (js/Object.getOwnPropertyDescriptor js/HTMLInputElement.prototype "value")]
+    (.call (.-set d) node v)))
+
+(defn- type-into!
+  "Type `text` at the caret, the way a browser does it: the field changes
+  first, the `input` event fires second."
+  [node text]
+  (let [start (.-selectionStart node)
+        end   (.-selectionEnd node)
+        v     (.-value node)]
+    (set-native-value! node (str (subs v 0 start) text (subs v end)))
+    (let [c (+ start (count text))]
+      (.setSelectionRange node c c))
+    (.dispatchEvent node (js/Event. "input" #js {:bubbles true}))
+    nil))
+
+(defn- key-event
+  "Build a `keydown` the way an IME's host browser sends one. Returned
+  rather than dispatched so a caller can ASSERT the signal it thinks it
+  is sending: `keyCode` and `isComposing` are legacy/extension members of
+  `KeyboardEventInit`, and a row whose event silently carried neither
+  would be a green gate over an unexercised fence."
+  [{:keys [key composing? key-code]}]
+  (js/KeyboardEvent. "keydown"
+                     #js {:key         (or key "Enter")
+                          :bubbles     true
+                          :isComposing (boolean composing?)
+                          :keyCode     (or key-code 13)}))
+
+(defn- set-model!
+  "Put a value in the model out of band — the setup door, and also the
+  async-normalisation door. OUT of the discrete-event path, so this is
+  where `settle!` is legitimate."
+  [i v]
+  (rt/dispatch! frame-id [:agrid/set i v])
+  (mount/settle!)
+  nil)
+
+(defn- after-a-frame
+  "Give Reagent's after-render queue the animation frame it is scheduled
+  on, then a macrotask for anything that frame scheduled in turn."
+  [f]
+  (js/requestAnimationFrame (fn [] (js/setTimeout f 0))))
+
+(defn- with-grid
+  "Mount the arm's grid with `impl` pinned, run `f` with the handle, and
+  tear it down whatever happens. Synchronous bodies only — an async body
+  returns before its timer fires, and a grid torn down under a pending
+  callback dispatches into a frame that is gone."
+  ([f] (with-grid :react f))
+  ([impl f]
+   (pin! impl)
+   (fresh!)
+   (let [handle (arm-mount!)]
+     (try (f handle)
+          (finally (mount/release! handle) (unpin!))))))
+
+;; ---------------------------------------------------------------------------
+;; The UIx comparator — its own root, its own provider
+;; ---------------------------------------------------------------------------
+;;
+;; Deliberately NOT the arm's root: the control must not borrow the
+;; candidate's plumbing, or a plumbing bug would hide inside the very
+;; comparison that is supposed to expose it. Same frame, same model, same
+;; keystroke — the ONLY variable is which library minted the element.
+
+(defui uix-cell [{:keys [i]}]
+  (let [v                        (uix-adapter/use-subscribe [:agrid/cell i])
+        {:keys [dispatch-sync]}  (uix-adapter/use-frame)]
+    ($ :input {:id        (str "u" i)
+               :type      "text"
+               :value     v
+               :on-change (fn [e] (dispatch-sync [:agrid/edit i (.. e -target -value)]))})))
+
+(defn- uix-mount! [i]
+  (let [container (mount/fresh-container!)
+        root      (react-dom-client/createRoot container)]
+    (react-dom/flushSync
+      (fn [] (.render root ($ uix-adapter/frame-provider {:frame frame-id}
+                              ($ uix-cell {:i i})))))
+    {:root root :container container}))
+
+(defn- uix-release! [{:keys [root container]}]
+  (react-dom/flushSync (fn [] (.unmount root)))
+  (when-some [p (.-parentNode container)] (.removeChild p container))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; 0 — the arm's element path is React's own, and the classpath cannot
+;;     reach it
+;; ---------------------------------------------------------------------------
+
+(deftest the-selector-is-live-in-this-bundle
+  (testing "UIx's default answer is a fact about the classpath, and this
+           bundle carries Reagent — so an unpinned UIx `:input` here is not
+           a plain React controlled input at all"
+    (is (some? reagent.impl.batching/do-after-render)
+        "Reagent's after-render queue is in this bundle, which is exactly
+         what makes UIx's default answer `true`")
+    (unpin!)
+    (is (true? (uix.compiler.input/should-use-reagent-input?)))
+    (pin! :react)
+    (is (false? (uix.compiler.input/should-use-reagent-input?)))
+    (pin! :uix-reagent-input)
+    (is (true? (uix.compiler.input/should-use-reagent-input?)))
+    (unpin!)))
+
+(deftest the-arms-input-is-reacts-own-whatever-the-selector-says
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      ;; THE PIN THAT WOULD CHANGE A UIx CELL. Both elements are minted in
+      ;; the same turn, on the same frame, against the same model, with
+      ;; the port SELECTED. If the arm went through UIx, its refused
+      ;; character would still be on screen when the event returned.
+      (do
+        (pin! :uix-reagent-input)
+        (fresh!)
+        (let [arm   (arm-mount!)
+              ctrl  (uix-mount! 11)
+              a     (cell-input arm 11)
+              u     (.querySelector (:container ctrl) "#u11")]
+          (set-model! 11 "12")
+          (mount/settle!)
+          (.focus a)
+          (.setSelectionRange a 2 2)
+          (type-into! a "a")
+          (is (= "12" (.-value a))
+              "ARM: the refused character is off the screen on the line
+               after `dispatchEvent` — React's own restore, inside the
+               discrete event, with the port pinned ON")
+          (is (= "12" (model-value 11)))
+          (.focus u)
+          (.setSelectionRange u 2 2)
+          (type-into! u "a")
+          (is (= "12a" (.-value u))
+              "UIx, SAME PIN, SAME TURN: still on the screen — the port
+               deleted `value` from the props and drives the element from
+               an animation-frame queue, so React's restore has nothing to
+               restore. This is the difference the pin makes, and the arm
+               does not have it")
+          (after-a-frame
+            (fn []
+              (try
+                (is (= "12" (.-value u))
+                    "one animation frame later the port has converged —
+                     which is the timing rf2-n3dxw originally recorded as
+                     React's")
+                (catch :default e
+                  (is false (str "the deferred converge threw: " (ex-message e)))))
+              (uix-release! ctrl)
+              (mount/release! arm)
+              (unpin!)
+              (done))))))))
+
+(deftest the-arm-reads-the-same-on-both-pins
+  (testing "the selector cannot reach `react/createElement \"input\"`, so
+           the arm's cell is byte-identical under both pins — which is what
+           licenses every row below to name React and mean it"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (let [reading (fn [impl]
+                      (with-grid impl
+                        (fn [handle]
+                          (let [n (cell-input handle 11)]
+                            (set-model! 11 "12")
+                            (.focus n)
+                            (.setSelectionRange n 2 2)
+                            (type-into! n "a")
+                            {:value (.-value n) :caret (caret n) :model (model-value 11)}))))]
+        (is (= {:value "12" :caret [2 2] :model "12"} (reading :react)))
+        (is (= (reading :react) (reading :uix-reagent-input))
+            "same reading with the port pinned ON — the arm never asked")))))
+
+;; ---------------------------------------------------------------------------
+;; 1 — :same-turn-echo, at the witness's stated size, and the per-keystroke
+;;     budget
+;; ---------------------------------------------------------------------------
+
+(deftest a-keystroke-echoes-inside-the-discrete-event
+  (testing "100 cells mounted; a real `input` event on one of them reaches
+           app-db and comes back to the DOM before the event returns — no
+           act, no flushSync, no yield"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (is (= grid/cells (.-length (.querySelectorAll (:container handle) ".cell")))
+              "the witness is at its stated size")
+          (let [n (cell-input handle 7)]
+            (.focus n)
+            (type-into! n "hello")
+            (is (= "hello" (model-value 7)) "the model took the keystroke")
+            (is (= "hello" (.-value n))
+                "and the field shows it, on the next line — HD-019's
+                 synchronous door, through the arm's own dispatch")))))))
+
+(deftest the-echo-is-one-body-run-not-one-hundred
+  (testing "the per-keystroke budget: a keystroke in cell 7 re-runs cell 7"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [n (cell-input handle 7)]
+            (.focus n)
+            (reset! grid/!body-runs 0)
+            (type-into! n "x")
+            (is (= 1 @grid/!body-runs)
+                (str "one boundary body ran, not " grid/cells))))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — :mid-string-caret
+;; ---------------------------------------------------------------------------
+
+(deftest editing-mid-string-leaves-the-caret-where-the-typing-put-it
+  (testing "the model agreed with the field, so React wrote nothing and the
+           cursor stayed where the character went in"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [n (cell-input handle 7)]
+            (set-model! 7 "abcd")
+            (.focus n)
+            (.setSelectionRange n 2 2)
+            (type-into! n "X")
+            (is (= "abXcd" (model-value 7)))
+            (is (= "abXcd" (.-value n)))
+            (is (= [3 3] (caret n))
+                "the caret did not jump to the end")))))))
+
+(deftest a-normalising-model-moves-the-caret-to-the-end
+  (testing "RECORDED BEHAVIOUR, NOT DESIRED BEHAVIOUR (rf2-n3dxw,
+           rf2-fki5d). The model uppercases what was typed, so React
+           WRITES — and every write React makes lands the caret at the end
+           of the string. This is the classic controlled-input caret jump,
+           and it belongs to React's restore rather than to anything this
+           arm does"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [n (cell-input handle 13)]
+            (set-model! 13 "ABCD")
+            (.focus n)
+            (.setSelectionRange n 2 2)
+            (type-into! n "x")
+            (is (= "ABXCD" (model-value 13)) "the model normalised the case")
+            (is (= "ABXCD" (.-value n)) "and the field followed, in the same turn")
+            (is (= [5 5] (caret n))
+                "but the caret is at the END, not after the character just
+                 typed — React restores a selection only around a commit in
+                 which focus MOVED, and focus did not move")))))))
+
+(deftest a-grouping-model-keeps-the-caret-after-the-digit-just-typed
+  (testing "1,234 + \"5\" becomes 12,345 — one character longer than what
+           was typed. The caret survives here only because the edit was at
+           the END of the field, which is where React's write puts it
+           anyway"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [n (cell-input handle 17)]
+            (set-model! 17 "1,234")
+            (.focus n)
+            (.setSelectionRange n 5 5)
+            (type-into! n "5")
+            (is (= "12,345" (model-value 17)))
+            (is (= "12,345" (.-value n)))
+            (is (= [6 6] (caret n)) "the caret is still after the 5")))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — :selection-preserved
+;; ---------------------------------------------------------------------------
+
+(deftest a-write-to-another-cell-leaves-this-fields-selection-alone
+  (testing "a commit that moves a DIFFERENT cell's subscription writes
+           nothing here, so nothing here moves — the index's narrowness
+           read as a caret rather than as a re-render count"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [n (cell-input handle 7)]
+            (set-model! 7 "abcdef")
+            (.focus n)
+            (.setSelectionRange n 1 4)
+            (is (= [1 4] (caret n)) "the range is really there before the write")
+            (set-model! 23 "elsewhere")
+            (is (= [1 4] (caret n)) "and it survived a commit elsewhere")
+            (is (= "abcdef" (.-value n)))))))))
+
+(deftest a-range-collapses-when-the-restore-writes-this-field
+  (testing "RECORDED BEHAVIOUR, NOT DESIRED BEHAVIOUR (rf2-n3dxw). Arm 2
+           restored both ends of a selection by distance from the end of
+           the string. React does not: it assigns `value`, which collapses
+           the selection to a cursor at the end of the new string. Nothing
+           here pretends otherwise"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [n (cell-input handle 7)]
+            (set-model! 7 "abcdef")
+            (.focus n)
+            (.setSelectionRange n 1 4)
+            (set-model! 7 "Xabcdef")
+            (is (= "Xabcdef" (.-value n)) "the new value reached the field")
+            (is (= [7 7] (caret n))
+                "and the range is a cursor at the end of what React wrote")))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — :ime-composition-commits-nothing
+;; ---------------------------------------------------------------------------
+;;
+;; The claim authoring.md pins, and the one the arm actually owns: **a
+;; composing Enter commits nothing**. The gate is
+;; `front.intent/composing?`, written over the WHOLE key-map rather than
+;; over Enter alone, because during composition every keystroke belongs to
+;; the IME and a per-key exception list is a second place for the law to
+;; rot.
+;;
+;; What is NOT asserted, and why, so the absence reads as a decision: the
+;; **value** path during composition. Synthetic `compositionstart` /
+;; `compositionend` events do not exercise React's composition plugin, and
+;; a fence asserted without being demonstrated is worse than no assertion.
+;; `bench/hicasso/controlled_restore_dom_cljs_test` carries the same
+;; carve-out and rf2-n3dxw carries the bead.
+
+(def ^:private !probe (atom []))
+
+(defview compose-probe
+  "An `h/fn` at a key position, so the row can read what React actually
+  hands a keydown handler."
+  [_]
+  [:input.probe {:type        "text"
+                 :on-key-down (hfn [e]
+                                (swap! !probe conj
+                                       {:synthetic (.-isComposing e)
+                                        :native    (.-isComposing (.-nativeEvent e))
+                                        :key-code  (.-keyCode e)})
+                                nil)}])
+
+(deftest reacts-synthetic-keyboard-event-drops-is-composing
+  (testing "MEASURED, and the reason `composing?` reads the NATIVE event.
+           React's `KeyboardEventInterface` enumerates key, code, location,
+           the modifier flags, repeat, locale, charCode, keyCode and which
+           — and `createSyntheticEvent` copies THAT LIST and nothing else.
+           `isComposing` is not on it, so a gate reading it off the
+           synthetic event is dead on React and only the legacy keyCode
+           half ever fires"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (do
+        (fresh!)
+        (reset! !probe [])
+        (let [handle (mount/root! (mount/fresh-container!) frame-id [compose-probe {}])]
+          (try
+            (let [node (.querySelector (:container handle) ".probe")
+                  e    (key-event {:key "Enter" :composing? true :key-code 229})]
+              (is (true? (.-isComposing e))
+                  "the event this row sends really does carry isComposing")
+              (is (= 229 (.-keyCode e))
+                  "and really does carry the legacy signal")
+              (.dispatchEvent node e)
+              (let [seen (first @!probe)]
+                (is (some? seen) "the handler ran")
+                (is (nil? (:synthetic seen))
+                    "React's synthetic keyboard event does NOT carry
+                     isComposing — this is the finding")
+                (is (true? (:native seen))
+                    "the native event does, and that is where the gate has
+                     to read it")
+                (is (= 229 (:key-code seen))
+                    "while the legacy signal survives the synthetic
+                     interface, because keyCode IS on React's list")))
+            (finally (mount/release! handle))))))))
+
+(deftest a-composing-enter-commits-nothing
+  (testing "both signals, each on its own, through a real React keydown on
+           a real cell"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [n (cell-input handle 7)]
+            (set-model! 7 "shi")
+            (.focus n)
+            (testing "isComposing alone — the modern signal"
+              (let [e (key-event {:key "Enter" :composing? true :key-code 13})]
+                (is (true? (.-isComposing e)))
+                (.dispatchEvent n e))
+              (is (nil? (committed-value 7))
+                  "the IME's Enter selected a candidate; it did not commit
+                   the field"))
+            (testing "keyCode 229 alone — all some IMEs on some browsers send"
+              (let [e (key-event {:key "Enter" :composing? false :key-code 229})]
+                (is (false? (.-isComposing e)))
+                (is (= 229 (.-keyCode e)))
+                (.dispatchEvent n e))
+              (is (nil? (committed-value 7))
+                  "the legacy signal gates the same map"))
+            (testing "and an ordinary Enter DOES commit, so the gate is a
+                     gate and not an off switch"
+              (.dispatchEvent n (key-event {:key "Enter" :composing? false :key-code 13}))
+              (is (= "shi" (committed-value 7))))
+            (testing "the model never moved through any of it"
+              (is (= "shi" (model-value 7)))
+              (is (= "shi" (.-value n))))))))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — :unchanged-model-rejection
+;; ---------------------------------------------------------------------------
+
+(deftest a-refused-keystroke-moves-no-model-and-re-runs-no-boundary
+  (testing "cell 11 takes digits only. The browser has already shown the
+           letter; the model does not move, so NOTHING re-renders"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [n (cell-input handle 11)]
+            (set-model! 11 "12")
+            (.focus n)
+            (.setSelectionRange n 2 2)
+            (reset! grid/!body-runs 0)
+            (type-into! n "a")
+            (is (= "12" (model-value 11)) "the model refused the letter")
+            (is (zero? @grid/!body-runs)
+                "and no boundary body ran at all — the value the model holds
+                 did not change, so there was nothing for React to
+                 re-render")))))))
+
+(deftest a-refused-keystroke-is-taken-off-the-screen-inside-the-event
+  (testing "the row rf2-n3dxw was opened for, taken on the arm. Nothing
+           re-rendered — the row above counts zero body runs on this exact
+           keystroke — so the write below cannot have come from a render.
+           It is React's own controlled-state restore, and all of it lands
+           before `dispatchEvent` returns"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [n (cell-input handle 11)]
+            (set-model! 11 "12")
+            (.focus n)
+            (.setSelectionRange n 2 2)
+            (reset! grid/!body-runs 0)
+            (type-into! n "a")
+            (is (= "12" (.-value n))
+                "the refused character is off the screen, on the next line")
+            (is (= "12" (model-value 11)) "and the field and the model agree")
+            (is (zero? @grid/!body-runs) "with nothing re-rendered to do it")
+            (is (= [2 2] (caret n))
+                "caret at the position before the refused character —
+                 because the edit was AT the end, which is where React's
+                 write leaves it anyway")))))))
+
+(deftest a-refused-keystroke-mid-string-converges-with-the-caret-at-the-end
+  (testing "RECORDED BEHAVIOUR, NOT DESIRED BEHAVIOUR (rf2-n3dxw,
+           rf2-fki5d). The residue after the headline row is met: the
+           refused character IS removed, in the same turn — but React's
+           write moves the cursor to the end, so a user editing mid-string
+           is thrown to the end of the field on every refused keystroke"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [n (cell-input handle 11)]
+            (set-model! 11 "12345")
+            (.focus n)
+            (.setSelectionRange n 2 2)
+            (type-into! n "z")
+            (is (= "12345" (.-value n)) "the refused character is gone")
+            (is (= "12345" (model-value 11)))
+            (is (= [5 5] (caret n))
+                "but the caret is at the end of the field, not at 2")))))))
+
+;; ---------------------------------------------------------------------------
+;; 6 — :async-normalisation
+;; ---------------------------------------------------------------------------
+
+(deftest a-correction-that-arrives-later-still-converges
+  (testing "the same restore driven by a timer instead of a keystroke — the
+           shape a server normalisation or a debounced validation takes.
+           Nothing about the arm's door is synchronous here, and it still
+           lands"
+    (async done
+      (if-not (mount/browser?)
+        (do (skip! ":node-test has no DOM") (done))
+        ;; NOT `with-grid`: its `finally` runs the moment the body returns,
+        ;; and the body of an async test returns before its timer fires.
+        (do
+          (pin! :react)
+          (fresh!)
+          (let [handle (arm-mount!)
+                n      (cell-input handle 17)]
+            (set-model! 17 "1234")
+            (.focus n)
+            (.setSelectionRange n 4 4)
+            (is (= "1234" (.-value n)) "the field starts where the model does")
+            (js/setTimeout
+              (fn []
+                (try
+                  (set-model! 17 (grid/group-digits "1234"))
+                  (is (= "1,234" (model-value 17)) "the late correction reached the model")
+                  (is (= "1,234" (.-value n)) "and the field")
+                  (is (= [5 5] (caret n))
+                      "with the caret still after the last digit")
+                  (catch :default e
+                    (is false (str "the late correction threw: " (ex-message e)))))
+                (mount/release! handle)
+                (unpin!)
+                (done))
+              0)))))))
+
+;; ---------------------------------------------------------------------------
+;; Teardown
+;; ---------------------------------------------------------------------------
+
+(deftest the-grid-leaves-no-residue
+  (testing "one hundred controlled boundaries, typed into, then released"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (do
+        (pin! :react)
+        (fresh!)
+        (let [handle (arm-mount!)
+              n      (cell-input handle 7)]
+          (.focus n)
+          (type-into! n "abc")
+          (is (= "abc" (model-value 7)))
+          (mount/release! handle)
+          (unpin!)
+          (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                 (rt/residue))
+              "zero leaked subscription ref-counts after teardown"))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/grid.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/grid.cljs
@@ -1,0 +1,164 @@
+(ns re-frame.bench.hicasso.arm1.grid
+  "THE 100-CELL CONTROLLED GRID, WRITTEN ON ARM 1 (K4, HD-019's full door
+  — rf2-2rtt6.41).
+
+  validation.md's `:controlled/grid-100` witness, on the arm's own
+  runtime: 100 boundaries, one event, one parametric subscription, and a
+  per-cell policy in `app-db`. `arm1_controlled_grid_dom_cljs_test` is
+  what reads it.
+
+  ## The model is Arm 2's, deliberately unchanged
+
+  The retired PATCH arm's `:controlled/grid-100` model — four policies
+  over one `[:agrid/cell i]` subscription — is the clearest statement in
+  the repo of what a store-backed controlled input has to do, and it now
+  drives two files: `bench/hicasso/controlled_restore_dom_cljs_test`
+  measures the **UIx adapter's** two input implementations against it, and
+  this one measures **Arm 1's own element path** against the same four
+  policies. Two arms, one model, so a difference between them is a
+  difference between the renderers rather than between two grids.
+
+  The ids are `:agrid/*` rather than a second copy of `:cgrid/*` because
+  image assembly refuses one id registered from two source namespaces
+  with different implementations (`:rf.error/image-duplicate-id`) — and it
+  is right to: the two files are two different grids on one page, and
+  letting load order pick which `:cgrid/edit` a frame runs is exactly the
+  silent selection that rule exists to prevent.
+
+  | policy | what the model does with the typed value |
+  |---|---|
+  | `:plain` | takes it |
+  | `:digits` | **refuses** it unless it is all digits — the model does not move |
+  | `:upper` | normalises it to upper case |
+  | `:group` | normalises `12345` to `12,345` — the length changes |
+
+  ## The commit door exists for the composition gate
+
+  `:agrid/commit` copies a cell's live value into `:committed`, and the
+  cell's `:on-key-down` map binds `\"Enter\"` to it. That is the case
+  authoring.md pins for the IME fence — **a composing Enter must commit
+  nothing** — expressed as a value a witness can read out of `app-db`
+  rather than as an absence it has to infer.
+
+  ## What the views are, and what they are not
+
+  One `defview` per cell, reading through the ambient collector, writing
+  through the intent-vector surface with `::h/value`. No `h/fn`, no ref,
+  no effect and no per-instance state — the claim under test is that the
+  ordinary authoring surface meets HD-019's door, so anything the cell
+  needed beyond `:value` / `:on-input` would be part of the finding."
+  (:require [clojure.string :as str]
+            [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.core :as rf])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(def cells
+  "The witness size validation.md names for the controlled grid."
+  100)
+
+(def policies
+  "Which cells are not `:plain`. Three indices, so 97 of the 100 are the
+  ordinary case and the interesting ones are addressable by number."
+  {11 :digits 13 :upper 17 :group})
+
+;; ---------------------------------------------------------------------------
+;; The model
+;; ---------------------------------------------------------------------------
+
+(defn group-digits
+  "`\"12345\"` → `\"12,345\"`. Non-digits are dropped, which is what makes
+  this a normalisation rather than a rejection."
+  [s]
+  (let [ds (str/replace (str s) #"[^0-9]" "")
+        n  (count ds)]
+    (if (<= n 3)
+      ds
+      (->> (reverse ds)
+           (partition-all 3)
+           (map (comp str/join reverse))
+           reverse
+           (str/join ",")))))
+
+(defn apply-policy
+  "What the model does with a typed value. `old` is what it holds now,
+  which is the whole of a rejection: the model returns itself."
+  [policy old v]
+  (case policy
+    :digits (if (re-matches #"[0-9]*" v) v old)
+    :upper  (str/upper-case v)
+    :group  (group-digits v)
+    v))
+
+(rf/reg-sub :agrid/cell (fn [db [_ i]] (get-in db [:cells i] "")))
+
+(rf/reg-sub :agrid/committed (fn [db [_ i]] (get-in db [:committed i])))
+
+(rf/reg-event :agrid/seed
+  (fn [_ [_ n]]
+    {:db {:cells     (into {} (map (fn [i] [i ""])) (range n))
+          :committed {}
+          :policies  policies}}))
+
+(rf/reg-event :agrid/edit
+  (fn [{:keys [db]} [_ i v]]
+    (let [policy (get-in db [:policies i] :plain)
+          old    (get-in db [:cells i] "")]
+      {:db (assoc-in db [:cells i] (apply-policy policy old v))})))
+
+;; The door an out-of-band correction arrives through — a server
+;; normalisation, a debounce, a validation that resolves late. Also the
+;; setup door, because a witness that typed its own setup would be
+;; measuring the keystroke it is about to take.
+(rf/reg-event :agrid/set
+  (fn [{:keys [db]} [_ i v]] {:db (assoc-in db [:cells i] v)}))
+
+(rf/reg-event :agrid/commit
+  (fn [{:keys [db]} [_ i]]
+    {:db (assoc-in db [:committed i] (get-in db [:cells i] ""))}))
+
+;; ---------------------------------------------------------------------------
+;; The frame
+;; ---------------------------------------------------------------------------
+
+(defn make-frame!
+  "Create (or idempotently replace) `frame-id`, seeded with `n` empty
+  cells."
+  [frame-id n]
+  (rf/make-frame {:id frame-id :initial-events [[:agrid/seed n]]})
+  frame-id)
+
+(defn reseed!
+  "Return the frame to its seeded state, so one row never reads a grid a
+  previous one already typed into."
+  [frame-id n]
+  (rf/with-frame frame-id (rf/dispatch-sync [:agrid/seed n]))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; The views
+;; ---------------------------------------------------------------------------
+
+(def !body-runs
+  "How many cell bodies have run. The per-keystroke budget is COUNTED
+  here rather than asserted about, and the rejection row's \"nothing
+  re-rendered\" is the same counter reading zero."
+  (atom 0))
+
+(defview cell
+  "One controlled cell. The whole of it: a `:value` read through the
+  ambient collector, an `:on-input` intent carrying `::h/value`, and a
+  key-map whose `\"Enter\"` branch is what the IME fence has to stop."
+  [{:keys [i]}]
+  (swap! !body-runs inc)
+  [:input.cell {:id          (str "c" i)
+                :type        "text"
+                :value       (sub [:agrid/cell i])
+                :on-input    [:agrid/edit i :re-frame.hicasso/value]
+                :on-key-down {"Enter" [:agrid/commit i]}}])
+
+(defview grid
+  "`n` cells, keyed."
+  [{:keys [n]}]
+  [:div.grid {:role "group"}
+   (for [i (range (or n cells))]
+     [cell {:key i :i i}])])

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/lifecycle_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/lifecycle_dom_cljs_test.cljs
@@ -1,0 +1,340 @@
+(ns re-frame.bench.hicasso.arm1.lifecycle-dom-cljs-test
+  "STRICTMODE, THE HMR BODY SWAP, AND A REAL ERROR BOUNDARY
+  (rf2-2rtt6.41).
+
+  validation.md's `:lifecycle/strict-abandoned-teardown-hmr` row names
+  four things; rf2-2rtt6.9 witnessed the abandoned render (the generation
+  fence suite) and the teardown (the standing zero-residue assertion).
+  The other two are here, together with the `:foreign/…-error-boundary`
+  half that HD-020(c) owes — the runtime's internal class-based
+  [[re-frame.bench.hicasso.arm1.boundary/boundary]], which did not exist
+  until this bead.
+
+  ## StrictMode is CLAIMED correct by construction, so it is PROVED
+
+  `runtime/run-once` resets the scratch and both provenance flags
+  **unconditionally**, and the runtime's docstring says in two places
+  that this is what makes StrictMode's double-invoke correct rather than
+  additive. HD-002's ownership table is blunter still — of the
+  `COMMITTED → COMMITTED` transition (StrictMode's mount / unmount /
+  mount of effects) it says *\"idempotent because the index is set-valued
+  — but **prove it with a witness, do not assume it**\"*.
+
+  So the row below asserts the double-invoke actually happened before it
+  asserts anything about the result. A StrictMode witness on a build where
+  React did not double-invoke is a green gate over nothing, and that is
+  the failure mode this bead exists to close elsewhere too.
+
+  ## What an HMR body swap is, concretely
+
+  `defview` expands to a `def` of `mint-view!`'s product, so re-evaluating
+  a view's form mints a **new React component**. That — not a mutated
+  closure — is what shadow-cljs's reload hands React, and it is what is
+  swapped below: same root, same container, same frame, same app-db, a
+  different component in the tree. HD-021(c)'s minimum is that the first
+  four survive, that the changed body is used, and that no subscription
+  leaks; all five are read here.
+
+  Runtime: `-dom-cljs-test`; under `:node-test` every claim degrades to a
+  stated skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.boundary :refer [boundary]]
+            [re-frame.bench.hicasso.arm1.hook-probe :as probe]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+;; Registered ABOVE `use-fixtures`, deliberately. The reset fixture
+;; captures its source-store baseline when the `use-fixtures` form is
+;; EVALUATED and restores that baseline before every test — so a `reg-sub`
+;; written below it is erased before the first row runs.
+
+(rf/reg-sub :life/cell (fn [db [_ i]] (get-in db [:cells i] "")))
+(rf/reg-sub :life/a (fn [db _] (:a db)))
+(rf/reg-sub :life/b (fn [db _] (:b db)))
+(rf/reg-sub :life/boom? (fn [db _] (:boom? db)))
+(rf/reg-sub :life/attempt (fn [db _] (:attempt db)))
+
+(rf/reg-event :life/seed
+  (fn [_ [_ n]]
+    {:db {:cells   (into {} (map (fn [i] [i (str "v" i)])) (range n))
+          :a       "alpha"
+          :b       "beta"
+          :boom?   false
+          :attempt 0
+          :errors  []}}))
+
+(rf/reg-event :life/set-cell
+  (fn [{:keys [db]} [_ i v]] {:db (assoc-in db [:cells i] v)}))
+
+(rf/reg-event :life/set (fn [{:keys [db]} [_ k v]] {:db (assoc db k v)}))
+
+(rf/reg-event :life/record-error
+  (fn [{:keys [db]} [_ err]]
+    {:db (update db :errors conj (or (ex-message err) (str err)))}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::arm1-lifecycle)
+(def ^:private reads 5)
+
+(defn- skip! [why] (is true (str "a lifecycle claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (lane/leave-act-environment!)
+  (rf/make-frame {:id frame-id :initial-events [[:life/seed reads]]})
+  (rf/with-frame frame-id (rf/dispatch-sync [:life/seed reads]))
+  frame-id)
+
+(defn- db [] (rf/app-db-value frame-id))
+
+;; ---------------------------------------------------------------------------
+;; 1 — StrictMode
+;; ---------------------------------------------------------------------------
+
+(def ^:private !runs (atom 0))
+
+(defview reader
+  "One boundary, `n` reads inside a `for`. The counter is what makes the
+  double-invoke a measured premise rather than an assumed one."
+  [{:keys [n]}]
+  (swap! !runs inc)
+  [:ul.reads
+   (for [i (range n)]
+     [:li.read {:key i :data-i i} (str (rt/sub [:life/cell i]))])])
+
+(defn- strict-root!
+  "`mount/root!`, wrapped in `React.StrictMode`. Written here rather than
+  in the shared mount door because StrictMode is this row's variable and
+  every other suite in the arm must keep measuring the ordinary tree."
+  [container frame-kw hiccup]
+  (let [root (react-dom-client/createRoot container)]
+    (react-dom/flushSync
+      (fn [] (.render root (react/createElement
+                             react/StrictMode nil
+                             (mount/provider frame-kw (codec/as-element hiccup))))))
+    {:root root :frame frame-kw :container container}))
+
+(defn- read-texts [handle]
+  (mapv #(.-textContent %) (array-seq (.querySelectorAll (:container handle) ".read"))))
+
+(deftest strictmodes-double-invoke-is-not-additive
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (reset! !runs 0)
+      (let [handle (strict-root! (mount/fresh-container!) frame-id [reader {:n reads}])]
+        (try
+          (testing "the premise: React really did invoke the body twice"
+            (is (= 2 @!runs)
+                (str "StrictMode double-invokes the render in development. "
+                     "If this reads 1 the build is not double-invoking and "
+                     "every assertion below is a green gate over nothing — "
+                     "fix the build, do not relax this")))
+          (testing "ONE read-set entry, not two — the scratch is reset by
+                   overwrite at the top of every body, so the second
+                   invocation resolves the SAME set rather than appending to
+                   the first's"
+            (is (= 1 (:entries (rt/stats)))
+                "a reset guarded by \"if empty\" would concatenate the two
+                 renders' reads and mint a second entry of twice the length"))
+          (testing "and the COMMITTED → COMMITTED transition is idempotent —
+                   StrictMode mounts the effect, tears it down and mounts it
+                   again, and the index is set-valued"
+            (let [{:keys [boundaries edges cells cell-refs]} (rt/stats)]
+              (is (= 1 boundaries) "one boundary, not two registrations")
+              (is (= reads edges) (str "one edge per read, not " (* 2 reads)))
+              (is (= reads cells))
+              (is (= reads cell-refs)
+                  "one reference per cell — a double-mounted effect that did
+                   not release would read twice this")))
+          (testing "the page is right, and a later write still reaches it"
+            (is (= (mapv #(str "v" %) (range reads)) (read-texts handle)))
+            (mount/dispatch! handle [:life/set-cell 2 "moved"])
+            (is (= "moved" (nth (read-texts handle) 2)))
+            (is (= "v1" (nth (read-texts handle) 1)) "and its neighbour did not"))
+          (finally (mount/release! handle))))
+      (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0} (rt/residue))
+          "and a StrictMode tree leaves the same zero residue an ordinary one does"))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the HMR body swap
+;; ---------------------------------------------------------------------------
+;;
+;; Two separately minted components, because that is what re-evaluating a
+;; `defview` form produces: `defview` expands to `(def v (mint-view! …))`,
+;; so a reload hands React a NEW component rather than a mutated closure.
+;; They read different subscriptions on purpose — that is what makes "no
+;; subscriptions leak" a reading rather than a hope.
+
+(def ^:private before
+  (rt/mint-view! "hmr/before" (fn [_] [:div.hmr {:data-v "1"} (str (rt/sub [:life/a]))])))
+
+(def ^:private after
+  (rt/mint-view! "hmr/after" (fn [_] [:div.hmr {:data-v "2"} (str (rt/sub [:life/b]))])))
+
+(defn- hmr-node [handle] (.querySelector (:container handle) ".hmr"))
+
+(deftest an-hmr-body-swap-keeps-the-root-the-frame-and-app-db
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [container (mount/fresh-container!)
+            handle    (mount/root! container frame-id [before {}])
+            root      (:root handle)
+            db-before (db)]
+        (try
+          (is (= "1" (.getAttribute (hmr-node handle) "data-v")))
+          (is (= "alpha" (.-textContent (hmr-node handle))))
+          (is (= 1 (:edges (rt/stats))) "one edge, on the OLD body's read")
+
+          ;; The swap. Same root object, same container, same frame.
+          (mount/render! handle [after {}])
+
+          (testing "HD-021(c)'s four survivals"
+            (is (identical? root (:root handle)) "the root survived")
+            (is (identical? container (:container handle)) "and the container")
+            (is (= frame-id (:frame handle)) "and the frame")
+            (is (= db-before (db)) "and app-db is untouched by the swap"))
+          (testing "the changed body is the one that renders"
+            (is (= "2" (.getAttribute (hmr-node handle) "data-v")))
+            (is (= "beta" (.-textContent (hmr-node handle)))))
+          (testing "and no subscription leaks across the swap"
+            (let [{:keys [boundaries edges cell-refs]} (rt/stats)]
+              (is (= 1 boundaries) "the old body's registration is gone")
+              (is (= 1 edges) "and so is its edge")
+              (is (= 1 cell-refs)
+                  "exactly one reference is held — the new body's. The old
+                   cell's object may outlive this line by one macrotask (the
+                   reaper's grace window) but it holds NO reference, which is
+                   the standing assertion")))
+          (testing "the swapped-in body is really wired, not merely painted"
+            (mount/dispatch! handle [:life/set :b "beta-moved"])
+            (is (= "beta-moved" (.-textContent (hmr-node handle)))))
+          (finally (mount/release! handle))))
+      (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0} (rt/residue))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — a real error boundary
+;; ---------------------------------------------------------------------------
+
+(defview risky
+  "Throws from the render phase when the model says so — which is where a
+  React error boundary is the only thing that can catch."
+  [_]
+  (when (rt/sub [:life/boom?])
+    (throw (ex-info "the body threw" {:planted true})))
+  [:p.ok "ok"])
+
+(defview guarded
+  "The boundary as an author writes it: three keys, hiccup children, and
+  the reset key read from the model like any other value."
+  [_]
+  [boundary {:fallback  [:p.fallback "caught"]
+             :reset-key (rt/sub [:life/attempt])
+             :on-error  [:life/record-error]}
+   [risky {}]])
+
+(defn- errors [] (:errors (db)))
+(defn- has? [handle sel] (some? (.querySelector (:container handle) sel)))
+
+(deftest the-boundary-catches-reports-once-and-resets
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (rf/with-frame frame-id (rf/dispatch-sync [:life/set :boom? true]))
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [guarded {}])]
+        (try
+          (testing "the throw is caught and the fallback is on screen"
+            (is (has? handle ".fallback"))
+            (is (not (has? handle ".ok")) "the child that threw rendered nothing"))
+          (testing ":on-error fired exactly once, into the frame the boundary
+                   is mounted under"
+            (is (= ["the body threw"] (errors))
+                "once — not once per render attempt, and not once per commit
+                 of the fallback"))
+          (testing "the render that threw registered NOTHING — HD-002's
+                   RENDERING → ∅ row, which needs no cleanup because it never
+                   did anything that would need cleaning"
+            (let [{:keys [boundaries edges]} (rt/stats)]
+              (is (= 1 boundaries)
+                  "only the host boundary committed; the thrower's
+                   registration does not exist")
+              (is (= 1 edges) "and its one edge is the host's reset-key read")))
+
+          (testing "a changed :reset-key retries the child — and a failure
+                   after a reset is a NEW failure, so it reports again"
+            (mount/dispatch! handle [:life/set :attempt 1])
+            (is (has? handle ".fallback") "it threw again, so the fallback stands")
+            (is (= ["the body threw" "the body threw"] (errors))))
+
+          (testing "and once the cause is gone the child renders"
+            (rf/with-frame frame-id (rf/dispatch-sync [:life/set :boom? false]))
+            (mount/dispatch! handle [:life/set :attempt 2])
+            (is (has? handle ".ok") "the retry succeeded")
+            (is (not (has? handle ".fallback")))
+            (is (= 2 (count (errors))) "with nothing further reported")
+            (is (= 2 (:boundaries (rt/stats)))
+                "and the child that now renders holds its own registration"))
+          (finally (mount/release! handle))))
+      (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0} (rt/residue))
+          "a tree that caught a throw still tears down to nothing"))))
+
+(deftest a-function-fallback-sees-the-error
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (rf/with-frame frame-id (rf/dispatch-sync [:life/set :boom? true]))
+      (let [view   (rt/mint-view!
+                     "boundary/fn-fallback"
+                     (fn [_] [boundary {:fallback (fn [e] [:p.fallback (ex-message e)])}
+                              [risky {}]]))
+            handle (mount/root! (mount/fresh-container!) frame-id [view {}])]
+        (try
+          (is (= "the body threw"
+                 (.-textContent (.querySelector (:container handle) ".fallback")))
+              "the fallback may be a function of the error — the one thing
+               beyond static hiccup this boundary offers, and it is why
+               `:fallback` is not simply a child")
+          (finally (mount/release! handle)))))))
+
+(deftest the-boundary-spends-no-shell-hook
+  (testing "HD-020(b)'s ≤2 is the boundary SHELL's budget, and
+           `h/boundary` is a class — it calls no hooks at all. Counted at
+           React's own dispatcher, on a page that wraps one Hicasso
+           boundary in another"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (if-not (probe/install!)
+        (is false (str "React's internals slot was not found, so this claim is "
+                       "UNWITNESSED on this build — fix the probe rather than "
+                       "reading this as a pass"))
+        (do
+          (fresh!)
+          (let [container (mount/fresh-container!)
+                handle    (volatile! nil)
+                names     (probe/record!
+                            (fn [] (vreset! handle (mount/root! container frame-id
+                                                                [guarded {}]))))]
+            (mount/release! @handle)
+            (is (= ["useContext" "useSyncExternalStore"
+                    "useContext" "useSyncExternalStore"]
+                   names)
+                (str "two Hicasso boundaries, two hooks each, and the class "
+                     "between them contributes none: " (pr-str names)))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/lifecycle_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/lifecycle_dom_cljs_test.cljs
@@ -100,6 +100,33 @@
 
 (defn- db [] (rf/app-db-value frame-id))
 
+(defn- teardown-census!
+  "Unmount the root, read the live-reference census, and THEN finish the
+  release. The order is the entire load-bearing part, and it is not
+  fussiness: `mount/release!` calls `runtime/reset-runtime!`, which
+  disposes every cell and empties the index **by fiat** — so a census
+  taken after it reads all zeros whatever the teardown did or did not
+  release. Measured: with `make-subscribe`'s cleanup `release-cell!`
+  deleted, this reading goes red and a post-`release!` reading stays
+  green.
+
+  Three counts, because those three are exact the instant React's unmount
+  returns. `:cells` and `:entries` belong to the reaper, one macrotask
+  later, and asserting them here would be asserting a schedule rather
+  than a release."
+  [handle]
+  (react-dom/flushSync (fn [] (.unmount (:root handle))))
+  (let [census (select-keys (rt/residue) [:cell-refs :boundaries :edges])]
+    ;; `:root nil` so the arm's teardown door does the rest — reset the
+    ;; runtime, drop the container — without unmounting a root that is
+    ;; already gone.
+    (mount/release! (assoc handle :root nil))
+    census))
+
+(def ^:private released
+  "What [[teardown-census!]] must read after any clean teardown."
+  {:cell-refs 0 :boundaries 0 :edges 0})
+
 ;; ---------------------------------------------------------------------------
 ;; 1 — StrictMode
 ;; ---------------------------------------------------------------------------
@@ -136,7 +163,8 @@
     (do
       (fresh!)
       (reset! !runs 0)
-      (let [handle (strict-root! (mount/fresh-container!) frame-id [reader {:n reads}])]
+      (let [handle (strict-root! (mount/fresh-container!) frame-id [reader {:n reads}])
+            census (volatile! nil)]
         (try
           (testing "the premise: React really did invoke the body twice"
             (is (= 2 @!runs)
@@ -166,9 +194,10 @@
             (mount/dispatch! handle [:life/set-cell 2 "moved"])
             (is (= "moved" (nth (read-texts handle) 2)))
             (is (= "v1" (nth (read-texts handle) 1)) "and its neighbour did not"))
-          (finally (mount/release! handle))))
-      (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0} (rt/residue))
-          "and a StrictMode tree leaves the same zero residue an ordinary one does"))))
+          (finally (vreset! census (teardown-census! handle))))
+        (is (= released @census)
+            "and a StrictMode tree releases exactly as an ordinary one does —
+             read after React's unmount and before the reset door")))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — the HMR body swap
@@ -196,7 +225,8 @@
       (let [container (mount/fresh-container!)
             handle    (mount/root! container frame-id [before {}])
             root      (:root handle)
-            db-before (db)]
+            db-before (db)
+            census    (volatile! nil)]
         (try
           (is (= "1" (.getAttribute (hmr-node handle) "data-v")))
           (is (= "alpha" (.-textContent (hmr-node handle))))
@@ -225,8 +255,9 @@
           (testing "the swapped-in body is really wired, not merely painted"
             (mount/dispatch! handle [:life/set :b "beta-moved"])
             (is (= "beta-moved" (.-textContent (hmr-node handle)))))
-          (finally (mount/release! handle))))
-      (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0} (rt/residue))))))
+          (finally (vreset! census (teardown-census! handle))))
+        (is (= released @census)
+            "and the swapped tree releases everything it took")))))
 
 ;; ---------------------------------------------------------------------------
 ;; 3 — a real error boundary
@@ -258,7 +289,8 @@
     (do
       (fresh!)
       (rf/with-frame frame-id (rf/dispatch-sync [:life/set :boom? true]))
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [guarded {}])]
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [guarded {}])
+            census (volatile! nil)]
         (try
           (testing "the throw is caught and the fallback is on screen"
             (is (has? handle ".fallback"))
@@ -291,9 +323,36 @@
             (is (= 2 (count (errors))) "with nothing further reported")
             (is (= 2 (:boundaries (rt/stats)))
                 "and the child that now renders holds its own registration"))
-          (finally (mount/release! handle))))
-      (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0} (rt/residue))
-          "a tree that caught a throw still tears down to nothing"))))
+          (finally (vreset! census (teardown-census! handle))))
+        (is (= released @census)
+            "a tree that caught a throw still releases everything it took")))))
+
+(deftest the-boundary-reports-once-under-strictmode
+  (testing "WHERE THE ONCE-PER-FAILURE GUARANTEE ACTUALLY COMES FROM.
+           StrictMode runs the failing render TWICE — the body throws
+           twice — and React still calls `componentDidCatch` once. So an
+           application's failure channel gets ONE record however many times
+           React re-ran the render that produced it, and it gets it because
+           `report!` is wired to that one lifecycle rather than because
+           anything counts.
+
+           An instance flag gating the report used to sit in
+           `arm1/boundary`; removing it left every row green, so it was a
+           line nothing observed and it is gone. What reds this row is
+           reporting from a lifecycle React runs more than once — moving
+           `report!` into `render` is the mutation, and StrictMode is why
+           it is visible"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (do
+        (fresh!)
+        (rf/with-frame frame-id (rf/dispatch-sync [:life/set :boom? true]))
+        (let [handle (strict-root! (mount/fresh-container!) frame-id [guarded {}])]
+          (try
+            (is (has? handle ".fallback") "the throw was caught")
+            (is (= ["the body threw"] (errors))
+                "ONE record, not one per invocation of the render that threw")
+            (finally (mount/release! handle))))))))
 
 (deftest a-function-fallback-sees-the-error
   (if-not (mount/browser?)

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -340,10 +340,26 @@
 (defn composing?
   "Is this key event part of an in-flight IME composition? `isComposing`
   where the browser sets it, and the legacy keyCode-229 signal where it
-  is all the browser sends."
+  is all the browser sends.
+
+  **Both signals are read off the NATIVE event**, and that is not
+  defensive tidiness — it is the difference between a live fence and a
+  dead one. React does not hand a handler the browser's event: it hands
+  it a synthetic one built by copying an enumerated interface, and
+  `KeyboardEventInterface` lists key, code, location, the modifier flags,
+  repeat, locale, `charCode`, `keyCode` and `which`. **`isComposing` is
+  not on that list**, so on React it reads `undefined` however plainly the
+  browser set it, and the modern half of this gate would never fire —
+  leaving only the legacy signal, on browsers that happen to send it.
+  Measured at
+  `arm1_controlled_grid_dom_cljs_test/reacts-synthetic-keyboard-event-drops-is-composing`.
+
+  A raw DOM event has no `nativeEvent`, so it falls back to itself and
+  the node-side unit tests read exactly as they did."
   [e]
-  (or (true? (.-isComposing e))
-      (identical? 229 (.-keyCode e))))
+  (let [native (or (.-nativeEvent e) e)]
+    (or (true? (.-isComposing native))
+        (identical? 229 (.-keyCode native)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Lowering


### PR DESCRIPTION
Items 1–3 of rf2-2rtt6.41 — the witness-set rows rf2-2rtt6.9 landed the runtime for but did not build. **Items 4 (the allocation-slope half of the survival metric) and 5 (the candidate bar rows) are deliberately NOT in this PR**; item 5 is `worker/heapaxis-2rtt6-34`'s under the restated-bar posture, and item 4 would contend with it. The bead stays open on those two.

No bar row is published here, and no clock is read.

## 1. The 100-cell controlled grid (K4, HD-019's full door)

New: `arm1/grid.cljs` (the model + views) and `arm1/controlled_grid_dom_cljs_test.cljs` (the rows). The model is the retired PATCH arm's, unchanged — four policies over one parametric subscription — so the arm's element path and the UIx adapter's are measured against the same grid rather than against two. The ids are `:agrid/*` rather than a second copy of `:cgrid/*` because image assembly refuses one id registered from two source namespaces, and it is right to.

`:mid-string-caret`, `:selection-preserved`, `:ime-composition-commits-nothing`, `:unchanged-model-rejection` and `:async-normalisation`, plus `:same-turn-echo` re-taken at the witness's stated size. **No `act` anywhere in the file**, and no `flushSync` inside a discrete-event path an assertion reads — `mount/settle!` appears only after an out-of-band dispatch, which is the setup door and never the claim. Every synchronous assertion runs on the line after `dispatchEvent` returns.

### The implementation is pinned, and the arm turns out not to have one to pin

Two rows in this repo were once green while measuring UIx's Reagent-input port and reading it as React (rf2-n3dxw). `uix.compiler.input/*use-reagent-input-enabled?*` is used here to stop that recurring — and the finding is that **Arm 1 never reaches the selector at all**: `front.codec` emits `[:input …]` through `react/createElement` against the tag string, so `uix.compiler.aot/create-uix-input` is not on the path.

That is proved rather than asserted, in one turn, on one frame:

- `the-arms-input-is-reacts-own-whatever-the-selector-says` — pin the port **on**, mount the arm's grid and a UIx cell side by side, refuse a keystroke in each. The arm's refused character is off the screen on the line after `dispatchEvent`; the UIx cell's is still there, and converges one animation frame later. Same pin, same turn, two element paths, two behaviours.
- `the-arm-reads-the-same-on-both-pins` — value, caret and model are identical under both pins.
- `the-selector-is-live-in-this-bundle` — and the selector really does answer differently, so the row above is not passing vacuously.

### What is asserted is what is true, not what would be nice

Neither shipped path gives both same-turn convergence and the caret where the edit left it. React converges in-turn and throws the caret to the end; the port gets the caret right a frame late (rf2-n3dxw; rf2-fki5d prices the third behaviour that would have both). So the caret and rejection rows assert the **measured** value and name the limitation in place:

- a refused keystroke at the end of the field: gone inside the event, **zero body runs**, caret at 2 — React's own restore, with nothing re-rendered to do it;
- the same keystroke mid-string: still gone inside the event, but the caret is at the **end**, not at 2. Recorded behaviour, not desired behaviour;
- a normalising model moves the caret to the end for the same reason;
- a selection **range** collapses to a cursor when the restore writes this field.

The day something puts the caret back, those rows go red, and whoever makes them red is the person who should be reading rf2-n3dxw.

### The IME row found a live defect

`front.intent/composing?` read `isComposing` off the event it was handed. React does not hand a handler the browser's event — it hands it a synthetic one built by copying an enumerated interface, and `KeyboardEventInterface` lists key, code, location, the modifier flags, repeat, locale, `charCode`, `keyCode` and `which`. **`isComposing` is not on that list.** The modern half of the gate was dead on React, and only the legacy keyCode-229 signal was firing.

`reacts-synthetic-keyboard-event-drops-is-composing` measures that directly through an `h/fn` at a key position — synthetic `isComposing` is `undefined`, native is `true`, `keyCode` survives — and `composing?` now reads both signals off the native event, falling back to the event itself so a raw DOM event (and every node-side unit test) reads exactly as before. `a-composing-enter-commits-nothing` then takes both signals **separately**, through real React keydowns on a real cell, with a non-composing Enter as the control that proves the gate is a gate and not an off switch. Each row asserts the event it built really carries the signal it intends, so a browser that ignored the init member cannot make the row vacuous.

The **value** path during composition is still not asserted, and the file says so: synthetic composition events do not exercise React's composition plugin, and a fence asserted without being demonstrated is worse than no assertion.

## 2. StrictMode, the HMR body swap, and a real error boundary

New: `arm1/boundary.cljs` and `arm1/lifecycle_dom_cljs_test.cljs`.

**`h/boundary` did not exist** — HD-020(c) owes it and this builds it: a React class component with `:fallback` (hiccup, or a function of the error), `:reset-key` (a change clears the failure and re-mounts the child) and `:on-error` (an intent vector dispatched into the frame the boundary is mounted under, or a plain function). A class, so it spends **no shell hook** — counted at React's dispatcher by `the-boundary-spends-no-shell-hook`, which reads exactly `["useContext" "useSyncExternalStore" "useContext" "useSyncExternalStore"]` for two nested Hicasso boundaries with the class between them.

**StrictMode is proved, not assumed.** HD-002's ownership table says of `COMMITTED → COMMITTED` "idempotent because the index is set-valued — but prove it with a witness, do not assume it". The row asserts the premise first (the body really ran twice; a build that stopped double-invoking would fail rather than pass silently), then that the unconditional scratch reset leaves **one** read-set entry rather than two, and that the double-mounted effect leaves one reference per cell rather than two.

**The HMR body swap** is the realistic shape: `defview` expands to a `def` of `mint-view!`'s product, so a reload hands React a new component rather than a mutated closure. Same root, same container, same frame, same app-db, different component, different read set — and one boundary, one edge, one cell reference afterwards, with a write through the swapped-in body proving it is wired rather than merely painted.

## 3. H2 — declined, swing unspent, no SHA cited

H2 needs each `(sub q)` to compare positionally against the committed sequence **for the boundary currently rendering**, and Arm 1's render phase cannot name that boundary. Reaching it needs either a third hook (a stated HD-020(b) breach, and the thing the hook ledger measures at React's dispatcher) or a module-level map keyed by fiber/render/attempt — the candidate ledger the charter's fence and `retained-inventory`'s `:absent` list both name verbatim. `runtime.cljs`'s own clause-(b) section (rf2-2rtt6.47) reaches the identical conclusion about the durable per-boundary id the set difference would need; H2 needs a strictly stronger version of the same thing.

So no commit implements it and no bench row cites a SHA for it: under HD-002's counting rule **nothing is consumed**, and H1 remains the only spent swing. The reasoning is recorded on rf2-2rtt6.41, as the counting rule requires. It is a precondition rather than a dead end — H2 becomes testable the moment an arm buys per-instance render-phase storage under a different budget.

## Where this sits in the TESTING.md matrix

Both new suites are `*_dom_cljs_test.cljs`, so they ride **two** lanes by construction: `:browser-test` (classifier key `cljs_browser` → the Playwright `cljs-browser` PR job) against real React DOM, and `:node-test` (key `cljs_node_test` → the consolidated `cljs` job), where every DOM claim degrades to a **stated skip** rather than a false green. They are `re-frame.bench.hicasso.*`, so the `:browser-test-freehand-bench` partition — which selects `re-frame.freehand.bench.*` — does not claim them and the browser-lane partition gate stays satisfied. `arm1/boundary.cljs` and `arm1/grid.cljs` define no `deftest` and are compiled into both builds as ordinary namespaces. `lint.yml` fires on `implementation/**`. Tier 1 (`scripts/test-fast-pr.sh`) covers the node half; the browser half is tier 2.

## Quality gates

Run from the worker worktree, **rebased onto `origin/main` @ `afb1da2a8e` and re-run in full afterwards**. Main moved twice under this branch — first 37 commits that rewrote much of this tree (rf2-2rtt6.47 in `runtime.cljs`, plus `mount.cljs`, `codec.cljs`, `front/intent.cljs`), then 17 more carrying the rf2-2rtt6.34 heap rungs — so every figure below is from the second rebase, taken foreground and read as counts rather than as exit codes.

| gate | command | exit | result |
|---|---|---|---|
| browser | `npm run test:browser` | **0** | Ran 931 tests containing 5839 assertions. 0 failures, 0 errors. |
| node CLJS | `npm run test:cljs` | **0** | Ran 12246 tests containing 61140 assertions. 0 failures, 0 errors. |
| fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` |
| clj-kondo | CI's exact command at the **CI-pinned 2026.04.15** (local npm carries 2025.10.23; the pinned release was fetched and run through the Clojure CLI) | **0** | `errors: 0, warnings: 4526` — the repo baseline, and **no finding of any level in the new files** |

### Mutation proofs

Every new witness was watched failing. Each fault was planted alone, the browser lane run to completion, and the fault reverted; the clean run is the last row.

**Re-taken after each rebase**, so no proof rests on a base that has since moved: M1 and M7 after the first (main had rewritten the code they target), and M7 + M4c again after the second — the two that guard the repairs in the second commit. Every other mutation target (`runtime.cljs`, `mount.cljs`, `front/codec.cljs`, `front/sub_index.cljs`) is byte-identical between the base its proof was taken on and this one, checked with `git diff --quiet` per file rather than assumed.

| # | planted fault | exit | rows that went RED |
|---|---|---|---|
| M1 | `run-once`'s scratch reset guarded by "if empty" | 1 | `strictmodes-double-invoke-is-not-additive` — `expected: (= 1 (:entries (rt/stats)))`, `actual: (not (= 1 2))` |
| M2 | `composing?` reverted to reading the **synthetic** event | 1 | `a-composing-enter-commits-nothing` — the composing Enter committed `"shi"` where `nil` was required |
| M3 | `h/boundary` loses `getDerivedStateFromError` | 1 | `the-boundary-catches-reports-once-and-resets` (no fallback), `a-function-fallback-sees-the-error` (error) |
| M4 | `h/boundary` loses its once-per-failure instance flag | **0** | **nothing** — see below |
| M4c | `report!` moved into `render` | 1 | `the-boundary-reports-once-under-strictmode`, `the-boundary-catches-reports-once-and-resets` (2 reports became 9) |
| M5 | `:reset-key` reconcile never clears the caught state | 1 | `the-boundary-catches-reports-once-and-resets` — no retry, no second report, `.ok` never appears |
| M6 | `runtime/dispatch!` takes the **queued** door | 1 | 19 of the new rows, including every controlled-grid row — the whole family is measuring HD-019's synchronous door |
| M7 | `make-subscribe`'s cleanup loses `release-cell!` | 1 | `the-grid-leaves-no-residue`, `an-hmr-body-swap-…`, `strictmodes-…`, `the-boundary-catches-…` (and, on the rebased base, main's own three residue rows) |
| M8 | the input-implementation pin made inert | 1 | `the-selector-is-live-in-this-bundle`, `the-arms-input-is-reacts-own-whatever-the-selector-says` |
| M8b | the compose probe reads the native event for both fields | 1 | `reacts-synthetic-keyboard-event-drops-is-composing` |
| M9 | a third hook (`useRef`) in the shell | 1 | `the-boundary-spends-no-shell-hook` (`["useRef" "useContext" "useSyncExternalStore" …]`), and the three existing hook-ledger rows |
| — | all faults reverted | **0** | 931 tests / 5839 assertions, 0 failures, 0 errors |

### Two of these witnesses were decoration, and the mutations are what said so

The second commit on this branch, and the more useful half of the work.

**M4 went green.** The boundary's once-per-failure instance flag was the shape `re-frame.freehand.error-react` uses — and deleting it changed no row, because that boundary promotes from three lifecycles and this one reports from exactly one. React calls `componentDidCatch` once per caught failure, including under StrictMode's double-invoked render. The flag was a line nothing observed, so it is gone, and a new row (`the-boundary-reports-once-under-strictmode`) reads the guarantee where it actually comes from. M4c is the mutation that can red it.

**The residue rows were blind, and it is the same class as the residue gate this tree was recently found passing a planted defect through.** `mount/release!` calls `runtime/reset-runtime!`, which disposes every cell and empties the index **by fiat** — so a census read after it is all zeros whatever the teardown released. M7 did not red them. They now unmount, read `:cell-refs`/`:boundaries`/`:edges`, and only then finish the release; all four go red on M7. (`:cells` and `:entries` are deliberately excluded: they belong to the one-macrotask reaper, and asserting them there would assert a schedule rather than a release.)

**And a note worth carrying back to #7331**: on the pre-rebase base M7 reddened only my rows; on the rebased base it also reds `the-collector-screen-leaves-no-residue`, `the-grouped-screen-leaves-no-residue` and `the-fenced-boundary-leaves-no-residue`. The residue repair that landed there generalised further than it claimed — those three now catch a cleanup that does not release, which they did not before. The blindness is closed on both sides, independently.

`the-grid-leaves-no-residue`'s pre-teardown count was also wrong — 100 where the truth is 101, because the enclosing `grid` is a `defview` and therefore a boundary like any other. Caught by M9, of all things.

### One coordination note for `worker/heqwo-default`

That branch makes React's controlled-input path the unconditional default. It had not landed at `afb1da2a8e`, and this suite is written so that it cannot silently invalidate the rows: every behavioural row **pins explicitly** rather than inheriting, so the default is not what any of them measures. The one row that reads the default at all is `the-selector-is-live-in-this-bundle`, which asserts that an unpinned UIx `:input` in a Reagent-carrying bundle selects the port. **That row is the one to re-check when `heqwo-default` lands** — it should be updated to assert the new default rather than deleted, because its job is to keep the pin honest, and a pin nobody can tell apart from the default is not a pin.

### One unrelated flake seen

`query-cycles-are-collectible-in-the-real-browser-heap` failed in two mutation runs and in none of the four clean ones. It is a GC-timing row in another surface and nothing here touches it; noted rather than actioned.
