### PR TITLE
docs(hicasso): HD-008's provenance no longer reproduces its cited exit code (rf2-2rtt6.31)

### DIFF
--- a/docs/design/hicasso/studio/hd8-composed-donor-arm.md
+++ b/docs/design/hicasso/studio/hd8-composed-donor-arm.md
@@ -40,7 +40,10 @@ Bead **`rf2-2rtt6.7`**. Decision **[HD-008](../decisions.md)**. The standard is
 > `rf2-2rtt6.1` — in [the re-take on the current
 > tree](#the-re-take-on-the-current-tree-rf2-2rtt631). The published deficit
 > against stock Reagent does not reproduce there, and the gated donor-vs-UIx
-> pairs sit at the amended 1.10× line, instrument-limited. The rows above stand
+> pairs sit at the amended 1.10× line, instrument-limited. **Five of the
+> re-take's six clock rows failed their positive control**, so every comparative
+> claim in that section names the rows it stands on, and only the
+> control-passing `reagent-U` row carries one on its own. The rows above stand
 > as measured, under their stamp; the re-taken rows are what a post-landing
 > candidate is judged against.
 
@@ -222,8 +225,8 @@ So the re-take is two measurements, deliberately separate:
 | **Witness stamp** | B/E/Q = 300/300/300 — 300 boundaries, one subscription edge each, 300 distinct query vectors; `M` 903 elements, `U` 301; `ctl-2x` doubles them |
 | **Quiet box** | 8 consecutive sub-30 % CPU samples verified immediately before **every** clock-of-record row; loud attempts refused and recorded (three were). Measurement windows (2026-08-02): uix 04:59:59–05:02:46 Z · reagent 05:02:46–05:05:02 Z · slim 05:05:02–05:07:41 Z; the sweep followed at ~05:08–05:13 Z on the box the last gate had just verified. The sibling implementation worker (`worker/burst-2rtt6-55`) held its browser gates out of these windows |
 | **Datasets** | `implementation/freehand/test/re_frame/bench/hicasso/data/hd8clock-2rtt6-31/{uix,reagent,slim}.json` — the reduced quantities every clock-of-record figure below recomputes from |
-| **Exit codes** | clock-of-record run `0`; sweep `0` — measured, guard clean, no refusal |
-| **Reproduce** | `node implementation/freehand/test/re_frame/bench/hicasso/hd8_clock_run.cjs` · `node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs` |
+| **Exit codes** | clock-of-record run ~~`0`~~; sweep `0` — as taken: measured, guard clean, no refusal. **The clock-of-record `0` is superseded — see the addendum below** |
+| **Reproduce** | `node implementation/freehand/test/re_frame/bench/hicasso/hd8_clock_run.cjs` · `node implementation/freehand/test/re_frame/bench/hicasso/hd8_run.cjs` — **at the producing commit above**, whose drivers are the blobs in the table below. The first command's exit rule at `main`'s tip is not the one that produced the code beside it |
 
 Instrument blobs at the producing commit (they survive a rebase; they pin the
 files they name and nothing else):
@@ -236,6 +239,27 @@ files they name and nothing else):
 | `hd8_witnesses.cljs` | `8669cc71d1a2406af8aa3395fe5e9dec5b9ddc64` |
 | `lane.cljs` | `0642815dc234c1544d1f97bd9e1e4dd24365c027` |
 | `spine.cljs` | `ad7b19d9d8957e7a1872e58f9b18ace8acdc4841` |
