### PR TITLE
docs(hicasso): triple-pass draft guide (completeness, correctness, voice)

### DIFF
--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -1,12 +1,11 @@
 # Getting started
 
-> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Behaviour matches the experimental arm under `implementation/freehand/test/re_frame/bench/hicasso/`.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Mechanisms are proven under `implementation/freehand/test/re_frame/bench/hicasso/`; product spellings and some call shapes are still settling.
 
 Booting a re-frame2 app today takes about thirty lines: create a React root,
 install an adapter, render a `frame-root` inside it, remember the root across
 hot reloads so React doesn't get a second `create-root` for a live node. Every
-app writes the same ceremony and gets one of the lines subtly wrong at least
-once.
+app writes the same ceremony and gets one of the lines wrong at least once.
 
 Hicasso collapses that into one call.
 

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -1,13 +1,14 @@
 # Views and reads
 
-> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Behaviour matches the experimental arm under `implementation/freehand/test/re_frame/bench/hicasso/`.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Mechanisms are proven under `implementation/freehand/test/re_frame/bench/hicasso/`; product spellings and some call shapes are still settling.
 
 Views that re-render too coarse, and subscription reads that can't live where
-you use them, are the same pain twice: either you hoist a value and re-render a
+you use them, are the same pain twice. Either you hoist a value and re-render a
 room full of siblings, or you invent a second way to read just so a helper can
-see the current filter. Hicasso's answer is a view that is a function from a
-props map to hiccup, and **one** way to read — `sub`, an ordinary function call
-at the point of use:
+see the current filter.
+
+Hicasso's answer is a view that is a function from a props map to hiccup, and
+**one** way to read — `sub`, an ordinary function call at the point of use:
 
 ```clojure
 (ns todo.views
@@ -31,8 +32,8 @@ at the point of use:
 
 ## Boundaries and inlining
 
-Two ways to reach another function from a view body, and the difference is
-visible in the syntax.
+Two ways to reach another function from a view body. The difference is in the
+syntax:
 
 ```clojure
 [todo-row {:key id :id id}]   ;; a vector — a BOUNDARY child
@@ -48,14 +49,12 @@ intents in its hiccup dispatch to.
 A **plain call** is just a function call, and owns none of them. Its hiccup is
 spliced into the caller's tree, and any `sub` it performs donates that read
 *upward* to the enclosing boundary. Helpers cost nothing at runtime and buy no
-re-render granularity. And because reads are ordinary calls, **helpers can
-read**: a `filter-button` that needs the current filter just reads it, and the
-read belongs to whichever boundary is rendering — no value threaded down as an
-argument.
+re-render granularity. Because reads are ordinary calls, **helpers can read**: a
+`filter-button` that needs the current filter just reads it, and the read belongs
+to whichever boundary is rendering — no value threaded down as an argument.
 
-One rule, one visible distinction. Re-render granularity is something you should
-see by reading the source. Keys go in the props map (no Reagent `^{:key}`
-metadata):
+One rule, one visible distinction. Re-render granularity should be obvious from
+the source. Keys go in the props map (no Reagent `^{:key}` metadata):
 
 ```clojure
 (defview todo-list [_]
@@ -92,6 +91,31 @@ hiccup, and a vector whose head is itself a vector is not a legal element.
 
 `:key` never reaches your body. That is React's contract, not a Hicasso choice.
 
+**Fragments and multi-root returns.** A view may return a fragment when it has
+no single wrapper to offer:
+
+```clojure
+(defview toolbar [_]
+  [:<>
+   [save-button {}]
+   [cancel-button {}]])
+```
+
+**Trailing children become `(:children props)`.** A parent that wraps markup
+around its children splices that vector — it does not drop the whole vector in
+as one hiccup child:
+
+```clojure
+(defview card [{:keys [title children]}]
+  (into [:section.card
+         [:h2 title]]
+        children))
+
+[card {:title "Inbox"}
+ [message-row {:id 1}]
+ [message-row {:id 2}]]
+```
+
 ### Bodies are pure and re-runnable
 
 React StrictMode runs your body twice in development. That is fine — bodies are
@@ -121,9 +145,9 @@ takes an explicit changing revision prop, not a `:memo false` switch.
 Reading a subscription high in the tree and passing the value down as a prop
 does **not** lose an update: the boundary that reads is the boundary that
 invalidates, and every boundary the changed value actually reaches receives
-unequal props at that hop. What the default buys you, beyond that chain, is that
-a boundary the value does **not** reach skips instead of re-rendering for
-nothing. Moving the read down is a granularity fix, not a correctness fix.
+unequal props at that hop. What the default buys you is that a boundary the
+value does **not** reach skips instead of re-rendering for nothing. Moving the
+read down is a granularity fix, not a correctness fix.
 
 Whether the bail-out stays the *default* is still open; see **Not settled yet**.
 Nothing you write changes either way; what may change is whether you have to ask
@@ -179,12 +203,12 @@ One further key is reserved, and it is the only attribute merge Hicasso has.
 `:&` carries a map of attributes from somewhere else — a caller's forwarded
 remainder, a theme's part attributes — and **the literal keys you write always
 win over it**. The case that makes the law worth having is a controlled input, so
-[Controlled inputs](04-controlled-inputs.md#forwarding-attributes-)
+[Controlled inputs](04-controlled-inputs.md#forwarding-attributes)
 teaches it in full.
 
 ## How `sub` works
 
-Four sentences:
+Four operational claims:
 
 1. One fixed runtime hook per boundary collects the reads the body actually made,
    and the commit installs exactly that edge set — so **a branch not taken
@@ -198,15 +222,21 @@ Four sentences:
    flow changes its reads from render to render re-subscribes the whole set, not
    just the changed key.
 
-That last point is the one to design around. Dynamic control flow is legal; the
-price when taken branches change is a whole-set refresh. See **Advanced** for
+That last point is the one to design around. Dynamic control flow is legal; when
+taken branches change, the price is a whole-set refresh. See **Advanced** for
 the collector mechanics.
 
 ## Rules every read obeys
 
 - **Reading outside a render is an error.** There is no `@`-anywhere. Handler
-  and utility code uses `rf/subscribe-once`, which is a one-shot read that
-  retains no reactive handle.
+  and utility code uses `rf/subscribe-once` — a one-shot read that retains no
+  reactive handle:
+
+  ```clojure
+  ;; Outside a render — e.g. a utility, or an effect body:
+  (let [rows (rf/subscribe-once [:report/rows])]
+    (export/write! rows))
+  ```
 - **Framework subscriptions read identically to your own** — machine tags,
   resource and mutation state, route identity. They are first-class in the
   index, not a special case.

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -1,6 +1,6 @@
 # Events as data
 
-> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Behaviour matches the experimental arm under `implementation/freehand/test/re_frame/bench/hicasso/`.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Mechanisms are proven under `implementation/freehand/test/re_frame/bench/hicasso/`; product spellings and some call shapes are still settling.
 
 Handler attributes are where a data-oriented view layer usually gives up. You
 write pure data all the way down the tree, then `:on-click` needs a function, so
@@ -188,10 +188,22 @@ Most of an application's anchors are navigations. Spell the link as
 
 You name a route and its params and never see a URL. What comes back is one real
 `<a>` whose `:href` is routing's own synthesis and whose `:on-click` carries the
-click decision **as data**, under the second reserved head, `[::h/navigate {…}]`
-— so two renders of one link are equal under `=`, and a structural test reads
-the click decision off the tree. Because it is a plain function, not a boundary,
-it inlines: no hook, no subscription read, no row in any boundary count.
+click decision **as data**, under the second reserved head:
+
+```clojure
+;; Closed map, four keys — the shape a structural test can `=`.
+;; :payload is routing's own synthesis, not something you invent at the link site.
+[::h/navigate {:frame   :rf/default
+               :payload [:rf.route/url-requested {:url    "/profile/jane"
+                                                  :to     :conduit.profile/show
+                                                  :params {:username "jane"}}]
+               :native? false
+               :veto    nil}]
+```
+
+So two renders of one link are equal under `=`, and a structural test reads the
+click decision off the tree. Because it is a plain function, not a boundary, it
+inlines: no hook, no subscription read, no row in any boundary count.
 
 The click law is routing's, stated once: a modifier-click or auxiliary click
 stays the browser's (a new tab opens), a `:target` or `:download` anchor stays

--- a/docs/design/hicasso/draft-guide/04-controlled-inputs.md
+++ b/docs/design/hicasso/draft-guide/04-controlled-inputs.md
@@ -1,8 +1,6 @@
 # Controlled inputs
 
-> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]**
-> may change. Behaviour matches the experimental arm under
-> `implementation/freehand/test/re_frame/bench/hicasso/`.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Mechanisms are proven under `implementation/freehand/test/re_frame/bench/hicasso/`; product spellings and some call shapes are still settling.
 
 A text field whose value lives in app-db: value in from a subscription, intent out
 on every keystroke. That is the whole required path.
@@ -16,8 +14,9 @@ on every keystroke. That is the whole required path.
 
 > **Ordinary `:value` and `:on-input` — no caret helper, no local atom.**
 
-`:on-change` works the same way; if a field carries both, the runtime keeps the
-last one that ran for that keystroke. For checkboxes, use
+`:on-change` works the same way. If a field carries both, both still lower and
+can fire; the runtime's converge (value + caret) wraps **`onChange` when both
+are present**, otherwise `onInput`. For checkboxes, use
 [`::h/checked`](03-events-as-data.md#the-value-placeholders) the same way — see
 [Events as data](03-events-as-data.md).
 
@@ -25,8 +24,8 @@ last one that ran for that keystroke. For checkboxes, use
 
 The value on screen is app-db state, so every keystroke is a round trip:
 keystroke → dispatch → handler → commit → subscription → re-render → DOM value.
-Hicasso keeps that path **inside the same browser turn**, so two things hold without
-you writing either:
+Hicasso keeps that path **inside the same browser turn**, so two things hold
+without you writing either:
 
 1. **Same-tick echo.** The accepted character is back in the field before the
    browser finishes the event. Fast typists do not drop characters.
@@ -34,8 +33,8 @@ you writing either:
    typed — mid-string edits included. Remounting the input to "reset" it is not
    an answer here: remount destroys focus, selection, and composition.
 
-Return `nil` from the handler and the field stays on the model value with the caret
-intact. That is the same path as a successful write; you do not special-case
+Return `nil` from the handler and the field stays on the model value with the
+caret intact. That is the same path as a successful write; you do not special-case
 rejection in the view.
 
 ```clojure
