### PR TITLE
fix(hicasso): render-position enforcement is invocation-scoped, and the owner forwards (rf2-2rtt6.74)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -788,6 +788,52 @@ cost is **unmeasured** and is named here rather than claimed away.
 
 ## HD-024 — One callback form; the position selects the contract
 
+> **Addendum, 2026-08-03 — render-position enforcement is INVOCATION-scoped, and
+> the owner forwards (`rf2-2rtt6.74`).** Both laws below stand: a `:render`
+> position is pure, and dispatching from inside the call is
+> `:rf.error/hicasso-dispatch-in-render-position`, naming the position. What is
+> superseded is the Rationale's mechanism sentence — "enforced by poisoning the
+> ambient dispatch for the call's dynamic extent" — insofar as it read as though
+> handlers *lowered* inside the call stayed poisoned forever. They do not; the
+> sentence stays below as the record of what was ruled first.
+>
+> **The defect.** Lowering captures the same var the poison replaced, so the row a
+> `renderRow` prop exists to build — `(h/as-element [:li {:on-click [:row/pick
+> id]} …])` — closed over the poison and raised at the USER'S click, for a click:
+> a legitimate event position that merely happened to be lowered during a render.
+> A render prop producing a non-interactive row worked; one producing an
+> interactive row did not — which is most of what render props are for — and the
+> failure landed a phase and a component away from the author's site, the worst
+> failure geometry available.
+>
+> **What was ruled.** Enforcement is scoped to the INVOCATION, not to everything
+> the invocation lowered: poison while the call is running, forward to the owner
+> once it has returned. The wrapper captures the ambient dispatch and frame at
+> LOWERING time, and each invocation mints a fresh gate over them, binds it as the
+> ambient dispatch for the call, and arms it in a `finally`. The discrimination is
+> TEMPORAL — call-active versus call-complete — which is the law's own line, and
+> it is why a synchronous lower-and-fire-NOW inside the body still raises while a
+> lower-now/fire-later row no longer does. A second "capturable" binding would
+> instead have let the synchronous case dispatch silently, weakening law 1 to
+> preserve a mechanism.
+>
+> **The owner is the SUPPLYING boundary's frame** — the boundary whose codec walk
+> lowered the `:render` prop. It is the only candidate: the wrapper is minted
+> inside that boundary's `with-frame` extent, the foreign component has no frame
+> of its own, and frames-as-isolated-contexts forbids any other. The ambient frame
+> is rebound to it for the invocation as well, so a `route-link` written in a row
+> body pins its navigation there rather than failing loudly. Where no owner was in
+> scope at wrapper creation, a handler lowered inside raises the ordinary
+> `:rf.error/hicasso-intent-outside-boundary` when it fires — loud, never silent,
+> and never a new error id.
+>
+> **Fence.** No new API, no config knob, no new error id, nothing about
+> scheduling, and no auto-conversion of what a render body returns. Witnessed by a
+> two-frame ownership row at the real declared-`:render` crossing
+> (`arm1/host_hatch_dom_cljs_test`), by its closure-level twin and the no-owner
+> edge (`front/intent_cljs_test`); the two purity edges — a direct dispatch inside
+> the call, and a synchronous lower-and-fire — are unmodified and still raise.
+
 **Ruling.** Hicasso ships **one** callback form — `h/fn` (spelling unfrozen) — and
 it is **an ordinary function**. The contract comes from the **position**, because
 the runtime already knows every position it walks:

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
@@ -757,6 +757,61 @@
             (is (re-find #":on-render-row" (ex-message e))))))
       (is (= [] @!seen) "and nothing reached the frame"))))
 
