### PR TITLE
docs(hicasso): record the SSR ruling as HD-020/EP-0038 addenda; reconcile charter + guide (rf2-2rtt6.83)

### DIFF
--- a/docs/EP/EP-0038-the-hicasso-view-layer-programme.md
+++ b/docs/EP/EP-0038-the-hicasso-view-layer-programme.md
@@ -248,12 +248,78 @@ HALF"). Design record: `docs/design/hicasso/decisions.md` HD-002 (superseded
 blockquote),
 `docs/design/hicasso/studio/arm1-lean-react-dogfood-judgement.md` §2.
 
+### Addendum, 2026-08-04 — SSR + hydration is required Hicasso scope; the programme rides Spec 011
+
+**Operator ruling (Mike), verbatim:** *"SSR is an important part of re-frame2.
+If hicasso is to be the re-frame native view layer then it has to be used with
+SSR"* — **and, earlier the same day, verbatim:** *"hicasso is useless unless it
+does SSR."*
+
+Recorded here per rule 2, and as an addendum rather than an edit per EP-0009
+rule 3 — the wave text and the Non-goals section below are left as written.
+HD-020(d) ("SSR is out of v0") carried its own reopening clause — "at product
+phase (SSR, richer boundary API) by ordinary ruling" — and this is that ruling,
+taken by the operator. The design record carries the matching HD-020 addendum
+(`docs/design/hicasso/decisions.md`).
+
+- **The requirement set, R0–R8.**
+  - **R0 — one SSR story.** Hicasso participates in re-frame2's *existing*
+    Spec 011 (`spec/011-SSR.md`) mechanism — the payload policy, the
+    `#__rf_payload` EDN embed, the `hydrate!` boot helper and the reserved
+    `:rf/hydrate` db adoption before first render, the hydration-mismatch
+    machinery, `ssr-ring` as the HTTP host — **never a parallel Hicasso-only
+    mechanism**.
+  - **R1 — pure server render.** A server render is produced purely from a db
+    snapshot.
+  - **R2 — hydration adopts.** Zero hydration mismatch, server node identity
+    preserved (React adopts the server DOM, never re-creates it), and exactly
+    one body pass.
+  - **R3 — reactivity adopted on hydrateRoot's schedule.** Subscriptions come
+    live on React's own hydration schedule; the settle horizon is best-effort,
+    never a caller contract.
+  - **R4 — the live page.** Events and the controlled door work
+    post-hydration to the `rf2-2rtt6.67` equivalence standard.
+  - **R5 — the `defhost` SSR policy is activated.** HD-011's declared
+    placeholder becomes the real `:ssr` option.
+  - **R6 — the ledger discipline holds server-side.** HD-002's discipline is
+    unbroken on the server: a server render is an abandoned render, leaving
+    zero durable registration.
+  - **R7 — scope is stated known-losses style.**
+  - **R8 — witnesses carry SHA + repro commands.**
+- **Non-goals, explicitly:** streaming, RSC, islands/partial hydration, no-JS
+  progressive enhancement, SEO metadata, and SSR-speed-as-bar — HD-012 and the
+  Motivation's "fast applications, not fast SSR" line stand unchanged.
+- **The sitting linkage — one sitting, no separate gate.** The X1–X5 spike
+  witness on the hydrated dogfood screen (`rf2-2rtt6.87`) is a **required
+  feasibility input** to the P2/HD-013 sitting, and the production-server-arm
+  choice — JVM structural walk (the default direction to be priced) vs Node
+  sidecar (`rf2-2rtt6.88`) — is priced and ruled **at that same sitting**.
+- **A stale blocker, corrected on the record.** The 2026-08-04 audits' claim
+  that the spine's `useSyncExternalStore` lacks `getServerSnapshot` — so
+  "hydration throws by construction" — was stale, refuted independently three
+  times: the spine passes its snapshot fn as both the 2nd and 3rd arguments
+  (`implementation/core/src/re_frame/substrate/spine.cljs:3031`); the arm-1
+  shells do likewise
+  (`implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs:1540`,
+  `:1595`); and the `{:hydrate? true}` adoption-reporter tier ships with DOM
+  tests (`implementation/ssr/src/re_frame/ssr/boot.cljc:202-213`). **No core
+  code change is needed for hydration snapshots.**
+
+Status is honest tense: the hydration door, the `defhost` `:ssr` policy, the
+Node render entry and the spike witness are dispatched as `rf2-2rtt6.84`–`.87`;
+nothing has landed at the time of this addendum. Evidence and full text on
+`rf2-2rtt6` and `rf2-2rtt6.83`.
+
 ## Open Issues
 
 1. The donor-gate ruling (delegated advisory; expected days after P0 publishes).
 2. The P2 fork ruling (operator; end of the tournament). **Narrowed 2026-07-31**
    by the addendum above: the choice between the two Hicasso arms is settled, so
