### PR TITLE
feat(hicasso): the converge carves out live IME composition (rf2-digtt)

### DIFF
--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -211,10 +211,19 @@ arrives as `:id`/`:class`, as `"id"`/`"className"`, or as `:x/id`/`:x/class`
 Controlled text rides the synchronous door: dispatch → drain/commit → re-render
 lands the echo in the keystroke's own task; the caret survives value
 reassertion, and the key-map's composition gate keeps a composing Enter from
-committing (R-A1/R-A2 are v0's acceptance). The **value** path through a live
-composition is not fenced on any implementation: a refused or normalised value
-is written back mid-composition and the browser aborts the exchange, here and
-on plain React alike (`rf2-digtt`, unruled). On the lean-React arm the
+committing (R-A1/R-A2 are v0's acceptance). **A live IME composition is carved
+out of the convergence, and that is a deliberate divergence from plain React**
+(`rf2-digtt`, ruled 2026-08-03; HD-019's dated addendum). Nothing writes a
+controlled text field while a composition is running — not the runtime's
+converge and not React's own end-of-event restore — so a model that refuses or
+normalises what is being composed no longer destroys the exchange to say so:
+the composition survives, and the refusal or normalisation lands whole, once,
+at `compositionend`. Everywhere else the conduct is unchanged, including the
+model, which still sees and still refuses every intermediate composition state.
+Plain React and the UIx port abort the exchange in the same case; that is
+measured beside this in one run, and it is what the divergence is measured
+against. **Witnessed on Chromium only** — the harness drives composition over
+CDP, which is Chromium's protocol. On the lean-React arm the
 end-of-discrete-event restore is React's; a PATCH back end must own it
 (architecture.md, hard gate).
 

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -453,7 +453,13 @@ is the failure mode.
 > or normalises every intermediate composition state exactly as before, and on
 > the refusing field the exchange ends with the same model and the same field as
 > the React baseline reaches. `ime_run.cjs` asserts the divergence and its scope
-> comparatively, in one run, on one model.
+> comparatively, in one run, on one model. The re-run turned up one thing the
+> scope claim does **not** extend to, and it is pinned rather than smoothed
+> over: on a *normalising* field the baseline does not merely lose the
+> composition, it corrupts what the exchange commits — each aborted draft is
+> written back and the IME's next composition composes on top of it, so
+> `s`/`sh`/commit ends at model `"SSHSH"` where the carve-out commits the `"SH"`
+> that was typed.
 >
 > **The mechanism is two halves, because two writes destroy the exchange and
 > only one is ours.** (a) The converge declines to run when the change event
@@ -490,7 +496,10 @@ is the failure mode.
 > change event that is not composing (the recovery path for a composition some
 > other write aborted silently, which fires nothing), `blur`, and unmount for
 > free — the shadow is the component's own state and cannot outlive the element.
-> The worst degradation available is a converge, which is today's conduct.
+> The hold or release also runs **before** the author's handler at every slot,
+> so a handler that throws cannot strand one either. The worst degradation
+> available is a converge, which is today's conduct. All four paths are
+> witnessed in a live React tree by `arm1_controlled_grid_dom_cljs_test` §7.
 >
 > **Witness scope: Chromium only.** `Input.imeSetComposition` is a CDP method and
 > CDP is Chromium's protocol, so every composition claim here is witnessed on

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -431,6 +431,76 @@ is the failure mode.
 
 ## HD-019 — The synchronous controlled-input door (v0 mechanics)
 
+> **Addendum, 2026-08-03 — the composition carve-out is IN (`rf2-digtt`).** The
+> ruling below left one question open and named the bead that would settle it:
+> whether to suspend convergence until `compositionend`. It is settled, in
+> favour of the carve-out, and this record's "not proven, and not to be written
+> as though it were" clause about the value path through a live composition is
+> superseded by what follows. Everything else in the ruling stands unchanged.
+>
+> **What was ruled.** Controlled-text convergence is suppressed while an IME
+> composition is live; the field converges **once**, at `compositionend`,
+> against the then-current model. Automatic for any `:value`/`:on-input` pair —
+> no public option and no config knob. Under the old conduct a CJK/IME user on a
+> refusing or normalising field had in-flight kana destroyed mid-word with no
+> feedback at all; under the carve-out the composition survives and the refusal
+> lands whole and visibly at the commit. A composition is a browser-owned draft
+> of the user's, and destroying it silently is not a parity target worth
+> keeping.
+>
+> **This is a deliberate divergence from plain React, and it is claimed as
+> one.** It is scoped precisely to Hicasso's converge: the model still refuses
+> or normalises every intermediate composition state exactly as before, and on
+> the refusing field the exchange ends with the same model and the same field as
+> the React baseline reaches. `ime_run.cjs` asserts the divergence and its scope
+> comparatively, in one run, on one model.
+>
+> **The mechanism is two halves, because two writes destroy the exchange and
+> only one is ours.** (a) The converge declines to run when the change event
+> arrived mid-composition — one reading of the native event's `isComposing`.
+> (b) React's own end-of-discrete-event restore is not ours to skip, so an
+> internal single-`useState` component holds **the value React sees at the live
+> DOM draft** while a composition runs, and React's own `element.value !== value`
+> guard does the skipping. A bare "skip the converge" is proven insufficient by
+> this bead's measured matrix: plain React, which has no converge in the loop,
+> aborts the exchange anyway. Nothing reaches into React's internals, mutates
+> props React holds, or intercepts a value setter.
+>
+> **The second `flushSync` call site is audited here, as this record requires.**
+> `front.controlled/converge!` is now reached from two places in its own
+> namespace: the end of a change handler that is *not* composing, and once at
+> `compositionend`. Same element, same door, at most one per event, and the
+> composition path is the keystroke path with its convergence deferred to the
+> end of the exchange rather than a second mechanism. The grant stands on that
+> reading; a call site outside this namespace still needs its own ruling.
+>
+> **The price, paid in public.** One React fiber and one `useState` cell per
+> controlled `input`/`textarea`, plus one props copy and three handler closures
+> per render of a convergeable one. **HD-020(b)'s ≤2-hook budget is untouched**:
+> the shadow is not a boundary shell, and `shapes/hook_budget_dom_cljs_test`
+> now separates the two counts — the shell sequence is still the declared pair
+> once per boundary, the shadow's hook is counted per controlled text field, and
+> no hook is ever interleaved into a shell's pair. A page with no controlled
+> input pays nothing. The shadow's component deliberately does **not** read
+> `:type`, because an element type that changed under a live field would remount
+> it; the `:type` question is asked inside, one render later, where a wrong
+> answer costs nothing.
+>
+> **Release is unconditional**, which is the safety rider: `compositionend`, any
+> change event that is not composing (the recovery path for a composition some
+> other write aborted silently, which fires nothing), `blur`, and unmount for
+> free — the shadow is the component's own state and cannot outlive the element.
+> The worst degradation available is a converge, which is today's conduct.
+>
+> **Witness scope: Chromium only.** `Input.imeSetComposition` is a CDP method and
+> CDP is Chromium's protocol, so every composition claim here is witnessed on
+> Chromium and nowhere else. WebKit has had composition/key-ordering defects of
+> its own; this harness cannot drive it, and misconduct there is a new bug bead
+> rather than a known limitation.
+>
+> **K4's IME half is no longer open on this question.** `rf2-dfz6f` rewrites the
+> fitness harness's R-A2 wording separately.
+
 **Ruling.** On the lean-React arm: a controlled element's event-vector lowering
 dispatches **synchronously inside the discrete browser event** (the
 dispatch-sync-class drain), and the spine's store notification runs synchronously

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -481,8 +481,9 @@ is the failure mode.
 > reading; a call site outside this namespace still needs its own ruling.
 >
 > **The price, paid in public.** One React fiber and one `useState` cell per
-> controlled `input`/`textarea`, plus one props copy and three handler closures
-> per render of a convergeable one. **HD-020(b)'s ≤2-hook budget is untouched**:
+> controlled `input`/`textarea`, plus — on a convergeable one, per render — one
+> props copy and four closures: the three wrapped handlers and the release they
+> share. **HD-020(b)'s ≤2-hook budget is untouched**:
 > the shadow is not a boundary shell, and `shapes/hook_budget_dom_cljs_test`
 > now separates the two counts — the shell sequence is still the declared pair
 > once per boundary, the shadow's hook is counted per controlled text field, and

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -52,8 +52,9 @@ commit before React's end-of-event restore, so value *and caret* are correct
 in-turn — including when the model rejected or normalised the keystroke. What you
 get for free is exactly what the first example shows: ordinary `:value` and
 `:on-change`/`:on-input`, no ceremony, and a caret that stays put. The boundary
-is equally exact: the exception is one audited call site, reached from the
-element path once per keystroke, on controlled text entry only (a caret-bearing
+is equally exact: the exception is one audited converge, reached from the
+element path once per keystroke — and once at `compositionend` instead, for the
+composition carve-out below — on controlled text entry only (a caret-bearing
 `input` or a `textarea` with a non-nil `:value`), and inert everywhere else.
 Needing `flushSync` anywhere else would still be a finding, not an implementation
 detail.
@@ -80,26 +81,39 @@ unchanged-model rejection, and async normalisation. K4 in
 fails same-tick echo or IME on Chromium and WebKit for a simple form. This is
 not a polish item.
 
-The sixth is IME, and it is the one place where the guarantee is narrower than
-you would assume, so it is worth stating exactly.
+The sixth is IME, and it is the one place where this runtime deliberately does
+something plain React does not, so it is worth stating exactly.
 
-**Proven: a composing Enter commits nothing.** Mid-composition, Enter picks an
+**A composing Enter commits nothing.** Mid-composition, Enter picks an
 IME candidate; it is not a submit. The runtime's key-map gates on the native
 event's `isComposing` and on the legacy keyCode-229 signal that some browsers
 still send, each on its own — witnessed on the grid, and again against the
 browser's real composition machinery driven over CDP, on this runtime, on plain
 React and on the UIx port alike.
 
-**Open: the value path through a live composition.** If your model refuses or
-normalises what the IME has composed so far, the corrected value is written back
-*inside* the composing input event — and a value write during composition
-silently aborts the exchange. The in-flight kana are gone, no `compositionend`
-fires, and the IME opens a fresh composition on its next update. That is
-measured, and it is not something this runtime introduced: plain React does the
-same thing in the same turn through its own restore, and the UIx port does it a
-frame later. So do not lean on composition surviving value reassertion. For a
-field whose model can disagree mid-composition it survives nowhere today, and
-whether to suspend convergence until `compositionend` is an open ruling.
+**A live composition is carved out of the convergence, and it survives.** If
+your model refuses or normalises what the IME has composed so far, nothing is
+written to the field while the composition is running — not the runtime's
+converge, and not React's own end-of-event restore. Your handler still runs on
+every composing update and your model still refuses or normalises exactly as it
+would for a keystroke; what changed is that the *field* keeps showing the
+composition until the user commits it, and the refusal or normalisation lands
+whole, once, at `compositionend`.
+
+That is a divergence from plain React, claimed as one. On plain React the
+corrected value is written back *inside* the composing input event, and a value
+write during composition silently aborts the exchange: the in-flight kana are
+gone, no `compositionend` fires, and the IME opens a fresh composition on its
+next update — with each aborted draft left in the field for the next one to
+compose on top of. The UIx port does the same a frame later. Both are measured
+beside this runtime in the same harness run, which is where the claim comes
+from.
+
+Two things to know about the scope. It applies to controlled **text** entry —
+the same door everything else on this page describes — and it is **witnessed on
+Chromium**, because the harness drives real composition over CDP and CDP is
+Chromium's protocol. If you see an IME misbehave on WebKit, that is a bug worth
+reporting rather than a documented limit.
 
 ## Rejection: when the model says no
 
@@ -191,7 +205,7 @@ This table names mechanisms; the door's failures are behavioural, not error ids.
 | Characters drop when typing fast | The dispatch path went async — a debounce, a `setTimeout`, a queued effect between keystroke and commit | Keep the controlled path on the synchronous door; debounce the *consumer* of the value, not the write |
 | Caret jumps to end of field on every keystroke | The value was reasserted without caret preservation | R-A2 territory — a real bug in the runtime, not in your view |
 | Enter commits half-typed text mid-composition | A hand-written key handler that bypasses the intent path | Use the data key-map — the commit fence lives there, on both composition signals |
-| An IME composition dies when the model refuses or normalises it | Value reassertion during composition, which the browser treats as an abort | Open, and not yours to fix: plain React and the UIx port do the same. A field whose model agrees mid-composition is unaffected |
+| An IME composition dies when the model refuses or normalises it | Value reassertion during composition, which the browser treats as an abort | Not this runtime: the converge is carved out of a live composition and React's restore is held off with it. On plain React and the UIx port it is theirs, and not yours to fix |
 | Typing the "reset" value clears the field | Reset keyed on value equality somewhere | Reset on explicit revision |
 | Field goes read-only after an async normalise | The model round-trip didn't complete | Async normalisation is one of the six door witnesses; check the handler returns a `:db` write |
 | Focus lost after a validation failure | Something remounted the node | Remount-as-reset is disqualified precisely for this |
@@ -217,5 +231,5 @@ with a commit on blur is not a compromise. It is the right shape.
 | The buffered / draft-and-commit input ladder | **Post-v0, explicitly.** The charter defers "the full buffered/revision input ladder"; v0 ships R-A1/R-A2 and no more |
 | The controls kit that owns drafts and revisions | **Post-v0.** HD-009 leans on it for ephemeral state, and it does not exist in v0 — so in v0 a draft is app-db state you write yourself |
 | Which props count as controlled | HD-010's merge law names `:value` and `:checked`; the converge's own scope is exact (caret-bearing `input` or `textarea`, non-nil `:value`); whether the controlled roster is longer is unstated |
-| The value path through a live IME composition | **Open.** The commit fence is proven; a refused or normalised value is still written back mid-composition, which aborts the exchange — measured on this runtime, plain React and the UIx port alike. Whether to suspend convergence until `compositionend` is an unruled behavioural choice |
+| The value path through a live IME composition | **Ruled 2026-08-03, and shipped.** Convergence is suspended while a composition is live and the field converges once at `compositionend` — a deliberate divergence from plain React and the UIx port, both of which still abort the exchange. Witnessed on Chromium (the harness drives composition over CDP); WebKit is undriven rather than known-good |
 | Whether `:on-input` or `:on-change` is the taught attribute | The landed screens write `:on-input` for text and `:on-change` for checkboxes; the choice is convention, not ruling |

--- a/docs/design/hicasso/studio/controlled-input-two-implementations.md
+++ b/docs/design/hicasso/studio/controlled-input-two-implementations.md
@@ -205,20 +205,79 @@ path with the converge installed. What it holds and what it measured:
 - **The model observes every intermediate composition state** on all three:
   the change handler fires per composing `input`, so `s`/`sh`/`し` each
   reach app-db. The fence is the commit door, not the value path.
-- **A refused or normalised value is written back mid-composition on all
+- **A refused or normalised value was written back mid-composition on all
   three, and the write silently destroys the exchange** — no
   `compositionend`, fresh `compositionstart` on the IME's next update.
-  React in-turn, the converge in-turn, the port one frame late. The
-  converge is nowhere worse than the React baseline (asserted
-  comparatively, same run), but the PR #7371 audit's pin — that it
-  neither writes nor moves selection mid-composition — is false for every
-  implementation the moment the model disagrees. A composition carve-out
-  is a behavioural choice inside HD-019's exception scope and needs a
-  ruling: **`rf2-digtt`**, where the measured matrix lives.
+  React in-turn, the converge in-turn, the port one frame late. That was
+  the finding (`rf2-digtt`), and the converge was nowhere worse than the
+  React baseline; but the PR #7371 audit's pin — that it neither writes
+  nor moves selection mid-composition — was false for every
+  implementation the moment the model disagreed. **The operator ruled the
+  carve-out IN on 2026-08-03, and the section below is what the same
+  harness measures now.**
+
+### The composition carve-out, and where it diverges from React
+
+**Taken 2026-08-03 (`rf2-digtt`, HD-019's dated addendum).** Controlled-text
+convergence is suppressed while a composition is live; the field converges
+once, at `compositionend`, against the then-current model. The re-run of
+`ime_run.cjs` is two conducts rather than one, and the difference is the
+claim — measured in a single run, on one model, in one browser:
+
+| after one composing input on a model-**refusing** field (`digits`, model `"12"`, composing `し`) | Arm 1 | plain React | UIx port |
+|---|---|---|---|
+| field, in-turn | `"12し"` | `"12"` | `"12し"` |
+| field, settled | `"12し"` | `"12"` | `"12"` |
+| `compositionstart` across the exchange | **1** | 2 | 2 |
+| `compositionend` delivered | **1** | 0 | 0 |
+| field once the exchange closes | `"12"` | `"12"` | `"12"` |
+| model, throughout | `"12"` | `"12"` | `"12"` |
+
+Read it as one sentence: **the refusal is identical; what differs is that the
+user's composition survives to reach it.** Arm 1 writes nothing while the
+composition runs — neither its own converge, suppressed by one reading of the
+native event's `isComposing`, nor React's end-of-event restore, which finds
+the controlled value already agreeing with the live draft and assigns
+nothing. The refusal then lands whole and visibly at the commit.
+
+On the **normalising** field (`upper`) the divergence is larger than
+"survives versus does not", and the harness pins it:
+
+| `upper`, composing `s` then `sh`, then committing | Arm 1 | plain React |
+|---|---|---|
+| field while composing | `"s"`, `"sh"` (the draft) | `"S"`, `"S"` |
+| model while composing | `"S"`, `"SH"` | `"S"`, `"SH"` |
+| model once the exchange closes | **`"SH"`** | **`"SSHSH"`** |
+
+The baseline does not merely lose the composition: each aborted draft is
+written back into the field, and the IME's next composition composes *on top
+of it* — `s` → `S`, `sh` on top of `S` → `SSH`, the commit on top of that →
+`SSHSH`. Arm 1, having written nothing until the end, commits the `SH` that
+was typed. That row is a `comparative:` check in `ime_run.cjs`, not prose
+here.
+
 - A cancelled exchange (`compositionend` with empty data) leaves field and
-  model exactly as before, on all three — with the measured wrinkle that on
-  a refusing field there is no `compositionend` at all, because the abort
-  already happened.
+  model exactly as before, on all three. The refusing field is where the two
+  conducts part again: on Arm 1 it cancels like any other field, because
+  there is a live composition left to cancel; on React and the port there is
+  no `compositionend` at all, because the abort already happened.
+- **What is in-page, and what needs the harness.** A composition is browser
+  machinery and nothing dispatched from page script creates one, so the
+  *exchange* is `ime_run.cjs`'s claim alone. What the PR-gated suite witnesses
+  is the **write** — the cause — in
+  `arm1_controlled_grid_dom_cljs_test` §7: on a composing `input` event the
+  arm's field is untouched in-turn, while plain React's cell on the same
+  model in the same turn already shows the refused-to value. The
+  safety-rider paths (blur, a non-composing keystroke, unmount) are witnessed
+  there too.
+
+> **Witness scope: Chromium only.** `Input.imeSetComposition` is a CDP method
+> and CDP is Chromium's protocol, so every composition measurement on this page
+> — before and after the carve-out — is Chromium's and nowhere else's. WebKit
+> has had composition/key-ordering defects of its own; driving it would need a
+> different instrument, which is not built and is not being mandated here.
+> Misconduct observed on WebKit is a new bug rather than a known limitation of
+> this record.
 
 ## The options, and what they cost
 
@@ -355,7 +414,9 @@ element path — a UIx consumer is not on that path and does not get it.
   it. One thing it recorded is not answered and is not rounded up — the
   **range** row (a second algorithm, and off the change path entirely). The
   **IME** fence is now established by the real-composition harness
-  (`rf2-o27h3`, the *IME composition* section above), whose one open
-  residue — the mid-composition rewrite every implementation performs when
-  the model disagrees — is `rf2-digtt`. And nothing here reaches a UIx
-  consumer's `:input`.
+  (`rf2-o27h3`, the *IME composition* section above), and its one open
+  residue — the mid-composition rewrite every implementation performed when
+  the model disagreed — was closed by `rf2-digtt`'s carve-out on
+  2026-08-03, in Arm 1 only. And nothing here reaches a UIx consumer's
+  `:input`: the carve-out is the element path's, so a UIx consumer's
+  composition is still React's to abort.

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -455,8 +455,10 @@ selection, unchanged-model rejection, async normalisation — IME composition is
 asserted by the real-composition harness `ime_run.cjs` (`rf2-o27h3`: CDP-driven
 trusted composition against all three input implementations; the commit fence
 on both signals, survival of a model-agreeing exchange, cancellation restoring
-field and model, and the measured mid-composition rewrite matrix `rf2-digtt`
-records), never in-page — a dispatched `Event` exercises neither React's
+field and model, and — since `rf2-digtt`'s carve-out ruling, 2026-08-03 — the
+divergence matrix: one uninterrupted exchange on this arm against the abort
+plain React and the UIx port still perform, with the refusal landing whole at
+`compositionend`. Chromium only, CDP being Chromium's protocol), never in-page — a dispatched `Event` exercises neither React's
 composition path nor the browser's composition range, which is why the grid
 suites still carry no composition row; the caret across a
 refusal and across a normalisation is the arm's own since `rf2-fki5d`, taken in

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
@@ -1030,6 +1030,293 @@
               0)))))))
 
 ;; ---------------------------------------------------------------------------
