### PR TITLE
fix(bench): the band bootstrap must preserve run clustering (rf2-nk1hq)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/ladder_band.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ladder_band.cjs
@@ -6,6 +6,7 @@
 //   node .../ladder_band.cjs --emit data.json out/.../*.json   ... and write the
 //                                                              compact dataset
 //   node .../ladder_band.cjs --from data.json                recompute FROM it
+//   node .../ladder_band.cjs --selftest                      the resampling model
 //
 // ## Why this file exists
 //
@@ -39,6 +40,17 @@
 // What it does NOT carry is the per-sample distribution inside a block. A
 // question about within-block shape needs the raw datasets, which are kept
 // beside the run and named in the page's provenance.
+//
+// ## What durability caught (rf2-nk1hq)
+//
+// Because the dataset survived, the ceiling's derivation could be checked
+// after the fact — and it did not hold. This file's bootstrap pooled all 342
+// blocks and built each synthetic run by drawing eighteen of them across
+// unrelated runs and load rungs, which is not a future run, and a comment here
+// argued that pooling was the CONSERVATIVE choice. It is the narrower one. The
+// bootstrap below is now run-preserving, both models are printed side by side
+// so the retraction can be checked, and `--selftest` fails if the pooled model
+// is ever reinstated. No new measurement was taken to find any of it.
 
 const fs = require('node:fs');
 const path = require('node:path');
