### PR TITLE
docs(hicasso): the guide, brought up to the landed surface

### DIFF
--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -13,7 +13,7 @@ thirty lines and every app gets one of them subtly wrong at least once.
 
 Hicasso collapses that into one call. HD-021 pins the semantics: **one root
 operation associates a DOM node, a frame, and initial events, and returns an
-idempotent teardown.** The names wait for the donor spike; the behaviour does not.
+idempotent teardown.** The names wait for the API freeze; the behaviour does not.
 
 ## Your first app
 
@@ -135,9 +135,8 @@ into another frame's state.
 
 ## Troubleshooting
 
-No Hicasso error ids exist yet, so this table names mechanisms rather than
-`:rf.error/*` ids. Expect the real guide to replace the middle column with minted
-ids.
+No boot-path error ids are minted yet, so this table names mechanisms rather than
+`:rf.error/*` ids.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
@@ -163,7 +162,7 @@ be the answer is a *successful* outcome for Hicasso, not a failure mode.
 
 | Question | Status |
 |---|---|
-| The root operation's name, its config keys, and the teardown's name | Semantics pinned by HD-021; names explicitly unfrozen until the donor spike |
+| The root operation's name, its config keys, and the teardown's name | Semantics pinned by HD-021; names explicitly unfrozen until the API freeze |
 | Does `rf/init!` and adapter installation still apply? | **Not addressed.** Hicasso is a native view layer rather than an adapter, but the record never says whether the root operation subsumes process setup or whether an `init!`-equivalent survives |
 | May a boundary child omit its props map — `[views/todo-app]` rather than `[views/todo-app {}]`? | **Not addressed.** HD-016 says bodies take a single props map; whether the map is optional at the call site is unstated. This page writes `{}` to stay inside what is ruled |
 | Does a hot-reload body swap need an explicit re-render call? | **Not addressed.** HD-021 pins the guarantees, not the mechanism |

--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -1,10 +1,10 @@
 # Getting started
 
-> **Pre-implementation draft — Hicasso does not exist yet.** This page describes the
-> *designed* surface so it can be read before it is built. Spellings marked
-> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
-> is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-025).
+> **Draft ahead of the product artefact.** This page teaches the landed surface —
+> ruled in [decisions.md](../decisions.md) (HD-001…HD-027), witnessed by the bench
+> arm's tests under `implementation/freehand/test/re_frame/bench/hicasso/` — but no
+> `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
+> stay provisional until the API freeze.
 
 Booting a re-frame2 app today takes about thirty lines: create a React root, install
 an adapter, render a `frame-root` inside it, remember the root across hot reloads so
@@ -56,9 +56,9 @@ Three namespaces, in the shape any re-frame2 app already uses.
        title]])])
 ```
 
-That view reads with `sub`, which is the *collector* surface — one of two candidates
-still under adjudication. [Views and reads](02-views-and-reads.md) covers both and
-explains why this draft doesn't choose. Nothing on this page turns on it.
+That view reads with `sub` — an ordinary function call, and the ruled read surface
+(the fork the earlier draft hedged on was decided on 2026-07-31).
+[Views and reads](02-views-and-reads.md) covers it.
 
 And the boot namespace, which is the actual subject of this page:
 

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -1,21 +1,40 @@
 # Views and reads
 
-> **Pre-implementation draft — Hicasso does not exist yet.** This page describes the
-> *designed* surface so it can be read before it is built. Spellings marked
-> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
-> is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-025).
+> **Draft ahead of the product artefact.** This page teaches the landed surface —
+> ruled in [decisions.md](../decisions.md) (HD-001…HD-027), witnessed by the bench
+> arm's tests under `implementation/freehand/test/re_frame/bench/hicasso/` — but no
+> `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
+> stay provisional until the API freeze.
 
 A Hicasso view is a function from a props map to hiccup, which reads whatever
-subscriptions it needs along the way. That much is settled and has been since the
-charter.
+subscriptions it needs along the way — with `sub`, an ordinary function call, at
+the point where the value is used:
 
-**How the reads are spelled is not.** HD-002 has two candidate surfaces in the ring
-and a measurement scheduled to choose between them. This page teaches both, because
-that is the honest state of the design — and because if you skip to one of them you
-will pick the wrong one about half the time.
+```clojure
+(ns todo.views
+  (:require [re-frame.hicasso :as h :refer [defview sub]]))
 
