### PR TITLE
ci: the spine runs mkdocs --strict, or says loudly what it did not check (rf2-g7p7l)

### DIFF
--- a/scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
+++ b/scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
@@ -27,7 +27,10 @@
 #   per-artefact JVM selection (S-V) — a diff under an artefact's tree adds
 #     that artefact's suite, a diff elsewhere does not pay for it, a roster
 #     entry matches on a path boundary, and a skipped tier selects nothing
-#     (rf2-uwszd).
+#     (rf2-uwszd);
+#   mkdocs resolution (W-Y)        — the console script is preferred, an
+#     installed-as-a-module mkdocs is still FOUND rather than soft-skipped, and
+#     a code-only diff never probes for it (rf2-g7p7l).
 #
 # Run from any cwd:
 #   bash scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
@@ -292,6 +295,54 @@ r="$tmp_root/jvm-none"; mkrepo "$r"
 mkdir -p "$r/docs"; printf '# h\n' > "$r/docs/x.md"
 git -C "$r" add -A; git -C "$r" commit -q -m d
 assert "V tier skipped → no artefact suite at all" "PLAN-JVM" "$(plan_jvm "$r")"
+
+# ---------------------------------------------------------------------------
+# mkdocs RESOLUTION (rf2-g7p7l).  The spine probed only for a bare `mkdocs`
+# console script, so on a checkout where mkdocs is installed as a module —
+# `pip install --user`, console script off PATH — the strict site build
+# soft-skipped on EVERY run and the spine still printed PASS.  `PLAN-MKDOCS`
+# makes the resolution observable without paying for an 18-second build, and
+# these cases pin it: the console script wins when present, the module is
+# found when it is not, and a code-only diff never pays to look.
+# ---------------------------------------------------------------------------
+plan_mkdocs() {
+  bash "$spine" --plan --repo-root "$1" 2>/dev/null | grep '^PLAN-MKDOCS' \
+    || printf 'PLAN-MKDOCS <none>\n'
+}
+
+r="$tmp_root/mkdocs-docs"; mkrepo "$r"
+mkdir -p "$r/docs"; printf '# h\n' > "$r/docs/x.md"
+git -C "$r" add -A; git -C "$r" commit -q -m d
+
+# W — the console script is preferred when it is on PATH.  A stub suffices:
+# resolution must not depend on the real tool being installed.
+stub_bin="$tmp_root/stub-bin"; mkdir -p "$stub_bin"
+printf '#!/bin/sh\nexit 0\n' > "$stub_bin/mkdocs"
+chmod +x "$stub_bin/mkdocs"
+if PATH="$stub_bin:$PATH" command -v mkdocs >/dev/null 2>&1; then
+  assert "W console script on PATH → resolved as mkdocs" "PLAN-MKDOCS mkdocs" \
+    "$(PATH="$stub_bin:$PATH" plan_mkdocs "$r")"
+else
+  printf '  SKIP W: this shell cannot make a stub executable discoverable\n'
+fi
+
+# X — THE REGRESSION.  Wherever `python -m mkdocs` runs, the spine must resolve
+# mkdocs; `unresolved` there is the fail-open this case exists to catch.  On CI
+# (console script on PATH) it resolves to `mkdocs`; on a module-only checkout,
+# to `python -m mkdocs`.  Either is a pass; `unresolved` is not.
+if command -v mkdocs >/dev/null 2>&1 || python -m mkdocs --version >/dev/null 2>&1; then
+  case "$(plan_mkdocs "$r")" in
+    "PLAN-MKDOCS unresolved"|"PLAN-MKDOCS <none>") mkdocs_found=no ;;
+    *)                                             mkdocs_found=yes ;;
+  esac
+  assert "X mkdocs installed → the spine resolves it (not soft-skipped)" "yes" "$mkdocs_found"
+else
+  printf '  SKIP X: mkdocs is installed neither as a script nor as a module here\n'
+fi
+
+# Y — the common case pays nothing: a code-only diff never probes for mkdocs.
+assert "Y code-only diff → mkdocs never probed" "PLAN-MKDOCS (docs tier skipped)" \
+  "$(plan_mkdocs "$tmp_root/coverage-note")"
 
 # ---- Summary ----
 total=$((pass_count + fail_count))

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -10,7 +10,8 @@ set -euo pipefail
 #   always     the cheap repo-wide static/drift checks (each paired with its
 #              own self-test where it has one);
 #   docs tier  the documentation-content gates, plus `mkdocs build --strict`
