### PR TITLE
docs(hicasso): defhost's worked example obeys the event-first law (rf2-2rtt6.81)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj
@@ -77,13 +77,24 @@
         {:callbacks {:on-change :event}})
 
       [date-picker {:selected  due-date
-                    :on-change [:task/set-due ::h/value]}]
+                    :on-change (hfn [date & _] [:task/set-due date])}]
 
   `opts` is optional and carries `:callbacks` — a FINITE map from exact
   prop names to `:event`, `:handler` or `:render`, never inferred from an
   `on*` spelling. Policy lives on the declaration, so every use site
   inherits it; the defaults, the refusals and the crossing itself are
   [[re-frame.bench.hicasso.front.codec/mint-host!]]'s.
+
+  The callback is an [[hfn]] and not an intent vector because
+  react-datepicker calls `onChange(date, event)` — VALUE-first, with no
+  event at argument one — while the vector spelling is EVENT-first
+  (HD-024's argument law, in
+  [[re-frame.bench.hicasso.front.intent]]). `[:task/set-due ::h/value]`
+  there raises `:rf.error/hicasso-intent-needs-the-event` naming the
+  position, and the one callback form is the spelling that sees the
+  library's own arguments, in order. At an EVENT-first foreign callback —
+  `onDraft(event)` — the vector and its markers are legal and shorter.
+  Both halves are witnessed in `arm1/host_hatch_dom_cljs_test`.
 
   Like [[defview]] it is not a compiler: it expands to a `def` of the
   minted head, reads no body, and captures only the name — for


### PR DESCRIPTION
Closes rf2-2rtt6.81 (P3, under EP-0038).

## The contradiction

`defhost`'s macro docstring carried a worked example that the landed event-first
law refuses:

```clojure
(defhost date-picker DatePicker
  {:callbacks {:on-change :event}})

[date-picker {:selected  due-date
              :on-change [:task/set-due ::h/value]}]
```

It names `date-picker`/`DatePicker` — react-datepicker, whose `onChange` is
**value-first** (`onChange(date, event)`) — and puts a `::h/value`-carrying intent
vector at `:on-change`. Under HD-024's landed argument law (`front/intent.cljs`
`event-arg!`, reached from `intent-handler`'s `dynamic` branch on the `"target"`
read) that call raises `:rf.error/hicasso-intent-needs-the-event`. The draft
guide's interop opening teaches the `h/fn` spelling on the *same component* for
exactly that reason, so the macro and the guide disagreed with each other.

## The route taken, and why

**Keep `date-picker`/`DatePicker`; switch the call site to the `hfn` spelling the
law requires at a value-first invoker.** The alternative — keep the marker and
swap in an event-first component — would have meant inventing a library whose
`onChange` is event-first, which a reader cannot check, and then finding a name
that does not collide with the guide's react-datepicker. That relocates the
contradiction rather than deleting it. react-datepicker is real, its contract is
verifiable, and after this change the macro and the guide teach the same
component the same way.

New:

```clojure
(defhost date-picker DatePicker
  {:callbacks {:on-change :event}})

[date-picker {:selected  due-date
              :on-change (hfn [date & _] [:task/set-due date])}]
```

The `& _` is load-bearing, not decoration: `event-callback` is `[& args]` +
`apply`, so a fixed one-arity `hfn` handed react-datepicker's `(date, event)`
would throw an arity error. The guide's spelling (`(h/fn [date & _] …)`) is the
same shape, and this is the pair a reader most often checks one against the other.

The bead's own diagnosis notes the docstring was **not wrong about the grammar** —
`::h/value` at a declared `:event` slot is correct whenever the invoker is
event-first — so one paragraph now says why the `hfn` is there and keeps that
half, rather than silently withdrawing the vector spelling from host callbacks.

## Witnesses (the corrected example is not an assertion)

Both halves of the new paragraph are already proven in
`implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs`:

| Claim | Witness |
|---|---|
| `h/fn` at a declared `:event` slot, invoked **value-first**, dispatches — the corrected example's exact shape | `the-declaration-governs-every-carrier-at-its-position`, first block: `(hfn [city e] [:hatch/picked city (.-type e)])` invoked as `((prop el "onPick") "paris" #js {:type "click"})` |
| the same, end-to-end in a real DOM | `callbacks-cross-out-and-react-owned-state-survives-hicasso-rerenders` — "declared `:event` + h/fn: EVERY argument the foreign invoker passed reached the body — (onPick value event)" |
| a marker vector at an **event-first** foreign callback is legal | `the-value-marker-materializes-when-the-foreign-invoker-hands-an-event`, and `the-vector-spelling-is-event-first-and-says-so-when-it-is-not`'s positive half (`:on-draft [:hatch/typed ::h/value]`) |
| a marker vector at a **value-first** callback refuses — the old example's fate | `the-vector-spelling-is-event-first-and-says-so-when-it-is-not`, third block: `:needed "target"`, `:rf.error/hicasso-intent-needs-the-event` |

## The sweep — the real count is one

Grepped the pattern, not the line: every `::h/value` / `::h/checked` /
`:re-frame.hicasso/value` site under `implementation/**`, `docs/**`, `spec/**`,
`tools/**` and `skills/**`, plus every `defhost` and `:callbacks` example in the
repo.

**Exactly one site taught a marker intent vector at a value-first invoker** — the
one this PR fixes. The rest classify cleanly:

- **Native DOM positions** (`:on-input`, `:on-key-down`, `:on-submit`) — event-first
  by definition, so the marker is correct. `grid.cljs`, `dogfood_collector.cljs`,
  `dogfood_grouped.cljs`, `ime_app.cljs`, `shapes/ordinary.cljs`,
  `census_article_editor_cljs_test.cljs`, `controlled_grid_dom_cljs_test.cljs`,
  `authoring.md`.
- **The event-first host callback** `:on-draft` on the hatch widget — legal, and the
  positive witness above.
- **Deliberate refusal witnesses** — `intent_cljs_test.cljs` (`:on-pick` at 631 and
  its neighbours) and `host_hatch_dom_cljs_test.cljs` (788, 800); these *must* carry
  the shape.
- **Freehand's `v/defhost date-picker` examples** (`docs/core/freehand/host/*`,
  `docs/api/re-frame.freehand.md`, `D022`, `codex-design.md`) — a different product
  surface, and already correct: they spell the callback `(v/event [js-date] …)`,
  taking the value from argument one rather than a marker.
- `skills/**` carries no Hicasso content at all (`git grep -l hicasso -- skills` is
  empty), so there was nothing to sweep there.

## Scope

Docstring only, one file, one hunk. **No lowering behaviour changed** — `event-arg!`,
`intent-handler`, `event-callback` and `lower-declared-prop` are untouched; the law
is ruled and landed and this is the documentation catching up to it. `spec/**` and
`docs/design/hicasso/draft-guide/**` (PR #7446's territory, already correct) are
untouched.

## Quality gates

Both run from this worktree, foreground, to completion. Each printed
`gate root: /c/Users/miket/code/re-frame2-worktrees/defhostdoc-2rtt6-81`.

| Gate | Result |
|---|---|
| `sh scripts/test-fast-pr.sh` | exit **0**, anchored terminal marker `PASS fast PR spine` present |
| `npm run test:hicasso-compile` (run again standalone, since `lang.clj` is a macro namespace the whole lane compiles) | exit **0** — "101 lane namespaces compiled with zero warnings" |

The spine runs the hicasso bench-lane compile itself, so the macro change is
covered twice.
