### PR TITLE
perf(reagent-slim): the hiccup walk drops from 1.82x to 1.19x stock Reagent (rf2-lhdp0)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -239,30 +239,23 @@
 ;; to carry. See `own-key?`'s epitaph below.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private reserved-prop-keys
-  "JS property keys that must NEVER be `aset` from user-controlled
-  input. Writing to these mutates the prototype of the object instead
-  of creating an own property, which leaks inherited slots across
-  every subsequent prop-map conversion. Per rf2-dwds9 MEDIUM."
-  #{"__proto__" "prototype" "constructor"})
+(defn- ^boolean reserved-prop-key?
+  "True for the three JS property names that must NEVER be `aset` from
+  user-controlled input: writing to one of them mutates the target's
+  prototype instead of creating an own property, leaking inherited slots
+  across every subsequent prop-map conversion. Per rf2-dwds9 MEDIUM.
 
-;; A null-prototype index DERIVED from the roster above, so there is exactly
-;; ONE list of reserved names in this file and nothing to keep in step
-;; (rf2-lhdp0). `contains?` on a PersistentHashSet costs a string hash plus a
-;; hash-map probe; this costs one property load. It is asked once per prop
-;; occurrence on every element of every mount, at the `aset` chokepoint, so
-;; the difference is a per-mount term rather than a micro-optimisation.
-;;
-;; `__proto__` is an ORDINARY own key on a null-prototype object — the
-;; magic accessor lives on `Object.prototype`, which this object does not
-;; have — so the roster indexes itself with no special case.
-(def ^:private reserved-prop-key-index
-  (reduce (fn [o k] (unchecked-set o k true) o)
-          (js/Object.create nil)
-          reserved-prop-keys))
-
-(defn- ^boolean reserved-prop-key? [n]
-  (true? (unchecked-get reserved-prop-key-index n)))
+  THE ROSTER IS THE FUNCTION BODY (rf2-lhdp0). This was a
+  `PersistentHashSet` and a `contains?`, which is a string hash plus a
+  hash-map probe — 53.7 ns/op on the census page's own prop names, for a
+  roster of three, asked once per prop occurrence on every element of every
+  mount. Three `===` compares answer it in 10.4 ns and need no second
+  data structure to keep in step with. `front/codec`'s `reserved-name?`
+  is the same shape for the same reason."
+  [n]
+  (or (identical? "__proto__" n)
+      (identical? "prototype" n)
+      (identical? "constructor" n)))
 
 ;; WHY THERE IS NO `own-key?` ANY MORE (rf2-tsuk6, closed structurally by
 ;; rf2-lhdp0).
@@ -743,9 +736,14 @@
 ;; OR via `:key` in the props map. We honour the meta first, falling
 ;; back to the props map.
 ;;
-;; Reached from two directions: the element constructors AND `expand-seq`'s
-;; per-child missing-key DEBUG warning, which runs on the RAW list children
-;; of EVERY head shape. That warning path is why each interop head keeps a
+;; ONE rule, TWO entry points. `react-key` is the rule and takes the props
+;; slot; `get-react-key` finds the slot first, for a caller that holds only
+;; a vector. The constructors that have already shaped their argv
+;; (`native-element`, `fragment-element`) call the rule; `expand-seq`'s
+;; per-child missing-key DEBUG warning — which runs on the RAW list children
+;; of EVERY head shape — and the cold component constructors call the finder.
+;;
+;; That warning path is why each interop head keeps a
 ;; case here — including `:r>`: `raw-element` owns `:r>` key stamping during
 ;; construction, but a raw `:r>` child (e.g.
 ;; `(for [x xs] [:r> C #js {:key x}])`) still flows through the missing-key
@@ -754,40 +752,33 @@
 ;; properly-keyed `:r>` list child.
 ;; ---------------------------------------------------------------------------
 
