### PR TITLE
fix(hicasso,uix): re-check caret applicability after the converge's flush; UIx arm left for a ruling (rf2-fki5d, rf2-47sko)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
@@ -793,6 +793,113 @@
                    the field shows"))))))))
 
 ;; ---------------------------------------------------------------------------
+;; 5c — the flush is a render, and the guards are one render old after it
+;; ---------------------------------------------------------------------------
+
+(defview type-flipping-cell
+  "A controlled field whose TYPE is derived from the model, so ONE
+  accepted keystroke re-renders the same `<input>` from `text` to
+  `number` — and does it inside the converge's own `flushSync`, against
+  a wrapper the `text` render minted."
+  [{:keys [i]}]
+  (let [v (rt/sub [:agrid/cell i])]
+    [:input.flip {:type     (if (= "" v) "text" "number")
+                  :value    v
+                  :on-input [:agrid/edit i :re-frame.hicasso/value]}]))
+
+(defn- reported-errors
+  "Run `f` and return the messages the page reported while it ran.
+
+  React does not let a throw from inside a discrete event escape
+  `dispatchEvent`: it hands it to `reportError`, which dispatches an
+  `error` event on `window`. So a `try`/`catch` around the keystroke sees
+  NOTHING, and a row that relied on one would be green over a live
+  exception — the browser runner's uncaught-pageerror gate would fail the
+  build (`rf2-mwx08`) while every assertion here passed. A listener is
+  what makes the throw this row's own to assert."
+  [f]
+  (let [!errs (atom [])
+        on-err (fn [e]
+                 (swap! !errs conj (or (some-> (.-error e) (.-message))
+                                       (.-message e))))]
+    (.addEventListener js/window "error" on-err)
+    (try (f) (finally (.removeEventListener js/window "error" on-err)))
+    @!errs))
+
+(deftest a-type-change-inside-the-flush-leaves-the-converge-inert
+  (testing "THE GUARD THAT HAS TO BE TAKEN TWICE (PR #7371 audit).
+
+           `front.controlled/install!` decides an element is
+           caret-bearing from the props that MINT the wrapper. Step 1 of
+           the converge is a `flushSync`, which is a render — so by the
+           time the caret is restored those props can be one render old.
+           A synchronous handler that re-renders the same `<input>` from
+           `text` to `number` is the case that separates them: React
+           keeps the node and updates the attribute, so the wrapper from
+           the `text` render goes on running against an element that no
+           longer has a caret, and `setSelectionRange` throws
+           `InvalidStateError` on such a type.
+
+           Reading the caret a SECOND time, after the flush, is what makes
+           the element behave exactly as it would have had it been minted
+           a `number` field to begin with.
+
+           Measured with the post-flush reading deleted: `InvalidStateError:
+           Failed to execute 'setSelectionRange' on 'HTMLInputElement': The
+           input element's type ('number') does not support selection.`"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (do
+        (pin! :react)
+        (fresh!)
+        (let [handle (mount/root! (mount/fresh-container!) frame-id
+                                  [type-flipping-cell {:i 31}])]
+          (try
+            (let [before (.querySelector (:container handle) ".flip")]
+              (is (= "text" (.-type before))
+                  "it mounts as a text field — which is what installs the
+                   wrapper in the first place")
+              (is (= "" (.-value before)))
+              (.focus before)
+              (.setSelectionRange before 0 0)
+              (is (= [0 0] (caret before)) "there really is a caret to lose")
+
+              ;; The keystroke. The model takes it (cell 31 is `:plain`),
+              ;; so the boundary re-renders inside the converge's flush and
+              ;; the type changes under the running wrapper.
+              (let [errs (reported-errors #(type-into! before "5"))
+                    after (.querySelector (:container handle) ".flip")]
+                (is (= [] errs)
+                    "NOTHING THREW — the row. Without the post-flush
+                     reading this carries the InvalidStateError quoted
+                     above")
+                (is (identical? before after)
+                    "React kept the NODE and updated the attribute — the
+                     premise the whole row turns on, asserted rather than
+                     assumed")
+                (is (= "5" (model-value 31)) "the model took the keystroke")
+                (is (= "number" (.-type after))
+                    "and the re-render landed inside the converge's own
+                     flush, so the type changed before the caret restore
+                     would have run")
+                (is (nil? (.-selectionStart after))
+                    "the node has no caret any more — which is both why
+                     the restore would throw and why there is nothing it
+                     could legitimately restore")
+                (is (= "5" (.-value after))
+                    "and the field still shows the keystroke that caused
+                     the flip")
+                (is (= "" (controlled/last-rendered after))
+                    "THE RECORD IS STALE HERE, and this is the second
+                     reason to be inert rather than merely careful with
+                     the caret: `setDefaultValue` skips a FOCUSED number
+                     field (`react-dom@19.2.0:1738`), so React's mirror
+                     still holds what the TEXT render wrote. It is no
+                     longer the value this element renders, so there is
+                     nothing here the converge could correctly write")))
+            (finally (mount/release! handle) (unpin!))))))))
+
+;; ---------------------------------------------------------------------------
 ;; 6 — :async-normalisation
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
@@ -111,6 +111,24 @@
   that quietly does less. The element then behaves exactly as it did
   before this namespace existed.
 
+  ## The guard that has to be taken twice
+
+  Every condition above is read off the props that MINT a wrapper, and
+  those props are one render old the moment step 1 returns — because
+  step 1 *is* a render. A synchronous handler can re-render the same
+  `<input>` from `text` to `number`; React keeps the node and updates
+  the attribute, so a wrapper installed on a caret-bearing element
+  goes on running against one that is not.
+
+  So [[converge!]] asks the caret question again after the flush.
+  Answered no, it does nothing at all — which matters twice over:
+  `setSelectionRange` throws `InvalidStateError` on such a type, and
+  `setDefaultValue` skips a focused `number` field (`:1738`), leaving
+  the record holding what the *text* render wrote rather than what
+  the element now renders. The throw is the measured defect;
+  `arm1_controlled_grid_dom_cljs_test/a-type-change-inside-the-flush-leaves-the-converge-inert`
+  quotes it and reds by name without this reading.
+
   ## The one handler, and the door
 
   `onChange` when the author wrote one, `onInput` otherwise. React's
@@ -216,19 +234,47 @@
   both: they are what the user's edit left behind, and the caret is
   only meaningful as an offset into that string.
 
-  Two readings make this inert rather than wrong where it does not
-  apply. A caret that is not a number is not a text-entry control —
-  a synthetic target in a unit test, or a type whose selection is not
-  applicable — and a record that is not a string is an element React
-  never wrote a mirror for. Either way the element is left exactly as
-  React leaves it."
+  Three readings make this inert rather than wrong where it does not
+  apply. A caret that is not a number is not a text-entry control — a
+  synthetic target in a unit test, or a type whose selection is not
+  applicable. A record that is not a string is an element React never
+  wrote a mirror for. And the caret is read a SECOND time, after the
+  flush, because the flush is a render.
+
+  ## Why the caret is read twice
+
+  [[install!]] decided this element was caret-bearing from the props
+  that minted *this* wrapper, and those props are one render old the
+  moment `flushSync` returns. A synchronous handler may re-render the
+  same `<input>` from `text` to `number` — React keeps the node and
+  updates the attribute, so the wrapper from the text render is still
+  the one running, against an element that no longer has a caret.
+
+  Both halves of the converge are wrong there. `setSelectionRange`
+  throws `InvalidStateError` on a type whose selection is not
+  applicable — that is the measured failure, and it is the whole of
+  why this is a correctness fix rather than a tidy-up. And the record
+  is stale rather than merely unused: `setDefaultValue` deliberately
+  skips a focused `number` field (`react-dom@19.2.0:1738`), so
+  `defaultValue` still holds what the *text* render put there. The
+  converge would write that over the field mid-event; React's own
+  end-of-event restore happens to put the committed value back
+  afterwards, so the field survives — but only by accident, and the
+  write was never this code's to make.
+
+  So the post-flush reading is not a guard bolted onto the caret
+  restore; it is the same question [[install!]] asked, asked again at
+  the only other moment it can change. Answered no, the element is
+  left exactly as React leaves it — which is what it would have been
+  had it been minted as a `number` field to begin with."
   [node]
   (let [dom-value (.-value node)
         caret-was (.-selectionStart node)]
     (when (number? caret-was)
       (react-dom/flushSync noop)
       (let [rendered (last-rendered node)]
-        (when (string? rendered)
+        (when (and (string? rendered)
+                   (number? (.-selectionStart node)))
           (converge-to! node dom-value caret-was rendered)))))
   nil)
 


### PR DESCRIPTION
Closes the correctness gap PR #7371's merged-PR audit found in the shipped
controlled-element converge. **The behavioural diff is one line**; the rest is
the row that proves it and the prose that explains why the reading is taken
twice.

## rf2-fki5d — the guard that has to be taken twice

`front.controlled/install!` decides an element is caret-bearing from the props
that **mint** the wrapper. But step 1 of the converge is a `flushSync`, and a
`flushSync` is a render — so by the time the caret is restored those props can
be one render old.

A synchronous handler that re-renders the same `<input>` from `type="text"` to
`type="number"` is the case that separates them. React keeps the node and
updates the attribute, so the wrapper minted by the *text* render goes on
running against an element that no longer has a caret:

```
InvalidStateError: Failed to execute 'setSelectionRange' on 'HTMLInputElement':
The input element's type ('number') does not support selection.
```

`converge!` now reads the caret a second time, after the flush, and is inert
when the answer changed — the same question `install!` asked, asked again at the
only other moment it can change:

```clojure
(when (and (string? rendered)
           (number? (.-selectionStart node)))     ; <- the whole fix
  (converge-to! node dom-value caret-was rendered))
```

`converge-to!` is deliberately untouched, so the trap row that calls it twice
with one argument different still says exactly what it said.

**The record is stale there too, and that is measured rather than argued.**
`setDefaultValue` skips a *focused* number field (`react-dom@19.2.0:1738`), so
`defaultValue` still holds what the text render wrote. The new row asserts
`(= "" (last-rendered after))` directly. React's own end-of-event restore
happens to put the committed value back afterwards, so the field survives a
converge that ignored the second reading — but only by accident, and the write
was never this code's to make. The prose says exactly that and does not
overclaim a data loss that does not occur.

### The row, and why it needed a listener

`arm1_controlled_grid_dom_cljs_test/a-type-change-inside-the-flush-leaves-the-converge-inert`
— a live React tree, no `act`, no `flushSync` in the path it reads. A
`type-flipping-cell` derives its `:type` from the model, so one accepted
keystroke re-renders `text` → `number` **inside the converge's own flush**.

React does not let a throw from inside a discrete event escape `dispatchEvent`
— it hands it to `reportError`. A `try`/`catch` around the keystroke therefore
sees nothing, and the first draft of this row was **green over a live
exception** while the runner's uncaught-pageerror gate (rf2-mwx08) failed the
build from outside. The row now installs a `window` `error` listener, so the
throw is its own to assert and it reds **by name**.

It also asserts the premise rather than assuming it: `(identical? before after)`
pins that React really did keep the node across the type change.

### Mutation-proved

Deleting only the post-flush reading and re-running the full browser suite:
**exit 1, exactly 1 failure**, by name, with

```
expected: (= [] errs)
  actual: (not (= [] ["Failed to execute 'setSelectionRange' on 'HTMLInputElement':
                      The input element's type ('number') does not support selection."]))
```

Every other assertion in the row passed under the mutation — including the
stale-record one — which is what establishes that the throw is the defect and
the record staleness is the second, quieter reason to be inert. Guard restored,
suite green. **The five landed rows are untouched and green throughout**, as is
`arm1_hook_ledger_dom_cljs_test` (no hook added — this adds a *reading*, never
a write).

### rf2-digtt (IME composition) is untouched

This adds a DOM read and removes a write; it never consults, sets or clears any
composing state, and does not change the composing path in either direction.
The composition carve-out remains unruled and unimplemented.

## rf2-47sko — NOT implemented; it is a ruling and the ruling has not been made

The bead says so in terms: *"THE OPTIONS, and this is a ruling rather than an
implementation"*, listing (a) port the converge into `re-frame.adapter.uix`,
(b) rule that the UIx adapter keeps React's behaviour and the caret is one of
the things Hicasso is *for*, (c) something narrower such as an opt-in wrapper.
`rf2-n3dxw` agrees: *"That is a decision, not an implementation, and it is filed
separately."*

The bead carries **no comments and no recorded ruling**, and none exists in the
studio matrix, in `bd memories`, or on the blocking bead. Option (a) would have
the adapter acquire an element path (or wrap `create-uix-input`) purely to hold
this — a real architectural commitment to a shipped, first-class,
publicly-documented adapter. That is not a worker's call to make, so this PR
does not make it. **rf2-47sko stays open for Mike.**

Nothing is missing on the evidence side, which is why the ruling is cheap to
take: the UIx gap is already witnessed executably by
`controlled_restore_dom_cljs_test/a-normalising-model-moves-the-caret-to-the-end-on-react`
(`[5 5]` where `[2 2]` is wanted) and documented for consumers in
`docs/api/re-frame.adapter.uix.md`. A second witness would have been
duplication, so none was added.

One fact this PR adds for whoever takes the ruling: **any port of the mechanism
now has to carry the post-flush reading too.** It is not Hicasso-specific — it
follows from `flushSync` being a render, which is true wherever the converge is
hung.

## Quality gates

Foreground, to completion, never piped through `tail`/`grep`; logs captured
worktree-local under `ai-logs/`.

| gate | exit | result |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`; per-ns isolation 17/17; JVM tiers 2210 tests / 11506 assertions and 1288 tests / 8857 assertions |
| `npm run test:browser` (guard restored) | **0** | 1025 tests / 6345 assertions, 0 failures, 0 errors |
| `npm run test:browser` (mutation: guard deleted) | **1** | 1 failure, by name — the `InvalidStateError` above |
| `shadow-cljs compile browser-test` | **0** | 1105 files, 0 warnings |
| `serve-and-run-adapter-smokes.cjs --filter uix` | **0** | 1 adapter-smoke spec, 0 failures (`implementation/adapters/uix/testbed/spec.cjs`) |

Foreground and to completion; logs captured worktree-local under `ai-logs/`.

**Not run / skipped, stated honestly.** The spine names three of its own gaps:
documentation gates (surface unchanged), the JVM artefact suites the diff did
not touch, and the whole CI-only tier — prod-elision, bundle-isolation, perf
gates, Xray feature matrix, mcp-conformance, tool JVM suites. Of the adapter
smokes I ran only the UIx one (`--filter uix`), not the full sweep.
`mkdocs build --strict` was not run: no documentation surface changed.
**Local-green is not CI-green.**
