### PR TITLE
docs(hicasso): where is :on-mount? — the absence, stated (rf2-2rtt6.95)

### DIFF
--- a/docs/design/hicasso/draft-guide/07-ephemeral-state.md
+++ b/docs/design/hicasso/draft-guide/07-ephemeral-state.md
@@ -186,10 +186,16 @@ jump to a new slot halfway through its animation. Surviving keys keep the order
 they had and genuinely new keys are appended. A list that re-sorts while items are
 leaving therefore sorts at the data layer, not here.
 
-**Enter is the weak half, and this guide will not pretend otherwise.**
-`::h/mounting` exists, but driving an entrance as a `:mounting` → `:present` class
-flip can lose the race to the browser's first paint, and then nothing animates. For
-enter, use an animation on insertion or `@starting-style`:
+### Enter is the weak half
+
+This guide will not pretend otherwise, so here is the enter side in full.
+
+`::h/mounting` is the mirror of `::h/unmounting`: an attribute-override map that
+presence merges onto the nodes it can see while a child is in its `:mounting`
+phase — on the way in, rather than on the way out. It exists, it ships, and it
+works. But driving an entrance as a `:mounting` → `:present` class flip can lose
+the race to the browser's first paint, and then nothing animates. For enter, use
+an animation on insertion or `@starting-style`:
 
 ```css
 .toast { animation: toast-in 200ms ease-out; }
@@ -200,6 +206,63 @@ enter, use an animation on insertion or `@starting-style`:
 
 Exit is the phase that transitions happily, because the node is already painted.
 
+So `::h/mounting` earns its keep on the attributes that are simply *true during
+entry* rather than on the animation itself. An arriving node that should not take
+focus or be announced until it has settled wants `:inert` and `:aria-hidden`, in
+the same map shape the exit override uses. A class flip is legitimate too, once
+you have looked at the paint race and decided you can live with losing it now and
+then. What it is not is the recommended way to make something fade in.
+
+One thing to know before you lean on mounting-phase attributes for correctness
+rather than for looks. Under the ruled SSR design a presence-managed node
+**hydrates born-present**, so server HTML never carries `:mounting`-phase
+attributes at all ([Server-side rendering](10-server-side-rendering.md)). Nothing
+that arrived with the page replays an entrance over content the user is already
+reading, which is the behaviour you want — but it does mean the first paint of a
+server-rendered page is not a moment when `::h/mounting` has been applied.
+
+## Where is `:on-mount`?
+
+There is no `:on-mount` and no `:on-unmount`, and as with `local`, the absence is
+ruled rather than pending. Hicasso took the *attribute* half of Replicant's
+mechanism — `::h/mounting` and `::h/unmounting` above — and rejected the callback
+half, `:replicant/on-mount` and `:replicant/on-unmount`, as less data-oriented
+than a registered behaviour. Presence is the one mechanism that knows a node
+arrived or left, and it never dispatches anything about either, deliberately. And
+the hook-budget witness holds the tier-1 shapes to a page with no `useEffect` on
+it anywhere.
+
+An absence with nowhere to go would be a gap. Four jobs send people looking for
+`:on-mount`, and each of them has a home.
+
+**Load the data this screen needs.** The route declares it, not the view. A
+route's `:resources` are ensured on entry and its `:on-match` carries activation
+events, which is also what closes the click-away race — a fetch kicked off by a
+mounting component has nothing to suppress the late reply when the user navigates
+away first
+([Routing](../../../routing/concepts.md#loaders-declaring-a-pages-data)).
+
+**Run something once at startup.** `:initial-events` — ordinary events, run in
+order, seeding app-db *before* first paint rather than a beat after it
+([Getting started](01-getting-started.md)).
+
+**Animate an entrance or an exit.** Presence, above. `::h/unmounting` for exit;
+an animation on insertion, or `@starting-style`, for enter.
+
+**Drive a real DOM node or a third-party SDK.** The host edge, which is where
+[the placement rule](#the-placement-rule) says lifecycle honestly lives. A
+callback `:ref` hands you the node on attach and takes your return value as the
+cleanup, and a `defhost` component brings whatever hooks it already had — its own
+`useEffect` included, running inside a Hicasso tree exactly as it ran outside one
+([Interop](05-interop.md)).
+
+The last of those has an open edge, and it is worth naming rather than papering
+over. The *data* spelling of a host behaviour — a registered id and a config map,
+with the imperative code out of your view, as in
+`{:ref [::autosize {:max-rows 8}]}` — is refused today with
+`:rf.error/hicasso-ref-vector-reserved`. That value space is reserved, not
+designed. Until it lands, write the function.
+
 ## Troubleshooting
 
 This table names mechanisms; the one minted id on this surface is named in its
@@ -208,6 +271,7 @@ row.
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | Reaching for `useState` to hold "is this open?" | That's semantic state | app-db, or CSS if the platform tracks it |
+| Searching for `:on-mount`, `componentDidMount`, or a mount `useEffect` | There is none, and the absence is ruled rather than pending | Name the job: route `:resources` for page data, `:initial-events` for startup, presence for animation, a callback `:ref` or `defhost` at a host edge |
 | A dismissed item disappears instantly with no exit animation | The node left with the data | `h/presence` with a `:timeout-ms` at least as long as the exit transition |
 | A retained node still takes focus or clicks while fading | The exit override does not carry `:inert` / `:aria-hidden` | Put all three in the `::h/unmounting` map |
 | An exit override on a view head raises `:rf.error/hicasso-presence-override-on-a-view` | Presence merges overrides into nodes it can see; a view is opaque to it, and a silently dropped override is the failure class the loud error exists to delete | The view receives `:rf/phase` — branch or style on that |

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -22,7 +22,7 @@ narrower question — **what does a programmer actually type?**
 | [Controlled inputs](04-controlled-inputs.md) | Type into a text field whose value round-trips through app-db, and keep your caret |
 | [Interop](05-interop.md) | Use a React component from npm |
 | [Theming](06-theming.md) | Style a component library without a context API |
-| [Ephemeral state](07-ephemeral-state.md) | Decide where "is this dropdown open?" lives, given there is no `local` — and where "it left but is still fading out" lives, given app-db cannot hold it |
+| [Ephemeral state](07-ephemeral-state.md) | Decide where "is this dropdown open?" lives, given there is no `local`; where "it left but is still fading out" lives, given app-db cannot hold it; and where the jobs you wanted `:on-mount` for actually go |
 | [Testing](08-testing.md) | Assert a view's output without a browser, and know when you still need one |
 | [When a view throws](09-when-a-view-throws.md) | Keep one broken view from taking the page down with it |
 | [Server-side rendering](10-server-side-rendering.md) | Serve a page rendered from a db snapshot and adopt it live in the browser — what exists, what is landing, and how to write an app so SSR is free |


### PR DESCRIPTION
Closes rf2-2rtt6.95.

A reader coming from React or Reagent searched the draft guide for `:on-mount`
and found neither the feature nor an explanation (the operator hit this on
2026-08-04). The absence is ruled, not pending, so the guide now says so and says
where the work goes instead.

## What changed

**`07-ephemeral-state.md` gains a `## Where is :on-mount?` passage.** It states
the absence, cites the reasoning, and then maps the four jobs people actually
reach for `:on-mount` to do onto their ruled homes:

