### PR TITLE
hicasso: the IME fence, driven by real composition events on both implementations (rf2-o27h3)

### DIFF
--- a/docs/design/hicasso/studio/controlled-input-two-implementations.md
+++ b/docs/design/hicasso/studio/controlled-input-two-implementations.md
@@ -180,13 +180,45 @@ implementations run.
 
 ### IME composition
 
-Still not established, and still not asserted. Synthetic `Event`s named
-`compositionstart`/`compositionend` do not exercise React's composition path,
-and there are now **two** implementations to establish a fence against rather
-than one — React's `SyntheticCompositionEvent` plumbing on the controlled
-path, and the port's write-owning path, which never consults composition
-state at all. A fence asserted without being demonstrated is worse than no
-fence. It needs a real `CompositionEvent` harness against both.
+**Established** (`rf2-o27h3`), by a harness that drives the browser's own
+composition machinery rather than dispatching Events shaped like it:
+`ime_run.cjs` (beside the bench drivers, in
+`implementation/freehand/test/re_frame/bench/hicasso/`) uses CDP
+`Input.imeSetComposition` / `Input.insertText` / `Input.dispatchKeyEvent`,
+which mint **trusted** `compositionstart`/`compositionupdate` events, trusted
+`input` events carrying `insertCompositionText` and `isComposing true`, real
+mid-composition keydowns, and a real composition range — against **three**
+pages, one implementation each: plain React, the port, and Arm 1's element
+path with the converge installed. What it holds and what it measured:
+
+- **The commit fence holds, on each signal independently, on all three.** A
+  mid-composition Enter (native `isComposing true`) commits nothing; a bare
+  keyCode-229 Enter commits nothing; an ordinary Enter commits. The gate
+  reads the **native** event — React's synthetic keyboard event drops
+  `isComposing` (measured at the handler, again), and the harness's
+  mutation run (the guard re-pointed at the synthetic event) reds exactly
+  the modern-signal row on all three pages while the 229 row stays green.
+- **A model-agreeing exchange survives to `compositionend`** on all three —
+  one `compositionstart`, the composition string forming through the
+  updates, commit data delivered. The converge's `flushSync` and its
+  unconditional `setSelectionRange` did not disturb the composition range.
+- **The model observes every intermediate composition state** on all three:
+  the change handler fires per composing `input`, so `s`/`sh`/`し` each
+  reach app-db. The fence is the commit door, not the value path.
+- **A refused or normalised value is written back mid-composition on all
+  three, and the write silently destroys the exchange** — no
+  `compositionend`, fresh `compositionstart` on the IME's next update.
+  React in-turn, the converge in-turn, the port one frame late. The
+  converge is nowhere worse than the React baseline (asserted
+  comparatively, same run), but the PR #7371 audit's pin — that it
+  neither writes nor moves selection mid-composition — is false for every
+  implementation the moment the model disagrees. A composition carve-out
+  is a behavioural choice inside HD-019's exception scope and needs a
+  ruling: **`rf2-digtt`**, where the measured matrix lives.
+- A cancelled exchange (`compositionend` with empty data) leaves field and
+  model exactly as before, on all three — with the measured wrinkle that on
+  a refusing field there is no `compositionend` at all, because the abort
+  already happened.
 
 ## The options, and what they cost
 
@@ -320,7 +352,10 @@ element path — a UIx consumer is not on that path and does not get it.
   caret half of this correction rather than leaving it to this page.
 - `rf2-n3dxw`'s headline residue is **answered for Arm 1**: a refused
   keystroke converges in the same turn with the caret at the position before
-  it. Two things it recorded are not answered and are not rounded up — the
-  **range** row (a second algorithm, and off the change path entirely) and
-  the **IME** fence (`rf2-o27h3`, still needing a real `CompositionEvent`
-  harness). And nothing here reaches a UIx consumer's `:input`.
+  it. One thing it recorded is not answered and is not rounded up — the
+  **range** row (a second algorithm, and off the change path entirely). The
+  **IME** fence is now established by the real-composition harness
+  (`rf2-o27h3`, the *IME composition* section above), whose one open
+  residue — the mid-composition rewrite every implementation performs when
+  the model disagrees — is `rf2-digtt`. And nothing here reaches a UIx
+  consumer's `:input`.

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -451,7 +451,13 @@ kill-bounded arms, and both did run before the ruling.)
 separated scaling curves (fixed reads × growing boundaries; fixed boundaries ×
 growing reads); the 100-cell controlled grid (same-turn echo, mid-string caret,
 selection, unchanged-model rejection, async normalisation — IME composition is
-named here but **not asserted**, and `rf2-n3dxw` says why; the caret across a
+asserted by the real-composition harness `ime_run.cjs` (`rf2-o27h3`: CDP-driven
+trusted composition against all three input implementations; the commit fence
+on both signals, survival of a model-agreeing exchange, cancellation restoring
+field and model, and the measured mid-composition rewrite matrix `rf2-digtt`
+records), never in-page — a dispatched `Event` exercises neither React's
+composition path nor the browser's composition range, which is why the grid
+suites still carry no composition row; the caret across a
 refusal and across a normalisation is the arm's own since `rf2-fki5d`, taken in
 the element path and witnessed on this grid);
 keyed insert/delete/reorder; changing query identity through an abandoned render;

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
@@ -514,12 +514,19 @@
 ;; the IME and a per-key exception list is a second place for the law to
 ;; rot.
 ;;
-;; What is NOT asserted, and why, so the absence reads as a decision: the
-;; **value** path during composition. Synthetic `compositionstart` /
-;; `compositionend` events do not exercise React's composition plugin, and
-;; a fence asserted without being demonstrated is worse than no assertion.
-;; `bench/hicasso/controlled_restore_dom_cljs_test` carries the same
-;; carve-out and rf2-n3dxw carries the bead.
+;; What is NOT asserted HERE, and where it is: the **value** path during
+;; composition. Synthetic `compositionstart` / `compositionend` events do
+;; not exercise React's composition plugin — or the browser's composition
+;; range — so the real-composition harness owns it instead (rf2-o27h3):
+;; `bench/hicasso/ime_run.cjs` drives trusted CDP composition against this
+;; arm's element path (converge included), plain React and the port, and
+;; asserts the fence there. Its one open residue — every implementation
+;; rewrites a refused/normalised value mid-composition, destroying the
+;; exchange — is rf2-digtt. The two rows below stay: they witness the
+;; gate's two signals through React's keydown plumbing cheaply, on every
+;; PR, in-page — while the events they build are exactly the synthetic
+;; kind the harness exists to go beyond, which is why the harness, not
+;; these rows, is what establishes the fence.
 
 (def ^:private !probe (atom []))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs
@@ -115,15 +115,25 @@
   scaffolding but the mechanism being measured, and it is used by that
   row alone.
 
-  ## What is still not asserted, and why
+  ## What is asserted elsewhere, and what is still not
 
