### PR TITLE
hicasso: prevent is an in-band head, assertable by equality (rf2-2rtt6.57)

### DIFF
--- a/docs/design/hicasso/README.md
+++ b/docs/design/hicasso/README.md
@@ -8,7 +8,7 @@ by [EP-0038](../../EP/EP-0038-the-hicasso-view-layer-programme.md).
 | Document | Contents |
 |---|---|
 | [charter.md](charter.md) | Product identity, evidence base, goals, constraints, use-case roster, known losses |
-| [decisions.md](decisions.md) | HD-001…HD-025 — every design decision, resolved, with rationale and reopen conditions |
+| [decisions.md](decisions.md) | HD-001…HD-026 — every design decision, resolved, with rationale and reopen conditions |
 | [hd-002-adjudication.md](hd-002-adjudication.md) | HD-002 adjudicated — the tripwire, the boundary, ownership, and the hypotheses under test |
 | [architecture.md](architecture.md) | The architecture space, the one live arm (and the withdrawn second), the shared front half, inside-React feasibility, the sub-read mechanism ladder |
 | [validation.md](validation.md) | The bar, the budgets, the P0→P1→P2 plan, witnesses, tournament and measurement discipline, kill criteria |

--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -94,10 +94,19 @@ steady-state change belongs on an effect, not on the ref.
 - A literal vector at an event position is the intent; `::h/value` is the value
   placeholder (~97% of corpus handler sites become pure data). Ordinary functions
   remain legal at event positions.
-- Census-weighted policy defaults: `:on-submit` intents auto-prevent (opt-out
-  available); a data key-map `{:on-keydown {"Enter" [...] "Escape" [...]}}` with
-  the composition law centralised — a composing Enter (IME, including the
+- Census-weighted policy defaults: `:on-submit` intents auto-prevent (the rare
+  opt-out is the `h/fn` escape — a callback holds the event, so it owns it); a
+  data key-map `{:on-keydown {"Enter" [...] "Escape" [...]}}` with the
+  composition law centralised — a composing Enter (IME, including the
   keyCode-229 legacy signal) commits nothing.
+- Everywhere else, prevention is opted **in** by one reserved head,
+  `[::h/prevent [:conduit/show-your-feed]]` (HD-026) — the shape is the
+  anchor-acting-as-a-button, which a click default cannot absorb because a
+  modifier-click on a real link must still open a tab. It is a head rather than metadata on the intent
+  because metadata does not participate in `=`, and HD-021's headless door reads
+  intent vectors by equality. The grammar is closed: exactly one inner intent
+  vector, unwrapped before `::h/value` is looked for, and anything else is
+  `:rf.error/hicasso-malformed-prevent` naming the position.
 - Callbacks generated from intents close over the boundary's frame (resolved once
   per boundary from the substrate's single internal context) so they remain valid
   when the browser invokes them after render scope unwinds.

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1,4 +1,4 @@
-# Hicasso — decisions (HD-001 … HD-025)
+# Hicasso — decisions (HD-001 … HD-026)
 
 Every design decision for the Hicasso programme, resolved. Each record carries the
 ruling, the decisive rationale, and the condition under which it reopens. These
@@ -754,3 +754,101 @@ identical, and driven through React and a real DOM in
 `arm1/presence_dom_cljs_test`.
 **Reopens** if a witness needs a phase on a node the boundary genuinely cannot see
 and `:rf/phase` cannot reach.
+
+## HD-026 — `preventDefault` is opted in by a reserved HEAD, not by metadata
+
+**Ruling.** The `^{::h/prevent? true}` metadata spelling is **retired**. Prevention
+is opted in by **one reserved intent head** at an event position:
+
+```clojure
+[:a.nav-link {:href "#" :on-click [::h/prevent [:conduit/show-your-feed]]}]
+```
+
+The grammar is **closed, and this is all of it**: `[::h/prevent INTENT]` — exactly
+two forms, the second a non-empty intent vector that is not itself a decorator.
+Anything else is `:rf.error/hicasso-malformed-prevent`, **naming the position**.
+The decorator is **classified and unwrapped at lowering time**, once per render,
+*before* marker analysis — so `::h/value` and `::h/checked` compose inside a
+prevented intent — and what reaches `dispatch` is the ordinary inner vector.
+Key-map branches are accepted through the same call, because a branch is lowered by
+the same code.
+
+**Scope, fenced.** `:on-submit` auto-prevent is **unchanged**; the rare form that
+wants a real submission opts out through the existing `h/fn` escape, because a
+callback is handed the event and the event is the callback's (HD-024). There is
+**no** `::h/allow-default`, **no** event-options map, and **no** modifier language;
+a symmetric allow head is added only if dogfooding produces a real site needing
+both native submission *and* equality-based structural testing. Auto-prevent cannot
+absorb the click case in the other direction either: a click intent on a real link
+must **not** prevent by default — modifier-click, open-in-new-tab — so the
+anchor-acting-as-a-button genuinely needs an explicit opt-in, and this ruling only
+picks its spelling.
+
+**Rationale — one defect is disqualifying, and it is a correctness one.**
+**Metadata does not participate in `=`.** HD-021's headless door returns the tree
+as data and sells itself on *intent vectors assertable by equality*, and the
+measured probe is unambiguous:
+
+```clojure
+(= [:app/go] (with-meta [:app/go] {::h/prevent? true})) ;=> true
+(= [:app/go] [::h/prevent [:app/go]])                   ;=> false
+```
+
+So the one axis the annotation carried was exactly the axis a structural test could
+not see — and neither could a hash-keyed lookup, a log line or a snapshot, since
+metadata is omitted from printing unless `*print-meta*`. `preventDefault` changes
+the event's `canceled` flag per the DOM standard: it is **behaviour**, not
+annotation, and a spelling that hides behaviour from the product's own
+structural-testing story contradicts that story. Two further defects stand
+alongside and would not alone have forced the change: the metadata value **does not
+fit on the attribute key's line at any sane indent**, so the one attribute carrying
+behaviour is the one that looks like a mistake; and `^{…}` before a vector **reads
+as a type hint**, invisible to a reader scanning for behaviour. The shape is not
+exotic — the census's home page has three anchors-acting-as-buttons (feed tabs, tag
+pills) and every Bootstrap-shaped nav has more, against ten such sites across the
+two RealWorld implementations and 35 direct `preventDefault` calls in `examples/`.
+
+**Prior art: Replicant, the most data-oriented neighbour** (verified 2026-08-02,
+replicant.fun). **Taken:** its shape for *data that means behaviour* is a vector
+with a namespaced-keyword head and positional payload — `{:replicant/on-render
+[::update-map-places places]}` — which is the shape this ruling picks, arrived at
+independently and confirmed against the library that has pushed the school
+furthest. **Declined, deliberately:** Replicant carries listener modifiers as
+sibling attribute keys (`:replicant.event/capture`, `:replicant.event/once`,
+`:replicant.event/passive`), which is the sibling-attribute option this ruling
+rejects — an intent in Hicasso **travels as a value** (a view may hand one to a
+child, which places it on an element), and a policy written in a sibling key cannot
+travel with it. **Also declined:** Replicant *infers no meaning* from handler data,
+so it owes no diagnostic and offers none. Hicasso's roster is interpreted —
+`::h/value`, `::h/checked`, and now `::h/prevent` — so it owes one, and the
+refusal follows Freehand's house style instead: state the legal grammar, then what
+was found, then the form to write (`events/event-plan`'s `:rf.error/view-bad-event`
+is the model, down to the imperative `recovery` key).
+
+**Rejected.** (b) A keyed attribute `{:intent [...] :prevent? true}` makes maps
+legal at event positions — a second broad calling convention at every event key,
+against the census's ~97%-literal-vector grain, and an invitation to the options
+language HD-024's collapse deliberately deleted (it is precisely Freehand's
+`{:event [...] :prevent-default true}`). (c) Keep the metadata and add a
+headless-door lint — patches the equality defect with tooling that would have to
+duplicate the semantic knowledge, while defects 1 and 3 stand and printing stays
+blind. Also rejected: a sibling element attribute (separates the policy from the
+intent it decorates, and cannot travel with it); and requiring `h/fn` for the
+recurring click case (discards the data benefit exactly where a one-head wrapper
+preserves it).
+
+**Cost, stated.** One reserved head and one extra pair of brackets. Against K5 it
+is a swap rather than a growth: the metadata *mechanism* is deleted — one fewer
+kind of place for behaviour to hide — and one member joins a roster that is a
+list rather than a convention. The event-time path acquires nothing: the
+classification is one `=` against the head, taken once per lowered position per
+render, and the closure that runs on the click is the same closure as before.
+
+**Demonstrated, not asserted.** The equality property is asserted directly in
+`front/intent_cljs_test/a-prevented-intent-is-assertable-by-equality` — including
+the retired spelling's `=`, `hash` and `pr-str` blindness, stated as the defect it
+was — and the browser half, which no equality can show, is a **real cancelable
+click** on the census feed tab against an un-decorated control on the same page:
+`shapes/large_template_dom_cljs_test/the-prevent-head-is-what-prevents`.
+**Amends** HD-021: its equality promise now holds for the prevent axis at the spine
+shapes. **Reopens** on the dogfooding condition named under Scope.

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -4,7 +4,7 @@
 > *designed* surface so it can be read before it is built. Spellings marked
 > **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
 > is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-025).
