### PR TITLE
uix: React's controlled-input path is the default, not a classpath accident (rf2-heqwo)

### DIFF
--- a/docs/api/re-frame.adapter.uix.md
+++ b/docs/api/re-frame.adapter.uix.md
@@ -211,6 +211,26 @@ For narrative coverage and the substrate decision set, see [Use UIx or reagent-s
 
 - **Shared React Context.** The `frame-provider` in both adapters (Reagent and UIx) consumes the same `createContext` object, factored into `re-frame.adapter.context` (a CLJS-only file in core). There is exactly one Context, not two. A mixed-substrate app therefore composes: a UIx `frame-provider` can wrap a Reagent subtree, and vice versa.
 - **DOM source-coord annotations.** Adapters inject `data-rf2-source-coord` on every registered view's root element; `wrap-view` is the explicit seam for that injection. The attribute is gated on debug builds and elided from production `:advanced` builds via dead-code elimination, so it costs no shipped bytes. It powers click-to-source in Xray and re-frame2-pair. The full contract is in the [Observability concept guide](../core/observability.md).
+- **Controlled inputs use React's own implementation.** UIx can build a `<input>` two ways, and unset it chooses by asking whether Reagent happens to be on the classpath — so adding the Reagent adapter beside UIx used to change how the UIx app's inputs behaved, silently. Requiring `re-frame.adapter.uix` pins the choice to React's own path. See the note below for what that means for the caret.
+
+## Controlled inputs and the caret
+
+A UIx `:input` with a `:value` and an `:on-change` is a plain React controlled input, and it stays one whatever else is in the bundle. Requiring this namespace sets `uix.compiler.input/*use-reagent-input-enabled?*` to `false` at load, which is what makes that true.
+
+**What this means when your handler refuses or rewrites a keystroke.** React converges the field inside the discrete event — the character the model refused is off the screen before `dispatchEvent` returns, with nothing re-rendered. Writing `value` moves the text cursor to the end of the field, though, so the caret lands at the end rather than where the edit was: type `z` into `"12345"` with the caret at position 2, have the model refuse it, and you get `"12345"` with the caret at 5. Every write React makes does this; it is React's own long-standing controlled-input caret jump, not something re-frame2 introduces. A model that takes the keystroke verbatim never triggers a write and never moves the caret.
+
+**What changed, and why.** UIx also ships a port of Reagent's controlled-input workaround, which makes the element uncontrolled and restores value *and* caret itself — but one animation frame later, off Reagent's `requestAnimationFrame` queue, never inside the event. Before this pin you got that one whenever Reagent was on the classpath and React's one when it wasn't. An app whose inputs behave differently because of what else is in its bundle is the worse defect, so the adapter takes in-turn convergence and a predictable, React-native path over late caret preservation. Neither implementation gives you both halves; `rf2-fki5d` is the priced route to a path that does.
+
+**If you want the port instead**, ask for it explicitly — after requiring the adapter, and before you render:
+
+```clojure
+(:require [re-frame.adapter.uix :as uix-adapter]
+          [uix.compiler.input])
+
+(set! uix.compiler.input/*use-reagent-input-enabled?* true)
+```
+
+That is the whole opt-in, and it is deliberately explicit. `true` selects UIx's port, `false` selects React's implementation, and `nil` restores UIx's own classpath-sniffing default — which is the behaviour this pin exists to keep you out of. The port reaches for `reagent.impl.batching`, so it needs Reagent on the classpath; it is not an option for a UIx-only bundle.
 
 ## See also
 

--- a/docs/design/hicasso/studio/controlled-input-two-implementations.md
+++ b/docs/design/hicasso/studio/controlled-input-two-implementations.md
@@ -1,12 +1,15 @@
 # A controlled input has two implementations, and the bundle was picking
 
 **Bead** `rf2-n3dxw` · **epic** `rf2-2rtt6` (EP-0038)
-**Witness content hash** `966e6d8390ecc9945193417bb221b6c574c9681f`
+**Witness content hash** `d747b10d82daa24ce39a4a7a6cff825ce7716483`
 (`implementation/freehand/test/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs`;
-authored on `worker/reject-n3dxw`). A SHA does not survive a rebase and this
-branch was rebased once already — the content hash is the identifier, and
-`git log --oneline --all -- <path>` plus `git rev-parse <candidate>:<path>`
-finds a commit carrying the blob.
+authored on `worker/reject-n3dxw`, amended on `worker/heqwo-default` when
+`rf2-heqwo` pinned the selector — the measured rows are unchanged, the
+restore-to-default helper is not; the previous blob was
+`966e6d8390ecc9945193417bb221b6c574c9681f`). A SHA does not survive a rebase
+and this branch was rebased once already — the content hash is the
+identifier, and `git log --oneline --all -- <path>` plus
+`git rev-parse <candidate>:<path>` finds a commit carrying the blob.
 **Measured** 2026-08-01 AUSEST
 
 **Runtime for every row on this page**: headless Chromium via Playwright
