### PR TITLE
docs: HD-019 names the controlled-text converge as its one flushSync exception (rf2-ncn5p)

### DIFF
--- a/docs/design/hicasso/architecture.md
+++ b/docs/design/hicasso/architecture.md
@@ -159,8 +159,10 @@ hook + frame-context hook); shells use callback refs, never `useRef`.
 **The synchronous controlled-input door (HD-019)**: controlled-element intent
 lowering dispatches synchronously inside the discrete browser event; the store
 notification runs synchronously so React commits the echo in the same turn;
-`flushSync` is the evidence-gated last resort. Rejected/unchanged-model paths
-lean on React's own end-of-event restore; resets are by explicit caller
+`flushSync` is never the general default, and its single evidence-gated
+exception is the controlled-text converge in the element path (amended by
+`rf2-ncn5p`). Rejected/unchanged-model paths lean on React's own end-of-event
+restore for the value but not the caret; resets are by explicit caller
 revision, never value equality. The 100-cell grid witnesses prove the door.
 
 **Measured 2026-08-01 (rf2-n3dxw), and the lean holds for the value only.**

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -392,10 +392,22 @@ is the failure mode.
 **Ruling.** On the lean-React arm: a controlled element's event-vector lowering
 dispatches **synchronously inside the discrete browser event** (the
 dispatch-sync-class drain), and the spine's store notification runs synchronously
