### PR TITLE
docs: AGENTS.md teaches the node_modules junction rule, not just the worktree guard (rf2-rxkht)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,28 @@ powershell -ExecutionPolicy Bypass -File scripts/assert-worker-worktree.ps1
 Report the printed `WORKTREE_ROOT` in your final handoff. If the guard fails,
 stop and switch to the correct worktree before editing.
 
+## The `node_modules` Junction — Remove the Link, Never Its Target
+
+A worker worktree cannot compile without a `node_modules`, so the convention
+here is to point `<worktree>/implementation/node_modules` at the mayor
+checkout's **real** one — a directory junction on Windows, a symlink
+elsewhere. Anything that deletes *through* that link destroys shared state: a
+bare `git worktree remove`, or an `rm -rf` of the link itself, follows the
+reparse point and empties the mayor's real `node_modules` — exit 0, silently,
+breaking every local build in the repo until `npm ci --prefix implementation`
+restores it. That has happened twice.
+
+So if you create the link, unlink it as your last act before reporting done —
+`cmd /c rmdir <path>` on Windows, or `rm` **without** `-r` elsewhere; both
+unlink, `rm -rf` deletes through. And never remove a worktree by hand: the
+removal scripts disarm every link first, remove second, and fail loudly if the
+mayor's `node_modules` shrank.
+
+```bash
+sh scripts/remove-worker-worktree.sh <worktree-path>   # POSIX (primary)
+# Windows: powershell -ExecutionPolicy Bypass -File scripts/remove-worker-worktree.ps1 <worktree-path>
+```
+
 ## Non-Interactive Shell Commands
 
 **ALWAYS use non-interactive flags** with file operations to avoid hanging on confirmation prompts.


### PR DESCRIPTION
Closes rf2-rxkht (AUDIT-REOPEN remainder).

## What was missing

PR #7314 landed the prevention *tooling* for the `node_modules` junction
hazard — two removal scripts, an unbounded/pruned link scan, a
fail-before-remove postcondition, mayor/unregistered refusals, Windows and
POSIX self-tests, a CI non-vacuity check, mayor-hygiene routing, and a
dispatch-template rule. The audit on the bead found one gap: the **worker
half never reached `AGENTS.md`**, the active instruction file for Codex
workers in this repository. It taught the worker worktree guard and said
nothing about the one failure mode that has actually destroyed shared state
here — twice.

## What this adds

One section in `AGENTS.md`, placed between the worktree guard and the
shell-command rules, which is the lifecycle position where it is needed:
guard before edits, unlink before handoff.

It states the rule with its reason (a rule without its reason gets optimised
away by the next reader): **remove the LINK, never its target**, because a
bare `git worktree remove` — or an `rm -rf` of the link itself — follows the
reparse point and empties the mayor checkout's real `node_modules`, exit 0,
silently. It tells a worker that created a link to unlink it as its last act
before reporting done, and it points at
`scripts/remove-worker-worktree.sh` / `.ps1` rather than restating their
procedure, so it cannot drift from them.

No new tooling. No duplication of the removal algorithm. `AGENTS.md` grows by
21 lines.

## Other instruction surfaces — surveyed

Already carry the rule, unchanged here:

- `CLAUDE.md` — the "Remove a worker worktree only via
  `scripts/remove-worker-worktree.sh`" bullet under Workflow.
- `docs/the-mayor-method/dispatch-prompt-template.md` — inside the verbatim
  worktree-boundary block every dispatch pastes.
- `.claude/commands/mayor-hygiene.md` — routes removal through the scripts.

Silent, and deliberately left so:

- `.claude/commands/mayor-dispatch.md` — dispatches *per* the template above,
  so the rule already reaches every worker it briefs; restating it here would
  be a second copy to drift.
- `.claude/commands/mayor-posture.md` — a posture reassert, not a procedure.
- `skills/re-frame-migration/**` — skill content must stay generic to any
  consumer app; this repo's junction convention does not belong there.
- `docs/the-mayor-method/{README,bootstrap}.md` — the method narrative. The
  hazard is a genuine peer of bootstrap.md's "never let a worker `git stash`"
  hard-won lesson and arguably belongs in that list, but that is the
  publishable methodology doc rather than this repo's instruction file, and
  the bead's audit scoped this to `AGENTS.md` plus "one short cross-agent
  instruction/reference". Named here rather than silently expanded into.

## Quality gates

Derived from `TESTING.md` §Changed-surface classifier. The diff is one
repo-root Markdown file.

| Gate | Exit | Notes |
|---|---|---|
| `.github/scripts/report-changed-surfaces.sh AGENTS.md` | 0 | **All 25 outputs `false`** — `AGENTS.md` arms no job in `test.yml`. |
| `scripts/test-fast-pr.sh` | 0 | `PASS fast PR spine`. The `*.md` doc-surface predicate armed the docs tier (README links, docs-corpus anchors, EP status-sync, runtime-subsystem grading). |
| `python scripts/check_retired_composition_vocab.py --self-test` | 0 | |
| `python scripts/check_retired_composition_vocab.py` | 0 | **The one gate that actually scans this file** — `AGENTS.md` is in its `_ROOT_SUPPORT_MARKDOWN` list. It is not in the fast-PR spine; `docs.yml` runs it, keyed on the `AGENTS.md` path trigger. Run here explicitly. |
| `python -m mkdocs build --strict` | 0 | The spine soft-skipped it (`mkdocs` not on bare PATH); run explicitly to close that gap. |

**Gates that do not cover this surface**, stated rather than cited:

- `mkdocs build --strict` — `mkdocs.yml` sets `docs_dir: docs` and never
  references `AGENTS.md`; `find site -iname '*agents*'` after the build is
  empty. **`AGENTS.md` is not in the published site.** Established, not
  assumed. The build is reported above as green, not as coverage.
- `scripts/check_doc_slugs.py` — `DEFAULT_ROOTS` is `docs`, `spec`, `skills`,
  `migration` (+ `tools/*/spec`). Repo root is outside it.
- `scripts/check_readme_links.py` — walks `repo_root.rglob("README.md")` by
  filename. `AGENTS.md` is not a `README.md`.
- `npm run test:script-policy` — **not run**: nothing under `scripts/` changed.

Not applicable: no link targets or headings elsewhere point into the new
section, so no anchor gate is load-bearing.

## Hazard hygiene

This worktree carried **no** `node_modules` link at any point (the change is
Markdown-only and no build ran in it), so there was nothing to disarm before
reporting done. `git status` is clean; the mayor checkout was verified
untouched after the edit.
