### PR TITLE
docs(hicasso): studio magnitudes must carry their control status (rf2-mgegk, rf2-vd333)

### DIFF
--- a/docs/design/hicasso/studio/our-walk-against-reagents.md
+++ b/docs/design/hicasso/studio/our-walk-against-reagents.md
@@ -138,34 +138,77 @@ after the arms, so they sample a different moment of a shared box; stock
 Reagent's own `string-child` reads 8.8 in one run and 20.3 in the other with
 identical code. The within-run column differences are the finding.
 
+**`↳` marks a stage measured INSIDE the row above it**, and the rows are ordered
+so the nesting is visible.
+
 **BEFORE** (ns/op):
 
 | stage | hicasso | slim | reagent | ours − Reagent's |
 |---|---|---|---|---|
 | tag lookup (cached) | 21.2 | — | 29.5 | **−8.3** |
-| prop-name lookup (cached) | 21.5 | 49.4 | 24.5 | **−3.0** |
-| prop-value conversion | 6.7 | 8.1 | 7.1 | −0.4 |
 | **whole prop pipeline / element** | **209.2** | — | **182.2** | **+27.0** |
+| ↳ prop-name lookup (cached) | 21.5 | 49.4 | 24.5 | **−3.0** |
+| ↳ prop-value conversion | 6.7 | 8.1 | 7.1 | −0.4 |
 | per-element tag hook | 9.2 | — | 6.7 | +2.5 |
 | **`as-element` on a string child** | **33.5** | 7.9 | **8.8** | **+24.7** |
 | `createElement` (shared floor) | 54.9 | 54.9 | 54.9 | — |
 
-**The decomposition closes.** Weighted by the roster — prop pipeline
-+27.0 × 1,202, strings +24.7 × 567, tag hook +2.5 × 1,202, tag lookup
-−8.3 × 1,202, prop names −3.0 × 1,489, values −0.4 × 1,489 — the named stages
-sum to **+34.4 µs/walk** against a measured whole-walk delta of **+37.5 µs**.
-**92% of the difference between the two interpreters is accounted for by named
-stages**, which is what makes the two convictions below convictions rather than
-guesses.
+**Two rows are NESTED, and the sum must not count them twice.**
+`convert-props-hicasso` and `convert-props-reagent` invoke each interpreter's
+**whole** `convert-props` over every element, and that pipeline already performs
+the cached prop-name lookup and the value conversion for every prop it emits.
+The two are priced separately so the pipeline has named parts — the same
+relation `:cedn` and `:lookup` have to `route-url` on the
+[route-link page](the-route-link-render-term-priced.md) — and, like those, they
+are **shares of the row above rather than stages beside it**. The tag lookup is
+not nested: the instrument precomputes the parsed tag outside the pipeline's
+window precisely so that row prices one thing.
+
+The non-overlapping sum, weighted by the roster:
+
+| stage | ours − Reagent's | × roster | µs/walk |
+|---|---|---|---|
+| **whole prop pipeline** | +27.0 ns | 1,202 elements | **+32.5** |
+| **`as-element` on a string child** | +24.7 ns | 567 strings | **+14.0** |
+| per-element tag hook | +2.5 ns | 1,202 elements | +3.0 |
+| tag lookup | −8.3 ns | 1,202 elements | −10.0 |
+| *prop-name lookup* | *−3.0 ns* | *1,489 props* | *nested — not added* |
+| *prop-value conversion* | *−0.4 ns* | *1,489 props* | *nested — not added* |
+| **named stages** | | | **+39.5** |
+| **observed whole-walk delta** | | | **+37.5** |
+
+**The named stages sum to 105% of the observed delta, and this page previously
+said 92%.** That figure came from adding the two nested rows to the pipeline
+that contains them; because both are negative, the double-count pulled the total
+*down*, from +39.5 µs to +34.4 µs, and made an overshoot look like a shortfall.
+There was never a measured 8% residual to report.
+
+**The overshoot is the instrument's, not a missing stage — and it is why no
+closure percentage belongs here at all.** Read against the limits this section
+already declared, 5% is nothing: these absolutes are ceilings taken on a box §7
+declares was not quiet. Run the same arithmetic over the AFTER table and the
+named stages come to **+5.6 µs** against an observed delta of **−25.0 µs** —
+they do not even agree in sign. A table with that much room in it can say which
+stages are large and roughly how large; it cannot be totalled to the percentage
+point in either direction.
+
+**So the table is read as an attribution and not as an accounting.** What it
+supports is that the prop pipeline and the string branch are the two terms that
+matter, each worth tens of µs per walk where the rest are worth single digits —
+and that is what the two convictions below rest on, together with their own
+before/after tables in §4a and §4b. Neither conviction, and neither landed
+optimization, depends on this sum. The independent evidence for the page's
+conclusions is §2's arm ratios, which are same-run interleaved and untouched by
+any of this.
 
 **AFTER** (ns/op, same instrument):
 
 | stage | hicasso | slim | reagent | ours − Reagent's |
 |---|---|---|---|---|
 | tag lookup (cached) | 20.4 | — | 34.9 | −14.5 |
