### PR TITLE
hicasso: a delay held as a map key is as loud as one held as a value (rf2-2rtt6.32)

### DIFF
--- a/docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md
+++ b/docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md
@@ -423,19 +423,31 @@ the same refusal, in the same window, naming the same recovery. No walker, no
 render identity, nothing forced.
 
 **It cost something, and it was measured rather than assumed.** Three walks
-A/B/C'd in one process with the rounds interleaved, best of five per round, four
-whole repetitions — ratios only, because the box was carrying another arm's
-ladder and absolute figures drifted 2.6x between repetitions while every ratio
-held. Walking keys unconditionally costs **+31% to +43%** of the walk at the
-dogfood row's props and **+24% to +35%** at the 100-row collection prop; against
-the whole boundary element build measured in the same process, **+4.3% to
-+5.9%**. That is a real cost at the shape that matters most, and one predicate
-removes it: a `Keyword` is provably neither a collection nor a `Delay`, so the
-key half short-circuits on one `instanceof` rather than paying `coll?` — which,
-for anything without the `ICollection` marker, falls through to
+A/B/C'd in one process on an idle box, rounds interleaved, best of seven per
+round, four whole repetitions. Walking keys unconditionally costs **+51% to
++67%** of the walk at the dogfood row's props, **+20% to +28%** with two hiccup
+children beside them, and **+40% to +56%** at the 100-row collection prop —
+against the whole boundary element build measured in the same process, **+7.6%
+to +9.9%**. That is a real cost at the shape that matters most, and one
+predicate removes it: a `Keyword` is provably neither a collection nor a
+`Delay`, so the key half short-circuits on one `instanceof` rather than paying
+`coll?` — which, for anything without the `ICollection` marker, falls through to
 `native-satisfies?` and is the dearest predicate on the path. With the
-short-circuit the repair costs **0.2% to 1.1%** of the element build. The dear
+short-circuit the repair costs **0.2% to 2.8%** of the element build. The dear
 part was never the traversal; it was proving that a keyword is not a collection.
+
+**One methodological note, because it nearly published a wrong number.** The
+first cut wrote the two comparison arms in the measuring namespace and reached
+for `codec/realize-deep` itself as the third. That arm reported **9–20% faster
+than a walk doing strictly less work** — impossible, and the only reason the
+confound was caught: an inline `(throw (ex-info …))` in the local arms against a
+call to `refuse-deferred!` in the real one is a difference V8 optimises
+differently, and it was being read as a fact about keys. All three arms are now
+the same shape in the same namespace. The instrument disagrees with the
+published walk figure too and says so rather than reconciling: the boundary
+element build reads 1.08–1.16 µs here against the recorded 1,089 ns, while the
+walk reads 148–177 ns against the recorded 69 ns. Two instruments agreeing on
+the denominator and not on the numerator is why only ratios are quoted.
 
 | Witness | Asserts |
 |---|---|

--- a/docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md
+++ b/docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md
@@ -387,7 +387,7 @@ property of Surface B and not a later discovery.
 
 | Witness | Asserts |
 |---|---|
-| `deferred-read-cljs-test` (10 rows) | the unforced `delay` is refused at the crossing, with the id, the refusing position and the recovery; at every position the walk reaches — bare prop, vector, nested map, list, lazy seq, set, and the children slot; a realised `delay` crosses untouched and the read stays the parent's; the refused render installs nothing |
+| `deferred-read-cljs-test` (13 rows) | the unforced `delay` is refused at the crossing, with the id, the refusing position and the recovery; at every position the walk reaches — bare prop, vector, nested map, list, lazy seq, set, and the children slot; a realised `delay` crosses untouched and the read stays the parent's; the refused render installs nothing |
 | the same file, classification rows | the fault the refusal replaces, driven around the codec; a function prop keeping its edge across two renders; a function prop invoked outside a render raising the existing error; a body that stops calling one holding no edge; and the mutable-reference limit, asserted unrepaired |
 
 Mutation-proved by deleting the guard from `realize-deep`: node exit 1, 12
@@ -396,6 +396,61 @@ deliberate — the refusal is a pure codec verdict reached before any element is
 built, so a Chromium mount would re-prove what the node rows already prove. The
 DOM half was earned for `rf2-2rtt6.45` because *that* claim was about liveness,
 which a first paint cannot tell you; this one is not.