@@ -46,11 +45,11 @@ rejection in the view.
       nil)))                                       ;; rejected — model unchanged
 ```
 
-IME composition is handled for you on the data key-map: a composing Enter does not
-submit, and a live composition is not overwritten when the model refuses or
+IME composition is handled for you on the data key-map: a composing Enter does
+not submit, and a live composition is not overwritten when the model refuses or
 normalises mid-draft. Details under [Advanced](#advanced) if you need them.
 
-## Forwarding attributes: `:&`
+## Forwarding attributes
 
 Sooner or later you wrap the controlled contract once and let call sites pass
 placeholder, `name`, test id, and friends. The remainder rides under one reserved
@@ -66,10 +65,11 @@ key, `:&`:
 [field {:id :title :busy? busy? :type "text" :placeholder "Article Title"}]
 ```
 
-**Literal keys always win** over anything in `:&`. A caller (or a hostile remainder)
-cannot override your `:value` or `:on-input`. When you *want* the caller's value to
-win, leave the literal out: `[:input {:& attrs}]`. Put the element's own classes on
-the tag (`[:input.form-control …]`); `:key` and `:ref` are never taken from `:&`.
+**Literal keys always win** over anything in `:&`. A caller (or a hostile
+remainder) cannot override your `:value` or `:on-input`. When you *want* the
+caller's value to win, leave the literal out: `[:input {:& attrs}]`. Put the
+element's own classes on the tag (`[:input.form-control …]`); `:key` and `:ref`
+are never taken from `:&`.
 
 The law is on the prop slot React ends up with, not the key spelling — so
 `"key"`, `:x/ref`, or `:onInput` against your `:on-input` reach nothing that
@@ -77,11 +77,11 @@ matters either.
 
 ## Resets are by revision, not by value
 
-Force a field back to a value with an **explicit revision** from the caller — form
-reset, revert, server normalisation — not by comparing the incoming value to a
-target. Value-equality reset is how a user who legitimately types that value gets
-yanked mid-edit, and how a same-value reassertion becomes invisible. The prop that
-carries the revision is still unnamed; see **Not settled yet**.
+Force a field back to a value with an **explicit revision** from the caller —
+form reset, revert, server normalisation — not by comparing the incoming value
+to a target. Value-equality reset is how a user who legitimately types that
+value gets yanked mid-edit, and how a same-value reassertion becomes invisible.
+The prop that carries the revision is still unnamed; see **Not settled yet**.
 
 ## Troubleshooting
 
@@ -108,26 +108,26 @@ commit on blur. That is the right shape, not a shortcut.
 
 ### Same-tick mechanics (and the one `flushSync`)
 
-Dispatch for a controlled element runs **synchronously inside the discrete browser
-event**, and store notification is synchronous too, so React commits the echo in
-the same turn. The value is back in the DOM before the browser finishes handling
-the event.
+Dispatch for a controlled element runs **synchronously inside the discrete
+browser event**, and store notification is synchronous too, so React commits the
+echo in the same turn. The value is back in the DOM before the browser finishes
+handling the event.
 
-`flushSync` is not a general default. The one named exception is the controlled-text
-**converge**: it flushes the pending commit before React's end-of-event restore, so
-value *and caret* are correct in-turn — including when the model rejected or
-normalised the keystroke. That path runs once per keystroke on controlled text
-entry only (a caret-bearing `input` or a `textarea` with a non-nil `:value`), and
-once at `compositionend` for the composition carve-out below. Everywhere else it
-is inert. Needing `flushSync` for anything else is a design problem, not a
-feature.
+`flushSync` is not a general default. The one named exception is the
+controlled-text **converge**: it flushes the pending commit before React's
+end-of-event restore, so value *and caret* are correct in-turn — including when
+the model rejected or normalised the keystroke. That path runs once per keystroke
+on controlled text entry only (a caret-bearing `input` or a `textarea` with a
+non-nil `:value`), and once at `compositionend` for the composition carve-out
+below. Everywhere else it is inert. Needing `flushSync` for anything else is a
+design problem, not a feature.
 
 ### Rejection and React's restore
 
-When the handler returns `nil`, the DOM node may briefly hold the typed character;
-React reasserts the model value when the discrete event ends. React's restore
-throws the caret away, so the runtime restores caret and selection itself on that
-converge path. You still only write `nil`.
+When the handler returns `nil`, the DOM node may briefly hold the typed
+character; React reasserts the model value when the discrete event ends. React's
+restore throws the caret away, so the runtime restores caret and selection itself
+on that converge path. You still only write `nil`.
 
 ### IME composition
 
@@ -137,24 +137,25 @@ Two rules, both automatic on the data key-map and controlled-text path:
 candidate; it is not a submit. The key-map gates on the native event's
 `isComposing` and on the legacy keyCode-229 signal some browsers still send.
 
-**A live composition is not overwritten.** If the model refuses or normalises what
-the IME has composed so far, nothing is written to the field while composition is
-running — not the converge, and not React's end-of-event restore. Your handler
-still runs on every composing update; the field keeps showing the composition until
-the user commits it, and the refusal or normalisation applies whole at
-`compositionend`.
+**A live composition is not overwritten.** If the model refuses or normalises
+what the IME has composed so far, nothing is written to the field while
+composition is running — not the converge, and not React's end-of-event restore.
+Your handler still runs on every composing update; the field keeps showing the
+composition until the user commits it, and the refusal or normalisation applies
+whole at `compositionend`.
 
-That last point differs from plain React. On plain React a corrected value written
-during composition can abort the exchange: in-flight kana vanish, `compositionend`
-never fires, and the next update starts a fresh composition on a half-written
-draft. On a *normalising* field it does not merely lose the composition — each
-aborted draft is written back and the IME composes on top of it, so `s`, `sh`,
-commit ends the model at `SSHSH` where Hicasso commits the `SH` that was typed.
-Hicasso carves the live composition out of that restore on purpose.
+That last point differs from plain React. On plain React a corrected value
+written during composition can abort the exchange: in-flight kana vanish,
+`compositionend` never fires, and the next update starts a fresh composition on a
+half-written draft. On a *normalising* field it does not merely lose the
+composition — each aborted draft is written back and the IME composes on top of
+it, so `s`, `sh`, commit ends the model at `SSHSH` where Hicasso commits the `SH`
+that was typed. Hicasso carves the live composition out of that restore on
+purpose.
 
-Scope: controlled **text** entry (same path as the rest of this page). Composition
-behaviour is proven on Chromium; a WebKit IME misbehave is a bug report, not a
-documented limit.
+Scope: controlled **text** entry (same path as the rest of this page).
+Composition behaviour is proven on Chromium; a WebKit IME misbehave is a bug
+report, not a documented limit.
 
 ## Not settled yet
 

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -1,8 +1,6 @@
 # Interop
 
-> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]**
-> may change. Behaviour matches the experimental arm under
-> `implementation/freehand/test/re_frame/bench/hicasso/`.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Mechanisms are proven under `implementation/freehand/test/re_frame/bench/hicasso/`; product spellings and some call shapes are still settling.
 
 You want a date picker from npm. Declare it once, then use it anywhere a view is
 legal:
