### PR TITLE
fix(scripts): beads checkpoint must not treat equal row counts as equality (rf2-rjqtj)

### DIFF
--- a/scripts/beads-checkpoint.ps1
+++ b/scripts/beads-checkpoint.ps1
@@ -23,6 +23,24 @@
 # THE FIX: EXPORT FIRST. A checkpoint asks the Dolt database what the tracker
 # says (`bd export`) instead of trusting whatever sits in the working tree.
 #
+# THE SECOND FAULT (rf2-rjqtj): EXPORT FIRST IS NOT ENOUGH ON ITS OWN.
+#
+#   Exporting first is right when the database is strictly ahead of Git. It is
+#   wrong when Git is ahead in places, and Git can be: a second writer exists.
+#   The merged-PR audit commits issue rows straight to Git, and a `git pull`
+#   brings other checkouts' rows in the same way. When both sides move they can
+#   diverge at the SAME ROW COUNT, one row for one row. The row-count floor
+#   below then sees 1938 == 1938 and waves the export through, and the commit
+#   deletes the Git-only rows and reverts the newer Git statuses.
+#
+#   OBSERVED, not hypothetical: commit 667c744dc875 dropped rf2-3jw04,
+#   rf2-jv36i and rf2-lhdp0 and reverted rf2-2rtt6.52/.63 exactly this way.
+#   This script is the one that produced that commit.
+#
+#   So the export is now compared to HEAD by issue id, `updated_at` and
+#   `status` before it is allowed to overwrite anything. See Get-GitOnlyFacts.
+#   EQUAL COUNTS ARE NOT EQUALITY.
+#
 # The commit carries the rows that changed and nothing else: `bd export` does
 # not fix the order of the memory rows, so the file is written in minimal-diff
 # order first (rf2-51uz1.1, Write-MinimalDiffOrder below).
@@ -31,14 +49,19 @@
 #   powershell -ExecutionPolicy Bypass -File scripts/beads-checkpoint.ps1
 #   powershell -ExecutionPolicy Bypass -File scripts/beads-checkpoint.ps1 -Message "chore(beads): checkpoint (6931 merged)"
 #   powershell -ExecutionPolicy Bypass -File scripts/beads-checkpoint.ps1 -PrePull
+#   powershell -ExecutionPolicy Bypass -File scripts/beads-checkpoint.ps1 -SelfTest
 
 [CmdletBinding()]
 param(
     [switch]$PrePull,
+    [switch]$SelfTest,
     [string]$Message = 'chore(beads): checkpoint'
 )
 
 $ErrorActionPreference = 'Stop'
+# An unset variable or a missing property is a bug in a script whose whole job
+# is to not lose data quietly. Every arm below is exercised by -SelfTest.
+Set-StrictMode -Version Latest
 
 $tracker = '.beads/issues.jsonl'
 
@@ -205,6 +228,131 @@ function Test-SameContent {
     return $true
 }
 
+# First value of a top-level JSON string key, or '' when the key is absent.
+#
+# FIRST match, deliberately: `"id":"` occurs up to eight times in one issue row
+# because every comment carries its own id, and only the leading one is the
+# bead's. `bd export` writes `_type` and `id` at the front of the row.
+function Get-JsonValue {
+    param([string]$Line, [string]$Key)
+    $m = [regex]::Match($Line, ('"' + $Key + '":"([^"]*)"'))
+    if ($m.Success) { return $m.Groups[1].Value }
+    return ''
+}
+
+# Get-GitOnlyFacts - every tracker fact HEAD carries that the fresh export does
+# not. Identical contract to git_only_facts in the .sh sibling, down to the
+# wording of the lines it returns.
+#
+# THE FAULT THIS EXISTS TO STOP (rf2-rjqtj): see the second fault at the top of
+# this file. Row counts are a floor, not an equality test.
+#
+# Three classes, all of them "Git knows something Dolt does not":
+#
+#   GONE    an issue id at HEAD that the export has no row for at all. The
+#           commit would DELETE that bead.
+#   REVERT  an id in both, where HEAD's `updated_at` is strictly NEWER than the
+#           export's. The commit would revert it to an older status.
+#   AMBIG   an id in both carrying the SAME `updated_at` but a DIFFERENT
+#           `status`. Neither side can be called newer, so neither may be
+#           chosen automatically.
+#
+# The opposite direction - ids only the export has, rows the export has newer -
+# is the normal forward motion of a checkpoint and is deliberately not reported.
+#
+# WHY `status` AND `updated_at`, NOT JUST THE ID SET: an id-set comparison
+# proves presence, nothing more. Confirmed in the field: an interrupted Dolt
+# generational GC reverted a bead's close and five note appends while every id
+# stayed intact. Presence is not state.
+#
+# THE ID IS THE STABLE BEAD ID (rf2-...), NEVER A ROW UUID. `bd` regenerates row
+# and comment UUIDs on re-import, so a UUID-keyed diff reports phantom losses -
+# it flagged three beads that existed and were closed. A row whose id cannot be
+# read is REPORTED rather than skipped: a guard that silently stops guarding is
+# the bug being fixed here.
+#
+# Rows are compared only when both sides carry a non-empty `updated_at`. Without
+# timestamps there is no basis on which to call either side newer, and inventing
+# one would turn every ordinary close into a refusal.
+#
+# RemedyRows are the GONE and REVERT rows exactly as HEAD holds them, so
+# `bd import` of that file is the whole recovery - the bead's own verified,
+# bounded mechanism. AMBIG rows are deliberately left out; an import cannot
+# adjudicate them.
+function Get-GitOnlyFacts {
+    param([string]$Export, [string]$HeadCopy)
+
+    $cap = 20
+    $report = New-Object 'System.Collections.Generic.List[string]'
+    $remedy = New-Object 'System.Collections.Generic.List[string]'
+
+    $xst = New-Object 'System.Collections.Generic.Dictionary[string,string]' ([System.StringComparer]::Ordinal)
+    $xup = New-Object 'System.Collections.Generic.Dictionary[string,string]' ([System.StringComparer]::Ordinal)
+    $xbad = 0
+    $hbad = 0
+
+    foreach ($raw in [System.IO.File]::ReadLines($Export)) {
+        $line = $raw -replace "`r$", ''
+        if ($line.IndexOf('"_type":"issue"', [System.StringComparison]::Ordinal) -lt 0) { continue }
+        $id = Get-JsonValue -Line $line -Key 'id'
+        if ($id -eq '') { $xbad++; continue }
+        $xst[$id] = Get-JsonValue -Line $line -Key 'status'
+        $xup[$id] = Get-JsonValue -Line $line -Key 'updated_at'
+    }
+
+    $ngone = 0; $nrev = 0; $namb = 0
+    foreach ($raw in [System.IO.File]::ReadLines($HeadCopy)) {
+        $line = $raw -replace "`r$", ''
+        if ($line.IndexOf('"_type":"issue"', [System.StringComparison]::Ordinal) -lt 0) { continue }
+        $id = Get-JsonValue -Line $line -Key 'id'
+        if ($id -eq '') { $hbad++; continue }
+        $st = Get-JsonValue -Line $line -Key 'status'
+        $up = Get-JsonValue -Line $line -Key 'updated_at'
+
+        if (-not $xup.ContainsKey($id)) {
+            $ngone++
+            if ($ngone -le $cap) {
+                $report.Add("  GONE    $id  would be DELETED (HEAD: status=$st updated_at=$up)")
+            }
+            $remedy.Add($line)
+            continue
+        }
+        # Ordinal, to match the .sh sibling's byte comparison rather than the
+        # current culture's collation. ISO-8601 Z timestamps are fixed width, so
+        # lexical order is chronological order.
+        if ($up -ne '' -and $xup[$id] -ne '' -and
+            [string]::CompareOrdinal($up, $xup[$id]) -gt 0) {
+            $nrev++
+            if ($nrev -le $cap) {
+                $report.Add("  REVERT  $id  HEAD status=$st updated_at=$up -> export status=$($xst[$id]) updated_at=$($xup[$id])")
+            }
+            $remedy.Add($line)
+            continue
+        }
+        if ($up -ne '' -and [string]::CompareOrdinal($up, $xup[$id]) -eq 0 -and $st -ne $xst[$id]) {
+            $namb++
+            if ($namb -le $cap) {
+                $report.Add("  AMBIG   $id  same updated_at=$up but HEAD status=$st, export status=$($xst[$id])")
+            }
+        }
+    }
+
+    if ($ngone -gt $cap) { $report.Add("  ... and $($ngone - $cap) more that would be DELETED") }
+    if ($nrev  -gt $cap) { $report.Add("  ... and $($nrev  - $cap) more that would be REVERTED") }
+    if ($namb  -gt $cap) { $report.Add("  ... and $($namb  - $cap) more ambiguous rows") }
+    if ($xbad -gt 0) {
+        $report.Add("  UNREADABLE  $xbad issue rows in the fresh export carry no readable id")
+    }
+    if ($hbad -gt 0) {
+        $report.Add("  UNREADABLE  $hbad issue rows at HEAD carry no readable id")
+    }
+
+    return [pscustomobject]@{
+        Report     = $report.ToArray()
+        RemedyRows = $remedy.ToArray()
+    }
+}
+
 # ---------------------------------------------------------------------------
 # The tracker database is the MAYOR checkout's to commit (rf2-ia8o7). The
 # primary worktree is the first entry of `git worktree list --porcelain`; the
