### PR TITLE
fix(hicasso): the controlled-grid probe must restore the adapter pin, not clear it (rf2-2rtt6.41)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
@@ -37,6 +37,21 @@
   beside it on the same frame changes behaviour with the pin. That is the
   measurement that licenses every row after it to say \"React\" and mean it.
 
+  ## AND THE PIN GOES BACK WHERE THE ADAPTER PUT IT
+
+  Since rf2-heqwo, `re-frame.adapter.uix` `set!`s the var to `false` at
+  LOAD, so a re-frame2 UIx app no longer runs the classpath sniff at all.
+  `cljs.test` runs every namespace in ONE shared JS runtime, so a row here
+  that cleared the pin and walked away would hand the `:input` choice back
+  to the bundle for every namespace scheduled after this one — a fault
+  that is invisible where it is caused and reds a suite nobody is looking
+  at. This file shipped exactly that (rf2-2rtt6.41: the teardown wrote
+  `nil`) and nothing noticed, so the discipline is now enforced rather
+  than described: rows restore through [[restore-adapter-pin!]], the raw
+  `nil` selector is reachable only inside [[with-uix-raw-default]]'s
+  `try`/`finally`, and [[pin-is-adapters-default!]] re-reads the var after
+  EVERY row in the `:each` teardown.
+
   ## What React's own restore does, and what it does not
 
   React's end-of-discrete-event state restore fires even when nothing
@@ -111,7 +126,78 @@
             ["react-dom/client" :as react-dom-client])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview hfn]]))
 
