### PR TITLE
fix(tools): safe definition summary and complete Xray runtime coords (rf2-oztox, rf2-5dut1)

### DIFF
--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -51,7 +51,7 @@ registry).
 | Prop | Required | Default | Meaning |
 |---|---|---|---|
 | `:machine-id` | no | `nil` | Identifies the machine. Surfaces as the chart's aria-label and on every per-node `:data` payload (read by tests + hosts). |
-| `:definition` | no | `nil` | The machine definition map. When `nil` the chart renders an empty-state placeholder. A **structurally-invalid** definition (rf2-j538f7.18) is REJECTED by the canonical recursive grammar gate INSIDE `chart.layout/project-definition` BEFORE graph construction — nothing reaches ELK and no orphan edges to absent nodes are created; the chart renders a distinct **invalid-definition** placeholder (`data-testid "…-invalid-definition"`, `data-invalid-definition "<:rf.error/machine-* category>"`) carrying the value-free defect category + structural path. The component does NOT subscribe to a framework registry directly — hosts pull the definition via `(rf/machine-meta machine-id)` and pass it in. |
+| `:definition` | no | `nil` | The machine definition map. When `nil` the chart renders an empty-state placeholder. A **structurally-invalid** definition (rf2-j538f7.18) is REJECTED by the canonical recursive grammar gate INSIDE `chart.layout/project-definition` BEFORE graph construction — nothing reaches ELK and no orphan edges to absent nodes are created; the chart renders a distinct **invalid-definition** placeholder (`data-testid "…-invalid-definition"`, `data-invalid-definition "<:rf.error/machine-* category>"`) carrying the value-free defect category + the DEPTH the defect sits at (never the state-id path — see [The value-free definition summary](#the-value-free-definition-summary)). The component does NOT subscribe to a framework registry directly — hosts pull the definition via `(rf/machine-meta machine-id)` and pass it in. |
 | `:current-state` | no | `nil` | The live snapshot `:state` value for the active-state highlight. Accepts all three Spec 005 `:state` arms: a flat keyword (`:authing`), a hierarchical path (`[:auth :authing]`), **or a parallel region-map** (`{:data :loading :form :neutral}`). For a region-map the chart lights up **every** active region leaf simultaneously (the multi-active highlight — see [§Parallel multi-active highlight](#parallel-multi-active-highlight-rf2-yoe6e-rf2-g2svr)). `nil` renders no highlight. |
 | `:from-highlight` | no | `nil` | Focused-event lens origin (a `:state` value). |
 | `:to-highlight` | no | `nil` | Focused-event lens landing (a `:state` value). |
@@ -2327,7 +2327,7 @@ sentence, and `ex-message` leads with the sentence and trails the
 
 | `:rf.error/id` | Meaning |
 |---|---|
-| `:scxml/invalid-spec` | Input spec fails the canonical **recursive** grammar gate (`grammar/valid-definition?` — rf2-j538f7.18): not just a missing root `:initial` / `:states` (or `:type :parallel` / `:regions`), but any structural defect the runtime machine contract rejects at `reg-machine` — a nested compound missing `:initial`, a dangling / malformed transition target, an unknown bare node / spawn key, a malformed history / final-state / `:tags` / `:after`-delay shape. The thrown ex-data carries the value-free `grammar/definition-summary` under `:spec-summary` (its `:defect :category` is the canonical `:rf.error/machine-*` id). |
+| `:scxml/invalid-spec` | Input spec fails the canonical **recursive** grammar gate (`grammar/valid-definition?` — rf2-j538f7.18): not just a missing root `:initial` / `:states` (or `:type :parallel` / `:regions`), but any structural defect the runtime machine contract rejects at `reg-machine` — a nested compound missing `:initial`, a dangling / malformed transition target, an unknown bare node / spawn key, a malformed history / final-state / `:tags` / `:after`-delay shape. The thrown ex-data carries the value-free `grammar/definition-summary` under `:spec-summary` (its `:defect :category` is the canonical `:rf.error/machine-*` id) — see [The value-free definition summary](#the-value-free-definition-summary) for exactly what that may and may not name. |
 | `:scxml/parse-error`  | Input XML is malformed or missing the `<scxml>` root. |
 
 ## AI-generate-a-machine (v1.1, rf2-1bncf)
@@ -2424,7 +2424,7 @@ sentence, and `ex-message` leads with the sentence and trails the
 |---|---|
 | `:ai-generate/no-resolver`  | `:resolver` opt was not provided. |
 | `:ai-generate/parse-failed` | Resolver output could not be parsed as EDN. |
-| `:ai-generate/invalid-spec` | Parsed value failed the canonical **recursive** grammar gate (`grammar/valid-definition?`) — see step 4 above. The thrown ex-data carries the value-free `grammar/definition-summary` under `:spec-summary` (its `:defect :category` is the canonical `:rf.error/machine-*` id). |
+| `:ai-generate/invalid-spec` | Parsed value failed the canonical **recursive** grammar gate (`grammar/valid-definition?`) — see step 4 above. The thrown ex-data carries the value-free `grammar/definition-summary` under `:spec-summary` (its `:defect :category` is the canonical `:rf.error/machine-*` id) — see [The value-free definition summary](#the-value-free-definition-summary). An LLM response is untrusted input, so nothing the model emitted survives into the diagnostic. |
 
 ### Determinism
 
@@ -2432,6 +2432,50 @@ The fn itself is deterministic given a deterministic resolver. LLM
 resolvers are not deterministic by default; for reproducible tests
 inject a stub mapping known prompts to canned EDN responses (see
 the AI-generate test ns for examples).
+
+## The value-free definition summary
+
+`grammar/definition-summary` is the ONE diagnostic every rejection path in
+this artefact stashes, so their reports agree: the SCXML importer under
+`:spec-summary`, AI-generate under `:spec-summary`, the Mermaid emitter under
+`:definition-summary`, the chart projector under `:definition-error`, and — via
+`valid-definition?` — the share decoder's `:invalid-chart-state`.
+
+Every one of those inputs is untrusted. A share fragment is forged by
+assumption, an LLM response is a string a model chose, and an SCXML / Mermaid
+document arrives from wherever the user got it. Projection cannot walk
+`ex-data` after the fact (EP-0015 / Spec 015 §exception-path residual), so the
+summary must not carry anything it was given — and it does not (rf2-oztox):
+
+| Slot | Carries |
+|---|---|
+| `:type` | The closed vocabulary `:map` / `:vector` / `:seq` / `:set` / `:keyword` / `:symbol` / `:string` / `:number` / `:boolean` / `:nil` / `:fn` / `:scalar` — the same set `re-frame.error/diag-value-summary` and `share/value-free-summary` use, so one diagnostic vocabulary reads across all three surfaces. |
+| `:count` | Cardinality of a counted collection or string. A lazy seq is deliberately NOT counted — realising it on the failure path is its own hazard. |
+| `:parallel` | Boolean: is the root a `:type :parallel` root. |
+| `:state-count`, `:region-count` | Integer child counts, when the definition has a map `:states` / `:regions`. |
+| `:defect` | The first structural defect, itself value-free: `:category` (the runtime's canonical `:rf.error/machine-*` id), `:slot` (`:on` / `:after` / `:always` / `:on-done`), `:depth` (an integer — how deep the defect sits), `:key-count` (an integer — how many keys offended). |
+
+That is content-free **by construction** rather than by redaction: every slot
+is a member of a closed vocabulary, an integer or a boolean, so no expression
+in the output is derived from the definition's content and the summary
+serializes to a fixed size whatever arrives. There is no key set to cap and no
+prefix to bound.
+
+Two slots are deliberately **absent**, and both used to be present:
+
+- the definition's top-level **`:keys`** — every key, uncapped and
+  unsanitised. A forged definition's key set is attacker-chosen in content
+  (keys carry markup, control characters and secrets as readily as values do)
+  and in size, so the summary grew with the forger's input without limit.
+  `:count` is what survives that rule, and it is the diagnosis a reader acts
+  on: "a 2000-key map where a machine definition was expected".
+- the defect's **`:path`** and **`:keys`** — the state ids and offending keys
+  read straight off the definition. `grammar/definition-defect` still returns
+  both, because its caller is holding the definition already; the SUMMARY
+  reports `:depth` and `:key-count` instead.
+
+Size and cardinality are kept on purpose. An integer cannot carry a fragment
+of a token, and without them the summary would be safe but useless.
 
 ## Public CLJS API surface — summary
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/chart.cljs
@@ -1451,9 +1451,17 @@
           ;; the recursive grammar gate (`chart.layout/project-definition`)
           ;; BEFORE graph construction, so nothing reached ELK. Render a
           ;; rejection placeholder carrying the value-free canonical defect
-          ;; category (`:rf.error/machine-*`) + structural path — never the raw
-          ;; definition. Must precede the empty-nodes branch (a rejected
-          ;; definition also has empty `:nodes`).
+          ;; category (`:rf.error/machine-*`) + the DEPTH the defect sits at —
+          ;; never the raw definition. Must precede the empty-nodes branch (a
+          ;; rejected definition also has empty `:nodes`).
+          ;;
+          ;; rf2-oztox — this used to print the defect's `:path`, a vector of
+          ;; state ids read straight off the definition. `:definition` is a host
+          ;; prop, and the viewer's is decoded from a share URL, so on the
+          ;; rejection path those ids are precisely the material someone forged;
+          ;; `grammar/definition-summary` no longer carries them and this no
+          ;; longer prints them. `:depth` is the part of the path that survives
+          ;; being content-free, and it is the part a reader acts on.
           (:definition-error parsed)
           (let [{:keys [defect]} (:definition-error parsed)]
             [:div {:data-testid         (str testid "-invalid-definition")
@@ -1476,8 +1484,8 @@
              (str "Machine definition is structurally invalid"
                   (when (:category defect)
                     (str " — " (name (:category defect))))
-                  (when (seq (:path defect))
-                    (str " at " (pr-str (:path defect))))
+                  (when (pos? (or (:depth defect) 0))
+                    (str " at depth " (:depth defect)))
                   " — nothing to render.")])
 
           (empty? (:nodes parsed))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/grammar.cljc
@@ -300,37 +300,120 @@
   [definition]
   (nil? (definition-defect definition)))
 
+(def summary-type-vocabulary
+  "The CLOSED `:type` vocabulary `definition-summary` may emit — deliberately
+  the set `re-frame.error/diag-value-summary` and
+  `machines-viz.share/value-free-summary` already share (rf2-210uq /
+  rf2-m46qv), so a tool reading a thrown `ex-data` from any of the three reads
+  ONE diagnostic vocabulary."
+  #{:map :vector :seq :set :keyword :symbol :string :number :boolean :nil
+    :fn :scalar})
+
+(defn- defect-summary
+  "The value-free projection of a `definition-defect` (rf2-oztox).
+
+  `definition-defect` is the diagnostic for a caller that ALREADY HOLDS the
+  definition, so it names the offending material directly: a `:path` of state
+  ids and, for key defects, the offending `:keys`. Both are read straight off
+  the definition, so both are attacker-chosen in CONTENT and in SIZE when the
+  definition is forged — which is exactly the case `definition-summary` exists
+  to describe. This projection keeps the diagnosis and drops the material:
+
+    {:category  <:rf.error/machine-*>   ;; closed — the literals in this file
+     :slot      :on | :after | :always | :on-done   ;; closed, when present
+     :depth     <int>      ;; how deep the defect sits, not WHERE
+     :key-count <int>}     ;; how many keys offended, not WHICH
+
+  Every slot is a member of a closed vocabulary or an integer, so nothing here
+  is derived from the definition's content. `:depth` and `:key-count` are the
+  parts of `:path` / `:keys` that survive that rule, and they are the useful
+  parts: \"two unknown keys on a node three levels down\" is the diagnosis a
+  reader acts on, and an integer cannot carry a fragment of a token."
+  [defect]
+  (let [{:keys [category path slot]} defect
+        offending                    (get defect :keys)]
+    (cond-> {:category category}
+      slot          (assoc :slot slot)
+      (some? path)  (assoc :depth (count path))
+      (seq offending) (assoc :key-count (count offending)))))
+
 (defn definition-summary
   "EP-0015 / Spec 015 §exception-path residual (rf2-8nzxib) — a value-FREE
-  structural diagnostic for a rejected `definition`. A definition can carry
-  a `:data` slot holding live runtime values, and projection cannot walk
-  `ex-data` after the fact, so the summary reports only STRUCTURAL facts —
-  the top-level key SET, parallel?, and child counts — never the values.
-  The single summary the three emitters share so their thrown-error
-  diagnostics agree (each stashes it under its own surface-specific ex-data
-  key: `:spec-summary` / `:definition-summary`).
+  structural diagnostic for a rejected `definition`. The single summary the
+  three emitters, the share boundary and the chart projector share so their
+  rejection diagnostics agree (each stashes it under its own surface-specific
+  key: `:spec-summary` / `:definition-summary` / `:definition-error`).
 
-  rf2-j538f7.18 — when the definition carries a structural defect the summary
-  also carries the value-free `:defect` (the FIRST `definition-defect` — its
-  `:category` = the engine's `:rf.error/machine-*` id, plus a structural
-  `:path` and, for key/target defects, the offending keys / slot), so every
-  surface that stashes this summary carries the CANONICAL defect category while
-  keeping its own surface-specific error id."
+  Shape:
+
+    {:type         <member of `summary-type-vocabulary`>
+     :count        <int>   ;; counted collection / string
+     :parallel     <bool>  ;; map only
+     :state-count  <int>   ;; map with a map `:states`
+     :region-count <int>   ;; map with a map `:regions`
+     :defect       <`defect-summary`>}  ;; when the definition is rejected
+
+  **Content-free BY CONSTRUCTION (rf2-oztox).** Every value this can carry is
+  a member of a closed vocabulary, an integer, or a boolean, so no expression
+  in the output is derived from the input's CONTENT and the serialized summary
+  is a fixed size whatever arrives. That is a structural guarantee rather than
+  a redaction-quality argument — there is no prefix to bound and no key set to
+  cap — and it is the only claim worth making about a value this function is
+  handed from a forged share URL (`share/decode-share-url` gates `…/chart`'s
+  `:definition` through `valid-definition?`), from an LLM response
+  (`ai_generate`), and from SCXML / Mermaid input.
+
+  IT DID NOT HOLD BEFORE, on the two legs rf2-210uq removed from
+  `re-frame.error/diag-value-summary` and rf2-m46qv removed from
+  `share/value-free-summary`, reproduced here a third time:
+
+  - `:keys` — every top-level key of the rejected definition, uncapped and
+    unsanitised, riding into an ex-info that names itself value-free. A
+    forged definition's key set is attacker-chosen in content (keys carry
+    markup, control characters and secrets as readily as values do) and in
+    size, so the summary grew with the forger's input without limit. Removing
+    it also removes the `(sort-by str (keys definition))` that ran `str` over
+    caller-supplied keys, where a key whose `toString` THREW replaced the
+    documented failure with its own exception.
+  - the `:else {:type :value}` tag, outside the closed vocabulary the other
+    two summarisers now share.
+
+  SIZE AND SHAPE ARE DELIBERATELY KEPT. `:count` / `:state-count` /
+  `:region-count` / `:parallel` are what make the summary useful rather than
+  merely safe — \"a 2000-key map where a machine definition was expected\", \"a
+  parallel root with 3 regions\" is the diagnosis — and none of them can carry
+  a fragment of a token. A lazy seq is NOT counted: realising it on the
+  failure path is its own hazard.
+
+  rf2-j538f7.18 — a rejected definition also carries `:defect`, whose
+  `:category` is the engine's canonical `:rf.error/machine-*` id, so every
+  surface that stashes this summary reports the CANONICAL defect while keeping
+  its own surface-specific error id. See `defect-summary` for why it is a
+  projection of `definition-defect` rather than the defect itself."
   [definition]
   (let [defect (definition-defect definition)
-        base   (if (map? definition)
+        base   (cond
+                 (map? definition)
                  (cond-> {:type     :map
-                          :keys     (vec (sort-by str (keys definition)))
+                          :count    (count definition)
                           :parallel (parallel-definition? definition)}
                    (map? (:states definition))  (assoc :state-count  (count (:states definition)))
                    (map? (:regions definition)) (assoc :region-count (count (:regions definition))))
-                 (cond
-                   (nil? definition)        {:type :nil}
-                   (sequential? definition) {:type  (if (vector? definition) :vector :seq)
-                                             :count (count definition)}
-                   :else                    {:type :value}))]
+
+                 (nil? definition)     {:type :nil}
+                 (vector? definition)  {:type :vector :count (count definition)}
+                 (set? definition)     {:type :set    :count (count definition)}
+                 (string? definition)  {:type :string :count (count definition)}
+                 (keyword? definition) {:type :keyword}
+                 (symbol? definition)  {:type :symbol}
+                 (boolean? definition) {:type :boolean}
+                 (number? definition)  {:type :number}
+                 (seq? definition)     {:type :seq}      ; NOT counted — see above
+                 (fn? definition)      {:type :fn}
+                 (seqable? definition) {:type :seq}
+                 :else                 {:type :scalar})]
     (cond-> base
-      defect (assoc :defect defect))))
+      defect (assoc :defect (defect-summary defect)))))
 
 (defn parent-path
   "The parent path of `path` (its `pop`); `[]` for an empty/top-level
@@ -566,9 +649,27 @@
 
 (defn- unknown-bare-keys
   "The BARE keys of `m` not in `known` (a namespaced key is the open extension
-  carve-out and never flagged)."
+  carve-out and never flagged).
+
+  TOTAL over any key a forged definition can carry (rf2-oztox). The carve-out
+  used to be a bare `(remove #(namespace %))`, and `namespace` THROWS on a key
+  that is not `Named` — so `{:initial :a :states {:a {}} \"x\" 1}`, which a
+  transit-decoded share payload carries as readily as a keyword-keyed one, threw
+  a host `ClassCastException` out of `definition-defect`, and therefore out of
+  `valid-definition?`, in place of the documented `:invalid-chart-state` /
+  `:invalid-definition` rejection every boundary here promises. That is the
+  rf2-210uq path-5 shape one level below the one the bead named: a hostile key
+  destroying the failure it was supposed to produce.
+
+  Testing `Named`-ness first also makes the answer the RIGHT one rather than
+  merely non-throwing. A node key that is not a keyword is not a legal node key
+  under any reading of the grammar, so it belongs in `offending` — the same
+  `:rf.error/machine-unknown-node-key` a misspelled `:on-entry` earns."
   [m known]
-  (->> (keys m) (remove #(namespace %)) (remove known) vec))
+  (->> (keys m)
+       (remove #(and (or (keyword? %) (symbol? %)) (namespace %)))
+       (remove known)
+       vec))
 
 ;; ---- per-node defect checks (each returns a value-free defect map or nil) --
 

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/chart/layout_cljs_test.cljc
@@ -1011,9 +1011,20 @@
         (is (empty? edges) (str label ": no orphan edges to absent nodes"))
         (is (= expected (get-in definition-error [:defect :category]))
             (str label ": carries the canonical defect category"))
-        ;; the value-free summary never leaks a raw node/value.
-        (is (some? (:keys definition-error))
-            (str label ": carries the structural top-level key set")))))
+        ;; rf2-oztox — the summary is content-free BY CONSTRUCTION, so what it
+        ;; carries beside the category is CARDINALITY, never material read off
+        ;; the definition. `:keys` (every top-level key, uncapped) is gone, and
+        ;; this assertion — which pinned it — now pins its replacement. The
+        ;; full grammar is `definition-summary-is-content-free-by-construction`
+        ;; in the grammar-validation ns.
+        (is (nil? (:keys definition-error))
+            (str label ": no raw top-level key set rides the projection result"))
+        (is (nil? (get-in definition-error [:defect :path]))
+            (str label ": no raw state-id path either"))
+        (is (integer? (:count definition-error))
+            (str label ": carries the structural top-level key COUNT"))
+        (is (integer? (get-in definition-error [:defect :depth]))
+            (str label ": carries the defect's DEPTH, not its path")))))
 
   (testing "a nil definition is NOT an error (it is the empty-state placeholder),
             and a VALID definition still projects nodes"

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/cross_emitter_agreement_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/cross_emitter_agreement_cljs_test.cljc
@@ -745,3 +745,84 @@
         (is (= :ai-generate/invalid-spec (:rf.error/id (ex-data ex))))
         (is (= category (get-in (ex-data ex) [:spec-summary :defect :category]))
             (str label ": ai's summary carries the canonical defect category"))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-oztox — the summary is content-free by construction, and the guarantee
+;; is only worth anything WHERE IT LANDS: the whole thrown `ex-data` of every
+;; surface that stashes it. `grammar-validation-cljs-test` pins the summary's
+;; own grammar over a hostile corpus; this pins that no emitter re-introduces
+;; the definition alongside it, and that every thrown diagnostic stays a fixed
+;; size however large the forged definition is.
+;;
+;; All three emitters take untrusted input by their own headers' account —
+;; `ai_generate` an LLM response, `scxml` / `mermaid` an imported document,
+;; and the chart projector a host prop that the viewer decodes from a share
+;; URL.
+
+(def ^:private disclosure-sentinel "hunter2-swordfish-SENTINEL")
+
+(def ^:private disclosure-fragments
+  "Every 8-character window of the sentinel — a leak is proved by a FRAGMENT,
+  since a bounded prefix of attacker material is the defect, not the fix."
+  (into #{} (map #(subs disclosure-sentinel % (+ % 8)))
+        (range (- (count disclosure-sentinel) 7))))
+
+(defn- disclosing? [x]
+  (let [s (pr-str x)]
+    (boolean (some #(str/includes? s %) disclosure-fragments))))
+
+(def ^:private forged-definition
+  "A forged definition that reaches a defect leg through KEY-position material
+  — sentinel state ids, a sentinel-bearing unknown root key, and a live `:data`
+  slot. Pre-fix the thrown ex-data reproduced the root key set verbatim and the
+  embedded defect named the offending keys and their state-id path."
+  {:initial                                        (keyword disclosure-sentinel)
+   (keyword (str disclosure-sentinel "-root-key")) 1
+   :data                                           {:token disclosure-sentinel}
+   :states  {(keyword disclosure-sentinel)
+             {:on {:go (keyword (str disclosure-sentinel "-gone"))}}}})
+
+(def ^:private forged-definition-huge
+  "The same shape with 2000 sentinel-named states — the size arm."
+  (assoc forged-definition
+         :states (into {} (map (fn [i] [(keyword (str disclosure-sentinel "-" i)) {}]))
+                       (range 2000))))
+
+(def ^:private ex-data-serialized-bound
+  "The whole thrown ex-data — human `:message`/`:reason` prose included —
+  against a forged definition of ~2000 states. The bound proves
+  SIZE-INDEPENDENCE, not brevity."
+  700)
+
+(deftest thrown-diagnostics-disclose-nothing-they-were-given
+  (doseq [[surface throw-it] [["mermaid" #(mermaid/emit %)]
+                              ["scxml"   #(scxml/spec->scxml %)]
+                              ["ai"      #(ai/generate-machine "x" {:resolver (constantly (pr-str %))})]]]
+    (doseq [[size d] [["small" forged-definition] ["huge" forged-definition-huge]]]
+      (let [ex (throws-ex #(throw-it d))
+            dt (ex-data ex)]
+        (is (some? ex) (str surface "/" size ": must reject"))
+        (is (not (disclosing? dt))
+            (str surface "/" size ": no sentinel fragment anywhere in ex-data — " (pr-str dt)))
+        (is (not (disclosing? (ex-message ex)))
+            (str surface "/" size ": no sentinel fragment in the thrown message"))
+        (is (< (count (pr-str dt)) ex-data-serialized-bound)
+            (str surface "/" size ": ex-data serialized " (count (pr-str dt)) " chars")))))
+  (testing "the chart projection result is the fourth stash of the same summary"
+    (doseq [[size d] [["small" forged-definition] ["huge" forged-definition-huge]]]
+      (let [result (layout/project-definition d)]
+        (is (some? (:definition-error result)) (str "chart/" size ": rejects"))
+        (is (not (disclosing? (:definition-error result)))
+            (str "chart/" size ": no sentinel fragment in :definition-error — "
+                 (pr-str (:definition-error result))))))))
+
+(deftest thrown-diagnostics-do-not-grow-with-the-definition
+  (testing "a 2000-state forged definition throws the same-size ex-data as a 1-state one"
+    (doseq [[surface throw-it] [["mermaid" #(mermaid/emit %)]
+                                ["scxml"   #(scxml/spec->scxml %)]]]
+      (let [size  (fn [d] (count (pr-str (ex-data (throws-ex #(throw-it d))))))
+            small (size forged-definition)
+            big   (size forged-definition-huge)]
+        (is (<= (- big small) 6)
+            (str surface ": ex-data may grow only by the DIGITS of its counts; "
+                 small " -> " big))))))

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/grammar_validation_cljs_test.cljc
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/grammar_validation_cljs_test.cljc
@@ -388,3 +388,218 @@
                                     :on {:one [:a :two]}
                                     :regions {:a {:initial :one :states {:one {} :two {}}}
                                               :b {:initial :one :states {:one {} :two {}}}}})))))
+
+;; ---------------------------------------------------------------------------
+;; EP-0015 — the summary is content-free BY CONSTRUCTION (rf2-oztox)
+;;
+;; `defect-diagnostics-are-value-free` above plants a secret in a VALUE
+;; position and hunts for it. It passed for as long as `definition-summary`
+;; disclosed the definition anyway, because a sentinel hunt only ever finds the
+;; leak someone thought to plant: the map leg returned `:keys` — every
+;; top-level key, uncapped and unsanitised — and the `:defect` it embedded
+;; named the offending KEYS and the state-id PATH they sat at. All three are
+;; KEY-position material that hunt never looked at, and all three are
+;; attacker-chosen in content and in size: a definition reaches this function
+;; from a forged share URL (the share decoder gates `…/chart`'s `:definition`
+;; through `valid-definition?`), from an LLM response, and from SCXML /
+;; Mermaid import.
+;;
+;; So the checks below are a GRAMMAR, not a hunt. Every summary this namespace
+;; can emit, over a corpus of hostile definitions, must consist of a `:type`
+;; from a closed vocabulary plus integers and booleans and NOTHING else, and
+;; must serialize inside a fixed bound however large the forged definition is.
+;; A future leak fails that without anyone remembering to plant a sentinel.
+
+(def ^:private sentinel
+  "The token planted in every position a forged definition can reach. Nothing
+  the summary carries may reproduce it — as a string, a keyword, a symbol, a
+  state id, or a map KEY."
+  "hunter2-swordfish-SENTINEL")
+
+(def ^:private sentinel-fragments
+  "Every 8-character window of the sentinel. A leak is proved by a FRAGMENT,
+  not only by the whole token: a bounded prefix of attacker material is the
+  defect, not the fix."
+  (into #{} (map #(subs sentinel % (+ % 8))) (range (- (count sentinel) 7))))
+
+(defn- discloses?
+  "Does `x`, once serialized, reproduce any fragment of the sentinel — under
+  any key, at any depth, as a string, a keyword, a symbol or a map key?
+  `pr-str` is the check rather than a string walk precisely because a leaked
+  KEYWORD is not a string, which is how `:keys` survived a test file that
+  already claimed to assert this."
+  [x]
+  (let [s (pr-str x)]
+    (boolean (some #(str/includes? s %) sentinel-fragments))))
+
+(def ^:private exploding-key
+  "A map key whose `toString` THROWS. The old summary ran `(sort-by str (keys
+  definition))` over caller-supplied keys, and `unknown-bare-keys` called
+  `namespace` on them — either could raise the KEY's own exception in place of
+  the failure the summariser was called to describe (the rf2-210uq path-5
+  shape). A caller can put one in a definition, and a forged payload decodes to
+  a non-`Named` key as readily as to a keyword."
+  #?(:clj  (reify Object
+             (toString [_] (throw (ex-info (str "toString exploded: " sentinel) {}))))
+     :cljs (let [o #js {}]
+             (set! (.-toString o)
+                   (fn [] (throw (js/Error. (str "toString exploded: " sentinel)))))
+             o)))
+
+(def ^:private hostile-keys
+  "Sentinel-bearing keys of every type a forged definition can carry, plus keys
+  that are markup and control characters — a disclosed key set is pasted into a
+  console, a log viewer or an issue tracker."
+  {(str "string-key-" sentinel)                 1
+   (keyword sentinel)                           2
+   (keyword sentinel sentinel)                  3
+   (symbol sentinel)                            4
+   [sentinel]                                   5
+   {sentinel sentinel}                          6
+   (str "<script>alert(" sentinel ")</script>") 7
+   (str \u001b "[31m" sentinel \u001b "[0m")    8
+   (str "CR\r\nLF-" sentinel)                   9
+   (str "NUL" \u0000 "-" sentinel)              10
+   4111111111111111                             11
+   true                                         12})
+
+(def ^:private attacker-sized-definition
+  "2000 sentinel-named states. The old `:keys` leg reproduced every top-level
+  key and the embedded `:defect` named the offending ones and their path, so
+  the summary grew with the forger's input without limit."
+  {:initial                             (keyword (str sentinel "-0"))
+   (keyword (str sentinel "-root-key")) 1
+   :states  (into {} (map (fn [i] [(keyword (str sentinel "-" i)) {}])) (range 2000))})
+
+(def ^:private forged-definitions
+  "Definitions a forged share fragment, an LLM response or an SCXML / Mermaid
+  import can hand the grammar. Each is rejected; no rejection may name anything
+  it was given."
+  [["hostile keys of every key type on the root"
+    (merge hostile-keys {:initial :a :states {:a {}}})]
+   ["a hostile key on a state node"
+    {:initial :a :states {:a (merge hostile-keys {})}}]
+   ["a key whose toString throws"
+    {:initial :a :states {:a {}} exploding-key 1}]
+   ["sentinel state ids with a dangling target"
+    {:initial (keyword sentinel)
+     :states  {(keyword sentinel) {:on {(keyword sentinel) (keyword (str sentinel "-gone"))}}}}]
+   ["a sentinel-named nested compound missing :initial"
+    {:initial (keyword sentinel)
+     :states  {(keyword sentinel) {:states {(keyword (str sentinel "-inner")) {}}}}}]
+   ["an attacker-sized 2000-state definition" attacker-sized-definition]
+   ["a live :data slot beside a defect"
+    {:initial :a :states {:a {:on-entry (fn [_] sentinel)}} :data {:token sentinel}}]
+   ["a parallel root of sentinel-named regions"
+    {:type :parallel :regions {(keyword sentinel) {:states {(keyword sentinel) {}}}}}]
+   ["a sentinel string where a definition was expected"    sentinel]
+   ["a sentinel keyword with no length bound"
+    (keyword (apply str (repeat 20 sentinel)))]
+   ["a sentinel symbol"                                    (symbol sentinel)]
+   ["a vector of secrets"                                  [sentinel sentinel]]
+   ["a set of secrets"                                     #{sentinel}]
+   ["a list of secrets"                                    (list sentinel)]
+   ["a lazy seq of secrets"                                (map identity [sentinel])]
+   ["a live fn"                                            (fn [] sentinel)]
+   ["a 16-digit card number"                               4111111111111111]
+   ["a boolean"                                            true]
+   ["nil"                                                  nil]
+   ;; The `:else` leg. It is the one the bead named directly (`{:type :value}`,
+   ;; outside the closed vocabulary the other two summarisers share), and
+   ;; without an opaque host object in the corpus nothing would reach it — a
+   ;; hole that would have let the tag drift back unnoticed.
+   ["an opaque host object naming the sentinel"
+    #?(:clj (java.io.File. ^String sentinel) :cljs (js-obj "k" sentinel))]])
+
+(def ^:private summary-keys
+  "The CLOSED key set of a summary. Nothing else may appear, because every
+  other slot would have to be derived from the definition's CONTENT."
+  #{:type :count :parallel :state-count :region-count :defect})
+
+(def ^:private defect-keys
+  "The CLOSED key set of an embedded `:defect`. `:path` and `:keys` are
+  deliberately absent — they are the state ids and the offending keys read
+  straight off the definition, which is to say the forger's own material."
+  #{:category :slot :depth :key-count})
+
+(def ^:private defect-slots #{:on :after :always :on-done})
+
+(defn- non-neg-int-slots?
+  "Every one of `ks` present in `m` is a non-negative integer."
+  [m ks]
+  (every? (fn [k] (or (not (contains? m k))
+                      (let [v (get m k)] (and (integer? v) (not (neg? v))))))
+          ks))
+
+(defn- content-free-defect? [d]
+  (and (map? d)
+       (every? defect-keys (keys d))
+       (keyword? (:category d))
+       (= "rf.error" (namespace (:category d)))
+       (str/starts-with? (name (:category d)) "machine-")
+       (or (not (contains? d :slot)) (contains? defect-slots (:slot d)))
+       (non-neg-int-slots? d [:depth :key-count])))
+
+(defn- content-free-summary?
+  "The grammar. A summary's key set is a subset of `summary-keys`, its `:type`
+  is in the closed vocabulary, its counts are non-negative integers, its
+  `:parallel` is a boolean, and its `:defect` — when present — satisfies
+  `content-free-defect?`."
+  [s]
+  (and (map? s)
+       (every? summary-keys (keys s))
+       (contains? g/summary-type-vocabulary (:type s))
+       (non-neg-int-slots? s [:count :state-count :region-count])
+       (or (not (contains? s :parallel)) (boolean? (:parallel s)))
+       (or (not (contains? s :defect))   (content-free-defect? (:defect s)))))
+
+(def ^:private summary-serialized-bound
+  "A summary is the same size whatever arrives. 200 characters is slack over
+  the longest legal shape (every optional slot present, the longest
+  `:rf.error/machine-*` category, four-digit counts) and orders of magnitude
+  under the definitions below."
+  200)
+
+(deftest definition-summary-is-content-free-by-construction
+  (doseq [[label d] forged-definitions]
+    (let [s (g/definition-summary d)]
+      (is (content-free-summary? s)
+          (str label " — not a content-free summary: " (pr-str s)))
+      (is (not (discloses? s))
+          (str label " — no sentinel fragment may survive: " (pr-str s)))
+      (is (<= (count (pr-str s)) summary-serialized-bound)
+          (str label " — fixed serialized bound, got " (count (pr-str s))))))
+  (testing "every forged definition is in fact REJECTED, so the summary is on
+            the path that matters rather than a valid-definition no-op"
+    (doseq [[label d] forged-definitions]
+      (is (false? (g/valid-definition? d)) (str label " — must be rejected"))
+      (is (some? (:defect (g/definition-summary d)))
+          (str label " — the summary carries the defect")))))
+
+(deftest definition-summary-does-not-grow-with-the-definition
+  (testing "a 2000-state forged definition summarises to the same size as a
+            1-state one — the guarantee a capped `:keys` could never give"
+    (let [size  #(count (pr-str (g/definition-summary %)))
+          small (size {:initial :a :states {:a {}} "x" 1})
+          big   (size (assoc attacker-sized-definition "x" 1))]
+      (is (<= (- big small) 6)
+          (str "the summary may grow only by the DIGITS of its counts; "
+               small " -> " big)))))
+
+(deftest hostile-keys-do-not-destroy-the-failure-being-described
+  (testing "rf2-oztox — a key that is not `Named` no longer throws out of the
+            validator. `unknown-bare-keys` called `namespace` on every key, and
+            `namespace` throws on a String / host object, so a forged
+            definition carrying a string key replaced the documented rejection
+            with a host cast exception — out of `valid-definition?` itself, and
+            therefore out of every boundary that delegates to it."
+    (doseq [[label d] [["a string key on the root"    {:initial :a :states {:a {}} "x" 1}]
+                       ["a string key on a node"      {:initial :a :states {:a {"x" 1}}}]
+                       ["a key whose toString throws" {:initial :a :states {:a {}} exploding-key 1}]
+                       ["a number key"                {:initial :a :states {:a {}} 42 1}]
+                       ["a vector key"                {:initial :a :states {:a {}} [:x] 1}]]]
+      (is (= :rf.error/machine-unknown-node-key (category d))
+          (str label " — the documented defect, not a host exception"))
+      (is (false? (g/valid-definition? d)) (str label " — rejects cleanly"))))
+  (testing "the namespaced-key carve-out is unchanged"
+    (is (nil? (g/definition-defect {:initial :a :states {:a {:my.app/note "x"}}})))))


### PR DESCRIPTION
Two bugs on the `tools/` surface, in disjoint subdirectories.

## rf2-oztox — the definition summary discloses nothing it was given (FIXED)

`grammar/definition-summary` is the ONE diagnostic every rejection path in
machines-viz stashes: SCXML and AI-generate under `:spec-summary`, Mermaid
under `:definition-summary`, the chart projector under `:definition-error`,
and — through `valid-definition?` — the share decoder's `:invalid-chart-state`.
Every one of those inputs is untrusted by its own header's account.

It is the **third** independent EP-0015 summariser in this repo, after
`re-frame.error/diag-value-summary` (rf2-210uq) and `share/value-free-summary`
(rf2-m46qv), and it reproduced the same legs both of those removed. This
follows their established shape rather than inventing a second convention:
same closed `:type` vocabulary, same "integers are the diagnosis" rule, same
grammar-shaped witness.

**Four disclosure paths, all reproduced before the fix:**

| # | Path | Before | After |
|---|---|---|---|
| 1 | map `:keys` | every top-level key of the forged definition, uncapped and unsanitised | removed; `:count` carries the cardinality |
| 2 | `(sort-by str (keys definition))` | `str` over caller-supplied keys | gone with `:keys` |
| 3 | `:else {:type :value}` | outside the closed vocabulary the other two share | full closed vocabulary, `:scalar` for the opaque leg |
| 4 | `unknown-bare-keys` — not in the bead, worse than what was | `namespace` THROWS on a non-`Named` key, so `{:initial :a :states {:a {}} "x" 1}` raised a host `ClassCastException` **out of `valid-definition?` itself** — i.e. out of the forged-share-URL gate — in place of the documented rejection | total; a non-keyword key earns the same `:rf.error/machine-unknown-node-key` a misspelled `:on-entry` does |

**The ruling the bead asked for.** The bead noted `:defect` "may carry
offending KEYS, so the ruling has to decide what a definition's structural
diagnostic may name — not merely delete a leg." It carried more than that: a
`:path` of state ids read straight off the definition. The ruling taken —
forced by the bead's own acceptance ("the whole thrown ex-data discloses no
sentinel fragment and serializes inside a fixed bound") — splits the two
audiences:

- **`definition-defect` is unchanged.** Its caller is holding the definition
  already, so `:path` and `:keys` name material the reader has.
- **`definition-summary` projects it.** `:category` and `:slot` (both closed
  vocabularies) survive intact; `:path` becomes an integer `:depth`, `:keys`
  an integer `:key-count`.

Result: every slot in a summary is a member of a closed vocabulary, an integer
or a boolean. Nothing is derived from the input's content, so there is no
prefix to bound and no key set to cap — safe **by construction**, not a pile of
redaction special-cases. Size and cardinality are kept deliberately: "a
2000-key map where a machine definition was expected" is the diagnosis, and an
integer cannot carry a fragment of a token.

The chart's rejection placeholder printed the defect's `:path` into the DOM.
It now names the depth.

### The witness is a grammar, not a sentinel hunt

`defect-diagnostics-are-value-free` already planted a secret and hunted for it,
and passed throughout — because a hunt only ever finds the leak someone thought
to plant, and `:keys` / the defect's `:path` are KEY-position material it never
looked at.

What the forged corpus actually forges (19 definitions, in
`grammar_validation_cljs_test.cljc`):

- **sentinel-bearing keys of every key type** — string, keyword, namespaced
  keyword, symbol, vector, map, `<script>` markup, ANSI colour escapes, CRLF,
  an embedded NUL, a 16-digit card number, a boolean — placed both on the root
  and on a state node;
- **a key whose `toString` throws** (`reify Object` on JVM, a `#js` object with
  a throwing `toString` on CLJS);
- **an attacker-sized definition** — 2000 sentinel-named states plus a
  sentinel-named unknown root key;
- **sentinel state ids** with a dangling target, and a sentinel-named nested
  compound missing `:initial` — the cases that put the forger's own names into
  the defect's `:path`;
- **a live `:data` slot** and a `:on-entry` fn returning the sentinel;
- every non-map arm: a 520-char keyword, a symbol, vector/set/list/lazy-seq of
  secrets, a live fn, a number, a boolean, `nil`, and an **opaque host object
  named after the sentinel** (the `:else` leg — without it nothing in the
  corpus reached the tag the bead named, a hole that would have let it drift
  back unnoticed).

Assertions: every summary is a closed-vocabulary `:type` plus integers and
booleans and nothing else; reproduces **no 8-character fragment** of the
sentinel (`pr-str`-based, because a leaked *keyword* is not a string — which is
exactly how `:keys` survived a file that already claimed to assert this);
serializes inside a fixed 200-char bound; and a 2000-state definition
summarises within 6 chars of a 1-state one. `cross_emitter_agreement` extends
the same three assertions to the **whole thrown ex-data** of Mermaid, SCXML and
AI-generate plus the chart projection result, at both sizes.

### Mutation proof

**M1 — surgical, single token.** `:scalar` to `:value` in the `:else` leg.
Suite exits **1** with **exactly one named failure**:

```
FAIL in (definition-summary-is-content-free-by-construction) (grammar_validation_cljs_test.cljc:566)
  actual: (not (content-free-summary? {:type :value, :defect {:category :rf.error/machine-bad-definition, :depth 0}}))
Ran 637 tests containing 2688 assertions.
1 failures, 0 errors.
```

**M2 — the original defect restored.** Re-added `:keys (vec (sort-by str (keys
definition)))` to the map leg. Suite exits **1** with **16 failures + 1 error**
across four named deftests — `definition-summary-is-content-free-by-construction`
(FAIL *and* ERROR: the ERROR is the exploding-`toString` key blowing up
`sort-by str`, i.e. the path-5 shape reproducing itself),
`definition-summary-does-not-grow-with-the-definition`,
`project-definition-rejects-structurally-invalid-before-elk`, and
`thrown-diagnostics-disclose-nothing-they-were-given`. The failure output was
literally unreadable as text (`grep` reported the log as binary) because the
old `:keys` leg printed the corpus's raw NUL and ANSI-escape keys into it — the
leak demonstrating itself.

Both mutations reverted and confirmed **byte-identical** (`cmp` against a
pristine copy), and the suite re-run green afterwards.

## rf2-5dut1 — Xray's published pom (VERIFIED, NOT CLOSED — blocked on a ruling)

**No code in this PR.** The packaging half landed on main in PR #7349
(`76ed76d84d`, `fae9552c85`, `f98fce002b`) and holds; what remains is the
Freehand operator ruling, which is not a worker's to make. Re-verified against
the build rather than the bead:

- `clojure -M:clein pom` on the pristine `tools/xray/deps.edn` prints exactly
  **ten** `Skipping coordinate` lines and writes a pom whose `<dependencies>`
  are **four** third-party artefacts (clojure, zprint, reagent, editscript) and
  **zero** in-repo ones. The mechanism reproduces today.
- The rewrite could not be run end-to-end locally: after
  `rewrite-local-root-coord.sh` pins the nine, `clein pom` cannot build a
  classpath (`Could not find artifact day8:re-frame2-routing:jar:0.0.1.alpha in
  central`) — nothing is published at the lockstep version. Expected;
  `release-xray.yml`'s own header says the rewrite assumes core is already on
  Clojars.
- The assertion that would have come from that pom is instead proved by the
  recurrence guard #7349 added: `node
  implementation/scripts/_preflight-xray-package.test.cjs` gives **15/15, exit
  0**, including "rewrites EVERY publishable in-repo coordinate", "rewrites NO
  unpublishable coordinate", "the two-coordinate rewrite fails — the shipping
  state rf2-5dut1 found", and "the nine-coordinate rewrite fails on Freehand
  ALONE".
- `verify-version-lockstep.sh`'s `TOOLS_LOCAL_ROOTS` now inventories all ten
  xray coordinates (bead body item 2 — closed).

The three routes are costed on the bead. Route (2), late-binding, is a change
in **Freehand's** lane (`re-frame.freehand.tool` is a leaf nothing in
`implementation/freehand/src` requires, so a load path has to be added, which
puts a dev-only ns into the D021 production-bundle measurement) — so it could
not have been done from this surface even had the ruling been made.

## Spec

`tools/machines-viz/spec/API.md` gains a normative **"The value-free definition
summary"** section — the slot-by-slot contract, what is deliberately absent and
why, and the `definition-defect` vs `definition-summary` split — cross-linked
from the `MachineChart` `:definition` prop row (whose "value-free defect
category + structural path" claim was stale) and from the SCXML and AI-generate
error tables. `scripts/check_doc_slugs.py` exit 0.

**`tools/xray/spec/*` is unchanged, because** nothing in this PR touches
`tools/xray/` source or behaviour: the machines-viz change is confined to the
grammar summariser, and `tools/xray/spec` references machines-viz only for the
chart component (`000-Vision.md`, `003-Machine-Inspector.md` — both of which
point at `tools/machines-viz/spec/` for exactly this kind of detail). The
rf2-5dut1 half is packaging with no code change at all.

Anchors and table column counts in the edited spec section were checked by hand
(the new table is 2-column throughout; the new anchor
`#the-value-free-definition-summary` resolves from all three link sites).

## Quality gates

All foreground, to completion, captured to worktree-local logs, exit code
echoed explicitly and never piped through `tail`/`grep`.

| Gate | Result | Exit |
|---|---|---|
| `clojure -M:test` in `tools/machines-viz` (JVM) | 637 tests, 2688 assertions, 0 failures, 0 errors | **0** |
| `npm run test:tools-machines-viz` (machines-viz CLJS lane) | 837 tests, 3621 assertions, 0 failures, 0 errors | **0** |
| `npm run test:cljs` (consolidated node-test) | 12428 tests, 62181 assertions, 0 failures, 0 errors | **0** |
| `sh scripts/test-jvm-tools.sh` | 60 tests, 633 assertions, 0 failures, 0 errors — PASS tools JVM artefacts | **0** |
| `sh scripts/test-fast-pr.sh` | PASS fast PR spine | **0** |
| `python scripts/check_doc_slugs.py` | clean | **0** |
| `node implementation/scripts/_preflight-xray-package.test.cjs` | 15 passed | **0** |

No retry was needed — no par-compile/still-waiting contention aborts occurred.

Both new suites were confirmed present in the CLJS bundle (`grep` for the
compiled deftest names under
`.shadow-cljs/builds/node-test/dev/out/cljs-runtime/`) — the `.cljc` reader
conditionals for the exploding-`toString` key and the opaque host object
compile and run on both runtimes.

Bundle isolation untouched: nothing in `implementation/` gained a `tools/`
edge, and nothing here reaches the other way.

Closes rf2-oztox. **rf2-5dut1 stays open** — the Freehand ruling is
outstanding, and a note recording exactly what remains and the three routes has
been added to the bead.
