### PR TITLE
feat(hicasso): the SSR Node render entry (rf2-2rtt6.86)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/driver.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/driver.cjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+'use strict';
+// THE HICASSO SSR DRIVER — build once, then BAKE or SERVE (rf2-2rtt6.86
+// clauses 3, 4 and 5).
+//
+//     node freehand/test/re_frame/bench/hicasso/ssr/driver.cjs bake
+//     node freehand/test/re_frame/bench/hicasso/ssr/driver.cjs serve [--port 8137]
+//
+// One renderer, run in two places: `bake` writes the static
+// HTML + payload corpus, `serve` answers real requests with the same
+// entry, and neither has a renderer of its own — both call
+// `re-frame.bench.hicasso.ssr.node`'s API through the compiled bundle.
+//
+// ## NO EDIT TO shadow-cljs.edn, deliberately (clause 5)
+//
+// The bead says to carry this on existing node-build infrastructure first
+// and mint `:hicasso-ssr-node` only if needed. It is not needed: the build
+// rides `:freehand-bench-node` — the tree's existing `:node-script` — and
+// supplies its own `:main` and `:output-to` through `--config-merge`,
+// exactly as every arm in this lane rides `:hicasso-bench` with its own
+// `:init-fn` and exactly as `b6_prod_run.cjs` rides `:freehand-release`.
+// HD-017 makes a build-id touch a hot-zone, sequenced dispatch; this lane
+// was built so a sibling never has to pay one, and an SSR entry is no
+// more entitled to than an arm is.
+//
+// `:hicasso-bench` — the lane's own id — could NOT serve here: it is a
+// `:browser` target, and `renderToString` wants Node's `server.node.js`
+// through Node's own conditional exports.
+//
+// ## The cache rule (rf2-2rtt6.20), and why it is cheap here
+//
+// shadow-cljs derives the build cache directory from the build id alone,
+// before any `--config-merge` is applied, so two programs under one id
+// share one cache entry. The lane's answer is to clear it, and this
+// driver does the same. It is cheaper here than in the browser lane: a
+// `:node-script` uses `:js-provider :require`, so there is no shadow-js
+// npm-conversion index — the exact artefact rf2-2rtt6.20 isolated as the
+// carrier — and what is discarded is a plain per-namespace CLJS cache.
+// The cost is a cold `npm run bench:freehand-node` afterwards, which is a
+// manual bench for a withdrawn programme and not a gate.
+//
+// ## Warnings are failures, on BOTH sides of the build
+//
+// `lane_build.cjs` refuses a shadow build that merely warned. This driver
+// extends the same rule to the RENDER: React reports a bad server render
+// through `console.error` while returning markup and exiting 0 — a
+// hydration-relevant defect that would otherwise ride into a baked
+// fixture behind a green run. Every render here happens with the console
+// captured, and any React diagnostic is a refusal.
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+const { shadowBuild } = require('../lane_build.cjs');
+const { resetLaneBuildCache } = require('../../../freehand/bench/lane_cache.cjs');
+
+const IMPL = path.resolve(__dirname, '../../../../../..');
+const BUILD_ID = 'freehand-bench-node';
+const OUTPUT_TO = 'out/hicasso-ssr-node.js';
+const BUNDLE = path.join(IMPL, OUTPUT_TO);
+const BAKE_DIR = path.join(IMPL, 'out', 'hicasso-ssr-fixtures');
+const TAG = 'hicasso-ssr';
+
+// ONE LINE, deliberately: shadow-cljs's CLI re-splits `--config-merge` on
+// whitespace once the EDN contains a newline, then reports `EOF while
+// reading` from a fragment.
+const CONFIG_MERGE =
+  `{:main re-frame.bench.hicasso.ssr.node/-main :output-to "${OUTPUT_TO}"}`;
+
+function build() {
+  if (resetLaneBuildCache(IMPL, BUILD_ID)) {
+    console.error(
+      `[${TAG}] cleared .shadow-cljs/builds/${BUILD_ID} — one build id, N programs (rf2-2rtt6.20)`,
+    );
+  }
+  console.error(`[${TAG}] building the SSR node entry -> ${OUTPUT_TO}`);
+  shadowBuild({ impl: IMPL, mode: 'compile', buildId: BUILD_ID, configMerge: CONFIG_MERGE, tag: TAG });
+}
+
+/** The API the compiled bundle publishes. Requiring it IS the boot. */
+function loadApi() {
+  require(BUNDLE);
+  const api = globalThis.HICASSO_SSR;
+  if (!api) {
+    console.error(
+      `[${TAG}] the bundle loaded but published no API on globalThis.HICASSO_SSR — ` +
+        `did :main stop being re-frame.bench.hicasso.ssr.node/-main?`,
+    );
+    process.exit(1);
+  }
+  return api;
+}
+
+/**
+ * Run `fn` with `console.error` / `console.warn` captured, and REFUSE if
+ * React said anything. React's server renderer reports a bad render — a
+ * `value` without a change handler, an unknown prop, a hook that cannot
+ * run on the server — through the console while still returning markup
+ * and still exiting 0. A bake that swallowed that would publish a fixture
+ * the hydration bead then fails on, one bead later and one layer away.
+ */
+function renderQuietly(label, fn) {
+  const said = [];
+  const realError = console.error;
+  const realWarn = console.warn;
+  console.error = (...a) => said.push(['error', a.map(String).join(' ')]);
+  console.warn = (...a) => said.push(['warn', a.map(String).join(' ')]);
+  let out;
+  try {
+    out = fn();
+  } finally {
+    console.error = realError;
+    console.warn = realWarn;
+  }
+  if (said.length > 0) {
+    console.error(`\n[${TAG}] REFUSED — ${label} rendered, but React reported ${said.length} diagnostic(s):`);
+    for (const [kind, text] of said) console.error(`[${TAG}]   ${kind}: ${text}`);
+    console.error(
+      `[${TAG}] A server render that warns is a hydration defect that has not ` +
+        `happened yet. Fix the render; do not bake the fixture.`,
+    );
+    process.exit(1);
+  }
+  return out;
+}
+
+const sha256 = (s) => crypto.createHash('sha256').update(s, 'utf8').digest('hex');
+
+// ---------------------------------------------------------------------------
+// bake
+// ---------------------------------------------------------------------------
+
+function bake(api) {
+  fs.rmSync(BAKE_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  fs.mkdirSync(BAKE_DIR, { recursive: true });
+
+  const rows = [];
+  for (const id of api.ids) {
+    const r = renderQuietly(id, () => api.renderTwice(id));
+
+    // Clause 2, and the driver's half of it: the entry already compared
+    // the two documents byte-for-byte; this hashes them, because a hash is
+    // what a manifest can carry and what a later run can be compared to.
+    const a = sha256(r.first.document);
+    const b = sha256(r.second.document);
+    if (!r.identical || a !== b) {
+      console.error(
+        `\n[${TAG}] REFUSED — ${id} rendered two DIFFERENT documents from the ` +
+          `same bundle and the same snapshot` +
+          (r.differsAt >= 0 ? ` (first difference at character ${r.differsAt})` : ''),
+      );
+      console.error(`[${TAG}]   sha256 #1 ${a}`);
+      console.error(`[${TAG}]   sha256 #2 ${b}`);
+      console.error(
+        `[${TAG}] Determinism is the property that makes a baked fixture a ` +
+          `fixture. Find the nondeterminism; do not re-run until it agrees.`,
+      );
+      process.exit(1);
+    }
+    // The two renders took two different per-request frames and produced
+    // the same bytes — which is the gensym's invisibility, demonstrated.
+    if (r.first.frameId === r.second.frameId) {
+      console.error(
+        `\n[${TAG}] REFUSED — ${id}'s two renders shared a frame id ` +
+          `(${r.first.frameId}); the per-request frame is not per-request.`,
+      );
+      process.exit(1);
+    }
+
+    fs.writeFileSync(path.join(BAKE_DIR, `${id}.html`), r.first.document, 'utf8');
+    fs.writeFileSync(path.join(BAKE_DIR, `${id}.body.html`), r.first.html, 'utf8');
+    fs.writeFileSync(path.join(BAKE_DIR, `${id}.payload.edn`), r.first.payloadEdn, 'utf8');
+
+    rows.push({
+      id,
+      documentBytes: r.first.document.length,
+      bodyBytes: r.first.html.length,
+      payloadBytes: r.first.payloadEdn.length,
+      renderHash: r.first.renderHash,
+      sha256: a,
+      frames: [r.first.frameId, r.second.frameId],
+    });
+    console.error(
+      `[${TAG}] ${id.padEnd(24)} ${String(r.first.document.length).padStart(7)} B  sha256 ${a.slice(0, 16)}…`,
+    );
+  }
+
+  const manifest = {
+    bead: 'rf2-2rtt6.86',
+    generatedBy: 'freehand/test/re_frame/bench/hicasso/ssr/driver.cjs bake',
+    // No timestamp: a manifest that changes on every run cannot be
+    // compared to the previous one, which is the only thing it is for.
+    rows,
+  };
+  fs.writeFileSync(
+    path.join(BAKE_DIR, 'manifest.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    'utf8',
+  );
+
+  console.error(`[${TAG}] ok — ${rows.length} fixtures baked to ${path.relative(IMPL, BAKE_DIR)}`);
+}
+
+// ---------------------------------------------------------------------------
+// serve — the live demo (clause 4)
+// ---------------------------------------------------------------------------
+
+// PAGE-LEVEL, and explicitly NOT a production host: Spec 011's HTTP
+// response contract — the response accumulator, cookies, redirects, the
+// CRLF fail-fast — stays `ssr-ring`'s. This exists so that live,
+// per-request Hicasso SSR is DEMONSTRABLE at the P2 sitting, the way the
+// adapters' live SSR already is.
+function serve(api, port) {
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, 'http://localhost');
+
+    if (url.pathname === '/main.js') {
+      // There is no client bundle in this bead — the hydration door is
+      // rf2-2rtt6.84's. Answering with a comment rather than a 404 keeps
+      // the demo's console clean and says why.
+      res.writeHead(200, { 'content-type': 'text/javascript; charset=utf-8' });
+      res.end('// no client bundle in this bead — the hydration door is rf2-2rtt6.84\n');
+      return;
+    }
+
+    // The request's OWN state, so "per-request" is something a reader can
+    // see rather than something this comment claims.
+    const n = Math.max(0, Math.min(200, Number(url.searchParams.get('todos') ?? 5) || 0));
+    const started = process.hrtime.bigint();
+    const out = renderQuietly(`GET ${req.url}`, () => api.renderDogfood(n));
+    const ms = Number(process.hrtime.bigint() - started) / 1e6;
+
+    console.error(
+      `[${TAG}] ${req.method} ${req.url} -> 200, ${n} to-dos, ` +
+        `${out.document.length} B, frame ${out.frameId}, ${ms.toFixed(1)} ms`,
+    );
+    res.writeHead(200, {
+      'content-type': 'text/html; charset=utf-8',
+      // The frame id on a header, because the demo's whole claim is that
+      // each request got its own and it was destroyed before the response.
+      'x-hicasso-ssr-frame': out.frameId,
+    });
+    res.end(out.document);
+  });
+
+  server.listen(port, () => {
+    console.error(`[${TAG}] live SSR on http://127.0.0.1:${port}/  (try /?todos=12)`);
+  });
+  return server;
+}
+
+// ---------------------------------------------------------------------------
+
+if (require.main === module) {
+  const argv = process.argv.slice(2);
+  const mode = argv.find((a) => !a.startsWith('-')) || 'bake';
+  const portArg = argv.indexOf('--port');
+  const port = Number(portArg >= 0 ? argv[portArg + 1] : process.env.HICASSO_SSR_PORT || 8137);
+
+  if (mode !== 'bake' && mode !== 'serve') {
+    console.error(`[${TAG}] unknown mode ${JSON.stringify(mode)} — expected 'bake' or 'serve'`);
+    process.exit(1);
+  }
+
+  build();
+  const api = loadApi();
+
+  if (mode === 'bake') bake(api);
+  else serve(api, port);
+}
+
+module.exports = { sha256, renderQuietly, BAKE_DIR, BUILD_ID, OUTPUT_TO };

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry.cljs
@@ -246,9 +246,11 @@
             ;; It is left as the framework's own call (R0 — this bead does
             ;; not invent a payload byte) and pinned by
             ;; `the-render-hash-is-degenerate-for-an-interpreted-root` so