+
+#### The refusal checked a map's values and not its keys
+
+The walk it was built into descended into a map's **values** only, and said so
+in a comment that gave the reason: hashing a seq realises it, so nothing
+unrealised can already be a key. The claim the walk makes is about **reach** —
+every unforced `delay` reachable from a boundary's props — and a map entry is
+two reachable positions. So an unforced `Delay` written as a map key crossed
+untouched (`rf2-2rtt6.32`, the merged-PR audit of #7333).
+
+The comment's reason is wrong twice, and both halves are worth recording because
+each is a plausible thing to believe. A `Delay` **hashes by object identity** —
+`cljs.core` extends `IHash` on `default` to `goog/getUid` — so hashing a map
+containing one never forces it; hashing realises a *seq*, and only a seq. And a
+map small enough to be a `PersistentArrayMap`, which every props map is,
+compares keys with `=` against the entries it has already accumulated and hashes
+nothing at all — so the first key of a one-entry map is not so much as looked
+at, and even an unrealised **lazy seq** can sit there. Both are asserted:
+`realize-deep-reaches-a-lazy-seq-at-a-key-position-too` checks that the seq is
+still unrealised *after construction* before it checks that the walk forces it.
+
+The repair is the one call the position was missing, and no more: `realize-entry`
+walks the key half through the same `realize-deep`, so a key-held deferral meets
+the same refusal, in the same window, naming the same recovery. No walker, no
+render identity, nothing forced.
+
+**It cost something, and it was measured rather than assumed.** Three walks
+A/B/C'd in one process with the rounds interleaved, best of five per round, four
+whole repetitions — ratios only, because the box was carrying another arm's
+ladder and absolute figures drifted 2.6x between repetitions while every ratio
+held. Walking keys unconditionally costs **+31% to +43%** of the walk at the
+dogfood row's props and **+24% to +35%** at the 100-row collection prop; against
+the whole boundary element build measured in the same process, **+4.3% to
++5.9%**. That is a real cost at the shape that matters most, and one predicate
+removes it: a `Keyword` is provably neither a collection nor a `Delay`, so the
+key half short-circuits on one `instanceof` rather than paying `coll?` — which,
+for anything without the `ICollection` marker, falls through to
+`native-satisfies?` and is the dearest predicate on the path. With the
+short-circuit the repair costs **0.2% to 1.1%** of the element build. The dear
+part was never the traversal; it was proving that a keyword is not a collection.
+
+| Witness | Asserts |
+|---|---|
+| `a-delay-held-as-a-map-key-is-refused-exactly-as-a-value-is` | six key positions the walk reaches — a key of the props map, of a nested map, inside a *collection* key, and of a map held in a vector, a seq and a set |
+| `a-key-held-delay-is-refused-before-the-child-can-cache-it` | the crossing refuses; and on a runtime that does not, the row's second half prints the two child read sets that should have been equal |
+| `the-fault-a-key-held-delay-would-restore` | the mechanism, driven around the codec: first render `#{[:dogfood/todo 1]}`, second render `#{}` |
+| `realize-deep-walks-map-keys-without-disturbing-the-map` | identity and lookup are untouched — the map, each key, and retrieval by an identical and by an equal key, on an array map and on a hash map |
+| `the-keyword-key-short-circuit-skips-only-a-provable-no-op` | the premise the short-circuit rests on, pinned; and that it skips the **key**, never the entry |
+
+Mutation-proved by restoring `(defn- realize-entry [_ _ x] (realize-deep x) nil)`
+— the exact text at merge `9d3b423d17`: node exit 1, **9 failures**, among them
+the two-render receipt reading
+`(not (= #{[…/arm1-deferred-read [:dogfood/todo 1]]} #{}))`. Restored, node exit
+0 with `git diff` empty. Every first-paint assertion in the file passed on the
+mutated runtime, which is why the decisive row is two renders deep.
 
 ## 3. Two places the record did not survive contact with the substrate
 

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -446,6 +446,38 @@ teardown, HMR body swap. Assert the DOM, actual
 commits, and **zero leaked subscription ref-counts after teardown**; an unchanged
 hot read performs no new attach/release.
 
+#### The four deferred-read crossings, named (rf2-2rtt6.32)
+
+The read-outside-the-render family was enumerated as four cases, and it is
+carried here as four **named** rows rather than as one property, because the
+verdicts differ and two of them are not a throw. Each row asserts what the
+runtime does; where that is not a refusal the row says why, and where it is a
+limit rather than a repair it says that instead.
+
+| # | The crossing | Verdict | Witnesses |
+|---|---|---|---|
+| 1 | a lazy seq handed straight to React as children — iterated during the **parent's** reconciliation, after the body returned | **repaired, so it never reaches React unrealised** — and a throw would be wrong here: a seq is structure, and forcing it changes nothing an author can observe. `expand-seq` drives a child seq to exhaustion, `realize-children` folds one into a vector, and `realize-deep` covers the boundary hand-off | `a-lazy-for-registers-its-edges-and-its-readers-re-run`, `a-lazy-seq-returned-as-the-body-root-registers-its-edges-too`, `a-lazy-seq-handed-across-a-boundary-is-the-parents-read`, `the-childs-second-render-reads-nothing-which-is-why-the-first-row-matters` |
+| 2 | a `(sub …)` inside a render prop handed to a foreign component | **split, and one half is a declared limit.** Invoked outside any render it throws. Invoked inside **another** boundary's live render it does not: `read-key!` asks whether *any* body is running, not whether *this* one is, so the read is attributed to whichever boundary is rendering. The `defhost` / `[:> …]` spelling is not in this codec at all — HD-011 owns that surface — so the row is named against the general shape it is an instance of | `a-function-prop-not-called-in-the-render-is-already-loud`, `a-function-prop-keeps-its-edge-because-the-child-re-runs-it`, `a-body-that-stops-calling-a-render-prop-simply-holds-no-edge` |
+| 3 | a `(sub …)` inside an event handler | **throws.** The render frame is set in a `try` and cleared in the matching `finally`, so a handler the browser invokes later finds none and says so | `every-read-that-escapes-the-render-is-loud-rather-than-a-missing-edge` (the stored handler, and the handler actually called), `a-read-outside-a-render-is-a-loud-error` |
+| 4 | a `(sub …)` inside a `delay` or a lazy seq the author returns as a **prop value** | the seq is **repaired** at the crossing; the `delay` is **refused** there, inside the render of the body that wrote it. Refused at **both halves of a map entry** since `rf2-2rtt6.32`: a `Delay` hashes by object identity and a small map literal never hashes its keys at all, so a key position holds an unforced one as readily as a value position does | `an-unforced-delay-crossing-a-boundary-is-refused`, `the-refusal-reaches-wherever-the-walk-reaches`, `a-delay-held-as-a-map-key-is-refused-exactly-as-a-value-is`, `a-key-held-delay-is-refused-before-the-child-can-cache-it` |
+
+**Two limits, stated rather than discovered.** Row 2's second half is one: a read
+landing inside another boundary's live extent is attributed to it, and refusing
+that needs per-boundary render identity, which the HD-002 adjudication rejected
+as one line from the candidate-ledger tripwire and as an error made of a
+legitimate authoring shape. The other is a deferral parked in a **mutable
+reference** — an atom, or a module-level var the codec never sees — which no
+structural walk reaches;
+`a-deferral-parked-in-a-mutable-reference-is-outside-the-walk` asserts the
+unrepaired behaviour so it is a property of Surface B rather than a later
+surprise. React with hooks has the identical hole.
+
+**Every row of this family is asserted two renders deep, never at first paint.**
+A `Delay` and a `LazySeq` both cache, so a broken runtime's first render is
+correct and its second is empty — a witness that stopped at the first paint
+passes on every fault this section names, which is how the map-key hole survived
+the walk that was built to close it.
+
 ### Measurement discipline
 
 Same React version, build settings, tree, frame, queries, writes, and data across

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary_crossing_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary_crossing_cljs_test.cljs
@@ -266,6 +266,65 @@
         (codec/realize-deep v)
         (is (= 3 @!n) label)))))
 
