### PR TITLE
fix(bench): the clock driver must name the error it caught (rf2-029ed)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/chrome_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/chrome_app.cljs
@@ -288,13 +288,14 @@
   (rf/init! uix-adapter/adapter)
   (lane/leave-act-environment!)
   (set! (.-HCHROME js/window)
+        (lane/legible-doors
         #js {"mountArm"      mountArm
              "runOp"         runOp
              "releaseArm"    releaseArm
              "residue"       residue
              "resetRuntime"  resetRuntime
              "runtimeLabel"  runtimeLabel
-             "cardsN"        cardsN})
+             "cardsN"        cardsN}))
   (lane/record! "ready" {:arms (mapv (fn [[k v]] {:id k :why (:why v)}) arms)
                          :cards cards-n
                          :runtime (lane/runtime-label)})

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_app.cljs
@@ -139,6 +139,38 @@
 (defn- next-gen! [] (:gen (swap! state update :gen inc)))
 (defn- next-op! [] (:op (swap! state update :op inc)))
 
+(def ^:private clock-images
+  "THE FRAME'S IMAGES, and the reason this row cannot use the default one.
+
+  `[:sub :p0/cell]` is registered TWICE in this bundle, at load, from two
+  namespaces: `p0-reagent-views/register!` — the shared floor accessor
+  every other row's arms read — and `clock-views/register-subs!`, which
+  registers the SAME computation (`v/cell-value`, so there is still one
+  body) behind the recompute census the keystroke witness gates on.
+
+  A second `reg-sub` from a second namespace does not OVERWRITE the first;
+  the registrar keeps both, tagged with their source provenance, and
+  default image assembly then refuses to let selection order decide which
+  one the frame runs — `:rf.error/image-duplicate-id`, and correctly so.
+  That refusal is what stopped this driver dead in round 0 on every row
+  (rf2-029ed), and it stopped it at `enter-segment!`, before any sample.
+
+  So the override is made DELIBERATE, through the mechanism the refusal
+  itself names: two composed images, the census-instrumented registration
+  in the LATER one, which wins and whose shadow is reported. The resulting
+  registry is exactly the one `register-subs!`'s docstring already
+  describes — `enter-segment!` calls it on every segment entry, for every
+  row, so the census-bearing body was always the intended survivor.
+
+  The two images UNION to the whole store, so nothing is dropped: the
+  first selects every namespace except the witness's, the second selects
+  the witness's alone."
+  [(rf/image {:id :clock/lane
+              :select-ns {:include ["**"]
+                          :exclude ["re-frame.bench.hicasso.clock-views"]}})
+   (rf/image {:id :clock/witness
+              :select-ns {:include ["re-frame.bench.hicasso.clock-views"]}})])
+
 (defn enter-segment!
   "Tear down whatever adapter is installed, install this segment's,
   re-register the sub graph and stand the frame back up seeded.
@@ -167,7 +199,7 @@
     ;; the indexed `:p0/draft`, both behind the recompute census the
     ;; keystroke witness gates on.
     (kv/register-subs!)
-    (rf/make-frame {:id v/subs-frame})
+    (rf/make-frame {:id v/subs-frame :images clock-images})
     (frame/replace-app-db! v/subs-frame (v/seed-cells v/cells-n 0))
     (lane/leave-act-environment!)
     (swap! state assoc :segment seg-id :cells (zeros v/cells-n))
@@ -904,6 +936,7 @@
   (lane/leave-act-environment!)
   (swap! state assoc :tally (lane/tally))
   (set! (.-HCLOCK js/window)
+        (lane/legible-doors
         #js {:rows     (clj->js (mapv (fn [[k m]] {:id (name k) :why (:why m)}) rows))
              :segments (clj->js (mapv (fn [s] {:id (name (:id s)) :name (:name s)}) segments))
              :cellsN    v/cells-n
@@ -947,7 +980,7 @@
              ;; sub-cache, `runtime/residue` counts the candidate's own
              ;; cells, edges and cached entries.
              :residue       (fn [] (pr-str {:lane (lane/residue v/subs-frame)
-                                            :arm1 (hrt/residue)}))})
+                                            :arm1 (hrt/residue)}))}))
   (set! (.-HCLOCK_READY js/window) true)
   (js/console.log ";; HCLOCK ready")
   nil)

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -773,7 +773,12 @@ const EVENT_TIMING_INIT = `
 // One row
 // ---------------------------------------------------------------------------
 
-async function runRow(browser, rowId) {
+// `trace` is the caller's `{step}` box, and it exists because THE SEGMENT
+// ORDER ROTATES WITH THE ROUND: a bare `M1: <error>` does not say which
+// segment was on the page when it threw, so it does not say whether the
+// candidate failed or a donor did (rf2-029ed). Written at each point the
+// row moves, read only if the row dies.
+async function runRow(browser, rowId, trace) {
   // A FRESH PAGE per row, not a fresh navigation in the same one: this
   // lane's recorded fault is a page that gets slower the longer it runs,
   // and a reused page carries whatever caused that across the row boundary.
@@ -884,6 +889,7 @@ async function runRow(browser, rowId) {
     const perSegLayout = {};
 
     for (const seg of segOrder) {
+      trace.step = `round ${round}, segment ${seg}`;
       await page.evaluate((s) => window.HCLOCK.enterSegment(s), seg);
       const plan = await page.evaluate(([r, s]) => window.HCLOCK.plan(r, s), [rowId, seg]);
       const armIds = plan.map((a) => a.id);
@@ -919,6 +925,7 @@ async function runRow(browser, rowId) {
       for (let s = 0; s < WARMUP + SAMPLES; s++) {
         for (const j of guard.schedule(armIds.length, s)) {
           const armId = armIds[j];
+          trace.step = `round ${round}, segment ${seg}, sample ${s}, arm ${armId}`;
           let inPageMs = NaN;
           let ok = true;
 
@@ -1827,11 +1834,12 @@ function report(out) {
   try {
     for (const rowId of ROWS) {
       console.error(`[clock] row ${rowId}`);
+      const trace = { step: null };
       try {
-        const out = await runRow(browser, rowId);
+        const out = await runRow(browser, rowId, trace);
         outcomes.push({ out, verdict: report(out) });
       } catch (e) {
-        died = `${rowId}: ${e.message}`;
+        died = `${rowId}${trace.step ? ` at ${trace.step}` : ''}: ${e.message}`;
         break;
       }
     }

--- a/implementation/freehand/test/re_frame/bench/hicasso/hd8_clock_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/hd8_clock_app.cljs
@@ -255,6 +255,7 @@
                       "canFail"  (boolean can-fail?)
                       "problems" (mapv pr-str problems)})))
     (set! (.-HD8CLOCK js/window)
+          (lane/legible-doors
           #js {:adapter       (name which)
                :plan          (fn [row]
                                 (clj->js (mapv (fn [a] {:id      (name (:id a))
@@ -269,7 +270,7 @@
                :tally         (fn [] (clj->js (lane/tally-value (:tally @state))))
                :teardownCheck (fn [] (clj->js (mapv :where (lane/drain-teardown-failures!))))
                :runtime       (fn [] (pr-str (lane/runtime-label)))
-               :residue       (fn [] (pr-str (lane/residue (rows/frame-of :floor))))})
+               :residue       (fn [] (pr-str (lane/residue (rows/frame-of :floor))))}))
     (set! (.-HD8CLOCK_READY js/window) true)
     (js/console.log ";; HD8CLOCK ready")
     nil))

--- a/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/lane.cljs
@@ -916,6 +916,70 @@
      v)))
 
 ;; ---------------------------------------------------------------------------
+;; The `page.evaluate` boundary
+;; ---------------------------------------------------------------------------
+;;
+;; Playwright carries plain data and plain `js/Error`s back out of
+;; `page.evaluate`. A CLJS `ex-info` is neither, so what the driver was
+;; handed for an arm's own `fail!` was the MINIFIED TYPE NAME of the thing
+;; that was caught:
+;;
+;;     [clock] FAILED: M1: page.evaluate: vj
+;;
+;; `vj` is `cljs.core/ExceptionInfo` under `:advanced`. The `:rf.error/id`,
+;; the message, the `:where` and the whole ex-data map — every field the
+;; thrower wrote precisely so the reader would know what broke — were
+;; destroyed at the boundary (rf2-029ed). An instrument that reports on
+;; itself instead of on its subject cannot be debugged by anyone.
+;;
+;; The repair belongs HERE, on the page side, because this is the last
+;; place `ex-message` and `ex-data` are still in vocabulary. Every front
+;; door goes through [[legible-doors]] once, at construction, and any
+;; throw leaves as an ordinary `js/Error` whose message names the door,
+;; the id and the data. Nothing is special-cased to a particular id: what
+;; the arm threw is what the driver prints.
+
+(def ^:private ^:const ex-data-cap
+  "How much of an ex-data map crosses the boundary. A payload can carry a
+  DOM node or a whole app-db, and a report that is itself unreadable is
+  the defect this repairs."
+  2000)
+
+(defn describe-throw
+  "One line a driver can act on, for anything a front door can throw."
+  [door e]
+  (try
+    (let [d (ex-data e)]
+      (if (some? d)
+        (let [s (pr-str d)]
+          (str door " threw " (or (:rf.error/id d) "an ex-info with no :rf.error/id")
+               " — " (ex-message e)
+               " — ex-data " (if (> (count s) ex-data-cap)
+                               (str (subs s 0 ex-data-cap) " …(truncated)")
+                               s)))
+        (str door " threw " (or (ex-message e) (str e)))))
+    (catch :default e2
+      ;; The reporter must not become the fault. Whatever defeated the
+      ;; printer, the driver still gets the door and a reason.
+      (str door " threw something whose description itself failed: " (.-message e2)))))
+
+(defn legible-doors
+  "Wrap every function on a front-door `#js {}` so an `ex-info` reaching
+  `page.evaluate` arrives as a plain `js/Error` that names the fault.
+  Returns the same object, mutated in place."
+  [^js door-obj]
+  (doseq [k (js/Object.keys door-obj)]
+    (let [f (aget door-obj k)]
+      (when (fn? f)
+        (aset door-obj k
+              (fn [& args]
+                (try
+                  (apply f args)
+                  (catch :default e
+                    (throw (js/Error. (describe-throw k e))))))))))
+  door-obj)
+
+;; ---------------------------------------------------------------------------
 ;; Publication
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_app.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/census_clock_app.cljs
@@ -186,6 +186,7 @@
                       "canFail"  (boolean can-fail?)
                       "problems" (mapv pr-str problems)})))
     (set! (.-C56CLOCK js/window)
+          (lane/legible-doors
           #js {:adapter       (name which)
                :plan          (fn [row]
                                 (clj->js (mapv (fn [a] {:id      (name (:id a))
@@ -202,7 +203,7 @@
                :tally         (fn [] (clj->js (lane/tally-value (:tally @state))))
                :teardownCheck (fn [] (clj->js (mapv :where (lane/drain-teardown-failures!))))
                :runtime       (fn [] (pr-str (lane/runtime-label)))
-               :residue       (fn [] (pr-str (lane/residue (arms/frame-of :feed :hicasso))))})
+               :residue       (fn [] (pr-str (lane/residue (arms/frame-of :feed :hicasso))))}))
     (set! (.-C56CLOCK_READY js/window) true)
     (js/console.log ";; C56CLOCK ready")
     nil))