@@ -224,7 +372,7 @@ function Get-NormalizedPath {
     return ($Path -replace '\\', '/').TrimEnd('/').ToLowerInvariant()
 }
 
-if (-not $PrePull) {
+if (-not $PrePull -and -not $SelfTest) {
     $gitRoot = (& git rev-parse --show-toplevel 2>$null)
     if ($LASTEXITCODE -ne 0 -or -not $gitRoot) {
         Die 'not inside a git checkout.'
@@ -239,6 +387,243 @@ if (-not $PrePull) {
         (Get-NormalizedPath $gitRoot.Trim()) -ne (Get-NormalizedPath $primary.Trim())) {
         Die 'this is a linked (worker) worktree; the tracker database is the mayor checkout''s to commit.'
     }
+}
+
+# ---------------------------------------------------------------------------
+# -SelfTest - prove the divergence guard rather than asserting it.
+#
+# The .sh sibling is covered by layer 8 of scripts/git-hooks/test-pre-commit.sh,
+# which is POSIX sh and cannot run this file. Windows is the operator's platform
+# and the platform that produced commit 667c744dc875, so the Windows half needs
+# its own proof. Everything below runs against a throwaway git repo and a stub
+# `bd` in a temp directory: the real tracker database is never opened, let alone
+# written.
+#
+# The cases are the bead's acceptance (rf2-rjqtj), plus the false-positive case
+# that matters more than any of them - ordinary forward motion must still commit,
+# because a guard that fires on every checkpoint is a guard that gets bypassed.
+# ---------------------------------------------------------------------------
+if ($SelfTest) {
+    $script:failures = 0
+    $box = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "rf2-bdchk-selftest-$PID")
+    if (Test-Path -LiteralPath $box) { Remove-Item -LiteralPath $box -Recurse -Force }
+    $bin  = Join-Path $box 'bin'
+    $repo = Join-Path $box 'repo'
+    New-Item -ItemType Directory -Force -Path $bin | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $repo 'scripts') | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $repo '.beads') | Out-Null
+    $dbPath = Join-Path $box 'db.jsonl'
+
+    function Write-Rows {
+        param([string]$Path, [string[]]$Rows)
+        $sw = New-Object System.IO.StreamWriter($Path, $false,
+                                                (New-Object System.Text.UTF8Encoding $false))
+        try {
+            $sw.NewLine = "`n"
+            foreach ($r in $Rows) { $sw.WriteLine($r) }
+        } finally { $sw.Dispose() }
+    }
+
+    # Stub `bd`. It REFUSES a bare export, modelling bd v1.1.2 (rf2-fifk0): the
+    # flagless form drops every `bd remember` row, so a checkpoint that ever
+    # loses --include-memories reds every case below instead of quietly
+    # committing a memory-less tracker.
+    $stub = @(
+        '@echo off',
+        'echo.%*| findstr /C:"--include-memories" >nul',
+        'if errorlevel 1 (',
+        '  echo stub bd: a bare export would drop every memory row ^(rf2-fifk0^) 1>&2',
+        '  exit /b 1',
+        ')',
+        'type "%~dp0..\db.jsonl"'
+    )
+    Write-Rows -Path (Join-Path $bin 'bd.cmd') -Rows $stub
+
+    Copy-Item -LiteralPath $PSCommandPath -Destination (Join-Path $repo 'scripts/beads-checkpoint.ps1') -Force
+    & git -C $repo init -q -b main 2>&1 | Out-Null
+    & git -C $repo config user.email 'bdchk-selftest@example.invalid' | Out-Null
+    & git -C $repo config user.name  'bdchk-selftest' | Out-Null
+    & git -C $repo config commit.gpgsign false | Out-Null
+
+    $env:PATH = "$bin;$env:PATH"
+    # Re-invoke THIS host, so the proof is about the interpreter the operator
+    # actually runs (Windows PowerShell 5.x via `powershell -File`, or pwsh).
+    $hostExe = (Get-Process -Id $PID).Path
+    $childOut = Join-Path $box 'out.txt'
+    $childErr = Join-Path $box 'err.txt'
+
+    function Invoke-Child {
+        param([string[]]$ChildArgs)
+        $all = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File',
+                 (Join-Path $repo 'scripts/beads-checkpoint.ps1')) + $ChildArgs
+        $p = Start-Process -FilePath $hostExe -ArgumentList $all -WorkingDirectory $repo `
+                           -NoNewWindow -Wait -PassThru `
+                           -RedirectStandardOutput $childOut -RedirectStandardError $childErr
+        return $p.ExitCode
+    }
+
+    function Get-ChildErr { return (Get-Content -LiteralPath $childErr -Raw -ErrorAction SilentlyContinue) }
+    function Get-ChildOut { return (Get-Content -LiteralPath $childOut -Raw -ErrorAction SilentlyContinue) }
+    function Get-HeadTracker { return (& git -C $repo show 'HEAD:.beads/issues.jsonl') -join "`n" }
+    function Get-HeadSha { return (& git -C $repo rev-parse HEAD).Trim() }
+
+    function Assert-True {
+        param([bool]$Cond, [string]$What, [string]$Detail = '')
+        if ($Cond) { Write-Output "  PASS  $What" }
+        else {
+            Write-Output "  FAIL  $What"
+            if ($Detail) { Write-Output "        $Detail" }
+            $script:failures++
+        }
+    }
+
+    Write-Output 'beads-checkpoint -SelfTest: divergence guard (rf2-rjqtj)'
+
+    # THE FIXTURE, and it is the bead's own: HEAD and Dolt hold the SAME NUMBER
+    # of rows but different facts, one for one.
+    #
+    #   rf2-a   unchanged on both sides
+    #   rf2-b   NEWER ON GIT   - closed at 03:00; Dolt still has it open at 12:00
+    #                            the previous day
+    #   rf2-c   NEWER ON DOLT  - closed at 02:00; Git still has it open
+    #   rf2-g1  GIT ONLY       - Dolt has never heard of it
+    #   rf2-d1  DOLT ONLY      - Git has never heard of it
+    #
+    # Four issue rows plus two memories on each side. The row-count floor sees
+    # 6 == 6 and is satisfied; that is precisely the hole.
+    $headRowsFixture = @(
+        '{"_type":"issue","id":"rf2-a","status":"open","updated_at":"2026-08-01T00:00:00Z"}',
+        '{"_type":"issue","id":"rf2-b","status":"closed","updated_at":"2026-08-02T03:00:00Z"}',
+        '{"_type":"issue","id":"rf2-c","status":"open","updated_at":"2026-08-01T00:00:00Z"}',
+        '{"_type":"issue","id":"rf2-g1","status":"open","updated_at":"2026-08-02T01:00:00Z"}',
+        '{"_type":"memory","key":"m1","value":"one"}',
+        '{"_type":"memory","key":"m2","value":"two"}'
+    )
+    $doltRowsFixture = @(
+        '{"_type":"issue","id":"rf2-a","status":"open","updated_at":"2026-08-01T00:00:00Z"}',
+        '{"_type":"issue","id":"rf2-b","status":"open","updated_at":"2026-08-01T12:00:00Z"}',
+        '{"_type":"issue","id":"rf2-c","status":"closed","updated_at":"2026-08-02T02:00:00Z"}',
+        '{"_type":"issue","id":"rf2-d1","status":"open","updated_at":"2026-08-02T01:30:00Z"}',
+        '{"_type":"memory","key":"m1","value":"one"}',
+        '{"_type":"memory","key":"m2","value":"two"}'
+    )
+
+    Write-Rows -Path (Join-Path $repo '.beads/issues.jsonl') -Rows $headRowsFixture
+    & git -C $repo add -- 'scripts/beads-checkpoint.ps1' '.beads/issues.jsonl' | Out-Null
+    & git -C $repo commit -q -m 'seed: tracker at HEAD' | Out-Null
+    Write-Rows -Path $dbPath -Rows $doltRowsFixture
+
+    # T1 - THE ACCEPTANCE. Equal counts, disjoint one-for-one substitution, one
+    # newer state on each side. Neither side's facts may be lost, so the only
+    # safe answer is to refuse and name them.
+    $before = Get-HeadSha
+    $code = Invoke-Child @()
+    $err  = Get-ChildErr
+    Assert-True ($code -ne 0) 'T1 an equal-count divergence is REFUSED' "exit $code"
+    Assert-True ($err -match 'EQUAL COUNTS ARE NOT EQUALITY') 'T1 and it says why the floor was not enough'
+    Assert-True ($err -match 'GONE\s+rf2-g1') 'T1 names the Git-only bead that would be DELETED'
+    Assert-True ($err -match 'REVERT\s+rf2-b') 'T1 names the Git-newer bead that would be REVERTED'
+    Assert-True ($err -match '2026-08-02T03:00:00Z' -and $err -match 'status=closed') `
+                'T1 reports the FIELDS, not just the ids'
+    Assert-True (-not ($err -match 'rf2-c')) 'T1 does not cry wolf over the Dolt-newer row'
+    Assert-True (-not ($err -match 'rf2-d1')) 'T1 does not cry wolf over the Dolt-only row'
+    Assert-True ((Get-HeadSha) -eq $before) 'T1 commits nothing'
+    $work = (Get-Content -LiteralPath (Join-Path $repo '.beads/issues.jsonl') -Raw)
+    Assert-True ($work -match 'rf2-g1' -and -not ($work -match 'rf2-d1')) `
+                'T1 leaves the working tracker UNTOUCHED'
+
+    # T1b - the refusal is actionable: the remedy file holds the Git-only and
+    # Git-newer rows and nothing else, so one `bd import` is the whole recovery.
+    $remedyPath = ''
+    if ($err -match 'bd import (\S+)') { $remedyPath = $Matches[1] }
+    Assert-True ($remedyPath -ne '' -and (Test-Path -LiteralPath $remedyPath)) `
+                'T1b a remedy file is written and named in the message'
+    if ($remedyPath -and (Test-Path -LiteralPath $remedyPath)) {
+        $rem = @(Get-Content -LiteralPath $remedyPath)
+        Assert-True ($rem.Count -eq 2 -and ($rem -join "`n") -match 'rf2-g1' -and
+                     ($rem -join "`n") -match 'rf2-b') `
+                    'T1b it holds exactly the two Git-only/Git-newer rows' "got $($rem.Count) rows"
+        Remove-Item -LiteralPath $remedyPath -Force -ErrorAction SilentlyContinue
+    }
+
+    # T2 - AND THE RECOVERY COMPLETES. The operator runs that import; the
+    # database is now the UNION. The next checkpoint must commit, and the
+    # committed tracker must carry ALL FOUR facts - neither side lost anything.
+    $union = @(
+        '{"_type":"issue","id":"rf2-a","status":"open","updated_at":"2026-08-01T00:00:00Z"}',
+        '{"_type":"issue","id":"rf2-b","status":"closed","updated_at":"2026-08-02T03:00:00Z"}',
+        '{"_type":"issue","id":"rf2-c","status":"closed","updated_at":"2026-08-02T02:00:00Z"}',
+        '{"_type":"issue","id":"rf2-d1","status":"open","updated_at":"2026-08-02T01:30:00Z"}',
+        '{"_type":"issue","id":"rf2-g1","status":"open","updated_at":"2026-08-02T01:00:00Z"}',
+        '{"_type":"memory","key":"m1","value":"one"}',
+        '{"_type":"memory","key":"m2","value":"two"}'
+    )
+    Write-Rows -Path $dbPath -Rows $union
+    $before = Get-HeadSha
+    $code = Invoke-Child @()
+    Assert-True ($code -eq 0) 'T2 the post-import checkpoint succeeds' "exit $code : $(Get-ChildErr)"
+    Assert-True ((Get-HeadSha) -ne $before) 'T2 and it commits'
+    $committed = Get-HeadTracker
+    Assert-True ($committed -match 'rf2-g1') 'T2 the Git-only bead SURVIVED'
+    Assert-True ($committed -match '"id":"rf2-b","status":"closed"') 'T2 the Git-side close SURVIVED'
+    Assert-True ($committed -match 'rf2-d1') 'T2 the Dolt-only bead SURVIVED'
+    Assert-True ($committed -match '"id":"rf2-c","status":"closed"') 'T2 the Dolt-side close SURVIVED'
+    Assert-True ($committed -match '"key":"m1"' -and $committed -match '"key":"m2"') `
+                'T2 and the memory rows rode along (--include-memories intact)'
+
+    # T3 - THE FALSE-POSITIVE CASE, which matters more than the rest. Ordinary
+    # forward motion - Dolt closes a bead and gains a new one, Git is simply
+    # behind - is what a checkpoint is FOR. It must commit without a murmur.
+    $forward = $union + @('{"_type":"issue","id":"rf2-e","status":"open","updated_at":"2026-08-03T00:00:00Z"}')
+    $forward = $forward -replace '"id":"rf2-a","status":"open","updated_at":"2026-08-01T00:00:00Z"',
+                                 '"id":"rf2-a","status":"closed","updated_at":"2026-08-03T01:00:00Z"'
+    Write-Rows -Path $dbPath -Rows $forward
+    $before = Get-HeadSha
+    $code = Invoke-Child @()
+    Assert-True ($code -eq 0) 'T3 a strictly-ahead database still checkpoints' "exit $code : $(Get-ChildErr)"
+    Assert-True ((Get-HeadSha) -ne $before) 'T3 and it commits the forward motion'
+    $committed = Get-HeadTracker
+    Assert-True ($committed -match '"id":"rf2-a","status":"closed"' -and $committed -match 'rf2-e') `
+                'T3 the new close and the new bead both landed'
+
+    # T4 - THE AMBIGUOUS ROW. Same `updated_at`, different `status`: neither
+    # side is newer, so neither may be chosen automatically. Presence is not
+    # state - an interrupted Dolt GC reverted a close in the field while every
+    # id stayed intact, which an id-set comparison would have called clean.
+    $ambig = $forward -replace '"id":"rf2-e","status":"open"', '"id":"rf2-e","status":"closed"'
+    Write-Rows -Path $dbPath -Rows $ambig
+    $before = Get-HeadSha
+    $code = Invoke-Child @()
+    $err = Get-ChildErr
+    Assert-True ($code -ne 0) 'T4 a same-timestamp status conflict is REFUSED' "exit $code"
+    Assert-True ($err -match 'AMBIG\s+rf2-e') 'T4 and the row is named as ambiguous'
+    Assert-True ((Get-HeadSha) -eq $before) 'T4 commits nothing'
+    Assert-True (-not ($err -match 'bd import')) `
+                'T4 offers no import: an import cannot adjudicate a tie'
+
+    # T5 - the read-only arm still answers, under the same StrictMode. The
+    # working tracker matches HEAD here, so the answer is a silent yes.
+    & git -C $repo checkout -q HEAD -- .beads/issues.jsonl
+    $code = Invoke-Child @('-PrePull')
+    Assert-True ($code -eq 0) 'T5 -PrePull is silent on a checkpointed tracker' "exit $code : $(Get-ChildErr)"
+
+    # T6 - and it warns when the working export IS ahead of HEAD (rf2-51uz1),
+    # which is the other half of this file's job.
+    Add-Content -LiteralPath (Join-Path $repo '.beads/issues.jsonl') `
+                -Value '{"_type":"issue","id":"rf2-z","status":"open","updated_at":"2026-08-04T00:00:00Z"}'
+    $code = Invoke-Child @('-PrePull')
+    Assert-True ($code -ne 0) 'T6 -PrePull warns when clearing .beads would discard state'
+    Assert-True ((Get-ChildErr) -match 'AHEAD of HEAD') 'T6 and says so in those words'
+
+    Remove-Item -LiteralPath $box -Recurse -Force -ErrorAction SilentlyContinue
+    if ($script:failures -gt 0) {
+        Write-Output ''
+        Write-Output "beads-checkpoint -SelfTest: $($script:failures) FAILED"
+        exit 1
+    }
+    Write-Output ''
+    Write-Output 'beads-checkpoint -SelfTest: all cases passed'
+    exit 0
 }
 
 $tmpExport = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(),
@@ -314,6 +699,59 @@ try {
         Die ("export has $exportRows rows, HEAD has $headRows - more than a tenth of the " +
              "tracker would disappear. Refusing to checkpoint; $tracker is untouched. " +
              'Inspect with `bd status`, then commit by hand if the shrink is genuine.')
+    }
+
+    # DIVERGENCE GUARD (rf2-rjqtj). The floor above answers "is the export big
+    # enough?". It cannot answer "does the export still contain what HEAD
+    # contains?" - and at equal counts it has already said yes to an export
+    # that did not. Nothing has been written yet, so a refusal here leaves the
+    # tracker exactly as it was found.
+    $facts = Get-GitOnlyFacts -Export $tmpExport -HeadCopy $tmpHead
+    if ($facts.Report.Count -gt 0) {
+        $lines = New-Object 'System.Collections.Generic.List[string]'
+        $lines.Add('beads-checkpoint: HEAD carries tracker facts the fresh export does NOT.')
+        if ($exportRows -eq $headRows) {
+            $lines.Add("  export $exportRows rows, HEAD $headRows rows. EQUAL COUNTS ARE NOT EQUALITY:")
+            $lines.Add('  commit 667c744dc875 passed this floor at 1938 == 1938 and still deleted three')
+            $lines.Add('  issues and reverted two closes, because Git and Dolt had diverged one for one.')
+        } else {
+            $lines.Add("  export $exportRows rows, HEAD $headRows rows.")
+        }
+        $lines.Add('')
+        foreach ($r in $facts.Report) { $lines.Add($r) }
+        $lines.Add('')
+        $lines.Add('  Committing this export would lose exactly those facts, so it was NOT committed.')
+        $lines.Add("  $tracker is UNTOUCHED.")
+        $lines.Add('')
+        if ($facts.RemedyRows.Count -gt 0) {
+            $remedyPath = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(),
+                                                    "rf2-beads-git-only-$PID.jsonl")
+            $sw = New-Object System.IO.StreamWriter($remedyPath, $false,
+                                                    (New-Object System.Text.UTF8Encoding $false))
+            try {
+                $sw.NewLine = "`n"
+                foreach ($r in $facts.RemedyRows) { $sw.WriteLine($r) }
+            } finally {
+                $sw.Dispose()
+            }
+            $lines.Add('  To teach the database what Git already knows, then checkpoint again:')
+            $lines.Add('')
+            $lines.Add("      bd import $remedyPath")
+            $lines.Add('      powershell -ExecutionPolicy Bypass -File scripts/beads-checkpoint.ps1')
+            $lines.Add('')
+            $lines.Add('  That file holds only the rows above, as HEAD holds them; `bd import` is')
+            $lines.Add('  timestamp-safe, so it creates what is missing, updates what is genuinely')
+            $lines.Add('  newer, and skips the rest. Newer database rows are preserved.')
+            $lines.Add('')
+        }
+        $lines.Add('  If the loss is DELIBERATE (a `bd delete`, a `bd gc`, an AMBIG row you have')
+        $lines.Add('  adjudicated), take the export by hand and commit it yourself:')
+        $lines.Add('')
+        $lines.Add("      bd export --include-memories > $tracker")
+        $lines.Add("      git add -- $tracker; git commit -m ""chore(beads): ...""")
+        $lines.Add('')
+        [Console]::Error.WriteLine(($lines -join "`n"))
+        exit 1
     }
 
     # The export is trustworthy - it is now the working tracker. From here on

