### PR TITLE
test(story): the skipped reg-decorator scenario has an owner (rf2-kvsm1)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,16 +19,22 @@
 // reported 24 findings across 17 files — every one of them dead code — all of
 // which were deleted in the landing PR.
 //
-// SUPPRESSIONS IN THE TREE: exactly one, and it is load-bearing.
-// `tools/story/test/story_feature_load.cjs` wraps a skipped scenario's body in
-// `/* eslint-disable no-unreachable */` … `/* eslint-enable no-unreachable */`.
-// That probe returns early behind a `console.warn` while its assertions wait
-// for a CLJS port; delete the pair and `no-unreachable` errors on them, so it
-// goes only when the code it guards goes. This header used to claim ZERO
-// suppressions anywhere in the tree, which was wrong the day it was written:
-// the landing PR deleted two dead directives from that very file and kept this
-// live one. Keep the count here honest — a suppression that no comment admits
-// to is how a gate quietly stops meaning what it says (rf2-o4ohg).
+// SUPPRESSIONS IN THE TREE: none.
+// This claim is checkable, so check it rather than trusting it — the regex
+// matches the DIRECTIVE forms only, so prose mentioning them (this header
+// included) does not register as a hit, and a clean run prints nothing:
+//   git grep -nE "(/\*|//) *eslint-(disable|enable)" -- '*.cjs' '*.js' '*.mjs'
+// The count has been wrong before. The header first claimed ZERO, which was
+// false the day it was written (rf2-o4ohg); it then claimed exactly one — a
+// load-bearing `no-unreachable` pair in
+// `tools/story/test/story_feature_load.cjs` holding the dead body of a probe
+// that returned early behind a `console.warn` while its assertions waited for
+// a CLJS port. That wait had already ended: every assertion had a live owner
+// in the CLJS units and in the sibling `story_browser_scenarios.cjs`. The row
+// was demoted to `kind: 'owned-by'` and the dead body deleted, and the
+// suppression went with the code it guarded (rf2-kvsm1).
+// Keep the count here honest — a suppression that no comment admits to is how
+// a gate quietly stops meaning what it says.
 //
 // EVERY RULE HERE ANSWERS "WHAT BUG DOES THIS CATCH?":
 //

--- a/tools/story/test/story_feature_load.cjs
+++ b/tools/story/test/story_feature_load.cjs
@@ -172,14 +172,6 @@ function canvasFor(page, variantKeyword) {
   );
 }
 
