### PR TITLE
refactor(hicasso): the sub-index stops carrying derivable structure (rf2-ixb92)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -1596,10 +1596,8 @@
   {:per-boundary
    [{:token :registration
      :what  "one JS object: the read set (shared with its entry), React's onStoreChange, and the acquired cell vector"}
-    {:token :index/live
-     :what  "one membership in the index's :live set"}
     {:token :index/b->subs
-     :what  "one map entry holding this boundary's read set"}
+     :what  "one map entry holding this boundary's read set — and, since rf2-ixb92, the index's ONLY record that the boundary is live; there is no separate :live membership beside it"}
     {:token :index/sub->bs
      :what  "one membership per edge in each read key's reader set"}
     {:token :react/use-sync-external-store
@@ -1644,7 +1642,7 @@
   (let [idx (index/snapshot)]
     {:cells      (count @!cells)
      :cell-refs  (reduce-kv (fn [acc _ ^js c] (+ acc (.-refs c))) 0 @!cells)
-     :boundaries (count (:live idx))
+     :boundaries (count (:b->subs idx))
      :edges      (reduce + 0 (map (fn [[_ v]] (count v)) (:b->subs idx)))
      :entries    (reduce + 0 (map (fn [[_ v]] (count v)) @!entries))
      :generation (generation)

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime_cljs_test.cljs
@@ -51,6 +51,15 @@
 
 (defn- key-of [query] [frame-id query])
 
+(defn- the-live-boundary
+  "The one live boundary's id, for the tests that mount exactly one. It
+  comes from the forward-edge map's key set because that IS the index's
+  record of liveness (rf2-ixb92) — there is no separate `:live` set to
+  read it from, and asking `:b->subs` for it is the same lookup the old
+  set answered."
+  []
+  (first (keys (:b->subs (idx/snapshot)))))
+
 ;; ---------------------------------------------------------------------------
 ;; The hook ledger and the retained inventory (HD-020(b))
 ;; ---------------------------------------------------------------------------
@@ -319,7 +328,7 @@
     (release)
     (let [narrow  (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
           release (rt/commit-boundary! narrow (fn []))
-          b       (first (:live (idx/snapshot)))]
+          b       (the-live-boundary)]
       (is (= 1 (count (idx/edges-of (idx/snapshot) b))))
       (is (empty? (idx/readers-of (idx/snapshot) (key-of [:dogfood/todo 1])))
           "and the dropped key has no reader left behind")
@@ -350,7 +359,7 @@
                change — there is no cheap route for `n-1 of n unchanged`")
           (let [narrow (render (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]))
                 stop2  (rt/commit-boundary! narrow (fn []))
-                b      (first (:live (idx/snapshot)))]
+                b      (the-live-boundary)]
             (is (= 1 (:cell-refs (rt/stats))) "and re-acquired from nothing")
             (is (= #{(key-of [:dogfood/todo 0])} (idx/edges-of (idx/snapshot) b))
                 "the narrowing landed")

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index.cljs
@@ -10,19 +10,38 @@
   in this namespace exists to keep that answer correct as boundaries
   mount, read, re-run with a different read set, and unmount.
 
-  The index is **global maps, not reactions**. Two maps and a set live in
-  a single atom:
+  The index is **global maps, not reactions**. Two maps live in a single
+  atom:
 
       :sub->bs   sub-key      -> #{boundary-id}    the reverse edges
       :b->subs   boundary-id  -> #{sub-key}        the forward edges
-      :live      #{boundary-id}                    mounted boundaries
 
   Shared structure, not per-boundary object fan-out. A boundary's
-  membership in the index is one entry in `:b->subs`, one entry in
-  `:live`, and one membership per edge in `:sub->bs` — there is no
-  per-boundary reaction, watcher, or cell here, and a ViewCell-class
-  object graph appearing in this file is the explicit failure marker for
-  the whole programme (architecture.md, Arm 1).
+  membership in the index is one entry in `:b->subs` and one membership
+  per edge in `:sub->bs` — there is no per-boundary reaction, watcher, or
+  cell here, and a ViewCell-class object graph appearing in this file is
+  the explicit failure marker for the whole programme (architecture.md,
+  Arm 1).
+
+  ## Liveness is the forward-edge entry, and there is no second record
+
+  A boundary is live exactly when `:b->subs` holds an entry for it
+  (rf2-ixb92). There used to be a third structure — `:live`, a set of
+  mounted boundary ids — and it carried no information the forward edges
+  did not already carry: [[mount]] installs `#{}` for a boundary it has
+  not seen, [[unmount]] drops the entry, and [[record-reads]] only ever
+  writes for a boundary that is already there, so the set was the key set
+  of `:b->subs` at every reachable index value. Deriving it costs
+  nothing — `contains?` and `count` are the same operations on a
+  persistent map as on a persistent set — and it removes both a
+  membership per mounted boundary from the retained inventory and a
+  second place [[mount]] and [[unmount]] had to stay symmetric in.
+
+  That makes the empty set [[mount]] installs load-bearing rather than
+  tidy: it is *the* record that the boundary exists, so a boundary whose
+  body read nothing is still live and can still record edges later.
+  `liveness-is-the-forward-edge-entry-and-there-is-no-second-record-of-it`
+  holds both halves.
 
   **Nothing in here is reactive.** The index does not watch, subscribe,
   schedule, or notify. It is a pure function of the edges it has been
@@ -94,18 +113,22 @@
   "A fresh, empty index value."
   []
   {:sub->bs {}
-   :b->subs {}
-   :live    #{}})
+   :b->subs {}})
 
 (defn mount
-  "Register `boundary-id` as live. Idempotent: a boundary already in the
-  index keeps the edges it has recorded, because StrictMode mounts a
-  boundary twice and HMR remounts it, and neither event means its reads
-  went away."
+  "Register `boundary-id` as live — which, since rf2-ixb92, is exactly
+  *give it a forward-edge entry*. The empty set is therefore the whole
+  registration and not a convenience: it is what [[live?]] answers from
+  and what [[record-reads]] checks before it writes.
+
+  Idempotent, and now by returning the index unchanged rather than by
+  rebuilding it: a boundary already in the index keeps the edges it has
+  recorded, because StrictMode mounts a boundary twice and HMR remounts
+  it, and neither event means its reads went away."
   [idx boundary-id]
-  (cond-> (update idx :live conj boundary-id)
-    (not (contains? (:b->subs idx) boundary-id))
-    (assoc-in [:b->subs boundary-id] #{})))
+  (if (contains? (:b->subs idx) boundary-id)
+    idx
+    (assoc-in idx [:b->subs boundary-id] #{})))
 
 (defn- drop-edges
   "Remove `boundary-id` from the reverse edges of every key in `sub-keys`,
@@ -127,8 +150,7 @@
   [idx boundary-id]
   (-> idx
       (update :sub->bs drop-edges boundary-id (get-in idx [:b->subs boundary-id] #{}))
-      (update :b->subs dissoc boundary-id)
-      (update :live disj boundary-id)))
+      (update :b->subs dissoc boundary-id)))
 
 (defn record-reads
   "Replace `boundary-id`'s edge set with the sub-keys its body just read.
@@ -169,7 +191,7 @@
   narrowing it to one caller's wiring would make a second `record-reads`
   for the same id leak edges silently."
   [idx boundary-id read-sub-keys]
-  (if-not (contains? (:live idx) boundary-id)
+  (if-not (contains? (:b->subs idx) boundary-id)
     idx
     (let [reads   (set read-sub-keys)
           held    (get-in idx [:b->subs boundary-id] #{})
@@ -204,9 +226,11 @@
   (get (:sub->bs idx) sub-key #{}))
 
 (defn live?
-  "Is `boundary-id` mounted?"
+  "Is `boundary-id` mounted? Answered from the forward edges, because
+  holding a forward-edge entry is what being mounted *is* (rf2-ixb92) —
+  including the entry that is still `#{}` because the body read nothing."
   [idx boundary-id]
-  (contains? (:live idx) boundary-id))
+  (contains? (:b->subs idx) boundary-id))
 
 ;; ---------------------------------------------------------------------------
 ;; The global index — one atom, the runtime's door

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index_laws_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index_laws_cljs_test.cljs
@@ -21,9 +21,10 @@
 
   Below the six sit the tests for what a runtime needs beyond the paper
   algebra: sub-key identity under value equality, the abandoned-render
-  guard, mount idempotence, the global-atom door, and the HD-005 evidence
-  seam. Those are not laws and do not pretend to be; they are the
-  obligations the laws would silently lose without them.
+  guard, mount idempotence, liveness as the forward-edge entry, the
+  global-atom door, and the HD-005 evidence seam. Those are not laws and
+  do not pretend to be; they are the obligations the laws would silently
+  lose without them.
 
   Everything here is a pure-value test against the algebra in
   [[re-frame.bench.hicasso.front.sub-index]] except the last two groups,
@@ -219,6 +220,54 @@
       (is (set? (idx/edges-of index :b)))
       (is (= #{[:x] [:y]} (idx/edges-of index :b)) "duplicates collapse")
       (is (= #{:b} (idx/dirty-boundaries index #{[:y]}))))))
+
+(deftest liveness-is-the-forward-edge-entry-and-there-is-no-second-record-of-it
+  (testing "rf2-ixb92. The index used to carry a third structure — `:live`,
+           a set of mounted boundary ids — beside the two edge maps, and it
+           held nothing `:b->subs` did not already hold: mount installs an
+           entry, unmount drops it, and record-reads only ever writes for a
+           boundary that is already there. This is that derivability as an
+           executable statement rather than an argument, walked across the
+           reachable values: at every step the set of boundaries the index
+           treats as mounted is exactly the key set of the forward edges"
+    (let [b0 (idx/empty-index)
+          b1 (idx/mount b0 :one)
+          b2 (idx/record-reads b1 :one #{[:x] [:y]})
+          b3 (idx/mount b2 :two)
+          b4 (idx/record-reads b3 :two #{[:x]})
+          b5 (idx/record-reads b4 :one #{[:x]})       ; law 4's narrowing
+          b6 (idx/record-reads b5 :one #{})           ; a body that read nothing
+          b7 (idx/mount b6 :one)                      ; StrictMode's second mount
+          b8 (idx/unmount b7 :one)
+          b9 (idx/record-reads b8 :one #{[:z]})       ; an abandoned render
+          ids [:one :two :never-mounted]]
+      (doseq [[step index live] [[:empty       b0 #{}]
+                                 [:mount       b1 #{:one}]
+                                 [:read        b2 #{:one}]
+                                 [:mount-2nd   b3 #{:one :two}]
+                                 [:read-2nd    b4 #{:one :two}]
+                                 [:narrow      b5 #{:one :two}]
+                                 [:read-none   b6 #{:one :two}]
+                                 [:remount     b7 #{:one :two}]
+                                 [:unmount     b8 #{:two}]
+                                 [:abandoned   b9 #{:two}]]]
+        (is (= live (set (keys (:b->subs index))))
+            (str "the forward edges' key set is the mounted set at " step))
+        (is (= live (into #{} (filter #(idx/live? index %)) ids))
+            (str "and `live?` answers from it, for every id, at " step)))))
+  (testing "the empty set `mount` installs is the whole registration, which
+           is why a boundary whose body read nothing is still live and can
+           still record edges afterwards — drop that entry as an
+           optimisation and the boundary dies silently"
+    (let [index (-> (idx/empty-index) (idx/mount :b))]
+      (is (true? (idx/live? index :b)))
+      (is (= #{} (idx/edges-of index :b)))
+      (is (= #{[:x]} (idx/edges-of (idx/record-reads index :b #{[:x]}) :b)))))
+  (testing "and there is no second record to drift out of step with the
+           first: an index value is exactly the two edge maps"
+    (is (= #{:sub->bs :b->subs} (set (keys (idx/empty-index)))))
+    (is (= #{:sub->bs :b->subs}
+           (set (keys (-> (idx/empty-index) (run :b [:x]) (idx/unmount :b))))))))
 
 (deftest the-global-index-is-one-atom-and-commit-is-its-only-door
   (idx/mount! :a)


### PR DESCRIPTION
The sub-index carried three structures where two carry the information. `:live` — a set of mounted boundary ids — is deleted, and liveness is derived from the forward edges instead.

## The derivability

`(:live idx)` was exactly `(set (keys (:b->subs idx)))` at **every reachable index value**, and the three ops are the whole proof:

- `mount` adds to `:live` and installs `#{}` in `:b->subs` when absent, so after a mount both contain the boundary;
- `unmount` removes it from both;
- `record-reads` only ever `assoc-in`s `:b->subs` for a boundary that is already live.

So `live?` is `(contains? (:b->subs idx) b)`, and `stats`' `:boundaries` counts the forward-edge map. **An elimination, not a cheaper encoding** — the structure is gone rather than compressed.

## Complexity: unchanged, in both directions

Stated plainly because a byte win paid for with an algorithmic regression would be a bad trade. `contains?` and `count` are the same operations on a `PersistentHashMap` as on a `PersistentHashSet` — the old `:live` lookup and the new `:b->subs` lookup are the same lookup, and `count` is O(1) on both. **No call site gets slower and none gets faster.** `mount` improves marginally in passing: it now returns the index *unchanged* on the idempotent path instead of rebuilding a set membership and re-asserting it.

## No byte figure is claimed, and that is deliberate

This is a per-**boundary** term on the shell axis, not a per-read one on the slope, so it would not show on the instrument the ladder is taken on. **Nothing was measured and nothing is claimed.** The box is also carrying several concurrent workers today and absolute figures have moved run-to-run on unchanged arms, so a figure taken now would not have been quotable anyway. The argument here is structural and stands on its own: a derivable structure is deleted and derived. What it removes is one set membership per mounted boundary from the retained inventory (`:index/live` is gone from `retained-inventory`) and one of the two places `mount` and `unmount` had to stay symmetric in.

## The empty set `mount` installs is now load-bearing

It used to be tidiness beside a `:live` membership; it is now *the* record that the boundary exists. That is what keeps a boundary whose body read nothing live and still able to record edges afterwards — the case law 4 already exercises from the other side. It is stated in `mount`'s docstring and held by the new test rather than left as a reader's inference.

## The proof is a test, not a stopwatch

`liveness-is-the-forward-edge-entry-and-there-is-no-second-record-of-it` walks the reachable values — mount, read, second boundary's mount, second boundary's read, law 4's narrowing, a run that read nothing, StrictMode's remount, unmount, an abandoned render's reads — and asserts at **each** step that the forward edges' key set is the mounted set and that `live?` agrees for every id including one never mounted. It also asserts an index value is exactly `#{:sub->bs :b->subs}`, so a third structure cannot reappear without a line being deleted.

**The six laws are untouched.** The suite discharges them through the `live?` *function*, never through the key, so no law changed and none needed to.

## Mutation proofs

Both taken through `npm run test:cljs` (gated, in the fast-PR spine), both reverted byte-identically afterwards — `git status` clean, `git diff HEAD` empty.

| mutation | exit | result |
|---|---:|---|
| **M1** — restore the deleted structure's use: `live?` reads `(:live idx)` again | **1** | **13 failures**: `law-3-unmount-removes-every-edge-the-boundary-held`, `law-4-a-rerun-with-fewer-reads-drops-the-edges-it-stopped-reading`, `mount-is-idempotent-and-does-not-clear-recorded-edges`, and `liveness-is-the-forward-edge-entry-and-there-is-no-second-record-of-it` at 9 sites |
| **M2** — remove the sole liveness record: `mount` no longer installs `#{}` | **1** | **79 failures** across all six laws, the new liveness test (20), `the-wired-path-never-takes-the-diffs-dropping-half`, `the-index-answers-the-screens-own-narrow-and-broad-writes`, `a-narrow-write-notifies-exactly-the-boundary-that-read-it`, `a-lazy-for-registers-its-edges-and-its-readers-re-run`, and the evidence-seam suite |

## Two corrections to the bead

- **`docs/design/hicasso/architecture.md` needs no edit**, though rf2-ixb92 expects one: the document never names `:live`. It says the index is "sub-key → boundary set" and that "index edges live in global maps — shared structure, not per-boundary object fan-out", and both remain true — `:live` was not an edge.
- **The bead also names `stats`' `:boundaries` count as a cost site.** It is one, but it lives in `arm1/runtime.cljs`, not in the index; the bead reads as though it were in the namespace. The `:edges` line beside it already reduced over `:b->subs`, so the two now read from one structure.

## Sequencing against #7418

#7418 (rf2-aqgr2) merged mid-run and touched two of these four files. This branch was rebased onto it and its work is carried forward **verbatim**: the `record-reads` docstring block on the `(set read-sub-keys)` coercion, and `the-forward-edge-shares-a-callers-set-rather-than-copying-it`. The one conflict — both landings inserting a `deftest` at the same point in the laws file — was resolved by keeping both, never by taking a side. **`(set read-sub-keys)` is untouched**; that question is settled and is not re-derived here. #7418's removal of the minted per-cell watch keyword was checked against `retained-inventory`: no row named it (it lived on the shared `:key-cell`, whose row is still accurate), so nothing there double-counts or names something that no longer exists.

## rf2-dabt3 is HELD, not forgotten

rf2-dabt3 (*the sub-index's reverse edge duplicates the cell table's key space*) was dispatched alongside this and is **deliberately absent from this PR**. Investigating it established that it is larger than the bead states: all six laws are statements about the reverse edge, so there is no "keep the algebra, move one map" split; and `:b->subs` goes too, because `record-reads` exists to feed `:sub->bs` and Arm 1's registration already holds `.-reads`. The honest end state is that `front.sub-index` has no role in Arm 1 at all — i.e. the question is *"is deliverable 2 of the shared front half retired?"*, which moves `architecture.md`'s central sentence. That is an operator ruling and it is with the mayor. Nothing here forecloses either answer.

## Quality gates

All foreground to completion, none piped, each exit code read directly from `$?`. Logs went to gitignored `*.log` paths and exit codes to stdout rather than to a `.exit` file; `git status --untracked-files=all` is empty, so the worktree reaps cleanly.

Taken on `10c073f5e8` (`origin/main` tip at the time of writing) after the rebase:

| gate | exit | result |
|---|---:|---|
| `cd implementation && npm run test:cljs` | **0** | 12,472 tests / 62,526 assertions / 0 failures / 0 errors |
| `cd implementation && npm run test:browser` | **0** | 1,040 tests / 6,468 assertions / 0 failures / 0 errors |

Taken on `11800137e6`, the base immediately before those 12 commits landed:

| gate | exit | result |
|---|---:|---|
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`; its CLJS node integration leg ran 12,466 tests / 62,454 assertions / 0 failures / 0 errors |
| `cd implementation && npm run test:browser` | **0** | 1,036 tests / 6,432 assertions / 0 failures / 0 errors |

The spine is quoted against the earlier base because main moved 12 commits under this branch mid-run. **None of them touches any of these four files**, and the two gates that cover this diff's transitive surface were re-taken on the tip afterwards rather than carried forward. No flake was hit; `re-frame.ui.tool-evidence-dom-cljs-test` passed on every run, and this diff cannot reach `re-frame.ui` in any case.

**Gated surface.** The change is in `front/sub_index.cljs`; its `:require` edges reach `arm1/runtime.cljs`, `arm1/runtime_cljs_test.cljs`, `front/dogfood_cljs_test.cljs`, `read_profile_app.cljs` and `shapes/framework_subs_dom_cljs_test.cljs`. The first four are in the `node-test` bundle (`cljs-test$`), the last in `browser-test` (`-dom-cljs-test$`); both bundles are gated above. The hicasso bench lane's own `run.cjs` is compile-ungated (rf2-2rtt6.73) and was deliberately **not** used as a proof surface here.

**The shell is untouched** — no hook was added or removed, `shell-hook-ledger` still declares two and `frame-prop-shell-hook-ledger` one, and `subscribe` still closes over the read set alone. Bodies stay `.cljc`-compatible.

Closes rf2-ixb92.