+;; 7 — the composition carve-out (rf2-digtt)
+;; ---------------------------------------------------------------------------
+;;
+;; **What these rows can witness, and what they cannot.** A composition
+;; is browser machinery — a range the IME owns — and nothing dispatched
+;; from page script creates one. `bench/hicasso/ime_run.cjs` drives the
+;; real thing over CDP and owns every claim about the EXCHANGE: that it
+;; survives, that a JS value write mid-composition aborts it silently,
+;; that the refusal lands whole at `compositionend`.
+;;
+;; What is witnessable here is the WRITE — the cause the harness measured
+;; the effect of — and it is worth witnessing on every PR because it is
+;; the mechanism, in-page, beside plain React on the same model in the
+;; same turn. The rows below assert that during a composing input event
+;; **nothing writes the field**: not this arm's converge (suppressed by
+;; one reading of the native event) and not React's own end-of-event
+;; restore (which finds the controlled value agreeing with the draft,
+;; because the shadow holds it there). The plain-React comparator writes
+;; in exactly that turn, which is the divergence stated as a measurement
+;; rather than as a claim.
+
+(defn- composition-start!
+  "Open a composition on `node`. The carve-out deliberately does not
+  read this event — the shadow is held by the composing `input` events
+  themselves — so it is here for faithfulness rather than as a signal,
+  which is one fewer thing to keep in step."
+  [node]
+  (.dispatchEvent node (js/CompositionEvent. "compositionstart"
+                                             #js {:bubbles true :data ""}))
+  nil)
+
+(defn- compose-into!
+  "Put `text` in the field the way a composing IME does: the value
+  changes first, and the `input` event that follows carries
+  `isComposing true` and `inputType \"insertCompositionText\"` — the two
+  members a real composing input carries and the one
+  [[re-frame.bench.hicasso.front.controlled/composing-input?]] reads.
+
+  The whole value is replaced rather than inserted at the caret, because
+  that is what a composition range does: each update REPLACES the draft
+  it is composing."
+  [node text]
+  (set-native-value! node text)
+  (.setSelectionRange node (count text) (count text))
+  (.dispatchEvent node (js/InputEvent. "input"
+                                       #js {:bubbles     true
+                                            :data        text
+                                            :inputType   "insertCompositionText"
+                                            :isComposing true}))
+  nil)
+
+(defn- composition-end!
+  "Close the composition, committing `data`."
+  [node data]
+  (.dispatchEvent node (js/CompositionEvent. "compositionend"
+                                             #js {:bubbles true :data data}))
+  nil)
+
+(deftest the-events-a-composition-carries-are-verified-on-the-native-event
+  (testing "the instrument before the rows that trust it — the
+           dead-`isComposing` lesson applied to this file's own composing
+           input. A row whose event silently carried `isComposing false`
+           would be green over a carve-out that never engaged"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM, and no InputEvent constructor")
+      (let [e (js/InputEvent. "input" #js {:bubbles     true
+                                           :data        "し"
+                                           :inputType   "insertCompositionText"
+                                           :isComposing true})]
+        (is (= "input" (.-type e)))
+        (is (true? (.-isComposing e))
+            "the signal the carve-out turns on is really on the event")
+        (is (= "insertCompositionText" (.-inputType e)))
+        (is (true? (.-bubbles e)) "React listens at the root")
+        (is (false? (.-isTrusted e))
+            "the one thing no synthetic event can carry — which is why the
+             EXCHANGE is the CDP harness's claim and only the WRITE is
+             this file's")))))
+
+(deftest a-composing-keystroke-writes-nothing-and-the-refusal-lands-at-the-end
+  (testing "THE CARVE-OUT (rf2-digtt). On a refusing cell, every write
+           that used to land mid-composition is gone — the arm's converge
+           by one reading of the native event, React's own restore because
+           the value it compares against is the live draft — and the
+           refusal arrives whole at `compositionend` instead"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [n (cell-input handle 11)]
+            (set-model! 11 "12")
+            (.focus n)
+            (.setSelectionRange n 2 2)
+            (composition-start! n)
+            (let [errs (reported-errors #(compose-into! n "12し"))]
+              (is (= [] errs)
+                  "NOTHING THREW — asserted through a window error listener,
+                   because React routes a throw inside a discrete event to
+                   `reportError` and a `try`/`catch` here would see nothing")
+              (is (= "12し" (.-value n))
+                  "THE ROW. The draft is still on the screen on the line
+                   after `dispatchEvent` returned — neither write happened")
+              (is (= [3 3] (caret n))
+                  "and the caret is where the IME left it, untouched")
+              (is (= "12" (model-value 11))
+                  "while the model refused it, exactly as it always did —
+                   the authored handler still runs and the policy still
+                   applies"))
+            (testing "and the next update continues the same draft"
+              (compose-into! n "12しん")
+              (is (= "12しん" (.-value n)))
+              (is (= "12" (model-value 11))))
+            (testing "the refusal lands whole, once, at compositionend"
+              (composition-end! n "しん")
+              (is (= "12" (.-value n))
+                  "the field snapped back to the model — visibly, at the
+                   commit, rather than silently mid-word")
+              (is (= [2 2] (caret n))
+                  "with the caret restored by offset from the end, which is
+                   the same algorithm every other row of this file reads")
+              (is (= "12" (model-value 11))))
+            (testing "and the field is an ordinary controlled field again"
+              (type-into! n "3")
+              (is (= "123" (.-value n)) "an accepted keystroke lands in-turn")
+              (is (= "123" (model-value 11)))
+              (type-into! n "z")
+              (is (= "123" (.-value n))
+                  "and a refused one comes off the screen in-turn, which is
+                   the conduct the carve-out suspends and nothing more"))))))))
+
+(deftest plain-react-writes-the-refused-value-in-the-same-turn
+  (testing "THE DIVERGENCE, measured beside the row above rather than
+           claimed. The same model, the same composing input event, on
+           UIx's plain-React cell: React's end-of-discrete-event restore
+           assigns `element.value` because the DOM differs from the
+           controlled value, and it does it in the turn the event
+           returned.
+
+           In a real composition that write is what destroys the exchange
+           — no `compositionend`, the in-flight kana gone — which is
+           `ime_run.cjs`'s measurement and not this row's. This row
+           witnesses the CAUSE: the write is there on React, and it is not
+           there on the arm"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (do
+        (pin! :react)
+        (fresh!)
+        (let [handle (uix-mount! 11)
+              n      (.querySelector (:container handle) "#u11")]
+          (try
+            (set-model! 11 "12")
+            (.focus n)
+            (.setSelectionRange n 2 2)
+            (composition-start! n)
+            (compose-into! n "12し")
+            (is (= "12" (.-value n))
+                "plain React put the refused-to value back over the live
+                 draft, in-turn — the conduct this arm now diverges from")
+            (is (= "12" (model-value 11)) "the model refused, as everywhere")
+            (finally
+              (react-dom/flushSync (fn [] (.unmount (:root handle))))
+              (restore-adapter-pin!))))))))
+
+(deftest a-composing-keystroke-on-an-agreeing-cell-changes-nothing
+  (testing "the survival law, kept: where the model takes what is composed
+           there was never a write to suppress, so the carve-out is
+           invisible — the field tracks the draft and the model tracks it
+           too, update by update"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [n (cell-input handle 7)]
+            (.focus n)
+            (composition-start! n)
+            (compose-into! n "s")
+            (is (= "s" (.-value n)))
+            (is (= "s" (model-value 7)) "the model observes the intermediate state")
+            (compose-into! n "し")
+            (is (= "し" (.-value n)))
+            (is (= "し" (model-value 7)))
+            (composition-end! n "し")
+            (is (= "し" (.-value n)) "and the commit moves nothing")
+            (is (= [1 1] (caret n)))
+            (is (= "し" (model-value 7)))))))))
+
+(deftest a-normalising-cell-shows-the-normalisation-at-the-commit
+  (testing "the other half of the carve-out's behavioural claim: the model
+           normalises every intermediate state as it always did, and the
+           FIELD shows the composition until the exchange closes"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [n (cell-input handle 13)]
+            (.focus n)
+            (composition-start! n)
+            (compose-into! n "s")
+            (is (= "s" (.-value n)) "the draft, not the normalisation")
+            (is (= "S" (model-value 13)) "while the model normalised it")
+            (compose-into! n "sh")
+            (is (= "sh" (.-value n)))
+            (is (= "SH" (model-value 13)))
+            (composition-end! n "sh")
+            (is (= "SH" (.-value n)) "the normalisation lands whole, at the end")
+            (is (= [2 2] (caret n)))))))))
+
+(deftest a-blur-releases-the-shadow-whatever-else-happened
+  (testing "THE SAFETY RIDER, first half. A composition the browser
+           abandons with the focus fires no `compositionend`, so the
+           release cannot be that event's alone. Blur releases
+           unconditionally, and the worst outcome available is the
+           ordinary converge"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [n (cell-input handle 11)]
+            (set-model! 11 "12")
+            (.focus n)
+            (composition-start! n)
+            (compose-into! n "12し")
+            (is (= "12し" (.-value n)) "the draft is held")
+            (.blur n)
+            ;; OUT of the discrete-event claim: the row is that the release
+            ;; happens at all, not that it happens in the blur's own turn.
+            (mount/settle!)
+            (is (= "12" (.-value n))
+                "the field is the model's again with no compositionend
+                 anywhere in the exchange")
+            (is (= "12" (model-value 11)))))))))
+
+(deftest a-non-composing-keystroke-releases-a-shadow-nothing-else-closed
+  (testing "THE SAFETY RIDER, second half — the recovery path for a
+           composition destroyed by some OTHER value write, which fires
+           nothing at all. The next ordinary keystroke is not composing,
+           and a change event that is not composing releases before it
+           converges, so the field cannot stay stuck on a draft the model
+           never agreed to"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (with-grid
+        (fn [handle]
+          (let [n (cell-input handle 11)]
+            (set-model! 11 "12")
+            (.focus n)
+            (composition-start! n)
+            (compose-into! n "12し")
+            (is (= "12し" (.-value n)) "a shadow is held, and nothing closed it")
+            (type-into! n "4")
+            (is (= "12" (.-value n))
+                "the ordinary keystroke released the shadow and converged in
+                 the same turn — the draft is gone and the model, which
+                 refused `12し4`, is what the field shows")
+            (is (= "12" (model-value 11)))))))))
+
+(deftest an-unmount-cannot-strand-a-shadow
+  (testing "THE SAFETY RIDER, third half, and the reason it needs no code:
+           the shadow is the internal component's own `useState`. There is
+           no registry, no node property and no module-level record, so an
+           element that goes away takes its shadow with it and the next
+           mount reads the model"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (do
+        (pin! :react)
+        (fresh!)
+        (let [first-handle (arm-mount!)]
+          (try
+            (let [n (cell-input first-handle 11)]
+              (set-model! 11 "12")
+              (.focus n)
+              (composition-start! n)
+              (compose-into! n "12し")
+              (is (= "12し" (.-value n)) "a shadow is live when the tree goes"))
+            (finally (mount/release! first-handle)))
+          (let [second-handle (arm-mount!)]
+            (try
+              (is (= "12" (.-value (cell-input second-handle 11)))
+                  "the remounted field is the model's, with nothing carried
+                   over from the composition that never ended")
+              (is (= "12" (model-value 11)))
+              (finally (mount/release! second-handle)
+                       (restore-adapter-pin!)))))))))
+
+;; ---------------------------------------------------------------------------
 ;; Teardown
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/controlled_grid_dom_cljs_test.cljs
@@ -613,12 +613,15 @@
 ;; `bench/hicasso/ime_run.cjs` drives trusted CDP composition against this
 ;; arm's element path (converge included), plain React and the port, and
 ;; asserts the fence there. Its one open residue — every implementation
-;; rewrites a refused/normalised value mid-composition, destroying the
-;; exchange — is rf2-digtt. The two rows below stay: they witness the
-;; gate's two signals through React's keydown plumbing cheaply, on every
-;; PR, in-page — while the events they build are exactly the synthetic
-;; kind the harness exists to go beyond, which is why the harness, not
-;; these rows, is what establishes the fence.
+;; rewrote a refused/normalised value mid-composition, destroying the
+;; exchange — was rf2-digtt, and the operator ruled the carve-out IN on
+;; 2026-08-03: this arm no longer writes during a composition, and §7
+;; below witnesses the half of that a dispatched event CAN reach. The two
+;; rows below stay: they witness the gate's two signals through React's
+;; keydown plumbing cheaply, on every PR, in-page — while the events they
+;; build are exactly the synthetic kind the harness exists to go beyond,
+;; which is why the harness, not these rows, is what establishes the
+;; fence.
 
 (def ^:private !probe (atom []))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -1619,7 +1619,7 @@
      :what  "the codec's tag and prop caches, per distinct literal in the build"}]
    :absent
    [{:token :use-ref   :what "no useRef anywhere in the shell (HD-020(b))"}
-    {:token :use-state :what "no per-instance render-phase state of any kind"}
+    {:token :use-state :what "no per-instance render-phase state of any kind IN THE SHELL. The one useState on an Arm 1 page belongs to `front.controlled`'s composition shadow and is a controlled TEXT ELEMENT's, one per field — never a boundary's, and priced per field on `shapes/hook_budget_dom_cljs_test` (rf2-digtt)"}
     {:token :view-cell :what "no per-boundary object graph, reaction, watcher or scheduler"}
     {:token :candidate-ledger
      :what  "one scratch buffer, never two; nothing keyed by render, attempt, lane or generation; no per-read object; no commit-phase deref"}]})

