### PR TITLE
hicasso: the tier-1 shapes, authored and witnessed

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/bulk_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/bulk_dom_cljs_test.cljs
@@ -1,0 +1,219 @@
+(ns re-frame.bench.hicasso.shapes.bulk-dom-cljs-test
+  "**SHAPE 3'S WITNESS — the make-or-break row** (rf2-2rtt6.51).
+
+  > 3. Bulk re-render — ~300 boundaries on one commit; the make-or-break
+  >    row.
+
+  The charter calls it make-or-break on the clock. **No clock is read
+  here**: siblings are measuring on a quiet box, and a bench driver run
+  from a correctness suite would corrupt their samples. What this file
+  establishes is the half a clock cannot — that the commit does the work
+  it is supposed to do, to every boundary it is supposed to reach, and to
+  no others.
+
+  Four claims:
+
+  1. **The page is 300 boundaries**, at the element count the arithmetic
+     predicts, with one read-set entry per boundary (the distinct-query
+     rung `runtime/retained-inventory` prices).
+  2. **One commit moves all 300.** `[:conduit/refresh-feed]` re-runs
+     exactly 300 card bodies and — this is the load-bearing half — **zero
+     page bodies**. A list that rebuilt its children would produce the
+     same DOM and the same 300 re-renders, and would not be this shape.
+  3. **Every card's DOM actually moved**, checked across all 300 in one
+     assertion rather than spot-checked.
+  4. **The cards are byte-identical to shape 2's.** The large template and
+     this page build the same card from the same source
+     (`shapes.card`), so the roster's claim that the two shapes differ in
+     exactly one authoring decision is a DOM comparison, not a docstring.
+
+  Runtime: `-dom-cljs-test`. Under `:node-test` every claim degrades to a
+  stated skip."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.shapes.card :as card]
+            [re-frame.bench.hicasso.shapes.feed :as shape]
+            [re-frame.bench.hicasso.shapes.large-template :as lt]
+            [re-frame.bench.hicasso.shapes.model :as m]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::shape-bulk)
+
+(def ^:private predicted-boundaries
+  "One page boundary plus one per card."
+  (inc shape/article-count))
+
+(def ^:private predicted-reads
+  "`3` for the page chrome, `2` per card."
+  (+ 3 (* 2 shape/article-count)))
+
+(defn- skip! [why]
+  (is true (str "shape 3's witness needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (lane/leave-act-environment!)
+  (shape/make-frame! frame-id)
+  (shape/reseed! frame-id)
+  (shape/reset-runs!)
+  frame-id)
+
+(defn- mount! []
+  (mount/root! (mount/fresh-container!) frame-id [shape/page {}]))
+
+(defn- q [handle sel] (.querySelector (:container handle) sel))
+(defn- q* [handle sel] (array-seq (.querySelectorAll (:container handle) sel)))
+
+(defn- favourite-counts
+  "Every card's rendered favourites count, in document order — one read of
+  the whole page, so a claim about 300 rows is one assertion."
+  [handle]
+  (mapv #(.-textContent %) (q* handle "[data-testid^=\"favorites-count-\"]")))
+
+(defn- canonical-card
+  "One card's subtree with attribute names sorted. `lane/canonical` walks a
+  node's CHILDREN, so the card is cloned into a box first — otherwise the
+  card's own tag and attributes would sit outside the comparison, which is
+  where a class difference would hide."
+  [handle slug]
+  (let [node (q handle (str "[data-testid=\"article-preview-" slug "\"]"))
+        box  (js/document.createElement "div")]
+    (.appendChild box (.cloneNode node true))
+    (lane/canonical box)))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the page is the shape
+;; ---------------------------------------------------------------------------
+
+(deftest the-page-is-three-hundred-boundaries
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (let [{:keys [boundaries edges entries]} (rt/stats)
+                measured (lane/element-count (:container handle))]
+            (is (= predicted-boundaries boundaries)
+                (str shape/article-count " card boundaries plus the page = "
+                     predicted-boundaries "; measured " boundaries))
+            (is (= shape/article-count (count (q* handle ".article-list > .article-preview"))))
+            (is (= (shape/element-arithmetic) measured)
+                (str "chrome " lt/chrome-elements " + tags " shape/tag-count " + "
+                     shape/article-count " x " card/elements-per-card
+                     " = " (shape/element-arithmetic) "; the DOM holds " measured))
+            (is (= predicted-reads edges))
+            (is (= predicted-boundaries entries)
+                "every card reads a read SEQUENCE only it reads, so the entry
+                 cache holds one per boundary — the distinct-query rung
+                 `runtime/retained-inventory` says it is priced on"))
+          (is (= {:cards shape/article-count :page 1} (shape/runs))
+              "and the mount ran every card body once and the page's once")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 + 3 — one commit, three hundred boundaries, and no parent rebuild
+;; ---------------------------------------------------------------------------
+
+(deftest one-commit-re-runs-all-three-hundred-card-bodies-and-not-the-page
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (let [before (favourite-counts handle)]
+            (is (= shape/article-count (count before)))
+            (shape/reset-runs!)
+            (rt/dispatch! frame-id [:conduit/refresh-feed])
+            (mount/settle!)
+            (is (= shape/article-count (:cards (shape/runs)))
+                (str "one commit re-ran exactly " shape/article-count " card bodies"))
+            (is (= 0 (:page (shape/runs)))
+                "and did NOT re-run the page. A list that rebuilt its children
+                 would produce the identical DOM below and would not be this
+                 shape — this is the assertion that tells the two apart")
+            (testing "and every one of the 300 cards moved in the DOM"
+              (let [after (favourite-counts handle)]
+                (is (= (mapv #(str (inc (js/parseInt % 10))) before) after)
+                    "all 300 counts incremented by one"))))
+          (finally (mount/release! handle)))))))
+
+(deftest the-broad-write-can-answer-false
+  (testing "the comparison above is not passing vacuously: a commit that
+           moves nothing the cards read moves no card body and no count"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (do
+        (fresh!)
+        (let [handle (mount!)]
+          (try
+            (let [before (favourite-counts handle)]
+              (shape/reset-runs!)
+              (rt/dispatch! frame-id [:conduit/go-to-page 2])
+              (mount/settle!)
+              (is (= 0 (:cards (shape/runs))) "no card body ran")
+              (is (= 0 (:page (shape/runs))) "and the page reads no page number, so nor did it")
+              (is (= before (favourite-counts handle)) "and nothing in the DOM moved"))
+            (finally (mount/release! handle))))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — the same card, both decompositions
+;; ---------------------------------------------------------------------------
+
+(deftest the-card-is-byte-identical-to-the-large-templates
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (lane/leave-act-environment!)
+      (let [slug (shape/slug-at 3)
+            ;; Shape 2's page, on its own seed.
+            _        (m/make-frame! frame-id lt/seed)
+            _        (m/reseed! frame-id lt/seed)
+            template (mount/root! (mount/fresh-container!) frame-id [lt/page {}])
+            from-template (canonical-card template slug)
+            _        (mount/release! template)
+            ;; Shape 3's page, on its own.
+            _        (m/reseed! frame-id shape/seed)
+            feed     (mount! )
+            from-feed (canonical-card feed slug)]
+        (mount/release! feed)
+        (is (= from-template from-feed)
+            "the ~1,200-element template and the 300-boundary page build the
+             SAME card — so the only difference between the two shapes is
+             where `defview` is written")
+        (is (re-find #"article-preview" from-template)
+            "and the comparison is of a real card, not of two empty strings")))))
+
+;; ---------------------------------------------------------------------------
+;; Teardown at three hundred boundaries
+;; ---------------------------------------------------------------------------
+
+(deftest three-hundred-boundaries-leave-no-residue
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (async done
+      (fresh!)
+      (let [handle (mount!)]
+        (rt/dispatch! frame-id [:conduit/refresh-feed])
+        (mount/settle!)
+        (is (pos? (:cell-refs (rt/stats))))
+        (mount/unmount! handle)
+        (js/setTimeout (fn []
+                         (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                                (rt/residue))
+                             (str predicted-boundaries " boundaries and "
+                                  predicted-reads " edges, all released by React's
+                                  own cleanup"))
+                         (rt/reset-runtime!)
+                         (done))
+                       8)))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/card.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/card.cljs
@@ -1,0 +1,95 @@
+(ns re-frame.bench.hicasso.shapes.card
+  "THE CENSUS'S ARTICLE CARD — written **once**, so shapes 2 and 3 differ
+  in one thing (rf2-2rtt6.51).
+
+  Ported from RealWorld's `article-preview`
+  (`examples/real-apps/realworld_resources/ui_views.cljs:111-143`), the
+  card that carries Conduit's home feed and every profile list.
+
+  ## Why it is a plain function
+
+  Shape 2 (large templates) and shape 3 (bulk re-render) are **the same
+  screen at two boundary decompositions** — one boundary interpreting
+  ~1,200 elements, or ~300 boundaries interpreting ~17 each. The roster
+  is only evidence about boundaries if nothing else differs between the
+  two pages, so the markup is written here, once, and:
+
+  - [[re-frame.bench.hicasso.shapes.large-template]] **calls** it —
+    `(card slug)` — and it inlines into the page's single boundary
+    (HD-016: a plain function call mints no boundary of its own, and its
+    `sub` reads are donated to the enclosing one);
+  - [[re-frame.bench.hicasso.shapes.feed]] **wraps** it — one `defview`
+    whose whole body is `(card slug)` — and it becomes a boundary.
+
+  **That is the entire diff between the two shapes**, and it is the
+  headline authoring result of the roster: the decision \"is this row a
+  component?\" costs one `defview` and one pair of brackets at the call
+  site, and changes nothing about the markup, the reads, the intents or
+  the DOM. `bulk_dom_cljs_test` asserts the two pages build byte-identical
+  cards, so the claim is a comparison rather than a reading of this
+  docstring.
+
+  ## The two reads, and why both stay
+
+  A card reads its article and its favourite-in-flight status — the
+  census's own pair (`[:rf/mutation {:instance [:favorite slug]}]` there,
+  `[:conduit/favorite-pending? slug]` here). Both are kept because the
+  read *count* per row is what the per-read budget is priced against, and
+  a port that dropped the status read to make a page cheaper would be
+  quoting a row the census does not have.
+
+  `.cljc`-compatible by construction: no interop, no JS literal."
+  (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.bench.hicasso.shapes.model :as m]))
+
+(def elements-per-card
+  "The element count of one rendered card, with the two tags
+  [[re-frame.bench.hicasso.shapes.model/tags-for]] gives every article.
+
+  Written down because a page's total is then arithmetic a witness can
+  **predict** — `chrome + n * elements-per-card` — rather than a number it
+  has to accept from the DOM it is supposed to be checking. A markup edit
+  that forgets to update it fails
+  `large_template_dom_cljs_test/the-page-is-the-size-the-arithmetic-predicts`
+  rather than silently re-baselining the shape."
+  17)
+
+(defn card
+  "One article card. A plain function: called from a body it inlines, and
+  the two `sub` reads below are donated to whichever boundary is running."
+  [slug]
+  (let [{:keys [title description createdAt favoritesCount favorited author tagList]}
+        (sub [:conduit/article slug])
+        pending? (sub [:conduit/favorite-pending? slug])]
+    ;; `:key` on the root, in the attribute map, because the card is a
+    ;; **keyed list child in both shapes**: a seq element in the large
+    ;; template, and a boundary's root under a keyed `[article-card {:key
+    ;; …}]` in the feed. Native-element keys live in the props position
+    ;; (HD-016), and a key React does not need is a key React ignores — so
+    ;; one spelling serves both decompositions and neither call site has to
+    ;; know which one it is in.
+    [:div.article-preview {:key         slug
+                           :data-testid (str "article-preview-" slug)}
+     [:div.article-meta
+      [:a.author-link {:href (str "#/profile/" (:username author))}
+       [:img.user-pic {:src (m/avatar-src (:image author)) :alt ""}]]
+      [:div.info
+       [:a.author {:href (str "#/profile/" (:username author))} (:username author)]
+       [:span.date createdAt]]
+      [:button.btn.btn-outline-primary.btn-sm.pull-xs-right
+       {:type        "button"
+        :data-testid (str "favorite-" slug)
+        :class       (cond-> ""
+                       favorited (str " active")
+                       pending?  (str " optimistic"))
+        :on-click    [:conduit/favorite slug]}
+       [:i.ion-heart] " "
+       [:span {:data-testid (str "favorites-count-" slug)} favoritesCount]]]
+     [:a.preview-link {:href        (str "#/article/" slug)
+                       :data-testid (str "article-link-" slug)}
+      [:h1 title]
+      [:p description]
+      [:span "Read more..."]
+      [:ul.tag-list
+       (for [tag tagList]
+         [:li.tag-default.tag-pill.tag-outline {:key tag} tag])]]]))

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/feed.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/feed.cljs
@@ -1,0 +1,153 @@
+(ns re-frame.bench.hicasso.shapes.feed
+  "**TIER-1 SHAPES 3 AND 4** — the same page, and the two writes that
+  separate them (charter §Use cases A3/A4; rf2-2rtt6.51).
+
+  > 3. Bulk re-render — ~300 boundaries on one commit; **the make-or-break
+  >    row**.
+  > 4. Narrow update — one cell moves in a large mounted page.
+
+  One page carries both, because both are statements about **the same
+  mounted page** and only the commit differs. Splitting them across two
+  pages would make every comparison between them a comparison of two
+  applications.
+
+      [:conduit/refresh-feed]     every article moves  ->  300 bodies run   (shape 3)
+      [:conduit/favorite slug]    one article moves    ->    1 body runs    (shape 4)
+
+  Neither write is synthetic: a feed refresh is what a poll, a reconnect
+  or a return-to-tab does to a cached list, and favouriting is Conduit's
+  most-clicked control.
+
+  ## The page is [[re-frame.bench.hicasso.shapes.large-template]], re-cut
+
+  Same chrome, same card, same model, same intents. The **only** edit is
+  the one the shape is about:
+
+      ;; large-template, one boundary:
+      (for [slug (sub [:conduit/slugs])]
+        (card/card slug))
+
+      ;; feed, one boundary per card:
+      (for [slug (sub [:conduit/slugs])]
+        [article-card {:key slug :slug slug}])
+
+  plus the four lines of [[article-card]] below, whose entire body is the
+  same `(card/card slug)`. `bulk_dom_cljs_test` asserts the two pages
+  build byte-identical card DOM, so \"the only edit\" is a comparison and
+  not a claim.
+
+  ## What the page boundary reads, and why that is the whole design
+
+  The page reads `[:conduit/slugs]`, `[:conduit/tags]` and
+  `[:conduit/your-feed?]`. It does **not** read any article. So neither
+  write above reaches it: the 300 re-renders on a refresh are the index
+  answering for 300 cards, not a list rebuilding its children, and the one
+  re-render on a favourite is one card. Both witnesses assert the page
+  body's run count did not move, because that is the difference between a
+  narrow update and a page that merely looks narrow.
+
+  ## The cascade this page also makes visible
+
+  A write the **page** reads — the feed toggle — re-renders the page, and
+  React then re-renders all 300 card boundaries beneath it, because a
+  Hicasso boundary is a plain function component with no props-equality
+  bail-out. Reagent's default `shouldComponentUpdate` compares argv and
+  stops exactly this cascade. `narrow_dom_cljs_test` measures it rather
+  than leaving it to be discovered on a clock: see that file's
+  `a-page-chrome-write-re-renders-every-row`. It is reported as a
+  **finding**, not repaired here — repairing it is a runtime change, and
+  the roster's job is to find out what the shapes cost.
+
+  `.cljc`-compatible by construction (HD-020(d))."
+  (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.bench.hicasso.shapes.card :as card]
+            [re-frame.bench.hicasso.shapes.large-template :as lt]
+            [re-frame.bench.hicasso.shapes.model :as m])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(def article-count
+  "The charter's rung: ~300 boundaries on one commit."
+  300)
+
+(def tag-count 10)
+
+(def seed {:articles article-count :tags tag-count})
+
+(defn element-arithmetic
+  "Predicted element count — the same chrome as the large template, the
+  same card, a different number of them."
+  []
+  (+ lt/chrome-elements tag-count (* card/elements-per-card article-count)))
+
+(def !card-runs
+  "How many card bodies have run. Shape 3's claim is that one commit makes
+  this move by exactly 300; shape 4's is that another makes it move by
+  exactly one. Both are counted, not asserted about."
+  (atom 0))
+
+(def !page-runs
+  "How many times the page body has run. Both claims need this NOT to
+  move."
+  (atom 0))
+
+(defn reset-runs! [] (reset! !card-runs 0) (reset! !page-runs 0) nil)
+
+(defn runs [] {:cards @!card-runs :page @!page-runs})
+
+(defview article-card
+  "One card, as a boundary. The whole body is the shared markup — see
+  [[re-frame.bench.hicasso.shapes.card]] for why that is the point."
+  [{:keys [slug]}]
+  (swap! !card-runs inc)
+  (card/card slug))
+
+(defview page
+  "The feed, one boundary per card."
+  [_]
+  (swap! !page-runs inc)
+  (let [your-feed? (sub [:conduit/your-feed?])]
+    [:div.home-page
+     [:div.banner
+      [:div.container
+       [:h1.logo-font "conduit"]
+       [:p "A place to share your knowledge."]]]
+     [:div.container.page
+      [:div.row
+       [:div.col-md-9
+        [:div.feed-toggle
+         [:ul.nav.nav-pills.outline-active
+          [:li.nav-item
+           [:a.nav-link {:href        "#"
+                         :data-testid "your-feed-tab"
+                         :class       (when your-feed? "active")
+                         :on-click    ^{:re-frame.hicasso/prevent? true}
+                                      [:conduit/show-your-feed]}
+            "Your Feed"]]
+          [:li.nav-item
+           [:a.nav-link {:href        "#"
+                         :data-testid "global-feed-tab"
+                         :class       (when-not your-feed? "active")
+                         :on-click    ^{:re-frame.hicasso/prevent? true}
+                                      [:conduit/show-global-feed]}
+            "Global Feed"]]]]
+        [:div.article-list {:data-testid "article-list"}
+         (for [slug (sub [:conduit/slugs])]
+           [article-card {:key slug :slug slug}])]]
+       [:div.col-md-3
+        [:div.sidebar
+         [:p "Popular Tags"]
+         [:div.tag-list {:data-testid "tag-list"}
+          (for [tag (sub [:conduit/tags])]
+            [:a.tag-pill.tag-default {:key         tag
+                                      :href        "#"
+                                      :data-testid (str "tag-" tag)}
+             tag])]]]]]]))
+
+(defn make-frame! [frame-id] (m/make-frame! frame-id seed))
+(defn reseed! [frame-id] (m/reseed! frame-id seed))
+
+(defn slug-at
+  "The slug of the `i`th article, for a witness that wants to name one row
+  out of three hundred."
+  [i]
+  (:slug (m/article i)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/hook_budget_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/hook_budget_dom_cljs_test.cljs
@@ -1,0 +1,165 @@
+(ns re-frame.bench.hicasso.shapes.hook-budget-dom-cljs-test
+  "**THE ≤2-HOOK BUDGET, HELD AT EVERY TIER-1 SHAPE** (HD-020(b);
+  rf2-2rtt6.51).
+
+  `arm1_hook_ledger_dom_cljs_test` proves the budget on a synthetic
+  boundary at 1, 7 and 20 reads. That is the right instrument for the
+  claim it makes, and it leaves one question open: **does the budget
+  survive the shapes v0 is judged on?** A budget that held on a probe and
+  broke on a real screen would be a budget nobody had checked.
+
+  So this file re-takes it on the roster, with the same probe, counting
+  at React's own dispatcher:
+
+  | shape | boundaries | reads | hooks |
+  |---|---|---|---|
+  | 1 ordinary | 7 | 15 | 14 |
+  | 2 large template | **1** | **141** | **2** |
+  | 3/4 feed | 301 | 603 | 602 |
+
+  Row 2 is the one worth reading twice. One hundred and forty-one
+  subscription reads — written inside a `for`, inside a plain helper
+  called from inside that `for` — cost the same two hooks as one read,
+  because `subscribe` closes over the read SET and nothing else, so the
+  read count cannot reach the hook count. No per-read hook surface has a
+  row here at all: 141 reads would be 141 hooks, which no rule about hook
+  order permits inside a loop.
+
+  **A shape that cost a third hook would be a finding, not a cost to
+  spend.** None did.
+
+  Runtime: `-dom-cljs-test`. Under `:node-test`, and on any React build
+  whose internals slot has moved, the claims degrade to a stated skip or
+  to **unwitnessed** — never to a false green."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.hook-probe :as probe]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.shapes.feed :as feed]
+            [re-frame.bench.hicasso.shapes.large-template :as large-template]
+            [re-frame.bench.hicasso.shapes.model :as m]
+            [re-frame.bench.hicasso.shapes.ordinary :as ordinary]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::shape-hooks)
+
+(defn- skip! [why]
+  (is true (str "a dispatcher-level hook count needs a real React DOM — " why)))
+
+(defn- unwitnessed! []
+  (is false (str "React's internals slot was not found, so the ≤2-hook budget is "
+                 "UNWITNESSED on these shapes. A gate nobody has watched fire is "
+                 "not evidence — fix " (pr-str 're-frame.bench.hicasso.arm1.hook-probe)
+                 " rather than reading this as a pass.")))
+
+(defn- mount-and-count
+  "Mount `hiccup` on `seed` and answer the hook names React was asked for
+  while it mounted, alongside the runtime's own boundary and edge counts —
+  read BEFORE the release that would empty them."
+  [seed hiccup]
+  (lane/leave-act-environment!)
+  (m/make-frame! frame-id seed)
+  (m/reseed! frame-id seed)
+  (let [container (mount/fresh-container!)
+        handle    (volatile! nil)
+        names     (probe/record!
+                    (fn [] (vreset! handle (mount/root! container frame-id hiccup))))
+        stats     (rt/stats)]
+    (mount/release! @handle)
+    {:hooks      names
+     :boundaries (:boundaries stats)
+     :edges      (:edges stats)}))
+
+(def ^:private shapes
+  "The roster, as the probe sees it. Shape 4 is shape 3's page — the same
+  mount — so it has no separate row: the budget is a property of the
+  mounted page, and one commit later cannot add a hook."
+  [{:label "1 — ordinary views"
+    :seed  {:articles 2 :comments 5 :tags 2}
+    :tree  [ordinary/screen {}]}
+   {:label "2 — large templates"
+    :seed  large-template/seed
+    :tree  [large-template/page {}]}
+   {:label "3/4 — bulk + narrow"
+    :seed  feed/seed
+    :tree  [feed/page {}]}])
+
+;; ---------------------------------------------------------------------------
+;; The budget, shape by shape
+;; ---------------------------------------------------------------------------
+
+(deftest every-shape-costs-exactly-two-hooks-per-boundary
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (if-not (probe/install!)
+      (unwitnessed!)
+      (doseq [{:keys [label seed tree]} shapes]
+        (testing label
+          (let [{:keys [hooks boundaries edges]} (mount-and-count seed tree)]
+            (is (pos? boundaries) (str label ": the mount built boundaries to count"))
+            (is (= (* 2 boundaries) (count hooks))
+                (str label ": " boundaries " boundaries reading " edges
+                     " subscriptions cost " (count hooks) " hooks — the budget is "
+                     (* 2 boundaries)))
+            (is (= #{"useContext" "useSyncExternalStore"} (set hooks))
+                (str label ": and they are the two `shell-hook-ledger` declares"))
+            (is (= (vec (mapcat (fn [_] ["useContext" "useSyncExternalStore"])
+                                (range boundaries)))
+                   (vec hooks))
+                (str label ": in `shell-hook-ledger`'s order, once per boundary —
+                     React runs a component's hooks to completion before it
+                     starts the next, so the whole page's sequence is the
+                     declared pair repeated"))
+            (is (= (count rt/shell-hook-ledger) 2)
+                "and the ledger the runtime declares is still two entries long")
+            (testing "no third hook of any kind"
+              (doseq [banned ["useRef" "useState" "useMemo" "useCallback" "useEffect"
+                              "useLayoutEffect" "useReducer" "useId"]]
+                (is (not (contains? (set hooks) banned))
+                    (str label ": " banned " must not appear in a boundary shell"))))))))))
+
+;; ---------------------------------------------------------------------------
+;; The row the budget exists for
+;; ---------------------------------------------------------------------------
+
+(deftest the-read-count-cannot-reach-the-hook-count
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (if-not (probe/install!)
+      (unwitnessed!)
+      (testing "shape 2 is one boundary making 141 subscription reads, every
+               one of them inside a `for` and inside a plain helper called
+               from inside it. It costs the same two hooks as a boundary with
+               one read, because `subscribe` closes over the read SET and
+               nothing else."
+        (let [{:keys [hooks boundaries edges]}
+              (mount-and-count large-template/seed [large-template/page {}])]
+          (is (= 1 boundaries))
+          (is (= 141 edges) "141 reads")
+          (is (= 2 (count hooks))
+              (str "and two hooks: " (pr-str hooks)))
+          (is (= ["useContext" "useSyncExternalStore"] hooks)
+              "in the declared order"))))))
+
+(deftest the-budget-does-not-move-when-the-page-grows
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (if-not (probe/install!)
+      (unwitnessed!)
+      (testing "hooks per boundary is 2 at 50, 150 and 300 mounted card
+               boundaries — the axis a bulk row grows along"
+        (doseq [n [50 150 300]]
+          (let [{:keys [hooks boundaries]}
+                (mount-and-count {:articles n :tags feed/tag-count} [feed/page {}])]
+            (is (= (inc n) boundaries))
+            (is (= (* 2 (inc n)) (count hooks))
+                (str "B = " n ": " (count hooks) " hooks over " boundaries
+                     " boundaries"))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/large_template.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/large_template.cljs
@@ -1,0 +1,155 @@
+(ns re-frame.bench.hicasso.shapes.large-template
+  "**TIER-1 SHAPE 2 — LARGE TEMPLATES**, the ~1,200-element shape
+  (charter §Use cases A2; rf2-2rtt6.51).
+
+  RealWorld's home feed — `ui_views.cljs:223-274`, banner, feed toggle,
+  article list and popular-tags sidebar — **as one boundary**. Every card,
+  every tag pill and every element of the chrome is interpreted inside a
+  single `defview` body. That is the shape's definition: not \"a big
+  page\", but *one template that is big*, which is the rung that prices
+  **the hiccup interpreter** with the boundary shell held at one.
+
+  ## The page
+
+      chrome 19 + tags 10 + 69 cards x 17 = 1,202 elements, ONE boundary
+
+  [[element-arithmetic]] is that sum, and
+  `large_template_dom_cljs_test` asserts the DOM matches it. A page whose
+  size is arithmetic rather than a measurement is a page a witness can
+  check; a page whose size is whatever the DOM says is a page that
+  re-baselines itself on every markup edit.
+
+  ## Two deviations from the census screen, both named
+
+  1. **Unpaginated.** Conduit paginates at ten articles a page, so
+     Conduit's own home page is a ~200-element screen. The shape the
+     charter names is ~1,200, and the honest way to get there from this
+     screen is the variant every real feed grew into — one long page — so
+     the port drops the `pagination` subtree along with the page division
+     that is its only reason to exist. The census's own `pagination` view
+     renders nothing when there is one page, so this is the branch it
+     already has.
+  2. **No auth-conditional chrome.** The census hides the *Your Feed* tab
+     from a signed-out reader. The roster's reader is always signed in
+     (`model/signed-in-user`), so the branch would have one answer for the
+     life of every witness, and a constant conditional in a page whose
+     size is asserted is a trap rather than a fidelity.
+
+  Everything else is Conduit's: class names, nesting, `data-testid`
+  retail, the `favoritesCount` field names, the tag pills.
+
+  ## What this shape is really asking
+
+  **~141 subscription reads in one body, and the shell still costs two
+  hooks.** Sixty-nine cards read two subs each, the chrome reads three
+  more, and every one of those reads sits inside a `for`, inside a plain
+  helper called from inside that `for`
+  ([[re-frame.bench.hicasso.shapes.card/card]]) — which is the collector's
+  authoring claim taken to a rung no hook-shaped read surface can reach at
+  all. `hook_budget_dom_cljs_test` counts it at React's own dispatcher:
+  two, the same two the one-read boundary pays.
+
+  It is also the shape most exposed to the runtime's own read-set
+  machinery. One boundary with ~141 reads means a 141-entry scratch, a
+  141-key read-set entry, and a 141-term `getSnapshot` sum. Nothing here
+  changed to accommodate that, and nothing needed to.
+
+  ## Reading the body
+
+  The whole page is one `let` and one nested hiccup literal. There is no
+  \"large template\" idiom — no `into`, no `apply`, no fragment ceremony,
+  no keys on anything that is not in a `for`. The card is a function call
+  because a card here is not a component; making it one is
+  [[re-frame.bench.hicasso.shapes.feed]], and the diff between the two
+  files is the deliberate finding.
+
+  `.cljc`-compatible by construction (HD-020(d))."
+  (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.bench.hicasso.shapes.card :as card]
+            [re-frame.bench.hicasso.shapes.model :as m])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(def article-count
+  "Sixty-nine cards. Chosen so the page lands on the charter's
+  ~1,200-element shape — and, not by coincidence, within one element of
+  the predecessor's own 1,203-element `W1` witness, so a reader comparing
+  the two is comparing pages of the same size."
+  69)
+
+(def tag-count 10)
+
+(def chrome-elements
+  "Every element of the page that is not a card and not a tag pill:
+
+      home-page, banner, banner container, h1, p,
+      page container, row, col-md-9, feed-toggle, ul.nav,
+      li, a, li, a, article-list,
+      col-md-3, sidebar, p, tag-list
+
+  Nineteen. Counted by hand and then held there by
+  `the-page-is-the-size-the-arithmetic-predicts`, which fails on a markup
+  edit rather than absorbing it."
+  19)
+
+(def seed
+  "The seed the shape is mounted on."
+  {:articles article-count :tags tag-count})
+
+(defn element-arithmetic
+  "The page's element count, predicted rather than measured."
+  []
+  (+ chrome-elements tag-count (* card/elements-per-card article-count)))
+
+(def !body-runs
+  "How many times the page's one body has run."
+  (atom 0))
+
+(defn reset-runs! [] (reset! !body-runs 0) nil)
+
+(defview page
+  "The whole feed, in one boundary."
+  [_]
+  (swap! !body-runs inc)
+  (let [your-feed? (sub [:conduit/your-feed?])]
+    [:div.home-page
+     [:div.banner
+      [:div.container
+       [:h1.logo-font "conduit"]
+       [:p "A place to share your knowledge."]]]
+     [:div.container.page
+      [:div.row
+       [:div.col-md-9
+        [:div.feed-toggle
+         [:ul.nav.nav-pills.outline-active
+          [:li.nav-item
+           [:a.nav-link {:href        "#"
+                         :data-testid "your-feed-tab"
+                         :class       (when your-feed? "active")
+                         :on-click    ^{:re-frame.hicasso/prevent? true}
+                                      [:conduit/show-your-feed]}
+            "Your Feed"]]
+          [:li.nav-item
+           [:a.nav-link {:href        "#"
+                         :data-testid "global-feed-tab"
+                         :class       (when-not your-feed? "active")
+                         :on-click    ^{:re-frame.hicasso/prevent? true}
+                                      [:conduit/show-global-feed]}
+            "Global Feed"]]]]
+        [:div.article-list {:data-testid "article-list"}
+         (for [slug (sub [:conduit/slugs])]
+           ;; A plain call. It inlines into THIS boundary and donates its
+           ;; two reads to it — the whole difference between this shape and
+           ;; the next one.
+           (card/card slug))]]
+       [:div.col-md-3
+        [:div.sidebar
+         [:p "Popular Tags"]
+         [:div.tag-list {:data-testid "tag-list"}
+          (for [tag (sub [:conduit/tags])]
+            [:a.tag-pill.tag-default {:key         tag
+                                      :href        "#"
+                                      :data-testid (str "tag-" tag)}
+             tag])]]]]]]))
+
+(defn make-frame! [frame-id] (m/make-frame! frame-id seed))
+(defn reseed! [frame-id] (m/reseed! frame-id seed))

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/large_template_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/large_template_dom_cljs_test.cljs
@@ -89,7 +89,13 @@
             (is (= 2 (count (q* handle ".feed-toggle .nav-item"))))
             (is (some? (q handle "[data-testid=\"global-feed-tab\"].active"))
                 "the default tab is the global feed")
-            (is (= shape/tag-count (count (q* handle ".tag-list > .tag-pill")))))
+            ;; `[data-testid="tag-list"]`, not `.tag-list`: the census gives
+            ;; the sidebar's tag cloud and every card's own tag row the SAME
+            ;; class, so the bare selector answers 10 + 69x2 = 148. Its own
+            ;; collision, faithfully ported — and the reason the sidebar is
+            ;; addressed by the test id the census also wrote.
+            (is (= shape/tag-count
+                   (count (q* handle "[data-testid=\"tag-list\"] > .tag-pill")))))
           (testing "and the cards are the model's"
             (is (= shape/article-count (count (q* handle ".article-list > .article-preview"))))
             (doseq [i [0 1 34 68]]
@@ -159,7 +165,7 @@
               (let [other (:slug (m/article 8))]
                 (is (= (str (:favoritesCount (m/article 8)))
                        (.-textContent (q handle (str "[data-testid=\"favorites-count-"
-                                                     other "\"]")))))))))
+                                                     other "\"]"))))))))
           (finally (mount/release! handle)))))))
 
 (deftest the-feed-toggle-flips-the-chrome

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/large_template_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/large_template_dom_cljs_test.cljs
@@ -184,6 +184,53 @@
           (finally (mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
+;; The one authoring spelling this roster uses that nothing else witnesses
+;; ---------------------------------------------------------------------------
+;;
+;; The census's feed tabs are anchors, so a port that keeps them has to opt
+;; `preventDefault` IN — `^{::h/prevent? true}` on the intent — where the
+;; comment form's `:on-submit` gets it from the position's own default.
+;; Every other assertion in the roster reaches its intents through
+;; `rt/dispatch!`, which would never have exercised the metadata at all.
+;; Fired here as a real cancelable click, with the un-annotated control on
+;; the same page as the control: if the pair both prevented, or neither
+;; did, the metadata would not be the thing doing it.
+
+(defn- click!
+  "A real, cancelable click, dispatched at the node. Answers the event, so
+  the caller can read `defaultPrevented` off it."
+  [node]
+  (let [ev (js/MouseEvent. "click" #js {:bubbles true :cancelable true})]
+    (.dispatchEvent node ev)
+    (mount/settle!)
+    ev))
+
+(deftest the-prevent-metadata-is-what-prevents
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (testing "an anchor carrying ^{::h/prevent? true} dispatches AND
+                   prevents, so the href=\"#\" does not navigate"
+            (let [ev (click! (q handle "[data-testid=\"your-feed-tab\"]"))]
+              (is (true? (.-defaultPrevented ev)))
+              (is (some? (q handle "[data-testid=\"your-feed-tab\"].active"))
+                  "and the intent reached the model")))
+          (testing "the control: an ordinary intent on the same page dispatches
+                   and does NOT prevent"
+            (let [slug (:slug (m/article 4))
+                  ev   (click! (q handle (str "[data-testid=\"favorite-" slug "\"]")))]
+              (is (false? (.-defaultPrevented ev)))
+              (is (= (str (inc (:favoritesCount (m/article 4))))
+                     (.-textContent (q handle (str "[data-testid=\"favorites-count-"
+                                                   slug "\"]"))))
+                  "and it reached the model too — so the difference between the
+                   two is the metadata and nothing else")))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
 ;; Teardown
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/large_template_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/large_template_dom_cljs_test.cljs
@@ -1,0 +1,200 @@
+(ns re-frame.bench.hicasso.shapes.large-template-dom-cljs-test
+  "**SHAPE 2'S WITNESS** — the ~1,200-element template is one boundary,
+  and it renders the census's page (rf2-2rtt6.51).
+
+  Four claims:
+
+  1. **The page is the size the arithmetic predicts.** `chrome + tags +
+     69 x 17` is computed from constants in the source and compared
+     against the DOM. A markup edit that changes a card's element count
+     fails here instead of silently re-baselining what \"the ~1,200-element
+     shape\" means.
+  2. **It is ONE boundary** — the defining property of the shape, and the
+     reason it prices the hiccup interpreter rather than the shell.
+  3. **141 subscription reads land on that one boundary**, in one
+     read-set entry, over 141 cells. The reads sit inside a `for`, inside
+     a plain helper called from inside it — the collector's authoring
+     claim at a rung no per-read hook surface can reach.
+  4. **The template is live.** A write moves the DOM, and the page's one
+     body re-runs exactly once for it — which is also the honest cost of
+     this decomposition and the reason shape 3 exists.
+
+  Runtime: `-dom-cljs-test`. Under `:node-test` every claim degrades to a
+  stated skip."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.shapes.card :as card]
+            [re-frame.bench.hicasso.shapes.large-template :as shape]
+            [re-frame.bench.hicasso.shapes.model :as m]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::shape-large-template)
+
+(def ^:private predicted-reads
+  "What the page's single boundary reads:
+
+      page chrome  [:conduit/your-feed?] [:conduit/slugs] [:conduit/tags]   3
+      per card     [:conduit/article slug] [:conduit/favorite-pending? slug] 2
+
+  so `3 + 2 x 69`."
+  (+ 3 (* 2 shape/article-count)))
+
+(defn- skip! [why]
+  (is true (str "shape 2's witness needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (lane/leave-act-environment!)
+  (shape/make-frame! frame-id)
+  (shape/reseed! frame-id)
+  (shape/reset-runs!)
+  frame-id)
+
+(defn- mount! []
+  (mount/root! (mount/fresh-container!) frame-id [shape/page {}]))
+
+(defn- q [handle sel] (.querySelector (:container handle) sel))
+(defn- q* [handle sel] (array-seq (.querySelectorAll (:container handle) sel)))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the size is arithmetic, not a measurement
+;; ---------------------------------------------------------------------------
+
+(deftest the-page-is-the-size-the-arithmetic-predicts
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (let [predicted (shape/element-arithmetic)
+                measured  (lane/element-count (:container handle))]
+            (is (= predicted measured)
+                (str "chrome " shape/chrome-elements " + tags " shape/tag-count
+                     " + " shape/article-count " cards x " card/elements-per-card
+                     " = " predicted "; the DOM holds " measured))
+            (is (<= 1150 measured 1250)
+                (str "and that is the charter's ~1,200-element shape (" measured ")")))
+          (testing "the census's own chrome is all there"
+            (is (some? (q handle ".home-page > .banner .logo-font")))
+            (is (= 2 (count (q* handle ".feed-toggle .nav-item"))))
+            (is (some? (q handle "[data-testid=\"global-feed-tab\"].active"))
+                "the default tab is the global feed")
+            (is (= shape/tag-count (count (q* handle ".tag-list > .tag-pill")))))
+          (testing "and the cards are the model's"
+            (is (= shape/article-count (count (q* handle ".article-list > .article-preview"))))
+            (doseq [i [0 1 34 68]]
+              (let [a (m/article i)]
+                (is (= (:title a)
+                       (.-textContent (q handle (str "[data-testid=\"article-preview-"
+                                                     (:slug a) "\"] h1"))))
+                    (str "card " i " carries the model's title"))
+                (is (= (str (:favoritesCount a))
+                       (.-textContent (q handle (str "[data-testid=\"favorites-count-"
+                                                     (:slug a) "\"]"))))
+                    (str "card " i " carries the model's favourites count")))))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 + 3 — one boundary, 141 reads, one read-set entry
+;; ---------------------------------------------------------------------------
+
+(deftest the-whole-page-is-one-boundary
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (let [{:keys [boundaries edges entries cells]} (rt/stats)]
+            (is (= 1 boundaries)
+                (str "a large TEMPLATE is one boundary interpreting many "
+                     "elements; this page reports " boundaries))
+            (is (= predicted-reads edges)
+                (str "and it holds all " predicted-reads " edges itself"))
+            (is (= predicted-reads cells)
+                "one cell per unique (frame, query), and every query here is distinct")
+            (is (= 1 entries)
+                "one read SEQUENCE, so one cached subscribe/getSnapshot pair"))
+          (is (= 1 @shape/!body-runs) "and its body ran once to build the page")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — the template is live, and re-running it is what it costs
+;; ---------------------------------------------------------------------------
+
+(deftest a-write-moves-the-dom-and-re-runs-the-one-body-once
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (let [slug   (:slug (m/article 7))
+                before (:favoritesCount (m/article 7))
+                count- (fn [] (.-textContent
+                                (q handle (str "[data-testid=\"favorites-count-" slug "\"]"))))]
+            (is (= (str before) (count-)) "the first paint is right — which proves nothing on its own")
+            (reset! shape/!body-runs 0)
+            (rt/dispatch! frame-id [:conduit/favorite slug])
+            (mount/settle!)
+            (is (= (str (inc before)) (count-))
+                "a later write reaches the DOM — the half a first render cannot tell you")
+            (is (some? (q handle (str "[data-testid=\"favorite-" slug "\"].active")))
+                "and the favourited class flipped with it")
+            (is (= 1 @shape/!body-runs)
+                "the page's one body re-ran exactly once — which is also the honest
+                 cost of this decomposition: a one-card write re-interprets all
+                 1,202 elements, and that is what shape 3 exists to change")
+            (testing "every other card is untouched"
+              (let [other (:slug (m/article 8))]
+                (is (= (str (:favoritesCount (m/article 8)))
+                       (.-textContent (q handle (str "[data-testid=\"favorites-count-"
+                                                     other "\"]")))))))))
+          (finally (mount/release! handle)))))))
+
+(deftest the-feed-toggle-flips-the-chrome
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (is (some? (q handle "[data-testid=\"global-feed-tab\"].active")))
+          (is (nil? (q handle "[data-testid=\"your-feed-tab\"].active")))
+          (rt/dispatch! frame-id [:conduit/show-your-feed])
+          (mount/settle!)
+          (is (some? (q handle "[data-testid=\"your-feed-tab\"].active")))
+          (is (nil? (q handle "[data-testid=\"global-feed-tab\"].active")))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; Teardown
+;; ---------------------------------------------------------------------------
+
+(deftest the-page-leaves-no-residue
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (async done
+      (fresh!)
+      (let [handle (mount!)]
+        (rt/dispatch! frame-id [:conduit/favorite (:slug (m/article 2))])
+        (mount/settle!)
+        (is (pos? (:cell-refs (rt/stats))))
+        (mount/unmount! handle)
+        (js/setTimeout (fn []
+                         (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                                (rt/residue))
+                             "141 edges and 141 cells, all released by React's own cleanup")
+                         (rt/reset-runtime!)
+                         (done))
+                       8)))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/model.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/model.cljs
@@ -1,0 +1,303 @@
+(ns re-frame.bench.hicasso.shapes.model
+  "THE TIER-1 SHAPE ROSTER'S STATE LAYER — one census-real app behind all
+  four shapes (rf2-2rtt6.51).
+
+  The charter's §Use cases names five tier-1 shapes as v0's definition of
+  done. Four of them are *the everyday SPA spine* and they differ in
+  exactly one thing: **how many boundaries the same markup is cut into,
+  and how many of them one commit moves.**
+
+  | shape | the page | boundaries | what a commit moves |
+  |---|---|---|---|
+  | 1 ordinary | the article page's comment column | ~8 | a few |
+  | 2 large template | the whole feed, ONE boundary | **1** | that one |
+  | 3 bulk | the same feed, one boundary per card | **300** | **all 300** |
+  | 4 narrow | the same page as 3, mounted | 300 | **exactly one** |
+
+  Putting them on one state layer is not tidiness. A shape roster whose
+  four pages sit on four hand-written models is measuring four
+  applications, and any difference read between two rows is
+  unattributable — the same argument
+  [[re-frame.bench.hicasso.front.dogfood]] makes for the three dogfood
+  renderings and `jsfb-model` makes for the two js-framework-benchmark
+  arms. Here it binds harder, because shapes 2/3/4 are deliberately **the
+  same screen at three boundary decompositions**: if the model differed,
+  the decomposition would not be the only variable and the roster would
+  prove nothing about boundaries at all.
+
+  ## The app is the census's, not an invention
+
+  RealWorld (Conduit) — `examples/real-apps/realworld_resources/` — is
+  the corpus the fitness harness census was taken on, and it is the app
+  the earlier ergonomics work ported from (the article editor's four
+  fields, `front/census_article_editor_cljs_test`). The shapes port its
+  screens: the article page's comment column (shape 1) and the home feed
+  (shapes 2/3/4). Field names are Conduit's own, down to the
+  `favoritesCount` / `createdAt` camelCase the API hands back, because a
+  port that renamed them would be a screen this repo wrote rather than
+  one it found.
+
+  **What the port leaves behind, and why.** The census screens read
+  `[:rf/resource …]` and `[:rf/mutation …]` — framework subs, which the
+  charter counts at **27% of read traffic**. Those are re-frame2
+  capabilities, not view-layer surface, and standing them up here would
+  put an HTTP-shaped resource cache behind a view-layer witness. The
+  shapes read plain `reg-sub`s with the same *shapes* — a per-instance
+  `:conduit/favorite-pending?` where the census reads
+  `[:rf/mutation {:instance [:favorite slug]}]` — and the omission is
+  filed rather than papered over: **framework subs are not exercised by
+  this roster** (see the bead's Findings).
+
+  ## The two writes the roster turns on
+
+  `:conduit/favorite` is **the narrow write**: it changes one article, so
+  exactly one `[:conduit/article slug]` moves, so under a correct index
+  exactly one boundary re-runs. `:conduit/refresh-feed` is **the broad
+  write**: every article moves in one commit, which is shape 3's
+  make-or-break row. They live here rather than beside a view because
+  both feed pages dispatch the same two, and a shape whose write differed
+  from its neighbour's would not be the same page re-cut.
+
+  Neither is synthetic. Favouriting an article is the single most-clicked
+  control in Conduit, and a feed refresh is what a poll, a reconnect or a
+  page change does to a cached list.
+
+  ## Determinism
+
+  Every string is a pure function of an index — no `rand`, no clock. Two
+  mounts of the same seed build byte-identical DOM, which is what lets a
+  witness compare a page against itself across a commit and read the
+  difference as the commit's."
+  (:require [re-frame.core :as rf]))
+
+;; ---------------------------------------------------------------------------
+;; The seed data — Conduit's own field names, from a deterministic index
+;; ---------------------------------------------------------------------------
+
+(def ^:private authors
+  "Four authors, so a feed of any size has a repeating byline the way a
+  real one does, and so `mine?`-style per-row branches have both answers
+  to take."
+  ["jane" "riku" "amara" "tomas"])
+
+(def ^:private tag-vocabulary
+  ["clojure" "react" "hiccup" "state" "forms" "perf" "cljs" "design"
+   "testing" "routing"])
+
+(defn- author-for [i]
+  (let [name (nth authors (mod i (count authors)))]
+    {:username  name
+     :image     (str "https://example.invalid/avatar/" name ".png")
+     :following (odd? i)}))
+
+(defn- tags-for
+  "Two tags per article, drawn from the vocabulary by index. Two rather
+  than a varying count on purpose: a card's element count is then a
+  constant, so a page's total is arithmetic a witness can predict rather
+  than a number it has to accept."
+  [i]
+  [(nth tag-vocabulary (mod i (count tag-vocabulary)))
+   (nth tag-vocabulary (mod (+ i 3) (count tag-vocabulary)))])
+
+(defn article
+  "One Conduit article, as the API shapes it."
+  [i]
+  (let [slug (str "article-" i)]
+    {:slug           slug
+     :title          (str "Article " i)
+     :description    (str "What article " i " is about.")
+     :body           (str "The body of article " i ".")
+     :createdAt      (str "2026-0" (inc (mod i 9)) "-1" (mod i 10))
+     :favoritesCount (mod (* 7 i) 23)
+     :favorited      (zero? (mod i 5))
+     :author         (author-for i)
+     :tagList        (tags-for i)}))
+
+(defn comment-for
+  "One comment on the article page. Every fourth is the signed-in
+  reader's own, so the card's author-only delete control has both
+  branches present on one page."
+  [i]
+  (let [mine? (zero? (mod i 4))]
+    {:id        i
+     :body      (str "Comment " i " on this article.")
+     :createdAt (str "2026-07-2" (mod i 10))
+     :author    (if mine?
+                  {:username "me" :image "https://example.invalid/avatar/me.png"}
+                  (author-for i))}))
+
+(def signed-in-user
+  "The reader the pages render for. Present rather than nil, because the
+  signed-out branches of these screens render *less*, and a roster whose
+  pages took the cheap branch would be understating every shape."
+  {:username "me" :image "https://example.invalid/avatar/me.png"})
+
+(def comment-draft-key
+  "The draft key for the not-yet-posted comment. HD-009: the half-typed
+  comment lives in app-db under one parametric subscription and one named
+  event, not in a component-local cell."
+  ::comment-draft)
+
+(def page-size
+  "Articles per page — Conduit's own. It decides the pagination control's
+  size, which is part of the ported chrome rather than a knob."
+  10)
+
+(defn seed-db
+  "`articles` articles, `comments` comments, one signed-in reader. The one
+  place the shape is written out."
+  [{:keys [articles comments tags]
+    :or   {articles 20 comments 5 tags 10}}]
+  {:articles      (into {} (map (fn [i] (let [a (article i)] [(:slug a) a]))) (range articles))
+   :order         (mapv (fn [i] (:slug (article i))) (range articles))
+   :comments      (into {} (map (fn [i] [i (comment-for i)])) (range comments))
+   :comment-order (vec (range comments))
+   :tags          (vec (take tags tag-vocabulary))
+   :drafts        {}
+   :pending       #{}
+   :page          1
+   :your-feed?    false
+   :user          signed-in-user})
+
+;; ---------------------------------------------------------------------------
+;; Subscriptions — what a boundary reads
+;; ---------------------------------------------------------------------------
+
+(rf/reg-sub :conduit/user (fn [db _] (:user db)))
+
+(rf/reg-sub :conduit/slugs (fn [db _] (:order db)))
+
+(rf/reg-sub :conduit/article (fn [db [_ slug]] (get-in db [:articles slug])))
+
+(rf/reg-sub :conduit/tags (fn [db _] (:tags db)))
+
+(rf/reg-sub :conduit/your-feed? (fn [db _] (boolean (:your-feed? db))))
+
+(rf/reg-sub :conduit/page (fn [db _] (:page db)))
+
+(rf/reg-sub :conduit/page-count
+  (fn [db _] (max 1 (long (Math/ceil (/ (count (:order db)) page-size))))))
+
+(rf/reg-sub :conduit/comment-ids (fn [db _] (:comment-order db)))
+
+(rf/reg-sub :conduit/comment (fn [db [_ id]] (get-in db [:comments id])))
+
+(rf/reg-sub :conduit/draft (fn [db [_ k]] (get-in db [:drafts k] "")))
+
+;; The mutation-shaped reads. The census spells these
+;; `[:rf/mutation {:instance [:favorite slug]}]`; here they are ordinary
+;; parametric subs over one `:pending` set, so the *read shape* a card
+;; carries — one per-instance status read alongside its data read — is the
+;; census's even though the machinery behind it is not.
+(rf/reg-sub :conduit/favorite-pending?
+  (fn [db [_ slug]] (contains? (:pending db) [:favorite slug])))
+
+(rf/reg-sub :conduit/comment-pending?
+  (fn [db _] (contains? (:pending db) [:post-comment])))
+
+(rf/reg-sub :conduit/delete-pending?
+  (fn [db [_ id]] (contains? (:pending db) [:delete-comment id])))
+
+;; ---------------------------------------------------------------------------
+;; Events
+;; ---------------------------------------------------------------------------
+
+(rf/reg-event :conduit/seed (fn [_ [_ opts]] {:db (seed-db opts)}))
+
+(rf/reg-event :conduit/favorite
+  ;; **THE NARROW WRITE.** One article changes, so exactly one
+  ;; `[:conduit/article slug]` moves. Everything else in app-db is
+  ;; untouched, including `:order` — which is what makes the list
+  ;; boundary's non-re-render an assertion the witness can make.
+  (fn [{:keys [db]} [_ slug]]
+    {:db (update-in db [:articles slug]
+                    (fn [a]
+                      (let [now (not (:favorited a))]
+                        (assoc a :favorited now
+                                 :favoritesCount ((if now inc dec) (:favoritesCount a))))))}))
+
+(rf/reg-event :conduit/refresh-feed
+  ;; **THE BROAD WRITE** — shape 3's make-or-break commit. Every article
+  ;; moves, in one commit, so every card boundary is dirty. `:order` does
+  ;; NOT move, so the list boundary above them is not: the 300 re-renders
+  ;; are the index's answer about the cards, not a parent rebuilding its
+  ;; children.
+  (fn [{:keys [db]} _]
+    {:db (update db :articles
+                 (fn [as]
+                   (reduce-kv (fn [m slug a] (assoc m slug (update a :favoritesCount inc)))
+                              {} as)))}))
+
+(rf/reg-event :conduit/edit-draft
+  (fn [{:keys [db]} [_ k v]] {:db (assoc-in db [:drafts k] v)}))
+
+(rf/reg-event :conduit/post-comment
+  ;; The draft clears by explicit caller revision (HD-019), never by
+  ;; value equality.
+  (fn [{:keys [db]} _]
+    (let [body (get-in db [:drafts comment-draft-key] "")]
+      (if (= "" body)
+        {:db db}
+        (let [id (inc (reduce max -1 (:comment-order db)))]
+          {:db (-> db
+                   (assoc-in [:comments id] {:id id :body body
+                                             :createdAt "2026-08-01"
+                                             :author signed-in-user})
+                   (update :comment-order conj id)
+                   (update :drafts dissoc comment-draft-key))})))))
+
+(rf/reg-event :conduit/delete-comment
+  (fn [{:keys [db]} [_ id]]
+    {:db (-> db
+             (update :comments dissoc id)
+             (update :comment-order (fn [o] (filterv #(not= id %) o))))}))
+
+(rf/reg-event :conduit/go-to-page
+  (fn [{:keys [db]} [_ p]] {:db (assoc db :page p)}))
+
+;; The feed toggle. A page-chrome write: it moves `[:conduit/your-feed?]`,
+;; which the page boundary reads and no card does — so it re-runs the page
+;; and none of its rows, which is the mirror image of the narrow write.
+(rf/reg-event :conduit/show-your-feed
+  (fn [{:keys [db]} _] {:db (assoc db :your-feed? true)}))
+
+(rf/reg-event :conduit/show-global-feed
+  (fn [{:keys [db]} _] {:db (assoc db :your-feed? false)}))
+
+(rf/reg-event :conduit/begin
+  ;; An in-flight write, so the pending branches of the ported screens are
+  ;; reachable from a witness without an HTTP stack behind them.
+  (fn [{:keys [db]} [_ instance]] {:db (update db :pending conj instance)}))
+
+(rf/reg-event :conduit/settle
+  (fn [{:keys [db]} [_ instance]] {:db (update db :pending disj instance)}))
+
+;; ---------------------------------------------------------------------------
+;; The frame lifecycle
+;; ---------------------------------------------------------------------------
+
+(defn make-frame!
+  "Create (or idempotently replace) `frame-id`'s frame, seeded per `opts`."
+  [frame-id opts]
+  (rf/make-frame {:id frame-id :initial-events [[:conduit/seed opts]]})
+  frame-id)
+
+(defn reseed!
+  "Return the frame to its seeded state, so one witness never reads a page
+  a previous one already mutated. `make-frame!` is idempotent and will
+  NOT replay its initial events for an id that already exists, so both
+  halves are needed."
+  [frame-id opts]
+  (rf/with-frame frame-id (rf/dispatch-sync [:conduit/seed opts]))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Small pure helpers the ported markup uses
+;; ---------------------------------------------------------------------------
+
+(defn avatar-src
+  "The census screens call `realworld-shared.avatar/avatar-src`; the
+  examples tree is not on this classpath, so the one line it contributes
+  is inlined rather than depended on."
+  [image]
+  (or image "https://example.invalid/avatar/default.png"))

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/model.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/model.cljs
@@ -138,11 +138,6 @@
   event, not in a component-local cell."
   ::comment-draft)
 
-(def page-size
-  "Articles per page — Conduit's own. It decides the pagination control's
-  size, which is part of the ported chrome rather than a knob."
-  10)
-
 (defn seed-db
   "`articles` articles, `comments` comments, one signed-in reader. The one
   place the shape is written out."
@@ -173,10 +168,11 @@
 
 (rf/reg-sub :conduit/your-feed? (fn [db _] (boolean (:your-feed? db))))
 
+;; Registered and read by nothing, deliberately. `:conduit/go-to-page` is
+;; the roster's **negative control** — a commit that moves a key no
+;; boundary holds — and `bulk_dom_cljs_test/the-broad-write-can-answer-false`
+;; needs it to move something real rather than nothing at all.
 (rf/reg-sub :conduit/page (fn [db _] (:page db)))
-
-(rf/reg-sub :conduit/page-count
-  (fn [db _] (max 1 (long (Math/ceil (/ (count (:order db)) page-size))))))
 
 (rf/reg-sub :conduit/comment-ids (fn [db _] (:comment-order db)))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/model.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/model.cljs
@@ -87,7 +87,7 @@
 (defn- author-for [i]
   (let [name (nth authors (mod i (count authors)))]
     {:username  name
-     :image     (str "https://example.invalid/avatar/" name ".png")
+     :image     name
      :following (odd? i)}))
 
 (defn- tags-for
@@ -298,6 +298,15 @@
 (defn avatar-src
   "The census screens call `realworld-shared.avatar/avatar-src`; the
   examples tree is not on this classpath, so the one line it contributes
-  is inlined rather than depended on."
+  is inlined rather than depended on.
+
+  It answers a `data:` URI rather than a URL, and that is deliberate: the
+  bulk page renders **300 `<img>` elements**, and a witness that is not
+  about images should not open 300 network requests to find out whether a
+  commit re-rendered a row. A hostname that does not resolve is worse than
+  useless — it fills the console with `ERR_NAME_NOT_RESOLVED` and buries
+  the failures a reader is actually looking for. The author's own token
+  stays *in* the URI, so per-author distinctness survives into the DOM and
+  a card comparison still compares something."
   [image]
-  (or image "https://example.invalid/avatar/default.png"))
+  (str "data:," (or image "anon")))

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/model.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/model.cljs
@@ -123,14 +123,14 @@
      :body      (str "Comment " i " on this article.")
      :createdAt (str "2026-07-2" (mod i 10))
      :author    (if mine?
-                  {:username "me" :image "https://example.invalid/avatar/me.png"}
+                  {:username "me" :image "me"}
                   (author-for i))}))
 
 (def signed-in-user
   "The reader the pages render for. Present rather than nil, because the
   signed-out branches of these screens render *less*, and a roster whose
   pages took the cheap branch would be understating every shape."
-  {:username "me" :image "https://example.invalid/avatar/me.png"})
+  {:username "me" :image "me"})
 
 (def comment-draft-key
   "The draft key for the not-yet-posted comment. HD-009: the half-typed

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/narrow_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/narrow_dom_cljs_test.cljs
@@ -1,0 +1,211 @@
+(ns re-frame.bench.hicasso.shapes.narrow-dom-cljs-test
+  "**SHAPE 4'S WITNESS** — one cell moves in a large mounted page
+  (rf2-2rtt6.51).
+
+  validation.md states this shape's win condition as **a law rather than
+  a ratio**: the commit-side dirty set is flat in `B` across mounted
+  subscribing boundaries. No clock is read here; what is established is
+  the law's correctness half — that one commit reaches exactly one
+  boundary and exactly one cell, and that the number does not move when
+  the page grows.
+
+  Four claims:
+
+  1. **One body runs.** A favourite on one of 300 cards re-runs that
+     card's body and nothing else — including, load-bearingly, not the
+     page above it.
+  2. **One cell moves.** Across all 300 rendered counts, exactly one
+     differs after the commit, by exactly one, at exactly the index
+     written to. And the card's DOM node is the SAME node — React patched
+     text in place rather than replacing a subtree.
+  3. **It is flat in B.** The same commit on pages of 50, 150 and 300
+     boundaries re-runs one body every time.
+  4. **What narrow does NOT cover, measured.** A write the *page*
+     boundary reads re-renders the page, and React then re-renders all
+     300 cards beneath it, because a Hicasso boundary is a plain function
+     component with no props-equality bail-out — where Reagent's default
+     `shouldComponentUpdate` compares argv and stops the cascade. This is
+     recorded as a **finding** with a number against it, not repaired
+     here: repairing it is a runtime change and this file's job is to find
+     out what the shape costs. See the bead's Findings.
+
+  Runtime: `-dom-cljs-test`. Under `:node-test` every claim degrades to a
+  stated skip."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.shapes.feed :as shape]
+            [re-frame.bench.hicasso.shapes.model :as m]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::shape-narrow)
+
+(def ^:private moved-index
+  "The row the witness writes to — deliberately deep in the page rather
+  than first or last, where an off-by-one in a list rebuild would be
+  hardest to tell from a correct narrow update."
+  137)
+
+(defn- skip! [why]
+  (is true (str "shape 4's witness needs a real React DOM — " why)))
+
+(defn- fresh!
+  ([] (fresh! shape/seed))
+  ([seed]
+   (lane/leave-act-environment!)
+   (m/make-frame! frame-id seed)
+   (m/reseed! frame-id seed)
+   (shape/reset-runs!)
+   frame-id))
+
+(defn- mount! []
+  (mount/root! (mount/fresh-container!) frame-id [shape/page {}]))
+
+(defn- q [handle sel] (.querySelector (:container handle) sel))
+(defn- q* [handle sel] (array-seq (.querySelectorAll (:container handle) sel)))
+
+(defn- favourite-counts [handle]
+  (mapv #(.-textContent %) (q* handle "[data-testid^=\"favorites-count-\"]")))
+
+(defn- differing-indices [before after]
+  (into [] (keep-indexed (fn [i b] (when (not= b (nth after i)) i))) before))
+
+;; ---------------------------------------------------------------------------
+;; 1 + 2 — one body, one cell
+;; ---------------------------------------------------------------------------
+
+(deftest one-write-re-runs-one-body-out-of-three-hundred
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (let [slug   (shape/slug-at moved-index)
+                node   (q handle (str "[data-testid=\"article-preview-" slug "\"]"))
+                before (favourite-counts handle)]
+            (is (= shape/article-count (count before)))
+            (shape/reset-runs!)
+            (rt/dispatch! frame-id [:conduit/favorite slug])
+            (mount/settle!)
+            (is (= 1 (:cards (shape/runs)))
+                (str "exactly one card body re-ran out of " shape/article-count))
+            (is (= 0 (:page (shape/runs)))
+                "and the page boundary did not — it reads the order, and the
+                 order did not move")
+            (let [after (favourite-counts handle)
+                  moved (differing-indices before after)]
+              (is (= [moved-index] moved)
+                  (str "exactly one of the " shape/article-count
+                       " rendered counts differs, and it is the one written to"))
+              (is (= (str (inc (js/parseInt (nth before moved-index) 10)))
+                     (nth after moved-index))
+                  "by exactly one"))
+            (is (identical? node (q handle (str "[data-testid=\"article-preview-" slug "\"]")))
+                "and the card is the SAME DOM node — React patched it in place
+                 rather than replacing a subtree"))
+          (finally (mount/release! handle)))))))
+
+(deftest the-narrow-reading-can-answer-false
+  (testing "the assertion above is not passing vacuously: the broad write on
+           the same page moves every count, so `differing-indices` is a live
+           comparison rather than one that always answers empty"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (do
+        (fresh!)
+        (let [handle (mount!)]
+          (try
+            (let [before (favourite-counts handle)]
+              (rt/dispatch! frame-id [:conduit/refresh-feed])
+              (mount/settle!)
+              (is (= shape/article-count
+                     (count (differing-indices before (favourite-counts handle))))
+                  "all 300 differ"))
+            (finally (mount/release! handle))))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — flat in B
+;; ---------------------------------------------------------------------------
+
+(deftest one-body-runs-whatever-the-page-size
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (doseq [n [50 150 300]]
+      (fresh! {:articles n :tags shape/tag-count})
+      (let [handle (mount!)]
+        (try
+          (is (= n (count (q* handle ".article-list > .article-preview")))
+              (str n " boundaries mounted"))
+          (shape/reset-runs!)
+          (rt/dispatch! frame-id [:conduit/favorite (shape/slug-at (quot n 2))])
+          (mount/settle!)
+          (is (= {:cards 1 :page 0} (shape/runs))
+              (str "one body, at B = " n " — the dirty set is flat in B, which is
+                   how validation.md states this shape's win condition: a law,
+                   not a ratio"))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — the cascade, measured rather than discovered on a clock
+;; ---------------------------------------------------------------------------
+
+(deftest a-page-chrome-write-re-renders-every-row
+  (testing "**FINDING, not a repair.** A Hicasso boundary is a plain React
+           function component with no props-equality bail-out, so a write the
+           PAGE reads re-renders the page and React re-renders all 300 cards
+           beneath it — even though every card's props and every card's
+           subscription values are unchanged. Reagent's default
+           `shouldComponentUpdate` compares argv and stops exactly this
+           cascade, so this is a real difference on the axis the bar is set
+           on. Pinned here so it is a number in the record rather than
+           something a bulk clock discovers later and cannot attribute."
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (do
+        (fresh!)
+        (let [handle (mount!)]
+          (try
+            (let [before (favourite-counts handle)]
+              (shape/reset-runs!)
+              (rt/dispatch! frame-id [:conduit/show-your-feed])
+              (mount/settle!)
+              (is (= 1 (:page (shape/runs)))
+                  "the page re-ran once, which is correct — it reads the tab")
+              (is (= shape/article-count (:cards (shape/runs)))
+                  (str "and so did every one of the " shape/article-count
+                       " cards, none of whose reads moved"))
+              (is (= before (favourite-counts handle))
+                  "producing an identical DOM — which is why a DOM-only witness
+                   could never have seen this"))
+            (finally (mount/release! handle))))))))
+
+;; ---------------------------------------------------------------------------
+;; Teardown
+;; ---------------------------------------------------------------------------
+
+(deftest the-narrow-page-leaves-no-residue
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (async done
+      (fresh!)
+      (let [handle (mount!)]
+        (rt/dispatch! frame-id [:conduit/favorite (shape/slug-at moved-index)])
+        (mount/settle!)
+        (is (pos? (:cell-refs (rt/stats))))
+        (mount/unmount! handle)
+        (js/setTimeout (fn []
+                         (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                                (rt/residue)))
+                         (rt/reset-runtime!)
+                         (done))
+                       8)))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/ordinary.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/ordinary.cljs
@@ -1,0 +1,166 @@
+(ns re-frame.bench.hicasso.shapes.ordinary
+  "**TIER-1 SHAPE 1 — ORDINARY VIEWS**, the ~50-element form/list/layout
+  screen (charter §Use cases A1; rf2-2rtt6.51).
+
+  Ported, not invented: this is the comment column of RealWorld's article
+  page —
+  `examples/real-apps/realworld_resources/ui_views.cljs:325-411`, the
+  `comment-form` + `comment-card` pair and the
+  `div.row > div.col-xs-12.col-md-8.offset-md-2` that holds them. It is
+  the shape's three nouns in one screen and in one place: **layout** (the
+  page/container/row/column chrome), **form** (a controlled textarea with
+  a submit and an in-flight rule), **list** (keyed cards with a
+  per-row author-only control).
+
+  ## What the port changed, and what it did not
+
+  Three lines differ from the census original, and each is a claim rather
+  than a convenience:
+
+  1. **The row reads its own comment.** The census threads the comment
+     down as a prop — `[comment-card {:key (:id c) :comment c …}]` — which
+     is right for a substrate whose list boundary re-renders wholesale and
+     wrong for re-frame2, where the point of a row boundary is that it
+     reads its OWN row and moves when that row moves. So the row takes
+     `id` and reads `[:conduit/comment id]`. Same argument
+     `jsfb-model` makes about an index-keyed vector.
+  2. **`current-user` is no longer threaded.** The census passes it into
+     every card because a hook-shaped read has to sit at a fixed site and
+     the fixed site is the page. `sub` is an ordinary call, so the card
+     reads it where it uses it, and one prop disappears from the call site
+     and from the row's argument vector. That deletion is the collector's
+     whole ergonomic claim, stated on a real screen.
+  3. **The delete-status read moved inside the branch that uses it.** The
+     census reads `[:rf/mutation {:instance [:delete-comment slug id]}]`
+     unconditionally, at the top of the body, because it has to. Here it
+     sits inside `(when mine? …)`, so a card showing somebody else's
+     comment holds **two edges** and a card showing your own holds
+     **three**. A branch not taken contributes no edge — that is the
+     property `arm1_dogfood_dom_cljs_test` states as a number, and
+     `ordinary_dom_cljs_test` restates it on this screen.
+
+  Everything else is the census's: Conduit's class names, its
+  `data-testid` retail, its element nesting, its `mine?` rule, its
+  disabled-while-pending discipline, and its `favoritesCount`-era
+  camelCase field names.
+
+  ## What the port could not keep
+
+  `ui/route-link` — the census's author byline is a route-link, and the
+  census counts **106 of them** and calls the form tier-1. This arm has
+  no `route-link` (`front.intent`'s docstring says so in as many words),
+  so the byline is spelled `[:a {:href …}]`. That is a v0 gap, filed, not
+  a design position.
+
+  ## Reading the body
+
+  Nothing here is a Hicasso idiom an author has to learn: a `let`, a
+  `when`, a `for`, ordinary destructuring, hiccup vectors, and event
+  intents as data. The two things that are not plain Clojure —
+  `defview` minting a boundary, and `:re-frame.hicasso/value` as the
+  placeholder for the typed value — are one concept each.
+
+  Body forms are `.cljc`-compatible by construction (HD-020(d)): no
+  interop, no JS literal, no React import. SSR is out of v0; the
+  constraint that keeps it reachable is not."
+  (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.bench.hicasso.shapes.model :as m])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(def !body-runs
+  "How many bodies have run, by view name. The narrow-write claims on this
+  screen are counted here rather than asserted about."
+  (atom {}))
+
+(defn- ran! [view-name]
+  (swap! !body-runs update view-name (fnil inc 0))
+  nil)
+
+(defn reset-runs! [] (reset! !body-runs {}) nil)
+
+(defn runs-of [view-name] (get @!body-runs view-name 0))
+
+;; ---------------------------------------------------------------------------
+;; The list — one keyed card per comment
+;; ---------------------------------------------------------------------------
+
+(defn- profile-href
+  "A plain function called from a body: it inlines, mints no boundary, and
+  is where a `route-link` would go if this arm had one."
+  [username]
+  (str "#/profile/" username))
+
+(defview comment-card
+  "One comment — a keyed row. The delete control shows only for the
+  reader's own comments, and the in-flight read that greys it out is read
+  **inside that branch**, so it is an edge only the rows that can use it
+  pay for."
+  [{:keys [id]}]
+  (ran! :comment-card)
+  (let [{:keys [body createdAt author]} (sub [:conduit/comment id])
+        mine? (= (:username (sub [:conduit/user])) (:username author))]
+    [:div.card {:data-testid (str "comment-card-" id)}
+     [:div.card-block
+      [:p.card-text {:data-testid "comment-body"} body]]
+     [:div.card-footer
+      [:a.comment-author {:href (profile-href (:username author))}
+       [:img.comment-author-img {:src (m/avatar-src (:image author)) :alt ""}]
+       " "
+       (:username author)]
+      [:span.date-posted createdAt]
+      (when mine?
+        [:button.mod-options {:type        "button"
+                              :data-testid (str "delete-comment-" id)
+                              :aria-label  "Delete comment"
+                              :disabled    (sub [:conduit/delete-pending? id])
+                              :on-click    [:conduit/delete-comment id]}
+         [:i.ion-trash-a]])]]))
+
+;; ---------------------------------------------------------------------------
+;; The form — the controlled textarea, the submit, the in-flight rule
+;; ---------------------------------------------------------------------------
+
+(defview comment-form
+  "The composer. `:on-submit` carries an intent and takes the
+  census-weighted default — it auto-prevents, so there is no
+  `preventDefault` to remember and no options map to spell. The textarea
+  is controlled through the synchronous door: `:value` is a `sub`,
+  `:on-input` is an intent carrying the value placeholder."
+  [_]
+  (ran! :comment-form)
+  (let [pending? (sub [:conduit/comment-pending?])]
+    [:form.card.comment-form {:data-testid "comment-form"
+                              :on-submit   [:conduit/post-comment]}
+     [:div.card-block
+      [:textarea.form-control {:data-testid "comment-body-input"
+                               :rows        3
+                               :placeholder "Write a comment..."
+                               :value       (sub [:conduit/draft m/comment-draft-key])
+                               :disabled    pending?
+                               :on-input    [:conduit/edit-draft m/comment-draft-key
+                                             :re-frame.hicasso/value]}]]
+     [:div.card-footer
+      [:button.btn.btn-sm.btn-primary {:type        "submit"
+                                       :data-testid "comment-submit"
+                                       :disabled    pending?}
+       (if pending? "Posting…" "Post Comment")]]]))
+
+;; ---------------------------------------------------------------------------
+;; The layout — the census's own container/row/column chrome
+;; ---------------------------------------------------------------------------
+
+(defview screen
+  "The comment column of the article page. The list boundary reads the
+  order and nothing else, so a comment's own edit does not reach it."
+  [_]
+  (ran! :screen)
+  [:div.article-page
+   [:div.container.page
+    [:div.row
+     [:div.col-xs-12.col-md-8.offset-md-2
+      [:h2.comments-heading "Comments"]
+      [comment-form {}]
+      [:hr]
+      [:div.comments-list {:data-testid "comments-list"}
+       (for [id (sub [:conduit/comment-ids])]
+         [comment-card {:key id :id id}])]]]]])

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/ordinary.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/ordinary.cljs
@@ -67,6 +67,42 @@
             [re-frame.bench.hicasso.shapes.model :as m])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
+;; ---------------------------------------------------------------------------
+;; The screen's size, as arithmetic
+;; ---------------------------------------------------------------------------
+;;
+;; Written down for the same reason the large template's is: a page whose
+;; size is arithmetic is a page a witness can CHECK, and a page whose size
+;; is whatever the DOM says is a page that re-baselines itself on every
+;; markup edit. "~50 elements" is the charter's phrase for this shape, and
+;; a band would have let a card silently gain or lose an element inside it.
+
+(def chrome-elements
+  "article-page, container.page, row, column, h2, hr, comments-list."
+  7)
+
+(def form-elements
+  "form.card, card-block, textarea, card-footer, button."
+  5)
+
+(def elements-per-card
+  "card, card-block, card-text, card-footer, author link, avatar,
+  date-posted."
+  7)
+
+(def elements-per-own-card
+  "The same, plus the author-only delete control and its icon — the two
+  elements the `(when mine? …)` branch contributes."
+  9)
+
+(defn element-arithmetic
+  "The screen's element count, predicted rather than measured."
+  [comment-count mine-count]
+  (+ chrome-elements
+     form-elements
+     (* elements-per-card (- comment-count mine-count))
+     (* elements-per-own-card mine-count)))
+
 (def !body-runs
   "How many bodies have run, by view name. The narrow-write claims on this
   screen are counted here rather than asserted about."

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/ordinary_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/ordinary_dom_cljs_test.cljs
@@ -92,11 +92,18 @@
             (is (some? (q handle "button[data-testid=\"comment-submit\"]"))))
           (testing "list — keyed cards"
             (is (= comment-count (count (q* handle ".comments-list > .card")))))
-          (testing "and the whole screen is the ~50-element shape"
-            (let [n (lane/element-count (:container handle))]
+          (testing "and the whole screen is the ~50-element shape, at the size
+                   the arithmetic predicts"
+            (let [predicted (shape/element-arithmetic comment-count mine-count)
+                  n         (lane/element-count (:container handle))]
+              (is (= predicted n)
+                  (str "chrome " shape/chrome-elements " + form "
+                       shape/form-elements " + " (- comment-count mine-count)
+                       " cards x " shape/elements-per-card " + " mine-count
+                       " own cards x " shape/elements-per-own-card " = " predicted
+                       "; the DOM holds " n))
               (is (<= 40 n 60)
-                  (str "the ordinary-view shape is ~50 elements; this screen "
-                       "renders " n))))
+                  (str "and that is the charter's ~50-element shape (" n ")"))))
           (finally (mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/ordinary_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/ordinary_dom_cljs_test.cljs
@@ -1,0 +1,264 @@
+(ns re-frame.bench.hicasso.shapes.ordinary-dom-cljs-test
+  "**SHAPE 1'S WITNESS** — the ~50-element form/list/layout screen renders
+  what the census screen renders, and behaves like it (rf2-2rtt6.51).
+
+  Five claims, and the last two are the ones that could not be made by
+  looking at the file:
+
+  1. **It is the shape.** Layout, form and list are all present, and the
+     page lands in the ~50-element band the charter names.
+  2. **The list is the model's.** Five keyed cards, bodies from the model,
+     and the author-only delete control on exactly the reader's own two.
+  3. **The form works through the synchronous door** — the controlled
+     textarea echoes in the caller's turn, and submit creates a card and
+     clears the draft by explicit revision.
+  4. **Typing moves the form and nothing else.** The draft key is read by
+     the form boundary alone, so a keystroke re-runs one body out of
+     seven. A screen that re-rendered its list on every keystroke would
+     look identical in the DOM and pass claims 1–3.
+  5. **The conditional read costs what the branch costs.** A card showing
+     somebody else's comment holds two edges; a card showing your own
+     holds three. Asserted as an arithmetic identity over the whole
+     screen, so it fails if the read moves back to the top of the body.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against real React
+  DOM; under `:node-test` every claim degrades to a stated skip."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.shapes.model :as m]
+            [re-frame.bench.hicasso.shapes.ordinary :as shape]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     ;; Load-bearing, for the reason `arm1_dogfood_dom_cljs_test` records:
+     ;; the fixture's default leaves a dynamic-var frame stamp in scope and
+     ;; the carried-invariant chain resolves it BEFORE React context.
+     :ambient-frame nil
+     ;; The map shape, because the teardown claim is `async`: the cell and
+     ;; entry reapers are macrotasks, so the residue a React unmount leaves
+     ;; is not readable inside one synchronous test body.
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::shape-ordinary)
+
+(def ^:private seed
+  "Five comments, of which the reader's own are ids 0 and 4 — see
+  `model/comment-for`, which makes every fourth `mine?`."
+  {:articles 2 :comments 5 :tags 2})
+
+(def ^:private comment-count 5)
+(def ^:private mine-count 2)
+
+(defn- skip! [why]
+  (is true (str "shape 1's witness needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (lane/leave-act-environment!)
+  (m/make-frame! frame-id seed)
+  (m/reseed! frame-id seed)
+  (shape/reset-runs!)
+  frame-id)
+
+(defn- mount! []
+  (mount/root! (mount/fresh-container!) frame-id [shape/screen {}]))
+
+(defn- q [handle sel] (.querySelector (:container handle) sel))
+(defn- q* [handle sel] (array-seq (.querySelectorAll (:container handle) sel)))
+
+;; ---------------------------------------------------------------------------
+;; 1 — it is the shape the charter names
+;; ---------------------------------------------------------------------------
+
+(deftest the-screen-is-layout-form-and-list-at-the-fifty-element-band
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (testing "layout — the census's own container/row/column chrome"
+            (is (some? (q handle ".article-page")))
+            (is (some? (q handle ".container.page")))
+            (is (some? (q handle ".row > .col-xs-12.col-md-8.offset-md-2"))))
+          (testing "form — one controlled textarea with a submit"
+            (is (some? (q handle "form.comment-form")))
+            (is (some? (q handle "textarea.form-control")))
+            (is (some? (q handle "button[data-testid=\"comment-submit\"]"))))
+          (testing "list — keyed cards"
+            (is (= comment-count (count (q* handle ".comments-list > .card")))))
+          (testing "and the whole screen is the ~50-element shape"
+            (let [n (lane/element-count (:container handle))]
+              (is (<= 40 n 60)
+                  (str "the ordinary-view shape is ~50 elements; this screen "
+                       "renders " n))))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the list is the model's, including the per-row branch
+;; ---------------------------------------------------------------------------
+
+(deftest the-cards-carry-the-models-comments-and-the-author-only-control
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (doseq [i (range comment-count)]
+            (let [card (q handle (str "[data-testid=\"comment-card-" i "\"]"))]
+              (is (some? card) (str "card " i " rendered"))
+              (is (= (:body (m/comment-for i))
+                     (.-textContent (.querySelector card "[data-testid=\"comment-body\"]")))
+                  (str "card " i " carries the model's body"))))
+          (testing "the delete control appears on exactly the reader's own comments"
+            (is (= mine-count (count (q* handle ".mod-options")))
+                "two of five comments are the signed-in reader's")
+            (is (some? (q handle "[data-testid=\"delete-comment-0\"]")))
+            (is (nil? (q handle "[data-testid=\"delete-comment-1\"]"))
+                "and a comment that is not yours renders no delete control"))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the form, through the synchronous door
+;; ---------------------------------------------------------------------------
+
+(deftest the-controlled-textarea-echoes-in-the-callers-turn
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (is (= "" (.-value (q handle "textarea"))))
+          ;; The intent's own path: the arm's synchronous door, exactly as
+          ;; the lowered `:on-input` closure takes it.
+          (rt/dispatch! frame-id [:conduit/edit-draft m/comment-draft-key "nice piece"])
+          (mount/settle!)
+          (is (= "nice piece" (.-value (q handle "textarea")))
+              "the echo landed without waiting for a later turn")
+          (finally (mount/release! handle)))))))
+
+(deftest submitting-creates-a-card-and-clears-the-draft
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (rt/dispatch! frame-id [:conduit/edit-draft m/comment-draft-key "nice piece"])
+          (mount/settle!)
+          (rt/dispatch! frame-id [:conduit/post-comment])
+          (mount/settle!)
+          (is (= (inc comment-count) (count (q* handle ".comments-list > .card"))))
+          (is (= "nice piece"
+                 (.-textContent (q handle (str "[data-testid=\"comment-card-" comment-count "\"] "
+                                               "[data-testid=\"comment-body\"]"))))
+              "the new card carries what was typed")
+          (is (= "" (.-value (q handle "textarea")))
+              "and the draft cleared by explicit caller revision, never by
+               value equality")
+          (is (some? (q handle (str "[data-testid=\"delete-comment-" comment-count "\"]")))
+              "a comment you just posted is your own, so it gets the control")
+          (finally (mount/release! handle)))))))
+
+(deftest an-in-flight-post-disables-the-form
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (is (false? (.-disabled (q handle "textarea"))))
+          (rt/dispatch! frame-id [:conduit/begin [:post-comment]])
+          (mount/settle!)
+          (is (true? (.-disabled (q handle "textarea"))) "R-A10: busy discipline")
+          (is (true? (.-disabled (q handle "[data-testid=\"comment-submit\"]"))))
+          (is (= "Posting…" (.-textContent (q handle "[data-testid=\"comment-submit\"]"))))
+          (rt/dispatch! frame-id [:conduit/settle [:post-comment]])
+          (mount/settle!)
+          (is (false? (.-disabled (q handle "textarea"))))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — a keystroke moves one body out of seven
+;; ---------------------------------------------------------------------------
+
+(deftest typing-re-runs-the-form-boundary-and-nothing-else
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (is (= comment-count (shape/runs-of :comment-card)) "the mount ran every card once")
+          (shape/reset-runs!)
+          (rt/dispatch! frame-id [:conduit/edit-draft m/comment-draft-key "n"])
+          (mount/settle!)
+          (is (= 1 (shape/runs-of :comment-form))
+              "the keystroke re-ran the form")
+          (is (= 0 (shape/runs-of :screen))
+              "and did NOT re-run the screen, which reads the order and not the draft")
+          (is (= 0 (shape/runs-of :comment-card))
+              "and re-ran no card at all — the claim a DOM comparison cannot make")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — the conditional read costs what the branch costs
+;; ---------------------------------------------------------------------------
+
+(deftest a-card-that-cannot-delete-does-not-hold-the-delete-edge
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (let [edges (:edges (rt/stats))
+                ;; screen: [:conduit/comment-ids]                      = 1
+                ;; form:   [:conduit/comment-pending?] + [:conduit/draft k] = 2
+                ;; card:   [:conduit/comment id] + [:conduit/user]     = 2 each
+                ;; card (mine, additionally): [:conduit/delete-pending? id] = 1
+                predicted (+ 1 2 (* 2 comment-count) mine-count)]
+            (is (= predicted edges)
+                (str "a branch not taken contributes no edge: " comment-count
+                     " cards, " mine-count " of which can delete, is " predicted
+                     " edges — measured " edges))
+            (is (< edges (+ 1 2 (* 3 comment-count)))
+                "and it is strictly fewer than a declaration that named all
+                 three reads up front would have cost"))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; Teardown — read while the runtime still holds it
+;; ---------------------------------------------------------------------------
+;;
+;; `mount/release!` resets the runtime, so a residue reading taken after it
+;; answers zero however badly teardown went (rf2-2rtt6.48). This one is
+;; taken between the unmount and the reset.
+
+(deftest the-screen-leaves-no-residue
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (async done
+      (fresh!)
+      (let [handle (mount!)]
+        (rt/dispatch! frame-id [:conduit/edit-draft m/comment-draft-key "x"])
+        (mount/settle!)
+        (is (pos? (:cell-refs (rt/stats)))
+            "the mounted screen holds references, so the reading below is a
+             reading of something")
+        (mount/unmount! handle)
+        (js/setTimeout (fn []
+                         (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                                (rt/residue))
+                             "React's own cleanup released every edge, reference
+                              and cached entry")
+                         (rt/reset-runtime!)
+                         (done))
+                       8)))))


### PR DESCRIPTION
Charter §Use cases names five tier-1 shapes as v0's definition of done. Nothing under `implementation/freehand/test/re_frame/bench/hicasso/` was named for one — the dogfood screen and the 100-cell grid existed, the shape roster did not. This adds it for shapes 1–4. Shape 5 (controlled text) is already the best-witnessed shape of the five; what I found for it is below.

Bench/test tree only. No spec, no workflow, no `implementation/*/src`, no `shadow-cljs.edn`. **No clock read, no bench driver run, no timing row published** — siblings are measuring.

## The roster

`implementation/freehand/test/re_frame/bench/hicasso/shapes/` — five view namespaces and five witness namespaces.

| shape | page | boundaries | elements | reads |
|---|---|---|---|---|
| 1 ordinary views | RealWorld's article-page comment column | 7 | **51** | 15 |
| 2 large templates | RealWorld's home feed, **one boundary** | **1** | **1,202** | **141** |
| 3 bulk re-render | the same feed, one boundary per card | **301** | 5,129 | 603 |
| 4 narrow update | the same mount as 3 | 301 | 5,129 | 603 |

Ported, not invented. The screens are RealWorld/Conduit's (`examples/real-apps/realworld_resources/ui_views.cljs`), down to the class names, the `data-testid` retail, the element nesting and the `favoritesCount` camelCase the API hands back — the same corpus the earlier `:&` ergonomics work ported the article editor from. Every deviation is named in the file that makes it.

**Shapes 2 and 3 are deliberately the same screen at two boundary decompositions.** The card markup is written once (`shapes/card.cljs`); the large template *calls* it and it inlines, the feed *wraps* it in a four-line `defview` and it becomes a boundary. That is the entire diff, and `bulk_dom_cljs_test` asserts the two pages build byte-identical cards so it is a comparison rather than a claim.

## What the witnesses establish

- **Shape 1** — layout + form + list; the controlled textarea echoes in the caller's turn; submit creates a card and clears the draft by explicit revision; R-A10 busy discipline; **a keystroke re-runs one body out of seven**; and the conditional read costs 13 edges where naming all three reads up front would cost 18.
- **Shape 2** — the page is the size the *arithmetic* predicts (`chrome 19 + tags 10 + 69 × 17 = 1,202`), matched against the DOM, so a markup edit fails the gate rather than silently re-baselining what "the ~1,200-element shape" means. One boundary, 141 edges, one read-set entry.
- **Shape 3, the make-or-break row** — one commit re-runs **exactly 300 card bodies and zero page bodies**. The second half is the load-bearing one: a list that rebuilt its children would produce the identical DOM and the identical 300 re-renders, and would not be this shape. All 300 rendered counts are checked in one assertion.
- **Shape 4** — one body, one cell, at the index written to, by exactly one, on the same DOM node; and **flat in `B`** — one body at 50, 150 and 300 mounted boundaries, which is how validation.md states this shape's win condition (a law, not a ratio).
- **The ≤2-hook budget held at every shape**, counted at React's own dispatcher, never self-reported: 7 boundaries → 14 hooks, 301 → 602, 2-per-boundary at B = 50/150/300, and the headline row — **141 reads in one boundary still cost two hooks**, because `subscribe` closes over the read set alone. No shape cost a third hook.

## Findings (six beads filed, none repaired here)

The significant one: **a page-chrome write cascades to every row.** A write moving a key the *page* boundary reads re-renders the page, and React then re-renders all 300 cards — props unchanged, subscription values unchanged, resulting DOM byte-identical. A Hicasso boundary is a plain function component with no props-equality bail-out; Reagent's default `shouldComponentUpdate` compares argv and stops exactly this cascade. Measured (`narrow_dom_cljs_test/a-page-chrome-write-re-renders-every-row`) rather than left for a bulk clock to discover and be unable to attribute.

Also filed: shape 5's burst gap; framework subs unexercised by the roster; `route-link` absent; the `^{::h/prevent? true}` spelling; and the measurement the roster's pages suggest.

## Quality gates

Run foreground, in this worktree, logs kept worktree-local, exit codes echoed. clj-kondo is the CI-pinned **2026.04.15** (local npm ships 2025.10.23), invoked with the exact `--lint` list from `.github/workflows/lint.yml`.

| gate | exit | result |
|---|---|---|
| `npm run test:cljs` | **0** | Ran 12308 tests, 61608 assertions — 0 failures, 0 errors (clean rebuild, 2112 files) |
| `npm run test:browser` | **0** | Ran 958 tests, 6000 assertions — 0 failures, 0 errors (clean rebuild, 1093 files) |
| `scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`; per-ns isolation 17/17 standalone |
| clj-kondo 2026.04.15 | **0** | **errors: 0** (4530 warnings, all pre-existing; **0 findings of any level in the roster tree**) |

Counts reconcile against the run before the last two commits (957 tests / 5995 assertions): **+1 test** — the prevent-metadata click witness — and **+5 assertions**, being its four plus the one added when shape 1's element band became an arithmetic check.

One process note worth passing on: the first `test:cljs` after `test-fast-pr.sh` failed with a wall of `aborted par-compile … still waiting for` against `re-frame.story.*` namespaces this branch does not touch, and **no root error anywhere in the log**. It is the spine's per-ns isolation stage leaving `.shadow-cljs/builds/node-test` inconsistent; the incremental builds before it were compiling only 11 files. `rm -rf .shadow-cljs/builds/node-test` and a full rebuild is green. Both final runs above are clean rebuilds for that reason, so neither is reading a partly stale build.

TESTING.md matrix: these are `*_dom_cljs_test` namespaces under `re-frame.bench.hicasso.*`, so they run in **`:browser-test`** on every PR (the `^(?!re-frame\.freehand\.bench\.).*-dom-cljs-test$` selector — they are *not* in the excluded `:browser-test-freehand-bench` partition, and `_browser-dom-lane-partition.test.cjs` proves the two selectors still partition the tree), and in **`:node-test`** via `cljs-test$`, where every DOM claim degrades to a stated skip rather than a false green. No new build id, so no hot-zone touch.

### Mutation proof

Every witness was proved to look. Five faults planted in the **subjects**, never in the tests; two red runs, then reverted to green.

| fault (in the view, not the test) | caught by | run |
|---|---|---|
| conditional read hoisted out of its `when` branch | `ordinary/a-card-that-cannot-delete-does-not-hold-the-delete-edge` | A |
| one chrome element deleted from the template | `large_template/the-page-is-the-size-the-arithmetic-predicts` | A |
| page boundary made to read an article | `bulk/the-page-is-three-hundred-boundaries`, `bulk/one-commit-…-and-not-the-page` | A |
| a `react/useRef` added to a body | `hook_budget/every-shape-costs-exactly-two-hooks-per-boundary` ×4, `the-read-count-cannot-reach-the-hook-count` ×2 | A |
| a row made to read a **coarse** key (the whole articles map) | `narrow/one-write-re-runs-one-body-out-of-three-hundred`, `one-body-runs-whatever-the-page-size` ×3 | B |

- run A (4 faults): **exit 1**, 11 failures.
- run B (1 fault): **exit 1**, 5 failures.
- reverted: **exit 0**, 0 failures.

The first green run also found two real defects in the witnesses themselves, both fixed: the census gives its sidebar tag cloud and every card's tag row the same `.tag-list` class (so a bare selector answered 148, not 10), and avatar `src`s were URLs, so 300 cards opened 300 DNS lookups and filled the console with `ERR_NAME_NOT_RESOLVED` — they are `data:` URIs now, with the author token still in them.

## Fences

Surface B only. No candidate ledger, no compiler, no analyzer, no dual mode, no ViewCell-class object graph. **The runtime is untouched** — every file added is new, under `shapes/`, and nothing in `arm1/` or `front/` was edited (in particular not `front/codec.cljs`, which `worker/mapkeys-2rtt6-32` holds). The ≤2-hook shell and `subscribe`-closes-over-the-read-set-alone are preserved and now witnessed at four more shapes. All view bodies are `.cljc`-compatible by construction (HD-020(d)) — no interop, no JS literal, no React import.