-Everything before the fork applies to both.
+(defview todo-row [{:keys [id]}]
+  (let [todo     (sub [:todo/by-id id])
+        editing? (sub [:todo.ui/editing? id])]
+    [:li
+     [:span (:title todo)]
+     [:button {:on-click [:todo/toggle id]} "✓"]
+     (when editing?
+       [:input {:value    (sub [:todo.ui/draft id])   ;; read inside a conditional
+                :on-input [:todo.ui/edit id ::h/value]}])]))
+```
+
+Note the third read: it happens only when `editing?` is true, in the middle of an
+expression, and that is legal — the whole point of the surface. An earlier draft
+of this guide taught two candidate read surfaces because HD-002 had a measured
+fork open between them. **The fork is ruled.** On 2026-07-31 the operator ruled
+the ambient collector — `sub` as a plain call, anywhere in the body — the only
+acceptable read surface on ergonomics; the grouped `use-subs` alternative was
+ruled below the usability bar and survives only as a comparator rendering in the
+bench arm. The ruling and the three-rendering diff that informed it are recorded
+in the [dogfood judgement](../studio/arm1-lean-react-dogfood-judgement.md);
+HD-002's correctness gates were not waived and are witnessed there too.
 
 ## Boundaries and inlining
 
@@ -31,10 +50,17 @@ A **vector** in head position mints a React element. It is its own boundary: Rea
 owns its identity, and it can re-render without its parent.
 
 A **plain call** is just a function call. Its hiccup is spliced into the caller's
-tree, it has no boundary of its own, and — this is the part that matters for
-performance — any subscription it reads donates that read *upward* to the enclosing
-boundary. Helpers cost nothing at runtime and buy no re-render granularity, which is
-the trade in one sentence.
+tree, it has no boundary of its own, and any `sub` it performs donates that read
+*upward* to the enclosing boundary. Helpers cost nothing at runtime and buy no
+re-render granularity, which is the trade in one sentence. And because reads are
+ordinary calls, **helpers can read**: a `filter-button` that needs the current
+filter just reads it, and the read belongs to whichever boundary is rendering —
+no value threaded down as an argument. The census's article card is written
+exactly this way
+(`implementation/freehand/test/re_frame/bench/hicasso/shapes/card.cljs`): one
+plain function with two reads, called from a one-boundary page in one shape and
+wrapped in a one-line `defview` in another, with the markup, reads and intents
+identical between the two.
 
 One rule, one visible distinction. This is deliberate: re-render granularity is a
 thing you should be able to see by reading the source, and Reagent's `^{:key}`
@@ -43,7 +69,7 @@ metadata folklore is deleted along with it. Keys go in the props map:
 ```clojure
 (defview todo-list [_]
   [:ul
-   (for [id (sub [:todo/visible-ids])]     ;; collector spelling — see the fork below
+   (for [id (sub [:todo/visible-ids])]
      [todo-row {:key id :id id}])])
 ```
 
@@ -99,182 +125,32 @@ value arrives. What you have bought yourself is invalidation that is **too coars
 never invalidation that is missing. Moving the read down is a granularity fix, not a
 correctness fix, and if you go looking for a lost update you will not find one.
 
-## The fork: how a view reads a subscription
+## How `sub` works, in the four sentences that matter
 
-HD-002 ranks three tiers. One of them is not a product surface at all — **scalar
-per-read hooks** (one `useSyncExternalStore` per read, the raw UIx spine) are a
-measurement control only. They can't be the product: N reads means N hooks, which
-blows HD-020's ≤2-hook budget on the very first realistic view, and React's hook
-rules forbid reading conditionally.
+One fixed runtime hook per boundary collects the reads the body actually made,
+and the commit installs exactly that edge set — so **a branch not taken
+contributes no edge**, measured on the dogfood screen, where the collector
+rendering holds fewer edges than the declaration-style rendering of the same
+page. Reads inside a lazy `for` are forced by the same pass that turns hiccup
+into elements, so they land in the right boundary's window. **A read that
+escapes the render is loud, never silently stale**: a stored handler, a stashed
+lazy seq, or a `delay` forced later fails naming the query, and an unforced
+`delay` crossing a boundary is refused at the crossing — the alternative in each
+case would be a value that is correct on screen and frozen thereafter,
+attributable to nothing. The honest cost sits on the other side: the edge set is
+a function of what the body *did*, so a body whose control flow changes its
+reads from render to render pays a re-subscribe that replaces the whole set, not
+just the changed key.
 
-That leaves two real candidates, and this guide does not pick between them, because
-**HD-002 is a measurement and the measurement has not run.**
+That last sentence is the one to design around. It is a real difference from a
+surface whose edges are static, and it is priced honestly in the
+[dogfood judgement](../studio/arm1-lean-react-dogfood-judgement.md) — as is the
+kill condition that still stands over the mechanism: the first time correctness
+requires a per-read candidate ledger, the collector dies, whatever its numbers
+([hd-002-adjudication.md](../hd-002-adjudication.md)). The witnesses so far say
+it does not.
 
-### Surface A — grouped `use-subs` (the current default)
-
-One hook, at the top of the body, receiving every query the body needs. The hook
-count and order are fixed; the *query values* are free to vary.
-
-```clojure
-(ns todo.views
-  (:require [re-frame.hicasso :as h :refer [defview use-subs]]))
-
-(defview todo-row [{:keys [id]}]
-  (let [{:keys [todo editing? draft]}
-        (use-subs {:todo     [:todo/by-id id]
-                   :editing? [:todo.ui/editing? id]
-                   :draft    [:todo.ui/draft id]})]
-    [:li
-     [:span (:title todo)]
-     [:button {:on-click [:todo/toggle id]} "✓"]
-     (when editing?
-       [:input {:value draft :on-input [:todo.ui/edit id ::h/value]}])]))
-```
-
-`use-subs` **[unfrozen]** takes a map of names to query vectors and returns a map of
-names to values. You destructure it and use plain locals for the rest of the body.
-
-**Status.** This is the **product default** today. It is the only budget-compliant
-surface with a fixed hook count, and HD-002 requires it to be dogfooded from the
-start of P1 rather than held in reserve — precisely so that if the challenger loses,
-the fallback is a surface that has already been scored, not one discovered mid-clock.
-
-**What it costs you.** Reads sit at fixed sites, so conditional reads need a
-different shape. Two moves cover it:
-
-```clojure
-;; 1. Conditionally-constructed query values, at a fixed site.
-(defview article [{:keys [id draft?]}]
-  (let [{:keys [body]} (use-subs {:body (if draft?
-                                          [:article/draft-body id]
-                                          [:article/published-body id])})]
-    [:article body]))
-
-;; 2. A conditional child boundary — the read moves into the child,
-;;    which only exists when the condition holds.
-(defview article-comments [{:keys [id]}]
-  (let [{:keys [comments]} (use-subs {:comments [:comments/for id]})]
-    [:ul (for [c comments] [comment-row {:key (:id c) :comment c}])]))
-
-(defview article-page [{:keys [id show-comments?]}]
-  [:<>
-   [article {:id id}]
-   (when show-comments? [article-comments {:id id}])])
-```
-
-The second move is the one to internalise: **a conditional read is a conditional
-boundary.** Which is often the right design anyway, since it is also where you
-wanted the re-render granularity.
-
-There is a sharper consequence for helpers. **An inlined helper cannot read under the
-grouped surface** — and the reason is not the one you would guess. HD-002 defines
-grouped as one fixed hook receiving *the complete query collection before the body*,
-and a helper's queries are not knowable before the body, because the body has to run
-to reach the helper. A reading helper is structurally incompatible with the tier as
-defined. HD-020's budget agrees from the other side: it is already fully consumed by
-the subscription hook and the frame hook, so a helper calling `use-subs` would be a
-third hook in the boundary.
-
-Both grounds are the [HD-002 adjudication](../hd-002-adjudication.md)'s, which reached
-the verdict after this guide's first pass had reached it from React's hook rules — the
-weaker argument, now withdrawn. React, notably, is *not* the reason. A helper called
-unconditionally and exactly once per render, itself calling `use-subs`
-unconditionally, is a custom hook by React's own definition and React would allow it.
-The grouped tier forbids it anyway. Do not reach for the hook-rules argument when
-someone asks you why.
-
-So there are two shapes for a helper:
-
-```clojure
-;; 1. The helper takes values and reads nothing.
-(defn- badge [{:keys [count]}]
-  [:span.badge count])
-
-;; 2. The helper contributes QUERIES, which compose into the one hook.
-(defn- badge-queries [id]
-  {:badge-count [:cart/count id]})
-
-(defview cart-header [{:keys [id]}]
-  (let [{:keys [title badge-count]}
-        (use-subs (merge {:title [:cart/title id]}
-                         (badge-queries id)))]
-    [:header title (badge {:count badge-count})]))
-```
-
-The second shape adds nothing to the surface: `use-subs` takes a map and maps merge.
-Hook count fixed, order fixed, the complete collection still assembled before the
-body. It matters beyond ergonomics — the adjudication's recommendation is that the
-dogfood screen's grouped rendering exercise query-contributing helpers explicitly, so
-that the ergonomic half of the HD-002 verdict is not scored against a grouped
-rendering written with one hand tied.
-
-### Surface B — the ambient collector (the challenger)
-
-`sub` is an ordinary function call. Call it anywhere in the body: inside a `when`,
-inside a `for`, inside an inlined helper. One fixed runtime hook collects the reads,
-and the runtime diffs the edge set after the body returns.
-
-```clojure
-(ns todo.views
-  (:require [re-frame.hicasso :as h :refer [defview sub]]))
-
-(defview todo-row [{:keys [id]}]
-  (let [todo     (sub [:todo/by-id id])
-        editing? (sub [:todo.ui/editing? id])]
-    [:li
-     [:span (:title todo)]
-     [:button {:on-click [:todo/toggle id]} "✓"]
-     (when editing?
-       [:input {:value    (sub [:todo.ui/draft id])   ;; read inside a conditional
-                :on-input [:todo.ui/edit id ::h/value]}])]))
-```
-
-Note the third read: it happens only when `editing?` is true, in the middle of an
-expression, and that is the entire point of the surface.
-
-**Status.** This is the **challenger**, and HD-002 says it is ridden hardest in P1 —
-but it ships only by *winning*. It is the same mechanism class as the per-read
-dependency ledger that the predecessor programme measured as its single largest
-cost, so it has to earn its place rather than defend it. There is a standing
-tripwire that **overrides the clock**: the first time correctness requires a
-candidate ledger or generic post-render dependency reconciliation, the collector
-dies, however good its numbers look.
-
-**What it buys you.** The census's tier-1 shape is conditional-reads-legal, and most
-of the authoring differentiation against raw UIx lives here. Helpers can read.
-Loops can read. You write the obvious thing.
-
-### How this gets decided
-
-Four adjudication clauses are pinned before any P1 code is written, and they now have
-a written adjudication of their own — [hd-002-adjudication.md](../hd-002-adjudication.md),
-a delegated advisory the operator may overturn. Read it before you form an opinion
-about the fork. It settles what the collector may do and what kills it; it does
-**not** decide which surface ships, and neither does this page.
-
-The four clauses:
-
-1. a render/commit **ownership state machine** — how a candidate read survives a
-   winning render and disappears after an abandoned render, a replay, or a teardown;
-2. the **exact allowed edge-diff operation**, distinguished from the ledger class
-   that trips the kill rule;
-3. **two pre-registered strategy hypotheses**, each counted only by a benchmarked
-   commit — tuning passes don't count;
-4. the **survival metric** — steady-state allocation slope across warm 1/3/7/20
-   reads, plus zero retained per-occurrence objects after commit or teardown.
-
-Three outcomes, and only three. Collector wins and becomes the product mechanism;
-collector loses and grouped stays the default; **both fail their gates and the
-outcome is null.** There is no fourth read model, and there is no "internal swap" —
-either way this is an API choice made on evidence, in public.
-
-The dogfood screen is written in all three renderings — collector, grouped, and raw
-UIx — and judged on diff and on the authors' preference. Ergonomics is half the
-verdict, not a tiebreaker.
-
-## Reads that are the same either way
-
-Whichever surface wins:
+## Rules every read obeys
 
 - **Reading outside a render is an error.** There is no `@`-anywhere. Handler and
   utility code uses `rf/subscribe-once`, which is a one-shot read that retains no
@@ -293,14 +169,12 @@ Whichever surface wins:
 
 ## Troubleshooting
 
-No Hicasso error ids exist yet; this table names mechanisms.
-
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | A child re-renders whenever its parent does | Expected — there is no default memoization (HD-006) | Move the boundary, or apply `React.memo` where you measured a reason |
 | One cell changes and 300 boundaries re-render | The read lives too high in the tree | Push the read down into the boundary that displays it |
 | One value changes and a whole subtree re-renders with it | The value is read in an ancestor and passed down as a prop. Nothing is *lost* — the reading ancestor re-renders with the new value and, there being no default memoization, so does everything under it. Coarse invalidation, not missed invalidation | Read at the point of use, so the boundary that displays the value is the boundary that invalidates |
-| A helper wants to read, under Surface A | Grouped takes the complete query collection *before* the body, so a helper's queries are out of reach — HD-002's definition, not React's hook rules | Pass the value in, or have the helper return queries that `merge` into the one `use-subs` call |
+| A read after the render throws, naming the query | A handler closure, a stashed lazy seq, or a `delay` deferred a `sub` past the render | Read during the render and close over the value; the loud error is the alternative to a silently frozen edge |
 | Index thrash, subscriptions constantly re-created | Query args that are not *value*-stable — a re-sorted seq, a folded-in timestamp, a JS object or a function | Allocation is fine; two equal persistent values are one key. Make the args equal under `=` between renders |
 | A body's side effect fires twice | StrictMode double-invoke | Bodies are pure; move the effect out |
 
@@ -316,10 +190,6 @@ independently, not because the markup got long.
 
 | Question | Status |
 |---|---|
-| Which read surface ships | **Open by design.** HD-002 is decided by P1 measurement; three outcomes, including null |
-| `use-subs` and `sub` spellings | Pre-declared working names; [authoring.md](../authoring.md) holds all declaration spellings unfrozen until the tournament |
-| Does `use-subs` accept anything but a map — a vector of queries, a single query? | **Not addressed.** Only the map form appears in the record |
-| Can an inlined helper read under Surface A? | **Answered: no** — and no longer on this guide's authority. [hd-002-adjudication.md](../hd-002-adjudication.md) derives it from HD-002's "complete query collection before the body", with HD-020's spent budget as a second ground. This guide's earlier hook-rules argument reached the same verdict on weaker ground and is withdrawn |
-| Whether query-contributing helpers are the taught idiom or merely legal | The adjudication marks the shape **[INFERRED]** and recommends the dogfood screen exercise it. Nothing rules it in as the taught form |
-| `defview`'s own spelling and whether a props-map argument is required | Working name; the single-props-map body signature is ruled by HD-016 |
+| `sub` and `defview` spellings | Working names; [authoring.md](../authoring.md) holds all declaration spellings unfrozen until the freeze |
+| The bar | The read surface is ruled, but the ship-bar rows (mount and bulk ≤ 1.0× Reagent, HD-012) are not yet taken; the programme can still end null on them |
 | The dev warning for an unkeyed seq — its id and whether it is dev-only | **Not addressed** beyond "dev warning" |

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -1,10 +1,10 @@
 # Events as data
 
-> **Pre-implementation draft — Hicasso does not exist yet.** This page describes the
-> *designed* surface so it can be read before it is built. Spellings marked
-> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
-> is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-026).
+> **Draft ahead of the product artefact.** This page teaches the landed surface —
+> ruled in [decisions.md](../decisions.md) (HD-001…HD-027), witnessed by the bench
+> arm's tests under `implementation/freehand/test/re_frame/bench/hicasso/` — but no
+> `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
+> stay provisional until the API freeze.
 
 Handler attributes are where a data-oriented view layer usually gives up. You have
 been writing pure data all the way down the tree, and then `:on-click` needs a
@@ -21,10 +21,15 @@ callback.
 That is not sugar for a closure you could have written. The tree still holds data at
 that node, which means a test can assert it with `=` and a tool can read it.
 
-## The value placeholder
+Lowering is by shape, not by roster: any prop whose name reads `on-` plus a letter
+(or camelCase `onClick`, for the migrating author) is an event position, so there is
+no list of blessed event names to keep in step with the DOM.
 
-Most handlers need something out of the event object. `::h/value` **[unfrozen]** is
-the placeholder that gets substituted at dispatch time:
+## The value placeholders
+
+Most handlers need something out of the event object. Two markers exist —
+`::h/value` and `::h/checked` — substituted at dispatch time with the event
+target's `.value` and `.checked`:
 
 ```clojure
 [:input {:value    draft
@@ -33,11 +38,13 @@ the placeholder that gets substituted at dispatch time:
 
 At dispatch, the placeholder is replaced by the input's value, so the handler
 receives `[:todo.ui/edit 7 "milk"]` — an ordinary event vector, indistinguishable
-from one you dispatched by hand.
+from one you dispatched by hand. Substitution happens at the intent vector's top
+level only, which is the shape the corpus writes; a marker buried in nested
+structure is not looked for.
 
-The census says this covers about **97% of the corpus's 183 handler sites**. That
-number is why the placeholder exists: one marker turns nearly every handler
-attribute in a real application into data.
+The census says the markers cover about **97% of the corpus's 183 handler sites**.
+That number is why they exist: two markers turn nearly every handler attribute in a
+real application into data.
 
 ## Functions still work
 
@@ -153,20 +160,62 @@ Keyboard handling arrives as data, not as a `case` over `.-key`:
 ```clojure
 [:input {:value    draft
          :on-input [:todo.ui/edit id ::h/value]
-         :on-keydown {"Enter"  [:todo.ui/commit id]
-                      "Escape" [:todo.ui/cancel id]}}]
+         :on-key-down {"Enter"  [:todo.ui/commit id]
+                       "Escape" [:todo.ui/cancel id]}}]
 ```
 
-A map from key name to intent. Keys you don't list are ignored.
+A map from key name to intent. The names are strings, matched against the DOM
+event's own `.key` value; keys you don't list are ignored, and there is no
+modifier language.
 
 The reason this belongs in the runtime rather than in your view is the composition
 law: **a composing Enter commits nothing.** Mid-IME, Enter selects a candidate — it
 is not a submit, and treating it as one is how a Japanese or Chinese user loses a
 sentence. The runtime centralises that check, including the legacy keyCode-229
-signal that some browsers still use to say "this keystroke belongs to the IME."
+signal that some browsers still use to say "this keystroke belongs to the IME" —
+and it reads both signals off the *native* event, because React's synthetic
+keyboard event drops `isComposing`, which is exactly the trap a hand-written
+handler falls into.
 
 Get this wrong in your own handler and it fails silently for every user who
 composes. Which is a good argument for it not being your handler.
+
+## Links: `route-link` and the navigate head
+
+Most of an application's anchors are navigations — the census counts **106
+route-links across 85 files**, which makes the link the most-repeated tier-1 form
+there is. Its spelling is `route-link`, a plain function over the routing
+artefact's link seam (HD-027):
+
+```clojure
+(route-link {:to :conduit.profile/show :params {:username username}}
+  username)
+```
+
+You name a route and its params and never see a URL. What comes back is one real
+`<a>` whose `:href` is routing's own synthesis and whose `:on-click` carries the
+click decision **as data**, under the second reserved head, `[::h/navigate {…}]` —
+so two renders of one link are equal under `=`, and a structural test reads the
+click decision off the tree. Because it is a plain function, not a boundary, it
+inlines: no hook, no subscription read, no row in any boundary count. An author
+byline is not a unit of re-render.
+
+The click law is routing's, stated once, and it is the one every other link
+surface already runs: a modifier-click or auxiliary click stays the browser's (a
+new tab opens), a `:target` or `:download` anchor stays native, and everything
+else is `preventDefault` plus a dispatch of the routing intent to the frame that
+was captured at render. Rendering a `route-link` with routing absent fails at
+render, naming the `:to` — never a dead anchor.
+
+**The `:on-click` you pass is the pre-navigation veto**, and its roster is closed:
+`nil`, `[::h/prevent [:app/event]]`, `h/fn`, or a plain function. The prevent form
+is the declarative veto — the navigation is cancelled and your intent dispatched
+instead, which is exactly the cancelable-navigation case the prevent head was
+built for. A **bare** intent vector there is refused loudly: the click already
+produces the one routing intent, and one user action must not yield two semantic
+events. Witnessed end-to-end — grammar, equality, refusals, real clicks through a
+real router — in `front/route_link_cljs_test` and
+`shapes/route_link_dom_cljs_test`.
 
 ## Callbacks carry their frame
 
@@ -191,7 +240,8 @@ are named in the sections above.
 |---|---|---|
 | Page navigates and reloads on form submit | Something bypassed the intent path — a hand-written `:on-submit` function | Use an intent vector, or call `.preventDefault` yourself in the function |
 | Handler receives the placeholder keyword instead of a value | The placeholder was used at an event position with no value to substitute | `::h/value` is for value-bearing events; read the event object with a function elsewhere |
-| Enter commits half-typed Japanese text | Composition handling was written by hand | Use the `:on-keydown` key map — the composition law is centralised there |
+| Enter commits half-typed Japanese text | Composition handling was written by hand | Use the `:on-key-down` key map — the composition law is centralised there |
+| A `route-link` refuses your `:on-click` intent vector | The click already produces the one routing intent — a bare second intent is one action, two events | Wrap it: `[::h/prevent [:app/event]]` cancels the navigation and dispatches yours instead |
 | `:rf.error/no-frame-context` from a timeout | A bare `dispatch` in async code | Capture the frame at the call site, or dispatch an event that owns the async work through `:fx` |
 | An intent fires but no handler runs | Unregistered event id | Registration happens on namespace load; check the boot namespace requires it |
 
@@ -208,8 +258,6 @@ dispatch, and a plain `(fn …)` when you want to read it and do something else.
 
 | Question | Status |
 |---|---|
-| The auto-prevent opt-out spelling | **Settled** (HD-026). The submit opt-out is `h/fn`; prevention elsewhere is opted in by the `[::h/prevent …]` head, and the metadata spelling this page once carried is retired |
-| Whether markers other than `::h/value` exist | **Not addressed.** The charter names "the intent-marker roster and its one pure materializer" as a micro-mechanic worth copying from the predecessor, but only `::h/value` is spelled. A checked-state marker for checkboxes is an obvious gap this guide could not fill honestly — the example on [Getting started](01-getting-started.md) sidesteps it by passing the id and letting the handler flip the value |
-| Which attributes get intent lowering | **Not addressed.** `:on-click`, `:on-input`, `:on-submit`, and `:on-keydown` appear in the record; whether lowering is universal across `:on-*` or a named roster is unstated |
-| The key map's key vocabulary | Key names appear as strings (`"Enter"`, `"Escape"`); whether keywords are accepted, and how modifiers are spelled, is unstated |
-| `::h/value` semantics on non-input elements | **Not addressed** |
+| `h/fn`'s spelling | Working name; HD-024 leaves the spelling unfrozen like every declaration spelling |
+| A symmetric allow-default head | **Explicitly not shipped.** Added only if dogfooding produces a real site needing both native submission and equality-based structural testing (HD-026) |
+| `:prefetch` on `route-link` | **Declined for v0** — the census counts no prefetch site; reopens if one appears (HD-027) |

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -1,10 +1,10 @@
 # Controlled inputs
 
-> **Pre-implementation draft — Hicasso does not exist yet.** This page describes the
-> *designed* surface so it can be read before it is built. Spellings marked
-> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
-> is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-025).
+> **Draft ahead of the product artefact.** This page teaches the landed surface —
+> ruled in [decisions.md](../decisions.md) (HD-001…HD-027), witnessed by the bench
+> arm's tests under `implementation/freehand/test/re_frame/bench/hicasso/` — but no
+> `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
+> stay provisional until the API freeze.
 
 A controlled text input is the hardest correctness problem a view layer has, and
 almost none of the difficulty is visible in the code you write.