-   what remains is the surviving arm against the null.
+   what remains is the surviving arm against the null. **Amended 2026-08-04** by
+   the SSR addendum above: the sitting additionally takes the X1–X5 SSR spike
+   witness (`rf2-2rtt6.87`) as a required feasibility input, and prices + rules
+   the production-server-arm choice (`rf2-2rtt6.88`) at the same sitting — one
+   sitting, no separate gate.
 3. The HD-002 read-mechanism adjudication (resolved by P1 instrumentation).
    **Narrowed 2026-07-31** by the addendum above: the ergonomics half is
    decided — Surface B (the ambient collector) is the only acceptable read

--- a/docs/design/hicasso/charter.md
+++ b/docs/design/hicasso/charter.md
@@ -154,6 +154,15 @@ render path ships). Deferred past v0: the full buffered/revision input ladder,
 overlay excellence, batteries/library platform, SSR as identity, devtools glass,
 per-keystroke envelopes as a gate.
 
+**Amended 2026-08-04 (operator ruling):** the out-of-v0 SSR posture above is
+superseded — **SSR + hydration is required Hicasso scope** ("hicasso is useless
+unless it does SSR"), through the framework's own Spec 011 story, recorded as
+the HD-020 addendum in [decisions.md](decisions.md) and the same-date EP-0038
+addendum. The sentences above stand as the record of what v0 pre-registered.
+SSR *speed* stays off the bar, and "SSR as identity" stays in the deferred
+list — SSR is a required capability, not the product's identity. In progress as
+beads `rf2-2rtt6.84`–`.87`; nothing has landed yet.
+
 **A. The everyday SPA spine** (where the bar lives)
 1. Ordinary views — the ~50-element form/list/layout shape.
 2. Large templates — the ~1,200-element shape.
@@ -199,6 +208,11 @@ as the dogfood demands)
 14. SSR + hydration surviving production posture. 15. Routing (route-link is
 tier-1). 16. Multi-frame isolation. 17. Hot reload with clean remount semantics.
 18. Time travel, including mounted host state.
+
+**Amended 2026-08-04 (operator ruling):** item 14 is no longer waiting past
+v0 — SSR + hydration is required Hicasso scope, per the same-date note under
+the v0 scope paragraph above and the HD-020 addendum in
+[decisions.md](decisions.md).
 
 **G. Proof and production posture**
 19. Testable without a browser through the public door; structural tests on data

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -577,6 +577,33 @@ candidate second call site appears. The composition value path reopens on
 
 ## HD-020 — v0 host mechanics: frame plumbing, hook ledger, error boundary, SSR posture
 
+> **Addendum, 2026-08-04 — clause (d) is reopened and reversed: SSR + hydration
+> is REQUIRED Hicasso scope (`rf2-2rtt6.83`).** This entry's own Reopens line
+> says "at product phase (SSR, richer boundary API) by ordinary ruling"; this
+> is that ruling, taken by the operator. **Mike, 2026-08-04, verbatim:** *"SSR
+> is an important part of re-frame2. If hicasso is to be the re-frame native
+> view layer then it has to be used with SSR"* — and, earlier the same day:
+> *"hicasso is useless unless it does SSR."*
+>
+> **What is ruled.** SSR + hydration moves from out-of-v0 to required Hicasso
+> scope. Hicasso participates in re-frame2's **existing** SSR story — Spec 011
+> (`spec/011-SSR.md`): the payload policy, the `#__rf_payload` EDN embed, the
+> `hydrate!` boot helper and the reserved `:rf/hydrate` db adoption before
+> first render, the hydration-mismatch machinery, and `ssr-ring` as the HTTP
+> host — **never a parallel Hicasso-only mechanism** (requirement R0). The full
+> requirement set R0–R8, the non-goals, and the P2-sitting linkage are recorded
+> in the same-date addendum in
+> `docs/EP/EP-0038-the-hicasso-view-layer-programme.md`.
+>
+> **What does not move.** SSR *speed* stays off the bar: HD-012 and
+> validation.md's "never SSR or test-lane speed" line stand unchanged. Clauses
+> (a)–(c) of the ruling below — frame plumbing, the hook ledger, the error
+> boundary — stand as written.
+>
+> **Status is honest tense.** The ruling is recorded; nothing has landed. The
+> hydration door, the `defhost` `:ssr` policy, the Node render entry, and the
+> X1–X5 spike witness are in progress as beads `rf2-2rtt6.84`–`.87`.
+
 **Ruling.** (a) **Frame plumbing**: each boundary reads the frame once via the
 substrate's single internal context, then binds it ambiently for the render's
 dynamic extent so inlined helpers and generated callbacks resolve it without

