### PR TITLE
bench(hicasso): the R=0 shell heap with the memo wrapper (rf2-2rtt6.58)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1347,24 +1347,36 @@ The heap delta reproduces at **~200 B per boundary**, which is a Fiber. The cloc
 rows do not separate from run-to-run noise at this round count, so the mount and
 bulk cost is stated as a **bound (≲10%)** rather than a figure. On the card-shaped
 boundary actually measured, 200 B is **+1.8%**. Against the **R=0 shell** — the
-figure validation.md's paper line is stated against, which the ladder puts at
-1,143 B, already over the 1 KB line — the same 200 B would be ≈ +17%. Both
-readings are true, they are not interchangeable, and the shell one had to be
-re-taken on the ladder's own instrument.
+figure validation.md's paper line is stated against, which the ladder put at
+1,143 B at the time, already over the 1 KB line — the same 200 B would be ≈ +17%.
+Both readings are true, they are not interchangeable, and the shell one had to be
+re-taken on the ladder's own instrument. *(Both figures in this paragraph are the
+2026-08-02 state; the shell has since moved and the re-take below is the current
+one.)*
 
-**The shell re-take has since been done** (`rf2-2rtt6.58`, 2026-08-02, P0 bench,
-both arms in one session with a third run bracketing them —
-[the rows](studio/reads-per-boundary-heap-ladder.md#the-memo-wrapper-priced-on-this-rung-rf2-2rtt658)):
+**The shell re-take has since been done twice.** The first pair
+(`rf2-2rtt6.58`, 2026-08-02) was taken on `worker/cascade-2rtt6-52`, and its
+audit found the blobs did not match the post-#7390 landed implementation, so it
+does not stand as the current price. **The pair below was re-taken on
+2026-08-04 against `origin/main` `81321da3fe`** — `A → B → A`, one session, box
+verified quiet before each run, exit 0 on all three
+([the rows](studio/reads-per-boundary-heap-ladder.md#the-memo-wrapper-re-taken-on-the-tree-that-ships-rf2-2rtt658-re-take)):
 
-| R=0 shell | no wrapper | wrapper | delta |
-|---|---:|---:|---:|
-| Hicasso, Reagent segment | 1,141 B [1,125–1,154] | **1,247 B** [1,240–1,257] | **+106 B, +9.3%** |
-| Hicasso, UIx segment | 1,138 B [1,119–1,159] | **1,236 B** [1,227–1,250] | **+100 B, +8.8%** |
+| R=0 shell | no wrapper | wrapper | delta | vs the 1 KB line |
+|---|---:|---:|---:|---|
+| Hicasso, Reagent segment | 994 B [985–1,003] | **1,099.5 B** [1,088–1,112] | **+105.5 B, +10.6%** | 0.99× → **1.10×** |
+| Hicasso, UIx segment | 992 B [985–998] | **1,097 B** [1,092–1,105] | **+105.0 B, +10.6%** | 0.99× → **1.10×** |
+
+*(The 2026-08-02 pair read 1,141 → 1,247 B and 1,138 → 1,236 B: +106 B / +9.3%
+and +98 B / +8.6%. The **delta reproduced to within 1 B on both segments**; the
+base fell ~140 B under `rf2-aqgr2` and `rf2-dabt3`, which is where the
+percentage and the disposition move.)*
 
 **≈ +100 B, not ≈ +200 B — the ≈ +17% projection above over-estimated it by
 about a factor of two.** The A/B ranges are disjoint, the donors do not move, and
 the per-read slope is **identical to the byte** with and without the wrapper
-(1,447 and 2,289 B/read), confirming this ruling's claim that the cost is
+(1,278 and 2,115 B/read on the 2026-08-04 tree; 1,447 and 2,289 on the
+2026-08-02 one), confirming this ruling's claim that the cost is
 constant in R and lands in the shell. ~~The two instruments differ because the
 ladder mounts and *holds* while the page-chrome rig writes first, and an updated
 component retains an `alternate` fiber a held one does not — offered as the
@@ -1382,13 +1394,29 @@ taken on; what separates them is open as `rf2-2rtt6.79`. The ruling itself is
 untouched: the wrapper is a per-boundary constant in R, and **a Fiber is not a
 fixed byte count — the shape it sits on decides what it costs.**
 
-**What remains open is the disposition, and it is the operator's.** Whether +9%
-on a shell **already 1.14× over** the paper line is "pushing retained heap
-meaningfully farther past the bar" is not answered by any text: the clause is
-unquantified here, in validation.md and in the heap-regime ruling, and the
-*Reopens* clause below is worded as **failing** the bar — which this shell did at
-1,141 B before any wrapper existed. The wrapper widens a pre-existing failure
-rather than causing one. Still one thing the measurement does **not** settle:
+**What remains open is the disposition, and it is the operator's.** Whether
++10.6% is "pushing retained heap meaningfully farther past the bar" is not
+answered by any text: the clause is unquantified here, in validation.md and in
+the heap-regime ruling.
+
+**Amended 2026-08-04 (`rf2-2rtt6.58` re-take): the argument this paragraph used
+to make no longer holds.** It read *"the Reopens clause below is worded as
+failing the bar — which this shell did at 1,141 B before any wrapper existed, so
+the wrapper widens a pre-existing failure rather than causing one."* On the tree
+that ships, the shell without the wrapper reads **994 / 992 B** — not over the
+line — and with it **1,099.5 / 1,097 B**, which is. `rf2-aqgr2` and `rf2-dabt3`
+took ~140 B out of the shell in between, and **the wrapper is now the thing that
+carries it across.** Two cautions belong with that, both in the operator's
+favour rather than the ruling's: 994 B is 6 B under 1,000 and its own per-round
+band straddles the line, so the no-wrapper arm is *at* the line and not
+distinguishable from it, while the wrapper arm clears the line by more than
+validation.md's ~75 B shape sensitivity in **every** measured round. The
+`Reopens` clause is therefore live in a way it was not on 2026-08-02, and
+**this ruling's own pre-registered fallback is the one on the table**: retain
+HD-006 and ship the same comparator as an explicit boundary-level opt-in. No
+candidate-bar row has been written into validation.md either way.
+
+Still one thing the measurement does **not** settle:
 whether the mount row carries a real few-per-cent regression, which needs
 `clock_run.cjs`'s adjudicated M1 row.
 

--- a/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
+++ b/docs/design/hicasso/studio/reads-per-boundary-heap-ladder.md
@@ -1050,6 +1050,29 @@ rule on.
 
 ### The memo wrapper, priced on this rung (rf2-2rtt6.58)
 
+> **HISTORICAL, and not comparable to the tree that ships (2026-08-04).** These
+> rows were taken on `worker/cascade-2rtt6-52` at tree `4a33c61e1c`. The
+> provenance paragraph below says the recorded blobs "will prove the measured
+> tree and the merged tree agree once it is rebased" — **they do not agree**:
+> the measured runtime and codec blobs were `a6d6c55a58` and `12284ef8f4`, and
+> after PR #7390 and the landings that followed, the shipped blobs are
+> `9f3d42be7b` and `cf9ef32dc8`. The audit on `rf2-2rtt6.58` (PR #7392) reopened
+> the bead for exactly that.
+>
+> **The wrapper delta below survived the re-take almost exactly** — +105.5 and
+> +105.0 B against the +106 and +98 B here — but the **base did not**, and one
+> conclusion drawn from the base is now false. On the tree that ships the
+> no-wrapper shell reads **994 / 992 B**, not 1,141 / 1,138 B, so the claim
+> repeated throughout this subsection that the shell *was already over the 1 KB
+> line before any wrapper existed* **no longer holds**.
+> [The re-take](#the-memo-wrapper-re-taken-on-the-tree-that-ships-rf2-2rtt658-re-take)
+> is the current price. Nothing below is edited; it is kept as the record of
+> what was measured on that branch.
+>
+> One arithmetic correction the audit also named, recorded here rather than
+> silently fixed in the table: the UIx row's `1,138 → 1,236` is **+98 B,
+> +8.6%** — not the +100 B / +8.8% printed below.
+
 **Measured 2026-08-02** for `rf2-2rtt6.58`, to answer the one question
 [HD-028](../decisions.md#hd-028--value-equality-is-the-boundary-default) left
 open when it made a value-equality bail-out the boundary default: what its
@@ -1745,6 +1768,245 @@ the fused arm at R=0. The first attempt at this measurement declined to widen
 that gate to admit its own run, and published nothing; the fix landed as
 PR #7451 and the expectation is now `R === 0 ? 0 : B`, which is strictly
 stronger — the old form could not have detected a boundary retained at R=0.
+
+### The memo wrapper, re-taken on the tree that ships (rf2-2rtt6.58, re-take)
+
+**Measured 2026-08-04** on `81321da3fe`, `origin/main`. This replaces the
+2026-08-02 rows in [the subsection above](#the-memo-wrapper-priced-on-this-rung-rf2-2rtt658)
+as the wrapper's current price. Those rows were taken on
+`worker/cascade-2rtt6-52` at tree `4a33c61e1c`, and their own provenance
+paragraph promised that the recorded blobs *"will prove the measured tree and
+the merged tree agree once it is rebased"*. **They do not agree.** The runtime
+blob measured was `a6d6c55a58` and the codec blob `12284ef8f4`; after PR #7390
+and the four landings that followed it the shipped blobs are `9f3d42be7b` and
+`cf9ef32dc8`. The audit on `rf2-2rtt6.58` (PR #7392) called that out and asked
+for the pair to be re-taken on the landed implementation before the number is
+used as the current price. This is that re-take.
+
+**The delta survives almost exactly. The base does not, and the conclusion
+drawn from the base is now false.**
+
+#### The prior, quoted, and how it fared
+
+From the bead's own verdict line, written 2026-08-02:
+
+> the wrapper costs ~+100 B on the R=0 shell, NOT the ~+200 B projected —
+> +9%, not +17%.
+>
+> | R=0 shell | no wrapper | wrapper | delta |
+> |---|---:|---:|---:|
+> | Reagent segment | 1,141 B | 1,247 B | +106 B, +9.3% |
+> | UIx segment | 1,138 B | 1,236 B | +100 B, +8.8% |
+
+| the claim | verdict | what was measured |
+|---|---|---|
+| the wrapper costs ≈ +100 B, not ≈ +200 B | **MET**, and closely | +105.5 B and +105.0 B |
+| the cost is constant in R and lands wholly in the shell | **MET** | slope identical to the byte across all three runs, both segments |
+| the percentage is ≈ +9% | **MISSED**, low | **+10.6%** on both segments — the delta held, the base fell |
+| the shell was *already over* the 1 KB line without the wrapper | **NO LONGER TRUE** | without the wrapper the shell reads **994 / 992 B** |
+| ⇒ "the wrapper widens a pre-existing failure rather than causing one" | **WITHDRAWN** | on the tree that ships, the wrapper is what carries the shell across the line |
+
+The last row is the reason this re-take was worth its box time. HD-028's
+disposition paragraph, this page's own 2026-08-02 subsection and
+[the page-chrome row](the-page-chrome-row-and-what-the-bail-out-costs.md) all
+rest their argument on the shell having failed the paper line *before any
+wrapper existed*. That was true at 1,141 B. It is not true at 994 B.
+
+#### The rows
+
+Three runs, `A1 → B → A2`, one session, box probed before each. B = 1,200
+boundaries, six rounds, rungs 0/1/3/7/20, Q = E. `shell` is the driver's own
+**directly measured R=0 rung**, never the fitted intercept; bands are min–max
+across the six rounds.
+
+| R=0 shell | A1 *(wrapper)* | B *(no wrapper)* | A2 *(wrapper)* | delta |
+|---|---:|---:|---:|---:|
+| Hicasso, Reagent segment | **1,101** [1,088–1,112] | **994** [985–1,003] | **1,098** [1,090–1,103] | **+105.5 B, +10.6%** |
+| Hicasso, UIx segment | **1,097** [1,095–1,098] | **992** [985–998] | **1,097** [1,092–1,105] | **+105.0 B, +10.6%** |
+
+**The estimator is named rather than left to be inferred.** The delta is the
+paired one — `mean(A1, A2) − B` — and the percentage is that delta over **B**,
+the no-wrapper arm, because the question is what the wrapper *adds* to a shell
+without it. The unpaired deltas are `A1 − B` = +107 / +105 B and `A2 − B` =
++104 / +105 B, so the pairing changes the Reagent figure by 1.5 B and the UIx
+figure by nothing.
+
+**The A/B bands are disjoint on both segments** — 85 B and 87 B of clear air on
+the Reagent segment, 97 B and 94 B on the UIx segment — so the arms are
+distinguishable by this studio's house rule before the delta is quoted.
+
+**A1 and A2 bracket B in time and do not separate**: 1,101 against 1,098 (bands
+overlap over [1,090–1,103]) and 1,097 against 1,097. The box did not move under
+the pair.
+
+#### Against the 1 KB line, which is what changed
+
+| | Reagent segment | UIx segment | against the 1 KB paper-fail line |
+|---|---:|---:|---|
+| no wrapper (B) | 994 B | 992 B | **0.99× — at the line** |
+| wrapper (A, paired) | 1,099.5 B | 1,097 B | **1.10× — over it** |
+
+**Read the no-wrapper row as "at the line", not as "passing".** 994 B and 992 B
+are 6 B and 8 B under 1,000, the Reagent arm's own per-round band
+[985–1,003] straddles it, and [validation.md](../validation.md) puts this line's
+component-shape sensitivity at **~75 B**. The honest statement is that the
+no-wrapper shell is **not distinguishable from the line in either direction**.
+
+The wrapper arm is a different matter. Its per-round bands are
+[1,088–1,112] and [1,092–1,105]: **every one of the twelve readings is above
+1,075 B**, so it clears the line by more than the shape sensitivity in every
+round rather than on the mean. The flip is also robust to which "1 KB" is
+meant — at 1,024 B the no-wrapper arm reads 0.97× and the wrapper arm 1.07×.
+
+So the shape of the finding is: **the design's own shell now arrives at the
+paper line, and the wrapper is what puts it past.** That is a materially
+different question for the operator than the one the 2026-08-02 rows posed.
+
+#### The wrapper is exactly R-independent, again
+
+The 2026-08-02 session's strongest result reproduces on a tree 145 / 139 B
+lighter in the shell and 169 / 174 B lighter per read:
+
+| marginal slope | A1 *(wrapper)* | B *(no wrapper)* | A2 *(wrapper)* |
+|---|---:|---:|---:|
+| Hicasso, Reagent segment | 1,278 [1,275–1,280] | 1,278 [1,276–1,279] | 1,279 [1,276–1,280] |
+| Hicasso, UIx segment | 2,115 [2,110–2,118] | 2,115 [2,110–2,118] | 2,115 [2,110–2,118] |
+
+A per-boundary constant is what HD-028 priced the wrapper as, and three runs on
+two segments put the slope inside a 1 B spread. Nothing leaked into the
+per-read term.
+
+#### The controls
+
+**Negative controls — the donors, taken in the same runs.** Neither donor goes
+through `mint-view!`, so neither can see the toggle:
+
+| donor | A1 | B | A2 |
+|---|---:|---:|---:|
+| Reagent shell (R=0) | 510 [499–518] | 510 [503–516] | 506 [499–516] |
+| UIx shell (R=0) | 223 [220–230] | 222 [217–226] | 224 [221–231] |
+| Reagent per read | 947 [947–948] | 947 [947–948] | 947 [947–948] |
+| UIx per read | 2,979 [2,978–2,980] | 2,979 [2,978–2,981] | 2,979 [2,978–2,980] |
+
+**The donors also reproduce their published anchor**, which is what licenses the
+cross-session sentences above: 947 and 2,979 B/read against the 947–948 and
+2,978–2,981 the two most recent sections state. And the **A arm reproduces this
+page's own most recent published `main` rows** — slope 1,278 / 2,115 exactly, and
+shell 1,101 / 1,097 against the 1,103 / 1,097 the fusion section published two
+hours earlier. That reproduction, rather than a table of blob hashes, is what
+says the measured tree and the shipped tree are the same tree; it is the check
+the 2026-08-02 provenance promised and could not deliver.
+
+**Positive control.** The same dense array of 587,500 unboxed doubles —
+**4,700,000 B, fixed before any run.** Measured 4,698,736 B, 4,697,603 B and
+4,698,736 B: ratios 0.9997, 0.9995 and 0.9997, **`ok` under
+`lane/control-verdict`** at the driver's ±25% slack in all three.
+
+> **The control protocol, stated unambiguously (the audit's third item).** The
+> binding gate is `lane/control-verdict` at ±25%, which the driver *exits on*.
+> It is the only band this session registered. The deviations from the
+> prediction — −0.027%, −0.051%, −0.027% — are reported as a **non-gating
+> observation** with no acceptance band attached. The 2026-08-02 session
+> pre-registered a separate ±0.05% expectation, missed it on all three runs and
+> accepted the miss afterwards; registering no second band is the way not to
+> repeat that, and is a deliberate choice made before the first run rather than
+> a band dropped after seeing one.
+
+**0 unverified of 154 mounts**, structural read-back **every field answered**,
+arm-order guard **reportable**, **exit 0** — all three runs, no gate waived and
+none widened.
+
+#### The 145 / 139 B the shell lost since 2026-08-02 is not attributed here
+
+The wrapper arm read 1,247 / 1,236 B on 2026-08-02 and reads 1,099.5 / 1,097 B
+now; `rf2-aqgr2`'s A″/B″ pair puts the shell at 1,244–1,246 / 1,236–1,237 as
+late as that section, so the drop is later than it and no section on this page
+attributes it. The obvious suspect is `rf2-dabt3`'s sub-index fusion, but the
+fusion section's own ablation reports the shell **unmoved** by the part of the
+fusion it ablates, which is about the reader array and not about the whole
+landing. **It is left unattributed rather than guessed at**, and filed as
+`rf2-2rtt6.82`. Nothing in this subsection depends on the answer: A and B were
+taken hours apart from nothing, in one session, on one tree.
+
+#### What this settles, and what it hands the operator
+
+**Settles.** On the tree that ships, the wrapper costs **+105 B — +10.6%** — on
+the R=0 shell, moving it from **994 / 992 B to 1,099.5 / 1,097 B**. The delta is
+within 1 B of the 2026-08-02 re-take on both segments, so that session's
+measurement of the *wrapper* stands and only its base was overtaken. The delta
+is above validation.md's ~75 B shape sensitivity, though not by a wide margin.
+
+**Changes.** The argument every carrier of the old figure rests on —
+*the wrapper widens a failure that pre-dates it* — **no longer holds.** Without
+the wrapper the shell is at the line; with it the shell is 1.10× over. HD-028's
+*Reopens* clause is worded as **failing** the bar, and on this tree the wrapper
+is the thing that reaches it.
+
+**Does not settle, deliberately.** Whether that is "pushing retained heap
+meaningfully farther past the bar" in HD-028's sense. The clause remains
+unquantified in HD-028, in validation.md and in the heap-regime ruling, and it
+is not this page's to quantify. **No candidate-bar row is written into
+validation.md**, matching §6's posture under `rf2-b0tz5`.
+
+**The pre-registered fallback, named and not executed.** HD-028 already records
+what happens if the Fiber fails its gate: *retain HD-006 and ship the same
+comparator as an explicit boundary-level opt-in.* That is the operator's call to
+make, not this section's, and it is written here so the disposition does not
+have to be invented when it is taken.
+
+#### Provenance
+
+Whole-tree anchor **`81321da3fe`**, which is `origin/main`; the working tree was
+clean at the start of A1, carried exactly the one-line B edit for B, and was
+restored **byte-identically** for A2 (`git status --porcelain` empty, runtime
+blob back to `9f3d42be7b`).
+
+The one line under test, `mint-view!` in `arm1/runtime.cljs`:
+
+| arm | line | `arm1/runtime.cljs` blob |
+|---|---|---|
+| **A1, A2** | `(codec/memoize-boundary! (codec/mark-boundary! component))` | `9f3d42be7b3aa529e8fc6ef8531262ceb4d65f1a` |
+| **B** | `(codec/mark-boundary! component)` | `a832fafb1ef164e7a8aaddb329a43875dc38b5c1` |
+
+`front/codec.cljs` is `cf9ef32dc8f751e344016cfa01b1db722ba2440b` in all three —
+the wrapper's definition is present throughout and merely goes uncalled in B.
+`mint-frame-prop-view!` acquired a second `memoize-boundary!` call site since
+2026-08-02 and is **deliberately untouched**: `defview` expands to `mint-view!`
+only, so the frame-prop twin is unreachable from this rig and editing it would
+have made the arms differ by two lines instead of one.
+
+The instrument, all under `implementation/core/test/re_frame/bench/`:
+
+| file | blob | vs §6 run 3 |
+|---|---|---|
+| `p0_run.cjs` | `586474b5cfad0f09df5e3e968ca0282e2c1cd95c` | moved — PRs #7448/#7450/#7451 |
+| `p0_heap.cljs` | `0a568a63cd24b66865e433c49a62eadff8993e8a` | moved |
+| `p0_hicasso.cljs` | `f2440e307423665048dfe227b14baaf4ffc8ac89` | identical |
+| `p0_reagent.cljs` | `b1f5ec9223536557403f6ae9415ab42ac26843b0` | identical |
+| `p0_uix.cljs` | `deec8976010c17e4d2c6e8dc3499678997acd2c0` | identical |
+| `p0_fixture.cljc` | `867ad5838ab64ac6aa7afbf8317d8fb305f53619` | identical |
+
+The two that moved moved **towards refusing more**, not less: nine conditions
+that previously printed a fault and exited 0 now exit non-zero. The four arm
+files are byte-identical to §6's published run 3.
+
+Reproduce — the wrapper arm as `main` stands, the no-wrapper arm by deleting the
+one call above:
+
+```
+node implementation/core/test/re_frame/bench/p0_run.cjs --only ladder
+```
+
+**Conditions.** 2026-08-04 02:45–02:57 +1000, three runs of ~3.5 minutes,
+React 19.2.0, Reagent 2.0.1, UIx 1.4.4, `:advanced` with `goog.DEBUG false`,
+headless Chromium via Playwright, Windows 11, 24 logical cores, 32 GB.
+**Box verified quiet before each run and at close** — real CPU occupancy
+**1.38% / 1.60% / 1.89% / 2.07%**, measured as summed per-process CPU-time
+deltas over a 5-second window divided by the core count. `LoadPercentage` is
+deliberately not used: it reads 15–20% on this box when the true occupancy is
+under 2%. Throughout: 15 node processes (idle MCP servers), 56 chrome, **zero
+java**, ~500 processes, ~30.7 GB free, no other worker and no open PR. The box
+did not change across the window, so the three runs are same-load.
 
 ---
 

--- a/docs/design/hicasso/studio/the-page-chrome-row-and-what-the-bail-out-costs.md
+++ b/docs/design/hicasso/studio/the-page-chrome-row-and-what-the-bail-out-costs.md
@@ -153,6 +153,29 @@ for it.
 > re-take was taken, on instrument blobs byte-identical to the published run.
 > The bead `rf2-2rtt6.58` was filed from this sentence and inherited its error.
 
+> **Re-taken again 2026-08-04, on the tree that ships — and the ≈ +100 B held
+> while the sentence built on top of it did not.** The 2026-08-02 rows above
+> were measured on `worker/cascade-2rtt6-52` at tree `4a33c61e1c`, and the audit
+> on `rf2-2rtt6.58` (PR #7392) established that their blobs do **not** match the
+> post-#7390 landed implementation, so they could not stand as the current
+> price. The `A → B → A` pair was re-taken on `81321da3fe`:
+>
+> | R=0 shell | no wrapper | wrapper | delta | vs the 1 KB line |
+> |---|---:|---:|---:|---|
+> | Hicasso, Reagent segment | **994 B** [985–1,003] | **1,099.5 B** | **+105.5 B, +10.6%** | 0.99× → **1.10×** |
+> | Hicasso, UIx segment | **992 B** [985–998] | **1,097 B** | **+105.0 B, +10.6%** | 0.99× → **1.10×** |
+>
+> **The wrapper's price is confirmed to within 1 B on both segments.** What
+> changed is underneath it: `rf2-aqgr2` and `rf2-dabt3` took ~140 B out of the
+> shell, so the no-wrapper arm now sits **at** the 1 KB line rather than 1.14×
+> over it. **The claim in this section that the wrapper "widens a pre-existing
+> failure rather than causing one" is therefore withdrawn** — on the tree that
+> ships, the wrapper is what carries the shell across the line. Read the
+> no-wrapper figure as *at* the line and not as passing: 994 B is 6 B under
+> 1,000, inside validation.md's own ~75 B shape sensitivity. The rows, the
+> controls and the box state are on
+> [the ladder's own page](reads-per-boundary-heap-ladder.md#the-memo-wrapper-re-taken-on-the-tree-that-ships-rf2-2rtt658-re-take).
+
 ## 4. What this page does and does not settle
 
 **Settles.** The cascade is gone — 300 → 0 card bodies on a page-chrome write, on
@@ -162,8 +185,11 @@ retained cost is a reproducible ~200 B per boundary.
 **Does not settle.** Whether the mount row carries a real few-per-cent regression
 (needs `clock_run.cjs`'s M1 row and its adjudicators). ~~And what +200 B does to
 the **R=0 shell** figure against the paper line.~~ **That second one is now
-settled** — `rf2-2rtt6.58` re-took the shell on the P0 bench and reads
-**+100 B / +9%**, moving it from 1,141 B to 1,247 B; see the note in
+settled** — `rf2-2rtt6.58` re-took the shell on the P0 bench, and re-took it
+again on 2026-08-04 against the landed implementation after the first pair's
+provenance was audited: **+105 B / +10.6%**, moving it from **994 B to
+1,099.5 B**. See the notes in
 [§3](#what-200-b-means-depends-on-the-boundary-shape-and-both-readings-are-true).
-Whether that is acceptable for a **default** on a line the shell was already over
-remains the operator's call.
+Whether that is acceptable for a **default** remains the operator's call — and
+it is now a sharper question than this page framed it as, because the shell is
+**no longer over the line before the wrapper is applied**.


### PR DESCRIPTION
The `A → B → A` pair, re-taken on the **landed post-#7390 implementation** —
which is what the audit on PR #7392 reopened `rf2-2rtt6.58` to get. The
2026-08-02 rows were measured on `worker/cascade-2rtt6-52` at tree `4a33c61e1c`;
the durable page nonetheless claimed those blobs "prove the measured tree and
the merged tree agree". They do not: the measured runtime/codec blobs were
`a6d6c55a58` / `12284ef8f4`, the shipped ones are `9f3d42be7b` / `cf9ef32dc8`.

## The prior, and the result beside it

| | the prior (bead NOTES, 2026-08-02) | measured here (2026-08-04) | agree? |
|---|---|---|---|
| wrapper delta, Reagent seg. | +106 B | **+105.5 B** | **yes, to 0.5 B** |
| wrapper delta, UIx seg. | +98 B *(printed +100)* | **+105.0 B** | yes, to 7 B |
| constant in R, lands wholly in the shell | claimed | **confirmed** — slope identical to the byte, 3 runs × 2 segments | yes |
| the percentage | +9% | **+10.6%** | no — same delta, smaller base |
| the shell was already over the line unwrapped | 1,141 / 1,138 B | **994 / 992 B** | **no — this is the finding** |

**The wrapper's price reproduced. The argument built on top of it did not.**

## The rows

`p0_run.cjs --only ladder`, B = 1,200, six rounds, rungs 0/1/3/7/20, Q = E.
`shell` is the driver's own directly measured R=0 rung, never the fitted
intercept.

| R=0 shell | A1 *(wrapper)* | B *(no wrapper)* | A2 *(wrapper)* | delta |
|---|---:|---:|---:|---:|
| Hicasso, Reagent segment | **1,101** [1,088–1,112] | **994** [985–1,003] | **1,098** [1,090–1,103] | **+105.5 B, +10.6%** |
| Hicasso, UIx segment | **1,097** [1,095–1,098] | **992** [985–998] | **1,097** [1,092–1,105] | **+105.0 B, +10.6%** |

Estimator named rather than inferred: the delta is paired, `mean(A1, A2) − B`,
and the percentage is that delta over **B**. Unpaired: `A1 − B` = +107 / +105,
`A2 − B` = +104 / +105.

## Against the 1 KB line — what actually changed

`rf2-aqgr2` and `rf2-dabt3` took ~140 B out of the shell since 2026-08-02, so:

- **without** the wrapper the shell reads **994 / 992 B — 0.99×, at the line**
- **with** it, **1,099.5 / 1,097 B — 1.10×, over it**

So **the claim every carrier of the old figure rests on — "the wrapper widens a
pre-existing failure rather than causing one" — is withdrawn.** On the tree that
ships, the wrapper is what carries the shell across. Stated with its two
cautions, both against the sharper reading: 994 B is 6 B under 1,000 and its own
per-round band straddles the line, so the unwrapped arm is *at* the line and
**not distinguishable from it** — read it as "at", never as "passing". The
wrapper arm, by contrast, is above 1,075 B in **all twelve** measured readings,
i.e. clears the line by more than validation.md's own ~75 B shape sensitivity in
every round rather than on the mean. The flip survives either reading of "1 KB"
(at 1,024 B: 0.97× → 1.07×).

**This PR decides nothing.** HD-028's "meaningfully farther past the bar" is
unquantified in HD-028, in `validation.md` and in the heap-regime ruling. **No
candidate-bar row is written into `validation.md`.** HD-028's own pre-registered
fallback — *retain HD-006 and ship the same comparator as an explicit
boundary-level opt-in* — is named in all three files and left for the operator.

## Why the number is trustworthy

- **Exit 0 on all three runs**, no gate waived and none widened. This matters
  more than it used to: #7448/#7450/#7451 closed nine conditions that previously
  printed a fault and exited 0.
- **A/B bands disjoint** on both segments — 85/87 B and 97/94 B of clear air.
- **A1 and A2 bracket B in time and do not separate** — 3 B and 0 B apart, bands
  overlapping. The box did not move under the pair.
- **Arms differ by one line** — `mint-view!`'s call to `memoize-boundary!`.
  `mint-frame-prop-view!` gained a second call site since 2026-08-02 and is
  deliberately untouched: `defview` expands to `mint-view!` only, so it is
  unreachable from this rig and editing it would have made the arms differ by two.
- **Negative controls flat**: donor shells 510/510/506 and 223/222/224, donor
  slopes 947/947/947 and 2,979/2,979/2,979.
- **Donors reproduce their published anchor** (947 / 2,979 vs the published
  947–948 / 2,978–2,981), which is what makes the cross-session sentences
  quotable at all.
- **The A arm reproduces this page's own most recent published `main` rows** —
  slope 1,278 / 2,115 exactly, shell 1,101 / 1,097 against `rf2-zei9w`'s
  1,103 / 1,097 taken hours earlier. That reproduction, not a blob table, is
  what says the measured tree is the shipped tree — the check the 2026-08-02
  provenance promised and could not deliver.
- **0 unverified of 154 mounts**, structural read-back every field answered,
  arm-order guard **reportable** — all three runs.
- **Positive control** 4,700,000 B fixed before any run; measured 4,698,736 /
  4,697,603 / 4,698,736 B, **`ok` under `lane/control-verdict`** at ±25% in all
  three.
- **Nothing sits near a quantisation floor.** The delta is ~10× the widest
  per-round band. The one quantity that *is* at its resolution is called out as
  such: B's 6–8 B margin under 1,000, which is why it is reported as "at the
  line" and not as a pass.

## The audit's three smaller items, all carried

1. **False provenance corrected at its source** — the 2026-08-02 subsection now
   opens with a HISTORICAL banner naming the blob mismatch, and is kept
   unedited below it as the record of what that branch measured.
2. **Control protocol made unambiguous** — `lane/control-verdict` at ±25% is
   the binding gate and the only band **this** session registered; the −0.027%
   / −0.051% / −0.027% deviations are reported as a **non-gating observation**
   with no acceptance band attached. Registering no second band, before the
   first run, is the way not to repeat 2026-08-02's missed-then-accepted ±0.05%.
3. **Arithmetic** — `1,138 → 1,236` is recorded as **+98 B / +8.6%**, not the
   +100 B / +8.8% printed.

## Filed, not guessed

`rf2-2rtt6.82` — the shell lost **145 / 139 B** between `rf2-aqgr2` and the
fusion and **nothing on the page attributes it**. The obvious suspect is
`rf2-dabt3`, but that section's ablation reports the shell unmoved by the part
it ablates (a per-key array, which cannot be a shell term either way), so it
neither convicts nor exonerates. Left unattributed rather than guessed at.
Nothing here depends on the answer: A and B were taken in one session on one
tree.

## Files

`reads-per-boundary-heap-ladder.md` (new dated subsection + banner on the
superseded one), `the-page-chrome-row-and-what-the-bail-out-costs.md` (sections
3 and 4), `decisions.md` (HD-028's cost + disposition paragraphs). Docs-only,
3 files, +341/−25.

## Quality gates

| gate | result |
|---|---|
| `p0_run.cjs --only ladder` × 3 (A1, B, A2) | **exit 0, 0, 0** — terminal `[p0] done` on each, no refusal |
| `sh scripts/test-fast-pr.sh` | **exit 0 — PASS fast PR spine** |
| `python scripts/check_doc_slugs.py` | **exit 0**, run directly as well as inside the spine |
| `mkdocs build --strict` (inside the spine) | passed — **but it does not cover `docs/design/`**, so it is not nominated as this diff's gate |
| anchors | **hand-verified.** New heading `### The memo wrapper, re-taken on the tree that ships (rf2-2rtt6.58, re-take)` slugs to `the-memo-wrapper-re-taken-on-the-tree-that-ships-rf2-2rtt658-re-take`; all four inbound links (two in the ladder page, one in the page-chrome row, one in `decisions.md`) checked against it, plus the two pre-existing anchors re-used |
| table column counts | **hand-verified, then cross-checked.** 10 tables added — 4×2, 3×5, 5×2, 4×2, 4×2, 4×4, 3×2, 3×6 (ladder), 5×2 (page-chrome), 5×2 (decisions) — header, separator and every row agree in all 10; 0 mismatches across all 52 tables in the three files |
| box state | quiet at **both** ends: occupancy **1.38% → 1.60% → 1.89% → 2.07%** (summed per-process CPU-time deltas over 24 logical cores — `LoadPercentage` reads 15–20% on this box and is noise), 0 java, 15 node, 56 chrome, ~30.7 GB free throughout, no other worker, no open PR |
| not run | JVM artefact suites and npm/CLJS/isolation — the spine classified both surfaces unchanged, correctly: the diff is three `.md` files. `shellcheck` is not installed on this host and no shell script changed. |
