### PR TITLE
fix(hicasso): route-link's navigate grammar is closed, and prefetch is refused (rf2-2rtt6.54)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1004,7 +1004,11 @@ reserved head:
 
 The grammar is **closed, and this is all of it**: `[::h/navigate MAP]` — exactly
 two forms, the map carrying `:frame` (keyword), `:payload` (non-empty vector),
-`:native?` (boolean) and `:veto`. Everything else is
+`:native?` (boolean) and `:veto` — **those four keys and no others**, asserted as
+the exact key SET rather than as four presence tests, because a check that
+validates only the keys it knows admits both a map missing `:veto` (an
+uncancelable navigation where a cancelable one was promised) and a map carrying a
+fifth key the lowering then silently drops. Everything else is
 `:rf.error/hicasso-malformed-navigate`, naming the position; decorators do not
 nest in either order. Classified and lowered once per render, beside the prevent
 head, in `front/intent.cljs`.
@@ -1058,7 +1062,13 @@ click interceptor for routing — ambient behaviour no vector carries is what th
 in-band school exists to avoid.**)** **Also declined for v0:** the
 `:prefetch :intent` trio routing publishes and Freehand consumes — the census
 counts no prefetch site, and the opt-in is sugar over an event a Hicasso author
-can already spell at an ordinary intent position.
+can already spell at an ordinary intent position. **Declined means REFUSED, not
+ignored**: any present `:prefetch` fails at render with
+`:rf.error/hicasso-route-link-prefetch-declined`, `:intent` included. Routing's
+`link-model` validates and ACCEPTS `:intent` while Hicasso installs none of the
+three handlers behind the opt-in, so a key that merely fell through would leave a
+link that prefetches nothing, says so nowhere, and carries a stray `prefetch`
+attribute on the anchor.
 
 **Rejected.** (b) A boundary (`defview`) route-link — costs two hooks per link
 and pollutes every boundary count for a form that appears 106 times per census

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -203,8 +203,10 @@
                                     :veto     nil}]}]
 
   Same school as the prevent head (HD-026): behaviour in the vector where
-  `=` can see it, a closed grammar ([[unwrap-navigate]] is the whole of
-  it), classified once at lowering, loud on every malformed form. The
+  `=` can see it, a closed grammar — [[unwrap-navigate]] is the whole of
+  it, and it asserts the map's EXACT key set ([[navigate-keys]]) rather
+  than the presence of the keys it happens to know — classified once at
+  lowering, loud on every malformed form. The
   click LAW is not restated here: the lowered closure hands the event to
   routing's own `:routing/activate-link!` late-bound seam — the same one
   decision `rf/route-link`, `ui/route-link` and Freehand's `v/route-link`
@@ -618,18 +620,37 @@
            :veto-with-prevent-a-callback-or-nothing
            {:position k :veto veto})))
 