--- a/implementation/freehand/test/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/controlled_restore_dom_cljs_test.cljs
@@ -131,9 +131,12 @@
     React's composition plumbing nor the browser's composition state —
     the very reason the row sat unasserted so long — and `:browser-test`
     runs in-page. What the harness also measured: every implementation
-    (React's own restore included) rewrites a refused/normalised value
-    mid-composition and silently destroys the exchange — rf2-digtt,
-    which is where the carve-out ruling lives.
+    (React's own restore included) rewrote a refused/normalised value
+    mid-composition and silently destroyed the exchange — rf2-digtt.
+    The operator ruled the carve-out IN on 2026-08-03, and it landed in
+    **Arm 1's element path only**: the two implementations THIS file
+    measures are the ones that still abort, which is what makes the
+    divergence a divergence. Nothing here changes.
   - `teardown-leaves-no-boundary-and-no-edge` — dropped as a duplicate.
     Arm 1's dogfood suite already asserts zero residue after unmount
     (`:cells :cell-refs :boundaries :edges :entries` all 0), and one

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/census_article_editor_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/census_article_editor_cljs_test.cljs
@@ -53,6 +53,7 @@
   the PR would be measuring two different things."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.controlled :as controlled]
             [re-frame.bench.hicasso.front.intent :as intent]))
 
 (use-fixtures :each {:before (fn [] (codec/reset-caches!))})
