### PR TITLE
fix(hicasso): the SSR render entry opens the adoption window (rf2-2rtt6.94)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry.cljs
@@ -34,7 +34,8 @@
     2. seeded through the FRAMEWORK'S doors — `:initial-events`, and the
        reserved `:rf/set-db` for a snapshot handed in whole;
     3. rendered as `(provider frame (codec/root-element frame hiccup))`,
-       the same two calls `arm1/mount/render!` makes in the browser;
+       the same two calls `arm1/mount/render!` makes in the browser,
+       **inside an open adoption window** — see below;
     4. the payload built out of the FRAMEWORK'S OWN BYTES —
        `payload-policy/apply-policy` (the fail-closed `:payload`
        contract), `project-app-db-egress`, `build-payload`, and
@@ -42,8 +43,9 @@
        `__rf_payload` script id. Nothing Hicasso-specific touches the
        payload path (R0); this namespace supplies the app-db and gets out
        of the way;
-    5. `destroy-frame!` in a `finally`, so a render that threw leaks no
-       more than one that returned.
+    5. the adoption window closed and `destroy-frame!` run in a
+       `finally`, so a render that threw leaks no more than one that
+       returned.
 
   ## The wire frame-id is nil, deliberately
 
@@ -71,31 +73,39 @@
   **No streaming.** `renderToPipeableStream` is out of scope per the
   adversarial review, and out of scope here means absent, not deferred.
 
-  ## The one thing this entry does not do yet — THE ADOPTION WINDOW
+  ## THE ADOPTION WINDOW IS OPEN AROUND `renderToString` (rf2-2rtt6.94)
 
