### PR TITLE
fix(ci): Story full-gate runner changes execute the gate they define (rf2-65ajl)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -74,6 +74,14 @@ template_expensive=false
 mcp_conformance=false
 mcp_live=false
 story_xray_browser=false
+# rf2-65ajl — the FULL Story feature-load gate (`npm run test:story-feature-load`),
+# as distinct from the PR-SMOKE tier `story_xray_browser` gates. Its own output
+# because the two tiers run DIFFERENT COMMANDS: the smoke job runs
+# `test:xray-feature-gate:smoke` + `test:story-play-scripts`, neither of which
+# loads the full-gate runners. Arming `story_xray_browser` for a change to
+# tools/story/test/story_feature_load.cjs would therefore schedule a job that
+# still never executes the changed file. See is_story_full_gate_path below.
+story_full_gate=false
 tenant_switcher_smoke=false
 skills_structural=false
 playground=false
@@ -101,6 +109,7 @@ mark_all() {
   mcp_conformance=true
   mcp_live=true
   story_xray_browser=true
+  story_full_gate=true
   tenant_switcher_smoke=true
   skills_structural=true
   playground=true
@@ -274,6 +283,57 @@ is_story_xray_dom_test_path() {
   esac
 }
 
+# rf2-65ajl — predicate: is `$1` part of the FULL Story feature-load gate
+# itself — the two Playwright spec modules `npm run test:story-feature-load`
+# loads, or the run/serve orchestration that loads them? Returns 0 / 1.
+#
+# WHY IT IS NOT `story_xray_browser`. That output schedules the PR-SMOKE tier
+# (rf2-wa3oo), whose two steps are `test:xray-feature-gate:smoke` and
+# `test:story-play-scripts`. NEITHER command loads
+# tools/story/test/story_feature_load.cjs or story_browser_scenarios.cjs — only
+# `test:story-feature-load` does, and that command was nightly-only. So the gap
+# had two independent halves and closing either alone left the hole open:
+# the classifier did not arm on tools/story/test/** at all, AND the job the
+# output schedules would not have run the changed file if it had. #7472 changed
+# story_feature_load.cjs's COVERAGE_MATRIX, said in its body that CI would be
+# the first end-to-end exercise of the demoted row, and merged with the job
+# skipped (rf2-65ajl).
+#
+# The roster is the runner's own spec list plus the orchestration that stages
+# and serves it:
+#   * the two spec modules — `ALL_SPEC_FILES` in
+#     examples/scripts/run-story-feature-load-tests.cjs. A test in
+#     implementation/scripts/_changed-surfaces.test.cjs reads that array off the
+#     runner and asserts every entry is armed here, so a third spec added to the
+#     runner is armed on arrival rather than on the next audit.
+#   * run-story-feature-load-tests.cjs — the runner: it selects the spec
+#     modules, owns the per-spec timeout and the console/pageerror verdict.
+#   * serve-and-run-story-feature-load-tests.cjs — the orchestrator: it compiles
+#     the two Story testbeds, cleans + stages their HTML and serves them.
+#   * story-feature-load-port.cjs — the dedicated port resolver both launchers
+#     call before anything is compiled or served.
+#
+# Deliberately NOT the SHARED examples/scripts helpers (port-resolver.cjs,
+# examples-staging.cjs, examples-asset-manifest.cjs). Each is already armed for
+# `story_xray_browser`, and the PR-smoke tier RUNS `test:story-play-scripts`,
+# which calls resolveStoryFeatureLoadPort + cleanStageDirs over the same staged
+# output — so a break in a shared helper reds a job that already runs at PR
+# time. Paying for the full gate on top would buy no new signal.
+#
+# Deliberately NOT the rest of tools/story/test/**: an ordinary JVM `.clj` or a
+# CLJS unit suite there cannot change what the Playwright runner executes, and
+# they have their own lanes (tools_jvm, cljs_node_test, cljs_browser).
+is_story_full_gate_path() {
+  case "$1" in
+    tools/story/test/story_feature_load.cjs|tools/story/test/story_browser_scenarios.cjs)
+      return 0 ;;
+    examples/scripts/run-story-feature-load-tests.cjs|examples/scripts/serve-and-run-story-feature-load-tests.cjs|examples/scripts/story-feature-load-port.cjs)
+      return 0 ;;
+    *)
+      return 1 ;;
+  esac
+}
+
 if [ "$files" = "__ALL__" ]; then
   mark_all
 else
@@ -324,6 +384,19 @@ else
         examples_compile=true
         ;;
     esac
+
+    # rf2-65ajl — its own dispatch rather than an arm of the big `case` below,
+    # for the reason a POSIX `case` takes the FIRST match: the full gate's
+    # roster straddles two trees that already have arms there
+    # (`tools/story/*` and the examples/scripts launcher case), so an arm would
+    # have to be duplicated in both and could be shadowed by a future one added
+    # above it. A predicate consulted for every file cannot be shadowed. It only
+    # ever SETS `story_full_gate`, so it cannot narrow anything; the one
+    # deliberate narrowing this bead makes is in the examples/scripts launcher
+    # arms below, and is spelled out there.
+    if is_story_full_gate_path "$file"; then
+      story_full_gate=true
+    fi
 
     case "$file" in
       .github/workflows/test.yml|.github/workflows/expensive-tests.yml|.github/scripts/report-changed-surfaces.sh|TESTING.md)
@@ -502,16 +575,47 @@ else
         adapter_testbed_smokes=true
         ui_smoke=true
         ;;
-      examples/scripts/serve-and-run-story-feature-load-tests.cjs|examples/scripts/run-story-feature-load-tests.cjs|examples/scripts/serve-and-run-story-play-scripts.cjs|examples/scripts/story-feature-load-port.cjs)
+      examples/scripts/serve-and-run-story-feature-load-tests.cjs|examples/scripts/run-story-feature-load-tests.cjs)
+        # rf2-65ajl — the full gate's own orchestrator + runner. Their gate is
+        # `story_full_gate`, armed by is_story_full_gate_path above for every
+        # file in this arm, so nothing is set here.
+        #
+        # The arm exists to STOP the walk, and that is load-bearing: a POSIX
+        # `case` takes the first match, and with no arm of their own these two
+        # fall through to the generic `examples/*` case below, which arms
+        # cljs_node_test + cljs_browser. Neither compiles a line of CLJS — they
+        # are Node launchers — so the fall-through would put two heavy jobs on
+        # every edit to them, coverage they did not carry before and cannot use.
+        # (`examples_compile` still fires, from the first case block at the top
+        # of the loop, exactly as it did before.)
+        :
+        ;;
+      examples/scripts/serve-and-run-story-play-scripts.cjs|examples/scripts/story-feature-load-port.cjs)
         # rf2-y9o5e3 — the Story CI-as-test launchers + their dedicated
         # port resolver under examples/scripts/ are the executable
         # orchestration for `npm run test:story-feature-load` and
