### PR TITLE
hicasso: presence lowers its children inside the frame (rf2-2rtt6.66)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -757,20 +757,31 @@ length and the hard terminal bound; re-entry cancels exit; keys are required on
 every dynamic child; presence never dispatches domain mount/unmount events.
 **Cost, stated.** The phase transform and the retention machine are **pure**
 (`front/presence`), which is what makes the whole thing assertable with no clock.
-The React component that drives them (`arm1/presence`) spends **two hooks —
-`useState` and `useEffect` — in its own component**. That is not a shell-budget
-breach: HD-020(b)'s ≤2 is the *boundary shell's*, and presence reads no
+The React component that drives them (`arm1/presence`) spends **three hooks —
+`useContext`, `useState` and `useEffect` — in its own component**. That is not a
+shell-budget breach: HD-020(b)'s ≤2 is the *boundary shell's*, and presence reads no
 subscription, mounts no registration and takes no cell; the dispatcher-level ledger
-still counts exactly two in `runtime/shell`. The hooks are legitimate under
-HD-003's placement rule rather than in spite of it — animation lifecycle is
+still counts exactly two in `runtime/shell`. The two lifecycle hooks are legitimate
+under HD-003's placement rule rather than in spite of it — animation lifecycle is
 component mechanics by that rule's own list — and they are a library mechanic paid
 once, not an application one paid per view. The machine is adjusted **during
 render** rather than in an effect (`step` is idempotent, so the comparison
 converges), because an effect there would cost a paint with the wrong tree in it.
+**The frame hook is the third, and it was bought by a defect rather than by a
+design** (rf2-2rtt6.66). A presence child is hiccup written in the parent's body
+and **lowered inside presence's own render**, so `intent/*dispatch*` was unbound
+when the codec walked it and *any* intent on *any* presence child raised
+`:rf.error/hicasso-intent-outside-boundary` — the inline dismiss button this
+ruling is sold on could not be written. Presence therefore resolves the frame once
+from the substrate's single internal context and re-binds it (HD-020(a)) around the
+one `as-element` call, so a child lowers exactly as it would have in the parent's
+body. No frame in scope stays legal — presence reads nothing — and an intent
+written under a frameless tray remains the same loud error, naming the intent.
 **Demonstrated, not asserted.** The predecessor's own worked toast tray is ported
 both ways in `front/presence_cljs_test` with the rendered attributes asserted
-identical, and driven through React and a real DOM in
-`arm1/presence_dom_cljs_test`.
+identical, driven through React and a real DOM in `arm1/presence_dom_cljs_test`,
+and clicked — both intent shapes, live and retained, against a second live frame —
+in `arm1/presence_intent_dom_cljs_test`.
 **Reopens** if a witness needs a phase on a node the boundary genuinely cannot see
 and `:rf/phase` cannot reach.
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence.cljs
@@ -6,19 +6,51 @@
 
   ## What this costs, stated rather than buried
 
-  **Two React hooks — `useState` and `useEffect` — in THIS component.**
-  The ≤2-hook budget HD-020(b) polices is the *boundary shell's*, and
-  this is not a boundary shell: it reads no subscription, mounts no
-  registration and takes no cell. `runtime/shell` is untouched and the
-  dispatcher-level ledger still counts exactly two there.
+  **Three React hooks — `useContext`, `useState` and `useEffect` — in
+  THIS component.** The ≤2-hook budget HD-020(b) polices is the *boundary
+  shell's*, and this is not a boundary shell: it reads no subscription,
+  mounts no registration and takes no cell. `runtime/shell` is untouched
+  and the dispatcher-level ledger still counts exactly two there.
 
-  The hooks are legitimate under HD-003's placement rule rather than in
-  spite of it: presence is animation lifecycle, which is component
-  mechanics by that rule's own list, and it is a *library* mechanic paid
-  once rather than an application one paid per view. The alternative
-  — keeping retention in a module-level registry keyed by instance —
-  would be a second reactivity system, which is the top item on the
-  anti-regression fence.
+  The two lifecycle hooks are legitimate under HD-003's placement rule
+  rather than in spite of it: presence is animation lifecycle, which is
+  component mechanics by that rule's own list, and it is a *library*
+  mechanic paid once rather than an application one paid per view. The
+  alternative — keeping retention in a module-level registry keyed by
+  instance — would be a second reactivity system, which is the top item
+  on the anti-regression fence.
+
+  ## The frame hook, and why children lowered here need one (rf2-2rtt6.66)
+
+  A presence child is hiccup **data**, written in the parent boundary's
+  body — but it is **lowered in THIS component's render**, one React
+  render later, after that body's dynamic extent has unwound. So
+  `intent/*dispatch*` is unbound at the moment the codec walks it, and
+  before this hook existed an intent at an event position on ANY presence
+  child raised `:rf.error/hicasso-intent-outside-boundary` at render, and
+  an `h/fn` at one raised it at invocation. Loud, never silent — and it
+  meant the tray this whole ruling is sold on,
+
+      [:div.toast {:key id :on-click [:toasts/dismiss id]} …]
+
+  could not be written. The retained half is where it bit hardest: a
+  child the author has already removed from app-db is still on screen and
+  still clickable for `:timeout-ms`, and its dismiss button is exactly
+  the control an exiting toast wants.
+
+  The frame is therefore resolved once, from the substrate's single
+  internal context — the same object `runtime/shell` reads and
+  `arm1.boundary` takes through `contextType` — and re-bound around the
+  one `as-element` call below, with `runtime/frame-dispatch`'s memoised
+  frame-locked dispatch. That is HD-020(a)'s rule applied where the
+  lowering actually happens rather than where the hiccup was written.
+
+  **No frame in scope is not an error here.** Presence reads nothing, so
+  a tray mounted outside a frame is legal until one of its children
+  writes an intent — at which point the existing loud error fires and
+  names the intent, which is better attribution than a generic
+  no-frame-context throw from the tray. The binding is therefore
+  unconditional and simply carries `nil` when there is no provider.
 
   ## Why the machine is adjusted during render and not in an effect
 