-async function assertMainNotContains(page, text, timeoutMs = 3000) {
-  await waitForValue(
-    () => page.getByRole('main').getByText(text, { exact: false }).count(),
-    (count) => count === 0,
-    { timeoutMs, description: `main does not contain ${text}` },
-  );
-}
-
 async function setToolbarMode(page, mode) {
   const toolbar = page.locator('[data-test="story-toolbar"]');
   await toolbar.waitFor({ state: 'visible', timeout: 5000 });
@@ -1233,26 +1225,34 @@ const COVERAGE_MATRIX = [
     why: 'Form B desugaring is a macro/registration shape comparison; the browser shell cannot distinguish Form A from Form B at runtime.',
   },
   { feature: 'reg-workspace layouts', kind: 'probe', probe: assertWorkspaceLayouts },
+  // rf2-kvsm1 — this row was a probe that returned early behind a
+  // `console.warn`, its body held live only by an `eslint-disable
+  // no-unreachable` pair, waiting on a "follow-on bead" that was never
+  // filed. The count-based assertions went brittle when `:play-script`
+  // (rf2-0wrud, PR #1726) shifted runner-event timing — the same break
+  // that skipped the reg-variant row above. The wait is over: every
+  // assertion the dead body held now has a live owner elsewhere, so the
+  // row is demoted per this file's own rule ("never wire a probe whose
+  // body does not exercise the row's feature"). Where each went:
+  //   - 'decorator: story-level' + 'decorator: variant-level' on
+  //     /clicked-three-times → story_browser_scenarios.cjs's
+  //     'substrate-decorator-and-frame-isolation' scenario asserts both
+  //     strings after the same clickVariant + waitForCanvas (live, unskipped).
+  //   - the count-3 baseline → reg_variant_e2e_cljs_test.cljs's
+  //     `clicked-three-times-runs-clean-count-3`, which drives
+  //     `story/run-variant` directly and so has no DOM-count race.
+  //   - story-level applies / variant-level does NOT leak to :loaded →
+  //     render_shell_cljs_test.cljs's `render-variant-and-canvas-resolve-
+  //     same-inherited-decorators` (inherited pack) and
+  //     `render-decorated-view-bare-when-no-decorators` (no spurious wrap).
+  //   - assertDecoratorFailure → still called live by the 'Error projection'
+  //     row below, and by the browser scenario's /decorator-throws leg.
+  // Deleting the body retires the tree's last eslint suppression with it.
   {
     feature: 'reg-decorator composition',
-    kind: 'probe',
-    probe: async (page) => {
-      // SKIP: brittle count-based assertion · :play-script runner-events shifted
-      // timing semantics · CLJS-unit migration in follow-on bead (cf rf2-w1mnq
-      // schema-violation skip + rf2-8awk1 reg-variant skip patterns).
-      console.warn('SKIP: reg-decorator composition scenario · migrating to CLJS unit');
-      return;
-      /* eslint-disable no-unreachable */
-      await assertMatrixVariant(page, '/clicked-three-times', ':story.counter/clicked-three-times', 3);
-      await assertMainContains(page, 'decorator: story-level');
-      await assertMainContains(page, 'decorator: variant-level');
-      await clickVariant(page, '/loaded');
-      await waitForCanvasVariant(page, ':story.counter/loaded');
-      await assertMainContains(page, 'decorator: story-level');
-      await assertMainNotContains(page, 'decorator: variant-level');
-      await assertDecoratorFailure(page);
-      /* eslint-enable no-unreachable */
-    },
+    kind: 'owned-by',
+    gate: 'npm run test:cljs + story_browser_scenarios.cjs',
+    why: 'rf2-kvsm1 — composition/inheritance asserted in CLJS units; the rendered story-level + variant-level decorator text is asserted live by the sibling browser scenario.',
   },
   {
     feature: 'reg-story-panel',


### PR DESCRIPTION
Closes rf2-kvsm1.

The `reg-decorator composition` row in `tools/story/test/story_feature_load.cjs`
was a probe that returned early behind a `console.warn`, its eight assertions
held live only by an `eslint-disable no-unreachable` pair, waiting on a
"follow-on bead" that was never filed. That pair was the tree's only eslint
suppression, and `eslint.config.mjs`'s header named it as load-bearing.

## The skip was no longer warranted

The bead asks for one of two outcomes: port the assertions to CLJS and delete
the dead body plus the suppression, or — if the scenario is not worth porting —
delete the body outright and the suppression with it. The second applies, and
for a stronger reason than "not worth porting": **the port had already
happened**. Every assertion the dead body held has a live owner today.

| dead assertion | live owner |
| --- | --- |
| `decorator: story-level` + `decorator: variant-level` on `/clicked-three-times` | `story_browser_scenarios.cjs` → `substrate-decorator-and-frame-isolation` asserts both strings verbatim after the same `clickVariant` + `waitForCanvas`. That file carries **no** skips. |
| the count-`3` baseline (the brittle assertion that caused the skip when `:play-script`/rf2-0wrud shifted runner-event timing) | `reg_variant_e2e_cljs_test.cljs` → `clicked-three-times-runs-clean-count-3`, which drives `story/run-variant` directly and so has no DOM-count race |
| story-level applies / variant-level does **not** leak to `:loaded` | `render_shell_cljs_test.cljs` → `render-variant-and-canvas-resolve-same-inherited-decorators` (inherited pack) + `render-decorated-view-bare-when-no-decorators` (no spurious wrap). Fixture confirms the semantics: the story-level decorator sits on `reg-story :story.counter`, the variant-level one only on the clicked-three-times variant. |
| `assertDecoratorFailure` | still called live by the `Error projection` row **in this same file**, and by the browser scenario's `/decorator-throws` leg |

`clickVariant` / `waitForCanvasVariant` in the dead body were navigation, not
assertions.

## The change

The row is demoted to `kind: 'owned-by'` — which is not an invention but this
file's own documented rule for exactly this situation:

> Never wire a probe whose body does not exercise the row's feature — demote to
> 'owned-by' instead and name the owning gate.

The harness validates the shape (`gate` string, `why` string, and no `probe`,
which would re-introduce aliasing). A comment above the row records where each
assertion went, matching the established rf2-sgdd3 style of a comment block plus
a terse `why`. The dead body is deleted and the suppression goes with the code
it guarded.

Two consequences worth calling out:

- `assertMainNotContains` loses its only caller with that body. It is not
  exported, so leaving it would red `no-unused-vars`; it is deleted.
- `eslint.config.mjs`'s header claimed "exactly one suppression". That claim is
  now false, and the header's own standing instruction is to keep the count
  honest, so it records **none**. The documented verification regex is
  directive-shaped, so prose mentioning `eslint-disable` (the header itself
  included) does not register as a hit — the first draft matched its own
  sentence and would have made the check useless. It now returns nothing:
  `git grep -nE "(/\*|//) *eslint-(disable|enable)" -- '*.cjs' '*.js' '*.mjs'`

No lint rule was changed; `no-unreachable` remains `'error'` in the curated set.

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/storyskip-kvsm1`.

| gate | exit |
| --- | --- |
| `npm run lint:js` (root) | **0** |
| `npm run test:script-policy && npm run test:script-helpers` (chained, from `implementation/`) | **0** |
| `sh scripts/test-fast-pr.sh` | **0** |
| `node -e "require('./tools/story/test/story_feature_load.cjs')"` | **0** |
| `git grep -nE "(/\*|//) *eslint-(disable|enable)"` | 1 (no matches — zero suppressions, as the header now claims) |

The JS harness gate was run **chained**, both halves, as `test.yml:2581` composes
it.

The spine classified this change as `docs=false jvm=false node=false` and
**skipped 4 tiers**, none of which cover this diff:

- documentation gates (surface unchanged)
- all JVM artefact suites (surface unchanged)
- npm/CLJS/isolation (surface unchanged)
- browser lanes + the rest (CI only)

That last one matters here: the lane that actually executes this file's
`COVERAGE_MATRIX` is browser-only and therefore **CI-only**, so CI is the first
place the demoted row is exercised end-to-end. The row shape is validated by
`validateCoverageMatrix()`, whose three `owned-by` requirements this row meets;
the module-load check above proves the file still parses and requires cleanly.