### PR TITLE
core: an :initial-events flush no longer clobbers the just-installed generation (rf2-rt4jz)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -352,6 +352,52 @@
                (compare-and-set! available? true false))
       owner)))
 
+(defn- unspent-frame-construction-handoff?
+  "True when THIS caller already stands inside an exact reservation for `id`
+  handed to it by an outer preflight, with the permission still UNSPENT.
+  Deliberately NON-consuming — `consume-frame-construction-handoff!` at engine
+  entry is the one place that spends it, and this predicate must not race that
+  one-shot."
+  [id]
+  (let [{:keys [owner available?] handoff-id :id} *frame-construction-handoff*]
+    (boolean (and (= id handoff-id)
+                  (some? available?)
+                  (true? @available?)
+                  (owner-holds-frame-id? owner id)))))
+
+(defn ^:no-doc call-with-frame-construction-claim!
+  "Invoke zero-arg `f` holding ONE exact per-id construction reservation for
+  `id`, with the engine hand-off armed so the `upsert-frame!` inside `f` enters
+  that SAME reservation instead of colliding with it.
+
+  This is how a caller puts work of its OWN inside the frame transaction rather
+  than beside it. `make-frame`'s generation-provenance publication and its
+  rollback are that work (rf2-rt4jz): they write a second process-global store
+  that a reprojection reads, so they have to be admitted, ordered and rolled
+  back under the same authority as the frame revision they describe.
+
+  Contention is the engine's own typed `:rf.error/frame-construction-in-progress`,
+  raised HERE — before `f` runs — so a LOSING attempt performs none of `f`'s
+  writes at all. That is the property the alternative shape cannot have: a
+  caller that writes first and enters the engine second has already mutated
+  process-global state by the time the engine rejects it.
+
+  An outer preflight that already reserved `id` and handed it off (re-frame.ui's
+  multi-plan `execute-frame-plans!`) is ADOPTED as-is: nothing is claimed and
+  nothing is released, so its window and its release point are unchanged, and
+  `f`'s writes fall inside the reservation it is already holding. A hand-off
+  that has already been SPENT is not adoption — the nested public entry claims
+  and loses normally, exactly as it did when the engine claimed for itself.
+  INTERNAL."
+  [id kind f]
+  (if (unspent-frame-construction-handoff? id)
+    (f)
+    (let [owner (claim-frame-construction! #{id} kind)]
+      (try
+        (call-with-frame-construction-handoff! owner id f)
+        (finally
+          (release-frame-construction! owner))))))
+
 (defn- call-with-frame-transaction!
   [id kind handoff? join-current-owner? f]
   (if-let [owner (or (when handoff?

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -602,13 +602,19 @@
 ;; memory, bounded by the number of distinct frame ids ever created in a
 ;; session.
 ;;
-;; ---- WHEN the row is written, and why that is load-bearing (rf2-rt4jz) ----
+;; ---- WHEN the row is written, and under WHOSE authority (rf2-rt4jz) -------
 ;;
-;; The row is written BEFORE the `upsert-frame!` engine commit and rolled back
-;; EXACTLY on failure. It used to be written after the commit returned, which
-;; reads as the safer order — a failed construction cannot leave residue if it
-;; never writes — but it is not, because the record and the row are two stores
-;; and the frame is REPROJECTABLE the moment the first of them lands.
+;; The row is written BEFORE the `upsert-frame!` engine commit, rolled back
+;; EXACTLY on failure, and the whole pair runs INSIDE the engine's own exact
+;; per-id construction reservation (`frame/call-with-frame-construction-claim!`).
+;; Order and admission are separate properties and the row needs both: the
+;; order decides what the CONSTRUCTING thread's own cascade reads, the
+;; reservation decides who is allowed to write the row at all.
+;;
+;; ORDER. The row used to be written after the commit returned, which reads as
+;; the safer order — a failed construction cannot leave residue if it never
+;; writes — but it is not, because the record and the row are two stores and
+;; the frame is REPROJECTABLE the moment the first of them lands.
 ;;
 ;; `upsert-frame!` publishes the record carrying the new generation and then,
 ;; still inside the call, runs the `:initial-events` setup steps (EP-0027).
@@ -632,15 +638,41 @@
 ;; what it means at the site, instead of depending on nothing ever resolving
 ;; between the two writes.
 ;;
-;; The one thing the early write does NOT buy: on a RE-construction the row
-;; names the incoming pool for the brief interval before `upsert-frame!`'s
-;; surgical swap installs the incoming generation, so a JVM-concurrent flush
-;; landing in THAT interval re-resolves the OUTGOING composition against the
-;; INCOMING pool. That is transient and self-correcting — the swap that
-;; follows overwrites it unconditionally, so no completed call can observe it —
-;; whereas the window it replaces corrupted the value the constructor returned.
-;; The remaining exposure is at worst one spurious
-;; `:rf.warning/reprojection-failed` diagnostic on the dev channel.
+;; ADMISSION. Order alone is a single-threaded property, and it left the row
+;; open to attempts the ENGINE REJECTS. `upsert-frame!` admits exactly ONE
+;; construction per id and fails every other promptly with
+;; `:rf.error/frame-construction-in-progress` — a loss that writes nothing,
+;; which is the whole point of failing at admission rather than inside an
+;; adapter or setup callback. A row written AHEAD of that admission broke the
+;; property: a same-id contender published its own pool into this shared table
+;; on its way to being rejected. While the WINNER sat inside its commit and its
+;; `:initial-events` cascade, a reprojection landing in the loser's interval
+;; read the loser's pool, re-resolved the winner's frame against it and swapped
+;; that on — the original defect, reached by a second route. The rollback was
+;; no safer in the other direction: an undo computed from a row read outside
+;; any reservation can restore over a row a NEWER owner has since written.
+;;
+;; So the write, the commit and the rollback all happen inside ONE exact
+;; reservation for the id. A losing attempt throws at the claim, before the
+;; first `swap!`; a winning attempt cannot be interleaved with any other
+;; attempt on the same id, so the row it restores is still the row it
+;; displaced. `frame/call-with-frame-construction-claim!` ADOPTS an outer
+;; preflight's existing reservation (re-frame.ui's multi-plan
+;; `execute-frame-plans!` claims its whole plan set up front and hands each id
+;; off), so that path keeps one reservation for its whole run rather than
+;; nesting a second.
+;;
+;; What the reservation does NOT do is fence READERS: a reprojection takes no
+;; claim, and must not — it is a resolution, not a construction. So one
+;; interval survives, on a RE-construction only: the row names the incoming
+;; pool from the moment it is written until `upsert-frame!`'s surgical swap
+;; installs the incoming generation, and a JVM-concurrent flush landing in THAT
+;; interval re-resolves the OUTGOING composition against the INCOMING pool.
+;; Transient and self-correcting — the swap that follows overwrites it
+;; unconditionally, so no completed call can observe it — where the window it
+;; replaced corrupted the value the constructor returned. The remaining
+;; exposure is at worst one spurious `:rf.warning/reprojection-failed`
+;; diagnostic on the dev channel.
 
 (defonce ^{:private true
            :doc "frame id -> the descriptor pool its CURRENT generation was
@@ -652,7 +684,11 @@
   INSIDE that commit (rf2-rt4jz) — and rolled back exactly on failure by
   `restore-frame-generation-pool!`, which is how rf2-ktmto9's contract (a
   failed creation records nothing; a failed re-construction preserves the old
-  row) is kept. Reprojection then re-resolves against the SAME provenance
+  row) is kept. Both the write and its rollback run inside the engine's exact
+  per-id construction reservation, so the only attempt that ever touches an
+  id's row is the one the engine ADMITTED: a rejected same-id contender
+  publishes nothing, and a rollback cannot land on a successor's row.
+  Reprojection then re-resolves against the SAME provenance
   (rf2-rf3zgt) instead of silently defaulting to the live store for a frame
   that was never resolved against it. See the §Generation PROVENANCE section
   above for the full rationale."}
@@ -678,7 +714,12 @@
 
   This is rf2-ktmto9's no-residue contract, stated (rf2-rt4jz): a failed
   creation records nothing, and a failed re-construction preserves the old row.
-  Returns nil."
+
+  Callers MUST still hold the id's construction reservation here. The undo is
+  computed from a row read at `record-frame-generation-pool!` time, so it is
+  only exact while no other attempt can have written in between — which is
+  precisely what the reservation guarantees, and why `make-frame` performs both
+  halves inside `frame/call-with-frame-construction-claim!`. Returns nil."
   [runnable-id had-row? prior]
   (if had-row?
     (swap! frame-generation-pool assoc runnable-id prior)
@@ -897,37 +938,64 @@
      ;; VALUE (below) is what gives an owner exact teardown authority — with NO
      ;; post-return `frame-incarnation-token` re-sample that a concurrent
      ;; destroy + same-id reseat could race into a successor's token.
-     (let [token-box (volatile! nil)
-           ;; Record which pool this generation was resolved against — see
-           ;; §Generation PROVENANCE above (rf2-rf3zgt): a later reprojection
-           ;; reads this back so it re-resolves against the SAME pool (explicit
-           ;; or live) rather than always falling through to the live store.
-           ;; Written on every call (creation + hot-reload re-construction), so a
-           ;; re-`make-frame` that changes arity keeps the row current.
-           ;;
-           ;; rf2-rt4jz — BEFORE the engine commit, not after it. The record and
-           ;; this row are two stores, and the frame becomes REPROJECTABLE the
-           ;; moment the FIRST of them lands: `upsert-frame!` publishes the record
-           ;; carrying the new generation and then, still inside the call, runs
-           ;; the `:initial-events` setup steps, whose dispatches flush any
-           ;; pending reprojection through `call-with-frame-resolution`. Recording
-           ;; afterwards left that flush reading a PREVIOUS incarnation's row: it
-           ;; re-resolved the frame against the wrong pool and `set-generation!`d
-           ;; the result over what had just been installed, so the constructor
-           ;; returned having silently lost its own swap. One synchronous call,
-           ;; both hosts, no race.
-           ;;
-           ;; rf2-ktmto9's no-residue contract survives the move by being STATED
-           ;; instead of implied: the prior row is captured here and restored
-           ;; exactly if the commit throws, so a FAILED creation still records
-           ;; nothing and a FAILED re-construction still preserves the OLD row.
-           [had-pool-row? prior-pool]
-           (record-frame-generation-pool! runnable-id descriptors)]
-       (try
-         (frame/upsert-frame! runnable-id record-config token-box)
-         (catch #?(:clj Throwable :cljs :default) e
-           (restore-frame-generation-pool! runnable-id had-pool-row? prior-pool)
-           (throw e)))
+     (let [token-box (volatile! nil)]
+       ;; ONE per-id construction transaction covers BOTH stores this constructor
+       ;; writes — see §Generation PROVENANCE above.
+       ;;
+       ;; The provenance row records which pool this generation was resolved
+       ;; against (rf2-rf3zgt): a later reprojection reads it back so it
+       ;; re-resolves against the SAME pool (explicit or live) rather than
+       ;; falling through to the live store. It is written on every call
+       ;; (creation + hot-reload re-construction), so a re-`make-frame` that
+       ;; changes arity keeps the row current.
+       ;;
+       ;; rf2-rt4jz — the row is written BEFORE the engine commit, and the whole
+       ;; pair is INSIDE the engine's own exact per-id reservation. Both halves
+       ;; are load-bearing and each fixes what the other cannot:
+       ;;
+       ;;   ORDER. The record and the row are two stores, and the frame becomes
+       ;;   REPROJECTABLE the moment the FIRST of them lands: `upsert-frame!`
+       ;;   publishes the record carrying the new generation and then, still
+       ;;   inside the call, runs the `:initial-events` setup steps, whose
+       ;;   dispatches flush any pending reprojection through
+       ;;   `call-with-frame-resolution`. Recording afterwards left that flush
+       ;;   reading a PREVIOUS incarnation's row: it re-resolved the frame
+       ;;   against the wrong pool and `set-generation!`d the result over what
+       ;;   had just been installed, so the constructor returned having silently
+       ;;   lost its own swap. One synchronous call, both hosts, no race.
+       ;;
+       ;;   ADMISSION. Ordering alone left the row written by attempts the
+       ;;   ENGINE REJECTS. `frame/upsert-frame!` admits exactly one
+       ;;   construction per id and fails every other promptly with
+       ;;   `:rf.error/frame-construction-in-progress` — a loss that writes
+       ;;   NOTHING. Writing the row ahead of that admission broke the
+       ;;   zero-write property: a same-id contender published its own pool into
+       ;;   the shared table on its way to being rejected, and a reprojection
+       ;;   landing in that interval — while the WINNER was inside its commit /
+       ;;   `:initial-events` cascade — resolved the winner's frame against the
+       ;;   LOSER's pool and swapped it on. Its rollback was no safer: an undo
+       ;;   computed from a row it read outside any reservation can restore over
+       ;;   a newer owner's row. Claiming FIRST makes both impossible rather
+       ;;   than unlikely — a loser throws before `f` runs, and the winner's
+       ;;   write, commit and rollback are all serialised against every other
+       ;;   attempt on the id.
+       ;;
+       ;; rf2-ktmto9's no-residue contract survives the reordering by being
+       ;; STATED instead of implied: the prior row is captured here and restored
+       ;; exactly if the commit throws, so a FAILED creation still records
+       ;; nothing and a FAILED re-construction still preserves the OLD row — and
+       ;; because the restore runs while this attempt still OWNS the id, the row
+       ;; it restores is still the row it displaced.
+       (frame/call-with-frame-construction-claim!
+         runnable-id :construction
+         (fn []
+           (let [[had-pool-row? prior-pool]
+                 (record-frame-generation-pool! runnable-id descriptors)]
+             (try
+               (frame/upsert-frame! runnable-id record-config token-box)
+               (catch #?(:clj Throwable :cljs :default) e
+                 (restore-frame-generation-pool! runnable-id had-pool-row? prior-pool)
+                 (throw e))))))
        ;; rf2-djkr0 — THE INVARIANT: a PARTIALLY-CONSTRUCTED frame is never
        ;; observable as live, so a registration that lands while a frame is
        ;; mid-construction is never lost.

--- a/implementation/core/test/re_frame/make_frame_generation_pool_contention_jvm_test.clj
+++ b/implementation/core/test/re_frame/make_frame_generation_pool_contention_jvm_test.clj
@@ -1,0 +1,359 @@
+(ns re-frame.make-frame-generation-pool-contention-jvm-test
+  "rf2-rt4jz, contended — only the attempt the engine ADMITS may touch a frame
+  id's generation-provenance row.
+
+  THE ADMISSION CONTRACT. `frame/upsert-frame!` reserves an id for exactly one
+  in-flight construction and fails every same-id contender promptly with
+  `:rf.error/frame-construction-in-progress`. That loss is defined to be a
+  ZERO-WRITE loss: it is raised at admission precisely so a contender never
+  reaches an adapter callback, a setup cascade or a teardown — and so it never
+  leaves a trace of having tried.
+
+  WHAT BROKE IT. `make-frame` writes a SECOND process-global store beside the
+  frame record — `frame-generation-pool`, the row naming which descriptor pool
+  a frame's current generation was resolved against (rf2-rf3zgt) — and rf2-rt4jz
+  moved that write BEFORE the engine commit, which is right for a reason that
+  has nothing to do with contention (the `:initial-events` cascade runs INSIDE
+  the commit and reprojects against the row; see
+  `make-frame-generation-pool-window-jvm-test`). Before the commit is also
+  before ADMISSION, and that is what this namespace is about:
+
+    - a rejected same-id contender published its own pool into the shared table
+      on its way to being told it had lost. Reprojection is a READ of that
+      table, takes no reservation, and runs on any thread — so a reader landing
+      in the loser's interval re-resolved the WINNER's live frame against the
+      LOSER's pool and swapped the result on. The frame ran descriptors nobody
+      asked for, sourced from a construction that never happened.
+
+    - the rollback had the same shape in reverse. `restore-frame-generation-pool!`
+      undoes the write by restoring the value read at write time; computed
+      outside any reservation, that undo can land on a row a NEWER owner has
+      since written.
+
+  THE REPAIR is not a defensive read and not a re-write after the fact. It is to
+  put the publication, the commit and the rollback inside the SAME exact per-id
+  reservation the frame revision is made under
+  (`frame/call-with-frame-construction-claim!`), so a losing attempt throws
+  before its first `swap!` and a winning attempt cannot interleave with any
+  other attempt on the id. The engine's zero-write admission loss then covers
+  both stores instead of one.
+
+  THE HARNESS is deterministic — no sleeps decide anything, and both windows are
+  opened by seams that already exist:
+
+    - the WINNER parks inside its construction transaction on
+      `frame/*upsert-decide-probe*` (the `nil`-in-production JVM linearization
+      seam `frame-upsert-linearization-jvm-test` and
+      `make-frame-generation-seal-race-jvm-test` use). Parked there it holds the
+      id's reservation, so the contender that follows is a genuine engine loss.
+
+    - the READER lands on the exact instant of a transient publication via an
+      atom WATCH on the provenance table. A watch fires synchronously, on the
+      writing thread, inside the `swap!` that made the transition — so it is the
+      one place a test can stand that no timing tolerance can reach. What it
+      then runs is the REAL reader: `live-frame/reproject-live-frame!`, the
+      per-frame reprojection both sweeps call.
+
+  JVM-scoped because contention is: CLJS is single-threaded, so no second
+  attempt can be in flight at all, and the repair is common `.cljc` code that
+  simply never loses there. Its SINGLE-THREADED half — the ordering wart the
+  cascade reaches on both hosts — is covered by
+  `make-frame-generation-pool-window-jvm-test` and, on CLJS,
+  `live-frame-reload-cljs-test`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.image :as image]
+            [re-frame.image-assembly :as asm]
+            [re-frame.live-frame :as lf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+;; ---------------------------------------------------------------------------
+;; White-box handles. The defect lives entirely in the relationship between two
+;; pieces of private process-local bookkeeping — the provenance table and the
+;; per-id construction reservations — so the reproduction observes both
+;; directly, exactly as its two sibling namespaces do.
+;; ---------------------------------------------------------------------------
+
+(def ^:private provenance #'lf/frame-generation-pool)
+
+(defn- pool-row [id] (get (deref @provenance) id))
+
+(def ^:private ids
+  [:pool-race/target :pool-race/rollback :pool-race/nil-pool :pool-race/adopted
+   :pool-race/after-release])
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [t]
+    ;; The provenance table is process-local `defonce` bookkeeping that no
+    ;; fixture resets (a destroyed id's row deliberately survives). Clear this
+    ;; namespace's own ids so a re-run inside one JVM starts from the documented
+    ;; "no row" state, and leave none behind for a sibling.
+    (swap! @provenance #(apply dissoc % ids))
+    (try
+      (t)
+      (finally
+        (remove-watch @provenance ::row-watch)
+        (swap! @provenance #(apply dissoc % ids))))))
+
+;; A latch we expect to FIRE waits this long; it only bounds a hang.
+(def ^:private ^:const settle-ms 10000)
+
+(defn- await! [^CountDownLatch latch ^long ms]
+  (.await latch ms TimeUnit/MILLISECONDS))
+
+(defn- err-id [thunk]
+  (try
+    (thunk)
+    nil
+    (catch clojure.lang.ExceptionInfo e
+      (:rf.error/id (ex-data e)))))
+
+;; Park the constructor of `target` inside its construction transaction: the
+;; per-id reservation is held, and the authoritative registry decision has not
+;; been taken yet.
+(defn- window-probe [target ^CountDownLatch reached ^CountDownLatch release]
+  (fn [id]
+    (when (= id target)
+      (.countDown reached)
+      (.await release settle-ms TimeUnit/MILLISECONDS))))
+
+(defn- exclusively-reserved?
+  "Is `id` held by an in-flight construction transaction RIGHT NOW? Asked the
+  only way the reservation registry answers: by trying to claim it. A claim that
+  succeeds is released immediately — the question is the answer's only purpose."
+  [id]
+  (let [owner (try
+                (frame/claim-frame-construction! #{id} ::reservation-probe)
+                (catch clojure.lang.ExceptionInfo e
+                  (if (= :rf.error/frame-construction-in-progress
+                         (:rf.error/id (ex-data e)))
+                    nil
+                    (throw e))))]
+    (if owner
+      (do (frame/release-frame-construction! owner) false)
+      true)))
+
+(defn- watch-row!
+  "Record every REAL transition of `id`'s provenance row into `log`, noting
+  whether the id was exclusively reserved at that instant, and run `on-change`
+  (nil for none) there too.
+
+  The watch fires synchronously on the WRITING thread, inside the `swap!` that
+  made the transition — so `log` is a record of what a reader standing at each
+  publication would have seen, with no timing tolerance anywhere. Writes that do
+  not MOVE the row (a re-construction re-recording the pool it already names)
+  are not transitions and are ignored."
+  [id log on-change]
+  (add-watch
+    @provenance ::row-watch
+    (fn [_ _ old new]
+      (let [before (get old id ::absent)
+            after  (get new id ::absent)]
+        (when (not= before after)
+          (swap! log conj {:from before :to after :reserved? (exclusively-reserved? id)})
+          (when on-change (on-change)))))))
+
+;; ---------------------------------------------------------------------------
+;; Two explicit descriptor pools selected by the SAME image (the shape
+;; `make-frame-generation-pool-window-jvm-test` uses, renamed for this
+;; namespace). Both carry the frame's namespace, so a reprojection against the
+;; WRONG one resolves happily rather than zero-matching: the clobber is SILENT.
+;; ---------------------------------------------------------------------------
+
+(defn- reg-desc [provenance-ns kind id impl]
+  {:rf.provenance/ns provenance-ns
+   :kind             kind
+   :id               id
+   :handler-fn       impl})
+
+(def ^:private pool-v1
+  [(reg-desc "pool.race.core" :event :pool-race/inc ::inc-v1)])
+
+(def ^:private pool-v2
+  [(reg-desc "pool.race.core" :event :pool-race/inc   ::inc-v2)
+   (reg-desc "pool.race.core" :event :pool-race/reset ::reset)])
+
+(def ^:private img
+  (image/image {:id :pool-race/img :select-ns {:include ["pool.race.core"]}}))
+
+(defn- inc-impl
+  "The `:pool-race/inc` implementation the frame's CURRENT generation resolves —
+  `::inc-v1` when the frame is running pool V1, `::inc-v2` for pool V2. The
+  one-line discriminator between the pool the winner sealed and the pool a
+  rejected contender transiently published."
+  [id]
+  (:handler-fn (asm/resolve-descriptor (lf/frame-generation id) :event :pool-race/inc)))
+
+;; ---------------------------------------------------------------------------
+;; 1. THE REPRODUCTION. A same-id contender the engine REJECTS must leave the
+;;    provenance table exactly as it found it — and therefore must not be able
+;;    to make a live frame run its pool.
+;; ---------------------------------------------------------------------------
+
+(deftest rejected-same-id-attempt-neither-publishes-nor-clobbers
+  (testing "a make-frame that loses admission for an id publishes no provenance
+            row, so no reprojection can resolve the winner's live frame against
+            the loser's pool"
+    (let [target :pool-race/target]
+      ;; The frame the winner owns, sealed from pool V2.
+      (lf/make-frame {:id target :images [img]} pool-v2)
+      (is (= ::inc-v2 (inc-impl target)) "control: the frame is running pool V2")
+      (is (= pool-v2 (pool-row target)) "control: its row names pool V2")
+
+      (let [log      (atom [])
+            moved    (atom [])
+            reached  (CountDownLatch. 1)
+            release  (CountDownLatch. 1)]
+        ;; THE READER, standing on the instant of any transient publication: the
+        ;; real per-frame reprojection, which re-resolves the frame against
+        ;; whatever the table says right now and swaps the result on. Its return
+        ;; is the reload diff — non-nil exactly when the frame MOVED.
+        (watch-row! target log #(swap! moved conj (lf/reproject-live-frame! target)))
+        (try
+          (let [winner (binding [frame/*upsert-decide-probe*
+                                 (window-probe target reached release)]
+                         (future (lf/make-frame {:id target :images [img]} pool-v2)))]
+            (is (await! reached settle-ms)
+                "the winner parked inside its construction transaction")
+            (is (exclusively-reserved? target)
+                "control: the winner holds the id's reservation")
+
+            ;; THE CONTENDER. It loses admission — and pre-fix it had already
+            ;; published pool V1 into the shared table before finding out.
+            (is (= :rf.error/frame-construction-in-progress
+                   (err-id #(lf/make-frame {:id target :images [img]} pool-v1)))
+                "the same-id contender is rejected by the engine")
+
+            (is (= [] @log)
+                (str "the rejected contender wrote nothing to the provenance "
+                     "table — pre-fix it published pool V1 there and then "
+                     "restored it, a window any reader on any thread could "
+                     "land in"))
+            (is (= [] @moved)
+                (str "no reprojection was offered a pool the winner had not "
+                     "sealed — pre-fix the reader in that window re-resolved "
+                     "the live frame against V1 and swapped it on"))
+            (is (= ::inc-v2 (inc-impl target))
+                "the live frame is still running the pool its owner sealed")
+            (is (= pool-v2 (pool-row target))
+                "the row still names the pool the frame is running")
+
+            (.countDown release)
+            (is (not= ::timeout (deref winner settle-ms ::timeout))
+                "the winner completed")
+            (is (= ::inc-v2 (inc-impl target))
+                "and completed on its own generation")
+            (is (= pool-v2 (pool-row target))
+                "with its row still in step"))
+          (finally
+            (.countDown release)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. THE ROLLBACK, and the publication it undoes, run INSIDE the reservation.
+;;    This is the structural statement the reproduction above cannot make on its
+;;    own: an undo computed from a row read outside any reservation is only
+;;    accidentally exact. Under the reservation the row it restores is still the
+;;    row it displaced, because no other attempt on the id can have run.
+;; ---------------------------------------------------------------------------
+
+(deftest provenance-write-and-rollback-both-hold-the-id-reservation
+  (testing "a construction that fails in the engine publishes and rolls back its
+            provenance row while it exclusively owns the id — so neither half
+            can land on another attempt's row"
+    (let [id  :pool-race/rollback
+          log (atom [])]
+      (lf/make-frame {:id id :images [img]} pool-v1)
+      (is (= pool-v1 (pool-row id)) "control: V1 recorded")
+
+      (watch-row! id log nil)
+      ;; `:on-create` is retired and fails loud INSIDE the engine — i.e. after
+      ;; the early provenance write, which is the branch the rollback exists for.
+      (is (= :rf.error/on-create-retired
+             (err-id #(lf/make-frame {:id id :images [img] :on-create [:boom]}
+                                     pool-v2)))
+          "control: the re-construction failed inside the engine")
+
+      (is (= [{:from pool-v1 :to pool-v2 :reserved? true}
+              {:from pool-v2 :to pool-v1 :reserved? true}]
+             @log)
+          (str "the publication and its rollback both ran while the id was "
+               "exclusively reserved — pre-fix both ran outside every "
+               "reservation, so a same-id successor could be interleaved "
+               "between them"))
+      (is (= pool-v1 (pool-row id))
+          "the failed re-construction preserved the ORIGINAL row"))))
+
+;; ---------------------------------------------------------------------------
+;; 3. ABSENT versus RECORDED-NIL, under the reservation. `nil` is a legitimate
+;;    recorded pool — it means "the live source store", which is what the
+;;    1-arity `make-frame` resolves against — so an absent row cannot be spelled
+;;    by assoc'ing nil, and a rollback that confused the two would convert a
+;;    live-store frame into one with no provenance at all.
+;; ---------------------------------------------------------------------------
+
+(deftest rollback-restores-a-recorded-nil-row-rather-than-removing-it
+  (testing "a 1-arity frame's row is PRESENT with value nil, and a failed
+            re-construction against an explicit pool restores it to present-nil
+            — not to absent, and not to the incoming pool"
+    (let [id  :pool-race/nil-pool
+          log (atom [])]
+      ;; The 1-arity: the DEFAULT image over the LIVE source store. Its row is
+      ;; recorded as nil, which is what "the live store" is spelled as.
+      (lf/make-frame {:id id})
+      (is (contains? (deref @provenance) id) "control: the row is present")
+      (is (nil? (pool-row id)) "control: and its value is nil — the live store")
+
+      (watch-row! id log nil)
+      (is (= :rf.error/on-create-retired
+             (err-id #(lf/make-frame {:id id :on-create [:boom]} pool-v1))))
+      (is (= [{:from nil :to pool-v1 :reserved? true}
+              {:from pool-v1 :to nil  :reserved? true}]
+             @log)
+          "both halves ran under the reservation, and the undo restored nil")
+      (is (contains? (deref @provenance) id)
+          "the row is still PRESENT — a recorded nil was not mistaken for absent")
+      (is (nil? (pool-row id))
+          "and still names the live source store"))))
+
+;; ---------------------------------------------------------------------------
+;; 4. AN OUTER PREFLIGHT'S RESERVATION IS ADOPTED, NOT NESTED. re-frame.ui's
+;;    `execute-frame-plans!` claims its whole plan set up front and hands each id
+;;    to `make-frame` in turn. `make-frame` must recognise that it is already
+;;    inside an exact reservation for the id and neither re-claim it (which
+;;    would collide with its own caller) nor release it early. A hand-off
+;;    already SPENT is not adoption: the nested public entry loses normally, and
+;;    must lose without publishing.
+;; ---------------------------------------------------------------------------
+
+(deftest a-handed-off-reservation-is-adopted-and-a-spent-one-is-not
+  (testing "make-frame under an outer preflight's hand-off publishes its row
+            inside that owner's reservation, and a second entry under the same
+            spent hand-off loses without touching the table"
+    (let [id    :pool-race/adopted
+          log   (atom [])
+          owner (frame/claim-frame-construction! #{id} :plan-preflight)]
+      (watch-row! id log nil)
+      (try
+        (is (= [true :rf.error/frame-construction-in-progress]
+               (frame/call-with-frame-construction-handoff!
+                 owner id
+                 (fn []
+                   [(some? (lf/make-frame {:id id :images [img]} pool-v1))
+                    (err-id #(lf/make-frame {:id id :images [img]} pool-v2))])))
+            "one hand-off permits exactly one construction; a second loses")
+        (finally
+          (frame/release-frame-construction! owner)))
+
+      (is (= [{:from ::absent :to pool-v1 :reserved? true}] @log)
+          (str "exactly ONE publication, made under the outer owner's "
+               "reservation — the losing second entry published nothing"))
+      (is (= pool-v1 (pool-row id)) "the row names the pool that was admitted")
+      (is (= ::inc-v1 (inc-impl id)) "and the frame is running it")
+
+      ;; The outer owner compare-released, so ordinary construction resumes.
+      (is (some? (rf/make-frame {:id :pool-race/after-release}))
+          "the adopted reservation was not released early by make-frame"))))


### PR DESCRIPTION
Closes the audit reopening on rf2-rt4jz (PR #7197 shipped the ordering half; this is the admission half).

## The defect

`rf/make-frame` writes two process-global stores: the frame record, through `frame/upsert-frame!`, and the **generation-provenance row** naming which descriptor pool that record's generation was resolved against. PR #7197 moved the row write **before** the engine commit, and that is right for a reason that has nothing to do with contention — the `:initial-events` cascade runs *inside* the commit and reprojects against the row.

Before the commit is also **before admission**, and that is what was still wrong.

`upsert-frame!` reserves an id for exactly one in-flight construction and fails every same-id contender promptly with `:rf.error/frame-construction-in-progress`. That loss is a **zero-write loss by design** — it is raised at admission precisely so a contender never reaches an adapter callback, a setup cascade or a teardown, and therefore never leaves a trace of having tried. A row written ahead of the commit is written ahead of that admission, so the property held for one store and not the other:

- **A rejected contender published.** A same-id attempt wrote its own pool into the shared table on its way to being told it had lost. Reprojection is a *read* of that table, takes no reservation, and runs on any thread — so a reader landing in the loser's interval re-resolved the **winner's** live frame against the **loser's** pool and swapped the result on, while the winner was still inside its commit and its `:initial-events` cascade. That is the rf2-rt4jz clobber reached by a second route.
- **The rollback was the same defect reversed.** `restore-frame-generation-pool!` undoes the write by restoring the value read at write time. Computed outside any reservation, that undo can land on a row a newer owner has since written.

## The fix — ordering, not a symptom patch

Not a defensive read, and not a re-write after the fact; either would leave "publishes outside the transaction" in place for the next caller. The publication, the commit and the rollback now happen inside **one exact per-id reservation** — the same one the frame revision is made under.

`frame/call-with-frame-construction-claim!` claims the id, arms the engine hand-off so `upsert-frame!` enters *that* reservation instead of colliding with it, and compare-releases in `finally`. A losing attempt therefore throws **before its first `swap!`**, and a winning attempt cannot be interleaved with any other attempt on the id, so the row its rollback restores is still the row it displaced. `restore-frame-generation-pool!` now states that precondition at the site.

**Adoption, not nesting.** re-frame.ui's `execute-frame-plans!` already claims its whole plan set up front and hands each id to `make-frame` in turn, so a blanket claim here would collide with its own caller. An **unspent** hand-off for the id is adopted as-is — nothing claimed, nothing released, `make-frame`'s writes falling inside the reservation the preflight already holds. A **spent** hand-off is not adoption: the nested public entry claims and loses exactly as it did when the engine claimed for itself, and now loses without publishing.

## No pinned contract moved

`upsert-frame!`'s signature, arities, typed error, `'rf/make-frame` where-sym and the reservation primitives are all unchanged. The provenance table stays private process-local `defonce` bookkeeping; no spec page and no doc page describes it, so `spec/` and `docs/` are untouched. CLJS is single-threaded and cannot lose a claim — there the change is one uncontended CAS and a release.

**What the reservation deliberately does not do** (stated at the site): it does not fence *readers*. A reprojection is a resolution, not a construction, and must take no claim. So the residual documented on the bead stands unchanged — on a re-construction the row names the incoming pool until the surgical swap installs the incoming generation, and a JVM-concurrent flush in that interval re-resolves the outgoing composition against the incoming pool. Transient, overwritten unconditionally by the swap that follows, never observable to a completed call.

## Observable frame behaviour — for merge sequencing

Frame construction is beneath the SSR, fx-args, diagnostics and Playwright clusters in flight. One observable change, narrow and same-typed:

- the id's construction reservation is now acquired **one step earlier** — in `make-frame`, before `upsert-frame!`'s preflight validation (retired-key rejection, `:initial-events` normalization, observability-policy validation) rather than after it. A same-id contender racing *that* window now loses with `:rf.error/frame-construction-in-progress` instead of proceeding. Same error id, same `'rf/make-frame` where-sym, same `:owner-kind :construction`, same recovery. Nothing else about construction ordering, return values, tokens or lifecycle emission changed.

## The witness

`implementation/core/test/re_frame/make_frame_generation_pool_contention_jvm_test.clj` — deterministic, no sleeps deciding anything, both windows opened by seams that already exist:

- the **winner** parks inside its construction transaction on `frame/*upsert-decide-probe*` (the `nil`-in-production JVM linearization seam the two sibling namespaces use). Parked there it holds the reservation, so the contender that follows is a genuine engine loss.
- the **reader** reaches the exact instant of a transient publication through an atom **watch** on the provenance table. A watch fires synchronously, on the writing thread, *inside* the `swap!` that made the transition — the one place a test can stand that no timing tolerance can reach. What it runs there is the real reader: `live-frame/reproject-live-frame!`.

Four cases: the reproduction; publication-and-rollback both holding the reservation; a recorded **nil** row (the 1-arity's "live source store") restored as present-and-nil rather than absent; and the re-frame.ui hand-off adopted while a *spent* one is not.

## Quality gates

All foreground, exit codes echoed, logs kept worktree-local, nothing piped through `tail`/`grep` before the exit code was taken.

### Mutation proof

The mutation removes only the `call-with-frame-construction-claim!` wrapper, restoring the pre-fix shape in which the row is published before admission.

| | command | exit | result |
|---|---|---|---|
| **RED** (fix reverted) | `clojure -M:test -n re-frame.make-frame-generation-pool-contention-jvm-test` | **1** | 4 tests, 27 assertions, **5 failures** — all four deftests red |
| **GREEN** (fix restored) | same | **0** | 4 tests, 27 assertions, 0 failures |

What the red actually said, case by case:

- **the reproduction** — `@log` carried the rejected contender's two transitions (V2→V1, then V1→V2), and `@moved` carried two real reload diffs: `{:changed #{[:event :pool-race/inc]} :removed #{[:event :pool-race/reset]}}`. The reader in that window re-resolved the winner's live frame against V1 and **swapped it on**, losing the V2-only registration.
- **publication + rollback** — both transitions came back `:reserved? false`.
- **recorded-nil rollback** — likewise `:reserved? false` on both halves.
- **the hand-off** — three transitions instead of one: the losing nested entry published pool V2 and restored it.

### Gate matrix

Derived from `TESTING.md`: the diff is `implementation/core/src/**` plus one new core test namespace, and `implementation/core/*` fans out to almost everything — so the transitive surface is gated, not just the core JVM lane.

| gate | command | exit | result |
|---|---|---|---|
| core JVM (dev posture) | `clojure -M:test` in `implementation/core` | **0** | 2202 tests / 11368 assertions, 0 failures |
| core JVM (production gate, real `-Dre-frame.debug=false`) | `bash scripts/test-core-prod-gate.sh` | **0** | 1945 tests / 8390 assertions, 175 namespaces — the new witness joins this roster by default and is green under it (`--plan` lists `re-frame.make-frame-generation-pool-contention-jvm-test`) |
| **every** JVM implementation artefact | `bash scripts/test-jvm-implementation.sh` | **0** | all 23 artefacts, 9402 tests / 94551 assertions, 0 failures — `PASS implementation JVM artefacts`. Run in full rather than relying on the fast spine's narrowing, because a core change reaches every downstream artefact |
| CLJS node integration | `npm run test:cljs` | **0** | 12249 tests / 61148 assertions, 0 failures |
| browser unit | `npm run test:browser` | **0** | 931 tests / 5840 assertions, 0 failures |
| adapter + substrate smokes — Reagent, UIx, re-frame.ui | `npm run test:adapter-smokes` | **0** | 3 specs, 0 failures. All three spine consumers, because frame creation is beneath all of them |
| fast PR spine | `bash scripts/test-fast-pr.sh` | **1** | every tier green — drift/lockstep/doc gates, `PLAN-JVM implementation/core` (2202 / 11368, 0 failures), the JS harness self-tests — **except** the CLJS node tier, which came back with 35 failures **all inside `re-frame.test-quiet-shadow-node-cljs-test`**. See the load note below |
| clj-kondo, exactly as CI runs it — pinned **2026.04.15**, the 12 `--lint` roots from `lint.yml`, `--fail-level error` | | **0** | **errors: 0**; 4526 warnings, all pre-existing and unchanged |

`mkdocs build --strict` is not nominated: no page under `docs/` or `spec/` is touched.

### The load flake, named rather than absorbed

A sibling worker is running a deliberate load generator on this box for the flake beads themselves (`re-frame2-worktrees/flakes-2i1ay/.wtlogs/load.sh 1800 32`, plus an A/B driver) — 44 load processes, 743 processes total, CPU pinned at 100% for the duration. Under it, `re-frame.test-quiet-shadow-node-cljs-test` fails on `spawnSync … ETIMEDOUT`: it shells out to a real `node` subprocess and asserts its exit code, so a starved box makes it assert on `nil`. That is exactly the known load-sensitive suite (rf2-hofhx / rf2-2i1ay).

It reddened twice, both times contended, both times **confined to that one namespace**:

- the first `npm run test:cljs`, run alongside `clj-kondo --parallel` — 11 failures. **Re-run uncontended: exit 0, 0 failures.**
- `test-fast-pr.sh`'s CLJS node tier, run at the peak of the sibling's generator — 35 failures, same namespace, same signature. Its tier content is identical to `npm run test:cljs`: same 12249 tests / 61148 assertions, and the uncontended run of exactly this commit is the green one recorded in the row above.

No other namespace was red in any run, on any lane. Reported as contention, not as a regression.
