### PR TITLE
hicasso: framework subs exercised, and route-link as data (rf2-2rtt6.53, rf2-2rtt6.54)

### DIFF
--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -110,6 +110,19 @@ steady-state change belongs on an effect, not on the ref.
 - Callbacks generated from intents close over the boundary's frame (resolved once
   per boundary from the substrate's single internal context) so they remain valid
   when the browser invokes them after render scope unwinds.
+- **The route-link is a plain function over routing's link seam** (HD-027; the
+  census counts 106 and calls the form tier-1). The author names a route and
+  params and never sees a URL —
+  `(route-link {:to :conduit.profile/show :params {:username u}} u)` — and what
+  comes back is one real `<a>` whose href is routing's and whose click decision
+  travels as data under the second reserved head, `[::h/navigate {…}]`. It
+  inlines (no boundary, no hook, no read), the click law is routing's
+  `activate-link!` seam verbatim (modifier-click and native anchors stay the
+  browser's), and its `:on-click` is the pre-navigation veto:
+  `[::h/prevent [:app/event]]` there cancels the navigation and dispatches the
+  app intent instead — the cancelable-navigation case the prevent head was built
+  for. A bare intent vector at that position is refused loudly: the click
+  already produces the one routing intent.
 
 ### When a vector is not enough: one form, and the position decides (HD-024)
 

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1,4 +1,4 @@
-# Hicasso — decisions (HD-001 … HD-026)
+# Hicasso — decisions (HD-001 … HD-027)
 
 Every design decision for the Hicasso programme, resolved. Each record carries the
 ruling, the decisive rationale, and the condition under which it reopens. These
@@ -852,3 +852,104 @@ click** on the census feed tab against an un-decorated control on the same page:
 `shapes/large_template_dom_cljs_test/the-prevent-head-is-what-prevents`.
 **Amends** HD-021: its equality promise now holds for the prevent axis at the spine
 shapes. **Reopens** on the dogfooding condition named under Scope.
+
+## HD-027 — `route-link`: a plain function over routing's link seam, and a second reserved head
+
+**Ruling.** The fifth tier-1 shape's Hicasso spelling is **`route-link`, a plain
+function** (`front/route_link.cljs` in the bench arm): the author writes
+`(route-link {:to :conduit.profile/show :params {:username u}} u)` and never sees
+a URL. It renders ONE real `<a>` whose `:href` is routing's own synthesis and
+whose `:on-click` carries the click decision **as data**, under the SECOND
+reserved head:
+
+```clojure
+[:a {:href     "/profile/jane"
+     :on-click [::h/navigate {:frame    :app/frame     ; captured at render
+                              :payload  [:rf.route/url-requested {…}]
+                              :native?  false           ; target/download verdict
+                              :veto     nil}]}          ; the caller's :on-click
+ "jane"]
+```
+
+The grammar is **closed, and this is all of it**: `[::h/navigate MAP]` — exactly
+two forms, the map carrying `:frame` (keyword), `:payload` (non-empty vector),
+`:native?` (boolean) and `:veto`. Everything else is
+`:rf.error/hicasso-malformed-navigate`, naming the position; decorators do not
+nest in either order. Classified and lowered once per render, beside the prevent
+head, in `front/intent.cljs`.
+
+**How far into routing it reaches — no further than the published seam.** The
+href, payload and `:native?` come from `:routing/link-model` at render; the click
+runs `:routing/activate-link!` — the substrate-neutral late-bound seams routing
+publishes for exactly this consumer class, already consumed by `rf/route-link`,
+`ui/route-link` and Freehand's `v/route-link`. Hicasso restates **none** of the
+click law (caller veto first, modifier/auxiliary and native-anchor deferral,
+`preventDefault` + dispatch to the render-captured frame with `:source :router`),
+and the packaging graph stays `hicasso → core late-bind ← routing`. A missing
+routing artefact fails at RENDER with `:rf.error/routing-artefact-missing` naming
+the link's `:to`; a hook that vanished between render and click (dev hot-reload)
+degrades to native navigation after the veto runs, never a throw at a detached
+click.
+
+**Composition with `::h/prevent` — the existing grammar is the veto.** The
+caller's `:on-click` rides the `:veto` slot, and its roster is closed: nil,
+`[::h/prevent [:app/event]]`, `h/fn`, or a plain fn. The prevent form lowers to
+the ordinary prevent closure; routing runs it FIRST and stands down on
+`defaultPrevented` — the navigation is cancelled and the app intent dispatched
+instead, which is precisely the cancelable-navigation case HD-026 named. A BARE
+intent vector is refused at render AND at lowering (the route click already
+produces the one routing intent; an un-prevented second intent would be one user
+action yielding two semantic events — Freehand's route-link law, kept). No new
+composition machinery exists: `activate-link!` already honours `defaultPrevented`,
+and the prevent head already sets it.
+
+**Not a boundary, deliberately.** Freehand's `v/route-link` is a `defview`; here
+that citation is declined. A Hicasso boundary costs two hooks and a row in every
+boundary count, and the census's 106 links live INSIDE rows that are already
+boundaries — an author byline is not a unit of re-render. `route-link` is a plain
+function like the card: it inlines, mints no boundary, adds no hook, and reads no
+subscription (the link model is a pure calculation), so the ≤2-hook budget and
+every roster page's boundary/read arithmetic are untouched by links. The frame is
+captured at render from the ambient binding the arm establishes
+(`intent/*frame*`, bound by the 3-arity `with-frame` beside the ambient
+dispatch), because a click fires after the render's dynamic extent has unwound —
+Freehand's `require-current-frame!` precedent, in the collector's ambient idiom.
+
+**Prior art, cited.** **Routing (taken whole):** the two-seam split and the one
+click law. **Freehand (taken):** render-time frame capture; render-time
+artefact-missing refusal; the one-intent-per-click law at the veto position.
+**(Declined:** its fn-only `:on-click` roster — Freehand has no in-band spelling
+for "cancel-and-replace"; Hicasso does, and admits exactly it.**)**
+**Replicant via HD-026 (taken):** behaviour as a namespaced-keyword-headed vector
+`=` can see — two renders of one link are equal data, and a structural test reads
+the click decision off the tree. **(Declined:** Replicant's global body-level
+click interceptor for routing — ambient behaviour no vector carries is what the
+in-band school exists to avoid.**)** **Also declined for v0:** the
+`:prefetch :intent` trio routing publishes and Freehand consumes — the census
+counts no prefetch site, and the opt-in is sugar over an event a Hicasso author
+can already spell at an ordinary intent position.
+
+**Rejected.** (b) A boundary (`defview`) route-link — costs two hooks per link
+and pollutes every boundary count for a form that appears 106 times per census
+(see "Not a boundary"). (c) A closure at `:on-click` (Freehand's own anchor
+shape) — loses hiccup equality exactly where the census's most-repeated tier-1
+form lives; HD-026's axis, again. (d) A codec-recognised element head
+(`[::h/route-link …]`) — puts routing knowledge in the codec, which is the one
+shared surface the school keeps semantics-free, and makes the link a special form
+rather than a view.
+
+**Cost, stated.** One reserved head joins the roster-as-list (two members now),
+one `=` per lowered event position to classify it, and three `route-url`
+syntheses per card per render on the roster pages — priced on the routing
+artefact's own render path, the same cost every other link surface pays.
+
+**Demonstrated, not asserted.** Equality and grammar refusals:
+`front/route_link_cljs_test` (two renders `=`, the decision readable off the
+tree, every malformed form loud, the veto composition mechanical). The browser
+half: `shapes/route_link_dom_cljs_test` — the ported census card's three anchors
+mount as real routed anchors, a real `MouseEvent` click installs the destination
+through the routing cascade and the `[:rf/route]`-reading boundary re-renders,
+a modifier click moves nothing, and the prevent veto cancels the navigation while
+its unvetoed sibling (the mutation control) still navigates. **Reopens** if
+dogfooding surfaces a real site needing `:prefetch`, or if the census's
+zero-prefetch count stops describing the corpus.

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -1088,7 +1088,7 @@
   (set! (.-grouped rstate) false)
   (set! (.-frame rstate) frame-kw)
   (try
-    (intent/with-frame (frame-dispatch frame-kw)
+    (intent/with-frame frame-kw (frame-dispatch frame-kw)
       (fn [] (codec/as-element (body-fn props))))
     (finally (set! (.-frame rstate) nil))))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -141,14 +141,53 @@
     of key-string → handler, so an event is one `.-key` lookup and no
     allocation.
 
-  This namespace deliberately does not implement `route-link` (routing-
-  coupled, and outside this bead's three deliverables), `defhost`/`[:>]`
+  ## The navigate head (rf2-2rtt6.54)
+
+  The SECOND reserved head, and the router-owned counterpart of
+  `::h/prevent`: `[::h/navigate {…}]` at an event position is the click
+  half of [[re-frame.bench.hicasso.front.route-link/route-link]]. The
+  route-link view puts it on the anchor it builds, carrying the whole
+  click decision AS DATA — the render-captured frame, the routing-owned
+  dispatch payload, the native-attrs verdict, and the caller's veto:
+
+      [:a {:href \"/profile/jane\"
+           :on-click [::h/navigate {:frame    :app/frame
+                                    :payload  [:rf.route/url-requested {…}]
+                                    :native?  false
+                                    :veto     nil}]}]
+
+  Same school as the prevent head (HD-026): behaviour in the vector where
+  `=` can see it, a closed grammar ([[unwrap-navigate]] is the whole of
+  it), classified once at lowering, loud on every malformed form. The
+  click LAW is not restated here: the lowered closure hands the event to
+  routing's own `:routing/activate-link!` late-bound seam — the same one
+  decision `rf/route-link`, `ui/route-link` and Freehand's `v/route-link`
+  all run — so caller-veto-first, modifier-click deferral, native-anchor
+  deferral and `preventDefault`-then-dispatch stay routing's law, stated
+  once. A hook that vanished between render and click (dev hot-reload of
+  the routing artefact) degrades to native navigation — the browser
+  follows the real `href` — after running the veto, exactly as Freehand's
+  seam degrades.
+
+  The `:veto` slot is where the two heads compose, and the composition is
+  the existing grammar: `[::h/prevent [:app/event]]` there lowers to the
+  ordinary prevent closure, `activate-link!` runs it FIRST, sees
+  `defaultPrevented`, and stands down — the navigation is cancelled and
+  the app intent dispatched instead. That is the cancelable-navigation
+  case the prevent head was built for, reached with no new machinery. A
+  BARE intent vector at the veto slot is refused loudly: a route click
+  already produces the one routing intent, and a second un-prevented
+  intent site on the same click would be one user action yielding two
+  semantic events (Freehand's route-link law, kept).
+
+  This namespace deliberately does not implement `defhost`/`[:>]`
   interop (HD-011, its own surface), or any controlled-value restore.
   HD-019's door belongs to whatever owns the DOM element, which is the
   emitter rather than the lowering:
   [[re-frame.bench.hicasso.front.controlled]] wraps the handler this
   namespace produced, after it has produced it, and nothing about the
-  lowering changes because of it (rf2-fki5d).")
+  lowering changes because of it (rf2-fki5d)."
+  (:require [re-frame.late-bind :as late-bind]))
 
 ;; ---------------------------------------------------------------------------
 ;; The ambient frame (HD-020(a))
@@ -160,12 +199,26 @@
   what makes an intent lowered outside a boundary a loud error."
   nil)
 
+(def ^:dynamic *frame*
+  "The frame KEYWORD for the boundary currently rendering, bound for the
+  render's dynamic extent alongside [[*dispatch*]]. `nil` outside a
+  render. [[re-frame.bench.hicasso.front.route-link/route-link]] reads it
+  to capture the render frame into its navigate vector — a browser click
+  fires long after the render's dynamic extent has unwound, so the frame
+  must travel as data (the same render-time capture Freehand's
+  `v/route-link` performs with `require-current-frame!`)."
+  nil)
+
 (defn with-frame
-  "Run `body-fn` with `dispatch` — the frame-locked dispatch resolved once
-  for this boundary — bound ambiently. An arm's boundary shell calls this
-  around the body."
-  [dispatch body-fn]
-  (binding [*dispatch* dispatch] (body-fn)))
+  "Run `body-fn` with the boundary's render context bound ambiently. Two
+  doors: an ARM binds both the frame keyword and its frame-locked
+  `dispatch` (the 3-arity — the one [[route-link]] and the navigate head
+  need); a lowering test that only drives closures may bind the dispatch
+  alone (the 2-arity), and anything frame-keyword-dependent it lowers
+  stays a loud error rather than a silent guess."
+  ([dispatch body-fn] (with-frame nil dispatch body-fn))
+  ([frame-kw dispatch body-fn]
+   (binding [*frame* frame-kw *dispatch* dispatch] (body-fn))))
 
 (defn- fail! [id where reason recovery extra]
   (throw (ex-info (str reason " [" id "]")
@@ -321,11 +374,18 @@
   :re-frame.hicasso/checked)
 
 (def prevent-head
-  "`::h/prevent` — the one reserved intent HEAD. `[::h/prevent [:app/go]]`
+  "`::h/prevent` — the FIRST reserved intent HEAD. `[::h/prevent [:app/go]]`
   at an event position dispatches `[:app/go]` and calls `.preventDefault`
   first. See [[unwrap-prevent]] for the closed grammar, and the policy
   defaults above for why it is a head rather than metadata."
   :re-frame.hicasso/prevent)
+
+(def navigate-head
+  "`::h/navigate` — the SECOND reserved intent HEAD, minted by
+  [[re-frame.bench.hicasso.front.route-link/route-link]] and carrying a
+  route-link's whole click decision as data. See the namespace docstring
+  §The navigate head, and [[unwrap-navigate]] for the closed grammar."
+  :re-frame.hicasso/navigate)
 
 (def ^:private marker-readers
   "The roster, as marker → the reader that pulls its value off the event
@@ -406,6 +466,18 @@
   [v]
   (and (vector? v) (= prevent-head (nth v 0 nil))))
 
+(defn navigate-head?
+  "Is `v` the `::h/navigate` decorator? Same one-compare shape as
+  [[prevent-head?]]."
+  [v]
+  (and (vector? v) (= navigate-head (nth v 0 nil))))
+
+(defn- reserved-head?
+  "Is `v` a vector carrying either reserved head? The roster is a LIST —
+  two entries — which is what keeps the grammar closed."
+  [v]
+  (or (prevent-head? v) (navigate-head? v)))
+
 (defn- unwrap-prevent
   "CLASSIFY AND UNWRAP. `v` is the decorator; answer the intent inside it,
   refusing anything that is not exactly one inner intent vector.
@@ -429,22 +501,115 @@
     (when-not (and (= 2 (count v))
                    (vector? inner)
                    (seq inner)
-                   (not (prevent-head? inner)))
+                   (not (reserved-head? inner)))
       (fail! :rf.error/hicasso-malformed-prevent
              'front.intent/lower-prop
              (str "The " (pr-str prevent-head) " decorator at " (pr-str k)
                   " wraps EXACTLY ONE intent vector; this one "
                   (cond
-                    (not= 2 (count v))    (str "carries " (dec (count v))
-                                               " forms after the head")
-                    (prevent-head? inner) "wraps another decorator, and it does not nest"
-                    (not (vector? inner)) (str "wraps " (pr-str inner)
-                                               ", which is not an intent vector")
-                    :else                 "wraps the empty vector, which names no event")
+                    (not= 2 (count v))     (str "carries " (dec (count v))
+                                                " forms after the head")
+                    (reserved-head? inner) "wraps another decorator, and decorators do not nest"
+                    (not (vector? inner))  (str "wraps " (pr-str inner)
+                                                ", which is not an intent vector")
+                    :else                  "wraps the empty vector, which names no event")
                   ". Write [" (pr-str prevent-head) " [:my-event …]].")
              :wrap-exactly-one-intent-vector
              {:position k :form v}))
     inner))
