### PR TITLE
feat(hicasso): one attribute-merge spelling — reserved :& key (rf2-2rtt6.36)

### DIFF
--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -179,14 +179,17 @@ element the caller wrote). The same key and the same law hold at a crossing — 
 view head, a `defhost` head, `[:>]` — because `:&` is merged before any conversion
 and the conversion that follows is the position's own, so a forwarded `:className`
 crosses under the name it was written as. And an element's own classes belong on
-the **tag**, where the shorthand merge composes them with a forwarded `:class`
-rather than one silently replacing the other.
+the **tag**, where the shorthand composes them with a forwarded class rather than
+one silently replacing the other.
 
 Both halves of the law are enforced on the **slot the key is emitted into**, not on
 the key itself. Prop names reach React through one canonicalisation, so `"key"`,
 `:x/key` and `'key` are all React's key, and `:onInput` is the same handler as an
 owned `:on-input` — a remainder cannot reach either by changing how it spells them
-(HD-023(c′)).
+(HD-023(c′)). The tag shorthand is folded on the emitted slot for the same reason:
+an explicit id beats `#tag` and a declared class composes with `.foo` whether it
+arrives as `:id`/`:class`, as `"id"`/`"className"`, or as `:x/id`/`:x/class`
+(HD-023(c″)).
 
 ## The controlled-input door
 

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -628,6 +628,22 @@ resolver is the codec's own emitted prop name (`canonical-slot`) — the thing a
 asks is the thing the emitter will do. That resolver must be a pure function of the
 key, which is why a string prop name does not share the prop-name cache with the
 keyword of the same name.
+(c″) **The tag's `#id`/`.class` shorthand is folded on the emitted slot too.** The
+rule — an explicit id wins over `#tag`, and `.foo` composes with a declared class —
+was stated over the props *map*, where it read `:id`, `:class` and `:className` and
+therefore saw three of the spellings the codec accepts. Every other spelling
+survived as a second map key landing on the same React slot, so
+`[:div#tag.foo {:& {"id" "caller" "className" "bar"}}]` let the explicit id lose to
+`#tag` and the caller's class replace `.foo` instead of composing with it — map-order
+dependent again, and through `:&`'s own door, where the author of the element never
+sees the key. The shorthand is folded onto the object the walk EMITS instead: every
+spelling has already been through the canonical slot on its way into that object, so
+there is no key left to miss and nothing left to resolve. The class slot is a
+position in the same sense `ref` is — its value is coerced by the class rule rather
+than by the generic prop conversion, and two spellings of it compose rather than the
+last write silently winning. The fold also deletes the map surgery the shorthand
+merge performed on every element carrying a shorthand; that is a structural change,
+and its clock effect is **unmeasured** like the rest of `:&`.
 (d) The **same key and the same law hold at a crossing** (a Hicasso view head, a
 `defhost` head, `[:>]`). `:&` is merged *before* any conversion, and the conversion
 that follows is the position's own — so a forwarded `:className` crosses under the
@@ -653,8 +669,10 @@ precedent: UIx already uses `:&` for exactly this in this repo
 (`examples/substrates/uix/login/core.cljs:148`).
 **Class composition needs no exception.** An element's own classes are written on
 the **tag** (`[:input.form-control {:& caller}]`), which is not a literal attribute
-key, so the shorthand merge composes them with whatever the remainder brought. A
-literal `:class` still wins outright, because it is a literal.
+key, so the shorthand merge composes them with whatever the remainder brought —
+however the remainder spelled it (c″). A literal `:class` still wins outright,
+because it is a literal, and what composes is what SURVIVED the merge: an alias at a
+slot an owned literal claims never gets that far.
 **Demonstrated, not asserted.** The RealWorld article editor's four form fields
 (`examples/real-apps/realworld_resources/article_editor.cljs:496-522`) are ported
 both ways in `front/census_article_editor_cljs_test`, with the produced elements

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -56,10 +56,9 @@
 
   A [[PropSlot]] is the React name the cache always held plus the four
   classifications that are pure functions of the same literal — reserved
-  slot, event position, ref slot, class slot (rf2-y1jkm,
-  rf2-2rtt6.36). Same keys, same lifetime,
-  same guard; one lookup now answers everything the per-prop walk used
-  to re-derive per element per render.
+  slot, event position, ref slot, class slot (rf2-y1jkm, rf2-2rtt6.36).
+  Same keys, same lifetime, same guard; one lookup now answers everything
+  the per-prop walk used to re-derive per element per render.
 
   That is the whole of the accelerant HD-004 permits in the lean arm.
   There is **no template extraction, no hole plan, no node reference, and
@@ -307,10 +306,10 @@
   ;; per-prop walk used to re-derive per element per render — is the
   ;; emitted slot reserved, is the position an event position, is it the
   ;; ref slot, is it the class slot. Each is a pure function of the