-| prop-name lookup (cached) | 16.8 | 53.4 | 26.2 | −9.4 |
-| prop-value conversion | 8.1 | 23.5 | 10.7 | −2.6 |
 | **whole prop pipeline / element** | **207.6** | — | **186.8** | **+20.8** |
+| ↳ prop-name lookup (cached) | 16.8 | 53.4 | 26.2 | −9.4 |
+| ↳ prop-value conversion | 8.1 | 23.5 | 10.7 | −2.6 |
 | per-element tag hook | 12.1 | — | 9.6 | +2.5 |
 | **`as-element` on a string child** | **11.5** | 12.3 | **20.3** | **−8.8** |
 

--- a/docs/design/hicasso/studio/the-route-link-render-term-priced.md
+++ b/docs/design/hicasso/studio/the-route-link-render-term-priced.md
@@ -239,19 +239,20 @@ floor-normalised, plumb-tared**. Before rows are `rf2-6c237`'s.
 
 `uix` run — **the gate**:
 
-| row | before | **after** | band | verdict |
+| row | before | **after** | band | control | verdict |
+|---|---|---|---|---|---|
+| large-template (acceptance) | 1.4759× [1.3281 – 1.6302], band 6.1% | **1.1884× [1.1223 – 1.2660]** | 7.0% | **PASS** | **FAILS THE LINE** — whole range above 1.10, margin 8.0% clears the band |
+| feed | 1.3311× [1.2357 – 1.4195], band 3.9% | **1.0737× [0.9669 – 1.1859]** | 6.7% | **PASS** | **INSTRUMENT-LIMITED** — the range straddles 1.10, which is NOT a pass |
+| ordinary | 1.2097× [1.0751 – 1.3274], band 10.0% | 1.1698× [0.9671 – 1.5014] | 19.2% | **FAIL** | INSTRUMENT-LIMITED (straddles 1.10) **and the control FAILED** |
+
+`reagent` run — co-instrumented, **never a second gate**. Its control held on
+one row of three, and the other two rows are reported carrying that failure:
+
+| row | control | hicasso / uix | hicasso / reagent | uix / reagent |
 |---|---|---|---|---|
-| large-template (acceptance) | 1.4759× [1.3281 – 1.6302], band 6.1% | **1.1884× [1.1223 – 1.2660]** | 7.0% | **FAILS THE LINE** — whole range above 1.10, margin 8.0% clears the band |
-| feed | 1.3311× [1.2357 – 1.4195], band 3.9% | **1.0737× [0.9669 – 1.1859]** | 6.7% | **INSTRUMENT-LIMITED** — the range straddles 1.10, which is NOT a pass |
-| ordinary | 1.2097× [1.0751 – 1.3274], band 10.0% | 1.1698× [0.9671 – 1.5014] | 15.8% | INSTRUMENT-LIMITED (straddles 1.10) **and the control FAILED** |
-
-`reagent` run — co-instrumented, **never a second gate**:
-
-| row | hicasso / uix | hicasso / reagent | uix / reagent |
-|---|---|---|---|
-| large-template | 1.1566× [0.9258 – 1.3686] | 1.0436× [STRADDLES 1.0] | 0.9064× [STRADDLES 1.0] |
-| feed | 1.1814× [1.1121 – 1.3159] | 1.1438× [STRADDLES 1.0] | 0.9685× [STRADDLES 1.0] |
-| ordinary | 1.1334× [STRADDLES 1.0] | — | — |
+| large-template | **PASS** | 1.1566× [0.9258 – 1.3686] | 1.0436× [STRADDLES 1.0] | 0.9064× [STRADDLES 1.0] |
+| feed | **FAIL** | 1.1814× [1.1121 – 1.3159] | 1.1438× [STRADDLES 1.0] | 0.9685× [STRADDLES 1.0] |
+| ordinary | **FAIL** | 1.1334× [STRADDLES 1.0] | — | — |
 
 **Absolutes, `uix` run** (p50 raw `TaskDuration`, tared; `= taskNet + in-page`):
 
