### PR TITLE
fix(lint): the tree's only suppression and the config header disagree (rf2-o4ohg)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,8 +17,18 @@
 // disable comments to land green. A gate that ships with a suppression file is
 // worse than no gate, because people stop reading it. The curated set below
 // reported 24 findings across 17 files — every one of them dead code — all of
-// which were deleted in the landing PR, so this config lands with ZERO
-// suppressions anywhere in the tree.
+// which were deleted in the landing PR.
+//
+// SUPPRESSIONS IN THE TREE: exactly one, and it is load-bearing.
+// `tools/story/test/story_feature_load.cjs` wraps a skipped scenario's body in
+// `/* eslint-disable no-unreachable */` … `/* eslint-enable no-unreachable */`.
+// That probe returns early behind a `console.warn` while its assertions wait
+// for a CLJS port; delete the pair and `no-unreachable` errors on them, so it
+// goes only when the code it guards goes. This header used to claim ZERO
+// suppressions anywhere in the tree, which was wrong the day it was written:
+// the landing PR deleted two dead directives from that very file and kept this
+// live one. Keep the count here honest — a suppression that no comment admits
+// to is how a gate quietly stops meaning what it says (rf2-o4ohg).
 //
 // EVERY RULE HERE ANSWERS "WHAT BUG DOES THIS CATCH?":
 //

--- a/implementation/freehand/test/re_frame/bench/hicasso/adoption_witness_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/adoption_witness_run.cjs
@@ -289,7 +289,6 @@ async function runPage(browser, horizonMs, ceilingMs) {
           `A measured margin on this Chromium today, never a React guarantee.`,
       );
       process.exit(0);
