### PR TITLE
fix(bench): an unadjudicated row cannot exit 0 (rf2-y7mw7)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 'use strict';
-// THE HD8/CENSUS CLOCK DRIVERS' EXIT PATH — a printed refusal must refuse.
-// rf2-rr6do, following rf2-tb345's repair of the same defect in b8_run.cjs.
+// THE HICASSO CLOCK DRIVERS' EXIT PATH — a printed refusal must refuse.
+// rf2-rr6do, following rf2-tb345's repair of the same defect in b8_run.cjs,
+// and rf2-y7mw7, which found the twenty-fourth instance of it — in
+// `clock_run.cjs`, the driver this file's header once held up as the correct
+// shape.
 //
 //     node freehand/test/re_frame/bench/hicasso/clock_exit_path.test.cjs
 //
@@ -32,6 +35,14 @@
 //
 // THE CORRECT SHAPE ALREADY EXISTED: `clock_run.cjs` gates all three. This
 // is that shape, made checkable.
+//
+// AND THEN `clock_run.cjs` ITSELF (rf2-y7mw7). It gated all three and still
+// exited 0 on a row it had adjudicated NOTHING on: it computes a row-level
+// control verdict and a bar-level adjudication independently, and only the
+// first reached the exit code. `HCLOCK_ONLY=keystroke` alone printed
+// `[clock] ok` for a run whose every bar it had just labelled UNADJUDICATED.
+// Its decision now has one seat too, and the last section of this file is
+// that seat's fixtures plus the wiring that makes them load-bearing.
 //
 // Wired into implementation/package.json via `test:script-helpers`.
 
@@ -300,6 +311,142 @@ test('census P4 is now KEPT: its own prediction of a refusal reaches the exit', 
   const band = verdict({ failed: null, rows: [row({ ceilingBreached: true, band: 0.4 })] });
   assert.notStrictEqual(band.code, 0, 'P4 promises a refusal when the band cannot hold');
 });
