### PR TITLE
docs(mayor-method): a tracker write can silently revert (rf2-alxg2)

### DIFF
--- a/docs/the-mayor-method/bootstrap.md
+++ b/docs/the-mayor-method/bootstrap.md
@@ -90,6 +90,16 @@ of a drain; the binding rule is hot-zone parallelism, not strict same-surface.
 - *Checkpoint tracker state on the heartbeat.* Many trackers auto-stage but never
   commit; commit + push the tracker file each cycle so a long session's state
   isn't stranded locally.
+- *A tracker write can silently revert.* Items verified closed can read OPEN again
+  cycles later — a rollback to an earlier snapshot, a re-import over the top — and
+  nothing in the loop surfaces it, so the session's "closed" count quietly
+  overstates. Verifying at the moment you close is not enough: each cycle, re-check
+  everything closed this session and re-close what reverted, with evidence. Two ways
+  that audit lies — key it on the stable item id, never an internal row UUID
+  (re-import regenerates UUIDs, so a UUID-keyed diff reports phantom losses), and
+  read the status FIELD, not the whole record, which matches "open" inside a title.
+  A verification tool that misreports is the same defect class as the bug it was
+  written to catch.
 - *The exit code is the verdict; the summary is decoration.* Piping a gate into
   `tail` or `grep` returns the pipe's status, not the runner's, so a worker reads
   "0 failures" and reports green on a failed run. Require capture to a file, an


### PR DESCRIPTION
Closes rf2-alxg2.

`bootstrap.md` told the mayor to close items "only after merge or verifiable
completion" and to record close reasons concretely. It never said to verify the
close **stuck**. On 2026-08-03 five closes made against merged PRs — each verified
CLOSED at the time — were silently back to OPEN when the raw list was reread
cycles later. Nothing was lost (the PRs were re-confirmed merged and the items
re-closed with evidence), but the running "beads closed" count overstated for part
of the session, and nothing in the loop would have surfaced it. It was found only
because the operator asked for a full reread.

The tracker-side fix landed separately as rf2-rjqtj (#7410), which made the
checkpoint compare ids / `updated_at` / `status` rather than trust a row count.
This is the other half: the mayor's habit, which no script covers.

## What changed

One bullet in the **Hard-won** list, placed next to *Checkpoint tracker state on
the heartbeat* — its topical neighbour, both being about tracker durability:

```
- *A tracker write can silently revert.* Items verified closed can read OPEN again
  cycles later — a rollback to an earlier snapshot, a re-import over the top — and
  nothing in the loop surfaces it, so the session's "closed" count quietly
  overstates. Verifying at the moment you close is not enough: each cycle, re-check
  everything closed this session and re-close what reverted, with evidence. Two ways
  that audit lies — key it on the stable item id, never an internal row UUID
  (re-import regenerates UUIDs, so a UUID-keyed diff reports phantom losses), and
  read the status FIELD, not the whole record, which matches "open" inside a title.
  A verification tool that misreports is the same defect class as the bug it was
  written to catch.
```

Both audit caveats were learned by getting them wrong on the day. A UUID-keyed
diff flagged three phantom losses — all three items existed and were closed,
because re-import regenerates row UUIDs. And a first pass that grepped the whole
`show` output matched the substring `OPEN` inside a bead *title* ("the fail-OPEN
CSRF compare") and reported a false reopen.

**Kept general.** The bullet is a page of operational law for a fresh mayor on any
tracker, not a changelog of this repo's incidents, so it names the failure mode
("a rollback to an earlier snapshot, a re-import over the top") rather than the
specific storage engine whose interrupted GC caused it here. Ten lines, one
paragraph, inside the existing list's range (the longest neighbour runs seven).
No new section, no procedure, no nested bullets — the list uses none. No script or
tooling, per the bead's scope.

No equivalent bullet existed. Verified against current `origin/main` (7c39be58ca,
after #7436 and #7422, neither of which touched `bootstrap.md`).

## Quality gates

| gate | exit |
| --- | --- |
| `python scripts/check_doc_slugs.py` | **0** |
| `sh scripts/test-fast-pr.sh` | **0** |

Both run in the foreground to completion, captured to worktree-local logs
(`alxg2-` prefixed), never piped. The spine's `gate root:` line read
`/c/Users/miket/code/re-frame2-worktrees/closeheld-alxg2` — this worktree — and it
printed its own terminal marker `PASS fast PR spine`, classifying the diff as
`docs=true jvm=false node=false`.

`docs/the-mayor-method/` is **not** in `mkdocs.yml`'s `exclude_docs`, so
`mkdocs build --strict` does cover this file; it ran inside the fast-PR spine and
listed `the-mayor-method\bootstrap.md` among the files it processed.

Hand checks: the edit adds no headings, no links and no tables, so there are no
anchors or column counts to verify. The whole prompt body is inside a ```text
fence, so the added lines render literally.