-        # `npm run test:story-play-scripts`, both of which run under the
-        # story-xray-browser PR job. A break in one of these launchers
+        # `npm run test:story-play-scripts`. A break in one of these launchers
         # (compile step, server staging, port resolution, runner spawn)
         # can break the Story browser gate, so editing one must fire that
         # gate — closing the false-green hole where the launcher could
         # break and still avoid the gate it drives.
+        #
+        # rf2-65ajl — the arm was right about the principle and wrong about
+        # which output carries it, for two of the four files it used to list.
+        # `story_xray_browser` schedules the PR-SMOKE tier, whose two steps are
+        # `test:xray-feature-gate:smoke` and `test:story-play-scripts`. These
+        # two files ARE on the play-script path — serve-and-run-story-play-
+        # scripts.cjs is the command, story-feature-load-port.cjs is the port
+        # resolver it calls — so the smoke tier really does execute them and
+        # they stay here. The other two, serve-and-run-story-feature-load-
+        # tests.cjs and run-story-feature-load-tests.cjs, are reachable from
+        # `npm run test:story-feature-load` and from nothing else: arming the
+        # smoke tier for them scheduled a job running two commands that never
+        # load them. They now arm `story_full_gate` (is_story_full_gate_path
+        # above), which schedules the step that DOES run them, and they are off
+        # this arm so a full-gate-only PR does not also pay for two smoke
+        # compiles it cannot affect. story-feature-load-port.cjs arms both,
+        # being on both paths.
         story_xray_browser=true
         ;;
       examples/scripts/port-resolver.cjs)
@@ -1791,6 +1895,7 @@ emit template_expensive "$template_expensive"
 emit mcp_conformance "$mcp_conformance"
 emit mcp_live "$mcp_live"
 emit story_xray_browser "$story_xray_browser"
+emit story_full_gate "$story_full_gate"
 emit tenant_switcher_smoke "$tenant_switcher_smoke"
 emit skills_structural "$skills_structural"
 emit playground "$playground"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,7 @@ jobs:
       mcp_conformance: ${{ steps.detect.outputs.mcp_conformance }}
       mcp_live: ${{ steps.detect.outputs.mcp_live }}
       story_xray_browser: ${{ steps.detect.outputs.story_xray_browser }}
+      story_full_gate: ${{ steps.detect.outputs.story_full_gate }}
       tenant_switcher_smoke: ${{ steps.detect.outputs.tenant_switcher_smoke }}
       skills_structural: ${{ steps.detect.outputs.skills_structural }}
       playground: ${{ steps.detect.outputs.playground }}
@@ -3366,7 +3367,15 @@ jobs:
   story-xray-browser:
     name: Story/Xray browser gates (PR-smoke)
     needs: detect_changed_surfaces
-    if: needs.detect_changed_surfaces.outputs.story_xray_browser == 'true'
+    # rf2-65ajl — two tiers, two conditions. `story_xray_browser` schedules the
+    # PR-smoke steps; `story_full_gate` schedules the full Story feature-load
+    # step. Either alone must open the job, and each step carries its own tier's
+    # condition, so a change to the full-gate runners does not pay for two smoke
+    # compiles it cannot affect and an ordinary Story/Xray runtime change keeps
+    # exactly the cheap path it had.
+    if: >-
+      needs.detect_changed_surfaces.outputs.story_xray_browser == 'true' ||
+      needs.detect_changed_surfaces.outputs.story_full_gate == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
@@ -3456,9 +3465,12 @@ jobs:
       #     assertion-strip :key fix stays covered on the PR critical
       #     path.
       #
-      # The full sweep (test:xray-feature-gate, test:story-feature-load,
-      # test:story-static) runs nightly in expensive-tests.yml.
+      # The rest of the full sweep (test:xray-feature-gate, test:story-static)
+      # still runs nightly in expensive-tests.yml. test:story-feature-load is
+      # the exception, and only for the PRs that change it — see the step at
+      # the end of this job (rf2-65ajl).
       - name: Run Xray feature browser gate (PR-smoke)
+        if: needs.detect_changed_surfaces.outputs.story_xray_browser == 'true'
         run: npm run test:xray-feature-gate:smoke
 
       # rf2-3qcxk — every Story variant whose body carries a
@@ -3469,7 +3481,36 @@ jobs:
       # single-testbed compile and is the live render path that exercises
       # the assertion-strip (rf2-5lw9w).
       - name: Run Story :play-script CI-as-test gate
+        if: needs.detect_changed_surfaces.outputs.story_xray_browser == 'true'
         run: npm run test:story-play-scripts
+
+      # rf2-65ajl — the half of the fix that lives in the job. Arming a
+      # changed-surface output is worthless if the job it schedules does not run
+      # the changed file, and that was the case here: the two steps above are
+      # the only commands this job ran, and NEITHER loads
+      # tools/story/test/story_feature_load.cjs or story_browser_scenarios.cjs.
+      # Only `npm run test:story-feature-load` does — it compiles the two Story
+      # testbeds, serves them, and drives both spec modules through Chromium —
+      # and it was nightly-only. #7472 changed story_feature_load.cjs's
+      # COVERAGE_MATRIX and said in its body that CI would be the first
+      # end-to-end exercise of the demoted row; the job was skipped, and had it
+      # run it would have executed neither command that loads the file.
+      #
+      # Gated on `story_full_gate`, which arms ONLY on the gate's own spec
+      # modules and its run/serve orchestration — not on ordinary Story/Xray
+      # runtime changes, which keep the cheaper smoke path above. So this adds
+      # nothing to the critical path of a normal Story/Xray PR: it runs on the
+      # rare PR that edits the runner itself, where it is the only step that
+      # exercises the diff at all. Cost when it does run is one extra testbed
+      # compile (login-form; counter-with-stories is already compiled by the
+      # play-script step, and both share this job's keyed .shadow-cljs cache)
+      # plus the two Playwright specs.
+      #
+      # The nightly sweep in expensive-tests.yml is unchanged and remains the
+      # system of record for the full matrix.
+      - name: Run the FULL Story feature-load gate (direct-runner change, rf2-65ajl)
+        if: needs.detect_changed_surfaces.outputs.story_full_gate == 'true'
+        run: npm run test:story-feature-load
 
       # rf2-315cf (Option B) — on a RED browser gate, upload the failed-run
       # evidence so the failure is a downloadable, off-CI post-mortem

