### PR TITLE
docs(hicasso): the interop page meets the landed door, and HD-002's remainder (rf2-ga1r1, rf2-n4mad)

### DIFF
--- a/docs/design/hicasso/README.md
+++ b/docs/design/hicasso/README.md
@@ -9,7 +9,7 @@ by [EP-0038](../../EP/EP-0038-the-hicasso-view-layer-programme.md).
 |---|---|
 | [charter.md](charter.md) | Product identity, evidence base, goals, constraints, use-case roster, known losses |
 | [decisions.md](decisions.md) | HD-001…HD-028 — every design decision, resolved, with rationale and reopen conditions |
-| [hd-002-adjudication.md](hd-002-adjudication.md) | HD-002 adjudicated — the tripwire, the boundary, ownership, and the hypotheses under test |
+| [hd-002-adjudication.md](hd-002-adjudication.md) | HD-002's correctness/cost gates, adjudicated and still binding — the tripwire, the boundary, ownership, and the hypotheses under test. Written before the operator's 2026-07-31 ergonomics ruling ([decisions.md](decisions.md) HD-002) and stands as written per that ruling; read it alongside HD-002, not in place of it |
 | [architecture.md](architecture.md) | The architecture space, the one live arm (and the withdrawn second), the shared front half, inside-React feasibility, the sub-read mechanism ladder |
 | [validation.md](validation.md) | The bar, the budgets, the P0→P1→P2 plan, witnesses, tournament and measurement discipline, kill criteria |
 | [authoring.md](authoring.md) | The authoring surface: views, subs, intents, interop door, theming, ephemeral state, testing doors |

--- a/docs/design/hicasso/architecture.md
+++ b/docs/design/hicasso/architecture.md
@@ -18,7 +18,7 @@ normative in [decisions.md](decisions.md); the proof obligations live in
 | | **Views re-run when dirty** | **Views run once; reactive holes** |
 |---|---|---|
 | **React owns the DOM** | **Hicasso lean-React** — the product line | dead — two-owner input clobber |
-| **Own renderer, React at islands** | ~~**Hicasso/PATCH**~~ — withdrawn 2026-07-31 (HD-007, superseded) | dead — authoring pin (HD-002) |
+| **Own renderer, React at islands** | ~~**Hicasso/PATCH**~~ — withdrawn 2026-07-31 (HD-007, superseded) | dead — the shipped read surface requires a re-running body (HD-002) |
 
 `sub`-as-a-value in open Clojure forces the re-run column: without a compiler to
 thunk expressions, run-once economics require hole-based authoring, which the
@@ -44,9 +44,10 @@ elements vs own DOM).
    dirty set is the union of all readers of any dirty sub; (6) an unknown dirty
    sub yields the empty set — no phantom boundaries. Index edges live in global
    maps — shared structure, not per-boundary object fan-out — and are not
-   reactions: only the commit applies the dirty set. **The index serves the two
-   product read tiers** (grouped declares its edges; the collector records
-   them); the scalar comparator arm does not use it. The index carries a
+   reactions: only the commit applies the dirty set. **The index serves the
+   one product read tier** — the ambient collector, which records edges — **and
+   its comparator**, grouped, which declares them; the scalar comparator arm
+   does not use it. The index carries a
    ~3-line nil-checked evidence sink seam (HD-005) so tooling can attach later;
    no evidence subsystem ships in v0.
 3. **Ergonomics-as-data** — event vectors in attributes, the value placeholder,
@@ -124,31 +125,34 @@ elements vs own DOM).
   can *beat* the UIx frontier on bulk and memory rather than approach it. That
   argument was never refuted — it was set aside by the product ruling.
 
-## The sub-read mechanism (HD-002: grouped default, collector challenger, scalar comparator)
+## The sub-read mechanism (HD-002, superseded 2026-07-31 — `sub` is the one product surface)
 
