### PR TITLE
docs(hicasso): the band page's open-work pointers are answered (rf2-7cmco)

### DIFF
--- a/docs/design/hicasso/studio/the-band-re-calibrated.md
+++ b/docs/design/hicasso/studio/the-band-re-calibrated.md
@@ -44,8 +44,9 @@ by eye.
 > [§5](#5-the-third-explanation-which-is-the-one-the-data-names) reports.
 > The correction is 13× against us on the advertised rate and still leaves 35%
 > a real improvement on 25%, whose rate is **9.1%**. Recomputed from the
-> committed dataset; the ceiling constant and the analysis script are code and
-> are `rf2-nk1hq`.
+> committed dataset. `rf2-nk1hq` has since corrected the script and **left the
+> constant at 35%**, restated in `seam.cjs` as a judgement rather than a
+> quantile.
 
 **No published magnitude changes** ([§8](#8-what-changes-for-the-record-nothing-and-why-that-is-the-check)).
 
@@ -304,9 +305,19 @@ model — pooled says 29.4%, run-preserving says 41.4% — and its real per-run
 false-fire rate is **2.7%**, thirteen times the advertised one. **The derivation
 is withdrawn.** What survives is the comparison the change was made for: at 25%
 the rate was **9.1%**, so 35% is still a 3.4× improvement, and it is the ceiling
-in force. Whether the constant should move again — 41% is where a genuine q99
-sits — is a judgement about code and is `rf2-nk1hq`, together with the analysis
-script that still resamples the wrong way.
+in force.
+
+**And the constant stays at 35%.** `rf2-nk1hq` corrected the script — it
+resamples run-preservingly now, and prints both models — and left `BAND_CEILING`
+where it was, restated in `seam.cjs` as a judgement rather than a quantile.
+Moving it to 41%, where a genuine q99 sits, would *relax* the gate, which is the
+direction that needs the stronger evidence, on the strength of the least stable
+number in the table: a 1% quantile whose whole tail above 35% is carried by one
+or two of nineteen run-regimes, and which reads 41.4% at 200,000 draws against
+42.4% at 20,000. No published magnitude is adjudicated differently at either
+value, and **0 of these nineteen runs breach 35% where 2 breach 25%**. So what
+the constant carries is a price — **2.7% per run** — rather than a derivation,
+and moving it again is an operator's call rather than this page's.
 
 **Three firings in two days is what a one-in-eleven rate produces.** The gate
 did not start failing. It was never a tripwire — it was a lottery ticket with
@@ -559,9 +570,12 @@ gitignored `out/`. Both are closed here.
   breaches, digit for digit. **And that durability is what caught the
   bootstrap**: [§5](#5-the-third-explanation-which-is-the-one-the-data-names)'s
   retraction is a recomputation over the committed file, taking no new run.
-  The **one figure on this page the script does not yet reproduce** is the
-  run-preserving distribution itself — `ladder_band.cjs` still pools blocks
-  across runs, which is `rf2-nk1hq`.
+  The **one figure the script did not reproduce** was the run-preserving
+  distribution itself, because `ladder_band.cjs` pooled blocks across runs. It
+  now computes both models and prints them side by side (`rf2-nk1hq`), so every
+  bootstrap figure this page publishes — both columns, on both clocks —
+  recomputes from the committed file, and its `--selftest` fails if the pooled
+  model is ever reinstated.
 - A raw dataset is ~220 KB and nineteen are ~4 MB, which does not belong in a
   repository. So `--emit` writes the reduced quantities every statistic is a
   function of — the eighteen per-block tared `floor` and `ctl-2x` cells on each
@@ -598,8 +612,11 @@ gitignored `out/`. Both are closed here.
   q99 is withdrawn ([§5](#5-the-third-explanation-which-is-the-one-the-data-names)).
 - **The ceiling is 35%, at a measured per-run false-fire rate of 2.7% against
   25%'s 9.1%, and the gate adjudicates the clock the rows are stated on.** The
-  frame-only band is reported on every run and refuses nothing. Whether 35%
-  should move to a genuine q99 is `rf2-nk1hq`.
+  frame-only band is reported on every run and refuses nothing. **It stays at
+  35%** (`rf2-nk1hq`): a genuine q99 sits at ~41%, and moving there would
+  *relax* the gate on the strength of the table's least stable number, while no
+  published magnitude is adjudicated differently at either value. The constant
+  is a judgement, and `seam.cjs` now says so.
 - **`rf2-cvvb7`'s multiplicativity finding is withdrawn.** Pure
   multiplicativity predicts `ctl-2x / floor = 2.00` with no variance; nineteen
   runs read 1.71 [1.62 – 1.84]. The correlation that carried it reads +0.88 on


### PR DESCRIPTION
`rf2-nk1hq` is closed and [PR #7428](https://github.com/day8/re-frame2/pull/7428)
is merged, so the three forward-references `the-band-re-calibrated.md` carried
to it now point at work that is done. Each is rewritten to state the outcome.

Docs-only, one file, three pointers plus one clause of the same class found by
grep. **No new ceiling is minted and the retracted derivation is not restated** —
`rf2-ymi6j` deliberately withdrew "35%, set from the statistic's own bootstrap
q99, at `P(fire)` 0.2%" without replacing it, and that posture is kept.

## The three pointers

**1 — §9.1, "the one figure the script does not yet reproduce".**

> The **one figure on this page the script does not yet reproduce** is the
> run-preserving distribution itself — `ladder_band.cjs` still pools blocks
> across runs, which is `rf2-nk1hq`.

becomes

> The **one figure the script did not reproduce** was the run-preserving
> distribution itself, because `ladder_band.cjs` pooled blocks across runs. It
> now computes both models and prints them side by side (`rf2-nk1hq`), so every
> bootstrap figure this page publishes — both columns, on both clocks —
> recomputes from the committed file, and its `--selftest` fails if the pooled
> model is ever reinstated.

**2 — §5, "the analysis script that still resamples the wrong way"**, and
**3 — §5, "whether 35% should move to a genuine q99"**. These were one sentence:

> Whether the constant should move again — 41% is where a genuine q99 sits — is
> a judgement about code and is `rf2-nk1hq`, together with the analysis script
> that still resamples the wrong way.

becomes a short paragraph stating the settled outcome — the script resamples
run-preservingly now and prints both models; `BAND_CEILING` stays at 35%,
restated in `seam.cjs` as a judgement rather than a quantile; moving to ~41%
would *relax* the gate on a 1% quantile whose tail above 35% is carried by one
or two of nineteen run-regimes (41.4% at 200,000 draws against 42.4% at 20,000);
no published magnitude is adjudicated differently at either value; 0 of the
nineteen runs breach 35% where 2 breach 25%; and moving it again is an
operator's call.

**3 again — §10's closing bullet.**

> Whether 35% should move to a genuine q99 is `rf2-nk1hq`.

becomes

> **It stays at 35%** (`rf2-nk1hq`): a genuine q99 sits at ~41%, and moving
> there would *relax* the gate on the strength of the table's least stable
> number, while no published magnitude is adjudicated differently at either
> value. The constant is a judgement, and `seam.cjs` now says so.

**A fourth clause of the same class**, which the bead did not name and grep
found — the retraction blockquote's tail read "the ceiling constant and the
analysis script are code and are `rf2-nk1hq`", which also defers to open work.
It now records that `rf2-nk1hq` corrected the script and left the constant at
35%. The retraction's substance is untouched.

## Verification

Every figure was checked against the merged code rather than taken from the
bead, and against a deterministic recomputation over the committed dataset
(`node ladder_band.cjs --from data/ladder-ymi6j.json` — no run taken, no bench
driver, no measurement):

| | page | recomputed |
|---|---|---|
| run-preserving q50/q90/q95/q99, raw `TaskDuration` | 11.5 / 23.4 / 31.0 / **41.4%** | identical |
| pooled-block, same four | 13.0 / 19.9 / 22.7 / 29.4% | identical |
| run-preserving, frame-only | 12.5 / 26.2 / 33.1 / **45.9%** | identical |
| `P(fire)` at 35% / at 25%, published clock | 2.7% / 9.1% | identical |
| §5 candidate-ceiling table, all five rows, both columns | 9.8/15.0, 2.7/9.1, 0.9/5.9, 0.2/2.7, 0.06/1.2 | identical |
| §0.1's P3 row, frame-only | 11.3% run-preserving, 4.7% pooled | identical |
| runs of 19 breaching 35% / 25% | 0 / 2 | identical |

Nothing differed. `BAND_CEILING` is `0.35` in the merged `seam.cjs`, whose
header now states the 2.7% rate and calls the constant a judgement rather than
a quantile, flagging a move as an operator's call.

## Quality gates

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `sh scripts/test-fast-pr.sh` | **0** — `docs=true jvm=false node=false (classified)`, terminal marker `PASS fast PR spine` |

`mkdocs build --strict` is **not** nominated: `exclude_docs` drops
`design/hicasso/`, so it verifies nothing of this diff. It ran inside the spine
and exited clean, which says nothing about this file.

**Hand-verified, because nothing validates tables, rendering or nav in this
tree** (GitHub-style slugs, which do *not* collapse hyphen runs):

- **14 outbound links, all same-page anchors, 0 dead** against the page's 20 headings.
- **9 inbound links** to this page from 851 tracked `.md` files, **0 dead anchors**.
- **12 tables, 0 column-count mismatches** (header against every body row).
- **No heading text changed**, so no anchor could move; the inbound sweep confirms it.

## Scope

One file. `ladder_band.cjs`, `seam.cjs` and every other instrument are
untouched — that work is merged. No overlap with open PRs #7429 or #7430
(checked with `gh pr diff --name-only`). No sibling studio page carries these
pointers: the two that quote the recalibration
(`bulk-broad-re-taken.md`, `rows-re-adjudicated-on-the-corrected-clock.md`)
already state the withdrawal correctly and defer nothing, and the studio
`README.md` cites `rf2-nk1hq` as the source of the correction rather than as
pending work.

Closes `rf2-7cmco`.