@@ -30,6 +28,8 @@ legal:
                 ;; takes the library's arguments in order.
                 :on-change (h/fn [date & _] [:task/set-due date])}])
 ```
+
+> **Declare the host once. Use it like any other view head.**
 
 Children cross as ordinary hiccup and lower where they render — including as
 another view's child.
@@ -242,8 +242,8 @@ and put React's hook rules on you. Both are fine; both are yours.
 
 #### If you are not on React 19
 
-Cleanup-returning refs are a React 19 contract. Older shape: callback with the node
-on attach and `nil` on detach, handle in a ref that outlives one invocation:
+Cleanup-returning refs are a React 19 contract. Older shape: callback with the
+node on attach and `nil` on detach, handle in a ref that outlives one invocation:
 
 ```clojure
 (let [handle (react/useRef nil)

--- a/docs/design/hicasso/draft-guide/06-theming.md
+++ b/docs/design/hicasso/draft-guide/06-theming.md
@@ -1,16 +1,24 @@
 # Theming
 
-> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Behaviour matches the experimental arm under `implementation/freehand/test/re_frame/bench/hicasso/`.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Mechanisms are proven under `implementation/freehand/test/re_frame/bench/hicasso/`; product spellings and some call shapes are still settling.
 
-Every React component library reaches for context to theme itself. Hicasso doesn't ship a context API, and theming doesn't need one.
+Every React component library reaches for context to theme itself. Hicasso doesn't
+ship a context API, and theming doesn't need one.
 
-Context is a side channel: invisible to the data tree (so headless tests can't see it), one hook per consumer (hooks already spend their budget elsewhere), a full re-render of every consumer on change, and a second dependency-injection channel next to props. CSS cascade and the data tree each do the job better. Real apps already live on a global theme plus per-instance overrides — that pattern never needed subtree context.
+Context is a side channel: invisible to the data tree (so headless tests can't see
+it), one hook per consumer, a full re-render of every consumer on change, and a
+second dependency-injection channel next to props. CSS cascade and the data tree
+each do the job better. Real apps already live on a global theme plus per-instance
+overrides — that pattern never needed subtree context.
 
-Three layers. Tokens in CSS, part maps as data, the *choice* of theme in app-db.
+> **Tokens in CSS, part maps as data, the *choice* of theme in app-db.**
+
+Three layers.
 
 ## Layer 1 — design tokens as CSS custom properties
 
-The cascade already is a context system. Nearest ancestor wins, it is subtree-scoped, and it is platform-native.
+The cascade already is a context system. Nearest ancestor wins, it is
+subtree-scoped, and it is platform-native.
 
 ```css
 :root {
@@ -30,15 +38,21 @@ The cascade already is a context system. Nearest ancestor wins, it is subtree-sc
 }
 ```
 
-Nothing about the `--app-*` prefix is Hicasso's; name your custom properties whatever your stylesheet already does.
+Nothing about the `--app-*` prefix is Hicasso's; name your custom properties
+whatever your stylesheet already does.
 
-Switching theme is one attribute flip on one element. **After the attribute changes, restyling costs zero React work** — no re-render, no hook, no diff. The cascade recomputes and the component tree is never consulted.
+Switching theme is one attribute flip on one element. **After the attribute
+changes, restyling costs zero React work** — no re-render, no hook, no diff. The
+cascade recomputes and the component tree is never consulted.
 
-That claim is about *after* the flip. What puts the attribute on the DOM is layer 3's job — see [Bridging the choice to the DOM](#bridging-the-choice-to-the-dom).
+That claim is about *after* the flip. What puts the attribute on the DOM is layer
+3's job — see [Bridging the choice to the DOM](#bridging-the-choice-to-the-dom).
 
 ## Layer 2 — parts as data addresses
 
-A control emits keyword-tagged **parts**: named addresses for its internal pieces. A theme is a map from part address to classes and attributes. Applying it is a pure tree-to-tree transform.
+A control emits keyword-tagged **parts**: named addresses for its internal pieces.
+A theme is a map from part address to classes and attributes. Applying it is a
+pure tree-to-tree transform.
 
 ```clojure
 ;; A theme: part address → classes/attrs.
@@ -48,15 +62,22 @@ A control emits keyword-tagged **parts**: named addresses for its internal piece
    [:typeahead :menu]  {:class "ta__menu" :role "listbox"}})
 ```
 
-Merge order is fixed: **`base < app-theme < instance-props`**. The control's own base wins least, the app's theme overrides it, and props at a specific use site override both.
+Merge order is fixed: **`base < app-theme < instance-props`**. The control's own
+base wins least, the app's theme overrides it, and props at a specific use site
+override both.
 
-Because the transform is pure, you can unit-test a theme with `=`. No registry, no multimethods, no runtime resolution order.
+Because the transform is pure, you can unit-test a theme with `=`. No registry, no
+multimethods, no runtime resolution order.
 
-How a control *declares* a part, and how an app *installs* a theme, are not settled yet — see **Not settled yet**. The merge order and the pure-function shape are fixed.
+How a control *declares* a part, and how an app *installs* a theme, are not settled
+yet — see **Not settled yet**. The merge order and the pure-function shape are
+fixed.
 
 ## Layer 3 — app-db for the choice
 
-Which theme is selected is application state like any other: read it with a subscription, write it with an event. Frame isolation, time travel, and Xray visibility come free.
+Which theme is selected is application state like any other: read it with a
+subscription, write it with an event. Frame isolation, time travel, and Xray
+visibility come free.
 
 ```clojure
 (rf/reg-sub :theme/current
@@ -66,11 +87,13 @@ Which theme is selected is application state like any other: read it with a subs
   (fn [{:keys [db]} [_ theme]] {:db (assoc db :theme/current theme)}))
 ```
 
-App-db holds the *choice*. It does not hold the tokens, and it does not hold the part maps.
+App-db holds the *choice*. It does not hold the tokens, and it does not hold the
+part maps.
 
 ## Bridging the choice to the DOM
 
-The event above moves a keyword into app-db. Layer 1's cascade keys off a `data-theme` attribute on a DOM element. Something has to join them.
+The event above moves a keyword into app-db. Layer 1's cascade keys off a
+`data-theme` attribute on a DOM element. Something has to join them.
 
 Two practical options. Pick one for your app; neither needs a new Hicasso API.
 
@@ -87,17 +110,32 @@ One view reads `:theme/current` and puts it on its own element:
 [theme-scope {} [app {}]]
 ```
 
-`children` arrives as a realized *vector* of hiccup forms, which is why it is spliced with `into` rather than dropped in as one child — [Views and reads](02-views-and-reads.md#the-component-abi) has the rule.
+`children` arrives as a realized *vector* of hiccup forms, which is why it is
+spliced with `into` rather than dropped in as one child —
+[Views and reads](02-views-and-reads.md#the-component-abi) has the rule.
 
-**Tradeoff.** The boundary that reads the theme re-renders on every switch — one boundary, known cost. What happens below it depends on the [default value-equality bail-out](02-views-and-reads.md#boundaries-memoize-by-default). `app` is a boundary either way (handed down as `children` or minted inside `theme-scope`), and its props are unaffected by the theme, so they compare `=` and its memo wrapper bails. Lose that only by calling `app` as a plain function instead of writing `[app {}]` — a plain call has no boundary of its own, so it re-runs with `theme-scope` every time.
+**Tradeoff.** The boundary that reads the theme re-renders on every switch — one
+boundary, known cost. What happens below it depends on the
+[default value-equality bail-out](02-views-and-reads.md#boundaries-memoize-by-default).
+`app` is a boundary either way (handed down as `children` or minted inside
+`theme-scope`), and its props are unaffected by the theme, so they compare `=` and
+its memo wrapper bails. Lose that only by calling `app` as a plain function instead
+of writing `[app {}]` — a plain call has no boundary of its own, so it re-runs with
+`theme-scope` every time.
 
-Element identity does not help here: children cross a boundary as hiccup data, not as React elements, so `theme-scope` mints a fresh element for `app` on every render. The skip is always the comparator's `=`, never a referential short-circuit — and `=` on an unchanged props map is cheap. Keep `app` a boundary and the rest of the tree stays quiet.
+Element identity does not help here: children cross a boundary as hiccup data, not
+as React elements, so `theme-scope` mints a fresh element for `app` on every render.
+The skip is always the comparator's `=`, never a referential short-circuit — and
+`=` on an unchanged props map is cheap. Keep `app` a boundary and the rest of the
+tree stays quiet.
 
-**Wins.** The DOM is derived from state. Rewind app-db in Xray and the attribute follows. Tests and restored snapshots stay consistent.
+**Wins.** The DOM is derived from state. Rewind app-db in Xray and the attribute
+follows. Tests and restored snapshots stay consistent.
 
 ### Option B — an effect writes the attribute
 
-Nothing reads the theme in a view. The event that records the choice also returns an effect, and the effect does the flip:
+Nothing reads the theme in a view. The event that records the choice also returns
+an effect, and the effect does the flip:
 
 ```clojure
 (rf/reg-fx :theme/apply!
@@ -117,43 +155,73 @@ while the `:db` write still lands — which looks exactly like an unwired bridge
 `{:platforms #{:client}}` keeps the effect off the server, where there is no
 `document`; [Server-side rendering](10-server-side-rendering.md) has the rule.
 
-**Tradeoff.** Zero React work, literally: no subscription, no boundary, no render. The "one attribute flip, zero React work" claim is exact under this option. What you give up:
+**Tradeoff.** Zero React work, literally: no subscription, no boundary, no render.
+The "one attribute flip, zero React work" claim is exact under this option. What
+you give up:
 
-- **The DOM is no longer derived from state.** Rewind app-db in Xray and the attribute does not follow — no event ran. Time travel, a test fixture, or a restored snapshot can leave the document showing the old theme while app-db says otherwise.
-- **Boot needs its own hand.** Apply the initial theme with an initial event that carries the same effect, or the first paint is unthemed.
-- **It is not frame-isolated.** `document.documentElement` is one element; two frames on one page share it. Targeting each root's own node would need the effect to reach that node, and nothing in the product says an effect can today.
+- **The DOM is no longer derived from state.** Rewind app-db in Xray and the
+  attribute does not follow — no event ran. Time travel, a test fixture, or a
+  restored snapshot can leave the document showing the old theme while app-db says
+  otherwise.
+- **Boot needs its own hand.** Apply the initial theme with an initial event that
+  carries the same effect, or the first paint is unthemed.
+- **It is not frame-isolated.** `document.documentElement` is one element; two
+  frames on one page share it. Targeting each root's own node would need the
+  effect to reach that node, and nothing in the product says an effect can today.
 
 ### Which one?
 
-Ordinary trade: render a fact (A) vs assert it imperatively (B). A keeps derivation at the cost of one reading boundary; B has no render cost and gives up derivation. Neither is the taught default yet — whether A's cost holds at one boundary under multi-frame load, and whether the theme attribute is per-root or per-document, are still open. Until those settle, pick the tradeoff that matches your app.
+Ordinary trade: render a fact (A) vs assert it imperatively (B). A keeps derivation
+at the cost of one reading boundary; B has no render cost and gives up derivation.
+Neither is the taught default yet — whether A's cost holds at one boundary under
+multi-frame load, and whether the theme attribute is per-root or per-document, are
+still open. Until those settle, pick the tradeoff that matches your app.
 
 ## The two laws
 
 ### (a) Owned literals win the merge
 
-**`:key`, `:ref`, controlled `:value` and `:checked`, and owned event handlers cannot be overridden by a theme or by parts.**
+**`:key`, `:ref`, controlled `:value` and `:checked`, and owned event handlers
+cannot be overridden by a theme or by parts.**
 
-A theme can style a field. It cannot rewrite the field's controlled contract. Without this rule, a stylesheet-shaped map could clobber the `:value` of a controlled input — and you would debug that as an input bug for a day.
+A theme can style a field. It cannot rewrite the field's controlled contract.
+Without this rule, a stylesheet-shaped map could clobber the `:value` of a
+controlled input — and you would debug that as an input bug for a day.
 
-This is not theming-specific. There is one attribute merge, spelled `:&`, and the literal keys written in the map always win — whether what arrives is a theme's part attributes, a caller's forwarded remainder, or anything else. A control that emits parts and a control that forwards props share the same rule. See [Controlled inputs](04-controlled-inputs.md#forwarding-attributes-).
+This is not theming-specific. There is one attribute merge, spelled `:&`, and the
+literal keys written in the map always win — whether what arrives is a theme's
+part attributes, a caller's forwarded remainder, or anything else. A control that
+emits parts and a control that forwards props share the same rule. See
+[Controlled inputs](04-controlled-inputs.md#forwarding-attributes).
 
 ### (b) Switchable values live in CSS variables
 
-**Anything that changes at runtime lives in CSS variables. Part-to-class maps are boot-static per app. Structural replacement goes through children and slots, never through parts.**
+**Anything that changes at runtime lives in CSS variables. Part-to-class maps are
+boot-static per app. Structural replacement goes through children and slots, never
+through parts.**
 
 - Light/dark, density, brand — CSS variables, flipped by the attribute in layer 1.
-- A part-to-class map is fixed at boot. Changing one is an app rebuild, **by design** — that is the price of "theme switch is zero React work" for the token layer.
-- A different *structure* (custom menu row, replaced icon) is a child or a slot. Parts address the pieces a control renders; they do not replace them.
+- A part-to-class map is fixed at boot. Changing one is an app rebuild, **by
+  design** — that is the price of "theme switch is zero React work" for the token
+  layer.
+- A different *structure* (custom menu row, replaced icon) is a child or a slot.
+  Parts address the pieces a control renders; they do not replace them.
 
-Break (b) and parts become a second, worse rendering system driven by data at runtime. That is the failure mode the law exists to prevent.
+Break (b) and parts become a second, worse rendering system driven by data at
+runtime. That is the failure mode the law exists to prevent.
 
 ## React context is still there
 
-Hicasso has no context API of its own and does not theme through context. It does not ban React.
+Hicasso has no context API of its own and does not theme through context. It does
+not ban React.
 
-The substrate keeps exactly one internal context — frame identity — and ordinary React context remains available at the host edge: a compound-component contract you are implementing, or a provider an ecosystem library demands. Foreign providers come in through [`defhost`](05-interop.md) like any other component.
+The substrate keeps exactly one internal context — frame identity — and ordinary
+React context remains available at the host edge: a compound-component contract
+you are implementing, or a provider an ecosystem library demands. Foreign providers
+come in through [`defhost`](05-interop.md) like any other component.
 
-Using it means taking on React's rules, a hook per consumer, and a node your structural tests can see less of. Honest trade, stated once.
+Using it means taking on React's rules, a hook per consumer, and a node your
+structural tests can see less of. Honest trade, stated once.
 
 ## Troubleshooting
 
@@ -169,9 +237,13 @@ Using it means taking on React's rules, a hook per consumer, and a node your str
 
 ## When not to theme
 
-If you have one application and one look, skip layer 2 entirely. Parts are for **component-library authorship** — someone else's app consumes your control and needs to restyle its internals without forking it. An app styling its own components has CSS, and CSS is enough.
+If you have one application and one look, skip layer 2 entirely. Parts are for
+**component-library authorship** — someone else's app consumes your control and
+needs to restyle its internals without forking it. An app styling its own
+components has CSS, and CSS is enough.
 
-Reaching for parts inside a single app buys you an indirection layer and a merge order to remember, in exchange for flexibility nobody will use.
+Reaching for parts inside a single app buys you an indirection layer and a merge
+order to remember, in exchange for flexibility nobody will use.
 
 ## Not settled yet
 

--- a/docs/design/hicasso/draft-guide/07-ephemeral-state.md
+++ b/docs/design/hicasso/draft-guide/07-ephemeral-state.md
@@ -1,35 +1,50 @@
 # Ephemeral state
 
-> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Behaviour matches the experimental arm under `implementation/freehand/test/re_frame/bench/hicasso/`.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Mechanisms are proven under `implementation/freehand/test/re_frame/bench/hicasso/`; product spellings and some call shapes are still settling.
 
 Is this dropdown open? Is this row hovered? Is this panel expanded?
 
-In Reagent you reach for `r/atom`. In React you reach for `useState`. In Hicasso there is **no `local`** — no component-local reactive cell, no ratom, no `useState` for application state. Not discouraged. Absent.
+In Reagent you reach for `r/atom`. In React you reach for `useState`. In Hicasso
+there is **no `local`** — no component-local reactive cell, no ratom, no
+`useState` for application state. Not discouraged. Absent.
 
-Most "local state" demand was manufactured by machinery Hicasso does not have — reaction capture, argv memoization, a second reactive system. Open, hover, expanded: put them where the rest of the app already looks.
+Most "local state" demand was manufactured by machinery Hicasso does not have —
+reaction capture, argv memoization, a second reactive system. Open, hover,
+expanded: put them where the rest of the app already looks.
 
-## The placement rule
+> **Semantic application state belongs in app-db. Component mechanics —
+> composition, measurement, focus, animation, SDK handles — may use ordinary
+> React hooks at the host edge.**
 
-> **Semantic application state belongs in app-db. Component mechanics — composition, measurement, focus, animation, SDK handles — may use ordinary React hooks at the honest escape hatch.**
+The test is whether anyone other than this component could care. A dropdown's open
+state affects what the user can do next, so it is semantic. A tooltip's measured
+pixel offset is arithmetic, so it is mechanics.
 
-The test is whether anyone other than this component could care. A dropdown's open state affects what the user can do next, so it is semantic. A tooltip's measured pixel offset is arithmetic, so it is mechanics.
-
-A `defview` body is an honest React function component. Hooks physically work in it. There is no lint police, and if you use one you take on React's hook rules yourself — including the loss of headless testability for that body ([Testing](08-testing.md)).
+A `defview` body is a real React function component. Hooks physically work in it.
+There is no lint police, and if you use one you take on React's hook rules
+yourself — including the loss of headless testability for that body
+([Testing](08-testing.md)).
 
 ## The order to try
 
-1. **CSS.** Hover, focus, active, `:has()`, `<details>`. If the platform already tracks it, no state exists at all.
-2. **Platform-carried state.** Overlays that own open/dismiss, resources that own async status, a controls kit that owns drafts — when those exist. They don't ship yet; until they do, skip to the next step or use app-db.
-3. **Host-private React state at host edges.** Geometry, composition, measure-before-paint. Local to the edge, invisible to the app.
+1. **CSS.** Hover, focus, active, `:has()`, `<details>`. If the platform already
+   tracks it, no state exists at all.
+2. **Platform-carried state.** Overlays that own open/dismiss, resources that own
+   async status, a controls kit that owns drafts — when those exist. They don't
+   ship yet; until they do, skip to the next step or use app-db.
+3. **Host-private React state at host edges.** Geometry, composition,
+   measure-before-paint. Local to the edge, invisible to the app.
 4. **app-db**, for everything semantically meaningful.
 
 Work down the list. Most of the time you stop at 1.
 
 ## app-db for open / expanded / selected
 
-The objection is ceremony: an event, a subscription, and a keypath for "is this open?"
+The objection is ceremony: an event, a subscription, and a keypath for "is this
+open?"
 
-The tax is per-concern, not per-instance. One parametric subscription and one named event serve every instance forever:
+The tax is per-concern, not per-instance. One parametric subscription and one
+named event serve every instance forever:
 
 ```clojure
 (rf/reg-sub :panel/expanded?
@@ -47,7 +62,10 @@ The tax is per-concern, not per-instance. One parametric subscription and one na
    (when (sub [:panel/expanded? id]) [panel-body {:id id}])])
 ```
 
-Ten lines, once. A hundred panels, no further cost. And you get what a local cell cannot give: the state time-travels, it is visible in Xray, it is isolated per frame, and a test can set it with a `:db` write — "open this dropdown" is not a click simulation.
+Ten lines, once. A hundred panels, no further cost. And you get what a local cell
+cannot give: the state time-travels, it is visible in Xray, it is isolated per
+frame, and a test can set it with a `:db` write — "open this dropdown" is not a
+click simulation.
 
 ### The short form: `h/reg-state`
 
@@ -60,40 +78,89 @@ Ten lines, once. A hundred panels, no further cost. And you get what a local cel
 ;;        the documented path     [:ui ::expanded? panel-id]
 ```
 
-One declaration per *concern* — a namespace-qualified keyword — with `{:default v}` as the only option. No second state system: it registers ordinary re-frame artefacts that read and write plain app-db at a documented path. Time travel, Xray, per-frame isolation, and tests writing `:db` all still work.
+One declaration per *concern* — a namespace-qualified keyword — with
+`{:default v}` as the only option. No second state system: it registers ordinary
+re-frame artefacts that read and write plain app-db at a documented path. Time
+travel, Xray, per-frame isolation, and tests writing `:db` all still work.
 
-Keep the long form in mind. It is the definition of what `reg-state` mints, and the shape you graduate to when a write starts to *mean* something (the example's `:panel/toggle` is already that graduation).
+Keep the long form in mind. It is the definition of what `reg-state` mints, and
+the shape you graduate to when a write starts to *mean* something (the example's
+`:panel/toggle` is already that graduation).
 
 Two details that fail silently if you get them wrong:
 
-**Clearing is a framework event, not a magic value.** Dispatch `[::h/clear ::expanded? panel-id]` and the entry is removed, so the default shows through again. A reserved clear *value* is not offered — a concern whose legitimate values are keywords could then silently delete state.
+**Clearing is a framework event, not a magic value.** Dispatch
+`[::h/clear ::expanded? panel-id]` and the entry is removed, so the default shows
+through again. A reserved clear *value* is not offered — a concern whose
+legitimate values are keywords could then silently delete state.
 
-**A nil or malformed instance key refuses loudly**, at read and at write, with `:rf.error/hicasso-state-bad-key` naming the concern — instead of quietly filing every instance under the same broken key.
+**A nil or malformed instance key refuses loudly**, at read and at write, with
+`:rf.error/hicasso-state-bad-key` naming the concern — instead of quietly filing
+every instance under the same broken key.
 
 ## Choosing the instance key
 
-`reg-state` and the long form both need an instance key — `panel-id` above — so a hundred panels do not share one `expanded?`. Hicasso mints no identity for you. React's `useId` is not a fit: hydration ids can diverge under a hydration root, and outside hydration it is a counter whose ids do not survive remount — which app-db-resident state cannot tolerate. The key is authored data: a keyword, string, number, or vector of these.
+`reg-state` and the long form both need an instance key — `panel-id` above — so a
+hundred panels do not share one `expanded?`. Hicasso mints no identity for you.
+React's `useId` is not a fit: hydration ids can diverge under a hydration root,
+and outside hydration it is a counter whose ids do not survive remount — which
+app-db-resident state cannot tolerate. The key is authored data: a keyword,
+string, number, or vector of these.
 
 Checklist:
 
-1. **Domain ids first — entity-qualify when entities can collide.** Prefer the order's id, the row's id, a namespaced keyword for a singleton. Bare ids collide across entity types: order 42 and invoice 42 both landing on `(sub [::expanded? 42])` share one entry. Qualify the value: `[:order/id 42]` and `[:invoice/id 42]`.
-2. **Placement-like concerns key by placement; value-like concerns key by entity.** Is the concern about the *slot on screen* or the *thing shown in it*? A draft of order 42 is value-like — both panes share one draft. `expanded?` is placement-like — collapse the detail pane without folding the list row.
-3. **Nest with `h/child-key`.** A widget inside a widget extends its parent's key: `(h/child-key parent-key :filter)` → `[parent-key :filter]`. Conj's onto a key that is already a vector, so every key bottoms out as a flat vector of authored data.
-4. **If it would be a good React `:key`, it is a good instance key.** Derived from your data, stable across renders, unique among siblings. Same judgment for SSR determinism: server and client must compute the same key from the same snapshot — authored data does; render-order counters do not. Instance state lives under `[:ui …]`; when server-side events write render-affecting instance state, the payload allowlist must name `:ui`, or hydration reports the mismatch ([Server-side rendering](10-server-side-rendering.md)).
+1. **Domain ids first — entity-qualify when entities can collide.** Prefer the
+   order's id, the row's id, a namespaced keyword for a singleton. Bare ids
+   collide across entity types: order 42 and invoice 42 both landing on
+   `(sub [::expanded? 42])` share one entry. Qualify the value:
+   `[:order/id 42]` and `[:invoice/id 42]`.
+2. **Placement-like concerns key by placement; value-like concerns key by
+   entity.** Is the concern about the *slot on screen* or the *thing shown in
+   it*? A draft of order 42 is value-like — both panes share one draft.
+   `expanded?` is placement-like — collapse the detail pane without folding the
+   list row.
+3. **Nest with `h/child-key`.** A widget inside a widget extends its parent's key
+   instead of inventing a fresh one:
+
+   ```clojure
+   (let [filter-key (h/child-key panel-id :filter)]  ;; => [panel-id :filter]
+     (sub [::filter-open? filter-key]))
+   ```
+
+   Conj's onto a key that is already a vector, so every key bottoms out as a flat
+   vector of authored data.
+4. **If it would be a good React `:key`, it is a good instance key.** Derived from
+   your data, stable across renders, unique among siblings. Same judgment for SSR
+   determinism: server and client must compute the same key from the same
+   snapshot — authored data does; render-order counters do not. Instance state
+   lives under `[:ui …]`; when server-side events write render-affecting instance
+   state, the payload allowlist must name `:ui`, or hydration reports the
+   mismatch ([Server-side rendering](10-server-side-rendering.md)).
 
 ## Named events, not a generic setter
 
 Write `[:panel/toggle id]`, never a generic `[:ui/set [:panel/expanded id] true]`.
 
-A named event is a name for what happened — the event log stays readable. A generic setter turns history into a diff stream. `reg-state` keeps that law for the sugar: the setter it mints is **named by its concern** — `[::expanded? panel-id false]` — never a generic `ui/set`.
+A named event is a name for what happened — the event log stays readable. A
+generic setter turns history into a diff stream. `reg-state` keeps that law for
+the sugar: the setter it mints is **named by its concern** —
+`[::expanded? panel-id false]` — never a generic `ui/set`.
 
-The concern-named setter is a floor, not a ceiling. When an occurrence means more than an assignment — fire an effect, other state reacts, the log should say *toggle* — graduate to a named domain event and let the setter go. The sugar exists so ceremony never stops you putting state where it belongs, not so assignment replaces meaning.
+The concern-named setter is a floor, not a ceiling. When an occurrence means more
+than an assignment — fire an effect, other state reacts, the log should say
+*toggle* — graduate to a named domain event and let the setter go. The sugar
+exists so ceremony never stops you putting state where it belongs, not so
+assignment replaces meaning.
 
 ## Exit animation: `h/presence`
 
-One piece of view state app-db cannot hold: a toast is dismissed and gone from app-db (correct), but it should fade out over 300ms, so the node has to outlive the data. App-db is about what is *true*; this is about what is still *painted*.
+One piece of view state app-db cannot hold: a toast is dismissed and gone from
+app-db (correct), but it should fade out over 300ms, so the node has to outlive
+the data. App-db is about what is *true*; this is about what is still *painted*.
 
-`h/presence` retains keyed children that have left the source data, for `:timeout-ms`, and lets each child say what it looks like on the way out — **in its own attribute map**:
+`h/presence` retains keyed children that have left the source data, for
+`:timeout-ms`, and lets each child say what it looks like on the way out — **in
+its own attribute map**:
 
 ```clojure
 (defview toast-tray [_]
@@ -105,28 +172,55 @@ One piece of view state app-db cannot hold: a toast is dismissed and gone from a
       (:message t)])])
 ```
 
-**There is no child view.** The whole tray is inline. Exit attributes sit on the node itself as data, so inline markup is safe — phase is not an ambient dynamic that could silently resolve to the parent's context.
+**There is no child view.** The whole tray is inline. Exit attributes sit on the
+node itself as data, so inline markup is safe — phase is not an ambient dynamic
+that could silently resolve to the parent's context.
 
-**The a11y attributes are one map, not three conditionals.** A retained node is still in the document: it can take focus and clicks until you say otherwise. `:inert`, `:aria-hidden`, and an exit class arrive together, as data, in the phase they belong to.
+**The a11y attributes are one map, not three conditionals.** A retained node is
+still in the document: it can take focus and clicks until you say otherwise.
+`:inert`, `:aria-hidden`, and an exit class arrive together, as data, in the phase
+they belong to.
 
-**When the child is a view, the phase is an ordinary prop:**
+**When the child is a view, the phase is an ordinary prop** — branch on it for
+exit styling (presence cannot merge `::h/unmounting` into an opaque view head):
 
 ```clojure
-[toast-card {:key (:id t) :toast t}]   ;; receives :rf/phase :unmounting
+(defview toast-card [{:keys [toast] :as props}]
+  (let [exiting? (= (:rf/phase props) :unmounting)]
+    [:div.toast (cond-> {:class "toast"}
+                  exiting? (assoc :class "toast toast--exit"
+                                  :inert true
+                                  :aria-hidden true))
+     (:message toast)]))
+
+;; In the tray:
+[toast-card {:key (:id t) :toast t}]
 ```
 
-A test can pass `:rf/phase :unmounting` and assert the exit rendering with no timers, no browser, and no clock.
+A test can pass `:rf/phase :unmounting` and assert the exit rendering with no
+timers, no browser, and no clock.
 
 ### What presence does not do
 
-- `:timeout-ms` is mandatory — both the retention length and a hard terminal bound. Presence is a clock, not a `transitionend` listener, so the node leaves on time whether or not your CSS ran, was disabled, or was overridden by `prefers-reduced-motion`.
-- Re-entry cancels exit: a toast that comes back before the timeout returns to `:present` rather than finishing exit and remounting.
-- Presence never dispatches anything — a node lingering on screen is not a reason for app-db to linger with it.
-- **Order is frozen at first appearance**, so an exiting child does not jump slots mid-animation. Surviving keys keep the order they had; new keys are appended. A list that re-sorts while items are leaving sorts at the data layer, not here.
+- `:timeout-ms` is mandatory — both the retention length and a hard terminal
+  bound. Presence is a clock, not a `transitionend` listener, so the node leaves
+  on time whether or not your CSS ran, was disabled, or was overridden by
+  `prefers-reduced-motion`.
+- Re-entry cancels exit: a toast that comes back before the timeout returns to
+  `:present` rather than finishing exit and remounting.
+- Presence never dispatches anything — a node lingering on screen is not a reason
+  for app-db to linger with it.
+- **Order is frozen at first appearance**, so an exiting child does not jump slots
+  mid-animation. Surviving keys keep the order they had; new keys are appended. A
+  list that re-sorts while items are leaving sorts at the data layer, not here.
 
 ### Enter is the weak half
 
-`::h/mounting` is the mirror of `::h/unmounting`: an attribute-override map presence merges onto nodes in their `:mounting` phase. It ships and it works. Driving an entrance as a `:mounting` → `:present` class flip can lose the race to the browser's first paint, and then nothing animates. For enter, prefer an animation on insertion or `@starting-style`:
+`::h/mounting` is the mirror of `::h/unmounting`: an attribute-override map
+presence merges onto nodes in their `:mounting` phase. It ships and it works.
+Driving an entrance as a `:mounting` → `:present` class flip can lose the race to
+the browser's first paint, and then nothing animates. For enter, prefer an
+animation on insertion or `@starting-style`:
 
 ```css
 .toast { animation: toast-in 200ms ease-out; }
@@ -135,13 +229,24 @@ A test can pass `:rf/phase :unmounting` and assert the exit rendering with no ti
 @media (prefers-reduced-motion: reduce) { .toast { animation: none; transition: none; } }
 ```
 
-Exit transitions happily, because the node is already painted. `::h/mounting` earns its keep on attributes that are simply *true during entry* — `:inert` and `:aria-hidden` until settled — not as the recommended way to fade something in.
+Exit transitions happily, because the node is already painted. `::h/mounting`
+earns its keep on attributes that are simply *true during entry* — `:inert` and
+`:aria-hidden` until settled — not as the recommended way to fade something in.
 
-Under SSR, a presence-managed node **hydrates born-present**, so server HTML never carries `:mounting`-phase attributes ([Server-side rendering](10-server-side-rendering.md)). Nothing that arrived with the page replays an entrance over content the user is already reading — which means the first paint of a server-rendered page is not a moment when `::h/mounting` has been applied.
+Under SSR, a presence-managed node **hydrates born-present**, so server HTML never
+carries `:mounting`-phase attributes
+([Server-side rendering](10-server-side-rendering.md)). Nothing that arrived with
+the page replays an entrance over content the user is already reading — which
+means the first paint of a server-rendered page is not a moment when
+`::h/mounting` has been applied.
 
 ## Where is `:on-mount`?
 
-There is no `:on-mount` and no `:on-unmount`. Hicasso took the *attribute* half of Replicant's mechanism (`::h/mounting` / `::h/unmounting`) and rejected the callback half as less data-oriented than a registered behaviour. Presence knows a node arrived or left, and it never dispatches about either. Four jobs send people looking for `:on-mount`; each has a home:
+There is no `:on-mount` and no `:on-unmount`. Hicasso took the *attribute* half of
+Replicant's mechanism (`::h/mounting` / `::h/unmounting`) and rejected the
+callback half as less data-oriented than a registered behaviour. Presence knows a
+node arrived or left, and it never dispatches about either. Four jobs send people
+looking for `:on-mount`; each has a home:
 
 | Job | Home |
 |---|---|
@@ -150,7 +255,9 @@ There is no `:on-mount` and no `:on-unmount`. Hicasso took the *attribute* half 
 | Animate an entrance or exit | Presence, above. `::h/unmounting` for exit; animation on insertion or `@starting-style` for enter |
 | Drive a real DOM node or a third-party SDK | The host edge. A callback `:ref` hands you the node on attach and takes your return value as the cleanup; a `defhost` component brings whatever hooks it already had ([Interop](05-interop.md)) |
 
-The data spelling of a host behaviour — `{:ref [::autosize {:max-rows 8}]}` — is refused today with `:rf.error/hicasso-ref-vector-reserved`. That value space is reserved, not designed. Until it lands, write the function.
+The data spelling of a host behaviour — `{:ref [::autosize {:max-rows 8}]}` — is
+refused today with `:rf.error/hicasso-ref-vector-reserved`. That value space is
+reserved, not designed. Until it lands, write the function.
 
 ## Troubleshooting
 
@@ -165,15 +272,20 @@ The data spelling of a host behaviour — `{:ref [::autosize {:max-rows 8}]}` �
 | A nil or malformed instance key raises `:rf.error/hicasso-state-bad-key` | The key is not a keyword, string, number, or vector of those | Author a stable domain or placement key; nest with `h/child-key` when needed |
 | A hook body can't be tested headlessly | Hooks put a body outside headless scope, by design | Move the semantic half to app-db; mount-test the mechanics |
 | Hook-order error after a conditional early-return | React's rules, now yours | Hooks at the top of the body, unconditionally |
-| app-db is full of `:ui` noise | Expected — it is the honest home | Namespace the keys and exclude the tier from persistence by convention |
+| app-db is full of `:ui` noise | Expected — it is the right home | Namespace the keys and exclude the tier from persistence by convention |
 
 ## When app-db is the wrong home
 
-**The platform already knows.** Hover and focus are CSS. Writing them into app-db is a re-render per pointer move for a fact the browser was tracking for free.
+**The platform already knows.** Hover and focus are CSS. Writing them into app-db
+is a re-render per pointer move for a fact the browser was tracking for free.
 
-**High-rate host mechanics.** A drag in flight, a scroll offset, an animation frame — 60 to 240 updates a second. Host-local motion off app-db; semantic commits into it. Drag *ends* in app-db. Drag *moves* do not.
+**High-rate host mechanics.** A drag in flight, a scroll offset, an animation
+frame — 60 to 240 updates a second. Host-local motion off app-db; semantic commits
+into it. Drag *ends* in app-db. Drag *moves* do not.
 
-**Values nobody else can see.** A measured pixel offset, an SDK handle, a composition buffer. Host-private React state at the host edge; no one outside that edge needs to know it exists.
+**Values nobody else can see.** A measured pixel offset, an SDK handle, a
+composition buffer. Host-private React state at the host edge; no one outside that
+edge needs to know it exists.
 
 ## Not settled yet
 

--- a/docs/design/hicasso/draft-guide/08-testing.md
+++ b/docs/design/hicasso/draft-guide/08-testing.md
@@ -1,23 +1,90 @@
 # Testing
 
-> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Behaviour matches the experimental arm under `implementation/freehand/test/re_frame/bench/hicasso/`.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Mechanisms are proven under `implementation/freehand/test/re_frame/bench/hicasso/`; product spellings and some call shapes are still settling.
 
-Two ways to test a Hicasso view:
+What you can assert **today** without a browser is data: intent vectors, prevent
+heads, a `route-link`'s click decision, a presence child's exit attrs. What you
+still need a browser for is hooks, foreign components, caret/IME, and real React
+lifecycle. A full headless *render* of a view body is designed but **not built**
+— see the sketch under Advanced.
 
-1. **Headless** — structural render to hiccup data, assert with `=`. Fast, JVM-friendly. **Not built yet** — the sketch below is the intended shape, not a call you can make today.
-2. **Mounted** — real browser, real React. Covers hooks, foreign components, and anything at a host edge.
+> **No fake hook dispatcher, ever.** A stubbed dispatcher passes tests that real
+> React would fail — abandoned renders, StrictMode double-invoke, effect
+> ordering. Split instead: keep the semantic half as data you can `=`, and
+> mount-test the mechanics once.
 
-**No fake hook dispatcher, ever.** A stubbed dispatcher passes tests that real React would fail — abandoned renders, StrictMode double-invoke, effect ordering. Better a loud boundary you can see than a green suite you can't trust. Split instead: keep the semantic half in a hook-free body headless can assert, and mount-test the mechanics once.
-
-What you *can* assert today without a headless render: **intent vectors with `=`**. `{:on-click [:todo/toggle 7]}` is data. The experimental tests already assert intents that way — prevented intents, route-link click decisions, presence exit rendering — with no browser and no clock.
-
-## Headless (sketch — not built)
-
-A structural render returns the view's hiccup tree as data. No DOM, no React, no browser. Nothing in the tree implements this yet; read the block as the designed shape:
+## Assert as data (today)
 
 ```clojure
-;; SKETCH — h/render does not exist, and its spelling is [unfrozen] besides.
-;; Intended semantics, so the shape is visible.
+;; Intent on a button — pure data, no DOM.
+(is (= [:button {:on-click [:todo/toggle 7]} "✓"]
+       (some-lowered-or-hand-built-node)))
+
+;; Prevent head is visible to `=` (metadata would not be).
+(is (= [::h/prevent [:conduit/show-your-feed]]
+       (-> anchor second :on-click)))
+
+;; route-link's click decision — closed navigate map (see Events as data).
+(let [click (:on-click attrs)]
+  (is (vector? click))
+  (is (= :re-frame.hicasso/navigate (first click))))
+```
+
+Events and subscriptions stay ordinary: handlers are functions of coeffects →
+effects map, subs are functions of app-db — test those without any view layer.
+
+## Mounted (real browser)
+
+What exists today is the experimental test fixture under
+`implementation/freehand/test/re_frame/bench/hicasso/` — not a product-named API.
+It covers root lifecycle, a synchronous dispatch path, and residue assertions
+**[unfrozen — no product name yet]**.
+
+It flushes rather than using `act`: `act` diverts React's work to a queue that is
+not the browser's, which is right for an effect-ordering test and wrong when the
+assertion reads the page. After a dispatch, the next line sees the DOM the user
+would have seen.
+
+Every mounted test asserts **zero leaked subscription ref-counts after
+teardown.** Related: an unchanged hot read performs no new attach or release — a
+re-render that reads the same query should show no churn.
+
+Reach for a mounted test when you need:
+
+- a real error boundary catching a real throw ([When a view throws](09-when-a-view-throws.md));
+- caret, selection, or IME behaviour ([Controlled inputs](04-controlled-inputs.md));
+- StrictMode, abandoned first mount, root teardown, or an HMR body swap;
+- keyed insert, delete, and reorder against real DOM nodes;
+- a foreign component's hooks, context, or refs.
+
+## Troubleshooting
+
+| Symptom | What went wrong | Fix |
+|---|---|---|
+| You need a full view tree as data and nothing exists to build it | Headless render is not built yet | Assert the intent / prevent / navigate / presence attrs you *can* see as data; mount-test the rest |
+| A sub read returns `nil` in a future headless test | The query wasn't in the resolver map | Sub-key identity is `(query-id, args)` under value equality — check the args match exactly |
+| Assertion fails on a `nil` in a hiccup tree | A `when` produced `nil`, which renders nothing but is still in the data | Assert the `nil`, or filter before comparing |
+| Ref-count leak after teardown | A subscription outlived its root | A runtime bug — not a test you tune around |
+| A data-level assert passes and the mounted test fails | Real React does things data does not — effect order, double invoke, commit timing | The mounted result is the truth for lifecycle |
+| Caret / IME test can't be written as data | Correct — caret is a browser fact | Mounted browser tests |
+
+## When not to test through the view
+
+If the assertion is about *state*, test the event handler. If it is about
+*derived values*, test the subscription. A view test that dispatches an event and
+then asserts on app-db is testing three things and will fail for reasons that have
+nothing to do with the view.
+
+## Advanced
+
+### Full headless render (not built)
+
+A structural render would return the view's hiccup tree as data — no DOM, no
+React — with sub reads overridable through a pure resolver. Nothing implements
+that yet; the block below is the intended shape only:
+
+```clojure
+;; SKETCH — h/render does not exist; spelling [unfrozen].
 (deftest todo-row-renders-title
   (let [tree (h/render [todo-row {:id 7}]
                        {:subs {[:todo/by-id 7]      {:title "Buy milk"}
@@ -29,64 +96,15 @@ A structural render returns the view's hiccup tree as data. No DOM, no React, no
            tree))))
 ```
 
-Two halves:
-
-**Sub reads overridable through a pure read resolver.** Hand the render a map of query vector → value; the body reads from it. No frame, no app-db, no registration — just the values the view is a function of. This half is the headless path's, and it does not exist yet.
-
-**Intent vectors assertable by equality.** `{:on-click [:todo/toggle 7]}` is data. You can `=` it. The alternative is asserting that a node holds *some function* which, when called, dispatches something — which is why codebases render to a DOM and click things just to find out what a button was going to do. That property is real today; only the full structural render is waiting.
-
-Make the tree data and most of the `data-testid` scaffolding that only existed because the tree wasn't inspectable stops earning its place.
-
-### Where headless stops
-
-**Hook-free tier-1 bodies.** That is the scope, exactly.
-
-If a body calls a React hook — a callback ref for measurement, a `useEffect` for an SDK, anything at a host edge — headless is out. If a body renders a foreign component through [`defhost`](05-interop.md) (or the `[:>]` escape, once it is built), the foreign region is out.
-
-## Mounted (real browser)
-
-What exists today is the experimental test fixture under `implementation/freehand/test/re_frame/bench/hicasso/` — not a product-named API. It covers root lifecycle, a synchronous dispatch path, and residue assertions **[unfrozen — no product name yet]**.
-
-It flushes rather than using `act`: `act` diverts React's work to a queue that is not the browser's, which is right for an effect-ordering test and wrong when the assertion reads the page. After a dispatch, the next line sees the DOM the user would have seen.
-
-Standing assertion on every mounted test: **zero leaked subscription ref-counts after teardown.** Related: an unchanged hot read performs no new attach or release — a re-render that reads the same query should show no churn.
-
-Reach for a mounted test when you need:
-
-- a real error boundary catching a real throw ([When a view throws](09-when-a-view-throws.md));
-- caret, selection, or IME behaviour ([Controlled inputs](04-controlled-inputs.md));
-- StrictMode, abandoned first mount, root teardown, or an HMR body swap;
-- keyed insert, delete, and reorder against real DOM nodes;
-- a foreign component's hooks, context, or refs.
-
-## Testing events and subscriptions
-
-Nothing changes. Events are functions from coeffects to an effects map, and subscriptions are functions of app-db — both testable without any view layer at all, in Hicasso exactly as under Reagent or UIx.
-
-The view-layer question is only ever "what tree did this body produce, given these reads?" — which is the headless path's whole job.
-
-## Troubleshooting
-
-| Symptom | What went wrong | Fix |
-|---|---|---|
-| Headless render throws on a body with hooks | Out of scope by design | Mount-test it, or split the semantic half into a hook-free body |
-| A sub read returns `nil` in a headless test | The query wasn't in the resolver map | Sub-key identity is `(query-id, args)` under value equality — check the args match exactly |
-| Assertion fails on a `nil` in the tree | A `when` produced `nil`, which renders nothing but is still in the data | Assert the `nil`, or filter before comparing |
-| Ref-count leak after teardown | A subscription outlived its root | A runtime bug — not a test you tune around |
-| A test passes headless and fails mounted | Real React does things a data render doesn't — effect order, double invoke, commit timing | The mounted result is the truth |
-| Caret test can't be written headlessly | Correct — caret is a browser fact | Browser witnesses, e.g. the 100-cell editing grid |
-
-## When not to test through the view
-
-If the assertion is about *state*, test the event handler. If it is about *derived values*, test the subscription. A view test that dispatches an event and then asserts on app-db is testing three things and will fail for reasons that have nothing to do with the view.
-
-Headless view tests answer one question — did this body produce the right tree from these reads — and they are excellent at it precisely because that is all they do.
+**Scope when it lands:** hook-free tier-1 bodies only. Hooks, `defhost`, and host
+edges stay mounted tests. Do not invent a fake hook dispatcher to widen the
+scope.
 
 ## Not settled yet
 
 | Question | Status |
 |---|---|
-| Headless render name and signature | Not built. Intended shape: structural render as data, sub reads overridable; `h/render` and `{:subs …}` above are this guide's sketch **[unfrozen]** |
+| Headless render name and signature | Not built. Sketch above is this guide's invention **[unfrozen]** |
 | Read resolver shape | Open. A map is the obvious form; not fixed |
 | Mounted facade name and API | Open. Experimental fixture only; flushes rather than using `act` |
 | One boundary vs a subtree | Open. Whether child boundaries render through or return as unexpanded nodes changes how every test is written |

--- a/docs/design/hicasso/draft-guide/09-when-a-view-throws.md
+++ b/docs/design/hicasso/draft-guide/09-when-a-view-throws.md
@@ -1,8 +1,6 @@
 # When a view throws
 
-> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]**
-> may change. Behaviour matches the experimental arm under
-> `implementation/freehand/test/re_frame/bench/hicasso/`.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Mechanisms are proven under `implementation/freehand/test/re_frame/bench/hicasso/`; product spellings and some call shapes are still settling.
 
 A view body throws — `nil` where a map was expected, a key that moved, a
 subscription shape last week's code cannot handle. React's default is not a red

--- a/docs/design/hicasso/draft-guide/10-server-side-rendering.md
+++ b/docs/design/hicasso/draft-guide/10-server-side-rendering.md
@@ -1,60 +1,135 @@
 # Server-side rendering
 
-> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Behaviour matches the experimental arm under `implementation/freehand/test/re_frame/bench/hicasso/`. This page says what works there and what is still open.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Mechanisms are proven under `implementation/freehand/test/re_frame/bench/hicasso/`; product spellings and some call shapes are still settling.
 
-You want HTML on the first response, then the same app to take over in the browser — without writing the UI twice and without a second renderer that drifts. re-frame2 already treats that as a core goal: pure views, data events, a frame cheap enough to build for one request and tear down when the response is written. Hicasso is meant to be the native view layer in that story, so it has to render on the server, adopt in the browser, and stay honest about both.
+You want HTML on the first response, then the same app to take over in the
+browser — without writing the UI twice and without a second renderer that drifts.
+re-frame2 already treats that as a core goal: pure views, data events, a frame
+cheap enough to build for one request and tear down when the response is written.
+Hicasso is meant to be the native view layer in that story, so it has to render
+on the server, adopt in the browser, and stay honest about both.
 
-The design fits in a sentence:
-
-> **One renderer, run in two places, judged by the framework's hydration machinery.**
+> **One renderer, run in two places, judged by the framework's hydration
+> machinery.**
 
 ## What SSR means here
 
-The runtime that paints in the browser is the runtime that paints on the server. There is no separate HTML emitter hoping to match. The framework's existing hydration path carries the result across: a payload of app state plus a structural render hash goes into the page; the client seeds from that payload, verifies the first client tree against the server hash, and React's `hydrateRoot` keeps the server's nodes and attaches listeners.
+The runtime that paints in the browser is the runtime that paints on the server.
+There is no separate HTML emitter hoping to match. The framework's existing
+hydration path carries the result across: a payload of app state plus a
+structural render hash goes into the page; the client seeds from that payload,
+verifies the first client tree against the server hash, and React's `hydrateRoot`
+keeps the server's nodes and attaches listeners.
 
-Hicasso does not invent a parallel mechanism. It participates in the framework path — payload, `:rf/hydrate`, mismatch check, `ssr-ring` as the HTTP host — and only has to hold up its own end: render a tree on the server, and adopt that tree in the browser.
+Hicasso does not invent a parallel mechanism. It participates in the framework
+path — payload, `:rf/hydrate`, mismatch check, `ssr-ring` as the HTTP host — and
+only has to hold up its own end: render a tree on the server, and adopt that tree
+in the browser.
 
 ## The framework story today
 
-One app, written once, run twice. The runnable reference is `examples/capabilities/ssr` — one `.cljc` shared between JVM and browser, exercised headlessly on every PR. The published [SSR guide](../../../ssr/index.md) teaches the full corpus.
+One app, written once, run twice. The runnable reference is
+`examples/capabilities/ssr` — one `.cljc` shared between JVM and browser,
+exercised headlessly on every PR. The published [SSR guide](../../../ssr/index.md)
+teaches the full corpus.
 
-**Server, per request:** create a fresh frame for that request; run `:initial-events` (client-only effects with `:platforms #{:client}` are skipped); render the settled snapshot to HTML; embed the serialised state and render hash in a framework-owned payload (`__rf_payload`); destroy the frame in a `finally`.
+**Server, per request:** create a fresh frame for that request; run
+`:initial-events` (client-only effects with `:platforms #{:client}` are skipped);
+render the settled snapshot to HTML; embed the serialised state and render hash
+in a framework-owned payload (`__rf_payload`); destroy the frame in a `finally`.
 
-**Client, once:** `hydrate!` reads the payload, dispatches `:rf/hydrate` **before** the first render so the server's state *replaces* the client's, verifies the structural hash (disagreement raises `:rf.ssr/hydration-mismatch`), then adopts the DOM.
+**Client, once:** `hydrate!` reads the payload, dispatches `:rf/hydrate` **before**
+the first render so the server's state *replaces* the client's, verifies the
+structural hash (disagreement raises `:rf.ssr/hydration-mismatch`), then adopts
+the DOM.
 
-None of that is Hicasso-specific. Everything below is what the view layer adds on top.
+None of that is Hicasso-specific. Everything below is what the view layer adds on
+top.
 
 ## What Hicasso adds
 
 | Piece | Status |
 |---|---|
-| `hydrate-root!` **[unfrozen]** — adopt server DOM into a live root (same handle shape as `root!`) | Works in the experimental arm |
+| `hydrate-root!` **[unfrozen]** — adopt server DOM into a live root (same contract shape as `root!`) | Works under the freehand bench |
 | `defhost` `:ssr` — what a foreign region does server-side | Works |
-| Node render entry — existing runtime under `renderToString`, fixture bake, live demo | Works in the experimental arm |
+| Node render entry — existing runtime under `renderToString`, fixture bake, live demo | Works under the freehand bench |
 | End-to-end measurements on a hydrated screen | Have run; not a ship decision |
 | How production hosts will look | Not decided |
 
-The server engine is the client runtime under `react-dom/server`'s `renderToString`, so parity holds by construction. Under a server render every `sub` read is a cold probe: no durable registration, no effects, no commit. The per-request entry seeds app-db through the framework, renders, builds the framework payload, and destroys the frame — see `ssr/entry.cljs` under the experimental arm. That entry is **not** a production host; Spec 011's HTTP contract stays with `ssr-ring`.
+The server engine is the client runtime under `react-dom/server`'s
+`renderToString`, so parity holds by construction. Under a server render every
+`sub` read is a cold probe: no durable registration, no effects, no commit. The
+per-request entry seeds app-db through the framework, renders, builds the
+framework payload, and destroys the frame — see `ssr/entry.cljs` under the
+freehand bench. That entry is **not** a production host; Spec 011's HTTP contract
+stays with `ssr-ring`.
 
-A few properties of `hydrate-root!` matter when you write apps, not when you read status:
+`hydrate-root!` **[unfrozen]** stands beside `root!`
+([Getting started](01-getting-started.md)): same association of a DOM node that
+already holds server HTML, a frame that has already adopted the server's state,
+and one view. Names and arities are not frozen; treat the shape as the teaching
+contract:
 
-- It calls React's `hydrateRoot` without `flushSync`, so it returns before adoption finishes. Completion is observable; do not assume the DOM on the next line is already client-owned.
-- Presence children are **born present** — nothing that arrived with the page replays an entrance over content the user is already reading.
-- Hydration never rewrites controlled text after the fact. The model's value is the one truth from the first paint.
+```clojure
+;; After framework hydrate! has seeded app-db from #__rf_payload:
+(defonce stop!                                    ;; hydrate-root! is [unfrozen]
+  (h/hydrate-root! (js/document.getElementById "app")
+                   {:frame :rf/default}
+                   [views/todo-app {}]))
+```
+
+Properties that matter when you write apps:
+
+- It calls React's `hydrateRoot` without `flushSync`, so it returns before
+  adoption finishes. Completion is observable; do not assume the DOM on the next
+  line is already client-owned.
+- Presence children are **born present** — nothing that arrived with the page
+  replays an entrance over content the user is already reading.
+- Hydration never rewrites controlled text after the fact. The model's value is
+  the one truth from the first paint.
+
+## Instance state and the payload allowlist
+
+`h/reg-state` and other UI instance state live under `[:ui …]` in app-db
+([Ephemeral state](07-ephemeral-state.md)). The framework's hydration payload is
+**fail-closed**: if server-side events write render-affecting values under
+`:ui`, the payload policy must allowlist `:ui` (or the whole app-db). Otherwise
+the client hydrates without those keys, paints from different state than the
+server HTML, and you get `:rf.ssr/hydration-mismatch`.
 
 ## Write the app so SSR is free
 
-Everything above is the runtime's problem. Whether SSR is cheap *for your app* is decided in how you write views and events — and every rule below is usable now.
+Everything above is the runtime's problem. Whether SSR is cheap *for your app* is
+decided in how you write views and events — and every rule below is usable now.
 
-**Keep view bodies portable.** A tier-1 `defview` body is hiccup, reads, and ordinary Clojure. No JS interop in the forms. JS lives at declared edges: `defhost` and host-edge namespaces ([Interop](05-interop.md)). Keep it there and view namespaces load anywhere — the precondition for every server story.
+**Keep view bodies portable.** A tier-1 `defview` body is hiccup, reads, and
+ordinary Clojure. No JS interop in the forms. JS lives at declared edges:
+`defhost` and host-edge namespaces ([Interop](05-interop.md)). Keep it there and
+view namespaces load anywhere — the precondition for every server story.
 
-**Put events as data on the tree.** `[:todo/toggle id]` on `:on-click` has no closure to ship. The runtime builds the callback from the vector on whichever side is rendering. App state crosses the wire as EDN because it *is* data. There is no "serialise my functions" problem.
+**Put events as data on the tree.** `[:todo/toggle id]` on `:on-click` has no
+closure to ship. The runtime builds the callback from the vector on whichever
+side is rendering. App state crosses the wire as EDN because it *is* data. There
+is no "serialise my functions" problem.
 
-**A body is a function of its props and reads.** Same snapshot in, same tree out — that is what "render from a db snapshot" means, and what adoption demands. A clock, a `js/window` sniff, or a random in a body paints one thing on the server and another in the browser; React reports that as a hydration mismatch. Platform work belongs in effects (`:platforms #{:client}`) and at host edges, never in tier-1 bodies — the same purity [Views and reads](02-views-and-reads.md) already requires.
+**A body is a function of its props and reads.** Same snapshot in, same tree out
+— that is what "render from a db snapshot" means, and what adoption demands. A
+clock, a `js/window` sniff, or a random in a body paints one thing on the server
+and another in the browser; React reports that as a hydration mismatch. Platform
+work belongs in effects (`:platforms #{:client}`) and at host edges, never in
+tier-1 bodies — the same purity [Views and reads](02-views-and-reads.md) already
+requires.
 
-**Controlled inputs are already SSR-shaped.** The value comes from the model ([Controlled inputs](04-controlled-inputs.md)); the server renders that value; hydration does not converge the text afterward. Nothing extra to write.
+**Controlled inputs are already SSR-shaped.** The value comes from the model
+([Controlled inputs](04-controlled-inputs.md)); the server renders that value;
+hydration does not converge the text afterward. Nothing extra to write.
 
-**Do not gate entrances on "I just mounted."** Drive enter with insertion animation or `@starting-style` — [Ephemeral state](07-ephemeral-state.md)'s standing rule. The entrance is a CSS fact of the markup; adoption reuses the server's nodes, so it gets no second trigger. Presence handles the other half: a presence-managed node hydrates born-present, so nothing that arrived with the page replays an entrance.
+**Do not gate entrances on "I just mounted."** Drive enter with insertion
+animation or `@starting-style` — [Ephemeral state](07-ephemeral-state.md)'s rule
+for enter. The entrance is a CSS fact of the markup; adoption reuses the server's
+nodes, so it gets no second trigger. Presence handles the other half: a
+presence-managed node hydrates born-present, so nothing that arrived with the
+page replays an entrance.
 
 **Declare each foreign region's server story at `defhost`:**
 
@@ -64,13 +139,23 @@ Everything above is the runtime's problem. Whether SSR is cheap *for your app* i
 (h/defhost chart Chart {:ssr {:fallback [:div.skel]}})  ;; that markup until adoption
 ```
 
-`:client-only` renders nothing in that slot until the client has adopted; `{:fallback <hiccup>}` puts a skeleton there instead. Unknown policies fail at declaration (`:rf.error/hicasso-host-bad-ssr-policy`); unknown options fail too (`:rf.error/hicasso-host-unknown-option`). One declaration covers server render, the first client pass after hydration, and a fresh client-only mount (which mounts the foreign component immediately, with no placeholder flash).
+`:client-only` renders nothing in that slot until the client has adopted;
+`{:fallback <hiccup>}` puts a skeleton there instead. Unknown policies fail at
+declaration (`:rf.error/hicasso-host-bad-ssr-policy`); unknown options fail too
+(`:rf.error/hicasso-host-unknown-option`). One declaration covers server render,
+the first client pass after hydration, and a fresh client-only mount (which mounts
+the foreign component immediately, with no placeholder flash).
 
-Do all of that — write idiomatic Hicasso — and SSR is not a rewrite waiting to happen. The app that is easiest to write is also the app that serves.
+Do all of that — write idiomatic Hicasso — and SSR is not a rewrite waiting to
+happen. The app that is easiest to write is also the app that serves.
 
 ## Non-goals
 
-Out of scope for this story: **streaming** (`renderToPipeableStream`), **React Server Components**, **islands / partial hydration**, **no-JS progressive enhancement**, and **SEO metadata management**. SSR *speed* is not a bar either — fast applications, not fast SSR. The story is one page, rendered whole from a snapshot, adopted whole by the client.
+Out of scope for this story: **streaming** (`renderToPipeableStream`), **React
+Server Components**, **islands / partial hydration**, **no-JS progressive
+enhancement**, and **SEO metadata management**. SSR *speed* is not a bar either —
+fast applications, not fast SSR. The story is one page, rendered whole from a
+snapshot, adopted whole by the client.
 
 ## Troubleshooting
 
@@ -84,14 +169,22 @@ Out of scope for this story: **streaming** (`renderToPipeableStream`), **React S
 
 ## When you need production SSR today
 
-Use a first-class adapter. Reagent and UIx [adapters](../../../core/views.md) are supported, maintained, and carry Spec 011 end to end. `examples/capabilities/ssr` is that path, runnable now. Adapters remaining a production answer is a successful outcome, not a consolation.
+Use a first-class adapter. Reagent and UIx [adapters](../../../core/views.md) are
+supported, maintained, and carry Spec 011 end to end. `examples/capabilities/ssr`
+is that path, runnable now. Adapters remaining a production answer is a successful
+outcome, not a consolation.
 
-Hicasso's hydration path, `:ssr` host policy, Node render entry, and end-to-end measurements work under the experimental arm; they are not yet a product package under `implementation/hicasso/`. What this chapter still gives you, on any substrate, is the authored discipline above — pure bodies, events as data, platform work in effects — which is portable re-frame2 and costs nothing to adopt early.
+Hicasso's hydration path, `:ssr` host policy, Node render entry, and end-to-end
+measurements work under the freehand bench; they are not yet a product package
+under `implementation/hicasso/`. What this chapter still gives you, on any
+substrate, is the authored discipline above — pure bodies, events as data,
+platform work in effects — which is portable re-frame2 and costs nothing to adopt
+early.
 
-## Not settled
+## Not settled yet
 
 | Question | Status |
 |---|---|
-| Production host shape | Not decided: JVM structural walk (in-process with `ssr-ring`) vs a Node sidecar behind an EDN render contract. `ssr-ring` keeps Spec 011's HTTP contract either way. Do not design a deployment against either yet. Both arms are priced, with no verdict, in [the production-server-arm dossier](../production-server-arm.md). |
-| How boot composes once there is a product package | Open. Today the experimental path associates a container, a frame, and a view; framework `hydrate!` seeds and verifies state before first render. Whether the product offers one operation or two — and where `:initial-events` sits on a hydrating load — is unstated. |
+| Production host shape | Open. JVM structural walk (in-process with `ssr-ring`) vs a Node sidecar behind an EDN render contract. `ssr-ring` keeps Spec 011's HTTP contract either way. Do not design a deployment against either yet. |
+| How boot composes once there is a product package | Open. Today the freehand path associates a container, a frame, and a view; framework `hydrate!` seeds and verifies state before first render. Whether the product offers one operation or two — and where `:initial-events` sits on a hydrating load — is unstated. |
 | Spellings | `hydrate-root!` and every other name on this page are **[unfrozen]** until the API freeze. |

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -1,6 +1,6 @@
 # Hicasso — draft user guide
 
-> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Behaviour matches the experimental arm under `implementation/freehand/test/re_frame/bench/hicasso/`.
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Mechanisms are proven under `implementation/freehand/test/re_frame/bench/hicasso/`; product spellings and some call shapes are still settling.
 
 Hicasso is re-frame2's native view layer: interpreted Hiccup on a React
 function-component host. This guide answers one question — **what does a
@@ -13,9 +13,9 @@ programmer actually type?**
 | [Events as data](03-events-as-data.md) | Put an event vector in an attribute and let the runtime build the callback — clicks, keys, prevention, and links |
 | [Controlled inputs](04-controlled-inputs.md) | Type into a text field whose value round-trips through app-db, and keep your caret |
 | [Interop](05-interop.md) | Use a React component from npm |
-| [Theming](06-theming.md) | Style a component library without a context API |
+| [Theming](06-theming.md) | Theme with CSS tokens and app-db — without a context API (part maps for libraries are still open) |
 | [Ephemeral state](07-ephemeral-state.md) | Decide where "is this dropdown open?" lives, given there is no `local`; where "it left but is still fading out" lives, given app-db cannot hold it; and where the jobs you wanted `:on-mount` for actually go |
-| [Testing](08-testing.md) | Assert a view's output without a browser, and know when you still need one |
+| [Testing](08-testing.md) | Assert intents and trees as data today; know when you still need a browser |
 | [When a view throws](09-when-a-view-throws.md) | Keep one broken view from taking the page down with it |
 | [Server-side rendering](10-server-side-rendering.md) | Serve a page rendered from a db snapshot and adopt it live in the browser |
 


### PR DESCRIPTION
## Summary

Three **serial, independent** passes over `docs/design/hicasso/draft-guide/` after #7482 / #7484.

### 1. Completeness
- Worked examples for taught-but-missing forms: `subscribe-once`, fragments + trailing children, full `::h/navigate` map, presence view-child on `:rf/phase`, `h/child-key`, `hydrate-root!` sketch, SSR `:ui` payload allowlist
- Testing: **assert as data today** is the required path; full `h/render` sketch under Advanced
- README/theming job lines narrowed to what can actually be shipped
- Fixed `#forwarding-attributes` anchor

### 2. Correctness
- Navigate payload matches routing's real `url-requested` shape (structural `=`)
- Dual `:on-input` / `:on-change`: converge prefers `onChange` when both present (both still lower)
- Banners: mechanisms proven under freehand bench; product call shapes still settling (no overclaim vs arm `root!` arity)
- `subscribe-once` shown as utility/outside-render, not preferred event-body style

### 3. Voice (deep)
- Against `docs/AUTHORING.md` + core register: problem → code → short why, pull-quotes, operational claims
- Unified draft banner; killed programme jargon that crept back
- Dense pages (02/05/07/10) tightened without dropping error ids or completeness fixes

## Gate notes
- `python scripts/check_doc_slugs.py` exit 0
- Tree is `exclude_docs`; slug checker is the content gate for design/

## Test plan
- [x] `check_doc_slugs.py`
- [ ] Spot-read 02, 03, 08, 10 for example fidelity