+> source: [decisions.md](../decisions.md) (HD-001…HD-026).
 
 Handler attributes are where a data-oriented view layer usually gives up. You have
 been writing pure data all the way down the tree, and then `:on-click` needs a
@@ -118,8 +118,33 @@ An intent vector at `:on-submit` prevents the browser's default navigation:
 ```
 
 No `(.preventDefault e)`. It is census-weighted policy — forms in the corpus wanted
-it every time — so the runtime does it and offers an opt-out for the rare case that
-doesn't. The opt-out's spelling is not in the record; see **Not settled yet**.
+it every time — so the runtime does it. For the rare form that wants a real
+submission, write the handler as `h/fn`: a callback is handed the event, so the
+runtime leaves it alone and the event is yours (HD-026).
+
+### Everywhere else, prevention is one head
+
+A click does **not** auto-prevent, and must not: a modifier-click on a real link
+has to open a tab. So the anchor-acting-as-a-button — the feed tab, the tag pill,
+the pagination link — opts in, and the opt-in is part of the intent:
+
+```clojure
+[:a.nav-link {:href "#" :on-click [::h/prevent [:conduit/show-your-feed]]}]
+```
+
+`[::h/prevent INTENT]` and nothing else: exactly one inner intent vector, which is
+what gets dispatched. Write it wrong — two payloads, a keyword instead of a vector,
+a decorator inside a decorator — and you get `:rf.error/hicasso-malformed-prevent`
+naming the attribute you wrote it at, at render time rather than at the click.
+
+It is a head rather than metadata on the vector for a reason worth knowing, because
+it is the reason you can test it: **metadata does not participate in `=`**.
+`(= [:app/go] ^{::h/prevent? true} [:app/go])` is `true`, so an annotation is
+invisible to a structural test that compares the tree — and to `pr-str`, and to
+anything hashing the intent. A head is visible to all three.
+
+Markers still work inside it: `[::h/prevent [:filter/set ::h/value]]` prevents and
+materializes, because the decorator is unwrapped before the markers are looked for.
 
 ### The key map
 
@@ -182,7 +207,7 @@ dispatch, and a plain `(fn …)` when you want to read it and do something else.
 
 | Question | Status |
 |---|---|
-| The auto-prevent opt-out spelling | **Not addressed.** HD-002-era record says "opt-out available" and stops there |
+| The auto-prevent opt-out spelling | **Settled** (HD-026). The submit opt-out is `h/fn`; prevention elsewhere is opted in by the `[::h/prevent …]` head, and the metadata spelling this page once carried is retired |
 | Whether markers other than `::h/value` exist | **Not addressed.** The charter names "the intent-marker roster and its one pure materializer" as a micro-mechanic worth copying from the predecessor, but only `::h/value` is spelled. A checked-state marker for checkboxes is an obvious gap this guide could not fill honestly — the example on [Getting started](01-getting-started.md) sidesteps it by passing the id and letting the handler flip the value |
 | Which attributes get intent lowering | **Not addressed.** `:on-click`, `:on-input`, `:on-submit`, and `:on-keydown` appear in the record; whether lowering is universal across `:on-*` or a named roster is unstated |
 | The key map's key vocabulary | Key names appear as strings (`"Enter"`, `"Escape"`); whether keywords are accepted, and how modifiers are spelled, is unstated |

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -184,7 +184,8 @@ explicitly.**
 
 ## Troubleshooting
 
-No Hicasso error ids exist yet; this table names mechanisms.
+This table names mechanisms rather than error ids; the ids the record does mint
+are named in the sections above.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/dogfood.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/dogfood.cljs
@@ -182,8 +182,8 @@
 
 (defn new-item-intents
   "The same, for the one controlled field at the head of the screen. The
-  submit intent carries no explicit prevent metadata, so it takes the
-  position's census-weighted default."
+  submit intent carries no `::h/prevent` head, so it takes the position's
+  census-weighted default."
   []
   {:on-input    [:dogfood/edit-draft new-draft-key :re-frame.hicasso/value]
    :on-submit   [:dogfood/create]

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -9,6 +9,7 @@
       [:form   {:on-submit [:todo/create]}]
       [:input  {:on-key-down {\"Enter\"  [:todo/commit id]
                               \"Escape\" [:todo.ui/cancel id]}}]
+      [:a      {:href \"#\" :on-click [::h/prevent [:todo/show-done]]}]
 
   authoring.md's whole event surface, and nothing beyond it. Four
   behaviours, dispatched on the *shape* of the value at an `on-*` prop
@@ -112,11 +113,23 @@
 
   ## The policy defaults
 
-  - **`:on-submit` auto-prevents** (authoring.md, census-weighted). The
-    opt-out is metadata on the intent — `^{::h/prevent? false} [:ev]` —
-    which costs no new prop, no new spelling, and no second calling
-    convention. The same metadata opts *in* at any other event position,
-    so there is one mechanism rather than a default and an override.
+  - **`:on-submit` auto-prevents** (authoring.md, census-weighted), and
+    the opt-out for the rare form that wants a real submission is the
+    existing `h/fn` escape — a callback is handed the event, so the event
+    is the callback's.
+  - **Anywhere else, prevention is opted IN by one reserved head**:
+    `[::h/prevent [:conduit/show-your-feed]]`. It is a head rather than
+    metadata because **metadata does not participate in `=`**, and
+    HD-021's headless door sells itself on intent vectors assertable by
+    equality: `(= [:app/go] ^{::h/prevent? true} [:app/go])` is `true`,
+    so the one axis the annotation carried was the one axis a structural
+    test — or a log, or a snapshot — could not see. `preventDefault`
+    changes the event's `canceled` flag; it is behaviour, and behaviour a
+    spelling hides from the product's own testing story is a defect
+    rather than a taste. A click cannot simply auto-prevent the way
+    submit does: a modifier-click on a real link must still open a tab,
+    so the anchor-acting-as-a-button needs an explicit opt-in and this is
+    its spelling (HD-026).
   - **The key-map is composition-gated, centrally.** A key event arriving
     mid-composition commits nothing: `isComposing`, or the legacy
     keyCode-229 signal that is all some IMEs on some browsers ever send.
@@ -307,10 +320,12 @@
   "`::h/checked` — the event target's current checked state."
   :re-frame.hicasso/checked)
 
-(def prevent-key
-  "`::h/prevent?` — metadata on an intent vector, opting `.preventDefault`
-  in or out against the position's default."
-  :re-frame.hicasso/prevent?)
+(def prevent-head
+  "`::h/prevent` — the one reserved intent HEAD. `[::h/prevent [:app/go]]`
+  at an event position dispatches `[:app/go]` and calls `.preventDefault`
+  first. See [[classify-intent]] for the grammar and why it is a head
+  rather than metadata."
+  :re-frame.hicasso/prevent)
 
 (def ^:private marker-readers
   "The roster, as marker → the reader that pulls its value off the event
@@ -385,23 +400,67 @@
   (let [n (name k)]
     (or (= n "on-submit") (= n "onSubmit"))))
 
-(defn- prevent?
-  "Does the intent at `k` prevent the default action? The position's
-  default, overridden either way by `^{::h/prevent? …}` on the intent."
-  [k intent]
-  (let [m (meta intent)]
-    (if (contains? m prevent-key)
-      (boolean (get m prevent-key))
-      (prevent-by-default? k))))
+(defn prevent-head?
+  "Is `v` the `::h/prevent` decorator? One `=` against the vector's first
+  element. Asked once per lowered position, never per event."
+  [v]
+  (and (vector? v) (= prevent-head (nth v 0 nil))))
+
+(defn- unwrap-prevent
+  "CLASSIFY AND UNWRAP. `v` is the decorator; answer the intent inside it,
+  refusing anything that is not exactly one inner intent vector.
+
+  **The grammar is closed, and this is the whole of it.** `[::h/prevent
+  INTENT]` — two forms, the second a non-empty vector that is not itself a
+  decorator. Everything else is
+  `:rf.error/hicasso-malformed-prevent`, named at the position it was
+  written at. There is no options map, no second decorator, no modifier
+  language: one reserved head in the same tiny roster as `::h/value`, so
+  the thing that keeps it closed is that the roster is a list rather than
+  a convention.
+
+  It is deliberately NOT a walker. The decorator is recognised at ONE
+  known position — a vector at an event position, which lowering already
+  had in its hand — and the answer is a classification taken once per
+  render. Nothing descends into the intent, and the inner vector stays
+  ordinary data all the way to `dispatch`."
+  [k v]
+  (let [inner (nth v 1 nil)]
+    (when-not (and (= 2 (count v))
+                   (vector? inner)
+                   (seq inner)
+                   (not (prevent-head? inner)))
+      (fail! :rf.error/hicasso-malformed-prevent
+             'front.intent/lower-prop
+             (str "The " (pr-str prevent-head) " decorator at " (pr-str k)
+                  " wraps EXACTLY ONE intent vector; this one "
+                  (cond
+                    (not= 2 (count v))    (str "carries " (dec (count v))
+                                               " forms after the head")
+                    (prevent-head? inner) "wraps another decorator, and it does not nest"
+                    (not (vector? inner)) (str "wraps " (pr-str inner)
+                                               ", which is not an intent vector")
+                    :else                 "wraps the empty vector, which names no event")
+                  ". Write [" (pr-str prevent-head) " [:my-event …]].")
+             :wrap-exactly-one-intent-vector
+             {:position k :form v}))
+    inner))
 
 (defn- intent-handler
   "Lower one intent vector into the closure the browser will call. The
   three axes — prevent, markers, dispatch — are all resolved here, so the
-  event path is the shortest one this intent can have."
-  [k intent]
-  (let [dispatch (require-dispatch intent)
-        prevent  (prevent? k intent)
-        dynamic  (markers? intent)]
+  event path is the shortest one this intent can have.
+
+  Classification comes FIRST, so the markers compose inside a prevented
+  intent: `[::h/prevent [:filter/set ::h/value]]` is unwrapped before
+  [[markers?]] is ever asked, and the materializer then sees the ordinary
+  intent it has always seen."
+  [k v]
+  (let [decorated (prevent-head? v)
+        intent    (if decorated (unwrap-prevent k v) v)
+        dispatch  (require-dispatch intent)
+        prevent   (or decorated (prevent-by-default? k))
+        dynamic   (markers? intent)]
     (cond
       (and prevent dynamic)       (fn [e] (.preventDefault e) (dispatch (materialize intent e)))
       prevent                     (fn [e] (.preventDefault e) (dispatch intent))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -323,8 +323,8 @@
 (def prevent-head
   "`::h/prevent` — the one reserved intent HEAD. `[::h/prevent [:app/go]]`
   at an event position dispatches `[:app/go]` and calls `.preventDefault`
-  first. See [[classify-intent]] for the grammar and why it is a head
-  rather than metadata."
+  first. See [[unwrap-prevent]] for the closed grammar, and the policy
+  defaults above for why it is a head rather than metadata."
   :re-frame.hicasso/prevent)
 
 (def ^:private marker-readers

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent_cljs_test.cljs
@@ -238,9 +238,10 @@
         "the retired metadata is no longer a spelling of anything")))
 
 (deftest the-retired-metadata-spelling-does-nothing
-  ;; Not a formality: an author porting old code must find out at the click,
-  ;; not never. The metadata is inert, so the anchor navigates — which is
-  ;; loud in the browser and is what the DOM witness asserts.
+  ;; Not a formality. The retirement is real: the annotation is inert, so a
+  ;; port that missed an anchor navigates on the first click rather than
+  ;; quietly keeping the old behaviour. Pinned here so "retired" is a
+  ;; measured fact and not a claim in a docstring.
   (let [!seen      (recorder)
         !prevented (atom false)
         h (lowered (dispatching !seen) :on-click

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent_cljs_test.cljs
@@ -143,7 +143,8 @@
     (is (false? (intent/markers? [:e 1 "two"])))))
 
 ;; ---------------------------------------------------------------------------
-;; Submit auto-prevent, and the one metadata mechanism that overrides it
+;; Submit auto-prevent, and the one reserved head that opts in elsewhere
+;; (HD-026)
 ;; ---------------------------------------------------------------------------
 
 (deftest on-submit-auto-prevents
@@ -159,22 +160,36 @@
     ((lowered (dispatching (recorder)) :on-click [:ping]) (ev {:prevented !prevented}))
     (is (false? @!prevented))))
 
-(deftest prevent-metadata-overrides-the-positions-default-in-both-directions
-  (testing "opting out of the submit default"
-    (let [!seen (recorder)
+(deftest the-prevent-head-opts-in-and-dispatches-the-inner-intent
+  (testing "the anchor-acting-as-a-button, which is the shape this exists for"
+    (let [!seen      (recorder)
+          !prevented (atom false)
+          h (lowered (dispatching !seen) :on-click
+                     [:re-frame.hicasso/prevent [:conduit/show-your-feed]])]
+      (h (ev {:prevented !prevented}))
+      (is (true? @!prevented) "the browser does not follow the href")
+      (is (= [[:conduit/show-your-feed]] @!seen)
+          "and what reaches dispatch is the INNER vector — ordinary data, with no
+           decorator on it")))
+  (testing "the decorator is unwrapped BEFORE marker analysis, so the markers
+            compose inside a prevented intent"
+    (let [!seen      (recorder)
+          !prevented (atom false)
+          h (lowered (dispatching !seen) :on-input
+                     [:re-frame.hicasso/prevent
+                      [:filter/set :re-frame.hicasso/value]])]
+      (h (ev {:value "milk" :prevented !prevented}))
+      (is (true? @!prevented))
+      (is (= [[:filter/set "milk"]] @!seen))))
+  (testing "the submit default still holds under the head, and is not doubled"
+    (let [!seen      (recorder)
           !prevented (atom false)
           h (lowered (dispatching !seen) :on-submit
-                     (with-meta [:todo/create] {:re-frame.hicasso/prevent? false}))]
+                     [:re-frame.hicasso/prevent [:todo/create]])]
       (h (ev {:prevented !prevented}))
-      (is (false? @!prevented))
+      (is (true? @!prevented))
       (is (= [[:todo/create]] @!seen))))
-  (testing "opting in anywhere else"
-    (let [!prevented (atom false)
-          h (lowered (dispatching (recorder)) :on-click
-                     (with-meta [:ping] {:re-frame.hicasso/prevent? true}))]
-      (h (ev {:prevented !prevented}))
-      (is (true? @!prevented))))
-  (testing "auto-prevent composes with the value marker"
+  (testing "auto-prevent composes with the value marker, decorator or not"
     (let [!seen (recorder)
           !prevented (atom false)
           h (lowered (dispatching !seen) :on-submit
@@ -182,6 +197,103 @@
       (h (ev {:value "milk" :prevented !prevented}))
       (is (true? @!prevented))
       (is (= [[:todo/create "milk"]] @!seen)))))
+
+(deftest a-prevented-intent-is-assertable-by-equality
+  ;; THE REASON THE SPELLING CHANGED. HD-021's headless door returns the tree
+  ;; as data and sells itself on "intent vectors assertable by equality" —
+  ;; and metadata does not participate in `=`, so the one axis the retired
+  ;; spelling carried was the one axis a structural test could not see.
+  (testing "the retired spelling, stated as the defect it was"
+    (is (= [:conduit/show-your-feed]
+           (with-meta [:conduit/show-your-feed] {:re-frame.hicasso/prevent? true}))
+        "`=` could not tell a prevented intent from a plain one")
+    (is (= (hash [:conduit/show-your-feed])
+           (hash (with-meta [:conduit/show-your-feed] {:re-frame.hicasso/prevent? true})))
+        "and neither could a hash-keyed lookup")
+    (is (= "[:conduit/show-your-feed]"
+           (pr-str (with-meta [:conduit/show-your-feed] {:re-frame.hicasso/prevent? true})))
+        "nor a log line, nor a snapshot — metadata is omitted from printing"))
+  (testing "the head, which every one of those instruments can see"
+    (is (not= [:conduit/show-your-feed]
+              [:re-frame.hicasso/prevent [:conduit/show-your-feed]]))
+    (is (not= (hash [:conduit/show-your-feed])
+              (hash [:re-frame.hicasso/prevent [:conduit/show-your-feed]])))
+    (is (= "[:re-frame.hicasso/prevent [:conduit/show-your-feed]]"
+           (pr-str [:re-frame.hicasso/prevent [:conduit/show-your-feed]]))))
+  (testing "which is the property a structural test actually takes: two props
+            maps that differ ONLY in whether the click prevents"
+    (let [plain     {:href "#" :on-click [:conduit/show-your-feed]}
+          prevented {:href "#" :on-click [:re-frame.hicasso/prevent
+                                          [:conduit/show-your-feed]]}]
+      (is (not= plain prevented))
+      (is (= plain (update prevented :on-click #(nth % 1)))
+          "and the difference is exactly the decorator, nothing else")))
+  (testing "the predicate the classification uses is public, so a test can ask
+            the same question the lowering asks"
+    (is (true? (intent/prevent-head? [:re-frame.hicasso/prevent [:x]])))
+    (is (false? (intent/prevent-head? [:conduit/show-your-feed])))
+    (is (false? (intent/prevent-head?
+                  (with-meta [:conduit/show-your-feed]
+                             {:re-frame.hicasso/prevent? true})))
+        "the retired metadata is no longer a spelling of anything")))
+
+(deftest the-retired-metadata-spelling-does-nothing
+  ;; Not a formality: an author porting old code must find out at the click,
+  ;; not never. The metadata is inert, so the anchor navigates — which is
+  ;; loud in the browser and is what the DOM witness asserts.
+  (let [!seen      (recorder)
+        !prevented (atom false)
+        h (lowered (dispatching !seen) :on-click
+                   (with-meta [:ping] {:re-frame.hicasso/prevent? true}))]
+    (h (ev {:prevented !prevented}))
+    (is (false? @!prevented))
+    (is (= [[:ping]] @!seen))))
+
+(deftest a-malformed-prevent-head-is-refused-loudly
+  (let [d (dispatching (recorder))]
+    (testing "wrong arity — a bare head"
+      (is (thrown-with-msg? js/Error #"wraps EXACTLY ONE intent vector"
+                            (lowered d :on-click [:re-frame.hicasso/prevent]))))
+    (testing "wrong arity — two payloads, which is how an author would try to
+              write a second decorator"
+      (is (thrown-with-msg? js/Error #"carries 2 forms after the head"
+                            (lowered d :on-click [:re-frame.hicasso/prevent
+                                                  [:a] [:b]]))))
+    (testing "a non-vector payload"
+      (is (thrown-with-msg? js/Error #"not an intent vector"
+                            (lowered d :on-click [:re-frame.hicasso/prevent
+                                                  :conduit/show-your-feed]))))
+    (testing "the empty vector, which names no event"
+      (is (thrown-with-msg? js/Error #"names no event"
+                            (lowered d :on-click [:re-frame.hicasso/prevent []]))))
+    (testing "the decorator does not nest — the grammar is closed, so there is
+              no open decorator language to grow"
+      (is (thrown-with-msg? js/Error #"does not nest"
+                            (lowered d :on-click
+                                     [:re-frame.hicasso/prevent
+                                      [:re-frame.hicasso/prevent [:ping]]]))))
+    (testing "the diagnostic carries its id and NAMES THE POSITION"
+      (try
+        (lowered d :on-key-up [:re-frame.hicasso/prevent])
+        (is false "should have thrown")
+        (catch :default e
+          (let [data (ex-data e)]
+            (is (= :rf.error/hicasso-malformed-prevent (:rf.error/id data)))
+            (is (= :on-key-up (:position data)))
+            (is (= [:re-frame.hicasso/prevent] (:form data)))
+            (is (re-find #":on-key-up" (ex-message e)))
+            (is (re-find #"Write \[:re-frame.hicasso/prevent" (ex-message e))
+                "and it shows the form to write")))))
+    (testing "the refusal is taken at LOWERING time — before any event exists,
+              so a malformed decorator cannot reach a user's click"
+      (is (thrown? js/Error
+                   (intent/with-frame d
+                     (fn [] (intent/lower-props
+                              {:on-click [:re-frame.hicasso/prevent :nope]}))))))
+    (testing "and only at an event position: an intent travelling as data is
+              not lowered, so it is not classified either"
+      (is (= [:re-frame.hicasso/prevent :nope]
+             (lowered d :data-intent [:re-frame.hicasso/prevent :nope]))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The composition-gated key-map
@@ -230,16 +342,35 @@
                          {"Enter" [:todo/commit :re-frame.hicasso/value]})]
       (h (ev {:key "Enter" :value "milk"}))
       (is (= [[:todo/commit "milk"]] @!seen))))
-  (testing "prevent metadata works inside a branch, and is off by default"
-    (let [!a (atom false)
+  (testing "the prevent head is accepted inside a branch — through the same
+            classification, because a branch is lowered by the same code — and
+            prevention is off by default in the branch that does not carry it"
+    (let [!seen (recorder)
+          !a (atom false)
           !b (atom false)
-          h  (lowered (dispatching (recorder)) :on-key-down
-                      {"Enter"  (with-meta [:commit] {:re-frame.hicasso/prevent? true})
+          h  (lowered (dispatching !seen) :on-key-down
+                      {"Enter"  [:re-frame.hicasso/prevent [:commit]]
                        "Escape" [:cancel]})]
       (h (ev {:key "Enter" :prevented !a}))
       (h (ev {:key "Escape" :prevented !b}))
       (is (true? @!a))
-      (is (false? @!b))))
+      (is (false? @!b))
+      (is (= [[:commit] [:cancel]] @!seen)
+          "and both branches dispatch ordinary intents")))
+  (testing "a malformed decorator in a branch is refused at lowering, naming
+            the position"
+    (is (thrown-with-msg? js/Error #"wraps EXACTLY ONE intent vector"
+                          (lowered (dispatching (recorder)) :on-key-down
+                                   {"Enter" [:re-frame.hicasso/prevent]}))))
+  (testing "a marker composes inside a prevented branch"
+    (let [!seen (recorder)
+          !p    (atom false)
+          h     (lowered (dispatching !seen) :on-key-down
+                         {"Enter" [:re-frame.hicasso/prevent
+                                   [:todo/commit :re-frame.hicasso/value]]})]
+      (h (ev {:key "Enter" :value "milk" :prevented !p}))
+      (is (true? @!p))
+      (is (= [[:todo/commit "milk"]] @!seen))))
   (testing "an ordinary function is a legal branch"
     (let [!called (atom false)
           h (lowered (dispatching (recorder)) :on-key-down

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/feed.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/feed.cljs
@@ -120,15 +120,13 @@
            [:a.nav-link {:href        "#"
                          :data-testid "your-feed-tab"
                          :class       (when your-feed? "active")
-                         :on-click    ^{:re-frame.hicasso/prevent? true}
-                                      [:conduit/show-your-feed]}
+                         :on-click    [:re-frame.hicasso/prevent [:conduit/show-your-feed]]}
             "Your Feed"]]
           [:li.nav-item
            [:a.nav-link {:href        "#"
                          :data-testid "global-feed-tab"
                          :class       (when-not your-feed? "active")
-                         :on-click    ^{:re-frame.hicasso/prevent? true}
-                                      [:conduit/show-global-feed]}
+                         :on-click    [:re-frame.hicasso/prevent [:conduit/show-global-feed]]}
             "Global Feed"]]]]
         [:div.article-list {:data-testid "article-list"}
          (for [slug (sub [:conduit/slugs])]

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/large_template.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/large_template.cljs
@@ -125,15 +125,13 @@
            [:a.nav-link {:href        "#"
                          :data-testid "your-feed-tab"
                          :class       (when your-feed? "active")
-                         :on-click    ^{:re-frame.hicasso/prevent? true}
-                                      [:conduit/show-your-feed]}
+                         :on-click    [:re-frame.hicasso/prevent [:conduit/show-your-feed]]}
             "Your Feed"]]
           [:li.nav-item
            [:a.nav-link {:href        "#"
                          :data-testid "global-feed-tab"
                          :class       (when-not your-feed? "active")
-                         :on-click    ^{:re-frame.hicasso/prevent? true}
-                                      [:conduit/show-global-feed]}
+                         :on-click    [:re-frame.hicasso/prevent [:conduit/show-global-feed]]}
             "Global Feed"]]]]
         [:div.article-list {:data-testid "article-list"}
          (for [slug (sub [:conduit/slugs])]

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/large_template_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/large_template_dom_cljs_test.cljs
@@ -188,13 +188,19 @@
 ;; ---------------------------------------------------------------------------
 ;;
 ;; The census's feed tabs are anchors, so a port that keeps them has to opt
-;; `preventDefault` IN — `^{::h/prevent? true}` on the intent — where the
-;; comment form's `:on-submit` gets it from the position's own default.
-;; Every other assertion in the roster reaches its intents through
-;; `rt/dispatch!`, which would never have exercised the metadata at all.
-;; Fired here as a real cancelable click, with the un-annotated control on
-;; the same page as the control: if the pair both prevented, or neither
-;; did, the metadata would not be the thing doing it.
+;; `preventDefault` IN — `[::h/prevent [:conduit/show-your-feed]]` at the
+;; event position — where the comment form's `:on-submit` gets it from the
+;; position's own default. Every other assertion in the roster reaches its
+;; intents through `rt/dispatch!`, which would never have exercised the
+;; spelling at all. Fired here as a real cancelable click, with the
+;; un-decorated intent on the same page as the control: if the pair both
+;; prevented, or neither did, the decorator would not be the thing doing it.
+;;
+;; The head replaced `^{::h/prevent? true}` metadata (HD-026) because
+;; metadata does not participate in `=`. That is a claim about data, and
+;; `front/intent_cljs_test/a-prevented-intent-is-assertable-by-equality`
+;; is where it is asserted; this file answers the other half — that the
+;; browser's `canceled` flag actually moves, which no equality can show.
 
 (defn- click!
   "A real, cancelable click, dispatched at the node. Answers the event, so
@@ -205,15 +211,15 @@
     (mount/settle!)
     ev))
 
-(deftest the-prevent-metadata-is-what-prevents
+(deftest the-prevent-head-is-what-prevents
   (if-not (mount/browser?)
     (skip! ":node-test has no DOM")
     (do
       (fresh!)
       (let [handle (mount!)]
         (try
-          (testing "an anchor carrying ^{::h/prevent? true} dispatches AND
-                   prevents, so the href=\"#\" does not navigate"
+          (testing "an anchor carrying [::h/prevent [:conduit/show-your-feed]]
+                   dispatches AND prevents, so the href=\"#\" does not navigate"
             (let [ev (click! (q handle "[data-testid=\"your-feed-tab\"]"))]
               (is (true? (.-defaultPrevented ev)))
               (is (some? (q handle "[data-testid=\"your-feed-tab\"].active"))
@@ -227,7 +233,7 @@
                      (.-textContent (q handle (str "[data-testid=\"favorites-count-"
                                                    slug "\"]"))))
                   "and it reached the model too — so the difference between the
-                   two is the metadata and nothing else")))
+                   two is the decorator and nothing else")))
           (finally (mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
Retires the `^{::h/prevent? true}` metadata spelling for **one reserved intent
head**, `[::h/prevent [:app/go]]`, classified and unwrapped at lowering time.
Implements the ruling on rf2-2rtt6.57.

The tier-1 shapes roster (#7372) hit this porting the census feed, whose tabs are
anchors: a faithful port has to opt `preventDefault` IN, and the metadata was the
ugliest thing in the roster. But taste is not why it changed. **Metadata does not
participate in `=`**, and HD-021's headless door sells itself on *intent vectors
assertable by equality* — so the one axis the annotation carried was exactly the
axis a structural test could not see, and neither could `hash`, `pr-str`, a log
line or a snapshot. `preventDefault` moves the event's `canceled` flag; that is
behaviour, and a spelling that hides behaviour from the product's own
structural-testing story contradicts that story.

## Where lowering runs, and where the classification went

Intent lowering is `front/intent.cljs` — `lower-prop`, called from
`front/codec.cljs`'s `convert-props` inside its single walk over an element's
attribute map, with the boundary's frame bound ambiently by `arm1/runtime.cljs`.
The bead's factual correction was right: **no head dispatch existed**.
`intent-handler` dispatched the vector it was handed, unexamined.

It now begins with the classification, and only there:

```clojure
(let [decorated (prevent-head? v)                      ;; one = against the head
      intent    (if decorated (unwrap-prevent k v) v)  ;; closed grammar, or a refusal
      dispatch  (require-dispatch intent)
      prevent   (or decorated (prevent-by-default? k))
      dynamic   (markers? intent)]                     ;; markers see the UNWRAPPED intent
  …)