-(defn- get-react-key [v]
-  (let [k (when (vector? v) (some-> (meta v) :key))]
-    (or k
-        (case (when (vector? v) (nth v 0 nil))
-          (:> :f>) (when (map? (nth v 2 nil)) (:key (nth v 2 nil)))
-          ;; `:r>` reaches here only via expand-seq's missing-key warning
-          ;; (see the header note); read the js-props `.key` React honours.
-          :r>      (some-> (nth v 2 nil) (.-key))
-          (when (map? (nth v 1 nil)) (:key (nth v 1 nil)))))))
+(defn- react-key
+  "THE RULE: `^{:key …}` meta on the hiccup vector wins; failing that, the
+  props map's `:key`. `props` is the vector's props slot, nil when it has
+  none — `(:key nil)` is nil, so the absence needs no branch.
 
-(defn- react-key-from-props
-  "`get-react-key` for a caller that ALREADY knows the props slot.
-
-  `native-element` — the emit path for every DOM element and every `:>`
-  interop element, so the overwhelming majority of a mount's elements —
-  has just computed `hiccup-shape`'s `head`, which IS the slot
-  `get-react-key` goes looking for. Given that, the general function's
-  work is a `vector?` pair, an `nth 0`, a `case` dispatch, a second `nth`
-  and a `map?` — all of it to re-derive a value already in hand — before
-  the one `:key` lookup it wanted (rf2-lhdp0).
-
-  EQUIVALENT BY CONSTRUCTION, both routes into `native-element`:
-
-    - a DOM tag enters at `first-pos` 1, so `head` is `(nth argv 1 nil)`,
-      which is what `get-react-key`'s DEFAULT branch reads;
-    - `:>` enters at `first-pos` 2 (`interop-element`), so `head` is
-      `(nth argv 2 nil)`, which is what its `(:> :f>)` branch reads.
-
-  `props` is `hiccup-shape`'s `head` — nil or a map, because that is what
-  made `has-props?` true. `(:key nil)` is nil, matching the general
-  function's `map?` guard for the nil case."
+  This is what an element constructor calls. Locating the props slot is
+  precisely what `hiccup-shape` has just done for it, so re-deriving the
+  slot from the head — `get-react-key`'s `nth`/`case` ladder below — is
+  work the hot path does not owe: 133.9 → 62.8 ns per element on the
+  census page (rf2-lhdp0)."
   [argv props]
   (or (some-> (meta argv) :key)
       (:key props)))
+
+(defn- get-react-key
+  "[[react-key]] for a caller holding only a hiccup vector, which must
+  find the props slot before it can read it: the slot is at index 2 under
+  an interop head and index 1 otherwise."
+  [v]
+  (when (vector? v)
+    (case (nth v 0 nil)
+      (:> :f>) (react-key v (let [h (nth v 2 nil)] (when (map? h) h)))
+      ;; `:r>` reaches here only via expand-seq's missing-key warning (see
+      ;; the header note); its props slot is a JS object, so the rule's
+      ;; `:key` lookup does not apply — read the `.key` React honours.
+      :r>      (or (some-> (meta v) :key) (some-> (nth v 2 nil) (.-key)))
+      (react-key v (let [h (nth v 1 nil)] (when (map? h) h))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Source-coord stamping (per IMPL-SPEC §5.4 + §9.4)
@@ -853,9 +844,13 @@
 
 ;; A null-prototype index DERIVED from `void-tags`, so the roster above stays
 ;; the single source of truth and there is no second list to drift
-;; (rf2-lhdp0). The probe is asked once per DOM element of every mount, and a
-;; `contains?` on a 14-entry PersistentHashSet costs a string hash plus a
-;; hash-map probe where a property load costs one lookup.
+;; (rf2-lhdp0). The probe is asked once per DOM element of every mount, and
+;; `contains?` on this 14-entry PersistentHashSet measured 102.3 ns/op on the
+;; census page's own tag strings — a string hash plus a hash-map probe, where
+;; a property load on a prototype-less object is 17.5. Unlike the three-name
+;; reserved roster, fourteen `===` compares are not the readable answer here,
+;; so the index earns its five lines; a `case` was costed too (25.4) and
+;; declined because it would be a SECOND copy of the roster.
 (def ^:private void-tag-index
   (reduce (fn [o t] (unchecked-set o t true) o)
           (js/Object.create nil)
@@ -1008,10 +1003,11 @@
         props     (cond-> (when has-props head)
                     (and *source-coord* (string? component)) merge-source-coord-attr)
         js-props  (or (convert-props props parsed) #js {})]
-    ;; `props` is `hiccup-shape`'s own props slot (the source-coord merge only
-    ;; ever adds `:data-rf2-source-coord`, never `:key`), so the slot the
-    ;; general `get-react-key` would go and re-derive is already bound here.
-    (when-some [key (react-key-from-props argv props)]
+    ;; `props` IS the props slot `get-react-key` would go and re-derive, on
+    ;; both routes here: a DOM tag enters at `first-pos` 1 and `:>` at 2,
+    ;; which are exactly the two indices that ladder reads. (The source-coord
+    ;; merge only ever adds `:data-rf2-source-coord`, never `:key`.)
+    (when-some [key (react-key argv props)]
       (set! (.-key js-props) key))
     (make-element argv component js-props first-child)))
 
@@ -1121,7 +1117,8 @@
         js-props  (or (when (and has-props (some? head))
                         (convert-prop-value head))
                       #js {})]
-    (when-some [key (get-react-key argv)]
+    ;; The slot is in hand, so the rule is read directly — see `react-key`.
+    (when-some [key (react-key argv (when has-props head))]
       (set! (.-key js-props) key))
     (make-element argv (.-Fragment react) js-props first-child)))
 

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -216,21 +216,27 @@
 ;; Strategy: BLOCK the reserved key trio (`__proto__`, `prototype`,
 ;; `constructor`) before any `aset`. Two enforcement points:
 ;;
-;;   - `cached-prop-name` — never caches a reserved name; returns it
-;;     verbatim. (Belt: keeps the shared cache map clean.)
-;;   - `kv-conv` — drops reserved camelCased names before writing to
-;;     the per-render JS props object. (Braces: the actual prototype-
-;;     pollution chokepoint, because the props object is what flows
-;;     into `React.createElement`.)
+;;   - `cached-prop-name` — never caches a reserved name. (Belt: keeps the
+;;     shared cache clean.)
+;;   - `kv-conv` / `top-prop-conv` — drop reserved camelCased names before
+;;     writing to the per-render JS props object. (Braces: the actual
+;;     prototype-pollution chokepoint, because the props object is what
+;;     flows into `React.createElement`.)
 ;;
-;; Why NOT null-prototype objects? React's renderer calls
-;; `styles.hasOwnProperty(...)` on nested objects like `:style` when
-;; diffing inline styles (`react-dom` ReactDOMHostConfig). A
-;; null-proto object throws `TypeError: styles.hasOwnProperty is not
-;; a function`. So props objects stay on the default prototype, and
-;; the reserved-key filter is the sole defence — sufficient on its
-;; own because every prototype-pollution path runs through the filtered
-;; `aset` chokepoints.
+;; PROPS OBJECTS STAY ON THE DEFAULT PROTOTYPE, and that is not negotiable:
+;; React's renderer calls `styles.hasOwnProperty(...)` on nested objects like
+;; `:style` when diffing inline styles (`react-dom` ReactDOMHostConfig), and a
+;; null-prototype object throws `TypeError: styles.hasOwnProperty is not a
+;; function`. So for anything reaching React the reserved-key filter is the
+;; sole defence — sufficient on its own because every pollution path runs
+;; through the filtered `aset` chokepoints.
+;;
+;; THE CACHES ARE NOT PROPS OBJECTS (rf2-lhdp0). `tag-name-cache` and
+;; `prop-name-cache` are module-private lookup tables; nothing in them is ever
+;; handed to React, so the constraint above does not reach them and they take
+;; `Object.create(null)` instead. That is what lets their HIT path — the path
+;; a mount takes once per element and once per prop — drop BOTH guards it used
+;; to carry. See `own-key?`'s epitaph below.
 ;; ---------------------------------------------------------------------------
 
 (def ^:private reserved-prop-keys
@@ -240,30 +246,50 @@
   every subsequent prop-map conversion. Per rf2-dwds9 MEDIUM."
   #{"__proto__" "prototype" "constructor"})
 
-(defn- ^boolean reserved-prop-key? [n]
-  (contains? reserved-prop-keys n))
+;; A null-prototype index DERIVED from the roster above, so there is exactly
+;; ONE list of reserved names in this file and nothing to keep in step
+;; (rf2-lhdp0). `contains?` on a PersistentHashSet costs a string hash plus a
+;; hash-map probe; this costs one property load. It is asked once per prop
+;; occurrence on every element of every mount, at the `aset` chokepoint, so
+;; the difference is a per-mount term rather than a micro-optimisation.
+;;
+;; `__proto__` is an ORDINARY own key on a null-prototype object — the
+;; magic accessor lives on `Object.prototype`, which this object does not
+;; have — so the roster indexes itself with no special case.
+(def ^:private reserved-prop-key-index
+  (reduce (fn [o k] (unchecked-set o k true) o)
+          (js/Object.create nil)
+          reserved-prop-keys))
 
-;; Unspoofable own-property test for the shared `#js {}` caches (rf2-tsuk6).
+(defn- ^boolean reserved-prop-key? [n]
+  (true? (unchecked-get reserved-prop-key-index n)))
+
+;; WHY THERE IS NO `own-key?` ANY MORE (rf2-tsuk6, closed structurally by
+;; rf2-lhdp0).
 ;;
 ;; The caches key entries by user-controlled names: `tag-name-cache` on tag
 ;; heads (a string head like "hasOwnProperty" is accepted) and
 ;; `prop-name-cache` on prop-key names (`{:hasOwnProperty x}` is accepted).
-;; Testing a hit with `(.hasOwnProperty cache n)` reads the method OFF the
-;; cache object — so caching a tag or prop literally named "hasOwnProperty"
-;; `aset`s a value under that exact own-property name and SHADOWS the method.
-;; The lookup itself was fine (`.hasOwnProperty` checks own props, so
-;; inherited prototype keys never falsely hit), but the very next lookup then
-;; invokes the shadowing value as a function and throws a raw host TypeError,
-;; disabling every later parse until reload. `Object.prototype.hasOwnProperty`
-;; called with an explicit receiver can never be shadowed by cache contents.
-(defn- ^boolean own-key?
-  "True when `obj` carries `k` as an OWN property, tested via
-  `Object.prototype.hasOwnProperty.call(obj, k)` so a cache entry named
-  `hasOwnProperty` cannot shadow the check (rf2-tsuk6)."
-  [obj k]
-  (.call (.. js/Object -prototype -hasOwnProperty) obj k))
+;; When the caches were `#js {}` this raised two hostile questions on EVERY
+;; lookup. Testing a hit with `(.hasOwnProperty cache n)` read the method OFF
+;; the cache object, so caching an entry literally named "hasOwnProperty"
+;; shadowed the method and the next lookup invoked a string as a function
+;; (rf2-tsuk6); and an inherited name like `toString` could falsely hit a
+;; value nobody cached. The answer was `Object.prototype.hasOwnProperty.call`
+;; plus a reserved-name check, both on the HIT path.
+;;
+;; `Object.create(null)` answers both questions in the cache's CONSTRUCTION.
+;; There is no prototype chain, so a lookup can only ever return an own
+;; property: no inherited name can hit, and no entry can shadow a method the
+;; lookup does not use. The hit path is now one `unchecked-get` and an
+;; `undefined?` test. The write guard survives on the MISS branch — the only
+;; branch that writes — where it runs once per distinct literal for the life
+;; of the build instead of once per element per mount.
+;;
+;; This is strictly safer than the guard it replaces, not a trade: a cache
+;; that CANNOT serve an inherited value beats one that promises to notice.
 
-(def ^:private tag-name-cache #js {})
+(def ^:private tag-name-cache (js/Object.create nil))
 
 ;; The cache key is the head's FULLY-QUALIFIED name, not its bare `name`
 ;; (rf2-01zvu). Keyed on `name` alone, `:button` and `:rf/button` collide on
@@ -305,14 +331,16 @@
   ;; unnamespaced head and for any string head), so a legitimate head pays
   ;; a single cheap predicate and still resolves through the cache.
   (reject-reserved-rf-head! k element)
-  (let [n (cache-key k)]
-    (if (and (not (reserved-prop-key? n))
-             (own-key? tag-name-cache n))
-      (aget tag-name-cache n)
-      (let [v (parse-tag k element)]
+  (let [n (cache-key k)
+        v (unchecked-get tag-name-cache n)]
+    ;; The cache has no prototype, so a non-undefined answer is necessarily
+    ;; an own entry somebody cached — the hit test IS the lookup (rf2-lhdp0).
+    (if (undefined? v)
+      (let [v' (parse-tag k element)]
         (when-not (reserved-prop-key? n)
-          (aset tag-name-cache n v))
-        v))))
+          (unchecked-set tag-name-cache n v'))
+        v')
+      v)))
 
 ;; ---------------------------------------------------------------------------
 ;; Prop-name cache (kebab → camel)
@@ -353,10 +381,10 @@
             (apply str start (map capitalize parts))))))))
 
 (def ^:private prop-name-cache
-  (doto #js {}
-    (aset "class" "className")
-    (aset "for" "htmlFor")
-    (aset "charset" "charSet")))
+  (doto (js/Object.create nil)
+    (unchecked-set "class" "className")
+    (unchecked-set "for" "htmlFor")
+    (unchecked-set "charset" "charSet")))
 
 (defn cached-prop-name
   "Look up the React prop-name string for hiccup-keyword `k`.
@@ -371,24 +399,27 @@
     :aria-label → \"aria-label\" (aria-* not camelCased)
 
   Per rf2-dwds9 MEDIUM: reserved JS keys (`__proto__`, `prototype`,
-  `constructor`) are never cached and are returned verbatim. The
-  downstream `convert-props` writes drop these too (see `kv-conv`),
-  so a malicious key cannot reach the React props object."
+  `constructor`) are never cached. The downstream `convert-props` writes
+  drop these too (see `kv-conv`), so a malicious key cannot reach the
+  React props object.
+
+  The cache has no prototype (rf2-lhdp0), so the HIT path is one property
+  load and an `undefined?` test — no own-property guard, no reserved-name
+  probe. A reserved name simply never occupies an entry, so it misses every
+  time and takes the conversion path, which answers it verbatim:
+  `dash-to-prop-name` of each of the three returns the name unchanged (no
+  `-`, no `--` prefix, no `data`/`aria` start), exactly what the previous
+  early-return produced."
   [k]
   (if (or (keyword? k) (symbol? k))
-    (let [n (name k)]
-      (cond
-        ;; Reserved keys: skip the cache entirely, return the raw name.
-        ;; (Downstream kv-conv drops the aset; the name is harmless here.)
-        (reserved-prop-key? n) n
-
-        :else
-        (if-some [cached (when (own-key? prop-name-cache n)
-                           (aget prop-name-cache n))]
-          cached
-          (let [v (dash-to-prop-name k)]
-            (aset prop-name-cache n v)
-            v))))
+    (let [n (name k)
+          cached (unchecked-get prop-name-cache n)]
+      (if (undefined? cached)
+        (let [v (dash-to-prop-name k)]
+          (when-not (reserved-prop-key? n)
+            (unchecked-set prop-name-cache n v))
+          v)
+        cached))
     k))
 
 ;; ---------------------------------------------------------------------------
@@ -659,20 +690,24 @@
   `:className` is treated as an additional class and merged with a
   space. When only `:className` is present it is renamed to `:class`
   so `set-id-class`'s shorthand merge has a single key to read. A no-op
-  when neither `:className` nor `:class` is present."
+  when neither `:className` nor `:class` is present.
+
+  `:className` IS THE DISCRIMINATOR, so it is probed first (rf2-lhdp0).
+  Every branch that does anything requires it; when it is absent — which is
+  every element of idiomatic hiccup, where the spelling is `:class` — the
+  answer is `props` unchanged and one probe has settled it. Asking
+  `:class` first cost two probes on that path and three when `:class` was
+  present, the extra one re-asking a question already answered."
   [props]