@@ -13,21 +13,15 @@ Here is what you write:
 
 ```clojure
 (defview title-field [{:keys [id]}]
-  (let [{:keys [draft]} (use-subs {:draft [:todo.ui/draft id]})]
-    [:input {:type     :text
-             :value    draft
-             :on-input [:todo.ui/edit id ::h/value]}]))
+  [:input {:type     :text
+           :value    (sub [:todo.ui/draft id])
+           :on-input [:todo.ui/edit id ::h/value]}])
 ```
 
-That's it. Value in from a subscription, intent out to an event. The rest of this
-page is about the machinery underneath, because you need to know what it guarantees
-and where it stops.
-
-The read above uses the grouped surface; on the collector surface the same line is
-`(sub [:todo.ui/draft id])` inline in the attribute map.
-[Views and reads](02-views-and-reads.md) explains why there are two and why this
-draft doesn't choose. Nothing on this page depends on which one wins — the door is
-below both of them.
+That's it. Value in from a subscription, intent out to an event — ordinary
+`:value` and `:on-input`, no ceremony. The rest of this page is about the
+machinery underneath, because you need to know what it guarantees and where it
+stops.
 
 ## Why this is hard
 
@@ -47,17 +41,22 @@ generous.
 HD-019 names the mechanism instead of leaving it to taste, because the first
 controlled-input commit cannot stall on an undecided design.
 
