### PR TITLE
feat(hicasso): hook-scoped provisional hand-off (rf2-2rtt6.25)

### DIFF
--- a/docs/design/hicasso/studio/coldmount-double-build-priced.md
+++ b/docs/design/hicasso/studio/coldmount-double-build-priced.md
@@ -32,6 +32,16 @@ HeadlessChrome 147.0.7727.15 (Chromium via Playwright), `:advanced`,
 > | `coldmount_views.cljs` | `ad3556a641ce174e3575c9f91668330db2861f93` |
 > | `coldmount_app.cljs`   | `46fcb53f43b2f87ef7d91a221456924c53bf9f3b` |
 > | `coldmount_run.cjs`    | `d37fd07688f6e9a47f18938117ba776cb8d098e9` (unchanged) |
+>
+> Those three blobs pin **what produced the figures**, so they stay as they
+> are. The instrument's working copy has since moved past them: the merged-PR
+> audit of #7326 found that the retraction above had not reached the source,
+> where the `shipped` arm still called itself this bead's acceptance witness
+> and the emitted records still said the shipped cold read builds once. The
+> arm is now named in the source and stamped in every emitted record as the
+> **forced-synchronous mechanism arm**, with a `:schedule` key carrying the
+> qualifier the prose here carries. Wording only — no measurement window was
+> altered to repair provenance, so the rows below still say what they said.
 
 Reproduce (each row is one page and one driver invocation; the plain command
 runs all five over the same gates):

--- a/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
+++ b/implementation/adapters/uix/test/re_frame/adapter/uix_use_subscribe_dom_cljs_test.cljs
@@ -374,6 +374,10 @@
    :gap-public-set-phase  gap-public-set-phase
    :pm-gap-frame          :rf.uix-handoff/public-gap-frame
    :pm-gap-control-frame  :rf.uix-handoff/public-gap-control-frame
+   ;; rf2-2rtt6.25 (audit of #7326) — the reaped provisional's own frame. The
+   ;; abandonment and the later mount must race on the SAME (frame, query), and
+   ;; the frame must be cold before the abandoned render, so it is its own.
+   :rv-frame              :rf.uix-handoff/reaped-provisional-frame
    ;; rf2-es09qq — Suspense abort-before-commit probe (reuses :rc-frame /
    ;; :rc-query so the abandoned render and the committed control mount race
    ;; on the SAME (frame, query)).
@@ -518,6 +522,15 @@
 
 (deftest use-subscribe-abandoned-layer-2-render-cascades-at-the-horizon
   (suite/assert-use-subscribe-abandoned-layer-2-render-cascades-at-the-horizon cfg))
+
+;; rf2-2rtt6.25 (merged-PR audit of #7326) — the adversarial row. On the public
+;; schedule the reaper usually WINS, so "reaped, then rebuilt fresh" is the
+;; ordinary consumer path: a provisional the reaper released must be
+;; unreachable, and a later mount must paint an app-db movement the abandoned
+;; render never saw. That is what makes the retracted benefit a performance
+;; retraction rather than a correctness one.
+(deftest use-subscribe-reaped-provisional-is-never-adopted-by-a-later-mount
+  (suite/assert-use-subscribe-reaped-provisional-is-never-adopted-by-a-later-mount cfg))
 
 (deftest use-subscribe-ssr-render-without-commit-nets-zero-at-the-horizon
   (suite/assert-use-subscribe-ssr-render-without-commit-nets-zero-at-the-horizon cfg))

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -5631,6 +5631,153 @@
                     (done))))
               0))))))))
 
