### PR TITLE
fix(hicasso): a namespaced keyword keeps its namespace at the crossing (rf2-vrvv9)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_hatch_dom_cljs_test.cljs
@@ -143,7 +143,13 @@
 (defn- instr! []
   (reset! !instr {:mounts 0 :cleanups 0 :renders 0
                   :imperative-args [] :imperative-return nil
-                  :received-imperative nil :ref-node nil :ref-cleanups 0}))
+                  :received-imperative nil :ref-node nil :ref-cleanups 0
+                  ;; Every context value the foreign side ever read, in the
+                  ;; order it read them (rf2-vrvv9). Accumulated rather than
+                  ;; overwritten because the question is whether two
+                  ;; DISTINCT values stay distinct across the crossing, and
+                  ;; the last one alone cannot answer it.
+                  :context-themes []}))
 
 (defn- widget
   "The worst reasonable case, as a plain React function component — raw
@@ -154,6 +160,7 @@
   (when-some [f (.-onImperative props)]
     (swap! !instr assoc :received-imperative f))
   (let [theme       (react/useContext theme-context)
+        _           (swap! !instr update :context-themes (fnil conj []) theme)
         clicks-hook (react/useState 0)
         clicks      (aget clicks-hook 0)
         set-clicks  (aget clicks-hook 1)
@@ -272,6 +279,20 @@
              :on-imperative stable-imperative
              :ref           grab-ref}
      [:em.gifted "from hiccup"]]]])
+
+(defview namespaced-theme-page
+  "TWO hosted providers of the ONE context, side by side, each handed a
+  namespaced keyword from a DIFFERENT namespace (rf2-vrvv9). Siblings
+  rather than nested, because the question is whether two distinct values
+  stay two — and a nested pair would only ever show the inner one.
+
+  This is HD-011's flagship case at its full width: a provider an
+  ecosystem library hands you, whose `:value` names a theme, and a
+  foreign consumer below reading it back through `useContext`."
+  [_]
+  [:div.themes
+   [:div.theme-a [themed {:value :theme/dark} [picker {:label "a"}]]]
+   [:div.theme-b [themed {:value :other/dark} [picker {:label "b"}]]]])
 
 (defview host-page
   "The minimal page the hook probe counts: one shell, one hosted widget,
@@ -426,6 +447,42 @@
                       (finally (vreset! census (teardown-census! handle))))
                     (is (= released @census))
                     (done))))
