### PR TITLE
test(core,subs): four always-on witnesses that could not fail, and the flush-path C1 pins (rf2-d2841, rf2-gncxk.1)

### DIFF
--- a/implementation/core/test/re_frame/configure_test.clj
+++ b/implementation/core/test/re_frame/configure_test.clj
@@ -176,15 +176,28 @@
             an event handler so the emit rides an in-flight dispatch-id +
             frame (push-to-ring! skips frameless/dispatch-id-less emits
             per the B3 ruling) and lands in the frame's retained ring."
+    ;; The handler stamps a SENTINEL rather than returning `{:db db}`.
+    ;; MERGED-PR AUDIT #7245 (rf2-d2841): the witness here used to be
+    ;; `(some? (rf/app-db-value :rf/default))` over a handler that committed
+    ;; `db` unchanged — but `reset-runtime`'s `make-frame` seeds `:rf/default`
+    ;; app-db as `{}`, which is already `some?` BEFORE any dispatch. It could
+    ;; not fail, so it proved nothing about the handler. An actual state
+    ;; TRANSITION can: the key is absent up front and present afterwards, so a
+    ;; handler that never ran, or a `configure!` throw that derailed the
+    ;; dispatch before the commit, reddens this.
     (rf/reg-event :bad-configure-call
                   (fn [{:keys [db]} _]
                     (rf/configure! {:trace-buffer {:depth 200}})
-                    {:db db}))
+                    {:db (assoc db ::bad-configure-committed :yes)}))
+    (is (nil? (::bad-configure-committed (rf/app-db-value :rf/default)))
+        "the sentinel is absent before the dispatch — the witness below is a
+         real transition, not a property app-db already had")
     (rf/dispatch-sync [:bad-configure-call])
     ;; ALWAYS-ON (rf2-d2841): the bad `configure!` call from inside a handler
-    ;; must not derail the dispatch — the handler's `{:db db}` still commits.
-    (is (some? (rf/app-db-value :rf/default))
-        "the enclosing dispatch completed despite the rejected configure! call")
+    ;; must not derail the dispatch — the handler's `:db` effect still commits.
+    (is (= :yes (::bad-configure-committed (rf/app-db-value :rf/default)))
+        "the enclosing dispatch completed despite the rejected configure! call
+         — the handler ran to its end and its commit landed")
     ;; rf2-d2841 — dev-instrumentation arm (see ns docstring §Posture split).
     ;; BOTH reads go inside: `trace-buffer` returns [] in production, so the
     ;; `{:severity :error}` sanity NEGATIVE would pass over an empty vector —
@@ -227,13 +240,21 @@
     (rf/configure! {:strict-subs true})
     (rf/configure! {:ssr {:public-error-id :nope}})
     (rf/configure! {:no-such-key {}})
-    (rf/reg-event :ping (fn [{:keys [db]} _] {:db db}))
+    ;; `:ping` COUNTS. MERGED-PR AUDIT #7245 (rf2-d2841): this used to be a
+    ;; `{:db db}` no-op handler witnessed by `(some? (rf/app-db-value
+    ;; :rf/default))`, which is true of the `{}` `make-frame` seeds before any
+    ;; dispatch at all — so a missing handler, a perturbed registry or a
+    ;; dispatch loop that ran three times instead of thirty all passed. An
+    ;; exact counter cannot: the claim is "thirty landings", so assert thirty.
+    (rf/reg-event :ping (fn [{:keys [db]} _] {:db (update db ::pings (fnil inc 0))}))
+    (is (nil? (::pings (rf/app-db-value :rf/default)))
+        "no landings recorded yet")
     (dotimes [_ 30] (rf/dispatch-sync [:ping]))
     ;; ALWAYS-ON (rf2-d2841): whatever the posture, thirty dispatches bracketed
     ;; by four unknown-key `configure!` calls still all landed — the
     ;; production-visible half of "an unknown key perturbs nothing".
-    (is (some? (rf/app-db-value :rf/default))
-        "the bracketed dispatches ran to completion")
+    (is (= 30 (::pings (rf/app-db-value :rf/default)))
+        "all thirty bracketed dispatches ran to completion and committed")
     ;; rf2-d2841 — dev-instrumentation arm. `(<= (count []) 11)` is true for
     ;; every N under the gate: the retention cap is unreadable in production.
     (when interop/debug-enabled?

--- a/implementation/core/test/re_frame/sub_memo_flush_path_cljs_test.cljs
+++ b/implementation/core/test/re_frame/sub_memo_flush_path_cljs_test.cljs
@@ -15,20 +15,48 @@
 
     * `flush!` — the WRITE path, run once per dirty entry at epoch drain.
 
-  rf2-gncxk records a proof that the guard is guaranteed to MISS on the
-  flush path: `flush!` runs only if the value was marked dirty, which
+  rf2-gncxk was filed on a proof that the guard is guaranteed to MISS on
+  the flush path: `flush!` runs only if the value was marked dirty, which
   happens only if the source's `notify` fired, which requires movement by
   `rf=` — and `rf=` moved implies `=` differs.
 
-  **That proof is sound for `:db` and `:runtime-db`, and UNSOUND for
-  `:frame-state` — all three of which share this one wrapper**
-  (`subs/single-source-input-kinds`). The difference is what sits between
-  the sub and the physical frame-state atom:
+  **THAT PROOF IS FALSE, and the correction is the whole point of this
+  namespace** (rf2-gncxk.1's design pass; merged-PR audit #7233). It
+  establishes \"the source moved since the source's PREVIOUS NOTIFY\". The
+  guard asks a DIFFERENT question — \"did the input move since THE WRAPPER
+  LAST RAN\" — and two reachable interleavings separate them, in both of
+  which the guard correctly HITS on the flush path even for `:db`:
+
+    * **(a) DEREF-BETWEEN.** The source moves P → N and marks the sub
+      dirty. Anything derefs the sub before the drain reaches its queued
+      flush; `deref-derived` is PULL-based, so that read recomputes against
+      N and leaves `last-db` = N. The queued `flush!` then arrives with N
+      against N.
+
+    * **(b) RETURN-TO-EQUAL.** Two writes inside one drain take app-db
+      A → B → A′ with A′ `=` A but a fresh object. The sub's `mark-dirty!`
+      dedups, so ONE flush arrives with A′ against `last-db` = A: the
+      source moved twice by `rf=`, `=` says equal.
+
+  So no fast path may key on \"am I on the flush path?\". The landed fix
+  (rf2-gncxk.1) keys on an exact fact about the SOURCE instead — the
+  `re-frame.movement/IMovementWitness` departure value — and this namespace
+  is where its consumer-side obligation is pinned: **C1, VERDICT-
+  PRESERVING**. The witness may only skip a comparison whose answer it
+  already determines, so every deftest below asserts a `{hit, miss}`
+  verdict that must be bit-identical with and without it.
+
+  There IS still an asymmetry between the single-source kinds, and the
+  first two tests pin it. All three share this one wrapper
+  (`subs/single-source-input-kinds`); what differs is what sits between the
+  sub and the physical frame-state atom:
 
     * `:db` / `:runtime-db` read a PROJECTION — a `make-derived-value` whose
       `notify` is gated on `rf=`. A commit that installs a value-equal
-      app-db does not propagate, so the sub is never marked dirty and
-      `flush!` never runs. The guard genuinely cannot hit on this path.
+      app-db does not propagate, so with NO interleaving the sub is never
+      marked dirty and `flush!` never runs: the guard is not reached at all.
+      (Not \"reached and misses\" — never consulted. The interleavings above
+      are how it IS reached, and there it hits.)
 
     * `:frame-state` reads the RAW physical container. A raw atom source is
       wired through the spine's per-source fan-out coordinator, whose
@@ -38,23 +66,30 @@
       otherwise. So a commit whose new app-db is `=`-but-not-`identical?`
       installs a fresh frame-state, marks every `:frame-state` sub dirty,
       and reaches the wrapper on the FLUSH path with a value-equal input —
-      where the guard HITS and suppresses the body.
+      where the guard HITS and suppresses the body, with no interleaving
+      needed at all.
 
-  These two tests pin exactly that asymmetry, so a future change that
-  teaches the flush path to skip the comparison cannot silently start
-  re-running `:frame-state` sub bodies on value-equal commits — which would
-  break Spec 006 §Invalidation algorithm (\"invalidated ONLY when an input
-  changes value by `rf=`\") and turn a spec'd `:rf.sub/skip` into a
-  `:rf.sub/run` (Spec 009 §`:rf.sub/skip`).
+  Between them these four tests mean a change that teaches the flush path
+  to skip the comparison cannot silently start re-running sub bodies on
+  value-equal input — which would break Spec 006 §Invalidation algorithm
+  (\"invalidated ONLY when an input changes value by `rf=`\") and turn a
+  spec'd `:rf.sub/skip` into a `:rf.sub/run` (Spec 009 §`:rf.sub/skip`).
 
-  The instrument is the `:rf.sub/skip` trace counted DURING `dispatch-sync`
-  with no interleaved deref: the commit and its epoch drain both complete
-  inside that call, so a skip observed there was emitted by `flush!` and by
-  nothing else.
+  The instrument is the `:rf.sub/skip` trace counted DURING `dispatch-sync`:
+  the commit and its epoch drain both complete inside that call. In the two
+  no-interleaving tests nothing else runs there, so a skip observed is a
+  `flush!` skip and nothing else. The two interleaving tests interpose
+  DELIBERATELY, from a watcher on the app-db projection — which runs inside
+  that projection's `notify` fan-out, after the witness is armed and always
+  before the drain reaches the sub's queued flush thunk. That is the seam
+  production reaches whenever anything reads or writes app-db from inside
+  the fan-out, and it is the only seam from which either interleaving can
+  be driven: `dispatch-sync` opens AND closes the epoch inside one call.
 
   ns ends in -cljs-test so shadow-cljs's :node-test build picks it up."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.frame :as frame]
             [re-frame.subs :as subs]
             [re-frame.substrate.spine :as spine]
             [re-frame.test-support :as test-support]
@@ -99,10 +134,16 @@
     @n))
 
 ;; ---------------------------------------------------------------------------
-;; :db — the guard CANNOT hit on the flush path (rf2-gncxk's proof, pinned)
+;; :db, NO INTERLEAVING — a value-equal commit never reaches the guard at all
+;;
+;; Narrowed by merged-PR audit #7233. This test proves exactly one scenario:
+;; a lone value-equal commit with nothing interleaved. It does NOT prove the
+;; general claim its old name (`db-sub-guard-never-hits-on-the-flush-path`)
+;; made — see the two interleaving tests below, where the guard DOES hit on
+;; the flush path for a `:db` sub.
 ;; ---------------------------------------------------------------------------
 
-(deftest db-sub-guard-never-hits-on-the-flush-path
+(deftest db-sub-value-equal-commit-never-reaches-the-guard
   (testing "a value-equal commit never marks a `:db` sub dirty, so `flush!`
             never runs and the guard is never consulted there — the app-db
             projection's `rf=` gate absorbed the write one layer up"
@@ -127,21 +168,33 @@
           (is (= 1 @runs)
               "body still has not re-run — the projection's rf= gate stopped
                propagation, and the deref-path guard absorbed the fresh object")
-          ;; A genuine move DOES reach the sub, and the guard MISSES there —
-          ;; which is exactly rf2-gncxk's point: on this path the comparison
-          ;; is paid and is known in advance to fail.
+          ;; A genuine move DOES reach the sub, and with nothing interleaved
+          ;; the guard MISSES there — the comparison is paid and fails. That
+          ;; is the case rf2-gncxk was filed on; it is the wrapper's FIRST
+          ;; invocation after a movement, and it is exactly the one the
+          ;; landed movement witness proves in advance (`-moved-from` is
+          ;; still `identical?` to `last-db` here, so the `=` walk is
+          ;; skipped and the verdict is the same miss).
           (rf/dispatch-sync [:bump])
           (is (= 43 @r))
           (is (= 2 @runs) "a real value move re-runs the body"))))))
 
 ;; ---------------------------------------------------------------------------
-;; :frame-state — the guard DOES hit on the flush path (the counterexample)
+;; :frame-state, NO INTERLEAVING — the guard hits on the flush path anyway
+;;
+;; The one kind that needs no interleaving to get there, which is why it was
+;; the original counterexample. It is ALSO the kind the landed witness cannot
+;; touch: a raw physical container does not implement `IMovementWitness`, so
+;; `subs.memo`'s `witness-src` is nil here and the guard expression is
+;; byte-for-byte the one that shipped (pinned in
+;; `movement_witness_cljs_test.cljs`).
 ;; ---------------------------------------------------------------------------
 
 (deftest frame-state-sub-guard-does-hit-on-the-flush-path
   (testing "a `:frame-state` sub reads the RAW container, whose fan-out is not
             movement-gated, so a value-equal commit DOES reach the wrapper on
-            the flush path — and the memo guard is what suppresses the body"
+            the flush path — with nothing interleaved — and the memo guard is
+            what suppresses the body"
     (rf/with-frame :rf/default
       (let [runs (atom 0)]
         (subs/reg-frame-state-sub
@@ -173,3 +226,114 @@
           (rf/dispatch-sync [:bump])
           (is (= 43 @r))
           (is (= 2 @runs) "a real value move re-runs the body"))))))
+
+;; ---------------------------------------------------------------------------
+;; :db WITH INTERLEAVING — the guard hits on the flush path here too
+;;
+;; Added by merged-PR audit #7233. These are the two cases rf2-gncxk.1's
+;; design pass named when it falsified the bead's own premise, and neither
+;; had a consumer-level pin: `movement_witness_cljs_test.cljs` pins the
+;; SOURCE's W1/W2, not the wrapper's C1 verdict along these paths.
+;;
+;; Both interpose from a watcher on the app-db projection. That watcher runs
+;; inside the projection's own `notify` fan-out — so the witness is already
+;; armed (`notify` `vreset!`s it BEFORE fanning out) and the sub's queued
+;; flush thunk has not run yet, whichever order the fan-out visits the two
+;; watchers in. It is the only seam these interleavings can be driven from:
+;; `dispatch-sync` opens the epoch and drains it inside one call.
+;; ---------------------------------------------------------------------------
+
+(deftest db-sub-guard-hits-on-the-flush-path-when-a-deref-interleaves
+  (testing "INTERLEAVING (a), DEREF-BETWEEN. The source moves P -> N and marks
+            the sub dirty; something derefs the sub before the drain reaches
+            its queued flush. `deref-derived` is PULL-based, so that read
+            recomputes against N and leaves `last-db` = N — and the queued
+            `flush!` then arrives with N against N, where the guard HITS.
+
+            C1: the witness must NOT short-circuit that. After the interleaved
+            read `last-db` holds N while `-moved-from` still holds P, so the
+            `identical?` proof term fails and the `=` walk is performed — and
+            returns the hit. This is the structural reason the optimisation
+            cannot fire twice running on one movement."
+    (rf/with-frame :rf/default
+      (let [runs (atom 0)]
+        (rf/reg-event :seed (fn [_ _] {:db {:n 42 :other :a}}))
+        (rf/reg-event :bump (fn [{:keys [db]} _] {:db (assoc db :n 43)}))
+        (rf/reg-sub :n (fn [db _] (swap! runs inc) (:n db)))
+        (rf/dispatch-sync [:seed])
+        (let [r     (rf/subscribe [:n])
+              proj  (frame/app-db-container :rf/default)
+              reads (atom 0)]
+          (is (= 42 @r))
+          (is (= 1 @runs) "first deref runs the body")
+          (add-watch proj ::deref-between
+                     (fn [_ _ _ _] (swap! reads inc) @r))
+          (let [flush-skips (try
+                              (skips-for :n #(rf/dispatch-sync [:bump]))
+                              (finally (remove-watch proj ::deref-between)))]
+            (is (= 1 @reads)
+                "the interposition genuinely fired — without this the two
+                 assertions below would be about an ordinary flush")
+            (is (= 2 @runs)
+                "the interleaved deref ran the body ONCE, against the moved db")
+            (is (pos? flush-skips)
+                "and the queued `flush!` then found its input `=` to what that
+                 deref had already left in `last-db`: the guard HIT on the
+                 FLUSH path, for a `:db` sub. The premise rf2-gncxk was filed
+                 on says this cannot happen."))
+          (is (= 43 @r) "the sub projects the moved value")
+          (is (= 2 @runs)
+              "and the flush-path hit was load-bearing: ONE body run for one
+               movement, not two (Spec 009 §`:rf.sub/skip`)"))))))
+
+(deftest db-sub-guard-hits-on-the-flush-path-on-a-return-to-equal
+  (testing "INTERLEAVING (b), RETURN-TO-EQUAL. Two writes inside one drain take
+            app-db A -> B -> A' with A' `=` A but a FRESH object. The sub's
+            `mark-dirty!` dedups, so its flush arrives with A' against
+            `last-db` = A: the source moved twice by `rf=`, `=` says equal, and
+            the guard HITS.
+
+            C1: W1 is what keeps the witness honest here. The second write's
+            `mark-dirty!` on the projection RETRACTS the witness — the
+            container's live value may now run ahead of its last completed
+            movement — so `-moved-from` answers `no-witness`, the proof term
+            fails, and the wrapper performs the walk instead of trusting a
+            stale departure value. Delete W1's `vreset!` and this test is what
+            goes red."
+    (rf/with-frame :rf/default
+      (let [runs (atom 0)]
+        (rf/reg-event :seed (fn [_ _] {:db {:n 42 :other :a}}))
+        (rf/reg-event :bump (fn [{:keys [db]} _] {:db (assoc db :n 43)}))
+        (rf/reg-sub :n (fn [db _] (swap! runs inc) (:n db)))
+        (rf/dispatch-sync [:seed])
+        (let [r       (rf/subscribe [:n])
+              proj    (frame/app-db-container :rf/default)
+              returns (atom 0)]
+          (is (= 42 @r))
+          (is (= 1 @runs) "first deref runs the body")
+          ;; The SECOND write, from inside the projection's fan-out: the move
+          ;; to B is established (witness armed, sub marked dirty, flush
+          ;; queued) and app-db is returned to a fresh A' before the drain
+          ;; reaches that thunk. `replace-app-db!` is `commit-frame-
+          ;; transition!` — the same write boundary the router commit uses —
+          ;; and its re-entrant `with-epoch` cannot drain (the outer
+          ;; `drain-scheduler!` holds `flushing?`), so the two writes coalesce
+          ;; into one flush exactly as the design pass described.
+          (add-watch proj ::return-to-equal
+                     (fn [_ _ _ _]
+                       (when (zero? @returns)
+                         (swap! returns inc)
+                         (frame/replace-app-db! :rf/default {:n 42 :other :a}))))
+          (let [flush-skips (try
+                              (skips-for :n #(rf/dispatch-sync [:bump]))
+                              (finally (remove-watch proj ::return-to-equal)))]
+            (is (= 1 @returns) "the interposed second write genuinely fired")
+            (is (pos? flush-skips)
+                "the sub's `flush!` found A' `=` to the A still sitting in
+                 `last-db`: the guard HIT on the FLUSH path, for a `:db` sub,
+                 on an input that moved twice by `rf=`")
+            (is (= 1 @runs)
+                "and the hit is load-bearing: the body did NOT re-run anywhere
+                 across A -> B -> A'"))
+          (is (= 42 @r) "the sub still projects the returned-to value")
+          (is (= 1 @runs)))))))

--- a/implementation/core/test/re_frame/trace_cascade_captured_test.clj
+++ b/implementation/core/test/re_frame/trace_cascade_captured_test.clj
@@ -151,31 +151,41 @@
 
 (deftest layer-2-memo-hit-emits-sub-skip-with-upstream
   (testing "layer-2 sub on memo-hit names its upstream input(s) in :rf.sub/input-paths-unchanged"
-    (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 3}}))
-    (rf/reg-sub :n (fn [db _] (:n db)))
-    (rf/reg-sub :doubled
-      :<- [:n]
-      (fn [n _] (* 2 n)))
-    (rf/dispatch-sync [:seed])
-    (let [seen   (atom [])
-          events (collect-trace
-                   (fn []
-                     (let [r (rf/subscribe [:doubled])]
-                       (swap! seen conj @r)
-                       (swap! seen conj @r))))
-          skips  (filter #(and (= :rf.sub/skip (:operation %))
-                               (= :doubled (get-in % [:tags :rf.sub/id])))
-                         events)]
-      ;; ALWAYS-ON (rf2-d2841): the layer-2 projection the skip emit reports
-      ;; on is production state — both derefs see the same committed value.
-      (is (= [6 6] @seen)
-          "the layer-2 sub projects 2*3 on both derefs in this posture")
-      (when interop/debug-enabled?
-        (is (seq skips)
-            "expected at least one :rf.sub/skip emit for the layer-2 sub")
-        (let [skip (first skips)]
-          (is (= [[:n]] (get-in skip [:tags :rf.sub/input-paths-unchanged]))
-              "input-paths-unchanged names the upstream sub vector"))))))
+    ;; MERGED-PR AUDIT #7250 (rf2-d2841): the always-on half used to be
+    ;; `(= [6 6] @seen)` alone, which a BROKEN memo passes — recomputing
+    ;; `:doubled` on the second deref returns 6 again. Mirror the layer-1 test
+    ;; above and COUNT the derived body: the memo hit the `:rf.sub/skip` emit
+    ;; reports is one body execution across two derefs, and that is production
+    ;; behaviour whatever the posture.
+    (let [body-runs (atom 0)]
+      (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 3}}))
+      (rf/reg-sub :n (fn [db _] (:n db)))
+      (rf/reg-sub :doubled
+        :<- [:n]
+        (fn [n _] (swap! body-runs inc) (* 2 n)))
+      (rf/dispatch-sync [:seed])
+      (let [seen   (atom [])
+            events (collect-trace
+                     (fn []
+                       (let [r (rf/subscribe [:doubled])]
+                         (swap! seen conj @r)
+                         (swap! seen conj @r))))
+            skips  (filter #(and (= :rf.sub/skip (:operation %))
+                                 (= :doubled (get-in % [:tags :rf.sub/id])))
+                           events)]
+        ;; ALWAYS-ON (rf2-d2841): the layer-2 projection the skip emit reports
+        ;; on is production state — both derefs see the same committed value.
+        (is (= [6 6] @seen)
+            "the layer-2 sub projects 2*3 on both derefs in this posture")
+        (is (= 1 @body-runs)
+            "the memo the :rf.sub/skip emit reports actually held — two derefs,
+             one derived body run, in BOTH postures")
+        (when interop/debug-enabled?
+          (is (seq skips)
+              "expected at least one :rf.sub/skip emit for the layer-2 sub")
+          (let [skip (first skips)]
+            (is (= [[:n]] (get-in skip [:tags :rf.sub/input-paths-unchanged]))
+                "input-paths-unchanged names the upstream sub vector")))))))
 
 ;; ---- :rf.flow/skip carries :rf.sub/input-paths-unchanged -------------------------
 
@@ -198,6 +208,18 @@
                        (rf/dispatch-sync [:bump-z])
                        (rf/dispatch-sync [:bump-z])))
             skips  (filter #(= :rf.flow/skip (:operation %)) events)]
+        ;; MERGED-PR AUDIT #7250 (rf2-d2841): the two always-on assertions
+        ;; below say what did NOT happen — the flow fn did not re-run, the
+        ;; durable output did not move. Both stay green if the DRIVER never
+        ;; ran: delete the two `:bump-z` dispatches and nothing here notices,
+        ;; because a flow that was never given the chance to skip also does
+        ;; not run and also leaves its output alone. Only the guarded dev
+        ;; trace sees the missing skips. So prove the driver landed first,
+        ;; exactly — two dispatches, `:z` = 2 — and the two negatives below
+        ;; become claims about a cascade that demonstrably happened.
+        (is (= 2 (:z (rf/app-db-value :rf/default)))
+            "both :bump-z dispatches landed — the epochs the flow skipped in
+             are real epochs")
         (is (= runs-after-seed @flow-runs)
             "neither :bump-z touched [:x] or [:y], so the flow fn did not run
              again — the skip is real in BOTH postures")

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -44,7 +44,7 @@
 # a rewrite of how those assertions are spelled.  Triage beads are named per
 # cluster below.
 #
-# What is left IS green, and it is not a rump: 173 namespaces, 1933 tests, 8332
+# What is left IS green, and it is not a rump: 175 namespaces, 1953 tests, 8532
 # assertions, exit 0 — versus the zero suites that had ever executed under this
 # posture before.  (It was
 # 88 / 934 / 4340 tests/assertions before rf2-d2841 split the spine's
@@ -391,8 +391,9 @@ fi
 # ordinary churn; raise it when the roster grows materially.
 #
 # RAISED 800 -> 1360 (rf2-d2841, third pass), 1360 -> 1510 (fourth pass),
-# 1510 -> 1690 (fifth pass), 1690 -> 1880 (sixth pass), then 1880 -> 1900
-# (seventh).  800 was calibrated against the 915-test lane of rf2-f8x2i's
+# 1510 -> 1690 (fifth pass), 1690 -> 1880 (sixth pass), 1880 -> 1900
+# (seventh), then 1900 -> 1920 (see "THE EIGHTH MOVE" below — a budget
+# repair, not a pass).  800 was calibrated against the 915-test lane of rf2-f8x2i's
 # original run and had stopped doing its job.  1360 was calibrated against 1401
 # and stopped doing its job the same way; 1510 did the same in its turn; and so
 # did 1690, against the 1931 tests the sixth pass left.
@@ -417,12 +418,23 @@ fi
 # test file, and nothing else counts what it excluded.
 #
 # So the floor is now doing a second job: it is the budget for tagging.  At
-# 1900 against 1933 there are 33 tests of slack, so tagging more than about
+# 1920 against 1953 there are 33 tests of slack, so tagging more than about
 # thirty tests' worth of deftests reddens this lane and the author has to come
 # here and move the number — which is exactly the review prompt a
 # coverage-reducing change should trigger.  That is deliberate.  Do not raise
 # the floor to make room for a tag without saying, in the same diff, what was
 # tagged and why it has no production residue.
+#
+# THE EIGHTH MOVE, 1900 -> 1920, WAS NOT A PASS.  It tags nothing and adds no
+# namespace; it repairs the budget the seventh pass set.  1900 was calibrated
+# against 1933, and the lane has since grown to 1953 on other beads' test
+# files — which silently widened the tagging budget from the intended ~33
+# tests to 53.  That is the same "a floor left behind by a growing lane is
+# inert" failure as every earlier move, arriving through the back door: nobody
+# raised the budget, the lane just drifted out from under it.  So the rule to
+# apply is not "raise it when you add namespaces" but "keep the SLACK at ~33",
+# and it wants checking whenever this lane's observed count is read, not only
+# when a d2841 pass lands.
 #
 # Note which direction the OTHER failure mode falls.  If `-e :requires-debug`
 # is ever dropped from the `:prod-gate` alias or misspelled, the fifteen tagged
@@ -446,7 +458,7 @@ fi
 # invokes, so the rule covers every lane in the repo rather than this one, and
 # it fires before a single test runs.  `verify_roster` below is unchanged and
 # still cannot see this class on its own — see its guard #1.
-export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1900}"
+export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1920}"
 
 args=()
 for ns in $runnable; do


### PR DESCRIPTION
Two merged-PR audit repairs. Both are test-truth work: no production code
changes, no runtime defect implied, and every dev-posture trace assertion kept
verbatim.

## rf2-gncxk.1 — pin the wrapper's C1 verdict in both flush-path interleavings

Merged-PR audit #7233 found `sub_memo_flush_path_cljs_test.cljs` asserting a
claim rf2-gncxk.1's own design pass had already falsified. The bead was filed on
a proof that the layer-1 memo guard is guaranteed to MISS on the flush path;
that proof establishes "the source moved since the source's previous NOTIFY",
while the guard asks "did the input move since THE WRAPPER LAST RAN". Two
reachable interleavings separate them, and in both the guard correctly HITS on
the flush path for a `:db` sub — so the namespace prose, its section heading and
the deftest name `db-sub-guard-never-hits-on-the-flush-path` were all stating
something known false.

The two original tests keep every assertion verbatim; only their names and prose
narrow to the no-interleaving scenario each actually proves. The first becomes
`db-sub-value-equal-commit-never-reaches-the-guard`, which is the true claim: a
value-equal commit does not move the `rf=`-gated app-db projection, so the sub is
never marked dirty and the guard is never consulted — not "reached and misses".

The two interleavings then get the consumer-level witnesses they never had.
`movement_witness_cljs_test` pins the SOURCE's W1/W2; C1 (verdict-preserving)
binds the CONSUMER, and nothing pinned it along these paths:

- **(a) DEREF-BETWEEN.** The source moves P → N and marks the sub dirty;
  something derefs the sub before the drain reaches its queued flush.
  `deref-derived` is pull-based, so that read recomputes against N and leaves
  `last-db` = N; the queued flush then arrives with N against N. The witness
  still holds P, so the `identical?` term fails, the walk runs, and it hits. One
  body run for one movement.
- **(b) RETURN-TO-EQUAL.** Two writes inside one drain take app-db A → B → A′
  with A′ `=` A but a fresh object. `mark-dirty!` dedups, so one flush arrives
  with A′ against `last-db` = A. W1 is what keeps this honest: the second write's
  `mark-dirty!` retracts the witness, so the wrapper walks rather than trusting a
  stale departure value.

Both interpose from a watcher on the app-db projection, which runs inside that
projection's `notify` fan-out — after the witness is armed and always before the
drain reaches the sub's queued flush thunk, whichever order the fan-out visits
the watchers in. That is the only seam either interleaving can be driven from:
`dispatch-sync` opens the epoch and drains it inside one call. Each test also
asserts its interposition actually fired, so neither can degrade into a claim
about an ordinary flush.

The protocol and the optimisation are untouched, per the audit's "do not alter
the protocol or broaden the optimization".

## rf2-d2841 — four always-on witnesses that could not fail, and the lane's floor

**Audit #7245 — `configure_test.clj`**, two witnesses resting on `some?` over an
app-db that `make-frame` already seeds as `{}`:

- `trace-buffer-severity-warning-filter-catches-unrecognised-opts` claimed "the
  enclosing dispatch completed despite the rejected `configure!` call" from
  `(some? (rf/app-db-value :rf/default))`, over a handler returning `{:db db}`.
  True before the dispatch, so it could not fail. The handler now stamps a
  sentinel and the test asserts the key is absent first and present after — an
  actual state transition, which a handler that never ran or a `configure!`
  throw that derailed the commit both redden.
- `configure-unknown-key-is-silent-no-op` used the same assertion for "thirty
  dispatches bracketed by four unknown-key `configure!` calls still all landed".
  A missing handler, a perturbed registry, or three landings instead of thirty
  all passed it. `:ping` now increments a counter and the test asserts exactly 30.

**Audit #7250 — `trace_cascade_captured_test.clj`**, two witnesses that do not
prove the production behaviour their guarded trace assertions narrate:

- `layer-2-memo-hit-emits-sub-skip-with-upstream` asserted only `seen == [6 6]`,
  which a broken memo passes — recomputing `:doubled` on the second deref returns
  6 again. It now mirrors the layer-1 test above and counts the derived body: one
  execution across two derefs.
- `flow-skip-emits-input-paths-unchanged` asserted the flow-run count did not
  change and `[:derived :sum]` stayed 0 — both green if the driver never ran,
  since a flow denied the chance to skip also does not run and also leaves its
  output alone. It now proves both `:bump-z` dispatches landed (`:z` = 2) before
  making either negative claim.

**The floor, 1900 → 1920, and this one is not a pass.** It tags nothing and adds
no namespace. 1900 was calibrated against 1933 tests to leave the ~33 tests of
slack the seventh pass chose as the tagging budget; the lane has since grown to
1953 on other beads' test files, which widened that budget to 53 without anyone
deciding to. Same "a floor left behind by a growing lane is inert" failure as
every earlier move, arriving through the back door. The rule is therefore
restated in the script as "keep the SLACK at ~33", checked whenever the observed
count is read. The script's header counts are corrected with it: 173/1933/8332 →
175/1953/8532.

## Quality gates

Run from the worktree root, foreground, to completion. Logs captured
worktree-locally.

| Gate | Result | Exit |
|---|---|---|
| `sh scripts/test-core-prod-gate.sh` | 175 of 187 namespaces; Ran **1953** tests / **8532** assertions; 0 failures, 0 errors | **0** |
| `sh scripts/test-fast-pr.sh` | `PASS fast PR spine` | **0** |
| ↳ JVM `implementation/core` (dev posture) | Ran **2210** tests / **11510** assertions; 0 failures, 0 errors | 0 |
| ↳ CLJS node integration (`npm run test:cljs`) | Ran **12425** tests / **62044** assertions; 0 failures, 0 errors | 0 |
| ↳ implementation JS harness helpers, per-ns isolation | all pass; all 17 namespaces pass standalone | 0 |

The node lane's `12425 / 62044` is exactly `+2` tests and `+14` assertions over
the `12423 / 62030` measured on a sibling branch off the same base — the two new
rf2-gncxk.1 interleaving deftests and nothing else.

`scripts/test-core-prod-gate.sh` is run explicitly because the fast spine does
NOT cover it, and this diff moves that lane's floor. Its observed counts match
the header this PR corrects exactly (175 / 1953 / 8532), and the dev-posture core
run matches the commit's claim exactly (2210 / 11510) — test count HELD in both
postures, no deftest added or removed, no assertion deleted or weakened.

Spine tiering for this diff: `docs=false jvm=true (implementation/core)
node=true`. The spine names what it does not run: documentation gates and the
browser / prod-elision / bundle-isolation / perf / adapter / Xray /
mcp-conformance / tool-JVM gates (CI only).

Cross-refs rf2-gncxk.1 (parent rf2-gncxk) and rf2-d2841.

**rf2-gncxk.1 is NOT closed by this PR.** It carries a second, independent
reopen — AUDIT PR #7325 requires the bead's binding obligation 6, hicasso
`retention_run.cjs` showing no growth beyond the single predecessor generation,
run on a settled tree. That is not in this diff and this box is not settled
(three other workers were driving it during these gates). This PR discharges the
#7233 bounded repair only.

Closes rf2-d2841.