-  - `:ime-composition-commits-nothing` — **not established, not
-    asserted.** Arm 2 owned a composition fence because it owned the
-    writes. Synthetic `Event`s named `compositionstart`/`compositionend`
-    do not exercise React's composition path, and there are now two
-    implementations to establish it against rather than one. A fence
-    asserted without being demonstrated is worse than no assertion.
-    Still open on rf2-n3dxw.
+  - `:ime-composition-commits-nothing` — **established, and asserted by
+    the real-composition harness rather than here** (rf2-o27h3):
+    `bench/hicasso/ime_run.cjs` drives CDP `Input.imeSetComposition` /
+    `insertText` / `dispatchKeyEvent` — trusted composition events, a
+    real composition range, real mid-composition keydowns — against
+    three pages, one implementation each: plain React, the port, and
+    Arm 1's element path with its converge. The commit fence holds on
+    `isComposing` and on keyCode-229 independently; a model-agreeing
+    exchange survives to `compositionend`; a cancelled exchange leaves
+    field and model exactly as before. It stays out of THIS file
+    because an `Event` dispatched from page script exercises neither
+    React's composition plumbing nor the browser's composition state —
+    the very reason the row sat unasserted so long — and `:browser-test`
+    runs in-page. What the harness also measured: every implementation
+    (React's own restore included) rewrites a refused/normalised value
+    mid-composition and silently destroys the exchange — rf2-digtt,
+    which is where the carve-out ruling lives.
   - `teardown-leaves-no-boundary-and-no-edge` — dropped as a duplicate.
     Arm 1's dogfood suite already asserts zero residue after unmount
     (`:cells :cell-refs :boundaries :edges :entries` all 0), and one

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
@@ -131,7 +131,26 @@
   own restore is still what converges it. That is why a *range* selection
   still collapses across such a write: this converge is not on that path,
   and restoring two offsets is a different algorithm from the one it
-  runs (rf2-n3dxw)."
+  runs (rf2-n3dxw).
+
+  ## Composition, measured (rf2-o27h3)
+
+  A composing IME produces exactly the `input` events this wrapper runs
+  on, so its conduct mid-composition is a measured property, not an
+  intention — `bench/hicasso/ime_run.cjs` drives real CDP composition
+  at it beside plain React and the UIx port. Measured: on a
+  model-agreeing field the exchange **survives** — the value write never
+  fires (and an equal write is short-circuited by the browser's own
+  setter anyway), and the unconditional `setSelectionRange` did not
+  disturb the composition range. On a field whose model refuses or
+  normalises, the write lands **mid-composition and silently destroys
+  the exchange** — precisely as React's own end-of-event restore does on
+  the same field in the same turn, and as the UIx port does one frame
+  later. Nowhere worse than the baseline, asserted comparatively; not
+  composition-fenced either, same as the baseline. Whether this path
+  should carve composition out — suppress the converge while
+  `isComposing`, converge once at `compositionend` — is a behavioural
+  choice inside HD-019's exception scope awaiting a ruling: rf2-digtt."
   (:require ["react-dom" :as react-dom]))
 
 (defn- noop [])

