### PR TITLE
docs(hicasso): K5 is removed as a kill criterion (operator ruling 2026-08-04)

### DIFF
--- a/docs/design/hicasso/charter.md
+++ b/docs/design/hicasso/charter.md
@@ -106,6 +106,12 @@ canonical.
    perf gate**: the dogfood screen and five-shape ports judged on their diff;
    public-door-only witness tests; more than ~8 public concepts or ~8 guide pages
    to ship CRUD is a kill signal.
+   **Amended 2026-08-04 (operator ruling):** that last clause is the criterion
+   [validation.md](validation.md) carried as **K5**, and K5 was removed. The
+   sentence above stands as the record of what this charter pre-registered.
+   Consumer code from day one, the diff judgement and the public-door-only
+   witness tests are unchanged — only the ergonomics *kill* is gone, and nothing
+   replaces it.
 5. **Keep what's differentiating**: intent-as-data; the controlled door;
    browserless testing; demand-driven reads; zero-cost-when-absent tooling; the
    queryable registry; AI ergonomics throughout.

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -640,6 +640,12 @@ replacement**, because the unsolved problem the review found is
 a census-real screen rather than argued; where the diff did not come out better,
 the record says so.
 
+**K5 was removed as a kill criterion by operator ruling on 2026-08-04**
+([validation.md](validation.md)). The rationales that cite it — this paragraph,
+HD-023, HD-024, HD-025 and HD-026 — were written while it stood and are left
+exactly as argued: they record why each shape was chosen at the time, and the
+deletions they justify are shipped. Read every "against K5" below as historical.
+
 ## HD-022 — `:ref`'s vector value-space is reserved now, and refused loudly in v0
 
 **Ruling.** `:ref` accepts **a function** — HD-003's escape hatch and HD-016's
@@ -1094,8 +1100,9 @@ intent it decorates, and cannot travel with it); and requiring `h/fn` for the
 recurring click case (discards the data benefit exactly where a one-head wrapper
 preserves it).
 
-**Cost, stated.** One reserved head and one extra pair of brackets. Against K5 it
-is a swap rather than a growth: the metadata *mechanism* is deleted — one fewer
+**Cost, stated.** One reserved head and one extra pair of brackets. Against K5 —
+since removed ([validation.md](validation.md), 2026-08-04) — it is a swap rather
+than a growth: the metadata *mechanism* is deleted — one fewer
 kind of place for behaviour to hide — and one member joins a roster that is a
 list rather than a convention. The event-time path acquires nothing: the
 classification is one `=` against the head, taken once per lowered position per

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -545,11 +545,24 @@ comparison this section schedules was originally written as
 | K2 | Bulk (≥ ~100 boundaries, one commit) > 1.5× Reagent view work after those iterations |
 | K3 | Per-boundary heap worse than Reagent with no paper path to the floor |
 | K4 | Controlled text fails same-tick echo / IME on Chromium and WebKit for a simple form |
-| K5 | > ~8 public concepts or > ~8 guide pages to ship CRUD |
 | K6 | A compiler/analyzer/dual mode is required to meet K1–K3 |
 | K7 | Six weeks (HD-014) with no path that is both preferable and ≤ Reagent on K1–K2 |
 
 Red gates shrink scope; they never expand features.
+
+**K5 was removed as an operative kill criterion — operator ruling, 2026-08-04.**
+Its row read, verbatim: `> ~8 public concepts or > ~8 guide pages to ship CRUD`.
+It was the ergonomics kill — the one criterion that could stop the programme for
+costing too many concepts or too much guide — and it no longer bites. **No
+criterion replaces it.** **K6 and K7 keep their identifiers**: the row is gone
+and nothing is renumbered, so every citation of K6 or K7 elsewhere in the tree
+still resolves.
+
+K5 is still argued *from* in several places — the HD-022 … HD-026 rationales in
+[decisions.md](decisions.md), item 4 of [charter.md](charter.md), and two
+comments in the Wave-1 bench sources. Those are historical: they record why a
+shape was chosen while the criterion stood. They are left intact, and they are
+read against this note.
 
 ## Timing (HD-015)
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -125,7 +125,9 @@
 
   Both are attribute *keys*, not forms — so the merge survives into a
   structural test and into tooling, and neither adds a public concept in