+
+// --- clock_run.cjs: the bar-level adjudication must reach the exit code -------
+//
+// rf2-y7mw7. `clock_run.cjs` is the candidate clock and needs an `:advanced`
+// build and a headless Chromium, so — exactly as above — its decision is a
+// pure function over a flat per-row summary and is exercised here directly.
+
+{
+  const CLOCK = path.join(__dirname, 'clock_run.cjs');
+  const { reportability, reportabilitySelfTest } = require('./clock_run.cjs');
+  const SRC = fs.readFileSync(CLOCK, 'utf8');
+  const t = (what, fn) => test(`clock_run.cjs: ${what}`, fn);
+  const KEYSTROKE_WHY = "UNADJUDICATED — this row's control burns a fixed 50 ms rather than doubling the page";
+  const clockRow = (over) => ({ rowId: 'M1', ctlOk: true, ctlNote: '', adjudicable: true, ...over });
+
+  // --- the driver's own fixtures, which `--selftest` also runs --------------
+
+  t("the decision's own self-test passes, every case", () => {
+    const { checks } = reportabilitySelfTest();
+    assert.ok(checks.length >= 10, `expected the decision's fixtures, got ${checks.length}`);
+    const bad = checks.filter((c) => !c.ok);
+    assert.deepStrictEqual(bad, [], bad.map((c) => `${c.name}: ${c.detail}`).join('\n'));
+  });
+
+  // --- the defect itself, driven here as well as in the driver -------------
+
+  t('THE FAIL-OPEN: a row whose every bar is UNADJUDICATED cannot exit 0', () => {
+    const v = reportability([
+      clockRow({ rowId: 'keystroke', adjudicable: false, unadjudicatedWhy: KEYSTROKE_WHY }),
+    ]);
+    assert.notStrictEqual(v.code, 0, 'a run with no adjudicable bar must not exit 0');
+    assert.strictEqual(v.code, 1);
+    assert.match(v.lines[0], /no published bar can be ADJUDICATED on: keystroke/);
+    assert.match(v.lines[1], /keystroke: UNADJUDICATED/);
+    assert.strictEqual(v.lines[2], '[clock] REPORTABLE: none.');
+  });
+
+  t('a row that adjudicated NO bar at all fails closed rather than open', () => {
+    // The summary the driver builds sets `adjudicable` false when the verdict
+    // carries no bars, so a verdict that went missing refuses instead of
+    // passing quietly — the same reason `seam.cjs` refuses a NaN band.
+    const v = reportability([clockRow({ adjudicable: false, unadjudicatedWhy: undefined })]);
+    assert.strictEqual(v.code, 1);
+    assert.match(v.lines[1], /M1: no proportional control on this row/);
+  });
+
+  t('a genuinely reportable run still exits 0 and says nothing', () => {
+    const v = reportability([clockRow({}), clockRow({ rowId: 'bulk300' })]);
+    assert.deepStrictEqual(v, { code: 0, lines: [] });
+  });
+
+  t('a bar INSIDE the band is adjudicated, so an instrument-limited row still exits 0', () => {
+    // `LIMITED` is a verdict. Only `UNADJUDICATED` is the absence of one, and
+    // conflating them would turn this gate into a magnitude gate.
+    assert.strictEqual(reportability([clockRow({ adjudicable: true })]).code, 0);
+  });
+
+  // --- the control gate is UNCHANGED, which is half the repair --------------
+
+  t('a failed positive control alone still exits 1, exactly as before', () => {
+    const v = reportability([clockRow({ ctlOk: false, ctlNote: ' (three-point 1.2134x vs 2.0101x)' })]);
+    assert.strictEqual(v.code, 1);
+    assert.match(v.lines[0], /the positive control did not see the change its own arithmetic predicts on: /);
+    assert.match(v.lines[0], /M1 \(three-point 1\.2134x vs 2\.0101x\)/);
+    assert.match(v.lines[0], /No MAGNITUDE from those rows is reportable/);
+  });
+
+  t('the control refusal is still per-row: the rows that passed are still rows', () => {
+    const v = reportability([clockRow({}), clockRow({ rowId: 'narrow', ctlOk: false })]);
+    assert.strictEqual(v.code, 1);
+    assert.match(v.lines[v.lines.length - 1], /^\[clock\] REPORTABLE: M1 —/);
+  });
+
+  t('HCLOCK_CTL3_SABOTAGE still declares the run a falsification', () => {
+    const v = reportability([clockRow({ ctlOk: false })], { sabotage: 140 });
+    assert.strictEqual(v.code, 1);
+    assert.match(v.lines[1], /HCLOCK_CTL3_SABOTAGE=140 WAS SET/);
+  });
+
+  t('neither verdict masks the other — a row failing both is refused for both', () => {
+    const v = reportability([
+      clockRow({ rowId: 'keystroke', ctlOk: false, adjudicable: false, unadjudicatedWhy: KEYSTROKE_WHY }),
+    ]);
+    assert.strictEqual(v.code, 1);
+    assert.match(v.lines[0], /positive control/);
+    assert.match(v.lines[1], /no published bar can be ADJUDICATED/);
+    assert.strictEqual(v.lines[3], '[clock] REPORTABLE: none.');
+  });
+
+  // --- and the sentence that invited the publication -----------------------
+
+  t('REPORTABLE no longer says "Publish those" without saying "adjudicated"', () => {
+    const v = reportability([clockRow({}), clockRow({ rowId: 'keystroke', adjudicable: false })]);
+    const line = v.lines[v.lines.length - 1];
+    assert.match(line, /every published bar adjudicated against this run's own band/);
+    assert.doesNotMatch(line, /keystroke/, 'an unadjudicated row must never appear in REPORTABLE');
+  });
+
+  // --- the wiring: `reportability` is load-bearing, not decorative ----------
+
+  const MAIN = SRC.slice(SRC.indexOf('async function main()'), SRC.indexOf('\nmodule.exports'));
+
+  t('the driver exposes its decision and does not drive itself on require', () => {
+    assert.ok(MAIN.length > 0, 'the driver must expose its run as `main`');
+    assert.match(SRC, /module\.exports = \{ reportability, reportabilitySelfTest \};/);
+    assert.match(SRC, /if \(require\.main === module\) \{\s*main\(\);/);
+  });
+
+  t('the summary reads the adjudication the report printed, rather than recomputing it', () => {
+    // A second computation is a second decision, and a second decision is
+    // this whole file's subject.
+    assert.match(MAIN, /o\.verdict\.seamTask && o\.verdict\.seamTask\.rows/);
+    assert.match(MAIN, /adjudicable: names\.length > 0 && unadj\.length < names\.length,/);
+  });
+
+  t('the exit code comes from `reportability` and from nothing else', () => {
+    assert.match(MAIN, /for \(const line of decision\.lines\) console\.error\(line\);/);
+    assert.match(MAIN, /if \(decision\.code !== 0\) process\.exit\(decision\.code\);/);
+    const tail = MAIN.slice(MAIN.indexOf('for (const line of decision.lines)'));
+    assert.strictEqual(
+      (tail.match(/process\.exit/g) || []).length,
+      1,
+      'the decision must have ONE seat — a second exit below it is a second decision'
+    );
+    assert.ok(
+      !/ctlBad\(|seamTask|unadjudicated|ctlFailed/.test(tail),
+      'nothing downstream of the decision may read a refusal on its own'
+    );
+  });
+
+  t('`--selftest` runs the decision, so an operator sees it before the browser opens', () => {
+    const block = SRC.slice(SRC.indexOf('if (SELFTEST_ONLY) {'), SRC.indexOf('if (!NO_BUILD)'));
+    assert.match(block, /reportabilitySelfTest\(\)/);
+    assert.match(block, /\[\.\.\.g\.checks, \.\.\.s\.checks, \.\.\.x\.checks\]\.filter/);
+  });
+}
 
 let failed = 0;
 for (const [name, fn] of tests) {

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_readjudicate.cjs
@@ -128,13 +128,26 @@ for (const rowId of rowIds) {
     if (!task.some(Number.isFinite)) continue;
 
     // The REPORTABLE subset, beside the whole ensemble and never instead of
-    // it. A run is reportable on this row when its control held AND its band
-    // stayed under the ceiling — the ceiling is a whole-run refusal that
-    // fires before any control is consulted, so a run that breached it
-    // contributes no magnitude even if its control passed.
+    // it. A run is reportable on this row when its control held, its band
+    // stayed under the ceiling, AND the row has an adjudicated bar at all —
+    // the ceiling is a whole-run refusal that fires before any control is
+    // consulted, so a run that breached it contributes no magnitude even if
+    // its control passed.
+    //
+    // THE THIRD TERM IS rf2-y7mw7's, and it was missing here for the same
+    // reason it was missing from the driver's exit code: a row whose bars are
+    // all UNADJUDICATED has a magnitude and no band to tell it from parity,
+    // and this function prints its ensemble mean under the label
+    // "control-passing subset". A dataset that stored no bar verdict at all
+    // is not adjudicated either — absent is not clean.
+    const adjudicated = (row) => {
+      const bars = (row.seamTask && row.seamTask.rows) || {};
+      const names = Object.keys(bars);
+      return names.length > 0 && names.some((n) => !bars[n].unadjudicated);
+    };
     const reportable = ({ row }) =>
       row.ctlTask && row.ctlTask.ok && !(row.seam && row.seam.verdict && row.seam.verdict.ceilingBreached) &&
-      !(row.seamTask && row.seamTask.ceilingBreached);
+      !(row.seamTask && row.seamTask.ceilingBreached) && adjudicated(row);
     const passIdx = runs.map((r, i) => (reportable(r) ? i : -1)).filter((i) => i >= 0);
     const taskPass = passIdx.map((i) => task[i]);
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -1744,7 +1744,8 @@ function reportability(rows, opts) {
   const list = Array.isArray(rows) ? rows : [];
   const sabotage = (opts && opts.sabotage) || null;
   const ctlFailed = list.filter((r) => !r.ctlOk);
-  const passed = list.filter((r) => r.ctlOk).map((r) => r.rowId);
+  const unadjudicated = list.filter((r) => !r.adjudicable);
+  const passed = list.filter((r) => r.ctlOk && r.adjudicable).map((r) => r.rowId);
   const lines = [];
   if (ctlFailed.length > 0) {
     lines.push(
@@ -1760,14 +1761,115 @@ function reportability(rows, opts) {
       );
     }
   }
-  if (ctlFailed.length === 0) return { code: 0, lines };
+  // AND A ROW MAY HAVE NO ADJUDICABLE BAR AT ALL (rf2-y7mw7). This is a
+  // different claim from the control's and it used to reach nothing: the
+  // driver labelled every bar on such a row UNADJUDICATED four hundred lines
+  // above, then exited 0 because the control had passed. A control that
+  // passes certifies the instrument had SIGNAL; it does not supply the band a
+  // magnitude is adjudicated AGAINST, and a driver that cannot adjudicate a
+  // figure may not announce it. Refused after the control and never instead
+  // of it — a row can fail both, and both are said.
+  if (unadjudicated.length > 0) {
+    lines.push(
+      `[clock] FAILED: no published bar can be ADJUDICATED on: ` +
+        `${unadjudicated.map((r) => r.rowId).join(', ')}. The row has a magnitude and nothing to tell it ` +
+        `from parity, so no figure from it is reportable — a passing control is not a band:`
+    );
+    for (const r of unadjudicated) {
+      lines.push(`[clock]   ${r.rowId}: ${r.unadjudicatedWhy || 'no proportional control on this row'}`);
+    }
+  }
+  if (ctlFailed.length === 0 && unadjudicated.length === 0) return { code: 0, lines };
   lines.push(
     passed.length > 0
       ? `[clock] REPORTABLE: ${passed.join(', ')} — control passed, guard clean, canonical DOM identical, ` +
-          `0 unverified. Publish those and mark the rest.`
+          `0 unverified, and every published bar adjudicated against this run's own band. ` +
+          `Publish those and mark the rest.`
       : `[clock] REPORTABLE: none.`
   );
   return { code: 1, lines };
+}
+
+/**
+ * THE DECISION'S OWN FIXTURES, in the idiom of every other adjudicator here:
+ * the refusals stated as cases rather than as prose, run by `--selftest`
+ * before a browser opens and by `clock_exit_path.test.cjs` in CI.
+ *
+ * The case that matters is the FIRST one. It is the run this driver actually
+ * produces under `HCLOCK_ONLY=keystroke` — both controls pass, every whole-run
+ * gate clears, and every bar comes back UNADJUDICATED — and until rf2-y7mw7 it
+ * printed `[clock] ok` and exited 0.
+ */
+function reportabilitySelfTest() {
+  const checks = [];
+  const check = (name, ok, detail) => checks.push({ name, ok: !!ok, detail: detail || '' });
+  const KEYSTROKE_WHY = "UNADJUDICATED — this row's control burns a fixed 50 ms rather than doubling the page";
+  const row = (over) => ({ rowId: 'M1', ctlOk: true, ctlNote: '', adjudicable: true, ...over });
+  const keystroke = () => row({ rowId: 'keystroke', adjudicable: false, unadjudicatedWhy: KEYSTROKE_WHY });
+
+  const green = reportability([row({}), row({ rowId: 'bulk300' })]);
+  check('a run whose every row is adjudicated exits 0 and says nothing', green.code === 0 && green.lines.length === 0);
+
+  const unadj = reportability([keystroke()]);
+  check(
+    'a row whose every bar is UNADJUDICATED cannot exit 0 — the case that used to be green',
+    unadj.code !== 0,
+    `code ${unadj.code}`
+  );
+  check(
+    'and the refusal NAMES the row and the adjudicator\'s own reason',
+    /no published bar can be ADJUDICATED on: keystroke/.test(unadj.lines[0] || '') &&
+      unadj.lines.some((l) => l.includes(KEYSTROKE_WHY)),
+    unadj.lines.join(' | ')
+  );
+  check(
+    'a row with nothing to publish is not announced as REPORTABLE',
+    unadj.lines[unadj.lines.length - 1] === '[clock] REPORTABLE: none.',
+    unadj.lines[unadj.lines.length - 1]
+  );
+
+  const mixed = reportability([row({}), keystroke()]);
+  check(
+    'an unadjudicated row refuses the run while the adjudicated rows stay reportable',
+    mixed.code !== 0 && /REPORTABLE: M1 —/.test(mixed.lines[mixed.lines.length - 1]),
+    mixed.lines[mixed.lines.length - 1]
+  );
+  check(
+    'and REPORTABLE no longer says "publish" without saying "adjudicated"',
+    /every published bar adjudicated against this run's own band/.test(mixed.lines[mixed.lines.length - 1]),
+    mixed.lines[mixed.lines.length - 1]
+  );
+
+  // THE CONTROL GATE IS UNCHANGED, which is the other half of the repair: the
+  // bar-level verdict was ADDED to the exit code, not substituted for the
+  // row-level one.
+  const ctl = reportability([row({ ctlOk: false, ctlNote: ' (three-point 1.2134x vs 2.0101x)' })]);
+  check(
+    'a failed positive control still refuses, alone, exactly as before',
+    ctl.code === 1 && /the positive control did not see the change/.test(ctl.lines[0] || ''),
+    ctl.lines.join(' | ')
+  );
+  const sab = reportability([row({ ctlOk: false })], { sabotage: 140 });
+  check(
+    'the falsification knob still says the run was a falsification',
+    sab.code === 1 && sab.lines.some((l) => l.includes('HCLOCK_CTL3_SABOTAGE=140')),
+    sab.lines.join(' | ')
+  );
+
+  const both = reportability([row({ rowId: 'keystroke', ctlOk: false, adjudicable: false, unadjudicatedWhy: KEYSTROKE_WHY })]);
+  check(
+    'a row that fails BOTH is refused for both — neither verdict masks the other',
+    both.code === 1 &&
+      both.lines.some((l) => l.includes('the positive control did not see the change')) &&
+      both.lines.some((l) => l.includes('no published bar can be ADJUDICATED')),
+    both.lines.join(' | ')
+  );
+
+  const empty = reportability([]);
+  check('a run that took no rows is not a refusal', empty.code === 0 && empty.lines.length === 0);
+  check('and neither is one that never ran', reportability(undefined).code === 0);
+
+  return { checks };
 }
 
 // ---------------------------------------------------------------------------
@@ -1804,9 +1906,15 @@ async function main() {
   if (SELFTEST_ONLY) {
     const g = guard.selfTest();
     const s = seamlib.selfTest();
+    // AND THE DECISION ITSELF (rf2-y7mw7). Every other self-test here asks
+    // whether an adjudicator can refuse; this one asks whether its refusal
+    // reaches the exit code, which is the fault the other twenty-three could
+    // not have caught.
+    const x = reportabilitySelfTest();
     for (const c of g.checks) console.error(`[clock] guard self-test ${c.ok ? 'ok  ' : 'FAIL'}  ${c.name}`);
     for (const c of s.checks) console.error(`[clock] seam self-test  ${c.ok ? 'ok  ' : 'FAIL'}  ${c.name}`);
-    const bad = [...g.checks, ...s.checks].filter((c) => !c.ok);
+    for (const c of x.checks) console.error(`[clock] exit self-test  ${c.ok ? 'ok  ' : 'FAIL'}  ${c.name}${c.ok ? '' : ` — ${c.detail}`}`);
+    const bad = [...g.checks, ...s.checks, ...x.checks].filter((c) => !c.ok);
     console.error(`[clock] --selftest: ${bad.length === 0 ? 'ALL ADJUDICATORS OK' : 'FAILURES: ' + bad.length}`);
     process.exit(bad.length === 0 ? 0 : 1);
   }
@@ -2165,13 +2273,25 @@ async function main() {
   // refusal on its own: the summary is built, the function decides, its lines
   // are printed and its code is the exit code.
   const decision = reportability(
-    outcomes.map((o) => ({
-      rowId: o.out.rowId,
-      ctlOk: !(ctlBad(o) || (o.verdict.etVerdict && !o.verdict.etVerdict.ok)),
-      ctlNote: o.verdict.ctl3
-        ? ` (three-point ${o.verdict.ctl3.measured.mean.toFixed(4)}x vs ${o.verdict.ctl3.predicted}x)`
-        : '',
-    })),
+    outcomes.map((o) => {
+      // THE ADJUDICATION OF THE PUBLISHED CLOCK, read off the same object the
+      // report printed and the dataset stored — not recomputed here, because a
+      // second computation is a second decision.
+      const bars = (o.verdict.seamTask && o.verdict.seamTask.rows) || {};
+      const names = Object.keys(bars);
+      const unadj = names.filter((n) => bars[n].unadjudicated);
+      return {
+        rowId: o.out.rowId,
+        ctlOk: !(ctlBad(o) || (o.verdict.etVerdict && !o.verdict.etVerdict.ok)),
+        ctlNote: o.verdict.ctl3
+          ? ` (three-point ${o.verdict.ctl3.measured.mean.toFixed(4)}x vs ${o.verdict.ctl3.predicted}x)`
+          : '',
+        // Fail closed on a row that adjudicated no bar at all: an empty
+        // verdict is an absent one, not a clean one.
+        adjudicable: names.length > 0 && unadj.length < names.length,
+        unadjudicatedWhy: unadj.length > 0 ? bars[unadj[0]].why : 'the run adjudicated no bar on this row at all',
+      };
+    }),
     { sabotage: CTL3_SABOTAGE }
   );
   for (const line of decision.lines) console.error(line);
@@ -2179,7 +2299,7 @@ async function main() {
   console.error('[clock] ok');
 }
 
-module.exports = { reportability };
+module.exports = { reportability, reportabilitySelfTest };
 
 if (require.main === module) {
   main();

--- a/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/clock_run.cjs
@@ -1717,7 +1717,62 @@ function report(out) {
 
 // ---------------------------------------------------------------------------
 
-(async () => {
+/**
+ * THE RUN'S FINAL DECISION, as a pure function of a flat per-row summary.
+ *
+ * Everything above this point is a WHOLE-RUN gate — a page that threw, a
+ * guard refusal, two arms building different pages, an unverified write, a
+ * band over the ceiling — and each takes its own exit where it is found.
+ * What is left is the pair of judgements that are about a ROW, and they are
+ * taken here, together, because the defect this function exists to prevent
+ * is one of them being computed and never reaching the exit code.
+ *
+ * `rows` is one entry per measured row:
+ *
+ *   rowId             the row's id, as printed
+ *   ctlOk             its positive control saw the change its arithmetic predicts
+ *   ctlNote           the parenthetical a control refusal prints, if any
+ *   adjudicable       at least one PUBLISHED bar carries a band
+ *   unadjudicatedWhy  why it does not, in the adjudicator's own words
+ *
+ * EXIT 1 HERE IS PER-ROW, AND THE ROWS THAT PASSED ARE STILL ROWS. Reaching
+ * this point means every whole-run gate cleared on every row; these two are
+ * the only ones this driver scopes to the row that failed them, because they
+ * are the only ones whose claim is about a row.
+ */
+function reportability(rows, opts) {
+  const list = Array.isArray(rows) ? rows : [];
+  const sabotage = (opts && opts.sabotage) || null;
+  const ctlFailed = list.filter((r) => !r.ctlOk);
+  const passed = list.filter((r) => r.ctlOk).map((r) => r.rowId);
+  const lines = [];
+  if (ctlFailed.length > 0) {
+    lines.push(
+      `[clock] FAILED: the positive control did not see the change its own arithmetic predicts on: ` +
+        `${ctlFailed.map((r) => `${r.rowId}${r.ctlNote || ''}`).join(', ')}. ` +
+        `No MAGNITUDE from those rows is reportable.`
+    );
+    if (sabotage) {
+      lines.push(
+        `[clock] HCLOCK_CTL3_SABOTAGE=${sabotage} WAS SET: the control's arms rendered ${sabotage} cells ` +
+          `while declaring 200. This refusal is the DEMONSTRATION that the control can fail, and this run is not ` +
+          `a measurement of anything.`
+      );
+    }
+  }
+  if (ctlFailed.length === 0) return { code: 0, lines };
+  lines.push(
+    passed.length > 0
+      ? `[clock] REPORTABLE: ${passed.join(', ')} — control passed, guard clean, canonical DOM identical, ` +
+          `0 unverified. Publish those and mark the rest.`
+      : `[clock] REPORTABLE: none.`
+  );
+  return { code: 1, lines };
+}
+
+// ---------------------------------------------------------------------------
+
+async function main() {
   // THE ADJUDICATORS' SELF-TESTS, and they run before anything is built or
   // launched. `ctl3SelfTest` is the one that matters for this driver's new
   // control: its cases are the REFUSALS — superlinear work, an arm that does
@@ -2095,7 +2150,6 @@ function report(out) {
     o.verdict.ctl3
       ? !o.verdict.ctl3.ok
       : !o.verdict.ctlVerdict.ok || (o.verdict.ctlTask && !o.verdict.ctlTask.ok);
-  const ctlFailed = outcomes.filter((o) => ctlBad(o) || (o.verdict.etVerdict && !o.verdict.etVerdict.ok));
   const demoted = outcomes.filter(
     (o) => o.verdict.ctl3 && o.verdict.ctl3.ok && (!o.verdict.ctlVerdict.ok || (o.verdict.ctlTask && !o.verdict.ctlTask.ok))
   );
@@ -2107,34 +2161,26 @@ function report(out) {
         `${o.verdict.constants ? o.verdict.constants.c2x.mean.toFixed(4) : '?'} ms is the reported reason they differ.`
     );
   }
-  if (ctlFailed.length > 0) {
-    const passed = outcomes.filter((o) => !ctlFailed.includes(o)).map((o) => o.out.rowId);
-    console.error(
-      `[clock] FAILED: the positive control did not see the change its own arithmetic predicts on: ` +
-        `${ctlFailed
-          .map((o) => `${o.out.rowId}${o.verdict.ctl3 ? ` (three-point ${o.verdict.ctl3.measured.mean.toFixed(4)}x vs ${o.verdict.ctl3.predicted}x)` : ''}`)
-          .join(', ')}. No MAGNITUDE from those rows is reportable.`
-    );
-    if (CTL3_SABOTAGE) {
-      console.error(
-        `[clock] HCLOCK_CTL3_SABOTAGE=${CTL3_SABOTAGE} WAS SET: the control's arms rendered ${CTL3_SABOTAGE} cells ` +
-          `while declaring 200. This refusal is the DEMONSTRATION that the control can fail, and this run is not ` +
-          `a measurement of anything.`
-      );
-    }
-    // EXIT 1 HERE IS PER-ROW, AND THE ROWS THAT PASSED ARE STILL ROWS.
-    // Everything before this line is a whole-run gate — a page that threw,
-    // a guard refusal, two arms building different pages, an unverified
-    // write — and reaching here means every one of them cleared on every
-    // row. A control is the only gate this driver scopes to the row that
-    // failed it, because that is the only one whose claim is about a row.
-    console.error(
-      passed.length > 0
-        ? `[clock] REPORTABLE: ${passed.join(', ')} — control passed, guard clean, canonical DOM identical, ` +
-            `0 unverified. Publish those and mark the rest.`
-        : `[clock] REPORTABLE: none.`
-    );
-    process.exit(1);
-  }
+  // THE DECISION HAS ONE SEAT (`reportability`, above). Nothing below reads a
+  // refusal on its own: the summary is built, the function decides, its lines
+  // are printed and its code is the exit code.
+  const decision = reportability(
+    outcomes.map((o) => ({
+      rowId: o.out.rowId,
+      ctlOk: !(ctlBad(o) || (o.verdict.etVerdict && !o.verdict.etVerdict.ok)),
+      ctlNote: o.verdict.ctl3
+        ? ` (three-point ${o.verdict.ctl3.measured.mean.toFixed(4)}x vs ${o.verdict.ctl3.predicted}x)`
+        : '',
+    })),
+    { sabotage: CTL3_SABOTAGE }
+  );
+  for (const line of decision.lines) console.error(line);
+  if (decision.code !== 0) process.exit(decision.code);
   console.error('[clock] ok');
-})();
+}
+
+module.exports = { reportability };
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
Closes rf2-y7mw7.

`clock_run.cjs` computed two verdicts per row and only one of them reached the exit code. The row-level **control** verdict gated the exit; the bar-level **adjudication** did not. So a row that passed its control, cleared every whole-run gate, and had every published bar labelled `UNADJUDICATED` four hundred lines above printed `[clock] ok` and exited 0 — and the summary line invited a reader to *"Publish those"*. `HCLOCK_ONLY=keystroke` alone is exactly that run; today's window was saved only because `M1` shared the invocation and refused on its own control.

This makes the driver honest about not having a band on that row. **The missing control is `rf2-swwud` and is not touched here.**

## It reproduced

The bead was explicit that the claim came from reading the code, not from a run, so the first act was to reproduce it — hermetically, with the driver's own adjudicator on the driver's own arguments (`fixedCells: null`, `noFixedPairWhy` = the fixed-50 ms control) and the driver's own final decision. No build, no browser, no measurement:

```
--- what the driver ADJUDICATED on the keystroke row ---
  hicasso / reagent-subs     UNADJ   UNADJUDICATED — this row's control burns a fixed 50 ms rather than doubling the page
  hicasso / uix-subs         UNADJ   UNADJUDICATED — this row's control burns a fixed 50 ms rather than doubling the page
  uix-subs / reagent-subs    UNADJ   UNADJUDICATED — this row's control burns a fixed 50 ms rather than doubling the page
--- what the driver would EXIT with ---
  lines: 0
  EXIT CODE: 0   <-- FAIL-OPEN
```

That is against `a425d1017e`, which lifts the exit block into a pure `reportability()` **byte for byte, with no behaviour change**, purely so the decision is observable. The defect is in the first commit's diff as much as in `main`'s.

## The fix

Fold "every published bar carries a band" into the same decision. Three commits:

| commit | what |
|---|---|
| `a425d1017e` | lift the exit block into a pure `reportability(rows, opts)` over a flat per-row summary; export it; put the driver behind `require.main === module`. **No behaviour change.** |
| `7b6b58e7a0` | the fix: the adjudication reaches the exit code, plus fixtures and the CI pin |
| `b21b1b8023` | the sibling: `clock_readjudicate.cjs`'s reportable-subset predicate carries the same term |

**+366 / −40 across three files.** No row's measurement changed, no arm changed, no threshold moved, and no published dataset was touched.

The control gate is **untouched** — the bar-level verdict is *added* to the exit code, not substituted for it. A row that fails both is refused for both, in the file's established "no refusal may mask another" idiom. A row that adjudicated no bar at all fails **closed**: absent is not clean.

The `REPORTABLE` line now says what it means. `passed` excludes unadjudicated rows, and the sentence no longer says "Publish those" without also saying what was adjudicated:

```
[clock] FAILED: no published bar can be ADJUDICATED on: keystroke. The row has a magnitude and
nothing to tell it from parity, so no figure from it is reportable — a passing control is not a band:
[clock]   keystroke: UNADJUDICATED — this row's control burns a fixed 50 ms rather than doubling the page
[clock] REPORTABLE: none.
```

## Mutation-proved, both directions

| direction | result |
|---|---|
| a run whose every bar is `UNADJUDICATED` | **exit 1**, naming the row and the adjudicator's own reason (above) |
| a genuinely reportable row (`ctl-2x` present, bars `CLEARS`) | **exit 0**, no lines — `[clock] ok` |
| a bar `INSIDE` the band (`LIMITED`) | **exit 0** — `LIMITED` is a verdict; only `UNADJUDICATED` is the absence of one |
| **the fix broken** (`unadjudicated.length` dropped from the exit condition) | back to **exit 0** while still printing the refusal — the original defect exactly; `clock_exit_path.test.cjs` goes `4/55 failed` and `--selftest` exits 1 |
| **the sibling's term broken** | the readjudicator quotes a `control-passing subset` mean for a row whose every bar is `UNADJUDICATED` |

## Sibling sweep — real count

**4 `seam.cjs` callers checked; 1 could produce an unadjudicable row; 0 live holes remain in a driver exit path.** `unavailable` is set only when `assess()` is called with a falsy `fixedCells`. `hd8_clock_run.cjs:611` and `shapes/census_clock_run.cjs:650` build it unconditionally, so the state is structurally unreachable there, and their degenerate case (NaN band) falls to `ceilingBreached`, which *is* gated to exit 4 — fail-closed. `ladder_band.cjs` never calls `assess`/`adjudicate` at all.

**1 sibling site found and fixed here** (`b21b1b8023`): `clock_readjudicate.cjs`'s `reportable` predicate had two of the three terms and not the adjudication one, thirty lines above a column that prints `UNADJUDICATED` for the very runs it was admitting into a published ensemble mean. Not live today, and only by accident — `clock_run.cjs` keys `ctlTask` and `fixedCells` off the same `hasProportionalControl` boolean, so `row.ctlTask &&` short-circuits `keystroke` out. Output on both retained `clock-0qj9w` datasets is **byte-identical**; on a counterfactual row that passes a control while its bars stay `UNADJUDICATED`, the subset now reads `NONE` instead of quoting a mean.

**27 drivers/gates swept for the general shape** — a refusal computed and the exit not consulting it. **1 has a live hole, and it is not this driver:** `hd8_run.cjs` prints a failed DOM read-back (`UNPUBLISHED (1/78 unverified)`) and a `REFUSED` yield correction, reads neither at exit, and prints `[hd8] ok`. Filed as **rf2-x6g04 (P1)** with the evidence — it is a different driver with different refusals and wants its own reproduction and mutation proof, not a rider on this PR. A nine-driver cross-cutting `pageerror`-prints-and-exits-0 class is filed as **rf2-jvheq (P3)**, explicitly as an audit rather than a confirmed fault, naming what would settle it.

## Quality gates

| gate | exit |
|---|---|
| `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine` |
| `node .../clock_run.cjs --selftest` | **0** — **71** checks, `ALL ADJUDICATORS OK` (**60** on `main`; the decision's 11 fixtures are new) |
| `cd implementation && npm run test:script-policy` | **0** |
| `cd implementation && npm run test:script-helpers` | **0** — `clock_exit_path.test.cjs: 55 passed` (was 41) |
| `python scripts/check_fast_pr_gap.py` | **0** — map clean; `test:script-helpers` is spine-covered (`scripts/test-fast-pr.sh:855`) and CI-required (`.github/workflows/test.yml:2606`) |
| `npm run lint:js` (root ESLint — required, **not** in the spine) | **0**, no findings |
| `clj-kondo` / `splint` | not applicable — no `.clj`/`.cljs` touched, so `Detect lint surface` does not select them |

`clock_run.cjs` is an operator-driven measurement driver and is not invoked by any CI job, so nothing in CI changes behaviour. The regression pin is `clock_exit_path.test.cjs`, which **is** required.

Every gate was run in the foreground to completion and its own marker read, not a pipeline's.

The fixtures live in one place — `reportabilitySelfTest()`, beside the decision, exactly as `guard.selfTest()` and `seamlib.selfTest()` live beside theirs. `--selftest` runs them before a browser opens; `clock_exit_path.test.cjs` runs them in CI and adds the wiring assertions a self-test cannot make: one seat, one exit, and nothing downstream of the decision reading a refusal on its own.