@@ -147,9 +148,17 @@
     (cond (array? c) (vec c) (nil? c) [] :else [c])))
 
 (defn- inputs
-  "Every `<input>` element in a rendered fieldset, in document order."
+  "Every `<input>` element in a rendered fieldset, in document order.
+
+  Read through [[re-frame.bench.hicasso.front.controlled/element-tag]]
+  rather than `.-type`, because a controlled field's element type is the
+  composition shadow's component and the tag it renders is what this
+  question is about (rf2-digtt). Every prop these rows go on to read —
+  the static attributes, `onInput`, `onBlur` — is on that element
+  unchanged; only the type moved."
   [e]
-  (into [] (mapcat (fn [group] (filter #(and (some? %) (= "input" (.-type %)))
+  (into [] (mapcat (fn [group] (filter #(and (some? %)
+                                             (= "input" (controlled/element-tag %)))
                                        (children-of group))))
         (children-of e)))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -1311,7 +1311,13 @@
   EMITTED element — a controlled `value`, a change handler, a type with
   a caret — and those are canonical slots rather than spellings. It is
   one JS `switch` on the tag for every element that is not an `:input`
-  or a `:textarea`, which is nearly all of them. rf2-fki5d."
+  or a `:textarea`, which is nearly all of them. rf2-fki5d.
+
+  It also **answers what to render the props as**, which since rf2-digtt
+  is the tag for everything except a controlled `input`/`textarea` —
+  those get the composition shadow's component, and the tag it renders
+  is the tag parsed here. The codec asks one question and takes one
+  answer; which of the two it is belongs entirely to that namespace."
   [argv]
   (let [parsed      (cached-parse (nth argv 0))
         has-props?  (props-map? argv 1)
@@ -1319,10 +1325,10 @@
         ;; nil, not `(or props {})` — the absent attribute map is
         ;; [[convert-props]]'s first lane, and wrapping it in an empty
         ;; map was the whole cost of telling it so (rf2-y1jkm).
-        js-props    (convert-props props parsed)]
-    (controlled/install! (.-tag parsed) js-props)
+        js-props    (convert-props props parsed)
+        component   (controlled/install! (.-tag parsed) js-props)]
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
-    (make-element (.-tag parsed) js-props argv (if has-props? 2 1))))
+    (make-element component js-props argv (if has-props? 2 1))))
 
 (defn- boundary-element [argv]
   (let [has-props? (props-map? argv 1)

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
@@ -244,7 +244,12 @@
 
   A release is `set-shadow(nil)`, and a release when nothing is held is
   free — React bails out of an update to an identical state. So the
-  degenerate outcome is a converge, which is exactly today's conduct."
+  degenerate outcome is a converge, which is exactly today's conduct.
+
+  The release also runs **before** the author's handler at every slot
+  that has one, so a handler that throws cannot strand a shadow either.
+  `arm1_controlled_grid_dom_cljs_test` §7 witnesses the blur, the
+  non-composing keystroke and the unmount paths in a real React tree."
   (:require ["react" :as react]
             ["react-dom" :as react-dom]))
 
@@ -474,18 +479,24 @@
   differs from the controlled value, so agreeing with the draft is what
   makes the restore a no-op. See the namespace docstring.
 
-  Three slots, and each is a release or a hold:
+  Three slots, and each is a release or a hold. **The hold or release
+  happens FIRST at every one of them**, before the handler the author
+  wrote — not for ordering's sake but because that is what makes the
+  release unconditional: a handler of the author's that throws must not
+  be able to strand a shadow, and the worst it can then leave behind is
+  a converge.
 
-  - the **change slot** — [[install!]]'s converging handler, called
-    first so the author's handler and the model move exactly as they
-    always did. Composing, the draft is held and the converge inside it
-    has already declined to run; not composing, the shadow is released
-    *before* the inner handler, so the release renders inside the
-    converge's own `flushSync` and one flush does both jobs.
+  - the **change slot** — [[install!]]'s converging handler, wrapped.
+    Composing, the live draft is held and the converge inside has
+    already declined to run; not composing, the shadow is released, and
+    releasing *before* the inner handler means the release renders
+    inside the converge's own `flushSync` — one flush, both jobs.
   - **`onCompositionEnd`** — release, then converge once against the
-    then-current model. This is where a refusal lands, whole and
-    visible, on a field whose model would have destroyed the exchange
-    to say so.
+    then-current model, which is why the converge is the one thing here
+    that runs after the author (their handler may move the model, and
+    the model this converges against is the one it leaves behind). This
+    is where a refusal lands, whole and visible, on a field whose model
+    would have destroyed the exchange to say so.
   - **`onBlur`** — release, and nothing else. A blurred field has no
     caret worth restoring; the release alone re-renders the model's
     value and React's own commit writes it.
@@ -504,22 +515,21 @@
     (unchecked-set out slot
                    (fn hicasso-composition-shadow [e]
                      (if (composing-input? e)
-                       (do (inner e)
-                           (set-shadow (some-> (.-target e) (.-value))))
-                       (do (release!)
-                           (inner e)))
+                       (set-shadow (some-> (.-target e) (.-value)))
+                       (release!))
+                     (inner e)
                      nil))
     (unchecked-set out "onCompositionEnd"
                    (fn hicasso-composition-end [e]
-                     (when (fn? ended) (ended e))
                      (release!)
+                     (when (fn? ended) (ended e))
                      (when-some [node (.-target e)]
                        (converge! node))
                      nil))
     (unchecked-set out "onBlur"
                    (fn hicasso-composition-release [e]
-                     (when (fn? blurred) (blurred e))
                      (release!)
+                     (when (fn? blurred) (blurred e))
                      nil))
     out))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
@@ -28,6 +28,15 @@
   (`uix/compiler/input.cljs:132-143`); this one is not that wrapper, and
   the caret half of the mechanism is still the element path's.
 
+  **That hook is priced rather than asserted away.**
+  `shapes/hook_budget_dom_cljs_test` counts every hook React is asked for
+  across each tier-1 shape and separates the two questions: the shell
+  budget is still `2 × boundaries` in the declared order, and the
+  shadow's `useState` is counted per controlled TEXT FIELD from a number
+  the file declares. It also asserts that no hook is ever interleaved
+  into a shell's pair, which is what makes \"not in the shell\" a
+  measurement. A page with no controlled input pays nothing.
+
   ## What runs, and when
 
   At the end of the change handler — still inside the discrete event,

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs
@@ -1,6 +1,7 @@
 (ns re-frame.bench.hicasso.front.controlled
   "THE CONTROLLED-ELEMENT CONVERGE — same turn, caret where the edit left
-  it (rf2-fki5d, the residue rf2-n3dxw was left open on).
+  it (rf2-fki5d, the residue rf2-n3dxw was left open on), and a live IME
+  composition carved out of it (rf2-digtt).
 
   Neither shipped path gives a store-backed field both halves of what it
   owes its user. React converges inside the discrete event and throws the
@@ -15,14 +16,24 @@
   it applies to, and wraps the change handler the author already wrote.
   The view is unchanged: an ordinary `:value` / `:on-input` pair, no
   ref, no effect, no escape hatch, and **nothing added to the boundary
-  shell**, so HD-020's ≤2-hook budget is untouched. UIx's own answer to
-  the same problem is a wrapper *component* per input carrying three
-  hooks (`uix/compiler/input.cljs:132-143`).
+  shell**, so HD-020's ≤2-hook budget is untouched.
+
+  One thing is *not* in the element path, and [[shadow-component]] says
+  why: React's own end-of-event restore is not ours to skip, so the
+  composition carve-out needs a fiber of its own. It is one internal
+  component carrying one `useState`, standing in front of controlled
+  `input`/`textarea` elements and nowhere else — still not the boundary
+  shell, and still not the author's to know about. UIx's answer to the
+  *caret* problem is a wrapper component per input carrying three hooks
+  (`uix/compiler/input.cljs:132-143`); this one is not that wrapper, and
+  the caret half of the mechanism is still the element path's.
 
   ## What runs, and when
 
   At the end of the change handler — still inside the discrete event,
-  and still **ahead of React's own end-of-event restore**:
+  and still **ahead of React's own end-of-event restore** — unless the
+  event arrived mid-composition, which is [[composing-input?]]'s
+  question and the whole of the carve-out's first half:
 
   1. `flushSync`, so the synchronous door's commit lands now rather than
      in the `finally` of React's `batchedUpdates$1`;
@@ -106,6 +117,8 @@
     (`:1738`), so the two exclusions are the same exclusion. React's own
     restore still converges the *value* on those types; there was never
     a caret there to lose.
+  - **A change handler to run after.** No handler, no end of a handler
+    to converge at.
 
   A guard that does not hold means no wrapper at all — not a wrapper
   that quietly does less. The element then behaves exactly as it did
@@ -129,6 +142,16 @@
   `arm1_controlled_grid_dom_cljs_test/a-type-change-inside-the-flush-leaves-the-converge-inert`
   quotes it and reds by name without this reading.
 
+  **The same measurement is why [[shadow-component]] stands in front of
+  every controlled `input`/`textarea` rather than only the convergeable
+  ones.** That row asserts React kept the NODE across the type change —
+  a premise that holds only while the element's React *type* is stable,
+  and a component chosen by a predicate reading `:type` would flip from
+  the wrapper to the bare tag under exactly that keystroke, remounting
+  the field and taking the focus with it. So the component question is
+  the tag and the controlled `value`, and the `:type` question is asked
+  inside, where a wrong answer costs nothing.
+
   ## The one handler, and the door
 
   `onChange` when the author wrote one, `onInput` otherwise. React's
@@ -151,25 +174,70 @@
   and restoring two offsets is a different algorithm from the one it
   runs (rf2-n3dxw).
 
-  ## Composition, measured (rf2-o27h3)
+  ## The composition carve-out (rf2-digtt), and why it is two halves
 
   A composing IME produces exactly the `input` events this wrapper runs
-  on, so its conduct mid-composition is a measured property, not an
-  intention — `bench/hicasso/ime_run.cjs` drives real CDP composition
-  at it beside plain React and the UIx port. Measured: on a
-  model-agreeing field the exchange **survives** — the value write never
-  fires (and an equal write is short-circuited by the browser's own
-  setter anyway), and the unconditional `setSelectionRange` did not
-  disturb the composition range. On a field whose model refuses or
-  normalises, the write lands **mid-composition and silently destroys
-  the exchange** — precisely as React's own end-of-event restore does on
-  the same field in the same turn, and as the UIx port does one frame
-  later. Nowhere worse than the baseline, asserted comparatively; not
-  composition-fenced either, same as the baseline. Whether this path
-  should carve composition out — suppress the converge while
-  `isComposing`, converge once at `compositionend` — is a behavioural
-  choice inside HD-019's exception scope awaiting a ruling: rf2-digtt."
-  (:require ["react-dom" :as react-dom]))
+  on. `bench/hicasso/ime_run.cjs` drives real CDP composition at it
+  beside plain React and the UIx port, and what it measured is the whole
+  reason the carve-out exists: on a field whose model **refuses or
+  normalises** the composition text, the value written back lands
+  mid-composition and **silently destroys the exchange** — no
+  `compositionend`, the in-flight kana gone, a fresh `compositionstart`
+  on the IME's next update. Plain React does it in the same turn through
+  its own restore; the UIx port does it one frame later.
+
+  The operator ruled the carve-out IN (2026-08-03, recorded as an
+  addendum to HD-019): controlled-text convergence is suppressed while a
+  composition is live, and the field converges ONCE at `compositionend`
+  against the then-current model. A composition is a browser-owned draft
+  of the user's; destroying it silently is not a parity target worth
+  keeping. **On a refusing or normalising field this runtime therefore
+  diverges from plain React deliberately** — the composition survives to
+  its commit and the refusal lands whole, visibly, at `compositionend`.
+
+  It takes two halves because **two different writes destroy the
+  exchange, and only one of them is ours**:
+
+  1. **This converge**, suppressed by [[composing-input?]] at the end of
+     the change handler. One reading, one branch.
+  2. **React's own end-of-discrete-event restore**, which is not ours to
+     skip. `ChangeEventPlugin` banks a restore target for every
+     controlled change; the `finally` of `batchedUpdates$1` flushes
+     pending sync work and then hands the committed props to
+     `updateInput`, which assigns `element.value` **whenever it differs
+     from the controlled value**. Skipping only half (1) falls through to
+     exactly the plain-React conduct the harness measured aborting the
+     exchange — which is why a bare `when-not composing` is proven
+     insufficient rather than merely incomplete.
+
+  [[shadow-component]] is half (2), and it is stated as a property
+  rather than as a trick: **while a composition is live, the value React
+  sees agrees with the live DOM draft**, so React's restore finds
+  nothing to write and its own `element.value !== value` guard is what
+  does the skipping. Nothing here reaches into React's internals, mutates
+  props React holds, or intercepts a value setter.
+
+  ## The shadow is released unconditionally, and that is the safety rider
+
+  The worst thing this could degrade to is a field stuck showing a draft
+  the model never agreed to. It cannot, because **every path out of a
+  composition releases the shadow** and there is no path that only
+  *some* of them cover:
+
+  - `compositionend` — the ordinary end, commit or cancel alike;
+  - a change event that is **not** composing — which is what recovers a
+    composition some *other* value write aborted silently, since the
+    abort itself fires nothing;
+  - `blur` — the composition the browser abandoned with the focus;
+  - unmount, for free: the shadow is this component's own `useState` and
+    cannot outlive the element that holds it. There is no registry, no
+    node property and no module-level record to strand.
+
+  A release is `set-shadow(nil)`, and a release when nothing is held is
+  free — React bails out of an update to an identical state. So the
+  degenerate outcome is a converge, which is exactly today's conduct."
+  (:require ["react" :as react]
+            ["react-dom" :as react-dom]))
 
 (defn- noop [])
 
@@ -194,6 +262,32 @@
   about it."
   [node]
   (.-defaultValue node))
