### PR TITLE
fix(skills): the form-action pattern must not teach a fail-open CSRF compare (rf2-1iclq)

### DIFF
--- a/scripts/check_skill_re_frame2_drift.py
+++ b/scripts/check_skill_re_frame2_drift.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """No-bead-id + verification-posture + launcher-canonical + machine-handler-
-recipe + managed-http-recipe drift guard for the re-frame2 (authoring) skill.
+recipe + managed-http-recipe + form-action-CSRF drift guard for the re-frame2
+(authoring) skill.
 
 `spec/design.md` is the single normative source for the skill's locked
 decisions (L1–L11), file structure, cardinal rules, and verification posture;
@@ -124,6 +125,33 @@ existing automated guards did not catch (the no-bead-id guard was scoped to
      006 lawfully carries bead ids and Reagent-owned `:contextType` prose that
      the leaf-wide rules would reject).
 
+  7. **The form-action pattern's two fail-open shapes, in copyable code.** The
+     skill's `patterns/form-action.md` shipped
+     `(and server? (not= (:csrf-token form-params) active-token))` as its
+     canonical CSRF arm — the exact shape `spec/Pattern-FormAction.md` lists as
+     an anti-pattern, because it fails **open** on a request with no session
+     (`active-token` is nil, a token-less POST supplies nil, nil = nil, and the
+     rejection arm never fires). It also typed the draft, the event `:schema`
+     and the handler's validation call with one token-requiring schema, which
+     400s every hydrated-client submission in the release build. Rules 1-6 all
+     exited 0 over both. Rule 7 checks the two invariants inside code fences, at
+     BOTH ends of the projection — the skill leaves and the spec page.
+
+WHAT THIS GUARD IS, AND IS NOT (read before trusting a green run):
+    Rules 1-6 are *retrospective token patterns*. Each encodes one regression
+    somebody already found, checked against a leaf's own text. Nothing in this
+    script relates a `patterns/*.md` leaf to the `spec/Pattern-*.md` page it
+    projects — there is no notion of an upstream here at all — so the general
+    class "the spec page moved and the leaf did not" is invisible BY
+    CONSTRUCTION, and a green run is not evidence that any leaf agrees with its
+    source. A full fence-equivalence check is not buildable either: the leaves
+    are deliberately abridged projections, not copies. What Rule 7 does instead
+    is promote a pattern's SECURITY-shaped invariants out of prose and check
+    them at both ends, so neither the leaf nor the spec can carry the
+    anti-pattern in code a reader would copy, and a regression at either end
+    fails the gate. That is a narrower claim than "skill and spec agree", and it
+    is the claim this guard makes.
+
 Scanned leaves (globbed, so a new leaf is covered automatically):
     SKILL.md, README.md, references/**/*.md, patterns/**/*.md,
     decision-trees/**/*.md.
@@ -221,6 +249,29 @@ VERIFY_PROSE_RE = re.compile(
 #     prose — the retained advanced-note mention — is allowed; only a
 #     copy-pasteable positive recipe is rejected.
 FENCE_RE = re.compile(r"^\s*```")
+
+
+def fenced_blocks(text: str):
+    """Yield (opening-fence-lineno, block-body) for every fenced code block.
+
+    Three rules read code fences rather than prose, because a fence is what a
+    reader copies: an inline single-backtick mention of a bad shape in a
+    labelled "not this" warning is legal teaching, and a fenced one is not.
+    """
+    in_block = False
+    block_start = 0
+    block_lines: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if FENCE_RE.match(line):
+            if not in_block:
+                in_block, block_start, block_lines = True, lineno, []
+            else:
+                yield block_start, "\n".join(block_lines)
+                in_block, block_lines = False, []
+        elif in_block:
+            block_lines.append(line)
+
+
 REG_EVENT_TOKEN_RE = re.compile(r"\breg-event\b")
 MAKE_MACHINE_HANDLER_TOKEN_RE = re.compile(r"\bmake-machine-handler\b")
 MACHINE_HANDLER_MSG = (
@@ -245,21 +296,10 @@ def machine_handler_recipe_problems(text: str) -> list[tuple[int, str]]:
     self-test can pass a fenced fixture directly; an inline single-backtick
     mention in prose never enters a fenced block, so it is allowed."""
     problems: list[tuple[int, str]] = []
-    in_block = False
-    block_start = 0
-    block_lines: list[str] = []
-    for lineno, line in enumerate(text.splitlines(), start=1):
-        if FENCE_RE.match(line):
-            if not in_block:
-                in_block, block_start, block_lines = True, lineno, []
-            else:
-                body = "\n".join(block_lines)
-                if (REG_EVENT_TOKEN_RE.search(body)
-                        and MAKE_MACHINE_HANDLER_TOKEN_RE.search(body)):
-                    problems.append((block_start, MACHINE_HANDLER_MSG))
-                in_block, block_lines = False, []
-        elif in_block:
-            block_lines.append(line)
+    for block_start, body in fenced_blocks(text):
+        if (REG_EVENT_TOKEN_RE.search(body)
+                and MAKE_MACHINE_HANDLER_TOKEN_RE.search(body)):
+            problems.append((block_start, MACHINE_HANDLER_MSG))
     return problems
 
 
