### PR TITLE
docs(hicasso): review draft guide for completeness, correctness, and voice

### DIFF
--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -1,19 +1,19 @@
 # Getting started
 
-> **Draft ahead of the product artefact.** This page teaches the landed surface —
-> ruled in [decisions.md](../decisions.md) (HD-001…HD-028), witnessed by the bench
-> arm's tests under `implementation/freehand/test/re_frame/bench/hicasso/` — but no
-> `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
-> stay provisional until the API freeze.
+> **Draft ahead of the product artefact.** No `implementation/hicasso/` ships yet.
+> Spellings marked **[unfrozen]** are provisional until the API freeze. Behaviour
+> shown here is witnessed under `implementation/freehand/test/re_frame/bench/hicasso/`.
 
-Booting a re-frame2 app today takes about thirty lines: create a React root, install
-an adapter, render a `frame-root` inside it, remember the root across hot reloads so
-React doesn't get a second `create-root` for a live node. Every app writes the same
-thirty lines and every app gets one of them subtly wrong at least once.
+Booting a re-frame2 app today takes about thirty lines: create a React root,
+install an adapter, render a `frame-root` inside it, remember the root across
+hot reloads so React doesn't get a second `create-root` for a live node. Every
+app writes the same thirty lines and every app gets one of them subtly wrong at
+least once.
 
-Hicasso collapses that into one call. HD-021 pins the semantics: **one root
-operation associates a DOM node, a frame, and initial events, and returns an
-idempotent teardown.** The names wait for the API freeze; the behaviour does not.
+Hicasso collapses that into one call. **One root operation associates a DOM
+node, a frame, and initial events, and returns an idempotent teardown.** Names
+and arities wait for the API freeze; the product-shaped surface below is what
+this guide teaches.
 
 ## Your first app
 
@@ -56,8 +56,7 @@ Three namespaces, in the shape any re-frame2 app already uses.
        title]])])
 ```
 
-That view reads with `sub` — an ordinary function call, and the ruled read surface
-(the fork the earlier draft hedged on was decided on 2026-07-31).
+That view reads with `sub` — an ordinary function call at the point of use.
 [Views and reads](02-views-and-reads.md) covers it.
 
 And the boot namespace, which is the actual subject of this page:
@@ -77,17 +76,19 @@ And the boot namespace, which is the actual subject of this page:
            [views/todo-app {}]))
 ```
 
-That is the whole boot. `h/root!` **[unfrozen]** takes the DOM node, a config map,
-and one view, and hands back a teardown function.
+That is the whole boot. `h/root!` **[unfrozen]** takes the DOM node, a config
+map, and one view, and hands back a teardown function. Exact names and arities
+are not frozen; treat the shape — node, config, view → teardown — as the
+authoring contract this guide teaches.
 
-The `{}` on `[views/todo-app {}]` is optional — `[views/todo-app]` renders the same
-thing, and the body receives an empty props map either way. Write whichever reads
-better at the call site.
+The `{}` on `[views/todo-app {}]` is optional — `[views/todo-app]` renders the
+same thing, and the body receives an empty props map either way. Write whichever
+reads better at the call site.
 
 `:initial-events` behaves exactly as it does under
-[`frame-root`](../../../core/how-to/boot-and-mount-an-app.md): ordinary events, run
-once in order, seeding app-db before first paint. Even initial values arrive by
-event — that rule does not change because the view layer did.
+[`frame-root`](../../../core/how-to/boot-and-mount-an-app.md): ordinary events,
+run once in order, seeding app-db before first paint. Even initial values arrive
+by event — that rule does not change because the view layer did.
 
 ## The teardown
 
@@ -98,9 +99,9 @@ release, and the DOM node is yours again:
 (stop!)   ;; idempotent — calling it twice is not an error
 ```
 
-Idempotence is in the ruling, not a courtesy. Teardown paths get called from
-`finally` blocks, test fixtures, and reload hooks that don't coordinate, so a second
-call has to be a no-op rather than a crash.
+Idempotence is part of the contract, not a courtesy. Teardown paths get called
+from `finally` blocks, test fixtures, and reload hooks that don't coordinate, so
+a second call has to be a no-op rather than a crash.
 
 The standing assertion behind it is worth knowing even if you never write it
 yourself: **zero leaked subscription ref-counts after teardown**. If a root goes
@@ -109,41 +110,40 @@ lifecycle subtlety you were supposed to manage.
 
 ## Hot reload
 
-HD-021 gives hot reload a floor rather than a mechanism. After a body swap:
+Hot reload has a floor rather than a prescribed mechanism. After a body swap:
 
 - the root, the frame, and app-db survive;
 - the changed view body is the one that runs;
 - no subscriptions leak.
 
-Preserving hook-local state across a swap is explicitly optional, so don't build on
-it.
+Preserving hook-local state across a swap is optional, so don't build on it.
 
 Note what the floor implies for the code above. `defonce` keeps the root alive
-across reloads, and the guarantee says the *changed body* is used — so on the
-designed behaviour a `^:dev/after-load` remount hook is not part of the story.
+across reloads, and the guarantee says the *changed body* is used — so a
+`^:dev/after-load` remount hook is not part of the designed story.
 
-Half the mechanism is visible in how `defview` expands. It is a `def` of a freshly
-minted head, so re-evaluating the namespace produces a *new* head — which is a new
-React element type, and React replaces that subtree rather than trying to reconcile
-it. Nothing has to force its way past the default bail-out. What the record does not
-say is what makes the next render happen at all; see **Not settled yet**.
+Half the mechanism is visible in how `defview` expands. It is a `def` of a
+freshly minted head, so re-evaluating the namespace produces a *new* head —
+which is a new React element type, and React replaces that subtree rather than
+trying to reconcile it. Nothing has to force its way past the default bail-out.
+What is not pinned is what makes the next render happen at all; see **Not
+settled yet**.
 
-If you edit `:todo/initialise` itself and want the new seed to run, reset the frame
-or reload the page. Hot reload preserves state by design, and it will happily
-preserve it right past your edited setup event.
+If you edit `:todo/initialise` itself and want the new seed to run, reset the
+frame or reload the page. Hot reload preserves state by design, and it will
+happily preserve it right past your edited setup event.
 
 ## More than one frame
 
-`:frame` names the frame the root ensures, the same way `:id` does for `frame-root`.
-Two roots with two different frame ids give you two isolated apps on one page — own
-app-db, own queue, own subscription cache. This is how the multi-frame witnesses in
-[validation.md](../validation.md) are built, and views inside one root never reach
-into another frame's state.
+`:frame` names the frame the root ensures, the same way `:id` does for
+`frame-root`. Two roots with two different frame ids give you two isolated apps
+on one page — own app-db, own queue, own subscription cache. Views inside one
+root never reach into another frame's state.
 
 ## Troubleshooting
 
-No boot-path error ids are minted yet, so this table names mechanisms rather than
-`:rf.error/*` ids.
+No boot-path error ids are minted yet, so this table names mechanisms rather
+than `:rf.error/*` ids.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
@@ -155,28 +155,24 @@ No boot-path error ids are minted yet, so this table names mechanisms rather tha
 
 ## When not to use this
 
-**Server-side rendering is required Hicasso scope — and it is landing, not
-landed.** HD-020 originally ruled SSR out of v0; the 2026-08-04 operator ruling
-reopened that clause and made SSR + hydration required scope (the HD-020 addendum
-in [decisions.md](../decisions.md) is the record). The story is the framework's
+**Server-side rendering is in scope for Hicasso.** The story is the framework's
 own Spec 011 mechanism, not a Hicasso-private one: the server embeds the
 `#__rf_payload` EDN payload and the client adopts it through the reserved
-`:rf/hydrate` door before first render. Of the pieces (`rf2-2rtt6.84`–`.87`),
-the hydration door and `defhost`'s `:ssr` policy are witnessed in the bench arm
-today; the Node render entry and the spike witness are still in flight —
-[Server-side rendering](10-server-side-rendering.md) tells the story door by
-door, in honest tense. Until the doors all land, an app that needs SSR now still
-uses a [Reagent or UIx adapter](../../../core/views.md), which are first-class
-and supported.
+`:rf/hydrate` door before first render. In the bench arm, the hydration door,
+`defhost`'s `:ssr` policy, the Node render entry, and the spike witness are
+landed and witnessed. The production server arm is still open.
 
-The same applies to the whole programme, not just this page: adapters continuing to
-be the answer is a *successful* outcome for Hicasso, not a failure mode.
+There is still no product `implementation/hicasso/` artefact. If you need the
+full published SSR guide path in production today, a
+[Reagent or UIx adapter](../../../core/views.md) remains first-class and
+supported. [Server-side rendering](10-server-side-rendering.md) tells the Hicasso
+story door by door.
 
 ## Not settled yet
 
 | Question | Status |
 |---|---|
-| The root operation's name, its config keys, and the teardown's name | Semantics pinned by HD-021; names explicitly unfrozen until the API freeze |
-| Does `rf/init!` and adapter installation still apply? | **Not addressed.** Hicasso is a native view layer rather than an adapter, but the record never says whether the root operation subsumes process setup or whether an `init!`-equivalent survives |
-| What triggers the re-render after a hot-reload body swap | **Not addressed.** HD-021 pins the guarantees and `defview`'s expansion settles how the new body is picked up; nothing says who asks for the render |
+| The root operation's name, its config keys, and the teardown's name | Semantics pinned; names **[unfrozen]** until the API freeze |
+| Does `rf/init!` and adapter installation still apply? | **Not addressed.** Hicasso is a native view layer rather than an adapter, but nothing yet says whether the root operation subsumes process setup or whether an `init!`-equivalent survives |
+| What triggers the re-render after a hot-reload body swap | **Not addressed.** The guarantees and `defview`'s expansion settle how the new body is picked up; nothing says who asks for the render |
 | Where the frame config other than `:initial-events` goes | **Not addressed.** `frame-root` takes a config map today; whether the root operation passes one through is unstated |

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -1,14 +1,15 @@
 # Views and reads
 