--- a/scripts/beads-checkpoint.sh
+++ b/scripts/beads-checkpoint.sh
@@ -24,6 +24,23 @@
 # working tree. A reverted file can then never be committed over newer database
 # state, because the file is regenerated before it is read.
 #
+# THE SECOND FAULT (rf2-rjqtj): EXPORT FIRST IS NOT ENOUGH ON ITS OWN.
+#
+#   Exporting first is right when the database is strictly ahead of Git. It is
+#   wrong when Git is ahead in places — and Git can be, because a second writer
+#   exists: the merged-PR audit commits issue rows straight to Git, and a `git
+#   pull` brings other checkouts' rows in the same way. When both sides move,
+#   they can diverge at the SAME ROW COUNT, one row for one row. The row-count
+#   floor below then sees 1938 == 1938 and waves the export through, and the
+#   commit deletes the Git-only rows and reverts the newer Git statuses.
+#
+#   OBSERVED, not hypothetical: commit 667c744dc875 dropped rf2-3jw04,
+#   rf2-jv36i and rf2-lhdp0 and reverted rf2-2rtt6.52/.63 exactly this way.
+#
+#   So the export is now compared to HEAD by issue id, `updated_at` and
+#   `status` before it is allowed to overwrite anything — see `git_only_facts`.
+#   EQUAL COUNTS ARE NOT EQUALITY.
+#
 # USAGE
 #
 #   sh scripts/beads-checkpoint.sh [-m MESSAGE]
