### PR TITLE
fix(hicasso): three instruments and claims brought back to the truth (rf2-6wh9o, rf2-e3i6y, rf2-2rtt6.75)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_dom_cljs_test.cljs
@@ -30,6 +30,21 @@
      claim and the script are the same size. DOM parity proves the
      renderings build the same page; this is the half that proves the
      page MEANS the same thing when a user touches it.
+
+     **And the comparator PINS the controlled-input implementation it is
+     compared against (rf2-2rtt6.75).** The script types into two UIx
+     `:input`s (`dogfood_uix.cljs`'s `.new-input` and `.draft`), and
+     `uix.compiler.aot/create-uix-input` can build either React's
+     controlled input or UIx's port of Reagent's rAF-driven one. Which
+     one was INHERITED here — correct, but only because
+     `re-frame.adapter.uix` pins it at load (rf2-heqwo), never because
+     this row asked. Measured, not inferred: with that pin cleared every
+     claim in this namespace stayed GREEN while those two fields were the
+     Reagent port, so the gate was silent about which product it was
+     comparing against (rf2-2rtt6.41 reproduced exactly that). The
+     `:each` fixture now pins [[adapter-default-implementation]] going in
+     and witnesses it coming out ([[pin-is-adapters-default!]]), so the
+     comparison names its own subject.
   2. **The narrow write touches one row.** A toggle re-renders the row it
      names and no other, on both Hicasso renderings — which is the index
      doing its job through React rather than a claim about it.
@@ -54,12 +69,63 @@
             [re-frame.bench.hicasso.lane :as lane]
             [re-frame.core :as rf]
             [re-frame.test-support :as test-support]
+            [uix.compiler.input]
             [uix.core :refer [$ defui]]
             ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
 
-(use-fixtures :each
+;; ---------------------------------------------------------------------------
+;; Pinning the input implementation
+;; ---------------------------------------------------------------------------
+
+(def input-implementations
+  "The two things `uix.compiler.aot/create-uix-input` can build, and the
+  value of `uix.compiler.input/*use-reagent-input-enabled?*` that selects
+  each. `nil` — UIx's OWN unset default — is not a third option; it is
+  *whichever of these two the bundle's contents imply*, which is exactly
+  the thing a parity gate must not be deciding by accident."
+  {:react false :uix-reagent-input true})
+
+(def adapter-default-implementation
+  "What `re-frame.adapter.uix` pins at load (rf2-heqwo) — i.e. what a
+  re-frame2 UIx app actually renders `:input` with — and therefore what
+  the comparator is held to. NOT `nil`: `cljs.test` runs every namespace
+  in one shared JS runtime, so leaving the var cleared would hand the
+  `:input` choice back to the bundle for every namespace scheduled after
+  this one. That this literal is the adapter's real default is
+  `controlled_grid_dom_cljs_test`'s claim to make, not this file's; here
+  it is the subject the parity gate names."
+  :react)
+
+(defn- pin! [impl]
+  (set! uix.compiler.input/*use-reagent-input-enabled?*
+        (get input-implementations impl)))
+
+(defn- pin-is-adapters-default!
+  "The witness for a fault that is invisible where it is caused. A row
+  that leaves the pin somewhere other than the adapter's own value breaks
+  LATER namespaces, not itself — its own assertions stay green and the
+  suite that reds is someone else's. So the check cannot live in a row
+  (it would have to be scheduled last to mean anything, and `cljs.test`
+  promises no order within a namespace); it lives in the `:each`
+  teardown, where it reads the var after every row in this file. It
+  OBSERVES and never repairs — a teardown that re-pinned would make
+  itself true."
+  []
+  (is (= (get input-implementations adapter-default-implementation)
+         uix.compiler.input/*use-reagent-input-enabled?*)
+      "a row in this namespace has just left
+       `uix.compiler.input/*use-reagent-input-enabled?*` somewhere other
+       than the adapter's own pin — a cleared pin re-arms UIx's classpath
+       sniff for every namespace scheduled after this one in the same
+       build"))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures
+;; ---------------------------------------------------------------------------
+
+(def ^:private runtime-fixture
   (test-support/make-reset-runtime-fixture
     {:adapter uix-adapter/adapter
      ;; `:ambient-frame nil` is load-bearing, not tidiness. The fixture's
@@ -76,6 +142,14 @@
      ;; leaves is not readable inside one synchronous test body.
      :async?  true
      :init-fn (fn [] (rt/reset-runtime!))}))
+
+(use-fixtures :each
+  {:before (fn []
+             ((:before runtime-fixture))
+             (pin! adapter-default-implementation))
+   :after  (fn []
+             ((:after runtime-fixture))
+             (pin-is-adapters-default!))})
 
 (def ^:private frame-id ::arm1-dogfood)
 (def ^:private todo-count 6)

--- a/implementation/freehand/test/re_frame/bench/hicasso/read_profile_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/read_profile_app.cljs
@@ -358,15 +358,32 @@
 (def ^:const C-NOINDEX 3)
 (def ^:const C-NOMAP 4)
 
-(def ^:private !local-watch-counter (volatile! 0))
+(def ^:private cell-watch-key
+  "**One constant keyword for every local cell's value-change watch**,
+  because that is what the runtime this file copies now installs
+  (`arm1/runtime.cljs`'s own `cell-watch-key`, rf2-aqgr2). It used to mint
+  `(keyword \"rf-readprof\" (str \"w\" (vswap! counter inc)))` per cell, which
+  was faithful to the runtime of the day and stopped being so the moment
+  the runtime dropped its counter — a copy that prices a cell shape the
+  original no longer builds is an instrument measuring itself (rf2-6wh9o).
+
+  Uniqueness is structural here for the same reason it is there: a mode's
+  cells are built one per key of a read SET, `subs/subscribe` hands back
+  the cached reaction for that `(frame, query)`, and [[rounds-async!]]
+  runs every teardown and clears every sub-cache between arms behind the
+  residue gate — so no two live cells ever hold the same reaction. The
+  namespace is this file's own, so it cannot collide with the runtime's
+  watches when the `commit` arm and a `c-*` arm touch the same cached
+  reactions."
+  ::rp-cell-watch)
 
 (defn- commit-local!
   "Faithful copy of the commit half `make-subscribe` performs for one
   boundary at `mode`: the registration object, one cell per key of the
-  read SET (mint + `subs/subscribe` + the baseline deref + the
-  value-change watch + the disposal hook + the map insert), then the
-  index mount and the whole-set `record-reads!`. Answers a teardown fn
-  that mirrors the returned unsubscribe closure — run OUTSIDE the window.
+  read SET (`subs/subscribe` + the baseline deref + the value-change
+  watch + the disposal hook + the map insert), then the index mount and
+  the whole-set `record-reads!`. Answers a teardown fn that mirrors the
+  returned unsubscribe closure — run OUTSIDE the window.
 
   The stubs, stated: `c-nosub` keeps the computation (a `compute-sub`
   against the frame-state snapshot) so its delta prices the reaction
@@ -383,12 +400,10 @@
             r  (if (identical? mode C-NOSUB)
                  nil
                  (subs/subscribe q {:frame frame-id}))
-            wk (keyword "rf-readprof" (str "w" (vswap! !local-watch-counter inc)))
             ^js cell #js {"subKey"   sub-key
                           "frameKw"  frame-id
                           "queryV"   q
                           "reaction" r
-                          "watchKey" wk
                           "epoch"    (rt/commit-basis frame-id)
                           "refs"     1
                           "disposed" false}]
@@ -396,7 +411,7 @@
           (subs/compute-sub q fs)
           (do @r
               (when-not (identical? mode C-NOWATCH)
-                (add-watch r wk (fn [_ _ _ _] nil))
+                (add-watch r cell-watch-key (fn [_ _ _ _] nil))
                 (interop/add-on-dispose! r (fn [] nil)))))
         (.push cells cell)
         (when-not (identical? mode C-NOMAP)
@@ -411,7 +426,7 @@
       (dotimes [i (alength cells)]
         (let [^js cell (aget cells i)]
           (when-some [r (.-reaction cell)]
-            (remove-watch r (.-watchKey cell))
+            (remove-watch r cell-watch-key)
             (subs/unsubscribe frame-id (.-queryV cell))))))))
 
 (defn- build-only!


### PR DESCRIPTION
Three P3 beads filed today, all the same species: **an instrument or a claim that
no longer matches what the code does.** Two are repaired here. The third is
verified but NOT actioned, because its file is held by a live worker — the
diagnosis is on the bead so the next hand can land it in five minutes.

---

## rf2-6wh9o — read_profile's local cell copy is faithful again

`commit-local!` calls itself a "faithful copy" of the commit half
`arm1.runtime/make-subscribe` performs. Since rf2-aqgr2 (`f7fd0c6a52`) it has
not been one: the runtime now installs a single namespaced constant on every
cell's value-change watch, while the copy still minted
`(keyword "rf-readprof" (str "w" (vswap! counter inc)))` per cell and carried
the resulting `watchKey` field. A copy that prices a cell shape the original
no longer builds is an instrument measuring itself.

The repair mirrors the runtime's — one `::rp-cell-watch` constant, its
namespace this file's own so it cannot collide with the runtime's watches when
the `commit` arm and a `c-*` arm touch the same cached reactions. Uniqueness
was already structural on both sides: one cell per key of a read SET,
`subs/subscribe` handing back that `(frame, query)`'s own cached reaction, and
`rounds-async!` running every teardown and clearing every sub-cache between
arms behind the residue gate.

**NO PUBLISHED CLOCK ROW MOVES, and this was checked rather than assumed.**
The mint was bound *unconditionally* — before the `C-NOWATCH` guard, present in
every mode — so it appeared on both sides of all four published phase-B deltas
in `the-cold-read-mount-term.md` §1 (`c-local − c-nosub`, `− c-noindex`,
`− c-nomap`, `− c-nowatch`) and cancelled exactly. The bead's own guess that
the `c-nowatch` delta was "measuring a keyword mint" is therefore wrong in the
programme's favour.

The only published figure involving `c-local` absolutely is the
`copy fidelity c-local/commit = 0.9718` cell — and its *other* term was already
re-based by rf2-aqgr2's merged runtime change, independently of this PR. Making
the copy faithful restores the two sides to the same shape; it does not part
them further. **No rows were re-taken and none are restated here.** That stale
cell is filed as **rf2-gttif** (P3, blocked on this bead), scope pinned to
exactly one table cell, with an explicit "do not bundle with rf2-0qj9w /
rf2-2rtt6.76" note — both of those carry quiet-box preconditions and are about
axes this cell is not on.

## rf2-2rtt6.75 — dogfood's UIx comparator pins what it compares against

The interaction script in
`the-two-live-renderings-dispatch-the-same-intents-on-the-same-interactions`
types into two UIx `:input`s (`dogfood_uix.cljs`'s `.new-input` at :109 and
`.draft` at :144), and `uix.compiler.aot/create-uix-input` can build either
React's controlled input or UIx's port of Reagent's rAF-driven one. This
namespace never named which. It inherited `false` from `re-frame.adapter.uix`'s
load-time pin (rf2-heqwo) and was therefore correct — but only because the
adapter pins it, never because the gate asked.

The `:each` fixture now pins `adapter-default-implementation` going in, and
`pin-is-adapters-default!` reads the var back in the teardown — where it must
live, because a row that leaves the pin elsewhere breaks LATER namespaces in
the shared `cljs.test` runtime and never itself. The teardown OBSERVES and
never repairs: a teardown that re-pinned would make itself true.

Shape and names follow `arm1/controlled_grid_dom_cljs_test` (rf2-2rtt6.41 /
#7417), the most recent ruling on this exact fault. `with-uix-raw-default` is
deliberately absent — no row here has any business observing UIx's unset
default — and so is `pin-at-load`, because "the literal equals the adapter's
real default" is `controlled_grid`'s claim to make, and duplicating it here
would be coverage of someone else's contract.

## rf2-e3i6y — verified, NOT actioned: the file is held

The diagnosis is confirmed **and understated**, but `front/sub_index.cljs` is
held by **rf2-ixb92** (IN_PROGRESS, unmerged on `worker/subindex-dabt3`, which
touches this same file plus its law suite). Per the worker fence I stopped
rather than raced it, and put the full read-only verification on the bead:

- The bead says the claim "holds at the `commit!` tap point". **It does not** —
  `commit!` builds a 3-entry map literal unconditionally before `evidence!`
  derefs the sink. The HD-005 docstring's "one deref and one nil test at EACH
  OF THE TWO tap points" is false at **both**, not one of two.
- The bead's arithmetic checks out, verified against `clojurescript-1.12.42`
  read from the jar rather than from memory: with `held = #{}` both
  `set/difference` calls are allocation-free (`(reduce disj reads #{})` returns
  `reads` itself; `(reduce f #{} #{})` returns `#{}`), and `cljs.core/set` on an
  already-meta-less set returns it unchanged. So the entire detached residue is
  the map literals — one 4-entry per boundary per commit, one 3-entry per
  commit. Nothing is retained, which is why the heap ladder never saw it.
- The recommended fix is on the bead, including the one that looks right and is
  not: a thunk (`(evidence! #(hash-map …))`) allocates a closure over the same
  locals, trading a map for an object while the claim stays false. Pushing the
  `when-some` out to the two call sites makes the claim literal *and* removes
  the indirection that was hiding the cost.

`rf2-e3i6y` is now marked blocked on `rf2-ixb92` so the two get sequenced
instead of colliding.

---

## Quality gates

Run from `worker/insttruth-6wh9o`, rebased on `origin/main` @ `5362fdf382`.
Worktree guard printed
`WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/insttruth-6wh9o`.

| gate | exit | result |
|---|---|---|
| `npm run test:browser` | **0** | Ran 1036 tests containing 6445 assertions. 0 failures, 0 errors. |
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`, classified `docs=false jvm=true node=true` |
| lane compile (`shadow-cljs compile hicasso-bench`, entry `read-profile-app/-main`) | 0 | Build completed. 187 files, 186 compiled, **0 warnings** |

**Every fast-PR spine run is reported, as instructed. It took three, and the
middle one is worth reading — it is a live reproduction of the harness
path-resolution leak `scripts/assert-worker-worktree.sh` exists to mitigate.**

1. **Foreground, in this worktree.** Aborted with 73
   `_changed-surfaces.test.cjs` failures whose messages were all git *process*
   failures rather than assertions: `Command failed: git init -q` (×8) and
   `Command failed: git ls-files -s -- …` (×1), on a surface this diff cannot
   reach. Isolated immediately — `node scripts/_changed-surfaces.test.cjs`
   standalone gave **275 passed, exit 0, zero git failures**. Contention.
2. **Backgrounded, and it ran in someone else's worktree.** Launched as
   `cd <my worktree> && sh scripts/test-fast-pr.sh`; the `cd` did not take, and
   because the script resolves its root from `BASH_SOURCE[0]` a *relative*
   invocation resolved against whatever cwd the background shell actually had.
   The log named `re-frame2-worktrees/slimresid-e7zxb` in its mkdocs, story-build
   and shadow-cljs lines, and it classified `docs=true` — that worker's diff,
   not mine. It then produced the exact documented two-concurrent-spines
   signature: 13 phantom `re_frame/test_quiet_shadow_node_cljs_test` failures.
   Killed on sight. **`git status` in `slimresid-e7zxb` is clean** — only
   gitignored build output (`out/`, `site/`, `.shadow-cljs/`) was written there,
   no source touched.
3. **Backgrounded with an ABSOLUTE script path**
   (`sh C:/…/insttruth-6wh9o/scripts/test-fast-pr.sh`), which pins `spine_root`
   and `diff_root` regardless of cwd. Correct classification
   (`docs=false jvm=true node=true`), **zero** occurrences of `slimresid` in the
   log, **zero** `Command failed: git`, and `PASS fast PR spine` / exit 0.

The practical rule, and it cost an hour here: **a backgrounded gate must be
invoked by absolute path, not by `cd` plus a relative one.** The `cd` is not
load-bearing enough to trust, and a relative `BASH_SOURCE[0]` turns that into a
green (or a red) belonging to a different tree. Run 1's git failures are almost
certainly the same family — another worker's git operations racing this one.

## Mutation proofs

**rf2-2rtt6.75** — through `npm run test:browser` (the gated lane, *not* a bench
driver). Pinning `:uix-reagent-input` in `:before` exits **1** with **13 named
failures at `dogfood_dom_cljs_test.cljs:116:7`** — one per row, so the fixture
demonstrably covers the whole namespace:

```
FAIL in () (re_frame/bench/hicasso/arm1/dogfood_dom_cljs_test.cljs:116:7)
expected: (= (get input-implementations adapter-default-implementation)
             uix.compiler.input/*use-reagent-input-enabled?*)
  actual: (not (= false true))
```

Those 13 were the **only** failures in the run (1036 tests / 6445 assertions).
That is rf2-2rtt6.41's measurement reproduced inside the suite: every other
claim in the namespace stays green while both fields are Reagent's rAF port.
Reverted byte-identically.

**rf2-6wh9o** — no test covers `read_profile_app.cljs`, so the compile is the
gate, and it was proved able to fail: renaming the constant at one use site
produces `WARNING #1 - :undeclared-var … read-profile-app/cell-watch-keyy` at
line 414. Reverted byte-identically; the re-compile then reported `0 compiled,
0 warnings` — shadow's content cache matched, which is byte-identity by
construction.

> **Corroborates rf2-2rtt6.73 from a second direction.** That mutated compile
> **exited 0** with the `:undeclared-var` warning on screen. The lane's build is
> fail-open exactly as rf2-2rtt6.73 reports, so the warning has to be read out
> of the log and the exit code cannot be trusted. It is why both mutation proofs
> above were driven through `test:browser` rather than through a bench driver.

## Fence compliance

- **No bench driver was run, and no timing row was published or restated.** The
  only lane invocation was `shadow-cljs compile` — a build, no measurement.
- ≤2-hook shell untouched; no hook added. Surface B only; both changed files
  live under `implementation/freehand/test/`.
- Open PRs checked with `gh pr diff --name-only` before every edit. #7418 merged
  mid-session (this branch was rebased onto it); #7420 and #7422 touch nothing
  here. Live-worker branches were diffed against their **merge-bases** rather
  than against `main` — which is what surfaced `worker/subindex-dabt3`'s real
  hold on `front/sub_index.cljs` and kept three unrelated branches from looking
  like holders.

## Beads

- `rf2-6wh9o` — fixed, closed.
- `rf2-2rtt6.75` — fixed, closed.
- `rf2-e3i6y` — verified, left OPEN with the full diagnosis and the corrected
  `commit!` finding appended; now blocked on `rf2-ixb92`.
- `rf2-gttif` — **filed**: the one stale cell in `the-cold-read-mount-term.md`,
  blocked on `rf2-6wh9o`.
- `rf2-g2mxd` — **filed**: the backgrounded-gate worktree leak reproduced in
  run 2 above, with the absolute-path fix.