-> **Draft ahead of the product artefact.** This page teaches the landed surface —
-> ruled in [decisions.md](../decisions.md) (HD-001…HD-028), witnessed by the bench
-> arm's tests under `implementation/freehand/test/re_frame/bench/hicasso/` — but no
-> `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
-> stay provisional until the API freeze.
+> **Draft ahead of the product artefact.** No `implementation/hicasso/` ships yet.
+> Spellings marked **[unfrozen]** are provisional until the API freeze. Behaviour
+> shown here is witnessed under `implementation/freehand/test/re_frame/bench/hicasso/`.
 
-A Hicasso view is a function from a props map to hiccup, which reads whatever
-subscriptions it needs along the way — with `sub`, an ordinary function call, at
-the point where the value is used:
+Views that re-render too coarse, and subscription reads that can't live where
+you use them, are the same pain twice: either you hoist a value and re-render a
+room full of siblings, or you invent a second way to read just so a helper can
+see the current filter. Hicasso's answer is a view that is a function from a
+props map to hiccup, and **one** read surface — `sub`, an ordinary function
+call at the point of use:
 
 ```clojure
 (ns todo.views
@@ -25,46 +26,34 @@ the point where the value is used:
                 :on-input [:todo.ui/edit id ::h/value]}])]))
 ```
 
-Note the third read: it happens only when `editing?` is true, in the middle of an
-expression, and that is legal — the whole point of the surface. An earlier draft
-of this guide taught two candidate read surfaces because HD-002 had a measured
-fork open between them. **The fork is ruled.** On 2026-07-31 the operator ruled
-the ambient collector — `sub` as a plain call, anywhere in the body — the only
-acceptable read surface on ergonomics; the grouped `use-subs` alternative was
-ruled below the usability bar and survives only as a comparator rendering in the
-bench arm. The ruling and the three-rendering diff that informed it are recorded
-in the [dogfood judgement](../studio/arm1-lean-react-dogfood-judgement.md);
-HD-002's correctness gates were not waived and are witnessed there too.
+Note the third read: it happens only when `editing?` is true, in the middle of
+an expression, and that is legal — the whole point of the surface. `sub` is the
+only product read surface; read where you need the value.
 
 ## Boundaries and inlining
 
-Two ways to reach another function from a view body, and the difference is visible
-in the syntax.
+Two ways to reach another function from a view body, and the difference is
+visible in the syntax.
 
 ```clojure
 [todo-row {:key id :id id}]   ;; a vector — a BOUNDARY child
 (todo-row {:id id})           ;; a call — INLINED into the enclosing boundary
 ```
 
-A **vector** in head position mints a React element. It is its own boundary: React
-owns its identity, and it can re-render without its parent.
+A **vector** in head position mints a React element. It is its own boundary:
+React owns its identity, and it can re-render without its parent.
 
-A **plain call** is just a function call. Its hiccup is spliced into the caller's
-tree, it has no boundary of its own, and any `sub` it performs donates that read
-*upward* to the enclosing boundary. Helpers cost nothing at runtime and buy no
-re-render granularity, which is the trade in one sentence. And because reads are
-ordinary calls, **helpers can read**: a `filter-button` that needs the current
-filter just reads it, and the read belongs to whichever boundary is rendering —
-no value threaded down as an argument. The census's article card is written
-exactly this way
-(`implementation/freehand/test/re_frame/bench/hicasso/shapes/card.cljs`): one
-plain function with two reads, called from a one-boundary page in one shape and
-wrapped in a one-line `defview` in another, with the markup, reads and intents
-identical between the two.
+A **plain call** is just a function call. Its hiccup is spliced into the
+caller's tree, it has no boundary of its own, and any `sub` it performs donates
+that read *upward* to the enclosing boundary. Helpers cost nothing at runtime
+and buy no re-render granularity, which is the trade in one sentence. And
+because reads are ordinary calls, **helpers can read**: a `filter-button` that
+needs the current filter just reads it, and the read belongs to whichever
+boundary is rendering — no value threaded down as an argument.
 
-One rule, one visible distinction. This is deliberate: re-render granularity is a
-thing you should be able to see by reading the source, and Reagent's `^{:key}`
-metadata folklore is deleted along with it. Keys go in the props map:
+One rule, one visible distinction. Re-render granularity is a thing you should
+be able to see by reading the source, and Reagent's `^{:key}` metadata folklore
+is gone with it. Keys go in the props map:
 
 ```clojure
 (defview todo-list [_]
@@ -74,15 +63,13 @@ metadata folklore is deleted along with it. Keys go in the props map:
 ```
 
 A bare seq of boundary children needs keys, and today you get React's own key
-warning in development if you forget — a Hicasso-minted one is ruled but not built.
-The `for`-lowering sugar that would derive the key from the binding is **not v0** —
-you write `:key` yourself. Putting a plain `defn` in head position — `[badge {...}]`
-where `badge` was never minted by `defview` — is `:rf.error/hicasso-bad-head`,
-a loud error rather than a silent embedding.
+warning in development if you forget — a Hicasso-minted one is planned but not
+built. The `for`-lowering sugar that would derive the key from the binding is
+**not v0** — you write `:key` yourself. Putting a plain `defn` in head position
+— `[badge {...}]` where `badge` was never minted by `defview` — is
+`:rf.error/hicasso-bad-head`, a loud error rather than a silent embedding.
 
 ### The component ABI
-
-HD-016 pins this table, and the keyed insert/delete/reorder witness enforces it.
 
 | Head | Props | Children | `:key` | `:ref` |
 |---|---|---|---|---|
@@ -91,32 +78,32 @@ HD-016 pins this table, and the keyed insert/delete/reorder witness enforces it.
 | Fragment — `[:<> …]` | — | trailing forms | on the fragment's props map | — |
 | Foreign — `defhost` (and `[:>]`, once it is built) | converted per declaration | hiccup children become elements | `:key` in props | callback ref, legal |
 
-Children arrive realized and predictably flattened: nested and lazy sequences are
-realized once and flattened one level, `nil` and `false` render nothing, `true` is an
-error, and an existing React element is a legal child anywhere. A view may return
-`nil`, a single root, or a fragment.
+Children arrive realized and predictably flattened: nested and lazy sequences
+are realized once and flattened one level, `nil` and `false` render nothing,
+`true` is an error, and an existing React element is a legal child anywhere. A
+view may return `nil`, a single root, or a fragment.
 
 `(:children props)` is a **vector of hiccup forms**, so splice it rather than
 dropping it in whole — `(into [:ul.nested] children)`, or `(into [:<>] children)`
 when you have nothing to wrap it in. A raw vector in child position is read as
 hiccup, and a vector whose head is itself a vector is not a legal element.
 
-`:key` never reaches your body. That is React's contract, not a Hicasso choice, and
-pretending otherwise would be the kind of leaky convenience that costs you a day
-when it finally bites.
+`:key` never reaches your body. That is React's contract, not a Hicasso choice,
+and pretending otherwise would be the kind of leaky convenience that costs you a
+day when it finally bites.
 
 ### Bodies are pure and re-runnable
 
-React StrictMode runs your body twice in development. That is fine — bodies are pure
-by contract. Anything that would break under a second run (mutating a captured atom,
-kicking off a fetch, counting renders) does not belong in a body.
+React StrictMode runs your body twice in development. That is fine — bodies are
+pure by contract. Anything that would break under a second run (mutating a
+captured atom, kicking off a fetch, counting renders) does not belong in a body.
 
 ### Boundaries memoize by default
 
-A value-equality bail-out is the boundary **default** (HD-028, amending HD-006):
-every minted head carries one stable internal memo wrapper comparing the whole
-props map with CLJS `=`. If a boundary's props compare equal to last render, its
-body does not run — even though its parent's did.
+A value-equality bail-out is the boundary **default**: every minted head carries
+one stable internal memo wrapper comparing the whole props map with CLJS `=`. If
+a boundary's props compare equal to last render, its body does not run — even
+though its parent's did.
 
 Two things still outrank the bail-out, and both are the boundary's **own**
 invalidation. A subscription or context read that boundary made itself always
@@ -133,21 +120,18 @@ time its parent does takes an explicit changing revision prop, not a `:memo
 false` switch.
 
 One corollary is worth stating outright, because the opposite is the thing people
-worry about. Reading a subscription high in the tree and passing the value down as
-a prop does **not** lose an update: the boundary that reads is the boundary that
-invalidates, and every boundary the changed value actually reaches receives unequal
-props at that hop, so the default bail-out never applies to it — the value arrives.
-What the default buys you, beyond that chain, is that a boundary the value does
-**not** reach skips instead of re-rendering for nothing. Moving the read down is
-still a granularity fix, not a correctness fix, and if you go looking for a lost
-update you will not find one.
+worry about. Reading a subscription high in the tree and passing the value down
+as a prop does **not** lose an update: the boundary that reads is the boundary
+that invalidates, and every boundary the changed value actually reaches receives
+unequal props at that hop, so the default bail-out never applies to it — the
+value arrives. What the default buys you, beyond that chain, is that a boundary
+the value does **not** reach skips instead of re-rendering for nothing. Moving
+the read down is still a granularity fix, not a correctness fix, and if you go
+looking for a lost update you will not find one.
 
-Whether the bail-out stays the *default* is the one thing on this page still in
-front of the operator. It costs about 100 bytes of retained heap per boundary, and
-on the smallest measurable shell that is what carries the shell across the 1 KB
-line — so HD-028's own pre-registered fallback, shipping the same comparator as an
-explicit opt-in instead, is live. Nothing you write changes either way; what
-changes is whether you have to ask for it.
+Whether the bail-out stays the *default* is still open; see **Not settled yet**.
+Nothing you write changes either way; what may change is whether you have to ask
+for it.
 
 ## Attributes
 
@@ -173,33 +157,35 @@ Five rules cover the whole of it.
 **Names go kebab to camel.** `:on-click` emits `onClick` and `:default-value`
 emits `defaultValue`. `:aria-*` and `:data-*` pass through exactly as written,
 because that is what the DOM wants, and a `--custom-property` is preserved
-verbatim. Three attributes React spells differently from HTML are renamed for you:
-`:class` → `className`, `:for` → `htmlFor`, `:charset` → `charSet`.
+verbatim. Three attributes React spells differently from HTML are renamed for
+you: `:class` → `className`, `:for` → `htmlFor`, `:charset` → `charSet`.
 
 **Values convert one level deep.** A nested map — `:style` and its kin — has its
 own keys camelCased, so `{:margin-top 8}` arrives as `marginTop`. Keywords and
-symbols become their names, which is why `:type :text` is `type="text"`. Functions
-cross by identity, deliberately: rewrapping them would defeat the default
-value-equality bail-out and every other comparison that looks at handler identity.
+symbols become their names, which is why `:type :text` is `type="text"`.
+Functions cross by identity, deliberately: rewrapping them would defeat the
+default value-equality bail-out and every other comparison that looks at handler
+identity.
 
 **`:class` takes more than a string.** A keyword, a symbol, or a collection of
-those, with `nil`s dropped and the rest joined by spaces — so the `(when …)` above
-contributes nothing at all when it is false, and you never build a class string by
-hand.
+those, with `nil`s dropped and the rest joined by spaces — so the `(when …)`
+above contributes nothing at all when it is false, and you never build a class
+string by hand.
 
-**The tag's `#id` and `.class` shorthand composes** — and the id comes first, as it
-does in every hiccup dialect: `:input#title.form-control`, never
-`:input.form-control#title`. An explicit `:id` in the map wins over `#title`, and
-`.form-control` on the tag is joined with whatever `:class` brings rather than one
-of them silently replacing the other.
+**The tag's `#id` and `.class` shorthand composes** — and the id comes first, as
+it does in every hiccup dialect: `:input#title.form-control`, never
+`:input.form-control#title`. An explicit `:id` in the map wins over `#title`,
+and `.form-control` on the tag is joined with whatever `:class` brings rather
+than one of them silently replacing the other.
 
-**`:key` is not an attribute.** It is React's identity contract: it is read off the
-map, it never reaches your body, and it is not emitted as a prop.
+**`:key` is not an attribute.** It is React's identity contract: it is read off
+the map, it never reaches your body, and it is not emitted as a prop.
 
-One further key is reserved, and it is the only attribute merge Hicasso has. `:&`
-carries a map of attributes from somewhere else — a caller's forwarded remainder, a
-theme's part attributes — and **the literal keys you write always win over it**.
-The case that makes the law worth having is a controlled input, so
+One further key is reserved, and it is the only attribute merge Hicasso has.
+`:&` carries a map of attributes from somewhere else — a caller's forwarded
+remainder, a theme's part attributes — and **the literal keys you write always
+win over it**. The case that makes the law worth having is a controlled input,
+so
 [Controlled inputs](04-controlled-inputs.md#forwarding-attributes-onto-a-controlled-input)
 teaches it in full.
 
@@ -207,65 +193,61 @@ teaches it in full.
 
 One fixed runtime hook per boundary collects the reads the body actually made,
 and the commit installs exactly that edge set — so **a branch not taken
-contributes no edge**, measured on the dogfood screen, where the collector
-rendering holds fewer edges than the declaration-style rendering of the same
-page. Reads inside a lazy `for` are forced by the same pass that turns hiccup
-into elements, so they land in the right boundary's window. **A read that
-escapes the render is loud, never silently stale**: a stored handler, a stashed
-lazy seq, or a `delay` forced later fails naming the query, and an unforced
-`delay` crossing a boundary is refused at the crossing — the alternative in each
-case would be a value that is correct on screen and frozen thereafter,
-attributable to nothing. The honest cost sits on the other side: the edge set is
-a function of what the body *did*, so a body whose control flow changes its
-reads from render to render pays a re-subscribe that replaces the whole set, not
-just the changed key.
+contributes no edge**. Reads inside a lazy `for` are forced by the same pass
+that turns hiccup into elements, so they land in the right boundary's window.
+**A read that escapes the render is loud, never silently stale**: a stored
+handler, a stashed lazy seq, or a `delay` forced later fails naming the query,
+and an unforced `delay` crossing a boundary is refused at the crossing — the
+alternative in each case would be a value that is correct on screen and frozen
+thereafter, attributable to nothing. The honest cost sits on the other side: the
+edge set is a function of what the body *did*, so a body whose control flow
+changes its reads from render to render pays a re-subscribe that replaces the
+whole set, not just the changed key.
 
 That last sentence is the one to design around. It is a real difference from a
-surface whose edges are static, and it is priced honestly in the
-[dogfood judgement](../studio/arm1-lean-react-dogfood-judgement.md) — as is the
-kill condition that still stands over the mechanism: the first time correctness
-requires a per-read candidate ledger, the collector dies, whatever its numbers
-([hd-002-adjudication.md](../hd-002-adjudication.md)). The witnesses so far say
-it does not.
+surface whose edges are static: dynamic control flow is legal, and the price is
+a whole-set refresh when the taken branches change.
 
 ## Rules every read obeys
 
-- **Reading outside a render is an error.** There is no `@`-anywhere. Handler and
-  utility code uses `rf/subscribe-once`, which is a one-shot read that retains no
-  reactive handle.
-- **Framework subscriptions read identically to your own** — machine tags, resource
-  and mutation state, route identity. They are 27% of the census's read traffic, so
-  the index serves them first-class rather than as a special case.
-- **Sub-key identity is `(query-id, args)` under value equality.** Note what that
-  buys you: a *freshly allocated* map or vector is not a problem. Two structurally
-  equal persistent values are one cache key, so rebuilding `{:scope :all}` inside the
-  query on every render hits the same entry every time, and you do not have to hoist
-  it into a `def` or memoize it to be safe. Sorting the same items into the same order
-  is the same story — `=` compares sequential values by their contents, so a freshly
-  sorted seq is the key the last one was, at the cost of walking it. Two things do
-  thrash the index. An argument whose **value** genuinely moved is a different key, and
-  correctly so: a timestamp folded into the query, or a sort order that really changed.
-  And an argument carrying **reference** identity rather than value identity — a
-  function, a JS object or array, a host object — is unequal to itself between renders,
-  because for those `=` is identity. Documented, programmer-trusted, not policed.
+- **Reading outside a render is an error.** There is no `@`-anywhere. Handler
+  and utility code uses `rf/subscribe-once`, which is a one-shot read that
+  retains no reactive handle.
+- **Framework subscriptions read identically to your own** — machine tags,
+  resource and mutation state, route identity. They are first-class in the
+  index, not a special case.
+- **Sub-key identity is `(query-id, args)` under value equality.** Note what
+  that buys you: a *freshly allocated* map or vector is not a problem. Two
+  structurally equal persistent values are one cache key, so rebuilding
+  `{:scope :all}` inside the query on every render hits the same entry every
+  time, and you do not have to hoist it into a `def` or memoize it to be safe.
+  Sorting the same items into the same order is the same story — `=` compares
+  sequential values by their contents, so a freshly sorted seq is the key the
+  last one was, at the cost of walking it. Two things do thrash the index. An
+  argument whose **value** genuinely moved is a different key, and correctly so:
+  a timestamp folded into the query, or a sort order that really changed. And an
+  argument carrying **reference** identity rather than value identity — a
+  function, a JS object or array, a host object — is unequal to itself between
+  renders, because for those `=` is identity. Documented, programmer-trusted,
+  not policed.
 
 ## Troubleshooting
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| A boundary doesn't re-render even though something on screen should have changed | Its props still compare `=` to last render and it made no read of its own that moved — the default bail-out (HD-028) is doing exactly what it's for | Read the changing value with `sub` inside the boundary that displays it, or thread it down as a prop so the value actually differs there |
+| A boundary doesn't re-render even though something on screen should have changed | Its props still compare `=` to last render and it made no read of its own that moved — the default bail-out is doing exactly what it's for | Read the changing value with `sub` inside the boundary that displays it, or thread it down as a prop so the value actually differs there |
 | A boundary re-renders every time though its props look unchanged | A prop carries reference identity rather than value identity — an inline function literal, a JS object or array, a host object — so `=` correctly says unequal | Hoist the function, or convert the value to a persistent one. Freshness is not the problem: two structurally equal persistent values are `=` however recently they were built |
 | One cell changes and 300 boundaries re-render | The read lives too high in the tree | Push the read down into the boundary that displays it |
-| One value changes and a whole subtree re-renders with it | The value is read in an ancestor and passed down as a prop. Nothing is *lost* — the reading ancestor re-renders with the new value, and every boundary the value actually reaches has unequal props at that hop, so the default bail-out (HD-028) does not catch it there. Coarse invalidation, not missed invalidation | Read at the point of use, so the boundary that displays the value is the boundary that invalidates |
+| One value changes and a whole subtree re-renders with it | The value is read in an ancestor and passed down as a prop. Nothing is *lost* — the reading ancestor re-renders with the new value, and every boundary the value actually reaches has unequal props at that hop, so the default bail-out does not catch it there. Coarse invalidation, not missed invalidation | Read at the point of use, so the boundary that displays the value is the boundary that invalidates |
 | A read after the render throws, naming the query | A handler closure, a stashed lazy seq, or a `delay` deferred a `sub` past the render | Read during the render and close over the value; the loud error is the alternative to a silently frozen edge |
 | Index thrash, subscriptions constantly re-created | Query args that are not *value*-stable — a folded-in timestamp, a sort order that really changed, or a JS object or function carrying reference identity | Allocation is fine; two equal persistent values are one key however freshly built. Make the args equal under `=` between renders |
 | A body's side effect fires twice | StrictMode double-invoke | Bodies are pure; move the effect out |
 
 ## When not to use a boundary
 
-Not every function needs to be a view. If a piece of markup has no reads of its own
-and always re-renders with its parent anyway, a plain function is cheaper and
-simpler — no element, no identity, no index membership. Boundaries are for
+Not every function needs to be a view. If a piece of markup has no reads of its
+own and always re-renders with its parent anyway, a plain function is cheaper
+and simpler — no element, no identity, no index membership. Boundaries are for
 *re-render granularity*. Reach for one when you want something to update
 independently, not because the markup got long.
 
@@ -273,7 +255,6 @@ independently, not because the markup got long.
 
 | Question | Status |
 |---|---|
-| `sub` and `defview` spellings | Working names; [authoring.md](../authoring.md) holds all declaration spellings unfrozen until the freeze |
-| The bar | The read surface is ruled, but the ship-bar rows (mount and bulk ≤ 1.0× Reagent, HD-012) are not yet taken; the programme can still end null on them |
-| Whether the value-equality bail-out stays the **default** | **An open operator ruling.** HD-028 rules it the default and the runtime implements it, but the wrapper is what carries the R=0 shell across the 1 KB retained-heap line (994/992 B without it, 1,099.5/1,097 B with it), so HD-028's own fallback — the same comparator as an explicit boundary-level opt-in, with HD-006 restored as the default — is on the table. This page teaches the default because that is what is landed |
-| The dev warning for an unkeyed seq — its id and whether it is dev-only | **Not addressed** beyond HD-016's "dev warning", and nothing mints one: what a reader sees today is React's own key warning |
+| `sub` and `defview` spellings | Working names; declaration spellings stay **[unfrozen]** until the API freeze |
+| Whether the value-equality bail-out stays the **default** | **Open.** The runtime implements memo-by-default today; an alternative that ships the same comparator as an explicit opt-in is still on the table. This page teaches the default because that is what is landed |
+| The dev warning for an unkeyed seq — its id and whether it is dev-only | **Not addressed** beyond "dev warning"; nothing mints one yet — what a reader sees today is React's own key warning |

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -1,10 +1,7 @@
 # Events as data
 
-> **Draft ahead of the product artefact.** This page teaches the landed surface —
-> ruled in [decisions.md](../decisions.md) (HD-001…HD-028), witnessed by the bench
-> arm's tests under `implementation/freehand/test/re_frame/bench/hicasso/` — but no
-> `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
-> stay provisional until the API freeze.
+> **Draft ahead of the product artefact.** No `implementation/hicasso/` artefact
+> ships yet. Spellings marked **[unfrozen]** stay provisional until the API freeze.
 
 Handler attributes are where a data-oriented view layer usually gives up. You have
 been writing pure data all the way down the tree, and then `:on-click` needs a
@@ -36,15 +33,22 @@ target's `.value` and `.checked`:
          :on-input [:todo.ui/edit id ::h/value]}]
 ```
 
-At dispatch, the placeholder is replaced by the input's value, so the handler
-receives `[:todo.ui/edit 7 "milk"]` — an ordinary event vector, indistinguishable
-from one you dispatched by hand. Substitution happens at the intent vector's top
-level only, which is the shape the corpus writes; a marker buried in nested
-structure is not looked for.
+```clojure
+[:input {:type      :checkbox
+         :checked   done?
+         :on-change [:todo/set-done id ::h/checked]}]
+```
 
-The census says the markers cover about **97% of the corpus's 183 handler sites**.
-That number is why they exist: two markers turn nearly every handler attribute in a
-real application into data.
+At dispatch, the placeholder is replaced by the input's value or checked state, so
+the handler receives `[:todo.ui/edit 7 "milk"]` or `[:todo/set-done 7 true]` —
+ordinary event vectors, indistinguishable from ones you dispatched by hand.
+Substitution happens at the intent vector's top level only, which is the shape you
+write; a marker buried in nested structure is not looked for.
+
+Those two markers cover almost every handler site that only needs the target's
+value or checked state. For the full controlled-input round-trip — value in from a
+subscription, intent out, caret and same-tick echo — see
+[Controlled inputs](04-controlled-inputs.md).
 
 ## Functions still work
 
@@ -88,14 +92,10 @@ conditional dispatch is an ordinary `when`:
 | `:ref` | React's own contract — the node on attach, your return as the cleanup |
 | a raw `#js` prop you built yourself | nothing at all. It is a function; it runs |
 
-That last row is the one worth knowing about, because of what it is not. In the
-predecessor there are four callback forms plus a rule about where they reach, and
-the forms are *carriers* — marker objects, not functions. Hand one to a raw `#js`
-prop and the library calls `props.onPing(…)` on something that is not callable, so
-what you get is the JavaScript engine's own `TypeError`, worded after whatever
-expression it tripped on, naming nothing you wrote. `h/fn` is a function
-everywhere. Put it somewhere the runtime does not walk and you lose the contract,
-not the call.
+That last row is worth knowing about. `h/fn` is a real function everywhere. Put it
+somewhere the runtime does not walk and you lose the contract, not the call — the
+library gets a callable, not a marker object that blows up as a `TypeError` naming
+nothing you wrote.
 
 You never pick a form. There is one, and where you put it is the decision.
 
@@ -124,10 +124,9 @@ An intent vector at `:on-submit` prevents the browser's default navigation:
  [:button {:type :submit} "Sign up"]]
 ```
 
-No `(.preventDefault e)`. It is census-weighted policy — forms in the corpus wanted
-it every time — so the runtime does it. For the rare form that wants a real
-submission, write the handler as `h/fn`: a callback is handed the event, so the
-runtime leaves it alone and the event is yours (HD-026).
+No `(.preventDefault e)`. Forms almost always want it, so the runtime does it. For
+the rare form that wants a real submission, write the handler as `h/fn`: a callback
+is handed the event, so the runtime leaves it alone and the event is yours.
 
 ### Everywhere else, prevention is one head
 
@@ -182,14 +181,17 @@ composes. Which is a good argument for it not being your handler.
 
 ## Links: `route-link` and the navigate head
 
-Most of an application's anchors are navigations — the census counts **106
-route-links across 85 files**, which makes the link the most-repeated tier-1 form
-there is. Its spelling is `route-link`, a plain function over the routing
-artefact's link seam (HD-027):
+Most of an application's anchors are navigations. Spell the link as `route-link`, a
+plain function over the routing artefact's link seam:
 
 ```clojure
-(route-link {:to :conduit.profile/show :params {:username username}}
-  username)
+(ns conduit.views.profile
+  (:require [re-frame.hicasso :as h :refer [defview sub route-link]]))
+
+(defview author-byline [{:keys [username]}]
+  (route-link {:to :conduit.profile/show :params {:username username}
+               :class "author"}
+    username))
 ```
 
 You name a route and its params and never see a URL. What comes back is one real
@@ -200,22 +202,19 @@ click decision off the tree. Because it is a plain function, not a boundary, it
 inlines: no hook, no subscription read, no row in any boundary count. An author
 byline is not a unit of re-render.
 
-The click law is routing's, stated once, and it is the one every other link
-surface already runs: a modifier-click or auxiliary click stays the browser's (a
-new tab opens), a `:target` or `:download` anchor stays native, and everything
-else is `preventDefault` plus a dispatch of the routing intent to the frame that
-was captured at render. Rendering a `route-link` with routing absent fails at
-render, naming the `:to` — never a dead anchor.
+The click law is routing's, stated once: a modifier-click or auxiliary click stays
+the browser's (a new tab opens), a `:target` or `:download` anchor stays native,
+and everything else is `preventDefault` plus a dispatch of the routing intent to
+the frame that was captured at render. Rendering a `route-link` with the routing
+artefact absent fails at render with `:rf.error/routing-artefact-missing`, naming
+the `:to` — never a dead anchor.
 
 **The `:on-click` you pass is the pre-navigation veto**, and its roster is closed:
 `nil`, `[::h/prevent [:app/event]]`, `h/fn`, or a plain function. The prevent form
 is the declarative veto — the navigation is cancelled and your intent dispatched
-instead, which is exactly the cancelable-navigation case the prevent head was
-built for. A **bare** intent vector there is refused loudly: the click already
+instead. A **bare** intent vector there is refused loudly: the click already
 produces the one routing intent, and one user action must not yield two semantic
-events. Witnessed end-to-end — grammar, equality, refusals, real clicks through a
-real router — in `front/route_link_cljs_test` and
-`shapes/route_link_dom_cljs_test`.
+events.
 
 Routing also publishes a `:prefetch` opt-in, and Hicasso declines it for v0 — out
 loud, rather than by ignoring it. A `route-link` carrying `:prefetch` in any form,
@@ -241,15 +240,16 @@ explicitly.**
 
 ## Troubleshooting
 
-This table names mechanisms rather than error ids; the ids the record does mint
-are named in the sections above.
+This table names mechanisms rather than error ids; the ids the page does mint are
+named in the sections above.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | Page navigates and reloads on form submit | Something bypassed the intent path — a hand-written `:on-submit` function | Use an intent vector, or call `.preventDefault` yourself in the function |
-| Handler receives the placeholder keyword instead of a value | The placeholder was used at an event position with no value to substitute | `::h/value` is for value-bearing events; read the event object with a function elsewhere |
+| Handler receives the placeholder keyword instead of a value | The placeholder was used at an event position with no value to substitute | `::h/value` is for value-bearing events; `::h/checked` for checkboxes; read the event object with a function elsewhere |
 | Enter commits half-typed Japanese text | Composition handling was written by hand | Use the `:on-key-down` key map — the composition law is centralised there |
 | A `route-link` refuses your `:on-click` intent vector | The click already produces the one routing intent — a bare second intent is one action, two events | Wrap it: `[::h/prevent [:app/event]]` cancels the navigation and dispatches yours instead |
+| `:rf.error/routing-artefact-missing` when rendering a `route-link` | Routing is not on the classpath / not required at boot | Require `re-frame.routing` (and the rest of your routing setup) so the artefact is present before the link renders |
 | `:rf.error/no-frame-context` from a timeout | A bare `dispatch` in async code | Capture the frame at the call site, or dispatch an event that owns the async work through `:fx` |
 | An intent fires but no handler runs | Unregistered event id | Registration happens on namespace load; check the boot namespace requires it |
 
@@ -257,13 +257,11 @@ are named in the sections above.
 
 When you need the event object itself. Pointer coordinates, `dataTransfer`,
 `stopPropagation`, anything measuring the DOM — those are functions, and reaching
-for one is not a failure. The census puts these at roughly 3% of handler sites,
-which is the right size for an escape hatch: too small to design the syntax around,
-too real to pretend away. Reach for `h/fn` when you want to read the event *and*
+for one is not a failure. Reach for `h/fn` when you want to read the event *and*
 dispatch, and a plain `(fn …)` when you want to read it and do something else.
 
 ## Not settled yet
 
 | Question | Status |
 |---|---|
-| `h/fn`'s spelling | Working name; HD-024 leaves the spelling unfrozen like every declaration spelling |
+| `h/fn`'s spelling | Working name; unfrozen like every declaration spelling |

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -1,10 +1,7 @@
 # Controlled inputs
 
-> **Draft ahead of the product artefact.** This page teaches the landed surface —
-> ruled in [decisions.md](../decisions.md) (HD-001…HD-028), witnessed by the bench
-> arm's tests under `implementation/freehand/test/re_frame/bench/hicasso/` — but no
-> `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
-> stay provisional until the API freeze.
+> **Draft ahead of the product artefact.** No `implementation/hicasso/` artefact
+> ships yet. Spellings marked **[unfrozen]** stay provisional until the API freeze.
 
 A controlled text input is the hardest correctness problem a view layer has, and
 almost none of the difficulty is visible in the code you write.
@@ -25,6 +22,10 @@ converges after whichever of the two runs last for a keystroke, and takes
 machinery underneath, because you need to know what it guarantees and where it
 stops.
 
+For checkboxes and other non-text controls, the same intent-vector style applies —
+see [`::h/checked`](03-events-as-data.md#the-value-placeholders) on
+[Events as data](03-events-as-data.md).
+
 ## Why this is hard
 
 The value shown on screen lives in app-db, which means every keystroke makes a round
@@ -33,15 +34,12 @@ re-render → DOM value.
 
 If any part of that is asynchronous, you get the classic failure set. Fast typists
 drop characters. The caret jumps to the end of the field on every edit. IME
-composition breaks mid-word. Reagent pays for this with a dedicated caret-heuristic
-module that tracks the last DOM value and repositions the cursor — the comment in
-its source says the alternative "gives the user a jarring experience," which is
-generous.
+composition breaks mid-word. Frameworks that leave this to taste end up with ad-hoc
+caret heuristics — track the last DOM value, reposition the cursor, hope composition
+survives. The comment in one such module says the alternative "gives the user a
+jarring experience," which is generous.
 
 ## The synchronous door
-
-HD-019 names the mechanism instead of leaving it to taste, because the first
-controlled-input commit cannot stall on an undecided design.
 
 A controlled element's intent **dispatches synchronously inside the discrete
 browser event**, and the subscription layer's store notification runs
@@ -63,7 +61,7 @@ detail.
 
 ## What the door guarantees
 
-Two requirements from the fitness harness, and they are v0's acceptance bar:
+Two operational guarantees, and they are v0's acceptance bar:
 
 **R-A1 — same-tick echo.** A keystroke flows event → commit → re-render such that
 the DOM value never lags the accepted keystroke. No dropped characters, no
@@ -76,15 +74,11 @@ what was typed. Reject, transform, reformat: mid-string edits included.
 **Remount-as-reset is disqualified** — it destroys focus, selection, and
 composition state, so "just change the key" is not an available answer here.
 
-Six browser witnesses stand behind the door. Five prove it outright, all on a
-100-cell editing grid: same-turn echo, mid-string caret, selection,
-unchanged-model rejection, and async normalisation. K4 in
-[validation.md](../validation.md) kills the whole programme if controlled text
-fails same-tick echo or IME on Chromium and WebKit for a simple form. This is
-not a polish item.
+Browser witnesses stand behind the door on a 100-cell editing grid: same-turn echo,
+mid-string caret, selection, unchanged-model rejection, and async normalisation.
 
-The sixth is IME, and it is the one place where this runtime deliberately does
-something plain React does not, so it is worth stating exactly.
+The IME path is the one place where this runtime deliberately does something plain
+React does not, so it is worth stating exactly.
 
 **A composing Enter commits nothing.** Mid-composition, Enter picks an
 IME candidate; it is not a submit. The runtime's key-map gates on the native
@@ -133,10 +127,9 @@ The rejected path leans on **React's own end-of-discrete-event restore** for the
 *value*: the DOM node briefly holds the typed character, the model doesn't change,
 and React reasserts the model value when the discrete event ends. The **caret**,
 though, React's restore throws away — so the runtime takes it itself, in the
-element path, which is what the converge above is for. The gap was measured
-before it was closed (HD-019 records both beads), and R-A2 is why closing it was
-not optional. Either way, none of this is your code: return `nil` from the
-handler and the field shows the model, caret intact.
+element path, which is what the converge above is for. Either way, none of this is
+your code: return `nil` from the handler and the field shows the model, caret
+intact. R-A2 is why that path is not optional.
 
 ## Forwarding attributes onto a controlled input
 
@@ -159,11 +152,9 @@ merge form" — always. So a caller who forwards a whole props map, a theme that
 supplies part attributes, or a genuinely hostile remainder carrying `:value` and
 `:on-input` all reach nothing that matters. Your `:value` is your `:value`.
 
-That is the whole design, and it exists because of the thing it deletes. In the
-predecessor there are **three** merge forms and the wrong one is silent: pick the
-general spread on a controlled input and caret and IME protection stop, with no
-error raised anywhere. Correctness by choice of syntax is the worst kind, because
-the code looks fine.
+That is the whole design, and it exists because of the thing it deletes: merge forms
+where the wrong choice silently drops caret and IME protection. Correctness by
+choice of syntax is the worst kind, because the code looks fine.
 
 Two consequences worth knowing.
 
@@ -195,8 +186,8 @@ from under them, and a rejected same-value reassertion becomes invisible. Explic
 revision means the reset fires exactly when the caller says so: zero stale paints,
 loop-impossible, correct on retry.
 
-This is the predecessor's ruled reset law, kept deliberately. The prop that carries
-the revision does not have a Hicasso spelling yet; see **Not settled yet**.
+The prop that carries the revision does not have a Hicasso spelling yet; see
+**Not settled yet**.
 
 ## Troubleshooting
 
@@ -209,17 +200,14 @@ This table names mechanisms; the door's failures are behavioural, not error ids.
 | Enter commits half-typed text mid-composition | A hand-written key handler that bypasses the intent path | Use the data key-map — the commit fence lives there, on both composition signals |
 | An IME composition dies when the model refuses or normalises it | Value reassertion during composition, which the browser treats as an abort | Not this runtime: the converge is carved out of a live composition and React's restore is held off with it. On plain React and the UIx port it is theirs, and not yours to fix |
 | Typing the "reset" value clears the field | Reset keyed on value equality somewhere | Reset on explicit revision |
-| Field goes read-only after an async normalise | The model round-trip didn't complete | Async normalisation is one of the six door witnesses; check the handler returns a `:db` write |
+| Field goes read-only after an async normalise | The model round-trip didn't complete | Async normalisation is one of the door witnesses; check the handler returns a `:db` write |
 | Focus lost after a validation failure | Something remounted the node | Remount-as-reset is disqualified precisely for this |
 
 ## When not to control an input
 
-Controlled means every keystroke writes to app-db. On a 100-cell grid that is 100
-event dispatches and 100 commits per pass, which is why the predecessor's grid
-example deliberately went uncontrolled. Price it before you reach for it: the
-per-keystroke budget in [validation.md](../validation.md) demands a stated path for
-both a 4-field form and a 100-cell grid, and "which subs recompute" matters as much
-as "which boundaries re-render."
+Controlled means every keystroke writes to app-db. On a dense editing grid that is
+one dispatch and one commit per cell per keystroke — price it before you reach for
+it. Which subs recompute matters as much as which boundaries re-render.
 
 If a field's intermediate values are nobody's business — a search box whose only
 consumer is a debounced query, a scratch field in a modal — an uncontrolled input
@@ -229,7 +217,7 @@ with a commit on blur is not a compromise. It is the right shape.
 
 | Question | Status |
 |---|---|
-| The revision prop's spelling on a controlled element | **Not addressed.** The reset law is ruled; the attribute that carries the revision is unnamed |
-| The buffered / draft-and-commit input ladder | **Post-v0, explicitly.** The charter defers "the full buffered/revision input ladder"; v0 ships R-A1/R-A2 and no more |
-| The controls kit that owns drafts and revisions | **Post-v0.** HD-009 leans on it for ephemeral state, and it does not exist in v0 — so in v0 a draft is app-db state you write yourself |
-| Whether `:on-input` or `:on-change` is the taught attribute | Both work, and the runtime takes whichever runs last. The landed screens write `:on-input` for text and `:on-change` for checkboxes; which one the guide should teach is convention, not ruling |
+| The revision prop's spelling on a controlled element | **Not addressed.** The reset law is fixed; the attribute that carries the revision is unnamed |
+| The buffered / draft-and-commit input ladder | **Post-v0.** v0 ships R-A1/R-A2 and no more |
+| The controls kit that owns drafts and revisions | **Post-v0.** In v0 a draft is app-db state you write yourself |
+| Whether `:on-input` or `:on-change` is the taught attribute | Both work, and the runtime takes whichever runs last. Landed screens write `:on-input` for text and `:on-change` for checkboxes; which one the guide should teach is convention, not a hard law |

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -1,20 +1,13 @@
 # Interop
 
-> **Draft ahead of the product artefact.** This page teaches the landed surface —
-> ruled in [decisions.md](../decisions.md) (HD-001…HD-028). `defhost`'s door is
-> witnessed end-to-end by
-> `implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs`:
-> one foreign React component with its own state, its own effects, its own context
-> read and three different invoker styles on its callbacks, declared once and
-> driven from a Hicasso tree. No `implementation/hicasso/` artefact ships yet,
-> though, and spellings marked **[unfrozen]** stay provisional until the API
-> freeze. Two things this page describes are ruled but **not built** — the `[:>]`
-> raw escape and the migration codemod — and one default, deep prop conversion,
-> is deliberately not offered at all. The `defhost` `:ssr` policy, in progress
-> when this page was first written, is **landed and witnessed**
-> (`rf2-2rtt6.85`, 2026-08-04);
-> [Server-side rendering](10-server-side-rendering.md) owns the SSR story. See
-> **Not settled yet**.
+> **Draft ahead of the product artefact.** Spellings marked **[unfrozen]** stay
+> provisional until the API freeze. `defhost` is witnessed end-to-end by the bench
+> arm under `implementation/freehand/test/re_frame/bench/hicasso/` — one foreign
+> React component with its own state, effects, context read, and three invoker
+> styles on its callbacks. No `implementation/hicasso/` artefact ships yet. The
+> `[:>]` raw escape and the migration codemod are **not built**. Deep prop
+> conversion is deliberately not offered. The `defhost` `:ssr` policy is landed;
+> [Server-side rendering](10-server-side-rendering.md) owns the SSR story.
 
 You want a date picker from npm. In Reagent you write `[:> DatePicker {...}]` and
 move on. Hicasso asks you to write one line first:
@@ -44,13 +37,11 @@ children cross as ordinary hiccup and are lowered by whoever renders them:
                 :on-change (h/fn [date & _] [:task/set-due date])}])
 ```
 
-## Why a declaration instead of `[:>]`
+## Why a declaration
 
-HD-011's Ruling settles the hierarchy in a sentence: **`defhost` is the door, and the
-only form taught**; `[:>]` "survives only as the explicitly secondary raw escape …
-for the cases a static declaration cannot express." Both forms are ruled legal.
-Only one is built, and only one is taught. This page is written in that order for
-that reason.
+`defhost` is the door, and the only form taught. A raw escape exists as design for
+cases a static declaration cannot express, but it is secondary and **not built**
+yet — see [The escape](#the-escape--is-legal-unbuilt).
 
 `[:> DatePicker {...}]` puts a raw JavaScript value inside your data tree. Three
 things break at that node, all of them quietly:
@@ -65,11 +56,10 @@ things break at that node, all of them quietly:
 `defhost` gives the crossing a name, keeps the JS require quarantined in one `.cljs`
 host namespace, and leaves the rest of your view tree pure data.
 
-The honest counter-argument is that a declaration is friction, and the counter to
-*that* is arithmetic: it amortizes to zero over every use site. HD-011's rationale
-leans on a migration codemod as well, and that half has not been built, so today
-the conversion is by hand. It is a small hand: the expensive part of leaving
-Reagent was never `[:>]`, it was `r/atom`.
+A declaration is friction once. It amortizes to zero over every use site. Today the
+conversion from Reagent is by hand; a codemod is planned and not built. It is a
+small hand: the expensive part of leaving Reagent was never `[:>]`, it was
+`r/atom`.
 
 ## The defaults
 
@@ -80,15 +70,14 @@ Reagent was never `[:>]`, it was `r/atom`.
 | Props | shallow camelCase conversion — `:on-change` becomes `onChange` |
 | Children | hiccup children are converted to React elements |
 | Functions | pass through unconverted |
-| SSR | `:client-only` — the host region renders nothing server-side until the client has adopted the page. Declarable as the `:ssr` option: `:client-only` (the default), or `{:fallback <hiccup>}` for placeholder markup, with an unrecognised policy refused at mint (`:rf.error/hicasso-host-bad-ssr-policy`). Landed 2026-08-04 (`rf2-2rtt6.85`); [Server-side rendering](10-server-side-rendering.md) tells the story |
+| SSR | `:client-only` — the host region renders nothing server-side until the client has adopted the page. Declarable as the `:ssr` option: `:client-only` (the default), or `{:fallback <hiccup>}` for placeholder markup, with an unrecognised policy refused at mint (`:rf.error/hicasso-host-bad-ssr-policy`). [Server-side rendering](10-server-side-rendering.md) tells the story |
 
 Policy overrides live on the declaration rather than at the call site, which is the
 whole point: one place decides how this component is crossed, and every use site
 inherits it. There are exactly two options today — `:callbacks`, a finite map
 from prop name to `:event`, `:handler` or `:render`, and the subject of the next
-section; and `:ssr`, the server policy in the table above, which
-[Server-side rendering](10-server-side-rendering.md) teaches. An option the door
-does not know is refused at mint rather than ignored
+section; and `:ssr`, the server policy in the table above. An option the door does
+not know is refused at mint rather than ignored
 (`:rf.error/hicasso-host-unknown-option`).
 
 Everything a declaration can get wrong, it gets wrong *at the declaration*, where
@@ -172,11 +161,11 @@ function`. **`h/fn` is the spelling for those positions** — it receives every
 argument the invoker passed, in order, which is exactly what the opening example
 does.
 