```

Three consequences the ruling asked for, and each is a test:

- **Unwrapped before marker analysis**, so `[::h/prevent [:filter/set ::h/value]]`
  prevents *and* materializes.
- **Key-map branches come through the same call** (`key-map-handler` already routed
  vectors to `intent-handler`), so the decorator works in a branch and a malformed
  one is refused there too, with no second code path.
- **The event path is unchanged.** The classification is one `=` per lowered
  position per render; the closure that runs on the click is the closure that ran
  before, and what reaches `dispatch` is the ordinary inner vector.

It is a classification, not a walker: one decision at one known position, nothing
descends into the intent.

## The closed grammar, and how a malformed head is refused

`[::h/prevent INTENT]` — exactly two forms, the second a non-empty intent vector
that is not itself a decorator. Everything else is
`:rf.error/hicasso-malformed-prevent`, raised at **lowering** (render time, not
click time) and **naming the position**:

```
The :re-frame.hicasso/prevent decorator at :on-key-up wraps EXACTLY ONE intent
vector; this one carries 0 forms after the head. Write
[:re-frame.hicasso/prevent [:my-event …]]. [:rf.error/hicasso-malformed-prevent]
```

with `{:rf.error/id … :position :on-key-up :form [:re-frame.hicasso/prevent]
:recovery :wrap-exactly-one-intent-vector}` in the ex-data. Wrong arity, a
non-vector payload, the empty vector and a nested decorator each name what was
found; the closed roster is a list (`::h/value`, `::h/checked`, `::h/prevent`),
not a convention, so there is no options map and no modifier language to grow.

## The equality property, witnessed directly

`front/intent_cljs_test/a-prevented-intent-is-assertable-by-equality` asserts the
defect and the fix side by side — the retired spelling's `=`, `hash` and `pr-str`
blindness, then the head visible to all three, then the property as a structural
test actually takes it: two props maps that differ only in whether the click
prevents are `not=`, and become `=` when the decorator is unwrapped.

## Prior art, per the standing directive

**Replicant** (verified 2026-08-02, replicant.fun) is the directly applicable
source and it is the school this ruling belongs to.

- **Taken.** Its shape for *data that means behaviour* is a vector with a
  namespaced-keyword head and a positional payload — `{:replicant/on-render
  [::update-map-places places]}`. That is the shape this ruling picked, arrived at
  independently and now confirmed against the library that has pushed
  data-orientation furthest. No better spelling inside the ruled grammar surfaced.
- **Declined.** Replicant carries listener modifiers as *sibling attribute keys*
  (`:replicant.event/capture`, `:replicant.event/once`, `:replicant.event/passive`).
  That is the sibling-attribute option the ruling already rejected, and Hicasso has
  a reason of its own: an intent **travels as a value** — a view may hand one to a
  child, which places it on an element — and a policy written in a sibling key
  cannot travel with it.
- **Declined.** Replicant *infers no meaning* from handler data, so it owes no
  diagnostic and offers none. Hicasso's roster is interpreted, so it owes one.

**Freehand** is where the refusal style comes from: `events/event-plan` is total
over its closed roster and raises `:rf.error/view-bad-event` stating the legal
grammar, then what was found, then the form to write, with an imperative
`recovery` key. The new refusal is written to that shape. Freehand's own event
grammar is also the concrete form of rejected option (b) — `{:event [...]
:prevent-default true}` is precisely the options map HD-024's collapse deleted.

## Migration

Both spine shapes' census feed tabs (`shapes/feed`, `shapes/large_template` — four
anchors) now read:

```clojure
[:a.nav-link {:href        "#"
              :data-testid "your-feed-tab"
              :class       (when your-feed? "active")
              :on-click    [:re-frame.hicasso/prevent [:conduit/show-your-feed]]}
 "Your Feed"]