@@ -267,12 +268,34 @@ arms (the cleanest gated pair in the file), E=5,129, grain 1.836 ms; ordinary
 B=7, E=51, and it sits near this door's own floor, which is why its control
 could not hold.
 
-**Positive controls:** large-template **PASS** 1.8392× [1.6188 – 2.0111]
-against the arithmetic prediction 1.9759× (strict — every block inside the
-band); feed **PASS** 1.9924× [1.8057 – 2.1729] against 1.9943×; ordinary
-**FAIL** 1.2056× [0.9188 – 1.6452] against 1.7255× — the 51-element page is
-below what this door can resolve, and the row is published carrying that
-failure rather than quoting a magnitude the instrument did not earn.
+**Positive controls, per run and per row** — `ctl-2x` / floor per block, judged
+strict against ±25% of the row's element arithmetic, and a run has a control
+verdict on each row separately rather than one for the whole run:
+
+| row | prediction | band | `uix` run | `reagent` run |
+|---|---|---|---|---|
+| large-template | 1.9759× | [1.4819 – 2.4698] | **PASS** 1.8392× [1.6188 – 2.0111] | **PASS** 1.8411× [1.6835 – 2.3183] |
+| feed | 1.9943× | [1.4958 – 2.4929] | **PASS** 1.9924× [1.8057 – 2.1729] | **FAIL** 2.0331× [1.8533 – 2.5099] |
+| ordinary | 1.7255× | [1.2941 – 2.1569] | **FAIL** 1.2056× [0.9188 – 1.6452] | **FAIL** 1.2374× [0.9437 – 1.6574] |
+
+**The two rows that carry the gate are certified on the `uix` run; on the
+`reagent` run only large-template's control held.** The ordinary control fails
+on both runs for the same reason and fails badly — a 51-element page is below
+what this door can resolve, and most of its blocks land under the floor of the
+band. The `reagent` feed control fails differently: seventeen of its eighteen
+blocks are inside, and one reads 2.5099× against a 2.4929× ceiling. Strict is
+strict, and a rule that only binds when the outlier is large is not a control —
+so it is recorded as a failure, with its distance from the ceiling stated so
+the reader can see which kind of failure it is.
+
+That distinction changes nothing about the gate and everything about how the
+secondary table is read. Per
+[the census clock rows](census-real-clock-rows.md), a Reagent comparison is
+never a second product gate — but **every magnitude from a run whose control
+failed carries that failure**, so the `reagent` table's feed and ordinary rows
+above are recorded, not adjudicative, and no argument on this page rests on
+them. The gated verdicts of record are the `uix` run's, whose acceptance and
+feed controls both passed.
 
 **Read-backs:** 0 unverified of 1,260 per `uix`-run row, 0 of 1,512 per
 `reagent`-run row.
@@ -323,7 +346,8 @@ failure rather than quoting a magnitude the instrument did not earn.
 | **Runtime** | `HeadlessChrome/147.0.7727.15` (Windows NT 10.0 x64), node `v24.13.0`, hardware-concurrency 24, device-memory 32 |
 | **Design** | 6 rounds × 3 blocks × (4 warmup + 10 samples) per arm per row — 18 blocks, the published shape |
 | **Clock / door / tare** | PUBLISHED: `Performance.getMetrics` raw `TaskDuration`, frame-settled. DIAGNOSTIC: `taskNet` + the in-page window on the same samples. One door for every arm including the plumb tare (`page.evaluate → C56CLOCK.sample`), tare subtracted from every figure |