-On the lean-React arm, a controlled element's intent **dispatches synchronously
-inside the discrete browser event**, and the subscription layer's store notification
-runs synchronously too, so React commits the echo in the same turn. The value is
-back in the DOM before the browser's event handling finishes.
+A controlled element's intent **dispatches synchronously inside the discrete
+browser event**, and the subscription layer's store notification runs
+synchronously too, so React commits the echo in the same turn. The value is back
+in the DOM before the browser's event handling finishes.
 
-`flushSync` is never the general default, and the one exception is named rather than
-left to taste: the controlled-text converge flushes the door's pending commit before
-React's end-of-event restore, so the caret survives a rejected or normalised
-keystroke. That exception is evidence-gated and scoped to controlled text entry in
-the element path. Needing `flushSync` anywhere else would still be a finding, not an
-implementation detail.
+`flushSync` is never the general default, and the one exception is named rather
+than left to taste: the controlled-text **converge** flushes the door's pending
+commit before React's end-of-event restore, so value *and caret* are correct
+in-turn — including when the model rejected or normalised the keystroke. What you
+get for free is exactly what the first example shows: ordinary `:value` and
+`:on-change`/`:on-input`, no ceremony, and a caret that stays put. The boundary
+is equally exact: the exception is one audited call site, reached from the
+element path once per keystroke, on controlled text entry only (a caret-bearing
+`input` or a `textarea` with a non-nil `:value`), and inert everywhere else.
+Needing `flushSync` anywhere else would still be a finding, not an implementation
+detail.
 
 ## What the door guarantees
 
