### PR TITLE
docs(hicasso): record the measured verdict AGAINST an :advanced nightly gate (rf2-2rtt6.77)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/compile_gate.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/compile_gate.cjs
@@ -51,18 +51,72 @@
 // thing that can silently drop the file you cared about, and re-compiling a
 // handful of test namespaces is cheaper than that risk.
 //
+// ## `:advanced` — MEASURED, and why there is no nightly release gate
+//
+// This block used to say that an "externs-inference fault" was invisible to a
+// dev-mode gate and that `lane_build.cjs` caught the `:advanced` classes at
+// driver time. rf2-2rtt6.77 was filed off that claim, asking for a nightly
+// that releases each arm under `:advanced`. The claim was then TESTED rather
+// than assumed, and it does not hold. Recorded here so it is not re-derived a
+// third time. Timings are one box, with `.shadow-cljs/builds/hicasso-bench`
+// cleared before each, which the lane's cache rule requires anyway:
+//
+//     dev compile, all 101 lane namespaces (THIS gate)     77s
+//     `:advanced` release, ONE arm                         64s
+//     `:advanced` release, all 101 in one module          132s
+//
+//   1. EXTERNS INFERENCE IS ALREADY COVERED HERE, in dev. `:infer-externs
+//      :auto` is shadow-cljs's own `default-compiler-options`
+//      (`shadow.build.api`), and `shadow.build.compiler` binds `:infer-warning`
+//      into `ana/*cljs-warnings*` for every non-jar source in BOTH modes — it
+//      is not a release-only pass. MUTATION-PROVED: rewriting
+//      `parity_probe_app`'s `(some-> e .-message)` to an unknown property made
+//      THIS gate exit 1 with `WARNING #1 - :infer-warning` / `Cannot infer
+//      target type in expression`. The `:advanced` release of the same tree
+//      reported the identical single warning from the identical line. Same
+//      catch, half the wall clock. `check-examples-compile.cjs` already said
+//      as much — it lists "an externs-inference miss" among the classes its
+//      own DEV compile catches — so this file was the outlier, not the rule.
+//   2. CLOSURE RENAMING FAULTS EMIT NO COMPILER DIAGNOSTIC AT ALL, so no build
+//      gate in any mode sees them: a release of a program that will die on a
+//      renamed property still exits 0 with 0 warnings. EXECUTION catches those
+//      — the driver's fail-closed page.
+//   3. THE rf2-2rtt6.20 CLASS IS EXPLICITLY NOT BUILD-OBSERVABLE. That bead's
+//      own words are that the poisoned shadow-js index "COMPILES CLEANLY and
+//      then produce[s] an `:advanced` bundle that DIED ON ITS FIRST
+//      EXECUTION". Its fix is `lane_cache.cjs`, which this gate already calls.
+//
+// What is left for an `:advanced` BUILD to catch over lane sources is Closure
+// hard errors, and that class is empty by construction: no lane source uses
+// `js*`, so there is no unparsed JS for Closure to reject; the only npm
+// modules the lane requires directly are `react`, `react-dom` and
+// `react-dom/client`, the same three `test:bundle-isolation`,
+// `test:perf-bundle`, `test:elision` and `test:ui-g1` already push through
+// shadow-js under `:advanced`; and Closure type checking is off by shadow's
+// default (`:closure-warnings {:check-types :off}`), so there are no
+// `:advanced`-only type errors to find either.
+//
+// So the nightly was NOT built: no fault could be constructed that it would
+// catch and this gate would miss, and a gate nobody can make fire is the
+// fail-open class this lane keeps repairing rather than a repair of it.
+// Per-arm was priced for completeness — 25 `-main`s x 64s is ~27 minutes —
+// and it buys nothing over the one-module release above, whose namespace set
+// is a SUPERSET of every arm's.
+//
 // ## LIMITS — what this gate still cannot see
 //
-//   * `:advanced`-only breakage. It compiles in dev mode, so a Closure
-//     renaming / externs-inference fault that only appears in the `:advanced`
-//     bundle the drivers actually measure is invisible here. `lane_build.cjs`
-//     catches those at driver time, on the run that would publish them.
 //   * Anything that COMPILES. An arm whose numbers stopped meaning what its
 //     name says, a local copy that has drifted from the shipping code it
 //     mirrors, a measurement window that no longer brackets the work — all
 //     compile clean. This gate proves the lane still BUILDS, never that it
 //     still MEASURES.
-//   * Runtime faults. Nothing is executed here; no page is mounted.
+//   * Runtime faults. Nothing is executed here; no page is mounted — and per
+//     (2) and (3) above, that is where the whole remaining `:advanced` risk
+//     lives. An arm nobody has run since it broke can still be `:advanced`-
+//     broken with every gate green. The only instrument that reaches it is a
+//     BOOT of each arm's release bundle, ~30 minutes nightly across 25 arms
+//     plus a per-arm sentinel contract; judged out of proportion to the
+//     residual on rf2-2rtt6.77, not overlooked.
 
 const fs = require('node:fs');
 const path = require('node:path');


### PR DESCRIPTION
**VERDICT: the nightly `:advanced` gate rf2-2rtt6.77 asks for was NOT built.** The bead's
premise was tested rather than assumed and it does not hold. This PR is the correction to the
false claim that caused the bead to be filed, so the question is not re-derived a third time.
It is comment-only: one file, no CI wiring, **no `.github/workflows/*` edit**, and **no
`implementation/shadow-cljs.edn` edit**.

## What the bead asked for