+
+(declare intent-handler)
+
+(defn- lower-veto
+  "Lower the `:veto` slot of a navigate vector into the pre-navigation
+  callback routing runs first — a plain one-argument fn, or nil — or
+  refuse it loudly. The roster is CLOSED, and it is the route-click law
+  that closes it: nil, the `::h/prevent` decorator (the DECLARATIVE veto —
+  its lowered closure calls `.preventDefault` and dispatches the wrapped
+  intent, and `activate-link!` stands down on `defaultPrevented`, so the
+  navigation is cancelled and the app intent takes its place), the one
+  callback form, or a plain fn (both the IMPERATIVE veto — whoever holds
+  the event owns it, HD-024). A BARE intent vector is refused: the click
+  already produces the one routing intent, and an un-prevented second
+  intent on the same click is one user action yielding two semantic
+  events. [[re-frame.bench.hicasso.front.route-link/route-link]] refuses
+  the same forms at RENDER, where the author's stack is live; this refusal
+  is the lowering's own, because a navigate vector is in-band data anyone
+  can write."
+  [k veto]
+  (cond
+    (nil? veto)            nil
+    (prevent-head? veto)   (intent-handler k veto)
+    (callback? veto)       veto
+    (fn? veto)             veto
+    :else
+    (fail! :rf.error/hicasso-malformed-navigate
+           'front.intent/lower-prop
+           (str "The " (pr-str navigate-head) " decorator at " (pr-str k)
+                " carries the veto " (pr-str veto) ", which is outside the "
+                "closed roster: nil, [" (pr-str prevent-head) " [:my-event …]] "
+                "(cancel the navigation and dispatch this instead), h/fn, or a "
+                "plain function. A bare intent vector is refused — the click "
+                "already produces the one routing intent; wrap the vector in "
+                (pr-str prevent-head) " to veto the navigation, or move the "
+                "reaction behind the routing event.")
+           :veto-with-prevent-a-callback-or-nothing
+           {:position k :veto veto})))
+
+(defn- unwrap-navigate
+  "CLASSIFY AND UNWRAP the navigate decorator. `[::h/navigate {…}]` —
+  exactly two forms, the second a map carrying `:frame` (a keyword),
+  `:payload` (a non-empty vector), `:native?` (a boolean) and `:veto`
+  (the [[lower-veto]] roster). Everything else is
+  `:rf.error/hicasso-malformed-navigate`, named at the position. Answers
+  the validated map; like [[unwrap-prevent]] it is not a walker — the
+  payload stays ordinary data all the way to routing."
+  [k v]
+  (let [{:keys [frame payload native?] :as m} (nth v 1 nil)]
+    (when-not (and (= 2 (count v))
+                   (map? m)
+                   (keyword? frame)
+                   (vector? payload)
+                   (seq payload)
+                   (boolean? native?))
+      (fail! :rf.error/hicasso-malformed-navigate
+             'front.intent/lower-prop
+             (str "The " (pr-str navigate-head) " decorator at " (pr-str k)
+                  " wraps EXACTLY ONE map carrying :frame (a keyword), :payload "
+                  "(a non-empty event vector), :native? (a boolean) and :veto; this one "
+                  (cond
+                    (not= 2 (count v))  (str "carries " (dec (count v)) " forms after the head")
+                    (not (map? m))      (str "wraps " (pr-str m) ", which is not a map")
+                    (not (keyword? frame))  "names no :frame keyword"
+                    (not (and (vector? payload) (seq payload))) "carries no :payload event vector"
+                    :else               "answers no boolean at :native?")
+                  ". route-link mints this form; hand-written ones must carry all four slots.")
+             :carry-frame-payload-native-and-veto
+             {:position k :form v}))
+    m))
+
+(defn- navigate-handler
+  "Lower one navigate vector into the closure the browser will call. The
+  veto is lowered HERE, at lowering time — a prevent veto needs the
+  ambient dispatch, which is gone by click time — and the click decision
+  itself stays routing's: the closure hands the event to the
+  `:routing/activate-link!` late-bound seam (caller veto first, modifier
+  and native deferral, `preventDefault` + dispatch to the captured frame).
+  When the hook is unbound at click time — the routing artefact
+  hot-reloaded away between render and click — the closure runs the veto
+  and otherwise stands aside, so the browser follows the anchor's real
+  `href`: native navigation, never a throw at a detached click.
+  ([[re-frame.bench.hicasso.front.route-link/route-link]] already proved
+  routing present at RENDER, so absence here is transient by
+  construction.)"
+  [k v]
+  (let [{:keys [frame payload native? veto]} (unwrap-navigate k v)
+        veto-fn (lower-veto k veto)]
+    (fn hicasso-navigate [e]
+      (if-some [activate (late-bind/get-fn :routing/activate-link!)]
+        (activate e veto-fn frame payload native?)
+        (when veto-fn (veto-fn e)))
+      nil)))
 
 (defn- intent-handler
   "Lower one intent vector into the closure the browser will call. The
@@ -454,18 +619,22 @@
   Classification comes FIRST, so the markers compose inside a prevented
   intent: `[::h/prevent [:filter/set ::h/value]]` is unwrapped before
   [[markers?]] is ever asked, and the materializer then sees the ordinary
-  intent it has always seen."
+  intent it has always seen. The navigate head is classified here too —
+  the same one-compare, once per render — and its whole lowering lives in
+  [[navigate-handler]]."
   [k v]
-  (let [decorated (prevent-head? v)
-        intent    (if decorated (unwrap-prevent k v) v)
-        dispatch  (require-dispatch intent)
-        prevent   (or decorated (prevent-by-default? k))
-        dynamic   (markers? intent)]
-    (cond
-      (and prevent dynamic)       (fn [e] (.preventDefault e) (dispatch (materialize intent e)))
-      prevent                     (fn [e] (.preventDefault e) (dispatch intent))
-      dynamic                     (fn [e] (dispatch (materialize intent e)))
-      :else                       (fn [_e] (dispatch intent)))))
+  (if (navigate-head? v)
+    (navigate-handler k v)
+    (let [decorated (prevent-head? v)
+          intent    (if decorated (unwrap-prevent k v) v)
+          dispatch  (require-dispatch intent)
+          prevent   (or decorated (prevent-by-default? k))
+          dynamic   (markers? intent)]
+      (cond
+        (and prevent dynamic)       (fn [e] (.preventDefault e) (dispatch (materialize intent e)))
+        prevent                     (fn [e] (.preventDefault e) (dispatch intent))
+        dynamic                     (fn [e] (dispatch (materialize intent e)))
+        :else                       (fn [_e] (dispatch intent))))))
 
 (defn- key-map-handler
   "Lower a data key-map into one closure over a plain map of key-string →

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -509,7 +509,7 @@
                   (cond
                     (not= 2 (count v))     (str "carries " (dec (count v))
                                                 " forms after the head")
-                    (reserved-head? inner) "wraps another decorator, and decorators do not nest"
+                    (reserved-head? inner) "wraps another decorator, and it does not nest"
                     (not (vector? inner))  (str "wraps " (pr-str inner)
                                                 ", which is not an intent vector")
                     :else                  "wraps the empty vector, which names no event")

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/route_link.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/route_link.cljs
@@ -1,0 +1,161 @@
+(ns re-frame.bench.hicasso.front.route-link
+  "`route-link` — the fifth tier-1 shape's Hicasso spelling
+  (rf2-2rtt6.54; the census counts **106** route-links across 85
+  idiomatic files and the charter names the form tier-1).
+
+  The census author writes
+
+      (route-link {:to :conduit.profile/show :params {:username u}} u)
+
+  and never sees a URL. What comes back is ONE real anchor, as data:
+
+      [:a {:href     \"/profile/jane\"          ; routing-owned
+           :on-click [::h/navigate {…}]}       ; the click decision, as data
+       \"jane\"]
+
+  ## A plain function, deliberately — not a boundary
+
+  Freehand's `v/route-link` is a `defview`; here that would be the wrong
+  citation. A Hicasso boundary costs two hooks and a row in every
+  boundary count, and the census's 106 links live INSIDE rows that are
+  already boundaries — an author byline is not a unit of re-render. So
+  `route-link` is a plain function like
+  [[re-frame.bench.hicasso.shapes.card/card]]: called from a body it
+  inlines, mints no boundary, adds no hook, and reads no subscription at
+  all (the link model is a pure calculation), so the ≤2-hook budget and
+  every page's boundary arithmetic are untouched by links.
+
+  ## What is taken from whom, and what is declined
+
+  - **From routing (taken whole): the law.** The href, the dispatch
+    payload and the click decision come from the substrate-neutral
+    late-bound seams routing publishes for exactly this consumer class —
+    `:routing/link-model` here at render, `:routing/activate-link!` in
+    the lowered closure ([[re-frame.bench.hicasso.front.intent]]). This
+    file restates NO routing law: `rf/route-link`, `ui/route-link`,
+    Freehand's `v/route-link` and this one all run the same two
+    definitions, and the packaging graph stays
+    `hicasso -> core late-bind <- routing` (Conventions §Packaging).
+  - **From Freehand (taken): render-time capture and render-time
+    refusal.** The frame is captured at RENDER (a click fires after the
+    render scope has unwound); a missing routing artefact fails at the
+    LINK SITE with `:rf.error/routing-artefact-missing`; and the
+    route-click one-intent law is kept — see [[on-click-roster!]].
+    **(Declined:** the fn-only `:on-click` roster. Freehand narrows to
+    fn / `v/handler` because it has no in-band spelling for
+    \"cancel-and-replace\"; Hicasso does — `[::h/prevent [:app/event]]`
+    is the declarative veto, and it is admitted.**)**
+  - **From Replicant (taken, via HD-026): behaviour as a
+    namespaced-keyword-headed vector.** The anchor's click carries a
+    `[::h/navigate {…}]` vector `=` can see, so two renders of one link
+    are equal and a structural test reads the click decision off the
+    tree. **(Declined:** Replicant's routing posture of a GLOBAL
+    body-level click interceptor — ambient behaviour no vector carries is
+    exactly what the in-band school exists to avoid.**)**
+  - **Declined for v0: the `:prefetch :intent` trio.** Routing publishes
+    it and Freehand consumes it; the census counts no prefetch site, and
+    the opt-in is sugar over an event a Hicasso author can already spell
+    (`:on-mouse-enter [:rf.route/prefetch {…}]`). A tier-1 roster takes
+    the tier-1 surface.
+
+  ## Composition with `::h/prevent`
+
+  A route-link's click is the cancelable-navigation case the prevent head
+  was built for, and the composition is the existing grammar: the
+  caller's `:on-click` rides the navigate vector's `:veto` slot; a
+  `[::h/prevent [:app/event]]` there lowers to the ordinary prevent
+  closure; routing runs it FIRST and stands down on `defaultPrevented`.
+  One click, one semantic event — the navigation, or the app intent that
+  cancelled it. See intent.cljs §The navigate head for the click-time
+  half."
+  (:require [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.late-bind :as late-bind]))
+
+(def ^:private routing-artefact
+  "The optional-artefact identity the fail-loud missing-hook error
+  reports, carried here so the diagnostic names the missing artefact AT
+  THE LINK SITE (the same private copy Freehand and re-frame.ui each
+  keep, for the same reason)."
+  {:error-keyword :rf.error/routing-artefact-missing
+   :maven         "day8/re-frame2-routing"
+   :require-ns    "re-frame.routing"})
+
+(defn- fail! [id where reason recovery extra]
+  (throw (ex-info (str reason " [" id "]")
+                  (merge {:rf.error/id id :where where
+                          :reason reason :recovery recovery}
+                         extra))))
+
+(def control-keys
+  "The keys `route-link` owns. Everything else on the props map is a
+  passthrough HTML attribute and reaches the `<a>` untouched — `:class`,
+  `:title`, `:data-testid`, `:aria-label`, and the native-handling
+  `:target` / `:download` pair the link model reads for its `:native?`
+  verdict."
+  [:to :params :query :fragment :on-click])
+
+(defn on-click-roster!
+  "Refuse, AT RENDER, an `:on-click` outside the route-click roster: nil,
+  `[::h/prevent [:app/event]]` (the declarative veto), `h/fn`, or a plain
+  function. The same roster [[intent/lower-veto]] enforces at lowering;
+  stated twice because the two failures land differently — this one fails
+  at the site that wrote the link, with the render stack, before any
+  anchor exists. A BARE intent vector is the taught mistake and gets the
+  teaching diagnostic: the click already produces the one routing intent
+  (Freehand's route-link law, kept)."
+  [on-click]
+  (when-not (or (nil? on-click)
+                (intent/prevent-head? on-click)
+                (intent/callback? on-click)
+                (fn? on-click))
+    (fail! :rf.error/hicasso-route-link-bad-on-click
+           'front.route-link/route-link
+           (str "route-link's :on-click is the pre-navigation veto; it takes nil, "
+                "[" (pr-str intent/prevent-head) " [:my-event …]] (cancel the "
+                "navigation and dispatch this instead), h/fn, or a plain function — "
+                "never " (pr-str on-click) ". A bare intent vector is refused "
+                "because the click already produces the one routing intent; an "
+                "application reaction belongs behind the routing event, or inside "
+                (pr-str intent/prevent-head) " if it replaces the navigation.")
+           :veto-with-prevent-a-callback-or-nothing
+           {:on-click on-click}))
+  on-click)
+
+(defn- require-frame! [to]
+  (or intent/*frame*
+      (fail! :rf.error/hicasso-route-link-outside-boundary
+             'front.route-link/route-link
+             (str "route-link {:to " (pr-str to) "} was rendered with no ambient "
+                  "frame; a link is only legal inside a boundary's render, because "
+                  "the navigation must be pinned to the frame that rendered it.")
+             :render-route-links-inside-a-boundary
+             {:to to})))
+
+(defn route-link
+  "One census route-link: compute the routing-owned link model for
+  `props`' address (`:to` / `:params` / `:query` / `:fragment`), and
+  answer a real `[:a …]` whose `:href` is routing's and whose `:on-click`
+  is the `[::h/navigate {…}]` data form. `children` land inside the
+  anchor. A plain function — call it: `(route-link {:to …} \"jane\")`.
+
+  Fails loud at render when routing is absent
+  (`:rf.error/routing-artefact-missing`, naming the `:to`), when rendered
+  outside a boundary, or when `:on-click` is outside the roster
+  ([[on-click-roster!]])."
+  [{:keys [to on-click] :as props} & children]
+  (let [frame-kw (require-frame! to)
+        _        (on-click-roster! on-click)
+        {:keys [href payload native?]}
+        ((late-bind/require-fn! :routing/link-model
+                                'route-link
+                                routing-artefact
+                                {:to to})
+         (dissoc props :on-click) frame-kw)
+        attrs    (-> (apply dissoc props control-keys)
+                     (assoc :href href
+                            :on-click [intent/navigate-head
+                                       {:frame    frame-kw
+                                        :payload  payload
+                                        :native?  native?
+                                        :veto     on-click}]))]
+    (into [:a attrs] children)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/route_link.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/route_link.cljs
@@ -74,8 +74,9 @@
 (def ^:private routing-artefact
   "The optional-artefact identity the fail-loud missing-hook error
   reports, carried here so the diagnostic names the missing artefact AT
-  THE LINK SITE (the same private copy Freehand and re-frame.ui each
-  keep, for the same reason)."
+  THE LINK SITE. Every link surface that consumes the seam keeps its own
+  private copy of this map, for the same reason — see HD-027's prior-art
+  ledger in docs/design/hicasso/decisions.md for the roster."
   {:error-keyword :rf.error/routing-artefact-missing
    :maven         "day8/re-frame2-routing"
    :require-ns    "re-frame.routing"})

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/route_link_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/route_link_cljs_test.cljs
@@ -1,0 +1,207 @@
+(ns re-frame.bench.hicasso.front.route-link-cljs-test
+  "ROUTE-LINK'S GRAMMAR, tested as data (rf2-2rtt6.54).
+
+  Everything here is the node-provable half: that a route-link render is
+  a PURE value (two renders of one link are `=`, and the click decision
+  is readable off the tree), that the routing-owned href is the SHIPPING
+  link law's (the real `re-frame.routing` artefact publishes the seam;
+  no stub), that every malformed form is loud at the position it was
+  written, and that the veto composition is mechanical — the prevent
+  closure runs first and routing's own `activate-link!` stands down on
+  `defaultPrevented`. The real browser click, the real route change and
+  the real page re-render are `shapes/route_link_dom_cljs_test`'s."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.bench.hicasso.front.route-link :as link]
+            [re-frame.core :as rf]
+            [re-frame.routing :as routing]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil}))
+
+(def ^:private frame-id ::grammar)
+
+(defn- fresh! []
+  (routing/reg-route :conduit.profile/show {} "/profile/:username")
+  (rf/make-frame {:id frame-id :initial-events [[:rf/set-db {}]]})
+  frame-id)
+
+(defn- rendered
+  "Render one link under the ambient context an arm binds — the 3-arity
+  [[intent/with-frame]] — and answer the hiccup value."
+  [props & children]
+  (fresh!)
+  (intent/with-frame frame-id (fn [_] nil)
+    (fn [] (apply link/route-link props children))))
+
+(defn- ev
+  "A stand-in click event: `:button`/`:metaKey` select the click class,
+  `:prevented` records `preventDefault`, and `defaultPrevented` mirrors
+  it the way a real event's flag would."
+  [{:keys [button meta? prevented]}]
+  (let [e #js {:button           (or button 0)
+               :metaKey          (boolean meta?)
+               :ctrlKey          false :shiftKey false :altKey false
+               :defaultPrevented false}]
+    (unchecked-set e "preventDefault"
+                   (fn []
+                     (unchecked-set e "defaultPrevented" true)
+                     (when prevented (reset! prevented true))
+                     nil))
+    e))
+
+;; ---------------------------------------------------------------------------
+;; The anchor is data
+;; ---------------------------------------------------------------------------
+
+(deftest two-renders-of-one-link-are-equal-data
+  (let [a (rendered {:to :conduit.profile/show :params {:username "jane"} :class "author"} "jane")
+        b (rendered {:to :conduit.profile/show :params {:username "jane"} :class "author"} "jane")]
+    (is (= a b)
+        "the whole anchor — href, click decision, veto — is a value `=` can
+         see, which is the axis the prevent head was ruled on (HD-026) and
+         the axis a closure-carrying anchor loses")
+    (is (= :a (first a)))
+    (is (= "/profile/jane" (:href (second a)))
+        "the href is the routing artefact's own synthesis — no hand-built URL")
+    (is (= "author" (:class (second a))) "passthrough attrs reach the anchor")
+    (is (= ["jane"] (subvec a 2)) "children land inside the anchor")))
+
+(deftest the-click-decision-is-readable-off-the-tree
+  (let [[_ attrs] (rendered {:to :conduit.profile/show :params {:username "jane"}} "jane")
+        on-click  (:on-click attrs)]
+    (is (intent/navigate-head? on-click) "the click position carries the navigate head")
+    (let [{:keys [frame payload native? veto]} (second on-click)]
+      (is (= frame-id frame) "the frame was captured at render, as data")
+      (is (= [:rf.route/url-requested {:url "/profile/jane"
+                                       :to :conduit.profile/show
+                                       :params {:username "jane"}}]
+             payload)
+          "the payload is routing's own url-requested synthesis, in band")
+      (is (false? native?))
+      (is (nil? veto)))))
+
+(deftest a-native-anchor-is-classified-at-render
+  (let [[_ attrs] (rendered {:to :conduit.profile/show :params {:username "jane"}
+                             :target "_blank"} "jane")]
+    (is (true? (:native? (second (:on-click attrs))))
+        "target=_blank is routing's native-anchor verdict, carried as data")
+    (is (= "_blank" (:target attrs)) "and the attribute still reaches the anchor")))
+
+(deftest a-prevent-veto-rides-the-vector-as-data
+  (let [[_ attrs] (rendered {:to :conduit.profile/show :params {:username "jane"}
+                             :on-click [intent/prevent-head [:conduit/track "jane"]]}
+                            "jane")]
+    (is (= [intent/prevent-head [:conduit/track "jane"]]
+           (:veto (second (:on-click attrs))))
+        "the declarative veto is visible to `=` on the rendered tree")))
+
+;; ---------------------------------------------------------------------------
+;; Loud at the site that wrote it
+;; ---------------------------------------------------------------------------
+
+(deftest a-bare-intent-vector-at-on-click-is-refused-at-render
+  (is (thrown-with-msg?
+        js/Error #"hicasso-route-link-bad-on-click"
+        (rendered {:to :conduit.profile/show :params {:username "jane"}
+                   :on-click [:conduit/track "jane"]}
+                  "jane"))
+      "the click already produces the one routing intent; the bare vector is
+       the taught mistake and fails at render with the teaching diagnostic"))
+
+(deftest a-key-map-at-on-click-is-refused-at-render
+  (is (thrown-with-msg?
+        js/Error #"hicasso-route-link-bad-on-click"
+        (rendered {:to :conduit.profile/show :params {:username "jane"}
+                   :on-click {"Enter" [:conduit/track]}}
+                  "jane"))))
+
+(deftest a-link-outside-a-boundary-is-loud
+  (fresh!)
+  (is (thrown-with-msg?
+        js/Error #"hicasso-route-link-outside-boundary"
+        (link/route-link {:to :conduit.profile/show :params {:username "jane"}} "jane"))))
+
+(deftest a-malformed-navigate-vector-is-loud-at-lowering
+  (testing "the navigate head is in-band data anyone can write, so the
+           lowering is total over it — each violation names the position"
+    (doseq [bad [[intent/navigate-head]
+                 [intent/navigate-head {:frame frame-id}]
+                 [intent/navigate-head "not-a-map"]
+                 [intent/navigate-head {:frame frame-id :payload [] :native? false}]
+                 [intent/navigate-head {:frame frame-id :payload [:x] :native? "yes"}]]]
+      (is (thrown-with-msg?
+            js/Error #"hicasso-malformed-navigate"
+            (intent/with-frame frame-id (fn [_] nil)
+              (fn [] (intent/lower-prop :on-click bad))))
+          (pr-str bad)))))
+
+(deftest a-bare-vector-at-the-veto-slot-is-loud-at-lowering
+  (is (thrown-with-msg?
+        js/Error #"hicasso-malformed-navigate"
+        (intent/with-frame frame-id (fn [_] nil)
+          (fn [] (intent/lower-prop
+                   :on-click
+                   [intent/navigate-head {:frame frame-id
+                                          :payload [:rf.route/url-requested {:to :x}]
+                                          :native? false
+                                          :veto [:conduit/track]}]))))))
+
+(deftest prevent-does-not-wrap-a-navigate
+  (is (thrown-with-msg?
+        js/Error #"hicasso-malformed-prevent"
+        (intent/with-frame frame-id (fn [_] nil)
+          (fn [] (intent/lower-prop
+                   :on-click
+                   [intent/prevent-head
+                    [intent/navigate-head {:frame frame-id :payload [:x]
+                                           :native? false :veto nil}]]))))
+      "decorators do not nest, in either order"))
+
+;; ---------------------------------------------------------------------------
+;; The composition, mechanically
+;; ---------------------------------------------------------------------------
+
+(defn- lowered-click
+  "Lower a rendered link's `:on-click` under a recording dispatch and
+  answer `[closure !dispatched]` — the closure the browser would call."
+  [props]
+  (let [!seen  (atom [])
+        [_ attrs] (rendered props "jane")
+        h      (intent/with-frame frame-id
+                 (fn [ev] (swap! !seen conj ev) nil)
+                 (fn [] (intent/lower-prop :on-click (:on-click attrs))))]
+    [h !seen]))
+
+(deftest a-prevent-veto-cancels-the-navigation-and-dispatches-instead
+  (let [[h !seen] (lowered-click {:to :conduit.profile/show :params {:username "jane"}
+                                  :on-click [intent/prevent-head [:conduit/track "jane"]]})
+        !prevented (atom false)]
+    (h (ev {:prevented !prevented}))
+    (is (true? @!prevented)
+        "the veto's prevent closure ran first and cancelled the default")
+    (is (= [[:conduit/track "jane"]] @!seen)
+        "…and dispatched the app intent — routing's activate-link! saw
+         defaultPrevented and stood down, so one click yielded ONE semantic
+         event: the intent that replaced the navigation")))
+
+(deftest a-modifier-click-is-left-native
+  (let [[h !seen] (lowered-click {:to :conduit.profile/show :params {:username "jane"}})
+        !prevented (atom false)]
+    (h (ev {:meta? true :prevented !prevented}))
+    (is (false? @!prevented)
+        "routing's own plain-left-click law deferred to the browser")
+    (is (= [] @!seen))))
+
+(deftest a-plain-click-is-intercepted
+  (let [[h _] (lowered-click {:to :conduit.profile/show :params {:username "jane"}})
+        !prevented (atom false)]
+    (h (ev {:prevented !prevented}))
+    (is (true? @!prevented)
+        "a plain left click is routing's to take: preventDefault fired and the
+         url-requested dispatch went to the captured frame (the route change
+         itself is the DOM witness's claim)")))

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/card.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/card.cljs
@@ -38,8 +38,24 @@
   a port that dropped the status read to make a page cheaper would be
   quoting a row the census does not have.
 
+  ## The three links are route-links (rf2-2rtt6.54)
+
+  The census card carries three `ui/route-link`s — both author bylines
+  and the preview link — and until rf2-2rtt6.54 this port spelled them
+  `[:a {:href (str \"#/profile/\" …)}]`: a faithful port of the MARKUP
+  and an unfaithful one of the AUTHORING, hand-building the URL the
+  router owns. They are now
+  [[re-frame.bench.hicasso.front.route-link/route-link]] calls — the
+  author names a route and params and never sees a URL. A route-link is a
+  plain function producing ONE `<a>`, reading NO subscription, so
+  [[elements-per-card]] and the card's two-read count are exactly what
+  they were; what changed per card is three `route-url` synthesis calls
+  per render, priced on the routing artefact's own render path.
+  (`shapes/route_link_dom_cljs_test` owns the click witnesses.)
+
   `.cljc`-compatible by construction: no interop, no JS literal."
   (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.bench.hicasso.front.route-link :refer [route-link]]
             [re-frame.bench.hicasso.shapes.model :as m]))
 
 (def elements-per-card
@@ -71,10 +87,13 @@
     [:div.article-preview {:key         slug
                            :data-testid (str "article-preview-" slug)}
      [:div.article-meta
-      [:a.author-link {:href (str "#/profile/" (:username author))}
-       [:img.user-pic {:src (m/avatar-src (:image author)) :alt ""}]]
+      (route-link {:to :conduit.profile/show :params {:username (:username author)}
+                   :class "author-link"}
+        [:img.user-pic {:src (m/avatar-src (:image author)) :alt ""}])
       [:div.info
-       [:a.author {:href (str "#/profile/" (:username author))} (:username author)]
+       (route-link {:to :conduit.profile/show :params {:username (:username author)}
+                    :class "author"}
+         (:username author))
        [:span.date createdAt]]
       [:button.btn.btn-outline-primary.btn-sm.pull-xs-right
        {:type        "button"
@@ -85,11 +104,11 @@
         :on-click    [:conduit/favorite slug]}
        [:i.ion-heart] " "
        [:span {:data-testid (str "favorites-count-" slug)} favoritesCount]]]
-     [:a.preview-link {:href        (str "#/article/" slug)
-                       :data-testid (str "article-link-" slug)}
-      [:h1 title]
-      [:p description]
-      [:span "Read more..."]
-      [:ul.tag-list
-       (for [tag tagList]
-         [:li.tag-default.tag-pill.tag-outline {:key tag} tag])]]]))
+     (route-link {:to :conduit.article/show :params {:slug slug}
+                  :class "preview-link" :data-testid (str "article-link-" slug)}
+       [:h1 title]
+       [:p description]
+       [:span "Read more..."]
+       [:ul.tag-list
+        (for [tag tagList]
+          [:li.tag-default.tag-pill.tag-outline {:key tag} tag])])]))

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/framework_subs_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/framework_subs_dom_cljs_test.cljs
@@ -22,7 +22,12 @@
      `reg-frame-state-sub`: an app-db commit re-runs its body and the
      output `=` cutoff keeps its readers quiet. Both clocks are driven
      here and judged against the same narrow law the roster's own
-     witnesses state — **one commit → one body** (per reader).
+     witnesses state — **one commit → one body** (per reader) — with the
+     roster's one documented rider: a commit the PAGE reads re-runs the
+     page once, and React's no-bail-out cascade then re-runs the child
+     boundaries beneath it (the finding
+     `narrow_dom_cljs_test/a-page-chrome-write-re-renders-every-row`
+     pins; restated here on the resource clock, not contradicted).
 
   The page is deliberately NOT one of the measured roster pages
   (`shapes/ordinary` / `shapes/feed` / `shapes/large_template` carry the
@@ -88,15 +93,19 @@
   and a mutation write in one page's life."
   (atom []))
 
-(defn- capturing-transport-fixture [f]
-  (reset! !managed [])
-  (fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! !managed conj args) nil))
-  (f))
+(def ^:private capturing-transport-fixture
+  "Map-form (this suite has an async test, and cljs.test requires every
+  fixture on an async suite to be a map)."
+  {:before (fn []
+             (reset! !managed [])
+             (fx/reg-fx :rf.http/managed
+                        (fn [_ctx args] (swap! !managed conj args) nil)))})
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
     {:adapter       uix-adapter/adapter
      :ambient-frame nil
+     :async?        true
      :init-fn       (fn [] (rt/reset-runtime!))})
   capturing-transport-fixture)
 
@@ -358,18 +367,26 @@
           (is (= "idle" (text handle "fw-feed-status")) "no entry yet — the documented empty projection")
           (reset-runs!)
           (ensure-feed!)
-          (testing "ensure's :loading install is one commit → one body"
+          (testing "ensure's :loading install is one commit → one PAGE body —
+                   plus the documented cascade: a Hicasso boundary is a plain
+                   function component with no props-equality bail-out, so a
+                   write the PAGE reads re-renders the page and React
+                   re-renders every child boundary beneath it (the finding
+                   `narrow_dom_cljs_test/a-page-chrome-write-re-renders-every-row`
+                   pins on the roster; the same number, restated here on the
+                   resource clock rather than contradicted)"
             (is (= "loading" (text handle "fw-feed-status")))
-            (is (= 1 (runs :page)))
-            (is (= 0 (+ (runs slug-0) (runs (:slug (m/article 1))) (runs (:slug (m/article 2)))))
-                "no card reads the feed, so no card ran"))
+            (is (= 1 (runs :page)) "the index answered for exactly one boundary")
+            (is (= 1 (runs slug-0)) "…and React's cascade re-ran the children")
+            (is (= 1 (runs :detail))))
           (reset-runs!)
           (settle-feed! 42)
-          (testing "the decoded reply is one more commit → one more body"
+          (testing "the decoded reply is one more commit → one more page body
+                   (and the same cascade beneath it)"
             (is (= "loaded" (text handle "fw-feed-status")))
             (is (= "42" (text handle "fw-feed-total")))
             (is (= 1 (runs :page)))
-            (is (= 0 (runs :detail))))
+            (is (= 1 (runs :detail)) "cascade, not index: its read did not move"))
           (finally (mount/release! handle)))))))
 
 ;; ===========================================================================

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/framework_subs_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/framework_subs_dom_cljs_test.cljs
@@ -1,0 +1,421 @@
+(ns re-frame.bench.hicasso.shapes.framework-subs-dom-cljs-test
+  "**FRAMEWORK SUBS, EXERCISED THROUGH THE ARM** (rf2-2rtt6.53).
+
+  The charter counts framework subs at **27% of census read traffic** and
+  says \"the index serves them first-class\". The roster ports read the
+  same *shape* through plain `reg-sub`s (`:conduit/favorite-pending?`),
+  so until this file nothing witnessed that a real framework sub reads
+  identically to an app sub through the collector. Two things went
+  unchecked, and each has a test here named for it:
+
+  1. **The query vector's arg is a MAP.** The index's sub-key identity is
+     value equality on `[frame-kw query-v]`, and every roster read
+     exercises it on scalars. Here the census's own pair —
+     `[:rf/mutation {:instance [:favorite slug]}]` alongside the row's
+     app sub — is mounted through the arm, and a *freshly constructed*
+     value-equal key finds the same cell and the same reader set.
+
+  2. **A framework sub's value moves on a different clock than a db
+     write.** `:rf/mutation` is a `reg-runtime-sub`: its facts live in
+     the frame's runtime-db partition, installed by the resources
+     machinery, never by an app-db commit. `:rf/resource` is a
+     `reg-frame-state-sub`: an app-db commit re-runs its body and the
+     output `=` cutoff keeps its readers quiet. Both clocks are driven
+     here and judged against the same narrow law the roster's own
+     witnesses state — **one commit → one body** (per reader).
+
+  The page is deliberately NOT one of the measured roster pages
+  (`shapes/ordinary` / `shapes/feed` / `shapes/large_template` carry the
+  box's published clock rows and stay exactly as the census port wrote
+  them). It is the same state layer (`shapes/model`) under a small page
+  whose card reads the census pair verbatim:
+
+      (sub [:conduit/article slug])                          ; the app sub
+      (sub [:rf/mutation {:instance [:favorite slug]}])      ; the framework sub
+
+  and whose page-level read is the census's list shape:
+
+      (sub [:rf/resource {:resource :conduit/feed :params {:page 1}}])
+
+  The machinery behind the reads is the REAL resources artefact —
+  `reg-resource` / `reg-mutation`, `:rf.resource/ensure`,
+  `:rf.mutation/execute`, the internal reply events — with only the
+  transport stubbed, exactly as the resources artefact's own suites stub
+  it (a capturing `:rf.http/managed` fx; the reply is the genuine
+  reply-event-append shape). No HTTP, no invented sub machinery.
+
+  ## The arithmetic
+
+  Three articles. One page boundary (2 reads: `[:conduit/slugs]` + the
+  resource), three cards (2 reads each), one detail panel reading the
+  SAME `[:rf/mutation {:instance [:favorite slug-0]}]` as card 0 — so
+  law 2 (two boundaries sharing a sub both dirty) is exercised on a
+  map-arg key, and the shared key holds ONE cell:
+
+      boundaries  1 + 3 + 1        = 5
+      cells       2 + (3×2) + 0    = 8   (the detail's read shares card 0's cell)
+      edges       2 + (3×2) + 1    = 9
+
+  Runtime: `-dom-cljs-test`. Under `:node-test` every claim degrades to a
+  stated skip."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.hook-probe :as probe]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt :refer [sub]]
+            [re-frame.bench.hicasso.front.sub-index :as index]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.shapes.model :as m]
+            [re-frame.core :as rf]
+            [re-frame.fx :as fx]
+            [re-frame.http.managed]
+            [re-frame.resources]
+            [re-frame.resources.state :as state]
+            [re-frame.resources.test-support]
+            [re-frame.schemas]
+            [re-frame.subs :as subs]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures — the shared reset, plus the same capturing transport the
+;; resources artefact's own suites use (no real fetch ever fires)
+;; ---------------------------------------------------------------------------
+
+(def ^:private !managed
+  "Every `:rf.http/managed` lowering the stub saw, in order. A vector
+  rather than a single slot because one witness drives a resource fetch
+  and a mutation write in one page's life."
+  (atom []))
+
+(defn- capturing-transport-fixture [f]
+  (reset! !managed [])
+  (fx/reg-fx :rf.http/managed (fn [_ctx args] (swap! !managed conj args) nil))
+  (f))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (rt/reset-runtime!))})
+  capturing-transport-fixture)
+
+(def ^:private frame-id ::shape-framework-subs)
+
+(def ^:private article-count 3)
+
+(def ^:private seed {:articles article-count :comments 0 :tags 2})
+
+(defn- skip! [why]
+  (is true (str "the framework-subs witness needs a real React DOM — " why)))
+
+;; ---------------------------------------------------------------------------
+;; The real registrations — the resources artefact's own doors
+;; ---------------------------------------------------------------------------
+
+(defn- register-framework! []
+  (rf/reg-resource :conduit/feed
+    {:scope         :rf.scope/global
+     :params-schema [:map [:page :int]]
+     :tags          (fn [_params _data] #{[:feed]})}
+    (fn [{:keys [page]} _ctx]
+      {:request {:method :get :url (str "/api/articles?page=" page)}}))
+  (rf/reg-mutation :conduit/favorite-remote
+    {:params-schema [:map [:slug :string]]}
+    (fn [{:keys [slug]} _ctx]
+      {:request {:method :post :url (str "/api/articles/" slug "/favorite")}})))
+
+(defn- fresh! []
+  (lane/leave-act-environment!)
+  (register-framework!)
+  (m/make-frame! frame-id seed)
+  (m/reseed! frame-id seed)
+  frame-id)
+
+;; ---------------------------------------------------------------------------
+;; The page — the census pair, read through the collector
+;; ---------------------------------------------------------------------------
+
+(def !runs (atom {}))
+
+(defn- ran! [k] (swap! !runs update k (fnil inc 0)) nil)
+
+(defn- reset-runs! [] (reset! !runs {}) nil)
+
+(defn- runs [k] (get @!runs k 0))
+
+(def ^:private slug-0 (:slug (m/article 0)))
+
+(defn- mutation-read
+  "The census's per-row status read, verbatim
+  (`examples/real-apps/realworld_resources/ui_views.cljs:119`). Built
+  fresh at every call site — never shared through a def — so every read
+  and every assertion exercises VALUE equality on the map arg rather than
+  object identity."
+  [slug]
+  [:rf/mutation {:instance [:favorite slug]}])
+
+(def ^:private resource-read
+  "The census's list-shape read: `:resource` + `:params`, scope resolved
+  from the registration (Spec 016 §Subscription-side scope resolution)."
+  [:rf/resource {:resource :conduit/feed :params {:page 1}}])
+
+(defview fw-card
+  "One row: the app sub and the framework sub, side by side — the
+  census's own pair."
+  [{:keys [slug]}]
+  (ran! slug)
+  (let [{:keys [title favoritesCount]} (sub [:conduit/article slug])
+        fav (sub (mutation-read slug))]
+    [:div.fw-card {:data-testid (str "fw-card-" slug)}
+     [:span.fw-title title]
+     [:span {:data-testid (str "fw-count-" slug)} favoritesCount]
+     [:span {:data-testid (str "fw-status-" slug)}
+      (cond (:pending? fav) "pending"
+            (:success? fav) "settled"
+            :else           "idle")]]))
+
+(defview fw-detail
+  "A second boundary reading the SAME map-arg framework sub as card 0 —
+  law 2's two-readers case, on a map-arg key. Its ONLY read is the
+  runtime sub, so it is also the pure converse probe: an app-db commit
+  must never move it."
+  [_]
+  (ran! :detail)
+  (let [fav (sub (mutation-read slug-0))]
+    [:span {:data-testid "fw-detail"}
+     (if (:pending? fav) "saving" "quiet")]))
+
+(defview fw-page
+  [_]
+  (ran! :page)
+  (let [feed (sub resource-read)]
+    [:div.fw-page
+     [:span {:data-testid "fw-feed-status"} (name (:status feed))]
+     [:span {:data-testid "fw-feed-total"}
+      (str (get-in feed [:data :articlesCount] "-"))]
+     [fw-detail {}]
+     [:div.fw-list
+      (for [slug (sub [:conduit/slugs])]
+        [fw-card {:key slug :slug slug}])]]))
+
+;; ---------------------------------------------------------------------------
+;; Drives
+;; ---------------------------------------------------------------------------
+
+(defn- mount! []
+  (reset-runs!)
+  (mount/root! (mount/fresh-container!) frame-id [fw-page {}]))
+
+(defn- text [handle testid]
+  (some-> (.querySelector (:container handle) (str "[data-testid=\"" testid "\"]"))
+          (.-textContent)))
+
+(defn- execute-favorite! []
+  (rt/dispatch! frame-id
+                [:rf.mutation/execute {:mutation :conduit/favorite-remote
+                                       :params   {:slug slug-0}
+                                       :instance [:favorite slug-0]
+                                       :cause    [:test ::witness slug-0]}])
+  (mount/settle!))
+
+(defn- settle-favorite!
+  "Replay the genuine reply-event-append shape the live transport would
+  dispatch (the resources suites' own pattern), targeted at the witness
+  frame through the arm's synchronous door."
+  []
+  (let [args (last @!managed)]
+    (is (some? (:on-success args)) "the stub transport saw the mutation lowering")
+    (rt/dispatch! frame-id (conj (:on-success args)
+                                 {:status :ok :value {:article {:slug slug-0}}}))
+    (mount/settle!)))
+
+(defn- ensure-feed! []
+  (rt/dispatch! frame-id
+                [:rf.resource/ensure {:resource :conduit/feed
+                                      :scope    :rf.scope/global
+                                      :params   {:page 1}
+                                      :owner    [:app ::witness 1]}])
+  (mount/settle!))
+
+(defn- settle-feed! [total]
+  (let [scoped-key (state/scoped-resource-key :rf.scope/global :conduit/feed {:page 1})
+        runtime-db (:rf.db/runtime (rf/frame-state-value frame-id))
+        work-id    (:current-work (get-in runtime-db (state/entry-path scoped-key)))]
+    (is (some? work-id) "ensure minted in-flight work in the frame's runtime-db")
+    (rt/dispatch! frame-id [:rf.resource.internal/succeeded
+                            {:resource/key scoped-key :work/id work-id :generation 1
+                             :data {:articlesCount total}}])
+    (mount/settle!)))
+
+;; ===========================================================================
+;; 1 — the index serves a map-arg framework sub under VALUE equality
+;; ===========================================================================
+
+(deftest the-sub-key-identity-holds-on-a-map-arg-key
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (testing "the mount is the arithmetic's page"
+            (is (= {:boundaries 5 :cells 8 :edges 9}
+                   (select-keys (rt/stats) [:boundaries :cells :edges]))
+                (str "1 page + " article-count " cards + 1 detail; the detail's "
+                     "read SHARES card 0's cell, which is the map-arg dedup")))
+          (testing "a freshly constructed value-equal key finds the cell"
+            (is (some? (rt/cell-reaction [frame-id (mutation-read slug-0)]))
+                "the map arg is a value, not an object identity")
+            (is (some? (rt/cell-reaction [frame-id resource-read]))
+                "and so is the resource read's"))
+          (testing "and finds the readers the index holds for it"
+            (let [idx (index/snapshot)]
+              (is (= 2 (count (index/readers-of idx [frame-id (mutation-read slug-0)])))
+                  "card 0 and the detail both hold the shared instance's edge")
+              (is (= 1 (count (index/readers-of idx [frame-id (mutation-read (:slug (m/article 1)))])))
+                  "card 1's instance has exactly its own reader")
+              (is (= 0 (count (index/readers-of idx [frame-id (mutation-read "no-such-slug")])))
+                  "law 6: an instance nobody reads has no phantom reader")))
+          (finally (mount/release! handle)))))))
+
+;; ===========================================================================
+;; 2 — the mutation clock: runtime-db installs, never app-db commits
+;; ===========================================================================
+
+(deftest a-mutation-commit-moves-its-readers-and-only-its-readers
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (let [app-db-before (:rf.db/app (rf/frame-state-value frame-id))
+                cells-before  (:cells (rt/stats))]
+            (reset-runs!)
+            (execute-favorite!)
+            (testing "one commit → one body, per reader of the map-arg key"
+              (is (= 1 (runs slug-0)) "card 0 re-ran once")
+              (is (= 1 (runs :detail)) "law 2: the second reader of the SAME instance re-ran once")
+              (is (= 0 (runs (:slug (m/article 1)))) "card 1 did not")
+              (is (= 0 (runs (:slug (m/article 2)))) "card 2 did not")
+              (is (= 0 (runs :page)) "the page did not"))
+            (testing "the DOM shows the in-flight instance"
+              (is (= "pending" (text handle (str "fw-status-" slug-0))))
+              (is (= "saving" (text handle "fw-detail")))
+              (is (= "idle" (text handle (str "fw-status-" (:slug (m/article 1)))))))
+            (testing "the value moved on the runtime-db clock — app-db did not move"
+              (is (identical? app-db-before (:rf.db/app (rf/frame-state-value frame-id)))
+                  "no app-db write happened; the framework sub moved anyway"))
+            (reset-runs!)
+            (settle-favorite!)
+            (testing "the reply is one more commit → one more body per reader"
+              (is (= 1 (runs slug-0)))
+              (is (= 1 (runs :detail)))
+              (is (= 0 (runs :page)))
+              (is (= "settled" (text handle (str "fw-status-" slug-0))))
+              (is (= "quiet" (text handle "fw-detail"))))
+            (testing "two commits on the same instance reused ONE cell"
+              (is (= cells-before (:cells (rt/stats)))
+                  "value-equal map args re-key the same cell — no thrash")))
+          (finally (mount/release! handle)))))))
+
+(deftest an-app-db-commit-does-not-move-the-runtime-sub
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (let [fav-before (subs/subscribe-once (mutation-read slug-0) {:frame frame-id})]
+            (reset-runs!)
+            (rt/dispatch! frame-id [:conduit/favorite slug-0])
+            (mount/settle!)
+            (testing "the app-db write reached the app sub's reader and nothing else"
+              (is (= 1 (runs slug-0)) "card 0 re-ran — its article moved")
+              (is (= 0 (runs :detail))
+                  "the detail reads ONLY the runtime sub, and a runtime sub is
+                   inert to an app-db commit — the different clock, in the
+                   converse direction")
+              (is (= 0 (runs :page))
+                  "the frame-state resource sub re-derived over the new app-db
+                   and its output = cutoff held its reader quiet"))
+            (testing "the framework sub's value did not move"
+              (is (= fav-before (subs/subscribe-once (mutation-read slug-0) {:frame frame-id})))))
+          (finally (mount/release! handle)))))))
+
+;; ===========================================================================
+;; 3 — the resource clock: the census's list read, ensure → reply
+;; ===========================================================================
+
+(deftest a-resource-read-follows-the-census-shape-through-the-arm
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (is (= "idle" (text handle "fw-feed-status")) "no entry yet — the documented empty projection")
+          (reset-runs!)
+          (ensure-feed!)
+          (testing "ensure's :loading install is one commit → one body"
+            (is (= "loading" (text handle "fw-feed-status")))
+            (is (= 1 (runs :page)))
+            (is (= 0 (+ (runs slug-0) (runs (:slug (m/article 1))) (runs (:slug (m/article 2)))))
+                "no card reads the feed, so no card ran"))
+          (reset-runs!)
+          (settle-feed! 42)
+          (testing "the decoded reply is one more commit → one more body"
+            (is (= "loaded" (text handle "fw-feed-status")))
+            (is (= "42" (text handle "fw-feed-total")))
+            (is (= 1 (runs :page)))
+            (is (= 0 (runs :detail))))
+          (finally (mount/release! handle)))))))
+
+;; ===========================================================================
+;; 4 — the hook budget survives framework subs
+;; ===========================================================================
+
+(deftest framework-subs-cost-no-third-hook
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (if-not (probe/install!)
+      (is false (str "React's internals slot was not found, so the ≤2-hook budget "
+                     "is UNWITNESSED on the framework-subs page — fix "
+                     (pr-str 're-frame.bench.hicasso.arm1.hook-probe)
+                     " rather than reading this as a pass."))
+      (do
+        (fresh!)
+        (let [container (mount/fresh-container!)
+              handle    (volatile! nil)
+              names     (probe/record!
+                          (fn [] (vreset! handle (mount/root! container frame-id [fw-page {}]))))
+              stats     (rt/stats)]
+          (try
+            (is (= 5 (:boundaries stats)))
+            (is (= (* 2 (:boundaries stats)) (count names))
+                "two hooks per boundary — a framework sub is a read, and a
+                 read cannot reach the hook count")
+            (is (= #{"useContext" "useSyncExternalStore"} (set names)))
+            (finally (mount/release! @handle))))))))
+
+;; ===========================================================================
+;; Teardown
+;; ===========================================================================
+
+(deftest the-framework-subs-page-leaves-no-residue
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (async done
+      (fresh!)
+      (let [handle (mount!)]
+        (execute-favorite!)
+        (settle-favorite!)
+        (is (pos? (:cell-refs (rt/stats))))
+        (mount/unmount! handle)
+        (js/setTimeout (fn []
+                         (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                                (rt/residue)))
+                         (rt/reset-runtime!)
+                         (done))
+                       8)))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/model.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/model.cljs
@@ -37,16 +37,21 @@
   port that renamed them would be a screen this repo wrote rather than
   one it found.
 
-  **What the port leaves behind, and why.** The census screens read
-  `[:rf/resource …]` and `[:rf/mutation …]` — framework subs, which the
-  charter counts at **27% of read traffic**. Those are re-frame2
-  capabilities, not view-layer surface, and standing them up here would
-  put an HTTP-shaped resource cache behind a view-layer witness. The
-  shapes read plain `reg-sub`s with the same *shapes* — a per-instance
+  **What the port keeps out of the measured pages, and where it is
+  exercised instead.** The census screens read `[:rf/resource …]` and
+  `[:rf/mutation …]` — framework subs, which the charter counts at **27%
+  of read traffic**. Those are re-frame2 capabilities, not view-layer
+  surface, and standing them up behind the MEASURED pages would put an
+  HTTP-shaped resource cache in the clock rows' way. The shapes read
+  plain `reg-sub`s with the same *shapes* — a per-instance
   `:conduit/favorite-pending?` where the census reads
-  `[:rf/mutation {:instance [:favorite slug]}]` — and the omission is
-  filed rather than papered over: **framework subs are not exercised by
-  this roster** (see the bead's Findings).
+  `[:rf/mutation {:instance [:favorite slug]}]` — and the real framework
+  subs are exercised through the arm by their own witness on this same
+  state layer: `shapes/framework_subs_dom_cljs_test` mounts the census
+  pair (`[:rf/mutation {:instance …}]` beside the app sub, the
+  `[:rf/resource …]` list read above them) against the genuine resources
+  machinery with only the transport stubbed, and holds it to the same
+  one-commit→one-body law (rf2-2rtt6.53).
 
   ## The two writes the roster turns on
 
@@ -67,8 +72,20 @@
   Every string is a pure function of an index — no `rand`, no clock. Two
   mounts of the same seed build byte-identical DOM, which is what lets a
   witness compare a page against itself across a commit and read the
-  difference as the commit's."
-  (:require [re-frame.core :as rf]))
+  difference as the commit's.
+
+  ## The routes
+
+  The census's screens link with `ui/route-link`, so the ported cards do
+  too (rf2-2rtt6.54) — which makes the ROUTE TABLE part of the state
+  layer: a route-link's href is synthesised from a registered route, and
+  rendering one against an empty table is a loud error. [[make-frame!]]
+  registers the three routes the ported anchors name, per test, because
+  the shared reset fixture clears the registrar between tests. The
+  registration is `re-frame.routing`'s own `reg-route` — the roster adds
+  no routing machinery, it consumes the artefact's."
+  (:require [re-frame.core :as rf]
+            [re-frame.routing :as routing]))
 
 ;; ---------------------------------------------------------------------------
 ;; The seed data — Conduit's own field names, from a deterministic index
@@ -272,9 +289,22 @@
 ;; The frame lifecycle
 ;; ---------------------------------------------------------------------------
 
+(defn register-routes!
+  "Register the routes the ported anchors link to — the census's own
+  three, under the roster's `:conduit` prefix. Idempotent (a `reg-route`
+  re-registration replaces), and called from [[make-frame!]] so every
+  witness that mounts a page has the table its links resolve against."
+  []
+  (routing/reg-route :conduit/home {} "/")
+  (routing/reg-route :conduit.profile/show {} "/profile/:username")
+  (routing/reg-route :conduit.article/show {} "/article/:slug")
+  nil)
+
 (defn make-frame!
-  "Create (or idempotently replace) `frame-id`'s frame, seeded per `opts`."
+  "Create (or idempotently replace) `frame-id`'s frame, seeded per `opts`,
+  with the [[register-routes!]] table its pages' links resolve against."
   [frame-id opts]
+  (register-routes!)
   (rf/make-frame {:id frame-id :initial-events [[:conduit/seed opts]]})
   frame-id)
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/ordinary.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/ordinary.cljs
@@ -44,13 +44,16 @@
   disabled-while-pending discipline, and its `favoritesCount`-era
   camelCase field names.
 
-  ## What the port could not keep
+  ## The byline is a route-link (rf2-2rtt6.54)
 
-  `ui/route-link` — the census's author byline is a route-link, and the
-  census counts **106 of them** and calls the form tier-1. This arm has
-  no `route-link` (`front.intent`'s docstring says so in as many words),
-  so the byline is spelled `[:a {:href …}]`. That is a v0 gap, filed, not
-  a design position.
+  The census's author byline is a `ui/route-link` — the census counts
+  **106 of them** and calls the form tier-1 — and this port spelled it
+  `[:a {:href …}]` while the arm had no route-link. It now has one
+  ([[re-frame.bench.hicasso.front.route-link/route-link]]), so the
+  byline names a route and params and never sees a URL, exactly as the
+  census author writes it. A route-link is a plain function: it inlines,
+  mints no boundary, reads no subscription, and emits the same single
+  `<a>` — the element arithmetic below is untouched.
 
   ## Reading the body
 
@@ -64,6 +67,7 @@
   interop, no JS literal, no React import. SSR is out of v0; the
   constraint that keeps it reachable is not."
   (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.bench.hicasso.front.route-link :refer [route-link]]
             [re-frame.bench.hicasso.shapes.model :as m])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
@@ -120,12 +124,6 @@
 ;; The list — one keyed card per comment
 ;; ---------------------------------------------------------------------------
 
-(defn- profile-href
-  "A plain function called from a body: it inlines, mints no boundary, and
-  is where a `route-link` would go if this arm had one."
-  [username]
-  (str "#/profile/" username))
-
 (defview comment-card
   "One comment — a keyed row. The delete control shows only for the
   reader's own comments, and the in-flight read that greys it out is read
@@ -139,10 +137,11 @@
      [:div.card-block
       [:p.card-text {:data-testid "comment-body"} body]]
      [:div.card-footer
-      [:a.comment-author {:href (profile-href (:username author))}
-       [:img.comment-author-img {:src (m/avatar-src (:image author)) :alt ""}]
-       " "
-       (:username author)]
+      (route-link {:to :conduit.profile/show :params {:username (:username author)}
+                   :class "comment-author"}
+        [:img.comment-author-img {:src (m/avatar-src (:image author)) :alt ""}]
+        " "
+        (:username author))
       [:span.date-posted createdAt]
       (when mine?
         [:button.mod-options {:type        "button"

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/route_link_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/route_link_dom_cljs_test.cljs
@@ -1,0 +1,296 @@
+(ns re-frame.bench.hicasso.shapes.route-link-dom-cljs-test
+  "**THE FIFTH TIER-1 SHAPE'S CLICK WITNESS** (rf2-2rtt6.54).
+
+  The census counts 106 route-links and the charter names the form
+  tier-1. The roster's ported anchors are now
+  [[re-frame.bench.hicasso.front.route-link/route-link]] calls, and this
+  file witnesses the half a grammar test cannot: **a real `MouseEvent`
+  on a mounted ported card, a real route change through the routing
+  cascade, and the page re-rendering on the navigation commit** — which
+  is also a framework runtime sub (`[:rf/route]`) read through the arm's
+  collector, end to end.
+
+  Four claims:
+
+  1. **The ported anchors are real routed anchors.** The card's three
+     links and the comment byline mount as `HTMLAnchorElement`s whose
+     hrefs the ROUTER synthesised — no hand-built URL survives the port.
+  2. **A plain click navigates.** The route slice moves to the link's
+     destination, and the `[:rf/route]`-reading boundary re-renders —
+     the navigation commit reaches the index like any other.
+  3. **A modifier click stays native.** Nothing dispatches, nothing
+     moves, nothing re-renders; the browser keeps open-in-new-tab.
+  4. **`::h/prevent` composes as the declarative veto.** A route-link
+     whose `:on-click` carries `[::h/prevent [:conduit/show-your-feed]]`
+     cancels its navigation and dispatches the app intent instead — the
+     cancelable-navigation case the prevent head was built for — while
+     its unvetoed sibling (the mutation control) still navigates.
+
+  Navigation of the HARNESS page is suppressed by a document-level guard,
+  exactly as `freehand/route_link_matrix_dom_cljs_test` suppresses it.
+
+  Runtime: `-dom-cljs-test`. Under `:node-test` every claim degrades to a
+  stated skip."
+  (:require [cljs.test :refer-macros [async deftest is use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt :refer [sub]]
+            [re-frame.bench.hicasso.front.route-link :as link]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.shapes.card :as card]
+            [re-frame.bench.hicasso.shapes.model :as m]
+            [re-frame.bench.hicasso.shapes.ordinary :as ordinary]
+            [re-frame.subs :as subs]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::shape-route-link)
+
+(def ^:private seed {:articles 2 :comments 4 :tags 2})
+
+(defn- skip! [why]
+  (is true (str "the route-link witness needs a real React DOM — " why)))
+
+;; ---------------------------------------------------------------------------
+;; The page: the ported card, the ported comment column's byline shape,
+;; a route display, and the veto pair
+;; ---------------------------------------------------------------------------
+
+(def !runs (atom {}))
+(defn- ran! [k] (swap! !runs update k (fnil inc 0)) nil)
+(defn- reset-runs! [] (reset! !runs {}) nil)
+(defn- runs [k] (get @!runs k 0))
+
+(defview where-am-i
+  "The `[:rf/route]` display — a framework runtime sub read through the
+  collector, so claim 2's re-render is the arm's own machinery answering
+  for the navigation commit."
+  [_]
+  (ran! :where)
+  (let [route (sub [:rf/route])]
+    [:span {:data-testid "where-am-i"}
+     (if-some [id (:route-id route)]
+       (str (name id) "/" (get-in route [:params :username]
+                                   (get-in route [:params :slug] "")))
+       "nowhere")]))
+
+(defview card-host
+  "The ported census card, mounted whole — its three route-links are the
+  anchors the clicks below land on."
+  [_]
+  (ran! :card-host)
+  (card/card (:slug (m/article 0))))
+
+(defview veto-pair
+  [_]
+  (ran! :veto-pair)
+  [:div
+   (link/route-link {:to :conduit.profile/show :params {:username "jane"}
+                     :class "vetoed" :data-testid "vetoed-link"
+                     :on-click [:re-frame.hicasso/prevent [:conduit/show-your-feed]]}
+     "vetoed")
+   (link/route-link {:to :conduit.profile/show :params {:username "riku"}
+                     :class "unvetoed" :data-testid "unvetoed-link"}
+     "control")])
+
+(defview nav-page
+  [_]
+  (ran! :page)
+  [:div.nav-page
+   [where-am-i {}]
+   [veto-pair {}]
+   [card-host {}]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- fresh! []
+  (lane/leave-act-environment!)
+  (m/make-frame! frame-id seed)
+  (m/reseed! frame-id seed)
+  (reset-runs!)
+  frame-id)
+
+(defn- mount! []
+  (mount/root! (mount/fresh-container!) frame-id [nav-page {}]))
+
+(defn- q [handle sel] (.querySelector (:container handle) sel))
+
+(defn- text [handle testid]
+  (some-> (q handle (str "[data-testid=\"" testid "\"]")) (.-textContent)))
+
+(defn- current-route []
+  (subs/subscribe-once [:rf/route] {:frame frame-id}))
+
+(defn- click!
+  "Fire a real `MouseEvent` at `node` under a document-level guard that
+  keeps a natively-handled click from navigating the harness page."
+  ([node] (click! node #js {}))
+  ([node event-init]
+   (let [guard (fn [e] (.preventDefault e))]
+     (.addEventListener js/document "click" guard)
+     (try
+       (.dispatchEvent node (js/MouseEvent. "click"
+                                            (js/Object.assign
+                                              #js {:bubbles true :cancelable true}
+                                              event-init)))
+       (finally (.removeEventListener js/document "click" guard))))))
+
+(defn- settled
+  "Give the routing cascade its drain and React its flush, then run
+  `assert-fn` and `done`."
+  [assert-fn done]
+  (js/setTimeout (fn []
+                   (mount/settle!)
+                   (assert-fn)
+                   (done))
+                 15))
+
+;; ===========================================================================
+;; 1 — the ported anchors are real routed anchors
+;; ===========================================================================
+
+(deftest the-ported-census-anchors-are-real-routed-anchors
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (let [author (:username (:author (m/article 0)))]
+            (doseq [[sel href] [[".author-link" (str "/profile/" author)]
+                                [".author"      (str "/profile/" author)]
+                                [".preview-link" (str "/article/" (:slug (m/article 0)))]]]
+              (let [a (q handle sel)]
+                (is (instance? js/HTMLAnchorElement a)
+                    (str sel " is a real anchor"))
+                (is (= href (.getAttribute a "href"))
+                    (str sel "'s href is the router's synthesis — the port no "
+                         "longer hand-builds the URL the router owns")))))
+          (finally (mount/release! handle)))))))
+
+(deftest the-comment-byline-is-a-routed-anchor-too
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [ordinary/screen {}])]
+        (try
+          (let [a (q handle ".comment-author")]
+            (is (instance? js/HTMLAnchorElement a))
+            (is (re-matches #"/profile/.+" (.getAttribute a "href"))
+                "ordinary.cljs's byline names a route, not a URL"))
+          (finally (mount/release! handle)))))))
+
+;; ===========================================================================
+;; 2 — a real click, a real route change, a real re-render
+;; ===========================================================================
+
+(deftest a-plain-click-navigates-and-the-page-re-renders
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (async done
+      (fresh!)
+      (let [handle (mount!)
+            author (:username (:author (m/article 0)))]
+        (is (= "nowhere" (text handle "where-am-i")) "no route yet")
+        (reset-runs!)
+        (click! (q handle ".author"))
+        (settled
+          (fn []
+            (is (= :conduit.profile/show (:route-id (current-route)))
+                "the routing cascade installed the link's destination")
+            (is (= {:username author} (:params (current-route)))
+                "with the census author's params — never a parsed URL")
+            (is (= (str "show/" author) (text handle "where-am-i"))
+                "and the [:rf/route]-reading boundary re-rendered: the
+                 navigation commit reached the index like any other")
+            (is (= 1 (runs :where)) "exactly one body ran for it")
+            (is (= 0 (runs :card-host)) "the card did not — it reads no route")
+            (mount/release! handle))
+          done)))))
+
+(deftest a-modifier-click-stays-native
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (async done
+      (fresh!)
+      (let [handle (mount!)]
+        (reset-runs!)
+        (click! (q handle ".author") #js {:metaKey true})
+        (settled
+          (fn []
+            (is (nil? (:route-id (current-route)))
+                "nothing dispatched — the modifier click kept its
+                 open-in-new-tab meaning")
+            (is (= "nowhere" (text handle "where-am-i")))
+            (is (= 0 (runs :where)) "and nothing re-rendered")
+            (mount/release! handle))
+          done)))))
+
+;; ===========================================================================
+;; 3 — the prevent head is the declarative veto, and it composes
+;; ===========================================================================
+
+(deftest a-prevent-veto-cancels-the-navigation-and-dispatches-instead
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (async done
+      (fresh!)
+      (let [handle (mount!)]
+        (is (false? (subs/subscribe-once [:conduit/your-feed?] {:frame frame-id})))
+        (click! (q handle ".vetoed"))
+        (js/setTimeout
+          (fn []
+            (mount/settle!)
+            (is (nil? (:route-id (current-route)))
+                "the navigation was vetoed — activate-link! saw
+                 defaultPrevented and stood down")
+            (is (true? (subs/subscribe-once [:conduit/your-feed?] {:frame frame-id}))
+                "and the wrapped app intent dispatched in its place: one
+                 click, one semantic event")
+            ;; The MUTATION CONTROL: the same anchor without the veto
+            ;; navigates, so the claim above cannot pass vacuously.
+            (click! (q handle ".unvetoed"))
+            (js/setTimeout
+              (fn []
+                (mount/settle!)
+                (is (= :conduit.profile/show (:route-id (current-route)))
+                    "the unvetoed sibling navigates — the veto, not the
+                     machinery, is what cancelled the first click")
+                (is (= {:username "riku"} (:params (current-route))))
+                (mount/release! handle)
+                (done))
+              15))
+          15)))))
+
+;; ===========================================================================
+;; Teardown
+;; ===========================================================================
+
+(deftest the-route-link-page-leaves-no-residue
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (async done
+      (fresh!)
+      (let [handle (mount!)]
+        (click! (q handle ".author"))
+        (js/setTimeout
+          (fn []
+            (mount/settle!)
+            (mount/unmount! handle)
+            (js/setTimeout (fn []
+                             (is (= {:cells 0 :cell-refs 0 :boundaries 0 :edges 0 :entries 0}
+                                    (rt/residue)))
+                             (rt/reset-runtime!)
+                             (done))
+                           8))
+          15)))))


### PR DESCRIPTION
Two beads from the tier-1 roster port, in dependency order: **rf2-2rtt6.53** exercises what existed (the framework subs the charter counts at 27% of census read traffic), **rf2-2rtt6.54** builds what didn't (the fifth tier-1 shape, route-link).

## rf2-2rtt6.53 — the roster now exercises real framework subs

`shapes/framework_subs_dom_cljs_test.cljs` mounts a page on the roster's own state layer whose rows read the census pair verbatim — `[:rf/mutation {:instance [:favorite slug]}]` beside the row's app sub, `[:rf/resource {:resource … :params …}]` above them — against the **genuine resources machinery** (`reg-resource` / `reg-mutation`, `:rf.resource/ensure`, `:rf.mutation/execute`, the internal reply events), with only the transport stubbed via the same capturing `:rf.http/managed` fx the resources artefact's own suites use. The measured roster pages are untouched.

What the index genuinely served, witnessed:

- **Map-arg sub-key identity is value equality.** A freshly constructed value-equal key finds the cell (`cell-reaction`) and the reader set (`readers-of`); two boundaries reading one instance share ONE cell and both dirty (law 2 on a map-arg key); an instance nobody reads has no phantom reader (law 6); two commits on one instance reuse one cell — no thrash. Mount arithmetic: 5 boundaries, 8 cells, 9 edges, exactly as predicted.
- **The different clock, in both directions.** `:rf.mutation/execute` and its reply each move the mutation sub with **app-db untouched** (`identical?` before/after) — one commit → one body per reader, page still. Conversely an app-db write re-runs the article's reader only: the runtime sub's reader does not move (a `reg-runtime-sub` is inert to an app-db commit), and the frame-state resource sub re-derives but its output `=` cutoff holds its reader quiet.
- **The one documented rider, stated not contradicted:** the resource `ensure`/reply commits move the PAGE's read, so the index answers for exactly one boundary and React's no-bail-out cascade then re-runs the children — the same finding `narrow_dom_cljs_test/a-page-chrome-write-re-renders-every-row` pins, restated here on the resource clock.
- **Hook budget:** 2 hooks per boundary at React's dispatcher on the framework-subs page — a framework sub is a read, and a read cannot reach the hook count. Zero residue after teardown.

## rf2-2rtt6.54 — route-link as data (HD-027)

The census counts **106 route-links** across 85 idiomatic files; the roster spelled them `[:a {:href (str "#/profile/" u)}]`. Now:

```clojure
(route-link {:to :conduit.profile/show :params {:username u}} u)
;; => [:a {:href "/profile/jane"
;;         :on-click [::h/navigate {:frame … :payload … :native? … :veto …}]} "jane"]
```

- **A plain function, not a boundary** (declined Freehand's `defview` citation): it inlines, mints no boundary, adds no hook, reads no sub — the ≤2-hook budget and every page's boundary/read arithmetic are untouched by links.
- **The click decision travels as data** under the second reserved head, `[::h/navigate {…}]`, lowered beside `::h/prevent` with the same school (HD-026 / Replicant): closed grammar, classified once per render, loud on every malformed form (`:rf.error/hicasso-malformed-navigate`), refusals at render (`:rf.error/hicasso-route-link-bad-on-click`, `:rf.error/hicasso-route-link-outside-boundary`, `:rf.error/routing-artefact-missing` naming the `:to`). Two renders of one link are `=`.
- **No routing law is restated.** Href, payload and the native-anchor verdict come from `:routing/link-model` at render; the click runs `:routing/activate-link!` — the substrate-neutral late-bound seams already consumed by `rf/route-link`, `ui/route-link` and Freehand's `v/route-link`. Packaging stays `hicasso → core late-bind ← routing`. **No ruling was needed**: the design reaches no deeper than the published seam built for exactly this consumer class; anything deeper (restating the click law, touching routing internals) would have needed one and was not done.
- **Composition with `::h/prevent`:** the caller's `:on-click` rides the `:veto` slot; `[::h/prevent [:app/event]]` there lowers to the ordinary prevent closure, routing runs it FIRST and stands down on `defaultPrevented` — navigation cancelled, app intent dispatched instead: the cancelable-navigation case the prevent head was built for, with zero new machinery. A bare intent vector is refused at render AND at lowering (Freehand's one-intent-per-click law, kept; its fn-only roster, declined — Hicasso has an in-band spelling for cancel-and-replace and admits exactly it). Declined for v0: the `:prefetch :intent` trio (census counts no prefetch site).
- **Migrated:** `card.cljs`'s three census anchors (both bylines + preview link) and `ordinary.cljs`'s comment byline (`profile-href` deleted). `model.cljs` registers the three conduit routes per frame. Prior art is cited in full in HD-027 (`docs/design/hicasso/decisions.md`) and the namespace docstrings.
- **Witnessed:** `front/route_link_cljs_test` (node) — equality-as-data, the grammar's refusals, and the veto mechanics against the SHIPPING routing artefact; `shapes/route_link_dom_cljs_test` (browser) — a real `MouseEvent` on the mounted ported card installs the destination through the routing cascade and the `[:rf/route]`-reading boundary re-renders (a framework runtime sub end-to-end, tying the two beads); a modifier click moves nothing; the prevent veto cancels while its unvetoed sibling navigates (the mutation control); zero residue.

## Coordination — the census box (worker/census-2rtt6-56)

- **Browser gates vs the box's windows:** the box announced its measurement window on rf2-2rtt6.56 and announced CLOSE (uix 05:57–06:00Z, reagent 06:00–06:03:53Z, 2026-08-02). I checked the bead before every browser run; all my browser gates ran outside the window (first at ~06:20Z, final at ~06:41Z), with the announcement/close count re-verified immediately before each.
- **Measured-page impact, stated prominently:** element counts and read counts of every measured page are **unchanged** (a route-link emits the same single `<a>` and reads no sub; card stays 17 elements / 2 reads), so the box's arithmetic checks hold against this tree. Two things do change on the card pages: the anchors' href VALUES (path-form, router-owned — `/profile/jane` not `#/profile/jane`), and per-card render cost (+3 `route-url` syntheses per card per render — the routing artefact's documented render-path cost). **Future clock rows taken on a tree containing this PR are not comparable to rows taken on origin/main's blobs**; the box measures `origin/main`, so its published rows are uncontaminated, but its arithmetic checks should be re-run against this tree before any future row (they pass: counts unchanged).

## Docs

`docs/design/hicasso/decisions.md` gains HD-027 (title now HD-001 … HD-027); `authoring.md` gains the route-link bullet. `mkdocs build --strict` does not cover `docs/design/**`, so per the standing rule I verified by hand: no inbound link targets the renamed H1 anchor (repo-wide grep empty), 27 `## HD-` headings one per decision, HD-027's single code fence balanced, and **no tables were added or edited** in either file; `scripts/check_doc_slugs.py` (whole corpus) is green.

## Quality gates

All gates foreground, logs worktree-local, exit codes echoed. TESTING.md matrix for this diff (CLJS bench/test tree + `docs/design/**`): CLJS unit, browser unit, the fast-PR spine (docs tier + node tier + JVM tier for core + the freehand artefact), doc-slugs, and clj-kondo; the diff owns no bundle-isolation / elision / adapter-smoke / MCP / Xray tier (no production source, adapter, tool, or spec surface touched).

| Gate | Result |
|---|---|
| `npm run test:cljs` (final tree) | **EXIT 0** — 12356 tests, 61762 assertions, 0 failures, 0 errors |
| `npm run test:browser` (final tree) | **EXIT 0** — 979 tests, 6120 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` | **EXIT 0** — PASS line in `gate-fast-pr.log` (docs + node + JVM tiers armed) |
| clj-kondo **2026.04.15** (fetched pin), CI's exact invocation | **EXIT 0** — errors: 0 (4531 pre-existing-class warnings, informational; 1 in new files: `rf/reg-mutation` unresolved-var, same class as the repo's existing facade-var warnings) |
| `python scripts/check_doc_slugs.py` (whole corpus) | **EXIT 0** |

**Mutation proof** (green → red → revert → green; both mutations surgical, both reverted, final green runs above are on the reverted tree):

- **M1 (rf2-2rtt6.53):** `read-key!` stripped map args from the sub-key. Browser gate RED with **20 failing assertions, all three framework-subs witnesses, and nothing else red** — the scalar-key roster stayed green, so the witness distinguishes exactly the map-arg surface it claims. (`gate-mutation-m1.log`)
- **M2 (rf2-2rtt6.54):** `navigate-handler` never activates routing. Browser RED on the click witnesses (plain-click navigation ×4, the unvetoed-sibling control ×2) and node RED on `a-plain-click-is-intercepted`; the prevent-veto half stayed green (the veto still ran) and its **control caught the mutation**, which is what the control exists for. (`gate-mutation-m2-{browser,node}.log`)