@@ -94,17 +93,14 @@ Your handler doesn't have to accept what was typed:
       nil)))                                       ;; rejected — no-op, model unchanged
 ```
 
-On the lean-React arm the rejected path leans on **React's own end-of-discrete-event
-restore**: the DOM node briefly holds the typed character, the model doesn't change,
-and React reasserts the model value when the discrete event ends. You get the
-rejection for free from the host, and R-A2 says the caret survives it.
-
-This is one of the concrete payoffs of accepting React's model rather than owning
-the DOM. On a PATCH back end the obligation transfers to the renderer, which must
-converge value and checked state against the live node after every controlled
-dispatch, caret preserved, composition fenced — a hard gate in
-[architecture.md](../architecture.md). A PATCH spike that cannot demonstrate that on
-the 100-cell grid has failed regardless of its clock numbers.
+The rejected path leans on **React's own end-of-discrete-event restore** for the
+*value*: the DOM node briefly holds the typed character, the model doesn't change,
+and React reasserts the model value when the discrete event ends. The **caret**,
+though, React's restore throws away — so the runtime takes it itself, in the
+element path, which is what the converge above is for. The gap was measured
+before it was closed (HD-019 records both beads), and R-A2 is why closing it was
+not optional. Either way, none of this is your code: return `nil` from the
+handler and the field shows the model, caret intact.
 
 ## Forwarding attributes onto a controlled input
 
@@ -168,7 +164,7 @@ the revision does not have a Hicasso spelling yet; see **Not settled yet**.
 
 ## Troubleshooting
 
-No Hicasso error ids exist yet; this table names mechanisms.
+This table names mechanisms; the door's failures are behavioural, not error ids.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
@@ -199,5 +195,5 @@ with a commit on blur is not a compromise. It is the right shape.
 | The revision prop's spelling on a controlled element | **Not addressed.** The reset law is ruled; the attribute that carries the revision is unnamed |
 | The buffered / draft-and-commit input ladder | **Post-v0, explicitly.** The charter defers "the full buffered/revision input ladder"; v0 ships R-A1/R-A2 and no more |
 | The controls kit that owns drafts and revisions | **Post-v0.** HD-009 leans on it for ephemeral state, and it does not exist in v0 — so in v0 a draft is app-db state you write yourself |
-| Which props count as controlled | HD-010's merge law names `:value` and `:checked`; whether the roster is longer is unstated |
-| Whether `:on-input` or `:on-change` is the taught attribute | Both appear across the record. This guide uses `:on-input` for text and `:on-change` for checkboxes, matching the source examples, but the choice is not ruled |
+| Which props count as controlled | HD-010's merge law names `:value` and `:checked`; the converge's own scope is exact (caret-bearing `input` or `textarea`, non-nil `:value`); whether the controlled roster is longer is unstated |
+| Whether `:on-input` or `:on-change` is the taught attribute | The landed screens write `:on-input` for text and `:on-change` for checkboxes; the choice is convention, not ruling |

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -1,10 +1,11 @@
 # Interop
 
-> **Pre-implementation draft — Hicasso does not exist yet.** This page describes the
-> *designed* surface so it can be read before it is built. Spellings marked
-> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
-> is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-025).
+> **Draft ahead of the product artefact.** This page teaches the ruled surface —
+> [decisions.md](../decisions.md) (HD-001…HD-027) — and spellings marked
+> **[unfrozen]** stay provisional until the API freeze. One honesty note specific
+> to this page: `defhost` is ruled (HD-011) but is the one tier-1 door the bench
+> arm has not yet exercised, so unlike its siblings this page still describes
+> design rather than witnessed behaviour.
 
 You want a date picker from npm. In Reagent you write `[:> DatePicker {...}]` and
 move on. Hicasso asks you to write one line first:
@@ -246,7 +247,8 @@ will rescue it later.
 
 ## Troubleshooting
 
-No Hicasso error ids exist yet; this table names mechanisms.
+This table names mechanisms; the one minted id on this surface —
+`:rf.error/hicasso-ref-vector-reserved` — is covered above.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|

--- a/docs/design/hicasso/draft-guide/06-theming.md
+++ b/docs/design/hicasso/draft-guide/06-theming.md
@@ -1,10 +1,10 @@
 # Theming
 
-> **Pre-implementation draft — Hicasso does not exist yet.** This page describes the
-> *designed* surface so it can be read before it is built. Spellings marked
-> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
-> is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-025).
+> **Draft ahead of the product artefact.** This page teaches the ruled surface —
+> [decisions.md](../decisions.md) (HD-001…HD-027) — and spellings marked
+> **[unfrozen]** stay provisional until the API freeze. Theming is ruled (HD-010,
+> HD-023) but largely unexercised by the bench arm, and this page still carries
+> the record's one genuine hole, named below.
 
 Every React component library reaches for context to theme itself. Hicasso doesn't
 ship a context API at all, and its theming uses none.
@@ -116,7 +116,7 @@ The obvious one: one view reads `:theme/current` and puts it on its own element.
 
 ```clojure
 (defview theme-scope [{:keys [children]}]
-  [:div {:data-theme (name (sub [:theme/current]))}   ;; collector spelling
+  [:div {:data-theme (name (sub [:theme/current]))}
    children])
 
 ;; At the root:
@@ -247,7 +247,7 @@ than a mechanism the guide pretends doesn't exist.
 
 ## Troubleshooting
 
-No Hicasso error ids exist yet; this table names mechanisms.
+This table names mechanisms rather than error ids.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|

--- a/docs/design/hicasso/draft-guide/07-ephemeral-state.md
+++ b/docs/design/hicasso/draft-guide/07-ephemeral-state.md
@@ -1,10 +1,10 @@
 # Ephemeral state
 
-> **Pre-implementation draft — Hicasso does not exist yet.** This page describes the
-> *designed* surface so it can be read before it is built. Spellings marked
-> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
-> is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-025).
+> **Draft ahead of the product artefact.** This page teaches the landed surface —
+> ruled in [decisions.md](../decisions.md) (HD-001…HD-027), witnessed by the bench
+> arm's tests under `implementation/freehand/test/re_frame/bench/hicasso/` — but no
+> `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
+> stay provisional until the API freeze.
 
 Is this dropdown open? Is this row hovered? Is this panel expanded?
 
@@ -69,13 +69,10 @@ forever:
 ```
 
 ```clojure
-;; Read shown in the grouped surface; the collector spelling is
-;; (sub [:panel/expanded? id]) inline. See 02-views-and-reads.md.
 (defview panel [{:keys [id title]}]
-  (let [{:keys [expanded?]} (use-subs {:expanded? [:panel/expanded? id]})]
-    [:section
-     [:h3 {:on-click [:panel/toggle id]} title]
-     (when expanded? [panel-body {:id id}])]))
+  [:section
+   [:h3 {:on-click [:panel/toggle id]} title]
+   (when (sub [:panel/expanded? id]) [panel-body {:id id}])])
 ```
 
 Ten lines, once. A hundred panels, no further cost. And you get the things a local
