### PR TITLE
hicasso: a boundary lowers its fallback and children inside the frame (rf2-uo9di)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -472,6 +472,24 @@ render path ships in v0; `defhost`'s SSR-placeholder default is declared policy
 for later phases, inert in v0.
 **Rationale.** Each is a decision a v0 implementer would otherwise have to make
 ad hoc mid-spike; none is reversible for free once witnesses pin behaviour.
+**(a) reaches further than a boundary shell, and (c) is what proved it**
+(rf2-uo9di). A `h/boundary`'s `:fallback` and its children are hiccup written in
+the *parent's* body and walked by the codec inside the **class's own render**,
+one render later — so `intent/*dispatch*` was unbound when the codec reached
+them, and an intent at an event position on either raised
+`:rf.error/hicasso-intent-outside-boundary`. The fallback half made (c)'s own
+worked example unwritable: `:fallback` ships beside `:reset-key` precisely so
+that "the retry is the caller's to schedule", and the control that schedules it
+is a button whose `:on-click` is an intent. Worse, a fallback that throws while
+rendering takes the *next* boundary up, so an application's error path became an
+application-wide failure. The class therefore re-binds its frame (a) around that
+one crossing. **It costs no hook** — the frame was already reaching it through
+`contextType`, which is a property of the component rather than a dispatcher
+read, so unlike `arm1/presence`'s identical repair (HD-025) this one is
+invisible to (b)'s ledger. No frame in scope stays legal — the class reads
+nothing — and an intent written under a frameless boundary remains the same loud
+error, naming the intent. Witnessed, retry button and all, in
+`arm1/boundary_intent_dom_cljs_test`.
 **Reopens** at product phase (SSR, richer boundary API) by ordinary ruling.
 
 ## HD-021 — The v0 execution contract: root, HMR, headless

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary.cljs
@@ -25,10 +25,13 @@
 
   **A class component calls no hooks, so this costs the ≤2-hook shell
   budget exactly nothing** — the boundary is not a boundary *shell*, it
-  reads no subscription, mints no registration and takes no cell.
-  `arm1_lifecycle_dom_cljs_test` counts that at React's own dispatcher
-  rather than asserting it here: a page wrapping a Hicasso boundary in
-  one of these still reads two.
+  reads no subscription, mints no registration and takes no cell. That
+  stayed true when the frame binding below arrived: `contextType` is a
+  property of the component, not a hook call, so it is invisible at
+  React's dispatcher. `arm1_lifecycle_dom_cljs_test` counts a healthy
+  page there and `arm1_boundary_intent_dom_cljs_test` counts one in its
+  ERROR state, rather than either asserting it here: a page wrapping a
+  Hicasso boundary in one of these still reads two.
 
   ## The three keys
 
@@ -66,6 +69,43 @@
   was mounted under rather than in whatever happened to be ambient when
   the throw arrived.
 
+  ## The fallback and the children are lowered HERE (rf2-uo9di)
+
+  Both are hiccup **data**, written in the parent boundary's body — and
+  both are walked by the codec inside **this class's own React render**,
+  one render later, after that body's dynamic extent has unwound. So
+  `intent/*dispatch*` was unbound at the moment the codec reached them,
+  and before the binding below existed an intent at an event position on
+  the fallback or on a native child raised
+  `:rf.error/hicasso-intent-outside-boundary` at render, while an `h/fn`
+  at one raised the same id at invocation.
+
+  The fallback half is the sharp one, because it is the half the ruling
+  above is sold on: `:fallback` sits beside `:reset-key` precisely so
+  that \"the retry is the CALLER's to schedule\", and the control that
+  schedules it is a button whose `:on-click` is an intent. So the table's
+  own worked example could not be written — and a fallback that throws
+  while rendering does not fail quietly in a corner, it takes the *next*
+  boundary up, turning an application's error path into an
+  application-wide failure.
+
+  The repair is [[re-frame.bench.hicasso.arm1.presence]]'s, one component
+  along, and **cheaper**: presence had to buy a `useContext` to find its
+  frame and paid for it in HD-025's stated cost, while this class already
+  has [[frame-of]] through `contextType`. So there is no new hook and no
+  new accessor — only HD-020(a)'s rule applied where the lowering
+  actually happens rather than where the hiccup was written, with
+  `runtime/frame-dispatch`'s memoised frame-locked dispatch so a child
+  here lowers *identically* to one written in the parent's body and
+  nothing is allocated per render.
+
+  **No frame in scope is not an error here.** The class reads nothing, so
+  a boundary mounted outside a frame is legal until something below it
+  writes an intent — at which point the existing loud error fires and
+  names the intent, which is better attribution than a generic
+  no-frame-context throw from the boundary. The binding is therefore
+  unconditional and simply carries `nil` when there is no provider.
+
   ## What it does NOT catch, stated because a boundary that quietly does
   ## not catch is worse than none
 
