### PR TITLE
docs(hicasso): two claims about the HD-008 re-take carry what they rest on

### DIFF
--- a/docs/design/hicasso/studio/our-walk-against-reagents.md
+++ b/docs/design/hicasso/studio/our-walk-against-reagents.md
@@ -500,7 +500,12 @@ here is the **diagnostic in-page walk clock**, not the clock of record. The
 advisory pass separates these explicitly: this run answers its rider (b), while
 moving the null is its (a), "a donor-row re-take on the census or M1
 instrument, which needs a window that can adjudicate". That re-take is
-`rf2-2rtt6.31` and it remains open and untaken.
+`rf2-2rtt6.31`, and it has been taken — it landed in `1ac48c4a0b` (PR #7378)
+and its rows are published in
+[the re-take on the current tree](hd8-composed-donor-arm.md#the-re-take-on-the-current-tree-rf2-2rtt631).
+The bead is still open, but on a separate held question — the clock-of-record
+driver's write-before-refuse dataset ordering, which is an operator ruling —
+and not because the re-take is outstanding.
 
 ### Controls, all of them, and the box
 

--- a/docs/design/hicasso/validation.md
+++ b/docs/design/hicasso/validation.md
@@ -245,7 +245,20 @@ mount-gate amendment (2026-08-02, `rf2-2rtt6.1`). On the re-take the published
 rungs read indistinguishable from both Reagent paths on raw `TaskDuration`, and
 beat `reagent-slim` outright on the page's own instrument — while the gated
 `donor / uix` pairs sit **at** the amended 1.10× line (means 1.086 – 1.139,
-every range straddling the boundary; instrument-limited, not a pass). The
+every range straddling the boundary; instrument-limited, not a pass).
+**On the clock of record that rests on one row, and this paragraph should say
+so.** Replaying the driver's current `verdict()` over the committed datasets
+exits `5`: five of the six rows missed their positive control — `uix/M` 1.6503,
+`uix/U` 1.5566, `reagent/M` 1.6868, `slim/M` 1.5518 and `slim/U` 1.7100 against
+a predicted 2.00× — and no magnitude from a failed-control row is reportable.
+`reagent/U` is the row that passed strict, on the tightest band that page
+carries at 5.4%; on it `donor-r1 / reagent` reads 0.9880 [0.8915 – 1.0737] and
+`donor-r2 / reagent` 0.9888 [0.8891 – 1.0349], so the non-reproduction is
+stated by a row entitled to state it. `reagent/M` agrees in direction and
+contributes no magnitude of its own, and the four straddling `uix` and `slim`
+rows failed the control as well. The `reagent-slim` result is the page's own
+instrument rather than the clock of record — a separate measurement, whose
+control was clean on every round. The
 verdict's direction stands; its published magnitude was a property of the stale
 spine and the demoted clock. Full tables and provenance:
 [the re-take on the current tree](studio/hd8-composed-donor-arm.md#the-re-take-on-the-current-tree-rf2-2rtt631).


### PR DESCRIPTION
PR #7462 gave `hd8-composed-donor-arm.md`'s comparative claims their control
status. Two claims elsewhere in the tree did not follow it, and both were
fenced out of that dispatch deliberately. This is prose only: **no measurement
taken, no driver run, no dataset written, no published magnitude altered, no
threshold, budget, kill criterion or verdict changed.** Every figure added is a
quotation of one already published on `hd8-composed-donor-arm.md`.

## Site 1 — `docs/design/hicasso/validation.md`, the P1 gate section

The paragraph restated *"the published 1.333 – 1.542× deficit against stock
Reagent does not reproduce"* and the amended 1.10× line **with no control
status at all** — while, per PR #7462, replaying the driver's current
`verdict()` over the committed datasets exits `5` and five of the six
clock-of-record rows missed their positive control.

It now names the exit code and the five failing rows with their figures,
attributes the non-reproduction to **`reagent/U` alone** — the row that passed
strict, tightest band at 5.4% — with its two cells quoted, marks `reagent/M` as
direction-only corroboration contributing no magnitude, names the four
straddling `uix` and `slim` rows as failed-control, and separates the
`reagent-slim` result as the page's own instrument rather than the clock of
record. This follows the treatment PR #7462 landed one page over rather than
inventing a second style.

**Fence honoured.** The ship bar at line 9 is untouched; the kill-criteria
table is untouched; `rf2-hyd50`'s open ship-bar/mount-gate question is not
pre-empted. *"instrument-limited, not a pass"* and *"the verdict's direction
stands"* stand exactly as written. The HD-008 stop rule is neither restated nor
reissued. No heading was reworded and no table was touched on either page.

## Site 2 — `docs/design/hicasso/studio/our-walk-against-reagents.md`

Said the re-take *"remains open and untaken"*. Verified in the tree: it landed
in `1ac48c4a0b`, PR #7378, state `MERGED`, and its rows are published. The bead
**is** still open — on the driver's write-before-refuse dataset ordering, an
operator ruling — which is what the sentence now says. `rf2-2rtt6.31` is
deliberately left open. No P2-fork conclusion is drawn.

## The sweep

Every tracked `.md` swept for both patterns. **Two sites carry either defect,
and both are fixed here.**

Three further sites were read and judged clean, with reasons:

- `census-real-clock-rows.md:129-131` and `:173-177` cross-reference the
  re-take's decomposition and its parity finding. Neither quotes an HD-008
  magnitude, both link or defer to the section that now carries control status,
  and that page prints a `ctl-2x` PASS/FAIL column on every one of its own rows.
- `the-clock-behind-the-published-rows.md:335-341` calls the HD-008 donor rows
  *"EXPOSED, UNMEASURED"* and proposes the bounded check that became this
  re-take. That page is an **audit of the record as it stood on 2026-08-01**
  and says so in its second line; the statement was true at its date and is
  correctly past-tensed by its own header. Whether that page's findings list
  should gain a supersession note is a judgement about that page, not this
  defect — reported, not widened into.

## Quality gates

- `python scripts/check_doc_slugs.py` — **exit 0**. This is the gate that
  actually covers `docs/design/**`: link targets and heading anchors.
- `sh scripts/test-fast-pr.sh` — **exit 0**, `PASS fast PR spine`,
  `gate root: /c/Users/miket/code/re-frame2-worktrees/staleclaims`.

**The spine classified this diff `docs=true jvm=false node=false` and skipped
three tiers — this PR does not claim their coverage:**

1. all JVM artefact suites (`implementation_jvm` surface unchanged);
2. npm/CLJS/isolation (`cljs_node_test` surface unchanged);
3. browser lanes, prod-elision/bundle-isolation/perf gates, adapter probes +
   smokes, Xray feature matrix, mcp-conformance, tool JVM suites (CI only).

**`mkdocs build --strict` ran inside the spine and exited 0 having verified
nothing of this change** — `mkdocs.yml`'s `exclude_docs` lists
`design/hicasso/`, so both edited files are outside the built site. It is not
nominated as a gate here.

**Hand-verified, since nothing automated covers it:**

- **Tables: 0 touched.** `git diff -U0 | grep -c '^[+-].*|'` returns `0` — the
  diff adds and removes no table row on either page, so no column count moved.
- **Headings: 0 touched.** `git diff -U0 | grep -E '^[+-]#'` returns `0`, so no
  inbound anchor could break. The 4 inbound links to
  `validation.md#p1-gate--the-composed-donor-arm-hd-008` (a hyphen-run slug, the
  documented trap) are unaffected and `check_doc_slugs.py` resolves them.
- **Outbound anchors: 1 added** —
  `hd8-composed-donor-arm.md#the-re-take-on-the-current-tree-rf2-2rtt631` from
  `our-walk-against-reagents.md`, same directory. Slug hand-derived from
  `## The re-take on the current tree (rf2-2rtt6.31)` and already in use by two
  other files; `check_doc_slugs.py` resolves it.
