### PR TITLE
docs(hicasso): the memo default, taught as it ships (rf2-3jw04)

### DIFF
--- a/docs/design/hicasso/architecture.md
+++ b/docs/design/hicasso/architecture.md
@@ -185,12 +185,20 @@ node as `defaultValue`, which React maintains there itself. The matrix, the
 two implementations UIx chooses between, and the price are on
 [the studio page](studio/controlled-input-two-implementations.md).
 
-## Memoization (HD-006)
+## Memoization (HD-028, amending HD-006)
 
-No default `=`/argv memoization: React semantics stand (a child may render with
-its parent); narrow updates come from boundary placement; `React.memo` remains an
-opt-in escape. Revisit only if the keyed-row or broad witnesses demand it — do not
-recreate Reagent's equality semantics from taste.
+A value-equality bail-out is the boundary **default**: every minted head carries
+one stable internal `React.memo` wrapper (`codec/memoize-boundary!`) comparing
+the whole `rfProps` value with CLJS `=`, fail-open on a throw. It stops the
+cascade HD-006 assumed boundary placement alone would prevent — a page-chrome
+write re-ran all 300 of 300 card boundaries beneath it with every card's props
+value-equal; it now re-runs 0. `useContext` and `useSyncExternalStore`
+invalidation still outrank it — React tests `checkScheduledUpdateOrContext`
+*before* it consults the comparator, so a boundary whose own reads moved
+re-renders regardless of what its props compare equal to. There is no public
+`:memo false` opt-out in v1; a boundary that wants parent-driven re-runs takes an
+explicit changing revision prop instead. Full ruling, prior-art audit and priced
+cost: [HD-028](decisions.md#hd-028--value-equality-is-the-boundary-default).
 
 ## Code residence (HD-017)
 

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -105,25 +105,36 @@ React StrictMode runs your body twice in development. That is fine — bodies ar
 by contract. Anything that would break under a second run (mutating a captured atom,
 kicking off a fetch, counting renders) does not belong in a body.
 
-### There is no automatic memoization
+### Boundaries memoize by default
 
-React semantics stand: a child may render because its parent did. Hicasso adds **no
-default `=` or argv comparison** (HD-006).
+A value-equality bail-out is the boundary **default** (HD-028, amending HD-006):
+every minted head carries one stable internal memo wrapper comparing the whole
+props map with CLJS `=`. If a boundary's props compare equal to last render, its
+body does not run — even though its parent's did.
 
-If you are coming from Reagent this is the change most likely to surprise you.
-Reagent compares argv and skips; Hicasso does not, because every default comparison
-is a cost every render pays whether it helps or not. Narrow updates come from
-**where you put your boundaries**, and `React.memo` is available as an explicit
-opt-out when you have measured a reason.
+Two things still outrank the bail-out, and both are the boundary's **own**
+invalidation. A subscription or context read that boundary made itself always
+wins: React checks for a boundary's own pending update *before* it ever asks the
+comparator, so a boundary whose reads moved re-renders regardless of what its
+props say. And a function-valued prop compares unequal by identity, deliberately
+— a freshly allocated closure is never `=` to the last one, so an inline handler
+defeats the bail-out every time it is passed fresh.
+
+If you are coming from Reagent this should feel familiar rather than surprising —
+Reagent has compared argv and skipped for a decade, and this is the same shape.
+There is no public opt-out in v1: a boundary that genuinely wants to re-run every
+time its parent does takes an explicit changing revision prop, not a `:memo
+false` switch.
 
 One corollary is worth stating outright, because the opposite is the thing people
-worry about. Reading a subscription high in the tree and passing the value down as a
-prop does **not** lose an update. The boundary that reads is the boundary that
-invalidates; it re-renders with the new value, passes it down, and — precisely
-because nothing is memoized by default — every descendant re-renders with it. The
-value arrives. What you have bought yourself is invalidation that is **too coarse**,
-never invalidation that is missing. Moving the read down is a granularity fix, not a
-correctness fix, and if you go looking for a lost update you will not find one.
+worry about. Reading a subscription high in the tree and passing the value down as
+a prop does **not** lose an update: the boundary that reads is the boundary that
+invalidates, and every boundary the changed value actually reaches receives unequal
+props at that hop, so the default bail-out never applies to it — the value arrives.
+What the default buys you, beyond that chain, is that a boundary the value does
+**not** reach skips instead of re-rendering for nothing. Moving the read down is
+still a granularity fix, not a correctness fix, and if you go looking for a lost
+update you will not find one.
 
 ## How `sub` works, in the four sentences that matter
 
@@ -171,9 +182,10 @@ it does not.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| A child re-renders whenever its parent does | Expected — there is no default memoization (HD-006) | Move the boundary, or apply `React.memo` where you measured a reason |
+| A boundary doesn't re-render even though something on screen should have changed | Its props still compare `=` to last render and it made no read of its own that moved — the default bail-out (HD-028) is doing exactly what it's for | Read the changing value with `sub` inside the boundary that displays it, or thread it down as a prop so the value actually differs there |
+| A boundary re-renders every time though its props look unchanged | A prop carries reference identity rather than value identity — an inline function literal, a JS object, a freshly re-sorted seq — so `=` correctly says unequal | Hoist the function or stabilize the value; two structurally equal persistent values are `=`, a fresh closure or JS object is not |
 | One cell changes and 300 boundaries re-render | The read lives too high in the tree | Push the read down into the boundary that displays it |
-| One value changes and a whole subtree re-renders with it | The value is read in an ancestor and passed down as a prop. Nothing is *lost* — the reading ancestor re-renders with the new value and, there being no default memoization, so does everything under it. Coarse invalidation, not missed invalidation | Read at the point of use, so the boundary that displays the value is the boundary that invalidates |
+| One value changes and a whole subtree re-renders with it | The value is read in an ancestor and passed down as a prop. Nothing is *lost* — the reading ancestor re-renders with the new value, and every boundary the value actually reaches has unequal props at that hop, so the default bail-out (HD-028) does not catch it there. Coarse invalidation, not missed invalidation | Read at the point of use, so the boundary that displays the value is the boundary that invalidates |
 | A read after the render throws, naming the query | A handler closure, a stashed lazy seq, or a `delay` deferred a `sub` past the render | Read during the render and close over the value; the loud error is the alternative to a silently frozen edge |
 | Index thrash, subscriptions constantly re-created | Query args that are not *value*-stable — a re-sorted seq, a folded-in timestamp, a JS object or a function | Allocation is fine; two equal persistent values are one key. Make the args equal under `=` between renders |
 | A body's side effect fires twice | StrictMode double-invoke | Bodies are pure; move the effect out |

--- a/docs/design/hicasso/draft-guide/06-theming.md
+++ b/docs/design/hicasso/draft-guide/06-theming.md
@@ -124,21 +124,23 @@ The obvious one: one view reads `:theme/current` and puts it on its own element.
 ```
 
 **Its true cost.** The boundary that reads the theme re-renders on every switch —
-that much is certain and it is one boundary. What is *not* certain is whether the
-subtree comes with it. If `theme-scope` takes its content through `(:children props)`,
-those children are elements its parent already created, and the parent did not
-re-render (it does not read the theme), so React's ordinary bailout on referentially
-identical children should skip them. If instead the scope view renders its content
-directly, the whole app re-renders on a theme switch, because
-[there is no default memoization](02-views-and-reads.md).
+that much is certain, and it is one boundary. What happens below it now turns on
+the [default value-equality bail-out](02-views-and-reads.md#boundaries-memoize-by-default)
+(HD-028) rather than on how `theme-scope` gets its content. `app` is a boundary
+either way — handed down as `children` or minted directly inside `theme-scope`'s
+own body — and its props are unaffected by the theme, so they compare `=` at every
+re-render and its own memo wrapper bails regardless of which style you write. The
+way to lose the bail-out is different from either style above: splice `app`'s
+markup in as a plain call instead of `[app {}]`. A plain call has no boundary of
+its own to hold a memo wrapper, so it re-runs with `theme-scope` every time —
+independent of which bridge you chose.
 
-That first "should" is doing real work and this guide will not launder it. Whether an
-*interpreted* hiccup runtime preserves element identity for children a boundary
-merely passes through is a runtime property nobody has measured. The ABI says
-children arrive realized and an existing React element is a legal child anywhere; it
-does not say identity survives a re-render of the receiving boundary. **If it does,
-bridge A costs one boundary. If it does not, bridge A costs the app, and "zero React
-work" is off by the size of your tree.**
+That leaves one open question, not two. Whether an *interpreted* hiccup runtime
+preserves element identity for children a boundary merely passes through is still
+unmeasured, but it now decides only how *cheap* the skip is: a referentially
+identical child never reaches the comparator; a freshly minted one still reaches
+it and still bails, one step later. Neither path costs the app, as long as `app`
+stays a boundary.
 
 ### Bridge B — an effect writes the attribute
 
@@ -178,14 +180,16 @@ bridge.
 **Which bridge is the taught one is not settled**, and this guide is not the place to
 settle it — naming one would be designing the missing half rather than reporting it.
 The shape of the choice is clear enough to state, though: bridge A keeps the DOM
-derived from state at a render cost nobody has measured; bridge B has no render cost
-and gives up the derivation. It is the ordinary trade between rendering a fact and
-imperatively asserting it, and it is a design decision with a witness attached.
+derived from state at the cost of the one reading boundary (HD-028's default
+bail-out covers the rest, per [Bridge A](#bridge-a--a-scope-view-reads-the-choice)
+above); bridge B has no render cost and gives up the derivation. It is the ordinary
+trade between rendering a fact and imperatively asserting it, and it is a design
+decision with a witness attached.
 
-What would settle it: a measurement of bridge A on the multi-frame witness — does a
-theme flip re-render one boundary or the tree — and a ruling on whether the theme
-attribute is per-root or per-document. The first is a P1 instrument. The second is a
-sentence somebody has to write.
+What would settle it: confirmation on the multi-frame witness that bridge A's cost
+holds at one boundary in practice, and a ruling on whether the theme attribute is
+per-root or per-document. The first is a P1 instrument. The second is a sentence
+somebody has to write.
 
 ## The two laws
 
@@ -252,7 +256,7 @@ This table names mechanisms rather than error ids.
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | The theme keyword changes in app-db and nothing on screen changes | No bridge is wired — app-db holds the choice, and the cascade keys off a DOM attribute | Wire one of the two bridges above; the event alone does nothing to the document |
-| Theme switch re-renders the whole app | Bridge A, with the themed content rendered directly by the scope view rather than passed through as children — so there is no bailout and no memoization (HD-006) to stop it | Pass the content through as children, or use bridge B |
+| Theme switch re-renders the whole app | Bridge A, with the themed content spliced in as a plain call rather than a `[boundary …]` vector — a plain call has no boundary of its own for HD-028's default bail-out to attach to | Put the content behind a boundary (children or a direct `[app {}]`, either works), or use bridge B |
 | A time-travel rewind shows the old theme | Bridge B — the attribute was asserted by an effect, so it is not derived from the state you rewound | Expected under bridge B; it is the price named above |
 | A controlled input's value gets clobbered by a theme | Should be impossible — law (a) | A runtime bug, not a usage error |
 | A part override doesn't take effect | Merge order: instance props beat app theme beat base | Check which layer you set it in |
@@ -274,7 +278,7 @@ order to remember, in exchange for a flexibility nobody is going to use.
 | Question | Status |
 |---|---|
 | **How the app-db choice reaches the `data-theme` scope** | **Unresolved, and the largest hole on this page.** HD-010 rules the choice into app-db and rules the switch to be one attribute flip, and never joins them. [Layer 3 and the DOM](#layer-3-and-the-dom) names both candidate bridges and prices them; picking one is a design decision, not a writing decision |
-| Whether a boundary that only passes children through re-renders them | **Not addressed**, and bridge A's whole cost turns on it. The ABI says children arrive realized; it does not say element identity survives a re-render of the receiving boundary. A P1 instrument, not a paper question |
+| Whether a boundary that only passes children through preserves their element identity | **Not addressed**, but HD-028's default bail-out now covers bridge A's cost either way — this decides only whether the skip is free (identity-preserved) or a cheap `=` check (identity not preserved), not whether it happens |
 | Whether the theme attribute is per-root or per-document | **Not addressed.** Layer 3 promises frame isolation; a document-level attribute does not have it |
 | How a control declares a part | **Not addressed.** "Controls emit keyword-tagged parts" is the whole of the record; the attribute or macro that does it is unnamed |
 | How an app installs a theme | **Not addressed.** The merge order `base < app-theme < instance-props` is ruled; the mechanism that supplies the app-theme layer is not. Since there is no context, it is presumably passed or registered — the record does not say which |

--- a/docs/design/hicasso/studio/our-walk-against-reagents.md
+++ b/docs/design/hicasso/studio/our-walk-against-reagents.md
@@ -243,7 +243,8 @@ cheaper.
   rather than revisiting it. A mount is the *first* walk, so a value-keyed
   element cache only pays on subtrees repeated within one page (under 12% of
   this one) — and now there is no gap for it to close: our walk reads below
-  stock Reagent's. HD-006's no-element-memoisation line stands untouched.
+  stock Reagent's. HD-004's anti-fence on element/skeleton caching stands
+  untouched (HD-028 declines the same for boundary-level identity caching too).
 - **Forking `reagent2.impl.template`.** Needs a ruling and is not sought. The
   measurement makes it look backwards anyway: the donor's walk is 1.73–1.90×
   stock Reagent's and 1.8× ours.

--- a/docs/design/hicasso/studio/the-interpreter-walk-profiled-and-cheapened.md
+++ b/docs/design/hicasso/studio/the-interpreter-walk-profiled-and-cheapened.md
@@ -145,8 +145,8 @@ props object per element per render stands.
   not share handlers), and the cache would grow with distinct data for the
   life of the build. The profile prices the whole prop pipeline at 67.5%
   reachable *without* any of that; the skeleton cache buys the remainder's
-  minority at an unbounded-memory cost. HD-006's no-element-memoisation
-  line therefore stands untouched.
+  minority at an unbounded-memory cost. HD-004's anti-fence on element/skeleton
+  caching therefore stands untouched.
 - **Amortisation across commits** (the bead's direction 3): the memo
   wrapper (HD-028, PR #7375) stops child re-walks on re-render; what
   mount prices is the first walk, which no cross-commit amortisation can


### PR DESCRIPTION
## Summary

HD-028 (PR #7375) made a value-equality bail-out the boundary DEFAULT,
amending HD-006's "no default memoization" position — but the downstream
prose was never reconciled. `architecture.md` and the draft guide kept
teaching the overturned position as current, including in a
troubleshooting row that told a reader hitting a re-render question the
opposite of what the runtime does (rf2-3jw04).

**The shipped semantics, as established from HD-028 and the implementation
before writing a word of prose:**

- Every minted boundary carries one stable internal `React.memo` wrapper
  (`codec/memoize-boundary!`) comparing the whole `rfProps` value with
  CLJS `=`, fail-open on a comparator throw.
- A boundary's own subscription/context invalidation always outranks the
  bail-out: React tests `checkScheduledUpdateOrContext` *before* it
  consults the comparator, so a boundary whose own reads moved re-renders
  regardless of what its props compare equal to.
- Function-valued props compare unequal by identity, deliberately — a
  freshly allocated closure defeats the bail-out every time it's passed
  fresh.
- No public `:memo false` opt-out in v1; a boundary that wants
  parent-driven re-runs takes an explicit changing revision prop instead.

**Corrected in place, no annotate-beside:**

- `docs/design/hicasso/architecture.md` — the "Memoization (HD-006)"
  section rewritten as "Memoization (HD-028, amending HD-006)": the
  shipped wrapper, its comparator, what still outranks it.
- `docs/design/hicasso/draft-guide/02-views-and-reads.md` — "There is no
  automatic memoization" replaced with "Boundaries memoize by default";
  the Reagent-surprise framing flipped (this now matches Reagent's
  decade-old default rather than departing from it); the "every
  descendant re-renders" corollary corrected to "every boundary the value
  actually reaches re-renders, and one that doesn't skips instead". The
  troubleshooting row that told readers "expected — there is no default
  memoization" is replaced with two rows covering both directions of
  surprise: a boundary that doesn't re-render (bail-out working as
  designed — check for an own read or a threaded prop) and a boundary
  that re-renders every time despite unchanged-looking props (a
  reference-typed prop — an inline closure, a JS object, a freshly
  re-sorted seq).
- `docs/design/hicasso/draft-guide/06-theming.md` — Bridge A's cost
  analysis no longer claims a directly-rendered theme subtree costs the
  whole app: under the default memo, `app` bails whether it arrives as
  `children` or is minted directly inside `theme-scope`'s body, as long
  as it stays a `[boundary]` vector. The real remaining risk is inlining
  the content as a plain call (no boundary, no wrapper to attach to) —
  that's what the troubleshooting row and the "Not settled yet" row now
  say. The unmeasured question about interpreted-hiccup element identity
  for pass-through children is narrowed from "does bridge A cost the
  app" to "how cheap is the skip" (free vs. one `=` check) — still
  unaddressed, now lower-stakes.
- Two studio pages (`our-walk-against-reagents.md`,
  `the-interpreter-walk-profiled-and-cheapened.md`) cited "HD-006's
  no-element-memoisation line" as still standing. HD-006 itself is
  amended, so the citation now points to HD-004's still-standing
  anti-fence on element/skeleton caching (which HD-028(e) independently
  declines extending to boundary-level identity caching).

**Sweep.** Grepped the whole `docs/design/hicasso/` tree for
`memoiz|HD-006|argv|bail-?out|comparator|React\.memo|child may render|
boundary placement|narrow updates come from`. Beyond the five files above:
`authoring.md:147` and `decisions.md:686` mention `React.memo` in the
unrelated HD-011 raw-fn/handler-identity context — not stale.
`draft-guide/07-ephemeral-state.md:18` names "argv memoization" as part of
Reagent's *deleted* reaction-engine machinery, not a claim about Hicasso's
own default — not stale. `decisions.md`'s HD-006 entry itself is already
correctly annotated **AMENDED** with a callout pointing to HD-028 — left
untouched, it's the historical record of the overturned position.
`studio/the-page-chrome-row-and-what-the-bail-out-costs.md:12` ("If the
Fiber fails the gate, HD-006 stands") is the forward-looking reopen
condition, correctly phrased — not stale. Every other studio-page
`memoiz`/comparator hit (`the-cold-read-mount-term.md`,
`the-interpreter-walk-profiled-and-cheapened.md`'s other mentions,
`README.md`, etc.) already describes the shipped `memoize-boundary!`
wrapper correctly.

**Length.** Net +25 lines across 5 files (77 insertions / 52 deletions) —
mostly the troubleshooting table gaining one row to cover both directions
of the bail-out surprise, and the theming page's cost analysis needing a
few more sentences to state the corrected (and simpler) conclusion.

## Quality gates

- `python scripts/check_doc_slugs.py` — the covering gate for
  `docs/design/**` (mkdocs `--strict` excludes this tree; not cited as a
  gate here, per the tree's own exclusion). Exit 0.
- `scripts/test-fast-pr.sh` — diff is docs-only; classified `docs=true
  jvm=false node=false` by `--plan`, so only the always-on checks + docs
  tier (including `mkdocs --strict` on the tiers it does cover) ran.
  `PASS fast PR spine`, exit 0. Neither of the box's known flaky
  conditions (JVM `implementation/core` hang, mkdocs Windows
  `PermissionError`) armed, since the JVM tier didn't run at all.
- Table column counts and anchors (`#boundaries-memoize-by-default`,
  `#bridge-a--a-scope-view-reads-the-choice`) verified by hand.

## Test plan

- [x] `python scripts/check_doc_slugs.py` — exit 0
- [x] `scripts/test-fast-pr.sh` — exit 0, `PASS fast PR spine`
- [x] Manual table column count + anchor check on every touched table/link