-  ;; literal's NAME, so caching
-  ;; them beside the name changes what a lookup ANSWERS and nothing about
-  ;; when it is valid: there is still exactly one entry per distinct
-  ;; literal, minted on first sight, correct for the life of the build.
+  ;; literal's NAME, so caching them beside the name changes what a lookup
+  ;; ANSWERS and nothing about when it is valid: there is still exactly
+  ;; one entry per distinct literal, minted on first sight, correct for
+  ;; the life of the build.
   ;;
   ;; `event?` is the name-string's answer (`intent/event-prop?` on the
   ;; NAME), and the consumer must gate it on `keyword?` — a symbol

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -54,9 +54,10 @@
     tag-cache    \"div#main.wide\" -> ParsedTag
     prop-cache   \"on-click\"      -> PropSlot
 
-  A [[PropSlot]] is the React name the cache always held plus the three
+  A [[PropSlot]] is the React name the cache always held plus the four
   classifications that are pure functions of the same literal — reserved
-  slot, event position, ref slot (rf2-y1jkm). Same keys, same lifetime,
+  slot, event position, ref slot, class slot (rf2-y1jkm,
+  rf2-2rtt6.36). Same keys, same lifetime,
   same guard; one lookup now answers everything the per-prop walk used
   to re-derive per element per render.
 
@@ -137,7 +138,15 @@
   is asked of [[canonical-slot]], the slot the value will actually be
   emitted into, and never of the key it happened to be written as. A rule
   written against the raw key is a rule that `\"key\"`, `:x/ref` and
-  `:onInput` walk straight past."
+  `:onInput` walk straight past.
+
+  The tag's `#id`/`.class` shorthand answers the same question one step
+  further on: it is folded onto the **emitted object**, where the slot is
+  not resolved at all because it already *is* the slot. An explicit id
+  therefore beats `#tag` in every spelling, and a declared class composes
+  with `.foo` in every spelling — including a spelling a `:&` remainder
+  forwarded, which is the one door where the author of the element never
+  sees the key at all."
   (:require [clojure.string :as str]
             [re-frame.bench.hicasso.front.controlled :as controlled]
             [re-frame.bench.hicasso.front.intent :as intent]
@@ -292,12 +301,13 @@
               n
               (apply str start (map capitalize parts))))))))
 
-(deftype PropSlot [js-name reserved? event? ref?]
+(deftype PropSlot [js-name reserved? event? ref? class?]
   ;; What the prop cache holds for one prop literal (rf2-y1jkm): the React
-  ;; name the codec always cached, PLUS the three classifications the
+  ;; name the codec always cached, PLUS the four classifications the
   ;; per-prop walk used to re-derive per element per render — is the
   ;; emitted slot reserved, is the position an event position, is it the
-  ;; ref slot. Each is a pure function of the literal's NAME, so caching
+  ;; ref slot, is it the class slot. Each is a pure function of the
+  ;; literal's NAME, so caching
   ;; them beside the name changes what a lookup ANSWERS and nothing about
   ;; when it is valid: there is still exactly one entry per distinct
   ;; literal, minted on first sight, correct for the life of the build.
@@ -325,16 +335,23 @@
                 ;; "ref" — [[ref-slot]], spelled literally because the def
                 ;; sits below; `identical?` on primitive strings is value
                 ;; comparison.
-                (identical? "ref" js-name))))
+                (identical? "ref" js-name)
+                ;; "className" — [[class-slot]], likewise. The class slot
+                ;; is a position too: its value is coerced by
+                ;; [[class-names]] rather than by [[convert-prop-value]],
+                ;; and two spellings of it COMPOSE instead of one
+                ;; overwriting the other.
+                (identical? "className" js-name))))
 
 (def ^:private prop-cache
   ;; The three seeded entries are the RULE, not memos of one — see
   ;; [[react-renames]]. None is reserved, an event position, or the ref
-  ;; slot.
+  ;; slot; `class` IS the class slot, which is the whole reason the rule
+  ;; is stated on the emitted name rather than on the key.
   (doto (empty-cache)
-    (unchecked-set "class" (->PropSlot "className" false false false))
-    (unchecked-set "for" (->PropSlot "htmlFor" false false false))
-    (unchecked-set "charset" (->PropSlot "charSet" false false false))))
+    (unchecked-set "class" (->PropSlot "className" false false false true))
+    (unchecked-set "for" (->PropSlot "htmlFor" false false false false))
+    (unchecked-set "charset" (->PropSlot "charSet" false false false false))))
 
 (defn- prop-slot
   "The [[PropSlot]] for keyword/symbol `k` with name `n` — the caller has
@@ -409,6 +426,14 @@
 
 (def ^:private ref-slot "ref")
 
+;; The two slots the TAG can write into, named because the shorthand fold
+;; asks the emitted object for them rather than asking the props map for a
+;; key ([[convert-props]]). `#tag` is the weakest source of an id there is
+;; — it loses to any explicit one, in any spelling — and `.foo` composes
+;; with whatever the map emitted into `className`, in any spelling.
+(def ^:private id-slot "id")
+(def ^:private class-slot "className")
+
 (defn structural-slot?
   "Does `k` — in any spelling — land on `key` or `ref`?"
   [k]
@@ -454,18 +479,43 @@
    (let [a (class-names a) b (class-names b)]
      (cond (nil? a) b (nil? b) a :else (str a " " b)))))
 