@@ -353,24 +393,13 @@ def managed_http_recipe_problems(text: str) -> list[tuple[int, str]]:
     machine-form `:machine-id :rf.http/managed` spawn and the
     `[:rf.http/managed-abort …]` dispatch are deliberately not matched."""
     problems: list[tuple[int, str]] = []
-    in_block = False
-    block_start = 0
-    block_lines: list[str] = []
-    for lineno, line in enumerate(text.splitlines(), start=1):
-        if FENCE_RE.match(line):
-            if not in_block:
-                in_block, block_start, block_lines = True, lineno, []
-            else:
-                body = "\n".join(block_lines)
-                if (
-                    FX_MANAGED_RE.search(body)
-                    and HTTP_REQUEST_RE.search(body)
-                    and not HTTP_REPLY_TARGET_RE.search(body)
-                ):
-                    problems.append((block_start, MANAGED_HTTP_TARGETLESS_MSG))
-                in_block, block_lines = False, []
-        elif in_block:
-            block_lines.append(line)
+    for block_start, body in fenced_blocks(text):
+        if (
+            FX_MANAGED_RE.search(body)
+            and HTTP_REQUEST_RE.search(body)
+            and not HTTP_REPLY_TARGET_RE.search(body)
+        ):
+            problems.append((block_start, MANAGED_HTTP_TARGETLESS_MSG))
     return problems
 
 
@@ -754,6 +783,169 @@ def anchored_block_problems(label: str, block: str) -> list[str]:
     return problems
 
 
+# --- Rule 7 (rf2-1iclq): the form-action pattern's two FAIL-OPEN shapes,
+#     checked inside code fences at BOTH ends of the projection.
+#
+#     Rules 1-6 are retrospective token patterns over a leaf's own text, and
+#     none of them relates a leaf to the spec page it projects — see "WHAT THIS
+#     GUARD IS, AND IS NOT" in the module docstring. This rule does not close
+#     that gap in general (it cannot; the leaves are abridged, not copies). It
+#     closes it for the two shapes where being wrong is a security defect rather
+#     than a teaching wobble, and it checks them on the spec page too, so the
+#     source of truth cannot regress underneath the leaves either.
+#
+#     FENCED BLOCKS ONLY, and that is the semantics rather than a convenience:
+#     both pages teach the wrong shape deliberately, in inline prose, as an
+#     explicitly labelled "not this". A reader skimming for code to copy reads
+#     fences — so a fence must show only the correct form.
+#
+#     7a — FAIL-OPEN CSRF COMPARE. `(not= submitted active-token)` fails OPEN on
+#          a request with no session: `active-token` is nil, a token-less POST
+#          supplies nil, nil = nil, and the rejection arm never fires. Stated
+#          POSITIVELY rather than as a blacklist of bad spellings — any fenced
+#          CSRF equality comparison must carry a separate presence limb on the
+#          session token — so `(when-not (= …))` and `(if (= …))` are caught by
+#          the same rule, not by a second regex someone has to think to add.
+#     7b — THE TOKEN REQUIRED IN A FIELD SCHEMA. `[:csrf-token [:string …]]`
+#          with no `{:optional true}` props map rejects every hydrated-client
+#          submission in the RELEASE build (the handler's validation arm is
+#          ordinary code and does not elide, unlike the `:schema` tripwire), and
+#          makes the form slice's `:draft` unsatisfiable by construction, since
+#          the failure arm must never write a credential into a slice the page
+#          re-renders.
+#
+#     Beyond the globbed skill leaves, Rule 7 also reads the spec pattern page —
+#     the projection's source. Bounded to whole files that carry CSRF fences, in
+#     the spirit of the Rule 6c anchors.
+CSRF_EXTRA_FILES = (("spec", "Pattern-FormAction.md"),)
+
+CSRF_TOKEN_RE = re.compile(r"csrf", re.IGNORECASE)
+# A comparison head, as a form start.
+CSRF_COMPARE_HEAD_RE = re.compile(r"\(\s*(?:not=|=)\s")
+# How far past the comparison head a `csrf` mention still counts as the subject
+# of that comparison.
+CSRF_COMPARE_WINDOW = 140
+# The fail-CLOSED limb: the session token's PRESENCE, asserted separately from
+# the equality. `(some? active-token)` is the worked spelling; `nil?` and `seq`
+# are the same assertion written the other way round.
+CSRF_PRESENCE_LIMB_RE = re.compile(r"\bsome\?|\bnil\?|\(\s*seq\s")
+
+CSRF_FAIL_OPEN_MSG = (
+    "CSRF-FAIL-OPEN: this fenced block compares a CSRF token for equality but "
+    "carries no PRESENCE limb on the session token, so the rejection arm fails "
+    "OPEN. `(not= (:csrf-token form-params) active-token)` does not fire on a "
+    "request with no session: `active-token` is nil, an attacker's token-less "
+    "POST supplies nil, and nil = nil waves it through. Both limbs must hold — "
+    "`(not (and (some? active-token) (= (:csrf-token form-params) "
+    "active-token)))` (spec/Pattern-FormAction.md §Anti-patterns, §Conformance "
+    "checklist). A fence is what a reader copies, so the fail-closed form must "
+    "be the only one shown here; keep the `not=` shape as a labelled 'not this' "
+    "in inline prose, which this rule deliberately does not read."
+)
+CSRF_REQUIRED_IN_SCHEMA_MSG = (
+    "CSRF-TOKEN-REQUIRED-IN-SCHEMA: this fenced block declares `:csrf-token` as "
+    "a REQUIRED map entry (no `{:optional true}` props map). The hydrated client "
+    "has no session token to send, so a token-requiring schema pointed at the "
+    "handler's validation call rejects every client submission — and that arm is "
+    "ordinary handler code, NOT the elided `:schema` tripwire, so the form 400s "
+    "in the release build and never navigates. It also makes the form slice's "
+    "`:draft` unsatisfiable, since the failure arm must never write a credential "
+    "into a slice the page re-renders. Split the schemas: the editable FIELDS "
+    "type the draft and the validation call; the token rides the event-args "
+    "envelope as `[:csrf-token {:optional true :sensitive? true} …]` and is "
+    "checked in the server-guarded CSRF arm (spec/Pattern-FormAction.md "
+    "§The form schema and slice)."
+)
+
+# `[:csrf-token` followed by its optional props map. A required entry has no
+# props map at all, or one that does not mark the entry `:optional`.
+CSRF_SCHEMA_ENTRY_RE = re.compile(r"\[:csrf-token\b[ \t]*(\{[^}]*\})?")
+
+
+def _code_only(block: str) -> str:
+    """The block with string literals and `;` comments blanked to spaces —
+    offsets preserved, so a match index still points into the original. Paren
+    balance is only meaningful over code, and a fence's prose comments carry
+    both parens and (deliberately) the anti-pattern's own spelling."""
+    out = list(block)
+    i, n = 0, len(block)
+    while i < n:
+        ch = block[i]
+        if ch == '"':
+            j = i + 1
+            while j < n and block[j] != '"':
+                j += 2 if block[j] == "\\" else 1
+            for k in range(i, min(j + 1, n)):
+                out[k] = " "
+            i = j + 1
+        elif ch == ";":
+            j = block.find("\n", i)
+            j = n if j == -1 else j
+            for k in range(i, j):
+                out[k] = " "
+            i = j
+        else:
+            i += 1
+    return "".join(out)
+
+
+def _enclosing_form(code: str, idx: int) -> str:
+    """The balanced form one level OUT from the form opening at `idx` — the
+    rejection expression the comparison sits inside.
+
+    Scoping the presence limb to THIS form rather than to the whole fence is
+    what makes the rule honest. The worked handler's fence also contains
+    `(some? explanation)` for the unrelated validation arm, so a block-wide
+    search for a presence limb would have been satisfied by it and the guard
+    would have exited 0 over the very defect it exists to catch — fail-open by
+    construction, which is the shape of bug this rule was written for."""
+    depth = 0
+    start = None
+    for i in range(idx - 1, -1, -1):
+        c = code[i]
+        if c == ")":
+            depth += 1
+        elif c == "(":
+            if depth == 0:
+                start = i
+                break
+            depth -= 1
+    if start is None:
+        return code
+    depth = 0
+    for i in range(start, len(code)):
+        if code[i] == "(":
+            depth += 1
+        elif code[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return code[start:i + 1]
+    return code[start:]
+
+
+def csrf_fence_problems(text: str) -> list[tuple[int, str]]:
+    """Rule 7 — the two fail-open form-action shapes, inside code fences.
+    Returns (opening-fence-lineno, message) tuples."""
+    problems: list[tuple[int, str]] = []
+    for block_start, body in fenced_blocks(text):
+        code = _code_only(body)
+        # 7a — a CSRF equality comparison whose own rejection expression carries
+        # no presence limb on the session token.
+        for m in CSRF_COMPARE_HEAD_RE.finditer(code):
+            window = code[m.start():m.start() + CSRF_COMPARE_WINDOW]
+            if not CSRF_TOKEN_RE.search(window):
+                continue
+            if not CSRF_PRESENCE_LIMB_RE.search(_enclosing_form(code, m.start())):
+                problems.append((block_start, CSRF_FAIL_OPEN_MSG))
+                break
+        # 7b — `:csrf-token` declared as a required map entry.
+        for m in CSRF_SCHEMA_ENTRY_RE.finditer(code):
+            if ":optional" not in (m.group(1) or ""):
+                problems.append((block_start, CSRF_REQUIRED_IN_SCHEMA_MSG))
+                break
+    return problems
+
+
 # --- Rule 3: launcher points at BOTH canonical files, without regrowing the
 #     tree / locks sections. Operates on the whole authoring-prompt.md body
 #     (not the line-by-line leaf scan). `design.md` / `inputs.md` are the
@@ -871,6 +1063,9 @@ def find_drift(files: list[Path]) -> tuple[list[str], int]:
             problems.append(f"{rel}:{start_lineno}: {label}")
         for start_lineno, label in managed_http_recipe_problems(body):
             problems.append(f"{rel}:{start_lineno}: {label}")
+        # Rule 7 — the form-action fail-open shapes, per fenced block.
+        for start_lineno, label in csrf_fence_problems(body):
+            problems.append(f"{rel}:{start_lineno}: {label}")
         # Rule 6b — hooks-recipe residue shapes, checked PER SENTENCE (a mixed
         # Reagent+hooks physical line is carved so a Reagent `:contextType` never
         # bleeds into the hooks sentence, and a far-away negation cannot mask a
@@ -933,6 +1128,22 @@ def find_drift(files: list[Path]) -> tuple[list[str], int]:
         for text in anchored_block_problems(label, block):
             problems.append(f"{rel}:{lineno}: {text}")
 
+    # Rule 7 (extra files) — the spec pattern page is the projection's SOURCE,
+    # so the same fail-open shapes are refused there too. Whole-file fenced
+    # scan; the page's own labelled "not this" prose is unfenced and unread.
+    for parts in CSRF_EXTRA_FILES:
+        target = REPO_ROOT.joinpath(*parts)
+        rel = "/".join(parts)
+        if not target.is_file():
+            problems.append(
+                f"{rel}: SETUP: the form-action CSRF authority is missing — "
+                "Rule 7's spec-side anchor has no file. If the page moved, "
+                "re-point CSRF_EXTRA_FILES in the same change."
+            )
+            continue
+        for start_lineno, label in csrf_fence_problems(_slurp(target)):
+            problems.append(f"{rel}:{start_lineno}: {label}")
+
     # Rule 3 — the launcher (authoring-prompt.md) is checked as a whole body,
     # not line-by-line, and lives under spec/ (out of the leaf scan above).
     if not AUTHORING_PROMPT.is_file():
@@ -962,10 +1173,11 @@ def run(*, verbose: bool, ci: bool) -> int:
     if verbose:
         print(
             "re-frame2 no-bead-id + verify-posture + launcher-canonical + "
-            "machine-handler-recipe + managed-http-recipe + uix-helix-hooks "
-            "guard: scanned "
+            "machine-handler-recipe + managed-http-recipe + uix-helix-hooks + "
+            "form-action-csrf guard: scanned "
             f"{len(files)} user-facing leaves ({lines_checked} lines), "
-            f"{len(HOOKS_ANCHORED_BLOCKS)} bounded hooks-recipe blocks, plus "
+            f"{len(HOOKS_ANCHORED_BLOCKS)} bounded hooks-recipe blocks, "
+            f"{len(CSRF_EXTRA_FILES)} spec-side CSRF authority file(s), plus "
             "the spec/authoring-prompt.md launcher."
         )
 
@@ -981,9 +1193,12 @@ def run(*, verbose: bool, ci: bool) -> int:
                 "bare no-arg capture-frame carry), the bounded recipe blocks "
                 "(the views per-adapter UIx/Helix rows, the setup skill's "
                 "'Reagent only' warning, and the Spec 006 UIx/Helix paragraph) "
-                "each still state that recipe in place, and the "
-                "launcher points at design.md + inputs.md without regrowing the "
-                "tree / locks."
+                "each still state that recipe in place, no code fence carries "
+                "a fail-open CSRF compare or a required `:csrf-token` field "
+                "(leaves and spec page alike), and the launcher points at "
+                "design.md + inputs.md without regrowing the tree / locks. "
+                "NOTE: this guard is a catalogue of known regressions, not a "
+                "skill/spec equivalence check — see the module docstring."
             )
         return 0
 
