### PR TITLE
docs(hicasso): the draft guide matches the landed surface (rf2-2rtt6.64)

### DIFF
--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -8,6 +8,8 @@ You want a date picker from npm. Declare it once, then use it anywhere a view is
 legal:
 
 ```clojure
+;; cf. implementation/freehand/test/re_frame/bench/hicasso/arm1/
+;;     host_hatch_dom_cljs_test.cljs — the witness for every claim on this page.
 (ns app.hosts.date-picker
   (:require [re-frame.hicasso :as h]
             ["react-datepicker" :default DatePicker]))

--- a/docs/design/hicasso/draft-guide/06-theming.md
+++ b/docs/design/hicasso/draft-guide/06-theming.md
@@ -101,14 +101,21 @@ Nothing reads the theme in a view. The event that records the choice also return
 
 ```clojure
 (rf/reg-fx :theme/apply!
-  (fn [theme]
+  {:platforms #{:client}}
+  (fn [_ctx theme]
     (.setAttribute (.-documentElement js/document) "data-theme" (name theme))))
 
 (rf/reg-event :theme/choose
   (fn [{:keys [db]} [_ theme]]
-    {:db           (assoc db :theme/current theme)
-     :theme/apply! theme}))
+    {:db (assoc db :theme/current theme)
+     :fx [[:theme/apply! theme]]}))
 ```
+
+Custom effects are rows under `:fx`. The effect map is closed at the top level, so
+a stray `:theme/apply!` beside `:db` is dropped with `:rf.error/effect-map-shape`
+while the `:db` write still lands — which looks exactly like an unwired bridge.
+`{:platforms #{:client}}` keeps the effect off the server, where there is no
+`document`; [Server-side rendering](10-server-side-rendering.md) has the rule.
 
 **Tradeoff.** Zero React work, literally: no subscription, no boundary, no render. The "one attribute flip, zero React work" claim is exact under this option. What you give up:
 


### PR DESCRIPTION
Closes the audit-reopen backlog on `rf2-2rtt6.64`. The bead carried **five** audit
notes; four were already discharged by the passes that ran after they were written,
and this PR discharges the fifth. The verification is the bulk of the work here — the
diff is deliberately small.

## Audit items, verified against the current tree

| Audit | Item | Status |
|---|---|---|
| #7382 | `05-interop.md` opening sample: unreadable `::h/value`, undeclared callback contract | **Already fixed.** The sample declares `{:callbacks {:on-change :event}}` and uses `h/fn` for the value-first `onChange(date)` invoker. No `::h/value`. |
| #7396 | `defhost` described as the tier-1 door the bench has not exercised; `::h/value` across a host listed as unaddressed | **Already fixed.** Neither claim survives; the "Not settled yet" table no longer carries the `::h/value` row. |
| #7396 | `[:> Component …]` taught as legal; migration codemod taught as existing | **Already fixed.** `05-interop.md:48` calls the escape "**not built** yet", the section heading is literally `## The escape: [:>] (unbuilt)`, and the codemod reads "planned and not built" in both prose and the table. |
| #7398 | Callback section overclaims `::h/prevent` — "whichever invoker argument is the real DOM event" | **Already fixed by PR #7420.** `rf2-2rtt6.35`'s close reason records that sentence as retired. The page now states the event-first law and names `:rf.error/hicasso-intent-needs-the-event`, which I verified exists at `implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs:482`. |
| #7482 / #7484 | `06-theming.md` Option B registers a live, copyable invalid effect | **Fixed here.** |

`#7484` is the same defect as `#7482` — the voice pass rewrote the prose around the
same invalid sample and carried all three API errors forward.

## The one live defect

`06-theming.md`'s Option B was a copy-paste trap, and I confirmed all three claims
against `implementation/` rather than taking the audit's word:

1. **Top-level custom effect key.** `events.cljc`'s `closed-effect-map-keys` closes the
   effect map to `#{:db :rf.db/runtime :fx}` plus the four EP-0025 classification keys.
   A top-level `:theme/apply!` emits `:rf.error/effect-map-shape` with
   `:recovery :logged-and-skipped` and is dropped — while the `:db` write still lands.
   That is exactly the "theme keyword changes and nothing happens" symptom the page's
   own troubleshooting table blames on an unwired bridge. Now an `:fx` row.
2. **One-argument `reg-fx`.** `fx.cljc:89` documents `(fn [ctx args] …)` and flags it
   **"v2 changed from v1"**. The one-arg handler would have received the context map and
   called `(name {:frame … :event …})`. Now `(fn [_ctx theme] …)`.
3. **`js/document` with no platform fence.** `reg-fx`'s `:platforms` defaults to
   `#{:client :server}`. This guide ships an SSR chapter that already teaches
   `:platforms #{:client}`, so the sample contradicted its own corpus. Now declared.

I added a short paragraph naming the closed-map law and the error id, so a reader does
not "simplify" the sample back into the broken shape. The tradeoff prose is untouched,
per the audit's instruction.

## Also

`05-interop.md`'s opening sample now carries the `;; cf.` source comment
`AUTHORING.md` asks for, pointing at `arm1/host_hatch_dom_cljs_test.cljs`. This was an
open acceptance-criteria clause ("point the sample at the focused host-hatch witness")
— every page's Draft banner names the bench arm as a whole, but nothing named the file
that proves this page.

## Flagged, not resolved

**`rf2-l0wfx` (P1) touches this guide.** `defhost`'s `:ssr` has no value that renders
children, so a provider crossing deletes its subtree server-side. `05-interop.md`'s
`## Providers` section does **not** claim SSR safety, so there is no live falsehood to
correct — but it is silent on the trap, and the `:ssr` default is `:client-only`. The
wording belongs to `rf2-l0wfx` once that bead settles what `:ssr` should offer;
pre-empting it here would just have to be rewritten.

## Size

**+12 / −3 across two files.** The guide has had three net-negative passes and is at
1,875 lines; the standard is editorial restraint, not coverage. Four of five audit
items needed no diff at all, and reporting that is the result. The only prose added is
the five lines that stop the corrected sample being "simplified" back into the bug.

## Quality gates

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `sh scripts/test-fast-pr.sh` | **0** (`PASS fast PR spine`) |

**`mkdocs build --strict` is not nominated as the gate for this change.** `mkdocs.yml`'s
`exclude_docs` keeps `design/hicasso/` out of the site, so the build exits 0 having
verified nothing of this diff. It ran inside the spine and passed, but it is not
evidence here.

**Mutation proof of the slug checker** (it is the only gate that actually covers this
tree, so it gets proved rather than trusted):

- baseline → **exit 0**
- broke one anchor to `#bridging-the-choice-to-the-dom-MUTANT` → **exit 1**, naming
  `06-theming.md:37 -> #bridging-the-choice-to-the-dom-MUTANT`
- restored → **exit 0**, restore verified byte-identical against a pre-mutation copy

**Nothing validates tables, so I hand-counted both in the file I touched.**
`06-theming.md` Troubleshooting: 3 columns across header, separator and all 7 body rows.
"Not settled yet": 2 columns across header, separator and all 7 body rows. I edited
neither table.

**Anchors.** One link added (`10-server-side-rendering.md`, no fragment; file exists).
No heading was added, renamed or removed in either file, so no inbound link sweep was
needed. `05-interop.md`'s existing `#forwarding-attributes-` trailing-hyphen anchor is
unchanged and still resolves.

`python scripts/check_fast_pr_gap.py --list` consulted: 126 required checks are not
decided locally. This diff is confined to `docs/design/hicasso/draft-guide/**`, which is
surface-gated out of every one of them except `Docs required`.
