### PR TITLE
perf(reagent-slim): attack the residual gap over stock Reagent (rf2-e7zxb)

### DIFF
--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -744,15 +744,15 @@
 (defn- emit-dom-vector
   "Emit a hiccup vector whose head is a DOM-tag keyword/symbol/string."
   [^StringBuffer sb argv]
-  (let [head      (nth argv 0 nil)
-        parsed    (template/parse-tag head argv)
-        tag-str   (.-tag parsed)
-        first-arg  (nth argv 1 nil)
-        has-props  (template/props-slot? first-arg)
+  (let [head         (nth argv 0 nil)
+        parsed       (template/parse-tag head argv)
+        tag-str      (.-tag parsed)
+        first-arg    (nth argv 1 nil)
+        has-props    (template/props-slot? first-arg)
         children-pos (if has-props 2 1)
-        user-attrs (when (and has-props (some? first-arg)) first-arg)
-        attrs      (merge-shorthand parsed user-attrs)
-        n          (count argv)
+        user-attrs   (when (and has-props (some? first-arg)) first-arg)
+        attrs        (merge-shorthand parsed user-attrs)
+        n            (count argv)
         children     (when (< children-pos n)
                        (subvec argv children-pos))
         void?        (contains? template/void-tags tag-str)

--- a/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/dom/server.cljs
@@ -747,7 +747,9 @@
   (let [head      (nth argv 0 nil)
         parsed    (template/parse-tag head argv)
         tag-str   (.-tag parsed)
-        [first-arg has-props children-pos] (template/hiccup-shape argv 1)
+        first-arg  (nth argv 1 nil)
+        has-props  (template/props-slot? first-arg)
+        children-pos (if has-props 2 1)
         user-attrs (when (and has-props (some? first-arg)) first-arg)
         attrs      (merge-shorthand parsed user-attrs)
         n          (count argv)
@@ -782,8 +784,8 @@
 (defn- emit-fragment
   "Emit a `:<>` fragment — children only, no surrounding markup."
   [^StringBuffer sb argv]
-  (let [n         (count argv)
-        [_head _has-props children-pos] (template/hiccup-shape argv 1)]
+  (let [n            (count argv)
+        children-pos (if (template/props-slot? (nth argv 1 nil)) 2 1)]
     (when (< children-pos n)
       (emit-children sb (subvec argv children-pos)))))
 

--- a/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs
@@ -765,10 +765,11 @@
   none — `(:key nil)` is nil, so the absence needs no branch.
 
   This is what an element constructor calls. Locating the props slot is
-  precisely what `hiccup-shape` has just done for it, so re-deriving the
-  slot from the head — `get-react-key`'s `nth`/`case` ladder below — is
-  work the hot path does not owe: 133.9 → 62.8 ns per element, the two
-  costed side by side on one run over the census page (rf2-lhdp0)."
+  precisely what the constructor's own `props-slot?` test has just done for
+  it, so re-deriving the slot from the head — `get-react-key`'s `nth`/`case`
+  ladder below — is work the hot path does not owe: 133.9 → 62.8 ns per
+  element, the two costed side by side on one run over the census page
+  (rf2-lhdp0)."
   [argv props]
   (or (some-> (meta argv) :key)
       (:key props)))
@@ -963,26 +964,36 @@
 ;; ---------------------------------------------------------------------------
 ;; Shared hiccup-shape detection
 ;;
-;; Five sites (native-element, fragment-element, emit-dom-vector,
-;; emit-fragment, plus the make-element consumer) ask the same shape
-;; question: "is the slot at `first-pos` a props map, and where do
-;; children start?" One helper, one shape — drift-proof.
+;; Four sites (native-element, fragment-element, and the server walker's
+;; emit-dom-vector / emit-fragment) ask the same shape question: "is the slot
+;; at `first-pos` a props map, and where do children start?"
+;;
+;; THE RULE IS THE SHARED THING; THE ARITHMETIC IS NOT (rf2-e7zxb). This was
+;; `hiccup-shape`, which answered all three parts at once and handed them back
+;; in a freshly minted `[head has-props first-child]` vector that every call
+;; site destructured and discarded — an allocation plus three `nth` calls per
+;; element, to carry two answers that are one expression each. Costed side by
+;; side on the census page's own 1,202 element vectors, the tuple read 85.3
+;; ns/element against 44.9 for the same three answers derived in place (0.53x;
+;; 0.49x and 0.49x on two further runs, so the sign is not a run artefact).
+;; Stock Reagent allocates nothing here.
+;;
+;; What could actually drift between four sites is the RULE — what counts as a
+;; props slot — so that is what keeps a name. `(nth argv first-pos nil)` and
+;; "children start one later if there was a props map" are self-evident at each
+;; site, and reading them there beats trusting the field order of a positional
+;; tuple.
 ;; ---------------------------------------------------------------------------
 
-(defn hiccup-shape
-  "Inspect `argv` starting at index `first-pos`. Returns a 3-element
-  vector `[head has-props? first-child]` where:
+(defn ^boolean props-slot?
+  "True when hiccup slot value `head` occupies the conventional props-map
+  position: nil, or a map. Anything else is the first CHILD.
 
-    - `head` is `(nth argv first-pos nil)`.
-    - `has-props?` is true when `head` is nil or a map (the
-      props-map slot is the conventional Reagent shape).
-    - `first-child` is the argv index where children begin
-      (`first-pos + 1` if a props map is present, else `first-pos`)."
-  [argv first-pos]
-  (let [head      (nth argv first-pos nil)
-        has-props (or (nil? head) (map? head))
-        first-child (+ first-pos (if has-props 1 0))]
-    [head has-props first-child]))
+  `head` is the slot VALUE — `(nth argv first-pos nil)` — not the vector, so
+  the `nil` arm covers both an explicit `[:div nil \"x\"]` and an index past
+  the end of the vector."
+  [head]
+  (or (nil? head) (map? head)))
 
 (defn- native-element
   "Emit a DOM element. `parsed` is the parsed HiccupTag; `argv` the
@@ -1006,11 +1017,13 @@
   DOM element downstream (§5.4's 'first hiccup vector with a DOM-tag
   head')."
   [^HiccupTag parsed argv first-pos]
-  (let [component (.-tag parsed)
-        [head has-props first-child] (hiccup-shape argv first-pos)
-        props     (cond-> (when has-props head)
-                    (and *source-coord* (string? component)) merge-source-coord-attr)
-        js-props  (or (convert-props props parsed) #js {})]
+  (let [component   (.-tag parsed)
+        head        (nth argv first-pos nil)
+        has-props   (props-slot? head)
+        first-child (+ first-pos (if has-props 1 0))
+        props       (cond-> (when has-props head)
+                      (and *source-coord* (string? component)) merge-source-coord-attr)
+        js-props    (or (convert-props props parsed) #js {})]
     ;; `props` IS the props slot `get-react-key` would go and re-derive, on
     ;; both routes here: a DOM tag enters at `first-pos` 1 and `:>` at 2,
     ;; which are exactly the two indices that ladder reads. (The source-coord
@@ -1121,10 +1134,12 @@
   `[:<> & children]` or `[:<> {:key k} & children]`. Props map (if
   present) is JS-converted; only `:key` is meaningful on Fragments."
   [argv]
-  (let [[head has-props first-child] (hiccup-shape argv 1)
-        js-props  (or (when (and has-props (some? head))
-                        (convert-prop-value head))
-                      #js {})]
+  (let [head        (nth argv 1 nil)
+        has-props   (props-slot? head)
+        first-child (if has-props 2 1)
+        js-props    (or (when (and has-props (some? head))
+                          (convert-prop-value head))
+                        #js {})]
     ;; The slot is in hand, so the rule is read directly — see `react-key`.
     (when-some [key (react-key argv (when has-props head))]
       (set! (.-key js-props) key))
@@ -1160,51 +1175,69 @@
                                        "vector a head tag (e.g. [:div …]).")
                      :recovery    :supply-a-head-tag})))
   (let [tag (nth argv 0 nil)]
-    (cond
-      ;; Interop heads — checked first so they don't get treated as
-      ;; user fns or DOM tags.
-      (= tag :>)  (interop-element argv)
-      (= tag :<>) (fragment-element argv)
-      (= tag :r>) (raw-element argv)
-      (= tag :f>) (function-element argv)
+    ;; The four interop heads are KEYWORD SENTINELS, and `case` is what says
+    ;; so — they are answered together, before anything can mistake one for a
+    ;; user fn or a DOM tag.
+    ;;
+    ;; `case` over all-keyword tests lowers to `(if (keyword? tag) (.-fqn tag)
+    ;; nil)` and a JS `switch` on that string, so the whole roster costs ONE
+    ;; keyword test and one constant-time dispatch. The ladder it replaces
+    ;; asked four `(= tag :>)`-shaped questions, and `cljs.core/=` falls
+    ;; through `identical?` to an `-equiv` protocol dispatch on a miss — which
+    ;; every DOM element, i.e. essentially every element, misses four times.
+    ;; Costed on the census page's own 1,202 heads: 191.3 ns/element for the
+    ;; ladder against 33.7 for the `case` (9.6 and 9.2 against 64.5 and 68.6
+    ;; on two further runs — the absolutes move with the box, the sign does
+    ;; not). rf2-e7zxb.
+    ;;
+    ;; The lowering is also why this is not merely an identity trick: the fqn
+    ;; switch answers a RECONSTRUCTED `(keyword ">")` exactly as `=` did, and
+    ;; still refuses the string `">"` and the symbol `'>`, which are DOM-tag
+    ;; heads and must fall through to `hiccup-tag?`.
+    (case tag
+      :>  (interop-element argv)
+      :<> (fragment-element argv)
+      :r> (raw-element argv)
+      :f> (function-element argv)
 
-      ;; DOM-tag head — keyword, symbol, or string.
-      (hiccup-tag? tag)
-      (native-element (cached-parse tag argv) argv 1)
+      (cond
+        ;; DOM-tag head — keyword, symbol, or string.
+        (hiccup-tag? tag)
+        (native-element (cached-parse tag argv) argv 1)
 
-      ;; Reagent / React class head — instantiate directly.
-      (component/reagent-class? tag)
-      (react-component-element tag argv)
+        ;; Reagent / React class head — instantiate directly.
+        (component/reagent-class? tag)
+        (react-component-element tag argv)
 
-      (component/react-class? tag)
-      (react-component-element tag argv)
+        (component/react-class? tag)
+        (react-component-element tag argv)
 
-      ;; Plain user fn head — wrap via fn-to-class for reactive
-      ;; subscription wiring.
-      (fn? tag)
-      (react-component-element tag argv)
+        ;; Plain user fn head — wrap via fn-to-class for reactive
+        ;; subscription wiring.
+        (fn? tag)
+        (react-component-element tag argv)
 
-      :else
-      ;; Canonical shape replicated inline (bundle isolation — see the
-      ;; empty-vector throw above for the rationale).
-      ;; EP-0015 (rf2-uwqale): the head + argv summarise into shape-only
-      ;; diagnostics — never the raw head/children. A bad-tag throw is
-      ;; captured by error boundaries / host logs before the projector can
-      ;; classify it, and the argv carries app-owned hiccup children that
-      ;; can hold sensitive/large values.
-      (throw (ex-info (str "Hiccup head " (pr-str (diag/value-summary tag))
-                           " is not a valid element head; use a keyword "
-                           "(DOM tag or :>/:<>/:r>/:f>), a Reagent component "
-                           "class, a React component class, or a fn. "
-                           "[:rf.error/template-bad-tag]")
-                      {:rf.error/id   :rf.error/template-bad-tag
-                       :where         'reagent2.template/as-element
-                       :reason        (str "Hiccup head must be a keyword (DOM tag "
-                                           "or :>/:<>/:r>/:f>), a Reagent component "
-                                           "class, a React component class, or a fn.")
-                       :recovery      :supply-a-valid-hiccup-head
-                       :tag/summary   (diag/value-summary tag)
-                       :argv/summary  (diag/value-summary argv)})))))
+        :else
+        ;; Canonical shape replicated inline (bundle isolation — see the
+        ;; empty-vector throw above for the rationale).
+        ;; EP-0015 (rf2-uwqale): the head + argv summarise into shape-only
+        ;; diagnostics — never the raw head/children. A bad-tag throw is
+        ;; captured by error boundaries / host logs before the projector can
+        ;; classify it, and the argv carries app-owned hiccup children that
+        ;; can hold sensitive/large values.
+        (throw (ex-info (str "Hiccup head " (pr-str (diag/value-summary tag))
+                             " is not a valid element head; use a keyword "
+                             "(DOM tag or :>/:<>/:r>/:f>), a Reagent component "
+                             "class, a React component class, or a fn. "
+                             "[:rf.error/template-bad-tag]")
+                        {:rf.error/id   :rf.error/template-bad-tag
+                         :where         'reagent2.template/as-element
+                         :reason        (str "Hiccup head must be a keyword (DOM tag "
+                                             "or :>/:<>/:r>/:f>), a Reagent component "
+                                             "class, a React component class, or a fn.")
+                         :recovery      :supply-a-valid-hiccup-head
+                         :tag/summary   (diag/value-summary tag)
+                         :argv/summary  (diag/value-summary argv)}))))))
 
 (defn as-element
   "Top-level hiccup → React element conversion.

--- a/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/reagent2/impl/template_cljs_test.cljs
@@ -505,6 +505,54 @@
       (is (= 1 (.-length (js/Object.keys js-props)))
           "caller's js-props gained no extra own keys"))))
 
+(deftest as-element-interop-heads-are-keyword-sentinels-rf2-e7zxb
+  (testing "rf2-e7zxb: the four interop heads are dispatched by a `case`,
+            which lowers to a switch on the head's `.-fqn`. A head
+            RECONSTRUCTED at runtime is not `identical?` to the literal, so
+            this is the pin that the dispatch is by VALUE — exactly what the
+            `(= tag :>)` ladder it replaced answered."
+    (let [Comp (fn FakeComp [_props] nil)]
+      (is (= Comp (.-type ^js (template/as-element [(keyword ">") Comp {:foo "bar"}])))
+          "a reconstructed :> still reaches interop-element")
+      (is (= (.-Fragment react)
+             (.-type ^js (template/as-element [(keyword "<>") [:div "a"]])))
+          "a reconstructed :<> still reaches fragment-element")
+      (is (= Comp (.-type ^js (template/as-element [(keyword "r>") Comp #js {}])))
+          "a reconstructed :r> still reaches raw-element")
+      (is (fn? (.-type ^js (template/as-element [(keyword "f>") (fn [] [:div])])))
+          "a reconstructed :f> still reaches function-element")))
+
+  (testing "rf2-e7zxb: the STRING and SYMBOL look-alikes are DOM-tag heads,
+            not sentinels — the `case` must refuse a non-keyword, and the
+            `(= tag :>)` ladder did too."
+    (is (= ">" (.-type ^js (template/as-element [">" "x"])))
+        "the string \">\" is a custom-element tag, not the :> head")
+    (is (= "<>" (.-type ^js (template/as-element ["<>" "x"])))
+        "the string \"<>\" is a tag, not the :<> head")
+    (is (= ">" (.-type ^js (template/as-element [(symbol ">") "x"])))
+        "the symbol '> is a tag, not the :> head")))
+
+(deftest props-slot-rule-rf2-e7zxb
+  (testing "rf2-e7zxb: `props-slot?` is the one named rule four call sites
+            share — nil or a map occupies the props slot, anything else is
+            the first child."
+    (is (true? (template/props-slot? nil)))
+    (is (true? (template/props-slot? {})))
+    (is (true? (template/props-slot? {:id "x"})))
+    (is (false? (template/props-slot? "x")))
+    (is (false? (template/props-slot? [:span])))
+    (is (false? (template/props-slot? 0)))
+    (is (false? (template/props-slot? :kw))))
+
+  (testing "an explicit nil props slot is a props slot, so children start
+            one later — the arm a past-the-end index also takes"
+    (let [^js el (template/as-element [:div nil "only-child"])]
+      (is (= "div" (.-type el)))
+      (is (= "only-child" (-> el .-props .-children))))
+    (let [^js el (template/as-element [:div "first" "second"])]
+      (is (= 2 (.-length (-> el .-props .-children)))
+          "a non-map slot is the first CHILD, not props"))))
+
 (deftest as-element-function-component-is-real-fn-component-rf2-bf4uw2
   (testing "rf2-bf4uw2: [:f> f] renders f as a REAL React FUNCTION
             component — NOT a class. The prior fn-to-class lowering

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -791,6 +791,79 @@
 (defn- ^boolean slim-void-idx? [t]
   (true? (unchecked-get slim-void-index t)))
 
+;; --- the per-element hiccup-shape read (rf2-e7zxb) --------------------------
+;;
+;; `hiccup-shape` answers three questions at once — the slot value, whether it
+;; is a props map, and where children begin — and hands them back in a freshly
+;; minted 3-element PersistentVector that every one of its four call sites
+;; destructures and discards. The destructure is three `nth` calls ON TOP of
+;; the allocation, and the two derived answers are one expression each.
+;;
+;; Both arms fold the three values into ONE number, so the row prices the SHAPE
+;; DERIVATION and not a tail that differs between them.
+
+(defn- slim-shape-ship [argv first-pos]
+  (let [[head has-props first-child] (slim/hiccup-shape argv first-pos)]
+    (+ first-child (if has-props 100 0) (if (nil? head) 10000 0))))
+
+(defn- slim-shape-inline [argv first-pos]
+  (let [head        (nth argv first-pos nil)
+        has-props   (or (nil? head) (map? head))
+        first-child (+ first-pos (if has-props 1 0))]
+    (+ first-child (if has-props 100 0) (if (nil? head) 10000 0))))
+
+;; --- the per-element head dispatch (rf2-e7zxb) ------------------------------
+;;
+;; `vec-to-elem` asks four `(= tag :>)`-shaped questions before it reaches the
+;; `hiccup-tag?` branch that EVERY DOM element takes, and `cljs.core/=` falls
+;; through `identical?` to an `-equiv` protocol dispatch on a miss — so the
+;; common head pays four of them. `keyword-identical?` answers the same
+;; question with an `instance?` pair and an interned-string compare; `case` is
+;; the third shape. The three arms end identically so the row prices the
+;; DISPATCH, and the roster is `tags` — the page's own DOM heads, i.e. exactly
+;; the population that misses all four.
+
+(defn- ^boolean slim-hiccup-tag? [x]
+  (or (keyword? x) (symbol? x) (string? x)))
+
+(defn- slim-head-ship [tag]
+  (cond
+    (= tag :>)  0
+    (= tag :<>) 1
+    (= tag :r>) 2
+    (= tag :f>) 3
+    (slim-hiccup-tag? tag) 4
+    :else 5))
+
+(defn- slim-head-kwid [tag]
+  (cond
+    (keyword-identical? tag :>)  0
+    (keyword-identical? tag :<>) 1
+    (keyword-identical? tag :r>) 2
+    (keyword-identical? tag :f>) 3
+    (slim-hiccup-tag? tag) 4
+    :else 5))
+
+(defn- slim-head-case [tag]
+  (case tag
+    :>  0
+    :<> 1
+    :r> 2
+    :f> 3
+    (if (slim-hiccup-tag? tag) 4 5)))
+
+;; The heads a hiccup renderer must answer for and the census page does not
+;; carry — the four interop sentinels themselves; the same four RECONSTRUCTED
+;; at runtime, which a constants-table identity test would miss and `=` would
+;; not; their STRING and SYMBOL look-alikes, which must NOT match a keyword
+;; sentinel; a reserved head; and the non-named heads reaching the component
+;; branches.
+(def ^:private hostile-heads
+  [:> :<> :r> :f>
+   (keyword ">") (keyword "<>") (keyword "r>") (keyword "f>")
+   ">" "<>" "r>" "f>" ":>" (symbol ">") (symbol "<>")
+   :rf/suspense-boundary :div "div" (symbol "div") nil 7 (fn [] nil)])
+
 (defn- warm-slim! [^js tags ^js prop-keys]
   (dotimes [i (.-length prop-keys)]
     (let [k (aget prop-keys i)] (slim-prop-ship k) (slim-prop-np k)))
@@ -836,7 +909,14 @@
      ;; the per-element void probe
      [:slim-void-set  (ns-per-op micro-reps tag-strs slim-void-set?)]
      [:slim-void-case (ns-per-op micro-reps tag-strs slim-void-case?)]
-     [:slim-void-idx  (ns-per-op micro-reps tag-strs slim-void-idx?)]]))
+     [:slim-void-idx  (ns-per-op micro-reps tag-strs slim-void-idx?)]
+     ;; the per-element hiccup-shape read (rf2-e7zxb)
+     [:slim-shape-ship   (ns-per-op micro-reps el-vecs (fn [v] (slim-shape-ship v 1)))]
+     [:slim-shape-inline (ns-per-op micro-reps el-vecs (fn [v] (slim-shape-inline v 1)))]
+     ;; the per-element head dispatch (rf2-e7zxb)
+     [:slim-head-ship (ns-per-op micro-reps tags slim-head-ship)]
+     [:slim-head-kwid (ns-per-op micro-reps tags slim-head-kwid)]
+     [:slim-head-case (ns-per-op micro-reps tags slim-head-case)]]))
 
 (defn- slim-agreement
   "Every cheapened slim variant answers what the shipping shape answers —
@@ -876,7 +956,32 @@
                          (slim-convert-props-static slim-preamble-cheap p t)))
             (swap! bad conj [:pipeline-static i])))
         (when-not (= (slim-key-ship v) (slim-key-spec v p))
-          (swap! bad conj [:key i]))))
+          (swap! bad conj [:key i]))
+        ;; the shape read, at BOTH positions its call sites use (1 for a DOM
+        ;; tag and `:<>`, 2 for `:>`)
+        (when-not (= (slim-shape-ship v 1) (slim-shape-inline v 1))
+          (swap! bad conj [:shape-1 i]))
+        (when-not (= (slim-shape-ship v 2) (slim-shape-inline v 2))
+          (swap! bad conj [:shape-2 i]))))
+    ;; the head dispatch, over the page's own heads and the heads it lacks
+    (dotimes [i (.-length tags)]
+      (let [t (aget tags i)
+            s (slim-head-ship t)]
+        (when-not (= s (slim-head-kwid t)) (swap! bad conj [:head-kwid t]))
+        (when-not (= s (slim-head-case t)) (swap! bad conj [:head-case t]))))
+    (doseq [t hostile-heads]
+      (let [s (slim-head-ship t)]
+        (when-not (= s (slim-head-kwid t)) (swap! bad conj [:hostile-head-kwid (pr-str t)]))
+        (when-not (= s (slim-head-case t)) (swap! bad conj [:hostile-head-case (pr-str t)]))))
+    ;; the shape read over hostile SLOTS — nil and a map are the props shape,
+    ;; everything else is a child
+    (doseq [h [nil {} {:a 1} [] "x" 0 :k]]
+      (let [v ["div" h "c"]]
+        (when-not (= (slim-shape-ship v 1) (slim-shape-inline v 1))
+          (swap! bad conj [:hostile-shape (pr-str h)]))))
+    ;; and past the end of the vector, which `nth`'s not-found arm answers
+    (when-not (= (slim-shape-ship ["div"] 1) (slim-shape-inline ["div"] 1))
+      (swap! bad conj [:shape-past-end]))
     ;; hostile names the page does not carry
     (doseq [n ["__proto__" "prototype" "constructor" "toString" "hasOwnProperty"
                "valueOf" "isPrototypeOf"]]

--- a/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/walk_vs_reagent_app.cljs
@@ -793,17 +793,23 @@
 
 ;; --- the per-element hiccup-shape read (rf2-e7zxb) --------------------------
 ;;
-;; `hiccup-shape` answers three questions at once — the slot value, whether it
-;; is a props map, and where children begin — and hands them back in a freshly
-;; minted 3-element PersistentVector that every one of its four call sites
-;; destructures and discards. The destructure is three `nth` calls ON TOP of
-;; the allocation, and the two derived answers are one expression each.
+;; The pre-rf2-e7zxb `hiccup-shape` answered three questions at once — the slot
+;; value, whether it is a props map, and where children begin — and handed them
+;; back in a freshly minted 3-element PersistentVector that every one of its
+;; four call sites destructured and discarded. The destructure is three `nth`
+;; calls ON TOP of the allocation, and the two derived answers are one
+;; expression each. The `-inline` arm won and shipped; `props-slot?` is what
+;; kept a name, because the RULE is the thing four sites could drift on.
 ;;
 ;; Both arms fold the three values into ONE number, so the row prices the SHAPE
 ;; DERIVATION and not a tail that differs between them.
 
 (defn- slim-shape-ship [argv first-pos]
-  (let [[head has-props first-child] (slim/hiccup-shape argv first-pos)]
+  (let [[head has-props first-child]
+        (let [head        (nth argv first-pos nil)
+              has-props   (or (nil? head) (map? head))
+              first-child (+ first-pos (if has-props 1 0))]
+          [head has-props first-child])]
     (+ first-child (if has-props 100 0) (if (nil? head) 10000 0))))
 
 (defn- slim-shape-inline [argv first-pos]
@@ -814,14 +820,17 @@
 
 ;; --- the per-element head dispatch (rf2-e7zxb) ------------------------------
 ;;
-;; `vec-to-elem` asks four `(= tag :>)`-shaped questions before it reaches the
-;; `hiccup-tag?` branch that EVERY DOM element takes, and `cljs.core/=` falls
-;; through `identical?` to an `-equiv` protocol dispatch on a miss — so the
-;; common head pays four of them. `keyword-identical?` answers the same
-;; question with an `instance?` pair and an interned-string compare; `case` is
-;; the third shape. The three arms end identically so the row prices the
-;; DISPATCH, and the roster is `tags` — the page's own DOM heads, i.e. exactly
-;; the population that misses all four.
+;; The pre-rf2-e7zxb `vec-to-elem` asked four `(= tag :>)`-shaped questions
+;; before it reached the `hiccup-tag?` branch that EVERY DOM element takes, and
+;; `cljs.core/=` falls through `identical?` to an `-equiv` protocol dispatch on
+;; a miss — so the common head paid four of them. `keyword-identical?` answers
+;; the same question with an `instance?` pair and an interned-string compare;
+;; `case` over all-keyword tests lowers to ONE `(if (keyword? x) (.-fqn x) nil)`
+;; and a JS `switch`, which is both the cheapest of the three on every run and
+;; the one that says "these four heads are constants" structurally. `case`
+;; shipped. The three arms end identically so the row prices the DISPATCH, and
+;; the roster is `tags` — the page's own DOM heads, i.e. exactly the population
+;; that misses all four.
 
 (defn- ^boolean slim-hiccup-tag? [x]
   (or (keyword? x) (symbol? x) (string? x)))


### PR DESCRIPTION
Closes rf2-e7zxb. Follow-on to rf2-lhdp0 / #7405, which took reagent-slim's whole-page hiccup walk from 1.82x stock Reagent to 1.19-1.24x and then filed this bead because the residual was no longer in the prop pipeline. The bead named two terms and costed neither. Both are costed here, both convict, and both land.

**The census-page walk now reads 0.97x stock Reagent** — slim is marginally *faster* than the interpreter it was 1.82x behind two beads ago.

## The two terms

**1. The head dispatch.** `vec-to-elem` asked four `(= tag :>)`-shaped questions before the `hiccup-tag?` branch that every DOM element takes, and `cljs.core/=` falls through `identical?` to an `-equiv` protocol dispatch on a miss — so the common head paid four of them. Three shapes were costed. `case` over all-keyword tests lowers to one `(if (keyword? tag) (.-fqn tag) nil)` and a JS `switch` on that interned string; it was the cheapest on every run *and* the one that says "these four heads are constants" structurally, so it shipped.

**2. The shape read.** `hiccup-shape` minted a `[head has-props first-child]` PersistentVector per element that all four call sites destructured and discarded — an allocation plus three `nth` calls, carrying two answers that are one expression each. Stock Reagent allocates nothing here. `props-slot?` keeps the only part four sites could actually drift on — the *rule* for what counts as a props slot — and the `nth` and the `+` are read where they are used.

## Measurements

Every figure is a same-run pair from the `walk_vs_reagent_app` instrument (1,202-element census page, its own roster, `:advanced` + `goog.DEBUG=false`, headless Chromium). Absolutes moved ~3x run-to-run on this box — five other workers are on it — so **the ratio against the same-run control is the statistic**, and every claim below is over five runs.

Head dispatch, ns/element over the page's own 1,202 DOM heads (the population that misses all four compares):

| run | `-ship` (four `=`) | `keyword-identical?` | `case` | case/ship |
|---|---|---|---|---|
| before 1 | 191.3 | 41.6 | 33.7 | 0.176 |
| before 2 | 64.5 | 14.1 | 9.6 | 0.149 |
| before 3 | 68.6 | 24.5 | 9.2 | 0.134 |
| after 1 | 61.1 | 12.9 | 7.5 | 0.123 |
| after 2 | 81.5 | 17.1 | 12.1 | 0.148 |

Shape read, ns/element over the page's own 1,202 element vectors:

| run | `-ship` (3-vector) | `-inline` | inline/ship |
|---|---|---|---|
| before 1 | 85.3 | 44.9 | 0.526 |
| before 2 | 53.2 | 25.8 | 0.485 |
| before 3 | 49.9 | 24.5 | 0.491 |
| after 1 | 51.2 | 23.7 | 0.463 |
| after 2 | 68.2 | 31.6 | 0.463 |

The arm rows — the verdict on the shipping functions, not on the replicas:

| run | arm-order guard | slim ns/el | reagent ns/el | slim/reagent |
|---|---|---|---|---|
| before 1 | clean (exit 0) | 946 | 811 | **1.1667** |
| before 2 | REFUSED (exit 2) | 634 | 530 | (1.1961) |
| before 3 | REFUSED (exit 2) | 692 | 582 | (1.1875) |
| after 1 | clean (exit 0) | 426 | 437 | **0.9762** |
| after 2 | clean (exit 0) | 572 | 593 | **0.9649** |

Both "after" runs are guard-clean and reportable. Two of the three "before" runs were refused, so their ratios are parenthesised and are **not** published as measured. That refusal was a lane-wide phase drift — FIRST-THIRD reading ~1.2x LAST-THIRD on *all four* arms, ranges disjoint — i.e. a loaded box still warming through the run, not an arm-specific artefact. The guard's tolerance was not touched and `run.cjs` was not edited.

**Canonical DOM is byte-identical: 1,202 elements / 58,529 bytes in all five runs**, before and after — the figure the predecessor bead recorded, and the same figure stock Reagent's arm produces, diverging from Hicasso's at the same index with the same context on every run.

Agreement failures were `[]` in all five runs: every candidate answers what its shipping twin answers, over the page's own literals *and* over 22 hostile heads it does not carry — checked before any figure is read, per the instrument's own convention.

## Costed and DECLINED

- **`keyword-identical?` for the head.** The bead's own suggested answer, and a real win (~0.21x of the ladder) — but it lost to `case` on all five runs, on the clock and on the reading. Kept in the instrument as a costed alternative; not shipped.
- **Static reducers for the per-element prop closure** — rf2-lhdp0 declined this for having no reliable sign, and two more runs here re-confirm it: 145.2 static vs 151.8 closure on after-1, 223.4 vs 213.8 on after-2. Opposite signs. Left alone.
- **No further micro-optimisation.** With the arm at 0.97x there is no residual gap left to chase, and every remaining `-ship`/`-cheap` pair in the decomposition is already on its cheap side. Cutting further would spend clarity for nothing.

## Mutation proof

Two mutations applied together — `props-slot?` narrowed to `(map? head)` (dropping the nil arm), and the `case` swapped for `condp identical?`:

```
Ran 12451 tests containing 62355 assertions.
25 failures, 6 errors.        exit 1

FAIL in (as-element-interop-heads-are-keyword-sentinels-rf2-e7zxb)  :515 :517 :520 :522
FAIL in (props-slot-rule-rf2-e7zxb)                                 :539 :551
```

Both new tests are named, at the assertions they exist for (the four reconstructed sentinels; the nil props slot). Reverted with `git checkout HEAD --`, byte-identical, `git status` clean.

The `condp identical?` arm is itself instructive: it broke the *literal* sentinels too, because keyword literals are not interned into one shared constants table under this build. That is the pin behind `as-element-interop-heads-are-keyword-sentinels-rf2-e7zxb` — the `case` is an fqn switch, not an identity trick, so a reconstructed `(keyword ">")` must dispatch as the literal does while the string `">"` and the symbol `'>` stay DOM-tag heads.

## Quality gates

All foreground to completion, none piped (exit codes read from `$?` directly, never through a pipeline), logs to gitignored `*.log` paths outside the repo.

| gate | exit | result |
|---|---:|---|
| `sh scripts/test-fast-pr.sh --all` | **0** | `PASS fast PR spine`; classified `docs=true jvm=true node=true (override (--all))` so no tier could under-run |
| ↳ its CLJS node integration leg | **0** | 12,451 tests / 62,355 assertions / 0 failures / 0 errors |
| ↳ its JVM leg (incl. `implementation/adapters/reagent-slim`) | **0** | 2,210 / 11,510 and 1,288 / 8,857 assertions, 0 failures |
| `cd implementation && npm run test:cljs` (standalone) | **0** | 12,451 tests / 62,355 assertions / 0 failures / 0 errors |
| `cd implementation && npm run test:reagent-slim:smoke` | **0** | testbed browser smoke — `Ran 1 reagent-slim client-runtime smoke. 0 failures.` |
| `cd implementation && npm run test:reagent-slim:bundle-isolation` | **0** | `PASS reagent-slim-bundle-isolation: 6 contracts passed; 25 sentinel checks` |
| mutation run (see above) | **1** | 25 failures / 6 errors, both new tests named; reverted byte-identically |

reagent-slim is a shipped, first-class adapter, so its consumers were gated too, not just the file that changed: the SSR walker (`reagent2.dom.server`, which is the other `props-slot?` caller and is covered by the CLJS leg), the testbed client-runtime smoke, and the `examples/counter-slim-and-fast` bundle-isolation contract.

**A first spine run was discarded, not hidden.** It misclassified its tiers (`jvm=false node=false`) and reported harness failures that could not be reproduced standalone; the cause was that this box's agent scratchpad is shared between concurrent workers, and a sibling was writing the same log filename — the log had a NUL gap and two contradictory summaries in it. The run above was re-taken to a uniquely named path with `--all`, and its classifier line was verified by hand (`report-changed-surfaces.sh` on the changed paths prints `implementation_jvm=true cljs_node_test=true`, exit 0).

## Fences

`implementation/adapters/reagent-slim/**` plus `walk_vs_reagent_app.cljs` — exactly the bead's fence. No adapter other than reagent-slim is touched; `implementation/deps.edn` and `implementation/shadow-cljs.edn` are untouched (the bench rides `run.cjs`'s env vars, which exist so an arm needs no build id). Every behaviour is witnessed, no diagnostics were removed, and the reserved-head guard, the keyword-prop warn-once and the source-coord stamp all stay off the hit path.