### PR DESCRIPTION
`clock_run.cjs` died in round 0 of **every** row with

    [clock] FAILED: M1: page.evaluate: vj

`vj` is `cljs.core/ExceptionInfo` under `:advanced`. The page threw a CLJS
ex-info carrying an `:rf.error/id`, a `:where`, a `:recovery` and a full
ex-data map, and the boundary reported the minified **type name** of what it
caught and discarded everything else. A driver that cannot say *which* error
fired cannot be debugged by anyone.

## Stage 1 — make the failure legible

`lane.cljs` gains `legible-doors` / `describe-throw`. A front door's functions
are wrapped **once, at construction, on the page side** — the last place
`ex-message` and `ex-data` are still in vocabulary — and any throw leaves as a
plain `js/Error` naming the door, the id and the data. Nothing is special-cased
to a particular id.

The same line now reads:

    [clock] FAILED: M1 at round 0, segment reagent-subs: page.evaluate: Error:
    enterSegment threw :rf.error/image-duplicate-id — rf/image assembly: id
    [:sub :p0/cell] is selected from 2 distinct source namespaces with different
    implementations within image nil … — ex-data {:rf.error/id
    :rf.error/image-duplicate-id, :where rf/make-frame, :recovery
    :narrow-the-selection-or-rename-the-id, :reason "…", :image nil, :kind :sub,
    :id :p0/cell, :colliding-coordinates [{:ns "…p0-reagent-views"}
    {:ns "…clock-views"}]}