--- a/TESTING.md
+++ b/TESTING.md
@@ -31,7 +31,7 @@ This table is also the command catalogue: each kind names the command that runs 
 | **MCP conformance, wire** — `test:mcp-conformance` (single entry point; per-suite scripts in `tools/mcp-conformance/`) | medium | Both servers honour the strict `CallToolResultSchema`; exec-safety helpers. |
 | **docs/cljs playground** — `tools-playground` job | medium | The live-CLJS-cell engine: builds both bundles, Chromium-smokes them, byte-diffs the committed esbuild bootstrap, and structurally validates the generated SCI bundle (untracked since rf2-tzy13 — built in-run, so it cannot be stale). `docs.yml` re-runs the build + smoke on deploy, so the shipped artifact is the smoked one. |
 | **MCP conformance, live** — `test:re-frame2-pair-live-hermetic-suite` | expensive | Real re-frame2-pair-mcp against a real shadow-cljs nREPL: eval cap, subscribe lifecycle, redaction, isError, cofx, event metadata. |
-| **Story gates** — `test:story-play-scripts` (PR smoke), `test:story-feature-load` + `test:story-static` (nightly) | expensive | Every variant's `:play-script` runs as a regression test; the full feature-load + static-export sweep runs nightly. |
+| **Story gates** — `test:story-play-scripts` (PR smoke), `test:story-feature-load` (nightly, plus PR when its own runners change), `test:story-static` (nightly) | expensive | Every variant's `:play-script` runs as a regression test; the full feature-load + static-export sweep runs nightly. |
 | **Xray gates** — `test:xray-feature-gate:smoke` (PR), `test:xray-feature-gate` (nightly) | medium / expensive | The Xray feature matrix; smoke = highest-signal scenarios over few staged surfaces, nightly = all scenarios, all surfaces. |
 | **Template emitted-app smoke** — `jvm-tools-template` job | expensive | The emitted app boots and passes its own gates, plus the `re-frame2-setup` day-one scaffold materialise-and-compile drift net. Behind `RF2_TEMPLATE_RUN_EMITTED_TESTS`. |
 
@@ -66,7 +66,9 @@ The classifier maps "what files changed" → "which expensive jobs fire." The fu
 3. **Nightly / manual** — `.github/workflows/expensive-tests.yml`. The rigorous browser/bundle matrix, unconditional all-examples compile, full Story/Xray sweeps, template smoke, live MCP conformance.
 4. **Release** — `.github/workflows/release.yml` plus the latest green expensive run on the release candidate.
 
-**The Story/Xray two-tier split.** The `story-xray-browser` PR job runs `test:xray-feature-gate:smoke` + `test:story-play-scripts`; the full sweep runs nightly. The dominant cost is testbed compilation, so both tiers share a keyed shadow-cljs compile cache that any source change busts. When adding an Xray scenario, tag it `smoke: true` (in `tools/xray/testbeds/feature_matrix/scenarios.cjs`) only if it earns a slot on every PR **and** loads an already-staged smoke surface; everything else is nightly by default. The gate fails loud if the smoke set is ever empty.
+**The Story/Xray two-tier split.** The `story-xray-browser` PR job runs `test:xray-feature-gate:smoke` + `test:story-play-scripts`; the full sweep runs nightly. The dominant cost is testbed compilation, so both tiers share a keyed shadow-cljs compile cache that any source change busts.
+
+One exception, and it is the exception that keeps the split honest (rf2-65ajl): a gate that is nightly-only cannot be *changed* safely, because the PR changing it runs nothing that loads it. `test:story-feature-load` therefore also runs at PR time on the PRs that edit its own two Playwright spec modules (`tools/story/test/story_feature_load.cjs`, `story_browser_scenarios.cjs`) or the run/serve orchestration that stages them — the `story_full_gate` surface. Ordinary Story/Xray runtime changes are untouched and keep the cheap smoke path; the nightly sweep remains the system of record for the full matrix. When adding an Xray scenario, tag it `smoke: true` (in `tools/xray/testbeds/feature_matrix/scenarios.cjs`) only if it earns a slot on every PR **and** loads an already-staged smoke surface; everything else is nightly by default. The gate fails loud if the smoke set is ever empty.
 
 ## Test authoring policy
 
@@ -129,7 +131,8 @@ The classifier is the **source of truth for "which jobs run when"** on a PR: the
 | `template_expensive` | `tools/template/*` changes | the emitted-app smoke |
 | `mcp_conformance` | any MCP server, mcp-base, or mcp-conformance changes | the MCP conformance jobs |
 | `mcp_live` | re-frame2-pair-mcp / mcp-base / mcp-conformance change | the live + hermetic MCP job |
