### PR TITLE
fix(hicasso): the evidence seam's detached-cost claim is made true (rf2-e3i6y)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index.cljs
@@ -90,10 +90,19 @@
 
   ## The evidence sink (HD-005)
 
-  Three lines — a holder, a setter, and a nil-checked emit — so dev
-  tooling can attach to the dependency index later with no redesign.
-  Detached cost is one deref and one nil test at each of the two tap
-  points. **No evidence subsystem ships**: there is no manifest, no
+  Two lines — a holder and a setter — so dev tooling can attach to the
+  dependency index later with no redesign. Detached cost is one deref and
+  one nil test at each of the two tap points, and **that is a literal
+  count, which it only is because the nil test is the outermost form at
+  each tap point**: nothing the sink would have been handed gets built
+  when there is no sink. A third line used to own that check — a private
+  `evidence!` the tap points called with the event already constructed —
+  and the indirection is what hid the cost, charging the detached path one
+  event map per boundary per commit at [[record-reads!]] and one per
+  commit at [[commit!]], garbage the moment it was made and so invisible
+  to a retained-heap ladder (rf2-e3i6y). Factoring the guard back out
+  restores the claim's falsity, which is why it reads as duplication here
+  and stays. **No evidence subsystem ships**: there is no manifest, no
   registry, no buffering, and the sink is nil until something sets it."
   (:require [clojure.set :as set]))
 
@@ -103,7 +112,6 @@
 
 (defonce ^:private !evidence-sink (atom nil))
 (defn set-evidence-sink! "Attach (or with nil, detach) the evidence sink." [f] (reset! !evidence-sink f) nil)
-(defn- evidence! [event] (when-some [sink @!evidence-sink] (sink event)) nil)
 
 ;; ---------------------------------------------------------------------------
 ;; The pure algebra — an index is a value; every op returns the next value
@@ -262,11 +270,12 @@
         after  (:b->subs (swap! !index record-reads boundary-id read-sub-keys))
         held   (get before boundary-id #{})
         reads  (get after boundary-id #{})]
-    (when (not= held reads)
-      (evidence! {:event   :edges-changed
-                  :boundary boundary-id
-                  :added   (set/difference reads held)
-                  :dropped (set/difference held reads)}))
+    (when-some [sink @!evidence-sink]
+      (when (not= held reads)
+        (sink {:event    :edges-changed
+               :boundary boundary-id
+               :added    (set/difference reads held)
+               :dropped  (set/difference held reads)})))
     nil))
 
 (defn commit!
@@ -275,7 +284,8 @@
   re-run. Reads the index; never mutates it."
   [dirty-sub-keys]
   (let [dirty (dirty-boundaries @!index dirty-sub-keys)]
-    (evidence! {:event :commit :dirty-subs (set dirty-sub-keys) :dirty-boundaries dirty})
+    (when-some [sink @!evidence-sink]
+      (sink {:event :commit :dirty-subs (set dirty-sub-keys) :dirty-boundaries dirty}))
     dirty))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index_laws_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/sub_index_laws_cljs_test.cljs