```

The value is back on the key's line. The roster's real-cancelable-click witness is
carried forward as `the-prevent-head-is-what-prevents` and still asserts the
annotated anchor against an un-annotated control on the same page.

Docs: **HD-026** in `decisions.md` (the amendment ships with the implementation, as
ruled), the `authoring.md` policy-defaults bullet, and the draft guide's
events-as-data page — whose "Not settled yet" row said the opt-out spelling was not
in the record, and now is. The `dogfood` docstring that mentioned "prevent
metadata" went with it, so no reference to the retired spelling survives except the
ones deliberately describing it as retired.

## Quality gates

Foreground, worktree-local logs, exit codes echoed, nothing piped through
`tail`/`grep`. TESTING.md matrix: **CLJS unit** (`test:cljs`, fast lane — the
consolidated default gate) and **Browser unit** (`test:browser`, medium lane —
DOM-dependent `*_dom_cljs_test.cljs` only, which is where a real cancelable click
has to be answered); the fast-PR spine is the agent pre-checkin tier, and clj-kondo
is `lint.yml` at its pinned version.

| Gate | Result | Exit |
|---|---|---|
| `npm run test:cljs` | 12331 tests, 61722 assertions, 0 failures, 0 errors | **0** |
| `npm run test:browser` | 967 tests, 6055 assertions, 0 failures, 0 errors | **0** |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine` — docs + JVM + node tiers all armed by the classifier; JVM core 2209 tests, JVM freehand 1288 tests, node 12331 tests, per-ns isolation 17/17 | **0** |
| clj-kondo 2026.04.15, CI's exact `--lint` set, `--fail-level error` | **errors: 0** (4530 warnings, none in the touched files) | **0** |
| `python scripts/check_doc_slugs.py` (whole corpus) | PASS | **0** |