| The job | Where it goes |
|---|---|
| Load the data this screen needs | The route declares it — `:resources` ensured on entry, `:on-match` for activation events, which is also what closes the click-away race |
| Run something once at startup | `:initial-events`, seeding app-db before first paint |
| Animate an entrance or an exit | Presence — `::h/unmounting` for exit, CSS on insertion or `@starting-style` for enter |
| Drive a real DOM node or a third-party SDK | The host edge — a callback `:ref`, or `defhost` for a foreign component that brings its own hooks |

**One thing is marked open rather than improvised.** The *data* spelling of a
host behaviour (`{:ref [::autosize {:max-rows 8}]}`) is refused today with
`:rf.error/hicasso-ref-vector-reserved`; the passage says the value space is
reserved, not designed, and that the callback is the spelling until it lands. No
replacement was invented for it.

**`::h/mounting` gets its own short treatment** (the bead's scope-widening
comment). It was named exactly once on the page, as a warning, with no
definition — the exit half got the full treatment while the enter half was a
deflection. The `Enter is the weak half` paragraph is now a `###` section that
says what `::h/mounting` *is* (the enter-phase attribute-override map, symmetric
with `::h/unmounting`, merged onto nodes presence can see during the `:mounting`
phase), when it is legitimately used (mounting-phase `:inert` / `:aria-hidden`
during entry; a class flip where the paint race is acceptable), and why CSS
animation-on-insertion stays the recommended enter answer. The ruling's own
reasoning, already on the page, is kept verbatim.

**One honest-tense forward note**, per the same comment: under the ruled SSR
design a presence-managed node hydrates *born-present*, so server HTML never
carries `:mounting`-phase attributes — authors should not rely on them being
applied at first paint of a server-rendered page.