-(use-fixtures :each
+;; ---------------------------------------------------------------------------
+;; Pinning the input implementation
+;; ---------------------------------------------------------------------------
+
+(def input-implementations
+  "The two things `uix.compiler.aot/create-uix-input` can build, and the
+  value of `uix.compiler.input/*use-reagent-input-enabled?*` that selects
+  each. `nil` — UIx's OWN unset default — is not a third option; it is
+  *whichever of these two the bundle's contents imply*, which is the thing
+  this file exists to stop measuring by accident."
+  {:react false :uix-reagent-input true})
+
+(def adapter-default-implementation
+  "What `re-frame.adapter.uix` pins at load (rf2-heqwo), and therefore what
+  every row here restores. NOT `nil`: see the ns docstring's second
+  section — clearing the pin re-arms the classpath sniff for every later
+  namespace in the same build."
+  :react)
+
+(def ^:private pin-at-load
+  "The var as `re-frame.adapter.uix`'s load left it, snapshotted at THIS
+  namespace's load. `re-frame.adapter.uix` is in the `:require` above so
+  CLJS runs its load first, and every other `set!` in this build happens
+  inside a test body — i.e. after all loads. So this is the adapter's own
+  answer and nothing else's, and it is what stops
+  [[adapter-default-implementation]] from being a literal that could drift
+  away from the adapter it names."
+  uix.compiler.input/*use-reagent-input-enabled?*)
+
+(defn- pin! [impl]
+  (set! uix.compiler.input/*use-reagent-input-enabled?*
+        (get input-implementations impl)))
+
+(defn- restore-adapter-pin!
+  "The teardown half of [[pin!]]. Restores the ADAPTER's pin, which is not
+  the same thing as clearing it."
+  []
+  (pin! adapter-default-implementation))
+
+(defn- with-uix-raw-default
+  "Run `f` with the adapter's pin CLEARED, so UIx's own classpath sniff is
+  observable, and restore the pin however `f` ends. The only place in this
+  file that writes `nil`, and the `finally` is why it is allowed to."
+  [f]
+  (set! uix.compiler.input/*use-reagent-input-enabled?* nil)
+  (try (f) (finally (restore-adapter-pin!))))
+
+(defn- pin-is-adapters-default!
+  "The witness for a fault that is invisible where it is caused.
+
+  A row that leaves the pin cleared breaks LATER namespaces, not itself:
+  its own assertions stay green and the suite that reds is someone else's.
+  So the check cannot live in a row — a row would have to be scheduled
+  last to mean anything, and `cljs.test` promises no order within a
+  namespace. It lives in the `:each` teardown instead, where it reads the
+  var after every row in this file."
+  []
+  (is (= (get input-implementations adapter-default-implementation)
+         uix.compiler.input/*use-reagent-input-enabled?*)
+      "a row in this namespace has just left
+       `uix.compiler.input/*use-reagent-input-enabled?*` somewhere other
+       than the adapter's own pin. Tear down with `restore-adapter-pin!`,
+       never `set! nil`, and reach the raw selector only inside
+       `with-uix-raw-default` — a cleared pin re-arms UIx's classpath
+       sniff for every namespace scheduled after this one in the same
+       build"))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures
+;; ---------------------------------------------------------------------------
+
+(def ^:private runtime-fixture
   (test-support/make-reset-runtime-fixture
     {:adapter       uix-adapter/adapter
      ;; `:ambient-frame nil` is load-bearing: the fixture's default leaves
@@ -123,27 +209,16 @@
      :async?        true
      :init-fn       (fn [] (rt/reset-runtime!))}))
 
+(use-fixtures :each
+  {:before (:before runtime-fixture)
+   :after  (fn []
+             ((:after runtime-fixture))
+             (pin-is-adapters-default!))})
+
 (def ^:private frame-id ::arm1-grid)
 
 (defn- skip! [why]
   (is true (str "a caret in a real text field needs a real DOM — " why)))
-
-;; ---------------------------------------------------------------------------
-;; Pinning the input implementation
-;; ---------------------------------------------------------------------------
-
-(def input-implementations
-  "The two things `uix.compiler.aot/create-uix-input` can build, and the
-  value of `uix.compiler.input/*use-reagent-input-enabled?*` that selects
-  each. `nil` — the shipped default — is not a third option; it is
-  *whichever of these two the bundle's contents imply*."
-  {:react false :uix-reagent-input true})
-
-(defn- pin! [impl]
-  (set! uix.compiler.input/*use-reagent-input-enabled?*
-        (get input-implementations impl)))
-
-(defn- unpin! [] (set! uix.compiler.input/*use-reagent-input-enabled?* nil))
 
 ;; ---------------------------------------------------------------------------
 ;; The harness
@@ -236,7 +311,7 @@
    (fresh!)
    (let [handle (arm-mount!)]
      (try (f handle)
-          (finally (mount/release! handle) (unpin!))))))
+          (finally (mount/release! handle) (restore-adapter-pin!))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The UIx comparator — its own root, its own provider
@@ -274,19 +349,36 @@
 ;; ---------------------------------------------------------------------------
 
 (deftest the-selector-is-live-in-this-bundle
-  (testing "UIx's default answer is a fact about the classpath, and this
-           bundle carries Reagent — so an unpinned UIx `:input` here is not
-           a plain React controlled input at all"
+  (testing "the pin is the adapter's and the sniff underneath it would have
+           answered the other way — two claims, and the row is worth
+           nothing without both"
     (is (some? reagent.impl.batching/do-after-render)
         "Reagent's after-render queue is in this bundle, which is exactly
-         what makes UIx's default answer `true`")
-    (unpin!)
-    (is (true? (uix.compiler.input/should-use-reagent-input?)))
+         what makes UIx's UNPINNED answer `true`")
+    (is (= (get input-implementations adapter-default-implementation) pin-at-load)
+        "`re-frame.adapter.uix`'s load really did leave the var at
+         `adapter-default-implementation`'s value — asserted from a
+         snapshot taken at this namespace's load, so no sibling suite's
+         per-row pinning can stand in for the pin and mask its absence")
+    (is (false? (uix.compiler.input/should-use-reagent-input?))
+        "and that is still the live answer here: React's own controlled
+         input, by the adapter's decision rather than the classpath's")
+    (with-uix-raw-default
+      (fn []
+        (is (true? (uix.compiler.input/should-use-reagent-input?))
+            "CLEAR the pin and the bundle chooses instead — the port. This
+             is the accident rf2-heqwo removed, and it is what makes the
+             assertion above a measurement rather than a coincidence")))
+    (is (false? (uix.compiler.input/should-use-reagent-input?))
+        "the pin is back, because the raw probe ran inside a `finally` and
+         not merely before a restore that an early return could skip")
     (pin! :react)
     (is (false? (uix.compiler.input/should-use-reagent-input?)))
     (pin! :uix-reagent-input)
-    (is (true? (uix.compiler.input/should-use-reagent-input?)))
-    (unpin!)))
+    (is (true? (uix.compiler.input/should-use-reagent-input?))
+        "the port stays reachable by name — the ruling made React the
+         default, not the only option")
+    (restore-adapter-pin!)))
 
 (deftest the-arms-input-is-reacts-own-whatever-the-selector-says
   (async done
@@ -333,7 +425,7 @@
                   (is false (str "the deferred converge threw: " (ex-message e)))))
               (uix-release! ctrl)
               (mount/release! arm)
-              (unpin!)
+              (restore-adapter-pin!)
               (done))))))))
 
 (deftest the-arm-reads-the-same-on-both-pins
@@ -897,7 +989,7 @@
                      still holds what the TEXT render wrote. It is no
                      longer the value this element renders, so there is
                      nothing here the converge could correctly write")))
-            (finally (mount/release! handle) (unpin!))))))))
+            (finally (mount/release! handle) (restore-adapter-pin!))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 6 — :async-normalisation
@@ -933,7 +1025,7 @@
                   (catch :default e
                     (is false (str "the late correction threw: " (ex-message e)))))
                 (mount/release! handle)
-                (unpin!)
+                (restore-adapter-pin!)
                 (done))
               0)))))))
 
@@ -974,7 +1066,7 @@
           (react-dom/flushSync (fn [] (.unmount (:root handle))))
           (let [census (select-keys (rt/residue) [:cell-refs :boundaries :edges])]
             (mount/release! (assoc handle :root nil))
-            (unpin!)
+            (restore-adapter-pin!)
             (is (= {:cell-refs 0 :boundaries 0 :edges 0} census)
                 "zero leaked subscription ref-counts, zero boundaries and zero
                  edges the moment React's unmount returned")))))))


### PR DESCRIPTION
Audit defect 2 of PR #7338's chronological audit — the last live item rf2-2rtt6.41 owned itself. It was still on `origin/main` exactly as the audit described it.

## The defect

`arm1/controlled_grid_dom_cljs_test.cljs:146` read

```clojure
(defn- unpin! [] (set! uix.compiler.input/*use-reagent-input-enabled?* nil))
```

and every sync and async teardown in the namespace called it — six sites.

Since rf2-heqwo, `re-frame.adapter.uix` `set!`s that var to `false` at **load**, so writing `nil` did not restore anything. It **cleared** the pin, handing UIx's controlled-input choice back to the classpath sniff for every namespace scheduled after this one in the same `cljs.test` runtime. This bundle carries Reagent, so the sniff answers `true` and a later suite's UIx `:input` is Reagent's rAF-driven port rather than React's controlled input — the precise accident this file's own docstring says it exists to prevent (rf2-n3dxw).

The fault is invisible where it is caused: the leaking rows stay green, and the suite that pays is someone else's.

## The repair

- **`restore-adapter-pin!`** replaces `unpin!` and restores `adapter-default-implementation` (`:react` → `false`). This is the shape the sibling `hicasso/controlled_restore_dom_cljs_test` already carries; the two files now agree.
- **`with-uix-raw-default`** is the only place in the file that writes `nil`, and it does so inside `try`/`finally`.
- **`the-selector-is-live-in-this-bundle`** now asserts the **adapter's** pin rather than the bundle's sniff, against a **load-time snapshot** (`pin-at-load`) so that no sibling suite's per-row pinning can stand in for the pin and mask its absence — and proves the raw bundle answer separately, inside the new `finally`.

## The witness, and why it is a fixture rather than a row

A restore that nothing checks is exactly as silent as the bug, so the change is not worth much without something that notices. **`pin-is-adapters-default!`** runs in the `:each` **teardown** and re-reads the var after every row in the namespace.

It is deliberately not a `deftest`. A row could only mean something if it were scheduled last, and `cljs.test` promises no order within a namespace — `test-ns-block` collects vars from `ns-interns`, i.e. from the analyzer's `:defs` **map**. A row would have been a witness that passed by luck. The `:each` teardown is order-independent and covers every row including the last.

Composing it required lifting the pinning section above the fixture and giving the existing runtime fixture a name (`runtime-fixture`), then wrapping it in one map fixture — the same shape `b10_two_clock_dom_cljs_test` already uses. `cljs.test` requires all `:each` fixtures be maps when any test is async, and they are.

## Mutation proof

The mutation is the entire value of the change, so it was taken over the **whole browser bundle** — a single-namespace run cannot show cross-test contamination.

Reintroducing the original `nil` restore (`restore-adapter-pin!`'s body → `(set! ... nil)`):

```
npm run test:browser   exit 1
Ran 1029 tests containing 6408 assertions. 21 failures, 0 errors.
```

- **20** of the 21 are the guard at `controlled_grid_dom_cljs_test.cljs:186`, once per row:
  ```
  expected: (= (get input-implementations adapter-default-implementation)
               uix.compiler.input/*use-reagent-input-enabled?*)
    actual: (not (= false nil))
  ```
- the 21st is `the-selector-is-live-in-this-bundle`'s restored-pin assertion at `:372` — `(not (false? true))`, the sniff answering for the cleared pin.

Reverted **byte-identically** (`git checkout --` of the committed file; `git diff --exit-code` = 0, working tree clean). The clean re-run is exit 0 with the same 1029 / 6408, 0 failures.

## Was a later namespace actually affected? Yes — and it stayed green

Measured from the mutation run's own log rather than inferred.

**149 of the browser bundle's 164 namespaces run after this one.** The very next, `arm1/dogfood-dom-cljs-test`, mounts a UIx comparator (`uix-mount!`, rendering `arm1/dogfood-uix/root`) whose screen mints two UIx `:input` elements (`dogfood_uix.cljs:109` `.new-input`, `:144` `.draft`), and it **never pins**. `the-two-live-renderings-dispatch-the-same-intents-on-the-same-interactions` then drives a 16-step `type-into!` / `keydown!` script through exactly those two fields and compares the intents against Hicasso's.

Under the mutation, every dogfood row **stayed green** while those two fields were built by Reagent's port instead of React's controlled input.

So the honest reading: **no verdict on main was wrong by colour — what was wrong is what the green meant.** The parity gate did not notice which of the two products it was comparing against. That is the rf2-n3dxw fault mode reproduced one namespace over, and it is why this defect was worth a witness rather than just a one-line fix. Filed as **rf2-2rtt6.75** (P3): dogfood should pin explicitly rather than inherit.

## Scope

Surface B, one test file, teardown only. No production code, no bench driver run, no timing row published. The ≤2-hook shell, `subscribe`'s read-set closure and HD-020's `.cljc`-compatible bodies are untouched — this PR does not enter the runtime at all. `arm1/grid.cljs` is unchanged.

**Item 4** of rf2-2rtt6.41 (the survival metric's allocation-slope half) is **deferred**, re-homed to **rf2-2rtt6.76** (P2) with the reason recorded: the box was carrying six concurrent workers, and absolute figures on that rig move ~2x run-to-run on unchanged arms. A slope is a difference of such figures, so it is strictly less robust to the contention than the absolute readings — measuring it today would have produced a number that reads as evidence without being any. rf2-2rtt6.41 is left **open**: item 5 still needs a re-home decision that is not a worker's to make.

## Quality gates

Foreground, to completion, never piped. Exit codes read directly from `$?`.

| gate | exit | result |
| --- | --- | --- |
| `npm run test:browser` | **0** | Ran 1029 tests containing 6408 assertions. 0 failures, 0 errors. |
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`. CLJS node integration: 12442 tests / 62354 assertions, 0 failures. JVM core 2210/11510, JVM freehand 1288/8857. 12 PASS steps, 0 FAIL. |
| `npx clj-kondo --lint <the file>` | **0** | errors: 0, warnings: 0 |
| `npm run test:browser` *(mutation M1, expected red)* | **1** | 21 failures — 20 the new guard, 1 the updated selector row |

`npm run test:browser` is the gate that matters here: the defect is cross-test contamination, and only a run over the whole bundle can show it. No retry was needed — neither browser run hit a par-compile abort.
