### PR TITLE
docs(hicasso): teach the amended HD-006 and HD-002 (rf2-3jw04, rf2-n4mad, rf2-x5dvk)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,16 @@ cp -rf source dest          # NOT: cp -r source dest
 - `apt-get` - use `-y` flag
 - `brew` - use `HOMEBREW_NO_AUTO_UPDATE=1` env var
 
+## Docs Gates — What Covers `docs/design/**`
+
+`mkdocs build --strict` does **not** cover `docs/design/**`. `mkdocs.yml`'s
+`exclude_docs` block deliberately keeps `design/freehand/` and `design/hicasso/`
+out of the site, so never nominate it as the gate for an edit confined to that
+tree — it will exit 0 having verified nothing. `scripts/check_doc_slugs.py` does
+cover it: markdown link targets and heading anchors, in the fast-PR spine and in
+`docs.yml`. Nothing checks tables, rendering, or nav, so verify anchors and table
+column counts by hand and say so in the PR body.
+
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
 ## Beads Issue Tracker
 

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -376,8 +376,10 @@ the fragment spelling is `[:<> …]`, and a view may return `nil`, one root, or 
 fragment; `:ref` is legal on native tags and `defhost`/`[:>]` crossings
 (callback refs only) and is **not** a v0 surface on Hicasso views (use ids).
 **Reopens** if the dogfood shows the vector/call distinction confusing — the
