### PR TITLE
test(hicasso): real input and submit receipts on the ordinary shape (rf2-2rtt6.51)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/ordinary_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/ordinary_dom_cljs_test.cljs
@@ -9,9 +9,16 @@
      page lands in the ~50-element band the charter names.
   2. **The list is the model's.** Five keyed cards, bodies from the model,
      and the author-only delete control on exactly the reader's own two.
-  3. **The form works through the synchronous door** — the controlled
-     textarea echoes in the caller's turn, and submit creates a card and
-     clears the draft by explicit revision.
+  3. **The form works through the browser's own door.** A real,
+     cancelable `input` at the rendered `<textarea>` echoes in the
+     caller's turn; a real, cancelable `submit` at the rendered
+     `<form>` creates a card, clears the draft by explicit revision,
+     and **auto-prevents**. The store-write rows beside them witness the
+     fan-out from a commit and are named for that — they reach the
+     model through `rt/dispatch!`, so a missing `:on-input`, a
+     substituted value placeholder or a lost submit prevent leaves every
+     one of them green. That was PR #7372's audit finding, and §3b is
+     the repair.
   4. **Typing moves the form and nothing else.** The draft key is read by
      the form boundary alone, so a keystroke re-runs one body out of
      seven. A screen that re-rendered its list on every keystroke would
@@ -27,9 +34,11 @@
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.bench.hicasso.arm1.mount :as mount]
             [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.controlled :as controlled]
             [re-frame.bench.hicasso.lane :as lane]
             [re-frame.bench.hicasso.shapes.model :as m]
             [re-frame.bench.hicasso.shapes.ordinary :as shape]