`clock_run.cjs` also carries a `trace.step`, because **the segment order rotates
with the round**: a bare row id did not say whether a donor or the candidate
threw. It now names the round and segment (and, inside the sample loop, the
sample and arm).

### Mutation proof, both directions

A known `ex-info` with a distinctive id was thrown from inside the first
`page.evaluate`:

* **mutated** — `enterSegment threw :rf.error/mutation-probe-029ed — MUTATION
  PROBE rf2-029ed — ex-data {:rf.error/id :rf.error/mutation-probe-029ed,
  :where probe/enterSegment, :canary 4242, :seg "reagent-subs"}`. The id, the
  message and every ex-data key including the `:canary` crossed the boundary.
* **reverted** — byte-identically; `git diff origin/main...HEAD` on
  `clock_app.cljs` shows only the `legible-doors` wrapping and the images, and
  `git grep mutation-probe-029ed` is empty.

A first attempt at the probe was **refused by the lane's own build door** for
`unreachable code` — that door working exactly as designed.

### The real count of front doors that swallowed ex-infos: 4

Every lane front door that exposes arm entry points had the identical
`#js {…}` shape, so each is a one-line change against the shared helper:
`HCLOCK` (clock_app), `HD8CLOCK` (hd8_clock_app), `C56CLOCK`
(shapes/census_clock_app) and `HCHROME` (chrome_app). All four are fixed here.