-Both halves are witnessed at a real crossing, which is what settles the question
-this page used to hedge. The host-hatch suite drives `::h/value` through a widget's
-event-first `onChange` and the model updates; it then drives `::h/prevent`,
-`::h/value` and a key-map through the *same* widget's value-first `onPick` and gets
-the refusal instead, naming `:on-pick` and the string that actually arrived.
+Both halves are witnessed at a real crossing. The host-hatch suite drives
+`::h/value` through a widget's event-first `onChange` and the model updates; it
+then drives `::h/prevent`, `::h/value` and a key-map through the *same* widget's
+value-first `onPick` and gets the refusal instead, naming `:on-pick` and the
+string that actually arrived.
 
 An intent carrying neither a marker nor `::h/prevent` never touches its argument,
 so `{:on-pick [:city/picked "paris"]}` is correct under any invoker contract at
@@ -197,8 +186,8 @@ the Hicasso tree exactly as it would through any other one.
 
 ## When a boundary bails out, the host inside it does too
 
-Every Hicasso boundary is a `React.memo` comparing its props by value (HD-028), and
-that bail-out reaches a hosted component exactly as it reaches a native one:
+Every Hicasso boundary is a `React.memo` comparing its props by value, and that
+bail-out reaches a hosted component exactly as it reaches a native one:
 
 ```clojure
 (defview chrome-page [_]
@@ -219,15 +208,14 @@ to reach *its own* boundary's props — reading it one component further up and
 stopping there is indistinguishable, from the host's side, from the value never
 having changed.
 
-## The escape: `[:>]` is legal
+## The escape: `[:>]` is legal, unbuilt
 
-`[:> Component props & children]` is HD-011's explicitly secondary form — ruled
-legal, not merely tolerated, for the cases a static declaration cannot express.
-It stays **unbuilt in the bench arm**, deliberately: the census found zero
-raw-escape sites to build against, so the door's proof took the v0 budget instead.
-When it lands, the design is that it lowers through the same foreign path with the
-same default conversions, `.cljs`-only at that node, with reduced structural
-identity — exactly the costs listed above, accepted knowingly.
+`[:> Component props & children]` is the explicitly secondary form — legal for
+the cases a static declaration cannot express. It stays **unbuilt**, so there is
+nothing to call today. When it lands, the design is that it lowers through the
+same foreign path with the same default conversions, `.cljs`-only at that node,
+with reduced structural identity — exactly the costs listed under
+[Why a declaration](#why-a-declaration), accepted knowingly.
 
 Reach for it, once it exists, when a static declaration genuinely cannot express
 the case:
@@ -249,22 +237,52 @@ which by looking somewhere else.
 
 ## Migrating from Reagent
 
-HD-011 rules a codemod for the mechanical part — collect the `[:> X …]` sites, emit
-the `defhost` block, rewrite the call sites — but nothing has been built, and the
-record names neither a tool nor an invocation. By hand it is the same three moves,
-and it goes a namespace at a time, so a large app never needs one big commit.
+A codemod for the mechanical part — collect the `[:> X …]` sites, emit the
+`defhost` block, rewrite the call sites — is planned and **not built**. Nothing
+names a tool or an invocation. By hand it is the same three moves, and it goes a
+namespace at a time, so a large app never needs one big commit.
 
-## Imperative SDKs
+## Troubleshooting
+
+This table names mechanisms; the minted ids on this surface —
+`:rf.error/hicasso-ref-vector-reserved`,
+`:rf.error/hicasso-intent-at-a-non-event-contract`,
+`:rf.error/hicasso-intent-needs-the-event`,
+`:rf.error/hicasso-host-bad-ssr-policy` and
+`:rf.error/hicasso-host-unknown-option` — are covered above and under Advanced.
+
+| Symptom | What went wrong | Fix |
+|---|---|---|
+| Prop arrives as `on-change` and the library ignores it | Nested keys expected in camelCase; deep conversion is deliberately not offered | Convert the nested map yourself before it crosses |
+| An intent vector or key-map at a declared slot raises `:rf.error/hicasso-intent-at-a-non-event-contract` | The slot is declared `:handler` or `:render`, and neither contract dispatches — the declaration governs the carrier, so the value cannot overrule it | Declare the slot `:event` if what happens there is an event, or write an `h/fn` that does the `:handler`/`:render` work |
+| `:rf.error/hicasso-intent-needs-the-event`, naming a slot whose library hands a value first | The vector spelling reads the DOM event from argument one, and this invoker put something else there | Write an `h/fn` at that slot — it gets every argument the library passed, in order |
+| A namespace stops loading on the JVM | A JS require reached a `.cljc` file | Quarantine the require in a `.cljs` host namespace |
+| Structural test can't match a node | A `[:>]` node, once the escape is built — reduced structural identity, by design | Declare it with `defhost`, or assert around it |
+| Provider from a library needs to wrap the tree | Hosted like anything else | `defhost` the provider; it is a component |
+| A hosted component doesn't update when the page clearly changed | The boundary above it bailed out on value-equal props — it was never re-entered, so the host was never asked to render | Trace the value to the host's *own* boundary's props, not a parent's |
+| The SDK mounts twice in dev and you end with two live handles | StrictMode double-invoke, plus a handle stored outside the attach's closure — so the second attach overwrote the first instead of replacing it | One attach, one handle, one cleanup, all in one closure; return the cleanup from the ref |
+| The SDK is destroyed and rebuilt on every unrelated render | The ref function has a fresh identity each render, so React detaches and re-attaches | `useCallback` with `#js []` — a stable ref identity |
+| A `nil`-node branch in a ref never runs | The callback returns a cleanup, so React calls that instead of re-invoking with `nil` | Pick one contract; with React 19, pick the return |
+| A listener or observer survives unmount | The cleanup tears down less than the attach built | The cleanup returns the world to the state the attach found it in — nothing checks this for you |
+
+## When not to reach for the door
+
+If the library is a thin wrapper over DOM you could write yourself in twenty lines
+of hiccup, write the twenty lines. Every hosted component is a node your tools can
+see less of and your tests can assert less about. Most applications never need the
+door, and the ones that do need it for two or three genuinely hard widgets.
+
+## Advanced
+
+### Imperative SDKs
 
 A mapping SDK, a chart library that wants a DOM node, anything that hands you a
 handle and expects you to feed it — that is **not** an interop-door problem. It is
