### PR TITLE
docs(hicasso): repair a cross-PR anchor break on main

### DIFF
--- a/docs/design/hicasso/studio/cross-checked-against-an-outside-instrument.md
+++ b/docs/design/hicasso/studio/cross-checked-against-an-outside-instrument.md
@@ -331,7 +331,7 @@ caveat on the rows it guards, and that is not being re-described here. What this
 control certifies is *the instrument tracks work over a 10× change*, and it
 certifies that with a 31–37% overshoot rather than cleanly. The right control for
 these rows would hold page size fixed and double the **changed set** — the same
-repair [the clock page](the-candidates-clock.md#what-a-future-run-would-have-to-change)
+repair [the clock page](the-candidates-clock.md#63-what-a-future-run-would-have-to-change)
 already filed for its own bulk rows, and this run inherits the gap rather than
 closing it.
 


### PR DESCRIPTION
`main` is red on `scripts/check_doc_slugs.py`, which blocks the docs gate on every
open PR. One link, one character class of fix.

## What broke

The cross-check page links at the clock page's future-run section:

```
docs/design/hicasso/studio/cross-checked-against-an-outside-instrument.md:334
  -> the-candidates-clock.md#what-a-future-run-would-have-to-change
```

The clock page numbers its headings. Line 607 reads `### 6.3 What a future run
would have to change`, so the rendered id carries the number and the link omitted
it.

This is a cross-PR break, not one PR's fault. The link landed in one PR and the
numbered heading in another; each ran `check_doc_slugs.py` green on its own branch,
where the other's page did not yet exist. The break only came into being once both
were on `main` — the mutually-invalidating-changes case, and the ordinary hazard of
concurrent merges rather than a defect in the checker.

## The fix

The **link** is corrected, not the heading. The numbered-section scheme runs
throughout the clock page and renumbering would break its other anchors.

```diff
-repair [the clock page](the-candidates-clock.md#what-a-future-run-would-have-to-change)
+repair [the clock page](the-candidates-clock.md#63-what-a-future-run-would-have-to-change)
```

The slug was not guessed. It was derived through the checker's own slugifier —
`pymdownx.slugs.slugify(case="lower")`, the same one `mkdocs.yml` configures —
which returns `63-what-a-future-run-would-have-to-change` for that heading title,
and the page's rendered-id index confirms it resolves exactly once.

## Corpus sweep

Run over the whole corpus, not just the edited file. All 151 anchor links resolving
into the hicasso tree now land on a real heading; the four studio pages that landed
today carry no other drifted anchor. One latent, non-breaking observation is noted
below rather than changed.

`p0-converged-witness-set.md` has two headings that slugify to `provenance`
(`## Provenance` at 137, `### Provenance` at 1204), so the second is reachable only
as `#provenance_1`. The page's single `#provenance` link says "in [Provenance]
(#provenance) **above**" and sits below line 137, so it resolves where it intends.
Nothing is broken and nothing is changed here — recording it only so the ambiguity
is on the record.

## Quality gates

Run in the foreground, from the worker worktree.

| Gate | Before | After |
| --- | --- | --- |
| `python scripts/check_doc_slugs.py --verbose` | **exit 1** — `1 broken anchor link(s) found` | **exit 0** — `no broken links` (650 files scanned) |
| `scripts/test-fast-pr.sh` | — | **exit 0** — `PASS fast PR spine` |

`mkdocs build --strict` ran inside the spine and built green in 18.4s. It does
**not** reach `docs/design/**` (excluded via `exclude_docs`), so it is not the gate
for this file — `check_doc_slugs.py` is, and it does validate this tree's link
targets and heading anchors. The JVM and node tiers were correctly skipped as
surface-unchanged for a docs-only diff.

The diff is one link. No prose rewrites, no restructuring, no `.beads` paths.