@@ -34,7 +66,10 @@
   `:mounting` to `:present` after paint, and it arms **one** timer at the
   earliest deadline. Deadlines are absolute instants, so a timer re-armed
   because some *other* key changed cannot extend a child's retention."
-  (:require [re-frame.bench.hicasso.front.codec :as codec]
+  (:require [re-frame.adapter.context :as adapter-context]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.intent :as intent]
             [re-frame.bench.hicasso.front.presence :as presence]
             ["react" :as react]))
 
@@ -44,6 +79,11 @@
   (let [props      (or (unchecked-get js-props "rfProps") {})
         timeout-ms (presence/check-timeout! (:timeout-ms props))
         children   (:children props)
+        ;; The frame hook. Classified through the shared reader the whole
+        ;; substrate uses, so the no-provider sentinel resolves to nil
+        ;; ("no scope") rather than being mistaken for a frame keyword.
+        frame-kw   (adapter-context/context-value->current-frame
+                     (react/useContext adapter-context/frame-context))
         hook       (react/useState presence/initial)
         state      (aget hook 0)
         set-state  (aget hook 1)
@@ -68,7 +108,15 @@
             (when expiry (js/clearTimeout expiry))
             (when enter (js/clearTimeout enter)))))
       #js [(presence/pending-signature next)])
-    (codec/as-element (into [:<>] (presence/render next)))))
+    ;; THE LOWERING, inside the frame (rf2-2rtt6.66). These children were
+    ;; written in the parent's body and are walked here, so the ambient
+    ;; frame the codec's intent lowering reads has to be re-established
+    ;; around this call and nowhere else. `nil` when no provider is above
+    ;; the tray — the binding is unconditional so the branch does not
+    ;; exist, and an intent written under a frameless tray still lands on
+    ;; the existing loud error naming the intent.
+    (intent/with-frame frame-kw (when frame-kw (rt/frame-dispatch frame-kw))
+      (fn [] (codec/as-element (into [:<>] (presence/render next)))))))
 
 (def presence
   "`h/presence` — a boundary that retains exiting keyed children for

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence_intent_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence_intent_dom_cljs_test.cljs
@@ -42,6 +42,12 @@
      dispatcher read on React 19.2's dev build, which is why a hook
      ROSTER is `distinct` rather than a count.
 
+  One row exists only to make a mutation legible.
+  `an-intent-under-a-framed-tray-raises-nothing` puts an error boundary
+  over an ordinary framed tray and asserts it caught nothing: every other
+  row above reds on an *absence* — no tray, so every query is nil — and
+  React does not print the `ex-info` it swallowed. That row prints it.
+
   ## The host child, and why it is not witnessed here
 
   The bead names native and host children alike. The `defhost` door is
@@ -143,6 +149,27 @@
                      :data-role "note"}
        "note"]])])
 