-  the K5 sense.
+  the K5 sense. (K5 — the ergonomics kill criterion — was removed by
+  operator ruling on 2026-08-04; this records the reason the shape was
+  chosen, not a live gate.)
 
   ## One canonical slot, and every rule asks it
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/presence.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/presence.cljs
@@ -43,7 +43,9 @@
   headless test can supply it with no clock.
 
   The consequence worth recording: `presence-phase` has no Hicasso
-  equivalent. One fewer public concept against K5.
+  equivalent. One fewer public concept against K5. (K5 — the ergonomics
+  kill criterion — was removed by operator ruling on 2026-08-04; this
+  records the reason the shape was chosen, not a live gate.)
 
   ## Why the predecessor's rejection does not apply
 


### PR DESCRIPTION
Operator ruling, 2026-08-04: K5 is removed as a kill criterion. This executes
that ruling and leaves the record legible.

**What removing a kill criterion means here.** K5 was the *ergonomics* kill —
K1/K2/K3 price performance, K4 prices controlled-text correctness, K6 fences the
compiler/analyzer, K7 is the six-week clock, and K5 was the only one that could
stop the programme for costing too many public concepts or too much guide. After
this change the programme can no longer be killed on concept count or guide
length; every other way it can die is unchanged. Nothing replaces it, and the
identifiers are deliberately not renumbered.

## What changed

**The table row is gone; the criterion is not erased.** `validation.md`'s
kill-criteria table now runs K1–K4, K6, K7. Immediately below the table's
standing rule ("Red gates shrink scope; they never expand features") a dated note
records that K5 was removed by operator ruling on 2026-08-04, quotes the row
verbatim (`> ~8 public concepts or > ~8 guide pages to ship CRUD`), states that
no criterion replaces it, states that K6 and K7 keep their identifiers so every
citation of them still resolves, and points at the places K5 is still argued
*from* — so a reader landing on one of those arguments can tell the criterion has
since been removed. That note is the anchor for every other site.

**K6 and K7 were NOT renumbered.** They are cited by name across the tree; the
row was deleted and nothing shifted.

**No replacement criterion was added.**

## The citation count — verified, and one the brief's grep could not find

The brief listed nine `K5` sites from a grep over `*.md`, `*.clj*` and `*.cjs`.
I re-grepped the **whole tracked tree** with no filetype filter. The nine are
right, and the real number of sites carrying K5's content is **ten**:

| Site | Treatment |
|---|---|
| `validation.md:548` | the criterion — row removed, dated note added |
| `decisions.md:639` | historical — left intact, block note added after it |
| `decisions.md:751` (HD-023) | historical — untouched |
| `decisions.md:902` (HD-024) | historical — untouched |
| `decisions.md:949` (HD-025) | historical — untouched |
| `decisions.md:1097` (HD-026) | historical — argument intact, four-word aside |
| `front/codec.cljs:128` | historical — comment intact, one clause appended |
| `front/presence.cljs:46` | historical — comment intact, one clause appended |
| `draft-guide/README.md:28` | **not mine** — untouched (owned by `guidedone-2rtt6-64b`) |
| **`charter.md:107`** | **found by this PR** — see below |

**`charter.md` item 4 is the tenth, and a grep for `K5` cannot find it.** It
restates the criterion inline without ever naming it: *"…more than ~8 public
concepts or ~8 guide pages to ship CRUD is a kill signal."* That was the one
remaining **operative** statement of the gate anywhere in the tree. It is
superseded in place — the sentence is kept verbatim as the record of what the
charter pre-registered, followed by a dated amendment noting that this clause is
K5 and K5 was removed, and that consumer-code-from-day-one, the diff judgement
and the public-door-only witness tests are unchanged; only the *kill* is gone.

