### PR TITLE
bench(hicasso): the instance-key payload obligation, witnessed both ways (rf2-2rtt6.99)

### DIFF
--- a/docs/design/hicasso/studio/ssr-spike-witness.md
+++ b/docs/design/hicasso/studio/ssr-spike-witness.md
@@ -288,9 +288,42 @@ after that reset is zero however badly the teardown went (`rf2-2rtt6.48`).
 non-zero and its `:cell-refs` positive, so the zeros above are a reading of
 something.
 
+## Addendum — the instance-key payload obligation (`rf2-2rtt6.99`)
+
+A later bead added a seventh row to this lane, and it is a PAIR rather than a
+single reading. `h/reg-state` (`rf2-2rtt6.98`) puts a widget's own state at
+`[:ui ::concern ikey]`, which is app-space data, so the ruled obligation is
+that an allowlist must name `:ui` whenever server-side events write
+render-affecting instance state. The corpus therefore carries one page — two
+disclosure panels keyed by authored roster ids, boot events that open the first
+one server-side — under two allowlists that differ by exactly that key, and the
+server bytes of the two are byte-identical, so the allowlist is the only
+variable. With `:ui` named, the client hydrates the open panel and the run
+reads `{:mismatches 0, :warnings 0, :panels 2, :open-after? true}` — no
+`:rf.ssr/hydration-mismatch`, nothing on either console channel, and every
+element on the page still the server's own node. With `:ui` omitted — a
+perfectly well-formed allowlist, which is why the fail-closed policy has
+nothing to refuse — the client boots without the entry, reads `reg-state`'s
+`false` default, and the run reads `{:mismatches 1, :warnings 1, :where
+"re-frame.bench.hicasso.arm1.mount/hydrate-root!", :open-after? false}`: the
+structured diagnostic fires from the arm's own hydrate door, the uncaught
+report is still there beside it (so `rf2-2rtt6.97`'s composing reporter holds
+and `rf2-mwx08` is not softened), and the panel the server rendered open is
+shut on the adopted page. That last figure is the whole teaching — the cost of
+omitting `:ui` is not an error message, it is the server's work thrown away and
+the user shown a default. The red row is red-by-design and asserts the error
+positively; the green row is its control, since a diagnostic that fired on
+every adoption would agree with every page. Neither row leans on
+`:rf/render-hash`, and that is measured rather than promised: both take
+`83b865f8`, the same value the dogfood screen takes, so the instrument
+`rf2-2rtt6.91` describes could not have carried either claim. Repro:
+`cd implementation && npm run test:cljs` for the payload-shape and determinism
+rows, `npm run test:browser` for the two hydration rows.
+
 ## What this page does not say
 
 It does not recommend for or against P2, and it does not weigh SSR against
 anything. Five rows published, one instrument defect reproduced
 (`rf2-2rtt6.91`), one new one filed (`rf2-2rtt6.97`), one vacuous gate repaired.
-The reading is the operator's.
+The reading is the operator's. The addendum above is `rf2-2rtt6.99`'s and
+carries no verdict either.

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/fixtures.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/fixtures.cljs
@@ -27,6 +27,12 @@
     [[nested-host-screen]].
   - **Presence's `::h/mounting` overrides** — and that row is a PINNED
     DEFECT rather than a feature. See [[presence-tray]].
+  - **The instance-key payload obligation, TWICE** — one page whose boot
+    events write `h/reg-state` instance state, rendered once with `:ui`
+    on the allowlist and once without it. The two rows are a matched
+    pair and only mean anything together; see
+    [[re-frame.bench.hicasso.ssr.instance-key]] and the witness
+    `ssr/instance-key-payload-dom-cljs-test`.
 
   ## The host rows are REAL DECLARATIONS (rf2-2rtt6.92)
 
@@ -50,6 +56,7 @@
             [re-frame.bench.hicasso.front.dogfood :as dogfood]
             [re-frame.bench.hicasso.shapes.large-template :as large-template]
             [re-frame.bench.hicasso.shapes.model :as model]
+            [re-frame.bench.hicasso.ssr.instance-key :as instance-key]
             [re-frame.routing :as routing]
             ["react" :as react])
   (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defhost defview]]))
@@ -208,6 +215,28 @@
     :snapshot {}
     :payload  :rf.ssr.payload/whole-app-db
     :title    "Hicasso SSR — defhost :ssr policy, nested"