+
+> **Addendum, 2026-08-04 — the clock-of-record run's `0` no longer reproduces
+> (`rf2-2rtt6.31`).** The exit code above was true of the run that took these
+> rows, and it is kept rather than rewritten because it is what that instrument
+> reported. The instrument has since tightened. `rf2-rr6do` (PR #7450,
+> `2926049d5e`) moved this driver's exit decision into one pure exported
+> `verdict(summary)` and made three refusals it had only ever *printed* fail
+> closed — `3` unverified operations, `4` a breached band ceiling, **`5` a
+> positive control that missed its own prediction**. The old exit came off the
+> arm-order guard alone, which is why a run whose controls read the way these did
+> could exit `0`.
+>
+> Replaying that `verdict()` over the committed datasets — a re-derivation from
+> the published data, not a second draw, and no figure on this page moves —
+> returns **`5`**, naming `uix/M 1.6503`, `uix/U 1.5566`, `reagent/M 1.6868`,
+> `slim/M 1.5518` and `slim/U 1.7100`. Only `reagent/U` passes strict.
+> `unverified` is `0` and the band ceiling clean on all six rows, so the control
+> is the whole of the refusal. **A reader running the first reproduce command
+> today, on rows that behave as these did, gets `5` and not `0`** — and with it
+> the driver's own rule: *no magnitude from a failed-control row is reportable*.
+> Every comparative claim below therefore names the rows it stands on.
 
 ### The gated pairs on the clock of record
 
@@ -262,10 +286,20 @@ inside its row's band (5.4 – 27.2 %). Under the amendment's own clause a resul
 that cannot resolve the 1.10 boundary is instrument-limited, **not a pass** —
 and not a fail either: the donor mount cost over direct UIx sits **at** the
 line, means 1.086 – 1.139 across six independent row-runs. What *is* resolved:
-on the reagent run — both rows, including the one whose control passed strict
-and whose band is 5.4 % — both gated pairs sit **wholly above parity** with
-margins that clear the band, so the donor cost over UIx is a real ~10 – 13 %,
-not noise; on the uix and slim runs the same pairs straddle 1.0.
+on the reagent run both gated pairs sit **wholly above parity** with margins
+that clear the band, so the donor cost over UIx is a real ~10 – 13 %, not noise;
+on the uix and slim runs the same pairs straddle 1.0.
+
+**That reads off two rows of unequal standing, and the difference matters.**
+`reagent-U` is the row whose control passed strict, and its band is the tightest
+on the page at 5.4 %; its pairs read 1.1301 [1.0387 – 1.2275] and
+1.1316 [1.0158 – 1.2121], both ranges clear of 1.0. **It carries the finding on
+its own** — one row, one passing control, one band that resolves it, and it is
+the strongest thing on this page rather than one of six. `reagent-M` agrees in
+direction and in shape, but its control failed (1.6868× against a predicted
+2.00×), so under the driver's rule it corroborates and contributes no magnitude
+of its own. The four uix and slim rows, whose pairs straddle 1.0, failed the
+control too — a straddle is what they report, and it is not a magnitude.
 
 **The control, stated per its own record.** Mount rows carry `ctl-2x` and the
 plumb tare, and no changed-set control can reach a mount (`rf2-jcm3p`). The
