### PR TITLE
feat(hicasso): h/reg-state — the instance-key sugar (rf2-2rtt6.98)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/state_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/state_dom_cljs_test.cljs
@@ -1,0 +1,265 @@
+(ns re-frame.bench.hicasso.arm1.state-dom-cljs-test
+  "`h/reg-state`, MOUNTED — two disclosures on one page (rf2-2rtt6.98).
+
+  `front/state-cljs-test` proves the sugar against a real frame with no
+  React at all. This file proves the three claims only a browser can, and
+  the first two are the architectural ones:
+
+  1. **It costs no hook.** The widget's shell is counted at React's own
+     dispatcher (`arm1/hook-probe`), and it is the same two calls a
+     boundary that had never heard of `reg-state` makes. That is the
+     whole \"ordinary core artefacts\" claim, measured: the sugar mints a
+     sub and an event, and a sub read through the ambient collector is not
+     a hook.
+  2. **HD-028's memo bail-out still bails.** A parent re-render rebuilds
+     its children's key vectors — `(child-key row :detail)` allocates a
+     fresh vector every time — and `React.memo`'s comparator is `=` on the
+     props map, so a fresh-but-equal vector must NOT look like a changed
+     prop. If it did, this sugar would have re-introduced the 300-of-300
+     cascade `arm1/props-bailout-dom-cljs-test` exists to keep dead, and
+     it would have done it through the very helper that makes nesting
+     work.
+  3. **Two instances on one page are independent**, clicked in a real
+     browser, read back out of the real DOM.
+
+  ## Why a `console` capture rides the ordinary path
+
+  React routes a handler exception to `reportError` — a `window` `error`
+  event — and reports other faults by `console.error`, and NEITHER
+  reaches `cljs.test`. A row here asserting the page rendered correctly
+  could therefore be green over a live exception. So the ordinary path is
+  driven inside `hydration-support/capture-console!`, which watches both
+  channels, and the row asserts the capture is EMPTY. That helper is the
+  lane's one copy of this refusal; a second copy is the copy that quietly
+  weakens.
+
+  And because a bad instance key is *recovered* rather than thrown (the
+  sub body's throw is caught, fanned on the always-on error channel, and
+  the read answers `nil`), the refusal row reads that channel — the same
+  reasoning `front/state-cljs-test` sets out at length.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every DOM claim degrades to a stated
+  skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.hook-probe :as probe]
+            [re-frame.bench.hicasso.arm1.hydration-support :as support]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.state :as state]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-id ::arm1-state-dom)
+
+(def ^:private open? ::open?)
+(def ^:private label ::label)
+
+;; ---------------------------------------------------------------------------
+;; The screen — one widget, mounted twice
+;; ---------------------------------------------------------------------------
+
+(def ^:private !panel-runs (atom 0))
+(def ^:private !page-runs (atom 0))
+
+(defn- reset-runs! [] (reset! !panel-runs 0) (reset! !page-runs 0) nil)
+
+(defview disclosure
+  "A disclosure panel. It holds its own open flag and knows nothing about
+  where it is on the page beyond the instance key it was handed — which
+  is the ergonomic claim: the widget is written ONCE and mounted twice."
+  [{:keys [ikey title]}]
+  (swap! !panel-runs inc)
+  (let [shown? (rt/sub [open? ikey])]
+    [:section.panel {:data-ikey (pr-str ikey)}
+     [:button.toggle {:on-click [open? ikey (not shown?)]} title]
+     (when shown? [:div.body "body of " title])]))
+
+(defview page
+  "Two disclosures, and a page-level read of its own so a chrome write
+  can re-render the page without touching either panel. Every child key
+  is REBUILT here on every render — `child-key` allocates — which is
+  exactly the condition claim 2 is about."
+  [_]
+  (swap! !page-runs inc)
+  [:div.page
+   [:h1.chrome (str (rt/sub [label :page]))]
+   [disclosure {:key "billing"  :ikey (state/child-key :panel :billing)  :title "Billing"}]
+   [disclosure {:key "shipping" :ikey (state/child-key :panel :shipping) :title "Shipping"}]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- skip! [why] (is true (str "a reg-state DOM claim needs a real React DOM — " why)))
+
+(defn- fresh! []
+  (lane/leave-act-environment!)
+  (state/reg-state open? {:default false})
+  (state/reg-state label {:default ""})
+  (rf/make-frame {:id frame-id})
+  (reset-runs!)
+  (rt/reset-body-runs!)
+  frame-id)
+
+(defn- panels [handle]
+  (array-seq (.querySelectorAll (:container handle) "section.panel")))
+
+(defn- bodies [handle]
+  (mapv #(some-> (.querySelector % "div.body") (.-textContent))
+        (panels handle)))
+
+(defn- click! [handle i]
+  (-> (nth (vec (panels handle)) i)
+      (.querySelector "button.toggle")
+      (.click))
+  (mount/settle!)
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; 1 — two instances on one page, independent, in a real browser
+;; ---------------------------------------------------------------------------
+
+(deftest two-mounted-instances-of-one-widget-are-independent
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [[result captured]
+            (support/capture-console!
+              (fn []
+                (let [handle (mount/root! (mount/fresh-container!) frame-id [page {}])]
+                  (try
+                    (let [before (bodies handle)]
+                      (click! handle 0)
+                      {:before before
+                       :after  (bodies handle)
+                       :db     (rf/app-db-value frame-id)})
+                    (finally (mount/release! handle))))))]
+        (is (= [nil nil] (:before result)) "both panels start closed — the default")
+        (is (= ["body of Billing" nil] (:after result))
+            "one click opened ONE panel. Before the explicit-key ruling the
+             guide's own pitfall opened both, silently.")
+        (is (= {:ui {open? {[:panel :billing] true}}} (:db result))
+            "one entry, at the documented app-space path, under the composed key")
+        (is (= [] @captured)
+            "and React complained on NEITHER channel — without this the rows
+             above could be green over a live exception cljs.test never sees")))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — no hook. The ≤2-hook ledger is untouched.
+;; ---------------------------------------------------------------------------
+
+(deftest a-reg-state-widget-shell-still-calls-exactly-two-hooks
+  (cond
+    (not (mount/browser?)) (skip! ":node-test has no DOM")
+
+    (not (probe/install!))
+    (is false (str "React's internals slot was not found, so the ≤2-hook budget "
+                   "is UNWITNESSED for reg-state. A gate nobody has watched fire "
+                   "is not evidence — fix "
+                   (pr-str 're-frame.bench.hicasso.arm1.hook-probe)
+                   " rather than reading this as a pass."))
+
+    :else
+    (do
+      (fresh!)
+      (let [container (mount/fresh-container!)
+            !handle   (volatile! nil)
+            names     (probe/record!
+                        (fn []
+                          (vreset! !handle
+                                   (mount/root! container frame-id
+                                                [disclosure {:ikey :solo :title "Solo"}]))))]
+        (mount/release! @!handle)
+        (is (= ["useContext" "useSyncExternalStore"] names)
+            (str "the shell called " (pr-str names) " — reg-state mints a sub "
+                 "and an event, and a sub read through the ambient collector is "
+                 "not a hook. A third call here is a budget breach (HD-020(b)) "
+                 "and would mean this sugar had grown machinery."))
+        (is (= (count rt/shell-hook-ledger) (count names))
+            "and the declared ledger is still the measured one — reg-state
+             added nothing to it")
+        (is (not-any? #{"useRef" "useState"} names)
+            "neither hook is per-instance React state: the value lives in
+             app-db, which is the whole point of keying it explicitly")))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — HD-028's bail-out survives a key vector rebuilt every render
+;; ---------------------------------------------------------------------------
+
+(deftest a-fresh-but-equal-key-vector-does-not-defeat-the-memo-bail-out
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [handle (mount/root! (mount/fresh-container!) frame-id [page {}])]
+        (try
+          (let [nodes-before (vec (panels handle))]
+            (reset-runs!)
+            (mount/dispatch! handle [label :page "chrome moved"])
+            (is (= 1 @!page-runs) "the page re-ran — it reads the chrome")
+            (is (= 0 @!panel-runs)
+                "and NEITHER panel did, although the page rebuilt both their
+                 `ikey` vectors from scratch on the way through. `child-key`
+                 allocates; `React.memo`'s comparator is `=`; a fresh-but-equal
+                 vector is an EQUAL prop. Had it been compared by identity this
+                 sugar would have re-introduced the cascade rf2-2rtt6.52 killed.")
+            (is (= "chrome moved"
+                   (.-textContent (.querySelector (:container handle) "h1.chrome")))
+                "and the write really landed — without this the row above could
+                 pass by doing nothing at all")
+            (is (= nodes-before (vec (panels handle)))
+                "the panels are the IDENTICAL DOM nodes"))
+          (testing "and a bail-out is not a disconnection: the panel still
+                   answers its own write afterwards"
+            (reset-runs!)
+            (click! handle 1)
+            (is (= ["" "body of Shipping"] (mapv #(or % "") (bodies handle))))
+            (is (= 1 @!panel-runs) "exactly the panel that moved, and no other"))
+          (finally (mount/release! handle)))))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — a bad key refuses on the page, and the page keeps working
+;; ---------------------------------------------------------------------------
+
+(deftest a-nil-keyed-widget-refuses-loudly-and-its-sibling-keeps-rendering
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (fresh!)
+      (let [records (volatile! [])]
+        (error-emit/register-error-listener! ::state-dom (fn [r] (vswap! records conj r)))
+        (let [handle (mount/root! (mount/fresh-container!) frame-id [:div.empty])]
+          (try
+            (mount/render! handle
+                           [:div.page
+                            [disclosure {:key "good" :ikey :billing :title "Billing"}]
+                            [disclosure {:key "bad" :ikey nil :title "Broken"}]])
+            (let [refusals (->> @records
+                                (mapcat (juxt (comp ex-data :exception)
+                                              (comp ex-data ex-cause :exception)))
+                                (filter #(= :rf.error/hicasso-state-bad-key
+                                            (:rf.error/id %))))]
+              (is (seq refusals)
+                  "a nil instance key refused — this is the guide's silent
+                   every-instance-shares pitfall converted into a loud error")
+              (is (some #(= open? (:concern %)) refusals)
+                  "and the refusal NAMES the concern, which is what makes it
+                   actionable on a page with several of them"))
+            (is (= 2 (count (panels handle)))
+                "the well-keyed sibling still rendered — one widget's bad key
+                 is not the page's problem")
+            (finally
+              (error-emit/unregister-error-listener! ::state-dom)
+              (mount/release! handle))))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/state.cljc
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/state.cljc
@@ -193,19 +193,19 @@
 ;; Registration
 ;; ---------------------------------------------------------------------------
 
-(defonce ^:private !defaults
-  "concern -> the `:default` it was registered with.
-
-  Registration-time bookkeeping, NOT runtime state: nothing reads it
-  during a render, it holds no per-instance value, and it is the same kind
-  of thing the sub and event registries themselves are. It exists so a
-  second [[reg-state]] for one concern with a DIFFERENT default can be
-  refused rather than silently changing what every un-set instance reads.
-
-  `defonce`, so a hot reload of THIS namespace does not forget what is
-  already registered — which is the stricter reading, and the cost is
-  stated in [[reg-state]]."
-  (atom {}))
+;; `concern -> the :default it was registered with`.
+;;
+;; Registration-time bookkeeping, NOT runtime state: nothing reads it
+;; during a render, it holds no per-instance value, and it is the same kind
+;; of thing the sub and event registries themselves are. It exists so a
+;; second `reg-state` for one concern with a DIFFERENT default can be
+;; refused rather than silently changing what every un-set instance reads.
+;;
+;; `defonce`, so a hot reload of THIS namespace does not forget what is
+;; already registered — which is the stricter reading, and the cost is
+;; stated in `reg-state`. (`defonce` takes no docstring in CLJS, which is
+;; why this one is a comment.)
+(defonce ^:private !defaults (atom {}))
 
 (defn reg-state
   "Register a per-instance state `concern`, and mint the two ordinary core

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/state.cljc
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/state.cljc
@@ -1,0 +1,309 @@
+(ns re-frame.bench.hicasso.front.state
+  "`h/reg-state` — THE INSTANCE-KEY SUGAR (rf2-2rtt6.98, HD-009 as amended
+  by the 2026-08-04 explicit-key ruling).
+
+  A widget that wants a scrap of its own state — a disclosure's open flag,
+  a tab strip's selection, a row's draft text — has to answer one question
+  first: *which* instance's flag is this? The guide's own answer, before
+  this ruling, was a pitfall written out in prose: pick an app-db path by
+  hand, forget to vary it per instance, and **every instance on the page
+  silently shares one value**. Two accordions open together. Nothing
+  throws, nothing logs, and the screen is simply wrong.
+
+  This namespace converts that silence into a loud error, and it does so
+  with **no new machinery at all**.
+
+  ## What it mints — ordinary core artefacts, and nothing else
+
+  [[reg-state]] is a plain function. It calls `re-frame.subs/reg-sub` and
+  `re-frame.events/reg-event`, which is what any application author would
+  have called by hand, and then it stops. There is:
+
+  - **no new runtime state** — no cell, no registry, no per-instance
+    record; the value lives in `app-db` where every other value lives;
+  - **no hook** — nothing here runs inside a React render, so the ≤2-hook
+    shell budget (HD-020(b), counted at React's own dispatcher by
+    `arm1/hook-ledger-dom-cljs-test`) is untouched by construction;
+  - **no context** — a widget reads its state through the ordinary
+    subscription path and therefore through whatever frame its boundary
+    already resolved.
+
+  That is the whole architectural claim, and it is why this file is 200
+  lines rather than a subsystem: the sugar is a NAMING CONVENTION with
+  refusals, not a feature.
+
+  ## The tier — ONE app-space conventional root, concern-first
+
+  The path is `[:ui ::concern ikey]`.
+
+  - `:ui` is **app-space**, deliberately. It is NEVER an `:rf/*` app-db
+    root: `spec/Conventions.md`'s two-partition doctrine reserves the
+    `:rf/*` single-root scheme for the framework, and widget state is the
+    application's own data, readable and writable by ordinary handlers,
+    dumpable in a tool, serialisable in a fixture.
+  - **Concern-first**, then instance. Grouping by concern is what makes
+    `[:ui ::open?]` one inspectable map of every open disclosure rather
+    than a scatter of unrelated leaves.
+  - **Per-frame comes free**, with nothing spent on it: `app-db` is
+    per-frame already, so two frames holding the same concern at the same
+    instance key hold two independent values without this namespace
+    containing a single line about frames.
+
+  ## The four rules an author is TAUGHT but this file does not police
+
+  Policing them would need to know what a domain is, and it does not.
+
+  1. **Domain ids first.** If the widget is showing a to-do, key it by the
+     to-do's id; invent an identity only when the domain has none.
+  2. **Entity-qualified id VALUES** — `{:id [:order/id 42]}` — when one
+     widget serves multiple entity types, because a bare `42` from two
+     entity types is one key and the bleed is silent.
+  3. **Placement-like concerns key by placement; value-like concerns key
+     by entity.** \"Is this panel open?\" belongs to where the panel is;
+     \"what is the draft text for this order?\" belongs to the order.
+  4. **If it would be a good React `:key`, it is a good instance key** —
+     which is the determinism rule: the key must be derived from data, not
+     from render order, a counter or `random-uuid`, or a server render and
+     its client hydration will not agree on it.
+
+  And the graduation rule: when an occurrence means more than \"this slot
+  now holds that value\" — when something else must happen, or the change
+  must be recorded — retire the concern and write a named domain event.
+  This sugar is for the assignments that mean nothing but themselves.
+
+  ## What was REJECTED, and stays rejected
+
+  Clear is a FRAMEWORK-NAMED EVENT, `[::h/clear ::concern ikey]`, and not
+  a sentinel VALUE. The rejected variant put `::h/clear` in the value
+  position of the ordinary setter — which reads beautifully right up to
+  the first concern whose values are keywords, at which point setting the
+  concern to a legitimate value would silently `dissoc` it instead. That
+  is a fail-silent hazard of exactly the class this whole ruling exists to
+  delete, so there is no sentinel here and no \"convenience\" arity that
+  accepts one."
+  (:require [re-frame.events :as events]
+            [re-frame.subs :as subs]))
+
+;; ---------------------------------------------------------------------------
+;; The spellings
+;; ---------------------------------------------------------------------------
+
+(def ui-root
+  "`:ui` — the ONE app-space conventional root every concern sits under.
+  App-space, never `:rf/*`: widget state is the application's data."
+  :ui)
+
+(def clear-event-id
+  "`::h/clear` — the FRAMEWORK-NAMED clear event, `[::h/clear ::concern
+  ikey]`. One handler serves every concern, because removing an entry
+  needs to know nothing about what used to be in it."
+  :re-frame.hicasso/clear)
+
+;; ---------------------------------------------------------------------------
+;; Errors — the lane's shape (front.presence/fail!)
+;; ---------------------------------------------------------------------------
+
+(defn- fail! [id where reason recovery extra]
+  (throw (ex-info (str reason " [" id "]")
+                  (merge {:rf.error/id id :where where
+                          :reason reason :recovery recovery}
+                         extra))))
+
+;; ---------------------------------------------------------------------------
+;; Instance keys
+;; ---------------------------------------------------------------------------
+
+(defn instance-key?
+  "A keyword, a string, a number, or a vector of those (recursively).
+
+  The list is short on purpose. It is every shape that reads as an
+  identity, prints legibly in a tool, survives EDN, and — the reason the
+  vector case is in it — can be COMPOSED by [[child-key]] without
+  becoming a new kind of thing. `nil` is not on it, and that exclusion is
+  the whole point: `nil` is what a missing prop, a mistyped destructure
+  and a forgotten argument all evaluate to, and `nil` as a key is
+  precisely the every-instance-shares-one-value pitfall."
+  [k]
+  (boolean (or (keyword? k)
+               (string? k)
+               (number? k)
+               (and (vector? k) (every? instance-key? k)))))
+
+(defn- check-key!
+  "Refuse a bad instance key, **naming the concern**, at read and at write
+  alike. A read-only check would leave a bad key written and only fail on
+  the way back out, one interaction later and in a different component."
+  [concern ikey op]
+  (when-not (instance-key? ikey)
+    (fail! :rf.error/hicasso-state-bad-key
+           'front.state/check-key!
+           (str "The instance key for " (pr-str concern) " was "
+                (pr-str ikey) ", which is not a keyword, string, number, "
+                "or vector of those. Without a per-instance key every "
+                "instance of this widget shares one value, which is a "
+                "wrong screen that never complains — so it is refused "
+                "here instead.")
+           :key-the-widget-by-a-domain-id
+           {:concern concern :instance-key ikey :op op}))
+  ikey)
+
+(defn child-key
+  "Extend an instance key by one `part` — the ONE composition helper, and
+  the whole answer to widget-in-widget nesting.
+
+      (child-key :panel :row)          ;=> [:panel :row]
+      (child-key [:panel :row] :cell)  ;=> [:panel :row :cell]
+
+  Pure, total and associative-shaped: a parent hands its own key down, a
+  child extends it, and the resulting keys are distinct by construction
+  without any component knowing how deeply it is nested. It does not
+  validate — a bad key is refused at the read or the write, which is
+  where the concern is known and can be named."
+  [k part]
+  (if (vector? k) (conj k part) [k part]))
+
+;; ---------------------------------------------------------------------------
+;; The clear event
+;; ---------------------------------------------------------------------------
+
+(defn- clear-entry
+  "Remove `[ui-root concern ikey]`, pruning an emptied concern map.
+
+  Removal, not a write of the default: the default lives in the sub, so a
+  cleared concern reads its default because the entry is ABSENT — one
+  representation of \"unset\", not two."
+  [db concern ikey]
+  (if-some [concerns (get db ui-root)]
+    (let [entries (dissoc (get concerns concern) ikey)]
+      (assoc db ui-root (if (seq entries)
+                          (assoc concerns concern entries)
+                          (dissoc concerns concern))))
+    db))
+
+(defn- reg-clear-event!
+  "Register `[::h/clear ::concern ikey]`. Idempotent — one handler serves
+  every concern, and re-registration replaces it with an identical one."
+  []
+  (events/reg-event clear-event-id
+    (fn clear-handler [{:keys [db]} [_ concern ikey]]
+      (check-key! concern ikey :clear)
+      {:db (clear-entry db concern ikey)})))
+
+;; ---------------------------------------------------------------------------
+;; Registration
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private !defaults
+  "concern -> the `:default` it was registered with.
+
+  Registration-time bookkeeping, NOT runtime state: nothing reads it
+  during a render, it holds no per-instance value, and it is the same kind
+  of thing the sub and event registries themselves are. It exists so a
+  second [[reg-state]] for one concern with a DIFFERENT default can be
+  refused rather than silently changing what every un-set instance reads.
+
+  `defonce`, so a hot reload of THIS namespace does not forget what is
+  already registered — which is the stricter reading, and the cost is
+  stated in [[reg-state]]."
+  (atom {}))
+
+(defn reg-state
+  "Register a per-instance state `concern`, and mint the two ordinary core
+  artefacts a widget needs to use it.
+
+      (reg-state ::open? {:default false})
+
+      (sub [::open? panel-id])                ;; read
+      (dispatch [::open? panel-id true])      ;; write
+      (dispatch [::h/clear ::open? panel-id]) ;; back to the default
+
+  `concern` must be a NAMESPACE-QUALIFIED keyword — it is simultaneously a
+  sub id, an event id and an `app-db` key, and an unqualified one would
+  collide across features on all three at once. `opts` may carry
+  `:default` and nothing else; an unknown option is refused rather than
+  ignored, because an ignored option is a setting the author believes is
+  in force.
+
+  ## What it registers
+
+  - a **sub** under `concern`, reading `[:ui concern ikey]` and falling
+    back to `:default` when the entry is absent;
+  - a **setter event** under `concern`, `[::concern ikey v]`, writing that
+    same path;
+  - the shared **clear event** [[clear-event-id]], if it is not already
+    registered by another concern.
+
+  Both are registered through the ordinary programmatic doors
+  (`re-frame.subs/reg-sub`, `re-frame.events/reg-event`), so everything
+  downstream — caching, the frame's app-db, tooling, a test's
+  `dispatch-sync` — behaves exactly as it does for a hand-written pair.
+
+  ## Registering twice
+
+  Re-registering a concern with the SAME `:default` is a no-op-shaped
+  refresh, which is what a namespace reload is. Re-registering it with a
+  DIFFERENT `:default` **refuses**: the un-set instances of a live widget
+  would otherwise start reading a different value with nothing on screen
+  to say why. That is the stricter of the two behaviours the ruling
+  allowed, and its cost is honest — changing a `:default` in a
+  hot-reloading dev session needs a page reload.
+
+  Returns `concern`.
+
+  See the namespace docstring for the tier (`[:ui ::concern ikey]`,
+  app-space and never `:rf/*`), the determinism rule (\"if it would be a
+  good React `:key`, it is a good instance key\"), and the rules an author
+  is taught but this function does not police."
+  ([concern] (reg-state concern nil))
+  ([concern opts]
+   (when-not (and (keyword? concern) (namespace concern))
+     (fail! :rf.error/hicasso-state-bad-concern
+            'front.state/reg-state
+            (str "A state concern must be a namespace-qualified keyword; it "
+                 "was " (pr-str concern) ". The concern is a sub id, an event "
+                 "id and an app-db key at once, so an unqualified one collides "
+                 "with every other feature on the page in three registries.")
+            :namespace-qualify-the-concern
+            {:concern concern}))
+   (when-not (or (nil? opts) (map? opts))
+     (fail! :rf.error/hicasso-state-bad-option
+            'front.state/reg-state
+            (str "reg-state options must be a map; for " (pr-str concern)
+                 " they were " (pr-str opts) ".")
+            :pass-a-map-of-options
+            {:concern concern :options opts}))
+   (let [unknown (seq (disj (set (keys opts)) :default))]
+     (when unknown
+       (fail! :rf.error/hicasso-state-bad-option
+              'front.state/reg-state
+              (str "reg-state accepts :default and nothing else; "
+                   (pr-str concern) " was given " (pr-str (vec (sort-by str unknown)))
+                   ". An option that is quietly ignored is a setting its author "
+                   "believes is in force.")
+              :remove-the-unknown-option
+              {:concern concern :unknown (vec (sort-by str unknown))})))
+   (let [default (:default opts)]
+     (when (and (contains? @!defaults concern)
+                (not= default (get @!defaults concern)))
+       (fail! :rf.error/hicasso-state-redefined
+              'front.state/reg-state
+              (str "The concern " (pr-str concern) " is already registered with "
+                   ":default " (pr-str (get @!defaults concern)) " and cannot be "
+                   "re-registered with " (pr-str default) ". Every instance that "
+                   "has not been written to would start reading a different value "
+                   "with nothing on screen to say why.")
+              :register-each-concern-once
+              {:concern concern
+               :registered-default (get @!defaults concern)
+               :offered-default default}))
+     (subs/reg-sub concern
+       (fn read-state [db query-v]
+         (let [ikey (check-key! concern (nth query-v 1 nil) :read)]
+           (get-in db [ui-root concern ikey] default))))
+     (events/reg-event concern
+       (fn write-state [{:keys [db]} [_ ikey v]]
+         (check-key! concern ikey :write)
+         {:db (assoc-in db [ui-root concern ikey] v)}))
+     (reg-clear-event!)
+     (swap! !defaults assoc concern default)
+     concern)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/state_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/state_cljs_test.cljs
@@ -1,0 +1,317 @@
+(ns re-frame.bench.hicasso.front.state-cljs-test
+  "`h/reg-state`, PROVED AGAINST A REAL FRAME (rf2-2rtt6.98).
+
+  The sugar's whole claim is that it mints ORDINARY core artefacts, so
+  every row here drives it the way an application would: a real frame, a
+  real `subscribe`, a real `dispatch-sync`, and the frame's real `app-db`
+  read back out. Nothing here stubs a registry or calls a private fn.
+
+  ## Why the refusals are read off the ERROR CHANNEL and not off a throw
+
+  This is the trap this file exists to not fall into. In this substrate
+  neither refusal reaches the caller as an exception:
+
+  - an **event handler**'s throw is captured by the interceptor chain
+    into `:rf/interceptor-error` and fanned as
+    `:rf.error/handler-exception` — `dispatch-sync` returns normally;
+  - a **sub body**'s throw is caught by `compute-and-cache!`, fanned, and
+    **recovered to `nil`** — so `(deref (subscribe …))` answers `nil`.
+
+  A row spelled `(is (thrown? …))` would therefore be RED over a working
+  refusal, and — far worse — a row spelled `(is (nil? …))` would be GREEN
+  over a refusal that had been deleted. So [[refusals]] registers a real
+  `error-emit` listener, unwraps the fanned exception, and every refusal
+  row asserts on the `:rf.error/id` AND on the concern being named. Each
+  one was proved able to go red by deleting the guard it watches; the
+  mutation ledger is in the PR body.
+
+  The DOM half — two mounted instances, the hook ledger, and the memo
+  bail-out over fresh-but-equal key vectors — is
+  `arm1/state-dom-cljs-test`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.bench.hicasso.front.state :as state]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; The harness
+;; ---------------------------------------------------------------------------
+
+(defn- frame! [id]
+  (rf/make-frame {:id id})
+  id)
+
+(defn- read* [frame-id query]
+  (rf/with-frame frame-id (deref (rf/subscribe query))))
+
+(defn- send! [frame-id event]
+  (rf/with-frame frame-id (rf/dispatch-sync event))
+  nil)
+
+(defn- db-of [frame-id] (rf/app-db-value frame-id))
+
+(defn- refusals
+  "Every framework ex-data `thunk` produced, from BOTH paths — a direct
+  throw (registration, which happens on the caller's own stack) and the
+  always-on error channel (a read or a write, whose throw the runtime
+  captures and fans). Watching one path only would be green over the
+  other, and the two surfaces genuinely differ."
+  [thunk]
+  (let [direct  (volatile! nil)
+        records (volatile! [])]
+    (error-emit/register-error-listener! ::state (fn [r] (vswap! records conj r)))
+    (try
+      (try (thunk) (catch :default e (vreset! direct (ex-data e))))
+      (finally (error-emit/unregister-error-listener! ::state)))
+    (->> (concat [@direct]
+                 (map (comp ex-data :exception) @records)
+                 (map (comp ex-data ex-cause :exception) @records))
+         (filter #(some-> % :rf.error/id namespace (= "rf.error")))
+         (vec))))
+
+(defn- refused?
+  "Did `thunk` refuse with `id`, naming `concern`?"
+  [id concern thunk]
+  (boolean (some (fn [d] (and (= id (:rf.error/id d))
+                              (= concern (:concern d))
+                              (string? (:reason d))))
+                 (refusals thunk))))
+
+;; ---------------------------------------------------------------------------
+;; Independence — the whole reason the key is explicit
+;; ---------------------------------------------------------------------------
+
+(deftest two-instances-of-one-widget-are-independent
+  (testing "the pitfall this sugar deletes: two disclosures on one page,
+           one concern, two keys, two values"
+    (state/reg-state ::open? {:default false})
+    (let [f (frame! ::independent)]
+      (is (= false (read* f [::open? :billing])) "unwritten reads the default")
+      (is (= false (read* f [::open? :shipping])))
+      (send! f [::open? :billing true])
+      (is (= true  (read* f [::open? :billing])))
+      (is (= false (read* f [::open? :shipping]))
+          "the sibling did NOT move — this is the row that was silently
+           false before the ruling")
+      (is (= {:ui {::open? {:billing true}}} (db-of f))
+          "one entry, at the documented app-space path, concern first"))))
+
+(deftest the-same-instance-key-shares-and-that-is-correct
+  (testing "two widgets given ONE key are one instance on purpose — a
+           master/detail pair that must open together says so by sharing
+           the key, and nothing here treats that as an error"
+    (state/reg-state ::open? {:default false})
+    (let [f (frame! ::shared)]
+      (send! f [::open? :billing true])
+      (is (= true (read* f [::open? :billing])))
+      (is (= 1 (count (get-in (db-of f) [:ui ::open?])))
+          "one key, one entry, however many widgets read it"))))
+
+(deftest a-default-is-per-concern-and-any-value
+  (state/reg-state ::draft {:default ""})
+  (state/reg-state ::tab {:default :first})
+  (let [f (frame! ::defaults)]
+    (is (= "" (read* f [::draft [:order/id 42]])))
+    (is (= :first (read* f [::tab :panel])))
+    (testing "a concern registered with no options at all defaults to nil"
+      (state/reg-state ::no-opts)
+      (is (nil? (read* f [::no-opts :x]))))))
+
+;; ---------------------------------------------------------------------------
+;; Clear — a framework-named EVENT, and a removal
+;; ---------------------------------------------------------------------------
+
+(deftest clear-restores-the-default-by-removing-the-entry
+  (testing "the entry is GONE, not set to the default — one representation
+           of unset, and the concern map is pruned once it empties"
+    (state/reg-state ::open? {:default false})
+    (let [f (frame! ::cleared)]
+      (send! f [::open? :billing true])
+      (is (= {:ui {::open? {:billing true}}} (db-of f)))
+      (send! f [state/clear-event-id ::open? :billing])
+      (is (= false (read* f [::open? :billing])) "back to the default")
+      (is (= {:ui {}} (db-of f))
+          "the entry is removed AND the emptied concern map is pruned"))))
+
+(deftest clear-leaves-its-siblings-alone
+  (state/reg-state ::open? {:default false})
+  (let [f (frame! ::clear-sibling)]
+    (send! f [::open? :billing true])
+    (send! f [::open? :shipping true])
+    (send! f [state/clear-event-id ::open? :billing])
+    (is (= {:ui {::open? {:shipping true}}} (db-of f))
+        "one key removed, the concern map kept because it is not empty")
+    (is (= false (read* f [::open? :billing])))
+    (is (= true  (read* f [::open? :shipping])))))
+
+(deftest clear-of-something-never-written-changes-nothing
+  (testing "and in particular does not plant an empty `:ui` root in a db
+           that never had one"
+    (state/reg-state ::open? {:default false})
+    (let [f (frame! ::clear-absent)]
+      (send! f [state/clear-event-id ::open? :billing])
+      (is (= {} (db-of f)))
+      (is (= false (read* f [::open? :billing]))))))
+
+(deftest a-keyword-valued-concern-survives-being-set-to-any-value
+  (testing "the REJECTED value-sentinel clear would have made this row a
+           silent dissoc: a concern whose values are keywords could be set
+           to the sentinel by legitimate domain data. Clear is an event, so
+           there is no value this concern cannot hold."
+    (state/reg-state ::tab {:default :first})
+    (let [f (frame! ::sentinel-free)]
+      (doseq [v [:second :re-frame.hicasso/clear ::anything nil false]]
+        (send! f [::tab :panel v])
+        (is (= v (read* f [::tab :panel]))
+            (str "the concern holds " (pr-str v) " as an ordinary value"))
+        (is (contains? (get-in (db-of f) [:ui ::tab]) :panel)
+            "and the entry is still THERE — no value clears anything")))))
+
+;; ---------------------------------------------------------------------------
+;; The loud refusals
+;; ---------------------------------------------------------------------------
+
+(deftest a-bad-instance-key-is-refused-at-the-read-naming-the-concern
+  (state/reg-state ::open? {:default false})
+  (let [f (frame! ::bad-read)]
+    (testing "nil — what a missing prop, a mistyped destructure and a
+             forgotten argument all evaluate to"
+      (is (refused? :rf.error/hicasso-state-bad-key ::open?
+                    #(read* f [::open? nil]))))
+    (testing "a map — a whole entity handed over where its id was meant"
+      (is (refused? :rf.error/hicasso-state-bad-key ::open?
+                    #(read* f [::open? {:id 1}]))))
+    (testing "and a missing key altogether"
+      (is (refused? :rf.error/hicasso-state-bad-key ::open?
+                    #(read* f [::open?]))))
+    (testing "the refusal carries the offending key and the side it fired on"
+      (let [d (first (refusals #(read* f [::open? {:id 1}])))]
+        (is (= {:id 1} (:instance-key d)))
+        (is (= :read (:op d)))))))
+
+(deftest a-bad-instance-key-is-refused-at-the-write-naming-the-concern
+  (state/reg-state ::open? {:default false})
+  (let [f (frame! ::bad-write)]
+    (is (refused? :rf.error/hicasso-state-bad-key ::open?
+                  #(send! f [::open? nil true])))
+    (is (refused? :rf.error/hicasso-state-bad-key ::open?
+                  #(send! f [::open? {:id 1} true])))
+    (testing "and nothing was written"
+      (is (= {} (db-of f))
+          "a refused write is a refused write — the read-side check alone
+           would have left this entry in the db"))
+    (testing "the refusal names the side it fired on"
+      (is (= :write (:op (first (refusals #(send! f [::open? nil true]))))))))
+
+  (testing "clear refuses a bad key too — it is a write"
+    (state/reg-state ::open? {:default false})
+    (let [f (frame! ::bad-clear)]
+      (is (refused? :rf.error/hicasso-state-bad-key ::open?
+                    #(send! f [state/clear-event-id ::open? nil]))))))
+
+(deftest registration-refuses-an-unqualified-concern
+  (is (refused? :rf.error/hicasso-state-bad-concern :open?
+                #(state/reg-state :open? {:default false})))
+  (is (refused? :rf.error/hicasso-state-bad-concern "open?"
+                #(state/reg-state "open?" {:default false}))))
+
+(deftest registration-refuses-an-unknown-option
+  (testing "an option that is quietly ignored is a setting its author
+           believes is in force"
+    (is (refused? :rf.error/hicasso-state-bad-option ::typo
+                  #(state/reg-state ::typo {:default false :defualt true})))
+    (is (refused? :rf.error/hicasso-state-bad-option ::not-a-map
+                  #(state/reg-state ::not-a-map [:default false])))
+    (testing "and the refusal names what it did not recognise"
+      (is (= [:defualt]
+             (:unknown (first (refusals #(state/reg-state ::typo2
+                                                          {:defualt true})))))))))
+
+(deftest re-registering-is-a-refresh-only-when-the-default-agrees
+  (testing "a namespace reload re-runs the same call, and that must work"
+    (is (= ::reloaded (state/reg-state ::reloaded {:default 0})))
+    (is (= ::reloaded (state/reg-state ::reloaded {:default 0}))))
+  (testing "a DIFFERENT default refuses — the stricter of the two
+           behaviours the ruling allowed. Every un-set instance of a live
+           widget would otherwise start reading a different value with
+           nothing on screen to say why."
+    (is (refused? :rf.error/hicasso-state-redefined ::reloaded
+                  #(state/reg-state ::reloaded {:default 1})))
+    (testing "and the first registration is still the one in force"
+      (let [f (frame! ::reg-twice)]
+        (is (= 0 (read* f [::reloaded :a])))))))
+
+;; ---------------------------------------------------------------------------
+;; Instance keys as values
+;; ---------------------------------------------------------------------------
+
+(deftest instance-key-admits-exactly-the-composable-shapes
+  (testing "admitted"
+    (doseq [k [:kw ::ns-kw "s" 0 -1 1.5 [:a] [:a 1 "b"] [[:order/id 42] :row] []]]
+      (is (state/instance-key? k) (str (pr-str k) " is an instance key"))))
+  (testing "refused"
+    (doseq [k [nil false true {} {:id 1} #{:a} '(:a) [:a nil] [:a {}]]]
+      (is (not (state/instance-key? k)) (str (pr-str k) " is not an instance key")))))
+
+(deftest child-key-nests-and-deep-nests
+  (testing "a scalar parent key becomes a two-element vector"
+    (is (= [:panel :row] (state/child-key :panel :row)))
+    (is (= ["panel" 0] (state/child-key "panel" 0))))
+  (testing "a vector parent key CONJes — so depth costs one element, not
+           one level of nesting, and no component needs to know how deep
+           it is"
+    (is (= [:panel :row :cell] (state/child-key [:panel :row] :cell)))
+    (is (= [:panel :row :cell :label]
+           (-> :panel (state/child-key :row) (state/child-key :cell) (state/child-key :label)))))
+  (testing "and every key it produces is a legal instance key, which is
+           what makes nesting total"
+    (is (state/instance-key? (state/child-key [[:order/id 42]] :row)))))
+
+(deftest sibling-widgets-nested-under-one-parent-do-not-collide
+  (state/reg-state ::open? {:default false})
+  (let [f    (frame! ::nested)
+        row1 (state/child-key :panel 1)
+        row2 (state/child-key :panel 2)]
+    (send! f [::open? (state/child-key row1 :detail) true])
+    (is (= true  (read* f [::open? (state/child-key row1 :detail)])))
+    (is (= false (read* f [::open? (state/child-key row2 :detail)])))
+    (is (= false (read* f [::open? :panel]))
+        "the parent's own key is a different key from any child's")))
+
+(deftest a-fresh-but-equal-key-vector-is-the-same-instance
+  (testing "keys are compared by VALUE, so a key rebuilt every render
+           addresses the entry the previous render wrote"
+    (state/reg-state ::draft {:default ""})
+    (let [f (frame! ::value-equality)]
+      (send! f [::draft [:order/id 42] "hi"])
+      (is (= "hi" (read* f [::draft (into [] [:order/id 42])]))
+          "a distinct vector object, equal by value")
+      (is (= "hi" (read* f [::draft (state/child-key :order/id 42)]))
+          "and one composed by child-key")
+      (is (= 1 (count (get-in (db-of f) [:ui ::draft])))
+          "one entry, not two"))))
+
+;; ---------------------------------------------------------------------------
+;; Frames
+;; ---------------------------------------------------------------------------
+
+(deftest two-frames-hold-the-same-concern-and-key-independently
+  (testing "per-frame isolation costs this namespace NOTHING — app-db is
+           per-frame already, and there is not one line about frames in it"
+    (state/reg-state ::open? {:default false})
+    (let [a (frame! ::frame-a)
+          b (frame! ::frame-b)]
+      (send! a [::open? :billing true])
+      (is (= true  (read* a [::open? :billing])))
+      (is (= false (read* b [::open? :billing])) "frame b never moved")
+      (is (= {:ui {::open? {:billing true}}} (db-of a)))
+      (is (= {} (db-of b)))
+      (testing "and clearing in one frame leaves the other"
+        (send! b [::open? :billing true])
+        (send! a [state/clear-event-id ::open? :billing])
+        (is (= false (read* a [::open? :billing])))
+        (is (= true  (read* b [::open? :billing])))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/state_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/state_cljs_test.cljs
@@ -25,6 +25,12 @@
   one was proved able to go red by deleting the guard it watches; the
   mutation ledger is in the PR body.
 
+  One consequence of that recovery is worth stating, because it shapes
+  how the read rows are written: the recovered `nil` is **cached**, so a
+  second read of the same bad query is served from the cache and fans
+  nothing. Every read row below therefore uses each bad key exactly once
+  and takes all of its claims off that single read.
+
   The DOM half — two mounted instances, the hook ledger, and the memo
   bail-out over fresh-but-equal key vectors — is
   `arm1/state-dom-cljs-test`."
@@ -73,13 +79,21 @@
          (filter #(some-> % :rf.error/id namespace (= "rf.error")))
          (vec))))
 
+(defn- refusal
+  "The ex-data of the `id` refusal `thunk` produced, or nil.
+
+  Selected by id rather than taken as the first record, because the
+  runtime fans its OWN category alongside ours — a refused read arrives
+  as a sub-exception carrying our ex-info as its cause — and a row that
+  read the first record would be asserting about the wrapper."
+  [id thunk]
+  (first (filter #(= id (:rf.error/id %)) (refusals thunk))))
+
 (defn- refused?
   "Did `thunk` refuse with `id`, naming `concern`?"
   [id concern thunk]
-  (boolean (some (fn [d] (and (= id (:rf.error/id d))
-                              (= concern (:concern d))
-                              (string? (:reason d))))
-                 (refusals thunk))))
+  (let [d (refusal id thunk)]
+    (boolean (and d (= concern (:concern d)) (string? (:reason d))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Independence — the whole reason the key is explicit
@@ -182,16 +196,21 @@
              forgotten argument all evaluate to"
       (is (refused? :rf.error/hicasso-state-bad-key ::open?
                     #(read* f [::open? nil]))))
-    (testing "a map — a whole entity handed over where its id was meant"
-      (is (refused? :rf.error/hicasso-state-bad-key ::open?
-                    #(read* f [::open? {:id 1}]))))
+    (testing "a map — a whole entity handed over where its id was meant.
+             Read ONCE, and every claim about it taken off that one read:
+             the runtime recovers a failed sub to nil and CACHES it, so a
+             second read of the same query is served from the cache and
+             fans nothing. Each bad key below therefore appears exactly
+             once in this file."
+      (let [d (refusal :rf.error/hicasso-state-bad-key
+                       #(read* f [::open? {:id 1}]))]
+        (is (some? d) "the read refused")
+        (is (= ::open? (:concern d)) "and NAMED the concern")
+        (is (= {:id 1} (:instance-key d)) "and carried the offending key")
+        (is (= :read (:op d)) "and the side it fired on")))
     (testing "and a missing key altogether"
       (is (refused? :rf.error/hicasso-state-bad-key ::open?
-                    #(read* f [::open?]))))
-    (testing "the refusal carries the offending key and the side it fired on"
-      (let [d (first (refusals #(read* f [::open? {:id 1}])))]
-        (is (= {:id 1} (:instance-key d)))
-        (is (= :read (:op d)))))))
+                    #(read* f [::open?]))))))
 
 (deftest a-bad-instance-key-is-refused-at-the-write-naming-the-concern
   (state/reg-state ::open? {:default false})
@@ -205,7 +224,8 @@
           "a refused write is a refused write — the read-side check alone
            would have left this entry in the db"))
     (testing "the refusal names the side it fired on"
-      (is (= :write (:op (first (refusals #(send! f [::open? nil true]))))))))
+      (is (= :write (:op (refusal :rf.error/hicasso-state-bad-key
+                                  #(send! f [::open? nil true])))))))
 
   (testing "clear refuses a bad key too — it is a write"
     (state/reg-state ::open? {:default false})
@@ -228,8 +248,8 @@
                   #(state/reg-state ::not-a-map [:default false])))
     (testing "and the refusal names what it did not recognise"
       (is (= [:defualt]
-             (:unknown (first (refusals #(state/reg-state ::typo2
-                                                          {:defualt true})))))))))
+             (:unknown (refusal :rf.error/hicasso-state-bad-option
+                                #(state/reg-state ::typo2 {:defualt true}))))))))
 
 (deftest re-registering-is-a-refresh-only-when-the-default-agrees
   (testing "a namespace reload re-runs the same call, and that must work"


### PR DESCRIPTION
Implements the 2026-08-04 explicit-key ruling (three designs, three adversarial reviews, unanimous synthesis on EP-0038; the operator ruled the feature INTO v0, amending HD-009). Bench lane only — no `spec/**`, no `implementation/core` edits, no `ssr`/`ssr-ring`, and the ordinary render path is byte-for-byte unchanged.

## The exact spellings landed

`rf2-2rtt6.99` should read these rather than guess them.

| Thing | Spelling |
| --- | --- |
| namespace | `re-frame.bench.hicasso.front.state` (`.cljc`) |
| file | `implementation/freehand/test/re_frame/bench/hicasso/front/state.cljc` |
| registration fn | `(state/reg-state ::concern {:default v})` — also 1-arity `(state/reg-state ::concern)` |
| composition helper | `(state/child-key k part)` |
| key predicate | `(state/instance-key? k)` |
| app-space root | `state/ui-root` = `:ui` |
| clear event id | `state/clear-event-id` = `:re-frame.hicasso/clear` |
| documented path | `[:ui ::concern ikey]` |
| read | `(sub [::concern ikey])` |
| write | `(dispatch [::concern ikey v])` |
| clear | `(dispatch [:re-frame.hicasso/clear ::concern ikey])` |
| bad-key error id | `:rf.error/hicasso-state-bad-key` (ex-data: `:concern`, `:instance-key`, `:op` ∈ `#{:read :write :clear}`) |
| bad-concern error id | `:rf.error/hicasso-state-bad-concern` (ex-data: `:concern`) |
| bad-option error id | `:rf.error/hicasso-state-bad-option` (ex-data: `:concern`, `:unknown` / `:options`) |
| redefinition error id | `:rf.error/hicasso-state-redefined` (ex-data: `:concern`, `:registered-default`, `:offered-default`) |
| unit witnesses | `re-frame.bench.hicasso.front.state-cljs-test` |
| DOM witnesses | `re-frame.bench.hicasso.arm1.state-dom-cljs-test` |

## The four surface items, against the bead's text

1. **`(h/reg-state ::concern {:default v})` — a plain `.cljc` FUNCTION, not a macro.** One namespace-qualified concern keyword; `{:default v}` is the only option; unknown options refused loudly at registration. It mints a parametric sub (`(sub [::concern ikey])` → `(get-in db [:ui ::concern ikey] default)`), a concern-named setter event (`[::concern ikey v]` → `assoc-in`), and the documented path `[:ui ::concern ikey]` — one app-space conventional root, concern-first, per-frame free because `app-db` is per-frame, and never an `:rf/*` root.
2. **Clear is a FRAMEWORK-NAMED EVENT**, `[:re-frame.hicasso/clear ::concern ikey]`, restoring the default by REMOVING the entry (`dissoc`, with the emptied concern map pruned). **The rejected value-sentinel variant was NOT reintroduced** — there is no sentinel value, no sentinel-accepting arity, and a dedicated row (`a-keyword-valued-concern-survives-being-set-to-any-value`) sets a concern to `:re-frame.hicasso/clear` itself as an ordinary value and asserts the entry is still there.
3. **Loud refusals.** Non-`(keyword|string|number|vector-of-these)` instance keys — `nil` included — refuse at read AND write with `:rf.error/hicasso-state-bad-key` naming the concern. Registration refuses a non-namespaced concern and unknown options.
4. **`(child-key k part)` ⇒ `(if (vector? k) (conj k part) [k part])`** — pure, total, and the only composition helper.

Register-twice: the bead allowed "refuses" or "last-wins with a loud warn — pick the stricter, state it". **Stricter picked**: re-registering with the SAME `:default` is a refresh (a namespace reload must work); a DIFFERENT `:default` refuses with `:rf.error/hicasso-state-redefined`. Stated cost: changing a `:default` in a hot-reloading dev session needs a page reload.

## Ordinary core artefacts — no hook, no runtime state, no context

`reg-state` calls `re-frame.subs/reg-sub` and `re-frame.events/reg-event` (the documented programmatic doors) and stops. **Measured, not asserted**: `a-reg-state-widget-shell-still-calls-exactly-two-hooks` counts at React's own dispatcher via `arm1/hook-probe` and reads `["useContext" "useSyncExternalStore"]` — the shell's declared `rt/shell-hook-ledger`, unchanged. The ≤2-hook budget (HD-020(b)) is untouched; `arm1/hook-ledger-dom-cljs-test` was not edited.

The one piece of mutable state added is a private `defonce` atom mapping concern → registered default. It is registration-time bookkeeping in the same class as the sub/event registries themselves: nothing reads it during a render, it holds no per-instance value, and it is what makes the strict register-twice refusal possible. Flagging it explicitly so the fence can judge it rather than discover it.

## Two findings worth the operator's attention

1. **Neither refusal reaches the caller as an exception in this substrate.** An event handler's throw is captured by the interceptor chain and fanned as `:rf.error/handler-exception`; a sub body's throw is caught, fanned, and **recovered to `nil`**. So `(is (thrown? ...))` would be RED over a working refusal and `(is (nil? ...))` would be GREEN over a deleted one. Every refusal row therefore reads the always-on `error-emit` channel and unwraps the fanned exception. Related: the recovered `nil` is **cached**, so a second read of the same bad query fans nothing — each bad key appears exactly once per row.
2. **Pruning stops at the concern level, as the bead words it** ("empty concern maps pruned"), so clearing the last entry leaves `{:ui {}}` rather than `{}`. Pruning `:ui` too would give the cleaner "clear returns the db to what it was", but the bead names the concern level and this did not grow past it. The db shape is pinned in the witness either way.

## Witnesses

21 tests / 88 assertions across the two suites, covering every row the bead enumerates: two instances independent (unit + real-browser click); same ikey shares, stated as correct; clear restores the default and removes the entry with the db shape and pruning asserted; bad-key refusal on `nil`, on a map, and on a missing key, naming the concern; frames isolated; `child-key` induction and deep-nesting; HD-028 memo bail-out unaffected by fresh-but-equal key vectors; register-twice.

The DOM suite drives its ordinary path inside `hydration-support/capture-console!` and asserts the capture is EMPTY — React routes a handler exception to `reportError` (a `window` `error` event) and reports other faults by `console.error`, and neither reaches `cljs.test`, so a row asserting the page rendered correctly could otherwise be green over a live exception.

## Mutation ledger — every guard proved able to go red

Each row deletes ONE guard, recompiles, and runs the suite. Baseline unmutated: 17 tests / 84 assertions, 0 failures.

| # | Mutation | Result |
| --- | --- | --- |
| M1 | read-side `check-key!` deleted | 6 failures — `a-bad-instance-key-is-refused-at-the-read-naming-the-concern` |
| M2 | write-side `check-key!` deleted | 4 failures — `a-bad-instance-key-is-refused-at-the-write-naming-the-concern` |
| M3 | clear-side `check-key!` deleted | 1 failure — same row's clear clause |
| M4 | concern-qualification guard deleted | 2 failures — `registration-refuses-an-unqualified-concern` |
| M5 | unknown-option guard deleted | 2 failures — `registration-refuses-an-unknown-option` |
| M6 | redefinition guard deleted | 2 failures — `re-registering-is-a-refresh-only-when-the-default-agrees` |
| M7 | instance key dropped from the path (every instance shares — the pitfall itself) | 17 failures, 1 error across 7 rows |
| M8 | empty-concern pruning deleted | 1 failure — `clear-restores-the-default-by-removing-the-entry` |

And because a silently-skipped DOM row is the failure mode that matters in the browser lane, all four DOM rows were proved live in one instrumented browser run — four failures, one per row, each at its own line. The hook row's mutation output records the measurement directly: `the shell called ["useContext" "useSyncExternalStore"]`.

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/regstate-2rtt6-98`, foreground, to completion.

| Gate | Exit |
| --- | --- |
| `npm run test:hicasso-compile` | **0** — 115 lane namespaces, zero warnings |
| `npm run test:cljs` | **0** — Ran 12569 tests containing 62987 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **0** — Ran 1081 tests containing 6701 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` | **0** — JVM core 2210/11510, JVM freehand 1288/8857, CLJS node 12569/62987, per-ns isolation, hicasso bench-lane compile, all 0 failures |
| `npm run test:script-policy && npm run test:script-helpers` | **0** and **0** (chained, both halves run) |
| clj-kondo **2026.04.15** (CI-pinned binary, `lint.yml`'s exact invocation) | **0** — `errors: 0, warnings: 4534` (the standing baseline) |
| EP-0036 donor-boundary grep over `implementation/freehand` | no match (clean) |

`mkdocs build --strict` not run and not applicable — no `docs/**` edits. No `spec/**`, `decisions.md`, `ssr`, `ssr-ring`, or `implementation/core` edits; `rf2-2rtt6.100` owns the ruling record and `rf2-2rtt6.97` owns `arm1/hydrate*`, neither of which this branch touches (it only *requires* `arm1/hydration-support`, read-only).
