### PR TITLE
docs(hicasso): deep voice pass on draft guide

### DIFF
--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -1,19 +1,17 @@
 # Getting started
 
-> **Draft ahead of the product artefact.** No `implementation/hicasso/` ships yet.
-> Spellings marked **[unfrozen]** are provisional until the API freeze. Behaviour
-> shown here is witnessed under `implementation/freehand/test/re_frame/bench/hicasso/`.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Behaviour matches the experimental arm under `implementation/freehand/test/re_frame/bench/hicasso/`.
 
 Booting a re-frame2 app today takes about thirty lines: create a React root,
 install an adapter, render a `frame-root` inside it, remember the root across
 hot reloads so React doesn't get a second `create-root` for a live node. Every
-app writes the same thirty lines and every app gets one of them subtly wrong at
-least once.
+app writes the same ceremony and gets one of the lines subtly wrong at least
+once.
 
-Hicasso collapses that into one call. **One root operation associates a DOM
-node, a frame, and initial events, and returns an idempotent teardown.** Names
-and arities wait for the API freeze; the product-shaped surface below is what
-this guide teaches.
+Hicasso collapses that into one call.
+
+> **One root associates a DOM node, a frame, and initial events, and returns
+> an idempotent teardown.**
 
 ## Your first app
 
@@ -79,7 +77,7 @@ And the boot namespace, which is the actual subject of this page:
 That is the whole boot. `h/root!` **[unfrozen]** takes the DOM node, a config
 map, and one view, and hands back a teardown function. Exact names and arities
 are not frozen; treat the shape — node, config, view → teardown — as the
-authoring contract this guide teaches.
+contract this guide teaches.
 
 The `{}` on `[views/todo-app {}]` is optional — `[views/todo-app]` renders the
 same thing, and the body receives an empty props map either way. Write whichever
@@ -103,14 +101,12 @@ Idempotence is part of the contract, not a courtesy. Teardown paths get called
 from `finally` blocks, test fixtures, and reload hooks that don't coordinate, so
 a second call has to be a no-op rather than a crash.
 
-The standing assertion behind it is worth knowing even if you never write it
-yourself: **zero leaked subscription ref-counts after teardown**. If a root goes
-away and a subscription cache entry survives, that is a bug in Hicasso, not a
-lifecycle subtlety you were supposed to manage.
+After teardown, **subscription ref-counts drop to zero**. A surviving cache
+entry after a root goes away is a Hicasso bug, not something you manage.
 
 ## Hot reload
 
-Hot reload has a floor rather than a prescribed mechanism. After a body swap:
+After a body swap:
 
 - the root, the frame, and app-db survive;
 - the changed view body is the one that runs;
@@ -118,20 +114,16 @@ Hot reload has a floor rather than a prescribed mechanism. After a body swap:
 
 Preserving hook-local state across a swap is optional, so don't build on it.
 
-Note what the floor implies for the code above. `defonce` keeps the root alive
-across reloads, and the guarantee says the *changed body* is used — so a
-`^:dev/after-load` remount hook is not part of the designed story.
-
-Half the mechanism is visible in how `defview` expands. It is a `def` of a
-freshly minted head, so re-evaluating the namespace produces a *new* head —
-which is a new React element type, and React replaces that subtree rather than
-trying to reconcile it. Nothing has to force its way past the default bail-out.
-What is not pinned is what makes the next render happen at all; see **Not
-settled yet**.
+`defonce` keeps the root alive across reloads, and the guarantee says the
+*changed body* is used — so a `^:dev/after-load` remount hook is not required.
+`defview` expands to a `def` of a freshly minted head: re-evaluating the
+namespace produces a *new* head, which is a new React element type, so React
+replaces that subtree rather than reconciling past the default bail-out. What
+is still open is what *triggers* the next render; see **Not settled yet**.
 
 If you edit `:todo/initialise` itself and want the new seed to run, reset the
-frame or reload the page. Hot reload preserves state by design, and it will
-happily preserve it right past your edited setup event.
+frame or reload the page. Hot reload preserves state by design — including past
+your edited setup event.
 
 ## More than one frame
 
@@ -148,31 +140,25 @@ than `:rf.error/*` ids.
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | `sub` throws outside a view | `sub` is render-scoped; there is no `@`-anywhere in Hicasso | Use `rf/subscribe-once` in handler and utility code |
-| Async callback dispatches and nothing happens | A bare `dispatch` from a timeout has no frame | Callbacks generated from intent vectors carry their boundary's frame; hand-written async needs the frame explicitly |
+| Async callback dispatches and nothing happens | A bare `dispatch` from a timeout has no frame | Callbacks from intent vectors carry their boundary's frame; hand-written async needs the frame explicitly |
 | First paint shows empty state, then flickers | Seeding raced the first render | Seed through `:initial-events`, not a post-mount dispatch |
 | A view renders twice on mount in dev | React StrictMode double-invokes bodies | Nothing to fix — bodies are pure and re-runnable by contract |
 | Second `h/root!` on the same node | The node already has a live root | Keep the root in a `defonce`; call the teardown before re-rooting |
 
 ## When not to use this
 
-**Server-side rendering is in scope for Hicasso.** The story is the framework's
-own Spec 011 mechanism, not a Hicasso-private one: the server embeds the
-`#__rf_payload` EDN payload and the client adopts it through the reserved
-`:rf/hydrate` door before first render. In the bench arm, the hydration door,
-`defhost`'s `:ssr` policy, the Node render entry, and the spike witness are
-landed and witnessed. The production server arm is still open.
-
-There is still no product `implementation/hicasso/` artefact. If you need the
-full published SSR guide path in production today, a
+**SSR is in scope for Hicasso**, via the framework's Spec 011 path rather than a
+private one. [Server-side rendering](10-server-side-rendering.md) covers the
+Hicasso side. Until there is a product `implementation/hicasso/` package, if you
+need a published production SSR path today, a
 [Reagent or UIx adapter](../../../core/views.md) remains first-class and
-supported. [Server-side rendering](10-server-side-rendering.md) tells the Hicasso
-story door by door.
+supported.
 
 ## Not settled yet
 
 | Question | Status |
 |---|---|
-| The root operation's name, its config keys, and the teardown's name | Semantics pinned; names **[unfrozen]** until the API freeze |
-| Does `rf/init!` and adapter installation still apply? | **Not addressed.** Hicasso is a native view layer rather than an adapter, but nothing yet says whether the root operation subsumes process setup or whether an `init!`-equivalent survives |
-| What triggers the re-render after a hot-reload body swap | **Not addressed.** The guarantees and `defview`'s expansion settle how the new body is picked up; nothing says who asks for the render |
-| Where the frame config other than `:initial-events` goes | **Not addressed.** `frame-root` takes a config map today; whether the root operation passes one through is unstated |
+| Root operation name, config keys, teardown name | Behaviour fixed; names **[unfrozen]** |
+| Does `rf/init!` and adapter installation still apply? | **Open.** Hicasso is a native view layer, not an adapter — unclear whether the root subsumes process setup |
+| What triggers re-render after a hot-reload body swap | **Open.** Guarantees and `defview` expansion settle how the new body is picked up; not who asks for the render |
+| Where frame config other than `:initial-events` goes | **Open.** `frame-root` takes a config map today; whether the root passes one through is unstated |

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -1,15 +1,13 @@
 # Views and reads
 
-> **Draft ahead of the product artefact.** No `implementation/hicasso/` ships yet.
-> Spellings marked **[unfrozen]** are provisional until the API freeze. Behaviour
-> shown here is witnessed under `implementation/freehand/test/re_frame/bench/hicasso/`.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Behaviour matches the experimental arm under `implementation/freehand/test/re_frame/bench/hicasso/`.
 
 Views that re-render too coarse, and subscription reads that can't live where
 you use them, are the same pain twice: either you hoist a value and re-render a
 room full of siblings, or you invent a second way to read just so a helper can
 see the current filter. Hicasso's answer is a view that is a function from a
-props map to hiccup, and **one** read surface — `sub`, an ordinary function
-call at the point of use:
+props map to hiccup, and **one** way to read — `sub`, an ordinary function call
+at the point of use:
 
 ```clojure
 (ns todo.views
@@ -26,9 +24,10 @@ call at the point of use:
                 :on-input [:todo.ui/edit id ::h/value]}])]))
 ```
 
-Note the third read: it happens only when `editing?` is true, in the middle of
-an expression, and that is legal — the whole point of the surface. `sub` is the
-only product read surface; read where you need the value.
+> **`sub` is legal anywhere in the body** — inside a `let`, a `when`, a helper
+> call. Read where you need the value.
+
+`sub` is the only read form. There is no second spelling for helpers.
 
 ## Boundaries and inlining
 
@@ -46,14 +45,14 @@ React owns its identity, and it can re-render without its parent.
 A **plain call** is just a function call. Its hiccup is spliced into the
 caller's tree, it has no boundary of its own, and any `sub` it performs donates
 that read *upward* to the enclosing boundary. Helpers cost nothing at runtime
-and buy no re-render granularity, which is the trade in one sentence. And
-because reads are ordinary calls, **helpers can read**: a `filter-button` that
-needs the current filter just reads it, and the read belongs to whichever
-boundary is rendering — no value threaded down as an argument.
+and buy no re-render granularity. And because reads are ordinary calls,
+**helpers can read**: a `filter-button` that needs the current filter just
+reads it, and the read belongs to whichever boundary is rendering — no value
+threaded down as an argument.
 
-One rule, one visible distinction. Re-render granularity is a thing you should
-be able to see by reading the source, and Reagent's `^{:key}` metadata folklore
-is gone with it. Keys go in the props map:
+One rule, one visible distinction. Re-render granularity is something you should
+see by reading the source. Keys go in the props map (no Reagent `^{:key}`
+metadata):
 
 ```clojure
 (defview todo-list [_]
@@ -62,19 +61,19 @@ is gone with it. Keys go in the props map:
      [todo-row {:key id :id id}])])
 ```
 
-A bare seq of boundary children needs keys, and today you get React's own key
-warning in development if you forget — a Hicasso-minted one is planned but not
-built. The `for`-lowering sugar that would derive the key from the binding is
-**not v0** — you write `:key` yourself. Putting a plain `defn` in head position
-— `[badge {...}]` where `badge` was never minted by `defview` — is
-`:rf.error/hicasso-bad-head`, a loud error rather than a silent embedding.
+A bare seq of boundary children needs keys. Forget one today and you get React's
+own key warning in development; a Hicasso-minted warning is planned but not
+built. Sugar that would derive the key from a `for` binding is **not yet** —
+you write `:key` yourself. Putting a plain `defn` in head position —
+`[badge {...}]` where `badge` was never minted by `defview` — raises
+`:rf.error/hicasso-bad-head`.
 
 ### The component ABI
 
 | Head | Props | Children | `:key` | `:ref` |
 |---|---|---|---|---|
 | Native tag — `[:div …]` | attribute map | trailing forms | `:key` in the attribute map | callback ref, legal |
-| Hicasso view — `[todo-row …]` | one props map | trailing forms, arriving as `(:children props)` | in the props map, **extracted before your body sees props** | not a v0 surface — use ids |
+| Hicasso view — `[todo-row …]` | one props map | trailing forms, arriving as `(:children props)` | in the props map, **extracted before your body sees props** | not yet — use ids |
 | Fragment — `[:<> …]` | — | trailing forms | on the fragment's props map | — |
 | Foreign — `defhost` (and `[:>]`, once it is built) | converted per declaration | hiccup children become elements | `:key` in props | callback ref, legal |
 
@@ -88,9 +87,7 @@ dropping it in whole — `(into [:ul.nested] children)`, or `(into [:<>] childre
 when you have nothing to wrap it in. A raw vector in child position is read as
 hiccup, and a vector whose head is itself a vector is not a legal element.
 
-`:key` never reaches your body. That is React's contract, not a Hicasso choice,
-and pretending otherwise would be the kind of leaky convenience that costs you a
-day when it finally bites.
+`:key` never reaches your body. That is React's contract, not a Hicasso choice.
 
 ### Bodies are pure and re-runnable
 
@@ -113,21 +110,17 @@ props say. And a function-valued prop compares unequal by identity, deliberately
 — a freshly allocated closure is never `=` to the last one, so an inline handler
 defeats the bail-out every time it is passed fresh.
 
-If you are coming from Reagent this should feel familiar rather than surprising —
-Reagent has compared argv and skipped for a decade, and this is the same shape.
-There is no public opt-out in v1: a boundary that genuinely wants to re-run every
-time its parent does takes an explicit changing revision prop, not a `:memo
-false` switch.
+If you are coming from Reagent this should feel familiar — Reagent has compared
+argv and skipped for a decade, and this is the same shape. There is no public
+opt-out: a boundary that genuinely wants to re-run every time its parent does
+takes an explicit changing revision prop, not a `:memo false` switch.
 
-One corollary is worth stating outright, because the opposite is the thing people
-worry about. Reading a subscription high in the tree and passing the value down
-as a prop does **not** lose an update: the boundary that reads is the boundary
-that invalidates, and every boundary the changed value actually reaches receives
-unequal props at that hop, so the default bail-out never applies to it — the
-value arrives. What the default buys you, beyond that chain, is that a boundary
-the value does **not** reach skips instead of re-rendering for nothing. Moving
-the read down is still a granularity fix, not a correctness fix, and if you go
-looking for a lost update you will not find one.
+Reading a subscription high in the tree and passing the value down as a prop
+does **not** lose an update: the boundary that reads is the boundary that
+invalidates, and every boundary the changed value actually reaches receives
+unequal props at that hop. What the default buys you, beyond that chain, is that
+a boundary the value does **not** reach skips instead of re-rendering for
+nothing. Moving the read down is a granularity fix, not a correctness fix.
 
 Whether the bail-out stays the *default* is still open; see **Not settled yet**.
 Nothing you write changes either way; what may change is whether you have to ask
@@ -152,31 +145,29 @@ you.
       :on-input    [:editor/set-title ::h/value]}]))
 ```
 
-Five rules cover the whole of it.
+Five rules cover it.
 
 **Names go kebab to camel.** `:on-click` emits `onClick` and `:default-value`
 emits `defaultValue`. `:aria-*` and `:data-*` pass through exactly as written,
-because that is what the DOM wants, and a `--custom-property` is preserved
-verbatim. Three attributes React spells differently from HTML are renamed for
-you: `:class` → `className`, `:for` → `htmlFor`, `:charset` → `charSet`.
+and a `--custom-property` is preserved verbatim. Three attributes React spells
+differently from HTML are renamed for you: `:class` → `className`,
+`:for` → `htmlFor`, `:charset` → `charSet`.
 
 **Values convert one level deep.** A nested map — `:style` and its kin — has its
 own keys camelCased, so `{:margin-top 8}` arrives as `marginTop`. Keywords and
 symbols become their names, which is why `:type :text` is `type="text"`.
-Functions cross by identity, deliberately: rewrapping them would defeat the
-default value-equality bail-out and every other comparison that looks at handler
-identity.
+Functions cross by identity: rewrapping them would defeat the default
+value-equality bail-out.
 
 **`:class` takes more than a string.** A keyword, a symbol, or a collection of
 those, with `nil`s dropped and the rest joined by spaces — so the `(when …)`
-above contributes nothing at all when it is false, and you never build a class
-string by hand.
+above contributes nothing when it is false, and you never build a class string
+by hand.
 
-**The tag's `#id` and `.class` shorthand composes** — and the id comes first, as
-it does in every hiccup dialect: `:input#title.form-control`, never
+**The tag's `#id` and `.class` shorthand composes** — id first, as in every
+hiccup dialect: `:input#title.form-control`, never
 `:input.form-control#title`. An explicit `:id` in the map wins over `#title`,
-and `.form-control` on the tag is joined with whatever `:class` brings rather
-than one of them silently replacing the other.
+and `.form-control` on the tag is joined with whatever `:class` brings.
 
 **`:key` is not an attribute.** It is React's identity contract: it is read off
 the map, it never reaches your body, and it is not emitted as a prop.
@@ -184,29 +175,29 @@ the map, it never reaches your body, and it is not emitted as a prop.
 One further key is reserved, and it is the only attribute merge Hicasso has.
 `:&` carries a map of attributes from somewhere else — a caller's forwarded
 remainder, a theme's part attributes — and **the literal keys you write always
