### PR TITLE
docs(hicasso): the guide's interop opening matches the landed host grammar (rf2-2rtt6.64)

### DIFF
--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -88,7 +88,7 @@ HD-016 pins this table, and the keyed insert/delete/reorder witness enforces it.
 | Native tag — `[:div …]` | attribute map | trailing forms | `:key` in the attribute map | callback ref, legal |
 | Hicasso view — `[todo-row …]` | one props map | trailing forms, arriving as `(:children props)` | in the props map, **extracted before your body sees props** | not a v0 surface — use ids |
 | Fragment — `[:<> …]` | — | trailing forms | on the fragment's props map | — |
-| Foreign — `defhost` or `[:>]` | converted per declaration | hiccup children become elements | `:key` in props | callback ref, legal |
+| Foreign — `defhost` (and `[:>]`, once it is built) | converted per declaration | hiccup children become elements | `:key` in props | callback ref, legal |
 
 Children arrive realized and predictably flattened: nested and lazy sequences are
 realized once and flattened one level, `nil` and `false` render nothing, `true` is an

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -2,14 +2,16 @@
 
 > **Draft ahead of the product artefact.** This page teaches the landed surface —
 > ruled in [decisions.md](../decisions.md) (HD-001…HD-028). `defhost`'s door is
-> now witnessed end-to-end by the bench arm's tests under
-> `implementation/freehand/test/re_frame/bench/hicasso/` (rf2-2rtt6.65), but no
-> `implementation/hicasso/` artefact ships yet, and spellings marked
-> **[unfrozen]** stay provisional until the API freeze. Two things stay
-> deliberately unbuilt at v0 — the `[:>]` raw escape and SSR — and one default,
-> deep prop conversion, is deliberately not offered at all; two things stay
-> genuinely unsettled — `defhost`'s option keys and the codemod. See
-> **Not settled yet**.
+> witnessed end-to-end by
+> `implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs`
+> (rf2-2rtt6.65): one foreign React component with its own state, its own effects,
+> its own context read and three different invoker styles on its callbacks,
+> declared once and driven from a Hicasso tree. No `implementation/hicasso/`
+> artefact ships yet, though, and spellings marked **[unfrozen]** stay provisional
+> until the API freeze. Three things this page describes are ruled but **not
+> built** — the `[:>]` raw escape, the migration codemod and SSR — one default,
+> deep prop conversion, is deliberately not offered at all, and `defhost`'s option
+> keys are still open. See **Not settled yet**.
 
 You want a date picker from npm. In Reagent you write `[:> DatePicker {...}]` and
 move on. Hicasso asks you to write one line first:
@@ -27,21 +29,24 @@ Then use it anywhere, and it is indistinguishable from a native view:
 
 ```clojure
 (ns app.views
-  (:require [re-frame.hicasso :as h]
+  (:require [re-frame.hicasso :as h :refer [defview sub]]
             [app.hosts.date-picker :refer [date-picker]]))
 
-[date-picker {:selected  due-date
-              ;; the library hands the date first, not an event — no target
-              ;; for ::h/value to read, so h/fn takes the value directly
-              :on-change (h/fn [date & _] [:task/set-due date])}]
+(defview due-field [_]
+  [date-picker {:selected  (sub [:task/due-date])
+                ;; react-datepicker calls onChange(date) — the date first, and
+                ;; no event at argument one. An intent vector refuses there;
+                ;; h/fn takes the library's own arguments, in order.
+                :on-change (h/fn [date & _] [:task/set-due date])}])
 ```
 
 ## Why a declaration instead of `[:>]`
 
 HD-011's Ruling settles the hierarchy in a sentence: **`defhost` is the door, and the
 only form taught**; `[:>]` "survives only as the explicitly secondary raw escape …
-for the cases a static declaration cannot express." Both forms are legal. Only one is
-taught. This page is written in that order for that reason.
+for the cases a static declaration cannot express." Both forms are ruled legal.
+Only one is built, and only one is taught. This page is written in that order for
+that reason.
 
 `[:> DatePicker {...}]` puts a raw JavaScript value inside your data tree. Three
 things break at that node, all of them quietly:
@@ -57,9 +62,10 @@ things break at that node, all of them quietly:
 host namespace, and leaves the rest of your view tree pure data.
 
 The honest counter-argument is that a declaration is friction, and the counter to