-  Predicted by the rf2-2rtt6.84 worker and CONFIRMED here by measurement,
-  so it is a named gap rather than a surprise waiting for the spike
-  witness.
+  A server render is the FIRST HALF OF AN ADOPTION, so it runs in the
+  same window the client's hydrating half does
+  (`arm1/runtime.cljs` — [[re-frame.bench.hicasso.arm1.runtime/adopting?]]
+  says as much: *\"A server render entry opens the same window around its
+  own `renderToString`, so the two halves of an SSR route answer this
+  identically\"*).
 
-  Presence starts a child at `:mounting` (`arm1/presence.cljs` —
-  `(react/useState presence/initial)`) and applies that child's
-  `::h/mounting` attribute overrides while it is in that phase. A server
-  render therefore ships the ENTER appearance — the class an animation is
-  about to move off. rf2-2rtt6.84 makes the hydrating client's first pass
-  render those same children `:present` instead (born-present under an
-  open adoption window), so the server's markup and the client's first
-  pass disagree, and React reports a hydration mismatch on every
-  presence-managed node. Measured on the corpus's `presence-mounting`
-  row, which bakes `toast--enter` today and is pinned red-when-fixed by
-  `the-server-render-ships-presences-mounting-overrides`.
+  Without it the two halves disagree. Presence starts a child at
+  `:mounting` (`arm1/presence.cljs` — `(react/useState
+  presence/initial)`) and applies that child's `::h/mounting` attribute
+  overrides while it is in that phase, so a windowless server render
+  ships the ENTER appearance — the class (and, in the shapes that use
+  one, the `opacity: 0` style) an animation is about to move off. The
+  hydrating client's first pass renders those same children `:present`
+  (born-present, rf2-2rtt6.84), and React then reports a hydration
+  mismatch on every presence-managed node. Measured on the corpus's
+  `presence-mounting` row, which baked `toast--enter` twice before this
+  window existed and is now pinned the other way by
+  `the-server-render-ships-no-mounting-overrides`.
 
-  **The repair is one line, and it is not writable yet**:
-  `renderToString` below must run between `rt/open-adoption-window!` and
-  `rt/close-adoption-window!`, and neither function exists on main — they
-  are in rf2-2rtt6.84's still-open PR #7469. Wiring it is rf2-2rtt6.94,
-  which is blocked on that merge. Nothing here is edited to anticipate
-  it: a call to a var that does not exist does not compile, and guessing
-  at a var that does is how two beads race one file.
+  The window is one flag and exactly one thing reads it — presence's
+  born-present seeding. Opening it changes no transform, adds no fiber
+  and installs no effect; the ordinary render path is untouched.
+
+  **It closes in the `finally`, beside `destroy-frame!`, and that
+  placement is the point**: the flag is module-level, so a render that
+  threw with the window still open would leave the whole PROCESS
+  adopting and every later request born-present — which is what
+  [[re-frame.bench.hicasso.arm1.runtime/close-adoption-window!]]'s own
+  docstring warns about. A per-request window is a per-request window
+  for the same reason a per-request frame is.
 
   ## What this is NOT
 
@@ -106,6 +116,7 @@
   shape closely enough to be recognisable and is a BENCH-LANE page, priced
   and ruled elsewhere."
   (:require [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
             [re-frame.bench.hicasso.front.codec :as codec]
             [re-frame.bench.hicasso.ssr.host-policy :as host-policy]
             [re-frame.core :as rf]
@@ -232,7 +243,9 @@
       :version         :schema-digest  passed through to `build-payload`.
       :app-element-id  :script-src  :title  the document envelope's.
 
-  The frame is destroyed in a `finally`. `destroy-frame!`'s lifecycle was
+  The adoption window is closed and the frame destroyed in a `finally`,
+  in that order and for the same reason — see the namespace docstring's
+  §The adoption window. `destroy-frame!`'s lifecycle was
   verified sound for this use in the design programme (`frame.cljc` —
   destroy tears down the frame's containers and registrations), so a
   per-request frame is a per-request frame and not a per-request leak."
@@ -243,6 +256,10 @@
       (rf/make-frame (assoc frame-opts
                             :id             frame-id
                             :initial-events (setup-events snapshot initial-events)))
+      ;; The server half of an adoption renders inside the same window as
+      ;; the client half — see the namespace docstring. Closed in the
+      ;; `finally`.
+      (rt/open-adoption-window!)
       (let [;; The server walk consults `defhost`'s `:ssr` policy BEFORE
             ;; anything is turned into an element — see
             ;; `ssr.host-policy` for which hosts it reaches and which
@@ -307,6 +324,11 @@
                                     :script-src     script-src
                                     :title          title})})
       (finally
+        ;; FIRST, and unconditionally: the window is a module-level flag,
+        ;; so a throw here that skipped it would leave the whole process
+        ;; adopting. `destroy-frame!` is the per-request cleanup that may
+        ;; itself throw; the window must already be shut when it runs.
+        (rt/close-adoption-window!)
         (rf/destroy-frame! frame-id)))))
 
 (defn render-twice

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry_cljs_test.cljs
@@ -190,7 +190,8 @@
           "the server's bytes carry NO enter override — remove
            `rt/open-adoption-window!` from ssr/entry.cljs and this is the
            assertion that goes red")
-      (is (= 0 (count (re-seq #"toast--enter" html))))
+      (is (zero? (count (re-seq #"toast--enter" html)))
+          "zero occurrences, where the defect shipped one per child")
       ;; The non-vacuity control, kept verbatim from the measuring row: the
       ;; tray DID render its children, so the assertion above is about the
       ;; override being absent and not about an empty tray.

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry_cljs_test.cljs
@@ -173,24 +173,50 @@
       ;; interpreted root that defeats it.
       (is (not= dogfood markup)))))
 
-(deftest the-server-render-ships-presences-mounting-overrides
-  (testing "PINNED AS A DEFECT (rf2-2rtt6.94). Presence starts a child at
-           `:mounting` and applies its `::h/mounting` overrides while it is
-           there, so a server render — which runs with no adoption window,
-           because this entry cannot open one until rf2-2rtt6.84 lands —
-           emits the ENTER appearance. rf2-2rtt6.84 makes the hydrating
-           client's first pass render those children `:present`, and the two
-           then disagree. This row goes RED when the repair lands, which is
-           the point of writing it."
+(deftest the-server-render-ships-no-mounting-overrides
+  (testing "THE REGRESSION GUARD (rf2-2rtt6.94), and the inversion of the row
+           that measured the defect. Presence starts a child at `:mounting`
+           and applies its `::h/mounting` overrides while it is there, so a
+           server render with no adoption window open emits the ENTER
+           appearance — and the hydrating client's first pass renders those
+           same children `:present` (born-present, rf2-2rtt6.84), which is a
+           hydration mismatch on every presence-managed node. The entry now
+           opens the window around `renderToString`, so the server's bytes
+           are born-present too and the two halves agree by construction.
+           This row goes RED if that window is ever removed, narrowed, or
+           closed before the render."
     (let [{:keys [html]} (entry/render (fixtures/row "presence-mounting"))]
-      (is (str/includes? html "toast--enter")
-          "if this is now absent, the adoption window is being opened around
-           the server render — delete this row and assert the opposite")
-      (is (= 2 (count (re-seq #"toast--enter" html))))
-      ;; The non-vacuity control: the tray DID render its children, so the
-      ;; assertion above is about the override and not about an empty tray.
+      (is (not (str/includes? html "toast--enter"))
+          "the server's bytes carry NO enter override — remove
+           `rt/open-adoption-window!` from ssr/entry.cljs and this is the
+           assertion that goes red")
+      (is (= 0 (count (re-seq #"toast--enter" html))))
+      ;; The non-vacuity control, kept verbatim from the measuring row: the
+      ;; tray DID render its children, so the assertion above is about the
+      ;; override being absent and not about an empty tray.
       (is (str/includes? html "toast 0"))
       (is (str/includes? html "toast 1")))))
+
+(deftest the-adoption-window-does-not-outlive-the-request
+  (testing "shut going in — the window belongs to a render, not to the process"
+    (is (false? (rt/adopting?))))
+
+  (testing "and shut again on the way out of a render that RETURNED"
+    (entry/render (fixtures/row "presence-mounting"))
+    (is (false? (rt/adopting?))))
+
+  (testing "and on the way out of one that THREW, which is why the close is
+           in the `finally`. The flag is module-level, so a render that threw
+           with it still open would leave every LATER request in this process
+           born-present — the failure `close-adoption-window!`'s own
+           docstring names."
+    (is (= :rf.error/ssr-missing-payload-policy
+           (error-id #(entry/render (dissoc dogfood-request :payload))))
+        "the render really did throw, and it threw AFTER renderToString had
+         run — so the window was genuinely open at the moment of the throw;
+         a row where nothing threw would prove nothing")
+    (is (false? (rt/adopting?))
+        "the finally shut it anyway")))
 
 ;; ---------------------------------------------------------------------------
 ;; Clause 2 — determinism

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/fixtures.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/fixtures.cljs
@@ -87,31 +87,29 @@
       [:li {:key i} [fallback-host {:kind "fallback" :i i}]])]])
 
 ;; ---------------------------------------------------------------------------
-;; The presence row — a PINNED DEFECT, not a passing feature
+;; The presence row — the hydration-parity guard
 ;; ---------------------------------------------------------------------------
 
 (def presence-tray
   "A presence tray whose children carry `::h/mounting` attribute
   overrides.
 
-  This row is here to MEASURE a defect the rf2-2rtt6.84 worker predicted
-  and this bead confirmed, not to show something working. Presence's
-  machine starts a child at `:mounting` (`arm1/presence.cljs` —
-  `(react/useState presence/initial)`), and while a child is in that
-  phase the tray applies its `::h/mounting` overrides. A server render
-  therefore ships the ENTER appearance — the `opacity: 0` class an
-  animation is about to move off — into the HTML.
+  This row MEASURED a defect the rf2-2rtt6.84 worker predicted, and now
+  guards its repair. Presence's machine starts a child at `:mounting`
+  (`arm1/presence.cljs` — `(react/useState presence/initial)`), and
+  while a child is in that phase the tray applies its `::h/mounting`
+  overrides. A server render with no adoption window open therefore
+  shipped the ENTER appearance — the `opacity: 0` class an animation is
+  about to move off — into the HTML, while the hydrating client's first
+  pass rendered those same children `:present` (born-present under an
+  open window): a hydration mismatch on every presence-managed node.
 
-  rf2-2rtt6.84 makes the hydrating client's first pass render those same
-  children `:present` instead (born-present under an open adoption
-  window), so the server's overrides and the client's first pass
-  disagree and React reports a hydration mismatch on every
-  presence-managed node. The repair is for this entry to open the same
-  adoption window around `renderToString` — which it CANNOT do yet,
-  because `runtime/open-adoption-window!` does not exist on main; it is
-  in rf2-2rtt6.84's still-open PR. See
-  [[re-frame.bench.hicasso.ssr.entry]] §The one thing this entry does not
-  do yet."
+  rf2-2rtt6.94 opened the same window around `renderToString`, so this
+  row's server bytes are born-present too and carry no `toast--enter` at
+  all. `the-server-render-ships-no-mounting-overrides` asserts exactly
+  that, and this row is the only shape in the corpus that can go red if
+  the window is ever removed. See [[re-frame.bench.hicasso.ssr.entry]]
+  §The adoption window."
   [presence {:timeout-ms 200}
    (for [i (range 2)]
      [:div.toast {:key                          i
@@ -164,11 +162,11 @@
     :script-src "/main.js"}
 
    {:id     "presence-mounting"
-    :why    "PINNED DEFECT — a server render ships presence's ::h/mounting overrides; rf2-2rtt6.94 is the repair"
+    :why    "presence's children are born PRESENT server-side — the adoption window is open around renderToString, so no ::h/mounting override reaches the HTML (rf2-2rtt6.94)"
     :hiccup presence-tray
     :snapshot {}
     :payload  :rf.ssr.payload/whole-app-db
-    :title    "Hicasso SSR — presence (pinned defect)"
+    :title    "Hicasso SSR — presence (born present)"
     :script-src "/main.js"}
 
    {:id     "defhost-ssr-policy"


### PR DESCRIPTION
Closes rf2-2rtt6.94.

A server render is the **first half of an adoption**, so `ssr/entry.cljs` now runs `renderToString` inside the same window the hydrating client's half opens. `runtime/adopting?`'s own docstring already stated the requirement — *"A server render entry opens the same window around its own `renderToString`, so the two halves of an SSR route answer this identically"* — and this is the entry catching up to it. It was blocked on #7469 (the window did not exist on main); that has merged.

## The defect

Presence starts a child at `:mounting` (`arm1/presence.cljs` — `(react/useState presence/initial)`) and applies that child's `::h/mounting` attribute overrides while it is in that phase. A windowless server render therefore shipped the ENTER appearance — the class an animation is about to move off — while the hydrating client's first pass rendered those same children `:present` (born-present, rf2-2rtt6.84). React reports a hydration mismatch on every presence-managed node. Measured, not argued: the `presence-mounting` corpus row baked `toast--enter` twice.

## The fix — three lines

```clojure
[re-frame.bench.hicasso.arm1.runtime :as rt]   ; the require entry.cljs did not have
(rt/open-adoption-window!)                     ; after make-frame, before renderToString
(rt/close-adoption-window!)                    ; first in the EXISTING try/finally
```

The close is **in the `finally`, before `destroy-frame!`**, and the placement is load-bearing: the flag is module-level, so a render that threw with the window open would leave the whole *process* adopting and every later request born-present — the failure `close-adoption-window!`'s own docstring names. `destroy-frame!` is the cleanup that may itself throw, so the window is already shut when it runs.

Everything else in the diff is prose: the ns docstring's §"The one thing this entry does not do yet" is now §"The adoption window is open around `renderToString`", and the `presence-mounting` fixture's docstring and `:why` no longer describe an unrepaired defect.

## The witness is INVERTED, not deleted

`the-server-render-ships-presences-mounting-overrides` said *"delete this row and assert the opposite"*. A deleted witness protects nothing, so it is now `the-server-render-ships-no-mounting-overrides`: **zero** `toast--enter` occurrences, with the `toast 0` / `toast 1` non-vacuity control kept verbatim so the assertion is about the override being absent and not about an empty tray.

One row is added — `the-adoption-window-does-not-outlive-the-request` — covering shut-going-in, shut after a render that **returned**, and shut after one that **threw**. The throwing case reuses the entry's own `:rf.error/ssr-missing-payload-policy` refusal, which fires *after* `renderToString` has run, so the window was genuinely open at the moment of the throw.

## Fences held

- **No `implementation/ssr` or `ssr-ring` edit.** R0 stands: those payload functions are consumed, not modified. The diff is three files, all under `implementation/freehand/test/re_frame/bench/hicasso/ssr/`.
- **The ordinary render path is byte-for-byte unchanged.** No file under `arm1/` is in the diff — `mount.cljs`, `runtime.cljs` and `presence.cljs` are untouched. No fiber, no passive effect, nothing new in `retained-inventory`.
- **The ≤2-hook shell is untouched.** Zero hooks added: the only `react/use*` strings in the added lines are prose inside docstrings citing `presence.cljs`.
- **`mount/tree` was NOT widened.** The bead asked whether the SSR entry's root shape agrees with `mount/tree`'s. It does, and the answer is "do nothing": `tree` is `defn-`, and its non-hydrated branch returns exactly `(provider (:frame handle) (codec/root-element (:frame handle) hiccup))` — which is what `entry.cljs` already builds. Widening a deliberately-private var whose docstring says the one-place arrangement is the point, for zero behavioural gain, was rejected. `tree` is still `(defn- tree` at `arm1/mount.cljs:58`.

## Quality gates

Run from the worker worktree (`gate root:` verified on each), foreground to completion, none piped.

| Gate | Exit | Result |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | PASS fast PR spine |
| `npm run test:cljs` | **0** | 0 failures, 0 errors |
| `npm run test:hicasso-compile` | **0** | 109 lane namespaces, **0 warnings** |
| clj-kondo (CI pin **2026.04.15**, `lint.yml`'s exact invocation) | **0** | **errors: 0**, warnings 4534 (pre-existing baseline) |

clj-kondo was run with the **pinned** binary fetched from the release tag, not the local 2025.10.23 build, because the two disagree on this tree.

**`npm run test:browser` NOT run, and not claimed.** The diff contains no `-dom-cljs-test` namespace; `entry_cljs_test.cljs` is a `-cljs-test` (node) namespace and `entry.cljs` / `fixtures.cljs` are lane sources the `:hicasso-bench` browser build compiles, which `test:hicasso-compile` covers. Nothing in the browser lane requires `ssr.entry` or `ssr.fixtures` — the hydration DOM witnesses build their own server HTML through `mount/root!` under an open window and are unaffected.

**Skipped tiers** (the spine's own report): documentation gates (doc surface unchanged), the JVM artefact suites the diff did not touch, and the CI-only browser/bundle-isolation/perf/Xray-matrix/mcp-conformance lanes.

## Mutation-proved, both directions

Each mutation was applied to the committed tree, gated, then reverted — `git status` clean against HEAD afterwards, verified before the PR opened.

| Mutation | Exit | Red |
|---|---|---|
| `(rt/open-adoption-window!)` removed | **1** | exactly 2 failures, **both** in `the-server-render-ships-no-mounting-overrides` (`entry_cljs_test.cljs:189`, `:193`) — nothing else |
| `(rt/close-adoption-window!)` moved out of the `finally` into the `let` body | **1** | exactly 1 failure, `the-adoption-window-does-not-outlive-the-request` (`entry_cljs_test.cljs:219`) — the **throw** row only; the returned row stayed green |

The second mutation is the sharp one: it isolates the `finally` *placement* rather than the call, because a close that runs on the happy path only leaves the throw row red and the returned row green — exactly what was observed.