-Three tiers, one product. **Tier 1 — scalar per-read hooks** (the raw UIx
-spine): a comparator arm only, the measured floor, exempt from the product hook
-budget because it is the control (N reads = N hooks can never satisfy the
-product budget, and hook rules forbid conditional reads). **Tier 2 — grouped
-`use-subs`, the product default**: one fixed hook receiving the complete query
-collection before the body; query values may vary while hook count and order
-stay fixed; conditional needs are met by conditional child boundaries and
-conditionally-constructed query values at fixed sites; its canonical spelling
-is pre-declared and dogfooded from P1 start. **Tier 3 — the ambient collector,
-the challenger ridden hardest**: `(sub q)` as a plain tracked read anywhere in
-the body, one fixed runtime hook, edge diff after the body; it replaces grouped
-only by winning the per-read instrumentation under the HD-002 adjudication
-clauses (the render/commit ownership state machine; the allowed edge-diff
-operation vs the forbidden ledger; two pre-registered strategy hypotheses
-counted by benchmarked commits; the warm 1/3/7/20 allocation-slope survival
-metric) — and the standing tripwire **overrides the clock**: the first need for
-a candidate ledger or generic post-render dependency reconciliation kills the
-collector outright. It is the same mechanism class as the predecessor's
-per-read ledger — the single largest measured killer — which is why it must win
-its place rather than defend it, and why it is worth riding hard: it carries
-the census's tier-1 authoring shape (conditional reads legal) and most of the
-differentiation vs raw UIx. If both product tiers fail their gates, the outcome
-is null — never a fourth read model.
+The operator ruled on ergonomics, not on the measurement this section
+originally set up: **the ambient collector — `(sub q)` as a plain tracked read
+anywhere in the body — is the only read surface acceptable**, and grouped
+`use-subs` sits below the usability bar. **Tier 1 — scalar per-read hooks**
+(the raw UIx spine) stays a comparator arm only, the measured floor, exempt
+from the product hook budget because it is the control (N reads = N hooks can
+never satisfy the product budget, and hook rules forbid conditional reads).
+**Grouped `use-subs`** — one fixed hook receiving the complete query
+collection before the body — is ergonomically rejected as a product surface
+and is kept, and kept working, only as the **comparator** the collector is
+measured against; it is not a fallback, and a collector loss does not promote
+it. **The ambient collector** — one fixed runtime hook, edge diff after the
+body — is the one product tier, and the correctness and cost gates this
+ruling did **not** waive still bind in full, adjudicated in
+[hd-002-adjudication.md](hd-002-adjudication.md): the render/commit ownership
+state machine, the allowed edge-diff operation vs the forbidden ledger, two
+pre-registered strategy hypotheses counted only by benchmarked commits, and
+the warm 1/3/7/20 allocation-slope survival metric — and the standing
+tripwire **overrides the clock**: the first need for a candidate ledger or
+generic post-render dependency reconciliation kills the collector outright,
+however good its numbers look. It is the same mechanism class as the
+predecessor's per-read ledger — the single largest measured killer — which is
+why it must win its place rather than defend it. **If the collector trips the
+tripwire or fails the survival metric, the outcome is null — never a fallback
+to grouped** — or a mechanism not currently on the table must earn its way in
+(decisions.md HD-002).
 
 **Frame plumbing and the hook ledger (HD-020)**: each boundary reads the frame
 once via the substrate's single internal context, then binds it ambiently for

--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -32,16 +32,17 @@ cited as HD-nnn are normative in [decisions.md](decisions.md).
   `[view-var props-map]` is a boundary child (a React element; `:key` lives in
   the props map — no metadata keys; native-element keys are likewise `:key` in
   the props position). A **plain function call** `(helper …)` inlines into the
-  enclosing boundary — no boundary of its own (helper-donated `sub` reads are
-  collector-contingent, HD-002). A bare seq of boundary children requires keys
-  (dev warning); a plain function in head position is a loud error, never a
-  silent embedding; the `for`-lowering sugar is not v0 (HD-016).
-- **`sub` returns a value.** Whether it is legal *anywhere* inside a render —
-  conditionals, loops, helpers, as sketched above — is **collector-contingent
-  (HD-002)**: the sketch shows the challenger's authoring model, which ships only
-  if the collector wins its per-read budget in P1. Under the hook-fixed working
-  default, reads sit at fixed sites and conditional needs are met by conditional
-  child boundaries or conditionally-constructed query values. Either way: `sub`
+  enclosing boundary — no boundary of its own; a helper's `sub` reads are
+  ordinary ambient reads (HD-002 — `sub` is the one product surface). A bare
+  seq of boundary children requires keys (dev warning); a plain function in
+  head position is a loud error, never a silent embedding; the `for`-lowering
+  sugar is not v0 (HD-016).
+- **`sub` returns a value, legal *anywhere* inside a render** —
+  conditionals, loops, helpers, as sketched above. The operator ruled this the
+  only ergonomically acceptable surface (HD-002, superseded 2026-07-31); the
+  correctness and cost gates a per-read collector must still clear — the
+  tripwire, the ownership state machine, the survival metric — are unwaived
+  and adjudicated in [hd-002-adjudication.md](hd-002-adjudication.md). `sub`
   outside a render is an error; `subscribe-once` is the sanctioned snapshot for
   handler/utility code; framework subs (machine tags, resource/mutation state,
   route identity) read identically to app subs.