@@ -1002,9 +1217,10 @@ def run(*, verbose: bool, ci: bool) -> int:
         "+ use-frame recipe (never a reg-view-macro / bare-capture-frame / "
         ":contextType-attribution / semantic-reversal residue), keep each "
         "bounded recipe block stating that recipe IN PLACE (a correct paragraph "
-        "elsewhere in the file does not cover the table cell), and keep the "
-        "launcher pointing at the canonical design.md + inputs.md instead of "
-        "re-holding the tree / locks."
+        "elsewhere in the file does not cover the table cell), keep every CSRF "
+        "compare in a code fence failing CLOSED on both limbs with the token "
+        "off the field schema, and keep the launcher pointing at the canonical "
+        "design.md + inputs.md instead of re-holding the tree / locks."
     )
     return 1
 
@@ -1556,6 +1772,117 @@ def _self_test() -> int:
         if got:
             print(f"SELF-TEST FAIL ({lawful_label}): expected green, got {got}")
             failures += 1
+
+    # --- Rule 7 (rf2-1iclq): the form-action fail-open shapes in code fences.
+    #     `csrf_fence_problems` takes the WHOLE body (a fence spans lines), so
+    #     these fixtures carry their own fences.
+    def _fence(*lines: str) -> str:
+        return "```clojure\n" + "\n".join(lines) + "\n```\n"
+
+    fail_open_compare = _fence(
+        "(cond",
+        "  (and server? (not= (:csrf-token form-params) active-token))",
+        "  {:fx [[:rf.server/set-status 403]]})",
+    )
+    expect(
+        csrf_fence_problems, fail_open_compare,
+        dirty=True, label="W1 fenced `not=`-alone CSRF compare",
+    )
+    # The blacklist-free framing earns its keep here: a spelling nobody wrote a
+    # regex for is caught by the same missing-presence-limb rule.
+    fail_open_when_not = _fence(
+        "(when-not (= (:csrf-token form-params) active-token)",
+        "  {:fx [[:rf.server/set-status 403]]})",
+    )
+    expect(
+        csrf_fence_problems, fail_open_when_not,
+        dirty=True, label="W2 fenced `when-not (= …)` CSRF compare",
+    )
+    # CLEAN — the fail-closed form: presence limb AND equality.
+    fail_closed_compare = _fence(
+        "(cond",
+        "  (and server? (not (and (some? active-token)",
+        "                         (= (:csrf-token form-params) active-token))))",
+        "  {:fx [[:rf.server/set-status 403]]})",
+    )
+    expect(
+        csrf_fence_problems, fail_closed_compare,
+        dirty=False, label="X1 fenced fail-closed CSRF compare (both limbs)",
+    )
+    # CLEAN — the labelled 'not this' in INLINE prose is legal teaching and this
+    # rule must not read it. Both pages carry exactly this sentence.
+    expect(
+        csrf_fence_problems,
+        "- **Comparing the tokens with `not=` alone.** "
+        "`(not= (:csrf-token form-params) active-token)` fails **open** on a "
+        "request with no session.",
+        dirty=False, label="X2 unfenced 'not this' prose is not read",
+    )
+    # CLEAN — the view's hidden input names the field as a STRING, and a fence
+    # that merely mentions the token performs no comparison.
+    expect(
+        csrf_fence_problems,
+        _fence('[:input {:type "hidden" :name "csrf-token" :value csrf-token}]'),
+        dirty=False, label="X3 hidden-input fence (no comparison, no schema)",
+    )
+    # 7b — the token as a REQUIRED map entry.
+    expect(
+        csrf_fence_problems,
+        _fence("(def AddToCartForm",
+               "  [:map",
+               "   [:item-id [:string {:min 1}]]",
+               "   [:csrf-token [:string {:min 1}]]])"),
+        dirty=True, label="W3 fenced required `:csrf-token` field schema",
+    )
+    # CLEAN — the envelope shape: optional + sensitive, off the field schema.
+    expect(
+        csrf_fence_problems,
+        _fence("(def AddToCartSubmission",
+               "  (conj AddToCartFields",
+               "        [:csrf-token {:optional true :sensitive? true} "
+               "[:string {:min 1}]]))"),
+        dirty=False, label="X4 fenced `{:optional true}` envelope entry",
+    )
+
+    # --- Rule 7 against the REAL corpus, with mutations. A guard that cannot be
+    #     made to fail is worthless — that was the whole finding behind this
+    #     rule (the shipped leaf carried the fail-open compare and every existing
+    #     rule exited 0 over it). So: the shipped files must be green, and each
+    #     reintroduction of the defect must be caught.
+    for parts in (
+        ("skills", "re-frame2", "patterns", "form-action.md"),
+        ("spec", "Pattern-FormAction.md"),
+    ):
+        target = REPO_ROOT.joinpath(*parts)
+        rel = "/".join(parts)
+        if not target.is_file():
+            print(f"SELF-TEST FAIL (Y real file missing): {rel}")
+            failures += 1
+            continue
+        shipped = _slurp(target)
+        if csrf_fence_problems(shipped):
+            print(f"SELF-TEST FAIL (Y shipped file flagged): {rel}: "
+                  f"{csrf_fence_problems(shipped)}")
+            failures += 1
+        mutations = (
+            # The exact drift the shipped leaf carried before this rule existed.
+            ("fail-open compare",
+             "(and server? (not (and (some? active-token)",
+             "(and server? (not= (:csrf-token form-params) active-token)) #_("),
+            ("required token field",
+             "[:csrf-token {:optional true :sensitive? true} [:string {:min 1}]]",
+             "[:csrf-token [:string {:min 1}]]"),
+        )
+        for mut_label, old, new in mutations:
+            if old not in shipped:
+                print(f"SELF-TEST FAIL (Y {mut_label} mutation was a no-op): "
+                      f"{rel}")
+                failures += 1
+                continue
+            if not csrf_fence_problems(shipped.replace(old, new)):
+                print(f"SELF-TEST FAIL (Y {mut_label} mutation not caught): "
+                      f"{rel}")
+                failures += 1
 
     if failures:
         print(f"self-test: {failures} failure(s).")

