### PR TITLE
fix(scripts): the spine must name the root it resolved (rf2-g2mxd)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,19 @@ sh scripts/remove-worker-worktree.sh <worktree-path>   # POSIX (primary)
 # Windows: powershell -ExecutionPolicy Bypass -File scripts/remove-worker-worktree.ps1 <worktree-path>
 ```
 
+## A Backgrounded Gate Runs by Absolute Path — or in Someone Else's Worktree
+
+Every gate script under `scripts/` derives its repo root from
+`${BASH_SOURCE[0]}`, which is relative when the invocation is — and a
+`cd <worktree> && sh scripts/…` does not reliably keep that `cd` once
+backgrounded, so the run adopts whatever cwd the shell really has. One did
+exactly that inside *another live worker's* checkout: it took that tree as its
+spine root, its diff root and its classifier input, then reported the resulting
+verdict as its own. A complete, internally consistent run about somebody else's
+work is far harder to catch than a broken one, so every gate prints
+`gate root: <path>` as its first line — check that line against your worktree
+before believing any colour.
+
 ## Gate Artefacts Go Where Git Ignores Them
 
 Never pipe a gate through `tail`, `head` or `grep` — a pipeline's exit status is
@@ -59,7 +72,7 @@ artefact that produces — the log *and* the exit-code file — must land on an
 ignored path; `*.log`, `*.exit` and `*-exit.txt` all are:
 
 ```bash
-sh scripts/test-fast-pr.sh > gate-fastpr.log 2>&1; echo "$?" > gate-fastpr.exit
+sh <WORKTREE_ROOT>/scripts/test-fast-pr.sh > gate-fastpr.log 2>&1; echo "$?" > gate-fastpr.exit
 ```
 
 A single untracked leftover makes `git worktree remove` refuse the tree from

--- a/docs/the-mayor-method/dispatch-prompt-template.md
+++ b/docs/the-mayor-method/dispatch-prompt-template.md
@@ -92,7 +92,7 @@ relying on CI"). A silent skip fails review.
 
 ### How a gate is run, not just which one
 
-Three rules about the mechanics. Each is here because it cost real hours, and
+Four rules about the mechanics. Each is here because it cost real hours, and
 none of them is obvious from the gate command itself.
 
 - **Foreground, to completion.** A worker that backgrounds a long gate and ends
@@ -103,6 +103,16 @@ none of them is obvious from the gate command itself.
   every one recovered intact the moment somebody asked it for a status. If you
   background a gate anyway, **poll its log on a timer**; never end a turn
   waiting to be woken.
+- **Invoke a backgrounded gate by its ABSOLUTE path.** The gate scripts derive
+  their repo root from `${BASH_SOURCE[0]}`, which is relative when the
+  invocation is — and a `cd <worktree> && sh scripts/…` does not reliably keep
+  that `cd` once backgrounded, so the run adopts whatever cwd the shell really
+  has. One did exactly that inside *another live worker's* checkout: it took
+  that tree as its spine root, its diff root and its classifier input, then
+  reported the resulting verdict as its own. A complete, internally consistent
+  run about somebody else's work is far harder to catch than a broken one, so
+  every gate now prints `gate root: <path>` as its first line — **check that
+  line against your worktree before believing any colour.**
 - **Never pipe a gate through `tail`, `head` or `grep`.** A pipeline's exit
   status is its *last* command's, so a red runner reads green and the PR claims
   a pass it never got. Redirect to a log file, echo the runner's own exit code
@@ -112,7 +122,7 @@ none of them is obvious from the gate command itself.
   behind:
 
   ```bash