@@ -51,8 +52,9 @@ cited as HD-nnn are normative in [decisions.md](decisions.md).
   hook simply takes on React's hook rules themselves (HD-003: taught fence, not
   runtime police).
 
-**The grouped (default) spelling of the same view** — pre-declared per HD-002 so
-the default surface is scored from day one, not discovered mid-clock:
+**The grouped spelling of the same view, kept as the collector's comparator**
+(HD-002 — ergonomically rejected as a product surface, not a fallback) — pre-
+declared so it is scored from day one, not discovered mid-clock:
 
 ```clojure
 (:require [re-frame.hicasso :as h :refer [defview use-subs]])

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -1,11 +1,15 @@
 # Interop
 
-> **Draft ahead of the product artefact.** This page teaches the ruled surface —
-> [decisions.md](../decisions.md) (HD-001…HD-028) — and spellings marked
-> **[unfrozen]** stay provisional until the API freeze. One honesty note specific
-> to this page: `defhost` is ruled (HD-011) but is the one tier-1 door the bench
-> arm has not yet exercised, so unlike its siblings this page still describes
-> design rather than witnessed behaviour.
+> **Draft ahead of the product artefact.** This page teaches the landed surface —
+> ruled in [decisions.md](../decisions.md) (HD-001…HD-028). `defhost`'s door is
+> now witnessed end-to-end by the bench arm's tests under
+> `implementation/freehand/test/re_frame/bench/hicasso/` (rf2-2rtt6.65), but no
+> `implementation/hicasso/` artefact ships yet, and spellings marked
+> **[unfrozen]** stay provisional until the API freeze. Two things stay
+> deliberately unbuilt at v0 — the `[:>]` raw escape and SSR — and one default,
+> deep prop conversion, is deliberately not offered at all; two things stay
+> genuinely unsettled — `defhost`'s option keys and the codemod. See
+> **Not settled yet**.
 
 You want a date picker from npm. In Reagent you write `[:> DatePicker {...}]` and
 move on. Hicasso asks you to write one line first:
@@ -15,17 +19,21 @@ move on. Hicasso asks you to write one line first:
   (:require [re-frame.hicasso :as h]
             ["react-datepicker" :default DatePicker]))
 
-(h/defhost date-picker DatePicker)     ;; defhost is [unfrozen]
+(h/defhost date-picker DatePicker
+  {:callbacks {:on-change :event}})     ;; defhost is [unfrozen]
 ```
 
 Then use it anywhere, and it is indistinguishable from a native view:
 
 ```clojure
 (ns app.views
-  (:require [app.hosts.date-picker :refer [date-picker]]))
+  (:require [re-frame.hicasso :as h]
+            [app.hosts.date-picker :refer [date-picker]]))
 
 [date-picker {:selected  due-date
-              :on-change [:task/set-due ::h/value]}]
+              ;; the library hands the date first, not an event — no target
+              ;; for ::h/value to read, so h/fn takes the value directly
+              :on-change (h/fn [date & _] [:task/set-due date])}]
 ```
 
 ## Why a declaration instead of `[:>]`
@@ -68,23 +76,97 @@ Policy overrides live on the declaration rather than at the call site, which is 
 whole point: one place decides how this component is crossed, and every use site
 inherits it. The option keys are not in the record; see **Not settled yet**.
 