+(deftest realize-deep-walks-map-keys-without-disturbing-the-map
+  (testing "descending into the key half of an entry is a READ, not a
+           rewrite (rf2-2rtt6.32). The map comes back by identity, each key
+           comes back by identity, and lookup still finds what it found
+           before — by the identical key and by an equal one, so nothing
+           the map hashed has moved"
+    (let [composite [:composite 1]
+          m         {composite :a :plain :b "s" :c 7 :d}
+          walked    (codec/realize-deep m)]
+      (is (identical? m walked))
+      (is (= m walked))
+      (is (= (keys m) (keys walked)))
+      (is (identical? composite (first (filter vector? (keys walked)))))
+      (is (= :a (get walked composite)))
+      (is (= :a (get walked [:composite 1])))
+      (is (= :b (get walked :plain)))
+      (is (= :c (get walked "s")))
+      (is (= :d (get walked 7)))))
+  (testing "a map big enough to be a hash map rather than an array map is
+           equally untouched"
+    (let [m      (into {} (map (fn [i] [[:k i] i]) (range 32)))
+          walked (codec/realize-deep m)]
+      (is (identical? m walked))
+      (is (= 32 (count walked)))
+      (is (= 17 (get walked [:k 17]))))))
+
+(deftest realize-deep-reaches-a-lazy-seq-at-a-key-position-too
+  (testing "the reason keys were skipped was that hashing a seq realises
+           it, so nothing unrealised could already be one. A small map
+           literal is a `PersistentArrayMap`: it compares keys with `=`
+           against what it has already accumulated and hashes nothing, so
+           the first key of a one-entry map is never touched. The seq
+           arrives unrealised and the walk is what forces it"
+    (let [!n             (volatile! 0)
+          m              {(map (fn [i] (vswap! !n inc) i) (range 3)) :marked}
+          at-construction @!n]
+      (is (zero? at-construction)
+          "constructing the map neither hashed nor compared the key")
+      (codec/realize-deep m)
+      (is (= 3 @!n)
+          "and the walk reaches it, inside the window of the body that
+           wrote it"))))
+
+(deftest the-keyword-key-short-circuit-skips-only-a-provable-no-op
+  (testing "the key half is walked through one guard — a `Keyword` is
+           neither a collection nor a `Delay`, so the walk on one can
+           reach nothing and return nothing. The premise is pinned here
+           rather than assumed, because the guard is only sound while it
+           holds"
+    (is (not (coll? :k)))
+    (is (not (delay? :k))))
+  (testing "and the guard skips the KEY, never the entry: a keyword-keyed
+           entry's value half is walked exactly as before"
+    (is (thrown-with-msg? js/Error #"unforced `delay` reached a boundary's props"
+                          (codec/realize-deep {:k (delay 1)})))
+    (let [!n (volatile! 0)]
+      (codec/realize-deep {:k (map (fn [i] (vswap! !n inc) i) (range 3))})
+      (is (= 3 @!n)))))
+
 (deftest realize-deep-does-not-walk-into-a-react-element-or-a-function
   (testing "a React element is an opaque JS object and a function is a
            value, not a structure; neither is a collection and neither is

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/deferred_read_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/deferred_read_cljs_test.cljs
@@ -156,6 +156,85 @@
                             (codec/realize-deep v))
           label))))
 
+;; ---------------------------------------------------------------------------
+;; 1b — the same deferral, held as a map KEY (rf2-2rtt6.32)
+;; ---------------------------------------------------------------------------
+
+(defn- child-derefs-key-body
+  "Forces a `delay` it finds at a KEY position. Nothing about the child is
+  unusual — a map arrives as a prop and the child reads it — which is the
+  point: the carrier is the same, only the half of the entry differs."
+  [{:keys [m]}]
+  [:li.deref-key (str @(first (keys m)))])
+
+(def ^:private child-derefs-key
+  (rt/mint-view! "deferred/child-derefs-key" child-derefs-key-body))
+
+(defn- parent-key-delay-body [_]
+  [child-derefs-key {:m {(delay (:title (rt/sub [:dogfood/todo 1]))) :marked}}])
+
+(deftest a-delay-held-as-a-map-key-is-refused-exactly-as-a-value-is
+  (testing "the invariant is about **reach** — every unforced `delay`
+           reachable from the props — and a map entry is two reachable
+           positions rather than one. The walk descended into values only
+           until `rf2-2rtt6.32`, on an argument that does not survive
+           contact with either half of the substrate: a `delay` hashes by
+           object identity, so hashing never forces one; and a small map
+           literal is a `PersistentArrayMap`, which compares keys with `=`
+           and hashes nothing at all, so a one-entry map never so much as
+           looks at its key. Both halves now go through the same refusal."
+    (doseq [[label v] [["a key of the props map"          {(delay 1) :marked}]
+                       ["a key of a nested map"           {:m {(delay 1) :marked}}]
+                       ["inside a COLLECTION key"         {:m {[(delay 1)] :marked}}]
+                       ["a key of a map inside a vector"  {:v [{(delay 1) :marked}]}]
+                       ["a key of a map inside a seq"     {:v (list {(delay 1) :marked})}]
+                       ["a key of a map inside a set"     {:v #{{(delay 1) :marked}}}]]]
+      (is (thrown-with-msg? js/Error #"unforced `delay` reached a boundary's props"
+                            (codec/realize-deep v))
+          label))))
+
+(deftest a-key-held-delay-is-refused-before-the-child-can-cache-it
+  (seeded!)
+  (testing "**Deliberately two renders deep.** A witness that stopped at
+           the first paint would pass on a runtime that never looked at a
+           key: the child's FIRST render forces the delay and files the
+           read under itself, so the screen is right. The SECOND render is
+           the wrong one — a `Delay` caches, so that walk calls `sub` zero
+           times, the read set collapses to empty, React re-subscribes and
+           the edge is dropped. The parent holds no edge either, so nothing
+           ever rebuilds the delay.
+
+           On this runtime the crossing refuses and the branch below is
+           never entered. On one whose walk skips keys the crossing
+           succeeds, and the assertion inside prints the two read sets that
+           should have been equal and are not."
+    (let [built (try (render parent-key-delay-body {}) (catch :default _ ::refused))]
+      (is (= ::refused built)
+          "an unforced `delay` at a key position refuses at the crossing")
+      (when (not= ::refused built)
+        (let [props  (crossing-props (:element built))
+              first' (:reads (render child-derefs-key-body props))
+              again  (:reads (render child-derefs-key-body props))]
+          (is (= first' again)
+              "UNREFUSED: the child's first render holds the edge and its
+               cached second render drops it"))))))
+
+(deftest the-fault-a-key-held-delay-would-restore
+  (seeded!)
+  (testing "driven around the codec, because the codec now refuses to build
+           it. Identical to `the-fault-the-refusal-replaces` in every
+           respect but where the `delay` sits, and that is the finding: the
+           position it occupies changes nothing about what it does to the
+           edge, so the walk's **reach** was the whole of the defect."
+    (let [d      (delay (:title (rt/sub [:dogfood/todo 1])))
+          props  {:m {d :marked}}
+          first' (render child-derefs-key-body props)
+          again  (render child-derefs-key-body props)]
+      (is (= #{(key-of [:dogfood/todo 1])} (:reads first'))
+          "the first walk files the read under whoever forced it")
+      (is (= #{} (:reads again))
+          "and the second calls `sub` zero times, so the edge is dropped"))))
+
 (deftest a-delay-in-the-children-position-is-refused-too
   (seeded!)
   (testing "`:children` is a key in the same props map, so the one walk

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -540,7 +540,30 @@
 ;; mint a fresh function object on every collection visited, and `run!`
 ;; mints one of its own. Named here, the walk allocates nothing at all.
 
-(defn- realize-entry [_ _ x] (realize-deep x) nil)
+;; A map entry is TWO reachable positions, not one. Keys were skipped
+;; here until rf2-2rtt6.32 on the argument that hashing a seq realises
+;; it, so nothing unrealised can already be a key — and that argument is
+;; wrong twice. A `delay` hashes by object identity (cljs.core extends
+;; `IHash` on `default` to `goog/getUid`), so hashing never forces one;
+;; and a small map literal is a `PersistentArrayMap`, which compares keys
+;; with `=` against the entries already accumulated and hashes nothing at
+;; all, so the first key of a one-entry map is never even compared. Both
+;; positions therefore go through the same walk.
+;;
+;; The `keyword?` short-circuit is not a special case, it is the same
+;; allocation-and-predicate accounting as the two named vars above, and
+;; it is worth as much. A `Keyword` is neither a collection nor a
+;; `Delay`, so [[realize-deep]] on one is a provable no-op — but proving
+;; it costs `coll?`, which for anything without the `ICollection` marker
+;; falls through to `native-satisfies?` and is the dearest predicate on
+;; the path. `keyword?` is one `instanceof`. Prop-map keys are keywords
+;; essentially always, and skipping the no-op for them is the difference
+;; between the key half costing +30–43% of the walk and costing nothing
+;; measurable (rf2-2rtt6.32, table in [[realize-deep]]).
+(defn- realize-entry [_ k x]
+  (when-not (keyword? k) (realize-deep k))
+  (realize-deep x)
+  nil)
 (defn- realize-item  [_ x]   (realize-deep x) nil)
 
 (defn- refuse-deferred!
@@ -628,10 +651,38 @@
   already rested on is 4.7x dearer than the position this walk repairs.
 
   Maps are reduced with `reduce-kv` rather than over their entries, so
-  the walk allocates no `MapEntry`; their keys are not descended into
-  because hashing a seq realises it, so a lazy seq cannot already be a
-  key in a map. `coll?` is tested before `map?` so a scalar — the
-  overwhelming case — costs exactly one predicate.
+  the walk allocates no `MapEntry`; **both** halves of an entry are
+  descended into, because a map entry is two reachable positions and the
+  invariant above is about reach, not about position. `coll?` is tested
+  before `map?` so a scalar — the overwhelming case — costs exactly one
+  predicate.
+
+  ### What the key half costs (rf2-2rtt6.32)
+
+  Not nothing, and it was measured rather than assumed. Three walks
+  A/B/C'd in one process, rounds interleaved, best of five per round,
+  four whole repetitions — **ratios only**: the box was carrying another
+  arm's ladder, so absolute figures drifted 2.6x between repetitions
+  while every ratio below held. A is the value-only walk this replaced,
+  B walks keys unconditionally, C is B with the `keyword?` short-circuit
+  above and is what ships.
+
+  | shape | B vs A | C vs A |
+  |---|---|---|
+  | the dogfood row's props | +31%, +35%, +43%, +31% | +8%, +2%, +6%, −2% |
+  | the same plus two hiccup children | +8%, +9%, +9%, +16% | +6%, +4%, +3%, +5% |
+  | a 100-row collection prop | +24%, +27%, +27%, +35% | +3%, +7%, +1%, +11% |
+
+  Against the whole boundary element build, measured in the same process
+  on the same instrument, **B adds 4.3–5.9% of it and C adds 0.2–1.1%**.
+  The unconditional walk is therefore a real cost at the shape that
+  matters most, and one predicate removes it: the dear part was never
+  the traversal, it was proving that a keyword is not a collection.
+
+  The 100-row collection prop is the honest ceiling, every element of it
+  a map and so every element two positions rather than one; it is still
+  the position whose eagerness costs far less than the NATIVE prop
+  position's `clj->js` beside it.
 
   A seq of unbounded length at a boundary prop position now diverges here
   rather than in the child. That is the same thing `clj->js` already does

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -558,8 +558,8 @@
 ;; falls through to `native-satisfies?` and is the dearest predicate on
 ;; the path. `keyword?` is one `instanceof`. Prop-map keys are keywords
 ;; essentially always, and skipping the no-op for them is the difference
-;; between the key half costing +30–43% of the walk and costing nothing
-;; measurable (rf2-2rtt6.32, table in [[realize-deep]]).
+;; between the key half costing +51–67% of the walk and costing almost
+;; nothing (rf2-2rtt6.32, table in [[realize-deep]]).
 (defn- realize-entry [_ k x]
   (when-not (keyword? k) (realize-deep k))
   (realize-deep x)
@@ -660,24 +660,37 @@
   ### What the key half costs (rf2-2rtt6.32)
 
   Not nothing, and it was measured rather than assumed. Three walks
-  A/B/C'd in one process, rounds interleaved, best of five per round,
-  four whole repetitions — **ratios only**: the box was carrying another
-  arm's ladder, so absolute figures drifted 2.6x between repetitions
-  while every ratio below held. A is the value-only walk this replaced,
-  B walks keys unconditionally, C is B with the `keyword?` short-circuit
-  above and is what ships.
+  A/B/C'd in one process on an otherwise idle box, rounds interleaved,
+  best of seven per round, four whole repetitions. A is the value-only
+  walk this replaced, B walks keys unconditionally, C is B with the
+  `keyword?` short-circuit above and is what ships.
+
+  **All three arms are written in the measuring namespace, including the
+  one that ships**, and that is not fussiness. Timing two local arms
+  against `realize-deep` itself compares an inline `(throw (ex-info …))`
+  with a call to [[refuse-deferred!]] as much as it compares anything
+  about keys, and it reported the shipping arm 9–20% *faster* than a
+  walk doing strictly less work — an impossible result, and the only
+  reason the confound was caught.
 
   | shape | B vs A | C vs A |
   |---|---|---|
-  | the dogfood row's props | +31%, +35%, +43%, +31% | +8%, +2%, +6%, −2% |
-  | the same plus two hiccup children | +8%, +9%, +9%, +16% | +6%, +4%, +3%, +5% |
-  | a 100-row collection prop | +24%, +27%, +27%, +35% | +3%, +7%, +1%, +11% |
+  | the dogfood row's props | +59%, +57%, +67%, +51% | +4%, +2%, +1%, +18% |
+  | the same plus two hiccup children | +28%, +20%, +20%, +24% | +7%, +3%, +0%, −2% |
+  | a 100-row collection prop | +56%, +40%, +47%, +49% | +7%, +1%, +2%, +3% |
 
-  Against the whole boundary element build, measured in the same process
-  on the same instrument, **B adds 4.3–5.9% of it and C adds 0.2–1.1%**.
-  The unconditional walk is therefore a real cost at the shape that
-  matters most, and one predicate removes it: the dear part was never
-  the traversal, it was proving that a keyword is not a collection.
+  Against the whole boundary element build, measured in the same process:
+  **B adds 7.6–9.9% of it, C adds 0.2–2.8%.** The unconditional walk is a
+  real cost at the shape that matters most, and one predicate removes it
+  — the dear part was never the traversal, it was proving that a keyword
+  is not a collection.
+
+  Two instruments, one denominator: the element build reads 1.08–1.16 µs
+  here, within a few percent of the 1,089 ns in the table above, while
+  the walk itself reads 148–177 ns against that table's 69 ns. They agree
+  on what an element costs and not on what the walk inside it costs, so
+  the rows above are quoted as ratios and the absolute figures are not
+  carried forward.
 
   The 100-row collection prop is the honest ceiling, every element of it
   a map and so every element two positions rather than one; it is still


### PR DESCRIPTION
At merge `9d3b423d17`, the crossing walk's map step was:

```clojure
(defn- realize-entry [_ _ x] (realize-deep x) nil)
```

Map values were checked; map keys were not — though the invariant the walk
states covers *every unforced `delay` reachable from a boundary's props*. A map
entry is two reachable positions, so an unforced `Delay` written as a key
crossed untouched, was forced inside the **child's** render, and cached there.

The consequence is the one this bead exists to make loud: the child's first
render records the edge and the cached second render drops it. Correct on the
first paint, frozen thereafter, attributable to nothing — the parent never held
an edge, so nothing ever rebuilds the delay.

## The comment that justified skipping keys was wrong twice

> their keys are not descended into because hashing a seq realises it, so a lazy
> seq cannot already be a key in a map

- A **`Delay` hashes by object identity** — `cljs.core` extends `IHash` on
  `default` to `goog/getUid` — so hashing never forces one. Hashing realises a
  *seq*, and only a seq.
- A **`PersistentArrayMap` hashes nothing at all**. It compares keys with `=`
  against the entries it has already accumulated, so the first key of a
  one-entry map is never so much as looked at — and even an unrealised **lazy
  seq** can sit there. `realize-deep-reaches-a-lazy-seq-at-a-key-position-too`
  asserts the seq is still unrealised *after construction* before asserting that
  the walk forces it.

## The repair, bounded

`realize-entry` walks the key half through the same `realize-deep`, so a
key-held deferral meets the same refusal, in the same window, naming the same
recovery. **No general walker, no render identity, no forcing.** Per-boundary
render identity stays rejected for the reasons the HD-002 adjudication gives.
`realize-deep` still returns its argument by identity, and
`realize-deep-walks-map-keys-without-disturbing-the-map` asserts that the map,
each key, and lookup by an identical *and* by an equal key are all untouched, on
an array map and on a hash map.

## What walking keys costs — measured, not assumed

Three walks A/B/C'd in one process on an idle box, rounds interleaved, best of
seven per round, four repetitions. A is the value-only walk, B walks keys
unconditionally, C is B with a `keyword?` short-circuit and is what ships.

| shape | B vs A | C vs A |
|---|---|---|
| the dogfood row's props | +59%, +57%, +67%, +51% | +4%, +2%, +1%, +18% |
| the same plus two hiccup children | +28%, +20%, +20%, +24% | +7%, +3%, +0%, −2% |
| a 100-row collection prop | +56%, +40%, +47%, +49% | +7%, +1%, +2%, +3% |

Against the whole boundary element build in the same process: **B adds 7.6–9.9%
of it; C adds 0.2–2.8%.** So the unconditional walk is a real cost at the shape
that matters most, and one predicate removes it. A `Keyword` is provably neither
a collection nor a `Delay`, so `realize-deep` on one is a no-op — but *proving*
it costs `coll?`, which for anything without the `ICollection` marker falls
through to `native-satisfies?` and is the dearest predicate on the path.
`keyword?` is one `instanceof`. **The dear part was never the traversal; it was
proving that a keyword is not a collection.**
`the-keyword-key-short-circuit-skips-only-a-provable-no-op` pins the premise and
asserts the guard skips the *key*, never the entry.

Two instrument notes, recorded rather than smoothed over:

- The **first cut of this measurement was confounded** and its numbers are
  superseded by the third commit here. It wrote two arms locally and reached for
  `codec/realize-deep` itself as the third — and that arm read **9–20% faster
  than a walk doing strictly less work**. An impossible result, and what gave it
  away: an inline `(throw (ex-info …))` against a call to `refuse-deferred!` is a
  difference V8 optimises differently, and it was being read as a fact about keys.
- The instrument **disagrees with the published walk figure** and says so: the
  element build reads 1.08–1.16 µs here against the recorded 1,089 ns, while the
  walk reads 148–177 ns against the recorded 69 ns. Two instruments agreeing on
  the denominator and not on the numerator is why only ratios are quoted.

## The named P1 validation rows

`validation.md`'s P1 **Witness set** — the section the bead's line reference
resolves to — now carries the four deferred-read crossings as four named rows.
They are *not* four assertions of a throw, because the verdicts genuinely
differ, and the bead asked for the verdict either way:

| # | crossing | verdict |
|---|---|---|
| 1 | a lazy seq handed to React as children | **repaired** — and a throw would be wrong; a seq is structure |
| 2 | a `(sub …)` in a render prop handed to a foreign component | **split** — throws outside any render; **cannot be made to throw** inside another boundary's live extent |
| 3 | a `(sub …)` in an event handler | **throws** |
| 4 | a `(sub …)` in a `delay` / lazy seq returned as a prop value | seq **repaired**, `delay` **refused** — now at both halves of a map entry |

Row 2's second half and the mutable-reference case are written down as **declared
limits of the Surface B ruling**, not as gaps: `read-key!` asks whether *any*
body is running, not whether *this* one is, and refusing that needs the
per-boundary render identity HD-002 rejected. React with hooks has the identical
hole.

## Quality gates

**Mutation proof.** Restoring the exact pre-fix text
`(defn- realize-entry [_ _ x] (realize-deep x) nil)`:

- **RED — exit 1**, 24 tests / 80 assertions, **9 failures**. The decisive row is
  two renders deep and prints the fault verbatim:
  ```
  UNREFUSED: the child's first render holds the edge and its cached second render drops it
  expected: (= first' again)
    actual: (not (= #{[…/arm1-deferred-read [:dogfood/todo 1]]} #{}))
  ```
  with the parent's own read set `#{}` in the same output — nobody holds the edge.
- **GREEN — exit 0**, 24 tests / 79 assertions, 0 failures, with `git diff` empty.

Every first-paint assertion in the file passed on the mutated runtime. That is
why the decisive witness renders the child twice.

| Gate | Result |
|---|---|
| `npm run test:cljs` | **exit 0** — 12,287 tests, 61,536 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **exit 0** — 931 tests, 5,840 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` | **exit 0** — `PASS fast PR spine` (docs tier incl. `mkdocs --strict`; JVM core + freehand; CLJS node integration; JS harness self-tests; per-ns isolation 17/17) |
| clj-kondo **2026.04.15** (CI's pin, fetched; local npm is older), CI's exact `--lint` list | **exit 0 — errors: 0**, warnings 4530 (unchanged baseline) |
| `scripts/check_doc_slugs.py` over the whole corpus | **exit 0** — 653 markdown files, no broken links |

**TESTING.md matrix.** This diff is `cljs_node_test` + documentation tier: CLJS
bench tests under `implementation/freehand/test/` and markdown under
`docs/design/hicasso/`. Scenario 1 (agent pre-checkin) is the spine above;
scenario 2 (PR CI) adds the browser lanes and bundle/elision gates, run here as
`test:browser`. `mkdocs build --strict` does **not** reach `docs/design/**`
(`exclude_docs`), so the anchors and both new tables were verified by hand —
every table in the two edited files re-counted header-vs-row cells, all
consistent — and `check_doc_slugs.py`, which *does* reach the tree, was run over
the whole corpus rather than the diff.

## Coordination

`front/codec.cljs` is also on `worker/converge-fki5d`'s path. This diff touches
`realize-entry` and `realize-deep`'s docstring only — **the walk, not the element
path**; `boundary-element`, `make-element`, `as-element`, `convert-props` and the
tag/prop caches are untouched.