-  (cond
-    (and (contains? props :class) (contains? props :className))
-    (-> props
-        (assoc :class (class-names (:class props) (:className props)))
-        (dissoc :className))
-
-    (contains? props :className)
-    (-> props
-        (assoc :class (:className props))
-        (dissoc :className))
-
-    :else props))
+  (if (contains? props :className)
+    (if (contains? props :class)
+      (-> props
+          (assoc :class (class-names (:class props) (:className props)))
+          (dissoc :className))
+      (-> props
+          (assoc :class (:className props))
+          (dissoc :className)))
+    props))
 
 (defn- convert-props
   "Convert a hiccup prop map `props` to a React-shape JS props object.
@@ -728,6 +763,31 @@
           ;; (see the header note); read the js-props `.key` React honours.
           :r>      (some-> (nth v 2 nil) (.-key))
           (when (map? (nth v 1 nil)) (:key (nth v 1 nil)))))))
+
+(defn- react-key-from-props
+  "`get-react-key` for a caller that ALREADY knows the props slot.
+
+  `native-element` — the emit path for every DOM element and every `:>`
+  interop element, so the overwhelming majority of a mount's elements —
+  has just computed `hiccup-shape`'s `head`, which IS the slot
+  `get-react-key` goes looking for. Given that, the general function's
+  work is a `vector?` pair, an `nth 0`, a `case` dispatch, a second `nth`
+  and a `map?` — all of it to re-derive a value already in hand — before
+  the one `:key` lookup it wanted (rf2-lhdp0).
+
+  EQUIVALENT BY CONSTRUCTION, both routes into `native-element`:
+
+    - a DOM tag enters at `first-pos` 1, so `head` is `(nth argv 1 nil)`,
+      which is what `get-react-key`'s DEFAULT branch reads;
+    - `:>` enters at `first-pos` 2 (`interop-element`), so `head` is
+      `(nth argv 2 nil)`, which is what its `(:> :f>)` branch reads.
+
+  `props` is `hiccup-shape`'s `head` — nil or a map, because that is what
+  made `has-props?` true. `(:key nil)` is nil, matching the general
+  function's `map?` guard for the nil case."
+  [argv props]
+  (or (some-> (meta argv) :key)
+      (:key props)))
 
 ;; ---------------------------------------------------------------------------
 ;; Source-coord stamping (per IMPL-SPEC §5.4 + §9.4)
@@ -791,8 +851,18 @@
   #{"area" "base" "br" "col" "embed" "hr" "img" "input" "link"
     "meta" "param" "source" "track" "wbr"})
 
+;; A null-prototype index DERIVED from `void-tags`, so the roster above stays
+;; the single source of truth and there is no second list to drift
+;; (rf2-lhdp0). The probe is asked once per DOM element of every mount, and a
+;; `contains?` on a 14-entry PersistentHashSet costs a string hash plus a
+;; hash-map probe where a property load costs one lookup.
+(def ^:private void-tag-index
+  (reduce (fn [o t] (unchecked-set o t true) o)
+          (js/Object.create nil)
+          void-tags))
+
 (defn- ^boolean void-tag? [tag-str]
-  (contains? void-tags tag-str))
+  (true? (unchecked-get void-tag-index tag-str)))
 
 (defn- make-element
   "Construct a React element via React.createElement.
@@ -938,7 +1008,10 @@
         props     (cond-> (when has-props head)
                     (and *source-coord* (string? component)) merge-source-coord-attr)
         js-props  (or (convert-props props parsed) #js {})]
-    (when-some [key (get-react-key argv)]
+    ;; `props` is `hiccup-shape`'s own props slot (the source-coord merge only
+    ;; ever adds `:data-rf2-source-coord`, never `:key`), so the slot the
+    ;; general `get-react-key` would go and re-derive is already bound here.
+    (when-some [key (react-key-from-props argv props)]
       (set! (.-key js-props) key))
     (make-element argv component js-props first-child)))
 

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -250,10 +250,11 @@
   probe, for a roster of three, asked once per prop occurrence on every
   element of every mount. Costed side by side on one run over the census
   page's own prop names: set 53.7 ns/op, three `===` compares 10.4, a