-(defn- merge-shorthand
-  "Fold the tag's `#id`/`.class` shorthand into the props map. An explicit
-  `:id` wins over the shorthand; the shorthand class is *prepended* to an
-  explicit class, so `[:div.a {:class \"b\"}]` is `\"a b\"`."
-  [props ^ParsedTag parsed]
-  (let [id        (.-id parsed)
-        shorthand (.-className parsed)
-        props     (if (and id (not (contains? props :id))) (assoc props :id id) props)
-        declared  (or (:class props) (:className props))
-        merged    (class-names shorthand declared)]
-    (cond-> (dissoc props :className :class)
-      merged (assoc :class merged))))
+(defn- fold-shorthand!
+  "Fold the tag's `#id`/`.class` shorthand into the object the walk just
+  emitted, and return it.
+
+  **On the emitted object, and that is the whole repair.** The rule has
+  always been *an explicit id wins over the shorthand, and the shorthand
+  class is prepended to a declared one*; stated over the props MAP it read
+  `:id`, `:class` and `:className` and saw exactly three of the spellings
+  this codec accepts. `[:div#tag.foo {:& {\"id\" \"caller\" \"className\"
+  \"bar\"}}]` walked straight past it: neither key was seen, the shorthand
+  was added as a second entry landing on the same React slot, and which
+  one survived was decided by the order the props map happened to iterate
+  in — the explicit id could lose to `#tag`, and the caller's class could
+  replace `.foo` instead of composing with it.
+
+  Asked of the emitted object there is nothing left to resolve. Every
+  spelling has already been through [[canonical-slot]] on its way into
+  this object, so `id` present means *the author or their caller wrote an
+  id*, however they spelled it, and `className` holds the composed class
+  ([[convert-entry]]) whatever it was written as. One `undefined?` test
+  and one `class-names` answer both halves for every spelling at once.
+
+  It also deletes the map surgery the walk profile priced at most of
+  [[convert-props]]'s cost — the `dissoc`/`assoc` pair that rebuilt the
+  attribute map of every element carrying a shorthand — and with it the
+  fast lane that existed to dodge it."
+  [^js o ^ParsedTag parsed]
+  (when-some [id (.-id parsed)]
+    (when (undefined? (unchecked-get o id-slot))
+      (unchecked-set o id-slot id)))
+  (when-some [shorthand (.-className parsed)]
+    (let [declared (unchecked-get o class-slot)]
+      (unchecked-set o class-slot
+                     (if (undefined? declared)
+                       shorthand
+                       (class-names shorthand declared)))))
+  o)
 
 ;; ---------------------------------------------------------------------------
 ;; Prop values
@@ -614,7 +664,20 @@
   takes. The paths [[intent/lower-prop]] IS entered on reproduce its
   answers by construction: it re-asks `event-prop?` and re-takes the
   same branch this slot was minted from. A string key keeps the donor's