+Deep conversion — camelCasing keys *inside* a nested option map — is deliberately
+not offered at any level. Guessing which nested maps are options and which are data
+is the support burden the shallow default exists to delete; convert the map yourself
+when a library wants camelCase inside it.
+
+## Callbacks: `:event` and `:handler`
+
+A declared slot in `:callbacks` carries a contract, never inferred from an `on*`
+spelling:
+
+```clojure
+(h/defhost picker Widget
+  {:callbacks {:on-pick       :event
+               :on-imperative :handler}})
+```
+
+**`:event`** is the door's version of an ordinary `:on-*` position — an intent
+vector, or an `h/fn` when you need to read what the library handed you. The proof
+pins the detail a native position doesn't have to: a foreign invoker calls with
+*its own* arguments, not a lone DOM event — `onPick(value, event)`,
+`onDraft(event)` — and **every argument the invoker passed reaches the `h/fn`
+body**, in the order the library sent them. `::h/prevent` works at a declared
+`:event` position too, and calls `.preventDefault` on whichever argument is the
+real DOM event.
+
+**`:handler`** crosses the function by identity rather than wrapping it: the
+library gets exactly the function you wrote — so a library that memoises on
+callback identity is not defeated — and whatever the library's own call returns
+goes back to *that caller*; Hicasso never sees the return and never dispatches
+from it. This is the shape for a library's imperative surface (`open()`,
+`scrollTo()`): `defhost` doesn't know what an arbitrary imperative call means, so
+`:handler` stays out of its way entirely.
+
+## Providers cross the door too
+
+A provider an ecosystem library hands you is hosted like anything else — it's a
+component, not a special case:
+
+```clojure
+(h/defhost themed (.-Provider some-context))
+```
+
+A consumer reading the same context below the crossing reads it correctly: the
+crossing is a real React element, so React's own context plumbing runs through
+the Hicasso tree exactly as it would through any other one.
+
+## When a boundary bails out, the host inside it does too
+
+Every Hicasso boundary is a `React.memo` comparing its props by value (HD-028), and
+that bail-out reaches a hosted component exactly as it reaches a native one:
+
+```clojure
+(defview chrome-page [_]
+  [:div
+   [:span.chrome (str (sub [:hatch/label]))]   ;; re-renders on every write
+   [hosted-row {:label "fixed"}]])             ;; value-equal props — bails out
+```
+
+A write that only moves `:hatch/label` re-renders `.chrome` and stops there.
+`hosted-row`'s boundary receives the same `{:label "fixed"}` it always does, the
+comparator holds, the boundary bails out, and the foreign component inside it is
+not re-rendered at all — not once, not with stale props, simply never re-entered.
+That is the memo working exactly as designed: nothing in `hosted-row`'s own props
+moved. It is also exactly the shape that sends someone hunting a bug in the
+third-party library they are hosting, when the library never got a render to be
+wrong in. If a host should react to a subscription, that subscription's value has
+to reach *its own* boundary's props — reading it one component further up and
+stopping there is indistinguishable, from the host's side, from the value never
+having changed.
+
 ## The escape: `[:>]` is legal
 
-`[:> Component props & children]` lowers through the same foreign path with the same
-default conversions. It is `.cljs`-only at that node and has reduced structural
+`[:> Component props & children]` is HD-011's explicitly secondary form — ruled
+legal, not merely tolerated, for the cases a static declaration cannot express.
+It stays **unbuilt in the bench arm**, deliberately: the census found zero
+raw-escape sites to build against, so the door's proof took the v0 budget instead.
+When it lands, the design is that it lowers through the same foreign path with the
+same default conversions, `.cljs`-only at that node, with reduced structural
 identity — exactly the costs listed above, accepted knowingly.
 
-Use it when a static declaration genuinely cannot express the case:
+Reach for it, once it exists, when a static declaration genuinely cannot express
+the case:
 
 - the component is **selected at runtime** from a map or a prop;
 - it is a `memo` or `lazy` value;
 - it arrives from a **render prop**;
-- it is a **provider an ecosystem library hands you**, not one you named;
 - it is a **one-off migration site** you have not got to yet.
 