+(def ^:private navigate-keys
+  "The navigate map's key set, and it is CLOSED: `:frame`, `:payload`,
+  `:native?`, `:veto` — those four, no fewer and no more (HD-027).
+
+  Held as a SET the map's own keys must EQUAL, rather than as four
+  presence tests, because a grammar that checks only the keys it knows is
+  fail-open by construction. Under presence tests a map missing `:veto`
+  passes — and `:veto` is the slot that decides whether the click can be
+  cancelled, so its absence is the difference between an uncancelable
+  navigation and a promised one. So does a map carrying a fifth key,
+  which the lowering then silently drops: the author wrote something and
+  nothing happened, which is the failure class every loud error in this
+  namespace exists to delete."
+  #{:frame :payload :native? :veto})
+
 (defn- unwrap-navigate
   "CLASSIFY AND UNWRAP the navigate decorator. `[::h/navigate {…}]` —
-  exactly two forms, the second a map carrying `:frame` (a keyword),
-  `:payload` (a non-empty vector), `:native?` (a boolean) and `:veto`
-  (the [[lower-veto]] roster). Everything else is
+  exactly two forms, the second a map whose keys are EXACTLY
+  [[navigate-keys]]: `:frame` (a keyword), `:payload` (a non-empty
+  vector), `:native?` (a boolean), and `:veto` (the [[lower-veto]]
+  roster, `nil` included — which is why its presence is asked of the key
+  set and never of its value). Everything else is
   `:rf.error/hicasso-malformed-navigate`, named at the position. Answers
   the validated map; like [[unwrap-prevent]] it is not a walker — the
   payload stays ordinary data all the way to routing."
   [k v]
-  (let [{:keys [frame payload native?] :as m} (nth v 1 nil)]
+  (let [m  (nth v 1 nil)
+        {:keys [frame payload native?]} m
+        ks (when (map? m) (set (keys m)))]
     (when-not (and (= 2 (count v))
-                   (map? m)
+                   (= navigate-keys ks)
                    (keyword? frame)
                    (vector? payload)
                    (seq payload)
@@ -638,14 +659,22 @@
              'front.intent/lower-prop
              (str "The " (pr-str navigate-head) " decorator at " (pr-str k)
                   " wraps EXACTLY ONE map carrying :frame (a keyword), :payload "
-                  "(a non-empty event vector), :native? (a boolean) and :veto; this one "
+                  "(a non-empty event vector), :native? (a boolean) and :veto — "
+                  "those four keys and no others; this one "
                   (cond
                     (not= 2 (count v))  (str "carries " (dec (count v)) " forms after the head")
                     (not (map? m))      (str "wraps " (pr-str m) ", which is not a map")
+                    (not= navigate-keys ks)
+                    (str "carries " (pr-str (vec (sort ks)))
+                         (when-some [missing (seq (sort (remove ks navigate-keys)))]
+                           (str ", so it is missing " (pr-str (vec missing))))
+                         (when-some [extra (seq (sort (remove navigate-keys ks)))]
+                           (str ", and nothing reads " (pr-str (vec extra)))))
                     (not (keyword? frame))  "names no :frame keyword"
                     (not (and (vector? payload) (seq payload))) "carries no :payload event vector"
                     :else               "answers no boolean at :native?")
-                  ". route-link mints this form; hand-written ones must carry all four slots.")
+                  ". route-link mints this form; hand-written ones must carry all "
+                  "four slots and nothing else.")
              :carry-frame-payload-native-and-veto
              {:position k :form v}))
     m))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/route_link.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/route_link.cljs
@@ -56,7 +56,12 @@
     it and Freehand consumes it; the census counts no prefetch site, and
     the opt-in is sugar over an event a Hicasso author can already spell
     (`:on-mouse-enter [:rf.route/prefetch {…}]`). A tier-1 roster takes
-    the tier-1 surface.
+    the tier-1 surface. **Declined means REFUSED, not ignored** — see
+    [[prefetch-declined!]]. Routing's link model validates and ACCEPTS
+    `:intent`, so a declined key that merely fell through would leave a
+    link that prefetches nothing (Hicasso installs none of the three
+    handlers behind the opt-in) and says so nowhere, plus a stray
+    `prefetch` attribute on the anchor.
 
   ## Composition with `::h/prevent`
 
@@ -92,8 +97,52 @@
   passthrough HTML attribute and reaches the `<a>` untouched — `:class`,
   `:title`, `:data-testid`, `:aria-label`, and the native-handling
   `:target` / `:download` pair the link model reads for its `:native?`
-  verdict."
+  verdict.
+
+  `:prefetch` is the one key that is neither: v0 declines it, and a
+  declined key is REFUSED rather than dissoc'd
+  ([[prefetch-declined!]]) — a link carrying one never renders, so it can
+  reach no anchor and needs no row here. Were it listed instead, the
+  decline would be spelled as silent removal, which is the reading this
+  file exists to refuse."
   [:to :params :query :fragment :on-click])