-ordinary host-edge React (HD-003): a callback ref, written in a `.cljs` namespace at
-the edge of your app.
+ordinary host-edge React: a callback ref, written in a `.cljs` namespace at the
+edge of your app.
 
-There is no Hicasso concept for this, deliberately. "Behaviors" — a predecessor
-product concept for imperative host ownership — is **not v0 vocabulary**. A richer
-host-ownership pattern is a product-phase question; the v0 answer is React, used
-honestly, at the edge.
+There is no Hicasso concept for this, deliberately — no "behaviors" tier and no
+second ownership model. The v0 answer is React, used honestly, at the edge.
 
 Used honestly means **the attach and the teardown are written as one thing.** An SDK
 that mounts and never tears down is the most common bug at this edge, and it is not
@@ -321,7 +339,7 @@ re-attached on every render, so the SDK is destroyed and rebuilt on every keystr
 elsewhere in the tree. The stable identity is the difference between one mount and
 one mount per render.
 
-### Under StrictMode
+#### Under StrictMode
 
 StrictMode double-invokes the mount in development: attach, cleanup, attach. The
 shape above survives it, and the reason is the first property, not the second. The
@@ -336,12 +354,12 @@ everything in dev and one leak per remount in production. **The rule is that the
 cleanup returns the world to the state the attach found it in**; there is no runtime
 that can check that for you.
 
-### If the runtime does not target React 19
+#### If the runtime does not target React 19
 
