### PR TITLE
spec,ssr: the form-POST path does not rest its validation on a dev-only check (rf2-eane2)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr_doc_example_form_action_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_doc_example_form_action_test.clj
@@ -1,0 +1,355 @@
+(ns re-frame.ssr-doc-example-form-action-test
+  "rf2-eane2 ACCEPTANCE — the `/cart/add` worked example printed in
+  `spec/Pattern-FormAction.md` is EXECUTED, not merely read.
+
+  WHY THIS SUITE EXISTS. Pattern-FormAction is a copyable example for the one
+  surface where getting it wrong is a security event: an HTML form POST, which
+  is untrusted input arriving on a production server. Two docs-only gates cover
+  the page — `scripts/check_doc_slugs.py` proves its links and anchors resolve,
+  `mkdocs build --strict` proves it renders — and neither can evaluate a single
+  form in it. The example drifted twice under exactly that blind spot:
+
+    - rf2-eane2 as filed: the page rested its whole validation story on the
+      `:schema` metadata key, which [010 §Production builds] compile-time
+      elides. The documented 400 could not happen on a release server.
+    - rf2-eane2 after the #7232 audit: the repaired example gave `:item-id`,
+      `:quantity` AND `:csrf-token` to one required-key schema, then pointed
+      the form slice's `:draft`, the event's `:schema`, and the handler's own
+      validation call at it. The hydrated client dispatches the draft WITHOUT
+      a token, so every post-hydration submission took the validation-failure
+      arm, 400'd, and never navigated — in production, because unlike the
+      `:schema` tripwire the handler's arm is ordinary code and does not
+      elide. The same schema also made `[:cart :add-form :draft]` unsatisfiable
+      by the page's own rule that the token must never enter that draft.
+
+  Both defects are invisible to a reader and to every gate the page had. Both
+  are caught below by DRIVING the documented handler, so this suite cannot
+  drift from the page: every schema, helper and branch under test is read out
+  of the markdown fences at run time rather than transcribed here. A rewritten
+  example that still works stays green; one that reintroduces either defect
+  goes red naming the arm.
+
+  WHAT `deftest`s 1-2 PROVE THAT A SCHEMA-ONLY CHECK COULD NOT. The defect was
+  never that a schema rejected a bad value — it was that the SHARED handler
+  reached different arms for the two legitimate call sites. So the shapes are
+  driven THROUGH the extracted handler fn and the arm it chose is asserted, not
+  merely `m/validate`d. The server POST shape is itself derived from the view
+  fence's `<input name=…>` attributes, which ties the HTML the browser submits
+  to the schema the handler validates — the cross-platform shape proof the
+  #7232 audit found missing.
+
+  POSTURE-INDEPENDENT. Every assertion is a pure function call on extracted
+  code: no frame, no dispatch, no trace bus, no `debug-enabled?` read. The
+  namespace therefore executes identically under `scripts/test-ssr-prod-gate.sh`'s
+  real `-Dre-frame.debug=false` gate and in the ordinary lane — which is the
+  posture that matters, since the defect it pins is specifically an arm whose
+  wrongness only shows up once the dev-only tripwire in front of it is gone."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [malli.core :as m]
+            [malli.error :as me]))
+
+;; ---------------------------------------------------------------------------
+;; Reading the worked example out of the page
+;; ---------------------------------------------------------------------------
+
+(def ^:private pattern-page
+  "`spec/Pattern-FormAction.md`, anchored to a CLASSPATH RESOURCE rather than
+  the working directory (rf2-ywrwkl; the same anchoring
+  `re-frame.ssr-doc-example-projector-test` uses for the API page). A
+  `(io/file \"../../spec/...\")` form would resolve correctly under the
+  per-artefact gate run from `implementation/ssr/` and silently MIS-SCOPE under
+  the combined `implementation/deps.edn :test` alias. This namespace's own
+  source is on the test classpath, so five parents
+  (`…_test.clj → re_frame → test → ssr → implementation → repo root`) reach the
+  repo root from wherever the JVM was started."
+  (let [res (io/resource "re_frame/ssr_doc_example_form_action_test.clj")]
+    (assert res
+            (str "ssr-doc-example-form-action-test cannot locate its own source "
+                 "on the classpath — the ssr test/ dir must be on the test "
+                 "classpath for the pattern page to be found."))
+    (-> (io/file res)
+        .getParentFile .getParentFile .getParentFile .getParentFile .getParentFile
+        (io/file "spec" "Pattern-FormAction.md")
+        .getCanonicalFile)))
+
+(defn- fence
+  "The text of the one ```clojure fence on the pattern page containing
+  `needle`. Hard-errors on zero or many matches, so a rewritten page fails
+  loudly rather than silently pinning nothing.
+
+  Line endings are normalised first: the page is stored LF but checks out CRLF
+  on a Windows dev box (`core.autocrlf`), and a `\\n`-only fence regex matches
+  zero blocks there while passing on the Linux CI runner."
+  [needle]
+  (let [md   (str/replace (slurp pattern-page) "\r\n" "\n")
+        hits (->> (re-seq #"(?s)```clojure\n(.*?)```" md)
+                  (map second)
+                  (filter #(str/includes? % needle)))]
+    (assert (= 1 (count hits))
+            (str "expected EXACTLY ONE ```clojure fence in " pattern-page
+                 " containing " (pr-str needle) ", found " (count hits)
+                 " — the pin has lost its anchor."))
+    (first hits)))
+
+(defn- forms
+  "Every top-level form in a fence. Wrapping in a vector is what gets all of
+  them; `read-string` alone would silently return only the first and pin a
+  fraction of the block. The reader drops the fence's `;;` commentary."
+  [fence-text]
+  (read-string (str "[" fence-text "]")))
+
+(def ^:private example
+  "The page's worked example, evaluated into THIS namespace.
+
+  Order is load-bearing: the schema `def`s must exist before the handler fn is
+  evaluated, because the handler's body resolves `AddToCartFields` by name, and
+  the two app-level helpers must exist before the handler is CALLED. Evaluating
+  the handler rather than transcribing it is the whole point — a transcription
+  is a second copy that drifts, which is how the page reached its second audit."
+  (delay
+    (binding [*ns* (find-ns 're-frame.ssr-doc-example-form-action-test)]
+      (let [schema-forms (forms (fence "(def AddToCartFields"))
+            helper-forms (forms (fence "defn write-form-errors"))
+            handler-form (first (forms (fence "rf/reg-event :cart/add-item")))]
+        ;; The two `def`s (skip the `reg-app-schema` calls — `rf` is not
+        ;; required here and `FormSlice` lives in Pattern-Forms).
+        (doseq [f schema-forms :when (= 'def (first f))]
+          (eval f))
+        ;; `write-form-errors` / `explain->errors`.
+        (doseq [f helper-forms :when (= 'defn (first f))]
+          (eval f))
+        (is (= 'rf/reg-event (first handler-form))
+            "the example still registers the action handler with reg-event")
+        {:fields     @(resolve 'AddToCartFields)
+         :submission @(resolve 'AddToCartSubmission)
+         ;; The event-args schema exactly as the page declares it, with
+         ;; `AddToCartSubmission` resolved from the metadata map.
+         :event-schema (eval (:schema (nth handler-form 2)))
+         ;; The registration form's last element is the handler fn.
+         :handler    (eval (last handler-form))
+         ;; The symbol the page types the form slice's `:draft` with.
+         :draft-schema-sym (->> schema-forms
+                                (filter #(= [:cart :add-form :draft] (second %)))
+                                first
+                                (#(nth % 2)))}))))
+
+;; ---------------------------------------------------------------------------
+;; The two canonical call sites, derived from the page rather than invented
+;; ---------------------------------------------------------------------------
+
+(def ^:private posted-field-names
+  "The `name` attributes the documented form actually submits, read off the
+  view fence's `<input>` elements. This is what a browser POSTs with JS off."
+  (delay
+    (->> (re-seq #":name\s+\"([^\"]+)\"" (fence "rf/reg-view add-to-cart-form"))
+         (map second)
+         (map keyword)
+         set)))
+
+(def ^:private server-post
+  "The canonical no-JS POST body: every field the HTML form carries."
+  {:item-id "sku-1" :quantity 2 :csrf-token "tok-abc"})
+
+(def ^:private client-dispatch
+  "The canonical hydrated-client payload: the draft plus the view's `item-id`,
+  and deliberately NO token — the browser has no session token to add."
+  {:item-id "sku-1" :quantity 2})
+
+(defn- invoke
+  "Call the documented handler the way the runtime would. Both declared
+  coeffects are `:platforms #{:server}`, so on the client neither key is
+  present — key ABSENCE is the platform boundary the handler tests, and
+  building the cofx map this way is what makes the client arm reachable here."
+  [{:keys [server? active-token db] :or {db {}}} form-params]
+  ((:handler @example)
+   (cond-> {:db db}
+     server? (assoc :rf.server/request      {:request-method :post :uri "/cart/add"}
+                    :app.csrf/active-token  active-token))
+   [:cart/add-item form-params]))
+
+;; ===========================================================================
+;; (1) THE REGRESSION: the hydrated client reaches the SUCCESS arm
+;; ===========================================================================
+
+(deftest the-hydrated-client-submission-navigates-rather-than-400ing
+  (testing "rf2-eane2 (#7232 audit): the client dispatches the draft with no
+            CSRF token. When the handler validated that payload against a
+            token-REQUIRING schema, every client submission took the
+            validation-failure arm — a 400 and no navigation, in production,
+            because the handler's arm is ordinary code and does not elide.
+            The success arm is the assertion; reaching it is the whole fix."
+    (let [{:keys [db fx]} (invoke {:server? false} client-dispatch)]
+      (is (= [[:dispatch [:rf.route/navigate {:to :route/cart}]]] fx)
+          "the client arm navigates — it did not fall into the 400 arm")
+      (is (= [client-dispatch] (get-in db [:cart :items]))
+          "and the item actually reached the cart")
+      (is (nil? (get-in db [:cart :add-form :errors]))
+          "no errors were written on a clean client submission"))))
+
+(deftest the-no-js-post-reaches-the-same-success-arm
+  (testing "rf2-eane2: the other legitimate call site. The server POST carries
+            one extra key — the token — and must be accepted by the same
+            handler and the same field schema, then answered with the canonical
+            POST-redirect-GET."
+    (let [{:keys [db fx]} (invoke {:server? true :active-token "tok-abc"} server-post)]
+      (is (= [[:rf.server/redirect {:status 303 :location "/cart"}]] fx)
+          "the server arm emits the 303, not the client's :dispatch")
+      (is (= [{:item-id "sku-1" :quantity 2}] (get-in db [:cart :items]))
+          "the cart holds the EDITABLE FIELDS only — the token was never
+           written into app-db"))))
+
+;; ===========================================================================
+;; (2) The shapes are the ones the page's own HTML and schemas describe
+;; ===========================================================================
+
+(deftest the-post-body-the-form-submits-is-the-shape-the-schemas-name
+  (testing "rf2-eane2 (#7232 COMPLETENESS): nothing tied the HTML the browser
+            POSTs to the schema the handler validates. These assertions are
+            that tie — derived from the view fence, not transcribed."
+    (let [{:keys [fields submission]} @example
+          entry-keys (fn [s] (set (map first (m/children (m/schema s)))))]
+      (is (= #{:csrf-token :item-id :quantity} @posted-field-names)
+          "the documented form still submits exactly these three inputs")
+      (is (= @posted-field-names (entry-keys submission))
+          "and the event-args schema names exactly them — no field the form
+           posts is unnamed, no key the schema names is unposted")
+      (is (= #{:item-id :quantity} (entry-keys fields))
+          "while the FIELD schema names only the editable fields")
+      (is (not (contains? (entry-keys fields) :csrf-token))
+          "the token is absent from the field schema — this is the split the
+           #7232 audit required, and the assertion that fails first if one
+           schema is ever pointed at both jobs again"))))
+
+(deftest both-call-sites-satisfy-the-field-schema-and-the-event-tripwire
+  (testing "rf2-eane2: the field schema validates BOTH payloads (Malli maps are
+            open, so the server's extra token passes through), and the dev-time
+            event `:schema` admits both dispatch shapes. The tripwire rejecting
+            the client was the second half of the audit's CORRECTNESS finding."
+    (let [{:keys [fields event-schema]} @example]
+      (is (m/validate fields client-dispatch)
+          "field schema accepts the client draft")
+      (is (m/validate fields server-post)
+          "field schema accepts the server POST body unchanged")
+      (is (m/validate event-schema [:cart/add-item client-dispatch])
+          "the dev tripwire admits the client dispatch — it did not before")
+      (is (m/validate event-schema [:cart/add-item server-post])
+          "and the server POST")
+      (is (not (m/validate fields (assoc client-dispatch :quantity 0)))
+          "the field schema still REJECTS a bad quantity — the split did not
+           soften the check it exists to make"))))
+
+(deftest the-token-is-marked-sensitive-on-the-surface-it-travels-through
+  (testing "rf2-eane2: `:rf/server-init` dispatches the whole POST body as the
+            event args, and 010 says a schema-validation-failure trace carries
+            the failing value VERBATIM. The token therefore needs its
+            `:sensitive?` mark on the event-args schema — the page previously
+            told the reader to mark an app-db slot that this pattern
+            deliberately never writes."
+    (let [{:keys [submission]} @example
+          props (->> (m/children (m/schema submission))
+                     (filter #(= :csrf-token (first %)))
+                     first
+                     second)]
+      (is (true? (:sensitive? props))
+          ":csrf-token is marked :sensitive? so the dev-time event-args trace
+           redacts it")
+      (is (true? (:optional props))
+          "and :optional, which is what lets ONE registration admit both the
+           server POST and the token-less client dispatch"))))
+
+;; ===========================================================================
+;; (3) The failure arm writes a draft its own registered schema accepts
+;; ===========================================================================
+
+(deftest the-failure-arm-writes-a-draft-that-satisfies-the-registered-schema
+  (testing "rf2-eane2 (#7232): the page registers a schema for
+            `[:cart :add-form :draft]` and separately rules that the token must
+            never enter that draft. When both pointed at the token-requiring
+            schema the canonical draft was invalid BY CONSTRUCTION. Proven here
+            against what the real handler writes, not against a transcription."
+    (let [{:keys [fields draft-schema-sym]} @example
+          bad-post (assoc server-post :quantity 0)
+          {:keys [db fx]} (invoke {:server? true :active-token "tok-abc"} bad-post)
+          drafted  (get-in db [:cart :add-form :draft])]
+      (is (= 'AddToCartFields draft-schema-sym)
+          "the draft is typed with the FIELD schema, not the POST envelope")
+      (is (= [[:rf.server/set-status 400]] fx)
+          "a malformed POST is answered 400 by the handler's own arm")
+      (is (= {:item-id "sku-1" :quantity 0} drafted)
+          "the submitted values went back into the draft — with JS off the
+           re-render reads the SLICE, so without this the user's input is lost")
+      (is (not (contains? drafted :csrf-token))
+          "and the token did NOT, because the page re-renders this slice")
+      (is (m/validate fields (assoc drafted :quantity 1))
+          "the draft the arm writes is a value the registered draft schema can
+           accept — it is not unsatisfiable by construction")
+      (is (seq (get-in db [:cart :add-form :errors]))
+          "errors were written beside it")
+      (is (nil? (get-in db [:cart :items]))
+          "and the cart was not touched"))))
+
+(deftest client-side-validation-failure-takes-the-same-arm
+  (testing "rf2-eane2: the field validation is not server-only — the same arm
+            must catch a malformed client draft. The fix must not have turned
+            the client path into an unvalidated one."
+    (let [{:keys [db fx]} (invoke {:server? false} (assoc client-dispatch :quantity 0))]
+      (is (= [[:rf.server/set-status 400]] fx)
+          "the client takes the validation arm too")
+      (is (nil? (get-in db [:cart :items]))
+          "and nothing reached the cart"))))
+
+;; ===========================================================================
+;; (4) The CSRF arm fails CLOSED on both limbs
+;; ===========================================================================
+
+(deftest the-csrf-arm-rejects-a-mismatched-token
+  (testing "rf2-eane2: the baseline the page always claimed — a submitted token
+            that does not match the session's is a 403, before any mutation."
+    (let [{:keys [db fx]} (invoke {:server? true :active-token "tok-abc"}
+                                  (assoc server-post :csrf-token "tok-WRONG"))]
+      (is (= [[:rf.server/set-status 403]] fx) "403, not 400 and not success")
+      (is (nil? (get-in db [:cart :items])) "no state mutation"))))
+
+(deftest the-csrf-arm-fails-closed-when-the-request-carries-no-session
+  (testing "rf2-eane2: a bare `(not= submitted active-token)` compares nil to
+            nil on a session-less request and WAVES A TOKEN-LESS POST THROUGH.
+            The page held this arm up as the model the validation arm should
+            copy, so a fail-open here undercuts the whole section. Both limbs
+            must hold: session token present AND equal."
+    (let [{:keys [db fx]} (invoke {:server? true :active-token nil}
+                                  (dissoc server-post :csrf-token))]
+      (is (= [[:rf.server/set-status 403]] fx)
+          "no session ⇒ 403; nil = nil must NOT read as a valid token")
+      (is (nil? (get-in db [:cart :items]))
+          "and emphatically no cart mutation"))))
+
+(deftest the-csrf-arm-does-not-fire-on-the-client
+  (testing "rf2-eane2: the CSRF arm is guarded on coeffect PRESENCE. Ungated it
+            would measure every client submission against an absent cofx and
+            403 all of them — the mirror image of the bug this bead fixes."
+    (let [{:keys [fx]} (invoke {:server? false} client-dispatch)]
+      (is (not= [[:rf.server/set-status 403]] fx)
+          "the client never takes the CSRF arm"))))
+
+;; ---------------------------------------------------------------------------
+;; The helpers the page publishes are the ones driven above
+;; ---------------------------------------------------------------------------
+
+(deftest the-published-helpers-produce-the-shapes-pattern-forms-expects
+  (testing "rf2-eane2: `write-form-errors` / `explain->errors` are printed on
+            the page as app-owned code a reader copies. They are executed by
+            every assertion above; this one names their contract directly."
+    (binding [*ns* (find-ns 're-frame.ssr-doc-example-form-action-test)]
+      @example
+      (let [explain->errors (resolve 'explain->errors)
+            errors (explain->errors (m/explain (:fields @example)
+                                               (assoc client-dispatch :quantity 0)))]
+        (is (map? errors) "a per-field error map, as Pattern-Forms expects")
+        (is (contains? errors :quantity)
+            "keyed by the failing field, so the view can render it beside the input")
+        (is (= (me/humanize (m/explain (:fields @example)
+                                       (assoc client-dispatch :quantity 0)))
+               errors)
+            "and it is the humanized explanation, not a re-shaped copy")))))

--- a/spec/Pattern-FormAction.md
+++ b/spec/Pattern-FormAction.md
@@ -30,18 +30,59 @@ A cart page lets the user add an item to their basket from a product-detail card
 
 ### The form schema and slice
 
+Two shapes reach the action handler, and they are not the same shape. The no-JS
+POST body carries the editable fields **plus a CSRF token**; the hydrated
+client dispatches the editable fields **alone**. One schema describes what they
+share, and it is the one everything else is built from.
+
 ```clojure
-(def AddToCartForm
+;; The editable fields — what the user may type, what the form slice's :draft
+;; holds, and what BOTH platforms submit. This is the schema the handler
+;; validates against.
+(def AddToCartFields
   [:map
-   [:item-id   [:string {:min 1}]]
-   [:quantity  [:and :int [:>= 1] [:<= 99]]]
-   [:csrf-token [:string {:min 1}]]])
+   [:item-id  [:string {:min 1}]]
+   [:quantity [:and :int [:>= 1] [:<= 99]]]])
+
+;; What the event ACCEPTS, on either platform: the fields, plus the token the
+;; server POST carries and the client does not. `:optional` is what makes one
+;; registration admit both call sites; `:sensitive?` keeps the token out of the
+;; dev-time validation trace, which would otherwise carry the event args
+;; verbatim ([010 §`:sensitive?`](010-Schemas.md#sensitive--privacy-in-schema-validation-error-traces)).
+(def AddToCartSubmission
+  (conj AddToCartFields
+        [:csrf-token {:optional true :sensitive? true} [:string {:min 1}]]))
 
 (rf/reg-app-schema [:cart :add-form]        FormSlice)
-(rf/reg-app-schema [:cart :add-form :draft] AddToCartForm)
+(rf/reg-app-schema [:cart :add-form :draft] AddToCartFields)   ;; the fields, never the token
 ```
 
 (`FormSlice` is the standard slice from [Pattern-Forms §Form slice](Pattern-Forms.md#the-form-slice).)
+
+**Why the token is not a field.** It is tempting to write one schema with
+`:csrf-token` required and point everything at it. That single decision breaks
+the pattern in three places at once, and each break is silent:
+
+- **The draft would have to hold a secret.** `[:cart :add-form :draft]` is
+  re-rendered into the page on every failure, and the token is a credential.
+  The failure arm below deliberately writes only the editable fields, so a
+  draft typed with a token-bearing schema is invalid by construction — its own
+  canonical value can never satisfy it.
+- **The client's own dev tripwire would reject the client.** The hydrated
+  `:on-submit` has no session token to add. An event `:schema` that requires
+  one fails every post-hydration submission in development.
+- **The client would never get past validation in production.** The handler's
+  validation arm runs on both platforms. Against a token-requiring schema every
+  client submission takes the failure arm, so the form 400s and never
+  navigates — and because the arm is ordinary handler code, that one is *not*
+  elided in a release build. It is the shipped behaviour.
+
+The token is not form state and not a field; it is a per-request credential
+that belongs to the POST envelope. It gets the check it actually deserves — an
+equality compare against the session's active token, in the server-guarded CSRF
+arm — which is strictly stronger than any string schema could be. Malli maps
+are open, so `AddToCartFields` validates the server's POST body unchanged; the
+extra key simply passes through to the arm that owns it.
 
 ### The view (runs on both platforms)
 
@@ -54,6 +95,9 @@ A cart page lets the user add an item to their basket from a product-detail card
     [:form
      {:method    "POST"
       :action    (str "/cart/add")
+      ;; The fields only. No token: there is no session token to read in the
+      ;; browser, and a same-frame dispatch crosses no trust boundary. The
+      ;; hidden input below still renders, because the NO-JS path needs it.
       :on-submit (fn [e]
                    (.preventDefault e)
                    (dispatch [:cart/add-item (assoc draft :item-id item-id)]))}
@@ -101,7 +145,11 @@ The `action` attribute is what makes the form work without JS: the browser will 
 
 (rf/reg-event :cart/add-item
   {:doc              "Add an item to the user's cart. Runs on both platforms; the POST entry point lives on the server."
-   :schema           [:cat [:= :cart/add-item] AddToCartForm]  ;; DEV TRIPWIRE ONLY — elided in production (010 §Production builds)
+   ;; DEV TRIPWIRE ONLY — elided in production (010 §Production builds). It
+   ;; admits BOTH call sites: the server's POST body (fields + token) and the
+   ;; client's dispatch (fields alone). `:csrf-token` is `:optional` in
+   ;; `AddToCartSubmission` precisely so this one registration covers both.
+   :schema           [:cat [:= :cart/add-item] AddToCartSubmission]
    :rf.cofx/requires [:rf.server/request                       ;; server request context — SERVER-ONLY, see below
                       :app.csrf/active-token]}                 ;; app-owned cofx — see §CSRF
   (fn [{:keys [db] :as cofx} [_ form-params]]
@@ -112,7 +160,12 @@ The `action` attribute is what makes the form work without JS: the browser will 
           ;; request slot is a legitimately nil value under a present key.
           server?      (contains? cofx :rf.server/request)
           active-token (:app.csrf/active-token cofx)
-          explanation  (m/explain AddToCartForm form-params)   ;; nil when the form is clean
+          ;; The FIELDS, on both platforms — not the envelope. Malli maps are
+          ;; open, so the server's extra `:csrf-token` passes straight through
+          ;; to the CSRF arm, which is the thing that actually checks it.
+          ;; Validating the token here instead would 400 every client
+          ;; submission, which is the one arm production does NOT elide.
+          explanation  (m/explain AddToCartFields form-params) ;; nil when the fields are clean
           ;; The editable fields, and only those. `:csrf-token` is a secret
           ;; carrier and never belongs in a slice the page re-renders — the
           ;; view emits a fresh one from the session on every render.
@@ -122,7 +175,11 @@ The `action` attribute is what makes the form work without JS: the browser will 
         ;; `server?`: the token check belongs to the POST entry point, and on
         ;; the client `active-token` is absent, so an unguarded compare would
         ;; measure every client submission against nil and 403 all of them.
-        (and server? (not= (:csrf-token form-params) active-token))
+        ;; BOTH limbs must hold. A bare `(not= submitted active-token)` fails
+        ;; OPEN on a request with no session: `active-token` is nil, a POST
+        ;; carrying no token is nil, and nil = nil would wave it through.
+        (and server? (not (and (some? active-token)
+                               (= (:csrf-token form-params) active-token))))
         {:db (assoc-in db [:cart :add-form :errors :_form]
                        ["Session expired. Please refresh and try again."])
          :fx [[:rf.server/set-status 403]]}
@@ -167,11 +224,13 @@ The success path **chooses** its destination; it does not emit both and let the 
 
 A form POST is untrusted input arriving on a production server, and the response it deserves — `400`, plus the form re-rendered with inline errors and the user's values still in the fields — has to be produced by code that is actually in the production build. The handler's own `cond` arm is that code. Three framework surfaces sit close enough to be mistaken for it, and it is worth being precise about how far each one gets:
 
-- **`:schema` on `reg-event` is a tripwire, not a guard.** Per [010 §Production builds](010-Schemas.md#production-builds), every dev-time validation site is compile-time eliminated under `:advanced` + `goog.DEBUG=false` (and on the JVM under `-Dre-frame.debug=false`). On a production server the `:schema` check never runs, and a POST body that violates `AddToCartForm` flows straight into the handler body. Keep the `:schema` — it catches the day someone deletes the branch, and it is what tools and agents introspect — but never let it be the check. This one gets nowhere in production.
+- **`:schema` on `reg-event` is a tripwire, not a guard.** Per [010 §Production builds](010-Schemas.md#production-builds), every dev-time validation site is compile-time eliminated under `:advanced` + `goog.DEBUG=false` (and on the JVM under `-Dre-frame.debug=false`). On a production server the `:schema` check never runs, and a POST body that violates `AddToCartSubmission` flows straight into the handler body. Keep the `:schema` — it catches the day someone deletes the branch, and it is what tools and agents introspect — but never let it be the check. This one gets nowhere in production.
 - **`:rf.schema/at-boundary` gets you a status, not a page.** The boundary interceptor ([010 §Production builds](010-Schemas.md#production-builds)) forces the `:schema` check past elision: its check is ungated and runs in every build, which is exactly right for an untrusted HTTP response or websocket frame. A rejection in a release build is real and it is visible — the handler is skipped so the payload never reaches `app-db`, one always-on structural `:rf.error/schema-validation-failure` record is fanned (`:source :boundary`, identifiers only — no event vector, no offending value, because a boundary payload is attacker-controlled by definition), the event-emit record settles `:outcome :rejected`, and the SSR error projector turns that record into a `400` ([011 §Server error projection](011-SSR.md#server-error-projection)). What the interceptor cannot do is *shape* the answer. A skipped handler writes no `:errors`, keeps no submitted values, and re-renders no form, so the user is handed a generic public-error body instead of their own form back. Reach for `:rf.schema/at-boundary` on the fire-and-forget ingress events described in 010, where a status is the whole answer owed; on a form action, write the branch.
 - **The error projector answers in the public-error shape, which is not a form.** [011 §Server error projection](011-SSR.md#server-error-projection) maps `:rf.error/schema-validation-failure` to a `400`, and that arm does reach a release server — but only via the record a boundary rejection fans, because that is the only schema-validation failure a production build still produces. It never sees a `:schema` step-1 failure, since in production there is no step-1 check left to fail. And what it emits is a status and a generic body. The field errors above the inputs, and the values the user typed, come from the handler's `[:rf.server/set-status 400]` and the slice it wrote.
 
 So the gap the handler's arm closes is not "nothing else runs" — under [000 §C-000.35](000-Vision.md#contract--pattern-obligations) what the *programmer* declares is a development aid and elides, while what the *framework* promises about its own boundaries holds in every build, and the boundary interceptor is one of the latter. The gap is narrower and more stubborn: a form action owes the user a *page*, and only handler code can compose one. The CSRF check in the worked example above was always written this way — an explicit arm, failing closed with its own status — and form validation is the same kind of rule, so it gets the same shape.
+
+The two arms check different things, and keeping them separate is what lets one handler serve both platforms. The **fields** arm validates `AddToCartFields` on every submission, server and client alike. The **credential** arm validates the token, on the server alone, by comparing it to the session. Fold the credential into the field schema and the client — which has no token to send — fails its own validation on every submit, in production, where nothing elides the arm that rejects it.
 
 ### Failure path — re-render with errors
 
@@ -225,7 +284,11 @@ An app-owned `:app.csrf/active-token` cofx exposes the session token to action h
 
 Token rotation, double-submit-vs-sync-pattern, and cookie attributes (`SameSite=Lax`, `HttpOnly`, `Secure`) are host concerns — the pattern names *where* the check happens (in the action handler, before any state mutation), not *which* token scheme the app uses.
 
-The CSRF token field is also on the `[:rf.http :sensitive-headers]` denylist via the `X-CSRF-Token` / `X-XSRF-Token` entries in the standard set ([014 §Header denylist](014-HTTPRequests.md#1-header-denylist-always-on)) — when the token is carried in a request header (the JS-fetch path), the redaction is automatic. When carried in a form-body field that lands in `app-db`, mark the token's app-db slot sensitive at the schema — `[:csrf-token {:sensitive? true} [:string {:min 1}]]` — so a schema-validation-failure trace redacts the value at that path ([010 §`:sensitive?` — privacy in schema-validation error traces](010-Schemas.md#sensitive--privacy-in-schema-validation-error-traces)). Sensitivity is path-marked at the data value, not declared on the handler that touched it.
+The CSRF token field is also on the `[:rf.http :sensitive-headers]` denylist via the `X-CSRF-Token` / `X-XSRF-Token` entries in the standard set ([014 §Header denylist](014-HTTPRequests.md#1-header-denylist-always-on)) — when the token is carried in a request header (the JS-fetch path), the redaction is automatic.
+
+In the form-body path it is not automatic, and the slot to mark is **not** an `app-db` slot. This pattern deliberately keeps the token out of `app-db` altogether: the failure arm's `select-keys` writes the editable fields and nothing else, so there is no persisted slot to declare sensitive. What the token *does* travel through is the **event args** — `:rf/server-init` dispatches the whole POST body as `[:cart/add-item form-params]` — and a dev-time `:schema` failure on that event carries the args verbatim. That is why `AddToCartSubmission` marks its `:csrf-token` entry `{:sensitive? true}`: it is the schema at the path the token actually occupies, and the mark is what redacts it out of the `:rf.error/schema-validation-failure` trace ([010 §`:sensitive?` — privacy in schema-validation error traces](010-Schemas.md#sensitive--privacy-in-schema-validation-error-traces)). Sensitivity is path-marked at the data value, not declared on the handler that touched it — so it goes on the schema describing the shape the secret is *in*, whichever surface that is.
+
+(A form whose secret genuinely must persist — a password held in a draft across a wizard step, say — marks the `app-db` slot instead, at the schema registered for that path. The rule is the same; only the surface differs.)
 
 ## File uploads — multipart POST
 
@@ -256,8 +319,10 @@ The `:cart/add-item` event runs unchanged on both platforms — one registration
 |---|---|---|
 | Dispatch site | `:rf/server-init`'s POST branch | view's `:on-submit` handler |
 | Source of `form-params` | parsed by host adapter from POST body | the view's `:draft` slice (Pattern-Forms) |
+| Shape of `form-params` | fields **+ `:csrf-token`** (the POST envelope) | fields **alone** — the browser has no session token |
+| Field validation | `(m/explain AddToCartFields form-params)` | identical — same call, same schema, both platforms |
 | `:rf.server/request` cofx | delivered | **absent** (platform-skipped) — this is the platform test |
-| CSRF check | compares against the app-owned `:app.csrf/active-token` cofx | not run — the cofx is server-only, and the submission crosses no trust boundary |
+| CSRF check | compares against the app-owned `:app.csrf/active-token` cofx, failing closed when either side is absent | not run — the cofx is server-only, and the submission crosses no trust boundary |
 | Success effect | `[:rf.server/redirect …]` (full-page navigation) | `[:dispatch [:rf.route/navigate {:to :route/cart}]]` (SPA navigation, shipped routing event) |
 | Failure render | `render-to-string` re-emits the page with errors, fields repopulated from `:draft` | the form view's existing error subs re-render in place |
 
@@ -296,6 +361,8 @@ An action without a form slice (a pure-API endpoint sharing the action-event sur
 - **Skipping the `action` attribute.** A form without `method` and `action` only works with JS — the progressive-enhancement guarantee breaks. Always emit the attributes; the `:on-submit` interceptor is purely additive.
 - **Validating only on the client.** Client validation is for UX; the server is the authority. The action handler MUST re-check the POST body in its own body — never trust what the browser sent.
 - **Letting `:schema` be the server-side validation.** The commonest way to ship an unvalidated form endpoint: declare `:schema` on the action handler, read it as "the framework checks this", and write no branch. It is a dev tripwire and is absent from the production build ([010 §Production builds](010-Schemas.md#production-builds)), so the endpoint that passes every test accepts anything in production. Attaching `:rf.schema/at-boundary` gets you further than nothing — the interceptor's check is ungated, so the payload is refused and the projector answers 400 — but it skips the handler, so the user gets a generic error body instead of their form back, with everything they typed gone. See [§Validation is the handler's job](#validation-is-the-handlers-job).
+- **Requiring the CSRF token in the form's field schema.** One `[:map … [:csrf-token [:string {:min 1}]]]` pointed at the draft, the event `:schema`, and the handler's validation call looks like admirable economy and is a live production bug. The hydrated client submits no token, so the handler's own validation arm rejects every client submission — and that arm is ordinary handler code, so unlike the `:schema` tripwire it is *not* elided; the form 400s in the release build and never navigates. The same schema also makes the draft unsatisfiable, since the failure arm must not write a secret into a slice the page re-renders. Type the draft and the validation call with the **fields**; let the token be `{:optional true :sensitive? true}` on the event-args schema and check it in the server-guarded CSRF arm.
+- **Comparing the submitted token against the session token with `not=` alone.** `(not= (:csrf-token form-params) active-token)` fails **open** on a request with no session: `active-token` is `nil`, an attacker's token-less POST supplies `nil`, and the arm does not fire. Require both: the session token present, *and* equal to the submitted one.
 - **Emitting the redirect and the navigate together.** The tempting shape is one `:fx` vector carrying both, on the theory that each platform no-ops the one it does not own. Only half of that is true. `:platforms` gating is a `reg-fx` / `reg-cofx` property ([011 §`:platforms` metadata on `reg-fx`](011-SSR.md#platforms-metadata-on-reg-fx)), so `:rf.server/redirect` really does lapse on the client — but `:rf.route/navigate` is an event reached through `:dispatch`, and `:dispatch` has no platform gate, so on the server it runs: route slice written, destination route work possibly fired, no browser history behind it. Choose one arm per platform from the presence of a server-only coeffect key.
 - **Deciding the platform by truthiness instead of key presence.** `(if request …)` looks equivalent to `(if (contains? cofx :rf.server/request) …)` and is not. A platform-skipped supplier delivers no key; a supplier that *ran* on the server and found its slot unpopulated delivers the key carrying `nil`. Under truthiness the second case reads as "client" and dispatches a browser navigation on a request thread.
 - **Inventing an app-owned effect for a plain URL.** `[:rf.route/navigate {:url "/cart"}]` is shipped — `:url` is the raw-URL escape in the navigate request grammar, exclusive with `:to`. An app-owned navigation effect earns its place only when you mean to bypass the router outright (hard `window.location`, external redirect). And do not reach for a navigate fx under `:rf.nav/*`: the framework ships none.
@@ -309,11 +376,12 @@ An action without a form slice (a pure-API endpoint sharing the action-event sur
 A form-action implementation conforms to this convention when:
 
 - The form HTML carries both `method="POST"` and `action="/<route>"`; submit-handler interception is purely additive on top.
-- The form carries a CSRF token in a hidden `<input>` field with name `csrf-token` (or via header for JS-fetch submits); the action handler MUST verify it on the server, before any state mutation.
+- The form carries a CSRF token in a hidden `<input>` field with name `csrf-token` (or via header for JS-fetch submits); the action handler MUST verify it on the server, before any state mutation. The check fails closed on **both** limbs — it MUST reject when the session carries no active token, not merely when the two differ.
+- The field schema and the POST envelope are **distinct**. The editable-field schema types the form slice's `:draft` and is what the handler validates on both platforms; the token appears only on the event-args schema, `{:optional true}` so one registration admits both call sites, and `{:sensitive? true}` so a dev-time validation trace does not carry it. A schema that requires the token of every submission is non-conformant: it rejects the hydrated client in production and makes the draft unsatisfiable.
 - The host adapter parses POST bodies (form-urlencoded and multipart) and binds them to `*current-request*` under a `:form-params` slot.
 - `:rf/server-init` routes GET → page loader; POST → action event. Apps MAY collapse the two when the route's action and loader share an event.
 - The action handler validates `form-params` **in its own body** and branches on the result. This check is what runs on a production server; it is NEVER skipped, even when client validation matches.
-- The action handler ALSO carries a `:schema` matching the form schema, as the dev tripwire and the introspection surface — but the conformance criterion above is not satisfied by the `:schema` alone ([010 §Production builds](010-Schemas.md#production-builds)).
+- The action handler ALSO carries a `:schema` describing what the event accepts — the fields plus the optional token — as the dev tripwire and the introspection surface. It MUST admit both call sites: the server's POST envelope and the client's field-only dispatch. The conformance criterion above is not satisfied by the `:schema` alone ([010 §Production builds](010-Schemas.md#production-builds)).
 - On validation failure, the handler repopulates the per-form slice's `:draft` from the submitted fields — editable fields only, never a token or other secret carrier — populates its `:errors` map, emits `[:rf.server/set-status 400]`, and the page re-renders. Without the `:draft` write the no-JS path returns a blank form, since the server renders the fields from the slice and not from the POST body.
 - On success, the handler emits `[:rf.server/redirect {:status 303 :location "..."}]`.
 - When the form's fields carry credentials, PII, or other secrets, the credential-bearing app-db slots MUST be marked `{:sensitive? true}` at the schema so a schema-validation-failure trace redacts the value at that path ([010 §`:sensitive?` — privacy in schema-validation error traces](010-Schemas.md#sensitive--privacy-in-schema-validation-error-traces)); on the JS-fetch submit path, the re-POST via `:rf.http/managed` additionally carries the per-request / per-call `:sensitive?` flag ([014 §Per-request / per-call `:sensitive?`](014-HTTPRequests.md#3-per-request--per-call-sensitive)). Sensitivity is a property of the data value at a path, not a flag on the action handler.


### PR DESCRIPTION
Closes rf2-eane2.

## What was actually wrong

The bead was reopened by the **#7232 merged-PR audit**, and the live scope is that audit's note, not the original filing. The original defect — the pattern resting its 400 on the production-elided `:schema` — was fixed by the earlier passes, and I verified the four sibling sites the filing listed are already corrected (`Pattern-RemoteData:277`, `Pattern-Forms:54-55`, `Construction-Prompts:638`, `Conventions.md:323`). No change was needed to any of them.

What the audit found is a different and sharper defect, and I confirmed all of it from the page:

`AddToCartForm` required `:item-id`, `:quantity` **and** `:csrf-token`, and one schema was pointed at three surfaces at once — the form slice's `:draft`, the event's `:schema`, and the handler's own `(m/explain …)` call. The hydrated `:on-submit` dispatches `(assoc draft :item-id item-id)` and deliberately carries no token. So:

1. **The client never got past validation in production.** The handler ran `(m/explain AddToCartForm form-params)` unconditionally, so every post-hydration submission took the validation-failure arm — 400, no navigation. That arm is ordinary handler code, so unlike the `:schema` tripwire it does **not** elide. This was shipped behaviour, not a dev-only wrinkle.
2. **The dev tripwire rejected the same legitimate dispatch**, before the handler.
3. **The canonical draft was invalid by construction.** `[:cart :add-form :draft]` was registered against the token-requiring schema while the page repeatedly rules that the token must never enter that draft — and the failure arm writes `(select-keys form-params [:item-id :quantity])`, which can never satisfy it.

**Which kind of fix this is:** the page's *code* was wrong, not merely its prose. The production form-POST path does have a real, unconditional guard — the handler's own `cond` arm, which the earlier pass correctly installed — but that guard was checking the wrong schema, and the resulting rejection of every client submission is live production behaviour.

## The fix

One schema for the editable fields; the token is not a field.

- **`AddToCartFields`** (`:item-id`, `:quantity`) types the `:draft` and is what the handler validates **on both platforms**. Malli maps are open, so it accepts the server's POST body unchanged and the extra `:csrf-token` passes through to the arm that owns it.
- **`AddToCartSubmission`** — a plain `conj` onto the fields, so no `malli.util` dependency — adds `[:csrf-token {:optional true :sensitive? true} [:string {:min 1}]]` and serves as the event-args schema. `:optional` is what lets one registration admit both call sites. `:sensitive?` is a real bug fix in its own right: `:rf/server-init` dispatches the whole POST body as the event args, 010 says a schema-validation-failure trace carries the failing value verbatim, and the token was previously unmarked on the one surface it actually travels through. The page's own advice pointed at an app-db slot this pattern deliberately never writes.
- The token keeps the check it deserves — an equality compare against the session token, in the already-server-guarded CSRF arm, which is strictly stronger than any string schema.

**One adjacent fix, flagged deliberately.** The CSRF arm the page holds up as the model for the validation arm to copy **failed open**. `(not= (:csrf-token form-params) active-token)` compares `nil` to `nil` on a session-less request, so a token-less POST was waved straight through to the cart. Both limbs are now required. I judged this in scope because the page claims this arm "fails closed" three times and it is the arm the whole §Validation-is-the-handler's-job section reasons from; a fail-open there undercuts the fix. Called out here so it can be split if you disagree.

Prose, the anti-pattern list, the server/client table and the conformance checklist were all brought into line, including two new anti-patterns naming both defects.

## The executable witness

The audit's COMPLETENESS finding was that "no executable witness checks that the canonical no-JS POST shape and hydrated-client dispatch shape are both accepted by the shared handler/schema".

New `implementation/ssr/test/re_frame/ssr_doc_example_form_action_test.clj`, following the `ssr_doc_example_projector_test` precedent: every schema, helper and branch under test is **read out of the markdown fences at run time and evaluated**, so it cannot drift from the page. The server POST shape is derived from the view fence's `<input name=…>` attributes, tying the HTML a browser actually submits to the schema the handler validates.

The load-bearing assertions **drive the extracted handler and check which arm it chose**, because the defect was never that a schema rejected a bad value — it was that the shared handler reached different arms for the two legitimate call sites. 11 tests / 34 assertions covering: client dispatch → navigate arm; server POST → 303; malformed POST → 400 with the draft repopulated *without* the token and validating against its registered schema; mismatched token → 403; session-less token-less POST → 403; client never takes the CSRF arm.

It is posture-independent (pure function calls on extracted code — no frame, no dispatch, no trace bus, no `debug-enabled?` read), which is why it also runs green under the real production gate below.

## Mutation proof

Behaviour changed, so both fixes were mutation-proved.

**Mutation 1 — reintroduce the required token in the field schema** (the exact pre-fix shape): **exit 1**, 7 failures + 4 errors. First named failure is the defect itself:

```
FAIL in (the-hydrated-client-submission-navigates-rather-than-400ing)
expected: (= [[:dispatch [:rf.route/navigate {:to :route/cart}]]] fx)
  actual: (not (= [[:dispatch [:rf.route/navigate {:to :route/cart}]]] [[:rf.server/set-status 400]]))
```

**Mutation 2 — restore the bare `not=` CSRF compare**: **exit 1**, 2 failures:

```
FAIL in (the-csrf-arm-fails-closed-when-the-request-carries-no-session)
expected: (nil? (get-in db [:cart :items]))
  actual: (not (nil? [{:item-id "sku-1", :quantity 2}]))
```

A session-less, token-less POST reached the cart. Both mutations reverted with `git diff` reporting **0 bytes**, and the suite returns to exit 0.

## Sibling sweep

Swept every `spec/Pattern-*.md` plus the SSR docs for other places a production path's story rests on a dev-only check. The schema-as-production-guarantee class is now **clean**: Pattern-Forms, Pattern-RemoteData and Construction-Prompts all carry explicit dev-tripwire qualifications; `Conventions.md` has dropped the "the validator *is* the registration" parenthetical; `Pattern-AsyncEffect:163` mentions `:schema` only to warn against threading parameters through it; seven Pattern docs mention schemas not at all. I also checked `011-SSR:1749` — `:rf.error/cofx-value-invalid` is documented in `re_frame/cofx.cljc` as "a PRODUCTION hard error", so its unconditional 400 mapping is correct.

One finding, **filed not fixed** as `rf2-096js` (P2): `spec/Pattern-WebSocket.md` makes no false guarantee but states **no validation obligation at all** for inbound frame payloads, on a surface 010 explicitly names as an `:rf.schema/at-boundary` case. It needs a ruling on shape and `Pattern-WebSocket.md` is hot-zone, so it is out of this bead's fence.

## Quality gates

Matrix derived from `TESTING.md` and `scripts/test-fast-pr.sh --plan` (which classified this diff as `docs=true jvm=true node=true`, JVM artefacts `implementation/core implementation/ssr`). All foreground, worktree-local logs, exit codes echoed, nothing piped through `tail`/`grep` before the exit code was captured.

| Gate | Command | Result |
|---|---|---|
| SSR JVM artefact | `clojure -M:test` in `implementation/ssr` | **exit 0** — 614 tests / 3088 assertions, 0 failures (603/3054 before; my 11/34 added) |
| **SSR production gate** | `bash scripts/test-ssr-prod-gate.sh` | **exit 0** — 616 tests / 2915 assertions, 0 failures, whole suite, no exclusions |
| Core JVM artefact | via spine | **exit 0** — 2209 tests / 11499 assertions, 0 failures |
| Docs corpus anchors | `scripts/check_doc_slugs.py` via spine | **exit 0** |
| mkdocs strict | `python -m mkdocs build --strict` | **exit 0** (the spine soft-skips it — `mkdocs` is not a bare command on this box — so it was run explicitly; `spec/` is in the built site) |
| clj-kondo @ CI pin | `clj-kondo 2026.04.15`, exact `lint.yml` argv | **exit 0** — `errors: 0`, warnings 4527 (unchanged baseline), zero findings in the new file |
| Fast-PR spine | `bash scripts/test-fast-pr.sh` | **exit 0** — `PASS fast PR spine`; all drift/self-test gates, docs gates, both JVM artefacts, JS harness, CLJS node integration, per-ns isolation (17 namespaces standalone) |
| CLJS substrate | `npm run test:cljs` via spine | **exit 0** |

**`test:browser-prod-elision`** — not run, and it is not implicated by this diff: the change is a spec document plus a JVM test namespace, and **no CLJS source was touched**, so there is nothing new that must survive or vanish under `:advanced`. What it proves *about this defect class* is the load-bearing half of the pattern's argument: it is the standing executable proof that the dev-only validation sites really do DCE-elide under `:advanced` + `goog.DEBUG=false`. That is exactly why the page must not rest a production 400 on `:schema` — and the SSR production-gate lane above is this change's own counterpart evidence, since it executes the new witness under the real `-Dre-frame.debug=false` posture and proves the handler arm the fix relies on is *not* elided.

**Hand-verified** (nothing gates these): the `Server vs client` table's three new rows each carry exactly 3 cells against its 3-column header, and the one link added — `010-Schemas.md#sensitive--privacy-in-schema-validation-error-traces` — is an anchor already used elsewhere on the page and is covered by the docs corpus anchor validator above.

**Hot-zone:** `spec/` is hot-zone and I was its only claimant this wave. The one sibling in flight, `worker/vizleak-m46qv` (PR #7345, a `tools/machines-viz` summariser leak), does not touch `spec/` or `implementation/ssr/`.