@@ -200,14 +197,15 @@ Exit is the phase that transitions happily, because the node is already painted.
 
 ## Troubleshooting
 
-No Hicasso error ids exist yet; this table names mechanisms.
+This table names mechanisms; the one minted id on this surface is named in its
+row.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | Reaching for `useState` to hold "is this open?" | That's semantic state | app-db, or CSS if the platform tracks it |
 | A dismissed item disappears instantly with no exit animation | The node left with the data | `h/presence` with a `:timeout-ms` at least as long as the exit transition |
 | A retained node still takes focus or clicks while fading | The exit override does not carry `:inert` / `:aria-hidden` | Put all three in the `::h/unmounting` map |
-| An exit override on a child view does nothing | Presence merges overrides into nodes it can see; a view is opaque to it | The view receives `:rf/phase` — branch or style on that |
+| An exit override on a view head raises `:rf.error/hicasso-presence-override-on-a-view` | Presence merges overrides into nodes it can see; a view is opaque to it, and a silently dropped override is the failure class the loud error exists to delete | The view receives `:rf/phase` — branch or style on that |
 | Every panel in a list opens at once | The state isn't parameterised by instance | Key the app-db path by the widget's id |
 | A hook body can't be tested headlessly | Hooks put a body outside headless scope, by design | Move the semantic half to app-db; mount-test the mechanics |
 | Hook-order error after a conditional early-return | React's rules, now yours | Hooks at the top of the body, unconditionally |

--- a/docs/design/hicasso/draft-guide/08-testing.md
+++ b/docs/design/hicasso/draft-guide/08-testing.md
@@ -1,10 +1,10 @@
 # Testing
 
