### PR TITLE
bench(hicasso): the R=0 shell anchor with the wrapper in place (rf2-2rtt6.58)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1111,14 +1111,40 @@ heap ladder to find, and it was **measured before this ruling landed** —
 
 The heap delta reproduces at **~200 B per boundary**, which is a Fiber. The clock
 rows do not separate from run-to-run noise at this round count, so the mount and
-bulk cost is stated as a **bound (≲10%)** rather than a figure. Two things the
-measurement deliberately does **not** settle are recorded on the page rather than
-smoothed over: whether the mount row carries a real few-per-cent regression, which
-needs `clock_run.cjs`'s adjudicated M1 row; and what +200 B does to the **R=0
-shell** figure, which the reads ladder puts at 1,143 B — already over the 1 KB
-paper line, and ≈ +17% with the wrapper. On the card-shaped boundary actually
-measured the same 200 B is +1.8%. Both readings are true, they are not
-interchangeable, and the shell one is the one to re-take on the ladder.
+bulk cost is stated as a **bound (≲10%)** rather than a figure. On the card-shaped
+boundary actually measured, 200 B is **+1.8%**. Against the **R=0 shell** — the
+figure validation.md's paper line is stated against, which the ladder puts at
+1,143 B, already over the 1 KB line — the same 200 B would be ≈ +17%. Both
+readings are true, they are not interchangeable, and the shell one had to be
+re-taken on the ladder's own instrument.
+
+**The shell re-take has since been done** (`rf2-2rtt6.58`, 2026-08-02, P0 bench,
+both arms in one session with a third run bracketing them —
+[the rows](studio/reads-per-boundary-heap-ladder.md#the-memo-wrapper-priced-on-this-rung-rf2-2rtt658)):
+
+| R=0 shell | no wrapper | wrapper | delta |
+|---|---:|---:|---:|
+| Hicasso, Reagent segment | 1,141 B [1,125–1,154] | **1,247 B** [1,240–1,257] | **+106 B, +9.3%** |
+| Hicasso, UIx segment | 1,138 B [1,119–1,159] | **1,236 B** [1,227–1,250] | **+100 B, +8.8%** |
+
+**≈ +100 B, not ≈ +200 B — the ≈ +17% projection above over-estimated it by
+about a factor of two.** The A/B ranges are disjoint, the donors do not move, and
+the per-read slope is **identical to the byte** with and without the wrapper
+(1,447 and 2,289 B/read), confirming this ruling's claim that the cost is
+constant in R and lands in the shell. The two instruments differ because the
+ladder mounts and *holds* while the page-chrome rig writes first, and an updated
+component retains an `alternate` fiber a held one does not — offered as the
+leading explanation, not as a counted result.
+
+**What remains open is the disposition, and it is the operator's.** Whether +9%
+on a shell **already 1.14× over** the paper line is "pushing retained heap
+meaningfully farther past the bar" is not answered by any text: the clause is
+unquantified here, in validation.md and in the heap-regime ruling, and the
+*Reopens* clause below is worded as **failing** the bar — which this shell did at
+1,141 B before any wrapper existed. The wrapper widens a pre-existing failure
+rather than causing one. Still one thing the measurement does **not** settle:
+whether the mount row carries a real few-per-cent regression, which needs
+`clock_run.cjs`'s adjudicated M1 row.
 
 **Rejected.** *Keep HD-006 and teach `React.memo` + `areEqual` as an opt-in
 pattern* — inverts the posture and ships a known 300× re-render cascade on the

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -688,7 +688,10 @@ fails its own paper line.**
   rung is **1,143 B** [1,132–1,156] against Reagent's 508 B and UIx's
   220 B. The one subscription hook is per *boundary*, so a boundary that
   reads nothing still pays it — which is the same structural choice that
-  wins the slope, seen from the other end.
+  wins the slope, seen from the other end. **HD-028's memo wrapper has
+  since been priced on this same rung and adds ≈ 100 B to it** — half the
+  projected figure, and it is the shell row rather than the slope that
+  moves: [below](#the-memo-wrapper-priced-on-this-rung-rf2-2rtt658).
 - **Nothing is retained after teardown**, in bytes *or* in objects, on
   every arm of every round. [Below](#the-survival-metric-in-objects-and-not-only-in-bytes).
 
@@ -1038,6 +1041,210 @@ those rows unpublished under the restated-bar posture (`rf2-b0tz5`), and
 the measurement being available is not the same act as the bar being
 restated. The numbers are here, on the studio page, for the operator to
 rule on.
+
+### The memo wrapper, priced on this rung (rf2-2rtt6.58)
+
+**Measured 2026-08-02** for `rf2-2rtt6.58`, to answer the one question
+[HD-028](../decisions.md#hd-028--value-equality-is-the-boundary-default) left
+open when it made a value-equality bail-out the boundary default: what its
+extra Fiber does to **this** rung — the R=0 shell, which is the figure
+[validation.md](../validation.md)'s paper line is stated against, and which
+was already over that line at 1,143 B before any wrapper existed.
+
+**The answer is ≈ +100 B, not the ≈ +200 B the card-shaped reading implied,
+and ≈ +9%, not ≈ +17%.** The projection was carried in three places — this
+bead, HD-028's cost paragraph, and
+[the page-chrome row](the-page-chrome-row-and-what-the-bail-out-costs.md#3-per-boundary-retained-heap--the-fiber-priced)
+— and all three are corrected against the measurement rather than left to
+stand beside it.
+
+#### Which instrument this had to be taken on, and the mis-citation it corrects
+
+`rf2-2rtt6.58` and the page-chrome row both name
+`implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs` as
+"the instrument that produced 1,143 B". **It is not, and it could not have
+been.** 1,143 B is published in [§6](#6-the-hicasso-candidate-rung--one-hook-plus-a-shared-index)
+above, whose own opening sentence names the **P0 bench** — `p0_run.cjs --only
+ladder` — "and not on the instrument §§1–4 were taken on". The freehand ladder
+carries `reagent,uix` and nothing else: it has no Hicasso arm, never reaches
+`re-frame.bench.hicasso.*`, and so cannot mount the wrapper at all. A run there
+would have produced no candidate row to compare. This re-take is therefore on
+`p0_run.cjs --only ladder`, and the six P0 instrument blobs below are
+**byte-identical to §6's published run 3** — same instrument, not merely the
+same kind of instrument.
+
+The mis-citation is traceable and is fixed at its source: the page-chrome row's
+§3 said "re-taken on the ladder rig itself (`reads_ladder_run.cjs`)", and the
+bead was filed from that sentence.
+
+#### Design: both arms in one session, and a third run to catch drift
+
+The two arms differ by **one line** at
+`arm1/runtime.cljs:1261` — `mint-view!` returning
+`(codec/memoize-boundary! (codec/mark-boundary! component))` against
+`(codec/mark-boundary! component)`. That is the wrapper's only call site in the
+repository, so removing it removes the wrapper and nothing else; the rest of the
+`rf2-2rtt6.52` branch, `codec.cljs` included, is identical across both arms.
+
+Runs are **A → B → A**, all three in one session on a box verified quiet before
+each. A1 and A2 bracket B in time, so if the box moved under the pair the two
+wrapper readings separate and say so. **They do not: A1 and A2 agree to 0 B on
+the Reagent segment and 5 B on the UIx segment.**
+
+**A first A/B pair was taken and is discarded, not reported.** An API outage
+killed the worker while its B arm was running; under `rf2-6t03c` a run that dies
+mid-way is discarded, and because the arms are paired *within* a session the
+surviving A arm is discarded with it rather than matched against a later B. Both
+arms below were re-taken afterwards.
+
+#### The rows
+
+1,200 boundaries; `y` is exclusive retained bytes per boundary above the
+same-round, same-segment floor. Witness stamp: **B = 1,200 · E = 0 · Q = 0**
+(R = 0 reads nothing, so the distinct-query regime is vacuous on this rung and
+the fan-out E/Q is undefined rather than 1). Six rounds per run; ranges are
+min–max across them. **0 unverified of 154 mounts** in each of the three runs.
+
+| R=0 shell | A1 *(wrapper)* | B *(no wrapper)* | A2 *(wrapper)* | delta |
+|---|---:|---:|---:|---:|
+| Hicasso, Reagent segment | **1,247** [1,240–1,257] | **1,141** [1,125–1,154] | **1,247** [1,239–1,267] | **+106 B, +9.3%** |
+| Hicasso, UIx segment | **1,236** [1,227–1,250] | **1,138** [1,119–1,159] | **1,241** [1,227–1,261] | **+100 B, +8.8%** |
+
+**The A and B ranges are disjoint on both segments** — an 85 B gap on the
+Reagent segment and 68 B on the UIx segment — so by this studio's own house rule
+the two arms are distinguishable, which is the thing a 100 B delta on a 1,140 B
+figure has to establish before it may be quoted.
+
+**B reproduces the published anchor.** 1,141 and 1,138 B against §6's 1,143 and
+1,134 B, every range overlapping. That is a second result riding along: the
+`rf2-2rtt6.52` branch's other changes — 112 lines of `codec.cljs` — are
+**shell-neutral**, and the whole of the shell movement is the wrapper.
+
+#### The wrapper is exactly R-independent, which is what the ruling predicted
+
+HD-028 priced the wrapper as a per-boundary constant, so it must land in the
+shell and leave the per-read slope alone. It does, to the byte:
+
+| marginal slope | A1 *(wrapper)* | B *(no wrapper)* | A2 *(wrapper)* |
+|---|---:|---:|---:|
+| Hicasso, Reagent segment | 1,447 [1,444–1,448] | 1,447 [1,444–1,448] | 1,447 [1,443–1,448] |
+| Hicasso, UIx segment | 2,289 [2,284–2,291] | 2,289 [2,284–2,291] | 2,289 [2,283–2,291] |
+
+**Identical medians across all three runs on both segments.** A wrapper that had
+leaked into the per-read term would have shown here, and it does not.
+
+#### The controls
+
+**Negative controls — the donors, which cannot see the toggle.** Neither Reagent
+nor UIx goes through `mint-view!`, so they must not move between arms. They do
+not, which is what licenses reading the Hicasso difference as the wrapper rather
+than as the box:
+
+| donor | A1 | B | A2 |
+|---|---:|---:|---:|
+| Reagent shell (R=0) | 506 [499–517] | 506 [501–513] | 507 [498–516] |
+| UIx shell (R=0) | 221 [217–226] | 223 [213–230] | 225 [217–232] |
+| Reagent per read | 947 [947–948] | 948 [947–948] | 948 [947–948] |
+| UIx per read | 2,981 [2,979–2,986] | 2,980 [2,978–2,985] | 2,981 [2,979–2,985] |
+
+**Positive control, predicted before any run.** The same dense array of 587,500
+unboxed doubles — **4,700,000 B, known in advance**. Read **4,697,434 B**
+(−0.055%), **4,697,603 B** (−0.051%) and **4,697,603 B** (−0.051%). The
+pre-registered prediction was ±0.05% and all three land marginally **outside**
+it, at 0.05–0.06% low; that is recorded rather than rounded into compliance. It
+is common-mode across the arms — the same offset on the wrapper run and the
+no-wrapper run — so it cannot manufacture a difference between them, and it sits
+three orders of magnitude inside the driver's own ±25% verdict slack.
+
+Arm-order guard **reportable**, structural read-back **every field answered**,
+and exit **0** on all three runs.
+
+#### Why this instrument reads half of what the card-shaped one did
+
+The page-chrome row measured **+195 and +220 B** per boundary for the same
+wrapper; this rung reads **+100 to +106 B**. Both reproduce on their own
+instrument, so the disagreement is real and belongs to the shapes, not to a bad
+run. **The leading candidate explanation is React's double buffering, and it is
+offered as a hypothesis because this run did not count fibers:** the ladder
+mounts an arm and *holds* it with no writes, so only the current tree exists and
+the wrapper costs one extra fiber; the page-chrome instrument performs its four
+write ops before reading, and an updated component retains an `alternate` fiber
+beside its current one, so a wrapper position there can be holding two. Roughly
+2× is what that predicts, and roughly 2× is what the two instruments differ by.
+**Testing it needs a fiber count, which is filed rather than claimed.**
+
+The practical reading is the one the ruling asked for: **a Fiber is not a fixed
+tax, and the shape it sits on decides what it costs.** Quoting either
+instrument's figure onto the other's shape is the error this rung exists to
+prevent.
+
+#### What this settles, and what it hands the operator
+
+**Settles.** The wrapper costs **≈ +100 B** on the R=0 shell — **+9%**, moving it
+from **1,141 B to 1,247 B**. The ≈ +17% / ≈ 1,343 B projection carried by the
+bead and by HD-028 was an over-estimate by about a factor of two. The delta is
+above the **~75 B** shape sensitivity [validation.md](../validation.md) names for
+this line, so it is not shape noise — though not by a wide margin, and that is
+worth saying plainly.
+
+**Does not settle, deliberately.** Whether ≈ +9% on a figure **already 1.14×
+over** the 1 KB paper line is "pushing retained heap meaningfully farther past
+the bar" in HD-028's sense. **That clause is not quantified anywhere** — not in
+HD-028, not in validation.md, not in the heap-regime ruling — and HD-028's
+reopen clause is worded as *failing* the bar, which this shell already did at
+1,141 B without any wrapper. The wrapper cannot cause a failure that pre-dates
+it; what it does is widen one. Whether that widening is acceptable for a
+**default** is the operator's call under the restated-bar posture (`rf2-b0tz5`),
+exactly as §6's own shell row was left to be — and this section, like §6, writes
+**no candidate-bar row into validation.md**.
+
+#### Provenance
+
+Whole-tree anchor **`4a33c61e1c`** on `worker/cascade-2rtt6-52`. That branch was
+**conflicting with `main` and deliberately not rebased while these rows were
+taken**, so the blobs are what to trust — and they are what will prove the
+measured tree and the merged tree agree once it is rebased.
+
+The one line under test, and the only thing that differs between the arms:
+
+| arm | `arm1/runtime.cljs` blob |
+|---|---|
+| **A1, A2** — wrapper present | `a6d6c55a5885689cb62dcf444da2e58562d53d23` |
+| **B** — wrapper absent | `5b4f4e065f689f955a8750c9533c75650a3077a3` |
+
+`front/codec.cljs` is `12284ef8f47d99e909e4ca40326310262d6f7c6a` in **all three**
+runs — the wrapper's definition is present throughout and merely goes uncalled
+in B. The remaining Arm 1 blobs are unmoved from §6: `arm1/mount.cljs`
+`4653e168d08dcd91386df4e78b3cd5b0b5cf9267`, `arm1/lang.clj`
+`0151ddafb4aefe6a6a2403a349187ae5b28cc537`, `front/sub_index.cljs`
+`394927d6f6493ea651daac84b9f140cd54f8f6c1`.
+
+The instrument, **byte-identical to §6's run 3**, all under
+`implementation/core/test/re_frame/bench/`:
+
+| file | blob |
+|---|---|
+| `p0_run.cjs` | `4718aaead7035ae9a6cf74a89ef13141803742cc` |
+| `p0_heap.cljs` | `34c9210dfe39d3c7ee153c724fa63cf8e65dd1e1` |
+| `p0_hicasso.cljs` | `f2440e307423665048dfe227b14baaf4ffc8ac89` |
+| `p0_reagent.cljs` | `b1f5ec9223536557403f6ae9415ab42ac26843b0` |
+| `p0_uix.cljs` | `deec8976010c17e4d2c6e8dc3499678997acd2c0` |
+| `p0_fixture.cljc` | `867ad5838ab64ac6aa7afbf8317d8fb305f53619` |
+
+Reproduce — the wrapper arm as it stands, the no-wrapper arm by reverting the one
+line above:
+
+```
+node implementation/core/test/re_frame/bench/p0_run.cjs --only ladder
+```
+
+**Conditions.** Three runs, ~3.5 minutes each, 2026-08-02 13:23–13:35 AUSEST, on
+a box checked before **each** run for live bench, browser and shadow-cljs
+processes — no process consumed more than 0.5 CPU-seconds over a 5-second sample
+apart from the checking shell itself and an idle browser tab. React **19.2.0**,
+Reagent **2.0.1**, UIx **1.4.4**, `:advanced` with `goog.DEBUG false`, headless
+Chromium via Playwright, Windows 11. One machine; no claim here is evidence about
+a second box.
 
 ### The slope went stale before this section merged, and the landing that moved it (rf2-2rtt6.60)
 

--- a/docs/design/hicasso/studio/the-page-chrome-row-and-what-the-bail-out-costs.md
+++ b/docs/design/hicasso/studio/the-page-chrome-row-and-what-the-bail-out-costs.md
@@ -116,15 +116,32 @@ be compared to the 1 KB paper-fail line.
 - Against **this** boundary — a real card — the wrapper is **+1.8%**.
 - Against the **R=0 shell anchor** the
   [reads ladder](reads-per-boundary-heap-ladder.md) measured at **1,143 B**,
-  +200 B is **≈ +17%**, moving it to ≈ 1,343 B on a figure that was **already over**
-  the 1 KB paper line.
+  the same +200 B would be ≈ +17%, on a figure that was **already over** the
+  1 KB paper line.
 
 The second reading is the one an operator might call "meaningfully farther past
-the bar", and it is stated here rather than left for a ladder to find. **The
-decisive number is the R=0 shell delta re-taken on the ladder rig itself**
-(`reads_ladder_run.cjs`), which is a heavier, separately-sequenced instrument;
-this page does not have it, and does not pretend the card-shaped +1.8% substitutes
+the bar", and it is stated here rather than left for a ladder to find. **This
+page does not have it** and does not pretend the card-shaped +1.8% substitutes
 for it.
+
+> **Re-taken 2026-08-02 (`rf2-2rtt6.58`) — and the ≈ +17% projection above was
+> an over-estimate by about a factor of two.** On the R=0 rung the wrapper costs
+> **≈ +100 B, not ≈ +200 B**: **+9%**, moving the shell from 1,141 B to
+> **1,247 B** rather than to ≈ 1,343 B. The A/B ranges are disjoint and the
+> per-read slope is unmoved to the byte. The rows are on
+> [the ladder's own page](reads-per-boundary-heap-ladder.md#the-memo-wrapper-priced-on-this-rung-rf2-2rtt658).
+>
+> **Two corrections to this section, recorded rather than silently edited.**
+> First, the ≈ +17% figure: it assumed the card-shaped +200 B transferred
+> unchanged to a boundary that reads nothing, and it does not — this instrument
+> mounts and writes, the ladder mounts and holds, and an updated component
+> retains an `alternate` fiber that a held one does not. Second, this paragraph
+> originally named **`reads_ladder_run.cjs`** as the rig to re-take it on. That
+> is the wrong instrument: the freehand ladder carries only `reagent,uix`, has
+> no Hicasso arm, and could not have produced the 1,143 B figure. That number
+> comes from the **P0 bench** — `p0_run.cjs --only ladder` — which is where the
+> re-take was taken, on instrument blobs byte-identical to the published run.
+> The bead `rf2-2rtt6.58` was filed from this sentence and inherited its error.
 
 ## 4. What this page does and does not settle
 
@@ -133,6 +150,10 @@ a production build, with the three other write shapes unchanged. The wrapper's
 retained cost is a reproducible ~200 B per boundary.
 
 **Does not settle.** Whether the mount row carries a real few-per-cent regression
-(needs `clock_run.cjs`'s M1 row and its adjudicators), and what +200 B does to the
-**R=0 shell** figure against the paper line (needs the reads ladder). Both are
-filed rather than asserted.
+(needs `clock_run.cjs`'s M1 row and its adjudicators). ~~And what +200 B does to
+the **R=0 shell** figure against the paper line.~~ **That second one is now
+settled** — `rf2-2rtt6.58` re-took the shell on the P0 bench and reads
+**+100 B / +9%**, moving it from 1,141 B to 1,247 B; see the note in
+[§3](#what-200-b-means-depends-on-the-boundary-shape-and-both-readings-are-true).
+Whether that is acceptable for a **default** on a line the shell was already over
+remains the operator's call.


### PR DESCRIPTION
**Re-raises #7376, closed by GitHub's own auto-close.** That PR targeted
`worker/cascade-2rtt6-52` (two of its three files existed only there); when
#7375 merged the cascade branch was deleted in routine cleanup and GitHub
auto-closed #7376 with it. Its base is gone, so it cannot be reopened. Nothing
was lost — the branch and its commit survive at `0973ba1b14` — but the
measurement an operator ruling already rests on was not on `main`. This PR
lands it, rebased.

## What this answers

HD-028 (renumbered from HD-026 during its own rebase onto `main`) made the
value-equality bail-out the boundary **default** conditional on what its extra
Fiber does to retained heap. The cascade PR priced that Fiber on a
**card-shaped** boundary (~11 KB), where it reads **+1.8%**. The clause is
judged on the **R=0 boundary shell** — the figure `validation.md`'s paper line
is stated against, and one the candidate was **already over** at 1,143 B. The
projection carried by the bead, by HD-028 and by the page-chrome row was that
the same ~200 B would be **≈ +17%** there.

**Measured, it is about half that.**

| R=0 shell | no wrapper | wrapper | delta |
|---|---:|---:|---:|
| Hicasso, Reagent segment | 1,141 B [1,125–1,154] | **1,247 B** [1,240–1,257] | **+106 B, +9.3%** |
| Hicasso, UIx segment | 1,138 B [1,119–1,159] | **1,236 B** [1,227–1,250] | **+100 B, +8.8%** |

## Why the number is trustworthy

- **Both arms in one session**, `A → B → A`, box verified quiet before **each**
  run. A1 and A2 agree to **0 B** (Reagent seg) and **5 B** (UIx seg) — the box
  did not move under the pair.
- **The A/B ranges are disjoint** on both segments (85 B and 68 B gaps), so the
  arms are distinguishable by this studio's own house rule.
- **The arms differ by one line** — `mint-view!`'s single call to
  `memoize-boundary!`, the wrapper's only call site in the repo.
- **Negative controls flat.** Reagent and UIx do not go through `mint-view!` and
  do not move: shells 506/506/507 and 221/223/225, slopes 947/948/948 and
  2,981/2,980/2,981.
- **The slope is identical to the byte** with and without the wrapper (1,447 and
  2,289 B/read), confirming HD-028's own claim that the cost is constant in R and
  lands wholly in the shell.
- **Positive control predicted before the runs**: 587,500 doubles = 4,700,000 B.
  Read 0.051–0.055% low. The pre-registered band was ±0.05%, so all three land
  *marginally outside* it — stated rather than rounded into compliance. It is
  common-mode across arms and cannot manufacture a difference between them.
- 0 unverified of 154 mounts, structural read-back complete, arm-order guard
  **reportable**, **exit 0** on all three runs.

## Two results riding along

1. **The no-wrapper arm reproduces the published anchor** — 1,141 against §6's
   1,143 B — so the cascade branch's other 112 lines of `codec.cljs` are
   **shell-neutral**.
2. **The two instruments genuinely disagree by ~2×.** The ladder mounts and
   *holds*; the page-chrome rig writes first, and an updated component retains an
   `alternate` fiber a held one does not. Offered as the leading explanation,
   **not** as a counted result — testing it needs a fiber count, filed not claimed.

## An instrument mis-citation, corrected at its source

The bead and the page-chrome row both named
`implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs` as
"the instrument that produced 1,143 B". **It is not.** That file carries only
`reagent,uix`, has no Hicasso arm, never reaches `re-frame.bench.hicasso.*`, and
could not have mounted the wrapper — a run there would have produced no candidate
row at all. 1,143 B comes from the **P0 bench**, `p0_run.cjs --only ladder`, which
§6's own opening sentence says explicitly. This re-take was taken there, on six
instrument blobs **byte-identical to §6's published run 3**. The page-chrome
sentence the bead was filed from is fixed.

## What this does NOT decide

**The disposition is the operator's.** Whether **+9% on a shell already 1.14×
over** the paper line is "pushing retained heap meaningfully farther past the
bar" is **not answered by any text**: the clause is unquantified in HD-028, in
`validation.md` and in the heap-regime ruling. HD-028's *Reopens* clause is
worded as **failing** the bar — which this shell did at **1,141 B before any
wrapper existed**. The wrapper widens a pre-existing failure rather than causing
one. **No candidate-bar row is written into `validation.md`**, matching §6's own
posture under `rf2-b0tz5`.

## What the rebase changed

Main moved substantially since these rows were taken: HD-028 itself landed
(renumbered from HD-026 during its own rebase — HD-026 is now `preventDefault`,
HD-027 is `route-link`), plus the walk optimisation (`rf2-2rtt6.63`), the cold-read
change, presence/boundary frame bindings, the IME harness, `route-link`, and the
tier-1 roster.

- **One whole commit dropped as a duplicate.** `2158869e2b` ("HD-006 amended")
  reduced to a no-op against the rebased tree — every file it touched (including
  `decisions.md`'s HD-006/HD-028 text) is already on `main`, landed via the
  cascade's own history under the corrected numbering. It was skipped rather than
  committed empty.
- **Two files that existed only on the cascade branch now exist on `main`** (via
  #7375), as expected. The diff reduces to this measurement's own additions.
- **One genuine content conflict**, in `reads-per-boundary-heap-ladder.md`: this
  PR's new subsection ("The memo wrapper, priced on this rung", `rf2-2rtt6.58`)
  and an already-landed subsection ("The slope went stale...", `rf2-2rtt6.60`)
  were both inserted at the same point. They are not duplicates — the `.60`
  section explicitly cites "the `rf2-2rtt6.58` session" and computes deltas
  against this section's own rows, so **the `.58` section now sits first**, with
  `.60` immediately after it. Both are kept, whole, in that order.
- **Every `HD-026` reference in the touched files that meant "value equality is
  the boundary default" was updated to `HD-028`**, per-site, including the
  cross-reference link's anchor. `HD-026` mentions that legitimately mean the
  `preventDefault` decision (elsewhere in `decisions.md`) were left alone.
  `git grep -n "HD-02"` after the rebase turned up nothing further to fix.

## Provenance — one claim the rebase invalidated, stated rather than edited

The `.58` section's own Provenance sub-section says the tree anchor's blobs
"are what will prove the measured tree and the merged tree agree once it is
rebased." **They do not, and that text is left exactly as measured.** The
walk-optimisation landing (`02a440a4d1`, `rf2-2rtt6.63`, merged after these rows
were taken and after #7375) rewrote both files the arms differ by:

| file | claimed blob | current `main` blob |
|---|---|---|
| `arm1/runtime.cljs` (wrapper present) | `a6d6c55a5885689cb62dcf444da2e58562d53d23` | `0cd4311c228fd26e66a6c1639dcc3d969dce8950` |
| `front/codec.cljs` | `12284ef8f47d99e909e4ca40326310262d6f7c6a` | `874bd699aa4015fec847d0b4cc699b299e9ca0bd` |

The other nine blobs the section cites (the three remaining Arm 1 files and the
six P0 instrument files) are still byte-identical on `main` today — only these
two moved, both under the walk-optimisation commit, neither touching
`memoize-boundary!`'s call site (`arm1/runtime.cljs:1387` still reads
`(codec/memoize-boundary! (codec/mark-boundary! component))`). The measured
numbers stand as a historical record either way; the forward-looking blob-match
promise in the provenance paragraph is what no longer holds, and it is reported
here rather than quietly re-hashed.

## Discarded, not reported

A first A/B pair was taken and thrown away: an API outage killed the worker while
its B arm ran. Under `rf2-6t03c` a run that dies mid-way is discarded, and because
these arms pair *within* a session the surviving A arm went with it rather than
being matched to a later B. Both logs are kept unedited so the discard is
auditable. Nothing from them is quoted.

## Quality gates

- `python scripts/check_doc_slugs.py` over the whole corpus — **exit 0**. This is
  the covering gate for `docs/design/**`; `mkdocs --strict` deliberately excludes
  that tree (`exclude_docs` in `mkdocs.yml`) and is not cited as a substitute.
- `scripts/test-fast-pr.sh` — **exit 0**, `PASS fast PR spine`. Classified
  `docs=true jvm=false node=false`; the diff is docs-only so the JVM tier
  (including the box's known `implementation/core` hang) never armed. One earlier
  run hit a transient Windows file-lock `PermissionError` inside the spine's own
  `mkdocs --strict` step (unrelated fixture path the diff never touches); an
  isolated `python -m mkdocs build --strict` retry passed clean, and a full
  re-run of the spine afterwards passed clean end to end — both exit codes
  captured directly from the script, not a wrapper.
- **Table column counts verified by hand** (script-assisted): every table across
  all three touched files is internally consistent with its own header.
- **Anchors verified**: `check_doc_slugs.py` covers all link targets and heading
  anchors in this tree, including the reordered `.58`/`.60` subsections and the
  `HD-028` cross-reference.
- Nothing here touches JVM/CLJS/node surfaces, so those tiers are correctly
  skipped by the spine; CI's own matrix (browser lanes, Xray, mcp-conformance,
  tool JVM suites) is unaffected by a docs-only diff and is not delegated to here.