A nightly job releasing each hicasso arm under `:advanced`, on the premise that "Closure
renaming, externs-inference faults, and the shadow-js module-index class rf2-2rtt6.20
documents are all `:advanced`-time". The premise came straight from `compile_gate.cjs`'s own
LIMITS block, which claimed an externs-inference fault "is invisible here".

## What was measured

All timings on one Windows box, `.shadow-cljs/builds/hicasso-bench` cleared before each (the
lane's cache rule requires it, so no warm reuse is available between arms):

| build | cost | result |
|---|---|---|
| dev compile, all 101 lane namespaces (the existing PR gate) | 77s | 0 warnings |
| `:advanced` release, ONE arm (`parity-probe-app`) | 64s | 0 warnings |
| `:advanced` release, all 101 namespaces in one module | 132s | 0 warnings |

Three findings, each of which removes one leg of the premise:

1. **The externs-inference class is already gated at PR time, in dev.** `:infer-externs :auto`
   is shadow-cljs's own `default-compiler-options` (`shadow/build/api.clj`), and
   `shadow/build/compiler.clj` binds `:infer-warning` into `ana/*cljs-warnings*` for every
   non-jar source in **both** modes — it is not a release-only pass.
   `check-examples-compile.cjs` already said as much; this file was the outlier.
2. **Closure renaming faults emit no compiler diagnostic at all**, in any mode. A release of a
   program that will die on a renamed property still exits 0 with 0 warnings. Execution catches
   those, not a build.
3. **The rf2-2rtt6.20 class is explicitly not build-observable** — that bead's own words are
   that the poisoned shadow-js index "COMPILES CLEANLY and then produce[s] an `:advanced`
   bundle that DIED ON ITS FIRST EXECUTION". Its fix is `lane_cache.cjs`, already called
   everywhere.

What is left for an `:advanced` *build* over lane sources is Closure hard errors, and that
class is empty by construction here: no lane source uses `js*`; the only npm modules the lane
requires directly are `react` / `react-dom` / `react-dom/client`, which
`test:bundle-isolation`, `test:perf-bundle`, `test:elision` and `test:ui-g1` already push
through shadow-js under `:advanced`; and Closure type checking is off by shadow's default
(`:closure-warnings {:check-types :off}`).

**So no fault could be constructed that the nightly would catch and the existing gate would
miss** — and a gate nobody can make fire is the fail-open class this lane keeps repairing, not
a repair of it. Per-arm was priced anyway for completeness: 25 `-main`s x 64s is ~27 minutes
local, and it buys nothing over the one-module release, whose namespace set is a **superset**
of every arm's.

## Mutation proof (`:advanced`-only class, both directions)

The mutation is an **externs-inference** fault, not an `:undeclared-var` — deliberately the
class the LIMITS block claimed a dev compile could not see. In `parity_probe_app.cljs`,
`(some-> e .-message)` (a known extern) became `(some-> e .-hicassoAdvProbeZz)` (an unknown
property on an untyped binding). Under `:advanced` that property is renamed and the read is
`undefined` at the call site.

* `:advanced` release, mutated — `Build completed. (392 files, 332 compiled, 1 warnings)`,
  `WARNING #1 - :infer-warning`, `Cannot infer target type in expression (. G__31147
  -hicassoAdvProbeZz)`, `File: ...parity_probe_app.cljs:52:33`. Named the arm.
* **dev gate (`npm run test:hicasso-compile`), same mutated tree — EXIT 1**, `WARNING #1 -
  :infer-warning`, `[hicasso-compile] BUILD REFUSED — :hicasso-bench compiled with 1
  warning(s)`. **This is the result that decided the bead**: the existing PR gate catches it in
  45s, so the nightly would have added nothing.
* Reverted byte-identically (sha256
  `6c4983ae2a2f8d49decc61c7e2629029e2e08dbf93bc38c26eca6bd94d36bd86` before and after,
  `git status` clean) — dev gate exit 0, 101 namespaces, 0 warnings.

## What remains ungated, stated honestly

An arm nobody has run since it broke can still be `:advanced`-broken at **runtime** with every
gate green. That residual is real and is now written into the LIMITS block rather than left
implied. The only instrument that reaches it is a **boot** of each arm's release bundle —
~30 min nightly across 25 arms, plus a per-arm sentinel contract, since the drivers' completion
protocols differ. Judged out of proportion to a P3 residual; recorded on the bead as
not-taken rather than overlooked, so the option survives the close.

Also filed rather than lost from rf2-2rtt6.77's description: the lane's ~25 driver `.cjs`
files are linted by nothing. That turned out to be repo-wide (there is no eslint config
anywhere) rather than lane-specific, so it is its own bead, not this one.

## Quality gates

* `npm run test:hicasso-compile` — **exit 0** (101 lane namespaces, 0 warnings) — the gate whose
  file this PR edits.
* `sh scripts/test-fast-pr.sh` — **exit 0** (its own terminal marker `PASS fast PR spine` reached — marker confirmed in the log, not inferred from the exit code).
* Rebased onto current `main` (which moved: #7425's sub-index `:live` deletion touches this lane), then `npm run test:hicasso-compile` re-run on the REBASED tree — **exit 0**, 101 namespaces, 0 warnings. The spine above ran pre-rebase; the gate it covers was re-run after.
* Mutation proof above ran both directions to completion; no gate was piped through
  `tail`/`head`/`grep` and no exit code here comes from a killed wrapper.

Surface is one comment block in
`implementation/freehand/test/re_frame/bench/hicasso/compile_gate.cjs`. No executable line
changed, no hot-zone file touched.