+            [re-frame.core :as rf]
             [re-frame.test-support :as test-support]))
 
 (use-fixtures :each
@@ -70,6 +79,16 @@
 
 (defn- q [handle sel] (.querySelector (:container handle) sel))
 (defn- q* [handle sel] (array-seq (.querySelectorAll (:container handle) sel)))
+
+;; ---------------------------------------------------------------------------
+;; The model side of every agreement below — read from the frame, never
+;; from the renderer. A DOM reading alone cannot tell "the intent reached
+;; app-db" from "the field still shows what the keystroke wrote".
+;; ---------------------------------------------------------------------------
+
+(defn- draft [] (get-in (rf/app-db-value frame-id) [:drafts m/comment-draft-key] ""))
+(defn- comment-ids [] (:comment-order (rf/app-db-value frame-id)))
+(defn- body-of [id] (get-in (rf/app-db-value frame-id) [:comments id :body]))
 
 ;; ---------------------------------------------------------------------------
 ;; 1 — it is the shape the charter names
@@ -132,10 +151,19 @@
           (finally (mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------
-;; 3 — the form, through the synchronous door
+;; 3a — the form's fan-out, from a commit
 ;; ---------------------------------------------------------------------------
+;;
+;; These three reach the model through `rt/dispatch!` and commit with an
+;; explicit `settle!`. That is the right door for a FAN-OUT claim — *when
+;; this key moves, this is what the page shows* — and the wrong one for
+;; any claim about the handlers the page is written with, because it
+;; never runs one. So the first of them is no longer named for the
+;; caller's turn (PR #7372's audit): a `settle!` supplied by the test is
+;; the test supplying the very commit the name claimed to witness. §3b
+;; owns that claim now, through the door the browser uses.
 
-(deftest the-controlled-textarea-echoes-in-the-callers-turn
+(deftest a-draft-commit-fans-out-to-the-controlled-textarea
   (if-not (mount/browser?)
     (skip! ":node-test has no DOM")
     (do
@@ -143,8 +171,10 @@
       (let [handle (mount!)]
         (try
           (is (= "" (.-value (q handle "textarea"))))
-          ;; The intent's own path: the arm's synchronous door, exactly as
-          ;; the lowered `:on-input` closure takes it.
+          ;; The key's own path: the arm's synchronous door, which is what
+          ;; the lowered `:on-input` closure eventually calls — but NOT
+          ;; the closure, and not the event that reaches it. §3b is where
+          ;; that half is witnessed.
           (rt/dispatch! frame-id [:conduit/edit-draft m/comment-draft-key "nice piece"])
           (mount/settle!)
           (is (= "nice piece" (.-value (q handle "textarea")))
@@ -191,6 +221,226 @@
           (mount/settle!)
           (is (false? (.-disabled (q handle "textarea"))))
           (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 3b — the same form, through the door the browser uses
+;; ---------------------------------------------------------------------------
+;;
+;; PR #7372's audit, and the repair it asked for. §3a never dispatches a
+;; DOM event, so it never runs `:on-input`, never materialises
+;; `::h/value`, and never gives `:on-submit`'s auto-prevent anything to
+;; prevent. Delete any of the three from `shapes/ordinary` and every row
+;; above stays green. These two rows are the ones that go red, and they
+;; go red because a real, cancelable event was dispatched at a rendered
+;; node and the receipt — model, DOM, body counts, `defaultPrevented`,
+;; and what the page reported — was read off what came back.
+;;
+;; **Cancelable on purpose, and on both.** The browser's own `input` is
+;; not cancelable — `arm1/controlled_burst_dom_cljs_test` builds it that
+;; way because its claim is about what a keystroke *is*. The claim here
+;; is about what the arm *does*: `:on-submit` prevents and `:on-input`
+;; must not, and `defaultPrevented` on a non-cancelable event reads
+;; `false` however hard anything calls `preventDefault`. A reading that
+;; cannot move is not a reading, so both events are cancelable and the
+;; pair is asserted together — the same shape `large_template_dom`'s
+;; prevent pair takes, on the other half of the grammar (there the head
+;; opts IN, here the position's default).
+;;
+;; **No `settle!` and no `act` in either row**, which is the whole point:
+;; a `settle!` is an empty `flushSync`, so a row that calls one is the
+;; test supplying the very commit it then reads. Taking the two events
+;; the way the browser takes them turned the arm's commit timing into a
+;; MEASUREMENT rather than an assumption, and the two halves differ:
+;;
+;; - **A keystroke echoes inside `dispatchEvent`.** The controlled
+;;   converge (`front/controlled/converge!`) runs at the end of the change
+;;   handler and its step 1 is a `flushSync`, so the field and the model
+;;   agree on the line after the event returns. That is the arm's own
+;;   flush, not this file's.
+;; - **A submit's page update lands on React's next microtask.** The
+;;   model moves synchronously — `rt/dispatch!` is the arm's synchronous
+;;   door — but nothing flushes React inside the event, and React 19
+;;   schedules sync-lane work in a microtask (`ensureRootIsScheduled` →
+;;   `processRootScheduleInMicrotask`) rather than at the end of
+;;   `dispatchDiscreteEvent`. Measured here, and it is React's schedule
+;;   rather than a defect: the commit is still before paint. So the DOM
+;;   half of the submit row is read after a `queueMicrotask`, which lets
+;;   React's own task run and forces nothing.
+;;
+;; The asymmetry is worth reading twice, because it is the authoring
+;; answer to "why does a controlled field need anything at all": without
+;; the converge, a keystroke's echo would land on that same later
+;; microtask, one turn behind the character the user can already see.
+
+(defn- set-native-value!
+  "Write `v` through `HTMLTextAreaElement.prototype`'s OWN `value` setter,
+  bypassing React's per-instance change tracker — a plain `set!` updates
+  the tracker too, after which React discards the `input` event as a
+  no-op change and the handler under test never runs."
+  [node v]
+  (let [d (js/Object.getOwnPropertyDescriptor js/HTMLTextAreaElement.prototype "value")]
+    (.call (.-set d) node v)))
+
+(defn- type-into!
+  "Type `text` at the caret the way a browser does it: the field changes
+  first, the `input` event fires second. Answers the event, so the caller
+  can read `defaultPrevented` off it on the line after."
+  [node text]
+  (let [start (.-selectionStart node)
+        end   (.-selectionEnd node)
+        v     (.-value node)]
+    (set-native-value! node (str (subs v 0 start) text (subs v end)))
+    (let [c (+ start (count text))]
+      (.setSelectionRange node c c))
+    (let [ev (js/InputEvent. "input" #js {:bubbles    true
+                                          :cancelable true
+                                          :data       text
+                                          :inputType  "insertText"})]
+      (.dispatchEvent node ev)
+      ev)))
+
+(defn- submit!
+  "A real, cancelable `submit` at the form node — the event the browser's
+  own form-submission algorithm fires, and whose canceled flag is what
+  decides whether the page navigates. Answers the event.
+
+  Dispatched at the `<form>` rather than clicked at the `<button>` on
+  purpose: a dispatched click on a `type=\"submit\"` runs the button's
+  activation behaviour, so the moment the auto-prevent is the thing being
+  broken — which is the whole point of the row — the harness page
+  navigates and takes the run with it."
+  [node]
+  (let [ev (js/SubmitEvent. "submit" #js {:bubbles true :cancelable true})]
+    (.dispatchEvent node ev)
+    ev))
+
+(defn- error-watch!
+  "Start collecting what the page reports; answers the 0-arity that stops
+  collecting and returns the messages.
+
+  React does not let a throw from inside a discrete event escape
+  `dispatchEvent`: it hands it to `reportError`, which dispatches an
+  `error` event on `window`. A `try`/`catch` around the dispatch sees
+  NOTHING, so a row that took its green through one would be green over a
+  live exception, and only the runner's uncaught-pageerror gate would
+  know. The same is true of the commit React schedules on its own
+  microtask — which is why this is a stoppable watch rather than a
+  wrapper around a single call."
+  []
+  (let [!errs  (atom [])
+        on-err (fn [e] (swap! !errs conj (or (some-> (.-error e) (.-message))
+                                             (.-message e))))]
+    (.addEventListener js/window "error" on-err)
+    (fn [] (.removeEventListener js/window "error" on-err) @!errs)))
+
+(deftest a-real-keystroke-moves-the-model-and-the-field-in-the-callers-turn
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount!)]
+        (try
+          (let [node (q handle "textarea.form-control")]
+            (.focus node)
+            (.setSelectionRange node 0 0)
+            (is (= "" (draft)) "the model holds no draft before anything is typed")
+            (is (= "" (.-value node)) "and the field agrees with it")
+            (shape/reset-runs!)
+            (let [stop! (error-watch!)
+                  ev    (type-into! node "n")
+                  errs  (stop!)]
+              ;; Every reading below is on the line after `dispatchEvent`
+              ;; returned, in the caller's own turn.
+              (is (= "n" (draft))
+                  "the :on-input intent reached the model, and ::h/value
+                   materialised as the value the field carried — a
+                   substituted placeholder lands here")
+              (is (= "n" (controlled/last-rendered node))
+                  "and React COMMITTED it back into this element in the same
+                   turn. Read off React's own mirror of the committed value
+                   prop rather than off `.value`, which would read \"n\"
+                   whether or not anything rendered — the keystroke wrote it")
+              (is (= "n" (.-value node)) "the field shows it too")
+              (is (false? (.-defaultPrevented ev))
+                  "a cancelable input is NOT prevented: the arm prevents at
+                   :on-submit and where ::h/prevent is written, nowhere else")
+              (is (= [] errs)
+                  (str "and nothing threw inside the handler — React would have
+                        routed it to reportError and left this row green: "
+                       (pr-str errs)))
+              (is (= 1 (shape/runs-of :comment-form)) "one keystroke re-ran the form")
+              (is (= 0 (shape/runs-of :screen)) "and not the screen")
+              (is (= 0 (shape/runs-of :comment-card)) "and no card at all"))
+            ;; A SECOND keystroke, because one cannot tell a live
+            ;; placeholder from a constant: the value the intent carries has
+            ;; to be what the field holds NOW, not what it held when the
+            ;; closure was minted.
+            (let [ev (type-into! node "i")]
+              (is (= "ni" (draft)) "the placeholder read the field again")
+              (is (= "ni" (controlled/last-rendered node)))
+              (is (= "ni" (.-value node)))
+              (is (false? (.-defaultPrevented ev)))))
+          (finally (mount/release! handle)))))))
+
+(deftest submitting-the-rendered-form-posts-and-auto-prevents
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (async done
+      (fresh!)
+      (let [handle (mount!)
+            node   (q handle "textarea.form-control")
+            form   (q handle "form.comment-form")
+            finish (fn [] (mount/release! handle) (done))]
+        (.focus node)
+        (.setSelectionRange node 0 0)
+        ;; Composed on purpose: the draft this posts arrived through the
+        ;; field's own handler, so a broken `:on-input` reds this row too.
+        (type-into! node "nice piece")
+        (is (= "nice piece" (draft)) "typed through the field, not written past it")
+        (shape/reset-runs!)
+        (let [stop! (error-watch!)
+              ev    (submit! form)]
+          (is (true? (.-defaultPrevented ev))
+              ":on-submit takes the census-weighted default and AUTO-PREVENTS
+               — read on the line after dispatchEvent, so the form never
+               navigates and the author wrote no preventDefault. The one
+               reading in this file that no store write can produce")
+          (testing "and the model moved in the same turn, through the arm's
+                   synchronous door"
+            (is (= (inc comment-count) (count (comment-ids))))
+            (is (= "nice piece" (body-of comment-count)))
+            (is (= "" (draft)) "the draft cleared by explicit revision"))
+          ;; React's own commit. `queueMicrotask` is queued BEHIND the one
+          ;; `ensureRootIsScheduled` already posted, so this lets React's
+          ;; task run and forces nothing — no `settle!`, no `act`.
+          (js/queueMicrotask
+            (fn []
+              (try
+                (let [errs (stop!)]
+                  (is (= [] errs)
+                      (str "nothing threw, in the event OR in the commit it
+                            scheduled — React routes both to reportError, and
+                            a row without this listener is green over either: "
+                           (pr-str errs))))
+                (testing "the page committed on React's own microtask"
+                  (is (= (inc comment-count) (count (q* handle ".comments-list > .card"))))
+                  (is (= "nice piece"
+                         (.-textContent (q handle (str "[data-testid=\"comment-card-"
+                                                       comment-count "\"] "
+                                                       "[data-testid=\"comment-body\"]")))))
+                  (is (= "" (.-value node)) "and the field cleared with it")
+                  (is (some? (q handle (str "[data-testid=\"delete-comment-"
+                                            comment-count "\"]")))
+                      "the comment you just posted is your own, so it gets
+                       the control"))
+                (testing "and the commit woke the boundaries that read what moved"
+                  (is (= 1 (shape/runs-of :screen)) "the list boundary reads the order")
+                  (is (= 1 (shape/runs-of :comment-form)) "the form reads the draft")
+                  (is (= 1 (shape/runs-of :comment-card))
+                      "and exactly ONE card body ran — the new row's. The five
+                       already on screen bailed out on equal props, so a post
+                       is a narrow write and not a list rebuild"))
+                (finally (finish))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 4 — a keystroke moves one body out of seven


### PR DESCRIPTION
PR #7372's merged-PR audit found `shapes/ordinary_dom_cljs_test`'s three named form rows are not end-to-end for the authoring they claim. They reach the model through `rt/dispatch!` and then call `mount/settle!`, so they never run `:on-input`, never materialise `::h/value`, and never give `:on-submit`'s auto-prevent anything to prevent. The file contained no `dispatchEvent` and no `defaultPrevented` anywhere.

§3b adds the two rows that cannot be green over those faults, ported from the convention already in the directory — `large_template_dom_cljs_test`'s prevent pair, `arm1/controlled_grid_dom_cljs_test`'s native-value setter and its `window` error listener. Nothing else in the roster changed.

## What the two rows are

**`a-real-keystroke-moves-the-model-and-the-field-in-the-callers-turn`** — a real, cancelable `InputEvent` at the rendered `<textarea>`, the field mutated first through `HTMLTextAreaElement.prototype`'s own `value` setter so React's change tracker does not discard it. Read on the line after `dispatchEvent` returns: the model holds what was typed (a substituted `::h/value` lands here), React's own mirror of the committed value prop (`front/controlled/last-rendered`) holds it too, `defaultPrevented` is `false`, nothing reached `reportError`, and the body counts are 1 form / 0 screen / 0 card. A second keystroke follows, because one cannot tell a live placeholder from a constant.

The DOM half is asserted off `defaultValue` rather than `.value` on purpose: `.value` reads `"n"` whether or not anything rendered — the keystroke wrote it. `defaultValue` only moves when React commits.

**`submitting-the-rendered-form-posts-and-auto-prevents`** — a real, cancelable `SubmitEvent` at the rendered `<form>`, after a draft typed through the field. `defaultPrevented` is `true` on the line after `dispatchEvent`: the census-weighted `:on-submit` default, and the one reading in this file that no store write can produce. Model, DOM, body counts and the error watch follow.

Dispatched at the `<form>` rather than clicked at the `<button>` deliberately: a dispatched click on a `type="submit"` runs the button's activation behaviour, so the moment the auto-prevent is the thing being broken the harness page navigates and takes the run with it. Not hypothetical — see mutation run 2.

**Both events are cancelable**, where `arm1/controlled_burst_dom_cljs_test`'s deliberately is not. That file's claim is about what a keystroke *is*; the claim here is about what the arm *does*, and `defaultPrevented` on a non-cancelable event reads `false` however hard anything calls `preventDefault`. A reading that cannot move is not a reading, so the pair is asserted together on one page — the shape `large_template_dom`'s prevent pair takes on the other half of the grammar.

## What the rows measured

Taking both events the way the browser takes them — **no `settle!` and no `act` in either row** — turned the arm's commit timing into a measurement rather than an assumption, and the two halves differ:

- **A keystroke echoes inside `dispatchEvent`.** `front/controlled/converge!` runs at the end of the change handler and its step 1 is a `flushSync`.
- **A submit's page update lands on React's next microtask.** The model moves synchronously (the arm's door is synchronous), but nothing flushes React inside the event, and React 19 schedules sync-lane work in a microtask rather than at the end of `dispatchDiscreteEvent`. The DOM half of the submit row is therefore read after a `queueMicrotask`, which lets React's own task run and forces nothing. Still before paint; React's schedule, not a defect — recorded in the section note.

The first draft of the submit row asserted the DOM synchronously and went red on exactly this. Written up rather than papered over with a `settle!`.

## Mutation proof

Three faults, all planted in SUBJECTS, never in the test; all reverted byte-identically (`git status` clean at the commit afterwards).

| # | fault | file | result |
|---|---|---|---|
| 1 | `:on-input` binding deleted | `shapes/ordinary.cljs` | full browser suite **exit 1**, 15 failures / 1 error, **all 16 in the two new rows and nowhere else** across 1028 tests |
| 2 | `::h/value` replaced by the constant `"typed"` | `shapes/ordinary.cljs` | **exit 1**; 6 named failures in the keystroke row, 3 in the submit row — `(not (= "nice piece" "typed"))` at the model, at the posted body, and in the DOM |
| 3 | `prevent-by-default?` forced false | `front/intent.cljs` | **exit 1**; exactly one named failure, `expected: (true? (.-defaultPrevented ev))` / `actual: (not (true? false))` |

**Fault 1 is the audit's finding restated as a number.** With `:on-input` deleted, `a-draft-commit-fans-out-to-the-controlled-textarea`, `submitting-creates-a-card-and-clears-the-draft`, `an-in-flight-post-disables-the-form` and `typing-re-runs-the-form-boundary-and-nothing-else` all stayed **green**. Only the two new rows went red.

Faults 2+3 were run together. On the **full** suite fault 3 aborted the run before reaching this namespace — `page.evaluate: Execution context was destroyed, most likely because of a navigation`, from an unrelated form elsewhere in the suite. A second, unplanned proof that the auto-prevent is load-bearing, but it yields no named failure, so the pair was re-run with `:browser-test`'s `:ns-regexp` temporarily narrowed to this one namespace (10 tests / 68 assertions, 10 failures, 0 errors). `implementation/shadow-cljs.edn` was reverted byte-identically and is **not** in this diff.

## What was left alone

Every pre-existing row keeps its body byte-for-byte. The one edit outside §3b is a rename: `the-controlled-textarea-echoes-in-the-callers-turn` → `a-draft-commit-fans-out-to-the-controlled-textarea`, because an explicit `settle!` is the test supplying the very commit the old name claimed to witness. §3b owns that claim now. The ns docstring's claim 3 and the §3a header say which door each group takes and why. The pure fan-out rows keep their direct store writes.

## Fences

Surface B only. No hook added anywhere — the shape's ≤2-hook shell is untouched and the subject is unmodified, so `hook_budget_dom_cljs_test` is unaffected. Bodies unchanged, so HD-020(d) `.cljc` compatibility is unaffected. **No bench driver run, no clock read, no timing row published.** One file changed: `implementation/freehand/test/re_frame/bench/hicasso/shapes/ordinary_dom_cljs_test.cljs`.

## Quality gates

Run from the worktree, in the foreground, to completion, never piped; output redirected to a worktree-local log and the exit code echoed.

| gate | exit | result |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | green |
| `npm run test:browser` | **0** | Ran 1028 tests containing 6383 assertions. 0 failures, 0 errors. |

No compile contention or retry was needed on either.