-  null-prototype index 15.8. The chain wins on the clock AND is the only
-  one of the three with no second data structure to keep in step with, so
-  the roster can live where it reads best — here. `front/codec`'s
-  `reserved-name?` is the same shape for the same reason."
+  null-prototype index derived from the set 15.8. The chain wins on the
+  clock, and it is the only one of the three that needs no data structure
+  at all — so the roster stops being a thing to look up and becomes
+  something to read. `front/codec`'s `reserved-name?` is the same shape
+  for the same reason."
   [n]
   (or (identical? "__proto__" n)
       (identical? "prototype" n)

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -246,12 +246,14 @@
   across every subsequent prop-map conversion. Per rf2-dwds9 MEDIUM.
 
   THE ROSTER IS THE FUNCTION BODY (rf2-lhdp0). This was a
-  `PersistentHashSet` and a `contains?`, which is a string hash plus a
-  hash-map probe — 53.7 ns/op on the census page's own prop names, for a
-  roster of three, asked once per prop occurrence on every element of every
-  mount. Three `===` compares answer it in 10.4 ns and need no second
-  data structure to keep in step with. `front/codec`'s `reserved-name?`
-  is the same shape for the same reason."
+  `PersistentHashSet` and a `contains?` — a string hash plus a hash-map
+  probe, for a roster of three, asked once per prop occurrence on every
+  element of every mount. Costed side by side on one run over the census
+  page's own prop names: set 53.7 ns/op, three `===` compares 10.4, a
+  null-prototype index 15.8. The chain wins on the clock AND is the only
+  one of the three with no second data structure to keep in step with, so
+  the roster can live where it reads best — here. `front/codec`'s
+  `reserved-name?` is the same shape for the same reason."
   [n]
   (or (identical? "__proto__" n)
       (identical? "prototype" n)
@@ -281,6 +283,10 @@
 ;;
 ;; This is strictly safer than the guard it replaces, not a trade: a cache
 ;; that CANNOT serve an inherited value beats one that promises to notice.
+;; It is also where the bead's named term went: `cached-prop-name` read 2.0x
+;; stock Reagent's over the census page's 1,489 prop occurrences before this
+;; and 0.53x after, measured on the real function in the same instrument
+;; either side of the change (rf2-lhdp0).
 
 (def ^:private tag-name-cache (js/Object.create nil))
 
@@ -760,8 +766,8 @@
   This is what an element constructor calls. Locating the props slot is
   precisely what `hiccup-shape` has just done for it, so re-deriving the
   slot from the head — `get-react-key`'s `nth`/`case` ladder below — is
-  work the hot path does not owe: 133.9 → 62.8 ns per element on the
-  census page (rf2-lhdp0)."
+  work the hot path does not owe: 133.9 → 62.8 ns per element, the two
+  costed side by side on one run over the census page (rf2-lhdp0)."
   [argv props]
   (or (some-> (meta argv) :key)
       (:key props)))
@@ -845,12 +851,13 @@
 ;; A null-prototype index DERIVED from `void-tags`, so the roster above stays
 ;; the single source of truth and there is no second list to drift
 ;; (rf2-lhdp0). The probe is asked once per DOM element of every mount, and
-;; `contains?` on this 14-entry PersistentHashSet measured 102.3 ns/op on the
-;; census page's own tag strings — a string hash plus a hash-map probe, where
-;; a property load on a prototype-less object is 17.5. Unlike the three-name
-;; reserved roster, fourteen `===` compares are not the readable answer here,
-;; so the index earns its five lines; a `case` was costed too (25.4) and
-;; declined because it would be a SECOND copy of the roster.
+;; costed side by side on one run over the census page's own tag strings,
+;; `contains?` on this 14-entry PersistentHashSet was 102.3 ns/op — a string
+;; hash plus a hash-map probe — against 17.5 for a property load on a
+;; prototype-less object. Fourteen `===` compares are not the readable answer
+;; the three-name reserved roster's are, so here the index earns its five
+;; lines; a `case` was costed too (25.4) and declined because it would be a
+;; SECOND copy of the roster.
 (def ^:private void-tag-index
   (reduce (fn [o t] (unchecked-set o t true) o)
           (js/Object.create nil)

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -953,3 +953,127 @@
           "the subsequent element parses, not a TypeError")
       (is (= "c" (.. el -props -className))
           "and its prop still camelCases through prop-name-cache"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-lhdp0: the caches have NO PROTOTYPE, and that is load-bearing
+;;
+;; `tag-name-cache` and `prop-name-cache` are `Object.create(null)`. Nothing in
+;; them is ever handed to React (the props objects that ARE handed to React
+;; keep their prototype — React's style diffing calls `styles.hasOwnProperty`),
+;; so the caches are free to drop the chain, and dropping it is what lets their
+;; HIT path — once per element and once per prop of every mount — carry no
+;; guard at all.
+;;
+;; With no prototype a lookup can only ever answer an OWN property, so an
+;; inherited name cannot falsely hit. These witnesses pin exactly that: a tag
+;; or prop literally NAMED after an `Object.prototype` member must be parsed
+;; and converted AS ITSELF, and must still answer itself the second time
+;; (proving the entry it then owns is its own and not the inherited one).
+;;
+;; THE MUTATION THEY EXIST FOR: put either cache back to `#js {}` and these go
+;; red — the lookup is served `Object.prototype`'s member for a name nobody
+;; cached. They are not vacuous: each asserts the parsed VALUE, so a stub
+;; answering nil fails them too.
+;; ---------------------------------------------------------------------------
+
+(def ^:private prototype-member-names
+  ["toString" "valueOf" "hasOwnProperty" "isPrototypeOf"
+   "propertyIsEnumerable" "toLocaleString"])
+
+(deftest tag-cache-inherited-name-cannot-falsely-hit-rf2-lhdp0
+  (testing "rf2-lhdp0: a string head named after an Object.prototype member
+            parses as ITSELF, twice — a prototype-less cache cannot serve
+            the inherited member"
+    (doseq [n prototype-member-names]
+      ;; First sight: a MISS that must parse rather than inherit.
+      (let [^js first-el (template/as-element [n "x"])]
+        (is (= n (.-type first-el))
+            (str "head \"" n "\" renders as its own element on first sight")))
+      ;; Second sight: a HIT that must answer the entry we cached, not the
+      ;; prototype member of the same name.
+      (let [^js second-el (template/as-element [n "y"])]
+        (is (= n (.-type second-el))
+            (str "head \"" n "\" still renders as itself on the cached path"))
+        (is (string? (.-type second-el))
+            (str "head \"" n "\" answers a parsed tag, never a host function"))))))
+
+(deftest prop-cache-inherited-name-cannot-falsely-hit-rf2-lhdp0
+  (testing "rf2-lhdp0: a prop key named after an Object.prototype member
+            converts to its own name, twice"
+    (doseq [n prototype-member-names]
+      (let [k (keyword n)]
+        ;; The public cache entry point, direct.
+        (is (= n (template/cached-prop-name k))
+            (str ":" n " converts to its own name on first sight"))
+        (is (= n (template/cached-prop-name k))
+            (str ":" n " converts to its own name on the cached path"))
+        (is (string? (template/cached-prop-name k))
+            (str ":" n " answers a string, never a host function"))
+        ;; And through a whole element, where the name reaches the props object.
+        (let [^js el (template/as-element [:div {k "v"}])]
+          (is (= "v" (gobj/get (.-props el) n))
+              (str ":" n " reaches the props object under its own name")))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-lhdp0: `void-tag?` indexes `void-tags` — one roster, not two
+;;
+;; The probe is a null-prototype index BUILT FROM the `void-tags` set, so the
+;; set stays the single source of truth. This witness walks the WHOLE roster
+;; (the pre-existing cases cover br/input/img — 3 of 14) so the derivation is
+;; pinned end to end rather than sampled, and checks a non-void tag still
+;; keeps its children.
+;; ---------------------------------------------------------------------------
+
+(deftest every-void-tag-drops-children-rf2-lhdp0
+  (testing "rf2-lhdp0: every member of void-tags is recognised by the probe"
+    (is (= 14 (count template/void-tags))
+        "the HTML5 void roster is the fixed 14")
+    (doseq [t template/void-tags]
+      (let [^js el (template/as-element [(keyword t) "dropped"])]
+        (is (= t (.-type el)) (str "<" t "> renders"))
+        (is (nil? (-> el .-props .-children))
+            (str "<" t "> drops the child React would reject"))))))
+
+(deftest non-void-tag-keeps-children-rf2-lhdp0
+  (testing "rf2-lhdp0: the index answers false for ordinary tags, which
+            therefore keep their children (the probe is not stuck true)"
+    (doseq [t ["div" "span" "p" "section" "a"]]
+      (let [^js el (template/as-element [(keyword t) "kept"])]
+        (is (= t (.-type el)) (str "<" t "> renders"))
+        (is (= "kept" (-> el .-props .-children))
+            (str "<" t "> keeps its child"))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-lhdp0: the specialised per-element `:key` read
+;;
+;; `native-element` reads the key from the props slot `hiccup-shape` already
+;; bound rather than re-deriving it through `get-react-key`'s `nth`/`case`
+;; ladder. `native-element` is the emit path for BOTH routes — a DOM tag
+;; (props at index 1) and `:>` interop (props at index 2) — so both are
+;; witnessed here, on both key spellings, plus the precedence between them
+;; and the absence case.
+;; ---------------------------------------------------------------------------
+
+(deftest key-read-covers-both-native-element-routes-rf2-lhdp0
+  (testing "rf2-lhdp0: DOM tag — meta key, prop key, neither"
+    (is (= "m" (.-key ^js (template/as-element ^{:key "m"} [:div "x"])))
+        "meta key on a DOM tag")
+    (is (= "p" (.-key ^js (template/as-element [:div {:key "p"} "x"])))
+        "prop key on a DOM tag")
+    (is (nil? (.-key ^js (template/as-element [:div "x"])))
+        "no key at all on a DOM tag")
+    (is (nil? (.-key ^js (template/as-element [:div {:class "c"} "x"])))
+        "props without :key leave the key unset"))
+
+  (testing "rf2-lhdp0: meta key WINS over the prop key, both routes"
+    (is (= "m" (.-key ^js (template/as-element ^{:key "m"} [:div {:key "p"} "x"])))
+        "DOM tag: meta beats props"))
+
+  (testing "rf2-lhdp0: :> interop — props live at index 2, not 1"
+    (let [C (fn [_] nil)]
+      (is (= "p" (.-key ^js (template/as-element [:> C {:key "p"} "x"])))
+          "prop key on an interop head")
+      (is (= "m" (.-key ^js (template/as-element ^{:key "m"} [:> C {:key "p"} "x"])))
+          "meta key beats the prop key on an interop head")
+      (is (nil? (.-key ^js (template/as-element [:> C "x"])))
+          "interop head with no props slot has no key"))))

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -1044,14 +1044,19 @@
             (str "<" t "> keeps its child"))))))
 
 ;; ---------------------------------------------------------------------------
-;; rf2-lhdp0: the specialised per-element `:key` read
+;; rf2-lhdp0: the per-element `:key` read, straight off the props slot
 ;;
-;; `native-element` reads the key from the props slot `hiccup-shape` already
-;; bound rather than re-deriving it through `get-react-key`'s `nth`/`case`
-;; ladder. `native-element` is the emit path for BOTH routes — a DOM tag
-;; (props at index 1) and `:>` interop (props at index 2) — so both are
-;; witnessed here, on both key spellings, plus the precedence between them
-;; and the absence case.
+;; `react-key` is the RULE (meta wins, then the props map's `:key`) and the
+;; constructors that have already shaped their argv call it with the slot in
+;; hand; `get-react-key` is that same rule plus the `nth`/`case` search for
+;; the slot, for callers holding a bare vector.
+;;
+;; So every constructor that took the short road is witnessed here, on both
+;; key spellings, with the precedence between them and the absence case:
+;; a DOM tag (props at index 1), `:>` interop (index 2 — both are
+;; `native-element`), and `:<>` fragments. The heads still on the finder
+;; (`:f>`, `:r>`, component heads) are witnessed by the sibling suites above,
+;; and `expand-seq`'s missing-key warning is the finder's other caller.
 ;; ---------------------------------------------------------------------------
 
 (deftest key-read-covers-both-native-element-routes-rf2-lhdp0
@@ -1076,4 +1081,14 @@
       (is (= "m" (.-key ^js (template/as-element ^{:key "m"} [:> C {:key "p"} "x"])))
           "meta key beats the prop key on an interop head")
       (is (nil? (.-key ^js (template/as-element [:> C "x"])))
-          "interop head with no props slot has no key"))))
+          "interop head with no props slot has no key")))
+
+  (testing "rf2-lhdp0: :<> fragments read the same rule off the same slot"
+    (is (= "p" (.-key ^js (template/as-element [:<> {:key "p"} "x"])))
+        "prop key on a fragment")
+    (is (= "m" (.-key ^js (template/as-element ^{:key "m"} [:<> "x"])))
+        "meta key on a fragment")
+    (is (= "m" (.-key ^js (template/as-element ^{:key "m"} [:<> {:key "p"} "x"])))
+        "fragment: meta beats props")
+    (is (nil? (.-key ^js (template/as-element [:<> "x"])))
+        "fragment with no props slot has no key")))

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -719,8 +719,15 @@
 ;; Shipping threads `native?` into the reduce through a CLOSURE minted per
 ;; element — `(fn [o k v] (top-prop-conv native? o k v))`. Decide the rule
 ;; once per element instead and the reduce takes a static fn, so the mount
-;; allocates nothing to carry a boolean it already knows. Costed rather than
-;; assumed: V8 allocates closures cheaply and this may be free.
+;; allocates nothing to carry a boolean it already knows.
+;;
+;; COSTED AND DECLINED (rf2-lhdp0). It is free: `slim-convert-props-cheap`
+;; and `slim-convert-props-static` read 151.8303 ns/op EACH — the same
+;; figure to four places, because both windows landed in the same 100 µs
+;; `performance.now` bucket, which bounds the term at under ~0.3 ns per
+;; element. V8 does not charge for the closure, so shipping keeps the
+;; version that reads as one function instead of three. The row stays so
+;; the next reader does not re-derive the guess.
 (defn- slim-native-prop-conv  [o k v] (slim-top-prop-conv slim-reserved-chain? true o k v))
 (defn- slim-interop-prop-conv [o k v] (slim-top-prop-conv slim-reserved-chain? false o k v))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -589,9 +589,11 @@
 (defn- ^boolean slim-reserved-idx? [n]
   (true? (unchecked-get slim-reserved-index n)))
 
-;; Shipping resolves `Object.prototype.hasOwnProperty` on EVERY call (two
-;; property loads) and then `.call`s it. Hoisted here the way the codec's
-;; `has-own` is, so the row prices the guard and not the resolution.
+;; The pre-rf2-lhdp0 `own-key?`, replicated FAITHFULLY — including that it
+;; re-resolved `Object.prototype.hasOwnProperty` on every call (two property
+;; loads) rather than hoisting it the way the codec's `has-own` does. The
+;; resolution is part of what the `-ship` cache rows are pricing, so hoisting
+;; it here would have flattered the shape this bead cut.
 (defn- ^boolean slim-own-key? [obj k]
   (.call (.. js/Object -prototype -hasOwnProperty) obj k))
 
@@ -755,9 +757,14 @@
 
 ;; --- the per-element `:key` read -------------------------------------------
 ;;
-;; Shipping asks `vector?` twice, reads `meta`, then `nth 0`, a `case`, `nth 1`
-;; and a `map?` before the `:key` lookup it wanted. Every call site already
-;; knows the props slot, so the specialised form is the read alone.
+;; The `-ship` form asks `vector?` twice, reads `meta`, then `nth 0`, a `case`,
+;; `nth 1` and a `map?` before the `:key` lookup it wanted — all of it to find
+;; a props slot the caller is holding. The `-spec` form is the read alone. It
+;; won and shipped for the constructors that HAVE the slot (`native-element`,
+;; which is every DOM element and every `:>`, and `fragment-element`); the
+;; `-ship` form survives as `get-react-key`, which is what the callers holding
+;; only a bare vector still need — `expand-seq`'s missing-key DEBUG warning
+;; and the cold component heads.
 
 (defn- slim-key-ship [v]
   (let [k (when (vector? v) (some-> (meta v) :key))]

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -529,21 +529,30 @@
 ;; The arm rows put `reagent2.impl.template` at 1.73-1.90x stock Reagent, and
 ;; the stage table names ONE term (`cached-prop-name`, ~2x stock). That term
 ;; weighs 1,489 prop occurrences over 1,202 elements — nowhere near the whole
-;; gap, and rf2-lhdp0 says so in as many words. These rows name the rest.
+;; gap, and rf2-lhdp0 says so in as many words. These rows named the rest, and
+;; the cuts they convicted took the arm to 1.19-1.24x.
+;;
+;; A `-ship` ROW IS THE PRE-rf2-lhdp0 SHAPE, not today's. It was shipping when
+;; these rows were written; the cheapened twin beside it is what shipped
+;; instead. They are kept as a PAIR because a delta measured in one process on
+;; one roster is the only way these terms compare — see the run-to-run spread
+;; on the arms — and because a future reader deserves the alternatives that
+;; were costed, not just the winner.
 ;;
 ;; Slim's per-element shapes are `defn-` private, so they are replicated here
 ;; the way the cache candidates above already are ("written here so every arm
 ;; is local"). Everything the replicas cannot reach privately is called for
 ;; real: `slim/parse-tag`, `slim/class-names`, `slim/cached-prop-name`,
-;; `slim/convert-prop-value` and `slim/void-tags` are all public.
+;; `slim/convert-prop-value` and `slim/void-tags` are all public. That last
+;; point is also why a `-ship` row does not freeze: its miss path calls the
+;; REAL `slim/cached-prop-name`, which moved.
 ;;
-;; WHAT A ROW HERE IS, AND IS NOT. A `-ship` row is a REPLICA of the shipping
-;; shape, not the shipping shape. It is held honest by AGREEMENT — every
-;; cheapened variant answers what its `-ship` twin answers, over the page's
-;; own literals AND the hostile names it does not carry, checked before any
-;; figure is read — so a `ship → cheap` delta names a term and its sign
-;; reliably. It is NOT calibrated in absolute terms against the real
-;; function, and must not be read as if it were: measured on the first run,
+;; WHAT A ROW HERE IS, AND IS NOT. A replica is held honest by AGREEMENT —
+;; every cheapened variant answers what its `-ship` twin answers, over the
+;; page's own literals AND the hostile names it does not carry, checked
+;; before any figure is read — so a `ship → cheap` delta names a term and its
+;; sign reliably. It is NOT calibrated in absolute terms against the real
+;; function, and must not be read as if it were: measured on one run,
 ;; `slim-prop-lookup-ship` read 86.0 ns/op where `prop-name-slim` — the same
 ;; algorithm, but the REAL `slim/cached-prop-name` — read 66.8. Same shape,
 ;; different call site, 29% apart.
@@ -556,20 +565,23 @@
 
 (def ^:private slim-reserved #{"__proto__" "prototype" "constructor"})
 
-;; Shipping: a PersistentHashSet `contains?` — a string hash plus a hash-map
-;; probe for a roster of three. Candidate: the `identical?` chain the codec
-;; already ships (prior art: front/codec.cljs `reserved-name?`).
+;; Was: a PersistentHashSet `contains?` — a string hash plus a hash-map probe
+;; for a roster of three. The `identical?` chain won and shipped (prior art:
+;; front/codec.cljs `reserved-name?`); the null-prototype index below lost to
+;; it on the clock AND carries a second roster, so it was declined.
 (defn- ^boolean slim-reserved-set? [n] (contains? slim-reserved n))
 (defn- ^boolean slim-reserved-chain? [n]
   (or (identical? "__proto__" n)
       (identical? "prototype" n)
       (identical? "constructor" n)))
 
-;; A null-prototype index DERIVED from the same set. Drift-proof by
-;; construction — there is no second roster to keep in step — and it is the
-;; shape that scales to the 14-entry void-tag roster, where an `identical?`
-;; chain would be 14 compares. `__proto__` is an ordinary own key on a
-;; null-prototype object, so the roster indexes itself without special-casing.
+;; A null-prototype index DERIVED from the same set, so it cannot drift from
+;; it. It loses to the chain at three names but WINS at fourteen, which is
+;; why `void-tag?` ships this shape and `reserved-prop-key?` ships the chain
+;; — the crossover is real and is the whole reason both are costed here.
+;; `__proto__` is an ordinary own key on a null-prototype object (the magic
+;; accessor lives on `Object.prototype`), so a roster indexes itself with no
+;; special case.
 (defn- ^js index-of-strings [ss]
   (reduce (fn [o s] (unchecked-set o s true) o) (js/Object.create nil) ss))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -533,19 +533,26 @@
 ;;
 ;; Slim's per-element shapes are `defn-` private, so they are replicated here
 ;; the way the cache candidates above already are ("written here so every arm
-;; is local"). The replicas are held honest two ways:
-;;
-;;   1. FIDELITY. `slim-prop-lookup-ship` replicates `slim/cached-prop-name`
-;;      exactly; its row must read the same as `prop-name-slim`, which calls
-;;      the REAL function. A replica that drifted would show up as a split
-;;      between those two rows.
-;;   2. AGREEMENT. Every cheapened variant answers what the shipping shape
-;;      answers, over the page's own literals AND the hostile names it does
-;;      not carry — checked before any figure is read.
-;;
-;; Everything the replicas cannot reach privately is called for real:
-;; `slim/parse-tag`, `slim/class-names`, `slim/cached-prop-name`,
+;; is local"). Everything the replicas cannot reach privately is called for
+;; real: `slim/parse-tag`, `slim/class-names`, `slim/cached-prop-name`,
 ;; `slim/convert-prop-value` and `slim/void-tags` are all public.
+;;
+;; WHAT A ROW HERE IS, AND IS NOT. A `-ship` row is a REPLICA of the shipping
+;; shape, not the shipping shape. It is held honest by AGREEMENT — every
+;; cheapened variant answers what its `-ship` twin answers, over the page's
+;; own literals AND the hostile names it does not carry, checked before any
+;; figure is read — so a `ship → cheap` delta names a term and its sign
+;; reliably. It is NOT calibrated in absolute terms against the real
+;; function, and must not be read as if it were: measured on the first run,
+;; `slim-prop-lookup-ship` read 86.0 ns/op where `prop-name-slim` — the same
+;; algorithm, but the REAL `slim/cached-prop-name` — read 66.8. Same shape,
+;; different call site, 29% apart.
+;;
+;; So the authority for "did the landed change move the shipping function?"
+;; is the STAGE table's own real-function rows (`prop-name-slim`,
+;; `convert-props-*`) and the ARM rows, compared across a before run and an
+;; after run. These rows are the map that says WHERE to cut; those rows are
+;; the verdict on the cut.
 
 (def ^:private slim-reserved #{"__proto__" "prototype" "constructor"})
 
@@ -709,6 +716,21 @@
       (reduce-kv (fn [o k v] (slim-top-prop-conv reserved? native? o k v))
                  #js {} with-shorthand))))
 
+;; Shipping threads `native?` into the reduce through a CLOSURE minted per
+;; element — `(fn [o k v] (top-prop-conv native? o k v))`. Decide the rule
+;; once per element instead and the reduce takes a static fn, so the mount
+;; allocates nothing to carry a boolean it already knows. Costed rather than
+;; assumed: V8 allocates closures cheaply and this may be free.
+(defn- slim-native-prop-conv  [o k v] (slim-top-prop-conv slim-reserved-chain? true o k v))
+(defn- slim-interop-prop-conv [o k v] (slim-top-prop-conv slim-reserved-chain? false o k v))
+
+(defn- slim-convert-props-static [preamble props parsed]
+  (let [native?        (string? (.-tag parsed))
+        with-shorthand (preamble props parsed)]
+    (when (seq with-shorthand)
+      (reduce-kv (if native? slim-native-prop-conv slim-interop-prop-conv)
+                 #js {} with-shorthand))))
+
 ;; --- the per-element `:key` read -------------------------------------------
 ;;
 ;; Shipping asks `vector?` twice, reads `meta`, then `nth 0`, a `case`, `nth 1`
@@ -774,7 +796,11 @@
                   (fn [p t] (slim-convert-props slim-preamble-ship slim-reserved-set? p t)))]
      [:slim-convert-props-cheap
       (ns-per-op2 micro-reps el-props parsed
-                  (fn [p t] (slim-convert-props slim-preamble-cheap slim-reserved-idx? p t)))]
+                  (fn [p t] (slim-convert-props slim-preamble-cheap slim-reserved-chain? p t)))]
+     ;; cheap vs static differ ONLY by the per-element closure.
+     [:slim-convert-props-static
+      (ns-per-op2 micro-reps el-props parsed
+                  (fn [p t] (slim-convert-props-static slim-preamble-cheap p t)))]
      ;; the per-element key read
      [:slim-key-ship (ns-per-op micro-reps el-vecs slim-key-ship)]
      [:slim-key-spec (ns-per-op2 micro-reps el-vecs el-props slim-key-spec)]
@@ -810,11 +836,16 @@
             v (aget el-vecs i)]
         (when-not (= (slim-preamble-ship p t) (slim-preamble-cheap p t))
           (swap! bad conj [:preamble i]))
-        (when-not (= (js/JSON.stringify
-                       (slim-convert-props slim-preamble-ship slim-reserved-set? p t))
-                     (js/JSON.stringify
-                       (slim-convert-props slim-preamble-cheap slim-reserved-chain? p t)))
-          (swap! bad conj [:pipeline i]))
+        (let [shipped (js/JSON.stringify
+                        (slim-convert-props slim-preamble-ship slim-reserved-set? p t))]
+          (when-not (= shipped
+                       (js/JSON.stringify
+                         (slim-convert-props slim-preamble-cheap slim-reserved-chain? p t)))
+            (swap! bad conj [:pipeline i]))
+          (when-not (= shipped
+                       (js/JSON.stringify
+                         (slim-convert-props-static slim-preamble-cheap p t)))
+            (swap! bad conj [:pipeline-static i])))
         (when-not (= (slim-key-ship v) (slim-key-spec v p))
           (swap! bad conj [:key i]))))
     ;; hostile names the page does not carry

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -721,13 +721,16 @@
 ;; once per element instead and the reduce takes a static fn, so the mount
 ;; allocates nothing to carry a boolean it already knows.
 ;;
-;; COSTED AND DECLINED (rf2-lhdp0). It is free: `slim-convert-props-cheap`
-;; and `slim-convert-props-static` read 151.8303 ns/op EACH — the same
-;; figure to four places, because both windows landed in the same 100 µs
-;; `performance.now` bucket, which bounds the term at under ~0.3 ns per
-;; element. V8 does not charge for the closure, so shipping keeps the
-;; version that reads as one function instead of three. The row stays so
-;; the next reader does not re-derive the guess.
+;; COSTED AND DECLINED (rf2-lhdp0), and it took TWO runs to say so honestly.
+;; On the first, `slim-convert-props-cheap` and `slim-convert-props-static`
+;; read 151.8303 ns/op EACH — the same figure to four places, because both
+;; windows landed in the same 100 µs `performance.now` bucket. Read alone
+;; that looks like a tight zero. On the second the static form read 326.1
+;; against the closure's 287.4, i.e. 13% SLOWER. So the term is not merely
+;; small, it does not reliably have a SIGN: V8 does not charge for the
+;; closure, and the run-to-run spread on this row is wider than anything the
+;; restructure could win. Shipping keeps the version that reads as one
+;; function rather than three. The row stays so the guess is not re-derived.
 (defn- slim-native-prop-conv  [o k v] (slim-top-prop-conv slim-reserved-chain? true o k v))
 (defn- slim-interop-prop-conv [o k v] (slim-top-prop-conv slim-reserved-chain? false o k v))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -171,7 +171,7 @@
   index primitively."
   [h]
   (let [tags #js [] ks #js [] vs #js [] strs #js [] kids #js []
-        el-tags #js [] el-props #js []]
+        el-tags #js [] el-props #js [] el-vecs #js []]
     (letfn [(visit-child [c]
               (.push kids c)
               (cond (vector? c) (visit c)
@@ -186,7 +186,11 @@
                            (not= :<> head))
                   (.push tags head)
                   (.push el-tags head)
-                  (.push el-props (if has-props? props nil)))
+                  (.push el-props (if has-props? props nil))
+                  ;; The WHOLE argv, meta included — the `:key` read prices a
+                  ;; `(meta v)` probe, so a reconstructed childless vector
+                  ;; (which would carry nil meta) is not the same question.
+                  (.push el-vecs argv))
                 (when props
                   (doseq [[k v] props]
                     (.push ks k)
@@ -195,7 +199,7 @@
                   (visit-child c))))]
       (visit h))
     {:tags tags :prop-keys ks :prop-vals vs :strings strs :children kids
-     :el-tags el-tags :el-props el-props}))
+     :el-tags el-tags :el-props el-props :el-vecs el-vecs}))
 
 ;; ---------------------------------------------------------------------------
 ;; The timed arms
