### PR TITLE
test: a test namespace that cannot be loaded fails the lane instead of vanishing (rf2-vruo9)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -101,10 +101,14 @@
   ## What the lane will DISCOVER
 
   Both rules above are about the tests that RAN.  Neither can see a test
-  file that never entered the run at all, because cognitect's discovery
-  reads each file's `(ns ...)` form and silently drops the ones it cannot
-  read.  `discovery-defects` is the third rule and it fires BEFORE any test
-  does; see its own docstring, and rf2-vruo9."
+  file that never entered the run at all — and there are two ways for one
+  not to.  Cognitect's discovery reads each file's `(ns ...)` form and
+  silently drops the ones it cannot read; and it returns a namespace once
+  per FILE, so two files declaring the same one leave `require` loading
+  whichever the classpath resolves while the other never loads, running a
+  suite twice under a tally that goes UP rather than down.
+  `discovery-defects` is the third rule and it fires BEFORE any test does;
+  see its own docstring, and rf2-vruo9."
   (:require
     [re-frame.test-quiet]
     [clojure.java.io :as io]
@@ -717,29 +721,99 @@
                   (when line (str " (line " line ", column " col ")"))
                   ": " msg)]))))
 
+(defn- scan
+  "Every source file discovery will WALK under `dirs`, one map per physical
+  file: `{:path :rel :ext :declared :complaint}`.
+
+  The files come from `find/find-sources-in-dir` — the same walk
+  `find-ns-decls-in-dir` makes, before it drops anything — so what follows
+  compares what discovery SAW against what discovery KEEPS, rather than
+  against a file-naming convention this guard invented.
+
+  Deduplicated by CANONICAL path, so two `-d` roots naming one directory
+  contribute each file once. The same file is one file; a collision below
+  has to mean two of them, or this guard would redden a lane over its
+  alias spelling rather than over its sources."
+  [dirs]
+  (->> (for [d               (sort dirs)
+             :let            [dir (io/file d)]
+             ^java.io.File f (ns-find/find-sources-in-dir dir discovery-platform)
+             :let  [rel       (relative-path dir f)
+                    [declared complaint] (declared-namespace f)]]
+         {:path      (str/replace (.getPath f) "\\" "/")
+          :canonical (.getCanonicalPath f)
+          :rel       rel
+          :ext       (subs rel (str/last-index-of rel "."))
+          :declared  declared
+          :complaint complaint})
+       (reduce (fn [[seen acc] {:keys [canonical] :as file}]
+                 (if (contains? seen canonical)
+                   [seen acc]
+                   [(conj seen canonical) (conj acc file)]))
+               [#{} []])
+       second))
+
+(defn- own-path-defect
+  "Why `file` will not reach the runner as ITS OWN namespace, or nil.
+
+  Either the reader cannot read its `(ns ...)` form — in which case
+  discovery drops it and it contributes no namespace at all — or the name
+  it declares resolves to some other file's path."
+  [{:keys [rel ext declared complaint]}]
+  (when (not= rel (some-> declared (ns->path ext)))
+    (or complaint
+        (str "it declares `" declared "`, which discovery resolves to `"
+             (ns->path declared ext) "` - a different file."))))
+
+(defn- collision-defects
+  "One `[path complaint]` per file for every namespace declared by MORE
+  THAN ONE of `files`, each complaint naming the others.
+
+  Applied only to files that already spell their own path, because a file
+  that does not is named by `own-path-defect` and its declaration is
+  already known bad.  Two files can both spell their own path and still
+  collide, which is the whole reason this rule exists beside that one:
+
+    - `probe/x_test.clj` beside `probe/x_test.cljc`, each resolving under
+      its OWN extension;
+    - one relative path repeated under two `-d` roots.
+
+  Neither is two suites.  Discovery returns the name once PER FILE, so
+  `require` loads whichever the classpath resolves and treats the rest as
+  already loaded, and `run-tests` is then handed the same symbol twice:
+  one file runs twice while the other never runs at all.  The tally goes
+  UP, not down, so neither the summary nor the `RF2_MIN_TESTS` floor can
+  see the substitution (rf2-vruo9)."
+  [files]
+  (for [[declared group] (group-by :declared files)
+        :when            (next group)
+        :let             [paths (sort (map :path group))]
+        {:keys [path]}   group]
+    [path (str "it declares `" declared "`, which is also declared by "
+               (str/join ", " (map #(str "`" % "`") (remove #{path} paths)))
+               ". Discovery returns that name once per file, so `require`"
+               " loads only the file the classpath resolves and the"
+               " other(s) never run.")]))
+
 (defn discovery-defects
   "Every source file under `dirs` that will NOT reach the runner as its own
   namespace, as `[path complaint]` pairs sorted by path.
 
-  Empty is the only acceptable answer.  The files come from
-  `find/find-sources-in-dir` — the same walk `find-ns-decls-in-dir` makes,
-  before it drops anything — so the comparison is between what discovery
-  SAW and what discovery KEPT, rather than between discovery and a
-  file-naming convention this guard invented."
+  Empty is the only acceptable answer.  Two rules, both required: a file
+  must declare a namespace that resolves to ITS OWN path
+  (`own-path-defect`), and no two files may declare the SAME one
+  (`collision-defects`).  The first alone leaves the shadowing door open,
+  because it derives each file's extension from that file and so clears a
+  `.clj`/`.cljc` pair — and a repeated relative path under two roots —
+  where each half spells its own path perfectly and only one of them ever
+  loads."
   [dirs]
-  (vec
-    (sort
-      (for [d               (sort dirs)
-            :let            [dir (io/file d)]
-            ^java.io.File f (ns-find/find-sources-in-dir dir discovery-platform)
-            :let  [rel       (relative-path dir f)
-                   ext       (subs rel (str/last-index-of rel "."))
-                   [declared complaint] (declared-namespace f)]
-            :when (not= rel (some-> declared (ns->path ext)))]
-        [(str/replace (.getPath f) "\\" "/")
-         (or complaint
-             (str "it declares `" declared "`, which discovery resolves to `"
-                  (ns->path declared ext) "` - a different file."))]))))
+  (let [files (scan dirs)]
+    (vec
+      (sort
+        (concat (for [f files :let [complaint (own-path-defect f)] :when complaint]
+                  [(:path f) complaint])
+                (collision-defects (remove own-path-defect files)))))))
 
 (defn- verify-discovery!
   "Refuse the run when any file in this lane's discovery directories will
@@ -761,17 +835,27 @@
           (println (str "  " path))
           (println (str "      " complaint)))
         (println (str "cognitect.test-runner discovers a namespace by READING each"
-                      " file's `(ns ...)` form and\n"
-                      "silently drops the files it cannot read"
+                      " file's `(ns ...)` form,\n"
+                      "once per file, and both ways that can go wrong end in a"
+                      " green run:\n\n"
+                      "  - a file it CANNOT READ is dropped silently"
                       " (clojure.tools.namespace.find/find-ns-decls-in-dir\n"
-                      "is a `keep` over `ignore-reader-exception`). Such a file"
-                      " contributes no namespace: its\n"
-                      "tests do not run, the suite still prints `0 failures, 0"
-                      " errors.`, and the run exits 0.\n"
-                      "Measured: one stray quote in an ns docstring took"
-                      " implementation/core from 2190 tests\n"
-                      "to 2182, green. Fix the file, or move it out of the"
-                      " discovery directory (rf2-vruo9).\n"))
+                      "    is a `keep` over `ignore-reader-exception`), so it"
+                      " contributes no namespace and its\n"
+                      "    tests simply do not run. Measured: one stray quote in"
+                      " an ns docstring took\n"
+                      "    implementation/core from 2190 tests to 2182, green.\n"
+                      "  - two files declaring ONE namespace yield that name"
+                      " TWICE. `require` loads whichever\n"
+                      "    the classpath resolves and skips the rest as already"
+                      " loaded, then `run-tests` gets the\n"
+                      "    symbol twice: one file runs twice, the other never"
+                      " runs, and the tally goes UP - so\n"
+                      "    neither the summary nor the RF2_MIN_TESTS floor can"
+                      " see the substitution.\n\n"
+                      "Either way the suite still prints `0 failures, 0 errors.`"
+                      " and exits 0. Fix the file, or\n"
+                      "move it out of the discovery directory (rf2-vruo9).\n"))
         (flush))
       (System/exit 1))))
 