**The five `decisions.md` rationales are historical arguments and are left as
argued.** Not one of the sentences that reasons from K5 was rewritten, and no
decision they support was touched — HD-022 … HD-026 stand exactly as ruled, and
the deletions they justify are shipped. Discoverability is added with the
lightest touch that works: `decisions.md:639` is the shared preamble that
introduces K5 and frames the whole HD-022 … HD-025 block ("the unsolved problem
the review found is K5"), so one dated note there covers four of the five sites;
HD-026 sits ~450 lines later under its own heading outside that framing, so it
gets a four-word parenthetical aside (`Against K5 — since removed
(validation.md, 2026-08-04) — it is a swap…`) that leaves the argument's grammar
and content wholly intact.

**The two source comments are likewise historical, and neither was gutted.** Each
keeps its full design explanation and gains one parallel clause: *"(K5 — the
ergonomics kill criterion — was removed by operator ruling on 2026-08-04; this
records the reason the shape was chosen, not a live gate.)"* A reader in source
has no path to `validation.md`'s note otherwise. **Both edits are inside the `ns`
docstring** (`codec.cljs` docstring runs to line 149's `(:require`;
`presence.cljs`'s to line 86) — `git diff -- '*.cljs'` shows two hunks, both pure
prose, **no line of code altered**.

## Deliberately not changed

- **`docs/design/hicasso/draft-guide/**` — untouched.** `git status --porcelain
  -- docs/design/hicasso/draft-guide/` is empty. Owned by `guidedone-2rtt6-64b`.
- **`validation.md:549`, `:550` and `EP-0038:57`** cite the ranges `K1–K3`,
  `K1–K2` and `kill criteria K1–K7`. Because nothing is renumbered, `K1–K7`
  remains an accurate span of the identifiers, and the two narrow ranges never
  included K5. Left alone rather than churned. Flagged here for the record.
- **`authoring.md:332`** ("v0 ships nothing here; the concept budget arbitrates")
  is the nearest thing to a dangling paraphrase — the only "concept budget" in
  the tree was K5. Left as-is: it reads as ordinary prose about parsimony, which
  survives the *gate's* removal as a design preference, and rewriting it would
  mean inventing what replaces K5 — which the ruling explicitly does not do.
- **`witnesses_cljs_test.cljs:36`** asserts `(every? (w/gates) [:K1 :K2 :K3 :K4])`
  — K5 was never a gate the witness set fed, and `:K5` appears nowhere in the
  tree. No test needed changing.
- False positives excluded from the count: three `sha512-…K5…` substrings in
  lockfiles, 17 binary PNGs, and `check_skill_migration_contract_drift.py:2780`
  (a `"K5 owner…"` label in the unrelated skill-migration K-table).

## Table integrity — hand-verified

Nothing in the toolchain validates markdown tables, and this PR edits one.
Checked by hand, row by row: the kill-criteria table is **2 columns** (`| # |
Kill if |`) with **6 body rows** after the removal (K1, K2, K3, K4, K6, K7), each
row 3 pipes / 2 columns. Swept **all 8 tables in `validation.md`** the same way:
2, 4, 3, 4, 3, 4, 4 and 2 columns respectively, **0 mismatches** between any body
row and its header.

**Anchors.** No heading was added, removed or reworded in any of the three docs —
`diff` of the heading lines against `origin/main` is empty for `validation.md`,
`decisions.md` and `charter.md` — so all **10 inbound anchor links** into them
still resolve. The 5 outbound links this PR adds are deliberately **anchorless
file links** to sibling files that exist, which sidesteps the GitHub-vs-
python-markdown hyphen-run slug divergence entirely.

## Quality gates

Each run foreground to completion from this worktree
(`C:/Users/miket/code/re-frame2-worktrees/k5retire`), by absolute path, never
piped:

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine`, 0 `FAIL` lines |
| `npm run test:hicasso-compile` | **0** — 101 lane namespaces, **0 warnings** |

The spine printed `gate root: /c/Users/miket/code/re-frame2-worktrees/k5retire`
— this worktree, not another live worker's. It classified `docs=true jvm=true
node=true`, ran `implementation/core` + `implementation/freehand` JVM suites, the
CLJS node integration and per-ns isolation lanes, and `mkdocs --strict` (resolved
as `python -m mkdocs`). `NOT RUN by this spine (2)`: the JVM artefact suites this
diff did not touch, and the browser/bundle/adapter/Xray/MCP/tool-JVM gates that
are CI-only.

**`mkdocs build --strict` is not the gate for this edit and is not offered as
one.** `mkdocs.yml`'s `exclude_docs` drops `design/hicasso/`, so it exits 0
having verified nothing here; it ran only as part of the spine.
`scripts/check_doc_slugs.py` is the gate that actually validates this tree's link
targets and heading anchors, and the hand-verification above covers the tables it
does not check.
