### PR TITLE
hicasso: a controlled element converges in-turn, caret where the edit left it (rf2-fki5d)

### DIFF
--- a/docs/design/hicasso/architecture.md
+++ b/docs/design/hicasso/architecture.md
@@ -169,9 +169,18 @@ nothing re-rendered, so the refused character comes off the screen for free.
 It does not put the caret back: assigning `value` moves the cursor to the end
 of the control, and React restores a selection only around a commit in which
 focus moved. So a mid-string refusal — and every keystroke a normalising model
-rewrites — converges with the caret thrown to the end of the field. The
-matrix, the two implementations UIx chooses between, and a measured option
-that carries both halves in one turn are on
+rewrites — converges with the caret thrown to the end of the field.
+
+**The caret half is the arm's, taken 2026-08-02 (rf2-fki5d), in the element
+path.** `front.codec/native-element` calls `front.controlled/install!`, which
+wraps the change handler the author wrote: at the end of it, inside the same
+discrete event and ahead of React's restore, `flushSync`, write the value the
+element renders if the field disagrees — which makes React's own later write a
+no-op — and put the caret back by offset from the end of the string. The
+authoring surface does not change (an ordinary `:value` / `:on-input` pair),
+**no hook is spent**, and the value the element last rendered is read off the
+node as `defaultValue`, which React maintains there itself. The matrix, the
+two implementations UIx chooses between, and the price are on
 [the studio page](studio/controlled-input-two-implementations.md).
 
 ## Memoization (HD-006)

--- a/docs/design/hicasso/studio/controlled-input-two-implementations.md
+++ b/docs/design/hicasso/studio/controlled-input-two-implementations.md
@@ -1,5 +1,13 @@
 # A controlled input has two implementations, and the bundle was picking
 
+> **Amended 2026-08-02 (`rf2-fki5d`).** Option B below is **TAKEN** and
+> shipped in Arm 1's element path, so there is now a third behaviour on this
+> page and the matrix has a column for it. Nothing measured here moved: the
+> two shipped implementations behave exactly as the rows below record, and
+> the arm's converge is a third thing sitting on top of React's. The one
+> figure that changed is the price — see
+> [the record turned out to be React's own](#the-record-turned-out-to-be-reacts-own).
+
 **Bead** `rf2-n3dxw` · **epic** `rf2-2rtt6` (EP-0038)
 **Witness content hash** `d747b10d82daa24ce39a4a7a6cff825ce7716483`
 (`implementation/freehand/test/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs`;
@@ -11,6 +19,14 @@ and this branch was rebased once already — the content hash is the
 identifier, and `git log --oneline --all -- <path>` plus
 `git rev-parse <candidate>:<path>` finds a commit carrying the blob.
 **Measured** 2026-08-01 AUSEST
+
+**The arm's own witnesses** (`rf2-fki5d`, measured 2026-08-02 AUSEST, same
+runtime): `22e7e6f456fd1ac9a1628fd985588ff87e68532d`
+(`…/hicasso/arm1/controlled_grid_dom_cljs_test.cljs`) and
+`176442a54e1be2ea346e7cfee460f4583bf10233`
+(`…/hicasso/front/controlled_dom_cljs_test.cljs`). The mechanism is
+`e625d031cb251614899015894bccc2703052ddfd`
+(`…/hicasso/front/controlled.cljs`).
 
 **Runtime for every row on this page**: headless Chromium via Playwright
 1.59.1, shadow-cljs `:browser-test` (development optimisations, `goog.DEBUG`
@@ -116,11 +132,39 @@ uppercases, cell 17 regroups, cell 7 takes what it is given.
 
 Read the table as one sentence: **React converges in the same turn and puts
 the caret in the wrong place; UIx's port puts the caret in the right place
-one frame late.** Neither gives both.
+one frame late.** Neither *shipped implementation* gives both.
 
 The regrouping row is green on React only because the edit was at the *end*
 of the field, which is where React's write leaves the caret anyway. It is not
 evidence that React preserves a caret across a length change.
+
+### The third column — Arm 1's element path
+
+**Taken 2026-08-02 (`rf2-fki5d`).** The same five rows, same model, same
+keystrokes, on Arm 1's own grid
+(`arm1_controlled_grid_dom_cljs_test/the-family-converges-in-one-turn-with-the-caret-where-the-edit-left-it`),
+every reading taken on the line after `dispatchEvent` returns:
+
+| row | `:react` in-turn | Arm 1 in-turn |
+|---|---|---|
+| refusal at the end — `"12"` + `a` at `[2 2]` | `"12"` `[2 2]` ✅ | `"12"` `[2 2]` ✅ |
+| refusal mid-string — `"12345"` + `z` at `[2 2]` | `"12345"` **`[5 5]`** ⚠️ | `"12345"` **`[2 2]`** ✅ |
+| uppercasing mid-string — `"ABCD"` + `x` at `[2 2]` | `"ABXCD"` **`[5 5]`** ⚠️ | `"ABXCD"` **`[3 3]`** ✅ |
+| regrouping at the end — `"1,234"` + `5` at `[5 5]` | `"12,345"` `[6 6]` ✅ | `"12,345"` `[6 6]` ✅ |
+| accepted keystroke mid-string — `"abcd"` + `X` at `[2 2]` | `"abXcd"` `[3 3]` ✅ | `"abXcd"` `[3 3]` ✅ |
+
+There is no "settled" column because there is nothing to settle: every row
+above is final when the discrete event returns, and no later frame moves it.
+
+**Mutation-proved, twice.** Removing the one call in
+`front.codec/native-element` that installs the converge reds 14 assertions,
+and every caret reading falls back to `[5 5]` with the refused character
+still on the screen — React's own behaviour, exactly as the matrix records
+it. Removing only the `flushSync` reds 4, all of them caret readings at
+`[5 5]`, including the **ordinary accepted keystroke**: without it the
+record is one render stale, the converge writes the wrong value, and React's
+restore repairs the value and throws the caret away. Both were restored and
+the suite is green at 59 tests / 303 assertions.
 
 ### The range row
 
@@ -156,10 +200,12 @@ re-frame2 introduced.
 
 ### B — converge at the end of the change handler
 
-Measured, green, and committed as
-`a-same-turn-converge-can-have-both-halves-at-a-stated-price`. At the end of
-the change handler, still inside the discrete event and still ahead of
-React's own restore:
+**TAKEN** (`rf2-fki5d`, 2026-08-02). Prototyped as
+`a-same-turn-converge-can-have-both-halves-at-a-stated-price` and now
+shipped in Arm 1's element path:
+`front.codec/native-element` calls `front.controlled/install!`, which wraps
+the change handler the author already wrote. At the end of that handler,
+still inside the discrete event and still ahead of React's own restore:
 
 1. `flushSync` so the synchronous door's commit lands now rather than in the
    `finally` of `batchedUpdates$1`;
@@ -172,26 +218,64 @@ Every row of the family, in one turn, including the mid-string refusal that
 neither shipped path gets right.
 
 **Price, stated rather than hidden.** One `flushSync` per keystroke on a
-controlled element. A per-instance record of the value that element last
-rendered — the handler's own closure carries the value from the render that
-*minted* it, which is stale after a re-render, and `(= (.-value node)
-dom-value)` alone cannot tell a refusal from a keystroke the model took
-verbatim. The synchronous door only: `dispatch` drains on a macrotask, so at
-the end of the handler the model has not moved and there is nothing to
-converge to.
+controlled element, and the synchronous door only: `dispatch` drains on a
+macrotask, so at the end of the handler the model has not moved and there is
+nothing to converge to. A queued field converges one macrotask later, as it
+always did.
 
 **What it does not cost.** No user-visible ceremony — the view still writes
 an ordinary `:value`/`:on-change` pair, with no ref, no effect and no escape
 hatch. No hook in the boundary shell, so the ≤2-hook budget (HD-020) is
-untouched. UIx's own answer to the same problem costs a wrapper *component*
-per input with three hooks in it (`uix/compiler/input.cljs:132-143`); this
-one costs none, because it lives in the element path rather than in a
-component.
+untouched, and `arm1_hook_ledger_dom_cljs_test` reads the same ledger it did
+before. UIx's own answer to the same problem costs a wrapper *component* per
+input with three hooks in it (`uix/compiler/input.cljs:132-143`); this one
+costs none, because it lives in the element path rather than in a component.
+`grid.cljs` — the 100-cell witness's view — did not change by a character.
 
-Where it would live is the open question: neither Hicasso nor the shipped
-UIx adapter mints its own `:input` element today — UIx does — so the
-prototype sits in the witness's view, labelled as a measurement rather than
-an authoring pattern.
+#### The record turned out to be React's own
+
+The third item on the quoted price was **a per-instance record of the value
+that element last rendered**, and it is not charged. The handler's own
+closure cannot serve: it carries the value from the render that *minted* it,
+which is one behind the moment step 1 commits a new one, and writing it back
+**deletes a keystroke the model took verbatim** — reproduced in
+`front/controlled_dom_cljs_test/the-closure-value-wipes-a-keystroke-the-model-took-verbatim`,
+which calls the same function twice with one argument different. Comparing
+the field against what the handler saw cannot serve either: `(= (.-value
+node) dom-value)` reads true on a refusal *and* on a keystroke taken
+verbatim — the same reading, two opposite obligations.
+
+What does serve is `node.defaultValue`, and **React already maintains it**.
+On any genuinely controlled input or textarea, every commit mirrors the
+committed `value` prop into the element's default value —
+`updateInput:1671-1672` → `setDefaultValue:1737-1741`, `initInput:1721` on
+mount, `updateTextarea:1842-1851` for the other tag. It is the element's own
+bookkeeping, per instance, on the node: no `ref`, no `WeakMap`, no extra
+prop, nothing to keep in step. Typing does not disturb it, because the
+`value` IDL setter sets the value and the dirty flag and never the content
+attribute `defaultValue` reflects.
+
+That leaves a **dependency** rather than a cost, and it is named in one
+place. `front.controlled/last-rendered` is the only reader, every guard in
+`install!` is a condition under which React's mirror really is the rendered
+value — `input`/`textarea` only, a non-nil `value`, no author `defaultValue`
+(a `<textarea>` honours that one over the mirror), and a type with a text
+cursor (`setDefaultValue` deliberately skips a focused `number` field, and
+`setSelectionRange` does not apply to it either — the same exclusion twice)
+— and
+`arm1_controlled_grid_dom_cljs_test/the-record-is-reacts-own-mirror-and-is-not-the-handlers-closure`
+asserts the invariant against a live React tree, including that it *moves*
+when the rendered value moves. If React ever stops mirroring, that row goes
+red by name instead of five caret rows going quietly wrong.
+
+#### One thing for the decisions record
+
+HD-019 says `flushSync` is "the evidence-gated last resort, never the
+default". This makes it the default for every controlled element, and the
+evidence gate is met — the mutation probe above shows the ordinary accepted
+keystroke regressing without it — but the ruling's text and the code now
+disagree in letter. Raised rather than resolved here; the amendment is
+Mike's.
 
 ### C — pin the selector
 
@@ -213,10 +297,10 @@ either one by accident. The consumer-facing statement of the trade-off,
 including the caret, lives in `docs/api/re-frame.adapter.uix.md`.
 
 What this does **not** settle: the mid-string refusal row above is still red
-on the caret, because React is now the path every UIx consumer is on. Pinning
-the selector made the default honest; it did not give either implementation
-the half it lacks. `rf2-n3dxw` stays open, and B (priced as `rf2-fki5d`)
-remains the route to both halves.
+on the caret **for a UIx consumer**, because React is now the path every UIx
+consumer is on. Pinning the selector made the default honest; it did not give
+either implementation the half it lacks. Option B closed it for Arm 1, in the
+element path — a UIx consumer is not on that path and does not get it.
 
 ## What this changes in the record
 
@@ -225,5 +309,13 @@ remains the route to both halves.
   the element is actually controlled — which UIx did not guarantee, and which
   `re-frame.adapter.uix` now does (`rf2-heqwo`, Option C above).
 - HD-019's "rejected/unchanged-model paths lean on React's own end-of-event
-  restore" is **confirmed for the value and refuted for the caret**.
-- `rf2-n3dxw` stays open on the residue: no shipped path gives both halves.
+  restore" is **confirmed for the value and refuted for the caret** — and the
+  caret is now the *arm's*, taken in the element path rather than leaned on
+  (`rf2-fki5d`, Option B above). HD-019's `flushSync` clause needs the
+  amendment noted under B.
+- `rf2-n3dxw`'s headline residue is **answered for Arm 1**: a refused
+  keystroke converges in the same turn with the caret at the position before
+  it. Two things it recorded are not answered and are not rounded up — the
+  **range** row (a second algorithm, and off the change path entirely) and
+  the **IME** fence (`rf2-o27h3`, still needing a real `CompositionEvent`
+  harness). And nothing here reaches a UIx consumer's `:input`.

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -438,7 +438,9 @@ kill-bounded arms, and both did run before the ruling.)
 separated scaling curves (fixed reads × growing boundaries; fixed boundaries ×
 growing reads); the 100-cell controlled grid (same-turn echo, mid-string caret,
 selection, unchanged-model rejection, async normalisation — IME composition is
-named here but **not asserted**, and `rf2-n3dxw` says why);
+named here but **not asserted**, and `rf2-n3dxw` says why; the caret across a
+refusal and across a normalisation is the arm's own since `rf2-fki5d`, taken in
+the element path and witnessed on this grid);
 keyed insert/delete/reorder; changing query identity through an abandoned render;
 a foreign hook/context/ref component and a real error boundary (the runtime's
 `h/boundary` class component, HD-020); StrictMode, abandoned first mount, root

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
@@ -52,14 +52,32 @@
   What it does not do is put the caret back. Assigning `value` moves the
   cursor to the end of the control (the HTML `value` IDL setter), and
   React restores a selection only around a commit in which focus MOVED.