@@ -78,6 +118,7 @@
   (:require [re-frame.adapter.context :as adapter-context]
             [re-frame.bench.hicasso.arm1.runtime :as rt]
             [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.intent :as intent]
             ["react" :as react]))
 
 (defn- props-of
@@ -151,8 +192,23 @@
           (fn []
             (this-as ^js this
               (let [{:keys [fallback children]} (props-of this)
-                    error (unchecked-get (.-state this) "error")]
-                (if (some? error)
-                  (codec/as-element (if (fn? fallback) (fallback error) fallback))
-                  (codec/as-element (into [:<>] children)))))))
+                    error    (unchecked-get (.-state this) "error")
+                    frame-kw (frame-of this)]
+                ;; THE LOWERING, inside the frame (rf2-uo9di). The fallback
+                ;; and the children were both written in the parent's body
+                ;; and are both walked HERE, so the ambient frame the codec's
+                ;; intent lowering reads has to be re-established around this
+                ;; call and nowhere else. ONE binding covers both branches
+                ;; because both are the same crossing — including
+                ;; `(fallback error)` itself, so hiccup the fallback function
+                ;; mints is lowered under the same frame as hiccup it was
+                ;; handed. `nil` when no provider is above the boundary: the
+                ;; binding is unconditional so the branch does not exist, and
+                ;; an intent written under a frameless boundary still lands on
+                ;; the existing loud error naming the intent.
+                (intent/with-frame frame-kw (when frame-kw (rt/frame-dispatch frame-kw))
+                  (fn []
+                    (if (some? error)
+                      (codec/as-element (if (fn? fallback) (fallback error) fallback))
+                      (codec/as-element (into [:<>] children)))))))))
     (codec/mark-boundary! ctor)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary_intent_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/boundary_intent_dom_cljs_test.cljs