+(defn- crossed-in-frame
+  "[[crossed]] with the boundary's FRAME KEYWORD bound as well — the
+  3-arity door, which is what a row body's `intent/*frame*` read (and a
+  `route-link` in one) needs. Answers `[element !dispatched]`."
+  [frame-kw head props]
+  (let [!seen (atom [])
+        el    (intent/with-frame frame-kw (fn [ev] (swap! !seen conj ev) nil)
+                (fn [] (codec/as-element [head props])))]
+    [el !seen]))
+
+(deftest a-render-props-row-is-owned-by-the-boundary-that-supplied-the-callback
+  (testing "rf2-2rtt6.74, at the real `renderRow` seam. HD-024's refusal is
+            INVOCATION-scoped — poison while the call runs, forward to the
+            owner once it has returned — so the handlers a `:render` body
+            LOWERS are not poisoned with it. Which is most of what a render
+            prop is for: a row that is not interactive works either way, and
+            the failure this pins used to land on the USER's click.
+
+            Two frames and two recorders are live, and the ambient one at
+            invocation is the OTHER — what a foreign component nested below
+            a second boundary does — so the ownership claim cannot pass by
+            accident."
+    (let [!other (atom [])
+          !frame (atom ::unread)
+          !row   (atom nil)
+          [el !supplier]
+          (crossed-in-frame
+            ::supplier render-picker
+            {:on-render-row
+             (hfn [label]
+               (reset! !frame intent/*frame*)
+               (reset! !row (codec/as-element
+                              [:li {:on-click [:hatch/picked label "row"]}]))
+               ;; an event-position h/fn, lowered in the same body
+               (codec/as-element
+                 [:button {:on-click (hfn [_] [:hatch/closed])}]))})
+          btn (intent/with-frame ::other (fn [ev] (swap! !other conj ev) nil)
+                (fn [] ((prop el "onRenderRow") "paris")))]
+      (is (= ::supplier @!frame)
+          "inside the invocation the ambient frame is the OWNER's, not the
+           invoking boundary's — the frame a route-link in a row body pins to")
+      (is (= [] @!supplier) "the render itself dispatched nothing")
+      (is (= [] @!other))
+
+      (testing "and then the browser's click, long after both extents unwound"
+        (is (nil? intent/*dispatch*))
+        ((prop @!row "onClick") #js {})
+        ((prop btn "onClick") #js {})
+        (is (= [[:hatch/picked "paris" "row"] [:hatch/closed]] @!supplier)
+            "the row's intent vector AND the event-position h/fn both fired
+             into the SUPPLYING boundary's recorder")
+        (is (= [] @!other)
+            "and nothing reached the boundary that merely invoked the render
+             prop — which is what makes the ownership assertion non-vacuous")))))
+
 (deftest the-vector-spelling-is-event-first-and-says-so-when-it-is-not
   (testing "the positive half, at the invoker contract the door was built for:
             an EVENT-FIRST foreign call, which is what onDraft makes"

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -135,6 +135,14 @@
   A vector at an event position with no ambient frame is a loud error,
   never a silently inert handler.
 
+  A RENDER callback ([[render-callback]]) re-establishes that ambient
+  context for its own invocation, out of what it captured when it was
+  lowered, so a row built inside a foreign `renderRow` belongs to the
+  boundary that SUPPLIED the callback — the only frame that can own it.
+  The render-position refusal is scoped to the invocation and not to
+  everything the invocation lowered: poison while the call is running,
+  forward to the owner after it returns (rf2-2rtt6.74).
+
   ## The marker roster and its one pure materializer
 
   Two markers, both of which the ruled surface names:
@@ -373,23 +381,83 @@
   POSITION rather than the form the author chose, because under one form
   the form is never the answer to \"what did I get wrong?\".
 
-  Enforced by poisoning the ambient dispatch for the call's dynamic
-  extent: an intent lowered inside, or a direct call, both land on the
-  same error id. `.preventDefault`-style side effects are untouched."
+  **Enforcement is INVOCATION-SCOPED: poison while the call is running,
+  forward to the owner once it has returned.** Poisoning the ambient
+  dispatch for the call's dynamic extent and leaving it at that conflates
+  two different things, because lowering captures the same var the poison
+  replaced. The row a `renderRow` prop exists to build —
+
+      (h/as-element [:li {:on-click [:row/pick (:id row)]} (:title row)])
+
+  — closes over the poison and raises at the USER'S CLICK, for a click:
+  a legitimate event position that merely happened to be LOWERED during a
+  render (rf2-2rtt6.74). The law is \"dispatching from inside the call\",
+  and a closure that will dispatch later is not that.
+
+  So the wrapper captures the ambient dispatch AND frame at LOWERING
+  time — the supplying boundary's, because the wrapper is minted during
+  that boundary's eager `with-frame` + `as-element` walk — and each
+  invocation mints a fresh GATE over them, binds it as [[*dispatch*]] for
+  the call, and arms it in a `finally`. Call-active, the gate raises;
+  call-complete, it forwards to the owner. That is a TEMPORAL
+  discrimination, which is the law's own line, rather than a second
+  \"capturable\" binding — which would let the synchronous
+  lower-and-fire-NOW case succeed silently and weaken the law it was
+  meant to preserve.
+
+  [[require-dispatch]], [[intent-handler]] and [[event-callback]] are
+  UNCHANGED: they still capture [[*dispatch*]], which inside a callback is
+  now the gate, and that one substitution is the whole of the repair.
+
+  [[*frame*]] is rebound to the owner's for the same extent, so a
+  [[re-frame.bench.hicasso.front.route-link/route-link]] in a row body
+  pins its navigation to the boundary that SUPPLIED the callback. That is
+  the only frame that can own it: the foreign component has no frame of
+  its own, and frames are isolated contexts.
+
+  A callback lowered with no owner in scope at all still poisons while it
+  runs, and a handler lowered inside it raises the ordinary
+  `:rf.error/hicasso-intent-outside-boundary` when it fires — loud, never
+  a silently inert handler. `.preventDefault`-style side effects are
+  untouched."
   [k f]
-  (fn hicasso-render-callback [& args]
-    (binding [*dispatch*
-              (fn [event]
-                (fail! :rf.error/hicasso-dispatch-in-render-position
-                       'front.intent/lower-prop
-                       (str "A callback at " (pr-str k) " dispatched " (pr-str event)
-                            " while it was running. " (pr-str k) " is a RENDER "
-                            "position: it is invoked during a render, so it must be "
-                            "pure. Move the dispatch to an event position, or to an "
-                            "event handler that owns the work.")
-                       :dispatch-from-an-event-position
-                       {:position k :event event}))]
-      (apply f args))))
+  (let [owner-dispatch *dispatch*
+        owner-frame    *frame*]
+    (fn hicasso-render-callback [& args]
+      ;; `armed?` is false for the call's dynamic extent and set in the
+      ;; `finally` below, so ARMED means the invocation has RETURNED and
+      ;; the gate now forwards rather than raises.
+      (let [armed? (volatile! false)
+            gate   (fn hicasso-render-gate [event]
+                     (cond
+                       (not @armed?)
+                       (fail! :rf.error/hicasso-dispatch-in-render-position
+                              'front.intent/lower-prop
+                              (str "A callback at " (pr-str k) " dispatched " (pr-str event)
+                                   " while it was running. " (pr-str k) " is a RENDER "
+                                   "position: it is invoked during a render, so it must be "
+                                   "pure. Move the dispatch to an event position, or to an "
+                                   "event handler that owns the work.")
+                              :dispatch-from-an-event-position
+                              {:position k :event event})
+
+                       owner-dispatch (owner-dispatch event)
+
+                       :else
+                       (fail! :rf.error/hicasso-intent-outside-boundary
+                              'front.intent/lower-prop
+                              (str "A handler lowered inside the callback at " (pr-str k)
+                                   " dispatched " (pr-str event) " after the render "
+                                   "returned, but the callback itself was lowered with no "
+                                   "frame-locked dispatch in scope. A render callback's "
+                                   "handlers fire into the frame of the boundary that "
+                                   "SUPPLIED it, and there was none.")
+                              :lower-intents-inside-a-boundary-render
+                              {:position k :event event})))]
+        (binding [*frame* owner-frame *dispatch* gate]
+          (try
+            (apply f args)
+            (finally (vreset! armed? true))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The argument law — the vector spelling is EVENT-FIRST (HD-024)

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent_cljs_test.cljs
@@ -502,6 +502,77 @@
             (is (re-find #":row-renderer" (ex-message e))))))
       (is (= [] @!seen) "and nothing reached the frame"))))
 
+(deftest a-handler-lowered-inside-a-render-body-belongs-to-the-supplying-boundary
+  (testing "rf2-2rtt6.74. The refusal above is INVOCATION-scoped: it covers the
+            call, not everything the call LOWERED. A render prop exists to
+            build interactive rows, and a row's `:on-click` is a legitimate
+            event position that merely happened to be lowered during a render
+            — so it fires later, into the frame of the boundary that SUPPLIED
+            the callback. Nothing else can own it: the invoker has no frame of
+            its own, and frames are isolated contexts."
+    (let [!supplier (recorder)
+          !other    (recorder)
+          !row      (atom nil)
+          !cb       (atom nil)
+          !frame    (atom ::unread)
+          h (intent/with-frame ::supplier (dispatching !supplier)
+              (fn [] (intent/lower-prop
+                       :row-renderer
+                       (intent/callback
+                         (fn [title]
+                           (reset! !frame intent/*frame*)
+                           (reset! !row (intent/lower-prop :on-click [:row/pick title]))
+                           (reset! !cb  (intent/lower-prop
+                                          :on-change
+                                          (intent/callback (fn [_] [:row/changed title]))))
+                           [:li title])))))]
+      (testing "the invocation runs under a DIFFERENT boundary — what a foreign
+                component nested below another one does — so neither claim
+                below can pass by accident"
+        (is (= [:li "milk"]
+               (intent/with-frame ::other (dispatching !other)
+                 (fn [] (h "milk"))))
+            "the return is still the render output")
+        (is (= ::supplier @!frame)
+            "and inside the call the ambient frame is the OWNER's, which is
+             what route-link reads to pin a navigation")
+        (is (= [] @!supplier) "the render itself dispatched nothing")
+        (is (= [] @!other)))
+      (testing "and then the browser's click, long after both extents unwound"
+        (is (nil? intent/*dispatch*))
+        (@!row (ev {}))
+        (@!cb (ev {}))
+        (is (= [[:row/pick "milk"] [:row/changed "milk"]] @!supplier)
+            "the intent vector AND the event-position h/fn both landed on the
+             supplying boundary's recorder")
+        (is (= [] @!other)
+            "two frames, two recorders — and the OTHER one was the ambient
+             frame while the row was built, so this is not vacuous")))))
+
+(deftest a-render-callback-with-no-owner-forwards-to-a-loud-error-never-to-silence
+  (testing "the no-owner edge of the same law. The wrapper was lowered with no
+            frame-locked dispatch in scope, so there is nothing to forward to.
+            The refusal still covers the call; a handler lowered inside it
+            raises the ordinary outside-boundary error when it fires — the
+            silently inert handler is the one outcome that is never available."
+    (is (nil? intent/*dispatch*))
+    (let [!row (atom nil)
+          h    (intent/lower-prop
+                 :row-renderer
+                 (intent/callback (fn [_]
+                                    (reset! !row (intent/lower-prop :on-click [:oops]))
+                                    [:li])))]
+      (is (= [:li] (h {})) "the body ran and its return is the output")
+      (try
+        (@!row (ev {}))
+        (is false "should have thrown")
+        (catch :default e
+          (let [d (ex-data e)]
+            (is (= :rf.error/hicasso-intent-outside-boundary (:rf.error/id d)))
+            (is (= :row-renderer (:position d)) "named at the render position")
+            (is (= [:oops] (:event d)))
+            (is (re-find #":row-renderer" (ex-message e)))))))))
+
 (deftest a-declaration-can-name-the-contract-instead-of-the-position
   (testing "the position table's second row. A `defhost` declaration carries
             `:event` or `:handler` per EXACT prop name and never infers it


### PR DESCRIPTION
Closes rf2-2rtt6.74 (P2, under EP-0038).

## The defect

A `:render` prop that returns *lowered* hiccup poisoned that row's own handlers.
`front/intent/render-callback` bound a poison into the same ambient `*dispatch*`
that `intent-handler` captures at lowering time, so the row a `renderRow` prop
exists to build —

```clojure
(h/as-element [:li {:on-click [:row/pick (:id row)]} (:title row)])
```

— closed over the poison and raised `:rf.error/hicasso-dispatch-in-render-position`
at the **user's click**, for a click: a legitimate event position that merely
happened to be *lowered* during a render. A render prop producing a
non-interactive row worked; one producing an interactive row did not, which is
most of what render props are for, and the failure landed a phase and a component
away from the author's site.

## The shape as implemented

Enforcement is **invocation-scoped**: poison while the call is running, forward to
the owner once it has returned. Both HD-024 laws stand.

`render-callback` captures the ambient dispatch **and** frame at wrapper-creation
(lowering) time — the supplying boundary's, because the wrapper is minted during
that boundary's eager `with-frame` + `as-element` walk (`arm1/runtime.cljs`
`run-once`). Each invocation mints a fresh **gate** closing over an `armed?` flag
and the captured owner dispatch, binds `*frame*` = captured frame and `*dispatch*`
= gate around `(apply f args)`, and arms the gate in a `finally`:

* **call-active** — raise the existing `:rf.error/hicasso-dispatch-in-render-position`,
  naming the position, message byte-for-byte unchanged;
* **call-complete** — forward to the captured owner dispatch;
* **call-complete, no owner at wrapper creation** — raise the existing
  `:rf.error/hicasso-intent-outside-boundary`. Loud, never silent. (This is the
  ruled disposition of the fence's no-owner edge, so the fence was not tripped.)

`require-dispatch`, `intent-handler` and `event-callback` are **unchanged**: they
still capture `*dispatch*`, which inside a callback is now the gate. That single
substitution is the whole repair, and the discrimination is **temporal** —
call-active vs call-complete, which is the law's own line — rather than a second
"capturable" binding, which would have let the synchronous lower-and-fire-**NOW**
case dispatch silently and weakened law 1.

The change composes with #7420's outer-`case` dispatch in `lower-declared-prop`:
the contract still selects, and `:render` still reaches `render-callback` as the
one carrier it accepts. No value-selects-contract path is reintroduced.

**No new API, no config knob, no new error id, nothing about scheduling, no
auto-conversion of render returns.** The two-hook shell budget is untouched — no
hook is added; the gate is a closure. Bodies stay `.cljc`-compatible. Surface B
only; no `spec/**` edit.

## Witnesses

**1 — two-frame ownership, at the real `renderRow` seam** (NEW,
`arm1/host_hatch_dom_cljs_test`: `a-render-props-row-is-owned-by-the-boundary-that-supplied-the-callback`).
This is the witness that crosses the declared-`:render` seam: it goes through the
`defhost` head `render-picker` (`:on-render-row :render`) and therefore through
`codec/as-element` → `lower-declared-prop` → `render-callback`, not a synthetic
proxy. The `h/fn` body lowers **both** shapes — an `:on-click` intent vector on an
`:li`, and an event-position `h/fn` on a `:button` — and both fire later into the
**supplying** boundary's recorder.

**Non-vacuity, explicitly:** two frames and two recorders are live. The element is
crossed under `::supplier` (recorder A); the render prop is then **invoked from
inside a different boundary**, `::other` (recorder B) — what a foreign component
nested below a second boundary does. If ownership were "whatever is ambient at
invocation", both intents would land in B. The row asserts `[] = @!other` after
firing, so it fails if the wrong frame owns the row. A single-frame version would
pass either way; this one does not.

**2 — the purity edges stay green, UNMODIFIED.** Neither deftest was touched:

* `arm1/host_hatch_dom_cljs_test` `a-dispatch-from-a-declared-render-position-names-the-position`
  (immediate direct `intent/*dispatch*` call inside the body) — still raises
  `:rf.error/hicasso-dispatch-in-render-position`;
* `front/intent_cljs_test` `at-a-render-position-the-return-is-output-and-dispatching-is-a-loud-error`
  (synchronous lower-and-fire inside the body) — still raises the same id.

**3 — frame visibility.** Both new ownership rows read `intent/*frame*` inside the
invocation and assert it is the **owner's** (`::supplier`), not the invoking
boundary's — the value `route-link`'s `require-frame!` reads to pin a navigation.

Also new, closure-level, in `front/intent_cljs_test`:

* `a-handler-lowered-inside-a-render-body-belongs-to-the-supplying-boundary` —
  the two-frame twin at the contract tier that file owns;
* `a-render-callback-with-no-owner-forwards-to-a-loud-error-never-to-silence` —
  the no-owner edge, pinned to `:rf.error/hicasso-intent-outside-boundary` named
  at the render position.

### The `reportError` trap does not apply here, and it is proven rather than asserted

None of the new rows mount into React or assert "nothing threw" — they invoke the
lowered props directly, so an exception reaches `cljs.test` normally. The mutation
run below is the proof: it surfaced the throw as `ERROR in (…)` in exactly those
deftests, so a live exception in these rows is visible, not swallowed.

## Mutation proof

One token, `(vreset! armed? true)` → `(vreset! armed? false)` in the gate's
`finally` — which breaks owner-forwarding so a lowered handler stays poisoned,
i.e. restores the pre-fix behaviour.

**Mutated** — `npm run test:cljs` exit **1**, `1 failures, 2 errors` out of
12501 tests / 62704 assertions, and the reds are exactly the three new witnesses
and nothing else:

```
ERROR in (a-render-props-row-is-owned-by-the-boundary-that-supplied-the-callback)
  A callback at :on-render-row dispatched [:hatch/picked "paris" "row"] while it
  was running. … [:rf.error/hicasso-dispatch-in-render-position]
ERROR in (a-handler-lowered-inside-a-render-body-belongs-to-the-supplying-boundary)
  A callback at :row-renderer dispatched [:row/pick "milk"] while it was running. …
FAIL  in (a-render-callback-with-no-owner-forwards-to-a-loud-error-never-to-silence)
  expected: :rf.error/hicasso-intent-outside-boundary
    actual: :rf.error/hicasso-dispatch-in-render-position
```

**Reverted byte-identically** — `npm run test:cljs` exit **0**,
`12501 tests containing 62706 assertions, 0 failures, 0 errors`.

## HD-024 addendum

`docs/design/hicasso/decisions.md` HD-024 takes a dated blockquote addendum in the
rf2-digtt pattern (HD-019's 2026-08-03 addendum): both laws stand; enforcement is
invocation-scoped; owner = the supplying boundary's frame; the no-owner edge is
the existing outside-boundary error. It **supersedes** the Rationale sentence
*"enforced by poisoning the ambient dispatch for the call's dynamic extent"*
insofar as that implied handlers *lowered* inside stay poisoned forever — and
**does not delete it**: the sentence is still at `decisions.md:908`, quoted in the
addendum as the record of what was ruled first. The heading is unchanged, which is
the precedent HD-019's addendum sets.

## Quality gates

`decisions.md` is **not** covered by `mkdocs build --strict` — `mkdocs.yml`'s
`exclude_docs` drops `design/hicasso/` — so the doc claims below are hand-verified
and the counts stated, as the bead requires.

| Gate | Command | Exit |
|---|---|---|
| fast-PR spine | `sh <worktree>/scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine`; first line `gate root: /c/Users/miket/code/re-frame2-worktrees/renderown-2rtt6-74` |
| browser | `npm run test:browser` | **0** — `Ran 1053 tests containing 6557 assertions. 0 failures, 0 errors.`; build `1105 files, 0 warnings` |
| node CLJS | `npm run test:cljs` | **0** — `Ran 12501 tests containing 62706 assertions. 0 failures, 0 errors.` |
| doc slugs | `python scripts/check_doc_slugs.py` | **0** — silent |

Each gate was taken to its own terminal marker rather than inferred from an exit
code, and the browser gate was re-run after the final commit so every byte under
test is a byte that was pushed.

**Hand-verified anchors.** The addendum introduces **no headings** and **no
markdown links**, so it adds no anchor and retargets none. HD-024's heading text is
unchanged, so `#hd-024--one-callback-form-the-position-selects-the-contract` still
resolves; the only in-file anchor links in `decisions.md` are
`#hd-028--value-equality-is-the-boundary-default` (line 150) and
`#hd-006--memoization-defaults--amended-2026-08-02` (line 1204), neither touched.
The blockquote is contiguous: lines 791–835 all begin with `>`, line 836 is blank,
`**Ruling.**` resumes at 837.

**Hand-verified table column counts.** The addendum contains no table. All three
tables in `decisions.md` are internally consistent and unchanged by this PR:

| Table | Lines | Rows | Columns |
|---|---|---|---|
| HD-024 position table | 841–847 | header + separator + 5 body | 2, every row |
| HD-028 (first) | 1339–1344 | header + separator + 4 body | 4, every row |
| HD-028 (second) | 1359–1362 | header + separator + 2 body | 4, every row |

No bench driver was run and no timing row is published.