--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -155,10 +155,16 @@ No boot-path error ids are minted yet, so this table names mechanisms rather tha
 
 ## When not to use this
 
-**Server-side rendering is out of v0**, explicitly (HD-020). `defview` bodies stay
-`.cljc`-compatible by construction, so nothing is being painted into a corner, but no
-JVM or SSR render path ships in v0 and `defhost`'s SSR-placeholder default is inert
-policy for a later phase. If you need SSR now, use a
+**Server-side rendering is required Hicasso scope — and none of it has landed
+yet.** HD-020 originally ruled SSR out of v0; the 2026-08-04 operator ruling
+reopened that clause and made SSR + hydration required scope (the HD-020 addendum
+in [decisions.md](../decisions.md) is the record). The story is the framework's
+own Spec 011 mechanism, not a Hicasso-private one: the server embeds the
+`#__rf_payload` EDN payload and the client adopts it through the reserved
+`:rf/hydrate` door before first render. The pieces — the hydration door,
+`defhost`'s `:ssr` policy, the Node render entry and the spike witness — are in
+progress as beads `rf2-2rtt6.84`–`.87`, and no Hicasso SSR or JVM render path
+exists in the tree today. Until they land, an app that needs SSR now still uses a
 [Reagent or UIx adapter](../../../core/views.md), which are first-class and
 supported.
 

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -9,8 +9,10 @@
 > driven from a Hicasso tree. No `implementation/hicasso/` artefact ships yet,
 > though, and spellings marked **[unfrozen]** stay provisional until the API
 > freeze. Three things this page describes are ruled but **not built** — the `[:>]`
-> raw escape, the migration codemod and SSR — and one default, deep prop
-> conversion, is deliberately not offered at all. See **Not settled yet**.
+> raw escape, the migration codemod, and the `defhost` `:ssr` policy (being
+> activated now that the 2026-08-04 ruling made SSR required Hicasso scope —
+> `rf2-2rtt6.85`, in progress) — and one default, deep prop conversion, is
+> deliberately not offered at all. See **Not settled yet**.
 
 You want a date picker from npm. In Reagent you write `[:> DatePicker {...}]` and
 move on. Hicasso asks you to write one line first:
@@ -76,7 +78,7 @@ Reagent was never `[:>]`, it was `r/atom`.
 | Props | shallow camelCase conversion — `:on-change` becomes `onChange` |
 | Children | hiccup children are converted to React elements |
 | Functions | pass through unconverted |
-| SSR | a placeholder (declared policy; inert in v0, since SSR is out of v0 per HD-020) |
+| SSR | `:client-only` — the host region renders nothing server-side. Being activated as the declarable `:ssr` option (`:client-only` default, or `{:fallback <hiccup>}` for pre-adoption placeholder markup) per the 2026-08-04 SSR ruling (HD-020 addendum); in progress as `rf2-2rtt6.85`, not landed |
 
 Policy overrides live on the declaration rather than at the call site, which is the
 whole point: one place decides how this component is crossed, and every use site
@@ -427,9 +429,9 @@ two or three genuinely hard widgets.
 
 | Question | Status |
 |---|---|
-| Whether `defhost` grows a second option beyond `:callbacks` | **Not addressed.** HD-011 names strong defaults and "policy overrides on the declaration", and `:callbacks` is the only override the landed door carries. Whether the SSR placeholder or the conversion defaults ever become declarable is unstated |
+| Whether `defhost` grows a second option beyond `:callbacks` | **Settled for SSR, in progress.** The 2026-08-04 SSR ruling activates the placeholder as the second option: `:ssr`, taking `:client-only` (the default) or `{:fallback <hiccup>}`, any other value refused at mint time (`rf2-2rtt6.85`; not landed — `:callbacks` is still the only override the landed door carries). Whether the conversion defaults ever become declarable is still unstated |
 | The migration codemod | **Ruled, unbuilt.** HD-011's rationale leans on it, but nothing has been built and the record names neither a tool nor an invocation |
 | When the reserved `{:ref [id config]}` spelling lands, and what registers an id | **Reserved, not designed.** HD-022 rules the refusal and the value-space; the registry, the timings and the commands roster are explicitly out of v0 |
 | Which React version the runtime targets | **Not addressed by the design record.** The cleanup-returning callback ref taught above is a React 19 contract; this repo's implementation currently pins React 19.2, but that is a fact about today's tree, not a Hicasso ruling. If v0 lands on 18, the fallback shape above is the one to teach |
-| The SSR placeholder's shape | Declared policy, inert in v0 |
+| The SSR placeholder's shape | **Ruled 2026-08-04, unbuilt.** `:ssr` — `:client-only` (default) or `{:fallback <hiccup>}`, refusal on anything else (`rf2-2rtt6.85`). Today the landed door reads only `:callbacks`, so no placeholder exists in the tree, inert or otherwise |
 | Embedding Hicasso *inside* a React-primary app | Named in the charter's use-case roster (item 11); no surface designed |