-The cleanup-returning ref is a React 19 contract. The record does not pin a React
-version (see **Not settled yet**), so the older shape is worth knowing: the callback
-is invoked with the node on attach and with `nil` on detach, and the handle needs a
-home that outlives one invocation.
+The cleanup-returning ref is a React 19 contract. Hicasso does not pin a React
+version in the product surface (see **Not settled yet**), so the older shape is
+worth knowing: the callback is invoked with the node on attach and with `nil` on
+detach, and the handle needs a home that outlives one invocation.
 
 ```clojure
 (let [handle (react/useRef nil)
@@ -400,44 +418,12 @@ If you find yourself wanting the ref to notice that a prop changed, that is the
 signal to move the change onto the effect path. Nothing in the reserved vector
 will rescue it later.
 
-## Troubleshooting
-
-This table names mechanisms; the minted ids on this surface —
-`:rf.error/hicasso-ref-vector-reserved`,
-`:rf.error/hicasso-intent-at-a-non-event-contract`,
-`:rf.error/hicasso-intent-needs-the-event`,
-`:rf.error/hicasso-host-bad-ssr-policy` and
-`:rf.error/hicasso-host-unknown-option` — are covered above.
-
-| Symptom | What went wrong | Fix |
-|---|---|---|
-| Prop arrives as `on-change` and the library ignores it | Nested keys expected in camelCase; deep conversion is deliberately not offered | Convert the nested map yourself before it crosses |
-| An intent vector or key-map at a declared slot raises `:rf.error/hicasso-intent-at-a-non-event-contract` | The slot is declared `:handler` or `:render`, and neither contract dispatches — the declaration governs the carrier, so the value cannot overrule it | Declare the slot `:event` if what happens there is an event, or write an `h/fn` that does the `:handler`/`:render` work |
-| `:rf.error/hicasso-intent-needs-the-event`, naming a slot whose library hands a value first | The vector spelling reads the DOM event from argument one, and this invoker put something else there | Write an `h/fn` at that slot — it gets every argument the library passed, in order |
-| A namespace stops loading on the JVM | A JS require reached a `.cljc` file | Quarantine the require in a `.cljs` host namespace |
-| Structural test can't match a node | A `[:>]` node, once the escape is built — reduced structural identity, by design | Declare it with `defhost`, or assert around it |
-| Provider from a library needs to wrap the tree | Hosted like anything else | `defhost` the provider; it is a component |
-| A hosted component doesn't update when the page clearly changed | The boundary above it bailed out on value-equal props (HD-028) — it was never re-entered, so the host was never asked to render | Trace the value to the host's *own* boundary's props, not a parent's |
-| The SDK mounts twice in dev and you end with two live handles | StrictMode double-invoke, plus a handle stored outside the attach's closure — so the second attach overwrote the first instead of replacing it | One attach, one handle, one cleanup, all in one closure; return the cleanup from the ref |
-| The SDK is destroyed and rebuilt on every unrelated render | The ref function has a fresh identity each render, so React detaches and re-attaches | `useCallback` with `#js []` — a stable ref identity |
-| A `nil`-node branch in a ref never runs | The callback returns a cleanup, so React calls that instead of re-invoking with `nil` | Pick one contract; with React 19, pick the return |
-| A listener or observer survives unmount | The cleanup tears down less than the attach built | The cleanup returns the world to the state the attach found it in — nothing checks this for you |
-
-## When not to reach for the door
-
-If the library is a thin wrapper over DOM you could write yourself in twenty lines
-of hiccup, write the twenty lines. Every hosted component is a node your tools can
-see less of and your tests can assert less about. The census found **zero** foreign
-components across 85 idiomatic files, which is why this is an escape hatch and not
-tier-1 syntax — most applications never need it, and the ones that do need it for
-two or three genuinely hard widgets.
-
 ## Not settled yet
 
 | Question | Status |
 |---|---|
-| Whether `defhost` grows a second option beyond `:callbacks` | **Settled, landed.** `:ssr` is the second option — `:client-only` (the default) or `{:fallback <hiccup>}`, any other value refused at mint — landed 2026-08-04 with the dated HD-011 addendum, witnessed in `arm1/host_ssr_dom_cljs_test` (`rf2-2rtt6.85`). Whether the conversion defaults ever become declarable is still unstated |
-| The migration codemod | **Ruled, unbuilt.** HD-011's rationale leans on it, but nothing has been built and the record names neither a tool nor an invocation |
-| When the reserved `{:ref [id config]}` spelling lands, and what registers an id | **Reserved, not designed.** HD-022 rules the refusal and the value-space; the registry, the timings and the commands roster are explicitly out of v0 |
-| Which React version the runtime targets | **Not addressed by the design record.** The cleanup-returning callback ref taught above is a React 19 contract; this repo's implementation currently pins React 19.2, but that is a fact about today's tree, not a Hicasso ruling. If v0 lands on 18, the fallback shape above is the one to teach |
-| Embedding Hicasso *inside* a React-primary app | Named in the charter's use-case roster (item 11); no surface designed |
+| Whether conversion defaults ever become declarable on `defhost` | **Open.** `:callbacks` and `:ssr` are the two options today; prop-conversion knobs are unstated |
+| The migration codemod | **Planned, unbuilt.** Nothing names a tool or an invocation |
+| When the reserved `{:ref [id config]}` spelling lands, and what registers an id | **Reserved, not designed.** The refusal and the value-space exist; the registry, timings and commands roster are out of v0 |
+| Which React version the runtime targets | **Not pinned by the product surface.** The cleanup-returning callback ref taught above is a React 19 contract; this repo currently pins React 19.2, which is a fact about today's tree. If v0 lands on 18, the fallback shape above is the one to teach |
+| Embedding Hicasso *inside* a React-primary app | Named as a use case; no surface designed |

--- a/docs/design/hicasso/draft-guide/06-theming.md
+++ b/docs/design/hicasso/draft-guide/06-theming.md
@@ -1,10 +1,9 @@
 # Theming
 
-> **Draft ahead of the product artefact.** This page teaches the ruled surface —
-> [decisions.md](../decisions.md) (HD-001…HD-028) — and spellings marked
-> **[unfrozen]** stay provisional until the API freeze. Theming is ruled (HD-010,
-> HD-023) but largely unexercised by the bench arm, and this page still carries
-> the record's one genuine hole, named below.
+> **Draft ahead of the product artefact.** Spellings marked **[unfrozen]** stay
+> provisional until the API freeze. Theming is largely unexercised by the bench
+> arm, and this page still carries one genuine hole — how the app-db theme
+> choice reaches a DOM attribute — named below rather than papered over.
 
 Every React component library reaches for context to theme itself. Hicasso doesn't
 ship a context API at all, and its theming uses none.
@@ -13,9 +12,9 @@ This is not asceticism. Context is a side channel: it is invisible to the data t
 which kills headless testing and makes SSR harder; it costs a hook per consumer,
 against a ≤2 hook budget already fully spent; it re-renders every consumer when it
 changes; and it is a second dependency-injection channel next to props. The platform
-cascade and the data tree each do the job better on every axis the charter measures,
-and the predecessor library's real usage — a global theme plus per-instance
-overrides — never needed subtree context in the first place.
+cascade and the data tree each do the job better on every axis that matters. Real
+apps already live on a global theme plus per-instance overrides — that pattern
+never needed subtree context in the first place.
 
 Three layers do the work.
 
@@ -50,8 +49,8 @@ costs zero React work** — no re-render, no hook, no diff. The cascade recomput
 your component tree is never consulted, which is exactly right, because nothing in it
 needed to be.
 
