### PR TITLE
bench(hicasso): a published row says which load regime produced it (rf2-cvvb7)

### DIFF
--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -14,7 +14,10 @@ it.
 On per-keystroke it is **indistinguishable from both donors**, and all three are
 one frame. The three bulk rows **could not be measured honestly**; this page
 publishes no magnitude for them and [§6](#6-the-three-rows-this-page-refuses)
-says exactly why.
+says exactly why — including one ground it has since **withdrawn as refuted**,
+and the measured band that replaced it
+([§6.1](#61-the-seam-measured-against-load), [§6.2](#62-what-replaces-it-the-band-a-magnitude-must-clear)).
+Every row now carries the regime it was taken in.
 
 That is the first paragraph because the result is negative, and a negative here
 is decisive information about the six-week clock rather than a failure to
@@ -119,7 +122,12 @@ and is untouched by which adapter is installed. Every figure is a ratio to the
 floor measured in **that round of that segment**, so a cross-segment figure is a
 ratio of two floor-normalised ratios with the seam cancelled. That is a weaker
 interleaving than one segment's, and this page says so rather than describing it
-as though it were sample-level. The seam is measured and published on every row.
+as though it were sample-level. **That the seam cancels is now measured rather
+than asserted** ([§6.1](#61-the-seam-measured-against-load)): the perturbation a
+busy box applies is multiplicative, and a multiplicative perturbation cancels
+exactly. Every row publishes the seam, the null of the seam's own statistic, an
+orthogonal decomposition of where the floor's variation lives, and the **band** a
+magnitude must clear to be one.
 
 - **Witness**: the `M1` page — 300 sub-reading boundaries, 901 elements, one
   `[:p0/cell i]` read per boundary. Identical markup on all three substrates,
@@ -210,11 +218,20 @@ declared beside it.
 ### 3.3 The published run, and the four before it
 
 Run 5 is the published run: it is the only one taken on a genuinely idle box at
-the final tree, and it has the tightest segment seams of any (3.8–8.4% against
-22–34% on runs 3 and 4). All five are tabulated because selecting a run after
-seeing its result is the fault this whole page is built to avoid, and the
-selection here is on a stated pre-condition — a quiet box — with objective
-evidence for it.
+the final tree. All five are tabulated because selecting a run after seeing its
+result is the fault this whole page is built to avoid, and the selection here is
+on a stated pre-condition — a quiet box — with objective evidence for it.
+
+**The evidence originally cited for that pre-condition was the wrong one, and
+[§6.1](#61-the-seam-measured-against-load) is why.** This paragraph used to
+offer run 5's tight segment seams (3.8–8.4% against 22–34% on runs 3 and 4) as
+the objective sign of a quiet box. A nineteen-run load ladder has since shown
+the seam does not track load at all — 4.3% at idle against 4.6% with twenty of
+twenty-four cores saturated — so it cannot be evidence of quietness, and
+selecting on it would have been selecting on noise. The evidence that *does*
+hold is the one the next paragraph already used: **the absolute floor level**,
+which over that same ladder rose from 3.06 to 5.50 ms, an 80% span, and tracks
+load exactly as a busy box should make it.
 
 | run | instrument | `hicasso / reagent-subs` on M1 | `ctl-2x` | box |
 |---|---|---|---|---|
@@ -403,14 +420,18 @@ earns its place. It refused.
    (run 3), **0.9802×** (run 4) and **1.0100×** (run 5). A 59% spread that
    changes the sign of the verdict. The mount row's five estimates span 1.01 to
    1.21 and never change sign; these do.
-3. **On runs 3 and 4 the cross-segment floor seam exceeded the effect.** The
-   *same* floor — identical work, no substrate — read 3.147 / 2.437 / 2.349 ms
-   across the three segments on run 3's `bulk300`: a **34% spread**, against 23%
-   and 22% on the other two bulk rows. Floor-normalisation cancels a
-   *multiplicative* seam, not an additive one. **This reason does not apply to
-   run 5**, whose seams are 3.8–8.4%, and it is kept because a refusal that
-   quietly drops one of its grounds when a later run looks better is not a
-   refusal.
+3. ~~**On runs 3 and 4 the cross-segment floor seam exceeded the effect.**~~
+   **WITHDRAWN — measured and refuted, `rf2-cvvb7`.** The observation stands:
+   the *same* floor — identical work, no substrate — read 3.147 / 2.437 /
+   2.349 ms across the three segments on run 3's `bulk300`, a **34% spread**,
+   against 23% and 22% on the other two bulk rows. The *inference* does not.
+   Floor-normalisation cancels a multiplicative seam and not an additive one,
+   and [§6.1](#61-the-seam-measured-against-load) measures which this is: it is
+   multiplicative, it cancels exactly, and the seam is not attributable to the
+   segment at all. **The rows are still refused, on grounds 1 and 2 and on the
+   band `rf2-cvvb7` put in this ground's place** — which refuses them on a
+   quantity that was measured rather than assumed. A ground is withdrawn here
+   because it was shown wrong, which is the only reason a refusal may drop one.
 
 **One qualitative result from these rows is robust and needs no control**,
 because it does not depend on a magnitude. On the `narrow` row all three
@@ -422,7 +443,151 @@ neither better nor worse at it than the donors are.** The `narrow`-as-a-law win
 condition — commit-side dirty-set flat in `B` across 300/600/1,200/2,400 — is a
 different experiment and this run does not attempt it.
 
-### What a future run would have to change
+### 6.1 The seam, measured against load
+
+Ground 3 above rested on a comparison between two runs — 34% on one, 3.8% on
+another — with *"nothing changed but how busy the machine was"* offered as the
+difference. Two points are a line through two dots. `rf2-cvvb7` put a stated
+number of competing busy cores on the box and took the row nineteen times.
+
+`seam_ladder.cjs` forks *N* spinners, each walking a 4 MB array so it competes
+for cache and memory bandwidth as well as cycles, runs the clock, and kills
+them. Every spinner carries its own deadline, so it cannot outlive its window if
+the parent dies, and `--load` is capped four cores below the box.
+
+| competing cores | runs | floor ms | seam | SEGMENT | ROUND | POSITION | band |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 0 | 4 | 3.433 | 4.3% | 5.5% | 30.2% | 6.1% | 9.3% |
+| 2 | 3 | 3.728 | 7.0% | 4.9% | 41.4% | 9.9% | 6.8% |
+| 4 | 3 | 4.442 | 5.9% | 6.1% | 17.0% | 5.9% | 8.0% |
+| 8 | 3 | 4.696 | 3.5% | 4.0% | 27.4% | 5.0% | 9.5% |
+| 12 | 3 | 5.365 | 3.7% | 4.8% | 20.3% | 3.8% | 13.5% |
+| 20 | 3 | 4.659 | 4.6% | 4.0% | 8.2% | 3.2% | 6.4% |
+
+**The ladder unquestionably moved the box**: the absolute floor rose from 3.06
+to 5.50 ms, an **80% span**. It is monotone to twelve cores and turns over at
+twenty, which is not explained here and is left in rather than smoothed.
+
+**The seam did not move with it.** Over all nineteen runs it read **0.1%–16.4%,
+mean 4.8%**, with no trend — 4.3% at idle against 4.6% at twenty saturated
+cores. Row position inside the process does not explain it either: a five-row
+run read 4.9 / 2.4 / 1.1 / 9.4 / 3.3% across its five rows. So the published
+34% is not what a busy box does to this design, and **what produced it remains
+unidentified**.
+
+**And it is not attributable to the segment.** The seam is a max-over-min of
+three noisy block medians, which has a long right tail even when segment
+identity means nothing at all, so the instrument now takes that tail
+explicitly: relabel the three segments *within* each round — keeping every
+round's three blocks together and destroying only which segment owned which —
+and recompute the same statistic.
+
+| the seam's own null, pooled over 19 runs × 2,000 relabellings | |
+|---|---:|
+| median | 5.5% |
+| q95 | 14.1% |
+| q99 | 17.6% |
+| q99.9 | 23.9% |
+| largest of 38,000 draws | 26.8% |
+
+Every observed seam sat at or below that null's median, and **not one of the
+nineteen runs reached p < 0.2**. The published 22% is a 1-in-400 draw from it.
+The published 34% is beyond all 38,000 draws — which is the honest shape of the
+finding: it is not noise of this kind either, and nothing this study could
+produce reproduced it.
+
+Where the floor's variation actually lives is the **round**, not the segment.
+The rotation makes segment, round and position-in-round mutually orthogonal
+whenever the number of rounds is a multiple of the number of segments, and the
+instrument checks that balance rather than assuming it.
+
+**The perturbation is multiplicative, so floor-normalisation cancels it, and
+the arithmetic is exact**: `(k·H)/(k·F) = H/F`, to the last bit, for any `k`.
+The measurement that says it is multiplicative rather than additive is
+`ctl-2x / floor` — two arms in the *same* block whose true ratio is a property
+of the page and not of the box:
+
+| across the ladder's 80% floor span | |
+|---|---:|
+| `ctl-2x / floor` moved | 6.5% (1.657 → 1.765) |
+| correlation of that ratio with the floor | **+0.41** — an additive `c` reads `(2W+c)/(W+c)`, which *falls* as `c` grows, so the sign is wrong for additivity |
+| correlation of the published bar row with the floor | **−0.10** |
+| correlation of the published bar row with the seam | **−0.18** |
+| `hicasso / reagent-subs` over all 19 runs | 1.0161, [0.9643 – 1.1041] |
+
+So a bar row does not move when the floor moves by 80%, and does not move with
+the seam. **The bar row was not quoting the seam.**
+
+### 6.2 What replaces it: the band a magnitude must clear
+
+The seam was the wrong statistic to gate on. What bounds a bar row is not how
+far apart two segments' floors are; it is **how much of a block's perturbation
+fails to cancel when that block's own floor is divided out** — and `ctl-2x /
+floor` measures exactly that, because its true value is fixed. The **band** is
+the half-width of the p10–p90 interval of that ratio over the run's eighteen
+segment-blocks, relative to its median. An interior quantile rather than a
+max/min, because a max/min over eighteen blocks is the tail-heavy statistic this
+section exists to stop trusting.
+
+It is deliberately conservative: `ctl-2x` and `floor` differ in size (1,801
+against 901 elements), so a perturbation that is multiplicative but
+size-dependent lands in this ratio and would not land between a substrate arm
+and its own same-size floor. The band therefore over-states the noise a real bar
+row carries, which is the direction a gate should err in.
+
+It is also calibrated. Over the ladder the band averaged **8.9%** while the bar
+row's own run-to-run spread was ±7% around 1.016 — it predicts the noise a bar
+row actually carries.
+
+**The rule, and it is a generalisation of one this programme already has.**
+`validation.md` holds that *a margin under 5% is instrument-limited rather than
+cleared*. That 5% is assumed. The band is the same rule with the figure
+**measured by the run itself**: a magnitude whose distance from 1.0 is inside
+the band is instrument-limited and the row says so. A run whose band exceeds
+**25%** has no reportable magnitude at all — a tripwire that did *not* fire
+anywhere on the ladder that calibrated it (bands 4.4%–18.5%), because a ceiling
+tight enough to fire there would have refused an **idle** run: the widest band
+of the nineteen was taken at zero load.
+
+**The new rule reproduces both verdicts this page already reached**, from one
+measured quantity instead of three assorted grounds — which is the check on it,
+since a gate that changed the answers would need arguing for rather than
+adopting.
+
+Run 5 predates the band and its raw readings were not kept, so the band cannot
+be recomputed for it. Only `M1` publishes both ends of its control's range and
+so admits a conservative max/min stand-in — `(2.1817 − 1.7258) / (2 × 1.9534)`
+= 11.7%, which the shipped p10–p90 definition would put *below*. The bulk rows
+publish only their worst round, which is not enough to reconstruct a band; what
+settles them is that their margins are smaller than **any** band this
+instrument has ever produced, the tightest of twenty runs being 4.4%.
+
+| run 5 row | margin from 1.0 | against | verdict |
+|---|---:|---|---|
+| `M1`, `hicasso / reagent-subs` 1.2107 | 21.1% | its own band, ≤ 11.7% | **clears** — published, as it was |
+| `bulk300` 1.0100 | 1.0% | smaller than every band ever measured here | instrument-limited — refused, as it was |
+| `bulk100` 0.9902 | 1.0% | the same | instrument-limited — refused, as it was |
+| `narrow` 1.0369 | 3.7% | the same | instrument-limited — refused, as it was |
+
+And on the first run taken with the band instrument itself in place — five rows,
+idle box, same design — every row now carries its regime:
+
+| row | seam | band | `hicasso / reagent-subs` | disposition |
+|---|---:|---:|---:|---|
+| `M1` | 6.7% | 9.4% | 1.0952 | margin 9.5% **clears**, barely |
+| `bulk300` | 3.3% | 7.7% | 1.0084 | margin 0.8% — instrument-limited |
+| `bulk100` | 3.9% | 7.7% | 1.0299 | margin 3.0% — instrument-limited |
+| `narrow` | 6.2% | 10.6% | 1.0358 | margin 3.6% — instrument-limited |
+| `keystroke` | 0.7% | — | 0.9284 | **unadjudicated** — no proportional control |
+
+`keystroke` has no band and is marked rather than passed. Its control burns a
+fixed 50 ms instead of doubling the page, so `control / floor` reads `(F+50)/F`
+and moves with `F`; it is not a pair whose true ratio is a property of the page,
+and a row with no gate must not report as though it had cleared one. That is a
+result about the keystroke row's control, and it is [§6.3](#63-what-a-future-run-would-have-to-change)'s
+first bullet arriving from the other direction.
+
+### 6.3 What a future run would have to change
 
 Filed rather than attempted here, because each is a different instrument:
 
@@ -432,11 +597,13 @@ Filed rather than attempted here, because each is a different instrument:
   even a perfect instrument reads below 2.00 and the control is mis-specified
   for the row rather than the clock being wrong. A control that doubles the
   *changed set* at fixed page size is the right one.
-- **The segment seam, measured rather than assumed to cancel.** It was 34% on
-  one run and 3.8% on another with nothing changed but how busy the machine was.
-  A run that alternates segments *within* a round, or prices the seam with a
-  second floor at the segment's other end, would say whether it is an order
-  effect, GC, or the adapter install itself.
+- ~~**The segment seam, measured rather than assumed to cancel.**~~ **Done —
+  [§6.1](#61-the-seam-measured-against-load), `rf2-cvvb7`.** A nineteen-run load
+  ladder and an exact within-round relabelling null answered it without needing
+  a second floor arm: the variation is on the **round**, the perturbation is
+  multiplicative and cancels exactly, and the seam is not attributable to the
+  segment. The band in [§6.2](#62-what-replaces-it-the-band-a-magnitude-must-clear)
+  replaces it as the gate.
 - **More rounds.** The strict rule bites on round-level variance, and 6 × 10 is
   what the mount row needed rather than what these rows need.
 
@@ -444,9 +611,19 @@ Filed rather than attempted here, because each is a different instrument:
 
 ## 7. Provenance
 
-Every row on this page comes from **one run** — run 5 — of one instrument. The
-four runs before it are tabulated in [§3.3](#33-the-published-run-and-the-four-before-it)
-as the instrument's development record and are never averaged with it.
+Every **magnitude** on this page comes from **one run** — run 5 — of one
+instrument. The four runs before it are tabulated in
+[§3.3](#33-the-published-run-and-the-four-before-it) as the instrument's
+development record and are never averaged with it.
+
+**[§6.1](#61-the-seam-measured-against-load) and [§6.2](#62-what-replaces-it-the-band-a-magnitude-must-clear)
+are a separate study on separate runs and are kept separate deliberately.** They
+are twenty runs taken for `rf2-cvvb7` on the same box, at the blobs in the
+second table below, and they contribute **no magnitude** to any row above — they
+are about the instrument, not about the candidate. The one figure they publish
+about an arm, `hicasso / reagent-subs` over nineteen `bulk300` runs, is there to
+show that the bar row does not move with the floor or with the seam, and it is
+not offered as a `bulk300` result: `bulk300` is refused.
 
 | | |
 |---|---|
@@ -479,6 +656,34 @@ and 5 comparable, and `git diff` between the two commits is the check. Runs 1
 and 2 were taken on the two commits before that and are the *different*
 instruments §3.1 describes.
 
+### 7.1 The seam study (`rf2-cvvb7`)
+
+Twenty runs, on the same box and the same Chromium, taken **after** the rows
+above and contributing no magnitude to them. The page half was untouched, which
+is what makes the seam study's floor comparable with run 5's: `clock_app.cljs`
+and `clock_views.cljs` are at the blobs in the table above, unchanged.
+
+| file | blob |
+|---|---|
+| `implementation/freehand/test/re_frame/bench/hicasso/seam.cjs` | `a6789197e1bd9744879a2c8a143e48dc643b7f26` |
+| `implementation/freehand/test/re_frame/bench/hicasso/seam_ladder.cjs` | `ae0ddf6e1df15c8d5ad2e90a35154258762a553a` |
+| `implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs` | `f5bb751d6692b894cfc361ff1c54bfd782cf95d0` |
+
+| | |
+|---|---|
+| Design | 6 rounds × (4 warm-up + 10 samples) per arm per segment, unchanged from run 5 |
+| Ladder | 19 runs of `bulk300` at 0 / 2 / 4 / 8 / 12 / 20 competing busy cores, 3–4 replicates a rung, plus one five-row run at zero load for the row-position control |
+| Band run | 1 five-row run at zero load, the first taken with the band instrument in place |
+| Load windows | two, 23:10–23:17 and 23:18–23:23 AUSEST 2026-08-01, each rung a single ~40 s run with the load released between runs |
+| Reproduction | `node freehand/test/re_frame/bench/hicasso/seam_ladder.cjs --load 12 --label x --json out/x.json`, and `node freehand/test/re_frame/bench/hicasso/seam.cjs` for the adjudicator's own self-test |
+| Discarded | none. Every run that started finished; the driver writes no dataset for a run that died part-way, so a partial one cannot be analysed by mistake |
+
+The 19 ladder runs were taken with the seam adjudicator **not yet wired in**, so
+nothing they measured was influenced by the gate they calibrate; the ladder
+figures in [§6.1](#61-the-seam-measured-against-load) are recomputed from their
+stored raw readings using the shipped `seam.cjs`, so the published figures and
+the instrument's figures are the same figures.
+
 ---
 
 ## 8. What this hands the programme
@@ -497,7 +702,20 @@ instruments §3.1 describes.
   them. A pass on the user-facing axis, for the candidate and both donors alike.
 - **The bulk rows remain unmeasured** — the same place they were before this
   page, but now with a named instrument, a named failure mode and three named
-  repairs.
+  repairs, and refused on a **measured** quantity rather than an assumed one.
+- **Every row now says which regime produced it.** The seam is published with
+  the null of its own statistic and an orthogonal decomposition; the band — the
+  part of a block's perturbation that survives floor-normalisation — is measured
+  on every row and a magnitude inside it is marked instrument-limited. That
+  turns `validation.md`'s assumed *"a margin under 5% is instrument-limited"*
+  into a figure each run measures for itself.
+- **One of this page's own refusal grounds was wrong, and a load ladder found
+  it.** The seam does not track load, is not attributable to the segment, and is
+  multiplicative — so it cancels, exactly. The ground is withdrawn and the
+  measurement that withdrew it is published beside it. The general lesson is
+  cheap and reusable: a max-over-min of three noisy block medians has a long
+  right tail, and quoting one without its null invites a reader to treat 6% as a
+  finding.
 - **An in-page `performance.now()` window mis-reads a substrate arm by 300–610%,
   and by a different factor per arm.** That is the strongest methodological
   finding here. It does not overturn a published row, and it does mean no

--- a/docs/design/hicasso/studio/the-candidates-clock.md
+++ b/docs/design/hicasso/studio/the-candidates-clock.md
@@ -518,6 +518,23 @@ of the page and not of the box:
 So a bar row does not move when the floor moves by 80%, and does not move with
 the seam. **The bar row was not quoting the seam.**
 
+**Reconciled with the window audit**, which landed alongside this and reads the
+seam at **31.9%** on its own runs
+([the clock behind the published rows](the-clock-behind-the-published-rows.md)).
+That figure is a **single round's** cross-segment spread, and single-round
+spreads of 30–45% are ordinary here — this ladder saw 45% in one round of an
+*idle* run whose pooled seam was 3.8%. So the audit corroborates the
+*observation* and not the *load attribution*; the pooled statistic is the one
+§6 quoted and the one this ladder moved a box under without shifting.
+
+The two pages also reach cancellation by different routes, and conflating them
+would overstate both. The audit's `(U/F) ÷ (R/F) = U/R` is **algebra**, and it
+is exact only where both legs are divided by the *same* floor — the converged
+witness, whose arms share one segment. Here the three segments have three
+different floors, so nothing cancels algebraically; what makes it cancel is the
+measured fact that the perturbation is multiplicative. Same conclusion, and only
+one of the two is free.
+
 ### 6.2 What replaces it: the band a magnitude must clear
 
 The seam was the wrong statistic to gate on. What bounds a bar row is not how

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -105,6 +105,12 @@ const WARMUP = Number(process.env.HCLOCK_WARMUP || 4);
 const SAMPLES = Number(process.env.HCLOCK_SAMPLES || 10);
 const NO_BUILD = process.argv.includes('--no-build');
 
+// Where to write the run's RAW per-sample readings, if anywhere. The seam
+// study (rf2-cvvb7) had to compare eleven runs against each other, and a
+// console line is not a dataset: the segment decomposition below is
+// recomputed from this file rather than scraped back out of the log.
+const JSON_OUT = (process.env.HCLOCK_JSON || '').trim();
+
 // The lane's slack, unchanged and for its reason: the claim a clock
 // control certifies is THE INSTRUMENT HAS SIGNAL, not THE MODEL IS EXACT.
 // A top-down React re-render is not perfectly linear in element count —
@@ -598,6 +604,7 @@ function report(out) {
   // --- the floor seam -------------------------------------------------------
   const floorBySeg = SEGMENTS.map((s) => p50(rounds.flatMap((r) => r[s][FLOOR])));
   const seamSpread = Math.max(...floorBySeg) / Math.min(...floorBySeg);
+  const seam = { floorBySeg: floorBySeg.map(r4), pooledSpread: r4(seamSpread - 1) };
   console.log(
     `;; seam     the SAME floor read ${SEGMENTS.map((s, i) => `${s} ${floorBySeg[i].toFixed(3)}`).join(', ')} ms ` +
       `— spread ${((seamSpread - 1) * 100).toFixed(1)}%. Every figure below is floor-normalised WITHIN its ` +
@@ -770,7 +777,7 @@ function report(out) {
   const v = guard.verdict(samples, { tolerance: 0.1 });
   for (const line of guard.format(v, `${rowId} — frame-inclusive task time`)) console.log(line);
 
-  return { bar, ctlVerdict, etVerdict, guardVerdict: v, parityOk: disagree.length === 0, tally };
+  return { bar, ctlVerdict, etVerdict, guardVerdict: v, parityOk: disagree.length === 0, tally, seam };
 }
 
 // ---------------------------------------------------------------------------
@@ -863,8 +870,47 @@ function report(out) {
   }
 
   if (died) {
+    // A RUN THAT DIED IS NOT A RUN. Nothing is written, including the
+    // rows that completed before it: a partial dataset on disk is the
+    // shape of `rf2-6t03c`'s recorded fault, where a stale artefact was
+    // silently measured after the thing that produced it had aborted.
     console.error(`[clock] FAILED: ${died}`);
     process.exit(1);
+  }
+
+  if (JSON_OUT) {
+    fs.mkdirSync(path.dirname(path.resolve(JSON_OUT)), { recursive: true });
+    fs.writeFileSync(
+      path.resolve(JSON_OUT),
+      JSON.stringify(
+        {
+          label: process.env.HCLOCK_LABEL || null,
+          load: process.env.HCLOCK_LOAD === undefined ? null : Number(process.env.HCLOCK_LOAD),
+          chromium: version,
+          node: process.version,
+          when: new Date().toISOString(),
+          design: { rounds: ROUNDS, warmup: WARMUP, samples: SAMPLES, tare: TARE, segments: SEGMENTS },
+          rows: outcomes.map((o) => ({
+            rowId: o.out.rowId,
+            // Raw per-sample task-time readings, [round][segment][arm].
+            // Everything the seam decomposition needs is derived from
+            // these; the segment's POSITION in a round is
+            // `(SEGMENTS.indexOf(seg) - round) mod 3` by construction.
+            rounds: o.out.rounds,
+            decomposition: o.out.decomposition,
+            granularity: o.out.granularity,
+            seam: o.verdict.seam,
+            tally: o.verdict.tally,
+            ctlOk: o.verdict.ctlVerdict ? o.verdict.ctlVerdict.ok : null,
+            guardRefuse: o.verdict.guardVerdict.refuse,
+            bar: o.verdict.bar,
+          })),
+        },
+        null,
+        1
+      )
+    );
+    console.error(`[clock] raw readings -> ${path.resolve(JSON_OUT)}`);
   }
 
   const errored = outcomes.filter((o) => o.out.pageErrors.length > 0);

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -133,7 +133,7 @@ const SAMPLES = Number(process.env.HCLOCK_SAMPLES || 10);
 const NO_BUILD = process.argv.includes('--no-build');
 
 // Where to write the run's RAW per-sample readings, if anywhere. The seam
-// study (rf2-cvvb7) had to compare eleven runs against each other, and a
+// study (rf2-cvvb7) had to compare twenty runs against each other, and a
 // console line is not a dataset: the segment decomposition below is
 // recomputed from this file rather than scraped back out of the log.
 const JSON_OUT = (process.env.HCLOCK_JSON || '').trim();

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -67,6 +67,32 @@
 // (Playwright's `keyboard.press`), because a JavaScript-dispatched event
 // is not a user interaction and Event Timing reports user interactions.
 //
+// ## EVERY ROW SAYS WHICH REGIME PRODUCED IT (rf2-cvvb7)
+//
+// The first pass of this driver printed a cross-segment floor seam and hoped
+// it cancelled, and `the-candidates-clock.md` §6 refused three rows partly
+// because that seam once read 34% where a later run read 3.8%. A run whose
+// seam swings like that cannot tell a reader which regime it was taken in,
+// so `seam.cjs` now measures the regime and every row carries it:
+//
+//   * the seam, WITH THE NULL of its own statistic — segments relabelled
+//     within each round — because a max-over-min of three noisy block
+//     medians has a long right tail with nothing to attribute it to, and a
+//     seam published bare invites a reader to treat 6% as a finding;
+//   * where the floor's variation lives, decomposed orthogonally into
+//     SEGMENT, ROUND and POSITION-IN-ROUND. A nineteen-run load ladder put
+//     it on the round, not the segment;
+//   * THE BAND — how much of a block's perturbation survives dividing by
+//     that block's own floor, measured on `ctl-2x / floor`, two arms in one
+//     block whose true ratio is a property of the page. A magnitude whose
+//     margin is inside the band is INSTRUMENT-LIMITED and says so on the
+//     row.
+//
+// `seam.cjs`'s header carries the ladder and the arithmetic. The short of it
+// is that the perturbation a busy box applies is MULTIPLICATIVE and cancels
+// exactly, the seam does not track load at all, and the band is the number
+// that was actually wanted.
+//
 // ## EXIT CODES — the guard owns 2, and it is not the arm's to move
 //
 //   0  measured, guard clean, controls passed
@@ -91,6 +117,7 @@ const path = require('node:path');
 const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs');
 const { resetLaneBuildCache } = require('../../freehand/bench/lane_cache.cjs');
 const guard = require('../../freehand/bench/order_guard.cjs');
+const seamlib = require('./seam.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 
@@ -601,15 +628,59 @@ function report(out) {
       `(${plumbBySeg.join(', ')}) — ${TARE ? 'SUBTRACTED from every figure below' : 'NOT subtracted (HCLOCK_TARE=off)'}`
   );
 
-  // --- the floor seam -------------------------------------------------------
-  const floorBySeg = SEGMENTS.map((s) => p50(rounds.flatMap((r) => r[s][FLOOR])));
-  const seamSpread = Math.max(...floorBySeg) / Math.min(...floorBySeg);
-  const seam = { floorBySeg: floorBySeg.map(r4), pooledSpread: r4(seamSpread - 1) };
-  console.log(
-    `;; seam     the SAME floor read ${SEGMENTS.map((s, i) => `${s} ${floorBySeg[i].toFixed(3)}`).join(', ')} ms ` +
-      `— spread ${((seamSpread - 1) * 100).toFixed(1)}%. Every figure below is floor-normalised WITHIN its ` +
-      `segment, so this cancels; it is published because a segment seam that is not published is not cancelled either`
-  );
+  // --- the bar row ----------------------------------------------------------
+  // Computed HERE and printed below, because the seam block adjudicates it:
+  // a magnitude is reportable only against the band the same run measured,
+  // and the band has to be in hand before the seam block can say so.
+  const bar = {};
+  const barMeans = {};
+  for (const den of ['reagent-subs', 'uix-subs']) {
+    const v = crossSegment(rounds, 'hicasso', 'hicasso', den, den, false);
+    const rv = crossSegment(rounds, 'hicasso', 'hicasso', den, den, true);
+    bar[den] = { tared: v, untared: rv };
+    barMeans[`hicasso / ${den}`] = v.mean;
+  }
+
+  // --- the floor seam, its null, and the band a magnitude must clear ---------
+  //
+  // rf2-cvvb7 measured what this seam is and what it does. A nineteen-run
+  // load ladder — 0, 2, 4, 8, 12 and 20 competing busy cores on a 24-core
+  // box — moved the absolute floor by 80% and left the seam unmoved
+  // (0.1–16.4%, no trend), showed the seam is not attributable to the
+  // segment under an exact within-round relabelling null, and showed the
+  // perturbation is MULTIPLICATIVE, so floor-normalisation cancels it
+  // exactly. What a bar row must clear is not the seam; it is the part of a
+  // block's perturbation that survives dividing by that block's own floor,
+  // and `seam.cjs` measures that on `ctl-2x / floor`.
+  const floorBlocks = rounds.map((r) => SEGMENTS.map((s) => r[s][FLOOR]));
+  const floorCells = rounds.map((_, i) => SEGMENTS.map((s) => tared(rounds, s, FLOOR, i)));
+  const hasProportionalControl = rowId !== 'keystroke';
+  const fixedCells = hasProportionalControl
+    ? rounds.map((_, i) => SEGMENTS.map((s) => tared(rounds, s, 'ctl-2x', i)))
+    : null;
+  const assessed = seamlib.assess({
+    floorBlocks,
+    floorCells,
+    fixedCells,
+    bars: barMeans,
+    noFixedPairWhy:
+      "this row's control burns a fixed 50 ms rather than doubling the page, so control/floor " +
+      'reads (F+50)/F and moves with F — not a pair whose true ratio is a property of the page',
+  });
+  for (const line of seamlib.format(assessed, SEGMENTS)) console.log(line);
+  const seam = {
+    floorBySeg: assessed.seam.bySeg.map(r4),
+    pooledSpread: r4(assessed.seam.spread),
+    null: { q50: r4(assessed.null.q50), q95: r4(assessed.null.q95), q99: r4(assessed.null.q99), p: assessed.null.p },
+    effects: {
+      segment: r4(assessed.effects.segment),
+      round: r4(assessed.effects.round),
+      position: r4(assessed.effects.position),
+      balanced: assessed.effects.balanced,
+    },
+    band: Number.isFinite(assessed.bandStats.band) ? r4(assessed.bandStats.band) : null,
+    verdict: assessed.verdict,
+  };
 
   // --- the rows -------------------------------------------------------------
   console.log(`;; ---- per-arm, ratio to the floor measured in that round of that segment ----`);
@@ -633,16 +704,15 @@ function report(out) {
 
   // --- the bar row ----------------------------------------------------------
   console.log(`;; ---- THE BAR: candidate against each donor, both floor-normalised ----`);
-  const bar = {};
   for (const den of ['reagent-subs', 'uix-subs']) {
-    const v = crossSegment(rounds, 'hicasso', 'hicasso', den, den, false);
-    const rv = crossSegment(rounds, 'hicasso', 'hicasso', den, den, true);
-    bar[den] = { tared: v, untared: rv };
+    const { tared: v, untared: rv } = bar[den];
+    const adj = assessed.verdict.rows[`hicasso / ${den}`];
     console.log(
       `;;   hicasso / ${den.padEnd(14)} ${v.mean.toFixed(4)}x [${v.min.toFixed(4)} – ${v.max.toFixed(4)}]` +
         `   (untared ${rv.mean.toFixed(4)}x [${rv.min.toFixed(4)} – ${rv.max.toFixed(4)}])` +
         (v.straddles1 ? '   — RANGE STRADDLES 1.0, indistinguishable at this n' : '')
     );
+    console.log(`;;     ${adj.unadjudicated ? 'UNADJ  ' : adj.clear ? 'CLEARS ' : 'LIMITED'} ${adj.why}`);
   }
 
   // --- the two instruments, side by side ------------------------------------
@@ -803,6 +873,16 @@ function report(out) {
   }
   console.error(`[clock] arm-order guard self-test: ${st.checks.length} checks, all ok`);
 
+  const sst = seamlib.selfTest();
+  const badSeam = sst.checks.filter((c) => !c.ok);
+  if (badSeam.length > 0) {
+    console.error(`[clock] the seam adjudicator's own self-test FAILED: ${badSeam.map((c) => c.name).join(', ')}`);
+    await browser.close();
+    server.close();
+    process.exit(1);
+  }
+  console.error(`[clock] seam adjudicator self-test: ${sst.checks.length} checks, all ok`);
+
   console.log(`;; ==== HICASSO CANDIDATE CLOCK ====`);
   console.log(`;; chromium ${version} (playwright), :advanced, goog.DEBUG false`);
   console.log(`;; rows      ${ROWS.join(', ')}`);
@@ -949,6 +1029,28 @@ function report(out) {
     );
     process.exit(1);
   }
+  // THE BAND CEILING is a tripwire and is honest about being one. The
+  // nineteen-run ladder that calibrated it produced bands of 4.4–18.5%
+  // INCLUDING the rung with twenty of twenty-four cores saturated, and the
+  // ceiling sits at 25% above all of them — so this gate did not fire
+  // anywhere on its own calibration. It catches a box outside that whole
+  // range, in which the instrument's own reproducibility has gone and no
+  // magnitude means anything. The gate that actually bites is the per-row
+  // one printed in the seam block: a margin inside the band is
+  // instrument-limited.
+  const overCeiling = outcomes.filter((o) => o.verdict.seam.verdict.ceilingBreached);
+  if (overCeiling.length > 0) {
+    console.error(
+      `[clock] FAILED: the run's own reproducibility band exceeds the ` +
+        `${(seamlib.BAND_CEILING * 100).toFixed(0)}% ceiling on: ` +
+        overCeiling.map((o) => `${o.out.rowId} (${(o.verdict.seam.band * 100).toFixed(1)}%)`).join(', ') +
+        `. ctl-2x and floor are two arms in the SAME block whose true ratio is a property of the ` +
+        `page, so a band that wide means the box could not reproduce identical work — no magnitude ` +
+        `from those rows is reportable, whatever its margin.`
+    );
+    process.exit(1);
+  }
+
   const ctlFailed = outcomes.filter((o) => !o.verdict.ctlVerdict.ok || (o.verdict.etVerdict && !o.verdict.etVerdict.ok));
   if (ctlFailed.length > 0) {
     const passed = outcomes.filter((o) => !ctlFailed.includes(o)).map((o) => o.out.rowId);

--- a/implementation/freehand/test/re_frame/bench/hicasso/seam.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/seam.cjs
@@ -44,7 +44,7 @@
 //   * THE PERTURBATION IS MULTIPLICATIVE, so floor-normalisation cancels it
 //     and the arithmetic is exact: `(k·H)/(k·F) = H/F`. Across the ladder's
 //     80% floor span, `ctl-2x / floor` — two arms in the SAME block whose
-//     true ratio is a property of the page — moved 5% and moved the WRONG
+//     true ratio is a property of the page — moved 6.5% and moved the WRONG
 //     WAY for additivity (correlation with the floor +0.41; an additive `c`
 //     reads `(2W+c)/(W+c)`, which FALLS as `c` grows). The published bar
 //     row did not move with the floor at all (correlation -0.10), nor with
@@ -483,11 +483,20 @@ function selfTest() {
       v.rows.tight.clear === false && v.rows.wide.clear === true,
       `${v.rows.tight.why} | ${v.rows.wide.why}`
     );
-    const v2 = adjudicate({ wide: 1.35 }, 0.2);
+    // Stated against BAND_CEILING rather than a literal, so moving the
+    // ceiling cannot leave this check silently testing nothing — which is
+    // exactly what a literal 0.2 did when the ceiling moved from 15% to 25%.
+    const v2 = adjudicate({ wide: 1.35 }, BAND_CEILING + 0.05);
     check(
       'a band above the ceiling takes EVERY magnitude with it, however wide the margin',
       v2.ceilingBreached && v2.rows.wide.clear === false,
       v2.rows.wide.why
+    );
+    const v2ok = adjudicate({ wide: 1.35 }, BAND_CEILING - 0.05);
+    check(
+      'a band just BELOW the ceiling does not breach, so the ceiling check is not vacuous',
+      v2ok.ceilingBreached === false && v2ok.rows.wide.clear === true,
+      v2ok.rows.wide.why
     );
     // A NaN band must refuse rather than pass: `margin > NaN` is false, so
     // `clear` is already false, but the ceiling test has to agree — written

--- a/implementation/freehand/test/re_frame/bench/hicasso/seam.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/seam.cjs
@@ -1,0 +1,554 @@
+#!/usr/bin/env node
+'use strict';
+// THE SEGMENT SEAM, ITS NULL, AND THE BAND A MAGNITUDE MUST CLEAR (rf2-cvvb7).
+//
+//   node .../seam.cjs            the deterministic self-test
+//
+// ## The finding this module exists to carry
+//
+// `the-candidates-clock.md` §6 refused three rows, and one of its three
+// grounds was the cross-segment floor seam: the SAME floor arm — identical
+// work, no substrate, untouched by which adapter is installed — read
+// 3.147 / 2.437 / 2.349 ms across the three segments on one run's
+// `bulk300`, a 34% spread, while a later run on a quieter box read 3.8% on
+// the same row. The ground reasoned that floor-normalisation cancels a
+// MULTIPLICATIVE seam and not an ADDITIVE one, so a bar row formed across
+// segments that disagree by 34% is quoting the seam.
+//
+// A load ladder settled it. Nineteen runs of `bulk300` at a stated number
+// of competing busy cores — 0, 2, 4, 8, 12 and 20 of this box's 24 —
+// produced:
+//
+//   * THE SEAM DOES NOT TRACK LOAD. Pooled seam 0.1% – 16.4%, mean 4.8%,
+//     with no trend: 4.3% at idle and 4.6% at twenty competing cores. Over
+//     the same ladder the absolute floor rose 3.06 -> 5.50 ms, an 80% span,
+//     so the ladder unquestionably moved the box. "How busy the machine
+//     was" therefore does not explain the published 34%, and neither does
+//     row position within the process (a five-row run read 4.9 / 2.4 / 1.1
+//     / 9.4 / 3.3% across its five rows).
+//   * IT IS NOT SEGMENT-ATTRIBUTABLE. [[seamNull]] relabels the segments
+//     WITHIN each round — keeping every round's three blocks together and
+//     destroying only which segment owned which — and recomputes the same
+//     statistic. Pooled over the nineteen runs the null's median is 5.5%,
+//     its q95 14.1% and its q99 17.6%, because a max-over-min of three
+//     noisy block medians has a long right tail even when segment identity
+//     means nothing. NOT ONE of the nineteen runs reached p < 0.2, and the
+//     observed seams sit at or below that null's median. The published 22%
+//     is a 1-in-400 draw from it; the published 34% is beyond all 38,000
+//     permutations and beyond every rung of the ladder, and remains
+//     unexplained by anything this study could reproduce.
+//   * WHERE THE FLOOR'S VARIATION ACTUALLY LIVES is the round, not the
+//     segment: by rung, ROUND 8–41% against SEGMENT 4.0–6.1% and
+//     POSITION-in-round 3.2–9.9%. The three are orthogonal by construction
+//     (see [[effects]]).
+//   * THE PERTURBATION IS MULTIPLICATIVE, so floor-normalisation cancels it
+//     and the arithmetic is exact: `(k·H)/(k·F) = H/F`. Across the ladder's
+//     80% floor span, `ctl-2x / floor` — two arms in the SAME block whose
+//     true ratio is a property of the page — moved 5% and moved the WRONG
+//     WAY for additivity (correlation with the floor +0.41; an additive `c`
+//     reads `(2W+c)/(W+c)`, which FALLS as `c` grows). The published bar
+//     row did not move with the floor at all (correlation -0.10), nor with
+//     the seam (-0.18).
+//
+// **So the seam is the wrong statistic to gate on**, and gating on it would
+// refuse good runs on a tail draw while passing a genuinely additive seam
+// half its size. What bounds a bar row is not how far apart two segments'
+// floors are; it is how much of a block's perturbation FAILS to cancel when
+// the block's own floor is divided out.
+//
+// ## The band, which is that quantity measured
+//
+// `ctl-2x` builds exactly twice the floor's page in the same block. Its
+// ratio to the floor is therefore a property of the witness and not of the
+// box, and every departure from a constant is the part of the ambient
+// perturbation that survived normalisation. [[band]] is that departure,
+// over the run's segment-blocks, in the units a bar row is quoted in.
+//
+// It is deliberately CONSERVATIVE. `ctl-2x` and `floor` differ in size
+// (1,801 against 901 elements), so a perturbation that is multiplicative
+// but size-dependent shows up in this ratio and would NOT show up between a
+// substrate arm and its own same-size floor. The band therefore over-states
+// the noise a real bar row carries, which is the right direction for a gate
+// to err in and is stated rather than left to be discovered.
+//
+// ## What it gates
+//
+//   * A MAGNITUDE whose distance from 1.0 is inside the band is
+//     INSTRUMENT-LIMITED and is not reportable as a magnitude. This
+//     generalises `validation.md`'s standing rule — *a margin under 5% is
+//     instrument-limited rather than cleared* — from an assumed 5% to the
+//     figure the run itself measured. **This is the gate that bites**, and
+//     it is calibrated: over the ladder the band averaged 8.9% while the
+//     published bar row's own run-to-run spread was 0.9643 – 1.1041, about
+//     ±7% around 1.016. The band predicts the noise a bar row actually
+//     carries, slightly conservatively, which is the direction a gate
+//     should err in.
+//   * A RUN whose band exceeds [[BAND_CEILING]] has no reportable magnitude
+//     at all, whatever its margin. The ladder produced bands of 4.4% –
+//     18.5% across all nineteen runs, so the ceiling is **25%** — above
+//     everything the calibration produced, including the rung with twenty
+//     of twenty-four cores saturated. It therefore did NOT fire anywhere on
+//     its own calibration, and that is stated rather than left for a reader
+//     to discover: it is a tripwire for a box outside the whole range this
+//     ladder could reach, not a gate on a busy one. A ceiling tight enough
+//     to fire on the ladder would have refused an IDLE run (the widest band
+//     of the nineteen, 18.5%, was taken at zero load), which is how a
+//     threshold on a noisy statistic turns into a coin toss.
+
+const SEGMENT_PERMUTATIONS = [
+  [0, 1, 2], [0, 2, 1], [1, 0, 2], [1, 2, 0], [2, 0, 1], [2, 1, 0],
+];
+
+/** A run whose band exceeds this has no reportable magnitude. See the header. */
+const BAND_CEILING = 0.25;
+
+/** Permutations drawn for the seam null. Fixed, because a null that moves between two reports of the same run is not a null. */
+const NULL_DRAWS = 4000;
+
+// A seeded xorshift, so the null is REPRODUCIBLE. A report whose p-value
+// changes when it is recomputed on the same data cannot be checked by the
+// reader, and this module's whole claim is that a number should be checkable.
+function rng(seed) {
+  let s = seed >>> 0 || 0x9e3779b9;
+  return () => {
+    s ^= s << 13; s >>>= 0;
+    s ^= s >>> 17;
+    s ^= s << 5; s >>>= 0;
+    return s / 0x100000000;
+  };
+}
+
+function median(xs) {
+  const v = [...xs].sort((a, b) => a - b);
+  if (v.length === 0) return NaN;
+  return v.length % 2 ? v[(v.length - 1) / 2] : (v[v.length / 2 - 1] + v[v.length / 2]) / 2;
+}
+const mean = (xs) => xs.reduce((a, b) => a + b, 0) / xs.length;
+const spread = (xs) => Math.max(...xs) / Math.min(...xs) - 1;
+function quantile(xs, p) {
+  const v = [...xs].sort((a, b) => a - b);
+  return v[Math.min(v.length - 1, Math.max(0, Math.floor(p * v.length)))];
+}
+
+/**
+ * The published seam: the same floor arm's pooled median in each segment,
+ * and the max-over-min of those.
+ *
+ * `blocks[round][segment]` is the array of that block's floor samples.
+ */
+function seam(blocks) {
+  const nSeg = blocks[0].length;
+  const bySeg = [];
+  for (let j = 0; j < nSeg; j++) bySeg.push(median(blocks.flatMap((b) => b[j])));
+  return { bySeg, spread: spread(bySeg) };
+}
+
+/**
+ * The null distribution of THAT STATISTIC when segment identity is
+ * irrelevant.
+ *
+ * The relabelling is WITHIN a round, so each round keeps its own three
+ * blocks and only the question "which segment owned which" is destroyed.
+ * That is the exact null the ground needs: not "is there any structure",
+ * but "is the structure attributable to the segment".
+ *
+ * It is reported as quantiles rather than as a bare p-value because the
+ * point of it is the SHAPE — this statistic's null median is around 5% and
+ * its q99 around 18%, so a seam of 6% is the middle of the noise and
+ * reporting it without the null invites a reader to treat it as a finding.
+ */
+function seamNull(blocks, opts = {}) {
+  const draws = opts.draws || NULL_DRAWS;
+  const next = rng(opts.seed || 0x5eed5eed);
+  const nSeg = blocks[0].length;
+  const observed = seam(blocks).spread;
+  const nulls = [];
+  for (let it = 0; it < draws; it++) {
+    const perm = blocks.map(() => SEGMENT_PERMUTATIONS[Math.floor(next() * SEGMENT_PERMUTATIONS.length) % SEGMENT_PERMUTATIONS.length]);
+    const bySeg = [];
+    for (let j = 0; j < nSeg; j++) bySeg.push(median(blocks.flatMap((b, r) => b[perm[r][j]])));
+    nulls.push(spread(bySeg));
+  }
+  const atLeast = nulls.filter((x) => x >= observed).length;
+  return {
+    observed,
+    draws,
+    q50: quantile(nulls, 0.5),
+    q95: quantile(nulls, 0.95),
+    q99: quantile(nulls, 0.99),
+    p: atLeast / draws,
+  };
+}
+
+/**
+ * Where a floor's variation lives: with the SEGMENT, with the ROUND, or
+ * with the POSITION the segment occupied in its round.
+ *
+ * `cells[round][segment]` is one number per block — the tared floor. The
+ * three factors are mutually orthogonal by construction when the number of
+ * rounds is a multiple of the number of segments, because the driver
+ * rotates the segment order with the round: segment `j` sits at position
+ * `(j - round) mod nSeg`, so each segment visits each position equally
+ * often and each round contains every position exactly once.
+ *
+ * That balance is CHECKED rather than assumed. An unbalanced design makes
+ * the three marginal spreads confounded with each other, and a confounded
+ * decomposition reported as though it were orthogonal is how "it is the
+ * adapter" gets said about an order effect.
+ */
+function effects(cells) {
+  const R = cells.length;
+  const nSeg = cells[0].length;
+  const posOf = (j, r) => (((j - r) % nSeg) + nSeg) % nSeg;
+  const balanced = R % nSeg === 0;
+
+  const bySeg = [];
+  for (let j = 0; j < nSeg; j++) bySeg.push(mean(cells.map((c) => c[j])));
+  const byRound = cells.map((c) => mean(c));
+  const byPos = [];
+  for (let p = 0; p < nSeg; p++) {
+    const vs = [];
+    for (let r = 0; r < R; r++) for (let j = 0; j < nSeg; j++) if (posOf(j, r) === p) vs.push(cells[r][j]);
+    byPos.push(mean(vs));
+  }
+  return {
+    balanced,
+    bySeg, byRound, byPos,
+    segment: spread(bySeg),
+    round: spread(byRound),
+    position: spread(byPos),
+  };
+}
+
+/**
+ * THE BAND — how much of a block's perturbation survives dividing by that
+ * block's own floor.
+ *
+ * `pairs` is one `{fixed, floor}` per block: two arms measured in the same
+ * block whose true ratio is a property of the page. The band is the
+ * half-width of the p10–p90 interval of `fixed / floor`, relative to its
+ * median — a range and not a standard deviation, because this lane quotes
+ * ranges, and an interior quantile and not a max/min, because a max/min
+ * over eighteen blocks is the very tail-heavy statistic this module was
+ * written to stop trusting.
+ */
+function band(pairs) {
+  const ratios = pairs.map((p) => p.fixed / p.floor).filter(Number.isFinite);
+  if (ratios.length < 4) return { n: ratios.length, band: NaN, why: 'fewer than four blocks' };
+  const p50 = median(ratios);
+  const lo = quantile(ratios, 0.1);
+  const hi = quantile(ratios, 0.9);
+  return {
+    n: ratios.length,
+    p50,
+    p10: lo,
+    p90: hi,
+    min: Math.min(...ratios),
+    max: Math.max(...ratios),
+    band: (hi - lo) / (2 * p50),
+  };
+}
+
+/**
+ * Is a measured magnitude far enough from 1.0 to be one?
+ *
+ * `bars` is `{name: mean}`. A row inside the band is INSTRUMENT-LIMITED:
+ * the instrument cannot tell it from parity, which is a result about the
+ * instrument and not about the candidate, and publishing it as a magnitude
+ * would be quoting noise.
+ */
+function adjudicate(bars, bandWidth, unavailableWhy) {
+  // A row that STRUCTURALLY has no proportional control is UNADJUDICATED,
+  // which is a different thing from a run whose band came out too wide.
+  // Collapsing the two would let a row with no gate at all report as though
+  // it had failed one, and would let a broken band report as though it were
+  // merely absent. `keystroke` is the real case: its control burns a fixed
+  // 50 ms rather than doubling the page, so `control/floor` is `(F+50)/F`
+  // and moves with `F` — not a pair whose true ratio is a page property.
+  const unavailable = !!unavailableWhy;
+  const ceilingBreached = !unavailable && !(bandWidth <= BAND_CEILING);
+  const rows = {};
+  for (const [name, value] of Object.entries(bars)) {
+    const margin = Math.abs(value - 1);
+    rows[name] = {
+      value,
+      margin,
+      band: unavailable ? null : bandWidth,
+      clear: !unavailable && !ceilingBreached && margin > bandWidth,
+      unadjudicated: unavailable,
+      why: unavailable
+        ? `UNADJUDICATED — ${unavailableWhy}`
+        : ceilingBreached
+          ? `the run's band ${(bandWidth * 100).toFixed(1)}% exceeds the ${(BAND_CEILING * 100).toFixed(0)}% ceiling — ` +
+            'no magnitude from this run is reportable'
+          : margin > bandWidth
+            ? `margin ${(margin * 100).toFixed(1)}% clears the band ${(bandWidth * 100).toFixed(1)}%`
+            : `margin ${(margin * 100).toFixed(1)}% is INSIDE the band ${(bandWidth * 100).toFixed(1)}% — instrument-limited`,
+    };
+  }
+  return { band: unavailable ? null : bandWidth, ceiling: BAND_CEILING, unavailable, ceilingBreached, rows };
+}
+
+/** Everything above, for one row. `fixedCells` null when the row has no proportional control. */
+function assess({ floorBlocks, floorCells, fixedCells, bars, noFixedPairWhy }) {
+  const s = seam(floorBlocks);
+  const nul = seamNull(floorBlocks);
+  const eff = effects(floorCells);
+  let b = { n: 0, band: NaN, why: noFixedPairWhy || 'no proportional control on this row' };
+  if (fixedCells) {
+    const pairs = [];
+    for (let r = 0; r < floorCells.length; r++) {
+      for (let j = 0; j < floorCells[r].length; j++) pairs.push({ fixed: fixedCells[r][j], floor: floorCells[r][j] });
+    }
+    b = band(pairs);
+  }
+  return {
+    seam: s, null: nul, effects: eff, bandStats: b,
+    verdict: adjudicate(bars || {}, b.band, fixedCells ? null : b.why),
+  };
+}
+
+function format(a, segmentNames) {
+  const pc = (x) => (x * 100).toFixed(1) + '%';
+  const out = [];
+  out.push(
+    `;; seam     the SAME floor read ${segmentNames.map((s, i) => `${s} ${a.seam.bySeg[i].toFixed(3)}`).join(', ')} ms ` +
+      `— spread ${pc(a.seam.spread)}`
+  );
+  out.push(
+    `;;          NULL for that statistic with segment identity relabelled WITHIN each round: ` +
+      `median ${pc(a.null.q50)}, q95 ${pc(a.null.q95)}, q99 ${pc(a.null.q99)} over ${a.null.draws} draws — ` +
+      `p=${a.null.p.toFixed(3)}. A max-over-min of three noisy block medians has a long right tail with ` +
+      `nothing to attribute it to, so the seam is published WITH its null or not at all`
+  );
+  out.push(
+    `;;          where the floor's variation lives: SEGMENT ${pc(a.effects.segment)}, ` +
+      `ROUND ${pc(a.effects.round)}, POSITION-in-round ${pc(a.effects.position)}` +
+      (a.effects.balanced
+        ? ' (orthogonal — rounds are a multiple of segments, so each segment visits each position equally often)'
+        : ' (NOT ORTHOGONAL — rounds are not a multiple of segments, so these three are confounded)')
+  );
+  out.push(
+    Number.isFinite(a.bandStats.band)
+      ? `;; band     ctl-2x/floor, two arms in the SAME block whose true ratio is a property of the page: ` +
+        `p50 ${a.bandStats.p50.toFixed(4)} [p10 ${a.bandStats.p10.toFixed(4)} – p90 ${a.bandStats.p90.toFixed(4)}] ` +
+        `over ${a.bandStats.n} blocks — BAND ${pc(a.bandStats.band)}. This is the part of the ambient ` +
+        `perturbation that floor-normalisation does NOT cancel, and it is what a magnitude must clear`
+      : `;; band     NOT AVAILABLE on this row — ${a.bandStats.why}`
+  );
+  for (const [name, r] of Object.entries(a.verdict.rows)) {
+    const mark = r.unadjudicated ? 'UNADJ  ' : r.clear ? 'CLEARS ' : 'LIMITED';
+    out.push(`;;   ${mark} ${name.padEnd(24)} ${r.value.toFixed(4)}x — ${r.why}`);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// The self-test — deterministic, and it prices the claims the header makes.
+// ---------------------------------------------------------------------------
+
+function selfTest() {
+  const checks = [];
+  const check = (name, ok, detail) => checks.push({ name, ok: !!ok, detail });
+
+  // Six rounds of three segments, a flat floor, one block per round of
+  // samples. Deterministic values so nothing here depends on the PRNG
+  // except the null, which is seeded.
+  const flat = () => {
+    const bs = [];
+    for (let r = 0; r < 6; r++) bs.push([[10, 10, 10], [10, 10, 10], [10, 10, 10]]);
+    return bs;
+  };
+
+  check('a flat floor has no seam', Math.abs(seam(flat()).spread) < 1e-12, `${seam(flat()).spread}`);
+
+  // 1. A PURELY MULTIPLICATIVE PERTURBATION CANCELS EXACTLY. This is the
+  //    header's central claim and it is arithmetic, not a measurement: scale
+  //    every reading in a block by k and the block's floor-normalised ratio
+  //    is unchanged to the last bit.
+  {
+    const H = 13.7, F = 10.0;
+    const ks = [1, 1.34, 0.8, 2.5, 1.05];
+    const rs = ks.map((k) => (H * k) / (F * k));
+    check(
+      'a block-wide multiplicative perturbation cancels EXACTLY in H/F',
+      rs.every((x) => Math.abs(x - H / F) < 1e-12),
+      `k in {${ks.join(', ')}} all give ${(H / F).toFixed(6)}`
+    );
+  }
+
+  // 2. AN ADDITIVE ONE DOES NOT, and the band SEES it. `ctl-2x/floor` under
+  //    an additive c reads (2W+c)/(W+c) and falls as c grows — which is the
+  //    signature the ladder looked for and did not find.
+  {
+    const W = 5;
+    const rat = (c) => (2 * W + c) / (W + c);
+    const falls = rat(0) > rat(1) && rat(1) > rat(3);
+    check(
+      'an ADDITIVE perturbation makes ctl-2x/floor fall, which is how the band detects it',
+      falls && Math.abs(rat(0) - 2) < 1e-12,
+      `c=0 -> ${rat(0).toFixed(4)}, c=1 -> ${rat(1).toFixed(4)}, c=3 -> ${rat(3).toFixed(4)}`
+    );
+  }
+
+  // 3. THE NULL HAS A LONG RIGHT TAIL, which is the reason the seam may not
+  //    be reported bare. Three segments of IDENTICAL distribution, differing
+  //    only by noise, must still produce a null q95 well above zero.
+  {
+    const next = rng(12345);
+    const bs = [];
+    for (let r = 0; r < 6; r++) {
+      const blk = [];
+      for (let j = 0; j < 3; j++) {
+        const lvl = 10 * (1 + 0.25 * (next() - 0.5)); // a per-BLOCK ambient level, nothing to do with the segment
+        blk.push(Array.from({ length: 10 }, () => lvl * (1 + 0.1 * (next() - 0.5))));
+      }
+      bs.push(blk);
+    }
+    const n = seamNull(bs);
+    check(
+      'the null of the seam statistic has a long right tail with NOTHING to attribute it to',
+      n.q50 > 0.01 && n.q95 > n.q50 * 1.5,
+      `median ${(n.q50 * 100).toFixed(1)}%, q95 ${(n.q95 * 100).toFixed(1)}%, q99 ${(n.q99 * 100).toFixed(1)}%`
+    );
+    check(
+      'the null is REPRODUCIBLE — the same data twice gives the same p',
+      seamNull(bs).p === n.p,
+      `p=${n.p.toFixed(4)} both times`
+    );
+  }
+
+  // 4. THE DECOMPOSITION SEPARATES A ROUND EFFECT FROM A SEGMENT ONE. Build
+  //    a floor whose ONLY structure is a per-round ambient level; the
+  //    segment and position marginals must come back flat, because the
+  //    rotation balances them.
+  {
+    const lvls = [10, 14, 9, 12, 11, 13];
+    const cells = lvls.map((L) => [L, L, L]);
+    const e = effects(cells);
+    check(
+      'a pure ROUND effect lands on round and NOT on segment or position',
+      e.balanced && e.round > 0.5 && e.segment < 1e-12 && e.position < 1e-12,
+      `round ${(e.round * 100).toFixed(1)}%, segment ${(e.segment * 100).toFixed(1)}%, position ${(e.position * 100).toFixed(1)}%`
+    );
+  }
+  {
+    // and a pure POSITION effect must land on position, not on segment —
+    // this is the contrast that says "order effect" rather than "adapter".
+    const byPos = [12, 10, 9];
+    const cells = [];
+    for (let r = 0; r < 6; r++) cells.push([0, 1, 2].map((j) => byPos[(((j - r) % 3) + 3) % 3]));
+    const e = effects(cells);
+    check(
+      'a pure POSITION-in-round effect lands on position and NOT on segment',
+      e.position > 0.3 && e.segment < 1e-12,
+      `position ${(e.position * 100).toFixed(1)}%, segment ${(e.segment * 100).toFixed(1)}%, round ${(e.round * 100).toFixed(1)}%`
+    );
+  }
+  {
+    // and a pure SEGMENT effect must land on segment. Without this the two
+    // checks above would pass for a decomposition that always answered zero.
+    const bySeg = [12, 10, 9];
+    const cells = [];
+    for (let r = 0; r < 6; r++) cells.push([0, 1, 2].map((j) => bySeg[j]));
+    const e = effects(cells);
+    check(
+      'a pure SEGMENT effect lands on segment and NOT on position',
+      e.segment > 0.3 && e.position < 1e-12 && e.round < 1e-12,
+      `segment ${(e.segment * 100).toFixed(1)}%, position ${(e.position * 100).toFixed(1)}%, round ${(e.round * 100).toFixed(1)}%`
+    );
+  }
+  {
+    // An UNBALANCED design cannot be decomposed, and must say so rather than
+    // answering. Five rounds of three segments: each segment does not visit
+    // each position equally often, so the marginals are confounded.
+    const cells = [];
+    for (let r = 0; r < 5; r++) cells.push([10, 10, 10]);
+    check(
+      'a design whose rounds are not a multiple of its segments is flagged NOT ORTHOGONAL',
+      effects(cells).balanced === false,
+      '5 rounds, 3 segments'
+    );
+  }
+
+  // 5. THE GATE. A margin inside the band is instrument-limited; one outside
+  //    it clears; and a band above the ceiling takes every magnitude with it.
+  {
+    const pairs = Array.from({ length: 18 }, (_, i) => ({ fixed: 2 * (10 + (i % 3) * 0.2), floor: 10 + (i % 3) * 0.2 }));
+    const b = band(pairs);
+    check('a perfectly proportional pair has a ZERO band', Math.abs(b.band) < 1e-12, `band ${b.band}`);
+    const v = adjudicate({ tight: 1.02, wide: 1.35 }, 0.06);
+    check(
+      'a margin inside the band is INSTRUMENT-LIMITED and one outside it CLEARS',
+      v.rows.tight.clear === false && v.rows.wide.clear === true,
+      `${v.rows.tight.why} | ${v.rows.wide.why}`
+    );
+    const v2 = adjudicate({ wide: 1.35 }, 0.2);
+    check(
+      'a band above the ceiling takes EVERY magnitude with it, however wide the margin',
+      v2.ceilingBreached && v2.rows.wide.clear === false,
+      v2.rows.wide.why
+    );
+    // A NaN band must refuse rather than pass: `margin > NaN` is false, so
+    // `clear` is already false, but the ceiling test has to agree — written
+    // as `!(band <= ceiling)` for exactly this reason.
+    const v3 = adjudicate({ wide: 1.35 }, NaN);
+    check(
+      'a band that could not be computed REFUSES rather than passing quietly',
+      v3.ceilingBreached && v3.rows.wide.clear === false,
+      v3.rows.wide.why
+    );
+    // A row with NO proportional control is UNADJUDICATED, not breached —
+    // and the two must not read alike, because one says "this instrument
+    // could not answer" and the other says "this box was too unstable".
+    const v4 = adjudicate({ wide: 1.35 }, NaN, 'its control burns a fixed 50 ms rather than doubling the page');
+    check(
+      'a row with no proportional control is UNADJUDICATED, which is not the same as breached',
+      v4.unavailable && v4.rows.wide.unadjudicated && v4.rows.wide.clear === false && v4.ceilingBreached === false,
+      v4.rows.wide.why
+    );
+    const a5 = assess({
+      floorBlocks: Array.from({ length: 6 }, () => [[10], [10], [10]]),
+      floorCells: Array.from({ length: 6 }, () => [10, 10, 10]),
+      fixedCells: null,
+      bars: { 'h / r': 1.35 },
+      noFixedPairWhy: 'no doubled-page control on this row',
+    });
+    check(
+      'assess with no fixed pair reports the band as unavailable and adjudicates nothing',
+      !Number.isFinite(a5.bandStats.band) && a5.verdict.unavailable && a5.verdict.rows['h / r'].unadjudicated,
+      a5.verdict.rows['h / r'].why
+    );
+  }
+
+  // 6. THE LADDER'S OWN HEADLINE, replayed as a fixture: the published run's
+  //    three floors. The seam is 34% and the decomposition is the point —
+  //    with one round of data there is nothing to attribute it to, which is
+  //    why the instrument now takes the null alongside.
+  {
+    const published = [3.147, 2.437, 2.349];
+    check(
+      "the published run's 34% seam is reproduced by this module's own arithmetic",
+      Math.abs(spread(published) - 0.3397) < 0.001,
+      `${(spread(published) * 100).toFixed(1)}%`
+    );
+  }
+
+  return { ok: checks.every((c) => c.ok), checks };
+}
+
+module.exports = {
+  BAND_CEILING, NULL_DRAWS,
+  median, quantile, spread,
+  seam, seamNull, effects, band, adjudicate, assess, format, selfTest,
+};
+
+if (require.main === module) {
+  const st = selfTest();
+  for (const c of st.checks) console.log(`${c.ok ? 'ok  ' : 'FAIL'}  ${c.name}${c.detail ? '  — ' + c.detail : ''}`);
+  if (!st.ok) {
+    console.error('\nseam self-test FAILED');
+    process.exit(1);
+  }
+  console.log('\nseam self-test ok');
+}

--- a/implementation/freehand/test/re_frame/bench/hicasso/seam_ladder.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/seam_ladder.cjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// THE SEAM AGAINST LOAD — the load half (rf2-cvvb7).
+//
+//   node .../seam_ladder.cjs --load 12 --label heavy-A --json out/heavy-A.json
+//   node .../seam_ladder.cjs --spin 30000          (the load generator alone)
+//
+// `the-candidates-clock.md` §6 refuses three rows, and one of its grounds
+// is that the cross-segment floor seam read 34% on one run and 3.8% on
+// another "with nothing changed but how busy the machine was". Two points
+// are a line through two dots. This runs the clock at a STATED number of
+// competing busy cores so the relationship can be measured instead of
+// asserted.
+//
+// ## THE LOAD IS BOUNDED BY CONSTRUCTION, AND THAT IS NOT A COURTESY
+//
+// A benchmark box is shared. A 32-way load generator run on this one for a
+// legitimate reason timed out unrelated work across the machine, so every
+// spinner here carries its own deadline (`--spin <ms>`) and exits on it
+// whether or not the parent is alive to kill it. The parent kills them in a
+// `finally`, and the deadline is what covers the case where the parent
+// itself dies. A load generator that can outlive its window is a hazard
+// left lying around, not an instrument.
+//
+// `--load` is capped at `hardware-concurrency - 4` so the box keeps enough
+// cores to stay answerable. The cap is reported when it bites, because a
+// rung that silently became a different rung is worse than a missing one.
+//
+// ## WHAT THE SPINNER IS, AND WHY NOT `while (true) {}`
+//
+// A bare empty loop is optimised into something that touches no memory, and
+// what a busy neighbour actually costs a benchmark is cache and memory
+// bandwidth as much as cycles. Each spinner walks a 4 MB typed array with a
+// data-dependent stride, which keeps it resident in cache and out of the
+// optimiser's reach, and reads a value at the end so nothing is dead code.
+
+'use strict';
+
+const os = require('node:os');
+const path = require('node:path');
+const { spawn, spawnSync } = require('node:child_process');
+
+const argv = process.argv.slice(2);
+const flag = (name, dflt) => {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 && argv[i + 1] !== undefined ? argv[i + 1] : dflt;
+};
+
+// --- the spinner child -----------------------------------------------------
+
+const SPIN_MS = Number(flag('spin', 0));
+if (SPIN_MS > 0) {
+  const N = 1 << 20; // 4 MB of Int32
+  const buf = new Int32Array(N);
+  for (let i = 0; i < N; i++) buf[i] = (i * 2654435761) | 0;
+  const deadline = Date.now() + SPIN_MS;
+  let acc = 0;
+  let i = 0;
+  // The deadline is checked once per 2^16 steps: often enough that the
+  // spinner cannot overrun its window by anything a human would notice,
+  // rarely enough that `Date.now` is not what is being benchmarked.
+  for (;;) {
+    for (let k = 0; k < 65536; k++) {
+      i = (i + (buf[i & (N - 1)] & 1023) + 1) & (N - 1);
+      acc = (acc + buf[i]) | 0;
+      buf[i] = (buf[i] * 1103515245 + 12345) | 0;
+    }
+    if (Date.now() >= deadline) break;
+  }
+  process.stdout.write(String(acc & 1));
+  process.exit(0);
+}
+
+// --- the parent ------------------------------------------------------------
+
+const HERE = __dirname;
+const IMPL = path.resolve(HERE, '../../../../..');
+const CORES = os.cpus().length;
+const CAP = Math.max(0, CORES - 4);
+
+const wanted = Number(flag('load', 0));
+const load = Math.min(wanted, CAP);
+const label = flag('label', `load${load}`);
+const json = flag('json', '');
+const budgetMs = Number(flag('budget', 20 * 60 * 1000));
+const only = flag('only', 'bulk300');
+
+if (wanted > CAP) {
+  console.error(
+    `[ladder] --load ${wanted} CAPPED to ${CAP} — this box reports ${CORES} cores and the ` +
+      `harness keeps 4 of them free so the machine stays answerable`
+  );
+}
+
+const children = [];
+function startLoad() {
+  for (let i = 0; i < load; i++) {
+    const c = spawn(process.execPath, [__filename, '--spin', String(budgetMs)], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+      detached: false,
+    });
+    children.push(c);
+  }
+}
+function stopLoad() {
+  for (const c of children) {
+    try {
+      c.kill('SIGKILL');
+    } catch {
+      /* already gone; the spinner's own deadline covers it */
+    }
+  }
+}
+
+process.on('exit', stopLoad);
+process.on('SIGINT', () => {
+  stopLoad();
+  process.exit(130);
+});
+
+console.error(
+  `[ladder] label=${label} load=${load}/${CORES} cores, spinner deadline ${budgetMs} ms, row(s) ${only}`
+);
+startLoad();
+
+// Let the spinners reach steady state before the clock starts, so the run
+// is not measuring the ramp.
+const settleUntil = Date.now() + (load > 0 ? 3000 : 0);
+while (Date.now() < settleUntil) {
+  /* deliberate spin: this parent has nothing else to do and a sleep here
+     would need a timer the synchronous spawnSync below cannot yield to */
+}
+
+const started = Date.now();
+const r = spawnSync(
+  process.execPath,
+  [path.join(HERE, 'clock_run.cjs'), '--no-build'],
+  {
+    cwd: IMPL,
+    stdio: ['ignore', 'inherit', 'inherit'],
+    env: {
+      ...process.env,
+      HCLOCK_ONLY: only,
+      HCLOCK_LABEL: label,
+      HCLOCK_JSON: json,
+      HCLOCK_LOAD: String(load),
+    },
+    timeout: budgetMs,
+  }
+);
+const elapsed = Date.now() - started;
+stopLoad();
+console.error(`[ladder] ${label}: clock exited ${r.status} after ${(elapsed / 1000).toFixed(1)} s, load released`);
+process.exit(r.status === null ? 1 : r.status);


### PR DESCRIPTION
`the-candidates-clock.md` §6 refused three bulk rows, and one of its three
grounds was the cross-segment floor seam: the same floor arm read
3.147 / 2.437 / 2.349 ms across the three segments on one run — a 34% spread —
while a later run read 3.8%, *"with nothing changed but how busy the machine
was."* The ground reasoned that floor-normalisation cancels a multiplicative
seam and not an additive one, so a bar row built across segments that disagree
by 34% is quoting the seam.

Two points are a line through two dots. This puts a **stated** number of
competing busy cores on the box and takes the row nineteen times.

## What the ladder found

| | |
|---|---|
| **The seam does not track load** | 0.1–16.4% over 19 runs, mean 4.8%, no trend — **4.3%** at idle against **4.6%** at twenty of twenty-four cores saturated. The ladder unquestionably moved the box: the absolute floor rose 3.06 → 5.50 ms, an **80% span**. Row position inside the process does not explain it either (a five-row run read 4.9 / 2.4 / 1.1 / 9.4 / 3.3%). |
| **It is not segment-attributable** | Under an exact within-round relabelling null — every round keeps its three blocks, only *which segment owned which* is destroyed — the same statistic has median 5.5%, q95 14.1%, q99 17.6%. **Not one of the nineteen runs reached p < 0.2**, and every observed seam sat at or below that null's median. A max-over-min of three noisy block medians has a long right tail with nothing to attribute it to. |
| **The variation is on the ROUND** | By rung: ROUND 8–41% against SEGMENT 4.0–6.1% and POSITION-in-round 3.2–9.9%, decomposed orthogonally (the rotation makes the three factors balanced whenever rounds are a multiple of segments, and the instrument checks that rather than assuming it). |
| **The perturbation is MULTIPLICATIVE** | So floor-normalisation cancels it, exactly: `(k·H)/(k·F) = H/F`. Across the 80% floor span, `ctl-2x / floor` moved 6.5% and moved the **wrong way for additivity** (correlation with the floor **+0.41**; an additive `c` reads `(2W+c)/(W+c)`, which *falls* as `c` grows). The published bar row did not move with the floor (**−0.10**) or with the seam (**−0.18**). |

**The ground is withdrawn as refuted.** The rows stay refused — on the two
grounds that hold, and on the band below. A refusal may drop a ground only when
the ground is shown wrong, and this one was measured wrong rather than quietly
dropped because a later run looked better.

The published 22% is a 1-in-400 draw from that null. The published 34% is beyond
all 38,000 permutations *and* beyond every rung of the ladder — so it is not
noise of this kind either, and **what produced it remains unidentified**. That
is stated rather than smoothed.

## What replaces it

The seam was the wrong statistic to gate on. What bounds a bar row is **how much
of a block's perturbation fails to cancel when that block's own floor is divided
out** — and `ctl-2x / floor` measures exactly that, because it is two arms in the
*same* block whose true ratio is a property of the page, not of the box. The
**band** is the half-width of that ratio's p10–p90 interval over the run's
eighteen segment-blocks. An interior quantile, not a max/min, because a max/min
over eighteen blocks is the tail-heavy statistic this work exists to stop
trusting.

- **The gate that bites**: a magnitude whose distance from 1.0 is inside the band
  is INSTRUMENT-LIMITED and the row says so. That turns `validation.md`'s assumed
  *"a margin under 5% is instrument-limited"* into a figure each run measures for
  itself. It is calibrated — over the ladder the band averaged 8.9% while the bar
  row's own run-to-run spread was ±7% around 1.016 — and deliberately
  conservative, since `ctl-2x` and `floor` differ in size so a size-dependent
  perturbation lands in it that would not land between a substrate arm and its
  own same-size floor.
- **A ceiling of 25%** takes every magnitude with it. The ladder produced bands of
  4.4–18.5%, so this did **not fire anywhere on its own calibration** — stated
  plainly rather than left to be discovered. A ceiling tight enough to fire on
  the ladder would have refused an *idle* run, since the widest band of the
  nineteen was taken at zero load.
- **`keystroke` gets no band and is marked UNADJUDICATED**, not passed. Its
  control burns a fixed 50 ms instead of doubling the page, so `control/floor`
  reads `(F+50)/F` and moves with `F`. A row with no gate must not report as
  though it cleared one.

**The new rule reproduces both verdicts the page already reached** — `M1`
publishable, the three bulk rows not — from one measured quantity instead of
three assorted grounds. That is the check on it: a gate that changed the answers
would need arguing for rather than adopting.

## Why not the alternatives

- **Stamp the seam and nothing else** — that is the status quo the bead
  complains about, and it stamps a statistic now known not to propagate.
- **Refuse above a seam threshold** — wrong statistic. Its null tail means a
  threshold at 20% refuses good runs ~0.5% of the time while passing a genuinely
  *additive* seam half that size.
- **Re-derive the normalisation so an additive seam cancels** — costed and
  rejected on the measurement. The additive component is what the `plumb` tare
  already subtracts, and what remains was measured to be multiplicative, so it
  cancels exactly as it stands. It would have bought nothing.

## Also here

- `seam_ladder.cjs` — the load half, bounded by construction. Every spinner
  carries its own deadline so it cannot outlive its window if the parent dies,
  and `--load` is capped four cores below the box.
- `HCLOCK_JSON` — the driver writes its raw per-sample readings, and writes
  nothing at all for a run that died part-way. The §6.1 figures are recomputed
  from those stored readings using the shipped `seam.cjs`, so the published
  figures and the instrument's figures are the same figures.
- §3.3 loses the wrong evidence for its own selection: it offered run 5's tight
  seams as the objective sign of a quiet box. The ladder shows the seam is not
  that. The **absolute floor level** is, and it was already in the paragraph
  below.
- §6.1 reconciles with the window audit that landed alongside. Its 31.9% is a
  *single round's* spread — routine, this ladder saw 45% in one round of an idle
  run whose pooled seam was 3.8% — so it corroborates the observation, not the
  load attribution. And its `(U/F) ÷ (R/F) = U/R` is algebra that holds only
  where both legs share one floor; three segments have three floors, so nothing
  cancels for free here.

## Discipline

- **Load windows, announced and bounded**: 23:10–23:17 and 23:18–23:23 AUSEST
  2026-08-01, each rung a single ~40 s run with the load released between runs,
  capped at 20 of 24 cores. No load generator ran outside those two windows.
- **Every prediction registered before its run, and the wrong ones reported.**
  Two were wrong at the baseline: the seam came in at 3.8% against a predicted
  5–15%, and `ctl-2x` PASSed strict where FAIL was predicted. The load-ladder
  prediction that the seam would reach the published 22–34% band around load
  8–12 was **wrong** — it never moved at all, which is the finding.
- **No run discarded**: every run that started finished. The driver writes no
  dataset for a run that died part-way, so a partial one cannot be analysed by
  mistake.
- **Provenance by blob** in §7.1, alongside the commit.
- Instrument blobs at the branch base matched the published run's exactly, so
  these runs are directly comparable to runs 4 and 5.

## Quality gates

Foreground, to completion, worktree-local logs, exit codes echoed.

| gate | exit |
|---|---|
| `sh scripts/assert-worker-worktree.sh` → `WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/seam-cvvb7` | **0** |
| `sh scripts/test-fast-pr.sh` (docs + jvm + node tiers, pre-rebase) | **0** — `PASS fast PR spine` |
| `sh scripts/test-fast-pr.sh` (re-run on the post-rebase tree) | **0** — `PASS fast PR spine` |
| `python scripts/check_doc_slugs.py` | **0** |
| `node .../hicasso/seam.cjs` — the adjudicator's own self-test, 17 checks | **0** |
| `node .../freehand/bench/order_guard.cjs` — arm-order guard self-test, 12 checks | **0** |
| five-row clock run on the shipped instrument | **1** — scoped to the rows whose control failed, as the driver documents; every whole-run gate cleared |

`mkdocs build --strict` is **not** nominated for the doc change: `mkdocs.yml`'s
`exclude_docs` keeps `docs/design/**` out of the site. It ran anyway inside the
spine's docs tier and passed. `scripts/check_doc_slugs.py` is the gate that
reaches this tree, and it was **negative-tested** on this very file — a
deliberately broken anchor was introduced, the checker reported
`BROKEN ANCHOR: ...the-candidates-clock.md:676`, and the file was restored.
**Table column counts verified by hand**: all 20 tables in the file checked
row-by-row, 0 mismatched. All 7 in-page anchors resolve.

Closes `rf2-cvvb7`.