@@ -307,7 +307,7 @@
     (is (= #{} (idx/commit! #{[:stray]})))))
 
 ;; ---------------------------------------------------------------------------
-;; HD-005 — the evidence seam is three lines, nil by default, and silent
+;; HD-005 — the evidence seam is two lines, nil by default, and silent
 ;; ---------------------------------------------------------------------------
 
 (deftest the-evidence-seam-is-detached-by-default-and-attachable-without-redesign


### PR DESCRIPTION
Closes rf2-e3i6y.

## The claim, and how false it was

`front/sub_index.cljs`'s HD-005 section promised:

> Detached cost is one deref and one nil test at each of the two tap points.

**Both tap points violated it, not one.** The bead named only `record-reads!` and
said the claim "holds at the `commit!` tap point"; it does not. A read-only
predecessor pass on this bead corrected the count to two, and that correction is
confirmed here against the current file (which has moved since — PR #7425 deleted
`:live`, so `live?` now reads `(contains? (:b->subs idx) b)` and the line numbers in
that note are stale).

Counted by pattern rather than by line: `evidence!` had **exactly two** call sites,
and both built their event map *before* `evidence!` derefed the sink.

| Tap point | Detached residue before |
|---|---|
| `record-reads!` | one 4-entry map per boundary per commit, plus the `not=` and two `set/difference` calls that fill it |
| `commit!` | one 3-entry map per commit |

Nothing was retained — the sink is nil, so both were garbage the instant they were
made, which is why the per-read heap ladder never saw them.

## Which side I changed, and why

**I changed the CODE, not the docstring.** The brief left either answer open and
asked for whichever leaves the seam honest with the least machinery. Two things
decided it:

1. **HD-005's own ruling already says the cost is zero.** `docs/design/hicasso/decisions.md`
   reads "detached cost is zero", and `draft-guide/08-testing.md` says "at zero detached
   cost". The design record was right and the *code* had drifted from it. Rewriting the
   docstring to state the real cost would have put the implementation file at odds with
   the ruling it implements, and left two design docs to correct as well.
2. **The repair removes machinery rather than adding it.** `evidence!` is deleted and its
   `when-some` moves out to the two tap points. Net +1 line in the file body and one
   fewer private fn. No closure, no extra branch, no structural change — and the detached
   path now does strictly *less* work than before, not more.

The claim is now literal: the nil test is the outermost form at each tap point, so
nothing the sink would have been handed gets built when there is no sink.

### The trap I avoided

The obvious "make it lazy" move does not work, and the predecessor flagged it
specifically: `(evidence! #(hash-map ...))` allocates a **closure capturing the same
locals**. That trades a map for an object and leaves the claim exactly as false. The
fix had to *remove* the indirection, because the indirection is precisely what hid the
cost — a helper that takes an already-constructed event can never be cheap at the call
site. The ns docstring now says so, so a future tidy-up that factors the guard back
into a helper is refactoring against a stated reason rather than into a vacuum.

Hoisting the sink test above `record-reads!`'s `not=` is behaviour-preserving: both
guards are side-effect-free, and neither `when-some` form's value was ever used.

The seam is two lines now — a holder and a setter — so the ns docstring and the law
suite's section header, which both said "three lines", are restated to match.

## Mutation proof

There *is* a behavioural-adjacent change (a reordered guard and a deleted fn), so it is
proved through a gated suite rather than a bench driver.

- Mutated `(when (not= held reads) …)` to `(when true …)` in `record-reads!` — the guard
  the change actually reorders.
- `npm run test:cljs` → **1 failure, 0 errors**, exactly the named one:
  `FAIL in (the-evidence-seam-is-detached-by-default-and-attachable-without-redesign)`
  at `sub_index_laws_cljs_test.cljs:333`, the "an unchanged read set emits nothing —
  the seam reports change, not traffic" assertion. No collateral failures.
- Reverted byte-identically; diffstat returned to 22 insertions / 12 deletions, and
  `grep -c "when true"` is 0.

The suite is demonstrably live on **both** tap points in **both** states: the same
deftest asserts the exact `:edges-changed` *and* `:commit` events when a sink is
attached, and silence at both when it is detached.

## Quality gates

Both run foreground to completion in this worktree
(`C:\Users\miket\code\re-frame2-worktrees\evseam-e3i6y`), verified by resolved root in
each log, not by exit code alone.

| Gate | Exit | Terminal marker confirmed |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` |
| `npm run test:browser` | **0** | `Ran 1040 tests containing 6481 assertions. 0 failures, 0 errors.` |
| `npm run test:cljs` (baseline, pre-mutation) | **0** | `Ran 12477 tests containing 62567 assertions. 0 failures, 0 errors.` |

The spine classified this diff `docs=false jvm=true node=true` and ran the
`hicasso bench-lane compile` gate over the changed surface —
`101 lane namespaces compiled with zero warnings`.

Not run by the spine, per its own honest exit line: documentation gates (surface
unchanged), untouched JVM artefact suites, and the browser/bundle/adapter/tooling
gates that are CI-only — of which `test:browser` is run above.

### A note on gate hygiene

An intermediate `until`-loop of mine matched a broad `FAIL` alternative against
incidental fixture output (`→ FAILED` lines from a POM-validation self-test) and
reported the spine finished when it had not. Caught by checking for the runner's own
marker: `PASS fast PR spine` was absent and the process was still alive. Both verdicts
above are from the real marker on a process confirmed exited.

## Scope

Two files, both under `implementation/freehand/test/re_frame/bench/hicasso/front/`.

The three design docs that restate HD-005 (`architecture.md`, `decisions.md`,
`draft-guide/08-testing.md`) are deliberately **untouched**: they say "~3-line"
approximately and "detached cost is zero" exactly, and this change is what makes the
second one true. They were never the drifted party.
