### PR TITLE
fix(hicasso): the hydrate door reports recoverable errors (rf2-2rtt6.97)

### DIFF
--- a/docs/design/hicasso/studio/ssr-spike-witness.md
+++ b/docs/design/hicasso/studio/ssr-spike-witness.md
@@ -172,6 +172,18 @@ not unasserted, it *is* the assertion. The proper repair is at the door and is
 filed as **`rf2-2rtt6.97`**: `arm1/mount/hydrate-root!` passes no
 `onRecoverableError`, where both the spine and `host_ssr_dom_cljs_test` do.
 
+**Repaired — and the `preventDefault` stays** (`rf2-2rtt6.97`, landed after this
+page published). The door now installs the spine's arrangement: an
+`onRecoverableError` that emits `:rf.ssr/hydration-mismatch` while the adoption
+window is open. What it does *not* do is make the mismatch quieter, and that is
+the arrangement rather than a shortfall — installing any `onRecoverableError`
+takes React's default off, so the spine re-reports through
+`report-recoverable-default!` and never clobbers. A door that stopped
+re-reporting would have deleted the uncaught `pageerror` `rf2-mwx08` reads,
+which is precisely the fail-open that rule exists to prevent. So the diagnostic
+is added *beside* the uncaught error, not instead of it, and a row that
+manufactures a fault still swallows it at its own call site.
+
 ## X3 — reactivity adopted
 
 `rf2-2rtt6.80`'s on-demand diagnostic, **extended to the hydration schedule** as

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/hydrate_recoverable_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/hydrate_recoverable_dom_cljs_test.cljs
@@ -1,0 +1,301 @@
+(ns re-frame.bench.hicasso.arm1.hydrate-recoverable-dom-cljs-test
+  "THE HYDRATE DOOR'S RECOVERABLE-ERROR REPORTER (rf2-2rtt6.97).
+
+  `arm1/mount/hydrate-root!` used to call `hydrateRoot` with no root
+  options at all, so React's DEFAULT `onRecoverableError` ran and a
+  hydration mismatch was an uncaught window error and NOTHING ELSE:
+  Spec 011's `:rf.ssr/hydration-mismatch` never fired, and a mismatch was
+  invisible to every tool that reads the instrumentation stream. This
+  file is the witness for the repair.
+
+  ## What it must prove, and the shape of each proof
+
+  | Row | Claim | How it could lie |
+  |---|---|---|
+  | [[a-divergent-adoption-surfaces-the-framework-diagnostic]] | a real mismatch emits the diagnostic | the diagnostic could be emitted unconditionally |
+  | [[a-clean-adoption-emits-no-diagnostic]] | a clean adoption stays silent | — it is the answer to the row above |
+  | [[the-reporter-composes-over-the-default-and-does-not-swallow]] | the error is still REPORTED | a reporter that only emitted would fail open |
+  | [[the-emit-is-bounded-to-the-adoption-window]] | a LATER recoverable error is not a mismatch | React holds the callback for the root's whole lifetime |
+
+  ## Why row three exists at all
+
+  Installing any `onRecoverableError` takes React's default OFF. A
+  reporter that emitted the diagnostic and stopped would make the
+  mismatch quieter than it was before the repair — the browser lane's
+  runner treats an uncaught `pageerror` as fatal whatever the `cljs.test`
+  tally says (`rf2-mwx08`), and a door that swallowed the error would
+  have removed exactly that signal. So the reporter composes over
+  React's default and never clobbers it, and the third row is what holds
+  that true. **`rf2-mwx08` is not softened here and this file must not
+  be read as softening it.**
+
+  ## Why two rows call `preventDefault`
+
+  Both rows that MANUFACTURE a recoverable error set
+  `hydration-support/open-console-capture!`'s `:swallow-uncaught?`. Not a
+  weakening: the error each provokes is the row's own subject and is
+  asserted on, so it is not an unasserted throw — which is the case that
+  rule exists for.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every DOM claim degrades to a stated
+  skip."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.hydration-support
+             :refer [adopted! open-console-capture! server-dom!]]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace.tooling :as trace-tooling])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(def ^:private frame-id ::arm1-hydrate-recoverable)
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn [] (rt/reset-runtime!) (rt/reset-body-runs!))}))
+
+(defn- skip! [why]
+  (is true (str "a hydration claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (lane/leave-act-environment!)
+  (rf/make-frame {:id frame-id})
+  (rt/reset-runtime!)
+  (rt/reset-body-runs!)
+  frame-id)
+
+;; ---------------------------------------------------------------------------
+;; The screen
+;; ---------------------------------------------------------------------------
+
+(defview screen
+  "One boundary with one text child, and the text is a PROP.
+
+  A prop is what makes the divergence a one-argument change: the server
+  bytes and the client tree can be made to disagree on text and on
+  nothing else, with no second frame, no reseed, and no second
+  subscription to explain away. A single text child on purpose — React's
+  SSR puts a `<!-- -->` separator between adjacent text runs and a client
+  render does not, so two children would be measuring rf2-2rtt6.88's
+  known text-separator divergence instead of this reporter."
+  [{:keys [label]}]
+  [:div.screen [:h1.title label]])
+
+;; ---------------------------------------------------------------------------
+;; The fixture doors
+;; ---------------------------------------------------------------------------
+
+(defn- server-html!
+  "The bytes an SSR route would deliver for `[screen {:label label}]`.
+
+  This arm's own client render, captured as `innerHTML` under an OPEN
+  adoption window — the substitution `arm1/hydrate_dom_cljs_test`
+  documents. Honest for what this file asserts (whether a DIVERGENCE is
+  reported) and irrelevant to what it does not (byte identity, which is
+  the SSR spike's claim and is made against `react-dom/server`)."
+  [label]
+  (rt/open-adoption-window!)
+  (let [container (mount/fresh-container!)
+        handle    (mount/root! container frame-id [screen {:label label}])
+        html      (.-innerHTML container)]
+    (mount/release! handle)
+    html))
+
+(defn- watch-mismatches!
+  "Capture every `:rf.ssr/hydration-mismatch` the framework emits, on the
+  live trace stream. Answers `{:seen atom :stop! fn}`; `stop!` is
+  idempotent.
+
+  The diagnostic is frameless — it fires from a React root-error
+  callback, outside any dispatch scope — so it streams to listeners and
+  never reaches a per-frame ring. A listener is therefore the only place
+  it can be read."
+  []
+  (let [seen (atom [])
+        k    (keyword (str "rf2-2rtt6-97-" (gensym)))]
+    (trace-tooling/register-listener!
+      k (fn [ev] (when (= :rf.ssr/hydration-mismatch (:operation ev))
+                   (swap! seen conj ev))))
+    {:seen seen :stop! (fn [] (trace-tooling/unregister-listener! k) @seen)}))
+
+(defn- tags-of
+  "The diagnostic's tags, merged with its top level, so a read is robust
+  to whichever slots the envelope hoists."
+  [ev]
+  (merge (:tags ev) ev))
+
+;; ===========================================================================
+;; 1 — a divergent adoption surfaces Spec 011's diagnostic
+;; ===========================================================================
+
+(deftest a-divergent-adoption-surfaces-the-framework-diagnostic
+  (testing "**the repair, stated as a measurement.** Server bytes saying
+           `server` adopted by a client tree saying `client` is a text
+           divergence React RECOVERS FROM, and a recovered divergence is
+           exactly what `onRecoverableError` carries. The door must
+           surface it as `:rf.ssr/hydration-mismatch`, tagged with its own
+           site — with no root options this emitted NOTHING and the whole
+           complaint was an uncaught window error"
+    (async done
+      (if-not (mount/browser?)
+        (do (skip! ":node-test has no DOM") (done))
+        (do
+          (fresh!)
+          (let [html      (server-html! "server")
+                container (server-dom! html)
+                {:keys [seen stop!]} (watch-mismatches!)
+                ;; MANUFACTURED fault, asserted on — see the ns docstring.
+                {:keys [captured close!]} (open-console-capture!
+                                            {:swallow-uncaught? true})
+                handle    (mount/hydrate-root! container frame-id
+                                               [screen {:label "client"}])]
+            (-> (adopted!)
+                (.then
+                  (fn [ok]
+                    (close!)
+                    (stop!)
+                    (try
+                      (is (true? ok) "the adoption completed")
+                      (is (= 1 (count @seen))
+                          (str "the door emitted exactly one "
+                               ":rf.ssr/hydration-mismatch. Saw: "
+                               (pr-str @seen)))
+                      (when-let [mm (first @seen)]
+                        (let [tags (tags-of mm)]
+                          (is (= :rf.ssr/hydration-mismatch (:operation mm)))
+                          (is (= 're-frame.bench.hicasso.arm1.mount/hydrate-root!
+                                 (:where tags))
+                              "tier-discriminated by :where — this door's site")
+                          (is (= :warned-and-replaced (:recovery tags))
+                              "React had already patched the DOM when the
+                               callback ran, so there is no escalation to
+                               report")
+                          (is (string? (:error tags))
+                              "and the recoverable error's own message rides
+                               along")
+                          (is (not (contains? (or (:tags mm) {}) :server-hash))
+                              "no fabricated :server-hash — a React-element
+                               root has no hash channel")))
+                      (is (= "client" (.-textContent
+                                        (.querySelector container ".title")))
+                          "and the CLIENT's model won, as a recovered
+                           hydration mismatch's repair must")
+                      (is (seq @captured)
+                          (str "the complaint also reached a channel this
+                                witness watches: " (pr-str @captured)))
+                      (finally (mount/release! handle) (done))))))))))))
+
+;; ===========================================================================
+;; 2 — and it is a READING, not a constant
+;; ===========================================================================
+
+(deftest a-clean-adoption-emits-no-diagnostic
+  (testing "**the answer to row one.** A diagnostic that fired on every
+           adoption would agree with every page. The same door, the same
+           screen, and server bytes that MATCH the client tree: nothing is
+           emitted, and nothing is reported on either console channel
+           either"
+    (async done
+      (if-not (mount/browser?)
+        (do (skip! ":node-test has no DOM") (done))
+        (do
+          (fresh!)
+          (let [html      (server-html! "agreed")
+                container (server-dom! html)
+                {:keys [seen stop!]} (watch-mismatches!)
+                {:keys [captured close!]} (open-console-capture!)
+                handle    (mount/hydrate-root! container frame-id
+                                               [screen {:label "agreed"}])]
+            (-> (adopted!)
+                (.then
+                  (fn [ok]
+                    (close!)
+                    (stop!)
+                    (try
+                      (is (true? ok) "the adoption completed")
+                      (is (= [] @seen)
+                          (str "a clean adoption emits no "
+                               ":rf.ssr/hydration-mismatch. Saw: "
+                               (pr-str @seen)))
+                      (is (= [] @captured)
+                          (str "and React reported nothing on either channel: "
+                               (pr-str @captured)))
+                      (finally (mount/release! handle) (done))))))))))))
+
+;; ===========================================================================
+;; 3 — the reporter COMPOSES over React's default; it does not swallow
+;; ===========================================================================
+
+(deftest the-reporter-composes-over-the-default-and-does-not-swallow
+  (testing "**the row that keeps `rf2-mwx08` intact.** Installing any
+           `onRecoverableError` takes React's default OFF, so a reporter
+           that only emitted the diagnostic would make a mismatch QUIETER
+           than it was before the repair — the uncaught `pageerror` the
+           runner treats as fatal would simply stop happening. Drive the
+           REAL callback and read both outcomes: the diagnostic fires AND
+           the error is still reported"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (do
+        (fresh!)
+        (rt/open-adoption-window!)
+        (let [{:keys [seen stop!]} (watch-mismatches!)
+              ;; MANUFACTURED fault, asserted on — see the ns docstring.
+              {:keys [captured close!]} (open-console-capture!
+                                          {:swallow-uncaught? true})]
+          (try
+            (mount/hydration-reporter (js/Error. "manufactured recoverable") nil)
+            (is (= 1 (count @seen)) "the diagnostic fired")
+            (is (some #(re-find #"manufactured recoverable" %) @captured)
+                (str "and the error was STILL reported — the reporter composes
+                      over React's default rather than replacing it. Saw: "
+                     (pr-str @captured)))
+            (finally
+              (close!)
+              (stop!)
+              (rt/close-adoption-window!))))))))
+
+;; ===========================================================================
+;; 4 — the emit is bounded to the adoption window
+;; ===========================================================================
+
+(deftest the-emit-is-bounded-to-the-adoption-window
+  (testing "React holds a hydrating root's `onRecoverableError` for the
+           root's WHOLE LIFETIME and fires it for later recoverable errors
+           too — a concurrent render it retried and recovered. Labelling
+           one of those a hydration mismatch would be a false diagnostic,
+           so the emit is bounded to the window `hydrate-root!` opens and
+           the closer's passive effect shuts. Drive the REAL callback
+           across that boundary: the report happens in BOTH windows, the
+           emit in only one"
+    (if-not (mount/browser?)
+      (skip! ":node-test has no DOM")
+      (do
+        (fresh!)
+        (let [{:keys [seen stop!]} (watch-mismatches!)
+              ;; MANUFACTURED faults, asserted on — see the ns docstring.
+              {:keys [captured close!]} (open-console-capture!
+                                          {:swallow-uncaught? true})]
+          (try
+            (rt/open-adoption-window!)
+            (mount/hydration-reporter (js/Error. "inside the window") nil)
+            (is (= 1 (count @seen)) "inside the window it is a mismatch")
+            (rt/close-adoption-window!)
+            (mount/hydration-reporter (js/Error. "after the window") nil)
+            (is (= 1 (count @seen))
+                (str "and after the window it is NOT — no second emit. Saw: "
+                     (pr-str @seen)))
+            (is (= 2 (count @captured))
+                (str "while BOTH were reported, because delegation is
+                      unconditional. Saw: " (pr-str @captured)))
+            (finally
+              (close!)
+              (stop!)
+              (rt/close-adoption-window!))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/hydration_support.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/hydration_support.cljs
@@ -84,9 +84,15 @@
   it, so the signal moves into the row's own assertion instead of being
   lost.
 
-  It is off by default and it belongs at the ONE call site that
-  deliberately hydrates mismatched markup. Anywhere else it would be
-  exactly the fail-open the runner's rule exists to prevent."
+  **It is off by default and it belongs at a call site that MANUFACTURES
+  a recoverable error and asserts on it — nowhere else.** Anywhere else
+  it would be exactly the fail-open the runner's rule exists to prevent.
+  The uncaught error stays uncaught at the DOOR: `mount/hydrate-root!`'s
+  reporter emits the framework diagnostic and then ALWAYS reports
+  (rf2-2rtt6.97), so composing a diagnostic in did not — and must not —
+  make a mismatch quieter than React left it. Every call site that sets
+  this is therefore a deliberate fault, not a door that stopped
+  complaining."
   ([] (open-console-capture! nil))
   ([{:keys [swallow-uncaught?]}]
    (let [captured (atom [])

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/mount.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/mount.cljs
@@ -171,11 +171,18 @@
 (defn- emit-hydration-mismatch!
   "Spec 011's `:rf.ssr/hydration-mismatch`, tier-discriminated by
   `:where` — this door's own site, the way the spine tags
-  `re-frame.substrate.spine/make-render` and the compiled tier tags
-  `re-frame.ui/hydrate-root`. No hash and no `:root-id`: a React-element
-  root has neither. `:recovery` is `:warned-and-replaced` because React
-  has already patched the DOM by the time this runs — there is no
+  `re-frame.substrate.spine/make-render` and the compiled tier tags its
+  own hydrate door. No hash and no `:root-id`: a React-element root has
+  neither. `:recovery` is `:warned-and-replaced` because React has
+  already patched the DOM by the time this runs — there is no
   `:hard-error` escalation to make.
+
+  **The compiled tier's namespace is deliberately not spelled**, here or
+  anywhere under `implementation/freehand`. EP-0036's donor-boundary law
+  is enforced by a plain `git grep` over this tree, and a grep cannot
+  tell a docstring from a `:require` — correctly, because a cleverer one
+  would eventually let a real dependency through. Naming the donor in
+  prose reds the gate; describing it does not.
 
   Not an event and it mints no epoch: it fires from a React root-error
   callback, outside any dispatch scope."

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/mount.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/mount.cljs
@@ -33,6 +33,8 @@
   (:require [re-frame.adapter.context :as adapter-context]
             [re-frame.bench.hicasso.arm1.runtime :as rt]
             [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.interop :as interop]
+            [re-frame.trace :as trace]
             ["react" :as react]
             ["react-dom" :as react-dom]
             ["react-dom/client" :as react-dom-client]))
@@ -135,6 +137,91 @@
 ;; (`runtime/mint-view!`, `codec/memoize-boundary!`) are spelled this way.
 (unchecked-set adoption-window-closer "displayName" "hicasso/adoption-window-closer")
 
+;; ---------------------------------------------------------------------------
+;; The recoverable-error reporter (rf2-2rtt6.97)
+;; ---------------------------------------------------------------------------
+;;
+;; React reports the adoption divergences it RECOVERS FROM — a text
+;; mismatch, or a missing / extra / wrong-type element — through the root's
+;; `onRecoverableError`. Left with no root options this door got React's
+;; DEFAULT handler, so a mismatch was an uncaught window error and NOTHING
+;; ELSE: Spec 011's `:rf.ssr/hydration-mismatch` never fired, and a mismatch
+;; was invisible to every tool that reads the instrumentation stream.
+;;
+;; The shape below is the spine's (`re-frame.substrate.spine`,
+;; `native-hydration-reporter` / `hydrate-root-options`), because this arm is
+;; a React-element root exactly as a native UIx root is: no hashable client
+;; render-tree, so adoption IS the verification channel. Attribute-only
+;; divergences are outside it by React's own contract and stay outside it
+;; here (Spec 011 §Hydration-mismatch detection).
+
+(defn- report-recoverable-default!
+  "React's own default reporting, replicated.
+
+  Installing ANY `onRecoverableError` takes React's default OFF, so a
+  reporter that only emitted would SWALLOW the error — the fail-open
+  `rf2-mwx08` exists to prevent. This door composes over React's default
+  and never clobbers it: the uncaught error a runner treats as fatal is
+  still uncaught, and the diagnostic is added beside it."
+  [error]
+  (if (fn? (.-reportError js/globalThis))
+    (js/reportError error)
+    (when (exists? js/console) (.error js/console error))))
+
+(defn- emit-hydration-mismatch!
+  "Spec 011's `:rf.ssr/hydration-mismatch`, tier-discriminated by
+  `:where` — this door's own site, the way the spine tags
+  `re-frame.substrate.spine/make-render` and the compiled tier tags
+  `re-frame.ui/hydrate-root`. No hash and no `:root-id`: a React-element
+  root has neither. `:recovery` is `:warned-and-replaced` because React
+  has already patched the DOM by the time this runs — there is no
+  `:hard-error` escalation to make.
+
+  Not an event and it mints no epoch: it fires from a React root-error
+  callback, outside any dispatch scope."
+  [error]
+  (trace/emit! :warning :rf.ssr/hydration-mismatch
+               {:error    (some-> error .-message)
+                :where    're-frame.bench.hicasso.arm1.mount/hydrate-root!
+                :recovery :warned-and-replaced}))
+
+(defn hydration-reporter
+  "The `onRecoverableError` a hydrating root installs. **The callback
+  itself, not a builder** — the spine builds one per root because its
+  adoption window is root-local; this arm's window is module-level
+  (`runtime/adopting?`, and the reason is stated there), so there is
+  nothing to close over.
+
+  Emits the framework diagnostic ONLY while the adoption window is open,
+  then ALWAYS reports. React holds this callback for the root's whole
+  lifetime and fires it for post-hydration recoverable errors too — a
+  concurrent render it retried and recovered — and emitting outside the
+  window would label one of those a hydration mismatch. The window shuts
+  on the hydration commit, from [[adoption-window-closer]]'s passive
+  effect.
+
+  Public because that is what lets a witness drive the REAL callback
+  across the window boundary rather than a copy of it — the spine's own
+  reason for publishing `native-hydration-reporter`."
+  [error _error-info]
+  (when (rt/adopting?)
+    (emit-hydration-mismatch! error))
+  (report-recoverable-default! error))
+
+(defn- hydrate-root-options
+  "The `react-dom/client` root options for a hydrating root, or nil.
+
+  Nil in production, where the emit DCEs behind `interop/debug-enabled?`
+  and the only thing left to install would be a replica of the default
+  React would have run anyway — so the caller passes no options at all
+  and the shipped path is exactly what it was. The spine gates the same
+  way, one clause wider: it also installs for a host-authored
+  `:on-recoverable-error`, and this arm has no host-authored callback to
+  compose with."
+  []
+  (when interop/debug-enabled?
+    #js {:onRecoverableError hydration-reporter}))
+
 (defn hydrate-root!
   "Associate `container`'s **existing server-rendered DOM** with
   `frame-kw` and `hiccup`, by adoption. [[root!]]'s hydrating twin, and
@@ -144,7 +231,7 @@
   :container}` — so [[render!]], [[dispatch!]], [[unmount!]] and
   [[release!]] all take a hydrated handle unchanged.
 
-  ## `hydrateRoot` is called PLAIN
+  ## `hydrateRoot` is not wrapped in `flushSync`
 
   No `flushSync`, and that is a finding rather than an omission: nothing
   in this tree forces hydration synchronously, so a flush here would
@@ -168,6 +255,17 @@
   subscription and needs no frame, and a nil-rendering component with no
   frame dependency is the smallest thing that can carry the effect.
 
+  ## It DOES carry root options, and only these (rf2-2rtt6.97)
+
+  [[hydration-reporter]] rides as the root's `onRecoverableError`, so a
+  divergence React recovers from surfaces as Spec 011's
+  `:rf.ssr/hydration-mismatch` instead of only as an uncaught window
+  error. It is the SPINE's arrangement, and it does not soften
+  `rf2-mwx08`: the reporter always reports, so the uncaught error is
+  still uncaught and the diagnostic is added beside it. In production
+  [[hydrate-root-options]] answers nil and this call is the bare
+  two-argument one it always was.
+
   ## The handle carries `:hydrated?`, and it has to
 
   [[root!]]'s three keys are all here and every door takes this handle
@@ -177,8 +275,12 @@
   decision is made and `:hydrated?` is what it reads."
   [container frame-kw hiccup]
   (rt/open-adoption-window!)
-  (let [handle {:frame frame-kw :container container :hydrated? true}]
-    (assoc handle :root (react-dom-client/hydrateRoot container (tree handle hiccup)))))
+  (let [handle  {:frame frame-kw :container container :hydrated? true}
+        element (tree handle hiccup)
+        opts    (hydrate-root-options)]
+    (assoc handle :root (if opts
+                          (react-dom-client/hydrateRoot container element opts)
+                          (react-dom-client/hydrateRoot container element)))))
 
 (defn unmount!
   "Unmount the root and detach its container, and **touch nothing the


### PR DESCRIPTION
`arm1/mount/hydrate-root!` called `hydrateRoot` with **no root options at all**,
so React's default `onRecoverableError` ran — `reportError` — and a hydration
mismatch was an uncaught window error and *nothing else*. Spec 011's
`:rf.ssr/hydration-mismatch` never fired, so a mismatch was invisible to every
tool that reads the instrumentation stream.

## The three claims, verified in the tree

| Claim | Verified |
|---|---|
| the arm's door omits `onRecoverableError` | **true** — `mount.cljs`'s old line was `(react-dom-client/hydrateRoot container (tree handle hiccup))`, two arguments. `git grep onRecoverableError` over the tree does not name `arm1/mount.cljs`. |
| the spine passes it | **true** — `spine.cljs` `hydrate-root-options` builds `#js {:onRecoverableError (native-hydration-reporter adoption-ref authored)}`; `native-hydration-reporter` emits `:rf.ssr/hydration-mismatch`, then always delegates. |
| `host_ssr_dom_cljs_test` passes it | **true, with a distinction worth stating** — its `hydrate!` does pass `#js {:onRecoverableError …}` and says why, but the callback is a *test recorder* pushing onto a `seen` atom. It passes the option; it does not emit the framework diagnostic. Only the spine does both. |

## The fix — the spine's arrangement, one clause narrower

`hydrate-root-options` answers `nil` in production and `#js {:onRecoverableError
hydration-reporter}` in debug; `hydrate-root!` branches exactly the way
`spine/make-render` does (`(if ropts (hydrateRoot c t ropts) (hydrateRoot c t))`).
`hydration-reporter` emits Spec 011's diagnostic **only while the adoption
window is open**, then **always** reports.

Two deliberate narrowings against the spine, both because the arm is smaller:

* **No `opts` argument.** The spine's gate is `(or (fn? authored)
  interop/debug-enabled?)` because a host may author `:on-recoverable-error`.
  This arm has no host-authored callback to compose with, so the gate reduces
  to `interop/debug-enabled?` and no new parameter was invented for a caller
  that does not exist.
* **The reporter is the callback, not a builder.** The spine builds one per
  root because its adoption window is root-local. This arm's window is
  module-level (`runtime/adopting?` — `runtime.cljs` states why), so there is
  nothing to close over.

`:where` is `re-frame.bench.hicasso.arm1.mount/hydrate-root!` — the same
tier-discrimination Spec 011 already describes for the compiled and native
tiers. **No `spec/` file is touched**, per the epic's pre-P2 sequencing law.

## The finding: `:swallow-uncaught?` **cannot** go, and that is correct

The bead's *THE WORK* clause expected `rf2-2rtt6.87`'s `preventDefault` call
site to become removable. **It does not, and the repair is why.**

Installing *any* `onRecoverableError` takes React's default off. The spine
therefore replicates it (`report-recoverable-default!` → `globalThis.reportError`,
else `console.error`) and composes over any host callback — *never clobbers*.
Matching that arrangement, as both the bead and the brief require, means the
uncaught `pageerror` is **byte-for-byte the behaviour it was**; the diagnostic
is added *beside* it. A door that stopped re-reporting would have deleted
exactly the signal `rf2-mwx08` reads — the fail-open that rule exists to
prevent — so the workaround stays and **`rf2-mwx08` is unweakened**. It is now
`open-console-capture!`'s documented contract that every `:swallow-uncaught?`
site is a *manufactured, asserted* fault rather than a door that stopped
complaining, and `docs/design/hicasso/studio/ssr-spike-witness.md` carries the
same correction so nobody re-derives the wrong expectation.

Two related corrections to the bead's text, for the record: the
`:swallow-uncaught?` docstring names **`rf2-mwx08`**, not this bead (`git grep
2rtt6.97` hits only `.beads/`, the studio page and the studio README); and the
witness page's own prose never claimed the workaround would go — it said the
proper repair is *at the door*, which is what this is.

## The witness — four rows, and three of them can fail

New `arm1/hydrate_recoverable_dom_cljs_test.cljs`. Server bytes rendered for
one label, adopted by a client tree carrying another: a text divergence React
recovers from.

1. **a divergent adoption surfaces the framework diagnostic** — exactly one
   `:rf.ssr/hydration-mismatch`, `:where` this door, `:recovery
   :warned-and-replaced`, the error's message carried, no fabricated hash, the
   client's model wins.
2. **a clean adoption emits no diagnostic** — the answer to row 1; a diagnostic
   that fired on every adoption would agree with every page.
3. **the reporter composes over the default and does not swallow** — drives the
   real callback and reads *both* outcomes.
4. **the emit is bounded to the adoption window** — real callback driven across
   the boundary: reported in both windows, emitted in one.

The console capture uses the **honest window** throughout (opened before the
call, closed after `adopted!` resolves) — `rf2-2rtt6.87` measured a
close-on-return window seeing 0 of 1 complaints.

## Mutation proof, both directions

Forward: row 1 is green with the option installed — one diagnostic, correctly
tagged.

Backward, one `npm run test:browser` with **both levers broken at once** so each
row fails for its own reason (`hydrate-root-options` forced nil; the delegation
tail removed):

```
FAIL in (a-divergent-adoption-surfaces-the-framework-diagnostic)   expected: (= 1 (count @seen))      actual: (not (= 1 0))
FAIL in (the-reporter-composes-over-the-default-and-does-not-swallow)  expected: (some #"manufactured recoverable" @captured)  actual: (not (some #object[Function] []))
FAIL in (the-emit-is-bounded-to-the-adoption-window)               expected: (= 2 (count @captured))  actual: (not (= 2 0))
```

`Ran 1081 tests … 3 failures, 0 errors.` exit 1. Row 2 stayed green throughout,
correctly — it asserts silence. Reverted **byte-identically**: `git status
--porcelain` empty, `git diff HEAD --stat` empty, HEAD unchanged at
`495ad50ab8`.

## Fences held

* **Ordinary render path byte-for-byte unchanged** — `root!`, `render!` and
  `tree` are untouched; only `hydrate-root!`'s call acquired a third argument,
  and only in debug. No extra fiber, no extra passive effect, nothing new in
  `runtime/retained-inventory`.
* **Hook ledger untouched** — the change adds **zero** hooks. The only hook in
  the hydrate path is `adoption-window-closer`'s pre-existing `useEffect`
  (`rf2-2rtt6.84`). The ≤2-hook shell is unmoved.
* **`implementation/ssr` and `ssr-ring` untouched**; `spec/` untouched.
* Doc edit is confined to `docs/design/hicasso/studio/` — **12 lines of prose,
  no new heading, no new link, no table touched**. Anchors and table column
  counts verified by hand (nothing structural changed); `check_doc_slugs.py`
  runs green in the spine.

## Quality gates

| Gate | Exit | Result |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`; `gate root:` named this worktree |
| `npm run test:cljs` | **0** | 12552 tests / 62903 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **0** | 1081 tests / 6702 assertions, 0 failures, 0 errors (was 1077/6685 on main — the four new rows, 17 assertions) |
| `npm run test:hicasso-compile` | **0** | 113 lane namespaces, 0 warnings (standalone, and again inside the spine) |
| clj-kondo **2026.04.15** (the CI pin, `lint.yml`'s exact invocation) | **0** | **errors 0**, warnings 4534 (standing baseline); **zero findings on any file in this diff** |

clj-kondo was run from the pinned binary, not the local 2025.10.23 — the spine
does not run it at all.

`test:browser` was taken at `495ad50ab8`; `test-fast-pr.sh` and `test:cljs` at
`fc43054385`. The only commit between them is markdown, so no code moved under
the browser run.

**Tiers this spine did NOT run** (its own PASS line enumerates them, restated
rather than papered over): the JVM artefact suites for the 21 artefacts this
diff does not touch; and the browser lanes, prod-elision / bundle-isolation /
perf gates, adapter probes and smokes, the Xray feature matrix, mcp-conformance,
and the tool JVM suites — all CI-only. The browser lane is nonetheless covered
here directly: this diff carries a `-dom-cljs-test` namespace and
`npm run test:browser` was run to completion.

Closes `rf2-2rtt6.97`.


---

## Follow-up: the EP-0036 donor-boundary gate fired on a docstring (`45925d1900`)

The first push went red on **`JVM freehand (clojure -M:test)`** — but not on a
test. That job's last step is EP-0036's donor-boundary law, a plain grep
(`test.yml` line 2123):

```
git grep -n -e 're-frame\.ui' -e 're_frame/ui' -e 're-frame2-ui' -- implementation/freehand
```

Its single hit was **prose in my `emit-hydration-mismatch!` docstring**, which
named the compiled tier's namespace while explaining `:where`
tier-discrimination. There was no `:require` and no dependency.

**The gate is right about the string and right to be right about it.** A grep
that could tell a docstring from a `:require` is a grep that would eventually
let a real dependency through, so the conservative shape is the correct one and
nothing about it was changed: **no exemption, no weakening, no
`.github/workflows/**` edit.** The docstring now describes the compiled tier's
hydrate door instead of spelling it, and carries the reason in place so the
spelling is not restored by a later editor who reads the omission as an
oversight.

**Checked for siblings, not just for mine.** The gate's own command over
`implementation/freehand` now exits **1 (zero hits)**, and all four files in
this diff are individually clean of all three patterns — the studio doc is
outside the gate's path scope and clean anyway.

Re-run on the fixed tree (docstring-only, so the spine's full sweep was not
re-taken — the code is byte-identical to the tree the gates above passed on):

| Gate | Exit |
|---|---|
| `npm run test:hicasso-compile` | **0** — 113 lane namespaces, 0 warnings |
| clj-kondo **2026.04.15**, `lint.yml`'s exact invocation | **0** — errors 0, warnings 4534 baseline, zero findings on this diff |
| the gate's own `git grep` | **1 (no hits)** |

**Worth recording: this is a required gate the local spine does not run.** It
makes three this week — `clj-kondo`, the chained
`test:script-policy && test:script-helpers`, and now the donor-boundary grep
buried in the `JVM freehand` job's last step. The spine's PASS line enumerates
the *tiers* it skips, but a gate that rides inside a job the spine does run is
invisible to that enumeration, which is the gap that cost this PR a round trip.