-| **Guard / band** | arm-order guard tolerance 0.35 — **reportable on all six row-runs**; band ceiling 35%, and every row's band was well inside it (6.7–15.8%) |
+| **Guard / band** | arm-order guard tolerance 0.35 — **reportable on all six row-runs**; band ceiling 35%, and every row's band was inside it — **6.7–29.8% across the six**: `uix` 7.0 / 6.7 / 19.2%, `reagent` 8.7 / 11.9 / 29.8% (large-template / feed / ordinary) |
+| **Controls** | strict ±25%, adjudicated **per row within each run** rather than once per run: `uix` PASS / PASS / FAIL, `reagent` PASS / FAIL / FAIL (large-template / feed / ordinary). §5 carries each failure onto the magnitudes it touches |
 | **Read-backs** | 0 unverified of 1,260 (`uix` rows) and 1,512 (`reagent` rows) |
 | **Windows** | announced on the bead before opening and closed after. `uix` `2026-08-02T18:14:02Z – 18:17:26Z`; `reagent` `18:17:26Z – 18:21:10Z`. Quiet gate (8 × 1 s < 30% CPU) **QUIET on attempt 1 for all six rows** |
 | **Exit codes** | published run `0`. **The first attempt was REFUSED and published nothing**: the box would not go quiet before `uix/feed` across five attempts (CPU runs in the 22–46% range against the 30% gate) while sibling workers held the machine, and the runner discards a partial run rather than reporting it. The `uix/large-template` row of that attempt did take, and it is not quoted here |


### PR DESCRIPTION
Two audit-derived corrections to Hicasso studio records, on one principle:
**a published magnitude carries the status of the run that produced it.**
Neither bead says the code is wrong. Both say the RECORD overstated what its
own committed data shows. Nothing is re-measured, no instrument, bench app or
test is touched, and no magnitude is deleted — a figure with its status stated
is useful, a deleted one is lost.

---

## rf2-mgegk — the walk decomposition does not close to 92%

`docs/design/hicasso/studio/our-walk-against-reagents.md` §3 claimed the named
stages explain 34.4 µs of a 37.5 µs whole-walk delta (92%). It summed nested
measurements as though they were independent.

**Confirmed against the instrument, not just the bead.**
`walk_vs_reagent_app/stage-table` prices `:convert-props-hicasso` /
`:convert-props-reagent` by invoking each interpreter's *whole* `convert-props`
over every element, and `codec.cljs`'s `convert-entry` calls `cached-prop-name`
and `convert-prop-value` for every prop it emits. So the prop-name and
prop-value rows are shares of the pipeline row, not stages beside it. The tag
lookup is genuinely additive — the instrument precomputes the parsed tag
*outside* the pipeline's window (`h-parsed` / `r-parsed`) precisely so that row
prices one thing.

**The arithmetic, reproduced from the published figures:**

| | µs/walk |
|---|---|
| whole prop pipeline, +27.0 ns × 1,202 elements | +32.5 |
| `as-element` on a string child, +24.7 ns × 567 strings | +14.0 |
| per-element tag hook, +2.5 ns × 1,202 | +3.0 |
| tag lookup, −8.3 ns × 1,202 | −10.0 |
| **non-overlapping total** | **+39.5** |
| observed whole-walk delta | +37.5 |
| *published sum, incl. the two nested rows* | *+34.4 (reproduces to 34.4247)* |

**The decomposition closes to 105%, not 92%.** Because both nested deltas are
negative, the double-count pulled the total *down* and made an overshoot look
like a shortfall — there was never a measured 8% residual. The claim is
retracted rather than restated at a new number, because the same arithmetic
over the AFTER table gives **+5.6 µs against an observed −25.0 µs** — the named
stages do not agree in sign. A table taken on a box §7 declares was not quiet,
whose absolutes are ceilings by its own declaration, can say which stages are
large; it cannot be totalled to the percentage point.

Both stage tables now mark nesting structurally (`↳`, rows re-ordered under the
pipeline) and the non-overlapping arithmetic is shown row by row.

**Explicitly out of scope, and left alone:** §2's arm ratios are same-run
interleaved and untouched; the two landed cheapenings are adjudicated by their
own before/after tables in §4a/§4b and do not depend on this sum; PR #7405's
−36% is a separate before/after ratio with a same-run control. The corrected
page says so in as many words.

No derived authority carries the retracted figure — `git grep` over `docs/` and
`spec/` finds `34.4` / `92%` only on this page.

## rf2-vd333 — the route-link rows now carry their run's control status

`docs/design/hicasso/studio/the-route-link-render-term-priced.md` published the
secondary Reagent-run feed and ordinary ratios carrying none of their controls'
failures, and its unqualified "Positive controls" paragraph reported only the
UIx run.

**Verified against `data/censusclock-cno31/reagent.json`**, whose stored
`adjudication.ctl` says exactly what the bead says (strict, ±25%, every block
inside):