+(defn assert-use-subscribe-reaped-provisional-is-never-adopted-by-a-later-mount
+  "rf2-2rtt6.25 (merged-PR audit of #7326): THE ADVERSARIAL ROW. A provisional
+  reference the reaper released must be UNREACHABLE — a later mount of the same
+  query builds its own reaction and paints the CURRENT value, never the one the
+  abandoned render's disposed reaction was holding.
+
+  This is the property that makes the lost race harmless, and it is the reason
+  `use-subscribe-public-mount-schedule-rebuilds` can assert a defect without
+  asserting a bug: on the public schedule the reaper usually DOES win, so
+  `reaped → rebuilt fresh` is the ordinary consumer path, not an edge case. If
+  a reaped reaction could be handed to a later subscriber the retraction would
+  be a correctness retraction rather than a performance one.
+
+  THE TEETH ARE THE WRITE. Between the horizon and the second mount the app-db
+  moves with NOBODY subscribed, so the abandoned render's reaction — had it
+  survived and been adopted — would paint the pre-write value. The DOM read is
+  therefore a discriminator and not a smoke test: `m=42` can only come from a
+  reaction built after the write.
+
+  SCHEDULE. The abandonment leg runs under `act` because what it needs is
+  React's abort, which `act` does not distort; the CLAIM leg is mounted through
+  `re-frame.substrate.adapter/render` with NO act and NO flushSync, so the
+  freshness property is pinned on the schedule consumers actually mount on.
+  It holds either way — whether the second mount's own commit adopts its render
+  build or rebuilds after its own reaper, the tenant is a reaction younger than
+  the write — which is exactly the schedule-independence Spec 006 requires.
+
+  The final leg crosses the horizon a second time: the abandoned render's token
+  is spent and the second mount's token is spent, and neither may decrement the
+  successor entry. This is the browser-level counterpart of the JVM
+  `unsubscribe-if-reaction-no-ops-against-a-successor-entry`, through the hook
+  rather than against the helper.
+
+  cfg keys: `:probe-suspense-abort-element` (the abandonment), the
+  public-schedule surface `:probe-public-mount-element` / `:pm-on-commit` (the
+  claim leg — its mount effect is declared after the read, so React runs it
+  immediately after the same fiber's `useSyncExternalStore` subscribe and the
+  snapshot is placed causally rather than by timing), `:refcount-target`,
+  `:rc-query`, and `:rv-frame` (this assertion's own frame, hence its own
+  sub-cache — the property is only load-bearing on a COLD read)."
+  [{:keys [name probe-suspense-abort-element probe-public-mount-element
+           pm-on-commit refcount-target rc-query rv-frame]}]
+  (testing (str name " — a reaped provisional is never adopted by a later mount (rf2-2rtt6.25)")
+    (if (nil? probe-suspense-abort-element)
+      (is true (str name ": no Suspense-abort probe wired; substrate skips this case"))
+      (with-browser-act
+       (fn [act-fn]
+        (reset! refcount-target rv-frame)
+        (rf/make-frame {:id rv-frame :doc "rf2-2rtt6.25 reaped-provisional revival frame"})
+        (rf/reg-event ::rv-seed (fn [_ _] {:db {:m 0}}))
+        (rf/reg-event ::rv-move (fn [_ _] {:db {:m 42}}))
+        (rf/dispatch-sync [::rv-seed] {:frame rv-frame})
+        (let [builds      (atom 0)
+              _           (rf/reg-sub rc-query (fn [db _] (swap! builds inc) (:m db)))
+              cache-key-v [rc-query]
+              cache       (:sub-cache (frame/frame rv-frame))
+              root        (react-dom-client/createRoot (make-mount-node!))
+              mount-node  (make-mount-node!)
+              at-commit   (atom nil)
+              unmount     (atom nil)]
+          (is (nil? (get @cache cache-key-v))
+              "precondition: no live cache entry, so the abandoned render is genuinely COLD")
+          ;; The abandoned render: `use-subscribe`'s render phase escrows a
+          ;; provisional reference, the child suspends, the fallback commits,
+          ;; and no fiber will ever adopt it.
+          (act-fn (fn [] (.render root (probe-suspense-abort-element))))
+          (let [abandoned (get-in @cache [cache-key-v :reaction])]
+            (is (some? abandoned)
+                "the abandoned render materialised a reaction and the escrow is holding it")
+            (is (pos? (ref-count-of cache cache-key-v))
+                (str "still held before the horizon — observed "
+                     (ref-count-of cache cache-key-v)))
+            (async done
+              (js/setTimeout
+                (fn []
+                  ;; The horizon: the escrow is released, 1 → 0 disposes, the
+                  ;; slot is evicted. `abandoned` is now a DISPOSED reaction.
+                  (is (nil? (get @cache cache-key-v))
+                      (str "one settle later the abandoned render's provisional is "
+                           "reaped, disposed and evicted — observed ref-count "
+                           (ref-count-of cache cache-key-v)))
+                  (act-fn (fn [] (try (.unmount root) (catch :default _ nil))))
+                  ;; THE WRITE, with nobody subscribed. Whatever the disposed
+                  ;; reaction is holding is now provably stale.
+                  (rf/dispatch-sync [::rv-move] {:frame rv-frame})
+                  (let [builds-before @builds]
+                    ;; THE CLAIM LEG — public schedule, no act, no flushSync.
+                    ;; The snapshot is taken from inside the probe's own mount
+                    ;; effect, which React runs immediately after that fiber's
+                    ;; commit-owned subscribe.
+                    (reset! pm-on-commit
+                            (fn []
+                              (when (nil? @at-commit)
+                                (reset! at-commit
+                                        {:builds    @builds
+                                         :tenant    (get-in @cache [cache-key-v :reaction])
+                                         :ref-count (ref-count-of cache cache-key-v)
+                                         :dom       (.-textContent mount-node)}))))
+                    (try
+                      (reset! unmount (substrate-adapter/render (probe-public-mount-element) mount-node {}))
+                      (catch :default e
+                        (is false (str "the public adapter render slot threw: " e))))
+                    (await-settlement!
+                      (fn [] (some? @at-commit))
+                      (fn []
+                        (let [snap @at-commit]
+                          (is (some? snap)
+                              (str "the later mount committed and its mount effect fired, "
+                                   "so there IS a post-subscribe moment to read. DOM was "
+                                   (pr-str (some-> mount-node .-textContent))))
+                          (when snap
+                            (is (not (identical? abandoned (:tenant snap)))
+                                (str "the reaped provisional was NOT handed to the later "
+                                     "mount — the tenant is a reaction built after it. "
+                                     "Snapshot " snap))
+                            (is (= "m=42" (:dom snap))
+                                (str "and the later mount paints the value the app-db holds "
+                                     "NOW, not the one the abandoned render's disposed "
+                                     "reaction was built on — the discriminator, because "
+                                     "the write landed with nobody subscribed. Observed "
+                                     (pr-str (:dom snap))))
+                            (is (pos? (- (:builds snap) builds-before))
+                                (str "which required a fresh construction — builds moved "
+                                     "from " builds-before " to " (:builds snap)))
+                            (is (= 1 (:ref-count snap))
+                                (str "exactly one durable reference — observed "
+                                     (:ref-count snap)))))
+                        ;; And neither spent token may decrement the successor.
+                        (js/setTimeout
+                          (fn []
+                            (try
+                              (is (= 1 (ref-count-of cache cache-key-v))
+                                  (str "across the horizon the successor entry still holds "
+                                       "exactly one reference: the abandoned render's token "
+                                       "and the later mount's are both spent, and a spent "
+                                       "token cannot reach an entry it never escrowed. "
+                                       "Observed " (ref-count-of cache cache-key-v)))
+                              (is (= "m=42" (.-textContent mount-node))
+                                  "and the mounted probe still renders its value")
+                              (finally
+                                (reset! pm-on-commit nil)
+                                (when-let [u @unmount] (try (u) (catch :default _ nil)))
+                                (done))))
+                          0))
+                      240)))
+                0)))))))))
+
 (defn assert-use-subscribe-ssr-render-without-commit-nets-zero-at-the-horizon
   "rf2-2rtt6.25 (SSR): `renderToString` runs the hook's render phase and never
   commits — there is no React commit on the server at all. The provisional

--- a/implementation/freehand/test/re_frame/bench/hicasso/coldmount_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/coldmount_app.cljs
@@ -76,15 +76,47 @@
       the census back to zero, and a leak here would silently convert
       later samples into warm-cache mounts. Equality, no tolerance.
 
+  ## WHICH SCHEDULE THESE ROWS SPEAK FOR — read this before quoting one
+
+  Every mount in this instrument — timed and counted alike — runs inside
+  `react-dom/flushSync` (`coldmount_views.cljs`). That forces React's
+  passive `useSyncExternalStore` subscribe to run before control returns,
+  and that IS the ordering the rf2-2rtt6.25 hand-off needs in order to
+  win its race with its own reaper. **The shipping client mount path does
+  not force it**: `re-frame.substrate.adapter/render` is a bare
+  `createRoot(…).render(…)`, and there the `setTimeout 0` reaper fires
+  first, so the escrowed reference is released, the commit misses, and
+  the mount rebuilds — `bodyRuns` 2.00N, measured at N = 1 and N = 300
+  (rf2-2rtt6.25, merged-PR audit of #7305; the browser assertion is
+  `use-subscribe-public-mount-schedule-rebuilds`).
+
+  So the `shipped` arm here is **the forced-synchronous MECHANISM arm**,
+  not an acceptance witness for shipped performance. Its rows say what
+  the hand-off costs and saves WHEN IT RUNS TO COMPLETION. They are not a
+  statement about any mount a consumer performs today, and the
+  `:schedule` key on every record emitted below says so in the data as
+  well as in this docstring. The instruments themselves — the counting
+  witness, the fidelity control, the residue gate, the segment-order
+  control — are unaffected; what changed is which schedule they speak
+  for. Nothing here is unsound: Spec 006 §Render-phase provisional
+  acquisition and commit adoption requires that correctness never depend
+  on the reaper losing the race, and the lost race costs a construction
+  and nothing else.
+
+  The reap horizon that would recover the saving on the public schedule
+  is an OPERATOR DECISION (rf2-2rtt6.14 ruled the primitive), so no
+  measurement window in this file is touched to repair the wording.
+
   ## What fails the run
 
   The counting witness adjudicated per page BEFORE any clock (predicted
   commits / rebuilt / per-layer bodyRuns, exact — including the SHIPPED
-  arm, which since rf2-2rtt6.25 must read the `handoff` row); the clock
-  fidelity control (`uix-subs` vs `handoff` — ranges overlap or medians
-  within the pre-declared 3% band, else every delta is void; re-pointed
-  from `xcript` by rf2-2rtt6.25, because the shipped hook IS the hand-off
-  now and `xcript` is the retired double build); the positive controls;
+  arm, which under THIS harness's forced-synchronous schedule reads the
+  `handoff` row); the clock fidelity control (`uix-subs` vs `handoff` —
+  ranges overlap or medians within the pre-declared 3% band, else every
+  delta is void; re-pointed from `xcript` by rf2-2rtt6.25, because on
+  this schedule the shipped hook runs the hand-off to completion and
+  `xcript` is the double build it transcribes); the positive controls;
   the DOM read-backs; the residue gate; the arm-order guard (exit 2); the
   segment-order direction refusal. The records are written to the console
   before any refusal, so the evidence survives it.