+
+(defn prefetch-declined!
+  "Refuse, AT RENDER, any present `:prefetch`. The namespace docstring
+  declines routing's `:prefetch :intent` trio for v0, and a declined key
+  has to FAIL rather than cross: routing's `link-model` validates and
+  ACCEPTS `:intent` (its own spelling), while Hicasso installs none of
+  the three handlers the opt-in needs. So the only thing a passthrough
+  could produce is a link that prefetches nothing and a stray attribute
+  on the anchor — a silent no-op, which is what every loud refusal in
+  this file exists to delete.
+
+  `contains?` rather than a truthiness test: `{:prefetch nil}` and
+  `{:prefetch false}` are just as much a site that believes it opted in
+  as `{:prefetch :intent}` is, and a decline that let the falsey ones
+  through would be the same fail-open shape one level down.
+
+  If HD-027 is deliberately reopened to admit prefetch, what replaces
+  this is routing's full three-handler behaviour
+  (`:routing/prefetch-on-intent!` at `:on-mouse-enter` / `:on-focus` /
+  `:on-touch-start`). A passthrough is not the middle ground between the
+  two."
+  [{:keys [to] :as props}]
+  (when (contains? props :prefetch)
+    (fail! :rf.error/hicasso-route-link-prefetch-declined
+           'front.route-link/route-link
+           (str "route-link {:to " (pr-str to) "} carries :prefetch "
+                (pr-str (:prefetch props)) ", and v0 declines the prefetch trio "
+                "outright — :intent included, even though routing's own link "
+                "model accepts it. Hicasso installs none of routing's prefetch "
+                "handlers, so the key could only prefetch nothing and leave a "
+                "stray attribute on the anchor. Spell the warm-up at an "
+                "ordinary intent position instead — :on-mouse-enter "
+                "[:rf.route/prefetch {…}] — which needs nothing this link does "
+                "not already give you.")
+           :spell-prefetch-as-an-on-mouse-enter-intent
+           {:to to :prefetch (:prefetch props)}))
+  props)
 
 (defn on-click-roster!
   "Refuse, AT RENDER, an `:on-click` outside the route-click roster: nil,
@@ -141,10 +190,16 @@
 
   Fails loud at render when routing is absent
   (`:rf.error/routing-artefact-missing`, naming the `:to`), when rendered
-  outside a boundary, or when `:on-click` is outside the roster
-  ([[on-click-roster!]])."
+  outside a boundary, when `:on-click` is outside the roster
+  ([[on-click-roster!]]), or when the props carry the declined
+  `:prefetch` ([[prefetch-declined!]]).
+
+  Both props refusals run BEFORE the link model is consulted, so the
+  author's own mistake is what the stack names — not routing's reading of
+  a key Hicasso had already declined."
   [{:keys [to on-click] :as props} & children]
   (let [frame-kw (require-frame! to)
+        _        (prefetch-declined! props)
         _        (on-click-roster! on-click)
         {:keys [href payload native?]}
         ((late-bind/require-fn! :routing/link-model

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/route_link_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/route_link_cljs_test.cljs
@@ -85,6 +85,19 @@
       (is (false? native?))
       (is (nil? veto)))))
 
+(deftest no-control-key-reaches-the-anchor
+  (let [[_ attrs] (rendered {:to       :conduit.profile/show
+                             :params   {:username "jane"}
+                             :query    {:tab "posts"}
+                             :fragment "bio"
+                             :class    "author"}
+                            "jane")]
+    (is (= #{:href :on-click :class} (set (keys attrs)))
+        "the address keys are route-link's OWN: they are consumed by the link
+         model and never emitted. What reaches the anchor is the routing-owned
+         href, the click decision, and the author's passthrough attrs — nothing
+         else")))
+
 (deftest a-native-anchor-is-classified-at-render
   (let [[_ attrs] (rendered {:to :conduit.profile/show :params {:username "jane"}
                              :target "_blank"} "jane")]
@@ -126,19 +139,62 @@
         js/Error #"hicasso-route-link-outside-boundary"
         (link/route-link {:to :conduit.profile/show :params {:username "jane"}} "jane"))))
 
+(deftest a-prefetch-is-refused-at-render
+  (testing "v0 declines routing's prefetch trio, and a DECLINED key fails
+           rather than crossing — :intent included, which is the one routing's
+           own link model validates and accepts, and which would otherwise
+           reach the anchor as a stray attribute over a link that prefetches
+           nothing"
+    (doseq [v [:intent true false nil]]
+      (is (thrown-with-msg?
+            js/Error #"hicasso-route-link-prefetch-declined"
+            (rendered {:to :conduit.profile/show :params {:username "jane"}
+                       :prefetch v}
+                      "jane"))
+          (str ":prefetch " (pr-str v) " — presence is what is declined, not
+               truthiness: a falsey value is just as much a site that believes
+               it opted in")))))
+
 (deftest a-malformed-navigate-vector-is-loud-at-lowering
   (testing "the navigate head is in-band data anyone can write, so the
            lowering is total over it — each violation names the position"
     (doseq [bad [[intent/navigate-head]
                  [intent/navigate-head {:frame frame-id}]
                  [intent/navigate-head "not-a-map"]
-                 [intent/navigate-head {:frame frame-id :payload [] :native? false}]
-                 [intent/navigate-head {:frame frame-id :payload [:x] :native? "yes"}]]]
+                 [intent/navigate-head {:frame frame-id :payload [] :native? false :veto nil}]
+                 [intent/navigate-head {:frame frame-id :payload [:x] :native? "yes" :veto nil}]]]
       (is (thrown-with-msg?
             js/Error #"hicasso-malformed-navigate"
             (intent/with-frame frame-id (fn [_] nil)
               (fn [] (intent/lower-prop :on-click bad))))
           (pr-str bad)))))
+
+(defn- lower-navigate
+  "Lower `[::h/navigate m]` at an event position and answer the closure."
+  [m]
+  (intent/with-frame frame-id (fn [_] nil)
+    (fn [] (intent/lower-prop :on-click [intent/navigate-head m]))))
+
+(deftest the-navigate-map-is-a-closed-key-set
+  (testing "HD-027 promises EXACTLY :frame, :payload, :native? and :veto, so
+           the check is the exact key SET rather than four presence tests — a
+           grammar that validates only the keys it knows is fail-open by
+           construction, and admits both the map missing the veto slot (an
+           uncancelable navigation where a cancelable one was promised) and
+           the map carrying a fifth key the lowering then silently drops"
+    (doseq [bad [{:frame frame-id :payload [:x] :native? false}
+                 {:payload [:x] :native? false :veto nil}
+                 {:frame frame-id :native? false :veto nil}
+                 {:frame frame-id :payload [:x] :veto nil}
+                 {:frame frame-id :payload [:x] :native? false :veto nil :replace? true}]]
+      (is (thrown-with-msg? js/Error #"hicasso-malformed-navigate" (lower-navigate bad))
+          (pr-str bad))))
+  (testing "and the exact four keys still lower — :veto nil is PRESENT, which
+           is why the slot is asked of the key set and never of its value"
+    (is (fn? (lower-navigate {:frame    frame-id
+                              :payload  [:rf.route/url-requested {:to :conduit.profile/show}]
+                              :native?  false
+                              :veto     nil})))))
 
 (deftest a-bare-vector-at-the-veto-slot-is-loud-at-lowering
   (is (thrown-with-msg?


### PR DESCRIPTION
Closes the two fail-open seams the PR #7380 audit recorded against HD-027's boundary. Both are enforcement of the ruling exactly as already written — **HD-027 itself is unchanged**, and no `spec/**` file is touched (Hicasso stays out of `spec/` until P2 graduation).

The bead's DESCRIPTION is stale: it says route-link does not exist and that the census's 106 tier-1 links are spelled as bare anchors. `front/route_link.cljs` shipped in #7380. The live scope is the bead's NOTES plus its acceptance criteria — and both defects were still present on `origin/main` at `fa4454f696`.

## What was actually still defective

**1. `:prefetch` crossed silently into the anchor's attrs.** `route_link.cljs`'s namespace docstring declines routing's `:prefetch :intent` trio for v0, but nothing enforced the decline. `control-keys` was `[:to :params :query :fragment :on-click]`, so `:prefetch` survived `(apply dissoc props control-keys)` and landed on the `<a>`. It also reached routing intact — `link-model` calls `validate-prefetch!`, which **accepts** `:intent`, routing's own spelling — so the props map passed validation while Hicasso installed none of the three handlers behind the opt-in (`:routing/prefetch-on-intent!` at `:on-mouse-enter` / `:on-focus` / `:on-touch-start`). Net effect: a link that prefetched nothing, said so nowhere, and carried a stray DOM attribute.

`prefetch-declined!` now refuses any **present** `:prefetch` at render with `:rf.error/hicasso-route-link-prefetch-declined`. `contains?`, not truthiness — `{:prefetch nil}` and `{:prefetch false}` are just as much a site that believes it opted in, and letting the falsey ones through would be the same fail-open shape one level down. It runs **before** the link model is consulted, so the author's own mistake names the stack rather than routing's reading of a key Hicasso had already declined.

Prefetch is **not implemented**, deliberately. HD-027 declines the trio and has not been reopened; implementing routing's three-handler behaviour is only correct if that ruling is deliberately changed.

**2. `unwrap-navigate` was a closed grammar that only checked the keys it knew.** It validated the value types of `:frame`, `:payload` and `:native?` and asked nothing about the key set. So a map **missing `:veto`** passed — and `:veto` is the slot that decides whether the click can be cancelled, so its absence is the difference between an uncancelable navigation and the cancelable one HD-027 promises — and so did a map carrying a **fifth key**, which the lowering then silently dropped.

## The key-set check

```clojure
(def ^:private navigate-keys #{:frame :payload :native? :veto})

(let [m  (nth v 1 nil)
      {:keys [frame payload native?]} m
      ks (when (map? m) (set (keys m)))]
  (when-not (and (= 2 (count v))
                 (= navigate-keys ks)
                 (keyword? frame)
                 (vector? payload)
                 (seq payload)
                 (boolean? native?))
    …))
```

The assertion is the exact **set** the map's own keys must equal, not four presence tests. A presence check cannot see a fifth key at all, and `:veto`'s legal value includes `nil`, so its presence can only be asked of the key set and never of its value. `(= navigate-keys ks)` also subsumes the old `(map? m)` conjunct, since a non-map yields `ks` = `nil`. Every existing value contract is preserved verbatim; the diagnostic gained one branch that names both the missing and the unknown keys.

Two pre-existing bad-form cases in `a-malformed-navigate-vector-is-loud-at-lowering` gained `:veto nil` so they keep pinning the value contract they were written for instead of tripping the new key-set branch first.

## Mutation proof

Each mutation was applied to the shipped source, the focused lane run, then reverted byte-identically (`git diff` empty after each).

Lane is `npm run test:cljs` (12474 tests) — the node lane whose `cljs-test$` regexp discovers `front/route_link_cljs_test`.

| # | Mutation | Expected | Observed |
|---|---|---|---|
| d | *(none — baseline)* | everything green | **exit 0**, `0 failures, 0 errors.` |
| a | `navigate-keys` → `#{:frame :payload :native?}` (drop `:veto`) | the missing-`:veto` case stops raising | **exit 1**, `1 failures, 4 errors.` — `FAIL in (the-navigate-map-is-a-closed-key-set)` |
| b | `(= navigate-keys ks)` → `(every? #(contains? m %) navigate-keys)` (presence tests, the strawman) | the extra-key case stops raising | **exit 1**, `1 failures, 0 errors.` — `FAIL in (the-navigate-map-is-a-closed-key-set)`, and nothing else |
| c | `(contains? props :prefetch)` → `(:prefetch props)` (truthiness) | `{:prefetch false}` and `{:prefetch nil}` stop raising | **exit 1**, `2 failures, 0 errors.` — `FAIL in (a-prefetch-is-refused-at-render)` twice, once per falsey value |

Every revert was byte-identical (`git checkout` of the committed file; `git diff --stat` empty after each, and `git status` clean at the end).

**Mutation (a)'s blast radius is itself evidence, and worth stating rather than trimming.** Dropping `:veto` from the set does not only unblock the missing-`:veto` map — it also makes the VALID four-key map fail, which is why the three lowered-click witnesses (`a-prevent-veto-cancels-the-navigation-and-dispatches-instead`, `a-modifier-click-is-left-native`, `a-plain-click-is-intercepted`) error too. That is the grammar and its only minting site agreeing: `route-link` emits exactly these four keys, so the closed set is load-bearing in both directions at once. Mutation (b) is the clean single-tooth isolation of the closedness half.

## Can a declined control key still reach the anchor attrs?

**No.** `:prefetch` is the only declined key, and a link carrying one never renders — the refusal precedes both the `link-model` call and the `attrs` construction, so there is no path from a declined key to an `<a>`. `:prefetch` is deliberately **not** added to `control-keys`: listing it would spell the decline as silent removal, which is the reading the refusal exists to delete, and the dissoc would be unreachable. `no-control-key-reaches-the-anchor` pins the positive half — a link with `:to` / `:params` / `:query` / `:fragment` / `:class` emits exactly `#{:href :on-click :class}`.

## Docs

`docs/design/hicasso/decisions.md` HD-027 gains two clauses stating the **enforcement** of the existing ruling: that the navigate map's four keys are asserted as the exact set, and that "declined" for `:prefetch` means refused rather than ignored. No ruling changed.

`docs/design/**` is outside `mkdocs build --strict` by `mkdocs.yml`'s `exclude_docs`, so that is not the gate for this edit. `scripts/check_doc_slugs.py` passes (exit 0). Both edits are prose inside existing paragraphs — **no tables, headings, anchors or link targets are touched**, so there are no column counts to verify and no anchor to re-check; verified by reading the rendered paragraphs in the diff.

## Architecture

The ≤2-hook shell is untouched: `route-link` remains a plain function that mints no boundary, adds no hook and reads no subscription. No hook is added anywhere. Bodies stay `.cljc`-compatible (HD-020) — `set`, `keys`, `sort`, `remove`, `contains?`, `when-some` only. Surface B only. No bench driver was run and no timing row is published.

## Quality gates

Both run foreground to completion in the worker worktree, unpiped, exit code captured to a file outside the repo. Branch rebased onto `origin/main@6dcf950f58` after the runs; the rebase was a clean replay (`origin/main` had moved only `front/sub_index*`, a different worker's surface).

| Gate | Command | Exit | Result |
|---|---|---|---|
| Fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`, classified `docs=true jvm=true node=true` |
| Browser | `npm run test:browser` | **0** | `Ran 1040 tests containing 6468 assertions. 0 failures, 0 errors.` |

Inside the spine:

- JVM `implementation/core` — `Ran 2210 tests containing 11510 assertions. 0 failures, 0 errors.`
- JVM `implementation/freehand` — `Ran 1288 tests containing 8857 assertions. 0 failures, 0 errors.`
- CLJS node (`:node-test`, 2128 files, 0 warnings) — `Ran 12474 tests containing 62512 assertions. 0 failures, 0 errors.`
- per-ns isolation — `all 17 namespace(s) pass standalone`
- docs — `mkdocs build --strict` clean; `scripts/check_doc_slugs.py` exit 0

**Transitive surface.** `unwrap-navigate` and `route-link` are consumed by `front/intent`'s own lowering, `shapes/card`, `shapes/ordinary` and the arm1 boundaries; the navigate head has exactly one minting site (`route-link`) and one consumer (`intent/navigate-handler`), verified by grep across the bench. The node lane covers the structural half and the browser lane covers `shapes/route_link_dom_cljs_test` — the real `MouseEvent` click, the routing cascade and the prevent-veto cancellation. Both are green.

**One re-run, disclosed.** The first spine invocation was discarded rather than reported: a second process sharing the log path truncated it and its exit file, so that run's exit code could not be attributed. The re-run above is a single clean invocation with uniquely-named artefacts, and its classification line (`jvm=true node=true`) confirms it actually gated this diff rather than skipping it as unchanged.
