### PR TITLE
ci(spine): the 17 invariant checkers get a local lane (rf2-ejm7m)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -146,8 +146,19 @@ distinguish prose from a `:require`, and a cleverer grep would eventually admit 
 dependency. A worker reading that red goes looking for a failing test that does not exist,
 which is why the report names the **check** and prints what it actually runs. The same
 class covers `npm run test:ui-isolation` (a step of the `cljs` job whose node-test build
-the spine *does* run) and the required `python scripts/check_*.py` invariant checkers that
-have no local lane.
+the spine *does* run).
+
+**The invariant checkers used to be the bulk of this report; one of them still is.** The
+first run of the gap map named **thirty-eight** required `python scripts/check_*.py`
+invocations with no local lane at all. rf2-ejm7m timed each one and gave thirty-seven of
+them a lane — twenty-nine in the spine's always-on block (mirroring `verify-skill-mcp-drift`
+and `verify-readme-links`, which CI runs unconditionally) and eight in the documentation
+tier (mirroring `docs.yml`'s `docs_surface`-gated `build`). Together those thirty-seven
+cost **6.4s**. The thirty-eighth, `check_retired_image_keys.py --verbose`, costs **37.7s by
+itself** — more than double the spine's whole documentation tier — so it is CI-only *on
+purpose*, and the report still names it. That is a measured decision rather than an
+oversight (rf2-e1xx0 tracks making it fast enough to join the others, after which it leaves
+this report with no list edited anywhere).
 
 **A local `clj-kondo` pass proves nothing unless it is the pinned build.** CI installs an
 exact version and fails on ERROR level only, warnings staying informational; two versions

--- a/scripts/check_fast_pr_gap.py
+++ b/scripts/check_fast_pr_gap.py
@@ -182,6 +182,14 @@ SPINE_LANES = (
         r"^\./\.github/scripts/verify-version-lockstep\.sh$",
         "spine always-on: 'lockstep version drift'",
     ),
+    # Its self-test arm is a SEPARATE required step of the same job, so it needs
+    # its own signature -- the live lane's `$`-anchored pattern cannot match it,
+    # which is why it sat in this report until rf2-ejm7m gave it a lane.
+    Lane(
+        "version-lockstep-self-test",
+        r"^\./\.github/scripts/verify-version-lockstep\.sh --self-test$",
+        "spine always-on: 'lockstep gate self-test'",
+    ),
     Lane(
         "spine-self-test",
         r"^bash scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test\.sh$",

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -47,10 +47,17 @@ set -euo pipefail
 # STEP INSIDE A JOB THIS SPINE RUNS — the EP-0036 donor-boundary `git grep` is
 # the last step of `jvm-freehand`, so it reports as "JVM freehand (clojure
 # -M:test)" and is not a test; `npm run test:ui-isolation` is a step of the same
-# `cljs` job whose node-test build this spine does run; and thirteen of CI's
-# required `python scripts/check_*.py` invariant checkers had no local lane at
-# all.  None of those is a skipped TIER, so nothing above can see them.  Run
-# `python scripts/check_fast_pr_gap.py --list` for the local command for each.
+# `cljs` job whose node-test build this spine does run; and thirty-seven of CI's
+# required `python scripts/check_*.py` invocations had no local lane at all until
+# rf2-ejm7m measured them and gave them one — twenty-nine in the always-on block
+# below, eight in the documentation tier.  None of those is a skipped TIER, so
+# nothing above can see them.  Run `python scripts/check_fast_pr_gap.py --list`
+# for the local command for each of the ones that remain.
+#
+# EXACTLY ONE required checker was measured and DELIBERATELY left out:
+# `check_retired_image_keys.py --verbose`, at 37.7s, is more than double this
+# spine's entire documentation tier.  The report still names it, which is the
+# correct answer rather than a gap in this comment.
 #
 # What it DOES mirror is CI's *tiering* — which tiers run for a given diff —
 # because that decision is delegated wholesale to the classifier CI uses.  Tier
@@ -99,7 +106,12 @@ set -euo pipefail
 #   2. python scripts/check_doc_slugs.py               — docs corpus anchors
 #   3. python scripts/check_ep_status_sync.py          — docs/EP index status-sync
 #   4. python scripts/check_runtime_subsystem_grading.py — EP-0006 grading table
-#   5. mkdocs build --strict (console script, else `python -m mkdocs`)
+#   5. python scripts/check_inject_cofx_residue.py       — retired inject-cofx
+#   6. python scripts/check_failure_corpus_residue.py    — retired failure spellings
+#   7. python scripts/check_retired_composition_vocab.py — retired composition vocab
+#   8. python scripts/check_retired_image_keys.py --self-test only (rf2-ejm7m;
+#      its 37.7s live corpus sweep stays CI-only, and the gap map names it)
+#   9. mkdocs build --strict (console script, else `python -m mkdocs`)
 
 # The spine's own tree (scripts, gate commands, the shared classifier) is
 # always derived from this script's location.  `--repo-root` overrides ONLY
@@ -309,6 +321,19 @@ is_doc_surface_path() {
     scripts/check_readme_links.py|scripts/check_doc_slugs.py) return 0 ;;
     scripts/check_ep_status_sync.py|scripts/check_runtime_subsystem_grading.py) return 0 ;;
     scripts/_test_fixtures/check_readme_links/*|scripts/_test_fixtures/check_doc_slugs/*) return 0 ;;
+    # The residue sweeps added to this tier by rf2-ejm7m, same rule as their
+    # neighbours above: a gate whose own script changed has to run.  The first
+    # three are named IDENTICALLY in docs.yml's `detect` classifier, so this is
+    # mirroring CI, not inventing a local surface.  `check_retired_image_keys.py`
+    # is the one CI does not list — added anyway because this spine now executes
+    # its self-test, and a gate that runs here should arm on its own source; the
+    # direction is the safe one (over-arming a 0.08s check).
+    scripts/check_inject_cofx_residue.py|scripts/check_failure_corpus_residue.py) return 0 ;;
+    scripts/check_retired_composition_vocab.py|scripts/check_retired_image_keys.py) return 0 ;;
+    scripts/_test_fixtures/check_inject_cofx_residue/*) return 0 ;;
+    scripts/_test_fixtures/check_failure_corpus_residue/*) return 0 ;;
+    scripts/_test_fixtures/check_retired_composition_vocab/*) return 0 ;;
+    scripts/_test_fixtures/check_retired_image_keys/*) return 0 ;;
   esac
   # The spine's own tree is on this surface too — delegated rather than
   # re-listed, so the two predicates cannot drift apart.
@@ -890,8 +915,65 @@ if [ "$run_docs" = true ]; then
   run "README link/anchor validator" "python scripts/check_readme_links.py --ci" \
     python "$spine_root/scripts/check_readme_links.py" --ci
 
+  run "docs corpus anchor self-test" "python scripts/check_doc_slugs.py --self-test --verbose" \
+    python "$spine_root/scripts/check_doc_slugs.py" --self-test --verbose
+
   run "docs corpus anchor validator" "python scripts/check_doc_slugs.py" \
     python "$spine_root/scripts/check_doc_slugs.py"
+
+  # CI's docs-tier residue sweeps (rf2-ejm7m).  These four live in docs.yml's
+  # `build` job, which is gated on `docs_surface` — so the documentation tier is
+  # where they belong locally, and a code-only diff pays nothing for them.
+  #
+  # MEASURED: eight of the nine invocations cost 1.93s together, against a docs
+  # tier already ~28s (mkdocs --strict dominates).  The NINTH is excluded and
+  # named below.
+  #
+  # They are not subject to the trap PR #7496 found in the mkdocs build — that
+  # gate reads `docs/`, and docs.yml stages `cp -r spec docs/spec` first, so a
+  # bare local run exits 0 having read nothing of a spec edit.  Each of these
+  # scans the TRACKED `spec/` tree and explicitly excludes the staged
+  # `docs/spec/` mirror (`_EXCLUDE_REL_PREFIXES`), so running them here reads
+  # exactly what CI reads, with no staging step to forget.
+  run "inject-cofx residue self-test" "python scripts/check_inject_cofx_residue.py --self-test --verbose" \
+    python "$spine_root/scripts/check_inject_cofx_residue.py" --self-test --verbose
+
+  run "inject-cofx residue" "python scripts/check_inject_cofx_residue.py --verbose" \
+    python "$spine_root/scripts/check_inject_cofx_residue.py" --verbose
+
+  run "failure-corpus residue self-test" "python scripts/check_failure_corpus_residue.py --self-test --verbose" \
+    python "$spine_root/scripts/check_failure_corpus_residue.py" --self-test --verbose
+
+  run "failure-corpus residue" "python scripts/check_failure_corpus_residue.py --verbose" \
+    python "$spine_root/scripts/check_failure_corpus_residue.py" --verbose
+
+  run "retired composition-vocab self-test" "python scripts/check_retired_composition_vocab.py --self-test --verbose" \
+    python "$spine_root/scripts/check_retired_composition_vocab.py" --self-test --verbose
+
+  run "retired composition vocab" "python scripts/check_retired_composition_vocab.py --verbose" \
+    python "$spine_root/scripts/check_retired_composition_vocab.py" --verbose
+
+  # THE ONE THAT IS NOT CHEAP, and the one exception in this bead (rf2-ejm7m).
+  #
+  # `check_retired_image_keys.py --verbose` is 37.7s cold / ~42s warm on this
+  # checkout — 95% of that job's whole checker batch, and more than the entire
+  # documentation tier it would join.  Folding it in would take the docs tier
+  # from ~28s to ~66s: every worker touching a single `.md` file pays a 2.4x
+  # slowdown, which is a worse trade than the ambush it would prevent.  So the
+  # live scan stays CI-only ON PURPOSE, and `check_fast_pr_gap.py` keeps naming
+  # it — correctly, and derivedly, with no exception list anywhere.
+  #
+  # The cost is real work, not a pathology of this machine: the scan is 9.4M
+  # regex searches plus a per-character Clojure string-masking pass over 3,534
+  # files (`_mask_multiline_clj_strings` alone is 12s of it).  A token pre-filter
+  # would very likely make it a sub-second gate and earn it a lane here; that is
+  # rf2-e1xx0, not this bead.
+  #
+  # Its SELF-TEST arm is 0.08s, so that one is here: the thing that proves the
+  # guard still has teeth is cheap even when the corpus sweep is not.
+  run "retired image-keys self-test" "python scripts/check_retired_image_keys.py --self-test --verbose" \
+    python "$spine_root/scripts/check_retired_image_keys.py" --self-test --verbose
+  note_skipped "check_retired_image_keys.py --verbose (docs.yml, required) — 37.7s measured, 95% of that job's checker batch and >2x this whole tier; self-test arm runs above, live corpus sweep is CI-only by measurement (rf2-ejm7m, perf follow-up rf2-e1xx0)"
 
   # EP index status-sync guard (rf2-8cw3m7): docs/EP/README.md restates each
   # EP's Status: line in its index table; the two drift by hand (EP-0001 sat at

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -721,6 +721,136 @@ run "fast-PR gap map (rf2-13zre)" "python scripts/check_fast_pr_gap.py --verbose
   python "$spine_root/scripts/check_fast_pr_gap.py" --check
 
 # ---------------------------------------------------------------------------
+# THE REST OF CI'S ALWAYS-ON INVARIANT CHECKERS (rf2-ejm7m).
+#
+# The gate above NAMED these; this block RUNS them.  Every line below is a
+# required check from a job CI runs UNCONDITIONALLY — `verify-skill-mcp-drift`
+# and `verify-readme-links` both sit in `all-required-passed`'s `needs:` with no
+# `if:` and no `needs: detect`, so no diff can fail to reach them.  Always-on
+# here is therefore the faithful mirror, not a local choice.
+#
+# MEASURED BEFORE ADDING, because "cheap" was an assumption worth checking
+# (rf2-ejm7m ruling).  All 29 invocations below, timed individually from a clean
+# checkout: 4.46s cold / 4.58s warm as a batch.  The largest single one is
+# `check_keyword_catalogue_drift --verbose` at ~1.0s; twenty-five of the
+# remaining twenty-eight are under 0.15s, which is barely more than the ~0.02s
+# interpreter start each one pays.  Against a 14.3s always-on block that is
+# ~30%, for thirteen live scans and sixteen self-test arms that previously had
+# NO way to be run locally at all.
+#
+# WRITTEN OUT ONE PER LINE, deliberately.  A loop over a script-name variable
+# would be shorter and would BREAK THE RATCHET: `check_fast_pr_gap.py` derives
+# this spine's coverage by reading THIS FILE's source for the literal shape
+# `python "$spine_root/scripts/check_<name>.py"`, matching (script, mode) pairs
+# against CI's.  Interpolate the name and the derivation sees nothing, every CI
+# checker is re-reported as unrun, and the gap map goes from derived to
+# fictional.  The literal form is what keeps the map true with no second list to
+# maintain — add a line here and the checker leaves the report by construction.
+#
+# Each pairs CI's self-test arm with CI's live arm, in CI's own order and with
+# CI's own flags, so this block and the `verify-skill-mcp-drift` job log read
+# the same way.  The rationale for each individual gate lives where it was
+# written — in that job's step comments in `.github/workflows/test.yml`.
+run "MCP/skill title-safety self-test" "python scripts/check_skill_mcp_drift.py --self-test --ci" \
+  python "$spine_root/scripts/check_skill_mcp_drift.py" --self-test --ci
+
+run "skill migration cite-integrity self-test" "python scripts/check_skill_migration_cites.py --self-test" \
+  python "$spine_root/scripts/check_skill_migration_cites.py" --self-test
+
+run "migration contract-drift self-test" "python scripts/check_skill_migration_contract_drift.py --self-test" \
+  python "$spine_root/scripts/check_skill_migration_contract_drift.py" --self-test
+
+run "migration contract drift (M-11/M-13)" "python scripts/check_skill_migration_contract_drift.py --verbose --ci" \
+  python "$spine_root/scripts/check_skill_migration_contract_drift.py" --verbose --ci
+
+run "migration O-16/O-17 router self-test" "python scripts/check_skill_migration_o1617_router_drift.py --self-test" \
+  python "$spine_root/scripts/check_skill_migration_o1617_router_drift.py" --self-test
+
+run "migration O-16/O-17 router drift" "python scripts/check_skill_migration_o1617_router_drift.py --verbose --ci" \
+  python "$spine_root/scripts/check_skill_migration_o1617_router_drift.py" --verbose --ci
+
+run "implementor partition self-test" "python scripts/check_skill_implementor_partition_drift.py --self-test" \
+  python "$spine_root/scripts/check_skill_implementor_partition_drift.py" --self-test
+
+run "implementor partition drift" "python scripts/check_skill_implementor_partition_drift.py --verbose --ci" \
+  python "$spine_root/scripts/check_skill_implementor_partition_drift.py" --verbose --ci
+
+run "re-frame2 skill drift self-test" "python scripts/check_skill_re_frame2_drift.py --self-test" \
+  python "$spine_root/scripts/check_skill_re_frame2_drift.py" --self-test
+
+run "re-frame2 skill drift" "python scripts/check_skill_re_frame2_drift.py --verbose --ci" \
+  python "$spine_root/scripts/check_skill_re_frame2_drift.py" --verbose --ci
+
+run "skill package-refs self-test" "python scripts/check_skill_package_refs.py --self-test" \
+  python "$spine_root/scripts/check_skill_package_refs.py" --self-test
+
+run "skill package refs" "python scripts/check_skill_package_refs.py --verbose --ci" \
+  python "$spine_root/scripts/check_skill_package_refs.py" --verbose --ci
+
+run "pair-authoring drift self-test" "python scripts/check_skill_pair_authoring_drift.py --self-test" \
+  python "$spine_root/scripts/check_skill_pair_authoring_drift.py" --self-test
+
+run "pair-authoring drift" "python scripts/check_skill_pair_authoring_drift.py --verbose --ci" \
+  python "$spine_root/scripts/check_skill_pair_authoring_drift.py" --verbose --ci
+
+run "setup-counter drift self-test" "python scripts/check_skill_setup_counter_drift.py --self-test" \
+  python "$spine_root/scripts/check_skill_setup_counter_drift.py" --self-test
+
+run "setup-counter drift" "python scripts/check_skill_setup_counter_drift.py --verbose --ci" \
+  python "$spine_root/scripts/check_skill_setup_counter_drift.py" --verbose --ci
+
+run "eval-packaging self-test" "python scripts/check_skill_eval_packaging.py --self-test --ci" \
+  python "$spine_root/scripts/check_skill_eval_packaging.py" --self-test --ci
+
+run "skill eval packaging" "python scripts/check_skill_eval_packaging.py --verbose --ci" \
+  python "$spine_root/scripts/check_skill_eval_packaging.py" --verbose --ci
+
+run "Xray tab-inventory self-test" "python scripts/check_skill_xray_tab_inventory_drift.py --self-test" \
+  python "$spine_root/scripts/check_skill_xray_tab_inventory_drift.py" --self-test
+
+run "Xray tab-inventory drift" "python scripts/check_skill_xray_tab_inventory_drift.py --verbose --ci" \
+  python "$spine_root/scripts/check_skill_xray_tab_inventory_drift.py" --verbose --ci
+
+run "skill redirect anchors" "python scripts/check_skill_redirect_anchors.py" \
+  python "$spine_root/scripts/check_skill_redirect_anchors.py"
+
+run "keyword-catalogue drift self-test" "python scripts/check_keyword_catalogue_drift.py --self-test --verbose" \
+  python "$spine_root/scripts/check_keyword_catalogue_drift.py" --self-test --verbose
+
+run "keyword-catalogue drift" "python scripts/check_keyword_catalogue_drift.py --verbose" \
+  python "$spine_root/scripts/check_keyword_catalogue_drift.py" --verbose
+
+run "CI reproduce-commands self-test" "python scripts/check_ci_reproduce_commands.py --self-test --verbose" \
+  python "$spine_root/scripts/check_ci_reproduce_commands.py" --self-test --verbose
+
+run "CI reproduce-commands" "python scripts/check_ci_reproduce_commands.py --check --verbose" \
+  python "$spine_root/scripts/check_ci_reproduce_commands.py" --check --verbose
+
+# The last three are `verify-readme-links`', not the invariant job's.  Note that
+# CI runs `check_readme_links --ci` ALWAYS-ON while this spine runs it in the
+# documentation tier; only the self-test arm is added here, so the live scan
+# keeps its existing tier and nothing gets slower for a code-only diff.
+run "README link validator self-test" "python scripts/check_readme_links.py --self-test --verbose" \
+  python "$spine_root/scripts/check_readme_links.py" --self-test --verbose
+
+run "README inventory ratchet self-test" "python scripts/check_readme_inventories.py --self-test --verbose" \
+  python "$spine_root/scripts/check_readme_inventories.py" --self-test --verbose
+
+run "adapter-disposition self-test" "python scripts/check_adapter_disposition.py --self-test --verbose" \
+  python "$spine_root/scripts/check_adapter_disposition.py" --self-test --verbose
+
+run "adapter disposition" "python scripts/check_adapter_disposition.py --verbose --ci" \
+  python "$spine_root/scripts/check_adapter_disposition.py" --verbose --ci
+
+# The lockstep gate's OWN self-test (rf2-ejm7m).  The live scan above is the
+# spine's oldest always-on gate; its self-test arm — the thing that proves the
+# lockstep checkers still fire — is a separate required step of the same job and
+# had no lane.  ~1.7s.  Same CRLF-stripping dance as the live invocation: this
+# checkout is Windows, and the script is `bash`, not `python`.
+run "lockstep gate self-test" "./.github/scripts/verify-version-lockstep.sh --self-test" \
+  bash -lc "tmp='$spine_root/.github/scripts/.verify-version-lockstep.selftest.tmp.'\$\$; trap 'rm -f \"\$tmp\"' EXIT; tr -d '\r' < '$spine_root/.github/scripts/verify-version-lockstep.sh' > \"\$tmp\"; bash \"\$tmp\" --self-test"
+
+# ---------------------------------------------------------------------------
 # The spine's OWN self-test — armed only when the spine's own tree changed
 # (rf2-fhdd3).  Every other gate above pairs a self-test with a live scan; the
 # runner had neither.  `run-self-test.sh` drives this script in `--plan` mode


### PR DESCRIPTION
Closes rf2-ejm7m.

`scripts/check_fast_pr_gap.py` (rf2-13zre) named the gap; this gives it a lane. The
largest single finding in that report was not a browser lane or a linter — it was
**thirty-eight required `python scripts/check_*.py` invocations with no way to be run
locally at all**. Thirty-seven now have one. The thirty-eighth is measured, named, and
deliberately left out.

## The measurement, which is the whole decision

The ruling was *measure first, fold in only if the batch is genuinely cheap*. So every
invocation was timed individually, from a clean checkout, foreground, with CI's own flags.
Two consecutive passes (first = cold):

| Group | Invocations | Cold | Warm |
|---|---:|---:|---:|
| Always-on (`verify-skill-mcp-drift` + `verify-readme-links`) | 29 | **4.46s** | 4.58s |
| Docs tier (`docs.yml` `build`) | 9 | **39.59s** | 44.53s |
| **Total** | **38** | **44.05s** | 49.12s |

That total is misleading on purpose, and it is why the answer is not "yes" or "no" but
"yes to 37". **One checker is 85% of it.**

| Invocation | Cold | Share of its group |
|---|---:|---:|
| `check_retired_image_keys.py --verbose` | **37.66s** | 95% of the docs batch |
| `check_keyword_catalogue_drift.py --verbose` | 1.00s | 22% of the always-on batch |
| `check_retired_composition_vocab.py --verbose` | 1.06s | |
| every one of the other 35 | ≤ 0.36s | |

**The other thirty-seven cost 6.4s between them.** Twenty-five are under 0.15s, which is
barely more than the ~0.02s interpreter start each one already pays.

Baselines to price that against, measured the same way on this checkout:

| Spine tier | Before (measured) | Delta (measured) | After |
|---|---:|---:|---:|
| Always-on block | 14.27s | +4.46s python, +1.68s lockstep | ~20.4s (+43%) |
| Documentation tier | 28.2s | +1.93s | ~30.1s (+7%) |
| Documentation tier *if the 38th were folded in* | 28.2s | +37.66s | **~66s (+134%)** |

The "after" column is baseline-plus-delta arithmetic over two separately measured
quantities, not one end-to-end timing: once the spine's own tree is in the diff it forces
*every* tier (rf2-fhdd3), so the always-on block and the docs tier cannot be timed in
isolation from this branch. Both inputs were measured on this checkout — the baselines
before any edit, the deltas per invocation.

## The verdict, and where it agrees and disagrees with the ruling

**It agrees for 37 of 38, and the ruling anticipated the 38th** ("a 16-cheap-1-expensive
split is a different decision from 17 uniformly cheap ones, and it may deserve a different
answer for that one"). It does.

- **Folded in: 29 always-on.** CI runs `verify-skill-mcp-drift` and `verify-readme-links`
  with no `if:` and no `needs: detect` — no diff can skip them, so always-on here is the
  faithful mirror rather than a local choice. 4.5s.
- **Folded in: 8 docs-tier.** CI gates `docs.yml`'s `build` on `docs_surface`, so these go
  in the documentation tier and a code-only diff pays nothing for them. 1.9s.
- **Not folded in: `check_retired_image_keys.py --verbose`.** 37.7s alone. It would take
  the documentation tier from ~28s to ~66s — every worker touching a single `.md` file
  pays a 2.4x slowdown to prevent an ambush that costs one round trip. That is a worse
  trade than the ambush, which is exactly the case the ruling reserved. **Here is the
  number; it is not folded in.** Its 0.08s **self-test arm is** in the docs tier — the
  thing that proves the guard still has teeth is cheap even when the corpus sweep is not.
- **Also folded in: `verify-version-lockstep.sh --self-test`** (~1.7s), which the bead
  names alongside the Python ones. Its live arm is the spine's oldest always-on gate; the
  self-test arm that proves its checkers fire had no lane.

The 37.7s is real CPU, not I/O and not a Windows artefact. cProfile over a clean checkout,
3,534 files: 28.0s in `re.Pattern.search` across **9,374,502 calls**, plus 11.9s in a
per-character `_mask_multiline_clj_strings` (2.6M `str.join` calls). Actual file reads are
0.7s. A literal-token pre-filter in front of the regex battery should elide >95% of those
searches. Filed as **rf2-e1xx0** with the profile and an acceptance test; when it lands,
one `run` line moves it into the tier and the gap map stops naming it by construction.

## How the gap map stays derived and true

**No hand-edit anywhere, and none is possible.** `check_fast_pr_gap.py` derives this
spine's coverage by parsing the runner's own source for the literal shape
`python "$spine_root/scripts/check_<name>.py"`, matching `(script, mode)` pairs against
CI's. Add a `run` line and the checker leaves the report; delete one and it returns.

That constraint dictated the shape of the change, and is why **there is no helper, no loop
and no framework** — a loop over a script-name variable would be shorter and would break
the derivation outright: the parser would see nothing, and every CI checker would be
re-reported as unrun. The lines are written out one per invocation on purpose, and the
reason is in the comment so the next person does not "tidy" it.

Verified end to end:

```
before:  126 required checks unrun locally   (38 python-checker invocations)
after:    88 required checks unrun locally   ( 1 python-checker invocation)
```

The one that remains is `check_retired_image_keys` — which is correct, derived, and the
honest state of the world.

One signature had to be added to `SPINE_LANES`: the lockstep gate's self-test is a separate
required step and the live lane's `$`-anchored pattern cannot match the `--self-test` form.
**The ratchet still holds** — `--self-test` and `--check` both pass, and a lane matching no
required step is still a hard failure.

## Surface-gating: honoured, and one gap closed

Each group went to the tier CI already gates it on, verified by reading the workflows rather
than assumed:

- `verify-skill-mcp-drift`, `verify-readme-links` — no `if:`, no `needs:` → **always-on**.
- `docs.yml` `build` — `if: needs.detect.outputs.docs_surface == 'true'` → **docs tier**.

The spine's `is_doc_surface_path` was **narrower than `docs.yml`'s own classifier** for
exactly these scripts, so adding them without widening it would have created a lane that
does not arm when you edit the gate itself. The four checker scripts and their fixture trees
are now on the documentation surface — the same rule already applied to their neighbours.
Three are named identically in `docs.yml`'s `detect`, so that part mirrors CI rather than
inventing a local surface; `check_retired_image_keys.py` is not in CI's list but is added
anyway, because this spine now executes its self-test and the direction is the safe one.

**Note on `check_readme_links`:** CI runs its live scan always-on while this spine runs it
in the documentation tier. Only the **self-test** arm is added here, so the live scan keeps
its existing tier and nothing gets slower for a code-only diff. Flagging it rather than
silently changing it.

## Not the PR #7496 trap

#7496 found that `mkdocs build --strict` reads `docs/`, and `docs.yml` stages
`cp -r spec docs/spec` before it — so a bare local run exits 0 having read nothing of a
spec edit. That is a lane that arms and catches nothing, and it is the exact failure mode a
change like this one could introduce four more of.

It does not apply here, and this was checked rather than assumed. All three residue sweeps
carry `_EXCLUDE_REL_PREFIXES = ("docs/spec/",)`: they scan the **tracked** `spec/` tree and
explicitly skip the staged mirror. `check_retired_image_keys` names `spec` directly in
`DEFAULT_DOC_DIRS`. `check_failure_corpus_residue` scans a 28-file corpus by name. Nothing
here depends on a staging step that only CI performs — and the mutation proofs below plant
their residue in the source tree and watch the spine go red, which is the empirical version
of the same claim.

## Mutation proof

**Six of the thirty-seven, chosen by axis rather than at random.** The lanes differ along
three dimensions that could each fail independently, so the sample covers every value of
each: **tier** (always-on / docs), **mode** (live scan / self-test arm — sixteen of the
thirty-eight are self-test arms, so a sample of live scans only would prove half of
nothing), **input surface** (skills corpus / workflow YAML / tracked `spec/` tree / named
file corpus), plus the one **non-Python mechanism** (the lockstep shell gate, invoked
through a CRLF-stripping `bash -lc` dance rather than `python`) and the one checker whose
**live arm is deliberately excluded**, whose surviving self-test lane is the one most at
risk of being decorative.

Each case plants a defect the gate is designed to catch, runs **the spine** (not the
checker alone) foreground to completion, and asserts a non-zero exit naming that gate.
Then reverts. All six:

| # | Lane proven | Tier / mode | Mutation | Spine result |
|---|---|---|---|---|
| A | `check_skill_package_refs --verbose --ci` | always-on / live | stripped the distribution caveat from `skills/re-frame2-pair/README.md` | rc=1 `FAIL skill package refs` |
| B | `check_ci_reproduce_commands` | always-on / live+self-test | dropped `--self-test` from a checker step in `test.yml` | rc=1 `FAIL CI reproduce-commands self-test` |
| C | `check_readme_links --self-test --verbose` | always-on / self-test | made `check()` report no broken link, ever | rc=1 `FAIL README link validator self-test` |
| D | `check_inject_cofx_residue --verbose` | docs / live | planted `(rf/inject-cofx :now)` in a fenced block in `spec/002-Frames.md` | rc=1 `FAIL inject-cofx residue` |
| E | `check_retired_image_keys --self-test --verbose` | docs / self-test | neutered `_retired_key_hits` | rc=1 `FAIL retired image-keys self-test` |
| F | `verify-version-lockstep.sh --self-test` | always-on / shell | made `check_no_git_coords_in_runtime_deps` never report | rc=1 `FAIL lockstep gate self-test` |

Two of them took more than one attempt, and both detours are worth reporting rather than
quietly fixing.

**B cannot be isolated, and that is a property of the checker.**
`check_ci_reproduce_commands`' self-test re-runs the live audit against the *real*
workflow, so any `test.yml` drift reds the self-test arm before the live arm is reached.
Both arms are lanes this PR adds, so the defect is caught either way; the live invocation
was additionally run standalone against the same mutation and returned **rc=1**, so it is
proven wired, not merely shadowed.

**E exposed a real hole in `check_retired_image_keys`' own self-test — filed as
rf2-e1xx0.** The first mutation deleted `:replace-standard` detection outright and the
self-test **stayed green**; the second deleted `:rf.gen/requires` and it stayed green
again. The cause is fixture coverage: there are three positive fixtures, and between them
they exercise `:include-ns`, `:capabilities`, `:replace`, `:rf.image/requires` and
`:rf.gen/requires` — but not `:replace-standard` or `:exclude-ns`, and the positive
assertion is "≥1 finding", so a fixture carrying two retired tokens stays "detected" when
one of them loses its detector. **Two of the seven tokens this gate claims to enforce can
lose their teeth silently.** That matters more now, not less: this PR puts the 0.08s
self-test in the spine and leaves the 37.7s live scan CI-only, so the self-test is what
stands behind the gate locally. The third mutation (neuter the detector wholesale) reds the
spine correctly, so the **lane** is wired; the gap is fixture coverage, and one positive
fixture per retired token is now on rf2-e1xx0's acceptance.

That is the arming-not-catching pattern this project has been finding all week, caught here
because the sample deliberately included the arm whose live counterpart was being dropped.

## Quality gates

All foreground to completion, exit codes read from each runner's own marker.

| Gate | Exit | Note |
|---|---|---|
| `sh scripts/test-fast-pr.sh` (full spine) | **0** | `PASS fast PR spine`, **74** gates — every tier, since the spine's own tree is in the diff |
| `python scripts/check_fast_pr_gap.py --self-test` | **0** | all self-tests passed (incl. the ratchet cases) |
| `python scripts/check_fast_pr_gap.py --check` | **0** | map clean; 88 unrun, down from 126 |
| `npm run test:script-policy && npm run test:script-helpers` (chained, as CI runs it) | **0** | |
| `npm ci` (implementation) | 0 | this worktree had no `node_modules`; a **real directory**, not a junction, so no junction cleanup applies |

The spine's own PASS line now reports **3** not-run items, and the first is the excluded
checker naming its own measurement:

```
NOT RUN by this spine (3):
  - check_retired_image_keys.py --verbose (docs.yml, required) - 37.7s measured, 95% of
    that job's checker batch and >2x this whole tier; self-test arm runs above, live
    corpus sweep is CI-only by measurement (rf2-ejm7m, perf follow-up rf2-e1xx0)
```

**Root ESLint (`npm run lint:js`) not run and not required here** — it gates `.cjs`, and
this diff touches none (`scripts/test-fast-pr.sh`, `scripts/check_fast_pr_gap.py`,
`TESTING.md`). CI reports it `skipping`.

**`mkdocs build --strict` is not the gate for the `TESTING.md` edit** — it ran inside the
spine's docs tier and passed, but `check_doc_slugs.py` is the stronger gate for link
targets and heading anchors, and it also passed. The edit adds prose plus one table-free
paragraph; no new links or headings were introduced beyond plain-text bead ids.

CI on this PR: **76 pass / 0 fail** at the time of writing (1 pending, 5 skipping). The
three jobs this bead is about — `Repo invariant checks`, `Verify README link slugs`,
`Verify lockstep version contract` — are all green.
