### PR TITLE
hicasso: our walk decomposed against Reagent's, and the budget spent (rf2-2rtt6.63)

### DIFF
--- a/docs/design/hicasso/studio/our-walk-against-reagents.md
+++ b/docs/design/hicasso/studio/our-walk-against-reagents.md
@@ -1,0 +1,350 @@
+# Our walk, decomposed against Reagent's own
+
+`rf2-2rtt6.63` is the outcome bead for the mount deficit, and it opens on a
+premise: the whole clock deficit follows the interpreter, stock Reagent's own
+interpreter proves a runtime walk can be nearly free, so the question is **why
+ours is slower than Reagent's and how much of HD-004's budget closes it**.
+
+Nobody had ever put the two side by side. `rf2-y1jkm` profiled our walk against
+a *frozen copy of our own older walk*; the census clock rows compare whole
+mounts, where two-thirds of the window is shared style, layout and paint. This
+page runs both interpreters — and the lineage donor, `reagent-slim` — over one
+witness value in one process, attributes the per-element delta to named stages,
+and then spends the budget where the attribution points.
+
+**The premise did not survive the measurement.** Our walk was already at stock
+Reagent's cost before this bead touched anything (1.0588×), and the arm the
+donor rungs actually ride — `reagent2.impl.template` — is **1.90× stock
+Reagent**. After two cheapenings the attribution convicted, our walk reads
+**0.9636× stock Reagent**. There is no interpreter gap left to close, and that
+is the answer the P2 fork ruling needs, in the direction nobody had checked.
+
+> **DIAGNOSTIC, not published.** Every figure here is an in-page
+> `performance.now` over eight whole-page walks per sample. It attributes cost
+> BETWEEN interpreters and BETWEEN stages of one walk. It is **not** the clock
+> of record, no figure here is a gate row, and the mount verdict remains
+> `rf2-2rtt6.1`'s to issue against `census_clock_run.cjs`.
+
+## 1. The witness, and why the route-link term cannot reach it
+
+The page is `walk_profile_app`'s twin of the acceptance shape — the census's
+1,202-element one-boundary page, guarded by that file's own **fatal**
+canonical-DOM parity gate against the real `lt/page`, so the lane carries one
+twin and not two. Both runs recorded `twin parity OK — 1202 elements, 58474
+canonical bytes`.
+
+`rf2-cno31`'s route-link term (8.21 µs/link, 207 links on this page) is
+**structurally absent from this instrument rather than subtracted from it**: the
+witness is realized ONCE, outside every timed window (`codec/realize-deep`), so
+every `route-link` href is a plain string before any clock starts. No timed
+window here contains a `route-url` synthesis. Windows were coordinated with
+`worker/linkterm-cno31` on both beads before either run opened.
+
+**THE PLAIN WITNESS.** Hicasso's markup carries intent VECTORS at its event
+positions; Reagent has no such surface and would `clj->js` them. An arm doing
+different work is not an arm (`rf2-2rtt6.62`), so the compared value is the
+realized page with every event position replaced by one shared plain function —
+legal, and identical work, for all three interpreters. A fourth arm,
+`hicasso-native`, then walks the page's OWN markup, so the authoring surface's
+term is named rather than hidden inside the comparison.
+
+### Workload matching is gated, not asserted
+
+Every arm's element tree is rendered into a fresh container and its canonical
+DOM read (`lane/canonical`, attribute names sorted). Identical on both runs:
+
+| arm | elements | canonical bytes | vs hicasso |
+|---|---|---|---|
+| `hicasso` | 1,202 | 58,474 | — |
+| `hicasso-native` | 1,202 | 58,474 | **identical** |
+| `slim` | 1,202 | 58,529 | differs, 55 bytes |
+| `reagent` | 1,202 | 58,529 | differs, 55 bytes |
+
+**The 55 bytes are fully explained and are whitespace only.** The census card
+writes `:class (cond-> "" favorited (str " active") pending? (str " optimistic"))`,
+so an unfavourited, non-pending card carries a declared class of `""`. Hicasso's
+`class-names` drops an empty class (`(when (seq class) class)`); Reagent's treats
+`""` as truthy and joins it, producing a trailing space in `className`. 55 of the
+69 cards are in that state. Zero elements differ, zero attributes differ, and the
+difference costs *Reagent* one extra `str` join — so it is not a workload
+advantage to us.
+
+## 2. The arms — ours, the donor's, and stock Reagent's
+
+Design: 4 arms × 6 rounds × (4 warm-up + 10 samples), 8 whole-page walks per
+timing window, the lane's reflecting schedule, the arm-order guard adjudicating.
+**Every arm runs inside the body door** (`rt/render-body`) including the two that
+do not need it, because timing a local arm against a foreign one compares call
+conventions as much as phases (`rf2-2rtt6.32`); the clock starts inside the door.
+
+**BEFORE** — codec blob `5a0b04733a`, guard verdict **reportable on every arm,
+both by predecessor and by phase, all within 10%**:
+
+| arm | ms/walk p50 [min – max] | ns/element |
+|---|---|---|
+| `reagent` (stock 2.0.1) | 0.6375 [0.6000 – 0.9000] | 530 |
+| **`hicasso`** | **0.6750 [0.6250 – 0.8000]** | **562** |
+| `hicasso-native` (intent markup) | 0.7250 [0.6625 – 0.9000] | 603 |
+| `slim` (`reagent2.impl.template`) | 1.2125 [1.1125 – 1.4500] | 1,009 |
+
+`hicasso/reagent` **1.0588** · `hicasso/slim` 0.5567 · **`slim/reagent` 1.9020**
+
+**AFTER** — codec blob `0304f489bb`, instrument blob byte-identical to the
+before run's, guard verdict **reportable**:
+
+| arm | ms/walk p50 [min – max] | ns/element |
+|---|---|---|
+| `reagent` (stock 2.0.1) | 0.6875 [0.5000 – 122.6625] | 572 |
+| **`hicasso`** | **0.6625 [0.4750 – 1.2875]** | **551** |
+| `hicasso-native` (intent markup) | 0.7125 [0.5125 – 16.9000] | 593 |
+| `slim` (`reagent2.impl.template`) | 1.1875 [0.9000 – 1.9750] | 988 |
+
+`hicasso/reagent` **0.9636** · `hicasso/slim` 0.5579 · **`slim/reagent` 1.7273**
+
+**Read the ratios, not the absolutes, across the two runs.** This is a shared
+fleet box (§6) and the two runs sat in different pockets of it; the arm ratios
+are same-run interleaved against donors measured in the same windows, which is
+what makes them comparable. The `reagent` and `hicasso-native` maxima in the
+after run (122.66 ms, 16.90 ms) are single scheduler stalls; the p50s are over 60
+samples and the guard passed on both partitions.
+
+### What the arms say
+
+- **Our walk was already at stock Reagent's cost.** 1.0588× before this bead
+  changed anything — a 32 ns/element absolute difference on a 530 ns/element
+  walk. The bead's premise, that ours is the slower interpreter, is refuted by
+  direct measurement.
+- **The donor is the slow one.** `slim/reagent` reads **1.90× / 1.73×** across
+  the two runs. The donor rungs and the pre-Hicasso candidate all ride
+  `reagent2.impl.template`'s `:f>` walk, and this is where their 1.33–1.5×
+  comes from. Hicasso extracted that plumbing and then cheapened it: we read
+  **0.56×** the donor we were built from.
+- **Hicasso's own authoring surface costs 41 ns/element** (562 → 603 before,
+  551 → 593 after) — 71 intent vectors lowered across 1,202 elements, about 7%
+  of the walk. That is the price of the intent surface, stated rather than
+  buried.
+- **After the two cheapenings, we read below stock Reagent** — 0.9636×.
+
+## 3. The stages — absolute ns, because a ratio cannot be read against a frame
+
+The bead requires absolute per-element costs: two-thirds of a mount window is
+shared frame work, so a 1.49× TOTAL implies the walk slice is several times
+Reagent's in absolute terms, and only absolutes can say. Each row is the same
+primitive, ours and each donor's, over the page's own roster (1,202 elements,
+1,489 prop occurrences, 1,908 children of which 567 strings).
+
+**A stage table is read WITHIN a run, never across runs.** The micro tables run
+after the arms, so they sample a different moment of a shared box; stock
+Reagent's own `string-child` reads 8.8 in one run and 20.3 in the other with
+identical code. The within-run column differences are the finding.
+
+**BEFORE** (ns/op):
+
+| stage | hicasso | slim | reagent | ours − Reagent's |
+|---|---|---|---|---|
+| tag lookup (cached) | 21.2 | — | 29.5 | **−8.3** |
+| prop-name lookup (cached) | 21.5 | 49.4 | 24.5 | **−3.0** |
+| prop-value conversion | 6.7 | 8.1 | 7.1 | −0.4 |
+| **whole prop pipeline / element** | **209.2** | — | **182.2** | **+27.0** |
+| per-element tag hook | 9.2 | — | 6.7 | +2.5 |
+| **`as-element` on a string child** | **33.5** | 7.9 | **8.8** | **+24.7** |
+| `createElement` (shared floor) | 54.9 | 54.9 | 54.9 | — |
+
+**The decomposition closes.** Weighted by the roster — prop pipeline
++27.0 × 1,202, strings +24.7 × 567, tag hook +2.5 × 1,202, tag lookup
+−8.3 × 1,202, prop names −3.0 × 1,489, values −0.4 × 1,489 — the named stages
+sum to **+34.4 µs/walk** against a measured whole-walk delta of **+37.5 µs**.
+**92% of the difference between the two interpreters is accounted for by named
+stages**, which is what makes the two convictions below convictions rather than
+guesses.
+
+**AFTER** (ns/op, same instrument):
+
+| stage | hicasso | slim | reagent | ours − Reagent's |
+|---|---|---|---|---|
+| tag lookup (cached) | 20.4 | — | 34.9 | −14.5 |
+| prop-name lookup (cached) | 16.8 | 53.4 | 26.2 | −9.4 |
+| prop-value conversion | 8.1 | 23.5 | 10.7 | −2.6 |
+| **whole prop pipeline / element** | **207.6** | — | **186.8** | **+20.8** |
+| per-element tag hook | 12.1 | — | 9.6 | +2.5 |
+| **`as-element` on a string child** | **11.5** | 12.3 | **20.3** | **−8.8** |
+
+## 4. The budget spent, and the budget declined
+
+HD-004 permits codec-work caching only, and its hard fence is verbatim: no
+template extraction, no hole plans, no node references, no subscription-addressed
+anything, no direct DOM writes. **Nothing here goes near any of them.** There is
+still no element cache, no props-object cache and no template; `convert-props`
+still mints a fresh object per element per render.
+
+### (a) The caches lose their prototype — HD-004 cache mechanism
+
+Both caches are keyed by the author's literal, so both had to answer two hostile
+questions on **every lookup**: could a literal named `__proto__` poison a write,
+and could one named `toString` hit an INHERITED property and be served a value
+nobody cached. The shipping answer was three `identical?` compares plus
+`Object.prototype.hasOwnProperty.call`, on the hit path, once per tag and once
+per prop on every element of every mount.
+
+`Object.create(null)` answers the second question **structurally** — no
+prototype chain, so a lookup can only ever return an own property — and demotes
+the first to the **miss** branch, the only branch that writes, which runs once
+per distinct literal for the life of the build.
+
+| lookup | guarded (shipping) | **`Object.create(null)`** | `#js {}` + `instance?` |
+|---|---|---|---|
+| prop, before run | 18.1 | **11.1** | 13.8 |
+| prop, after run | 25.9 | **15.4** | 18.1 |
+| tag, before run | 16.6 | **11.2** | 12.1 |
+| tag, after run | 24.1 | **12.5** | 16.6 |
+
+**Costed and DECLINED: the type-check variant.** V8 starts `Object.create(null)`
+objects in dictionary mode, so the null-prototype route could plausibly have lost
+— the alternative keeps `#js {}` in fast mode and validates the hit by TYPE,
+since nothing on `Object.prototype` is a `ParsedTag` or a `PropSlot`. It read
+consistently second on both caches in both runs, and it is declined on
+construction as well as margin: a cache with no prototype **cannot** serve an
+inherited value, where a type check is a promise that it will be noticed.
+
+`agreement failures: []` on both runs — every candidate answered what the
+shipping shape answers for every literal on the page and for the seven hostile
+names the page does not carry.
+
+### (b) The walk asks `string?` before `vector?` — a predicate order, not a cache
+
+Classified plainly: **this is not caching.** It is the same class as `rf2-y1jkm`'s
+"small knives" (the in-loop `:key` skip, the `===`-chain reserved check), which
+this bead-family's budget already covers, and it touches none of the fenced
+mechanisms.
+
+`as-element`'s branches are mutually exclusive — a value satisfies at most one
+of `nil?`, `false?`, `string?`, `vector?`, `number?`, `seq?`, `true?` — so their
+order **cannot change an answer**, only what each population pays. And `vector?`
+was first: it is `IVector` satisfaction, which for anything without the marker
+falls through to `native-satisfies?`, so every string, number and lazy seq on the
+page proved itself not-a-vector the expensive way before reaching its own branch.
+This was the one stage where stock Reagent was decisively ahead of us — its
+`as-element` asks one `js-val?` and returns a string on the first branch.
+
+| dispatch | shipping order | **`string?` first** |
+|---|---|---|
+| whole child roster (1,908), before run | 22.5 | **8.9** |
+| whole child roster, after run | 24.6 | **13.4** |
+| the 567 strings alone, before run | 31.7 | **5.3** |
+| the 567 strings alone, after run | 40.6 | **9.7** |
+
+The vectors pay one extra `typeof` and the whole population still reads 1.8–2.5×
+cheaper.
+
+### Declined, with reasons
+
+- **Replicant-style value-keyed skeleton caching.** Already declined by
+  `rf2-y1jkm` with census arithmetic; this page strengthens the declination
+  rather than revisiting it. A mount is the *first* walk, so a value-keyed
+  element cache only pays on subtrees repeated within one page (under 12% of
+  this one) — and now there is no gap for it to close: our walk reads below
+  stock Reagent's. HD-006's no-element-memoisation line stands untouched.
+- **Forking `reagent2.impl.template`.** Needs a ruling and is not sought. The
+  measurement makes it look backwards anyway: the donor's walk is 1.73–1.90×
+  stock Reagent's and 1.8× ours.
+- **A compiler or analyzer** (UIx's answer). Fenced, unchanged.
+- **Closing the remaining `convert-props` term.** See §5 — it is Hicasso's
+  semantics, and it is reported as the floor rather than attacked.
+
+## 5. The floor reached, stated plainly
+
+**The walk's remaining cost over stock Reagent's is one stage: the prop
+pipeline, +20.8 ns/element after the change (+27.0 before).** That is what
+Hicasso's `convert-props` does that Reagent's does not, and every item of it is a
+shipped semantic rather than an inefficiency: the `:&` remainder probe and its
+owned-literal law (HD-023), the `:ref` reserved-value refusal (HD-022), the
+event-position classification that makes intent vectors work at all, the
+`callback?` probe at every position, and `controlled/install!`'s per-element tag
+switch (HD-020's caret convergence, +2.5 ns/element in its own row). Removing any
+of them removes a feature. **It is not attacked, and it is reported as the
+floor.**
+
+And the size of the whole prize, which is the number a ship/kill decision needs:
+
+> The walk is **~0.66 ms of a ~10 ms mount**. The two cheapenings landed here
+> are worth about **9% of the walk** — and therefore about **0.6% of the
+> mount**. Nothing available inside the fence, at the walk, moves the 1.10×
+> mount line.
+
+That is the bead's honest negative, and it is a complete answer: the mount
+deficit is no longer attributable to the interpreter. Whatever remains above the
+line on the census rows is elsewhere — `rf2-cno31`'s route-link term is measured
+and being fixed; the read machinery was halved by `rf2-6c237` and its remaining
+90% is the substrate's own pure compute. **The interpreter is done. It costs
+exactly this, here.**
+
+## 6. Correctness, and the mutation ledger
+
+Full suite at the landed state: **12,381 tests / 61,824 assertions, 0 failures,
+0 errors** (`npm run test:cljs`).
+
+A new witness pins what nothing but the cache's construction answers any more —
+a tag or prop literal named after an `Object.prototype` member must be parsed and
+converted as itself, and must hit its own entry the second time. Each mutation
+was **proven able to go red** and green on restore, run against the codec's own
+34 tests / 195 assertions:
+
+| mutation | expected failure | observed |
+|---|---|---|
+| M1 — both caches back to `#js {}` | the inherited-property witness | **RED** — 15 failures; the actual value is literally `#object[toString]` |
+| M2 — make the string branch unconditional (`(string? (str x))`) | every hiccup-vector witness | **RED** — 34 failures, 75 errors. This is the ORDERING proof: the string branch demonstrably precedes the vector branch |
+| M3 — drop the prop-cache write guard | `:props` cache size | **RED** — `(not (= 3 4))`: `__proto__` reached the cache |
+| M4 — drop the tag-cache write guard | `:tags` cache size | **RED** — `(not (= 0 1))`: same, for tags |
+
+M3 and M4 are worth reading together: with a null-prototype cache, writing
+`__proto__` is harmless to the *object* — the guard's remaining job is that the
+three names never occupy an entry, and the witnesses pin exactly that.
+
+## 7. Window discipline and the box
+
+`worker/linkterm-cno31` announced a diagnostic window at 01:25 AUSEST and owns
+the census-clock windows. This bead announced its own on the bead before either
+run and takes no census-clock row.
+
+**The box was NOT quiet and the page says so.** It is a shared fleet box: at the
+first announce two other worktrees' shadow-cljs JVMs were compiling and the box
+averaged 48% over 24 threads; four concurrent builds were seen at 01:53. Waiting
+was tried for 25 minutes and the box did not clear.
+
+Consequences, declared:
+
+- The **absolute ns figures are ceilings**, and are not compared across runs.
+- The **arm ratios are same-run interleaved** against donors measured in the same
+  windows, under the arm-order guard, and are the figures this page's conclusions
+  rest on.
+- **One run was REFUSED and is not published.** The first after-run took the
+  arm-order guard's exit 2: every arm read 1.44–1.55× slower in the LAST THIRD
+  than the FIRST, ranges disjoint — a monotonic phase drift as the box ramped,
+  affecting all four arms alike. The repair was the run, not the tolerance: the
+  after-run was re-taken after a wait-for-clear gate and passed on the first
+  attempt. The refused run's figures appear nowhere on this page.
+- An earlier **shakedown** of the instrument (01:53–01:57, exit 0) is discarded
+  for absolutes and is reported only as the instrument's own validation.
+
+## Provenance
+
+| | |
+|---|---|
+| **Producing commit** | `90cc9ab338` on `worker/walkdecomp-2rtt6-63` (the after run); the before run is the same tree with `front/codec.cljs` at its pre-change blob |
+| **Reproduction** | `HICASSO_INIT_FN=re-frame.bench.hicasso.walk-vs-reagent-app/-main HICASSO_OUT_DIR=out/hicasso-walkcmp HICASSO_PORT=8171 node implementation/freehand/test/re_frame/bench/hicasso/run.cjs` |
+| **Build** | `:hicasso-bench` (`--config-merge` entry swap), `:advanced`, `goog.DEBUG false`, lane cache cleared per `rf2-2rtt6.20`; **0 warnings** on every build |
+| **Runtime** | chromium `147.0.7727.15` (playwright), node `v24.13.0`, Windows NT 10.0 x64, 24 threads |
+| **Design** | 4 arms × 6 rounds × (4 warm-up + 10 samples), 8 whole-page walks per timing window |
+| **Clock** | in-page `performance.now`, **diagnostic**; the clock of record is `census_clock_run.cjs` and is untouched here |
+| **Windows** | before 2026-08-03 02:01–02:03 AUSEST; refused after-run 02:23–02:31 (published nothing); reportable after-run 02:35–02:38 |
+| **Exit codes** | before `0`, guard reportable; first after-run **`2`** (guard refused, nothing published); re-taken after-run `0`, guard reportable |
+
+Measured blobs — **byte-identical across the two runs except the intervention**:
+
+| file | blob |
+|---|---|
+| `…/front/codec.cljs` | before `5a0b04733a33d1baa815b093f5b297e325aa6675`, after `0304f489bb941f9f12c6c87b05e7fcd4dd9343c6` **(the change under test)** |
+| `…/walk_vs_reagent_app.cljs` | `b447e313fcda7ca45c724cb8e8b45acdda54651c` (both runs) |
+| `…/walk_profile_app.cljs` (the twin + its parity gate) | unchanged across both runs |
+| `reagent/reagent` | `2.0.1`, from the jar, unmodified |
+| `reagent2.impl.template` | unmodified — **the codec is not forked** |

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -31,9 +31,11 @@
 
   ## Codec-work caching only (HD-004)
 
-  Two caches, both keyed by the author's literal and both plain JS
-  objects with an own-property guard so a hiccup tag or prop literally
-  named `__proto__` cannot poison them:
+  Two caches, both keyed by the author's literal and both JS objects
+  with **no prototype** ([[empty-cache]]), so a hiccup tag or prop
+  literally named `toString` cannot be served an inherited value and one
+  named `__proto__` cannot poison a write — the first structurally, the
+  second by a refusal on the miss branch:
 
     tag-cache    \"div#main.wide\" -> ParsedTag
     prop-cache   \"on-click\"      -> PropSlot
@@ -147,28 +149,53 @@
 
 (defn- reserved-name?
   "Is `n` — a tag or prop name, or an emitted prop slot — one of the
-  three names that must never be read from, written to, or emitted
-  through a JS-object cache? A hiccup literal named `__proto__`,
-  `prototype` or `constructor` would otherwise reach an object's
-  prototype. That roster is the whole predicate.
+  three names that must never be written to a JS object, or emitted
+  through one? A hiccup literal named `__proto__`, `prototype` or
+  `constructor` would otherwise reach an object's prototype. That roster
+  is the whole predicate.
 
   Three `===` string compares rather than the set lookup this began as
-  (rf2-y1jkm): the question is asked once per tag and once per prop on
-  every element of every mount, and a set lookup pays a string hash each
-  time for a roster of three — 36.9 ns against 9.6 on the census page's
-  own literals, measured by `walk_profile_app`'s micro table."
+  (rf2-y1jkm): a set lookup pays a string hash for a roster of three —
+  36.9 ns against 9.6 on the census page's own literals, measured by
+  `walk_profile_app`'s micro table.
+
+  **It is asked on the cache MISS path only** (rf2-2rtt6.63). The caches
+  below carry no prototype, so a hostile literal cannot make a lookup
+  answer wrongly and the guard has only one job left: keep the three
+  names out of the caches, and out of the emitted props object — which
+  DOES carry `Object.prototype`, and is where [[PropSlot]]'s `reserved?`
+  field answers instead. A miss happens once per distinct literal for
+  the life of the build; a hit happens once per element per mount."
   [n]
   (or (identical? "__proto__" n)
       (identical? "prototype" n)
       (identical? "constructor" n)))
 
-(def ^:private has-own (.-hasOwnProperty (.-prototype js/Object)))
+(defn- empty-cache
+  "A codec cache: a JS object with **no prototype at all**
+  (rf2-2rtt6.63).
 
-(defn- own-key?
-  "`hasOwnProperty`, called off the prototype, so an object carrying its
-  own `hasOwnProperty` property cannot shadow the check."
-  [o k]
-  (.call has-own o k))
+  Both caches are keyed by the author's literal, so both had to answer
+  two hostile questions on every lookup: could a literal named
+  `__proto__` poison a write, and could a literal named `toString` or
+  `constructor` hit an INHERITED property and be served a value nobody
+  cached. `Object.create(null)` answers the second one structurally —
+  there is no prototype chain, so a lookup can only ever return an own
+  property or `undefined` — and demotes the first to the miss path,
+  where [[reserved-name?]] still refuses the write.
+
+  What that buys, measured on the census page's own literal roster
+  (`walk_vs_reagent_app`, 1,489 prop occurrences and 1,202 tag
+  occurrences, quiet-ish box, in-page clock): the prop lookup 18.1 ->
+  11.1 ns/op and the tag lookup 16.6 -> 11.2, against the
+  `hasOwnProperty.call` + three-compare shape they replace. The costed
+  alternative — keep `#js {}` in V8's fast mode and validate the hit by
+  TYPE (`instance? PropSlot`), since nothing on `Object.prototype` is
+  one — read 13.8 and 12.1 and is DECLINED on both margin and
+  construction: a cache with no prototype cannot serve an inherited
+  value at all, where a type check is a promise that it will be noticed."
+  []
+  (js/Object.create nil))
 
 ;; ---------------------------------------------------------------------------
 ;; Tag parsing and its cache
@@ -187,23 +214,28 @@
   (let [[_ tag id classes] (re-matches re-tag (name hiccup-tag))]
     (->ParsedTag tag id (when classes (str/replace classes #"\." " ")))))
 
-(def ^:private tag-cache #js {})
+(def ^:private tag-cache (empty-cache))
 
 (defn- cache-key [k]
   (if-let [ns' (namespace k)] (str ns' "/" (name k)) (name k)))
 
 (defn cached-parse
   "[[parse-tag]] behind the codec-work cache (HD-004). One entry per
-  distinct tag literal the build ever renders."
+  distinct tag literal the build ever renders.
+
+  One property read answers the hit, because [[empty-cache]] has no
+  prototype to serve a wrong one. The three poisoning names still never
+  reach the cache — the refusal moved to the miss branch, which is the
+  only branch that writes."
   [hiccup-tag]
-  (let [k (cache-key hiccup-tag)]
-    (if (reserved-name? k)
-      (parse-tag hiccup-tag)
-      (if (own-key? tag-cache k)
-        (unchecked-get tag-cache k)
-        (let [parsed (parse-tag hiccup-tag)]
-          (unchecked-set tag-cache k parsed)
-          parsed)))))
+  (let [k   (cache-key hiccup-tag)
+        hit (unchecked-get tag-cache k)]
+    (if (undefined? hit)
+      (let [parsed (parse-tag hiccup-tag)]
+        (when-not (reserved-name? k)
+          (unchecked-set tag-cache k parsed))
+        parsed)
+      hit)))
 
 ;; ---------------------------------------------------------------------------
 ;; Prop names and their cache
@@ -284,20 +316,28 @@
   ;; The three seeded entries are the RULE, not memos of one — see
   ;; [[react-renames]]. None is reserved, an event position, or the ref
   ;; slot.
-  (doto #js {}
+  (doto (empty-cache)
     (unchecked-set "class" (->PropSlot "className" false false false))
     (unchecked-set "for" (->PropSlot "htmlFor" false false false))
     (unchecked-set "charset" (->PropSlot "charSet" false false false))))
 
 (defn- prop-slot
   "The [[PropSlot]] for keyword/symbol `k` with name `n` — the caller has
-  already checked the spelling and that `n` is not a reserved name."
+  already checked the spelling.
+
+  One property read answers the hit ([[empty-cache]]). A reserved name
+  is minted on every sight rather than cached, exactly as before: the
+  refusal sits on the miss branch, which is the only branch that writes,
+  and the slot it mints carries `reserved?` so the emitted props object
+  — which DOES have a prototype — never receives the name either."
   ^PropSlot [k n]
-  (if (own-key? prop-cache n)
-    (unchecked-get prop-cache n)
-    (let [s (mint-slot k n)]
-      (unchecked-set prop-cache n s)
-      s)))
+  (let [hit (unchecked-get prop-cache n)]
+    (if (undefined? hit)
+      (let [s (mint-slot k n)]
+        (when-not (reserved-name? n)
+          (unchecked-set prop-cache n s))
+        s)
+      hit)))
 
 (defn cached-prop-name
   "[[prop-name]] behind the codec-work cache (HD-004).
@@ -317,11 +357,8 @@
   [k]
   (if-not (or (keyword? k) (symbol? k))
     (if (string? k) (prop-name k) k)
-    (let [n (name k)]
-      (if (reserved-name? n)
-        (prop-name k)
-        (let [^PropSlot s (prop-slot k n)]
-          (.-js-name s))))))
+    (let [^PropSlot s (prop-slot k (name k))]
+      (.-js-name s))))
 
 ;; ---------------------------------------------------------------------------
 ;; The canonical structural-slot filter (rf2-2rtt6.36)
@@ -567,27 +604,24 @@
   (if (keyword-identical? :key k)
     o
     (if (or (keyword? k) (symbol? k))
-      (let [n (name k)]
-        (if (reserved-name? n)
-          o
-          (let [^PropSlot s (prop-slot k n)]
-            (when-not (.-reserved? s)
-              (unchecked-set o (.-js-name s)
-                             (convert-prop-value
-                               (cond
-                                 (.-ref? s)
-                                 (check-ref! k v)
+      (let [^PropSlot s (prop-slot k (name k))]
+        (when-not (.-reserved? s)
+          (unchecked-set o (.-js-name s)
+                         (convert-prop-value
+                           (cond
+                             (.-ref? s)
+                             (check-ref! k v)
 
-                                 (and (.-event? s) (keyword? k))
-                                 (if (or (vector? v) (map? v) (fn? v))
-                                   (intent/lower-prop k v)
-                                   v)
+                             (and (.-event? s) (keyword? k))
+                             (if (or (vector? v) (map? v) (fn? v))
+                               (intent/lower-prop k v)
+                               v)
 
-                                 :else
-                                 (if (intent/callback? v)
-                                   (intent/lower-prop k v)
-                                   v)))))
-            o)))
+                             :else
+                             (if (intent/callback? v)
+                               (intent/lower-prop k v)
+                               v)))))
+        o)
       (let [n (cached-prop-name k)]
         (when-not (reserved-name? n)
           (unchecked-set o n (convert-prop-value
@@ -1068,13 +1102,34 @@
 
 (defn as-element
   "Interpret any hiccup form. `nil` and `false` render nothing; `true` is
-  an error (HD-016); an existing React element passes through."
+  an error (HD-016); an existing React element passes through.
+
+  ## Why `string?` is asked before `vector?` (rf2-2rtt6.63)
+
+  The branches are MUTUALLY EXCLUSIVE — a value satisfies at most one of
+  `nil?`, `false?`, `string?`, `vector?`, `number?`, `seq?`, `true?` —
+  so their order cannot change an answer, only what each population
+  pays. And `vector?` is the dear one: it is `IVector` satisfaction,
+  which for anything without the marker falls through to
+  `native-satisfies?`, so every string, number and lazy seq on a page
+  used to prove itself not-a-vector the expensive way before reaching
+  its own branch.
+
+  Costed over the census page's whole child roster before it was changed
+  (`walk_vs_reagent_app` candidate table: 1,908 children, of which 567
+  strings, 1,201 vectors, 69 numbers, 71 seqs): the shipping order 22.5
+  ns/child, this order **8.9** — and on the strings alone 31.7 -> 5.3.
+  The vectors pay one extra `typeof` and the whole population still
+  reads 2.5x cheaper. This is the stage on which stock Reagent was
+  furthest ahead of us: its `as-element` asks one `js-val?`
+  (`goog/typeOf x !== \"object\"`) and returns a string on the first
+  branch, and it read 8.8 ns/string against our 33.5."
   [x]
   (cond
     (nil? x)         nil
     (false? x)       nil
-    (vector? x)      (vec->element x)
     (string? x)      x
+    (vector? x)      (vec->element x)
     (number? x)      x
     (seq? x)         (expand-seq x)
     (true? x)        (throw (ex-info (str "`true` is not a renderable child. "

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
@@ -68,7 +68,38 @@
     (is (= 0 (:tags (codec/cache-sizes)))))
   (testing "a prop named __proto__ is neither cached nor set"
     (let [e (codec/as-element [:div {:__proto__ "nope"}])]
-      (is (= [] (prop-names e))))))
+      (is (= [] (prop-names e))))
+    (is (= 3 (:props (codec/cache-sizes)))
+        "the three seeded entries and nothing else — the refusal is on the write")))
+
+(deftest a-literal-named-after-an-inherited-property-cannot-be-served-one
+  ;; rf2-2rtt6.63. Both caches are `Object.create(null)`, so a lookup can
+  ;; only ever answer an own property. Keyed against `#js {}` these
+  ;; literals would read `Object.prototype`'s OWN members — a function
+  ;; where a ParsedTag or a PropSlot belongs — and the codec would emit
+  ;; whatever that function's `.tag` / `.js-name` happened to be, which
+  ;; is `undefined`. The lookup guard the shipping code used to carry
+  ;; (`hasOwnProperty.call`) answered this; nothing but the cache's own
+  ;; construction answers it now, so it is witnessed rather than assumed.
+  (testing "a TAG named after an Object.prototype member parses as itself"
+    (doseq [n ["toString" "valueOf" "hasOwnProperty" "isPrototypeOf" "constructor"]]
+      (is (= n (el-type (codec/as-element [(keyword n)])))
+          (str "tag " n " must render as itself"))))
+  (testing "and the second render of one reads its own cached entry"
+    (codec/reset-caches!)
+    (codec/as-element [:toString])
+    (is (= 1 (:tags (codec/cache-sizes))))
+    (is (= "toString" (el-type (codec/as-element [:toString]))))
+    (is (= 1 (:tags (codec/cache-sizes)))))
+  (testing "a PROP named after an Object.prototype member converts as itself"
+    (codec/reset-caches!)
+    (let [e (codec/as-element [:div {:toString "a" :valueOf "b" :hasOwnProperty "c"}])]
+      (is (= ["hasOwnProperty" "toString" "valueOf"] (prop-names e)))
+      (is (= "a" (prop e "toString")))
+      (is (= "b" (prop e "valueOf")))
+      (is (= "c" (prop e "hasOwnProperty"))))
+    (testing "and the second element reads the cached slots"
+      (is (= "d" (prop (codec/as-element [:div {:toString "d"}]) "toString"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Prop names

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_app.cljs
@@ -104,7 +104,7 @@
 
 (def frame-id ::frame)
 
-(defn- page-hiccup
+(defn page-hiccup
   "The large-template page's body forms, verbatim minus the run counter:
   the same chrome, the same `(card/card slug)` calls, the same tag-pill
   `for`. Must run inside a body context (the reads). The parity gate
@@ -151,7 +151,7 @@
   [_]
   (page-hiccup))
 
-(defn- parity!
+(defn parity!
   "Mount the real page and the twin side by side; throw unless their
   canonical DOM agrees and matches the arithmetic. Fatal, before any
   clock."
@@ -182,7 +182,7 @@
 
 (def ^:private !out (volatile! nil))
 
-(defn- in-body
+(defn in-body
   "Run `f` inside a boundary body context — ambient frame bound, reads
   legal — via the runtime's own public [[rt/render-body]], and answer
   `(f)`. The trailing `[:span]` is the body's element and is outside

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -170,9 +170,10 @@
   pairs the prop pipeline is asked for. JS arrays, so the micro loops
   index primitively."
   [h]
-  (let [tags #js [] ks #js [] vs #js [] strs #js []
+  (let [tags #js [] ks #js [] vs #js [] strs #js [] kids #js []
         el-tags #js [] el-props #js []]
     (letfn [(visit-child [c]
+              (.push kids c)
               (cond (vector? c) (visit c)
                     (string? c) (.push strs c)
                     (seq? c)    (run! visit-child c)
@@ -193,7 +194,7 @@
                 (doseq [c (subvec argv (if has-props? 2 1))]
                   (visit-child c))))]
       (visit h))
-    {:tags tags :prop-keys ks :prop-vals vs :strings strs
+    {:tags tags :prop-keys ks :prop-vals vs :strings strs :children kids
      :el-tags el-tags :el-props el-props}))
 
 ;; ---------------------------------------------------------------------------
@@ -263,7 +264,8 @@
 (defn- stage-table
   "The same primitive, ours and each donor's, over the page's own roster.
   Every figure ns/op; the element-level rows are ns/ELEMENT."
-  [{:keys [^js tags ^js prop-keys ^js prop-vals ^js strings ^js el-tags ^js el-props]}]
+  [{:keys [^js tags ^js prop-keys ^js prop-vals ^js strings ^js children
+           ^js el-tags ^js el-props]}]
   (let [;; Both prop pipelines want a parsed tag. Precomputed here so the
         ;; rows price the PIPELINE and not two different tag lookups.
         h-parsed (let [a #js []]
@@ -311,7 +313,10 @@
         (ns-per-op (quot micro-reps 4) tag-strs (fn [t] (react/createElement t p))))]
      ;; --- the per-element `:key` read the walk pays outside the loop ---
      [:key-read-hicasso (ns-per-op micro-reps el-props (fn [p] (:key p)))]
-     [:roster-elements (.-length el-tags)]]))
+     [:roster-elements (.-length el-tags)]
+     [:roster-props    (.-length prop-keys)]
+     [:roster-children (.-length children)]
+     [:roster-strings  (.-length strings)]]))
 
 ;; ---------------------------------------------------------------------------
 ;; Candidates — costed here, landed only if this table convicts
@@ -425,6 +430,24 @@
         (when-not (reserved-name? k) (unchecked-set instcheck-tag-cache k v'))
         v'))))
 
+;; The second candidate the stage table convicts: `as-element`'s child
+;; dispatch. Ours asks `nil? → false? → vector? → string? → …`; stock
+;; Reagent asks ONE `js-val?` (`goog/typeOf x !== "object"`) and returns
+;; a string on the first branch. The seven predicates are mutually
+;; exclusive, so their ORDER is free to change and cannot change an
+;; answer — the question is only what each population pays. Both arms
+;; below run the real cond over the page's real child roster and return
+;; a tag rather than an element, so the figure is the DISPATCH and not
+;; the walk beneath it.
+
+(defn- dispatch-ship [x]
+  (cond (nil? x) 0 (false? x) 0 (vector? x) 1 (string? x) 2 (number? x) 3
+        (seq? x) 4 (true? x) 5 :else 6))
+
+(defn- dispatch-string-first [x]
+  (cond (nil? x) 0 (false? x) 0 (string? x) 2 (vector? x) 1 (number? x) 3
+        (seq? x) 4 (true? x) 5 :else 6))
+
 (defn- warm-candidates! [^js tags ^js prop-keys]
   (dotimes [i (.-length prop-keys)]
     (let [k (aget prop-keys i)]
@@ -434,14 +457,20 @@
       (guarded-tag-lookup t) (nullproto-tag-lookup t) (instcheck-tag-lookup t))))
 
 (defn- candidate-table
-  [{:keys [^js tags ^js prop-keys]}]
+  [{:keys [^js tags ^js prop-keys ^js children ^js strings]}]
   (warm-candidates! tags prop-keys)
   [[:prop-lookup-guarded   (ns-per-op micro-reps prop-keys guarded-lookup)]
    [:prop-lookup-nullproto (ns-per-op micro-reps prop-keys nullproto-lookup)]
    [:prop-lookup-instcheck (ns-per-op micro-reps prop-keys instcheck-lookup)]
    [:tag-lookup-guarded    (ns-per-op micro-reps tags guarded-tag-lookup)]
    [:tag-lookup-nullproto  (ns-per-op micro-reps tags nullproto-tag-lookup)]
-   [:tag-lookup-instcheck  (ns-per-op micro-reps tags instcheck-tag-lookup)]])
+   [:tag-lookup-instcheck  (ns-per-op micro-reps tags instcheck-tag-lookup)]
+   ;; the whole child population, in the proportions the page has it
+   [:dispatch-all-ship        (ns-per-op micro-reps children dispatch-ship)]
+   [:dispatch-all-stringfirst (ns-per-op micro-reps children dispatch-string-first)]
+   ;; and the string half alone, which is where the stage table put the gap
+   [:dispatch-str-ship        (ns-per-op micro-reps strings dispatch-ship)]
+   [:dispatch-str-stringfirst (ns-per-op micro-reps strings dispatch-string-first)]])
 
 ;; No `^js` hint: these read DEFTYPE fields, whose names the compiler
 ;; munges (`js-name` -> `js_name`, `reserved?` -> `reserved_QMARK_`). The
@@ -459,9 +488,13 @@
   "Each candidate answers what the shipping shape answers, for every
   literal on the page AND for the five hostile names the page does not
   carry — checked, not asserted, before any figure is read."
-  [{:keys [^js tags ^js prop-keys]}]
+  [{:keys [^js tags ^js prop-keys ^js children]}]
   (warm-candidates! tags prop-keys)
   (let [bad (atom [])]
+    (dotimes [i (.-length children)]
+      (let [c (aget children i)]
+        (when-not (= (dispatch-ship c) (dispatch-string-first c))
+          (swap! bad conj [:dispatch i]))))
     (dotimes [i (.-length prop-keys)]
       (let [k (aget prop-keys i)
             g (guarded-lookup k)]

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -100,7 +100,7 @@
   most of the page, so the plain witness shares structure with the
   native one everywhere it can."
   [m]
-  (reduce-kv (fn [acc k v]
+  (reduce-kv (fn [acc k _v]
                (if (and (keyword? k) (intent/event-prop? k))
                  (assoc acc k noop)
                  acc))

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -1,0 +1,543 @@
+(ns re-frame.bench.hicasso.walk-vs-reagent-app
+  "OUR WALK, PUT BESIDE REAGENT'S OWN (rf2-2rtt6.63).
+
+  The mount deficit's attribution chain ends at the runtime hiccup
+  interpreter, and stock Reagent is the existence proof that a runtime
+  interpreter need not be dear. `rf2-y1jkm` profiled OUR walk against a
+  frozen copy of OUR OWN older walk; it never put the two interpreters
+  side by side. This entry does, on ONE witness value, in ONE process:
+
+  | arm | walks | input |
+  |---|---|---|
+  | `hicasso` | `front.codec/as-element` | the plain witness |
+  | `slim` | `reagent2.impl.template/as-element` | the plain witness |
+  | `reagent` | `reagent.impl.template/as-element` (stock 2.0.1) | the plain witness |
+  | `hicasso-native` | `front.codec/as-element` | the page's OWN markup (intent vectors) |
+
+  ## The witness, and why it is link-term free
+
+  The page is `walk_profile_app`'s twin of the acceptance shape — the
+  same 1,202-element census page, guarded by that file's own fatal
+  canonical-DOM parity gate against the real `lt/page`, so there is one
+  twin in the lane and not two. It is **realized once, outside every
+  timed window** (`codec/realize-deep`), which is what makes these rows
+  immune to the route-link render term `rf2-cno31` is fixing: every
+  `route-link` href on the page is synthesised during realisation and is
+  a plain string by the time any arm walks it. No timed window here
+  contains a `route-url` call.
+
+  **THE PLAIN WITNESS.** Hicasso's markup carries intent VECTORS at its
+  71 event positions; Reagent has no such surface and would `clj->js`
+  them. An arm doing different work is not an arm (`rf2-2rtt6.62`), so
+  the compared value is the realized page with every event position
+  replaced by one shared plain function — legal, and identical work, for
+  all three interpreters. `hicasso-native` then prices what Hicasso's own
+  authoring surface costs ON TOP of that, so the intent term is named
+  rather than hidden inside the comparison.
+
+  ## Workload matching is gated, not asserted
+
+  Every arm's element tree is rendered into a fresh container and its
+  canonical DOM read (`lane/canonical`, attribute names sorted). The
+  three canonicals and the three element counts are reported beside the
+  rows: a decomposition of arms whose OUTPUT differs would be a
+  decomposition of nothing.
+
+  ## DIAGNOSTIC, not published
+
+  In-page `performance.now` over K whole-page walks per sample. It
+  attributes cost BETWEEN interpreters and BETWEEN stages of one walk; it
+  is not the clock of record and no figure here is a gate row. Stated per
+  the instrument canon so a ratio here cannot be mistaken for a gated
+  one.
+
+  ## The three tables
+
+  1. ARMS — ms per whole-page walk, interleaved rounds, min/p50/max, the
+     arm-order guard adjudicating, plus ns/element.
+  2. STAGES — the same primitive, ours and Reagent's, over the page's own
+     literal roster: tag lookup, prop-name lookup, value conversion, the
+     whole per-element prop pipeline, the per-element tag hook
+     (`controlled/install!` against `input/input-component?`), and child
+     dispatch. **Absolute ns/element**, because two-thirds of a mount
+     window is shared frame work and a ratio cannot be read against it.
+  3. CANDIDATES — costed BEFORE anything is landed. Each is a shape the
+     stage table convicts, written here beside the shipping shape and
+     timed against it in the same process on the same roster.
+
+  Owner bead: rf2-2rtt6.63. Driver: `run.cjs` with
+  HICASSO_INIT_FN=re-frame.bench.hicasso.walk-vs-reagent-app/-main."
+  (:require [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as arm1-mount]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.controlled :as controlled]
+            [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.shapes.large-template :as lt]
+            [re-frame.bench.hicasso.walk-profile-app :as wp]
+            [re-frame.core :as rf]
+            [reagent.impl.input :as rinput]
+            [reagent.impl.protocols :as rp]
+            [reagent.impl.template :as rtpl]
+            [reagent2.impl.template :as slim]
+            ["react" :as react]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]))
+
+;; ---------------------------------------------------------------------------
+;; The plain witness
+;; ---------------------------------------------------------------------------
+
+(defn- noop
+  "The one handler every event position on the plain witness carries.
+  Shared by identity, so no arm pays a distinct allocation for it."
+  [_e]
+  nil)
+
+(defn- plain-props
+  "`m` with every EVENT position's value replaced by [[noop]]. Returns
+  `m` itself, by identity, when it holds no event position — which is
+  most of the page, so the plain witness shares structure with the
+  native one everywhere it can."
+  [m]
+  (reduce-kv (fn [acc k v]
+               (if (and (keyword? k) (intent/event-prop? k))
+                 (assoc acc k noop)
+                 acc))
+             m
+             m))
+
+(defn- plainify
+  "The realized page with every event position plainified. Hiccup vectors
+  are rebuilt (metadata preserved), seqs stay seqs and are realized, and
+  everything else comes back by identity."
+  [x]
+  (cond
+    (vector? x)
+    (let [head       (nth x 0 nil)
+          has-props? (map? (nth x 1 nil))
+          head'      (if has-props?
+                       [head (plain-props (nth x 1))]
+                       [head])]
+      (with-meta
+        (into head' (map plainify) (subvec x (if has-props? 2 1)))
+        (meta x)))
+
+    (seq? x) (doall (map plainify x))
+    :else    x))
+
+;; ---------------------------------------------------------------------------
+;; Workload matching — one gate, three arms
+;; ---------------------------------------------------------------------------
+
+(defn- render-canonical
+  "Render one already-built React element into a fresh container and
+  answer `[canonical-dom element-count]`. The tree is a value, so this
+  runs no interpreter and belongs to no timed window."
+  [el]
+  (let [c    (arm1-mount/fresh-container!)
+        root (react-dom-client/createRoot c)]
+    (react-dom/flushSync (fn [] (.render root el)))
+    (let [canon (lane/canonical c)
+          n     (lane/element-count c)]
+      (react-dom/flushSync (fn [] (.unmount root)))
+      (.remove c)
+      [canon n])))
+
+(defn- first-divergence
+  "Index of the first differing character of two canonical strings, with
+  40 characters of context from each — the shape a reader can act on."
+  [a b]
+  (let [n (min (count a) (count b))]
+    (loop [i 0]
+      (cond
+        (= i n)              (if (= (count a) (count b))
+                               nil
+                               {:at i :ours (subs a i (min (count a) (+ i 40)))
+                                :theirs (subs b i (min (count b) (+ i 40)))})
+        (= (nth a i) (nth b i)) (recur (inc i))
+        :else {:at     i
+               :ours   (subs a i (min (count a) (+ i 40)))
+               :theirs (subs b i (min (count b) (+ i 40)))}))))
+
+;; ---------------------------------------------------------------------------
+;; The roster — the page's own literals, weighted as the page uses them
+;; ---------------------------------------------------------------------------
+
+(defn- collect-roster
+  "Every native tag occurrence, every prop-key occurrence, every prop
+  value occurrence, every string child, and the per-element `[tag props]`
+  pairs the prop pipeline is asked for. JS arrays, so the micro loops
+  index primitively."
+  [h]
+  (let [tags #js [] ks #js [] vs #js [] strs #js []
+        el-tags #js [] el-props #js []]
+    (letfn [(visit-child [c]
+              (cond (vector? c) (visit c)
+                    (string? c) (.push strs c)
+                    (seq? c)    (run! visit-child c)
+                    :else       nil))
+            (visit [argv]
+              (let [head       (nth argv 0 nil)
+                    has-props? (map? (nth argv 1 nil))
+                    props      (when has-props? (nth argv 1))]
+                (when (and (or (keyword? head) (symbol? head) (string? head))
+                           (not= :<> head))
+                  (.push tags head)
+                  (.push el-tags head)
+                  (.push el-props (if has-props? props nil)))
+                (when props
+                  (doseq [[k v] props]
+                    (.push ks k)
+                    (.push vs v)))
+                (doseq [c (subvec argv (if has-props? 2 1))]
+                  (visit-child c))))]
+      (visit h))
+    {:tags tags :prop-keys ks :prop-vals vs :strings strs
+     :el-tags el-tags :el-props el-props}))
+
+;; ---------------------------------------------------------------------------
+;; The timed arms
+;; ---------------------------------------------------------------------------
+
+(def ^:private walks-per-sample
+  "Whole-page walks inside ONE timing window. Chrome clamps
+  `performance.now` to 100 µs; eight ~1,200-element walks hold the window
+  in whole milliseconds, so the clamp is percent-level noise."
+  8)
+
+(defn- timed-walks
+  "One sample: K walks of one already-realized witness under one clock.
+  Answers ms for the window."
+  [witness walk-one]
+  (let [t0 (lane/now-ms)]
+    (dotimes [_ walks-per-sample]
+      (walk-one witness))
+    (- (lane/now-ms) t0)))
+
+(def ^:private sampling {:warmup 4 :samples 10})
+(def ^:private rounds 6)
+
+;; ---------------------------------------------------------------------------
+;; Stage micro-benches
+;; ---------------------------------------------------------------------------
+
+(defn- ns-per-op
+  "Loop `f` over `arr` `reps` times; answer ns per element visit. A
+  volatile sink defeats dead-code elimination."
+  [reps ^js arr f]
+  (let [sink (volatile! nil)
+        n    (.-length arr)
+        t0   (lane/now-ms)]
+    (dotimes [_ reps]
+      (dotimes [i n]
+        (vreset! sink (f (aget arr i)))))
+    (let [ms (- (lane/now-ms) t0)]
+      (/ (* 1e6 ms) (* reps n)))))
+
+(defn- ns-per-op2
+  "[[ns-per-op]] over two parallel arrays — the `[tag props]` pairs the
+  prop pipeline takes."
+  [reps ^js a ^js b f]
+  (let [sink (volatile! nil)
+        n    (.-length a)
+        t0   (lane/now-ms)]
+    (dotimes [_ reps]
+      (dotimes [i n]
+        (vreset! sink (f (aget a i) (aget b i)))))
+    (let [ms (- (lane/now-ms) t0)]
+      (/ (* 1e6 ms) (* reps n)))))
+
+(def ^:private micro-reps 200)
+
+(defn- stage-table
+  "The same primitive, ours and each donor's, over the page's own roster.
+  Every figure ns/op; the element-level rows are ns/ELEMENT."
+  [{:keys [^js tags ^js prop-keys ^js prop-vals ^js strings ^js el-tags ^js el-props]}]
+  (let [;; Both prop pipelines want a parsed tag. Precomputed here so the
+        ;; rows price the PIPELINE and not two different tag lookups.
+        h-parsed (let [a #js []]
+                   (dotimes [i (.-length el-tags)]
+                     (.push a (codec/cached-parse (aget el-tags i))))
+                   a)
+        r-parsed (let [a #js []]
+                   (dotimes [i (.-length el-tags)]
+                     (.push a (rtpl/cached-parse nil (name (aget el-tags i)) (aget el-tags i))))
+                   a)
+        tag-strs (let [a #js []]
+                   (dotimes [i (.-length el-tags)]
+                     (.push a (.-tag ^js (aget h-parsed i))))
+                   a)]
+    [;; --- tag lookup -------------------------------------------------
+     [:tag-lookup-hicasso (ns-per-op micro-reps tags (fn [t] (codec/cached-parse t)))]
+     [:tag-lookup-reagent (ns-per-op micro-reps tags
+                                     (fn [t] (rtpl/cached-parse nil (name t) t)))]
+     ;; --- prop-name lookup -------------------------------------------
+     [:prop-name-hicasso (ns-per-op micro-reps prop-keys (fn [k] (codec/cached-prop-name k)))]
+     [:prop-name-slim    (ns-per-op micro-reps prop-keys (fn [k] (slim/cached-prop-name k)))]
+     [:prop-name-reagent (ns-per-op micro-reps prop-keys (fn [k] (rtpl/cached-prop-name k)))]
+     ;; --- value conversion -------------------------------------------
+     [:prop-value-hicasso (ns-per-op micro-reps prop-vals (fn [v] (codec/convert-prop-value v)))]
+     [:prop-value-slim    (ns-per-op micro-reps prop-vals (fn [v] (slim/convert-prop-value v)))]
+     [:prop-value-reagent (ns-per-op micro-reps prop-vals (fn [v] (rtpl/convert-prop-value v)))]
+     ;; --- the whole per-element prop pipeline -------------------------
+     [:convert-props-hicasso
+      (ns-per-op2 micro-reps el-props h-parsed (fn [p ^js t] (codec/convert-props p t)))]
+     [:convert-props-reagent
+      (ns-per-op2 micro-reps el-props r-parsed (fn [p ^js t] (rtpl/convert-props p t)))]
+     ;; --- the per-element tag hook ------------------------------------
+     [:tag-hook-hicasso (ns-per-op micro-reps tag-strs
+                                   (fn [t] (controlled/install! t #js {})))]
+     [:tag-hook-reagent (ns-per-op micro-reps tag-strs
+                                   (fn [t] (rinput/input-component? t)))]
+     ;; --- child dispatch ----------------------------------------------
+     [:string-child-hicasso (ns-per-op micro-reps strings (fn [s] (codec/as-element s)))]
+     [:string-child-slim    (ns-per-op micro-reps strings (fn [s] (slim/as-element s)))]
+     [:string-child-reagent (ns-per-op micro-reps strings
+                                       (fn [s] (rp/as-element rtpl/class-compiler s)))]
+     ;; --- the shared floor --------------------------------------------
+     [:create-element-shared
+      (let [p #js {:className "x"}]
+        (ns-per-op (quot micro-reps 4) tag-strs (fn [t] (react/createElement t p))))]
+     ;; --- the per-element `:key` read the walk pays outside the loop ---
+     [:key-read-hicasso (ns-per-op micro-reps el-props (fn [p] (:key p)))]
+     [:roster-elements (.-length el-tags)]]))
+
+;; ---------------------------------------------------------------------------
+;; Candidates — costed here, landed only if this table convicts
+;; ---------------------------------------------------------------------------
+;;
+;; The shipping cache lookup is a three-step: `reserved-name?` (three
+;; `===` compares against the JS prototype-poisoning roster), `own-key?`
+;; (`Object.prototype.hasOwnProperty.call`), then `unchecked-get`. All
+;; three exist because the caches are `#js {}` objects and therefore carry
+;; `Object.prototype`: a literal named `__proto__` would poison a write,
+;; and an inherited name (`toString`) would falsely hit a read.
+;;
+;; A cache made with `Object.create(null)` has NO prototype chain at all.
+;; `__proto__` on it is an ordinary own property with no setter to invoke,
+;; and a lookup can only ever answer an own property — so the whole guard
+;; collapses to one `unchecked-get` and an `undefined?` test, and it is
+;; STRICTLY SAFER than the guarded version rather than a relaxation of it.
+;; The arms below price that collapse over the page's own key roster
+;; before anything is landed in the codec.
+
+(defn- mint-name
+  "The candidate arms cache a NAME, which is enough to price the lookup
+  shape; the shipping cache holds a `PropSlot` whose extra fields are
+  minted by the same miss path either way."
+  [k]
+  (codec/prop-name k))
+
+(def ^:private guarded-cache #js {})
+(def ^:private nullproto-cache (js/Object.create nil))
+(def ^:private has-own (.-hasOwnProperty (.-prototype js/Object)))
+
+(defn- reserved-name? [n]
+  (or (identical? "__proto__" n)
+      (identical? "prototype" n)
+      (identical? "constructor" n)))
+
+(defn- guarded-lookup
+  "The shipping lookup shape, written here so both arms are local."
+  [k]
+  (let [n (name k)]
+    (if (reserved-name? n)
+      (mint-name k)
+      (if (.call has-own guarded-cache n)
+        (unchecked-get guarded-cache n)
+        (let [v (mint-name k)]
+          (unchecked-set guarded-cache n v)
+          v)))))
+
+(defn- nullproto-lookup
+  "The candidate: one `unchecked-get` on a prototype-less cache."
+  [k]
+  (let [n (name k)
+        v (unchecked-get nullproto-cache n)]
+    (if (undefined? v)
+      (let [v' (mint-name k)]
+        (unchecked-set nullproto-cache n v')
+        v')
+      v)))
+
+(def ^:private guarded-tag-cache #js {})
+(def ^:private nullproto-tag-cache (js/Object.create nil))
+
+(defn- tag-cache-key [k]
+  (if-let [ns' (namespace k)] (str ns' "/" (name k)) (name k)))
+
+(defn- guarded-tag-lookup [t]
+  (let [k (tag-cache-key t)]
+    (if (reserved-name? k)
+      (codec/parse-tag t)
+      (if (.call has-own guarded-tag-cache k)
+        (unchecked-get guarded-tag-cache k)
+        (let [v (codec/parse-tag t)]
+          (unchecked-set guarded-tag-cache k v)
+          v)))))
+
+(defn- nullproto-tag-lookup [t]
+  (let [k (tag-cache-key t)
+        v (unchecked-get nullproto-tag-cache k)]
+    (if (undefined? v)
+      (let [v' (codec/parse-tag t)]
+        (unchecked-set nullproto-tag-cache k v')
+        v')
+      v)))
+
+(defn- candidate-table
+  [{:keys [^js tags ^js prop-keys]}]
+  ;; Warm both caches before timing: a lookup arm must measure hits.
+  (dotimes [i (.-length prop-keys)]
+    (guarded-lookup (aget prop-keys i))
+    (nullproto-lookup (aget prop-keys i)))
+  (dotimes [i (.-length tags)]
+    (guarded-tag-lookup (aget tags i))
+    (nullproto-tag-lookup (aget tags i)))
+  [[:prop-lookup-guarded   (ns-per-op micro-reps prop-keys guarded-lookup)]
+   [:prop-lookup-nullproto (ns-per-op micro-reps prop-keys nullproto-lookup)]
+   [:tag-lookup-guarded    (ns-per-op micro-reps tags guarded-tag-lookup)]
+   [:tag-lookup-nullproto  (ns-per-op micro-reps tags nullproto-tag-lookup)]])
+
+(defn- candidate-agreement
+  "The candidate answers what the shipping shape answers, for every
+  literal on the page — checked, not asserted, before any figure is
+  read."
+  [{:keys [^js tags ^js prop-keys]}]
+  (let [bad (atom [])]
+    (dotimes [i (.-length prop-keys)]
+      (let [k (aget prop-keys i)]
+        (when-not (= (guarded-lookup k) (nullproto-lookup k))
+          (swap! bad conj [:prop k]))))
+    (dotimes [i (.-length tags)]
+      (let [t   (aget tags i)
+            ^js a (guarded-tag-lookup t)
+            ^js b (nullproto-tag-lookup t)]
+        (when-not (and (= (.-tag a) (.-tag b))
+                       (= (.-id a) (.-id b))
+                       (= (.-className a) (.-className b)))
+          (swap! bad conj [:tag t]))))
+    ;; The poisoning literals themselves, which the page does not carry.
+    (doseq [n ["__proto__" "prototype" "constructor" "toString" "hasOwnProperty"]]
+      (let [k (keyword n)]
+        (when-not (= (guarded-lookup k) (nullproto-lookup k))
+          (swap! bad conj [:hostile k]))))
+    @bad))
+
+;; ---------------------------------------------------------------------------
+;; Reporting
+;; ---------------------------------------------------------------------------
+
+(defn- fmt [x n] (.toFixed ^number x n))
+
+(defn- arm-rows [arms readings]
+  (into {}
+        (map (fn [id]
+               (let [xs       (mapcat #(get % id) readings)
+                     per-walk (mapv #(/ % walks-per-sample) xs)]
+                 [id (lane/summarise per-walk)])))
+        (map :id arms)))
+
+(defn ^:export -main []
+  (rf/init! uix-adapter/adapter)
+  (lane/leave-act-environment!)
+  (lane/self-test!)
+  (-> (js/Promise.resolve nil)
+      (.then
+        (fn [_]
+          (lt/make-frame! wp/frame-id)
+          (lt/reseed! wp/frame-id)
+          (let [{:keys [elements bytes]} (wp/parity!)]
+            (js/console.log (str ";; twin parity OK — " elements " elements, "
+                                 bytes " canonical bytes, identical to lt/page"))
+            (let [native  (wp/in-body (fn [] (codec/realize-deep (wp/page-hiccup))))
+                  plain   (plainify native)
+                  roster  (collect-roster plain)
+                  arms    [{:id :hicasso        :witness plain
+                            :walk (fn [h] (codec/as-element h))}
+                           {:id :slim           :witness plain
+                            :walk (fn [h] (slim/as-element h))}
+                           {:id :reagent        :witness plain
+                            :walk (fn [h] (rp/as-element rtpl/class-compiler h))}
+                           {:id :hicasso-native :witness native
+                            :walk (fn [h] (codec/as-element h))}]
+                  ;; ---- workload matching, before any figure ------------
+                  canons  (into {}
+                                (map (fn [{:keys [id witness walk]}]
+                                       [id (render-canonical (walk witness))]))
+                                arms)
+                  ref-canon (first (get canons :hicasso))
+                  parity  (into {}
+                                (map (fn [[id [canon n]]]
+                                       [id {:elements n
+                                            :bytes    (count canon)
+                                            :same?    (= canon ref-canon)
+                                            :diverges (when-not (= canon ref-canon)
+                                                        (first-divergence ref-canon canon))}]))
+                                canons)
+                  ;; ---- the interleaved rounds --------------------------
+                  {:keys [readings samples]}
+                  (lane/rounds! arms sampling rounds
+                                (fn [{:keys [witness walk]}] (timed-walks witness walk)))
+                  rows    (arm-rows arms readings)
+                  gv      (lane/guard! samples "walk-vs-reagent arms (in-page ms, diagnostic)")
+                  stages  (stage-table roster)
+                  cand-bad (candidate-agreement roster)
+                  cands   (candidate-table roster)
+                  hic     (:p50 (get rows :hicasso))
+                  rgt     (:p50 (get rows :reagent))
+                  slm     (:p50 (get rows :slim))]
+
+              (lane/record! :walk-vs-reagent-parity parity)
+              (lane/record! :walk-vs-reagent-arms
+                            (into {} (map (fn [[k v]]
+                                            [k (-> v (update :min lane/round4)
+                                                   (update :max lane/round4)
+                                                   (update :p50 lane/round4))]))
+                                  rows))
+              (lane/record! :walk-vs-reagent-stages
+                            (into {} (map (fn [[k v]] [k (lane/round4 v)])) stages))
+              (lane/record! :walk-vs-reagent-candidates
+                            {:disagreements cand-bad
+                             :ns-per-op (into {} (map (fn [[k v]] [k (lane/round4 v)])) cands)})
+
+              (js/console.log ";; ==== WORKLOAD MATCH (every arm's own DOM, canonical) ====")
+              (doseq [{:keys [id]} arms]
+                (let [p (get parity id)]
+                  (js/console.log (str ";;   " (name id) ": " (:elements p) " elements, "
+                                       (:bytes p) " canonical bytes, "
+                                       (if (:same? p) "IDENTICAL to hicasso"
+                                           (str "DIFFERS — " (pr-str (:diverges p))))))))
+
+              (js/console.log ";; ==== ARMS (ms per whole-page walk; diagnostic in-page clock) ====")
+              (js/console.log (str ";;   elements " elements
+                                   "  walks/sample " walks-per-sample
+                                   "  design " rounds "x(" (:warmup sampling) "+"
+                                   (:samples sampling) ")"))
+              (doseq [{:keys [id]} arms]
+                (let [{:keys [p50 min max]} (get rows id)]
+                  (js/console.log (str ";;   " (name id) ": p50 " (fmt p50 4)
+                                       " [" (fmt min 4) " - " (fmt max 4) "] ms/walk  ("
+                                       (fmt (* 1e6 (/ p50 elements)) 0) " ns/el)"))))
+              (js/console.log (str ";;   hicasso/reagent " (fmt (/ hic rgt) 4)
+                                   "   hicasso/slim " (fmt (/ hic slm) 4)
+                                   "   slim/reagent " (fmt (/ slm rgt) 4)))
+              (js/console.log (str ";;   ABSOLUTE per-element delta vs reagent: "
+                                   (fmt (* 1e6 (/ (- hic rgt) elements)) 1) " ns/el"))
+
+              (js/console.log ";; ==== STAGES (ns/op over the page's own roster) ====")
+              (doseq [[k v] stages]
+                (js/console.log (str ";;   " (name k) ": " (fmt v 1))))
+
+              (js/console.log ";; ==== CANDIDATES (costed, not landed) ====")
+              (js/console.log (str ";;   agreement failures: " (pr-str cand-bad)))
+              (doseq [[k v] cands]
+                (js/console.log (str ";;   " (name k) ": " (fmt v 1) " ns/op")))
+
+              (when (:refuse? gv)
+                (set! (.-HICASSO_GUARD_REFUSED js/window) true))
+              (lane/done!)))))
+      (.catch (fn [e]
+                (lane/fail! (or (some-> e .-message) (str e)))
+                (lane/done!)))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -208,12 +208,22 @@
 
 (defn- timed-walks
   "One sample: K walks of one already-realized witness under one clock.
-  Answers ms for the window."
+  Answers ms for the window.
+
+  **Every arm runs inside the body door**, including the two that do not
+  need it. Hicasso's intent lowering refuses to run with no ambient
+  dispatch (`front.intent/require-dispatch`), so the native arm has no
+  choice; running the donors inside the same door keeps the four arms on
+  ONE call convention, which is the confound `rf2-2rtt6.32` recorded and
+  the only reason that measurement's error was caught. The clock starts
+  INSIDE the door, so the door itself is never in the window."
   [witness walk-one]
-  (let [t0 (lane/now-ms)]
-    (dotimes [_ walks-per-sample]
-      (walk-one witness))
-    (- (lane/now-ms) t0)))
+  (wp/in-body
+    (fn []
+      (let [t0 (lane/now-ms)]
+        (dotimes [_ walks-per-sample]
+          (walk-one witness))
+        (- (lane/now-ms) t0)))))
 
 (def ^:private sampling {:warmup 4 :samples 10})
 (def ^:private rounds 6)
@@ -307,30 +317,36 @@
 ;; Candidates — costed here, landed only if this table convicts
 ;; ---------------------------------------------------------------------------
 ;;
-;; The shipping cache lookup is a three-step: `reserved-name?` (three
-;; `===` compares against the JS prototype-poisoning roster), `own-key?`
+;; The shipping cache lookup is a three-step, and every step of it is on
+;; the HIT path — the path a mount takes 1,202 times for tags and ~1,075
+;; times for props: `reserved-name?` (three `===` compares against the JS
+;; prototype-poisoning roster), `own-key?`
 ;; (`Object.prototype.hasOwnProperty.call`), then `unchecked-get`. All
 ;; three exist because the caches are `#js {}` objects and therefore carry
-;; `Object.prototype`: a literal named `__proto__` would poison a write,
-;; and an inherited name (`toString`) would falsely hit a read.
+;; `Object.prototype`: a literal named `__proto__` would poison a WRITE,
+;; and an inherited name (`toString`, `constructor`) would falsely hit a
+;; READ.
 ;;
-;; A cache made with `Object.create(null)` has NO prototype chain at all.
-;; `__proto__` on it is an ordinary own property with no setter to invoke,
-;; and a lookup can only ever answer an own property — so the whole guard
-;; collapses to one `unchecked-get` and an `undefined?` test, and it is
-;; STRICTLY SAFER than the guarded version rather than a relaxation of it.
-;; The arms below price that collapse over the page's own key roster
-;; before anything is landed in the codec.
-
-(defn- mint-name
-  "The candidate arms cache a NAME, which is enough to price the lookup
-  shape; the shipping cache holds a `PropSlot` whose extra fields are
-  minted by the same miss path either way."
-  [k]
-  (codec/prop-name k))
+;; Both candidates below move the write guard to the MISS path, where it
+;; runs once per distinct literal for the life of the build instead of
+;; once per element per mount, and answer the false-hit problem in the
+;; lookup itself. They differ in how:
+;;
+;;   nullproto  the cache is `Object.create(null)` — no prototype chain,
+;;              so a lookup can only ever answer an own property and the
+;;              test is `undefined?`. Strictly safer than the guard it
+;;              replaces. RISK, which is why it is costed and not
+;;              assumed: V8 starts `Object.create(null)` objects in
+;;              DICTIONARY mode, and a dictionary-mode lookup can be
+;;              dearer than the fast-mode lookup plus its guards.
+;;   instcheck  the cache stays a `#js {}` in fast mode and the hit is
+;;              validated by TYPE — nothing on `Object.prototype` is a
+;;              `ParsedTag` or a `PropSlot`, so `instance?` rejects every
+;;              inherited name in one test.
 
 (def ^:private guarded-cache #js {})
 (def ^:private nullproto-cache (js/Object.create nil))
+(def ^:private instcheck-cache #js {})
 (def ^:private has-own (.-hasOwnProperty (.-prototype js/Object)))
 
 (defn- reserved-name? [n]
@@ -338,31 +354,45 @@
       (identical? "prototype" n)
       (identical? "constructor" n)))
 
+(defn- mint-slot
+  "All three arms cache the same value shape the codec caches, so the
+  rows price the LOOKUP and not two different payloads."
+  [k n]
+  (codec/->PropSlot (codec/prop-name k) (reserved-name? n) false false))
+
 (defn- guarded-lookup
-  "The shipping lookup shape, written here so both arms are local."
+  "The shipping lookup shape, written here so every arm is local."
   [k]
   (let [n (name k)]
     (if (reserved-name? n)
-      (mint-name k)
+      (mint-slot k n)
       (if (.call has-own guarded-cache n)
         (unchecked-get guarded-cache n)
-        (let [v (mint-name k)]
+        (let [v (mint-slot k n)]
           (unchecked-set guarded-cache n v)
           v)))))
 
-(defn- nullproto-lookup
-  "The candidate: one `unchecked-get` on a prototype-less cache."
-  [k]
+(defn- nullproto-lookup [k]
   (let [n (name k)
         v (unchecked-get nullproto-cache n)]
     (if (undefined? v)
-      (let [v' (mint-name k)]
-        (unchecked-set nullproto-cache n v')
+      (let [v' (mint-slot k n)]
+        (when-not (reserved-name? n) (unchecked-set nullproto-cache n v'))
         v')
       v)))
 
+(defn- instcheck-lookup [k]
+  (let [n (name k)
+        v (unchecked-get instcheck-cache n)]
+    (if (instance? codec/PropSlot v)
+      v
+      (let [v' (mint-slot k n)]
+        (when-not (reserved-name? n) (unchecked-set instcheck-cache n v'))
+        v'))))
+
 (def ^:private guarded-tag-cache #js {})
 (def ^:private nullproto-tag-cache (js/Object.create nil))
+(def ^:private instcheck-tag-cache #js {})
 
 (defn- tag-cache-key [k]
   (if-let [ns' (namespace k)] (str ns' "/" (name k)) (name k)))
@@ -382,47 +412,77 @@
         v (unchecked-get nullproto-tag-cache k)]
     (if (undefined? v)
       (let [v' (codec/parse-tag t)]
-        (unchecked-set nullproto-tag-cache k v')
+        (when-not (reserved-name? k) (unchecked-set nullproto-tag-cache k v'))
         v')
       v)))
 
+(defn- instcheck-tag-lookup [t]
+  (let [k (tag-cache-key t)
+        v (unchecked-get instcheck-tag-cache k)]
+    (if (instance? codec/ParsedTag v)
+      v
+      (let [v' (codec/parse-tag t)]
+        (when-not (reserved-name? k) (unchecked-set instcheck-tag-cache k v'))
+        v'))))
+
+(defn- warm-candidates! [^js tags ^js prop-keys]
+  (dotimes [i (.-length prop-keys)]
+    (let [k (aget prop-keys i)]
+      (guarded-lookup k) (nullproto-lookup k) (instcheck-lookup k)))
+  (dotimes [i (.-length tags)]
+    (let [t (aget tags i)]
+      (guarded-tag-lookup t) (nullproto-tag-lookup t) (instcheck-tag-lookup t))))
+
 (defn- candidate-table
   [{:keys [^js tags ^js prop-keys]}]
-  ;; Warm both caches before timing: a lookup arm must measure hits.
-  (dotimes [i (.-length prop-keys)]
-    (guarded-lookup (aget prop-keys i))
-    (nullproto-lookup (aget prop-keys i)))
-  (dotimes [i (.-length tags)]
-    (guarded-tag-lookup (aget tags i))
-    (nullproto-tag-lookup (aget tags i)))
+  (warm-candidates! tags prop-keys)
   [[:prop-lookup-guarded   (ns-per-op micro-reps prop-keys guarded-lookup)]
    [:prop-lookup-nullproto (ns-per-op micro-reps prop-keys nullproto-lookup)]
+   [:prop-lookup-instcheck (ns-per-op micro-reps prop-keys instcheck-lookup)]
    [:tag-lookup-guarded    (ns-per-op micro-reps tags guarded-tag-lookup)]
-   [:tag-lookup-nullproto  (ns-per-op micro-reps tags nullproto-tag-lookup)]])
+   [:tag-lookup-nullproto  (ns-per-op micro-reps tags nullproto-tag-lookup)]
+   [:tag-lookup-instcheck  (ns-per-op micro-reps tags instcheck-tag-lookup)]])
+
+;; No `^js` hint: these read DEFTYPE fields, whose names the compiler
+;; munges (`js-name` -> `js_name`, `reserved?` -> `reserved_QMARK_`). The
+;; codec reads them the same way, through its own `^PropSlot` hint.
+(defn- slot= [^codec/PropSlot a ^codec/PropSlot b]
+  (and (= (.-js-name a) (.-js-name b))
+       (= (.-reserved? a) (.-reserved? b))))
+
+(defn- tag= [a b]
+  (and (= (.-tag a) (.-tag b))
+       (= (.-id a) (.-id b))
+       (= (.-className a) (.-className b))))
 
 (defn- candidate-agreement
-  "The candidate answers what the shipping shape answers, for every
-  literal on the page — checked, not asserted, before any figure is
-  read."
+  "Each candidate answers what the shipping shape answers, for every
+  literal on the page AND for the five hostile names the page does not
+  carry — checked, not asserted, before any figure is read."
   [{:keys [^js tags ^js prop-keys]}]
+  (warm-candidates! tags prop-keys)
   (let [bad (atom [])]
     (dotimes [i (.-length prop-keys)]
-      (let [k (aget prop-keys i)]
-        (when-not (= (guarded-lookup k) (nullproto-lookup k))
-          (swap! bad conj [:prop k]))))
+      (let [k (aget prop-keys i)
+            g (guarded-lookup k)]
+        (when-not (slot= g (nullproto-lookup k)) (swap! bad conj [:prop :nullproto k]))
+        (when-not (slot= g (instcheck-lookup k)) (swap! bad conj [:prop :instcheck k]))))
     (dotimes [i (.-length tags)]
-      (let [t   (aget tags i)
-            ^js a (guarded-tag-lookup t)
-            ^js b (nullproto-tag-lookup t)]
-        (when-not (and (= (.-tag a) (.-tag b))
-                       (= (.-id a) (.-id b))
-                       (= (.-className a) (.-className b)))
-          (swap! bad conj [:tag t]))))
-    ;; The poisoning literals themselves, which the page does not carry.
-    (doseq [n ["__proto__" "prototype" "constructor" "toString" "hasOwnProperty"]]
-      (let [k (keyword n)]
-        (when-not (= (guarded-lookup k) (nullproto-lookup k))
-          (swap! bad conj [:hostile k]))))
+      (let [t (aget tags i)
+            g (guarded-tag-lookup t)]
+        (when-not (tag= g (nullproto-tag-lookup t)) (swap! bad conj [:tag :nullproto t]))
+        (when-not (tag= g (instcheck-tag-lookup t)) (swap! bad conj [:tag :instcheck t]))))
+    (doseq [n ["__proto__" "prototype" "constructor" "toString" "hasOwnProperty"
+               "valueOf" "isPrototypeOf"]]
+      (let [k (keyword n)
+            g (guarded-lookup k)]
+        (when-not (slot= g (nullproto-lookup k)) (swap! bad conj [:hostile :nullproto k]))
+        (when-not (slot= g (instcheck-lookup k)) (swap! bad conj [:hostile :instcheck k]))
+        (let [gt (guarded-tag-lookup k)]
+          (when-not (tag= gt (nullproto-tag-lookup k))
+            (swap! bad conj [:hostile-tag :nullproto k]))
+          (when-not (tag= gt (instcheck-tag-lookup k))
+            (swap! bad conj [:hostile-tag :instcheck k])))))
     @bad))
 
 ;; ---------------------------------------------------------------------------
@@ -463,9 +523,13 @@
                            {:id :hicasso-native :witness native
                             :walk (fn [h] (codec/as-element h))}]
                   ;; ---- workload matching, before any figure ------------
+                  ;; The tree is built inside the body door (the native
+                  ;; arm's lowering needs it) and RENDERED outside it, so
+                  ;; no React commit happens inside a body context.
                   canons  (into {}
                                 (map (fn [{:keys [id witness walk]}]
-                                       [id (render-canonical (walk witness))]))
+                                       [id (render-canonical
+                                             (wp/in-body (fn [] (walk witness))))]))
                                 arms)
                   ref-canon (first (get canons :hicasso))
                   parity  (into {}


### PR DESCRIPTION
`rf2-2rtt6.63` is the outcome bead for the mount deficit, and it opens on a
premise: the whole clock deficit follows the interpreter, stock Reagent's own
interpreter proves a runtime walk can be nearly free, so the question is **why
ours is slower than Reagent's and how much of HD-004's budget closes it**.

Nobody had ever put the two side by side. `rf2-y1jkm` profiled our walk against
a *frozen copy of our own older walk*; the census clock rows compare whole
mounts, where two-thirds of the window is shared style, layout and paint. So the
bead's step 1 — measure before touching anything — is a new instrument:
`walk_vs_reagent_app` runs our codec, the lineage donor `reagent2.impl.template`,
and stock `reagent.impl.template` 2.0.1 over **one witness value in one
process**, with the arm-order guard adjudicating.

## The premise did not survive the measurement

| arm | ms/walk p50 [min – max] | ns/element |
|---|---|---|
| `reagent` (stock 2.0.1) | 0.6375 [0.6000 – 0.9000] | 530 |
| **`hicasso`** | **0.6750 [0.6250 – 0.8000]** | **562** |
| `hicasso-native` (intent markup) | 0.7250 [0.6625 – 0.9000] | 603 |
| `slim` (`reagent2.impl.template`) | 1.2125 [1.1125 – 1.4500] | 1,009 |

**Our walk was already at stock Reagent's cost before this PR changed anything**
— `hicasso/reagent` **1.0588**, a 32 ns/element difference on a 530 ns/element
walk. And **`slim/reagent` is 1.9020**: the interpreter the donor rungs actually
ride is nearly twice stock Reagent's, which is where their 1.33–1.5× comes from.
Hicasso extracted that plumbing and then cheapened it — we read **0.56×** the
donor we were built from.

After the two cheapenings the stage table convicted: **`hicasso/reagent`
0.9636** — our walk reads *below* stock Reagent's.

## The decomposition closes

Absolute ns/op over the page's own roster (1,202 elements, 1,489 props, 1,908
children of which 567 strings). Absolutes, because two-thirds of a mount is
shared frame work and a ratio cannot be read against it.

| stage | hicasso | slim | reagent | ours − Reagent's |
|---|---|---|---|---|
| tag lookup (cached) | 21.2 | — | 29.5 | −8.3 |
| prop-name lookup (cached) | 21.5 | 49.4 | 24.5 | −3.0 |
| prop-value conversion | 6.7 | 8.1 | 7.1 | −0.4 |
| **whole prop pipeline / element** | **209.2** | — | **182.2** | **+27.0** |
| per-element tag hook | 9.2 | — | 6.7 | +2.5 |
| **`as-element` on a string child** | **33.5** | 7.9 | **8.8** | **+24.7** |

Weighted by the roster, the named stages sum to **+34.4 µs/walk** against a
measured whole-walk delta of **+37.5 µs** — **92% accounted for**, which is what
makes the two changes below convictions rather than guesses.

## What the budget bought

**(a) The caches lose their prototype** — HD-004 cache mechanism. Every lookup
carried its guard on the **hit** path (three `identical?` compares plus
`Object.prototype.hasOwnProperty.call`) because the caches were `#js {}`.
`Object.create(null)` removes the false-hit class *structurally* and demotes the
poisoning guard to the **miss** branch, the only branch that writes.

| lookup | guarded | **`Object.create(null)`** | `#js {}` + `instance?` |
|---|---|---|---|
| prop | 18.1 | **11.1** | 13.8 |
| tag | 16.6 | **11.2** | 12.1 |

The type-check variant was **costed and declined** — V8 starts null-prototype
objects in dictionary mode so it could plausibly have won, and it did not, on
either cache in either run. Declined on construction too: a cache with no
prototype *cannot* serve an inherited value.

**(b) `as-element` asks `string?` before `vector?`** — a predicate order, not a
cache, and classified as such. The branches are mutually exclusive so their
order cannot change an answer; `vector?` is `IVector` satisfaction, which falls
to `native-satisfies?` for anything without the marker, so every string, number
and lazy seq proved itself not-a-vector the expensive way first. Over the whole
1,908-child roster **22.5 → 8.9 ns/child**; over the 567 strings alone **31.7 →
5.3**.

**Declined, with reasons**: Replicant-style skeleton caching (already declined by
`rf2-y1jkm` with census arithmetic; there is now no gap for it to close);
forking reagent-slim's codec (needs a ruling, and the donor is 1.8× ours); a
compiler or analyzer (fenced). The HD-004 hard fence is untouched — no template
extraction, no hole plans, no node references, no subscription-addressed
anything, no direct DOM writes.

## The floor, stated plainly

The one stage where we still pay more is the prop pipeline, **+20.8 ns/element**
after the change. Every item of it is a shipped semantic — the `:&` owned-literal
law (HD-023), the `:ref` reserved-value refusal (HD-022), the event-position
classification intent vectors need, `controlled/install!`'s caret convergence
(HD-020). Removing any of them removes a feature. It is reported as the floor,
not attacked.

> The walk is **~0.66 ms of a ~10 ms mount**. The two cheapenings are worth about
> **9% of the walk** and therefore about **0.6% of the mount**. **Nothing
> available inside the fence, at the walk, moves the 1.10× mount line.**

That is the bead's honest negative and it is a complete answer: the mount deficit
is no longer attributable to the interpreter.

## Measurement caveats, declared not buried

- **The route-link term (`rf2-cno31`) is structurally absent, not subtracted.**
  The witness is realized once *outside every timed window*, so all 207
  `route-link` hrefs are plain strings before any clock starts. No timed window
  contains a `route-url` synthesis. Windows were coordinated with
  `worker/linkterm-cno31` on both beads before either run opened, and this PR
  takes no census-clock row.
- **Workload matching is gated.** Every arm's tree is rendered and its canonical
  DOM read: 1,202 elements on all four arms. Reagent and slim differ from us by
  **55 bytes, all whitespace** — the card writes `:class (cond-> "" …)`, and
  Reagent's `class-names` joins an empty class into a trailing space where ours
  drops it. Zero attribute or element differences, and it costs *Reagent* the
  extra `str`.
- **The box was not quiet and the page says so.** Shared fleet box; waiting was
  tried for 25 minutes. Absolutes are ceilings and are not compared across runs;
  the arm ratios are same-run interleaved.
- **One run was REFUSED and is published as refused.** The first after-run took
  arm-order guard **exit 2** — every arm 1.44–1.55× slower in the last third,
  ranges disjoint, a monotonic phase drift as the box ramped. The repair was the
  run, not the tolerance; the re-take passed on the first attempt. None of the
  refused run's figures appears anywhere.

## Quality gates

All foreground, worktree-local logs, each exit code the script's own.

| gate | result |
|---|---|
| `npm run test:cljs` | **exit 0** — 12,381 tests / 61,824 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **exit 0** — 995 tests / 6,201 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` | **exit 0** — `PASS fast PR spine`; JVM `implementation/core` 2,210 tests / 11,506 assertions and `implementation/freehand` 1,288 / 8,857, `mkdocs --strict` built clean, node tier 12,381 / 61,824 |
| clj-kondo **2026.04.15**, CI's exact `--lint` surface | **exit 0 — errors: 0**, warnings 4533 (repo baseline) |
| `scripts/check_doc_slugs.py`, whole corpus | **exit 0** |
| shadow `:hicasso-bench` `:advanced` | **0 warnings** on every build |

clj-kondo note: npm only publishes clj-kondo to 2025.10.23, so the CI-pinned
2026.04.15 was fetched from the GitHub release and `--version` verified before
use. The one warning this diff introduced (`unused binding v`) is fixed.

`mkdocs build --strict` is **not** the gate for the docs change: `mkdocs.yml`'s
`exclude_docs` keeps `design/hicasso/` out of the site (the spine ran it anyway
and it built clean). `check_doc_slugs.py` validates the tree's link targets and
heading anchors and ran clean; **the table column counts and anchors were
verified by hand** — 10 tables, every row in each block agreeing (4/3/3/5/5/4/3/3/2/2
columns), and the page has no internal links to resolve.

TESTING.md matrix: this diff is bench + docs. The `cljs_node_test` tier owns the
codec's 34 witnesses (`npm run test:cljs`, run here); the browser lanes own the
DOM suites (run here); `implementation_jvm` is untouched by a CLJS-only bench
change but ran anyway inside the fast-PR spine. Not run and not owned by this
surface: the perf-bundle and bundle-isolation gates (nothing under
`implementation/*/src` changed — the codec is a `test/` tree artefact), the Xray
feature matrix, mcp-conformance, the adapter smokes.

### Mutation ledger — each proven able to go red, green on restore

| mutation | expected failure | observed |
|---|---|---|
| M1 — both caches back to `#js {}` | the new inherited-property witness | **RED** — 15 failures; the actual value is literally `#object[toString]` |
| M2 — string branch made unconditional | every hiccup-vector witness | **RED** — 34 failures, 75 errors. The ordering proof |
| M3 — drop the prop-cache write guard | `:props` cache size | **RED** — `(not (= 3 4))` |
| M4 — drop the tag-cache write guard | `:tags` cache size | **RED** — `(not (= 0 1))` |

The new witness pins what nothing but the cache's construction answers any more:
a tag or prop literal named after an `Object.prototype` member must be parsed
and converted as itself, and must hit its own entry the second time.

One browser-suite run showed a single failure in
`re_frame/freehand/projection_roster_dom_cljs_test` (a live-scroll timing
assertion, `expected 640 actual 320`). It is not this diff's surface — that file
requires nothing from `re-frame.bench.hicasso`, and this diff touches only
`bench/hicasso` files — and a clean re-run confirmed it. Recorded rather than
quietly dropped.

## Composition with what is in flight

- **PR #7375 (HD-026 memo wrapper, held)** — different layer, and stated rather
  than assumed: the wrapper sits on the boundary head and decides whether a
  body runs again; this diff is inside the element walk. On a mount the wrapper
  does nothing and this is the whole effect. The textual meeting point is
  `front/codec.cljs`, in disjoint regions.
- **`worker/linkterm-cno31`** — owns the census-clock windows; this PR takes no
  census row and its instrument cannot see the link term.

## Provenance

Studio page: `docs/design/hicasso/studio/our-walk-against-reagents.md`.
Reproduction: `HICASSO_INIT_FN=re-frame.bench.hicasso.walk-vs-reagent-app/-main
HICASSO_OUT_DIR=out/hicasso-walkcmp HICASSO_PORT=8171 node
implementation/freehand/test/re_frame/bench/hicasso/run.cjs`. Runtime chromium
147.0.7727.15 (playwright), node v24.13.0. Measured blobs byte-identical across
the two runs **except `front/codec.cljs`** — the intervention (`5a0b04733a` →
`0304f489bb`). `reagent2.impl.template` is unmodified: **the codec is not
forked.**
