### PR TITLE
docs(hicasso): HD-002 records the Surface B ruling it was settled by (rf2-fmxic)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -20,9 +20,27 @@ Alias `h` avoids inheriting Freehand's `v` (whose surfaces are deleted on a win,
 HD-018) and `ui`.
 **Reopens** never — names are permanent after first publish.
 
-## HD-002 — The sub-read mechanism: grouped default, collector challenger, scalar comparator
+## HD-002 — The sub-read mechanism: grouped default, collector challenger, scalar comparator — **SUPERSEDED 2026-07-31**
 
-**Ruling.** Three tiers, one product:
+> **Superseded by operator ruling, 2026-07-31.** The operator ruled that the
+> ambient collector — `sub` as a plain call, legal anywhere in the body — is
+> **the only read surface acceptable on ergonomics**, and that grouped
+> `use-subs` sits **below the usability bar**. The ruling decided on
+> **ergonomics, not on the benchmarked-win condition this record set up**: no
+> bar row for the survival metric exists yet (H1 is implemented, H2 untried),
+> so grouped is superseded without having lost a bench it was never run
+> against. **There is one product read surface: `sub`.** Grouped is kept —
+> and kept working — only as the comparator rendering the collector is
+> measured against; it is not a fallback, and had the collector failed
+> correctness the outcome would have been null, never a promotion of
+> grouped. The correctness gates ((a)–(d) below) were not waived by this
+> ruling; [the dogfood judgement](studio/arm1-lean-react-dogfood-judgement.md)
+> §2 is their clause-by-clause discharge, and
+> `implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs`
+> carries the same ruling in the code that implements it. Recorded on
+> `rf2-2rtt6`.
+
+**Ruling (superseded).** Three tiers, one product:
 
 1. **Scalar per-read hooks** (the raw UIx spine) are a **comparator arm only** —
    the measured floor, exempt from the product hook budget because they are the
@@ -74,8 +92,9 @@ per-read ledger, the single largest measured killer — must win its place under
 pre-registered, correctness-first adjudication. The collector is still ridden
 hardest because conditional-reads-legal is the census's tier-1 shape and most of
 the authoring differentiation vs raw UIx.
-**Reopens** via its own adjudication — the P1 instrumentation is the decision
-procedure.
+**Reopens** n/a — the ruling above is this decision's resolution, not a bypass
+of it; a future change needs a new operator ruling, not a rerun of the P1
+instrumentation.
 
 ## HD-003 — Hooks in view bodies
 


### PR DESCRIPTION
## Summary

- HD-002 in `docs/design/hicasso/decisions.md` still carried the pre-ruling "grouped default, collector challenger" teach-both text, even though the operator ruled 2026-07-31 that the ambient collector (`sub`) is the only acceptable read surface and grouped `use-subs` sits below the usability bar. The ruling is recorded on `docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md` and in `arm1/runtime.cljs`'s docstring, and the guide (merged PR #7382) now points readers through HD-002 to it -- so the record it pointed through contradicted it.
- Corrected in place, following HD-007's idiom exactly (that's the precedent for a superseded-but-preserved HD entry): heading gets `— **SUPERSEDED 2026-07-31**`, a blockquote states what was ruled and on what basis, and the pre-ruling text is preserved below labelled `**Ruling (superseded)**`.
- The blockquote is explicit that the ruling was decided on **ergonomics, not the benchmarked-win condition HD-002's own adjudication set up** (no bar row for the survival metric exists yet) -- mirroring how HD-007 was careful to say Arm 2 was dropped on product direction, not because it lost its measurement gate. Grouped `use-subs` should not read as though it lost a bench it was never run against.
- The `Reopens` line is updated: the original condition ("via its own adjudication -- the P1 instrumentation is the decision procedure") is exactly what ran, so it now says the ruling above is the resolution, not a bypass.
- Swept `decisions.md` and the `docs/design/hicasso/studio/` pages for other citations that treat HD-002 as an open fork: none found. The existing HD-002 clause references there (survival metric, tier-1 exclusion, 1/3/7/20 ladder, HD-016's "collector-contingent" note) are factual statements about the correctness gates, which the ruling did not waive, so they remain accurate as written.
- Out of this bead's scope (not touched, flagged for awareness): `architecture.md`'s "The sub-read mechanism" section (~L127-151) and its space-table cell (L21), `hd-002-adjudication.md`'s framing, `authoring.md`'s "collector-contingent" notes, `validation.md`'s HD-002 references, and `README.md`'s index row all still read as if the fork were open. These are outside `decisions.md`/`studio/`, so left for a follow-up rather than expanding this diff.

## Quality gates

- `python scripts/check_doc_slugs.py` (whole corpus) -- exit 0.
- `scripts/test-fast-pr.sh` -- exit 0 (docs-classified change; mkdocs build succeeded, JVM/CLJS suites correctly skipped as surface-unchanged).
- Verified by hand: no inbound links to `decisions.md` (anchored or not) exist anywhere in the corpus, so the heading-text change (which shifts the generated slug) moves nothing. No tables were touched.