+
+;; ---------------------------------------------------------------------------
+;; The composition reading
+;; ---------------------------------------------------------------------------
+
+(defn composing-input?
+  "Did this change event arrive in the middle of a live IME composition?
+
+  Read off the **native** event, for the reason
+  [[re-frame.bench.hicasso.front.intent/composing?]] states at length:
+  React hands a handler a synthetic event built by copying an enumerated
+  interface, and what is not on the list is not on the event.
+
+  This is deliberately **not** that gate, and not a second spelling of
+  it. The key-map's gate answers a KEY event, and it needs the legacy
+  keyCode-229 signal because that is all some IMEs send on a keydown. An
+  `input` event has no `keyCode` to read, and every browser that fires
+  composition events at all sets `isComposing` on the input events a
+  composition produces. Two different events, two readings; folding them
+  together would put a key signal on a path that cannot produce one.
+
+  A raw DOM event has no `nativeEvent`, and a synthetic `#js {:target …}`
+  from a node-side row has neither — so both read *not composing*, which
+  is what keeps every row written before the carve-out reading as it did."
+  [e]
+  (true? (some-> (.-nativeEvent e) (.-isComposing))))
 
 ;; ---------------------------------------------------------------------------
 ;; The converge
@@ -266,7 +360,17 @@
   restore; it is the same question [[install!]] asked, asked again at
   the only other moment it can change. Answered no, the element is
   left exactly as React leaves it — which is what it would have been
-  had it been minted as a `number` field to begin with."
+  had it been minted as a `number` field to begin with.
+
+  ## The two call sites, and why they are one behaviour
+
+  Since rf2-digtt this runs at the end of a change handler that is
+  **not** composing, and again once at `compositionend`. HD-019 grants
+  the `flushSync` exception to an audited call site rather than to a
+  count, and its addendum audits the second: same element, same
+  namespace, same door, and at most one of them per event. The
+  composition path is the keystroke path with its convergence deferred
+  to the end of the exchange — not a second mechanism."
   [node]
   (let [dom-value (.-value node)
         caret-was (.-selectionStart node)]
@@ -279,7 +383,7 @@
   nil)
 
 ;; ---------------------------------------------------------------------------
-;; Installation — what the element path calls
+;; The guards
 ;; ---------------------------------------------------------------------------
 
 (def ^:private caret-types
@@ -314,33 +418,184 @@
     (fn? (unchecked-get js-props "onInput"))  "onInput"
     :else                                     nil))
 
-(defn- convergeable?
-  "Is this element one whose rendered value React records on the node?
-  See the namespace docstring — each clause is a condition on the
-  record, not a taste about which elements deserve the behaviour."
+(defn- controlled-text-tag?
+  "Is this a form control React mirrors a controlled `value` onto?
+
+  **The `:type` is deliberately not asked**, and that omission is the
+  whole difference between this and [[convergeable?]]. This predicate
+  chooses a React element TYPE, and an element type that changed under a
+  live field would remount it — losing the focus, the selection and any
+  composition in flight — where the attribute change React actually
+  performs loses nothing. The type-flip row in
+  `arm1_controlled_grid_dom_cljs_test` measures precisely that node
+  identity, and a `text` → `number` keystroke is the case it measures."
   [tag js-props]
   (and (convergeable-tag? tag)
-       (some? (unchecked-get js-props "value"))
+       (some? (unchecked-get js-props "value"))))
+
+(defn- convergeable?
+  "Is this element one whose rendered value React records on the node,
+  and which has a handler to converge at the end of? See the namespace
+  docstring — each clause is a condition on the record, not a taste
+  about which elements deserve the behaviour."
+  [tag js-props]
+  (and (controlled-text-tag? tag js-props)
        (nil? (unchecked-get js-props "defaultValue"))
-       (caret-type? tag js-props)))
+       (caret-type? tag js-props)
+       (some? (change-slot js-props))))
+
+;; ---------------------------------------------------------------------------
+;; The composition shadow — the half of the carve-out that is React's
+;; ---------------------------------------------------------------------------
+
+(def ^:private native-tag-key
+  "Where [[shadow-component]] records the tag it renders, so
+  [[element-tag]] can answer for an emitted element without knowing
+  this namespace exists."
+  "hicassoNativeTag")
+
+(defn- shadowed-props
+  "The props the native tag is rendered with while `shadow` is held —
+  the author's, with the value and three handlers replaced.
+
+  `shadow` is `nil` when no composition is live, and the value the
+  element renders is then the author's own; while it is held, **the
+  value React sees is the live DOM draft**, which is the entire
+  mechanism: React's restore assigns `element.value` only when it
+  differs from the controlled value, so agreeing with the draft is what
+  makes the restore a no-op. See the namespace docstring.
+
+  Three slots, and each is a release or a hold:
+
+  - the **change slot** — [[install!]]'s converging handler, called
+    first so the author's handler and the model move exactly as they
+    always did. Composing, the draft is held and the converge inside it
+    has already declined to run; not composing, the shadow is released
+    *before* the inner handler, so the release renders inside the
+    converge's own `flushSync` and one flush does both jobs.
+  - **`onCompositionEnd`** — release, then converge once against the
+    then-current model. This is where a refusal lands, whole and
+    visible, on a field whose model would have destroyed the exchange
+    to say so.
+  - **`onBlur`** — release, and nothing else. A blurred field has no
+    caret worth restoring; the release alone re-renders the model's
+    value and React's own commit writes it.
+
+  The author's handler at each slot is preserved and called; an element
+  with no handler at a slot simply has one now, which is invisible."
+  [props shadow set-shadow]
+  (let [out      (js/Object.assign #js {} props)
+        release! (fn [] (set-shadow nil))
+        slot     (change-slot props)
+        inner    (unchecked-get props slot)
+        ended    (unchecked-get props "onCompositionEnd")
+        blurred  (unchecked-get props "onBlur")]
+    (when (some? shadow)
+      (unchecked-set out "value" shadow))
+    (unchecked-set out slot
+                   (fn hicasso-composition-shadow [e]
+                     (if (composing-input? e)
+                       (do (inner e)
+                           (set-shadow (some-> (.-target e) (.-value))))
+                       (do (release!)
+                           (inner e)))
+                     nil))
+    (unchecked-set out "onCompositionEnd"
+                   (fn hicasso-composition-end [e]
+                     (when (fn? ended) (ended e))
+                     (release!)
+                     (when-some [node (.-target e)]
+                       (converge! node))
+                     nil))
+    (unchecked-set out "onBlur"
+                   (fn hicasso-composition-release [e]
+                     (when (fn? blurred) (blurred e))
+                     (release!)
+                     nil))
+    out))
+
+(defn- shadow-component
+  "The internal component that holds the composition shadow for `tag`.
+
+  ONE `useState`, no ref, no effect, and no props of its own: the author
+  writes `[:input {:value … :on-input …}]` and the element path decides
+  this stands in front of it. It is a *public-React* mechanism on
+  purpose — the ruling's preference and this file's — because the only
+  supported way to change what React's controlled restore compares
+  against is to change what React rendered.
+
+  **It stands in front of every controlled `input`/`textarea`, not only
+  the convergeable ones**, and asks [[convergeable?]] again inside. A
+  component chosen by a predicate that reads `:type` would flip to the
+  bare tag the moment a synchronous handler re-rendered the field from
+  `text` to `number` — remounting the element React would otherwise have
+  kept, which is a strictly worse outcome than the inert render this
+  costs. Where the answer is no the props go through **by identity**: no
+  copy, no closures, nothing but the fiber and its one hook cell."
+  [tag]
+  (let [component (fn [props]
+                    (let [hook       (react/useState nil)
+                          shadow     (aget hook 0)
+                          set-shadow (aget hook 1)]
+                      (react/createElement
+                       tag
+                       (if (convergeable? tag props)
+                         (shadowed-props props shadow set-shadow)
+                         props))))]
+    (unchecked-set component "displayName" (str "hicasso/controlled-" tag))
+    (unchecked-set component native-tag-key tag)
+    component))
+
+(def ^:private shadow-input (shadow-component "input"))
+(def ^:private shadow-textarea (shadow-component "textarea"))
+
+(defn element-tag
+  "The native tag `e` will render — `\"input\"` for a controlled field
+  whose element type is the shadow component, and `(.-type e)` for
+  everything else.
+
+  The one reader an element-tree test needs, so that walking what the
+  codec emitted stays a question about the DOM rather than about this
+  namespace. `front/census_article_editor_cljs_test` picks its inputs
+  out of a rendered fieldset with it."
+  [e]
+  (let [t (.-type e)]
+    (or (when (fn? t) (unchecked-get t native-tag-key))
+        t)))
+
+;; ---------------------------------------------------------------------------
+;; Installation — what the element path calls
+;; ---------------------------------------------------------------------------
 
 (defn install!
-  "Wrap the change handler on `js-props` so the element converges in-turn
-  with the caret intact. Mutates the props object the codec has just
-  built and is about to hand to `createElement`, and returns it.
+  "Prepare `js-props` and answer **what to render them as**.
 
-  A fresh wrapper per render is the same shape the codec already has for
-  every lowered intent, and it closes over nothing but the author's
-  handler — deliberately **not** over the value, which is the stale
-  reading [[converge-to!]] exists to keep out of the write."
+  Mutates the props object the codec has just built and is about to hand
+  to `createElement`, and returns the component for it: the tag itself
+  for everything that is not a controlled `input`/`textarea`, and
+  [[shadow-component]]'s otherwise.
+
+  Where the element is [[convergeable?]] the change handler is wrapped
+  so the field converges in-turn with the caret intact — unless the
+  event arrived mid-composition, which is the carve-out's first half and
+  is one reading of the native event. A fresh wrapper per render is the
+  same shape the codec already has for every lowered intent, and it
+  closes over nothing but the author's handler — deliberately **not**
+  over the value, which is the stale reading [[converge-to!]] exists to
+  keep out of the write."
   [tag js-props]
   (when (convergeable? tag js-props)
-    (when-some [slot (change-slot js-props)]
-      (let [handler (unchecked-get js-props slot)]
-        (unchecked-set js-props slot
-                       (fn hicasso-converging-change [e]
-                         (handler e)
+    (let [slot    (change-slot js-props)
+          handler (unchecked-get js-props slot)]
+      (unchecked-set js-props slot
+                     (fn hicasso-converging-change [e]
+                       (handler e)
+                       (when-not (composing-input? e)
                          (when-some [node (.-target e)]
-                           (converge! node))
-                         nil)))))
-  js-props)
+                           (converge! node)))
+                       nil))))
+  (if (controlled-text-tag? tag js-props)
+    (case tag
+      "input"    shadow-input
+      "textarea" shadow-textarea)
+    tag))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/controlled_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/controlled_dom_cljs_test.cljs
@@ -256,6 +256,94 @@
           (finally (drop! node)))))))
 
 ;; ---------------------------------------------------------------------------