@@ -188,6 +205,117 @@ same_content() {
   cmp -s "$TMP_A" "$TMP_B"
 }
 
+# git_only_facts EXPORT HEAD_COPY REMEDY_PATH — print one line per tracker fact
+# HEAD carries that the fresh export does not, and write the rows that would
+# repair the database to REMEDY_PATH. No output means the export is a safe
+# superset of HEAD and the checkpoint may proceed.
+#
+# THE FAULT THIS EXISTS TO STOP (rf2-rjqtj): see the second fault at the top of
+# this file. Row counts are a floor, not an equality test.
+#
+# Three classes, all of them "Git knows something Dolt does not":
+#
+#   GONE    an issue id at HEAD that the export has no row for at all. The
+#           commit would DELETE that bead.
+#   REVERT  an id in both, where HEAD's `updated_at` is strictly NEWER than the
+#           export's. The commit would revert it to an older status.
+#   AMBIG   an id in both carrying the SAME `updated_at` but a DIFFERENT
+#           `status`. Neither side can be called newer, so neither may be
+#           chosen automatically.
+#
+# The opposite direction — ids only the export has, rows the export has newer —
+# is the normal forward motion of a checkpoint and is deliberately not reported.
+#
+# WHY `status` AND `updated_at`, NOT JUST THE ID SET: an id-set comparison
+# proves presence, nothing more. Confirmed in the field: an interrupted Dolt
+# generational GC reverted a bead's close and five note appends while every id
+# stayed intact. Presence is not state.
+#
+# THE ID IS THE STABLE BEAD ID (`rf2-…`), NEVER A ROW UUID. `bd` regenerates row
+# and comment UUIDs on re-import, so a UUID-keyed diff reports phantom losses —
+# it flagged three beads that existed and were closed. `"id":"` occurs up to
+# eight times in a single row because every comment carries one; only the FIRST
+# occurrence is the bead's, because `bd export` writes `_type` and `id` at the
+# front of the row. A row whose id cannot be read is REPORTED rather than
+# skipped: a guard that silently stops guarding is the bug being fixed here.
+#
+# Rows are compared only when both sides carry a non-empty `updated_at`. Without
+# timestamps there is no basis on which to call either side newer, and inventing
+# one would turn every ordinary close into a refusal.
+#
+# REMEDY_PATH receives the GONE and REVERT rows exactly as HEAD holds them, so
+# `bd import` of that file is the whole recovery — the bead's own verified,
+# bounded mechanism: it created the three missing ids, updated exactly the two
+# newer Git rows, skipped the stale ones, and preserved every newer Dolt row and
+# cursor. AMBIG rows are deliberately left out; an import cannot adjudicate them.
+#
+# REMEDY_PATH reaches awk through the ENVIRONMENT, not through `-v`: awk
+# processes escape sequences in a `-v` value, so a Windows-shaped TMPDIR
+# (`C:\Users\…`) would arrive with its backslashes eaten and the rows would land
+# somewhere other than the path the message names. ENVIRON is taken verbatim.
+git_only_facts() {
+  RF2_BDCHK_REMEDY="$3" awk -v cap=20 '
+    function jval(line, key,   pfx, re) {
+      pfx = "\"" key "\":\""
+      re  = pfx "[^\"]*\""
+      if (match(line, re)) {
+        return substr(line, RSTART + length(pfx), RLENGTH - length(pfx) - 1)
+      }
+      return ""
+    }
+    { sub(/\r$/, "") }
+    index($0, "\"_type\":\"issue\"") == 0 { next }
+    {
+      id = jval($0, "id")
+      st = jval($0, "status")
+      up = jval($0, "updated_at")
+    }
+    # First file: the fresh export. (FNR == NR is sound here because the caller
+    # has already refused a zero-row export, so file 1 is never empty.)
+    FNR == NR {
+      if (id == "") { xbad++; next }
+      xseen[id] = 1; xst[id] = st; xup[id] = up
+      next
+    }
+    # Second file: HEAD.
+    {
+      if (id == "") { hbad++; next }
+      if (!(id in xseen)) {
+        if (++ngone <= cap) {
+          printf "  GONE    %s  would be DELETED (HEAD: status=%s updated_at=%s)\n", id, st, up
+        }
+        print $0 > ENVIRON["RF2_BDCHK_REMEDY"]
+        next
+      }
+      if (up != "" && xup[id] != "" && up > xup[id]) {
+        if (++nrev <= cap) {
+          printf "  REVERT  %s  HEAD status=%s updated_at=%s -> export status=%s updated_at=%s\n", \
+                 id, st, up, xst[id], xup[id]
+        }
+        print $0 > ENVIRON["RF2_BDCHK_REMEDY"]
+        next
+      }
+      if (up != "" && up == xup[id] && st != xst[id]) {
+        if (++namb <= cap) {
+          printf "  AMBIG   %s  same updated_at=%s but HEAD status=%s, export status=%s\n", \
+                 id, up, st, xst[id]
+        }
+      }
+    }
+    END {
+      if (ngone > cap) printf "  ... and %d more that would be DELETED\n", ngone - cap
+      if (nrev  > cap) printf "  ... and %d more that would be REVERTED\n", nrev - cap
+      if (namb  > cap) printf "  ... and %d more ambiguous rows\n", namb - cap
+      if (xbad > 0) {
+        printf "  UNREADABLE  %d issue rows in the fresh export carry no readable id\n", xbad
+      }
+      if (hbad > 0) {
+        printf "  UNREADABLE  %d issue rows at HEAD carry no readable id\n", hbad
+      }
+    }
+  ' "$1" "$2"
+}
+
 # ---------------------------------------------------------------------------
 # --pre-pull: would clearing `.beads` throw tracker state away?
 # ---------------------------------------------------------------------------