-            ;; nobody can start relying on it by accident; the repair is
-            ;; a bead, and it is the SSR programme's, because a real fix
-            ;; is a server AND client contract.
+            ;; nobody can start relying on it by accident. The repair is
+            ;; rf2-2rtt6.91, and it is the SSR programme's rather than
+            ;; this bead's, because a real fix is a server AND client
+            ;; contract: a normalisation invented here alone would make
+            ;; every page a MISMATCH instead of a non-check.
             render-hash (ssr-hash/render-tree-hash hiccup)
             policy-opts (cond-> {:payload payload}
                           (some? client-frame-id) (assoc :client-frame-id client-frame-id)

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry.cljs
@@ -71,6 +71,32 @@
   **No streaming.** `renderToPipeableStream` is out of scope per the
   adversarial review, and out of scope here means absent, not deferred.
 
+  ## The one thing this entry does not do yet — THE ADOPTION WINDOW
+
+  Predicted by the rf2-2rtt6.84 worker and CONFIRMED here by measurement,
+  so it is a named gap rather than a surprise waiting for the spike
+  witness.
+
+  Presence starts a child at `:mounting` (`arm1/presence.cljs` —
+  `(react/useState presence/initial)`) and applies that child's
+  `::h/mounting` attribute overrides while it is in that phase. A server
+  render therefore ships the ENTER appearance — the class an animation is
+  about to move off. rf2-2rtt6.84 makes the hydrating client's first pass
+  render those same children `:present` instead (born-present under an
+  open adoption window), so the server's markup and the client's first
+  pass disagree, and React reports a hydration mismatch on every
+  presence-managed node. Measured on the corpus's `presence-mounting`
+  row, which bakes `toast--enter` today and is pinned red-when-fixed by
+  `the-server-render-ships-presences-mounting-overrides`.
+
+  **The repair is one line, and it is not writable yet**:
+  `renderToString` below must run between `rt/open-adoption-window!` and
+  `rt/close-adoption-window!`, and neither function exists on main — they
+  are in rf2-2rtt6.84's still-open PR #7469. Wiring it is rf2-2rtt6.94,
+  which is blocked on that merge. Nothing here is edited to anticipate
+  it: a call to a var that does not exist does not compile, and guessing
+  at a var that does is how two beads race one file.
+
   ## What this is NOT
 
   Not a production host. Spec 011's HTTP response contract — the response

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry.cljs
@@ -1,0 +1,308 @@
+(ns re-frame.bench.hicasso.ssr.entry
+  "THE HICASSO SSR RENDER ENTRY (rf2-2rtt6.86) — one renderer, run in two
+  places.
+
+  The server engine is **the existing Hicasso runtime** under Node's
+  `react-dom/server` `renderToString`. There is no second renderer here
+  and there is not going to be one: hydration parity is by construction
+  or it is a claim, and the difference is a whole class of bug the
+  adapters have already paid for.
+
+  ## Why running THIS runtime under renderToString is safe
+
+  Verified in the 2026-08-04 SSR design programme rather than assumed:
+
+  - Every shell passes `getServerSnapshot` (`arm1/runtime.cljs` — both
+    [[re-frame.bench.hicasso.arm1.runtime/shell]] and its frame-prop
+    twin hand `(.-snapshot entry)` as BOTH the client and server
+    snapshot). Under `renderToString` React calls the server snapshot and
+    **never calls `subscribe`**, so no registration is minted.
+  - Every `sub` read is therefore the mutation-free cold probe
+    (`runtime/cold-read!`): a pure compute against one coherent
+    frame-state snapshot, with no cache entry, no ref-count, no watch and
+    no disposal obligation.
+  - Commits and effects never run. The whole render is HD-002's
+    *abandoned render* by design, and the ledger discipline holds for the
+    same reason it holds for a render React throws away in the browser.
+
+  ## What one request is
+
+  [[render]] is the whole of it, and the order is the interesting part:
+
+    1. a per-request frame under a **gensym id** — never a shared one, so
+       two concurrent requests cannot read each other's app-db;
+    2. seeded through the FRAMEWORK'S doors — `:initial-events`, and the
+       reserved `:rf/set-db` for a snapshot handed in whole;
+    3. rendered as `(provider frame (codec/root-element frame hiccup))`,
+       the same two calls `arm1/mount/render!` makes in the browser;
+    4. the payload built out of the FRAMEWORK'S OWN BYTES —
+       `payload-policy/apply-policy` (the fail-closed `:payload`
+       contract), `project-app-db-egress`, `build-payload`, and
+       `html-helpers/escape-edn-script-body` under the pinned
+       `__rf_payload` script id. Nothing Hicasso-specific touches the
+       payload path (R0); this namespace supplies the app-db and gets out
+       of the way;
+    5. `destroy-frame!` in a `finally`, so a render that threw leaks no
+       more than one that returned.
+
+  ## The wire frame-id is nil, deliberately
+
+  `payload-policy/build-payload`'s first argument is the WIRE
+  `:rf/frame-id`, which its docstring is explicit must be a stable id both
+  ends agreed on ahead of time and **never a per-request server gensym**
+  (rf2-lm2yzy: stamping the gensym guarantees
+  `:rf.error/hydration-frame-id-mismatch` on every real page). The
+  per-request gensym is the PROJECTION frame — it drives
+  `project-app-db-egress` — and the wire id comes from the caller's
+  `:client-frame-id` or is omitted. An absent `:rf/frame-id` is no
+  conflict, which is precisely the anonymous-server-frame shape.
+
+  ## Determinism
+
+  Same bundle + same snapshot ⇒ byte-identical HTML. There is no `useId`
+  anywhere in the lane, no randomness on the render path, and
+  `renderToString` runs synchronously so the runtime's module-level render
+  context is sound per request. [[render-twice]] renders the same request
+  twice and compares the documents byte-for-byte; the driver hashes them.
+  The gensym differs between the two renders and MUST NOT be observable —
+  it never reaches the wire, which is one of the things the comparison
+  proves.
+
+  **No streaming.** `renderToPipeableStream` is out of scope per the
+  adversarial review, and out of scope here means absent, not deferred.
+
+  ## What this is NOT
+
+  Not a production host. Spec 011's HTTP response contract — the response
+  accumulator, cookies, redirects, CRLF fail-fast — stays `ssr-ring`'s,
+  and no file under `implementation/ssr` or `implementation/ssr-ring` is
+  touched by this bead. [[document]] mirrors `ssr-ring`'s own envelope
+  shape closely enough to be recognisable and is a BENCH-LANE page, priced
+  and ruled elsewhere."
+  (:require [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.ssr.host-policy :as host-policy]
+            [re-frame.core :as rf]
+            [re-frame.ssr.constants :as ssr-constants]
+            [re-frame.ssr.hash :as ssr-hash]
+            [re-frame.ssr.html-helpers :as ssr-html]
+            [re-frame.ssr.payload-policy :as payload-policy]
+            ["react-dom/server" :as rdom-server]))
+
+;; ---------------------------------------------------------------------------
+;; The per-request frame
+;; ---------------------------------------------------------------------------
+
+(defn fresh-frame-id
+  "A frame id no other request holds. `gensym` rather than a UUID because
+  the id is a projection target that lives for one synchronous render and
+  is destroyed before the function returns — it needs to be unique in this
+  process and nothing more, and it never reaches the wire."
+  []
+  (keyword "hicasso.ssr" (str (gensym "request-"))))
+
+(defn setup-events
+  "The construction-time setup vector for one request.
+
+  Both doors are the framework's own. `:rf/set-db` is the reserved
+  app-db seeding event (EP-0027) and is the SNAPSHOT-IN door — a host that
+  already has the request's state as a map hands it over whole. Anything
+  else the request needs (a route, a fetch already resolved) rides
+  `:initial-events` as ordinary events, in the order given, after the
+  snapshot."
+  [snapshot initial-events]
+  (cond-> []
+    (some? snapshot)     (conj [:rf/set-db snapshot])
+    (seq initial-events) (into initial-events)))
+
+;; ---------------------------------------------------------------------------
+;; The document envelope — bench lane, NOT the production host
+;; ---------------------------------------------------------------------------
+
+(defn payload-script
+  "The id-pinned `<script type=\"application/edn\">` carrying the
+  already-`pr-str`'d hydration payload.
+
+  Byte-for-byte the shape `re-frame.ssr.ring.shell/payload-script-tag`
+  emits, and it must stay that way: the id is
+  `re-frame.ssr.constants/payload-script-id` (the contract with the
+  client bootstrap's `getElementById` read) and the body goes through the
+  framework's EDN-aware escaper, which keeps `<` readable in token
+  position, escapes it inside string literals, and fails loud on a
+  genuine `</script` breakout. That namespace is JVM-only, so the three
+  lines are re-spelled here rather than required; the two CONSTANTS they
+  are made of are shared, which is the part that could drift."
+  [payload-edn]
+  (str "<script id=\"" ssr-constants/payload-script-id "\" type=\"application/edn\">"
+       (ssr-html/escape-edn-script-body payload-edn)
+       "</script>"))
+
+(defn document
+  "One page. The app root carries the body-only structural hash as
+  `data-rf-render-hash`, the payload script follows the root's close, and
+  the bootstrap `<script src>` is last — the order `ssr-ring`'s
+  non-streaming shell writes, so a fixture baked here is recognisable to
+  anyone who has read that one.
+
+  Deliberately minimal: no head model, no `:html-attrs`/`:body-attrs`
+  bags, no `:body-end` hook. Those are the production host's surface and
+  the production host is not this bead."
+  [{:keys  [html app-element-id script-src render-hash title]
+    script :payload-script}]
+  ;; `or`, not `:or` — a caller who threads `nil` through for an option it
+  ;; did not set (which is every caller with one options map) supplies the
+  ;; KEY, so destructuring defaults never fire and the page silently gets
+  ;; `id=""`. Caught by the first baked fixture, which is what a bake is
+  ;; for.
+  (str "<!DOCTYPE html>"
+       "<html lang=\"en\">"
+       "<head><meta charset=\"utf-8\"><title>"
+       (ssr-html/escape-html (or title "Hicasso SSR")) "</title></head>"
+       "<body>"
+       "<div id=\"" (ssr-html/escape-attr (or app-element-id "app")) "\""
+       " data-rf-render-hash=\"" (ssr-html/escape-attr (str render-hash)) "\">"
+       html
+       "</div>"
+       script
+       (when script-src
+         (str "<script src=\"" (ssr-html/escape-attr script-src) "\"></script>"))
+       "</body></html>"))
+
+;; ---------------------------------------------------------------------------
+;; The render entry
+;; ---------------------------------------------------------------------------
+
+(defn render
+  "Render one request. Returns
+
+      {:frame-id      the per-request gensym (destroyed by the time you
+                      read it — it is here to be asserted on, not used)
+       :html          the app root's INNER markup
+       :render-hash   the body-only structural hash of the render tree
+       :payload       the `:rf/hydration-payload` map
+       :payload-edn   that map, `pr-str`'d
+       :payload-script the `__rf_payload` <script> element
+       :document      the whole page}
+
+  `opts`:
+
+      :hiccup          REQUIRED. The root hiccup form.
+      :snapshot        a map seeded whole through `:rf/set-db`.
+      :initial-events  ordinary events, run after the snapshot.
+      :payload         REQUIRED, and the framework's fail-closed
+                       hydration-payload policy verbatim: a non-empty
+                       vector allowlist of top-level app-db keys, or
+                       `:rf.ssr.payload/whole-app-db`. Absence throws
+                       `:rf.error/ssr-missing-payload-policy` — from the
+                       framework's own validator, because this entry
+                       hands the value straight to it.
+      :frame-opts      merged UNDER the id and the setup vector, so a
+                       request that needs `:images`, `:url-strategy` or
+                       `:fx-overrides` declares them the same way any
+                       other frame does. `:id` and `:initial-events` are
+                       this entry's and cannot be overridden.
+      :client-frame-id the STABLE wire `:rf/frame-id`, or absent to omit
+                       the key (the anonymous-server-frame shape).
+      :version         :schema-digest  passed through to `build-payload`.
+      :app-element-id  :script-src  :title  the document envelope's.
+
+  The frame is destroyed in a `finally`. `destroy-frame!`'s lifecycle was
+  verified sound for this use in the design programme (`frame.cljc` —
+  destroy tears down the frame's containers and registrations), so a
+  per-request frame is a per-request frame and not a per-request leak."
+  [{:keys [hiccup snapshot initial-events payload frame-opts client-frame-id version
+           schema-digest app-element-id script-src title]}]
+  (let [frame-id (fresh-frame-id)]
+    (try
+      (rf/make-frame (assoc frame-opts
+                            :id             frame-id
+                            :initial-events (setup-events snapshot initial-events)))
+      (let [;; The server walk consults `defhost`'s `:ssr` policy BEFORE
+            ;; anything is turned into an element — see
+            ;; `ssr.host-policy` for which hosts it reaches and which
+            ;; rf2-2rtt6.85's own shell covers from the other side.
+            tree        (host-policy/apply-policy hiccup)
+            html        (rdom-server/renderToString
+                          (mount/provider frame-id (codec/root-element frame-id tree)))
+            ;; The hash is of the tree BOTH ENDS SHARE — the hiccup as
+            ;; written, not the policy-applied server tree. A
+            ;; `:client-only` region is a deliberate server/client
+            ;; difference in the MARKUP; the render tree's structural
+            ;; identity is the same on both sides, and hashing the server
+            ;; tree would make every host region a hydration mismatch by
+            ;; construction.
+            ;;
+            ;; FINDING, WITNESSED AND FILED rather than papered over: this
+            ;; hash is DEGENERATE for an interpreted root. Spec 011's
+            ;; hydration-mismatch instrument hashes the RENDER TREE, and a
+            ;; substrate that renders hiccup→hiccup hands it the whole
+            ;; tree. Hicasso's root hiccup is `[<minted head> {props}]`
+            ;; and the tree is walked INSIDE React, so what reaches the
+            ;; hash is one vector whose head is a function —
+            ;; `canonical-edn` renders every function identically, so two
+            ;; DIFFERENT screens hash the same (measured: the dogfood
+            ;; screen and the 1,200-element Conduit feed both hash
+            ;; `83b865f8`). The instrument is therefore fail-open here.
+            ;; It is left as the framework's own call (R0 — this bead does
+            ;; not invent a payload byte) and pinned by
+            ;; `the-render-hash-is-degenerate-for-an-interpreted-root` so
+            ;; nobody can start relying on it by accident; the repair is
+            ;; a bead, and it is the SSR programme's, because a real fix
+            ;; is a server AND client contract.
+            render-hash (ssr-hash/render-tree-hash hiccup)
+            policy-opts (cond-> {:payload payload}
+                          (some? client-frame-id) (assoc :client-frame-id client-frame-id)
+                          (some? version)         (assoc :version version)
+                          (some? schema-digest)   (assoc :schema-digest schema-digest))
+            payload-map (payload-policy/build-payload
+                          ;; WIRE id — the caller's stable one or nil.
+                          ;; NEVER `frame-id`.
+                          (:client-frame-id policy-opts)
+                          (payload-policy/project-app-db-egress
+                            (payload-policy/apply-policy (rf/app-db-value frame-id) policy-opts)
+                            ;; PROJECTION frame — the real per-request one.
+                            frame-id)
+                          render-hash
+                          policy-opts)
+            payload-edn (pr-str payload-map)
+            script      (payload-script payload-edn)]
+        {:frame-id       frame-id
+         :html           html
+         :render-hash    render-hash
+         :payload        payload-map
+         :payload-edn    payload-edn
+         :payload-script script
+         :document       (document {:html           html
+                                    :payload-script script
+                                    :render-hash    render-hash
+                                    :app-element-id app-element-id
+                                    :script-src     script-src
+                                    :title          title})})
+      (finally
+        (rf/destroy-frame! frame-id)))))
+
+(defn render-twice
+  "[[render]] the same request twice and compare the documents
+  byte-for-byte — the determinism check, run where the renderer is rather
+  than trusted to a docstring.
+
+  Two renders in one process take two DIFFERENT gensym frame ids, so this
+  is also the standing proof that the per-request id is invisible on the
+  wire. Returns `{:first :second :identical? :differs-at}`, where
+  `:differs-at` is the index of the first differing character (nil when
+  identical) — a diff position is what makes a red run diagnosable."
+  [opts]
+  (let [a (render opts)
+        b (render opts)
+        x (:document a)
+        y (:document b)]
+    {:first      a
+     :second     b
+     :identical? (= x y)
+     :differs-at (when (not= x y)
+                   (let [n (min (count x) (count y))]
+                     (loop [i 0]
+                       (cond
+                         (= i n)                          n
+                         (not= (.charAt x i) (.charAt y i)) i
+                         :else                            (recur (inc i))))))}))

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry_cljs_test.cljs
@@ -1,0 +1,240 @@
+(ns re-frame.bench.hicasso.ssr.entry-cljs-test
+  "THE GATED WITNESSES FOR THE SSR NODE RENDER ENTRY (rf2-2rtt6.86).
+
+  These run under `npm run test:cljs` — the consolidated `:node-test`
+  build — which is the right home for them and not a compromise: the
+  suite already runs in Node, `react-dom/server` resolves there through
+  the same conditional export the bake driver gets
+  (`adapters/reagent-slim`'s parity suite has required it from this build
+  since rf2-6hyy), and `renderToString` wants no DOM. So the entry's
+  correctness is proved by a PR gate rather than by a bench driver that
+  can exit 0 while emitting warnings.
+
+  One row per clause the bead lists, plus the two properties that would
+  make the whole thing unsafe if they were not true: that a server render
+  leaves ZERO durable registration behind, and that the per-request gensym
+  never reaches the wire."
+  (:require [cljs.reader :as reader]
+            [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.dogfood-collector :as collector]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.ssr.entry :as entry]
+            [re-frame.bench.hicasso.ssr.fixtures :as fixtures]
+            [re-frame.bench.hicasso.ssr.host-policy :as host-policy]
+            [re-frame.core :as rf]
+            [re-frame.ssr.constants :as ssr-constants]
+            [re-frame.test-support :as test-support]))
+
+;; The adapter is UIx's for the reason `arm1/runtime_cljs_test` gives: it
+;; is the substrate with a real reactivity layer, and Spec 006 allows
+;; exactly one per process. **The render entry does not install one** —
+;; installing a substrate is a process-level decision a host makes at
+;; boot, so it belongs to the driver (`ssr/node.cljs`) and to this
+;; fixture, never to a per-request function.
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     :init-fn (fn [] (fixtures/register!) (rt/reset-runtime!))}))
+
+(def ^:private dogfood-request
+  {:hiccup   [collector/screen {}]
+   :snapshot (dogfood/seed-db 4)
+   :payload  fixtures/dogfood-payload-keys})
+
+(defn- error-id
+  "The `:rf.error/id` a thunk throws, or `::none`."
+  [thunk]
+  (try (thunk) ::none
+       (catch :default e (or (:rf.error/id (ex-data e)) ::no-id))))
+
+;; ---------------------------------------------------------------------------
+;; Clause 1 — the render entry
+;; ---------------------------------------------------------------------------
+
+(deftest the-existing-runtime-renders-under-renderToString
+  (testing "a Hicasso boundary tree renders to markup under react-dom/server,
+           with the frame's own state in it"
+    (let [{:keys [html]} (entry/render dogfood-request)]
+      (is (str/includes? html "class=\"dogfood\""))
+      (is (str/includes? html "todos"))
+      ;; Seeded with four; the header count is a SUBSCRIPTION read, so
+      ;; this is the assertion that the cold probe answered rather than
+      ;; that the markup happened to appear.
+      (is (str/includes? html "data-remaining=\"4\""))
+      (is (str/includes? html "4 left"))
+      ;; The keyed list rendered every row — a `for` over a subscription
+      ;; value, realized inside the server render.
+      (is (= 4 (count (re-seq #"class=\"row\"" html))))
+      ;; A controlled input's server markup carries `value` as
+      ;; `defaultValue` would demand of hydration (HD-019's rider is
+      ;; rf2-2rtt6.84's to witness on the hydrated path; this is only the
+      ;; server half, asserted so a change to it is visible here).
+      (is (str/includes? html "class=\"new-input\"")))))
+
+(deftest the-per-request-frame-is-destroyed
+  (testing "the request's frame does not outlive the request"
+    (let [{:keys [frame-id]} (entry/render dogfood-request)]
+      (is (keyword? frame-id))
+      (is (nil? (rf/app-db-value frame-id))
+          "destroy-frame! ran in the finally — a per-request frame, not a per-request leak")))
+
+  (testing "two requests take different frames"
+    (let [a (entry/render dogfood-request)
+          b (entry/render dogfood-request)]
+      (is (not= (:frame-id a) (:frame-id b))))))
+
+(deftest a-server-render-leaves-zero-durable-registration
+  (testing "React never subscribes under renderToString, so the ledger is untouched"
+    (rt/reset-runtime!)
+    (entry/render dogfood-request)
+    (let [{:keys [cells cell-refs boundaries edges]} (rt/residue)]
+      ;; The four numbers a clean teardown asserts. Here they are zero
+      ;; without a teardown at all, because nothing ever committed: every
+      ;; `sub` read went through the mutation-free cold probe, and the
+      ;; only thing that installs a cell or an edge is a commit.
+      (is (= 0 cells))
+      (is (= 0 cell-refs))
+      (is (= 0 boundaries))
+      (is (= 0 edges)))))
+
+;; ---------------------------------------------------------------------------
+;; Clause 1(d) — the payload is the framework's, byte for byte
+;; ---------------------------------------------------------------------------
+
+(deftest the-payload-is-the-frameworks-own
+  (let [{:keys [payload payload-edn payload-script render-hash]} (entry/render dogfood-request)]
+
+    (testing "the three always-present keys, per Spec 011"
+      (is (= #{:rf/version :rf/app-db :rf/render-hash} (set (keys payload))))
+      (is (int? (:rf/version payload)))
+      (is (= render-hash (:rf/render-hash payload))))
+
+    (testing "the per-request gensym NEVER reaches the wire (rf2-lm2yzy)"
+      (is (not (contains? payload :rf/frame-id))
+          "an absent :rf/frame-id is the documented no-conflict shape for an
+           anonymous per-request server frame; stamping the gensym would be
+           :rf.error/hydration-frame-id-mismatch on every page")
+      (is (not (str/includes? payload-edn "hicasso.ssr"))))
+
+    (testing "the allowlist arm of the fail-closed payload contract"
+      (is (= (set fixtures/dogfood-payload-keys) (set (keys (:rf/app-db payload))))))
+
+    (testing "the script is the pinned id and the framework's EDN escaper"
+      (is (str/starts-with? payload-script
+                            (str "<script id=\"" ssr-constants/payload-script-id
+                                 "\" type=\"application/edn\">")))
+      (is (= "__rf_payload" ssr-constants/payload-script-id))
+      (is (str/ends-with? payload-script "</script>")))
+
+    (testing "the payload round-trips through the EDN reader"
+      (is (= payload (reader/read-string payload-edn))))))
+
+(deftest a-script-breakout-in-the-app-db-is-escaped-by-the-framework
+  (testing "the escaper on the payload path is re-frame's, and it is doing work"
+    (let [{:keys [payload-script payload-edn]}
+          (entry/render {:hiccup   [:div "x"]
+                         :snapshot {:hostile "</script><!-- pwned"}
+                         :payload  [:hostile]})]
+      ;; The one thing an EDN payload in a <script> may not contain.
+      (is (not (str/includes? payload-script "</script><!--")))
+      (is (str/includes? payload-script "\\u003c/script>"))
+      ;; And it round-trips to the original value — escaped, not mangled.
+      (is (= "</script><!-- pwned" (:hostile (:rf/app-db (reader/read-string payload-edn))))))))
+
+(deftest the-payload-policy-is-fail-closed
+  (testing "no :payload declared is the framework's refusal, not a default"
+    (is (= :rf.error/ssr-missing-payload-policy
+           (error-id #(entry/render (dissoc dogfood-request :payload))))))
+
+  (testing "the whole-app-db opt-in is explicit and works"
+    (let [{:keys [payload]} (entry/render (assoc dogfood-request
+                                                 :payload :rf.ssr.payload/whole-app-db))]
+      (is (= (set (keys (dogfood/seed-db 4))) (set (keys (:rf/app-db payload))))))))
+
+(deftest the-render-hash-is-degenerate-for-an-interpreted-root
+  (testing "PINNED AS A DEFECT, not asserted as behaviour: Spec 011's
+           hydration-mismatch hash is over the RENDER TREE, and Hicasso's
+           root hiccup is one vector whose head is a function — so two
+           different screens hash the same and the instrument is fail-open.
+           This row exists so the day someone repairs it, it goes red and
+           they read the comment in ssr/entry.cljs rather than rediscovering
+           the measurement."
+    (let [dogfood (:render-hash (entry/render dogfood-request))
+          conduit (:render-hash (entry/render (fixtures/row "conduit-feed")))
+          markup  (:render-hash (entry/render (fixtures/row "defhost-ssr-policy")))]
+      (is (= dogfood conduit)
+          "the dogfood screen and the 1,200-element Conduit feed hash the same")
+      ;; And the non-vacuity control: a root whose hiccup IS markup does
+      ;; hash differently, so the hash function itself works and it is the
+      ;; interpreted root that defeats it.
+      (is (not= dogfood markup)))))
+
+;; ---------------------------------------------------------------------------
+;; Clause 2 — determinism
+;; ---------------------------------------------------------------------------
+
+(deftest the-same-request-renders-byte-identical-documents
+  (testing "same bundle + same snapshot = byte-identical HTML"
+    (doseq [row fixtures/corpus]
+      (let [{:keys [identical? differs-at] a :first b :second} (entry/render-twice row)]
+        (is identical?
+            (str (:id row) " rendered two different documents"
+                 (when differs-at
+                   (str " — first difference at character " differs-at ": "
+                        (pr-str (subs (:document a) differs-at (min (count (:document a))
+                                                                    (+ differs-at 40))))
+                        " vs "
+                        (pr-str (subs (:document b) differs-at (min (count (:document b))
+                                                                    (+ differs-at 40))))))))))))
+
+;; ---------------------------------------------------------------------------
+;; Clause 6 — defhost regions honour the :ssr policy server-side
+;; ---------------------------------------------------------------------------
+
+(deftest a-host-with-no-declared-policy-renders-nothing
+  (testing "the ruled :client-only default, reached with no stamping at all"
+    (is (= :client-only (host-policy/policy-of fixtures/default-host)))
+    (let [{:keys [html]} (entry/render (fixtures/row "defhost-ssr-policy"))]
+      (is (not (str/includes? html "CLIENT-ONLY-WIDGET"))
+          "a :client-only host's component must not reach the server HTML")
+      (is (not (str/includes? html "client-widget"))))))
+
+(deftest a-host-declaring-a-fallback-renders-the-fallback
+  (testing "{:fallback hiccup} — including from inside a `for`, the lazy position"
+    (let [{:keys [html]} (entry/render (fixtures/row "defhost-ssr-policy"))]
+      (is (str/includes? html "class=\"host-fallback\""))
+      (is (= 2 (count (re-seq #"loading" html)))
+          "both rows of the `for` got their fallback — a walk that stopped at
+           the seq would render one (the root-level host) and miss these")
+      ;; The chrome around the hosts is untouched, so the walk replaced
+      ;; regions rather than pruning the tree.
+      (is (str/includes? html "<h1>hosts</h1>")))))
+
+(deftest an-unknown-policy-is-refused-rather-than-rendered
+  (testing "fail-CLOSED: a policy this walk does not know never falls through
+           to rendering the client's component"
+    (let [bogus (codec/mint-host! "ssr-fixture/bogus" (fn [_] nil))]
+      (unchecked-set bogus host-policy/policy-slot :sometimes)
+      (is (= :rf.error/hicasso-unknown-ssr-policy
+             (error-id #(host-policy/apply-policy [:div [bogus {}]])))))))
+
+;; ---------------------------------------------------------------------------
+;; The corpus renders at all — the bake's own precondition
+;; ---------------------------------------------------------------------------
+
+(deftest every-corpus-row-renders
+  (doseq [{:keys [id why] :as row} fixtures/corpus]
+    (testing (str id " — " why)
+      (let [{:keys [html document payload]} (entry/render row)]
+        (is (seq html) (str id " rendered empty markup"))
+        (is (str/starts-with? document "<!DOCTYPE html>"))
+        (is (str/includes? document "<div id=\"app\" data-rf-render-hash=")
+            "the app root carries the id the client bootstrap mounts on —
+             a `:or` default that never fires shipped `id=\"\"` once")
+        (is (str/includes? document (str "id=\"" ssr-constants/payload-script-id "\"")))
+        (is (str/ends-with? document "</body></html>"))
+        (is (some? (:rf/render-hash payload)))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry_cljs_test.cljs
@@ -173,6 +173,25 @@
       ;; interpreted root that defeats it.
       (is (not= dogfood markup)))))
 
+(deftest the-server-render-ships-presences-mounting-overrides
+  (testing "PINNED AS A DEFECT (rf2-2rtt6.94). Presence starts a child at
+           `:mounting` and applies its `::h/mounting` overrides while it is
+           there, so a server render — which runs with no adoption window,
+           because this entry cannot open one until rf2-2rtt6.84 lands —
+           emits the ENTER appearance. rf2-2rtt6.84 makes the hydrating
+           client's first pass render those children `:present`, and the two
+           then disagree. This row goes RED when the repair lands, which is
+           the point of writing it."
+    (let [{:keys [html]} (entry/render (fixtures/row "presence-mounting"))]
+      (is (str/includes? html "toast--enter")
+          "if this is now absent, the adoption window is being opened around
+           the server render — delete this row and assert the opposite")
+      (is (= 2 (count (re-seq #"toast--enter" html))))
+      ;; The non-vacuity control: the tray DID render its children, so the
+      ;; assertion above is about the override and not about an empty tray.
+      (is (str/includes? html "toast 0"))
+      (is (str/includes? html "toast 1")))))
+
 ;; ---------------------------------------------------------------------------
 ;; Clause 2 — determinism
 ;; ---------------------------------------------------------------------------

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/fixtures.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/fixtures.cljs
@@ -1,0 +1,149 @@
+(ns re-frame.bench.hicasso.ssr.fixtures
+  "THE SSR CONFORMANCE CORPUS (rf2-2rtt6.86 clause 3) — the requests the
+  bake driver bakes and the witnesses assert on.
+
+  One ordered vector, because the corpus is a ROSTER and a roster whose
+  order moves is a fixture set whose file names move with it. Each row is
+  exactly the `opts` map [[re-frame.bench.hicasso.ssr.entry/render]]
+  takes, plus an `:id` naming its output files and a `:why` naming what it
+  is here to cover — a row that cannot say what it covers is a row nobody
+  can decide to delete.
+
+  ## What the census covers
+
+  - **The dogfood screen**, which is what rf2-2rtt6.87's X-rows hydrate,
+    at two sizes and through BOTH seeding doors (`:rf/set-db` snapshot-in
+    and ordinary `:initial-events`) and BOTH arms of the hydration-payload
+    contract (a key allowlist and the explicit whole-app-db opt-in).
+  - **A tier-1 bulk shape** — the ~1,200-element Conduit feed page, which
+    is the size the charter's bar rows are taken at and the only row here
+    whose markup is a port of a real application's.
+  - **`defhost`'s `:ssr` policy**, both meanings: a host with no declared
+    policy (the ruled `:client-only` default — its component's markup MUST
+    be absent from the server HTML) and a host declaring a fallback (whose
+    placeholder markup MUST be present).
+
+  ## Why the host rows stamp the policy slot by hand
+
+  rf2-2rtt6.85 owns `mint-host!`'s `:ssr` option and has not landed. The
+  DEFAULT row needs nothing — a head with no policy already reads
+  `:client-only` — and the FALLBACK row stamps the slot directly, which is
+  the ordinary way to test a reader ahead of its writer. When that bead
+  lands, [[fallback-host]]'s two lines become `defhost … {:ssr {:fallback
+  …}}` and nothing else here moves."
+  (:require [re-frame.bench.hicasso.arm1.dogfood-collector :as collector]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.shapes.large-template :as large-template]
+            [re-frame.bench.hicasso.shapes.model :as model]
+            [re-frame.bench.hicasso.ssr.host-policy :as host-policy]
+            [re-frame.routing :as routing]
+            ["react" :as react]))
+
+;; ---------------------------------------------------------------------------
+;; The two host rows
+;; ---------------------------------------------------------------------------
+
+(defn- client-widget
+  "A foreign component whose markup is the tell. Both host rows render
+  THIS, so a fixture's verdict is a substring test on one distinctive
+  string rather than a structural argument."
+  [_js-props]
+  (react/createElement "em" #js {"className" "client-widget"} "CLIENT-ONLY-WIDGET"))
+
+(def default-host
+  "A host declaring no `:ssr` policy at all — which is the ruled
+  `:client-only` default, reached with no stamping because
+  `host-policy/policy-of` answers it for an absent slot."
+  (codec/mint-host! "ssr-fixture/default" client-widget))
+
+(def fallback-host
+  "A host declaring `{:fallback …}`. The stamp is rf2-2rtt6.85's to
+  replace; see the namespace docstring."
+  (let [head (codec/mint-host! "ssr-fixture/fallback" client-widget)]
+    (unchecked-set head host-policy/policy-slot
+                   {:fallback [:span.host-fallback "loading…"]})
+    head))
+
+(def host-screen
+  "One page carrying both hosts, nested inside ordinary markup and inside
+  a `for` — the lazy position, because a walk that stopped at a seq would
+  pass a root-level test and miss every row."
+  [:div.hosts
+   [:h1 "hosts"]
+   [default-host {:kind "default"}]
+   [:ul
+    (for [i (range 2)]
+      [:li {:key i} [fallback-host {:kind "fallback" :i i}]])]])
+
+;; ---------------------------------------------------------------------------
+;; The roster
+;; ---------------------------------------------------------------------------
+
+(def dogfood-payload-keys
+  "The dogfood app-db's top-level keys — the allowlist arm of the
+  hydration-payload contract, written out rather than derived, so a new
+  key is a decision to ship it rather than an accident of a `keys` call."
+  [:todos :order :drafts :filter :next-id])
+
+(def corpus
+  "The ordered roster. See the namespace docstring."
+  [{:id     "dogfood-snapshot"
+    :why    "the dogfood screen, seeded through the :rf/set-db snapshot-in door, with a key allowlist"
+    :hiccup [collector/screen {}]
+    :snapshot (dogfood/seed-db 8)
+    :payload  dogfood-payload-keys
+    :title    "Hicasso SSR — dogfood (snapshot-in)"
+    :script-src "/main.js"}
+
+   {:id     "dogfood-initial-events"
+    :why    "the same screen through the :initial-events door, and the whole-app-db payload opt-in"
+    :hiccup [collector/screen {}]
+    :initial-events [[:dogfood/seed 3]
+                     [:dogfood/toggle 1]
+                     [:dogfood/edit-draft dogfood/new-draft-key "half typed"]]
+    :payload  :rf.ssr.payload/whole-app-db
+    :title    "Hicasso SSR — dogfood (initial-events)"
+    :script-src "/main.js"}
+
+   {:id     "conduit-feed"
+    :why    "a tier-1 bulk shape — the ~1,200-element Conduit feed page, at the size the bar rows are taken at"
+    :hiccup [large-template/page {}]
+    :snapshot   (model/seed-db large-template/seed)
+    ;; The census is a HASH-URL app and its anchors go through routing's
+    ;; `link-model`, whose strategy consult defaults to the history
+    ;; strategy when a frame declares none — so the frame declares the
+    ;; one `shapes/model/make-frame!` declares, through the same door.
+    :frame-opts {:url-strategy routing/hash-url-strategy}
+    :payload    [:articles :order :tags :user :page :your-feed?]
+    :title      "Hicasso SSR — conduit feed"
+    :script-src "/main.js"}
+
+   {:id     "defhost-ssr-policy"
+    :why    "defhost regions honour the :ssr policy server-side — default :client-only renders nothing, {:fallback} renders the fallback"
+    :hiccup host-screen
+    :snapshot {}
+    :payload  :rf.ssr.payload/whole-app-db
+    :title    "Hicasso SSR — defhost :ssr policy"
+    :script-src "/main.js"}])
+
+(defn ids
+  "The corpus row ids, in roster order."
+  []
+  (mapv :id corpus))
+
+(defn row
+  "The corpus row named `id`, or nil."
+  [id]
+  (first (filter #(= id (:id %)) corpus)))
+
+(defn register!
+  "Everything the corpus needs registered before a request is rendered.
+
+  Only the census's route table today — `re-frame.routing/reg-route` is
+  a GLOBAL registration, not a frame's, so it cannot ride `:frame-opts`.
+  Idempotent, and called by every driver and every witness before the
+  first render so no caller has to remember an ordering."
+  []
+  (model/register-routes!)
+  nil)

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/fixtures.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/fixtures.cljs
@@ -22,16 +22,26 @@
     policy (the ruled `:client-only` default — its component's markup MUST
     be absent from the server HTML) and a host declaring a fallback (whose
     placeholder markup MUST be present).
+  - **Presence's `::h/mounting` overrides** — and that row is a PINNED
+    DEFECT rather than a feature. See [[presence-tray]].
 
   ## Why the host rows stamp the policy slot by hand
 
-  rf2-2rtt6.85 owns `mint-host!`'s `:ssr` option and has not landed. The
-  DEFAULT row needs nothing — a head with no policy already reads
-  `:client-only` — and the FALLBACK row stamps the slot directly, which is
-  the ordinary way to test a reader ahead of its writer. When that bead
-  lands, [[fallback-host]]'s two lines become `defhost … {:ssr {:fallback
-  …}}` and nothing else here moves."
+  rf2-2rtt6.85 owns `mint-host!`'s `:ssr` option and has NOT landed —
+  its PR (#7468) was still open when this file was written. The DEFAULT
+  row needs nothing (a head with no policy already reads `:client-only`)
+  and the FALLBACK row stamps the slot directly, which is the ordinary
+  way to test a reader ahead of its writer.
+
+  Checked against #7468 rather than assumed: that PR stores the policy
+  under the same own-property this stamp writes, and enforces it at the
+  element's own TYPE — so when it lands, [[fallback-host]] becomes
+  `defhost … {:ssr {:fallback …}}`, the two host rows keep asserting
+  exactly what they assert now, and the server WALK they exercise
+  ([[re-frame.bench.hicasso.ssr.host-policy]]) is retired under
+  rf2-2rtt6.92."
   (:require [re-frame.bench.hicasso.arm1.dogfood-collector :as collector]
+            [re-frame.bench.hicasso.arm1.presence :refer [presence]]
             [re-frame.bench.hicasso.front.codec :as codec]
             [re-frame.bench.hicasso.front.dogfood :as dogfood]
             [re-frame.bench.hicasso.shapes.large-template :as large-template]
@@ -77,6 +87,40 @@
       [:li {:key i} [fallback-host {:kind "fallback" :i i}]])]])
 
 ;; ---------------------------------------------------------------------------
+;; The presence row — a PINNED DEFECT, not a passing feature
+;; ---------------------------------------------------------------------------
+
+(def presence-tray
+  "A presence tray whose children carry `::h/mounting` attribute
+  overrides.
+
+  This row is here to MEASURE a defect the rf2-2rtt6.84 worker predicted
+  and this bead confirmed, not to show something working. Presence's
+  machine starts a child at `:mounting` (`arm1/presence.cljs` —
+  `(react/useState presence/initial)`), and while a child is in that
+  phase the tray applies its `::h/mounting` overrides. A server render
+  therefore ships the ENTER appearance — the `opacity: 0` class an
+  animation is about to move off — into the HTML.
+
+  rf2-2rtt6.84 makes the hydrating client's first pass render those same
+  children `:present` instead (born-present under an open adoption
+  window), so the server's overrides and the client's first pass
+  disagree and React reports a hydration mismatch on every
+  presence-managed node. The repair is for this entry to open the same
+  adoption window around `renderToString` — which it CANNOT do yet,
+  because `runtime/open-adoption-window!` does not exist on main; it is
+  in rf2-2rtt6.84's still-open PR. See
+  [[re-frame.bench.hicasso.ssr.entry]] §The one thing this entry does not
+  do yet."
+  [presence {:timeout-ms 200}
+   (for [i (range 2)]
+     [:div.toast {:key                          i
+                  :data-id                      i
+                  :re-frame.hicasso/mounting    {:class "toast--enter"}
+                  :re-frame.hicasso/unmounting  {:class "toast--exit"}}
+      (str "toast " i)])])
+
+;; ---------------------------------------------------------------------------
 ;; The roster
 ;; ---------------------------------------------------------------------------
 
@@ -117,6 +161,14 @@
     :frame-opts {:url-strategy routing/hash-url-strategy}
     :payload    [:articles :order :tags :user :page :your-feed?]
     :title      "Hicasso SSR — conduit feed"
+    :script-src "/main.js"}
+
+   {:id     "presence-mounting"
+    :why    "PINNED DEFECT — a server render ships presence's ::h/mounting overrides; rf2-2rtt6.94 is the repair"
+    :hiccup presence-tray
+    :snapshot {}
+    :payload  :rf.ssr.payload/whole-app-db
+    :title    "Hicasso SSR — presence (pinned defect)"
     :script-src "/main.js"}
 
    {:id     "defhost-ssr-policy"

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/host_policy.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/host_policy.cljs
@@ -26,13 +26,35 @@
   client cannot be trusted to adopt. Fail-closed here means render less,
   never render something the client will not agree with.
 
-  ## The seam, named so it is one line to reconcile
+  ## THIS NAMESPACE IS EXPECTED TO BE RETIRED (rf2-2rtt6.92)
 
-  [[policy-slot]] is the own-property the minted head carries the policy
-  on. It is a guess at rf2-2rtt6.85's spelling made ahead of that bead
-  landing, deliberately isolated to ONE constant and ONE reader so
-  reconciling the two halves is a one-line change rather than a hunt.
-  rf2-2rtt6.92 is the reconciliation.
+  Read rf2-2rtt6.85's open PR (#7468) before extending anything here.
+  That bead enforces the policy **at the element's own type**: `defhost`
+  mints a GATE component around the foreign one, whose
+  `useSyncExternalStore(noop, (constantly true), (constantly false))`
+  answers `false` under `renderToString`, so the gate renders the
+  fallback element — or nothing — with no walk involved at all. That
+  mechanism is strictly better than this one: it reaches a host minted
+  inside a boundary BODY, which this walk cannot (see below), and it
+  costs no per-request tree rebuild.
+
+  So the honest disposition is that this file exists because
+  rf2-2rtt6.86 landed while #7468 was still open and clause 6 had to be
+  real on main, and it should go when that PR merges. rf2-2rtt6.92 is
+  that retirement.
+
+  Two things were checked against #7468 rather than assumed, and both
+  hold, which is why merging in either order is safe:
+
+  - **The slot spelling agrees.** That PR stores the policy on the head
+    under the own-property `\"ssr\"` and reads it back with
+    `codec/host-ssr` — the same property [[policy-slot]] names and the
+    same `unchecked-get` [[policy-of]] performs. A fallback host is
+    therefore never mistaken for a `:client-only` one by this reader.
+  - **The two mechanisms agree on markup.** `:client-only` renders
+    nothing either way; `{:fallback hic}` renders `hic` either way. If
+    both are live at once the walk simply gets there first and the gate
+    finds nothing left to do.
 
   ## What this walk reaches, stated rather than implied
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/host_policy.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/host_policy.cljs
@@ -32,7 +32,7 @@
   on. It is a guess at rf2-2rtt6.85's spelling made ahead of that bead
   landing, deliberately isolated to ONE constant and ONE reader so
   reconciling the two halves is a one-line change rather than a hunt.
-  rf2-2rtt6.86 files the reconciliation bead.
+  rf2-2rtt6.92 is the reconciliation.
 
   ## What this walk reaches, stated rather than implied
 
@@ -47,7 +47,9 @@
   `renderToString` React takes the server snapshot, so the region renders
   its placeholder without this walk touching it. The two halves meet when
   that bead lands; neither is a substitute for the other, and saying so
-  here is cheaper than a reader discovering it."
+  here is cheaper than a reader discovering it. **That is an argument,
+  not a witness** — rf2-2rtt6.92 is the fixture that turns it into one,
+  and the ruling on whether one policy should have two mechanisms."
   (:require [re-frame.bench.hicasso.front.codec :as codec]))
 
 (def ^:const policy-slot

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/host_policy.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/host_policy.cljs
@@ -1,0 +1,150 @@
+(ns re-frame.bench.hicasso.ssr.host-policy
+  "THE SERVER SIDE OF `defhost`'s `:ssr` POLICY — the READ, never the write
+  (rf2-2rtt6.86 clause 6).
+
+  HD-011 declared `defhost`'s SSR placeholder; rf2-2rtt6.85 activates it —
+  it owns the OPTION (`:client-only` / `{:fallback …}`), the mint-time
+  refusal of anything else, and the client-side adoption behaviour. This
+  namespace owns one half only: **what the server does with the policy it
+  finds**, which is the half rf2-2rtt6.85's own clause 3 hands to the
+  Node-entry bead.
+
+  So nothing here declares a policy, validates one, or writes one onto a
+  head. [[policy-of]] READS the slot and [[apply-policy]] applies the two
+  ruled meanings:
+
+      :client-only        the region renders NOTHING server-side
+      {:fallback hiccup}  the region renders `hiccup` server-side
+
+  ## The default is the ruled default, and it is real today
+
+  `mint-host!` carries no policy slot yet, so [[policy-of]] finds nothing
+  on every head in the tree and answers `:client-only` — which is exactly
+  the option rf2-2rtt6.85 makes the DEFAULT. The conservative reading is
+  also the correct one: a host is foreign code with its own hooks, state
+  and refs, and a server that renders it by default would ship markup the
+  client cannot be trusted to adopt. Fail-closed here means render less,
+  never render something the client will not agree with.
+
+  ## The seam, named so it is one line to reconcile
+
+  [[policy-slot]] is the own-property the minted head carries the policy
+  on. It is a guess at rf2-2rtt6.85's spelling made ahead of that bead
+  landing, deliberately isolated to ONE constant and ONE reader so
+  reconciling the two halves is a one-line change rather than a hunt.
+  rf2-2rtt6.86 files the reconciliation bead.
+
+  ## What this walk reaches, stated rather than implied
+
+  It walks the hiccup form the render entry is HANDED — the root tree and
+  everything reachable from it through vectors and seqs. A host minted
+  inside a boundary BODY is not in that tree: the body runs inside
+  `renderToString`, and its host element is created by the codec's own
+  crossing, which is `front/codec.cljs` — rf2-2rtt6.85's file, not this
+  bead's. That case is covered by the SAME policy from the other side:
+  rf2-2rtt6.85's host boundary reads its adoption state through
+  `useSyncExternalStore(…, …, (constantly false))`, and under
+  `renderToString` React takes the server snapshot, so the region renders
+  its placeholder without this walk touching it. The two halves meet when
+  that bead lands; neither is a substitute for the other, and saying so
+  here is cheaper than a reader discovering it."
+  (:require [re-frame.bench.hicasso.front.codec :as codec]))
+
+(def ^:const policy-slot
+  "The own-property a minted host head carries its `:ssr` policy on.
+
+  ONE constant, read in ONE place ([[policy-of]]), because the WRITE side
+  is rf2-2rtt6.85's and this bead consumes it ahead of it landing."
+  "ssr")
+
+(def default-policy
+  "The policy a head with no declared `:ssr` gets — the ruled default."
+  :client-only)
+
+(defn policy-of
+  "The `:ssr` policy declared on a minted host `head`, or [[default-policy]]
+  when it declares none. One own-property read; no registry, no map —
+  the same shape as `codec/host-head?`."
+  [head]
+  (let [declared (unchecked-get head policy-slot)]
+    (if (some? declared) declared default-policy)))
+
+(defn client-only?
+  "Does `policy` mean *render nothing server-side*?"
+  [policy]
+  (= :client-only policy))
+
+(defn fallback-policy?
+  "Does `policy` mean *render this hiccup server-side*?"
+  [policy]
+  (and (map? policy) (contains? policy :fallback)))
+
+(defn- refuse!
+  "A head carrying a policy that is neither ruled meaning.
+
+  Unreachable once rf2-2rtt6.85 lands — that bead refuses an unknown
+  `:ssr` value at MINT time, where the author's stack is the declaration
+  site. It is kept as a fail-CLOSED floor rather than a fall-through to
+  rendering the component, because the failure mode of guessing here is
+  shipping a client-only region's markup to every reader of the page."
+  [host-name policy]
+  (throw (ex-info (str "defhost " (pr-str host-name) " carries an :ssr policy this "
+                       "server walk does not know: " (pr-str policy) ". The ruled "
+                       "meanings are :client-only and {:fallback <hiccup>}. "
+                       "[:rf.error/hicasso-unknown-ssr-policy]")
+                  {:rf.error/id :rf.error/hicasso-unknown-ssr-policy
+                   :where       'ssr.host-policy/apply-policy
+                   :reason      "An :ssr policy is :client-only or {:fallback <hiccup>}."
+                   :recovery    :declare-client-only-or-a-fallback
+                   :host        host-name
+                   :policy      policy})))
+
+(declare apply-policy)
+
+(defn- walk-vector
+  "Every slot of `v` through [[apply-policy]], rebuilding **only if
+  something moved**. A tree with no hosts in it comes back by identity,
+  so the walk costs a traversal and no allocation on the overwhelmingly
+  common page.
+
+  Slot 0 is the head and goes through the same call: a tag keyword, `:<>`
+  and a boundary head are all values [[apply-policy]] returns unchanged,
+  so the head needs no special case to be safe from one."
+  [v]
+  (let [n (count v)]
+    (loop [i 0
+           acc nil]
+      (if (< i n)
+        (let [x (nth v i)
+              y (apply-policy x)]
+          (recur (inc i)
+                 (if (identical? x y) acc (assoc (or acc v) i y))))
+        (or acc v)))))
+
+(defn apply-policy
+  "The server walk. Returns `form` with every `defhost` region replaced by
+  what its `:ssr` policy says the server renders — nothing, or the
+  fallback hiccup (itself walked, so a fallback containing a host is not a
+  hole).
+
+  Pure, and identity-preserving where nothing changes."
+  [form]
+  (cond
+    (vector? form)
+    (let [head (nth form 0 nil)]
+      (if (codec/host-head? head)
+        (let [policy (policy-of head)]
+          (cond
+            (client-only? policy)    nil
+            (fallback-policy? policy) (apply-policy (:fallback policy))
+            :else                    (refuse! (unchecked-get head "displayName") policy)))
+        (walk-vector form)))
+
+    ;; A `for`'s rows are the case the walk exists for: laziness is why a
+    ;; collector closed at body-return loses them (the Arm 2 finding), and
+    ;; it is equally why a walk that returned the seq untouched would miss
+    ;; every host inside one. Realized here, once, on the server.
+    (seq? form)
+    (doall (map apply-policy form))
+
+    :else form))

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/node.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/node.cljs
@@ -1,0 +1,118 @@
+(ns re-frame.bench.hicasso.ssr.node
+  "THE NODE ENTRY POINT — what the bake and the live demo call
+  (rf2-2rtt6.86 clauses 3 and 4).
+
+  This namespace is the *process* half of the render entry, and it is
+  deliberately thin: it installs the reactive substrate (Spec 006 allows
+  exactly one per process, so it is a boot-time decision and not a
+  per-request one), registers what the corpus needs, and publishes a tiny
+  JS API for the drivers.
+
+  ## Why the drivers are `.cjs` and this is the only CLJS in the process
+
+  Everything under this lane is compiled by `npm run
+  test:hicasso-compile`, which rides `:hicasso-bench` — a **browser**
+  build. A CLJS namespace here that required `node:fs` or `node:http`
+  would fail that gate, and a namespace placed outside the lane to dodge
+  it would be exactly the silently-uncovered file the gate exists to
+  catch. So the split is not a preference: the CLJS renders and returns
+  strings, and the file system and the socket belong to the drivers.
+  `react-dom/server` is the one npm module here, and it resolves in both
+  targets.
+
+  ## The API, and why it hangs off `globalThis`
+
+  `:node-script` emits a program, not a module — it runs `:main` on load
+  and exports nothing. A driver therefore `require`s the bundle for its
+  effect and then reads the API off `globalThis`, which is the smallest
+  thing that works and needs no build-target change. [[-main]] is that
+  effect.
+
+  Every returned value is a plain JS object of STRINGS: a driver that
+  wanted to see a ClojureScript map through this seam would be a driver
+  reaching into the render entry, which is the coupling the seam exists
+  to prevent."
+  (:require [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.dogfood-collector :as collector]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.ssr.entry :as entry]
+            [re-frame.bench.hicasso.ssr.fixtures :as fixtures]
+            [re-frame.core :as rf]))
+
+(def ^:const api-slot
+  "The `globalThis` property the drivers read the API off."
+  "HICASSO_SSR")
+
+(defn- result->js
+  [{:keys [html document payload-edn render-hash frame-id]}]
+  #js {"html"       html
+       "document"   document
+       "payloadEdn" payload-edn
+       "renderHash" (str render-hash)
+       ;; The per-request gensym, as a string, so a driver can SHOW that
+       ;; two requests took two frames. It is already destroyed.
+       "frameId"    (str frame-id)})
+
+(defn- require-row
+  [id]
+  (or (fixtures/row id)
+      (throw (ex-info (str "No SSR corpus row named " (pr-str id) ". Known: "
+                           (pr-str (fixtures/ids)))
+                      {:id id :known (fixtures/ids)}))))
+
+(defn render-fixture
+  "Render the corpus row named `id`."
+  [id]
+  (result->js (entry/render (require-row id))))
+
+(defn render-fixture-twice
+  "Render the corpus row named `id` TWICE and hand both documents back —
+  the determinism check's raw material. The driver hashes them; the
+  entry has already compared them byte-for-byte."
+  [id]
+  (let [{:keys [identical? differs-at] a :first b :second}
+        (entry/render-twice (require-row id))]
+    #js {"first"      (result->js a)
+         "second"     (result->js b)
+         "identical"  identical?
+         "differsAt"  (if differs-at differs-at -1)}))
+
+(defn render-dogfood
+  "The LIVE DEMO's own request: the dogfood screen seeded with `n` to-dos,
+  with no bootstrap `<script src>` — this bead ships no client bundle,
+  because the hydration door is rf2-2rtt6.84's.
+
+  `n` comes off the request, so a reader watching the demo can see that
+  the state is the REQUEST'S and not the process's."
+  [n]
+  (result->js
+    (entry/render {:hiccup   [collector/screen {}]
+                   :snapshot (dogfood/seed-db n)
+                   :payload  fixtures/dogfood-payload-keys
+                   :title    (str "Hicasso SSR — live, " n " to-dos")})))
+
+(defn boot!
+  "Install the substrate and register what the corpus needs. Once per
+  process — Spec 006's law, not a convention."
+  []
+  (rf/init! uix-adapter/adapter)
+  (fixtures/register!)
+  nil)
+
+(defn install!
+  "Publish the driver API."
+  []
+  (unchecked-set js/globalThis api-slot
+                 #js {"ids"          (clj->js (fixtures/ids))
+                      "render"       render-fixture
+                      "renderTwice"  render-fixture-twice
+                      "renderDogfood" render-dogfood})
+  nil)
+
+(defn -main
+  "Boot and publish. A `:node-script` runs this on load, which is exactly
+  what a driver `require`ing the bundle wants."
+  [& _args]
+  (boot!)
+  (install!)
+  nil)

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -25,6 +25,8 @@
   "scripts": {
     "dev": "node scripts/dev-testbed.cjs",
     "bench:hicasso": "node freehand/test/re_frame/bench/hicasso/run.cjs",
+    "ssr:hicasso-bake": "node freehand/test/re_frame/bench/hicasso/ssr/driver.cjs bake",
+    "ssr:hicasso-serve": "node freehand/test/re_frame/bench/hicasso/ssr/driver.cjs serve",
     "bench:freehand-node": "shadow-cljs compile freehand-bench-node >&2 && node out/freehand-bench-node.js",
     "bench:freehand-browser": "shadow-cljs compile browser-test-freehand-bench && node scripts/serve-and-run-browser-tests.cjs --root out/browser-test-freehand-bench --port 8024",
     "test:cljs": "node scripts/compile-node-test.cjs node-test out/node-test.js && node out/node-test.js",


### PR DESCRIPTION
The server engine is the **existing Hicasso runtime** under Node's `react-dom/server` `renderToString`. One renderer, run in two places — so hydration parity is by construction rather than by claim, and there is no second renderer anywhere in the tree.

Bench lane only. **No `implementation/ssr` file, no `implementation/ssr-ring` file, and no `implementation/shadow-cljs.edn` edit.** Six new files under `implementation/freehand/test/re_frame/bench/hicasso/ssr/` plus two npm scripts.

## The bead's clauses

**1 — the render entry** (`ssr/entry.cljs`). One request, in the bead's order: a per-request **gensym** frame; seeded through the framework's own doors (`:rf/set-db` for a snapshot handed in whole, `:initial-events` for events); rendered as `(provider frame (codec/root-element frame hiccup))` — literally the two calls `arm1/mount/render!` makes in the browser, through `mount/provider` so the two cannot drift; the payload built from the **framework's own bytes** (`payload-policy/apply-policy` → `project-app-db-egress` → `build-payload` → `html-helpers/escape-edn-script-body` under `ssr.constants/payload-script-id`); `destroy-frame!` in a `finally`.

The wire `:rf/frame-id` is **nil**, per `build-payload`'s own docstring (rf2-lm2yzy): the gensym is the *projection* frame and never reaches the wire, because stamping it would be `:rf.error/hydration-frame-id-mismatch` on every real page. Witnessed, and mutation-proved below.

The entry does **not** install a reactive substrate — Spec 006 allows one per process, so that is a boot-time decision and belongs to the driver.

**2 — determinism.** `render-twice` renders the same request twice and compares the documents **byte for byte** (with a first-differing-character index, so a red run is diagnosable); the driver SHA-256s both and refuses a mismatch. The two renders take two *different* gensym frames and produce identical bytes, which is the gensym's invisibility demonstrated rather than asserted. No streaming.

**3 — the bake.** `npm run ssr:hicasso-bake` writes `<id>.html`, `<id>.body.html`, `<id>.payload.edn` and a `manifest.json` (no timestamp — a manifest that changes every run cannot be compared to the previous one). Corpus: the dogfood screen through **both** seeding doors and **both** arms of the hydration-payload contract, the ~1,200-element Conduit feed as a tier-1 bulk shape, the two `defhost` policy rows, and the pinned presence row below.

```
dogfood-snapshot            3101 B  sha256 a510149b92f08901…
dogfood-initial-events      1798 B  sha256 c157329b13761522…
conduit-feed               79070 B  sha256 4308c2889bc5964a…
presence-mounting            452 B  sha256 2291d28e398dcc08…
defhost-ssr-policy           485 B  sha256 7444cc946c5e854b…
```

**4 — the live demo.** `npm run ssr:hicasso-serve` answers real requests per-request; `/?todos=N` puts the request's own state on the page so "per-request" is visible rather than claimed. Measured: `GET /?todos=3 → frame :hicasso.ssr/request-5, 1737 B, 6.2 ms`; `GET /?todos=7 → frame :hicasso.ssr/request-9, 2797 B, 7.8 ms` — different frames, different state, each destroyed before the response. Page-level, bench-lane; Spec 011's HTTP response contract stays `ssr-ring`'s.

**5 — build id: NO hot-zone edit was needed.** The driver rides the tree's existing `:node-script`, `:freehand-bench-node`, supplying its own `:main` and `:output-to` through `--config-merge` — the same way every arm in this lane rides `:hicasso-bench` with its own `:init-fn`. `:hicasso-bench` itself could not serve: it is a `:browser` target, and `renderToString` wants Node's `server.node.js` through Node's own conditional exports. The lane's cache rule (rf2-2rtt6.20) is honoured verbatim, and it is cheap here — a `:node-script` uses `:js-provider :require`, so there is no shadow-js conversion index, the artefact that bead isolated as the carrier.

**6 — `defhost` regions honour the `:ssr` policy server-side.** `ssr/host_policy.cljs` **reads** the policy and applies the two ruled meanings; it does not declare, validate or write one. A head with no policy answers `:client-only`, which is the ruled default reached with **no stamping at all**. Witnessed on real server HTML, including from inside a `for` — the lazy position a walk that stopped at a seq would miss.

## What I checked against the two open sibling PRs

Neither `.85` (#7468) nor `.84` (#7469) has merged, so nothing here can call anything they add. I read both diffs rather than taking the summaries.

- **#7468's slot spelling agrees with this bead's guess** — it stores the policy on the head under the own-property `"ssr"` and reads it with `codec/host-ssr`, the same property and the same `unchecked-get` this bead's reader performs. No mis-read is possible in either merge order.
- **#7468's mechanism supersedes this bead's walk**: it enforces the policy at the element's own *type* (a gate whose `useSyncExternalStore` server snapshot is `false`), which reaches a host minted inside a boundary *body* — which a walk over the handed-in hiccup cannot. Both agree on markup, so either merge order is safe. `ssr/host_policy.cljs` now says plainly that it expects to be retired, and **rf2-2rtt6.92** carries the retirement with the exact file list.

## Two findings, measured and pinned rather than relayed

**`:rf/render-hash` is degenerate for an interpreted root — the hydration-mismatch instrument is fail-open.** Spec 011 hashes the *render tree*; Hicasso's root hiccup is one vector whose head is a function, and `canonical-edn` renders every function identically. **Measured: the dogfood screen and the 1,200-element Conduit feed both hash `83b865f8`**, while a root whose hiccup is ordinary markup hashes `04cc3cdb` (the non-vacuity control — the hash function is fine; the interpreted root defeats it). Left as the framework's own call (R0: this bead invents no payload byte), pinned by `the-render-hash-is-degenerate-for-an-interpreted-root` so it cannot quietly become load-bearing, and filed as **rf2-2rtt6.91** — a real repair is a server *and* client contract.

**The server render ships presence's `::h/mounting` overrides.** Predicted by the #7469 worker; **confirmed here by measurement**, not relayed. The new `presence-mounting` corpus row bakes:

```html
<div data-id="0" class="toast toast--enter">toast 0</div><div data-id="1" class="toast toast--enter">toast 1</div>
```

`arm1/presence.cljs` starts a child at `:mounting` and applies its `::h/mounting` overrides while it is there; #7469 makes the hydrating client's first pass render those children `:present`, and the two then disagree on every presence-managed node. **The repair is one line — `renderToString` between `rt/open-adoption-window!` and `rt/close-adoption-window!` — and neither function exists on main.** A call to a var that does not exist does not compile, and guessing at one is how two beads race one file. So the gap is named at the seam (`ssr/entry.cljs` §The one thing this entry does not do yet), the defect is pinned by a witness written to go **red when the repair lands**, and it is filed as **rf2-2rtt6.94**, blocked on #7469. That bead also carries #7469's root-shape note (`mount/tree` keyed off `:hydrated?`), to be reconciled when the window is wired.

## Mutation proofs

Each break confirmed the *named* failure and each revert restored a byte-identical tree (`git diff --stat` empty). Run through the `:node-test` gate build and the `test:cljs` runner, filtered to this namespace.

| mutation | failure it produced | reverted |
|---|---|---|
| `apply-policy`'s `:client-only` arm renders the host instead of nothing | `a-host-with-no-declared-policy-renders-nothing` × 2 assertions — `CLIENT-ONLY-WIDGET` reached the server HTML | green |
| the per-request gensym stamped as the **wire** `:rf/frame-id` | 7 failures: `the-payload-is-the-frameworks-own` × 3 **and** `the-same-request-renders-byte-identical-documents` on all 4 corpus rows | green |
| `:payload` defaulted to `:rf.ssr.payload/whole-app-db` when absent | `the-payload-policy-is-fail-closed` — the framework's `:rf.error/ssr-missing-payload-policy` no longer raised | green |

The driver's own fail-closed instrument was proved non-vacuous too: a render that emits a `console.error` makes `renderQuietly` exit 1 with the diagnostic named, while a quiet render returns normally. It exists because React reports a bad server render through the console *while returning markup and exiting 0* — the fail-open class this repo has been closing all week.

## Quality gates

Run in this worktree (`gate root: C:/Users/miket/code/re-frame2-worktrees/ssrnode-2rtt6-86`), foreground to completion, on the final tree.

| gate | exit | result |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | `0` | `PASS fast PR spine` |
| `npm run test:cljs` | `0` | 12514 tests / 62782 assertions / 0 failures / 0 errors |
| `npm run test:hicasso-compile` | `0` | 106 lane namespaces, **0 warnings** (the lane auto-covers new files; this compiled all six under `:hicasso-bench`) |
| `npm run ssr:hicasso-bake` | `0` | 5 fixtures, double-render SHA-256 identical for every row |

**Tiers the spine reported as NOT RUN:** documentation gates (surface unchanged); the JVM artefact suites the diff did not touch; and its standing unconditional gap — browser lanes, prod-elision/bundle-isolation/perf gates, adapter probes + smokes, the Xray feature matrix, mcp-conformance, tool JVM suites (CI only, per `TESTING.md`).

`npm run test:browser` was **not** run and is not claimed: this diff adds no `-dom-cljs-test` namespace, and every witness here is a Node-side server render that wants no DOM. `shellcheck` is not installed here and was not run.

One earlier `test-fast-pr.sh` invocation was killed at a 10-minute call cap; that run was **discarded** and the spine re-run detached to completion, twice, with the terminal `PASS fast PR spine` marker read from the log both times.

## Note on `react-dom/server` under Node

The #7469 worker flagged that shadow's module resolution can hand a build `server.browser.js`, which does not release the Node event loop. Checked: `react-dom@19.2.0`'s `server.node.js` exports `renderToString`, both the `:node-test` gate and the `:node-script` driver use `:js-provider :require` so Node's own conditional exports resolve it, and `adapters/reagent-slim`'s parity suite has required `react-dom/server` from this same `:node-test` build since rf2-6hyy. No gate hung; `npm run test:cljs` exits cleanly.

Closes rf2-2rtt6.86.