-  uncached path, byte for byte."
+  uncached path, byte for byte.
+
+  **The class slot is a position, like the ref slot beside it.** Its
+  value is coerced by [[class-names]] — a string, a keyword, a symbol or
+  a collection of those, nils dropped — rather than by
+  [[convert-prop-value]], which would hand React the `clj->js` array of
+  `{:class [\"a\" nil :b]}`; that coercion used to live in the map surgery
+  this walk replaced, and it is on the emitted slot now, so it holds for
+  `\"class\"` and `:x/class` as well as for `:class`. And it COMPOSES
+  with whatever is already in the slot: two spellings of the class of one
+  element are two map keys and one React slot, so letting the last write
+  win would drop a class silently, which is the failure class HD-023
+  exists to delete. Composing drops nothing, and it is what the slot
+  means."
   [o k v]
   (if (keyword-identical? :key k)
     o
@@ -626,6 +689,9 @@
                            (cond
                              (.-ref? s)
                              (check-ref! k v)
+
+                             (.-class? s)
+                             (class-names (unchecked-get o class-slot) v)
 
                              (and (.-event? s) (keyword? k))
                              (if (or (vector? v) (map? v) (fn? v))
@@ -640,9 +706,10 @@
       (let [n (cached-prop-name k)]
         (when-not (reserved-name? n)
           (unchecked-set o n (convert-prop-value
-                              (if (= ref-slot n)
-                                (check-ref! k v)
-                                (intent/lower-prop k v)))))
+                              (cond
+                                (identical? ref-slot n)   (check-ref! k v)
+                                (identical? class-slot n) (class-names (unchecked-get o class-slot) v)
+                                :else                     (intent/lower-prop k v)))))
         o))))
 
 (defn convert-props
@@ -654,50 +721,43 @@
 
   Two things about the order. Intent lowering happens *inside* the single
   walk, so the codec does not traverse the props map a second time to
-  find the event positions. And [[merge-caller]] runs FIRST — before the
-  tag shorthand and before any prop-name conversion — which is what lets
-  one rule cover the class the predecessor needs a third form for. A
-  forwarded `:className` is merged as the key it was written as and then
-  converted by *this position's* grammar; nothing canonicalises it into
-  `:class` on the way through and hands the wrong name onward. It also
-  puts a forwarded `:class` into the shorthand merge, so
-  `[:input.form-control {:& caller}]` composes `\"form-control\"` with the
-  caller's classes instead of one silently replacing the other.
+  find the event positions. And [[merge-caller]] runs FIRST — before any
+  prop-name conversion — which is what lets one rule cover the class the
+  predecessor needs a third form for. A forwarded `:className` is merged
+  as the key it was written as and then converted by *this position's*
+  grammar; nothing canonicalises it into `:class` on the way through and
+  hands the wrong name onward.
 
-  The `:ref` reservation and the ref position's exclusion from intent
-  lowering are both taken on the CANONICAL SLOT the walk has just
-  computed, rather than on the key — which is what makes them hold for
-  `\"ref\"` and `:x/ref` as well as for `:ref`, and costs the walk one
-  comparison it already had the value for.
+  The tag shorthand is folded LAST, onto the emitted object
+  ([[fold-shorthand!]]) — so `[:input.form-control {:& caller}]` composes
+  `\"form-control\"` with the caller's classes instead of one silently
+  replacing the other, and does so however the caller spelled them.
 
-  ## The three lanes (rf2-y1jkm)
+  The `:ref` reservation, the ref position's exclusion from intent
+  lowering, the class coercion and the shorthand fold are all taken on
+  the CANONICAL SLOT rather than on the key — which is what makes them
+  hold for `\"ref\"`, `:x/class` and `\"id\"` as well as for `:ref`,
+  `:class` and `:id`, and costs the walk one comparison it already had
+  the value for.
+
+  ## The two lanes (rf2-y1jkm, narrowed by rf2-2rtt6.36)
 
   The walk-cost profile (`walk_profile_app`, census page: 1,202
   elements, 567 of them with no attribute map, 924 with a `.class`
   shorthand, 71 with a declared `:class`) priced this function at 67.5%
-  of the whole interpreter walk, most of it the map surgery
-  [[merge-shorthand]] performs on elements whose only class IS the
-  shorthand. So the general path keeps its exact shape and two lanes
-  peel off the shapes that dominate a page, each producing the same
-  emitted object the general path produces, property for property and in
-  the same order:
+  of the whole interpreter walk, most of it the map surgery the
+  shorthand merge performed on elements whose only class IS the
+  shorthand. That surgery is **gone**: the shorthand is folded onto the
+  object the walk emits rather than into the map the walk reads, so
+  there is no `dissoc`/`assoc` pair on any path and no shape to peel a
+  lane off for. What is left is one lane and one short-circuit:
 
   1. **No attribute map at all** (`props` nil): the emitted object is
-     exactly the shorthand's `id`/`className`, so it is built directly.
-     What the general path would do — an empty merge, the shorthand
-     folded into a fresh map, one map iteration converting it back out —
-     is the identity of that, at the cost of the map machinery.
-  2. **Shorthand class, nothing merged against it** — no literal
-     `:class`/`:className` (the two keys [[merge-shorthand]] itself
-     consults), no `:&`, no `#id` shorthand: the merged class is the
-     shorthand string verbatim (`class-names` of a string against nil),
-     and the general path's re-`assoc` puts `:class` LAST in the map, so
-     emitting the loop first and the shorthand's `className` after it
-     writes the same slots in the same order — including the overwrite
-     order for an exotic spelling (`:x/class`) that canonicalises onto
-     the same slot.
-  3. **Everything else** — a declared class, a `:&` remainder, an `#id`
-     — takes the donor's path unchanged.
+     exactly the shorthand's `id`/`className`, so it is built directly —
+     no merge, no map iteration, no fold.
+  2. **Everything else**: convert the map (a `:&` remainder merged in
+     first, by identity when there is none), then fold the shorthand onto
+     the result.
 
   React's own `key` contract: the LITERAL `:key` is dropped in-loop (one
   keyword-identity test) rather than by a `dissoc` that copies the map;