--- a/implementation/freehand/test/re_frame/bench/hicasso/ime_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ime_app.cljs
@@ -1,0 +1,304 @@
+(ns re-frame.bench.hicasso.ime-app
+  "THE IME COMPOSITION PAGE — the in-browser half of the real-CompositionEvent
+  harness (rf2-o27h3). `ime_run.cjs` is the other half and the only caller.
+
+  ## Why this page exists
+
+  The `:ime-composition-commits-nothing` row of the controlled grid was
+  probed with synthetic `Event`s named `compositionstart`/`compositionend`,
+  which exercise neither React's composition plumbing nor the browser's own
+  composition state, and the row was left deliberately unasserted
+  (rf2-n3dxw, rf2-m6if4). A real IME exchange is browser machinery — a
+  composition RANGE the IME owns, `input` events carrying
+  `inputType \"insertCompositionText\"` and `isComposing true`, keydowns
+  whose `isComposing` reflects live composition state — and nothing
+  dispatched from page script reproduces it. CDP's `Input.imeSetComposition`
+  / `Input.insertText` does: measured on this repo's Playwright Chromium,
+  it produces TRUSTED `compositionstart`/`compositionupdate` events, trusted
+  `input` events with the composition fields set, trusted keydowns with
+  `isComposing` computed from the live composition, and a real composition
+  range that a JS `value` write silently aborts. The driver drives those;
+  this page mounts the implementations and records what their handlers see.
+
+  ## The three input implementations, one per page load
+
+  `?impl=` selects exactly one, so no row can inherit another's machinery
+  (the rf2-n3dxw discipline — two rows were once green while measuring
+  UIx's Reagent-port and reading it as React):
+
+  | `?impl=` | what mounts | pin |
+  |---|---|---|
+  | `hicasso` | Arm 1's element path — `defview` cells, intent vectors, the composition-gated key-map, and `front.controlled/install!`'s converge wrapped around the change handler by the codec | `false` (recorded; the codec never consults it — `arm1_controlled_grid_dom_cljs_test` proves that) |
+  | `react` | UIx adapter `defui` cells on plain React controlled inputs | `false` — plain React |
+  | `uix-port` | the same `defui` cells on UIx's port of Reagent's controlled-input workaround | `true` — the port |
+
+  Each page is three fields of the grid model's policy family — `plain`
+  takes what is typed, `digits` refuses non-digits (the model does not
+  move), `upper` normalises to upper case — plus the commit door the IME
+  fence exists for: Enter copies a cell's live value into `:committed`,
+  gated by `front.intent/composing?` (on the hicasso row via the key-map,
+  which is composition-gated centrally; on the other two via the same
+  predicate called from an ordinary `:on-key-down`, so one gate is driven
+  through both event plumbings).
+
+  ## Two probe layers, and why both
+
+  - **`\"native\"`** — plain `addEventListener` on each field, recording
+    what the browser actually delivered: `isComposing`, `inputType`,
+    `data`, `keyCode`, `isTrusted`, and the field's value/selection at
+    delivery. This layer is the ground truth the driver's carriage
+    assertions read, and its `compositionstart` count is how a silent
+    composition abort is detected (a JS value write mid-composition kills
+    the composition WITHOUT a `compositionend`; the next IME update then
+    mints a fresh `compositionstart` — measured).
+  - **`\"handler\"`** — what React hands the application's own handlers,
+    recording the SAME fields off the synthetic event AND off
+    `.-nativeEvent`. The dead-`isComposing` defect (a gate reading
+    React's synthetic keyboard event, whose copied interface does not
+    include `isComposing`) is only visible at this layer, which is why it
+    exists: the harness asserts what the handler saw, not what was sent.
+
+  The page asserts nothing itself. It records, exposes the record and the
+  model over `window`, and leaves every verdict to the driver — the same
+  division every bench page in this directory keeps."
+  (:require [clojure.string :as str]
+            [re-frame.adapter.uix :as uixa]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
+            [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.core :as rf]
+            [uix.core :refer [$ defui]]
+            [uix.compiler.input]
+            ;; Required so `uix-port` can be SELECTED rather than merely
+            ;; inherited: the port reaches Reagent's after-render queue
+            ;; through the `reagent.impl.batching` global, which only
+            ;; exists once that namespace is loaded — and only in a dev
+            ;; (`:none`) bundle, which is why ime_run.cjs builds one.
+            [reagent.impl.batching]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview hfn]]))
+
+(def frame-id ::ime)
+
+(def fields
+  "One field per policy the exchange is driven against."
+  ["plain" "digits" "upper"])
+
+(def seed-values
+  "`digits` seeds non-empty so a refusal has something to stand beside."
+  {"plain" "" "digits" "12" "upper" ""})
+
+;; ---------------------------------------------------------------------------
+;; The model — the controlled grid's policy family, by field name
+;; ---------------------------------------------------------------------------
+
+(defn- apply-policy
+  "What the model does with a typed value. `old` is what it holds now,
+  which is the whole of a rejection: the model returns itself."
+  [field old v]
+  (case field
+    "digits" (if (re-matches #"[0-9]*" v) v old)
+    "upper"  (str/upper-case v)
+    v))
+
+(rf/reg-sub :ime/cell (fn [db [_ f]] (get-in db [:cells f] "")))
+
+(rf/reg-event :ime/seed
+  (fn [_ _] {:db {:cells seed-values :committed {}}}))
+
+(rf/reg-event :ime/edit
+  (fn [{:keys [db]} [_ f v]]
+    {:db (assoc-in db [:cells f]
+                   (apply-policy f (get-in db [:cells f] "") v))}))
+
+;; The commit door the IME fence exists for: a composing Enter must not
+;; reach this (authoring.md's pinned case).
+(rf/reg-event :ime/commit
+  (fn [{:keys [db]} [_ f]]
+    {:db (assoc-in db [:committed f] (get-in db [:cells f] ""))}))
+
+;; ---------------------------------------------------------------------------
+;; The probe log
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !log (atom []))
+
+(defn- log! [layer m]
+  (swap! !log conj (assoc m :layer layer))
+  nil)
+
+(defn- probe-handler-event!
+  "Record what React handed a handler: the synthetic reading AND the
+  native one, side by side, because the difference between them IS the
+  dead-`isComposing` finding."
+  [field kind ^js e]
+  (let [^js native (.-nativeEvent e)]
+    (log! "handler"
+          {:field                field
+           :type                 kind
+           :key                  (.-key e)
+           :syntheticIsComposing (.-isComposing e)
+           :syntheticKeyCode     (.-keyCode e)
+           :syntheticInputType   (.-inputType e)
+           :syntheticData        (.-data e)
+           :nativeIsComposing    (when native (.-isComposing native))
+           :nativeKeyCode        (when native (.-keyCode native))
+           :nativeInputType      (when native (.-inputType native))
+           :nativeData           (when native (.-data native))
+           :value                (some-> ^js (.-target e) .-value)})))
+
+(defn- attach-native-probes!
+  "The ground-truth layer: what the browser delivered to the node,
+  independent of React, with the field's value and selection at delivery."
+  [^js node field]
+  (doseq [t ["compositionstart" "compositionupdate" "compositionend"
+             "beforeinput" "input" "keydown"]]
+    (.addEventListener node t
+                       (fn [^js e]
+                         (log! "native"
+                               {:field       field
+                                :type        t
+                                :isComposing (.-isComposing e)
+                                :inputType   (.-inputType e)
+                                :data        (.-data e)
+                                :key         (.-key e)
+                                :keyCode     (.-keyCode e)
+                                :isTrusted   (.-isTrusted e)
+                                :value       (.-value node)
+                                :selStart    (.-selectionStart node)
+                                :selEnd      (.-selectionEnd node)}))))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; The hicasso page — Arm 1's element path, converge and key-map included
+;; ---------------------------------------------------------------------------
+
+(defview ime-cell
+  "One controlled cell on the arm's own authoring surface: a `:value` read
+  through the ambient collector, an `:on-input` intent carrying the value
+  marker — which is what makes the codec install the converge around it
+  (rf2-fki5d) — and a key-map whose `\"Enter\"` branch is what the
+  composition gate has to stop. The composition probes are `hfn`
+  callbacks; each returns nil deliberately, because an event callback's
+  returned VECTOR is dispatched."
+  [{:keys [field]}]
+  [:input {:id          field
+           :type        "text"
+           :value       (sub [:ime/cell field])
+           :on-input    [:ime/edit field :re-frame.hicasso/value]
+           :on-key-down {"Enter" [:ime/commit field]}
+           :on-composition-start  (hfn [e] (probe-handler-event! field "compositionstart" e) nil)
+           :on-composition-update (hfn [e] (probe-handler-event! field "compositionupdate" e) nil)
+           :on-composition-end    (hfn [e] (probe-handler-event! field "compositionend" e) nil)}])
+
+(defview ime-grid
+  []
+  (into [:div.grid]
+        (map (fn [f] [ime-cell {:key f :field f}]))
+        fields))
+
+;; ---------------------------------------------------------------------------
+;; The UIx page — plain React or the Reagent-port, the pin decides
+;; ---------------------------------------------------------------------------
+
+(defui ime-cell-uix
+  "The same three surfaces on the UIx adapter: a controlled `:value`, an
+  `:on-change` edit (the port's `input-render-setup` requires `onChange`
+  to engage at all), and an Enter commit gated by the SAME
+  `front.intent/composing?` the hicasso key-map is gated by — so one gate
+  is witnessed through both event plumbings, reading the native event."
+  [{:keys [field]}]
+  (let [v (uixa/use-subscribe [:ime/cell field])
+        {:keys [dispatch-sync]} (uixa/use-frame)]
+    ($ :input
+       {:id        field
+        :type      "text"
+        :value     v
+        :on-change (fn [^js e]
+                     (dispatch-sync [:ime/edit field (.. e -target -value)])
+                     (probe-handler-event! field "change" e))
+        :on-key-down (fn [^js e]
+                       (probe-handler-event! field "keydown" e)
+                       (when (and (= "Enter" (.-key e))
+                                  (not (intent/composing? e)))
+                         (dispatch-sync [:ime/commit field])))
+        :on-composition-start  (fn [^js e] (probe-handler-event! field "compositionstart" e))
+        :on-composition-update (fn [^js e] (probe-handler-event! field "compositionupdate" e))
+        :on-composition-end    (fn [^js e] (probe-handler-event! field "compositionend" e))})))
+
+(defui ime-grid-uix
+  []
+  ($ :div.grid
+     (for [f fields]
+       ($ ime-cell-uix {:key f :field f}))))
+
+;; ---------------------------------------------------------------------------
+;; Mounting, pinning, and the window API the driver reads
+;; ---------------------------------------------------------------------------
+
+(defn- container! []
+  (let [c (js/document.createElement "div")]
+    (.appendChild js/document.body c)
+    c))
+
+(defn- pin!
+  "Pin the UIx input implementation for this page's lifetime. `hicasso`
+  records `false` too — the codec never consults the selector, which the
+  grid suite proves; recording the pin keeps this page unable to measure
+  an implementation it cannot name."
+  [impl]
+  (set! uix.compiler.input/*use-reagent-input-enabled?*
+        (= "uix-port" impl)))
+
+(defn- mount-impl! [impl]
+  (case impl
+    "hicasso" (mount/root! (container!) frame-id [ime-grid {}])
+    (let [c    (container!)
+          root (react-dom-client/createRoot c)]
+      (react-dom/flushSync
+       (fn [] (.render root ($ uixa/frame-provider {:frame frame-id}
+                              ($ ime-grid-uix {})))))
+      {:root root :container c})))
+
+(defn- settle! []
+  (react-dom/flushSync (fn [] nil))
+  nil)
+
+(defn- state-js
+  "Everything the driver asserts on, as one JSON string: the model's two
+  maps, the pin, and both probe layers in arrival order."
+  [impl]
+  (let [db (rf/app-db-value frame-id)]
+    (js/JSON.stringify
+     (clj->js {:impl      impl
+               :pin       (str uix.compiler.input/*use-reagent-input-enabled?*)
+               :cells     (:cells db)
+               :committed (:committed db)
+               :log       @!log}))))
+
+(defn ^:export -main
+  []
+  (try
+    (let [impl (or (some-> (js/URLSearchParams. (.. js/window -location -search))
+                           (.get "impl"))
+                   "react")]
+      (rf/init! uixa/adapter)
+      (pin! impl)
+      (rf/make-frame {:id frame-id :initial-events [[:ime/seed]]})
+      (mount-impl! impl)
+      (settle!)
+      (doseq [f fields]
+        (attach-native-probes! (js/document.getElementById f) f))
+      (unchecked-set js/window "IME_STATE" (fn [] (state-js impl)))
+      (unchecked-set js/window "IME_CLEAR_LOG" (fn [] (reset! !log []) nil))
+      (unchecked-set js/window "IME_RESET"
+                     (fn []
+                       (rf/dispatch-sync [:ime/seed] {:frame frame-id})
+                       (settle!)
+                       (reset! !log [])
+                       nil))
+      (unchecked-set js/window "IME_READY" true))
+    (catch :default e
+      (unchecked-set js/window "IME_ERROR"
+                     (str (ex-message e) " " (pr-str (ex-data e)))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/ime_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ime_run.cjs
@@ -1,0 +1,604 @@
+#!/usr/bin/env node
+// THE IME COMPOSITION HARNESS — driver (rf2-o27h3).
+//
+//   node implementation/freehand/test/re_frame/bench/hicasso/ime_run.cjs
+//
+// Drives REAL composition exchanges — CDP `Input.imeSetComposition` /
+// `Input.insertText` / `Input.dispatchKeyEvent` — against the three
+// controlled-input implementations `ime_app.cljs` mounts one per page:
+// Arm 1's element path (converge installed), plain React, and UIx's port
+// of Reagent's workaround. Nothing here dispatches a synthetic Event from
+// page script: the exchange is the browser's own composition machinery,
+// which is the entire point (the row was left unasserted precisely
+// because synthetic composition Events exercise none of it).
+//
+// ## What CDP gives, measured on this Chromium before this file was built
+//
+//   - `imeSetComposition` mints a TRUSTED `compositionstart`, trusted
+//     `compositionupdate`s carrying `data`, and trusted `input` events
+//     with `inputType "insertCompositionText"` and `isComposing true`,
+//     mutating the field through a real composition range.
+//   - a trusted keydown sent DURING a composition carries
+//     `isComposing true`; `windowsVirtualKeyCode: 229` lands as
+//     `keyCode 229` — the two signals `front.intent/composing?` reads,
+//     each drivable on its own.
+//   - `insertText(text)` commits the composition (`compositionend` with
+//     the committed data); `insertText("")` cancels it (field restored,
+//     `compositionend` data "").
+//   - a JS `value` write mid-composition SILENTLY ABORTS the composition:
+//     no `compositionend` fires, and the next IME update mints a fresh
+//     `compositionstart`. That signature — more than one
+//     `compositionstart` in one exchange's log — is how this driver
+//     detects a converge (or React's own restore) destroying an exchange.
+//
+// ## Verdict discipline
+//
+// LAW rows assert what must hold (the commit fence on both signals, the
+// carriage of composition state on the native event, a cancelled
+// exchange leaving field and model exactly as before, a model-agreeing
+// exchange surviving to `compositionend`). RECORDED rows pin the
+// MEASURED per-implementation behaviour — the mid-composition rewrite a
+// refusing or normalising model provokes — so drift reds the run without
+// the row claiming the behaviour is desired. The comparative section
+// then asserts Arm 1's converge is nowhere WORSE than the plain-React
+// baseline measured in the same run, which is the question the PR #7371
+// audit put to this harness.
+//
+// ## Why the bundle is a DEV build (`shadow-cljs compile`), not `release`
+//
+// The uix-port page reaches Reagent's after-render queue through the raw
+// global `js/reagent.impl.batching.do-after-render`
+// (uix/compiler/input.cljs) — a path that only exists while namespaces
+// live on the global object, i.e. under `:none`. `:advanced` renames it
+// away and the port throws. The `:browser-test` lane is a dev build for
+// the same reason it works there. This is a correctness instrument, not
+// a clock; nothing here quotes a figure, so the release/dev distinction
+// the bench drivers guard does not apply.
+//
+// Exit codes:
+//   0  every law held, every recorded row matched its pin, floor met
+//   1  a law or pin failed, a page threw, or the check floor was unmet
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+const { navigate, NAV_TIMEOUT_MS } = require('../../freehand/bench/navigate.cjs');
+const { watchPage } = require('../../freehand/bench/sentinel.cjs');
+const { resetLaneBuildCache } = require('../../freehand/bench/lane_cache.cjs');
+
+const IMPL_ROOT = path.resolve(__dirname, '../../../../..');
+
+const BUILD_ID = 'hicasso-bench';
+const OUT_DIR = process.env.IME_OUT_DIR || 'out/hicasso-ime';
+const INIT_FN = 're-frame.bench.hicasso.ime-app/-main';
+const OUT = path.join(IMPL_ROOT, OUT_DIR);
+const PORT = Number(process.env.IME_PORT || 8146);
+const READY_TIMEOUT_MS = 60 * 1000;
+
+// The check floor (the rf2-qqzmf lesson, carried here): a run that
+// asserted almost nothing must not exit 0. A full three-page run banks
+// ~150 checks; 100 refuses a silently-skipped page while leaving room
+// for per-impl variation.
+const MIN_CHECKS = 100;
+
+const ALL_IMPLS = ['hicasso', 'react', 'uix-port'];
+// `IME_ONLY=react` runs one page over the same bundle and gates —
+// development convenience; the floor is prorated so a partial run can
+// still be green while a partial run masquerading as full cannot.
+const ONLY = (process.env.IME_ONLY || '').trim();
+const IMPLS = ONLY ? ALL_IMPLS.filter((i) => ONLY.split(',').includes(i)) : ALL_IMPLS;
+if (IMPLS.length === 0) {
+  console.error(`[ime] IME_ONLY=${ONLY} selects no page; known: ${ALL_IMPLS.join(', ')}`);
+  process.exit(1);
+}
+const CHECK_FLOOR = Math.floor(MIN_CHECKS * (IMPLS.length / ALL_IMPLS.length));
+
+// ONE LINE, deliberately: shadow-cljs's CLI re-splits `--config-merge` on
+// whitespace when the EDN contains a newline.
+const CONFIG_MERGE =
+  `{:output-dir "${OUT_DIR}" :asset-path "." ` +
+  `:modules {:main {:init-fn ${INIT_FN}}}}`;
+
+function build() {
+  if (resetLaneBuildCache(IMPL_ROOT, BUILD_ID)) {
+    console.error(`[ime] cleared .shadow-cljs/builds/${BUILD_ID} — one build id, N programs (rf2-2rtt6.20)`);
+  }
+  console.error(`[ime] building DEV bundle — ${INIT_FN} -> ${OUT_DIR} (see header for why not :advanced)`);
+  const runner = path.join(IMPL_ROOT, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+  const r = spawnSync(
+    process.execPath,
+    [runner, 'compile', BUILD_ID, '--config-merge', CONFIG_MERGE],
+    { cwd: IMPL_ROOT, stdio: ['ignore', 'inherit', 'inherit'] }
+  );
+  if (r.status !== 0) {
+    console.error(`[ime] build failed with status ${r.status}`);
+    process.exit(1);
+  }
+}
+
+const MIME = { '.js': 'text/javascript', '.html': 'text/html', '.map': 'application/json', '.json': 'application/json' };
+
+function serve() {
+  fs.writeFileSync(
+    path.join(OUT, 'index.html'),
+    '<!doctype html><html><head><meta charset="utf-8"><title>Hicasso IME harness</title></head>' +
+      '<body><div id="app"></div><script src="main.js"></script></body></html>'
+  );
+  return http
+    .createServer((req, res) => {
+      const rel = decodeURIComponent(req.url.split('?')[0]);
+      const file = path.join(OUT, rel === '/' ? 'index.html' : rel);
+      if (!file.startsWith(OUT) || !fs.existsSync(file)) {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      fs.createReadStream(file).pipe(res);
+    })
+    .listen(PORT);
+}
+
+// ---------------------------------------------------------------------------
+// The reporter — laws, pins, records, one tally
+// ---------------------------------------------------------------------------
+
+function reporter(impl) {
+  const checks = [];
+  const say = (line) => console.log(`;; [${impl}] ${line}`);
+  return {
+    impl,
+    checks,
+    check(label, ok, detail) {
+      checks.push({ label, ok: !!ok });
+      if (!ok) say(`FAIL  ${label}${detail === undefined ? '' : `  — got ${JSON.stringify(detail)}`}`);
+      return !!ok;
+    },
+    record(label, value) {
+      say(`record  ${label} = ${JSON.stringify(value)}`);
+    },
+    failed() { return checks.filter((c) => !c.ok); },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Page helpers
+// ---------------------------------------------------------------------------
+
+const state = async (page) => JSON.parse(await page.evaluate('window.IME_STATE()'));
+const clearLog = (page) => page.evaluate('window.IME_CLEAR_LOG()');
+// Two animation frames and a macrotask: the uix-port's refusal path
+// converges on Reagent's after-render queue (drained from rAF), and the
+// cell/entry reapers in the hicasso runtime ride a macrotask.
+const settle = (page) =>
+  page.evaluate(() => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(() => setTimeout(r, 0)))));
+const reset = async (page) => { await page.evaluate('window.IME_RESET()'); await settle(page); };
+const fieldRead = (page, f) =>
+  page.evaluate((id) => {
+    const n = document.getElementById(id);
+    return { value: n.value, s: n.selectionStart, e: n.selectionEnd };
+  }, f);
+const focusEnd = (page, f) =>
+  page.evaluate((id) => {
+    const n = document.getElementById(id);
+    n.focus();
+    n.setSelectionRange(n.value.length, n.value.length);
+  }, f);
+
+// ---------------------------------------------------------------------------
+// CDP input — the real exchange
+// ---------------------------------------------------------------------------
+
+const compose = (cdp, text) =>
+  cdp.send('Input.imeSetComposition', { text, selectionStart: text.length, selectionEnd: text.length });
+const commit = (cdp, text) => cdp.send('Input.insertText', { text });
+const cancel = (cdp) => cdp.send('Input.insertText', { text: '' });
+async function pressKey(cdp, { key = 'Enter', code = 'Enter', vk = 13 }) {
+  await cdp.send('Input.dispatchKeyEvent', {
+    type: 'keyDown', key, code, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk,
+  });
+  await cdp.send('Input.dispatchKeyEvent', {
+    type: 'keyUp', key, code, windowsVirtualKeyCode: vk, nativeVirtualKeyCode: vk,
+  });
+}
+
+// Log slices.
+const nativeOf = (st, field) => st.log.filter((e) => e.layer === 'native' && e.field === field);
+const handlerOf = (st, field) => st.log.filter((e) => e.layer === 'handler' && e.field === field);
+const ofType = (log, t) => log.filter((e) => e.type === t);
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — carriage: one full exchange on the model-agreeing field
+// ---------------------------------------------------------------------------
+//
+// This is also the SURVIVAL law: on a field whose model takes what the
+// IME composes, the exchange must reach `compositionend` uninterrupted —
+// exactly one `compositionstart` in the log. A converge (or restore)
+// that wrote or collapsed mid-composition mints a second one, which is
+// what the mutation run demonstrates.
+
+async function s1Carriage(page, cdp, R) {
+  await reset(page);
+  await focusEnd(page, 'plain');
+  await clearLog(page);
+
+  const trajectory = [];
+  for (const t of ['s', 'sh', 'し']) {
+    await compose(cdp, t);
+    await settle(page);
+    const st = await state(page);
+    trajectory.push({ composed: t, model: st.cells.plain, field: (await fieldRead(page, 'plain')).value });
+  }
+  await commit(cdp, 'し');
+  await settle(page);
+
+  const st = await state(page);
+  const nat = nativeOf(st, 'plain');
+  const starts = ofType(nat, 'compositionstart');
+  const updates = ofType(nat, 'compositionupdate');
+  const inputs = ofType(nat, 'input');
+  const ends = ofType(nat, 'compositionend');
+
+  R.check('s1: exactly one compositionstart — the exchange was never aborted', starts.length === 1, starts.length);
+  R.check('s1: compositionupdate data trail is the composition forming',
+    JSON.stringify(updates.map((e) => e.data)) === JSON.stringify(['s', 'sh', 'し', 'し']),
+    updates.map((e) => e.data));
+  R.check('s1: every native input event carries isComposing true',
+    inputs.length > 0 && inputs.every((e) => e.isComposing === true), inputs.map((e) => e.isComposing));
+  R.check('s1: every native input event carries inputType insertCompositionText',
+    inputs.every((e) => e.inputType === 'insertCompositionText'), inputs.map((e) => e.inputType));
+  R.check('s1: the composition events are trusted — this is the browser, not a dispatched Event',
+    starts.every((e) => e.isTrusted) && updates.every((e) => e.isTrusted) && inputs.every((e) => e.isTrusted),
+    { starts: starts.map((e) => e.isTrusted), inputs: inputs.map((e) => e.isTrusted) });
+  R.check('s1: compositionend carries the committed data',
+    ends.length === 1 && ends[0].data === 'し', ends.map((e) => e.data));
+
+  const f = await fieldRead(page, 'plain');
+  R.check('s1: the field holds the committed text with the caret after it',
+    f.value === 'し' && f.s === 1 && f.e === 1, f);
+  R.check('s1: the model holds the committed text', st.cells.plain === 'し', st.cells.plain);
+  R.check('s1: nothing committed through the commit door', st.committed.plain === undefined, st.committed);
+
+  // The model's view of the exchange, per intermediate update — RECORDED
+  // and pinned: on every implementation the change handler fires per
+  // composition input, so the model tracks the intermediate composition
+  // text. This is measured behaviour, not the fence; the fence is the
+  // commit door (s2/s3).
+  R.record('s1: model trajectory across the updates', trajectory.map((t) => t.model));
+  R.check('s1 (pinned): the model observes each intermediate composition state',
+    JSON.stringify(trajectory.map((t) => t.model)) === JSON.stringify(['s', 'sh', 'し']),
+    trajectory.map((t) => t.model));
+
+  // The handler layer — what the application's own handlers saw.
+  const handler = handlerOf(st, 'plain');
+  if (R.impl === 'hicasso') {
+    const hStarts = ofType(handler, 'compositionstart');
+    const hEnds = ofType(handler, 'compositionend');
+    R.check('s1: React delivered onCompositionStart/End to the hfn probes',
+      hStarts.length === 1 && hEnds.length === 1, { starts: hStarts.length, ends: hEnds.length });
+    R.record('s1: synthetic composition data at the handler',
+      ofType(handler, 'compositionupdate').map((e) => e.syntheticData));
+  } else {
+    const changes = ofType(handler, 'change');
+    R.check('s1: every change handler invocation saw isComposing true ON THE NATIVE EVENT',
+      changes.length > 0 && changes.every((e) => e.nativeIsComposing === true),
+      changes.map((e) => e.nativeIsComposing));
+    R.check('s1: and insertCompositionText on the native event',
+      changes.every((e) => e.nativeInputType === 'insertCompositionText'),
+      changes.map((e) => e.nativeInputType));
+    // The dead-half lesson, recorded where it lives: the synthetic event.
+    R.record('s1: syntheticInputType at the change handler', changes.map((e) => e.syntheticInputType));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — the commit fence, modern signal: a composing Enter
+// ---------------------------------------------------------------------------
+
+async function s2ComposingEnter(page, cdp, R) {
+  await reset(page);
+  await focusEnd(page, 'plain');
+  await clearLog(page);
+
+  await compose(cdp, 'し');
+  await settle(page);
+  await pressKey(cdp, { vk: 13 });   // Enter, mid-composition
+  await settle(page);
+
+  let st = await state(page);
+  const kd = ofType(nativeOf(st, 'plain'), 'keydown');
+  R.check('s2: the mid-composition keydown carried isComposing true, natively and trusted',
+    kd.length === 1 && kd[0].isComposing === true && kd[0].isTrusted === true, kd);
+  R.check('s2: LAW — a composing Enter commits nothing', st.committed.plain === undefined, st.committed);
+
+  if (R.impl !== 'hicasso') {
+    const hkd = ofType(handlerOf(st, 'plain'), 'keydown');
+    R.check('s2: the handler saw isComposing true on the NATIVE event',
+      hkd.length === 1 && hkd[0].nativeIsComposing === true, hkd);
+    R.check("s2: and React's synthetic keyboard event DROPPED it — the reason the gate reads the native event",
+      hkd[0].syntheticIsComposing === undefined || hkd[0].syntheticIsComposing === null,
+      hkd[0].syntheticIsComposing);
+  }
+
+  // Control: the gate is a gate, not an off switch.
+  await commit(cdp, 'し');
+  await settle(page);
+  await pressKey(cdp, { vk: 13 });   // Enter, composition over
+  await settle(page);
+  st = await state(page);
+  R.check('s2: control — an ordinary Enter after compositionend DOES commit',
+    st.committed.plain === 'し', st.committed);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — the commit fence, legacy signal: keyCode 229 alone
+// ---------------------------------------------------------------------------
+
+async function s3KeyCode229(page, cdp, R) {
+  await reset(page);
+  await focusEnd(page, 'plain');
+  await clearLog(page);
+
+  await commit(cdp, 'shi');          // plain text, no composition
+  await settle(page);
+  await pressKey(cdp, { vk: 229 });  // Enter whose keyCode is 229 — all some IMEs send
+  await settle(page);
+
+  let st = await state(page);
+  const kd = ofType(nativeOf(st, 'plain'), 'keydown');
+  R.check('s3: the keydown carried keyCode 229 with isComposing FALSE — the legacy signal alone',
+    kd.length === 1 && kd[0].keyCode === 229 && kd[0].isComposing === false, kd);
+  R.check('s3: LAW — keyCode 229 alone holds the fence', st.committed.plain === undefined, st.committed);
+
+  await pressKey(cdp, { vk: 13 });
+  await settle(page);
+  st = await state(page);
+  R.check('s3: control — keyCode 13 commits', st.committed.plain === 'shi', st.committed);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — a cancelled composition leaves field and model as before
+// ---------------------------------------------------------------------------
+
+async function s4Cancel(page, cdp, R) {
+  for (const field of ['plain', 'digits']) {
+    await reset(page);
+    await focusEnd(page, field);
+    await clearLog(page);
+    const before = { field: (await fieldRead(page, field)).value, model: (await state(page)).cells[field] };
+
+    await compose(cdp, 'か');
+    await settle(page);
+    await cancel(cdp);
+    await settle(page);
+
+    const st = await state(page);
+    const f = await fieldRead(page, field);
+    const ends = ofType(nativeOf(st, field), 'compositionend');
+    R.check(`s4 [${field}]: LAW — the cancelled exchange left the field exactly as before`,
+      f.value === before.field, { before, after: f.value });
+    R.check(`s4 [${field}]: and the model exactly as before`,
+      st.cells[field] === before.model, { before, after: st.cells[field] });
+    if (field === 'plain') {
+      R.check('s4 [plain]: a compositionend closed the exchange, with empty data',
+        ends.length >= 1 && ends[ends.length - 1].data === '', ends.map((e) => e.data));
+    } else {
+      // MEASURED, first run of this harness, all three implementations:
+      // on the refusing field there is NO compositionend to observe. The
+      // model refused `か`, the implementation wrote the refused-to value
+      // back MID-composition, and that write silently aborted the
+      // exchange (the measured JS-write semantics — no compositionend
+      // fires on an abort). The later cancel found no composition left
+      // to cancel. Pinned so a composition carve-out landing upstream
+      // reds this row and gets it rewritten on purpose.
+      R.check('s4 [digits] (pinned): the exchange was already silently aborted — no compositionend ever fired',
+        ends.length === 0, ends.map((e) => e.data));
+    }
+    R.check(`s4 [${field}]: nothing committed`, st.committed[field] === undefined, st.committed);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 5 — the mid-composition conduct matrix (the PR #7371 question)
+// ---------------------------------------------------------------------------
+//
+// `digits` refuses the composition text, `upper` normalises it, and each
+// implementation converges the field toward the model SOMEWHERE — Arm 1's
+// converge inside the input event, React's restore at the end of the same
+// discrete event, the uix-port on the after-render queue when nothing
+// re-rendered. Every one of those writes aborts the live composition (the
+// measured JS-write semantics above). The rows RECORD that per
+// implementation, pinned, so the day a composition carve-out lands the
+// row goes red and gets rewritten on purpose.
+
+async function s5MidComposition(page, cdp, R, out) {
+  // -- digits: the refusing model -------------------------------------------
+  await reset(page);
+  await focusEnd(page, 'digits');
+  await clearLog(page);
+
+  await compose(cdp, 'し');
+  const immediate = (await fieldRead(page, 'digits')).value;  // before any settle
+  await settle(page);
+  const settled = await fieldRead(page, 'digits');
+  const modelAfter = (await state(page)).cells.digits;
+
+  // Continue the exchange the way an IME would — the next update tells us
+  // whether the composition survived the implementation's convergence.
+  await compose(cdp, 'しん');
+  await settle(page);
+  const st2 = await state(page);
+  const starts = ofType(nativeOf(st2, 'digits'), 'compositionstart').length;
+  await cancel(cdp);
+  await settle(page);
+
+  R.check('s5 [digits]: LAW — the refusing model never moved', modelAfter === '12', modelAfter);
+  R.record('s5 [digits]: field immediately after the composing input (no settle)', immediate);
+  R.record('s5 [digits]: field after settle', settled.value);
+  R.record('s5 [digits]: compositionstart count across one attempted exchange', starts);
+
+  const immediateExpected = { hicasso: '12', react: '12', 'uix-port': '12し' }[R.impl];
+  R.check(`s5 [digits] (pinned): the refused composition text is rewritten ${R.impl === 'uix-port' ? 'ONE FRAME LATE' : 'IN-TURN'}`,
+    immediate === immediateExpected, { immediate, expected: immediateExpected });
+  R.check('s5 [digits] (pinned): after settling, the write has landed and the field shows the refused-to value',
+    settled.value === '12', settled.value);
+  R.check('s5 [digits] (pinned): the write ABORTED the live composition — the next IME update minted a NEW compositionstart',
+    starts === 2, starts);
+
+  out.digits = { immediate, settled: settled.value, caret: [settled.s, settled.e], starts };
+
+  // -- upper: the normalising model -----------------------------------------
+  await reset(page);
+  await focusEnd(page, 'upper');
+  await clearLog(page);
+
+  await compose(cdp, 's');
+  const upImmediate = (await fieldRead(page, 'upper')).value;
+  await settle(page);
+  const upSettled = await fieldRead(page, 'upper');
+  const upModel = (await state(page)).cells.upper;
+
+  await compose(cdp, 'sh');
+  await settle(page);
+  const st3 = await state(page);
+  const upStarts = ofType(nativeOf(st3, 'upper'), 'compositionstart').length;
+  await cancel(cdp);
+  await settle(page);
+
+  R.check('s5 [upper]: the model normalised the intermediate composition text', upModel === 'S', upModel);
+  R.record('s5 [upper]: field immediately after the composing input', upImmediate);
+  R.record('s5 [upper]: field after settle', upSettled.value);
+  R.record('s5 [upper]: compositionstart count across one attempted exchange', upStarts);
+  R.check('s5 [upper] (pinned): the normalised value is written back over the live composition',
+    upSettled.value === 'S', upSettled.value);
+  R.check('s5 [upper] (pinned): and that write aborted the composition',
+    upStarts === 2, upStarts);
+
+  out.upper = { immediate: upImmediate, settled: upSettled.value, starts: upStarts };
+}
+
+// ---------------------------------------------------------------------------
+// One page
+// ---------------------------------------------------------------------------
+
+async function runImpl(browser, impl) {
+  const page = await browser.newPage();
+  const watch = watchPage(page, `ime:${impl}`);
+  const R = reporter(impl);
+  const out = { impl, R };
+  try {
+    const cdp = await page.context().newCDPSession(page);
+    await navigate(page, `http://127.0.0.1:${PORT}/?impl=${impl}`, {
+      waitUntil: 'commit',
+      timeoutMs: NAV_TIMEOUT_MS,
+      budget: `the ${READY_TIMEOUT_MS / 1000}s wait for window.IME_READY`,
+    });
+    await watch.race('window.IME_READY === true || window.IME_ERROR', {
+      timeoutMs: READY_TIMEOUT_MS,
+      budget: `the ${READY_TIMEOUT_MS / 1000}s wait for window.IME_READY`,
+    });
+    const err = await page.evaluate('window.IME_ERROR || null');
+    if (err) throw new Error(`the page failed to mount: ${err}`);
+
+    const st = await state(page);
+    R.check('page: the pin matches the implementation this page claims to measure',
+      st.pin === (impl === 'uix-port' ? 'true' : 'false'), st.pin);
+
+    console.log(`;; ==== IME ${impl} ====`);
+    await s1Carriage(page, cdp, R);
+    await s2ComposingEnter(page, cdp, R);
+    await s3KeyCode229(page, cdp, R);
+    await s4Cancel(page, cdp, R);
+    await s5MidComposition(page, cdp, R, out);
+
+    out.pageErrors = watch.failures.map((f) => `${f.kind}: ${f.detail}`);
+    return out;
+  } finally {
+    watch.dispose();
+    await page.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+(async () => {
+  build();
+  const server = serve();
+  const { chromium } = require(require.resolve('playwright', { paths: [IMPL_ROOT] }));
+  const browser = await chromium.launch({ headless: true });
+  const outcomes = [];
+  let died = null;
+  try {
+    for (const impl of IMPLS) {
+      console.error(`[ime] page ${impl}`);
+      try {
+        outcomes.push(await runImpl(browser, impl));
+      } catch (e) {
+        died = `${impl}: ${e.message}`;
+        break;
+      }
+    }
+  } finally {
+    await browser.close();
+    server.close();
+  }
+  if (died) {
+    console.error(`[ime] FAILED: ${died}`);
+    process.exit(1);
+  }
+
+  // Comparative verdict: Arm 1's converge against the plain-React
+  // baseline measured in the SAME run. This is the audit's question in
+  // executable form — mid-composition, is the converge anywhere WORSE
+  // than what React's own restore already does?
+  const by = Object.fromEntries(outcomes.map((o) => [o.impl, o]));
+  if (by.hicasso && by.react) {
+    const R = by.hicasso.R;
+    console.log(';; ==== IME comparative (hicasso vs the plain-React baseline) ====');
+    R.check('comparative: on the refusing field the converge does exactly what React does — same in-turn rewrite, same abort',
+      by.hicasso.digits.immediate === by.react.digits.immediate &&
+        by.hicasso.digits.settled === by.react.digits.settled &&
+        by.hicasso.digits.starts === by.react.digits.starts,
+      { hicasso: by.hicasso.digits, react: by.react.digits });
+    R.check('comparative: on the normalising field likewise',
+      by.hicasso.upper.settled === by.react.upper.settled &&
+        by.hicasso.upper.starts === by.react.upper.starts,
+      { hicasso: by.hicasso.upper, react: by.react.upper });
+  }
+
+  console.log(';; ==== IME RUNTIME ====');
+  console.log(`;; chromium (playwright), DEV bundle (:none — see header), pages: ${IMPLS.join(', ')}`);
+  console.log(`;; reproduce  ${ONLY ? `IME_ONLY=${ONLY} ` : ''}node implementation/freehand/test/re_frame/bench/hicasso/ime_run.cjs`);
+
+  const errored = outcomes.filter((o) => o.pageErrors.length > 0);
+  if (errored.length > 0) {
+    console.error(
+      `[ime] FAILED: uncaught page error(s):\n  ` +
+        errored.map((o) => `${o.impl}: ${o.pageErrors.join(' | ')}`).join('\n  ')
+    );
+    process.exit(1);
+  }
+
+  const totalChecks = outcomes.reduce((n, o) => n + o.R.checks.length, 0);
+  const failures = outcomes.flatMap((o) => o.R.failed().map((c) => `${o.impl}: ${c.label}`));
+  console.log(`;; checks     ${totalChecks} (floor ${CHECK_FLOOR}), failures ${failures.length}`);
+  if (failures.length > 0) {
+    console.error(`[ime] FAILED:\n  ${failures.join('\n  ')}`);
+    process.exit(1);
+  }
+  if (totalChecks < CHECK_FLOOR) {
+    console.error(
+      `[ime] FAILED: only ${totalChecks} checks ran — below the floor of ${CHECK_FLOOR}. ` +
+        `A harness that asserted almost nothing must not exit 0.`
+    );
+    process.exit(1);
+  }
+  console.error('[ime] ok');
+})().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
The `:ime-composition-commits-nothing` row sat deliberately unasserted because synthetic `Event`s named `compositionstart`/`compositionend` exercise neither React's composition plumbing nor the browser's composition state, and a fence asserted without being demonstrated is worse than no fence (rf2-n3dxw, rf2-m6if4). This PR establishes it with the browser's own machinery, against **three** implementations — the bead's two plus the converge the PR #7371 audit added.

## The harness

- **`ime_app.cljs`** — one implementation per page load (`?impl=`), never inherited: Arm 1's element path (`defview` cells, intent vectors, the composition-gated key-map, `front.controlled/install!`'s converge wrapped by the codec), plain React (`defui`, pin `false`), and UIx's Reagent-port (pin `true`) — the rf2-n3dxw pinning discipline, recorded in the page's own state so a row cannot masquerade. Three fields carry the grid model's policy family (`plain` takes, `digits` refuses, `upper` normalises) plus the Enter commit door the fence exists for. Two probe layers: raw `addEventListener` ground truth, and a handler layer recording the synthetic and native readings side by side — the dead-`isComposing` lesson, made a measured column.
- **`ime_run.cjs`** — real composition over CDP: `Input.imeSetComposition` / `Input.insertText` / `Input.dispatchKeyEvent`. Measured on this Chromium before anything was asserted: these mint **trusted** `compositionstart`/`compositionupdate`, trusted `input` events carrying `insertCompositionText` + `isComposing true`, trusted mid-composition keydowns with `isComposing` computed from live composition state, `keyCode 229` via `windowsVirtualKeyCode`, a real composition range — and a JS value write mid-composition **silently aborts** the composition (no `compositionend`; the next IME update mints a fresh `compositionstart`), which is the abort signature the driver detects. The bundle is a dev build on purpose: the uix-port reaches Reagent's after-render queue through the raw `js/reagent.impl.batching.do-after-render` global, which `:advanced` renames away (the header documents this).

## What the events carry, verified on the native event

Asserted per page, not assumed: every composing `input` arrived with `isComposing true` and `inputType "insertCompositionText"` **on the native event**; the mid-composition keydown carried `isComposing true`, trusted; the change handler saw both readings, and React's synthetic keyboard event dropped `isComposing` (asserted) while the synthetic change event dropped `inputType` (recorded: `[null,null,null]`).

## The laws, on each implementation

| law | hicasso | react | uix-port |
|---|---|---|---|
| a composing Enter (native `isComposing`) commits nothing | held | held | held |
| keyCode-229 alone commits nothing; keyCode-13 commits (control) | held | held | held |
| a model-agreeing exchange survives to `compositionend` (exactly one `compositionstart`) | held | held | held |
| a cancelled exchange leaves field and model exactly as before | held | held | held |
| the model observes every intermediate composition state (pinned, recorded) | `s`/`sh`/`し` | same | same |
| a refused value is rewritten mid-composition, silently destroying the exchange (pinned, recorded) | in-turn (`12`) | in-turn (`12`) | one frame late (`12し` → `12`) |
| a normalised value likewise (pinned, recorded) | `S`, aborted | `S`, aborted | `S`, aborted |

Plus the measured wrinkle: on the refusing field a cancelled exchange sees **no `compositionend` at all** — the abort already happened; restoration still held.

## The converge (the PR #7371 audit's question)

The audit asked this harness to pin that the converge "neither writes nor moves selection mid-composition". Measured: on a model-agreeing field it writes nothing and its unconditional `setSelectionRange` did not disturb the composition range — the exchange survives. On a refusing/normalising field it **does** write mid-composition and destroys the exchange — **exactly as plain React's own end-of-event restore does on the same field in the same turn** (asserted comparatively, same run; the uix-port does it one frame later). Nowhere worse than the baseline; not composition-fenced either, same as the baseline. The carve-out (suppress while composing, converge once at `compositionend`) is a behavioural choice inside HD-019's exception scope and needs a ruling — filed as **rf2-digtt** (P1) with the full matrix. An extra measured fact: a mutation making the converge's write unconditional was *harmless* — Chromium's value setter short-circuits an equal write — so the `when-not (=)` guard protects the caret, not the composition.

## Docs reconciled

`validation.md`'s witness set, the studio two-implementations page, both grid suites' carve-out prose, and `front/controlled.cljs`'s docstring now name the harness as what establishes the row and rf2-digtt as the residue. The arm1 suite's two synthetic-signal rows stay, re-scoped as the cheap per-PR in-page witnesses of the gate's two signals.

`docs/design/**` is outside `mkdocs build --strict`; `scripts/check_doc_slugs.py` (exit 0, runs in the fast-PR spine) validates the tree's link targets and anchors. Verified by hand: the studio page edit replaces one prose section with a bulleted list and touches no table; the validation.md edit is prose inside an existing parenthetical, no table; every `rf2-…`/`HD-…` reference names a real bead/decision; the one intra-page reference ("the *IME composition* section above") targets a heading this PR itself keeps.

## Quality gates

Foreground, worktree-local logs (`implementation/out/ime-logs/`), exit codes are each script's own. The branch was **rebased onto `52dd008c5b`** (HD-002 #7384, guide #7382, burst witness #7381, walk optimisation #7383 — the last two land in this harness's compile closure) and **every gate below was re-run on the rebased tree**; the mutation runs predate the rebase and were not re-taken, because both mutation sites are byte-identical across it (`front/intent.cljs`, `front/controlled.cljs` unchanged by the merges) and the post-rebase baseline reproduces the identical 107-check green.

- Harness baseline, post-rebase: `node implementation/freehand/test/re_frame/bench/hicasso/ime_run.cjs` → **exit 0**, `107 checks (floor 100), failures 0`, three pages — the reworked codec (#7383's interpreter-walk changes) still routes `install!` and the converge's composition conduct is unchanged.
- **Mutation 1** — `composing?` re-pointed at the synthetic event (the dead-half regression): **exit 1**, reds exactly `s2: LAW — a composing Enter commits nothing` on **all three pages** while every keyCode-229 row stays green — the signal separation catching precisely the half that died last time. Restored.
- **Mutation 2** — the converge reads its record **before** the flush (the stale-closure trap the file documents): **exit 1**, reds the survival family on the **hicasso page alone** (3 compositionstarts, field `sshしし`, no `compositionend`), other pages green — the harness watches the converge's own mid-composition conduct. Restored; `git diff` against HEAD empty at both mutation sites.
- (A third mutation attempted — unconditional converge write — measured **harmless**, exit 0: Chromium's value setter short-circuits an equal write. Recorded above and in rf2-digtt rather than kept as a proof, because it isn't one.)
- `npm run test:cljs` → **exit 0** — `Ran 12366 tests containing 61776 assertions. 0 failures, 0 errors.` (Pre-rebase run also green: 12331/61722/0/0.)
- `npm run test:browser` → **exit 0** — `Ran 987 tests containing 6173 assertions. 0 failures, 0 errors.` — including the two suites this PR edits and the merged burst/route-link/framework-subs suites. (First post-rebase attempt failed with `aborted par-compile … still waiting` across unrelated namespaces — the stale shadow-cache class; cleared `.shadow-cljs/builds/browser-test`, reran clean. Pre-rebase run also green: 967/6055/0/0.)
- `scripts/test-fast-pr.sh` → **exit EXITFASTPR** post-rebase (pre-rebase: exit 0, `PASS fast PR spine`).
- clj-kondo **2026.04.15** (fetched pinned binary, CI's exact `--lint` roster and `--fail-level error`): **exit 0**, `errors: 0` (4532 pre-existing warnings, informational; none in the files this PR touches).
- `python scripts/check_doc_slugs.py` → **exit 0** (pre- and post-rebase).

TESTING.md matrix: the harness is a manual instrument in the same class as the directory's other `*_run.cjs` drivers — outside the PR/nightly/release matrix by design (CDP-IME, Chromium-only, minutes of wall clock); the PR-tier gates it must keep green are the four above. HD-020's ≤2-hook budget is untouched — nothing was added to any boundary shell, and the hook-ledger witness rides `test:browser` unchanged.

Coordination: rf2-y1jkm's measurement window (announced 2026-08-02 17:57:59 AUSEST, closed 18:32) **overlapped no run of mine** — the pre-rebase browser suites completed at 17:52:49 (log mtimes), the fast-PR spine runs no browser lanes, and every post-rebase browser run began after 19:50, an hour past the window's close; the bead was checked before each browser run. No file overlap with `worker/rlink-2rtt6-53-54`'s merged work (the composition gate's lines in `intent.cljs` are untouched by it — verified by diff) or with held `worker/cascade-2rtt6-52`'s codec changes (my diff touches neither `codec.cljs` nor `runtime.cljs`, and the post-rebase harness run proves the composition conduct against the merged codec).
