### PR TITLE
docs(hicasso): the guide's open questions reconciled with the landed record

### DIFF
--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -80,6 +80,10 @@ And the boot namespace, which is the actual subject of this page:
 That is the whole boot. `h/root!` **[unfrozen]** takes the DOM node, a config map,
 and one view, and hands back a teardown function.
 
+The `{}` on `[views/todo-app {}]` is optional — `[views/todo-app]` renders the same
+thing, and the body receives an empty props map either way. Write whichever reads
+better at the call site.
+
 `:initial-events` behaves exactly as it does under
 [`frame-root`](../../../core/how-to/boot-and-mount-an-app.md): ordinary events, run
 once in order, seeding app-db before first paint. Even initial values arrive by
@@ -117,9 +121,12 @@ it.
 Note what the floor implies for the code above. `defonce` keeps the root alive
 across reloads, and the guarantee says the *changed body* is used — so on the
 designed behaviour a `^:dev/after-load` remount hook is not part of the story.
-Whether a swap needs an explicit re-render call, or `defview` re-reads its var and
-the next commit picks the change up for free, is a mechanism question the record
-leaves open. See **Not settled yet**.
+
+Half the mechanism is visible in how `defview` expands. It is a `def` of a freshly
+minted head, so re-evaluating the namespace produces a *new* head — which is a new
+React element type, and React replaces that subtree rather than trying to reconcile
+it. Nothing has to force its way past the default bail-out. What the record does not
+say is what makes the next render happen at all; see **Not settled yet**.
 
 If you edit `:todo/initialise` itself and want the new seed to run, reset the frame
 or reload the page. Hot reload preserves state by design, and it will happily
@@ -164,6 +171,5 @@ be the answer is a *successful* outcome for Hicasso, not a failure mode.
 |---|---|
 | The root operation's name, its config keys, and the teardown's name | Semantics pinned by HD-021; names explicitly unfrozen until the API freeze |
 | Does `rf/init!` and adapter installation still apply? | **Not addressed.** Hicasso is a native view layer rather than an adapter, but the record never says whether the root operation subsumes process setup or whether an `init!`-equivalent survives |