@@ -1,0 +1,453 @@
+(ns re-frame.bench.hicasso.arm1.boundary-intent-dom-cljs-test
+  "AN INTENT ON A BOUNDARY'S FALLBACK, AND ON ITS CHILDREN (rf2-uo9di).
+
+  The sibling of `arm1/presence_intent_dom_cljs_test`, and the identical
+  mechanism one component along. A `h/boundary`'s `:fallback` and its
+  `:children` are hiccup **data**, written in the parent boundary's body
+  — and both are **lowered inside the class component's own React
+  render**, after that body's dynamic extent has unwound. With no ambient
+  frame re-bound there, `intent/*dispatch*` was nil at the moment the
+  codec walked those props, so
+
+      [boundary {:fallback [:button {:on-click [:app/retry]} \"try again\"]
+                 :reset-key attempt}
+       [risky {}]]
+
+  raised `:rf.error/hicasso-intent-outside-boundary` while the boundary
+  rendered its fallback — and an `h/fn` at an event position raised the
+  same id at invocation.
+
+  ## Why the fallback half is the sharp one
+
+  HD-020(c) ships `:fallback` **beside** `:reset-key`, and the reason it
+  gives is that \"the retry is the CALLER's to schedule\". The control that
+  schedules it is a button, the button lives in the fallback, and its
+  `:on-click` is an intent — so the ruling's own worked example was the
+  one thing the component could not render. Worse than unwritable: a
+  fallback that throws while rendering does not fail quietly in a corner,
+  it takes the *next* boundary up, so an application's error path became
+  an application-wide failure.
+
+  Seven claims:
+
+  1. a **retry button on the fallback** dispatches, and the `:reset-key`
+     it moves actually re-mounts the child — HD-020(c)'s whole story,
+     end to end;
+  2. an **`h/fn` at an event position on a function fallback** dispatches
+     what it returns, closing over the error the fallback was handed;
+  3. a **bare intent vector on a native child** of `h/boundary`
+     dispatches;
+  4. an **`h/fn` on a native child** does;
+  5. the intent lands in the frame the **boundary** was mounted under,
+     proved against a second live frame rather than against an absence;
+  6. a boundary with no frame above it is still legal until something
+     below it writes an intent, and that intent is still the loud error,
+     **named**;
+  7. the class still spends **no hook** — in its error state as well as
+     its healthy one, so the repair did not buy the fence what
+     `arm1/presence` had to buy it.
+
+  ## Why the shapes are on SEPARATE subjects
+
+  The two intent shapes fail at different **moments**. A bare vector is
+  refused at LOWERING, during the boundary's own render, so a subject
+  carrying one never reaches the screen at all; an `h/fn` is lowered
+  happily with no frame (the dispatch is captured, not required), renders,
+  and raises at INVOCATION. Mixed onto one subject the first would mask
+  the second, and every red on the callback path could be blamed on its
+  louder sibling. So rows 2 and 4 carry the callback form and nothing
+  else.
+
+  ## Why most rows mount under a watching boundary
+
+  A throw while the boundary lowers its own fallback or children escapes
+  the class and lands on the **next** boundary above it, and React does
+  not print the `ex-info` it swallowed. [[watched-root!]] puts an
+  ordinary `h/boundary` there for no reason except to catch that and hand
+  it to the assertion message, so a mutation names
+  `:rf.error/hicasso-intent-outside-boundary` in the test output rather
+  than in a browser console somebody has to go and read. Its own fallback
+  is deliberately intent-free — it is the instrument, and an instrument
+  that can fail the way the subject fails measures nothing.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every DOM claim degrades to a stated
+  skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.context :as adapter-context]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.boundary :refer [boundary]]
+            [re-frame.bench.hicasso.arm1.hook-probe :as probe]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview hfn]]))
+
+(def ^:private frame-id ::arm1-boundary-intent)
+(def ^:private other-frame-id ::arm1-boundary-intent-other)
+
+;; Registered ABOVE `use-fixtures`, deliberately — the reset fixture captures
+;; its source-store baseline when the `use-fixtures` form is EVALUATED and
+;; restores it before every test, so a `reg-sub` written below it is erased
+;; before the first row runs.
+
+(rf/reg-sub :bdy/boom? (fn [db _] (:boom? db)))
+(rf/reg-sub :bdy/attempt (fn [db _] (:attempt db)))
+
+(rf/reg-event :bdy/seed (fn [_ _] {:db {:boom? true :attempt 0}}))
+
+(rf/reg-event :bdy/retry
+              (fn [{:keys [db]} _]
+                {:db (-> db (assoc :boom? false) (update :attempt inc))}))
+
+(rf/reg-event :bdy/dismissed
+              (fn [{:keys [db]} [_ id]]
+                {:db (update db :dismissed (fnil conj []) id)}))
+
+(rf/reg-event :bdy/noted
+              (fn [{:keys [db]} [_ tag]]
+                {:db (update db :noted (fnil conj []) tag)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     ;; `:ambient-frame nil` is load-bearing. The fixture's default leaves a
+     ;; dynamic-var frame stamp in scope, and a boundary that resolved its
+     ;; frame through that tier instead of through React context would look
+     ;; correct here for the wrong reason. With no ambient stamp, the only
+     ;; thing that can name a frame is the provider above the tree.
+     :ambient-frame nil
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(defn- skip! [why]
+  (is true (str "an intent-on-a-boundary claim needs a real React DOM — " why)))
+
+(defn- fresh! [frame-kw]
+  (lane/leave-act-environment!)
+  (rf/make-frame {:id frame-kw})
+  (rf/with-frame frame-kw (rf/dispatch-sync [:bdy/seed]))
+  frame-kw)
+
+(defn- db [frame-kw] (rf/app-db-value frame-kw))
+
+(defn- query [handle sel] (.querySelector (:container handle) sel))
+
+(defn- click! [node]
+  (.click node)
+  ;; TWICE, and not for luck. The click's own dispatch commits on the first
+  ;; settle; a `:reset-key` that moved is then read by `componentDidUpdate`,
+  ;; which clears the caught error with a `setState` of its own — a second
+  ;; commit, from a lifecycle rather than from the event. Row 1 reads the DOM
+  ;; after both.
+  (mount/settle!)
+  (mount/settle!))
+
+;; ---------------------------------------------------------------------------
+;; The instrument — a boundary that records what escaped the subject
+;; ---------------------------------------------------------------------------
+
+(def ^:private !caught (atom nil))
+
+(defn- watched-root!
+  "Mount `hiccup` under an ordinary `h/boundary` whose only job is to
+  catch what the subject threw and hand it to the assertion message. Its
+  fallback and its `:on-error` are intent-free: an instrument that fails
+  the way the subject fails measures nothing."
+  [frame-kw hiccup]
+  (reset! !caught nil)
+  (mount/root! (mount/fresh-container!) frame-kw
+               [boundary {:fallback [:p.escaped "the subject refused to render"]
+                          :on-error (fn [e] (reset! !caught e))}
+                hiccup]))
+
+(defn- escaped
+  "What the watching boundary caught, as the two fields a reader wants."
+  []
+  (select-keys (ex-data @!caught) [:rf.error/id :intent :position]))
+
+;; ---------------------------------------------------------------------------
+;; The screens
+;; ---------------------------------------------------------------------------
+
+(defview risky
+  "Throws from the render phase while the model says so — which is where a
+  React error boundary is the only thing that can catch."
+  [_]
+  (when (rt/sub [:bdy/boom?])
+    (throw (ex-info "the child threw" {:planted true})))
+  [:p.ok "recovered"])
+
+(defview retry-screen
+  "HD-020(c)'s ADVERTISED CASE, and the reason this bead is P2: a fallback
+  whose whole point is a retry control, beside the `:reset-key` that makes
+  the retry the caller's to schedule rather than the boundary's to guess."
+  [_]
+  [boundary {:fallback  [:div.fb
+                         [:p "that did not work"]
+                         [:button.retry {:on-click [:bdy/retry]} "try again"]]
+             :reset-key (rt/sub [:bdy/attempt])}
+   [risky {}]])
+
+(defview note-fallback-screen
+  "The FUNCTION fallback, carrying **only** the one callback form. Two
+  things at once: `h/fn` is the second row of the position table, and the
+  closure reads the error the fallback was handed — so this is also the
+  `(fn [error] hiccup)` contract exercised at an event position rather
+  than at a text node."
+  [_]
+  [boundary {:fallback (fn [error]
+                         [:div.fb
+                          [:button.note
+                           {:data-role "note"
+                            :on-click  (hfn [e]
+                                         ;; A live event read, and ONE
+                                         ;; intent returned — the event
+                                         ;; contract the position imposes.
+                                         (when (= "note" (.. e -target -dataset -role))
+                                           [:bdy/noted (ex-message error)]))}
+                           "note"]])}
+   [risky {}]])
+
+(defview child-intent-screen
+  "The CHILDREN half. Nothing throws here: these are ordinary native
+  children of `h/boundary`, written in this body and lowered one render
+  later inside the class's."
+  [_]
+  [boundary {:fallback [:p.fb "unused — nothing throws on this screen"]}
+   [:div.body
+    [:button.dismiss {:on-click [:bdy/dismissed 1]} "dismiss"]]])
+
+(defview child-callback-screen
+  "The children half, carrying **only** the callback form — the same
+  separation rows 1 and 2 keep, for the same reason."
+  [_]
+  [boundary {:fallback [:p.fb "unused — nothing throws on this screen"]}
+   [:button.note
+    {:data-role "note"
+     :on-click  (hfn [e]
+                  (when (= "note" (.. e -target -dataset -role))
+                    [:bdy/noted "child"]))}
+    "note"]])
+
+;; ---------------------------------------------------------------------------
+;; 1 — the retry button HD-020(c) is sold on
+;; ---------------------------------------------------------------------------
+
+(deftest a-fallbacks-retry-button-dispatches-and-the-reset-key-retries
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id)
+      (let [handle (watched-root! frame-id [retry-screen {}])]
+        (try
+          (is (nil? @!caught)
+              (str "the boundary lowered its fallback with no ambient frame, so "
+                   "the retry intent raised while it rendered and the failure "
+                   "escaped to the boundary ABOVE — an application's error path "
+                   "becoming an application-wide one. Escaped: " (pr-str (escaped))))
+          (is (some? (query handle ".retry"))
+              "the fallback, and the retry control on it, are on screen")
+          (is (nil? (query handle ".ok"))
+              "and the child that threw rendered nothing")
+          (testing "the click reaches the frame, and the reset-key it moved
+                    re-mounts the child — the whole of what `:fallback` beside
+                    `:reset-key` was sold on"
+            (click! (query handle ".retry"))
+            (is (= 1 (:attempt (db frame-id)))
+                "the intent on the fallback dispatched")
+            (is (some? (query handle ".ok"))
+                "and the retry succeeded: a changed :reset-key cleared the caught
+                 failure and the child rendered")
+            (is (nil? (query handle ".fb"))
+                "with the fallback gone"))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the one callback form on a function fallback
+;; ---------------------------------------------------------------------------
+
+(deftest a-callback-on-the-fallback-dispatches-what-it-returned
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id)
+      ;; The callback-ONLY fallback, deliberately: see the namespace docstring.
+      ;; A bare vector on the same fallback would fail earlier and louder, and
+      ;; would take the credit for this row's red.
+      (let [handle (watched-root! frame-id [note-fallback-screen {}])]
+        (try
+          (is (some? (query handle ".note"))
+              "the fallback rendered — an h/fn is LOWERED with no frame in
+               scope, because the dispatch is captured rather than required, so
+               this path fails at invocation and not here")
+          (click! (query handle ".note"))
+          (is (= ["the child threw"] (:noted (db frame-id)))
+              "at invocation the h/fn read the real event, closed over the error
+               the fallback was handed, and the vector it RETURNED drained
+               through the arm's synchronous door")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — a bare intent vector on a native child of h/boundary
+;; ---------------------------------------------------------------------------
+
+(deftest a-native-child-of-a-boundary-dispatches-its-inline-intent
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id)
+      (let [handle (watched-root! frame-id [child-intent-screen {}])]
+        (try
+          (is (nil? @!caught)
+              (str "the boundary lowered its CHILDREN with no ambient frame. "
+                   "Escaped: " (pr-str (escaped))))
+          (is (some? (query handle ".dismiss"))
+              "the screen rendered at all — before this repair the intent on the
+               child raised during the class's own render and there was no
+               button to click")
+          (is (nil? (:dismissed (db frame-id))))
+          (click! (query handle ".dismiss"))
+          (is (= [1] (:dismissed (db frame-id))))
+          (click! (query handle ".dismiss"))
+          (is (= [1 1] (:dismissed (db frame-id)))
+              "and again, so this is a live handler and not a one-shot")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — the one callback form on a native child
+;; ---------------------------------------------------------------------------
+
+(deftest a-callback-on-a-native-child-dispatches-what-it-returned
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id)
+      (let [handle (watched-root! frame-id [child-callback-screen {}])]
+        (try
+          (is (some? (query handle ".note")))
+          (click! (query handle ".note"))
+          (is (= ["child"] (:noted (db frame-id)))
+              "the callback path, at a child position, on its own subject")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — the frame is the BOUNDARY's, proved against a second live frame
+;; ---------------------------------------------------------------------------
+
+(deftest a-fallbacks-intent-lands-in-the-frame-the-boundary-was-mounted-under
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh! frame-id)
+      (fresh! other-frame-id)
+      (let [a (watched-root! frame-id [retry-screen {}])
+            b (mount/root! (mount/fresh-container!) other-frame-id
+                           [retry-screen {}])]
+        (try
+          (click! (query a ".retry"))
+          (is (= 1 (:attempt (db frame-id))))
+          (is (= 0 (:attempt (db other-frame-id)))
+              "the second frame's app-db did not move — a frame is an isolated
+               context, and a fallback that dispatched to whatever was ambient
+               rather than to its own provider would have moved both")
+          (click! (query b ".retry"))
+          (is (= 1 (:attempt (db other-frame-id))))
+          (is (= 1 (:attempt (db frame-id)))
+              "and symmetrically the other way")
+          (finally (mount/release! a) (mount/release! b)))))))
+
+;; ---------------------------------------------------------------------------
+;; 6 — a frameless boundary is legal; an intent under one is still the loud error
+;; ---------------------------------------------------------------------------
+
+(defn- frameless-root!
+  "A root whose provider carries the **no-provider sentinel** — the React
+  context default, so this is exactly a tree with no frame boundary above
+  it, reached without a second door in `mount`. The children are native
+  hiccup throughout: a `defview` product refuses to render frameless on
+  its own account (`:rf.error/no-frame-context`), which would answer a
+  different question."
+  [hiccup]
+  (reset! !caught nil)
+  (mount/root! (mount/fresh-container!) adapter-context/no-provider-sentinel
+               [boundary {:fallback [:p.escaped "the subject refused to render"]
+                          :on-error (fn [e] (reset! !caught e))}
+                hiccup]))
+
+(deftest a-frameless-boundary-is-legal-until-something-below-writes-an-intent
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (lane/leave-act-environment!)
+      (testing "a boundary with no frame above it and no intent below it
+                renders. The class reads no subscription, so requiring a frame
+                it does not need would refuse a legal page — the binding is
+                unconditional and simply carries nil"
+        (let [handle (frameless-root!
+                       [boundary {:fallback [:p.fb "unused"]}
+                        [:p.body "quiet"]])]
+          (try
+            (is (some? (query handle ".body")))
+            (is (nil? @!caught) (str "nothing was raised. Escaped: " (pr-str (escaped))))
+            (finally (mount/release! handle)))))
+      (testing "and an intent under one is the loud error, NAMED — the
+                diagnostic points at the intent rather than at the boundary"
+        (let [handle (frameless-root!
+                       [boundary {:fallback [:p.fb "unused"]}
+                        [:button.dismiss {:on-click [:bdy/dismissed 1]} "x"]])]
+          (try
+            (is (some? (query handle ".escaped"))
+                "the boundary failed rather than rendering an inert handler")
+            (is (= :rf.error/hicasso-intent-outside-boundary
+                   (:rf.error/id (ex-data @!caught)))
+                (str "and it named the intent: " (pr-str (ex-data @!caught))))
+            (is (= [:bdy/dismissed 1] (:intent (ex-data @!caught))))
+            (finally (mount/release! handle))))))))
+
+;; ---------------------------------------------------------------------------
+;; 7 — the fence: the class still spends no hook, in its error state too
+;; ---------------------------------------------------------------------------
+
+(deftest the-boundary-spends-no-hook-in-its-error-state-either
+  (testing "`arm1/presence` had to buy a `useContext` to resolve its frame,
+           and paid for it in HD-025's stated cost. This class did not: it
+           already resolves its frame through `contextType`, which is a
+           property of the component rather than a hook call, so the repair
+           is invisible at React's dispatcher. Counted on the page where the
+           new binding actually runs — a boundary in its ERROR state,
+           rendering the fallback"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (if-not (probe/install!)
+        (is false (str "React's internals slot was not found, so this claim is "
+                       "UNWITNESSED on this build. A gate nobody has watched "
+                       "fire is not evidence — fix "
+                       (pr-str 're-frame.bench.hicasso.arm1.hook-probe)
+                       " rather than reading this as a pass."))
+        (do
+          (fresh! frame-id)
+          (let [handle (volatile! nil)
+                names  (probe/record!
+                         (fn [] (vreset! handle
+                                         (watched-root! frame-id
+                                                        [retry-screen {}]))))]
+            (try
+              (is (some? (query @handle ".retry"))
+                  "the fallback really did render, so the counts below were
+                   taken over the path this repair changed")
+              (is (= #{"useContext" "useSyncExternalStore"} (set names))
+                  (str "every dispatcher read on this page belongs to a "
+                       "`defview` SHELL — the two `rt/shell-hook-ledger` "
+                       "declares. Two `h/boundary` classes are in this tree "
+                       "(the watcher and the subject) and between them they "
+                       "contributed none. Raw: " (pr-str names)))
+              (is (= 2 (count rt/shell-hook-ledger) (count (distinct names)))
+                  "and the declared shell ledger is the measured roster")
+              (is (empty? (filter #{"useRef" "useMemo" "useCallback" "useState"
+                                    "useEffect"}
+                                  names))
+                  "no useRef, no memo, no state and no effect — the class is
+                   still a class")
+              (finally (mount/release! @handle)))))))))


### PR DESCRIPTION
`h/boundary`'s `:fallback` and its children are hiccup **data**, written in the
parent boundary's body — and both are walked by the codec inside the **class
component's own React render**, one render later, after that body's dynamic
extent has unwound. With no ambient frame re-bound there, `intent/*dispatch*`
was `nil` when the codec reached them, so an intent at an event position on the
fallback or on a native child raised
`:rf.error/hicasso-intent-outside-boundary` at render, and an `h/fn` there
raised the same id at invocation.

This is the sibling of rf2-2rtt6.66 (#7388), which repaired the identical
mechanism in `arm1/presence`.

## The fallback half is the sharp one

HD-020(c) ships `:fallback` **beside** `:reset-key`, and the reason it gives is
that *"the retry is the CALLER's to schedule"*. The control that schedules it is
a button, the button lives in the fallback, and its `:on-click` is an intent —
so the ruling's own worked example was the one thing the component could not
render. And a fallback that throws while rendering does not fail quietly in a
corner: it takes the **next** boundary up, so an application's error path became
an application-wide failure.

Reproduced before anything changed, on exactly that case — the witness file is
committed in `f1df696` and the repair in `f22e222`, so the first run below is
the defect under the final witnesses rather than a retrospective claim:

```
FAIL in (a-fallbacks-retry-button-dispatches-and-the-reset-key-retries)
the boundary lowered its fallback with no ambient frame, so the retry intent
raised while it rendered and the failure escaped to the boundary ABOVE — an
application's error path becoming an application-wide one.
Escaped: {:rf.error/id :rf.error/hicasso-intent-outside-boundary, :intent [:bdy/retry]}
```

## The repair, and how it differs from presence's

Same shape, one component along, and **cheaper — which is the bead's own note**.
`presence-body` had to buy a `useContext` to find its frame and paid for it in
HD-025's stated cost (two hooks → three). This class already resolves its frame
through `contextType` — `frame-of`, the accessor `report!` has always used for
`:on-error` — so there is **no new hook and no new accessor**. The render binds
`intent/with-frame` around its one crossing with `runtime/frame-dispatch`'s
memoised frame-locked dispatch (the same closure `run-once` binds, so a child
here lowers *identically* to one written in the parent's body, and nothing is
allocated per render).

**One binding covers both branches**, including the `(fallback error)` call
itself, so hiccup a fallback *function* mints is lowered under the same frame as
hiccup it was handed.

Following #7388, the binding is **unconditional and carries `nil`** when no
provider is above the boundary. The class reads nothing, so a frameless boundary
stays legal until something below it writes an intent — at which point the
existing loud error fires and still names the intent, which is better
attribution than a generic no-frame-context throw from the boundary.

## The witnesses

`arm1/boundary_intent_dom_cljs_test` — seven rows, modelled on
`arm1/presence_intent_dom_cljs_test`:

1. a **retry button on the fallback** dispatches, and the `:reset-key` it moves
   actually re-mounts the child — HD-020(c)'s whole story, end to end;
2. an **`h/fn` on a function fallback** dispatches what it returns, closing over
   the error the fallback was handed;
3. a **bare intent vector on a native child** of `h/boundary` dispatches, twice,
   so it is a live handler rather than a one-shot;
4. an **`h/fn` on a native child** does;
5. the intent lands in the frame the **boundary** was mounted under, proved
   against a second live frame rather than against an absence;
6. a frameless boundary is still legal until something below it writes an
   intent, and that intent is still the loud error, **named**;
7. the class still spends **no hook** — counted at React's own dispatcher on a
   page whose boundary is in its **error state**, i.e. on the path this repair
   changed.

**Both intent shapes are on separate subjects, deliberately.** They fail at
different *moments*: a bare vector is refused at LOWERING, during the boundary's
own render, so a subject carrying one never reaches the screen; an `h/fn` is
lowered happily with no frame (the dispatch is captured, not required), renders,
and raises at INVOCATION. Mixed onto one subject the first masks the second.

**The fallback rows drive a real throw.** `risky` throws from the render phase
while the model says so, so the boundary is genuinely in its error state and the
fallback genuinely rendered before anything is asserted about it — rows 1 and 7
assert the fallback is on screen and the child that threw is not.

Most rows mount under a watching `h/boundary` whose only job is to catch what
escaped the subject and print it, because React does not print the `ex-info` it
swallowed. Its own fallback and `:on-error` are intent-free: an instrument that
can fail the way the subject fails measures nothing.

## The hook fence

**No hook was added, and it is witnessed rather than asserted.** Row 7 records
every dispatcher read on a page carrying **two** `h/boundary` classes (the
watcher and the subject, the latter in its error state) and finds only
`#{"useContext" "useSyncExternalStore"}` — the two `rt/shell-hook-ledger`
declares for a `defview` SHELL — with no `useRef`/`useMemo`/`useCallback`/
`useState`/`useEffect` anywhere. The existing
`lifecycle_dom_cljs_test/the-boundary-spends-no-shell-hook` still pins the exact
sequence on a healthy page and is unchanged and green.

`boundary.cljs`'s docstring claimed "a class component calls no hooks, so this
costs the ≤2-hook shell budget exactly nothing". That claim is still true and
now says *why* it survived the repair (`contextType` is a property of the
component, not a dispatcher read) and names both witnesses that count it.

## Composition with the held memo wrapper (#7375)

`worker/cascade-2rtt6-52` is untouched. Its `codec/memoize-boundary!` is
**opt-in at the mint site** and its own docstring names this component as an
exclusion — *"heads that are not reactive boundaries — `h/boundary`'s
error-boundary class, presence — keep the semantics they were written with"* —
so `h/boundary` gets no memo wrapper and the two changes do not meet. Were one
ever attached, the composition would still be sound in one direction only, which
is the safe one: the binding lives **inside** the class's own render, below any
memo, so a bail-out skips the render entirely (nothing to lower) and a
non-bail-out lowers inside the frame.

## Quality gates

Run from `implementation/` on a fresh worktree (real `npm ci`, exit 0). Every
exit code below is the script's own.

**The mutation.** The binding's absence *is* the pre-repair tree, so the
reproduction run and the mutation run are the same run: the witness file was
committed first (`f1df696`) and is byte-identical in both, and the only
difference between them is `intent/with-frame` in `boundary.cljs`.

| | `npm run test:browser` | result |
|---|---|---|
| binding **absent** (mutation / reproduction) | `EXIT=1` | 1002 tests, 6223 assertions, **7 failures, 3 errors** — all ten in `boundary-intent-dom-cljs-test` and nowhere else, naming `:rf.error/hicasso-intent-outside-boundary` with `:intent [:bdy/retry]` (the fallback) and `:intent [:bdy/dismissed 1]` (the child) |
| binding **present** (restored) | `EXIT=0` | 1002 tests, 6229 assertions, **0 failures, 0 errors** |

Row 6 (the frameless case) is green on both sides, correctly: it asserts the
loud error still fires and still names the intent, which is an invariant the
repair preserves rather than a behaviour it introduces.

| Gate | Exit |
|---|---|
| `npm run test:browser` (repaired) | `0` |
| `npm run test:cljs` | `0` — 12387 tests, 61829 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` | `1` — **every step green except `JVM implementation/core`, which hangs on this box rather than failing**; see below |
| `clj-kondo` v2026.04.15, CI's own invocation, `--fail-level error` | `0` — **errors: 0**, warnings 4532 (unchanged baseline); no finding names either changed file |

**The one local red, named rather than waved past.** `scripts/test-fast-pr.sh`
exited `1` on `JVM implementation/core`. It is not this diff, and the evidence is
three-fold. It produced **no test output at all** — not one `FAIL in`, not a `Ran N
tests` line — only the launcher's `:paths external to the project` warnings, which
is a suite that never started rather than one that failed. Re-run standalone with a
warm `.cpcache` it **hung**: 37 minutes wall clock for 50 CPU-seconds in the last
14 of them, flat, until it was killed. And `implementation/core`'s `:test`
classpath (`test` plus the examples buckets and the sibling artefacts) contains
**none** of the three paths this diff touches — two `.cljs` files under
`implementation/freehand/test/` and one design document — so there is no route by
which it could reach them. It runs at all only because the changed-surface
classifier arms the whole JVM tier on any `implementation/**` path.

CI settles it on this branch: **`JVM core (clojure -M:test)` passes in 3m45s**,
alongside `CLJS (shadow-cljs :browser-test, headless Chromium)` and
`CLJS (shadow-cljs :node-test)`. The local box was running three other workers'
JVMs concurrently while this ran. Every other spine step passed, including
`mkdocs --strict` and the **docs corpus anchor validator** — `check_doc_slugs.py`,
the gate that owns `docs/design/**` link targets and heading anchors.

**The TESTING.md matrix.** `test:browser` is the *Browser unit* lane — DOM-dependent
tests only (`*_dom_cljs_test.cljs`), real React mounts and the context tier — and it
is the lane that owns this surface, because a React error boundary catches nothing
without a real React reconciler. The new namespace ends in `-dom-cljs-test`, so
`:browser-test`'s `-dom-cljs-test$` regexp picks it up with no config change, and its
DOM claims degrade to stated skips on `:node-test` (`test:cljs`), which it also rides
via the `cljs-test$` regexp. `scripts/test-fast-pr.sh` covers the node tier plus the
repo-wide static/drift checks including `check_doc_slugs.py`, which is what validates
`docs/design/**` link targets and heading anchors — `mkdocs build --strict` does not
cover that tree (`exclude_docs`). Per CLAUDE.md the doc edit's anchors and tables were
checked by hand: it is **prose only** — it adds no heading, no table row and no link,
so no anchor or column count moved.

Not in any tier here and left to CI: the production-elision, bundle-isolation,
perf-bundle and adapter lanes. Nothing in this diff reaches them — the change is
confined to the Hicasso bench arm under `implementation/freehand/test/`, which
ships in no bundle.

**Box coordination.** `worker/linkterm-cno31` owns the box's measurement windows
(rf2-cno31, route-link's render cost; its bead's step 3 calls for a re-take on
*"the clock of record, quiet box, same-run donors"*). Its bead and its branch were
checked before this work started and again after the gates: it is at step 1,
profiling — its one commit decomposes the route-link render term into stages — and
no measurement was in flight on either check (no `bench/hicasso/run.cjs`, no
`hicasso-bench` build and no bench-owned Chromium in the process table). The two
`test:browser` runs here cost ~90 s and ~113 s of compile plus ~46 s of Chromium
each; neither overlapped a clock window.

Closes rf2-uo9di.
