### PR TITLE
docs(hicasso): instance-key ruling — HD-009 addendum + guide 07 teaches reg-state (rf2-2rtt6.100)

### DIFF
--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -312,25 +312,29 @@ CSS for hover/focus; platform-carried state (the top layer owns open/dismiss;
 resources/mutations own async status; the controls kit owns drafts/revisions);
 host-private React state at host edges for geometry/composition; and app-db for
 everything semantically meaningful — where the tax is per-*concern*, not
-per-instance (one parametric sub + one named event serve every instance). If the
-dogfood shows the residual ceremony registering, the pre-agreed *response class*
-is one-declaration sugar — never a state system:
+per-instance (one parametric sub + one named event serve every instance). The
+one-declaration sugar for that pattern was **ruled into v0 on 2026-08-04**
+(HD-009's dated addendum in [decisions.md](decisions.md) is the record; it is
+in implementation, not yet landed):
 
 ```clojure
-;; SKETCH — v0 ships nothing here, and the shape is unfrozen.
-(h/defstate ::open {:default false})
-;; would mint: a parametric sub (sub [::open id])
-;;             and a NAMED setter event [::open id v] — never a generic ui/set
+;; RULED 2026-08-04 — in implementation, not yet landed; spelling [unfrozen].
+(h/reg-state ::open {:default false})
+;; mints: a parametric sub (sub [::open ikey])
+;;        a concern-named setter event [::open ikey v] — never a generic ui/set
+;;        the documented path [:ui ::open ikey]
+;; clear: the framework event [::h/clear ::open ikey] removes the entry;
+;;        bad keys refuse loudly (:rf.error/hicasso-state-bad-key)
+;; nesting: (h/child-key parent-key part)
 ```
 
-Read that as an illustration of the response *class*, not a plan of record.
-HD-009 freezes two things about it and nothing else: that any such sugar mints a
-**named** setter event rather than a generic `ui/set`, and that it is sugar
-rather than a state system. Its concrete shape — the `defstate` spelling,
-whether a declared app-db tier is involved at all, and what that tier's frame
-and persistence scope would be — stays **unfrozen until the evidence exists**,
-and so does whether it ever ships. v0 ships nothing here; the concept budget
-arbitrates.
+The instance key is authored data — domain ids first, entity-qualified id
+values when one widget serves two entity types, placement-like vs value-like
+sharing, "a good React `:key` is a good instance key" — four rules taught in
+[the guide](draft-guide/07-ephemeral-state.md), not policed. What HD-009 froze
+about any such sugar still holds under the ruled design: it mints a **named**
+setter event rather than a generic `ui/set`, and it is sugar rather than a
+state system — no runtime state, no hooks, no context.
 
 ## Testing doors
 