-Read that claim precisely, because layer 3 depends on where its edge is. HD-010's
-"one attribute flip, zero React work" describes what happens *after* the attribute
+Read that claim precisely, because layer 3 depends on where its edge is. "One
+attribute flip, zero React work" describes what happens *after* the attribute
 changes. It says nothing about what flips it. See
 [Layer 3 and the DOM](#layer-3-and-the-dom) — the one place this page has to report a
 hole rather than teach around it.
@@ -79,8 +78,8 @@ to tree, you can unit-test a theme with `=`. No registry, no multimethods, no
 runtime resolution order to reason about.
 
 The spellings for declaring a part in a control and installing a theme in an app are
-not in the record. See **Not settled yet** — this layer is the least specified of
-the three.
+not settled. See **Not settled yet** — this layer is the least specified of the
+three.
 
 ## Layer 3 — app-db for the choice
 
@@ -101,17 +100,17 @@ part maps.
 
 ## Layer 3 and the DOM
 
-Here is the part the record does not join up, and the reason this section exists
-rather than a paragraph of confident prose.
+Here is the part that is not joined up, and the reason this section exists rather
+than a paragraph of confident prose.
 
 **That event is a no-op as far as the browser is concerned.** It moves a keyword into
 app-db. Layer 1's cascade keys off a `data-theme` attribute on a DOM element. Nothing
-in HD-010 says how the first becomes the second — it rules "app-db + `sub` for the
-theme choice only" and, separately, "a theme switch is one attribute flip, zero React
-work", and never writes the line between them. A guide that skipped the gap would be
+in the product surface says how the first becomes the second — the choice lives in
+app-db, a theme switch is one attribute flip with zero React work *after* the flip,
+and the line between them is unwritten. A guide that skipped the gap would be
 telling you to write an event that visibly does nothing.
 
-Two bridges close it. Neither needs a new API, and the record picks neither.
+Two bridges close it. Neither needs a new API, and neither is the taught one yet.
 
 ### Bridge A — a scope view reads the choice
 
@@ -133,13 +132,13 @@ spliced with `into` rather than dropped in as one child —
 **Its true cost.** The boundary that reads the theme re-renders on every switch —
 that much is certain, and it is one boundary. What happens below it turns on the
 [default value-equality bail-out](02-views-and-reads.md#boundaries-memoize-by-default)
-(HD-028) rather than on how `theme-scope` gets its content. `app` is a boundary
-either way — handed down as `children` or minted directly inside `theme-scope`'s
-own body — and its props are unaffected by the theme, so they compare `=` at every
-re-render and its own memo wrapper bails regardless of which style you write. The
-way to lose the bail-out is to call `app` as a plain function instead of writing
-`[app {}]`. A plain call has no boundary of its own to hold a memo wrapper, so it
-re-runs with `theme-scope` every time — independent of which bridge you chose.
+rather than on how `theme-scope` gets its content. `app` is a boundary either way —
+handed down as `children` or minted directly inside `theme-scope`'s own body — and
+its props are unaffected by the theme, so they compare `=` at every re-render and
+its own memo wrapper bails regardless of which style you write. The way to lose the
+bail-out is to call `app` as a plain function instead of writing `[app {}]`. A plain
+call has no boundary of its own to hold a memo wrapper, so it re-runs with
+`theme-scope` every time — independent of which bridge you chose.
 
 Element identity does not enter into it, because there is none to preserve.
 Children cross a boundary as hiccup data, not as React elements, so `theme-scope`
@@ -165,8 +164,8 @@ returns an effect, and the effect does the flip.
 ```
 
 **Its true cost.** Zero React work, literally rather than approximately: no
-subscription, no boundary, no render. HD-010's claim is exactly true under this
-bridge.
+subscription, no boundary, no render. The "one attribute flip, zero React work"
+claim is exactly true under this bridge.
 
 **What you pay for it.** Three things, and they are real:
 
@@ -179,27 +178,25 @@ bridge.
 - **It is not frame-isolated.** `document.documentElement` is one element and two
   frames on one page share it, which contradicts the "frame isolation for free" that
   layer 3 otherwise gets. Targeting each root's own node instead would need the
-  effect to reach that node, and nothing in the record says an effect can.
+  effect to reach that node, and nothing in the product surface says an effect can.
 
-### Unresolved, and deliberately so
+### Pricing the bridges
 
-**Which bridge is the taught one is not settled**, and this guide is not the place to
-settle it — naming one would be designing the missing half rather than reporting it.
-The shape of the choice is clear enough to state, though: bridge A keeps the DOM
-derived from state at the cost of the one reading boundary (HD-028's default
-bail-out covers the rest, per [Bridge A](#bridge-a--a-scope-view-reads-the-choice)
-above); bridge B has no render cost and gives up the derivation. It is the ordinary
-trade between rendering a fact and imperatively asserting it, and it is a design
-decision with a witness attached.
+**Which bridge is the taught one is not settled.** Naming one here would be
+designing the missing half rather than reporting it. The shape of the choice is
+clear enough: bridge A keeps the DOM derived from state at the cost of the one
+reading boundary (the default bail-out covers the rest, per
+[Bridge A](#bridge-a--a-scope-view-reads-the-choice) above); bridge B has no render
+cost and gives up the derivation. It is the ordinary trade between rendering a fact
+and imperatively asserting it.
 
-What would settle it: confirmation on the multi-frame witness that bridge A's cost
-holds at one boundary in practice, and a ruling on whether the theme attribute is
-per-root or per-document. The first is a P1 instrument. The second is a sentence
-somebody has to write.
+What would settle it for the reader in practice: whether bridge A's cost holds at
+one boundary under multi-frame load, and whether the theme attribute is per-root or
+per-document. Both are open; neither is answered by picking a bridge in this guide.
 
 ## The two laws
 
-Layers 1 and 2 would be a footgun without these. Both are ruled in HD-010.
+Layers 1 and 2 would be a footgun without these.
 
 ### (a) The owned-literal merge law
 
@@ -211,12 +208,11 @@ Without this law, a stylesheet-shaped piece of data could reach in and clobber t
 `:value` of a controlled input — and you would debug that as an input bug for a day
 before you thought to look at the theme.
 
-**The law is not theming-specific.** HD-023 makes it unconditional: there is one
-attribute merge, spelled `:&`, and the literal keys written in the map always win
-over it — whether what arrives is a theme's part attributes, a caller's forwarded
-remainder, or anything else. So a control that emits parts and a control that
-forwards props are the same code, defended by the same rule, and there is no second
-merge form to choose between. See
+**The law is not theming-specific.** There is one attribute merge, spelled `:&`, and
+the literal keys written in the map always win over it — whether what arrives is a
+theme's part attributes, a caller's forwarded remainder, or anything else. So a
+control that emits parts and a control that forwards props are the same code,
+defended by the same rule, and there is no second merge form to choose between. See
 [Controlled inputs](04-controlled-inputs.md#forwarding-attributes-onto-a-controlled-input).
 
 ### (b) The static-map law
@@ -242,11 +238,11 @@ runtime. That is the failure mode the law exists to prevent.
 
 ## React context is still there
 
-HD-010 bans a *Hicasso* context API and context-based *theming*. It does not ban
+Hicasso bans a *Hicasso* context API and context-based *theming*. It does not ban
 React.
 
 The substrate keeps exactly one internal context — frame identity — and ordinary
-React context remains available to an advanced author at the HD-003 escape hatch: a
+React context remains available to an advanced author at the host-edge escape: a
 compound-component contract you are implementing, or a provider an ecosystem library
 demands. Foreign providers come in through [`defhost`](05-interop.md) like any other
 component.
@@ -262,7 +258,7 @@ This table names mechanisms rather than error ids.
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | The theme keyword changes in app-db and nothing on screen changes | No bridge is wired — app-db holds the choice, and the cascade keys off a DOM attribute | Wire one of the two bridges above; the event alone does nothing to the document |
-| Theme switch re-renders the whole app | Bridge A, with the themed content spliced in as a plain call rather than a `[boundary …]` vector — a plain call has no boundary of its own for HD-028's default bail-out to attach to | Put the content behind a boundary (children or a direct `[app {}]`, either works), or use bridge B |
+| Theme switch re-renders the whole app | Bridge A, with the themed content spliced in as a plain call rather than a `[boundary …]` vector — a plain call has no boundary of its own for the default bail-out to attach to | Put the content behind a boundary (children or a direct `[app {}]`, either works), or use bridge B |
 | A time-travel rewind shows the old theme | Bridge B — the attribute was asserted by an effect, so it is not derived from the state you rewound | Expected under bridge B; it is the price named above |
 | A controlled input's value gets clobbered by a theme | Should be impossible — law (a) | A runtime bug, not a usage error |
 | A part override doesn't take effect | Merge order: instance props beat app theme beat base | Check which layer you set it in |
@@ -283,10 +279,10 @@ order to remember, in exchange for a flexibility nobody is going to use.
 
 | Question | Status |
 |---|---|
-| **How the app-db choice reaches the `data-theme` scope** | **Unresolved, and the largest hole on this page.** HD-010 rules the choice into app-db and rules the switch to be one attribute flip, and never joins them. [Layer 3 and the DOM](#layer-3-and-the-dom) names both candidate bridges and prices them; picking one is a design decision, not a writing decision |
+| **How the app-db choice reaches the `data-theme` scope** | **Unresolved — the largest hole on this page.** The choice lives in app-db; the switch is one attribute flip after it lands. [Layer 3 and the DOM](#layer-3-and-the-dom) names both candidate bridges and prices them; picking one is still open |
 | Whether the theme attribute is per-root or per-document | **Not addressed.** Layer 3 promises frame isolation; a document-level attribute does not have it |
-| How a control declares a part | **Not addressed.** "Controls emit keyword-tagged parts" is the whole of the record; the attribute or macro that does it is unnamed |
-| How an app installs a theme | **Not addressed.** The merge order `base < app-theme < instance-props` is ruled; the mechanism that supplies the app-theme layer is not. Since there is no context, it is presumably passed or registered — the record does not say which |
-| The part-address shape | This guide writes `[:typeahead :root]` by analogy with the record's "part address" language; the actual shape is unstated |
+| How a control declares a part | **Not addressed.** "Controls emit keyword-tagged parts" is the whole of the claim; the attribute or macro that does it is unnamed |
+| How an app installs a theme | **Not addressed.** The merge order `base < app-theme < instance-props` is fixed; the mechanism that supplies the app-theme layer is not. Since there is no context, it is presumably passed or registered — which is unstated |
+| The part-address shape | This guide writes `[:typeahead :root]` by analogy; the actual shape is unstated |
 | Where the boot-static part map lives | Implied by law (b) to be fixed at build; the residence is unstated |
 | The controls kit that would ship parts | **Post-v0** |

--- a/docs/design/hicasso/draft-guide/07-ephemeral-state.md
+++ b/docs/design/hicasso/draft-guide/07-ephemeral-state.md
@@ -1,12 +1,10 @@
 # Ephemeral state
 
-> **Draft ahead of the product artefact.** This page teaches the landed surface —
-> ruled in [decisions.md](../decisions.md) (HD-001…HD-028), witnessed by the bench
-> arm's tests under `implementation/freehand/test/re_frame/bench/hicasso/` — but no
+> **Draft ahead of the product artefact.** This page teaches the landed surface,
+> witnessed by the bench arm under
+> `implementation/freehand/test/re_frame/bench/hicasso/` — but no
 > `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
-> stay provisional until the API freeze. One surface here is ahead of even that:
-> `h/reg-state` is **ruled but still landing** (2026-08-04), and the page says so
-> where it teaches it.
+> stay provisional until the API freeze.
 
 Is this dropdown open? Is this row hovered? Is this panel expanded?
 
@@ -18,9 +16,8 @@ That is a strong claim, so here is the evidence it rests on: a census of **85
 idiomatic re-frame files**, containing every classic hard case, found **zero
 view-local reactive cells**. Not few. Zero. Most of Reagent's local-state demand was
 manufactured by machinery — the reaction engine, deref capture, argv memoization —
-that Hicasso deletes structurally. And a second reactive system sits at the top of
-the anti-regression fence in the [charter](../charter.md): a view layer that grows
-one has failed back into its predecessors.
+that Hicasso deletes structurally. A second reactive system for application state
+is the failure mode this surface refuses to reintroduce.
 
 ## The placement rule
 
@@ -85,16 +82,11 @@ component.
 That last one is worth sitting with. "Open this dropdown in a test" is a `:db`
 write, not a click simulation.
 
-The second part is that **the ten lines become one.** On 2026-08-04 the sugar
-HD-009 had been holding as an unfrozen sketch was designed and ruled into v0
-(the dated HD-009 addendum in [decisions.md](../decisions.md) is the record).
-Honest tense, as this page's banner says: `h/reg-state` is ruled and in
-implementation — nothing has landed yet, and the spelling is **[unfrozen]** —
-so today you write the ten lines above, and they are exactly what the
-declaration will register for you:
+The second part is that **the ten lines become one.** `h/reg-state` **[unfrozen]**
+is landed sugar, witnessed in the bench arm. It registers the same ordinary sub
+and event you would have written by hand:
 
 ```clojure
-;; RULED 2026-08-04 — in implementation, not yet landed.
 (h/reg-state ::expanded? {:default false})
 ;; mints: a parametric sub        (sub [::expanded? panel-id])
 ;;        a concern-named setter  [::expanded? panel-id true]
@@ -103,33 +95,34 @@ declaration will register for you:
 
 One declaration per *concern* — a namespace-qualified keyword — with
 `{:default v}` as the only option. No state system arrives with it: it
-registers the same ordinary sub and event you would have written, reading and
-writing plain app-db at a documented path, which is why everything above stays
-true under it — time travel, Xray, per-frame isolation, tests writing `:db`.
-The long form remains worth knowing anyway: it is the definition of what
-`reg-state` does, and the shape you graduate to when a write starts to *mean*
-something (next section — the example's `:panel/toggle` is already that
-graduation).
+registers ordinary re-frame artefacts that read and write plain app-db at a
+documented path, which is why everything above stays true under it — time
+travel, Xray, per-frame isolation, tests writing `:db`.
 
-Two details are part of the ruling because getting them wrong is silent
-otherwise. **Clearing is a framework event, not a magic value**: dispatch
+Keep the long form in mind anyway. It is the definition of what `reg-state`
+mints, and the shape you graduate to when a write starts to *mean* something
+(next section — the example's `:panel/toggle` is already that graduation).
+
+Two details matter because getting them wrong is silent otherwise.
+
+**Clearing is a framework event, not a magic value.** Dispatch
 `[::h/clear ::expanded? panel-id]` and the entry is removed, so the default
-shows through again. A reserved clear *value* was rejected on the record — a
-concern whose legitimate values are keywords could then silently delete state.
-And **a nil or malformed instance key refuses loudly**, at read and at write,
-with `:rf.error/hicasso-state-bad-key` naming the concern — instead of quietly
-filing every instance's state under the same broken key.
+shows through again. A reserved clear *value* is not offered — a concern whose
+legitimate values are keywords could then silently delete state.
+
+**A nil or malformed instance key refuses loudly**, at read and at write, with
+`:rf.error/hicasso-state-bad-key` naming the concern — instead of quietly filing
+every instance's state under the same broken key.
 
 ## Choosing the instance key
 
 `reg-state` and the long form share one authored input: the instance key —
 `panel-id` above, the value that keeps a hundred panels from sharing one
-`expanded?`. Hicasso mints no identity for you. (React's `useId` was examined
-and disqualified on the record: its hydration ids diverge under the arm's own
-hydration root, and outside hydration it is a counter whose ids do not survive
-remount — which state resident in app-db cannot tolerate.) The key is authored
-data — a keyword, string, number, or vector of these — and four rules cover
-choosing it.
+`expanded?`. Hicasso mints no identity for you. React's `useId` is not a fit
+here: its hydration ids can diverge under a hydration root, and outside
+hydration it is a counter whose ids do not survive remount — which state
+resident in app-db cannot tolerate. The key is authored data — a keyword,
+string, number, or vector of these — and four rules cover choosing it.
 
 **Domain ids first — entity-qualified when entities can collide.** The best key
 already exists in your data: the order's id, the row's id, a literal namespaced
@@ -170,10 +163,10 @@ Write `[:panel/toggle id]`, never a generic `[:ui/set [:panel/expanded id] true]
 
 A named event is a name for what happened, which is the entire premise of the event
 log being readable. A generic setter turns your event history into a diff stream and
-takes the meaning out of the one place the framework was keeping it for you. This is
-also HD-009's law for the sugar, kept by the ruled `reg-state`: the setter it mints
-is **named by its concern** — `[::expanded? panel-id false]` reads as what it is in
-the log — never a generic `ui/set`.
+takes the meaning out of the one place the framework was keeping it for you.
+`reg-state` keeps that law for the sugar: the setter it mints is **named by its
+concern** — `[::expanded? panel-id false]` reads as what it is in the log — never a
+generic `ui/set`.
 
 The concern-named setter is a floor, not a ceiling. When an occurrence means more
 than an assignment — the collapse should fire an effect, other state reacts, the
@@ -187,25 +180,15 @@ Layer 2 above is mostly a promise. The controls kit that would own drafts and
 revisions is post-v0. So is the overlay top layer. In v0, a dismissible dropdown is
 CSS if you can manage it, and app-db if you can't.
 
-The ceremony story, though, moved on 2026-08-04. HD-009 originally shipped
-nothing here: the sugar was a pre-agreed *response class*, an unfrozen
-`defstate` sketch to be designed only if dogfooding demanded it. The operator
-ruled it into v0 instead, and the same-day design programme — three independent
-designs, three adversarial reviews — produced the `reg-state` ruling this page
-now teaches. One peer review had argued for a `useState` fence and a
-pre-designed tier; the fence is still rejected — there is no lint police — and
-the tier that was once withdrawn from pre-commitment is now simply *designed*,
-on evidence: `[:ui <concern> <instance-key>]`, one conventional app-space root.
-The no-`local` core stands throughout.
+What *is* in v0 is the ceremony answer: `reg-state` for the ordinary assignment
+case, the long form when a write means more than assignment, one conventional
+app-space root at `[:ui <concern> <instance-key>]`, and no second state system.
+There is still no lint fence around `useState` — the placement rule is taught, not
+policed — and the no-`local` core stands throughout.
 
-The response class did not disappear; it moved one rung up. If dogfooding shows
-that explicitly threading the instance key is itself what fails the preference
-test, the pre-registered escalation is the ambient/auto door from the rejected
-structural design — a recorded mechanism, not an ad-hoc invention, and still
-never a state system.
-
-So: a v0 complaint about state ceremony is still **expected signal**, not a
-verdict. The first response shipped early, and the next one is already named.
+A complaint about state ceremony is **expected signal**, not a verdict. If
+explicitly threading the instance key turns out to be the pain, the next step
+is an ambient/auto door — still never a parallel state system.
 
 ## The state you cannot put in app-db: "it left, but it is still on screen"
 
@@ -233,12 +216,10 @@ the way out — **in its own attribute map**:
 
 Three things about that block.
 
-**There is no child view.** The whole tray is written inline, in the parent. In the
-predecessor this is not possible: the phase is an ambient read, so reading it in
-markup written inline in the parent silently gives you the *parent's* phase, and
-the guide says so outright. The fix there is to extract the toast into a declared
-keyed view — a view whose only reason to exist is that a dynamic variable needs
-somewhere to resolve.
+**There is no child view.** The whole tray is written inline, in the parent.
+Phase is not an ambient dynamic that could silently resolve to the parent's
+context — exit attributes sit on the node itself as data, so inline markup is
+safe.
 
 **The a11y attributes are one map, not three conditionals.** A retained node is
 still in the document: it can take focus and clicks until you say otherwise. That
@@ -297,23 +278,22 @@ you have looked at the paint race and decided you can live with losing it now an
 then. What it is not is the recommended way to make something fade in.
 
 One thing to know before you lean on mounting-phase attributes for correctness
-rather than for looks. Under the ruled SSR design a presence-managed node
-**hydrates born-present**, so server HTML never carries `:mounting`-phase
-attributes at all ([Server-side rendering](10-server-side-rendering.md)). Nothing
-that arrived with the page replays an entrance over content the user is already
-reading, which is the behaviour you want — but it does mean the first paint of a
-server-rendered page is not a moment when `::h/mounting` has been applied.
+rather than for looks. Under SSR, a presence-managed node **hydrates
+born-present**, so server HTML never carries `:mounting`-phase attributes at all
+([Server-side rendering](10-server-side-rendering.md)). Nothing that arrived with
+the page replays an entrance over content the user is already reading, which is
+the behaviour you want — but it does mean the first paint of a server-rendered
+page is not a moment when `::h/mounting` has been applied.
 
 ## Where is `:on-mount`?
 
 There is no `:on-mount` and no `:on-unmount`, and as with `local`, the absence is
-ruled rather than pending. Hicasso took the *attribute* half of Replicant's
+deliberate rather than pending. Hicasso took the *attribute* half of Replicant's
 mechanism — `::h/mounting` and `::h/unmounting` above — and rejected the callback
-half, `:replicant/on-mount` and `:replicant/on-unmount`, as less data-oriented
-than a registered behaviour. Presence is the one mechanism that knows a node
-arrived or left, and it never dispatches anything about either, deliberately. And
-the hook-budget witness holds the tier-1 shapes to a page with no `useEffect` on
-it anywhere.
+half as less data-oriented than a registered behaviour. Presence is the one
+mechanism that knows a node arrived or left, and it never dispatches anything
+about either, deliberately. And the hook-budget witness holds the tier-1 shapes
+to a page with no `useEffect` on it anywhere.
 
 An absence with nowhere to go would be a gap. Four jobs send people looking for
 `:on-mount`, and each of them has a home.
@@ -353,12 +333,13 @@ row.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| Reaching for `useState` to hold "is this open?" | That's semantic state | app-db, or CSS if the platform tracks it |
-| Searching for `:on-mount`, `componentDidMount`, or a mount `useEffect` | There is none, and the absence is ruled rather than pending | Name the job: route `:resources` for page data, `:initial-events` for startup, presence for animation, a callback `:ref` or `defhost` at a host edge |
+| Reaching for `useState` to hold "is this open?" | That's semantic state | app-db (`reg-state` or the long form), or CSS if the platform tracks it |
+| Searching for `:on-mount`, `componentDidMount`, or a mount `useEffect` | There is none, and the absence is deliberate rather than pending | Name the job: route `:resources` for page data, `:initial-events` for startup, presence for animation, a callback `:ref` or `defhost` at a host edge |
 | A dismissed item disappears instantly with no exit animation | The node left with the data | `h/presence` with a `:timeout-ms` at least as long as the exit transition |
 | A retained node still takes focus or clicks while fading | The exit override does not carry `:inert` / `:aria-hidden` | Put all three in the `::h/unmounting` map |
 | An exit override on a view head raises `:rf.error/hicasso-presence-override-on-a-view` | Presence merges overrides into nodes it can see; a view is opaque to it, and a silently dropped override is the failure class the loud error exists to delete | The view receives `:rf/phase` — branch or style on that |
 | Every panel in a list opens at once | The state isn't parameterised by instance — or two instances share one key | Key the path per instance: [Choosing the instance key](#choosing-the-instance-key) |
+| A nil or malformed instance key raises `:rf.error/hicasso-state-bad-key` | The key is not a keyword, string, number, or vector of those | Author a stable domain or placement key; nest with `h/child-key` when needed |
 | A hook body can't be tested headlessly | Hooks put a body outside headless scope, by design | Move the semantic half to app-db; mount-test the mechanics |
 | Hook-order error after a conditional early-return | React's rules, now yours | Hooks at the top of the body, unconditionally |
 | app-db is full of `:ui` noise | Expected — it is the honest home | Namespace the keys and exclude the tier from persistence by convention |
@@ -382,8 +363,7 @@ that edge needs to know it exists.
 
 | Question | Status |
 |---|---|
-| `h/reg-state` (the sketch formerly spelled `defstate`) | **Ruled 2026-08-04** — the shape is fixed and in implementation (`rf2-2rtt6.98`), not yet landed; the spelling is **[unfrozen]** until the API freeze |
-| The declared app-db `[:ui …]` tier | **Ruled 2026-08-04.** One app-space conventional root, concern-first: `[:ui <concern> <instance-key>]`. Per-frame isolation is free (app-db is per frame); durable persistence excludes the tier by convention; the payload obligation above is the SSR half |
+| Vector `:ref` host behaviours (`{:ref [::id opts]}`) | **Reserved, not designed** — refused today with `:rf.error/hicasso-ref-vector-reserved`; write a function ref until a data spelling exists |
 | The controls kit (drafts, revisions) | **Post-v0** |
 | The overlay top layer that would own open and dismiss | **Post-v0** |
-| The reusable-widget instance-key convention | **Ruled 2026-08-04, in v0** — the four rules in [Choosing the instance key](#choosing-the-instance-key); the sugar that carries it is in implementation (`rf2-2rtt6.98`) |
+| The spellings | `h/reg-state`, `h/presence`, `h/child-key` and friends are bench-arm names; every spelling on this page is **[unfrozen]** until the API freeze |

--- a/docs/design/hicasso/draft-guide/08-testing.md
+++ b/docs/design/hicasso/draft-guide/08-testing.md
@@ -1,14 +1,13 @@
 # Testing
 
-> **Draft ahead of the product artefact.** This page teaches the ruled surface —
-> [decisions.md](../decisions.md) (HD-001…HD-028) — and spellings marked
-> **[unfrozen]** stay provisional until the API freeze. **Read this page with one
-> extra caution.** The mounted door exists: the bench arm's suites under
-> `implementation/freehand/test/re_frame/bench/hicasso/` are it. **The headless
-> door is ruled and not built** — no structural render function exists anywhere in
-> the tree, and the one below is this guide's illustration of HD-021's semantics
-> rather than a call you can make today. What is real now is the property the door
-> rests on, and this page says which is which.
+> **Draft ahead of the product artefact.** Spellings marked **[unfrozen]** stay
+> provisional until the API freeze. **Read this page with one extra caution.** The
+> mounted door exists as the bench arm's suites under
+> `implementation/freehand/test/re_frame/bench/hicasso/` — fixtures, not a named
+> product facade. **The headless door is not built** — no structural render function
+> exists in the tree, and the sketch below is this guide's illustration of the
+> intended semantics rather than a call you can make today. What is real now is
+> the property the door rests on, and this page says which is which.
 
 There are two doors into a Hicasso view under test, and knowing which one you are
 allowed through is most of the skill.
@@ -17,19 +16,19 @@ The headless door is fast, runs on the JVM, and asserts hiccup with `=`. It cove
 hook-free tier-1 bodies. Everything else — hooks, foreign components, anything at a
 host edge — goes through the mounted door, in a real browser.
 
-That boundary is a ruling, not a limitation of the current implementation. HD-021
-says it in four words: **no fake hook dispatcher, ever.**
+That boundary is deliberate, not a temporary gap: **no fake hook dispatcher,
+ever.**
 
 ## The headless door
 
 A structural render returns the view's hiccup tree as data. No DOM, no React, no
-browser. **Nothing implements this yet** — HD-021 rules the semantics and no
-function anywhere in the tree performs one, so read the block below as the shape
-that is ruled rather than a test you can write this afternoon:
+browser. **Nothing implements this yet** — the intended shape is fixed and no
+function in the tree performs one, so read the block below as the shape that is
+designed rather than a test you can write this afternoon:
 
 ```clojure
 ;; SKETCH — h/render does not exist, and its spelling is [unfrozen] besides.
-;; HD-021's ruled semantics, spelled by this guide so the shape is visible.
+;; Intended semantics, spelled by this guide so the shape is visible.
 (deftest todo-row-renders-title
   (let [tree (h/render [todo-row {:id 7}]
                        {:subs {[:todo/by-id 7]      {:title "Buy milk"}
@@ -61,10 +60,8 @@ presence child's exit rendering are each asserted by `=`, with no browser and no
 clock (`front/intent_cljs_test`, `front/route_link_cljs_test`,
 `front/presence_cljs_test`).
 
-This is what deletes the retail. The census counted **364 `data-testid` attributes**
-across the corpus, most of them scaffolding for browser tests that only existed
-because the tree wasn't inspectable. Make the tree data and most of them stop
-earning their place.
+Make the tree data and most of the `data-testid` scaffolding that only existed
+because the tree wasn't inspectable stops earning its place.
 
 ## Where headless stops
 
@@ -76,7 +73,7 @@ component through [`defhost`](05-interop.md) (or the `[:>]` escape, once it is
 built), the foreign region is out.
 
 The temptation is obvious: stub the hook dispatcher, get the whole tree back, keep
-the fast tests. HD-021 forecloses it. A fake dispatcher passes tests that a real
+the fast tests. That is foreclosed. A fake dispatcher passes tests that a real
 React would fail, and the bugs it hides are exactly the ones — abandoned renders,
 StrictMode double-invoke, effect ordering — that you needed a test for. Better a
 loud boundary you can see than a green suite you can't trust.
@@ -87,12 +84,13 @@ component you mount-test once.
 
 ## The mounted door
 
-A shared browser facade covers root lifecycle, a synchronous dispatch door, and
-residue assertions **[unfrozen — the facade has no name in the record]**. Note what
-it deliberately is not built on: `act` diverts React's work to a queue that is not
-the browser's, which is right for an effect-ordering test and wrong for a witness
-that reads the page. The bench arm's fixture flushes instead, so an assertion on
-the line after a dispatch reads the DOM the user would have seen.
+What exists today is the **bench arm's fixture**, not a product-named facade. It
+covers root lifecycle, a synchronous dispatch door, and residue assertions
+**[unfrozen — no product name yet]**. Note what it deliberately is not built on:
+`act` diverts React's work to a queue that is not the browser's, which is right for
+an effect-ordering test and wrong for a witness that reads the page. The bench
+fixture flushes instead, so an assertion on the line after a dispatch reads the DOM
+the user would have seen.
 
 One assertion is standing, on every mounted test: **zero leaked subscription
 ref-counts after teardown.** A related invariant rides with it — an unchanged hot
@@ -124,7 +122,7 @@ This table names mechanisms rather than error ids.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| Headless render throws on a body with hooks | Out of scope, by ruling | Mount-test it, or split the semantic half into a hook-free body |
+| Headless render throws on a body with hooks | Out of scope by design | Mount-test it, or split the semantic half into a hook-free body |
 | A sub read returns `nil` in a headless test | The query wasn't in the resolver map | Sub-key identity is `(query-id, args)` under value equality — check the args match exactly |
 | Assertion fails on a `nil` in the tree | A `when` produced `nil`, which renders nothing but is still in the data | Assert the `nil`, or filter before comparing |
 | Ref-count leak after teardown | A subscription outlived its root | A runtime bug — this is the standing assertion, not a test you tune |
@@ -145,10 +143,10 @@ these reads — and they are excellent at it precisely because that is all they 
 
 | Question | Status |
 |---|---|
-| The headless render function's name and signature | **Not addressed, and not built.** HD-021 pins the semantics — structural render as data, sub reads overridable — and names nothing; nothing in the tree implements one. `h/render` and the `{:subs …}` option above are this guide's invention |
-| The read resolver's shape | **Not addressed.** "A pure read resolver" is the whole of the record; a map is the obvious form, and it is a guess |
-| The mounted facade's name and API | **Not addressed.** The bench arm's fixture is the only one that exists, it is not a product surface, and it already diverges from the description the record sketched it with — it flushes rather than using `act` |
+| The headless render function's name and signature | **Not built.** Semantics are pinned — structural render as data, sub reads overridable — and nothing in the tree implements one. `h/render` and the `{:subs …}` option above are this guide's invention; the spelling is **[unfrozen]** |
+| The read resolver's shape | **Not addressed.** "A pure read resolver" is the whole of the claim; a map is the obvious form, and it is a guess |
+| The mounted facade's name and API | **Not addressed.** The bench arm's fixture is the only one that exists; it is not a product surface, and it flushes rather than using `act` |
 | Whether headless renders one boundary or a subtree | **Not addressed.** The example above renders one; whether child boundaries are rendered through or returned as unexpanded nodes is unstated, and it changes how every test is written |
 | How intent vectors are *invoked* in a headless test | **Not addressed.** They can be asserted by equality; whether the door lets you fire one and observe the dispatch is unstated |
 | The registry / manifest surface — views enumerable with schemas, docs, source coordinates | **Post-v0.** Named as the AI-ergonomics door |
-| Explain-render tooling | **Post-v0.** HD-005 ships a ~3-line nil-checked evidence sink on the index so it can attach later at zero detached cost; no evidence subsystem ships in v0 |
+| Explain-render tooling | **Post-v0.** A small nil-checked evidence sink is planned so tooling can attach later; no evidence subsystem ships in v0 |

--- a/docs/design/hicasso/draft-guide/09-when-a-view-throws.md
+++ b/docs/design/hicasso/draft-guide/09-when-a-view-throws.md
@@ -1,10 +1,7 @@
 # When a view throws
 
-> **Draft ahead of the product artefact.** This page teaches the landed surface —
-> ruled in [decisions.md](../decisions.md) (HD-001…HD-028), witnessed by the bench
-> arm's tests under `implementation/freehand/test/re_frame/bench/hicasso/` — but no
-> `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
-> stay provisional until the API freeze.
+> **Draft ahead of the product artefact.** No `implementation/hicasso/` artefact
+> ships yet. Spellings marked **[unfrozen]** stay provisional until the API freeze.
 
 A view body throws — a `nil` where a map was expected, a key that moved, a
 subscription returning a shape last week's code doesn't handle. React's answer is
@@ -128,6 +125,6 @@ flow, which is a worse version of a `:status` key.
 
 | Question | Status |
 |---|---|
-| `h/boundary`'s name and its three key names | Semantics pinned by HD-020(c); the spellings are unfrozen like every other declaration spelling |
-| Whether `:on-error` should reach an application-wide handler as well | **Not addressed.** The record ships the per-boundary door and stops there; how an app aggregates failures is its own business today |
-| A richer boundary API | **Post-v0**, explicitly. HD-020 reopens it at product phase by ordinary ruling |
+| `h/boundary`'s name and its three key names | Semantics pinned; the spellings are unfrozen like every other declaration spelling |
+| Whether `:on-error` should reach an application-wide handler as well | **Not addressed.** The per-boundary door ships; how an app aggregates failures is its own business today |
+| A richer boundary API | **Post-v0** |

--- a/docs/design/hicasso/draft-guide/10-server-side-rendering.md
+++ b/docs/design/hicasso/draft-guide/10-server-side-rendering.md
@@ -1,39 +1,31 @@
 # Server-side rendering
 
-> **Draft ahead of the product artefact — and this page carries more in-flight
-> scope than any other, so it is written in strict honest tense.** SSR +
-> hydration became **required** Hicasso scope by operator ruling on 2026-08-04;
-> the HD-020 addendum in [decisions.md](../decisions.md) is the record, and the
-> same-date addendum in
-> [EP-0038](../../../EP/EP-0038-the-hicasso-view-layer-programme.md) carries the
-> requirement set. The framework's own SSR machinery **ships today**. Of
-> Hicasso's doors, the hydration door and `defhost`'s `:ssr` policy are
-> **landed in the bench arm and witnessed**; the Node render entry is **in
-> review**; the end-to-end witness has **not run**; the production server arm
-> is **not ruled**. Every section says which of those it is describing,
-> spellings marked **[unfrozen]** stay provisional until the API freeze, and an
-> app that needs SSR before the doors land uses a first-class adapter — this
-> page ends on exactly that.
+> **Draft ahead of the product artefact — and this page carries more open scope
+> than most.** The framework's own SSR machinery **ships today**. Hicasso's
+> hydration door, `defhost`'s `:ssr` policy, the Node render entry, and the
+> spike witness set are **landed and witnessed in the bench arm**; the
+> production server arm is **not decided**. No `implementation/hicasso/`
+> artefact ships yet, spellings marked **[unfrozen]** stay provisional until
+> the API freeze, and an app that needs full production SSR today still has a
+> supported path through the first-class adapters — this page ends on exactly
+> that.
 
 SSR is not a feature re-frame2 bolted on; it is one of the reasons the
 architecture looks the way it does. Spec 011 opens by calling it a core goal,
 and the decisions that make it cheap were taken long ago: views are pure
 functions of state, events are data, and a frame is cheap enough to create for
 one request and destroy when the response is written. Hicasso claims to be
-re-frame2's **native** view layer, and on 2026-08-04 the operator drew the
-consequence — *"SSR is an important part of re-frame2. If hicasso is to be the
-re-frame native view layer then it has to be used with SSR."* HD-020 had ruled
-SSR out of v0; that clause carried its own reopening condition, and this is the
-ruling that reopened it.
+re-frame2's **native** view layer, so it has to hold up its end of that story —
+render on the server, adopt in the browser, and keep both sides honest.
 
-The design that came out of that ruling fits in a sentence:
+The design fits in a sentence:
 
-> **One renderer, run in two places, judged in one.**
+> **One renderer, run in two places, judged by the framework's hydration
+> machinery.**
 
 The runtime that renders in the browser is the runtime that renders on the
-server; the framework's existing hydration machinery carries the result across;
-and whether the whole story holds is decided by one witness set at one sitting,
-not by this guide's optimism.
+server; the framework's existing hydration path carries the result across;
+parity is construction, not a second emitter hoping to agree.
 
 ## The framework's story, which exists today
 
@@ -74,54 +66,53 @@ teaches it at corpus depth. The shape, in brief:
 4. The DOM is adopted with React's `hydrateRoot` — the server's nodes are kept
    and listeners attached, never thrown away and rebuilt.
 
-None of that is Hicasso's to reinvent. Requirement R0 of the ruling says so
-outright: Hicasso participates in the **existing** story — the payload, the
-`:rf/hydrate` door, the mismatch machinery, `ssr-ring` as the HTTP host —
-never a parallel Hicasso-only mechanism. Everything below is about the two
-places where a view layer has to hold up its own end: rendering on the server,
-and adopting in the browser.
+None of that is Hicasso's to reinvent. Hicasso participates in the **existing**
+story — the payload, the `:rf/hydrate` door, the mismatch machinery, `ssr-ring`
+as the HTTP host — never a parallel Hicasso-only mechanism. Everything below is
+about the two places where a view layer has to hold up its own end: rendering
+on the server, and adopting in the browser.
 
 ## What Hicasso adds, door by door
 
-| Door | What it is | Status, 2026-08-04 |
+| Door | What it is | Status |
 |---|---|---|
-| The hydration door | `hydrate-root!` **[unfrozen]** beside `root!` — adopt server DOM into a live root | **Landed**, witnessed in the bench arm (`rf2-2rtt6.84`) |
-| The `:ssr` host policy | `defhost` declares what a foreign region does server-side | **Landed**, witnessed; dated HD-011 addendum (`rf2-2rtt6.85`) |
-| The Node render entry | `renderToString` of the existing runtime, fixture bake, live demo | **In review** — the PR is open, not on main (`rf2-2rtt6.86`) |
-| The spike witness | X1–X5 on the hydrated dogfood screen | **Not run** (`rf2-2rtt6.87`) |
-| The production server arm | JVM structural walk vs Node sidecar | **Not ruled** — priced and ruled at the P2 sitting (`rf2-2rtt6.88`) |
+| The hydration door | `hydrate-root!` **[unfrozen]** beside `root!` — adopt server DOM into a live root | **Landed**, witnessed in the bench arm |
+| The `:ssr` host policy | `defhost` declares what a foreign region does server-side | **Landed**, witnessed |
+| The Node render entry | `renderToString` of the existing runtime, fixture bake, live demo | **Landed** in the bench arm (`ssr/entry.cljs`, `entry_cljs_test`) |
+| The spike witness | X1–X5 end-to-end on a hydrated screen | **Run** — measured rows exist in tests; no product verdict is claimed here |
+| The production server arm | JVM structural walk vs Node sidecar | **Not decided** |
 
 "Landed" means what it means everywhere in this guide: witnessed by the bench
 arm's tests under
 `implementation/freehand/test/re_frame/bench/hicasso/`, with no
-`implementation/hicasso/` artefact anywhere. "In review" means the code exists
-on a branch, and this page does not call a branch the tree.
+`implementation/hicasso/` artefact anywhere. "Run" for the spike means the
+witness measurements exist; it does not mean a product go/no-go has been
+declared from them.
 
 ### The server engine is the client runtime
 
-The ruled server engine is not a second renderer. It is the existing runtime
-run under `react-dom/server`'s `renderToString`, so hydration parity holds by
+The server engine is not a second renderer. It is the existing runtime run
+under `react-dom/server`'s `renderToString`, so hydration parity holds by
 construction — there is no separate emitter whose output could drift from what
 the client would have rendered. The property that makes this safe is already
-on main and witnessed: every boundary shell passes a server snapshot to its
+witnessed: every boundary shell passes a server snapshot to its
 `useSyncExternalStore`, so under a server render React never subscribes —
 every `sub` read is the mutation-free cold probe, no commit runs, no effect
 fires, and the render leaves **zero durable registration** behind. A server
-render is an abandoned render, and HD-002's ledger discipline already required
-the runtime to survive those (requirement R6).
+render is an abandoned render, and the runtime's ledger discipline already
+requires it to survive those.
 
 The *entry* that runs it per request — a gensym frame, app-db seeded through
 the framework doors, `renderToString`, the payload built with the framework's
 own bytes, `destroy-frame!` in a `finally`, plus baked fixtures and a live
-page-level demo driver — is `rf2-2rtt6.86`, in review and not on main. Two of
-its properties are requirements rather than aspirations, worth knowing in
-advance: the render is deterministic (same bundle + same snapshot means
+page-level demo driver — is in the bench arm at `ssr/entry.cljs` and covered
+by `entry_cljs_test`. Two of its properties are requirements rather than
+aspirations: the render is deterministic (same bundle + same snapshot means
 byte-identical HTML, checked by double render), and the demo driver is
 **explicitly not a production host** — Spec 011's HTTP response contract stays
 `ssr-ring`'s.
 
-SSR *speed*, meanwhile, is off the bar on the record — fast applications, not
-fast SSR (HD-012 stands unchanged).
+SSR *speed*, meanwhile, is off the bar — fast applications, not fast SSR.
 
 ### The hydration door — landed
 
@@ -131,8 +122,8 @@ node, a frame and one view, except the node already holds the server's markup
 and the frame has already adopted the server's state. It returns the same
 handle shape `root!` does, so teardown treats a hydrated root like any other.
 
-Three of its properties are the reason it took a ruling rather than an
-afternoon, and all three are witnessed (`arm1/hydrate_dom_cljs_test`):
+Three of its properties are the reason this door is more than a thin wrap, and
+all three are witnessed (`arm1/hydrate_dom_cljs_test`):
 
 - **It calls `hydrateRoot` plain — no `flushSync` — so it returns before
   adoption completes.** React adopts concurrently; the DOM on the line after
@@ -145,14 +136,13 @@ afternoon, and all three are witnessed (`arm1/hydrate_dom_cljs_test`):
   in its `:present` state: nothing that arrived with the page replays an
   entrance over content the user is already reading, and server HTML does not
   arrive carrying mounting-phase `opacity: 0` overrides.
-- **Hydration never converges controlled text.** HD-019's row extends to the
-  hydrated path: a controlled input arrives with React's `defaultValue` mirror
-  intact and the model's value as the one truth. There is no flash of server
-  text corrected a beat later.
+- **Hydration never converges controlled text.** A controlled input arrives
+  with React's `defaultValue` mirror intact and the model's value as the one
+  truth. There is no flash of server text corrected a beat later.
 
 One more, for the witnesses rather than the reader: the boundary memo never
-fakes adoption — body runs are counted, not inferred (HD-028) — which is what
-lets the spike below say "exactly one body pass" and mean it.
+fakes adoption — body runs are counted, not inferred — which is what lets the
+spike below say "exactly one body pass" and mean it.
 
 ### The `:ssr` host policy — landed
 
@@ -171,38 +161,33 @@ nothing about that. So the declaration says it
 adopted the page; `{:fallback <hiccup>}` renders that markup there instead.
 There is no third value: a policy the gate does not recognise is refused at
 the declaration (`:rf.error/hicasso-host-bad-ssr-policy`), and an option
-`defhost` does not know is now a refusal too
-(`:rf.error/hicasso-host-unknown-option`) rather than the silent ignore the
-2026-08-04 audit found. One mechanism serves all three places the policy has
-to hold — the server render, hydration's first client pass, and a fresh
-client-only mount, which renders the foreign component immediately with no
-placeholder flash. Witnessed in `arm1/host_ssr_dom_cljs_test`, with the honest
-cost on the record: the door used to mint no wrapper at all, and the gate is
-one fiber and one hook per declaration.
+`defhost` does not know is a refusal too
+(`:rf.error/hicasso-host-unknown-option`) rather than a silent ignore. One
+mechanism serves all three places the policy has to hold — the server render,
+hydration's first client pass, and a fresh client-only mount, which renders
+the foreign component immediately with no placeholder flash. Witnessed in
+`arm1/host_ssr_dom_cljs_test`. The honest cost: the gate is one fiber and one
+hook per declaration.
 
-### The witness and the sitting — ahead
+### The spike witness — measured
 
-Whether all of this works as **one page** is not this guide's to assert. The
-X1–X5 spike witness (`rf2-2rtt6.87`, not run; it depends on the render entry)
-drives the programme's dogfood screen through the whole arc and reports, with
-SHA and repro command per row: byte-identical double render and canonical-DOM
-parity with a client-only mount; adoption with zero mismatch, server node
-identity preserved and exactly one body pass; reactivity adopted on React's
-own schedule; a 17-step real-DOM intent script driven at the hydrated screen,
-controlled-text echo included; and clean teardown. It is the P2 sitting's SSR
-feasibility input, and it publishes **no verdict** — the verdict is the
-operator's.
+Whether all of this works as **one page** is not this guide's to declare as a
+product verdict. The X1–X5 spike witness has **run**: tests drive a
+representative screen through the whole arc and report measured outcomes —
+byte-identical double render and canonical-DOM parity with a client-only mount;
+adoption with zero mismatch, server node identity preserved and exactly one
+body pass; reactivity adopted on React's own schedule; a multi-step real-DOM
+intent script driven at the hydrated screen, controlled-text echo included; and
+clean teardown. Those rows are evidence, not a ship decision. This page claims
+what was measured; it does not claim a product go/no-go.
 
-The same sitting prices and rules the **production server arm**
-(`rf2-2rtt6.88`). The default direction to be priced is a JVM structural walk
-— the codec's pure analysis rules twinned on the JVM, folded to HTML by the
-tree emitter the SSR artefact already ships, in-process with `ssr-ring` —
-which would also discharge most of [Testing](08-testing.md)'s headless door,
-since a structural render core is the larger half of one. Priced beside it: a
-Node sidecar behind an EDN render contract, with `ssr-ring` keeping HTTP
-either way. Neither is built. Do not design a deployment against either yet —
-this is the one part of the story where the record genuinely does not know the
-answer.
+The **production server arm** remains open. One candidate is a JVM structural
+walk — pure analysis rules on the JVM, folded to HTML by the tree emitter the
+SSR artefact already ships, in-process with `ssr-ring` — which would also
+discharge most of [Testing](08-testing.md)'s headless door, since a structural
+render core is the larger half of one. Beside it: a Node sidecar behind an EDN
+render contract, with `ssr-ring` keeping HTTP either way. Neither is built as
+the production answer. Do not design a deployment against either yet.
 
 ## Write the app so SSR is free
 
@@ -262,19 +247,17 @@ easiest to write is also the app that serves.
 
 ## Non-goals
 
-Stated once, per the 2026-08-04 addendum in
-[EP-0038](../../../EP/EP-0038-the-hicasso-view-layer-programme.md), so nobody
-reads silence as intent: **streaming** (`renderToPipeableStream` is out of
-scope), **React Server Components**, **islands / partial hydration**, **no-JS
-progressive enhancement** and **SEO metadata management** are not part of this
-story. Neither is SSR speed as a bar — HD-012's line stands. The story is one
-page, rendered whole from a snapshot, adopted whole by the client.
+Stated once so nobody reads silence as intent: **streaming**
+(`renderToPipeableStream` is out of scope), **React Server Components**,
+**islands / partial hydration**, **no-JS progressive enhancement** and **SEO
+metadata management** are not part of this story. Neither is SSR speed as a
+bar. The story is one page, rendered whole from a snapshot, adopted whole by
+the client.
 
 ## Troubleshooting
 
 The first two rows are the framework machinery's, live today under the
-adapters and inherited unchanged (requirement R0); the rest belong to the
-landed doors.
+adapters and inherited unchanged; the rest belong to the landed doors.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
@@ -286,23 +269,26 @@ landed doors.
 
 ## When you need SSR today
 
-Use a first-class adapter. The Reagent and UIx
+Use a first-class adapter for a full production SSR app. The Reagent and UIx
 [adapters](../../../core/views.md) are supported, actively maintained, and
 carry the whole Spec 011 story end to end — the reference example at
-`examples/capabilities/ssr` is exactly that, runnable now. This is not a
-consolation: adapters remaining the answer is a *successful* outcome for the
-programme ([Getting started](01-getting-started.md) says the same about the
-whole of Hicasso). What this chapter adds for an adapter user is the
+`examples/capabilities/ssr` is exactly that, runnable now. That is not a
+consolation: adapters remaining a production answer is a *successful* outcome
+([Getting started](01-getting-started.md) says the same about the whole of
+Hicasso).
+
+Hicasso's own doors — hydration, `:ssr` host policy, the Node render entry, the
+spike measurements — are **bench-witnessed**. They prove the design holds under
+the arm's tests; they are not yet a product package under
+`implementation/hicasso/`. What this chapter still gives an adapter user is the
 authored-code discipline above, most of which — events as data, pure bodies,
-platform work in effects — is portable re-frame2 rather than Hicasso, and
-costs nothing to adopt early.
+platform work in effects — is portable re-frame2 rather than Hicasso, and costs
+nothing to adopt early.
 
 ## Not settled yet
 
 | Question | Status |
 |---|---|
-| The Node render entry, the fixture bake, the live demo driver | **In review** (`rf2-2rtt6.86`) — ruled and written, not on main. Until it merges, nothing in the tree renders a Hicasso page per request |
-| The X1–X5 spike witness | **Not run** (`rf2-2rtt6.87`); depends on the render entry. Its rows are the P2 sitting's SSR feasibility input, and it publishes no verdict |
-| The production server arm | **Not ruled** (`rf2-2rtt6.88`, decided at the P2 sitting): a JVM structural walk (the default direction, to be priced; it would co-discharge the headless testing door) vs a Node sidecar behind an EDN render contract. `ssr-ring` keeps Spec 011's HTTP response contract either way |
+| The production server arm | **Not decided**: a JVM structural walk (default direction to be priced; it would co-discharge the headless testing door) vs a Node sidecar behind an EDN render contract. `ssr-ring` keeps Spec 011's HTTP response contract either way |
 | How the boot composes at the product surface | **Not addressed.** The bench door associates a container, a frame and a view; the framework's `hydrate!` seeds and verifies state before first render. Whether the product artefact offers one operation or two — and where `:initial-events` sits on a hydrating load — is unstated |
 | The spellings | `hydrate-root!` is a bench-arm name, as `root!` was before it; every spelling on this page is **[unfrozen]** until the API freeze |

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -1,18 +1,12 @@
 # Hicasso — draft user guide
 
-> **Draft ahead of the product artefact.** These pages teach the *landed* authoring
-> surface: ruled in [decisions.md](../decisions.md) (HD-001…HD-028) and witnessed by
-> the bench arm's tests under
-> `implementation/freehand/test/re_frame/bench/hicasso/`. No
-> `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
-> stay provisional until the API freeze — but everything a page shows without that
-> marker has run, in tests, against a real React.
+> **Draft ahead of the product artefact.** No `implementation/hicasso/` ships yet.
+> Spellings marked **[unfrozen]** are provisional until the API freeze. Behaviour
+> shown here is witnessed under `implementation/freehand/test/re_frame/bench/hicasso/`.
 
 Hicasso is re-frame2's native view layer: interpreted Hiccup on a React
-function-component host, optimised for re-frame2. The
-[charter](../charter.md) argues why it should exist and
-[validation](../validation.md) says what would kill it. This guide answers a
-narrower question — **what does a programmer actually type?**
+function-component host, built for re-frame2. This guide answers one question —
+**what does a programmer actually type?**
 
 | Page | Its one job |
 |---|---|
@@ -25,43 +19,25 @@ narrower question — **what does a programmer actually type?**
 | [Ephemeral state](07-ephemeral-state.md) | Decide where "is this dropdown open?" lives, given there is no `local`; where "it left but is still fading out" lives, given app-db cannot hold it; and where the jobs you wanted `:on-mount` for actually go |
 | [Testing](08-testing.md) | Assert a view's output without a browser, and know when you still need one |
 | [When a view throws](09-when-a-view-throws.md) | Keep one broken view from taking the page down with it |
-| [Server-side rendering](10-server-side-rendering.md) | Serve a page rendered from a db snapshot and adopt it live in the browser — what exists, what is landing, and how to write an app so SSR is free |
-
-The page count is editorial judgement now. It used to be a budget: K5 in
-[validation.md](../validation.md) killed the programme at "more than ~8 public
-concepts or ~8 guide pages to ship CRUD", and this guide was written to spend
-exactly that and no more. **The operator removed K5 as a kill criterion on
-2026-08-04**, so a page is added when a reader genuinely needs one and not
-otherwise. The pressure to stay short did not go away with the number — it just
-stopped being a rule.
+| [Server-side rendering](10-server-side-rendering.md) | Serve a page rendered from a db snapshot and adopt it live in the browser — what is witnessed, what is still open, and how to write an app so SSR is free |
 
 ## How to read the markers
 
-**[unfrozen]** after a name means the *semantics* are ruled but the *spelling* is a
-placeholder — HD-021 pins the root operation's behaviour and says outright that its
-name waits, and [authoring.md](../authoring.md) holds every declaration spelling
-unfrozen until the freeze. Each page ends with **Not settled yet** — the questions
-that page raises which the record does not yet answer. Far fewer remain than when
-this draft was first written; the ones left are real.
+**[unfrozen]** after a name means the *semantics* are pinned but the *spelling*
+is a placeholder until the API freeze. Prefer the behaviour over the token.
+
+Each page ends with **Not settled yet** — open questions that page raises which
+are not yet answered. Those tables hold only the question and its status; they
+are not a backlog of design history.
 
 ## What this draft is not
 
-- **Not published.** `design/hicasso/` is in `exclude_docs` in `mkdocs.yml`, so this
-  subtree never reaches the site and is never in the nav. Read it in the source tree
-  or on GitHub. Because it is read as raw Markdown, banners and asides are
+- **Not published.** `design/hicasso/` is in `exclude_docs` in `mkdocs.yml`, so
+  this subtree never reaches the site and is never in the nav. Read it in the
+  source tree or on GitHub. Because it is raw Markdown, banners and asides are
   blockquotes rather than MkDocs admonitions.
-- **Not gated.** No fenced block here is digest-pinned by
-  `samples_coverage_jvm_test.clj` — that test scans `docs/core/freehand/` only.
-- **Not an API freeze.** [authoring.md](../authoring.md) is explicit that nothing in
-  the design record licenses freezing an API early, and this guide inherits that.
+- **Not an API freeze.** Names marked **[unfrozen]** wait; landed behaviour is
+  what the bench arm already runs.
 
-## Where the vocabulary comes from
-
-[decisions.md](../decisions.md) governs; [validation.md](../validation.md) is next;
-[authoring.md](../authoring.md) holds the canonical spellings. The read surface was
-ruled by the operator on 2026-07-31 — the ambient collector, on ergonomics, with
-[hd-002-adjudication.md](../hd-002-adjudication.md)'s correctness gates standing —
-recorded in the
-[dogfood judgement](../studio/arm1-lean-react-dogfood-judgement.md). The programme
-is sequenced by
-[EP-0038](../../../EP/EP-0038-the-hicasso-view-layer-programme.md).
+The design record for Hicasso lives in the parent directory for contributors;
+you do not need it to read this guide.


### PR DESCRIPTION
## Summary

Review and rewrite of `docs/design/hicasso/draft-guide/` (README + pages 01–10) in four stages: completeness, correctness, residue cleanup, and voice against `docs/authoring.md`.

### Completeness
- Filled reader gaps where the page could already teach: `::h/checked` example, `route-link` require, stronger problem open on views, `## Advanced` for interop SDKs.
- Left honest holes where the product still has none: theme install/declare APIs, headless `h/render`, controlled revision prop spelling.

### Correctness
- **`h/reg-state`**: taught as landed bench sugar (was \"in implementation\").
- **SSR**: Node render entry and X1–X5 spike marked landed/measured (were \"in review\" / \"not run\"). Production server arm remains open.
- Named `:rf.error/routing-artefact-missing`; fixed nested-anchor `route-link` example.

### Residue and voice
- Removed bead ids, HD citations, design-record links (decisions/validation/authoring/charter/EP/studio), operator dates, and process justifications.
- Condensed draft banners; kept **[unfrozen]** and **Not settled yet** without programme history.
- Prose aligned with `docs/authoring.md`: problem → code → explanation, operational claims, Troubleshooting / When-not kept.

## Gate notes

- Tree is under `docs/design/**` (`exclude_docs`); `mkdocs build --strict` does not cover it.
- `python scripts/check_doc_slugs.py` green (covers design markdown links/anchors).
- Anchors and table column counts reviewed by hand while editing.

## Test plan

- [x] `python scripts/check_doc_slugs.py` (exit 0)
- [ ] Spot-read README + 01/07/10 for status tense
- [ ] Confirm no bead/HD/design-doc links remain in the draft-guide tree