### PR TITLE
fix(ci,scripts): arm the mkdocs witness gate and stop gate artefacts blocking worktree reaps (rf2-03298, rf2-lci2z)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,15 @@ Thumbs.db
 .env.local
 .envrc
 
+# Gate artefacts from a worker run (rf2-lci2z). `*.log` above already covers the
+# gate log, but the exit-code file written beside it is not a `.log`, so it
+# survived as untracked residue — and one untracked path is enough to make
+# `git worktree remove` refuse the tree (rf2-p0m6m: nine worktrees would not
+# reap, every one dirty with exactly one leftover). Both spellings the dispatch
+# template names are ignored here.
+*.exit
+*-exit.txt
+
 # Throwaway test fixtures created under the repo so a repo-relative path can
 # reach them across all Bash flavours (rf2-6m7pn4 — Windows path portability).
 /.scratch/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,22 @@ sh scripts/remove-worker-worktree.sh <worktree-path>   # POSIX (primary)
 # Windows: powershell -ExecutionPolicy Bypass -File scripts/remove-worker-worktree.ps1 <worktree-path>
 ```
 
+## Gate Artefacts Go Where Git Ignores Them
+
+Never pipe a gate through `tail`, `head` or `grep` — a pipeline's exit status is
+its *last* command's, so a red runner reads green. Redirect to a file, capture
+the runner's own exit code, and quote that number in the PR body. **Every**
+artefact that produces — the log *and* the exit-code file — must land on an
+ignored path; `*.log`, `*.exit` and `*-exit.txt` all are:
+
+```bash
+sh scripts/test-fast-pr.sh > gate-fastpr.log 2>&1; echo "$?" > gate-fastpr.exit
+```
+
+A single untracked leftover makes `git worktree remove` refuse the tree from
+then on, and nine worktrees accumulated exactly that way before anyone worked
+out why they would not reap.
+
 ## Non-Interactive Shell Commands
 
 **ALWAYS use non-interactive flags** with file operations to avoid hanging on confirmation prompts.

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -107,11 +107,20 @@ none of them is obvious from the gate command itself.
   status is its *last* command's, so a red runner reads green and the PR claims
   a pass it never got. Redirect to a log file, echo the runner's own exit code
   explicitly, and quote that number in the PR body.
-- **Put the log somewhere git ignores** — `*.log` already is. An untracked
-  leftover (`bench-logs/`, `PRBODY.md`, `g-fastpr-exit.txt`) makes
-  `git worktree remove` refuse the tree from then on, and nine worktrees
-  accumulated exactly that way before anyone worked out why they would not
-  reap. Cheapest fix is to not create the residue.
+- **Put *every* gate artefact where git ignores it** — the log and the exit-code
+  file both. `*.log`, `*.exit` and `*-exit.txt` all are, so this leaves nothing
+  behind:
+
+  ```bash
+  sh scripts/test-fast-pr.sh > gate-fastpr.log 2>&1; echo "$?" > gate-fastpr.exit
+  ```
+
+  Saying only "put the log somewhere ignored" is the trap: a worker satisfies it
+  and still strands the exit file, which for a while was itself untracked. One
+  leftover is enough — `bench-logs/`, `PRBODY.md`, an unignored exit file — and
+  `git worktree remove` refuses the tree from then on. Nine worktrees
+  accumulated exactly that way before anyone worked out why they would not reap.
+  Cheapest fix is to not create the residue.
 
 ## Choosing solo vs cluster
 

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -1622,6 +1622,36 @@ test('adapter-disposition guard runs UNCONDITIONALLY in verify-readme-links (rf2
   );
 });
 
+// rf2-03298 — the fast-PR spine's tiering + mkdocs-resolution harness
+// (scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh) has existed
+// since rf2-lwweq, and for its whole life NO workflow and NO npm script ran it:
+// every assertion in it was local-only, i.e. skippable, i.e. not a gate. That is
+// how the module-only mkdocs fallback rf2-g7p7l added could have been deleted
+// while every remote check stayed green. #7364 wired the harness into the
+// unconditional verify-readme-links job — but that wiring has no pin of its own.
+// Deleting the step leaves valid YAML, a green matrix, and a witness that is
+// local-only again, which is the original defect in a new shape. Same invariant
+// as the adapter-disposition arm above, for the same reason, running in the same
+// unconditional job (js-harness-self-tests -> test:script-policy).
+test('the fast-PR spine self-test harness is wired into a REQUIRED check (rf2-03298)', () => {
+  const workflow = fs.readFileSync(WORKFLOW, 'utf8');
+  const readmeLinks = jobBlock(workflow, 'verify-readme-links');
+  assert.match(
+    readmeLinks,
+    /bash scripts\/_test_fixtures\/test_fast_pr_docs_gate\/run-self-test\.sh/,
+    'verify-readme-links must run the fast-PR spine self-test harness (unconditional job)',
+  );
+  // A job absent from all-required-passed's `needs:` is ADVISORY whatever its own
+  // gate says (the standing rule this repo pins elsewhere), so the invocation
+  // above only gates anything while verify-readme-links stays in that list.
+  const aggregator = jobBlock(workflow, 'all-required-passed');
+  assert.match(
+    aggregator,
+    /^\s*- verify-readme-links\s*$/m,
+    'all-required-passed must keep verify-readme-links in needs: — otherwise the spine self-test harness is advisory',
+  );
+});
+
 // rf2-f79t8 (a) — workflow-level shape: jvm-core + cljs must be
 // job-level gated (needs + if), NOT trigger-filtered, and the
 // pull_request trigger must stay unfiltered so the aggregator is always

--- a/scripts/_test_fixtures/test_fast_pr_docs_gate/README.md
+++ b/scripts/_test_fixtures/test_fast_pr_docs_gate/README.md
@@ -48,10 +48,17 @@ The harness covers:
   and on GitHub CI `requirements.txt` always puts a bare `mkdocs` on PATH, so it
   can never execute a module fallback there. These cases construct the
   module-only state instead: a PATH with every `mkdocs`-providing directory
-  removed plus a stub `python` that answers only `-m mkdocs --version`. They
-  assert the exact command the spine selected, that a console script still wins
-  over a working module launcher, and that a host where nothing resolves reports
-  `unresolved` rather than anything that reads as a pass.
+  removed plus a stub directory that shadows all three launchers `resolve_mkdocs`
+  tries and lets exactly one of them answer `-m mkdocs --version`. There is one
+  such case per supported launcher — AC (`python`), AC1 (`python3`), AC2 (`py`) —
+  because a witness for `python` alone cannot tell a working three-entry loop
+  from a one-entry one, and `python3`-only / `py`-only checkouts are the two this
+  fallback exists for. AD asserts a console script still wins over a working
+  module launcher; AE asserts a host where nothing resolves reports `unresolved`
+  rather than anything that reads as a pass. Shadowing matters: the sanitised
+  PATH still carries the host's real interpreters, so an unshadowed `python3`
+  witness would be satisfied by the host's `python` and stay green through the
+  regression it exists to catch.
 
 ## Where it runs
 
@@ -60,7 +67,12 @@ Two places, and both matter:
 * **CI** — test.yml's always-on `verify-readme-links` job runs this harness on
   every pull request, and that job is in `all-required-passed`'s `needs:`. Until
   rf2-03298 no workflow and no npm script referenced this file at all, so every
-  assertion in it was local-only and therefore skippable.
+  assertion in it was local-only and therefore skippable. That wiring is itself
+  pinned: `implementation/scripts/_changed-surfaces.test.cjs` asserts both halves
+  of it — the invocation inside `verify-readme-links`, and that job's presence in
+  `all-required-passed`'s `needs:` — under the equally unconditional
+  `js-harness-self-tests` job. Deleting the step leaves valid YAML and a green
+  matrix otherwise, which is exactly how the harness went unrun for so long.
 * **The local spine** — `scripts/test-fast-pr.sh` runs it when the diff touches
   the spine or this fixture tree (rf2-fhdd3). No recursion: the harness invokes
   the spine in `--plan` mode, which exits before the gate steps.

--- a/scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
+++ b/scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
@@ -433,9 +433,12 @@ assert "AB1 an ordinary scripts/ change does NOT arm the spine self-test" \
 #
 # These cases ask the host nothing.  They CONSTRUCT the module-only state — a
 # PATH with every directory that provides a bare `mkdocs` removed, plus a stub
-# directory whose `python` answers `-m mkdocs --version` and nothing else — and
-# assert the EXACT command the real spine selected.  resolve_mkdocs is not
-# copied here: `--plan` runs the real one.
+# directory that shadows all three launchers and lets exactly one of them answer
+# `-m mkdocs --version` — and assert the EXACT command the real spine selected.
+# One case per supported launcher (AC/AC1/AC2), because `resolve_mkdocs` tries
+# `python python3 py` in order and a witness for `python` alone cannot tell a
+# working three-entry loop from a one-entry one.  resolve_mkdocs is not copied
+# here: `--plan` runs the real one.
 # ---------------------------------------------------------------------------
 
 # The docs-armed disposable repo cases W-Y already built: the mkdocs resolution
@@ -466,10 +469,23 @@ mkdocs_free_path() {
 
 mkdocs_free="$(mkdocs_free_path)"
 
-# The stub launcher: a `python` that resolves ONLY `-m mkdocs --version`, so a
-# green case proves the spine took the module branch and not something else.
-module_bin="$tmp_root/module-only-bin"; mkdir -p "$module_bin"
-cat > "$module_bin/python" <<'STUB'
+# A stub launcher directory.  It SHADOWS all three launchers `resolve_mkdocs`
+# tries and lets exactly one of them — `$2`, or none at all for `none` — answer
+# `-m mkdocs --version`; every other invocation of every stub fails.  So a green
+# case proves the spine took the module branch, via that launcher and no other.
+#
+# Shadowing the other two is what makes the per-launcher cases hermetic
+# (rf2-03298).  The sanitised PATH only has bare `mkdocs` removed; the host's
+# REAL interpreters are still on it, and `resolve_mkdocs` tries `python` first.
+# A `python3`-only witness with no `python` stub in front of it would therefore
+# be satisfied on this runner by the host's own `python`, and would stay green
+# through exactly the regression it exists to catch.
+make_launcher_bin() {
+  local dir="$1" working="$2" l
+  mkdir -p "$dir"
+  for l in python python3 py; do
+    if [ "$l" = "$working" ]; then
+      cat > "$dir/$l" <<'STUB'
 #!/bin/sh
 if [ "${1:-}" = "-m" ] && [ "${2:-}" = "mkdocs" ] && [ "${3:-}" = "--version" ]; then
   printf 'mkdocs, version 1.6.1 (hermetic self-test stub)\n'
@@ -477,7 +493,24 @@ if [ "${1:-}" = "-m" ] && [ "${2:-}" = "mkdocs" ] && [ "${3:-}" = "--version" ];
 fi
 exit 1
 STUB
-chmod +x "$module_bin/python"
+    else
+      printf '#!/bin/sh\nexit 1\n' > "$dir/$l"
+    fi
+    chmod +x "$dir/$l"
+  done
+}
+
+# One sandbox per supported launcher.  `resolve_mkdocs` iterates
+# `python python3 py`; narrowing that list back to `python` alone leaves every
+# required check green today, and breaks precisely the python3-only and py-only
+# checkouts this Bead was filed for.  Three witnesses, one per iteration.
+module_bin="$tmp_root/module-only-bin";       make_launcher_bin "$module_bin" python
+module_bin_py3="$tmp_root/module-only-py3";   make_launcher_bin "$module_bin_py3" python3
+module_bin_py="$tmp_root/module-only-py";     make_launcher_bin "$module_bin_py" py
+
+# Every launcher present and none of them able to run mkdocs — the honest-skip
+# path, which must report `unresolved` rather than anything that reads as a pass.
+none_bin="$tmp_root/no-mkdocs-bin";           make_launcher_bin "$none_bin" none
 
 # A console-script stub for the preference case, alongside a working module
 # launcher — so "console script wins" is asserted against a live alternative.
@@ -485,14 +518,6 @@ both_bin="$tmp_root/console-wins-bin"; mkdir -p "$both_bin"
 cp "$module_bin/python" "$both_bin/python"
 printf '#!/bin/sh\nexit 0\n' > "$both_bin/mkdocs"
 chmod +x "$both_bin/mkdocs"
-
-# Every launcher present and none of them able to run mkdocs — the honest-skip
-# path, which must report `unresolved` rather than anything that reads as a pass.
-none_bin="$tmp_root/no-mkdocs-bin"; mkdir -p "$none_bin"
-for _launcher in python python3 py; do
-  printf '#!/bin/sh\nexit 1\n' > "$none_bin/$_launcher"
-  chmod +x "$none_bin/$_launcher"
-done
 
 # The sandbox must still carry the tools the spine itself shells out to.  If
 # stripping the mkdocs directories took one of them, the assertions below would
@@ -518,6 +543,14 @@ if [ "$hermetic_ready" = yes ]; then
     "PLAN-MKDOCS python -m mkdocs" \
     "$(PATH="$module_bin:$mkdocs_free" plan_mkdocs "$r_docs_for_mkdocs")"
 
+  assert "AC1 only python3 can run mkdocs → 'python3 -m mkdocs' selected" \
+    "PLAN-MKDOCS python3 -m mkdocs" \
+    "$(PATH="$module_bin_py3:$mkdocs_free" plan_mkdocs "$r_docs_for_mkdocs")"
+
+  assert "AC2 only py can run mkdocs → 'py -m mkdocs' selected" \
+    "PLAN-MKDOCS py -m mkdocs" \
+    "$(PATH="$module_bin_py:$mkdocs_free" plan_mkdocs "$r_docs_for_mkdocs")"
+
   assert "AD console script wins over a WORKING module launcher" \
     "PLAN-MKDOCS mkdocs" \
     "$(PATH="$both_bin:$mkdocs_free" plan_mkdocs "$r_docs_for_mkdocs")"
@@ -528,7 +561,7 @@ if [ "$hermetic_ready" = yes ]; then
 else
   printf '  FAIL AC-AE: cannot construct a module-only PATH on this host — %s\n' "$missing_tool"
   printf '        The module-only fallback in resolve_mkdocs was NOT exercised.\n'
-  fail_count=$((fail_count + 3))
+  fail_count=$((fail_count + 5))
 fi
 
 # ---- Summary ----


### PR DESCRIPTION
Two bugs on the CI/scripts hygiene surface, both the same family: a gate that
fails open, or a gate that leaves residue behind.

## rf2-lci2z — the gate exit-code file the dispatch template asks for was not gitignored

`docs/the-mayor-method/dispatch-prompt-template.md` tells every worker two
things: echo the runner's own exit code explicitly, and put the gate log "where
git ignores it — `*.log` already is". Workers do both. The log lands on an
ignored path; the exit-code file does not, because it is not a `.log`. Measured
before the fix:

```
git check-ignore -v gate-fastpr.exit   -> (nothing, exit 1) NOT IGNORED
git check-ignore -v g-fastpr-exit.txt  -> (nothing, exit 1) NOT IGNORED
git check-ignore -v gate.log           -> .gitignore:14:*.log
```

One untracked path is enough to make `git worktree remove` refuse the tree —
exit 128, permanent until forced. That is the mechanism rf2-p0m6m diagnosed for
nine worktrees that would not reap, every one dirty with exactly one untracked
file. The template's own residue list even NAMED `g-fastpr-exit.txt` as a
hazard, while the ignore rule that would have prevented it was never added.

**Checked before adding a broad rule**, as the Bead required:

```
$ git ls-files | grep -E '\.exit$|-exit\.txt$'
(no output, exit 1)
```

No tracked file is caught, so `*.exit` and `*-exit.txt` are safe. After the
change both spellings resolve to the new rules, and creating them leaves
`git status` clean.

The prose in the template and in `AGENTS.md` (the file Codex workers here are
handed, per #7412) now says plainly that **every** gate artefact — log and exit
code — goes to an ignored path, and gives one copyable spelling.

**How the exit code is captured is unchanged.** Redirect-and-read-the-file
stays: a pipeline reports its *last* command's status, which is how four workers
in one day reported a pipe's exit code instead of the runner's. Only the
artefact is now ignored.

## rf2-03298 — the mkdocs module-only fallback, hermetically pinned

#7364 landed the hermetic witness and wired it into the unconditional
`verify-readme-links` job. The merged-PR audit named two durability gaps that
remained; this closes both.

### 1. The CI wiring had no independent pin

The harness path appeared in `test.yml`, in the spine, and in its README — and
in no assertion. Deleting the step leaves valid YAML, a green matrix, and a
witness that is local-only again: the original defect (a harness no workflow had
ever run, so every assertion in it was skippable) in a new shape.

`implementation/scripts/_changed-surfaces.test.cjs` now pins both halves — the
invocation inside `verify-readme-links`, and that job's presence in
`all-required-passed`'s `needs:`, because a job absent from that list is
advisory whatever its own gate says. Same invariant and same unconditional job
(`js-harness-self-tests` → `test:script-policy`) as the adapter-disposition arm
directly above it, which is the established pattern from rf2-2718r.

**The assertion is scoped to `bash scripts/…/run-self-test.sh`, not the bare
path.** The explanatory comment block above the step names the same path, so a
looser match would still have been satisfied by that comment after the step was
deleted — a gate that cannot fail. Verified during mutation B below: with the
step removed, `grep -c run-self-test.sh test.yml` still returns 1 (the comment),
and the pin still reddens.

### 2. Hermetic case AC constructed only a `python` launcher

`resolve_mkdocs` tries `python python3 py` in order. Narrowing that back to
`python` alone left every required check green — CI installs `requirements.txt`,
so host smoke X takes the bare-console branch there — while breaking exactly the
python3-only and py-only checkouts this Bead was filed for.

There is now one hermetic case per launcher: **AC** (`python`), **AC1**
(`python3`), **AC2** (`py`). Each sandbox SHADOWS all three launchers and lets
exactly one answer `-m mkdocs --version`. The shadowing is load-bearing: the
sanitised PATH only has bare `mkdocs` removed, the host's real interpreters are
still on it, and `resolve_mkdocs` tries `python` first — so an unshadowed
`python3` witness would be satisfied by the host's own `python` and stay green
through the very regression it exists to catch.

**No workflow file is touched.** `.github/workflows/**` is hot-zone; the
required-check wiring already landed in `739e2a4bf2` and only needed a pin, and
the pin lives in a test file. This PR's diff touches no `.github/` path.

### Changes to the witness itself arm the gate

An explicit acceptance criterion, confirmed live. `sh scripts/test-fast-pr.sh
--plan` on this branch prints:

```
  documentation gates: run
  spine self-test:     run
  mkdocs --strict:     python -m mkdocs
PLAN-SELFTEST run
```

`is_spine_self_path` puts `scripts/_test_fixtures/test_fast_pr_docs_gate/*` on
both the documentation surface and the self-test trigger (rf2-fhdd3, cases
Z/AA/AB), and on CI the harness runs in an unconditional job, so no diff can
avoid it. Incidentally this maintainer host resolves mkdocs via `python -m
mkdocs` — the module-only path itself, live.

## Mutation proofs

Every mutation was reverted **byte-identically**, confirmed by `git hash-object`
and by `git status` showing neither file modified afterwards.

**A. Break the module-only fallback.** `for launcher in python python3 py` →
`for launcher in python` in `scripts/test-fast-pr.sh`:

```
34/36 self-test cases passed.
  FAIL AC1 only python3 can run mkdocs → 'python3 -m mkdocs' selected:
       expected PLAN-MKDOCS python3 -m mkdocs, got PLAN-MKDOCS unresolved
  FAIL AC2 only py can run mkdocs → 'py -m mkdocs' selected:
       expected PLAN-MKDOCS py -m mkdocs, got PLAN-MKDOCS unresolved
2 FAILED.                                                    (harness exit 1)
```

And the load-bearing counterfactual: **the pre-existing harness scores 34/34,
exit 0, against that same mutated spine.** The gap the audit named was real, and
case AC alone — which still passes under the mutation — would never have caught
it. `scripts/test-fast-pr.sh` restored to blob `d0481ea3f3`.

**B. Delete the harness step from `test.yml`.**

```
FAIL the fast-PR spine self-test harness is wired into a REQUIRED check (rf2-03298)
AssertionError: verify-readme-links must run the fast-PR spine self-test harness
                (unconditional job)
changed-surfaces tests: 1 failed.                                  (exit 1)
```

**C. Drop `- verify-readme-links` from `all-required-passed`'s `needs:`.**

```
FAIL the fast-PR spine self-test harness is wired into a REQUIRED check (rf2-03298)
AssertionError: all-required-passed must keep verify-readme-links in needs: —
                otherwise the spine self-test harness is advisory
changed-surfaces tests: 1 failed.                                  (exit 1)
```

`.github/workflows/test.yml` restored to blob `705ddca935` after both B and C.

## Quality gates

Every runner was redirected to a file and its own `$?` read back — never piped
through `tail`/`head`/`grep`, whose exit status would be the pipeline's last
command. Artefacts were written outside the worktree, and the two spellings this
PR adds to `.gitignore` cover them anyway.

| Gate | Command | Exit |
|---|---|---|
| Fast-PR spine | `sh scripts/test-fast-pr.sh` | `0` — `PASS fast PR spine`; 12442 tests / 62331 assertions, 0 failures 0 errors; per-ns isolation 17/17 |
| Spine self-test harness | `bash scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh` | `0` (36/36) |
| Script-policy pin | `node implementation/scripts/_changed-surfaces.test.cjs` | `0` (276 passed) |
| shellcheck, edited script | `shellcheck scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh` | `0` |
| shellcheck, `origin/main` baseline of the same file | (comparison) | `0` |
| Doc anchor validator | `python scripts/check_doc_slugs.py` | `0` |

`run-self-test.sh` is not on `portability.yml`'s shellcheck roster, so the
baseline was checked too: it was already clean, and it still is.

The spine armed and ran the witness on its own diff, as designed:

```
--- the spine itself changed → running its own tiering self-test ---
==> fast-PR spine tiering self-test
36/36 self-test cases passed.
```

`git status --porcelain` is empty in the worker worktree after every run — the
`node_modules` junction was unlinked with `cmd /c rmdir` before reporting done,
and the mayor checkout's real `node_modules` was re-counted at 103 entries,
unchanged.

## Out of scope, deliberately

- **How exit codes are captured.** Untouched, on the Bead's explicit
  instruction. Only the artefact is ignored.
- **No general command-resolution framework.** The Bead fences this by name.
  The change is three more cases in the existing shell fixture plus one
  assertion in the existing policy test.
- **No workflow edit.** The required-check wiring already landed; pinning it
  does not require re-touching hot-zone YAML.

Closes rf2-lci2z. Closes rf2-03298.