-win over it**. The case that makes the law worth having is a controlled input,
-so
-[Controlled inputs](04-controlled-inputs.md#forwarding-attributes-onto-a-controlled-input)
+win over it**. The case that makes the law worth having is a controlled input, so
+[Controlled inputs](04-controlled-inputs.md#forwarding-attributes-)
 teaches it in full.
 
-## How `sub` works, in the four sentences that matter
+## How `sub` works
 
-One fixed runtime hook per boundary collects the reads the body actually made,
-and the commit installs exactly that edge set — so **a branch not taken
-contributes no edge**. Reads inside a lazy `for` are forced by the same pass
-that turns hiccup into elements, so they land in the right boundary's window.
-**A read that escapes the render is loud, never silently stale**: a stored
-handler, a stashed lazy seq, or a `delay` forced later fails naming the query,
-and an unforced `delay` crossing a boundary is refused at the crossing — the
-alternative in each case would be a value that is correct on screen and frozen
-thereafter, attributable to nothing. The honest cost sits on the other side: the
-edge set is a function of what the body *did*, so a body whose control flow
-changes its reads from render to render pays a re-subscribe that replaces the
-whole set, not just the changed key.
+Four sentences:
 
-That last sentence is the one to design around. It is a real difference from a
-surface whose edges are static: dynamic control flow is legal, and the price is
-a whole-set refresh when the taken branches change.
+1. One fixed runtime hook per boundary collects the reads the body actually made,
+   and the commit installs exactly that edge set — so **a branch not taken
+   contributes no edge**.
+2. Reads inside a lazy `for` are forced by the same pass that turns hiccup into
+   elements, so they land in the right boundary's window.
+3. **A read that escapes the render is loud, never silently stale**: a stored
+   handler, a stashed lazy seq, or a `delay` forced later fails naming the
+   query; an unforced `delay` crossing a boundary is refused at the crossing.
+4. The edge set is a function of what the body *did*, so a body whose control
+   flow changes its reads from render to render re-subscribes the whole set, not
+   just the changed key.
+
+That last point is the one to design around. Dynamic control flow is legal; the
+price when taken branches change is a whole-set refresh. See **Advanced** for
+the collector mechanics.
 
 ## Rules every read obeys
 
@@ -216,31 +207,25 @@ a whole-set refresh when the taken branches change.
 - **Framework subscriptions read identically to your own** — machine tags,
   resource and mutation state, route identity. They are first-class in the
   index, not a special case.
-- **Sub-key identity is `(query-id, args)` under value equality.** Note what
-  that buys you: a *freshly allocated* map or vector is not a problem. Two
-  structurally equal persistent values are one cache key, so rebuilding
-  `{:scope :all}` inside the query on every render hits the same entry every
-  time, and you do not have to hoist it into a `def` or memoize it to be safe.
-  Sorting the same items into the same order is the same story — `=` compares
-  sequential values by their contents, so a freshly sorted seq is the key the
-  last one was, at the cost of walking it. Two things do thrash the index. An
-  argument whose **value** genuinely moved is a different key, and correctly so:
-  a timestamp folded into the query, or a sort order that really changed. And an
-  argument carrying **reference** identity rather than value identity — a
-  function, a JS object or array, a host object — is unequal to itself between
-  renders, because for those `=` is identity. Documented, programmer-trusted,
-  not policed.
+- **Sub-key identity is `(query-id, args)` under value equality.** A *freshly
+  allocated* map or vector is not a problem: two structurally equal persistent
+  values are one cache key, so rebuilding `{:scope :all}` inside the query on
+  every render hits the same entry. What thrashes the index: an argument whose
+  **value** genuinely moved (a timestamp, a sort order that really changed),
+  and an argument carrying **reference** identity (a function, a JS object or
+  array, a host object) — for those `=` is identity, so they are unequal to
+  themselves between renders. Documented, programmer-trusted, not policed.
 
 ## Troubleshooting
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| A boundary doesn't re-render even though something on screen should have changed | Its props still compare `=` to last render and it made no read of its own that moved — the default bail-out is doing exactly what it's for | Read the changing value with `sub` inside the boundary that displays it, or thread it down as a prop so the value actually differs there |
-| A boundary re-renders every time though its props look unchanged | A prop carries reference identity rather than value identity — an inline function literal, a JS object or array, a host object — so `=` correctly says unequal | Hoist the function, or convert the value to a persistent one. Freshness is not the problem: two structurally equal persistent values are `=` however recently they were built |
-| One cell changes and 300 boundaries re-render | The read lives too high in the tree | Push the read down into the boundary that displays it |
-| One value changes and a whole subtree re-renders with it | The value is read in an ancestor and passed down as a prop. Nothing is *lost* — the reading ancestor re-renders with the new value, and every boundary the value actually reaches has unequal props at that hop, so the default bail-out does not catch it there. Coarse invalidation, not missed invalidation | Read at the point of use, so the boundary that displays the value is the boundary that invalidates |
-| A read after the render throws, naming the query | A handler closure, a stashed lazy seq, or a `delay` deferred a `sub` past the render | Read during the render and close over the value; the loud error is the alternative to a silently frozen edge |
-| Index thrash, subscriptions constantly re-created | Query args that are not *value*-stable — a folded-in timestamp, a sort order that really changed, or a JS object or function carrying reference identity | Allocation is fine; two equal persistent values are one key however freshly built. Make the args equal under `=` between renders |
+| Boundary doesn't re-render though the screen should have changed | Props still `=` last render and no own read moved — bail-out working as designed | `sub` the changing value inside the boundary that displays it, or thread it as a prop so the value differs there |
+| Boundary re-renders every time though props look unchanged | A prop carries reference identity (inline `fn`, JS object/array, host object) | Hoist the function, or use a persistent value. Two equal persistent values are `=` however freshly built |
+| One cell changes and 300 boundaries re-render | The read lives too high | Push the read down into the boundary that displays it |
+| One value changes and a whole subtree re-renders | Value read in an ancestor and passed as a prop — coarse invalidation, not a missed one | Read at the point of use |
+| A read after the render throws, naming the query | A handler closure, stashed lazy seq, or `delay` deferred a `sub` past the render | Read during the render and close over the value |
+| Index thrash, subscriptions constantly re-created | Query args not *value*-stable (timestamp, real sort-order change, or JS/fn identity) | Make the args equal under `=` between renders; allocation of equal persistent values is fine |
 | A body's side effect fires twice | StrictMode double-invoke | Bodies are pure; move the effect out |
 
 ## When not to use a boundary
@@ -251,10 +236,36 @@ and simpler — no element, no identity, no index membership. Boundaries are for
 *re-render granularity*. Reach for one when you want something to update
 independently, not because the markup got long.
 
+## Advanced
+
+### The sub collector
+
+Each boundary owns one fixed runtime hook that opens a collection window for the
+duration of the body. Every `sub` call in that window records its query. At
+commit, the runtime installs **exactly** the edge set the body just made —
+nothing from a branch not taken, nothing from a previous render that no longer
+applies.
+
+Reads inside a lazy `for` (or any other lazy seq) are forced by the same pass
+that lowers hiccup to React elements. That is why they still land in the right
+boundary: the force happens while the window is open, not later when something
+else walks the seq.
+
+Escape is loud on purpose. If you close over a `sub` call site (rather than its
+value), stash an unforced lazy seq that contains a read, or force a `delay`
+after the render, the runtime fails naming the query. An unforced `delay` that
+would cross a boundary is refused at the crossing. The alternative in each case
+is a value that looks right on screen and freezes thereafter, with nothing to
+blame.
+
+Because the edge set tracks control flow, a body that sometimes reads three
+queries and sometimes five pays a full re-subscribe when the taken set changes —
+not a surgical add/remove of one key. That is the cost of legal dynamic reads.
+
 ## Not settled yet
 
 | Question | Status |
 |---|---|
-| `sub` and `defview` spellings | Working names; declaration spellings stay **[unfrozen]** until the API freeze |
-| Whether the value-equality bail-out stays the **default** | **Open.** The runtime implements memo-by-default today; an alternative that ships the same comparator as an explicit opt-in is still on the table. This page teaches the default because that is what is landed |
-| The dev warning for an unkeyed seq — its id and whether it is dev-only | **Not addressed** beyond "dev warning"; nothing mints one yet — what a reader sees today is React's own key warning |
+| `sub` and `defview` spellings | Working names; **[unfrozen]** until API freeze |
+| Whether value-equality bail-out stays the **default** | **Open.** Runtime implements memo-by-default today; explicit opt-in is still on the table |
+| Dev warning for an unkeyed seq — id and whether dev-only | **Open.** Today you see React's own key warning |

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -1,26 +1,24 @@
 # Events as data
 
-> **Draft ahead of the product artefact.** No `implementation/hicasso/` artefact
-> ships yet. Spellings marked **[unfrozen]** stay provisional until the API freeze.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Behaviour matches the experimental arm under `implementation/freehand/test/re_frame/bench/hicasso/`.
 
-Handler attributes are where a data-oriented view layer usually gives up. You have
-been writing pure data all the way down the tree, and then `:on-click` needs a
-function, so you write `#(rf/dispatch [:todo/toggle id])` and the node stops being
+Handler attributes are where a data-oriented view layer usually gives up. You
+write pure data all the way down the tree, then `:on-click` needs a function, so
+you write `#(rf/dispatch [:todo/toggle id])` and the node stops being
 inspectable, comparable, or assertable by equality.
 
-Hicasso's answer: **put the event vector in the attribute.** The runtime builds the
-callback.
+> **Put the event vector in the attribute.** The runtime builds the callback.
 
 ```clojure
 [:button {:on-click [:todo/toggle id]} "✓"]
 ```
 
-That is not sugar for a closure you could have written. The tree still holds data at
-that node, which means a test can assert it with `=` and a tool can read it.
+That is not sugar for a closure you could have written. The tree still holds
+data at that node, so a test can assert it with `=` and a tool can read it.
 
-Lowering is by shape, not by roster: any prop whose name reads `on-` plus a letter
-(or camelCase `onClick`, for the migrating author) is an event position, so there is
-no list of blessed event names to keep in step with the DOM.
+Lowering is by shape, not by roster: any prop whose name reads `on-` plus a
+letter (or camelCase `onClick`, for the migrating author) is an event position.
+There is no list of blessed event names to keep in step with the DOM.
 
 ## The value placeholders
 
@@ -39,15 +37,15 @@ target's `.value` and `.checked`:
          :on-change [:todo/set-done id ::h/checked]}]
 ```
 
-At dispatch, the placeholder is replaced by the input's value or checked state, so
-the handler receives `[:todo.ui/edit 7 "milk"]` or `[:todo/set-done 7 true]` —
-ordinary event vectors, indistinguishable from ones you dispatched by hand.
-Substitution happens at the intent vector's top level only, which is the shape you
-write; a marker buried in nested structure is not looked for.
+At dispatch, the placeholder is replaced by the input's value or checked state,
+so the handler receives `[:todo.ui/edit 7 "milk"]` or `[:todo/set-done 7 true]`
+— ordinary event vectors, indistinguishable from ones you dispatched by hand.
+Substitution happens at the intent vector's top level only; a marker buried in
+nested structure is not looked for.
 
 Those two markers cover almost every handler site that only needs the target's
-value or checked state. For the full controlled-input round-trip — value in from a
-subscription, intent out, caret and same-tick echo — see
+value or checked state. For the full controlled-input round-trip — value in from
+a subscription, intent out, caret and same-tick echo — see
 [Controlled inputs](04-controlled-inputs.md).
 
 ## Functions still work
@@ -64,9 +62,9 @@ everything, not because functions are forbidden.
 
 ## When you need the event *and* an intent: `h/fn`
 
-Sometimes the event has to be read before you know what to dispatch — a file list,
-a drag delta, a filtered key. For that there is **one** callback form, and it is an
-ordinary function:
+Sometimes the event has to be read before you know what to dispatch — a file
+list, a drag delta, a filtered key. For that there is **one** callback form, and
+it is an ordinary function:
 
 ```clojure
 [:input {:type "file"
@@ -92,23 +90,23 @@ conditional dispatch is an ordinary `when`:
 | `:ref` | React's own contract — the node on attach, your return as the cleanup |
 | a raw `#js` prop you built yourself | nothing at all. It is a function; it runs |
 
-That last row is worth knowing about. `h/fn` is a real function everywhere. Put it
-somewhere the runtime does not walk and you lose the contract, not the call — the
-library gets a callable, not a marker object that blows up as a `TypeError` naming
-nothing you wrote.
+That last row is worth knowing. `h/fn` is a real function everywhere. Put it
+somewhere the runtime does not walk and you lose the contract, not the call —
+the library gets a callable, not a marker object that blows up as a `TypeError`
+naming nothing you wrote.
 
 You never pick a form. There is one, and where you put it is the decision.
 
-**Write the parameter vector the caller actually calls with.** A DOM event position
-hands you one argument, so `(h/fn [e] …)` is what you will write almost every time
-— but at a `defhost` callback the declaration named `:event`, the arguments are the
-foreign component's, and it may pass two or three. Take them all: they arrive
-exactly as that library sends them.
+**Write the parameter vector the caller actually calls with.** A DOM event
+position hands you one argument, so `(h/fn [e] …)` is what you will write almost
+every time — but at a `defhost` callback the declaration named `:event`, the
+arguments are the foreign component's, and it may pass two or three. Take them
+all: they arrive exactly as that library sends them.
 
-One thing the policy defaults above do *not* do: **`h/fn` at `:on-submit` does not
-auto-prevent.** That default exists because an intent vector never sees the event,
-so the runtime has to decide for it. A callback is handed the event, so the event
-is yours — call `.preventDefault` in the body. Whoever holds the event owns it.
+One thing the policy defaults below do *not* do: **`h/fn` at `:on-submit` does
+not auto-prevent.** That default exists because an intent vector never sees the
+event, so the runtime has to decide for it. A callback is handed the event, so
+the event is yours — call `.preventDefault` in the body.
 
 ## Policy defaults the runtime owns
 
@@ -124,9 +122,9 @@ An intent vector at `:on-submit` prevents the browser's default navigation:
  [:button {:type :submit} "Sign up"]]
 ```
 
-No `(.preventDefault e)`. Forms almost always want it, so the runtime does it. For
-the rare form that wants a real submission, write the handler as `h/fn`: a callback
-is handed the event, so the runtime leaves it alone and the event is yours.
+No `(.preventDefault e)`. Forms almost always want it, so the runtime does it.
+For the rare form that wants a real submission, write the handler as `h/fn`: a
+callback is handed the event, so the runtime leaves it alone.
 
 ### Everywhere else, prevention is one head
 
@@ -138,19 +136,21 @@ the pagination link — opts in, and the opt-in is part of the intent:
 [:a.nav-link {:href "#" :on-click [::h/prevent [:conduit/show-your-feed]]}]
 ```
 
-`[::h/prevent INTENT]` and nothing else: exactly one inner intent vector, which is
-what gets dispatched. Write it wrong — two payloads, a keyword instead of a vector,
-a decorator inside a decorator — and you get `:rf.error/hicasso-malformed-prevent`
-naming the attribute you wrote it at, at render time rather than at the click.
+`[::h/prevent INTENT]` and nothing else: exactly one inner intent vector, which
+is what gets dispatched. Write it wrong — two payloads, a keyword instead of a
+vector, a decorator inside a decorator — and you get
+`:rf.error/hicasso-malformed-prevent` naming the attribute you wrote it at, at
+render time rather than at the click.
 
-It is a head rather than metadata on the vector for a reason worth knowing, because
-it is the reason you can test it: **metadata does not participate in `=`**.
+It is a head rather than metadata on the vector for a reason: **metadata does
+not participate in `=`**.
 `(= [:app/go] ^{::h/prevent? true} [:app/go])` is `true`, so an annotation is
 invisible to a structural test that compares the tree — and to `pr-str`, and to
 anything hashing the intent. A head is visible to all three.
 
-Markers still work inside it: `[::h/prevent [:filter/set ::h/value]]` prevents and
-materializes, because the decorator is unwrapped before the markers are looked for.
+Markers still work inside it: `[::h/prevent [:filter/set ::h/value]]` prevents
+and materializes, because the decorator is unwrapped before the markers are
+looked for.
 
 ### The key map
 
@@ -167,22 +167,14 @@ A map from key name to intent. The names are strings, matched against the DOM
 event's own `.key` value; keys you don't list are ignored, and there is no
 modifier language.
 
-The reason this belongs in the runtime rather than in your view is the composition
-law: **a composing Enter commits nothing.** Mid-IME, Enter selects a candidate — it
-is not a submit, and treating it as one is how a Japanese or Chinese user loses a
-sentence. The runtime centralises that check, including the legacy keyCode-229
-signal that some browsers still use to say "this keystroke belongs to the IME" —
-and it reads both signals off the *native* event, because React's synthetic
-keyboard event drops `isComposing`, which is exactly the trap a hand-written
-handler falls into.
-
-Get this wrong in your own handler and it fails silently for every user who
-composes. Which is a good argument for it not being your handler.
+The runtime owns composition: mid-IME, Enter selects a candidate — it is not a
+submit. Hand-write that check wrong and every user who composes loses a sentence.
+See **Advanced** for the IME detail.
 
 ## Links: `route-link` and the navigate head
 
-Most of an application's anchors are navigations. Spell the link as `route-link`, a
-plain function over the routing artefact's link seam:
+Most of an application's anchors are navigations. Spell the link as
+`route-link`, a plain function over the routing artefact:
 
 ```clojure
 (ns conduit.views.profile
@@ -196,33 +188,32 @@ plain function over the routing artefact's link seam:
 
 You name a route and its params and never see a URL. What comes back is one real
 `<a>` whose `:href` is routing's own synthesis and whose `:on-click` carries the
-click decision **as data**, under the second reserved head, `[::h/navigate {…}]` —
-so two renders of one link are equal under `=`, and a structural test reads the
-click decision off the tree. Because it is a plain function, not a boundary, it
-inlines: no hook, no subscription read, no row in any boundary count. An author
-byline is not a unit of re-render.
+click decision **as data**, under the second reserved head, `[::h/navigate {…}]`
+— so two renders of one link are equal under `=`, and a structural test reads
+the click decision off the tree. Because it is a plain function, not a boundary,
+it inlines: no hook, no subscription read, no row in any boundary count.
 
-The click law is routing's, stated once: a modifier-click or auxiliary click stays
-the browser's (a new tab opens), a `:target` or `:download` anchor stays native,
-and everything else is `preventDefault` plus a dispatch of the routing intent to
-the frame that was captured at render. Rendering a `route-link` with the routing
-artefact absent fails at render with `:rf.error/routing-artefact-missing`, naming
-the `:to` — never a dead anchor.
+The click law is routing's, stated once: a modifier-click or auxiliary click
+stays the browser's (a new tab opens), a `:target` or `:download` anchor stays
+native, and everything else is `preventDefault` plus a dispatch of the routing
+intent to the frame that was captured at render. Rendering a `route-link` with
+the routing artefact absent fails at render with
+`:rf.error/routing-artefact-missing`, naming the `:to` — never a dead anchor.
 
-**The `:on-click` you pass is the pre-navigation veto**, and its roster is closed:
-`nil`, `[::h/prevent [:app/event]]`, `h/fn`, or a plain function. The prevent form
-is the declarative veto — the navigation is cancelled and your intent dispatched
-instead. A **bare** intent vector there is refused loudly: the click already
-produces the one routing intent, and one user action must not yield two semantic
-events.
+**The `:on-click` you pass is the pre-navigation veto**, and its roster is
+closed: `nil`, `[::h/prevent [:app/event]]`, `h/fn`, or a plain function. The
+prevent form is the declarative veto — the navigation is cancelled and your
+intent dispatched instead. A **bare** intent vector there is refused loudly: the
+click already produces the one routing intent, and one user action must not yield
+two semantic events.
 
-Routing also publishes a `:prefetch` opt-in, and Hicasso declines it for v0 — out
-loud, rather than by ignoring it. A `route-link` carrying `:prefetch` in any form,
-`nil` and `false` included, fails at render with
+Routing also publishes a `:prefetch` opt-in; Hicasso declines it today — out
+loud, rather than by ignoring it. A `route-link` carrying `:prefetch` in any
+form, `nil` and `false` included, fails at render with
 `:rf.error/hicasso-route-link-prefetch-declined`. A key that merely fell through
 would leave you with a link that prefetches nothing, reports it nowhere, and
-carries a stray attribute on the anchor. If you want prefetching today, write it as
-an ordinary intent at `:on-mouse-enter`.
+carries a stray attribute on the anchor. If you want prefetching today, write it
+as an ordinary intent at `:on-mouse-enter`.
 
 ## Callbacks carry their frame
 
@@ -232,36 +223,50 @@ from the substrate's single internal context.
 That matters because the browser invokes the callback long after the render that
 created it, when the render's dynamic extent is gone. A hand-written
 `#(rf/dispatch …)` from an async context raises `:rf.error/no-frame-context` for
-exactly this reason. Intent vectors don't, because the frame was captured when the
-callback was built.
+exactly this reason. Intent vectors don't, because the frame was captured when
+the callback was built.
 
 The rule of thumb: **intents are always safe; hand-written async needs the frame
 explicitly.**
 
 ## Troubleshooting
 
-This table names mechanisms rather than error ids; the ids the page does mint are
-named in the sections above.
+This table names mechanisms rather than error ids; the ids the page does mint
+are named in the sections above.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| Page navigates and reloads on form submit | Something bypassed the intent path — a hand-written `:on-submit` function | Use an intent vector, or call `.preventDefault` yourself in the function |
-| Handler receives the placeholder keyword instead of a value | The placeholder was used at an event position with no value to substitute | `::h/value` is for value-bearing events; `::h/checked` for checkboxes; read the event object with a function elsewhere |
-| Enter commits half-typed Japanese text | Composition handling was written by hand | Use the `:on-key-down` key map — the composition law is centralised there |
-| A `route-link` refuses your `:on-click` intent vector | The click already produces the one routing intent — a bare second intent is one action, two events | Wrap it: `[::h/prevent [:app/event]]` cancels the navigation and dispatches yours instead |
-| `:rf.error/routing-artefact-missing` when rendering a `route-link` | Routing is not on the classpath / not required at boot | Require `re-frame.routing` (and the rest of your routing setup) so the artefact is present before the link renders |
-| `:rf.error/no-frame-context` from a timeout | A bare `dispatch` in async code | Capture the frame at the call site, or dispatch an event that owns the async work through `:fx` |
+| Page navigates and reloads on form submit | Hand-written `:on-submit` function bypassed the intent path | Use an intent vector, or call `.preventDefault` yourself |
+| Handler receives the placeholder keyword instead of a value | Placeholder used where there is no value to substitute | `::h/value` for value-bearing events; `::h/checked` for checkboxes; read the event with a function elsewhere |
+| Enter commits half-typed Japanese text | Composition handling written by hand | Use the `:on-key-down` key map — composition is centralised there |
+| A `route-link` refuses your `:on-click` intent vector | Click already produces the routing intent — bare second intent is one action, two events | Wrap it: `[::h/prevent [:app/event]]` |
+| `:rf.error/routing-artefact-missing` when rendering a `route-link` | Routing not on the classpath / not required at boot | Require `re-frame.routing` (and the rest of your routing setup) before the link renders |
+| `:rf.error/no-frame-context` from a timeout | Bare `dispatch` in async code | Capture the frame at the call site, or own the async work through `:fx` |
 | An intent fires but no handler runs | Unregistered event id | Registration happens on namespace load; check the boot namespace requires it |
 
 ## When not to use an intent
 
 When you need the event object itself. Pointer coordinates, `dataTransfer`,
-`stopPropagation`, anything measuring the DOM — those are functions, and reaching
-for one is not a failure. Reach for `h/fn` when you want to read the event *and*
-dispatch, and a plain `(fn …)` when you want to read it and do something else.
+`stopPropagation`, anything measuring the DOM — those are functions, and
+reaching for one is not a failure. Reach for `h/fn` when you want to read the
+event *and* dispatch, and a plain `(fn …)` when you want to read it and do
+something else.
+
+## Advanced
+
+### IME and the key map
+
+The reason the key map belongs in the runtime rather than in your view is
+composition: **a composing Enter commits nothing.** Mid-IME, Enter selects a
+candidate — it is not a submit. The runtime centralises that check, including
+the legacy keyCode-229 signal that some browsers still use to say "this
+keystroke belongs to the IME" — and it reads both signals off the *native*
+event, because React's synthetic keyboard event drops `isComposing`. That is the
+trap a hand-written handler falls into: silent failure for every user who
+composes.
 
 ## Not settled yet
 
 | Question | Status |
 |---|---|
-| `h/fn`'s spelling | Working name; unfrozen like every declaration spelling |
+| `h/fn`'s spelling | Working name; **[unfrozen]** like every declaration spelling |

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -1,12 +1,11 @@
 # Controlled inputs
 
-> **Draft ahead of the product artefact.** No `implementation/hicasso/` artefact
-> ships yet. Spellings marked **[unfrozen]** stay provisional until the API freeze.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]**
+> may change. Behaviour matches the experimental arm under
+> `implementation/freehand/test/re_frame/bench/hicasso/`.
 
-A controlled text input is the hardest correctness problem a view layer has, and
-almost none of the difficulty is visible in the code you write.
-
-Here is what you write:
+A text field whose value lives in app-db: value in from a subscription, intent out
+on every keystroke. That is the whole required path.
 
 ```clojure
 (defview title-field [{:keys [id]}]
@@ -15,131 +14,51 @@ Here is what you write:
            :on-input [:todo.ui/edit id ::h/value]}])
 ```
 
-That's it. Value in from a subscription, intent out to an event — ordinary
-`:value` and `:on-input`, no ceremony. `:on-change` works identically; the runtime
-converges after whichever of the two runs last for a keystroke, and takes
-`:on-change` when a field carries both. The rest of this page is about the
-machinery underneath, because you need to know what it guarantees and where it
-stops.
+> **Ordinary `:value` and `:on-input` — no caret helper, no local atom.**
 
