### PR TITLE
feat(hicasso): defhost's :ssr policy (rf2-2rtt6.85)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -258,6 +258,59 @@ instance props can express.
 
 ## HD-011 — The interop door
 
+> **Addendum, 2026-08-04 — the SSR placeholder listed among the defaults below
+> is BUILT, and it is a declaration option with two values (`rf2-2rtt6.85`).**
+> HD-020(d) held this default "declared policy for later phases, inert in v0";
+> the operator's same-date SSR ruling (HD-020's addendum, `rf2-2rtt6.83`) makes
+> SSR required scope, so it is activated here. The 2026-08-04 runtime audit
+> found it was not inert but **absent**: `mint-host!` read `:callbacks` and
+> silently ignored every other option, so a policy could be written and never
+> applied.
+>
+> **The spelling.** `defhost`'s `opts` carry `:ssr`, whose value is either
+> `:client-only` — the **default**, applied when `:ssr` is absent — or
+> `{:fallback <hiccup>}`. `:client-only` renders nothing where the host sits
+> until the client has adopted the markup; `{:fallback …}` renders that markup
+> there instead. There is no third value. The conservative default is the
+> honest one: a foreign React component is exactly the node whose render may
+> reach for `window`, and a declaration that names only the component tells the
+> door nothing about that.
+>
+> **Everything is refused at the declaration**, where this record already puts
+> every other host refusal. A third `:ssr` value, an explicit `nil`, an empty
+> or multi-key fallback map, and a fallback that is not hiccup all raise
+> `:rf.error/hicasso-host-bad-ssr-policy` or the walk's own error at mint —
+> the fallback is walked once, there. **And an option `defhost` does not know
+> is now refused rather than ignored** (`:rf.error/hicasso-host-unknown-option`,
+> roster `#{:callbacks :ssr}`): the silent-ignore was its own defect, of the
+> same class as an intent crossing to a library as inert data.
+>
+> **One mechanism, three places.** A declaration mints one gate — a component
+> whose single `useSyncExternalStore` answers `false` from its **server**
+> snapshot and `true` from its client one. React reads the server snapshot
+> under `renderToString` **and again on hydration's first client pass**, then
+> re-renders with the client snapshot once adoption completes. So the server
+> render honours the policy by rendering rather than by consulting it, the
+> first client pass produces what the server produced (there is no mismatch to
+> reconcile, which is asserted against React's own `onRecoverableError` rather
+> than by reading the settled DOM), and a fresh `createRoot` mount — which
+> never consults a server snapshot — renders the foreign component on its first
+> pass with no placeholder flash. A server walk therefore needs no policy
+> branch of its own.
+>
+> **The cost, because it changed a property this record claimed.** The door
+> used to mint no wrapper, no fiber and no hook: the foreign component was the
+> element's own type. It now mints one gate per declaration, so a crossing
+> costs **one fiber and one hook**. HD-020(b)'s ≤2-hook budget is untouched and
+> still means what it said — it is a statement about Hicasso's **boundary**
+> shells, `shell-hook-ledger` still declares two, and the gate is not a
+> boundary: it holds no subscription, reads no frame and runs no body. The
+> hosted-page hook census was updated to state the new truth rather than
+> deleted, and now reads the shell's two, then the door's one, then nothing
+> that is not the hosted component's own roster. Witnessed in
+> `arm1/host_ssr_dom_cljs_test` (declaration, server render, fresh mount,
+> hydration) and `arm1/host_hatch_dom_cljs_test` (the hook census).
+
 **Ruling.** **`defhost` is the door, and the only form taught**: a one-line
 declaration with strong defaults (shallow camelCase props, hiccup children →
 elements, functions pass through, SSR placeholder), policy overrides on the

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
@@ -29,13 +29,20 @@
 
   HD-020's ≤2-hook budget is a statement about HICASSO'S OWN boundary
   shells. The hosted component's hooks are its own affair — that
-  distinction is the whole point of the door — and the door itself mints
-  NO wrapper component, no fiber and no hook: the foreign component is
-  the element's own type, lowered at the crossing inside the parent
-  boundary's render window. The dispatcher-level probe below reads the
-  shell's two hooks first, exactly one subscription hook on the whole
-  page, and nothing after the shell that is not the widget's own
-  roster.
+  distinction is the whole point of the door — and the dispatcher-level
+  probe below is what measures the difference rather than asserting it.
+
+  **The door's own cost changed with rf2-2rtt6.85**, and this suite is
+  where the change is visible. Until HD-011's SSR placeholder was
+  activated the door minted no wrapper, no fiber and no hook: the
+  foreign component was the element's own type. Activating the policy
+  gives every declaration ONE gate — the component that renders the
+  placeholder until the markup is adopted and the foreign component
+  afterwards — so a crossing now costs one fiber and one
+  `useSyncExternalStore`. The budget itself is untouched: `shell-hook-
+  ledger` still declares two, the gate holds no subscription and reads
+  no frame, and the probe below counts the shell's two, then the door's
+  one, then nothing that is not the widget's own roster.
 
   ## The gap this suite found, and the half only the door can witness
 
@@ -867,7 +874,7 @@
 ;; 6 — the hook budget distinction, at React's own dispatcher
 ;; ---------------------------------------------------------------------------
 