@@ -274,7 +308,10 @@ inverting the doubling gives c = 0.48 – 2.96 ms across the six row-runs — an
 cannot certify exactness: the recorded mount undershoot (1.8173× over
 `rf2-emvod`'s seven runs) is exactly where these means sit (1.55 – 1.79). Five
 rows failed the *strict* rule on single blocks below 1.50; the reagent-U row
-passed it whole, and it is also the row with the tightest band.
+passed it whole, and it is also the row with the tightest band. **Under the
+instrument of record those five failures are a refusal rather than a footnote**
+— `verdict()` exits `5` on them and states the rule this section reads its rows
+by: *no magnitude from a failed-control row is reportable*.
 
 ### Co-instrumented beside the gate — and the published deficit does not reproduce
 
@@ -291,11 +328,21 @@ amendment's Reagent clause). Same blocks, same arithmetic:
 Every donor-vs-Reagent-path range **straddles 1.0**. The 1.333 – 1.473× (M) and
 1.448 – 1.542× (U) deficits against stock Reagent published above **do not
 reproduce on the current tree on the clock of record** — the donor rungs read
-indistinguishable from both Reagent paths. And on the control-passing reagent-U
-row, `uix / reagent` sits wholly below 1.0 with a 12.5 % margin against a 5.4 %
-band: on this witness family, on this clock, **direct UIx is now the faster
-donor**. The shell (`donor-r2 / donor-r1`) straddles 1.0 in all six row-runs
-(0.9957 – 1.0524) — rung 2 stays free, which re-confirms this page's finding.
+indistinguishable from both Reagent paths.
+
+**What that claim stands on: four rows, one of which passed its control.**
+`reagent-U` is that one, and on it `donor-r1 / reagent` reads 0.9880
+[0.8915 – 1.0737] and `donor-r2 / reagent` 0.9888 [0.8891 – 1.0349] — the
+non-reproduction stated on a row entitled to state it, since a straddle is a
+failure to resolve and not a magnitude. `reagent-M`, `slim-M` and `slim-U`
+straddle the same way and their controls failed, so they are agreement rather
+than evidence. And on the control-passing reagent-U row, `uix / reagent` sits
+wholly below 1.0 with a 12.5 % margin against a 5.4 % band: on this witness
+family, on this clock, **direct UIx is now the faster donor**. The shell
+(`donor-r2 / donor-r1`) straddles 1.0 in all six row-runs (0.9957 – 1.0524) —
+rung 2 stays free, which re-confirms this page's finding; five of those six
+carry a failed control, so what the six share is the straddle and reagent-U is
+the one that reaches it unaided.
 
 **Absolutes beside the ratios** (p50 raw `TaskDuration` ms per mount, M row,
 by run): floor 6.49 / 7.06 / 7.39 · uix 9.12 / 9.60 / 9.48 · donor-r1 9.96 /


### PR DESCRIPTION
Two documentation residuals on `rf2-2rtt6.31`, both on
`docs/design/hicasso/studio/hd8-composed-donor-arm.md`. **No measurement was
taken and no published magnitude changed.** The re-take is already on the tree
(commit `1ac48c4a0b`, PR #7378) and a competing draw taken after reading it
would be a selection opportunity; this PR is prose and provenance only.

## 1 — a provenance line that no longer reproduces

The re-take's provenance table records

> | **Exit codes** | clock-of-record run `0`; sweep `0` — measured, guard clean, no refusal |
> | **Reproduce** | `node …/hd8_clock_run.cjs` · `node …/hd8_run.cjs` |

`rf2-rr6do` (PR #7450, `2926049d5e`) has since moved that driver's exit
decision into one pure exported `verdict(summary)` and made three refusals it
had only ever *printed* fail closed — `3` unverified operations, `4` a breached
band ceiling, `5` a positive control that missed its prediction. The old exit
came off `failed` and the arm-order guard alone.

Replaying that `verdict()` over the committed datasets returns **`5`**, naming
`uix/M 1.6503`, `uix/U 1.5566`, `reagent/M 1.6868`, `slim/M 1.5518`,
`slim/U 1.7100`; only `reagent/U` passes strict, `unverified` is `0` and
`ceilingBreached` false on all six — so the control is the whole of the refusal.
That replay is a re-derivation from published data, not a run.

**The shape of the fix is supersede, not correct.** The `0` was true of the run
that took the rows; the instrument tightened afterwards. Writing `5` in its
place would misrepresent the run, and deleting the line would lose the
provenance the page exists to carry. So the `0` is struck through in place, the
row points at a **dated addendum** (the HD-019/HD-024 pattern), and the addendum
records what the old instrument reported, what the current one reports, and that
a reader running the first command today on rows behaving as these did gets `5`.
The `Reproduce` row now says the commands belong to the producing commit above.

## 2 — comparative claims resting on failed-control rows

The gate verdict was already correctly withheld (all twelve cells
INSTRUMENT-LIMITED, "not a pass and not a fail"), and this PR neither restates
nor issues it. What still read off failed-control rows were four comparative
claims, each of which now carries the control status of what it stands on:

* **the resolved donor-over-UIx finding** — was "on the reagent run — both rows,
  including the one whose control passed strict"; now attributed to `reagent-U`
  **alone**, the one row whose control passed strict and whose 5.4% band is the
  tightest on the page, with `reagent-M` named as direction-only corroboration
  (control 1.6868× against a predicted 2.00×) and the four uix/slim straddles
  named as failed too. This is the strongest thing on the page and it read as
  one of several.
* **"the published deficit does not reproduce"** — now names its four rows, of
  which one passed control, and quotes `reagent-U`'s own published cells as the
  claim's carrier.
* **the shell straddle across six row-runs** — now says five of the six carry a
  failed control.
* **the top banner** — now says five of six failed, so the summary is not
  stronger than the body.

The rule these read by is stated once, in the control paragraph that already
records the five failures: `verdict()` exits `5` and says *no magnitude from a
failed-control row is reportable*.

## Fenced out, deliberately

* **The dataset write-ordering question is untouched.** `hd8_clock_run.cjs:720-722`
  states it as landed intent — *"the datasets are written before this is
  consulted. A refusal is about what may be QUOTED, not about throwing the
  measurement away."* That is an operator ruling, not a patch.
* `validation.md`, `decisions.md` and `rf2-2rtt6.1`'s notes untouched; no
  conclusion drawn about the P2 fork.
* `### What the re-take does to the gate verdict` untouched — the stop rule's
  statement stands as written.

## Where else this instrument is cited (the real count)

* **Exit codes of `hd8_clock_run.cjs`: one page only.** `git grep hd8_clock_run`
  over tracked `.md` returns three hits, all on this page (prose, the reproduce
  row, the blob table). No sibling carries the false provenance.
* **Leaning on the failed-control rows: two pages.** This one, and
  `docs/design/hicasso/validation.md:243-251`, which restates *"the published
  1.333 – 1.542× deficit against stock Reagent **does not reproduce**"* and the
  1.10× line with no control status at all. `validation.md` is outside this PR's
  surface — flagged, not edited.
* **One adjacent staleness, also outside surface:**
  `docs/design/hicasso/studio/our-walk-against-reagents.md:503` still says the
  `rf2-2rtt6.31` re-take *"remains open and untaken"*. It landed in PR #7378.

## Quality gates

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** (silent) |
| `sh scripts/test-fast-pr.sh` | **0** — `gate root: /c/Users/miket/code/re-frame2-worktrees/hd8prov-2rtt6-31` |

`test-fast-pr.sh` classified the diff `docs=true jvm=false node=false` and
**skipped three tiers**, which this PR does not claim as coverage: all JVM
artefact suites; npm/CLJS/isolation; and the CI-only lanes (browser, bundle
isolation, perf, adapter smokes, Xray feature matrix, mcp-conformance, tool JVM).

**`mkdocs build --strict` is not the gate for this edit** — it ran inside the
spine and exited 0 having verified nothing here, because `mkdocs.yml`'s
`exclude_docs` keeps `design/hicasso/` out of the site.

**Tables verified by hand, since nothing validates them.** The edit lands inside
a two-column provenance table. All **19** tables on the page were counted
row-by-row (code spans and escaped pipes handled): every row of every table
matches its header width — the touched provenance table is 14 rows × **2**
columns, the blob table beside it 8 rows × **2**. No table row was added or
removed.

**Anchors.** No heading was added, removed or reworded (`git diff` contains no
`#` line), so no inbound-link sweep was owed; the page's **25** headings and
**21** outbound links are unchanged, and the diff adds no link at all. The four
tracked files linking to this page (`studio/README.md`,
`census-real-clock-rows.md`, `hd8-freehand-codec-donor-arm.md`, `validation.md`)
still resolve — `check_doc_slugs.py` exit 0.

## Bead

`rf2-2rtt6.31` is **left OPEN**. Closing it would strand the write-ordering item
held for an operator ruling, which is the only residual left on the record once
these two land.