--- a/docs/design/hicasso/charter.md
+++ b/docs/design/hicasso/charter.md
@@ -287,3 +287,8 @@ where Reagent is proven. The three design debts this record resolves explicitly:
 ephemeral-state ceremony (HD-009), per-keystroke economics (the named
 instrumentation in [validation.md](validation.md)), and the reusable-widget
 instance-key convention (post-v0, named in HD-009's sugar).
+**Amended 2026-08-04 (operator ruling):** the third debt is no longer post-v0.
+The instance-key convention and HD-009's sugar were ruled **into v0** — designed
+as `h/reg-state` plus the explicit-key rules, recorded in HD-009's dated
+addendum in [decisions.md](decisions.md). The sentence above stands as the
+record of what this charter deferred; the deferral itself is over.

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -193,6 +193,90 @@ predecessors' pattern of building before measuring.
 
 ## HD-009 — Ephemeral state: no `local`, ever
 
+> **Addendum, 2026-08-04 — the sugar and the reusable-widget instance-key
+> convention move INTO v0, and the sugar is ruled: `h/reg-state`
+> (`rf2-2rtt6.100`).** Operator ruling (Mike, 2026-08-04): both move from
+> post-v0 into v0 scope, amending this entry. The same-day design programme ran
+> three independent designs (explicit-key / auto-structural / ident) through
+> three adversarial reviews: explicit 0 fatal / 5 major, ident 0 fatal /
+> 8 major, auto **1 FATAL** — ordinal identity is strictly *less* stable than
+> React's own (a conditional sibling shifts ordinals at runtime and state
+> teleports between instances, silently), and the only repair collapses it
+> into the explicit design. All three attackers' forced choices converged:
+> **build explicit, amended.**
+>
+> **What is superseded, and what stands.** This entry's "v0 ships nothing and
+> pre-commits to nothing beyond 'sugar, not a state system'" sentence — and
+> with it the "unfrozen until the evidence exists" deferral of the sugar's
+> shape and tier — is superseded: the evidence now exists, and the shape is
+> ruled below. The no-`local` core, the **named**-setter-event law, and
+> "never a generic `ui/set`" stand unchanged; the ruled design is that sugar,
+> designed. "Sugar, not a state system" also survives inspection: `reg-state`
+> holds no runtime state, no hooks, no context — it registers ordinary core
+> artefacts.
+>
+> **The ruled design.** `(h/reg-state ::concern {:default v})` — a plain
+> `.cljc` function, not a macro; one namespace-qualified *concern* keyword;
+> `{:default v}` the only option; unknown options and a non-namespaced
+> concern refused loudly at registration. It mints a parametric sub
+> `(sub [::concern ikey])`, a concern-named setter event `[::concern ikey v]`,
+> and the documented path `[:ui ::concern ikey]`.
+>
+> **The tier, unanimously adjudicated.** ONE app-space conventional root,
+> concern-first: `[:ui <concern> <instance-key>]`. No `:rf/*` app-db root
+> exists or may be minted for it — Conventions' two-partition doctrine — and a
+> framework-squatted qualified root of the `:ui/state` kind is likewise
+> rejected. Per-frame isolation costs nothing, because app-db is per-frame.
+> Durable persistence excludes the tier by convention.
+>
+> **Clear is a framework-named EVENT, not a value sentinel.**
+> `[::h/clear ::concern ikey]` restores the default by removing the entry
+> (empty concern maps pruned). The `::h/clear`-in-value-position variant is
+> rejected on the record: a keyword-valued concern could silently dissoc
+> where app data flows.
+>
+> **Refusals are loud.** A nil or malformed instance key refuses at read and
+> at write with `:rf.error/hicasso-state-bad-key`, naming the concern —
+> converting the guide's silent every-instance-shares pitfall into an error.
+> Nesting composes by one pure helper, `h/child-key`
+> (`(if (vector? k) (conj k part) [k part])`), so every key is by induction a
+> flat vector of authored data.
+>
+> **Four rules are taught, not policed.** (a) Domain ids first, and
+> entity-qualified id *values* (`[:order/id 42]`) when one widget serves more
+> than one entity type — bare ids let order 42 and invoice 42 collide
+> silently. (b) Placement-like concerns (`expanded?`, `open?`, active tab)
+> key by placement; value-like concerns (drafts, favourites, in-flight
+> status) key by entity — a master list and a detail pane sharing one draft
+> of order 42 is correct, sharing one `expanded?` is a bug. (c) `h/child-key`
+> for widget-in-widget nesting. (d) Determinism: *"if it would be a good
+> React `:key`, it is a good instance key."*
+>
+> **The SSR payload obligation (unanimous adjudication).** The payload policy
+> is fail-closed, and therefore an allowlist MUST name `:ui` whenever
+> server-side events write render-affecting instance state; strip the tier
+> only if the server never writes it. The obligation is witnessed green AND
+> red-by-design by `rf2-2rtt6.99` — a deliberate omission producing the
+> hydration mismatch. The payload is render-consistency, not persistence.
+>
+> **The `useId` autopsy is preserved here so the question is never
+> relitigated.** React's `useId` is disqualified for app-db-resident keys:
+> fiber-position hydration ids diverge under the arm's own hydration root,
+> and counter-based ids are non-remount-stable outside hydration — state
+> keyed by them is orphaned on every remount, and app-db snapshots, event
+> logs and tests stop being comparable across boot modes.
+>
+> **The pre-registered response class is now the ambient door.** If dogfooding
+> shows the *explicit threading tax itself* failing the preference test, the
+> escalation is the rejected auto design's ambient/auto mechanism — a
+> recorded door, not ad-hoc invention, and still never a state system. That
+> updates this entry's Reopens shape in place.
+>
+> **Status is honest tense.** The ruling is recorded; nothing has landed.
+> `h/reg-state`, `[::h/clear …]`, `h/child-key` and the refusals are in
+> implementation as `rf2-2rtt6.98`; the guide teaches the convention in the
+> same tense.
+
 **Ruling.** No component-local reactive cell (`local`, ratom-equivalent, or
 `useState` for app state) exists in Hicasso. In order: CSS for hover/focus;
 platform-carried state (the top layer owns open/dismiss; resources/mutations own

--- a/docs/design/hicasso/draft-guide/07-ephemeral-state.md
+++ b/docs/design/hicasso/draft-guide/07-ephemeral-state.md
@@ -4,7 +4,9 @@
 > ruled in [decisions.md](../decisions.md) (HD-001…HD-028), witnessed by the bench
 > arm's tests under `implementation/freehand/test/re_frame/bench/hicasso/` — but no
 > `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
-> stay provisional until the API freeze.
+> stay provisional until the API freeze. One surface here is ahead of even that:
+> `h/reg-state` is **ruled but still landing** (2026-08-04), and the page says so
+> where it teaches it.
 
 Is this dropdown open? Is this row hovered? Is this panel expanded?
 
@@ -55,9 +57,9 @@ Work down the list, not up it. Most of the time you stop at 1.
 The objection to app-db for UI state is always ceremony: an event, a subscription,
 and a keypath for something as small as "is this open?"
 
-The answer is that **the tax is per-concern, not per-instance.** One parametric
-subscription and one named event serve every instance of the widget in the app,
-forever:
+The answer comes in two parts, and the first is that **the tax is per-concern,
+not per-instance.** One parametric subscription and one named event serve every
+instance of the widget in the app, forever:
 
 ```clojure
 (rf/reg-sub :panel/expanded?
@@ -83,6 +85,85 @@ component.
 That last one is worth sitting with. "Open this dropdown in a test" is a `:db`
 write, not a click simulation.
 
+The second part is that **the ten lines become one.** On 2026-08-04 the sugar
+HD-009 had been holding as an unfrozen sketch was designed and ruled into v0
+(the dated HD-009 addendum in [decisions.md](../decisions.md) is the record).
+Honest tense, as this page's banner says: `h/reg-state` is ruled and in
+implementation — nothing has landed yet, and the spelling is **[unfrozen]** —
+so today you write the ten lines above, and they are exactly what the
+declaration will register for you:
+
+```clojure
+;; RULED 2026-08-04 — in implementation, not yet landed.
+(h/reg-state ::expanded? {:default false})
+;; mints: a parametric sub        (sub [::expanded? panel-id])
+;;        a concern-named setter  [::expanded? panel-id true]
+;;        the documented path     [:ui ::expanded? panel-id]
+```
+
+One declaration per *concern* — a namespace-qualified keyword — with
+`{:default v}` as the only option. No state system arrives with it: it
+registers the same ordinary sub and event you would have written, reading and
+writing plain app-db at a documented path, which is why everything above stays
+true under it — time travel, Xray, per-frame isolation, tests writing `:db`.
+The long form remains worth knowing anyway: it is the definition of what
+`reg-state` does, and the shape you graduate to when a write starts to *mean*
+something (next section — the example's `:panel/toggle` is already that
+graduation).
+
+Two details are part of the ruling because getting them wrong is silent
+otherwise. **Clearing is a framework event, not a magic value**: dispatch
+`[::h/clear ::expanded? panel-id]` and the entry is removed, so the default
+shows through again. A reserved clear *value* was rejected on the record — a
+concern whose legitimate values are keywords could then silently delete state.
+And **a nil or malformed instance key refuses loudly**, at read and at write,
+with `:rf.error/hicasso-state-bad-key` naming the concern — instead of quietly
+filing every instance's state under the same broken key.
+
+## Choosing the instance key
+
+`reg-state` and the long form share one authored input: the instance key —
+`panel-id` above, the value that keeps a hundred panels from sharing one
+`expanded?`. Hicasso mints no identity for you. (React's `useId` was examined
+and disqualified on the record: its hydration ids diverge under the arm's own
+hydration root, and outside hydration it is a counter whose ids do not survive
+remount — which state resident in app-db cannot tolerate.) The key is authored
+data — a keyword, string, number, or vector of these — and four rules cover
+choosing it.
+
+**Domain ids first — entity-qualified when entities can collide.** The best key
+already exists in your data: the order's id, the row's id, a literal namespaced
+keyword for a singleton placement. But a *generic* widget serving two entity
+types must not key by bare id — order 42 and invoice 42 both landing on
+`(sub [::expanded? 42])` is one entry, and the two silently share state.
+Qualify the id *value*: `[:order/id 42]` and `[:invoice/id 42]` are different
+keys, and the vector is already legal key grammar.
+
+**Placement-like concerns key by placement; value-like concerns key by
+entity.** Ask whether the concern is about the *slot on screen* or the *thing
+shown in it*. A master list and a detail pane both showing order 42: the
+order's draft is value-like — key it by entity, and both panes sharing one
+draft is correct, because it is the same draft. `expanded?` is placement-like —
+key it by placement (or placement plus entity), because collapsing the detail
+pane must not fold the list row.
+
+**Nest with `h/child-key`.** A widget inside a widget extends its parent's key
+instead of inventing a fresh one: `(h/child-key parent-key :filter)` yields
+`[parent-key :filter]`, and conj's onto a key that is already a vector — so
+every key bottoms out as a flat vector of authored data, and two children of
+two different parents can never collide.
+
+**If it would be a good React `:key`, it is a good instance key.** Derived from
+your data, stable across renders, unique among siblings — the same judgment,
+reused. This is also the SSR determinism rule: server and client must compute
+the same key from the same snapshot, which authored data does and render-order
+counters do not. One obligation follows on server-rendered pages: instance
+state lives under `[:ui …]`, and the payload policy is fail-closed — when
+server-side events write render-affecting instance state, the payload allowlist
+must name `:ui`, or the client renders from state the server never sent and
+hydration reports the mismatch
+([Server-side rendering](10-server-side-rendering.md)).
+
 ## Named events, not a generic setter
 
 Write `[:panel/toggle id]`, never a generic `[:ui/set [:panel/expanded id] true]`.
@@ -90,8 +171,15 @@ Write `[:panel/toggle id]`, never a generic `[:ui/set [:panel/expanded id] true]
 A named event is a name for what happened, which is the entire premise of the event
 log being readable. A generic setter turns your event history into a diff stream and
 takes the meaning out of the one place the framework was keeping it for you. This is
-also why HD-009 pre-commits that any future sugar mints a **named** setter event and
-never a generic `ui/set`.
+also HD-009's law for the sugar, kept by the ruled `reg-state`: the setter it mints
+is **named by its concern** — `[::expanded? panel-id false]` reads as what it is in
+the log — never a generic `ui/set`.
+
+The concern-named setter is a floor, not a ceiling. When an occurrence means more
+than an assignment — the collapse should fire an effect, other state reacts, the
+log should say *toggle* — graduate to a named domain event like `[:panel/toggle id]`
+and let the setter go. The sugar exists so ceremony never stops you putting state
+where it belongs, not so assignment replaces meaning.
 
 ## What v0 actually gives you
 
@@ -99,30 +187,25 @@ Layer 2 above is mostly a promise. The controls kit that would own drafts and
 revisions is post-v0. So is the overlay top layer. In v0, a dismissible dropdown is
 CSS if you can manage it, and app-db if you can't.
 
-HD-009 is explicit that this is expected to generate complaints, and equally
-explicit about what happens next. If dogfooding shows the residual ceremony
-registering, the pre-agreed *response class* is one-declaration sugar — never a
-state system:
+The ceremony story, though, moved on 2026-08-04. HD-009 originally shipped
+nothing here: the sugar was a pre-agreed *response class*, an unfrozen
+`defstate` sketch to be designed only if dogfooding demanded it. The operator
+ruled it into v0 instead, and the same-day design programme — three independent
+designs, three adversarial reviews — produced the `reg-state` ruling this page
+now teaches. One peer review had argued for a `useState` fence and a
+pre-designed tier; the fence is still rejected — there is no lint police — and
+the tier that was once withdrawn from pre-commitment is now simply *designed*,
+on evidence: `[:ui <concern> <instance-key>]`, one conventional app-space root.
+The no-`local` core stands throughout.
 
-```clojure
-;; SKETCH — v0 ships nothing here, and the shape is unfrozen.
-(h/defstate ::open {:default false})
-;; would mint: a parametric sub (sub [::open id])
-;;             and a NAMED setter event [::open id v]
-```
+The response class did not disappear; it moved one rung up. If dogfooding shows
+that explicitly threading the instance key is itself what fails the preference
+test, the pre-registered escalation is the ambient/auto door from the rejected
+structural design — a recorded mechanism, not an ad-hoc invention, and still
+never a state system.
 
-Read that block as an illustration of a *response class*, not a plan of record. Its
-concrete shape — including whether a declared app-db tier is involved and what that
-tier's frame and persistence scope would be — is **unfrozen until the evidence
-exists**. v0 ships nothing here and pre-commits to nothing beyond "sugar, not a state
-system."
-
-One peer review argued for a `useState` fence and a pre-designed tier. It was
-adopted in part: the tier pre-commitment was withdrawn and there is no lint police.
-The no-`local` core stands.
-
-So: a v0 complaint about state ceremony is **expected signal**, not a verdict. It
-triggers the sugar iteration, not a kill.
+So: a v0 complaint about state ceremony is still **expected signal**, not a
+verdict. The first response shipped early, and the next one is already named.
 
 ## The state you cannot put in app-db: "it left, but it is still on screen"
 
@@ -275,7 +358,7 @@ row.
 | A dismissed item disappears instantly with no exit animation | The node left with the data | `h/presence` with a `:timeout-ms` at least as long as the exit transition |
 | A retained node still takes focus or clicks while fading | The exit override does not carry `:inert` / `:aria-hidden` | Put all three in the `::h/unmounting` map |
 | An exit override on a view head raises `:rf.error/hicasso-presence-override-on-a-view` | Presence merges overrides into nodes it can see; a view is opaque to it, and a silently dropped override is the failure class the loud error exists to delete | The view receives `:rf/phase` — branch or style on that |
-| Every panel in a list opens at once | The state isn't parameterised by instance | Key the app-db path by the widget's id |
+| Every panel in a list opens at once | The state isn't parameterised by instance — or two instances share one key | Key the path per instance: [Choosing the instance key](#choosing-the-instance-key) |
 | A hook body can't be tested headlessly | Hooks put a body outside headless scope, by design | Move the semantic half to app-db; mount-test the mechanics |
 | Hook-order error after a conditional early-return | React's rules, now yours | Hooks at the top of the body, unconditionally |
 | app-db is full of `:ui` noise | Expected — it is the honest home | Namespace the keys and exclude the tier from persistence by convention |
@@ -299,8 +382,8 @@ that edge needs to know it exists.
 
 | Question | Status |
 |---|---|
-| `defstate`'s shape, and whether it ever ships | **Unfrozen by ruling.** HD-009 pre-commits to a response *class*, not a design; v0 ships nothing |
-| Whether a declared app-db `:ui` tier exists, and its frame and persistence scope | **Withdrawn from pre-commitment.** The `[:ui …]` keypaths on this page are ordinary app-db keys this guide chose, not a ruled tier |
+| `h/reg-state` (the sketch formerly spelled `defstate`) | **Ruled 2026-08-04** — the shape is fixed and in implementation (`rf2-2rtt6.98`), not yet landed; the spelling is **[unfrozen]** until the API freeze |
+| The declared app-db `[:ui …]` tier | **Ruled 2026-08-04.** One app-space conventional root, concern-first: `[:ui <concern> <instance-key>]`. Per-frame isolation is free (app-db is per frame); durable persistence excludes the tier by convention; the payload obligation above is the SSR half |
 | The controls kit (drafts, revisions) | **Post-v0** |
 | The overlay top layer that would own open and dismiss | **Post-v0** |
-| The reusable-widget instance-key convention | **Post-v0**, named as a resolved design debt in HD-009's sugar |
+| The reusable-widget instance-key convention | **Ruled 2026-08-04, in v0** — the four rules in [Choosing the instance key](#choosing-the-instance-key); the sugar that carries it is in implementation (`rf2-2rtt6.98`) |


### PR DESCRIPTION
Records the 2026-08-04 operator ruling (rf2-2rtt6.100): the reusable-widget instance-key convention and HD-009's sugar move INTO v0, ruled as `h/reg-state` by the same-day design programme (3 independent designs, 3 adversarial reviews, unanimous convergence on explicit-amended).

## Per-file

- **`docs/design/hicasso/decisions.md`** — dated HD-009 addendum blockquote (HD-019/HD-020 format) atop the entry: the scope ruling and programme verdicts (auto's FATAL named); what is superseded ("v0 ships nothing…", the unfrozen-shape deferral) vs what stands (no-`local` core, named-setter law, never a generic `ui/set`); the ruled design (`h/reg-state`, plain `.cljc` fn, `{:default}` only); the tier ruling (`[:ui <concern> <ikey>]`, one app-space root, `:rf/*` roots unlawful, `:ui/state`-style squats rejected); the clear-EVENT ruling with the rejected value-sentinel and its silent-dissoc hazard; the loud `:rf.error/hicasso-state-bad-key` refusal; `h/child-key`; the four taught rules with their named examples; the fail-closed SSR payload obligation (witnesses green and red-by-design: `rf2-2rtt6.99`); the `useId` autopsy preserved (fiber-position hydration ids diverge under the arm's hydration root; counter-based non-remount-stable outside hydration → disqualified for app-db-resident keys) so it is never relitigated; the pre-registered response class (the ambient door) with its trigger; honest-tense status (`rf2-2rtt6.98` in implementation, nothing landed). The original entry text below the addendum is left as written, per the model.
- **`docs/design/hicasso/charter.md`** — the design-debt line at :289 amended in the K5-note style (model `417fd06c65`): the original "post-v0" sentence stands as the record, a dated **Amended 2026-08-04 (operator ruling)** note states the deferral is over.
- **`docs/design/hicasso/draft-guide/07-ephemeral-state.md`** — "app-db without the ceremony" now teaches `reg-state` in honest tense (ruled 2026-08-04, in implementation via `rf2-2rtt6.98`, nothing landed, spelling [unfrozen]); the parametric pattern stays on the page as the shipping answer and the definition of what `reg-state` registers; new "Choosing the instance key" section teaches the four rules with the bead's named examples (order-42/invoice-42 entity-qualified values; master-list/detail-pane placement-vs-value; `h/child-key` nesting; the React-`:key` determinism rule plus one payload-obligation paragraph pointing at guide 10); "Named events" gains the graduation rule (setter is a floor); "What v0 actually gives you" rewritten (the response class moved one rung up to the ambient door); banner flags the one ruled-but-landing surface; the ~:214 pitfall row now points at the new section; all five Not-settled-yet rows updated to honest status.
- **`docs/design/hicasso/authoring.md`** — the "Ephemeral state (HD-009)" summary reconciled: the stale "v0 ships nothing here" `defstate` sketch replaced with the ruled `reg-state` shape (same honest tense), the four taught rules named, the kept HD-009 freezes restated.

Cross-check sweep: `grep -rn "instance-key\|instance key\|defstate" docs/design/hicasso/` — every remaining "post-v0"/sketch mention is either the deliberately-kept original sentence under a dated amendment (charter, HD-009 entry body) or a historical reference in the new prose. No other page states the convention is post-v0.

## Gates and hand-verification

- `python scripts/check_doc_slugs.py` exit **0**, run foreground to completion. Mutation-proved both ways: breaking `#choosing-the-instance-key` → exit 1 naming both call sites (07:361, 07:389); restored → exit 0.
- This tree is outside `mkdocs build --strict` (`exclude_docs`), so anchors and tables were hand-verified: the one new heading (`## Choosing the instance key`, slug `choosing-the-instance-key`) probe-confirmed; no heading renamed or removed; inbound sweep found zero links into 07 with a fragment. Tables hand-counted: 07 Troubleshooting 3 cols × 9 rows (one row edited, 3 cells), 07 Not settled yet 2 cols × 5 rows (all rows 2 cells); no other edited file touches a table.

## Sequencing

rf2-2rtt6.95 (the sibling bead also touching guide 07) landed first as PR #7476 and is MERGED; this branch is cut from that merge commit (`31d2a52a78`), so both intents are already merged — no conflict, no rebase needed.

Cites rf2-2rtt6.100 (epic rf2-2rtt6; ruling note of 2026-08-04 on the epic).