### PR TITLE
docs(hicasso): restate the cold-read mount term's stale figures (rf2-gttif)

### DIFF
--- a/docs/design/hicasso/studio/the-cold-read-mount-term.md
+++ b/docs/design/hicasso/studio/the-cold-read-mount-term.md
@@ -66,7 +66,7 @@ interleave, adjudicated before anything is read.
 `commit-boundary!` seam; four identically-seeded frames per window; released
 and settled between samples behind a residue equality gate that never fired):
 
-| term | delta ms/commit | share |
+| term | delta ms/commit | share of `c-local` |
 |---|---|---|
 | whole commit (`commit`, shipping seam) | 0.8875 [0.8000–1.0750] | — (6.29 µs/key; copy fidelity c-local/commit = 0.9718) |
 | — **reaction build + cache insert** (`c-local − c-nosub`) | **0.4125** | **47.8%** |
@@ -74,6 +74,23 @@ and settled between samples behind a residue equality gate that never fired):
 | — cell-map insert (`c-local − c-nomap`) | 0.0375 | 4.3% |
 | — watch wiring (`c-local − c-nowatch`) | 0.0250 | 2.9% |
 | `b-build` (141 × subscribe + deref, no in-window dispose) | 0.6000 | context: build + compute alone |
+
+> **These rows are dated `cb41ee537b`, and one change has landed under them**
+> (rf2-gttif). `rf2-aqgr2` (`f7fd0c6a52`) stopped the runtime minting a
+> `Keyword` per key cell — 141 mints per commit on this shape — so **0.8875
+> and 6.29 µs/key are now upper bounds** on the shipping seam, and the shares,
+> which divide by `c-local` (0.8625 here), are lower bounds by the same term:
+> the copy carried that mint too, until `rf2-6wh9o` (`54a2a78924`) removed it
+> there as well. The term is small — 141 mints against a phase-B grid that
+> resolves to 0.025 ms/commit, and the nearest anchor in the micro table below
+> is 53 ns for a two-element vector — so it is about one quantum, and only a
+> re-take on a quiet box settles it (`rf2-d360z`). **The four deltas do not
+> move at all**: the mint was bound above `commit-local!`'s `C-NOWATCH` guard
+> and present in every mode, so it stood on both sides of each and cancelled
+> exactly. **Nor does the fidelity ratio** — both arms carried the mint and
+> both have since lost it, so it is common-mode there too; and the copy is
+> once again *structurally* identical to the seam it prices, which warrants
+> the `c-*` ablations better than a clock agreement on its own ever did.
 
 Micro table, over the page's own roster (ns/op): `subscribe-once` 5,284;
 `compute-sub` 1,170; the raw handler invoke 227; `registrar/lookup` 67;
@@ -245,7 +262,10 @@ resolve and peek), and the honest next rung — 0.89 µs/read — belongs to
 its fences. The commit half re-read 0.7625 ms [0.5750–1.0250] with the same
 decomposition as before (reaction build + cache insert 51.9%, index write
 5.6%, watch wiring 3.7%, cell-map insert on the quantum), and stays as
-designed: the durable wiring, amortised over the mount.
+designed: the durable wiring, amortised over the mount. That re-read is
+`0c0ff21f0d`'s and carries §1's staleness for the same reason — the per-cell
+keyword mint was still on both arms — so it is an upper bound and its shares
+lower bounds, by the same about-one-quantum term.
 
 ## 5. The parity gap the re-take tripped over — found, bisected, repaired
 

--- a/docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md
+++ b/docs/design/hicasso/studio/the-in-page-mount-term-decomposed.md
@@ -270,6 +270,12 @@ within box drift (this box is demonstrably noisier — §8), and their sum,
 regressed since `rf2-6c237` landed its 0.49×, and nothing has improved
 either.
 
+*Both commit-half figures in that table predate `rf2-aqgr2` (`f7fd0c6a52`,
+2026-08-03 12:58), which stopped the runtime minting a `Keyword` per key
+cell — this run closed at 05:28 and `rf2-6c237`'s at 21:43 the night before.
+The comparison is therefore still like for like, but 0.827 and 0.7625 are
+both upper bounds on today's seam (rf2-gttif).*
+
 **(c) By counterfactual, on our own arm.** The decisive arm. `coarse` is the
 candidate's page reading **the twin's five coarse subscriptions** at five
 fixed sites, cards rendered from the collections — byte-identical DOM, five


### PR DESCRIPTION
Closes rf2-gttif.

`the-cold-read-mount-term.md` §1's commit-half table was taken at
`cb41ee537b`, before **rf2-aqgr2** (`f7fd0c6a52`, 2026-08-03 12:58) stopped
`arm1/runtime.cljs` minting a `Keyword` per key cell, and before **rf2-6wh9o**
(`54a2a78924`, 14:15) removed the mirror mint from `commit-local!`. Both arms
of that table are cheaper today than the page reports.

**No measurement was taken and no bench driver was run.** Every figure below
is restated from the merged commits and the page's own arithmetic, on the
brief's quiet-box discipline.

## What changed

| figure | before | after |
|---|---|---|
| `commit` p50 | `0.8875 [0.8000–1.0750]` ms/commit | unchanged, stamped **upper bound** |
| `commit` per key | `6.29 µs/key` | unchanged, stamped **upper bound** |
| share column header | `share` | ``share of `c-local` `` |
| shares `47.8 / 8.7 / 4.3 / 2.9%` | unchanged | stamped **lower bounds** |
| copy fidelity `c-local/commit` | `0.9718` | **unchanged and it STANDS** — see below |
| §4 commit-half re-read `0.7625` + `51.9/5.6/3.7%` | unchanged | same one-sentence stamp |