@@ -128,6 +160,31 @@
   "Boundaries per counting-witness mount; 3 reads each, so N = 300 reads
   per call — the same N as a timed M1 mount."
   100)
+
+(def ^:private schedule-provenance
+  "STAMPED ON EVERY EMITTED RECORD (rf2-2rtt6.25, merged-PR audit of
+  #7326). A row that travels without its schedule is a row that will be
+  quoted as a shipped-performance claim, which is exactly what happened
+  to this instrument's first `shipped` table. So the schedule rides in
+  the data, not only in the docstring.
+
+  See the namespace docstring's \"Which schedule these rows speak for\"."
+  {:mount-schedule :forced-synchronous
+   :how            "react-dom/flushSync around every mount — the timed ones in lane/mount-arm! and lane/mount-batch!, the counted ones in coldmount-views/witness!"
+   :arm            "the shipped hook's hand-off MECHANISM, measured where it is allowed to run to completion"
+   :not            (str "NOT a shipped-mount-performance claim. The public client mount path is "
+                        "re-frame.substrate.adapter/render — a bare createRoot().render() — and there "
+                        "the setTimeout-0 reaper releases the escrowed reference before React's passive "
+                        "useSyncExternalStore subscribe, so the commit misses and rebuilds: bodyRuns "
+                        "2.00N at N = 1 and N = 300 (rf2-2rtt6.25, merged-PR audit of #7305).")
+   :correctness    (str "unaffected either way — Spec 006 §Render-phase provisional acquisition and "
+                        "commit adoption requires that correctness never depend on the reaper losing "
+                        "the race; the lost race costs a construction and the steady state is one "
+                        "durable reference.")
+   :horizon        "the reap horizon that would recover the saving on the public schedule is an OPERATOR DECISION (rf2-2rtt6.14 ruled the primitive); no measurement window here was altered to repair provenance"
+   :assertions     ["use-subscribe-public-mount-schedule-rebuilds"
+                    "use-subscribe-escrow-leg-answers-on-the-public-mount-schedule"
+                    "use-subscribe-reaped-provisional-is-never-adopted-by-a-later-mount"]})
 
 ;; ---------------------------------------------------------------------------
 ;; Segments