@@ -251,6 +379,45 @@ if [ "$head_rows" -gt 0 ] && [ $((export_rows * 10)) -lt $((head_rows * 9)) ]; t
   printf '  Inspect with `bd status`, then commit by hand if the shrink is genuine.\n' >&2
   exit 1
 fi
+
+# DIVERGENCE GUARD (rf2-rjqtj). The floor above answers "is the export big
+# enough?". It cannot answer "does the export still contain what HEAD contains?"
+# — and at equal counts it has already said yes to an export that did not.
+# Nothing has been written yet, so a refusal here leaves the tracker exactly as
+# it was found.
+REMEDY="${TMPDIR:-/tmp}/rf2-beads-git-only-$$.jsonl"
+rm -f "$REMEDY"
+FACTS=$(git_only_facts "$TMP_EXPORT" "$TMP_HEAD" "$REMEDY")
+if [ -n "$FACTS" ]; then
+  printf 'beads-checkpoint: HEAD carries tracker facts the fresh export does NOT.\n' >&2
+  printf '  export %s rows, HEAD %s rows.' "$export_rows" "$head_rows" >&2
+  if [ "$export_rows" = "$head_rows" ]; then
+    printf ' EQUAL COUNTS ARE NOT EQUALITY:\n' >&2
+    printf '  commit 667c744dc875 passed this floor at 1938 == 1938 and still deleted three\n' >&2
+    printf '  issues and reverted two closes, because Git and Dolt had diverged one for one.\n' >&2
+  else
+    printf '\n' >&2
+  fi
+  printf '\n%s\n\n' "$FACTS" >&2
+  printf '  Committing this export would lose exactly those facts, so it was NOT committed.\n' >&2
+  printf '  %s is UNTOUCHED.\n\n' "$TRACKER" >&2
+  if [ -s "$REMEDY" ]; then
+    printf '  To teach the database what Git already knows, then checkpoint again:\n\n' >&2
+    printf '      bd import %s\n' "$REMEDY" >&2
+    printf '      sh scripts/beads-checkpoint.sh\n\n' >&2
+    printf '  That file holds only the rows above, as HEAD holds them; `bd import` is\n' >&2
+    printf '  timestamp-safe, so it creates what is missing, updates what is genuinely\n' >&2
+    printf '  newer, and skips the rest. Newer database rows are preserved.\n\n' >&2
+  else
+    rm -f "$REMEDY"
+  fi
+  printf '  If the loss is DELIBERATE (a `bd delete`, a `bd gc`, an AMBIG row you have\n' >&2
+  printf '  adjudicated), take the export by hand and commit it yourself:\n\n' >&2
+  printf '      bd export --include-memories > %s\n' "$TRACKER" >&2
+  printf '      git add -- %s && git commit -m "chore(beads): ..."\n\n' "$TRACKER" >&2
+  exit 1
+fi
+rm -f "$REMEDY"
 
 # The export is trustworthy — it is now the working tracker. From here on the
 # working file cannot be a stale revert, whatever it was a moment ago.

