### PR TITLE
feat(hicasso): one callback form — the position selects the convention (rf2-2rtt6.35)

### DIFF
--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -138,7 +138,7 @@ There is **one** callback form, `h/fn`, and it is an **ordinary function**:
 | Position | Contract |
 |---|---|
 | a native `:on-*` prop | **event** — a returned vector is dispatched; any other return is ignored |
-| a `defhost` `:callbacks` entry | as **declared** (`:event` or `:handler`) |
+| a `defhost` `:callbacks` entry | as **declared** (`:event`, `:handler` or `:render`) |
 | any other walked prop position (a slot, a foreign render prop) | **render** — pure; the return is output, and dispatching from inside is a loud error **naming the position** |
 | `:ref` | React's own contract; not lowered |
 | anywhere Hicasso does not walk | a plain function; it runs, and its return is ignored |
@@ -148,6 +148,21 @@ vector is; the value is lowered where it finally lands. Ordinary functions remai
 untouched at every position, which is why there is no separate identity-passthrough
 form: the codec already hands functions to React by identity so `React.memo` and
 handler-identity bail-outs keep working.
+
+**The declared contract governs every carrier at that position**, not just the
+`h/fn`. An intent vector and a key-map are each a dispatch and nothing else, so
+they are accepted at `:event` and refused at `:handler` and `:render` with
+`:rf.error/hicasso-intent-at-a-non-event-contract` — otherwise the value would be
+selecting the contract, which is the thing the row above forbids.
+
+**The vector spelling is event-first.** `::h/prevent`, `::h/value`, `::h/checked`
+and a key-map's key lookup read the DOM event from **argument one** — what a
+native position hands them and what `onDraft(event)` hands them. A value-first
+foreign invoker (`onPick(value, event)`) raises
+`:rf.error/hicasso-intent-needs-the-event` naming the position, rather than the
+engine's `value.preventDefault is not a function`; `h/fn` is the spelling there,
+since it receives every argument in order. An intent carrying neither a marker nor
+a decorator never reads its argument, so it is correct under any invoker contract.
 
 The point of the collapse is the last row. In the predecessor the roster forms are
 carriers — marker objects — so one handed to a raw `#js` prop is not callable and

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -715,7 +715,7 @@ the runtime already knows every position it walks:
 | Position | Contract |
 |---|---|
 | a native `:on-*` prop | **event** — a returned VECTOR is dispatched; any other return is ignored |
-| a `defhost` `:callbacks` entry | as **declared** (`:event` or `:handler`), never inferred from an `on*` name |
+| a `defhost` `:callbacks` entry | as **declared** (`:event`, `:handler` or `:render`), never inferred from an `on*` name |
 | any other walked prop position (a slot, a foreign render prop) | **render** — pure; the return is render output and is not dispatched, and dispatching from inside is `:rf.error/hicasso-dispatch-in-render-position`, **naming the position** |
 | `:ref` | React's own: commit phase, node in, cleanup out. Excluded from lowering |
 | anywhere Hicasso does not walk (a raw `#js` prop) | it is a plain function; it runs, and its return is ignored |
@@ -734,6 +734,32 @@ author wrote, against a form whose parameter vector is arbitrary by construction
 functions to React by identity, deliberately, so that `React.memo` and every
 downstream bail-out comparing handler identity keep working. The behaviour the
 predecessor spells as a fourth roster form is the default here.
+**The declaration governs EVERY carrier at its position, not only the one form.**
+A declared position accepts four carriers — the one form, an intent vector, a
+key-map, and an ordinary value — and the row above is a law about the POSITION,
+so the contract is the outer question and the carrier the inner one. `:event`
+keeps the vector and key-map conveniences, because dispatching is exactly what
+that contract means; at `:handler` and at `:render` both are **refused**
+(`:rf.error/hicasso-intent-at-a-non-event-contract`, naming the position), because
+each of those carriers is a dispatch and nothing else while neither contract
+dispatches. Reading the value first is how a declaration that says `:handler`
+comes to dispatch a bare intent silently, and how a `:render` position comes to
+dispatch during the foreign component's own render — the VALUE selecting the
+contract, which is the defect this ruling exists to delete. An ordinary unmarked
+function crosses untouched at every contract.
+**The vector spelling is EVENT-FIRST.** `::h/prevent`, `::h/value`,
+`::h/checked`, `:on-submit`'s auto-prevent and a key-map's key lookup all read
+the DOM event, and all read it from argument **one** — what every native position
+hands them, and what an event-first foreign contract (`(on-draft event)`) hands
+them too. A value-first invoker (`(on-pick value event)`) has no event there, and
+nothing guesses which of a library's arguments is one: inference at that seam is
+what HD-011 forbids in the first place. The refusal is
+`:rf.error/hicasso-intent-needs-the-event`, naming the position and pointing at
+`h/fn` — the one form, which receives every argument in order — rather than
+leaving the author `value.preventDefault is not a function`, the engine's own
+`TypeError` naming nothing they wrote. An intent carrying neither a marker nor a
+decorator never reads its argument at all, so it is correct under any invoker
+contract and pays no law.
 
 **Rationale.** The predecessor requires an author who cannot use a bare event
 vector to pick from a roster of **four** forms with four different contracts —

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -81,7 +81,7 @@ not offered at any level. Guessing which nested maps are options and which are d
 is the support burden the shallow default exists to delete; convert the map yourself
 when a library wants camelCase inside it.
 
-## Callbacks: `:event` and `:handler`
+## Callbacks: `:event`, `:handler` and `:render`
 
 A declared slot in `:callbacks` carries a contract, never inferred from an `on*`
 spelling:
@@ -89,7 +89,8 @@ spelling:
 ```clojure
 (h/defhost picker Widget
   {:callbacks {:on-pick       :event
-               :on-imperative :handler}})
+               :on-imperative :handler
+               :on-render-row :render}})
 ```
 
 **`:event`** is the door's version of an ordinary `:on-*` position — an intent
@@ -97,9 +98,7 @@ vector, or an `h/fn` when you need to read what the library handed you. The proo
 pins the detail a native position doesn't have to: a foreign invoker calls with
 *its own* arguments, not a lone DOM event — `onPick(value, event)`,
 `onDraft(event)` — and **every argument the invoker passed reaches the `h/fn`
-body**, in the order the library sent them. `::h/prevent` works at a declared
-`:event` position too, and calls `.preventDefault` on whichever argument is the
-real DOM event.
+body**, in the order the library sent them.
 
 **`:handler`** crosses the function by identity rather than wrapping it: the
 library gets exactly the function you wrote — so a library that memoises on
@@ -108,6 +107,43 @@ goes back to *that caller*; Hicasso never sees the return and never dispatches
 from it. This is the shape for a library's imperative surface (`open()`,
 `scrollTo()`): `defhost` doesn't know what an arbitrary imperative call means, so
 `:handler` stays out of its way entirely.
