### PR TITLE
docs(hicasso): true up the bench lane's stale "SSR is out of v0" posture (rf2-2rtt6.84)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj
@@ -27,8 +27,11 @@
   ## Why it is a `.clj` and not a `.cljc`
 
   Macros only. The runtime it names is CLJS-only (it requires React), and
-  a `.cljc` would invite a JVM-side implementation this arm does not have
-  — HD-020(d) puts SSR out of v0 explicitly.")
+  a `.cljc` would invite a JVM-side implementation this arm does not
+  have. SSR becoming required scope (the 2026-08-04 HD-020 addendum) did
+  not change that: the arm renders on **Node**, calling
+  `react-dom/server` from CLJS ([[re-frame.bench.hicasso.ssr.node]]), so
+  there is still no JVM render path for a `.cljc` to imply.")
 
 (defmacro defview
   "Mint a boundary — a real React function component (HD-016).

--- a/implementation/freehand/test/re_frame/bench/hicasso/shapes/ordinary.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/shapes/ordinary.cljs
@@ -64,8 +64,11 @@
   placeholder for the typed value — are one concept each.
 
   Body forms are `.cljc`-compatible by construction (HD-020(d)): no
-  interop, no JS literal, no React import. SSR is out of v0; the
-  constraint that keeps it reachable is not."
+  interop, no JS literal, no React import. That constraint was held
+  while SSR sat outside v0, and it is now load-bearing: the 2026-08-04
+  HD-020 addendum makes SSR and hydration **required** scope, so a body
+  that reached for `window` would be a body this screen could not render
+  on a server."
   (:require [re-frame.bench.hicasso.arm1.runtime :refer [sub]]
             [re-frame.bench.hicasso.front.route-link :refer [route-link]]
             [re-frame.bench.hicasso.shapes.model :as m])


### PR DESCRIPTION
Closes the one item left open on `rf2-2rtt6.84` by **merged-PR audit #7475**.

## Why this is not titled "the hydration capture spans the adoption it watches"

Because that work is already on `main`, and titling this PR after it would misdescribe the diff. The dispatch brief asked for that title from a recollection of the **#7469** reopen; the bead's **newest** note (#7475) supersedes it and is narrower. Verified against the tree before touching anything:

**Audit #7469 item 1 — the capture ending before hydration — is DISCHARGED.** `hydration-support/open-console-capture!` returns `{:captured :close!}`; the caller opens the window *before* `hydrate-root!` and closes it *inside* the `adopted!` continuation, so the capture spans the concurrent adoption rather than the synchronous call (`hydrate_dom_cljs_test.cljs:203`, `:316`, `:362`). `capture-console!` survives only as the documented synchronous special case. It is mutation-proved in **both** directions: `hydrate_recoverable_dom_cljs_test.cljs:190` asserts `(seq @captured)` over a deliberately divergent server/client render, and `:227` asserts `(= [] @captured)` over a clean adoption. Both React 19 channels are watched — the `window` `error` listener and the `console.error` spy — so a mismatch routed to `reportError` cannot read as zero failures. `:swallow-uncaught?` is confined to rows that manufacture a fault and assert on it, leaving `rf2-mwx08` intact.

**Audit #7469 item 2 — the live doc contradiction — was still live.** That is this PR, and it is all of it.

## The change

Two bench-lane namespace docstrings still asserted the pre-amendment SSR posture as present-tense fact, after the 2026-08-04 HD-020 addendum made SSR and hydration **required** Hicasso scope.

**`shapes/ordinary.cljs:66-68`** — the file the audit named. It said *"SSR is out of v0; the constraint that keeps it reachable is not."* The `.cljc`-compatible body constraint — no interop, no JS literal, no React import — is preserved exactly; only the superseded posture clause is replaced. That constraint was a bet while SSR sat outside v0 and is load-bearing now.

**`arm1/lang.clj:27-32`** — **not named by the audit; the #7465 repo-wide census missed it.** Same stale sentence, same lane: its "Why it is a `.clj` and not a `.cljc`" rationale ended *"— HD-020(d) puts SSR out of v0 explicitly."* Its actual reason survives untouched, because it is still true: the arm has no JVM-side implementation. Only the citation changed, and the replacement states *why* it is still true — the arm's SSR renders on **Node**, calling `react-dom/server` from CLJS (`ssr/node.cljs`), so a `.cljc` would still imply a render path that does not exist.

The three surviving hits for the phrase (`docs/EP/EP-0038-…:260`, `docs/design/hicasso/charter.md:152`, `docs/design/hicasso/decisions.md:752`) are deliberately-retained historical ruling text — each records what was pre-registered and each is superseded in place by its own amendment. Left alone.

## Scope

Docstrings only. The diff crosses no form, no `:require` and no macro expansion. The ordinary screen's render path, its element arithmetic and the HD-020(b) hook ledger are untouched; `defview`'s expansion is byte-identical. No hydration mechanism was reopened, per the #7475 instruction.

Nothing under `implementation/ssr`, `ssr-ring`, `decisions.md`, `validation.md` or `spec/**`. No bench-driver exit path (`hd8_run.cjs` and siblings belong to `rf2-x6g04`).

`shapes/ordinary.cljs` is listed in `census_clock_run.cjs`'s `BLOB_FILES`, but that is run **provenance** — `git hash-object` recorded into the output — not a pinned digest, so no gate re-baselines.

## Quality gates

Run locally to completion in this worktree. Exit codes are read from the runner's **own** anchored markers, not from a harness-reported wrapper status, and nothing was piped through `tail`/`head`/`grep`.

| Gate | Exit |
| --- | --- |
| `npm run test:hicasso-compile` — the lane compile gate, which owns both edited files | `0` |
| `npm run test:cljs` | `0` |
| `npm run test:browser` | `0` |
| `sh scripts/test-fast-pr.sh` | `0` |
| `clj-kondo --parallel --fail-level error` at the CI pin **2026.04.15** (fetched; local is 2025.10.23) | `0` — **errors: 0**, warnings 4534 against the ≈4,534 baseline |

Neither edited file produces any clj-kondo finding.

`python scripts/check_fast_pr_gap.py --list` was consulted for the required checks the spine does not decide. This diff reaches none of them: it is two docstrings under `implementation/freehand/test/`, so the skill/MCP/catalogue invariant families are surface-gated away from it. `mkdocs build --strict` is deliberately **not** nominated — no `docs/**` file changed.

Not run, and why: `test-rigorous-local.sh` and the JVM tool suites — no JVM artefact, no tool and no production namespace is in the diff.