--- a/scripts/git-hooks/test-pre-commit.sh
+++ b/scripts/git-hooks/test-pre-commit.sh
@@ -1537,6 +1537,173 @@ case "$out" in
     fi ;;
 esac
 
+# ----------------------------------------------------------------------------
+# 8j-8l: EQUAL COUNTS ARE NOT EQUALITY (rf2-rjqtj).
+#
+# 8i's floor answers "is the export big enough?". It cannot answer "does the
+# export still contain what HEAD contains?" — and there is a second writer that
+# makes the difference matter: the merged-PR audit commits issue rows straight
+# to Git, and `git pull` brings other checkouts' rows the same way. When both
+# sides move they diverge one row for one row, the count does not budge, and
+# the floor waves through an export that deletes the Git-only rows.
+#
+# OBSERVED: commit 667c744dc875 passed at 1938 == 1938 and still dropped
+# rf2-3jw04, rf2-jv36i and rf2-lhdp0 and reverted rf2-2rtt6.52/.63.
+#
+# The fixture is the bead's own acceptance, and every row below is load-bearing:
+#
+#   rf2-a   unchanged on both sides
+#   rf2-b   NEWER ON GIT   — closed at 03:00; the export still has it open
+#   rf2-c   NEWER ON DOLT  — closed at 02:00; HEAD still has it open
+#   rf2-g1  GIT ONLY       — the export has never heard of it
+#   rf2-d1  DOLT ONLY      — HEAD has never heard of it
+#
+# Four issue rows plus two memories a side: six against six. Neither side's
+# facts may be lost, and 8j proves the refusal while 8k proves the recovery.
+# ----------------------------------------------------------------------------
+{
+  printf '{"_type":"issue","id":"rf2-a","status":"open","updated_at":"2026-08-01T00:00:00Z"}\n'
+  printf '{"_type":"issue","id":"rf2-b","status":"closed","updated_at":"2026-08-02T03:00:00Z"}\n'
+  printf '{"_type":"issue","id":"rf2-c","status":"open","updated_at":"2026-08-01T00:00:00Z"}\n'
+  printf '{"_type":"issue","id":"rf2-g1","status":"open","updated_at":"2026-08-02T01:00:00Z"}\n'
+  printf '{"_type":"memory","key":"m1","value":"one"}\n'
+  printf '{"_type":"memory","key":"m2","value":"two"}\n'
+} > "$CBOX/head-diverged.jsonl"
+{
+  printf '{"_type":"issue","id":"rf2-a","status":"open","updated_at":"2026-08-01T00:00:00Z"}\n'
+  printf '{"_type":"issue","id":"rf2-b","status":"open","updated_at":"2026-08-01T12:00:00Z"}\n'
+  printf '{"_type":"issue","id":"rf2-c","status":"closed","updated_at":"2026-08-02T02:00:00Z"}\n'
+  printf '{"_type":"issue","id":"rf2-d1","status":"open","updated_at":"2026-08-02T01:30:00Z"}\n'
+  printf '{"_type":"memory","key":"m1","value":"one"}\n'
+  printf '{"_type":"memory","key":"m2","value":"two"}\n'
+} > "$CBOX/db-diverged.jsonl"
+
+(
+  cd "$CREPO"
+  cp -f "$CBOX/head-diverged.jsonl" .beads/issues.jsonl
+  git add -- .beads/issues.jsonl
+  git commit -q -m 'seed: HEAD and the database have diverged at equal row count'
+) >/dev/null 2>&1
+
+# 8j: THE ACCEPTANCE. Equal counts, disjoint one-for-one substitution, one
+# newer state on each side. The only safe answer is to refuse and name what
+# would be lost — with the FIELDS, because an id-set comparison proves presence
+# and nothing more (an interrupted Dolt GC reverted a close in the field while
+# every id stayed intact).
+cp -f "$CBOX/db-diverged.jsonl" "$CBOX/db.jsonl"
+before=$(git -C "$CREPO" rev-parse HEAD)
+out=$(run_checkpoint "$CREPO")
+after=$(git -C "$CREPO" rev-parse HEAD)
+case "$out" in
+  EXIT=0)
+    fail "(8j) an equal-count divergence was checkpointed: rf2-g1 and rf2-b's close are GONE"
+    cat "$COUT" >&2 ;;
+  *)
+    if [ "$before" != "$after" ]; then
+      fail "(8j) the divergence was refused but something was still committed"
+    elif ! grep -q 'EQUAL COUNTS ARE NOT EQUALITY' "$CERR"; then
+      fail "(8j) refused, but not for the equal-count reason"
+      cat "$CERR" >&2
+    elif ! grep -q 'GONE .*rf2-g1' "$CERR"; then
+      fail "(8j) did not name the Git-only bead that would be DELETED"
+      cat "$CERR" >&2
+    elif ! grep -q 'REVERT .*rf2-b' "$CERR"; then
+      fail "(8j) did not name the Git-newer bead that would be REVERTED"
+      cat "$CERR" >&2
+    elif ! grep -q '2026-08-02T03:00:00Z' "$CERR"; then
+      fail "(8j) named the ids but not the FIELDS; presence is not state"
+      cat "$CERR" >&2
+    elif grep -qE 'rf2-c|rf2-d1' "$CERR"; then
+      fail "(8j) cried wolf over the DOLT-side facts; forward motion is not a divergence"
+      cat "$CERR" >&2
+    elif ! grep -q 'rf2-g1' "$CREPO/.beads/issues.jsonl"; then
+      fail "(8j) the tracker was overwritten despite the refusal"
+    else
+      pass "(8j) an equal-count divergence is refused, naming both lost facts and their fields"
+    fi ;;
+esac
+
+# 8j-remedy: a refusal nobody can act on gets bypassed. The message names a file
+# holding exactly the Git-only and Git-newer rows, so `bd import` of it is the
+# whole recovery — the bead's own verified mechanism, and the reason this guard
+# does not need a sync service.
+remedy=$(sed -n 's/^ *bd import \(.*\)$/\1/p' "$CERR" | head -1)
+if [ -n "$remedy" ] && [ -s "$remedy" ]; then
+  if [ "$(awk 'END{print NR}' "$remedy")" = "2" ] \
+     && grep -q 'rf2-g1' "$remedy" && grep -q 'rf2-b' "$remedy"; then
+    pass "(8j) and it stages exactly the two rows an import must carry"
+  else
+    fail "(8j) the remedy file did not hold exactly the Git-only/Git-newer rows"
+    cat "$remedy" >&2
+  fi
+else
+  fail "(8j) no remedy file was written, so the refusal is not actionable"
+fi
+if [ -n "$remedy" ]; then rm -f "$remedy"; fi
+
+# 8k: AND THE RECOVERY COMPLETES. The operator runs that import, so the database
+# becomes the UNION. The next checkpoint must commit, and the committed tracker
+# must carry ALL FOUR facts — the bead's "neither fact may be lost", end to end.
+{
+  printf '{"_type":"issue","id":"rf2-a","status":"open","updated_at":"2026-08-01T00:00:00Z"}\n'
+  printf '{"_type":"issue","id":"rf2-b","status":"closed","updated_at":"2026-08-02T03:00:00Z"}\n'
+  printf '{"_type":"issue","id":"rf2-c","status":"closed","updated_at":"2026-08-02T02:00:00Z"}\n'
+  printf '{"_type":"issue","id":"rf2-d1","status":"open","updated_at":"2026-08-02T01:30:00Z"}\n'
+  printf '{"_type":"issue","id":"rf2-g1","status":"open","updated_at":"2026-08-02T01:00:00Z"}\n'
+  printf '{"_type":"memory","key":"m1","value":"one"}\n'
+  printf '{"_type":"memory","key":"m2","value":"two"}\n'
+} > "$CBOX/db.jsonl"
+before=$(git -C "$CREPO" rev-parse HEAD)
+out=$(run_checkpoint "$CREPO")
+after=$(git -C "$CREPO" rev-parse HEAD)
+case "$out" in
+  EXIT=0)
+    committed=$(git -C "$CREPO" show HEAD:.beads/issues.jsonl)
+    if [ "$before" = "$after" ]; then
+      fail "(8k) the post-import checkpoint committed nothing"
+    elif ! printf '%s\n' "$committed" | grep -q 'rf2-g1'; then
+      fail "(8k) the Git-only bead was lost after the import"
+    elif ! printf '%s\n' "$committed" | grep -q '"id":"rf2-b","status":"closed"'; then
+      fail "(8k) the Git-side close was reverted after the import"
+    elif ! printf '%s\n' "$committed" | grep -q 'rf2-d1'; then
+      fail "(8k) the Dolt-only bead was lost"
+    elif ! printf '%s\n' "$committed" | grep -q '"id":"rf2-c","status":"closed"'; then
+      fail "(8k) the Dolt-side close was lost"
+    elif ! printf '%s\n' "$committed" | grep -q '"key":"m1"'; then
+      fail "(8k) the memory rows did not ride along"
+    else
+      pass "(8k) after the import the checkpoint commits, and neither side's facts are lost"
+    fi ;;
+  *) fail "(8k) the checkpoint still refused a database that is now a superset ($out)"
+     cat "$CERR" >&2 ;;
+esac
+
+# 8l: THE AMBIGUOUS ROW. Same `updated_at`, different `status`: neither side is
+# newer, so neither may be chosen automatically — and no import can adjudicate a
+# tie, so none is offered. This is the class the field data insisted on: an
+# id-set comparison would call it clean.
+sed 's/"id":"rf2-c","status":"closed"/"id":"rf2-c","status":"open"/' \
+  "$CBOX/db.jsonl" > "$CBOX/db-ambig.jsonl"
+cp -f "$CBOX/db-ambig.jsonl" "$CBOX/db.jsonl"
+before=$(git -C "$CREPO" rev-parse HEAD)
+out=$(run_checkpoint "$CREPO")
+after=$(git -C "$CREPO" rev-parse HEAD)
+case "$out" in
+  EXIT=0) fail "(8l) a same-timestamp status conflict was silently resolved by the export" ;;
+  *)
+    if [ "$before" != "$after" ]; then
+      fail "(8l) the ambiguous row was refused but something was committed"
+    elif ! grep -q 'AMBIG .*rf2-c' "$CERR"; then
+      fail "(8l) refused, but did not name the row as ambiguous"
+      cat "$CERR" >&2
+    elif grep -q 'bd import' "$CERR"; then
+      fail "(8l) offered an import for a tie an import cannot adjudicate"
+      cat "$CERR" >&2
+    else
+      pass "(8l) a same-timestamp status conflict is refused, and no import is offered"
+    fi ;;
+esac
+
 rm -rf "$CBOX"
 
 fi


