### PR TITLE
docs(hicasso): the IME commit consequence, and 'boundary' means one thing (rf2-2rtt6.101, rf2-2rtt6.102)

### DIFF
--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -140,7 +140,7 @@ than `:rf.error/*` ids.
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | `sub` throws outside a view | `sub` is render-scoped; there is no `@`-anywhere in Hicasso | Use `rf/subscribe-once` in handler and utility code |
-| Async callback dispatches and nothing happens | A bare `dispatch` from a timeout has no frame | Callbacks from intent vectors carry their boundary's frame; hand-written async needs the frame explicitly |
+| Async callback dispatches and nothing happens | A bare `dispatch` from a timeout has no frame | Callbacks from intent vectors carry their [boundary](02-views-and-reads.md#boundaries-and-inlining)'s frame; hand-written async needs the frame explicitly |
 | First paint shows empty state, then flickers | Seeding raced the first render | Seed through `:initial-events`, not a post-mount dispatch |
 | A view renders twice on mount in dev | React StrictMode double-invokes bodies | Nothing to fix — bodies are pure and re-runnable by contract |
 | Second `h/root!` on the same node | The node already has a live root | Keep the root in a `defonce`; call the teardown before re-rooting |

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -39,16 +39,19 @@ visible in the syntax.
 (todo-row {:id id})           ;; a call — INLINED into the enclosing boundary
 ```
 
-A **vector** in head position mints a React element. It is its own boundary:
-React owns its identity, and it can re-render without its parent.
+A **vector** in head position mints a React element, and that element is a
+**boundary** — Hicasso's unit of independent re-rendering. A boundary owns four
+things: React's identity for it, the `sub` reads its body makes, its
+[value-equality bail-out](#boundaries-memoize-by-default), and the frame the
+intents in its hiccup dispatch to.
 
-A **plain call** is just a function call. Its hiccup is spliced into the
-caller's tree, it has no boundary of its own, and any `sub` it performs donates
-that read *upward* to the enclosing boundary. Helpers cost nothing at runtime
-and buy no re-render granularity. And because reads are ordinary calls,
-**helpers can read**: a `filter-button` that needs the current filter just
-reads it, and the read belongs to whichever boundary is rendering — no value
-threaded down as an argument.
+A **plain call** is just a function call, and owns none of them. Its hiccup is
+spliced into the caller's tree, and any `sub` it performs donates that read
+*upward* to the enclosing boundary. Helpers cost nothing at runtime and buy no
+re-render granularity. And because reads are ordinary calls, **helpers can
+read**: a `filter-button` that needs the current filter just reads it, and the
+read belongs to whichever boundary is rendering — no value threaded down as an
+argument.
 
 One rule, one visible distinction. Re-render granularity is something you should
 see by reading the source. Keys go in the props map (no Reagent `^{:key}`
@@ -232,8 +235,7 @@ the collector mechanics.
 
 Not every function needs to be a view. If a piece of markup has no reads of its
 own and always re-renders with its parent anyway, a plain function is cheaper
-and simpler — no element, no identity, no index membership. Boundaries are for
-*re-render granularity*. Reach for one when you want something to update
+and simpler. Reach for a boundary when you want something to update
 independently, not because the markup got long.
 
 ## Advanced

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -91,6 +91,7 @@ carries the revision is still unnamed; see **Not settled yet**.
 | Caret jumps to the end on every keystroke | Value reasserted without caret preservation | Runtime bug, not your view — report it |
 | Enter commits half-typed text mid-composition | A hand-written key handler that bypasses the intent path | Use the data key-map; the composition check lives there |
 | Composition dies when the model refuses mid-draft | A value write during composition (browser treats that as abort) | Not this runtime on controlled text: composition is left alone until `compositionend` |
+| An IME commit lands stale text, then corrects itself | Something async sat between keystroke and commit, so `compositionend` reconciled the field against a model the deferred write had not reached yet | Keep the controlled write synchronous. The composition survives either way — only what it commits is late |
 | Typing the "reset" value clears the field | Reset keyed on value equality somewhere | Reset on an explicit revision |
 | Focus lost after validation fails | Something remounted the node | Do not remount to reset — that is exactly what destroys focus |
 
@@ -146,7 +147,10 @@ the user commits it, and the refusal or normalisation applies whole at
 That last point differs from plain React. On plain React a corrected value written
 during composition can abort the exchange: in-flight kana vanish, `compositionend`
 never fires, and the next update starts a fresh composition on a half-written
-draft. Hicasso carves the live composition out of that restore on purpose.
+draft. On a *normalising* field it does not merely lose the composition — each
+aborted draft is written back and the IME composes on top of it, so `s`, `sh`,
+commit ends the model at `SSHSH` where Hicasso commits the `SH` that was typed.
+Hicasso carves the live composition out of that restore on purpose.
 
 Scope: controlled **text** entry (same path as the rest of this page). Composition
 behaviour is proven on Chromium; a WebKit IME misbehave is a bug report, not a

--- a/docs/design/hicasso/draft-guide/09-when-a-view-throws.md
+++ b/docs/design/hicasso/draft-guide/09-when-a-view-throws.md
@@ -20,7 +20,9 @@ box around the broken component.
 ```
 
 If `article-body` throws, the header and footer stay up and the paragraph takes
-its place. Nothing else in the tree notices.
+its place. Nothing else in the tree notices. `h/boundary` is a component you
+write; it is not the [rendering boundary](02-views-and-reads.md#boundaries-and-inlining)
+every vector child mints. Same word, different thing, and only this one catches.
 
 ## The three keys
 


### PR DESCRIPTION
Two P3 draft-guide beads on one surface. **Net +8 lines** across four files (23 insertions, 15 deletions; the guide goes 1867 → 1875 — `01` ±0, `02` +2, `04` +4, `09` +2). The guide came out of three passes today at 1867 lines and the bar for adding words is correspondingly high, so both beads are answered by definition and precision rather than by exposition — no new section, no glossary, no page.

## rf2-2rtt6.101 — the IME commit consequence and the corruption finding

**The tick-late consequence** is one troubleshooting row on `04-controlled-inputs.md`, beside the two IME rows already there:

> | An IME commit lands stale text, then corrects itself | Something async sat between keystroke and commit, so `compositionend` reconciled the field against a model the deferred write had not reached yet | Keep the controlled write synchronous. The composition survives either way — only what it commits is late |

The row reuses the rule the page already teaches three rows up ("keep the controlled write synchronous; debounce *consumers*, not the write") and adds the half a reader cannot infer: the composition is safe regardless of timing, and only the commit is late. That second clause matters — without it the row reads as "async breaks IME", which is false.

**Mechanism, from the source rather than invented.** Both halves of the carve-out are timing-independent by construction: the converge declines on `(.-isComposing (.-nativeEvent e))`, read off the event and not the clock, and the composition shadow holds `(.-value (.-target e))` — the *live DOM draft* — so React's own `element.value !== value` guard finds nothing to write. Neither consults the model. At `compositionend` the handler releases the shadow and calls `converge!`, which flushes the pending commit and writes `last-rendered` — the model *as it stands then*. With an async gap there is no pending commit to flush, so the stale model is written, and the deferred write later corrects the field through the ordinary render path. (`implementation/freehand/test/re_frame/bench/hicasso/front/controlled.cljs` — `composing-input?`, `shadowed-props`, `converge-to!`.)

**Measurement status, stated plainly:** this is a mechanical consequence of the carve-out, not a measured row. `ime_run.cjs` has five scenarios (carriage, composing Enter, keyCode-229, cancel, mid-composition) and none of them defers the model write. The row is therefore worded to be true of *any* deferral length — "stale text, then corrects itself" — rather than claiming a specific one-tick flicker. Nothing here needs a ruling, so nothing is marked open on that account.

**The corruption finding** replaces the divergence paragraph's kana-vanish-only wording:

> On a *normalising* field it does not merely lose the composition — each aborted draft is written back and the IME composes on top of it, so `s`, `sh`, commit ends the model at `SSHSH` where Hicasso commits the `SH` that was typed.

Evidence: `docs/design/hicasso/studio/controlled-input-two-implementations.md:243-256` (the pinned `upper` matrix, model `"SH"` vs `"SSHSH"`), HD-019's 2026-08-03 addendum in `decisions.md:596-599`, and the `comparative:` assertion in `ime_run.cjs:677-680`. The page's existing Chromium-only scope note two paragraphs down already covers the claim.

**Wording cross-check, no edits made.** `authoring.md`'s controlled-input-door section and `validation.md:467-475` both carry the divergence and the Chromium scope but not the corruption detail; `fitness-harness.md:117` and `decisions.md` carry it in full. The guide's new sentence is a subset of the fuller sites and contradicts none of them, so nothing outside the guide needed touching.

## rf2-2rtt6.102 — 'boundary' means one thing

The five loads, and what each became:

| Load | Where | What it became |
|---|---|---|
| Granularity — the unit of independent re-rendering | `02:32-51` "Boundaries and inlining" | Now the definition's opening clause; the restatement in 02's "When not to use a boundary" is deleted as redundant |
| Identity — React owns the element | `02:42-43` | Folded into the definition as one of the four things a boundary owns |
| Read attachment — reads belong to the rendering boundary | `02:47-51`, `05:145` | Folded into the definition; the downstream prose now reads against it |
| Memo — the value-equality bail-out | `02:101` "Boundaries memoize by default" | Kept where it is; the definition links to it, so the section stays the owner and the definition stays a pointer |
| Frame carrier — the frame a boundary's intents dispatch to | `01:143`, `03:220`, `05:98`, `09:58/63/102` | Folded into the definition — it had no home at the definition site at all. `01:143` now deep-links to it |

One sentence at the definition site, not four renames. **The brief proposed renaming the four non-nominal loads at their use sites; that is not the right fix here and I did not do it.** Four of the five are one concept seen from four angles — a boundary genuinely *is* the thing that owns the frame and owns the reads — so renaming "the boundary's frame" would make the guide less accurate, not less overloaded. What was actually missing was that no single place said a boundary owns all four, so each site taught its own aspect and the reader assembled five words. The definition costs five lines and lets four sites stay as written.

The definition, in `02`:

> A **vector** in head position mints a React element, and that element is a **boundary** — Hicasso's unit of independent re-rendering. A boundary owns four things: React's identity for it, the `sub` reads its body makes, its value-equality bail-out (linked to the section below), and the frame the intents in its hiccup dispatch to.
>
> A **plain call** is just a function call, and owns none of them. […]

`09-when-a-view-throws.md` gains one distinguishing sentence immediately after the opening example, where `h/boundary` first appears in prose:

> `h/boundary` is a component you write; it is not the [rendering boundary](02-views-and-reads.md#boundaries-and-inlining) every vector child mints. Same word, different thing, and only this one catches.

**Grep sweep — one deliberate no-op.** `05:98` ("under the frame of the boundary that supplied the callback") reads unambiguously in context: chapter 05 has no `h/boundary` mention, and its other three uses (`:133`, `:145`, `:175`) are all the rendering sense. A deep link there would be noise, so it was not added. `03:193-194` and `03:220` likewise read correctly against the new definition. The bead licences judgement and minimal edits here, and this is the judgement.

## FLAG, not a decision: the `h/boundary` name collision

`h/boundary` **[unfrozen]** is the error-boundary component; a *boundary* is also every view mounted as a vector child. This PR flags the collision for whoever freezes that API name and does not act on it — a docs worker does not rename surface. Chapter 09 now warns the reader that the word does two jobs, which is the most a docs change should do. `09`'s "Not settled yet" table already carries the name as unfrozen; if the name changes, the distinguishing sentence is the thing to delete.

## Anti-regression

`spec/**`, `implementation/**`, `decisions.md` and `validation.md` are untouched. No API is renamed, no ruling is taken, and `rf2-digtt` and `rf2-47sko` are cited, not reopened. No new samples were added, so there is no runnable snippet to be wrong.

## Quality gates

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine`, classified `docs=true jvm=false node=false` |

**`mkdocs build --strict` is not nominated and proves nothing here.** `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site, so the spine's mkdocs step exits 0 having verified none of this diff. The anchor validator is the gate that actually reaches this tree, and it ran inside the spine ("docs corpus anchor validator") as well as standalone.

**Mutation proof that the slug checker can fail.** With `#boundaries-and-inlining` → `#boundaries-and-inlining-BOGUS` in `09`, `check_doc_slugs.py` exited **1** with `BROKEN ANCHOR: …09-when-a-view-throws.md:24 -> 02-views-and-reads.md#boundaries-and-inlining-BOGUS`. Restored, it exits **0**. Exit 0 on this diff is therefore load-bearing rather than vacuous.

**Gap-map lane.** `scripts/check_fast_pr_gap.py --list` names nine `check_*.py` invocations inside docs.yml's MkDocs job with no local lane in the spine. All nine were run here, self-tests included — `check_retired_composition_vocab` in particular, since this diff adds a lot of the word *composition*:

`check_doc_slugs --self-test` 0 · `check_failure_corpus_residue` 0 / `--self-test` 0 · `check_inject_cofx_residue` 0 / `--self-test` 0 · `check_retired_composition_vocab` 0 / `--self-test` 0 · `check_retired_image_keys` 0 / `--self-test` 0

**Anchors, hand-verified.** Two anchors are introduced, both copied from an anchor already in use rather than derived (the slug trap: python-markdown collapses hyphen runs and GitHub does not; neither of these contains one).

| Link | Target heading | Verdict |
|---|---|---|
| `02:45` → `#boundaries-memoize-by-default` (same page) | `### Boundaries memoize by default`, `02:101` | Resolves. Identical to the anchor `06:92` already uses — **that inbound link is unchanged and still resolves** |
| `01:143` → `02-views-and-reads.md#boundaries-and-inlining` | `## Boundaries and inlining`, `02:32` | Resolves |
| `09:24` → `02-views-and-reads.md#boundaries-and-inlining` | same | Resolves |

No heading was added, renamed or removed anywhere in this diff, so no inbound-link sweep was required; the two pre-existing inbound links into `02` (`#the-component-abi` and `#boundaries-memoize-by-default`, both from `06`) are the complete set and both still resolve.

**Table columns, hand-verified.** Nothing validates tables, so every table in all four touched files was counted row by row.

| File | Table | Columns | Rows (incl. header + rule) |
|---|---|---|---|
| `01` | Troubleshooting `:140-146` — **edited cell** | 3 | 7 |
| `01` | Not settled yet `:159-164` | 2 | 6 |
| `02` | Component ABI `:76-81` | 5 | 6 |
| `02` | Troubleshooting `:224-232` | 3 | 9 |
| `02` | Not settled yet `:269-273` | 2 | 5 |
| `04` | Troubleshooting `:88-96` — **row added at `:94`** | 3 | 9 |
| `04` | Not settled yet `:161-166` | 2 | 6 |
| `09` | The three keys `:33-37` | 3 | 5 |
| `09` | Troubleshooting `:99-106` | 3 | 8 |
| `09` | Not settled yet `:117-121` | 2 | 5 |

The two edited tables are the `01` and `04` troubleshooting tables; both are 3-column throughout, and neither edited cell introduces or removes a pipe.
