### PR TITLE
fix(hicasso): a first registration inside the render->commit gap (rf2-2rtt6.50)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/first_registration_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/first_registration_cljs_test.cljs
@@ -33,19 +33,37 @@
   change again.
 
   The rows below are the direct witness the merged-PR audit asked for.
-  One of them is a **pin rather than a repair**: a first registration
-  landing in the render→commit gap reaches no cell, because the boundary
-  has none yet, and the epoch sum cannot report it either — a `reg-sub`
-  moves neither term of `commit-basis`. That is the registry axis inside
-  the second window, permanently outside this arithmetic and closable
-  only by the term this programme costed and declined; the commit does
-  acquire against the live registration, so what it costs is a delayed
-  paint the next write clears, not a retired computation.
+  The transition has **two halves**, and they are repaired by two
+  different mechanisms because they are two different situations.
 
-  The bottom row is the bill: a first registration of an id **no cell
-  holds** must still disturb nothing, because the alternative this
-  programme declined was a registry term in every key's contribution to
-  `getSnapshot`."
+  A boundary that already HOLDS a cell is repaired by the registration
+  event: `first-registration!` scans the cells for the id and drops the
+  reference, so the next read falls through to the cold probe and the
+  rebuilt attachment notifies later writes. That is the mounted case, and
+  the first two rows.
+
+  A boundary inside the **render→commit gap** holds no cell, so that scan
+  reaches nothing on its behalf. It is repaired by the `registry-epoch`
+  term of `commit-basis` (rf2-2rtt6.50): a key with no cell contributes a
+  LIVE basis reading, the cell the commit creates is stamped with the
+  basis as it stands then, and a `reg-sub` between the two makes the two
+  numbers differ — so React's own post-`subscribe` tear check schedules
+  the re-render. That was a **pin rather than a repair** until
+  rf2-2rtt6.50, on the reasoning that the only available term was the one
+  rf2-2rtt6.44 costed and declined. It is not: what that costing priced
+  was a registry term in every key's *live* contribution to
+  `getSnapshot`, which moves every mounted boundary in the application on
+  every `reg-sub` and buys each one a render that reads back through a
+  dead reference. A term in the *basis* is read live by the staged branch
+  alone — so it reaches exactly the keys that have the defect, and the
+  extra render it buys reads back through a cell that is alive and
+  correct.
+
+  The bottom rows are the bill, and they are what makes that distinction
+  checkable rather than argued: a first registration of an id **no cell
+  holds** must still disturb a mounted boundary by nothing at all. Those
+  assertions are unchanged by the term, which is the cleanest available
+  proof that the option taken is not the option declined."
   (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.bench.hicasso.arm1.runtime :as rt]
@@ -183,51 +201,59 @@
              to stop reading through it, not to re-read it")
         (release!)))))
 