-fallback is a lint, not a third convention. Note: helper-donated reads within
-this model are collector-contingent (HD-002's stated consequence).
+fallback is a lint, not a third convention. Note: helper-donated reads are
+settled rather than contingent. HD-002's ruling makes the ambient collector the
+one product read surface, so a `sub` performed inside a helper is an ordinary
+read that lands in the calling boundary's window.
 
 ## HD-017 — Code residence and graduation
 

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -173,21 +173,25 @@ it does not.
   buys you: a *freshly allocated* map or vector is not a problem. Two structurally
   equal persistent values are one cache key, so rebuilding `{:scope :all}` inside the
   query on every render hits the same entry every time, and you do not have to hoist
-  it into a `def` or memoize it to be safe. What thrashes the index is an argument
-  whose **value** changes when nothing meaningful did — a re-sorted seq, a timestamp
-  folded into the query, a JS object or a function, which carry reference identity
-  rather than value identity. Documented, programmer-trusted, not policed.
+  it into a `def` or memoize it to be safe. Sorting the same items into the same order
+  is the same story — `=` compares sequential values by their contents, so a freshly
+  sorted seq is the key the last one was, at the cost of walking it. Two things do
+  thrash the index. An argument whose **value** genuinely moved is a different key, and
+  correctly so: a timestamp folded into the query, or a sort order that really changed.
+  And an argument carrying **reference** identity rather than value identity — a
+  function, a JS object or array, a host object — is unequal to itself between renders,
+  because for those `=` is identity. Documented, programmer-trusted, not policed.
 
 ## Troubleshooting
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | A boundary doesn't re-render even though something on screen should have changed | Its props still compare `=` to last render and it made no read of its own that moved — the default bail-out (HD-028) is doing exactly what it's for | Read the changing value with `sub` inside the boundary that displays it, or thread it down as a prop so the value actually differs there |
-| A boundary re-renders every time though its props look unchanged | A prop carries reference identity rather than value identity — an inline function literal, a JS object, a freshly re-sorted seq — so `=` correctly says unequal | Hoist the function or stabilize the value; two structurally equal persistent values are `=`, a fresh closure or JS object is not |
+| A boundary re-renders every time though its props look unchanged | A prop carries reference identity rather than value identity — an inline function literal, a JS object or array, a host object — so `=` correctly says unequal | Hoist the function, or convert the value to a persistent one. Freshness is not the problem: two structurally equal persistent values are `=` however recently they were built |
 | One cell changes and 300 boundaries re-render | The read lives too high in the tree | Push the read down into the boundary that displays it |
 | One value changes and a whole subtree re-renders with it | The value is read in an ancestor and passed down as a prop. Nothing is *lost* — the reading ancestor re-renders with the new value, and every boundary the value actually reaches has unequal props at that hop, so the default bail-out (HD-028) does not catch it there. Coarse invalidation, not missed invalidation | Read at the point of use, so the boundary that displays the value is the boundary that invalidates |
 | A read after the render throws, naming the query | A handler closure, a stashed lazy seq, or a `delay` deferred a `sub` past the render | Read during the render and close over the value; the loud error is the alternative to a silently frozen edge |
-| Index thrash, subscriptions constantly re-created | Query args that are not *value*-stable — a re-sorted seq, a folded-in timestamp, a JS object or a function | Allocation is fine; two equal persistent values are one key. Make the args equal under `=` between renders |
+| Index thrash, subscriptions constantly re-created | Query args that are not *value*-stable — a folded-in timestamp, a sort order that really changed, or a JS object or function carrying reference identity | Allocation is fine; two equal persistent values are one key however freshly built. Make the args equal under `=` between renders |
 | A body's side effect fires twice | StrictMode double-invoke | Bodies are pure; move the effect out |
 
 ## When not to use a boundary


### PR DESCRIPTION
Three beads on one surface. All three had already had their bulk landed by earlier PRs and were **reopened by audit** for a narrow remainder — so this is a small, precise change, not the eight-page sweep the titles suggest.

## The two decisions, once

**HD-006, as amended by HD-028 (2026-08-02):** a value-equality bail-out is now the **default** at every minted Hicasso boundary — CLJS `=` over the complete `rfProps` value via one stable codec-level memo wrapper — so a child does **not** re-render merely because its parent did, though the boundary's own subscription and context invalidation still outranks the comparator.

**HD-002, as superseded by operator ruling (2026-07-31):** there is **one** product read surface, the ambient collector `sub` as a plain call legal anywhere in the body; grouped `use-subs` sits below the usability bar and is kept only as the comparator the collector is measured against, and the correctness gates were not waived.

The pages and the decision record did **not** contradict each other. Everything below follows the record.

## What actually changed

**rf2-3jw04 (P1)** — `43dcd2440a` (PR #7394) already reconciled the guide with HD-028; its audit reopened it for a factual error in the rows it added. Three sites in `docs/design/hicasso/draft-guide/02-views-and-reads.md` grouped *"a freshly re-sorted seq"* with inline functions and JS objects as values carrying **reference** identity. That is wrong. The comparator is literally `(= prev-rfProps next-rfProps)`, and sequential values compare by **contents** — sorting the same items into the same order yields an `=` seq however freshly it was allocated. The three sites (the sub-key identity rule, the "props look unchanged" row, and the "Index thrash" row) now separate the two real mechanisms: a value that genuinely moved (a timestamp, a sort order that actually changed) versus one carrying reference identity (a function, a JS object or array, a host object). They also say plainly that comparing a sequential value may walk and realize it — a real cost — but that freshness alone never defeats memoization or subscription-key equality.

**rf2-n4mad (P3)** — `fe089f1769` (PR #7398) swept the five named pages; its audit found one live site outside them. `decisions.md` HD-016 still closed with *"helper-donated reads within this model are collector-contingent (HD-002's stated consequence)."* There is no contingency left, and HD-016's own ruling two paragraphs above already describes the settled behaviour. Corrected in place.

I re-swept the whole tree from scratch rather than trusting the bead's list, per its instruction (`collector-contingent`, `challenger`, "on a collector win", grouped-as-default, `use-subs`). **No other live site.** The remaining hits are all inside `decisions.md`'s HD-002 **SUPERSEDED** block, which deliberately preserves the overturned position, and in `hd-002-adjudication.md`, which the operator ruled stands as written.

**rf2-x5dvk (P2)** — still real, but only its last item. `81ce0ba455` (PR #7318) put the exclusion warning in `CLAUDE.md` and the dispatch template; `AGENTS.md`, the instruction file Codex workers here are explicitly given, carried no docs-gate scope at all. Added a short pointer — not a copy of the CLAUDE paragraph. **No new checker and no new CI job**, per the operator's downward revision: `check_doc_slugs.py`'s `DEFAULT_ROOTS` already includes `docs`, and its exclude sets (`findings`, `node_modules`, `site`, `.git`, `.beads`, `ai`, `__pycache__`, `docs/spec`, `docs/migration`) do **not** exclude `docs/design/`, so the "cheap half" was already satisfied when the bead was written.

Files changed: `docs/design/hicasso/draft-guide/02-views-and-reads.md`, `docs/design/hicasso/decisions.md`, `AGENTS.md`.

**Deliberately not changed:** `docs/EP/EP-0038-…:73` still describes the draft guide as covering "the grouped default *and* the collector-contingent sketch". That is a record of what Wave 0 was commissioned to write, not a claim about the current surface — the same class as `hd-002-adjudication.md`, which the operator ruled stands as written. Rewriting it would edit programme history.

## Quality gates

```
python scripts/check_doc_slugs.py       EXIT=0
sh scripts/test-fast-pr.sh              EXIT=0   (PASS fast PR spine)
```

Both run in the foreground to completion, unpiped, captured to gitignored worktree-local `*.log`.

`mkdocs build --strict` ran inside the fast-PR spine and passed, but **it verified none of this change**. `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site, and `docs_dir: docs` means the repo-root `AGENTS.md` is not in the site either. It is reported here for completeness, not as the gate.

### Verified by hand, because nothing checks it

`check_doc_slugs.py` covers link targets and heading anchors. Nothing covers tables, rendering, or nav, so:

- **Anchors** — resolved every markdown link by hand across the three touched files, both directions. **18 outbound links from the touched files resolved, 0 dead. 36 inbound links to the touched files (swept across every tracked `.md` under `docs/`, plus `AGENTS.md` and `CLAUDE.md`) resolved, 0 dead.** This matters here because `06-theming.md:128` links into `02-views-and-reads.md#boundaries-memoize-by-default`; that heading is unchanged and the link still lands.
- **Table column counts** — `02-views-and-reads.md`: 3 tables (5 cols / 4 rows, 3 cols / 7 rows, 2 cols / 3 rows). `decisions.md`: 3 tables (2 cols / 5 rows, 4 cols / 4 rows, 4 cols / 2 rows). `AGENTS.md`: no tables. **Every body row matches its header's column count; 0 mismatches.** The two troubleshooting rows I rewrote are in the 3-column table and are still 3 columns.
- No fenced code block was touched, so the `docs/core/` digest pinning in `samples_coverage_jvm_test.clj` is not implicated — and it walks `docs/core/freehand` only, not the design tree.