+              (.catch (fn [e] (is false (str e)) (done)))))))))
+
+(deftest two-namespaced-keywords-reach-two-providers-as-two-distinct-values
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
+        (instr!)
+        (fresh!)
+        (let [handle (mount/root! (mount/fresh-container!) frame-id
+                                  [namespaced-theme-page {}])]
+          (-> (settled!)
+              (.then
+                (fn [_]
+                  (try
+                    (let [seen (set (:context-themes @!instr))]
+                      (testing "rf2-vrvv9, at the far end of the crossing. The
+                                foreign consumer records every context value it
+                                reads; under the old `(name v)` rule BOTH
+                                providers handed it \"dark\" and this set held
+                                ONE element — two themes, silently one, with
+                                nothing thrown anywhere."
+                        (is (= 2 (count seen))
+                            "the collision, stated as a count: two distinct
+                             keywords in, two distinct values out")
+                        (is (= #{:theme/dark :other/dark} seen)
+                            "and they are the keywords the author wrote,
+                             namespaces intact — so `=` against that literal is
+                             the whole of reading a context value back"))
+                      (testing "the DOM the foreign component built agrees: it
+                                puts the context value on an attribute, and the
+                                two subtrees differ there"
+                        (is (not= (attr handle ".theme-a .widget" "data-theme")
+                                  (attr handle ".theme-b .widget" "data-theme")))))
+                    (finally (mount/release! handle)))
+                  (done)))
               (.catch (fn [e] (is false (str e)) (done)))))))))
 
 ;; ---------------------------------------------------------------------------
@@ -616,10 +673,23 @@
     (let [h  (codec/mint-host! "hatch/shallow" widget {})
           el (codec/as-element [h {:menu-items [{:day-of-week 1}]
                                    :variant    :compact
+                                   :theme      :theme/dark
+                                   :class      :primary
                                    :plain-fn   identity}])
           ^js props (unchecked-get el "props")]
-      (is (= "compact" (unchecked-get props "variant"))
-          "keyword values cross by name")
+      (is (= :compact (unchecked-get props "variant"))
+          "keyword values cross by IDENTITY, not by name (rf2-vrvv9) — the
+           shallow default's own rule, applied to the value: the author is
+           handed to the library exactly what they typed, here as at the
+           nested map below")
+      (is (= :theme/dark (unchecked-get props "theme"))
+          "so a namespaced keyword keeps its namespace. `(name :theme/dark)`
+           was \"dark\", which :other/dark also was — one output for two
+           inputs, silently")
+      (is (= "primary" (unchecked-get props "className"))
+          "the one exception: a value bound for an HTML attribute has no
+           representation but a string, and this is the answer the native
+           walk gives at the same name")
       (is (identical? identity (unchecked-get props "plainFn"))
           "functions cross by identity — a value handed to a foreign API,
            not a position")

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -1520,22 +1520,85 @@
       (unchecked-set js-props "rfFrame" intent/*frame*))
     (react/createElement (element-type head) js-props)))
 
+(def ^:private html-attr-slots
+  "The emitted slots at a FOREIGN crossing whose value is bound for an
+  HTML attribute wherever the component passes it on, and which therefore
+  has no representation but a string. `className`, `id` and `role` named
+  as SLOTS rather than as keys — `:class`, `:className` and `\"class\"`
+  are one position ([[canonical-slot]]), and a rule written against the
+  spelling is a rule the other spellings walk past. The `data-*` /
+  `aria-*` families join them by prefix; [[prop-name]] leaves those two
+  uncamelCased, so the slot still carries the prefix to test.
+
+  The roster is this repo's own, not a guess: the `reagent-slim` adapter
+  narrowed exactly this seam after an audit and shipped this same set
+  (`adapters/reagent-slim/IMPL-SPEC.md` §7.2, `DESIGN-RATIONALE.md` §5)."
+  #{"className" "id" "role"})
+
+(defn- ^boolean html-attr-slot?
+  "Is `slot` one of the HTML-attribute positions? A non-string slot — the
+  key was neither keyword, symbol nor string, so [[cached-prop-name]]
+  answered it verbatim — is never one."
+  [slot]
+  (and (string? slot)
+       (or (contains? html-attr-slots slot)
+           (str/starts-with? slot "data-")
+           (str/starts-with? slot "aria-"))))
+
 (defn host-prop-value
-  "A host prop value, converted SHALLOWLY — HD-011's default. The
-  top-level KEY is camelCased (that is [[cached-prop-name]], applied by
-  [[host-element]]'s walk); the VALUE crosses with no renaming inside
-  it: functions by identity (so `React.memo` and every downstream
-  bail-out that compares handler identity keep working), keywords and
-  symbols by name, collections through `clj->js` — whose nested map keys
-  keep the spelling the author wrote. A library expecting camelCase
-  inside a nested option map is handed exactly what the author typed,
-  and the guide's answer is to convert that one map yourself: deep
-  conversion guessing at which nested maps are options and which are
-  data is the documented support burden the shallow default deletes."
-  [v]
+  "A host prop value, converted SHALLOWLY — HD-011's default — for the
+  emitted `slot` it is bound for. The top-level KEY is camelCased (that
+  is [[cached-prop-name]], applied by [[host-element]]'s walk); the VALUE
+  crosses with no renaming inside it: functions by identity (so
+  `React.memo` and every downstream bail-out that compares handler
+  identity keep working), collections through `clj->js` — whose nested
+  map keys keep the spelling the author wrote — and **a keyword or symbol
+  by identity, not by name**. A library expecting camelCase inside a
+  nested option map is handed exactly what the author typed, and the
+  guide's answer is to convert that one map yourself: deep conversion
+  guessing at which nested maps are options and which are data is the
+  documented support burden the shallow default deletes.
+
+  ## The named value crosses whole (rf2-vrvv9)
+
+  This branch read `(name v)` for every named value at every host prop,
+  which is stock Reagent's rule — and it silently deleted half of a
+  namespaced keyword's identity at the one crossing where that identity
+  is most often the point. `[provider {:value :theme/dark}]` handed the
+  provider `\"dark\"`, `:other/dark` handed it `\"dark\"` too, and every
+  consumer below read a plausible string that two distinct values now
+  share. Nothing threw. A crossing that answers two inputs with one
+  output is not a conversion, it is a collision.
+
+  **The rule is the shallow default's own rule, applied one level up.**
+  The paragraph above already refuses to guess that a nested map was
+  meant as options; `(name v)` is the same guess about a keyword — that
+  the author meant a string — made silently, on the value the author
+  most often meant literally. The honest answer is the one the nested map
+  already gets: hand the library exactly what was typed. An author who
+  wants `\"contained\"` writes `\"contained\"`, or `(name :contained)`,
+  at the call site where the intent is legible.
+
+  **[[html-attr-slots]] is the one exception, and it is not a roster of
+  taste.** At `className`, `id`, `role`, `data-*` and `aria-*` the value
+  is bound for an HTML attribute, whose only representation is a string —
+  there is nothing to preserve it AS. So those keep `(name v)`, which is
+  also the answer the NATIVE walk gives at the same names
+  ([[convert-prop-value]]) and the answer the server serializer gives, so
+  the two crossings agree on every attribute both can carry.
+
+  **No dev warning accompanies this**, and the omission is deliberate.
+  `reagent-slim` warns once per non-HTML keyword prop because it narrowed
+  the rule underneath an installed Reagent codebase and the warning is
+  that migration's safety-net (DESIGN-RATIONALE §5: \"the warning exists
+  for the case we did not audit\"). Hicasso has no such codebase to
+  protect, and after this change a keyword at a host prop is the CORRECT
+  and taught spelling of HD-011's flagship case — warning on the happy
+  path is a nag, not a diagnostic. The guide teaches the rule instead."
+  [slot v]
   (cond
     (fn? v)                       v
-    (or (keyword? v) (symbol? v)) (name v)
+    (or (keyword? v) (symbol? v)) (if (html-attr-slot? slot) (name v) v)
     (coll? v)                     (clj->js v)
     :else                         v))
 
@@ -1609,7 +1672,10 @@
             :else
             (do (when (and event? (or (vector? v) (map? v)))
                   (refuse-undeclared-host-event! head k v))
-                (host-prop-value v)))))
+                ;; The SLOT, never the key: `:class` and `:className` are
+                ;; one position, and the named-value rule is written
+                ;; against where the value lands (rf2-vrvv9).
+                (host-prop-value slot v)))))
       o)))
 
 (defn- host-element

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
@@ -685,6 +685,83 @@
     (is (= [[:todo.ui/edit 7 "bread"]] @!seen))))
 
 ;; ---------------------------------------------------------------------------
+;; The named value at a foreign crossing (rf2-vrvv9)
+;; ---------------------------------------------------------------------------
+
+(defn- a-foreign-component
+  "Stands in for a library's component — anything React would accept as
+  an element type. Nothing renders here; the questions below are all
+  about what the codec BUILT."
+  [_js-props]
+  nil)
+
+(def ^:private a-host (codec/mint-host! "AHost" a-foreign-component))
+
+(defn- host-prop
+  "The value the codec emitted at `slot` for a one-prop host crossing.
+  Reads the GATE element's props, which are the props object the foreign
+  component receives — the gate forwards it verbatim."
+  [k v slot]
+  (prop (codec/as-element [a-host {k v}]) slot))
+
+(deftest a-namespaced-keyword-keeps-its-namespace-at-a-host-prop
+  (testing "the shape rf2-vrvv9 names. `(name :theme/dark)` is \"dark\", so
+            the namespace used to be discarded on its way to a hosted
+            React-context provider and the value arrived as a plausible
+            string that had lost half its identity."
+    (is (= :theme/dark (host-prop :value :theme/dark "value"))
+        "the keyword crosses whole — not \"dark\", not \"theme/dark\""))
+  (testing "and the collision that made the loss silent is gone. Two
+            keywords from different namespaces used to arrive as ONE
+            string; a crossing that answers two inputs with one output is
+            not a conversion."
+    (let [crossed #{(host-prop :value :theme/dark "value")
+                    (host-prop :value :other/dark "value")}]
+      (is (= 2 (count crossed))
+          "two distinct values in, two distinct values out")
+      (is (= #{:theme/dark :other/dark} crossed))))
+  (testing "an unnamespaced keyword and a symbol take the same rule — the
+            question is the position, never the shape of the name"
+    (is (= :contained (host-prop :variant :contained "variant")))
+    (is (= 'sym (host-prop :variant 'sym "variant")))))
+
+(deftest a-named-value-bound-for-an-html-attribute-still-stringifies
+  (testing "className, id and role: the value is an HTML attribute wherever
+            the component passes it on, and a string is the only
+            representation there is"
+    (is (= "primary" (host-prop :class :primary "className")))
+    (is (= "greeting" (host-prop :id :greeting "id")))
+    (is (= "dialog" (host-prop :role :dialog "role"))))
+  (testing "the data-* / aria-* families, by prefix"
+    (is (= "row" (host-prop :data-kind :row "data-kind")))
+    (is (= "close" (host-prop :aria-label :close "aria-label"))))
+  (testing "the rule is written against the emitted SLOT, never the map key
+            — `:class` and `:className` are one position, and a rule that
+            read the spelling is a rule the other spelling walks past"
+    (is (= "primary" (host-prop :className :primary "className")))
+    (is (= "primary" (host-prop "class" :primary "className"))))
+  (testing "the namespace drop survives ONLY here, and it is the same answer
+            the native walk gives at the same name"
+    (is (= "dark" (host-prop :class :theme/dark "className")))
+    (is (= "dark" (prop (codec/as-element [:div {:class :theme/dark}]) "className"))
+        "the native crossing, unchanged")))
+
+(deftest every-other-host-prop-value-crosses-exactly-as-it-did
+  (testing "functions by identity — `React.memo` and every downstream
+            bail-out that compares handler identity"
+    (let [f (fn [_])]
+      (is (identical? f (host-prop :on-thing f "onThing")))))
+  (testing "collections through clj->js, whose nested keys keep the spelling
+            the author wrote"
+    (let [o (host-prop :options {:pageSize 10} "options")]
+      (is (= 10 (aget o "pageSize")))))
+  (testing "strings, numbers, booleans and nil, verbatim"
+    (is (= "due date" (host-prop :label "due date" "label")))
+    (is (= 7 (host-prop :count 7 "count")))
+    (is (true? (host-prop :open true "open")))
+    (is (nil? (host-prop :label nil "label")))))
+
+;; ---------------------------------------------------------------------------
 ;; What the codec must NOT be
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes **rf2-vrvv9**. `front/codec.cljs`'s `host-prop-value` read `(name v)` for
every named value at every host prop, so `[provider {:value :theme/dark}]` handed
the provider `"dark"` — and `[provider {:value :other/dark}]` handed it `"dark"`
too. Two distinct values, one output, nothing thrown. That is the shape this
project treats as worth fixing.

## What a programmer sees

| | before | after |
|---|---|---|
| `[host {:value :theme/dark}]` | `"dark"` | `:theme/dark` |
| `[host {:value :other/dark}]` | `"dark"` — the same string | `:other/dark` |
| `[host {:variant :compact}]` | `"compact"` | `:compact` |
| `[host {:class :primary}]` | `"primary"` | `"primary"` — unchanged |
| `[host {:data-kind :row}]` | `"row"` | `"row"` — unchanged |
| `[:div {:class :theme/dark}]` (native) | `"dark"` | `"dark"` — unchanged |
| fn / coll / string / number / nil at any host prop | — | unchanged, byte for byte |

**Who is affected.** React-context providers, which HD-011 names as a use case
and whose `:value` is very often a namespaced keyword naming a theme, a locale or
a variant. They gain a value they can compare with `=`. The cost lands on anyone
who wrote a keyword at a host prop *meaning a string* — `{:variant :compact}` —
who now writes `"compact"` or `(name …)`. Nobody in this repo does: the whole
corpus is six `defhost` declarations and their call sites, and every one already
passes strings, subscriptions, functions or intent vectors.

## The argument

**The rule is the shallow default's own rule, applied one level up.**
`host-prop-value`'s docstring already refuses to guess that a nested map was meant
as camelCase options — "deep conversion guessing at which nested maps are options
and which are data is the documented support burden the shallow default deletes".
`(name v)` was the same guess about a keyword: that the author meant a string. It
was made silently, on the value the author most often meant literally, and it was
the one guess in this codec that could answer two inputs with one output.

**`className` / `id` / `role` / `data-*` / `aria-*` are the exception, and not a
roster of taste.** There the value is bound for an HTML attribute wherever the
component passes it on, and a string is the only representation there is — so
those keep `(name v)`, which is also what the native walk answers at the same
names, so the two crossings agree on every attribute both can carry.

**The roster is this repo's own.** `reagent-slim` narrowed exactly this seam after
an audit and shipped exactly this set — `IMPL-SPEC.md` §7.2, `DESIGN-RATIONALE.md`
§5 ("keywords passed as values to any other prop name pass through unchanged").
Note what it decided: the keyword crosses **as a keyword**, not as `"theme/dark"`.
Hicasso now agrees.

**One divergence from `reagent-slim`, deliberate: no dev warning.** Its warn-once
is a migration safety-net for an installed Reagent codebase — "the warning exists
for the case we did not audit". Hicasso has no such codebase, and after this
change a keyword at a host prop is the *correct and taught* spelling of HD-011's
flagship case. Warning on the happy path is a nag, not a diagnostic.

**The rule is written against the emitted SLOT, never the map key** — `:class`,
`:className` and `"class"` are one position. That is the discipline `canonical-slot`
and the owned-literal law already use; a rule that read the spelling is a rule the
other spellings walk past.

## Scope

`host-prop-value` has exactly **one** call site (`host-entry`), and the SSR arm
renders through the same `codec/root-element`, so live and server share one seam
and cannot disagree. The native walk (`convert-prop-value`) is untouched — it must
keep stringifying for DOM and SSR parity. `[:>]` is not built; nothing here
pre-empts it, and it inherits the fix when it lands on this seam.

`defview` boundaries cross a CLJS props map whole and convert nothing.
Declared `:callbacks` slots bypass `host-prop-value` entirely.

**Untouched:** the ordinary render path (the `fn?`, `coll?` and `:else` branches
are identical, and only a keyword/symbol value pays the new slot test), the
`≤2-hook` shell, `shell-hook-ledger`, `PropSlot`, and the prop/tag caches. No hook
was added.

## Not in this PR

The guide now owes two rows it did not owe before — a **Defaults**-table row for
prop *values* in `draft-guide/05-interop.md`, and a Troubleshooting row for "the
library ignored my keyword prop". Guide prose was fenced out of this bead. No
existing sentence became false (the Defaults table speaks only about keys), but
without those rows the trap is moved rather than deleted. Filed as **rf2-pdfbk**,
along with the two namespace-dropping positions this change deliberately leaves
alone (a keyword *child*, and `clj->js` over a collection value).

## Quality gates

Run from `implementation/` unless noted. Every one foreground, to completion.

| Gate | Exit |
|---|---|
| `npm run test:hicasso-compile` | 0 — 118 lane namespaces, 0 warnings |
| `npm run test:cljs` | 0 — 12582 tests / 63071 assertions, 0 failures, 0 errors |
| `npm run test:browser` | see below |
| `sh scripts/test-fast-pr.sh` (repo root) | see below |
| `clj-kondo` (CI-pinned 2026.04.15, `lint.yml`'s invocation) | see below |

### Mutation proof

Reverting `host-prop-value` to `(name v)` and re-running is recorded below — a
test that cannot fail on the old behaviour proves nothing.


---

## Quality gates — the results promised above, recorded (mayor, 2026-08-05)

Added after merge because the table above left three gates as "see below" and the body ended. Recorded here so this PR is durable evidence rather than a promise. Source: the implementing worker's final report; the counts also appear in this bead's close record.

| Gate | Exit | Result |
|---|---|---|
| `npm run test:hicasso-compile` | **0** | 118 namespaces, 0 warnings |
| `npm run test:cljs` | **0** | 12,582 tests / 63,071 assertions, 0 failures / 0 errors |
| `npm run test:browser` | **0** | 1,091 tests / 6,766 assertions, 0 failures / 0 errors |
| clj-kondo, CI-pinned 2026.04.15, `lint.yml`'s exact invocation | **0** | **errors: 0**, warnings 4,534 (baseline exactly) |
| `sh scripts/test-fast-pr.sh` | **never completed, twice** | see below |

**The spine did not complete, and the reason is mine rather than the diff's.** Both runs died on `FileNotFoundError` for source files disappearing underneath them — first `re_frame/elision`, then `ssr-ring/.../payload.clj`. That was the mayor reaping this worktree mid-run after merging on green, not a real red. CI on this PR is the authority and was green: **47 pass / 36 skip / 0 fail / 0 cancelled**, with all three required contexts (`All required checks passed`, `Lint required`, `Docs required`) passing.

**Mutation proof, both directions, both runtimes.** Reverting `host-prop-value` to `(name v)`:
- **node: 7 failures** — `a-namespaced-keyword-keeps-its-namespace-at-a-host-prop` x5, `host-props-convert-shallowly` x2.
- **browser: 5 failures**, including all three rows of `two-namespaced-keywords-reach-two-providers-as-two-distinct-values` — which proves the DOM witness actually ran rather than skipping.

`host-props-convert-shallowly` previously asserted the old rule in as many words ("keyword values cross by name"); it now asserts the new one.