-#              — SOFT-SKIPPED when mkdocs is not on PATH;
+#              — a HARD gate wherever mkdocs can be resolved at all, whether as
+#              a console script or as `python -m mkdocs` (rf2-g7p7l);
 #   JVM tier   `implementation/core` PLUS the suite of every implementation
 #              artefact whose own tree the diff touched (rf2-uwszd).  Core runs
 #              whenever the tier runs — it is the substrate every artefact sits
@@ -34,8 +35,9 @@ set -euo pipefail
 #
 # So `PASS fast PR spine` means "the spine's own tiers passed" — never "what CI
 # will run passed".  The PASS line enumerates every tier and step that was
-# skipped, including the mkdocs soft-skip, so the gap is visible rather than
-# assumed.  `TESTING.md` carries the canonical PR/nightly/release matrix.
+# skipped, and a step that could not run names the surfaces it leaves ungated,
+# so the gap is visible rather than assumed.  `TESTING.md` carries the canonical
+# PR/nightly/release matrix.
 #
 # What it DOES mirror is CI's *tiering* — which tiers run for a given diff —
 # because that decision is delegated wholesale to the classifier CI uses.  Tier
@@ -79,7 +81,7 @@ set -euo pipefail
 #   2. python scripts/check_doc_slugs.py               — docs corpus anchors
 #   3. python scripts/check_ep_status_sync.py          — docs/EP index status-sync
 #   4. python scripts/check_runtime_subsystem_grading.py — EP-0006 grading table
-#   5. mkdocs build --strict (when mkdocs on PATH; soft-skip when not)
+#   5. mkdocs build --strict (console script, else `python -m mkdocs`)
 
 # The spine's own tree (scripts, gate commands, the shared classifier) is
 # always derived from this script's location.  `--repo-root` overrides ONLY
@@ -174,25 +176,45 @@ run() {
   fi
 }
 