@@ -356,9 +413,13 @@
                       (cmv/witness! :xcript  layer witness-boundaries 900)
                       (cmv/witness! :handoff layer witness-boundaries 1800)
                       (cmv/witness! :handoff layer witness-boundaries 2700)
-                      ;; rf2-2rtt6.25 — the ACCEPTANCE WITNESS. The shipped
-                      ;; hook must read the `handoff` row, on its own disjoint
-                      ;; cell ranges.
+                      ;; rf2-2rtt6.25 — the FORCED-SYNCHRONOUS MECHANISM arm.
+                      ;; `witness!` mounts inside `flushSync`, and on THAT
+                      ;; schedule the shipped hook runs the hand-off to
+                      ;; completion and reads the `handoff` row. On the public
+                      ;; `createRoot().render()` path it reads the `xcript` row
+                      ;; instead — ns docstring, "Which schedule these rows
+                      ;; speak for". Own disjoint cell ranges.
                       (cmv/witness! :shipped layer witness-boundaries 3600)
                       (cmv/witness! :shipped layer witness-boundaries 4500)])))
           {}
@@ -376,11 +437,19 @@
   Layers above L must read 0 — a non-zero there means the chain is not
   the chain this page claims to price.
 
-  `shipped` reading the `handoff` row is what rf2-2rtt6.25 has to prove:
-  the shipped hook adopting the render-phase materialisation rather than
-  rebuilding it. Its counters come from the sub-cache rather than from an
-  instrumented `subscribe-fn` (`coldmount-views` namespace docstring), so
-  the two arms are independent measurements of the same claim."
+  THE `shipped` ROW IS SCHEDULE-CONDITIONAL, and this is the harness's
+  schedule, not the consumer's. `witness!` mounts inside `flushSync`, so
+  React's passive subscribe runs before control returns and the hand-off
+  reaches its adoption; that is what makes `rebuilt 0` predictable here.
+  On the public `createRoot().render()` path the reaper wins first and
+  the same hook reads the `xcript` row — `rebuilt N`, `bodyRuns 2N`
+  (rf2-2rtt6.25, audit of #7305). So this prediction adjudicates that the
+  MECHANISM runs to completion when it is allowed to; it is not an
+  acceptance witness for shipped mount performance, and a failure here is
+  a broken mechanism rather than a lost race. Its counters come from the
+  sub-cache rather than from an instrumented `subscribe-fn`
+  (`coldmount-views` namespace docstring), so `shipped` and `handoff`
+  remain independent measurements of the same mechanism."
   [by-seg layer]
   (vec
     (for [[seg ws] by-seg
@@ -524,15 +593,19 @@
   shipped hook. Both readers here are the same clock, so the legs are the
   per-round p50 ranges and the medians.
 
-  RE-POINTED BY rf2-2rtt6.25. Before the hand-off landed, the shipped hook
-  was the double build and `xcript` was its transcription, so `xcript` was
-  the fidelity partner. The shipped hook IS the hand-off now, so the
-  transcription that has to reproduce it is `handoff` — and this control
-  is simultaneously the clock half of the acceptance witness: the shipped
-  arm must sit inside the single-build band, not the double-build one.
-  `xcript` stays in the run as the double-build reference; it is what the
-  published delta is measured against, and it is deliberately NOT expected
-  to match the shipped clock any more."
+  RE-POINTED BY rf2-2rtt6.25, ON THIS HARNESS'S SCHEDULE. Before the
+  hand-off landed, the shipped hook was the double build and `xcript` was
+  its transcription, so `xcript` was the fidelity partner. Inside
+  `flushSync` the shipped hook now runs the hand-off to completion, so
+  the transcription that has to reproduce it is `handoff`, and this
+  control is the clock half of the MECHANISM arm: the shipped arm must
+  sit inside the single-build band on the schedule the harness forces.
+  It says nothing about the public `createRoot().render()` path, where
+  the reaper wins and the shipped clock is the double build's — see the
+  ns docstring's schedule section. `xcript` stays in the run as the
+  double-build reference; it is what the published delta is measured
+  against, and on THIS schedule it is deliberately NOT expected to match
+  the shipped clock."
   [uix-vec handoff-vec]
   (let [a   (range-of uix-vec)
         b   (range-of handoff-vec)
@@ -590,17 +663,21 @@
         verdict   (rule-verdict fractions fractions-seam)]
     (lane/record! (name row-key)
                   {:benchmark   (keyword "hicasso.coldmount" (name row-key))
-                   :bead        "rf2-2rtt6.15 (instrument); re-run as the acceptance witness for rf2-2rtt6.25"
+                   :bead        "rf2-2rtt6.15 (instrument); re-run for rf2-2rtt6.25 as the forced-synchronous MECHANISM arm"
                    :doc         doc
                    :grade       grade
                    :layer       layer
                    :witness-set "rf2-2rtt6.2 (converged; p0-converged-witness-set.md)"
+                   :schedule    schedule-provenance
                    :spine       (str "the SHIPPED re-frame.substrate.spine/use-subscribe — "
                                      "rf2-2rtt6.13 (no retained dead handle) AND rf2-2rtt6.25 "
-                                     "(the hook-scoped provisional hand-off) both landed, so "
-                                     "the shipped cold read builds ONCE and the commit adopts "
-                                     "it; `xcript` is the retired double build, kept as the "
-                                     "reference the delta is measured against")
+                                     "(the hook-scoped provisional hand-off) both landed. Under "
+                                     "THIS harness's forced-synchronous schedule the cold read "
+                                     "builds ONCE and the commit adopts it; on the public "
+                                     "createRoot().render() path the reaper wins first and the "
+                                     "same hook builds TWICE (rf2-2rtt6.25, audit of #7305). "
+                                     "`xcript` is the double build, kept as the reference the "
+                                     "delta is measured against")
                    :rounds      rounds
                    :balanced-design? (even? rounds)
                    :per-round   {:floor-reagent (mapv lane/round4 (pick :floor-reagent))
@@ -627,6 +704,7 @@
                   {:row row-key
                    :layer layer
                    :grade grade
+                   :schedule schedule-provenance
                    :fraction-of-red-zone
                    {:raw           (when (resolved? fractions) (range-of fractions))
                     :seam-adjusted (when (resolved? fractions-seam) (range-of fractions-seam))
@@ -639,12 +717,13 @@
                               ">= 20% on representative layer-1 AND layer-2/3 mounts -> "
                               "reopen for a hook-scoped provisional hand-off design pass only")
                    :row-verdict verdict})
-    (lane/record! "fidelity" (assoc fid :row row-key))
+    (lane/record! "fidelity" (assoc fid :row row-key :schedule schedule-provenance))
     (lane/record! "witness-counts"
                   {:row row-key :layer layer
+                   :schedule schedule-provenance
                    :predictions {:xcript  "commits N, rebuilt N, bodyRuns 2N at every layer <= L"
                                  :handoff "commits N, rebuilt 0, bodyRuns N at every layer <= L"
-                                 :shipped "commits N, rebuilt 0, bodyRuns N at every layer <= L — rf2-2rtt6.25's ACCEPTANCE WITNESS: the shipped hook reads the handoff row"
+                                 :shipped "commits N, rebuilt 0, bodyRuns N at every layer <= L — SCHEDULE-CONDITIONAL: the shipped hook reads the handoff row only because this harness mounts inside flushSync. On the public createRoot().render() path it reads the xcript row (rf2-2rtt6.25, audit of #7305). Not an acceptance witness for shipped mount performance."
                                  :reagent "commits 0, rebuilt 0, bodyRuns N at every layer <= L"}
                    :results witness-results
                    :failures wfails})

--- a/implementation/freehand/test/re_frame/bench/hicasso/coldmount_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/coldmount_run.cjs
@@ -40,6 +40,22 @@
 //
 // A Chromium `pageerror` is FATAL: a benchmark that threw and kept going
 // publishes a precise number for a page that is not the page under test.
+//
+// ## WHICH SCHEDULE THESE ROWS SPEAK FOR (rf2-2rtt6.25, audit of #7326)
+//
+// Every mount this driver provokes runs inside `react-dom/flushSync`, which
+// forces React's passive `useSyncExternalStore` subscribe before control
+// returns — the ordering the rf2-2rtt6.25 provisional hand-off needs to win
+// its race with its own reaper. The public client mount path
+// (`re-frame.substrate.adapter/render`, a bare `createRoot().render()`) does
+// NOT force it, and there the reaper fires first and the cold mount rebuilds.
+//
+// So the `shipped` arm below is the forced-synchronous MECHANISM arm: it says
+// what the hand-off costs and saves when it runs to completion, and it is NOT
+// an acceptance witness for shipped mount performance. Every record this run
+// emits carries that as a `:schedule` key. Nothing is unsound — the lost race
+// costs a construction, never correctness (Spec 006 §Render-phase provisional
+// acquisition and commit adoption). The reap horizon is an operator decision.
 
 'use strict';
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/coldmount_views.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/coldmount_views.cljs
@@ -2,10 +2,36 @@
   "THE COLD-MOUNT DOUBLE BUILD, PRICED ON THE CLOCK — the views, the sub
   layers, the hook transcriptions and the counting witnesses
   (rf2-2rtt6.15, epic rf2-2rtt6 / EP-0038; decision input for the
-  rf2-2rtt6.14 ruling, and since rf2-2rtt6.25 the ACCEPTANCE WITNESS for
-  the hand-off that ruling adopted).
+  rf2-2rtt6.14 ruling, and since rf2-2rtt6.25 the FORCED-SYNCHRONOUS
+  MECHANISM ARM for the hand-off that ruling adopted).
 
-  ## The term that was priced, and then deleted
+  ## THE SCHEDULE THIS PAGE MEASURES — read this before quoting a row
+
+  Every mount this page provokes runs inside `react-dom/flushSync` — the
+  timed ones through `lane/mount-arm!` and `lane/mount-batch!`, the
+  counted ones in `witness!` below. That forces React's passive
+  `useSyncExternalStore` subscribe to run before control returns, which
+  is precisely the ordering the rf2-2rtt6.25 hand-off needs in order to
+  reach its adoption before its own `setTimeout 0` reaper fires. On the
+  public client mount path — `re-frame.substrate.adapter/render`, a bare
+  `createRoot(…).render(…)` with nothing forcing the schedule — THE
+  REAPER WINS: the escrowed reference is released, the commit misses, and
+  the cold read builds twice, `bodyRuns` 2.00N measured at N = 1 and
+  N = 300 (rf2-2rtt6.25, merged-PR audit of #7305; browser assertion
+  `use-subscribe-public-mount-schedule-rebuilds`).
+
+  So the `shipped` rows below are the MECHANISM measured where it is
+  allowed to run to completion. They are not an acceptance witness for
+  shipped mount performance and must not be quoted as one. Nothing here
+  is unsound: Spec 006 §Render-phase provisional acquisition and commit
+  adoption requires that correctness never depend on the reaper losing
+  the race, and it does not — the lost race costs a construction and the
+  steady state is one durable reference either way. The reap horizon that
+  would recover the saving on the public schedule is an OPERATOR DECISION
+  (rf2-2rtt6.14 ruled the primitive), and no measurement window in this
+  file was altered to repair this wording.
+
+  ## The term that was priced, and the schedule on which it is recovered
 
   `re-frame.substrate.spine/use-subscribe` USED TO take a BALANCED
   render-phase round trip — `subs/subscribe` immediately followed by
@@ -23,12 +49,11 @@
   red-zone in every round at layers 1, 2 and 3.
 
   rf2-2rtt6.14 ruled ADOPT on that evidence, and rf2-2rtt6.25 landed the
-  hook-scoped provisional hand-off. So the `handoff` arm below stopped
-  being a hypothesis and became a PREDICTION about shipped code, and this
-  page's job changed with it: the shipped arm must now reproduce the
-  handoff arm's counts and sit inside its clock band. `xcript` stays as
-  the double-build reference — the thing that was removed, kept so the
-  delta it defines can still be read.
+  hook-scoped provisional hand-off. So the `handoff` arm below became a
+  prediction about shipped code ON THE SCHEDULE THIS PAGE FORCES, and the
+  `shipped` arm exists to check it there: same counts, same clock band.
+  `xcript` stays as the double-build reference — still what a consumer
+  mount pays today, and what the delta is measured against.
 
   ## The single-variable ablation
 
@@ -44,7 +69,8 @@
   per mounted read (render, commit, unmount); both install the same
   watch, the same refs, the same six hooks. `xcript - handoff` is
   therefore the build/dispose/rebuild churn ALONE — the clock the shipped
-  hand-off recovers.
+  hand-off recovers WHEN IT RUNS TO COMPLETION, i.e. on the schedule this
+  page forces and not on the public one (schedule section above).
 
   `handoff` remains a MEASUREMENT ARM and not a copy of the shipped code:
   it holds its provisional +1 with no reaper, so a render abandoned
@@ -83,10 +109,14 @@
 
   `rebuilt = 0` is what makes the ablation single-variable: the
   commit-phase acquire hands back the IDENTICAL reaction the render
-  built. `shipped` reading the same row as `handoff` is the ACCEPTANCE
-  WITNESS for rf2-2rtt6.25 — the shipped hook converging onto what the
-  transcription measured. The witness components never appear in a timed
-  window and the timed arms never touch a counter.
+  built. `shipped` reading the same row as `handoff` adjudicates that the
+  MECHANISM completes — the shipped hook converging onto what the
+  transcription measured, on the flushSync schedule `witness!` forces. It
+  is SCHEDULE-CONDITIONAL and not an acceptance witness for shipped mount
+  performance: on the public `createRoot().render()` path the same hook
+  reads the `xcript` row instead. A failure here is therefore a broken
+  mechanism, not a lost race. The witness components never appear in a
+  timed window and the timed arms never touch a counter.
 
   ## How the SHIPPED arm is counted without a counter
 
@@ -790,7 +820,18 @@
 
   `:shipped` mounts the real hook and derives `commits` / `rebuilt` from
   the sub-cache rather than from a counter — same meanings, no seam cut
-  into production code (namespace docstring)."
+  into production code (namespace docstring).
+
+  SCHEDULE, STAMPED HERE BECAUSE THIS IS WHERE THE NUMBERS ARE MADE
+  (rf2-2rtt6.25, audit of #7326): the mount and the unmount below are
+  bracketed by `react-dom/flushSync`, which forces React's passive
+  `useSyncExternalStore` subscribe before control returns. The `:shipped`
+  arm therefore reports the hand-off RUNNING TO COMPLETION. On the public
+  `createRoot().render()` path the `setTimeout 0` reaper fires first and
+  the same hook reports the `:xcript` row. The `flushSync` is NOT here to
+  flatter the hand-off — it is what makes a counted mount a single
+  bounded window at all, and it predates the hand-off — so it stays; what
+  it costs is the right to read these rows as consumer-mount performance."
   [variant layer n offset]
   (reset-witness-counters!)
   (reset! shipped-render-observed {})


### PR DESCRIPTION
Closes the **merged-PR audit remainder on rf2-2rtt6.25** (audit of #7326). Everything else on that bead is an operator decision, not work — see "What is still Mike's" below.

## What the audit found, and what this fixes

#7326 retracted the hand-off's shipped-performance claims in the studio pages and Spec 006, but never touched **the executable evidence producer**. So the instrument still said the opposite of the retraction:

- `coldmount_app.cljs` predicted `:shipped` as `commits N / rebuilt 0 / bodyRuns N` under the heading **"rf2-2rtt6.25 — the ACCEPTANCE WITNESS"**, and its emitted `:spine` record read *"the shipped cold read builds ONCE and the commit adopts it"*.
- `coldmount_views.cljs` was headed **"The term that was priced, and then deleted"** and said the shipped hook *recovers* the double-build clock.

Because the harness **forces the winning schedule**, its gates stay green while its machine-readable provenance is false for every mount a consumer performs.

**Relabelled, not re-measured.** Every mount this instrument provokes runs inside `react-dom/flushSync` — the timed ones in `lane/mount-arm!` / `lane/mount-batch!`, the counted ones in `coldmount-views/witness!` — which forces React's passive `useSyncExternalStore` subscribe before control returns, and that *is* the ordering the hand-off needs to beat its own reaper. The `shipped` arm is now named for what it is: **the forced-synchronous mechanism arm**, saying what the hand-off costs and saves when it runs to completion, explicitly not an acceptance witness for shipped mount performance.

The predictions, the fidelity control, the residue gate and the segment-order control are **untouched**. The audit's instruction was not to alter a measurement window in order to repair wording, and the reap horizon remains Mike's call (rf2-2rtt6.14 ruled the primitive).

## The stamp rides in the data, not only in the docstrings

A `schedule-provenance` map is attached as `:schedule` to the **benchmark**, **coldmount-fraction**, **fidelity** and **witness-counts** records. It names the schedule, what the rows are *not* a claim about, why nothing is unsound, and the three browser assertions that pin the public-schedule behaviour. A row that travels without its schedule is a row that gets quoted as shipped performance — which is exactly what happened here.

## The adversarial test

One new assertion, **on the public schedule**: `use-subscribe-reaped-provisional-is-never-adopted-by-a-later-mount`.

An abandoned Suspense render escrows a provisional; the horizon reaps and evicts it; **the app-db then moves with nobody subscribed**; and a later mount through `re-frame.substrate.adapter/render` — no `act`, no `flushSync` — must build its own reaction and paint the new value.

The write is what gives the row teeth: a reaped reaction, had it survived and been adopted, would paint the pre-write value, so `m=42` can only come from a reaction younger than the write. The snapshot is taken **inside the probe's own mount effect**, which React orders after that fiber's commit-owned subscribe — placed causally, not by timing. A final leg crosses the horizon again: neither spent token may decrement the successor entry — the browser-level counterpart of the JVM `unsubscribe-if-reaction-no-ops-against-a-successor-entry`.

This is the property that makes the retraction a **performance** retraction rather than a correctness one. On the public schedule the reaper usually wins, so "reaped, then rebuilt fresh" is the *ordinary consumer path*, and until now nothing pinned it end-to-end through the hook.

**The witness was proved live, not assumed.** A falsification run (`m=42` replaced by a sentinel that cannot match) produced exactly one failure, naming this assertion, with `actual: (not (= "m=999-FALSIFICATION-PROBE" "m=42"))` — so the assertion really executes on the public schedule and really reads `m=42`. The probe was then reverted; the working tree is byte-identical to the green run.

## Hook budget

**Unchanged — no hook was added.** The diff is bench prose, emitted-record metadata, and test code; `re-frame.substrate.spine` and `re-frame.subs.cache` are not touched (the diffstat below has no `implementation/core/src` entry). The spine's hook shell is exactly what #7326 landed.

## rf2-2rtt6.50 (render to commit gap) — NOT closed by this PR

rf2-2rtt6.50 records that a **first registration** landing inside a Hicasso boundary's render/commit gap reaches no cell and is pinned rather than repaired. That is a different gap from this bead's: .50 is about a `reg-sub` arriving with no cell to invalidate on the Arm-1 boundary; this bead's is about a *provisional cache reference* surviving from render to commit on the React-hook spine. Nothing here touches `arm1/`, the registrar, or `getSnapshot`'s epoch sum, and .50's deliberately-`*` row is untouched. **.50 stays open and unabsorbed.**

## What is still Mike's (unchanged by this PR)

The reap horizon. `setTimeout 0` (shipped) reads 2.00N at N = 1 and N = 300 on the public schedule; `setTimeout 4` and `setTimeout 32` read 1.00N at both — but **every winner is a margin, not a guarantee**. rf2-2rtt6.14 ruled the primitive, so changing it is an operator lifecycle decision, not a worker's. The public-schedule assertions are written to be **inverted, not deleted**, the day it is ruled — this PR keeps them that way.

## Quality gates

Foreground, to completion, captured to worktree-local logs; exit codes echoed explicitly.

| gate | command | exit |
|---|---|---|
| fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** |
| browser DOM suite | `npm run test:browser` (from `implementation/`) | **0** |
| bench-lane compile (transitive surface of the coldmount diff) | `shadow-cljs compile hicasso-bench --config-merge ':init-fn re-frame.bench.hicasso.coldmount-app/-main'` | **0** |
| doc slugs (`docs/design/**` is outside `mkdocs --strict`) | `python scripts/check_doc_slugs.py` | **0** |

Browser suite: **Ran 1025 tests containing 6346 assertions. 0 failures, 0 errors.**
Bench-lane compile: `[:hicasso-bench] Build completed. (166 files, 165 compiled, 0 warnings)`.
Node-test build inside the spine: `(2125 files, 2124 compiled, 0 warnings)`.

**Falsification control** (deliberate, then reverted): the same browser suite with one assertion negated gave `1 failures, 0 errors`, `FAIL in (use-subscribe-reaped-provisional-is-never-adopted-by-a-later-mount)`. This is the proof the new row is not silently skipping.

**Doc gate note.** `mkdocs build --strict` does not cover `docs/design/**`, so per the repo convention I verified the edit by hand: it adds a paragraph inside an existing blockquote and touches **no heading, no table and no link**, so anchors and table column counts are unchanged. `scripts/check_doc_slugs.py` exits 0.

**No bench driver was run and no timing row is published** — siblings are measuring on a quiet box. The bench gate above is a compile only.
