### PR TITLE
refactor(hicasso): thread the frame as a codec prop and retire a stale bench arm (rf2-2rtt6.39, rf2-2rtt6.70)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/frame_prop_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/frame_prop_dom_cljs_test.cljs
@@ -1,0 +1,300 @@
+(ns re-frame.bench.hicasso.arm1.frame-prop-dom-cljs-test
+  "THE FRAME AS AN ORDINARY PROP — THE WITNESSES, NOT THE PRICE
+  (rf2-2rtt6.39).
+
+  HD-020(b) spends the whole ≤2-hook budget on two hooks: the
+  subscription/epoch hook and the frame-context hook. A third hook in the
+  shell is a budget breach, so v0 has no slot left for anything it later
+  needs. rf2-2rtt6.39's hypothesis is that the second hook is avoidable —
+  the frame is ordinary data flowing down the tree, and the codec knows it
+  at the moment it mints each boundary element, so it can bake it in
+  ([[re-frame.bench.hicasso.front.codec/mark-frame-prop!]]).
+
+  **This file is the CORRECTNESS half only.** The bead's heap ladder, its
+  mount/bulk clock and its studio row are measurement work on a quiet box
+  and are not taken here (rf2-2rtt6.71). What is settled here is what a
+  measurement is not allowed to be taken without:
+
+  1. **The hook count, at React's own dispatcher.** Never self-reported —
+     the same probe, the same page and the same root as
+     [[re-frame.bench.hicasso.arm1.hook-ledger-dom-cljs-test]], so the two
+     variants are a reading against a reading. Two hooks become one.
+  2. **Multi-frame isolation, which is the hard part and not the heap.**
+     Context gets frame isolation for free by construction; a prop must
+     PROVE it. One app mounted in two isolated frames, and no read
+     crosses. A red here kills the hypothesis outright regardless of any
+     number.
+  3. **A foreign component in the middle.** The bead's argument for why
+     the prop survives interop is that a foreign component's children were
+     CREATED by the Hicasso body above it, with the prop already in them —
+     so passing `props.children` through preserves it. That is an argument
+     about React, and it is asserted rather than reasoned about.
+  4. **The memo does not swallow a frame change.** This one is a defect
+     the variant CREATES and the incumbent does not have: React propagates
+     a context change to its consumers ahead of the comparator and through
+     a memo, so a context-fed boundary cannot be bailed out of a frame
+     change. A frame-fed one can — the frame is a prop, and props are the
+     one channel `React.memo` blocks. `boundary-props=` therefore compares
+     `rfFrame`, and claim 4 is what says so.
+
+  Claim 4 is the mutation witness: drop the `rfFrame` comparison from
+  [[re-frame.bench.hicasso.front.codec/boundary-props=]] and it goes red
+  while every other claim here stays green.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every claim degrades to a stated skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.hook-probe :as probe]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt :refer [sub]]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.test-support :as test-support]
+            ["react" :as react])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     ;; Same reason as the hook-ledger fixture: the default leaves a
+     ;; dynamic-var frame stamp in scope, and a frame resolved from there
+     ;; instead of from the prop would make an isolation miss look like a
+     ;; rendering difference.
+     :ambient-frame nil
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-a ::arm1-frame-prop-a)
+(def ^:private frame-b ::arm1-frame-prop-b)
+
+(def ^:private todos
+  "Small — nothing here is a bulk claim."
+  4)
+
+;; ---------------------------------------------------------------------------
+;; The two variants of ONE view
+;; ---------------------------------------------------------------------------
+;;
+;; Identical bodies, minted twice. That is the whole point: everything
+;; below reads the same markup from the same reads, and the only variable
+;; is where the shell got its frame.
+
+(defn- row-body
+  "Reads one to-do's `done?` through the collector and prints it. The read
+  is what isolation is asserted on: two frames hold different values for
+  the same key, so a boundary that resolved the wrong frame prints the
+  wrong word."
+  [{:keys [id]}]
+  [:span.row {:data-testid "row"} (if (sub [:dogfood/done? id]) "yes" "no")])
+
+(defview context-row
+  "The incumbent: the frame arrives through `useContext`."
+  [props]
+  (row-body props))
+
+(def frame-prop-row
+  "The challenger: the frame arrives as `rfFrame` on the element."
+  (rt/mint-frame-prop-view! "frame-prop-row" row-body))
+
+;; ---------------------------------------------------------------------------
+;; The foreign component in the middle (claim 3)
+;; ---------------------------------------------------------------------------
+
+(defn- passthrough-component
+  "A plain React component that owns none of Hicasso's machinery and
+  simply renders whatever children it was given. Declared as a host below,
+  which is the only door a foreign component has (HD-011)."
+  [^js props]
+  (react/createElement "div" #js {"className" "hatch"} (.-children props)))
+
+(def ^:private hatch
+  (codec/mint-host! "frame-prop-test/hatch" passthrough-component))
+
+;; ---------------------------------------------------------------------------
+;; Fixture helpers
+;; ---------------------------------------------------------------------------
+
+(defn- skip! [why] (is true (str "this claim needs a real React DOM — " why)))
+
+(defn- unwitnessed! []
+  (is false (str "React's internals slot was not found, so the hook count is "
+                 "UNWITNESSED on this build. A gate nobody has watched fire is "
+                 "not evidence — fix "
+                 (pr-str 're-frame.bench.hicasso.arm1.hook-probe)
+                 " rather than reading this as a pass.")))
+
+(defn- frames! []
+  (lane/leave-act-environment!)
+  (dogfood/make-frame! frame-a todos)
+  (dogfood/make-frame! frame-b todos)
+  (dogfood/reseed! frame-a todos)
+  (dogfood/reseed! frame-b todos))
+
+(defn- mount! [frame-kw hiccup]
+  (mount/root! (mount/fresh-container!) frame-kw hiccup))
+
+(defn- text-of [handle]
+  (.-textContent (:container handle)))
+
+(defn- mount-and-count
+  "Mount `hiccup` and answer the hook names React was asked for while it
+  mounted — the hook-ledger witness's own helper, deliberately the same
+  root, page and frame so only the component varies."
+  [hiccup]
+  (let [handle (volatile! nil)
+        names  (probe/record! (fn [] (vreset! handle (mount! frame-a hiccup))))]
+    (mount/release! @handle)
+    names))
+
+;; ---------------------------------------------------------------------------
+;; 1. The hook count, at React's dispatcher
+;; ---------------------------------------------------------------------------
+
+(deftest the-frame-prop-shell-calls-one-hook-where-the-context-shell-calls-two
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (if-not (probe/install!)
+      (unwitnessed!)
+      (testing "the same body, minted twice, counted by the same probe on
+               the same page — the frame hook is the whole difference"
+        (frames!)
+        (let [ctx  (mount-and-count [context-row {:id 0}])
+              prop (mount-and-count [frame-prop-row {:id 0}])]
+          (is (= ["useContext" "useSyncExternalStore"] ctx)
+              (str "the incumbent's ledger, unchanged: " (pr-str ctx)))
+          (is (= ["useSyncExternalStore"] prop)
+              (str "and the frame-fed shell asks for one hook: " (pr-str prop)))
+          (is (= (count rt/shell-hook-ledger) (count ctx))
+              "each declared ledger is the measured one")
+          (is (= (count rt/frame-prop-shell-hook-ledger) (count prop))
+              "for both variants")
+          (is (= 1 (- (count ctx) (count prop)))
+              "one slot of the ≤2 budget is freed, and it is exactly one"))))))
+
+(deftest the-freed-slot-does-not-come-back-with-the-read-count
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (if-not (probe/install!)
+      (unwitnessed!)
+      (testing "1, 7 and 20 reads all cost ONE hook — the budget claim the
+               ledger test makes at two, restated at one"
+        (frames!)
+        (let [many (rt/mint-frame-prop-view!
+                     "frame-prop-many"
+                     (fn [{:keys [n]}]
+                       [:ul.reads
+                        (for [i (range n)]
+                          [:li.read {:key i} (str (sub [:dogfood/todo i]))])]))]
+          (doseq [n [1 7 20]]
+            (let [names (mount-and-count [many {:n n}])]
+              (is (= ["useSyncExternalStore"] names)
+                  (str n " reads still cost one hook: " (pr-str names))))))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. Multi-frame isolation — the claim that can kill the hypothesis
+;; ---------------------------------------------------------------------------
+
+(deftest one-app-in-two-isolated-frames-and-no-read-crosses
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (testing "the same view mounted in two frames reads two app-dbs, and a
+             write to one moves only one"
+      (frames!)
+      (let [a (mount! frame-a [frame-prop-row {:id 0}])
+            b (mount! frame-b [frame-prop-row {:id 0}])]
+        (is (= "no" (text-of a)) "frame A starts undone")
+        (is (= "no" (text-of b)) "frame B starts undone")
+
+        (mount/dispatch! a [:dogfood/toggle 0])
+        (is (= "yes" (text-of a)) "the write lands in the frame it was sent to")
+        (is (= "no" (text-of b))
+            "and NOTHING crosses — a prop-threaded frame isolates as
+             completely as the context it replaces")
+
+        (mount/dispatch! b [:dogfood/toggle 0])
+        (is (= "yes" (text-of a)) "A is undisturbed by B's write")
+        (is (= "yes" (text-of b)) "and B moves on its own")
+
+        (mount/release! a)
+        (mount/release! b)))))
+
+(deftest the-two-variants-isolate-identically
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (testing "the incumbent is put through the identical witness, so
+             'isolation holds' is a comparison and not an assertion about
+             the challenger alone"
+      (frames!)
+      (let [a (mount! frame-a [context-row {:id 0}])
+            b (mount! frame-b [context-row {:id 0}])]
+        (mount/dispatch! a [:dogfood/toggle 0])
+        (is (= "yes" (text-of a)))
+        (is (= "no" (text-of b)))
+        (mount/release! a)
+        (mount/release! b)))))
+
+;; ---------------------------------------------------------------------------
+;; 3. A foreign component in the middle
+;; ---------------------------------------------------------------------------
+
+(deftest a-foreign-component-between-two-boundaries-preserves-the-frame
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (testing "the children handed to a foreign component were created by
+             the Hicasso body ABOVE it, with the frame already in them, so
+             `props.children` carries it through untouched"
+      (frames!)
+      (let [outer (rt/mint-frame-prop-view!
+                    "frame-prop-outer"
+                    (fn [_] [hatch {} [frame-prop-row {:id 0}]]))
+            a     (mount! frame-a [outer {}])
+            b     (mount! frame-b [outer {}])]
+        (is (= "no" (text-of a)))
+        (is (= "no" (text-of b)))
+        (mount/dispatch! a [:dogfood/toggle 0])
+        (is (= "yes" (text-of a))
+            "the inner boundary resolved a frame at all — no crossing threw")
+        (is (= "no" (text-of b))
+            "and it resolved the RIGHT one, through a component that knows
+             nothing about frames")
+        (mount/release! a)
+        (mount/release! b)))))
+
+;; ---------------------------------------------------------------------------
+;; 4. The memo does not swallow a frame change (the mutation witness)
+;; ---------------------------------------------------------------------------
+
+(deftest a-frame-change-with-unchanged-props-still-re-renders
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (testing "same root, same element, same props map, different frame.
+             The props-equality bail-out would otherwise leave the body
+             reading the frame it left — the one failure mode threading
+             the frame INTRODUCES, and the reason `boundary-props=`
+             compares `rfFrame`."
+      (frames!)
+      ;; Frame A's row is done; frame B's is not. Props are `{:id 0}` in
+      ;; both renders, so `=` on `rfProps` is true and the comparator is
+      ;; the only thing that can decide to re-render.
+      (rt/dispatch! frame-a [:dogfood/toggle 0])
+      (let [handle (mount! frame-a [frame-prop-row {:id 0}])]
+        (is (= "yes" (text-of handle)) "mounted in A, reading A")
+        (mount/render! (assoc handle :frame frame-b) [frame-prop-row {:id 0}])
+        (is (= "no" (text-of handle))
+            "re-rendered into B and reading B — the comparator saw the
+             frame move even though the props did not")
+        (mount/release! handle)))))
+
+(deftest the-incumbent-survives-the-same-frame-change
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (testing "for free, and by a different mechanism: React propagates a
+             context change to its consumers ahead of the comparator"
+      (frames!)
+      (rt/dispatch! frame-a [:dogfood/toggle 0])
+      (let [handle (mount! frame-a [context-row {:id 0}])]
+        (is (= "yes" (text-of handle)))
+        (mount/render! (assoc handle :frame frame-b) [context-row {:id 0}])
+        (is (= "no" (text-of handle)))
+        (mount/release! handle)))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/frame_prop_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/frame_prop_dom_cljs_test.cljs
@@ -12,7 +12,7 @@
 
   **This file is the CORRECTNESS half only.** The bead's heap ladder, its
   mount/bulk clock and its studio row are measurement work on a quiet box
-  and are not taken here (rf2-2rtt6.71). What is settled here is what a
+  and are not taken here (rf2-2rtt6.72). What is settled here is what a
   measurement is not allowed to be taken without:
 
   1. **The hook count, at React's own dispatcher.** Never self-reported —

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/mount.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/mount.cljs
@@ -47,10 +47,20 @@
   nil)
 
 (defn render!
-  "Render `hiccup` into an existing root, synchronously."
+  "Render `hiccup` into an existing root, synchronously.
+
+  The root hiccup is interpreted through
+  [[re-frame.bench.hicasso.front.codec/root-element]] rather than
+  `as-element`, because the root is the one creator with no ancestor body
+  to inherit the frame from — the case rf2-2rtt6.39's frame-as-a-prop
+  variant needs named. The context provider is installed regardless: it
+  is what the substrate's other React-shaped adapters read, and what the
+  error boundary and the presence tray resolve their frame from."
   [handle hiccup]
   (react-dom/flushSync
-    (fn [] (.render (:root handle) (provider (:frame handle) (codec/as-element hiccup)))))
+    (fn [] (.render (:root handle)
+                    (provider (:frame handle)
+                              (codec/root-element (:frame handle) hiccup)))))
   handle)
 
 (defn root!

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -1313,6 +1313,61 @@
     (react/useSyncExternalStore (.-subscribe entry) (.-snapshot entry) (.-snapshot entry))
     element))
 
+;; ---------------------------------------------------------------------------
+;; The frame-as-a-prop variant (rf2-2rtt6.39) — ONE hook
+;; ---------------------------------------------------------------------------
+;;
+;; A HYPOTHESIS UNDER MEASUREMENT, not the default. HD-020(b) spends the
+;; whole ≤2 budget on the subscription hook and the frame hook, so the
+;; shell has no slot left for anything v0 later needs. The frame does not
+;; obviously need a hook: it is ordinary data flowing down the tree, and
+;; the codec knows it at the moment it mints each boundary element
+;; ([[re-frame.bench.hicasso.front.codec/mark-frame-prop!]]). Threading it
+;; frees the slot; it costs one more entry in every boundary element's
+;; props map, on every render, which is an allocation on the other side of
+;; the ledger and is why this is priced rather than ruled.
+;;
+;; Both variants ship side by side deliberately: the heap and clock rows
+;; are only worth anything taken against the SAME witnesses in one run,
+;; and an incumbent that has been edited to make room for its challenger
+;; is not the incumbent.
+
+(def frame-prop-shell-hook-ledger
+  "The frame-fed shell's declared hook calls, in call order — ONE, where
+  [[shell-hook-ledger]] declares two. The dispatcher-level witness counts
+  against this the same way."
+  [:use-sync-external-store/subscription-epoch])
+
+(defn- resolve-frame-prop! [frame-kw]
+  (if (nil? frame-kw)
+    (fail! :rf.error/no-frame-prop
+           're-frame.bench.hicasso.arm1.runtime/frame-prop-shell
+           (str "A frame-fed Hicasso boundary rendered with no frame in its "
+                "props. Every boundary element below the root is minted by an "
+                "ancestor body, which carries the frame; the root and any "
+                "outward React bridge mint theirs outside a body and must name "
+                "it (`front.codec/root-element`, which `arm1.mount/render!` "
+                "calls).")
+           :mint-the-root-element-with-a-frame
+           {})
+    frame-kw))
+
+(defn frame-prop-shell
+  "The boundary shell with the frame taken from the element's props.
+  **One hook**, and it is the subscription hook — the frame arrives as
+  data, so there is nothing to consume a second slot.
+
+  Otherwise byte-for-byte [[shell]]'s shape: the body runs between the
+  read of the frame and the subscription hook, which is what lets the
+  hook close over the reads the body just made."
+  [body-fn js-props]
+  (let [frame-kw (resolve-frame-prop! (unchecked-get js-props "rfFrame"))
+        props    (or (unchecked-get js-props "rfProps") {})
+        element  (render-body frame-kw body-fn props)
+        ^js entry (.-entry rstate)]
+    (react/useSyncExternalStore (.-subscribe entry) (.-snapshot entry) (.-snapshot entry))
+    element))
+
 (defn mint-view!
   "Turn a body fn into a boundary: a React function component, marked as a
   legal hiccup head and given the codec's stable memo wrapper. Minted
@@ -1385,6 +1440,24 @@
   (let [component (fn hicasso-boundary [js-props] (shell body-fn js-props))]
     (unchecked-set component "displayName" view-name)
     (codec/memoize-boundary! (codec/mark-boundary! component))))
+
+(defn mint-frame-prop-view!
+  "[[mint-view!]]'s frame-fed twin (rf2-2rtt6.39): the same boundary, the
+  same memo wrapper, the same marking — plus the codec marker that makes
+  every element of this head carry `rfFrame`, and [[frame-prop-shell]] in
+  place of [[shell]].
+
+  Everything [[mint-view!]]'s docstring says about the bail-out holds
+  unchanged, with one addition it names there: the frame reaches this
+  boundary through PROPS rather than through context, so the comparator
+  compares it — see
+  [[re-frame.bench.hicasso.front.codec/boundary-props=]]."
+  [view-name body-fn]
+  (let [component (fn hicasso-frame-prop-boundary [js-props]
+                    (frame-prop-shell body-fn js-props))]
+    (unchecked-set component "displayName" view-name)
+    (codec/memoize-boundary!
+      (codec/mark-frame-prop! (codec/mark-boundary! component)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Retained inventory — honest accounting, not a claimed absence

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -799,6 +799,44 @@
   [f]
   (and (fn? f) (true? (unchecked-get f "hicassoBoundary"))))
 
+(def ^:private frame-prop-marker "hicassoFrameProp")
+
+(defn mark-frame-prop!
+  "Record that `f` — an already-marked boundary head — takes its frame as
+  an ordinary ELEMENT PROP rather than from React context, and return it
+  (rf2-2rtt6.39).
+
+  ## Why the codec can supply it at all
+
+  The frame is ordinary data that flows down the tree, and every boundary
+  element below the root is created by an ancestor BODY — which runs
+  inside [[re-frame.bench.hicasso.front.intent/with-frame]], so the frame
+  is already bound at the exact moment [[boundary-element]] mints the
+  element. Baking it in costs one dynamic-var read and one property
+  write per element, and buys the shell its `useContext` back.
+
+  A foreign component sitting between two Hicasso boundaries is harmless:
+  its children were created by the Hicasso body ABOVE it, with the prop
+  already in them, so passing `props.children` through preserves it. The
+  one creator with no ancestor body is an outward bridge — the root, or a
+  React component that mounts Hicasso itself — and that creator names the
+  frame explicitly ([[root-element]]).
+
+  **This is a MEASUREMENT variant, not the default** (rf2-2rtt6.39 is a
+  hypothesis to price, not a ruling). Both variants live here so the
+  comparison is like-for-like: an unmarked head pays exactly what it
+  always paid, because the marker is read where the head's memo wrapper
+  is already read and the prop is written only when it is set."
+  [f]
+  (unchecked-set f frame-prop-marker true)
+  f)
+
+(defn frame-prop-head?
+  "Does this head take the frame as a prop? One own-property read, on a
+  path that already reads one ([[element-type]])."
+  [f]
+  (true? (unchecked-get f frame-prop-marker)))
+
 (defn- boundary-props=
   "React's `areEqual` for a memoized boundary — CLJS `=` over the complete
   `rfProps` value, which is Reagent's argv compare spelled on the one slot
@@ -836,10 +874,26 @@
   case. Reagent's `*always-update*` dynamic escape is declined: it exists
   so `force-update-all` can bypass the comparison for hot reload, and
   re-evaluating a `defview` here re-mints the head and its wrapper — a new
-  React element *type*, which HMR replaces outright."
+  React element *type*, which HMR replaces outright.
+
+  ## `rfFrame` is compared too, and it has to be (rf2-2rtt6.39)
+
+  A context-fed boundary is safe from this comparator by construction:
+  React propagates a context change to its consumers directly, ahead of
+  the comparator and through a memo, so a subtree that changed frames
+  re-renders whatever its props say. A frame-fed boundary
+  ([[mark-frame-prop!]]) has no such channel — the frame IS a prop, and a
+  comparator that ignored it would bail a re-parented subtree out and
+  leave every body below reading the frame it left. One `identical?` on a
+  keyword closes it, ahead of the `=` that can throw.
+
+  The incumbent pays that one comparison on two `undefined`s, which is
+  the honest price of keeping ONE comparator rather than two: a second
+  memo path would be a second place for the fail-open ruling to rot."
   [^js prev ^js next]
   (try
-    (= (unchecked-get prev "rfProps") (unchecked-get next "rfProps"))
+    (and (identical? (unchecked-get prev "rfFrame") (unchecked-get next "rfFrame"))
+         (= (unchecked-get prev "rfProps") (unchecked-get next "rfProps")))
     (catch :default _e
       (when ^boolean js/goog.DEBUG
         (when (exists? js/console)
@@ -1304,9 +1358,17 @@
         ;; rf2-2rtt6.32.
         body-props (realize-deep (cond-> (dissoc props :key)
                                    children (assoc :children children)))
+        head       (nth argv 0)
         js-props   #js {"rfProps" body-props}]
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
-    (react/createElement (element-type (nth argv 0)) js-props)))
+    ;; THE FRAME AS DATA (rf2-2rtt6.39). Only for a head that asked for
+    ;; it, so the context-fed incumbent's element carries exactly what it
+    ;; always carried and the two variants are comparable. `intent/*frame*`
+    ;; is bound by the ancestor body this element is being created inside;
+    ;; at the root there is no ancestor body and [[root-element]] binds it.
+    (when (frame-prop-head? head)
+      (unchecked-set js-props "rfFrame" intent/*frame*))
+    (react/createElement (element-type head) js-props)))
 
 (defn host-prop-value
   "A host prop value, converted SHALLOWLY — HD-011's default. The
@@ -1530,6 +1592,27 @@
     (keyword? x)     (name x)
     (symbol? x)      (name x)
     :else            x))
+
+(defn root-element
+  "[[as-element]] for a hiccup form written OUTSIDE any boundary body —
+  the root, or an outward React bridge that mounts Hicasso from foreign
+  code (rf2-2rtt6.39).
+
+  Every other element in the tree is created by an ancestor body, which
+  is already running inside
+  [[re-frame.bench.hicasso.front.intent/with-frame]]. This is the one
+  creator that is not, so it is the one creator that has to NAME the
+  frame — which an outward bridge takes explicitly anyway. Binding it
+  here rather than in the arm's mount keeps the reason next to the
+  mechanism.
+
+  `*dispatch*` is deliberately NOT bound: the frame is an identity the
+  root genuinely has, while a frame-locked dispatch is what makes an
+  intent vector legal, and an intent written outside a boundary stays the
+  loud `:rf.error/hicasso-intent-outside-boundary` it was."
+  [frame-kw hiccup]
+  (binding [intent/*frame* frame-kw]
+    (as-element hiccup)))
 
 ;; ---------------------------------------------------------------------------
 ;; Cache observation — for the tests and the bench, never for the runtime

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_app.cljs
@@ -44,17 +44,38 @@
   on a mount the `for` seqs realize INSIDE `as-element`, so the
   mount-billed walk includes the card calls and their sub reads.
 
-  | arm          | input    | what it prices |
-  |--------------|----------|----------------|
-  | `ship-lazy`  | lazy     | the mount-billed walk: interpretation PLUS the body's lazy card/sub work |
-  | `ship`       | realized | the shipping walk alone |
-  | `local`      | realized | the faithful in-namespace copy — the ablation baseline, validated against `ship` |
-  | `no-create`  | realized | `local` with `react/createElement` swapped for a two-field object mint |
-  | `no-props`   | realized | `local` emitting `#js {}` per element — the whole prop pipeline removed |
-  | `no-lower`   | realized | `local` with intent lowering stubbed (vectors/maps at any position -> nil, cheaply) |
-  | `no-value`   | realized | `local` with `convert-prop-value` -> identity |
-  | `no-short`   | realized | `local` with the tag-shorthand merge -> identity |
-  | `parse-raw`  | realized | `local` parsing every tag fresh — what the tag cache is worth |
+  | arm           | input    | what it prices |
+  |---------------|----------|----------------|
+  | `ship-lazy`   | lazy     | the mount-billed walk: interpretation PLUS the body's lazy card/sub work |
+  | `ship`        | realized | the shipping walk alone |
+  | `local`       | realized | the faithful in-namespace copy — the ablation baseline, validated against `ship` |
+  | `no-create`   | realized | `local` with `react/createElement` swapped for a two-field object mint |
+  | `no-props`    | realized | `local` emitting `#js {}` per element — the whole prop pipeline removed |
+  | `no-lower`    | realized | `local` with intent lowering stubbed (vectors/maps at any position -> nil, cheaply) |
+  | `no-value`    | realized | `local` with `convert-prop-value` -> identity |
+  | `no-fold`     | realized | `local` with the shorthand fold onto the emitted object -> identity |
+  | `parse-raw`   | realized | `local` parsing every tag fresh — what the tag cache is worth |
+  | `no-propless` | realized | `local` with the propless short-circuit removed — every element pays the map path |
+
+  The last two do MORE work than `local`, not less, so they are read as
+  benefits rather than as phase costs and are reported on their own lines.
+
+  ## What replaced the `:shorthand-merge` / `:no-short` pair (rf2-2rtt6.70)
+
+  Those two rows priced `merge-shorthand` — a `dissoc`/`assoc` pair that
+  rebuilt the attribute map of every element carrying a `#id`/`.class`
+  shorthand — against a `local` copy that performed it. rf2-2rtt6.36
+  **deleted** that surgery: the shorthand is folded onto the object the
+  walk EMITS (`codec/fold-shorthand!`), where the slot is already
+  resolved, and the fast lane that existed only to dodge the map copy
+  went with it. `convert-props`' three lanes became two.
+
+  Nothing went red, because both arms were local copies. That is exactly
+  what made it worth repairing: an instrument whose arms outlive the code
+  they ablate keeps printing plausible numbers for a path nobody runs.
+  So `local`'s prop pipeline was re-pointed at the shipping shape — the
+  propless short-circuit, then convert-then-fold — and the two ablations
+  now name the two lanes that actually ship.
 
   The ablation baseline is written IN THIS NAMESPACE and validated
   against the shipping walk in the same process, for the reason the
@@ -84,8 +105,7 @@
 
   Owner bead: rf2-y1jkm. Driver: `run.cjs` with
   HICASSO_INIT_FN=re-frame.bench.hicasso.walk-profile-app/-main."
-  (:require [clojure.string :as str]
-            [re-frame.adapter.uix :as uix-adapter]
+  (:require [re-frame.adapter.uix :as uix-adapter]
             [re-frame.bench.hicasso.arm1.mount :as arm1-mount]
             [re-frame.bench.hicasso.arm1.runtime :as rt :refer [sub]]
             [re-frame.bench.hicasso.front.codec :as codec]
@@ -207,8 +227,9 @@
 (def ^:const M-NO-PROPS 2)
 (def ^:const M-NO-LOWER 3)
 (def ^:const M-NO-VALUE 4)
-(def ^:const M-NO-SHORT 5)
+(def ^:const M-NO-FOLD 5)
 (def ^:const M-PARSE-RAW 6)
+(def ^:const M-NO-PROPLESS 7)
 
 (declare walk-el)
 
@@ -269,29 +290,34 @@
 (defn- walk-value [mode v]
   (if (identical? mode M-NO-VALUE) v (codec/convert-prop-value v)))
 
-(defn- walk-class-names
-  ([class]
-   (cond
-     (nil? class)     nil
-     (string? class)  (when (seq class) class)
-     (or (keyword? class) (symbol? class)) (name class)
-     (coll? class)    (let [joined (->> class (keep walk-class-names) (str/join " "))]
-                        (when (seq joined) joined))
-     :else            (str class)))
-  ([a b]
-   (let [a (walk-class-names a) b (walk-class-names b)]
-     (cond (nil? a) b (nil? b) a :else (str a " " b)))))
+(def ^:private id-slot "id")
+(def ^:private class-slot "className")
 
-(defn- walk-shorthand [mode props parsed]
-  (if (identical? mode M-NO-SHORT)
-    props
-    (let [id        (.-id ^js parsed)
-          shorthand (.-className ^js parsed)
-          props     (if (and id (not (contains? props :id))) (assoc props :id id) props)
-          declared  (or (:class props) (:className props))
-          merged    (walk-class-names shorthand declared)]
-      (cond-> (dissoc props :className :class)
-        merged (assoc :class merged)))))
+(defn- walk-fold-shorthand!
+  "Fold the tag's `#id`/`.class` shorthand onto the object the walk just
+  emitted — `codec/fold-shorthand!`'s shape, which is private there — or
+  the no-fold stub, which answers the object untouched.
+
+  Asked of the EMITTED object, so there is no spelling left to resolve:
+  every key has already been through the canonical slot on its way in.
+  Two `undefined?` tests and, on the 924 elements of the census page that
+  carry a `.class`, one `class-names` call when a class was also
+  declared. The delta therefore prices the fold that ships, not the map
+  surgery it replaced."
+  [mode ^js o parsed]
+  (if (identical? mode M-NO-FOLD)
+    o
+    (do
+      (when-some [id (.-id ^js parsed)]
+        (when (undefined? (unchecked-get o id-slot))
+          (unchecked-set o id-slot id)))
+      (when-some [shorthand (.-className ^js parsed)]
+        (let [declared (unchecked-get o class-slot)]
+          (unchecked-set o class-slot
+                         (if (undefined? declared)
+                           shorthand
+                           (codec/class-names shorthand declared)))))
+      o)))
 
 (def ^:private reserved-names #{"__proto__" "prototype" "constructor"})
 
@@ -320,20 +346,45 @@
             (unchecked-set local-prop-cache n converted)
             converted))))))
 
-(defn- walk-convert-props [mode props parsed]
-  (if (identical? mode M-NO-PROPS)
+(defn- walk-convert-props
+  "The shipping `convert-props`' two lanes, with the phase switches.
+
+  Lane 1, the propless short-circuit: an element with no attribute map
+  emits exactly the shorthand's `id`/`className`, so it is built directly
+  — no merge, no map iteration, no fold. 567 of the census page's 1,202
+  elements take it. `no-propless` removes it, sending them through the
+  map path on an empty map, which is what the lane is worth.
+
+  Lane 2: merge a `:&` remainder (by identity when there is none),
+  convert the map in one pass with the literal `:key` skipped in-loop
+  rather than `dissoc`ed, then fold the shorthand onto the result."
+  [mode props parsed]
+  (cond
+    (identical? mode M-NO-PROPS)
     #js {}
-    (let [props (dissoc (walk-shorthand mode (codec/merge-caller props) parsed) :key)]
+
+    (and (nil? props) (not (identical? mode M-NO-PROPLESS)))
+    (let [o #js {}]
+      (when-some [id (.-id ^js parsed)] (unchecked-set o id-slot id))
+      (when-some [c (.-className ^js parsed)] (unchecked-set o class-slot c))
+      o)
+
+    :else
+    (walk-fold-shorthand!
+      mode
       (reduce-kv (fn [o k v]
-                   (let [n (local-prop-name k)]
-                     (when-not (reserved-names n)
-                       (unchecked-set o n (walk-value mode
-                                            (if (identical? "ref" n)
-                                              v
-                                              (walk-lower mode k v)))))
-                     o))
+                   (if (keyword-identical? :key k)
+                     o
+                     (let [n (local-prop-name k)]
+                       (when-not (reserved-names n)
+                         (unchecked-set o n (walk-value mode
+                                              (if (identical? "ref" n)
+                                                v
+                                                (walk-lower mode k v)))))
+                       o)))
                  #js {}
-                 props))))
+                 (codec/merge-caller (or props {})))
+      parsed)))
 
 (defn- walk-parse [mode tag]
   (if (identical? mode M-PARSE-RAW)
@@ -344,7 +395,10 @@
   (let [parsed     (walk-parse mode (nth argv 0))
         has-props? (map? (nth argv 1 nil))
         props      (if has-props? (nth argv 1) nil)
-        js-props   (walk-convert-props mode (or props {}) parsed)]
+        ;; nil, not `(or props {})` — the absent attribute map IS the
+        ;; first lane, and wrapping it in an empty map is exactly what
+        ;; hides the lane from the clock.
+        js-props   (walk-convert-props mode props parsed)]
     (controlled/install! (.-tag ^js parsed) js-props)
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
     (walk-make-element mode (.-tag ^js parsed) js-props argv (if has-props? 2 1))))
@@ -479,15 +533,16 @@
         (- (lane/now-ms) t0)))))
 
 (def ^:private arms
-  [{:id :ship-lazy :realize? false :walk (fn [h] (codec/as-element h))}
-   {:id :ship      :realize? true  :walk (fn [h] (codec/as-element h))}
-   {:id :local     :realize? true  :walk (fn [h] (walk-el M-FULL h))}
-   {:id :no-create :realize? true  :walk (fn [h] (walk-el M-NO-CREATE h))}
-   {:id :no-props  :realize? true  :walk (fn [h] (walk-el M-NO-PROPS h))}
-   {:id :no-lower  :realize? true  :walk (fn [h] (walk-el M-NO-LOWER h))}
-   {:id :no-value  :realize? true  :walk (fn [h] (walk-el M-NO-VALUE h))}
-   {:id :no-short  :realize? true  :walk (fn [h] (walk-el M-NO-SHORT h))}
-   {:id :parse-raw :realize? true  :walk (fn [h] (walk-el M-PARSE-RAW h))}])
+  [{:id :ship-lazy   :realize? false :walk (fn [h] (codec/as-element h))}
+   {:id :ship        :realize? true  :walk (fn [h] (codec/as-element h))}
+   {:id :local       :realize? true  :walk (fn [h] (walk-el M-FULL h))}
+   {:id :no-create   :realize? true  :walk (fn [h] (walk-el M-NO-CREATE h))}
+   {:id :no-props    :realize? true  :walk (fn [h] (walk-el M-NO-PROPS h))}
+   {:id :no-lower    :realize? true  :walk (fn [h] (walk-el M-NO-LOWER h))}
+   {:id :no-value    :realize? true  :walk (fn [h] (walk-el M-NO-VALUE h))}
+   {:id :no-fold     :realize? true  :walk (fn [h] (walk-el M-NO-FOLD h))}
+   {:id :parse-raw   :realize? true  :walk (fn [h] (walk-el M-PARSE-RAW h))}
+   {:id :no-propless :realize? true  :walk (fn [h] (walk-el M-NO-PROPLESS h))}])
 
 (def ^:private sampling {:warmup 4 :samples 10})
 (def ^:private rounds 6)
@@ -628,12 +683,17 @@
                                       [:whole-prop-pipeline :no-props]
                                       [:intent-lowering :no-lower]
                                       [:value-conversion :no-value]
-                                      [:shorthand-merge :no-short]]]
+                                      [:shorthand-fold :no-fold]]]
                 (js/console.log (phase-line label ship local (:p50 (get rows arm-id)) elements)))
+              (js/console.log ";; ==== BENEFITS (arms that do MORE work than local; delta minus local) ====")
               (let [pr' (:p50 (get rows :parse-raw))]
                 (js/console.log (str ";;   tag-cache-benefit: parse-raw " (fmt pr' 4)
                                      " ms/walk vs local " (fmt local 4)
                                      " — the cache is worth " (fmt (- pr' local) 4) " ms/walk")))
+              (let [np (:p50 (get rows :no-propless))]
+                (js/console.log (str ";;   propless-lane-benefit: no-propless " (fmt np 4)
+                                     " ms/walk vs local " (fmt local 4)
+                                     " — the short-circuit is worth " (fmt (- np local) 4) " ms/walk")))
               (js/console.log ";; ==== MICRO (ns/op over the page's own literal roster) ====")
               (doseq [[k v] micro]
                 (js/console.log (str ";;   " (name k) ": " (fmt v 1) " ns")))

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_profile_app.cljs
@@ -409,9 +409,15 @@
         children   (codec/realize-children argv (if has-props? 2 1))
         body-props (codec/realize-deep (cond-> (dissoc props :key)
                                          children (assoc :children children)))
+        head       (nth argv 0)
         js-props   #js {"rfProps" body-props}]
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
-    (walk-create mode (nth argv 0) js-props)))
+    ;; The frame-as-a-prop variant's one emission cost (rf2-2rtt6.39).
+    ;; Priced at nothing on THIS page — the census counts zero boundaries
+    ;; — and copied anyway, so the arm stays a copy of what ships.
+    (when (codec/frame-prop-head? head)
+      (unchecked-set js-props "rfFrame" intent/*frame*))
+    (walk-create mode head js-props)))
 
 (defn- walk-fragment [mode argv]
   (let [has-props? (map? (nth argv 1 nil))


### PR DESCRIPTION
Two beads on the Hicasso bench surface, both unblocked by #7404. They are
independent and are committed separately.

---

## rf2-2rtt6.70 — the stale instrument

#7404 deleted `merge-shorthand` — the `dissoc`/`assoc` pair that rebuilt the
attribute map of every element carrying a `#id`/`.class` shorthand — and folded
the shorthand onto the object the walk EMITS instead. `convert-props`' three
lanes became two, because the fast lane existed only to dodge that map copy.

`walk_profile_app` kept LOCAL copies of the deleted shape and priced
`:shorthand-merge` against `:no-short`: the map surgery versus no map surgery.
The shipping codec performs neither. Nothing went red, because both arms were
local — which is the worse failure for an instrument.

The bead offered "re-point or retire". **Re-pointed**, because retiring alone
would have been worse: `walk-shorthand` was *inside* the `local` baseline, so
deleting the row that names it while leaving the baseline paying for it would
have skewed every OTHER phase delta against a too-expensive baseline. So
`local`'s prop pipeline is now the shipping shape — the propless short-circuit,
then convert-then-fold, `:key` skipped in-loop rather than `dissoc`ed — and two
ablations name the two lanes that actually ship:

| was | is |
|---|---|
| `:no-short` — the tag-shorthand *merge* stubbed to identity | `:no-fold` — the shorthand fold onto the emitted object stubbed to identity |
| — | `:no-propless` — the propless short-circuit removed; every element pays the map path |

`:no-propless` does MORE work than `local`, so it is reported as a *benefit*
line beside `parse-raw`'s rather than as a phase cost — the sign convention the
delta table depends on. Deleted with the surgery: `walk-shorthand`,
`walk-class-names`, and the now-unused `clojure.string` alias. The arms table
and the reason the old pair went are in the namespace docstring, per the bead.

No timing rows are published here. The instrument was run once, to prove it is
not fail-open; the figures are contended (five concurrent workers) and belong to
whoever owns the clock.

---

## rf2-2rtt6.39 — the frame as a codec-supplied prop

**Read the bead before reading the diff.** rf2-2rtt6.39 is titled `MEASURE:`
and its own text opens "A HYPOTHESIS TO MEASURE, not a proposal to adopt". Its
scope has five items; items 3 and 5 are a retained-heap ladder, a mount/bulk
clock and a studio publication — measurement work needing a quiet box, which
this worker's brief explicitly fenced off. **So this PR builds the variant and
settles its correctness; rf2-2rtt6.72 carries the numbers.** The incumbent is
NOT deleted: the bead says "both variants on one branch, one instrument, one
run", and a comparison whose incumbent has been edited to make room for its
challenger is not a comparison.

HD-020(b) spends the whole ≤2-hook budget on the subscription/epoch hook and the
frame-context hook, so v0 has no slot left. The frame is ordinary data flowing
down the tree, and the codec knows it at the moment it mints each boundary
element — every boundary below the root is created by an ancestor BODY, which is
already running inside `intent/with-frame`. So the codec bakes it in and the
shell reads it off its props.

| | |
|---|---|
| `codec/mark-frame-prop!` | marks a head as frame-fed. One own-property read, taken where the memo wrapper is already read, so an unmarked head pays what it always paid and carries the props it always carried |
| `codec/root-element` | the root and any outward React bridge are the only creators with no ancestor body, so they NAME the frame. `*dispatch*` is deliberately not bound: an intent outside a boundary stays the loud error it was |
| `rt/frame-prop-shell` | one hook |
| `rt/mint-frame-prop-view!` | `mint-view!`'s twin |

### Hook count, at React's own dispatcher

Never self-reported — the same `hook_probe`, the same page and the same root as
`hook_ledger_dom_cljs_test`, so the two variants are a reading against a reading.

| shell | dispatcher-observed hooks |
|---|---|
| context-fed (incumbent, unchanged) | 2 — `useContext`, `useSyncExternalStore` |
| frame-fed | **1** — `useSyncExternalStore` |

It does not move with the read count: 1, 7 and 20 reads all cost one.

### One defect the variant CREATES, repaired in the same commit

React propagates a context change to its consumers ahead of the comparator and
through a memo, so a context-fed boundary cannot be bailed out of a frame
change. A frame-fed one can — the frame is a prop, and props are the one channel
`React.memo` blocks. A re-parented subtree would have kept reading the frame it
left. `boundary-props=` therefore compares `rfFrame` before the `=` that can
throw. The incumbent pays one `identical?` on two `undefined`s, which is the
price of keeping ONE comparator rather than two places for the fail-open ruling
to rot.

### Is it simpler than the hook it replaces?

**At the shell, yes and unambiguously**: one hook instead of two, one property
read instead of a context subscription, and no `no-provider-sentinel` dance.
**Across the whole change, no** — and that is worth stating rather than
smoothing over. The context version needs nothing at the root, because a
provider is installed there anyway; the prop version needs `root-element`, and
it needs the memo comparator to learn about a channel it previously did not have
to know existed. Threading data is simpler *per boundary* and slightly more
machinery *in total*. Whether the shell's saving is worth it is exactly what
rf2-2rtt6.72 measures.

### Witnesses (`frame_prop_dom_cljs_test`, browser, 7 tests)

1. the dispatcher hook count, both variants, one page
2. the count does not move with the read count (1/7/20)
3. **multi-frame isolation** — one app in two isolated frames, no read crosses;
   driven through BOTH variants identically. The bead makes this mandatory
   before any number is quotable and calls a red here fatal to the hypothesis.
   It is green.
4. a foreign component in the middle preserves the frame through
   `props.children` — the bead's interop argument, asserted rather than reasoned
5. the memo does not swallow a frame change (both variants)

---

## Quality gates

Run from the worker worktree
`C:/Users/miket/code/re-frame2-worktrees/frameprop-2rtt6-39` (guard printed
`WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/frameprop-2rtt6-39`).
Each runner captured to a gitignored `*.log`; no gate was piped through
`tail`/`grep`, so every exit code below is the runner's own.

| gate | result | exit |
|---|---|---|
| `npm run test:browser` | 1033 tests / 6379 assertions / **1 failure** (see below) | `BROWSER_EXIT=1` |
| `npm run test:browser` (mutation run) | 1033 tests / 6380 assertions / 1 failure — the *named* one | `MUTATION_EXIT=1` |
| `sh scripts/test-fast-pr.sh` | PASS fast PR spine — per-ns isolation all 17 pass standalone | `FASTPR_EXIT=0` |
| JVM `implementation/core` | 2210 tests / 11510 assertions / 0 failures | (inside fast-PR) |
| JVM `implementation/freehand` | 1288 tests / 8857 assertions / 0 failures | (inside fast-PR) |
| CLJS node integration (`test:cljs`) | 12446 tests / 62334 assertions / 0 failures | (inside fast-PR) |
| `hicasso-bench` build + `walk_profile_app` driver | `Build completed. (186 files, 131 compiled, 0 warnings)`, all 10 arms produced rows, arm-order guard clean | `RUNNER_EXIT=0` |

**The one browser failure is not this diff.**
`re-frame.ui.tool-evidence-dom-cljs-test/query-cycles-are-collectible-in-the-real-browser-heap`,
reporting `canonical requestGC unavailable: Playwright requestGC handshake
absent` — a harness capability, in an artefact this diff cannot reach (every
changed file is under `implementation/freehand/test/re_frame/bench/hicasso/`).
It **passed on the immediately following browser run** on the same tree with
only the mutation applied, which is the same box confirming it as environmental.

### Transitive surface

The codec change is a change to a *shared* front-half file, so its consumers are
what had to be gated, not itself. `boundary-props=` and `boundary-element` are
on the path of every Hicasso boundary in the arm — `props_bailout`,
`hook_ledger`, `lifecycle`, `dogfood`, `presence_intent`, `host_hatch`,
`boundary_crossing`, `controlled_grid`, the shape roster — and all of them ride
`npm run test:browser`, which is why the whole browser lane was run twice rather
than a focused slice. `mount/render!` is the root door for every one of them.

### Mutation proof

**rf2-2rtt6.39.** Removed the `rfFrame` comparison from `boundary-props=`
(reverting that one line to its pre-PR form) and re-ran `npm run test:browser`:

```
FAIL in (a-frame-change-with-unchanged-props-still-re-renders)
        (re_frame/bench/hicasso/arm1/frame_prop_dom_cljs_test.cljs:284:13)
expected: (= "no" (text-of handle))
  actual: (not (= "no" "yes"))
MUTATION_EXIT=1
```

Exactly one failure, and it is the claim the line exists for: the frame-fed
boundary kept reading the frame it left. Reverted byte-identically
(`git checkout --` on the one file; `git status --porcelain` empty afterwards).

**rf2-2rtt6.70 — and this is a finding, not a proof.** The mutation was to
rename `M-NO-PROPLESS`'s def and leave its two use sites alone. The instrument
**still ran and still exited 0**:

```
[:hicasso-bench] Build completed. (186 files, 131 compiled, 2 warnings, 35.49s)
------ WARNING #1 - :undeclared-var ------
 Use of undeclared Var re-frame.bench.hicasso.walk-profile-app/M-NO-PROPLESS
... [hicasso] ok
MUT_WALK_EXIT=0
```

Two undeclared vars, a full run, a printed table of numbers, exit 0. So the
answer to "why did the stale arm never go red" is *nothing could have*:
`walk_profile_app.cljs` is in no PR gate's bundle at all (`out/node-test.js`
contains zero occurrences of it; `out/browser-test/js/cljs-runtime/` has no such
module — `:node-test` selects `cljs-test$` and `:browser-test` selects
`-dom-cljs-test$`, and nothing test-shaped requires the arms), and its one
driver checks only the shadow-cljs exit status, which is 0 with warnings.
Reverted byte-identically. **Filed as rf2-2rtt6.73.**

---

## Beads

- rf2-2rtt6.70 — done, this PR
- rf2-2rtt6.39 — correctness half done, this PR
- **rf2-2rtt6.72** (filed) — the measurement half of rf2-2rtt6.39: retained-heap
  ladder on 1/3/7/20, mount + bulk clock, both variants in one run, studio row
  and the rf2-2rtt6.1 append. Carries what is already settled so it is not
  re-derived, plus the `retained-inventory` update (`:react/use-context` is not
  a frame-fed boundary's token).
- **rf2-2rtt6.73** (filed) — the bench lane is compile-ungated; `run.cjs` should
  refuse a build that emitted warnings, and the lane should decide whether it
  wants a compile-only PR gate (~35-40s, no quiet box needed, so it does not
  contend with the measurement lane).

## Notes

- No `spec/` file, workflow, donor src tree or `shadow-cljs.edn` build id is
  touched — the epic's sequencing law holds.
- `.beads/issues.jsonl` and `.beads/metadata.json` are not in this diff.
- PR #7409's file (`shapes/ordinary_dom_cljs_test.cljs`) is untouched.