@@ -218,12 +230,63 @@ function inflate(cr) {
 // ---------------------------------------------------------------------------
 //
 // The band is a p10–p90 half-width over EIGHTEEN blocks, and eighteen is not
-// many. Whether a 25% ceiling is a tripwire or a coin toss is a question about
-// that statistic's own tail, and nineteen calibration runs cannot answer it —
+// many. Whether a ceiling is a tripwire or a coin toss is a question about that
+// statistic's own tail, and nineteen calibration runs cannot answer it —
 // nineteen draws bound a 1-in-20 event at exactly one observation. Resampling
-// the blocks does: draw eighteen blocks with replacement from the pooled set,
-// recompute the band, and read off how often it clears the ceiling.
-function bootstrapBand(ratios, draws, seed) {
+// does.
+//
+// WHAT A DRAW HAS TO BE. A draw stands for a FUTURE RUN, and the eighteen
+// blocks of a real run are not eighteen independent draws from the ladder:
+// they are taken back-to-back, on one box, at one load rung, inside one
+// window, so they share a regime and they CLUSTER. Two models follow, and only
+// the second is a model of a run:
+//
+//   POOLED-BLOCK     draw eighteen blocks from the ladder's 342, ignoring
+//                    which run each came from. Every synthetic run is a
+//                    mixture of unrelated boxes and unrelated rungs.
+//   RUN-PRESERVING   draw one of the nineteen runs, then resample THAT run's
+//                    own eighteen blocks. The regime survives the draw.
+//
+// POOLING IS NARROWER, WHICH IS THE OPPOSITE OF WHAT THIS FILE FIRST ARGUED.
+// It said the pooled model "carries between-run variation and is the wider, so
+// it is what a ceiling should be set against". That is refuted by its own
+// arithmetic: mixing regimes averages the between-run spread INTO each
+// synthetic run instead of leaving it BETWEEN them, and averaging is what
+// narrows a tail. On this ladder's raw `TaskDuration`, pooled against
+// run-preserving — q50 13.0/11.5%, q90 19.9/23.4%, q95 22.7/31.0%, q99
+// 29.4/**41.4**% — pooling is narrower at every quantile above the median.
+// The correct figure was printed all along, in the column this file's own
+// comment then told the reader to disregard.
+//
+// Both are computed and both are printed. The run-preserving one is
+// OPERATIVE; the pooled one is kept because `BAND_CEILING`'s withdrawn "q99"
+// derivation was read off it, and a reader checking that retraction needs the
+// number being retracted. See `rf2-nk1hq` and section 5 of
+// `docs/design/hicasso/studio/the-band-re-calibrated.md`.
+
+/**
+ * Draws per model. Fixed, and large enough that a q99 is stable in its third
+ * significant figure — the page quotes these to a tenth of a percent, and at
+ * 20,000 the fourth figure still moves with the seed.
+ */
+const BOOT_DRAWS = 200000;
+
+/** The band of one synthetic eighteen-block run — `seam.cjs`'s definition. */
+function bandOfBlocks(pick) {
+  const v = [...pick].sort((a, b) => a - b);
+  const q = (p) => v[Math.min(v.length - 1, Math.max(0, Math.floor(p * v.length)))];
+  return (q(0.9) - q(0.1)) / (2 * p50(pick));
+}
+
+/**
+ * `draws` synthetic runs, each of eighteen blocks resampled from whatever
+ * `source(next)` hands back, sorted. Seeded, because a bootstrap that moves
+ * when it is recomputed on the same data cannot be checked by the reader.
+ *
+ * `source` is the ONLY difference between the two models, which is the whole
+ * lesson: the defect this function was fixed for was one line.
+ */
+function bootstrap(draws, seed, source) {
   let s = seed >>> 0 || 0x9e3779b9;
   const next = () => {
     s ^= s << 13; s >>>= 0;
@@ -233,16 +296,119 @@ function bootstrapBand(ratios, draws, seed) {
   };
   const out = [];
   for (let it = 0; it < draws; it++) {
+    const src = source(next);
     const pick = [];
-    for (let i = 0; i < 18; i++) pick.push(ratios[Math.floor(next() * ratios.length)]);
-    const v = [...pick].sort((a, b) => a - b);
-    const q = (p) => v[Math.min(v.length - 1, Math.max(0, Math.floor(p * v.length)))];
-    out.push((q(0.9) - q(0.1)) / (2 * p50(pick)));
+    for (let i = 0; i < 18; i++) pick.push(src[Math.floor(next() * src.length)]);
+    out.push(bandOfBlocks(pick));
   }
   out.sort((a, b) => a - b);
   return out;
 }
+
+/**
+ * RUN-PRESERVING — the operative model. `perRun[i]` is one run's block ratios.
+ */
+const bootstrapBand = (perRun, draws, seed) =>
+  bootstrap(draws, seed, (next) => perRun[Math.floor(next() * perRun.length)]);
+
+/**
+ * POOLED-BLOCK — the withdrawn model, printed beside the operative one so the
+ * retraction can be checked rather than taken on trust. Its `source` ignores
+ * `next`, so it consumes the same PRNG stream this file always did and still
+ * reproduces the pooled figures as first published.
+ */
+const bootstrapBandPooled = (perRun, draws, seed) => {
+  const pooled = perRun.flat();
+  return bootstrap(draws, seed, () => pooled);
+};
+
 const quant = (sorted, p) => sorted[Math.min(sorted.length - 1, Math.max(0, Math.floor(p * sorted.length)))];
+const rateAbove = (sorted, c) => sorted.filter((b) => b > c).length / sorted.length;
+
+// ---------------------------------------------------------------------------
+// The self-test — a test of the RESAMPLING MODEL, and of nothing else
+// ---------------------------------------------------------------------------
+//
+// `node ladder_band.cjs --selftest`, the convention `seam.cjs` already uses.
+//
+// The pooled-block bootstrap shipped for two days and nobody caught it,
+// because the two models agree on the median and every check anyone would
+// think to write is a check on the median. So both fixtures below are built to
+// FAIL under pooled-block resampling and PASS under run-preserving, with
+// margins wide enough that no seed rescues the wrong model, and they cover the
+// two directions the error can take:
+//
+//   1. Runs that differ in CENTRE. Pooling reports a band no run has.
+//   2. Runs that differ in DISPERSION — the ladder's own shape, one jumpy run
+//      among steady ones. Pooling reports a tail no run has, and it is the
+//      NARROWER of the two, which is the specific claim §5 retracted.
+//
+// Fixture 1 alone would leave "pooled is at least conservative" standing;
+// fixture 2 is what refutes it.
+function selfTest() {
+  const checks = [];
+  const check = (name, ok, detail) => checks.push({ name, ok: !!ok, detail });
+  const block18 = (v) => Array.from({ length: 18 }, () => v);
+  const q99 = (perRun, boot) => quant(boot(perRun, 20000, 0x5eed5eed), 0.99);
+
+  {
+    // 1. TWO CLEARLY-DIFFERENT RUNS, each internally constant: every block of
+    //    run A reads 1.0 and every block of run B reads 2.0. Neither run has
+    //    any band at all — resample either one and you get 1.0s or 2.0s, so
+    //    p10 = p90 and the band is EXACTLY zero. Pooling draws from both and
+    //    reports a third of a band that belongs to neither, which is the
+    //    defect in one line: a synthetic mixed-regime block sample is not a
+    //    run.
+    const f = [block18(1), block18(2)];
+    const r = q99(f, bootstrapBand);
+    const p = q99(f, bootstrapBandPooled);
+    check(
+      'two runs with no band of their own resample to NO band, and pooling invents one',
+      r < 0.01 && p > 0.25,
+      `run-preserving q99 ${pc(r)}, pooled-block q99 ${pc(p)}`
+    );
+  }
+
+  {
+    // 2. NINETEEN RUNS, EIGHTEEN STEADY AND ONE JUMPY — the ladder's shape,
+    //    where the band is widest on the idle box. The jumpy run is 1 run in
+    //    19, so it is 5.3% of the DRAWS under run-preserving and the q99 sits
+    //    inside its tail; but its blocks are also only 5.3% of the pool, so
+    //    under pooling a draw of eighteen gets about one of them and a p10–p90
+    //    half-width trims it away. Pooling therefore reports a tail LOWER than
+    //    any real run's, which is exactly what it does on the real ladder
+    //    (29.4% against 41.4%) and exactly what the withdrawn comment claimed
+    //    could not happen.
+    const jumpy = Array.from({ length: 18 }, (_, i) => 0.55 + i * 0.05);
+    const f = [...Array.from({ length: 18 }, () => block18(1)), jumpy];
+    const r = q99(f, bootstrapBand);
+    const p = q99(f, bootstrapBandPooled);
+    check(
+      'one jumpy run among eighteen steady ones is in the tail run-preserving, and POOLING NARROWS IT',
+      r > 0.35 && p < 0.25 && r > 2 * p,
+      `run-preserving q99 ${pc(r)}, pooled-block q99 ${pc(p)}`
+    );
+  }
+
+  {
+    // 3. And the models must not be told apart by the seed. Both fixtures are
+    //    re-read on four unrelated seeds; a check that passes only on
+    //    0x5eed5eed is a coincidence, not a regression.
+    const jumpy = Array.from({ length: 18 }, (_, i) => 0.55 + i * 0.05);
+    const f = [...Array.from({ length: 18 }, () => block18(1)), jumpy];
+    const spread = [1, 12345, 0x5eed5eed, 0xdeadbeef].map((s) => ({
+      r: quant(bootstrapBand(f, 20000, s), 0.99),
+      p: quant(bootstrapBandPooled(f, 20000, s), 0.99),
+    }));
+    check(
+      'the two models are separated on EVERY seed, so the separation is the model and not the draw',
+      spread.every((x) => x.r > 0.35 && x.p < 0.25),
+      spread.map((x) => `${pc(x.r)}/${pc(x.p)}`).join('  ')
+    );
+  }
+
+  return { ok: checks.every((c) => c.ok), checks };
+}
 
 // ---------------------------------------------------------------------------
 
@@ -254,7 +420,16 @@ function main() {
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--emit') emit = argv[++i];
     else if (argv[i] === '--from') from = argv[++i];
-    else files.push(argv[i]);
+    else if (argv[i] === '--selftest') {
+      const st = selfTest();
+      for (const c of st.checks) console.log(`${c.ok ? 'ok  ' : 'FAIL'}  ${c.name}${c.detail ? '  — ' + c.detail : ''}`);
+      if (!st.ok) {
+        console.error('\nladder_band self-test FAILED');
+        process.exit(1);
+      }
+      console.log('\nladder_band self-test ok');
+      return;
+    } else files.push(argv[i]);
   }
 
   let runs;
@@ -333,7 +508,13 @@ function main() {
     console.log('');
     console.log('**Correlations across the ladder** — the multiplicativity evidence:');
     console.log('');
-    console.log(`- corr(ctl-2x/floor, floor) = **${corr(rs.map((r) => r.ctl2xMean), floors).toFixed(2)}** — an additive \`c\` reads \`(2W+c)/(W+c)\`, which FALLS as \`c\` grows, so a NEGATIVE sign is the additive signature`);
+    // NOT diagnostic, and the line that said it was has been removed. The old
+    // reading — "`(2W+c)/(W+c)` FALLS as `c` grows, so a NEGATIVE sign is the
+    // additive signature" — holds `W` fixed and varies `c`, which is not what
+    // this ladder does. Here `c` is roughly fixed and load varies `W`, and
+    // `(2W+c)/(W+c)` RISES with `W`. Section 6 of `the-band-re-calibrated.md`
+    // and `seam.cjs` withdrew the argument; this printer kept emitting it.
+    console.log(`- corr(ctl-2x/floor, floor) = **${corr(rs.map((r) => r.ctl2xMean), floors).toFixed(2)}** — NOT DIAGNOSTIC, and not evidence either way. Across this ladder \`c\` is roughly fixed and load varies \`W\`, so \`(2W+c)/(W+c)\` RISES with \`W\`; and the statistic is unstable enough to read +0.88 on one nineteen-run ensemble and -0.04 on another taken 25 minutes later on the same box. The rung table below is what carries the argument`);
     console.log(`- corr(bar, floor)          = ${corr(rs.map((r) => r.bar), floors).toFixed(2)}`);
     console.log(`- corr(bar, seam)           = ${corr(rs.map((r) => r.bar), rs.map((r) => r.seam)).toFixed(2)}`);
     console.log(`- corr(band, floor)         = ${corr(rs.map((r) => r.band), floors).toFixed(2)} — does the BAND track load?`);
@@ -357,48 +538,38 @@ function main() {
     }
     console.log('');
 
-    // The bootstrap.
-    const pooled = rs.flatMap((r) => r.ratios);
-    const bs = bootstrapBand(pooled, 20000, 0x5eed5eed);
-    // AND a within-run bootstrap: resample each run's OWN eighteen blocks, so
-    // the question is "would this run breach again if re-taken under identical
-    // conditions" rather than "would a run drawn from the whole ladder". The
-    // pooled one carries between-run variation and is the wider — a future run
-    // is a future run, not a repeat of a past one, so the pooled one is what a
-    // ceiling should be set against and the within-run one is the floor of the
-    // estimate.
-    const withinRun = mean(
-      rs.map((r) => {
-        const b = bootstrapBand(r.ratios, 2000, 0x5eed5eed);
-        return b.filter((x) => x > seamlib.BAND_CEILING).length / b.length;
-      })
-    );
+    // The bootstrap. Both models, one sample each, reused for every candidate
+    // ceiling below — `P(fire)` at a threshold is a filter over the sample the
+    // quantiles are read from, so the two cannot disagree with each other.
+    const perRun = rs.map((r) => r.ratios);
+    const bsRun = bootstrapBand(perRun, BOOT_DRAWS, 0x5eed5eed);
+    const bsPooled = bootstrapBandPooled(perRun, BOOT_DRAWS, 0x5eed5eed);
     console.log(
-      `**The band's own run-level sampling distribution**, 20,000 resamples of 18 blocks from this ` +
-        `ladder's ${pooled.length} pooled blocks: median ${pc(quant(bs, 0.5))}, q90 ${pc(quant(bs, 0.9))}, ` +
-        `q95 ${pc(quant(bs, 0.95))}, q99 ${pc(quant(bs, 0.99))}.`
+      `**The band's own run-level sampling distribution**, ${BOOT_DRAWS.toLocaleString('en-US')} draws of 18 ` +
+        `blocks from this ladder's ${rs.length} runs. RUN-PRESERVING (operative — draw a run, resample ITS ` +
+        `blocks): median ${pc(quant(bsRun, 0.5))}, q90 ${pc(quant(bsRun, 0.9))}, q95 ${pc(quant(bsRun, 0.95))}, ` +
+        `q99 **${pc(quant(bsRun, 0.99))}**. POOLED-BLOCK (withdrawn — draw 18 of the ${perRun.flat().length} ` +
+        `blocks regardless of run): ${pc(quant(bsPooled, 0.5))} / ${pc(quant(bsPooled, 0.9))} / ` +
+        `${pc(quant(bsPooled, 0.95))} / ${pc(quant(bsPooled, 0.99))} — NARROWER through the whole upper tail, ` +
+        `which is why the ceiling's "q99" derivation was withdrawn.`
     );
     console.log('');
-    console.log(`| candidate ceiling | P(fire) pooled | P(fire) within-run | runs of these 19 that breach |`);
+    console.log(`| candidate ceiling | P(fire) pooled-block (withdrawn) | **P(fire) run-preserving** | runs of these 19 that breach |`);
     console.log('|---:|---:|---:|---:|');
     for (const c of [0.2, 0.25, 0.3, 0.35, 0.4]) {
-      const pooledP = bs.filter((b) => b > c).length / bs.length;
-      const wr = mean(
-        rs.map((r) => {
-          const b = bootstrapBand(r.ratios, 2000, 0x5eed5eed);
-          return b.filter((x) => x > c).length / b.length;
-        })
-      );
       console.log(
-        `| ${pc(c)} | ${(pooledP * 100).toFixed(1)}% | ${(wr * 100).toFixed(1)}% | ` +
+        `| ${pc(c)} | ${(rateAbove(bsPooled, c) * 100).toFixed(2)}% | **${(rateAbove(bsRun, c) * 100).toFixed(1)}%** | ` +
           `${rs.filter((r) => r.band > c).length} of ${rs.length} |`
       );
     }
     console.log('');
     console.log(
-      `At the ceiling in force (${pc(seamlib.BAND_CEILING)}) the within-run estimate is ` +
-        `${(withinRun * 100).toFixed(1)}% and ${rs.filter((r) => r.band > seamlib.BAND_CEILING).length} of ` +
-        `${rs.length} of this ladder's runs breach.`
+      `At the ceiling in force (${pc(seamlib.BAND_CEILING)}) a run false-fires at ` +
+        `**${(rateAbove(bsRun, seamlib.BAND_CEILING) * 100).toFixed(1)}%** run-preserving ` +
+        `(${(rateAbove(bsPooled, seamlib.BAND_CEILING) * 100).toFixed(2)}% under the withdrawn pooled model), and ` +
+        `${rs.filter((r) => r.band > seamlib.BAND_CEILING).length} of ${rs.length} of this ladder's runs breach. ` +
+        `${pc(seamlib.BAND_CEILING)} is the q99 of NEITHER model; it is a judgement, and the comparison it was ` +
+        `made for survives — 25% false-fires at ${(rateAbove(bsRun, 0.25) * 100).toFixed(1)}%.`
     );
     console.log('');
   }

--- a/implementation/freehand/test/re_frame/bench/hicasso/ladder_band.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ladder_band.cjs
@@ -438,7 +438,9 @@ function main() {
     runs = j.runs.map(inflate);
   } else {
     if (files.length === 0) {
-      console.error('usage: ladder_band.cjs [--emit out.json] <dataset.json ...>   |   --from compact.json');
+      console.error(
+        'usage: ladder_band.cjs [--emit out.json] <dataset.json ...>   |   --from compact.json   |   --selftest'
+      );
       process.exit(2);
     }
     runs = files.map(readRun);

--- a/implementation/freehand/test/re_frame/bench/hicasso/seam.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/seam.cjs
@@ -119,21 +119,19 @@
 //     only when the floor is inside the calibrated range" would refuse the
 //     most reproducible runs this instrument can take.
 //   * A RUN whose band exceeds [[BAND_CEILING]] has no reportable magnitude
-//     at all, whatever its margin. The ceiling is **35%**, and unlike its
-//     predecessor it is set from the statistic's own SAMPLING DISTRIBUTION
-//     rather than from the largest of nineteen draws: bootstrapping eighteen
-//     blocks from the ladder's 342 puts the run-level q99 at 29.1% and
-//     `P(band > 35%)` at **0.2%** per run. The 25% it replaces sits inside
-//     the bulk of that distribution — `P(band > 25%)` = **2.6%** pooled and
-//     **9.0%** resampling each run's own blocks, and **2 of the nineteen**
-//     re-take runs breach it, both at ZERO load.
+//     at all, whatever its margin. The ceiling is **35%**, and it is a
+//     JUDGEMENT rather than a quantile — see [[BAND_CEILING]], which carries
+//     the arithmetic. Its measured per-run false-fire rate is **2.7%**
+//     against the 25% predecessor's **9.1%**, and **2 of the nineteen**
+//     re-take runs breach 25% where **0 of 19** breach 35%, both breaches at
+//     ZERO load.
 //
-//     THAT IS WHY IT FIRED THREE TIMES IN TWO DAYS after being calibrated
+//     THAT IS WHY 25% FIRED THREE TIMES IN TWO DAYS after being calibrated
 //     never to fire — 26.2% on an earlier `bulk300` ensemble (rf2-yd52q),
 //     then 26.2% on `bulk300` and 28.4% on `narrow` in one run of
 //     rf2-emvod's. Not a regime departure and not, mainly, the clock: a
 //     threshold that was above nineteen draws of a tail was never above the
-//     tail, and roughly one run in eleven to one in forty crosses it.
+//     tail, and roughly one run in eleven crosses it.
 //   * THE GATE ADJUDICATES THE CLOCK THE ROWS ARE STATED ON. `clock_run.cjs`
 //     refuses a run whose band on raw `TaskDuration` breaches; the frame-only
 //     band is computed, printed and stored on every run and is never the
@@ -151,10 +149,35 @@ const SEGMENT_PERMUTATIONS = [
 /**
  * A run whose band exceeds this has no reportable magnitude. See the header.
  *
- * 35%, calibrated by `rf2-ymi6j` from the band's own bootstrap sampling
- * distribution on raw `TaskDuration` — `P(fire) = 0.2%` per run — and not from
- * the largest of nineteen observed draws, which is how its 25% predecessor came
- * to fire three times in two days after being calibrated never to.
+ * **35%, AND IT IS NOT A QUANTILE OF ANYTHING.** `rf2-ymi6j` published it as
+ * "the statistic's own bootstrap q99, at a measured `P(fire)` of 0.2%" and
+ * `rf2-nk1hq` withdrew that derivation: the bootstrap it was read off pooled
+ * all 342 of the ladder's blocks and drew each synthetic run's eighteen from
+ * across unrelated runs and load rungs, which estimates a mixed-regime block
+ * sample rather than a future run. Resampling run-preservingly — draw one of
+ * the nineteen runs, then resample THAT run's own eighteen blocks — the band's
+ * run-level distribution on raw `TaskDuration` reads q90 23.4%, q95 31.0%,
+ * q99 **41.4%**, and 35% false-fires at **2.7%** per run, thirteen times the
+ * advertised 0.2%. (`ladder_band.cjs --from data/ladder-ymi6j.json` prints
+ * both models; its `--selftest` fails if the pooled one is reinstated.)
+ *
+ * IT STAYS AT 35% ANYWAY, deliberately, and as a judgement now stated as one:
+ *
+ *   * The comparison the change was made for survives untouched. 25%
+ *     false-fires at **9.1%** per run, so 35% is a 3.4x improvement — and it
+ *     is the ceiling in force, breached by 0 of the nineteen calibration runs
+ *     where 25% is breached by 2.
+ *   * Moving to 41% would RELAX the gate, which is the direction that needs
+ *     the stronger evidence, on the strength of the noisiest number in the
+ *     table: a 1% quantile whose whole tail above 35% is carried by one or
+ *     two of nineteen run-regimes. It reads 41.4% at 200,000 draws and 42.4%
+ *     at 20,000.
+ *   * Nothing published moves at either value. No magnitude on any page is
+ *     adjudicated differently at 35% than at 41%.
+ *
+ * So the honest statement is that a 2.7% per-run false-fire rate is the price
+ * of this threshold, not that the threshold is a q99. A ceiling set at a
+ * genuine q99 would be ~41%; that is an operator's call, not this constant's.
  */
 const BAND_CEILING = 0.35;
 


### PR DESCRIPTION
Closes `rf2-nk1hq`. The CODE half of the band-calibration correction; the docs half landed as #7424 (`rf2-ymi6j`).

**No new measurement was taken.** Everything here is arithmetic over the committed compact dataset at `implementation/freehand/test/re_frame/bench/hicasso/data/ladder-ymi6j.json`. No bench driver was run and no run was published.

## The defect

`ladder_band.cjs`'s `bootstrapBand()` pooled all 342 block ratios from the ladder's nineteen runs and built each synthetic eighteen-block run by drawing individual blocks **across unrelated runs and load rungs**. The eighteen blocks of a real run are taken back-to-back on one box at one rung inside one window, so they share a regime and they cluster. Pooling shuffles that away, and what it estimates is a synthetic mixed-regime block sample rather than a future run.

The bootstrap is now **run-preserving**: draw one of the nineteen runs, then resample *that run's own* eighteen blocks.

## Reproduced from the committed dataset, 200,000 draws, raw `TaskDuration`

| quantile | pooled-block | run-preserving |
|---|---:|---:|
| q50 | 13.0% | 11.5% |
| q90 | 19.9% | 23.4% |
| q95 | 22.7% | 31.0% |
| q99 | 29.4% | **41.4%** |

| ceiling | P(fire) pooled | P(fire) run-preserving | observed of 19 |
|---|---:|---:|---:|
| 20% | 9.82% | 15.0% | 4 |
| 25% | 2.71% | 9.1% | 2 |
| 30% | 0.89% | 5.9% | 1 |
| 35% | 0.21% | 2.7% | 0 |
| 40% | 0.06% | 1.2% | 0 |

Matches `rf2-nk1hq`'s independent 200,000-draw recomputation digit for digit, and matches §5 of `the-band-re-calibrated.md`. **Pooling is narrower through the whole upper tail**, so the source comment arguing that pooling "carries between-run variation and is the wider, so it is what a ceiling should be set against" was refuted by its own arithmetic. That comment is gone.

Both models are still computed and printed side by side — the withdrawn "q99" derivation was read off the pooled column, and a reader checking the retraction needs the number being retracted. The printer now reproduces **every** bootstrap figure the docs half publishes, including the frame-only clock's 12.5 / 26.2 / 33.1 / **45.9%** and §0.1's P3 row (11.3% run-preserving, 4.7% pooled).

## The stale `corr` sign line

Removed. Section 6 of `the-band-re-calibrated.md` and `seam.cjs` withdrew the argument that "an additive `c` reads `(2W+c)/(W+c)`, which FALLS as `c` grows, so a NEGATIVE sign is the additive signature"; the printer kept emitting it. That reading holds `W` fixed and varies `c`, which is not what this ladder does — here `c` is roughly fixed and load varies `W`, so `(2W+c)/(W+c)` RISES with `W` and the sign carries no information.

## `BAND_CEILING`: it stays at 35%

Not moved — this restates the justification rather than minting a replacement ceiling.

- The comparison the change was made for survives untouched: 25% false-fires at **9.1%** per run against 35%'s **2.7%**, a 3.4x improvement. 0 of 19 calibration runs breach 35%; 2 breach 25%.
- Moving to the genuine q99 (~41%) would **relax** the gate — the direction that needs the stronger evidence — on the strength of the noisiest number in the table: a 1% quantile whose entire tail above 35% is carried by one or two of nineteen run-regimes. It reads 41.4% at 200,000 draws and 42.4% at 20,000.
- No published magnitude is adjudicated differently at 35% than at 41%.

`seam.cjs`'s header no longer claims `P(band > 35%) = 0.2%`; it now states 2.7% and says plainly that 35% is the q99 of neither model and is a judgement. **`seam.cjs` is comment-only here: 0 non-comment changed lines.**

If the ceiling itself should move, that is an operator ruling and is deliberately left open rather than taken here.

## The regression, mutation-proved in both directions

New `node ladder_band.cjs --selftest`, following `seam.cjs`'s existing convention — no new file, and no `package.json` or `test-fast-pr.sh` edit, both of which are owned by #7423. Two synthetic fixtures, covering the two directions the error takes:

1. **Runs differing in CENTRE** — two runs, every block of one reading 1.0 and of the other 2.0. Neither has any band of its own; run-preserving q99 is exactly 0.0%, pooled invents 50.0%.
2. **Runs differing in DISPERSION** — the ladder's own shape, one jumpy run among eighteen steady ones. Run-preserving q99 41.2%, pooled 17.5%. This is the fixture that refutes "pooling is at least conservative"; fixture 1 alone would leave that standing.
3. Both re-checked on four unrelated seeds, so the separation is the model and not the draw.

**MUTATION PROOF.** Reinstating the defect in the operative function (`(next) => perRun[...]` becomes `() => perRun.flat()`, one line):

| direction | `--selftest` exit | result |
|---|---:|---|
| **mutated** to pooled-block resampling | **1** | all three checks FAIL — fixture 1 reads 50.0%/50.0%, fixture 2 reads 17.5%/17.5%, seed sweep collapses |
| **reverted byte-identically** | **0** | all three PASS — blob back to `72417c781de6b6e60bebc646f33eefb4dd001492`, `git status` clean |

## Quality gates

All foreground to completion, none piped, each artefact under a gitignored path (`*.log`).

Taken on the **rebased** tree (`origin/main` tip, this branch's base):

| gate | exit | result |
|---|---:|---|
| `node ladder_band.cjs --selftest` | **0** | 3/3 checks pass |
| `node seam.cjs` (self-test) | **0** | all checks pass |
| `node clock_run.cjs --selftest` | **0** | `ALL ADJUDICATORS OK` |
| `node ladder_band.cjs --from data/ladder-ymi6j.json` | **0** | reproduces the page; byte-identical across repeat runs |
| `cd implementation && npm run test:hicasso-compile` | **0** | 101 lane namespaces, 393 files, **0 warnings** (the lane gate #7423 added) |

`sh scripts/test-fast-pr.sh` was taken on `10c073f5e8`, the base immediately before this branch was rebased onto the seven commits that landed under it:

| gate | exit | result |
|---|---:|---|
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` — JVM `implementation/core` 2,210 tests / 11,510 assertions, JVM `implementation/freehand` 1,288 / 8,857, CLJS node 12,471 / 62,501, all **0 failures, 0 errors**; 17/17 per-ns isolation ok |

**On that exit code specifically.** The first invocation was SIGTERM'd at the tool's 10-minute cap while the underlying shell kept running, and the `.exit` file it left behind read `0` before the runner had reached any terminal line — a phantom. That file was discarded. The run above is the surviving shell followed to completion, and the exit is asserted from the runner's **own** terminal marker `PASS fast PR spine` present in the log (the script is `set -euo pipefail` and that `printf` is its last statement), not from a wrapper's status. No second spine was launched — surviving processes were checked by ancestry first.

The spine is quoted against the earlier base because `main` moved seven commits mid-run. **None of them touches either file in this diff** (verified with `git log HEAD..origin/main -- ladder_band.cjs seam.cjs`, empty), the rebase was conflict-free, and every gate that actually covers this diff's surface — the four lane self-tests and the lane compile gate — was re-taken on the rebased tree afterwards rather than carried forward.

**Gated surface, honestly.** This diff is two `.cjs` analysis/driver files in the hicasso bench lane. Nothing in `implementation/` or `tools/` requires them, no CI job runs `ladder_band.cjs`, and the only references anywhere are two docs pages. So the real proof here is `--selftest` plus the recomputation against the committed dataset, and the spine is breadth rather than depth.

## Follow-up filed

`rf2-7cmco` (P2, docs-only) — `the-band-re-calibrated.md` carries three forward-references to `rf2-nk1hq` as *open* work: §10's "the one figure on this page the script does not yet reproduce", §5's "together with the analysis script that still resamples the wrong way", and "whether 35% should move to a genuine q99 is `rf2-nk1hq`". All three are answered by this PR and read stale once it lands. Not fixed here: #7424 owns those pages and this branch is fenced off `docs/design/hicasso/**`. Sequence it after this merges.