-*that* is arithmetic: it amortizes to zero over every use site, and a codemod exists
-for migration. The expensive half of leaving Reagent was never `[:>]` — it was
-`r/atom`.
+*that* is arithmetic: it amortizes to zero over every use site. HD-011's rationale
+leans on a migration codemod as well, and that half has not been built, so today
+the conversion is by hand. It is a small hand: the expensive part of leaving
+Reagent was never `[:>]`, it was `r/atom`.
 
 ## The defaults
 
@@ -141,6 +147,12 @@ function`. **`h/fn` is the spelling for those positions** — it receives every
 argument the invoker passed, in order, which is exactly what the opening example
 does.
 
+Both halves are witnessed at a real crossing, which is what settles the question
+this page used to hedge. The host-hatch suite drives `::h/value` through a widget's
+event-first `onChange` and the model updates; it then drives `::h/prevent`,
+`::h/value` and a key-map through the *same* widget's value-first `onPick` and gets
+the refusal instead, naming `:on-pick` and the string that actually arrived.
+
 An intent carrying neither a marker nor `::h/prevent` never touches its argument,
 so `{:on-pick [:city/picked "paris"]}` is correct under any invoker contract at
 all.
@@ -212,10 +224,10 @@ which by looking somewhere else.
 
 ## Migrating from Reagent
 
-A codemod handles the mechanical part: collect the `[:> X …]` sites, emit the
-`defhost` block, rewrite the call sites. It runs incrementally, so a large app
-converts a namespace at a time rather than in one commit. The codemod's name and
-invocation are not in the record.
+HD-011 rules a codemod for the mechanical part — collect the `[:> X …]` sites, emit
+the `defhost` block, rewrite the call sites — but nothing has been built, and the
+record names neither a tool nor an invocation. By hand it is the same three moves,
+and it goes a namespace at a time, so a large app never needs one big commit.
 
 ## Imperative SDKs
 
@@ -376,7 +388,7 @@ This table names mechanisms; the minted ids on this surface —
 | An intent vector or key-map at a declared slot raises `:rf.error/hicasso-intent-at-a-non-event-contract` | The slot is declared `:handler` or `:render`, and neither contract dispatches — the declaration governs the carrier, so the value cannot overrule it | Declare the slot `:event` if what happens there is an event, or write an `h/fn` that does the `:handler`/`:render` work |
 | `:rf.error/hicasso-intent-needs-the-event`, naming a slot whose library hands a value first | The vector spelling reads the DOM event from argument one, and this invoker put something else there | Write an `h/fn` at that slot — it gets every argument the library passed, in order |
 | A namespace stops loading on the JVM | A JS require reached a `.cljc` file | Quarantine the require in a `.cljs` host namespace |
-| Structural test can't match a node | It's a `[:>]` node — reduced structural identity, by design | Declare it with `defhost`, or assert around it |
+| Structural test can't match a node | A `[:>]` node, once the escape is built — reduced structural identity, by design | Declare it with `defhost`, or assert around it |
 | Provider from a library needs to wrap the tree | Hosted like anything else | `defhost` the provider; it is a component |
 | A hosted component doesn't update when the page clearly changed | The boundary above it bailed out on value-equal props (HD-028) — it was never re-entered, so the host was never asked to render | Trace the value to the host's *own* boundary's props, not a parent's |
 | The SDK mounts twice in dev and you end with two live handles | StrictMode double-invoke, plus a handle stored outside the attach's closure — so the second attach overwrote the first instead of replacing it | One attach, one handle, one cleanup, all in one closure; return the cleanup from the ref |
@@ -398,10 +410,9 @@ two or three genuinely hard widgets.
 | Question | Status |
 |---|---|
 | `defhost`'s option keys | **Not addressed.** "Policy overrides live on the declaration" is as far as the record goes |
-| The codemod's name and invocation | **Not addressed** |
+| The migration codemod | **Ruled, unbuilt.** HD-011's rationale leans on it, but nothing has been built and the record names neither a tool nor an invocation |
 | When the reserved `{:ref [id config]}` spelling lands, and what registers an id | **Reserved, not designed.** HD-022 rules the refusal and the value-space; the registry, the timings and the commands roster are explicitly out of v0 |
 | Which React version the runtime targets | **Not addressed by the design record.** The cleanup-returning callback ref taught above is a React 19 contract; this repo's implementation currently pins React 19.2, but that is a fact about today's tree, not a Hicasso ruling. If v0 lands on 18, the fallback shape above is the one to teach |
-| Whether `::h/value` works across a host crossing | **Settled, and it is a law rather than a caveat.** The vector spelling is event-first, so `::h/value` works exactly when the foreign contract hands the DOM event first — the way `onChange`/`onInput` do. A value-first invoker (`onPick(value, event)`, or the date picker's `onChange` above) raises `:rf.error/hicasso-intent-needs-the-event` naming the position; write an `h/fn` there instead, as the opening example does. See **The vector spelling is event-first** above |
 | The SSR placeholder's shape | Declared policy, inert in v0 |
 | Whether a hosted component can be a `defview`'s child via `(:children props)` | The ABI says an existing React element is a legal child anywhere, which implies yes; not stated for the host case specifically |
 | Embedding Hicasso *inside* a React-primary app | Named in the charter's use-case roster (item 11); no surface designed |

--- a/docs/design/hicasso/draft-guide/08-testing.md
+++ b/docs/design/hicasso/draft-guide/08-testing.md
@@ -62,7 +62,8 @@ earning their place.
 
 If a body calls a React hook — a callback ref for measurement, a `useEffect` for an
 SDK, anything at a host edge — headless is out. If a body renders a foreign
-component through [`defhost` or `[:>]`](05-interop.md), the foreign region is out.
+component through [`defhost`](05-interop.md) (or the `[:>]` escape, once it is
+built), the foreign region is out.
 
 The temptation is obvious: stub the hook dispatcher, get the whole tree back, keep
 the fast tests. HD-021 forecloses it. A fake dispatcher passes tests that a real


### PR DESCRIPTION
Closes rf2-2rtt6.64 (P1, EP-0038 — the charter's v0 "short guide").

## What the audit remainder turned out to be

Merged-PR audit #7398 flagged the interop page's new callback section for
overclaiming `::h/prevent` — a declared `:event` position calling
`preventDefault` on whichever invoker argument is the real DOM event, which the
unary `intent-handler` never does. **That sentence is already gone.** PR #7420
(rf2-2rtt6.35, `f91c434929`) deleted it in the same change that landed
`event-arg!`, and replaced it with the *event-first* section the page carries
today. I verified the claim against `front/intent.cljs` rather than the bead:
`intent-handler` returns `(fn [e] …)`, `event-arg!` checks the one property the
closure is about to read and raises `:rf.error/hicasso-intent-needs-the-event`
naming the position, and `h/fn` (`event-callback`, `[& args]` + `apply`) is the
answer for a value-first invoker. The page says exactly that.

**Sites still carrying the overclaim, after grepping the whole tree for the
pattern rather than the line: zero.** Nothing in `docs/`, `implementation/` or
the skills tree says a vector spelling hunts for the event among its arguments.

So this PR closes the acceptance criteria that were still genuinely open.

## What changed

**The witness is now named.** The page pointed at the bench-arm *directory*; the
acceptance criterion asks for the focused host-hatch witness, so the header now
names `arm1/host_hatch_dom_cljs_test.cljs` and says in one clause what it proves.

**The opening sample is a real view.** It was an `ns` form followed by a floating
hiccup vector over a free `due-date` symbol. It is now a `defview` reading
`(sub [:task/due-date])`, in the same spelling page 02 teaches
(`[re-frame.hicasso :as h :refer [defview sub]]`). The namespace reads, `h` is
aliased so `h/fn` resolves, the `defhost` declares `{:callbacks {:on-change
:event}}`, and the callback consumes react-datepicker's actual arguments
(`[date & _]`). Its comment now states the landed law — an intent vector
*refuses* at a value-first position — rather than the softer "no target for
`::h/value` to read".

**`::h/value` survived the witness check, so it moves out of "Not settled yet".**
`the-value-marker-materializes-when-the-foreign-invoker-hands-an-event` drives
`::h/value` through the widget's event-first `onChange` and the model updates;
`the-vector-spelling-is-event-first-and-says-so-when-it-is-not` drives
`::h/prevent`, `::h/value` and a key-map through the *same* widget's value-first
`onPick` and gets the refusal, naming `:on-pick` and `"paris"`. The event-first
section now cites both halves; the row saying "**Settled**" inside a table titled
*Not settled yet* is gone. The sample itself still uses `h/fn`, correctly —
react-datepicker's `onChange` is value-first.

**The codemod stopped existing.** It never did. `[:>]` was already described
honestly in its own section ("unbuilt in the bench arm", "once it exists"), but
the codemod was written in the present tense in two places — "a codemod exists
for migration" in the arithmetic paragraph, and the whole *Migrating from
Reagent* section. HD-011 rules one; nothing has been built, and no Hicasso
codemod exists anywhere in the tree (the only codemod that ships is
`migration/from-re-frame-v1/codemod/`, the unrelated EP-0018 `reg-event` one).
Both now say ruled-and-unbuilt, as does the *Not settled yet* row and the page
header.

**`[:>]` residue, swept by pattern.** Three sites still wrote it as available
today: "Both forms are legal" in the hierarchy paragraph, the troubleshooting row
"It's a `[:>]` node", and — on sibling pages — `02-views-and-reads.md`'s grammar
table row and `08-testing.md`'s headless-scope sentence. All four now qualify it.
`codec.cljs:954` is the authority: "The `[:>]` raw escape stays unbuilt here,
deliberately."

## What I checked and left alone

The rest of the guide is current and I did not re-do it: the `:&` merge spelling
(#7404), the single `h/fn` form and the contract-governs-carrier section (#7420),
HD-028's memo default (#7412), route-link's `:prefetch` refusal (#7429), HD-019's
narrowed IME claim with the composition carve-out (#7415, #7441). The `:event`
paragraph's "every argument the invoker passed reaches the `h/fn` body" is true —
`event-callback` is `[& args]` + `apply`. No file held by a concurrent worker was
touched: `decisions.md`, `front/intent.cljs`, the two `_cljs_test.cljs` files,
`b8_run.cjs` and `.github/workflows/**` are all untouched, and `gh pr list` was
empty when I started.

## Bead filed

**rf2-2rtt6.81** (P3, under EP-0038) — `defhost`'s macro docstring in
`arm1/lang.clj` teaches `[date-picker {:on-change [:task/set-due ::h/value]}]`,
naming the same `date-picker`/`DatePicker` pair the guide uses for
react-datepicker. That library's `onChange` is value-first, so under the landed
law that exact call raises `:rf.error/hicasso-intent-needs-the-event` — the
docstring and the guide contradict each other on the same component. Not fixed
here: `implementation/**` was fenced for this bead.

## Quality gates

Docs-only diff, three files, all under `docs/design/hicasso/draft-guide/`.

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine`, `gate root: /c/Users/miket/code/re-frame2-worktrees/guidev0-2rtt6-64` |

`mkdocs build --strict` ran inside the spine and exited clean, but it is **not**
the gate for this diff: `exclude_docs` drops `design/hicasso/`, so it verified
nothing here. `check_doc_slugs.py` is the one that covers this tree.

**Hand-verified, because nothing validates tables, rendering or nav:**

- **Outbound links — 12, 0 dead.** `05-interop.md` 3 (`../decisions.md`,
  `01-getting-started.md`, `08-testing.md`), `02-views-and-reads.md` 5,
  `08-testing.md` 4. Every target file exists; none of the twelve carries an
  anchor fragment.
- **Inbound links — 4, 0 dead.** To `05-interop.md`: `decisions.md:690`
  (`#the-reserved-vector-and-the-gap-it-does-not-close`), `06-theming.md:245`,
  `08-testing.md:65`, `draft-guide/README.md:23`. Only one carries an anchor and
  its heading is untouched.
- **Headings — 0 changed**, in any of the three files, so no anchor can have
  moved and no inbound-link sweep was needed. (`git diff HEAD~1 | grep '^[+-]#'`
  is empty.)
- **Tables — 7, 0 column mismatches.** `05-interop.md` 3 (2 cols × 4 rows;
  3 cols × 11 rows; 2 cols × 7 rows), `02-views-and-reads.md` 3 (5 × 4; 3 × 7;
  2 × 3), `08-testing.md` 2 (3 × 6; 2 × 7). Every body row matches its
  separator's column count.