-**The rule is: declare what you use twice.** First use, take the escape if it's
-faster. Second use, write the `defhost`. That is not a moral position; it is where
-the amortization crosses over.
+**The rule, once it exists, is: declare what you use twice.** First use, take the
+escape if it's faster. Second use, write the `defhost`. That is not a moral
+position; it is where the amortization crosses over.
 
 One thing stays rejected: **bare-head auto-hosting**. Putting a raw JS component in
 head position — `[DatePicker {...}]` — and having the runtime identity-key it is
@@ -252,10 +334,11 @@ This table names mechanisms; the one minted id on this surface —
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| Prop arrives as `on-change` and the library ignores it | Deep conversion expected; the default is shallow | Convert the nested map yourself, or set a policy on the declaration |
+| Prop arrives as `on-change` and the library ignores it | Nested keys expected in camelCase; deep conversion is deliberately not offered | Convert the nested map yourself before it crosses |
 | A namespace stops loading on the JVM | A JS require reached a `.cljc` file | Quarantine the require in a `.cljs` host namespace |
 | Structural test can't match a node | It's a `[:>]` node — reduced structural identity, by design | Declare it with `defhost`, or assert around it |
 | Provider from a library needs to wrap the tree | Hosted like anything else | `defhost` the provider; it is a component |
+| A hosted component doesn't update when the page clearly changed | The boundary above it bailed out on value-equal props (HD-028) — it was never re-entered, so the host was never asked to render | Trace the value to the host's *own* boundary's props, not a parent's |
 | The SDK mounts twice in dev and you end with two live handles | StrictMode double-invoke, plus a handle stored outside the attach's closure — so the second attach overwrote the first instead of replacing it | One attach, one handle, one cleanup, all in one closure; return the cleanup from the ref |
 | The SDK is destroyed and rebuilt on every unrelated render | The ref function has a fresh identity each render, so React detaches and re-attaches | `useCallback` with `#js []` — a stable ref identity |
 | A `nil`-node branch in a ref never runs | The callback returns a cleanup, so React calls that instead of re-invoking with `nil` | Pick one contract; with React 19, pick the return |
@@ -278,7 +361,7 @@ two or three genuinely hard widgets.
 | The codemod's name and invocation | **Not addressed** |
 | When the reserved `{:ref [id config]}` spelling lands, and what registers an id | **Reserved, not designed.** HD-022 rules the refusal and the value-space; the registry, the timings and the commands roster are explicitly out of v0 |
 | Which React version the runtime targets | **Not addressed by the design record.** The cleanup-returning callback ref taught above is a React 19 contract; this repo's implementation currently pins React 19.2, but that is a fact about today's tree, not a Hicasso ruling. If v0 lands on 18, the fallback shape above is the one to teach |
-| Whether `::h/value` works across a host crossing | **Not addressed.** The example above assumes it does; a foreign `onChange` may hand you something other than a DOM event |
+| Whether `::h/value` works across a host crossing | **Proven, conditionally.** It works exactly when the foreign contract hands the DOM event first — the way `onChange`/`onInput` do. A value-first invoker (`onPick(value, event)`, or the date picker's `onChange` above) has no event at that position for `::h/value` to read a target from; write an `h/fn` there instead, as the opening example does |
 | The SSR placeholder's shape | Declared policy, inert in v0 |
 | Whether a hosted component can be a `defview`'s child via `(:children props)` | The ABI says an existing React element is a legal child anywhere, which implies yes; not stated for the host case specifically |
 | Embedding Hicasso *inside* a React-primary app | Named in the charter's use-case roster (item 11); no surface designed |

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -440,12 +440,13 @@ kill-bounded arms, and both did run before the ruling.)
 - A root-pull arm may run as a non-product assumption-challenge that leaves no
   API behind.
 - **The dogfood screen**: one list + one controlled field + sub reads, written
