### PR TITLE
fix(ci): check-story-static changes execute the gate they define (rf2-9n2cv)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -82,6 +82,15 @@ story_xray_browser=false
 # tools/story/test/story_feature_load.cjs would therefore schedule a job that
 # still never executes the changed file. See is_story_full_gate_path below.
 story_full_gate=false
+# rf2-9n2cv — the Story STATIC-EXPORT gate (`npm run test:story-static`), a
+# third tier again distinct from the two above, and for the same reason: it is
+# a different COMMAND. `test:story-static` is `node scripts/check-story-static.cjs`
+# — it builds the static export, serves it under an ownership token and drives
+# Chromium at the published artefact. Neither smoke command runs it and neither
+# does the full feature-load gate, so arming either of those outputs for a
+# change to the static gate's own teeth would schedule a job that never
+# executes the changed file. See the arm on check-story-static.cjs below.
+story_static_gate=false
 tenant_switcher_smoke=false
 skills_structural=false
 playground=false
@@ -110,6 +119,7 @@ mark_all() {
   mcp_live=true
   story_xray_browser=true
   story_full_gate=true
+  story_static_gate=true
   tenant_switcher_smoke=true
   skills_structural=true
   playground=true
@@ -1424,6 +1434,53 @@ else
         reagent_slim_bundle=true
         freehand_reachability=true
         ;;
+      implementation/scripts/check-story-static.cjs|implementation/scripts/story-build.cjs)
+        # rf2-9n2cv — self-protection, the same shape as the two freehand
+        # checkers above and for the same reason. `npm run test:story-static`
+        # IS `node scripts/check-story-static.cjs`: the mounted-shell
+        # assertions, the first-visit-overlay suppression check, the
+        # ownership-token verification and the non-vacuity floor all live in
+        # that one file. The generic `implementation/scripts/*` case below
+        # arms cljs_node_test + cljs_browser + cljs_prod + bundle_isolation +
+        # reagent_slim_bundle, and NOT ONE of those schedules a job that runs
+        # the command the file defines — so a PR could soften an assertion or
+        # drop a check in the static-export gate's own teeth and merge with
+        # the gate unexercised.
+        #
+        # story-build.cjs is in the roster because it is this gate's build
+        # orchestration, the exact analogue of the run/serve launchers
+        # rf2-65ajl armed for the feature-load gate: check-story-static.cjs
+        # spawns it by name (`path.join(__dirname, 'story-build.cjs')`) to
+        # produce the export it then serves and asserts against. It is also
+        # `npm run story:build`, and NO workflow runs that script directly —
+        # grep the tree: its only CI execution path anywhere is through
+        # check-story-static.cjs. So without this arm it is doubly untraced.
+        # A test below reads the spawn list off check-story-static.cjs rather
+        # than trusting this roster, so a second spawned sibling is armed on
+        # arrival rather than on the next audit.
+        #
+        # Deliberately NOT the shared harness helpers this gate requires
+        # (lib/local-browser-harness.cjs, lib/browser-test-report.cjs). Each is
+        # required by run-browser-tests.cjs, run-ui-g8.cjs, run-ui-g13.cjs,
+        # serve-and-run-xray-feature-gate.cjs and serve-and-run-reagent-slim-
+        # smoke.cjs — all PR-time gates — and each carries its own dedicated
+        # policy test in the fast spine. A break in one already reds a job that
+        # runs at PR time, so paying for the static gate on top buys no signal.
+        #
+        # This arm WIDENS and never narrows: it re-sets every output the
+        # generic case below would have set, so there is no fall-through to
+        # worry about and no tier is lost. That is why it can be a plain `case`
+        # arm here, where rf2-65ajl needed a predicate dispatched in the loop
+        # body — its roster straddled two trees that already had arms and could
+        # be shadowed; this roster is two files in one tree, sitting directly
+        # above the only other arm that matches them.
+        cljs_node_test=true
+        cljs_browser=true
+        cljs_prod=true
+        bundle_isolation=true
+        reagent_slim_bundle=true
+        story_static_gate=true
+        ;;
       implementation/shadow-cljs.edn|implementation/package.json|implementation/package-lock.json|implementation/scripts/*)
         # rf2-8jz9t + rf2-bxdk8 + rf2-cjp0i + rf2-k9ekz + rf2-t5slp —
         # adapter_testbed_smokes and story_xray_browser are NOT fired
@@ -1896,6 +1953,7 @@ emit mcp_conformance "$mcp_conformance"
 emit mcp_live "$mcp_live"
 emit story_xray_browser "$story_xray_browser"
 emit story_full_gate "$story_full_gate"
+emit story_static_gate "$story_static_gate"
 emit tenant_switcher_smoke "$tenant_switcher_smoke"
 emit skills_structural "$skills_structural"
 emit playground "$playground"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,7 @@ jobs:
       mcp_live: ${{ steps.detect.outputs.mcp_live }}
       story_xray_browser: ${{ steps.detect.outputs.story_xray_browser }}
       story_full_gate: ${{ steps.detect.outputs.story_full_gate }}
+      story_static_gate: ${{ steps.detect.outputs.story_static_gate }}
       tenant_switcher_smoke: ${{ steps.detect.outputs.tenant_switcher_smoke }}
       skills_structural: ${{ steps.detect.outputs.skills_structural }}
       playground: ${{ steps.detect.outputs.playground }}
@@ -3367,15 +3368,18 @@ jobs:
   story-xray-browser:
     name: Story/Xray browser gates (PR-smoke)
     needs: detect_changed_surfaces
-    # rf2-65ajl — two tiers, two conditions. `story_xray_browser` schedules the
-    # PR-smoke steps; `story_full_gate` schedules the full Story feature-load
-    # step. Either alone must open the job, and each step carries its own tier's
-    # condition, so a change to the full-gate runners does not pay for two smoke
-    # compiles it cannot affect and an ordinary Story/Xray runtime change keeps
-    # exactly the cheap path it had.
+    # rf2-65ajl + rf2-9n2cv — three tiers, three conditions.
+    # `story_xray_browser` schedules the PR-smoke steps; `story_full_gate`
+    # schedules the full Story feature-load step; `story_static_gate` schedules
+    # the Story static-export step. Any one alone must open the job, and each
+    # step carries its own tier's condition, so a change to the full-gate
+    # runners or to the static gate does not pay for two smoke compiles it
+    # cannot affect and an ordinary Story/Xray runtime change keeps exactly the
+    # cheap path it had.
     if: >-
       needs.detect_changed_surfaces.outputs.story_xray_browser == 'true' ||
-      needs.detect_changed_surfaces.outputs.story_full_gate == 'true'
+      needs.detect_changed_surfaces.outputs.story_full_gate == 'true' ||
+      needs.detect_changed_surfaces.outputs.story_static_gate == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
@@ -3511,6 +3515,34 @@ jobs:
       - name: Run the FULL Story feature-load gate (direct-runner change, rf2-65ajl)
         if: needs.detect_changed_surfaces.outputs.story_full_gate == 'true'
         run: npm run test:story-feature-load
+
+      # rf2-9n2cv — the job half of the sibling fix, identical in shape to the
+      # step above. `npm run test:story-static` IS
+      # `node scripts/check-story-static.cjs`, and no job in this workflow ran
+      # it: the three steps above are the only commands this job runs, and
+      # none of them loads check-story-static.cjs or story-build.cjs. So a PR
+      # editing the static-export gate's own assertions merged with the gate
+      # unexercised — the classifier armed five outputs for the file and not
+      # one scheduled a job that runs its command.
+      #
+      # Gated on `story_static_gate`, which arms ONLY on the gate script and
+      # the build script it spawns — not on ordinary Story/Xray runtime
+      # changes, and not on the rest of implementation/scripts/. So this adds
+      # nothing to the critical path of a normal PR: it runs on the rare PR
+      # that edits the static gate itself, where it is the only step that
+      # exercises the diff at all.
+      #
+      # It shares this job's keyed .shadow-cljs cache with the steps above, but
+      # note it compiles its OWN build target (:story-static/counter-with-
+      # stories, the static-export entry point) rather than reusing the
+      # play-script step's dev compile — the two are different shadow-cljs
+      # builds of the same testbed, which is precisely the point of the gate.
+      #
+      # The nightly sweep in expensive-tests.yml is unchanged and remains the
+      # system of record for the full matrix.
+      - name: Run the Story static-export gate (direct-gate change, rf2-9n2cv)
+        if: needs.detect_changed_surfaces.outputs.story_static_gate == 'true'
+        run: npm run test:story-static
 
       # rf2-315cf (Option B) — on a RED browser gate, upload the failed-run
       # evidence so the failure is a downloadable, off-CI post-mortem

--- a/TESTING.md
+++ b/TESTING.md
@@ -31,7 +31,7 @@ This table is also the command catalogue: each kind names the command that runs 
 | **MCP conformance, wire** — `test:mcp-conformance` (single entry point; per-suite scripts in `tools/mcp-conformance/`) | medium | Both servers honour the strict `CallToolResultSchema`; exec-safety helpers. |
 | **docs/cljs playground** — `tools-playground` job | medium | The live-CLJS-cell engine: builds both bundles, Chromium-smokes them, byte-diffs the committed esbuild bootstrap, and structurally validates the generated SCI bundle (untracked since rf2-tzy13 — built in-run, so it cannot be stale). `docs.yml` re-runs the build + smoke on deploy, so the shipped artifact is the smoked one. |
 | **MCP conformance, live** — `test:re-frame2-pair-live-hermetic-suite` | expensive | Real re-frame2-pair-mcp against a real shadow-cljs nREPL: eval cap, subscribe lifecycle, redaction, isError, cofx, event metadata. |
-| **Story gates** — `test:story-play-scripts` (PR smoke), `test:story-feature-load` (nightly, plus PR when its own runners change), `test:story-static` (nightly) | expensive | Every variant's `:play-script` runs as a regression test; the full feature-load + static-export sweep runs nightly. |
+| **Story gates** — `test:story-play-scripts` (PR smoke), `test:story-feature-load` and `test:story-static` (nightly, plus PR when their own runners change) | expensive | Every variant's `:play-script` runs as a regression test; the full feature-load + static-export sweep runs nightly. |
 | **Xray gates** — `test:xray-feature-gate:smoke` (PR), `test:xray-feature-gate` (nightly) | medium / expensive | The Xray feature matrix; smoke = highest-signal scenarios over few staged surfaces, nightly = all scenarios, all surfaces. |
 | **Template emitted-app smoke** — `jvm-tools-template` job | expensive | The emitted app boots and passes its own gates, plus the `re-frame2-setup` day-one scaffold materialise-and-compile drift net. Behind `RF2_TEMPLATE_RUN_EMITTED_TESTS`. |
 
@@ -68,7 +68,14 @@ The classifier maps "what files changed" → "which expensive jobs fire." The fu
 
 **The Story/Xray two-tier split.** The `story-xray-browser` PR job runs `test:xray-feature-gate:smoke` + `test:story-play-scripts`; the full sweep runs nightly. The dominant cost is testbed compilation, so both tiers share a keyed shadow-cljs compile cache that any source change busts.
 
-One exception, and it is the exception that keeps the split honest (rf2-65ajl): a gate that is nightly-only cannot be *changed* safely, because the PR changing it runs nothing that loads it. `test:story-feature-load` therefore also runs at PR time on the PRs that edit its own two Playwright spec modules (`tools/story/test/story_feature_load.cjs`, `story_browser_scenarios.cjs`) or the run/serve orchestration that stages them — the `story_full_gate` surface. Ordinary Story/Xray runtime changes are untouched and keep the cheap smoke path; the nightly sweep remains the system of record for the full matrix. When adding an Xray scenario, tag it `smoke: true` (in `tools/xray/testbeds/feature_matrix/scenarios.cjs`) only if it earns a slot on every PR **and** loads an already-staged smoke surface; everything else is nightly by default. The gate fails loud if the smoke set is ever empty.
+One exception, and it is the exception that keeps the split honest (rf2-65ajl, rf2-9n2cv): a gate that is nightly-only cannot be *changed* safely, because the PR changing it runs nothing that loads it. Two nightly commands therefore also run at PR time, but only on the PRs that edit their own definitions:
+
+- `test:story-feature-load`, on its two Playwright spec modules (`tools/story/test/story_feature_load.cjs`, `story_browser_scenarios.cjs`) or the run/serve orchestration that stages them — the `story_full_gate` surface.
+- `test:story-static`, on the gate script it *is* (`implementation/scripts/check-story-static.cjs`) and the build script that gate spawns (`story-build.cjs`) — the `story_static_gate` surface.
+
+Ordinary Story/Xray runtime changes are untouched and keep the cheap smoke path; the nightly sweep remains the system of record for the full matrix.
+
+The Xray full matrix is deliberately **not** a third such exception. `test:xray-feature-gate:smoke` — a command the PR job already runs — loads and validates the whole of `tools/xray/testbeds/feature_matrix/scenarios.cjs`, so the file cannot merge unparsed; what runs nightly is the non-smoke *rows*, which is this policy working as designed rather than a hole in it. When adding an Xray scenario, tag it `smoke: true` only if it earns a slot on every PR **and** loads an already-staged smoke surface; everything else is nightly by default. The gate fails loud if the smoke set is ever empty.
 
 ## Test authoring policy
 
@@ -133,6 +140,7 @@ The classifier is the **source of truth for "which jobs run when"** on a PR: the
 | `mcp_live` | re-frame2-pair-mcp / mcp-base / mcp-conformance change | the live + hermetic MCP job |
 | `story_xray_browser` | runtime-extension files under `tools/{story,xray}/{src,testbeds}` change — specs, JVM tests, deps.edn, READMEs do **not** fire it (they can't affect chrome); core doesn't either | the PR-smoke steps of the browser job |
 | `story_full_gate` | the full Story feature-load gate's own spec modules (`tools/story/test/story_{feature_load,browser_scenarios}.cjs`) or its run/serve orchestration change | the `test:story-feature-load` step of the browser job |
+| `story_static_gate` | the Story static-export gate's own definition — `implementation/scripts/check-story-static.cjs` (the whole command) or `story-build.cjs` (the build step it spawns) | the `test:story-static` step of the browser job |
 | `tenant_switcher_smoke` | `testbeds/tenant_switcher/**` or `implementation/scripts/serve-and-run-tenant-switcher-testbed.cjs` change | the `tenant-switcher-testbed-smoke` browser job |
 | `skills_structural` | `skills/re-frame2-pair/*`, `skills/re-frame2-setup/*`, or `skills/shared/*` change | `skills-structural` |
 | `playground` | the playground tool, the committed esbuild bootstrap bundle, the SCI input-digest script, or a change to any tree baked into the SCI bundle — `implementation/core/*`, `implementation/adapters/reagent-slim/*`, `implementation/machines/*`, `implementation/flows/*` (rf2-tzy13) | `tools-playground` |

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -1838,13 +1838,160 @@ test('PR story-xray-browser job runs the FULL feature-load gate, gated on story_
   );
 });
 
+// rf2-9n2cv — this row USED to pin `test:story-static` out of the PR job too,
+// alongside the non-smoke Xray gate. That was the same forbids-the-fix pin
+// rf2-65ajl hit for `test:story-feature-load`, one gate over: the only command
+// that loads check-story-static.cjs was asserted absent, so the file could
+// never be exercised by the PR that changed it. The story-static half is now
+// present and CONDITIONAL (see the row below); the Xray half STAYS, and stays
+// deliberately — see the comment on it.
 test('PR story-xray-browser job still keeps the rest of the sweep nightly (rf2-wa3oo)', () => {
   const block = storyXrayJobBlock(fs.readFileSync(WORKFLOW, 'utf8'));
-  assert.doesNotMatch(block, /npm run test:story-static/);
   // The non-smoke (full-matrix) Xray gate must not run at PR time. The
   // `:smoke` suffix is intentionally allowed; assert the bare invocation
   // (followed by end-of-line, not `:smoke`) is absent.
+  //
+  // rf2-9n2cv considered lifting this too and deliberately did NOT. It is not
+  // the same defect: `test:xray-feature-gate:smoke` — a command this job
+  // already runs — `require`s the whole of
+  // tools/xray/testbeds/feature_matrix/scenarios.cjs, so the file IS loaded,
+  // parsed and validated at PR time (the launcher even fails loud on an empty
+  // smoke set). What is not EXECUTED at PR time is the non-smoke rows, and
+  // that is the documented two-tier policy in TESTING.md ("everything else is
+  // nightly by default"), not a fail-open hole. Reversing it means running the
+  // all-scenarios/all-surfaces sweep on every scenarios.cjs edit — a policy
+  // call, filed separately rather than smuggled in here.
   assert.doesNotMatch(block, /npm run test:xray-feature-gate(?!:smoke)/);
+});
+
+test('PR story-xray-browser job runs the Story STATIC gate, gated on story_static_gate (rf2-9n2cv)', () => {
+  const block = storyXrayJobBlock(fs.readFileSync(WORKFLOW, 'utf8'));
+  // Same two-part claim as the feature-load row above: the command and its
+  // condition must be in the SAME step, or the gate is either unconditional
+  // (nightly cost on every Story PR) or dead.
+  const step = stepRunning(block, 'npm run test:story-static');
+  assert.ok(
+    step,
+    'the PR job must RUN the one command that loads check-story-static.cjs',
+  );
+  assert.match(
+    step,
+    /if:\s*needs\.detect_changed_surfaces\.outputs\.story_static_gate == 'true'/,
+    'the static-export step must be gated on story_static_gate',
+  );
+});
+
+test('PR story-xray-browser job opens for the static tier too (rf2-9n2cv)', () => {
+  // A static-gate-only change leaves both other outputs false, so a job
+  // condition that did not name this one would skip the job and the new step
+  // with it — the same hole one level up, which is exactly how rf2-65ajl's
+  // never-fires mode would have presented.
+  const block = storyXrayJobBlock(fs.readFileSync(WORKFLOW, 'utf8'));
+  const header = block.slice(0, block.indexOf('steps:'));
+  assert.match(header, /outputs\.story_static_gate == 'true'/);
+  assert.match(header, /\|\|/, 'the tier conditions must be a disjunction');
+});
+
+test('detect_changed_surfaces exports story_static_gate (rf2-9n2cv)', () => {
+  // The never-fires mode. The classifier can emit an output and the workflow
+  // still never see it: a job reads `needs.<job>.outputs.<name>`, which
+  // resolves to the empty string unless the producing job DECLARES it. An
+  // undeclared output makes every `== 'true'` false — a gate that can never
+  // fire, and silently.
+  const block = jobBlock(fs.readFileSync(WORKFLOW, 'utf8'), 'detect_changed_surfaces');
+  assert.match(
+    block,
+    /story_static_gate: \$\{\{ steps\.detect\.outputs\.story_static_gate \}\}/,
+  );
+});
+
+test('the Story static gate arms on its own definition (rf2-9n2cv)', () => {
+  // The classifier half. Before this bead, check-story-static.cjs classified
+  // to cljs_node_test + cljs_browser + cljs_prod + bundle_isolation +
+  // reagent_slim_bundle — five outputs, not one of which schedules a job that
+  // runs `npm run test:story-static`.
+  for (const file of [
+    'implementation/scripts/check-story-static.cjs',
+    'implementation/scripts/story-build.cjs',
+  ]) {
+    assert.ok(
+      fs.existsSync(path.join(REPO_ROOT, file)),
+      `${file} must exist — this row pins the routing of a REAL gate file`,
+    );
+    const result = classify(file);
+    assert.equal(result.story_static_gate, 'true', file);
+    // WIDENS, NEVER NARROWS. The arm sits above the generic
+    // implementation/scripts/* case, so it must re-set everything that case
+    // would have set or this bead silently drops five tiers from two files.
+    for (const kept of [
+      'cljs_node_test',
+      'cljs_browser',
+      'cljs_prod',
+      'bundle_isolation',
+      'reagent_slim_bundle',
+    ]) {
+      assert.equal(result[kept], 'true', `${file} must keep ${kept}`);
+    }
+    // And it must not drag either sibling Story tier along: neither the smoke
+    // commands nor test:story-feature-load loads these two files.
+    assert.equal(result.story_xray_browser, 'false', file);
+    assert.equal(result.story_full_gate, 'false', file);
+  }
+});
+
+test('every script the static gate spawns is armed (rf2-9n2cv)', () => {
+  // The teeth. Read the roster off the GATE rather than trusting the list
+  // above: check-story-static.cjs spawns its build step by name, so a second
+  // spawned sibling is armed on arrival rather than on the next audit. Names,
+  // not counts.
+  const gate = path.join(
+    REPO_ROOT,
+    'implementation',
+    'scripts',
+    'check-story-static.cjs',
+  );
+  const source = fs.readFileSync(gate, 'utf8');
+  const spawned = [
+    ...source.matchAll(/path\.join\(__dirname,\s*'([^']+\.cjs)'\)/g),
+  ].map((m) => m[1]);
+  assert.ok(
+    spawned.length > 0,
+    'expected check-story-static.cjs to spawn at least one sibling script — ' +
+      'if the spawn shape changed, this parse has rotted and is no longer teeth',
+  );
+  for (const name of spawned) {
+    const rel = `implementation/scripts/${name}`;
+    assert.ok(
+      fs.existsSync(path.join(REPO_ROOT, rel)),
+      `${rel} is spawned by check-story-static.cjs but does not exist`,
+    );
+    assert.equal(
+      classify(rel).story_static_gate,
+      'true',
+      `${rel} is executed by npm run test:story-static but does not arm story_static_gate`,
+    );
+  }
+});
+
+test('ordinary implementation/scripts changes do NOT arm the static gate (rf2-9n2cv negative control)', () => {
+  // The expensive browser job must stay off scripts that cannot reach the
+  // static export. Real files, not hypotheticals: a negative control pinning a
+  // path nothing produces any more is permanently, silently green.
+  for (const file of [
+    'implementation/scripts/run-browser-tests.cjs',
+    'implementation/scripts/check-examples-compile.cjs',
+    // The two shared harness helpers the gate requires but which are
+    // deliberately out of the roster — each is already exercised by PR-time
+    // gates and carries its own policy test.
+    'implementation/scripts/lib/local-browser-harness.cjs',
+    'implementation/scripts/lib/browser-test-report.cjs',
+  ]) {
+    assert.ok(
+      fs.existsSync(path.join(REPO_ROOT, file)),
+      `${file} must exist — a negative control on a phantom path is vacuous`,
+    );
+    assert.equal(classify(file).story_static_gate, 'false', file);
+  }
 });
 
 test('PR story-xray-browser job opens for EITHER tier (rf2-65ajl)', () => {


### PR DESCRIPTION
Closes rf2-9n2cv. Same defect shape as rf2-65ajl (#7481), one gate over, and it follows that PR's pattern rather than inventing a second one.

`implementation/scripts/check-story-static.cjs` **is** `npm run test:story-static` — the whole command is `node scripts/check-story-static.cjs`. No job in `test.yml` ran it. The classifier routed the file through the generic `implementation/scripts/*` arm, arming five outputs — `cljs_node_test`, `cljs_browser`, `cljs_prod`, `bundle_isolation`, `reagent_slim_bundle` — and **not one of them schedules a job that runs the command the file defines**. So a softened assertion or a dropped check in the static-export gate's own teeth merged with the gate unexercised.

Both halves are fixed, because fixing either alone leaves the hole open.

## (a) Classifier

New output `story_static_gate`, armed by a self-protection `case` arm on two files:

* `implementation/scripts/check-story-static.cjs` — the gate itself.
* `implementation/scripts/story-build.cjs` — the build step the gate spawns by name (`path.join(__dirname, 'story-build.cjs')`) to produce the export it then serves and asserts against. It is also `npm run story:build`, and **no workflow runs that script directly** — its only CI execution path anywhere is through `check-story-static.cjs`, so it was doubly untraced. This is the exact analogue of the run/serve orchestration #7481 armed for the feature-load gate.

Deliberately **not** the shared harness helpers the gate requires (`lib/local-browser-harness.cjs`, `lib/browser-test-report.cjs`). Each is required by `run-browser-tests.cjs`, `run-ui-g8.cjs`, `run-ui-g13.cjs`, `serve-and-run-xray-feature-gate.cjs` and `serve-and-run-reagent-slim-smoke.cjs` — all PR-time gates — and each carries its own policy test in the fast spine. A break in one already reds a job that runs at PR time. Same reasoning #7481 used to exclude the shared `examples/scripts` helpers.

### Where this differs from #7481, deliberately

#7481 dispatched its predicate **in the loop body** rather than as a `case` arm, because its roster straddled two trees that already had arms and could be shadowed by a future arm added above. That does not apply here: this roster is two files in one tree, and the arm sits **directly above the only other arm that matches them**. The repo already has this exact shape twice — `check-freehand-evidence-elision.cjs` (rf2-xwa4n) and `check-freehand-reachability.cjs` (rf2-zl8ao) — and the bead names them as the precedent, so a plain `case` arm is the local convention here.

The related trap #7481 hit — files moved off one arm falling through to a generic case and silently arming heavy jobs — also cannot occur here, and not by luck: this arm **re-sets all five outputs the generic case would have set** rather than stopping the walk with a no-op. It widens and never narrows. That is asserted, and the `HEAD^` classification diff below proves it empirically rather than by reading.

## (b) Job

`.github/workflows/test.yml`'s `story-xray-browser` job gains a `npm run test:story-static` step gated on `story_static_gate`, and the job `if` becomes a three-way disjunction so the static tier **alone** opens the job. The job is already in `all-required-passed`, so the step is required coverage.

The nightly sweep in `expensive-tests.yml` is unchanged and remains the system of record for the full matrix.

## Pinned assertions found, and what changed

Grepped `_changed-surfaces.test.cjs` for `story-static`, `check-story-static`, `xray-feature-gate`, `test:xray` and `test:exec-safety` before writing anything. **One pin forbade the fix outright**, the same trap #7481 hit:

| Where | Was | Now |
|---|---|---|
| `PR story-xray-browser job still keeps the rest of the sweep nightly (rf2-wa3oo)` | `assert.doesNotMatch(block, /npm run test:story-static/)` — asserted the only command that loads `check-story-static.cjs` was **absent** from the PR job | Removed. The command is now present and **conditional**, asserted by a new row to run only under `story_static_gate`. |
| same test, Xray half | `assert.doesNotMatch(block, /npm run test:xray-feature-gate(?!:smoke)/)` | **Kept, deliberately** — see the scope judgement below. Comment now records why it is not the same defect. |

No other pin needed changing. Every new expectation is mutation-proved below, in both directions — a pinned expectation nobody can make fail is how these holes survive.

## Mutation proofs

Each mutation was applied to the real tree, the named rows run, then reverted. Six new rows; every one can be made to fail.

| # | Mutation | Result |
|---|---|---|
| **a-rev** | Neuter the classifier arm (roster pattern made non-matching, so the two files fall back to the generic case) | **RED**, exit 1 — `the Story static gate arms on its own definition`, `every script the static gate spawns is armed` |
| **a-roster** | Drop `story-build.cjs` from the arm **and** from the hand-written roster list in the test | **RED**, exit 1 — only `every script the static gate spawns is armed`. The hand-written row goes green; the **spawn-derived** row still reds because it reads the roster off `check-story-static.cjs` itself. Proves the teeth are independent of the hand list, so a newly-spawned sibling is armed on arrival rather than on the next audit. |
| **b-rev-1** | Remove the `run: npm run test:story-static` step from the job | **RED**, exit 1 — `PR story-xray-browser job runs the Story STATIC gate, gated on story_static_gate`. Note it stayed red with the command still named in the step's **comment**: the matcher anchors on `run: `, so prose cannot satisfy it. |
| **b-rev-2** (never-fires) | Narrow the job condition (drop the `story_static_gate` disjunct) **and** delete the output declaration from `detect_changed_surfaces` | **RED**, exit 1 — `PR story-xray-browser job opens for the static tier too`, `detect_changed_surfaces exports story_static_gate`. Two distinct silent failures: a job that cannot open, and an undeclared output that makes every `== 'true'` false. |

Baseline on the fix: the six `rf2-9n2cv` rows pass; full suite 295 passed (289 on main + 6).

## `HEAD^` classification diff

Reading the classifier is not evidence about what it emits — #7481 found a real fall-through this way that reading had missed. So each file's **classification** was diffed between the pre-change base and this branch, over a 218-file corpus: the whole of `implementation/scripts/` (128 files, the tree touched) plus a spread across `tools/story`, `tools/xray`, `examples/scripts`, `implementation/{core,ui,adapters}`, `spec`, `.github/workflows`, `testbeds` and `tools/mcp-conformance`.

```
CORPUS=218  files with a real classification change: 4
```

All 218 gain the new `story_static_gate=false` emission line (that is the new output existing, not a routing change). Filtering that, exactly **four** files flip it to `true`:

```
implementation/scripts/check-story-static.cjs   > story_static_gate=true   # the gate
implementation/scripts/story-build.cjs          > story_static_gate=true   # the build step it spawns
.github/workflows/test.yml                      > story_static_gate=true   # via mark_all
.github/workflows/expensive-tests.yml           > story_static_gate=true   # via mark_all
```

**Zero files lost any output.** No fall-through, no shadowing, no narrowing — the "widens, never narrows" claim is measured, not asserted.

## Cost, measured

`npm run test:story-static` run locally to completion, twice, both exit 0:

* **85s** first run (warm `.shadow-cljs` dependency cache, first compile of the `:story-static/counter-with-stories` target — the realistic CI shape, since the job restores a keyed cache)
* **62s** warm

**Which PRs it touches: only PRs editing one of two files.** Nothing else in the repo arms this output.

**Being straight about the direction: this is not a saving.** #7481 could report a full-gate-only PR as *cheaper* than before, because it narrowed the smoke tier off two files. There is no equivalent narrowing available here — this arm only widens. Before this PR a PR touching only `check-story-static.cjs` **skipped `story-xray-browser` entirely**; now that job opens for it, carrying job setup (JDK/Node/Clojure/npm ci/Playwright, mostly cached) plus the 85s step.

The honest wall-clock read: those two files already arm five other jobs, including the `cljs_browser` and `cljs_prod`/bundle lanes, which are comparable or longer and run **in parallel**. So the expected critical-path impact is near zero, with the worst case being that `story-xray-browser` becomes the critical path on a PR whose other five jobs all finish faster. That is the right trade for a gate that was previously editable without being run.

**A cheaper targeted invocation was considered and rejected.** The obvious candidate is running `story-build.cjs` alone (the compile + stage half) and skipping the serve-and-drive half. It is rejected because the assertions *are* the gate: the mounted-shell checks, the first-visit-overlay suppression check and the ownership-token verification all live in the browser half, and those are exactly the teeth a PR would soften. Running less of the file than the command runs re-opens the hole at a smaller scale. At 85s there is also little to buy.

## Scope judgement on the other three untraced commands

The bead flags three more things and is explicit that they were "not audited here". I judged them **not one coherent fix with the named defect** — one is a policy question, two are not defects at all — so I fixed the named one properly and did not half-fix four. Findings:

**1. `test:xray` — the premise is wrong; there is no such command.** `git grep '"test:xray"'` returns nothing repo-wide; the only near-match is `test:xray-feature-gate`. `expensive-tests.yml` carries a comment (rf2-mw1c0) recording that the line was **removed** as a stale artefact of the rf2-3pdp9 Xray rename — the underlying script had been deleted a week earlier in rf2-bu21t, so the rename mechanically produced a reference to a script that never existed. There is no defining file to trace and no gate to arm. `post-merge-workflow-sanity.yml` already guards the name. **Nothing to do.**

**2. `test:exec-safety` — already runs on a required PR check.** `tools/mcp-conformance/test/exec-safety.test.cjs` is a `node --test` row in `test-all.cjs`'s authoritative inventory; `test:unit` derives **every** `node --test` row from that inventory and runs them together; and `test.yml`'s `mcp-conformance-re-frame2-pair` job runs `npm run test:unit` — a job in `all-required-passed`. The classifier arms `mcp_conformance=true` and `mcp_live=true` for the file, and the job is gated on `mcp_live`. So the defining file is already executed by the PR that changes it. It is nightly-only *as a named script*, but not *as executed code* — which is the property that matters. **Not a defect.**

**3. `test:xray-feature-gate` (full), non-smoke rows — a real gap, but a different shape and a policy call. Filed separately as `rf2-rliq7`, not fixed here.** This is not the "file never loaded" defect: `test:xray-feature-gate:smoke` — a command the PR job already runs — `require`s the whole of `tools/xray/testbeds/feature_matrix/scenarios.cjs`, so the file is loaded, parsed and validated at PR time, and the launcher fails loud on an empty smoke set. What is not *executed* is the non-smoke **rows**, and that is the deliberate two-tier policy `TESTING.md` documents ("everything else is nightly by default"), not a fail-open instrument. Closing it means running the all-scenarios/all-surfaces sweep on every `scenarios.cjs` edit — a reversal of a documented policy with a real cost, which deserves its own decision rather than being smuggled into a bug fix. The pin keeping it nightly is retained and now carries this reasoning inline.

`TESTING.md` records all of it: the new `story_static_gate` row in the classifier table, the two-tier exception now covering both nightly commands, and an explicit note that the Xray full matrix is deliberately **not** a third exception.

## Relationship to rf2-13zre

`rf2-13zre` owns *enumerating* the required-gates-the-spine-does-not-run gap. This PR does not touch its territory. It does add one fact that bead would want when it runs: `test:story-static` moves from "nightly-only" to "nightly, plus PR when its own definition changes", joining `test:story-feature-load`.

## Notes for review

`.github/workflows/**` is hot-zone. The edit is surgical: one output declaration, one disjunct added to one job `if`, and one new conditional step. No existing step's behaviour changes. Branched off current `origin/main` (`83c21908e2`, #7481's merge), not an older base.

## Quality gates

All run in the worker worktree, foreground to completion, no gate piped through `tail`/`head`/`grep`.

| Gate | Exit | Notes |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`. 12578 tests / 63048 assertions, 0 failures, 0 errors. |
| `npm run test:script-policy` | **0** | first half of the chained JS harness gate |
| `npm run test:script-helpers` | **0** | second half — both halves run |
| `clj-kondo` **2026.04.15** (CI-pinned binary, `lint.yml`'s exact invocation) | **0** | **errors: 0**, warnings: 4534 (baseline) |
| EP-0036 donor grep | **clean** | `git grep -e 're-frame\.ui' -e 're_frame/ui' -e 're-frame2-ui' -- implementation/freehand` → no matches |
| `node scripts/_changed-surfaces.test.cjs` | **0** | **295 passed** (289 + 6 new) |
| `npm run test:story-static` (the gate this PR makes required) | **0** | run twice — 85s / 62s. `Story static smoke passed.` |

Local clj-kondo is 2025.10.23; the CI-pinned 2026.04.15 binary was downloaded and used instead, since the version pin is the point.

**Tiers the fast spine did not run**, as it reported them:

1. JVM artefact suites the diff did not touch (`implementation/adapters/*`, `schemas`, `machines`, `routing`, `flows`, `http`, `ssr`, `ssr-ring`, `epoch`, `resources`, `ui`, `freehand`, `security`, the conformance artefacts, …) — `scripts/test-jvm-implementation.sh` runs all.
2. Browser lanes, prod-elision/bundle-isolation/perf gates, adapter probes + smokes, Xray feature matrix, mcp-conformance, tool JVM suites — CI only.

This diff is CI configuration, one test file and one doc; it touches no Clojure source, so neither skipped tier can be affected by it. The one command it *does* make required was run locally to completion.