-| `story_xray_browser` | runtime-extension files under `tools/{story,xray}/{src,testbeds}` change — specs, JVM tests, deps.edn, READMEs do **not** fire it (they can't affect chrome); core doesn't either | the PR-smoke browser job |
+| `story_xray_browser` | runtime-extension files under `tools/{story,xray}/{src,testbeds}` change — specs, JVM tests, deps.edn, READMEs do **not** fire it (they can't affect chrome); core doesn't either | the PR-smoke steps of the browser job |
+| `story_full_gate` | the full Story feature-load gate's own spec modules (`tools/story/test/story_{feature_load,browser_scenarios}.cjs`) or its run/serve orchestration change | the `test:story-feature-load` step of the browser job |
 | `tenant_switcher_smoke` | `testbeds/tenant_switcher/**` or `implementation/scripts/serve-and-run-tenant-switcher-testbed.cjs` change | the `tenant-switcher-testbed-smoke` browser job |
 | `skills_structural` | `skills/re-frame2-pair/*`, `skills/re-frame2-setup/*`, or `skills/shared/*` change | `skills-structural` |
 | `playground` | the playground tool, the committed esbuild bootstrap bundle, the SCI input-digest script, or a change to any tree baked into the SCI bundle — `implementation/core/*`, `implementation/adapters/reagent-slim/*`, `implementation/machines/*`, `implementation/flows/*` (rf2-tzy13) | `tools-playground` |

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -72,9 +72,23 @@ test('Xray spec-only .md changes do NOT trigger story_xray_browser (rf2-k9ekz)',
   assert.equal(result.story_xray_browser, 'false');
 });
 
-test('Story test-only changes do NOT trigger story_xray_browser (rf2-k9ekz)', () => {
-  const result = classify('tools/story/test/story_feature_load.cjs');
-  assert.equal(result.story_xray_browser, 'false');
+// rf2-65ajl — this row's exemplar USED to be
+// tools/story/test/story_feature_load.cjs, pinned to false. The assertion was
+// correct about the behaviour and wrong about the intent: that file is the
+// FULL Story feature-load gate's own Playwright spec, and pinning it here read
+// as a considered decision that no browser gate needs to run for it. What was
+// actually true is narrower — the PR-SMOKE tier must not run for it, because
+// neither of the smoke's two commands loads it. The full gate must. So the row
+// keeps its claim with an exemplar that really is inert (a JVM unit test), and
+// story_feature_load.cjs is now covered POSITIVELY by the story_full_gate rows
+// further down, where its own gate is asserted to run.
+test('Story test-tree changes do NOT trigger the story_xray_browser PR-smoke tier (rf2-k9ekz)', () => {
+  const exemplar = 'tools/story/test/re_frame/story_decorator_chain_test.clj';
+  assert.ok(
+    fs.existsSync(path.join(REPO_ROOT, exemplar)),
+    `${exemplar} must exist — this row's whole claim is "a real JVM unit test"`,
+  );
+  assert.equal(classify(exemplar).story_xray_browser, 'false');
 });
 
 test('Xray test-only changes do NOT trigger story_xray_browser (rf2-k9ekz)', () => {
@@ -1786,14 +1800,92 @@ test('PR story-xray-browser job keeps the Story :play-script gate (assertion-str
   assert.match(block, /npm run test:story-play-scripts/);
 });
 
-test('PR story-xray-browser job does NOT run the full sweep (moved to nightly, rf2-wa3oo)', () => {
+// rf2-65ajl — this row USED to assert `test:story-feature-load` was absent
+// from the PR job outright. That pin is what made the second half of the
+// false-green permanent: a PR could change the full gate's own runner and no
+// PR-time command would load it, because the only command that does was pinned
+// out. The tier split it was defending is real and is kept — the full sweep
+// does not belong on every Story/Xray PR — but "not on every PR" is not "on no
+// PR". The command is now present and CONDITIONAL, so the claim becomes: it
+// runs only under story_full_gate.
+// Return the step that RUNS `command`: from its `- name:` header through the
+// `run:` line, so the step's own `if:` is inside and a neighbour's is not.
+// Anchored on `run: ` deliberately — every one of these commands is also named
+// in the surrounding prose, and a `.includes()` over a comment would let a
+// step's condition be read off the wrong step (which is how the first draft of
+// this row passed against the smoke step's `if:`).
+function stepRunning(block, command) {
+  const marker = `run: ${command}`;
+  const idx = block.indexOf(marker);
+  if (idx === -1) return null;
+  const start = block.lastIndexOf('\n      - name:', idx);
+  return start === -1 ? null : block.slice(start, idx + marker.length);
+}
+
+test('PR story-xray-browser job runs the FULL feature-load gate, gated on story_full_gate (rf2-65ajl)', () => {
   const block = storyXrayJobBlock(fs.readFileSync(WORKFLOW, 'utf8'));
-  assert.doesNotMatch(block, /npm run test:story-feature-load/);
+  // The command and its condition must be in the SAME step, or the gate is
+  // either unconditional (nightly cost on every Story PR) or dead.
+  const step = stepRunning(block, 'npm run test:story-feature-load');
+  assert.ok(
+    step,
+    'the PR job must RUN the one command that loads the full-gate runners',
+  );
+  assert.match(
+    step,
+    /if:\s*needs\.detect_changed_surfaces\.outputs\.story_full_gate == 'true'/,
+    'the full feature-load step must be gated on story_full_gate',
+  );
+});
+
+test('PR story-xray-browser job still keeps the rest of the sweep nightly (rf2-wa3oo)', () => {
+  const block = storyXrayJobBlock(fs.readFileSync(WORKFLOW, 'utf8'));
   assert.doesNotMatch(block, /npm run test:story-static/);
   // The non-smoke (full-matrix) Xray gate must not run at PR time. The
   // `:smoke` suffix is intentionally allowed; assert the bare invocation
   // (followed by end-of-line, not `:smoke`) is absent.
   assert.doesNotMatch(block, /npm run test:xray-feature-gate(?!:smoke)/);
+});
+
+test('PR story-xray-browser job opens for EITHER tier (rf2-65ajl)', () => {
+  // A full-gate-only change leaves story_xray_browser false, so a job condition
+  // reading only that output would skip the job and the new step with it — the
+  // same hole one level up.
+  const block = storyXrayJobBlock(fs.readFileSync(WORKFLOW, 'utf8'));
+  const header = block.slice(0, block.indexOf('steps:'));
+  assert.match(header, /outputs\.story_xray_browser == 'true'/);
+  assert.match(header, /outputs\.story_full_gate == 'true'/);
+  assert.match(header, /\|\|/, 'the two tier conditions must be a disjunction');
+});
+
+test('the two PR-smoke steps are gated on story_xray_browser (rf2-65ajl)', () => {
+  // The converse of the row above: a full-gate-only PR must not pay for two
+  // smoke testbed compiles whose commands its diff cannot reach.
+  const block = storyXrayJobBlock(fs.readFileSync(WORKFLOW, 'utf8'));
+  for (const command of [
+    'npm run test:xray-feature-gate:smoke',
+    'npm run test:story-play-scripts',
+  ]) {
+    const step = stepRunning(block, command);
+    assert.ok(step, `${command} must live in a named step`);
+    assert.match(
+      step,
+      /if:\s*needs\.detect_changed_surfaces\.outputs\.story_xray_browser == 'true'/,
+      `${command} must be gated on story_xray_browser`,
+    );
+  }
+});
+
+test('detect_changed_surfaces exports story_full_gate (rf2-65ajl)', () => {
+  // The classifier can emit an output and the workflow still never see it: a
+  // job reads `needs.<job>.outputs.<name>`, which resolves to the empty string
+  // unless the producing job DECLARES it. An undeclared output makes every
+  // `== 'true'` false — a gate that can never fire, and silently.
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'detect_changed_surfaces');
+  assert.match(
+    block,
+    /story_full_gate: \$\{\{ steps\.detect\.outputs\.story_full_gate \}\}/,
+  );
 });
 
 test('Nightly expensive workflow runs the full Story/Xray sweep (rf2-wa3oo)', () => {
@@ -1888,18 +1980,158 @@ for (const file of ADAPTER_SMOKE_GATE_FILES) {
   });
 }
 
-const STORY_GATE_FILES = [
-  'examples/scripts/serve-and-run-story-feature-load-tests.cjs',
-  'examples/scripts/run-story-feature-load-tests.cjs',
+// rf2-65ajl — this roster used to be four files all asserted to fire
+// story_xray_browser. Two of them are not on the PR-smoke tier's path at all:
+// the smoke runs `test:xray-feature-gate:smoke` + `test:story-play-scripts`,
+// and serve-and-run-story-feature-load-tests.cjs / run-story-feature-load-
+// tests.cjs are reachable from `npm run test:story-feature-load` and nothing
+// else. They move to the story_full_gate roster below, where the output
+// schedules the step that actually runs them.
+const STORY_SMOKE_GATE_FILES = [
   'examples/scripts/serve-and-run-story-play-scripts.cjs',
   'examples/scripts/story-feature-load-port.cjs',
 ];
-for (const file of STORY_GATE_FILES) {
+for (const file of STORY_SMOKE_GATE_FILES) {
   test(`${file} fires story_xray_browser (rf2-y9o5e3)`, () => {
     const result = classify(file);
     assert.equal(result.story_xray_browser, 'true');
   });
 }
+
+// rf2-65ajl — the FULL Story feature-load gate. Two independent halves had to
+// close together: the classifier armed nothing for tools/story/test/**, and the
+// job story_xray_browser schedules ran neither command that loads those files.
+// These rows pin the first half; the workflow rows above pin the second.
+
+const STORY_FULL_GATE_FILES = [
+  'tools/story/test/story_feature_load.cjs',
+  'tools/story/test/story_browser_scenarios.cjs',
+  'examples/scripts/serve-and-run-story-feature-load-tests.cjs',
+  'examples/scripts/run-story-feature-load-tests.cjs',
+  'examples/scripts/story-feature-load-port.cjs',
+];
+for (const file of STORY_FULL_GATE_FILES) {
+  test(`${file} fires story_full_gate (rf2-65ajl)`, () => {
+    const result = classify(file);
+    assert.equal(result.story_full_gate, 'true');
+  });
+}
+
+test('the full-gate launchers do not fall through to the generic examples fan-out (rf2-65ajl)', () => {
+  // Moving these two off the story_xray_browser arm left them with no arm of
+  // their own, so a POSIX `case` walked on to the generic `examples/*` case and
+  // silently armed cljs_node_test + cljs_browser — two heavy jobs, on two Node
+  // launchers that compile no CLJS. They have a dedicated no-op arm now whose
+  // only job is to stop the walk; this row is what keeps it there.
+  for (const file of [
+    'examples/scripts/serve-and-run-story-feature-load-tests.cjs',
+    'examples/scripts/run-story-feature-load-tests.cjs',
+  ]) {
+    const result = classify(file);
+    assert.equal(result.story_full_gate, 'true', file);
+    assert.equal(result.cljs_browser, 'false', file);
+    assert.equal(result.cljs_node_test, 'false', file);
+    // The one arm they kept: they are under examples/, so the examples-compile
+    // roster still fires, exactly as it did before this bead.
+    assert.equal(result.examples_compile, 'true', file);
+    // And the smoke tier they were wrongly on: neither smoke command loads
+    // them, so it must not fire.
+    assert.equal(result.story_xray_browser, 'false', file);
+  }
+});
+
+test('the play-script launcher stays on the smoke tier only (rf2-65ajl)', () => {
+  // The converse control. serve-and-run-story-play-scripts.cjs IS the command
+  // the smoke tier runs, so it must keep story_xray_browser and must NOT drag
+  // the full gate along.
+  const result = classify('examples/scripts/serve-and-run-story-play-scripts.cjs');
+  assert.equal(result.story_xray_browser, 'true');
+  assert.equal(result.story_full_gate, 'false');
+});
+
+test('every spec module the full-gate runner loads is armed (rf2-65ajl)', () => {
+  // The teeth. Read the roster off the RUNNER rather than trusting the list
+  // above: `ALL_SPEC_FILES` in run-story-feature-load-tests.cjs is what
+  // `npm run test:story-feature-load` actually executes, so a third spec added
+  // there is armed on arrival rather than on the next audit. Names, not counts.
+  const runner = path.join(
+    REPO_ROOT,
+    'examples',
+    'scripts',
+    'run-story-feature-load-tests.cjs',
+  );
+  const source = fs.readFileSync(runner, 'utf8');
+  const block = source.slice(
+    source.indexOf('const ALL_SPEC_FILES'),
+    source.indexOf('];', source.indexOf('const ALL_SPEC_FILES')),
+  );
+  assert.ok(block, 'ALL_SPEC_FILES not found in the full-gate runner');
+  const specs = [...block.matchAll(/path\.join\(REPO_ROOT,\s*([^)]+)\)/g)].map((m) =>
+    m[1]
+      .split(',')
+      .map((part) => part.trim().replace(/^['"]|['"]$/g, ''))
+      .filter(Boolean)
+      .join('/'),
+  );
+  assert.ok(specs.length > 0, 'expected the runner to declare at least one spec module');
+  for (const spec of specs) {
+    assert.ok(
+      fs.existsSync(path.join(REPO_ROOT, spec)),
+      `${spec} is listed in ALL_SPEC_FILES but does not exist — the parse has rotted`,
+    );
+    assert.equal(
+      classify(spec).story_full_gate,
+      'true',
+      `${spec} is executed by npm run test:story-feature-load but does not arm story_full_gate`,
+    );
+  }
+});
+
+test('ordinary Story/Xray runtime changes keep the cheap smoke path (rf2-65ajl)', () => {
+  // The bead's second criterion. A src/testbed change must NOT drag the full
+  // sweep onto the critical path — it gets the smoke tier it already had.
+  for (const file of [
+    'tools/story/src/re_frame/story.cljc',
+    'tools/story/testbeds/counter_with_stories/stories.cljs',
+    'tools/xray/src/day8/re_frame2_xray/core.cljs',
+    'tools/xray/testbeds/edn_inspector/core.cljs',
+    // The Xray gate's own scenario roster is the instructive contrast: unlike
+    // the Story runners, `test:xray-feature-gate:smoke` — a command the smoke
+    // tier already runs — reads this file, so the cheap tier really does
+    // exercise it and it needs no second output.
+    'tools/xray/testbeds/feature_matrix/scenarios.cjs',
+  ]) {
+    assert.ok(
+      fs.existsSync(path.join(REPO_ROOT, file)),
+      `${file} must exist — this row pins the routing of a REAL runtime file`,
+    );
+    const result = classify(file);
+    assert.equal(result.story_xray_browser, 'true', file);
+    assert.equal(result.story_full_gate, 'false', file);
+  }
+});
+
+test('unrelated JVM / unit-test-only changes arm NEITHER browser tier (rf2-65ajl negative control)', () => {
+  // The bead's fourth criterion. The expensive browser job must stay off
+  // changes that cannot reach a browser at all.
+  for (const file of [
+    // Real files, not hypotheticals: a negative control that pins a path
+    // nothing produces any more is permanently, silently green.
+    'tools/story/test/re_frame/story_decorator_chain_test.clj',
+    'tools/story/test/re_frame/story_cljs_test.cljs',
+    'tools/xray/test/day8/re_frame2_xray/config_test.clj',
+    'implementation/core/src/re_frame/core.cljc',
+    'spec/Conventions.md',
+  ]) {
+    assert.ok(
+      fs.existsSync(path.join(REPO_ROOT, file)),
+      `${file} must exist — a negative control on a phantom path is vacuous`,
+    );
+    const result = classify(file);
+    assert.equal(result.story_full_gate, 'false', file);
+    assert.equal(result.story_xray_browser, 'false', file);
+  }
+});
 
 test('examples/scripts/port-resolver.cjs (shared resolver) fires BOTH browser gates (rf2-y9o5e3)', () => {
   const result = classify('examples/scripts/port-resolver.cjs');


### PR DESCRIPTION
Closes rf2-65ajl.

`report-changed-surfaces.sh` did not arm anything for `tools/story/test/**`, **and** the job it would have armed runs neither command that loads those files. Either fix alone leaves the hole open, so both are here.

## (a) The classifier armed nothing for the full gate's own runners

`story_xray_browser` fires only for a runtime extension under `tools/{story,xray}/{src,testbeds}/**`, so a direct change to `tools/story/test/story_feature_load.cjs` classified **every** output false. New output `story_full_gate`, armed by `is_story_full_gate_path` on the five files that constitute the gate: the two Playwright spec modules `npm run test:story-feature-load` loads, plus `run-story-feature-load-tests.cjs`, `serve-and-run-story-feature-load-tests.cjs` and `story-feature-load-port.cjs`.

Deliberately **not** the shared `examples/scripts` helpers (`port-resolver.cjs`, `examples-staging.cjs`, `examples-asset-manifest.cjs`). Each is already armed for `story_xray_browser`, and the smoke tier *runs* `test:story-play-scripts`, which calls `resolveStoryFeatureLoadPort` + `cleanStageDirs` over the same staged output — a break in a shared helper already reds a job that already runs at PR time. Paying for the full gate on top would buy no new signal.

Deliberately **not** the rest of `tools/story/test/**`: a JVM `.clj` or a CLJS unit suite there cannot change what the Playwright runner executes, and each has its own lane.

## (b) The job would not have run the changed file even so

The `story-xray-browser` job ran exactly two commands — `test:xray-feature-gate:smoke` and `test:story-play-scripts` — and **neither loads either spec module**. Only `npm run test:story-feature-load` does, and it was nightly-only. It is now a step in that job, gated on `story_full_gate`; the two smoke steps are gated on `story_xray_browser`; the job opens for either tier.

The job is already in `all-required-passed`, so no aggregator change was needed and the new step is required coverage from the first PR that arms it.

**Workflow edit size: 9 functional lines added, 1 replaced** (one output declaration, a 3-line job disjunction replacing a 1-line condition, two step `if:`s, one 3-line step). The other 38 added lines are comment. Nothing else in `.github/workflows/**` is touched — the hot-zone edit is confined to `test.yml`'s `detect_changed_surfaces` outputs block and the `story-xray-browser` job.

## Two corrections to the brief I was given

- The pinned-to-false assertion is **not** the only pin that kept this hole open. `_changed-surfaces.test.cjs` also carried `PR story-xray-browser job does NOT run the full sweep`, asserting `assert.doesNotMatch(block, /npm run test:story-feature-load/)` — a workflow-level pin forbidding the fix for half (b) outright. Both are changed here, deliberately, and both are described below.
- `examples/scripts/serve-and-run-story-feature-load-tests.cjs` and `run-story-feature-load-tests.cjs` were **already** armed by rf2-y9o5e3 — for `story_xray_browser`, i.e. for a job that ran two commands that never load them. That arm was fail-open in the same shape as the missing one, not merely absent.

## The pinned assertions, and what they became

| was | is | why deliberate |
| --- | --- | --- |
| `Story test-only changes do NOT trigger story_xray_browser` with exemplar `tools/story/test/story_feature_load.cjs` → `false` | same claim, exemplar swapped to the real JVM unit test `story_decorator_chain_test.clj` | The assertion was **correct about behaviour and wrong about intent**. What is true is narrower than it read: the PR-*smoke* tier must not run for the full gate's spec module, because neither smoke command loads it. The *full* gate must. Pinning the file here read as a considered ruling that no browser gate need run for it. `story_feature_load.cjs` is now covered **positively**, by the `story_full_gate` rows. |
| `PR story-xray-browser job does NOT run the full sweep` → `test:story-feature-load` absent from the job | the command is present and **conditional**: present in a step gated on `story_full_gate` | The tier split it defended is real and is kept — the full sweep does not belong on every Story/Xray PR. But "not on every PR" is not "on no PR", and asserting absence is what made half (b) permanent. `test:story-static` and the bare `test:xray-feature-gate` are still asserted absent, in a separate row. |

Every exemplar the new rows pin is asserted to **exist** — a negative control on a phantom path is permanently, silently green, which is the failure mode `rf2-vxgfnd.90`'s donor-test row already found once in this file.

## Mutation proofs — both halves, both directions

Forward is not enough; each is broken and the named red recorded.

| # | mutation | result |
| --- | --- | --- |
| a-fwd | none — as shipped | `tools/story/test/story_feature_load.cjs` → `story_full_gate=true`, `story_xray_browser=false` |
| a-rev | `is_story_full_gate_path` roster replaced with a sentinel that matches nothing | **6 named tests red**: the five `… fires story_full_gate (rf2-65ajl)` rows **plus** `every spec module the full-gate runner loads is armed (rf2-65ajl)` |
| b-fwd | none — as shipped | `npm run test:story-feature-load` run locally to completion, **exit 0**, twice; it loaded and executed **both** spec modules (`Ran 2 Story feature-load specs. 0 failures.`) |
| b-rev-1 | the step's `run: npm run test:story-feature-load` replaced with `run: echo mutation` | **red**: `PR story-xray-browser job runs the FULL feature-load gate, gated on story_full_gate (rf2-65ajl)` — *"the PR job must RUN the one command that loads the full-gate runners"* |
| b-rev-2 | job `if` reverted to the single `story_xray_browser` condition **and** the `story_full_gate` output declaration deleted | **2 named tests red**: `PR story-xray-browser job opens for EITHER tier` and `detect_changed_surfaces exports story_full_gate` |
| c-rev | the two launchers' no-op stop arm removed, restoring the fall-through | **red**: `the full-gate launchers do not fall through to the generic examples fan-out (rf2-65ajl)` |

`b-rev-2` covers the two ways this gate could be wired and still never fire: a job that is never scheduled, and an output the producing job never declares (`needs.<job>.outputs.<undeclared>` resolves to the empty string, so every `== 'true'` is false — silently).

The first draft of the b-rev-1 row **passed against the wrong step**: `.split(/\n {6}- name:/).find(s => s.includes(command))` matched the play-script chunk, because the comment introducing the new step names the command. The rows now anchor on `run: <command>` and walk back to the enclosing `- name:`, so a step's condition can only be read off that step. That near-miss is recorded in a comment at `stepRunning`.

The wiring was also checked structurally, by parsing the YAML rather than by regex over its text:

```
JOB IF: "…story_xray_browser == 'true' || …story_full_gate == 'true'"
STEP: Run Xray feature browser gate (PR-smoke)          | if: …story_xray_browser == 'true'  | run: npm run test:xray-feature-gate:smoke
STEP: Run Story :play-script CI-as-test gate            | if: …story_xray_browser == 'true'  | run: npm run test:story-play-scripts
STEP: Run the FULL Story feature-load gate (rf2-65ajl)  | if: …story_full_gate == 'true'     | run: npm run test:story-feature-load
OUTPUT DECLARED: True     IN AGGREGATOR: True
```

### Half (b) also fires on this PR

Not a claim about the future: this diff touches `.github/workflows/test.yml`, `.github/scripts/report-changed-surfaces.sh` and `TESTING.md`, each of which is in the classifier's `mark_all` roster. Classified through the **git-derived discovery path** (the real CI path, not the explicit-path helper):

```
$ git diff --no-renames --name-only HEAD^ HEAD | ./.github/scripts/report-changed-surfaces.sh
story_xray_browser=true
story_full_gate=true
```

So the required `story-xray-browser` job runs `npm run test:story-feature-load` **on this PR**. And a runner-only diff, built as a real two-commit scratch repo and classified through the same discovery branch, arms the full gate and *only* the full gate:

```
tools/story/test/story_feature_load.cjs changed →
  story_full_gate=true   story_xray_browser=false   cljs_browser=false
```

## Cost of the newly-armed PR-time gate — reported, not buried

Measured locally, Windows, warm `~/.m2`:

| run | wall clock | testbed compiles |
| --- | --- | --- |
| cold `.shadow-cljs` (fresh worktree) | **3 min 55 s** | included |
| warm `.shadow-cljs` | **3 min 25 s** | 15.8 s + 4.1 s (689 files, 0 compiled) |

So ~3 minutes of it is Playwright and ~20–50 s is compile. On CI the job already pays JDK / Node / Chromium / Maven / `.shadow-cljs` setup at job level, and the keyed shadow cache is the one this job already maintains.

**Who pays.** Only a PR whose diff includes one of the five full-gate files. That is not a widening of the nightly budget onto ordinary work:

- an ordinary Story/Xray runtime PR (`src/**`, `testbeds/**`) runs **exactly what it ran before** — the two smoke steps, now explicitly gated on the output that always drove them;
- a full-gate-runner-only PR runs **only** the new step: the two smoke steps are skipped, because `serve-and-run-story-feature-load-tests.cjs` / `run-story-feature-load-tests.cjs` were moved off `story_xray_browser` (they are reachable from `test:story-feature-load` and nothing else). Such a PR is therefore **cheaper** than the same PR is on `main` today, where it pays two smoke compiles for commands its diff cannot reach;
- nightly `expensive-tests.yml` is untouched and remains the system of record.

**A cheaper targeted invocation was considered and rejected.** `run-story-feature-load-tests.cjs` honours `STORY_FEATURE_LOAD_SPEC`, so the job could run one spec module instead of two. It would save roughly half of ~3 minutes and cost the property that makes the gate trustworthy: the orchestrator compiles and serves *both* testbeds regardless, the two modules share `spec-helpers.cjs` and the staged surfaces, and `story_browser_scenarios.cjs` is the declared owner of assertions `story_feature_load.cjs`'s matrix demotes to it (see below) — splitting them would let a demotion point at an owner the same run never executed. The bead also asks in terms for a check that executes `npm run test:story-feature-load`. Three minutes on a five-file surface is the cheaper thing to buy.

## PR #7472's demoted `owned-by` row: it holds

#7472 demoted `reg-decorator composition` to `kind: 'owned-by'` and its body said CI would be the first end-to-end exercise of that row. CI skipped the job, so until this run **nothing had ever run it**. It has now been run:

- `validateCoverageMatrix()` accepts the row — the gate calls it before any probe, and the gate exits 0;
- the row is reported as declared-out-of-scope in **both** phases: `reg-decorator composition (owned-by: npm run test:cljs + story_browser_scenarios.cjs)`;
- every owner it names exists, and the browser-side owner **ran green in the same run**: `story_browser_scenarios.cjs:389` `substrate-decorator-and-frame-isolation` asserts `decorator: story-level` and `decorator: variant-level` verbatim (lines 393–394), and that spec module reported 0 failures;
- the two CLJS owners are present as named: `reg_variant_e2e_cljs_test.cljs:217` `clicked-three-times-runs-clean-count-3`, and `render_shell_cljs_test.cljs:346/361` `render-decorated-view-bare-when-no-decorators` / `render-variant-and-canvas-resolve-same-inherited-decorators`.

The work on `main` holds. It was simply never exercised, which is the bug this PR fixes rather than a defect in that PR.

## One near-miss worth recording

Moving `serve-and-run-story-feature-load-tests.cjs` and `run-story-feature-load-tests.cjs` off the `story_xray_browser` arm left them with no arm of their own, so they fell through to the generic `examples/*` case and silently picked up `cljs_node_test` + `cljs_browser` — two heavy jobs, on two Node launchers that compile no CLJS. Caught by diffing each of the five files' classification against `HEAD^` rather than by reading the change. They now have a dedicated no-op arm whose whole job is to stop the walk, and the before/after is exact:

| file | on `main` | on this branch |
| --- | --- | --- |
| `serve-and-run-story-feature-load-tests.cjs` | `examples_compile`, `story_xray_browser` | `examples_compile`, `story_full_gate` |
| `run-story-feature-load-tests.cjs` | `examples_compile`, `story_xray_browser` | `examples_compile`, `story_full_gate` |
| `serve-and-run-story-play-scripts.cjs` | `examples_compile`, `story_xray_browser` | unchanged |
| `story-feature-load-port.cjs` | `examples_compile`, `story_xray_browser` | + `story_full_gate` |
| `story_feature_load.cjs` | `tools_jvm`, `template_expensive`, `mcp_conformance` | + `story_full_gate` |
| `story_browser_scenarios.cjs` | `tools_jvm`, `template_expensive`, `mcp_conformance` | + `story_full_gate` |

## New teeth: the roster reads off the runner

`every spec module the full-gate runner loads is armed (rf2-65ajl)` parses `ALL_SPEC_FILES` out of `run-story-feature-load-tests.cjs` — what the command actually executes — and asserts each entry exists and arms `story_full_gate`. A third spec module added to the runner is armed on arrival rather than on the next audit. It is one of the six reds in mutation a-rev, so it is not a decoration.

## Not in scope

- The job's display name still reads `(PR-smoke)`. Renaming a job's `name:` changes the check-run name the branch ruleset matches, which is not a risk worth taking inside a CI-correctness fix. Noted, not changed.
- `tools/story/test/*.cjs` also fans out to `tools_jvm` / `mcp_conformance` / `template_expensive` through the generic `tools/story/*` arm. Arguably too wide for a Playwright `.cjs`, but narrowing it removes coverage and is a separate judgement; untouched here.
- `rf2-13zre` owns enumerating the gates the fast-PR spine does not run. Nothing here changes what that bead documents.

**Filed, not fixed: `rf2-9n2cv`.** Sweeping the nightly-only commands for the same shape found one live sibling. `implementation/scripts/check-story-static.cjs` **is** the `npm run test:story-static` gate (the command is `node scripts/check-story-static.cjs`), no job in `test.yml` runs that command, and the classifier routes the file through the generic `implementation/scripts/*` arm — arming `cljs_node_test`, `cljs_browser`, `cljs_prod`, `bundle_isolation`, `reagent_slim_bundle`, not one of which schedules a job that runs it. Identical false-green, different gate. The bead also flags `test:xray-feature-gate`'s non-smoke scenario rows, `test:xray` and `test:exec-safety` as untraced. Left to its own PR rather than widened into this one.

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/storygate-65ajl` (worktree guard printed `WORKTREE_ROOT=/c/Users/miket/code/re-frame2-worktrees/storygate-65ajl`).

| gate | exit |
| --- | --- |
| `sh scripts/test-fast-pr.sh` | **0** (20 min; classified `docs=true jvm=true node=true` — **no tier skipped**) |
| `npm run test:script-policy && npm run test:script-helpers` (chained, both halves, from `implementation/`) | **0** |
| `clj-kondo` @ **2026.04.15** (CI-pinned binary fetched; `lint.yml`'s exact invocation) | **0** — `errors: 0, warnings: 4534` |
| EP-0036 donor-boundary grep (`git grep -e 're-frame\.ui' -e 're_frame/ui' -e 're-frame2-ui' -- implementation/freehand`) | 1 (no matches — clean) |
| `node scripts/_changed-surfaces.test.cjs` | **0** — 289 passed |
| `npm run test:story-feature-load` (the gate this PR makes required) | **0**, twice — `Ran 2 Story feature-load specs. 0 failures.` |

Local `clj-kondo` is 2025.10.23; the pinned 2026.04.15 Windows binary was fetched and run rather than trusting the local one. The JS harness gate was run **chained**, both halves, as `test.yml` composes it.

**Skipped tiers.** The spine skipped **none** — it classified this diff `docs=true jvm=true node=true` and ran every tier. What was not run locally is the browser tiers beyond the Story feature-load gate: the Xray smoke, the play-script gate, the adapter smokes and the `cljs-browser` lane are CI's. This diff touches no CLJS, no CLJC and no CLJ, so none of them can be reached by it; and because the diff hits three `mark_all` paths, CI runs the entire matrix on this PR regardless.