-(deftest the-door-adds-no-hicasso-hook-and-the-hosted-hooks-are-its-own
+(deftest the-door-spends-one-hook-and-the-hosted-hooks-are-its-own
   (if-not (mount/browser?)
     (skip! ":node-test has no DOM")
     (if-not (probe/install!)
@@ -885,20 +892,25 @@
           (try
             (is (= ["useContext" "useSyncExternalStore"] (vec (take 2 names)))
                 (str "the shell's two hooks come FIRST, with nothing before "
-                     "them — the door minted no wrapper and spent no hook on "
-                     "the way to the foreign component: " (pr-str names)))
-            (is (every? #{"useContext" "useState" "useEffect"} (drop 2 names))
-                (str "and EVERYTHING after them is the widget's own roster — "
+                     "them: " (pr-str names)))
+            (is (= "useSyncExternalStore" (nth names 2 nil))
+                (str "then the door's ONE hook — the SSR gate's adoption "
+                     "read (rf2-2rtt6.85), and the whole of what a crossing "
+                     "costs: " (pr-str names)))
+            (is (every? #{"useContext" "useState" "useEffect"} (drop 3 names))
+                (str "and EVERYTHING after it is the widget's own roster — "
                      "useContext/useState/useEffect, however React's dev "
                      "dispatcher counts its reads of them. No useRef, no "
-                     "useCallback, no useMemo, and no hook of Hicasso's: "
+                     "useCallback, no useMemo, and no further hook of "
+                     "Hicasso's: " (pr-str names)))
+            (is (= 2 (count (filter #{"useSyncExternalStore"} names)))
+                (str "exactly TWO on the whole page — the boundary's "
+                     "subscription and the door's gate, and no third: "
                      (pr-str names)))
-            (is (= 1 (count (filter #{"useSyncExternalStore"} names)))
-                (str "exactly ONE subscription hook on the whole page — the "
-                     "one boundary's. HD-020's ≤2 budget is a statement about "
-                     "Hicasso's boundaries; the hosted component's hooks are "
-                     "its own affair, and that distinction is the door's "
-                     "whole point: " (pr-str names)))
+            (is (= 2 (count rt/shell-hook-ledger))
+                (str "and HD-020(b)'s ≤2 budget is untouched by the gate, "
+                     "which is not a boundary: it holds no subscription and "
+                     "reads no frame. " (pr-str rt/shell-hook-ledger)))
             (finally (mount/release! @handle))))))))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_ssr_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_ssr_dom_cljs_test.cljs
@@ -1,0 +1,402 @@
+(ns re-frame.bench.hicasso.arm1.host-ssr-dom-cljs-test
+  "DEFHOST'S `:ssr` POLICY, PROVEN IN ALL THREE PLACES IT HAS TO HOLD
+  (rf2-2rtt6.85, HD-011).
+
+  HD-011 listed \"SSR placeholder\" among `defhost`'s strong defaults;
+  HD-020(d) left it inert in v0; the operator's 2026-08-04 ruling makes
+  SSR required scope. The 2026-08-04 runtime audit then found the
+  placeholder was not inert but ABSENT — `mint-host!` read `:callbacks`
+  and silently ignored every other option — so activating it is two
+  jobs: give the declaration a policy, and make an option it does not
+  know a refusal rather than a shrug.
+
+  ## The policy
+
+      (defhost chart Chart)                                ; :client-only
+      (defhost chart Chart {:ssr :client-only})            ; the same, said
+      (defhost chart Chart {:ssr {:fallback [:div.skel]}}) ; markup instead
+
+  `:client-only` renders nothing where the host sits until the client
+  has adopted the markup. `{:fallback <hiccup>}` renders that markup
+  there instead. There is no third value.
+
+  ## The three places, and why ONE mechanism covers them
+
+  A declaration mints one gate — a component whose single
+  `useSyncExternalStore` answers `false` from its SERVER snapshot and
+  `true` from its client one. React reads the server snapshot under
+  `renderToString` AND again on hydration's first client pass, then
+  re-renders with the client snapshot once adoption completes. So:
+
+  1. **The server render** honours the policy without a server walk
+     that knows anything about it — it honours it by rendering.
+  2. **Hydration's first client pass** produces the same markup the
+     server did, so there is nothing to reconcile. That claim is taken
+     here the only way it can be taken honestly: React is asked, via
+     `onRecoverableError` and a console/window capture, whether it
+     found a mismatch. A row that merely asserts the final DOM would
+     pass over a mismatch React silently repaired.
+  3. **A fresh `createRoot` mount** never consults a server snapshot at
+     all, so the foreign component renders on the very first pass and
+     the placeholder never flashes. Asserted on the line after
+     `root!` returns, which is inside its own `flushSync`.
+
+  ## The mutation witnesses
+
+  Make `:client-only` render something — `gate-unadopted` answering
+  `true`, or the placeholder becoming the live element — and
+  [[client-only-hydrates-with-nothing-there-and-mounts-after-adoption]]
+  goes red on React's own mismatch report. Make `{:fallback …}` render
+  nothing — `mint-host-gate!`'s `placeholder` forced to `nil` — and
+  [[the-server-render-honours-the-policy]] goes red on the fallback
+  markup missing from the server HTML. Neither mutation is visible to
+  the other row, which is why there are two.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM. The declaration rows and the `renderToString` rows need no
+  DOM and run under `:node-test` too — `renderToString` is React's
+  server renderer, and the point of using it here is that it is the
+  same runtime the sibling Node entry (rf2-2rtt6.86) drives."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom/client" :as react-dom-client]
+            ["react-dom/server" :as react-dom-server])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview defhost]]))
+
+(def ^:private frame-id ::host-ssr)
+
+;; Registered above `use-fixtures`, deliberately — the reset fixture
+;; captures its source-store baseline when the `use-fixtures` form is
+;; evaluated (the sibling suites' convention).
+
+(rf/reg-sub :ssr/title (fn [db _] (:title db)))
+
+(rf/reg-event :ssr/seed (fn [_ _] {:db {:title "quarterly"}}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     ;; the hydration rows wait on a real clock, and `cljs.test`
+     ;; hard-errors on a fn-form fixture in a suite with an async test.
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(defn- skip! [why] (is true (str "an SSR-policy DOM claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (lane/leave-act-environment!)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:ssr/seed]))
+  frame-id)
+
+;; ---------------------------------------------------------------------------
+;; The foreign component, and the three declarations
+;; ---------------------------------------------------------------------------
+
+(def ^:private !renders
+  "How many times the foreign component's body ran. The server rows'
+  strongest assertion: a `:client-only` host is not merely absent from
+  the HTML, its component was never INVOKED — which is the property an
+  author relies on when the reason they declared `:client-only` is
+  that the thing reaches for `window`."
+  (atom 0))
+
+(defn- chart
+  "A stand-in for the library nobody wants running on a server: its own
+  state, its own effect, its own DOM."
+  [^js props]
+  (swap! !renders inc)
+  (let [ready-hook (react/useState "cold")
+        ready      (aget ready-hook 0)
+        set-ready  (aget ready-hook 1)]
+    (react/useEffect (fn [] (set-ready "warm") js/undefined) #js [])
+    (react/createElement "div"
+      #js {:className "chart" :data-live "yes" :data-ready ready}
+      (react/createElement "span" #js {:className "chart-label"} (.-label props))
+      (.-children props))))
+
+(defhost bare-chart
+  "No `:ssr` written at all — the default is what an author gets."
+  chart)
+
+(defhost client-only-chart chart {:ssr :client-only})
+
+(defhost fallback-chart chart
+  {:ssr {:fallback [:div.chart-skeleton {:data-live "no"} "loading"]}})
+
+;; ---------------------------------------------------------------------------
+;; The pages
+;; ---------------------------------------------------------------------------
+
+(defview client-only-page
+  "A native sibling beside the host, so \"the host is absent\" is
+  distinguishable from \"nothing rendered at all\"."
+  [_]
+  [:div.page
+   [:h1.title (rt/sub [:ssr/title])]
+   [client-only-chart {:label (rt/sub [:ssr/title])}]])
+
+(defview fallback-page
+  [_]
+  [:div.page
+   [:h1.title (rt/sub [:ssr/title])]
+   [fallback-chart {:label (rt/sub [:ssr/title])}]])
+
+(defview slotted-page
+  "Children and props still cross the door — the gate forwards its own
+  props object, so this is the regression guard for the crossing that
+  the gate now sits in front of."
+  [_]
+  [:div.page
+   [fallback-chart {:label (rt/sub [:ssr/title])}
+    [:span.kid "slotted"]]])
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- error-id [f]
+  (try (f) ::did-not-throw (catch :default e (:rf.error/id (ex-data e)))))
+
+(defn- server-html
+  "The page as a server render — the SAME runtime, under React's server
+  renderer, which is the sibling Node entry's whole architecture
+  (rf2-2rtt6.86) reduced to one call."
+  [hiccup]
+  (react-dom-server/renderToString
+    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+
+(defn- q [root sel] (.querySelector root sel))
+
+(defn- watch-errors!
+  "Everything React has to say about a hydration, from all three
+  channels it uses. `console.error` is the one that carries the
+  mismatch diff; `onRecoverableError` is the one that carries the
+  recovery; a `window` error listener is here because React routes a
+  throw during a commit to `reportError`, where `cljs.test` cannot see
+  it and a row would read 0 failures over a live exception."
+  []
+  (let [seen     (atom [])
+        original (.-error js/console)
+        on-error (fn [e] (swap! seen conj (str "window: " (.-message e))))]
+    (set! (.-error js/console)
+          (fn [& args] (swap! seen conj (str "console.error: " (pr-str (vec args))))))
+    (.addEventListener js/window "error" on-error)
+    {:seen    seen
+     :restore (fn []
+                (set! (.-error js/console) original)
+                (.removeEventListener js/window "error" on-error))}))
+
+(defn- hydrate!
+  "`hydrateRoot` over server HTML, plainly — no `flushSync`, because the
+  claim under test is about the schedule the browser actually runs."
+  [container element seen]
+  (react-dom-client/hydrateRoot
+    container element
+    #js {:onRecoverableError
+         (fn [err _info]
+           (swap! seen conj (str "onRecoverableError: " (ex-message err))))}))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the declaration (these rows run under :node-test too)
+;; ---------------------------------------------------------------------------
+
+(deftest the-default-policy-is-client-only
+  (testing "an author who writes no :ssr gets the conservative answer, and
+            an author who writes it explicitly gets the same one — a
+            foreign component is exactly the node whose render may reach
+            for `window`, and the door does not guess"
+    (is (= :client-only (codec/host-ssr bare-chart)))
+    (is (= :client-only (codec/host-ssr client-only-chart))))
+  (testing "and a declared fallback reads back as the data it was written as"
+    (is (= {:fallback [:div.chart-skeleton {:data-live "no"} "loading"]}
+           (codec/host-ssr fallback-chart)))))
+
+(deftest the-declaration-refuses-a-policy-it-cannot-honour
+  (testing "a third value is refused at the declaration, naming the two"
+    (is (= :rf.error/hicasso-host-bad-ssr-policy
+           (error-id #(codec/mint-host! "ssr/server" chart {:ssr :server}))))
+    (is (= :rf.error/hicasso-host-bad-ssr-policy
+           (error-id #(codec/mint-host! "ssr/true" chart {:ssr true})))))
+  (testing "an explicit nil is a value, not an absence — `:client-only` is
+            the default of an ABSENT key, and inferring it from nil is how
+            a typo becomes a policy"
+    (is (= :rf.error/hicasso-host-bad-ssr-policy
+           (error-id #(codec/mint-host! "ssr/nil" chart {:ssr nil})))))
+  (testing "a fallback map is exactly one key with a value"
+    (is (= :rf.error/hicasso-host-bad-ssr-policy
+           (error-id #(codec/mint-host! "ssr/empty" chart {:ssr {}}))))
+    (is (= :rf.error/hicasso-host-bad-ssr-policy
+           (error-id #(codec/mint-host! "ssr/nil-fb" chart {:ssr {:fallback nil}}))))
+    (is (= :rf.error/hicasso-host-bad-ssr-policy
+           (error-id #(codec/mint-host! "ssr/extra" chart
+                                        {:ssr {:fallback [:div] :timeout 3}})))))
+  (testing "and a fallback that is not hiccup fails HERE, at the
+            declaration, rather than one render into a server response —
+            it is walked once at mint, where the author's stack is"
+    (is (= :rf.error/hicasso-empty-vector
+           (error-id #(codec/mint-host! "ssr/bad-fb" chart {:ssr {:fallback []}}))))))
+
+(deftest the-declaration-refuses-an-option-it-does-not-know
+  (testing "`mint-host!` read :callbacks and IGNORED the rest, so a
+            misspelled policy was a setting that never applied — the same
+            defect class as an intent crossing as inert data, and it gets
+            the same refusal"
+    (is (= :rf.error/hicasso-host-unknown-option
+           (error-id #(codec/mint-host! "ssr/typo" chart {:sssr :client-only}))))
+    (is (= :rf.error/hicasso-host-unknown-option
+           (error-id #(codec/mint-host! "ssr/legacy" chart
+                                        {:callbacks {} :hydrate? true})))))
+  (testing "while the two it does know are accepted together"
+    (is (some? (codec/mint-host! "ssr/both" chart
+                                 {:callbacks {:on-pick :event}
+                                  :ssr       {:fallback [:div.s]}})))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the server render (no DOM needed; runs under :node-test too)
+;; ---------------------------------------------------------------------------
+
+(deftest the-server-render-honours-the-policy
+  (fresh!)
+  (testing ":client-only — the host region is ABSENT from the server HTML,
+            and the component was never even invoked"
+    (reset! !renders 0)
+    (let [html (server-html [client-only-page {}])]
+      (is (re-find #"quarterly" html)
+          (str "the page rendered — the sibling native node is there: " html))
+      (is (not (re-find #"class=\"chart\"" html))
+          (str "and the host region rendered NOTHING: " html))
+      (is (zero? @!renders)
+          "the foreign component's body never ran on the server, which is
+           the property an author declaring :client-only is relying on")))
+  (testing "{:fallback …} — the declared markup is what the server writes,
+            and still not the component"
+    (reset! !renders 0)
+    (let [html (server-html [fallback-page {}])]
+      (is (re-find #"chart-skeleton" html)
+          (str "the fallback hiccup is in the server HTML: " html))
+      (is (not (re-find #"data-live=\"yes\"" html))
+          (str "and the foreign component's own markup is not: " html))
+      (is (zero? @!renders)
+          "nor did its body run"))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — a fresh mount: no placeholder, ever
+;; ---------------------------------------------------------------------------
+
+(deftest a-fresh-mount-renders-the-component-on-its-first-pass
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (testing "a `createRoot` mount never consults a server snapshot, so
+                neither policy costs a placeholder pass — asserted on the
+                line after `root!` returns, which is inside its flushSync"
+        (let [a (mount/root! (mount/fresh-container!) frame-id [client-only-page {}])]
+          (try
+            (is (some? (q (:container a) ".chart"))
+                ":client-only mounted its component immediately")
+            (is (= "yes" (.getAttribute (q (:container a) ".chart") "data-live"))
+                "and it is the real one")
+            (finally (mount/release! a))))
+        (let [b (mount/root! (mount/fresh-container!) frame-id [fallback-page {}])]
+          (try
+            (is (some? (q (:container b) ".chart"))
+                "{:fallback …} mounted its component immediately too")
+            (is (nil? (q (:container b) ".chart-skeleton"))
+                "and the placeholder never flashed — a fallback is for the
+                 server's markup, not for a client that has none")
+            (finally (mount/release! b))))))))
+
+(deftest the-gate-forwards-props-and-children-untouched
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (testing "the gate hands its own props straight through, so the
+                crossing is the object `host-element` built — the door's
+                contract is unchanged by the policy sitting in front of it"
+        (let [h (mount/root! (mount/fresh-container!) frame-id [slotted-page {}])]
+          (try
+            (is (= "quarterly" (.-textContent (q (:container h) ".chart-label")))
+                "a declared prop reached the foreign component")
+            (is (some? (q (:container h) ".chart .kid"))
+                "and so did the children, in the component's own slot")
+            (finally (mount/release! h))))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — hydration: the first client pass matches, and adoption swaps
+;; ---------------------------------------------------------------------------
+
+(defn- hydration-row
+  "Bake the page on the server, hydrate that HTML, and answer what React
+  reported. Shared by the two policies because the difference between
+  them is the markup, not the procedure."
+  [hiccup after]
+  (fresh!)
+  (reset! !renders 0)
+  (let [html      (server-html hiccup)
+        container (mount/fresh-container!)
+        {:keys [seen restore]} (watch-errors!)]
+    (set! (.-innerHTML container) html)
+    (let [root (hydrate! container
+                         (mount/provider frame-id (codec/root-element frame-id hiccup))
+                         seen)]
+      (js/setTimeout
+        (fn []
+          (try
+            (after container @seen)
+            (finally
+              (restore)
+              (.unmount root)
+              (when-some [p (.-parentNode container)] (.removeChild p container))
+              (rt/reset-runtime!))))
+        150))))
+
+(deftest client-only-hydrates-with-nothing-there-and-mounts-after-adoption
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (hydration-row
+        [client-only-page {}]
+        (fn [container seen]
+          (is (empty? seen)
+              (str "REACT FOUND NOTHING TO RECONCILE. The client's first "
+                   "pass rendered what the server did — nothing — so there "
+                   "was no mismatch to repair. This is the row that goes "
+                   "red if the gate stops gating: " (pr-str seen)))
+          (is (some? (q container ".chart"))
+              "and after adoption the foreign component is mounted")
+          (is (= "yes" (.getAttribute (q container ".chart") "data-live"))
+              "the real one, not a placeholder")
+          (is (some? (q container ".title"))
+              "with the server's own markup still in place around it —
+               adoption, not a re-render of the page")
+          (is (pos? @!renders)
+              "the component ran on the client, and only on the client")
+          (done))))))
+
+(deftest a-fallback-hydrates-as-the-placeholder-and-is-swapped-after-adoption
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (hydration-row
+        [fallback-page {}]
+        (fn [container seen]
+          (is (empty? seen)
+              (str "the fallback the server wrote is what the client's "
+                   "first pass rendered, so again there was nothing to "
+                   "reconcile: " (pr-str seen)))
+          (is (nil? (q container ".chart-skeleton"))
+              "and the placeholder is GONE after adoption")
+          (is (some? (q container ".chart"))
+              "replaced by the foreign component")
+          (done))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_ssr_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_ssr_dom_cljs_test.cljs
@@ -338,8 +338,10 @@
 
 (defn- hydration-row
   "Bake the page on the server, hydrate that HTML, and answer what React
-  reported. Shared by the two policies because the difference between
-  them is the markup, not the procedure."
+  reported — plus the HTML it hydrated FROM, because a row that only
+  reads the settled DOM cannot tell a policy that worked from a policy
+  that was never applied on either side. Shared by the two policies
+  because the difference between them is the markup, not the procedure."
   [hiccup after]
   (fresh!)
   (reset! !renders 0)
@@ -353,7 +355,7 @@
       (js/setTimeout
         (fn []
           (try
-            (after container @seen)
+            (after container @seen html)
             (finally
               (restore)
               (.unmount root)
@@ -367,12 +369,16 @@
       (do (skip! ":node-test has no DOM") (done))
       (hydration-row
         [client-only-page {}]
-        (fn [container seen]
+        (fn [container seen html]
+          (is (not (re-find #"class=\"chart\"" html))
+              (str "the markup hydrated FROM has no host region in it — the "
+                   "row's own restatement of the policy, so that a gate "
+                   "which stopped gating is red HERE and not only in the "
+                   "server-render row: " html))
           (is (empty? seen)
               (str "REACT FOUND NOTHING TO RECONCILE. The client's first "
                    "pass rendered what the server did — nothing — so there "
-                   "was no mismatch to repair. This is the row that goes "
-                   "red if the gate stops gating: " (pr-str seen)))
+                   "was no mismatch to repair: " (pr-str seen)))
           (is (some? (q container ".chart"))
               "and after adoption the foreign component is mounted")
           (is (= "yes" (.getAttribute (q container ".chart") "data-live"))
@@ -390,7 +396,10 @@
       (do (skip! ":node-test has no DOM") (done))
       (hydration-row
         [fallback-page {}]
-        (fn [container seen]
+        (fn [container seen html]
+          (is (re-find #"chart-skeleton" html)
+              (str "the markup hydrated FROM carries the declared fallback: "
+                   html))
           (is (empty? seen)
               (str "the fallback the server wrote is what the client's "
                    "first pass rendered, so again there was nothing to "

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj
@@ -81,8 +81,22 @@
 
   `opts` is optional and carries `:callbacks` — a FINITE map from exact
   prop names to `:event`, `:handler` or `:render`, never inferred from an
-  `on*` spelling. Policy lives on the declaration, so every use site
-  inherits it; the defaults, the refusals and the crossing itself are
+  `on*` spelling — and `:ssr`, the placeholder policy:
+
+      (defhost chart Chart
+        {:ssr {:fallback [:div.chart-skeleton]}})
+
+  `:ssr :client-only` is the DEFAULT and needs no writing: the host
+  region renders nothing on the server and nothing on hydration's first
+  client pass, and the foreign component mounts once the markup is
+  adopted. `{:fallback <hiccup>}` renders that markup there instead.
+  A fresh (non-hydrated) mount renders the foreign component on its
+  first pass under either policy — the placeholder never flashes. There
+  is no third value, and an option `defhost` does not know is refused
+  rather than ignored.
+
+  Policy lives on the declaration, so every use site inherits it; the
+  defaults, the refusals and the crossing itself are
   [[re-frame.bench.hicasso.front.codec/mint-host!]]'s.
 
   The callback is an [[hfn]] and not an intent vector because

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -42,6 +42,11 @@
   is to trust the programmer). `defhost` — HD-011's taught door — is
   NOT absent any more: [[mint-host!]] is the declaration and the host
   head is the fourth element class, §Host heads below (rf2-2rtt6.65).
+  Neither is HD-011's SSR placeholder, which HD-020(d) left inert until
+  the operator ruled SSR into scope: `:ssr` is a declaration option
+  with two values, and [[mint-host-gate!]] is the one mechanism that
+  serves the server render, hydration's first client pass and a fresh
+  `createRoot` mount alike (rf2-2rtt6.85).
 
   ## Codec-work caching only (HD-004)
 
@@ -964,6 +969,42 @@
 ;; `:onPick` name the same slot, so the declaration binds however the
 ;; author spells the prop — while an undeclared `onFoo` never becomes an
 ;; event position no matter how event-shaped its name is.
+;;
+;; ## The `:ssr` policy — HD-011's placeholder, activated (rf2-2rtt6.85)
+;;
+;; HD-011 listed "SSR placeholder" among `defhost`'s strong defaults and
+;; HD-020(d) left it inert; the operator's 2026-08-04 ruling makes SSR
+;; required scope, so the placeholder is now real. TWO VALUES, and the
+;; author writes at most one of them:
+;;
+;;     :ssr :client-only        ; THE DEFAULT — omit :ssr and this is it
+;;     :ssr {:fallback <hiccup>}
+;;
+;; `:client-only` renders NOTHING where the host sits until the client
+;; has adopted the markup; `{:fallback …}` renders that hiccup there
+;; instead. Anything else is refused at the declaration. The default is
+;; the conservative one because a foreign React component is exactly the
+;; node whose render may reach for `window` — the door cannot know, so it
+;; does not guess.
+;;
+;; **ONE mechanism serves the server, the hydration pass and the fresh
+;; mount**, and it is [[mint-host-gate!]]: a one-hook component whose
+;; `useSyncExternalStore` answers `false` from its SERVER snapshot and
+;; `true` from its client one. React reads the server snapshot under
+;; `renderToString` and again on hydration's first client pass, then
+;; re-renders with the client snapshot once adoption completes — so the
+;; server HTML and the first client pass agree BY CONSTRUCTION (no
+;; mismatch to reconcile), and a `createRoot` mount, which never consults
+;; a server snapshot at all, renders the foreign component on its very
+;; first pass with no placeholder flash. A server walk therefore does not
+;; have to consult the policy separately; it consults it by rendering.
+;;
+;; **The price, stated because it changed** (rf2-2rtt6.85): the door used
+;; to mint no wrapper, no fiber and no hook — the foreign component was
+;; the element's own type. It now mints ONE gate per declaration, so a
+;; crossing costs one fiber and one hook. HD-020(b)'s ≤2 budget is a
+;; statement about Hicasso's BOUNDARY shells and is untouched: the gate
+;; is not a boundary, holds no subscription, and reads no frame.
 
 (def ^:private host-marker "hicassoHost")
 
@@ -971,6 +1012,80 @@
   "The three contracts a declaration may name — the position table's
   roster in `front.intent`, verbatim."
   #{:event :handler :render})
+
+(def ^:private host-options
+  "Every key a declaration may carry. [[mint-host!]] read `:callbacks`
+  and SILENTLY IGNORED everything else until rf2-2rtt6.85 — so a
+  misspelled `:ssr`, or a policy invented by an author reading the
+  wrong docstring, was a no-op that looked like a setting. That is the
+  same defect class as an intent crossing as inert data, and it gets
+  the same treatment: refused, at the declaration."
+  #{:callbacks :ssr})
+
+;; --- The gate -------------------------------------------------------------
+;;
+;; Three module-level functions rather than literals written at the call
+;; site: `useSyncExternalStore` compares the subscribe function by
+;; identity and re-subscribes when it changes, and a fresh closure per
+;; render would make every host re-subscribe on every render for no
+;; reason at all. There is nothing to subscribe TO — adoption happens
+;; once and never un-happens — so the subscribe function's whole body is
+;; the unsubscribe it must return.
+
+(def ^:private gate-no-subscribe (fn [_] (fn [] nil)))
+(def ^:private gate-adopted (fn [] true))
+(def ^:private gate-unadopted (fn [] false))
+
+(defn- mint-host-gate!
+  "The one component a declaration mints: the foreign component behind
+  its `:ssr` policy.
+
+  `fallback` is walked into an element HERE, at the declaration —
+  which is where every other host refusal fires, so a fallback that is
+  not hiccup fails with the author's own stack rather than one render
+  into a server response. It is walked ONCE and the element is reused
+  at every site of the host: React elements are immutable values, and a
+  placeholder that differs per site is not a placeholder. The corollary
+  is the rule the guide states: **a fallback is inert markup** — it is
+  not a body, so a subscription or an intent written there is the same
+  loud error it would be anywhere outside a boundary.
+
+  The gate hands its own props straight through to the foreign
+  component, so the crossing's props object is exactly the one
+  [[host-element]] built — `ref` included, which React 19 carries as an
+  ordinary prop — and `:key` never reaches here, because
+  `createElement` took it off the gate's own element."
+  [host-name component fallback]
+  (let [placeholder (when (some? fallback) (as-element fallback))
+        gate        (fn [props]
+                      (if (react/useSyncExternalStore
+                            gate-no-subscribe gate-adopted gate-unadopted)
+                        (react/createElement component props)
+                        placeholder))]
+    (unchecked-set gate "displayName" host-name)
+    gate))
+
+(defn- declared-ssr
+  "The `:ssr` policy this declaration carries, validated. Absent means
+  `:client-only` — the ruled default, so an author who writes nothing
+  gets the conservative answer and an author who writes the default
+  explicitly gets the same one."
+  [host-name opts]
+  (let [policy (get opts :ssr :client-only)]
+    (if (or (keyword-identical? :client-only policy)
+            (and (map? policy)
+                 (= 1 (count policy))
+                 (some? (:fallback policy))))
+      policy
+      (fail! :rf.error/hicasso-host-bad-ssr-policy
+             'front.codec/mint-host!
+             (str "defhost " host-name " declares :ssr " (pr-str policy)
+                  ". The policy is :client-only — the default, meaning the "
+                  "host region renders nothing until the client adopts it — "
+                  "or {:fallback <hiccup>}, meaning that markup renders "
+                  "there instead. There is no third value.")
+             :declare-client-only-or-a-fallback
+             {:host host-name :ssr policy}))))
 
 (defn mint-host!
   "THE ONE-LINE DECLARATION (HD-011). Give the crossing to `component` a
@@ -985,12 +1100,15 @@
   export) and the render-time alternative is React's own error naming
   nothing the author wrote.
 
-  `opts` carries `:callbacks` — the finite contract map above. Each key
-  is normalized to its canonical slot at MINT time, so the lookup the
-  crossing performs per prop is one `get`; a contract outside the roster,
-  a declaration on a structural slot (`key`/`ref` are React's, not
-  positions), and two spellings landing on one slot are all refused at
-  the declaration, where the author's stack is the declaration site."
+  `opts` carries `:callbacks` — the finite contract map above — and
+  `:ssr`, the placeholder policy (`:client-only` by default, or
+  `{:fallback <hiccup>}`). Each callback key is normalized to its
+  canonical slot at MINT time, so the lookup the crossing performs per
+  prop is one `get`; a contract outside the roster, a declaration on a
+  structural slot (`key`/`ref` are React's, not positions), two
+  spellings landing on one slot, an `:ssr` value outside the two, and
+  an option key outside `#{:callbacks :ssr}` are all refused at the
+  declaration, where the author's stack is the declaration site."
   ([host-name component] (mint-host! host-name component {}))
   ([host-name component opts]
    (when (nil? component)
@@ -1001,7 +1119,18 @@
                  "`:default` against a library with no default export.")
             :hand-the-declaration-a-real-component
             {:host host-name}))
-   (let [declared
+   (doseq [k (keys opts)]
+     (when-not (contains? host-options k)
+       (fail! :rf.error/hicasso-host-unknown-option
+              'front.codec/mint-host!
+              (str "defhost " host-name " was declared with " (pr-str k)
+                   ", which is not an option. A declaration carries "
+                   ":callbacks and :ssr. Reading past an option it does not "
+                   "know is how a policy comes to be set and never applied.")
+              :declare-callbacks-or-ssr
+              {:host host-name :option k :options host-options})))
+   (let [ssr (declared-ssr host-name opts)
+         declared
          (reduce-kv
            (fn [m k contract]
              (let [slot (cached-prop-name k)]
@@ -1035,7 +1164,10 @@
            {}
            (or (:callbacks opts) {}))
          ^js head #js {"component"   component
+                       "gate"        (mint-host-gate! host-name component
+                                                      (:fallback ssr))
                        "callbacks"   declared
+                       "ssr"         ssr
                        "displayName" host-name}]
      (unchecked-set head host-marker true)
      head)))
@@ -1045,6 +1177,16 @@
   no registry, no map — the same shape as [[boundary-head?]]."
   [v]
   (and (some? v) (true? (unchecked-get v host-marker))))
+
+(defn host-ssr
+  "The `:ssr` policy `head` was declared with — `:client-only` or
+  `{:fallback <hiccup>}`. The declaration read back as data, for a
+  server walk that wants to state the policy it is honouring
+  (rf2-2rtt6.86) and for the witnesses that assert on it. Nothing on
+  the render path reads it: the policy is enforced by the gate, which
+  is the element's type."
+  [^js head]
+  (unchecked-get head "ssr"))
 
 ;; ---------------------------------------------------------------------------
 ;; Hiccup shape
@@ -1493,11 +1635,16 @@
   Children are trailing forms converted hiccup→element and handed to the
   foreign component as ordinary React children — HD-011's third default.
 
-  The head itself contributes NOTHING at render: no wrapper component,
-  no fiber, no hook. The foreign component is the element's own type, so
-  its hooks, its state and its refs are React's affair under React's
-  rules — which is the whole point of the door, and what keeps HD-020's
-  ≤2-hook budget a statement about Hicasso's boundaries alone."
+  The element's TYPE is the declaration's gate ([[mint-host-gate!]]),
+  which is one fiber and one hook, and the foreign component is what
+  the gate renders once the markup is adopted. Everything else is
+  unchanged by that: the props object built here is the object the
+  foreign component receives, `:key` is React's on the gate's element
+  where it always was, and the component's hooks, state and refs stay
+  React's affair under React's rules — which is the whole point of the
+  door, and what keeps HD-020's ≤2-hook budget a statement about
+  Hicasso's BOUNDARIES. The gate is not one: no frame, no subscription,
+  no body."
   [argv]
   (let [^js head   (nth argv 0)
         declared   (unchecked-get head "callbacks")
@@ -1505,7 +1652,7 @@
         props      (merge-caller (if has-props? (nth argv 1) {}))
         js-props   (reduce-kv (partial host-entry head declared) #js {} props)]
     (when-some [k (:key props)] (unchecked-set js-props "key" k))
-    (make-element (unchecked-get head "component") js-props argv (if has-props? 2 1))))
+    (make-element (unchecked-get head "gate") js-props argv (if has-props? 2 1))))
 
 (defn- fragment-element [argv]
   (let [has-props? (props-map? argv 1)


### PR DESCRIPTION
Activates HD-011's SSR placeholder as a real `defhost` option. Bench lane + one dated HD-011 addendum. Closes rf2-2rtt6.85.

## The policy — the exact spelling, for the sibling to consume

`defhost`'s `opts` gain `:ssr`, with **exactly two values**:

```clojure
(defhost chart Chart)                                  ; :client-only — the DEFAULT
(defhost chart Chart {:ssr :client-only})              ; the same, said out loud
(defhost chart Chart {:ssr {:fallback [:div.chart-skeleton]}})
```

| value | server render | hydration's first client pass | fresh `createRoot` mount |
|---|---|---|---|
| `:client-only` (default, applied when `:ssr` is absent) | nothing; the component is never invoked | nothing | the component, on the first pass |
| `{:fallback <hiccup>}` | the fallback hiccup | the fallback hiccup | the component, on the first pass — the fallback never flashes |

Read it back with `(codec/host-ssr head)` → `:client-only` or `{:fallback <hiccup>}`.

**rf2-2rtt6.86 (the Node render entry): you need no policy branch.** The policy is enforced by the element's own type, so `renderToString` of the existing runtime honours it by rendering. A `:client-only` region emits nothing and its component's body never runs; a `{:fallback …}` region emits the fallback markup. `codec/host-ssr` is there if you want to *state* the policy in a witness, but nothing on the render path reads it.

## The mechanism — one gate, one hook

Each declaration mints one gate (`codec/mint-host-gate!`): a component whose single `useSyncExternalStore(noop, () => true, () => false)` answers `false` from its **server** snapshot and `true` from its client one. React reads the server snapshot under `renderToString` **and again on hydration's first client pass**, then re-renders with the client snapshot after adoption. So the server HTML and the first client pass agree by construction — there is nothing to reconcile — and a `createRoot` mount, which never consults a server snapshot, renders the component on its very first pass.

The gate hands its own props straight through, so the crossing's props object is exactly the one `host-element` built (`ref` included — React 19 carries it as an ordinary prop; `key` is taken off the gate's element by `createElement` and never re-forwarded). Children and declared `:callbacks` are unchanged.

The declared fallback is walked into an element **once, at mint**, so a fallback that is not hiccup fails at the declaration rather than one render into a server response — and the corollary is stated in the docstrings: a fallback is inert markup, not a body.

## While here: `mint-host!` refuses what it used to ignore

`mint-host!` read `:callbacks` and silently ignored every other option, so a policy could be written and never applied. Now: any `opts` key outside `#{:callbacks :ssr}` raises `:rf.error/hicasso-host-unknown-option`, and a bad `:ssr` (a third value, an explicit `nil`, an empty or multi-key fallback map) raises `:rf.error/hicasso-host-bad-ssr-policy` — both at the declaration, where every other host refusal already fires.

## The cost, stated plainly — this changed a witnessed property

The door used to mint **no wrapper, no fiber and no hook**: the foreign component was the element's own type, and `host_hatch_dom_cljs_test` witnessed exactly one `useSyncExternalStore` on a hosted page. It now mints one gate per declaration, so **a crossing costs one fiber and one hook**.

**HD-020(b)'s ≤2-hook shell budget is untouched.** `rt/shell-hook-ledger` is unchanged (still two entries), `arm1/runtime.cljs` is not in this diff at all, and the gate is not a boundary: no frame read, no subscription, no body. The hook census was updated to state the new truth rather than deleted — the shell's two, then the door's one, then nothing that is not the hosted component's own roster — and it now also asserts `(= 2 (count rt/shell-hook-ledger))`, so the budget is pinned by the same row that reads the gate.

The alternatives were priced and rejected: a module-level "adopted?" flag read at element-creation time keeps the zero-cost door, but it is **fail-open** (nothing sets it unless a sibling remembers to) and it needs edits in both siblings' files; folding adoption into the boundary's existing subscription re-renders every boundary on the page. Fail-closed and self-contained won.

## Coordination

- **No `arm1/runtime.cljs` and no `arm1/mount.cljs` in this diff**, so there is no collision with rf2-2rtt6.84 (the hydration door). The hydration witnesses call `react-dom/client`'s `hydrateRoot` directly rather than waiting on `.84`'s `hydrate-root!`.
- `docs/design/hicasso/decisions.md`: rf2-2rtt6.83 **merged** (`d518429b26`) before this branch rebased, so the HD-011 addendum this bead asks for is written here, as the bead's own fence allows. It adds no table and no links, so there are no column counts or anchors to drift; `scripts/check_doc_slugs.py` passes and the spine ran the documentation gates on this diff.

## Witnesses — `arm1/host_ssr_dom_cljs_test`

Declaration rows (the default is `:client-only`; every refusal asserted by id). Server-render rows (`renderToString` of the existing runtime: region absent / fallback present, and the component's body never ran). Fresh-mount rows (the component on the first pass under both policies; no placeholder flash; props and children still cross). Hydration rows (bake, then `hydrateRoot` **plain** — no `act`, no `flushSync`, settled on a real 150 ms timer — asserting the markup hydrated *from*, then that React reported nothing on **all three** channels: `onRecoverableError`, `console.error`, and a `window` `error` listener, because React routes a commit-time throw to `reportError` where `cljs.test` reads 0 failures over a live exception).

## Mutation proofs — both directions, through gated suites

| mutation | gate | result |
|---|---|---|
| make `:client-only` render something (`gate-unadopted` → `(fn [] true)`) | `npm run test:cljs` | **exit 1**, 5 failures, all `FAIL in (the-server-render-honours-the-policy)` |
| make `{:fallback …}` render nothing (`placeholder` → `nil`) | `npm run test:browser` | **exit 1**, 3 failures: `the-declaration-refuses-a-policy-it-cannot-honour`, `the-server-render-honours-the-policy`, `a-fallback-hydrates-as-the-placeholder-and-is-swapped-after-adoption` |

Both reverted byte-identically (`git status --porcelain` empty afterwards). The second proves the browser-only hydration rows are live in the browser gate; the first proves the suite is compiled into the node gate. Neither is a fail-open instrument.

## Quality gates

All run from `C:/Users/miket/code/re-frame2-worktrees/ssrpolicy-2rtt6-85` — each gate's `gate root:` line was checked against that path.

| gate | exit | result |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine` (re-run after the docs commit, so the documentation gates ran) |
| `npm run test:cljs` | **0** | Ran 12509 tests, 62735 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **0** | Ran 1061 tests, 6594 assertions, 0 failures, 0 errors |
| `npm run test:hicasso-compile` | **0** | 102 lane namespaces, 0 warnings |

Tiers the spine states it did **not** run (2): the JVM artefact suites the diff did not touch; and the CI-only lanes (browser lanes, prod-elision/bundle-isolation/perf gates, adapter probes + smokes, Xray feature matrix, mcp-conformance, tool JVM suites). `shellcheck` is not installed here and was not run.

Windows box, Linux CI: no platform-dependent assertion was added — the rows read DOM structure, error channels and `renderToString` output, never paths, line endings, or timing thresholds beyond one 150 ms settle.