+(defview note-only-tray
+  "The same tray carrying **only** the callback form, and it exists for
+  what it proves when the frame binding is taken away. The two intent
+  shapes fail at different MOMENTS: a bare vector is refused at LOWERING,
+  during presence's render, so a tray holding one never reaches the
+  screen — and a red on the tray above could always be blamed on that
+  sibling. `h/fn` is lowered happily with no frame (the dispatch is
+  captured, not required); it renders, it clicks, and it raises at
+  INVOCATION. So this tray is the one whose red is the callback path's
+  own."
+  [_]
+  [presence {:timeout-ms timeout-ms}
+   (for [t (rt/sub [:presence-intent/visible])]
+     [:div.toast {:key (:id t) :data-id (:id t)}
+      [:button.note {:data-id   (:id t)
+                     :on-click  (hfn [e]
+                                  (when (= "note" (.. e -target -dataset -role))
+                                    [:presence-intent/noted (:id t)]))
+                     :data-role "note"}
+       "note"]])])
+
 (defview toast-card
   "A BOUNDARY child of presence. It resolves its own frame in its own
   shell and receives `:rf/phase` as an ordinary prop, so it is the
@@ -204,13 +231,21 @@
     (skip! ":node-test has no DOM")
     (do
       (fresh! frame-id two)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
+      ;; The callback-ONLY tray, deliberately: see its docstring. A bare
+      ;; vector on the same child would fail earlier and louder with the
+      ;; binding removed, and would take the credit for this row's red.
+      (let [handle (mount/root! (mount/fresh-container!) frame-id
+                                [note-only-tray {}])]
         (try
+          (is (some? (button handle ".note" 1))
+              "the tray rendered — an h/fn is LOWERED with no frame in scope,
+               because the dispatch is captured rather than required, so this
+               path fails at invocation and not here")
           (click! (button handle ".note" 1))
           (is (= [1] (:noted (db frame-id)))
-              "the h/fn read the real event and the vector it RETURNED drained
-               through the arm's synchronous door — the second row of the
-               position table, at a position presence lowered")
+              "and at invocation the h/fn read the real event and the vector it
+               RETURNED drained through the arm's synchronous door — the second
+               row of the position table, at a position presence lowered")
           (finally (mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
@@ -326,6 +361,40 @@
                 (str "and it named the intent: " (pr-str (ex-data @!caught))))
             (is (= [:presence-intent/dismissed 1] (:intent (ex-data @!caught))))
             (finally (mount/release! handle))))))))
+
+;; ---------------------------------------------------------------------------
+;; 5b — the mutation sentinel: a framed tray raises NOTHING, by name
+;; ---------------------------------------------------------------------------
+;;
+;; Every other row above reds usefully when the binding is removed, but it
+;; reds on an ABSENCE — the tray never renders, so the queries come back nil
+;; and the diagnostic React swallowed is nowhere in the failure text. This row
+;; puts an error boundary over the tray for no reason except to catch what
+;; presence threw and print it, so a mutation names `:rf.error/hicasso-intent-
+;; outside-boundary` in the test output rather than in a browser console
+;; somebody has to go and read.
+
+(deftest an-intent-under-a-framed-tray-raises-nothing
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id two)
+      (reset! !caught nil)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id
+                                [boundary {:fallback [:p.oops "the tray refused"]
+                                           :on-error (fn [e] (reset! !caught e))}
+                                 [toast-tray {}]])]
+        (try
+          (is (nil? @!caught)
+              (str "presence raised while lowering its own children, and the "
+                   "error boundary above the tray caught: "
+                   (pr-str (select-keys (ex-data @!caught)
+                                        [:rf.error/id :intent :position]))))
+          (is (nil? (query handle ".oops"))
+              "so the fallback did not take over")
+          (is (= 2 (.-length (.querySelectorAll (:container handle) ".toast")))
+              "and both toasts, controls and all, are on screen")
+          (finally (mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 6 — the hook budget, counted at React's own dispatcher

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence_intent_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence_intent_dom_cljs_test.cljs
@@ -33,8 +33,14 @@
      absence;
   5. a tray with no frame above it is still legal until a child writes an
      intent, and that intent is still the loud error, **named**;
-  6. presence costs three hooks and `runtime/shell` still costs two —
-     counted at React's own dispatcher, so the budget claim is a reading.
+  6. presence's roster is three hooks and `runtime/shell`'s is still two —
+     counted at React's own dispatcher, so the budget claim is a reading
+     rather than a docstring. It also reads two things off the same log
+     that nothing measured before: presence's body runs exactly **twice**
+     on a mount, which is `step`'s adjust-during-render convergence seen
+     from outside; and a `useEffect` call surfaces more than one
+     dispatcher read on React 19.2's dev build, which is why a hook
+     ROSTER is `distinct` rather than a count.
 
   ## The host child, and why it is not witnessed here
 
@@ -344,18 +350,42 @@
                        (fn []
                          (vreset! handle
                                   (mount/root! (mount/fresh-container!)
-                                               frame-id [toast-tray {}]))))]
+                                               frame-id [toast-tray {}]))))
+              tail   (vec (drop 2 names))
+              freq   (frequencies tail)]
           (try
-            (is (= ["useContext" "useSyncExternalStore"
-                    "useContext" "useState" "useEffect"]
-                   names)
-                (str "the SHELL's two first, in the order rt/shell-hook-ledger "
-                     "declares, then presence's own three: " (pr-str names)))
+            (is (= ["useContext" "useSyncExternalStore"] (vec (take 2 names)))
+                (str "the SHELL's two come first, in the order "
+                     "rt/shell-hook-ledger declares, and they are still the "
+                     "whole of it — this repair added a hook to presence and "
+                     "to nothing that HD-020(b)'s ≤2 budget governs. Raw: "
+                     (pr-str names)))
             (is (= (count rt/shell-hook-ledger) (count (take 2 names)))
-                "the boundary shell gained nothing — HD-020(b)'s ≤2 budget is
-                 the shell's, and presence is not a shell: it reads no
-                 subscription, mounts no registration and takes no cell")
-            (is (= 3 (count (drop 2 names)))
-                "presence's cost is three: the frame hook this repair added,
-                 plus the retention state and the clock")
+                "and the declared shell ledger is the measured one")
+            (is (= ["useContext" "useState" "useEffect"] (vec (distinct tail)))
+                (str "presence's own roster is three, in call order: the frame "
+                     "hook this repair added, the retention state, and the "
+                     "clock. `distinct`, because the RAW list is a log of "
+                     "dispatcher reads rather than of calls — see the two "
+                     "claims below for why. Raw tail: " (pr-str tail)))
+            (is (empty? (filter #{"useRef" "useMemo" "useCallback"
+                                  "useSyncExternalStore"}
+                                tail))
+                "and nothing else — no useRef, and no second subscription")
+            (testing "the raw log's two multiplicities, both measured rather
+                      than assumed"
+              (is (= 2 (get freq "useContext") (get freq "useState"))
+                  "presence's body ran TWICE on this mount, which is the
+                   docstring's convergence claim read off React's own
+                   dispatcher: `step` is adjusted during render, so React
+                   re-runs the body, and `step`'s idempotence is what makes
+                   that ONE extra pass rather than a loop")
+              (is (= 4 (get freq "useEffect"))
+                  "twice per pass, against one call in the body: React 19.2's
+                   DEV dispatcher is read more than once per `useEffect` call,
+                   which is a property of the instrument rather than a second
+                   effect. It is exactly why the roster above is taken with
+                   `distinct` and not by counting, and it is pinned here so a
+                   React bump that changes it reds a test with an explanation
+                   attached rather than a bare number"))
             (finally (mount/release! @handle))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence_intent_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence_intent_dom_cljs_test.cljs
@@ -1,0 +1,361 @@
+(ns re-frame.bench.hicasso.arm1.presence-intent-dom-cljs-test
+  "AN INTENT ON A PRESENCE CHILD (rf2-2rtt6.66).
+
+  `arm1/presence_dom_cljs_test` proves the retention machine through a
+  real DOM: the exit attributes land, re-entry takes them off, the node
+  leaves on the timeout. Every child in that file is **callback-free**,
+  and that was not a stylistic choice — it was the shape of a defect.
+
+  A presence child is hiccup **data**, written in the parent boundary's
+  body; it is **lowered inside the presence component's own React
+  render**, one render later, after the parent body's dynamic extent has
+  unwound. With no ambient frame re-bound there, `intent/*dispatch*` was
+  nil at the moment the codec walked those props, so
+
+      [:div.toast {:key id :on-click [:toasts/dismiss id]}]
+
+  raised `:rf.error/hicasso-intent-outside-boundary` at render — and an
+  `h/fn` at an event position raised the same id at invocation. Loud,
+  never silent, and never *writable*: the inline tray with no child view
+  is the whole of what HD-025 sells, and its dismiss button could not be
+  written. This file is that button, clicked.
+
+  Six claims, and the third and fourth are the ones that matter:
+
+  1. a **bare intent vector** on a native presence child dispatches;
+  2. an **`h/fn` at an event position** on one dispatches what it returns;
+  3. both of them still dispatch **while the child is being retained** —
+     the `::h/unmounting` window, where the child is gone from app-db,
+     still on screen, still clickable, and re-lowered by presence on
+     every one of its own renders;
+  4. the intent lands in the frame the **tray** was mounted under, proved
+     against a second live frame on the same page rather than against an
+     absence;
+  5. a tray with no frame above it is still legal until a child writes an
+     intent, and that intent is still the loud error, **named**;
+  6. presence costs three hooks and `runtime/shell` still costs two —
+     counted at React's own dispatcher, so the budget claim is a reading.
+
+  ## The host child, and why it is not witnessed here
+
+  The bead names native and host children alike. The `defhost` door is
+  HD-011's own surface and does not exist on `main` yet (rf2-2rtt6.65),
+  so there is nothing here to mount one with. The repair does not
+  distinguish them and cannot: **both kinds cross the single
+  `codec/as-element` call** `presence-body` now wraps, so a host child's
+  declared `:callbacks` entry is lowered inside the same binding as a
+  native `:on-click`. The host-hatch suite is where that witness belongs,
+  and this bead is what un-fences its presence-tray children.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every DOM claim degrades to a stated
+  skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.context :as adapter-context]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.boundary :refer [boundary]]
+            [re-frame.bench.hicasso.arm1.hook-probe :as probe]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.presence :refer [presence]]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview hfn]]))
+
+(def ^:private frame-id ::arm1-presence-intent)
+(def ^:private other-frame-id ::arm1-presence-intent-other)
+(def ^:private timeout-ms 400)
+
+;; Registered ABOVE `use-fixtures`, deliberately — the reset fixture captures
+;; its source-store baseline when the `use-fixtures` form is EVALUATED and
+;; restores it before every test, so a `reg-sub` written below it is erased
+;; before the first row runs.
+
+(rf/reg-sub :presence-intent/visible (fn [db _] (:toasts db)))
+
+(rf/reg-event :presence-intent/set
+              (fn [{:keys [db]} [_ ts]] {:db (assoc db :toasts ts)}))
+
+(rf/reg-event :presence-intent/dismissed
+              (fn [{:keys [db]} [_ id]]
+                {:db (update db :dismissed (fnil conj []) id)}))
+
+(rf/reg-event :presence-intent/noted
+              (fn [{:keys [db]} [_ id]]
+                {:db (update db :noted (fnil conj []) id)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     ;; `:ambient-frame nil` is load-bearing. The fixture's default leaves a
+     ;; dynamic-var frame stamp in scope, and a tray that resolved the frame
+     ;; through that tier instead of through React context would look correct
+     ;; here for the wrong reason. With no ambient stamp, the only thing that
+     ;; can name a frame is the provider above the tray.
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(defn- skip! [why]
+  (is true (str "an intent-on-a-presence-child claim needs a real React DOM — " why)))
+
+(defn- fresh! [frame-kw ts]
+  (lane/leave-act-environment!)
+  (rf/make-frame {:id frame-kw})
+  (rf/with-frame frame-kw (rf/dispatch-sync [:presence-intent/set ts]))
+  frame-kw)
+
+(defn- db [frame-kw] (rf/app-db-value frame-kw))
+
+;; ---------------------------------------------------------------------------
+;; The screen — the tray HD-025 sells, with the button it could not carry
+;; ---------------------------------------------------------------------------
+
+(defview toast-tray
+  "The inline tray, with **no child view**, and now with controls on the
+  toast. `:on-click` carries a bare intent vector on one button and the
+  one callback form on the other, so both rows of the position table are
+  written at the same position on the same child."
+  [_]
+  [presence {:timeout-ms timeout-ms}
+   (for [t (rt/sub [:presence-intent/visible])]
+     [:div.toast {:key (:id t)
+                  :data-id (:id t)
+                  :re-frame.hicasso/unmounting {:class "toast--exit"}}
+      (:message t)
+      [:button.dismiss {:data-id  (:id t)
+                        :on-click [:presence-intent/dismissed (:id t)]}
+       "dismiss"]
+      [:button.note {:data-id  (:id t)
+                     :on-click (hfn [e]
+                                 ;; A live event read, and ONE intent
+                                 ;; returned — the event contract the
+                                 ;; position imposes.
+                                 (when (= "note" (.. e -target -dataset -role))
+                                   [:presence-intent/noted (:id t)]))
+                     :data-role "note"}
+       "note"]])])
+
+(defview toast-card
+  "A BOUNDARY child of presence. It resolves its own frame in its own
+  shell and receives `:rf/phase` as an ordinary prop, so it is the
+  control: presence's new binding must leave this path exactly as it was."
+  [{:keys [id]}]
+  [:div.card {:data-id id}
+   [:button.card-dismiss {:on-click [:presence-intent/dismissed id]} "dismiss"]])
+
+(defview card-tray
+  [_]
+  [presence {:timeout-ms timeout-ms}
+   (for [t (rt/sub [:presence-intent/visible])]
+     [toast-card {:key (:id t) :id (:id t)}])])
+
+(def ^:private two [{:id 1 :message "Saved"} {:id 2 :message "Copied"}])
+(def ^:private one [{:id 1 :message "Saved"}])
+
+(defn- query [handle sel] (.querySelector (:container handle) sel))
+
+(defn- button [handle cls id]
+  (.querySelector (:container handle)
+                  (str ".toast[data-id=\"" id "\"] " cls)))
+
+(defn- click! [node]
+  (.click node)
+  (mount/settle!))
+
+;; ---------------------------------------------------------------------------
+;; 1 — a bare intent vector on a native presence child
+;; ---------------------------------------------------------------------------
+
+(deftest a-native-presence-child-dispatches-its-inline-intent
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id two)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
+        (try
+          (is (some? (query handle ".toast"))
+              "the tray rendered at all — before this repair the intent on the
+               child raised :rf.error/hicasso-intent-outside-boundary during
+               presence's own render and there was no tray to click")
+          (is (nil? (:dismissed (db frame-id))))
+          (click! (button handle ".dismiss" 2))
+          (is (= [2] (:dismissed (db frame-id)))
+              "the inline dismiss button dispatched, which is the whole of what
+               the inline tray was sold on")
+          (click! (button handle ".dismiss" 1))
+          (is (= [2 1] (:dismissed (db frame-id)))
+              "and again, so this is a live handler and not a one-shot")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the one callback form at a presence child's event position
+;; ---------------------------------------------------------------------------
+
+(deftest a-callback-at-a-presence-childs-event-position-dispatches-what-it-returned
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id two)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
+        (try
+          (click! (button handle ".note" 1))
+          (is (= [1] (:noted (db frame-id)))
+              "the h/fn read the real event and the vector it RETURNED drained
+               through the arm's synchronous door — the second row of the
+               position table, at a position presence lowered")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the unmounting window: retained, on screen, and still clickable
+;; ---------------------------------------------------------------------------
+
+(deftest a-retained-child-dispatches-during-the-unmounting-window
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id two)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])]
+        (try
+          (mount/dispatch! handle [:presence-intent/set one])
+          (is (= 2 (.-length (.querySelectorAll (:container handle) ".toast")))
+              "toast 2 is gone from app-db and RETAINED on screen")
+          (is (.contains (.-classList (query handle ".toast[data-id=\"2\"]"))
+                         "toast--exit")
+              "and it is in the unmounting phase, not merely still present")
+          (testing "the retained child's controls still reach the frame. This is
+                    the sharpest case: the hiccup being lowered is the LAST one
+                    the parent produced for that key, re-lowered by presence on
+                    every one of its own renders, with the parent body long
+                    returned"
+            (click! (button handle ".dismiss" 2))
+            (is (= [2] (:dismissed (db frame-id))))
+            (click! (button handle ".note" 2))
+            (is (= [2] (:noted (db frame-id)))
+                "both intent shapes, from the retained phase"))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — the frame is the TRAY's, proved against a second live frame
+;; ---------------------------------------------------------------------------
+
+(deftest a-presence-child-lands-in-the-frame-the-tray-was-mounted-under
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id two)
+      (fresh! other-frame-id two)
+      (let [a (mount/root! (mount/fresh-container!) frame-id [toast-tray {}])
+            b (mount/root! (mount/fresh-container!) other-frame-id [toast-tray {}])]
+        (try
+          (click! (button a ".dismiss" 1))
+          (is (= [1] (:dismissed (db frame-id))))
+          (is (nil? (:dismissed (db other-frame-id)))
+              "the second frame's app-db did not move — a frame is an isolated
+               context, and a tray that dispatched to whatever was ambient
+               rather than to its own provider would have moved both")
+          (click! (button b ".dismiss" 2))
+          (is (= [2] (:dismissed (db other-frame-id))))
+          (is (= [1] (:dismissed (db frame-id)))
+              "and symmetrically the other way")
+          (finally (mount/release! a) (mount/release! b)))))))
+
+(deftest a-boundary-child-of-presence-still-lowers-in-its-own-render
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id two)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [card-tray {}])]
+        (try
+          (click! (.querySelector (:container handle)
+                                  ".card[data-id=\"2\"] .card-dismiss"))
+          (is (= [2] (:dismissed (db frame-id)))
+              "a boundary child resolves its own frame in its own shell, and
+               presence's binding around the crossing left that path alone")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — a frameless tray is legal; an intent under one is still the loud error
+;; ---------------------------------------------------------------------------
+
+(def ^:private !caught (atom nil))
+
+(defn- frameless-root!
+  "A root whose provider carries the **no-provider sentinel** — which is
+  the React-context default, so this is exactly a tray with no frame
+  boundary above it, reached without a second door in `mount`."
+  [hiccup]
+  (mount/root! (mount/fresh-container!) adapter-context/no-provider-sentinel hiccup))
+
+(deftest a-frameless-tray-is-legal-until-a-child-writes-an-intent
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (lane/leave-act-environment!)
+      (testing "a tray with no frame above it and no intent below it renders.
+                Presence reads no subscription, so requiring a frame it does not
+                need would refuse a legal page"
+        (let [handle (frameless-root!
+                       [presence {:timeout-ms timeout-ms}
+                        [:div.toast {:key 1 :data-id 1} "quiet"]])]
+          (try
+            (is (some? (query handle ".toast")))
+            (finally (mount/release! handle)))))
+      (testing "and an intent under one is the loud error, NAMED — the
+                diagnostic points at the intent rather than at the tray"
+        (reset! !caught nil)
+        (let [handle (frameless-root!
+                       [boundary {:fallback [:p.oops "no frame"]
+                                  :on-error (fn [e] (reset! !caught e))}
+                        [presence {:timeout-ms timeout-ms}
+                         [:div.toast {:key 1
+                                      :on-click [:presence-intent/dismissed 1]}
+                          "loud"]]])]
+          (try
+            (is (some? (query handle ".oops"))
+                "the tray failed rather than rendering an inert handler")
+            (is (= :rf.error/hicasso-intent-outside-boundary
+                   (:rf.error/id (ex-data @!caught)))
+                (str "and it named the intent: " (pr-str (ex-data @!caught))))
+            (is (= [:presence-intent/dismissed 1] (:intent (ex-data @!caught))))
+            (finally (mount/release! handle))))))))
+
+;; ---------------------------------------------------------------------------
+;; 6 — the hook budget, counted at React's own dispatcher
+;; ---------------------------------------------------------------------------
+
+(defn- unwitnessed! []
+  (is false (str "React's internals slot was not found, so the hook counts are "
+                 "UNWITNESSED on this build. A gate nobody has watched fire is "
+                 "not evidence — fix "
+                 (pr-str 're-frame.bench.hicasso.arm1.hook-probe)
+                 " rather than reading this as a pass.")))
+
+(deftest presence-costs-three-hooks-and-the-shell-still-costs-two
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (if-not (probe/install!)
+      (unwitnessed!)
+      (do
+        (fresh! frame-id one)
+        (let [handle (volatile! nil)
+              names  (probe/record!
+                       (fn []
+                         (vreset! handle
+                                  (mount/root! (mount/fresh-container!)
+                                               frame-id [toast-tray {}]))))]
+          (try
+            (is (= ["useContext" "useSyncExternalStore"
+                    "useContext" "useState" "useEffect"]
+                   names)
+                (str "the SHELL's two first, in the order rt/shell-hook-ledger "
+                     "declares, then presence's own three: " (pr-str names)))
+            (is (= (count rt/shell-hook-ledger) (count (take 2 names)))
+                "the boundary shell gained nothing — HD-020(b)'s ≤2 budget is
+                 the shell's, and presence is not a shell: it reads no
+                 subscription, mounts no registration and takes no cell")
+            (is (= 3 (count (drop 2 names)))
+                "presence's cost is three: the frame hook this repair added,
+                 plus the retention state and the clock")
+            (finally (mount/release! @handle))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -399,9 +399,22 @@
         (swap! !frame-ops assoc frame-kw ops)
         ops)))
 
-(defn- frame-dispatch
+(defn frame-dispatch
   "The ambient dispatch a boundary binds for its render's dynamic extent
-  (HD-020(a)), memoised per frame so binding it allocates nothing."
+  (HD-020(a)), memoised per frame so binding it allocates nothing.
+
+  **Public because a boundary shell is not the only thing that lowers
+  hiccup** (rf2-2rtt6.66). `arm1.presence` renders retained children
+  inside its OWN React render, after the parent body's dynamic extent has
+  unwound, so it must re-bind the ambient frame before it hands them to
+  the codec — and the dispatch it binds has to be *this* one. Handing it
+  a private route of its own (a fresh `(fn [e] (dispatch! frame-kw e))`
+  per render) would allocate a closure per presence render and would make
+  \"a presence child lowers exactly as it would in the parent's body\" an
+  approximation rather than an identity. Nothing new is exported: the
+  memo, the `capture-frame` pin and the [[with-commit]] batching are the
+  ones `run-once` already binds, and [[frame-ops]] beside it has been
+  public for the same reason."
   [frame-kw]
   (or (get @!frame-dispatch frame-kw)
       (let [f (fn dispatch-for-frame [event] (dispatch! frame-kw event))]


### PR DESCRIPTION
Closes rf2-2rtt6.66.

## The defect

A presence child is hiccup **data**, written in the parent boundary's body — but it is **lowered inside `arm1/presence`'s own React render**, one render later, after the parent body's dynamic extent has unwound. `presence-body` handed those children straight to `codec/as-element` with no `intent/with-frame` binding, so `intent/*dispatch*` was nil at the moment the codec walked their props.

Consequence, and it is not a corner case: an intent vector at an event position on **any** presence child raised `:rf.error/hicasso-intent-outside-boundary` at render, and an `h/fn` at one raised the same id at invocation. Loud, never silent — but it meant

```clojure
[:div.toast {:key id :on-click [:toasts/dismiss id]} …]
```

could not be written, which is the inline tray with no child view that HD-025 is entirely sold on. `arm1/presence_dom_cljs_test`'s children are callback-free, and that was the shape of this defect rather than a stylistic choice.

The retained half is where it bit hardest. A child the author has already removed from app-db is still on screen and still clickable for `:timeout-ms`, and its dismiss button is exactly the control an exiting toast wants — and it is re-lowered by presence on every one of presence's own renders.

## The repair

`presence-body` resolves the frame once from the substrate's single internal context (`useContext` on `adapter-context/frame-context`, classified through the shared `context-value->current-frame` so the no-provider sentinel resolves to nil rather than being mistaken for a frame keyword), and binds it around its one `as-element` call. HD-020(a)'s rule, applied where the lowering actually happens rather than where the hiccup was written.

**The dispatch route: `runtime/frame-dispatch` made public**, not a private closure over `rt/dispatch!`. It is a visibility change and no new machinery — the memo, the `capture-frame` pin and the `with-commit` batching are the ones `run-once` already binds, and `frame-ops` beside it has been public for exactly this reason. The alternative (`(fn [e] (rt/dispatch! frame-kw e))`) allocates a closure per presence render and makes "a presence child lowers exactly as it would in the parent's body" an approximation rather than an identity.

**No frame in scope stays legal.** Presence reads nothing, so a tray mounted outside a frame is fine until a child writes an intent — at which point the existing loud error fires and names the intent, which is better attribution than a generic no-frame-context throw from the tray. The binding is therefore unconditional and simply carries `nil`; there is no branch.

**No boundary shell gained a hook.** HD-020(b)'s ≤2 is the *shell's*, and presence is not a shell: it reads no subscription, mounts no registration and takes no cell. The new witness counts the shell's pair and presence's roster in one reading at React's own dispatcher, and `arm1/hook_ledger_dom_cljs_test` is untouched and green.

### The docstring claim, as it now reads

`arm1/presence`'s cost section now opens **"Three React hooks — `useContext`, `useState` and `useEffect` — in THIS component"**, with the two lifecycle hooks keeping their HD-003 justification and a new section explaining what bought the third. `docs/design/hicasso/decisions.md` HD-025 carries the same correction ("spends **three hooks**…"), and says the frame hook was bought by a defect rather than by a design.

## Witnessed

New: `implementation/freehand/test/re_frame/bench/hicasso/arm1/presence_intent_dom_cljs_test.cljs`.

| row | claim |
|---|---|
| `a-native-presence-child-dispatches-its-inline-intent` | a **bare intent vector** on a native child, clicked twice |
| `a-callback-at-a-presence-childs-event-position-dispatches-what-it-returned` | an **`h/fn` at an event position**, on a callback-only tray |
| `a-retained-child-dispatches-during-the-unmounting-window` | **both shapes, from the `::h/unmounting` phase** — gone from app-db, retained on screen, class asserted, clicked |
| `a-presence-child-lands-in-the-frame-the-tray-was-mounted-under` | two live frames on the page; a click in one moves that app-db and not the other's |
| `a-boundary-child-of-presence-still-lowers-in-its-own-render` | the control: a boundary child resolves its own frame, and the new binding left that path alone |
| `a-frameless-tray-is-legal-until-a-child-writes-an-intent` | the tray renders with no provider; an intent under one is caught by `h/boundary` and asserted to be `:rf.error/hicasso-intent-outside-boundary` carrying the intent |
| `an-intent-under-a-framed-tray-raises-nothing` | the mutation sentinel — see below |
| `presence-costs-three-hooks-and-the-shell-still-costs-two` | at React's own dispatcher |

Two of these were shaped by running the mutation rather than by writing them first.

- **The callback-only tray.** The two intent shapes fail at different *moments*: a bare vector is refused at LOWERING, inside presence's render, so a tray holding one never reaches the screen — and a red on a mixed tray could always be blamed on that sibling. An `h/fn` is lowered happily with no frame (the dispatch is captured, not required); it renders, it clicks, and it raises at INVOCATION. `note-only-tray` is the one whose red is the callback path's own, and under mutation its "the tray rendered" assertion passes while the dispatch assertion fails — which is the distinction, visible.
- **The sentinel.** Every other row reds on an *absence* — no tray, so every query is nil — and React swallows the `ex-info` it caught. `an-intent-under-a-framed-tray-raises-nothing` puts an error boundary over an ordinary framed tray for no reason except to print what presence threw.

The hook row also reads two things off the dispatcher log that nothing measured before: presence's body runs exactly **twice** on a mount, which is `step`'s adjust-during-render convergence seen from outside; and a `useEffect` call surfaces more than one dispatcher read on React 19.2's dev build, which is why a hook ROSTER is taken with `distinct` rather than by counting. Both are asserted, with the reason attached, so a React bump reds a test that explains itself.

### The host child

The bead names native and host children alike. **The `defhost` door is HD-011's own surface and does not exist on `main` yet** (rf2-2rtt6.65 is still in flight), so there is nothing here to mount one with. The repair cannot distinguish them: both kinds cross the single `codec/as-element` call now wrapped, so a host child's declared `:callbacks` entry is lowered inside the same binding as a native `:on-click`. The host-hatch suite is where that witness belongs — its presence-tray children are deliberately callback-free and cite this bead, and this is what un-fences them.

## Quality gates

All foreground, worktree-local logs, exit codes are each script's own.

| gate | exit |
|---|---|
| `npm run test:cljs` | **0** — 12373 tests, 61789 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **0** — 995 tests, 6201 assertions, 0 failures, 0 errors |
| `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine`; it names its own gap (JVM artefact suites the diff did not touch; browser lanes / elision / bundle-isolation / perf / adapter smokes / Xray / mcp-conformance are CI's) |
| `clj-kondo` v2026.04.15 (CI's pinned version, fetched; CI's exact `--lint` list, `--parallel --fail-level error`) | **0** — `errors: 0`, warnings 4532 (unchanged baseline; **zero findings on any file this PR touches**) |

TESTING.md matrix: this change lives in the Hicasso bench tree under `implementation/freehand/test/`. Its lanes are **CLJS unit** (`test:cljs` — the consolidated default gate; the new `*-dom-cljs-test` ns rides it and every DOM claim degrades to a stated skip on Node), **Browser unit** (`test:browser`, the `-dom-cljs-test$` lane — where the claims actually fire, because presence transitions need a real DOM and a real click), and the **fast-pr spine** for drift/lockstep. Nothing here touches an adapter smoke, a bundle-isolation or elision gate, the Xray/Story lanes, or MCP conformance. Docs: `docs/design/hicasso/**` is excluded from `mkdocs build --strict` by `mkdocs.yml`'s `exclude_docs`, so it is not the gate for the HD-025 edit; `scripts/check_doc_slugs.py` validates that tree's link targets and heading anchors and runs inside the fast-pr spine. The HD-025 edit adds no link, no heading and no table row — the paragraph's prose is replaced in place.

### Mutation

The one repair line — `intent/with-frame` around `presence-body`'s `as-element` — removed, suite re-run, restored, suite re-run. Same worktree, same command, nothing else changed.

**RED** (`npm run test:browser` exit **1**): `9 failures, 4 errors`, every one of them in the new suite. React's own report is `An error occurred in the <hicasso/presence> component`, and the sentinel prints what it caught:

```
FAIL in (an-intent-under-a-framed-tray-raises-nothing)
  presence raised while lowering its own children, and the error boundary above the tray caught:
  {:rf.error/id :rf.error/hicasso-intent-outside-boundary, :intent [:presence-intent/dismissed 1]}
  actual: #error {:message "Intent [:presence-intent/dismissed 1] was lowered with no ambient
                            frame; event vectors are only legal inside a boundary's render.
                            [:rf.error/hicasso-intent-outside-boundary]",
                  :data {:rf.error/id :rf.error/hicasso-intent-outside-boundary,
                         :where front.intent/lower-prop,
                         :recovery :lower-intents-inside-a-boundary-render,
                         :intent [:presence-intent/dismissed 1]}}
```

The two rows that must NOT move both stayed green under the mutation, which is what makes them controls rather than decoration: `a-boundary-child-of-presence-still-lowers-in-its-own-render` (a boundary child resolves its own frame in its own shell) and `a-frameless-tray-is-legal-until-a-child-writes-an-intent` (already about the no-frame case).

**GREEN** (restored, `npm run test:browser` exit **0**): 995 tests, 6201 assertions, 0 failures, 0 errors. `git diff` against the committed `presence.cljs` is empty after the restore.

## Coordination

- **`worker/readopt-6c237` (measurement windows).** `SendMessage` to that name was **not reachable**, so I read the box instead: its bead's last note says the census-clock re-take was starting, and at 21:58–22:03 AEST its worktree ran a heavy JVM + Chrome pair. By 22:03 it had moved to `docs/` writes and its own `fastpr.log`, i.e. out of measurement and into gates. **My first browser run started at 22:11:52**, after that transition, and every subsequent run is inside 22:11–22:28. No measurement window was occupied. If that reading is wrong, the rows to re-take are the census clock's, not anything here — nothing in this PR publishes a number.
- **`worker/hosthatch` (rf2-2rtt6.65).** Not met in a shared file. It owns `front/codec.cljs` + `arm1/lang.clj` for the host head and `defhost`; this PR touches neither. The one place we interlock is the host-hatch suite's deliberately callback-free presence-tray children, which this bead releases — see The host child above.
- **`worker/dogfood-pref` (rf2-2rtt6.67).** Not met. It owns the dogfood renderings; nothing here touches `front/dogfood.cljs`, `arm1/dogfood_*` or `front/intent.cljs`.
- **`front/intent.cljs` is untouched.** The repair is entirely on the calling side — presence re-binds what intent already exposes (`with-frame`, `*dispatch*`), and the diagnostics are the ones intent already emits.
- **PR #7375 (`worker/cascade-2rtt6-52`, held) not touched.** It also edits `arm1/runtime.cljs`, at lines ~1189+ and ~1233+ (the shell / `mint-view!` region); this PR's runtime edit is `frame-dispatch` at ~line 402. No overlapping hunk. It also edits `decisions.md`, as does #7376 — my edit is a paragraph inside HD-025, and #7375's hunk appends past its own (older) base, so both will need a rebase against current `main` regardless of this PR. **How this composes with its memo wrapper:** a `React.memo`'d subtree that bails out does not re-render, so presence does not re-run and re-lower — the children on screen keep the handlers minted at the last real render, which close over the frame-locked dispatch **memoised per frame** rather than one minted per render. A stale bail-out therefore cannot hand back a stale dispatch, and this repair adds nothing new for the wrapper to compare: the props presence receives are unchanged, and `frame-dispatch`'s identity is stable for the life of a frame incarnation (and dropped by `forget-frame-ops!` when the frame is destroyed).

## Follow-up filed

**rf2-uo9di** (P2) — `h/boundary` has the identical defect and it is not fixed here, because this bead names presence. `arm1/boundary.cljs`'s class render lowers **both its `:fallback` and its children** with no ambient frame, by the same mechanism. The fallback half is the sharper one: HD-020(c)'s whole pitch is a fallback beside a `:reset-key`, and the retry control that pairing implies — `[:button {:on-click [:app/retry]}]` — cannot be written today. The repair there is cheaper than this one and needs **no new hook and no new accessor**, because the class already resolves its frame through `contextType` for `:on-error`. This PR's own `h/boundary` uses keep their fallbacks intent-free and the bead records why.
