### PR TITLE
docs(hicasso): HD-019 must not claim IME composition is proven (rf2-ncn5p)

### DIFF
--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -194,8 +194,12 @@ arrives as `:id`/`:class`, as `"id"`/`"className"`, or as `:x/id`/`:x/class`
 ## The controlled-input door
 
 Controlled text rides the synchronous door: dispatch → drain/commit → re-render
-lands the echo in the keystroke's own task; caret and IME survive value
-reassertion (R-A1/R-A2 are v0's acceptance). On the lean-React arm the
+lands the echo in the keystroke's own task; the caret survives value
+reassertion, and the key-map's composition gate keeps a composing Enter from
+committing (R-A1/R-A2 are v0's acceptance). The **value** path through a live
+composition is not fenced on any implementation: a refused or normalised value
+is written back mid-composition and the browser aborts the exchange, here and
+on plain React alike (`rf2-digtt`, unruled). On the lean-React arm the
 end-of-discrete-event restore is React's; a PATCH back end must own it
 (architecture.md, hard gate).
 

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -451,10 +451,25 @@ rejected/unchanged-model path leans on React's own controlled restore for the
 measured the gap, `rf2-fki5d` closed it. Resets are by **explicit caller
 revision, never value equality** (the
 predecessor's ruled reset law, kept — `docs/design/freehand/decisions/D016-buffered-and-revision-controls.md`). The browser witnesses that prove the door
-are the 100-cell grid rows: same-turn echo, mid-string caret, selection, IME
-composition (`composing?`/keyCode-229), unchanged-model rejection, async
-normalisation. On a PATCH back end the restore obligation transfers to the
-renderer (architecture.md, hard gate).
+are the 100-cell grid rows: same-turn echo, mid-string caret, selection,
+unchanged-model rejection, async normalisation. **The IME witness is narrower
+than the other five, and is recorded as such.** What is proven is the *commit*
+fence — a composing Enter commits nothing, on the native event's `composing?`
+and on the legacy keyCode-229 signal, each independently — witnessed in-page on
+the grid and established against the browser's own composition machinery by
+`ime_run.cjs` (`rf2-o27h3`: CDP-driven trusted composition, on this arm's
+element path, plain React and the UIx port alike). What is **not** proven, and
+is not to be written as though it were, is the *value* path through a live
+composition: the same harness measured a refused or normalised value being
+written back mid-composition, and such a write silently aborts the exchange —
+this arm's converge in turn, plain React in turn through its own restore, the
+UIx port a frame later. The converge is therefore nowhere worse than the React
+baseline, but "composition survives value reassertion" is false for every
+implementation the moment the model disagrees. Whether to suspend convergence
+until `compositionend` is a behavioural choice inside this exception's scope and
+is unruled (`rf2-digtt`); until it is settled, K4's IME half is open rather than
+green. On a PATCH back end the restore obligation transfers to the renderer
+(architecture.md, hard gate).
 **Rationale.** The harness's trap table is explicit: any design where the input
 value round-trips through an external store must *name* its synchronous door.
 This names it, and the first controlled-input commit cannot stall on an
@@ -477,7 +492,8 @@ evidence recorded by `rf2-fki5d`).
 `flushSync` exception additionally reopens if its named live-tree invariant row
 goes red — React mirroring controlled text into `defaultValue` is what makes
 the node-held record valid, and it is not a public React guarantee — or if any
-candidate second call site appears.
+candidate second call site appears. The composition value path reopens on
+`rf2-digtt`'s ruling, whichever way it goes.
 
 ## HD-020 — v0 host mechanics: frame plumbing, hook ledger, error boundary, SSR posture
 

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -69,17 +69,37 @@ renders must state its input-path exception mechanically — the synchronous doo
 that statement.
 
 **R-A2 — caret and selection preservation** when the rendered value differs from
-what was typed. Reject, transform, reformat: mid-string edits included, and IME
-composition is never broken by value reassertion. **Remount-as-reset is
-disqualified** — it destroys focus, selection, and composition state, so "just
-change the key" is not an available answer here.
+what was typed. Reject, transform, reformat: mid-string edits included.
+**Remount-as-reset is disqualified** — it destroys focus, selection, and
+composition state, so "just change the key" is not an available answer here.
 
-Six browser witnesses prove the door, all on a 100-cell editing grid: same-turn
-echo, mid-string caret, selection, IME composition (including the keyCode-229
-signal), unchanged-model rejection, and async normalisation. K4 in
-[validation.md](../validation.md) kills the whole programme if controlled text fails
-same-tick echo or IME on Chromium and WebKit for a simple form. This is not a
-polish item.
+Six browser witnesses stand behind the door. Five prove it outright, all on a
+100-cell editing grid: same-turn echo, mid-string caret, selection,
+unchanged-model rejection, and async normalisation. K4 in
+[validation.md](../validation.md) kills the whole programme if controlled text
+fails same-tick echo or IME on Chromium and WebKit for a simple form. This is
+not a polish item.
+
+The sixth is IME, and it is the one place where the guarantee is narrower than
+you would assume, so it is worth stating exactly.
+
+**Proven: a composing Enter commits nothing.** Mid-composition, Enter picks an
+IME candidate; it is not a submit. The runtime's key-map gates on the native
+event's `isComposing` and on the legacy keyCode-229 signal that some browsers
+still send, each on its own — witnessed on the grid, and again against the
+browser's real composition machinery driven over CDP, on this runtime, on plain
+React and on the UIx port alike.
+
+**Open: the value path through a live composition.** If your model refuses or
+normalises what the IME has composed so far, the corrected value is written back
+*inside* the composing input event — and a value write during composition
+silently aborts the exchange. The in-flight kana are gone, no `compositionend`
+fires, and the IME opens a fresh composition on its next update. That is
+measured, and it is not something this runtime introduced: plain React does the
+same thing in the same turn through its own restore, and the UIx port does it a
+frame later. So do not lean on composition surviving value reassertion. For a
+field whose model can disagree mid-composition it survives nowhere today, and
+whether to suspend convergence until `compositionend` is an open ruling.
 
 ## Rejection: when the model says no
 
@@ -170,7 +190,8 @@ This table names mechanisms; the door's failures are behavioural, not error ids.
 |---|---|---|
 | Characters drop when typing fast | The dispatch path went async — a debounce, a `setTimeout`, a queued effect between keystroke and commit | Keep the controlled path on the synchronous door; debounce the *consumer* of the value, not the write |
 | Caret jumps to end of field on every keystroke | The value was reasserted without caret preservation | R-A2 territory — a real bug in the runtime, not in your view |
-| IME composition breaks mid-word | Value reassertion during composition | The runtime fences composition; a hand-written handler bypassing the intent path won't |
+| Enter commits half-typed text mid-composition | A hand-written key handler that bypasses the intent path | Use the data key-map — the commit fence lives there, on both composition signals |
+| An IME composition dies when the model refuses or normalises it | Value reassertion during composition, which the browser treats as an abort | Open, and not yours to fix: plain React and the UIx port do the same. A field whose model agrees mid-composition is unaffected |
 | Typing the "reset" value clears the field | Reset keyed on value equality somewhere | Reset on explicit revision |
 | Field goes read-only after an async normalise | The model round-trip didn't complete | Async normalisation is one of the six door witnesses; check the handler returns a `:db` write |
 | Focus lost after a validation failure | Something remounted the node | Remount-as-reset is disqualified precisely for this |
@@ -196,4 +217,5 @@ with a commit on blur is not a compromise. It is the right shape.
 | The buffered / draft-and-commit input ladder | **Post-v0, explicitly.** The charter defers "the full buffered/revision input ladder"; v0 ships R-A1/R-A2 and no more |
 | The controls kit that owns drafts and revisions | **Post-v0.** HD-009 leans on it for ephemeral state, and it does not exist in v0 — so in v0 a draft is app-db state you write yourself |
 | Which props count as controlled | HD-010's merge law names `:value` and `:checked`; the converge's own scope is exact (caret-bearing `input` or `textarea`, non-nil `:value`); whether the controlled roster is longer is unstated |
+| The value path through a live IME composition | **Open.** The commit fence is proven; a refused or normalised value is still written back mid-composition, which aborts the exchange — measured on this runtime, plain React and the UIx port alike. Whether to suspend convergence until `compositionend` is an unruled behavioural choice |
 | Whether `:on-input` or `:on-change` is the taught attribute | The landed screens write `:on-input` for text and `:on-change` for checkboxes; the choice is convention, not ruling |


### PR DESCRIPTION
Closes the reopen from MERGED-PR AUDIT #7373 on `rf2-ncn5p`. The HD-019
`flushSync` amendment itself already landed in `649af4b040`; this is the
remaining documentation-truth half.

## The contradiction

The controlled-input authorities disagreed about IME.

- The **grid test** proves a *commit* fence and says so in its own header:
  `:ime-composition-commits-nothing`, with an explicit note that the **value**
  path during composition is *not* asserted there.
- The **studio page** and **validation.md** were already reconciled and
  accurate — they record the real CDP harness result, including its open
  residue.
- **HD-019** listed "IME composition" among the browser witnesses that *prove*
  the door, undifferentiated from the other five.
- The **draft guide** went further: R-A2 promised "IME composition is never
  broken by value reassertion", the witness paragraph counted IME among the six
  that prove the door, and a troubleshooting row said "the runtime fences
  composition".
- **`authoring.md`** carried the same clause: "caret and IME survive value
  reassertion".

That last claim is not merely unproven. `rf2-o27h3`'s real CDP composition
harness (`ime_run.cjs`, 2026-08-02) **measured it false**: on a store-refusing
or normalising field the corrected value is written back *inside* the composing
input event, which silently aborts the browser's composition — no
`compositionend`, in-flight kana lost, a fresh `compositionstart` on the IME's
next update. Arm 1's converge does it in turn, plain React does it in turn
through its own restore, the UIx port a frame later. `rf2-digtt` holds the
matrix and awaits an operator ruling on the carve-out.

The converge is on `onInput`/`onChange` and calls `setSelectionRange`, so this
is exactly the path the over-claim covered.

## What each claim was narrowed to

| Where | Was | Now |
|---|---|---|
| `decisions.md` HD-019 (Ruling) | "The browser witnesses that prove the door are the 100-cell grid rows: … IME composition (`composing?`/keyCode-229) …" | Five grid rows prove the door. The IME witness is recorded as narrower: what is **proven** is the *commit* fence (a composing Enter commits nothing, on `composing?` and on keyCode-229 each independently, in-page on the grid and against the browser's own machinery by `ime_run.cjs`); what is **not** proven is the *value* path through a live composition, with the measured abort stated, and K4's IME half recorded as open rather than green |
| `decisions.md` HD-019 (Reopens) | — | adds: the composition value path reopens on `rf2-digtt`'s ruling |
| `04-controlled-inputs.md` R-A2 | "…mid-string edits included, and IME composition is never broken by value reassertion." | the false clause removed; R-A2 states caret/selection preservation only |
| `04-controlled-inputs.md` witnesses | "Six browser witnesses prove the door … IME composition (including the keyCode-229 signal) …" | "Six … stand behind the door. Five prove it outright …", then two short paragraphs: **Proven: a composing Enter commits nothing**, **Open: the value path through a live composition** |
| `04-controlled-inputs.md` troubleshooting | one row: "IME composition breaks mid-word / Value reassertion during composition / The runtime fences composition …" | split into two honest rows — the commit fence (yours to get right, use the key-map) and the composition abort (open, and plain React and the UIx port do the same) |
| `04-controlled-inputs.md` Not settled yet | — | new row: the value path through a live IME composition is **Open** |
| `authoring.md` controlled door | "caret and IME survive value reassertion" | the caret survives; the key-map's composition gate keeps a composing Enter from committing; the value path through a live composition is **not** fenced on any implementation (`rf2-digtt`, unruled) |

No heading was added, renamed or removed, so no anchor migrated.

## Left alone deliberately

- **`studio/controlled-input-two-implementations.md`** and **`validation.md`** —
  already reconciled by the `rf2-o27h3` work; both already say the commit fence
  is established and the mid-composition rewrite is open. Nothing to correct.
- **`arm1/controlled_grid_dom_cljs_test.cljs`** — its header already states
  exactly what it does and does not assert. Correct as it stands, and this is a
  documentation bead: no test or runtime code is touched.
- **`architecture.md`** "controlled dispatch, caret preserved, composition
  fenced" — that is an *obligation* placed on a hypothetical PATCH back end,
  not a claim about the shipped arm. Whether the PATCH hard gate should demand
  more than any implementation currently delivers is a separate ruling, not a
  wording fix.
- **`docs/design/freehand/studio/fitness-harness.md`** line 117 — the *source*
  of the R-A2 wording this PR removed from the guide. It states an IME property
  no implementation satisfies, including the incumbent. Outside this bead's
  surface, and the honest restatement depends on how `rf2-digtt` is ruled, so
  filed as **`rf2-dfz6f`** (P3, blocked on `rf2-digtt`) rather than edited here.

## Quality gates

Green, foreground, unpiped, each redirected to a `*.log` file and read back.

| Gate | Command | Exit |
|---|---|---|
| docs corpus anchors | `python scripts/check_doc_slugs.py` | **0** |
| fast PR spine | `sh scripts/test-fast-pr.sh` | **0** |

The spine classified this as `docs=true jvm=false node=false` and ran the
documentation tier including `mkdocs --strict` (which resolved and built) —
noting that `mkdocs.yml`'s `exclude_docs` drops `design/hicasso/`, so the
strict build verifies **nothing** of this diff. `check_doc_slugs.py` is the
gate that does see this tree.

**Hand verification** (nothing automated validates this tree's tables, rendering
or nav), across the three changed files:

- **18 outbound links** (18 in-repo, 0 external) — **0 dead**, targets and
  anchors resolved by hand against each target file's headings.
- **42 inbound links** from tracked `.md` files (30 to `decisions.md`, 9 to
  `authoring.md`, 3 to `04-controlled-inputs.md`) — **0 dead anchors**. No
  heading changed, so nothing could have been orphaned; verified anyway.
- **7 tables**, header/separator/body column counts checked row by row —
  **0 mismatches**. The two tables edited here are the guide's troubleshooting
  table (3 cols, 7 body rows, up from 6) and its Not-settled-yet table (2 cols,
  6 body rows, up from 5).