--- a/skills/re-frame2/patterns/form-action.md
+++ b/skills/re-frame2/patterns/form-action.md
@@ -11,13 +11,36 @@ The prompt mentions: an SSR app handling a form POST, progressive enhancement, "
 ## The six-step shape
 
 1. **The HTML form** renders `method="POST" action="/<route>"` + a hidden CSRF token. The standard Pattern-Forms slice (server-rendered from `app-db`) drives field values.
-2. **The host adapter receives the POST**, parses the body (form-urlencoded or multipart), binds it under `:form-params`, and creates a per-request frame.
-3. **`:rf/server-init` routes** by declaring `:rf.cofx/requires [:rf.server/request]` — on GET dispatch the page loader (Pattern-SSR-Loaders); on POST dispatch the domain event with `form-params`.
+2. **The host adapter receives the POST**, parses the body (form-urlencoded or multipart), binds it under `:form-params`, and creates a per-request frame. What it binds is what the wire carried: HTML form encoding has no types and no keywords, so the parsed body is **strings keyed by strings**, and neither the host nor the framework is obliged to fix that.
+3. **`:rf/server-init` normalises, then routes**, declaring `:rf.cofx/requires [:rf.server/request]` — on GET dispatch the page loader (Pattern-SSR-Loaders); on POST decode that wire shape into domain values and dispatch the domain event with the result. This dispatch is the pattern's single normalisation seam.
 4. **The domain handler validates** `form-params` **in its own body** — not via `:schema`, which is a dev tripwire and elides from the production build. On failure → write the submitted fields back into the form slice's `:draft` and structured errors into its `:errors`, emit `[:rf.server/set-status 400]`, let the drain settle, re-render the page populated and with inline errors. On success → run the side effect, then `:rf.server/redirect` (303) or a success re-render.
 5. **The drain settles**, the SSR emitter runs (or is short-circuited by the redirect), the host materialises the response accumulator (read via `get-response`).
 6. **Once JS hydrates**, the form's `:on-submit` calls `(.preventDefault e)` and dispatches the *same* event. Only the dispatch site differs.
 
 ## Canonical declaration