@@ -37,14 +40,21 @@ UIx decides, per element and at element-creation time, between plain React
 and a port of Reagent's controlled-input workaround.
 `uix.compiler.aot/create-uix-input` branches on
 `uix.compiler.input/should-use-reagent-input?`, and that predicate — with
-`*use-reagent-input-enabled?*` unset, which is the shipped default — answers
+`*use-reagent-input-enabled?*` unset, which was the shipped default when this
+page was measured — answers
 
 > is `reagent.impl.util/*non-reactive*` present, and false?
 
-So the answer is a fact about **what else is on the classpath**, not a
+So the answer was a fact about **what else is on the classpath**, not a
 decision the application makes. Every `:browser-test` bundle in this repo
 carries Reagent, because the Reagent adapter is first-class and ships with
-tests. A UIx-only consumer app gets the other implementation.
+tests. A UIx-only consumer app got the other implementation.
+
+**This is the part that has since been fixed** — see [Option C](#c--pin-the-selector)
+below. `re-frame.adapter.uix` now pins the var at load, so a re-frame2 UIx app
+gets React's implementation whatever else is in the bundle. Every row below
+still measures what it says it measures: each one names its implementation and
+pins it explicitly, which is why the ruling did not move a single figure.
 
 The probe that found it read the props React had committed to the DOM node.
 Where the view had written `:value`, the node carried `defaultValue "12"` and
@@ -185,18 +195,35 @@ an authoring pattern.
 
 ### C — pin the selector
 
-Independent of A and B, and cheap: decide which implementation a re-frame2
-UIx app gets, instead of inheriting whatever the bundle implies. One `set!`
-of `uix.compiler.input/*use-reagent-input-enabled?*` at adapter load. The
-cost is not implementation, it is the ruling — the two implementations have
-materially different behaviour, and today a consumer's choice of a *second*
-adapter silently changes the first one's inputs.
+**TAKEN** (`rf2-heqwo`; Mike, 2026-08-01: *"make the React path the
+default"*). Independent of A and B, and cheap: decide which implementation a
+re-frame2 UIx app gets, instead of inheriting whatever the bundle implies.
+One `set!` of `uix.compiler.input/*use-reagent-input-enabled?*` to `false` at
+`re-frame.adapter.uix` load. The cost was never the implementation, it was
+the ruling — the two implementations have materially different behaviour, and
+a consumer's choice of a *second* adapter silently changed the first one's
+inputs.
+
+The ruling takes in-turn convergence and a React-native, predictable path
+over late caret preservation, and more importantly takes determinism over a
+silent classpath dependency: an app that behaves differently because of what
+else is in its bundle is the worse defect. The var stays public and dynamic,
+so the port remains reachable by an explicit `set!` — what is gone is getting
+either one by accident. The consumer-facing statement of the trade-off,
+including the caret, lives in `docs/api/re-frame.adapter.uix.md`.
+
+What this does **not** settle: the mid-string refusal row above is still red
+on the caret, because React is now the path every UIx consumer is on. Pinning
+the selector made the default honest; it did not give either implementation
+the half it lacks. `rf2-n3dxw` stays open, and B (priced as `rf2-fki5d`)
+remains the route to both halves.
 
 ## What this changes in the record
 
 - `architecture.md`'s "React owns ... the controlled-input end-of-event
   restore" is **confirmed**, with the qualification that it holds only while
-  the element is actually controlled, which UIx does not guarantee.
+  the element is actually controlled — which UIx did not guarantee, and which
+  `re-frame.adapter.uix` now does (`rf2-heqwo`, Option C above).
 - HD-019's "rejected/unchanged-model paths lean on React's own end-of-event
   restore" is **confirmed for the value and refuted for the caret**.
 - `rf2-n3dxw` stays open on the residue: no shipped path gives both halves.

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -11,10 +11,36 @@
   UIx's CLJS prop and trailing-child marshalling."
   (:require [uix.core          :as uix :refer-macros [defui]]
             [uix.hooks.alpha   :as uix-hooks]
+            [uix.compiler.input]
             [re-frame.frame             :as frame]
             [re-frame.substrate.spine   :as spine]
             [re-frame.adapter.use-frame :as use-frame-hook]
             [re-frame.views.frame-boundary :as boundary]))
+
+;; ---- controlled inputs: React's implementation, not the classpath's -------
+;;
+;; `uix.compiler.aot/create-uix-input` picks, per `:input` element and at
+;; element-creation time, between plain React and a port of Reagent's
+;; controlled-input workaround. Left unset, the var below makes that choice by
+;; asking whether `reagent.impl.util/*non-reactive*` happens to EXIST — so
+;; adding the Reagent adapter to a UIx app silently changed how the UIx app's
+;; controlled inputs behave, with no diagnostic and no opt-in (rf2-heqwo).
+;;
+;; re-frame2 pins it. React's own path keeps the element controlled and
+;; converges inside the discrete event, before `dispatchEvent` returns, through
+;; React's end-of-event state restore. The port makes the element UNCONTROLLED
+;; (deletes `:value`, installs `defaultValue` + a `ref`) and drives the value
+;; from `reagent.impl.batching/do-after-render` — a requestAnimationFrame
+;; queue, so one frame late, never in-turn. Both were measured in real Chromium
+;; against react-dom 19.2.0 (rf2-n3dxw); the trade-off and the caret behaviour
+;; consumers will see are documented in `docs/api/re-frame.adapter.uix.md`.
+;;
+;; This runs at namespace load — ahead of any render, and therefore ahead of
+;; any element creation. The var stays `^:dynamic` and public: a consumer who
+;; genuinely wants the port asks for it EXPLICITLY, by `set!`ing it back to
+;; `true` after requiring this namespace (or `binding` it around a render).
+;; What is no longer possible is getting either one by accident.
+(set! uix.compiler.input/*use-reagent-input-enabled?* false)
 
 ;; ---- shared spine wiring --------------------------------------------------
 

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_controlled_input_default_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_controlled_input_default_cljs_test.cljs
@@ -1,0 +1,77 @@
+(ns re-frame.adapter.uix-controlled-input-default-cljs-test
+  "The UIx adapter's controlled-input implementation is React's own, and it
+  is NOT selected by what else is on the classpath (rf2-heqwo).
+
+  `uix.compiler.aot/create-uix-input` picks, per `:input` element and at
+  element-creation time, between plain React and a port of Reagent's
+  controlled-input workaround. Left unset,
+  `uix.compiler.input/*use-reagent-input-enabled?*` makes that choice by
+  asking whether `reagent.impl.util/*non-reactive*` happens to EXIST — so
+  adding the Reagent adapter beside UIx silently changed how the UIx app's
+  `<input>` elements behave. `re-frame.adapter.uix` now `set!`s the var at
+  load, so the answer is the adapter's, not the bundle's.
+
+  The two implementations are materially different products, measured in
+  real Chromium against react-dom 19.2.0 in
+  `docs/design/hicasso/studio/controlled-input-two-implementations.md`
+  (rf2-n3dxw): React keeps the element controlled and converges inside the
+  discrete event; the port makes it uncontrolled and converges one
+  `requestAnimationFrame` later. Those DOM-level differences are witnessed
+  there, in the browser lane. What THIS namespace pins is narrower and is
+  the adapter's own contract: which of the two a consumer gets, and that
+  the other one remains reachable on purpose.
+
+  No DOM needed — the selector is a var read. ns ends in -cljs-test so
+  shadow-cljs's :node-test build picks it up."
+  (:require [cljs.test :refer-macros [deftest testing is]]
+            [uix.compiler.input]
+            [re-frame.adapter.uix :as uix-adapter]))
+
+(defn- selector []
+  (uix.compiler.input/should-use-reagent-input?))
+
+(defn- with-cleared-pin
+  "Run `f` with the adapter's load-time pin cleared, so UIx's own classpath
+  sniff can be observed, and restore the pin however `f` ends."
+  [f]
+  (set! uix.compiler.input/*use-reagent-input-enabled?* nil)
+  (try (f) (finally (set! uix.compiler.input/*use-reagent-input-enabled?* false))))
+
+(deftest reacts-controlled-input-is-the-adapters-default
+  (testing "requiring the adapter is enough: a UIx `:input` is a plain React
+           controlled input"
+    (is (some? uix-adapter/adapter)
+        "the adapter namespace is loaded — which is what runs the pin")
+    (is (false? (selector))
+        "`should-use-reagent-input?` answers false, so
+         `create-uix-input` builds a plain React element")))
+
+(deftest the-pin-is-load-bearing-in-a-bundle-that-carries-reagent
+  (testing "clear the pin and this bundle's contents choose instead — which
+           is the accident rf2-heqwo removes, and the reason this assertion
+           is not vacuous"
+    (with-cleared-pin
+      (fn []
+        (if (true? (selector))
+          (is (true? (selector))
+              "Reagent is in this bundle, so UIx's unset default would have
+               selected the port — the adapter's pin is what stops it")
+          ;; A bundle without Reagent answers false either way. Say so
+          ;; rather than asserting a coincidence: the pin still holds, it
+          ;; simply cannot be distinguished from the sniff here.
+          (is (false? (selector))
+              "no Reagent in this bundle, so UIx's unset default already
+               answers false; the pin is still what makes it a decision"))))
+    (is (false? (selector))
+        "and the pin is back after the probe")))
+
+(deftest the-port-remains-reachable-explicitly
+  (testing "the ruling makes React the DEFAULT, not the only option: the var
+           stays public and dynamic, so a consumer who genuinely wants
+           Reagent's port asks for it by name"
+    (set! uix.compiler.input/*use-reagent-input-enabled?* true)
+    (is (true? (selector))
+        "an explicit opt-in reaches the port")
+    (set! uix.compiler.input/*use-reagent-input-enabled?* false)
+    (is (false? (selector))
+        "and an explicit opt-out returns to React's own implementation")))

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_controlled_input_default_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_controlled_input_default_cljs_test.cljs
@@ -27,6 +27,15 @@
             [uix.compiler.input]
             [re-frame.adapter.uix :as uix-adapter]))
 
+(def ^:private value-at-load
+  "The var as `re-frame.adapter.uix`'s load left it, snapshotted at THIS
+  namespace's load — which CLJS runs after the adapter's, and before any
+  test runs. Asserting the snapshot rather than only the live read is what
+  makes the pin order-independent: sibling suites pin the var per row, and
+  a live read alone would be masked by whichever of them the runner happens
+  to schedule first."
+  uix.compiler.input/*use-reagent-input-enabled?*)
+
 (defn- selector []
   (uix.compiler.input/should-use-reagent-input?))
 
@@ -42,6 +51,10 @@
            controlled input"
     (is (some? uix-adapter/adapter)
         "the adapter namespace is loaded — which is what runs the pin")
+    (is (false? value-at-load)
+        "the adapter's load left the var at false — asserted from the
+         load-time snapshot, so no sibling suite's per-row pinning can
+         stand in for the pin and mask its absence")
     (is (false? (selector))
         "`should-use-reagent-input?` answers false, so
          `create-uix-input` builds a plain React element")))

--- a/implementation/freehand/test/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs
@@ -272,18 +272,35 @@
 (def input-implementations
   "The two things `uix.compiler.aot/create-uix-input` can build, and the
   value of `uix.compiler.input/*use-reagent-input-enabled?*` that selects
-  each. `nil` — the shipped default — is not a third option; it is
+  each. `nil` — UIx's OWN unset default — is not a third option; it is
   *whichever of these two the bundle's contents imply*, which is what
-  this file exists to stop measuring by accident."
+  this file exists to stop measuring by accident. Since rf2-heqwo,
+  `re-frame.adapter.uix` pins the var to `false` at load, so `nil` is no
+  longer what a re-frame2 UIx app runs; it is reachable here only by
+  deliberately clearing the pin."
   {:react             false
    :uix-reagent-input true})
+
+(def adapter-default-implementation
+  "What `re-frame.adapter.uix` pins at load (rf2-heqwo). Rows restore THIS,
+  not `nil`: leaving the var cleared would hand the choice back to the
+  bundle for every later namespace in the same test build — the exact
+  accident this file exists to stop."
+  :react)
 
 (defn- pin-input-implementation! [impl]
   (set! uix.compiler.input/*use-reagent-input-enabled?*
         (get input-implementations impl)))
 
 (defn- unpin-input-implementation! []
-  (set! uix.compiler.input/*use-reagent-input-enabled?* nil))
+  (pin-input-implementation! adapter-default-implementation))
+
+(defn- with-uix-raw-default
+  "Run `f` with the adapter's pin CLEARED, so UIx's own classpath sniff can
+  be observed, and restore the pin however `f` ends."
+  [f]
+  (set! uix.compiler.input/*use-reagent-input-enabled?* nil)
+  (try (f) (finally (unpin-input-implementation!))))
 
 ;; ---------------------------------------------------------------------------
 ;; The harness
@@ -395,21 +412,28 @@
 ;; The selector itself — the reason every row below names an implementation
 ;; ---------------------------------------------------------------------------
 
-(deftest the-input-implementation-is-chosen-by-the-bundle-not-the-app
-  (testing "UIx's default answer is a fact about the classpath, and this
-           bundle carries Reagent, so the shipped default here is the port
-           rather than plain React"
+(deftest the-input-implementation-is-the-adapters-choice-not-the-bundles
+  (testing "UIx's own unset answer is a fact about the classpath, and this
+           bundle carries Reagent — so unset, a UIx `:input` here would be
+           the port. `re-frame.adapter.uix` pins it to React (rf2-heqwo), so
+           it is not."
     (is (some? reagent.impl.batching/do-after-render)
         "Reagent's after-render queue is in this bundle — which is exactly
-         what makes UIx's default answer `true`")
-    (unpin-input-implementation!)
-    (is (true? (uix.compiler.input/should-use-reagent-input?))
-        "with nothing pinned, a UIx `:input` in THIS bundle is not a plain
-         React controlled input at all")
+         what makes UIx's own unset answer `true`")
+    (with-uix-raw-default
+      (fn []
+        (is (true? (uix.compiler.input/should-use-reagent-input?))
+            "clear the adapter's pin and this bundle's contents choose:
+             a UIx `:input` here would not be a plain React controlled
+             input at all")))
+    (is (false? (uix.compiler.input/should-use-reagent-input?))
+        "the adapter's load-time pin holds — React's own implementation,
+         whatever else the bundle carries")
     (pin-input-implementation! :react)
     (is (false? (uix.compiler.input/should-use-reagent-input?)))
     (pin-input-implementation! :uix-reagent-input)
-    (is (true? (uix.compiler.input/should-use-reagent-input?)))
+    (is (true? (uix.compiler.input/should-use-reagent-input?))
+        "the explicit opt-in still reaches the port")
     (unpin-input-implementation!)))
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## The defect

`uix.compiler.aot/create-uix-input` picks, per `:input` element and at element-creation time, between plain React and a port of Reagent's controlled-input workaround. It branches on `uix.compiler.input/should-use-reagent-input?`, and that predicate — with `*use-reagent-input-enabled?*` unset, which was the shipped default — answers:

> is `reagent.impl.util/*non-reactive*` **present**, and false?

So which implementation a consumer got was a fact about their **classpath**, not a decision their application made. Every `:browser-test` bundle in this repo carries Reagent, and so does any app using both adapters — adding the Reagent adapter alongside UIx **silently** changed how the UIx app's controlled inputs behave, with no diagnostic and no opt-in.

The two implementations are materially different products, measured in real Chromium against `react-dom` 19.2.0 under `rf2-n3dxw` (`docs/design/hicasso/studio/controlled-input-two-implementations.md`):

- **React's own path** keeps the element controlled and converges the field **inside the discrete event**, before `dispatchEvent` returns, through React's end-of-event state restore — with nothing re-rendered.
- **UIx's port** makes the element **uncontrolled** (deletes `:value`, installs `defaultValue` + a `ref`) and drives the value itself off `reagent.impl.batching/do-after-render`, a `requestAnimationFrame` queue — **one frame late, never in-turn.**

## The ruling

**Mike, 2026-08-01, verbatim: "rule rf2-heqwo — make the React path the default."**

The UIx adapter's controlled-input implementation is React's own, and it must **not** be selected by whether Reagent happens to be on the classpath. The ruling takes in-turn convergence and a React-native, predictable path over late caret preservation — and, more importantly, takes **determinism over a silent classpath dependency**. An app that behaves differently because of what else is in its bundle is the worse defect.

## The change

It really was one `set!`. `re-frame.adapter.uix` now requires `uix.compiler.input` and pins the var at namespace load:

```clojure
(set! uix.compiler.input/*use-reagent-input-enabled?* false)
```

Namespace load runs ahead of any render and therefore ahead of any element creation, which is where `create-uix-input` reads the var. Total production diff: **one require, one `set!`, and the comment block explaining both.**

**The override still works, and is now the only way to get the port.** The var stays `^:dynamic` and public, so a consumer who genuinely wants Reagent's port asks for it explicitly:

```clojure
(:require [re-frame.adapter.uix :as uix-adapter]
          [uix.compiler.input])

(set! uix.compiler.input/*use-reagent-input-enabled?* true)
```

`binding` works too. What is no longer possible is getting either one by accident.

## The behaviour change consumers will see

Stated plainly rather than left to be discovered. On a **refused** keystroke the two paths differ:

| | value converges | caret |
|---|---|---|
| React (now the default) | in-turn, before `dispatchEvent` returns | **thrown to the end** — `"12345"` + a refused `z` with the caret at `[2 2]` lands at `[5 5]` |
| UIx's port (explicit opt-in) | one animation frame later | preserved at `[2 2]` |

Writing `value` moves the text cursor to the end of the control (HTML standard), and React restores a selection only around a commit in which focus moved — so every write React makes throws the caret to the end. A model that takes the keystroke verbatim never triggers a write and never moves the caret.

**Documented in `docs/api/re-frame.adapter.uix.md`** — the *published* adapter API page (in the mkdocs nav, so `mkdocs build --strict` covers it), under a new `## Controlled inputs and the caret` section plus a `## Notes` bullet pointing at it. It says what changed, why the silent classpath dependency was the worse defect, how to opt back in, and that `rf2-fki5d` is the priced route to getting both halves. `docs/design/hicasso/studio/controlled-input-two-implementations.md` records Option C as **TAKEN**.

## What this does NOT do

**It does not settle `rf2-n3dxw`, which stays open.** Neither shipped path gives both same-turn convergence *and* the caret where the edit left it. `rf2-fki5d` is the priced prototype that gets both halves. This ruling makes the default honest; `fki5d` would make it complete. The controlled-restore problem is **not** claimed solved.

## Quality gates

All foreground, worktree-local logs, exit codes echoed, nothing piped through `tail`/`grep` for its verdict.

### Mutation proof of the default

A default nobody has watched being wrong is not pinned. The classpath-sniffing branch was forced back on (`set!` … `nil`, i.e. the exact pre-fix defect) and the witness re-run:

| | command | exit | result |
|---|---|---|---|
| **GREEN** (pinned) | focused `node-test` over `uix-controlled-input-default-cljs-test` + `controlled-restore-dom-cljs-test` | **0** | Ran 19 tests, 27 assertions. 0 failures, 0 errors. |
| **RED** (mutated) | same | **1** | Ran 19 tests, 27 assertions. **2 failures**, 0 errors. |

Both failures land on `reacts-controlled-input-is-the-adapters-default`:

```
expected: (false? value-at-load)     actual: (not (false? nil))
expected: (false? (selector))        actual: (not (false? true))
```

Reverted; `git diff` empty and `git status --short` empty at HEAD.

**The proof is order-independent, deliberately.** A live read of the var inside a `deftest` can be masked by whichever sibling suite the runner schedules first — the controlled-restore witnesses pin the implementation per row, and one of them restoring the default would satisfy a live-read-only assertion with the adapter's pin removed. The new suite therefore snapshots the var at its **own namespace load** (`value-at-load`), which CLJS runs after the adapter's load and before any test. That assertion is the first of the two failures above, and it cannot be masked.

### PR #7330's controlled-restore witnesses

Re-run in the browser, since this is a real-DOM behaviour change:

```
npx shadow-cljs compile browser-test --config-merge '{:ns-regexp "controlled-restore-dom-cljs-test$"}'
node scripts/serve-and-run-browser-tests.cjs
→ exit 0 — Ran 16 tests containing 53 assertions. 0 failures, 0 errors.
```

**All 16 pass. No measured row's expectation changed** — every row names its implementation and pins it explicitly, which is exactly why the ruling moved no figure on the studio page. Two non-row changes, both explained:

1. **`unpin-input-implementation!` now restores the adapter's pin (`:react`), not `nil`.** `release!` calls it after every `with-grid`, so on `main` every row left the var cleared — which, in a shared test build, hands the choice back to the bundle for every namespace that runs later. That is the accident this file exists to stop, and it became load-bearing the moment the adapter had a default worth protecting.
2. **`the-input-implementation-is-chosen-by-the-bundle-not-the-app` → `the-input-implementation-is-the-adapters-choice-not-the-bundles`.** Its premise ("the shipped default here is the port") is now false for a re-frame2 UIx app. It still asserts UIx's raw classpath answer — inside a new `with-uix-raw-default` that clears the pin and restores it in a `finally` — and now additionally asserts that the adapter's pin holds, and that the explicit opt-in still reaches the port. No stale references to the old name remain in the corpus.

### Gate matrix

Derived from `TESTING.md` against the changed surfaces: `implementation/adapters/uix/src/**` fires `adapter_diagnostic`, `cljs_node_test`, `cljs_browser`, `cljs_prod`, `bundle_isolation`, `adapter_testbed_smokes`; `implementation/adapters/uix/test/**` and the freehand witness fire `cljs_node_test` / `cljs_browser`; `docs/**` fires the docs link validation.

| gate | command | exit | result |
|---|---|---|---|
| CLJS node | `npm run test:cljs` | **0** | Ran 12226 tests, 61079 assertions. 0 failures, 0 errors. |
| Browser (full lane) | `npm run test:browser` | **0** | Ran 908 tests, 5742 assertions. 0 failures, 0 errors. |
| Browser (7330 witnesses, focused) | see above | **0** | 16 tests, 53 assertions. 0/0. |
| Adapter + substrate smokes | `npm run test:adapter-smokes` | **0** | Ran 3 adapter-smoke specs. 0 failures. All three spine consumers: `adapters/reagent-testbed`, `adapters/uix-testbed`, `ui/testbed`. |
| Bundle isolation | `npm run test:bundle-isolation` | **0** | PASS bundle-isolation (23 artefacts, 39 sentinels); **PASS uix-reagent-free** (2 bundles, 4 sentinel checks); PASS login-bundle-isolation. |
| Production elision | `npm run test:browser-prod-elision` | **0** | ui mounted production elision: PASS. Ran 120 tests, 527 assertions. 0/0. |
| Fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` |
| CLJS node (post-rebase re-run) | `npm run test:cljs` | **0** | Ran 12226 tests, 61080 assertions. 0 failures, 0 errors. |
| UIx JVM probe (`adapter_diagnostic`) | `clojure -M:test` in `implementation/adapters/uix` | **0** | Ran 0 tests — the declared `--probe` exemption; UIx is CLJS-only, so zero is the correct outcome. |
| clj-kondo (CI-pinned) | `clj-kondo v2026.04.15`, exact `lint.yml` invocation | **0** | linting took 58379ms, **errors: 0**, warnings 4526 (pre-existing). **Zero findings on any changed file.** |
| Docs slugs / anchors | `python scripts/check_doc_slugs.py` | **0** | clean |
| Docs site | `python -m mkdocs build --strict` | **0** | built in 18.65s |

Local clj-kondo is v2025.10.23; CI pins **2026.04.15**, so the pinned release was fetched and run with the exact `--lint` path list from `.github/workflows/lint.yml`.

**Docs coverage note.** The consumer-facing note went into `docs/api/re-frame.adapter.uix.md`, which **is** in the mkdocs nav — so `mkdocs build --strict` covers it, and it passed. `docs/design/hicasso/studio/controlled-input-two-implementations.md` is outside mkdocs' reach by design; `scripts/check_doc_slugs.py` validated its link targets and heading anchors (it caught one bad anchor — the em-dash heading slugifies to `#c--pin-the-selector`, double hyphen — which is fixed). Its tables were **not** touched (`git diff` shows zero changed table rows) and I verified the column counts by hand.

## Scope, and the sibling in flight

**Correctly confined to the UIx adapter.** `rf2-2rtt6.41` (PR #7338) proved that Hicasso's own boundaries are immune by construction: `front.codec` emits `[:input …]` through `react/createElement` against the tag string, so `uix.compiler.aot/create-uix-input` is never on that path and the classpath selector cannot reach it. Nothing to fix there, and this PR does not widen toward it. The mutation above accordingly plants its fault where the selector actually runs — `uix.compiler.input/*use-reagent-input-enabled?*`, read by `create-uix-input`.

PR #7338 is **not yet on `main`** (`arm1/controlled_grid_dom_cljs_test.cljs` is absent from `origin/main` as of `d67a939ef6`), so this lands first and that branch rebases onto it. It named exactly one row needing an update when this lands — **`the-selector-is-live-in-this-bundle`** — and asked for **updating, not deleting**: its intent (the selector is live in this bundle) stays true, it just now has to clear the adapter's pin to observe it, exactly as `with-uix-raw-default` does here. All its other rows pin implementations explicitly and are undisturbed.

This branch was rebased onto `origin/main` (`d67a939ef6`) before opening; main touched none of the five files, and the rebased diff is byte-identical (`git hash-object` of the diff matches pre- and post-rebase). `test:cljs` was re-run after the rebase.

## Bead

`rf2-heqwo`. `rf2-n3dxw` stays **open**.