-  So every write React makes lands the caret at the end. Neither shipped
-  implementation gives both same-turn convergence and the caret where the
-  edit left it — React converges in-turn and throws the caret to the end,
-  UIx's port gets the caret right a frame late. rf2-n3dxw records it and
-  rf2-fki5d prices the third behaviour that would have both. **The rows
-  below assert the MEASURED value, not the desired one**: the day
-  something puts the caret back, they go red, and whoever makes them red
-  is exactly the person who should be reading those two beads.
+  So every write React makes lands the caret at the end.
+
+  ## The half the arm adds, and where it lives (rf2-fki5d)
+
+  Neither shipped implementation gives both same-turn convergence and the
+  caret where the edit left it: React converges in-turn and throws the
+  caret to the end, UIx's port gets the caret right an animation frame
+  late. rf2-n3dxw recorded that residue and this arm closes it, in the
+  **element path** — `front.controlled/install!` wraps the change handler
+  `front.codec` was about to emit, and at the end of that handler, still
+  inside the discrete event and still ahead of React's own restore, it
+  flushes the synchronous door's commit, writes the value the element
+  renders if the field disagrees, and puts the caret back by offset from
+  the END of the string.
+
+  Two consequences the rows below turn on. Writing the value first makes
+  React's later `updateInput` a no-op, because it only assigns when the
+  two differ — which is what lets the restored caret survive the restore.
+  And the converge is on the CHANGE path only: an out-of-band correction
+  fires no change event, so a write arriving from a timer is still
+  React's to converge, with React's caret.
+
+  Nothing was added to the cell, to `defview`, or to the boundary shell.
+  The grid below is the same grid, `grid.cljs` is unchanged, and HD-020's
+  ≤2-hook budget is untouched — `arm1_hook_ledger_dom_cljs_test` still
+  reads the same ledger.
 
   ## Typing is simulated the way the browser does it
 
@@ -78,6 +96,7 @@
             [re-frame.bench.hicasso.arm1.grid :as grid]
             [re-frame.bench.hicasso.arm1.mount :as mount]
             [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.controlled :as controlled]
             [re-frame.bench.hicasso.lane :as lane]
             [re-frame.core :as rf]
             [re-frame.test-support :as test-support]
@@ -393,13 +412,17 @@
             (is (= [3 3] (caret n))
                 "the caret did not jump to the end")))))))
 