+
+**`:render`** is the third contract, for a library that calls you back *during its
+own render* — `renderRow`, `renderItem`, a render prop. The body must be pure: its
+return is what the library puts in its tree, and dispatching from inside it raises
+`:rf.error/hicasso-dispatch-in-render-position`, naming the position.
+
+### The declaration decides; the value never overrules it
+
+The contract you declared governs **every** carrier at that position, not just the
+`h/fn`. An intent vector and a key-map are each a dispatch and nothing else, so
+they are accepted at `:event` — where dispatching is what the contract means — and
+**refused** at `:handler` and `:render` with
+`:rf.error/hicasso-intent-at-a-non-event-contract`. There is no reading of a bare
+vector that a `:handler` could honour, and a `:render` position that dispatched
+would be dispatching mid-render. If what happens at that slot is an event, declare
+it `:event`; otherwise write an `h/fn` that does the work. An ordinary unmarked
+function crosses untouched at all three.
+
+### The vector spelling is event-first
+
+`::h/prevent`, `::h/value`, `::h/checked` and a key-map's key lookup all read the
+DOM event, and they all read it from **argument one**. That is what every native
+position hands them, and what an event-first foreign contract (`onDraft(event)`)
+hands them too.
+
+A value-first invoker — `onPick(value, event)`, or the date picker's
+`onChange(date)` — has no event at argument one, and nothing can guess which of a
+library's arguments is one. Hicasso says so rather than letting the engine say it:
+you get `:rf.error/hicasso-intent-needs-the-event`, naming the position and the
+argument that actually arrived, instead of `value.preventDefault is not a
+function`. **`h/fn` is the spelling for those positions** — it receives every
+argument the invoker passed, in order, which is exactly what the opening example
+does.
+
+An intent carrying neither a marker nor `::h/prevent` never touches its argument,
+so `{:on-pick [:city/picked "paris"]}` is correct under any invoker contract at
+all.
 
 ## Providers cross the door too
 
@@ -329,12 +365,16 @@ will rescue it later.
 
 ## Troubleshooting
 
-This table names mechanisms; the one minted id on this surface —
-`:rf.error/hicasso-ref-vector-reserved` — is covered above.
+This table names mechanisms; the minted ids on this surface —
+`:rf.error/hicasso-ref-vector-reserved`,
+`:rf.error/hicasso-intent-at-a-non-event-contract` and
+`:rf.error/hicasso-intent-needs-the-event` — are covered above.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | Prop arrives as `on-change` and the library ignores it | Nested keys expected in camelCase; deep conversion is deliberately not offered | Convert the nested map yourself before it crosses |
+| An intent vector or key-map at a declared slot raises `:rf.error/hicasso-intent-at-a-non-event-contract` | The slot is declared `:handler` or `:render`, and neither contract dispatches — the declaration governs the carrier, so the value cannot overrule it | Declare the slot `:event` if what happens there is an event, or write an `h/fn` that does the `:handler`/`:render` work |
+| `:rf.error/hicasso-intent-needs-the-event`, naming a slot whose library hands a value first | The vector spelling reads the DOM event from argument one, and this invoker put something else there | Write an `h/fn` at that slot — it gets every argument the library passed, in order |
 | A namespace stops loading on the JVM | A JS require reached a `.cljc` file | Quarantine the require in a `.cljs` host namespace |
 | Structural test can't match a node | It's a `[:>]` node — reduced structural identity, by design | Declare it with `defhost`, or assert around it |
 | Provider from a library needs to wrap the tree | Hosted like anything else | `defhost` the provider; it is a component |
@@ -361,7 +401,7 @@ two or three genuinely hard widgets.
 | The codemod's name and invocation | **Not addressed** |
 | When the reserved `{:ref [id config]}` spelling lands, and what registers an id | **Reserved, not designed.** HD-022 rules the refusal and the value-space; the registry, the timings and the commands roster are explicitly out of v0 |
 | Which React version the runtime targets | **Not addressed by the design record.** The cleanup-returning callback ref taught above is a React 19 contract; this repo's implementation currently pins React 19.2, but that is a fact about today's tree, not a Hicasso ruling. If v0 lands on 18, the fallback shape above is the one to teach |
-| Whether `::h/value` works across a host crossing | **Proven, conditionally.** It works exactly when the foreign contract hands the DOM event first — the way `onChange`/`onInput` do. A value-first invoker (`onPick(value, event)`, or the date picker's `onChange` above) has no event at that position for `::h/value` to read a target from; write an `h/fn` there instead, as the opening example does |
+| Whether `::h/value` works across a host crossing | **Settled, and it is a law rather than a caveat.** The vector spelling is event-first, so `::h/value` works exactly when the foreign contract hands the DOM event first — the way `onChange`/`onInput` do. A value-first invoker (`onPick(value, event)`, or the date picker's `onChange` above) raises `:rf.error/hicasso-intent-needs-the-event` naming the position; write an `h/fn` there instead, as the opening example does. See **The vector spelling is event-first** above |
 | The SSR placeholder's shape | Declared policy, inert in v0 |
 | Whether a hosted component can be a `defview`'s child via `(:children props)` | The ABI says an existing React element is a legal child anywhere, which implies yes; not stated for the host case specifically |
 | Embedding Hicasso *inside* a React-primary app | Named in the charter's use-case roster (item 11); no surface designed |

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
@@ -68,6 +68,7 @@
             [re-frame.bench.hicasso.arm1.presence :refer [presence]]
             [re-frame.bench.hicasso.arm1.runtime :as rt]
             [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.intent :as intent]
             [re-frame.bench.hicasso.lane :as lane]
             [re-frame.core :as rf]
             [re-frame.test-support :as test-support]
@@ -195,6 +196,13 @@
                           (when-some [f (.-onImperative props)]
                             (swap! !instr assoc :imperative-return (f 41))))}
         "run")
+      ;; A RENDER PROP — invoked during THIS component's own render, which
+      ;; is the position table's render row met at a real foreign
+      ;; component (`renderRow`/`renderItem`, the shape half the ecosystem
+      ;; ships). Its return goes straight into the library's tree.
+      (react/createElement "div" #js {:className "widget-render"}
+        (when-some [f (.-onRenderRow props)]
+          (f (.-label props))))
       (react/createElement "div" #js {:className "widget-slot"}
         (.-children props)))))
 
@@ -212,6 +220,14 @@
   "A provider an ecosystem library hands you is hosted like anything
   else — it is a component (the guide's own troubleshooting row)."
   (.-Provider theme-context))
+
+(defhost render-picker widget
+  "The same component, declared with all THREE contracts on it — the
+  matrix below needs one host that can be handed every carrier at every
+  contract, and `:render` is the row `picker` above has no slot for."
+  {:callbacks {:on-pick       :event
+               :on-imperative :handler
+               :on-render-row :render}})
 
 (def ^:private memo-widget (react/memo widget))
 
@@ -254,6 +270,15 @@
   nothing else."
   [_]
   [picker {:label (rt/sub [:hatch/label])}])