+;; The composition carve-out, at the mechanism (rf2-digtt)
+;; ---------------------------------------------------------------------------
+;;
+;; Two halves, and these rows read the half that lives in the element
+;; path: the converge declines to run when the change event arrived
+;; mid-composition. The other half — the shadow that makes React's own
+;; restore a no-op — needs React, and is read in
+;; `arm1_controlled_grid_dom_cljs_test` §7; the exchange itself needs a
+;; browser composition and is read by `bench/hicasso/ime_run.cjs`.
+
+(deftest a-composing-change-event-is-the-one-argument-that-suppresses-the-converge
+  (testing "the same element, the same refused keystroke, one property
+           different on the event. Not composing, the refused character
+           comes off the screen in-turn as it always did; composing, the
+           field is left exactly as the IME left it and the model has
+           still refused — which is the whole of the carve-out's first
+           half"
+    (if-not (browser?)
+      (skip! ":node-test has no DOM")
+      (let [!ran (atom 0)
+            hiccup [:input {:value "12345" :on-input (fn [_e] (swap! !ran inc))}]
+            handler (fn [] (slot (codec/as-element hiccup) "onInput"))]
+        (testing "not composing — the converge runs"
+          (let [node (field! "12345")]
+            (try
+              (typed! node "z" 2)
+              ((handler) #js {:target node})
+              (is (= {:value "12345" :caret [2 2]} (reading node)))
+              (finally (drop! node)))))
+        (testing "composing — it does not"
+          (let [node (field! "12345")]
+            (try
+              (typed! node "z" 2)
+              ((handler) #js {:target node :nativeEvent #js {:isComposing true}})
+              (is (= {:value "12z345" :caret [3 3]} (reading node))
+                  "the draft and the caret are untouched")
+              (finally (drop! node)))))
+        (is (= 2 @!ran)
+            "and the author's handler ran BOTH times — the carve-out
+             suppresses the converge, never the model")))))
+
+(deftest the-composition-reading-is-taken-off-the-native-event
+  (testing "React hands a handler a synthetic event, so a gate reading
+           `isComposing` off it would be dead. A synthetic target from a
+           node-side row carries no native event at all, which is why
+           every row written before the carve-out reads as it did"
+    (is (false? (controlled/composing-input? #js {:target #js {}})))
+    (is (false? (controlled/composing-input? #js {})))
+    (is (false? (controlled/composing-input? #js {:nativeEvent #js {}})))
+    (is (false? (controlled/composing-input? #js {:nativeEvent #js {:isComposing false}})))
+    (is (true? (controlled/composing-input? #js {:nativeEvent #js {:isComposing true}})))))
+
+(deftest the-element-type-does-not-move-when-the-input-type-does
+  (testing "why the shadow's component is chosen without reading `:type`.
+           A React element type that changed would REMOUNT the field —
+           taking focus, selection and any composition with it — and a
+           synchronous handler re-rendering the same `<input>` from `text`
+           to `number` is a measured case, not a hypothetical
+           (`arm1_controlled_grid_dom_cljs_test/a-type-change-inside-the-flush-leaves-the-converge-inert`
+           asserts React kept the node). The converge's own guard still
+           reads the type — one render later, where a wrong answer costs
+           nothing"
+    (let [f   (fn [_e])
+          typ (fn [props] (.-type (codec/as-element [:input props])))
+          controlled-as (fn [t] (typ (cond-> {:value "1" :on-input f}
+                                       (some? t) (assoc :type t))))]
+      (is (identical? (controlled-as "text") (controlled-as "number"))
+          "one element type across the flip the row above measures")
+      (is (identical? (controlled-as nil) (controlled-as "password")))
+      (is (identical? (controlled-as "text") (controlled-as "checkbox")))
+      (is (= "input" (typ {:on-input f}))
+          "while an uncontrolled input is still emitted as the bare tag —
+           the shadow has no controlled value to hold"))))
+
+(deftest the-tag-an-emitted-element-renders-is-readable-without-knowing-this-namespace
+  (testing "a controlled field's element type is the shadow's component,
+           so an element-tree reader asks for the TAG rather than the
+           type. Everything else answers itself"
+    (let [f (fn [_e])
+          tag-of (fn [hiccup] (controlled/element-tag (codec/as-element hiccup)))]
+      (is (= "input" (tag-of [:input {:value "x" :on-input f}])))
+      (is (= "textarea" (tag-of [:textarea {:value "x" :on-input f}])))
+      (is (= "input" (tag-of [:input {:on-input f}]))
+          "an uncontrolled input is emitted as the tag, and answers it")
+      (is (= "div" (tag-of [:div {}])))
+      (is (= "select" (tag-of [:select {:value "x" :on-input f}]))))))
+
+;; ---------------------------------------------------------------------------
 ;; What it leaves alone — every guard, by identity
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/ime_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ime_run.cjs
@@ -665,10 +665,20 @@ async function runImpl(browser, impl) {
       by.hicasso.digits.model === by.react.digits.model &&
         by.hicasso.digits.closed === by.react.digits.closed,
       { hicasso: by.hicasso.digits, react: by.react.digits });
-    R.check('comparative: on the normalising field the same divergence, scoped the same way',
+    R.check('comparative: on the normalising field the same divergence — one uninterrupted exchange against two, a compositionend against none',
       by.hicasso.upper.starts === 1 && by.react.upper.starts === 2 &&
-        by.hicasso.upper.model === by.react.upper.model,
+        by.hicasso.upper.ends === 1 && by.react.upper.ends === 0,
       { hicasso: by.hicasso.upper, react: by.react.upper });
+    // MEASURED 2026-08-03, and the row the digits scope-claim above does
+    // NOT extend to: on a normalising model the baseline's abort does not
+    // merely lose the composition, it CORRUPTS what the exchange commits.
+    // Each aborted draft is written back into the field, and the IME's
+    // next composition composes on top of it — `s` → `S`, `sh` on top of
+    // `S` → `SSH`, the commit on top of that → `SSHSH`. The arm, having
+    // written nothing until the end, commits the `SH` the user typed.
+    R.check('comparative: THE SCOPE, on the normalising field — the arm commits what was composed; the baseline commits what its own restarts left behind',
+      by.hicasso.upper.model === 'SH' && by.react.upper.model === 'SSHSH',
+      { hicasso: by.hicasso.upper.model, react: by.react.upper.model });
   }
   if (by.hicasso && by['uix-port']) {
     const R = by.hicasso.R;

--- a/implementation/freehand/test/re_frame/bench/hicasso/ime_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ime_run.cjs
@@ -96,8 +96,8 @@ const READY_TIMEOUT_MS = 60 * 1000;
 
 // The check floor (the rf2-qqzmf lesson, carried here): a run that
 // asserted almost nothing must not exit 0. A full three-page run banks
-// ~150 checks; 100 refuses a silently-skipped page while leaving room
-// for per-impl variation.
+// ~120 checks (122 as of rf2-digtt's carve-out rows); 100 refuses a
+// silently-skipped page while leaving room for per-impl variation.
 const MIN_CHECKS = 100;
 
 const ALL_IMPLS = ['hicasso', 'react', 'uix-port'];

--- a/implementation/freehand/test/re_frame/bench/hicasso/ime_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ime_run.cjs
@@ -37,12 +37,26 @@
 // carriage of composition state on the native event, a cancelled
 // exchange leaving field and model exactly as before, a model-agreeing
 // exchange surviving to `compositionend`). RECORDED rows pin the
-// MEASURED per-implementation behaviour — the mid-composition rewrite a
-// refusing or normalising model provokes — so drift reds the run without
-// the row claiming the behaviour is desired. The comparative section
-// then asserts Arm 1's converge is nowhere WORSE than the plain-React
-// baseline measured in the same run, which is the question the PR #7371
-// audit put to this harness.
+// MEASURED per-implementation behaviour, so drift reds the run without
+// the row claiming the behaviour is desired.
+//
+// Since **rf2-digtt** the mid-composition rows are two conducts rather
+// than one, and the difference is the point. `hicasso` carries the
+// COMPOSITION CARVE-OUT — nothing writes a controlled text field while a
+// composition is live, and the refusal or normalisation lands whole at
+// `compositionend` — so its rows are `(CARVE-OUT)`. `react` and
+// `uix-port` keep the old `(pinned, DIVERGENT)` rows because the abort is
+// still what they do. The comparative section, which used to assert
+// PARITY (the converge is nowhere worse than React's own restore — the
+// PR #7371 audit's question, and true when it was asked), now asserts
+// the DIVERGENCE and its scope: one uninterrupted exchange against two,
+// and the same model and the same field once the exchange closes.
+//
+// **Witness scope: Chromium only.** `Input.imeSetComposition` is a CDP
+// method and CDP is Chromium's protocol, so every claim in this file is
+// witnessed on Chromium and nowhere else. WebKit's composition/key
+// ordering has had defects of its own; this harness cannot drive it, and
+// misconduct there would be a new bug rather than a known one.
 //
 // ## Why the bundle is a DEV build (`shadow-cljs compile`), not `release`
 //
@@ -383,16 +397,23 @@ async function s4Cancel(page, cdp, R) {
     if (field === 'plain') {
       R.check('s4 [plain]: a compositionend closed the exchange, with empty data',
         ends.length >= 1 && ends[ends.length - 1].data === '', ends.map((e) => e.data));
+    } else if (R.impl === 'hicasso') {
+      // THE CARVE-OUT, on the cancel path (rf2-digtt). Nothing wrote the
+      // field while the composition was live, so there IS a composition
+      // for the cancel to cancel — and cancelling it is the ordinary
+      // exchange the `plain` branch above asserts, on a field whose model
+      // refused every intermediate state.
+      R.check('s4 [digits]: the refusing field cancels like any other — a compositionend closed the exchange, with empty data',
+        ends.length >= 1 && ends[ends.length - 1].data === '', ends.map((e) => e.data));
     } else {
-      // MEASURED, first run of this harness, all three implementations:
-      // on the refusing field there is NO compositionend to observe. The
-      // model refused `か`, the implementation wrote the refused-to value
-      // back MID-composition, and that write silently aborted the
-      // exchange (the measured JS-write semantics — no compositionend
-      // fires on an abort). The later cancel found no composition left
-      // to cancel. Pinned so a composition carve-out landing upstream
-      // reds this row and gets it rewritten on purpose.
-      R.check('s4 [digits] (pinned): the exchange was already silently aborted — no compositionend ever fired',
+      // MEASURED, first run of this harness (2026-08-02), and now the
+      // DIVERGENCE rather than the parity: on plain React and on the UIx
+      // port there is NO compositionend to observe. The model refused
+      // `か`, the implementation wrote the refused-to value back
+      // MID-composition, and that write silently aborted the exchange
+      // (the measured JS-write semantics — no compositionend fires on an
+      // abort). The later cancel found no composition left to cancel.
+      R.check('s4 [digits] (pinned, DIVERGENT): the exchange was already silently aborted — no compositionend ever fired',
         ends.length === 0, ends.map((e) => e.data));
     }
     R.check(`s4 [${field}]: nothing committed`, st.committed[field] === undefined, st.committed);
@@ -400,19 +421,36 @@ async function s4Cancel(page, cdp, R) {
 }
 
 // ---------------------------------------------------------------------------
-// Scenario 5 — the mid-composition conduct matrix (the PR #7371 question)
+// Scenario 5 — the mid-composition conduct matrix (the PR #7371 question,
+// and since rf2-digtt the carve-out's own witness)
 // ---------------------------------------------------------------------------
 //
-// `digits` refuses the composition text, `upper` normalises it, and each
-// implementation converges the field toward the model SOMEWHERE — Arm 1's
-// converge inside the input event, React's restore at the end of the same
-// discrete event, the uix-port on the after-render queue when nothing
-// re-rendered. Every one of those writes aborts the live composition (the
-// measured JS-write semantics above). The rows RECORD that per
-// implementation, pinned, so the day a composition carve-out lands the
-// row goes red and gets rewritten on purpose.
+// `digits` refuses the composition text and `upper` normalises it, so on
+// both fields the model DISAGREES with what the IME is composing. That
+// disagreement is what every implementation used to resolve by writing
+// the field mid-composition — Arm 1's converge inside the input event,
+// React's restore at the end of the same discrete event, the uix-port on
+// the after-render queue — and every one of those writes silently aborts
+// the live exchange (the measured JS-write semantics in the header).
+//
+// **These rows were the tripwire the carve-out ruling was told to trip,
+// and they are flipped here on purpose (rf2-digtt).** Two conducts now,
+// asserted as a DIVERGENCE rather than as parity:
+//
+//   - `hicasso` re-pins ONE uninterrupted compositionstart → compositionend
+//     exchange. Nothing writes the field while the composition is live;
+//     the model refuses or normalises every intermediate state exactly as
+//     before; and the refusal or normalisation lands whole, once, at the
+//     commit.
+//   - `react` and `uix-port` keep pinning the OLD abort conduct, because
+//     it is still what they do and the pins are still true of them. They
+//     are the baseline the divergence is measured against, in the same
+//     run, on the same model.
 
 async function s5MidComposition(page, cdp, R, out) {
+  // The carve-out is Arm 1's; the other two pages are the baseline.
+  const carved = R.impl === 'hicasso';
+
   // -- digits: the refusing model -------------------------------------------
   await reset(page);
   await focusEnd(page, 'digits');
@@ -430,23 +468,55 @@ async function s5MidComposition(page, cdp, R, out) {
   await settle(page);
   const st2 = await state(page);
   const starts = ofType(nativeOf(st2, 'digits'), 'compositionstart').length;
-  await cancel(cdp);
+  const mid = (await fieldRead(page, 'digits')).value;
+
+  // COMMIT, rather than cancel: the carve-out defers the refusal to
+  // exactly here, so the row that reads it has to let the exchange close.
+  await commit(cdp, 'しん');
   await settle(page);
+  const st3 = await state(page);
+  const ends = ofType(nativeOf(st3, 'digits'), 'compositionend').length;
+  const closed = await fieldRead(page, 'digits');
 
   R.check('s5 [digits]: LAW — the refusing model never moved', modelAfter === '12', modelAfter);
+  R.check('s5 [digits]: LAW — and it had not moved when the exchange closed either',
+    st3.cells.digits === '12', st3.cells.digits);
   R.record('s5 [digits]: field immediately after the composing input (no settle)', immediate);
   R.record('s5 [digits]: field after settle', settled.value);
-  R.record('s5 [digits]: compositionstart count across one attempted exchange', starts);
+  R.record('s5 [digits]: field after the second composing update', mid);
+  R.record('s5 [digits]: compositionstart count across one exchange', starts);
+  R.record('s5 [digits]: compositionend count across one exchange', ends);
+  R.record('s5 [digits]: field once the exchange closed', closed.value);
 
-  const immediateExpected = { hicasso: '12', react: '12', 'uix-port': '12し' }[R.impl];
-  R.check(`s5 [digits] (pinned): the refused composition text is rewritten ${R.impl === 'uix-port' ? 'ONE FRAME LATE' : 'IN-TURN'}`,
-    immediate === immediateExpected, { immediate, expected: immediateExpected });
-  R.check('s5 [digits] (pinned): after settling, the write has landed and the field shows the refused-to value',
-    settled.value === '12', settled.value);
-  R.check('s5 [digits] (pinned): the write ABORTED the live composition — the next IME update minted a NEW compositionstart',
-    starts === 2, starts);
+  if (carved) {
+    R.check('s5 [digits] (CARVE-OUT): the composing input wrote NOTHING — the draft is on the screen in-turn',
+      immediate === '12し', immediate);
+    R.check('s5 [digits] (CARVE-OUT): and nothing wrote it after the settle either — not the converge, not React\'s restore',
+      settled.value === '12し', settled.value);
+    R.check('s5 [digits] (CARVE-OUT): the exchange was never aborted — ONE compositionstart across the whole of it',
+      starts === 1, starts);
+    R.check('s5 [digits] (CARVE-OUT): the second update grew the SAME draft',
+      mid === '12しん', mid);
+    R.check('s5 [digits] (CARVE-OUT): the exchange reached compositionend — exactly one, where the baseline has none',
+      ends === 1, ends);
+    R.check('s5 [digits] (CARVE-OUT): and the refusal landed WHOLE at the commit — the field is the model\'s again',
+      closed.value === '12', closed.value);
+  } else {
+    const immediateExpected = { react: '12', 'uix-port': '12し' }[R.impl];
+    R.check(`s5 [digits] (pinned, DIVERGENT): the refused composition text is rewritten ${R.impl === 'uix-port' ? 'ONE FRAME LATE' : 'IN-TURN'}`,
+      immediate === immediateExpected, { immediate, expected: immediateExpected });
+    R.check('s5 [digits] (pinned, DIVERGENT): after settling, the write has landed and the field shows the refused-to value',
+      settled.value === '12', settled.value);
+    R.check('s5 [digits] (pinned, DIVERGENT): the write ABORTED the live composition — the next IME update minted a NEW compositionstart',
+      starts === 2, starts);
+    R.check('s5 [digits] (pinned, DIVERGENT): and no compositionend was ever delivered for it',
+      ends === 0, ends);
+  }
 
-  out.digits = { immediate, settled: settled.value, caret: [settled.s, settled.e], starts };
+  out.digits = {
+    immediate, settled: settled.value, caret: [settled.s, settled.e],
+    starts, ends, closed: closed.value, model: st3.cells.digits,
+  };
 
   // -- upper: the normalising model -----------------------------------------
   await reset(page);
@@ -461,21 +531,42 @@ async function s5MidComposition(page, cdp, R, out) {
 
   await compose(cdp, 'sh');
   await settle(page);
-  const st3 = await state(page);
-  const upStarts = ofType(nativeOf(st3, 'upper'), 'compositionstart').length;
-  await cancel(cdp);
+  const st4 = await state(page);
+  const upStarts = ofType(nativeOf(st4, 'upper'), 'compositionstart').length;
+
+  await commit(cdp, 'sh');
   await settle(page);
+  const st5 = await state(page);
+  const upEnds = ofType(nativeOf(st5, 'upper'), 'compositionend').length;
+  const upClosed = await fieldRead(page, 'upper');
 
   R.check('s5 [upper]: the model normalised the intermediate composition text', upModel === 'S', upModel);
   R.record('s5 [upper]: field immediately after the composing input', upImmediate);
   R.record('s5 [upper]: field after settle', upSettled.value);
-  R.record('s5 [upper]: compositionstart count across one attempted exchange', upStarts);
-  R.check('s5 [upper] (pinned): the normalised value is written back over the live composition',
-    upSettled.value === 'S', upSettled.value);
-  R.check('s5 [upper] (pinned): and that write aborted the composition',
-    upStarts === 2, upStarts);
+  R.record('s5 [upper]: compositionstart count across one exchange', upStarts);
+  R.record('s5 [upper]: compositionend count across one exchange', upEnds);
+  R.record('s5 [upper]: field once the exchange closed', upClosed.value);
+  R.record('s5 [upper]: model once the exchange closed', st5.cells.upper);
 
-  out.upper = { immediate: upImmediate, settled: upSettled.value, starts: upStarts };
+  if (carved) {
+    R.check('s5 [upper] (CARVE-OUT): the composing input wrote nothing — the field shows the DRAFT while the model holds the normalisation',
+      upSettled.value === 's' && upModel === 'S', { field: upSettled.value, model: upModel });
+    R.check('s5 [upper] (CARVE-OUT): the exchange was never aborted', upStarts === 1, upStarts);
+    R.check('s5 [upper] (CARVE-OUT): it reached compositionend', upEnds === 1, upEnds);
+    R.check('s5 [upper] (CARVE-OUT): and the normalisation landed whole at the commit',
+      upClosed.value === 'SH' && st5.cells.upper === 'SH',
+      { field: upClosed.value, model: st5.cells.upper });
+  } else {
+    R.check('s5 [upper] (pinned, DIVERGENT): the normalised value is written back over the live composition',
+      upSettled.value === 'S', upSettled.value);
+    R.check('s5 [upper] (pinned, DIVERGENT): and that write aborted the composition',
+      upStarts === 2, upStarts);
+  }
+
+  out.upper = {
+    immediate: upImmediate, settled: upSettled.value, starts: upStarts,
+    ends: upEnds, closed: upClosed.value, model: st5.cells.upper,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -550,23 +641,40 @@ async function runImpl(browser, impl) {
     process.exit(1);
   }
 
-  // Comparative verdict: Arm 1's converge against the plain-React
-  // baseline measured in the SAME run. This is the audit's question in
-  // executable form — mid-composition, is the converge anywhere WORSE
-  // than what React's own restore already does?
+  // Comparative verdict: Arm 1's carve-out against the plain-React
+  // baseline measured in the SAME run, on the same model, in the same
+  // browser. Until rf2-digtt this section asserted PARITY — the converge
+  // is nowhere worse than React's own restore — and it was true. The
+  // ruling replaced the question: the arm is now deliberately BETTER
+  // here, and what has to be asserted is that the divergence is real and
+  // that it is scoped to the live composition and nothing else.
   const by = Object.fromEntries(outcomes.map((o) => [o.impl, o]));
   if (by.hicasso && by.react) {
     const R = by.hicasso.R;
     console.log(';; ==== IME comparative (hicasso vs the plain-React baseline) ====');
-    R.check('comparative: on the refusing field the converge does exactly what React does — same in-turn rewrite, same abort',
-      by.hicasso.digits.immediate === by.react.digits.immediate &&
-        by.hicasso.digits.settled === by.react.digits.settled &&
-        by.hicasso.digits.starts === by.react.digits.starts,
+    R.check('comparative: THE DIVERGENCE — one uninterrupted exchange on the arm where React aborts and the IME restarts',
+      by.hicasso.digits.starts === 1 && by.react.digits.starts === 2,
+      { hicasso: by.hicasso.digits.starts, react: by.react.digits.starts });
+    R.check('comparative: and the arm reaches a compositionend where React delivers none at all',
+      by.hicasso.digits.ends === 1 && by.react.digits.ends === 0,
+      { hicasso: by.hicasso.digits.ends, react: by.react.digits.ends });
+    R.check('comparative: mid-composition the arm shows the DRAFT where React has already written the refused-to value',
+      by.hicasso.digits.settled === '12し' && by.react.digits.settled === '12',
+      { hicasso: by.hicasso.digits.settled, react: by.react.digits.settled });
+    R.check('comparative: THE SCOPE — the refusal itself is identical. Same model throughout, same field once the exchange closes',
+      by.hicasso.digits.model === by.react.digits.model &&
+        by.hicasso.digits.closed === by.react.digits.closed,
       { hicasso: by.hicasso.digits, react: by.react.digits });
-    R.check('comparative: on the normalising field likewise',
-      by.hicasso.upper.settled === by.react.upper.settled &&
-        by.hicasso.upper.starts === by.react.upper.starts,
+    R.check('comparative: on the normalising field the same divergence, scoped the same way',
+      by.hicasso.upper.starts === 1 && by.react.upper.starts === 2 &&
+        by.hicasso.upper.model === by.react.upper.model,
       { hicasso: by.hicasso.upper, react: by.react.upper });
+  }
+  if (by.hicasso && by['uix-port']) {
+    const R = by.hicasso.R;
+    R.check('comparative: the UIx port aborts the exchange too — one frame later, and the arm diverges from it identically',
+      by.hicasso.digits.starts === 1 && by['uix-port'].digits.starts === 2,
+      { hicasso: by.hicasso.digits.starts, 'uix-port': by['uix-port'].digits.starts });
   }
 
   console.log(';; ==== IME RUNTIME ====');

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/hook_budget_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/hook_budget_dom_cljs_test.cljs
@@ -49,7 +49,7 @@
     declares, so a second one appearing anywhere reds;
   - **no hook of any kind is interleaved into a shell's pair**: every
     `useContext` is immediately followed by its `useSyncExternalStore`,
-    which is the property that makes "not in a shell" a measurement
+    which is the property that makes *not in a shell* a measurement
     rather than an assurance.
 
   The cost is per controlled TEXT FIELD, not per boundary and not per

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/hook_budget_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/hook_budget_dom_cljs_test.cljs
@@ -11,11 +11,11 @@
   So this file re-takes it on the roster, with the same probe, counting
   at React's own dispatcher:
 
-  | shape | boundaries | reads | hooks |
-  |---|---|---|---|
-  | 1 ordinary | 7 | 15 | 14 |
-  | 2 large template | **1** | **141** | **2** |
-  | 3/4 feed | 301 | 603 | 602 |
+  | shape | boundaries | reads | shell hooks | shadow hooks |
+  |---|---|---|---|---|
+  | 1 ordinary | 7 | 15 | 14 | **1** |
+  | 2 large template | **1** | **141** | **2** | 0 |
+  | 3/4 feed | 301 | 603 | 602 | 0 |
 
   Row 2 is the one worth reading twice. One hundred and forty-one
   subscription reads — written inside a `for`, inside a plain helper
@@ -25,8 +25,36 @@
   row here at all: 141 reads would be 141 hooks, which no rule about hook
   order permits inside a loop.
 
-  **A shape that cost a third hook would be a finding, not a cost to
-  spend.** None did.
+  **A shape that cost a third hook IN A SHELL would be a finding, not a
+  cost to spend.** None does, and that is what HD-020(b)'s budget is
+  about: `2 × boundaries`, `useContext` then `useSyncExternalStore`, in
+  that order, with nothing interleaved.
+
+  ## The fourth column, and why it is not a breach (rf2-digtt)
+
+  Shape 1's page carries **one hook that is not in any shell**: the
+  `useState` belonging to
+  [[re-frame.bench.hicasso.front.controlled]]'s composition shadow,
+  which stands in front of the shape's one controlled `<textarea>` (the
+  comment draft in `shapes/ordinary`). It is the price of the IME
+  composition carve-out the operator ruled in on 2026-08-03, and this
+  file is where it is paid in public.
+
+  The budget is **untouched**, and the rows below say so in a way a
+  reading eye can check rather than take on trust:
+
+  - the shell sequence — the hooks with the shadow's `useState` removed —
+    is still the declared pair, once per boundary, in order;
+  - the shadow's hooks are counted per shape, from a number this file
+    declares, so a second one appearing anywhere reds;
+  - **no hook of any kind is interleaved into a shell's pair**: every
+    `useContext` is immediately followed by its `useSyncExternalStore`,
+    which is the property that makes "not in a shell" a measurement
+    rather than an assurance.
+
+  The cost is per controlled TEXT FIELD, not per boundary and not per
+  read — a page with no controlled input pays nothing, which rows 2 and
+  3/4 are the witnesses for.
 
   Runtime: `-dom-cljs-test`. Under `:node-test`, and on any React build
   whose internals slot has moved, the claims degrade to a stated skip or
@@ -78,19 +106,33 @@
      :boundaries (:boundaries stats)
      :edges      (:edges stats)}))
 
+(def ^:private shadow-hook
+  "The one hook a shell never asks for, and the one thing on this page
+  that is not a boundary's: the composition shadow's state cell, one per
+  controlled text element (rf2-digtt)."
+  "useState")
+
 (def ^:private shapes
   "The roster, as the probe sees it. Shape 4 is shape 3's page — the same
   mount — so it has no separate row: the budget is a property of the
-  mounted page, and one commit later cannot add a hook."
-  [{:label "1 — ordinary views"
-    :seed  {:articles 2 :comments 5 :tags 2}
-    :tree  [ordinary/screen {}]}
-   {:label "2 — large templates"
-    :seed  large-template/seed
-    :tree  [large-template/page {}]}
-   {:label "3/4 — bulk + narrow"
-    :seed  feed/seed
-    :tree  [feed/page {}]}])
+  mounted page, and one commit later cannot add a hook.
+
+  `:shadows` is the number of controlled TEXT elements the shape mounts,
+  declared here rather than derived, so a shadow appearing where no
+  controlled field exists reds the row that names it."
+  [{:label   "1 — ordinary views"
+    :seed    {:articles 2 :comments 5 :tags 2}
+    :tree    [ordinary/screen {}]
+    ;; The comment draft — `shapes/ordinary`'s one controlled `<textarea>`.
+    :shadows 1}
+   {:label   "2 — large templates"
+    :seed    large-template/seed
+    :tree    [large-template/page {}]
+    :shadows 0}
+   {:label   "3/4 — bulk + narrow"
+    :seed    feed/seed
+    :tree    [feed/page {}]
+    :shadows 0}])
 
 ;; ---------------------------------------------------------------------------
 ;; The budget, shape by shape
@@ -101,30 +143,43 @@
     (skip! ":node-test has no DOM")
     (if-not (probe/install!)
       (unwitnessed!)
-      (doseq [{:keys [label seed tree]} shapes]
+      (doseq [{:keys [label seed tree shadows]} shapes]
         (testing label
-          (let [{:keys [hooks boundaries edges]} (mount-and-count seed tree)]
+          (let [{:keys [hooks boundaries edges]} (mount-and-count seed tree)
+                shell-hooks (vec (remove #{shadow-hook} hooks))]
             (is (pos? boundaries) (str label ": the mount built boundaries to count"))
-            (is (= (* 2 boundaries) (count hooks))
+            (is (= (* 2 boundaries) (count shell-hooks))
                 (str label ": " boundaries " boundaries reading " edges
-                     " subscriptions cost " (count hooks) " hooks — the budget is "
-                     (* 2 boundaries)))
-            (is (= #{"useContext" "useSyncExternalStore"} (set hooks))
+                     " subscriptions cost " (count shell-hooks) " shell hooks — the "
+                     "budget is " (* 2 boundaries)))
+            (is (= #{"useContext" "useSyncExternalStore"} (set shell-hooks))
                 (str label ": and they are the two `shell-hook-ledger` declares"))
             (is (= (vec (mapcat (fn [_] ["useContext" "useSyncExternalStore"])
                                 (range boundaries)))
-                   (vec hooks))
+                   shell-hooks)
                 (str label ": in `shell-hook-ledger`'s order, once per boundary —
                      React runs a component's hooks to completion before it
                      starts the next, so the whole page's sequence is the
                      declared pair repeated"))
             (is (= (count rt/shell-hook-ledger) 2)
                 "and the ledger the runtime declares is still two entries long")
-            (testing "no third hook of any kind"
-              (doseq [banned ["useRef" "useState" "useMemo" "useCallback" "useEffect"
+            (testing "the composition shadow's hook, and only it (rf2-digtt)"
+              (is (= shadows (count (filter #{shadow-hook} hooks)))
+                  (str label ": one `useState` per controlled text element, "
+                       shadows " declared — the price of the IME carve-out, paid "
+                       "per FIELD rather than per boundary or per read"))
+              (is (every? (fn [[a b]] (or (not= "useContext" a)
+                                          (= "useSyncExternalStore" b)))
+                          (partition 2 1 hooks))
+                  (str label ": and never inside a shell — every `useContext` is
+                       immediately followed by its `useSyncExternalStore` in the
+                       RAW sequence, so nothing was interleaved into the pair.
+                       This is what makes \"not in a shell\" a measurement")))
+            (testing "no other hook of any kind"
+              (doseq [banned ["useRef" "useMemo" "useCallback" "useEffect"
                               "useLayoutEffect" "useReducer" "useId"]]
                 (is (not (contains? (set hooks) banned))
-                    (str label ": " banned " must not appear in a boundary shell"))))))))))
+                    (str label ": " banned " must not appear anywhere on the page"))))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The row the budget exists for


### PR DESCRIPTION
Closes rf2-digtt. Implements the operator's 2026-08-03 ruling: **the composition
carve-out is IN.** Controlled-text convergence is suppressed while an IME
composition is live, and the field converges **once**, at `compositionend`,
against the then-current model. Automatic for any `:value`/`:on-input` pair — no
public option, no config knob, authoring API unchanged.

## Why

Under the old conduct a CJK/IME user on a refusing or normalising field had
in-flight kana destroyed **mid-word**, silently: the value written back inside
the composing input event aborts the browser's composition, so no
`compositionend` fires, the field snaps back while the user is still composing,
and the IME opens a fresh composition on its next update. A composition is a
browser-owned draft of the user's. Under the carve-out it survives, and the
refusal lands whole and visibly at the commit.

## The mechanism, and why it is public-React

The obvious "skip `converge!` when `isComposing`" is proven insufficient by this
bead's own measured matrix: plain React — which has no Hicasso converge in the
loop, i.e. exactly the path a bare skip falls through to — aborts the exchange
anyway through its own end-of-discrete-event restore. So the carve-out is two
halves, because two writes destroy the exchange and only one is ours:

1. **The converge**, suppressed in the element path by one reading of the native
   event's `isComposing` (`front/controlled.cljs`, `composing-input?`).
2. **React's restore**, which is not ours to skip. An internal component
   carrying one `useState` stands in front of controlled `input`/`textarea`
   elements and, while a composition is live, **holds the value React sees at
   the live DOM draft** — so `updateInput`'s own `element.value !== value` guard
   is what does the skipping. Nothing reaches into React's internals, mutates
   props React holds, or intercepts a value setter; the only supported way to
   change what React's controlled restore compares against is to change what
   React rendered, so the mechanism is a component and a hook.

The authored handler still runs on every composing update and the model still
refuses or normalises exactly as before. Authored composition handlers are
preserved and called.

**The component deliberately does not read `:type`.** A predicate that did would
flip from the wrapper to the bare tag the moment a synchronous handler
re-rendered a field from `text` to `number` — remounting the element React
otherwise keeps, which
`arm1_controlled_grid_dom_cljs_test/a-type-change-inside-the-flush-leaves-the-converge-inert`
asserts by node identity. The `:type` question is asked *inside*, one render
later, where a wrong answer costs nothing. Where the answer is no, props go
through by identity.

## The safety rider: release is unconditional

`compositionend`; any change event that is **not** composing (the recovery path
for a composition some other write aborted silently, which fires nothing at
all); `blur`; and unmount for free — the shadow is the component's own state and
cannot outlive the element, so there is no registry, node property or
module-level record to strand. The hold/release also runs **before** the
author's handler at every slot, so a handler that throws cannot strand one
either. Worst degradation available is a converge, i.e. today's conduct. All
four paths are witnessed in `arm1_controlled_grid_dom_cljs_test` §7.

## The tripwire, flipped on purpose

`ime_run.cjs`'s s5 rows went red the day this landed, as designed, and are
rewritten as a **divergence** rather than as parity:

- `hicasso` rows re-pin one uninterrupted `compositionstart` → `compositionend`
  exchange with commit-time refusal/normalisation (`(CARVE-OUT)` rows);
- `react` and `uix-port` keep pinning the old abort conduct, now labelled
  `(pinned, DIVERGENT)` — it is still what they do, and they are the baseline;
- the comparative section, which used to assert parity, now asserts the
  divergence **and its scope**.

Measured, one run, one model, one browser (refusing field `digits`, model
`"12"`, composing `し`):

| | Arm 1 | plain React | UIx port |
|---|---|---|---|
| field, in-turn / settled | `"12し"` / `"12し"` | `"12"` / `"12"` | `"12し"` / `"12"` |
| `compositionstart` | **1** | 2 | 2 |
| `compositionend` | **1** | 0 | 0 |
| field once the exchange closes | `"12"` | `"12"` | `"12"` |
| model, throughout | `"12"` | `"12"` | `"12"` |

One new finding fell out of the re-run and is pinned: on the **normalising**
field the baseline does not merely lose the composition, it **corrupts what the
exchange commits** — each aborted draft is written back and the IME's next
composition composes on top of it, so `s`/`sh`/commit ends at model `"SSHSH"`
where Arm 1 commits the `"SH"` that was typed.

Retained unchanged: the agreeing-field survival law, the cancel law, the commit
fence on both signals, the mid-string caret rows, the restoration law. The
`s4 [digits]` row is now per-implementation: on Arm 1 the refusing field cancels
like any other, because there is a live composition left to cancel.

## Honesty riders

- **The divergence from React is stated plainly, as a claimed win, precisely
  scoped to Hicasso's converge** — on the evidence page
  (`docs/design/hicasso/studio/controlled-input-two-implementations.md`, new
  *The composition carve-out, and where it diverges from React* section with
  both measured tables), in the authoring doc
  (`docs/design/hicasso/authoring.md`, *The controlled-input door*), in the
  draft guide (`draft-guide/04-controlled-inputs.md`), and in HD-019's addendum.
- **Witness scope: Chromium CDP only**, named on the evidence page, in the
  authoring doc, in the guide, in HD-019's addendum, in `validation.md` and in
  `ime_run.cjs`'s own header. `Input.imeSetComposition` is a CDP method and CDP
  is Chromium's protocol. WebKit is **undriven rather than known-good**; a new
  driver would be gold-plating, and misconduct observed there is a new bug bead.

## HD-019 addendum

`docs/design/hicasso/decisions.md` carries a dated addendum recording the
ruling, the mechanism, the price, the safety rider and the witness scope. It
also **audits the second `flushSync` call site** the original ruling requires an
audit for: `converge!` is now reached from two places in its own namespace — the
end of a non-composing change handler, and once at `compositionend`. Same
element, same door, at most one per event.

**R-A2 is untouched** — `rf2-dfz6f` owns that rewrite and dispatches after this
merges.

## The price, on the existing grid

One React fiber and one `useState` cell per controlled `input`/`textarea`, plus
— on a convergeable one, per render — one props copy and four closures: the
three wrapped handlers and the release they share. A page with no controlled
input pays nothing.

`shapes/hook_budget_dom_cljs_test` is where it is paid in public: shape 1's page
went 14 → 15 hooks and the gate caught it. It now separates the two questions
instead of hiding either — the **shell** sequence is still `2 × boundaries`,
`useContext` then `useSyncExternalStore`, in order (**HD-020(b)'s ≤2-hook budget
is untouched**); the shadow's `useState` is counted per controlled text field
from a number the file declares; and a new assertion pins that **no hook is ever
interleaved into a shell's pair**, which is what makes "not in a shell" a
measurement rather than an assurance. `arm1/runtime.cljs`'s retention ledger
carries the same correction on its `:use-state` absent-token.

All 100-cell controlled-grid witnesses (same-turn echo, mid-string caret,
selection, unchanged-model rejection, async normalisation, the burst rows and
the type-flip row) are green unchanged.

## Quality gates

Run in the worker worktree `re-frame2-worktrees/imecarve-digtt`, foreground, to
completion, each confirmed by the runner's own terminal marker:

| gate | exit | the runner's own terminal marker |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` (0 FAIL lines; node tier `Ran 12498 tests containing 62650 assertions. 0 failures, 0 errors.`, JVM core `Ran 2210 tests containing 11510 assertions. 0 failures`, JVM freehand `Ran 1288 tests containing 8857 assertions. 0 failures`) |
| `npm run test:browser` | **0** | `Ran 1052 tests containing 6550 assertions. 0 failures, 0 errors.` |
| `node implementation/freehand/test/re_frame/bench/hicasso/ime_run.cjs` | **0** | `checks 122 (floor 100), failures 0` / `[ime] ok` |

Two notes on how those were taken, because a gate report that hides them is
worth less than one that does not:

- Two docs-prose commits landed **after** the spine's docs tier had already run,
  so the docs tier's own gates were re-run on the final tree afterwards and are
  quoted separately: `check_readme_links.py --ci`, `check_doc_slugs.py`,
  `check_ep_status_sync.py` (+ self-test), `check_runtime_subsystem_grading.py`
  (+ self-test) — **all exit 0** — and `python -m mkdocs build --strict` —
  **exit 0**. Every other tier ran against the final code tree. (Per CLAUDE.md
  `mkdocs --strict` does not cover `docs/design/**` at all; `check_doc_slugs.py`
  does validate that tree's link targets and heading anchors, and the two new
  tables' column counts and the one new `###` heading were checked by hand.)
- An earlier spine invocation was killed by a 10-minute harness timeout, and its
  partial log carried 118 `_changed-surfaces.test.cjs` failures — every one of
  them `Command failed: bash -lc ./.github/scripts/report-changed-surfaces.sh`,
  i.e. nested login shells failing under load. The step passes standalone and
  passed clean in the completed spine above (0 FAIL lines). Recorded as an
  environment flake, not a finding.

Composition witnesses take the browser's own turn: no `act`, no `flushSync` on
any path an assertion reads, and the "nothing threw" row installs a `window`
error listener because React routes a throw inside a discrete event to
`reportError` (a `try`/`catch` would read green over a live exception).