-# Soft-run: log + continue when the binary is unavailable.  Used for mkdocs
-# on Windows machines where mkdocs is not always installed in PATH but the
-# CI Linux runners always have it (mkdocs.yml + requirements.txt pinned).
-run_soft() {
-  local surface="$1"
-  local repro="$2"
-  local probe="$3"
-  shift 3
-  printf '==> %s\n' "$surface"
-  if ! command -v "$probe" >/dev/null 2>&1; then
-    printf '    SKIP %s: %s not on PATH (CI will run this; local soft-skip OK)\n' \
-      "$surface" "$probe"
-    note_skipped "$surface ($probe not on PATH)"
+# ---------------------------------------------------------------------------
+# MKDOCS RESOLUTION (rf2-g7p7l).  `command -v mkdocs` is not how mkdocs is
+# necessarily installed.  A `pip install --user` puts the package on sys.path
+# while the console script lands in a per-user Scripts/ directory that is
+# routinely absent from PATH — the state of this project's own Windows
+# checkout, where `command -v mkdocs` fails and `python -m mkdocs --version`
+# prints 1.6.1.  The previous probe asked only for the console script, so the
+# strict docs build soft-skipped on EVERY local run while the spine still
+# printed `PASS ... SKIP ... (local soft-skip OK)`: a gate reporting success
+# without having examined anything.
+#
+# So resolve mkdocs the way it is actually installed — console script first,
+# then the module under each Python launcher.  `-m mkdocs --version` is the
+# probe rather than a bare import because it also proves the entry point runs.
+# It costs ~0.25s and is paid ONLY when the documentation tier runs, so a
+# code-only diff (the common case) pays nothing.
+#
+# The resolved command is invoked through `bash -c`, NOT `bash -lc`: a login
+# shell re-derives PATH from the profile, so probing here and running there
+# could disagree about which mkdocs — or which python — is meant.
+# ---------------------------------------------------------------------------
+mkdocs_cmd=""
+resolve_mkdocs() {
+  if [ -n "$mkdocs_cmd" ]; then
     return 0
   fi
-  if ! "$@"; then
-    printf '\nFAIL %s\nrepro: %s\n' "$surface" "$repro" >&2
-    return 1
+  if command -v mkdocs >/dev/null 2>&1; then
+    mkdocs_cmd="mkdocs"
+    return 0
   fi
+  local launcher
+  for launcher in python python3 py; do
+    if command -v "$launcher" >/dev/null 2>&1 &&
+       "$launcher" -m mkdocs --version >/dev/null 2>&1; then
+      mkdocs_cmd="$launcher -m mkdocs"
+      return 0
+    fi
+  done
+  return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -381,8 +403,21 @@ if [ -z "$jvm_run_list" ]; then
 fi
 
 if [ "$plan_only" = true ]; then
+  # Report how mkdocs resolved, so the docs gate's availability is observable
+  # without running an 18-second site build — and so the self-test can pin it
+  # (rf2-g7p7l).  Resolved ONLY when the documentation tier would run, so a
+  # code-only `--plan` stays free.
+  mkdocs_plan="(docs tier skipped)"
+  if [ "$run_docs" = true ]; then
+    if resolve_mkdocs; then
+      mkdocs_plan="$mkdocs_cmd"
+    else
+      mkdocs_plan="unresolved"
+    fi
+  fi
   printf 'fast-pr plan\n'
   printf '  documentation gates: %s\n' "$([ "$run_docs" = true ] && echo run || echo skip)"
+  printf '  mkdocs --strict:     %s\n' "$mkdocs_plan"
   printf '  JVM tier:            %s\n' "$([ "$run_jvm" = true ] && echo run || echo skip)"
   printf '  node/CLJS suite:     %s\n' "$([ "$run_node" = true ] && echo run || echo skip)"
   printf '  reason:              %s\n' "$plan_reason"
@@ -398,6 +433,7 @@ if [ "$plan_only" = true ]; then
   printf ' tool-JVM gate is in any tier.\n'
   printf 'PLAN docs=%s jvm=%s node=%s\n' "$run_docs" "$run_jvm" "$run_node"
   printf 'PLAN-JVM%s\n' "$([ "$run_jvm" = true ] && printf '%s' "$jvm_run_list")"
+  printf 'PLAN-MKDOCS %s\n' "$mkdocs_plan"
   exit 0
 fi
 
@@ -604,8 +640,36 @@ if [ "$run_docs" = true ]; then
   run "runtime-subsystem grading drift" "python scripts/check_runtime_subsystem_grading.py" \
     python "$spine_root/scripts/check_runtime_subsystem_grading.py"
 
-  run_soft "mkdocs --strict build" "mkdocs build --strict" mkdocs \
-    bash -lc "cd '$spine_root' && mkdocs build --strict"
+  # The strict site build.  A HARD gate wherever mkdocs resolves at all; where
+  # it does not, the step says what it did not check and — measured, not
+  # assumed — which surfaces that leaves with no local gate (rf2-g7p7l).
+  #
+  # What ONLY this build covers locally: `mkdocs.yml` itself (nav integrity,
+  # `exclude_docs`, the theme and markdown-extension pipeline), the
+  # `mkdocs_hooks.py` rewrites, `requirements.txt`, and link resolution in the
+  # STAGED tree — the build copies `spec/` and `migration/` under `docs/` and
+  # rewrites their cross-references, so a link correct in the source tree can
+  # still be broken in the site.  No other spine gate reads any of these.
+  #
+  # What it does NOT uniquely cover, so the skip must not claim it does: link
+  # targets and heading anchors across `docs/` (including all of `docs/EP/**`),
+  # `spec/`, `skills/`, `migration/` and `tools/*/spec/`.  `check_doc_slugs.py`
+  # above scans those roots and is the STRONGER gate there — mkdocs 1.6 grades
+  # a missing anchor INFO, so `--strict` does not fail on one.
+  if resolve_mkdocs; then
+    run "mkdocs --strict build" "$mkdocs_cmd build --strict" \
+      bash -c "cd '$spine_root' && $mkdocs_cmd build --strict"
+  else
+    printf '    NOT CHECKED: mkdocs --strict build — mkdocs resolves neither as a\n'
+    printf '      console script nor as `python -m mkdocs` (tried: mkdocs, python,\n'
+    printf '      python3, py).  This is NOT a pass.  Left with NO local gate:\n'
+    printf '      mkdocs.yml (nav, exclude_docs, theme, markdown extensions),\n'
+    printf '      mkdocs_hooks.py, requirements.txt, and link resolution in the\n'
+    printf '      staged docs/spec + docs/migration copies the build creates.\n'
+    printf '      Install it (pip install -r requirements.txt) and re-run, or\n'
+    printf '      rely on CI docs.yml — which does run it, and can fail there.\n'
+    note_skipped "mkdocs --strict build — UNRESOLVED, so mkdocs.yml/mkdocs_hooks.py/requirements.txt and staged-tree link resolution had NO local gate this run"
+  fi
 else
   printf '\n--- documentation surface unchanged → skipping doc gates (override with --with-docs) ---\n'
   note_skipped "documentation gates (surface unchanged; --with-docs forces)"


### PR DESCRIPTION
`scripts/test-fast-pr.sh` probed for mkdocs with `command -v mkdocs`, and when
that found nothing it printed

```
    SKIP mkdocs --strict build: mkdocs not on PATH (CI will run this; local soft-skip OK)
```

and carried on to `PASS fast PR spine`. On this project's own Windows checkout
that is not a rare fallback — it is **every run**. mkdocs is installed, as a
module: `python -m mkdocs --version` prints 1.6.1 while `command -v mkdocs`
exits 1, because `pip install --user` puts the console script in a per-user
`Scripts/` directory that is not on PATH. The strict site build had therefore
never run locally, and the spine reported that fact in language that reads as a
pass.

## The premise, verified rather than assumed

The bead asked for three things to be checked before fixing them. Two hold and
one does not, so the fix is scoped to what is actually true.

**(a) mkdocs is absent from bare PATH and present as a module — confirmed.**

```
$ command -v mkdocs ; echo $?
1
$ python -m mkdocs --version
python -m mkdocs, version 1.6.1 from C:\Users\miket\AppData\Roaming\Python\Python314\site-packages\mkdocs (Python 3.14)
$ py -m mkdocs --version            # exit 0, same build
```

**(c) the spine exits 0 with the step skipped — confirmed.** `sh scripts/test-fast-pr.sh --with-docs`
on a clean tree, before any change: `SPINE_EXIT=0`, `PASS fast PR spine`, and
`mkdocs --strict build (mkdocs not on PATH)` listed under `NOT RUN`.

**(b) `docs/EP/**` is outside every other checker's roots — this is FALSE, and
the PR does not repeat it.** `check_doc_slugs.py`'s `DEFAULT_ROOTS` is
`("docs", "spec", "skills", "migration")`, and `docs/EP/` is under `docs`. Driving
its own file-iterator over the repo:

```
total md scanned: 647
docs/EP md scanned: 40          # every EP page
```

Planting defects in `docs/EP/EP-0001-frame-partitions.md` one at a time and
running both gates:

| planted defect | `check_doc_slugs` | `mkdocs --strict` |
| --- | --- | --- |
| link to a missing `.md` | **1** (catches) | **1** (catches) |
| broken same-page anchor | **1** (catches) | 0 (misses) |
| broken cross-page anchor | **1** (catches) | 0 (misses) |

So mkdocs was never the only gate on `docs/EP/**`; on anchors it is the *weaker*
gate, because mkdocs 1.6 grades a missing anchor INFO and `--strict` only
escalates WARNINGs. The defect is real and unchanged in seriousness — a gate
that reports success without having examined anything — but its blast radius is
the **site build**, for the whole docs corpus, not `docs/EP` specifically. Writing
the bead's version of the claim into the skip message would have been a second
fail-open: a gate stating something false about its own coverage.

## What changed

**1. The probe finds mkdocs the way it is installed.** `resolve_mkdocs()` tries
the console script, then `python`, `python3`, `py` with `-m mkdocs --version`
(the `--version` call, not a bare import, so a broken entry point is caught).
The step is then a hard `run` — the `run_soft` helper existed only to serve the
wrong probe and is gone. Cost is ~0.25s, paid **only when the documentation tier
runs**, so a code-only diff pays nothing.

The resolved command is invoked through `bash -c` rather than `bash -lc`. A
login shell re-derives PATH from the profile, so the old form could probe in one
shell and run in another that disagreed about which mkdocs — or which python —
was meant.

**2. A skip that cannot be mistaken for a pass.** Where mkdocs resolves nowhere,
the step prints `NOT CHECKED`, says `This is NOT a pass`, names the launchers it
tried, and names the surfaces left with **no local gate at all** — `mkdocs.yml`
(nav, `exclude_docs`, theme, markdown extensions), `mkdocs_hooks.py`,
`requirements.txt`, and link resolution in the staged `docs/spec` +
`docs/migration` copies the build creates. It deliberately does not claim the
docs corpus is ungated, per (b) above. The `NOT RUN` line carries the same
wording rather than a bare step name.

**3. The resolution is observable.** `--plan` prints `PLAN-MKDOCS`, so the docs
gate's availability can be read without paying for an 18-second build — and the
self-test has a hook. Three new cases (W/X/Y) pin that the console script wins
when present, that a module-only install is **found** rather than soft-skipped,
and that a code-only diff never probes.

## Costing the strongest form (bead item 3) — recommended against

Should a skipped-but-required gate fail the spine outright when the diff touches
a surface only that gate covers? It is buildable and small: the mkdocs-only
surfaces are exactly `mkdocs.yml`, `mkdocs_hooks.py` and `requirements.txt`,
which `is_doc_surface_path` already enumerates, so it is a narrow predicate plus
one `exit 1` — perhaps eight lines.

I recommend not taking it, for two reasons.

- **It buys almost nothing after fix (1).** The skip path is now reachable only
  where mkdocs is installed under *no* name this machine can find — i.e. not
  installed. The fix removed the population that was hitting it.
- **It converts "one gate is unavailable" into "the spine will not run".** A
  contributor without mkdocs cannot run *any* pre-checkin gate for a diff that
  brushes `requirements.txt`, and the documented escape is `--no-docs` — which
  turns off the doc gates *silently*, reintroducing this exact defect somewhere
  quieter. Failing loud is only better than reporting loud when the failure is
  actionable; here it is not, and it teaches the workaround.

The honest middle is what landed: run it wherever it can run, and where it
cannot, say precisely what went unchecked. CI's `docs.yml` remains the hard
backstop and does fail there.

## Another silently-skippable step (reported, not fixed)

`run_soft` was the only such helper and it is gone, so no spine step can now
skip while printing a pass. Two adjacent observations, neither actioned here:

- A diff to the spine itself classifies as `unknown surface` → conservative
  full runtime, but `run_docs` stays keyed on the doc-surface predicate, which
  `scripts/test-fast-pr.sh` does not match. A change to the spine's **own docs
  gate** therefore does not arm the docs tier. That is why the runs below use
  `--with-docs`.
- `scripts/_test_fixtures/test_fast_pr_docs_gate/*` is not in
  `is_doc_surface_path`, though its siblings `check_readme_links/*` and
  `check_doc_slugs/*` are.

## Quality gates

Run foreground from the worker worktree
`C:/Users/miket/code/re-frame2-worktrees/spineskip-g7p7l`; logs kept
worktree-local under the gitignored `ai/logs/`.

**Mutation proof — the repair caught a real failure.** The mutation had to be a
defect the *earlier* doc gates do not already catch, or the run would go red
before reaching the mkdocs step and prove nothing. A broken nav entry in
`mkdocs.yml` (`- "MUTATION PROBE": EP/EP-9999-does-not-exist.md`) qualifies, and
was verified to qualify:

| gate, with the mutation applied | exit |
| --- | --- |
| `check_readme_links.py --ci` | 0 |
| `check_doc_slugs.py` | 0 |
| `check_ep_status_sync.py` | 0 |
| `check_runtime_subsystem_grading.py` | 0 |
| `python -m mkdocs build --strict` | **1** — `Aborted with 1 warnings in strict mode!` |

Same mutation, same docs-tier change set, the two spines:

| spine | exit | what it said |
| --- | --- | --- |
| `origin/main` (before) | **0** | `SKIP ... (local soft-skip OK)` → `PASS fast PR spine` |
| this branch (after) | **1** | `FAIL mkdocs --strict build` / `repro: python -m mkdocs build --strict` |

Mutation reverted; `git status --porcelain` and `git diff --stat` both empty.

**Loud-skip proof.** With `python`/`python3`/`py` shadowed by pass-through stubs
that fail only on `-m mkdocs` (so the other doc gates still run), and no console
script on PATH, the step printed the `NOT CHECKED` block naming the ungated
surfaces, and the `NOT RUN` line read `mkdocs --strict build — UNRESOLVED, so
mkdocs.yml/mkdocs_hooks.py/requirements.txt and staged-tree link resolution had
NO local gate this run`.

**Self-test teeth.** The three new cases were run against `origin/main`'s spine:
`22/25, 3 FAILED` — W, X and Y all red. Against this branch: **25/25**.

**Gate exit codes**

| gate | exit |
| --- | --- |
| `bash scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh` | 0 (25/25) |
| `npm run test:script-policy` (touched `scripts/`) | 0 |
| `python -m mkdocs build --strict` (clean tree) | 0 |
| clj-kondo **2026.04.15**, `--parallel --fail-level error`, CI's exact `--lint` list | 0 — `errors: 0, warnings: 4527` |
| `npm run test:cljs` | 0 — 12263 tests, 61442 assertions, 0 failures, 0 errors |
| `sh scripts/test-fast-pr.sh --with-docs` (rebased tree) | 0 — `PASS fast PR spine` |

The clearest single reading of the fix is that spine's own closing summary. It
used to end `NOT RUN by this spine (4):` with `mkdocs --strict build (mkdocs not
on PATH)` at the top of the list. It now ends `NOT RUN by this spine (2):`, and
the mkdocs entry is absent — because the step ran (`Documentation built in 24.99
seconds` at line 220 of the log). The two remaining entries are the honest,
structural ones this spine has always had: the untouched JVM artefact suites and
the browser/bundle/adapter/tooling lanes CI owns.

One earlier spine run went red at `CLJS node integration` with 18 failures, all
in `re_frame/test_quiet_shadow_node_cljs_test.cljs` and all of the same shape:
empty stdout and child status `3221225794` = `0xC0000142`
(`STATUS_DLL_INIT_FAILED`) — every child process that namespace spawns failed
to *start*, under concurrent worker load on this machine. It is not this diff:
`git diff --name-only origin/main...HEAD` is the two shell scripts above and
nothing else, so every CLJS source under test is byte-identical to `origin/main`
and cannot have been changed by this branch. Re-run unloaded, the suite is green
(row above). Same family as rf2-2i1ay, different mechanism (process creation
rather than shared fixture paths); not filed, as it is host resource pressure
rather than a repo defect.

**TESTING.md matrix derived.** The diff is confined to `scripts/**`. Per
`.github/workflows/lint.yml`'s `detect` job, `lint_surface` is armed only by
`implementation/*|tools/*|examples/*|testbeds/*|.clj-kondo/*|.splint.edn|spec/API.md|…`
— `scripts/**` is in none, so the clj-kondo and Splint jobs do **not** light for
this PR; it was run anyway, at the pinned version, and is clean. Per TESTING.md
§Kinds, the rows this change owns are *Lockstep + drift — fast-pr spine* and
*JS harness self-tests — `test:script-policy`*. No CLJS/adapter/browser/bundle
surface is touched. The docs tier does not self-arm for a `scripts/` diff (see
above), which is why the spine was driven with `--with-docs`.
