### PR TITLE
hicasso: a first registration is observed, not cached away (rf2-2rtt6.44)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/first_registration_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/first_registration_cljs_test.cljs
@@ -1,0 +1,224 @@
+(ns re-frame.bench.hicasso.arm1.first-registration-cljs-test
+  "THE OTHER REGISTRY TRANSITION (rf2-2rtt6.44).
+
+  `disposed_cell_cljs_test` closed the registry axis for a **replacement**
+  — an id that already had a handler and got another one — because that
+  transition arrives at the arm as a disposal: the sub-cache evicts the
+  query's entry, the reaction is disposed, and
+  `re-frame.bench.hicasso.arm1.runtime/invalidate-cell!` rides the event.
+
+  A **first** registration arrives as nothing at all. `registrar`'s
+  replacement hook fires only when a previous handler existed, so the
+  sub-cache evicts nothing and disposes nothing, and an arm that rode the
+  disposal alone would never hear about it.
+
+  That would matter to no one if a boundary could not hold the miss —
+  and the substrate is careful that it cannot. A subscribe to an
+  unregistered query emits `:rf.error/no-such-sub`, recovers to a
+  nil-yielding reaction, and **deliberately does not cache it**, so that
+  \"a later registration is observed by the next subscribe\"
+  (`re-frame.subs/build-and-cache!*`). Arm 1 breaks that assumption in
+  the one way it can: a cell holds its reaction for the life of every
+  boundary reading the key, and it never subscribes again. The recovery
+  the substrate declined to cache is cached anyway, in the arm's own
+  cell, where nothing evicts it.
+
+  Measured before the repair: the boundary read `nil`, the first
+  `reg-sub` for the query changed nothing, and no later write notified
+  it — **for the life of the mount**, on a query that was by then
+  perfectly well registered. That is the shape a lazily loaded module
+  hits, and it is the same failure mode `disposed_cell_cljs_test` pins
+  for the replacement transition: not a stale value but a retired
+  computation, which looks alive.
+
+  The rows below are the direct witness the merged-PR audit asked for.
+  The bottom row is the bill: a first registration of an id **no cell
+  holds** must still disturb nothing, because the alternative this
+  programme declined was a registry term in every key's contribution to
+  `getSnapshot`."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     ;; The rebuild rows resume on a later tick, and `cljs.test` refuses a
+     ;; fn-form fixture for an `async` test — the fn-form's ambient scope is
+     ;; a dynamic binding that would be unwound before the body resumes.
+     :async?        true
+     ;; The carried-invariant chain resolves the dynamic-var frame tier
+     ;; BEFORE React context, so a fixture-installed ambient frame would
+     ;; answer reads for a frame this file never made.
+     :ambient-frame nil
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+;; This file's OWN queries. Every row here turns on a query being
+;; UNREGISTERED when the boundary mounts, so these ids must be ones no
+;; other suite registers — and the fixture's registrar snapshot/restore
+;; is what keeps them unregistered at the top of each row.
+(def ^:private q-first [:firstreg/pending])
+(def ^:private q-held  [:firstreg/held])
+(def ^:private q-live  [:firstreg/live])
+
+(defn- make-frame! [id db]
+  (live-frame/make-frame {:id id})
+  (frame/replace-app-db! id db)
+  id)
+
+(defn- reader
+  "A boundary whose whole body is one read, so the read set is one key
+  and the snapshot arithmetic is one term."
+  [q seen]
+  (fn [_] (let [v (rt/sub q)] (vreset! seen v) [:li (str v)])))
+
+(defn- settle!
+  "Run the macrotask queue once. The repair's rebuild is deferred — it
+  fires inside a registrar hook, which is not a place to subscribe — so a
+  row that asserts about the REBUILT attachment has to wait for it.
+  Paired with `cljs.test/async`, without which the callback runs after the
+  run is reported and its assertions are counted by nobody."
+  [k]
+  (js/setTimeout k 0))
+
+;; ---------------------------------------------------------------------------
+;; The direct witness
+;; ---------------------------------------------------------------------------
+
+(deftest a-first-registration-reaches-a-boundary-that-already-holds-the-key
+  (testing "The transition `add-replacement-hook!` cannot see. A boundary
+            renders and COMMITS against a query nobody has registered, so
+            its cell holds the substrate's nil-recovery — the one object
+            core takes care never to cache. The query is then registered
+            for the FIRST time. Every later render must compute against
+            that registration, and every later write must notify."
+    (async done
+      (let [seen (volatile! :unread)
+            f    (make-frame! ::first {:v 1})]
+        ;; NO `reg-sub` yet. This is the boot-order / lazy-load shape: a
+        ;; boundary mounts, reads a query whose module has not registered
+        ;; its subs, and stays mounted while it does.
+        (rt/render-body f (reader q-first seen) {})
+        (is (nil? @seen)
+            "the recovery contract, unchanged: an unregistered read emits
+             `:rf.error/no-such-sub` and derefs to nil")
+        (let [entry    (rt/last-reads)
+              hits     (volatile! 0)
+              release! (rt/commit-boundary! entry (fn [] (vswap! hits inc)))]
+          (is (= 1 (:cells (rt/stats)))
+              "and the COMMIT is what makes it a problem: the boundary now
+               holds a cell for the key, so the read is a pure deref of
+               whatever that cell caught — and what it caught is the
+               recovery")
+
+          ;; THE FIRST REGISTRATION. No previous handler, so no replacement
+          ;; hook fires, no sub-cache entry is evicted, and no reaction is
+          ;; disposed anywhere in the substrate.
+          (rf/reg-sub (first q-first) (fn [db _] (:v db)))
+
+          (testing "the next render computes against the registration that
+                    now exists"
+            (rt/render-body f (reader q-first seen) {})
+            (is (= 1 @seen)
+                "1, not nil: the cell dropped the recovery, so the read falls
+                 through to `subscribe-once`, which resolves the handler that
+                 is registered NOW"))
+
+          (settle!
+            (fn []
+              (testing "and the durable attachment is built against it, so
+                        later writes notify"
+                (let [before @hits]
+                  (frame/replace-app-db! f {:v 2})
+                  (is (pos? (- @hits before))
+                      "the boundary was notified — without the repair the cell
+                       is deaf for the life of the mount, because the watch it
+                       installed is on a reaction the registration never
+                       reaches")))
+              (rt/render-body f (reader q-first seen) {})
+              (is (= 2 @seen) "and it reads the registered handler over the new db")
+              (release!)
+              (done))))))))
+
+(deftest deliberately-a-cell-that-keeps-the-recovery-answers-nil-forever
+  (testing "the failure the row above repairs, stated as its own assertion
+            so the repair cannot quietly stop being needed. The recovery
+            reaction is a constant nil — it is not wired to the frame, it
+            is not in any cache, and no registration can ever reach it. A
+            cell that keeps it answers nil for as long as the boundary
+            lives."
+    (let [f (make-frame! ::held {:v 1})]
+      (rt/render-body f (reader q-held (volatile! nil)) {})
+      (let [entry    (rt/last-reads)
+            release! (rt/commit-boundary! entry (fn []))
+            ;; Reach past the repair and hold the object the cell caught.
+            ;; This is exactly what the cell kept before the first
+            ;; registration was made an event.
+            held     (rt/cell-reaction [f q-held])]
+        (is (some? held)
+            "precondition: the commit acquired a reaction, and it is the
+             substrate's uncached nil-recovery")
+        (rf/reg-sub (first q-held) (fn [db _] (:v db)))
+        (is (nil? @held)
+            "the held recovery answers nil where the live registration answers
+             1 — and it will answer nil after every later write too, because
+             it derives from nothing")
+        (is (nil? (rt/cell-reaction [f q-held]))
+            "which is why the cell drops the reference instead: the repair is
+             to stop reading through it, not to re-read it")
+        (release!)))))
+
+;; ---------------------------------------------------------------------------
+;; What closing the transition cost
+;; ---------------------------------------------------------------------------
+
+(deftest a-first-registration-of-an-id-no-cell-holds-disturbs-nothing
+  (testing "the bill, and the tripwire on the alternative this programme
+            declined (a `:registry-epoch` term in every key's contribution
+            to `getSnapshot`, which would have moved every mounted
+            boundary's snapshot on every `reg-sub` in the application).
+            A first registration is TARGETED: it reaches the cells holding
+            that query and nothing else. An unrelated one — which is what
+            a boot, a lazy module load and every one of an HMR save's
+            first-time ids look like — must leave a mounted boundary's
+            snapshot exactly where it was."
+    (rf/reg-sub (first q-live) (fn [db _] (:v db)))
+    (let [seen  (volatile! nil)
+          f     (make-frame! ::unrelated {:v 1})
+          _     (rt/render-body f (reader q-live seen) {})
+          entry (rt/last-reads)
+          hits  (volatile! 0)
+          release! (rt/commit-boundary! entry (fn [] (vswap! hits inc)))
+          before   (rt/snapshot-of entry)
+          held     (rt/cell-reaction [f q-live])]
+      (is (= 1 @seen) "the control: a registered key, read and committed")
+      (is (some? held) "and holding its reaction")
+      (rf/reg-sub :firstreg/nobody-reads-this (fn [db _] (:v db)))
+      (is (= before (rt/snapshot-of entry))
+          "the snapshot did not move: nothing about an unrelated first
+           registration is in this key's contribution")
+      (is (zero? @hits) "and nothing notified the boundary")
+      (is (identical? held (rt/cell-reaction [f q-live]))
+          "and the cell still holds the SAME reaction — an unrelated
+           registration is not a reason to rebuild an attachment")
+      (release!))))
+
+(deftest closing-the-first-registration-cost-no-hook-and-nothing-in-the-snapshot
+  (testing "the same fences `disposed_cell_cljs_test` holds for the
+            disposal half. What repairs a first registration is an event,
+            not a term, so the shell is unchanged and the snapshot
+            arithmetic is unchanged."
+    (is (= 2 (count rt/shell-hook-ledger))
+        "still two hooks — a registrar hook is not a React hook")
+    (is (= [:use-context/frame :use-sync-external-store/subscription-epoch]
+           rt/shell-hook-ledger)
+        "and the same two, in the same order")
+    (let [inv (rt/retained-inventory)]
+      (is (= #{:use-ref :use-state :view-cell :candidate-ledger}
+             (into #{} (map :token) (:absent inv)))
+          "the enumerated absences are unchanged: no per-boundary object was
+           added, and nothing is keyed by a render or an attempt"))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/first_registration_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/first_registration_cljs_test.cljs
@@ -32,6 +32,15 @@
   computation, which looks alive.
 
   The rows below are the direct witness the merged-PR audit asked for.
+  One of them is a **pin rather than a repair**: a first registration
+  landing in the render→commit gap reaches no cell, because the boundary
+  has none yet, and the epoch sum cannot report it either — a `reg-sub`
+  moves neither term of `commit-basis`. That is the registry axis inside
+  the second window, permanently outside this arithmetic and closable
+  only by the term this programme costed and declined; the commit does
+  acquire against the live registration, so what it costs is a delayed
+  paint the next write clears, not a retired computation.
+
   The bottom row is the bill: a first registration of an id **no cell
   holds** must still disturb nothing, because the alternative this
   programme declined was a registry term in every key's contribution to
@@ -63,6 +72,7 @@
 ;; is what keeps them unregistered at the top of each row.
 (def ^:private q-first [:firstreg/pending])
 (def ^:private q-held  [:firstreg/held])
+(def ^:private q-gap   [:firstreg/gap])
 (def ^:private q-live  [:firstreg/live])
 
 (defn- make-frame! [id db]
@@ -171,6 +181,53 @@
             "which is why the cell drops the reference instead: the repair is
              to stop reading through it, not to re-read it")
         (release!)))))
+
+(deftest deliberately-a-first-registration-in-the-render-commit-gap-moves-no-snapshot
+  (testing "the OTHER window, pinned rather than closed. The rows above
+            are the mounted case — a boundary that already holds a cell.
+            The render→commit gap is the case where it does not: the body
+            has returned `nil`, and the registration lands before React
+            runs the effect that acquires the edge. There is no cell for
+            [[first-registration!]] to reach, and the epoch sum cannot
+            report it either — a key with no cell contributes its frame's
+            `commit-basis`, and a `reg-sub` moves neither term of it. So
+            the number React re-reads after `subscribe` is the number it
+            captured at render, and it schedules nothing.
+
+            This is the registry axis inside the second window, and it is
+            the same thing `generation_fence_coverage_cljs_test` states
+            for a re-registration: permanently outside this arithmetic,
+            and closable only by the registry term that programme
+            declined. What saves it is that the commit DID acquire against
+            the live registration, so the boundary is correct from its
+            next render onwards and the next write to the frame schedules
+            one. It is a delayed paint, not a retired computation."
+    (let [seen (volatile! :unread)
+          f    (make-frame! ::gap {:v 1})]
+      (rt/render-body f (reader q-gap seen) {})
+      (is (nil? @seen) "the body ran against no registration")
+      (let [entry     (rt/last-reads)
+            at-render (rt/snapshot-of entry)
+            hits      (volatile! 0)]
+        ;; THE REGISTRATION, inside the gap: after the body returned and
+        ;; before React's effect acquires the edge.
+        (rf/reg-sub (first q-gap) (fn [db _] (:v db)))
+        (let [release! (rt/commit-boundary! entry (fn [] (vswap! hits inc)))]
+          (is (= at-render (rt/snapshot-of entry))
+              "the snapshot did not move across the commit, so React's
+               post-`subscribe` re-check sees no tear and schedules no
+               re-render — the boundary keeps the `nil` it painted")
+          (is (zero? @hits) "and nothing notified it either")
+          (is (= 1 @(rt/cell-reaction [f q-gap]))
+              "though the cell the commit acquired holds the REAL handler:
+               nothing is retired here, and the next render is correct")
+          (testing "so it heals on the next write rather than at the
+                    registration"
+            (frame/replace-app-db! f {:v 2})
+            (is (pos? @hits) "the write notified")
+            (rt/render-body f (reader q-gap seen) {})
+            (is (= 2 @seen)))
+          (release!))))))
 
 ;; ---------------------------------------------------------------------------
 ;; What closing the transition cost

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/first_registration_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/first_registration_cljs_test.cljs
@@ -27,9 +27,10 @@
   `reg-sub` for the query changed nothing, and no later write notified
   it — **for the life of the mount**, on a query that was by then
   perfectly well registered. That is the shape a lazily loaded module
-  hits, and it is the same failure mode `disposed_cell_cljs_test` pins
-  for the replacement transition: not a stale value but a retired
-  computation, which looks alive.
+  hits. `disposed_cell_cljs_test`'s cell answers a RETIRED computation;
+  this one answers a computation that never arrived. Both look alive —
+  the boundary rendered, it painted, nothing errored, and it will never
+  change again.
 
   The rows below are the direct witness the merged-PR audit asked for.
   One of them is a **pin rather than a repair**: a first registration

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -284,24 +284,34 @@
   ### The other two axes, and why they are not the basis's to carry
 
   The predecessor compared three things, and the basis answers one of
-  them. The other two — a `:sub` re-registration (its `:registry-epoch`)
+  them. The other two — a `:sub` registration (its `:registry-epoch`)
   and a same-id frame reincarnation (its `:node-key`) — move neither
   term, and rf2-2rtt6.44 established that **adding a term for them would
-  have closed nothing**. Both events dispose the reaction a cell holds:
-  a re-registration through the sub-cache's replacement hook, a
-  reincarnation through frame teardown. A disposed container clears its
-  own watcher set, so the cell is deaf from that instant, and it answers
-  the RETIRED computation (or the destroyed incarnation's db) on every
-  later deref. A number that moved would have bought exactly one extra
-  render, and that render would have read back through the same dead
-  cell.
+  have closed nothing**. Each of them leaves the cell holding a reaction
+  that can no longer answer for its key, so a number that moved would
+  have bought exactly one extra render, and that render would have read
+  back through the same dead reference. What each does to the cell, and
+  what the arm hears when it happens:
 
-  So the arm takes the substrate's own event instead of a term:
-  [[invalidate-cell!]] is armed per unique key at [[wire-cell!]] time and
-  fires only when a reaction is actually disposed. It costs no hook, no
-  per-boundary object, nothing in the snapshot arithmetic, and no read of
-  the registry — the epoch-sum `getSnapshot` is untouched. rf2-2rtt6.44
-  records the costing that rejected the alternative.
+  | transition | what the cell is left holding | what announces it |
+  |---|---|---|
+  | `:sub` **re-registration** | a disposed container — the sub-cache evicted the entry, and `-dispose` cleared the watcher set, so the cell is deaf from that instant and answers the RETIRED computation on every later deref | the reaction's own disposal |
+  | **frame destruction** (incl. a same-id reincarnation) | a container wired to the frame that no longer exists, answering the destroyed incarnation's db | the reaction's own disposal |
+  | `:sub` **first registration** | the substrate's uncached nil-recovery, which was never wired to anything and can never see the handler that has now arrived | nothing — so [[first-registration!]] listens for the registration itself |
+
+  So the arm takes the substrate's own events instead of a term.
+  [[invalidate-cell!]] is the one repair all three reach:
+  [[wire-cell!]] arms it per unique key against the reaction's disposal,
+  which covers the two transitions that dispose; the third disposes
+  nothing — `registrar/add-replacement-hook!` fires only when a previous
+  handler existed — so the arm hangs it off
+  `registrar/add-registration-hook!`, narrowed to first-time `:sub`
+  registrations and to the cells that hold the id being registered. It
+  costs no React hook, no per-boundary object, nothing in the snapshot
+  arithmetic, and no read of the registry's own epoch — the epoch-sum
+  `getSnapshot` is untouched, and an unrelated registration moves no
+  boundary's snapshot. rf2-2rtt6.44 records the costing that rejected
+  the alternative.
 
   ## What is deliberately NOT here (the hard fences)
 
@@ -319,6 +329,7 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
+            [re-frame.registrar :as registrar]
             [re-frame.subs :as subs]
             ["react" :as react]))
 
@@ -455,16 +466,19 @@
   advances it, which costs at most one redundant re-render and cannot
   cost a missed one. Pure read; allocates nothing.
 
-  Silent on two axes, and permanently so — a `:sub` re-registration is
-  not a frame-state install, and a same-id frame reincarnation RESTARTS
+  Silent on two axes, and permanently so — no `:sub` registration is a
+  frame-state install, and a same-id frame reincarnation RESTARTS
   `frame-commit-epoch` at 0 (measured: A's epoch and B's are both 1, so
   the basis TIES across the reincarnation), which is the case the
   observation port needs its `:node-key` field for. **Neither axis is
   this number's to carry**, and rf2-2rtt6.44 settled why rather than
-  extending it: both events dispose the reaction a cell holds, so a
-  moved number would only buy a re-render that read back through the
-  same dead cell. [[invalidate-cell!]] carries them, off the substrate's
-  own disposal event."
+  extending it: every one of those transitions leaves the cell holding a
+  reaction that can no longer answer for its key, so a moved number
+  would only buy a re-render that read back through the same dead
+  reference. [[invalidate-cell!]] carries all three, reached from the
+  substrate's own disposal for the two that dispose (a re-registration,
+  a frame teardown) and from [[first-registration!]] for the one that
+  does not."
   [frame-kw]
   (+ @!generation (frame/frame-commit-epoch frame-kw)))
 
@@ -506,7 +520,10 @@
   `commit-basis` cannot see (rf2-2rtt6.44), and it is deliberately an
   *event* rather than a term in the epoch sum: the substrate already
   tells us, exactly and only when it happens, and a term would have to be
-  read by every key on every snapshot to discover the same thing later."
+  read by every key on every snapshot to discover the same thing later.
+  It covers every transition that *disposes* — which is all of them but
+  one, and [[first-registration!]] carries the one it is not: a first
+  registration announces itself by registering, and disposes nothing."
   [^js cell]
   (let [frame-kw (.-frameKw cell)
         query-v  (.-queryV cell)
@@ -522,23 +539,27 @@
     cell))
 
 (defn- invalidate-cell!
-  "**The two axes the epoch sum cannot carry, closed by the substrate's own
-  event** (rf2-2rtt6.44). A cell holds its reaction for the life of every
+  "**The repair for a cell whose reaction can no longer answer for its
+  key** (rf2-2rtt6.44). A cell holds its reaction for the life of every
   boundary that reads the key — that is what makes a warm read a pure
-  deref — and two substrate events dispose that reaction underneath it:
+  deref — and three substrate transitions retire what it is holding:
 
   1. a `:sub` **re-registration**, which evicts the query's sub-cache
      entry and disposes the reaction (`subs.cache/invalidate-sub-on-replace!`);
   2. a **frame destruction**, whose teardown disposes the frame's cached
-     reactions — including across a same-id reincarnation.
+     reactions — including across a same-id reincarnation;
+  3. a `:sub` **first registration**, which disposes nothing at all and
+     reaches here through [[first-registration!]] instead.
 
-  Both leave the cell holding a container whose `-dispose` has already
-  run `(reset! watchers {})`, so the watch this arm installed is gone and
-  `mark-dirty!` can never fire for that key again. Measured, before this
-  hook existed: the boundary read the RETIRED computation forever and no
-  later write notified it. That is why neither axis was ever closable by
-  adding a term to `getSnapshot` — the extra render a moved number buys
-  reads back through the same dead cell.
+  The first two leave the cell holding a container whose `-dispose` has
+  already run `(reset! watchers {})`, so the watch this arm installed is
+  gone and `mark-dirty!` can never fire for that key again. Measured,
+  before this hook existed: the boundary read the RETIRED computation
+  forever and no later write notified it. That is why neither axis was
+  ever closable by adding a term to `getSnapshot` — the extra render a
+  moved number buys reads back through the same dead cell. The third
+  leaves it holding the substrate's nil-recovery, which was never wired
+  to anything, and is deaf for the same reason.
 
   Two phases, and the split is what keeps this out of both re-entrant
   windows. **Synchronously** the reaction reference is dropped, which is
@@ -547,10 +568,10 @@
   `subscribe-once`, so every render from this instant on computes against
   the new registration and the live frame. **On a macrotask** the durable
   attachment is rebuilt, so later writes notify again — deferred because
-  this callback runs inside the registrar's replacement hook and inside
-  frame teardown, and neither is a place to subscribe. A frame that did
-  not come back has nothing to rebuild against, and the cell is disposed
-  instead."
+  this callback runs inside the registrar's replacement hook, inside its
+  registration hook and inside frame teardown, and none of them is a
+  place to subscribe. A frame that did not come back has nothing to
+  rebuild against, and the cell is disposed instead."
   [^js cell]
   (when-not (.-disposed cell)
     (set! (.-reaction cell) nil)
@@ -566,6 +587,64 @@
                 (mark-dirty! cell)))))
       0))
   nil)
+
+(defn- first-registration!
+  "**The registry transition no disposal announces** (rf2-2rtt6.44
+  audit follow-up). `registrar/add-replacement-hook!` — the hook the
+  sub-cache eviction that [[invalidate-cell!]] rides is built on — fires
+  only when a previous handler existed. A *first* `reg-sub` for a query
+  therefore evicts nothing, disposes nothing, and would reach an arm that
+  listened for disposals alone by no route whatsoever.
+
+  It has something to reach because a boundary can hold the miss. The
+  substrate is careful that it should not: a subscribe to an unregistered
+  query emits `:rf.error/no-such-sub`, recovers to a nil-yielding
+  reaction, and **deliberately does not cache it**, precisely so that a
+  later registration is observed by the next `subscribe`
+  (`subs/build-and-cache!*`). This arm has exactly one property that
+  breaks that assumption — a cell holds its reaction for the life of
+  every boundary reading the key, and never subscribes again — so the
+  recovery the substrate declined to cache was cached anyway, in a cell,
+  where nothing evicted it. Measured before this: the boundary painted
+  nil for the life of the mount and no later write notified it, on a
+  query that was by then registered.
+
+  So the repair is to restore the substrate's assumption rather than to
+  keep the recovery honest: the same [[invalidate-cell!]] the disposal
+  path uses, off `registrar/add-registration-hook!` — the public sibling
+  that fires on first-time *and* re-registration. Narrowed to the
+  first-time case (`:was` nil), because the re-registration case already
+  arrives as a disposal and doing it twice would rebuild one attachment
+  twice; and to the cells still holding a reaction, because a cell
+  already mid-rebuild has dropped its reference and is about to subscribe
+  against this very registration.
+
+  **Not the rejected registry term, and the difference is the whole
+  costing.** That term sat in every key's contribution to
+  `getSnapshot`, so every mounted boundary in the application re-rendered
+  on every `reg-sub` — and read back through a dead cell when it did.
+  This reaches the cells that hold the id being registered and nothing
+  else: an unrelated first registration moves no snapshot, notifies no
+  boundary, and rebuilds no attachment.
+
+  The scan is `@!cells`, on first-time `:sub` registrations only. Those
+  are namespace-load and lazy-module-load events — an HMR save
+  re-registers, so its ids take the `:was`-non-nil branch and never get
+  here — and at namespace load there are no cells to scan."
+  [{:keys [kind id was]}]
+  (when (and (= :sub kind) (nil? was))
+    (doseq [[sub-key ^js cell] @!cells]
+      (when (and (= id (nth (nth sub-key 1) 0))
+                 (some? (.-reaction cell)))
+        (invalidate-cell! cell))))
+  nil)
+
+(defonce ^:private first-registration-armed
+  ;; Once per process, at load. The hook is the substrate's own extension
+  ;; point and the arm installs nothing else global; it costs a keyword
+  ;; compare and a nil check on every registration of any kind, and the
+  ;; scan above only on a first-time `:sub`.
+  (do (registrar/add-registration-hook! first-registration!) true))
 
 (defn- acquire-cell!
   "**Commit-phase only.** Take (building if necessary) the durable
@@ -716,12 +795,14 @@
   subscribes, derefs and unsubscribes inside this tick and retains
   nothing, so an abandoned render leaves the world as it found it.
 
-  A cell whose reaction the substrate disposed underneath it takes the
-  cold path too, and that is the whole of what an invalidated read needs
-  to be correct: `subscribe-once` computes against the registration and
-  the frame incarnation that are live NOW, so a render in the window
-  between the disposal and [[invalidate-cell!]]'s rebuild reads the new
-  computation rather than the retired one. rf2-2rtt6.44."
+  A cell [[invalidate-cell!]] has dropped the reaction of takes the cold
+  path too, and that is the whole of what an invalidated read needs to be
+  correct: `subscribe-once` computes against the registration and the
+  frame incarnation that are live NOW, so a render in the window between
+  the invalidation and its rebuild reads the new computation rather than
+  the retired one — or, for a key registered for the FIRST time while the
+  boundary was mounted, the real handler rather than the nil-recovery.
+  rf2-2rtt6.44."
   [query-v]
   (when (nil? (.-frame rstate))
     (fail! :rf.error/hicasso-sub-outside-render

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -633,8 +633,14 @@
   here — and at namespace load there are no cells to scan."
   [{:keys [kind id was]}]
   (when (and (= :sub kind) (nil? was))
-    (doseq [[sub-key ^js cell] @!cells]
-      (when (and (= id (nth (nth sub-key 1) 0))
+    ;; `first`, not `(nth … 0)`: a registrar hook's throw is SWALLOWED by
+    ;; `registrar/register!`, so an exception here would not surface as a
+    ;; failure — it would abandon the rest of the scan silently, leaving
+    ;; some cells repaired and some not. `(sub [])` is a legal call that
+    ;; reaches a cell (`subs/subscribe` treats a nil query-id as a miss
+    ;; like any other), and `nth` on it would throw.
+    (doseq [^js cell (vals @!cells)]
+      (when (and (= id (first (.-queryV cell)))
                  (some? (.-reaction cell)))
         (invalidate-cell! cell))))
   nil)

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -645,11 +645,14 @@
         (invalidate-cell! cell))))
   nil)
 
+;; Arm it once per process, at load. `defonce` is the arming, so the var
+;; exists for its side effect and is deliberately never read — the hook
+;; vector is the only thing that holds the fn. The hook is the substrate's
+;; own extension point and the arm installs nothing else global; it costs
+;; a keyword compare and a nil check on every registration of any kind,
+;; and the scan above only on a first-time `:sub`.
+#_:clj-kondo/ignore
 (defonce ^:private first-registration-armed
-  ;; Once per process, at load. The hook is the substrate's own extension
-  ;; point and the arm installs nothing else global; it costs a keyword
-  ;; compare and a nil check on every registration of any kind, and the
-  ;; scan above only on a first-time `:sub`.
   (do (registrar/add-registration-hook! first-registration!) true))
 
 (defn- acquire-cell!

--- a/implementation/freehand/test/re_frame/bench/hicasso/generation_fence_coverage_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/generation_fence_coverage_cljs_test.cljs
@@ -48,15 +48,27 @@
   **rf2-2rtt6.44 settled both, and the rows below survive it unchanged** —
   which is the point of keeping this file. The commit basis is still blind
   to a re-registration, still blind to a reincarnation, and *should be*:
-  the costing found that a registry term would have bought nothing. Both
-  events dispose the reaction the arm's cell holds, so the cell is deaf
-  and derives through a retired computation from that instant; the extra
-  render a moved number scheduled would have read straight back through
-  it. What closes them is the substrate's own disposal event
-  (`arm1.runtime/invalidate-cell!`), armed per unique key, costing nothing
-  in this arithmetic — so `observation/registry-epoch*` stayed `^:private`
-  and no substrate reader was added. `arm1/disposed-cell-cljs-test` is the
-  measurement, both failures pinned and mutation-proved.
+  the costing found that a registry term would have bought nothing. Every
+  one of those events leaves the arm's cell holding a reaction that can no
+  longer answer for its key, so the cell is deaf from that instant; the
+  extra render a moved number scheduled would have read straight back
+  through it. What closes them is `arm1.runtime/invalidate-cell!`, costing
+  nothing in this arithmetic — so `observation/registry-epoch*` stayed
+  `^:private` and no substrate reader was added.
+  `arm1/disposed-cell-cljs-test` is the measurement for the two
+  transitions that reach it as a *disposal*, armed per unique key: a
+  re-registration and a frame teardown.
+
+  The registry axis has one more transition, and it is the one this
+  arithmetic is least able to help with: a **first** registration. It
+  disposes nothing — `registrar/add-replacement-hook!` fires only when a
+  previous handler existed — and it moves neither term of the basis for
+  the same reason a re-registration does not. The arm hears it from
+  `registrar/add-registration-hook!` instead
+  (`arm1.runtime/first-registration!`), still off this arithmetic and
+  still without a registry reader.
+  `arm1/first-registration-cljs-test` is that measurement. All three
+  failures pinned and mutation-proved.
 
   These rows are therefore a **standing statement of scope**: this number
   answers the version axis and only the version axis.
@@ -135,8 +147,11 @@
 
             That is correct and permanent, not a gap awaiting a term:
             rf2-2rtt6.44 closed this axis (and the `:node-key` axis the
-            same argument covers) off the substrate's disposal event
-            instead, leaving this arithmetic exactly as it stands."
+            same argument covers) off the substrate's own events instead
+            — the reaction's disposal for a re-registration and a frame
+            teardown, the registration itself for a first `reg-sub`,
+            which disposes nothing — leaving this arithmetic exactly as
+            it stands."
     (rf/reg-sub (first q) (fn [db _] (:v db)))
     (let [seen (volatile! nil)
           f    (make-frame! ::registry {:v 1})]


### PR DESCRIPTION
The merged-PR audit of #7334 named the one registry transition the disposal
event cannot see, and it turns out to be the one core takes the most care over.

## What the case actually does today, measured

`registrar/add-replacement-hook!` — the hook the sub-cache eviction that
`invalidate-cell!` rides is built on — fires **only when a previous handler
existed**. So a *first* `reg-sub` evicts nothing, disposes nothing, and reaches
an arm listening for disposals by no route whatsoever.

It has something to reach because a boundary can hold the miss, and core is
careful that it should not: a subscribe to an unregistered query emits
`:rf.error/no-such-sub`, recovers to a nil-yielding reaction, and **deliberately
does not cache it**, precisely so "a later registration is observed by the next
subscribe" (`subs/build-and-cache!*`, and the comment there says so). Arm 1
breaks that assumption in the one way it can — a cell holds its reaction for the
life of every boundary reading the key, and never subscribes again — so the
recovery core declined to cache was cached anyway, in a cell, where nothing
evicted it.

Written as a row and run against the pre-fix runtime — render + commit a
boundary on an unregistered query, then `reg-sub` it, then write:

- the render after the registration read **`nil`**, not `1`;
- the write after it notified the boundary **0 times**;
- the render after *that* read **`nil`** again.

For the life of the mount, on a query that was by then perfectly well
registered. Same failure mode `disposed_cell_cljs_test` pins for the replacement
transition — not a stale value but a computation that can never arrive, which
looks alive.

## The fix, and why this shape

The repair is to **restore core's assumption** rather than to keep the recovery
honest: the same `invalidate-cell!` the disposal path already uses, reached from
`registrar/add-registration-hook!` — the public sibling of the replacement hook,
which fires on first-time *and* re-registration. Narrowed twice: to `:was` nil,
because the re-registration case already arrives as a disposal and repairing it
twice would rebuild one attachment twice; and to the cells still holding a
reaction, because a cell already mid-rebuild has dropped its reference and is
about to subscribe against this very registration.

No second mechanism: the trigger is new, the repair is the landed one. The
synchronous drop makes every render from that instant compute through
`subscribe-once` against the live registration; the macrotask rebuild restores
the durable attachment, so later writes notify.

### Why not simply "don't cache the recovery" — measured, not argued

The brief's alternative was the smaller change, so it was **implemented and run**
rather than reasoned about. With `wire-cell!` declining to retain a reaction for
a query the registrar has no handler for, and this PR's hook disarmed, the
witness reports:

- `the next render computes against the registration that now exists` —
  **passes**. Reads do go cold and do see the real handler.
- `later writes notify` — **fails**, `(not (pos? 0))`.

Which is the whole point: not caching fixes the *read*, and nothing triggers a
read. The cell exists, so `getSnapshot` takes the cell's frozen birth epoch
rather than the staged `commit-basis` branch; there is no watch, so no
`mark-dirty!`, so no flush; and a mounted boundary whose read set never changes
never calls `subscribe` again. It stays deaf, and now paints nil *between*
renders that nobody schedules. The registration has to arrive as an event either
way — so the arm takes the event, and keeps the retention that makes a warm read
a pure deref.

A third shape (decline to build the cell at all, and let the staged
`commit-basis` term carry it) was rejected on the same evidence: `reg-sub` moves
neither term of the basis, so it would heal only on the next write to that
frame, and the boundary would then sit permanently in the conservative mode —
re-rendering on every write to its frame and rebuilding its whole input chain
through `subscribe-once` on every render, forever.

## Fences

- **Shell still 2 hooks**, asserted at React's dispatcher by
  `arm1_hook_ledger_dom_cljs_test` and by name in the new cost row. A registrar
  hook is not a React hook.
- **No substrate change.** `observation/registry-epoch*` stays `^:private`, no
  reader added, no private var widened, no spec surface touched.
  `registrar/add-registration-hook!` is the substrate's own documented extension
  point (routing uses it for the same class of job).
- **`subscribe` still closes over the read set alone** — `make-subscribe` is
  untouched by the diff.
- **Snapshot arithmetic untouched.**
  `a-first-registration-of-an-id-no-cell-holds-disturbs-nothing` is the tripwire
  on the alternative this programme declined: an unrelated first registration
  moves no snapshot, notifies no boundary, and rebuilds no attachment.
- **Retained-inventory absences unchanged.** The only new retention is one
  process-global closure in the registrar's hook vector — nothing per boundary,
  per key or per frame, so nothing the heap ladder counts moves.
- The scan is `@!cells`, on first-time `:sub` registrations only. An HMR save
  re-registers, so its ids take the `:was`-non-nil branch and never reach it; at
  namespace load there are no cells to scan. It reads the id off the cell's own
  `queryV` with `first` rather than `nth`, because a registrar hook's throw is
  swallowed by `register!` — an exception there would abandon the rest of the
  scan in silence.

## What this does NOT close, pinned rather than left implied

The audit's charge is the **mounted** case, and that is what the repair closes.
Writing it exposed the neighbouring one, so it is a row rather than a silence:
a first registration landing in the **render→commit gap** reaches no cell,
because the boundary does not have one yet. The epoch sum cannot report it
either — a key with no cell contributes its frame's `commit-basis`, and a
`reg-sub` moves neither term of it — so React's post-`subscribe` re-check sees
the number it captured at render and schedules nothing.

That is the registry axis inside the second window: the same thing
`generation_fence_coverage_cljs_test` already states for a re-registration,
permanently outside this arithmetic and closable only by the registry term this
programme costed and declined (or by recording what a read returned, which is a
fence this arm exists to hold). What saves it is that the commit DID acquire
against the live registration, so the cell holds the real handler, the boundary
is correct from its next render, and the next write to the frame schedules one —
a delayed paint the next write clears, not a retired computation.
`deliberately-a-first-registration-in-the-render-commit-gap-moves-no-snapshot`
asserts every clause of that, including the heal.

**rf2-2rtt6.50** carries the decision, and it is a real one rather than a
formality: the declined registry term would *not* have corrected the mounted
case (the extra render read back through a dead cell) but it *would* correct
this one, because here the cell is alive and holds the right handler. That is an
argument the original costing never had to answer, so it is filed for a ruling
rather than actioned.

## Docstrings

The bead named two places the claim was written down, and a third was found:

- `commit-basis` — was "both events dispose the reaction a cell holds … off the
  substrate's own disposal event". Now: three transitions, all reaching
  `invalidate-cell!`, two through the reaction's disposal and one through
  `first-registration!`.
- the ns docstring's *"The other two axes"* section — the same correction, now
  carrying a three-row table of what each transition leaves the cell holding and
  what announces it.
- `generation_fence_coverage_cljs_test`'s scope statement (not named on the
  bead, but it is the file that states what the basis does not see) — its rows
  are unchanged and still pass; its prose now names the first-registration
  transition and where the measurement lives.

`read-key!`, `wire-cell!` and `invalidate-cell!` are corrected in the same pass:
a first registration invalidates without disposing, so "the reaction the
substrate disposed" was no longer the general case.

## Quality gates

Foreground, worktree-local logs, every exit code echoed, nothing piped through
`tail`/`grep` for its verdict. No bench driver and no heavy browser measurement
was run — `worker/inpage-8nqsl` owns the quiet box.

**The witness, red then green (`arm1/first_registration_cljs_test`, 5 rows / 22
assertions):**

| step | exit | detail |
|---|---|---|
| the case, run against the unfixed runtime | **1** | 4 failures — the render after the registration reads `nil`; the write notifies `0` times; the render after that reads `nil`. This is the establishment: it was run before a line of the fix was written |
| **mutation** on the final tree — the `add-registration-hook!` line removed, nothing else | **1** | `Ran 5 tests containing 22 assertions. 4 failures` — and they fall in exactly the two mounted rows. The gap pin, the unrelated-registration tripwire and the cost row stay green, because none of them depends on the hook; `disposed_cell_cljs_test` stays green too, so the new rows are carried by the new line and not by the landed one |
| mutation restored | **0** | `Ran 5 tests containing 22 assertions. 0 failures` |
| the declined alternative, run on its own | **1** | 2 failures + 1 error — the read heals, the notification does not |

**The suites:**

| gate | exit | result |
|---|---|---|
| `npm run test:cljs` | **0** | 12281 tests / 61509 assertions, 0 failures |
| `npm run test:browser` | **0** | 931 tests / 5840 assertions, 0 failures |
| `scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`. Static + JVM tier (`implementation/core` 2209 tests / 11499 assertions, `implementation/freehand` 1288 tests / 8857 assertions) + node tier (`test:cljs`, the JS-harness self-tests, and per-namespace isolation — the new namespace passes standalone too) |
| clj-kondo **2026.04.15** (CI's pin, fetched — local npm is 2025.10.23), CI's exact `--lint` set | **0** | `errors: 0, warnings: 4530` — and 4530 is the count *without* this change: the three changed files contribute **0 errors and 0 warnings** |

The first full-repo run reported 4531, the extra one being
`Unused private var … /first-registration-armed` — the `defonce` that arms the
hook, which exists for its side effect and is deliberately never read. It is
suppressed at source with the repo's own `#_:clj-kondo/ignore` idiom plus a
comment saying why, rather than left as a new warning. (It was nearly missed:
kondo prints Windows paths with backslashes, so a forward-slash grep over the
log came back empty. The re-grep is what caught it.)

**TESTING.md matrix, derived from the classifier CI itself uses**
(`.github/scripts/report-changed-surfaces.sh` over this diff's paths):
`implementation_jvm`, `cljs_node_test`, `cljs_browser`, `examples_compile`,
`cljs_prod`. The first three ran locally, above — and `cljs_browser` genuinely
covers this change: the seven `re-frame.bench.hicasso.arm1.*-dom-cljs-test`
namespaces are in the `:browser-test` manifest (its `ns-regexp` excludes only
`re-frame.freehand.bench.*`). `examples_compile` and `cljs_prod` are CI lanes
armed by the coarse `implementation/freehand/**` path rule, not because this
change can reach an example build or a release bundle: `arm1.runtime` has
exactly two requirers outside its own tree,
`core/test/re_frame/bench/p0_heap.cljs` and `p0_hicasso.cljs`, both
bench/test-tree.

**Documentation gates.** The spine reports `documentation surface unchanged →
skipping doc gates`, correctly: this diff touches no `docs/**` and no
`mkdocs.yml`. So neither `mkdocs build --strict` (which would not reach
`docs/design/**` anyway) nor `scripts/check_doc_slugs.py` has anything to
validate here — no markdown link target, heading anchor or table was added or
moved outside the two CLJS files' own docstrings.

Closes rf2-2rtt6.44.