--- a/implementation/test-quiet/test/re_frame/test_quiet_discovery_integrity_test.clj
+++ b/implementation/test-quiet/test/re_frame/test_quiet_discovery_integrity_test.clj
@@ -11,6 +11,16 @@
   `implementation/core` from 2190 tests to 2182 — exactly that file's eight
   deftests — reporting `0 failures, 0 errors.` and exiting 0.
 
+  A file can also fail to run while spelling its own path PERFECTLY, which
+  is the second door and the one a per-file check cannot see. Discovery
+  returns a namespace once per FILE, so when two files declare the same one
+  — a `.clj` beside a `.cljc`, or one relative path repeated under two `-d`
+  roots — `require` loads whichever the classpath resolves, skips the rest
+  as already loaded, and hands `run-tests` the symbol twice. One file runs
+  TWICE and the other never runs. The tally goes UP, so no coverage floor
+  can see the substitution either. Hence two rules, not one: own-path, and
+  global uniqueness across every selected root.
+
   EVERY TEST HERE PINS THE DEFECT BEFORE IT PINS THE GUARD. Each fixture is
   handed to `find/find-namespaces-in-dir` FIRST, and the assertion is on
   what discovery does or does not return; only then is `discovery-defects`
@@ -160,6 +170,70 @@
                 because their paths differ"
         (is (= ["shadow_test.clj"]
                (defect-paths (runner/discovery-defects [(.getPath dir)]))))))))