-> **Pre-implementation draft — Hicasso does not exist yet.** This page describes the
-> *designed* surface so it can be read before it is built. Spellings marked
-> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
-> is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-025).
+> **Draft ahead of the product artefact.** This page teaches the landed surface —
+> ruled in [decisions.md](../decisions.md) (HD-001…HD-027), witnessed by the bench
+> arm's tests under `implementation/freehand/test/re_frame/bench/hicasso/` — but no
+> `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
+> stay provisional until the API freeze.
 
 There are two doors into a Hicasso view under test, and knowing which one you are
 allowed through is most of the skill.
@@ -37,15 +37,19 @@ Two things are doing the work here.
 
 **Sub reads are overridable through a pure read resolver.** You hand the render a
 map of query vector to value, and the body reads from it. No frame, no app-db, no
-registration — just the values the view is a function of. This works identically
-under either read surface from [Views and reads](02-views-and-reads.md): grouped or
-collector, a read is a read, and the resolver answers it.
+registration — just the values the view is a function of. `sub` is an ordinary
+call ([Views and reads](02-views-and-reads.md)), and the resolver answers it
+wherever the body makes it.
 
 **Intent vectors are assertable by equality.** `{:on-click [:todo/toggle 7]}` is
 data. You can `=` it. Compare that with the alternative — asserting that a node
 holds *some function* which, when called, dispatches something — which is why
 codebases end up rendering to a DOM and clicking things just to find out what a
-button was going to do.
+button was going to do. This is not aspiration: the bench arm's own tests already
+work this way — a prevented intent, a route-link's whole click decision, and a
+presence child's exit rendering are each asserted by `=`, with no browser and no
+clock (`front/intent_cljs_test`, `front/route_link_cljs_test`,
+`front/presence_cljs_test`).
 
 This is what deletes the retail. The census counted **364 `data-testid` attributes**
 across the corpus, most of them scaffolding for browser tests that only existed
@@ -101,7 +105,7 @@ these reads?" — which is the headless door's whole job.
 
 ## Troubleshooting
 
-No Hicasso error ids exist yet; this table names mechanisms.
+This table names mechanisms rather than error ids.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -1,27 +1,24 @@
 # Hicasso — draft user guide
 
-> **Pre-implementation draft — Hicasso does not exist yet.** These pages describe the
-> *designed* surface so it can be read before it is built. Spellings marked
-> **[unfrozen]** are placeholders that will change. The whole tree is disposable: it
-> is rewritten after the P2 fork ruling, against a real implementation. Normative
-> source: [decisions.md](../decisions.md) (HD-001…HD-025).
+> **Draft ahead of the product artefact.** These pages teach the *landed* authoring
+> surface: ruled in [decisions.md](../decisions.md) (HD-001…HD-027) and witnessed by
+> the bench arm's tests under
+> `implementation/freehand/test/re_frame/bench/hicasso/`. No
+> `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
+> stay provisional until the API freeze — but everything a page shows without that
+> marker has run, in tests, against a real React.
 
 Hicasso is re-frame2's native view layer: interpreted Hiccup on a React
 function-component host, optimised for re-frame2. The
 [charter](../charter.md) argues why it should exist and
-[validation](../validation.md) says what would kill it. This draft answers a
-narrower question — **what would a programmer actually type?** — and hands the
-operator something readable before a line of runtime code is written.
-
-It is a first cut in the literal sense. It was written from the design record
-alone, so every claim here is a *designed* claim: nothing on these pages has been
-compiled, run, or measured.
+[validation](../validation.md) says what would kill it. This guide answers a
+narrower question — **what does a programmer actually type?**
 
 | Page | Its one job |
 |---|---|
 | [Getting started](01-getting-started.md) | Put one Hicasso view on screen inside a frame, and take it down again |
-| [Views and reads](02-views-and-reads.md) | Write a view; read subscriptions from it — in **both** the surfaces still under adjudication |
-| [Events as data](03-events-as-data.md) | Put an event vector in an attribute and let the runtime build the callback |
+| [Views and reads](02-views-and-reads.md) | Write a view; read subscriptions where you use them |
+| [Events as data](03-events-as-data.md) | Put an event vector in an attribute and let the runtime build the callback — clicks, keys, prevention, and links |
 | [Controlled inputs](04-controlled-inputs.md) | Type into a text field whose value round-trips through app-db, and keep your caret |
 | [Interop](05-interop.md) | Use a React component from npm |
 | [Theming](06-theming.md) | Style a component library without a context API |
@@ -30,53 +27,36 @@ compiled, run, or measured.
 
 Eight pages is not an accident. K5 in [validation.md](../validation.md) kills the
 programme at "more than ~8 public concepts or ~8 guide pages to ship CRUD", so the
-draft deliberately spends its whole budget and no more. If the real guide needs a
-ninth page, that is a signal about the design, not about the writing.
+guide deliberately spends its whole budget and no more. If it ever needs a ninth
+page, that is a signal about the design, not about the writing.
 
 ## How to read the markers
 
 **[unfrozen]** after a name means the *semantics* are ruled but the *spelling* is a
-placeholder. Two things drive that. HD-021 pins the root operation's behaviour and
-says outright that its name waits for the donor spike; and
-[authoring.md](../authoring.md) puts a blanket hold on declaration spellings until
-the tournament has measured. So assume every symbol below is provisional, and treat
-the marked ones as *known* to be provisional.
-
-Each page ends with **Not settled yet** — a table of the questions that page raised
-and the design record does not answer. Those tables are the most useful part of this
-draft. A guide that reads as finished when the design is not is worse than one that
-says where the floor is missing.
-
-Examples deliberately alternate between the two candidate read surfaces rather than
-settling on one, and every page that shows a read says which surface it is using.
-[Views and reads](02-views-and-reads.md) is where the fork is explained; the real
-guide will have exactly one spelling and will be much shorter for it.
+placeholder — HD-021 pins the root operation's behaviour and says outright that its
+name waits, and [authoring.md](../authoring.md) holds every declaration spelling
+unfrozen until the freeze. Each page ends with **Not settled yet** — the questions
+that page raises which the record does not yet answer. Far fewer remain than when
+this draft was first written; the ones left are real.
 
 ## What this draft is not
 
 - **Not published.** `design/hicasso/` is in `exclude_docs` in `mkdocs.yml`, so this
   subtree never reaches the site and is never in the nav. Read it in the source tree
-  or on GitHub.
+  or on GitHub. Because it is read as raw Markdown, banners and asides are
+  blockquotes rather than MkDocs admonitions.
 - **Not gated.** No fenced block here is digest-pinned by
-  `samples_coverage_jvm_test.clj` — that test scans `docs/core/freehand/` only. Edit
-  freely; nothing downstream breaks.
+  `samples_coverage_jvm_test.clj` — that test scans `docs/core/freehand/` only.
 - **Not an API freeze.** [authoring.md](../authoring.md) is explicit that nothing in
   the design record licenses freezing an API early, and this guide inherits that.
 
-Three deviations from the [guide authoring brief](../../../AUTHORING.md), taken
-knowingly. Banners and asides are blockquotes rather than MkDocs admonitions,
-because an excluded tree is read as raw Markdown and `!!! warning` would render as
-literal punctuation. There are no `cljs-rf2` live cells, because there is nothing to
-run. And the troubleshooting tables name symptoms and fixes but carry no
-`:rf.error/*` ids, because no Hicasso error ids have been minted — inventing
-plausible ones would be the single most damaging thing this draft could do.
-
 ## Where the vocabulary comes from
 