-  in **three renderings** (HD-002) — the collector surface, the grouped
-  `use-subs` surface (its canonical spelling pre-declared), and raw UIx —
-  judged on diff and preference by its authors. The grouped rendering rides the
-  comparator spine, not a third runtime. The ergonomics half of the verdict,
-  and the guarantee that a collector loss promotes an already-scored surface
-  rather than triggering a mid-clock API rewrite.
+  in **three renderings** (HD-002) — the collector surface (the ruled product
+  surface), the grouped `use-subs` surface (kept as its comparator, canonical
+  spelling pre-declared), and raw UIx. The grouped rendering rides the
+  comparator spine, not a third runtime. **Ergonomics is decided by direct
+  ruling** (2026-07-31, on the draft guide) rather than by this comparison;
+  the renderings still carry the cost/correctness measurement, where a
+  collector loss is **null** — never a promotion of grouped.
 
 **Witness set**: the 300-boundary shapes; 1/3/7/20 reads-per-boundary as two
 separated scaling curves (fixed reads × growing boundaries; fixed boundaries ×


### PR DESCRIPTION
## Summary

Two docs-only corrections to `docs/design/hicasso/`, both fixing pages that describe a pre-landing state.

**rf2-ga1r1 — `draft-guide/05-interop.md`.** The host hatch is now proven end-to-end (rf2-2rtt6.65, PR #7396). Brought the page's "Not settled yet" table and teaching up to the witness:

- `::h/value` across a host crossing: pinned to the proven condition (works exactly when the foreign contract hands the DOM event first), not the general open claim.
- Hosted providers: taught directly (a provider is hosted like anything else, a consumer below the crossing reads it correctly) instead of only implied by a troubleshooting row.
- The callback-contract surface: new section teaching `:event` (every invoker argument forwarded, `::h/prevent` on the real event) and `:handler` (identity crossing, return goes to the foreign caller) — previously undocumented on this page.
- HD-028's boundary memo bail-out, taught as the gotcha it is: a page-chrome write can leave a hosted foreign component unrendered by design — exactly the shape that sends someone hunting a bug in the wrong library.
- Kept honest: the `[:>]` raw escape stays unbuilt in the bench arm (by choice, census-zero); SSR and deep prop conversion stay explicitly not offered; `defhost`'s option keys and the codemod stay genuinely unsettled.
- Also fixed the opening sample, broken since before the proof: the undeclared `:on-change` callback would have refused at the crossing, `app.views` never required `re-frame.hicasso`, and `::h/value` was the wrong form for a date picker's value-first `onChange` in the first place.

**rf2-n4mad — HD-002's remainder.** The operator ruled 2026-07-31: the ambient collector (`sub`) is the only ergonomically acceptable read surface; grouped `use-subs` is kept only as its comparator, never a fallback. `decisions.md`'s HD-002 already carries the SUPERSEDED blockquote (rf2-fmxic, PR #7384). Swept the whole `docs/design/hicasso/` tree from scratch rather than trusting the five-page list (told-three-found-eighteen precedent, rf2-m6if4). Fixed `architecture.md` (the "sub-read mechanism" section, a space-table cell, the index description), `authoring.md` (the "collector-contingent" framing, the grouped example's "(default)" label), `validation.md` (the dogfood screen's "promotes an already-scored surface" claim, now closed under the ruling), and `README.md`'s index row.

Left deliberately untouched: `hd-002-adjudication.md`. The operator's ruling says so explicitly — "hd-002-adjudication.md stands as written" (rf2-2rtt6.1) — its correctness/cost adjudication is a different axis the ergonomics ruling didn't touch. `studio/` pages left alone per the box-contention guard.

Filed **rf2-2rtt6.68** for a gap found beyond scope: EP-0038 (`docs/EP/`) promises operator rulings made under it are recorded as dated addenda (EP-0009 rule 2/3) — the Arm-2/PATCH ruling got one, the Surface B/HD-002 ergonomics ruling has not. Left for its own pass since EP-0038 is governed by stricter no-silent-edit rules.

## Quality gates

- `python scripts/check_doc_slugs.py` — whole corpus, the covering gate for `docs/design/**` (mkdocs `--strict` does not reach that tree) — exit 0, both commits.
- `sh scripts/test-fast-pr.sh` — exit 0, both commits (docs tier ran incl. `mkdocs build --strict`; JVM/CLJS tiers correctly skipped, surface unchanged).
- Table column counts and inbound anchors checked by hand: one heading renamed (`architecture.md`'s "sub-read mechanism" section) after confirming zero inbound links (`git grep "architecture.md#"` empty); no other headings moved.

## Test plan

- [x] `check_doc_slugs.py` exit 0
- [x] `test-fast-pr.sh` exit 0
- [x] Manual anchor/table check on every edited page