-(deftest deliberately-a-first-registration-in-the-render-commit-gap-moves-no-snapshot
-  (testing "the OTHER window, pinned rather than closed. The rows above
-            are the mounted case — a boundary that already holds a cell.
-            The render→commit gap is the case where it does not: the body
-            has returned `nil`, and the registration lands before React
-            runs the effect that acquires the edge. There is no cell for
-            [[first-registration!]] to reach, and the epoch sum cannot
-            report it either — a key with no cell contributes its frame's
-            `commit-basis`, and a `reg-sub` moves neither term of it. So
-            the number React re-reads after `subscribe` is the number it
-            captured at render, and it schedules nothing.
+(deftest a-first-registration-in-the-render-commit-gap-moves-the-snapshot
+  (testing "the OTHER window (rf2-2rtt6.50). The rows above are the
+            mounted case — a boundary that already holds a cell. The
+            render→commit gap is the case where it does not: the body has
+            returned `nil`, and the registration lands before React runs
+            the effect that acquires the edge. There is no cell for
+            [[first-registration!]] to reach, so the repair those rows
+            witness reaches nothing here.
 
-            This is the registry axis inside the second window, and it is
-            the same thing `generation_fence_coverage_cljs_test` states
-            for a re-registration: permanently outside this arithmetic,
-            and closable only by the registry term that programme
-            declined. What saves it is that the commit DID acquire against
-            the live registration, so the boundary is correct from its
-            next render onwards and the next write to the frame schedules
-            one. It is a delayed paint, not a retired computation."
+            What reaches it is the `registry-epoch` term of
+            `commit-basis`. A key with no cell contributes a LIVE basis
+            reading to `getSnapshot`; the cell the commit creates is
+            stamped with the basis as it stands THEN. A `reg-sub` between
+            the two moves the term, so the two numbers differ, so React's
+            post-`subscribe` re-check sees a tear and schedules the
+            re-render — which reads back through a cell that is alive and
+            holds the real handler. That is what distinguishes this from
+            the transitions rf2-2rtt6.44 declined a term for, where the
+            extra render would have read back through a dead reference.
+
+            The correction is React's tear check, NOT a notification: the
+            arm's own notify path runs off `flush!`, and a registration
+            is not a value change on an acquired reaction. `hits` staying
+            zero is that distinction on the board."
     (let [seen (volatile! :unread)
           f    (make-frame! ::gap {:v 1})]
       (rt/render-body f (reader q-gap seen) {})
       (is (nil? @seen) "the body ran against no registration")
       (let [entry     (rt/last-reads)
             at-render (rt/snapshot-of entry)
+            epoch     (rt/registry-epoch)
             hits      (volatile! 0)]
         ;; THE REGISTRATION, inside the gap: after the body returned and
         ;; before React's effect acquires the edge.
         (rf/reg-sub (first q-gap) (fn [db _] (:v db)))
+        (is (> (rt/registry-epoch) epoch)
+            "precondition: the arm counted the registration — the term the
+             rest of this row turns on actually moved")
         (let [release! (rt/commit-boundary! entry (fn [] (vswap! hits inc)))]
-          (is (= at-render (rt/snapshot-of entry))
-              "the snapshot did not move across the commit, so React's
-               post-`subscribe` re-check sees no tear and schedules no
-               re-render — the boundary keeps the `nil` it painted")
-          (is (zero? @hits) "and nothing notified it either")
+          (is (not= at-render (rt/snapshot-of entry))
+              "the snapshot MOVED across the commit, so React's
+               post-`subscribe` re-check sees a tear and schedules the
+               re-render the boundary needs to stop painting `nil`")
+          (is (zero? @hits)
+              "and it is the tear check that does it, not a notification —
+               a `reg-sub` reaches `flush!` by no route")
           (is (= 1 @(rt/cell-reaction [f q-gap]))
-              "though the cell the commit acquired holds the REAL handler:
-               nothing is retired here, and the next render is correct")
-          (testing "so it heals on the next write rather than at the
-                    registration"
-            (frame/replace-app-db! f {:v 2})
-            (is (pos? @hits) "the write notified")
+              "and the cell the commit acquired holds the REAL handler, so
+               the render React just scheduled reads the right value")
+          (testing "which the re-render then does, at once rather than at
+                    the next write"
             (rt/render-body f (reader q-gap seen) {})
-            (is (= 2 @seen)))
+            (is (= 1 @seen) "1, not nil: the delayed paint is gone"))
           (release!))))))
 
 ;; ---------------------------------------------------------------------------
@@ -265,11 +291,11 @@
            registration is not a reason to rebuild an attachment")
       (release!))))
 
-(deftest closing-the-first-registration-cost-no-hook-and-nothing-in-the-snapshot
+(deftest closing-the-first-registration-cost-no-hook-and-no-per-boundary-object
   (testing "the same fences `disposed_cell_cljs_test` holds for the
-            disposal half. What repairs a first registration is an event,
-            not a term, so the shell is unchanged and the snapshot
-            arithmetic is unchanged."
+            disposal half. The held-cell half is repaired by an event and
+            the gap half by one term shared by every key, so neither buys
+            a React hook and neither buys a per-boundary object."
     (is (= 2 (count rt/shell-hook-ledger))
         "still two hooks — a registrar hook is not a React hook")
     (is (= [:use-context/frame :use-sync-external-store/subscription-epoch]

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/generation_fence_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/generation_fence_dom_cljs_test.cljs
@@ -44,6 +44,7 @@
             [re-frame.bench.hicasso.arm1.runtime :as rt]
             [re-frame.bench.hicasso.front.dogfood :as dogfood]
             [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
             [re-frame.test-support :as test-support])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
@@ -214,6 +215,77 @@
             (is (= "true" (read-back handle "data-after"))
                 "the boundary was corrected: React re-read the store after
                  `subscribe` and found a number that had moved"))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; Case 4 — a first REGISTRATION lands in the gap (rf2-2rtt6.50)
+;; ---------------------------------------------------------------------------
+;;
+;; Case 3 moves a staged read's VALUE in the gap. This one moves its
+;; COMPUTATION: the reading boundary's query is not registered when its
+;; body runs, so the read takes the substrate's nil-recovery, and the
+;; registration lands before React acquires the edge. Neither the flush
+;; generation nor the frame's install epoch moves for a `reg-sub`, and
+;; the boundary has no cell for `first-registration!` to reach — so
+;; without the basis's registry term React re-reads the number the fiber
+;; captured at render, finds no tear, and the boundary paints the
+;; recovery's `nil` until the next write to the frame.
+;;
+;; Staged the way Case 3 is, and for the same reason: a SIBLING boundary
+;; acting during the same React render pass, after the reading boundary's
+;; fence has closed. That needs no guess about when React runs a passive
+;; effect — the registration is strictly inside the render, and
+;; `subscribe` runs strictly after it. This is the lazily-loaded-module
+;; shape, which is the one the reachability argument names.
+
+(def ^:private gap-q [::lazily-registered])
+
+(defonce ^:private !gap-registrations (atom 0))
+
+(defview gap-reader
+  "Renders FIRST, and reads a query NOTHING has registered."
+  [_]
+  (let [v (rt/sub gap-q)]
+    [:li.row {:data-after (str v) :data-before (str v)} (str v)]))
+
+(defview gap-registrar
+  "Renders SECOND, in the same pass, and registers the sub its sibling
+  just read. Once — a body that registers on every run moves the basis on
+  every run, which is a write loop, and the fence fails that loudly rather
+  than spinning."
+  [_]
+  ;; A read of its own, so this is an ordinary boundary rather than a
+  ;; contrivance with no edges.
+  (rt/sub [:dogfood/filter])
+  (when (zero? @!gap-registrations)
+    (swap! !gap-registrations inc)
+    (rf/reg-sub (first gap-q) (fn [_ _] :arrived)))
+  [:li.writer])
+
+(deftest a-first-registration-landing-in-the-gap-is-corrected-in-the-dom
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (reset! !gap-registrations 0)
+      (lane/leave-act-environment!)
+      (dogfood/make-frame! frame-id 3)
+      (dogfood/reseed! frame-id 3)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id
+                                [:ul [gap-reader {}] [gap-registrar {}]])]
+        (try
+          (is (= 1 @!gap-registrations) "the sibling registered, exactly once")
+          (mount/settle!)
+          (mount/settle!)
+          (testing "the reader's query had no handler when its body ran and no
+                   cell when the registration landed, so `first-registration!`
+                   reached nothing on its behalf and neither the generation nor
+                   the frame's install epoch moved — and the DOM must still not
+                   be stale"
+            (is (= ":arrived" (read-back handle "data-after"))
+                "the boundary was corrected inside the mount: React re-read the
+                 store after `subscribe`, found a number the registry term had
+                 moved, and re-rendered through the cell the commit acquired
+                 against the live registration"))
           (finally (mount/release! handle)))))))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -249,14 +249,17 @@
 
       commit-basis(frame) = this runtime's flush generation
                           + that frame's own physical-install epoch
+                          + this runtime's registry epoch
 
   [[generation]] counts flushes. `frame-commit-epoch` is the substrate's
   own counter, bumped once per physical frame-state install at both
   write chokepoints, and Spec 006's observation port already uses it for
   exactly this question — *did the frame's durable state move in the
   render→commit gap?* — because it answers without watching anything.
-  That second term is what the runtime was missing, and it is why the
-  basis is not just the generation:
+  [[registry-epoch]] counts `:sub` registrations, which are neither a
+  flush nor an install, so a `reg-sub` in the gap would otherwise move no
+  term at all (rf2-2rtt6.50). The second term is what the runtime was
+  missing, and it is why the basis is not just the generation:
 
   > The generation only moves when `flush!` bumps it, `flush!` only runs
   > from `mark-dirty!`, and `mark-dirty!`'s only caller is the
@@ -294,17 +297,33 @@
   component. Those notifications are deferred to a macrotask; the fence
   has already made the *rendering* boundary correct.
 
-  ### The other two axes, and why they are not the basis's to carry
+  ### The other two axes, and which half of each the basis carries
 
-  The predecessor compared three things, and the basis answers one of
-  them. The other two — a `:sub` registration (its `:registry-epoch`)
-  and a same-id frame reincarnation (its `:node-key`) — move neither
-  term, and rf2-2rtt6.44 established that **adding a term for them would
-  have closed nothing**. Each of them leaves the cell holding a reaction
-  that can no longer answer for its key, so a number that moved would
-  have bought exactly one extra render, and that render would have read
-  back through the same dead reference. What each does to the cell, and
-  what the arm hears when it happens:
+  The predecessor compared three things. The other two — a `:sub`
+  registration (its `:registry-epoch`) and a same-id frame reincarnation
+  (its `:node-key`) — split cleanly by whether the boundary in question
+  **already holds a cell** for the key, and the two halves want opposite
+  answers.
+
+  For a boundary that holds one, rf2-2rtt6.44 established that **adding a
+  term would have closed nothing**: each transition leaves the cell
+  holding a reaction that can no longer answer for its key, so a number
+  that moved would have bought exactly one extra render, and that render
+  would have read back through the same dead reference. That half is
+  carried by the substrate's own events, below.
+
+  For a boundary inside the render→commit gap there is no cell, so there
+  is no dead reference — the commit acquires against whatever is live
+  *then*, and one extra render is exactly the repair. rf2-2rtt6.50 closes
+  the registry half of that, with the [[registry-epoch]] term of the
+  basis; because a held key contributes a frozen stamp and only a staged
+  key reads the basis live, the term reaches the gap and costs the
+  mounted case nothing. The `:node-key` half stays open and is stated in
+  [[commit-basis]] — the basis TIES across a reincarnation, so no
+  arithmetic over these terms could report it.
+
+  What each transition does to a *held* cell, and what the arm hears when
+  it happens:
 
   | transition | what the cell is left holding | what announces it |
   |---|---|---|
@@ -318,13 +337,21 @@
   which covers the two transitions that dispose; the third disposes
   nothing — `registrar/add-replacement-hook!` fires only when a previous
   handler existed — so the arm hangs it off
-  `registrar/add-registration-hook!`, narrowed to first-time `:sub`
-  registrations and to the cells that hold the id being registered. It
-  costs no React hook, no per-boundary object, nothing in the snapshot
-  arithmetic, and no read of the registry's own epoch — the epoch-sum
-  `getSnapshot` is untouched, and an unrelated registration moves no
-  boundary's snapshot. rf2-2rtt6.44 records the costing that rejected
-  the alternative.
+  `registrar/add-registration-hook!` ([[sub-registered!]]), narrowed to
+  first-time `:sub` registrations and to the cells that hold the id being
+  registered. It costs no React hook and no per-boundary object.
+
+  The gap half rides the same hook, one line earlier, as a `vswap!` on
+  [[registry-epoch]] — so the arm reads a registry count it keeps itself
+  and `observation/registry-epoch*` stays `^:private`. **What
+  rf2-2rtt6.44 rejected is still rejected**: that was a registry term in
+  every key's *live* contribution to [[make-snapshot]], which moves every
+  mounted boundary in the application on every `reg-sub`. This term is in
+  the basis, which [[make-snapshot]] reads live for staged keys only, so
+  an unrelated registration still moves no *mounted* boundary's
+  snapshot — the invariant
+  `a-first-registration-of-an-id-no-cell-holds-disturbs-nothing` states,
+  and the one that distinguishes the two options.
 
   ## What is deliberately NOT here (the hard fences)
 
@@ -468,18 +495,32 @@
 (defonce ^:private !generation (volatile! 0))
 (defonce ^:private !deferred (volatile! #{}))
 (defonce ^:private !watch-counter (volatile! 0))
+(defonce ^:private !registry-epoch (volatile! 0))
 
 (defn generation
   "The commit generation. Bumped once per flush that moved something."
   []
   @!generation)
 
+(defn registry-epoch
+  "**The arm's own count of `:sub` registrations** — first-time and
+  replacement alike — and the third term of [[commit-basis]].
+
+  It is the arm's rather than the substrate's on purpose.
+  `observation/registry-epoch*` counts exactly this and is `^:private`;
+  the arm already installs a registration hook for [[first-registration!]],
+  so the counter is a `vswap!` on a hook that runs anyway rather than a
+  new public reader on a production namespace. Monotone, like both other
+  terms."
+  []
+  @!registry-epoch)
+
 (defn commit-basis
   "**The number both invariant-5 windows are judged against** — this
-  runtime's flush [[generation]] plus `frame`'s own physical-install
+  runtime's flush [[generation]], plus `frame`'s own physical-install
   epoch (`re-frame.frame/frame-commit-epoch`, the substrate's
   observation-port evidence counter, bumped once per frame-state install
-  at both write chokepoints).
+  at both write chokepoints), plus the arm's [[registry-epoch]].
 
   The generation alone cannot carry it, and the reason is structural
   rather than a matter of degree: the generation moves only through
@@ -488,29 +529,52 @@
   can move without moving it. The frame's install epoch has no such
   dependency — it is a counter read, not a watch — which is exactly why
   Spec 006's observation port uses it to ask whether durable state moved
-  in the render→commit gap.
+  in the render→commit gap. And neither of them is a registry write, so
+  the third term is what carries a `reg-sub` landing in that gap.
 
-  Both terms are monotone within a frame incarnation, so the basis is,
-  and so is any sum of bases and cell epochs. Deliberately
+  All three terms are monotone within a frame incarnation, so the basis
+  is, and so is any sum of bases and cell epochs. Deliberately
   install-counting rather than `=`-counting: a value-equal install still
   advances it, which costs at most one redundant re-render and cannot
   cost a missed one. Pure read; allocates nothing.
 
-  Silent on two axes, and permanently so — no `:sub` registration is a
-  frame-state install, and a same-id frame reincarnation RESTARTS
-  `frame-commit-epoch` at 0 (measured: A's epoch and B's are both 1, so
-  the basis TIES across the reincarnation), which is the case the
-  observation port needs its `:node-key` field for. **Neither axis is
-  this number's to carry**, and rf2-2rtt6.44 settled why rather than
-  extending it: every one of those transitions leaves the cell holding a
-  reaction that can no longer answer for its key, so a moved number
-  would only buy a re-render that read back through the same dead
-  reference. [[invalidate-cell!]] carries all three, reached from the
-  substrate's own disposal for the two that dispose (a re-registration,
-  a frame teardown) and from [[first-registration!]] for the one that
-  does not."
+  ## Why the registry term costs the mounted case nothing (rf2-2rtt6.50)
+
+  This is the term rf2-2rtt6.44 costed and declined, and **it is not the
+  thing that was declined.** What that costing priced was a registry term
+  in every key's *live* contribution to [[make-snapshot]] — which would
+  have moved every mounted boundary's number on every `reg-sub` in the
+  application, and bought a re-render that read straight back through a
+  dead cell. This term is in the basis, and the basis is read live by
+  exactly one branch of that sum: **a key no cell holds yet**. A held key
+  contributes its cell's *frozen* stamp, which no registration touches.
+
+  So the reach of the term is precisely the set of keys inside a
+  render→commit gap, which is the set of keys that have the defect. A
+  mounted boundary holds a reference to every key it reads, so it has no
+  staged term at all and an unrelated `reg-sub` moves its snapshot by
+  zero — `a-first-registration-of-an-id-no-cell-holds-disturbs-nothing`
+  asserts exactly that, and it is unchanged by this term, which is the
+  cleanest available proof that the two options are different options.
+
+  Conservative in the safe direction and only there, exactly as the
+  install term already is: a boundary mounting as an *unrelated* module
+  registers its subs re-renders once for nothing. A MISSED move would be
+  the P0, and adding a monotone term to a monotone sum cannot cause one.
+
+  Still silent on one axis, and permanently so: a same-id frame
+  reincarnation RESTARTS `frame-commit-epoch` at 0 (measured: A's epoch
+  and B's are both 1, so the basis TIES across the reincarnation), which
+  is the case the observation port needs its `:node-key` field for. That
+  axis is not this number's to carry, and rf2-2rtt6.44 settled why: the
+  transition leaves the cell holding a reaction that can no longer answer
+  for its key, so a moved number would only buy a re-render that read
+  back through the same dead reference. [[invalidate-cell!]] carries the
+  *held*-cell half of all three axes; this term carries the *staged* half
+  of the registry one, where there is no dead reference to read back
+  through because the commit acquires against the live registration."
   [frame-kw]
-  (+ @!generation (frame/frame-commit-epoch frame-kw)))
+  (+ @!generation (frame/frame-commit-epoch frame-kw) @!registry-epoch))
 
 (declare flush!)
 
@@ -660,7 +724,12 @@
   The scan is `@!cells`, on first-time `:sub` registrations only. Those
   are namespace-load and lazy-module-load events — an HMR save
   re-registers, so its ids take the `:was`-non-nil branch and never get
-  here — and at namespace load there are no cells to scan."
+  here — and at namespace load there are no cells to scan.
+
+  **It is the held-cell half of the axis, and only that half.** A
+  boundary inside the render→commit gap has no cell for the id, so this
+  scan reaches nothing on its behalf; the [[registry-epoch]] term of
+  [[commit-basis]] carries that half instead. rf2-2rtt6.50."
   [{:keys [kind id was]}]
   (when (and (= :sub kind) (nil? was))
     ;; `first`, not `(nth … 0)`: a registrar hook's throw is SWALLOWED by
@@ -675,15 +744,38 @@
         (invalidate-cell! cell))))
   nil)
 
+(defn- sub-registered!
+  "The arm's whole listening post on the registry, and the two halves of
+  the registry axis in one place because they are one event.
+
+  **Bump then scan.** [[registry-epoch]] counts every `:sub` registration,
+  first-time or replacement, because both are the same defect in the
+  render→commit gap: the body read one computation and the commit
+  acquires against another, and neither the flush generation nor the
+  frame's install epoch moves for either. [[first-registration!]] then
+  repairs the cells that already hold the id, which is the half a
+  replacement reaches by its own disposal and a first registration
+  reaches by no route at all.
+
+  The bump is before the scan deliberately. [[invalidate-cell!]]'s
+  synchronous phase drops a reaction reference, and a render that races
+  it must not see an epoch from before the registration it is about to
+  read against."
+  [{:keys [kind] :as registration}]
+  (when (= :sub kind)
+    (vswap! !registry-epoch inc)
+    (first-registration! registration))
+  nil)
+
 ;; Arm it once per process, at load. `defonce` is the arming, so the var
 ;; exists for its side effect and is deliberately never read — the hook
 ;; vector is the only thing that holds the fn. The hook is the substrate's
 ;; own extension point and the arm installs nothing else global; it costs
-;; a keyword compare and a nil check on every registration of any kind,
-;; and the scan above only on a first-time `:sub`.
+;; a keyword compare on every registration of any kind, a `vswap!` on
+;; every `:sub` one, and the scan above only on a first-time `:sub`.
 #_:clj-kondo/ignore
 (defonce ^:private first-registration-armed
-  (do (registrar/add-registration-hook! first-registration!) true))
+  (do (registrar/add-registration-hook! sub-registered!) true))
 
 (defn- acquire-cell!
   "**Commit-phase only.** Take (building if necessary) the durable
@@ -1112,7 +1204,10 @@
   That one term is what reaches the render→commit gap. A staged key
   contributes `basis@render` while the boundary renders and, once the
   commit has created its cell, `basis@commit` — the same number when
-  nothing installed in between and a different one when something did.
+  nothing moved in between and a different one when something did. It is
+  a *live* [[commit-basis]] read, which is why the basis's registry term
+  reaches a `reg-sub` in the gap (rf2-2rtt6.50) and why a held key —
+  whose contribution is the cell's frozen stamp — is untouched by one.
   React re-reads this closure immediately after `subscribe` returns
   (`updateStoreInstance` is the next passive effect) and compares
   against the value **that fiber** captured at render, so the tear check
@@ -1499,6 +1594,7 @@
   (vreset! !deferred #{})
   (vreset! !batching false)
   (vreset! !generation 0)
+  (vreset! !registry-epoch 0)
   (set! (.-entry rstate) nil)
   (set! (.-frame rstate) nil)
   (set! (.-probe rstate) nil)

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/staged_read_tear_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/staged_read_tear_cljs_test.cljs
@@ -49,14 +49,17 @@
 
       commit-basis(frame) = the runtime's flush generation
                           + `re-frame.frame/frame-commit-epoch`
+                          + the runtime's registry epoch
 
   The second term is the substrate's own observation-port evidence
   counter — one bump per physical frame-state install, at both write
   chokepoints — and Spec 006 already uses it to answer exactly this
-  question without watching anything. So a staged key's number is
-  `basis@render` while the boundary renders and `basis@commit` once the
-  commit acquires it: equal when nothing installed in the gap, different
-  when something did. React stores each fiber's render-time snapshot and
+  question without watching anything. The third counts `:sub`
+  registrations, which are neither a flush nor an install (rf2-2rtt6.50);
+  this file's rows are the version axis and do not exercise it. So a
+  staged key's number is `basis@render` while the boundary renders and
+  `basis@commit` once the commit acquires it: equal when nothing moved in
+  the gap, different when something did. React stores each fiber's render-time snapshot and
   re-reads `getSnapshot` immediately after `subscribe` returns
   (`updateStoreInstance` is the very next passive effect), so the
   comparison is per boundary, is one number, and holds **no record of

--- a/implementation/freehand/test/re_frame/bench/hicasso/generation_fence_coverage_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/generation_fence_coverage_cljs_test.cljs
@@ -18,12 +18,15 @@
   `arm1/generation_fence_dom_cljs_test`. Keeping a second copy here would
   give one assertion two homes, so this file no longer carries them.
 
-  What is left is the axis nothing closed, and it is the whole of this
-  file: **a `:sub` re-registration moves neither term of the basis.**
+  What is left is the registry axis, and it is the whole of this file:
+  **the two terms rf2-2rtt6.42 built cannot see a `:sub` registration, so
+  the basis carries a third one that can — and it reaches a staged key
+  without touching a held one.**
 
-  ## Why the basis cannot see it
+  ## Why the first two terms cannot see it
 
       commit-basis(frame) = flush generation + frame-commit-epoch(frame)
+                          + registry-epoch
 
   The first term moves only through `flush!`, whose only caller is
   `mark-dirty!`, whose only caller is the per-cell value-change watch
@@ -32,9 +35,25 @@
   reaction, so it reaches none of them. The second term is bumped once
   per physical frame-state install at the substrate's two write
   chokepoints — and a registry write is not a frame-state install. So
-  both terms sit still, and React's post-`subscribe` `getSnapshot`
-  re-check is equally blind: the number is the sum of the same epochs it
-  was before.
+  both of them sit still, and until rf2-2rtt6.50 React's post-`subscribe`
+  `getSnapshot` re-check sat still with them.
+
+  ## What the third term reaches, and what it deliberately does not
+
+  `getSnapshot` reads the basis **live** for a key no cell holds, and
+  reads a cell's **frozen** stamp for one that is held. The third term
+  therefore reaches exactly one situation: a boundary inside the
+  render→commit gap, whose body read one computation while the commit is
+  about to acquire another. A mounted boundary's number does not move at
+  all, and the row below asserts both halves one line apart.
+
+  That is what makes this not the term rf2-2rtt6.44 costed and declined.
+  That one sat in every key's live contribution, so every mounted
+  boundary in the application re-rendered on every `reg-sub` — and read
+  back through a cell the re-registration had just made deaf, which is
+  why it bought nothing. In the gap there is no cell to be deaf: the
+  commit acquires against the registration that is live then, so the one
+  extra render is the whole repair. rf2-2rtt6.50.
 
   The `:node-key` axis is silent for the same reason and is stated rather
   than staged, because a second row would re-prove this one's arithmetic
@@ -43,45 +62,44 @@
   RESTARTS at 0 across one, which is precisely why Spec 006's observation
   port carries `:node-key` as a third field.
 
-  ## The axes are closed; this arithmetic is not what closed them
+  ## The held-cell half is closed by events, and should stay that way
 
-  **rf2-2rtt6.44 settled both, and the rows below survive it unchanged** —
-  which is the point of keeping this file. The commit basis is still blind
-  to a re-registration, still blind to a reincarnation, and *should be*:
-  the costing found that a registry term would have bought nothing. Every
-  one of those events leaves the arm's cell holding a reaction that can no
-  longer answer for its key, so the cell is deaf from that instant; the
-  extra render a moved number scheduled would have read straight back
-  through it. What closes them is `arm1.runtime/invalidate-cell!`, costing
-  nothing in this arithmetic — so `observation/registry-epoch*` stayed
-  `^:private` and no substrate reader was added.
+  **rf2-2rtt6.44 settled the held-cell half of all three axes, and this
+  arithmetic is still not what closes it** — which is the point of keeping
+  this file. Where a boundary already holds a cell, the commit basis is
+  still blind to a re-registration, still blind to a reincarnation, and
+  *should be*: the costing found that a term would have bought nothing.
+  Each of those events leaves the arm's cell holding a reaction that can
+  no longer answer for its key, so the cell is deaf from that instant, and
+  the extra render a moved number scheduled would have read straight back
+  through it. What closes that half is `arm1.runtime/invalidate-cell!`,
+  costing nothing in this arithmetic — so `observation/registry-epoch*`
+  stayed `^:private` and no substrate reader was added, then or now: the
+  arm counts registrations on the registration hook it already installs.
   `arm1/disposed-cell-cljs-test` is the measurement for the two
   transitions that reach it as a *disposal*, armed per unique key: a
   re-registration and a frame teardown.
 
-  The registry axis has one more transition, and it is the one this
-  arithmetic is least able to help with: a **first** registration. It
-  disposes nothing — `registrar/add-replacement-hook!` fires only when a
-  previous handler existed — and it moves neither term of the basis for
-  the same reason a re-registration does not. The arm hears it from
+  The registry axis has one more transition, and it is the one no disposal
+  announces: a **first** registration. `registrar/add-replacement-hook!`
+  fires only when a previous handler existed, so the arm hears it from
   `registrar/add-registration-hook!` instead
-  (`arm1.runtime/first-registration!`), still off this arithmetic and
-  still without a registry reader.
-  `arm1/first-registration-cljs-test` is that measurement. All three
-  failures pinned and mutation-proved.
+  (`arm1.runtime/first-registration!`) for the held-cell half, and from
+  the basis's third term for the gap half.
+  `arm1/first-registration-cljs-test` is that measurement.
 
   These rows are therefore a **standing statement of scope**: this number
-  answers the version axis and only the version axis.
+  answers the version axis, and the registry axis for staged keys only.
 
   ## The row carries its own control, and needs to
 
-  The assertion is that a number does NOT move, and a still number is
-  trivially still on a broken fixture. So the row first makes a real
-  frame-state install and watches the basis and the snapshot move — same
-  frame, same boundary, same read set, same instruments, one line apart —
-  and only then re-registers and reads them still. Without the positive
-  half on the board this row would pass against a runtime that had no
-  counters at all.
+  Two of its four assertions are that a number does NOT move, and a still
+  number is trivially still on a broken fixture. So the row first makes a
+  real frame-state install and watches the basis and the snapshot move —
+  same frame, same boundary, same read set, same instruments, one line
+  apart — and only then re-registers. Without the positive half on the
+  board this row would pass against a runtime that had no counters at
+  all.
 
   ## Everything here runs against Arm 1's own runtime
 
@@ -129,29 +147,36 @@
   (fn [_] (let [v (rt/sub q)] (vreset! seen v) [:li (str v)])))
 
 ;; ---------------------------------------------------------------------------
-;; The registry-epoch axis has no counterpart in the commit basis
+;; The registry-epoch axis reaches a staged key and not a held one
 ;; ---------------------------------------------------------------------------
 
-(deftest the-commit-basis-has-no-registry-epoch-axis
-  (testing "The predecessor's third field, and the one rf2-2rtt6.42 did not
-            close. `obs/read` reports the registry epoch on every live node
-            and `moved?` compares it, so a handler re-registration between a
-            render and its commit corrects before paint there.
+(deftest the-commit-basis-registry-axis-reaches-a-staged-key-and-not-a-held-one
+  (testing "The predecessor's third field. `obs/read` reports the registry
+            epoch on every live node and `moved?` compares it, so a handler
+            re-registration between a render and its commit corrects before
+            paint there.
 
-            Here there is nothing to compare it against. A re-registration
+            The basis carries this axis too, since rf2-2rtt6.50 — but it
+            reaches only the half that needs it, and that asymmetry is the
+            row. Neither of the other two terms can see a registration: it
             is not a frame-state install, so `frame-commit-epoch` does not
-            move; and it is not a value change on an acquired reaction, so
-            it cannot reach `mark-dirty!` and the flush generation does not
-            move either. Both terms of the basis sit still, and the epoch
-            sum React re-checks sits still with them.
+            move, and it is not a value change on an acquired reaction, so
+            it never reaches `mark-dirty!` and the flush generation does not
+            move either. The third term, `registry-epoch`, moves.
 
-            That is correct and permanent, not a gap awaiting a term:
-            rf2-2rtt6.44 closed this axis (and the `:node-key` axis the
-            same argument covers) off the substrate's own events instead
-            — the reaction's disposal for a re-registration and a frame
-            teardown, the registration itself for a first `reg-sub`,
-            which disposes nothing — leaving this arithmetic exactly as
-            it stands."
+            **What that does and does not reach.** `getSnapshot` reads the
+            basis LIVE for a key no cell holds, and reads a cell's FROZEN
+            stamp for one that is held. So a boundary in the render→commit
+            gap sees the number move and re-renders through a cell the
+            commit acquired against the live registration; a mounted
+            boundary's number does not move at all. That is why this is not
+            the term rf2-2rtt6.44 declined — that one sat in every key's
+            live contribution and woke every mounted boundary in the
+            application, to read back through a cell the re-registration had
+            just made deaf. The mounted case is still repaired by the
+            substrate's own events (`arm1.runtime/invalidate-cell!`, off the
+            reaction's disposal), and this row asserts that its snapshot
+            stays exactly where it was."
     (rf/reg-sub (first q) (fn [db _] (:v db)))
     (let [seen (volatile! nil)
           f    (make-frame! ::registry {:v 1})]
@@ -174,18 +199,34 @@
                  too — this is what a MOVE looks like on these instruments")))
 
         (testing "and the axis: the same query, a different computation"
-          (let [basis      (rt/commit-basis f)
-                snapshot   (rt/snapshot-of entry)
-                generation (rt/generation)]
+          ;; A SECOND boundary, rendered and deliberately NOT committed, so
+          ;; its key is staged for the duration of the re-registration. Its
+          ;; own frame, because the assertion below is that this frame's
+          ;; mounted boundary is untouched and a shared frame would let one
+          ;; claim borrow the other's stillness.
+          (let [staged-f     (make-frame! ::registry-staged {:v 1})
+                _            (rt/render-body staged-f (reader (volatile! nil)) {})
+                staged-entry (rt/last-reads)
+                staged-snap  (rt/snapshot-of staged-entry)
+                basis        (rt/commit-basis f)
+                snapshot     (rt/snapshot-of entry)
+                generation   (rt/generation)]
             (rf/reg-sub (first q) (fn [db _] (* 10 (:v db))))
             (is (= generation (rt/generation))
                 "the flush generation did not move — a re-registration is not
                  a value change on an acquired reaction, so it never reaches
                  `mark-dirty!`")
-            (is (= basis (rt/commit-basis f))
-                "and neither did the basis — a registry write is not a
-                 frame-state install, so `frame-commit-epoch` is untouched")
+            (is (> (rt/commit-basis f) basis)
+                "but the basis did: `registry-epoch` is its third term, and a
+                 registration is the one thing that moves it (rf2-2rtt6.50)")
             (is (= snapshot (rt/snapshot-of entry))
-                "so React's post-`subscribe` `getSnapshot` re-check is blind
-                 to it: the number is exactly the number it was")))
+                "and the MOUNTED boundary's number is still exactly the
+                 number it was — its key is held, so its contribution is the
+                 cell's frozen stamp and not a live basis read. This is the
+                 assertion that separates this term from the one
+                 rf2-2rtt6.44 declined")
+            (is (not= staged-snap (rt/snapshot-of staged-entry))
+                "while the STAGED boundary's number moved — its key has no
+                 cell, so it contributes the basis live, and React's
+                 post-`subscribe` re-check will see the tear")))
         (release!)))))


### PR DESCRIPTION
Closes rf2-2rtt6.50 (EP-0038, Arm 1).

## What the bead asked for, and why this is a fix rather than a ruling

The bead is titled "pinned, not repaired" and ends *"Neither is obviously
right, so this wants a ruling, not a worker."* It costed two ways to close the
gap and rejected both:

- **(a)** a registry term *"in every key's contribution to `getSnapshot`"* — the
  option rf2-2rtt6.44 costed and declined, at up to 15 whole-tree concurrent-render
  invalidations per HMR save;
- **(b)** recording what a read returned — which Arm 1 exists to forbid
  ("no commit-phase deref"; `getSnapshot` "holds no record of what any read returned").

**(b) is genuinely closed at this arm's fences.** (a) is not the option that was
available, and that is the whole of this change.

What rf2-2rtt6.44 priced was a registry term in every key's **live** contribution
to `make-snapshot`. But `make-snapshot` reads live in exactly one branch:

```clj
(if-some [c (get cells k)]
  (+ acc (.-epoch c))                ; held   -> the cell's FROZEN stamp
  (+ acc (commit-basis (nth k 0))))  ; staged -> a LIVE basis read
```

A held key contributes a stamp that no registration touches; only a **staged**
key — one inside a render->commit gap — reads the basis live. So putting the term
in `commit-basis` reaches precisely the keys that have the defect and moves no
mounted boundary's snapshot at all. The HMR costing does not apply: an HMR save
is a *re*-registration, which reaches mounted boundaries through `invalidate-cell!`
with their cells still in `!cells` and their stamps still frozen.

The cleanest proof that the two options are different options is that the file's
own bill row, `a-first-registration-of-an-id-no-cell-holds-disturbs-nothing`,
asserts a mounted boundary's snapshot does not move on an unrelated `reg-sub` —
and it is **unchanged and still green** under this term.

## The change

`commit-basis` gains a third term, the arm's own count of `:sub` registrations,
bumped on the registration hook the arm *already installs* for
`first-registration!` (`sub-registered!`). `observation/registry-epoch*` stays
`^:private` and no substrate namespace is touched.

Counted for first-time **and** replacement registrations, because both are the
same defect in the gap: the body read one computation and the commit acquires
against another, and neither the flush generation nor the frame's install epoch
moves for either.

Failure direction is safe by construction: adding a monotone term to a monotone
sum can only cause **extra** renders, never a missed one (a missed move is the P0).
The over-approximation — a boundary mounting as an unrelated module registers its
subs re-renders once — is the same class the install term already accepts.

Still silent on the `:node-key` axis, deliberately: the basis TIES across a
same-id reincarnation, and that half is `invalidate-cell!`'s.

## The pin, flipped

| | |
|---|---|
| old | `deliberately-a-first-registration-in-the-render-commit-gap-moves-no-snapshot` |
| new | `a-first-registration-in-the-render-commit-gap-moves-the-snapshot` |

Flipped and renamed in the same commit as the fix, never deleted and never
loosened to accept both outcomes. Two further renames follow the claim:

- `the-commit-basis-has-no-registry-epoch-axis` ->
  `the-commit-basis-registry-axis-reaches-a-staged-key-and-not-a-held-one`
  (now carries both halves one line apart: the mounted boundary's snapshot still
  does not move, a staged one's does).
- `closing-the-first-registration-cost-no-hook-and-nothing-in-the-snapshot` ->
  `...-and-no-per-boundary-object` — the snapshot arithmetic *did* gain a term, so
  the old name was no longer true.

## The witness, taken the way the browser runs it

The node row asserts on `snapshot-of`, which is a faithful stand-in for React's
`checkIfSnapshotChanged` but is still a model of React. Added a real-Chromium
counterpart, `a-first-registration-landing-in-the-gap-is-corrected-in-the-dom`,
staged exactly as rf2-2rtt6.42's Case 3 stages its own — a sibling boundary
registering during the same render pass, after the reading boundary's fence has
closed, so nothing has to guess when React runs a passive effect. No `act`, and no
`flushSync` beyond the mount door Case 3 already uses.

`hits` staying zero is load-bearing in the node row: the correction is React's
tear check, not a notification, and a `reg-sub` reaches `flush!` by no route.

## Mutation proof

Mutation: delete `@!registry-epoch` from `commit-basis` (one term, nothing else).

- `npm run test:cljs` -> **exit 1**, 3 assertions in exactly 2 named rows and
  nothing else: `a-first-registration-in-the-render-commit-gap-moves-the-snapshot`,
  and `the-commit-basis-registry-axis-reaches-a-staged-key-and-not-a-held-one` (x2).
- `npm run test:browser` -> **exit 1**, exactly ONE named failure:
  `a-first-registration-landing-in-the-gap-is-corrected-in-the-dom`, with
  `actual: (not (= ":arrived" ""))` — `""` is `(str nil)`, i.e. the delayed paint
  itself, observed in real Chromium.

Reverted with `git checkout --`; `git status --porcelain` confirmed byte-identical
to the commit both times.

## Fences

- **Hook budget untouched.** No React hook added — a registrar hook is not a React
  hook and a counter is not a hook. `arm1_hook_ledger_dom_cljs_test` still counts 2
  at React's dispatcher; `closing-the-first-registration-cost-...` still asserts
  `[:use-context/frame :use-sync-external-store/subscription-epoch]`.
- `subscribe` still closes over the read set alone; the term lives in the basis,
  not on an entry.
- No per-boundary object: `retained-inventory`'s `:absent` set is unchanged.
- Surface B only. Nothing under `implementation/*/src` touched — the whole diff is
  the bench/test tree (HD-017).
- `docs/design/hicasso/hd-002-adjudication.md` §6.1 deliberately **not** edited: it
  is a dated adjudication record already superseded by rf2-2rtt6.42/.44 without
  rewrite, and this change follows that precedent rather than re-litigating it.

## Quality gates

Run in the worker worktree to completion, unpiped, each logged to a worktree-local
path with the exit code captured explicitly.

| gate | exit | result |
|---|---|---|
| `sh scripts/test-fast-pr.sh` (final tree) | **0** | full spine green |
| `npm run test:browser` (final tree) | **0** | 1025 tests / 6337 assertions / 0 failures / 0 errors |
| `npm run test:cljs` (inside the spine) | **0** | 12424 tests / 62032 assertions / 0 failures / 0 errors |
| JVM `implementation/core` (inside the spine) | **0** | 2210 tests / 11506 assertions |
| JVM `implementation/freehand` (inside the spine) | **0** | 1288 tests / 8857 assertions |
| per-ns bundle isolation (inside the spine) | **0** | all 17 namespaces pass standalone |

The browser count moved 1024 -> 1025 and assertions 6335 -> 6337, which is the new
Chromium row and its two assertions actually running rather than silently
skipping; the node count moved 12423 -> 12424 for the same row's `skip!` branch.

Transitive surface: nothing `:require`s these test namespaces, and the only
non-test file changed is `arm1/runtime.cljs`, whose dependents are the arm1 and
shared hicasso bench suites — all covered by `test:cljs` and `test:browser` above.