+
+Two shapes reach the action handler and they are not the same shape. The no-JS POST body carries the editable fields **plus a CSRF token**; the hydrated client dispatches the fields **alone**. Split the schema along that line — one registration still admits both call sites:
+
+```clojure
+;; The editable fields: what the user may type, what the form slice's :draft
+;; holds, and what BOTH platforms submit. This is what the handler validates.
+(def AddToCartFields
+  [:map
+   [:item-id  [:string {:min 1}]]
+   [:quantity [:and :int [:>= 1] [:<= 99]]]])
+
+;; What the EVENT accepts: the fields, plus the token the server POST carries and
+;; the client does not. `:optional` is what lets one registration cover both call
+;; sites; `:sensitive?` keeps the token out of the dev-time validation trace,
+;; which would otherwise carry the event args verbatim.
+(def AddToCartSubmission
+  (conj AddToCartFields
+        [:csrf-token {:optional true :sensitive? true} [:string {:min 1}]]))
+
+(rf/reg-app-schema [:cart :add-form :draft] AddToCartFields)   ;; the fields, never the token
+```
+
+One schema doing all three jobs looks like economy and is a live production bug. The hydrated client has no session token to add, so a token-requiring schema sends every client submission down the handler's own validation arm — and that arm is ordinary code, not the elided `:schema` tripwire, so the form 400s in the release build and never navigates. It also makes the draft unsatisfiable by construction, since the failure arm must never write a credential into a slice the page re-renders. The token is not form state and not a field; it is a per-request credential belonging to the POST envelope, and the CSRF arm below gives it a stronger check than any string schema could. Malli maps are open, so `AddToCartFields` validates the server's body unchanged and the extra key passes through to the arm that owns it.
 
 The view runs on both platforms; the `action` attribute is what makes it work JS-off, and `:on-submit` is purely additive:
 
@@ -42,11 +65,28 @@ The view runs on both platforms; the `action` attribute is what makes it work JS
      [:button {:type "submit"} "Add to cart"]]))
 ```
 
-`:rf/server-init` routes GET vs POST; the action handler validates **in its own body** and emits per-platform effects:
+`:rf/server-init` routes GET vs POST **and owns normalisation**. A POST body does not arrive as domain data: the browser sends `csrf-token=tok-abc&item-id=sku-1&quantity=2`, and what lands under `:form-params` is `{"quantity" "2"}`, not `{:quantity 2}`. Putting the one decode here is what makes "one handler, both platforms" a fact rather than an aspiration — a handler that normalised its own input would first have to work out which platform sent it, which is exactly the knowledge this pattern spends its effort not needing.
 
 ```clojure
