### PR TITLE
machines-viz: the value-free summary discloses nothing it was given (rf2-m46qv)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1802,6 +1802,30 @@ Failure modes:
 | `:unknown-version` | `:rf.machines-viz.share/v` is newer than the decoder knows. |
 | `:invalid-chart-state` | `:rf.machines-viz.share/chart` doesn't validate. The `:definition` slot is checked by the canonical **recursive** grammar gate (`grammar/valid-definition?` — rf2-j538f7.18), so a forged URL carrying a definition that is structurally invalid BELOW the root (a nested compound missing `:initial`, a dangling target, an unknown bare node key) fails closed at BOTH encode and decode, not just a shallow root-shape violation. |
 
+#### What the thrown `ex-data` may carry
+
+A share-URL is forged input by assumption — the encoder's privacy filter
+exists because a hand-edited fragment can smuggle `:snapshot {:data …}` and
+arbitrary runtime values — and projection cannot walk `ex-data` after the
+fact (EP-0015 / Spec 015 §exception-path residual). So no decode failure
+retains any part of what it rejected (rf2-m46qv):
+
+| Slot | Carries |
+|---|---|
+| `:url-summary`, `:envelope-summary`, `:chart-summary` | A value-free summary of the rejected value: `:type` drawn from the closed vocabulary `:map` / `:vector` / `:seq` / `:set` / `:keyword` / `:symbol` / `:string` / `:number` / `:boolean` / `:nil` / `:fn` / `:scalar`, plus an integer `:count` for a counted collection or string. Nothing else. It is content-free BY CONSTRUCTION rather than by redaction, so it serializes to a fixed size whatever arrives — there is no key set to cap and no prefix to bound. The same closed vocabulary `re-frame.error/diag-value-summary` uses, so one diagnostic vocabulary reads across both surfaces. |
+| `:payload-version` | For `:unknown-version` only: the INTEGER the version comparison used, or `nil` when `:v` did not parse as a number at all. Never the raw `:v`, which a forged payload chooses freely and without bound. |
+| `:reason`, `:message` | The category and the human sentence — both framework-authored, neither derived from the payload. |
+
+There is deliberately **no `:cause` slot**. `transit/read` calls `JSON.parse`,
+and V8 embeds a prefix of its input in the `SyntaxError` it throws
+(`Unexpected token 'h', "hunter2-sw"... is not valid JSON`), so republishing
+the host's message republished the payload under a slot named for the cause.
+`:reason` already names which stage failed and `:message` says so in words.
+
+The encoder holds the same line: `:host-carries-fragment` reports
+`:fragment-index` rather than the host, and `:invalid-chart-state` reports
+`:chart-state-summary` rather than the chart state.
+
 ### Pipeline
 
 ```

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
@@ -763,10 +763,10 @@
     ;;
     ;; — so a `:cause (.-message e)` republished the forged payload's own
     ;; plaintext under a slot named for the cause: a disclosure nobody wrote,
-    ;; inherited from the host and revised by the host at will. The message it
-    ;; replaced nothing of: `:reason` already discriminates WHICH stage failed
-    ;; and `:message` says so in words, which is the whole of the recovery
-    ;; ("this is not a share-URL this build can read").
+    ;; inherited from the host and revisable by the host at will. It replaced
+    ;; nothing, either — `:reason` already discriminates WHICH stage failed and
+    ;; `:message` says so in words, which is the whole of the recovery ("this
+    ;; is not a share-URL this build can read").
     (let [transit-str (try
                         (base64url->str fragment)
                         (catch :default _e

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
@@ -459,21 +459,70 @@
   a value-FREE diagnostic for a rejected payload `v`. Projection cannot
   walk `ex-data` after the fact, so a thrown error must NOT carry the raw
   payload (a forged share URL can smuggle `:snapshot {:data …}` /
-  arbitrary runtime values). We name the SHAPE — type tag + (for maps)
-  the key SET — never the values. The reader still recovers the category
-  + structural diagnostics; no secret-bearing slot survives."
+  arbitrary runtime values).
+
+  Shape (`:count` present only for a counted collection or string):
+
+    {:type   :map | :vector | :seq | :set | :keyword | :symbol
+             | :string | :number | :boolean | :nil | :fn | :scalar
+     :count  <int>}    ;; collection / string element count
+
+  **Content-free BY CONSTRUCTION (rf2-m46qv).** Every value this can
+  carry is either a member of the closed `:type` vocabulary above or an
+  integer count, so no expression here is derived from the input's
+  CONTENT. The serialized summary is a fixed size whatever arrives —
+  there is no prefix to bound and no key set to cap — which is the only
+  guarantee worth having over an input the header of this namespace
+  itself calls forged.
+
+  IT DID NOT HOLD BEFORE, on two legs:
+
+  - a map's `:keys` — every top-level key, uncapped and unsanitised.
+    A forged payload's key SET is attacker-chosen in CONTENT (keys carry
+    markup, control characters and secrets as readily as values do) and
+    in SIZE, so the summary grew with the forger's input without limit
+    and then rode into a thrown ex-info that names itself value-free.
+    Removing it also removes the `(sort-by str …)` that ran `str` over
+    caller-supplied keys, where a key whose `toString` THREW replaced
+    the documented failure with its own exception.
+  - a keyword's raw `:value`, justified inline by \"a keyword IS a state
+    name/address, not data\". That justification does not survive its own
+    threat model. This function is never handed a `:snapshot`'s `:state`
+    — its three call sites pass the whole chart-state, envelope or chart
+    — so the keyword leg fires exactly when the payload is NOT the shape
+    it was supposed to be, which is to say when someone forged it; and
+    transit decodes `~:<anything>` into a keyword of any length and any
+    content the forger likes. The guess that a keyword is structural is
+    the same one rf2-210uq rejected in `re-frame.error`.
+
+  SIZE IS DELIBERATELY KEPT. `:count` is what makes the summary useful
+  rather than merely safe — \"a 2000-key map where an envelope was
+  expected\" is the diagnosis — and an integer cannot carry a fragment of
+  a token. A lazy seq is NOT counted: realising it on the failure path
+  is its own hazard.
+
+  The `:type` vocabulary is deliberately the closed set
+  `re-frame.error/diag-value-summary` uses, so a tool reading a thrown
+  ex-data from either surface reads ONE diagnostic vocabulary. This
+  remains an INDEPENDENT implementation rather than a mirror — core
+  summarises a caller's argument, machines-viz summarises a forged wire
+  payload — but there is no reason for the two to disagree about what to
+  call a set."
   [v]
   (cond
-    (map? v)  {:type :map  :keys (vec (sort-by str (keys v))) :count (count v)}
-    (vector? v) {:type :vector :count (count v)}
-    (set? v)  {:type :set :count (count v)}
-    (sequential? v) {:type :seq}
-    (string? v) {:type :string :length (count v)}
-    (keyword? v) {:type :keyword :value v}     ; a keyword IS a state name/address, not data
-    (number? v) {:type :number}
+    (nil? v)     {:type :nil}
+    (map? v)     {:type :map :count (count v)}
+    (vector? v)  {:type :vector :count (count v)}
+    (set? v)     {:type :set :count (count v)}
+    (string? v)  {:type :string :count (count v)}
+    (keyword? v) {:type :keyword}
+    (symbol? v)  {:type :symbol}
     (boolean? v) {:type :boolean}
-    (nil? v)  {:type :nil}
-    :else     {:type :value}))
+    (number? v)  {:type :number}
+    (seq? v)     {:type :seq}
+    (fn? v)      {:type :fn}
+    (seqable? v) {:type :seq}
+    :else        {:type :scalar}))
 
 (defn- decode-error
   "Throw the documented `:rf.machines-viz.share/decode-failed` ex-info.
@@ -698,19 +747,36 @@
     (when-not fragment
       (decode-error :malformed-fragment
                     "URL carries no #machine= share fragment"
-                    {:url url}))
+                    ;; rf2-m46qv — the SHAPE of the argument, never the URL.
+                    ;; The encoder above already refuses to put `:host` in
+                    ;; ex-data because "a viewer URL can carry a query string
+                    ;; with a token in it" (rf2-8nzxib, hence its
+                    ;; `:fragment-index`); the decoder is handed URLs from
+                    ;; elsewhere, so it is the more exposed of the two and was
+                    ;; carrying the whole thing.
+                    {:url-summary (value-free-summary url)}))
+    ;; NEITHER STAGE BELOW REPORTS THE HOST'S OWN ERROR MESSAGE (rf2-m46qv).
+    ;; `transit/read` calls `JSON.parse`, and V8 embeds a PREFIX OF ITS INPUT
+    ;; in the SyntaxError it throws —
+    ;;
+    ;;   Unexpected token 'h', "hunter2-sw"... is not valid JSON
+    ;;
+    ;; — so a `:cause (.-message e)` republished the forged payload's own
+    ;; plaintext under a slot named for the cause: a disclosure nobody wrote,
+    ;; inherited from the host and revised by the host at will. The message it
+    ;; replaced nothing of: `:reason` already discriminates WHICH stage failed
+    ;; and `:message` says so in words, which is the whole of the recovery
+    ;; ("this is not a share-URL this build can read").
     (let [transit-str (try
                         (base64url->str fragment)
-                        (catch :default e
+                        (catch :default _e
                           (decode-error :malformed-fragment
-                                        "fragment is not valid base64url"
-                                        {:cause (.-message e)})))
+                                        "fragment is not valid base64url")))
           envelope    (try
                         (transit/read (transit/reader :json) transit-str)
-                        (catch :default e
+                        (catch :default _e
                           (decode-error :malformed-payload
-                                        "decoded bytes are not valid transit"
-                                        {:cause (.-message e)})))]
+                                        "decoded bytes are not valid transit")))]
       (when-not (and (map? envelope)
                      (contains? envelope :rf.machines-viz.share/v)
                      (contains? envelope :rf.machines-viz.share/chart))
@@ -732,7 +798,15 @@
         (when newer?
           (decode-error :unknown-version
                         "share-URL was produced by a newer Machines-Viz"
-                        {:payload-version v :decoder-version current-version}))
+                        ;; rf2-m46qv — `:v` is forged input: any transit value,
+                        ;; of any size, and it reaches here through the string
+                        ;; fallback as readily as through the numeric compare.
+                        ;; Report the INTEGER the comparison actually used
+                        ;; (nil when `:v` did not parse as a number at all),
+                        ;; never the raw value. A number cannot carry a token,
+                        ;; and "newer than 2" is the whole diagnosis.
+                        {:payload-version (when-not (js/isNaN v-num) v-num)
+                         :decoder-version current-version}))
         ;; Reject any :snapshot carrying keys beyond :state (a
         ;; hand-edited URL trying to smuggle :data), and validate the
         ;; whole ChartState.

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
@@ -612,7 +612,9 @@
           d (try (share/decode-share-url future-url)
                  (catch :default e (ex-data e)))]
       (is (= :unknown-version (:reason d)))
-      (is (= "3" (:payload-version d))))))
+      ;; rf2-m46qv — the INTEGER the version comparison used, not the raw
+      ;; `:v` off the payload (which is forged input of any size).
+      (is (= 3 (:payload-version d))))))
 
 (deftest frame-id-is-optional
   (testing "a ChartState with no :frame-id encodes + round-trips (v2 / EP-0023)"
@@ -1085,3 +1087,265 @@
       (is (some? (:chart-summary d)) "value-free summary present")
       (is (not (some #(str/includes? % secret) (ex-data-strings d)))
           "the secret string must not survive anywhere in ex-data"))))
+
+;; ---------------------------------------------------------------------------
+;; EP-0015 — the thrown diagnostic is content-free BY CONSTRUCTION (rf2-m46qv)
+;;
+;; The section above plants a secret in a VALUE position and hunts for it.
+;; It passed for as long as `value-free-summary` disclosed the payload
+;; anyway, because a sentinel hunt only ever finds the leak someone thought
+;; to plant: the map leg returned `:keys` — every top-level key, uncapped
+;; and unsanitised — and the keyword leg returned the raw keyword as
+;; `:value`. Both sit in KEY / TYPE positions the old hunt never looked at,
+;; and both are attacker-chosen in CONTENT and in SIZE, since the whole
+;; point of this namespace's header is that "a forged share URL can smuggle
+;; arbitrary runtime values".
+;;
+;; So the checks below are a GRAMMAR, not a hunt. Every summary this
+;; namespace can emit, over a corpus of hostile inputs, must consist of a
+;; `:type` drawn from a closed vocabulary plus an integer `:count` and
+;; NOTHING else, and every thrown ex-data must serialize inside a fixed
+;; bound however large the forged payload is. A future leak fails that
+;; without anyone remembering to plant a sentinel for it.
+
+(def ^:private sentinel
+  "The token planted in every position a forged payload can reach. Nothing
+  this namespace throws may reproduce it — as a string, a keyword, a
+  symbol, a map KEY, or a fragment of any of them."
+  "hunter2-swordfish-SENTINEL")
+
+(def ^:private sentinel-fragments
+  "Every 8-character window of the sentinel. A leak is proved by a FRAGMENT,
+  not only by the whole token: a bounded prefix of attacker material is the
+  defect, not the fix, and a host `JSON.parse` message discloses exactly
+  such a prefix."
+  (into #{} (map #(subs sentinel % (+ % 8))) (range (- (count sentinel) 7))))
+
+(defn- discloses?
+  "Does `x`, once serialized, reproduce any fragment of the sentinel — under
+  any key, at any depth, as a string, a keyword, a symbol or a map key?
+  `pr-str` is the check rather than the string walk above precisely because
+  a leaked KEYWORD is not a string, which is how the `:keys` leg survived a
+  test file that already claimed to assert this."
+  [x]
+  (let [s (pr-str x)]
+    (boolean (some #(str/includes? s %) sentinel-fragments))))
+
+(def ^:private summary-type-vocabulary
+  "The CLOSED `:type` vocabulary a value-free summary may emit — the same
+  set `re-frame.error/diag-value-summary` uses, so a tool reading a thrown
+  ex-data from either surface reads ONE diagnostic vocabulary."
+  #{:map :vector :seq :set :keyword :symbol :string :number :boolean :nil
+    :fn :scalar})
+
+(defn- content-free-summary?
+  "The grammar. A summary is a map whose key set is a subset of
+  `#{:type :count}`, whose `:type` is in the closed vocabulary, and whose
+  `:count` — when present — is a non-negative integer. Nothing else may
+  appear, because every other slot would have to be derived from the
+  input's CONTENT."
+  [s]
+  (and (map? s)
+       (every? #{:type :count} (keys s))
+       (contains? summary-type-vocabulary (:type s))
+       (or (not (contains? s :count))
+           (let [c (:count s)]
+             (and (integer? c) (not (neg? c)))))))
+
+(def ^:private summary-serialized-bound
+  "A summary is `{:type :keyword}`-sized whatever arrives. 48 characters is
+  slack over the longest legal shape (`{:type :boolean, :count 999999}`)
+  and orders of magnitude under the inputs below."
+  48)
+
+(def ^:private ex-data-serialized-bound
+  "The whole thrown ex-data — human `:message` included — against forged
+  payloads of ~50 KB. The bound proves SIZE-INDEPENDENCE, not brevity."
+  600)
+
+(defn- exploding-object
+  "A host object whose `toString` throws. A caller can put one in a
+  chart-state key, and `(sort-by str (keys v))` ran `str` over every key —
+  so the old summariser could throw the key's OWN exception in place of the
+  failure it was called to describe."
+  []
+  (let [o #js {}]
+    (set! (.-toString o)
+          (fn [] (throw (js/Error. (str "toString exploded: " sentinel)))))
+    o))
+
+(def ^:private hostile-keys
+  "Sentinel-bearing map keys of every key type transit carries, plus keys
+  that are markup and control characters — a disclosed key set is pasted
+  into a console, a log viewer or an issue tracker."
+  {(str "string-key-" sentinel)                    1
+   (keyword sentinel)                              2
+   (keyword sentinel sentinel)                     3
+   (symbol sentinel)                               4
+   [sentinel]                                      5
+   {sentinel sentinel}                             6
+   (str "<script>alert(" sentinel ")</script>")    7
+   (str (js/String.fromCharCode 27) "[31m" sentinel (js/String.fromCharCode 27) "[0m")  8
+   (str "CR\r\nLF-" sentinel)                      9
+   (str "NUL" (js/String.fromCharCode 0) "-" sentinel)               10
+   4111111111111111                                11
+   true                                            12})
+
+(def ^:private attacker-sized-envelope
+  "2000 sentinel-bearing keys. The old `:keys` leg reproduced every one of
+  them, so the summary grew with the forger's input without limit."
+  (into {} (map (fn [i] [(keyword (str sentinel "-" i)) i])) (range 2000)))
+
+(def ^:private forged-payloads
+  "Payloads a forged `#machine=` fragment can decode to. Transit carries
+  every one of them, so every one is attacker-reachable through the PUBLIC
+  decoder — including the arms whose summary legs the old code never
+  bounded at all."
+  [["a map keyed by sentinels of every key type"  hostile-keys]
+   ["an attacker-sized 2000-key map"              attacker-sized-envelope]
+   ["a nested map-of-map-of-set"                  {:a {:b #{sentinel}}
+                                                   :c [{(keyword sentinel) 1}]}]
+   ["a keyword with no length bound"              (keyword (apply str (repeat 20 sentinel)))]
+   ["a namespaced keyword"                        (keyword sentinel sentinel)]
+   ["a symbol"                                    (symbol sentinel)]
+   ["a 4004-character string"                     (apply str (repeat 154 sentinel))]
+   ["a vector of secrets"                         [sentinel sentinel]]
+   ["a set of secrets"                            #{sentinel}]
+   ["a list of secrets"                           (list sentinel)]
+   ["a 16-digit card number"                      4111111111111111]
+   ["a boolean"                                   true]
+   ["nil"                                         nil]])
+
+(deftest value-free-summary-is-content-free-by-construction
+  (testing "every summary is a closed-vocabulary :type plus an integer :count, and nothing else"
+    (doseq [[label v] (concat forged-payloads
+                              ;; The arms no transit payload can reach, which a
+                              ;; caller of `encode-share-url` still can.
+                              [["a lazy seq"                          (map identity [sentinel])]
+                               ["a live fn"                           (fn [] sentinel)]
+                               ["an opaque host object"               (js-obj "k" sentinel)]
+                               ["a host object whose toString throws" (exploding-object)]
+                               ["a map keyed by an exploding object"  {(exploding-object) :x}]])]
+      (let [s (#'share/value-free-summary v)]
+        (is (content-free-summary? s)
+            (str label " — expected {:type …} (+ :count), got " (pr-str s)))
+        (is (not (discloses? s))
+            (str label " — no sentinel fragment may survive"))
+        (is (<= (count (pr-str s)) summary-serialized-bound)
+            (str label " — fixed serialized bound, got " (count (pr-str s))))))))
+
+(deftest decode-error-discloses-nothing-it-was-given
+  (testing "a forged payload's decode failure names the shape and nothing else"
+    (doseq [[label payload] forged-payloads]
+      (let [url (envelope->url payload)
+            e   (try (share/decode-share-url url) nil
+                     (catch :default ex ex))
+            d   (ex-data e)]
+        (is (some? e) (str label " — decode must refuse"))
+        (is (= :missing-envelope (:reason d)) (str label " — the category survives"))
+        (is (content-free-summary? (:envelope-summary d))
+            (str label " — summary was " (pr-str (:envelope-summary d))))
+        (is (not (discloses? d))
+            (str label " — no sentinel fragment anywhere in ex-data"))
+        (is (not (discloses? (ex-message e)))
+            (str label " — no sentinel fragment in the thrown message"))
+        (is (< (count (pr-str d)) ex-data-serialized-bound)
+            (str label " — ex-data serialized " (count (pr-str d)) " chars"))))))
+
+(deftest decode-error-ex-data-does-not-grow-with-the-payload
+  (testing "a 2000-key forged envelope throws the same size ex-data as a 2-key one"
+    (let [size  (fn [payload]
+                  (count (pr-str (ex-data (try (share/decode-share-url (envelope->url payload))
+                                               nil
+                                               (catch :default e e))))))
+          small (size {:a 1 :b 2})
+          big   (size attacker-sized-envelope)]
+      (is (<= (- big small) 4)
+          (str "ex-data may grow only by the DIGITS of :count; "
+               small " → " big)))))
+
+(deftest decode-error-omits-the-caller-url
+  (testing "a URL with no #machine= fragment does not ride into ex-data"
+    ;; The encoder already refuses to put `:host` in ex-data, because "a
+    ;; viewer URL can carry a query string with a token in it" — that is what
+    ;; its `:fragment-index` slot is for. The decoder is the far more exposed
+    ;; side (it is handed URLs from elsewhere) and it carried the WHOLE url.
+    (let [url (str "https://x/viewer.html?session=" sentinel)
+          e   (try (share/decode-share-url url) nil (catch :default ex ex))
+          d   (ex-data e)]
+      (is (= :malformed-fragment (:reason d)))
+      (is (not (contains? d :url)) "no raw :url slot")
+      (is (content-free-summary? (:url-summary d)))
+      (is (not (discloses? d)) "no sentinel fragment in ex-data")
+      (is (not (discloses? (ex-message e))) "no sentinel fragment in the message"))))
+
+(deftest decode-error-omits-the-host-parse-message
+  (testing "the host parser's own error message does not republish the payload"
+    ;; `transit/read` calls `JSON.parse`, and V8 embeds a PREFIX OF ITS INPUT
+    ;; in the SyntaxError it throws. `:cause (.-message e)` therefore
+    ;; republished the forged payload's plaintext under a slot named for the
+    ;; cause — a leak nobody wrote, inherited from the host.
+    (let [plaintext (str sentinel "-not-transit")
+          b64       (-> (js/btoa (js/unescape (js/encodeURIComponent plaintext)))
+                        (str/replace "+" "-")
+                        (str/replace "/" "_")
+                        (str/replace "=" ""))
+          e         (try (share/decode-share-url (str test-host "#machine=" b64))
+                         nil
+                         (catch :default ex ex))
+          d         (ex-data e)]
+      (is (= :malformed-payload (:reason d)))
+      (is (not (contains? d :cause)) "no host-message slot")
+      (is (not (discloses? d)) "no sentinel fragment in ex-data")
+      (is (not (discloses? (ex-message e))) "no sentinel fragment in the message")))
+  (testing "the base64 stage carries no host message either"
+    (let [e (try (share/decode-share-url (str test-host "#machine=" sentinel "!!!"))
+                 nil
+                 (catch :default ex ex))
+          d (ex-data e)]
+      (is (= :malformed-fragment (:reason d)))
+      (is (not (contains? d :cause)) "no host-message slot")
+      (is (not (discloses? d)) "no sentinel fragment in ex-data"))))
+
+(deftest decode-error-omits-the-forged-version
+  (testing "a numeric-looking version reports the INTEGER the compare used"
+    (let [url (envelope->url {:rf.machines-viz.share/v     (str "9999-" sentinel)
+                              :rf.machines-viz.share/chart chart-state})
+          e   (try (share/decode-share-url url) nil (catch :default ex ex))
+          d   (ex-data e)]
+      (is (= :unknown-version (:reason d)))
+      (is (= 9999 (:payload-version d)) "the parsed integer, not the raw :v")
+      (is (not (discloses? d)) "no sentinel fragment in ex-data")))
+  (testing "a version that does not parse at all reports no version"
+    (let [url (envelope->url {:rf.machines-viz.share/v     (str "v" sentinel)
+                              :rf.machines-viz.share/chart chart-state})
+          e   (try (share/decode-share-url url) nil (catch :default ex ex))
+          d   (ex-data e)]
+      (is (= :unknown-version (:reason d)))
+      (is (nil? (:payload-version d)) "nil, not a 4000-character 'version'")
+      (is (not (discloses? d)) "no sentinel fragment in ex-data"))))
+
+(deftest encode-error-discloses-nothing-it-was-given
+  (testing "a rejected chart-state's key set does not ride into ex-data"
+    (let [leaky (merge hostile-keys
+                       {:machine-id :auth/flow
+                        :definition idle-loading-success
+                        :snapshot   {:state "not-an-arm"}})
+          e     (try (encode leaky) nil (catch :default ex ex))
+          d     (ex-data e)]
+      (is (= :invalid-chart-state (:reason d)))
+      (is (content-free-summary? (:chart-state-summary d)))
+      (is (not (discloses? d)) "no sentinel fragment in ex-data")
+      (is (not (discloses? (ex-message e))) "no sentinel fragment in the message")))
+  (testing "a chart-state key whose toString throws no longer destroys the failure being described"
+    (let [leaky {(exploding-object) :whatever
+                 :machine-id        :auth/flow
+                 :definition        idle-loading-success
+                 :snapshot          {:state "not-an-arm"}}
+          e     (try (encode leaky) nil (catch :default ex ex))
+          d     (ex-data e)]
+      (is (= :rf.machines-viz.share/encode-failed (:rf.error/id d))
+          "the documented ex-info, not the hostile key's own exception")
+      (is (= :invalid-chart-state (:reason d)))
+      (is (content-free-summary? (:chart-state-summary d)))
+      (is (not (discloses? d)) "no sentinel fragment in ex-data"))))


### PR DESCRIPTION
Fixes **rf2-m46qv**.

`share/value-free-summary` is the primitive this namespace reaches for *because* it believes it cannot disclose — and it runs over input the file's own header calls forged: "a forged share URL can smuggle `:snapshot {:data …}` / arbitrary runtime values". It did not meet that claim.

## Every path by which the payload reached the thrown error

I walked the function leg by leg and then walked the ex-data of every `decode-error` / `encode-failed` throw site in the namespace, rather than fixing the two the bead named. There were **five**, and the last three are not in the bead.

| # | Path | What escaped |
|---|---|---|
| 1 | `:keys` on a **map** | Every top-level key of the rejected payload, uncapped and unsanitised. A forged payload's key set is attacker-chosen in **content** (keys carry markup, control characters and secrets as readily as values do) and in **size**, so the "bounded" summary grew with the forger's input — and it rode into a thrown ex-info that names itself value-free. Removing the leg also removes the `(sort-by str (keys v))` that ran `str` over caller-supplied keys, where a key whose `toString` **threw** replaced the documented failure with its own exception. |
| 2 | `:value` on a **keyword** | The raw keyword, with no length or namespace bound. See the justification section below. |
| 3 | `:url` on `:malformed-fragment` | The **whole caller URL**, raw. *(Not in the bead.)* |
| 4 | `:cause` on `:malformed-fragment` / `:malformed-payload` | The host parser's own error message. *(Not in the bead.)* |
| 5 | `:payload-version` on `:unknown-version` | The forged `:v`, raw and unbounded. *(Not in the bead.)* |

Paths 3–5 are in scope because the bead's own acceptance is *"asserting no sentinel in the thrown message or ex-data"* for a forged URL, and the test section they live in is already titled "error ex-data carries NO raw payload". Fixing the summariser and leaving three raw values in the same ex-data would be a fix that fails its own acceptance test. Each was **proved by the witness**, not assumed.

**Path 4 is a leak nobody wrote.** `transit/read` calls `JSON.parse`, and V8 embeds a prefix of its input in the `SyntaxError` it throws:

```
Unexpected token 'h', "hunter2-sw"... is not valid JSON
```

so `:cause (.-message e)` republished the forged payload's own plaintext under a slot named for the cause — a bounded prefix of attacker material, chosen by the host and revisable by the host.

## The keyword leg's inline justification, and why it does not survive

The leg carried a written decision, so it gets a written answer rather than a silent deletion:

```clojure
(keyword? v) {:type :keyword :value v}     ; a keyword IS a state name/address, not data
```

It is a real argument — this file goes to some trouble elsewhere to preserve state configurations verbatim, and `allowlist-chart-state` says of `:snapshot`'s `:state` that it "is a state name/address, not runtime data" in almost those words. But it does not hold **here**, for three reasons that are all visible in the same file:

1. **This function is never handed a `:state`.** Its three call sites pass the whole `chart-state`, the whole `envelope`, or the whole `chart`. The value the justification describes never reaches the leg.
2. **The leg fires only when the payload is not what it was supposed to be.** Every call site expects a map; the keyword arm executes precisely when a forger sent something else. Its premise is false exactly in the situation that runs it.
3. **Transit decodes `~:<anything>` into a keyword** of any length, any namespace and any content, with no bound applied anywhere. `(keyword "<400 characters>")` is a legal keyword and prints verbatim.

And the file already argues against itself: forty lines up, the encoder deliberately reports `:fragment-index` instead of `:host` because "a viewer URL can carry a query string with a token in it". Same namespace, same discipline, opposite conclusion.

So this is case (a) in the brief — the justification does not survive the threat model the same file's docstring describes — and the leg is removed. The reasoning above is recorded in the docstring, so the next reader meets the decision rather than its absence.

## What was removed, what was kept

**Removed:** `:keys`, the keyword `:value`, `:cause`, and the raw `:url`. Nothing is bounded-but-retained, and that is the point: a bounded prefix of attacker material is the defect, not the fix, and a bound tuned for one caller's value is the wrong bound for the next one's.

The summary now carries a `:type` from a closed vocabulary plus, for a counted collection or string, an integer `:count` — **nothing else**. That is content-free *by construction*: no expression in the output is derived from the input's content, so there is no key set to cap and no prefix to bound, and the serialized summary is a **fixed size** whatever arrives.

**Kept deliberately: size and cardinality.** "A 2000-key map where an envelope was expected" *is* the diagnosis, and an integer cannot carry a fragment of a token. A lazy seq is still not counted — realising it on the failure path is its own hazard.

**Kept in a content-free form: the version.** `:payload-version` now reports the **integer** the version comparison actually used (`nil` when `:v` did not parse as a number at all) rather than the raw `:v`. "Newer than 2" is the whole diagnosis, and a number cannot carry a token. The raw slot was reachable with arbitrary content through the string-compare fallback, not only through the numeric path.

**Vocabulary aligned with core.** `:length` became `:count` and `:value` became `:scalar`, and `:symbol` / `:fn` legs were added, so the closed set is exactly `re-frame.error/diag-value-summary`'s. This stays an **independent** implementation rather than a mirror — core summarises a caller's argument, machines-viz summarises a forged wire payload — but there is no reason for the two to disagree about what to call a set, and a tool reading a thrown ex-data from either surface now reads one vocabulary.

## Deliberately NOT touched

- **`tools/re-frame2-pair-mcp`'s `:rf.mcp/summary`** — a documented cross-MCP wire-protocol token-budget marker, not an EP-0015 redaction primitive. Correctly left alone, per the bead.
- **`grammar/definition-summary`** in the same artefact — the **third** independent summariser in the repo, and it carries the same `:keys (vec (sort-by str (keys definition)))` leg over definitions that arrive from forged share URLs, LLM responses and SCXML/Mermaid input. It is not a copy of this fix: it deliberately carries structural diagnostics this one does not (`:parallel`, `:state-count`, `:region-count`, and the rf2-j538f7.18 `:defect`, which may itself name offending keys), three emitters stash it, and `spec/API.md` documents its shape under `:spec-summary`. That needs a ruling on what a definition's structural diagnostic may name, not a drive-by deletion. **Filed as rf2-oztox (P2).**

## Adversarial inputs

Hostile, not tidy. The sentinel is `hunter2-swordfish-SENTINEL`, and a leak is proved by any **8-character window** of it, not only the whole token — because a bounded prefix is exactly what a host parser message discloses.

- sentinel-bearing **map keys of every key type** transit carries: string, keyword, namespaced keyword, symbol, vector, **map-as-key**, number, boolean
- keys that are **markup and control characters**: `<script>alert(…)</script>`, an ANSI colour escape, CR/LF, a NUL byte
- an **attacker-sized 2000-key map**
- a keyword built from a **20×-repeated** sentinel — the leg with no bound at all
- a **4004-character** string, a 16-digit **card number**, booleans, `nil`
- nesting: map-of-map-of-set, vector-of-map-keyed-by-sentinel, sets, lists, a lazy seq
- a live **fn**, an opaque host object, a host object whose **`toString` throws**, and a map **keyed by** such an object
- a URL carrying the sentinel in a **query string** with no `#machine=` fragment
- a fragment whose decoded bytes are sentinel-bearing **non-transit**
- a forged `:v` of `"9999-<sentinel>"` (numeric path) and `"v<sentinel>"` (string-compare fallback)

## The capstone is a grammar, not a sentinel hunt

The section this replaces planted a secret in a **value** position and hunted for it, using a walk that collected **strings only**. It passed for as long as the `:keys` leg disclosed the payload anyway — because the leaked keys were keywords, which are not strings, in a key position nobody looked at. That is the failure mode being fixed, so the new assertions are universal:

- **`content-free-summary?`** — every summary must be a map whose key set is a subset of `#{:type :count}`, whose `:type` is in the closed vocabulary, and whose `:count` is a non-negative integer. Nothing else may appear, because every other slot would have to be derived from the input's content.
- **`discloses?`** — `pr-str` of the whole ex-data (and of the thrown message) must contain no 8-character window of the sentinel, under any key, at any depth, as a string, keyword, symbol or map key.
- **a fixed serialized bound** — the summary under 48 characters and the whole ex-data under 600, against payloads of ~50 KB; plus a growth pin asserting a 2000-key forged envelope throws ex-data no more than **4 characters** larger than a 2-key one (the digits of `:count`).

**A sixth leak fails those without anyone writing a sentinel for it.**

## Mutation proof

The witnesses were written and watched **failing** against unmodified `share.cljs` first, then the fix applied and watched green. `git diff` is empty against the committed state at the green run.

| | mutated (pre-fix source) | fixed |
|---|---|---|
| `machines-viz-node-test` compile | exit **0** — 250 files, 0 warnings | exit **0** — 250 files, 0 warnings |
| `machines-viz-node-test` run | exit **1** — 832 tests, 3470 assertions, **50 failures**, 0 errors | exit **0** — 832 tests, 3470 assertions, **0 failures, 0 errors** |

The mutated run prints the production leak verbatim — the whole key set, sentinels, markup, ANSI and control characters included:

```
FAIL in (encode-error-discloses-nothing-it-was-given)
expected: (content-free-summary? (:chart-state-summary d))
  actual: (not (content-free-summary?
            {:type :map,
             :keys ["<ESC>[31mhunter2-swordfish-SENTINEL<ESC>[0m" 4111111111111111
                    :definition :hunter2-swordfish-SENTINEL
                    :hunter2-swordfish-SENTINEL/hunter2-swordfish-SENTINEL
                    :machine-id :snapshot
                    "<script>alert(hunter2-swordfish-SENTINEL)</script>"
                    "CR\r\nLF-hunter2-swordfish-SENTINEL" ...],
             :count 15}))
```

and, for the exploding key, the summariser destroying the failure it was called to describe:

```
FAIL in (encode-error-discloses-nothing-it-was-given)
a chart-state key whose toString throws no longer destroys the failure being described
expected: (= :rf.machines-viz.share/encode-failed (:rf.error/id d))
  actual: (not (= :rf.machines-viz.share/encode-failed nil))
```

— `nil`, because what escaped `encode-share-url` was the key's own `Error`, not the documented ex-info.

## Quality gates

All foreground, worktree-local logs, exit codes echoed, nothing piped through `tail` / `grep`.

| Gate | Exit | Result |
|---|---|---|
| `machines-viz-node-test` — **mutated** | **1** | 832 tests, 3470 assertions, 50 failures, 0 errors (witness red) |
| `machines-viz-node-test` — **fixed** (`cljs-tools-machines-viz`) | **0** | 832 tests, 3470 assertions, 0 failures, 0 errors; compile 250 files, **0 warnings** |
| `tools/machines-viz` JVM (`clojure -M:test`, `tools_jvm_machines_viz`) | **0** | 632 tests, 2537 assertions, 0 failures, 0 errors |
| `npm run test:cljs` (consolidated node suite, inside the spine) | **0** | 12263 tests, 61442 assertions, 0 failures, 0 errors |
| clj-kondo **2026.04.15** (CI's pin, CI's flags, CI's full `--lint` set) | **0** | **errors: 0**, 4527 warnings (all pre-existing; the three `info`s in the touched files sit on lines this diff does not alter) |
| `scripts/check_doc_slugs.py` | **0** | clean |
| `scripts/test-fast-pr.sh` | **0** | **PASS fast PR spine** — every stage green, no flake, no re-run |

**Every row was then re-run after rebasing onto current `main`** (16 commits), and every one repeated its result: `machines-viz-node-test` exit **0** (832 / 3470, compile 250 files / 0 warnings), `tools/machines-viz` JVM exit **0** (632 / 2537), `scripts/test-fast-pr.sh` exit **0** (`PASS fast PR spine`, 12263 / 61442), clj-kondo 2026.04.15 exit **0** (errors: 0, 4527 warnings — byte-identical to the pre-rebase count), `check_doc_slugs.py` exit **0**.

The spine names what it did not run, and this is the full list: documentation gates (surface unchanged — `tools/machines-viz/spec/**` is not `docs/`), the JVM artefact tier (`implementation_jvm` surface unchanged — this diff touches no `implementation/` artefact), and the standing CI-only set (browser lanes, prod-elision / bundle-isolation / perf, adapter probes, Xray feature matrix, mcp-conformance, tool JVM suites). The two tool-JVM/CLJS lanes that *this* diff does light are run above by hand, since the spine never runs them.

**The known load flake did not appear.** `test_quiet_shadow_node_cljs_test` (rf2-hofhx) is green in both spine runs; nothing in this PR needed a re-run or a flake attribution.

**Matrix derivation (TESTING.md).** The diff touches `tools/machines-viz/{src,test}/**` and `tools/machines-viz/spec/API.md`. `TESTING.md` maps that surface to exactly two artefact gates: `tools_jvm_machines_viz` (any non-spec-`.md` change under `tools/machines-viz/**` → `jvm-tools-machines-viz`, which exists for `engine_grammar_parity_test.cljc` and `mermaid_public_smoke_test.cljc`) and `tools_cljs_machines_viz` (the same surface → `cljs-tools-machines-viz`, the artefact's own `:machines-viz-node-test` build declared in `tools/machines-viz/shadow-cljs.edn`). `share_cljs_test.cljs` also compiles into the consolidated `:node-test` bundle via the borrowed source root, so the spine's `cljs_node_test` stage carries it too — both lanes are run here. `mkdocs build --strict` is **not** the gate for `tools/machines-viz/spec/API.md`: `mkdocs.yml` has no machines-viz entry and the tree is not under `docs/`, so `scripts/check_doc_slugs.py` is what validates it — run above, exit 0. Nothing validates the tree's tables, so **the added 2-column table's column counts and the new `####` anchor were checked by hand** (all rows 2 columns; the heading resolves under the slug checker). No browser, bundle, Xray, MCP or perf gate is in any tier for this diff.