### PR DESCRIPTION
Records the 2026-08-04 operator ruling (Mike, verbatim on the bead): "SSR is an important part of re-frame2. If hicasso is to be the re-frame native view layer then it has to be used with SSR" — and earlier the same day, "hicasso is useless unless it does SSR". HD-020(d) ("SSR is out of v0") is reopened via its own Reopens clause; this PR is the design-record landing of that ruling. Docs only; no code. Bead: rf2-2rtt6.83.

## Files

- **docs/design/hicasso/decisions.md** — dated addendum blockquote atop HD-020 (HD-019 IME-addendum format, model 0342d3787d): SSR + hydration is required Hicasso scope; rides the existing Spec 011 story (payload policy, `#__rf_payload` EDN embed, `hydrate!` + reserved `:rf/hydrate` adoption before first render, mismatch machinery, ssr-ring), never a parallel Hicasso-only mechanism (R0); SSR speed stays off the bar; clauses (a)-(c) stand; honest-tense status (beads rf2-2rtt6.84-.87 in progress, nothing landed). Original entry text untouched.
- **docs/EP/EP-0038-the-hicasso-view-layer-programme.md** — new "### Addendum, 2026-08-04" under Resolved Decisions (template of the two 2026-07-31 addenda): verbatim ruling, the R0-R8 requirement set, the non-goals (streaming, RSC, islands/partial hydration, no-JS progressive enhancement, SEO metadata, SSR-speed-as-bar), the sitting linkage (X1-X5 spike witness rf2-2rtt6.87 is a required feasibility input to the P2/HD-013 sitting; the production-server-arm choice rf2-2rtt6.88 is priced and ruled at that same sitting — one sitting, no separate gate), and the stale-blocker correction recorded in this one place: the spine already passes getServerSnapshot both-args (spine.cljs:3031; arm1 runtime.cljs:1540/:1595; boot.cljc:202-213 adoption reporter) — no core change needed for hydration snapshots. All three cited line references re-verified against this tree before recording. Open Issue 2 carries a matching "Amended 2026-08-04" sitting-linkage note, mirroring the prior addenda's narrowing pattern.
- **docs/design/hicasso/charter.md** — two conforming notes in the K5-note style (model 417fd06c65), originals kept visible: one after the v0-scope paragraph ("SSR is explicitly out of v0" superseded; "SSR as identity" stays deferred — required capability, not identity), one after use-case item 14 (no longer waiting past v0).
- **docs/design/hicasso/draft-guide/01-getting-started.md** — the "When not to use this" SSR passage rewritten: required scope per the ruling, the framework's own Spec 011 story, strictly honest tense (rf2-2rtt6.84-.87 in progress, no Hicasso SSR path exists today, an app needing SSR now still uses a first-class adapter). Respects the guide's no-unbuilt-doors discipline (rf2-2rtt6.64, d85a98620d).
- **docs/design/hicasso/draft-guide/05-interop.md** — four sites updated (intro blockquote, defaults-table SSR row, the two Not-settled-yet rows): the placeholder is being activated as the defhost `:ssr` option (`:client-only` default | `{:fallback <hiccup>}`, mint-time refusal otherwise) per rf2-2rtt6.85; ruled shape, in progress, honest tense — including that today's landed door reads only `:callbacks`, so no placeholder exists in the tree, inert or otherwise.

## Deliberately left unchanged

- `validation.md:203` (SSR speed off the bar) — the ruling preserves it, per the bead.
- `architecture.md:156` ("an SSR/hydration story of its own") — sits inside the WITHDRAWN Arm-2 section under its 2026-07-31 banner, describing the retired arm's own hard-gated obligation; historical record, does not mislead about the current posture, so no note added per the bead's "only if it now misleads" test.
- HD-011's ruling text, `authoring.md`'s defhost comment, HD-010/HD-012 rationales, theming page — restatements of declared policy or preserved posture, not contradictions; the HD-011 addendum belongs to sibling bead rf2-2rtt6.85.
- `docs/EP/README.md` row summary — outside this bead's fence (docs/design/hicasso/** + the EP-0038 file only); prior addenda appended a row clause there, so flagging for the mayor in case a follow-up is wanted.

## Verification

`python scripts/check_doc_slugs.py` exit 0. This tree is outside `mkdocs build --strict` coverage, so I hand-verified every anchor and table: exactly one heading was added (the EP addendum) and no existing heading was modified anywhere, so all inbound anchors remain valid; every changed table row was counted by hand at 2 cells, matching both affected 2-column tables; both added `decisions.md` link targets and the retained `core/views.md` target exist on disk.

Bead: rf2-2rtt6.83 (closes on merge per tracker convention).