### PR TITLE
bench(hicasso): where the P2 null sits after the slim walk fixes

### DIFF
--- a/docs/design/hicasso/studio/our-walk-against-reagents.md
+++ b/docs/design/hicasso/studio/our-walk-against-reagents.md
@@ -125,6 +125,13 @@ samples and the guard passed on both partitions.
   buried.
 - **After the two cheapenings, we read below stock Reagent** — 0.9636×.
 
+> **Two of these bullets no longer describe `main`, and the rows above are left
+> exactly as taken.** `reagent-slim` has since been fixed twice against this very
+> instrument, so `slim/reagent` **1.90× / 1.73×** and the **0.56×** that follows
+> from it are figures about a donor the programme has since repaired; and the
+> codec has itself moved on. Both are re-taken in one process on current `main`
+> in [the 2026-08-04 re-take](#2026-08-04-re-take-of-the-arms-on-current-main).
+
 ## 3. The stages — absolute ns, because a ratio cannot be read against a frame
 
 The bead requires absolute per-element costs: two-thirds of a mount window is
@@ -392,3 +399,156 @@ Measured blobs — **byte-identical across the two runs except the intervention*
 | `…/walk_profile_app.cljs` (the twin + its parity gate) | unchanged across both runs |
 | `reagent/reagent` | `2.0.1`, from the jar, unmodified |
 | `reagent2.impl.template` | unmodified — **the codec is not forked** |
+
+## 2026-08-04 re-take of the arms on current main
+
+**Why this run exists.** The P2 fork ruling compares the candidate against a
+null — adapter-Prime, the composed `reagent-slim` `:f>` plus UIx
+`use-subscribe` arm — and that arm rides `reagent2.impl.template`, the `slim`
+row above. Since §2 was taken, **two fixes landed in that shipped interpreter**:
+`rf2-lhdp0` (PR #7405) and `rf2-e7zxb` (PR #7427), the second closing on
+`slim/reagent` 0.9762 and 0.9649. The HD-013 creative advisory pass
+(2026-08-04, recorded on `rf2-2rtt6.1`) drew the obvious inference — that
+Hicasso's published 0.9636× and slim's 0.9762×/0.9649× are **parity**, so §2's
+`hicasso/slim` **0.56×** is stale — and then said in terms that this was a
+**hypothesis until one run put both arms in the same windows**, because the two
+figures come from different sessions on a shared box, which is exactly what
+this instrument's ratios are not for. This is that run.
+
+**One run. Four arms, one process, one witness value, the arm-order guard
+adjudicating.** Nothing was re-run, no run was selected after seeing its
+result, and no tolerance was touched. What would be reported was fixed before
+the run opened.
+
+### The rows
+
+| arm | ms/walk p50 [min – max] | ns/element |
+|---|---|---|
+| `reagent` (stock 2.0.1) | 0.4750 [0.3875 – 0.9000] | 395 |
+| **`hicasso`** | **0.4000 [0.3250 – 0.5125]** | **333** |
+| `slim` (`reagent2.impl.template`) | 0.4625 [0.4125 – 0.7125] | 385 |
+| `hicasso-native` (intent markup) | 0.5500 [0.4625 – 0.8875] | 458 |
+
+`hicasso/reagent` **0.8421** · `hicasso/slim` **0.8649** · `slim/reagent` 0.9737
+
+### The quantisation floor, applied before any sign is read
+
+Chrome clamps `performance.now` to 100 µs and this instrument holds **8** walks
+in one window, so **one grid step is 0.0125 ms per walk** — the instrument says
+so itself at `walk_vs_reagent_app.cljs`, and every p50 this page has ever
+published is an exact multiple of it. On a ~0.45 ms walk that is ~2.8%. Each
+pair is therefore read in grid steps first, and a pair inside one step is **not
+resolved as to sign**:
+
+| pair | Δ ms/walk | grid steps | verdict |
+|---|---|---|---|
+| `hicasso` vs `reagent` | 0.0750 | 6 | resolved |
+| `hicasso` vs `slim` | 0.0625 | 5 | resolved |
+| `hicasso` vs `hicasso-native` | 0.1500 | 12 | resolved |
+| `slim` vs `reagent` | 0.0125 | **1** | **NOT RESOLVED as to sign** |
+
+So `slim/reagent` 0.9737 reproduces `rf2-e7zxb`'s 0.9762 / 0.9649 in magnitude,
+but this run **does not establish that slim is faster than stock Reagent** — one
+grid step is the whole of the difference. The defensible statement is that the
+donor's walk and stock Reagent's are **at parity within the grain**, which is
+itself the finding: it was 1.90×/1.73× on this page's own two runs.
+
+### The rider the pass raised, answered
+
+**The codec advantage over the donor has NOT evaporated — but it has collapsed
+from 0.56× to 0.86×.** `hicasso/slim` reads **0.8649** here, five grid steps,
+same run, same process, same witness, guard reportable on both arms. The pass's
+hypothesis was reasonable and is refuted only by the thing it asked for: put the
+two in one process and the codec is still measurably ahead of the interpreter it
+was extracted from. What is stale is the **magnitude**. Any statement of the
+form "we read 0.56× the donor we were built from" is no longer true of `main`;
+0.86× is.
+
+### Whose code moved, and what that costs the comparison
+
+The donor arm is quotable across sessions and the candidate arm is not:
+
+- **`reagent2.impl.template` is byte-identical to `rf2-e7zxb`'s landing** —
+  blob `9b30b6b74c` at this run's `HEAD` and at commit `099c1f228e`. So the
+  donor ran at exactly the code that produced the published anchor, and it
+  reproduced it (0.9737 against 0.9762 / 0.9649). **The donor reproduces its
+  anchor.**
+- **`front/codec.cljs` does not.** It is **593 insertions / 114 deletions**
+  different from the `0304f489bb` blob that produced §2's 0.9636×, across seven
+  commits including `rf2-2rtt6.39`, `rf2-2rtt6.65`, `rf2-2rtt6.36` and
+  `rf2-digtt`. `hicasso/reagent` 0.8421 therefore **does not reproduce** §2's
+  published 0.9636× and is not evidence about it: it is a different codec. The
+  same-run `hicasso/slim` ratio is unaffected by this, which is why the rider
+  above can be answered and a cross-session candidate comparison cannot.
+
+### One thing nobody asked for, recorded because it is resolved
+
+**The intent surface now costs 125 ns/element, where §2 measured 41.** The
+`hicasso-native` arm walks the page's own intent markup; here it reads 458
+ns/element against the plain arm's 333, twelve grid steps apart. As a same-run
+ratio the authoring surface has gone from ~1.075× the plain walk (603/562 and
+593/551) to **1.375×**. This is the price of the surface the P2 fork is about,
+it is stated rather than buried, and no cause is offered here — the codec moved
+by 593 lines between the two readings and this run does not attribute.
+
+### What this run does not settle
+
+**It does not locate the P2 null.** The `slim` arm is the *interpreter*
+adapter-Prime rides, not adapter-Prime — which is the composed `reagent-slim`
+`:f>` plus UIx `use-subscribe` arm on the HD-008 instrument — and every figure
+here is the **diagnostic in-page walk clock**, not the clock of record. The
+advisory pass separates these explicitly: this run answers its rider (b), while
+moving the null is its (a), "a donor-row re-take on the census or M1
+instrument, which needs a window that can adjudicate". That re-take is
+`rf2-2rtt6.31` and it remains open and untaken.
+
+### Controls, all of them, and the box
+
+| control | outcome |
+|---|---|
+| arm-order guard self-test (12 cases) | all `ok` before any arm ran |
+| twin parity gate (fatal) | **OK** — 1,202 elements, 58,474 canonical bytes, identical to `lt/page` |
+| workload match | `hicasso` / `hicasso-native` 58,474 B; `slim` / `reagent` 58,529 B — the same **55-byte** whitespace-only difference §1 explains and prices *against* Reagent |
+| arm-order guard verdict | **reportable** — every one of the four arms `[ok]` by predecessor **and** by phase, tolerance 10% |
+| candidate agreement failures | `[]` |
+| `SLIM DECOMPOSED` agreement failures | `[]` |
+| exit code | **`0`** |
+
+**The box was quiet, and quiet is measured here as summed per-process CPU-time
+deltas over the core count** — not `Win32_Processor.LoadPercentage`, which read
+**50** and **14** at the two sampling instants below while the true figure was
+**1.44%** and **2.73%**, and is not usable on this host. **1.44%** of 24 logical
+cores immediately before the run, **2.73%** immediately after (that window
+includes this worker's own `git` calls). **Zero `java` processes** existed at
+either sample, so no shadow-cljs JVM was compiling; no other worker and no gate
+was running. Note that §7 declares its own runs were taken at ~48% with four
+concurrent builds, which is the likeliest reason every absolute here is well
+below every absolute above — and is why the absolutes are again **not** compared
+across runs.
+
+### Provenance
+
+| | |
+|---|---|
+| **Producing commit** | `77a92185ea` (`origin/main`), branch `worker/nullwalk` |
+| **Reproduction** | `HICASSO_INIT_FN=re-frame.bench.hicasso.walk-vs-reagent-app/-main HICASSO_OUT_DIR=out/hicasso-walkcmp HICASSO_PORT=8171 node implementation/freehand/test/re_frame/bench/hicasso/run.cjs` |
+| **Build** | `:hicasso-bench`, `:advanced`, `goog.DEBUG false`, **0 warnings** (200 files, 145 compiled, 19.35 s) |
+| **Runtime** | chromium `147.0.7727.15` (playwright), node `v24.13.0`, Windows NT 10.0 x64, 24 threads |
+| **Design** | 4 arms × 6 rounds × (4 warm-up + 10 samples), 8 whole-page walks per window — unchanged |
+| **Clock** | in-page `performance.now`, **diagnostic**; the clock of record is untouched here |
+| **Window** | 2026-08-04 07:53:51 – 07:54:28 AUSEST (37 s wall, build included) |
+| **Exit code** | `0`, guard reportable |
+
+| file | blob |
+|---|---|
+| `…/front/codec.cljs` | `2c0c26ccb57cf3c94a2d0626af4bedbd32dccf26` — **not** §2's `0304f489bb` |
+| `…/walk_vs_reagent_app.cljs` | `596d6c1220af1da797dee0797dc3dd1da9e7dbfb` — **not** §2's `b447e313fc`; `rf2-lhdp0`/`rf2-e7zxb` added the `SLIM DECOMPOSED` rows |
+| `…/run.cjs` | `1bc82c38ea59ca00f7b58ae479e6eb738eece0ec` |
+| `…/walk_profile_app.cljs` (the twin + its parity gate) | `5e12aaf7b2008dee5cb561c63109870fe7b5d291` |
+| `reagent/reagent` | `2.0.1`, from the jar, unmodified |
+| `reagent2.impl.template` | `9b30b6b74ca5cf348edf4be71ae32d332b93cfff` — byte-identical to `rf2-e7zxb`'s landing; **the codec is still not forked** |
+
+**Advisory only, and no conclusion about the P2 fork is drawn here.** No
+adapter, codec or runtime file was touched by this run; `validation.md`,
+`decisions.md` and `rf2-2rtt6.1`'s standard-bead notes are unmodified; no bead
+was closed or reprioritised. The decider is the operator.


### PR DESCRIPTION
One measurement, published as a dated section on
`docs/design/hicasso/studio/our-walk-against-reagents.md`. **Advisory only —
no conclusion about the P2 fork is drawn, and none is mine to draw.**

## Why

The HD-013 **creative** advisory pass (2026-08-04, recorded on `rf2-2rtt6.1`)
found one decision-relevant measurement nobody had booked. Two fixes landed in
the **shipped** `reagent-slim` interpreter — `rf2-lhdp0` (PR #7405) and
`rf2-e7zxb` (PR #7427) — and the pass raised a rider: that Hicasso's published
`0.9636×` against slim's published `0.9762×`/`0.9649×` is **parity**, which
would make this page's `hicasso/slim` **0.56×** stale. The pass then said, in
terms, that this was a **hypothesis until one run put both arms in the same
windows**, because those figures came from different sessions on a shared box —
exactly what this instrument's ratios are not for.

## What ran

One run. `run.cjs` with
`HICASSO_INIT_FN=re-frame.bench.hicasso.walk-vs-reagent-app/-main`. Four arms,
one process, one witness value, arm-order guard adjudicating. **Nothing was
re-run, no run was selected after seeing its result, no tolerance was touched**,
and what would be reported was written down before the run opened.

| arm | ms/walk p50 [min – max] | ns/element |
|---|---|---|
| `reagent` (stock 2.0.1) | 0.4750 [0.3875 – 0.9000] | 395 |
| **`hicasso`** | **0.4000 [0.3250 – 0.5125]** | **333** |
| `slim` (`reagent2.impl.template`) | 0.4625 [0.4125 – 0.7125] | 385 |
| `hicasso-native` (intent markup) | 0.5500 [0.4625 – 0.8875] | 458 |

`hicasso/reagent` **0.8421** · `hicasso/slim` **0.8649** · `slim/reagent` 0.9737

## What it says

**The rider is refuted — the codec advantage has NOT evaporated — but the
magnitude it doubted was stale anyway.** `hicasso/slim` reads **0.8649**, five
grid steps, same run, same process. It was **0.56×**.

**Quantisation is applied before any sign is read.** One grid step is
**0.0125 ms/walk** (100 µs `performance.now` clamp over 8 walks per window).
`slim` and `reagent` differ by **exactly one step**, so `slim/reagent` 0.9737
reproduces `rf2-e7zxb`'s anchor in magnitude but this run **does not establish
that slim is faster than stock Reagent** — parity within the grain. It was
1.90×/1.73× on this page's own runs.

**The donor reproduces its anchor; the candidate does not.**
`reagent2.impl.template` is byte-identical to `rf2-e7zxb`'s landing (blob
`9b30b6b74c`). `front/codec.cljs` is **593 insertions / 114 deletions** from the
blob that produced `0.9636×`, so `hicasso/reagent` 0.8421 is **not evidence
about that figure**. The same-run `hicasso/slim` ratio is untouched by this,
which is why the rider can be answered and a cross-session candidate comparison
cannot.

**This does not locate the P2 null.** The `slim` arm is the *interpreter*
adapter-Prime rides, not adapter-Prime, and this is the **diagnostic in-page
walk clock**, not the clock of record. Moving the null is the pass's **(a)** —
`rf2-2rtt6.31`'s donor-row re-take — which remains open and untaken.

**Filed: `rf2-vw412`.** The intent surface now costs **125 ns/element** where
section 2 measured **41** (`hicasso-native/hicasso` 1.375× against ~1.075×,
twelve grid steps, same run). Resolved, uncaused, recorded rather than buried.

## Quality gates

| gate | result |
|---|---|
| the run itself — `run.cjs`, walk-vs-reagent arms | **exit `0`** |
| arm-order guard self-test (12 cases) | all `ok` before any arm ran |
| arm-order guard verdict | **reportable** — all four arms `[ok]` by predecessor **and** by phase, tolerance 10% |
| twin parity gate (fatal) | **OK** — 1,202 elements, 58,474 canonical bytes, identical to `lt/page` |
| workload match | 58,474 B / 58,529 B — the documented 55-byte whitespace difference, priced *against* Reagent |
| candidate + `SLIM DECOMPOSED` agreement failures | `[]` and `[]` |
| build | `:advanced`, `goog.DEBUG false`, **0 warnings** (200 files, 145 compiled) |
| `python scripts/check_doc_slugs.py` | **exit `0`** |
| `sh scripts/test-fast-pr.sh` | **exit `0`** — PASS, but classified docs-only and skipped two tiers |
| `sh scripts/test-fast-pr.sh --all` | **exit `0`** — PASS. JVM core 2,210 tests / 11,510 assertions; CLJS 12,501 tests / 62,706 assertions; both 0 failures, 0 errors; per-ns isolation 17/17; hicasso bench-lane compile gate 101 namespaces, 0 warnings |

`--all` was run **because** the plain spine skipped the JVM and node tiers on a
docs-only diff; the skip is not claimed as coverage. `mkdocs --strict` does
**not** cover `docs/design/**` and is not nominated — **anchors and table
column counts were verified by hand**: 16 tables in the file, **0 malformed**,
the 5 new ones at 3 / 4 / 2 / 2 / 2 columns, and the one new intra-page anchor
resolves against its heading.

**Box state, measured as summed per-process CPU-time deltas over the core
count** — not `Win32_Processor.LoadPercentage`, which read **50** and **14** at
the two sampling instants while the true figure was **1.44%** and **2.73%** of
24 logical cores, and is unusable on this host. Zero `java` processes at both
samples; no other worker, no gate, no build.

## Not touched

No adapter, codec, runtime or instrument file. `validation.md`, `decisions.md`
and `rf2-2rtt6.1`'s standard-bead notes are unmodified. No bead closed or
reprioritised. The decider is the operator.