**One flake, named rather than hidden.** Two intermediate `test:browser` runs went
red on `re-frame.ui.tool-evidence-dom-cljs-test` — *"Playwright requestGC handshake
absent"* — while this box was running the fast-PR spine and other workers'
Chromiums at the same time. It is the known under-load class: the failing fixture
is re-frame.ui's GC-retention probe, which no hicasso namespace can reach, and the
same tree ran green before and after (the row above is the final idle run). Called
out so nobody re-discovers it as a mystery.

`mkdocs build --strict` does not cover `docs/design/**` (excluded in `mkdocs.yml`),
so it is not the gate for this diff. Per CLAUDE.md the worker verifies by hand:
**anchors** — no new intra-doc links were added, the existing ones still resolve
(`check_doc_slugs.py` agrees); **tables** — the one table row edited (the guide's
"Not settled yet") is 2 columns in a 2-column table; HD-026 adds no table.

### Mutation proof

Both mutations were run to completion and reverted; the tree is byte-identical to
the committed state afterwards.

1. **Remove the classification** — `decorated` forced to `false`, so the decorator
   is treated as an ordinary intent again. `npm run test:browser` → **exit 1**,
   2 failures, both in `the-prevent-head-is-what-prevents`, on a **real cancelable
   click**: `expected: (true? (.-defaultPrevented ev)) / actual: (not (true?
   false))`, and the intent no longer reached the model. The harness log even
   records the browser following the href: `[browser:navigation]
   http://127.0.0.1:8021/#`. The un-decorated control on the same page still
   passed, so the decorator is the thing doing it.
2. **Remove the refusal** — the closed-grammar guard forced open.
   `npm run test:cljs` → **exit 1**, 7 failures: every malformed form (bare head,
   two payloads, non-vector payload, empty vector, nested decorator, the ex-data
   assertions, and the malformed branch inside a key-map) goes silent.

Green after revert is the table above.

### Fences held

Surface B only. No candidate ledger, no compiler, no analyzer, no dual mode,
no codec authored. `arm1/runtime.cljs` and `front/codec.cljs` are untouched — the
change is entirely inside `front/intent.cljs`'s lowering. The ≤2-hook shell is
unchanged and re-proved green in the browser run:
`arm1/hook_ledger_dom_cljs_test/the-shell-calls-exactly-two-hooks` +
`the-count-does-not-move-with-the-read-count`, and
`shapes/hook_budget_dom_cljs_test/every-shape-costs-exactly-two-hooks-per-boundary`
at 1/7/20 reads. `subscribe` still closes over the read set alone. No bench driver
was run (`rf2-2rtt6.52` is measuring next door).

Closes rf2-2rtt6.57.