-    // eslint-disable-next-line no-fallthrough
     case 'REFUSED':
       console.error(
         `[${TAG}] REFUSED (exit 2) — this page could not bound its render-to-passive-flush ` +
@@ -299,7 +298,6 @@ async function runPage(browser, horizonMs, ceilingMs) {
           `flush — re-run on a quiet machine to tell them apart.`,
       );
       process.exit(2);
-    // eslint-disable-next-line no-fallthrough
     case 'NOT-ADOPTED':
       console.error(
         `[${TAG}] NOT-ADOPTED (exit 4) — every gap qualified, so this page CAN see the race, ` +
@@ -308,7 +306,6 @@ async function runPage(browser, horizonMs, ceilingMs) {
           `not a scheduling one. See the per-trial faults above.`,
       );
       process.exit(4);
-    // eslint-disable-next-line no-fallthrough
     default:
       console.error(
         `[${TAG}] FAILED: the page finished without recording a verdict ` +


### PR DESCRIPTION
Closes rf2-o4ohg.

The bead offered two fixes and said to pick one. The answer is that **both halves were true, and they are not alternatives** — the three directives really are dead, *and* the header was already wrong for a different reason that deleting them does not touch.

## The three directives are genuinely dead — they go

`no-fallthrough` is not in the curated bug-rule set. There is exactly one ESLint config in the entire tree (`eslint.config.mjs`), it has no `extends` and no preset, and the only mention of `js.configs.recommended` anywhere is the comment explaining why it is deliberately *not* used. No path reaches the rule, so the three `// eslint-disable-next-line no-fallthrough` comments suppress nothing.

**The code beneath them is correct without them**, which is the part worth checking before deleting a suppression. Every arm of that `switch` ends in `process.exit(N)`, so control never reaches the next `case` at runtime. The rule would have fired had it been enabled only because ESLint does not model `process.exit` as terminating — there is no real fallthrough to lose, and no new finding appears at those sites after removal (`no-unreachable` does not fire there for the same reason).

## The header was wrong before those three existed

It claimed the config "lands with ZERO suppressions anywhere in the tree". It did not, and deleting the three does not make the sentence true.

`tools/story/test/story_feature_load.cjs` carries a live `/* eslint-disable no-unreachable */` … `/* eslint-enable no-unreachable */` pair, and **`no-unreachable` is an error rule in the set**. A skipped scenario returns early behind a `console.warn` with eight assertions below it; the pair is the only thing keeping the gate green over them.

Two independent proofs it is live:

- **Negative**: ESLint's unused-disable-directive reporting flagged the three `no-fallthrough` comments and said nothing about this pair. Unused directives get reported; this one was not.
- **Mutation**: removing the pair yields `1245:7  error  Unreachable code  no-unreachable`. Reverted byte-identically — `sha256sum -c` OK and an empty `git diff`.

**It was false on the day it was written, not drift.** Before the lint config landed, that file held four directives. The landing PR (rf2-2rtt6.78) deleted two dead ones — a `no-console` and a stray `no-unreachable` — and kept this live pair, then wrote a header saying there were none. The three `no-fallthrough` comments arrived hours later with the adoption witness (rf2-2rtt6.80) and are a second, separate problem.

So the header now states the count honestly, names the one suppression, says why it is load-bearing, and says what would have to happen for it to go.

## Directive census, tree-wide

Swept every tracked file for `eslint-disable`, `eslint-disable-next-line`, `eslint-disable-line`, `eslint-enable` and `/* eslint … */` — not just `no-fallthrough`, not just the named file. **Five directives in two files**, and that is the whole population:

| Site | Directive | Verdict |
|---|---|---|
| `adoption_witness_run.cjs:292` | `no-fallthrough` | **dead** — deleted |
| `adoption_witness_run.cjs:302` | `no-fallthrough` | **dead** — deleted |
| `adoption_witness_run.cjs:311` | `no-fallthrough` | **dead** — deleted |
| `story_feature_load.cjs:1245` | `no-unreachable` (disable) | **live** — kept, header now names it |
| `story_feature_load.cjs:1254` | `no-unreachable` (enable) | **live** — kept, header now names it |

The `.beads/issues.jsonl` hits are tracker prose quoting these, not source. Nothing outside these two files carries a directive in any form.

The live pair is left alone deliberately: it is a different shape from the one-line dead ones, and removing it reds the gate. Filed **rf2-kvsm1** for it — its own comment promises a "follow-on bead" for the CLJS migration and no such bead existed, so the suppression the header now calls load-bearing had no owner and no end date.

## No rule was changed

33 rules before, 33 after. No rule line appears in the diff in either direction. `no-fallthrough` was **not** added — the curated set was chosen deliberately small and stays exactly as it was. The fix is what the header claims, not which rules apply.

## Quality gates

| Gate | Exit | Notes |
|---|---|---|
| `npm run lint:js` (root, CI form) — **before** | **0** | 3 warnings, all in `adoption_witness_run.cjs` — the pre-existing baseline |
| `npm run lint:js` (root, CI form) — **after** | **0** | **zero findings tree-wide**, no output at all |
| `npm run lint:js` — **after a full spine build** | **0** | re-run with generated output present; rf2-d4bqy's ignore fix still holds |
| `sh scripts/test-fast-pr.sh` | **0** | terminal marker `PASS fast PR spine` present (log line 818 of 822); `gate root:` names this worktree |

Warning count in `adoption_witness_run.cjs`: **3 → 0**, and those three were the only findings in the whole tree, so tree-wide is 3 → 0 as well. No warning was introduced anywhere.

**Tiers skipped, stated rather than implied**: the spine self-classified `docs=false jvm=true node=true`, so the **docs tier did not run** — this diff touches no docs. The JVM and node tiers ran in full. `shellcheck` is not installed in this environment and was not run; no shell script is touched by this diff.

A first `test-fast-pr.sh` attempt was killed by a 10-minute harness cap (exit 143) and **discarded as meaningless** rather than read for signal; the run reported above is a complete re-run whose real exit code was captured to a marker file and whose terminal marker is present.
