### PR TITLE
fix(bench): two instruments reconciled with their own predictions (rf2-l3jv4, rf2-2rtt6.61)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1229,10 +1229,22 @@ both arms in one session with a third run bracketing them —
 about a factor of two.** The A/B ranges are disjoint, the donors do not move, and
 the per-read slope is **identical to the byte** with and without the wrapper
 (1,447 and 2,289 B/read), confirming this ruling's claim that the cost is
-constant in R and lands in the shell. The two instruments differ because the
+constant in R and lands in the shell. ~~The two instruments differ because the
 ladder mounts and *holds* while the page-chrome rig writes first, and an updated
 component retains an `alternate` fiber a held one does not — offered as the
-leading explanation, not as a counted result.
+leading explanation, not as a counted result.~~
+
+**Amended 2026-08-03 (`rf2-2rtt6.61`): that explanation is withdrawn, and it was
+never a counted result.** Its premise was that the page-chrome rig writes before
+it reads heap, and it does not — `chrome_run.cjs` runs its whole heap half first
+on a quiet page (line 243) and does not touch the four write ops until the clock
+half at line 264, with the same ordering at `cb179b6b3c`, the commit that
+published the +195/+220 rows. **Both instruments mount and hold**, so no
+`alternate` fiber exists on either, and the rule it implied — one fiber held, two
+updated — is not adopted. Both deltas stand as measured against the shape each was
+taken on; what separates them is open as `rf2-2rtt6.79`. The ruling itself is
+untouched: the wrapper is a per-boundary constant in R, and **a Fiber is not a
+fixed byte count — the shape it sits on decides what it costs.**
 
 **What remains open is the disposition, and it is the operator's.** Whether +9%
 on a shell **already 1.14× over** the paper line is "pushing retained heap

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -1170,19 +1170,47 @@ and exit **0** on all three runs.
 The page-chrome row measured **+195 and +220 B** per boundary for the same
 wrapper; this rung reads **+100 to +106 B**. Both reproduce on their own
 instrument, so the disagreement is real and belongs to the shapes, not to a bad
-run. **The leading candidate explanation is React's double buffering, and it is
-offered as a hypothesis because this run did not count fibers:** the ladder
-mounts an arm and *holds* it with no writes, so only the current tree exists and
-the wrapper costs one extra fiber; the page-chrome instrument performs its four
-write ops before reading, and an updated component retains an `alternate` fiber
-beside its current one, so a wrapper position there can be holding two. Roughly
-2× is what that predicts, and roughly 2× is what the two instruments differ by.
-**Testing it needs a fiber count, which is filed rather than claimed.**
+run. **What produces it is not yet known, and the first candidate has been
+excluded.**
 
-The practical reading is the one the ruling asked for: **a Fiber is not a fixed
-tax, and the shape it sits on decides what it costs.** Quoting either
-instrument's figure onto the other's shape is the error this rung exists to
-prevent.
+> **Correction, 2026-08-03 (`rf2-2rtt6.61`).** This paragraph offered React's
+> double buffering as the leading explanation: the ladder mounts and *holds*, so
+> the wrapper costs one extra fiber, while the page-chrome instrument was said to
+> perform its four write ops before reading heap, so an updated component would
+> retain an `alternate` fiber beside its current one and a wrapper position there
+> could be holding two. Roughly 2× is what that predicts, and roughly 2× is what
+> the instruments differ by. It was published as a hypothesis and not as a
+> result, because neither run counted fibers.
+>
+> **Its premise is false, and the instruments' own source says so.**
+> `chrome_run.cjs` takes the whole heap half FIRST, on a quiet page —
+> `heapForArms` at line 243, under the comment *"the heap half, first, on a quiet
+> page"*, and the clock half's `runOp` calls do not begin until line 264.
+> `heapOnce` (lines 164–182) is `resetRuntime` → baseline read → `mountArm` →
+> held read, with no op between the mount and the read. The same ordering is
+> present at `cb179b6b3c`, the commit that published the +195/+220 figures, so
+> those numbers were taken on a held tree exactly as this rung's were — as is the
+> ladder's own window (`p0_run.cjs` lines 588–593: gc, pre-read, `mountOne`, gc,
+> held read).
+>
+> **Both instruments mount and hold.** Double buffering cannot be what separates
+> them, and the general rule the bead proposed — *a memo wrapper costs one fiber
+> on a held tree and two on a tree that has been updated* — is **not** adopted:
+> no measurement on this programme has read an updated tree's wrapper at all. The
+> exclusion is settled from committed source; no fiber count was needed to reach
+> it, and none was taken.
+>
+> **What separates them is still open**, and is `rf2-2rtt6.79`. It asks for the
+> fiber count on a different question: whether the wrapper is ONE fiber on both
+> shapes, in which case the difference is in what a fiber *holds* rather than in
+> how many there are — a 17-element card reading two subscriptions against an
+> R=0 cell reading nothing is an order of magnitude apart in retained bytes per
+> boundary, against a 2× in what the wrapper adds to it.
+
+The practical reading is the one the ruling asked for and it is unchanged by any
+of this: **a Fiber is not a fixed tax, and the shape it sits on decides what it
+costs.** Quoting either instrument's figure onto the other's shape is the error
+this rung exists to prevent.
 
 #### What this settles, and what it hands the operator
 

--- a/docs/design/hicasso/studio/the-page-chrome-row-and-what-the-bail-out-costs.md
+++ b/docs/design/hicasso/studio/the-page-chrome-row-and-what-the-bail-out-costs.md
@@ -133,9 +133,19 @@ for it.
 >
 > **Two corrections to this section, recorded rather than silently edited.**
 > First, the ≈ +17% figure: it assumed the card-shaped +200 B transferred
-> unchanged to a boundary that reads nothing, and it does not — this instrument
+> unchanged to a boundary that reads nothing, and it does not. ~~This instrument
 > mounts and writes, the ladder mounts and holds, and an updated component
-> retains an `alternate` fiber that a held one does not. Second, this paragraph
+> retains an `alternate` fiber that a held one does not.~~ **That reason is
+> withdrawn (`rf2-2rtt6.61`, 2026-08-03): this instrument does NOT write before
+> it reads.** `chrome_run.cjs` runs `heapForArms` to completion first, on a quiet
+> page (line 243, *"the heap half, first, on a quiet page"*), and the four write
+> ops do not begin until the clock half at line 264; `heapOnce` is `resetRuntime`
+> → baseline → `mountArm` → held, with nothing between the mount and the read.
+> The ordering is the same at `cb179b6b3c`, which published the +195/+220 rows.
+> **Both instruments mount and hold**, so the `alternate` fiber cannot be the
+> difference; the ~2× is real and unexplained, and is `rf2-2rtt6.79`. The +100 B
+> re-take stands — only the account of *why* the two disagree was wrong. Second,
+> this paragraph
 > originally named **`reads_ladder_run.cjs`** as the rig to re-take it on. That
 > is the wrong instrument: the freehand ladder carries only `reagent,uix`, has
 > no Hicasso arm, and could not have produced the 1,143 B figure. That number