-For checkboxes and other non-text controls, the same intent-vector style applies —
-see [`::h/checked`](03-events-as-data.md#the-value-placeholders) on
+`:on-change` works the same way; if a field carries both, the runtime keeps the
+last one that ran for that keystroke. For checkboxes, use
+[`::h/checked`](03-events-as-data.md#the-value-placeholders) the same way — see
 [Events as data](03-events-as-data.md).
 
-## Why this is hard
+## What you get
 
-The value shown on screen lives in app-db, which means every keystroke makes a round
-trip: keystroke → dispatch → event handler → app-db commit → subscription →
-re-render → DOM value.
+The value on screen is app-db state, so every keystroke is a round trip:
+keystroke → dispatch → handler → commit → subscription → re-render → DOM value.
+Hicasso keeps that path **inside the same browser turn**, so two things hold without
+you writing either:
 
-If any part of that is asynchronous, you get the classic failure set. Fast typists
-drop characters. The caret jumps to the end of the field on every edit. IME
-composition breaks mid-word. Frameworks that leave this to taste end up with ad-hoc
-caret heuristics — track the last DOM value, reposition the cursor, hope composition
-survives. The comment in one such module says the alternative "gives the user a
-jarring experience," which is generous.
+1. **Same-tick echo.** The accepted character is back in the field before the
+   browser finishes the event. Fast typists do not drop characters.
+2. **Caret and selection stay put** when the model rejects or rewrites what was
+   typed — mid-string edits included. Remounting the input to "reset" it is not
+   an answer here: remount destroys focus, selection, and composition.
 
-## The synchronous door
-
-A controlled element's intent **dispatches synchronously inside the discrete
-browser event**, and the subscription layer's store notification runs
-synchronously too, so React commits the echo in the same turn. The value is back
-in the DOM before the browser's event handling finishes.
-
-`flushSync` is never the general default, and the one exception is named rather
-than left to taste: the controlled-text **converge** flushes the door's pending
-commit before React's end-of-event restore, so value *and caret* are correct
-in-turn — including when the model rejected or normalised the keystroke. What you
-get for free is exactly what the first example shows: ordinary `:value` and
-`:on-change`/`:on-input`, no ceremony, and a caret that stays put. The boundary
-is equally exact: the exception is one audited converge, reached from the
-element path once per keystroke — and once at `compositionend` instead, for the
-composition carve-out below — on controlled text entry only (a caret-bearing
-`input` or a `textarea` with a non-nil `:value`), and inert everywhere else.
-Needing `flushSync` anywhere else would still be a finding, not an implementation
-detail.
-
-## What the door guarantees
-
-Two operational guarantees, and they are v0's acceptance bar:
-
-**R-A1 — same-tick echo.** A keystroke flows event → commit → re-render such that
-the DOM value never lags the accepted keystroke. No dropped characters, no
-reordering, under the substrate's scheduling. A substrate that batches or defers
-renders must state its input-path exception mechanically — the synchronous door *is*
-that statement.
-
-**R-A2 — caret and selection preservation** when the rendered value differs from
-what was typed. Reject, transform, reformat: mid-string edits included.
-**Remount-as-reset is disqualified** — it destroys focus, selection, and
-composition state, so "just change the key" is not an available answer here.
-
-Browser witnesses stand behind the door on a 100-cell editing grid: same-turn echo,
-mid-string caret, selection, unchanged-model rejection, and async normalisation.
-
-The IME path is the one place where this runtime deliberately does something plain
-React does not, so it is worth stating exactly.
-
-**A composing Enter commits nothing.** Mid-composition, Enter picks an
-IME candidate; it is not a submit. The runtime's key-map gates on the native
-event's `isComposing` and on the legacy keyCode-229 signal that some browsers
-still send, each on its own — witnessed on the grid, and again against the
-browser's real composition machinery driven over CDP, on this runtime, on plain
-React and on the UIx port alike.
-
-**A live composition is carved out of the convergence, and it survives.** If
-your model refuses or normalises what the IME has composed so far, nothing is
-written to the field while the composition is running — not the runtime's
-converge, and not React's own end-of-event restore. Your handler still runs on
-every composing update and your model still refuses or normalises exactly as it
-would for a keystroke; what changed is that the *field* keeps showing the
-composition until the user commits it, and the refusal or normalisation lands
-whole, once, at `compositionend`.
-
-That is a divergence from plain React, claimed as one. On plain React the
-corrected value is written back *inside* the composing input event, and a value
-write during composition silently aborts the exchange: the in-flight kana are
-gone, no `compositionend` fires, and the IME opens a fresh composition on its
-next update — with each aborted draft left in the field for the next one to
-compose on top of. The UIx port does the same a frame later. Both are measured
-beside this runtime in the same harness run, which is where the claim comes
-from.
-
-Two things to know about the scope. It applies to controlled **text** entry —
-the same door everything else on this page describes — and it is **witnessed on
-Chromium**, because the harness drives real composition over CDP and CDP is
-Chromium's protocol. If you see an IME misbehave on WebKit, that is a bug worth
-reporting rather than a documented limit.
-
-## Rejection: when the model says no
-
-Your handler doesn't have to accept what was typed:
+Return `nil` from the handler and the field stays on the model value with the caret
+intact. That is the same path as a successful write; you do not special-case
+rejection in the view.
 
 ```clojure
 (rf/reg-event :order/set-quantity
   (fn [{:keys [db]} [_ id typed]]
     (if (re-matches #"\d*" typed)
       {:db (assoc-in db [:orders id :qty] typed)}
-      nil)))                                       ;; rejected — no-op, model unchanged
+      nil)))                                       ;; rejected — model unchanged
 ```
 
-The rejected path leans on **React's own end-of-discrete-event restore** for the
-*value*: the DOM node briefly holds the typed character, the model doesn't change,
-and React reasserts the model value when the discrete event ends. The **caret**,
-though, React's restore throws away — so the runtime takes it itself, in the
-element path, which is what the converge above is for. Either way, none of this is
-your code: return `nil` from the handler and the field shows the model, caret
-intact. R-A2 is why that path is not optional.
+IME composition is handled for you on the data key-map: a composing Enter does not
+submit, and a live composition is not overwritten when the model refuses or
+normalises mid-draft. Details under [Advanced](#advanced) if you need them.
 
-## Forwarding attributes onto a controlled input
+## Forwarding attributes: `:&`
 
-Sooner or later you write a `field` wrapper: one place that owns the controlled
-contract, and call sites that still need to pass a placeholder, a `name`, a test id.
-The remainder rides in one reserved key, `:&`:
+Sooner or later you wrap the controlled contract once and let call sites pass
+placeholder, `name`, test id, and friends. The remainder rides under one reserved
+key, `:&`:
 
 ```clojure
 (defview field [{:keys [id busy?] :as attrs}]
-  [:input.form-control {:& (dissoc attrs :id :busy?)   ;; whatever the caller sent
+  [:input.form-control {:& (dissoc attrs :id :busy?)
                         :value    (sub [:editor/field id])
                         :disabled busy?
                         :on-input [:editor/edit-field id ::h/value]}])
@@ -147,77 +66,97 @@ The remainder rides in one reserved key, `:&`:
 [field {:id :title :busy? busy? :type "text" :placeholder "Article Title"}]
 ```
 
-**The literal keys you write always win.** Not "usually", not "if you pick the right
-merge form" — always. So a caller who forwards a whole props map, a theme that
-supplies part attributes, or a genuinely hostile remainder carrying `:value` and
-`:on-input` all reach nothing that matters. Your `:value` is your `:value`.
+**Literal keys always win** over anything in `:&`. A caller (or a hostile remainder)
+cannot override your `:value` or `:on-input`. When you *want* the caller's value to
+win, leave the literal out: `[:input {:& attrs}]`. Put the element's own classes on
+the tag (`[:input.form-control …]`); `:key` and `:ref` are never taken from `:&`.
 
-That is the whole design, and it exists because of the thing it deletes: merge forms
-where the wrong choice silently drops caret and IME protection. Correctness by
-choice of syntax is the worst kind, because the code looks fine.
+The law is on the prop slot React ends up with, not the key spelling — so
+`"key"`, `:x/ref`, or `:onInput` against your `:on-input` reach nothing that
+matters either.
 
-Two consequences worth knowing.
+## Resets are by revision, not by value
 
-**Say it by not saying it.** When you *want* the caller's value to win, leave the
-literal out. `[:input {:& attrs}]` takes everything the caller sent. The default is
-the safe direction and the override is the explicit one, which is the way round you
-want when the thing being defended is a caret.
-
-**Classes compose on the tag.** `:key` and `:ref` are never taken from `:&`, and a
-literal `:class` wins outright like any literal — so put your element's own classes
-on the tag (`[:input.form-control {:& attrs}]`) and the shorthand merge combines
-them with whatever the caller brought.
-
-**Spelling it differently does not get round it.** The law is enforced on the prop
-slot React ends up with, not on the key as written, so a remainder carrying
-`"key"`, `:x/ref` or an `:onInput` against your own `:on-input` reaches none of
-them. You do not have to think about this; it is here so you know there is nothing
-to think about.
-
-## Resets are by revision, never by value
-
-When you need to force a field back to a value — a form reset, a "revert" button, a
-server-supplied normalisation — **the trigger is an explicit caller revision, not
-value equality.**
-
-The reason is a specific bug. If you reset whenever the incoming value equals some
-target, then a user who legitimately types that value gets their field yanked out
-from under them, and a rejected same-value reassertion becomes invisible. Explicit
-revision means the reset fires exactly when the caller says so: zero stale paints,
-loop-impossible, correct on retry.
-
-The prop that carries the revision does not have a Hicasso spelling yet; see
-**Not settled yet**.
+Force a field back to a value with an **explicit revision** from the caller — form
+reset, revert, server normalisation — not by comparing the incoming value to a
+target. Value-equality reset is how a user who legitimately types that value gets
+yanked mid-edit, and how a same-value reassertion becomes invisible. The prop that
+carries the revision is still unnamed; see **Not settled yet**.
 
 ## Troubleshooting
 
-This table names mechanisms; the door's failures are behavioural, not error ids.
-
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| Characters drop when typing fast | The dispatch path went async — a debounce, a `setTimeout`, a queued effect between keystroke and commit | Keep the controlled path on the synchronous door; debounce the *consumer* of the value, not the write |
-| Caret jumps to end of field on every keystroke | The value was reasserted without caret preservation | R-A2 territory — a real bug in the runtime, not in your view |
-| Enter commits half-typed text mid-composition | A hand-written key handler that bypasses the intent path | Use the data key-map — the commit fence lives there, on both composition signals |
-| An IME composition dies when the model refuses or normalises it | Value reassertion during composition, which the browser treats as an abort | Not this runtime: the converge is carved out of a live composition and React's restore is held off with it. On plain React and the UIx port it is theirs, and not yours to fix |
-| Typing the "reset" value clears the field | Reset keyed on value equality somewhere | Reset on explicit revision |
-| Field goes read-only after an async normalise | The model round-trip didn't complete | Async normalisation is one of the door witnesses; check the handler returns a `:db` write |
-| Focus lost after a validation failure | Something remounted the node | Remount-as-reset is disqualified precisely for this |
+| Characters drop when typing fast | Something async sat between keystroke and commit — debounce, `setTimeout`, a queued effect | Keep the controlled write synchronous; debounce *consumers* of the value, not the write itself |
+| Caret jumps to the end on every keystroke | Value reasserted without caret preservation | Runtime bug, not your view — report it |
+| Enter commits half-typed text mid-composition | A hand-written key handler that bypasses the intent path | Use the data key-map; the composition check lives there |
+| Composition dies when the model refuses mid-draft | A value write during composition (browser treats that as abort) | Not this runtime on controlled text: composition is left alone until `compositionend` |
+| Typing the "reset" value clears the field | Reset keyed on value equality somewhere | Reset on an explicit revision |
+| Focus lost after validation fails | Something remounted the node | Do not remount to reset — that is exactly what destroys focus |
 
 ## When not to control an input
 
-Controlled means every keystroke writes to app-db. On a dense editing grid that is
-one dispatch and one commit per cell per keystroke — price it before you reach for
-it. Which subs recompute matters as much as which boundaries re-render.
+Controlled means every keystroke writes app-db. On a dense grid that is one
+dispatch per cell per keystroke — price it before you pay it.
 
-If a field's intermediate values are nobody's business — a search box whose only
-consumer is a debounced query, a scratch field in a modal — an uncontrolled input
-with a commit on blur is not a compromise. It is the right shape.
+If intermediate values are nobody's business — a search box that only feeds a
+debounced query, a scratch field in a modal — leave the input uncontrolled and
+commit on blur. That is the right shape, not a shortcut.
+
+## Advanced
+
+### Same-tick mechanics (and the one `flushSync`)
+
+Dispatch for a controlled element runs **synchronously inside the discrete browser
+event**, and store notification is synchronous too, so React commits the echo in
+the same turn. The value is back in the DOM before the browser finishes handling
+the event.
+
+`flushSync` is not a general default. The one named exception is the controlled-text
+**converge**: it flushes the pending commit before React's end-of-event restore, so
+value *and caret* are correct in-turn — including when the model rejected or
+normalised the keystroke. That path runs once per keystroke on controlled text
+entry only (a caret-bearing `input` or a `textarea` with a non-nil `:value`), and
+once at `compositionend` for the composition carve-out below. Everywhere else it
+is inert. Needing `flushSync` for anything else is a design problem, not a
+feature.
+
+### Rejection and React's restore
+
+When the handler returns `nil`, the DOM node may briefly hold the typed character;
+React reasserts the model value when the discrete event ends. React's restore
+throws the caret away, so the runtime restores caret and selection itself on that
+converge path. You still only write `nil`.
+
+### IME composition
+
+Two rules, both automatic on the data key-map and controlled-text path:
+
+**A composing Enter commits nothing.** Mid-composition, Enter picks an IME
+candidate; it is not a submit. The key-map gates on the native event's
+`isComposing` and on the legacy keyCode-229 signal some browsers still send.
+
+**A live composition is not overwritten.** If the model refuses or normalises what
+the IME has composed so far, nothing is written to the field while composition is
+running — not the converge, and not React's end-of-event restore. Your handler
+still runs on every composing update; the field keeps showing the composition until
+the user commits it, and the refusal or normalisation applies whole at
+`compositionend`.
+
+That last point differs from plain React. On plain React a corrected value written
+during composition can abort the exchange: in-flight kana vanish, `compositionend`
+never fires, and the next update starts a fresh composition on a half-written
+draft. Hicasso carves the live composition out of that restore on purpose.
+
+Scope: controlled **text** entry (same path as the rest of this page). Composition
+behaviour is proven on Chromium; a WebKit IME misbehave is a bug report, not a
+documented limit.
 
 ## Not settled yet
 
 | Question | Status |
 |---|---|
-| The revision prop's spelling on a controlled element | **Not addressed.** The reset law is fixed; the attribute that carries the revision is unnamed |
-| The buffered / draft-and-commit input ladder | **Post-v0.** v0 ships R-A1/R-A2 and no more |
-| The controls kit that owns drafts and revisions | **Post-v0.** In v0 a draft is app-db state you write yourself |
-| Whether `:on-input` or `:on-change` is the taught attribute | Both work, and the runtime takes whichever runs last. Landed screens write `:on-input` for text and `:on-change` for checkboxes; which one the guide should teach is convention, not a hard law |
+| The revision prop's spelling on a controlled element | Reset law fixed; the attribute name is still open |
+| A buffered / draft-and-commit input ladder | Not in the first ship of same-tick echo + caret preservation |
+| A controls kit that owns drafts and revisions | Not first ship — a draft is app-db state you write yourself |
+| Whether `:on-input` or `:on-change` is the taught attribute | Both work; the runtime takes whichever runs last. Current screens use `:on-input` for text and `:on-change` for checkboxes |

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -1,16 +1,11 @@
 # Interop
 
-> **Draft ahead of the product artefact.** Spellings marked **[unfrozen]** stay
-> provisional until the API freeze. `defhost` is witnessed end-to-end by the bench
-> arm under `implementation/freehand/test/re_frame/bench/hicasso/` — one foreign
-> React component with its own state, effects, context read, and three invoker
-> styles on its callbacks. No `implementation/hicasso/` artefact ships yet. The
-> `[:>]` raw escape and the migration codemod are **not built**. Deep prop
-> conversion is deliberately not offered. The `defhost` `:ssr` policy is landed;
-> [Server-side rendering](10-server-side-rendering.md) owns the SSR story.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]**
+> may change. Behaviour matches the experimental arm under
+> `implementation/freehand/test/re_frame/bench/hicasso/`.
 
-You want a date picker from npm. In Reagent you write `[:> DatePicker {...}]` and
-move on. Hicasso asks you to write one line first:
+You want a date picker from npm. Declare it once, then use it anywhere a view is
+legal:
 
 ```clojure
 (ns app.hosts.date-picker
@@ -21,9 +16,6 @@ move on. Hicasso asks you to write one line first:
   {:callbacks {:on-change :event}})     ;; defhost is [unfrozen]
 ```
 
-Then use it anywhere a view is legal — including as another view's child, since
-children cross as ordinary hiccup and are lowered by whoever renders them:
-
 ```clojure
 (ns app.views
   (:require [re-frame.hicasso :as h :refer [defview sub]]
@@ -31,71 +23,55 @@ children cross as ordinary hiccup and are lowered by whoever renders them:
 
 (defview due-field [_]
   [date-picker {:selected  (sub [:task/due-date])
-                ;; react-datepicker calls onChange(date) — the date first, and
-                ;; no event at argument one. An intent vector refuses there;
-                ;; h/fn takes the library's own arguments, in order.
+                ;; react-datepicker calls onChange(date) — value first, no DOM
+                ;; event at argument one. An intent vector refuses there; h/fn
+                ;; takes the library's arguments in order.
                 :on-change (h/fn [date & _] [:task/set-due date])}])
 ```
 
-## Why a declaration
+Children cross as ordinary hiccup and lower where they render — including as
+another view's child.
 
-`defhost` is the door, and the only form taught. A raw escape exists as design for
-cases a static declaration cannot express, but it is secondary and **not built**
-yet — see [The escape](#the-escape--is-legal-unbuilt).
+## Why declare
 
-`[:> DatePicker {...}]` puts a raw JavaScript value inside your data tree. Three
-things break at that node, all of them quietly:
+Putting a raw JS component in the tree breaks three things at once:
 
-- **`.cljc` purity.** The namespace can no longer load on the JVM, so it can no
-  longer be tested headlessly.
-- **Structural testing.** The node holds an opaque JS object, so you can't assert
-  the tree with `=`.
-- **Tooling identity.** There is nothing for a tool to name — the crossing has no
-  identity, just a value.
+- **JVM / `.cljc`.** A JS require in a shared namespace means the ns no longer loads
+  on the JVM, so headless tests die with it.
+- **`=` tests.** The node holds an opaque JS object; structural equality stops
+  working at that point.
+- **Named crossing.** Tools and readers get an identity — a declaration — instead
+  of a bare value.
 
-`defhost` gives the crossing a name, keeps the JS require quarantined in one `.cljs`
-host namespace, and leaves the rest of your view tree pure data.
+`defhost` quarantines the require in one `.cljs` host namespace and leaves the rest
+of the view tree as data. Friction once; free at every use site. The Reagent
+`[:> …]` escape is secondary, **not built** yet, and covered briefly below.
 
-A declaration is friction once. It amortizes to zero over every use site. Today the
-conversion from Reagent is by hand; a codemod is planned and not built. It is a
-small hand: the expensive part of leaving Reagent was never `[:>]`, it was
-`r/atom`.
+## Defaults
 
-## The defaults
-
-`defhost` with no options gives you:
+`defhost` with no options:
 
 | Default | Behaviour |
 |---|---|
-| Props | shallow camelCase conversion — `:on-change` becomes `onChange` |
-| Children | hiccup children are converted to React elements |
+| Props | shallow camelCase — `:on-change` → `onChange` |
+| Children | hiccup → React elements |
 | Functions | pass through unconverted |
-| SSR | `:client-only` — the host region renders nothing server-side until the client has adopted the page. Declarable as the `:ssr` option: `:client-only` (the default), or `{:fallback <hiccup>}` for placeholder markup, with an unrecognised policy refused at mint (`:rf.error/hicasso-host-bad-ssr-policy`). [Server-side rendering](10-server-side-rendering.md) tells the story |
+| SSR | `:client-only` — nothing server-side until the client adopts. Override with `:ssr`: `:client-only`, or `{:fallback <hiccup>}` for placeholder markup. Bad policy → `:rf.error/hicasso-host-bad-ssr-policy` at mint. Full story: [Server-side rendering](10-server-side-rendering.md) |
 
-Policy overrides live on the declaration rather than at the call site, which is the
-whole point: one place decides how this component is crossed, and every use site
-inherits it. There are exactly two options today — `:callbacks`, a finite map
-from prop name to `:event`, `:handler` or `:render`, and the subject of the next
-section; and `:ssr`, the server policy in the table above. An option the door does
-not know is refused at mint rather than ignored
-(`:rf.error/hicasso-host-unknown-option`).
+Two options today: `:callbacks` (next section) and `:ssr`. An unknown option is
+refused at mint (`:rf.error/hicasso-host-unknown-option`), not ignored. Bad
+contracts, contracts on `:key`/`:ref`, duplicate prop spellings, and a component
+that resolved to `nil` (classic `:default` against a library with no default
+export) also fail at the declaration — where your stack points at the line you
+wrote.
 
-Everything a declaration can get wrong, it gets wrong *at the declaration*, where
-your stack trace points at the line you wrote: a contract that is not one of the
-three, a contract on `:key` or `:ref` (React's, not positions), two spellings of
-one prop declared twice, and a component that resolved to `nil` — the classic
-`:default` against a library that has no default export, which React would
-otherwise report from somewhere else entirely.
+**No deep conversion.** Nested option maps are not camelCased for you. Guessing
+which nested maps are options and which are data is a support trap; convert those
+maps yourself when the library wants camelCase inside them.
 
-Deep conversion — camelCasing keys *inside* a nested option map — is deliberately
-not offered at any level. Guessing which nested maps are options and which are data
-is the support burden the shallow default exists to delete; convert the map yourself
-when a library wants camelCase inside it.
+## Callbacks: `:event`, `:handler`, `:render`
 
-## Callbacks: `:event`, `:handler` and `:render`
-
-A declared slot in `:callbacks` carries a contract, never inferred from an `on*`
-spelling:
+A declared slot carries a contract — never inferred from an `on*` name:
 
 ```clojure
 (h/defhost picker Widget
@@ -104,194 +80,124 @@ spelling:
                :on-render-row :render}})
 ```
 
-**`:event`** is the door's version of an ordinary `:on-*` position — an intent
-vector, or an `h/fn` when you need to read what the library handed you. The proof
-pins the detail a native position doesn't have to: a foreign invoker calls with
-*its own* arguments, not a lone DOM event — `onPick(value, event)`,
-`onDraft(event)` — and **every argument the invoker passed reaches the `h/fn`
-body**, in the order the library sent them.
+**`:event`** — like a native `:on-*`: intent vector, or `h/fn` when you need the
+library's arguments. Foreign invokers pass *their* arguments (`onPick(value,
+event)`, `onDraft(event)`), and **every argument reaches the `h/fn` body** in
+library order.
 
-**`:handler`** crosses the function by identity rather than wrapping it: the
-library gets exactly the function you wrote — so a library that memoises on
-callback identity is not defeated — and whatever the library's own call returns
-goes back to *that caller*; Hicasso never sees the return and never dispatches
-from it. This is the shape for a library's imperative surface (`open()`,
-`scrollTo()`): `defhost` doesn't know what an arbitrary imperative call means, so
-`:handler` stays out of its way entirely.
+**`:handler`** — function by identity, no wrap. The library gets exactly the
+function you wrote (memoisation on callback identity still works), and the
+library's return goes back to that caller. Use this for imperative APIs
+(`open()`, `scrollTo()`): Hicasso does not invent meaning for those calls.
 
-**`:render`** is the third contract, for a library that calls you back *during its
-own render* — `renderRow`, `renderItem`, a render prop. The body must be pure: its
-return is what the library puts in its tree, and dispatching from inside it raises
-`:rf.error/hicasso-dispatch-in-render-position`, naming the position.
+**`:render`** — library calls you *during its own render* (`renderRow`,
+`renderItem`). The body must be pure: its return is what the library puts in its
+tree. Dispatching *while that call runs* raises
+`:rf.error/hicasso-dispatch-in-render-position`, naming the position. The row you
+build may still carry ordinary intents — `[:li {:on-click [:row/pick id]} title]`
+is fine; those fire later, on the user's click, under the frame of the boundary
+that supplied the callback.
 
-Read "from inside it" exactly. **The row you build may carry ordinary intents.** A
-`renderRow` that returns `[:li {:on-click [:row/pick id]} title]` is the whole
-point of a render prop, and that handler fires later, at the user's click, into
-the frame of the boundary that supplied the callback — the only frame that could
-own it, since the foreign component has none. What is forbidden is dispatching
-*while the call is running*, whether directly or by lowering a handler and firing
-it synchronously in the same body. The distinction is the law's own: pure while
-you are building the row, ordinary once you have handed it over.
+### The declaration wins
 
-### The declaration decides; the value never overrules it
+The contract governs **every** carrier at that slot, not only `h/fn`. An intent
+vector or key-map is accepted at `:event` and **refused** at `:handler` and
+`:render` with `:rf.error/hicasso-intent-at-a-non-event-contract`. An ordinary
+unmarked function crosses untouched at all three.
 
-The contract you declared governs **every** carrier at that position, not just the
-`h/fn`. An intent vector and a key-map are each a dispatch and nothing else, so
-they are accepted at `:event` — where dispatching is what the contract means — and
-**refused** at `:handler` and `:render` with
-`:rf.error/hicasso-intent-at-a-non-event-contract`. There is no reading of a bare
-vector that a `:handler` could honour, and a `:render` position that dispatched
-would be dispatching mid-render. If what happens at that slot is an event, declare
-it `:event`; otherwise write an `h/fn` that does the work. An ordinary unmarked
-function crosses untouched at all three.
+### Intent vectors are event-first
 
-### The vector spelling is event-first
+`::h/prevent`, `::h/value`, `::h/checked`, and key-map lookups all read the DOM
+event from **argument one**. Value-first invokers — `onPick(value, event)`,
+`onChange(date)` — have no event there, so you get
+`:rf.error/hicasso-intent-needs-the-event` (naming the position and what arrived)
+instead of `value.preventDefault is not a function`. **`h/fn` is the spelling for
+those slots.**
 
-`::h/prevent`, `::h/value`, `::h/checked` and a key-map's key lookup all read the
-DOM event, and they all read it from **argument one**. That is what every native
-position hands them, and what an event-first foreign contract (`onDraft(event)`)
-hands them too.
+An intent with neither a marker nor `::h/prevent` never touches its arguments, so
+`{:on-pick [:city/picked "paris"]}` is fine under any invoker shape.
 
-A value-first invoker — `onPick(value, event)`, or the date picker's
-`onChange(date)` — has no event at argument one, and nothing can guess which of a
-library's arguments is one. Hicasso says so rather than letting the engine say it:
-you get `:rf.error/hicasso-intent-needs-the-event`, naming the position and the
-argument that actually arrived, instead of `value.preventDefault is not a
-function`. **`h/fn` is the spelling for those positions** — it receives every
-argument the invoker passed, in order, which is exactly what the opening example
-does.
+## Providers
 
-Both halves are witnessed at a real crossing. The host-hatch suite drives
-`::h/value` through a widget's event-first `onChange` and the model updates; it
-then drives `::h/prevent`, `::h/value` and a key-map through the *same* widget's
-value-first `onPick` and gets the refusal instead, naming `:on-pick` and the
-string that actually arrived.
-
-An intent carrying neither a marker nor `::h/prevent` never touches its argument,
-so `{:on-pick [:city/picked "paris"]}` is correct under any invoker contract at
-all.
-
-## Providers cross the door too
-
-A provider an ecosystem library hands you is hosted like anything else — it's a
-component, not a special case:
+A library provider is just a component:
 
 ```clojure
 (h/defhost themed (.-Provider some-context))
 ```
 
-A consumer reading the same context below the crossing reads it correctly: the
-crossing is a real React element, so React's own context plumbing runs through
-the Hicasso tree exactly as it would through any other one.
+Consumers below the crossing read context correctly — the node is a real React
+element, so React's plumbing runs through.
 
-## When a boundary bails out, the host inside it does too
+## Memo and hosted components
 
-Every Hicasso boundary is a `React.memo` comparing its props by value, and that
-bail-out reaches a hosted component exactly as it reaches a native one:
+Every Hicasso boundary is a `React.memo` that compares props by value. That
+bail-out reaches a hosted component the same way it reaches a native one:
 
 ```clojure
 (defview chrome-page [_]
   [:div
    [:span.chrome (str (sub [:hatch/label]))]   ;; re-renders on every write
-   [hosted-row {:label "fixed"}]])             ;; value-equal props — bails out
+   [hosted-row {:label "fixed"}]])             ;; equal props → bail out
 ```
 
-A write that only moves `:hatch/label` re-renders `.chrome` and stops there.
-`hosted-row`'s boundary receives the same `{:label "fixed"}` it always does, the
-comparator holds, the boundary bails out, and the foreign component inside it is
-not re-rendered at all — not once, not with stale props, simply never re-entered.
-That is the memo working exactly as designed: nothing in `hosted-row`'s own props
-moved. It is also exactly the shape that sends someone hunting a bug in the
-third-party library they are hosting, when the library never got a render to be
-wrong in. If a host should react to a subscription, that subscription's value has
-to reach *its own* boundary's props — reading it one component further up and
-stopping there is indistinguishable, from the host's side, from the value never
-having changed.
+A write that only moves `:hatch/label` re-renders `.chrome` and stops.
+`hosted-row` never re-enters the foreign component. If a host should react to a
+subscription, that value has to reach **its own** props — reading one boundary up
+and stopping looks identical, from the host's side, to the value never changing.
 
-## The escape: `[:>]` is legal, unbuilt
+## The escape: `[:>]` (unbuilt)
 
-`[:> Component props & children]` is the explicitly secondary form — legal for
-the cases a static declaration cannot express. It stays **unbuilt**, so there is
-nothing to call today. When it lands, the design is that it lowers through the
-same foreign path with the same default conversions, `.cljs`-only at that node,
-with reduced structural identity — exactly the costs listed under
-[Why a declaration](#why-a-declaration), accepted knowingly.
+`[:> Component props & children]` is the secondary form for cases a static
+declaration cannot express. It is **not built** — there is nothing to call today.
+When it exists, it will use the same foreign path and accept the costs in
+[Why declare](#why-declare).
 
-Reach for it, once it exists, when a static declaration genuinely cannot express
-the case:
+Reach for it (once it exists) when the component is selected at runtime, is a
+`memo`/`lazy` value, arrives from a render prop, or is a one-off migration site.
+**Declare what you use twice.** First use, escape if faster; second use, `defhost`.
 
-- the component is **selected at runtime** from a map or a prop;
-- it is a `memo` or `lazy` value;
-- it arrives from a **render prop**;
-- it is a **one-off migration site** you have not got to yet.
+**Bare-head auto-hosting stays illegal.** `[DatePicker {…}]` with a raw JS
+component in head position is not a shortcut. One sentinel when the escape ships —
+not two ways to smuggle JS into the tree.
 
-**The rule, once it exists, is: declare what you use twice.** First use, take the
-escape if it's faster. Second use, write the `defhost`. That is not a moral
-position; it is where the amortization crosses over.
-
-One thing stays rejected: **bare-head auto-hosting**. Putting a raw JS component in
-head position — `[DatePicker {...}]` — and having the runtime identity-key it is
-*not* legal. One sentinel, not two shortcuts. If `[:>]` and a bare head both worked,
-every codebase would have both, and the reader would have to know which node is
-which by looking somewhere else.
-
-## Migrating from Reagent
-
-A codemod for the mechanical part — collect the `[:> X …]` sites, emit the
-`defhost` block, rewrite the call sites — is planned and **not built**. Nothing
-names a tool or an invocation. By hand it is the same three moves, and it goes a
-namespace at a time, so a large app never needs one big commit.
+A hand migration from Reagent is three moves per namespace: collect `[:> X …]`,
+emit `defhost`, rewrite call sites. A codemod is planned and not built.
 
 ## Troubleshooting
 
-This table names mechanisms; the minted ids on this surface —
-`:rf.error/hicasso-ref-vector-reserved`,
-`:rf.error/hicasso-intent-at-a-non-event-contract`,
-`:rf.error/hicasso-intent-needs-the-event`,
-`:rf.error/hicasso-host-bad-ssr-policy` and
-`:rf.error/hicasso-host-unknown-option` — are covered above and under Advanced.
-
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| Prop arrives as `on-change` and the library ignores it | Nested keys expected in camelCase; deep conversion is deliberately not offered | Convert the nested map yourself before it crosses |
-| An intent vector or key-map at a declared slot raises `:rf.error/hicasso-intent-at-a-non-event-contract` | The slot is declared `:handler` or `:render`, and neither contract dispatches — the declaration governs the carrier, so the value cannot overrule it | Declare the slot `:event` if what happens there is an event, or write an `h/fn` that does the `:handler`/`:render` work |
-| `:rf.error/hicasso-intent-needs-the-event`, naming a slot whose library hands a value first | The vector spelling reads the DOM event from argument one, and this invoker put something else there | Write an `h/fn` at that slot — it gets every argument the library passed, in order |
-| A namespace stops loading on the JVM | A JS require reached a `.cljc` file | Quarantine the require in a `.cljs` host namespace |
-| Structural test can't match a node | A `[:>]` node, once the escape is built — reduced structural identity, by design | Declare it with `defhost`, or assert around it |
-| Provider from a library needs to wrap the tree | Hosted like anything else | `defhost` the provider; it is a component |
-| A hosted component doesn't update when the page clearly changed | The boundary above it bailed out on value-equal props — it was never re-entered, so the host was never asked to render | Trace the value to the host's *own* boundary's props, not a parent's |
-| The SDK mounts twice in dev and you end with two live handles | StrictMode double-invoke, plus a handle stored outside the attach's closure — so the second attach overwrote the first instead of replacing it | One attach, one handle, one cleanup, all in one closure; return the cleanup from the ref |
-| The SDK is destroyed and rebuilt on every unrelated render | The ref function has a fresh identity each render, so React detaches and re-attaches | `useCallback` with `#js []` — a stable ref identity |
-| A `nil`-node branch in a ref never runs | The callback returns a cleanup, so React calls that instead of re-invoking with `nil` | Pick one contract; with React 19, pick the return |
-| A listener or observer survives unmount | The cleanup tears down less than the attach built | The cleanup returns the world to the state the attach found it in — nothing checks this for you |
+| Prop arrives as `on-change` and the library ignores it | Nested keys expected camelCase; deep conversion is not offered | Convert the nested map yourself before it crosses |
+| `:rf.error/hicasso-intent-at-a-non-event-contract` | Slot is `:handler` or `:render`; neither dispatches | Declare `:event`, or write an `h/fn` for the real work |
+| `:rf.error/hicasso-intent-needs-the-event` | Vector spelling needs the DOM event at arg one; library put something else there | Use `h/fn` — full argument list, library order |
+| Namespace won't load on the JVM | A JS require reached a `.cljc` file | Quarantine the require in a `.cljs` host ns |
+| Structural test can't match a node | A `[:>]` node (once built) has reduced structural identity | Prefer `defhost`, or assert around the node |
+| Hosted component doesn't update when the page did | Boundary above bailed out on equal props — host never re-entered | Put the changing value on the host's *own* props |
+| SDK mounts twice in dev | StrictMode double-invoke plus a handle stored outside the attach closure | One attach, one handle, one cleanup, all in one closure |
+| SDK rebuilt on every unrelated render | Ref function has a fresh identity each render | `useCallback` with `#js []` |
+| `nil` branch in a ref never runs | Callback returns a cleanup; React calls that instead of re-invoking with `nil` | Pick one contract (React 19: prefer the return) |
+| Listener/observer survives unmount | Cleanup tears down less than attach built | Cleanup restores the world attach found |
 
-## When not to reach for the door
+## When not to host
 
-If the library is a thin wrapper over DOM you could write yourself in twenty lines
-of hiccup, write the twenty lines. Every hosted component is a node your tools can
-see less of and your tests can assert less about. Most applications never need the
-door, and the ones that do need it for two or three genuinely hard widgets.
+If the library is a thin wrapper over DOM you can write in twenty lines of hiccup,
+write the twenty lines. A hosted component is a node your tools see less of and
+your tests assert less about. Most apps need this rarely — usually two or three
+genuinely hard widgets.
 
 ## Advanced
 
 ### Imperative SDKs
 
-A mapping SDK, a chart library that wants a DOM node, anything that hands you a
-handle and expects you to feed it — that is **not** an interop-door problem. It is
-ordinary host-edge React: a callback ref, written in a `.cljs` namespace at the
-edge of your app.
+A map SDK, a chart that wants a DOM node, anything that hands you a handle — that
+is ordinary host-edge React, not a second interop API. Write a callback ref in a
+`.cljs` namespace at the edge of the app.
 
-There is no Hicasso concept for this, deliberately — no "behaviors" tier and no
-second ownership model. The v0 answer is React, used honestly, at the edge.
-
-Used honestly means **the attach and the teardown are written as one thing.** An SDK
-that mounts and never tears down is the most common bug at this edge, and it is not
-subtle — you get two maps, two resize observers, and a leak per remount. React 19's
-callback ref makes the pairing structural: **whatever the ref function returns is its
-cleanup**, so you cannot write the attach without deciding what undoes it.
+**Attach and teardown are one thing.** React 19's callback ref makes the pairing
+structural: whatever the ref function returns is its cleanup.
 
 ```clojure
-;; Sketch only — host-edge React inside a defview body, in a .cljs namespace.
+;; Sketch — host-edge React inside a defview body, in a .cljs namespace.
 (ns app.hosts.map-panel
   (:require [re-frame.hicasso :as h :refer [defview]]
             ["react" :as react]
@@ -300,66 +206,42 @@ cleanup**, so you cannot write the attach without deciding what undoes it.
 (defview map-panel [_]
   (let [attach (react/useCallback
                  (fn [node]
-                   ;; One attach, one handle, one teardown. The handle lives in
-                   ;; this closure and nowhere else.
                    (let [handle (sdk/mount node)
                          done?  (volatile! false)]
                      (fn cleanup []
                        (when-not @done?
                          (vreset! done? true)
                          (sdk/destroy handle)))))
-                 #js [])]                    ;; stable identity — see below
+                 #js [])]
     [:div.map {:ref attach}]))
 ```
 
-Four properties, and dropping any one of them breaks something specific.
+Four properties that each break something specific if dropped:
 
-**The handle is per-attach, not per-namespace.** It is created by the attach and
-captured by the cleanup that attach returned. Two attaches produce two handles and
-two cleanups, correctly paired. The moment you hoist that handle into a `defonce`
-atom or a module-level var, a second attach overwrites the first and the first
-instance leaks — which is the actual mechanism behind every "it mounted twice" report
-at this edge.
+1. **Handle is per-attach**, captured by the cleanup that attach returned — not a
+   module-level `defonce`. A hoisted handle lets the second attach overwrite the
+   first and leak it (the usual "it mounted twice" mechanism).
+2. **Teardown is idempotent.** The `done?` latch is cheap insurance against SDK
+   `destroy` methods that throw on a dead handle.
+3. **Cleanup return and `nil`-node handling are exclusive.** If the ref returns a
+   function, React calls that on detach *instead of* invoking the callback with
+   `nil`. Write both and the `nil` branch is dead.
+4. **`useCallback` with `#js []` keeps the ref identity stable.** A fresh function
+   every render detaches and re-attaches every time, so the SDK rebuilds on every
+   keystroke elsewhere in the tree.
 
-**The teardown is idempotent.** The `done?` latch makes a second call a no-op. React
-calls each cleanup exactly once, so strictly this is belt and braces — but SDK
-`destroy` methods that throw on a dead handle are common enough that the three lines
-are worth it, and the alternative is finding out in production. This is the same
-idempotence the root teardown has ([Getting started](01-getting-started.md)); the
-discipline does not change because the object is foreign.
+Under StrictMode (dev), React does attach → cleanup → attach. The shape above
+survives because the first handle dies with the cleanup that created it. A handle
+stored outside the closure, or a cleanup that leaves a listener on `window`, is
+what actually doubles.
 
-**Returning a cleanup and handling a `nil` node are exclusive.** When a ref callback
-returns a function, React calls that function on detach *instead of* invoking the
-callback again with `nil`. Write both and you will have written a `nil` branch that
-never runs — a dead path that reads like a teardown and is not one. Pick the return.
+Hooks in a body take you outside headless testing scope ([Testing](08-testing.md))
+and put React's hook rules on you. Both are fine; both are yours.
 
-**`useCallback` with an empty dependency array is what makes any of this
-deterministic.** A ref function with a fresh identity every render is detached and
-re-attached on every render, so the SDK is destroyed and rebuilt on every keystroke
-elsewhere in the tree. The stable identity is the difference between one mount and
-one mount per render.
+#### If you are not on React 19
 
-#### Under StrictMode
-
-StrictMode double-invokes the mount in development: attach, cleanup, attach. The
-shape above survives it, and the reason is the first property, not the second. The
-first attach's handle is destroyed by the cleanup that attach returned, and the
-second attach builds a fresh one. You end with exactly one live handle, which is what
-you would have had in production.
-
-What does *not* survive is a handle stored outside the closure, or a cleanup that
-tears down less than the attach built — a listener left on `window`, an observer left
-connected. Then the second attach genuinely doubles, and the symptom is two of
-everything in dev and one leak per remount in production. **The rule is that the
-cleanup returns the world to the state the attach found it in**; there is no runtime
-that can check that for you.
-
-#### If the runtime does not target React 19
-
-The cleanup-returning ref is a React 19 contract. Hicasso does not pin a React
-version in the product surface (see **Not settled yet**), so the older shape is
-worth knowing: the callback is invoked with the node on attach and with `nil` on
-detach, and the handle needs a home that outlives one invocation.
+Cleanup-returning refs are a React 19 contract. Older shape: callback with the node
+on attach and `nil` on detach, handle in a ref that outlives one invocation:
 
 ```clojure
 (let [handle (react/useRef nil)
@@ -368,62 +250,40 @@ detach, and the handle needs a home that outlives one invocation.
                  (if node
                    (set! (.-current handle) (sdk/mount node))
                    (when-let [h (.-current handle)]
-                     (set! (.-current handle) nil)   ;; clear first — idempotent
+                     (set! (.-current handle) nil)
                      (sdk/destroy h))))
                #js [])]
   [:div.map {:ref attach}])
 ```
 
-Same discipline, one more moving part. That the handle now needs a home outside the
-closure is exactly what the React 19 contract removes, which is why it is the shape
-taught above.
-
-Note the two consequences of putting hooks in a body at all: it is outside the
-headless testing scope ([Testing](08-testing.md)), and you have taken on React's hook
-rules yourself. Both are fine. Both are on you.
-
 ### The reserved vector, and the gap it does not close
-
-One thing about `:ref` is worth knowing before you write your first one, because it
-changes what you should put in the closure.
 
 **A vector at `:ref` is refused.** `{:ref [::autosize {:max-rows 8}]}` raises
 `:rf.error/hicasso-ref-vector-reserved`. That value-space is reserved for a later
-data spelling of exactly the pattern above — a registered id and a config map,
-with the imperative code in a registry instead of in your view — and v0 claims it
-now so that landing it later is not a breaking change. Today, write the function.
+data spelling (registered id + config); claiming it now keeps the later landing
+non-breaking. Today, write the function. The refusal is on the **slot**, so
+`{"ref" […]}` and `{:x/ref […]}` are refused too. An unrefused array would have
+been worse: React ignores an array at `ref` in silence.
 
-The refusal is on the ref **slot**, so it holds however you spell the key —
-`{"ref" […]}` and `{:x/ref […]}` are refused too, and name the spelling you wrote.
-An unrefused one would have been the worst of both: React ignores an array at
-`ref`, in silence, so you would be debugging a ref that never fires.
+**Limit that later spelling cannot erase.** A ref callback fires on **attach** and
+**detach** only — not on config change. Passing a different callback is the only
+way to re-invoke it, and that detaches and re-attaches the node (rebuilds your
+map). So:
 
-**And the honest limit on what that later spelling could ever be.** A React ref
-callback fires on **attach** and on **detach**. It does **not** fire on **config
-change**. There is no third call, and no amount of design gets one: passing a
-*different* callback is the only way to make React invoke it again, and doing that
-detaches and re-attaches the node — which destroys and rebuilds your map instance,
-which is precisely the thing you were trying to avoid.
+- attach and detach only, in one closure;
+- config fixed for the connection's life;
+- steady-state change through an ordinary event / effect
+  (`{:map/fly-to {:instance id :center [lat lng]}}`).
 
-So the shape to write, now and later, is:
-
-- **attach and detach only**, in one closure, as above;
-- **config immutable for the connection's life** — whatever the SDK needs at
-  `mount` time is decided once;
-- **steady-state change routed through an effect**, dispatched as an ordinary
-  event: `{:map/fly-to {:instance id :center [lat lng]}}`. That is already data,
-  it is already in the event log, and it is already testable.
-
-If you find yourself wanting the ref to notice that a prop changed, that is the
-signal to move the change onto the effect path. Nothing in the reserved vector
-will rescue it later.
+If you want the ref to "notice" a prop change, move the change onto the effect
+path. Nothing in the reserved vector will rescue that later.
 
 ## Not settled yet
 
 | Question | Status |
 |---|---|
-| Whether conversion defaults ever become declarable on `defhost` | **Open.** `:callbacks` and `:ssr` are the two options today; prop-conversion knobs are unstated |
-| The migration codemod | **Planned, unbuilt.** Nothing names a tool or an invocation |
-| When the reserved `{:ref [id config]}` spelling lands, and what registers an id | **Reserved, not designed.** The refusal and the value-space exist; the registry, timings and commands roster are out of v0 |
-| Which React version the runtime targets | **Not pinned by the product surface.** The cleanup-returning callback ref taught above is a React 19 contract; this repo currently pins React 19.2, which is a fact about today's tree. If v0 lands on 18, the fallback shape above is the one to teach |
-| Embedding Hicasso *inside* a React-primary app | Named as a use case; no surface designed |
+| Declarable conversion defaults on `defhost` | Open — `:callbacks` and `:ssr` are the two options today |
+| Migration codemod | Planned, unbuilt |
+| When `{:ref [id config]}` lands, and what registers an id | Reserved, not designed |
+| Which React version the product pins | Not pinned by the product; cleanup-returning refs need React 19; this repo currently pins 19.2 |
+| Embedding Hicasso inside a React-primary app | Named as a use case; no API designed |

--- a/docs/design/hicasso/draft-guide/06-theming.md
+++ b/docs/design/hicasso/draft-guide/06-theming.md
@@ -1,27 +1,16 @@
 # Theming
 
-> **Draft ahead of the product artefact.** Spellings marked **[unfrozen]** stay
-> provisional until the API freeze. Theming is largely unexercised by the bench
-> arm, and this page still carries one genuine hole — how the app-db theme
-> choice reaches a DOM attribute — named below rather than papered over.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Behaviour matches the experimental arm under `implementation/freehand/test/re_frame/bench/hicasso/`.
 
-Every React component library reaches for context to theme itself. Hicasso doesn't
-ship a context API at all, and its theming uses none.
+Every React component library reaches for context to theme itself. Hicasso doesn't ship a context API, and theming doesn't need one.
 
-This is not asceticism. Context is a side channel: it is invisible to the data tree,
-which kills headless testing and makes SSR harder; it costs a hook per consumer,
-against a ≤2 hook budget already fully spent; it re-renders every consumer when it
-changes; and it is a second dependency-injection channel next to props. The platform
-cascade and the data tree each do the job better on every axis that matters. Real
-apps already live on a global theme plus per-instance overrides — that pattern
-never needed subtree context in the first place.
+Context is a side channel: invisible to the data tree (so headless tests can't see it), one hook per consumer (hooks already spend their budget elsewhere), a full re-render of every consumer on change, and a second dependency-injection channel next to props. CSS cascade and the data tree each do the job better. Real apps already live on a global theme plus per-instance overrides — that pattern never needed subtree context.
 
-Three layers do the work.
+Three layers. Tokens in CSS, part maps as data, the *choice* of theme in app-db.
 
 ## Layer 1 — design tokens as CSS custom properties
 
-The cascade *is* a context system. Nearest ancestor wins, it is subtree-scoped, and
-it is platform-native.
+The cascade already is a context system. Nearest ancestor wins, it is subtree-scoped, and it is platform-native.
 
 ```css
 :root {
@@ -41,25 +30,15 @@ it is platform-native.
 }
 ```
 
-Nothing about the `--app-*` prefix is Hicasso's; name your custom properties
-whatever your stylesheet already does.
+Nothing about the `--app-*` prefix is Hicasso's; name your custom properties whatever your stylesheet already does.
 
-Switching theme is one attribute flip on one element, and **restyling from there
-costs zero React work** — no re-render, no hook, no diff. The cascade recomputes and
-your component tree is never consulted, which is exactly right, because nothing in it
-needed to be.
+Switching theme is one attribute flip on one element. **After the attribute changes, restyling costs zero React work** — no re-render, no hook, no diff. The cascade recomputes and the component tree is never consulted.
 
-Read that claim precisely, because layer 3 depends on where its edge is. "One
-attribute flip, zero React work" describes what happens *after* the attribute
-changes. It says nothing about what flips it. See
-[Layer 3 and the DOM](#layer-3-and-the-dom) — the one place this page has to report a
-hole rather than teach around it.
+That claim is about *after* the flip. What puts the attribute on the DOM is layer 3's job — see [Bridging the choice to the DOM](#bridging-the-choice-to-the-dom).
 
 ## Layer 2 — parts as data addresses
 
-A control emits keyword-tagged **parts**: named addresses for its internal pieces.
-A theme is a map from part address to classes and attributes, and applying it is a
-pure tree-to-tree transform.
+A control emits keyword-tagged **parts**: named addresses for its internal pieces. A theme is a map from part address to classes and attributes. Applying it is a pure tree-to-tree transform.
 
 ```clojure
 ;; A theme: part address → classes/attrs.
@@ -69,23 +48,15 @@ pure tree-to-tree transform.
    [:typeahead :menu]  {:class "ta__menu" :role "listbox"}})
 ```
 
-Merge order is fixed: **`base < app-theme < instance-props`**. The control's own base
-wins least, the app's theme overrides it, and props at a specific use site override
-both.
+Merge order is fixed: **`base < app-theme < instance-props`**. The control's own base wins least, the app's theme overrides it, and props at a specific use site override both.
 
-The property that makes this worth having: because it is a pure function from tree
-to tree, you can unit-test a theme with `=`. No registry, no multimethods, no
-runtime resolution order to reason about.
+Because the transform is pure, you can unit-test a theme with `=`. No registry, no multimethods, no runtime resolution order.
 
-The spellings for declaring a part in a control and installing a theme in an app are
-not settled. See **Not settled yet** — this layer is the least specified of the
-three.
+How a control *declares* a part, and how an app *installs* a theme, are not settled yet — see **Not settled yet**. The merge order and the pure-function shape are fixed.
 
 ## Layer 3 — app-db for the choice
 
-Which theme is selected is application state like any other: read it with a
-subscription, write it with an event, and get frame isolation, time travel, and
-Xray visibility for free.
+Which theme is selected is application state like any other: read it with a subscription, write it with an event. Frame isolation, time travel, and Xray visibility come free.
 
 ```clojure
 (rf/reg-sub :theme/current
@@ -95,26 +66,17 @@ Xray visibility for free.
   (fn [{:keys [db]} [_ theme]] {:db (assoc db :theme/current theme)}))
 ```
 
-App-db holds the *choice*. It does not hold the tokens, and it does not hold the
-part maps.
+App-db holds the *choice*. It does not hold the tokens, and it does not hold the part maps.
 
-## Layer 3 and the DOM
+## Bridging the choice to the DOM
 
-Here is the part that is not joined up, and the reason this section exists rather
-than a paragraph of confident prose.
+The event above moves a keyword into app-db. Layer 1's cascade keys off a `data-theme` attribute on a DOM element. Something has to join them.
 
-**That event is a no-op as far as the browser is concerned.** It moves a keyword into
-app-db. Layer 1's cascade keys off a `data-theme` attribute on a DOM element. Nothing
-in the product surface says how the first becomes the second — the choice lives in
-app-db, a theme switch is one attribute flip with zero React work *after* the flip,
-and the line between them is unwritten. A guide that skipped the gap would be
-telling you to write an event that visibly does nothing.
+Two practical options. Pick one for your app; neither needs a new Hicasso API.
 
-Two bridges close it. Neither needs a new API, and neither is the taught one yet.
+### Option A — a scope view reads the choice
 
-### Bridge A — a scope view reads the choice
-
-The obvious one: one view reads `:theme/current` and puts it on its own element.
+One view reads `:theme/current` and puts it on its own element:
 
 ```clojure
 (defview theme-scope [{:keys [children]}]
@@ -125,32 +87,17 @@ The obvious one: one view reads `:theme/current` and puts it on its own element.
 [theme-scope {} [app {}]]
 ```
 
-`children` arrives as a realized *vector* of hiccup forms, which is why it is
-spliced with `into` rather than dropped in as one child —
-[Views and reads](02-views-and-reads.md#the-component-abi) has the rule.
+`children` arrives as a realized *vector* of hiccup forms, which is why it is spliced with `into` rather than dropped in as one child — [Views and reads](02-views-and-reads.md#the-component-abi) has the rule.
 
-**Its true cost.** The boundary that reads the theme re-renders on every switch —
-that much is certain, and it is one boundary. What happens below it turns on the
-[default value-equality bail-out](02-views-and-reads.md#boundaries-memoize-by-default)
-rather than on how `theme-scope` gets its content. `app` is a boundary either way —
-handed down as `children` or minted directly inside `theme-scope`'s own body — and
-its props are unaffected by the theme, so they compare `=` at every re-render and
-its own memo wrapper bails regardless of which style you write. The way to lose the
-bail-out is to call `app` as a plain function instead of writing `[app {}]`. A plain
-call has no boundary of its own to hold a memo wrapper, so it re-runs with
-`theme-scope` every time — independent of which bridge you chose.
+**Tradeoff.** The boundary that reads the theme re-renders on every switch — one boundary, known cost. What happens below it depends on the [default value-equality bail-out](02-views-and-reads.md#boundaries-memoize-by-default). `app` is a boundary either way (handed down as `children` or minted inside `theme-scope`), and its props are unaffected by the theme, so they compare `=` and its memo wrapper bails. Lose that only by calling `app` as a plain function instead of writing `[app {}]` — a plain call has no boundary of its own, so it re-runs with `theme-scope` every time.
 
-Element identity does not enter into it, because there is none to preserve.
-Children cross a boundary as hiccup data, not as React elements, so `theme-scope`
-mints a fresh element for `app` on every render whichever style you write. The
-skip is therefore always the comparator's `=`, never a referential short-circuit
-ahead of it — and `=` on an unchanged props map is cheap. What matters is only
-that `app` stays a boundary.
+Element identity does not help here: children cross a boundary as hiccup data, not as React elements, so `theme-scope` mints a fresh element for `app` on every render. The skip is always the comparator's `=`, never a referential short-circuit — and `=` on an unchanged props map is cheap. Keep `app` a boundary and the rest of the tree stays quiet.
 
-### Bridge B — an effect writes the attribute
+**Wins.** The DOM is derived from state. Rewind app-db in Xray and the attribute follows. Tests and restored snapshots stay consistent.
 
-The other one: nothing reads the theme at all. The event that records the choice also
-returns an effect, and the effect does the flip.
+### Option B — an effect writes the attribute
+
+Nothing reads the theme in a view. The event that records the choice also returns an effect, and the effect does the flip:
 
 ```clojure
 (rf/reg-fx :theme/apply!
@@ -159,107 +106,55 @@ returns an effect, and the effect does the flip.
 
 (rf/reg-event :theme/choose
   (fn [{:keys [db]} [_ theme]]
-    {:db          (assoc db :theme/current theme)
+    {:db           (assoc db :theme/current theme)
      :theme/apply! theme}))
 ```
 
-**Its true cost.** Zero React work, literally rather than approximately: no
-subscription, no boundary, no render. The "one attribute flip, zero React work"
-claim is exactly true under this bridge.
+**Tradeoff.** Zero React work, literally: no subscription, no boundary, no render. The "one attribute flip, zero React work" claim is exact under this option. What you give up:
 
-**What you pay for it.** Three things, and they are real:
+- **The DOM is no longer derived from state.** Rewind app-db in Xray and the attribute does not follow — no event ran. Time travel, a test fixture, or a restored snapshot can leave the document showing the old theme while app-db says otherwise.
+- **Boot needs its own hand.** Apply the initial theme with an initial event that carries the same effect, or the first paint is unthemed.
+- **It is not frame-isolated.** `document.documentElement` is one element; two frames on one page share it. Targeting each root's own node would need the effect to reach that node, and nothing in the product says an effect can today.
 
-- **The DOM is no longer derived from state.** Rewind app-db in Xray and the
-  attribute does not follow, because no event ran. Any path that replaces app-db
-  without going through `:theme/choose` — time travel, a test fixture, a restored
-  snapshot — leaves the document showing the old theme while app-db says otherwise.
-- **Boot needs its own hand.** The initial theme is applied by an initial event that
-  carries the same effect, or the first paint is unthemed.
-- **It is not frame-isolated.** `document.documentElement` is one element and two
-  frames on one page share it, which contradicts the "frame isolation for free" that
-  layer 3 otherwise gets. Targeting each root's own node instead would need the
-  effect to reach that node, and nothing in the product surface says an effect can.
+### Which one?
 
-### Pricing the bridges
-
-**Which bridge is the taught one is not settled.** Naming one here would be
-designing the missing half rather than reporting it. The shape of the choice is
-clear enough: bridge A keeps the DOM derived from state at the cost of the one
-reading boundary (the default bail-out covers the rest, per
-[Bridge A](#bridge-a--a-scope-view-reads-the-choice) above); bridge B has no render
-cost and gives up the derivation. It is the ordinary trade between rendering a fact
-and imperatively asserting it.
-
-What would settle it for the reader in practice: whether bridge A's cost holds at
-one boundary under multi-frame load, and whether the theme attribute is per-root or
-per-document. Both are open; neither is answered by picking a bridge in this guide.
+Ordinary trade: render a fact (A) vs assert it imperatively (B). A keeps derivation at the cost of one reading boundary; B has no render cost and gives up derivation. Neither is the taught default yet — whether A's cost holds at one boundary under multi-frame load, and whether the theme attribute is per-root or per-document, are still open. Until those settle, pick the tradeoff that matches your app.
 
 ## The two laws
 
-Layers 1 and 2 would be a footgun without these.
+### (a) Owned literals win the merge
 
-### (a) The owned-literal merge law
+**`:key`, `:ref`, controlled `:value` and `:checked`, and owned event handlers cannot be overridden by a theme or by parts.**
 
-**`:key`, `:ref`, controlled `:value` and `:checked`, and owned event handlers are
-unoverridable by a theme or by parts.**
+A theme can style a field. It cannot rewrite the field's controlled contract. Without this rule, a stylesheet-shaped map could clobber the `:value` of a controlled input — and you would debug that as an input bug for a day.
 
-A theme can style a field. It can never rewrite the field's controlled contract.
-Without this law, a stylesheet-shaped piece of data could reach in and clobber the
-`:value` of a controlled input — and you would debug that as an input bug for a day
-before you thought to look at the theme.
+This is not theming-specific. There is one attribute merge, spelled `:&`, and the literal keys written in the map always win — whether what arrives is a theme's part attributes, a caller's forwarded remainder, or anything else. A control that emits parts and a control that forwards props share the same rule. See [Controlled inputs](04-controlled-inputs.md#forwarding-attributes-).
 
-**The law is not theming-specific.** There is one attribute merge, spelled `:&`, and
-the literal keys written in the map always win over it — whether what arrives is a
-theme's part attributes, a caller's forwarded remainder, or anything else. So a
-control that emits parts and a control that forwards props are the same code,
-defended by the same rule, and there is no second merge form to choose between. See
-[Controlled inputs](04-controlled-inputs.md#forwarding-attributes-onto-a-controlled-input).
+### (b) Switchable values live in CSS variables
 
-### (b) The static-map law
+**Anything that changes at runtime lives in CSS variables. Part-to-class maps are boot-static per app. Structural replacement goes through children and slots, never through parts.**
 
-**Anything runtime-switchable lives in CSS variables. Part-to-class maps are
-boot-static per app. Structural replacement goes through children and slots, never
-through parts.**
+- Light/dark, density, brand — CSS variables, flipped by the attribute in layer 1.
+- A part-to-class map is fixed at boot. Changing one is an app rebuild, **by design** — that is the price of "theme switch is zero React work" for the token layer.
+- A different *structure* (custom menu row, replaced icon) is a child or a slot. Parts address the pieces a control renders; they do not replace them.
 
-The three halves of that, spelled out:
-
-- If it changes while the app runs — light and dark, density, brand — it is a CSS
-  variable.
-- A part-to-class map is fixed at boot. Changing one is an app rebuild, **by
-  design**. The "theme switch is zero React work" claim holds for the token layer —
-  for the restyle, and for the flip itself only under bridge B — and this is the
-  price of it.
-- If you want a different *structure* — a custom menu row, a replaced icon — that is
-  a child or a slot. Parts address the pieces a control renders; they do not replace
-  them.
-
-Break (b) and parts become a second, worse rendering system driven by data at
-runtime. That is the failure mode the law exists to prevent.
+Break (b) and parts become a second, worse rendering system driven by data at runtime. That is the failure mode the law exists to prevent.
 
 ## React context is still there
 
-Hicasso bans a *Hicasso* context API and context-based *theming*. It does not ban
-React.
+Hicasso has no context API of its own and does not theme through context. It does not ban React.
 
-The substrate keeps exactly one internal context — frame identity — and ordinary
-React context remains available to an advanced author at the host-edge escape: a
-compound-component contract you are implementing, or a provider an ecosystem library
-demands. Foreign providers come in through [`defhost`](05-interop.md) like any other
-component.
+The substrate keeps exactly one internal context — frame identity — and ordinary React context remains available at the host edge: a compound-component contract you are implementing, or a provider an ecosystem library demands. Foreign providers come in through [`defhost`](05-interop.md) like any other component.
 
-Using it means taking on React's rules, a hook per consumer, and a node your
-structural tests can see less of. Which is the honest trade, stated once, rather
-than a mechanism the guide pretends doesn't exist.
+Using it means taking on React's rules, a hook per consumer, and a node your structural tests can see less of. Honest trade, stated once.
 
 ## Troubleshooting
 
-This table names mechanisms rather than error ids.
-
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| The theme keyword changes in app-db and nothing on screen changes | No bridge is wired — app-db holds the choice, and the cascade keys off a DOM attribute | Wire one of the two bridges above; the event alone does nothing to the document |
-| Theme switch re-renders the whole app | Bridge A, with the themed content spliced in as a plain call rather than a `[boundary …]` vector — a plain call has no boundary of its own for the default bail-out to attach to | Put the content behind a boundary (children or a direct `[app {}]`, either works), or use bridge B |
-| A time-travel rewind shows the old theme | Bridge B — the attribute was asserted by an effect, so it is not derived from the state you rewound | Expected under bridge B; it is the price named above |
+| The theme keyword changes in app-db and nothing on screen changes | No bridge is wired — app-db holds the choice; the cascade keys off a DOM attribute | Wire option A or B above; the event alone does nothing to the document |
+| Theme switch re-renders the whole app | Option A, with the themed content spliced in as a plain call rather than a `[boundary …]` vector | Put the content behind a boundary (children or a direct `[app {}]`), or use option B |
+| A time-travel rewind shows the old theme | Option B — the attribute was asserted by an effect, so it is not derived from the state you rewound | Expected under B; it is the price named above |
 | A controlled input's value gets clobbered by a theme | Should be impossible — law (a) | A runtime bug, not a usage error |
 | A part override doesn't take effect | Merge order: instance props beat app theme beat base | Check which layer you set it in |
 | Theme change needs a rebuild | Expected, if you changed a part-to-class map — law (b) | Move the switchable part into a CSS variable |
@@ -267,22 +162,18 @@ This table names mechanisms rather than error ids.
 
 ## When not to theme
 
-If you have one application and one look, skip layer 2 entirely. Parts are for
-**component-library authorship** — the case where someone else's app consumes your
-control and needs to restyle its internals without forking it. An app styling its
-own components has CSS, and CSS is enough.
+If you have one application and one look, skip layer 2 entirely. Parts are for **component-library authorship** — someone else's app consumes your control and needs to restyle its internals without forking it. An app styling its own components has CSS, and CSS is enough.
 
-Reaching for parts inside a single app buys you an indirection layer and a merge
-order to remember, in exchange for a flexibility nobody is going to use.
+Reaching for parts inside a single app buys you an indirection layer and a merge order to remember, in exchange for flexibility nobody will use.
 
 ## Not settled yet
 
 | Question | Status |
 |---|---|
-| **How the app-db choice reaches the `data-theme` scope** | **Unresolved — the largest hole on this page.** The choice lives in app-db; the switch is one attribute flip after it lands. [Layer 3 and the DOM](#layer-3-and-the-dom) names both candidate bridges and prices them; picking one is still open |
-| Whether the theme attribute is per-root or per-document | **Not addressed.** Layer 3 promises frame isolation; a document-level attribute does not have it |
-| How a control declares a part | **Not addressed.** "Controls emit keyword-tagged parts" is the whole of the claim; the attribute or macro that does it is unnamed |
-| How an app installs a theme | **Not addressed.** The merge order `base < app-theme < instance-props` is fixed; the mechanism that supplies the app-theme layer is not. Since there is no context, it is presumably passed or registered — which is unstated |
+| How the app-db choice reaches the `data-theme` scope | Open. Both bridges above work; neither is the taught default yet |
+| Whether the theme attribute is per-root or per-document | Open. Layer 3 promises frame isolation; a document-level attribute does not have it |
+| How a control declares a part | Open. "Controls emit keyword-tagged parts" is the claim; the attribute or macro is unnamed |
+| How an app installs a theme | Open. Merge order is fixed; the mechanism that supplies the app-theme layer is not |
 | The part-address shape | This guide writes `[:typeahead :root]` by analogy; the actual shape is unstated |
-| Where the boot-static part map lives | Implied by law (b) to be fixed at build; the residence is unstated |
-| The controls kit that would ship parts | **Post-v0** |
+| Where the boot-static part map lives | Implied by law (b) to be fixed at build; residence unstated |
+| The controls kit that would ship parts | Not shipped yet |

--- a/docs/design/hicasso/draft-guide/07-ephemeral-state.md
+++ b/docs/design/hicasso/draft-guide/07-ephemeral-state.md
@@ -1,62 +1,35 @@
 # Ephemeral state
 
-> **Draft ahead of the product artefact.** This page teaches the landed surface,
-> witnessed by the bench arm under
-> `implementation/freehand/test/re_frame/bench/hicasso/` — but no
-> `implementation/hicasso/` artefact ships yet, and spellings marked **[unfrozen]**
-> stay provisional until the API freeze.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Behaviour matches the experimental arm under `implementation/freehand/test/re_frame/bench/hicasso/`.
 
 Is this dropdown open? Is this row hovered? Is this panel expanded?
 
-In Reagent you reach for `r/atom`. In React you reach for `useState`. In Hicasso
-there is **no `local`** — no component-local reactive cell, no ratom equivalent, and
-no `useState` for application state. Not discouraged. Absent.
+In Reagent you reach for `r/atom`. In React you reach for `useState`. In Hicasso there is **no `local`** — no component-local reactive cell, no ratom, no `useState` for application state. Not discouraged. Absent.
 
-That is a strong claim, so here is the evidence it rests on: a census of **85
-idiomatic re-frame files**, containing every classic hard case, found **zero
-view-local reactive cells**. Not few. Zero. Most of Reagent's local-state demand was
-manufactured by machinery — the reaction engine, deref capture, argv memoization —
-that Hicasso deletes structurally. A second reactive system for application state
-is the failure mode this surface refuses to reintroduce.
+Most "local state" demand was manufactured by machinery Hicasso does not have — reaction capture, argv memoization, a second reactive system. Open, hover, expanded: put them where the rest of the app already looks.
 
 ## The placement rule
 
-One rule, and it is *taught*, not policed:
+> **Semantic application state belongs in app-db. Component mechanics — composition, measurement, focus, animation, SDK handles — may use ordinary React hooks at the honest escape hatch.**
 
-> **Semantic application state belongs in app-db. Component mechanics —
-> composition, measurement, focus, animation, SDK handles — may use ordinary React
-> hooks at the honest escape hatch.**
+The test is whether anyone other than this component could care. A dropdown's open state affects what the user can do next, so it is semantic. A tooltip's measured pixel offset is arithmetic, so it is mechanics.
 
-The test is whether anyone other than this component could care. A dropdown's open
-state affects what the user can do next, so it is semantic. A tooltip's measured
-pixel offset is arithmetic, so it is mechanics.
-
-A `defview` body is an honest React function component. Hooks physically work in it.
-There is no lint police in v0, and if you use one you take on React's hook rules
-yourself — including the loss of headless testability for that body
-([Testing](08-testing.md)).
+A `defview` body is an honest React function component. Hooks physically work in it. There is no lint police, and if you use one you take on React's hook rules yourself — including the loss of headless testability for that body ([Testing](08-testing.md)).
 
 ## The order to try
 
-1. **CSS.** Hover, focus, active, `:has()`, `<details>`. If the platform already
-   tracks it, no state exists at all.
-2. **Platform-carried state.** The top layer owns open and dismiss for overlays;
-   resources and mutations own their own async status; the controls kit owns drafts
-   and revisions. See the v0 caveat below — most of this layer is post-v0.
-3. **Host-private React state at host edges.** Geometry, composition,
-   measure-before-paint. Local to the edge, invisible to the app.
+1. **CSS.** Hover, focus, active, `:has()`, `<details>`. If the platform already tracks it, no state exists at all.
+2. **Platform-carried state.** Overlays that own open/dismiss, resources that own async status, a controls kit that owns drafts — when those exist. They don't ship yet; until they do, skip to the next step or use app-db.
+3. **Host-private React state at host edges.** Geometry, composition, measure-before-paint. Local to the edge, invisible to the app.
 4. **app-db**, for everything semantically meaningful.
 
-Work down the list, not up it. Most of the time you stop at 1.
+Work down the list. Most of the time you stop at 1.
 
-## app-db without the ceremony
+## app-db for open / expanded / selected
 
-The objection to app-db for UI state is always ceremony: an event, a subscription,
-and a keypath for something as small as "is this open?"
+The objection is ceremony: an event, a subscription, and a keypath for "is this open?"
 
-The answer comes in two parts, and the first is that **the tax is per-concern,
-not per-instance.** One parametric subscription and one named event serve every
-instance of the widget in the app, forever:
+The tax is per-concern, not per-instance. One parametric subscription and one named event serve every instance forever:
 
 ```clojure
 (rf/reg-sub :panel/expanded?
@@ -74,17 +47,11 @@ instance of the widget in the app, forever:
    (when (sub [:panel/expanded? id]) [panel-body {:id id}])])
 ```
 
-Ten lines, once. A hundred panels, no further cost. And you get the things a local
-cell can never give you: the state is in app-db, so it time-travels, it is visible
-in Xray, it is isolated per frame, and a test can set it directly without touching a
-component.
+Ten lines, once. A hundred panels, no further cost. And you get what a local cell cannot give: the state time-travels, it is visible in Xray, it is isolated per frame, and a test can set it with a `:db` write — "open this dropdown" is not a click simulation.
 
-That last one is worth sitting with. "Open this dropdown in a test" is a `:db`
-write, not a click simulation.
+### The short form: `h/reg-state`
 
-The second part is that **the ten lines become one.** `h/reg-state` **[unfrozen]**
-is landed sugar, witnessed in the bench arm. It registers the same ordinary sub
-and event you would have written by hand:
+`h/reg-state` **[unfrozen]** is sugar for the same ordinary sub and event:
 
 ```clojure
 (h/reg-state ::expanded? {:default false})
@@ -93,116 +60,40 @@ and event you would have written by hand:
 ;;        the documented path     [:ui ::expanded? panel-id]
 ```
 
-One declaration per *concern* — a namespace-qualified keyword — with
-`{:default v}` as the only option. No state system arrives with it: it
-registers ordinary re-frame artefacts that read and write plain app-db at a
-documented path, which is why everything above stays true under it — time
-travel, Xray, per-frame isolation, tests writing `:db`.
+One declaration per *concern* — a namespace-qualified keyword — with `{:default v}` as the only option. No second state system: it registers ordinary re-frame artefacts that read and write plain app-db at a documented path. Time travel, Xray, per-frame isolation, and tests writing `:db` all still work.
 
-Keep the long form in mind anyway. It is the definition of what `reg-state`
-mints, and the shape you graduate to when a write starts to *mean* something
-(next section — the example's `:panel/toggle` is already that graduation).
+Keep the long form in mind. It is the definition of what `reg-state` mints, and the shape you graduate to when a write starts to *mean* something (the example's `:panel/toggle` is already that graduation).
 
-Two details matter because getting them wrong is silent otherwise.
+Two details that fail silently if you get them wrong:
 
-**Clearing is a framework event, not a magic value.** Dispatch
-`[::h/clear ::expanded? panel-id]` and the entry is removed, so the default
-shows through again. A reserved clear *value* is not offered — a concern whose
-legitimate values are keywords could then silently delete state.
+**Clearing is a framework event, not a magic value.** Dispatch `[::h/clear ::expanded? panel-id]` and the entry is removed, so the default shows through again. A reserved clear *value* is not offered — a concern whose legitimate values are keywords could then silently delete state.
 
-**A nil or malformed instance key refuses loudly**, at read and at write, with
-`:rf.error/hicasso-state-bad-key` naming the concern — instead of quietly filing
-every instance's state under the same broken key.
+**A nil or malformed instance key refuses loudly**, at read and at write, with `:rf.error/hicasso-state-bad-key` naming the concern — instead of quietly filing every instance under the same broken key.
 
 ## Choosing the instance key
 
-`reg-state` and the long form share one authored input: the instance key —
-`panel-id` above, the value that keeps a hundred panels from sharing one
-`expanded?`. Hicasso mints no identity for you. React's `useId` is not a fit
-here: its hydration ids can diverge under a hydration root, and outside
-hydration it is a counter whose ids do not survive remount — which state
-resident in app-db cannot tolerate. The key is authored data — a keyword,
-string, number, or vector of these — and four rules cover choosing it.
+`reg-state` and the long form both need an instance key — `panel-id` above — so a hundred panels do not share one `expanded?`. Hicasso mints no identity for you. React's `useId` is not a fit: hydration ids can diverge under a hydration root, and outside hydration it is a counter whose ids do not survive remount — which app-db-resident state cannot tolerate. The key is authored data: a keyword, string, number, or vector of these.
 
-**Domain ids first — entity-qualified when entities can collide.** The best key
-already exists in your data: the order's id, the row's id, a literal namespaced
-keyword for a singleton placement. But a *generic* widget serving two entity
-types must not key by bare id — order 42 and invoice 42 both landing on
-`(sub [::expanded? 42])` is one entry, and the two silently share state.
-Qualify the id *value*: `[:order/id 42]` and `[:invoice/id 42]` are different
-keys, and the vector is already legal key grammar.
+Checklist:
 
-**Placement-like concerns key by placement; value-like concerns key by
-entity.** Ask whether the concern is about the *slot on screen* or the *thing
-shown in it*. A master list and a detail pane both showing order 42: the
-order's draft is value-like — key it by entity, and both panes sharing one
-draft is correct, because it is the same draft. `expanded?` is placement-like —
-key it by placement (or placement plus entity), because collapsing the detail
-pane must not fold the list row.
-
-**Nest with `h/child-key`.** A widget inside a widget extends its parent's key
-instead of inventing a fresh one: `(h/child-key parent-key :filter)` yields
-`[parent-key :filter]`, and conj's onto a key that is already a vector — so
-every key bottoms out as a flat vector of authored data, and two children of
-two different parents can never collide.
-
-**If it would be a good React `:key`, it is a good instance key.** Derived from
-your data, stable across renders, unique among siblings — the same judgment,
-reused. This is also the SSR determinism rule: server and client must compute
-the same key from the same snapshot, which authored data does and render-order
-counters do not. One obligation follows on server-rendered pages: instance
-state lives under `[:ui …]`, and the payload policy is fail-closed — when
-server-side events write render-affecting instance state, the payload allowlist
-must name `:ui`, or the client renders from state the server never sent and
-hydration reports the mismatch
-([Server-side rendering](10-server-side-rendering.md)).
+1. **Domain ids first — entity-qualify when entities can collide.** Prefer the order's id, the row's id, a namespaced keyword for a singleton. Bare ids collide across entity types: order 42 and invoice 42 both landing on `(sub [::expanded? 42])` share one entry. Qualify the value: `[:order/id 42]` and `[:invoice/id 42]`.
+2. **Placement-like concerns key by placement; value-like concerns key by entity.** Is the concern about the *slot on screen* or the *thing shown in it*? A draft of order 42 is value-like — both panes share one draft. `expanded?` is placement-like — collapse the detail pane without folding the list row.
+3. **Nest with `h/child-key`.** A widget inside a widget extends its parent's key: `(h/child-key parent-key :filter)` → `[parent-key :filter]`. Conj's onto a key that is already a vector, so every key bottoms out as a flat vector of authored data.
+4. **If it would be a good React `:key`, it is a good instance key.** Derived from your data, stable across renders, unique among siblings. Same judgment for SSR determinism: server and client must compute the same key from the same snapshot — authored data does; render-order counters do not. Instance state lives under `[:ui …]`; when server-side events write render-affecting instance state, the payload allowlist must name `:ui`, or hydration reports the mismatch ([Server-side rendering](10-server-side-rendering.md)).
 
 ## Named events, not a generic setter
 
 Write `[:panel/toggle id]`, never a generic `[:ui/set [:panel/expanded id] true]`.
 
-A named event is a name for what happened, which is the entire premise of the event
-log being readable. A generic setter turns your event history into a diff stream and
-takes the meaning out of the one place the framework was keeping it for you.
-`reg-state` keeps that law for the sugar: the setter it mints is **named by its
-concern** — `[::expanded? panel-id false]` reads as what it is in the log — never a
-generic `ui/set`.
+A named event is a name for what happened — the event log stays readable. A generic setter turns history into a diff stream. `reg-state` keeps that law for the sugar: the setter it mints is **named by its concern** — `[::expanded? panel-id false]` — never a generic `ui/set`.
 
-The concern-named setter is a floor, not a ceiling. When an occurrence means more
-than an assignment — the collapse should fire an effect, other state reacts, the
-log should say *toggle* — graduate to a named domain event like `[:panel/toggle id]`
-and let the setter go. The sugar exists so ceremony never stops you putting state
-where it belongs, not so assignment replaces meaning.
+The concern-named setter is a floor, not a ceiling. When an occurrence means more than an assignment — fire an effect, other state reacts, the log should say *toggle* — graduate to a named domain event and let the setter go. The sugar exists so ceremony never stops you putting state where it belongs, not so assignment replaces meaning.
 
-## What v0 actually gives you
+## Exit animation: `h/presence`
 
-Layer 2 above is mostly a promise. The controls kit that would own drafts and
-revisions is post-v0. So is the overlay top layer. In v0, a dismissible dropdown is
-CSS if you can manage it, and app-db if you can't.
+One piece of view state app-db cannot hold: a toast is dismissed and gone from app-db (correct), but it should fade out over 300ms, so the node has to outlive the data. App-db is about what is *true*; this is about what is still *painted*.
 
-What *is* in v0 is the ceremony answer: `reg-state` for the ordinary assignment
-case, the long form when a write means more than assignment, one conventional
-app-space root at `[:ui <concern> <instance-key>]`, and no second state system.
-There is still no lint fence around `useState` — the placement rule is taught, not
-policed — and the no-`local` core stands throughout.
-
-A complaint about state ceremony is **expected signal**, not a verdict. If
-explicitly threading the instance key turns out to be the pain, the next step
-is an ambient/auto door — still never a parallel state system.
-
-## The state you cannot put in app-db: "it left, but it is still on screen"
-
-There is one piece of view state app-db genuinely cannot hold, and it is worth
-knowing where it lives before you go looking for a `local` to put it in.
-
-A toast is dismissed. It is gone from app-db — that write already happened, and it
-was correct. But it should fade out over 300ms, which means the node has to outlive
-the data by 300ms. Nothing in app-db can express that, because app-db is about what
-is *true*, and this is about what is still *painted*.
-
-That is what `h/presence` is for. It retains keyed children that have left the
-source data, for `:timeout-ms`, and it lets each child say what it looks like on
-the way out — **in its own attribute map**:
+`h/presence` retains keyed children that have left the source data, for `:timeout-ms`, and lets each child say what it looks like on the way out — **in its own attribute map**:
 
 ```clojure
 (defview toast-tray [_]
@@ -214,52 +105,28 @@ the way out — **in its own attribute map**:
       (:message t)])])
 ```
 
-Three things about that block.
+**There is no child view.** The whole tray is inline. Exit attributes sit on the node itself as data, so inline markup is safe — phase is not an ambient dynamic that could silently resolve to the parent's context.
 
-**There is no child view.** The whole tray is written inline, in the parent.
-Phase is not an ambient dynamic that could silently resolve to the parent's
-context — exit attributes sit on the node itself as data, so inline markup is
-safe.
+**The a11y attributes are one map, not three conditionals.** A retained node is still in the document: it can take focus and clicks until you say otherwise. `:inert`, `:aria-hidden`, and an exit class arrive together, as data, in the phase they belong to.
 
-**The a11y attributes are one map, not three conditionals.** A retained node is
-still in the document: it can take focus and clicks until you say otherwise. That
-obligation is `:inert`, `:aria-hidden` and an exit class, and here they arrive
-together, as data, in the phase they belong to.
-
-**When the child is a view, the phase is an ordinary prop.**
+**When the child is a view, the phase is an ordinary prop:**
 
 ```clojure
 [toast-card {:key (:id t) :toast t}]   ;; receives :rf/phase :unmounting
 ```
 
-Which means a test can pass `:rf/phase :unmounting` and assert the exit rendering
-with no timers, no browser and no clock at all.
+A test can pass `:rf/phase :unmounting` and assert the exit rendering with no timers, no browser, and no clock.
 
 ### What presence does not do
 
-`:timeout-ms` is mandatory, and it is both the retention length and a hard terminal
-bound — presence is a clock, not a `transitionend` listener, so the node leaves on
-time whether or not your CSS ran, or was disabled, or was overridden by
-`prefers-reduced-motion`. Re-entry cancels exit: a toast that comes back before the
-timeout returns to `:present` rather than finishing its exit and remounting. And
-presence never dispatches anything — a node lingering on screen is not a reason for
-anything in app-db to linger with it.
-
-**Order is frozen at first appearance**, deliberately, so an exiting child does not
-jump to a new slot halfway through its animation. Surviving keys keep the order
-they had and genuinely new keys are appended. A list that re-sorts while items are
-leaving therefore sorts at the data layer, not here.
+- `:timeout-ms` is mandatory — both the retention length and a hard terminal bound. Presence is a clock, not a `transitionend` listener, so the node leaves on time whether or not your CSS ran, was disabled, or was overridden by `prefers-reduced-motion`.
+- Re-entry cancels exit: a toast that comes back before the timeout returns to `:present` rather than finishing exit and remounting.
+- Presence never dispatches anything — a node lingering on screen is not a reason for app-db to linger with it.
+- **Order is frozen at first appearance**, so an exiting child does not jump slots mid-animation. Surviving keys keep the order they had; new keys are appended. A list that re-sorts while items are leaving sorts at the data layer, not here.
 
 ### Enter is the weak half
 
-This guide will not pretend otherwise, so here is the enter side in full.
-
-`::h/mounting` is the mirror of `::h/unmounting`: an attribute-override map that
-presence merges onto the nodes it can see while a child is in its `:mounting`
-phase — on the way in, rather than on the way out. It exists, it ships, and it
-works. But driving an entrance as a `:mounting` → `:present` class flip can lose
-the race to the browser's first paint, and then nothing animates. For enter, use
-an animation on insertion or `@starting-style`:
+`::h/mounting` is the mirror of `::h/unmounting`: an attribute-override map presence merges onto nodes in their `:mounting` phase. It ships and it works. Driving an entrance as a `:mounting` → `:present` class flip can lose the race to the browser's first paint, and then nothing animates. For enter, prefer an animation on insertion or `@starting-style`:
 
 ```css
 .toast { animation: toast-in 200ms ease-out; }
@@ -268,76 +135,32 @@ an animation on insertion or `@starting-style`:
 @media (prefers-reduced-motion: reduce) { .toast { animation: none; transition: none; } }
 ```
 
-Exit is the phase that transitions happily, because the node is already painted.
+Exit transitions happily, because the node is already painted. `::h/mounting` earns its keep on attributes that are simply *true during entry* — `:inert` and `:aria-hidden` until settled — not as the recommended way to fade something in.
 
-So `::h/mounting` earns its keep on the attributes that are simply *true during
-entry* rather than on the animation itself. An arriving node that should not take
-focus or be announced until it has settled wants `:inert` and `:aria-hidden`, in
-the same map shape the exit override uses. A class flip is legitimate too, once
-you have looked at the paint race and decided you can live with losing it now and
-then. What it is not is the recommended way to make something fade in.
-
-One thing to know before you lean on mounting-phase attributes for correctness
-rather than for looks. Under SSR, a presence-managed node **hydrates
-born-present**, so server HTML never carries `:mounting`-phase attributes at all
-([Server-side rendering](10-server-side-rendering.md)). Nothing that arrived with
-the page replays an entrance over content the user is already reading, which is
-the behaviour you want — but it does mean the first paint of a server-rendered
-page is not a moment when `::h/mounting` has been applied.
+Under SSR, a presence-managed node **hydrates born-present**, so server HTML never carries `:mounting`-phase attributes ([Server-side rendering](10-server-side-rendering.md)). Nothing that arrived with the page replays an entrance over content the user is already reading — which means the first paint of a server-rendered page is not a moment when `::h/mounting` has been applied.
 
 ## Where is `:on-mount`?
 
-There is no `:on-mount` and no `:on-unmount`, and as with `local`, the absence is
-deliberate rather than pending. Hicasso took the *attribute* half of Replicant's
-mechanism — `::h/mounting` and `::h/unmounting` above — and rejected the callback
-half as less data-oriented than a registered behaviour. Presence is the one
-mechanism that knows a node arrived or left, and it never dispatches anything
-about either, deliberately. And the hook-budget witness holds the tier-1 shapes
-to a page with no `useEffect` on it anywhere.
+There is no `:on-mount` and no `:on-unmount`. Hicasso took the *attribute* half of Replicant's mechanism (`::h/mounting` / `::h/unmounting`) and rejected the callback half as less data-oriented than a registered behaviour. Presence knows a node arrived or left, and it never dispatches about either. Four jobs send people looking for `:on-mount`; each has a home:
 
-An absence with nowhere to go would be a gap. Four jobs send people looking for
-`:on-mount`, and each of them has a home.
+| Job | Home |
+|---|---|
+| Load the data this screen needs | The route declares it — `:resources` on entry, `:on-match` for activation events. Also closes the click-away race: a fetch kicked off by a mounting component has nothing to suppress the late reply when the user navigates away first ([Routing](../../../routing/concepts.md#loaders-declaring-a-pages-data)) |
+| Run something once at startup | `:initial-events` — ordinary events, in order, seeding app-db *before* first paint ([Getting started](01-getting-started.md)) |
+| Animate an entrance or exit | Presence, above. `::h/unmounting` for exit; animation on insertion or `@starting-style` for enter |
+| Drive a real DOM node or a third-party SDK | The host edge. A callback `:ref` hands you the node on attach and takes your return value as the cleanup; a `defhost` component brings whatever hooks it already had ([Interop](05-interop.md)) |
 
-**Load the data this screen needs.** The route declares it, not the view. A
-route's `:resources` are ensured on entry and its `:on-match` carries activation
-events, which is also what closes the click-away race — a fetch kicked off by a
-mounting component has nothing to suppress the late reply when the user navigates
-away first
-([Routing](../../../routing/concepts.md#loaders-declaring-a-pages-data)).
-
-**Run something once at startup.** `:initial-events` — ordinary events, run in
-order, seeding app-db *before* first paint rather than a beat after it
-([Getting started](01-getting-started.md)).
-
-**Animate an entrance or an exit.** Presence, above. `::h/unmounting` for exit;
-an animation on insertion, or `@starting-style`, for enter.
-
-**Drive a real DOM node or a third-party SDK.** The host edge, which is where
-[the placement rule](#the-placement-rule) says lifecycle honestly lives. A
-callback `:ref` hands you the node on attach and takes your return value as the
-cleanup, and a `defhost` component brings whatever hooks it already had — its own
-`useEffect` included, running inside a Hicasso tree exactly as it ran outside one
-([Interop](05-interop.md)).
-
-The last of those has an open edge, and it is worth naming rather than papering
-over. The *data* spelling of a host behaviour — a registered id and a config map,
-with the imperative code out of your view, as in
-`{:ref [::autosize {:max-rows 8}]}` — is refused today with
-`:rf.error/hicasso-ref-vector-reserved`. That value space is reserved, not
-designed. Until it lands, write the function.
+The data spelling of a host behaviour — `{:ref [::autosize {:max-rows 8}]}` — is refused today with `:rf.error/hicasso-ref-vector-reserved`. That value space is reserved, not designed. Until it lands, write the function.
 
 ## Troubleshooting
-
-This table names mechanisms; the one minted id on this surface is named in its
-row.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | Reaching for `useState` to hold "is this open?" | That's semantic state | app-db (`reg-state` or the long form), or CSS if the platform tracks it |
-| Searching for `:on-mount`, `componentDidMount`, or a mount `useEffect` | There is none, and the absence is deliberate rather than pending | Name the job: route `:resources` for page data, `:initial-events` for startup, presence for animation, a callback `:ref` or `defhost` at a host edge |
+| Searching for `:on-mount`, `componentDidMount`, or a mount `useEffect` | There is none | Name the job: route `:resources` for page data, `:initial-events` for startup, presence for animation, a callback `:ref` or `defhost` at a host edge |
 | A dismissed item disappears instantly with no exit animation | The node left with the data | `h/presence` with a `:timeout-ms` at least as long as the exit transition |
 | A retained node still takes focus or clicks while fading | The exit override does not carry `:inert` / `:aria-hidden` | Put all three in the `::h/unmounting` map |
-| An exit override on a view head raises `:rf.error/hicasso-presence-override-on-a-view` | Presence merges overrides into nodes it can see; a view is opaque to it, and a silently dropped override is the failure class the loud error exists to delete | The view receives `:rf/phase` — branch or style on that |
+| An exit override on a view head raises `:rf.error/hicasso-presence-override-on-a-view` | Presence merges overrides into nodes it can see; a view is opaque, and a silently dropped override is the failure the loud error exists to delete | The view receives `:rf/phase` — branch or style on that |
 | Every panel in a list opens at once | The state isn't parameterised by instance — or two instances share one key | Key the path per instance: [Choosing the instance key](#choosing-the-instance-key) |
 | A nil or malformed instance key raises `:rf.error/hicasso-state-bad-key` | The key is not a keyword, string, number, or vector of those | Author a stable domain or placement key; nest with `h/child-key` when needed |
 | A hook body can't be tested headlessly | Hooks put a body outside headless scope, by design | Move the semantic half to app-db; mount-test the mechanics |
@@ -346,24 +169,17 @@ row.
 
 ## When app-db is the wrong home
 
-Three cases where it genuinely is.
+**The platform already knows.** Hover and focus are CSS. Writing them into app-db is a re-render per pointer move for a fact the browser was tracking for free.
 
-**The platform already knows.** Hover and focus are CSS. Writing them into app-db is
-a re-render per pointer move for a fact the browser was tracking for free.
+**High-rate host mechanics.** A drag in flight, a scroll offset, an animation frame — 60 to 240 updates a second. Host-local motion off app-db; semantic commits into it. Drag *ends* in app-db. Drag *moves* do not.
 
-**High-rate host mechanics.** A drag in flight, a scroll offset, an animation frame
-— 60 to 240 updates a second. That is the two-clock envelope: host-local motion off
-app-db, semantic commits into it. Drag *ends* in app-db. Drag *moves* do not.
-
-**Values nobody else can see.** A measured pixel offset, an SDK handle, a
-composition buffer. Host-private React state at the host edge, and no one outside
-that edge needs to know it exists.
+**Values nobody else can see.** A measured pixel offset, an SDK handle, a composition buffer. Host-private React state at the host edge; no one outside that edge needs to know it exists.
 
 ## Not settled yet
 
 | Question | Status |
 |---|---|
-| Vector `:ref` host behaviours (`{:ref [::id opts]}`) | **Reserved, not designed** — refused today with `:rf.error/hicasso-ref-vector-reserved`; write a function ref until a data spelling exists |
-| The controls kit (drafts, revisions) | **Post-v0** |
-| The overlay top layer that would own open and dismiss | **Post-v0** |
-| The spellings | `h/reg-state`, `h/presence`, `h/child-key` and friends are bench-arm names; every spelling on this page is **[unfrozen]** until the API freeze |
+| Vector `:ref` host behaviours (`{:ref [::id opts]}`) | Reserved, not designed — refused today with `:rf.error/hicasso-ref-vector-reserved`; write a function ref until a data spelling exists |
+| The controls kit (drafts, revisions) | Not shipped yet |
+| The overlay layer that would own open and dismiss | Not shipped yet |
+| The spellings | `h/reg-state`, `h/presence`, `h/child-key` and friends are experimental names; every spelling on this page is **[unfrozen]** until the API freeze |

--- a/docs/design/hicasso/draft-guide/08-testing.md
+++ b/docs/design/hicasso/draft-guide/08-testing.md
@@ -1,34 +1,23 @@
 # Testing
 
-> **Draft ahead of the product artefact.** Spellings marked **[unfrozen]** stay
-> provisional until the API freeze. **Read this page with one extra caution.** The
-> mounted door exists as the bench arm's suites under
-> `implementation/freehand/test/re_frame/bench/hicasso/` — fixtures, not a named
-> product facade. **The headless door is not built** — no structural render function
-> exists in the tree, and the sketch below is this guide's illustration of the
-> intended semantics rather than a call you can make today. What is real now is
-> the property the door rests on, and this page says which is which.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Behaviour matches the experimental arm under `implementation/freehand/test/re_frame/bench/hicasso/`.
 
-There are two doors into a Hicasso view under test, and knowing which one you are
-allowed through is most of the skill.
+Two ways to test a Hicasso view:
 
-The headless door is fast, runs on the JVM, and asserts hiccup with `=`. It covers
-hook-free tier-1 bodies. Everything else — hooks, foreign components, anything at a
-host edge — goes through the mounted door, in a real browser.
+1. **Headless** — structural render to hiccup data, assert with `=`. Fast, JVM-friendly. **Not built yet** — the sketch below is the intended shape, not a call you can make today.
+2. **Mounted** — real browser, real React. Covers hooks, foreign components, and anything at a host edge.
 
-That boundary is deliberate, not a temporary gap: **no fake hook dispatcher,
-ever.**
+**No fake hook dispatcher, ever.** A stubbed dispatcher passes tests that real React would fail — abandoned renders, StrictMode double-invoke, effect ordering. Better a loud boundary you can see than a green suite you can't trust. Split instead: keep the semantic half in a hook-free body headless can assert, and mount-test the mechanics once.
 
-## The headless door
+What you *can* assert today without a headless render: **intent vectors with `=`**. `{:on-click [:todo/toggle 7]}` is data. The experimental tests already assert intents that way — prevented intents, route-link click decisions, presence exit rendering — with no browser and no clock.
 
-A structural render returns the view's hiccup tree as data. No DOM, no React, no
-browser. **Nothing implements this yet** — the intended shape is fixed and no
-function in the tree performs one, so read the block below as the shape that is
-designed rather than a test you can write this afternoon:
+## Headless (sketch — not built)
+
+A structural render returns the view's hiccup tree as data. No DOM, no React, no browser. Nothing in the tree implements this yet; read the block as the designed shape:
 
 ```clojure
 ;; SKETCH — h/render does not exist, and its spelling is [unfrozen] besides.
-;; Intended semantics, spelled by this guide so the shape is visible.
+;; Intended semantics, so the shape is visible.
 (deftest todo-row-renders-title
   (let [tree (h/render [todo-row {:id 7}]
                        {:subs {[:todo/by-id 7]      {:title "Buy milk"}
@@ -40,113 +29,67 @@ designed rather than a test you can write this afternoon:
            tree))))
 ```
 
-Two things would be doing the work there, and only one of them is waiting on the
-door.
+Two halves:
 
-**Sub reads are overridable through a pure read resolver.** You hand the render a
-map of query vector to value, and the body reads from it. No frame, no app-db, no
-registration — just the values the view is a function of. `sub` is an ordinary
-call ([Views and reads](02-views-and-reads.md)), and the resolver answers it
-wherever the body makes it. This half is entirely the door's, and it is the half
-that does not exist yet.
+**Sub reads overridable through a pure read resolver.** Hand the render a map of query vector → value; the body reads from it. No frame, no app-db, no registration — just the values the view is a function of. This half is the headless path's, and it does not exist yet.
 
-**Intent vectors are assertable by equality.** `{:on-click [:todo/toggle 7]}` is
-data. You can `=` it. Compare that with the alternative — asserting that a node
-holds *some function* which, when called, dispatches something — which is why
-codebases end up rendering to a DOM and clicking things just to find out what a
-button was going to do. This is not aspiration: the bench arm's own tests already
-work this way — a prevented intent, a route-link's whole click decision, and a
-presence child's exit rendering are each asserted by `=`, with no browser and no
-clock (`front/intent_cljs_test`, `front/route_link_cljs_test`,
-`front/presence_cljs_test`).
+**Intent vectors assertable by equality.** `{:on-click [:todo/toggle 7]}` is data. You can `=` it. The alternative is asserting that a node holds *some function* which, when called, dispatches something — which is why codebases render to a DOM and click things just to find out what a button was going to do. That property is real today; only the full structural render is waiting.
 
-Make the tree data and most of the `data-testid` scaffolding that only existed
-because the tree wasn't inspectable stops earning its place.
+Make the tree data and most of the `data-testid` scaffolding that only existed because the tree wasn't inspectable stops earning its place.
 
-## Where headless stops
+### Where headless stops
 
 **Hook-free tier-1 bodies.** That is the scope, exactly.
 
-If a body calls a React hook — a callback ref for measurement, a `useEffect` for an
-SDK, anything at a host edge — headless is out. If a body renders a foreign
-component through [`defhost`](05-interop.md) (or the `[:>]` escape, once it is
-built), the foreign region is out.
+If a body calls a React hook — a callback ref for measurement, a `useEffect` for an SDK, anything at a host edge — headless is out. If a body renders a foreign component through [`defhost`](05-interop.md) (or the `[:>]` escape, once it is built), the foreign region is out.
 
-The temptation is obvious: stub the hook dispatcher, get the whole tree back, keep
-the fast tests. That is foreclosed. A fake dispatcher passes tests that a real
-React would fail, and the bugs it hides are exactly the ones — abandoned renders,
-StrictMode double-invoke, effect ordering — that you needed a test for. Better a
-loud boundary you can see than a green suite you can't trust.
+## Mounted (real browser)
 
-The practical move is to split. Keep the semantic half of the component in a
-hook-free body that headless can assert, and put the mechanics in a small host-edge
-component you mount-test once.
+What exists today is the experimental test fixture under `implementation/freehand/test/re_frame/bench/hicasso/` — not a product-named API. It covers root lifecycle, a synchronous dispatch path, and residue assertions **[unfrozen — no product name yet]**.
 
-## The mounted door
+It flushes rather than using `act`: `act` diverts React's work to a queue that is not the browser's, which is right for an effect-ordering test and wrong when the assertion reads the page. After a dispatch, the next line sees the DOM the user would have seen.
 
-What exists today is the **bench arm's fixture**, not a product-named facade. It
-covers root lifecycle, a synchronous dispatch door, and residue assertions
-**[unfrozen — no product name yet]**. Note what it deliberately is not built on:
-`act` diverts React's work to a queue that is not the browser's, which is right for
-an effect-ordering test and wrong for a witness that reads the page. The bench
-fixture flushes instead, so an assertion on the line after a dispatch reads the DOM
-the user would have seen.
-
-One assertion is standing, on every mounted test: **zero leaked subscription
-ref-counts after teardown.** A related invariant rides with it — an unchanged hot
-read performs no new attach or release, so a re-render that reads the same query
-should show no churn at all.
+Standing assertion on every mounted test: **zero leaked subscription ref-counts after teardown.** Related: an unchanged hot read performs no new attach or release — a re-render that reads the same query should show no churn.
 
 Reach for a mounted test when you need:
 
-- a real error boundary catching a real throw
-  ([When a view throws](09-when-a-view-throws.md));
-- caret, selection, or IME behaviour, which only a real browser can prove
-  ([Controlled inputs](04-controlled-inputs.md));
+- a real error boundary catching a real throw ([When a view throws](09-when-a-view-throws.md));
+- caret, selection, or IME behaviour ([Controlled inputs](04-controlled-inputs.md));
 - StrictMode, abandoned first mount, root teardown, or an HMR body swap;
 - keyed insert, delete, and reorder against real DOM nodes;
 - a foreign component's hooks, context, or refs.
 
 ## Testing events and subscriptions
 
-Nothing changes. Events are functions from coeffects to an effects map, and
-subscriptions are functions of app-db — both testable without any view layer at all,
-in Hicasso exactly as under Reagent or UIx.
+Nothing changes. Events are functions from coeffects to an effects map, and subscriptions are functions of app-db — both testable without any view layer at all, in Hicasso exactly as under Reagent or UIx.
 
-The view-layer testing question is only ever "what tree did this body produce, given
-these reads?" — which is the headless door's whole job.
+The view-layer question is only ever "what tree did this body produce, given these reads?" — which is the headless path's whole job.
 
 ## Troubleshooting
-
-This table names mechanisms rather than error ids.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | Headless render throws on a body with hooks | Out of scope by design | Mount-test it, or split the semantic half into a hook-free body |
 | A sub read returns `nil` in a headless test | The query wasn't in the resolver map | Sub-key identity is `(query-id, args)` under value equality — check the args match exactly |
 | Assertion fails on a `nil` in the tree | A `when` produced `nil`, which renders nothing but is still in the data | Assert the `nil`, or filter before comparing |
-| Ref-count leak after teardown | A subscription outlived its root | A runtime bug — this is the standing assertion, not a test you tune |
+| Ref-count leak after teardown | A subscription outlived its root | A runtime bug — not a test you tune around |
 | A test passes headless and fails mounted | Real React does things a data render doesn't — effect order, double invoke, commit timing | The mounted result is the truth |
-| Caret test can't be written headlessly | Correct — caret is a browser fact | 100-cell grid witnesses, in a browser |
+| Caret test can't be written headlessly | Correct — caret is a browser fact | Browser witnesses, e.g. the 100-cell editing grid |
 
 ## When not to test through the view
 
-If the assertion is about *state*, test the event handler. If it is about *derived
-values*, test the subscription. A view test that dispatches an event and then
-asserts on app-db is testing three things and will fail for reasons that have
-nothing to do with the view.
+If the assertion is about *state*, test the event handler. If it is about *derived values*, test the subscription. A view test that dispatches an event and then asserts on app-db is testing three things and will fail for reasons that have nothing to do with the view.
 
-Headless view tests answer one question — did this body produce the right tree from
-these reads — and they are excellent at it precisely because that is all they do.
+Headless view tests answer one question — did this body produce the right tree from these reads — and they are excellent at it precisely because that is all they do.
 
 ## Not settled yet
 
 | Question | Status |
 |---|---|
-| The headless render function's name and signature | **Not built.** Semantics are pinned — structural render as data, sub reads overridable — and nothing in the tree implements one. `h/render` and the `{:subs …}` option above are this guide's invention; the spelling is **[unfrozen]** |
-| The read resolver's shape | **Not addressed.** "A pure read resolver" is the whole of the claim; a map is the obvious form, and it is a guess |
-| The mounted facade's name and API | **Not addressed.** The bench arm's fixture is the only one that exists; it is not a product surface, and it flushes rather than using `act` |
-| Whether headless renders one boundary or a subtree | **Not addressed.** The example above renders one; whether child boundaries are rendered through or returned as unexpanded nodes is unstated, and it changes how every test is written |
-| How intent vectors are *invoked* in a headless test | **Not addressed.** They can be asserted by equality; whether the door lets you fire one and observe the dispatch is unstated |
-| The registry / manifest surface — views enumerable with schemas, docs, source coordinates | **Post-v0.** Named as the AI-ergonomics door |
-| Explain-render tooling | **Post-v0.** A small nil-checked evidence sink is planned so tooling can attach later; no evidence subsystem ships in v0 |
+| Headless render name and signature | Not built. Intended shape: structural render as data, sub reads overridable; `h/render` and `{:subs …}` above are this guide's sketch **[unfrozen]** |
+| Read resolver shape | Open. A map is the obvious form; not fixed |
+| Mounted facade name and API | Open. Experimental fixture only; flushes rather than using `act` |
+| One boundary vs a subtree | Open. Whether child boundaries render through or return as unexpanded nodes changes how every test is written |
+| Invoking intent vectors headlessly | Open. Assertable by `=` today; whether headless can fire one and observe the dispatch is unstated |
+| Registry / manifest (views enumerable with schemas, docs, source coordinates) | Not shipped yet |
+| Explain-render tooling | Not shipped yet |

--- a/docs/design/hicasso/draft-guide/09-when-a-view-throws.md
+++ b/docs/design/hicasso/draft-guide/09-when-a-view-throws.md
@@ -1,15 +1,14 @@
 # When a view throws
 
-> **Draft ahead of the product artefact.** No `implementation/hicasso/` artefact
-> ships yet. Spellings marked **[unfrozen]** stay provisional until the API freeze.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]**
+> may change. Behaviour matches the experimental arm under
+> `implementation/freehand/test/re_frame/bench/hicasso/`.
 
-A view body throws — a `nil` where a map was expected, a key that moved, a
-subscription returning a shape last week's code doesn't handle. React's answer is
-not a red box around the broken component. **React unmounts the entire root**, and
-your user is looking at a blank page.
+A view body throws — `nil` where a map was expected, a key that moved, a
+subscription shape last week's code cannot handle. React's default is not a red
+box around the broken component.
 
-That is the right default for a framework that cannot know which parts of your app
-are independent. You do know, so you say so:
+> **React unmounts the entire root. You fence regions.**
 
 ```clojure
 (defview article-page [{:keys [id]}]
@@ -20,15 +19,14 @@ are independent. You do know, so you say so:
    [site-footer {}]])
 ```
 
-If `article-body` throws, the header and footer stay on screen and the paragraph
-takes its place. Nothing else in the tree notices.
+If `article-body` throws, the header and footer stay up and the paragraph takes
+its place. Nothing else in the tree notices.
 
 ## The three keys
 
-`h/boundary` **[unfrozen]** is the runtime's own error boundary, and it takes
-exactly three props. There is no error classification, no retry policy, no logging
-surface — each of those is your application's decision, and `:on-error` is the door
-you make them behind.
+`h/boundary` **[unfrozen]** takes exactly three props. No built-in classification,
+retry policy, or logging — those are your app's decisions; `:on-error` is where
+you make them.
 
 | Key | Shape | What it does |
 |---|---|---|
@@ -36,15 +34,13 @@ you make them behind.
 | `:reset-key` | any value, compared with `=` | changing it clears the caught failure and re-mounts the children |
 | `:on-error` | an intent vector, or a plain function | fires once per caught failure |
 
-**`:fallback` can read the error.** Pass a function and it is called with whatever
-was thrown, so a development build can show the message and a production one can
-show a sentence. Hiccup the function returns is lowered exactly like hiccup you
-wrote inline — intents included.
+**`:fallback` can read the error.** Pass a function and it receives whatever was
+thrown — show the message in development, a sentence in production. Hiccup it
+returns is lowered like any other, intents included.
 
-**`:reset-key` is how a retry happens, and it is yours to schedule.** The boundary
-never guesses. It clears its caught failure when the key changes, and remounts the
-children; if they throw again, it catches again. A counter in app-db is the usual
-shape:
+**`:reset-key` is how retry works.** The boundary never guesses. It clears when the
+key changes and remounts the children; if they throw again, it catches again. A
+counter in app-db is the usual shape:
 
 ```clojure
 (defview article-page [{:keys [id]}]
@@ -58,73 +54,66 @@ shape:
     [article-body {:id id}]]])
 ```
 
-That retry button is an ordinary intent inside a fallback, and it works — the
-fallback is walked inside the boundary's own render, and the boundary re-binds the
-frame it was mounted under around that walk so a handler there lowers exactly as it
-would in the parent's body.
+The retry button is an ordinary intent inside the fallback. The fallback is walked
+in the boundary's own render under the frame the boundary was mounted in, so
+handlers lower the same way they would in the parent.
 
 **`:on-error` fires once per failure.** A vector is dispatched with the error
-appended, so `[:app/record-failure]` reaches your handler as
-`[:app/record-failure error]`, in the frame the boundary is mounted under. A
-function is called with the error instead, and nothing is dispatched. Once means
-once even in development, where StrictMode runs the throwing render twice and React
-still reports a single catch.
+appended — `[:app/record-failure]` reaches the handler as
+`[:app/record-failure error]` — in the boundary's frame. A function is called with
+the error and nothing is dispatched. Once means once even under StrictMode: the
+throwing render may run twice in development, and React still reports a single
+catch.
 
-## What it does not catch
+## What it catches
 
-Worth knowing precisely, because a boundary that quietly does not catch is worse
-than no boundary at all. This is React's line, and Hicasso inherits it exactly.
+React's line, inherited exactly:
 
-**Caught:** a throw from a render, and from the lifecycle and effects of the tree
-below.
+**Caught:** a throw from render, and from lifecycle and effects of the tree below.
 
-**Not caught:** a throw from an event handler, from a `setTimeout`, or from
-anything else the browser calls outside React's own work loop. An intent handler
-that throws lands in the browser's error channel, not here — and that is the right
-place for it, because your event pipeline has its own error handling and a view
-layer should not be intercepting it.
+**Not caught:** a throw from an event handler, a `setTimeout`, or anything else the
+browser calls outside React's work loop. An intent handler that throws goes to the
+browser's error channel — correct, because the event pipeline has its own error
+handling and the view layer should not intercept it.
 
 ## Where to put them
 
 Not everywhere, and not once at the root.
 
-One boundary at the root gives you a whole-page fallback, which is barely better
-than the blank page: the user has lost their navigation too. One boundary per view
-is the other extreme — a fallback per byline is noise, and most of your views
-cannot fail independently of their parent anyway.
+A single root boundary is a whole-page fallback — barely better than a blank
+screen; navigation goes with it. One boundary per view is noise, and most views
+cannot fail independently of their parent.
 
-The useful grain is a **region a user can still work without**: a panel, a tab
+The useful grain is a **region the user can still work without**: a panel, a tab
 body, a sidebar widget, a route's main content. Ask what the rest of the page is
-still good for if this part is gone. If the answer is "nothing", the boundary
-belongs further up.
+worth if this part is gone. If the answer is "nothing", put the boundary higher.
 
-One caution on nesting. **A fallback that throws while rendering is caught by the
-next boundary up**, so a clever fallback that reads the state that caused the
-failure can turn one broken panel into a broken page. Keep fallbacks dull.
+**A fallback that throws while rendering is caught by the next boundary up.** A
+clever fallback that re-reads the state that caused the failure can turn one
+broken panel into a broken page. Keep fallbacks dull.
 
 ## Troubleshooting
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| The whole page goes blank when one view throws | Nothing caught it — React unmounts the root by default | Put an `h/boundary` around the region that can fail |
-| A throw from an event handler isn't caught | Handlers run outside React's work loop; boundaries only see render, lifecycle and effects | Handle it in the event pipeline, where the error already has a home |
-| The fallback shows and never goes away | No `:reset-key`, or the key never changes | The retry is the caller's to schedule — move a counter in app-db and read it as the key |
-| A retry button in the fallback does nothing | Check it is an intent vector at `:on-click` and that the boundary is mounted under a frame | Intents in a fallback lower under the boundary's own frame; with no frame in scope you get `:rf.error/hicasso-intent-outside-boundary` naming the intent |
-| One panel breaks and the whole page goes with it | The fallback itself threw, and the next boundary up caught that instead | Keep the fallback dull — no reads of the state that failed, no computation |
-| `:on-error` fires twice in development | It doesn't — StrictMode re-runs the failing render, and React still reports one catch | If you genuinely see two, they are two failures |
+| Whole page blanks when one view throws | Nothing caught it — React unmounts the root by default | Put `h/boundary` around the region that can fail |
+| Throw from an event handler isn't caught | Handlers run outside React's work loop | Handle it in the event pipeline |
+| Fallback shows and never leaves | No `:reset-key`, or the key never changes | Move a counter in app-db and read it as the key |
+| Retry button in the fallback does nothing | Missing intent at `:on-click`, or no frame in scope | Intents in a fallback lower under the boundary's frame; without a frame you get `:rf.error/hicasso-intent-outside-boundary` naming the intent |
+| One panel breaks and the whole page follows | The fallback itself threw; the next boundary up caught that | Keep the fallback dull — no reads of the failed state, no heavy work |
+| `:on-error` seems to fire twice in development | It doesn't — StrictMode re-runs the failing render; React still reports one catch | Two fires means two real failures |
 
-## When not to reach for one
+## When not to use one
 
 If the failure is *expected* — a request that can 404, a form that can be invalid,
-a resource that can be unavailable — it is not an exception, it is a state. Model
-it in app-db and render it. A boundary is for the failures you did not anticipate,
-and using one for the ones you did makes a thrown exception part of your control
-flow, which is a worse version of a `:status` key.
+a resource that can be unavailable — it is a state, not an exception. Model it in
+app-db and render it. A boundary is for failures you did not plan for. Using one
+for control flow is a worse version of a `:status` key.
 
 ## Not settled yet
 
 | Question | Status |
 |---|---|
-| `h/boundary`'s name and its three key names | Semantics pinned; the spellings are unfrozen like every other declaration spelling |
-| Whether `:on-error` should reach an application-wide handler as well | **Not addressed.** The per-boundary door ships; how an app aggregates failures is its own business today |
-| A richer boundary API | **Post-v0** |
+| `h/boundary` name and its three key names | Behaviour fixed; spellings **[unfrozen]** with the rest of the declaration API |
+| Whether `:on-error` should also reach an app-wide handler | Not addressed — per-boundary `:on-error` ships; aggregation is the app's business |
+| A richer boundary API | Open after the first ship |

--- a/docs/design/hicasso/draft-guide/10-server-side-rendering.md
+++ b/docs/design/hicasso/draft-guide/10-server-side-rendering.md
@@ -1,155 +1,62 @@
 # Server-side rendering
 
-> **Draft ahead of the product artefact — and this page carries more open scope
-> than most.** The framework's own SSR machinery **ships today**. Hicasso's
-> hydration door, `defhost`'s `:ssr` policy, the Node render entry, and the
-> spike witness set are **landed and witnessed in the bench arm**; the
-> production server arm is **not decided**. No `implementation/hicasso/`
-> artefact ships yet, spellings marked **[unfrozen]** stay provisional until
-> the API freeze, and an app that needs full production SSR today still has a
-> supported path through the first-class adapters — this page ends on exactly
-> that.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Behaviour matches the experimental arm under `implementation/freehand/test/re_frame/bench/hicasso/`. This page says what works there and what is still open.
 
-SSR is not a feature re-frame2 bolted on; it is one of the reasons the
-architecture looks the way it does. Spec 011 opens by calling it a core goal,
-and the decisions that make it cheap were taken long ago: views are pure
-functions of state, events are data, and a frame is cheap enough to create for
-one request and destroy when the response is written. Hicasso claims to be
-re-frame2's **native** view layer, so it has to hold up its end of that story —
-render on the server, adopt in the browser, and keep both sides honest.
+You want HTML on the first response, then the same app to take over in the browser — without writing the UI twice and without a second renderer that drifts. re-frame2 already treats that as a core goal: pure views, data events, a frame cheap enough to build for one request and tear down when the response is written. Hicasso is meant to be the native view layer in that story, so it has to render on the server, adopt in the browser, and stay honest about both.
 
 The design fits in a sentence:
 
-> **One renderer, run in two places, judged by the framework's hydration
-> machinery.**
+> **One renderer, run in two places, judged by the framework's hydration machinery.**
 
-The runtime that renders in the browser is the runtime that renders on the
-server; the framework's existing hydration path carries the result across;
-parity is construction, not a second emitter hoping to agree.
+## What SSR means here
 
-## The framework's story, which exists today
+The runtime that paints in the browser is the runtime that paints on the server. There is no separate HTML emitter hoping to match. The framework's existing hydration path carries the result across: a payload of app state plus a structural render hash goes into the page; the client seeds from that payload, verifies the first client tree against the server hash, and React's `hydrateRoot` keeps the server's nodes and attaches listeners.
 
-One app, written once, run twice. The runnable reference is the adapter-based
-example at `examples/capabilities/ssr` — a single `.cljc` file whose events,
-subscriptions and views are shared between the JVM and the browser, tested
-headlessly on every PR — and the published [SSR guide](../../../ssr/index.md)
-teaches it at corpus depth. The shape, in brief:
+Hicasso does not invent a parallel mechanism. It participates in the framework path — payload, `:rf/hydrate`, mismatch check, `ssr-ring` as the HTTP host — and only has to hold up its own end: render a tree on the server, and adopt that tree in the browser.
 
-**On the server, per request:**
+## The framework story today
 
-1. A fresh frame is created for the request — a gensym id, nothing shared —
-   and the incoming request rides in on a coeffect.
-2. `:initial-events` boots it: ordinary handlers run, effects marked
-   `:platforms #{:client}` are skipped, and app-db settles.
-3. The settled snapshot is rendered to an HTML string.
-4. The same state is serialised into the page — a
-   `<script id="__rf_payload" type="application/edn">` carrying the app-db
-   partition, the serialisable runtime slice, a protocol version and a
-   structural render hash, with `</script>`-safe escaping done by the
-   framework.
-5. The frame is destroyed in a `finally`. No leak per request, throw path
-   included.
+One app, written once, run twice. The runnable reference is `examples/capabilities/ssr` — one `.cljc` shared between JVM and browser, exercised headlessly on every PR. The published [SSR guide](../../../ssr/index.md) teaches the full corpus.
 
-**On the client, once:**
+**Server, per request:** create a fresh frame for that request; run `:initial-events` (client-only effects with `:platforms #{:client}` are skipped); render the settled snapshot to HTML; embed the serialised state and render hash in a framework-owned payload (`__rf_payload`); destroy the frame in a `finally`.
 
-1. `hydrate!` — the boot helper in `re-frame.ssr` — reads the payload by its
-   pinned id. A missing payload means nobody server-rendered this page, a
-   plain first load; a malformed one fails closed.
-2. It dispatches the reserved `:rf/hydrate` event **before the first render**.
-   The framework owns the handler, and the server's state **replaces** the
-   client's rather than merging into it — on this question the server is the
-   single source of truth.
-3. The first render is verified: the client hashes its own first render-tree
-   and compares it with the server's hash; disagreement raises
-   `:rf.ssr/hydration-mismatch` instead of quietly serving a subtly different
-   page.
-4. The DOM is adopted with React's `hydrateRoot` — the server's nodes are kept
-   and listeners attached, never thrown away and rebuilt.
+**Client, once:** `hydrate!` reads the payload, dispatches `:rf/hydrate` **before** the first render so the server's state *replaces* the client's, verifies the structural hash (disagreement raises `:rf.ssr/hydration-mismatch`), then adopts the DOM.
 
-None of that is Hicasso's to reinvent. Hicasso participates in the **existing**
-story — the payload, the `:rf/hydrate` door, the mismatch machinery, `ssr-ring`
-as the HTTP host — never a parallel Hicasso-only mechanism. Everything below is
-about the two places where a view layer has to hold up its own end: rendering
-on the server, and adopting in the browser.
+None of that is Hicasso-specific. Everything below is what the view layer adds on top.
 
-## What Hicasso adds, door by door
+## What Hicasso adds
 
-| Door | What it is | Status |
-|---|---|---|
-| The hydration door | `hydrate-root!` **[unfrozen]** beside `root!` — adopt server DOM into a live root | **Landed**, witnessed in the bench arm |
-| The `:ssr` host policy | `defhost` declares what a foreign region does server-side | **Landed**, witnessed |
-| The Node render entry | `renderToString` of the existing runtime, fixture bake, live demo | **Landed** in the bench arm (`ssr/entry.cljs`, `entry_cljs_test`) |
-| The spike witness | X1–X5 end-to-end on a hydrated screen | **Run** — measured rows exist in tests; no product verdict is claimed here |
-| The production server arm | JVM structural walk vs Node sidecar | **Not decided** |
+| Piece | Status |
+|---|---|
+| `hydrate-root!` **[unfrozen]** — adopt server DOM into a live root (same handle shape as `root!`) | Works in the experimental arm |
+| `defhost` `:ssr` — what a foreign region does server-side | Works |
+| Node render entry — existing runtime under `renderToString`, fixture bake, live demo | Works in the experimental arm |
+| End-to-end measurements on a hydrated screen | Have run; not a ship decision |
+| How production hosts will look | Not decided |
 
-"Landed" means what it means everywhere in this guide: witnessed by the bench
-arm's tests under
-`implementation/freehand/test/re_frame/bench/hicasso/`, with no
-`implementation/hicasso/` artefact anywhere. "Run" for the spike means the
-witness measurements exist; it does not mean a product go/no-go has been
-declared from them.
+The server engine is the client runtime under `react-dom/server`'s `renderToString`, so parity holds by construction. Under a server render every `sub` read is a cold probe: no durable registration, no effects, no commit. The per-request entry seeds app-db through the framework, renders, builds the framework payload, and destroys the frame — see `ssr/entry.cljs` under the experimental arm. That entry is **not** a production host; Spec 011's HTTP contract stays with `ssr-ring`.
 
-### The server engine is the client runtime
+A few properties of `hydrate-root!` matter when you write apps, not when you read status:
 
-The server engine is not a second renderer. It is the existing runtime run
-under `react-dom/server`'s `renderToString`, so hydration parity holds by
-construction — there is no separate emitter whose output could drift from what
-the client would have rendered. The property that makes this safe is already
-witnessed: every boundary shell passes a server snapshot to its
-`useSyncExternalStore`, so under a server render React never subscribes —
-every `sub` read is the mutation-free cold probe, no commit runs, no effect
-fires, and the render leaves **zero durable registration** behind. A server
-render is an abandoned render, and the runtime's ledger discipline already
-requires it to survive those.
+- It calls React's `hydrateRoot` without `flushSync`, so it returns before adoption finishes. Completion is observable; do not assume the DOM on the next line is already client-owned.
+- Presence children are **born present** — nothing that arrived with the page replays an entrance over content the user is already reading.
+- Hydration never rewrites controlled text after the fact. The model's value is the one truth from the first paint.
 
-The *entry* that runs it per request — a gensym frame, app-db seeded through
-the framework doors, `renderToString`, the payload built with the framework's
-own bytes, `destroy-frame!` in a `finally`, plus baked fixtures and a live
-page-level demo driver — is in the bench arm at `ssr/entry.cljs` and covered
-by `entry_cljs_test`. Two of its properties are requirements rather than
-aspirations: the render is deterministic (same bundle + same snapshot means
-byte-identical HTML, checked by double render), and the demo driver is
-**explicitly not a production host** — Spec 011's HTTP response contract stays
-`ssr-ring`'s.
+## Write the app so SSR is free
 
-SSR *speed*, meanwhile, is off the bar — fast applications, not fast SSR.
+Everything above is the runtime's problem. Whether SSR is cheap *for your app* is decided in how you write views and events — and every rule below is usable now.
 
-### The hydration door — landed
+**Keep view bodies portable.** A tier-1 `defview` body is hiccup, reads, and ordinary Clojure. No JS interop in the forms. JS lives at declared edges: `defhost` and host-edge namespaces ([Interop](05-interop.md)). Keep it there and view namespaces load anywhere — the precondition for every server story.
 
-`hydrate-root!` **[unfrozen]** stands beside `root!`
-([Getting started](01-getting-started.md)): the same association of a DOM
-node, a frame and one view, except the node already holds the server's markup
-and the frame has already adopted the server's state. It returns the same
-handle shape `root!` does, so teardown treats a hydrated root like any other.
+**Put events as data on the tree.** `[:todo/toggle id]` on `:on-click` has no closure to ship. The runtime builds the callback from the vector on whichever side is rendering. App state crosses the wire as EDN because it *is* data. There is no "serialise my functions" problem.
 
-Three of its properties are the reason this door is more than a thin wrap, and
-all three are witnessed (`arm1/hydrate_dom_cljs_test`):
+**A body is a function of its props and reads.** Same snapshot in, same tree out — that is what "render from a db snapshot" means, and what adoption demands. A clock, a `js/window` sniff, or a random in a body paints one thing on the server and another in the browser; React reports that as a hydration mismatch. Platform work belongs in effects (`:platforms #{:client}`) and at host edges, never in tier-1 bodies — the same purity [Views and reads](02-views-and-reads.md) already requires.
 
-- **It calls `hydrateRoot` plain — no `flushSync` — so it returns before
-  adoption completes.** React adopts concurrently; the DOM on the line after
-  the call is still the server's. Completion is observable rather than forced:
-  a closer component's passive effect ends the adoption window, the same
-  pattern the core substrate uses for its own hydration. (The reap horizon
-  that guards provisional subscription entries is margin, not contract — it
-  leaves adopted subscriptions alone, and no caller may rely on it.)
-- **Presence children are born present.** A node managed by presence hydrates
-  in its `:present` state: nothing that arrived with the page replays an
-  entrance over content the user is already reading, and server HTML does not
-  arrive carrying mounting-phase `opacity: 0` overrides.
-- **Hydration never converges controlled text.** A controlled input arrives
-  with React's `defaultValue` mirror intact and the model's value as the one
-  truth. There is no flash of server text corrected a beat later.
+**Controlled inputs are already SSR-shaped.** The value comes from the model ([Controlled inputs](04-controlled-inputs.md)); the server renders that value; hydration does not converge the text afterward. Nothing extra to write.
 
-One more, for the witnesses rather than the reader: the boundary memo never
-fakes adoption — body runs are counted, not inferred — which is what lets the
-spike below say "exactly one body pass" and mean it.
+**Do not gate entrances on "I just mounted."** Drive enter with insertion animation or `@starting-style` — [Ephemeral state](07-ephemeral-state.md)'s standing rule. The entrance is a CSS fact of the markup; adoption reuses the server's nodes, so it gets no second trigger. Presence handles the other half: a presence-managed node hydrates born-present, so nothing that arrived with the page replays an entrance.
 
-### The `:ssr` host policy — landed
-
-A foreign React component is exactly the node whose render may reach for
-`window`, and a declaration that names only the component tells the door
-nothing about that. So the declaration says it
-([Interop](05-interop.md) owns the door):
+**Declare each foreign region's server story at `defhost`:**
 
 ```clojure
 (h/defhost chart Chart)                                 ;; :client-only — the default
@@ -157,138 +64,34 @@ nothing about that. So the declaration says it
 (h/defhost chart Chart {:ssr {:fallback [:div.skel]}})  ;; that markup until adoption
 ```
 
-`:client-only` renders nothing where the host sits until the client has
-adopted the page; `{:fallback <hiccup>}` renders that markup there instead.
-There is no third value: a policy the gate does not recognise is refused at
-the declaration (`:rf.error/hicasso-host-bad-ssr-policy`), and an option
-`defhost` does not know is a refusal too
-(`:rf.error/hicasso-host-unknown-option`) rather than a silent ignore. One
-mechanism serves all three places the policy has to hold — the server render,
-hydration's first client pass, and a fresh client-only mount, which renders
-the foreign component immediately with no placeholder flash. Witnessed in
-`arm1/host_ssr_dom_cljs_test`. The honest cost: the gate is one fiber and one
-hook per declaration.
+`:client-only` renders nothing in that slot until the client has adopted; `{:fallback <hiccup>}` puts a skeleton there instead. Unknown policies fail at declaration (`:rf.error/hicasso-host-bad-ssr-policy`); unknown options fail too (`:rf.error/hicasso-host-unknown-option`). One declaration covers server render, the first client pass after hydration, and a fresh client-only mount (which mounts the foreign component immediately, with no placeholder flash).
 
-### The spike witness — measured
-
-Whether all of this works as **one page** is not this guide's to declare as a
-product verdict. The X1–X5 spike witness has **run**: tests drive a
-representative screen through the whole arc and report measured outcomes —
-byte-identical double render and canonical-DOM parity with a client-only mount;
-adoption with zero mismatch, server node identity preserved and exactly one
-body pass; reactivity adopted on React's own schedule; a multi-step real-DOM
-intent script driven at the hydrated screen, controlled-text echo included; and
-clean teardown. Those rows are evidence, not a ship decision. This page claims
-what was measured; it does not claim a product go/no-go.
-
-The **production server arm** remains open. One candidate is a JVM structural
-walk — pure analysis rules on the JVM, folded to HTML by the tree emitter the
-SSR artefact already ships, in-process with `ssr-ring` — which would also
-discharge most of [Testing](08-testing.md)'s headless door, since a structural
-render core is the larger half of one. Beside it: a Node sidecar behind an EDN
-render contract, with `ssr-ring` keeping HTTP either way. Neither is built as
-the production answer. Do not design a deployment against either yet.
-
-## Write the app so SSR is free
-
-Everything above is the runtime's problem. What makes SSR cheap or expensive
-in an *application* is authored long before a server enters the picture — and
-every rule below is usable now, because each one is a property the landed
-surface already has.
-
-**Bodies are portable by construction.** A tier-1 `defview` body is hiccup,
-reads and ordinary Clojure — no JS interop in the forms, the same property
-that gives the headless door its scope. JS lives at declared edges: `defhost`
-declarations and host-edge namespaces ([Interop](05-interop.md)). Keep it
-there and your view namespaces load anywhere, which is the precondition for
-every server story on the table.
-
-**Events are data, so nothing needs serialising.** `[:todo/toggle id]` at an
-`:on-click` has no closure to ship: the runtime builds the callback from the
-vector on whichever side is rendering, and a handler on the hydrated page is
-exactly the handler a fresh mount would have built. The same fact pays on the
-wire — app state crosses as EDN because it *is* data. There is no "serialise
-my functions" problem anywhere in this story.
-
-**A body is a function of its props and reads — keep it that way.** Same
-snapshot in, same tree out is what "render from a db snapshot" means, and it
-is also what adoption demands. A clock read, a `js/window` sniff or a random
-in a body renders one thing on the server and another in the browser, and
-React will report the disagreement as a mismatch. Platform differences belong
-in effects (`:platforms #{:client}` exists for exactly this) and at host
-edges, never in tier-1 bodies — which
-[Views and reads](02-views-and-reads.md) already requires: bodies are pure and
-re-runnable.
-
-**Controlled inputs are already SSR-shaped.** The value comes from the model
-([Controlled inputs](04-controlled-inputs.md)), the server renders the model's
-value, and hydration never converges the text. There is nothing to write and
-nothing to avoid; the one thing you would have had to worry about is the thing
-the door forecloses.
-
-**Entrances should not depend on being mounted.** Drive *enter* with an
-animation on insertion or `@starting-style` —
-[Ephemeral state](07-ephemeral-state.md)'s standing rule, and the SSR-friendly
-one: the entrance is a CSS fact of the markup, it runs at first paint, and
-adoption reuses the server's nodes rather than re-creating them, so it gets no
-second trigger. Presence handles the other half — a presence-managed node
-hydrates born-present, so nothing that arrived with the page replays an
-entrance.
-
-**Decide each foreign region's server story at its declaration.**
-`:client-only` when the region is genuinely browser-bound; `{:fallback …}`
-when a skeleton keeps the page's shape. One line, at the crossing, and it is
-the difference between "the chart area is blank until adoption" being a choice
-and being a surprise.
-
-Do all of that — which is to say, write idiomatic Hicasso — and SSR is not a
-rewrite waiting to happen. That is the design's actual bet: the app that is
-easiest to write is also the app that serves.
+Do all of that — write idiomatic Hicasso — and SSR is not a rewrite waiting to happen. The app that is easiest to write is also the app that serves.
 
 ## Non-goals
 
-Stated once so nobody reads silence as intent: **streaming**
-(`renderToPipeableStream` is out of scope), **React Server Components**,
-**islands / partial hydration**, **no-JS progressive enhancement** and **SEO
-metadata management** are not part of this story. Neither is SSR speed as a
-bar. The story is one page, rendered whole from a snapshot, adopted whole by
-the client.
+Out of scope for this story: **streaming** (`renderToPipeableStream`), **React Server Components**, **islands / partial hydration**, **no-JS progressive enhancement**, and **SEO metadata management**. SSR *speed* is not a bar either — fast applications, not fast SSR. The story is one page, rendered whole from a snapshot, adopted whole by the client.
 
 ## Troubleshooting
 
-The first two rows are the framework machinery's, live today under the
-adapters and inherited unchanged; the rest belong to the landed doors.
-
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| React reports a hydration mismatch during adoption | The client's first render disagreed with the server HTML — a body read the platform (a clock, `js/window`, a random) instead of being a function of props and reads | Keep bodies pure; platform work goes to effects (`:platforms #{:client}`) and host edges |
-| `:rf.ssr/hydration-mismatch` after the first render | The structural-hash verify: the client's first tree is not the one the server hashed — hydration ran after the first render, a seed overwrote the payload, or the two sides run different builds | `hydrate!` before anything renders; its whole job is holding read → hydrate → verify in that order |
-| A foreign component throws `window is not defined` in a server render | Its render reached for the browser, and a declaration that names only the component cannot know that | Declare the region's policy: `:client-only` (the default), or `{:fallback …}` under `:ssr` |
-| A controlled input's text jumps just after adoption | Not this design: hydration never converges controlled text, witnessed on the hydrated path | Seen under another stack, it means the server markup and the model disagreed — fix the state they share |
-| Frames accumulate on a long-running server | A request path that skips teardown | The per-request frame dies in a `finally`, throw path included — the reference example is the copyable shape |
+| React reports a hydration mismatch during adoption | The client's first render disagreed with the server HTML — a body read the platform (clock, `js/window`, random) instead of props and reads | Keep bodies pure; platform work goes to effects (`:platforms #{:client}`) and host edges |
+| `:rf.ssr/hydration-mismatch` after the first render | Structural-hash verify failed: hydrate ran after first render, a seed overwrote the payload, or the two sides run different builds | Call `hydrate!` before anything renders — read → hydrate → verify, in that order |
+| A foreign component throws `window is not defined` on the server | Its render reached for the browser, and a bare component name says nothing about that | Declare `:ssr :client-only` (default) or `{:fallback …}` on `defhost` |
+| A controlled input's text jumps just after adoption | Not this design: hydration does not converge controlled text | If you see it under another stack, the server markup and the model disagreed — fix the shared state |
+| Frames accumulate on a long-running server | A request path skipped teardown | Destroy the per-request frame in a `finally`, throw path included — copy the reference example |
 
-## When you need SSR today
+## When you need production SSR today
 
-Use a first-class adapter for a full production SSR app. The Reagent and UIx
-[adapters](../../../core/views.md) are supported, actively maintained, and
-carry the whole Spec 011 story end to end — the reference example at
-`examples/capabilities/ssr` is exactly that, runnable now. That is not a
-consolation: adapters remaining a production answer is a *successful* outcome
-([Getting started](01-getting-started.md) says the same about the whole of
-Hicasso).
+Use a first-class adapter. Reagent and UIx [adapters](../../../core/views.md) are supported, maintained, and carry Spec 011 end to end. `examples/capabilities/ssr` is that path, runnable now. Adapters remaining a production answer is a successful outcome, not a consolation.
 
-Hicasso's own doors — hydration, `:ssr` host policy, the Node render entry, the
-spike measurements — are **bench-witnessed**. They prove the design holds under
-the arm's tests; they are not yet a product package under
-`implementation/hicasso/`. What this chapter still gives an adapter user is the
-authored-code discipline above, most of which — events as data, pure bodies,
-platform work in effects — is portable re-frame2 rather than Hicasso, and costs
-nothing to adopt early.
+Hicasso's hydration path, `:ssr` host policy, Node render entry, and end-to-end measurements work under the experimental arm; they are not yet a product package under `implementation/hicasso/`. What this chapter still gives you, on any substrate, is the authored discipline above — pure bodies, events as data, platform work in effects — which is portable re-frame2 and costs nothing to adopt early.
 
-## Not settled yet
+## Not settled
 
 | Question | Status |
 |---|---|
-| The production server arm | **Not decided**: a JVM structural walk (default direction to be priced; it would co-discharge the headless testing door) vs a Node sidecar behind an EDN render contract. `ssr-ring` keeps Spec 011's HTTP response contract either way |
-| How the boot composes at the product surface | **Not addressed.** The bench door associates a container, a frame and a view; the framework's `hydrate!` seeds and verifies state before first render. Whether the product artefact offers one operation or two — and where `:initial-events` sits on a hydrating load — is unstated |
-| The spellings | `hydrate-root!` is a bench-arm name, as `root!` was before it; every spelling on this page is **[unfrozen]** until the API freeze |
+| Production host shape | Not decided: JVM structural walk (in-process with `ssr-ring`) vs a Node sidecar behind an EDN render contract. `ssr-ring` keeps Spec 011's HTTP contract either way. Do not design a deployment against either yet. |
+| How boot composes once there is a product package | Open. Today the experimental path associates a container, a frame, and a view; framework `hydrate!` seeds and verifies state before first render. Whether the product offers one operation or two — and where `:initial-events` sits on a hydrating load — is unstated. |
+| Spellings | `hydrate-root!` and every other name on this page are **[unfrozen]** until the API freeze. |

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -1,12 +1,10 @@
 # Hicasso — draft user guide
 
-> **Draft ahead of the product artefact.** No `implementation/hicasso/` ships yet.
-> Spellings marked **[unfrozen]** are provisional until the API freeze. Behaviour
-> shown here is witnessed under `implementation/freehand/test/re_frame/bench/hicasso/`.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Behaviour matches the experimental arm under `implementation/freehand/test/re_frame/bench/hicasso/`.
 
 Hicasso is re-frame2's native view layer: interpreted Hiccup on a React
-function-component host, built for re-frame2. This guide answers one question —
-**what does a programmer actually type?**
+function-component host. This guide answers one question — **what does a
+programmer actually type?**
 
 | Page | Its one job |
 |---|---|
@@ -19,25 +17,18 @@ function-component host, built for re-frame2. This guide answers one question �
 | [Ephemeral state](07-ephemeral-state.md) | Decide where "is this dropdown open?" lives, given there is no `local`; where "it left but is still fading out" lives, given app-db cannot hold it; and where the jobs you wanted `:on-mount` for actually go |
 | [Testing](08-testing.md) | Assert a view's output without a browser, and know when you still need one |
 | [When a view throws](09-when-a-view-throws.md) | Keep one broken view from taking the page down with it |
-| [Server-side rendering](10-server-side-rendering.md) | Serve a page rendered from a db snapshot and adopt it live in the browser — what is witnessed, what is still open, and how to write an app so SSR is free |
+| [Server-side rendering](10-server-side-rendering.md) | Serve a page rendered from a db snapshot and adopt it live in the browser |
 
 ## How to read the markers
 
-**[unfrozen]** after a name means the *semantics* are pinned but the *spelling*
-is a placeholder until the API freeze. Prefer the behaviour over the token.
+**[unfrozen]** after a name means the *behaviour* is fixed but the *spelling*
+may still change. Prefer the behaviour over the token.
 
-Each page ends with **Not settled yet** — open questions that page raises which
-are not yet answered. Those tables hold only the question and its status; they
-are not a backlog of design history.
+Each page ends with **Not settled yet** — short open questions for that page.
+Not a design backlog; just what is still open for a reader of that topic.
 
 ## What this draft is not
 
-- **Not published.** `design/hicasso/` is in `exclude_docs` in `mkdocs.yml`, so
-  this subtree never reaches the site and is never in the nav. Read it in the
-  source tree or on GitHub. Because it is raw Markdown, banners and asides are
-  blockquotes rather than MkDocs admonitions.
-- **Not an API freeze.** Names marked **[unfrozen]** wait; landed behaviour is
-  what the bench arm already runs.
-
-The design record for Hicasso lives in the parent directory for contributors;
-you do not need it to read this guide.
+- **Not published.** `design/hicasso/` is excluded from the MkDocs site; read it
+  in the source tree or on GitHub. Banners are blockquotes, not admonitions.
+- **Not an API freeze.** Names marked **[unfrozen]** may still change.


### PR DESCRIPTION
## Summary

Follow-up to #7482. That PR cleaned residue (beads, HD refs, status tables); this one does the **voice** work against `docs/AUTHORING.md` and the published core register (`docs/core/views.md`).

### What changed
- Shared short draft banner; killed `surface` / door-as-everything / witnessed-landed essays / programme status dumps
- Problem open → code → short why; pull-quotes where they earn keep
- Optional depth moved under `## Advanced` (memo collector, IME mechanics, imperative SDKs)
- Large cuts: ~1600 lines removed vs ~800 added across the 11 draft-guide pages
- 10 (SSR) rewritten around author discipline, not door inventory
- Anchor links updated for retitled headings; `check_doc_slugs.py` green

### Why
A tired peer should nod at the word choice. Previous pass still read like a design-record brief.

## Gate notes
- `design/hicasso/` is `exclude_docs`; slug checker is the real gate
- `python scripts/check_doc_slugs.py` exit 0
- Anchors/tables checked by hand

## Test plan
- [x] `python scripts/check_doc_slugs.py`
- [ ] Spot-read 01, 04, 09, 10 against `docs/core/views.md` register