### PR DESCRIPTION
Closes rf2-rjqtj (P1, bug).

## The fault

Two writers touch `.beads/issues.jsonl`. `scripts/beads-checkpoint.*` exports Dolt
wholesale over the file; the merged-PR audit commits issue rows straight to Git, and
`git pull` brings other checkouts' rows in the same way. The only guard between them
was a **row-count floor**, so when the two sides diverged at the *same* count — Git
carrying rows Dolt lacked, Dolt carrying rows Git lacked, one for one — the floor
passed and the export silently deleted the Git-only rows.

Recorded once already: commit `667c744dc875` passed at 1938 == 1938 and still dropped
rf2-3jw04, rf2-jv36i, rf2-lhdp0 and reverted rf2-2rtt6.52/.63. The `.ps1` in this diff
is the script that produced it.

Equal counts are not equality. That is the whole change.

## What it now detects

After the row-count floor (kept, unchanged) and **before** anything is written, the
fresh export is compared to HEAD on the **stable bead id**, `updated_at` and `status`.
Three classes, all of them "Git knows something Dolt does not":

| class | condition | what the old code would have done |
|---|---|---|
| `GONE` | issue id at HEAD, no row for it in the export | deleted the bead |
| `REVERT` | id in both, HEAD's `updated_at` strictly newer | reverted it to an older status |
| `AMBIG` | id in both, **same** `updated_at`, **different** `status` | silently picked Dolt's |

The opposite direction — ids only the export has, rows the export has newer — is the
normal forward motion of a checkpoint and is deliberately **not** reported. A guard
that fires on every checkpoint is a guard that gets bypassed.

Two details that are load-bearing rather than incidental:

- **The id is the stable `rf2-…` id, never a row UUID.** `bd` regenerates row and
  comment UUIDs on re-import, so a UUID-keyed diff reports phantom losses. `"id":"`
  occurs up to **eight times** in a single issue row because every comment carries one;
  only the first is the bead's, and `bd export` writes `_type` and `id` at the front.
  A row whose id cannot be read is *reported*, not skipped — a guard that silently
  stops guarding is the bug being fixed.