@@ -519,6 +523,324 @@
     @bad))
 
 ;; ---------------------------------------------------------------------------
+;; SLIM, DECOMPOSED (rf2-lhdp0)
+;; ---------------------------------------------------------------------------
+;;
+;; The arm rows put `reagent2.impl.template` at 1.73-1.90x stock Reagent, and
+;; the stage table names ONE term (`cached-prop-name`, ~2x stock). That term
+;; weighs 1,489 prop occurrences over 1,202 elements — nowhere near the whole
+;; gap, and rf2-lhdp0 says so in as many words. These rows name the rest.
+;;
+;; Slim's per-element shapes are `defn-` private, so they are replicated here
+;; the way the cache candidates above already are ("written here so every arm
+;; is local"). The replicas are held honest two ways:
+;;
+;;   1. FIDELITY. `slim-prop-lookup-ship` replicates `slim/cached-prop-name`
+;;      exactly; its row must read the same as `prop-name-slim`, which calls
+;;      the REAL function. A replica that drifted would show up as a split
+;;      between those two rows.
+;;   2. AGREEMENT. Every cheapened variant answers what the shipping shape
+;;      answers, over the page's own literals AND the hostile names it does
+;;      not carry — checked before any figure is read.
+;;
+;; Everything the replicas cannot reach privately is called for real:
+;; `slim/parse-tag`, `slim/class-names`, `slim/cached-prop-name`,
+;; `slim/convert-prop-value` and `slim/void-tags` are all public.
+
+(def ^:private slim-reserved #{"__proto__" "prototype" "constructor"})
+
+;; Shipping: a PersistentHashSet `contains?` — a string hash plus a hash-map
+;; probe for a roster of three. Candidate: the `identical?` chain the codec
+;; already ships (prior art: front/codec.cljs `reserved-name?`).
+(defn- ^boolean slim-reserved-set? [n] (contains? slim-reserved n))
+(defn- ^boolean slim-reserved-chain? [n]
+  (or (identical? "__proto__" n)
+      (identical? "prototype" n)
+      (identical? "constructor" n)))
+
+;; A null-prototype index DERIVED from the same set. Drift-proof by
+;; construction — there is no second roster to keep in step — and it is the
+;; shape that scales to the 14-entry void-tag roster, where an `identical?`
+;; chain would be 14 compares. `__proto__` is an ordinary own key on a
+;; null-prototype object, so the roster indexes itself without special-casing.
+(defn- ^js index-of-strings [ss]
+  (reduce (fn [o s] (unchecked-set o s true) o) (js/Object.create nil) ss))
+
+(def ^:private slim-reserved-index (index-of-strings slim-reserved))
+(defn- ^boolean slim-reserved-idx? [n]
+  (true? (unchecked-get slim-reserved-index n)))
+
+;; Shipping resolves `Object.prototype.hasOwnProperty` on EVERY call (two
+;; property loads) and then `.call`s it. Hoisted here the way the codec's
+;; `has-own` is, so the row prices the guard and not the resolution.
+(defn- ^boolean slim-own-key? [obj k]
+  (.call (.. js/Object -prototype -hasOwnProperty) obj k))
+
+(defn- slim-cache-key [k]
+  (let [n (name k)]
+    (if-let [ns* (and (keyword? k) (namespace k))]
+      (str ns* "/" n)
+      n)))
+
+;; --- the tag cache ---------------------------------------------------------
+
+(def ^:private slim-tag-ship-cache #js {})
+(def ^:private slim-tag-np-cache (js/Object.create nil))
+
+(defn- slim-tag-ship [t]
+  (let [n (slim-cache-key t)]
+    (if (and (not (slim-reserved-set? n))
+             (slim-own-key? slim-tag-ship-cache n))
+      (aget slim-tag-ship-cache n)
+      (let [v (slim/parse-tag t [t])]
+        (when-not (slim-reserved-set? n) (aset slim-tag-ship-cache n v))
+        v))))
+
+(defn- slim-tag-np [t]
+  (let [n (slim-cache-key t)
+        v (unchecked-get slim-tag-np-cache n)]
+    (if (undefined? v)
+      (let [v' (slim/parse-tag t [t])]
+        (when-not (slim-reserved-chain? n) (unchecked-set slim-tag-np-cache n v'))
+        v')
+      v)))
+
+;; --- the prop-name cache ---------------------------------------------------
+
+(def ^:private slim-prop-ship-cache
+  (doto #js {} (aset "class" "className") (aset "for" "htmlFor")
+               (aset "charset" "charSet")))
+
+(def ^:private slim-prop-np-cache
+  (doto (js/Object.create nil)
+    (unchecked-set "class" "className")
+    (unchecked-set "for" "htmlFor")
+    (unchecked-set "charset" "charSet")))
+
+(defn- slim-prop-ship [k]
+  (if (or (keyword? k) (symbol? k))
+    (let [n (name k)]
+      (if (slim-reserved-set? n)
+        n
+        (if-some [cached (when (slim-own-key? slim-prop-ship-cache n)
+                           (aget slim-prop-ship-cache n))]
+          cached
+          (let [v (slim/cached-prop-name k)]
+            (aset slim-prop-ship-cache n v)
+            v))))
+    k))
+
+(defn- slim-prop-np [k]
+  (if (or (keyword? k) (symbol? k))
+    (let [n (name k)
+          v (unchecked-get slim-prop-np-cache n)]
+      (if (undefined? v)
+        (let [v' (slim/cached-prop-name k)]
+          (when-not (slim-reserved-chain? n) (unchecked-set slim-prop-np-cache n v'))
+          v')
+        v))
+    k))
+
+;; --- the per-element prop-map preamble -------------------------------------
+;;
+;; Before a single prop is converted, `convert-props` shuffles the persistent
+;; map three times: `collapse-class-keys` (up to THREE `contains?` probes),
+;; a `:class` normalisation `assoc`, and `set-id-class`'s shorthand merge.
+;; The cheapened collapse probes `:className` FIRST — the discriminator that
+;; is false on essentially every real element — and so pays ONE probe on the
+;; common path instead of two or three. Same answers, fewer questions.
+
+(defn- slim-collapse-ship [props]
+  (cond
+    (and (contains? props :class) (contains? props :className))
+    (-> props
+        (assoc :class (slim/class-names (:class props) (:className props)))
+        (dissoc :className))
+
+    (contains? props :className)
+    (-> props
+        (assoc :class (:className props))
+        (dissoc :className))
+
+    :else props))
+
+(defn- slim-collapse-cheap [props]
+  (if (contains? props :className)
+    (if (contains? props :class)
+      (-> props
+          (assoc :class (slim/class-names (:class props) (:className props)))
+          (dissoc :className))
+      (-> props
+          (assoc :class (:className props))
+          (dissoc :className)))
+    props))
+
+(defn- slim-set-id-class [props parsed]
+  (let [id    (.-id parsed)
+        class (.-className parsed)]
+    (cond-> props
+      (and (some? id) (nil? (:id props)))
+      (assoc :id id)
+
+      class
+      (assoc :class (slim/class-names class (or (:class props) (:className props)))))))
+
+(defn- slim-preamble [collapse props parsed]
+  (let [collapsed  (collapse props)
+        class      (:class collapsed)
+        normalised (cond-> collapsed class (assoc :class (slim/class-names class)))]
+    (slim-set-id-class normalised parsed)))
+
+(defn- slim-preamble-ship  [props parsed] (slim-preamble slim-collapse-ship props parsed))
+(defn- slim-preamble-cheap [props parsed] (slim-preamble slim-collapse-cheap props parsed))
+
+;; --- the whole per-element prop pipeline -----------------------------------
+
+(defn- slim-top-prop-conv [reserved? native? o k v]
+  (let [k' (slim/cached-prop-name k)]
+    (if (and (string? k') (reserved? k'))
+      o
+      (do (aset o k' (slim/convert-prop-value k v native?)) o))))
+
+(defn- slim-convert-props [preamble reserved? props parsed]
+  (let [native?        (string? (.-tag parsed))
+        with-shorthand (preamble props parsed)]
+    (when (seq with-shorthand)
+      (reduce-kv (fn [o k v] (slim-top-prop-conv reserved? native? o k v))
+                 #js {} with-shorthand))))
+
+;; --- the per-element `:key` read -------------------------------------------
+;;
+;; Shipping asks `vector?` twice, reads `meta`, then `nth 0`, a `case`, `nth 1`
+;; and a `map?` before the `:key` lookup it wanted. Every call site already
+;; knows the props slot, so the specialised form is the read alone.
+
+(defn- slim-key-ship [v]
+  (let [k (when (vector? v) (some-> (meta v) :key))]
+    (or k
+        (case (when (vector? v) (nth v 0 nil))
+          (:> :f>) (when (map? (nth v 2 nil)) (:key (nth v 2 nil)))
+          :r>      (some-> (nth v 2 nil) (.-key))
+          (when (map? (nth v 1 nil)) (:key (nth v 1 nil)))))))
+
+(defn- slim-key-spec [v props]
+  (or (some-> (meta v) :key)
+      (:key props)))
+
+;; --- the per-element void-tag probe ----------------------------------------
+
+(defn- ^boolean slim-void-set? [t] (contains? slim/void-tags t))
+(defn- ^boolean slim-void-case? [t]
+  (case t
+    ("area" "base" "br" "col" "embed" "hr" "img" "input" "link"
+     "meta" "param" "source" "track" "wbr") true
+    false))
+
+(def ^:private slim-void-index (index-of-strings slim/void-tags))
+(defn- ^boolean slim-void-idx? [t]
+  (true? (unchecked-get slim-void-index t)))
+
+(defn- warm-slim! [^js tags ^js prop-keys]
+  (dotimes [i (.-length prop-keys)]
+    (let [k (aget prop-keys i)] (slim-prop-ship k) (slim-prop-np k)))
+  (dotimes [i (.-length tags)]
+    (let [t (aget tags i)] (slim-tag-ship t) (slim-tag-np t))))
+
+(defn- slim-table
+  [{:keys [^js tags ^js prop-keys ^js el-props ^js el-vecs ^js el-tags]}]
+  (warm-slim! tags prop-keys)
+  (let [parsed   (let [a #js []]
+                   (dotimes [i (.-length el-tags)] (.push a (slim-tag-ship (aget el-tags i))))
+                   a)
+        tag-strs (let [a #js []]
+                   (dotimes [i (.-length el-tags)] (.push a (.-tag (aget parsed i))))
+                   a)]
+    [;; the two caches, shipping vs null-prototype
+     [:slim-prop-lookup-ship (ns-per-op micro-reps prop-keys slim-prop-ship)]
+     [:slim-prop-lookup-np   (ns-per-op micro-reps prop-keys slim-prop-np)]
+     [:slim-tag-lookup-ship  (ns-per-op micro-reps tags slim-tag-ship)]
+     [:slim-tag-lookup-np    (ns-per-op micro-reps tags slim-tag-np)]
+     ;; the reserved-key probe, per prop, on the write chokepoint
+     [:slim-reserved-set   (ns-per-op micro-reps prop-keys (fn [k] (slim-reserved-set? (name k))))]
+     [:slim-reserved-chain (ns-per-op micro-reps prop-keys (fn [k] (slim-reserved-chain? (name k))))]
+     [:slim-reserved-idx   (ns-per-op micro-reps prop-keys (fn [k] (slim-reserved-idx? (name k))))]
+     ;; the per-element prop-map preamble
+     [:slim-preamble-ship  (ns-per-op2 micro-reps el-props parsed slim-preamble-ship)]
+     [:slim-preamble-cheap (ns-per-op2 micro-reps el-props parsed slim-preamble-cheap)]
+     ;; the WHOLE per-element prop pipeline — the row the hicasso/reagent
+     ;; table has and slim did not
+     [:slim-convert-props-ship
+      (ns-per-op2 micro-reps el-props parsed
+                  (fn [p t] (slim-convert-props slim-preamble-ship slim-reserved-set? p t)))]
+     [:slim-convert-props-cheap
+      (ns-per-op2 micro-reps el-props parsed
+                  (fn [p t] (slim-convert-props slim-preamble-cheap slim-reserved-idx? p t)))]
+     ;; the per-element key read
+     [:slim-key-ship (ns-per-op micro-reps el-vecs slim-key-ship)]
+     [:slim-key-spec (ns-per-op2 micro-reps el-vecs el-props slim-key-spec)]
+     ;; the per-element void probe
+     [:slim-void-set  (ns-per-op micro-reps tag-strs slim-void-set?)]
+     [:slim-void-case (ns-per-op micro-reps tag-strs slim-void-case?)]
+     [:slim-void-idx  (ns-per-op micro-reps tag-strs slim-void-idx?)]]))
+
+(defn- slim-agreement
+  "Every cheapened slim variant answers what the shipping shape answers —
+  over the page's own literals and over the hostile names it does not carry."
+  [{:keys [^js tags ^js prop-keys ^js el-props ^js el-vecs ^js el-tags]}]
+  (warm-slim! tags prop-keys)
+  (let [bad (atom [])]
+    (dotimes [i (.-length prop-keys)]
+      (let [k (aget prop-keys i)]
+        (when-not (= (slim-prop-ship k) (slim-prop-np k))
+          (swap! bad conj [:prop k]))
+        (when-not (= (slim-reserved-set? (name k)) (slim-reserved-chain? (name k)))
+          (swap! bad conj [:reserved-chain k]))
+        (when-not (= (slim-reserved-set? (name k)) (slim-reserved-idx? (name k)))
+          (swap! bad conj [:reserved-idx k]))))
+    (dotimes [i (.-length tags)]
+      (let [t (aget tags i)
+            a (slim-tag-ship t) b (slim-tag-np t)]
+        (when-not (and (= (.-tag a) (.-tag b)) (= (.-id a) (.-id b))
+                       (= (.-className a) (.-className b)))
+          (swap! bad conj [:tag t]))))
+    ;; the preamble, the whole pipeline and the key read, per element
+    (dotimes [i (.-length el-tags)]
+      (let [p (aget el-props i)
+            t (slim-tag-ship (aget el-tags i))
+            v (aget el-vecs i)]
+        (when-not (= (slim-preamble-ship p t) (slim-preamble-cheap p t))
+          (swap! bad conj [:preamble i]))
+        (when-not (= (js/JSON.stringify
+                       (slim-convert-props slim-preamble-ship slim-reserved-set? p t))
+                     (js/JSON.stringify
+                       (slim-convert-props slim-preamble-cheap slim-reserved-chain? p t)))
+          (swap! bad conj [:pipeline i]))
+        (when-not (= (slim-key-ship v) (slim-key-spec v p))
+          (swap! bad conj [:key i]))))
+    ;; hostile names the page does not carry
+    (doseq [n ["__proto__" "prototype" "constructor" "toString" "hasOwnProperty"
+               "valueOf" "isPrototypeOf"]]
+      (let [k (keyword n)]
+        (when-not (= (slim-prop-ship k) (slim-prop-np k))
+          (swap! bad conj [:hostile-prop k]))
+        (when-not (= (slim-reserved-set? n) (slim-reserved-chain? n))
+          (swap! bad conj [:hostile-reserved-chain n]))
+        (when-not (= (slim-reserved-set? n) (slim-reserved-idx? n))
+          (swap! bad conj [:hostile-reserved-idx n]))
+        (let [a (slim-tag-ship k) b (slim-tag-np k)]
+          (when-not (and (= (.-tag a) (.-tag b)) (= (.-id a) (.-id b))
+                         (= (.-className a) (.-className b)))
+            (swap! bad conj [:hostile-tag k])))))
+    ;; the void probe, over every void tag and every tag the page carries
+    (doseq [t (concat slim/void-tags ["div" "span" "p" "a" "section" ""
+                                      "__proto__" "constructor" "toString"])]
+      (when-not (= (slim-void-set? t) (slim-void-case? t))
+        (swap! bad conj [:void-case t]))
+      (when-not (= (slim-void-set? t) (slim-void-idx? t))
+        (swap! bad conj [:void-idx t])))
+    @bad))
+
+;; ---------------------------------------------------------------------------
 ;; Reporting
 ;; ---------------------------------------------------------------------------
 
@@ -582,6 +904,8 @@
                   stages  (stage-table roster)
                   cand-bad (candidate-agreement roster)
                   cands   (candidate-table roster)
+                  slim-bad (slim-agreement roster)
+                  slims    (slim-table roster)
                   hic     (:p50 (get rows :hicasso))
                   rgt     (:p50 (get rows :reagent))
                   slm     (:p50 (get rows :slim))]
@@ -598,6 +922,9 @@
               (lane/record! :walk-vs-reagent-candidates
                             {:disagreements cand-bad
                              :ns-per-op (into {} (map (fn [[k v]] [k (lane/round4 v)])) cands)})
+              (lane/record! :walk-vs-reagent-slim
+                            {:disagreements slim-bad
+                             :ns-per-op (into {} (map (fn [[k v]] [k (lane/round4 v)])) slims)})
 
               (js/console.log ";; ==== WORKLOAD MATCH (every arm's own DOM, canonical) ====")
               (doseq [{:keys [id]} arms]
@@ -630,6 +957,11 @@
               (js/console.log ";; ==== CANDIDATES (costed, not landed) ====")
               (js/console.log (str ";;   agreement failures: " (pr-str cand-bad)))
               (doseq [[k v] cands]
+                (js/console.log (str ";;   " (name k) ": " (fmt v 1) " ns/op")))
+
+              (js/console.log ";; ==== SLIM DECOMPOSED (rf2-lhdp0) ====")
+              (js/console.log (str ";;   agreement failures: " (pr-str slim-bad)))
+              (doseq [[k v] slims]
                 (js/console.log (str ";;   " (name k) ": " (fmt v 1) " ns/op")))
 
               (when (:refuse? gv)


### PR DESCRIPTION
`rf2-2rtt6.63` put three hiccup interpreters side by side on one witness value in one
process and caught `reagent2.impl.template` walking at **1.73–1.90x stock Reagent**, with
`cached-prop-name` — the one term its stage table could name — at ~2x stock.
`day8/reagent-slim` is a published artefact, so every consumer pays that today.

The bead was explicit that the named term is not the gap, and it was right: 1,489 prop
occurrences at ~25 ns of avoidable cost is ~37 µs against a whole-walk deficit of ~840 µs,
about 6%. So this starts by decomposing the walk element by element in the same
instrument, and cuts only what the decomposition convicts.

## The decomposition

Added to `walk_vs_reagent_app` as a fourth table. Every pair below was timed **side by
side on one run** over the census page's own roster (1,202 elements, 1,489 prop
occurrences), and every cheapened variant is checked to answer what the shipping shape
answers — over the page's own literals *and* over hostile names it does not carry —
before any figure is read. `agreement failures: []` on all three runs.

| per-element / per-prop term | before | after | asked per walk | ≈ per walk |
|---|---:|---:|---:|---:|
| `void-tag?` — `contains?` on the 14-name roster | 102.3 | 17.5 | 1,202 | −102 µs |
| the `:key` read — `get-react-key`'s `nth`/`case` ladder | 133.9 | 62.8 | 1,202 | −85 µs |
| `cached-prop-name` cache HIT | 86.0 | 21.2 | 1,489 | −97 µs |
| `cached-parse` cache HIT | 74.5 | 19.1 | 1,202 | −67 µs |
| `reserved-prop-key?` — `contains?` on the 3-name roster | 53.7 | 10.4 | 1,489 | −64 µs |
| the `:class`/`:className` preamble | 150.2 | 125.2 | 1,202 | −30 µs |

**What a `-ship` row is, and is not.** It is a replica of the shipping shape, not the
shipping shape — slim's per-element functions are `defn-` private. It is held honest by
agreement, so a `ship → cut` delta names a term and its sign reliably; it is **not**
calibrated in absolute terms, and the file now says so where it used to claim the
opposite. On the baseline run `slim-prop-lookup-ship` read 86.0 where `prop-name-slim` —
the same algorithm, but the REAL function — read 66.8. The decomposition is the map that
says where to cut. The arm rows below are the verdict on the cut.

## Before / after

Three runs of the same instrument, `[hicasso] ok` and the arm-order guard clean on each.
**Absolute ns moves with the box** — runs 1 and 3 sit ~2x slower than run 2 on arms that
were not touched at all — so the ratio is the comparable statistic, which is why the bead
reports one.

| | reagent arm | slim arm | **slim/reagent** | `cached-prop-name` vs stock | canonical DOM |
|---|---:|---:|---:|---:|---:|
| bead's run 1 (before) | — | — | 1.9020 | 2.0x | — |
| bead's run 2 (before) | — | — | 1.7273 | 2.0x | — |
| **this branch's base** | 1.0250 ms | 1.8687 ms | **1.8232** | 66.8 / 33.6 = **1.99x** | 58,529 B |
| **after, run A** | 0.5125 ms | 0.6375 ms | **1.2439** | 10.4 / 19.8 = **0.53x** | 58,529 B |
| **after, run B** | 1.0000 ms | 1.1875 ms | **1.1875** | 17.1 / 32.6 = **0.53x** | 58,529 B |

Run B landed on a box the baseline is directly readable against — its reagent arm is
within 2.5% of the baseline's — so slim's absolute cost is comparable across those two
rows: **1.8687 → 1.1875 ms per whole-page walk, 1,555 → 988 ns/element, −36%.**

The bead's named term is closed and then some: slim's prop-name lookup was 2.0x stock
Reagent's for the same answer and is now **0.53x** — it is now the cheapest of the three
interpreters on that row. The canonical DOM is byte-identical across all three runs
(58,529 B, same divergence signature against hicasso as stock Reagent's own), so nothing
here moved the rendered output.

## What landed

**The caches lose their prototype.** `tag-name-cache` and `prop-name-cache` become
`Object.create(null)`. This is the shape Hicasso landed for the same problem in #7390, and
it is the whole point: with no prototype chain a lookup can only ever answer an own
property, so the hit path — once per element and once per prop of every mount — drops
*both* guards it carried. `own-key?` is deleted outright and the write guard survives on
the MISS branch, where it runs once per distinct literal for the life of the build.

This is **strictly safer than the guard it replaces**, not a trade. The rf2-tsuk6 class — a
cached entry literally named `hasOwnProperty` shadowing the method the lookup used — is now
structurally impossible rather than defended against, and an inherited name can no longer
falsely hit. New witnesses pin it over six `Object.prototype` member names, as tags and as
props, on first sight *and* on the cached path; put either cache back to `#js {}` and they
go red.

Props objects handed to React keep their prototype, and that is unchanged and not
negotiable — React's style diffing calls `styles.hasOwnProperty` on nested `:style`
objects. Only the module-private lookup tables drop the chain; nothing in them ever
reaches React.

**The reserved roster is the predicate body.** `reserved-prop-key?` was a
`PersistentHashSet` and a `contains?` — a string hash plus a hash-map probe, for a roster
of three, asked at the `aset` chokepoint once per prop of every element. Three `===`
compares answer it in a fifth of the time and need no data structure at all, so the
roster stops being a thing to look up and becomes something to read. `front/codec`'s `reserved-name?`
is the same shape for the same reason.

**`void-tag?` indexes `void-tags`.** Fourteen `===` compares are not the readable answer
the three-name roster's are, so here a null-prototype index derived *from the set* earns
its five lines — one roster, nothing to drift.

**One key rule, two entry points.** `react-key` is the rule (`^{:key …}` meta wins, then
the props slot); `get-react-key` is that same rule *plus* the `nth`/`case` search for the
slot. Constructors that have already shaped their argv — `native-element`, which is every
DOM element and every `:>`, and `fragment-element` — call the rule with the slot in hand.
`expand-seq`'s missing-key warning and the cold component heads call the finder. The
precedence now lives in one place instead of being restated; previously `get-react-key`
mixed the two jobs.

**`collapse-class-keys` probes the discriminator first.** Every branch that does anything
requires `:className`; when it is absent — which is every element of idiomatic hiccup — one
probe settles it instead of two or three.

## Costed and DECLINED

Each of these was written beside the shipping shape and timed against it in the same
process; the rows stay in the bench so the guesses are not re-derived.

- **A null-prototype index for the 3-name reserved roster** — 15.8 ns against the
  `identical?` chain's 10.4, *and* it needs a data structure the chain does not. The chain
  wins on both axes.
- **A `case` for the 14-name void roster** — 25.8 against the index's 14.1–17.5, and it
  would be a SECOND copy of the roster.
- **Static reducers to kill the per-element closure `convert-props` mints to carry
  `native?`** — this needed two runs to read honestly. Run 1 put the closure and static
  forms at `151.8303` ns/op *each*, identical to four places, because both windows landed
  in the same 100 µs `performance.now` bucket; alone that reads as a tight zero. Run 2 put
  the static form **13% slower**. The term does not reliably have a *sign*, which is a
  firmer decline than "it is small". Shipping keeps the version that reads as one function
  rather than three.

## Obligations kept

The bead names three public-adapter obligations Hicasso does not carry and forbids
dropping any for speed: the reserved-`:rf/*`-head guard, the keyword-prop warn-once
diagnostic, and the source-coord stamp. None is dropped and none moved onto the hit path.
`cached-parse` still rejects a reserved head *before* the cache lookup (rf2-sgbna), which
is what the `:browser-test-prod-elision` pin exists for.

One behaviour is reasoned rather than reorganised: `cached-prop-name` used to early-return
reserved names verbatim, and now simply misses the cache every time and takes the
conversion path. `dash-to-prop-name` of each of the three returns the name unchanged (no
`-`, no `--` prefix, no `data`/`aria` start), so the answer is identical — and the existing
rf2-dwds9 witnesses for all three names stay green.

## Still open

slim remains 1.19–1.24x stock Reagent, and the residual is no longer in the prop pipeline
(the cut pipeline replica reads at or near stock's real `convert-props` row). Two
candidates this PR did **not** pursue, filed as **rf2-e7zxb** rather than guessed at here:
`hiccup-shape` allocates a 3-element `PersistentVector` per element only to be destructured
immediately, and `vec-to-elem` asks four `=` keyword compares before it reaches the DOM-tag
branch every element takes.

## Quality gates

Run to completion in this worktree, output captured whole to a worktree-local log — never
piped through `tail`/`grep`, whose status would mask the runner's — and the exit code taken
from the runner itself.

| gate | exit |
|---|---|
| `sh scripts/test-fast-pr.sh` — `PASS fast PR spine` | **0** |
| `cd implementation && npm run test:cljs` — 12,428 tests / 62,123 assertions, 0 failures, 0 errors | **0** |
| `cd implementation && npm run test:reagent-slim:smoke` — the adapter's own testbed browser smoke, 1 scenario, 0 failures | **0** |
| `cd implementation && npm run test:browser-prod-elision` — pins the reserved-`:rf/*`-head reject under `:advanced` + `goog.DEBUG=false`, i.e. the guard sitting on the `cached-parse` path this PR changed; 120 tests / 527 assertions | **0** |
| the walk-vs-reagent instrument ×3 (one baseline, two after) — `[hicasso] ok`, arm-order guard clean, `agreement failures: []` each time | **0**, **0**, **0** |

The adapter's own suites both ran inside the spine and are named in its log:
`JVM implementation/adapters/reagent-slim` (11 tests / 12 assertions — the artefact's
`deps.edn` `:test` lane) and the consolidated node-test bundle that `test:cljs` drives,
which is where `reagent2.impl.template-cljs-test` — including this PR's new witnesses —
actually runs. `test:cljs` is listed separately because it was additionally run standalone
against the final tree.

Not run here, and left to CI: the remaining browser lanes, the bundle-isolation and perf
gates, the Xray feature matrix, and mcp-conformance. The spine names its own gaps on exit.

`clj-kondo --fail-level error` is clean on all three changed files (0 errors, 0 warnings).

Closes rf2-lhdp0.
