### PR TITLE
perf(hicasso): reduce the per-read retained heap (rf2-aqgr2)

### DIFF
--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -659,7 +659,13 @@ record edited to match a later tree stops being a record; the attribution,
 the mechanism and the restated live numbers — **the bill is +499 B/read, not
 +415** — are in
 [the slope subsection](#the-slope-went-stale-before-this-section-merged-and-the-landing-that-moved-it-rf2-2rtt660)
-at the end of this section.
+at the end of this section. **That bill has since been attacked and it is
+now +390 B/read**, the candidate reading 1,338 / 2,175 — one of the three
+things the section names as buying the gap turned out to be a per-key
+identity the runtime did not need, one turned out not to exist at all, and
+the third is filed:
+[the attack](#attacking-the-gap-one-of-the-three-suspects-was-real-rf2-aqgr2),
+also at the end of this section.
 
 ### The answer, first, including the part that does not flatter the design
 
@@ -1390,6 +1396,157 @@ slope effect that runs 1 = 2 = 4 measure at zero. Conditions: 2026-08-02
 13:54–14:20 +1000, React 19.2.0, Reagent 2.0.1, UIx 1.4.4, `:advanced`
 with `goog.DEBUG false`, headless Chromium via Playwright, Windows 11;
 runs ~3.5 minutes each, all exit 0.
+
+### Attacking the gap: one of the three suspects was real (rf2-aqgr2)
+
+**Measured 2026-08-03.** The subsection above leaves the programme with a
+bill of **+499 B/read** against Reagent and three named things buying it —
+the index edge, the key cell and the read-set entry. `rf2-aqgr2` asked
+whether any of the three could be made cheaper or eliminated. One could,
+by 108 B/read; one turned out not to exist; the third is filed rather than
+taken.
+
+**Read these as DELTAS, not as replacement gate rows.** Every run below
+was taken on a box carrying five other workers, which is not the quiet box
+`validation.md` requires of a published absolute. What makes them
+quotable is that both donors ride every run as the negative control and
+answer 947–948 / 2,978–2,980 in all nine, the positive control is `ok`
+in all nine, the arm-order guard is reportable in all nine, the
+candidate reproduces byte-identically across every run that shares a
+tree, and the unchanged `main` arm reproduces the published 1,447. The
+*differences* are therefore instrument-clean even though the box was not
+certified for a new absolute.
+
+#### The key cell was minting an identity it did not need
+
+Every cell carried its own watch key — `(keyword "rf-hicasso-arm1" (str
+"w" (vswap! counter inc)))` — so that `add-watch`/`remove-watch` could
+name it. That bought a uniqueness the runtime already had: there is at
+most one cell per `(frame, query)`, `subs/subscribe` hands back that
+pair's own cached reaction, and no two cells ever hold the same reaction.
+The mint therefore retained a `Keyword`, its name string and its
+fully-qualified string **per unique key** — which is per *read* on this
+rung — plus a field on the cell to hold them. One namespaced constant does
+the same job, and the global counter goes with it.
+
+#### The nine runs
+
+`p0_run.cjs --only ladder`, six rounds, 0/1/3/7/20, Q = E, B = 1,200 —
+the same instrument, plan and guard as the runs above. **A″ and B″ are
+the pair that decides it**: back to back on `1ef3fdb73e`, the `main` this
+landing rebases onto, with `arm1/runtime.cljs` the only file differing
+between them. `main` moved twice under this session — `rf2-2rtt6.32`'s
+codec rewrite, then `rf2-2rtt6.50`'s registry-epoch term — so the pair
+was re-taken each time rather than carried forward. The earlier runs are
+kept because they corroborate, and because three unchanged arms agreeing
+to within 1 B is itself the evidence that neither landing touches this
+axis.
+
+| run | tree | Rg donor | UIx donor | Hicasso, Rg seg. | Hicasso, UIx seg. |
+|---|---|---:|---:|---:|---:|
+| **A″** | **`main` `1ef3fdb73e`, unchanged** | 948 | 2,979 | **1,446** [1,444–1,447] | **2,283** [2,277–2,287] |
+| **B″** | **that tree + this landing** | 947 | 2,980 | **1,338** [1,336–1,340] | **2,175** [2,170–2,179] |
+| A′ | `cda407be49`, unchanged | 948 | 2,980 | 1,447 [1,446–1,448] | 2,283 [2,278–2,287] |
+| B′ | that tree + this landing | 948 | 2,980 | 1,338 [1,337–1,340] | 2,175 [2,170–2,179] |
+| A | `18e92b671a`, unchanged | 948 | 2,980 | 1,446 [1,444–1,448] | 2,283 [2,277–2,287] |
+| B1 | that tree + this landing | 948 | 2,980 | 1,339 [1,338–1,339] | 2,175 [2,170–2,179] |
+| B2 | B1's tree, re-taken | 947 | 2,978 | 1,339 [1,338–1,339] | 2,175 [2,169–2,179] |
+| C | ablation: the watch key only | 947 | 2,979 | 1,339 [1,338–1,339] | 2,175 [2,169–2,179] |
+| D | probe: one forced set copy | 947 | 2,979 | 1,385 [1,384–1,385] | 2,222 [2,216–2,225] |
+
+**The unchanged arm reproduces the published `main` figure** — 1,446–1,447
+B/read against the 1,447 the slope subsection above restates — which is
+the strongest evidence available that this box, contended or not, is
+measuring the same quantity that session did. Its UIx segment reads 2,283
+against that session's 2,289, 0.26% apart and inside the between-session
+offset; the delta below is taken against A″ rather than against the
+published figure for exactly that reason.
+
+**Two `main` landings in this window move this axis by nothing**, which
+is worth recording because the subsection above exists precisely because
+one once did: `rf2-2rtt6.32`'s codec rewrite (A → A′) and
+`rf2-2rtt6.50`'s third `commit-basis` term (A′ → A″) leave the unchanged
+candidate at 1,446 / 1,447 / 1,446 and 2,283 / 2,283 / 2,283. A term
+added to a sum of numbers retains no object per read, and that is a
+prediction checked rather than assumed.
+
+**The shell does not move.** Across A″ → B″ the measured R = 0 rung reads
+`1,244 → 1,246` on the Reagent segment and `1,237 → 1,236` on the UIx
+segment, each inside its own round-to-round band, while the FIRST read
+falls with the slope — `1,893 → 1,779` and `2,740 → 2,624`. That is
+exactly what a per-*key* saving predicts and a per-boundary one does not,
+so the shape of the saving is checked rather than assumed.
+
+#### The index edge's duplicate read set does not exist, and run D prices the sharing that prevents it
+
+The second suspect looked certain on the page: `front.sub-index/record-reads`
+calls `(set read-sub-keys)` on a value the caller is already holding as a
+set, and stores the result as the forward edge for the life of the mount.
+**Run C is the honest negative.** With that call replaced by an explicit
+share-if-already-a-set the slope did not move by one byte, because
+`cljs.core/set` returns a meta-less set unchanged — the sharing was
+already there, and the code change was a no-op. The guard was reverted.
+
+**Run D prices what that sharing is worth**, by forcing the copy the
+suspect assumed (`(into #{} …)`): **+46 B/read** on the Reagent segment and
+**+47** on the UIx segment, donors unmoved. So one retained hash-set
+membership costs ~46 B/read on this rung — a term price the page did not
+have — and the property is now asserted with `identical?` in the index's
+law suite so a tidy-up cannot cost it silently.
+
+#### The read-set entry, and the term that is left
+
+The entry's key array and key set are not redundant with each other: the
+array is what `entry-matches?` compares and what `getSnapshot` sums over,
+the set is what the index and `acquire-cell!` consume, and eliminating
+either only moves its work. It is not attacked here.
+
+What run D's 46 B does make sayable is where the remaining bill most
+likely sits. At Q = E and fan-out 1 the reverse edge `:sub->bs` holds one
+persistent-map entry **and a singleton set** per key, keyed by exactly the
+sub-keys `!cells` is already keyed by — two global maps over one key
+space. That is filed as `rf2-dabt3`: it is an elimination rather than an
+encoding, and it is a redesign of where the dependency index lives rather
+than a byte shave, so it wants a ruling and not a perf worker.
+
+#### What this section hands the programme, restated again
+
+Both columns are A″ and B″, taken back to back on the same box, and both
+are stated against a donor of 948 / 2,980 so a 1 B round-to-round donor
+wobble does not read as a change in the bill.
+
+| live number | `main` before this landing (A″) | on this landing (B″) |
+|---|---:|---:|
+| the design's bill (Reagent seg., candidate − donor) | +498 B/read (1.5253×) | **+390 B/read** (1.4114×) |
+| the design's win (UIx seg., donor − candidate) | −697 B/read (0.7661×) | **−805 B/read** (0.7299×, a 27.0% margin) |
+| the bracket a shipped Hicasso sits in | 1,446 – 2,283 B/read | **1,338 – 2,175 B/read** |
+| the grouped tier's ~2,000 B line | cleared on the Reagent substrate only | unchanged in kind: 1,338 < 2,000 < 2,175 |
+
+**943/948 B/read is still not beaten**, and the verdict's shape is
+unchanged: the axis is won against UIx — now by more than five times the
+instrument-limited floor — and lost to Reagent's `deref`-capture. What
+moved is the size of the loss, by 22%. The crossover against the UIx
+spine is deliberately **not** restated: rf2-2rtt6.34 is reopened on which
+model this page states it in, and a fifth number computed a sixth way is
+the opposite of what that bead asks for.
+
+#### Provenance
+
+Whole-tree anchors: A″ on `1ef3fdb73e`; B″ on that tree plus this
+landing, which moves `arm1/runtime.cljs` alone. A′ and B′ were taken the
+same session on `cda407be49`, and A, B1, B2, C and D on `18e92b671a` —
+before `rf2-2rtt6.32`'s codec rewrite and `rf2-2rtt6.50`'s registry term
+landed on `main`. The unchanged arm measures both landings' effect on
+this axis at one byte, which is why the earlier seven still
+corroborate. C reverts
+`front/sub_index.cljs`'s share guard to `(set read-sub-keys)`; D forces
+that call to `(into #{} read-sub-keys)`; both are working-tree probes and
+ship nowhere. The six instrument blobs are unmoved from the provenance
+table above. Conditions: 2026-08-03 11:06–12:54 +1000, React 19.2.0,
+Reagent 2.0.1, UIx 1.4.4, `:advanced` with `goog.DEBUG false`, headless
+Chromium via Playwright, Windows 11, **box NOT verified quiet** (five
+concurrent workers); runs ~3.9 minutes each, all exit 0, `0 unverified of
+154 mounts` and the structural witness fully answered on every one.
 
 ---
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -494,8 +494,29 @@
 (defonce ^:private !batching (volatile! false))
 (defonce ^:private !generation (volatile! 0))
 (defonce ^:private !deferred (volatile! #{}))
-(defonce ^:private !watch-counter (volatile! 0))
 (defonce ^:private !registry-epoch (volatile! 0))
+
+(def ^:private cell-watch-key
+  "**One constant keyword for every cell's value-change watch** — not a
+  minted-per-cell identity (rf2-aqgr2).
+
+  A watch key has to be unique *within the watched reference*, and it is:
+  there is at most one cell per `(frame, query)`, `subs/subscribe` hands
+  back that pair's own cached reaction, and no two cells ever hold the
+  same reaction — so one namespaced constant collides with nothing this
+  arm installs, and its namespace keeps it clear of the substrate's own
+  watchers (`substrate.observation` keys per handle on the same
+  reactions).
+
+  It used to be `(keyword \"rf-hicasso-arm1\" (str \"w\" (vswap! counter inc)))`,
+  which bought that same uniqueness by allocating a `Keyword`, its name
+  string and its fully-qualified string per cell and retaining all three
+  in the cell and in the reaction's watch map — per *unique key*, which is
+  per *read* on the distinct-query rung the per-read heap ladder is taken
+  on. The uniqueness was already structural; only the identity was being
+  paid for. The counter goes with it: a global that numbered something
+  that never needed a number."
+  ::cell-watch)
 
 (defn generation
   "The commit generation. Bumped once per flush that moved something."
@@ -586,7 +607,7 @@
 (defn- dispose-cell! [^js cell]
   (when-not (.-disposed cell)
     (set! (.-disposed cell) true)
-    (when-some [r (.-reaction cell)] (remove-watch r (.-watchKey cell)))
+    (when-some [r (.-reaction cell)] (remove-watch r cell-watch-key))
     (swap! !cells dissoc (.-subKey cell))
     (subs/unsubscribe (.-frameKw cell) (.-queryV cell)))
   nil)
@@ -621,13 +642,12 @@
   [^js cell]
   (let [frame-kw (.-frameKw cell)
         query-v  (.-queryV cell)
-        wk       (.-watchKey cell)
         reaction (subs/subscribe query-v {:frame frame-kw})]
     (set! (.-reaction cell) reaction)
     (when (some? reaction)
       ;; ONE baseline deref, before the watch — see `acquire-cell!`.
       @reaction
-      (add-watch reaction wk
+      (add-watch reaction cell-watch-key
                  (fn [_ _ old nu] (when-not (= old nu) (mark-dirty! cell))))
       (interop/add-on-dispose! reaction (fn [] (invalidate-cell! cell))))
     cell))
@@ -786,13 +806,10 @@
   (let [^js cell (or (get @!cells sub-key)
                  (let [frame-kw (nth sub-key 0)
                        query-v  (nth sub-key 1)
-                       wk       (keyword "rf-hicasso-arm1"
-                                         (str "w" (vswap! !watch-counter inc)))
                        ^js fresh #js {"subKey"   sub-key
                                      "frameKw"  frame-kw
                                      "queryV"   query-v
                                      "reaction" nil
-                                     "watchKey" wk
                                      ;; NOT zero. A key with no cell
                                      ;; contributes the CURRENT
                                      ;; `commit-basis` to `getSnapshot`,

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
@@ -474,6 +474,16 @@
   (seeded! 3)
   (let [a (mounted! (fn [_] [:span (str (rt/sub [:dogfood/remaining]))]))
         b (mounted! (fn [_] [:span (str (rt/sub [:dogfood/remaining]))]))]
+    (is (= 1 (:cells (rt/stats)))
+        "ONE cell for the shared key, holding two references — and that is
+         also what lets `cell-watch-key` be a single namespaced constant
+         rather than an identity minted per cell (rf2-aqgr2). A watch key
+         has to be unique within the reference it watches; no two cells
+         ever hold the same reaction, so nothing can clobber another
+         cell's watch. Mint a cell per reader instead and this row goes
+         red: two cells on one reaction, and the second `add-watch`
+         silently replacing the first's")
+    (is (= 2 (:cell-refs (rt/stats))))
     (rt/dispatch! frame-id [:dogfood/toggle 0])
     (is (= 1 @(:hits a)))
     (is (= 1 @(:hits b)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index.cljs
@@ -141,6 +141,21 @@
   A boundary that is not live is ignored. See the namespace docstring:
   an abandoned render must not resurrect an unmounted boundary's edges.
 
+  **`set` here is a coercion and must never become a copy, and that is a
+  measured constraint rather than a stylistic one (rf2-aqgr2).** A caller
+  handing over a set — which is what every runtime caller does — hands
+  over the set the FORWARD EDGE THEN RETAINS FOR THE LIFE OF THE MOUNT,
+  and `cljs.core/set` gives it back unchanged when it is already a
+  meta-less set. Replace this call with a rebuild (`(into #{} …)`, a
+  transient loop) and the boundary retains a second hash set with
+  identical contents: measured on `p0_run.cjs --only ladder`, that costs
+  **+46 B/read** on the Reagent segment and **+47 B/read** on the UIx
+  segment, donors unmoved, and it would be invisible in every test in the
+  suite. The coercion stays for callers that pass a sequence, which is
+  the general contract this namespace is written to;
+  `the-forward-edge-shares-a-callers-set-rather-than-copying-it` is what
+  keeps the sharing from being lost to a tidy-up.
+
   **Which half of the difference a caller exercises depends on how
   durable its boundary ids are, and that is worth knowing before reading
   a discharge against this function (rf2-2rtt6.47).** A caller that

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index_laws_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index_laws_cljs_test.cljs
@@ -197,6 +197,29 @@
       (is (= #{} (idx/edges-of index :b)))
       (is (true? (idx/live? index :b))))))
 
+(deftest the-forward-edge-shares-a-callers-set-rather-than-copying-it
+  (testing "rf2-aqgr2, and the assertion is `identical?` on purpose. The
+           forward edge retains this set for the life of the mount, so a
+           `record-reads` that COPIED it would leave the boundary holding
+           a second hash set with the same contents — measured at +46
+           B/read (Reagent segment) and +47 (UIx) on `p0_run.cjs --only
+           ladder`, and invisible to every value-equality assertion in
+           this file. `cljs.core/set` returns a meta-less set unchanged,
+           so the sharing is already there; this is the row that stops a
+           rebuild being reintroduced as a tidy-up"
+    (let [reads #{[:x] [:y]}
+          index (-> (idx/empty-index) (idx/mount :b) (idx/record-reads :b reads))]
+      (is (identical? reads (idx/edges-of index :b)))))
+  (testing "and a caller handing over a SEQUENCE still gets a set edge —
+           that is the general contract this namespace is written to, and
+           the coercion is what a caller passing read order relies on"
+    (let [index (-> (idx/empty-index)
+                    (idx/mount :b)
+                    (idx/record-reads :b [[:x] [:y] [:x]]))]
+      (is (set? (idx/edges-of index :b)))
+      (is (= #{[:x] [:y]} (idx/edges-of index :b)) "duplicates collapse")
+      (is (= #{:b} (idx/dirty-boundaries index #{[:y]}))))))
+
 (deftest the-global-index-is-one-atom-and-commit-is-its-only-door
   (idx/mount! :a)
   (idx/mount! :b)


### PR DESCRIPTION
Closes rf2-aqgr2.

Section 6 of the reads-per-boundary heap ladder leaves the programme with a
**+499 B/read bill** against Reagent on the same substrate, and names three
things as buying it: the index edge, the key cell and the read-set entry.
`rf2-aqgr2` asked whether any of the three could be made cheaper or
**eliminated**. One could. One turned out not to exist. The third is filed
rather than taken.

**The bill is now +390 B/read.**

## The landing: the key cell was minting an identity it did not need

Every key cell minted its own watch key —
`(keyword "rf-hicasso-arm1" (str "w" (vswap! !watch-counter inc)))` — so
that `add-watch` / `remove-watch` could name it. That bought a uniqueness
the runtime already had structurally: there is at most one cell per
`(frame, query)`, `subs/subscribe` hands back that pair's own cached
reaction, and **no two cells ever hold the same reaction**. The mint
therefore retained a `Keyword`, its name string and its fully-qualified
string **per unique key** — which is per *read* on the distinct-query rung
the ladder is taken on — plus a field on the cell to hold it.

One namespaced constant does the same job. The global counter goes with it,
and `wire-cell!` loses a binding.

## Per-suspect verdict

Measured with `p0_run.cjs --only ladder`, six rounds, 0/1/3/7/20, Q = E,
B = 1,200 — the instrument the bead names. **A'' and B'' are the deciding
pair**, taken back-to-back on `main` `1ef3fdb73e` (this branch's base) with
only `arm1/runtime.cljs` differing between them.

| run | tree | Rg donor | UIx donor | Hicasso, Rg seg. | Hicasso, UIx seg. |
|---|---|---:|---:|---:|---:|
| **A''** | `main` `1ef3fdb73e`, unchanged | 948 | 2,979 | **1,446** [1,444-1,447] | **2,283** [2,277-2,287] |
| **B''** | + this landing | 947 | 2,980 | **1,338** [1,336-1,340] | **2,175** [2,170-2,179] |
| A' | `cda407be49`, unchanged | 948 | 2,980 | 1,447 | 2,283 |
| B' | + this landing | 948 | 2,980 | 1,338 | 2,175 |
| A | `18e92b671a`, unchanged | 948 | 2,980 | 1,446 | 2,283 |
| B1 | + this landing | 948 | 2,980 | 1,339 | 2,175 |
| B2 | B1 re-taken | 947 | 2,978 | 1,339 | 2,175 |
| C | ablation: watch key only | 947 | 2,979 | 1,339 | 2,175 |
| D | probe: one forced set copy | 947 | 2,979 | 1,385 | 2,222 |

**KEY CELL - real, and it is the whole of the saving.** -108 B/read on both
segments, reproduced across four runs on three bases. The **shell does not
move** (1,244 -> 1,246 and 1,237 -> 1,236, both inside their own bands)
while the FIRST read falls with the slope (1,893 -> 1,779 and
2,740 -> 2,624) - which is what a per-*key* saving predicts and a
per-boundary one does not, so the shape of the saving is checked, not
assumed.

`main` moved twice under this session (`rf2-2rtt6.32`'s codec rewrite, then
`rf2-2rtt6.50`'s registry-epoch term), so **the pair was re-taken on each
new base rather than carried forward** - which is the failure the slope
subsection above this one exists to record. The three unchanged arms agree
to within 1 B, so both of those landings measure at zero on this axis, and
that is now on the page too.

**INDEX EDGE - the duplicate does not exist. Honest negative.** It looked
certain: `front.sub-index/record-reads` calls `(set read-sub-keys)` on a
value the caller already holds as a set, and retains the result as the
forward edge for the life of the mount. I changed it to share explicitly,
measured, and **run C says the slope did not move by one byte** -
`cljs.core/set` returns a meta-less set unchanged, so the sharing was already
there and my change was a no-op. **The code change was reverted.** Run D then
prices what that existing sharing is worth, by forcing the copy the suspect
assumed (`(into #{} ...)`): **+46 B/read** (Reagent) / **+47** (UIx). That is
a term price the page did not have, and the property is now asserted with
`identical?` so a tidy-up cannot cost it silently.

**READ-SET ENTRY - not reducible as it stands.** Its key array and key set
are not redundant with each other: the array is what `entry-matches?`
compares and what `getSnapshot` sums over, the set is what the index and
`acquire-cell!` consume. Eliminating either only moves its work. Not
attacked.

## Costed and DECLINED

- **Merging `:sub->bs` into `!cells`** - two global persistent maps keyed by
  the same B*R sub-keys, plus a singleton reader set per key at fan-out 1.
  On run D's 46 B/membership this is plausibly the largest term left in the
  +390. It is an elimination, not an encoding, and I would have taken it -
  but it dissolves the shared front half's six-law algebra and moves
  `architecture.md`'s central sentence, so it is a **ruling**, not a perf
  worker's call. Filed as **rf2-dabt3 (P2)** with the method to measure it.
- **Denormalised `frameKw` / `queryV` on the cell** - both are
  `(nth subKey 0/1)`. Removing them saves two object slots per read, low tens
  of bytes, at the cost of a second lookup in `flush!`'s hot loop. Below what
  this instrument resolves, against the cost of touching a hot path.
  **Declined, not filed** - it is minutiae.
- **`:live`** - exactly the key set of `:b->subs` at every reachable index
  value, so a redundant index. It is per-*boundary*, so it moves the shell
  and not the slope this bead is about. Filed as **rf2-ixb92 (P3)**.
- **`read_profile_app.cljs`'s local cell copy** still mints a watch keyword,
  so its "faithful copy" claim is now one allocation out of date. It is a
  **clock** instrument; changing it moves its own rows and I had no mandate
  to re-take them. Filed as **rf2-6wh9o (P3)** - this is the "a bench arm
  prices a shape that no longer ships" trap, caught rather than joined.
- **The evidence seam** builds its event map before checking whether a sink
  is attached, so `record-reads!`'s docstring claim ("one deref and one nil
  test") is false. Allocation, not retention. Filed as **rf2-e3i6y (P3)**.

## Fences

**Hook count untouched - the shell is not in the diff.** `shell`,
`shell-hook-ledger` and `mint-view!` are byte-identical;
`arm1_hook_ledger_dom_cljs_test` still counts two at React's dispatcher.
`subscribe` still closes over the read set alone. No third hook, no
per-instance render-phase state, no candidate ledger. Bodies unchanged, and
everything here stays `.cljc`-compatible.

## Mutation proof

Two independent mutations applied together, each predicted **before** the run
to redden exactly one named row, in a suite of 12,424 tests. (Taken on this
branch before its final rebase; the rebase changed neither mutated site nor
either witness, and both sites are byte-identical in what is proposed here.)

| mutation | predicted | observed |
|---|---|---|
| `record-reads`'s `(set ...)` -> `(into #{} ...)` | `the-forward-edge-shares-a-callers-set-rather-than-copying-it` | **FAIL**, that row, on the `identical?` assertion |
| `acquire-cell!` mints a fresh cell when the existing one has readers | `two-boundaries-sharing-a-subscription-both-run` | **FAIL**, that row, `(= 2 (:cell-refs ...))` -> `(not (= 2 1))` |

`2 failures, 0 errors` - nothing else in the suite moved. Both reverted with
`git checkout HEAD --`, so byte-identically; `git status` clean afterwards.

## Quality gates

All foreground, to completion, nothing piped, all on the final rebased tree.
Logs are worktree-local under `ai/findings/logs/`.

| gate | result | exit |
|---|---|---|
| `npm run test:cljs` (node CLJS - carries both new witnesses) | 12,443 tests / 62,337 assertions / 0 failures / 0 errors | **0** |
| `npm run test:browser` | 1,029 tests / 6,385 assertions / 0 failures / 0 errors | **0** |
| `sh scripts/test-fast-pr.sh` | `PASS fast PR spine` - docs tier (all five gates incl. `mkdocs --strict`), JVM `implementation/core` 2,210 tests / 11,510 assertions, JVM `implementation/freehand` 1,288 tests / 8,857 assertions, JS harness helpers, node CLJS + per-ns isolation (17/17 standalone) | **0** |
| the five documentation gates, re-run directly on the final content: `check_readme_links.py`, `check_doc_slugs.py`, `check_ep_status_sync.py`, `check_runtime_subsystem_grading.py`, `mkdocs build --strict` | all pass | **0** each |
| `p0_run.cjs --only ladder` x 9 | positive control `ok`, `0 unverified of 154 mounts`, structural witness fully answered, arm-order guard reportable - every run | **0** each |

**Doc verification done by hand, as `CLAUDE.md` requires** -
`mkdocs build --strict` deliberately excludes `docs/design/**`, so it is not
the gate for this edit. Verified by hand: the new subsection's two tables are
6-column and 3-column throughout (header, separator and every data row), and
the one anchor I added a link to
(`#attacking-the-gap-one-of-the-three-suspects-was-real-rf2-aqgr2`) resolves.
`check_doc_slugs.py` re-validates every link target and heading anchor in the
tree and exits 0.

## Measurement honesty

**The box was NOT quiet** - five other workers - and the subsection says so
in those words. These are therefore **deltas against same-run donors**, not
replacement gate rows: both donors ride every run as the negative control and
answer 947-948 / 2,978-2,980 in all nine, and **the unchanged arm reproduces
the published `main` figure of 1,447**, which is the strongest available evidence
that this box is measuring the same quantity the publishing session did. Its
UIx segment reads 2,283 against that session's 2,289 (0.26% apart, inside the
between-session offset), which is why the delta is stated against A''
and never against the published number.

This branch also carries a merge-conflict resolution in
`arm1/runtime.cljs` against `rf2-2rtt6.50` (PR #7411), which landed on the
same lines: both intents are kept - their `!registry-epoch` counter and my
`cell-watch-key` constant - and the whole suite plus the re-taken pair is
what checks it.

The crossover against the UIx spine is **deliberately not restated**:
rf2-2rtt6.34 is reopened on which model this page states it in, and a fifth
number computed a sixth way is the opposite of what that bead asks for.