+
+(defview render-prop-page
+  "A declared `:render` slot, driven by the foreign component's own
+  render. The body is pure and its return is what the library puts in
+  its tree — the position table's render row, met where it actually
+  bites."
+  [_]
+  [render-picker {:label         (rt/sub [:hatch/label])
+                  :on-render-row (hfn [label] (str "rendered:" label))}])
 
 (defview tray
   "The host under presence, WITH callbacks — the fence rf2-2rtt6.66's
@@ -594,6 +619,193 @@
         (is (= 1 (unchecked-get row "day-of-week"))
             "nested keys are NOT renamed — shallow means shallow")
         (is (nil? (unchecked-get row "dayOfWeek")))))))
+
+;; ---------------------------------------------------------------------------
+;; 5b — the declaration GOVERNS, and the vector spelling is EVENT-FIRST
+;;      (HD-024, rf2-2rtt6.35). These rows run under :node-test too.
+;; ---------------------------------------------------------------------------
+;;
+;; Two laws, one surface, and both of them are about the door rather than
+;; about the value:
+;;
+;;   (a) the CONTRACT the declaration named governs every carrier at that
+;;       position — not only the `h/fn`.  Before this, a vector took the
+;;       intent path and a map the key-map path whatever the declaration
+;;       said, so a slot declared `:handler` silently dispatched and a
+;;       slot declared `:render` could dispatch during the foreign
+;;       component's own render.  That is the value selecting the
+;;       contract, which is precisely what HD-024 deletes.
+;;   (b) the vector spelling reads the DOM event from argument ONE.  A
+;;       foreign invoker that hands a value first has no event there, and
+;;       the refusal names the POSITION and points at `h/fn` — instead of
+;;       `value.preventDefault is not a function`, the engine's own
+;;       TypeError naming nothing the author wrote.
+;;
+;; The rows below cross through the real minted head and then invoke the
+;; lowered prop the way [[widget]] invokes it — `(f (.-value props) e)` for
+;; `onPick`, `(f e)` for `onDraft`, both visible in this file.  The mounted
+;; render-prop row above the matrix is the other half: a `:render` slot
+;; actually called during the foreign component's render.
+
+(defn- prop [^js el nm] (unchecked-get (unchecked-get el "props") nm))
+
+(defn- crossed
+  "Cross one attr map through the real door under a recording dispatch,
+  and answer `[element !dispatched]`. The frame is bound for the crossing
+  only, so every closure it produces is invoked — like a browser's — after
+  the render's dynamic extent has unwound."
+  [head props]
+  (let [!seen (atom [])
+        el    (intent/with-frame (fn [ev] (swap! !seen conj ev) nil)
+                (fn [] (codec/as-element [head props])))]
+    [el !seen]))
+
+(deftest a-declared-render-slot-is-invoked-during-the-foreign-render
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (instr!)
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [render-prop-page {}])]
+        (try
+          (mount/settle!)
+          (is (= "rendered:due date" (.-textContent (q handle ".widget-render")))
+              "the h/fn ran inside the foreign component's own render and its
+               return went into the library's tree — not to dispatch")
+          (is (= [] (:picked (db))) "and nothing dispatched")
+          (finally (mount/release! handle)))))))
+
+(deftest the-declaration-governs-every-carrier-at-its-position
+  (testing ":event takes all four carriers, because dispatching is what that
+            contract MEANS"
+    (let [[el !seen] (crossed render-picker
+                             {:on-pick (hfn [city e] [:hatch/picked city (.-type e)])})]
+      ((prop el "onPick") "paris" #js {:type "click"})
+      (is (= [[:hatch/picked "paris" "click"]] @!seen) "h/fn: the returned vector dispatched"))
+    (let [[el !seen] (crossed render-picker {:on-pick [:hatch/picked "static" "vec"]})]
+      ((prop el "onPick") #js {})
+      (is (= [[:hatch/picked "static" "vec"]] @!seen) "an intent vector lowers as at a native position"))
+    (let [[el !seen] (crossed render-picker {:on-pick {"Enter" [:hatch/closed]}})]
+      ((prop el "onPick") #js {:key "Enter"})
+      (is (= [[:hatch/closed]] @!seen) "and a key-map lowers as at a native position"))
+    (let [[el !seen] (crossed render-picker {:on-pick identity})]
+      (is (identical? identity (prop el "onPick"))
+          "an ordinary function is claimed by no contract and crosses by identity")
+      (is (= [] @!seen))))
+
+  (testing ":handler crosses the h/fn by identity and REFUSES the dispatching
+            carriers — its return is ignored and Hicasso dispatches nothing
+            from it, so a carrier whose entire content is a dispatch has no
+            reading there"
+    (let [[el _] (crossed render-picker {:on-imperative stable-imperative})]
+      (is (identical? stable-imperative (prop el "onImperative"))))
+    (is (= :rf.error/hicasso-intent-at-a-non-event-contract
+           (error-id #(crossed render-picker {:on-imperative [:hatch/closed]})))
+        "a bare intent at a declared :handler no longer silently dispatches")
+    (is (= :rf.error/hicasso-intent-at-a-non-event-contract
+           (error-id #(crossed render-picker {:on-imperative {"Enter" [:hatch/closed]}}))))
+    (let [[el _] (crossed render-picker {:on-imperative identity})]
+      (is (identical? identity (prop el "onImperative"))
+          "and an ordinary function still crosses untouched")))
+
+  (testing ":render wraps the h/fn and refuses the dispatching carriers too —
+            a :render position is invoked DURING a render, so a carrier that
+            is nothing but a dispatch is the one thing it can never be"
+    (let [[el !seen] (crossed render-picker {:on-render-row (hfn [label] (str "row:" label))})]
+      (is (= "row:x" ((prop el "onRenderRow") "x")) "the return went back to the caller")
+      (is (= [] @!seen)))
+    (is (= :rf.error/hicasso-intent-at-a-non-event-contract
+           (error-id #(crossed render-picker {:on-render-row [:hatch/closed]})))
+        "the audit's sharpest case: an intent vector at a declared :render
+         position used to take the intent path and dispatch during the
+         foreign component's render")
+    (is (= :rf.error/hicasso-intent-at-a-non-event-contract
+           (error-id #(crossed render-picker {:on-render-row {"Enter" [:hatch/closed]}}))))
+    (let [[el _] (crossed render-picker {:on-render-row identity})]
+      (is (identical? identity (prop el "onRenderRow")))))
+
+  (testing "the refusal names the position, the contract and the value —
+            never the form, because under ONE form the form is never the
+            answer to what went wrong"
+    (try
+      (crossed render-picker {:on-imperative [:hatch/closed]})
+      (is false "should have thrown")
+      (catch :default e
+        (let [d (ex-data e)]
+          (is (= :on-imperative (:position d)))
+          (is (= :handler (:contract d)))
+          (is (= [:hatch/closed] (:value d)))
+          (is (re-find #":on-imperative" (ex-message e))))))))
+
+(deftest a-dispatch-from-a-declared-render-position-names-the-position
+  (testing "HD-024's core law at the door: the CONTRACT the declaration named
+            decides, and a :render contract poisons the ambient frame-locked
+            dispatch for the call's dynamic extent — the same id a native
+            render position raises, because the position is the thing that
+            selected it"
+    (let [[el !seen] (crossed render-picker
+                             {:on-render-row (hfn [_] (intent/*dispatch* [:hatch/closed]) "never")})]
+      (try
+        ((prop el "onRenderRow") "x")
+        (is false "should have thrown")
+        (catch :default e
+          (let [d (ex-data e)]
+            (is (= :rf.error/hicasso-dispatch-in-render-position (:rf.error/id d)))
+            (is (= :on-render-row (:position d)))
+            (is (= [:hatch/closed] (:event d)))
+            (is (re-find #":on-render-row" (ex-message e))))))
+      (is (= [] @!seen) "and nothing reached the frame"))))
+
+(deftest the-vector-spelling-is-event-first-and-says-so-when-it-is-not
+  (testing "the positive half, at the invoker contract the door was built for:
+            an EVENT-FIRST foreign call, which is what onDraft makes"
+    (let [[el !seen] (crossed picker {:on-draft [:hatch/typed :re-frame.hicasso/value]})]
+      ((prop el "onDraft") #js {:target #js {:value "west"}})
+      (is (= [[:hatch/typed "west"]] @!seen))))
+
+  (testing "and the case audit #7398 named. The widget calls
+            `(f (.-value props) e)` — VALUE-first — so argument one is a
+            string, and `.preventDefault` on it is the engine's own
+            TypeError naming nothing the author wrote. It is this error
+            instead, and it names the POSITION"
+    (let [[el !seen] (crossed picker {:on-pick [:re-frame.hicasso/prevent [:hatch/closed]]})]
+      (try
+        ((prop el "onPick") "paris" #js {:preventDefault (fn [] nil)})
+        (is false "should have thrown")
+        (catch :default e
+          (let [d (ex-data e)]
+            (is (= :rf.error/hicasso-intent-needs-the-event (:rf.error/id d)))
+            (is (= :on-pick (:position d)))
+            (is (= "preventDefault" (:needed d)))
+            (is (= "paris" (:argument d)))
+            (is (re-find #"h/fn" (ex-message e)) "and it points at the spelling that works"))))
+      (is (= [] @!seen) "and nothing dispatched off a half-run handler")))
+
+  (testing "the SAME law, one message, for the markers — which is the whole
+            point of stating it once: `::h/value` at a value-first position
+            fails the same way and reads the same diagnostic"
+    (let [[el _] (crossed picker {:on-pick [:hatch/picked :re-frame.hicasso/value "kind"]})]
+      (try
+        ((prop el "onPick") "paris" #js {:target #js {:value "x"}})
+        (is false "should have thrown")
+        (catch :default e
+          (let [d (ex-data e)]
+            (is (= :rf.error/hicasso-intent-needs-the-event (:rf.error/id d)))
+            (is (= "target" (:needed d))))))))
+
+  (testing "and a key-map, whose failure without the law is the WORST of the
+            three — no `.key` to look up means no branch, which is a handler
+            that silently does nothing"
+    (let [[el _] (crossed picker {:on-pick {"Enter" [:hatch/closed]}})]
+      (is (= :rf.error/hicasso-intent-needs-the-event
+             (error-id #((prop el "onPick") "paris" #js {:key "Enter"}))))))
+
+  (testing "while an intent carrying NEITHER a marker nor a prevent never
+            touches its argument, so it is correct under any invoker contract
+            and pays no law at all — which is the overwhelmingly common case"
+    (let [[el !seen] (crossed picker {:on-pick [:hatch/picked "static" "kind"]})]
+      ((prop el "onPick") "paris" #js {})
+      (is (= [[:hatch/picked "static" "kind"]] @!seen)))))
 
 ;; ---------------------------------------------------------------------------
 ;; 6 — the hook budget distinction, at React's own dispatcher

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
@@ -221,10 +221,11 @@
   else — it is a component (the guide's own troubleshooting row)."
   (.-Provider theme-context))
 
-(defhost render-picker widget
+(defhost render-picker
   "The same component, declared with all THREE contracts on it — the
   matrix below needs one host that can be handed every carrier at every
   contract, and `:render` is the row `picker` above has no slot for."
+  widget
   {:callbacks {:on-pick       :event
                :on-imperative :handler
                :on-render-row :render}})
@@ -641,11 +642,11 @@
 ;;       `value.preventDefault is not a function`, the engine's own
 ;;       TypeError naming nothing the author wrote.
 ;;
-;; The rows below cross through the real minted head and then invoke the
+;; The matrix rows cross through the real minted head and then invoke the
 ;; lowered prop the way [[widget]] invokes it — `(f (.-value props) e)` for
-;; `onPick`, `(f e)` for `onDraft`, both visible in this file.  The mounted
-;; render-prop row above the matrix is the other half: a `:render` slot
-;; actually called during the foreign component's render.
+;; `onPick`, `(f e)` for `onDraft`, both written into the component above.
+;; The first row is the other half, and needs the DOM: a declared `:render`
+;; slot actually called during the foreign component's own render.
 
 (defn- prop [^js el nm] (unchecked-get (unchecked-get el "props") nm))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -43,7 +43,7 @@
   | Position | How it is recognised | Contract |
   |---|---|---|
   | a native `:on-*` prop | [[event-prop?]] — the same two-shape rule as an intent vector | **event**: a returned VECTOR is dispatched; any other return is ignored |
-  | a `defhost` `:callbacks` entry | the declaration already says `:event` or `:handler` — never inferred from an `on*` name | as declared; `:handler` is the return-ignored contract |
+  | a `defhost` `:callbacks` entry | the declaration already says `:event`, `:handler` or `:render` — never inferred from an `on*` name | as declared; `:handler` is the return-ignored contract |
   | any other prop position (a slot, a render prop) | not an event position | **render**: pure. The return is the render output and is NOT dispatched; dispatching *from inside the call* is a loud error naming the position |
   | `:ref` | [[ref-position?]] | React's own: commit phase, the node as the argument, the return as the detach cleanup. Excluded from lowering entirely |
   | anywhere Hicasso does not walk — a raw `#js` prop, a value handed to a foreign API | it is not a position | it is a plain function and it simply runs; the return is ignored |
@@ -51,6 +51,21 @@
   That last row is the deletion. There is no carrier object, so there is
   nothing that can fail to be callable, so the fifth rule has nothing to
   govern.
+
+  **THE DECLARATION GOVERNS EVERY CARRIER AT ITS POSITION, not just the
+  callback.** A declared position accepts four carriers — the one callback
+  form, an intent vector, a key-map, and an ordinary value — and the row
+  above is a law about the POSITION, so the contract has to be the outer
+  question and the carrier the inner one.
+  [[lower-declared-prop]] is written that way on purpose: dispatch on the
+  contract, then on the value. Reading the value first is how a
+  declaration that says `:handler` ends up silently dispatching a bare
+  intent, and how a `:render` position dispatches during the foreign
+  component's render — the value quietly selecting the contract, which is
+  the exact defect the ruling deletes. A dispatching carrier at
+  `:handler` or at `:render` is therefore
+  `:rf.error/hicasso-intent-at-a-non-event-contract`, named at the
+  position, rather than a contract silently overridden.
 
   **A Hicasso view's own props map is not a position — it is data in
   transit.** An intent vector handed to a view is not lowered there
@@ -68,6 +83,37 @@
   identity keep working. The behaviour the predecessor spells as a fourth
   roster form is the default here. The census agrees with the omission —
   zero foreign components across 85 idiomatic files.
+
+  ## The argument law: the vector spelling is EVENT-FIRST
+
+  One law, and it covers every feature of the vector spelling that reads
+  the event — `::h/prevent`, `::h/value`, `::h/checked`, `:on-submit`'s
+  auto-prevent and the key-map's `.key` lookup alike: **a vector or a
+  key-map takes the DOM event from argument ONE.** That is what every
+  native position hands it, and what an event-first foreign contract
+  (`(on-draft event)`) hands it too.
+
+  A value-first foreign invoker — `(on-pick value event)`, the date
+  picker's `(on-change date)` — has no event at argument one, and there is
+  nothing to guess: the vector cannot know which of the library's
+  arguments is the event, and a runtime that went looking for one would be
+  reintroducing inference at the exact seam HD-011 forbids it. **`h/fn` is
+  that spelling**, and it needs no rule of its own, because the one form
+  receives every argument the invoker passed, in order.
+
+  What the law buys is that the violation is LOUD.
+  [[event-arg!]] checks the one property the closure is about to read and
+  raises `:rf.error/hicasso-intent-needs-the-event` naming the position,
+  the intent, and the argument that actually arrived. Without it the
+  author gets `value.preventDefault is not a function` — the engine's own
+  `TypeError`, naming nothing they wrote, which is the failure class the
+  whole ruling exists to delete.
+
+  It is paid only by the closures that read the event. An intent carrying
+  no marker and no prevent never touches its argument, so it costs
+  nothing, and it is correct under ANY invoker contract — which is why the
+  overwhelmingly common `[:todo/toggle id]` at a declared position needs
+  no law at all.
 
   ## The frame, and why the closure closes over it
 
@@ -343,23 +389,39 @@
                        {:position k :event event}))]
       (apply f args))))
 
-(defn- declared-callback
-  "**A `defhost` `:callbacks` entry.** The declaration already carries the
-  contract — `:event` or `:handler`, never inferred from an `on*` name —
-  so this is the position table's third row and it needs no new
-  machinery. `:handler` is the return-ignored contract, which for a form
-  that is already an ordinary function is the function itself."
-  [k f contract]
-  (case contract
-    :event   (event-callback k f)
-    :handler f
-    :render  (render-callback k f)
-    (fail! :rf.error/hicasso-unknown-callback-contract
-           'front.intent/lower-declared-prop
-           (str "A declaration gave " (pr-str k) " the callback contract "
-                (pr-str contract) ". The contracts are :event, :handler and :render.")
-           :declare-event-handler-or-render
-           {:position k :contract contract})))
+;; ---------------------------------------------------------------------------
+;; The argument law — the vector spelling is EVENT-FIRST (HD-024)
+;; ---------------------------------------------------------------------------
+
+(defn- event-arg!
+  "Answer `e` when it is the DOM event this closure needs, and raise a
+  diagnostic naming the POSITION when it is not. `slot` is the one
+  property the closure is about to read off it — `preventDefault`,
+  `target`, `key` — so the check is the read that was going to happen
+  anyway, and the message can say which capability was missing rather
+  than asserting a type.
+
+  See the namespace docstring §The argument law. The whole point is that
+  a value-first foreign invoker produces THIS error, naming the position
+  and pointing at `h/fn`, instead of the engine's
+  `value.preventDefault is not a function` — which names nothing the
+  author wrote and is the failure class HD-024 exists to delete."
+  [k form e slot]
+  (if (and (some? e) (some? (unchecked-get e slot)))
+    e
+    (fail! :rf.error/hicasso-intent-needs-the-event
+           'front.intent/lower-prop
+           (str "The intent " (pr-str form) " at " (pr-str k) " reads the DOM "
+                "event's `" slot "`, but the first argument its invoker passed "
+                "was " (pr-str e) ", which has none. The vector spelling is "
+                "EVENT-FIRST: it takes the event from argument one, which is "
+                "what every native position and every event-first foreign "
+                "contract hands it. A value-first invoker — (on-pick value "
+                "event) — has no event there, and nothing can guess which of "
+                "its arguments is one. Write an h/fn instead: the one form "
+                "receives every argument the invoker passed, in order.")
+           :write-an-h-fn-at-a-value-first-position
+           {:position k :form form :argument e :needed slot})))
 
 ;; ---------------------------------------------------------------------------
 ;; The marker roster and its one pure materializer
@@ -621,7 +683,14 @@
   [[markers?]] is ever asked, and the materializer then sees the ordinary
   intent it has always seen. The navigate head is classified here too —
   the same one-compare, once per render — and its whole lowering lives in
-  [[navigate-handler]]."
+  [[navigate-handler]].
+
+  **Only the branches that read the event carry the argument law**
+  ([[event-arg!]], and the namespace docstring's §The argument law): each
+  checks the one property its own first read needs, and the `:else`
+  branch — an intent with no marker and no prevent, which is the
+  overwhelming case — never touches its argument at all, so it costs
+  nothing and is correct under any invoker contract."
   [k v]
   (if (navigate-head? v)
     (navigate-handler k v)
@@ -631,15 +700,26 @@
           prevent   (or decorated (prevent-by-default? k))
           dynamic   (markers? intent)]
       (cond
-        (and prevent dynamic)       (fn [e] (.preventDefault e) (dispatch (materialize intent e)))
-        prevent                     (fn [e] (.preventDefault e) (dispatch intent))
-        dynamic                     (fn [e] (dispatch (materialize intent e)))
+        (and prevent dynamic)       (fn [e] (event-arg! k v e "preventDefault")
+                                            (.preventDefault e)
+                                            (dispatch (materialize intent e)))
+        prevent                     (fn [e] (event-arg! k v e "preventDefault")
+                                            (.preventDefault e)
+                                            (dispatch intent))
+        dynamic                     (fn [e] (event-arg! k v e "target")
+                                            (dispatch (materialize intent e)))
         :else                       (fn [_e] (dispatch intent))))))
 
 (defn- key-map-handler
   "Lower a data key-map into one closure over a plain map of key-string →
   handler. The map is built once per render; an event costs one
-  composition test and one lookup."
+  composition test and one lookup.
+
+  The argument law applies here too, and the property it needs is `key`:
+  without the check a key-map handed a value-first invoker's first
+  argument would find no `.key`, look nothing up, and do NOTHING — the
+  silently dead handler every loud error in this namespace exists to
+  delete."
   [k key-map]
   (let [lowered (reduce-kv (fn [m key-name v]
                              (assoc m key-name (cond
@@ -649,6 +729,7 @@
                            {}
                            key-map)]
     (fn [e]
+      (event-arg! k key-map e "key")
       (when-not (composing? e)
         (when-some [h (get lowered (.-key e))]
           (h e))))))
@@ -694,6 +775,31 @@
       (render-callback k v)
       v)))
 
+(defn- refuse-dispatching-carrier!
+  "An intent vector or a key-map at a position the declaration gave the
+  `:handler` or `:render` contract. Both carriers ARE a dispatch and
+  nothing else, and neither contract dispatches, so there is no reading
+  of the value that could satisfy the declaration — which is why this is
+  a refusal at lowering rather than a wrapper that does less."
+  [k v contract]
+  (fail! :rf.error/hicasso-intent-at-a-non-event-contract
+         'front.intent/lower-declared-prop
+         (str "The declaration gives " (pr-str k) " the " (pr-str contract)
+              " contract, and it was handed " (pr-str v) ". "
+              (if (keyword-identical? :handler contract)
+                (str "A :handler's return is ignored and Hicasso dispatches "
+                     "nothing from it, so a carrier whose entire content is a "
+                     "dispatch has no meaning at that contract. ")
+                (str ":render is a PURE position — it is invoked during the "
+                     "foreign component's own render, where dispatching is "
+                     ":rf.error/hicasso-dispatch-in-render-position. "))
+              "Declare " (pr-str k) " :event if what happens there is an "
+              "event, or write an h/fn that does the " (pr-str contract)
+              " work. The contract comes from the position, so the value "
+              "never gets to overrule it.")
+         :declare-the-position-event-or-write-an-h-fn
+         {:position k :contract contract :value v}))
+
 (defn lower-declared-prop
   "Lower one prop whose contract a `defhost` declaration named — the
   position table's second row. Kept separate from [[lower-prop]] so the
@@ -701,13 +807,48 @@
   predecessor's own rule is that a host's callback contract is 'a finite
   map from EXACT prop names to `:event` or `:handler`; never inferred
   from an `on*` name', and that rule survives here because the position,
-  not the value, carries the contract."
+  not the value, carries the contract.
+
+  **The contract is the OUTER dispatch and the carrier the inner one**,
+  which is the whole law made structural. Dispatching on the value first
+  is how a declared `:handler` ends up silently dispatching a bare
+  intent, and how a declared `:render` dispatches during the foreign
+  component's render: the value selecting the contract, which is the
+  defect HD-024 exists to delete. So each contract states what it accepts
+  and refuses the rest:
+
+  | Contract | `h/fn` | intent vector / key-map | anything else |
+  |---|---|---|---|
+  | `:event`   | the event wrapper — a returned vector dispatches | lowered exactly as at a native event position | crosses untouched |
+  | `:handler` | the function itself, by identity | **refused** ([[refuse-dispatching-carrier!]]) | crosses untouched |
+  | `:render`  | the render wrapper — dispatching inside is loud | **refused** | crosses untouched |
+
+  `:event` keeps the vector and key-map conveniences because dispatching
+  is exactly what that contract means; the vector's own argument law
+  applies there unchanged ([[event-arg!]]). An ordinary unmarked function
+  crosses untouched at every contract — `raw-fn`'s passthrough is the
+  default here, and a plain fn is claimed by no position."
   [k v contract]
-  (cond
-    (callback? v) (declared-callback k v contract)
-    (vector? v)   (intent-handler k v)
-    (map? v)      (key-map-handler k v)
-    :else         v))
+  (case contract
+    :event   (cond
+               (callback? v) (event-callback k v)
+               (vector? v)   (intent-handler k v)
+               (map? v)      (key-map-handler k v)
+               :else         v)
+    :handler (cond
+               (callback? v)             v
+               (or (vector? v) (map? v)) (refuse-dispatching-carrier! k v contract)
+               :else                     v)
+    :render  (cond
+               (callback? v)             (render-callback k v)
+               (or (vector? v) (map? v)) (refuse-dispatching-carrier! k v contract)
+               :else                     v)
+    (fail! :rf.error/hicasso-unknown-callback-contract
+           'front.intent/lower-declared-prop
+           (str "A declaration gave " (pr-str k) " the callback contract "
+                (pr-str contract) ". The contracts are :event, :handler and :render.")
+           :declare-event-handler-or-render
+           {:position k :contract contract})))
 
 (defn lower-props
   "Walk a props map once, lowering every position that carries something

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent_cljs_test.cljs
@@ -545,6 +545,116 @@
             (is (= :rf.error/hicasso-unknown-callback-contract
                    (:rf.error/id (ex-data e))))))))))
 
+(deftest the-declared-contract-governs-the-value-and-not-the-other-way-round
+  (testing "the law made structural: the CONTRACT is the outer question and
+            the carrier the inner one. Reading the value first is how a
+            declaration that says :handler ends up silently dispatching a
+            bare intent, and how a :render position dispatches during the
+            foreign component's render — the value quietly selecting the
+            contract, which is the one thing HD-024 exists to prevent."
+    (let [!seen (recorder)]
+      (testing ":event keeps the vector and key-map conveniences, because
+                dispatching is exactly what that contract MEANS"
+        (let [h (intent/with-frame (dispatching !seen)
+                                   (fn [] (intent/lower-declared-prop
+                                            :onValueChange [:host/changed 1] :event)))]
+          (h (ev {}))
+          (is (= [[:host/changed 1]] @!seen)))
+        (reset! !seen [])
+        (let [h (intent/with-frame (dispatching !seen)
+                                   (fn [] (intent/lower-declared-prop
+                                            :onValueChange {"Enter" [:host/changed 2]} :event)))]
+          (h (ev {:key "Enter"}))
+          (is (= [[:host/changed 2]] @!seen))))
+      (testing "and refuses them precisely at :handler and at :render, where
+                no reading of the value could satisfy the declaration"
+        (reset! !seen [])
+        (doseq [contract [:handler :render]
+                carrier  [[:host/changed 3] {"Enter" [:host/changed 3]}]]
+          (try
+            (intent/with-frame (dispatching !seen)
+                               (fn [] (intent/lower-declared-prop :onValueChange carrier contract)))
+            (is false (str "should have thrown for " contract " / " (pr-str carrier)))
+            (catch :default e
+              (let [d (ex-data e)]
+                (is (= :rf.error/hicasso-intent-at-a-non-event-contract (:rf.error/id d)))
+                (is (= :onValueChange (:position d)))
+                (is (= contract (:contract d)))
+                (is (= carrier (:value d)))
+                (is (re-find #":onValueChange" (ex-message e))
+                    "and the diagnostic names the POSITION")))))
+        (is (= [] @!seen) "nothing was dispatched on the way to any refusal"))
+      (testing "an ordinary unmarked function crosses untouched at every
+                contract — a plain fn is claimed by no position, so `raw-fn`'s
+                passthrough stays the default here as everywhere else"
+        (let [f (fn [_] :whatever)]
+          (doseq [contract [:event :handler :render]]
+            (is (identical? f (intent/lower-declared-prop :onValueChange f contract))
+                (str "at " contract))))))))
+
+;; ---------------------------------------------------------------------------
+;; The argument law: the vector spelling is EVENT-FIRST (HD-024)
+;; ---------------------------------------------------------------------------
+;;
+;; One law over every feature of the vector spelling that reads the event.
+;; It cannot fail at a native position — React hands the event first, always
+;; — but the SAME lowering serves a `defhost` `:event` slot, where a foreign
+;; invoker calls with its own contract. Without the law the author gets
+;; `value.preventDefault is not a function`: the engine's TypeError, naming
+;; nothing they wrote, which is exactly the failure class the one-form ruling
+;; deletes.
+
+(deftest the-vector-spelling-reads-the-event-from-argument-one
+  (let [d (dispatching (recorder))]
+    (testing "`::h/prevent` needs `preventDefault`, and says so when argument
+              one has none"
+      (let [h (intent/with-frame d (fn [] (intent/lower-prop
+                                            :on-pick [:re-frame.hicasso/prevent [:go]])))]
+        (try
+          (h "a-value")
+          (is false "should have thrown")
+          (catch :default e
+            (let [data (ex-data e)]
+              (is (= :rf.error/hicasso-intent-needs-the-event (:rf.error/id data)))
+              (is (= :on-pick (:position data)))
+              (is (= "preventDefault" (:needed data)))
+              (is (= "a-value" (:argument data)))
+              (is (re-find #":on-pick" (ex-message e)) "it names the POSITION")
+              (is (re-find #"h/fn" (ex-message e)) "and the spelling that works"))))))
+    (testing "`:on-submit`'s auto-prevent is the same law, reached by the
+              policy default rather than by the head"
+      (let [h (intent/with-frame d (fn [] (intent/lower-prop :on-submit [:go])))]
+        (is (= :rf.error/hicasso-intent-needs-the-event
+               (try (h "a-value") ::no (catch :default e (:rf.error/id (ex-data e))))))))
+    (testing "the markers need `target`, and the diagnostic says which"
+      (let [h (intent/with-frame d (fn [] (intent/lower-prop
+                                            :on-pick [:set :re-frame.hicasso/value])))]
+        (try
+          (h 7)
+          (is false "should have thrown")
+          (catch :default e
+            (is (= "target" (:needed (ex-data e))))))))
+    (testing "a key-map needs `key` — and it is the sharpest of the three,
+              because without the law it looks nothing up and does NOTHING"
+      (let [h (intent/with-frame d (fn [] (intent/lower-prop
+                                            :on-pick {"Enter" [:go]})))]
+        (is (= :rf.error/hicasso-intent-needs-the-event
+               (try (h 7) ::no (catch :default e (:rf.error/id (ex-data e))))))))
+    (testing "nil is refused the same way rather than raising the engine's own
+              null dereference"
+      (let [h (intent/with-frame d (fn [] (intent/lower-prop :on-submit [:go])))]
+        (is (= :rf.error/hicasso-intent-needs-the-event
+               (try (h nil) ::no (catch :default e (:rf.error/id (ex-data e))))))))
+    (testing "while an intent with NEITHER a marker nor a prevent never reads
+              its argument at all, so it costs no law and is correct under any
+              invoker contract — the overwhelmingly common case"
+      (let [!seen (recorder)
+            h     (intent/with-frame (dispatching !seen)
+                                     (fn [] (intent/lower-prop :on-pick [:go 1])))]
+        (h "a-value")
+        (h nil)
+        (is (= [[:go 1] [:go 1]] @!seen))))))
+
 (deftest outside-every-walked-position-the-form-is-just-a-function
   (testing "the row that deletes the predecessor's FIFTH rule. There, the
             roster is site-owned and a carrier handed to a raw #js prop is a


### PR DESCRIPTION
Closes the two reopens on **rf2-2rtt6.35**. The one form and the position table
already shipped; what the merged-PR audits of #7396 and #7398 found is that the
law was stated but not *total* — in two places the VALUE still got to select the
contract, and in a third the vector spelling promised something it did not do.
This makes the law total and witnesses it.

## The one form, unchanged

`h/fn` — `intent/callback`, which marks a function and returns **that same
function**. There is no carrier object, so nothing can fail to be callable, so
the predecessor's fifth rule ("where the roster reaches") has nothing to govern.
The predecessor's four forms map onto four positions rather than four spellings:

| Position | Contract |
|---|---|
| native `:on-*` | **event** — a returned vector dispatches; any other return is ignored (`v/event` + `v/handler`) |
| `defhost` `:callbacks` entry | **as declared** — `:event`, `:handler` or `:render`, never inferred from an `on*` name |
| any other walked prop | **render** — pure; the return is output, dispatching inside is `:rf.error/hicasso-dispatch-in-render-position` (`v/render-fn`) |
| `:ref` | React's own; excluded from lowering |
| anywhere Hicasso does not walk | a plain function; it runs, its return is ignored (`v/raw-fn`, the default here) |

## What actually changed

**(1) The declared contract now governs EVERY carrier at its position (audit
#7396).** `lower-declared-prop` dispatched on the VALUE first — every vector took
`intent-handler`, every map took `key-map-handler`, for `:event`, `:handler` and
`:render` alike. So a declaration that said `:handler` silently dispatched a bare
intent, and a `:render` slot could dispatch during the foreign component's own
render without the required error. The contract is now the OUTER dispatch and the
carrier the inner one — the law made structural:

| Contract | `h/fn` | intent vector / key-map | anything else |
|---|---|---|---|
| `:event` | the event wrapper | lowered as at a native event position | crosses untouched |
| `:handler` | the function itself, by identity | **refused** — `:rf.error/hicasso-intent-at-a-non-event-contract` | crosses untouched |
| `:render` | the render wrapper | **refused** — same id | crosses untouched |

`declared-callback` is DELETED — its `case` became the outer dispatch. No new
form, no new concept: one new error id, and it names the position.

**(2) The vector spelling is EVENT-FIRST, and says so (audit #7398).**
`05-interop.md` taught that `::h/prevent` at a declared `:event` position "calls
`.preventDefault` on whichever argument is the real DOM event". The landed code
did no such thing — `intent-handler` returns a unary `fn [e]` and calls
`.preventDefault` on argument one, so a value-first invoker (`onPick(value,
event)`) called `"paris".preventDefault` and threw. The same page already taught
the *opposite* law two sections down for `::h/value` ("works exactly when the
foreign contract hands the DOM event first"), so one vector composing both
(`[::h/prevent [:filter/set ::h/value]]`) had two contradictory rules.

Resolved to **one law**: `::h/prevent`, `::h/value`, `::h/checked`,
`:on-submit`'s auto-prevent and a key-map's key lookup all read the DOM event
from **argument one**. Nothing goes looking for an event among a library's
arguments — that is inference at exactly the seam HD-011 forbids it. `h/fn` is
the spelling for a value-first invoker, which is what the page's own opening
example already does.

The violation is now LOUD: `event-arg!` checks the one property the closure is
about to read (`preventDefault` / `target` / `key`) and raises
`:rf.error/hicasso-intent-needs-the-event` naming the position, the intent and
the argument that arrived — instead of `value.preventDefault is not a function`,
the engine's own `TypeError` naming nothing the author wrote, which is the
failure class this whole ruling exists to delete. The key-map case was the worst
of the three: no `.key` meant no branch and a handler that silently did nothing.

**Cost.** Paid only by closures that already read the event: one property load
each. The `:else` branch — an intent with no marker and no prevent, the
overwhelming case — never touches its argument, so it costs nothing and is
correct under *any* invoker contract. No allocation added anywhere: the closures
stay unary (`(fn [e] …)`); JS ignores extra arguments, so there is no variadic
seq per event.

## Hooks and fences

**No hook added — measured, not asserted.** `the-door-adds-no-hicasso-hook-and-the-hosted-hooks-are-its-own`
reads React's own dispatcher and is green: the shell's two hooks (`useContext`,
`useSyncExternalStore`) come FIRST with nothing before them, exactly ONE
`useSyncExternalStore` on the page, and everything after is the hosted widget's
own roster. Every change here is in pure lowering functions. Surface B only — no
candidate ledger, no compiler, no analyzer, no dual mode. Bodies stay
`.cljc`-compatible (HD-020): nothing added reaches into a body.

## Tests: what was added, and the one thing that could have gone stale

**Nothing existing was flipped, and I checked before assuming.** No test asserted
either defective behaviour — the whole suite was green against the code change
alone (12441 tests, 0 failures) before a single new row was written. What *did*
assert the contrary was PROSE, and it is corrected in the same change:

- `docs/design/hicasso/draft-guide/05-interop.md:101-102` — the `::h/prevent`
  "whichever argument is the real DOM event" sentence. **Retired**, replaced by
  the stated event-first law, its error id, and the `h/fn` answer. The "Not
  settled yet" row on `::h/value` moves from "Proven, conditionally" to the
  settled law, and Troubleshooting gains a row per new id.
- `docs/design/hicasso/decisions.md` HD-024 and `authoring.md` — both stated the
  declared row as "`:event` or `:handler`" though `:render` has always been legal
  in `mint-host!`, and both were silent on carrier governance and on the argument
  law. HD-024 now states both, as its own ruling's consequences.

One existing test's SCOPE grew rather than its meaning:
`the-value-marker-materializes-when-the-foreign-invoker-hands-an-event` already
taught the event-first law in prose; it is unchanged, and now has the failure
half beside it.

New witnesses (all run under `:node-test` as well as the browser, except the
mounted row):

- `arm1/host_hatch_dom_cljs_test` §5b — the full contract × carrier matrix
  against a REAL minted host; `a-declared-render-slot-is-invoked-during-the-foreign-render`
  (mounted: the `h/fn` runs inside the foreign component's own render and its
  return reaches the DOM); `a-dispatch-from-a-declared-render-position-names-the-position`;
  and `the-vector-spelling-is-event-first-and-says-so-when-it-is-not`, driven at
  the widget's own value-first `(f (.-value props) e)` invoker. `widget` gains a
  real render prop; `render-picker` declares all three contracts.
- `front/intent_cljs_test` — `the-declared-contract-governs-the-value-and-not-the-other-way-round`
  and `the-vector-spelling-reads-the-event-from-argument-one`, at closure level.

## Mutation proof

Two mutations, each reverted **byte-identically** (`git diff HEAD --stat` empty
after each):

| Mutation | Result |
|---|---|
| `lower-declared-prop`'s `:render` branch back to `(intent-handler k v)` / `(key-map-handler k v)` — the value overruling the contract again | **EXIT 1**, 4 failures, named: `the-declaration-governs-every-carrier-at-its-position` (×2, real host) and `the-declared-contract-governs-the-value-and-not-the-other-way-round` (×2, closure level) |
| `event-arg!` reduced to `(if true e …)` — the law removed | **EXIT 1**, 18 failures, named: `the-vector-spelling-reads-the-event-from-argument-one` (×10) and `the-vector-spelling-is-event-first-and-says-so-when-it-is-not` (×8) |

## Finding, filed rather than spent silently

**rf2-2rtt6.74** — a `:render` prop that returns *lowered* hiccup poisons that
row's own handlers. `render-callback` enforces purity by binding the ambient
`*dispatch*` to a poison fn, and `intent-handler` captures `*dispatch*` at
LOWERING time, so `(h/as-element [:li {:on-click [:row/pick id]}])` inside a
render body produces a click handler that raises
`:rf.error/hicasso-dispatch-in-render-position` when the user clicks it — for a
click, which is a legitimate event position that merely happened to be lowered
during a render. HD-024 forbids dispatching *from inside the call*; a closure
that dispatches later is not that. Deliberately NOT witnessed here — pinning it
would record a defect as the contract — and not fixed here, because the repair
needs a ruling on which frame a render-produced row dispatches to. Three options
are written up on the bead.

**No capability was lost.** The only thing an author can no longer write is a
bare intent vector or key-map at a declared `:handler`/`:render` slot, which was
never coherent (neither contract dispatches). The `::h/prevent`
find-the-event-among-the-arguments behaviour was never implemented, so nothing
real was removed — the promise was retired in favour of a law `h/fn` already
covers, and the census counts zero foreign components across 85 idiomatic files.

## Quality gates

Run in the worker worktree, captured to gitignored `*.log`, exit code echoed
directly from the runner and never through a pipe.

| Gate | Result |
|---|---|
| `npm run test:cljs` (node tier — covers both new test files) | **EXIT 0** — Ran 12447 tests containing 62401 assertions. 0 failures, 0 errors. (baseline before this change: 12441 / 62329) |
| `npm run test:browser` | **EXIT 0** — Ran 1032 tests containing 6419 assertions. 0 failures, 0 errors. |
| `sh scripts/test-fast-pr.sh` | **EXIT 0** — `PASS fast PR spine` (docs tier incl. `mkdocs build --strict`; JVM `implementation/core` + `implementation/freehand`; node tier + per-ns isolation) |
| `python scripts/check_doc_slugs.py` | **EXIT 0** — the gate that does cover `docs/design/**` |

`mkdocs build --strict` deliberately excludes `docs/design/**`, so per CLAUDE.md
the worker verifies by hand and says so: **markdown tables and heading anchors in
the three edited design docs were checked by hand.** Every table in
`05-interop.md` has a uniform column count (3 / 4 / 3 across its three tables),
all headings are well-formed and hierarchical, no intra-doc link targets either
of the two new `###` headings, and `check_doc_slugs.py` is green on the tree.

Touches nothing PR #7411 carries (`arm1/runtime.cljs`,
`arm1/first_registration_cljs_test.cljs`, `arm1/generation_fence_dom_cljs_test.cljs`,
`arm1/staged_read_tear_cljs_test.cljs`, `generation_fence_coverage_cljs_test.cljs`),
and none of `front/codec.cljs`, `front/sub_index.cljs`, `walk_profile_app.cljs`,
the dogfood renderings, or the machines engine.