+    :script-src "/main.js"}
+
+   ;; THE MATCHED PAIR. Same hiccup, same boot events, same everything
+   ;; but the `:payload` allowlist — which is the only way to state the
+   ;; obligation as a measurement rather than as prose. Both allowlists
+   ;; are WELL FORMED: the fail-closed policy refuses an ABSENT one and
+   ;; has no way to refuse a wrong one, so what catches the second row is
+   ;; React's own hydration-mismatch machinery and nothing else.
+   {:id     "instance-key-payload"
+    :why    "server boot events write reg-state instance state and the allowlist NAMES :ui — the obligation met"
+    :hiccup [instance-key/screen {}]
+    :initial-events instance-key/boot-events
+    :payload  (conj instance-key/domain-keys :ui)
+    :title    "Hicasso SSR — instance state, :ui shipped"
+    :script-src "/main.js"}
+
+   {:id     "instance-key-payload-omitted"
+    :why    "the SAME page with :ui OMITTED — a well-formed allowlist that strands the instance state, and the red-by-design half of the obligation witness"
+    :hiccup [instance-key/screen {}]
+    :initial-events instance-key/boot-events
+    :payload  instance-key/domain-keys
+    :title    "Hicasso SSR — instance state, :ui stranded"
     :script-src "/main.js"}])
 
 (defn ids

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/instance_key.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/instance_key.cljs
@@ -1,0 +1,141 @@
+(ns re-frame.bench.hicasso.ssr.instance-key
+  "THE PAGE THE PAYLOAD OBLIGATION IS WITNESSED ON (rf2-2rtt6.99).
+
+  One screen, two disclosure panels, and one `h/reg-state` concern
+  (`re-frame.bench.hicasso.front.state`). The server's boot events open
+  the first panel — `[::open? \"billing\" true]`, the ordinary setter
+  `reg-state` mints — so the page this namespace describes is a page
+  whose APPEARANCE depends on instance state a server-side event wrote.
+
+  That is the whole reason it exists. `[:ui ::concern ikey]` is app-space
+  data like any other, which means the hydration payload policy is what
+  decides whether it crosses the wire, and the policy is fail-closed
+  against ABSENCE but cannot be fail-closed against a WRONG allowlist: a
+  list naming `[:panels]` is perfectly well formed and ships a page whose
+  server bytes say open and whose client says shut. The corpus therefore
+  carries this screen TWICE, under two allowlists, and
+  `ssr/instance-key-payload-dom-cljs-test` reads what happens.
+
+  ## The instance keys are AUTHORED DATA, and that is load-bearing
+
+  [[panels]] is a roster written out here. Every instance key is a
+  `:id` taken from it — never a render-order index, never a counter,
+  never `random-uuid`, and never `useId`. That is `front/state`'s own
+  determinism rule (\"if it would be a good React `:key`, it is a good
+  instance key\") stated as a fixture: a server render and its client
+  hydration agree on these keys because both read them out of the same
+  seeded app-db, so a divergence anywhere in the two rows below is a
+  divergence about the PAYLOAD and never about key generation.
+
+  ## Deliberately small
+
+  Two panels, one concern, one boolean. The rows this fixture serves are
+  structural — did the instance state cross the wire, and what did React
+  say when it did not — so every element on the page is either the thing
+  being measured or the sibling that proves the page rendered at all."
+  (:require [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.state :as state]
+            [re-frame.core :as rf])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+;; ---------------------------------------------------------------------------
+;; The concern, and the authored roster
+;; ---------------------------------------------------------------------------
+
+(def open?
+  "The `reg-state` concern this fixture is built on. Its `:default` is
+  `false`, which is what makes the omission row's client render a CLOSED
+  panel: an absent `[:ui ::open? ikey]` entry reads the default, and the
+  default is the shut one."
+  ::open?)
+
+(def panels
+  "The roster, as authored data. Instance keys are the `:id` values —
+  domain ids, per `front/state`'s first taught rule, and stable across
+  a server render and its client hydration because both read them from
+  this same seeded value."
+  [{:id "billing"  :title "Billing"}
+   {:id "shipping" :title "Shipping"}])
+
+(def open-key
+  "The panel the SERVER's boot events open. The other panel stays shut in
+  both rows, so \"the payload did not arrive\" is distinguishable from
+  \"the page rendered nothing\"."
+  "billing")
+
+(def state-path
+  "Where the opened panel's flag sits — `[:ui ::open? \"billing\"]`, the
+  documented tier. Written out so the witness asserts on the same vector
+  the sugar writes rather than on a hand-spelled copy of it."
+  [state/ui-root open? open-key])
+
+(defn seed-db
+  "The domain half of the app-db: the roster and nothing else. The
+  instance half is written by the boot event, which is the point."
+  []
+  {:panels panels})
+
+;; ---------------------------------------------------------------------------
+;; Registration — ordinary core artefacts, at ns load like every sibling
+;; ---------------------------------------------------------------------------
+
+(rf/reg-sub ::panel-ids (fn [db _] (mapv :id (:panels db))))
+
+(rf/reg-sub ::panel-title
+  (fn [db [_ id]] (some (fn [p] (when (= id (:id p)) (:title p))) (:panels db))))
+
+(rf/reg-event ::seed (fn [_ _] {:db (seed-db)}))
+
+;; The sugar's own registration. A plain call, at load, beside the
+;; `reg-sub`s above — because that is all `reg-state` is: two ordinary
+;; registrations and a naming convention. Re-registration with the same
+;; `:default` is the no-op-shaped refresh `reg-state` documents, so a
+;; reload of this namespace is safe.
+(state/reg-state open? {:default false})
+
+;; ---------------------------------------------------------------------------
+;; The screen
+;; ---------------------------------------------------------------------------
+
+(defview panel
+  "A disclosure. It holds its own open flag under the instance key it was
+  handed and knows nothing else about where it sits.
+
+  The body is a CONDITIONAL ELEMENT rather than a changed attribute or a
+  changed string: an element the server rendered and the client does not
+  is an unambiguous structural divergence, where a text difference would
+  be measuring React's SSR text-separator behaviour (rf2-2rtt6.88)
+  alongside the thing under test."
+  [{:keys [ikey title]}]
+  (let [shown? (rt/sub [open? ikey])]
+    [:section.panel {:data-ikey ikey}
+     [:button.panel-toggle {:on-click [open? ikey (not shown?)]} title]
+     (when shown?
+       [:div.panel-body "the details"])]))
+
+(defview screen
+  "The page. A heading, then one [[panel]] per roster entry, keyed by the
+  same authored id it is instance-keyed by."
+  [_]
+  [:div.instance-key-page
+   [:h1.title "instance state across the wire"]
+   [:div.panels
+    (for [id (rt/sub [::panel-ids])]
+      [panel {:key id :ikey id :title (rt/sub [::panel-title id])}])]])
+
+;; ---------------------------------------------------------------------------
+;; The two requests, minus their payload policies
+;; ---------------------------------------------------------------------------
+
+(def boot-events
+  "What the SERVER runs before it renders: seed the roster, then open one
+  panel through `reg-state`'s ordinary setter event. The second of these
+  is the whole obligation — a render-affecting write into `[:ui …]`
+  performed by a server-side event."
+  [[::seed]
+   [open? open-key true]])
+
+(def domain-keys
+  "The domain half of the allowlist, shared by both rows so the ONLY
+  difference between them is whether `:ui` is named beside it."
+  [:panels])

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/instance_key_payload_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/instance_key_payload_dom_cljs_test.cljs
@@ -1,0 +1,467 @@
+(ns re-frame.bench.hicasso.ssr.instance-key-payload-dom-cljs-test
+  "THE INSTANCE-KEY PAYLOAD OBLIGATION, WITNESSED BOTH WAYS (rf2-2rtt6.99).
+
+  `h/reg-state` puts a widget's own state at `[:ui ::concern ikey]`
+  (`front/state.cljc`), which is APP-SPACE data — so whether it reaches
+  the client is decided by the hydration payload policy and by nothing
+  else. The 2026-08-04 ruling states the obligation that follows:
+
+  > an allowlist MUST name `:ui` whenever server-side events write
+  > render-affecting instance state; strip it only if the server never
+  > writes it. Whole-app-db carries it automatically.
+
+  This file is that sentence turned into two measurements taken on the
+  same page, and the second one is the reason the file exists.
+
+  ## Why prose was not enough, stated precisely
+
+  The payload policy is fail-closed and stays fail-closed: an ABSENT
+  `:payload` throws `:rf.error/ssr-missing-payload-policy` at the
+  framework's own validator, and nothing here softens that (it is pinned
+  by `ssr/entry-cljs-test`'s `the-payload-policy-is-fail-closed`). But
+  `[:panels]` is a perfectly well-formed allowlist. There is no shape for
+  the validator to refuse, no default to fall back on, and no way for the
+  framework to know that `:ui` mattered on THIS page — so a policy that
+  is fail-closed against absence is silent about omission, and the
+  obligation is a rule the author keeps or does not.
+
+  What catches the author who does not is React. The divergence between
+  the server's open panel and the client's shut one is a hydration
+  mismatch, and since rf2-2rtt6.97 the arm's hydrate door surfaces one as
+  Spec 011's `:rf.ssr/hydration-mismatch`. **That is the enforcement**,
+  and [[omitting-ui-from-the-allowlist-fires-the-structured-mismatch]]
+  asserts it POSITIVELY — the row is red-by-design and the error is the
+  row's subject, not an accident it survives.
+
+  ## The two rows are each other's control
+
+  A witness that only manufactured a fault could be reading a diagnostic
+  that fires on every adoption; a witness that only took a clean
+  adoption could be reading a capture that never fires at all. So:
+
+  | Row | What it asserts | What it stops the other from lying about |
+  |---|---|---|
+  | [[naming-ui-on-the-allowlist-hydrates-with-zero-mismatch]] | zero emits, zero console complaints, the server's own nodes adopted | the diagnostic is not a constant |
+  | [[omitting-ui-from-the-allowlist-fires-the-structured-mismatch]] | the diagnostic fires, tagged with the door's own site | the silence above is a reading |
+
+  ## Where the structured error is read from, and why not `thrown?`
+
+  From the live trace stream — `re-frame.trace.tooling/register-listener!`,
+  filtered on `(= :rf.ssr/hydration-mismatch (:operation ev))`, which is
+  `arm1/hydrate-recoverable-dom-cljs-test`'s channel and the only place
+  this diagnostic can be read: it fires from a React root-error callback,
+  outside any dispatch scope, so it is frameless and never reaches a
+  per-frame ring.
+
+  `(is (thrown? …))` would be wrong here twice over. React routes a
+  recoverable hydration error to `reportError`, so nothing throws on any
+  stack `cljs.test` is watching — a `thrown?` row would be RED over a
+  working door. And the recoverable error is exactly the thing the door
+  is supposed to have RECOVERED from, so there is no exception left to
+  catch even in principle. The `window` `error` and `console.error`
+  channels are watched as well (`hydration-support/open-console-capture!`)
+  because a row asserting \"nothing complained\" that watched neither
+  would be green over a live failure — and in the red row they carry the
+  second half of rf2-2rtt6.97's finding: the door COMPOSES over React's
+  default, so the uncaught report is still there beside the diagnostic
+  and `rf2-mwx08` is not softened.
+
+  ## And the capture window is the honest one
+
+  Opened before `hydrate-root!` and closed after `adopted!` resolves.
+  `hydrateRoot` is called plain, so it returns BEFORE the tree is
+  adopted; a capture that closed at the call's return would be shut
+  across the only part that can complain (measured by rf2-2rtt6.87: 1
+  complaint across the adoption, 0 at the return).
+
+  ## `:rf/render-hash` is not load-bearing anywhere in this file
+
+  It cannot be. The hash is degenerate for an interpreted root — the
+  dogfood screen and the ~1,200-element Conduit feed take the same value
+  (rf2-2rtt6.91, pinned by `ssr/entry-cljs-test`) — and
+  [[the-instance-key-rows-cannot-lean-on-the-render-hash]] takes the
+  measurement on THESE rows so the exclusion is a reading rather than a
+  promise. Every determinism claim below is over the DOCUMENT BYTES.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM. The payload-shape and determinism rows need no DOM and run
+  under `:node-test` too; every DOM claim degrades to a stated skip
+  there."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.hydration-support
+             :refer [adopted! every-server-node? open-console-capture! server-dom!
+                     server-node? stamp-server-nodes!]]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.bench.hicasso.ssr.entry :as entry]
+            [re-frame.bench.hicasso.ssr.fixtures :as fixtures]
+            [re-frame.bench.hicasso.ssr.instance-key :as instance-key]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+(def ^:private frame-id ::instance-key-payload)
+
+(def ^:private green-id
+  "The row whose allowlist NAMES `:ui`." "instance-key-payload")
+
+(def ^:private red-id
+  "The row whose allowlist omits it — same page, same boot events."
+  "instance-key-payload-omitted")
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (fixtures/register!)
+                      (rt/reset-runtime!)
+                      (rt/reset-body-runs!))}))
+
+(defn- skip! [why]
+  (is true (str "a payload-obligation hydration claim needs a real React DOM — " why)))
+
+;; ---------------------------------------------------------------------------
+;; The two sides
+;; ---------------------------------------------------------------------------
+
+(defn- server!
+  "Render one corpus row through the real entry, with the runtime reset on
+  both sides so the hydration measured afterwards starts from an empty
+  table."
+  [row-id]
+  (rt/reset-runtime!)
+  (rt/reset-body-runs!)
+  (let [result (entry/render (fixtures/row row-id))]
+    (rt/reset-runtime!)
+    (rt/reset-body-runs!)
+    result))
+
+(defn- client-frame!
+  "Boot a CLIENT frame out of the payload the server shipped, and NOTHING
+  else.
+
+  `[:rf/set-db (:rf/app-db payload)]` is the reserved framework seeding
+  event carrying exactly the slice `re-frame.ssr.hydrate`'s own
+  `:rf/hydrate` handler installs — `(or (:rf/app-db payload) db)`. It is
+  spelled this way rather than by dispatching `:rf/hydrate` because
+  loading the `re-frame.ssr` entry namespace would install its late-bind
+  hooks and seven server-response fxs into every build this lane
+  compiles in, including the `:advanced` bench build; the lane requires
+  only leaf SSR namespaces for that reason, and the entry does the same
+  (`ssr/entry.cljs` requires `payload-policy`, `hash`, `constants` and
+  `html-helpers` and no more). What is under test is the CONTENT of the
+  payload, so the seeding door is deliberately the least interesting
+  part of the row."
+  [payload]
+  (lane/leave-act-environment!)
+  (rf/make-frame {:id             frame-id
+                  :initial-events [[:rf/set-db (:rf/app-db payload)]]})
+  frame-id)
+
+(defn- watch-mismatches!
+  "Capture every `:rf.ssr/hydration-mismatch` the framework emits, on the
+  live trace stream. Answers `{:seen atom :stop! fn}`; `stop!` is
+  idempotent. The diagnostic is frameless — it fires from a React
+  root-error callback, outside any dispatch scope — so a listener is the
+  only place it can be read."
+  []
+  (let [seen (atom [])
+        k    (keyword (str "rf2-2rtt6-99-" (gensym)))]
+    (trace-tooling/register-listener!
+      k (fn [ev] (when (= :rf.ssr/hydration-mismatch (:operation ev))
+                   (swap! seen conj ev))))
+    {:seen seen :stop! (fn [] (trace-tooling/unregister-listener! k) @seen)}))
+
+(defn- tags-of
+  "The diagnostic's tags, merged with its top level, so a read is robust
+  to whichever slots the envelope hoists."
+  [ev]
+  (merge (:tags ev) ev))
+
+(defn- open-panel-in [container]
+  (.querySelector container ".panel-body"))
+
+(defn- panel-count [container]
+  (.-length (.querySelectorAll container ".panel")))
+
+(defn- adopt!
+  "Put `html` on the page, stamp every node, hydrate it on `frame-id`, and
+  answer a promise of what happened across the WHOLE adoption.
+
+  `capture-opts` reaches `open-console-capture!`; the only caller that
+  sets `:swallow-uncaught?` is the row that manufactures the fault and
+  asserts on it."
+  [html capture-opts]
+  (let [container (stamp-server-nodes! (server-dom! html))
+        {:keys [seen stop!]} (watch-mismatches!)
+        {:keys [captured close!]} (open-console-capture! capture-opts)
+        before    (some? (open-panel-in container))
+        handle    (mount/hydrate-root! container frame-id [instance-key/screen {}])]
+    (-> (adopted!)
+        (.then (fn [ok]
+                 (close!)
+                 (stop!)
+                 {:handle    handle
+                  :container container
+                  :adopted?  ok
+                  :open-before? before
+                  :mismatches @seen
+                  :warnings   @captured})))))
+
+(defn- report! [label m]
+  (js/console.log (str ";; HICASSO SSR PAYLOAD-OBLIGATION " label " " (pr-str m)))
+  m)
+
+;; ===========================================================================
+;; The payload itself — the omission is a fact about the WIRE
+;; ===========================================================================
+
+(deftest the-two-rows-differ-by-exactly-the-ui-key
+  (testing "**the variable, isolated.** The two corpus rows render the
+           same hiccup from the same boot events, so the SERVER BYTES are
+           identical; the allowlist is the only thing that moves, and it
+           moves exactly one key. Without this row the two hydration rows
+           below could be measuring any difference at all between two
+           pages"
+    (let [green (server! green-id)
+          red   (server! red-id)
+          gdb   (:rf/app-db (:payload green))
+          rdb   (:rf/app-db (:payload red))]
+      (is (= (:html green) (:html red))
+          "the server rendered the same markup for both rows — the payload
+           policy is a decision about what CROSSES, never about what is
+           drawn")
+      (is (re-find #"class=\"panel-body\"" (:html green))
+          (str "and that markup carries the OPEN panel the boot event
+                wrote, so there is something for the payload to be
+                obliged about: " (:html green)))
+
+      (testing "the green row ships the instance state at the documented tier"
+        (is (= true (get-in gdb instance-key/state-path))
+            (str "[:ui ::open? \"billing\"] crossed the wire as written. Saw: "
+                 (pr-str gdb))))
+
+      (testing "the red row ships a WELL-FORMED allowlist that strands it"
+        (is (not (contains? rdb :ui))
+            (str "no :ui partition at all — not an empty one, not a
+                  defaulted one; absent: " (pr-str rdb)))
+        (is (nil? (get-in rdb instance-key/state-path))))
+
+      (testing "and everything else is identical, so `:ui` is the whole
+               difference"
+        (is (= (:panels gdb) (:panels rdb) instance-key/panels))
+        (is (= #{:panels :ui} (set (keys gdb))))
+        (is (= #{:panels} (set (keys rdb)))))
+
+      (testing "read off the EDN the client bootstrap actually parses,
+               because a claim about a payload map is a claim about the
+               wire only if the bytes agree with it"
+        (is (re-find #":ui\b" (:payload-edn green)))
+        (is (nil? (re-find #":ui\b" (:payload-edn red)))))
+
+      (report! "payload"
+               {:green-keys (vec (sort-by str (keys gdb)))
+                :red-keys   (vec (sort-by str (keys rdb)))
+                :green-edn-bytes (count (:payload-edn green))
+                :red-edn-bytes   (count (:payload-edn red))
+                :html-identical? (= (:html green) (:html red))}))))
+
+;; ===========================================================================
+;; Determinism — the instance keys are authored data
+;; ===========================================================================
+
+(deftest both-rows-render-byte-identical-documents-from-authored-keys
+  (testing "**the determinism row.** Every instance key on this page is an
+           `:id` out of the authored roster, so a double render must be
+           byte-identical — the two renders take two DIFFERENT per-request
+           gensym frames, which is also the standing proof that the
+           per-request id never reaches the wire. Stated over the document
+           bytes; see [[the-instance-key-rows-cannot-lean-on-the-render-hash]]
+           for why it could not be stated over the hash"
+    (doseq [row-id [green-id red-id]]
+      (let [{:keys [identical? differs-at] a :first b :second}
+            (entry/render-twice (fixtures/row row-id))]
+        (is identical?
+            (str "row " row-id " rendered two DIFFERENT documents"
+                 (when differs-at
+                   (str " — first difference at character " differs-at))))
+        (is (not= (:frame-id a) (:frame-id b))
+            (str "row " row-id " took two different per-request frames"))
+        (doseq [{ikey :id ptitle :title} instance-key/panels]
+          (is (re-find (re-pattern (str "data-ikey=\"" ikey "\"")) (:html a))
+              (str "the authored instance key " (pr-str ikey) " is in the
+                    markup as written — not an ordinal, not a counter, not
+                    a gensym"))
+          (is (re-find (re-pattern ptitle) (:html a))
+              "and so is the roster entry it was taken from"))))))
+
+(deftest the-instance-key-rows-cannot-lean-on-the-render-hash
+  (testing "**the exclusion, measured.** Spec 011's `:rf/render-hash` is
+           degenerate for an interpreted root — the hash is over a root
+           hiccup whose head is a function, and `canonical-edn` renders
+           every function identically (rf2-2rtt6.91). These rows take the
+           SAME hash as the dogfood screen, which is a different page
+           entirely, so no claim in this file is entitled to rest on it
+           and none does. If this row has gone red, rf2-2rtt6.91 has
+           landed and this file's premise needs re-reading"
+    (let [dogfood (:render-hash (entry/render (fixtures/row "dogfood-snapshot")))
+          green   (:render-hash (entry/render (fixtures/row green-id)))
+          red     (:render-hash (entry/render (fixtures/row red-id)))]
+      (is (= dogfood green red)
+          (str "still degenerate: " (pr-str [dogfood green red])))
+      (report! "render-hash" {:shared (str green)}))))
+
+;; ===========================================================================
+;; ROW 1 — GREEN. The obligation met.
+;; ===========================================================================
+
+(deftest naming-ui-on-the-allowlist-hydrates-with-zero-mismatch
+  (testing "**the obligation met.** `:ui` is on the allowlist, so the
+           panel the server's boot event opened crosses the wire, the
+           client's first render draws the same open panel, and React
+           finds nothing to reconcile — asserted on the framework's own
+           diagnostic AND on both channels React 19 complains through"
+    (async done
+      (if-not (mount/browser?)
+        (do (skip! ":node-test has no DOM") (done))
+        (let [{:keys [html payload]} (server! green-id)]
+          (client-frame! payload)
+          (is (= true (get-in (rf/app-db-value frame-id) instance-key/state-path))
+              "the client frame booted holding the instance state the
+               server wrote — which is the whole of what the allowlist
+               bought")
+          (-> (adopt! html nil)
+              (.then
+                (fn [{:keys [handle container adopted? open-before? mismatches warnings]}]
+                  (try
+                    (is (true? adopted?) "the adoption completed")
+                    (is (true? open-before?)
+                        "the panel was open in the bytes the client was
+                         handed, BEFORE any JavaScript adopted them")
+
+                    (is (= [] mismatches)
+                        (str "**zero `:rf.ssr/hydration-mismatch`.** The
+                              framework's own instrument stayed silent
+                              across the whole adoption. Saw: "
+                             (pr-str mismatches)))
+                    (is (= [] warnings)
+                        (str "and React reported nothing on either channel
+                              — `window` `error` or `console.error`: "
+                             (pr-str warnings)))
+
+                    (is (some? (open-panel-in container))
+                        "the panel is STILL open after adoption — open
+                         before, open after, which is what \"hydrated\"
+                         means for a page whose appearance is instance
+                         state")
+                    (is (server-node? (open-panel-in container))
+                        "and it is the SERVER'S own node. The stamp is an
+                         expando and cannot survive re-serialisation, so
+                         React reused the markup rather than building a
+                         replacement that happens to look alike")
+                    (is (every-server-node? container "*")
+                        "as is every element on the page — no partial
+                         adoption, which is what a mismatch on one subtree
+                         would look like")
+                    (is (= 2 (panel-count container))
+                        "both panels are there, so the row above is a
+                         claim about a page and not about an empty
+                         container")
+
+                    (report! "row-1-green"
+                             {:mismatches (count mismatches)
+                              :warnings   (count warnings)
+                              :panels     (panel-count container)
+                              :open-after? (some? (open-panel-in container))})
+                    (finally (mount/release! handle) (done)))))
+              (.catch (fn [e] (is false (str "row 1 threw: " e)) (done)))))))))
+
+;; ===========================================================================
+;; ROW 2 — RED BY DESIGN. The obligation broken, and caught.
+;; ===========================================================================
+
+(deftest omitting-ui-from-the-allowlist-fires-the-structured-mismatch
+  (testing "**the teaching witness, and it EXPECTS the error.** The same
+           page with `:ui` omitted: the client boots without the instance
+           state, its first render reads `reg-state`'s default and draws a
+           SHUT panel where the server's bytes say open, and the
+           structured `:rf.ssr/hydration-mismatch` fires. Asserted
+           positively — a row that merely documented the obligation, or
+           that passed because nothing happened, would be worth nothing.
+
+           **This row MANUFACTURES the fault and is the assertion about
+           it**, which is the one case `open-console-capture!`'s
+           `:swallow-uncaught?` exists for. `rf2-mwx08` is not softened:
+           the error is not unasserted here, it is the subject, and the
+           row goes on to assert that the door reported it as well as
+           emitting it"
+    (async done
+      (if-not (mount/browser?)
+        (do (skip! ":node-test has no DOM") (done))
+        (let [{:keys [html payload]} (server! red-id)]
+          (client-frame! payload)
+          (is (nil? (get-in (rf/app-db-value frame-id) instance-key/state-path))
+              "the client frame booted WITHOUT the instance state — the
+               entry is absent, so `reg-state`'s sub will read its
+               `:default`, which is `false`")
+          ;; MANUFACTURED fault, asserted on — see the testing string.
+          (-> (adopt! html {:swallow-uncaught? true})
+              (.then
+                (fn [{:keys [handle container adopted? open-before? mismatches warnings]}]
+                  (try
+                    (is (true? adopted?) "the adoption completed")
+                    (is (true? open-before?)
+                        "the server's bytes DID carry the open panel — the
+                         divergence is the payload's, not the render's")
+
+                    (is (pos? (count mismatches))
+                        (str "**the structured hydration-mismatch FIRED.**
+                              The taught obligation is enforced by the
+                              mismatch machinery, and this is that
+                              machinery answering. Saw "
+                             (count mismatches) ": " (pr-str mismatches)))
+                    (doseq [mm mismatches]
+                      (let [tags (tags-of mm)]
+                        (is (= :rf.ssr/hydration-mismatch (:operation mm)))
+                        (is (= 're-frame.bench.hicasso.arm1.mount/hydrate-root!
+                               (:where tags))
+                            "tier-discriminated by :where — the arm's hydrate
+                             door, so this is React's own reconciliation
+                             report and not a hash comparison")
+                        (is (= :warned-and-replaced (:recovery tags))
+                            "React had already patched the DOM when the
+                             callback ran")
+                        (is (string? (:error tags))
+                            "and the recoverable error's own message rides
+                             along")))
+
+                    (is (seq warnings)
+                        (str "and the complaint ALSO reached a console
+                              channel — the door composes over React's
+                              default rather than replacing it
+                              (rf2-2rtt6.97), so composing a diagnostic in
+                              did not make the mismatch quieter than React
+                              left it: " (pr-str warnings)))
+
+                    (is (nil? (open-panel-in container))
+                        "**and the client's model won, which is the cost.**
+                         The panel the server rendered open is SHUT on the
+                         adopted page: the server's work was thrown away
+                         and the user sees the default. That is what
+                         omitting `:ui` buys, stated as a DOM reading")
+                    (is (= 2 (panel-count container))
+                        "the rest of the page adopted normally — a stranded
+                         partition is a wrong screen, not a blank one")
+
+                    (report! "row-2-red-by-design"
+                             {:mismatches (count mismatches)
+                              :warnings   (count warnings)
+                              :where      (str (:where (tags-of (first mismatches))))
+                              :panels     (panel-count container)
+                              :open-after? (some? (open-panel-in container))})
+                    (finally (mount/release! handle) (done)))))
+              (.catch (fn [e] (is false (str "row 2 threw: " e)) (done)))))))))


### PR DESCRIPTION
Closes `rf2-2rtt6.99`.

`h/reg-state` (`rf2-2rtt6.98`) puts a widget's own state at `[:ui ::concern ikey]`, which is **app-space data** — so whether it reaches the client is decided by the hydration payload policy and by nothing else. The 2026-08-04 ruling states the obligation that follows: *an allowlist MUST name `:ui` whenever server-side events write render-affecting instance state; strip it only if the server never writes it.* This PR turns that sentence into two measurements taken on one page, plus the determinism row the bead asks for.

## Why prose was not enough

The payload policy is fail-closed and **stays** fail-closed here: an absent `:payload` still throws `:rf.error/ssr-missing-payload-policy` at the framework's own validator, and nothing in this PR softens, defaults or relaxes it (`ssr/entry-cljs-test`'s `the-payload-policy-is-fail-closed` is untouched and still green).

But `[:panels]` is a *perfectly well-formed* allowlist. There is no shape for the validator to refuse, no default to fall back on, and no way for the framework to know that `:ui` mattered on this page. **A policy that is fail-closed against absence is silent about omission** — so what catches the author who breaks the obligation is React, and since `rf2-2rtt6.97` the arm's hydrate door surfaces that as Spec 011's `:rf.ssr/hydration-mismatch`. That machinery *is* the enforcement, and the red row asserts it **positively**.

## The pair — same page, one variable

`ssr/instance_key.cljs` is the fixture: one `reg-state` concern (`::open?`, `:default false`), two disclosure panels instance-keyed by `:id` values out of an **authored roster**, and boot events that open the first panel server-side — `[[::seed] [::open? "billing" true]]`. Two corpus rows render it, and the second's allowlist is literally the first's minus `:ui` (`(conj instance-key/domain-keys :ui)` vs `instance-key/domain-keys`), so the allowlist is the only thing that moves.

Measured (`;; HICASSO SSR PAYLOAD-OBLIGATION` records, `RF2_VERBOSE_TESTS=1`):

```
payload             {:green-keys [:panels :ui], :red-keys [:panels],
                     :green-edn-bytes 208, :red-edn-bytes 137, :html-identical? true}
render-hash         {:shared "83b865f8"}
row-1-green         {:mismatches 0, :warnings 0, :panels 2, :open-after? true}
row-2-red-by-design {:mismatches 1, :warnings 1,
                     :where "re-frame.bench.hicasso.arm1.mount/hydrate-root!",
                     :panels 2, :open-after? false}
```

### Row 1 — GREEN, the obligation met

`:ui` on the allowlist. The client frame boots from the payload the server shipped and **holds the instance state** (asserted on `[:ui ::open? "billing"]` before anything mounts). Across the whole adoption: **zero** `:rf.ssr/hydration-mismatch`, **zero** complaints on either channel React 19 uses, the panel open *before* adoption and still open *after*, that panel node still carrying the server-node expando, and `every-server-node? container "*"` — X2-class node identity, so React **adopted** the markup rather than rebuilding a replacement that looks alike. Both panels present, so the equality is an equality of something.

### Row 2 — RED BY DESIGN, and this is the whole point

`:ui` omitted. The client frame boots **without** the entry (asserted: `nil` at `[:ui ::open? "billing"]`), `reg-state`'s sub reads its `false` default, the first render draws a shut panel where the server's bytes say open, and:

* **the structured error FIRES** — `(pos? (count mismatches))`, measured 1, and every event is checked for `:operation :rf.ssr/hydration-mismatch`, `:where 're-frame.bench.hicasso.arm1.mount/hydrate-root!` (tier-discriminated to the *door*, so this is React's own reconciliation report and not a hash comparison), `:recovery :warned-and-replaced`, and a string `:error` message;
* **the uncaught report is still there beside it** — `(seq warnings)`, measured 1. `rf2-2rtt6.97`'s reporter composes over React's default rather than replacing it, so composing a diagnostic in did not make the mismatch quieter. **`rf2-mwx08` is not softened**: `:swallow-uncaught?` is set at this one call site because the error is the row's own subject and is asserted on — the case that rule exists for is an *unasserted* throw;
* **the client's model won, and that is the cost** — `:open-after? false`. The panel the server rendered open is **shut** on the adopted page. The server's work was thrown away and the user sees a default. That DOM reading is the teaching, stated as a measurement.

### The two rows are each other's control

A diagnostic that fired on every adoption would agree with every page; a capture that never fired would agree with every page too. Row 1 is the "can it answer zero" control for row 2, and row 2 is the "is the silence a reading" control for row 1. Neither is worth reading without the other.

### Row 3 — determinism

Every instance key is an `:id` out of the authored roster — no ordinal, no counter, no `random-uuid`, no `useId`. `entry/render-twice` on **both** rows: documents byte-identical, `:differs-at` nil, and the two renders took two different per-request gensym frames (the standing proof the per-request id never reaches the wire). The authored keys are asserted present in the markup as written (`data-ikey="billing"`, `data-ikey="shipping"`). Both new rows also join `ssr/entry-cljs-test`'s existing corpus-wide `the-same-request-renders-byte-identical-documents` and `every-corpus-row-renders` loops for free.

## Not leaning on `:rf/render-hash` — measured, not promised

`the-instance-key-rows-cannot-lean-on-the-render-hash` takes the hash on both new rows **and** on the dogfood row: all three are `83b865f8`. The instrument is degenerate for an interpreted root exactly as `rf2-2rtt6.91` records, so no claim in this PR is *entitled* to rest on it — and every determinism claim is stated over the **document bytes** instead. The row mirrors `spike_cljs_test`'s wording: if it goes red, `rf2-2rtt6.91` has landed and the premise needs re-reading.

## Which channel the structured error is read from, and why not `thrown?`

The live trace stream — `re-frame.trace.tooling/register-listener!`, filtered on `(= :rf.ssr/hydration-mismatch (:operation ev))`. That is `arm1/hydrate-recoverable-dom-cljs-test`'s channel and the only place this diagnostic can be read: it fires from a React root-error callback, outside any dispatch scope, so it is **frameless** and never reaches a per-frame ring.

`(is (thrown? …))` would be wrong twice over. React routes a recoverable hydration error to `reportError`, so nothing throws on any stack `cljs.test` watches — a `thrown?` row would be **red over a working door**. And the error is precisely the thing the door has *recovered from*, so there is no exception left to catch even in principle. The `window` `error` and `console.error` channels are watched as well (`hydration-support/open-console-capture!`), and the capture window is **held open across the whole adoption** and closed only after `adopted!` resolves — `hydrateRoot` is called plain, so a capture that shut at the call's return would be shut across the only part that can complain (`rf2-2rtt6.87` measured 1 complaint across the adoption, 0 at the return).

## Fences

* **Bench lane only.** Nothing under `implementation/ssr` or `implementation/ssr-ring` is touched (R0 — Hicasso rides re-frame2's existing SSR story). No `spec/**`, no `decisions.md`, no `shadow-cljs.edn`, no `deps.edn`.
* **The ordinary render path is byte-for-byte unchanged.** The only edit to an existing code file is two rows appended to `fixtures/corpus` plus one require and one docstring bullet; `entry.cljs`, `mount.cljs`, `runtime.cljs` and `front/state.cljc` are untouched.
* **The ≤2-hook ledger is untouched and untouchable here.** `rt/shell-hook-ledger` is unchanged, `hook_ledger_dom_cljs_test` is unchanged, and nothing in this PR adds a hook: `reg-state` mints ordinary core artefacts and the fixture screen is two `defview`s reading subscriptions through the ambient collector. Both ledger fences ran green in `npm run test:browser`.
* No `node:` requires added (the lane compiles under a `:browser` build).

## Files

| File | Change |
|---|---|
| `implementation/freehand/test/re_frame/bench/hicasso/ssr/instance_key.cljs` | new — the fixture: concern, authored roster, screen, boot events |
| `implementation/freehand/test/re_frame/bench/hicasso/ssr/fixtures.cljs` | +2 corpus rows (`instance-key-payload`, `instance-key-payload-omitted`), +1 require, +1 docstring bullet |
| `implementation/freehand/test/re_frame/bench/hicasso/ssr/instance_key_payload_dom_cljs_test.cljs` | new — the witness: 5 deftests, 3 of which need no DOM |
| `docs/design/hicasso/studio/ssr-spike-witness.md` | +1 addendum section (the bead's "one paragraph appended to the SSR studio page") |

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/payload-2rtt6-99` (worker worktree; `sh scripts/assert-worker-worktree.sh` printed `WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/payload-2rtt6-99`, exit 0). `npm ci` run in **both** the root and `implementation/` — no `node_modules` junction; the mayor checkout's `implementation/node_modules` verified at 101 entries before and after.

| Gate | Exit | Reading |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | 0 | full spine PASS over the code diff (see note below) |
| `npm run test:cljs` | 0 | Ran **12578** tests containing **63048** assertions — 0 failures, 0 errors |
| `npm run test:browser` | 0 | Ran **1090** tests containing **6761** assertions — 0 failures, 0 errors |
| `npm run test:hicasso-compile` | 0 | **118** lane namespaces compiled, **0 warnings** |
| `clj-kondo` **pinned 2026.04.15** | 0 | **errors 0**, warnings 4534 (standing baseline); **zero findings on any file in this diff** |
| EP-0036 donor-boundary grep | 1 (no match) | `git grep -e 're-frame\.ui' -e 're_frame/ui' -e 're-frame2-ui' -- implementation/freehand` — clean |
| `npm run test:script-policy && npm run test:script-helpers` | 0 / 0 | both halves run separately, both green |

`scripts/check_doc_slugs.py` was additionally run standalone over the final tree: **exit 0**.

clj-kondo was run with `lint.yml`'s exact invocation:

```
clj-kondo --parallel --fail-level error \
  --lint implementation --lint examples --lint testbeds \
  --lint tools/xray --lint tools/machines-viz --lint tools/mcp-base \
  --lint tools/mcp-conformance --lint tools/re-frame2-pair-mcp \
  --lint tools/story --lint tools/story-mcp \
  --lint tools/template/src --lint tools/template/test
```

**`docs/design/**` is not covered by `mkdocs build --strict`** (`mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site), so the studio-page edit was verified **by hand**: it adds **one heading and no table and no intra-doc link**, changes no existing heading text, and the only inbound reference anywhere in `docs/` is a file link (`docs/design/hicasso/studio/README.md` → `ssr-spike-witness.md`), not an anchor. `scripts/check_doc_slugs.py` runs inside the fast-PR spine and covers the tree's link targets and heading anchors.

**Spine tiers NOT run locally**, enumerated rather than implied — CI owns them and this diff cannot reach them: `test:security`, `test:ui*` (all UI-artefact tiers), `test:bundle-isolation`, `test:perf-bundle`, `test:schemas-bundle`, `test:elision` / `test:freehand-evidence-elision` / `test:freehand-reachability`, `test:examples-compile`, `test:adapter-smokes`, `test:reagent-slim:*`, `test:xray-feature-gate`, `test:story-*`, `test:mcp-conformance`, `test:browser-schemas-boundary-prod`, `test:browser-prod-elision`, `test:cljs-perf-emit-nightly`, the JVM tool artefacts (`scripts/test-jvm-tools.sh`), and `scripts/test-rigorous-local.sh`. `shellcheck` is not installed on this host.

### One note about the spine run, stated rather than buried

The spine was run twice. The **first** run (exit **0**) covered the whole code diff but reported *"documentation surface unchanged → skipping doc gates"*, because it was launched before the studio-page commit. A **second** run was started over the final tree to pick the doc tier up — it reached `mkdocs --strict build` and the JVM tiers, and then died in `implementation JS harness helpers` with `bash: ./.github/scripts/report-changed-surfaces.sh: No such file or directory` for a script that plainly exists. It exists because **the worktree was removed underneath the run** (`git rev-parse` in it answers `fatal: not a git repository`; `git worktree list` no longer names it) — this PR had gone green and been merged, and the hygiene pass reclaimed the checkout. **That exit code is meaningless and is not reported as a gate result.** The doc surface is covered by `scripts/check_doc_slugs.py` (exit 0, final tree) — which is the only gate that reaches `docs/design/**` at all, since `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site. No junction was ever created, and the mayor checkout's `implementation/node_modules` was verified at 101 entries after the removal.

## Findings

None that required changing the rig. Two things worth recording:

1. **The witness needed no rig change at all.** `hydration_support`'s capture, `mount/hydrate-root!`'s reporter and `entry/render-twice` were all already the right shape; the two rows are composed out of them.
2. **The client boot door is `[:rf/set-db (:rf/app-db payload)]`, deliberately, and it is stated in the code.** That is exactly the slice `re-frame.ssr.hydrate/hydrate-event-handler` installs (`(or (:rf/app-db payload) db)`). Dispatching `:rf/hydrate` instead would mean loading the `re-frame.ssr` entry namespace, whose ns-load installs late-bind hooks (`:ssr/render-to-string`, `:ssr/on-frame-destroyed`, …) and seven `:rf.server/*` fxs into **every build this lane compiles in**, including the `:advanced` bench build the perf rows are taken on. The lane requires only leaf SSR namespaces for that reason and `ssr/entry.cljs` does the same. What is under test is the **content** of the payload, so the seeding door is deliberately the least interesting part of the row.
