### PR TITLE
feat(hicasso): the SSR hydration door (rf2-2rtt6.84)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/dogfood_dom_cljs_test.cljs
@@ -630,7 +630,10 @@
 ;; later, deliberately, so a keyed reorder reuses them.
 
 (def ^:private reaper-horizon-ms
-  "One macrotask, with room — `arm1/runtime` arms both reapers at 0 ms."
+  "One macrotask, with room: `arm1/runtime` arms the cell reaper at 0 ms
+  and the entry reaper at its 4 ms horizon (rf2-2rtt6.84), so 8 clears
+  both — and clears them in order, because the reapers are armed during
+  the unmount and this timer immediately after it."
   8)
 
 (def ^:private nothing-retained

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/hydrate_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/hydrate_cljs_test.cljs
@@ -1,0 +1,187 @@
+(ns re-frame.bench.hicasso.arm1.hydrate-cljs-test
+  "THE HYDRATION DOOR'S HEADLESS HALF (rf2-2rtt6.84).
+
+  Three of the door's four moving parts are answerable without React, a
+  root or a DOM, and they are answered here so the browser file is left
+  with only the claims a browser can make:
+
+  1. **The entry reap horizon is past a bare `setTimeout 0`** — the
+     property `hydrateRoot`'s passive subscribe needs, expressed as the
+     race it has to win rather than as the integer it is implemented
+     with.
+  2. **The adoption window opens, closes, and is closed by a runtime
+     reset** — so a fixture that throws mid-hydration cannot leave the
+     page permanently adopting.
+  3. **`body-runs` counts real body runs**, is monotone, and survives
+     `reset-runtime!` — HD-028's rider stated where it can be stated
+     exactly.
+
+  ## Why row 1 is not a contract test in disguise
+
+  `arm1.runtime/entry-reap-horizon-ms` is a MARGIN and its own docstring
+  says no caller may rely on it. What is asserted below is not \"4 ms\":
+  it is that an entry a render minted is **still in the cache one bare
+  macrotask later**, which is the defect a `setTimeout 0` horizon had and
+  the only thing about the horizon that is a design property rather than
+  a measurement. Setting the horizon back to 0 turns this row red;
+  raising it to 32 does not."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     ;; The horizon rows are `async` — a reap horizon is not observable
+     ;; inside one synchronous test body.
+     :async?  true
+     :init-fn (fn [] (rt/reset-runtime!) (rt/reset-body-runs!))}))
+
+(def ^:private frame-id ::arm1-hydrate)
+
+(defn- seeded! []
+  (rt/reset-runtime!)
+  (rt/reset-body-runs!)
+  (dogfood/make-frame! frame-id 3)
+  frame-id)
+
+(defn- one-body-run!
+  "One boundary body through the shell's own fence, minus React."
+  []
+  (rt/render-body frame-id (fn [_] [:li (str (rt/sub [:dogfood/todo 0]))]) {})
+  (rt/last-reads))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the reap horizon is past a bare `setTimeout 0`
+;; ---------------------------------------------------------------------------
+
+(deftest an-unclaimed-entry-survives-a-bare-macrotask-and-not-the-horizon
+  (async done
+    (seeded!)
+    (testing "**The race the hydration door has to win** (rf2-2rtt6.84 (2)).
+             An entry is minted in the RENDER and claimed in the COMMIT,
+             and `hydrateRoot` puts a scheduler turn between the two. A
+             reaper armed at `setTimeout 0` inside the render therefore
+             evicts the entry before React ever calls its `subscribe` —
+             the boundary ends up subscribed to a detached entry, and its
+             next render misses the cache, mints a second one, and hands
+             `useSyncExternalStore` a different `subscribe` to tear down
+             and rebuild. Same class as rf2-2rtt6.71 in the spine.
+
+             The horizon is asserted as the RACE, not as its integer: a
+             timer armed AFTER the reaper's, for zero, must still find the
+             entry cached"
+      (let [entry (one-body-run!)]
+        (is (some? entry) "the render minted an entry")
+        (is (zero? (.-refs entry)) "unclaimed — no commit has run")
+        (is (= 1 (:entries (rt/stats))) "and it is in the cache")
+        (js/setTimeout
+          (fn []
+            (is (= 1 (:entries (rt/stats)))
+                "one bare macrotask later it is STILL cached — a commit
+                 arriving here would find the entry its render minted")
+            (js/setTimeout
+              (fn []
+                (is (zero? (:entries (rt/stats)))
+                    "and the horizon is bounded, not disabled: an entry
+                     nothing claimed is still evicted")
+                (done))
+              8))
+          0)))))
+
+(deftest a-claimed-entry-is-never-reaped-at-any-horizon
+  (async done
+    (seeded!)
+    (testing "the horizon is a cache-eviction schedule and nothing else —
+             an entry a commit claimed is held by its `refs`, so no delay
+             can drop it and correctness never depended on the race"
+      (let [entry (one-body-run!)
+            stop  (rt/commit-boundary! entry (fn [] nil))]
+        (is (= 1 (.-refs entry)))
+        (js/setTimeout
+          (fn []
+            (is (= 1 (:entries (rt/stats))) "claimed, so past the horizon it stands")
+            (stop)
+            (js/setTimeout
+              (fn []
+                (is (zero? (:entries (rt/stats)))
+                    "and released, it is evicted on the ordinary edge")
+                (done))
+              8))
+          8)))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the adoption window
+;; ---------------------------------------------------------------------------
+
+(deftest the-adoption-window-is-shut-by-default-and-shut-again-by-a-reset
+  (seeded!)
+  (testing "**Adoption is a window, not a mode** (rf2-2rtt6.84 (3)). It is
+           false for every ordinary mount — which is what keeps the
+           charter's one-mode law intact — and `reset-runtime!` shuts it,
+           so a fixture that throws between `hydrateRoot` and the closer's
+           effect cannot leave the page adopting for every row after it"
+    (is (false? (rt/adopting?)) "shut by default")
+    (rt/open-adoption-window!)
+    (is (true? (rt/adopting?)) "opened by the door")
+    (rt/close-adoption-window!)
+    (is (false? (rt/adopting?)) "shut by the closer")
+    (rt/open-adoption-window!)
+    (rt/reset-runtime!)
+    (is (false? (rt/adopting?)) "and shut by a runtime reset, whatever threw")))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the body-run counter (HD-028's rider)
+;; ---------------------------------------------------------------------------
+
+(deftest body-runs-counts-bodies-that-ran-and-is-not-cleared-by-a-reset
+  (seeded!)
+  (testing "**The instrument the X-witnesses read** (rf2-2rtt6.84 (6)).
+           Always on, so the `:advanced` / `goog.DEBUG false` builds this
+           lane actually drives can see it; bumped inside `run-once`, so
+           what it counts is a body that RAN rather than a render React
+           was asked for — which is the whole of HD-028's rider, because a
+           `React.memo` bail-out has to read as an increment that did not
+           happen"
+    (is (zero? (rt/body-runs)) "the fixture zeroed it")
+    (one-body-run!)
+    (is (= 1 (rt/body-runs)))
+    (one-body-run!)
+    (one-body-run!)
+    (is (= 3 (rt/body-runs)) "one per body, counted")
+    (rt/reset-runtime!)
+    (is (= 3 (rt/body-runs))
+        "and a teardown does NOT zero it — an instrument a teardown door
+         resets is one a reading taken on the wrong side of the reset can
+         pass with")
+    (rt/reset-body-runs!)
+    (is (zero? (rt/body-runs)) "only the explicit door zeroes it")))
+
+(deftest a-fenced-re-run-is-two-body-runs-because-two-bodies-ran
+  (seeded!)
+  (testing "the generation fence re-runs a body that straddled a commit,
+           and the counter says TWO — which is the reason it is bumped in
+           `run-once` rather than once per `render-body`. A count of
+           renders React asked for would say one here, and one is not what
+           happened"
+    ;; A mid-body write is only observable when the key is already held —
+    ;; a key nothing holds has no watch to fire (`runtime_cljs_test`'s
+    ;; own fence row states it).
+    (rt/render-body frame-id (fn [_] [:li (str (rt/sub [:dogfood/done? 0]))]) {})
+    (let [stop (rt/commit-boundary! (rt/last-reads) (fn [] nil))
+          runs (volatile! 0)]
+      (rt/reset-body-runs!)
+      (rt/render-body frame-id
+                      (fn [_]
+                        (vswap! runs inc)
+                        (rt/sub [:dogfood/done? 0])
+                        (when (= 1 @runs)
+                          (rt/dispatch! frame-id [:dogfood/toggle 0]))
+                        [:li (str (rt/sub [:dogfood/done? 0]))])
+                      {})
+      (is (= 2 @runs) "the fence re-ran the body")
+      (is (= 2 (rt/body-runs))
+          "and the counter reads two, because two bodies ran")
+      (stop))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/hydrate_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/hydrate_dom_cljs_test.cljs
@@ -451,7 +451,7 @@
       (do
         (fresh!)
         (let [html      (server-html! [screen {}])
-              container (server-dom! html)]
+              container (stamp-server-nodes! (server-dom! html))]
           (rt/reset-body-runs!)
           (let [handle (mount/hydrate-root! container frame-id [screen {}])]
             (-> (adopted!)
@@ -470,10 +470,25 @@
                                NOT moving. An instrument that inferred a run
                                from the render React was asked for would move
                                here, and would then be unable to tell a
-                               genuine adoption from a skipped one"
+                               genuine adoption from a skipped one.
+
+                               **This row also pins the hydrated root's
+                               SHAPE** (`mount/tree`). The closer rides as a
+                               Fragment sibling, and a `render!` that handed
+                               the same root a bare provider instead would not
+                               be a cheap re-render — React would reconcile a
+                               different top element, tear the adopted subtree
+                               down and mount a fresh one. Measured before the
+                               repair: four body runs and four replaced nodes,
+                               i.e. everything the adoption achieved, undone by
+                               the first ordinary render"
                         (rt/reset-body-runs!)
                         (mount/render! handle [screen {}])
                         (is (zero? (rt/body-runs))
                             (str "a props-equal re-render ran no body; read "
-                                 (rt/body-runs))))
+                                 (rt/body-runs)))
+                        (is (every? server-node?
+                                    (array-seq (.querySelectorAll container ".row")))
+                            "and every row is still the SERVER'S node — the
+                             render did not remount the adopted tree"))
                       (finally (mount/release! handle) (done))))))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/hydrate_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/hydrate_dom_cljs_test.cljs
@@ -1,0 +1,479 @@
+(ns re-frame.bench.hicasso.arm1.hydrate-dom-cljs-test
+  "THE HYDRATION DOOR, MOUNTED (rf2-2rtt6.84).
+
+  `arm1/mount/hydrate-root!` adopting real server-shaped DOM in a real
+  browser: the closer closes the window, the reap horizon leaves the
+  adopted subscriptions alone, presence children are born PRESENT, a
+  controlled input arrives with React's `defaultValue` mirror intact, and
+  the body-run counter reports bodies that RAN rather than renders React
+  was asked for.
+
+  ## Where the \"server\" bytes come from, stated plainly
+
+  **Not from `react-dom/server`.** The Node render entry is
+  rf2-2rtt6.86's bead and the end-to-end spike is rf2-2rtt6.87's; this
+  file is about the DOOR, so its fixture markup is this same tree's own
+  CLIENT render, captured as `innerHTML` **under an open adoption
+  window** — which is the state a server render is in, and is why the
+  captured bytes are born-present rather than mid-enter.
+
+  That substitution is honest for what is asserted here and dishonest for
+  what is not, so the markup contract is asserted **explicitly on the
+  captured bytes** ([[the-hydrated-controlled-input-keeps-its-mirror]]
+  reads `value=` out of them) rather than assumed. A server that emits
+  something else fails that row instead of sliding past it. The
+  byte-identity and canonical-DOM parity claims belong to the spike and
+  are deliberately absent.
+
+  ## Two ways a row here could go green over a live failure
+
+  1. **React routes a render or effect exception to `reportError`**, so
+     `cljs.test` can read zero failures across a component that threw.
+     Every row runs inside [[capture-console!]], which listens on
+     `window`'s `error` event AND spies `console.error` — the two
+     channels React 19 reports a hydration mismatch on — and asserts the
+     capture is empty.
+  2. **`act` and `flushSync` are not the browser's schedule.** Adoption
+     is React's own concurrent business, so [[adopted!]] waits on real
+     timers for the closer's passive effect and never pulls it forward.
+     `mount/dispatch!` still flushes, but only in rows whose claim is
+     about the model rather than about the turn.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every DOM claim degrades to a stated
+  skip."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.presence :refer [presence]]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.controlled :as controlled]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(def ^:private frame-id ::arm1-hydrate-dom)
+(def ^:private toast-timeout-ms 400)
+
+;; Registered ABOVE `use-fixtures`, deliberately — the reset fixture
+;; captures its source-store baseline when the `use-fixtures` form is
+;; EVALUATED, so a `reg-sub` written below it is erased before the first
+;; row runs and every screen renders nothing.
+
+(rf/reg-sub :hyd/title (fn [db _] (:title db)))
+(rf/reg-sub :hyd/row (fn [db [_ i]] (get-in db [:rows i] "")))
+(rf/reg-sub :hyd/toasts (fn [db _] (:toasts db)))
+(rf/reg-sub :hyd/field (fn [db _] (:field db)))
+
+(rf/reg-event :hyd/seed
+  (fn [_ _]
+    {:db {:title  "hydrated"
+          :rows   {0 "alpha" 1 "beta" 2 "gamma"}
+          :toasts [{:id 1 :message "Saved"}]
+          :field  "abc"}}))
+
+(rf/reg-event :hyd/set-row
+  (fn [{:keys [db]} [_ i v]] {:db (assoc-in db [:rows i] v)}))
+
+(rf/reg-event :hyd/set-field
+  (fn [{:keys [db]} [_ v]] {:db (assoc db :field v)}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!) (rt/reset-body-runs!))}))
+
+(defn- skip! [why]
+  (is true (str "a hydration claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (lane/leave-act-environment!)
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:hyd/seed]))
+  (rt/reset-runtime!)
+  (rt/reset-body-runs!)
+  frame-id)
+
+;; ---------------------------------------------------------------------------
+;; The screens
+;; ---------------------------------------------------------------------------
+
+(defview row
+  "One row boundary. A single text child on purpose: React's SSR puts a
+  `<!-- -->` separator between adjacent text runs and a client render
+  does not, so a fixture with two text children would be measuring that
+  known divergence (rf2-2rtt6.88's text-separator row) instead of this
+  door."
+  [{:keys [i]}]
+  [:li.row {:data-i i} (rt/sub [:hyd/row i])])
+
+(defview screen
+  "Four boundaries: this one and three rows."
+  [_]
+  [:div.screen
+   [:h1.title (rt/sub [:hyd/title])]
+   [:ul.rows (for [i (range 3)] [row {:key i :i i}])]])
+
+(def ^:private boundary-count 4)
+
+(defview toast-tray
+  "A presence tray whose children carry BOTH override maps, so a child
+  that entered is visibly different from one that was born present."
+  [_]
+  [presence {:timeout-ms toast-timeout-ms}
+   (for [t (rt/sub [:hyd/toasts])]
+     [:div.toast {:key (:id t)
+                  :data-id (:id t)
+                  :re-frame.hicasso/mounting   {:class "toast toast--enter"}
+                  :re-frame.hicasso/unmounting {:class "toast toast--exit"}}
+      (:message t)])])
+
+(defview field-screen
+  "One controlled text input — HD-019's shape, on the hydrated path."
+  [_]
+  [:input#hyd-field.field {:type     "text"
+                           :value    (rt/sub [:hyd/field])
+                           :on-input [:hyd/set-field :re-frame.hicasso/value]}])
+
+;; ---------------------------------------------------------------------------
+;; The fixture doors
+;; ---------------------------------------------------------------------------
+
+(defn- server-html!
+  "The bytes an SSR route would deliver for `hiccup` — see the ns
+  docstring for what stands in for what. Rendered under an OPEN adoption
+  window, which is the state a server render is in, and released
+  afterwards so the runtime the hydration is measured on is empty."
+  [hiccup]
+  (rt/open-adoption-window!)
+  (let [container (mount/fresh-container!)
+        handle    (mount/root! container frame-id hiccup)
+        html      (.-innerHTML container)]
+    (mount/release! handle)
+    html))
+
+(defn- server-dom!
+  "A container carrying `html`, attached to the document — the page as it
+  arrives, before any JavaScript has adopted it."
+  [html]
+  (let [container (mount/fresh-container!)]
+    (set! (.-innerHTML container) html)
+    container))
+
+(def ^:private server-node-mark
+  "An EXPANDO, not an attribute — it cannot survive being re-serialised,
+  so a node still carrying it after adoption is the very node the server
+  markup produced rather than a replacement that happens to look alike."
+  "hicassoServerNode")
+
+(defn- stamp-server-nodes!
+  "Mark every element in the server DOM, so identity is checkable
+  anywhere in the tree."
+  [container]
+  (doseq [n (array-seq (.querySelectorAll container "*"))]
+    (unchecked-set n server-node-mark true))
+  container)
+
+(defn- server-node? [node]
+  (and (some? node) (true? (unchecked-get node server-node-mark))))
+
+(defn- capture-console!
+  "Run `f` with React's two failure channels captured, and answer
+  `[result captured]`.
+
+  React 19 reports a hydration mismatch by `console.error` in a
+  development build and routes a recoverable error to `reportError`,
+  which surfaces as a `window` `error` event — and an exception React
+  reports that way never reaches `cljs.test`, so a row asserting
+  \"nothing complained\" that watched neither channel would be green over
+  a live failure."
+  [f]
+  (let [captured (atom [])
+        original (.-error js/console)
+        on-error (fn [^js e]
+                   (swap! captured conj (str "window.error: " (.-message e))))]
+    (.addEventListener js/window "error" on-error)
+    (set! (.-error js/console)
+          (fn [& args]
+            (swap! captured conj (str "console.error: " (apply str args)))
+            nil))
+    (try
+      [(f) captured]
+      (finally
+        (set! (.-error js/console) original)
+        (.removeEventListener js/window "error" on-error)))))
+
+(defn- adopted!
+  "Wait for the adoption window to CLOSE — the closer component's passive
+  effect — and then for the entry reap horizon to pass.
+
+  Real timers only: no `act`, no `flushSync`. The claim every row here
+  makes is about React's own turn, and a witness that pulled the commit
+  forward would be a witness about the pull."
+  []
+  (js/Promise.
+    (fn [resolve]
+      (let [deadline (+ (js/Date.now) 3000)]
+        (letfn [(tick []
+                  (cond
+                    (not (rt/adopting?))
+                    ;; Past the closer AND past `entry-reap-horizon-ms`,
+                    ;; so a reading of the entry cache is a reading taken
+                    ;; on the far side of the race.
+                    (js/setTimeout (fn [] (resolve true)) 16)
+
+                    (< deadline (js/Date.now))
+                    (resolve false)
+
+                    :else (js/setTimeout tick 4)))]
+          (tick))))))
+
+(defn- text-of [container sel]
+  (some-> (.querySelector container sel) (.-textContent)))
+
+;; ===========================================================================
+;; 1 — the door adopts, and the CLOSER is what says so
+;; ===========================================================================
+
+(deftest hydrate-root-adopts-the-server-dom-and-the-closer-shuts-the-window
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
+        (fresh!)
+        (let [html      (server-html! [screen {}])
+              container (stamp-server-nodes! (server-dom! html))
+              title     (.querySelector container ".title")]
+          (is (server-node? title) "the stamp is on the server's own node")
+          (rt/reset-body-runs!)
+          (let [[handle captured]
+                (capture-console! (fn [] (mount/hydrate-root! container frame-id [screen {}])))]
+            (is (true? (rt/adopting?))
+                "the window is OPEN the instant `hydrate-root!` returns —
+                 `hydrateRoot` was called plain, so this returns before the
+                 tree is adopted and the window has to outlive the call")
+            (-> (adopted!)
+                (.then
+                  (fn [ok]
+                    (try
+                      (is (true? ok) "the closer's passive effect ran")
+                      (is (false? (rt/adopting?))
+                          "and shut the window — adoption is complete, and
+                           `(rt/adopting?)` answering false IS that effect
+                           having run, which is the completion signal this
+                           door offers in place of a `flushSync`")
+                      (is (= [] @captured)
+                          (str "React reported nothing on either channel: "
+                               (pr-str @captured)))
+                      (is (server-node? (.querySelector container ".title"))
+                          "the title node is the SERVER'S node — React adopted
+                           the DOM rather than replacing it")
+                      (is (every? server-node?
+                                  (array-seq (.querySelectorAll container ".row")))
+                          "and so is every row")
+                      (is (= "hydrated" (text-of container ".title")))
+                      (is (= "alpha" (text-of container ".row[data-i=\"0\"]")))
+                      (finally (mount/release! handle) (done))))))))))))
+
+;; ===========================================================================
+;; 2 — the reap horizon does not detach the adopted subscriptions
+;; ===========================================================================
+
+(deftest the-reaper-does-not-evict-the-entries-hydration-subscribed-to
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
+        (fresh!)
+        (let [html      (server-html! [screen {}])
+              container (server-dom! html)
+              handle    (mount/hydrate-root! container frame-id [screen {}])]
+          (-> (adopted!)
+              (.then
+                (fn [ok]
+                  (try
+                    (is (true? ok) "adoption completed")
+                    (let [stats (rt/stats)]
+                      (is (= boundary-count (:boundaries stats))
+                          "every boundary committed its reads")
+                      (is (= boundary-count (:entries stats))
+                          "**and every one of them is subscribed to an entry
+                           that is STILL IN THE CACHE.** This is the row the
+                           0 -> 4 ms horizon exists for: an entry minted in
+                           the render and reaped before `hydrateRoot`'s
+                           passive subscribe leaves its boundary holding a
+                           detached entry, and the count here falls below the
+                           boundary count. Four read sequences, four entries")
+                      (is (pos? (:cell-refs stats))
+                          "and the references are real, so this is a reading
+                           of something"))
+                    ;; The adopted subscription is LIVE, and re-rendering
+                    ;; through it does not rebuild the cache.
+                    (mount/dispatch! handle [:hyd/set-row 1 "BETA"])
+                    (is (= "BETA" (text-of container ".row[data-i=\"1\"]"))
+                        "a write after adoption reaches the adopted boundary")
+                    (is (= boundary-count (:entries (rt/stats)))
+                        "and mints no second entry — the read sequence is
+                         unchanged, so the cache hit keeps `subscribe`'s
+                         identity and React never re-subscribes")
+                    (finally (mount/release! handle) (done)))))))))))
+
+;; ===========================================================================
+;; 3 — presence is BORN PRESENT under adoption
+;; ===========================================================================
+
+(deftest a-client-mounted-tray-enters-so-the-row-below-can-answer-false
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [container (mount/fresh-container!)
+            handle    (mount/root! container frame-id [toast-tray {}])]
+        (try
+          (testing "**the control.** An ordinary client mount meets its
+                   children for the first time, so they are `:mounting` and
+                   wear the `::h/mounting` override — which is what makes
+                   the hydrated row below a difference rather than a claim
+                   about a class nothing ever sets"
+            (let [toast (.querySelector container ".toast")]
+              (is (some? toast))
+              (is (.contains (.-classList toast) "toast--enter")
+                  "the enter override is on the freshly mounted node")))
+          (finally (mount/release! handle)))))))
+
+(deftest a-hydrated-tray-is-born-present-and-never-replays-its-enter
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
+        (fresh!)
+        (let [html (server-html! [toast-tray {}])]
+          (is (not (re-find #"toast--enter" html))
+              "**the server's bytes carry no enter override.** A server
+               render is inside the adoption window, so its children are
+               born present — which is also what stops the server shipping
+               an `opacity: 0` mounting style over content the user is
+               meant to see")
+          (is (re-find #"toast" html) "and the toast itself IS in them")
+          (let [container (stamp-server-nodes! (server-dom! html))
+                toast     (.querySelector container ".toast")]
+            (is (server-node? toast))
+            (let [[handle captured]
+                  (capture-console!
+                    (fn [] (mount/hydrate-root! container frame-id [toast-tray {}])))]
+              (-> (adopted!)
+                  (.then
+                    (fn [ok]
+                      (try
+                        (is (true? ok) "adoption completed")
+                        (is (= [] @captured)
+                            (str "with nothing reported — an enter override
+                                  applied to DOM that carries none is exactly
+                                  a hydration mismatch: " (pr-str @captured)))
+                        (let [after (.querySelector container ".toast")]
+                          (is (server-node? after)
+                              "the toast is the server's own node")
+                          (is (not (.contains (.-classList after) "toast--enter"))
+                              "**born present.** No enter override at any point
+                               — the child was already on the screen, so
+                               entering it would replay an animation the user
+                               has already watched")
+                          (is (= "Saved" (.-textContent after))))
+                        (finally (mount/release! handle) (done)))))))))))))
+
+;; ===========================================================================
+;; 4 — HD-019's rider: the hydrated controlled input
+;; ===========================================================================
+
+(deftest the-hydrated-controlled-input-keeps-its-mirror
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
+        (fresh!)
+        (let [html (server-html! [field-screen {}])]
+          (is (re-find #"value=\"abc\"" html)
+              "**what a server must emit for a controlled input.** The
+               value is a rendered ATTRIBUTE, not something the client
+               supplies after the fact — `hydrateRoot` matches the field
+               against it, and `front.controlled`'s whole caret-restore
+               rests on React's `defaultValue` mirror of it")
+          (let [container (stamp-server-nodes! (server-dom! html))
+                before    (.querySelector container "#hyd-field")]
+            (is (server-node? before))
+            (is (= "abc" (.-value before))
+                "the field shows the server's value before any JS ran")
+            (rt/reset-body-runs!)
+            (let [[handle captured]
+                  (capture-console!
+                    (fn [] (mount/hydrate-root! container frame-id [field-screen {}])))]
+              (-> (adopted!)
+                  (.then
+                    (fn [ok]
+                      (try
+                        (is (true? ok) "adoption completed")
+                        (is (= [] @captured)
+                            (str "nothing reported: " (pr-str @captured)))
+                        (let [after (.querySelector container "#hyd-field")]
+                          (is (server-node? after)
+                              "**the node is the server's.** A remount here
+                               would lose focus, selection and any composition
+                               in flight")
+                          (is (= "abc" (.-value after))
+                              "**hydration converged nothing.** `converge!`
+                               runs at the end of a change handler and
+                               hydration fires none, so the field holds
+                               exactly what the server rendered")
+                          (is (= "abc" (controlled/last-rendered after))
+                              "**and the `defaultValue` mirror is established
+                               on the hydrated path too** — the one dependency
+                               `front.controlled` has on React, extended to
+                               adoption. Without it every caret restore on a
+                               hydrated field would converge to the wrong
+                               string"))
+                        (is (= 1 (rt/body-runs))
+                            (str "one boundary, one body run across the whole "
+                                 "adoption — no converge, and so no extra "
+                                 "render; read " (rt/body-runs)))
+                        (finally (mount/release! handle) (done)))))))))))))
+
+;; ===========================================================================
+;; 5 — HD-028's rider: the memo cannot fake adoption
+;; ===========================================================================
+
+(deftest the-body-run-count-across-adoption-is-counted-and-not-inferred
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
+        (fresh!)
+        (let [html      (server-html! [screen {}])
+              container (server-dom! html)]
+          (rt/reset-body-runs!)
+          (let [handle (mount/hydrate-root! container frame-id [screen {}])]
+            (-> (adopted!)
+                (.then
+                  (fn [ok]
+                    (try
+                      (is (true? ok) "adoption completed")
+                      (is (= boundary-count (rt/body-runs))
+                          (str "**each boundary's body ran exactly once to "
+                               "adopt.** Counted in `run-once`, where a body "
+                               "is invoked — read " (rt/body-runs)))
+                      (testing "**and the count is real, not memo-inferred**
+                               (HD-028's rider). Re-rendering the same tree
+                               with equal props bails out at `mint-view!`'s
+                               memo, no body runs, and the counter says so by
+                               NOT moving. An instrument that inferred a run
+                               from the render React was asked for would move
+                               here, and would then be unable to tell a
+                               genuine adoption from a skipped one"
+                        (rt/reset-body-runs!)
+                        (mount/render! handle [screen {}])
+                        (is (zero? (rt/body-runs))
+                            (str "a props-equal re-render ran no body; read "
+                                 (rt/body-runs))))
+                      (finally (mount/release! handle) (done))))))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/mount.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/mount.cljs
@@ -22,7 +22,14 @@
   `flushSync` that lets an already-scheduled sync-lane notification land.
   Neither is `act` — `act` diverts work to a queue that is not the
   browser's, which is the right tool for an effect-ordering test and the
-  wrong one for a witness that reads the page."
+  wrong one for a witness that reads the page.
+
+  **[[hydrate-root!]] is the exception, and deliberately** (rf2-2rtt6.84).
+  Adoption is React's own concurrent business and nothing in this tree
+  forces it synchronously; wrapping `hydrateRoot` in a `flushSync` would
+  be inventing a schedule to make a witness easier to write. So that one
+  door returns before the tree is adopted, and a witness for it waits for
+  the closer instead of for a flush."
   (:require [re-frame.adapter.context :as adapter-context]
             [re-frame.bench.hicasso.arm1.runtime :as rt]
             [re-frame.bench.hicasso.front.codec :as codec]
@@ -71,6 +78,70 @@
                 :container container}]
     (render! handle hiccup)
     handle))
+
+(defn adoption-window-closer
+  "The component that CLOSES the adoption window, on the hydration commit
+  and not before (rf2-2rtt6.84).
+
+  Lifted verbatim in shape from the spine's own
+  `re-frame.substrate.spine/adoption-window-closer`: a passive
+  `useEffect` with empty deps, so it runs exactly once and strictly AFTER
+  the commit that adopted the server DOM. Renders nil — no DOM, so it
+  adds nothing for `hydrateRoot` to match and cannot itself mismatch.
+
+  Public because that is what makes adoption OBSERVABLE without a probe:
+  `(rt/adopting?)` answering false is this effect having run, which is
+  the completion signal a witness waits on in place of the `flushSync`
+  [[hydrate-root!]] refuses to perform."
+  [_props]
+  (react/useEffect (fn close-window [] (rt/close-adoption-window!) js/undefined)
+                   #js [])
+  nil)
+
+(aset adoption-window-closer "displayName" "hicasso/adoption-window-closer")
+
+(defn hydrate-root!
+  "Associate `container`'s **existing server-rendered DOM** with
+  `frame-kw` and `hiccup`, by adoption. [[root!]]'s hydrating twin, and
+  the client half every SSR route shares (rf2-2rtt6.84).
+
+  Returns the same handle shape [[root!]] does — `{:root :frame
+  :container}` — so [[render!]], [[dispatch!]], [[unmount!]] and
+  [[release!]] all take a hydrated handle unchanged.
+
+  ## `hydrateRoot` is called PLAIN
+
+  No `flushSync`, and that is a finding rather than an omission: nothing
+  in this tree forces hydration synchronously, so a flush here would
+  manufacture a schedule no shipped caller has and every row taken
+  through it would be a row about the manufactured one. The consequence
+  is that **this returns before the tree is adopted** — React adopts
+  concurrently, and the DOM on the line after this call is still the
+  server's.
+
+  ## So the window is closed by a COMPONENT, not by this function
+
+  [[adoption-window-closer]] rides as a Fragment sibling of the app
+  subtree and clears the window from its passive effect. That is the
+  spine's pattern (`spine.cljs`, `adoption-window-closer` /
+  `make-render`), and the reason is the same in both places: a passive
+  effect is the earliest thing that is unambiguously after the hydration
+  commit. Closing the window here, before `hydrateRoot` returns, would
+  close it before a single body had run inside it.
+
+  The closer sits OUTSIDE the frame provider on purpose — it reads no
+  subscription and needs no frame, and a nil-rendering component with no
+  frame dependency is the smallest thing that can carry the effect."
+  [container frame-kw hiccup]
+  (rt/open-adoption-window!)
+  {:root      (react-dom-client/hydrateRoot
+                container
+                (react/createElement
+                  (.-Fragment react) nil
+                  (react/createElement adoption-window-closer nil)
+                  (provider frame-kw (codec/root-element frame-kw hiccup))))
+   :frame     frame-kw
+   :container container})
 
 (defn unmount!
   "Unmount the root and detach its container, and **touch nothing the

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/mount.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/mount.cljs
@@ -127,7 +127,13 @@
                    #js [])
   nil)
 
-(aset adoption-window-closer "displayName" "hicasso/adoption-window-closer")
+;; `unchecked-set`, not `aset`: `aset` is cljs.core's ARRAY writer and a
+;; component is a function, so the write was a type error the compiler
+;; happens not to enforce. Both emit the same `(x["displayName"] = ...)`,
+;; and it is the STRING key that keeps the property off Closure's renamer
+;; under `:advanced` — the reason the arm's other stamps
+;; (`runtime/mint-view!`, `codec/memoize-boundary!`) are spelled this way.
+(unchecked-set adoption-window-closer "displayName" "hicasso/adoption-window-closer")
 
 (defn hydrate-root!
   "Associate `container`'s **existing server-rendered DOM** with

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/mount.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/mount.cljs
@@ -53,6 +53,36 @@
   (react-dom/flushSync (fn [] nil))
   nil)
 
+(declare adoption-window-closer)
+
+(defn- tree
+  "The root element for `handle`'s next render — **the one place the root
+  tree's SHAPE is decided**, and the reason it is a function of the
+  handle rather than of its two callers.
+
+  A hydrated root carries [[adoption-window-closer]] as a Fragment
+  sibling of the app subtree, and it has to carry it on EVERY subsequent
+  render: React reconciles a root by its top element, so handing a
+  hydrated root a bare provider where a Fragment stood would not be a
+  cheaper render, it would be a different tree — React unmounts the
+  adopted subtree and mounts a fresh one, discarding every node, cell and
+  subscription the adoption just established. Measured: the first
+  `render!` after a hydration re-ran all four boundary bodies and
+  replaced all four DOM nodes.
+
+  An ordinary root gets no wrapper at all, which keeps the tree the whole
+  bench lane measures exactly what it was — no extra fiber, no extra
+  passive effect, and nothing new in
+  `re-frame.bench.hicasso.arm1.runtime/retained-inventory`."
+  [handle hiccup]
+  (let [app (provider (:frame handle)
+                      (codec/root-element (:frame handle) hiccup))]
+    (if (:hydrated? handle)
+      (react/createElement (.-Fragment react) nil
+                           (react/createElement adoption-window-closer nil)
+                           app)
+      app)))
+
 (defn render!
   "Render `hiccup` into an existing root, synchronously.
 
@@ -62,12 +92,11 @@
   to inherit the frame from — the case rf2-2rtt6.39's frame-as-a-prop
   variant needs named. The context provider is installed regardless: it
   is what the substrate's other React-shaped adapters read, and what the
-  error boundary and the presence tray resolve their frame from."
+  error boundary and the presence tray resolve their frame from.
+
+  Takes a hydrated handle unchanged — [[tree]] is what makes that true."
   [handle hiccup]
-  (react-dom/flushSync
-    (fn [] (.render (:root handle)
-                    (provider (:frame handle)
-                              (codec/root-element (:frame handle) hiccup)))))
+  (react-dom/flushSync (fn [] (.render (:root handle) (tree handle hiccup))))
   handle)
 
 (defn root!
@@ -131,17 +160,19 @@
 
   The closer sits OUTSIDE the frame provider on purpose — it reads no
   subscription and needs no frame, and a nil-rendering component with no
-  frame dependency is the smallest thing that can carry the effect."
+  frame dependency is the smallest thing that can carry the effect.
+
+  ## The handle carries `:hydrated?`, and it has to
+
+  [[root!]]'s three keys are all here and every door takes this handle
+  unchanged. The fourth key is not decoration: the wrapper above is part
+  of the ROOT's shape, so [[render!]] has to reproduce it or React tears
+  the adopted tree down and rebuilds it. [[tree]] is the one place that
+  decision is made and `:hydrated?` is what it reads."
   [container frame-kw hiccup]
   (rt/open-adoption-window!)
-  {:root      (react-dom-client/hydrateRoot
-                container
-                (react/createElement
-                  (.-Fragment react) nil
-                  (react/createElement adoption-window-closer nil)
-                  (provider frame-kw (codec/root-element frame-kw hiccup))))
-   :frame     frame-kw
-   :container container})
+  (let [handle {:frame frame-kw :container container :hydrated? true}]
+    (assoc handle :root (react-dom-client/hydrateRoot container (tree handle hiccup)))))
 
 (defn unmount!
   "Unmount the root and detach its container, and **touch nothing the

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/presence.cljs
@@ -65,7 +65,15 @@
   The effect that remains does the two things only a clock can: it flips
   `:mounting` to `:present` after paint, and it arms **one** timer at the
   earliest deadline. Deadlines are absolute instants, so a timer re-armed
-  because some *other* key changed cannot extend a child's retention."
+  because some *other* key changed cannot extend a child's retention.
+
+  ## Born present under adoption (rf2-2rtt6.84)
+
+  A hydrating tree's children are already on the screen, so they start
+  `:present` rather than `:mounting` — the machine's own `settle`,
+  applied one render earlier, gated on `runtime/adopting?`. It costs no
+  hook, changes no transform, and is scoped to the adoption window; see
+  the comment at the binding below."
   (:require [re-frame.adapter.context :as adapter-context]
             [re-frame.bench.hicasso.arm1.runtime :as rt]
             [re-frame.bench.hicasso.front.codec :as codec]
@@ -87,7 +95,30 @@
         hook       (react/useState presence/initial)
         state      (aget hook 0)
         set-state  (aget hook 1)
-        next       (presence/step state children (now) timeout-ms)]
+        stepped    (presence/step state children (now) timeout-ms)
+        ;; BORN PRESENT UNDER ADOPTION (rf2-2rtt6.84). A child a render
+        ;; meets for the first time is `:mounting`, which is right for a
+        ;; child that is genuinely appearing and wrong for one that is
+        ;; already on the screen: under hydration every child is already
+        ;; painted, so entering them replays an enter animation the user
+        ;; watched the server deliver, and — worse — makes the first
+        ;; client pass render each child's `::h/mounting` overrides
+        ;; (`opacity: 0`, typically) over DOM that carries none.
+        ;;
+        ;; The fix is the machine's own [[front.presence/settle]], the
+        ;; function the enter flip already uses, applied one render
+        ;; earlier. So this is ADOPTION BEHAVIOUR — a different starting
+        ;; phase for a tree that is being adopted — and not a second
+        ;; render mode: the transform, the overrides, the deadlines and
+        ;; the terminal bound are all unchanged, and `adopting?` is false
+        ;; for every ordinary mount and false again the moment the
+        ;; closer commits.
+        ;;
+        ;; A SERVER render entry opens the same window, so the server's
+        ;; HTML and the client's first pass agree by construction; that
+        ;; agreement is the whole reason the flag is read here in the
+        ;; RENDER rather than in the effect below.
+        next       (if (rt/adopting?) (presence/settle stepped) stepped)]
     ;; Adjusting state while rendering — React's own answer to "a value
     ;; derived from props that must persist". `step` is idempotent, so the
     ;; equality test converges rather than looping.

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -405,7 +405,11 @@
   ([[cold-read!]] — nil until a cold read mints it, reset by every
   [[run-once]] exactly as the scratch is). One JS object for the whole
   runtime — not one per render."
-  #js {"frame" nil "collector" false "grouped" false "entry" nil "probe" nil})
+  #js {"frame"    nil "collector" false "grouped" false "entry" nil "probe" nil
+       ;; The always-on body-run counter (rf2-2rtt6.84 (6)) — one integer
+       ;; on the object that already exists, bumped by [[run-once]] and
+       ;; read by [[body-runs]].
+       "bodyRuns" 0})
 
 (def ^:private ^js scratch
   "**The one scratch buffer**, reused by every body and reset by
@@ -420,6 +424,60 @@
   "Is a boundary body running right now?"
   []
   (some? (.-frame rstate)))
+
+;; ---------------------------------------------------------------------------
+;; The adoption window (rf2-2rtt6.84)
+;; ---------------------------------------------------------------------------
+
+(def ^:private ^js adoption
+  "Is this page's tree being ADOPTED from server-rendered HTML right now?
+
+  Opened by [[re-frame.bench.hicasso.arm1.mount/hydrate-root!]] before it
+  calls `hydrateRoot`, and closed by that root's closer component from a
+  passive effect on the hydration commit — the spine's own pattern
+  (`re-frame.substrate.spine/adoption-window-closer`), whose whole point
+  is that a passive effect runs strictly AFTER the commit and therefore
+  cannot close the window early.
+
+  **Module-level, like every other slot in this arm.** `rstate`, the
+  scratch and the cell table are one-per-page too. A page hydrates once,
+  at boot, so one window is the shape the case has; a second hydrating
+  root opened while the first window is still open would share it, and
+  that limit is stated rather than engineered around. The spine keeps its
+  flag root-local because it hands the flag to its closer as a prop —
+  doing the same here would put a prop or a context read on
+  `arm1.presence`, which is a cost this arm has no case for.
+
+  A boolean and nothing else: it selects **adoption behaviour** in a
+  renderer that still has exactly one render mode (the charter's
+  one-mode law). Nothing branches on it but presence's born-present
+  seeding."
+  #js {"open" false})
+
+(defn adopting?
+  "Is a hydration adoption in flight?
+
+  False on every ordinary client mount, and false again the moment the
+  adopted root's closer commits. A server render entry opens the same
+  window around its own `renderToString`, so the two halves of an SSR
+  route answer this identically — which is what stops the client's first
+  pass from rendering something the server did not."
+  []
+  (.-open adoption))
+
+(defn open-adoption-window!
+  "Declare the renders that follow to be adopting server-rendered DOM."
+  []
+  (set! (.-open adoption) true)
+  nil)
+
+(defn close-adoption-window!
+  "Close the window. The closer component's passive effect calls this,
+  and so does [[reset-runtime!]] — a fixture that throws mid-hydration
+  must not leave the page permanently adopting."
+  []
+  (set! (.-open adoption) false)
+  nil)
 
 ;; ---------------------------------------------------------------------------
 ;; Frame-locked ops, resolved once per frame and not once per boundary
@@ -1262,14 +1320,56 @@
                (if (seq left) (assoc m bucket-key left) (dissoc m bucket-key)))))
     nil))
 
+(def ^:private entry-reap-horizon-ms
+  "The provisional-entry reaper's delay: **4 ms, not 0** (rf2-2rtt6.84).
+
+  ## What the 0 raced
+
+  An entry is minted during the RENDER ([[entry-for]], from
+  [[render-body]]) and claimed during the COMMIT — React calls the
+  entry's `subscribe` from a passive effect, and that is the only place
+  `refs` goes above zero. A `setTimeout 0` armed inside the render
+  therefore has to beat React back to its own passive flush, and on a
+  root React renders CONCURRENTLY it does not: the entry is evicted from
+  the cache before it is claimed, the subscribed boundary holds a
+  detached entry, and the next render of the same read sequence misses,
+  mints a second entry, and hands `useSyncExternalStore` a different
+  `subscribe` — so React tears the subscription down and rebuilds it,
+  releasing and re-acquiring every cell, immediately after adoption.
+
+  `hydrateRoot` is exactly such a root, which is why this moved with the
+  hydration door. It is the same class rf2-2rtt6.71 fixed in the spine,
+  where a `setTimeout 0` escrow reaper beat `createRoot().render()`'s
+  passive flush and cost `bodyRuns` 2.00N on every consumer mount; 4 ms
+  was the SHORTEST delay measured to win there, at N = 1 and N = 300
+  alike, and this arm adopts that number rather than inventing one.
+
+  ## A MARGIN, NOT A CONTRACT
+
+  React documents no maximum render-to-subscribe interval, so 4 ms cannot
+  be sized against a guarantee — it is the measured distance on React 19
+  today, and a scheduling change can silently reintroduce the rebuild.
+  **No caller may rely on it.** Correctness does not: a lost race costs
+  a cache miss and a rebuilt subscription, never a wrong value, because
+  the entry object itself survives in the closure that was handed out.
+  What the horizon buys is that the adoption is realised, and what it
+  costs is that an abandoned render's entry sits in the cache 4 ms longer
+  than it used to — the zero-leak property is unchanged, its zero-POINT
+  moved."
+  4)
+
 (defn- arm-entry-reaper!
-  "An entry with no committed boundary is dropped one macrotask later.
+  "An entry with no committed boundary is dropped at the reap horizon.
   Two callers, one rule: an entry a discarded render minted was never
   claimed, and an entry whose last boundary unmounted is no longer
   anybody's. Both are cache eviction and neither is a record of something
-  to undo."
+  to undo.
+
+  The horizon is [[entry-reap-horizon-ms]] — deliberately past a bare
+  `setTimeout 0`, and deliberately not a promise to anyone."
   [^js entry]
-  (js/setTimeout (fn [] (when (zero? (.-refs entry)) (drop-entry! entry))) 0)
+  (js/setTimeout (fn [] (when (zero? (.-refs entry)) (drop-entry! entry)))
+                 entry-reap-horizon-ms)
   nil)
 
 (defn- entry-matches?
@@ -1440,6 +1540,11 @@
   (set! (.-grouped rstate) false)
   (set! (.-probe rstate) nil)
   (set! (.-frame rstate) frame-kw)
+  ;; THE BODY-RUN COUNTER, bumped where a body actually runs and nowhere
+  ;; else — see [[body-runs]]. Here rather than in `shell` because the
+  ;; generation fence can run a body twice for one render, and a real
+  ;; count is the one that says so.
+  (set! (.-bodyRuns rstate) (inc (.-bodyRuns rstate)))
   (try
     (intent/with-frame frame-kw (frame-dispatch frame-kw)
       (fn [] (codec/as-element (body-fn props))))
@@ -1506,6 +1611,46 @@
   claim in a docstring."
   []
   {:collector? (.-collector rstate) :grouped? (.-grouped rstate)})
+
+(defn body-runs
+  "How many boundary bodies this runtime has run, since the process
+  started or since the last [[reset-body-runs!]].
+
+  ## Always on, and why that was the choice (rf2-2rtt6.84 (6))
+
+  The SSR spike's adoption row has to read body runs out of the build it
+  actually drives, and the arm's builds are `:advanced` with
+  `goog.DEBUG false` — so a `goog.DEBUG`-gated instrument is not an
+  instrument there, it is dead code the compiler removes. The two
+  candidates were a declared dev-build witness row and an always-on
+  counter. **The counter wins**, because a dev-build row would answer
+  about a build nobody ships and would have to be believed rather than
+  read, and because the price is a single integer increment on a JS
+  object that already exists, next to a body run that allocates elements
+  — below the noise of everything the lane's clock rows measure.
+
+  ## It counts REAL runs (HD-028's rider)
+
+  The bump is inside [[run-once]], which is where a body is invoked. It
+  is therefore blind to how the render got there: a `React.memo` bail-out
+  on `mint-view!`'s wrapper shows up as an increment that did NOT happen,
+  which is exactly what makes this a measurement of adoption rather than
+  an inference from the memo's behaviour. A boundary React skipped and a
+  boundary React ran are two different numbers here, and the memo cannot
+  make the second look like the first.
+
+  Monotone: witnesses take a DELTA across the thing they are measuring,
+  which is why [[reset-runtime!]] deliberately leaves it alone — a
+  teardown door that zeroed the instrument would let a reading taken on
+  the wrong side of a reset look like a reading."
+  []
+  (.-bodyRuns rstate))
+
+(defn reset-body-runs!
+  "Zero [[body-runs]]. Explicit, and not part of [[reset-runtime!]]."
+  []
+  (set! (.-bodyRuns rstate) 0)
+  nil)
 
 ;; ---------------------------------------------------------------------------
 ;; The shell — exactly two React hooks, and no useRef
@@ -1833,5 +1978,8 @@
   (set! (.-frame rstate) nil)
   (set! (.-probe rstate) nil)
   (set! (.-length scratch) 0)
+  ;; A fixture that threw mid-hydration must not leave the page adopting.
+  ;; `bodyRuns` is deliberately NOT reset here — see [[body-runs]].
+  (close-adoption-window!)
   (forget-frame-ops!)
   nil)


### PR DESCRIPTION
The client half every Hicasso SSR route shares. Bench lane only — no `spec/*`, no `implementation/core`.

## What landed, clause by clause

**(1) `hydrate-root!` beside `root!`** (`arm1/mount.cljs`). `hydrateRoot` is called **plain — no `flushSync`**: nothing in the tree forces hydration synchronously, so a flush would manufacture a schedule no shipped caller has. The consequence is that the door returns *before* the tree is adopted, so the window is closed by a **component**: `adoption-window-closer`, a nil-rendering Fragment sibling whose passive `useEffect` clears the flag — the spine's own pattern (`spine.cljs` `adoption-window-closer` / `make-render`). `(rt/adopting?)` answering false *is* that effect having run, which is the completion signal a witness waits on in place of the flush.

**A defect the bead did not anticipate, found and fixed.** The hydrated root's top element is a Fragment; `render!` rebuilt a bare provider. React reconciles a root by its top element, so the first ordinary `render!` after adoption **tore the adopted tree down and mounted a fresh one** — measured at four re-run bodies and four replaced DOM nodes, i.e. everything adoption achieved, undone. The root tree's shape now lives in one place (`mount/tree`), keyed off `:hydrated?` on the handle. The ordinary path is byte-for-byte what it was: **no extra fiber, no extra passive effect, nothing new in `retained-inventory`** — deliberately, on a lane that measures fibers and heap.

The handle carries `{:root :frame :container}` plus `:hydrated?`. `render!`, `dispatch!`, `unmount!` and `release!` all take it unchanged.

**(2) Entry reaper 0 → 4 ms** (`arm1/runtime.cljs`, `entry-reap-horizon-ms`). An entry is minted in the RENDER and claimed in the COMMIT; a `setTimeout 0` armed inside the render cannot beat React back to its own passive flush on a concurrent root, so the entry is evicted before it is claimed and the next render mints a second one and rebuilds the subscription. Same class rf2-2rtt6.71 fixed in the spine, same number, and carrying the spine's **margin-not-a-contract** prose verbatim in intent: no caller may rely on it, and correctness never did — a lost race costs a cache miss, never a wrong value.

**(3) Presence born-present under adoption** (`arm1/presence.cljs`). One `if`, applying the machine's own `front.presence/settle` a render earlier when `rt/adopting?`. **No new hook** — presence stays at its declared three, the boundary shell stays at two. It is scoped to the adoption window and changes no transform, so the charter's one-mode law is intact. It is read in the RENDER, not an effect, because a server entry opens the same window and the two halves must agree by construction.

**(4) HD-019 rider.** Hydration converges nothing — `converge!` runs at the end of a change handler and hydration fires none — and the `defaultValue` mirror the whole caret restore rests on **is** established on the hydrated path. Witnessed, along with the markup contract a server must meet (`value="…"` present in the bytes).

**(5) HD-028 rider.** The body-run counter is bumped inside `run-once`, where a body is *invoked*. A `React.memo` bail-out therefore reads as an increment that did **not** happen, which is what makes it a measurement of adoption rather than an inference from the memo.

**(6) Instrument visibility (adversarial F6) — decision: an always-on counter, documented in `runtime/body-runs`.** A dev-build row would answer about a build nobody drives; the price here is one integer increment on a JS object that already exists, next to a body run that allocates elements. It is monotone and `reset-runtime!` deliberately leaves it alone, so witnesses take a delta.

### One correction to the bead

Clause 6 says the counter "is DCE'd `goog.DEBUG`-gated today". **It is not gated — it does not exist.** The only body-run counter in the lane is `arm1/grid.cljs`'s `!body-runs`, an always-on atom inside one fixture's view, invisible to any other screen. `goog.DEBUG` appears in the lane only in `codec.cljs`'s fail-open warn and `lane.cljs`'s build stamp. The remedy the clause asks for is the right one either way, and the new counter is on the shared render path, so it answers for the dogfood screen the X-witnesses drive.

## Witnesses

`arm1/hydrate_cljs_test.cljs` (headless) — the reap horizon as the *race* rather than the integer; a claimed entry is never reaped; the adoption window opens, closes, and is closed by `reset-runtime!`; `body-runs` counts real bodies and a fenced re-run reads **two**.

`arm1/hydrate_dom_cljs_test.cljs` (real React DOM) — adoption completes via the closer with server node identity preserved (an **expando**, so it cannot survive re-serialisation); the entry cache still holds one entry per boundary past the horizon and a post-adoption write reaches the adopted boundary without minting a second; presence born-present, **with a client-mount control that answers false**; the hydrated controlled input keeps value, node and mirror; body runs equal boundary count exactly, and a props-equal re-render moves the counter by zero without remounting.

**Both trap classes the lane has been bitten by are closed.** Every hydration row runs inside a capture that listens on `window`'s `error` event *and* spies `console.error` — the two channels React 19 reports a mismatch on, neither of which reaches `cljs.test` — and asserts the capture empty. Adoption is awaited on **real timers only**: no `act`, no `flushSync`.

**Where the "server" bytes come from, stated in the ns docstring:** not `react-dom/server` — the Node entry is rf2-2rtt6.86's and the spike is rf2-2rtt6.87's. The fixture markup is this tree's own client render captured under an open adoption window. The markup *contract* is therefore asserted explicitly on the captured bytes rather than assumed. Fixtures deliberately avoid adjacent text children, which would measure rf2-2rtt6.88's known text-separator divergence instead of this door.

## Mutation proofs (both directions, through gated suites)

| mutation | gate | result |
|---|---|---|
| `entry-reap-horizon-ms` 4 → 0 | `npm run test:cljs` | **1 failure**, `an-unclaimed-entry-survives-a-bare-macrotask-and-not-the-horizon`: `expected (= 1 (:entries (rt/stats))) / actual (not (= 1 0))` — the entry was reaped inside a bare macrotask |
| reverted byte-identically | `npm run test:cljs` | 0 failures, exit 0 |
| born-present removed (`next stepped`) | `npm run test:browser` | **1 failure**, `a-hydrated-tray-is-born-present-and-never-replays-its-enter`: `toast--enter` reappears in the server bytes |
| reverted byte-identically | `npm run test:browser` | 0 failures, exit 0 |

The `mount/tree` repair was mutation-proved by discovery: the bare-provider `render!` produced a real red (`(not (zero? 4))`) before the fix and green after.

Reverts confirmed byte-identical by a clean `git status`, not by re-typing.

## Quality gates

| gate | exit |
|---|---|
| `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine` |
| `npm run test:cljs` | **0** — 12512 tests / 62755 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **0** — 1059 tests / 6595 assertions, 0 failures, 0 errors |
| `npm run test:hicasso-compile` | **0** — 103 lane namespaces, zero warnings |

Run on Windows from `C:/Users/miket/code/re-frame2-worktrees/ssrhydrate-2rtt6-84`; CI is Linux. No assertion added here reads a checkout-dependent property (line endings, path separators, file modes).

`shellcheck` is not installed here and was **not** run.

**Tiers the spine skipped on this diff classification, stated rather than implied:** its own tiering self-test (`spine unchanged`) and the doc gates (`documentation surface unchanged`). Both are correct for a diff confined to `implementation/freehand/test/…`, and neither was overridden.

One transient on a first spine run — `_changed-surfaces.test.cjs` reported `Command failed: git ls-files` seven times. It reproduces neither standalone (277 passed) nor on the clean re-run; it touches no file in this diff.

## Fences

Bench lane only. `git diff origin/main...HEAD --stat` is six files, all under `implementation/freehand/test/re_frame/bench/hicasso/arm1/`. No `spec/`, no `implementation/core`, no `docs/`, no `.beads`, no `shadow-cljs.edn`.

`spine.cljs:3031` re-verified as `(React/useSyncExternalStore subscribe-fn get-snap get-snap)` — `getServerSnapshot` already passed, no core change needed.

**No collision with the siblings.** `arm1/runtime.cljs` is touched here (reaper, counter, adoption window). rf2-2rtt6.85's primary file is `front/codec.cljs` and its client mechanism is React's own `getServerSnapshot`, which needs nothing from this flag; rf2-2rtt6.86 is a new Node namespace. No sibling PR was open while this was written.

The **≤2-hook shell is unchanged**: every hunk in `runtime.cljs` is a pure insertion outside the shell region, `shell-hook-ledger` and `frame-prop-shell-hook-ledger` are untouched, and `hook_ledger_dom_cljs_test` is green. `adoption-window-closer` has one hook and is not a boundary shell — it reads no subscription, mounts no registration and takes no cell, the same classification `arm1/presence` carries.

Closes rf2-2rtt6.84. Unblocks rf2-2rtt6.87.