--- a/implementation/core/test/re_frame/bench/calibration.cljc
+++ b/implementation/core/test/re_frame/bench/calibration.cljc
@@ -1,0 +1,297 @@
+(ns re-frame.bench.calibration
+  "rf2-l3jv4 — the SMI/DBL control's verdict, made to FAIL CLOSED.
+
+  Both allocation harnesses in this directory carry the same pair of
+  `.slice()` controls: a PACKED_DOUBLE_ELEMENTS array whose copy has an
+  asserted layout, and a PACKED_SMI_ELEMENTS array whose copy has not.
+  Together they answer one question — is this instrument measuring a
+  tagged-slot copy at all? — and the answer is what licenses every absolute
+  byte figure the run goes on to print.
+
+  ## Why the answer had to grow teeth
+
+  The pair already printed its own disagreement. When the SMI/DBL ratio sat
+  outside both bands the harness printed
+
+      *** NEITHER — the SMI arm is not measuring a tagged-slot copy ***
+
+  and then carried on, exited 0, and printed `VERDICT: reportable` from the
+  arm-order guard beside it. That is the exact recurrence this owner exists
+  to catch: `arm-ctl` was once ONE function body closed over both kinds of
+  template, so the harness had ONE `.slice()` call site that saw both
+  elements kinds, and at that polymorphic site the SMI receiver lost
+  `.slice()`'s clone fast path and allocated its elements store TWICE — the
+  arm read 16.11 B/slot against a tagged slot's 8. Splitting the site per
+  elements kind returned it to 8.0. Nothing stops a future edit sharing that
+  site again, and until this namespace existed nothing would have stopped the
+  run REPORTING afterwards.
+
+  So the evidence the harnesses already computed is turned into a boolean
+  here, and that boolean joins the arm-order refusal in deciding the exit
+  code. A run whose control says it is not measuring its stated control is
+  not reportable, by the same rule that an order-contaminated run is not.
+
+  ## What is checked, and what deliberately is NOT
+
+  Three things, all of them measurement-against-measurement:
+
+    1. **Every SMI/DBL ratio names a regime.** At the same D the two copies
+       have identical layout with pointer compression OFF (ratio 1.00) and
+       every slot and both headers halve with it ON (ratio ~0.50). A ratio in
+       NEITHER band means the SMI arm is not copying tagged slots — refuse.
+       Nothing is asserted about a header anywhere; this is one measurement
+       divided by another from the same window of the same process.
+
+    2. **The sizes agree with each other.** One D answering ON while another
+       answers OFF is a single instrument giving two answers about one
+       machine. Refuse — regardless of how confidently either lands in its
+       band.
+
+    3. **The SMI slope sits at the exact width of the regime the ratios
+       selected.** The regime is READ off this pair, so predicting the slope
+       from an assumed width would be circular; but once the RATIOS have
+       named the regime, its width is 8 bytes or 4 and the slope may be
+       checked against it non-circularly. A tagged slot is never 16.1.
+
+  NOT checked: the DBL LARGE pair's documented ~+9% deviation. It is V8's
+  page-tail filler on an 87 KB object, it is understood, and every arm these
+  harnesses measure allocates small objects — gating it would refuse healthy
+  runs for a known large-object effect. It stays printed and open, exactly as
+  the harness docstrings say.
+
+  ## Pure, so the failure path is adjudicated rather than hoped for
+
+  Everything below takes numbers and returns a map. [[self-test]] injects
+  ratios — including the recorded 16.11 — and asserts the verdict each one
+  earns, so the refusal branch is exercised on every run of the harness and
+  on every run of `re-frame.bench.calibration-cljs-test`, which is what makes
+  it a checked behaviour rather than an unvisited branch.
+
+  `.cljc` because `re-frame.bench.read-attribution` is JVM Clojure and the
+  other two harnesses are ClojureScript; unlike
+  `re-frame.bench.order-guard`'s rule this one has a single expression, since
+  nothing outside `implementation/core` needs it."
+  (:require [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; The bands.
+
+(def ^:const off-lo
+  "Below this the SMI/DBL ratio is not compression-OFF." 0.95)
+(def ^:const off-hi
+  "Above this the SMI/DBL ratio is not compression-OFF." 1.05)
+(def ^:const on-lo
+  "Below this the SMI/DBL ratio is not compression-ON." 0.45)
+(def ^:const on-hi
+  "Above this the SMI/DBL ratio is not compression-ON." 0.55)
+
+(def ^:const slope-tolerance
+  "How far the SMI slope may sit from the exact slot width of the regime the
+  RATIOS selected, as a fraction. Deliberately loose: the widths themselves
+  are 8 and 4, a full 100%/50% apart, and the fault this exists to catch read
+  2x. The tightest legitimate deviation on record on this surface is the DBL
+  small pair's +0.5%, so 25% admits every honest reading of either width
+  while leaving no room for a doubled one."
+  0.25)
+
+(defn- abs* [x] #?(:clj (Math/abs (double x)) :cljs (js/Math.abs x)))
+
+(defn- finite? [x]
+  (and (number? x)
+       #?(:clj  (and (not (Double/isNaN (double x))) (not (Double/isInfinite (double x))))
+          :cljs (js/isFinite x))))
+
+(defn regime-of
+  "The regime one SMI/DBL ratio names: `:off` (8 B/slot), `:on` (4 B/slot) or
+  `:neither`. A non-finite ratio — a zero DBL reading divides to infinity —
+  is `:neither`, which is the honest answer and not an excuse."
+  [ratio]
+  (cond
+    (not (finite? ratio))            :neither
+    (< off-lo ratio off-hi)          :off
+    (< on-lo ratio on-hi)            :on
+    :else                            :neither))
+
+(def ^:private width-of {:off 8.0 :on 4.0})
+
+(defn verdict
+  "Adjudicate the SMI/DBL control pair.
+
+  `pairs` is a seq of `{:d D :smi B :dbl B}` — one entry per control size,
+  each carrying the measured bytes per copy of the two arms at that D.
+  `slope` is the measured SMI slope in B/slot across the small pair.
+
+  Answers
+
+      {:refuse?  true/false
+       :regime   :off | :on | :neither
+       :pairs    [{:d D :smi B :dbl B :ratio R :regime :off|:on|:neither} ...]
+       :slope    S
+       :width    8.0 | 4.0 | nil     ; the width the RATIOS selected
+       :off-by   fraction | nil      ; how far the slope sits from it
+       :why      one line}
+
+  Refusal is the disjunction of the three checks in the namespace docstring.
+  When the ratios cannot name a regime the slope check has no width to run
+  against and is skipped — the run is already refused."
+  [pairs slope]
+  (let [rows    (mapv (fn [{:keys [d smi dbl]}]
+                        (let [r (if (and (finite? smi) (finite? dbl) (not (zero? dbl)))
+                                  (/ smi dbl)
+                                  #?(:clj Double/NaN :cljs js/NaN))]
+                          {:d d :smi smi :dbl dbl :ratio r :regime (regime-of r)}))
+                      pairs)
+        named   (into #{} (map :regime) rows)
+        bad     (filterv #(= :neither (:regime %)) rows)
+        regime  (cond
+                  (empty? rows)          :neither
+                  (seq bad)              :neither
+                  (= 1 (count named))    (first named)
+                  :else                  :neither)
+        width   (width-of regime)
+        off-by  (when (and width (finite? slope))
+                  (/ (- slope width) width))
+        slope-bad? (or (and width (not (finite? slope)))
+                       (and off-by (> (abs* off-by) slope-tolerance)))
+        why     (cond
+                  (empty? rows)
+                  "no control pair was measured — the instrument has no calibration at all"
+
+                  (seq bad)
+                  (str "SMI/DBL ratio names NEITHER regime at D="
+                       (str/join "," (map :d bad))
+                       " — the SMI arm is not measuring a tagged-slot copy")
+
+                  (< 1 (count named))
+                  (str "the sizes disagree: "
+                       (str/join ", " (map #(str "D=" (:d %) " says " (name (:regime %))) rows))
+                       " — one instrument, two answers about one machine")
+
+                  slope-bad?
+                  (str "the ratios read pointer compression "
+                       (str/upper-case (name regime))
+                       " (" (long width) " B/slot) but the slope is " slope
+                       " B/slot — a tagged slot is 8 bytes or 4, never that")
+
+                  :else
+                  (str "SMI/DBL ratio names pointer compression "
+                       (str/upper-case (name regime))
+                       " at every size, and the slope sits at that width"))]
+    {:refuse? (boolean (or (= :neither regime) slope-bad?))
+     :regime  regime
+     :pairs   rows
+     :slope   slope
+     :width   width
+     :off-by  off-by
+     :why     why}))
+
+(defn report-lines
+  "The refusal, as harness-comment lines. Empty when the control is sound —
+  the harnesses print the pair's own numbers either way, and this speaks only
+  when they must not be quoted."
+  [v]
+  (when (:refuse? v)
+    [";;"
+     ";; ==== CONTROL CALIBRATION: THESE FIGURES ARE NOT REPORTABLE ===="
+     (str ";;   " (:why v))
+     ";;   every absolute byte figure above rests on the SMI/DBL pair agreeing"
+     ";;   about what a tagged slot costs on this build (rf2-l3jv4). It does not."
+     ";;   The table stands as raw data; nothing in it may be quoted."]))
+
+;; ---------------------------------------------------------------------------
+;; The self-test — injected ratios, so the REFUSAL branch is adjudicated on
+;; every run rather than only ever reached by a broken machine.
+
+(defn- pair [d smi dbl] {:d d :smi smi :dbl dbl})
+
+(defn self-test []
+  (let [;; 1. THE RECORDED FAULT, replayed from this bead's own measurement:
+        ;;    the polymorphic `.slice()` site, SMI D=100 at 1681.7 B against
+        ;;    the DBL D=100's 848, slope 16.1146 B/slot. This is the run that
+        ;;    exited 0 and printed `VERDICT: reportable`.
+        broken   (verdict [(pair 100 1681.7 848.0) (pair 200 3293.5 1648.0)] 16.1146)
+
+        ;; 2. THE SAME HARNESS AFTER THE FIX, from the numbers the docstring
+        ;;    of `write-attribution` quotes. It must pass, or the guard is
+        ;;    useless.
+        healthy  (verdict [(pair 100 849.1 848.0) (pair 200 1651.8 1648.0)] 8.0027)
+
+        ;; 3. A CHROME-LIKE BUILD. Pointer compression ON halves every slot
+        ;;    and both headers, so the ratio is ~0.5 and the slope ~4. The
+        ;;    harnesses are run on node, but a guard that refused a
+        ;;    compressed build would be asserting the regime it claims to
+        ;;    read.
+        compressed (verdict [(pair 100 448.0 848.0) (pair 200 848.0 1648.0)] 4.0)
+
+        ;; 4. THE SIZES DISAGREEING. Each ratio lands cleanly in a band and
+        ;;    they are DIFFERENT bands — no single reading is suspicious, and
+        ;;    the pair is still nonsense.
+        split    (verdict [(pair 100 849.1 848.0) (pair 200 824.0 1648.0)] 8.0)
+
+        ;; 5. A SOUND RATIO WITH A BROKEN SLOPE. The absolutes agree at both
+        ;;    sizes, so check 1 passes; only the size-to-size STEP is wrong,
+        ;;    which is what a constant added to both copies looks like.
+        slope-bad (verdict [(pair 100 849.1 848.0) (pair 200 1651.8 1648.0)] 12.5)
+
+        ;; 6. A DEAD DBL ARM. Dividing by zero must refuse, not produce an
+        ;;    infinity that slips through a range test.
+        zero-dbl (verdict [(pair 100 849.1 0.0)] 8.0)
+
+        ;; 7. NO CONTROL AT ALL. A plan that dropped its control arms has no
+        ;;    calibration, and "nothing to check" is not "checked".
+        empty-v  (verdict [] 8.0)
+
+        ;; 8. THE DOCUMENTED DBL DEVIATION IS NOT GATED. Both DBL arms read
+        ;;    9% over their own asserted layout — the page-tail effect — and
+        ;;    the SMI arms track them. Only the RATIO is adjudicated here, so
+        ;;    this must pass: turning a known large-object effect into a
+        ;;    refusal was ruled out by name.
+        ;;    Its own implied slope is 8.72 — the same +9% — and the 25%
+        ;;    tolerance must admit it.
+        tail     (verdict [(pair 100 924.3 924.3) (pair 200 1796.3 1796.3)] 8.72)
+
+        checks
+        [{:name "the recorded 16.11 B/slot polymorphic-site run is REFUSED"
+          :ok   (and (:refuse? broken)
+                     (= :neither (:regime broken))
+                     (every? #(= :neither (:regime %)) (:pairs broken)))
+          :detail (:why broken)}
+         {:name "the same harness after the fix is reportable"
+          :ok   (and (not (:refuse? healthy))
+                     (= :off (:regime healthy))
+                     (< (abs* (:off-by healthy)) 0.01))
+          :detail (:why healthy)}
+         {:name "a pointer-COMPRESSED build reads 4 B/slot and is reportable"
+          :ok   (and (not (:refuse? compressed))
+                     (= :on (:regime compressed)))
+          :detail (:why compressed)}
+         {:name "two sizes naming DIFFERENT regimes is refused, though each lands in a band"
+          :ok   (and (:refuse? split)
+                     (= :neither (:regime split))
+                     (= [:off :on] (mapv :regime (:pairs split))))
+          :detail (:why split)}
+         {:name "sound ratios with a slope off the selected width are refused"
+          :ok   (and (:refuse? slope-bad)
+                     (= :off (:regime slope-bad)))
+          :detail (:why slope-bad)}
+         {:name "a zero DBL reading refuses instead of dividing to infinity"
+          :ok   (and (:refuse? zero-dbl) (= :neither (:regime zero-dbl)))
+          :detail (:why zero-dbl)}
+         {:name "a plan with no control arms is refused, not silently excused"
+          :ok   (and (:refuse? empty-v) (= :neither (:regime empty-v)))
+          :detail (:why empty-v)}
+         {:name "a DBL arm 9% over its own layout prediction does NOT refuse — only the ratio is adjudicated"
+          :ok   (and (not (:refuse? tail)) (= :off (:regime tail)))
+          :detail (:why tail)}]]
+    {:ok?    (every? :ok checks)
+     :checks checks}))
+
+(defn print-self-test!
+  "Run [[self-test]], print each check, and answer whether it passed. A
+  harness that gets `false` must measure nothing."
+  []
+  (let [st (self-test)]
+    (doseq [c (:checks st)]
+      (println (str ";; calibration " (if (:ok c) "ok  " "FAIL") " " (:name c)
+                    (when (:detail c) (str "  — " (:detail c))))))
+    (:ok? st)))

--- a/implementation/core/test/re_frame/bench/calibration_cljs_test.cljs
+++ b/implementation/core/test/re_frame/bench/calibration_cljs_test.cljs
@@ -1,0 +1,109 @@
+(ns re-frame.bench.calibration-cljs-test
+  "rf2-l3jv4 — the calibration refusal, adjudicated by a GATED suite.
+
+  `re-frame.bench.calibration/self-test` runs inside each harness before it
+  measures anything, which is the right place for it but not a place CI ever
+  reaches: the allocation harnesses are `:advanced` release builds driven by
+  hand. The audit that reopened this owner said so plainly — every listed
+  gate exercised values inside the expected bands, so the newly introduced
+  failure branch was never adjudicated.
+
+  This runs the same injected fixtures under `npm run test:cljs`, and adds
+  the two properties the self-test cannot state about itself: that the
+  refusal is REACHABLE from the numbers actually recorded against this bead,
+  and that the healthy numbers actually recorded after the fix do NOT reach
+  it."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.bench.calibration :as calib]))
+
+(defn- pair [d smi dbl] {:d d :smi smi :dbl dbl})
+
+(deftest self-test-passes
+  (testing "every injected fixture earns the verdict it is asserted to earn"
+    (let [st (calib/self-test)]
+      (doseq [c (:checks st)]
+        (is (:ok c) (str (:name c) " — " (:detail c))))
+      (is (:ok? st)))))
+
+(deftest the-recorded-fault-refuses
+  (testing "the 16.11 B/slot polymorphic-.slice() run this bead was opened on"
+    ;; The measured figures from the bead: SMI D=100 1681.7 B/copy against a
+    ;; predicted (and DBL-measured) 848, SMI D=200 3293.5 against 1648,
+    ;; printed slope 16.1146 B/slot. That run exited 0.
+    (let [v (calib/verdict [(pair 100 1681.7 848.0) (pair 200 3293.5 1648.0)] 16.1146)]
+      (is (:refuse? v))
+      (is (= :neither (:regime v)))
+      (is (= [:neither :neither] (mapv :regime (:pairs v))))
+      (is (seq (calib/report-lines v))
+          "a refusal must produce the lines the harness prints before exiting 2"))))
+
+(deftest the-fixed-harness-is-reportable
+  (testing "the same control after the per-elements-kind split"
+    (let [v (calib/verdict [(pair 100 849.1 848.0) (pair 200 1651.8 1648.0)] 8.0027)]
+      (is (not (:refuse? v)))
+      (is (= :off (:regime v)))
+      (is (= 8.0 (:width v)))
+      (is (empty? (calib/report-lines v))
+          "a sound control says nothing — the harness prints its numbers either way"))))
+
+(deftest a-compressed-build-is-not-refused
+  (testing "pointer compression ON is a regime to be READ, not a fault"
+    (let [v (calib/verdict [(pair 100 448.0 848.0) (pair 200 848.0 1648.0)] 4.0)]
+      (is (not (:refuse? v)))
+      (is (= :on (:regime v)))
+      (is (= 4.0 (:width v))))))
+
+(deftest the-band-edges-are-where-they-are-documented
+  (testing "regime-of, swept across the boundaries it is specified at"
+    (is (= :off (calib/regime-of 1.0)))
+    (is (= :off (calib/regime-of 0.96)))
+    (is (= :off (calib/regime-of 1.04)))
+    (is (= :neither (calib/regime-of 0.95)) "the band is open at its edge")
+    (is (= :neither (calib/regime-of 1.05)) "the band is open at its edge")
+    (is (= :on (calib/regime-of 0.5)))
+    (is (= :neither (calib/regime-of 0.45)))
+    (is (= :neither (calib/regime-of 0.55)))
+    (is (= :neither (calib/regime-of 0.75)) "between the bands is not a regime")
+    (is (= :neither (calib/regime-of 2.0)) "the recorded fault's ratio")
+    (is (= :neither (calib/regime-of js/NaN)))
+    (is (= :neither (calib/regime-of js/Infinity)))))
+
+(deftest the-slope-is-checked-against-the-width-the-ratios-selected
+  (testing "sound absolutes with a wrong step still refuse"
+    ;; Both sizes name OFF, so the width is 8; only the size-to-size step is
+    ;; wrong, which is what a constant added to both copies looks like.
+    (doseq [[slope refuse?] [[8.0 false] [8.0027 false] [9.9 false]
+                             [10.1 true] [12.5 true] [16.1146 true]
+                             [4.0 true]]]
+      (let [v (calib/verdict [(pair 100 849.1 848.0) (pair 200 1651.8 1648.0)] slope)]
+        (is (= refuse? (:refuse? v)) (str "slope " slope " against a width of 8")))))
+  (testing "the same question in the compressed regime, where the width is 4"
+    (doseq [[slope refuse?] [[4.0 false] [4.9 false] [5.1 true] [8.0 true]]]
+      (let [v (calib/verdict [(pair 100 448.0 848.0) (pair 200 848.0 1648.0)] slope)]
+        (is (= refuse? (:refuse? v)) (str "slope " slope " against a width of 4"))))))
+
+(deftest a-missing-or-dead-control-refuses
+  (testing "nothing to check is not checked"
+    (is (:refuse? (calib/verdict [] 8.0)))
+    (is (= :neither (:regime (calib/verdict [] 8.0)))))
+  (testing "a zero DBL reading refuses rather than dividing to infinity"
+    (is (:refuse? (calib/verdict [(pair 100 849.1 0.0)] 8.0))))
+  (testing "a non-finite slope refuses even where the ratios are sound"
+    (is (:refuse? (calib/verdict [(pair 100 849.1 848.0) (pair 200 1651.8 1648.0)]
+                                 js/NaN)))))
+
+(deftest the-sizes-must-agree-with-each-other
+  (testing "one instrument giving two answers about one machine"
+    (let [v (calib/verdict [(pair 100 849.1 848.0) (pair 200 824.0 1648.0)] 8.0)]
+      (is (:refuse? v))
+      (is (= :neither (:regime v)))
+      (is (= [:off :on] (mapv :regime (:pairs v)))
+          "each ratio lands cleanly in a band; it is the disagreement that refuses"))))
+
+(deftest the-documented-large-object-deviation-is-not-gated
+  (testing "V8's page-tail filler must not refuse a healthy run"
+    ;; Both arms 9% over the asserted layout, tracking each other, with the
+    ;; +9% step to match. The bead's bounded repair ruled this out by name.
+    (let [v (calib/verdict [(pair 100 924.3 924.3) (pair 200 1796.3 1796.3)] 8.72)]
+      (is (not (:refuse? v)))
+      (is (= :off (:regime v))))))

--- a/implementation/core/test/re_frame/bench/read_attribution_cljs.cljs
+++ b/implementation/core/test/re_frame/bench/read_attribution_cljs.cljs
@@ -118,6 +118,16 @@
   printing only the slope is how an arm reading exactly TWICE its
   prediction at BOTH sizes went unremarked for as long as it did.
 
+  And the SMI pair REFUSES rather than merely commenting (rf2-l3jv4). It
+  used to print `*** NEITHER — the SMI arm is not measuring a tagged-slot
+  copy ***` and then exit 0 under the arm-order guard's `VERDICT:
+  reportable` beside it, so the exact recurrence the control exists to catch
+  could still be published. `re-frame.bench.calibration` turns the ratios
+  and the slope into a boolean, and this run's exit code is the OR of three
+  independent refusals: the arm order's, the read-back's, and the control's.
+  The DBL LARGE pair's ~+9% is deliberately NOT gated — it is an understood
+  large-object effect and every arm here allocates small ones.
+
   `NOOP` is the bare `keep!` loop — the inner-loop skeleton every arm below
   shares, with the arm's own body removed. It is PREDICTED TO READ 0, and
   it is the instrument's FLOOR. Near-zero arms are the CLJS story here (the
@@ -281,6 +291,7 @@
             [goog.string :as gstring]
             [goog.string.format]
             [re-frame.adapter.context :as adapter-context]
+            [re-frame.bench.calibration :as calib]
             [re-frame.bench.order-guard :as guard]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -1375,6 +1386,11 @@
   ;; a broken verdict here could lift a refusal it had no right to lift.
   (when-not (print-floor-self-test!)
     (throw (ex-info "floor-verdict self-test FAILED — nothing may be measured" {})))
+  ;; rf2-l3jv4 — and the control calibration, whose refusal is a third
+  ;; independent contributor to this run's exit code. Injected ratios,
+  ;; including the recorded 16.11 B/slot the owner bead was opened on.
+  (when-not (calib/print-self-test!)
+    (throw (ex-info "calibration self-test FAILED — nothing may be measured" {})))
   (let [n            (env-int "RA_N" 300)
         samples      (env-int "RA_SAMPLES" 42)
         warmup       (env-int "RA_WARMUP" 3)
@@ -1587,6 +1603,15 @@
                                            :windows    (get-in run [:windows label] 0))]))
                          plan))
             b    (fn [l] (:p50 (get res l)))
+            ;; rf2-l3jv4 — the control's own verdict, computed ONCE from the
+            ;; same p50s the CONTROLS block prints, and carried to the exit
+            ;; code at the bottom. The bands live in
+            ;; `re-frame.bench.calibration` and are expressed nowhere else,
+            ;; so what is printed and what refuses cannot drift apart.
+            cal  (calib/verdict
+                   (mapv (fn [d] {:d d :smi (b (ctl-key "SMI" d)) :dbl (b (ctl-key "DBL" d))})
+                         ctl-smi-ds)
+                   (slope b (ctl-key "SMI" 100) 100 (ctl-key "SMI" 200) 200))
             noop (b "NOOP")
             ;; per-READ figures. Every ladder arm runs `n` inner iterations, so
             ;; the per-read figure is the per-call figure over n — which divides
@@ -1617,30 +1642,36 @@
                 p (+ 32 16 (* 8 d))]
             (println (gstring/format ";;   DBL D=%-6d %12s B/copy   predicted %7d  %+.2f%%"
                              d (fmt m) p (* 100.0 (/ (- m p) p))))))
-        (doseq [d ctl-smi-ds]
-          (let [m (b (ctl-key "SMI" d))
-                r (b (ctl-key "DBL" d))]
-            (println (gstring/format
-                       ";;   SMI D=%-6d %12s B/copy   x%.4f of DBL D=%d (%s B)  -> %s"
-                       d (fmt m) (/ m r) d (fmt r)
-                       (cond
-                         (< 0.95 (/ m r) 1.05) "8 B/slot, compression OFF"
-                         (< 0.45 (/ m r) 0.55) "4 B/slot, compression ON"
-                         :else                 "*** NEITHER — the SMI arm is not measuring a tagged-slot copy ***")))))
+        (doseq [{:keys [d smi dbl ratio regime]} (:pairs cal)]
+          (println (gstring/format
+                     ";;   SMI D=%-6d %12s B/copy   x%.4f of DBL D=%d (%s B)  -> %s"
+                     d (fmt smi) ratio d (fmt dbl)
+                     (case regime
+                       :off     "8 B/slot, compression OFF"
+                       :on      "4 B/slot, compression ON"
+                       :neither "*** NEITHER — the SMI arm is not measuring a tagged-slot copy ***"))))
         (let [sm (slope b (ctl-key "DBL" 100) 100 (ctl-key "DBL" 200) 200)
               lg (slope b (ctl-key "DBL" 1000) 1000 (ctl-key "DBL" 10000) 10000)
-              si (slope b (ctl-key "SMI" 100) 100 (ctl-key "SMI" 200) 200)]
+              si (:slope cal)]
           (println (gstring/format
                      ";;   DBL slope, SMALL pair (100->200)     %.4f B/double  predicted 8.0000  %+.2f%%"
                      sm (* 100.0 (/ (- sm 8.0) 8.0))))
           (println (gstring/format
                      ";;   DBL slope, LARGE pair (1000->10000)  %.4f B/double  predicted 8.0000  %+.2f%%   (page-tail filler; the arms here are all SMALL objects)"
                      lg (* 100.0 (/ (- lg 8.0) 8.0))))
+          ;; rf2-l3jv4 — the width is the one the RATIOS above selected, not
+          ;; one read off this slope. Selecting it from the slope cannot see a
+          ;; doubled slope at all: 16.1 simply answers "OFF" and is then
+          ;; compared to 8.
           (println (gstring/format
-                     ";;   SMI slope, SMALL pair (100->200)     %.4f B/slot    -> pointer compression %s   %+.2f%% off that width"
-                     si (if (< si 6.0) "ON (4 B/slot, Chrome-like)"
-                            "OFF (8 B/slot, Node default)")
-                     (let [w (if (< si 6.0) 4.0 8.0)] (* 100.0 (/ (- si w) w))))))
+                     ";;   SMI slope, SMALL pair (100->200)     %.4f B/slot    -> pointer compression %s   %s"
+                     si (case (:regime cal)
+                          :off     "OFF (8 B/slot, Node default)"
+                          :on      "ON (4 B/slot, Chrome-like)"
+                          :neither "UNREADABLE — the ratios above name no regime")
+                     (if-let [off (:off-by cal)]
+                       (gstring/format "%+.2f%% off that width" (* 100.0 off))
+                       "no width to check it against"))))
         (println ";;")
         ;; --- the floor -----------------------------------------------------
         (println ";; THE FLOOR — NOOP is the bare keep! loop, PREDICTED 0 B")
@@ -2057,6 +2088,16 @@
                                              (keep #(when (not= :floor (:status %)) (:label %))
                                                    verdicts))
                                    " — what those arms read is not the per-window floor.")])))))))
+        ;; rf2-l3jv4 — the CONTROL's refusal, independent of the arm order's.
+        ;; The order guard asks whether an arm's figure moved with where in
+        ;; the plan it sat; this asks whether the instrument was measuring a
+        ;; tagged-slot copy at all. Until this bead the answer only ever
+        ;; printed, so a run could report `NEITHER` above and still exit 0
+        ;; under a `VERDICT: reportable`.
+        (doseq [line (calib/report-lines cal)]
+          (println line))
+        (when (:refuse? cal)
+          (set! (.-exitCode js/process) 2))
         (let [total (reduce + (map (fn [[l _ _]] (:unverified (get res l))) plan))
               wins  (reduce + (map (fn [[l _ _]] (:windows (get res l))) plan))]
           (println ";;")

--- a/implementation/core/test/re_frame/bench/write_attribution.cljs
+++ b/implementation/core/test/re_frame/bench/write_attribution.cljs
@@ -121,6 +121,22 @@
       several rebuilds of it and is not re-litigated here. Both orders are
       still run, and both must now meet the prediction.
 
+  ## The control REFUSES, it does not merely comment
+
+  Finding that fault and fixing it left the instrument able to find it again
+  and carry on anyway: the SMI/DBL ratio printed `*** NEITHER — the SMI arm
+  is not measuring a tagged-slot copy ***` and nothing consumed it, so the
+  run exited 0 and the arm-order guard beside it printed `VERDICT:
+  reportable`. `re-frame.bench.calibration` turns that evidence into a
+  boolean, and this harness's exit code is now the OR of two independent
+  refusals — the arm order's and the control's. Its bands are expressed
+  there and nowhere else, so what is printed below and what refuses cannot
+  drift apart, and its [[re-frame.bench.calibration/self-test]] injects the
+  recorded 16.11 among other fixtures so the refusal branch is adjudicated
+  on every run rather than waiting for a broken machine. The DBL LARGE
+  pair's ~+9% is deliberately NOT gated: it is an understood large-object
+  effect and every arm here allocates small ones.
+
   ## The ladder
 
   Every arm below is a strict subset of the one under it, so subtracting
@@ -272,6 +288,7 @@
   (:require [goog.object :as gobj]
             [goog.string :as gstring]
             [goog.string.format]
+            [re-frame.bench.calibration :as calib]
             [re-frame.bench.order-guard :as guard]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -1357,6 +1374,11 @@
   ;; deterministic — exactly as `b8_run.cjs` does it.
   (when-not (guard/print-self-test!)
     (throw (ex-info "order guard self-test FAILED — nothing may be measured" {})))
+  ;; rf2-l3jv4 — and the SAME discipline for the control calibration, whose
+  ;; refusal is the other half of this run's exit code. Injected ratios,
+  ;; including the recorded 16.11 B/slot this bead was opened on.
+  (when-not (calib/print-self-test!)
+    (throw (ex-info "calibration self-test FAILED — nothing may be measured" {})))
   (let [n        (env-int "WA_N" 300)
         samples  (env-int "WA_SAMPLES" 40)
         warmup   (env-int "WA_WARMUP" 3)
@@ -1552,7 +1574,16 @@
                                          :rounds  rnd
                                          :dropped (get-in run [:dropped label] 0))]))
                        plan))
-          b    (fn [l] (:p50 (get res l)))]
+          b    (fn [l] (:p50 (get res l)))
+          ;; rf2-l3jv4 — the control's own verdict, computed ONCE from the
+          ;; same p50s the CONTROLS block prints, and carried to the exit
+          ;; code at the bottom of this function. The bands live in
+          ;; `re-frame.bench.calibration` and are expressed nowhere else, so
+          ;; what is printed and what refuses cannot drift apart.
+          cal  (calib/verdict
+                 (mapv (fn [d] {:d d :smi (b (ctl-key "SMI" d)) :dbl (b (ctl-key "DBL" d))})
+                       ctl-smi-ds)
+                 (slope b (ctl-key "SMI" 100) 100 (ctl-key "SMI" 200) 200))]
       (doseq [[label _ per] plan]
         (let [r   (get res label)
               rnd (:rounds r)]
@@ -1605,34 +1636,39 @@
               p (+ 32 16 (* 8 d))]
           (println (gstring/format ";;   DBL D=%-6d %12s B/copy   predicted %7d  %+.2f%%"
                            d (fmt m) p (* 100.0 (/ (- m p) p))))))
-      (doseq [d ctl-smi-ds]
-        (let [m (b (ctl-key "SMI" d))
-              r (b (ctl-key "DBL" d))]
-          (println (gstring/format
-                     ";;   SMI D=%-6d %12s B/copy   x%.4f of DBL D=%d (%s B)  -> %s"
-                     d (fmt m) (/ m r) d (fmt r)
-                     (cond
-                       (< 0.95 (/ m r) 1.05) "8 B/slot, compression OFF"
-                       (< 0.45 (/ m r) 0.55) "4 B/slot, compression ON"
-                       :else                 "*** NEITHER — the SMI arm is not measuring a tagged-slot copy ***")))))
+      (doseq [{:keys [d smi dbl ratio regime]} (:pairs cal)]
+        (println (gstring/format
+                   ";;   SMI D=%-6d %12s B/copy   x%.4f of DBL D=%d (%s B)  -> %s"
+                   d (fmt smi) ratio d (fmt dbl)
+                   (case regime
+                     :off     "8 B/slot, compression OFF"
+                     :on      "4 B/slot, compression ON"
+                     :neither "*** NEITHER — the SMI arm is not measuring a tagged-slot copy ***"))))
       (let [sm (slope b (ctl-key "DBL" 100) 100 (ctl-key "DBL" 200) 200)
             lg (slope b (ctl-key "DBL" 1000) 1000 (ctl-key "DBL" 10000) 10000)
-            si (slope b (ctl-key "SMI" 100) 100 (ctl-key "SMI" 200) 200)]
+            si (:slope cal)]
         (println (gstring/format
                    ";;   DBL slope, SMALL pair (100->200)     %.4f B/double  predicted 8.0000  %+.2f%%"
                    sm (* 100.0 (/ (- sm 8.0) 8.0))))
         (println (gstring/format
                    ";;   DBL slope, LARGE pair (1000->10000)  %.4f B/double  predicted 8.0000  %+.2f%%"
                    lg (* 100.0 (/ (- lg 8.0) 8.0))))
-        ;; rf2-l3jv4 — the regime is READ off this slope, so it cannot also be
+        ;; rf2-l3jv4 — the regime is READ off this pair, so it cannot also be
         ;; predicted from an assumed slot width. What CAN be checked, without
         ;; circularity, is how close the slope sits to the exact width of the
-        ;; regime it just selected: a tagged slot is 8 bytes or 4, never 16.1.
+        ;; regime THE RATIOS ABOVE selected: a tagged slot is 8 bytes or 4,
+        ;; never 16.1. Selecting the width from the slope itself — which is
+        ;; what this line used to do — cannot see a doubled slope at all,
+        ;; because 16.1 simply answers "OFF" and is then compared to 8.
         (println (gstring/format
-                   ";;   SMI slope, SMALL pair (100->200)     %.4f B/slot    -> pointer compression %s   %+.2f%% off that width"
-                   si (if (< si 6.0) "ON (4 B/slot, Chrome-like)"
-                          "OFF (8 B/slot, Node default)")
-                   (let [w (if (< si 6.0) 4.0 8.0)] (* 100.0 (/ (- si w) w))))))
+                   ";;   SMI slope, SMALL pair (100->200)     %.4f B/slot    -> pointer compression %s   %s"
+                   si (case (:regime cal)
+                        :off     "OFF (8 B/slot, Node default)"
+                        :on      "ON (4 B/slot, Chrome-like)"
+                        :neither "UNREADABLE — the ratios above name no regime")
+                   (if-let [off (:off-by cal)]
+                     (gstring/format "%+.2f%% off that width" (* 100.0 off))
+                     "no width to check it against"))))
       (println ";;")
       (println ";; THE LADDER — bytes per WRITE")
       (doseq [[lbl v] [["MKDB      the application's own new-db value" (b "MKDB")]
@@ -1781,10 +1817,16 @@
           (println (str ";;     result in a register; PROBE 5 shows a second live caller does NOT restore"))
           (println (str ";;     it. So this figure is an UPPER BOUND — the cost this plan pays and a"))
           (println (str ";;     single-arm process does not. Quote it as <=, with the runtime named."))))
-      ;; --- arm order, LAST, and it governs everything above ----------------
-      ;; The figures are printed and the refusal is about what may be QUOTED,
-      ;; not about throwing the measurement away — so the exit code carries
-      ;; it rather than an exception.
+      ;; --- the two refusals, LAST, and together they govern everything
+      ;; above. The figures are printed and a refusal is about what may be
+      ;; QUOTED, not about throwing the measurement away — so the exit code
+      ;; carries it rather than an exception.
+      ;;
+      ;; rf2-l3jv4 — there are TWO of them and they are independent. The arm
+      ;; order asks whether an arm's figure moved with where in the plan it
+      ;; sat; the calibration asks whether the instrument was measuring a
+      ;; tagged-slot copy at all. A run that fails either is not reportable,
+      ;; and until this bead the second one only ever printed.
       (println ";;")
       (let [v (guard/verdict (:order run) {:tolerance tolerance})]
         (doseq [line (guard/report-lines v "the per-arm figure, one p50 per round")]
@@ -1796,7 +1838,10 @@
                         "in the run"))
           (println (str ";;   it was measured (rf2-88pie). The table above stands as raw data; "
                         "nothing in it"))
-          (println ";;   may be quoted.")
+          (println ";;   may be quoted."))
+        (doseq [line (calib/report-lines cal)]
+          (println line))
+        (when (or (:refuse? v) (:refuse? cal))
           (set! (.-exitCode js/process) 2))))
     (println (gstring/format ";; sink %s %s" @sink (some? @sink2)))))
 


### PR DESCRIPTION
Two instruments were reading roughly 2× what their own model predicted. In one
the instrument was wrong; in the other the model was. Both are settled here, and
neither needed a timing figure.

## rf2-l3jv4 — the SMI control: the INSTRUMENT was wrong, and it still could not refuse

The 2× itself was already settled, in `4231917178`: `arm-ctl` was ONE function
body closed over both template kinds, so the harness had a single polymorphic
`.slice()` call site that saw both `PACKED_SMI_ELEMENTS` and
`PACKED_DOUBLE_ELEMENTS` receivers. At that site the SMI receiver loses
`.slice()`'s clone fast path and allocates its elements store **twice** — 16.11
B/slot against a tagged slot's 8. Splitting the site per elements kind returned
it to 8.0. **The prediction was right; the instrument was not.**

What that left is what the merged-PR audits of #7230 and #7238 reopened this
owner for, and it is what this PR fixes. Both harnesses printed

```
*** NEITHER — the SMI arm is not measuring a tagged-slot copy ***
```

and then carried on. Nothing consumed it. Exit code 2 was reachable only through
the arm-order refusal (and, in `read_attribution_cljs`, the read-back), so the
exact recurrence the control exists to catch could still end in **exit 0 under a
`VERDICT: reportable`**. The failure branch had been introduced and never
adjudicated, because every gate on record ran values inside the bands.

`re-frame.bench.calibration` (new, `.cljc`) turns the evidence the harnesses
already computed into a boolean. Three checks, all
measurement-against-measurement — no header is asserted anywhere:

1. every SMI/DBL ratio at the same D must name a regime (≈1.00 → 8 B/slot,
   ≈0.50 → 4 B/slot);
2. the sizes must name the **same** regime — one instrument, one machine;
3. the SMI slope must sit within 25% of the exact slot width **those ratios**
   selected. Selecting the width from the slope itself, which is what both
   harnesses used to do, cannot see a doubled slope at all: 16.1 simply answers
   "OFF" and is then compared to 8.

The bands live in that namespace and nowhere else, so the `CONTROLS` block's
printed verdict and the refusal are the same expression and cannot drift. Both
harnesses now exit 2 on the OR of their refusals, and both run the calibration
self-test before measuring, exactly as they already do for the order guard.

**Deliberately NOT gated:** the DBL LARGE pair's ~+9%. It is V8's page-tail
filler on an 87 KB object, it is understood, and every arm these harnesses
measure allocates small ones. A fixture pins that a +9% reading does not refuse.

## rf2-2rtt6.61 — the memo wrapper: the PREDICTION was wrong, and no fiber count was needed

The bead asked for a heap snapshot classifying `FiberNode` by tag, to test the
published hypothesis that the ~2× between the two heap instruments
(`chrome_run.cjs` at +195/+220 B per boundary, `p0_run.cjs --only ladder` at
+100/+106 B) was React's double buffering.

**The count is not needed. The hypothesis's premise is false, and the
instruments' own committed source says so.**

The hypothesis rested on the page-chrome rig performing its four write ops before
reading heap, so an updated component would retain an `alternate` fiber beside
its current one. It does not:

- `chrome_run.cjs:242-243` — `// ---- the heap half, first, on a quiet page`,
  then `heap = await heapForArms(page, cdp, ARMS, HEAP_ROUNDS);`. The clock
  half's `runOp` calls do not begin until line 264.
- `chrome_run.cjs:164-182` — `heapOnce` is `resetRuntime` → baseline
  `collectAndRead` → `mountArm` → held `collectAndRead`. Nothing between the
  mount and the read.
- The ordering is present at `cb179b6b3c`, the commit that published the
  +195/+220 rows, verified with `git show cb179b6b3c:…` — so those figures were
  taken on a held tree.
- `p0_run.cjs:588-593` — `gc(); pre = read(); mountOne(entry); gc(); held =
  read();`. Mount and hold, as always claimed.

**Both instruments mount and hold.** Double buffering cannot be what separates
them, and the general rule the bead proposed — *a memo wrapper costs ONE fiber on
a held tree and TWO on a tree that has been updated* — is **not** adopted: no
measurement on this programme has read an updated tree's wrapper at all.

Corrected in all three places it was published — the ladder's own subsection,
the page-chrome page's 2026-08-02 correction block, and HD-028 in
`decisions.md` — with the prior wording struck through rather than deleted, per
this tree's rule that corrections are recorded. **Every measured figure stands.**
Only the account of *why* the two disagree was wrong, and the ruling's practical
reading is untouched: a Fiber is not a fixed tax, and the shape it sits on
decides what it costs.

The ~2× itself remains open as **rf2-2rtt6.79**, which asks the fiber count on a
different question: whether the wrapper is ONE fiber on both shapes, in which
case the difference is in what a fiber *holds* rather than in how many there are.
That bead records that no snapshot-classification capability exists anywhere
under `implementation/` (the nearest, `reads_ladder_run.cjs`'s `snapshotTotal`,
sums `self_size` and never reads the strings table), so it is a new instrument
rather than a flag. It is structural, not a clock — no quiet box needed.

## Quality gates

| gate | exit | note |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **`FAIL`** | classified `docs=true jvm=true node=true`. Stopped at `implementation JS harness helpers` on a **transient Windows temp-dir `EPERM`** — see below |
| ↳ `mkdocs build --strict` (in-spine) | `0` | `Documentation built in 28.91 seconds` |
| ↳ JVM `implementation/core` (in-spine) | `0` | `Ran 2210 tests containing 11510 assertions. 0 failures, 0 errors.` |
| `npm run test:script-helpers` (re-run standalone) | `0` | the failing step, whole chain, **zero `FAIL` lines** |
| `node scripts/_local-browser-harness.test.cjs` (re-run alone) | `0` | `local-browser-harness tests: 44 passed.` |
| `npm run test:cljs` | `0` | `Ran 12481 tests containing 62578 assertions. 0 failures, 0 errors.` |
| `node scripts/check-per-ns-isolation.cjs --self-test` | `0` | `all self-tests passed.` |
| `node scripts/check-per-ns-isolation.cjs` | `0` | `per-ns isolation: all 17 namespace(s) pass standalone.` |
| `npm run test:hicasso-compile` | `0` | `101 lane namespaces compiled with zero warnings` |
| `python scripts/check_doc_slugs.py` | `0` | the gate that actually covers `docs/design/**` |
| `npx shadow-cljs compile ui-bench --config-merge '{:main re-frame.bench.write-attribution/-main …}'` | `0` | `Build completed. (131 files, 130 compiled, 4 warnings)` — the 4 are pre-existing `:infer-warning`s in `spine.cljs` |
| `npx shadow-cljs compile ui-bench --config-merge '{:main re-frame.bench.read-attribution-cljs/-main …}'` | `0` | `Build completed. (131 files, 2 compiled, 4 warnings)` |

**The spine's one red, and why it is not this diff's.** It failed in
`scripts/_local-browser-harness.test.cjs`, on the case *"startLocalHttpServer
cleanup removes only THIS run's ownership token"*:

```
Error: EPERM, Permission denied: \\?\C:\Users\miket\AppData\Local\Temp\rf2-slh-FQRSQK
    at Object.rmSync (node:fs:1235:18)
    at rmTmp (…\scripts\_local-browser-harness.test.cjs:740:6)
```

That is an `rmSync` on a directory under the **shared machine `%TEMP%`** — a root
every concurrent worker on this box writes into — and this diff cannot reach it:
it touches four files under `implementation/core/test/re_frame/bench/` and three
markdown files under `docs/design/hicasso/`, none of which
`_local-browser-harness.test.cjs` or `_local-browser-harness.cjs` reads. Confirmed
by re-running the single test alone (44 passed, exit 0) and then the entire
`test:script-helpers` chain (exit 0, zero `FAIL` lines).

The spine stops on first failure, so it never reached its node tier. **Every step
it did not reach was run by hand** — the four rows above `check_doc_slugs.py` —
and all are green, which is why the individual gates rather than a spine `PASS`
line are what this section stands on.

**A note on the runner's exit code.** The spine exceeded my tool's wall-clock cap
and was detached; the harness then reported it as *"completed (exit code 0)"*
while the log's own terminal marker read `FAIL implementation JS harness
helpers`. The log won. Everything above is quoted from a runner's own terminal
marker, never from a wrapper's exit status.

**Why the two explicit harness compiles.** `implementation/core/test` is on the
`:node-test` classpath, so the new `calibration.cljc` and its test are compiled
and run by `npm run test:cljs` — but nothing requires `write_attribution` or
`read_attribution_cljs`, so a break in either would be invisible to every gate in
the spine. Both are therefore compiled explicitly. `:simple` rather than
`:advanced`, because the question asked is "does it compile", not "what does it
measure".

**`mkdocs build --strict` does not cover `docs/design/**`** — `mkdocs.yml`
excludes the tree. `check_doc_slugs.py` (which runs in the spine and in
`docs.yml`) validates its link targets and heading anchors, and it passes. Table
column counts and anchors were checked by hand as the tree requires: **the doc
diff adds and modifies no table rows at all** (`git diff -U0 -- docs/ | grep -E
'^\+.*\|'` is empty), and no heading was renamed — the two anchors linked from
elsewhere, `#the-memo-wrapper-priced-on-this-rung-rf2-2rtt658` and
`#what-200-b-means-depends-on-the-boundary-shape-and-both-readings-are-true`,
are untouched.

**No timing figure was taken or published**, per the dispatch. Both beads are
bytes and structure: rf2-l3jv4 is heap bytes read from committed source and
adjudicated by pure fixtures, rf2-2rtt6.61 is settled entirely from committed
instrument source and `git show` at the publishing commit. Neither harness was
run.

### Mutation proof (`npm run test:cljs`, a gated suite)

`re-frame.bench.calibration/slope-tolerance` `0.25` → `2.0`, one character class,
nothing else touched.

**Predicted before running:** 8 assertion failures — 6 in
`the-slope-is-checked-against-the-width-the-ratios-selected` (slopes 10.1, 12.5,
16.1146 and 4.0 against a width of 8; 5.1 and 8.0 against a width of 4, all
expected to refuse and no longer doing so) and 2 in `self-test-passes` (the
injected `slope-bad` fixture, plus the `:ok?` roll-up). No other test may move.

**Observed:** exit 1, `8 failures, 0 errors`, in exactly those two deftests at
exactly those line numbers, out of 12,481 tests. Reverted byte-identically; the
suite returns to exit 0. This also proves the new namespace is genuinely being
run by `npm run test:cljs` rather than silently excluded by the `cljs-test$`
ns-regexp — the earlier green was real.

### Log provenance

Every log quoted here is my own: all written to `l3jv4-*.log` **inside my own
worktree** (`*.log` is gitignored, so no residue), never to the shared agent
scratchpad. Each was confirmed to carry its runner's own terminal marker — the
`Build completed.` line for the two compiles, the `Ran N tests … failures,
errors` line for the suites — rather than being trusted on an exit code alone.