| row | prediction | band | `uix` | `reagent` |
|---|---|---|---|---|
| large-template | 1.9759× | [1.4819 – 2.4698] | PASS 1.8392× | **PASS** 1.8411× |
| feed | 1.9943× | [1.4958 – 2.4929] | PASS 1.9924× | **FAIL** 2.0331× [1.8533 – 2.5099] |
| ordinary | 1.7255× | [1.2941 – 2.1569] | FAIL 1.2056× | **FAIL** 1.2374× [0.9437 – 1.6574] |

**How control status is labelled** — applying the posture
`census-real-clock-rows.md` already records (a Reagent comparison is never a
second product gate, but every magnitude from a run whose control failed
carries that failure), not a new convention:

* both §5 row tables gain a **control column, per row per run** — the UIx gate
  table now states PASS/PASS/FAIL rather than annotating only ordinary, and the
  Reagent table is labelled PASS/FAIL/FAIL;
* the Reagent table's lead-in states that its control held on one row of three
  and the other two are reported carrying that failure;
* the controls paragraph becomes a per-run per-row table carrying both runs'
  predictions, bands and observed ranges, and distinguishes the two *kinds* of
  failure: ordinary fails wholesale on both runs (most blocks under the floor),
  while the Reagent feed fails on one block of eighteen reading 2.5099× against
  a 2.4929× ceiling — recorded as a failure, with its distance stated;
* provenance gains a **Controls** row giving the full six-cell matrix.

The magnitudes stay. They are marked recorded-not-adjudicative, and the page
notes that no argument on it rests on them — verified: those three ratios
appear nowhere else in the file.

**One extra error the bead did not name.** The provenance band claim read
6.7–15.8%. That range quoted only the UIx run *and* misread that run's ordinary
band: `uix.json` stores `band: 0.1921`. The six row-run bands are `uix`
7.0 / 6.7 / **19.2**% and `reagent` 8.7 / 11.9 / **29.8**%, so the true range is
**6.7–29.8%**. The stale 15.8% is corrected in the §5 table as well.

Nothing else the beads quoted was found already corrected; every other figure
checked (read-backs 1,260 / 1,512 with 0 unverified, quiet gate on attempt 1
for all six rows, all UIx control figures) reproduces exactly.

Filed **rf2-t0j8b** (P3): if a per-stage decomposition of record is ever
wanted, it needs a quiet-box re-take — carrying the same precondition as
rf2-0qj9w and rf2-2rtt6.76. Nothing depends on one today.

## Quality gates

`docs/design/**` is a fail-open surface, so the gate story matters:

* **`mkdocs build --strict` does NOT cover this diff.** `mkdocs.yml`'s
  `exclude_docs` drops `design/hicasso/`, so it exits 0 having verified nothing
  of these edits. It is not nominated as the gate.
* `python scripts/check_doc_slugs.py` — **exit 0**. This one *does* validate
  the tree's link targets and heading anchors.
* `sh scripts/test-fast-pr.sh` — **exit 0**, `PASS fast PR spine`. Docs tier
  ran (README + docs corpus anchor validators, EP status-sync, mkdocs strict);
  JVM and node tiers correctly skipped as unchanged surfaces.

**Nothing validates this tree's tables, rendering or nav, so those were
verified by hand** (GitHub slug rules, which do *not* collapse hyphen runs —
python-markdown's slugify does, and reports false dead anchors here):

* **3 outbound links, 0 dead** — 2 of them new: `our-walk-against-reagents.md`
  → `the-route-link-render-term-priced.md` (grounding the nested-stage
  classification in the existing `:cedn`/`:lookup`-inside-`route-url`
  precedent), and → `census-real-clock-rows.md` (the authority being applied).
* **3 inbound links, 0 dead anchors** — from `hicasso/decisions.md:1056`,
  `studio/the-cold-read-mount-term.md:348`, and the new cross-link. None
  targets a fragment, and no heading text changed on either page.
* **22 tables, 0 column-count mismatches** (11 per page) — header, separator
  and every body row agree in each. The three tables that changed width did so
  consistently: UIx gate 5→6 columns, Reagent 4→5, controls 0→5 (new).
* **25 headings / anchors**, unchanged in text by this diff — the new
  nested-stage section is deliberately a bold lead-in rather than an `###`, so
  it does not swallow the AFTER table into its section or mint an anchor.

Docs-only diff; two files, both under `docs/design/hicasso/studio/`. No
instrument, bench app, test, or bench driver was touched or run.