`window.RETENTION` (retention_probe.cljs) is **not** in this class and is left
alone: it does not require `lane`, and its single door is a heap census that
runs no arm code.

## Stage 2 — the actual fault

`[:sub :p0/cell]` is registered **at load from two namespaces** in this bundle:
`p0-reagent-views/register!` (the shared floor accessor every other row's arms
read) and `clock-views/register-subs!` (the same computation — `v/cell-value`,
so there is one body — behind the keystroke witness's recompute census).

A second `reg-sub` from a second namespace does **not** overwrite the first. The
registrar keeps both, tagged with their source provenance, and default image
assembly refuses to let selection order decide which one the frame runs. The
refusal is correct; it fired in `enter-segment!`, before any sample, on every
row. Introduced by `bacb5dc4db` (rf2-0qj9w, 2026-08-03), which added the second
registration.

The override is now **deliberate**, through the mechanism the refusal itself
names: two composed images unioning to the whole store, the census-bearing
registration in the **later** one. That reproduces exactly the registry
`register-subs!`'s own docstring already describes — `enter-segment!` calls it
on every segment entry, for every row, so the census-bearing body was always
the intended survivor.

**Confirmed by the harness's own witness, not by argument.** The keystroke row's
recompute census now reads `p0/cell x100, p0/draft x4` on all three substrate
arms and *no subscriptions at all* on every floor arm — validation.md's stated
104 layer-1 recomputes. That shape is only reachable if the census-instrumented
registration is the one the Reagent and UIx arms run, which is what the
composition makes true.

## No measurement was taken

No timing row was published or amended, and no figure is quoted anywhere in this
PR. The two live runs were 1-round designs run **to verify the driver runs**;
both exited 2 on the arm-order guard, which is the instrument correctly refusing
to report a statistically meaningless design.

## Quality gates

| gate | exit |
|---|---|
| `sh scripts/test-fast-pr.sh` | **0** (`PASS fast PR spine`) |
| `npm run lint:js` (repo root) | **0** |
| `npm run test:hicasso-compile` | **0** |
| `node …/clock_run.cjs --selftest` | **0** |

Rebased onto `23cc208f20` after the spine ran; both incoming commits are
documentation-only (a studio markdown file and one docstring string in
`arm1/runtime.cljs`), and `test:hicasso-compile` + `--selftest` were re-run on
the final rebased tree, both exit 0.

* `lint:js` — 0 errors; the 3 remaining warnings are pre-existing
  `Unused eslint-disable directive` in `adoption_witness_run.cjs`, a file this PR
  does not touch. (A first run reported 587 errors, all from
  `implementation/.shadow-cljs/**/externs.shadow.js` — a gitignored build
  artefact left by the local `:advanced` builds, absent in CI; exit 0 after
  clearing it.)
* `test:hicasso-compile` — all **101** lane namespaces compiled, zero warnings,
  which is what covers the three sibling front doors.
* `clock_run.cjs --selftest` — ALL ADJUDICATORS OK (11 three-point control +
  20 keystroke witness + 12 arm-order + 17 seam).