-  sh scripts/test-fast-pr.sh > gate-fastpr.log 2>&1; echo "$?" > gate-fastpr.exit
+  sh <WORKTREE_ROOT>/scripts/test-fast-pr.sh > gate-fastpr.log 2>&1; echo "$?" > gate-fastpr.exit
   ```
 
   Saying only "put the log somewhere ignored" is the trap: a worker satisfies it

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -118,6 +118,13 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# First line names the tree this run resolved — see scripts/test-fast-pr.sh
+# (rf2-g2mxd): a relative invocation resolves `${BASH_SOURCE[0]}` against the
+# shell's actual cwd, so a backgrounded gate can silently run in, and grade,
+# another worktree.  Invoke backgrounded gates by ABSOLUTE path.
+printf 'gate root: %s\n' "$repo_root"
+
 core="$repo_root/implementation/core"
 test_root="$core/test"
 

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -99,6 +99,20 @@ spine_root="$(cd "$script_dir/.." && pwd)"
 diff_root="$spine_root"
 classifier="$spine_root/.github/scripts/report-changed-surfaces.sh"
 
+# NAME THE TREE, FIRST LINE, ALWAYS (rf2-g2mxd).  That derivation is why an
+# INVOCATION PATH can silently retarget the whole gate: `${BASH_SOURCE[0]}` is
+# relative when the invocation is, so `dirname` resolves it against whatever
+# cwd the shell actually has — and a `cd <worktree> && sh scripts/…` does not
+# always survive backgrounding.  On 2026-08-03 a worker's spine ran end to end
+# inside a DIFFERENT live worker's checkout: it took that tree as its spine
+# root, its diff root and its classifier input, graded that worker's diff, and
+# reported the verdict in this one's PR body.  A complete, internally
+# consistent run about the wrong work — the only visible trace was a foreign
+# path in an mkdocs INFO line ninety lines down.  One line at the top turns
+# that into something a human or an agent sees immediately, and greps for.
+# The fix at the call site is to invoke a backgrounded gate by ABSOLUTE path.
+printf 'gate root: %s\n' "$spine_root"
+
 with_docs="auto"     # auto | force | skip
 run_all=false
 plan_only=false

--- a/scripts/test-freehand-prod-gate.sh
+++ b/scripts/test-freehand-prod-gate.sh
@@ -91,6 +91,13 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# First line names the tree this run resolved — see scripts/test-fast-pr.sh
+# (rf2-g2mxd): a relative invocation resolves `${BASH_SOURCE[0]}` against the
+# shell's actual cwd, so a backgrounded gate can silently run in, and grade,
+# another worktree.  Invoke backgrounded gates by ABSOLUTE path.
+printf 'gate root: %s\n' "$repo_root"
+
 artefact="$repo_root/implementation/freehand"
 test_root="$artefact/test"
 

--- a/scripts/test-jvm-implementation.sh
+++ b/scripts/test-jvm-implementation.sh
@@ -3,6 +3,14 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# First line names the tree this run resolved (rf2-g2mxd).  A relative
+# invocation resolves `${BASH_SOURCE[0]}` against the shell's actual cwd, which
+# a backgrounded `cd <worktree> && sh scripts/…` does not reliably set — so a
+# gate can grade another worktree's diff and look entirely normal doing it.
+# See scripts/test-fast-pr.sh for the incident; invoke backgrounded gates by
+# ABSOLUTE path.
+printf 'gate root: %s\n' "$repo_root"
+
 artefacts=(
   implementation/core
   implementation/adapters/reagent

--- a/scripts/test-jvm-tools.sh
+++ b/scripts/test-jvm-tools.sh
@@ -3,6 +3,12 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# First line names the tree this run resolved — see scripts/test-fast-pr.sh
+# (rf2-g2mxd): a relative invocation resolves `${BASH_SOURCE[0]}` against the
+# shell's actual cwd, so a backgrounded gate can silently run in, and grade,
+# another worktree.  Invoke backgrounded gates by ABSOLUTE path.
+printf 'gate root: %s\n' "$repo_root"
+
 tools=(
   tools/xray
   # rf2-wq17m — 632 tests / 2537 assertions. 29 of its 31 suites are

--- a/scripts/test-rigorous-local.sh
+++ b/scripts/test-rigorous-local.sh
@@ -3,6 +3,12 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# First line names the tree this run resolved — see scripts/test-fast-pr.sh
+# (rf2-g2mxd): a relative invocation resolves `${BASH_SOURCE[0]}` against the
+# shell's actual cwd, so a backgrounded gate can silently run in, and grade,
+# another worktree.  Invoke backgrounded gates by ABSOLUTE path.
+printf 'gate root: %s\n' "$repo_root"
+
 "$repo_root/scripts/test-fast-pr.sh"
 "$repo_root/scripts/test-jvm-implementation.sh"
 "$repo_root/scripts/test-jvm-tools.sh"

--- a/scripts/test-routing-prod-gate.sh
+++ b/scripts/test-routing-prod-gate.sh
@@ -75,6 +75,13 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# First line names the tree this run resolved — see scripts/test-fast-pr.sh
+# (rf2-g2mxd): a relative invocation resolves `${BASH_SOURCE[0]}` against the
+# shell's actual cwd, so a backgrounded gate can silently run in, and grade,
+# another worktree.  Invoke backgrounded gates by ABSOLUTE path.
+printf 'gate root: %s\n' "$repo_root"
+
 artefact="$repo_root/implementation/routing"
 test_root="$artefact/test"
 

--- a/scripts/test-ssr-prod-gate.sh
+++ b/scripts/test-ssr-prod-gate.sh
@@ -96,6 +96,13 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# First line names the tree this run resolved — see scripts/test-fast-pr.sh
+# (rf2-g2mxd): a relative invocation resolves `${BASH_SOURCE[0]}` against the
+# shell's actual cwd, so a backgrounded gate can silently run in, and grade,
+# another worktree.  Invoke backgrounded gates by ABSOLUTE path.
+printf 'gate root: %s\n' "$repo_root"
+
 artefact="$repo_root/implementation/ssr"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes rf2-g2mxd.

## What went wrong

A worker backgrounded its spine as `cd <its own worktree> && sh scripts/test-fast-pr.sh`.
The `cd` did not survive backgrounding. `scripts/test-fast-pr.sh:97-99` derives
`spine_root` / `diff_root` from `${BASH_SOURCE[0]}`, which is **relative when the
invocation is** — so `dirname` resolved against whatever cwd the shell actually had.
The run executed end to end inside a **different live worker's checkout**: that tree
became its spine root, its diff root and its classifier input. It graded that
worker's diff and reported the verdict as its own, and became a second concurrent
spine in a live checkout (13 phantom `test_quiet_shadow_node_cljs_test` failures).

The only visible trace was a foreign path in an mkdocs INFO line **ninety lines
down**. That is what makes this worse than an ordinary false green: the run is
complete and internally consistent, and every line of it is about the wrong work.

## The fix

All eight gate scripts under `scripts/` now print their resolved root as **line 1**:

```
gate root: /c/Users/miket/code/re-frame2-worktrees/spineroot-g2mxd
```

That is the whole mechanism. **No cwd validation, no lock file, no worktree-identity
assertion** — nothing that could refuse a legitimate run. An echoed root a human or
an agent can check beats a guard that guesses wrong and blocks work, and a script
whose job is to report failure modes should not acquire one of its own. The
call-site fix is to invoke a backgrounded gate by absolute path.

## How many scripts shared the pattern

Eight, not one — every gate script under `scripts/`, all fixed here:

| script | derivation |
| --- | --- |
| `test-fast-pr.sh` | `script_dir` → `spine_root` → `diff_root` |
| `test-jvm-implementation.sh` | `repo_root` |
| `test-jvm-tools.sh` | `repo_root` |
| `test-rigorous-local.sh` | `repo_root` |
| `test-core-prod-gate.sh` | `repo_root` |
| `test-freehand-prod-gate.sh` | `repo_root` |
| `test-routing-prod-gate.sh` | `repo_root` |
| `test-ssr-prod-gate.sh` | `repo_root` |

The rest of the spine's chain was audited and is **not** exposed: all 15 Python
checkers it invokes derive their root from `Path(__file__)`, and the spine calls
every step through `"$spine_root/…"`. The `${BASH_SOURCE[0]}` shell scripts were the
only cwd-exposed link. Scripts outside the gate family that resolve `$0` the same way
(`beads-checkpoint.sh`, `install-git-hooks.sh`, `install-skills.sh`,
`check-beads-pr-boundary.sh`, `git-hooks/test-pre-commit.sh`,
`.github/scripts/rewrite-in-repo-coords.sh`, `.github/scripts/verify-version-lockstep.sh`)
are left alone: they issue no verdict, so a retarget cannot mis-grade anything.

## Mutation proof

Run from a **throwaway** directory, never inside a live worker's worktree.

Absolute invocation from a foreign cwd — line 1 names the right tree:

```
cwd=/tmp/…/rf2-g2mxd-foreign
gate root: /c/Users/miket/code/re-frame2-worktrees/spineroot-g2mxd
```

Relative invocation from that same foreign cwd — line 1 names the foreign tree:

```
cwd=/tmp/…/rf2-g2mxd-foreign
gate root: /tmp/…/rf2-g2mxd-foreign
```

**The two runs' output below line 1 is byte-identical.** That is the point: only
line 1 discloses which tree was graded. Before this change neither run named a root
anywhere — the pre-fix baseline classified the throwaway tree's diff (`docs=true
jvm=false node=false`) with nothing in its output saying so.

The harness confirmed the mechanism in its own words when this PR's gate was
backgrounded: *"Session cwd remains `C:\Users\miket\code\re-frame2`; directory
changes made by the backgrounded command do not apply."* The gate was invoked by
absolute path and line 1 still read `spineroot-g2mxd`.

The seven siblings were verified the same way (run relative from the throwaway,
each printing `gate root: /tmp/…/rf2-g2mxd-foreign` before failing on the absent
artefact dirs). The throwaway tree was deleted; nothing under it was committed.

## Documentation

The GATE MECHANICS rule gains its fourth entry in
`docs/the-mayor-method/dispatch-prompt-template.md` ("Three rules" → "Four"), in the
same terse register as its neighbours, and `AGENTS.md` gets the matching section for
Codex workers. Both files' worked examples spelled the *relative* form the incident
turned on — `sh scripts/test-fast-pr.sh > gate-fastpr.log` — and now spell
`sh <WORKTREE_ROOT>/scripts/test-fast-pr.sh`.

## Quality gates

**`sh <ABS>/scripts/test-fast-pr.sh` — exit 0**, terminal marker `PASS fast PR spine`
present (log line 968), `FAIL` count 0. The diff touches the spine itself, so it
armed **every** tier: `docs=true jvm=true node=true (spine self-change (every tier))`,
including the spine's own tiering self-test, `mkdocs --strict`, `implementation/core`
JVM, the JS harness helpers, CLJS node integration and per-ns isolation. Log line 1
read `gate root: /c/Users/miket/code/re-frame2-worktrees/spineroot-g2mxd` — this PR's
own gate was run backgrounded by absolute path and the echo confirmed the root, which
is the change dogfooding itself. Not run, per the spine's own honest tail: the JVM
artefact suites the diff did not touch, and the CI-only browser/bundle/adapter/Xray/
mcp-conformance/tool-JVM lanes.

**`shellcheck` (0.11.0) — every one of the eight scripts touched.** Findings are
**byte-identical before and after** the edit in all eight (compared against the
`HEAD~1` copy of each file): `test-fast-pr.sh` 3, `test-core-prod-gate.sh` 5,
`test-freehand-prod-gate.sh` 5, `test-routing-prod-gate.sh` 5,
`test-ssr-prod-gate.sh` 5, and 0 for `test-jvm-implementation.sh`,
`test-jvm-tools.sh`, `test-rigorous-local.sh`. Every one is a pre-existing
SC2016/SC2086/SC2006 info/style hit inside a comment or a `printf` literal; this
change adds none.

**One flake, disclosed.** The first spine attempt failed `implementation JS harness
helpers` with 155 `changed-surfaces` failures — *every* `classify()` call, each an
`execFileSync('bash', ['-lc', …])` spawn failure against
`.github/scripts/report-changed-surfaces.sh`. That file is untouched here and the
test names none of the eight scripts, so the change cannot reach it. Re-run
standalone: **276 passed, exit 0**; and the clean full-spine run above passed the same
step. Five workers were live on the box — the known load-sensitive spawn flake.

Docs: `mkdocs --strict` covers `docs/the-mayor-method/` and passed in the run above;
`scripts/check_doc_slugs.py` (docs corpus anchor validator) also passed. The template
edit adds no headings and no links, so no anchor moved.