## The four phase-B deltas really do cancel — confirmed against the diff

`0.4125 / 0.0750 / 0.0375 / 0.0250` do **not** move. In the pre-`54a2a78924`
`commit-local!`, `wk` was bound in the `let`, *above* the
`(when-not (identical? mode C-NOWATCH) …)` guard, and `"watchKey" wk` sat on
the cell object in **every** mode — including `C-NOSUB`, where `r` is `nil`
and `add-watch` is never reached. So the mint stood on both sides of each of
the four `c-local − variant` deltas and cancelled exactly. Read off the
`54a2a78924` diff, not inferred.

## But one more row moves than the bead expected — the SHARE column

rf2-6wh9o's close reason says "no published clock row moves". That is true of
the four delta **values** and *not* of the shares derived from them.
`delta-line` computes `(/ d base)` where `base` is **`c-local`**, not the
whole commit — and `c-local` carried the same mint until `54a2a78924`, so its
absolute moved and every share is a lower bound. Confirmed two ways:

* from the instrument — `delta-line`'s `base` argument is `clocal` at
  `read_profile_app.cljs:663-666`;
* from the arithmetic — `0.4125 / 0.478 = 0.8630` and
  `0.9718 × 0.8875 = 0.8625`, two independent recoveries of the same
  unpublished `c-local`, both landing on the instrument's `0.025` ms grid.

The column header now names the denominator, which is also a plain clarity
win: nothing on the page said the shares were not shares of the whole commit.

## A figure that got STRONGER: the copy-fidelity ratio

`0.9718` is **retained, not withdrawn, and its warrant is better than it
was.** The mint sat on *both* arms when the ratio was taken and *both* have
since lost it (`f7fd0c6a52` from `commit`, `54a2a78924` from `c-local`), so
the perturbation is common-mode and cancels in the ratio for exactly the
reason it cancels in the four deltas. And rf2-6wh9o restored the copy to
*structural* identity with the seam, which warrants the `c-*` ablations
better than a clock agreement on its own ever did. The window in which the
ratio was genuinely broken is `f7fd0c6a52 → 54a2a78924` — denominator
re-based, numerator not — and that window is closed.

## Nothing retracted

The commit row is a real reading of a real commit; what was stale is what it
claimed about *today*. A provenance stamp plus a stated direction is the
honest repair (and the route the bead itself offers), so no figure is
withdrawn and no replacement is minted.

## Size of the drift, so nobody over-invests

141 keyword mints per commit against a phase-B grid that resolves to
**0.025 ms/commit** — the raw `0.1` ms coarsened `performance.now` divided by
the window's 4 frames; every published phase-B p50 lands on that grid or a
half-step of it (`0.8000`=32, `1.0750`=43, `0.8875`=35.5, `0.6000`=24, and
the implied `c-local` `0.8625`=34.5). The instrument's own micro table prices
its nearest anchor — a two-element vector mint — at **53 ns**. So the term is
about **one quantum** and may not be resolvable on this clock at all.

## Second site — grepped, and there is one

`the-in-page-mount-term-decomposed.md` §6(b) quotes the `0.7625` beside its
own `0.827`. Its run closed **2026-08-03 05:28**, seven hours before
`f7fd0c6a52`, so that comparison is still like for like — but both absolutes
are pre-mint-removal upper bounds, and it now says so in one sentence. Full
sweep of `0.8875` / `0.9718` / `6.29` / `0.7625` / `47.8%` / `51.9%` /
`copy fidelity` / `c-local` across tracked `.md` found no third site.

## Bead filed

**rf2-d360z** (P3, `discovered-from: rf2-gttif`) — re-take phase B's `commit`
and `c-local` arms and restate the two absolutes plus both share columns,
with the **quiet-box precondition** in the rf2-0qj9w / rf2-2rtt6.76 wording.
It says explicitly that the four deltas and the fidelity ratio need no
re-take, that the instrument must not be edited to chase this, and that a
result inside the quantum is a good result.

## Hand-verified, because nothing automated covers this tree

`mkdocs build --strict` runs in the spine and **verifies nothing of this
edit** — `exclude_docs` drops `design/hicasso/`. So, by hand:

* **Anchors** — `the-cold-read-mount-term.md`: **2 outbound** links (both
  bare `.md`, no fragment), **1 inbound** (from
  `the-route-link-render-term-priced.md:16`, no fragment).
  `the-in-page-mount-term-decomposed.md`: **0 outbound**, **1 inbound**
  (studio `README.md:112`, no fragment). **0 dead.** No heading was added,
  removed or reworded on either page, and **0** anchor fragments exist
  anywhere in play — so the GitHub-vs-python-markdown hyphen-run slug
  divergence cannot bite here.
* **Tables** — cold-read page **8 tables**, in-page page **10 tables**,
  header / separator / every data row column-counted: **0 mismatches**. The
  one table touched (§1 commit half) keeps 3 columns; the change is one
  header cell's text.
* Noted but **not** actioned (pre-existing, out of scope): the studio
  `README.md` index has **no row at all** for `the-cold-read-mount-term.md`.

## Quality gates

| gate | exit | marker |
|---|---|---|
| `python scripts/check_doc_slugs.py` | **0** | clean, no output |
| `sh scripts/test-fast-pr.sh` | **0** | runner's own terminal marker `PASS fast PR spine` |

Both foreground, to completion, in this worktree
(`WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/coldread-gttif`,
guard `OK`). The spine classified the diff `docs=true jvm=false node=false`,
which matches this diff exactly — two files, both `docs/design/hicasso/`.
No instrument, bench app or test was edited.