+;; `m` / `mt` are malli.core / malli.transform.
+
+;; App-supplied: route → the action event AND the schema describing the body it
+;; accepts. ONE table, so a form cannot acquire an action event without also
+;; declaring the shape its wire body decodes to.
+(def route->action
+  {:route/cart-add {:event :cart/add-item :schema AddToCartSubmission}})
+
+(defn decode-form-params
+  "The wire → domain seam: keywordise the parsed body's keys, then let the schema
+  drive the value coercion. This NEVER throws and never rejects — a value the
+  transformer cannot decode (`quantity=abc`) reaches the handler unchanged and
+  fails its validation arm, so malformed input takes the documented 400 path
+  instead of exploding at the seam. Decoding and validating are different jobs."
+  [schema form-params]
+  (m/decode schema (update-keys form-params keyword) mt/string-transformer))
+
 (rf/reg-event :rf/server-init
-  {:doc "Per-request boot. GET → page loader; POST → form action."
+  {:doc "Per-request boot. GET → page loader; POST → normalise, then form action."
    :platforms #{:server}
    :rf.cofx/requires [:rf.server/request]}
   (fn [{:keys [rf.server/request]} _]
@@ -54,11 +94,21 @@ The view runs on both platforms; the `action` attribute is what makes it work JS
           route (match-route (:uri request))]            ;; app-supplied route matcher
       (case request-method
         :get  {:fx [[:dispatch [:page/load route]]]}
-        :post {:fx [[:dispatch [(route->action-event route) form-params]]]}))))
+        :post (let [{:keys [event schema]} (route->action route)]
+                {:fx [[:dispatch [event (decode-form-params schema form-params)]]]})))))
+```
 
+A host whose middleware already keywordises keys (Ring's `wrap-keyword-params`) makes `update-keys` a no-op rather than a conflict, and one that also coerces types makes the transformer one. Neither is a reason to drop the call, and neither changes which layer is *responsible*. Only the server path needs any of it: the hydrated client dispatches a draft the view already holds as typed values.
+
+The action handler validates **in its own body** and emits per-platform effects:
+
+```clojure
 (rf/reg-event :cart/add-item
   {:doc    "Add an item to the cart. Same handler tree both platforms."
-   :schema [:cat [:= :cart/add-item] AddToCartForm]      ;; DEV TRIPWIRE ONLY — elided in production
+   ;; DEV TRIPWIRE ONLY — elided in production. `:csrf-token` is `:optional` in
+   ;; AddToCartSubmission precisely so this ONE registration admits both call
+   ;; sites: the server's POST envelope and the client's field-only dispatch.
+   :schema [:cat [:= :cart/add-item] AddToCartSubmission]
    :rf.cofx/requires [:rf.server/request
                       :app.csrf/active-token]}            ;; app-owned cofx — see §CSRF
   (fn [{:keys [db] :as cofx} [_ form-params]]
@@ -68,13 +118,21 @@ The view runs on both platforms; the `action` attribute is what makes it work JS
           ;; present key carrying nil.
           server?      (contains? cofx :rf.server/request)
           active-token (:app.csrf/active-token cofx)
-          explanation  (m/explain AddToCartForm form-params)          ;; nil when the form is clean
+          ;; The FIELDS, on both platforms — not the envelope. Malli maps are
+          ;; open, so the server's extra :csrf-token passes straight through to
+          ;; the CSRF arm, which is the thing that actually checks it. Validating
+          ;; the token here would 400 every client submission, in the one arm
+          ;; production does NOT elide.
+          explanation  (m/explain AddToCartFields form-params)        ;; nil when the fields are clean
           fields       (select-keys form-params [:item-id :quantity])] ;; editable fields ONLY — never the token
       (cond
-        ;; CSRF first — fail closed. Guarded on `server?`: the token check is
-        ;; the POST entry point's, and on the client `active-token` is ABSENT,
-        ;; so an unguarded compare 403s every client submission.
-        (and server? (not= (:csrf-token form-params) active-token))
+        ;; CSRF first — fail CLOSED, before any state mutation. Guarded on
+        ;; `server?`: the token check is the POST entry point's, and on the
+        ;; client `active-token` is ABSENT, so an unguarded compare 403s every
+        ;; client submission. BOTH limbs must hold — a bare `not=` fails OPEN on
+        ;; a request with no session (nil = nil waves a token-less POST through).
+        (and server? (not (and (some? active-token)
+                               (= (:csrf-token form-params) active-token))))
         {:db (assoc-in db [:cart :add-form :errors :_form] ["Session expired. Refresh and retry."])
          :fx [[:rf.server/set-status 403]]}
 
@@ -106,6 +164,10 @@ The view runs on both platforms; the `action` attribute is what makes it work JS
 
 `m` / `me` are `malli.core` / `malli.error`; `write-form-errors` and `explain->errors` are app-level helpers (`spec/Pattern-FormAction.md` gives both in full). The point is that the call sits in the **handler body**, where it survives into the release build. `:rf.schema/at-boundary` does not substitute for it: its check *is* ungated and a rejection does answer `400` via the SSR error projector, but it skips the handler, so the user gets a generic public-error body rather than their own form back with the values they typed.
 
+Note that both fates belong to the *same* declaration, and that is the rule rather than a quirk: what may be elided is settled by what a check protects, not by who declared the schema it reads (Spec 000 C-000.35). Read at dispatch, `AddToCartSubmission` is an ordinary registration diagnostic and goes; read by the boundary interceptor it survives, because refusing a malformed payload at an untrusted ingress is a promise the framework made, and a promise kept only in dev is not a promise.
+
+The two arms check different things, and keeping them apart is what lets one handler serve both platforms. The **fields** arm validates `AddToCartFields` on every submission, server and client alike; the **credential** arm compares the token against the session, on the server alone.
+
 Two slots diverge by platform — the CSRF compare and the success destination — and the handler **chooses** both from one test rather than emitting both arms. The boundary is one it already reads: `:rf.server/request` is `:platforms #{:server}`, and a platform-skipped supplier contributes **no key** to the coeffect map, so `(contains? cofx :rf.server/request)` is a clean platform switch. Use `contains?`, not `(if request …)`: on the server the key can legitimately be present carrying `nil` (a supplier that ran but found its slot unpopulated), and truthiness would read that as "client".
 
 Do **not** emit the redirect and the navigate together and label the navigate "client-only". `:rf.route/navigate` is **not** a server no-op — it is an event, `:dispatch` carries no platform gate, and dispatched server-side it writes the route slice and can run the target's `:on-match` work with no browser history behind it. `:rf.server/redirect` *would* lapse on the client, being a `:platforms #{:server}` fx; only one of the two cancels itself, which is why the handler picks. (`:rf.route/navigate` is the framework's programmatic-navigation event, registered by `day8/re-frame2-routing`; there is **no** `:rf.nav/navigate` fx.) For a **raw URL** rather than a route id, the shipped request grammar takes one directly — `[:rf.route/navigate {:url "/cart"}]`, the `:url` escape, exclusive with `:to` — so **no app-owned navigation fx is needed**. Reserve an app-owned fx only for a deliberate routing *bypass* that skips the router entirely (a hard `window.location` assignment, an external redirect), on the rare occasion you actually want that.
@@ -114,7 +176,11 @@ Do **not** emit the redirect and the navigate together and label the navigate "c
 
 **re-frame2 ships no CSRF surface** — there is no `:rf.csrf/*` sub, cofx, or app-db slot, and `:rf/*` (every sub-namespace, `:rf.csrf/*` included) is reserved (`SKILL.md` Cardinal rule 7; `spec/Conventions.md` single-root reserved set). Register the CSRF surface under **your app's own feature prefix** — the `:app.csrf/*` ids below are illustrative placeholders for *your* registrations, not framework-provided surfaces (substitute `:auth.csrf/*` or whatever prefix your app owns).
 
-Every form POST MUST carry a CSRF token; the server MUST reject a mismatch *before any state mutation*. Store the session token at an app-owned slot like `[:app.csrf :session-token]` (seeded by `:rf/server-init` from the request); the view subscribes to `[:app.csrf/token]` and emits a hidden `csrf-token` field; an app-owned `:app.csrf/active-token` cofx exposes it to the handler, which fails-closed with 403 on mismatch. Token rotation, double-submit-vs-sync-pattern, and cookie attributes (`SameSite`/`HttpOnly`/`Secure`) are host concerns — the pattern names *where* the check happens, not *which* scheme.
+Every form POST MUST carry a CSRF token; the server MUST reject a bad one *before any state mutation*. Store the session token at an app-owned slot like `[:app.csrf :session-token]` (seeded by `:rf/server-init` from the request); the view subscribes to `[:app.csrf/token]` and emits a hidden `csrf-token` field; an app-owned `:app.csrf/active-token` cofx exposes it to the handler.
+
+**The compare fails closed on both limbs, and getting that wrong is silent.** The handler answers 403 unless the session **has** an active token *and* it equals the submitted one — which is why the arm above reads `(not (and (some? active-token) (= …)))`. Do **not** write `(not= (:csrf-token form-params) active-token)`: on a request with no session `active-token` is `nil`, an attacker's token-less POST supplies `nil`, `nil` equals `nil`, and the arm never fires. The one shape that looks tidiest is the one that opens the endpoint.
+
+Token rotation, double-submit-vs-sync-pattern, and cookie attributes (`SameSite`/`HttpOnly`/`Secure`) are host concerns — the pattern names *where* the check happens, not *which* scheme. The token never enters `app-db`: the failure arm's `select-keys` writes the editable fields only, so the slot that needs the `:sensitive?` mark is the **event-args schema** (`AddToCartSubmission`), which is the shape the secret actually travels in.
 
 ## File uploads
 
@@ -134,11 +200,15 @@ The scrub is per-named-path, owned by the registration, not a whole-action toggl
 
 - **Skipping the `action` attribute.** A JS-only form breaks progressive enhancement. Always emit `method` + `action`; `:on-submit` is additive.
 - **Validating only on the client.** Client validation is UX; the server is the authority. Re-check the body in the **handler**, on every POST.
+- **Comparing the tokens with `not=` alone.** `(not= (:csrf-token form-params) active-token)` fails **open** on a request with no session: `active-token` is `nil`, a token-less POST supplies `nil`, and the arm does not fire. Require both limbs — the session token *present*, and equal to the submitted one.
+- **Requiring the CSRF token in the field schema.** One `[:map … [:csrf-token [:string {:min 1}]]]` pointed at the draft, the event `:schema`, and the handler's validation call is a live production bug. The hydrated client submits no token, so the handler's own validation arm rejects every client submission — and that arm is ordinary code, so unlike the `:schema` tripwire it is *not* elided; the form 400s in the release build and never navigates. The same schema also makes the draft unsatisfiable, since the failure arm must not write a secret into a slice the page re-renders. Type the draft and the validation call with the **fields**; let the token be `{:optional true :sensitive? true}` on the event-args schema.
+- **Assuming `:form-params` arrives as domain data.** A form submits text: `quantity=2` parses to the string `"2"` under the string key `"quantity"`, and the host is required to parse the body, not to keywordise or coerce it. Hand that map straight to the action handler and a *valid* submission takes the failure arm — the CSRF compare looks up `:csrf-token` in a string-keyed map and finds nothing, so a correct token 403s, and `"2"` fails an `:int` field.
+- **Normalising inside the action handler.** It looks like the tidier home for it and it costs the pattern its central property. The hydrated client sends typed values already, so a handler that decodes must first work out which platform called it — and the two arms it grows are two chances to diverge. One seam, above the dispatch, server side only.
 - **Letting `:schema` be the server-side check.** The commonest way to ship an unvalidated form endpoint: declare `:schema`, read it as "the framework checks this", write no branch. It elides from the production build, so the endpoint that passes every test accepts anything in production. Keep the `:schema` as the dev tripwire and the introspection surface; write the branch as the guard.
 - **Dropping the user's input on the failure path.** `write-form-errors` writes `:status` / `:errors` / `:submit-attempted?` — not `:draft`. With JS on the browser still holds the field values so nothing looks wrong; with JS off the server renders the fields from the slice and the user gets an empty form above "should be at least 1". Repopulate `:draft` from the submitted fields (editable fields only) before writing the errors.
 - **Emitting both the redirect and the navigate unconditionally.** `:rf.route/navigate` is **not** a server no-op — it is an event, `:dispatch` has no platform gate, and dispatched on the server it writes the route slice and can run the target's `:on-match` work with no browser history to back it. (`:rf.server/redirect` *does* lapse on the client; only one arm is self-cancelling.) Choose per platform: `:rf.server/redirect` for the server's POST-redirect-GET, `[:rf.route/navigate …]` for the client. (And do not invent `:rf.nav/navigate` — it does not exist; `:rf.route/navigate` is the shipped programmatic-navigation event, and `{:url "/cart"}` handles a raw URL without any app-owned fx.)
 - **Testing the platform by truthiness.** `(if request …)` is not `(if (contains? cofx :rf.server/request) …)`. A platform-skipped supplier delivers no key; a server-side supplier that ran and found its slot unpopulated delivers the key carrying `nil`. Truthiness reads the second case as "client" and dispatches a browser navigation on a request thread.
-- **Running the CSRF compare on both platforms.** `:app.csrf/active-token` is server-only, so on the client it is absent and `(not= (:csrf-token form-params) nil)` is true for every submission — the handler 403s the whole client path. Guard the arm on the same platform test the success path uses.
+- **Running the CSRF compare on both platforms.** `:app.csrf/active-token` is server-only, so on the client it is absent — the fail-closed compare's presence limb never holds and the handler 403s the whole client path. Guard the arm on the same platform test the success path uses.
 - **`302 Found` for POST success.** Some clients re-POST on 302; the canonical status is **303 See Other**. Set `:status 303` explicitly.
 - **CSRF token from a hardcoded value or query string.** Sessions rotate tokens; your app-owned `:app.csrf/active-token` cofx is the single source of truth. URL-borne tokens leak to referrer logs.
 - **Writing `app-db` from a multipart handler.** The drain runs to fixed point — a long upload inside the handler blocks the request thread. Hand the opaque `:tempfile` to a storage fx.
@@ -149,7 +219,7 @@ No standalone example app — the SSR worked apps are `examples/capabilities/ssr
 
 ## Pointers
 
-- Spec: [`spec/Pattern-FormAction.md`](../../../spec/Pattern-FormAction.md) — full worked `/cart/add` page, the failure-path projector hook, multipart privacy, the server-vs-client handler-tree table, conformance checklist.
+- Spec: [`spec/Pattern-FormAction.md`](../../../spec/Pattern-FormAction.md) — full worked `/cart/add` page, the normalisation seam in full, the failure-path projector hook, multipart privacy, the server-vs-client handler-tree table, conformance checklist.
 - Substrate: `SKILL-REDIRECT.md` → *EP — SSR (011)* (`:rf.server/request` cofx, the side-channel response accumulator read via `get-response`, the seven server-only fxs, `:platforms` gating, server error projection), *EP — Schemas (010)* (`:schema` boundary check, `:sensitive?`).
 - Cross-cutting: [`../references/cross-cutting/ssr-authoring.md`](../references/cross-cutting/ssr-authoring.md) (head/meta + `:rf/hydrate` checks); [`../references/cross-cutting/privacy-and-elision.md`](../references/cross-cutting/privacy-and-elision.md) (the path-based, fail-open owner-classification model; handler-meta `:sensitive?` is a no-op; no propagation).
 - Compose: `patterns/forms.md` (the form-slice shape this reuses server-side), `patterns/ssr-loaders.md` (the GET-path sibling — a page uses Loaders for the initial render, FormAction for subsequent POSTs).


### PR DESCRIPTION
Closes rf2-1iclq.

`skills/re-frame2/patterns/form-action.md` had tracked **none** of the three corrections `spec/Pattern-FormAction.md` took across #7232 / #7347 / #7406. All three were still live on `main` when this branch was cut — verified by reading both files, not assumed. One of them is the exact security bug the spec page lists as an anti-pattern.

The spec is the source of truth here and is **not** edited by this PR.

## What was actually still drifted

**1. Fail-open CSRF compare (the sharp one).** The canonical handler shipped:

```clojure
(and server? (not= (:csrf-token form-params) active-token))
```

That fails **open** on a request with no session: `active-token` is `nil`, an attacker's token-less POST supplies `nil`, `nil` = `nil`, and the rejection arm never fires. The corrected form is the spec's, both limbs:

```clojure
(and server? (not (and (some? active-token)
                       (= (:csrf-token form-params) active-token))))
```

No constant-time helper was introduced — the spec's worked example uses `=` and defines no such surface, and inventing one here would diverge from the source of truth. The fail-closed form is now the **only** shape in any code fence; the `not=` spelling survives solely as an explicitly labelled "not this" in prose (§CSRF and a new anti-pattern bullet).

**2. No field / envelope split.** One `AddToCartForm` typed the draft, the event `:schema` and the handler's `m/explain`. A token-requiring schema 400s every hydrated-client submission **in the release build** (the handler's validation arm is ordinary code and does not elide, unlike the `:schema` tripwire) and makes the draft unsatisfiable by construction. Now `AddToCartFields` (editable, types the draft, validated on both platforms) and `AddToCartSubmission` (fields + `{:optional true :sensitive? true} :csrf-token`, event-args only).

**3. No normalisation owner.** `:rf/server-init` dispatched raw `:form-params`. A parsed form body is STRING keys and STRING values, so the handler 403s a *valid* submission — the CSRF lookup misses a string key. The leaf now names `:rf/server-init` as the single normalisation seam and prints `route->action` + `decode-form-params`.

**4 (from the merged #7406).** The elision rule is propagated: what may be elided is settled by what a check *protects*, not by who declared the schema it reads (C-000.35). The leaf's own prose was compatible but silent on it; one paragraph now states it, with `AddToCartSubmission` as the same declaration with two fates.

**Sibling pages:** `patterns/forms.md` was checked (the bead asked) and carries **no** equivalent drift — its `LoginForm` is a pure field schema for a client-side form with no envelope and no credential riding a POST body, so one schema is correct there. A tracked-file sweep for `not=` near `csrf` across all markdown returns only the three deliberate "not this" prose quotes (this leaf twice, the spec page once). `docs/spec/` carries the old text but is gitignored generated output.

## The blind gate

`scripts/check_skill_re_frame2_drift.py` exited **0** over all of the above. Confirmed on `origin/main` before any edit.

**What it structurally could not see.** Rules 1-6 are *retrospective token patterns*: each encodes one regression somebody already found, checked against a leaf's own text. Nothing in the script relates a `patterns/*.md` leaf to the `spec/Pattern-*.md` page it projects — the concept of an upstream does not exist in it — so the entire class *"the spec page moved and the leaf did not"* is invisible **by construction**, and a green run was never evidence that any leaf agreed with its source. Rule 6c's block anchors do reach outside the skill, but they still ask "does this named block still say X", not "do these two files agree".

**How that is fixed, and the claim narrowed honestly.** A general fence-equivalence check is not buildable — the leaves are deliberately abridged projections, not copies — so the docstring now says plainly what the guard is and is not, and the verbose green line carries the same caveat instead of implying coverage it never had. **Rule 7** then closes the gap for the two shapes where being wrong is a security defect rather than a teaching wobble:

- **7a — fail-open CSRF compare.** Stated *positively* (any fenced CSRF equality comparison must carry a presence limb on the session token) rather than as a blacklist of bad spellings, so `(when-not (= ...))` and `(if (= ...))` are caught by the same rule, not by a second regex someone has to think to add.
- **7b — `:csrf-token` as a required field-schema entry.**

Both are checked at **both ends** — the globbed skill leaves *and* `spec/Pattern-FormAction.md`, so the source of truth cannot regress underneath the leaves either. Both are **fence-scoped**, and that is the semantics rather than a convenience: both pages teach the wrong shape deliberately in inline prose as a labelled "not this", and a fence is what a reader copies.

**The new rule was nearly fail-open itself.** A block-wide search for the presence limb would have been satisfied by the `(some? explanation)` in the *unrelated* validation arm of the same fence — so the guard would have exited 0 over the very defect it exists to catch. The limb is therefore scoped to the comparison's own enclosing form (balanced-paren, over a comment/string-stripped copy of the block). That is noted in the code where the next reader will need it.

## Mutation proof

A checker that cannot be made to fail is worthless, so each shape was reintroduced against the real corpus and reverted byte-identically (sha1 verified, `git status` clean afterwards, spec restored from `HEAD`):

| Mutation | Result |
|---|---|
| baseline, `origin/main`, drift live | `EXIT=0` — the finding |
| fail-open `not=` reintroduced in the leaf | `EXIT=1`, `skills/re-frame2/patterns/form-action.md:105: CSRF-FAIL-OPEN: ...` |
| revert | sha1 `5fd92cc...` unchanged, `EXIT=0` |
| `:csrf-token` made required, leaf **and** spec | `EXIT=1`, **two** issues — `form-action.md:24` and `spec/Pattern-FormAction.md:38`, proving the spec-side arm is wired |
| revert | spec sha1 `1bc85c7...` = `HEAD`, leaf sha1 `5fd92cc...`, `EXIT=0` |

The self-test also gained real-corpus mutation arms (`Y ...`), so the rule cannot rot into a no-op: the shipped files must be green *and* each reintroduction must be caught, or `--self-test` fails.

## Quality gates

Run foreground to completion in the worker worktree, captured to gitignored `*.log`, never piped:

| Gate | Exit |
|---|---|
| `python scripts/check_skill_re_frame2_drift.py --self-test` | `0` — `self-test: all cases passed.` |
| `python scripts/check_skill_re_frame2_drift.py --verbose` | `DRIFT_EXIT=0` |
| `sh scripts/test-fast-pr.sh` | `FAST_PR_EXIT=0` — `PASS fast PR spine` |
| `python scripts/check_doc_slugs.py` | `DOC_SLUGS_EXIT=0` |

**Coverage of the changed files, stated rather than assumed.** `check_doc_slugs.py`'s `DEFAULT_ROOTS` includes `skills`, so the leaf's link targets and heading anchors *are* gated. `mkdocs build --strict` (inside the fast-PR spine) renders the `docs/skills/*.md` landing pages, **not** the leaf files themselves — so nothing renders this page. `check_skill_re_frame2_drift.py` runs in `.github/workflows/test.yml` (both `--self-test` and `--verbose --ci`), so Rule 7 is CI-gated.

Verified by hand, since no gate covers it: the leaf's prose reads coherently end to end after the schema split (the `AddToCartForm` symbol no longer appears anywhere), the new fences are balanced Clojure, and the four new anti-pattern bullets do not duplicate the existing ones.