-so React commits the echo in the same turn; `flushSync` is the evidence-gated
-last resort, never the default. The rejected/unchanged-model path leans on
-React's own controlled restore (the value reasserts at end of the discrete
-event). Resets are by **explicit caller revision, never value equality** (the
+so React commits the echo in the same turn. `flushSync` is **never the general
+default**. The lean-React controlled-**text** converge is the single
+evidence-gated exception: it may flush the synchronous door's pending commit
+before React's controlled restore so value and caret are correct when the
+discrete event returns. That exception is exactly one audited call site —
+`front.controlled/converge!`, reached from the element path
+(`front.codec/native-element`), once per keystroke, on controlled text entry
+only (an `input` of a caret-bearing type or a `textarea`; non-nil `:value`; no
+authored `defaultValue`) and inert otherwise. A second call site, or any reach
+into another element or event path, needs fresh evidence and its own ruling;
+everywhere else "never the default" binds unchanged. The
+rejected/unchanged-model path leans on React's own controlled restore for the
+**value** (it reasserts at end of the discrete event) but **not** for the
+**caret**, which the arm takes itself in the element path — `rf2-n3dxw`
+measured the gap, `rf2-fki5d` closed it. Resets are by **explicit caller
+revision, never value equality** (the
 predecessor's ruled reset law, kept — `docs/design/freehand/decisions/D016-buffered-and-revision-controls.md`). The browser witnesses that prove the door
 are the 100-cell grid rows: same-turn echo, mid-string caret, selection, IME
 composition (`composing?`/keyCode-229), unchanged-model rejection, async
@@ -404,8 +416,26 @@ renderer (architecture.md, hard gate).
 **Rationale.** The harness's trap table is explicit: any design where the input
 value round-trips through an external store must *name* its synchronous door.
 This names it, and the first controlled-input commit cannot stall on an
-undecided mechanism.
-**Reopens** only if the witnesses fail on both mechanisms — which is K4.
+undecided mechanism. The `flushSync` exception is named for the same reason —
+an unnamed one is taste — and it is granted on measurement, not convenience.
+The flush is not what makes the echo land: dispatch and the store notification
+are already synchronous, so the value arrives without it. The flush exists to
+make the per-instance last-rendered record current *before* React's
+end-of-discrete-event controlled restore runs, because React's outer wrapper
+flushes pending sync work only in the `finally` immediately preceding that
+restore (verified against pinned React DOM 19.2.0), so a converge running
+inside the handler would otherwise read the previous commit's record. Removing
+only the `flushSync` reds four assertions with every caret reading `[5 5]`,
+**including the ordinary accepted keystroke**: the record goes one render
+stale, the converge writes the wrong value, and React's own restore repairs the
+value while throwing the caret away. That an *ordinary* keystroke breaks is
+what makes this an exception rather than an erosion (`rf2-ncn5p`, on the
+evidence recorded by `rf2-fki5d`).
+**Reopens** only if the witnesses fail on both mechanisms — which is K4. The
+`flushSync` exception additionally reopens if its named live-tree invariant row
+goes red — React mirroring controlled text into `defaultValue` is what makes
+the node-held record valid, and it is not a public React guarantee — or if any
+candidate second call site appears.
 
 ## HD-020 — v0 host mechanics: frame plumbing, hook ledger, error boundary, SSR posture
 

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -52,8 +52,12 @@ inside the discrete browser event**, and the subscription layer's store notifica
 runs synchronously too, so React commits the echo in the same turn. The value is
 back in the DOM before the browser's event handling finishes.
 
-`flushSync` is the evidence-gated last resort, never the default. If Hicasso ends up
-needing it routinely, that is a finding, not an implementation detail.
+`flushSync` is never the general default, and the one exception is named rather than
+left to taste: the controlled-text converge flushes the door's pending commit before
+React's end-of-event restore, so the caret survives a rejected or normalised
+keystroke. That exception is evidence-gated and scoped to controlled text entry in
+the element path. Needing `flushSync` anywhere else would still be a finding, not an
+implementation detail.
 
 ## What the door guarantees
 

--- a/docs/design/hicasso/studio/controlled-input-two-implementations.md
+++ b/docs/design/hicasso/studio/controlled-input-two-implementations.md
@@ -268,14 +268,18 @@ asserts the invariant against a live React tree, including that it *moves*
 when the rendered value moves. If React ever stops mirroring, that row goes
 red by name instead of five caret rows going quietly wrong.
 
-#### One thing for the decisions record
+#### What went to the decisions record
 
-HD-019 says `flushSync` is "the evidence-gated last resort, never the
-default". This makes it the default for every controlled element, and the
+HD-019 used to say `flushSync` was "the evidence-gated last resort, never the
+default", and this makes it the default for every controlled text element. The
 evidence gate is met — the mutation probe above shows the ordinary accepted
-keystroke regressing without it — but the ruling's text and the code now
-disagree in letter. Raised rather than resolved here; the amendment is
-Mike's.
+keystroke regressing without it, not merely the refusal — so the tension raised
+here was resolved by amending the record rather than the code (`rf2-ncn5p`).
+HD-019 now reads that `flushSync` is never the *general* default and that this
+converge is its single evidence-gated exception, scoped to the one audited call
+site in the element path and to controlled text entry. Anywhere else the old
+blanket binds unchanged: a second call site needs fresh evidence and its own
+ruling.
 
 ### C — pin the selector
 
@@ -311,8 +315,9 @@ element path — a UIx consumer is not on that path and does not get it.
 - HD-019's "rejected/unchanged-model paths lean on React's own end-of-event
   restore" is **confirmed for the value and refuted for the caret** — and the
   caret is now the *arm's*, taken in the element path rather than leaned on
-  (`rf2-fki5d`, Option B above). HD-019's `flushSync` clause needs the
-  amendment noted under B.
+  (`rf2-fki5d`, Option B above). HD-019's `flushSync` clause **has** the
+  amendment noted under B (`rf2-ncn5p`), and HD-019's own text now carries the
+  caret half of this correction rather than leaving it to this page.
 - `rf2-n3dxw`'s headline residue is **answered for Arm 1**: a refused
   keystroke converges in the same turn with the caret at the position before
   it. Two things it recorded are not answered and are not rounded up — the


### PR DESCRIPTION
Implements the operator's ruling on **rf2-ncn5p** (delegated, 2026-08-02): option (a) — **amend HD-019**. The shipped converge stands; no redesign.

HD-019 ruled `flushSync` "the evidence-gated last resort, **never the default**". The controlled converge shipped by rf2-fki5d (PR #7371) calls it once per keystroke on every controlled text element, so it *is* the default there. That worker raised the conflict rather than papering over it, and declined to make a design-law amendment on its own authority. This PR closes that gap.

## The amendment

**Before** (`docs/design/hicasso/decisions.md`, HD-019):

> `flushSync` is the evidence-gated last resort, never the default.

**After**, in the ruling's narrower controlled-**text** formulation:

> `flushSync` is **never the general default**. The lean-React controlled-**text** converge is the single evidence-gated exception: it may flush the synchronous door's pending commit before React's controlled restore so value and caret are correct when the discrete event returns.

## Why this is an exception and not an erosion

The evidence gate is met and is already on main. Removing **only** the `flushSync` reds four assertions and sends every caret to `[5 5]` — **including on an ordinary accepted keystroke**, not merely the refusal. Without it the per-instance last-rendered record is one render stale, the converge writes the wrong value, and React's own restore repairs the value while throwing the caret away.

The rationale records the mechanism precisely, because it is easy to misread: the flush is **not** what makes the echo land (dispatch and store notification are already synchronous). It makes the record current *before* React's end-of-discrete-event controlled restore, since React's outer wrapper flushes pending sync work only in the `finally` immediately preceding that restore (verified against pinned React DOM 19.2.0).

## How the exception is scoped so it cannot be read as a repeal

An exception that reads "when you need to" is a repeal. This one is fenced to:

- **exactly one audited call site** — `front.controlled/converge!`, reached from the element path (`front.codec/native-element`), once per keystroke;
- **controlled text entry only** — an `input` of a caret-bearing type or a `textarea`; non-nil `:value`; no authored `defaultValue`; inert otherwise;
- **a second call site, or any reach into another element or event path, needs fresh evidence and its own ruling**; everywhere else "never the default" binds unchanged.

`Reopens` also grew a clause: the exception reopens if the named live-tree invariant row goes red (React mirroring controlled text into `defaultValue` is what makes the node-held record valid, and it is not a public React guarantee).

## The citation set — swept, and wider than the ruling's named two

The ruling named a two-file edit. The blanket was repeated at **four** sites, all now corrected in place (this repo rewrites stale claims rather than appending beside them):

| File | Was | Now |
| --- | --- | --- |
| `docs/design/hicasso/decisions.md` | HD-019, the normative source | amended clause + rationale + reopens |
| `docs/design/hicasso/studio/controlled-input-two-implementations.md` | "One thing for the decisions record" — raised tension, "the amendment is Mike's" | "What went to the decisions record" — points at the amendment |
| `docs/design/hicasso/architecture.md` | "`flushSync` is the evidence-gated last resort." | names the exception |
| `docs/design/hicasso/draft-guide/04-controlled-inputs.md` | "the evidence-gated last resort, never the default" | names the exception; keeps "anywhere else would be a finding" |

Also corrected in HD-019: its adjacent claim that the rejected/unchanged-model path leans on React's own restore. Main already records that as **confirmed for the value and refuted for the caret** (`rf2-n3dxw` measured the gap, `rf2-fki5d` closed it) — architecture.md and the studio page both carried the correction while HD-019 itself did not. Leaving it would have left the record internally incoherent beside a new exception whose whole subject is caret correctness. Flagged as slightly beyond the ruling's letter.

`docs/EP/EP-0038` mentions HD-019 only as a one-line index entry ("the synchronous door") and needed no change.

## Quality gates

Surface edited is **`docs/design/hicasso/**` only** (4 files, prose; no code, no tables).

- `python scripts/check_doc_slugs.py` (whole corpus) — **exit 0**. **This is the gate that actually covers this PR**: `DEFAULT_ROOTS` includes `docs` and `design` is not in `EXCLUDE_DIR_NAMES`, so the tree is scanned for link targets and heading anchors.
- `sh scripts/test-fast-pr.sh` — **exit 0** (`PASS fast PR spine`). Ran `mkdocs build --strict` internally (built in 43.31s).
- `mkdocs build --strict` does **not** reach `docs/design/**` (`exclude_docs` keeps `design/hicasso/` out of the site), so it is *not* the covering gate here — noted per the brief. It is green regardless, via the spine.
- **Tables**: none touched. Verified mechanically — no added line in the diff contains a `|`.
- **Anchor rename**: the studio heading `#### One thing for the decisions record` became `#### What went to the decisions record`. Checked for inbound links to the old anchor across the corpus first — there are none — and the slug check is green.

## Coordination

`worker/cascade-2rtt6-52` ships an **HD-006** amendment and touches this same `decisions.md`. No conflict expected: HD-006 is at line 123, both hunks here start at line 392 — roughly 270 lines apart.