-| May a boundary child omit its props map — `[views/todo-app]` rather than `[views/todo-app {}]`? | **Not addressed.** HD-016 says bodies take a single props map; whether the map is optional at the call site is unstated. This page writes `{}` to stay inside what is ruled |
-| Does a hot-reload body swap need an explicit re-render call? | **Not addressed.** HD-021 pins the guarantees, not the mechanism |
+| What triggers the re-render after a hot-reload body swap | **Not addressed.** HD-021 pins the guarantees and `defview`'s expansion settles how the new body is picked up; nothing says who asks for the render |
 | Where the frame config other than `:initial-events` goes | **Not addressed.** `frame-root` takes a config map today; whether the root operation passes one through is unstated |

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -155,9 +155,9 @@ The attribute map is ordinary hiccup, with the conversions React wants done for
 you.
 
 ```clojure
-(defview title-field [_]
+(defview title-input [_]
   (let [invalid? (sub [:editor/title-invalid?])]
-    [:input.form-control#title
+    [:input#title.form-control
      {:type        :text
       :value       (sub [:editor/title])
       :placeholder "Article Title"
@@ -187,9 +187,11 @@ those, with `nil`s dropped and the rest joined by spaces — so the `(when …)`
 contributes nothing at all when it is false, and you never build a class string by
 hand.
 
-**The tag's `#id` and `.class` shorthand composes.** An explicit `:id` in the map
-wins over `#title`, and `.form-control` on the tag is joined with whatever `:class`
-brings rather than one of them silently replacing the other.
+**The tag's `#id` and `.class` shorthand composes** — and the id comes first, as it
+does in every hiccup dialect: `:input#title.form-control`, never
+`:input.form-control#title`. An explicit `:id` in the map wins over `#title`, and
+`.form-control` on the tag is joined with whatever `:class` brings rather than one
+of them silently replacing the other.
 
 **`:key` is not an attribute.** It is React's identity contract: it is read off the
 map, it never reaches your body, and it is not emitted as a prop.

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -73,11 +73,12 @@ metadata folklore is deleted along with it. Keys go in the props map:
      [todo-row {:key id :id id}])])
 ```
 
-A bare seq of boundary children needs keys, and you get a dev warning if you forget.
+A bare seq of boundary children needs keys, and today you get React's own key
+warning in development if you forget — a Hicasso-minted one is ruled but not built.
 The `for`-lowering sugar that would derive the key from the binding is **not v0** —
 you write `:key` yourself. Putting a plain `defn` in head position — `[badge {...}]`
-where `badge` was never minted by `defview` — is a loud error rather than a silent
-embedding.
+where `badge` was never minted by `defview` — is `:rf.error/hicasso-bad-head`,
+a loud error rather than a silent embedding.
 
 ### The component ABI
 
@@ -135,6 +136,65 @@ What the default buys you, beyond that chain, is that a boundary the value does
 **not** reach skips instead of re-rendering for nothing. Moving the read down is
 still a granularity fix, not a correctness fix, and if you go looking for a lost
 update you will not find one.
+
+Whether the bail-out stays the *default* is the one thing on this page still in
+front of the operator. It costs about 100 bytes of retained heap per boundary, and
+on the smallest measurable shell that is what carries the shell across the 1 KB
+line — so HD-028's own pre-registered fallback, shipping the same comparator as an
+explicit opt-in instead, is live. Nothing you write changes either way; what
+changes is whether you have to ask for it.
+
+## Attributes
+
+The attribute map is ordinary hiccup, with the conversions React wants done for
+you.
+
+```clojure
+(defview title-field [_]
+  (let [invalid? (sub [:editor/title-invalid?])]
+    [:input.form-control#title
+     {:type        :text
+      :value       (sub [:editor/title])
+      :placeholder "Article Title"
+      :aria-label  "Title"
+      :data-testid "title"
+      :style       {:margin-top 8}
+      :class       ["is-wide" (when invalid? "is-invalid")]
+      :on-input    [:editor/set-title ::h/value]}]))
+```
+
+Five rules cover the whole of it.
+
+**Names go kebab to camel.** `:on-click` emits `onClick` and `:default-value`
+emits `defaultValue`. `:aria-*` and `:data-*` pass through exactly as written,
+because that is what the DOM wants, and a `--custom-property` is preserved
+verbatim. Three attributes React spells differently from HTML are renamed for you:
+`:class` → `className`, `:for` → `htmlFor`, `:charset` → `charSet`.
+
+**Values convert one level deep.** A nested map — `:style` and its kin — has its
+own keys camelCased, so `{:margin-top 8}` arrives as `marginTop`. Keywords and
+symbols become their names, which is why `:type :text` is `type="text"`. Functions
+cross by identity, deliberately: rewrapping them would defeat the default
+value-equality bail-out and every other comparison that looks at handler identity.
+
+**`:class` takes more than a string.** A keyword, a symbol, or a collection of
+those, with `nil`s dropped and the rest joined by spaces — so the `(when …)` above
+contributes nothing at all when it is false, and you never build a class string by
+hand.
+
+**The tag's `#id` and `.class` shorthand composes.** An explicit `:id` in the map
+wins over `#title`, and `.form-control` on the tag is joined with whatever `:class`
+brings rather than one of them silently replacing the other.
+
+**`:key` is not an attribute.** It is React's identity contract: it is read off the
+map, it never reaches your body, and it is not emitted as a prop.
+
+One further key is reserved, and it is the only attribute merge Hicasso has. `:&`
+carries a map of attributes from somewhere else — a caller's forwarded remainder, a
+theme's part attributes — and **the literal keys you write always win over it**.
+The case that makes the law worth having is a controlled input, so
+[Controlled inputs](04-controlled-inputs.md#forwarding-attributes-onto-a-controlled-input)
+teaches it in full.
 
 ## How `sub` works, in the four sentences that matter
 
@@ -208,4 +268,5 @@ independently, not because the markup got long.
 |---|---|
 | `sub` and `defview` spellings | Working names; [authoring.md](../authoring.md) holds all declaration spellings unfrozen until the freeze |
 | The bar | The read surface is ruled, but the ship-bar rows (mount and bulk ≤ 1.0× Reagent, HD-012) are not yet taken; the programme can still end null on them |
-| The dev warning for an unkeyed seq — its id and whether it is dev-only | **Not addressed** beyond "dev warning" |
+| Whether the value-equality bail-out stays the **default** | **An open operator ruling.** HD-028 rules it the default and the runtime implements it, but the wrapper is what carries the R=0 shell across the 1 KB retained-heap line (994/992 B without it, 1,099.5/1,097 B with it), so HD-028's own fallback — the same comparator as an explicit boundary-level opt-in, with HD-006 restored as the default — is on the table. This page teaches the default because that is what is landed |
+| The dev warning for an unkeyed seq — its id and whether it is dev-only | **Not addressed** beyond HD-016's "dev warning", and nothing mints one: what a reader sees today is React's own key warning |

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -96,6 +96,11 @@ realized once and flattened one level, `nil` and `false` render nothing, `true` 
 error, and an existing React element is a legal child anywhere. A view may return
 `nil`, a single root, or a fragment.
 
+`(:children props)` is a **vector of hiccup forms**, so splice it rather than
+dropping it in whole — `(into [:ul.nested] children)`, or `(into [:<>] children)`
+when you have nothing to wrap it in. A raw vector in child position is read as
+hiccup, and a vector whose head is itself a vector is not a legal element.
+
 `:key` never reaches your body. That is React's contract, not a Hicasso choice, and
 pretending otherwise would be the kind of leaky convenience that costs you a day
 when it finally bites.

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -217,6 +217,14 @@ events. Witnessed end-to-end — grammar, equality, refusals, real clicks throug
 real router — in `front/route_link_cljs_test` and
 `shapes/route_link_dom_cljs_test`.
 
+Routing also publishes a `:prefetch` opt-in, and Hicasso declines it for v0 — out
+loud, rather than by ignoring it. A `route-link` carrying `:prefetch` in any form,
+`nil` and `false` included, fails at render with
+`:rf.error/hicasso-route-link-prefetch-declined`. A key that merely fell through
+would leave you with a link that prefetches nothing, reports it nowhere, and
+carries a stray attribute on the anchor. If you want prefetching today, write it as
+an ordinary intent at `:on-mouse-enter`.
+
 ## Callbacks carry their frame
 
 A generated callback closes over its boundary's frame, resolved once per boundary
@@ -259,5 +267,3 @@ dispatch, and a plain `(fn …)` when you want to read it and do something else.
 | Question | Status |
 |---|---|
 | `h/fn`'s spelling | Working name; HD-024 leaves the spelling unfrozen like every declaration spelling |
-| A symmetric allow-default head | **Explicitly not shipped.** Added only if dogfooding produces a real site needing both native submission and equality-based structural testing (HD-026) |
-| `:prefetch` on `route-link` | **Declined for v0** — the census counts no prefetch site; reopens if one appears (HD-027) |

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -19,7 +19,9 @@ Here is what you write:
 ```
 
 That's it. Value in from a subscription, intent out to an event — ordinary
-`:value` and `:on-input`, no ceremony. The rest of this page is about the
+`:value` and `:on-input`, no ceremony. `:on-change` works identically; the runtime
+converges after whichever of the two runs last for a keystroke, and takes
+`:on-change` when a field carries both. The rest of this page is about the
 machinery underneath, because you need to know what it guarantees and where it
 stops.
 
@@ -230,6 +232,4 @@ with a commit on blur is not a compromise. It is the right shape.
 | The revision prop's spelling on a controlled element | **Not addressed.** The reset law is ruled; the attribute that carries the revision is unnamed |
 | The buffered / draft-and-commit input ladder | **Post-v0, explicitly.** The charter defers "the full buffered/revision input ladder"; v0 ships R-A1/R-A2 and no more |
 | The controls kit that owns drafts and revisions | **Post-v0.** HD-009 leans on it for ephemeral state, and it does not exist in v0 — so in v0 a draft is app-db state you write yourself |
-| Which props count as controlled | HD-010's merge law names `:value` and `:checked`; the converge's own scope is exact (caret-bearing `input` or `textarea`, non-nil `:value`); whether the controlled roster is longer is unstated |
-| The value path through a live IME composition | **Ruled 2026-08-03, and shipped.** Convergence is suspended while a composition is live and the field converges once at `compositionend` — a deliberate divergence from plain React and the UIx port, both of which still abort the exchange. Witnessed on Chromium (the harness drives composition over CDP); WebKit is undriven rather than known-good |
-| Whether `:on-input` or `:on-change` is the taught attribute | The landed screens write `:on-input` for text and `:on-change` for checkboxes; the choice is convention, not ruling |
+| Whether `:on-input` or `:on-change` is the taught attribute | Both work, and the runtime takes whichever runs last. The landed screens write `:on-input` for text and `:on-change` for checkboxes; which one the guide should teach is convention, not ruling |

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -3,15 +3,14 @@
 > **Draft ahead of the product artefact.** This page teaches the landed surface —
 > ruled in [decisions.md](../decisions.md) (HD-001…HD-028). `defhost`'s door is
 > witnessed end-to-end by
-> `implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs`
-> (rf2-2rtt6.65): one foreign React component with its own state, its own effects,
-> its own context read and three different invoker styles on its callbacks,
-> declared once and driven from a Hicasso tree. No `implementation/hicasso/`
-> artefact ships yet, though, and spellings marked **[unfrozen]** stay provisional
-> until the API freeze. Three things this page describes are ruled but **not
-> built** — the `[:>]` raw escape, the migration codemod and SSR — one default,
-> deep prop conversion, is deliberately not offered at all, and `defhost`'s option
-> keys are still open. See **Not settled yet**.
+> `implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs`:
+> one foreign React component with its own state, its own effects, its own context
+> read and three different invoker styles on its callbacks, declared once and
+> driven from a Hicasso tree. No `implementation/hicasso/` artefact ships yet,
+> though, and spellings marked **[unfrozen]** stay provisional until the API
+> freeze. Three things this page describes are ruled but **not built** — the `[:>]`
+> raw escape, the migration codemod and SSR — and one default, deep prop
+> conversion, is deliberately not offered at all. See **Not settled yet**.
 
 You want a date picker from npm. In Reagent you write `[:> DatePicker {...}]` and
 move on. Hicasso asks you to write one line first:
@@ -25,7 +24,8 @@ move on. Hicasso asks you to write one line first:
   {:callbacks {:on-change :event}})     ;; defhost is [unfrozen]
 ```
 
-Then use it anywhere, and it is indistinguishable from a native view:
+Then use it anywhere a view is legal — including as another view's child, since
+children cross as ordinary hiccup and are lowered by whoever renders them:
 
 ```clojure
 (ns app.views
@@ -80,7 +80,16 @@ Reagent was never `[:>]`, it was `r/atom`.
 
 Policy overrides live on the declaration rather than at the call site, which is the
 whole point: one place decides how this component is crossed, and every use site
-inherits it. The option keys are not in the record; see **Not settled yet**.
+inherits it. There is exactly one option today — `:callbacks`, a finite map from
+prop name to `:event`, `:handler` or `:render`, and the subject of the next
+section.
+
+Everything a declaration can get wrong, it gets wrong *at the declaration*, where
+your stack trace points at the line you wrote: a contract that is not one of the
+three, a contract on `:key` or `:ref` (React's, not positions), two spellings of
+one prop declared twice, and a component that resolved to `nil` — the classic
+`:default` against a library that has no default export, which React would
+otherwise report from somewhere else entirely.
 
 Deep conversion — camelCasing keys *inside* a nested option map — is deliberately
 not offered at any level. Guessing which nested maps are options and which are data
@@ -118,6 +127,15 @@ from it. This is the shape for a library's imperative surface (`open()`,
 own render* — `renderRow`, `renderItem`, a render prop. The body must be pure: its
 return is what the library puts in its tree, and dispatching from inside it raises
 `:rf.error/hicasso-dispatch-in-render-position`, naming the position.
+
+Read "from inside it" exactly. **The row you build may carry ordinary intents.** A
+`renderRow` that returns `[:li {:on-click [:row/pick id]} title]` is the whole
+point of a render prop, and that handler fires later, at the user's click, into
+the frame of the boundary that supplied the callback — the only frame that could
+own it, since the foreign component has none. What is forbidden is dispatching
+*while the call is running*, whether directly or by lowering a handler and firing
+it synchronously in the same body. The distinction is the law's own: pure while
+you are building the row, ordinary once you have handed it over.
 
 ### The declaration decides; the value never overrules it
 
@@ -409,10 +427,9 @@ two or three genuinely hard widgets.
 
 | Question | Status |
 |---|---|
-| `defhost`'s option keys | **Not addressed.** "Policy overrides live on the declaration" is as far as the record goes |
+| Whether `defhost` grows a second option beyond `:callbacks` | **Not addressed.** HD-011 names strong defaults and "policy overrides on the declaration", and `:callbacks` is the only override the landed door carries. Whether the SSR placeholder or the conversion defaults ever become declarable is unstated |
 | The migration codemod | **Ruled, unbuilt.** HD-011's rationale leans on it, but nothing has been built and the record names neither a tool nor an invocation |
 | When the reserved `{:ref [id config]}` spelling lands, and what registers an id | **Reserved, not designed.** HD-022 rules the refusal and the value-space; the registry, the timings and the commands roster are explicitly out of v0 |
 | Which React version the runtime targets | **Not addressed by the design record.** The cleanup-returning callback ref taught above is a React 19 contract; this repo's implementation currently pins React 19.2, but that is a fact about today's tree, not a Hicasso ruling. If v0 lands on 18, the fallback shape above is the one to teach |
 | The SSR placeholder's shape | Declared policy, inert in v0 |
-| Whether a hosted component can be a `defview`'s child via `(:children props)` | The ABI says an existing React element is a legal child anywhere, which implies yes; not stated for the host case specifically |
 | Embedding Hicasso *inside* a React-primary app | Named in the charter's use-case roster (item 11); no surface designed |

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -260,7 +260,7 @@ host-ownership pattern is a product-phase question; the v0 answer is React, used
 honestly, at the edge.
 
 Used honestly means **the attach and the teardown are written as one thing.** An SDK
-that mounts and never tears down is the most common bug on this seam, and it is not
+that mounts and never tears down is the most common bug at this edge, and it is not
 subtle — you get two maps, two resize observers, and a leak per remount. React 19's
 callback ref makes the pairing structural: **whatever the ref function returns is its
 cleanup**, so you cannot write the attach without deciding what undoes it.
@@ -287,14 +287,14 @@ cleanup**, so you cannot write the attach without deciding what undoes it.
     [:div.map {:ref attach}]))
 ```
 
-Four properties, and each one is load-bearing.
+Four properties, and dropping any one of them breaks something specific.
 
 **The handle is per-attach, not per-namespace.** It is created by the attach and
 captured by the cleanup that attach returned. Two attaches produce two handles and
 two cleanups, correctly paired. The moment you hoist that handle into a `defonce`
 atom or a module-level var, a second attach overwrites the first and the first
 instance leaks — which is the actual mechanism behind every "it mounted twice" report
-on this seam.
+at this edge.
 
 **The teardown is idempotent.** The `done?` latch makes a second call a no-op. React
 calls each cleanup exactly once, so strictly this is belt and braces — but SDK

--- a/docs/design/hicasso/draft-guide/06-theming.md
+++ b/docs/design/hicasso/draft-guide/06-theming.md
@@ -42,6 +42,9 @@ it is platform-native.
 }
 ```
 
+Nothing about the `--app-*` prefix is Hicasso's; name your custom properties
+whatever your stylesheet already does.
+
 Switching theme is one attribute flip on one element, and **restyling from there
 costs zero React work** — no re-render, no hook, no diff. The cascade recomputes and
 your component tree is never consulted, which is exactly right, because nothing in it
@@ -116,31 +119,34 @@ The obvious one: one view reads `:theme/current` and puts it on its own element.
 
 ```clojure
 (defview theme-scope [{:keys [children]}]
-  [:div {:data-theme (name (sub [:theme/current]))}
-   children])
+  (into [:div {:data-theme (name (sub [:theme/current]))}]
+        children))
 
 ;; At the root:
 [theme-scope {} [app {}]]
 ```
 
+`children` arrives as a realized *vector* of hiccup forms, which is why it is
+spliced with `into` rather than dropped in as one child —
+[Views and reads](02-views-and-reads.md#the-component-abi) has the rule.
+
 **Its true cost.** The boundary that reads the theme re-renders on every switch —
-that much is certain, and it is one boundary. What happens below it now turns on
-the [default value-equality bail-out](02-views-and-reads.md#boundaries-memoize-by-default)
+that much is certain, and it is one boundary. What happens below it turns on the
+[default value-equality bail-out](02-views-and-reads.md#boundaries-memoize-by-default)
 (HD-028) rather than on how `theme-scope` gets its content. `app` is a boundary
 either way — handed down as `children` or minted directly inside `theme-scope`'s
 own body — and its props are unaffected by the theme, so they compare `=` at every
 re-render and its own memo wrapper bails regardless of which style you write. The
-way to lose the bail-out is different from either style above: splice `app`'s
-markup in as a plain call instead of `[app {}]`. A plain call has no boundary of
-its own to hold a memo wrapper, so it re-runs with `theme-scope` every time —
-independent of which bridge you chose.
+way to lose the bail-out is to call `app` as a plain function instead of writing
+`[app {}]`. A plain call has no boundary of its own to hold a memo wrapper, so it
+re-runs with `theme-scope` every time — independent of which bridge you chose.
 
-That leaves one open question, not two. Whether an *interpreted* hiccup runtime
-preserves element identity for children a boundary merely passes through is still
-unmeasured, but it now decides only how *cheap* the skip is: a referentially
-identical child never reaches the comparator; a freshly minted one still reaches
-it and still bails, one step later. Neither path costs the app, as long as `app`
-stays a boundary.
+Element identity does not enter into it, because there is none to preserve.
+Children cross a boundary as hiccup data, not as React elements, so `theme-scope`
+mints a fresh element for `app` on every render whichever style you write. The
+skip is therefore always the comparator's `=`, never a referential short-circuit
+ahead of it — and `=` on an unchanged props map is cheap. What matters is only
+that `app` stays a boundary.
 
 ### Bridge B — an effect writes the attribute
 
@@ -278,11 +284,9 @@ order to remember, in exchange for a flexibility nobody is going to use.
 | Question | Status |
 |---|---|
 | **How the app-db choice reaches the `data-theme` scope** | **Unresolved, and the largest hole on this page.** HD-010 rules the choice into app-db and rules the switch to be one attribute flip, and never joins them. [Layer 3 and the DOM](#layer-3-and-the-dom) names both candidate bridges and prices them; picking one is a design decision, not a writing decision |
-| Whether a boundary that only passes children through preserves their element identity | **Not addressed**, but HD-028's default bail-out now covers bridge A's cost either way — this decides only whether the skip is free (identity-preserved) or a cheap `=` check (identity not preserved), not whether it happens |
 | Whether the theme attribute is per-root or per-document | **Not addressed.** Layer 3 promises frame isolation; a document-level attribute does not have it |
 | How a control declares a part | **Not addressed.** "Controls emit keyword-tagged parts" is the whole of the record; the attribute or macro that does it is unnamed |
 | How an app installs a theme | **Not addressed.** The merge order `base < app-theme < instance-props` is ruled; the mechanism that supplies the app-theme layer is not. Since there is no context, it is presumably passed or registered — the record does not say which |
 | The part-address shape | This guide writes `[:typeahead :root]` by analogy with the record's "part address" language; the actual shape is unstated |
-| CSS custom property naming convention | **Not addressed.** The `--app-*` prefix above is this guide's invention |
 | Where the boot-static part map lives | Implied by law (b) to be fixed at build; the residence is unstated |
 | The controls kit that would ship parts | **Post-v0** |

--- a/docs/design/hicasso/draft-guide/07-ephemeral-state.md
+++ b/docs/design/hicasso/draft-guide/07-ephemeral-state.md
@@ -181,6 +181,11 @@ timeout returns to `:present` rather than finishing its exit and remounting. And
 presence never dispatches anything — a node lingering on screen is not a reason for
 anything in app-db to linger with it.
 
+**Order is frozen at first appearance**, deliberately, so an exiting child does not
+jump to a new slot halfway through its animation. Surviving keys keep the order
+they had and genuinely new keys are appended. A list that re-sorts while items are
+leaving therefore sorts at the data layer, not here.
+
 **Enter is the weak half, and this guide will not pretend otherwise.**
 `::h/mounting` exists, but driving an entrance as a `:mounting` → `:present` class
 flip can lose the race to the browser's first paint, and then nothing animates. For
@@ -235,5 +240,3 @@ that edge needs to know it exists.
 | The controls kit (drafts, revisions) | **Post-v0** |
 | The overlay top layer that would own open and dismiss | **Post-v0** |
 | The reusable-widget instance-key convention | **Post-v0**, named as a resolved design debt in HD-009's sugar |
-| Whether presence order can follow a live re-sort | **No, by design, inherited.** Presence freezes first-appearance slots so an exiting child does not jump mid-animation; a continuously re-sorting list orders at the data layer |
-| Where the line falls between "mechanics" and "semantic" in hard cases | **Judgment, by design.** HD-003 makes it a taught rule with no enforcement, and reopens if dogfooding shows it confusing in practice |

--- a/docs/design/hicasso/draft-guide/08-testing.md
+++ b/docs/design/hicasso/draft-guide/08-testing.md
@@ -77,8 +77,12 @@ component you mount-test once.
 
 ## The mounted door
 
-A shared browser facade covers `act`, root lifecycle, and residue assertions
-**[unfrozen — the facade has no name in the record]**.
+A shared browser facade covers root lifecycle, a synchronous dispatch door, and
+residue assertions **[unfrozen — the facade has no name in the record]**. Note what
+it deliberately is not built on: `act` diverts React's work to a queue that is not
+the browser's, which is right for an effect-ordering test and wrong for a witness
+that reads the page. The bench arm's fixture flushes instead, so an assertion on
+the line after a dispatch reads the DOM the user would have seen.
 
 One assertion is standing, on every mounted test: **zero leaked subscription
 ref-counts after teardown.** A related invariant rides with it — an unchanged hot
@@ -87,8 +91,8 @@ should show no churn at all.
 
 Reach for a mounted test when you need:
 
-- a real error boundary — `h/boundary` **[unfrozen]** is the runtime's class
-  component, taking `:fallback`, `:reset-key`, and `:on-error`;
+- a real error boundary catching a real throw
+  ([When a view throws](09-when-a-view-throws.md));
 - caret, selection, or IME behaviour, which only a real browser can prove
   ([Controlled inputs](04-controlled-inputs.md));
 - StrictMode, abandoned first mount, root teardown, or an HMR body swap;
@@ -133,7 +137,7 @@ these reads — and they are excellent at it precisely because that is all they 
 |---|---|
 | The headless render function's name and signature | **Not addressed.** HD-021 pins the semantics — structural render as data, sub reads overridable — and names nothing. `h/render` and the `{:subs …}` option above are this guide's invention |
 | The read resolver's shape | **Not addressed.** "A pure read resolver" is the whole of the record; a map is the obvious form, and it is a guess |
-| The mounted facade's name and API | **Not addressed** beyond "act, root lifecycle, residue assertions" |
+| The mounted facade's name and API | **Not addressed.** The bench arm's fixture is the only one that exists, it is not a product surface, and it already diverges from the description the record sketched it with — it flushes rather than using `act` |
 | Whether headless renders one boundary or a subtree | **Not addressed.** The example above renders one; whether child boundaries are rendered through or returned as unexpanded nodes is unstated, and it changes how every test is written |
 | How intent vectors are *invoked* in a headless test | **Not addressed.** They can be asserted by equality; whether the door lets you fire one and observe the dispatch is unstated |
 | The registry / manifest surface — views enumerable with schemas, docs, source coordinates | **Post-v0.** Named as the AI-ergonomics door |

--- a/docs/design/hicasso/draft-guide/08-testing.md
+++ b/docs/design/hicasso/draft-guide/08-testing.md
@@ -28,8 +28,8 @@ function anywhere in the tree performs one, so read the block below as the shape
 that is ruled rather than a test you can write this afternoon:
 
 ```clojure
