### PR TITLE
hicasso: the host hatch, proven end-to-end

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -124,6 +124,16 @@
   ;; the same terms as `defview` above.
   re-frame.bench.hicasso.arm1.lang/hfn     clojure.core/fn
 
+  ;; Hicasso's interop door (rf2-2rtt6.65, HD-011). `(defhost sym [doc]
+  ;; component [opts])` introduces a Var holding the head `mint-host!`
+  ;; minted, so `clojure.core\def` is its shape — the name resolves as a
+  ;; Var, the optional docstring is accepted, and the component and opts
+  ;; expressions are analysed as ordinary body forms. Not `defn`: a host
+  ;; declares no parameter vector, since the props it accepts are the
+  ;; foreign component's business rather than the declaration's. Retires
+  ;; with the arm on the same terms as `defview` above.
+  re-frame.bench.hicasso.arm1.lang/defhost clojure.core/def
+
   ;; `reg-view` is `(reg-view sym [args] body)` — defn-shape, but the
   ;; macro auto-injects `dispatch` / `subscribe` into the body. Handled
   ;; by the dedicated hook in `.clj-kondo/hooks/re_frame/core.clj` —

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
@@ -1,0 +1,696 @@
+(ns re-frame.bench.hicasso.arm1.host-hatch-dom-cljs-test
+  "THE HOST HATCH, PROVEN END-TO-END (rf2-2rtt6.65, HD-011).
+
+  The charter's v0 gate says 'one host hatch proven', and use case D9
+  names the claim: hosting React libraries via the one door — value in,
+  callback out, hook/context/ref owners, React-owned lifecycle. Before
+  this bead the contract half existed alone: `front/intent_cljs_test`
+  proves what a declared `:callbacks` entry lowers TO, at closure level,
+  with no door, no foreign component and no DOM anywhere in the witness.
+  This file is the other half: a real foreign React component — its own
+  `useState`, its own `useEffect`, its own `useContext`, its own ref
+  plumbing — declared once with `defhost`, driven from Hicasso
+  subscriptions, dispatching Hicasso intents, surviving what Hicasso
+  does around it, and tearing down to the residue witnesses' standard.
+
+  ## The proof component is a deliberate worst reasonable case
+
+  [[widget]] stands in for a third-party library without vendoring one:
+  React-owned state that must survive (`useState` twice), a mount effect
+  with a cleanup that must run (`useEffect`), a context read below the
+  crossing (`useContext` — and the PROVIDER is hosted too, which is the
+  guide's own answer to 'a library hands you a provider'), a ref it
+  forwards to its root node, children it slots, and three invoker styles
+  on its callbacks: value-first multi-arg (`(onPick value event)`),
+  event-first (`(onDraft event)`), and imperative-with-return
+  (`onImperative`).
+
+  ## The hook-budget distinction, measured rather than asserted
+
+  HD-020's ≤2-hook budget is a statement about HICASSO'S OWN boundary
+  shells. The hosted component's hooks are its own affair — that
+  distinction is the whole point of the door — and the door itself mints
+  NO wrapper component, no fiber and no hook: the foreign component is
+  the element's own type, lowered at the crossing inside the parent
+  boundary's render window. The dispatcher-level probe below reads the
+  shell's two hooks and then the widget's own four, with nothing
+  between.
+
+  ## One honest limit, found rather than smoothed
+
+  A child handed to `h/presence` is lowered inside the presence
+  component's OWN render, where no ambient frame is bound — presence
+  binds none — so an intent-bearing prop on ANY presence child (native
+  or host alike) lowers against no dispatch: a vector refuses at render,
+  a declared-`:event` `h/fn` refuses loudly at invocation. Loud, never
+  silent, but dead. The presence rows below therefore drive the host
+  child through model changes and prove state/retention/override
+  crossing; the gap is filed as its own bead rather than smoothed here,
+  because it is presence's frame plumbing, not the door's.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every DOM claim degrades to a stated
+  skip while the declaration/refusal rows run everywhere."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.hook-probe :as probe]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.presence :refer [presence]]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom" :as react-dom])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview defhost hfn]]))
+
+(def ^:private frame-id ::host-hatch)
+(def ^:private timeout-ms 60)
+
+;; Registered ABOVE `use-fixtures`, deliberately — the reset fixture
+;; captures its source-store baseline when the `use-fixtures` form is
+;; evaluated (see the sibling suites).
+
+(rf/reg-sub :hatch/label (fn [db _] (:label db)))
+(rf/reg-sub :hatch/draft (fn [db _] (:draft db)))
+(rf/reg-sub :hatch/city (fn [db _] (:city db)))
+(rf/reg-sub :hatch/theme (fn [db _] (:theme db)))
+(rf/reg-sub :hatch/picked-log (fn [db _] (:picked db)))
+(rf/reg-sub :hatch/widgets (fn [db _] (:widgets db)))
+
+(rf/reg-event :hatch/seed
+  (fn [_ _]
+    {:db {:label "due date" :draft "" :city "paris" :theme "noir"
+          :picked [] :closed 0 :widgets []}}))
+(rf/reg-event :hatch/set
+  (fn [{:keys [db]} [_ k v]] {:db (assoc db k v)}))
+(rf/reg-event :hatch/picked
+  (fn [{:keys [db]} [_ city kind]] {:db (update db :picked conj [city kind])}))
+(rf/reg-event :hatch/typed
+  (fn [{:keys [db]} [_ v]] {:db (assoc db :draft v)}))
+(rf/reg-event :hatch/closed
+  (fn [{:keys [db]} _] {:db (update db :closed inc)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     ;; the presence row waits on a real clock, and `cljs.test`
+     ;; hard-errors on a fn-form fixture in a suite with an async test.
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(defn- skip! [why] (is true (str "a host-hatch claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (lane/leave-act-environment!)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:hatch/seed]))
+  frame-id)
+
+(defn- db [] (rf/app-db-value frame-id))
+
+;; ---------------------------------------------------------------------------
+;; The foreign component — the library that never shipped
+;; ---------------------------------------------------------------------------
+
+(def ^:private theme-context (react/createContext "unthemed"))
+
+(def ^:private !instr
+  "What the foreign side observed. The witnesses read it because a
+  library's insides are exactly what the door cannot see — which is what
+  makes an instrumented stand-in the honest probe."
+  (atom {}))
+
+(defn- instr! []
+  (reset! !instr {:mounts 0 :cleanups 0 :renders 0
+                  :imperative-args [] :imperative-return nil
+                  :received-imperative nil :ref-node nil :ref-cleanups 0}))
+
+(defn- widget
+  "The worst reasonable case, as a plain React function component — raw
+  hooks, its own DOM, its own callback contracts, written exactly as a
+  JS library author would (ref as a prop: the React 19 contract)."
+  [^js props]
+  (swap! !instr update :renders (fnil inc 0))
+  (when-some [f (.-onImperative props)]
+    (swap! !instr assoc :received-imperative f))
+  (let [theme       (react/useContext theme-context)
+        clicks-hook (react/useState 0)
+        clicks      (aget clicks-hook 0)
+        set-clicks  (aget clicks-hook 1)
+        phase-hook  (react/useState "entering")
+        phase       (aget phase-hook 0)
+        set-phase   (aget phase-hook 1)]
+    ;; React-owned lifecycle: the component advances its own state from
+    ;; its own effect — the enter-transition shape, i.e. the stand-in
+    ;; for React-owned animation — and registers the cleanup teardown
+    ;; must run.
+    (react/useEffect
+      (fn []
+        (swap! !instr update :mounts (fnil inc 0))
+        (set-phase "settled")
+        (fn [] (swap! !instr update :cleanups (fnil inc 0))))
+      #js [])
+    (react/createElement "div"
+      #js {:className   (str "widget"
+                             (when-some [c (.-className props)] (str " " c)))
+           :ref         (.-ref props)
+           :data-theme  theme
+           :data-clicks clicks
+           :data-phase  phase}
+      (react/createElement "span" #js {:className "widget-label"} (.-label props))
+      (react/createElement "input"
+        #js {:className "widget-input"
+             :value     (or (.-draft props) "")
+             ;; event-first invoker: the DOM event, verbatim
+             :onChange  (fn [e] (when-some [f (.-onDraft props)] (f e)))})
+      (react/createElement "button"
+        #js {:className "widget-pick"
+             ;; value-first multi-arg invoker: (onPick value event) —
+             ;; and the click also moves the component's OWN state
+             :onClick   (fn [e]
+                          (set-clicks (fn [n] (inc n)))
+                          (when-some [f (.-onPick props)] (f (.-value props) e)))}
+        "pick")
+      (react/createElement "button"
+        #js {:className "widget-close"
+             :onClick   (fn [e] (when-some [f (.-onClose props)] (f e)))}
+        "close")
+      (react/createElement "button"
+        #js {:className "widget-run"
+             ;; imperative invoker that USES the return — :handler's
+             ;; 'return ignored' is Hicasso's contract, not the library's
+             :onClick   (fn [_]
+                          (when-some [f (.-onImperative props)]
+                            (swap! !instr assoc :imperative-return (f 41))))}
+        "run")
+      (react/createElement "div" #js {:className "widget-slot"}
+        (.-children props)))))
+
+;; ---------------------------------------------------------------------------
+;; The declarations — one line each, the whole of the door's surface
+;; ---------------------------------------------------------------------------
+
+(defhost picker widget
+  {:callbacks {:on-pick       :event
+               :on-close      :event
+               :on-draft      :event
+               :on-imperative :handler}})
+
+(defhost themed
+  "A provider an ecosystem library hands you is hosted like anything
+  else — it is a component (the guide's own troubleshooting row)."
+  (.-Provider theme-context))
+
+(def ^:private memo-widget (react/memo widget))
+
+(defhost memo-picker memo-widget
+  {:callbacks {:on-pick :event :on-imperative :handler}})
+
+(def ^:private stable-imperative
+  (hfn [x]
+    (swap! !instr update :imperative-args (fnil conj []) x)
+    (* x 2)))
+
+;; ---------------------------------------------------------------------------
+;; The screens
+;; ---------------------------------------------------------------------------
+
+(defn- grab-ref
+  "The consumer's callback ref, in the shape the guide teaches: the
+  return is the detach cleanup (React 19)."
+  [node]
+  (swap! !instr assoc :ref-node node)
+  (fn [] (swap! !instr update :ref-cleanups (fnil inc 0))))
+
+(defview screen
+  [_]
+  [:div.screen
+   [:output.picked-count (str (count (rt/sub [:hatch/picked-log])))]
+   [themed {:value (rt/sub [:hatch/theme])}
+    [picker {:label         (rt/sub [:hatch/label])
+             :draft         (rt/sub [:hatch/draft])
+             :value         (rt/sub [:hatch/city])
+             :on-pick       (hfn [city e] [:hatch/picked city (.-type e)])
+             :on-close      [:re-frame.hicasso/prevent [:hatch/closed]]
+             :on-draft      [:hatch/typed :re-frame.hicasso/value]
+             :on-imperative stable-imperative
+             :ref           grab-ref}
+     [:em.gifted "from hiccup"]]]])
+
+(defview host-page
+  "The minimal page the hook probe counts: one shell, one hosted widget,
+  nothing else."
+  [_]
+  [picker {:label (rt/sub [:hatch/label])}])
+
+(defview tray
+  "The host under presence. No callback props here, deliberately — see
+  the ns docstring's honest limit: presence lowers its children with no
+  ambient frame, so intent-bearing props on any presence child are a
+  filed gap, not this witness's subject."
+  [_]
+  [presence {:timeout-ms timeout-ms}
+   (for [w (rt/sub [:hatch/widgets])]
+     [picker {:key   (:id w)
+              :label (:name w)
+              :re-frame.hicasso/unmounting {:class "widget--exit"}}])])
+
+(defview memo-page
+  [_]
+  [:div
+   [:span.mlabel (str (rt/sub [:hatch/label]))]
+   [memo-picker {:label "fixed" :on-imperative stable-imperative}]])
+
+(defview memo-defeated-page
+  [_]
+  [:div
+   [:span.mlabel (str (rt/sub [:hatch/label]))]
+   [memo-picker {:label "fixed" :on-pick [:hatch/picked "static"]}]])
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- q [handle sel] (.querySelector (:container handle) sel))
+(defn- attr [handle sel a] (some-> (q handle sel) (.getAttribute a)))
+
+(defn- click! [handle sel]
+  (.click (q handle sel))
+  (mount/settle!))
+
+(defn- set-native-value!
+  "Write `v` through `HTMLInputElement.prototype`'s OWN value setter,
+  bypassing React's per-instance change tracker (the sibling controlled
+  suites' idiom)."
+  [node v]
+  (let [d (js/Object.getOwnPropertyDescriptor js/HTMLInputElement.prototype "value")]
+    (.call (.-set d) node v)))
+
+(defn- type-into! [handle sel text]
+  (let [node (q handle sel)]
+    (set-native-value! node text)
+    (.dispatchEvent node (js/Event. "input" #js {:bubbles true}))
+    (mount/settle!)))
+
+(defn- teardown-census!
+  "Unmount, read the live-reference census, THEN release — the
+  lifecycle suite's ordering, and for the same reason: a census taken
+  after `release!` reads an emptied table whatever teardown did."
+  [handle]
+  (react-dom/flushSync (fn [] (.unmount (:root handle))))
+  (let [census (select-keys (rt/residue) [:cell-refs :boundaries :edges])]
+    (mount/release! (assoc handle :root nil))
+    census))
+
+(def ^:private released {:cell-refs 0 :boundaries 0 :edges 0})
+
+;; ---------------------------------------------------------------------------
+;; 1 — the crossing, whole: value, context, children, ref, lifecycle
+;; ---------------------------------------------------------------------------
+
+(deftest the-declared-door-mounts-a-foreign-component-inside-a-hicasso-tree
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (instr!)
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [screen {}])
+            census (volatile! nil)]
+        (try
+          (mount/settle!)
+          (is (some? (q handle ".widget")) "the foreign component is on the page")
+          (testing "value in: a subscription value crossed as an ordinary prop"
+            (is (= "due date" (.-textContent (q handle ".widget-label")))))
+          (testing "context in: the PROVIDER is hosted, and the consumer reads
+                    it below the crossing — React context flows through the
+                    Hicasso tree because the tree is real React elements"
+            (is (= "noir" (attr handle ".widget" "data-theme"))))
+          (testing "React-owned lifecycle: the component advanced its own state
+                    from its own effect, with no Hicasso involvement — the
+                    enter-transition shape standing in for React-owned
+                    animation"
+            (is (= "settled" (attr handle ".widget" "data-phase")))
+            (is (= 1 (:mounts @!instr))))
+          (testing "children: hiccup children crossed as React children"
+            (is (= "from hiccup" (.-textContent (q handle ".widget-slot")))))
+          (testing "ref delivery: the consumer's callback ref was attached to
+                    the node the FOREIGN component chose"
+            (let [n (:ref-node @!instr)]
+              (is (some? n))
+              (is (.contains (.-classList n) "widget"))))
+          (finally (vreset! census (teardown-census! handle))))
+        (is (= released @census))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — callbacks out, and React-owned state surviving Hicasso re-renders
+;; ---------------------------------------------------------------------------
+
+(deftest callbacks-cross-out-and-react-owned-state-survives-hicasso-rerenders
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (instr!)
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [screen {}])
+            census (volatile! nil)]
+        (try
+          (mount/settle!)
+          (click! handle ".widget-pick")
+          (click! handle ".widget-pick")
+          (testing "declared :event + h/fn: EVERY argument the foreign
+                    invoker passed reached the body — (onPick value event),
+                    the variadic contract — and the returned intent
+                    dispatched into the frame"
+            (is (= [["paris" "click"] ["paris" "click"]] (:picked (db))))
+            (is (= "2" (.-textContent (q handle ".picked-count")))
+                "and the dispatch echoed back through the page"))
+          (is (= "2" (attr handle ".widget" "data-clicks"))
+              "the library's own useState moved under its own clicks")
+          (testing "REACT-OWNED STATE SURVIVES: the boundary above re-renders
+                    on a moved subscription, the new value crosses, and the
+                    foreign useState keeps its count — same fiber, no remount"
+            (mount/dispatch! handle [:hatch/set :label "arrival"])
+            (is (= "arrival" (.-textContent (q handle ".widget-label"))))
+            (is (= "2" (attr handle ".widget" "data-clicks")))
+            (is (= 1 (:mounts @!instr))
+                "the head is minted once at declaration, so React reconciled
+                 rather than remounted"))
+          (testing "and a context value driven by a subscription moves through
+                    the hosted provider"
+            (mount/dispatch! handle [:hatch/set :theme "sepia"])
+            (is (= "sepia" (attr handle ".widget" "data-theme")))
+            (is (= "2" (attr handle ".widget" "data-clicks"))))
+          (finally (vreset! census (teardown-census! handle))))
+        (is (= released @census))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the prevent head, and the marker, across the crossing
+;; ---------------------------------------------------------------------------
+
+(deftest a-prevented-intent-at-a-declared-position-prevents-then-dispatches
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (instr!)
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [screen {}])]
+        (try
+          (mount/settle!)
+          (let [ev      (js/MouseEvent. "click" #js {:bubbles true :cancelable true})
+                outcome (.dispatchEvent (q handle ".widget-close") ev)]
+            (mount/settle!)
+            (is (false? outcome)
+                "dispatchEvent answers false exactly when preventDefault ran —
+                 the ::h/prevent half fired on the real event")
+            (is (true? (.-defaultPrevented ev)))
+            (is (= 1 (:closed (db))) "and the wrapped intent dispatched"))
+          (finally (mount/release! handle)))))))
+
+(deftest the-value-marker-materializes-when-the-foreign-invoker-hands-an-event
+  (testing "the guide's open question — 'whether ::h/value works across a host
+            crossing' — answered with evidence: it works exactly when the
+            foreign contract hands the DOM event first, as this widget's
+            onChange does. A value-first invoker has no event to read a
+            target from; h/fn is that spelling (row 2 above proves it)."
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (do
+        (instr!)
+        (fresh!)
+        (let [handle (mount/root! (mount/fresh-container!) frame-id [screen {}])]
+          (try
+            (mount/settle!)
+            (type-into! handle ".widget-input" "west")
+            (is (= "west" (:draft (db)))
+                "the marker read the event's target across the door")
+            (is (= "west" (.-value (q handle ".widget-input")))
+                "and the model echoed back into the foreign input — the loop
+                 is closed in both directions")
+            (finally (mount/release! handle))))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — :handler crosses by identity, runs imperatively, returns to the caller
+;; ---------------------------------------------------------------------------
+
+(deftest a-declared-handler-crosses-by-identity-and-its-return-is-the-foreigners
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (instr!)
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [screen {}])]
+        (try
+          (mount/settle!)
+          (is (identical? stable-imperative (:received-imperative @!instr))
+              ":handler is the FUNCTION ITSELF — the door rewrapped nothing,
+               so a library memoising on handler identity is not defeated")
+          (click! handle ".widget-run")
+          (is (= [41] (:imperative-args @!instr)) "the imperative call ran")
+          (is (= 82 (:imperative-return @!instr))
+              "and the RETURN went back to the foreign caller — 'return
+               ignored' is Hicasso's side of the contract, not the library's")
+          (is (= [] (:picked (db))) "and nothing dispatched")
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — the declaration's refusals (these rows run under :node-test too)
+;; ---------------------------------------------------------------------------
+
+(defn- error-id [f]
+  (try (f) ::did-not-throw (catch :default e (:rf.error/id (ex-data e)))))
+
+(deftest the-declaration-refuses-what-it-cannot-carry
+  (testing "nil component — the broken-import symptom — refuses at the
+            declaration, where the author's stack is the declaration site"
+    (is (= :rf.error/hicasso-host-no-component
+           (error-id #(codec/mint-host! "hatch/nil-host" nil {})))))
+  (testing "a contract on a structural slot is refused in every spelling"
+    (is (= :rf.error/hicasso-host-structural-callback
+           (error-id #(codec/mint-host! "hatch/reffy" widget
+                                        {:callbacks {:ref :event}}))))
+    (is (= :rf.error/hicasso-host-structural-callback
+           (error-id #(codec/mint-host! "hatch/reffy" widget
+                                        {:callbacks {"ref" :handler}}))))
+    (is (= :rf.error/hicasso-host-structural-callback
+           (error-id #(codec/mint-host! "hatch/keyed" widget
+                                        {:callbacks {:x/key :event}})))))
+  (testing "an unknown contract is refused at mint, not at first render"
+    (is (= :rf.error/hicasso-unknown-callback-contract
+           (error-id #(codec/mint-host! "hatch/typo" widget
+                                        {:callbacks {:on-pick :evnt}})))))
+  (testing "two spellings landing on one slot are one contradiction, refused"
+    (is (= :rf.error/hicasso-host-callback-slot-collision
+           (error-id #(codec/mint-host! "hatch/twice" widget
+                                        {:callbacks {:on-pick :event
+                                                     :onPick  :handler}}))))))
+
+(deftest the-crossing-refuses-an-undeclared-event-spelled-intent
+  (let [h (codec/mint-host! "hatch/mini" widget {:callbacks {:on-pick :event}})]
+    (testing "an intent vector at an event-spelled prop the declaration does
+              not name refuses LOUDLY, naming the host and the position —
+              never inference, and never an inert array shipped to the
+              library"
+      (try
+        (codec/as-element [h {:on-nope [:boom]}])
+        (is false "should have thrown")
+        (catch :default e
+          (let [d (ex-data e)]
+            (is (= :rf.error/hicasso-host-undeclared-callback (:rf.error/id d)))
+            (is (= :on-nope (:position d)))
+            (is (= "hatch/mini" (:host d)))))))
+    (testing "an event-spelled KEY-MAP at an undeclared position is the same
+              refusal"
+      (is (= :rf.error/hicasso-host-undeclared-callback
+             (error-id #(codec/as-element [h {:on-key-down {"Enter" [:boom]}}])))))
+    (testing "a vector at the ref slot is HD-022's reservation, held at the
+              host position too"
+      (is (= :rf.error/hicasso-ref-vector-reserved
+             (error-id #(codec/as-element [h {:ref [:re-frame.hicasso/autosize {}]}])))))
+    (testing "while a plain data vector at a non-event prop is ordinary data"
+      (is (some? (codec/as-element [h {:columns [1 2 3]}]))))))
+
+(deftest the-declaration-binds-by-canonical-slot-not-by-spelling
+  (let [h (codec/mint-host! "hatch/slot-bound" widget {:callbacks {:on-pick :event}})]
+    (testing "the camel spelling lands on the declared slot: the vector was
+              LOWERED — outside a boundary that is the intent's own loud
+              error — rather than crossing as data"
+      (is (= :rf.error/hicasso-intent-outside-boundary
+             (error-id #(codec/as-element [h {:onPick [:hatch/picked "x"]}])))))
+    (testing "while an undeclared on* spelling never becomes an event position,
+              however event-shaped its name"
+      (is (= :rf.error/hicasso-host-undeclared-callback
+             (error-id #(codec/as-element [h {:onValueChange [:hatch/picked "x"]}])))))))
+
+(deftest host-props-convert-shallowly
+  (testing "HD-011's default: the top-level key camelCases, the value crosses
+            with no renaming inside it — a nested option map keeps the
+            spelling the author wrote, and converting it is the author's
+            explicit job when a library wants camelCase inside"
+    (let [h  (codec/mint-host! "hatch/shallow" widget {})
+          el (codec/as-element [h {:menu-items [{:day-of-week 1}]
+                                   :variant    :compact
+                                   :plain-fn   identity}])
+          ^js props (unchecked-get el "props")]
+      (is (= "compact" (unchecked-get props "variant"))
+          "keyword values cross by name")
+      (is (identical? identity (unchecked-get props "plainFn"))
+          "functions cross by identity — a value handed to a foreign API,
+           not a position")
+      (let [row (aget (unchecked-get props "menuItems") 0)]
+        (is (= 1 (unchecked-get row "day-of-week"))
+            "nested keys are NOT renamed — shallow means shallow")
+        (is (nil? (unchecked-get row "dayOfWeek")))))))
+
+;; ---------------------------------------------------------------------------
+;; 6 — the hook budget distinction, at React's own dispatcher
+;; ---------------------------------------------------------------------------
+
+(deftest the-door-adds-no-hicasso-hook-and-the-hosted-hooks-are-its-own
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (if-not (probe/install!)
+      (is false (str "React's internals slot was not found, so this claim is "
+                     "UNWITNESSED on this build — fix the probe rather than "
+                     "reading this as a pass"))
+      (do
+        (instr!)
+        (fresh!)
+        (let [handle (volatile! nil)
+              names  (probe/record!
+                       (fn [] (vreset! handle
+                                       (mount/root! (mount/fresh-container!)
+                                                    frame-id [host-page {}]))))]
+          (try
+            (is (= ["useContext" "useSyncExternalStore"
+                    "useContext" "useState" "useState" "useEffect"]
+                   (vec (take 6 names)))
+                (str "the shell's two hooks, then the FOREIGN component's own "
+                     "four, with NOTHING between: the door minted no wrapper, "
+                     "no fiber, no hook. HD-020's ≤2 budget is a statement "
+                     "about Hicasso's boundaries; the hosted component's hooks "
+                     "are its own affair — that distinction is the door's "
+                     "whole point: " (pr-str names)))
+            (is (every? #{"useContext" "useState" "useEffect"} (drop 6 names))
+                (str "anything after is the widget's own settle re-render — "
+                     "the same foreign hooks again, none of them Hicasso's: "
+                     (pr-str names)))
+            (finally (mount/release! @handle))))))))
+
+;; ---------------------------------------------------------------------------
+;; 7 — the host under presence: retention, override crossing, state survival
+;; ---------------------------------------------------------------------------
+
+(deftest react-owned-state-survives-a-presence-transition-around-the-host
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
+        (instr!)
+        (fresh!)
+        (rf/with-frame frame-id
+          (rf/dispatch-sync [:hatch/set :widgets [{:id 1 :name "one"}]]))
+        (let [handle (mount/root! (mount/fresh-container!) frame-id [tray {}])]
+          (mount/settle!)
+          (click! handle ".widget-pick")
+          (is (= "1" (attr handle ".widget" "data-clicks"))
+              "the library's own state moved before the transition")
+          (mount/dispatch! handle [:hatch/set :widgets []])
+          (is (some? (q handle ".widget"))
+              "gone from the model, retained on screen — presence retains a
+               host child by key exactly as it retains a native node")
+          (is (.contains (.-classList (q handle ".widget")) "widget--exit")
+              "the ::h/unmounting override crossed the door as an ordinary
+               prop — className — and the foreign component wore it")
+          (is (= "1" (attr handle ".widget" "data-clicks"))
+              "React-owned state survived entering the exit phase")
+          (is (= 1 (:mounts @!instr)))
+          (mount/dispatch! handle [:hatch/set :widgets [{:id 1 :name "one"}]])
+          (is (not (.contains (.-classList (q handle ".widget")) "widget--exit"))
+              "re-entry cancelled the exit and took the override off")
+          (is (= "1" (attr handle ".widget" "data-clicks"))
+              "and the state survived the WHOLE transition — retained key
+               identity means the fiber never remounted")
+          (is (= 1 (:mounts @!instr)))
+          ;; and a real departure is a real unmount, on the clock
+          (mount/dispatch! handle [:hatch/set :widgets []])
+          (js/setTimeout
+            (fn []
+              (mount/settle!)
+              (try
+                (is (nil? (q handle ".widget"))
+                    "past :timeout-ms the retained host left")
+                (is (= (:mounts @!instr) (:cleanups @!instr))
+                    "and its own effect cleanups ran — no foreign residue")
+                (finally (mount/release! handle) (done))))
+            (* 4 timeout-ms)))))))
+
+;; ---------------------------------------------------------------------------
+;; 8 — teardown: the hosted cleanups run, the ref detaches, nothing remains
+;; ---------------------------------------------------------------------------
+
+(deftest teardown-runs-the-hosted-cleanups-and-leaves-no-residue
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (instr!)
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [screen {}])]
+        (mount/settle!)
+        (is (= 1 (:mounts @!instr)))
+        (is (some? (:ref-node @!instr)))
+        (is (zero? (:ref-cleanups @!instr)))
+        (let [census (teardown-census! handle)]
+          (is (= 1 (:cleanups @!instr))
+              "unmounting the Hicasso root ran the FOREIGN effect's cleanup —
+               React owns the teardown because React owned the mount")
+          (is (= 1 (:ref-cleanups @!instr))
+              "and the callback ref's returned cleanup ran on detach — the
+               React 19 contract the guide teaches, witnessed through the
+               door")
+          (is (= released census)
+              "and the runtime holds nothing: the residue witnesses' standard"))))))
+
+;; ---------------------------------------------------------------------------
+;; 9 — React.memo at the door: what holds, and the honest cost
+;; ---------------------------------------------------------------------------
+
+(deftest a-memoised-hosted-component-and-the-doors-honest-cost
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (testing "the bail-out HOLDS when the door hands shallow-equal props:
+                scalars cross as values and a :handler crosses by identity"
+        (instr!)
+        (fresh!)
+        (let [handle (mount/root! (mount/fresh-container!) frame-id [memo-page {}])]
+          (mount/settle!)
+          (let [before (:renders @!instr)]
+            (mount/dispatch! handle [:hatch/set :label "moved"])
+            (is (= "moved" (.-textContent (q handle ".mlabel")))
+                "the parent boundary really re-rendered")
+            (is (= before (:renders @!instr))
+                "and React.memo held across it — the door mints a fresh props
+                 OBJECT per render, but every value in it was shallow-equal"))
+          (mount/release! handle)))
+      (testing "and the honest cost, stated: an intent VECTOR at a declared
+                :event position lowers to a fresh closure per parent render,
+                so it defeats a memoised host — the same price every native
+                event position pays. (The boundary-level value-equality
+                bail-out in flight on rf2-2rtt6.52 sits ABOVE this seam and
+                stops the equal-props parent re-render before the door is
+                reached at all.)"
+        (instr!)
+        ;; same frame, re-seeded — a second make-frame mid-test would be a
+        ;; reincarnation, which is its own suite's subject
+        (rf/with-frame frame-id (rf/dispatch-sync [:hatch/seed]))
+        (let [handle (mount/root! (mount/fresh-container!) frame-id
+                                  [memo-defeated-page {}])]
+          (mount/settle!)
+          (let [before (:renders @!instr)]
+            (mount/dispatch! handle [:hatch/set :label "moved-again"])
+            (is (= "moved-again" (.-textContent (q handle ".mlabel"))))
+            (is (= (inc before) (:renders @!instr))))
+          (mount/release! handle))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
@@ -62,8 +62,7 @@
             [re-frame.bench.hicasso.lane :as lane]
             [re-frame.core :as rf]
             [re-frame.test-support :as test-support]
-            ["react" :as react]
-            ["react-dom" :as react-dom])
+            ["react" :as react])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview defhost hfn]]))
 
 (def ^:private frame-id ::host-hatch)
@@ -308,11 +307,14 @@
     (mount/settle!)))
 
 (defn- teardown-census!
-  "Unmount, read the live-reference census, THEN release — the
-  lifecycle suite's ordering, and for the same reason: a census taken
-  after `release!` reads an emptied table whatever teardown did."
+  "Unmount through the arm's own residue door, read the live-reference
+  census, THEN release — the lifecycle suite's ordering, and for the
+  same reason: a census taken after `release!` reads an emptied table
+  whatever teardown did. `mount/unmount!` rather than a raw flushSync,
+  because it is the door a residue gate is designed to read through —
+  and the seam the teardown mutation breaks."
   [handle]
-  (react-dom/flushSync (fn [] (.unmount (:root handle))))
+  (mount/unmount! handle)
   (let [census (select-keys (rt/residue) [:cell-refs :boundaries :edges])]
     (mount/release! (assoc handle :root nil))
     census))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
@@ -33,8 +33,9 @@
   NO wrapper component, no fiber and no hook: the foreign component is
   the element's own type, lowered at the crossing inside the parent
   boundary's render window. The dispatcher-level probe below reads the
-  shell's two hooks and then the widget's own four, with nothing
-  between.
+  shell's two hooks first, exactly one subscription hook on the whole
+  page, and nothing after the shell that is not the widget's own
+  roster.
 
   ## One honest limit, found rather than smoothed
 
@@ -281,6 +282,17 @@
   (.click (q handle sel))
   (mount/settle!))
 
+(defn- settled!
+  "Let the widget's own effect-driven state land. Its `set-phase` runs in
+  a passive effect, so the update it schedules is DEFAULT-lane work that
+  commits on the scheduler's macrotask — an empty `flushSync` cannot pull
+  it forward. One macrotask, then the flush: the presence suite's idiom,
+  needed here for the same reason (a foreign enter transition is exactly
+  presence's weak half, owned by the library instead)."
+  []
+  (js/Promise. (fn [resolve]
+                 (js/setTimeout (fn [] (mount/settle!) (resolve true)) 0))))
+
 (defn- set-native-value!
   "Write `v` through `HTMLInputElement.prototype`'s OWN value setter,
   bypassing React's per-instance change tracker (the sibling controlled
@@ -312,37 +324,47 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-declared-door-mounts-a-foreign-component-inside-a-hicasso-tree
-  (if-not (mount/browser?)
-    (skip! ":node-test has no DOM")
-    (do
-      (instr!)
-      (fresh!)
-      (let [handle (mount/root! (mount/fresh-container!) frame-id [screen {}])
-            census (volatile! nil)]
-        (try
-          (mount/settle!)
-          (is (some? (q handle ".widget")) "the foreign component is on the page")
-          (testing "value in: a subscription value crossed as an ordinary prop"
-            (is (= "due date" (.-textContent (q handle ".widget-label")))))
-          (testing "context in: the PROVIDER is hosted, and the consumer reads
-                    it below the crossing — React context flows through the
-                    Hicasso tree because the tree is real React elements"
-            (is (= "noir" (attr handle ".widget" "data-theme"))))
-          (testing "React-owned lifecycle: the component advanced its own state
-                    from its own effect, with no Hicasso involvement — the
-                    enter-transition shape standing in for React-owned
-                    animation"
-            (is (= "settled" (attr handle ".widget" "data-phase")))
-            (is (= 1 (:mounts @!instr))))
-          (testing "children: hiccup children crossed as React children"
-            (is (= "from hiccup" (.-textContent (q handle ".widget-slot")))))
-          (testing "ref delivery: the consumer's callback ref was attached to
-                    the node the FOREIGN component chose"
-            (let [n (:ref-node @!instr)]
-              (is (some? n))
-              (is (.contains (.-classList n) "widget"))))
-          (finally (vreset! census (teardown-census! handle))))
-        (is (= released @census))))))
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
+        (instr!)
+        (fresh!)
+        (let [handle (mount/root! (mount/fresh-container!) frame-id [screen {}])]
+          (-> (settled!)
+              (.then
+                (fn [_]
+                  (let [census (volatile! nil)]
+                    (try
+                      (is (some? (q handle ".widget"))
+                          "the foreign component is on the page")
+                      (testing "value in: a subscription value crossed as an
+                                ordinary prop"
+                        (is (= "due date" (.-textContent (q handle ".widget-label")))))
+                      (testing "context in: the PROVIDER is hosted, and the
+                                consumer reads it below the crossing — React
+                                context flows through the Hicasso tree because
+                                the tree is real React elements"
+                        (is (= "noir" (attr handle ".widget" "data-theme"))))
+                      (testing "React-owned lifecycle: the component advanced
+                                its own state from its own effect, with no
+                                Hicasso involvement — the enter-transition
+                                shape standing in for React-owned animation"
+                        (is (= "settled" (attr handle ".widget" "data-phase")))
+                        (is (= 1 (:mounts @!instr))))
+                      (testing "children: hiccup children crossed as React
+                                children"
+                        (is (= "from hiccup" (.-textContent (q handle ".widget-slot")))))
+                      (testing "ref delivery: the consumer's callback ref was
+                                attached to the node the FOREIGN component
+                                chose"
+                        (let [n (:ref-node @!instr)]
+                          (is (some? n))
+                          (is (.contains (.-classList n) "widget"))))
+                      (finally (vreset! census (teardown-census! handle))))
+                    (is (= released @census))
+                    (done))))
+              (.catch (fn [e] (is false (str e)) (done)))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 2 — callbacks out, and React-owned state surviving Hicasso re-renders
@@ -564,19 +586,22 @@
                                        (mount/root! (mount/fresh-container!)
                                                     frame-id [host-page {}]))))]
           (try
-            (is (= ["useContext" "useSyncExternalStore"
-                    "useContext" "useState" "useState" "useEffect"]
-                   (vec (take 6 names)))
-                (str "the shell's two hooks, then the FOREIGN component's own "
-                     "four, with NOTHING between: the door minted no wrapper, "
-                     "no fiber, no hook. HD-020's ≤2 budget is a statement "
-                     "about Hicasso's boundaries; the hosted component's hooks "
-                     "are its own affair — that distinction is the door's "
-                     "whole point: " (pr-str names)))
-            (is (every? #{"useContext" "useState" "useEffect"} (drop 6 names))
-                (str "anything after is the widget's own settle re-render — "
-                     "the same foreign hooks again, none of them Hicasso's: "
+            (is (= ["useContext" "useSyncExternalStore"] (vec (take 2 names)))
+                (str "the shell's two hooks come FIRST, with nothing before "
+                     "them — the door minted no wrapper and spent no hook on "
+                     "the way to the foreign component: " (pr-str names)))
+            (is (every? #{"useContext" "useState" "useEffect"} (drop 2 names))
+                (str "and EVERYTHING after them is the widget's own roster — "
+                     "useContext/useState/useEffect, however React's dev "
+                     "dispatcher counts its reads of them. No useRef, no "
+                     "useCallback, no useMemo, and no hook of Hicasso's: "
                      (pr-str names)))
+            (is (= 1 (count (filter #{"useSyncExternalStore"} names)))
+                (str "exactly ONE subscription hook on the whole page — the "
+                     "one boundary's. HD-020's ≤2 budget is a statement about "
+                     "Hicasso's boundaries; the hosted component's hooks are "
+                     "its own affair, and that distinction is the door's "
+                     "whole point: " (pr-str names)))
             (finally (mount/release! @handle))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -658,39 +683,52 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest a-memoised-hosted-component-and-the-doors-honest-cost
-  (if-not (mount/browser?)
-    (skip! ":node-test has no DOM")
-    (do
-      (testing "the bail-out HOLDS when the door hands shallow-equal props:
-                scalars cross as values and a :handler crosses by identity"
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
         (instr!)
         (fresh!)
-        (let [handle (mount/root! (mount/fresh-container!) frame-id [memo-page {}])]
-          (mount/settle!)
-          (let [before (:renders @!instr)]
-            (mount/dispatch! handle [:hatch/set :label "moved"])
-            (is (= "moved" (.-textContent (q handle ".mlabel")))
-                "the parent boundary really re-rendered")
-            (is (= before (:renders @!instr))
-                "and React.memo held across it — the door mints a fresh props
-                 OBJECT per render, but every value in it was shallow-equal"))
-          (mount/release! handle)))
-      (testing "and the honest cost, stated: an intent VECTOR at a declared
-                :event position lowers to a fresh closure per parent render,
-                so it defeats a memoised host — the same price every native
-                event position pays. (The boundary-level value-equality
-                bail-out in flight on rf2-2rtt6.52 sits ABOVE this seam and
-                stops the equal-props parent re-render before the door is
-                reached at all.)"
-        (instr!)
-        ;; same frame, re-seeded — a second make-frame mid-test would be a
-        ;; reincarnation, which is its own suite's subject
-        (rf/with-frame frame-id (rf/dispatch-sync [:hatch/seed]))
-        (let [handle (mount/root! (mount/fresh-container!) frame-id
-                                  [memo-defeated-page {}])]
-          (mount/settle!)
-          (let [before (:renders @!instr)]
-            (mount/dispatch! handle [:hatch/set :label "moved-again"])
-            (is (= "moved-again" (.-textContent (q handle ".mlabel"))))
-            (is (= (inc before) (:renders @!instr))))
-          (mount/release! handle))))))
+        (let [handle (volatile! (mount/root! (mount/fresh-container!)
+                                             frame-id [memo-page {}]))]
+          (-> (settled!)
+              (.then
+                (fn [_]
+                  (testing "the bail-out HOLDS when the door hands
+                            shallow-equal props: scalars cross as values and
+                            a :handler crosses by identity"
+                    (let [before (:renders @!instr)]
+                      (mount/dispatch! @handle [:hatch/set :label "moved"])
+                      (is (= "moved" (.-textContent (q @handle ".mlabel")))
+                          "the parent boundary really re-rendered")
+                      (is (= before (:renders @!instr))
+                          "and React.memo held across it — the door mints a
+                           fresh props OBJECT per render, but every value in
+                           it was shallow-equal")))
+                  (mount/release! @handle)
+                  (instr!)
+                  ;; same frame, re-seeded — a second make-frame mid-test
+                  ;; would be a reincarnation, which is its own suite's
+                  ;; subject
+                  (rf/with-frame frame-id (rf/dispatch-sync [:hatch/seed]))
+                  (vreset! handle (mount/root! (mount/fresh-container!)
+                                               frame-id [memo-defeated-page {}]))
+                  (settled!)))
+              (.then
+                (fn [_]
+                  (try
+                    (testing "and the honest cost, stated: an intent VECTOR at
+                              a declared :event position lowers to a fresh
+                              closure per parent render, so it defeats a
+                              memoised host — the same price every native
+                              event position pays. (The boundary-level
+                              value-equality bail-out in flight on
+                              rf2-2rtt6.52 sits ABOVE this seam and stops the
+                              equal-props parent re-render before the door is
+                              reached at all.)"
+                      (let [before (:renders @!instr)]
+                        (mount/dispatch! @handle [:hatch/set :label "moved-again"])
+                        (is (= "moved-again" (.-textContent (q @handle ".mlabel"))))
+                        (is (= (inc before) (:renders @!instr)))))
+                    (finally (mount/release! @handle) (done)))))
+              (.catch (fn [e] (is false (str e)) (done)))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
@@ -37,17 +37,26 @@
   page, and nothing after the shell that is not the widget's own
   roster.
 
-  ## One honest limit, found rather than smoothed
+  ## The gap this suite found, and the half only the door can witness
 
-  A child handed to `h/presence` is lowered inside the presence
-  component's OWN render, where no ambient frame is bound — presence
-  binds none — so an intent-bearing prop on ANY presence child (native
-  or host alike) lowers against no dispatch: a vector refuses at render,
-  a declared-`:event` `h/fn` refuses loudly at invocation. Loud, never
-  silent, but dead. The presence rows below therefore drive the host
-  child through model changes and prove state/retention/override
-  crossing; the gap is filed as rf2-2rtt6.66 rather than smoothed here,
-  because it is presence's frame plumbing, not the door's.
+  Proving the crossing turned up a defect one component along: a child
+  handed to `h/presence` is lowered inside the presence component's OWN
+  render, and presence bound no frame there — so an intent-bearing prop
+  on ANY presence child, native or host alike, lowered against no
+  dispatch. Filed as rf2-2rtt6.66 rather than smoothed here, because it
+  was presence's frame plumbing and not the door's; repaired on main
+  (presence resolves the frame through the substrate's context and binds
+  it around its one `as-element` call), and `h/boundary` since took the
+  identical repair for its fallback and children (rf2-uo9di).
+
+  That repair could not witness its own host half — the door was still
+  in flight — and its bead says so, naming this suite's then-fenced
+  presence children as what it un-fences. So the fence is lifted below
+  and both shapes are driven through the door from the RETAINED window:
+  an intent vector, which lowers during presence's render, and a
+  declared-`:event` `h/fn`, which fails a whole phase later at
+  invocation. Two shapes that break at different moments is exactly why
+  witnessing one is not witnessing the other.
 
   Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
   React DOM; under `:node-test` every DOM claim degrades to a stated
@@ -247,17 +256,34 @@
   [picker {:label (rt/sub [:hatch/label])}])
 
 (defview tray
-  "The host under presence. No callback props here, deliberately — see
-  the ns docstring's honest limit: presence lowers its children with no
-  ambient frame, so intent-bearing props on any presence child are a
-  filed gap, not this witness's subject."
+  "The host under presence, WITH callbacks — the fence rf2-2rtt6.66's
+  repair lifted. Both shapes, because they break a phase apart: the
+  vector at `:on-close` is lowered during presence's own render, and the
+  `h/fn` at `:on-pick` survives lowering and would fail at invocation."
   [_]
   [presence {:timeout-ms timeout-ms}
    (for [w (rt/sub [:hatch/widgets])]
-     ;; no callback props on a presence child — rf2-2rtt6.66
-     [picker {:key   (:id w)
-              :label (:name w)
+     [picker {:key      (:id w)
+              :label    (:name w)
+              :value    (:name w)
+              :on-pick  (hfn [city e] [:hatch/picked city (.-type e)])
+              :on-close [:hatch/closed]
               :re-frame.hicasso/unmounting {:class "widget--exit"}}])])
+
+(defview hosted-row
+  "A host inside an ordinary boundary — which since rf2-2rtt6.52/HD-028
+  is a memoised one, every boundary being a `React.memo` carrying a
+  value-equality comparator."
+  [{:keys [label]}]
+  [picker {:label label :on-imperative stable-imperative}])
+
+(defview chrome-page
+  "Page chrome reads a key; the row below it reads nothing and takes
+  value-equal props. The write moves the chrome only."
+  [_]
+  [:div
+   [:span.chrome (str (rt/sub [:hatch/label]))]
+   [hosted-row {:label "fixed"}]])
 
 (defview memo-page
   [_]
@@ -635,12 +661,30 @@
           (is (= "1" (attr handle ".widget" "data-clicks"))
               "React-owned state survived entering the exit phase")
           (is (= 1 (:mounts @!instr)))
+          (testing "AND THE RETAINED HOST IS STILL LIVE — the half
+                    rf2-2rtt6.66's repair could not witness for itself,
+                    because the door was in flight when it landed. A
+                    declared :event h/fn on a child being animated OUT
+                    dispatches into the tray's frame: presence lowered this
+                    host's props inside its own render, and the frame it
+                    bound there is what the callback closed over"
+            (click! handle ".widget-pick")
+            (is (= [["one" "click"] ["one" "click"]] (:picked (db)))
+                "the retained host's callback reached the frame — a toast
+                 mid-exit is still clickable, which is the whole pitch"))
+          (testing "and the OTHER shape, which breaks a phase earlier: an
+                    intent VECTOR is lowered during presence's render, so it
+                    would have refused before any click could happen"
+            (click! handle ".widget-close")
+            (is (= 1 (:closed (db)))))
           (mount/dispatch! handle [:hatch/set :widgets [{:id 1 :name "one"}]])
           (is (not (.contains (.-classList (q handle ".widget")) "widget--exit"))
               "re-entry cancelled the exit and took the override off")
-          (is (= "1" (attr handle ".widget" "data-clicks"))
-              "and the state survived the WHOLE transition — retained key
-               identity means the fiber never remounted")
+          (is (= "2" (attr handle ".widget" "data-clicks"))
+              "and the state survived the WHOLE transition — one click before
+               it, one DURING the retained window, both still counted after
+               re-entry. Retained key identity means the fiber never
+               remounted, so the library's own state was never reset")
           (is (= 1 (:mounts @!instr)))
           ;; and a real departure is a real unmount, on the clock
           (mount/dispatch! handle [:hatch/set :widgets []])
@@ -685,6 +729,40 @@
 ;; 9 — React.memo at the door: what holds, and the honest cost
 ;; ---------------------------------------------------------------------------
 
+(deftest a-page-write-does-not-re-render-a-host-under-an-unchanged-boundary
+  (testing "the composition hazard, now that HD-028 ships: a hosted foreign
+            component sitting inside a memoised boundary. A write that moves
+            only the page chrome re-renders the chrome and stops at the row —
+            so the third-party component is not re-rendered AT ALL, and the
+            door did not have to know that. The cascade claim rf2-2rtt6.52
+            repaired, extended to foreign components, which are exactly the
+            ones whose render cost nobody controls."
+    (async done
+      (if-not (mount/browser?)
+        (do (skip! ":node-test has no DOM") (done))
+        (do
+          (instr!)
+          (fresh!)
+          (let [handle (mount/root! (mount/fresh-container!) frame-id
+                                    [chrome-page {}])]
+            (-> (settled!)
+                (.then
+                  (fn [_]
+                    (try
+                      (let [before (:renders @!instr)]
+                        (is (pos? before) "the host mounted")
+                        (mount/dispatch! handle [:hatch/set :label "chrome moved"])
+                        (is (= "chrome moved" (.-textContent (q handle ".chrome")))
+                            "the page chrome really re-rendered")
+                        (is (= before (:renders @!instr))
+                            "and the hosted component did not render again —
+                             the boundary above it bailed out on value-equal
+                             props, so the crossing was never re-run")
+                        (is (= 1 (:mounts @!instr))
+                            "nor was it remounted"))
+                      (finally (mount/release! handle) (done)))))
+                (.catch (fn [e] (is false (str e)) (done))))))))))
+
 (deftest a-memoised-hosted-component-and-the-doors-honest-cost
   (async done
     (if-not (mount/browser?)
@@ -725,10 +803,10 @@
                               closure per parent render, so it defeats a
                               memoised host — the same price every native
                               event position pays. (The boundary-level
-                              value-equality bail-out in flight on
-                              rf2-2rtt6.52 sits ABOVE this seam and stops the
+                              value-equality bail-out now SHIPS as HD-028,
+                              and it sits ABOVE this seam: it stops the
                               equal-props parent re-render before the door is
-                              reached at all.)"
+                              reached at all, which is the row below.)"
                       (let [before (:renders @!instr)]
                         (mount/dispatch! @handle [:hatch/set :label "moved-again"])
                         (is (= "moved-again" (.-textContent (q @handle ".mlabel"))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
@@ -46,7 +46,7 @@
   a declared-`:event` `h/fn` refuses loudly at invocation. Loud, never
   silent, but dead. The presence rows below therefore drive the host
   child through model changes and prove state/retention/override
-  crossing; the gap is filed as its own bead rather than smoothed here,
+  crossing; the gap is filed as rf2-2rtt6.66 rather than smoothed here,
   because it is presence's frame plumbing, not the door's.
 
   Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
@@ -254,6 +254,7 @@
   [_]
   [presence {:timeout-ms timeout-ms}
    (for [w (rt/sub [:hatch/widgets])]
+     ;; no callback props on a presence child — rf2-2rtt6.66
      [picker {:key   (:id w)
               :label (:name w)
               :re-frame.hicasso/unmounting {:class "widget--exit"}}])])

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj
@@ -1,6 +1,6 @@
 (ns re-frame.bench.hicasso.arm1.lang
-  "`defview` and `hfn` — the two macros Arm 1 has (rf2-2rtt6.9,
-  rf2-2rtt6.35).
+  "`defview`, `hfn` and `defhost` — the three macros Arm 1 has
+  (rf2-2rtt6.9, rf2-2rtt6.35, rf2-2rtt6.65).
 
   It exists because the authoring surface is a *deliverable*: HD-002 has
   the dogfood screen written in three renderings and judged on diff and
@@ -67,3 +67,31 @@
   [[re-frame.bench.hicasso.front.intent]] for the position table."
   [argv & body]
   `(re-frame.bench.hicasso.front.intent/callback (fn ~argv ~@body)))