-(deftest a-normalising-model-moves-the-caret-to-the-end
-  (testing "RECORDED BEHAVIOUR, NOT DESIRED BEHAVIOUR (rf2-n3dxw,
-           rf2-fki5d). The model uppercases what was typed, so React
-           WRITES — and every write React makes lands the caret at the end
-           of the string. This is the classic controlled-input caret jump,
-           and it belongs to React's restore rather than to anything this
-           arm does"
+(deftest a-normalising-model-keeps-the-caret-after-the-character-just-typed
+  (testing "the classic controlled-input caret jump, and the row that says
+           this arm does not have it. The model uppercases what was typed,
+           so a write happens — and every write React makes lands the
+           caret at the end of the string. The converge puts it back
+           before the event returns, by offset from the END, so the user
+           carries on typing where they were (rf2-fki5d).
+
+           Measured against the same keystroke on the shipped paths:
+           React alone leaves [5 5], and UIx's port reaches [3 3] one
+           animation frame later"
     (if-not (mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
@@ -411,16 +434,17 @@
             (type-into! n "x")
             (is (= "ABXCD" (model-value 13)) "the model normalised the case")
             (is (= "ABXCD" (.-value n)) "and the field followed, in the same turn")
-            (is (= [5 5] (caret n))
-                "but the caret is at the END, not after the character just
-                 typed — React restores a selection only around a commit in
-                 which focus MOVED, and focus did not move")))))))
+            (is (= [3 3] (caret n))
+                "with the caret still after the character just typed, on
+                 the line after `dispatchEvent`")))))))
 
 (deftest a-grouping-model-keeps-the-caret-after-the-digit-just-typed
   (testing "1,234 + \"5\" becomes 12,345 — one character longer than what
-           was typed. The caret survives here only because the edit was at
-           the END of the field, which is where React's write puts it
-           anyway"
+           was typed, so every absolute offset in the string moved. This
+           row was green before the converge existed, because the edit was
+           at the END of the field and that is where React's write leaves
+           the caret anyway; it stays green for the better reason, which
+           is that the offset is taken from the end"
     (if-not (mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
@@ -459,8 +483,13 @@
   (testing "RECORDED BEHAVIOUR, NOT DESIRED BEHAVIOUR (rf2-n3dxw). Arm 2
            restored both ends of a selection by distance from the end of
            the string. React does not: it assigns `value`, which collapses
-           the selection to a cursor at the end of the new string. Nothing
-           here pretends otherwise"
+           the selection to a cursor at the end of the new string.
+
+           The converge does not reach this row and is not meant to: an
+           out-of-band write fires no change event, so there is no handler
+           to run at the end of. Restoring a RANGE is a second algorithm
+           besides — two offsets rather than one — and rf2-n3dxw keeps it.
+           Nothing here pretends otherwise"
     (if-not (mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
@@ -621,12 +650,15 @@
                  because the edit was AT the end, which is where React's
                  write leaves it anyway")))))))
 
-(deftest a-refused-keystroke-mid-string-converges-with-the-caret-at-the-end
-  (testing "RECORDED BEHAVIOUR, NOT DESIRED BEHAVIOUR (rf2-n3dxw,
-           rf2-fki5d). The residue after the headline row is met: the
-           refused character IS removed, in the same turn — but React's
-           write moves the cursor to the end, so a user editing mid-string
-           is thrown to the end of the field on every refused keystroke"
+(deftest a-refused-keystroke-mid-string-converges-with-the-caret-where-it-was
+  (testing "THE ROW NEITHER SHIPPED IMPLEMENTATION GETS RIGHT, and the
+           reason rf2-fki5d exists. React removes the refused character
+           in the same turn and throws the cursor to the end of the field
+           — so a user correcting the middle of a number is dumped at the
+           end of it on every keystroke the model refuses. UIx's port
+           gets the caret right and arrives an animation frame late.
+
+           Here both halves land before `dispatchEvent` returns"
     (if-not (mount/browser?)
       (skip! ":node-test has no DOM")
       (with-grid
@@ -638,8 +670,120 @@
             (type-into! n "z")
             (is (= "12345" (.-value n)) "the refused character is gone")
             (is (= "12345" (model-value 11)))
-            (is (= [5 5] (caret n))
-                "but the caret is at the end of the field, not at 2")))))))
+            (is (= [2 2] (caret n))
+                "and the caret is at the position before it, not at the
+                 end of the field")))))))
+
+;; ---------------------------------------------------------------------------
+;; 5b — the whole family, in one turn, and the record underneath it
+;; ---------------------------------------------------------------------------
+
+(deftest the-family-converges-in-one-turn-with-the-caret-where-the-edit-left-it
+  (testing "every row of validation.md's controlled family, on one mounted
+           grid, in one turn, through the arm's ordinary authoring
+           surface — a `:value` and an `:on-input` intent, no ref, no
+           effect, no escape hatch, and nothing in the boundary shell.
+
+           The fifth row is not a formality. It is the one the naive
+           form regresses: a keystroke the model takes VERBATIM looks
+           exactly like a refusal from inside the handler, and a converge
+           that writes the value its closure holds deletes the character
+           the user just typed. `front/controlled_dom_cljs_test`
+           reproduces that deletion; this row is what says it does not
+           happen here"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [reject (cell-input handle 11)
+                upper  (cell-input handle 13)
+                group  (cell-input handle 17)
+                plain  (cell-input handle 7)]
+            (testing "a refused keystroke at the end of the field"
+              (set-model! 11 "12")
+              (.focus reject)
+              (.setSelectionRange reject 2 2)
+              (type-into! reject "a")
+              (is (= "12" (.-value reject)))
+              (is (= [2 2] (caret reject))))
+            (testing "a refused keystroke MID-STRING — the row React alone loses"
+              (set-model! 11 "12345")
+              (.focus reject)
+              (.setSelectionRange reject 2 2)
+              (type-into! reject "z")
+              (is (= "12345" (.-value reject)))
+              (is (= [2 2] (caret reject))
+                  "the caret is at the position before the refused
+                   character, in the same turn"))
+            (testing "a length-preserving normalisation"
+              (set-model! 13 "ABCD")
+              (.focus upper)
+              (.setSelectionRange upper 2 2)
+              (type-into! upper "x")
+              (is (= "ABXCD" (.-value upper)))
+              (is (= [3 3] (caret upper))))
+            (testing "a length-CHANGING normalisation"
+              (set-model! 17 "1,234")
+              (.focus group)
+              (.setSelectionRange group 5 5)
+              (type-into! group "5")
+              (is (= "12,345" (.-value group)))
+              (is (= [6 6] (caret group))))
+            (testing "and an ordinary accepted keystroke is not disturbed"
+              (set-model! 7 "abcd")
+              (.focus plain)
+              (.setSelectionRange plain 2 2)
+              (type-into! plain "X")
+              (is (= "abXcd" (.-value plain)))
+              (is (= "abXcd" (model-value 7)) "the model has it too")
+              (is (= [3 3] (caret plain))))
+            (testing "the model and the field agree everywhere afterwards"
+              (is (= ["12345" "ABXCD" "12,345" "abXcd"]
+                     [(model-value 11) (model-value 13)
+                      (model-value 17) (model-value 7)]))
+              (is (= [(.-value reject) (.-value upper)
+                      (.-value group) (.-value plain)]
+                     [(model-value 11) (model-value 13)
+                      (model-value 17) (model-value 7)])))))))))
+
+(deftest the-record-is-reacts-own-mirror-and-is-not-the-handlers-closure
+  (testing "THE ONE THING THE CONVERGE DEPENDS ON, pinned against a live
+           React tree.
+
+           The converge has to know what the element renders NOW, and the
+           value a change handler closed over is one render behind the
+           moment its own `flushSync` commits. The record it reads
+           instead is `node.defaultValue` — React's mirror of the
+           committed `value` prop, written by `initInput` on mount and by
+           `updateInput` on every commit of a genuinely controlled field.
+
+           This row asserts the mirror directly, and asserts that it
+           MOVES when the rendered value moves. If React ever stopped
+           writing it, this goes red by name instead of five caret rows
+           going quietly wrong"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [n (cell-input handle 7)]
+            (set-model! 7 "abcd")
+            (is (= "abcd" (controlled/last-rendered n))
+                "the record is what the last render put on the element")
+            (is (= (.-value n) (controlled/last-rendered n))
+                "and the field agrees with it before anything is typed")
+            (set-model! 7 "wxyz")
+            (is (= "wxyz" (controlled/last-rendered n))
+                "a re-render moves the record with it — which is exactly
+                 what a closure minted by the PREVIOUS render cannot do")
+            (testing "and typing does not disturb it, because the value
+                     IDL setter sets the value and the dirty flag, never
+                     the content attribute the record reflects"
+              (.focus n)
+              (.setSelectionRange n 4 4)
+              (set-native-value! n "wxyzQ")
+              (is (= "wxyz" (controlled/last-rendered n))
+                  "still the value the element rendered, not the value
+                   the field shows"))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 6 — :async-normalisation

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -66,6 +66,21 @@
   representation\" in architecture.md, and it is the reason the two are
   kept visibly apart below rather than interleaved.
 
+  ## The one behaviour emission adds (rf2-fki5d)
+
+  Everything else here translates what the author wrote. A controlled
+  `<input>` or `<textarea>` gets one thing more: its change handler is
+  wrapped so the field converges against the model **inside the discrete
+  event, with the caret where the edit left it** — the half neither
+  React nor UIx's port gives on its own (rf2-n3dxw).
+
+  It belongs at emission rather than in a boundary because that is what
+  makes it free at the authoring surface: the view writes an ordinary
+  `:value` / `:on-input` pair, nothing is added to the boundary shell,
+  and HD-020's ≤2-hook budget is untouched. See
+  [[re-frame.bench.hicasso.front.controlled]], which owns the mechanism,
+  its guards and its one dependency.
+
   ## The component ABI (HD-016)
 
   | Head | Props | Children | `:key` |
@@ -101,6 +116,7 @@
   written against the raw key is a rule that `\"key\"`, `:x/ref` and
   `:onInput` walk straight past."
   (:require [clojure.string :as str]
+            [re-frame.bench.hicasso.front.controlled :as controlled]
             [re-frame.bench.hicasso.front.intent :as intent]
             ["react" :as react]))
 
@@ -704,11 +720,22 @@
             (recur (inc i))))
         (.apply (.-createElement react) nil args)))))
 
-(defn- native-element [argv]
+(defn- native-element
+  "One native tag as a React element.
+
+  [[re-frame.bench.hicasso.front.controlled/install!]] is the only thing
+  here that is not a translation of what the author wrote. It runs on
+  the converted props, because the condition it tests is about the
+  EMITTED element — a controlled `value`, a change handler, a type with
+  a caret — and those are canonical slots rather than spellings. It is
+  one JS `switch` on the tag for every element that is not an `:input`
+  or a `:textarea`, which is nearly all of them. rf2-fki5d."
+  [argv]
   (let [parsed      (cached-parse (nth argv 0))
         has-props?  (props-map? argv 1)
         props       (if has-props? (nth argv 1) nil)
         js-props    (convert-props (or props {}) parsed)]
+    (controlled/install! (.-tag parsed) js-props)
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
     (make-element (.-tag parsed) js-props argv (if has-props? 2 1))))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
@@ -1,0 +1,281 @@
+(ns re-frame.bench.hicasso.front.controlled
+  "THE CONTROLLED-ELEMENT CONVERGE — same turn, caret where the edit left
+  it (rf2-fki5d, the residue rf2-n3dxw was left open on).
+
+  Neither shipped path gives a store-backed field both halves of what it
+  owes its user. React converges inside the discrete event and throws the
+  caret to the end of the control; UIx's port of Reagent's workaround
+  keeps the caret and arrives one animation frame late. The matrix is on
+  `docs/design/hicasso/studio/controlled-input-two-implementations.md`.
+
+  This is the third behaviour, and it lives in **the element path**
+  rather than in a component — which is the whole reason it is cheap.
+  [[install!]] is called from
+  [[re-frame.bench.hicasso.front.codec/native-element]] on the elements
+  it applies to, and wraps the change handler the author already wrote.
+  The view is unchanged: an ordinary `:value` / `:on-input` pair, no
+  ref, no effect, no escape hatch, and **nothing added to the boundary
+  shell**, so HD-020's ≤2-hook budget is untouched. UIx's own answer to
+  the same problem is a wrapper *component* per input carrying three
+  hooks (`uix/compiler/input.cljs:132-143`).
+
+  ## What runs, and when
+
+  At the end of the change handler — still inside the discrete event,
+  and still **ahead of React's own end-of-event restore**:
+
+  1. `flushSync`, so the synchronous door's commit lands now rather than
+     in the `finally` of React's `batchedUpdates$1`;
+  2. if the field still disagrees with what the element renders, write
+     the rendered value — which also makes React's later `updateInput` a
+     no-op, because it only assigns when the two differ
+     (`react-dom-client.development.js:1661-1667`), and a no-op there is
+     what lets the caret survive;
+  3. put the caret back **by offset from the END of the string**, which
+     is Arm 2's algorithm and Reagent's before it — the offset a
+     normalisation that changes the length preserves, where an absolute
+     position does not.
+
+  ## The trap, which is measured rather than assumed
+
+  Step 2 has to know what the element renders **now**, and neither
+  obvious source answers it.
+
+  The handler's own closure carries the value from the render that
+  *minted* it. That value is correct at the instant the handler is
+  invoked — React dispatches to the props it last committed — and
+  **stale the moment step 1 commits a new one**. Writing it back is not
+  a missing improvement, it is a regression: on a keystroke the model
+  took verbatim it wipes the character the user just typed.
+  `front/controlled_dom_cljs_test` reproduces exactly that, by handing
+  [[converge-to!]] the closure's value instead of the record's — one
+  argument different, and the accepted keystroke disappears.
+
+  Comparing the field against what the handler saw does not answer it
+  either. `(= (.-value node) dom-value)` is **true in both cases**: on a
+  refusal nothing re-rendered, so the field still shows the typed value;
+  on a keystroke the model took verbatim the field shows the typed value
+  *because that is what was committed*. The same reading, two opposite
+  obligations.
+
+  ## Where the per-instance record lives, and why it costs nothing
+
+  The record is `node.defaultValue`, and **React already maintains it**.
+  Whenever an `<input>` or `<textarea>` is genuinely controlled, every
+  commit mirrors the committed `value` prop into the element's default
+  value:
+
+  | line (`react-dom@19.2.0`, `cjs/react-dom-client.development.js`) | what happens |
+  |---|---|
+  | `1671-1672` | `updateInput`: `null != value` → `setDefaultValue(element, type, value)` |
+  | `1737-1741` | `setDefaultValue` assigns `node.defaultValue` unless it already matches |
+  | `1721` | `initInput` sets it on mount, so the record exists before the first event |
+  | `1842-1851` | `updateTextarea` does the same, when no `defaultValue` prop was written |
+
+  It is the element's own bookkeeping — the value a `form.reset()` would
+  return the field to — and it is exactly *the value the element last
+  rendered*, per instance, on the node, with no `ref`, no `WeakMap`, no
+  prop and no hook to keep it. Typing does not disturb it: the `value`
+  IDL setter sets the value and the dirty flag, never the content
+  attribute `defaultValue` reflects.
+
+  **So the price the option was quoted at is not charged here.** What
+  remains is the dependency, and [[last-rendered]] is the one place that
+  names it. `front/controlled_dom_cljs_test` asserts the invariant
+  directly, on a live element, across a re-render that moves the value —
+  so if React ever stopped mirroring, a row named for the invariant goes
+  red rather than five rows going subtly wrong.
+
+  ## What [[install!]] refuses, and why each refusal is the record's
+
+  Every guard below exists to keep [[last-rendered]] honest. Read them
+  as *the conditions under which React's mirror is the rendered value*:
+
+  - **`input` and `textarea` only.** A `select` has no text cursor to
+    restore and no `defaultValue` mirror; nothing here applies to it.
+  - **A `value` prop that is present and non-nil.** Absent, the element
+    is uncontrolled, React writes no mirror, and there is nothing to
+    converge *to*.
+  - **No `defaultValue` prop of the author's.** On a `<textarea>` React
+    honours it over the mirror (`:1852-1853`), so the record would be
+    the author's constant rather than the rendered value.
+  - **A type whose text cursor exists** — `text`, `search`, `url`,
+    `tel`, `password`, or no `:type` at all, which is `text`.
+    `setSelectionRange` is not applicable to the others, and
+    `setDefaultValue` deliberately skips a focused `number` field
+    (`:1738`), so the two exclusions are the same exclusion. React's own
+    restore still converges the *value* on those types; there was never
+    a caret there to lose.
+
+  A guard that does not hold means no wrapper at all — not a wrapper
+  that quietly does less. The element then behaves exactly as it did
+  before this namespace existed.
+
+  ## The one handler, and the door
+
+  `onChange` when the author wrote one, `onInput` otherwise. React's
+  `SimpleEventPlugin` extracts `onInput` before `ChangeEventPlugin`
+  extracts `onChange`, so wrapping the later of the two is what puts the
+  converge after every handler the element has rather than between them.
+
+  **The synchronous door only**, and that is a property of re-frame2
+  rather than a limitation of this code: `dispatch` drains on a
+  macrotask (Spec 002 §Drain scheduling), so at the end of the change
+  handler the model has not moved, `flushSync` has nothing to flush, and
+  the record still reads what the element rendered before the keystroke.
+  The wrapper is a no-op there, correctly — a queued field converges one
+  macrotask later, as it always did.
+
+  An out-of-band correction — a server normalisation, a debounced
+  validation — fires no change event, so nothing here runs and React's
+  own restore is still what converges it. That is why a *range* selection
+  still collapses across such a write: this converge is not on that path,
+  and restoring two offsets is a different algorithm from the one it
+  runs (rf2-n3dxw)."
+  (:require ["react-dom" :as react-dom]))
+
+(defn- noop [])
+
+;; ---------------------------------------------------------------------------
+;; The per-instance record
+;; ---------------------------------------------------------------------------
+
+(defn last-rendered
+  "**The value this element's last render put on it**, per instance, read
+  off the node.
+
+  React's mirror of the committed `value` prop — see the table in the
+  namespace docstring for the four lines of `react-dom` that maintain
+  it. The one place this namespace depends on that behaviour, so it is
+  the one place a row has to pin, and
+  `front/controlled_dom_cljs_test/the-record-is-the-elements-own-and-is-not-the-closures`
+  pins it.
+
+  `js/undefined` on anything that is not a live form control — a
+  synthetic target in a unit test, an element React never controlled —
+  which is what makes [[converge!]] inert there rather than defensive
+  about it."
+  [node]
+  (.-defaultValue node))
+
+;; ---------------------------------------------------------------------------
+;; The converge
+;; ---------------------------------------------------------------------------
+
+(defn converge-to!
+  "Make `node` show `rendered`, and put the caret back by offset from the
+  END of the string.
+
+  Split out from [[converge!]] because `rendered` is the whole of the
+  design: hand it [[last-rendered]] and every row of the family lands;
+  hand it the change handler's own closure value and an accepted
+  keystroke is wiped off the screen. The test that reproduces the trap
+  calls this function twice with one argument different, which is the
+  shortest true statement of it.
+
+  The offset is taken from the end because that is the half a
+  normalisation preserves. `\"1,234\"` + `5` becomes `\"12,345\"` — one
+  character longer than what was typed — and the caret belongs after the
+  `5`, which is `0` from the end in both strings and `6` in neither.
+
+  Writing the value only when it differs is not a micro-optimisation:
+  assigning `value` moves the cursor to the end of the control, so a
+  write that changed nothing would undo the caret this function is here
+  to restore."
+  [node dom-value caret-was rendered]
+  (when-not (= (.-value node) rendered)
+    (set! (.-value node) rendered))
+  (let [offset (- (count dom-value) caret-was)
+        c      (max 0 (- (count (.-value node)) offset))]
+    (.setSelectionRange node c c))
+  nil)
+
+(defn converge!
+  "Converge `node` against the model, inside the discrete event.
+
+  `dom-value` and the caret are read FIRST, because step 1 may write
+  both: they are what the user's edit left behind, and the caret is
+  only meaningful as an offset into that string.
+
+  Two readings make this inert rather than wrong where it does not
+  apply. A caret that is not a number is not a text-entry control —
+  a synthetic target in a unit test, or a type whose selection is not
+  applicable — and a record that is not a string is an element React
+  never wrote a mirror for. Either way the element is left exactly as
+  React leaves it."
+  [node]
+  (let [dom-value (.-value node)
+        caret-was (.-selectionStart node)]
+    (when (number? caret-was)
+      (react-dom/flushSync noop)
+      (let [rendered (last-rendered node)]
+        (when (string? rendered)
+          (converge-to! node dom-value caret-was rendered)))))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Installation — what the element path calls
+;; ---------------------------------------------------------------------------
+
+(def ^:private caret-types
+  "The `<input>` types with a text entry cursor — the ones
+  `setSelectionRange` applies to. Everything else has no caret to lose,
+  and React's own restore already converges its value."
+  #{"text" "search" "url" "tel" "password"})
+
+(defn- convergeable-tag?
+  "One JS `switch` on the tag string, so every `[:div …]` on the page
+  pays exactly that and nothing else."
+  [tag]
+  (case tag
+    ("input" "textarea") true
+    false))
+
+(defn- caret-type?
+  "Does this element have a text cursor? A `<textarea>` always does; an
+  `<input>` does for the five applicable types, and for no `:type` at
+  all, which is `text`."
+  [tag js-props]
+  (or (identical? "textarea" tag)
+      (let [t (unchecked-get js-props "type")]
+        (or (nil? t) (contains? caret-types t)))))
+
+(defn- change-slot
+  "The slot whose handler runs LAST for one keystroke, or nil when the
+  element has no change handler and so nothing to converge after."
+  [js-props]
+  (cond
+    (fn? (unchecked-get js-props "onChange")) "onChange"
+    (fn? (unchecked-get js-props "onInput"))  "onInput"
+    :else                                     nil))
+
+(defn- convergeable?
+  "Is this element one whose rendered value React records on the node?
+  See the namespace docstring — each clause is a condition on the
+  record, not a taste about which elements deserve the behaviour."
+  [tag js-props]
+  (and (convergeable-tag? tag)
+       (some? (unchecked-get js-props "value"))
+       (nil? (unchecked-get js-props "defaultValue"))
+       (caret-type? tag js-props)))
+
+(defn install!
+  "Wrap the change handler on `js-props` so the element converges in-turn
+  with the caret intact. Mutates the props object the codec has just
+  built and is about to hand to `createElement`, and returns it.
+
+  A fresh wrapper per render is the same shape the codec already has for
+  every lowered intent, and it closes over nothing but the author's
+  handler — deliberately **not** over the value, which is the stale
+  reading [[converge-to!]] exists to keep out of the write."
+  [tag js-props]
+  (when (convergeable? tag js-props)
+    (when-some [slot (change-slot js-props)]
+      (let [handler (unchecked-get js-props slot)]
+        (unchecked-set js-props slot
+                       (fn hicasso-converging-change [e]
+                         (handler e)
+                         (when-some [node (.-target e)]
+                           (converge! node))
+                         nil)))))
+  js-props)

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/controlled_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/controlled_dom_cljs_test.cljs
@@ -1,0 +1,325 @@
+(ns re-frame.bench.hicasso.front.controlled-dom-cljs-test
+  "THE CONVERGE'S OWN MECHANISM — the trap it avoids, and the elements it
+  refuses to touch (rf2-fki5d).
+
+  `arm1_controlled_grid_dom_cljs_test` reads the behaviour through a
+  hundred mounted boundaries and a real keystroke, which is where the
+  claim belongs. This file reads the two pieces underneath it:
+
+  - **the trap**, reproduced. [[re-frame.bench.hicasso.front.controlled/converge-to!]]
+    is called twice with one argument different — the change handler's
+    own closure value, then the per-instance record — and the first call
+    wipes a keystroke the model took verbatim. The regression the naive
+    form causes is measured here rather than asserted about elsewhere.
+  - **the install guards**, exercised through `codec/as-element`, because
+    the condition is about the emitted element and the emitted element
+    is what the codec builds. A guard that does not hold leaves the
+    author's handler at the element BY IDENTITY, which is the strongest
+    available statement of \"nothing was installed\".
+
+  ## The stand-in for React
+
+  A converge needs two things from the node: what the field shows, and
+  what the element last rendered. React maintains the second as
+  `node.defaultValue`, and the rows below set it by hand — which is
+  legitimate precisely because it is an ordinary DOM property with an
+  ordinary setter, and is the whole reason the mechanism needs nothing
+  of its own to keep. **That React really does write it is a separate
+  claim**, and it is asserted against a live React tree in
+  `arm1_controlled_grid_dom_cljs_test/the-record-is-reacts-own-mirror-and-is-not-the-handlers-closure`.
+  Setting it here would prove nothing about React; these rows prove what
+  the converge does with a record, given one.
+
+  Runtime: `-dom-cljs-test`, because a caret needs a real text field.
+  The guard rows need no DOM and run on both targets; the rest degrade
+  to a stated skip under `:node-test`."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.controlled :as controlled]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? js/document) (some? (.-body js/document))))
+
+(defn- skip! [why]
+  (is true (str "a caret in a real text field needs a real DOM — " why)))
+
+;; ---------------------------------------------------------------------------
+;; A field, and a keystroke, without React
+;; ---------------------------------------------------------------------------
+
+(defn- field!
+  "A real `<input>` in the document, left as a React render that put
+  `rendered` on it would leave it: the field shows it, and the node's
+  own record of what was rendered holds it."
+  ([rendered] (field! "input" rendered))
+  ([tag rendered]
+   (let [n (js/document.createElement tag)]
+     (when (= "input" tag) (set! (.-type n) "text"))
+     (.appendChild js/document.body n)
+     (set! (.-defaultValue n) rendered)
+     (set! (.-value n) rendered)
+     n)))
+
+(defn- drop! [node] (.remove node) nil)
+
+(defn- typed!
+  "What the browser has already done by the time any handler runs: the
+  character is in the field and the caret is after it."
+  [node text at]
+  (let [v (.-value node)
+        c (+ at (count text))]
+    (set! (.-value node) (str (subs v 0 at) text (subs v at)))
+    (.setSelectionRange node c c)
+    node))
+
+(defn- committed!
+  "What React's commit leaves on the node when the model moved to
+  `rendered`: the field is written only when it differs — and a write
+  throws the cursor to the end — while the record follows either way."
+  [node rendered]
+  (when-not (= (.-value node) rendered)
+    (set! (.-value node) rendered)
+    (.setSelectionRange node (count rendered) (count rendered)))
+  (set! (.-defaultValue node) rendered)
+  node)
+
+(defn- caret [node] [(.-selectionStart node) (.-selectionEnd node)])
+
+(defn- reading [node] {:value (.-value node) :caret (caret node)})
+
+;; ---------------------------------------------------------------------------
+;; The trap — one argument different
+;; ---------------------------------------------------------------------------
+
+(deftest the-closure-value-wipes-a-keystroke-the-model-took-verbatim
+  (testing "THE MEASURED TRAP, and the reason the converge reads a record
+           off the node rather than closing over a value it already has.
+
+           The field held `\"abcd\"`, the user typed `X` at 2, and the
+           model TOOK it — so the element now renders `\"abXcd\"` and
+           there is nothing to converge. The change handler's own
+           closure, though, still carries the value from the render that
+           MINTED it, and that render is one behind. Writing it back is
+           not a smaller improvement than writing the record: it deletes
+           the character the user just typed."
+    (if-not (browser?)
+      (skip! ":node-test has no DOM")
+      (let [node (field! "abcd")]
+        (try
+          (typed! node "X" 2)
+          (is (= {:value "abXcd" :caret [3 3]} (reading node))
+              "the browser got there first, as it always does")
+          (committed! node "abXcd")
+          (is (= "abXcd" (controlled/last-rendered node))
+              "and the commit moved the record with it")
+          (testing "the naive form — the handler's own closure value"
+            (.setSelectionRange node 3 3)
+            (controlled/converge-to! node "abXcd" 3 "abcd")
+            (is (= "abcd" (.-value node))
+                "the accepted keystroke is GONE. This is the regression,
+                 measured rather than assumed")
+            (is (= [2 2] (caret node))
+                "and the caret is two from the end of a string that no
+                 longer contains what the user typed — the arithmetic is
+                 not what is wrong here, the value it was given is"))
+          (testing "the same call, one argument different — the record"
+            (committed! node "abXcd")
+            (.setSelectionRange node 3 3)
+            (controlled/converge-to! node "abXcd" 3 (controlled/last-rendered node))
+            (is (= {:value "abXcd" :caret [3 3]} (reading node))
+                "nothing moved, which is the whole of what a keystroke
+                 the model took verbatim is owed"))
+          (finally (drop! node)))))))
+
+(deftest neither-the-field-nor-what-the-handler-saw-can-tell-the-two-apart
+  (testing "why the record is not optional. `(= (.-value node) dom-value)`
+           reads TRUE on a refusal and TRUE on a keystroke taken
+           verbatim — the same reading, two opposite obligations — so a
+           converge written against it either wipes accepted keystrokes
+           or leaves refused ones on the screen. Both fields below are in
+           that state at the same instant; only the record separates
+           them."
+    (if-not (browser?)
+      (skip! ":node-test has no DOM")
+      (let [refused  (field! "12")
+            accepted (field! "abcd")]
+        (try
+          (typed! refused "a" 2)             ; the model does not move
+          (typed! accepted "X" 2)
+          (committed! accepted "abXcd")      ; the model took it
+          (is (= "12a" (.-value refused))
+              "the field still shows what was typed — nothing re-rendered")
+          (is (= "abXcd" (.-value accepted))
+              "and so does this one — because that IS what was rendered")
+          (is (not= (controlled/last-rendered refused) (.-value refused))
+              "the record is the only thing that tells them apart")
+          (is (= (controlled/last-rendered accepted) (.-value accepted)))
+          (finally (drop! refused) (drop! accepted)))))))
+
+;; ---------------------------------------------------------------------------
+;; The caret comes back by offset from the END
+;; ---------------------------------------------------------------------------
+
+(deftest the-caret-is-restored-by-offset-from-the-end-of-the-string
+  (testing "the half an absolute position gets wrong. A normalisation that
+           CHANGES THE LENGTH moves every absolute offset in the string,
+           and what survives it is the distance back from the end — which
+           is the right side to measure from, because it is the side the
+           user is still typing into."
+    (if-not (browser?)
+      (skip! ":node-test has no DOM")
+      (let [node (field! "1,234")]
+        (try
+          (typed! node "5" 5)
+          (is (= {:value "1,2345" :caret [6 6]} (reading node)))
+          (committed! node "12,345")
+          (controlled/converge-to! node "1,2345" 6 "12,345")
+          (is (= {:value "12,345" :caret [6 6]} (reading node))
+              "0 from the end of a six-character string and 0 from the
+               end of a seven-character one are the same caret")
+          (finally (drop! node))))))
+  (testing "and a refusal mid-string, which is the row neither shipped
+           implementation gets right"
+    (if-not (browser?)
+      (skip! ":node-test has no DOM")
+      (let [node (field! "12345")]
+        (try
+          (typed! node "z" 2)
+          (is (= {:value "12z345" :caret [3 3]} (reading node)))
+          (controlled/converge-to! node "12z345" 3 (controlled/last-rendered node))
+          (is (= {:value "12345" :caret [2 2]} (reading node))
+              "3 from the end of \"12z345\" is 2 from the end of
+               \"12345\" — the position before the refused character")
+          (finally (drop! node)))))))
+
+;; ---------------------------------------------------------------------------
+;; What the codec installs
+;; ---------------------------------------------------------------------------
+
+(defn- slot [e name'] (aget (.-props e) name'))
+
+(defn- fire!
+  "Invoke the emitted handler the way React would, with `node` as the
+  event target, and read the node afterwards — so a row says whether a
+  converge ran without knowing how it was installed."
+  [hiccup name' node]
+  ((slot (codec/as-element hiccup) name') #js {:target node})
+  (reading node))
+
+(deftest a-controlled-field-converges-through-the-handler-the-codec-emitted
+  (testing "the whole installation, read through the element the codec
+           built: the author's handler still runs, and the field is
+           converged against the record afterwards"
+    (if-not (browser?)
+      (skip! ":node-test has no DOM")
+      (let [!ran (atom 0)
+            node (field! "12345")]
+        (try
+          (typed! node "z" 2)
+          (is (= {:value "12345" :caret [2 2]}
+                 (fire! [:input {:value    "12345"
+                                 :on-input (fn [_e] (swap! !ran inc))}]
+                        "onInput" node))
+              "the refused character is off the screen and the caret is at
+               the position before it")
+          (is (= 1 @!ran) "and the author's own handler ran, once")
+          (finally (drop! node))))))
+  (testing "`:on-change` is wrapped in preference to `:on-input`, because
+           React's `SimpleEventPlugin` extracts `onInput` before
+           `ChangeEventPlugin` extracts `onChange` — so the converge
+           lands after every handler the element has rather than between
+           them"
+    (if-not (browser?)
+      (skip! ":node-test has no DOM")
+      (let [node (field! "12345")]
+        (try
+          (typed! node "z" 2)
+          (let [e (codec/as-element [:input {:value     "12345"
+                                             :on-input  (fn [_e])
+                                             :on-change (fn [_e])}])]
+            ((slot e "onInput") #js {:target node})
+            (is (= {:value "12z345" :caret [3 3]} (reading node))
+                "the earlier handler is the author's, untouched")
+            ((slot e "onChange") #js {:target node})
+            (is (= {:value "12345" :caret [2 2]} (reading node))
+                "and the later one carries the converge"))
+          (finally (drop! node))))))
+  (testing "a <textarea> is a controlled text field too"
+    (if-not (browser?)
+      (skip! ":node-test has no DOM")
+      (let [node (field! "textarea" "12345")]
+        (try
+          (typed! node "z" 2)
+          (is (= {:value "12345" :caret [2 2]}
+                 (fire! [:textarea {:value "12345" :on-input (fn [_e])}]
+                        "onInput" node)))
+          (finally (drop! node)))))))
+
+;; ---------------------------------------------------------------------------
+;; What it leaves alone — every guard, by identity
+;; ---------------------------------------------------------------------------
+
+(deftest an-element-outside-the-guards-keeps-the-authors-handler-by-identity
+  (testing "each guard is a condition on the RECORD being the value the
+           element last rendered, so failing one means NO wrapper —
+           never a wrapper that quietly does less. The codec passes a
+           function to React by identity, so `identical?` is exactly the
+           question \"was anything installed here?\""
+    (let [f (fn [_e])
+          emitted (fn [hiccup] (slot (codec/as-element hiccup) "onInput"))]
+      (is (not (identical? f (emitted [:input {:value "x" :on-input f}])))
+          "the control: a controlled text field IS wrapped")
+      (is (identical? f (emitted [:input {:on-input f}]))
+          "no `:value` — the element is uncontrolled, and React writes no
+           record for it")
+      (is (identical? f (emitted [:input {:value nil :on-input f}]))
+          "a nil `:value` is the same statement")
+      (is (identical? f (emitted [:input {:value "x" :default-value "seed"
+                                          :on-input f}]))
+          "a `:default-value` of the author's — React honours it over the
+           mirror on a <textarea>, and the guard is taken on both tags
+           because one rule about the record is easier to keep true than
+           two")
+      (is (identical? f (emitted [:input {:type "number" :value "1" :on-input f}]))
+          "a type with no text cursor: `setSelectionRange` does not apply
+           to it, and `setDefaultValue` skips a focused number field —
+           the same exclusion twice")
+      (is (identical? f (emitted [:input {:type "checkbox" :value "1" :on-input f}])))
+      (is (identical? f (emitted [:select {:value "x" :on-input f}]))
+          "a <select> has neither a caret nor a mirror")
+      (is (identical? f (emitted [:div {:value "x" :on-input f}]))
+          "and a tag that is not a form control is not even asked")
+      (testing "while every applicable input type is"
+        (doseq [t ["text" "search" "url" "tel" "password"]]
+          (is (not (identical? f (emitted [:input {:type t :value "x" :on-input f}])))
+              (str "type=" t))))
+      (testing "as is an input with no `:type` at all, which is text"
+        (is (not (identical? f (emitted [:input {:value "x" :on-input f}]))))))))
+
+(deftest a-controlled-field-with-no-change-handler-has-nothing-wrapped
+  (testing "there is no slot to install into, and the codec does not mint
+           one — an element with no handler comes out with no handler"
+    (let [e (codec/as-element [:input {:value "12345"}])]
+      (is (nil? (slot e "onInput")))
+      (is (nil? (slot e "onChange")))
+      (is (= "12345" (slot e "value"))))))
+
+(deftest a-target-that-is-not-a-form-control-is-left-alone
+  (testing "the reading that makes this inert rather than defensive: a
+           caret that is not a number is not a text-entry control. Every
+           node-side codec row invokes an emitted handler with a
+           synthetic `#js {:target #js {…}}`, and none of them may throw
+           or flush anything."
+    (let [!seen (atom [])
+          e     (codec/as-element
+                 [:input {:value    "12345"
+                          :on-input (fn [ev] (swap! !seen conj (.. ev -target -value)))}])]
+      ((slot e "onInput") #js {:target #js {:value "typed"}})
+      (is (= ["typed"] @!seen) "the author's handler ran and saw the event")
+      (is (nil? (controlled/last-rendered #js {:value "typed"}))
+          "and there was no record to converge to")))
+  (testing "an event with no target at all"
+    (let [!ran (atom 0)
+          e    (codec/as-element [:input {:value "x" :on-input (fn [_e] (swap! !ran inc))}])]
+      ((slot e "onInput") #js {})
+      (is (= 1 @!ran)))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -130,8 +130,12 @@
 
   This namespace deliberately does not implement `route-link` (routing-
   coupled, and outside this bead's three deliverables), `defhost`/`[:>]`
-  interop (HD-011, its own surface), or any controlled-value restore
-  (HD-019's door belongs to the arm that owns the DOM).")
+  interop (HD-011, its own surface), or any controlled-value restore.
+  HD-019's door belongs to whatever owns the DOM element, which is the
+  emitter rather than the lowering:
+  [[re-frame.bench.hicasso.front.controlled]] wraps the handler this
+  namespace produced, after it has produced it, and nothing about the
+  lowering changes because of it (rf2-fki5d).")
 
 ;; ---------------------------------------------------------------------------
 ;; The ambient frame (HD-020(a))


### PR DESCRIPTION
Closes rf2-fki5d. **Does not close rf2-n3dxw** — see "What remains" below.

`rf2-fki5d` was blocked on "an element path to put it in". Hicasso has one:
`front.codec` emits `[:input …]` through `react/createElement` against the tag
string, and `rf2-2rtt6.41` proved rather than assumed that the arm never goes
through UIx's input selector. So the converge goes where it is cheapest — the
element path — and nothing about the authoring surface moves.

## What lands

`front.controlled/install!`, called from `front.codec/native-element`, wraps the
change handler the author already wrote. At the end of that handler, still
inside the discrete event and still ahead of React's own end-of-event restore:

1. `flushSync`, so the synchronous door's commit lands now rather than in the
   `finally` of `batchedUpdates$1`;
2. if the field disagrees with what the element renders, write the rendered
   value — which also makes React's later `updateInput` a no-op, because it
   only assigns when the two differ, and a no-op there is what lets the caret
   survive;
3. put the caret back by offset from the **end** of the string.

`grid.cljs` — the 100-cell witness's view — did not change by a character. The
view still writes an ordinary `:value` / `:on-input` pair: no ref, no effect, no
escape hatch. **No hook was spent**: nothing was added to the boundary shell, and
`arm1_hook_ledger_dom_cljs_test` still reads exactly
`["useContext" "useSyncExternalStore"]`. UIx's own answer to the same problem is
a wrapper *component* per input carrying three hooks
(`uix/compiler/input.cljs:132-143`).

## The five rows, in one turn

`arm1_controlled_grid_dom_cljs_test/the-family-converges-in-one-turn-with-the-caret-where-the-edit-left-it`,
one mounted grid, every reading on the line after `dispatchEvent` returns — no
`act`, and no `flushSync` in any assertion's path:

| row | asserts | `:react` alone |
|---|---|---|
| refusal at the end — `"12"` + `a` at `[2 2]` | `"12"` `[2 2]` | `"12"` `[2 2]` |
| refusal mid-string — `"12345"` + `z` at `[2 2]` | `"12345"` `[2 2]` | `[5 5]` |
| uppercasing mid-string — `"ABCD"` + `x` at `[2 2]` | `"ABXCD"` `[3 3]` | `[5 5]` |
| regrouping at the end — `"1,234"` + `5` at `[5 5]` | `"12,345"` `[6 6]` | `[6 6]` |
| accepted keystroke mid-string — `"abcd"` + `X` at `[2 2]` | `"abXcd"` `[3 3]` | `[3 3]` |

plus a closing assertion that all four fields and all four model values agree.
Two rows that recorded React's caret jump as "RECORDED, NOT DESIRED" are
corrected to what the arm now does — which is what those docstrings said would
happen to whoever made them red.

## The naive form, reproduced and then avoided

The bead says the trap is measured, not assumed. It is:
`front/controlled_dom_cljs_test/the-closure-value-wipes-a-keystroke-the-model-took-verbatim`
calls `converge-to!` **twice with one argument different**. Handed the change
handler's own closure value it writes `"abcd"` over the user's just-accepted
`"abXcd"` — the character is gone. Handed the record, nothing moves.

The companion row says why nothing cheaper works: `(= (.-value node) dom-value)`
reads true on a refusal **and** on a keystroke taken verbatim — the same reading,
two opposite obligations.

## Where the per-instance record lives, and why the closure cannot serve

The closure carries the value from the render that *minted* it, and step 1's own
`flushSync` is what makes it stale — a re-render commits a new value while the
handler that is running still holds the old one.

The record is **`node.defaultValue`, and React already maintains it**. On any
genuinely controlled input or textarea every commit mirrors the committed
`value` prop into the element's default value: `updateInput:1671-1672` →
`setDefaultValue:1737-1741`, `initInput:1721` on mount, `updateTextarea:1842-1851`
for the other tag (`react-dom@19.2.0`, `cjs/react-dom-client.development.js`).
Typing does not disturb it — the `value` IDL setter sets the value and the dirty
flag, never the content attribute `defaultValue` reflects.

**So the third item on the bead's quoted price is not charged.** No `ref` (which
would change the identity React uses to decide whether to re-attach — the exact
objection `front.intent/ref-position?` already documents), no `WeakMap`, no extra
prop, no hook. What is left is a **dependency**, and it is named in one place:
`front.controlled/last-rendered` is the only reader, every guard in `install!` is
a condition under which the mirror really is the rendered value, and
`arm1_controlled_grid_dom_cljs_test/the-record-is-reacts-own-mirror-and-is-not-the-handlers-closure`
pins the invariant against a live React tree — including that it *moves* when the
rendered value moves, which is the half a closure cannot do.

The guards, each a condition on the record: `input`/`textarea` only; a non-nil
`value`; no author `defaultValue` (a `<textarea>` honours that over the mirror);
and a type with a text cursor — `setSelectionRange` does not apply to the others
and `setDefaultValue` deliberately skips a focused `number` field, so the two
exclusions are the same exclusion. Failing a guard means **no wrapper at all**,
asserted by identity in `an-element-outside-the-guards-keeps-the-authors-handler-by-identity`,
because the codec hands a function to React by identity.

## Mutation-proved, twice

- **Remove the converge** (the one `controlled/install!` call in
  `native-element`): **14 assertions red**, every caret reading falling back to
  `[5 5]` and the refused character still on the screen (`"12z345"`) — React's
  own behaviour, exactly as the studio matrix records it.
- **Remove only the `flushSync`**: **4 assertions red**, all caret readings at
  `[5 5]`, including the *ordinary accepted keystroke*. Without it the record is
  one render stale, the converge writes the wrong value, and React's restore
  repairs the value and throws the caret away. This is the evidence HD-019 asks
  for before `flushSync` is used.

Both restored; the suite is green in both the narrow and the full lane.

## Raised, not resolved

HD-019 says `flushSync` is "the evidence-gated last resort, **never the
default**". This makes it the default for every controlled element. The evidence
gate is met (above), but the ruling's text and the code now disagree in letter.
Filed as a bead rather than amended here — the decisions record is Mike's.

## What remains, and why `rf2-n3dxw` stays open

That bead is titled for **the React adapter**, and this change does not reach it.
A UIx consumer's `:input` is minted by `uix.compiler.aot/create-uix-input`, not by
Hicasso's codec, so a mid-string refusal there still converges with the caret at
the end of the field. Two further things it recorded are also unanswered and are
not rounded up: a **range** does not survive a converge that writes (a second
algorithm — two offsets, not one — and out-of-band writes fire no change event,
so they are off this path entirely), and the **IME** fence is still not
established (`rf2-o27h3`, which needs a real `CompositionEvent` harness; nothing
here touches composition).

`rf2-n3dxw` is updated with exactly that and left open.

## Coordination

- `worker/mapkeys-2rtt6-32` is also in `front/codec.cljs`. Different functions:
  it is in the crossing walk (`realize-deep` / the deferred-read refusal); this
  touches the ns docstring and `native-element` (emission). No overlap.
- `worker/shapes-tier1` may author controlled inputs. **Nothing changes about
  what an author writes** — `:value` plus a change handler, exactly as before —
  so tier-1 shapes need no adjustment and get the caret for free.
- No bench driver was run and no timing row is published.

## Documentation

`docs/design/hicasso/studio/controlled-input-two-implementations.md` gets the
third column and the record finding; `architecture.md` and `validation.md` are
reconciled. Per `CLAUDE.md`, `mkdocs build --strict` **does not cover
`docs/design/`**, so it is not nominated as the gate here.
`scripts/check_doc_slugs.py` passed (exit 0), and I verified **by hand** that the
one new anchor (`#the-record-turned-out-to-be-reacts-own`) resolves and that every
markdown table in all three touched files has a uniform column count — the new
table is 3 columns across header, separator and five rows.

## Quality gates

| gate | command | exit | reading |
|---|---|---|---|
| CLJS unit | `npm run test:cljs` | **0** | Ran 12290 tests / 61538 assertions, 0 failures, 0 errors |
| Browser unit | `npx shadow-cljs compile browser-test` then `node scripts/serve-and-run-browser-tests.cjs` | **0** / **0** | Ran 940 tests / 5895 assertions, 0 failures, 0 errors |
| Browser, narrowed to the changed suites | same, `--config-merge '{:ns-regexp "controlled.*-dom-cljs-test$"}'` | **0** | Ran 59 tests / 303 assertions, 0 failures |
| Mutation probe — converge removed | same narrowed lane | **1** (expected red) | 14 failures, every caret `[5 5]`; restored |
| Mutation probe — `flushSync` removed | same narrowed lane | **1** (expected red) | 4 failures, every caret `[5 5]`; restored |
| Fast PR spine | `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`; JVM tier = core + freehand (the artefacts the diff touched), CLJS node integration, docs/lockstep/drift tiers, and all 17 per-namespace isolation namespaces green standalone |
| Doc slugs | `python scripts/check_doc_slugs.py` | **0** | no findings |
| Lint | clj-kondo **2026.04.15** (CI's pinned version, CI's exact `--parallel --fail-level error --lint …` invocation) | **0** | **errors: 0**, 4530 warnings (unchanged baseline; **zero findings in any file this PR touches**) |

Every gate was run in the foreground, to completion, with logs inside the
worktree, and every exit code was taken before anything was filtered.

**TESTING.md matrix.** The diff is confined to
`implementation/freehand/test/re_frame/bench/hicasso/` and
`docs/design/hicasso/`. The changed-surface classifier lights `cljs_node_test`
(→ the consolidated `cljs` job, run above), `cljs_browser` (→ the Playwright
`cljs-browser` job, run above) and — because the classifier arms all of
`implementation/freehand/`— `cljs_prod` plus the freehand JVM tier, which the
fast spine selected and ran. Deliberately **not** run locally, and CI's per
TESTING.md: bundle-isolation, prod-elision, adapter + substrate smokes, the Xray
feature matrix, the Story gates, mcp-conformance and the tool JVM suites. None of
them can see this diff — nothing here is reachable from a production bundle, and
`examples/` is untouched.