- **`status` and `updated_at`, not just the id set.** An id-set comparison proves
  presence, nothing more; an interrupted Dolt generational GC reverted a close and five
  note-appends in the field while every id stayed intact. Hence `AMBIG`. Rows are
  compared only when both sides carry a non-empty `updated_at` — without timestamps
  there is no basis to call either side newer, and inventing one would turn every
  ordinary close into a refusal.

## Refuse, not auto-import — and why

The bead allowed either. This refuses, for three reasons:

1. The script's own stated contract is "what it deliberately does not do: pull, push,
   **import**". Making it import contradicts the thing that makes it trustworthy.
2. Auto-import means writing to the database from the one script that exists to be
   careful. Not provably safe, so not done.
3. Refusing loudly with exact ids and fields is already a complete outcome.

What it *does* do is make the refusal actionable without becoming a sync engine: the
`GONE` and `REVERT` rows, exactly as HEAD holds them, are written to a temp file that
the message names, so the bead's own verified recovery is one command —
`bd import <that file>`, which is timestamp-safe, then checkpoint again. `AMBIG` rows
are deliberately excluded and no import is offered for them; an import cannot
adjudicate a tie. The message also names the escape for a deliberate `bd delete`/`bd gc`.

No generalized sync service, as the bead asked.

## The regression

Both platforms get it, and the fixture is the bead's own: HEAD and Dolt at **equal row
count** with disjoint one-for-one substitutions **plus one newer state on each side**.

```
rf2-a   unchanged            rf2-g1  GIT ONLY      rf2-b  NEWER ON GIT  (closed 03:00)
                             rf2-d1  DOLT ONLY     rf2-c  NEWER ON DOLT (closed 02:00)
```

- **POSIX** — `scripts/git-hooks/test-pre-commit.sh` layer 8, cases **8j/8k/8l** (the
  existing hermetic stub-`bd` harness; the real tracker is never opened).
- **PowerShell** — a new `-SelfTest` switch on `beads-checkpoint.ps1`, following the
  `remove-worker-worktree.ps1 -SelfTest` precedent. The `.ps1` had **no test surface at
  all** before this, and layer 8 is POSIX sh and cannot run it. Windows is the
  operator's platform and the platform that produced `667c744dc875`. 28 assertions,
  T1–T6, against a throwaway git repo and a stub `bd` in a temp directory.

Crucially both prove **neither** side's facts are lost: 8k/T2 run the documented import
and then require the committed tracker to carry all four facts — the Git-only bead, the
Git-side close, the Dolt-only bead and the Dolt-side close — plus the memory rows.

### Proof it fails without the fix

New cases run against `origin/main`'s `beads-checkpoint.sh` (scratch copy of the tree,
same suite):

```
FAIL  (8j) an equal-count divergence was checkpointed: rf2-g1 and rf2-b's close are GONE
FAIL  (8j) no remedy file was written, so the refusal is not actionable
PASS  (8k) after the import the checkpoint commits, and neither side's facts are lost
FAIL  (8l) a same-timestamp status conflict was silently resolved by the export
Summary: 69 passed, 3 failed
```

(8k passes pre-fix by design — it is the forward-motion case, and doubles as the
false-positive net.)

Same fixture through `origin/main`'s `.ps1`, by hand:

```
beads-checkpoint: committed .beads/issues.jsonl (4 rows, HEAD had 4).
BASELINE_PS1_EXIT=0
rf2-g1 in committed tracker : DELETED (bead lost)
rf2-b close                 : REVERTED
```

That `(4 rows, HEAD had 4)` line is the dangerous signature — the equal-count form of it
recurred repeatedly across the mayor's ~15 checkpoints today.

## Quality gates

All foreground, to completion, never piped through `tail`/`grep` (the pipe's exit status
would mask the runner's — a trap that is itself in scope here). Logs under `.gatelogs/`
(git-ignored).

| gate | result |
|---|---|
| `sh scripts/test-fast-pr.sh` | **exit 0** — `PASS fast PR spine` (JVM core, node/JS-harness tier, CLJS node integration, all 17 per-namespace isolation builds) |
| `sh scripts/git-hooks/test-pre-commit.sh` | **exit 0** — `Summary: 72 passed, 0 failed` |
| `beads-checkpoint.ps1 -SelfTest` (Windows PowerShell 5.1) | **exit 0** — 28 passed, 0 failed |
| `beads-checkpoint.ps1 -SelfTest` (pwsh 7.6.4) | **exit 0** — 28 passed, 0 failed |
| `shellcheck -s sh scripts/beads-checkpoint.sh` | exit 0 at `--severity=warning`; at info level only `SC1091` + `SC2016`, the same classes as `origin/main` (the two added `SC2016` are backticks in prose inside single quotes, matching the file's existing style) |
| `shellcheck -s sh scripts/git-hooks/test-pre-commit.sh` | finding set **byte-identical to `origin/main`** — zero new findings |

A note on that spine run, since it bit once: a fresh worktree has no `node_modules`, so the
**first** run exited **1** at the CLJS tier (`Cannot find module 'shadow-cljs/cli/runner.js'`) —
an environment gap, not a defect in the diff. A real `npm ci` (a real directory, **no junction**;
the mayor checkout's `node_modules` canary held at 101 entries throughout) then took it green.
The first run also taught the lesson it was supposed to: I had chained `; tail` after the runner,
and the harness reported the *pipeline's* exit 0 while the spine had actually returned 1. Every
gate result above was re-taken with the exit code captured directly.

`Set-StrictMode -Version Latest` is now on in the `.ps1`. Every arm it guards is
exercised by `-SelfTest`: checkpoint-commit, divergence-refusal, remedy-file write,
`-PrePull` silent, `-PrePull` warning, and the `git add`/`git commit` path against a
real temp repo.

### What no automated gate covers, and what I exercised by hand

These scripts are operator helpers — nothing in CI runs them, and CI's shellcheck roster
is scoped to `.github/scripts/`. So beyond the suites above:

- **The parser against the real 2741-row tracker**, read-only, from `git show HEAD:`.
  Identity comparison → **silent, zero findings** across 1951 issue rows with all their
  embedded prose, escaped quotes, 790 memory rows and up to 8 comment UUIDs per row.
  Then an equal-count 2741 vs 2741 divergence with two real beads removed and one real
  close back-dated → all three caught, with their real stable ids and real fields, and
  no noise. That is `667c744dc8` at full scale.
- **Row-shape invariants verified before writing the parser**, on the same real data:
  all 1951 issue rows carry exactly one `status` and one `updated_at`; all 790 memory
  rows carry neither; `"id":"` recurs up to 8x per row (which is why first-match
  anchoring is load-bearing).
- **The `.ps1` is pure ASCII and BOM-free** (`grep '[^ -~\t]'` → 0 matches), per the
  Windows PowerShell 5.x ANSI-codepage constraint the file documents.

**Not run against the live database, deliberately.** The mayor is checkpointing the live
tracker every ~11 minutes; a concurrent real run risks the very corruption this fixes.
Everything above is fixtures and throwaway directories.

## Scope

`scripts/beads-checkpoint.sh`, `scripts/beads-checkpoint.ps1`,
`scripts/git-hooks/test-pre-commit.sh`. Disjoint from open PR #7407
(`remove-worker-worktree.*`, `AGENTS.md`, `.claude/commands/mayor-hygiene.md`,
`docs/the-mayor-method/dispatch-prompt-template.md`) — checked before starting.

Known bound, stated rather than implied: the divergence guard compares **issue** rows.
Memory rows carry no id or timestamp to compare, so a memory dropped by the database is
still covered only by the row-count floor, as before.