+
+(def ^:private duplicate-body
+  (str "  (:require [clojure.test :refer [deftest is]]))\n"
+       "(deftest f (is (= 1 1)))\n"))
+
+(deftest a-clj-and-cljc-sibling-declaring-one-namespace-are-named
+  (with-tree {"probe/good_test.clj"       well-formed
+              "probe/duplicate_test.clj"  (str "(ns probe.duplicate-test\n"
+                                               duplicate-body)
+              "probe/duplicate_test.cljc" (str "(ns probe.duplicate-test\n"
+                                               duplicate-body)}
+    (fn [dir]
+      (testing "THE DEFECT: each sibling spells its OWN path under its own
+                extension, so the per-file rule clears both — yet discovery
+                returns the one name twice and only the `.clj` ever loads"
+        (is (= ['probe.duplicate-test 'probe.duplicate-test]
+               (vec (filter #{'probe.duplicate-test}
+                            (ns-find/find-namespaces-in-dir dir))))
+            "one namespace, two files, two entries in the discovered seq"))
+
+      (testing "THE GUARD: both files are named, each pointing at the other"
+        (let [defects (runner/discovery-defects [(.getPath dir)])]
+          (is (= ["duplicate_test.clj" "duplicate_test.cljc"]
+                 (defect-paths defects))
+              "every colliding file is named, not just one of them")
+          (is (str/includes? (complaint-for defects "duplicate_test.clj")
+                             "duplicate_test.cljc")
+              "the .clj complaint names the .cljc it shadows")
+          (is (str/includes? (complaint-for defects "duplicate_test.cljc")
+                             "duplicate_test.clj")
+              "and the .cljc complaint names the .clj that shadows it"))))))
+
+(deftest one-relative-path-under-two-roots-is-named
+  (with-tree {"probe/duplicate_test.clj" (str "(ns probe.duplicate-test\n"
+                                              duplicate-body)}
+    (fn [a]
+      (with-tree {"probe/duplicate_test.clj" (str "(ns probe.duplicate-test\n"
+                                                  duplicate-body)}
+        (fn [b]
+          (testing "THE DEFECT: each root's file spells its own relative path,
+                    so per-file checking clears both, and the collision only
+                    exists ACROSS roots"
+            (is (= ['probe.duplicate-test 'probe.duplicate-test]
+                   (vec (mapcat #(ns-find/find-namespaces-in-dir (io/file %))
+                                [(.getPath a) (.getPath b)])))))
+
+          (testing "THE GUARD: uniqueness is global to the selected roots"
+            (is (= ["duplicate_test.clj" "duplicate_test.clj"]
+                   (defect-paths (runner/discovery-defects
+                                   [(.getPath a) (.getPath b)])))
+                "both copies are named")
+            (is (= [] (runner/discovery-defects [(.getPath a)]))
+                "and either root ALONE is clean: the defect is the pairing,
+                 so a single-root lane must not be reddened by it")))))))
+
+(deftest one-directory-reached-by-two-spellings-is-not-a-collision
+  (testing "a lane naming one directory twice — `-d test -d ./test` — walks
+            each file twice, and the same file is one file. Deduplicating by
+            canonical path is what keeps this guard from reddening a lane
+            over its alias spelling rather than over its sources"
+    (with-tree {"probe/good_test.clj" well-formed}
+      (fn [dir]
+        (let [p (.getPath dir)]
+          (is (= [] (runner/discovery-defects [p (str p "/.")]))))))))
 
 (deftest a-well-formed-tree-has-nothing-to-say
   (testing "silent on success: the rule is a refusal, not a report"


### PR DESCRIPTION
Closes rf2-vruo9 — the audit reopen of PR #7249, not the original malformed-`ns` defect (that door is shipped and stays shut).

## The defect

PR #7249 closed two doors into the JVM lane's discovery — an unreadable `(ns ...)` form, and a file declaring a name that resolves to a different path — and claimed the per-file path comparison also made discovery **injective**. It does not. `discovery-defects` derived each file's extension *from that file* and compared it only to *its own* relative path, so there was no cross-file pass at all. Two legal layouts clear that check and still lose a whole suite:

1. One discovery root holding `probe/duplicate_test.clj` **and** `probe/duplicate_test.cljc`, each declaring `probe.duplicate-test`. Each resolves perfectly under its **own** extension.
2. Two `-d` roots each holding the same relative path and declaration. `tools/deps.edn:191-195` runs a real five-root lane.

Probed directly against the runner blob shipped by #7249 (`9d5e997024`, unchanged on this base):

```
=== CASE 1: probe/duplicate_test.clj + probe/duplicate_test.cljc, one root ===
  discovered: [probe.duplicate-test probe.duplicate-test]
  defects   : []
=== CASE 2: same relative path under TWO -d roots ===
  discovered: [probe.duplicate-test probe.duplicate-test]
  defects   : []
```

Discovery returns a namespace once **per file**. Cognitect mapcats those duplicate symbols, `require`s them in order (the second is already loaded, so it is a no-op), then hands both to `clojure.test/run-tests`. One physical file is loaded and run **twice** while the other never runs.

**End-to-end, against the shipped runner.** The `.cljc` sibling carried a deftest that fails if it ever executes:

```
Ran 2 tests containing 2 assertions.
0 failures, 0 errors.
EXIT=0
```

Green. The `.clj`'s single passing test ran twice; the failing file never loaded. Note the tally goes **UP**, not down — so neither the summary nor the `RF2_MIN_TESTS` floor (a collapse detector calibrated ~3% under the observed count) can see the substitution. That is what makes this fail-open rather than merely wrong.

## The fix

`discovery-defects` now runs **two** rules over one scan, in `implementation/test-quiet/src/re_frame/test_quiet/runner.clj`:

- `own-path-defect` — the existing readable-form + own-path comparison, unchanged in behaviour.
- `collision-defects` — global uniqueness of every declared namespace across **all** selected discovery roots, independent of `.clj`/`.cljc`. Applied to the files that already spell their own path, because a file that does not is named by the first rule and its declaration is already known bad.

Every colliding file is named, and each complaint points at the others rather than leaving the operator to find the twin. The scan deduplicates by **canonical path**, so a lane naming one directory twice (`-d test -d ./test`) is not reddened over its alias spelling — the same file is one file, and a collision has to mean two of them.

The `verify-discovery!` diagnostic now explains both doors, still ASCII-only for the Windows console.

**No named allowance was needed, and nothing was widened from an error to a warning.** Neither layout is ever legitimate on a JVM classpath: a `.clj` always shadows its `.cljc` sibling, and a repeated relative path across roots always loses one copy. Healthy files stay silent — the rule is a refusal, not a report.

Scope held to this owner: no new runner, roster, manifest, or source-root policy.

## What it had been hiding: nothing

Swept **every** quiet-runner lane in the repo — 44 aliases across 34 `deps.edn` files, each with its own `-d` set resolved from its `:main-opts`, since separate lanes are separate classpaths and per-lane is the only correct semantics. The five-root `tools :test` lane was included.

**Total defects: 0.** No existing test namespace was being silently dropped. The door was open; nothing had walked through it.

(Observed in passing and deliberately left alone: the top-level `implementation/deps.edn` `:test` alias resolves a `test/` root that does not exist. It is not on `scripts/test-jvm-implementation.sh`'s roster and is never invoked, and roster policy is explicitly outside this bead.)

## Regression controls

Three new deftests in `test_quiet_discovery_integrity_test.clj`, each pinning **the defect before the guard** as every test in that file already does — the fixture goes to `find/find-namespaces-in-dir` first, and only then is `discovery-defects` asked to name it, so the controls cannot degrade into testing the guard against its own output:

- `a-clj-and-cljc-sibling-declaring-one-namespace-are-named` — both files named, each complaint naming the other.
- `one-relative-path-under-two-roots-is-named` — both copies named, **and** either root alone stays clean, so a single-root lane is not reddened by a defect that only exists in the pairing.
- `one-directory-reached-by-two-spellings-is-not-a-collision` — the canonical-path dedupe, pinned so a later refactor cannot reintroduce a false red.

The unreadable, wrong-declaration, multi-dir parsing, clean-tree, and process-boundary controls are unchanged and green.

## Quality gates

**Mutation proof** — a `.clj`/`.cljc` pair declaring one namespace, run through the real runner:

| | result | exit |
|---|---|---|
| collision present, **before** fix | `Ran 2 tests … 0 failures, 0 errors.` | **0** (green — the bug) |
| collision present, **after** fix | `ERROR: 2 file(s) … will not reach the runner as their own namespace`, both paths named | **1** (red) |
| collision removed, `git diff` empty | `Ran 1 tests … 0 failures, 0 errors.` | **0** (green) |

The reverted run reports `Ran 1 tests`, not 2 — direct confirmation that the earlier 2 was one test executed twice.

The red names the files and says why:

```
[test-quiet] ERROR: 2 file(s) under ["..."] will not reach the runner as their own namespace:
  .../probe/duplicate_test.clj
      it declares `probe.duplicate-test`, which is also declared by
      `.../probe/duplicate_test.cljc`. Discovery returns that name once per
      file, so `require` loads only the file the classpath resolves and the
      other(s) never run.
  .../probe/duplicate_test.cljc
      it declares `probe.duplicate-test`, which is also declared by
      `.../probe/duplicate_test.clj`. ...
```

**Gates.** Per `TESTING.md`, the changed surface is `implementation/test-quiet/**`, which classifies as `implementation_jvm` → the per-artefact JVM suites plus `jvm-test-quiet`. `scripts/test-jvm-tools.sh` is cited on its own account: it carries the repo's only multi-root discovery lane and is therefore the one most exposed to this change.

| gate | exit |
|---|---|
| `scripts/test-jvm-implementation.sh` — 23 artefact suites, all `0 failures, 0 errors.` | **0** |
| `scripts/test-jvm-tools.sh` — includes the five-root `tools :test` lane | **0** |
| `scripts/test-fast-pr.sh` — includes CLJS node integration, 12263 tests / 61442 assertions | **0** |
| `clj-kondo` 2026.04.15 — the CI pin, fetched, since local npm is older — with CI's exact `--lint` set and `--fail-level error` | **0** (`errors: 0`, warnings pre-existing) |

Rebased onto `4a9cfc71e7` (rf2-g7p7l) before the final gate run, so the spine result is from the current `test-fast-pr.sh`, not the pre-merge one.

One environmental note, recorded rather than glossed: the spine's first run in this fresh worktree went red on CLJS node integration with `'shadow-cljs' is not recognized`, because a new worktree has no `implementation/node_modules`. That is the spine behaving **correctly** — it failed loudly and named the repro rather than skipping the step, which is the opposite of the class this bead is about. Fixed by a real `npm ci --prefix implementation` (exit 0, 101 packages) rather than a `node_modules` junction, so no junction-removal hazard was created; the mayor checkout's `node_modules` was verified at 101 before and after. The re-run is the exit 0 in the table above.

`npm run test:script-policy` is **not** cited: nothing under `scripts/` was touched. No CLJS lane is cited either — this is the JVM discovery path, and rf2-0i0ei already measured the CLJS side and closed it as not exposed: shadow-cljs selects test namespaces from the **file path** (`util/filename->ns`), not from the `(ns ...)` form, and polices the rest with its own `shadow.build.resolve/check-correct-ns!`.