Also: one Troubleshooting row (the reader's actual symptom is *searching*), and
the `README.md` page-table cell for 07 now mentions `:on-mount` so the index
answers the search too.

## The ruling, verified against the tree

Each citation was checked before writing, not taken from the brief.

| Claim | Verified at |
|---|---|
| Only the *attribute* half of Replicant's mechanism is taken; the `:replicant/on-mount` / `:on-unmount` **callbacks** are rejected as less data-oriented | `docs/design/hicasso/decisions.md:1055-1061` — "The callback half is less data-oriented than the predecessor's registered behaviors and is **rejected**." |
| Presence never dispatches domain mount/unmount events | `docs/design/hicasso/decisions.md:1070`, under "Inherited unchanged" |
| The hook-budget witness bans `useEffect` in authored bodies | `implementation/freehand/test/re_frame/bench/hicasso/shapes/hook_budget_dom_cljs_test.cljs:178-181` — `useEffect` is in the banned list asserted "must not appear anywhere on the page" across the tier-1 roster |

Two notes on precision, neither of which changes the outcome:

- The bead cites `~:1055-1061` for all three. The Replicant half is exactly
  there; "presence never dispatches domain mount/unmount events" is nine lines
  further down at `:1070`.
- The page already teaches that hooks physically work in a `defview` body at the
  HD-003 escape hatch, so the passage does **not** claim `useEffect` is
  prohibited. It says the hook-budget *witness* holds the tier-1 shapes to a page
  with no `useEffect` on it anywhere — which is what the test asserts.

Supporting mappings also verified: `defhost` foreign components keep their own
`useContext` / `useState` / `useEffect`
(`arm1/host_hatch_dom_cljs_test.cljs:877`, `the-door-spends-one-hook-and-the-hosted-hooks-are-its-own`);
the reserved `:ref` vector space is `rf2-2rtt6.38`, taught at
`05-interop.md:367-380`; `:resources` on route entry and the click-away race at
`docs/routing/coming-from-react-router.md:89-99` and
`docs/routing/glossary.md:33`.

## Quality gates

`mkdocs build --strict` **is not a gate for this change and is not nominated as
one.** `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site, so
the build ran (as part of the spine) and exited 0 having verified nothing of
these edits.

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `sh scripts/test-fast-pr.sh` (gate root confirmed `…/onmount-2rtt6-95`) | **0** |

**The slug checker was mutation-proved rather than trusted**, because it is the
only gate that sees this tree. Breaking the new cross-corpus anchor
(`…#loaders-declaring-a-pages-data-BOGUS`) → exit 1, "BROKEN ANCHOR". Breaking
the target file (`routing/NOSUCH.md`) → exit 1, "BROKEN TARGET". Restored → exit
0, working tree clean against HEAD. So the 0 above is a real pass, not fail-open.

**Anchors, hand-verified.** Two headings added, and their derived slugs were
confirmed by probe (temporary self-links, checker green, then reverted):
`#where-is-on-mount` and `#enter-is-the-weak-half`. Neither collides and neither
contains a hyphen run, so the GitHub / python-markdown slugify divergence does
not bite. No heading was renamed or removed — `### What presence does not do`
keeps its anchor. Inbound sweep across every tracked `.md`: no link anywhere
targets `07-ephemeral-state.md#…`, and nothing links the two new anchors, so
there was nothing to update. Outbound links added:
`../../../routing/concepts.md#loaders-declaring-a-pages-data` (an explicit
`<a id>` at `concepts.md:364`, already used twice elsewhere — copied rather than
derived), plus `#the-placement-rule`, `01-getting-started.md`,
`05-interop.md` and `10-server-side-rendering.md`.

**Tables, hand-counted** (nothing validates them):

| Table | Columns | Body rows |
|---|---|---|
| `07` Troubleshooting (one row added) | 3, uniform incl. header + separator | 9 |
| `07` Not settled yet (untouched) | 2, uniform | 5 |
| `README.md` page table (one cell edited) | 2, uniform | 10 |

**Tiers the spine skipped**, all three by its own surface classification
(`docs=true jvm=false node=false`) and reported by it:

- all JVM artefact suites — `implementation_jvm` surface unchanged
- npm/CLJS/isolation — `cljs_node_test` surface unchanged
- browser lanes, prod-elision/bundle-isolation/perf gates, adapter probes and
  smokes, Xray feature matrix, mcp-conformance, tool JVM suites — CI only

Appropriate: the diff is two markdown files under `docs/design/hicasso/draft-guide/`
and touches no code. No runnable sample was added, so there is no sample to be
false. Nothing under `spec/`, `implementation/` or `decisions.md` is touched —
`decisions.md` is the governing record here and is cited, not amended.