@@ -707,32 +767,22 @@
 
   Per prop, one [[prop-slot]] lookup answers the React name AND the
   classifications the walk used to re-derive per element — reserved slot,
-  event position, ref slot — so a non-event prop no longer pays
-  [[re-frame.bench.hicasso.front.intent/event-prop?]]'s regex, and only
-  a lowerable value at an event position (a vector, a map, a function)
-  enters [[re-frame.bench.hicasso.front.intent/lower-prop]] at all. The
-  slot's `event?` flag is gated on `keyword?` at the call site — a
-  symbol shares the cache entry but is not an event position — and a
-  string-keyed prop takes the donor's uncached path unchanged."
+  event position, ref slot, class slot — so a non-event prop no longer
+  pays [[re-frame.bench.hicasso.front.intent/event-prop?]]'s regex, and
+  only a lowerable value at an event position (a vector, a map, a
+  function) enters
+  [[re-frame.bench.hicasso.front.intent/lower-prop]] at all. The slot's
+  `event?` flag is gated on `keyword?` at the call site — a symbol shares
+  the cache entry but is not an event position — and a string-keyed prop
+  takes the donor's uncached path unchanged."
   [props ^ParsedTag parsed]
-  (cond
-    (nil? props)
+  (if (nil? props)
     (let [o #js {}]
-      (when-some [id (.-id parsed)] (unchecked-set o "id" id))
-      (when-some [c (.-className parsed)] (unchecked-set o "className" c))
+      (when-some [id (.-id parsed)] (unchecked-set o id-slot id))
+      (when-some [c (.-className parsed)] (unchecked-set o class-slot c))
       o)
-
-    (and (some? (.-className parsed))
-         (nil? (.-id parsed))
-         (not (contains? props :class))
-         (not (contains? props :className))
-         (not (contains? props merge-key)))
-    (let [o (reduce-kv convert-entry #js {} props)]
-      (unchecked-set o "className" (.-className parsed))
-      o)
-
-    :else
-    (reduce-kv convert-entry #js {} (-> props merge-caller (merge-shorthand parsed)))))
+    (fold-shorthand! (reduce-kv convert-entry #js {} (merge-caller props))
+                     parsed)))
 
 ;; ---------------------------------------------------------------------------
 ;; Boundary heads (HD-016 / HD-004)
@@ -1496,7 +1546,7 @@
   []
   (doseq [k (js/Object.keys tag-cache)] (js-delete tag-cache k))
   (doseq [k (js/Object.keys prop-cache)] (js-delete prop-cache k))
-  (unchecked-set prop-cache "class" (->PropSlot "className" false false false))
-  (unchecked-set prop-cache "for" (->PropSlot "htmlFor" false false false))
-  (unchecked-set prop-cache "charset" (->PropSlot "charSet" false false false))
+  (unchecked-set prop-cache "class" (->PropSlot "className" false false false true))
+  (unchecked-set prop-cache "for" (->PropSlot "htmlFor" false false false false))
+  (unchecked-set prop-cache "charset" (->PropSlot "charSet" false false false false))
   nil)

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
@@ -172,20 +172,88 @@
            lowering it here would also have thrown, there being no ambient
            frame in this test"))))
 
-(deftest the-shorthand-fast-lane-emits-what-the-donor-map-produced
-  ;; rf2-y1jkm lane 2: an element whose only class is the tag shorthand no
-  ;; longer routes through merge-shorthand's dissoc/assoc — the loop runs
-  ;; over the author's map and the shorthand's className is written AFTER
-  ;; it, because the donor path re-assoc'd `:class` LAST. The observable
-  ;; pin is the overwrite order for an exotic spelling that canonicalises
-  ;; onto the same slot: the shorthand won under the donor's map order and
-  ;; must keep winning under the lane.
-  (testing "a namespaced class spelling does not defeat the shorthand"
-    (is (= "a" (prop (codec/as-element [:div.a {:x/class "b"}]) "className"))))
-  (testing "a literal :class still takes the general lane and composes"
-    (is (= "a b" (prop (codec/as-element [:div.a {:class "b"}]) "className"))))
-  (testing "a caller remainder still takes the general lane and composes"
-    (is (= "a b" (prop (codec/as-element [:div.a {:& {:class "b"}}]) "className")))))
+(deftest the-shorthand-composes-with-a-class-however-it-is-spelled
+  ;; THIS TEST WAS THE OTHER WAY ROUND (rf2-2rtt6.36, merged-PR audit
+  ;; #7332). Under rf2-y1jkm's lane 2 the shorthand's className was written
+  ;; over whatever the loop had emitted, and an exotic spelling that
+  ;; canonicalises onto the same slot lost outright — `[:div.a {:x/class
+  ;; "b"}]` was pinned at "a". It was pinned because it MATCHED the general
+  ;; path, and the general path was itself wrong: the shorthand merge read
+  ;; `:class` and `:className` off the map by raw key, so it saw three of
+  ;; the spellings this codec accepts and silently dropped the rest.
+  ;;
+  ;; The shorthand is folded onto the EMITTED object now, where there is
+  ;; no spelling left to miss, so every one of them composes. The
+  ;; assertion below is the flipped one and it is the whole repair in a
+  ;; line.
+  (testing "a namespaced class spelling composes with the shorthand rather
+            than losing to it"
+    (is (= "a b" (prop (codec/as-element [:div.a {:x/class "b"}]) "className"))))
+  (testing "and so does every other spelling the codec accepts"
+    (doseq [k [:class :className "class" "className" 'class :x/class :class-name]]
+      (is (= "a b" (prop (codec/as-element [:div.a {k "b"}]) "className"))
+          (str "spelled " (pr-str k)))))
+  (testing "a caller remainder composes too, in every spelling"
+    (doseq [k [:class :className "class" "className" 'class :x/class]]
+      (is (= "a b" (prop (codec/as-element [:div.a {:& {k "b"}}]) "className"))
+          (str "forwarded as " (pr-str k)))))
+  (testing "the class value is coerced at the slot, so a collection joins
+            whatever key carried it — the coercion used to live in the map
+            surgery, where only `:class` and `:className` reached it"
+    (doseq [k [:class "className" :x/class]]
+      (is (= "a x y" (prop (codec/as-element [:div.a {k ["x" nil :y]}]) "className"))
+          (str "spelled " (pr-str k)))))
+  (testing "two spellings of the one slot COMPOSE rather than the last write
+            silently winning — a dropped class is the failure class the
+            ruling exists to delete"
+    (is (= "a b c" (prop (codec/as-element [:div.a {:class "b" :x/class "c"}]) "className")))))
+
+(deftest the-shorthand-id-loses-to-an-explicit-one-however-it-is-spelled
+  ;; The other half of merged-PR audit #7332. `#tag` is the weakest source
+  ;; of an id there is, and the rule "an explicit :id wins" was stated on
+  ;; the raw key — so `[:div#tag {"id" "explicit"}]` kept BOTH, landed both
+  ;; on React's one `id` slot, and left which one survived to the order the
+  ;; props map happened to iterate in.
+  (testing "written on the element"
+    (doseq [k [:id "id" 'id :x/id]]
+      (is (= "explicit" (prop (codec/as-element [:div#tag {k "explicit"}]) "id"))
+          (str "spelled " (pr-str k)))))
+  (testing "forwarded through the one merge — the door where the author of
+            the element never sees the key at all"
+    (doseq [k [:id "id" 'id :x/id]]
+      (is (= "caller" (prop (codec/as-element [:div#tag {:& {k "caller"}}]) "id"))
+          (str "forwarded as " (pr-str k)))))
+  (testing "and the shorthand still lands when nothing claims the slot"
+    (is (= "tag" (prop (codec/as-element [:div#tag {:& {:title "t"}}]) "id"))))
+  (testing "a near miss is not the id slot and keeps its own name"
+    (let [e (codec/as-element [:div#tag {:data-id "d" :ids "many"}])]
+      (is (= "tag" (prop e "id")))
+      (is (= "d" (prop e "data-id")))
+      (is (= "many" (prop e "ids"))))))
+
+(deftest the-shorthand-fold-does-not-depend-on-map-order
+  ;; The audit's phrasing: the answer must hold "independent of cache/render
+  ;; /map order". Both spellings of both slots in one remainder, written in
+  ;; both orders, and again in a map big enough to be a PersistentHashMap
+  ;; rather than an array map — the iteration order changes underneath and
+  ;; the emitted element does not.
+  (let [expected {"id" "caller" "className" "foo bar"}
+        emitted  (fn [e] {"id" (prop e "id") "className" (prop e "className")})]
+    (testing "the audit's own witness, both ways round"
+      (is (= expected (emitted (codec/as-element
+                                [:div#tag.foo {:& {"id" "caller" "className" "bar"}}]))))
+      (is (= expected (emitted (codec/as-element
+                                [:div#tag.foo {:& {"className" "bar" "id" "caller"}}])))))
+    (testing "and out of a hash map, whose iteration order is neither"
+      (let [caller (into {} (map (fn [i] [(keyword (str "data-" i)) i])) (range 12))]
+        (is (= expected (emitted (codec/as-element
+                                  [:div#tag.foo {:& (assoc caller "id" "caller" :x/class "bar")}]))))))
+    (testing "renders are independent of what the caches were asked first"
+      (codec/reset-caches!)
+      (codec/cached-prop-name "class")
+      (codec/cached-prop-name :x/id)
+      (is (= expected (emitted (codec/as-element
+                                [:div#tag.foo {:& {"id" "caller" "className" "bar"}}])))))))
 
 (deftest prop-values-are-converted-in-the-shapes-react-wants
   (testing "a style map becomes a JS object with camelCased keys"
@@ -380,7 +448,19 @@
       (is (= "form-control form-control-lg" (prop e "className"))))
     (testing "and a literal :class still wins outright, because it is a literal"
       (let [e (codec/as-element [:input.base {:& {:class "from-caller"} :class "owned"}])]
-        (is (= "base owned" (prop e "className")))))))
+        (is (= "base owned" (prop e "className")))))
+    (testing "composition does not reopen the deny: what composes is what
+              SURVIVED the merge, and an alias at a slot an owned literal
+              claims never gets that far — in either spelling"
+      (doseq [k ["className" :x/class 'class]]
+        (is (= "base owned"
+               (prop (codec/as-element [:input.base {:& {k "from-caller"} :class "owned"}])
+                     "className"))
+            (str "forwarded as " (pr-str k))))
+      (doseq [k ["id" :x/id 'id]]
+        (is (= "owned"
+               (prop (codec/as-element [:div#tag {:& {k "hostile"} :id "owned"}]) "id"))
+            (str "forwarded as " (pr-str k)))))))
 
 (deftest the-same-merge-and-the-same-law-hold-at-a-crossing
   (testing "the case the predecessor needs a THIRD rule for. Its spread forms

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -363,7 +363,7 @@
   "All three arms cache the same value shape the codec caches, so the
   rows price the LOOKUP and not two different payloads."
   [k n]
-  (codec/->PropSlot (codec/prop-name k) (reserved-name? n) false false))
+  (codec/->PropSlot (codec/prop-name k) (reserved-name? n) false false false))
 
 (defn- guarded-lookup
   "The shipping lookup shape, written here so every arm is local."


### PR DESCRIPTION
Closes rf2-2rtt6.36 (EP-0038, Hicasso). Third round on the bead: the merged-PR audits
of #7328 and #7332 reopened it twice on the same failure class, one step further along
each time. This closes the last of it.

## The one spelling

`:&` — a reserved attribute key carrying the caller's remainder map, under the
owned-literal law **unconditionally**: the literal keys written in the map always win.
That surface landed in #7328/#7332 and is unchanged here. What this PR finishes is the
half of the law that was still unenforced.

## What audit #7332 found

`merge-caller` and the structural exclusions already asked `canonical-slot` — the React
slot a key actually emits into — so `"key"`, `:x/ref` and `:onInput` could not walk past
the law by changing their spelling. **The tag shorthand still asked the raw key.**
`merge-shorthand` read `:id`, `:class` and `:className` off the props map, which is three
of the spellings this codec accepts. Every other spelling survived as a second map entry
landing on the *same* React slot, and which one React saw was left to the order the props
map happened to iterate in.

That was live through this bead's own door, because `:&` forwards a caller's remainder
verbatim and the element's author never sees the key:

```clojure
[:div#tag.foo {:& {"id" "caller" "className" "bar"}}]
;; before: id could be "tag"      — the explicit id LOST to the shorthand
;;         className "foo" or "bar" — one replacing the other instead of composing
;; after:  id "caller", className "foo bar" — in every spelling, in any map order
```

## The repair — fold the shorthand on the emitted slot

`merge-shorthand` is **deleted**. The shorthand is folded onto the object the walk emits
(`fold-shorthand!`), where there is nothing left to resolve: every spelling has already
been through `canonical-slot` on its way into that object, so `id` present means *an id
was written*, however spelled, and `className` already holds the composed class. One
`undefined?` test and one `class-names` answer both halves for every spelling at once.

Two things fall out of it:

* **The class slot becomes a position, like the ref slot beside it.** Its value is
  coerced by `class-names` rather than `convert-prop-value` — so `{"class" ["a" nil :b]}`
  joins instead of reaching React as a `clj->js` array; that coercion used to live inside
  the deleted map surgery, where only `:class`/`:className` reached it. And two spellings
  of the slot **compose** rather than the last write silently winning: a silently dropped
  class is the exact failure class HD-023 exists to delete.
* **Three lanes become two.** `rf2-y1jkm`'s fast lane existed to dodge `merge-shorthand`'s
  `dissoc`/`assoc` pair — the map surgery the walk profile priced at most of
  `convert-props`'s cost. With no surgery on any path there is no shape left to peel a
  lane off for: the propless short-circuit, and convert-then-fold.

**Nothing was loosened to accept both behaviours.** The deny still beats composition:
what composes is what SURVIVED the merge, and an alias at a slot an owned literal claims
never gets that far — `[:input.base {:& {"className" "x"} :class "owned"}]` is still
`"base owned"`, and `[:div#tag {:& {"id" "hostile"} :id "owned"}]` is still `"owned"`.

## The pinning test, flipped — not deleted, not loosened

`the-shorthand-fast-lane-emits-what-the-donor-map-produced` asserted that
`[:div.a {:x/class "b"}]` emits `"a"`. It pinned the old behaviour deliberately, because
it *matched* the general path — and the general path was itself wrong. It is renamed
`the-shorthand-composes-with-a-class-however-it-is-spelled`, the assertion now reads
`"a b"`, and its comment records why the old pin was pinning a defect. It is the only
test in the tree whose meaning changed; everything else passes untouched, which is the
useful signal — the first run after the codec change produced exactly one failure, that
one.

New witnesses beside it: every accepted spelling of the class slot composing with `.foo`
(written and forwarded), every accepted spelling of an id beating `#tag` (written and
forwarded), near misses (`:data-id`, `:ids`) keeping their own names, the collection
coercion at every spelling, two class spellings composing, the audit's own witness in
both key orders and again out of a `PersistentHashMap` (so iteration order differs), the
answer being independent of which spelling warmed the caches first, and the owned-literal
deny holding against every alias of `id` and `class`.

## Spec, and what was deliberately not touched

`spec/Conventions.md` is **unchanged**, and that is a decision rather than an oversight.
`:&` is a reserved key and the reserved-key scheme is Conventions' business — but
EP-0038's sequencing law is explicit that nothing edits `spec/*` before P2 graduation,
and this code lives in the bench lane
(`implementation/freehand/test/re_frame/bench/hicasso/`). The reserved-key record for
`:&` belongs in `spec/Conventions.md` at graduation, not in a bench-lane PR that would
also make a hot-zone file sequential for no benefit today. The normative record here is
HD-023 in `docs/design/hicasso/decisions.md`, which gains a `(c″)` clause.

**No bench driver was run and no timing row is published** — siblings are measuring on a
quiet box. The clock effect of deleting the map surgery is unmeasured and is not claimed
anywhere in the diff. `rf2-pqyxz` (which prices `:&`) carries a shape note so it measures
what ships, and **rf2-2rtt6.70** was filed for `walk_profile_app`'s `:shorthand-merge` /
`:no-short` arms, which now price a shape that ships nowhere.

`docs/design/hicasso/**` is outside `mkdocs build --strict` by `mkdocs.yml`'s
`exclude_docs`, so those edits were checked by hand: **no table and no heading was added
or changed** — `(c″)` is prose inside an existing `##` section and the `authoring.md` edit
is one sentence inside an existing paragraph — so no column counts and no anchors moved.
Link targets and heading anchors are validated by `scripts/check_doc_slugs.py`, run below.

## Quality gates

Foreground, to completion, captured to a worktree-local log, exit code echoed
explicitly — nothing backgrounded by choice, nothing piped through `tail`/`grep`.

| Gate | Result | Exit |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | PASS fast PR spine (static/drift + docs tier incl. `mkdocs build --strict` + JVM `implementation/core` and `implementation/freehand` + node CLJS tier + per-ns isolation) | `0` |
| `npm run test:cljs` (node CLJS tier, final tree) | Ran 12425 tests / 62067 assertions — 0 failures, 0 errors | `0` (also run inside the spine, on the final tree) |
| `npm run test:browser` (browser/DOM lane) | Ran 1024 tests / 6335 assertions — 0 failures, 0 errors | `0` |
| `python scripts/check_doc_slugs.py` | clean | `0` |
| `shadow-cljs compile` of the bench app that constructs `PropSlot` | `walk_vs_reagent_app` 202 files, 0 warnings; `walk_profile_app` 187 files, 0 warnings | `0`, `0` |

**Transitive surface.** A codec change breaks its consumers, not itself, so the gate
follows the `:require` edges out of the diff. `front/codec.cljs` is required by 23 other
namespaces, all inside the hicasso bench tree: `front/controlled`, `front/presence`,
`front/intent`, the whole `arm1/` runtime (`runtime`, `boundary`, `mount`, `presence`),
their tests, and the bench apps. The two suites above compile and run the full transitive
closure of both test lanes (`:node-test` takes every `-cljs-test` namespace, `:browser-test`
every `-dom-cljs-test` one). The DOM lane is the one that matters most here — the
controlled grid, the presence tray, the host hatch and the dogfood screen all render real
elements through `convert-props`, and all are green.

The only consumer outside both test lanes is `walk_vs_reagent_app`, which constructs
`codec/->PropSlot` directly and so had to take the new field; it is compiled explicitly in
the last row above rather than assumed.