-;; SKETCH — h/render does not exist. HD-021's ruled semantics, spelled by
-;; this guide so the shape is visible.
+;; SKETCH — h/render does not exist, and its spelling is [unfrozen] besides.
+;; HD-021's ruled semantics, spelled by this guide so the shape is visible.
 (deftest todo-row-renders-title
   (let [tree (h/render [todo-row {:id 7}]
                        {:subs {[:todo/by-id 7]      {:title "Buy milk"}

--- a/docs/design/hicasso/draft-guide/08-testing.md
+++ b/docs/design/hicasso/draft-guide/08-testing.md
@@ -1,10 +1,14 @@
 # Testing
 
-> **Draft ahead of the product artefact.** This page teaches the landed surface —
-> ruled in [decisions.md](../decisions.md) (HD-001…HD-028), witnessed by the bench
-> arm's tests under `implementation/freehand/test/re_frame/bench/hicasso/` — but no
-> `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
-> stay provisional until the API freeze.
+> **Draft ahead of the product artefact.** This page teaches the ruled surface —
+> [decisions.md](../decisions.md) (HD-001…HD-028) — and spellings marked
+> **[unfrozen]** stay provisional until the API freeze. **Read this page with one
+> extra caution.** The mounted door exists: the bench arm's suites under
+> `implementation/freehand/test/re_frame/bench/hicasso/` are it. **The headless
+> door is ruled and not built** — no structural render function exists anywhere in
+> the tree, and the one below is this guide's illustration of HD-021's semantics
+> rather than a call you can make today. What is real now is the property the door
+> rests on, and this page says which is which.
 
 There are two doors into a Hicasso view under test, and knowing which one you are
 allowed through is most of the skill.
@@ -19,11 +23,15 @@ says it in four words: **no fake hook dispatcher, ever.**
 ## The headless door
 
 A structural render returns the view's hiccup tree as data. No DOM, no React, no
-browser.
+browser. **Nothing implements this yet** — HD-021 rules the semantics and no
+function anywhere in the tree performs one, so read the block below as the shape
+that is ruled rather than a test you can write this afternoon:
 
 ```clojure
+;; SKETCH — h/render does not exist. HD-021's ruled semantics, spelled by
+;; this guide so the shape is visible.
 (deftest todo-row-renders-title
-  (let [tree (h/render [todo-row {:id 7}]                 ;; h/render is [unfrozen]
+  (let [tree (h/render [todo-row {:id 7}]
                        {:subs {[:todo/by-id 7]      {:title "Buy milk"}
                                [:todo.ui/editing? 7] false}})]
     (is (= [:li
@@ -33,13 +41,15 @@ browser.
            tree))))
 ```
 
-Two things are doing the work here.
+Two things would be doing the work there, and only one of them is waiting on the
+door.
 
 **Sub reads are overridable through a pure read resolver.** You hand the render a
 map of query vector to value, and the body reads from it. No frame, no app-db, no
 registration — just the values the view is a function of. `sub` is an ordinary
 call ([Views and reads](02-views-and-reads.md)), and the resolver answers it
-wherever the body makes it.
+wherever the body makes it. This half is entirely the door's, and it is the half
+that does not exist yet.
 
 **Intent vectors are assertable by equality.** `{:on-click [:todo/toggle 7]}` is
 data. You can `=` it. Compare that with the alternative — asserting that a node
@@ -135,7 +145,7 @@ these reads — and they are excellent at it precisely because that is all they 
 
 | Question | Status |
 |---|---|
-| The headless render function's name and signature | **Not addressed.** HD-021 pins the semantics — structural render as data, sub reads overridable — and names nothing. `h/render` and the `{:subs …}` option above are this guide's invention |
+| The headless render function's name and signature | **Not addressed, and not built.** HD-021 pins the semantics — structural render as data, sub reads overridable — and names nothing; nothing in the tree implements one. `h/render` and the `{:subs …}` option above are this guide's invention |
 | The read resolver's shape | **Not addressed.** "A pure read resolver" is the whole of the record; a map is the obvious form, and it is a guess |
 | The mounted facade's name and API | **Not addressed.** The bench arm's fixture is the only one that exists, it is not a product surface, and it already diverges from the description the record sketched it with — it flushes rather than using `act` |
 | Whether headless renders one boundary or a subtree | **Not addressed.** The example above renders one; whether child boundaries are rendered through or returned as unexpanded nodes is unstated, and it changes how every test is written |

--- a/docs/design/hicasso/draft-guide/09-when-a-view-throws.md
+++ b/docs/design/hicasso/draft-guide/09-when-a-view-throws.md
@@ -1,0 +1,133 @@
+# When a view throws
+
+> **Draft ahead of the product artefact.** This page teaches the landed surface —
+> ruled in [decisions.md](../decisions.md) (HD-001…HD-028), witnessed by the bench
+> arm's tests under `implementation/freehand/test/re_frame/bench/hicasso/` — but no
+> `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
+> stay provisional until the API freeze.
+
+A view body throws — a `nil` where a map was expected, a key that moved, a
+subscription returning a shape last week's code doesn't handle. React's answer is
+not a red box around the broken component. **React unmounts the entire root**, and
+your user is looking at a blank page.
+
+That is the right default for a framework that cannot know which parts of your app
+are independent. You do know, so you say so:
+
+```clojure
+(defview article-page [{:keys [id]}]
+  [:main
+   [site-header {}]
+   [h/boundary {:fallback [:p.oops "We couldn't load this article."]}   ;; [unfrozen]
+    [article-body {:id id}]]
+   [site-footer {}]])
+```
+
+If `article-body` throws, the header and footer stay on screen and the paragraph
+takes its place. Nothing else in the tree notices.
+
+## The three keys
+
+`h/boundary` **[unfrozen]** is the runtime's own error boundary, and it takes
+exactly three props. There is no error classification, no retry policy, no logging
+surface — each of those is your application's decision, and `:on-error` is the door
+you make them behind.
+
+| Key | Shape | What it does |
+|---|---|---|
+| `:fallback` | hiccup, or `(fn [error] hiccup)` | renders instead of the children once something below has thrown |
+| `:reset-key` | any value, compared with `=` | changing it clears the caught failure and re-mounts the children |
+| `:on-error` | an intent vector, or a plain function | fires once per caught failure |
+
+**`:fallback` can read the error.** Pass a function and it is called with whatever
+was thrown, so a development build can show the message and a production one can
+show a sentence. Hiccup the function returns is lowered exactly like hiccup you
+wrote inline — intents included.
+
+**`:reset-key` is how a retry happens, and it is yours to schedule.** The boundary
+never guesses. It clears its caught failure when the key changes, and remounts the
+children; if they throw again, it catches again. A counter in app-db is the usual
+shape:
+
+```clojure
+(defview article-page [{:keys [id]}]
+  [:main
+   [h/boundary {:fallback  (fn [_error]
+                             [:div.oops
+                              [:p "We couldn't load this article."]
+                              [:button {:on-click [:article/retry id]} "Try again"]])
+                :reset-key (sub [:article/attempt id])
+                :on-error  [:app/record-failure]}
+    [article-body {:id id}]]])
+```
+
+That retry button is an ordinary intent inside a fallback, and it works — the
+fallback is walked inside the boundary's own render, and the boundary re-binds the
+frame it was mounted under around that walk so a handler there lowers exactly as it
+would in the parent's body.
+
+**`:on-error` fires once per failure.** A vector is dispatched with the error
+appended, so `[:app/record-failure]` reaches your handler as
+`[:app/record-failure error]`, in the frame the boundary is mounted under. A
+function is called with the error instead, and nothing is dispatched. Once means
+once even in development, where StrictMode runs the throwing render twice and React
+still reports a single catch.
+
+## What it does not catch
+
+Worth knowing precisely, because a boundary that quietly does not catch is worse
+than no boundary at all. This is React's line, and Hicasso inherits it exactly.
+
+**Caught:** a throw from a render, and from the lifecycle and effects of the tree
+below.
+
+**Not caught:** a throw from an event handler, from a `setTimeout`, or from
+anything else the browser calls outside React's own work loop. An intent handler
+that throws lands in the browser's error channel, not here — and that is the right
+place for it, because your event pipeline has its own error handling and a view
+layer should not be intercepting it.
+
+## Where to put them
+
+Not everywhere, and not once at the root.
+
+One boundary at the root gives you a whole-page fallback, which is barely better
+than the blank page: the user has lost their navigation too. One boundary per view
+is the other extreme — a fallback per byline is noise, and most of your views
+cannot fail independently of their parent anyway.
+
+The useful grain is a **region a user can still work without**: a panel, a tab
+body, a sidebar widget, a route's main content. Ask what the rest of the page is
+still good for if this part is gone. If the answer is "nothing", the boundary
+belongs further up.
+
+One caution on nesting. **A fallback that throws while rendering is caught by the
+next boundary up**, so a clever fallback that reads the state that caused the
+failure can turn one broken panel into a broken page. Keep fallbacks dull.
+
+## Troubleshooting
+
+| Symptom | What went wrong | Fix |
+|---|---|---|
+| The whole page goes blank when one view throws | Nothing caught it — React unmounts the root by default | Put an `h/boundary` around the region that can fail |
+| A throw from an event handler isn't caught | Handlers run outside React's work loop; boundaries only see render, lifecycle and effects | Handle it in the event pipeline, where the error already has a home |
+| The fallback shows and never goes away | No `:reset-key`, or the key never changes | The retry is the caller's to schedule — move a counter in app-db and read it as the key |
+| A retry button in the fallback does nothing | Check it is an intent vector at `:on-click` and that the boundary is mounted under a frame | Intents in a fallback lower under the boundary's own frame; with no frame in scope you get `:rf.error/hicasso-intent-outside-boundary` naming the intent |
+| One panel breaks and the whole page goes with it | The fallback itself threw, and the next boundary up caught that instead | Keep the fallback dull — no reads of the state that failed, no computation |
+| `:on-error` fires twice in development | It doesn't — StrictMode re-runs the failing render, and React still reports one catch | If you genuinely see two, they are two failures |
+
+## When not to reach for one
+
+If the failure is *expected* — a request that can 404, a form that can be invalid,
+a resource that can be unavailable — it is not an exception, it is a state. Model
+it in app-db and render it. A boundary is for the failures you did not anticipate,
+and using one for the ones you did makes a thrown exception part of your control
+flow, which is a worse version of a `:status` key.
+
+## Not settled yet
+
+| Question | Status |
+|---|---|
+| `h/boundary`'s name and its three key names | Semantics pinned by HD-020(c); the spellings are unfrozen like every other declaration spelling |
+| Whether `:on-error` should reach an application-wide handler as well | **Not addressed.** The record ships the per-boundary door and stops there; how an app aggregates failures is its own business today |
+| A richer boundary API | **Post-v0**, explicitly. HD-020 reopens it at product phase by ordinary ruling |

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -17,18 +17,22 @@ narrower question — **what does a programmer actually type?**
 | Page | Its one job |
 |---|---|
 | [Getting started](01-getting-started.md) | Put one Hicasso view on screen inside a frame, and take it down again |
-| [Views and reads](02-views-and-reads.md) | Write a view; read subscriptions where you use them |
+| [Views and reads](02-views-and-reads.md) | Write a view; read subscriptions where you use them; write its attributes |
 | [Events as data](03-events-as-data.md) | Put an event vector in an attribute and let the runtime build the callback — clicks, keys, prevention, and links |
 | [Controlled inputs](04-controlled-inputs.md) | Type into a text field whose value round-trips through app-db, and keep your caret |
 | [Interop](05-interop.md) | Use a React component from npm |
 | [Theming](06-theming.md) | Style a component library without a context API |
 | [Ephemeral state](07-ephemeral-state.md) | Decide where "is this dropdown open?" lives, given there is no `local` — and where "it left but is still fading out" lives, given app-db cannot hold it |
 | [Testing](08-testing.md) | Assert a view's output without a browser, and know when you still need one |
+| [When a view throws](09-when-a-view-throws.md) | Keep one broken view from taking the page down with it |
 
-Eight pages is not an accident. K5 in [validation.md](../validation.md) kills the
-programme at "more than ~8 public concepts or ~8 guide pages to ship CRUD", so the
-guide deliberately spends its whole budget and no more. If it ever needs a ninth
-page, that is a signal about the design, not about the writing.
+The page count is editorial judgement now. It used to be a budget: K5 in
+[validation.md](../validation.md) killed the programme at "more than ~8 public
+concepts or ~8 guide pages to ship CRUD", and this guide was written to spend
+exactly that and no more. **The operator removed K5 as a kill criterion on
+2026-08-04**, so a page is added when a reader genuinely needs one and not
+otherwise. The pressure to stay short did not go away with the number — it just
+stopped being a rule.
 
 ## How to read the markers
 


### PR DESCRIPTION
Sweeps every **Not settled yet** row in `docs/design/hicasso/draft-guide/` against the code on `main` and the decision record, moves the answered ones into the pages, fixes what the pages got wrong, fills two coverage gaps, and holds all nine pages against `docs/AUTHORING.md`.

**The row count in the brief was stale.** There are **47** rows across the eight pages, not 17: 5 / 3 / 3 / 6 / 7 / 9 / 7 / 7. All 47 have a verdict below.

## Quality gates

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `sh scripts/test-fast-pr.sh` | **0** (`PASS fast PR spine`) |

`mkdocs build --strict` is **not** nominated: `exclude_docs` drops `design/hicasso/`, so it exits 0 having verified nothing of this diff. It ran inside the fast-PR spine and is green, but it is not evidence about these pages.

**Hand-verified, because nothing validates them.**

- **Tables: 23 tables, 0 column mismatches**, checked row-by-row against each header. Column counts — Troubleshooting tables 3 (nine of them), *Not settled yet* tables 2 (nine), component ABI 5, `h/fn` positions 2, `defhost` defaults 2, `h/boundary`'s three keys 3, README page table 2.
- **Anchors: 7 outbound intra-guide anchor links, all resolve.** `04#forwarding-attributes-onto-a-controlled-input` (×2), `06#layer-3-and-the-dom` (×2), `02#the-component-abi`, `02#boundaries-memoize-by-default`, `06#bridge-a--a-scope-view-reads-the-choice` (the double hyphen is correct for GitHub slugs — python-markdown collapses the run, which is the documented false-positive trap; `check_doc_slugs.py` is green).
- **Inbound: 1 anchor link from outside the guide** — `decisions.md:690` → `05-interop.md#the-reserved-vector-and-the-gap-it-does-not-close`. Intact; no file was renumbered, precisely so it stays intact. `EP-0038` links `02-views-and-reads.md`, also intact.

## Per-row verdicts (all 47)

**9 settled · 2 wrong question · 36 still open** (5 of those reworded because the wording had gone false). Net: 10 rows deleted, 1 added, 3 on the new page → **41 open rows**, down from 47.

### 01 — Getting started (5)

| Row | Verdict | What settled it |
|---|---|---|
| Root operation's name, config keys, teardown name | **still open** | — |
| Does `rf/init!` / adapter installation still apply | **still open** | Checked and left alone: the bench pages *do* call `rf/init!`, but with a UIx adapter for their comparator renderings, so that is not evidence about Hicasso's own boot |
| May a boundary child omit its props map | **SETTLED** | `codec/props-map?`; `boundary-element` and `native-element` both branch on it, and `front/codec_cljs_test` asserts `[a-view]` → `rfProps` `{}` under *"a boundary with no props map still works"*. One sentence into the body |
| Does a hot-reload swap need an explicit re-render call | **still open, reworded** | Half of it was settled and the row denied it: `defview` expands to a `def` of a freshly minted head (`arm1/lang.clj`), which is a new React element *type*, so the next render replaces the subtree — HD-028's declined `*always-update*` says the same. Only the *trigger* is open, and the row now says so |
| Where frame config other than `:initial-events` goes | **still open** | — |

### 02 — Views and reads (3, +1 added)

| Row | Verdict | What settled it |
|---|---|---|
| `sub` / `defview` spellings | **still open** | — |
| The bar | **still open** | — |
| Dev warning for an unkeyed seq | **still open, reworded** | Nothing mints one — the only `console.warn` in `front/codec.cljs` is the comparator's fail-open notice. What a reader actually sees is React's own key warning, and the body now says that instead of implying Hicasso raises it |
| *(added)* Whether the value-equality bail-out stays the **default** | **open — the operator's** | Not settled, deliberately. HD-028's cost argument was withdrawn: R=0 shell reads 994/992 B unwrapped and 1,099.5/1,097 B wrapped, so the wrapper is what carries the shell across the 1 KB line and the pre-registered fallback (opt-in, HD-006 restored) is live. The page had no row touching this at all while teaching the default across three pages |

### 03 — Events as data (3)

| Row | Verdict | What settled it |
|---|---|---|
| `h/fn`'s spelling | **still open** | — |
| A symmetric allow-default head | **SETTLED** | HD-026 *"Scope, fenced"* answers it outright — there is no `::h/allow-default`, no event-options map, no modifier language, and the rare real-submission form opts out through `h/fn`. The body already taught the escape; the row was restating a ruling as an open question |
| `:prefetch` on `route-link` | **SETTLED**, and harder than the row said | Not merely "declined": **refused at render** with `:rf.error/hicasso-route-link-prefetch-declined` (`front/route_link.cljs/prefetch-declined!`), on `contains?` so `{:prefetch nil}` and `{:prefetch false}` are refused too. Moved into the route-link section with the error id |

### 04 — Controlled inputs (6)

| Row | Verdict | What settled it |
|---|---|---|
| The revision prop's spelling | **still open** | — |
| The buffered / draft-and-commit ladder | **still open** | Post-v0 and undesigned — "what will it look like" is genuinely unanswered |
| The controls kit | **still open** | Same |
| Which props count as controlled | **WRONG QUESTION** | The ground moved under it. It hangs off "HD-010's merge law names `:value` and `:checked`", but HD-023(b) made the owned-literal law **unconditional over every literal key**, so no controlled roster governs the merge any more. The converge's own scope is exact in `front/controlled.cljs` (`convergeable?`: `input`/`textarea`, non-nil `value`, no `defaultValue`, caret type, a change handler) and the body already states it |
| The value path through a live IME composition | **SETTLED** | The row read **"Ruled 2026-08-03, and shipped."** inside a table titled *Not settled yet* — the same defect the sibling found on `::h/value`. HD-019's addendum, and the body already carries the whole thing |
| `:on-input` vs `:on-change` | **still open, reworded** | The *convention* question is genuinely unruled, but the row implied a choice the runtime forces. `front/controlled.cljs/change-slot` takes `onChange` when present and `onInput` otherwise, so both work — moved into the body beside the first example |

### 05 — Interop (7)

| Row | Verdict | What settled it |
|---|---|---|
| `defhost`'s option keys | **SETTLED**, row narrowed | "Not addressed" was false — the page's own examples pass `:callbacks`. `codec/mint-host!` takes `opts` carrying `:callbacks` and nothing else, normalises each key to its canonical slot at mint time, and refuses four things *at the declaration*: an unknown contract, a contract on a structural slot, two spellings of one prop, and a `nil` component. All four are now in the body; the row is replaced by the narrower question that really is open — whether a second option ever arrives |
| The migration codemod | **still open** | Verified unbuilt |
| Reserved `{:ref [id config]}` | **still open** | — |
| Which React version the runtime targets | **still open** | Wording checked and correct — `implementation/package.json` pins `"react": "19.2.0"` |
| The SSR placeholder's shape | **still open** | — |
| Hosted component as a `defview`'s child | **SETTLED** by construction | Children cross as realized hiccup in `rfProps` (`codec/realize-children` → `boundary-element`) and are lowered by whoever renders them, so `vec->element`'s host branch is reached exactly as for any other head. Nothing special-cases it out. One clause in the body |
| Embedding Hicasso inside a React-primary app | **still open** | — |

### 06 — Theming (9)

| Row | Verdict | What settled it |
|---|---|---|
| How the app-db choice reaches `data-theme` | **still open** | Still the largest hole on the page |
| Whether a boundary passing children through preserves element identity | **SETTLED** | Children cross as **hiccup**, not as elements, so `theme-scope` mints a fresh element for `app` on every render and identity is never preserved. The skip is therefore always the comparator's `=`, never a referential short-circuit ahead of it. The row said this was "unmeasured"; it is readable off `boundary-element` |
| Theme attribute per-root or per-document | **still open** | — |
| How a control declares a part | **still open** | — |
| How an app installs a theme | **still open** | — |
| The part-address shape | **still open** | — |
| CSS custom property naming convention | **WRONG QUESTION** | There is nothing here for the record to rule. What you name your own custom properties is your stylesheet's business, and a guide does not owe a ruling on it. Replaced with one clause in Layer 1 saying the `--app-*` prefix is illustrative |
| Where the boot-static part map lives | **still open** | — |
| The controls kit that would ship parts | **still open** | — |

### 07 — Ephemeral state (7)

| Row | Verdict | What settled it |
|---|---|---|
| `defstate`'s shape | **still open** | — |
| Declared app-db `:ui` tier | **still open** | — |
| The controls kit | **still open** | — |
| The overlay top layer | **still open** | — |
| Instance-key convention | **still open** | — |
| Whether presence order can follow a live re-sort | **SETTLED** | The row's own text was the answer — **"No, by design, inherited."** `front/presence/step` keeps surviving keys in `(:order state)` and appends new ones, so first-appearance slots are frozen. Moved into *What presence does not do* |
| Where the mechanics/semantic line falls | **SETTLED** | Also an answer, not a question — **"Judgment, by design."** HD-003 makes it taught-not-policed and the body's second sentence already says exactly that |

### 08 — Testing (7)

| Row | Verdict | What settled it |
|---|---|---|
| Headless render fn's name and signature | **still open, sharpened** | It is not just unnamed, it is **unbuilt** — see the correctness fix below |
| The read resolver's shape | **still open** | — |
| The mounted facade's name and API | **still open, reworded** | The row quoted the record's "act, root lifecycle, residue assertions", and the only facade that exists deliberately does not use `act` (`arm1/mount.cljs`: it flushes, because `act` diverts work to a queue that is not the browser's). Row and body now say so |
| Headless: one boundary or a subtree | **still open** | — |
| How intent vectors are invoked headlessly | **still open** | — |
| The registry / manifest surface | **still open** | — |
| Explain-render tooling | **still open** | — |

## Correctness fixes — what the guide had wrong

Three real defects, all found by reading the source rather than the record.

1. **`06-theming.md`'s Bridge A sample would have thrown.** It wrote

   ```clojure
   (defview theme-scope [{:keys [children]}]
     [:div {:data-theme …} children])      ;; children dropped in whole
   ```

   `(:children props)` is a realized **vector of hiccup forms**, and `as-element` on a vector calls `vec->element`, which would read `[app {}]` as the element head and raise `:rf.error/hicasso-bad-head`. The landed idiom is to splice — `(into [:ul.nested] children)` in `arm1/boundary_crossing_cljs_test`, `(into [:<>] children)` inside `arm1/boundary` and `arm1/presence`. Sample fixed to `into`, and the rule added to `02`'s ABI section, since nothing in the guide had ever stated it and the bug was a direct consequence.

2. **`08-testing.md` taught a door that does not exist.** Its banner claimed the page was "witnessed by the bench arm's tests" while the headless-render section showed `h/render` as though you could call it. There is **no structural render function anywhere in the tree** — `arm1/runtime/render-body` returns a React element, and the `front/*_cljs_test` suites assert pure functions and `codec/as-element` output. The banner now separates the two doors, the block is marked `SKETCH`, and the prose distinguishes the half that is real today (intents assertable by `=`, witnessed in `front/intent_cljs_test`, `front/route_link_cljs_test`, `front/presence_cljs_test`) from the half that is waiting on the door.

3. **A sample I wrote myself, caught before it landed.** My first draft of `02`'s attribute example used `[:input.form-control#title …]`. `codec/re-tag` is `#"([^\s\.#]+)(?:#([^\s\.#]+))?(?:\.([^\s#]+))?"` — **the `#id` must precede the classes**, so that tag fails `re-matches` outright. Fixed to `[:input#title.form-control …]`, and the ordering rule is now stated in the body rather than left as a trap.

Also corrected without being a bug: `02` now names `:rf.error/hicasso-bad-head` for a plain `defn` in head position, and `05`'s `:render` section explains the HD-024 addendum's authoring consequence — a `renderRow` **may** build a row carrying ordinary intents, which fire later into the supplying boundary's frame; what is forbidden is dispatching *while the call is running*. The page's previous "dispatching from inside it is an error" was true but invited exactly the wrong inference, and a render prop producing a non-interactive row is most of what render props are not for.

## Completeness — what I judged missing

I walked the surface an ordinary app needs (mount/unmount, views, reads, attributes, events, controlled inputs, lists and keys, conditionals, interop, styling, ephemeral state, links, testing, failure) and found two things the guide did not teach.

**Added — the attribute grammar, into `02`.** A reader could not write `[:div#id.card {:style {:margin-top 8} :class [...]}]` from this guide: nothing stated the kebab→camel conversion, the `:aria-*`/`:data-*` passthrough, the three React renames, `:style` as a nested map, `:class` accepting collections, the `#id`-before-`.class` ordering, or that `:key` is not an attribute. All verified against `codec/prop-name`, `codec/react-renames`, `codec/dont-camel-case`, `codec/class-names`, `codec/fold-shorthand!`, `codec/convert-prop-value`, `codec/re-tag`. It went into `02` rather than its own page because it serves that page's job, and a standalone page would be the catalogue `AUTHORING.md` tells you to push to an API reference.

**Added — one new page, `09-when-a-view-throws.md`.** `h/boundary` is a landed, witnessed surface (HD-020(c), `arm1/boundary.cljs`, `arm1/lifecycle_dom_cljs_test`, `arm1/boundary_intent_dom_cljs_test`) that appeared in the guide only as one bullet in the testing page's list of reasons to mount-test. An app whose first uncaught render throw blanks the page has a gap the guide caused. The page teaches the three keys and their exact shapes, the retry-is-yours contract, that `:on-error` fires once even under StrictMode, that intents work inside a fallback and why, what React boundaries do **not** catch, where to place them, and the nesting caution that a throwing fallback is caught by the next boundary up. Everything verified against `arm1/boundary.cljs`'s constructor, `getDerivedStateFromError`, `componentDidCatch`, `componentDidUpdate` and `render`.

**Deliberately left out.** Portals and the overlay top layer (post-v0, nothing landed). SSR (out of v0 by HD-020(d)). A routing page (`route-link` is one form and belongs with the other event attributes, where it already is). Any Hicasso API reference — there is no public artefact to reference, and inventing one would be the second home `AUTHORING.md` forbids. Explain-render / manifests (post-v0). Suspense and transitions: React surfaces the record says nothing about, and I will not teach what I have not verified.

## `AUTHORING.md` audit

| Section | Finding |
|---|---|
| **Non-negotiables 1 — one job, one mode** | Conformed. Every page states its job in the README table and opens with the reader's problem. `02`'s job widened to include attributes (README updated); the error boundary got its own page rather than being wedged into `02` or `08`, which is this rule applied rather than ignored |
| **2 — standalone corpus, no `spec/` links** | Conformed, verified: **zero** `spec/` links in the subtree |
| **3 — true snippets** | **Changed.** Three defects fixed (above). Every taught symbol re-verified: `reg-event`/`reg-sub` handler arities against `examples/capabilities/resources/**`, `subscribe-once` against `core.cljc`, the `nil`-return no-op against `events.cljc:1129`, `h/presence` as a vector head against `arm1/presence`, every `:rf.error/*` id against its `fail!` site |
| **4 — reader-first order** | Conformed. No page opens with internals; `09` opens with the blank page a user sees |
| **5 — no navigation ceremony** | Conformed. No "What's next" footers, no `## Start here`, no mini-TOCs. The README table is the only nav and there is no site nav for it to duplicate |
| **Voice** | **Changed.** Removed the one flagged status phrase ("each one is load-bearing" → "dropping any one of them breaks something specific") and two decorative uses of "seam" in `05` → "at this edge", the page's own term. Kept "link seam" in `03`: HD-027 uses it as a term of art. New prose written in full sentences, no dash-chained fragments |
| **What a concept page must carry** | Conformed. All nine pages carry problem open / unlabelled required path / `## Troubleshooting` / `## When not …`. No page needed `## Advanced` |
| **Don't label the required path** | Conformed — no "Basics", "Day one", "Essential" anywhere |
| **Standard headings** | Conformed — `## Troubleshooting` on all nine; no "When things go wrong", no "Going further", no `## Start here` |
| **Progressive pacing** | Conformed. Troubleshooting is a table on every page, recovery in the same row |
| **Slim model vs catalogue** | Applied as the counterweight. It is why the attribute grammar is five rules in `02` rather than a ninth page reproducing `codec/convert-props`, and why `09` stops at three keys and says outright that classification, retry policy and logging are the application's |
| **Structure of the corpus / technique owners** | Checked for a second home. `01` defers boot and `:initial-events` to `core/how-to/boot-and-mount-an-app.md` rather than re-teaching them; `01` points at `core/views.md` for adapters. Hicasso's hiccup and view composition differ mechanically from `core/hiccup.md` and `core/views.md` (boundary-vs-inline, keys in props, reserved heads, `:&`), so they are its own notation, not a second telling of the same one. `09` teaches only the view-layer boundary and explicitly hands event-handler failures back to the event pipeline, which owns them |
| **Live cells and demo shapes** | Cannot apply — the subtree is excluded from the site, so there is no playground runtime; cells would render as dead fences |
| **Callouts and takeaways** | Admonition syntax cannot apply for the same reason, and the README already records why banners are blockquotes. The budget rule does apply and is met: one banner per page, no stacks |
| **Reference** | n/a — no Hicasso glossary or API reference exists to route to |
| **Honesty** | **Changed.** Removed the one bead id in prose (`05`'s banner). Deferred surfaces marked throughout. `08`'s overclaim fixed. The README's K5 paragraph was false and is rewritten |
| **What CI enforces** | `check_doc_slugs.py` green. `mkdocs build --strict` does not reach this subtree and is not claimed as evidence |

## The README's K5 paragraph

Rewritten, since the operator removed K5 on 2026-08-04 and the paragraph asserted it as a live kill criterion. It now records that the eight-page shape came from a budget that no longer exists, that the count is editorial judgement, and that the pressure to stay short outlived the number. `validation.md`, `decisions.md` and the two `.cljs` comments are another worker's and untouched.

## Recommendation on the guide's shape, not acted on

You asked whether the eight were the right eight now the cap is gone. My reading: **the shape is close to right and I would not restructure it in this PR.** Two things I would consider separately, as judgement calls rather than gaps:

- **`02` is now doing two jobs** — boundaries and re-render granularity, and the hiccup/attribute notation. It reads fine because the second follows the first naturally, but by `AUTHORING.md`'s own "if a page can't state its one job, it's two pages" it is the one page that would split. The published corpus splits exactly here (`core/hiccup.md` vs `core/views.md`). I did not split it because renumbering breaks `decisions.md:690`, which I may not edit; a split wants that link updated in the same change.
- **`05-interop.md` is the longest page by a distance** (426 lines) and about half of it — imperative SDKs, callback refs, StrictMode, the React 18 fallback shape, the reserved `:ref` vector — is host-edge React rather than the interop door. That half is `## Advanced` material by `AUTHORING.md`'s definition, or its own page.

Neither is a coverage gap and neither strands a reader today.

## Confirmations

- **No `[unfrozen]` marker removed**, counted rather than asserted: `origin/main` carried **22** across the nine files, and the eight original pages plus the README still carry **21** — the missing one is `h/boundary`'s, which moved with its topic to the new page. `09` carries **4**, for **25** in total. (The count caught a regression of my own: rewriting `08`'s sketch block dropped the marker off `h/render`. Restored before this PR opened.)
- **Nothing touching HD-028 settled.** The one row I *added* records its disposition as an open operator ruling, with both shell figures, and the body says what is landed and what is in front of the operator.
- **No bead filed.** I found nothing wrong in the code — every discrepancy was the guide's.
- **Surface**: `docs/design/hicasso/draft-guide/**` only. No overlap with `clock_run.cjs`, the bench aggregate, `b7_run.cjs` or `reads_ladder_run.cjs`.
- **Already correct, left alone**: the React 19.2 pin row, the `::h/prevent` grammar, the `on-` shape rule (`codec`/`intent`'s `#"^on-[a-z]|^on[A-Z]"`), the top-level-only marker substitution, the key map's dual composition signals, `h/presence` as a vector head, every census number, and `04`'s whole IME body — all verified and all already true.
