### PR TITLE
fix(spec): 008 and 004B agree on the v1 host variant (rf2-whfte)

### DIFF
--- a/spec/008-Testing.md
+++ b/spec/008-Testing.md
@@ -767,10 +767,15 @@ that proves a law there.
 - **structural tree → 011** — the structural tree is the *input* server rendering
   consumes; the runner proves the tree, and [011](011-SSR.md) owns emission and
   hydration.
-- **qualified host** — a foreign boundary is opaque to the structural render (the v1
-  node set carries no host variant), so a qualified-host law is proven by connecting
-  the real behaviour or wrapper in a browser under its own host-boundary slice, never
-  by the structural surface.
+- **qualified host** — what the foreign component *renders* is opaque to the structural
+  render: a host node's `:children` are the declared SSR projection, never the registered
+  component's own output. So a law about that behaviour is proven by connecting the real
+  behaviour or wrapper in a browser under its own host-boundary slice. The **crossing
+  itself is not opaque** — the v1 node set carries a `host` variant
+  ([004B](004B-UI-Tree-and-Conversion.md#the-node-schema--version-1)), so its identity
+  (`:rf.ui/host`), its declared SSR policy (`:rf.ui/host-ssr`) and its `:props` are
+  ordinary headless reads in the `jvm` and `browser` structural cells. A view declaring
+  the crossing it should needs no browser to prove it.
 
 No cell claims structural coverage the runner cannot execute: the four `structural`
 cells (both modes × {jvm, browser}) are exactly what `t/render` renders headlessly on


### PR DESCRIPTION
Closes rf2-whfte.

**One bullet in `spec/008-Testing.md`. 9 insertions, 4 deletions, nothing else touched.**

## Which side was wrong

**008 was the stale side.** 008's host/mode matrix justified the `qualified host`
column with a claim about the node schema that the node schema contradicts:

> a foreign boundary is opaque to the structural render (the v1 node set carries no
> host variant), so a qualified-host law is proven by connecting the real behaviour or
> wrapper in a browser under its own host-boundary slice, **never by the structural
> surface**.

Four independent witnesses say the v1 node set *does* carry a host variant:

1. `spec/004B-UI-Tree-and-Conversion.md:134` — the version-1 roster row:
   `| **host** | map | :rf.ui/host :rf.ui/host-ssr :children | :props :rf.ui/host-children :rf.ui/host-map-props :key |`
2. `spec/004B:146-148` — `:rf.ui/host` is one of the four *primary* discriminators,
   pinned in order; `004B:349-353` states the fields **are** a node rather than
   annotations on one.
3. `implementation/freehand/src/re_frame/freehand/test.cljc:255` — `node-kind` has the
   host arm, and `:244` counts `:rf.ui/host` as a primary.
4. `implementation/freehand/test/re_frame/freehand/structural_test_surface_cljs_test.cljc:136-158`
   — `attrs-reaches-a-declared-hosts-props` finds the crossing with
   `#(contains? % :rf.ui/host)` and asserts `(= ::date-picker (:rf.ui/host host))` and
   `(= :client-only (:rf.ui/host-ssr host))`, headlessly.

**And 008 already contradicted itself.** Sixty lines above the stale bullet, its own
`t/attrs` row (`:695`) documents the projection as returning `:props` "on a view
boundary **and on a declared `v/defhost` crossing**". The document shipped both claims.

**The behaviour is correct; only the prose was wrong.** This is the cheap outcome —
had 004B or `node-kind` been the wrong half, the defect would have been behavioural.

## The cost the stale sentence was imposing

"never by the structural surface" told a reader that a declared host crossing cannot be
asserted structurally and must be proven in a browser. It can be asserted structurally —
the test above does exactly that, headlessly, on both lanes. The sentence was routing
readers to a browser test where a headless one already works.

## What changed, and what deliberately did not

The corrected bullet keeps the true half (what the foreign component *renders* is
opaque — a host node's `:children` are the declared SSR projection, never the
registered component's own output, per `004B:466-468`) and replaces the false reason,
adding the reader's actual recovery: the crossing's identity, SSR policy and props are
ordinary headless reads in the `jvm` and `browser` structural cells.

**The matrix table is unchanged and is correct as it stands.** The `qualified host`
column is the foreign runtime's own host — a law binding *there* is genuinely
mounted-only. The crossing node is emitted by our walk on the `jvm`/`browser` hosts, so
its structural coverage was always the `structural` cells. Only the justifying sentence
was wrong, so only the justifying sentence moved. No table cell, no heading, no
adjacent prose.

## Sibling sweep

`git grep -n -i -E "opaque to the structural|no host variant|carries no host|node set carries"`
across `spec/ docs/ implementation/ tools/ migration/`:

- **`spec/`: exactly one instance** — the one fixed here. No other spec repeats it.
- `docs/design/hicasso/studio/raw-escape-design-a-minimal.md:452-456` — **the finding
  record that produced this bead**, phrased "`spec/008-Testing.md` (~line 770) *still
  says* …". It goes stale the moment this merges. **Not touched**: it is outside this
  bead's fence, and rf2-2rtt6.103 holds a live locked worktree on that exact file.
  Filed as **rf2-pca72** for the owner to fold in.
- Every other hit is unrelated ("carries no host handles", "carries no host-facing
  props", "carries NO host-hook grammar") — different subject, all correct.

Also swept 008 itself for `opaque` (`:695` — "opaque role marker", a different and
correct sense), `qualified host`, `defhost`, `host-boundary`: no other restatement.

## Quality gates

Run foreground to completion in the worker worktree
(`/c/Users/miket/code/re-frame2-worktrees/spec008-whfte`), exit codes echoed:

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `python -m mkdocs build --strict` (with `spec/`+`migration/` staged into `docs/`, as `docs.yml` does) | **0** |
| `sh scripts/test-fast-pr.sh` | **0** (`PASS fast PR spine`) |
| `python scripts/check_fast_pr_gap.py --list` | **0** (consulted; 126 required checks not decided locally) |

**Mutation proof that `check_doc_slugs.py` can fail on *this* edit** — the new inbound
link's anchor was flipped to `#the-node-schema--version-9`: exit **1**. Restored: exit
**0**, tree clean. The gate is armed for the link this PR adds.

**Spine-adjacent checkers that read shared spec files**, run individually since
`check_fast_pr_gap.py` flags them as having no local lane — all exit **0**:
`check_keyword_catalogue_drift`, `check_retired_composition_vocab`,
`check_retired_image_keys`, `check_failure_corpus_residue`, `check_inject_cofx_residue`,
`check_readme_links`, `check_readme_inventories`, `check_skill_re_frame2_drift`,
`check_skill_mcp_drift`, `check_skill_migration_cites`.

**No CRLF normalisation.** `git diff --numstat` = `9	4	spec/008-Testing.md` — exactly
the 9-line bullet replacing the 4-line one, no whole-file re-ending.

**No tables touched**, so nothing needed hand-counting. **No headings touched**, so no
inbound-link sweep was required; the one link *added* points at
`004B-UI-Tree-and-Conversion.md#the-node-schema--version-1`, an anchor `008` already
links to at `:682`, and it is the anchor the mutation proof above exercises.