-[decisions.md](../decisions.md) governs; [validation.md](../validation.md) is next.
-[authoring.md](../authoring.md) holds the canonical spellings that do exist, and
-where this guide shows a symbol that authoring.md does not, the symbol is invented
-here and marked. [hd-002-adjudication.md](../hd-002-adjudication.md) is a delegated
-advisory on the read fork — it settles what the collector may do and what kills it,
-and explicitly does **not** decide which surface ships. The programme is sequenced by
+[decisions.md](../decisions.md) governs; [validation.md](../validation.md) is next;
+[authoring.md](../authoring.md) holds the canonical spellings. The read surface was
+ruled by the operator on 2026-07-31 — the ambient collector, on ergonomics, with
+[hd-002-adjudication.md](../hd-002-adjudication.md)'s correctness gates standing —
+recorded in the
+[dogfood judgement](../studio/arm1-lean-react-dogfood-judgement.md). The programme
+is sequenced by
 [EP-0038](../../../EP/EP-0038-the-hicasso-view-layer-programme.md).


### PR DESCRIPTION
Brings `docs/design/hicasso/draft-guide/` (pages 01-08 + README) out of its pre-implementation draft and up to the landed surface, per the charter's v0 requirement of "a short guide". Bead: rf2-2rtt6.64 (under EP-0038, rf2-2rtt6).

## What changed, page by page

- **README** — rewritten. The tree no longer claims "Hicasso does not exist yet"; it teaches the ruled surface (HD-001…HD-027) as witnessed by the bench arm's tests, and says where the read-surface ruling is recorded.
- **01 getting-started** — corrected. `sub` is no longer "one of two candidates under adjudication"; "donor spike" freeze language updated to the API freeze.
- **02 views-and-reads** — the big one, rewritten. The old page taught both read surfaces because HD-002's fork was open. The fork is ruled: the operator ruled the ambient collector the only acceptable read surface on 2026-07-31 (recorded in `studio/arm1-lean-react-dogfood-judgement.md` and in `arm1/runtime.cljs`'s own docstring), so the page now teaches `sub` as an ordinary call — legal in `when`/`for`/helpers — with the honest costs (whole-set re-subscribe on an edge-set change) and the standing kill condition (the candidate-ledger tripwire) stated, and the grouped surface reduced to one historical sentence. 325 → 195 lines.
- **03 events-as-data** — corrected and filled. `:on-keydown` → `:on-key-down` (the landed spelling); `::h/checked` added beside `::h/value` with the top-level-only substitution rule; lowering-by-shape (`on-` + letter, no name roster) stated; key-map vocabulary settled (strings against `.key`, no modifier language); and a new **route-link section** (HD-027): plain function, `[::h/navigate …]` as data, the closed veto roster, bare-intent refusal, composition with `[::h/prevent …]`. The "Not settled yet" table shrinks from five rows to the three genuinely open ones.
- **04 controlled-inputs** — corrected. Reads with `sub`; the converge paragraph states what the author gets for free and HD-019's exact boundary (one audited call site, controlled text only); the rejection section now says precisely what React restores (the value) and what the runtime takes itself (the caret); the retired PATCH arm (HD-007 superseded 2026-07-31) is gone.
- **05 interop** — banner honesty: `defhost` is ruled but is the one tier-1 door the bench arm has not yet exercised, and the page says so. (A defhost-proving worker is in flight; this page may warrant a second pass after it lands.)
- **06 theming** — banner + a stray "collector spelling" qualifier removed. The page's one genuine hole (how the app-db choice reaches `data-theme`) remains, correctly, a hole.
- **07 ephemeral-state** — reads with `sub`; the presence override-on-a-view troubleshooting row corrected — HD-025 makes it the loud error `:rf.error/hicasso-presence-override-on-a-view`, not a silent no-op.
- **08 testing** — one read surface; the equality claims now cite the landed witnesses (`front/intent_cljs_test`, `front/route_link_cljs_test`, `front/presence_cljs_test`) instead of promising them.
- **All pages** — the "No Hicasso error ids exist yet" preambles are gone (several ids are minted and landed); every banner replaced with the current truth.

## Retired spellings purged

- The two-surface read teaching (grouped `use-subs` examples in 02, 04, 07).
- `:on-keydown` (the landed key-map prop is `:on-key-down`).
- "PATCH back end" obligations in 04 (Arm 2 dropped by operator ruling 2026-07-31).
- The prevent-metadata spelling was already purged by rf2-2rtt6.57; this pass found no survivors.

## Length

1937 → 1834 lines (net −103) while gaining the route-link section — the guide got shorter because page 02 stopped teaching a dead surface. The charter's word is "short"; this moves toward it.

## How samples were verified

Every code sample was checked by eye against the landed grammar in the bench arm: `front/intent.cljs` (markers, prevent/navigate heads, lowering shapes), `front/route_link.cljs` (route-link signature and veto roster), `front/dogfood.cljs` (`:on-input` / `:on-key-down` / string key names), `shapes/card.cljs` (plain-function reads, keyed route-links), `arm1/runtime.cljs` (`sub`), `arm1/presence*.cljs` (`[presence {...}]` head form), and `authoring.md`. Samples for surfaces the arm has not exercised (`h/root!`, `defhost`, `h/render`) remain marked **[unfrozen]** and match the ruled semantics in decisions.md. No sample-hashing gate covers `docs/design/**` (`samples_coverage_jvm_test.clj` scans `docs/core/freehand/` only), so eye-verification against the landed tests is the check, and this section is the statement of it.

## Quality gates

Run foreground in the worker worktree, logs kept in-worktree; exit codes are the scripts' own.

- `python scripts/check_doc_slugs.py` (whole corpus — this is the gate that covers `docs/design/**`): **exit 0**
- `bash scripts/test-fast-pr.sh`: **exit 0** — classified docs-only; ran the always-on static/drift checks plus the full documentation tier (readme links, doc slugs, EP status-sync, grading drift, `mkdocs build --strict` — which succeeded, though note `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` itself out of the site, so the slug checker is the operative gate for this tree). JVM/node tiers correctly skipped (docs-only diff).
- Table column counts: checked by script over all nine pages — every table block has a consistent column count. Heading anchors: validated by `check_doc_slugs.py` (it indexes every heading and checks every intra-repo anchor link); the two inbound anchors from outside the tree (`decisions.md` → `05-interop.md#the-reserved-vector-and-the-gap-it-does-not-close`, `06-theming.md` → `04-controlled-inputs.md#forwarding-attributes-onto-a-controlled-input`) resolve against unchanged headings.