+
+(defmacro defhost
+  "**The interop door — the one-line declaration (HD-011).** Name the
+  crossing to a foreign React component once; use the resulting var as a
+  hiccup head anywhere, indistinguishable from a view:
+
+      (defhost date-picker DatePicker
+        {:callbacks {:on-change :event}})
+
+      [date-picker {:selected  due-date
+                    :on-change [:task/set-due ::h/value]}]
+
+  `opts` is optional and carries `:callbacks` — a FINITE map from exact
+  prop names to `:event`, `:handler` or `:render`, never inferred from an
+  `on*` spelling. Policy lives on the declaration, so every use site
+  inherits it; the defaults, the refusals and the crossing itself are
+  [[re-frame.bench.hicasso.front.codec/mint-host!]]'s.
+
+  Like [[defview]] it is not a compiler: it expands to a `def` of the
+  minted head, reads no body, and captures only the name — for
+  `displayName` and for every diagnostic the crossing raises."
+  [sym & more]
+  (let [doc         (when (string? (first more)) (first more))
+        [component opts] (if doc (rest more) more)
+        host-name   (str (ns-name *ns*) "/" sym)]
+    `(def ~(if doc (vary-meta sym assoc :doc doc) sym)
+       (re-frame.bench.hicasso.front.codec/mint-host!
+         ~host-name ~component ~(or opts {})))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -1304,6 +1304,53 @@
           :value    v
           :declared (into #{} (keys (unchecked-get head "callbacks")))}))
 
+(defn- host-entry
+  "ONE host prop into the emitted object — [[host-element]]'s reducing
+  function, and the position table's second row where
+  [[convert-entry]] is its first.
+
+  Same discipline as its native sibling, and deliberately the same
+  lookups: the literal `:key` is skipped in-loop (React's contract, not
+  an attribute), a keyword or symbol key is answered by its cached
+  [[prop-slot]] — React name plus `reserved?`/`event?`/`ref?` in one
+  read — and a reserved emitted slot is never written, because the props
+  object handed to React does have a prototype even though the caches no
+  longer do.
+
+  The one difference from [[convert-entry]] is the whole of HD-011: what
+  a position MEANS here comes from the DECLARATION rather than from the
+  key's spelling. A declared slot takes its declared contract; an
+  event-spelled slot the declaration does not name is refused rather
+  than inferred; everything else crosses shallowly. `event?` is gated on
+  `keyword?` for the same reason the native walk gates it — a symbol
+  spelled `on-click` shares the cache entry and is not an event
+  position."
+  [^js head declared o k v]
+  (if (keyword-identical? :key k)
+    o
+    (let [keyword-ish? (or (keyword? k) (symbol? k))
+          ^PropSlot s  (when keyword-ish? (prop-slot k (name k)))
+          slot         (if keyword-ish? (.-js-name s) (cached-prop-name k))
+          reserved?    (if keyword-ish? (.-reserved? s) (reserved-name? slot))
+          ref?         (if keyword-ish? (.-ref? s) (= ref-slot slot))
+          event?       (if keyword-ish?
+                         (and (.-event? s) (keyword? k))
+                         (intent/event-prop? k))]
+      (when-not reserved?
+        (unchecked-set o slot
+          (cond
+            ref?
+            (check-ref! k v)
+
+            (contains? declared slot)
+            (intent/lower-declared-prop k v (get declared slot))
+
+            :else
+            (do (when (and event? (or (vector? v) (map? v)))
+                  (refuse-undeclared-host-event! head k v))
+                (host-prop-value v)))))
+      o)))
+
 (defn- host-element
   "One declared foreign component as a React element — THE CROSSING
   (HD-011). Runs inside the render window of the boundary that wrote it,
@@ -1337,26 +1384,7 @@
         declared   (unchecked-get head "callbacks")
         has-props? (props-map? argv 1)
         props      (merge-caller (if has-props? (nth argv 1) {}))
-        js-props   (reduce-kv
-                     (fn [o k v]
-                       (let [slot (cached-prop-name k)]
-                         (when-not (reserved-cache-keys slot)
-                           (unchecked-set o slot
-                             (cond
-                               (= ref-slot slot)
-                               (check-ref! k v)
-
-                               (contains? declared slot)
-                               (intent/lower-declared-prop k v (get declared slot))
-
-                               :else
-                               (do (when (and (intent/event-prop? k)
-                                              (or (vector? v) (map? v)))
-                                     (refuse-undeclared-host-event! head k v))
-                                   (host-prop-value v)))))
-                         o))
-                     #js {}
-                     (dissoc props :key))]
+        js-props   (reduce-kv (partial host-entry head declared) #js {} props)]
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
     (make-element (unchecked-get head "component") js-props argv (if has-props? 2 1))))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -33,10 +33,15 @@
 
   Also absent, and worth naming so their absence reads as a decision
   rather than an omission: the `:r>` raw-props path, the class-component
-  `__rfArgv` crossing, `defhost`/`[:>]` interop (HD-011 — its own
-  surface), and the adapters' reserved-head and keyword-prop diagnostics
-  (public-boundary policy for a shipped adapter; this codec has no public
-  boundary, and the pre-alpha stance is to trust the programmer).
+  `__rfArgv` crossing, the `[:>]` raw escape (HD-011 keeps it explicitly
+  secondary — the taught door is built below, and the escape stays
+  unbuilt until a case a static declaration cannot express actually
+  appears in the corpus), and the adapters' reserved-head and
+  keyword-prop diagnostics (public-boundary policy for a shipped
+  adapter; this codec has no public boundary, and the pre-alpha stance
+  is to trust the programmer). `defhost` — HD-011's taught door — is
+  NOT absent any more: [[mint-host!]] is the declaration and the host
+  head is the fourth element class, §Host heads below (rf2-2rtt6.65).
 
   ## Codec-work caching only (HD-004)
 
@@ -104,6 +109,7 @@
   |---|---|---|---|
   | Native tag | attr map | trailing forms; seqs realized once and flattened one level; `nil`/`false` render nothing, `true` errors | `:key` in the attr map |
   | Boundary (a marked `defview` product) | one props map, every lazy sequence in it realized and every unforced `delay` in it refused ([[realize-deep]]) | trailing forms as `(:children props)`, a realized vector | `:key` in the props map, extracted before the body sees props |
+  | Host (a `defhost` declaration — HD-011) | attr map: declared `:callbacks` slots lowered by their DECLARED contract, `:ref` a callback ref (HD-022's vector refusal holds here), everything else converted shallowly ([[host-prop-value]]) | trailing forms converted hiccup→element, handed to the foreign component as React children | `:key` in the attr map |
   | Fragment `[:<> …]` | optional attr map | trailing forms | on the fragment's props map |
 
   A React element is a legal child anywhere. No metadata keys, no second
@@ -836,6 +842,106 @@
   (or (unchecked-get head "hicassoMemo") head))
 
 ;; ---------------------------------------------------------------------------
+;; Host heads (HD-011) — the declared door for a foreign React component
+;; ---------------------------------------------------------------------------
+;;
+;; `defhost` is the door, and the only form taught. The declaration is a
+;; VALUE — the foreign component, the finite `:callbacks` contract map,
+;; and a name for the crossing — minted once and legal as a hiccup head
+;; anywhere. The `[:>]` raw escape stays unbuilt here, deliberately: it
+;; is HD-011's explicitly secondary form, for the cases a static
+;; declaration cannot express, and the census counts none.
+;;
+;; The declaration's `:callbacks` is a finite map from EXACT prop names
+;; to `:event`, `:handler` or `:render` — NEVER inferred from an `on*`
+;; spelling. "Exact" is enforced on the CANONICAL SLOT, like every other
+;; rule in this codec: `{:on-pick :event}` and a call site writing
+;; `:onPick` name the same slot, so the declaration binds however the
+;; author spells the prop — while an undeclared `onFoo` never becomes an
+;; event position no matter how event-shaped its name is.
+
+(def ^:private host-marker "hicassoHost")
+
+(def ^:private callback-contracts
+  "The three contracts a declaration may name — the position table's
+  roster in `front.intent`, verbatim."
+  #{:event :handler :render})
+
+(defn mint-host!
+  "THE ONE-LINE DECLARATION (HD-011). Give the crossing to `component` a
+  name, a policy, and a place: returns the host HEAD — a marked carrier
+  legal in hiccup head position, rendered by [[vec->element]]'s fourth
+  branch.
+
+  `component` is anything React accepts as an element type — a function
+  component, a class, a `memo`/`lazy` product, a context provider. `nil`
+  is refused HERE, at the declaration, because it is the classic broken
+  interop symptom (`:default` against a library that has no default
+  export) and the render-time alternative is React's own error naming
+  nothing the author wrote.
+
+  `opts` carries `:callbacks` — the finite contract map above. Each key
+  is normalized to its canonical slot at MINT time, so the lookup the
+  crossing performs per prop is one `get`; a contract outside the roster,
+  a declaration on a structural slot (`key`/`ref` are React's, not
+  positions), and two spellings landing on one slot are all refused at
+  the declaration, where the author's stack is the declaration site."
+  ([host-name component] (mint-host! host-name component {}))
+  ([host-name component opts]
+   (when (nil? component)
+     (fail! :rf.error/hicasso-host-no-component
+            'front.codec/mint-host!
+            (str "defhost " host-name " was given nil as its component. The "
+                 "usual cause is a JS import that resolved nothing — e.g. "
+                 "`:default` against a library with no default export.")
+            :hand-the-declaration-a-real-component
+            {:host host-name}))
+   (let [declared
+         (reduce-kv
+           (fn [m k contract]
+             (let [slot (cached-prop-name k)]
+               (when-not (contains? callback-contracts contract)
+                 (fail! :rf.error/hicasso-unknown-callback-contract
+                        'front.codec/mint-host!
+                        (str "defhost " host-name " declares " (pr-str k) " with "
+                             "the callback contract " (pr-str contract)
+                             ". The contracts are :event, :handler and :render.")
+                        :declare-event-handler-or-render
+                        {:host host-name :position k :contract contract}))
+               (when (structural-slot? k)
+                 (fail! :rf.error/hicasso-host-structural-callback
+                        'front.codec/mint-host!
+                        (str "defhost " host-name " declares a callback contract on "
+                             (pr-str k) ", whose canonical slot is structural. `key` "
+                             "is React's identity contract and `ref` is HD-016's "
+                             "node handle; neither is a callback position.")
+                        :declare-contracts-on-ordinary-props-only
+                        {:host host-name :position k}))
+               (when (contains? m slot)
+                 (fail! :rf.error/hicasso-host-callback-slot-collision
+                        'front.codec/mint-host!
+                        (str "defhost " host-name " declares " (pr-str k) ", but the "
+                             "slot " (pr-str slot) " already carries a contract from "
+                             "another spelling. Two spellings of one prop are one "
+                             "position; declare it once.")
+                        :declare-each-slot-once
+                        {:host host-name :position k :slot slot}))
+               (assoc m slot contract)))
+           {}
+           (or (:callbacks opts) {}))
+         ^js head #js {"component"   component
+                       "callbacks"   declared
+                       "displayName" host-name}]
+     (unchecked-set head host-marker true)
+     head)))
+
+(defn host-head?
+  "Is `v` a minted host head? One own-property read behind a nil guard;
+  no registry, no map — the same shape as [[boundary-head?]]."
+  [v]
+  (and (some? v) (true? (unchecked-get v host-marker))))
+
+;; ---------------------------------------------------------------------------
 ;; Hiccup shape
 ;; ---------------------------------------------------------------------------
 
@@ -1153,6 +1259,107 @@
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
     (react/createElement (element-type (nth argv 0)) js-props)))
 
+(defn host-prop-value
+  "A host prop value, converted SHALLOWLY — HD-011's default. The
+  top-level KEY is camelCased (that is [[cached-prop-name]], applied by
+  [[host-element]]'s walk); the VALUE crosses with no renaming inside
+  it: functions by identity (so `React.memo` and every downstream
+  bail-out that compares handler identity keep working), keywords and
+  symbols by name, collections through `clj->js` — whose nested map keys
+  keep the spelling the author wrote. A library expecting camelCase
+  inside a nested option map is handed exactly what the author typed,
+  and the guide's answer is to convert that one map yourself: deep
+  conversion guessing at which nested maps are options and which are
+  data is the documented support burden the shallow default deletes."
+  [v]
+  (cond
+    (fn? v)                       v
+    (or (keyword? v) (symbol? v)) (name v)
+    (coll? v)                     (clj->js v)
+    :else                         v))
+
+(defn- refuse-undeclared-host-event!
+  "An intent vector or key-map at an event-SPELLED prop the declaration
+  does not name. The contract rule is 'never inferred from an `on*`
+  name', and this refusal is the loud half of it: no contract is guessed
+  — but the alternative to refusing is `clj->js` shipping the author's
+  intent to the library as an inert array, which is the silently dead
+  handler class every loud error in this codec exists to delete. A
+  FUNCTION at an undeclared prop is different and legal: it is a value
+  handed to a foreign API — not a position — so it crosses by identity
+  and simply runs (the position table's deletion row)."
+  [^js head k v]
+  (fail! :rf.error/hicasso-host-undeclared-callback
+         'front.codec/host-element
+         (str "The host " (unchecked-get head "displayName") " was handed "
+              (pr-str v) " at " (pr-str k) ", which its declaration does not "
+              "name. A host's callback contracts are a finite map from exact "
+              "prop names to :event, :handler or :render — never inferred "
+              "from an on* spelling — so an undeclared intent would cross as "
+              "inert data. Declare " (pr-str k) " in :callbacks, or hand a "
+              "function.")
+         :declare-the-callback-contract
+         {:host     (unchecked-get head "displayName")
+          :position k
+          :value    v
+          :declared (into #{} (keys (unchecked-get head "callbacks")))}))
+
+(defn- host-element
+  "One declared foreign component as a React element — THE CROSSING
+  (HD-011). Runs inside the render window of the boundary that wrote it,
+  like every other lowering in this walk, so a declared `:event`
+  contract closes over that boundary's frame-locked dispatch and a
+  crossing written outside any boundary is the same loud
+  `:rf.error/hicasso-intent-outside-boundary` an intent vector raises.
+
+  One pass over the attr map, mirroring [[convert-props]] with the
+  position table's second row swapped in for the first: fold a `:&`
+  remainder under the owned-literal law (the same one merge, at a third
+  position), extract `:key` (React's contract, not an attribute), refuse
+  a reserved `:ref` vector and pass a callback ref through untouched,
+  lower every DECLARED slot by its declared contract
+  ([[re-frame.bench.hicasso.front.intent/lower-declared-prop]] — an
+  `h/fn` takes the contract's wrapper, an intent vector or key-map
+  lowers as at a native position), refuse an event-spelled intent at an
+  UNDECLARED slot, and convert everything else shallowly
+  ([[host-prop-value]]) under its camelCased name.
+
+  Children are trailing forms converted hiccup→element and handed to the
+  foreign component as ordinary React children — HD-011's third default.
+
+  The head itself contributes NOTHING at render: no wrapper component,
+  no fiber, no hook. The foreign component is the element's own type, so
+  its hooks, its state and its refs are React's affair under React's
+  rules — which is the whole point of the door, and what keeps HD-020's
+  ≤2-hook budget a statement about Hicasso's boundaries alone."
+  [argv]
+  (let [^js head   (nth argv 0)
+        declared   (unchecked-get head "callbacks")
+        has-props? (props-map? argv 1)
+        props      (merge-caller (if has-props? (nth argv 1) {}))
+        js-props   (reduce-kv
+                     (fn [o k v]
+                       (let [slot (cached-prop-name k)]
+                         (when-not (reserved-cache-keys slot)
+                           (unchecked-set o slot
+                             (cond
+                               (= ref-slot slot)
+                               (check-ref! k v)
+
+                               (contains? declared slot)
+                               (intent/lower-declared-prop k v (get declared slot))
+
+                               :else
+                               (do (when (and (intent/event-prop? k)
+                                              (or (vector? v) (map? v)))
+                                     (refuse-undeclared-host-event! head k v))
+                                   (host-prop-value v)))))
+                         o))
+                     #js {}
+                     (dissoc props :key))]
+    (when-some [k (:key props)] (unchecked-set js-props "key" k))
+    (make-element (unchecked-get head "component") js-props argv (if has-props? 2 1))))
+
 (defn- fragment-element [argv]
   (let [has-props? (props-map? argv 1)
         props      (if has-props? (nth argv 1) nil)
@@ -1187,17 +1394,21 @@
       (fragment-head? head)   (fragment-element argv)
       (hiccup-tag? head)      (native-element argv)
       (boundary-head? head)   (boundary-element argv)
+      (host-head? head)       (host-element argv)
       :else
       (throw (ex-info (str "Hiccup head " (pr-str head) " is not a valid element head; "
-                           "use a tag keyword, :<>, or a view minted by defview. "
+                           "use a tag keyword, :<>, a view minted by defview, or a "
+                           "host minted by defhost. "
                            "A plain function in head position is never a silent "
-                           "embedding — call it, or make it a view. "
+                           "embedding — call it, or make it a view. A raw JS "
+                           "component is never a silent embedding either — "
+                           "declare it (HD-011). "
                            "[:rf.error/hicasso-bad-head]")
                       {:rf.error/id :rf.error/hicasso-bad-head
                        :where       'front.codec/vec->element
                        :reason      (if (fn? head)
                                       "A plain function in head position is a loud error (HD-016)."
-                                      "Hiccup head must be a tag keyword, :<>, or a defview product.")
+                                      "Hiccup head must be a tag keyword, :<>, a defview product, or a defhost product.")
                        :recovery    (if (fn? head) :call-it-or-make-it-a-view :supply-a-valid-hiccup-head)})))))
 
 (defn as-element


### PR DESCRIPTION
The charter's v0 gate says **"one host hatch proven"**, and use case D9 names the claim: hosting React libraries via the one door (`defhost`) — value/callback, hook/context/ref/compound owners, React-owned animation. Before this PR only the *contract half* existed: `front/intent.cljs` could lower a declared `:callbacks` entry, and `front/intent_cljs_test` witnessed what it lowered **to** — at closure level, with no door, no foreign component and no DOM anywhere in the witness. `front/codec.cljs`'s own docstring named `defhost`/`[:>]` interop as deliberately absent, and `vec->element` knew three head classes. There was nothing to prove the charter's claim against.

This builds HD-011's taught door in the bench and proves it end-to-end against a deliberately worst-reasonable-case foreign component.

## The door

- **`front/codec.cljs`** — `mint-host!` (the one-line declaration: `:callbacks` normalized to canonical slots at mint time, contracts validated against the roster, structural slots and two-spellings-one-slot collisions refused, a `nil` component refused where the author's stack is still the declaration site); `host-head?`; and `host-entry`/`host-element`, the crossing itself. The `[:>]` raw escape stays **unbuilt** — HD-011 makes it explicitly secondary, and the census counts zero foreign components across 85 idiomatic files.
- **`arm1/lang.clj`** — the `defhost` macro. Like `defview` it is not a compiler: a `def` of the minted head, reading no body, capturing only the name.

The head contributes **nothing** at render — no wrapper component, no fiber, no hook. The foreign component is the element's own type, so its hooks, state and refs are React's affair under React's rules. That is the door's whole point, and it is what keeps HD-020's ≤2-hook budget a statement about Hicasso's boundaries alone.

## What is witnessed, and what each row asserts

`arm1/host_hatch_dom_cljs_test.cljs`, against an in-test component that is a worst reasonable case rather than a friendly one: two `useState`s, a `useEffect` with a cleanup, a `useContext` read below the crossing, a forwarded ref, and three invoker styles (value-first multi-arg, event-first, imperative-using-the-return).

| Crossing | What the row asserts |
|---|---|
| Value in | a subscription value crosses as an ordinary prop, and moves when the sub moves |
| Context in | the **provider is hosted too**, and the consumer reads it below the crossing |
| Children | hiccup children cross as React children |
| Callback out (`:event`) | **every** argument the foreign invoker passes reaches the body — the variadic contract — and the returned vector dispatches |
| `::h/prevent` | `dispatchEvent` answers `false` on the real event, then the wrapped intent dispatches |
| `::h/value` | materializes across the door **exactly when** the foreign contract hands the event first — the guide's open question, answered with evidence rather than assumption |
| Callback out (`:handler`) | crosses **by identity** (`identical?`), and its return goes back to the *foreign* caller — "return ignored" is Hicasso's side of the contract, not the library's |
| Ref | attach delivers the node the foreign component chose; the React 19 returned-cleanup fires on detach |
| React-owned state | survives a boundary re-render, a hosted-provider context change, **and** a full presence exit + re-entry — with `:mounts` still 1, so the fiber never remounted |
| Teardown | unmounting runs the foreign effect's cleanup and the ref's cleanup, and the runtime residue reads `{:cell-refs 0 :boundaries 0 :edges 0}` |
| Hook budget | counted at React's own dispatcher: the shell's two hooks first, exactly **one** `useSyncExternalStore` on the page, and nothing after the shell outside the widget's own roster |
| Refusals | `nil` component, unknown contract, contract on a structural slot, two spellings colliding on one slot, an undeclared event-spelled intent/key-map, a reserved `:ref` vector — each named at the position, each at the earliest moment it can be caught |

The refusal design point worth calling out: an intent at an **undeclared** event-spelled prop is refused **loudly**. The rule is "never inferred from an `on*` name", and the alternative to refusing is `clj->js` shipping the author's intent to the library as an inert array — the silently-dead-handler class every loud error in this codec exists to delete. A plain *function* at an undeclared prop stays legal and simply crosses: it is a value handed to a foreign API, not a position.

## Composition hazards

- **Host under a memoised boundary.** HD-028 landed while this was in flight, so the hazard is real rather than pending: a page-chrome write re-renders the chrome and the boundary above the host bails out on value-equal props, so **the third-party component is not re-rendered at all**. The cascade repair, extended to the components whose render cost nobody controls.
- **Host under `::h/unmounting` presence.** The retained host keeps its own state, wears the override as an ordinary `className`, and — see below — is still *live*.
- **Host with `[::h/prevent …]`ed intents.** Witnessed on the real event.
- **`React.memo` at the door**, both directions: the bail-out **holds** when the door hands shallow-equal props (scalars by value, `:handler` by identity), and is **defeated** by an intent vector at a declared `:event` position, which lowers to a fresh closure per render — the same price every native event position pays. Stated as the honest cost rather than left for someone to discover.

## A defect this found, and the half only the door could witness

Proving the crossing turned up a defect one component along: a child handed to `h/presence` is lowered inside presence's **own** render, and presence bound no frame there — so an intent-bearing prop on **any** presence child, native or host alike, lowered against no dispatch. Filed as `rf2-2rtt6.66` rather than smoothed here, because it was presence's frame plumbing and not the door's. It has since been repaired on main, and `h/boundary` took the identical repair (`rf2-uo9di`).

That repair could not witness its own host half — the door was still in flight — and its bead says so, naming this suite's then-fenced presence children as what it un-fences. **The fence is lifted in this PR**: the tray's host child now carries both callback shapes, and both are driven from the retained `::h/unmounting` window — an intent vector, lowered during presence's render, and a declared-`:event` `h/fn`, which survives lowering and would fail a whole phase later at invocation. Two shapes that break at different moments is exactly why witnessing one is not witnessing the other.

## Rebase interaction, reported rather than absorbed

`rf2-2rtt6.63` replaced the codec caches' prototype guard while this branch was out: `reserved-cache-keys` is gone, and a prop literal is now answered by a cached `PropSlot` carrying `js-name` plus `reserved?`/`event?`/`ref?`. The host walk was written against the deleted var — an `:undeclared-var` warning at compile, and a `TypeError` at **every** crossing at runtime, which made the refusal rows catch the wrong error. The walk is now `host-entry`, a hoisted reducing fn in `convert-entry`'s exact idiom: one slot lookup per prop, `:key` skipped in-loop, a reserved emitted slot never written (the props object still has a prototype even though the caches no longer do), `event?` gated on `keyword?`. The one difference from its native sibling remains the whole of HD-011 — what a position *means* comes from the declaration.

## Quality gates

All foreground, worktree-local logs; every exit code is the script's own.

| Gate | Result |
|---|---|
| `npm run test:browser` (real DOM, Chromium) | **exit 0** — 1023 tests, 6332 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | **exit 0** — 12422 tests, 62029 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` | **exit 0** — `PASS fast PR spine` |
| clj-kondo v2026.04.15 (CI's pinned version, CI's exact `--lint` list) | **exit 0** — `errors: 0`; **zero findings on any file this PR touches** |

`shadow-cljs compile browser-test` reports **0 warnings**.

### Mutation red/green

Both mutations run against the rebased tree, browser suite each time.

| Mutation | Red | Restored |
|---|---|---|
| `declared-callback`'s `:event` arm returns the raw fn (the declared contract goes dead) | **exit 1** — 3 failures: the host dispatch witness, the multi-arg forwarding witness, **and** the newly un-fenced presence retained-window dispatch | exit 0 |
| `mount/unmount!` skips React's unmount (teardown stops running) | **exit 1** — 14 failures, including all three teardown-witness assertions: the hosted effect cleanups, the React 19 ref cleanup, and the residue census | exit 0 |

The teardown witness reads through `mount/unmount!` rather than a raw `flushSync` deliberately — that is the door a residue gate is designed to read through, and reading through it is what makes the mutation visible at all.

### TESTING.md matrix

Per `TESTING.md`, `-dom-cljs-test` namespaces ride the `:browser-test` build (real DOM) in CI's browser lane; the same file's non-DOM rows — the declaration refusals, the slot-binding rows, the shallow-conversion row — also match the always-on `:node-test` `cljs-test$` selector and so run under `npm run test:cljs`, where every DOM claim degrades to a **stated skip** rather than a false green. Left to CI, per the spine's own "NOT RUN" report: the JVM artefact suites the diff does not touch, the prod-elision/bundle-isolation/perf gates, adapter probes and smokes, the Xray feature matrix, and mcp-conformance.

### Box coordination

The sibling holding the box's measurement windows (`inpage409`, decomposing the in-page mount term) was mid `shadow-cljs release hicasso-bench` when these gates were due. I waited for it to go idle and confirmed zero bench-runner processes on the box before running any browser suite, so no browser lane here overlapped a measurement window.

## Fences

Surface B. Hicasso's own boundary shells keep their ≤2-hook budget — **the hosted component's hooks are its own affair**, and that distinction is stated in the witness and measured at React's dispatcher rather than asserted. No compiler, no analyzer, no ledger. Hicasso consumes reagent-slim's codec.
