### PR TITLE
docs(hicasso): the prop-value rule, the charter's landed SSR, and 02's key verdict (rf2-pdfbk, rf2-e7brp, rf2-2rtt6.111)

### DIFF
--- a/docs/design/hicasso/charter.md
+++ b/docs/design/hicasso/charter.md
@@ -124,6 +124,12 @@ canonical.
   lowers, or refuses body forms; any grammar; any proof system; any second body
   emitter. If a compiler or dual mode becomes *required* to meet the bar, that is
   a kill, not a feature.
+  **Amended 2026-08-04 (design + adversarial ruling, operator-overturnable):**
+  the `for`-lowering named above is ruled out on the evidence to date and retired
+  behind a door rather than deleted. The shelved shape is a scalar-refusing
+  `h/for`, and its trigger is the dogfood preference test failing specifically on
+  list ceremony; until then authors write `:key` themselves. The permission above
+  stands as the record of what this charter pre-registered.
 - **One mode.** No compiled tier, no promotion knob.
 - **The anti-regression fence** — the programme has failed back into its
   predecessors if any of these appear: dual authoring modes or a public compiler
@@ -160,8 +166,9 @@ unless it does SSR"), through the framework's own Spec 011 story, recorded as
 the HD-020 addendum in [decisions.md](decisions.md) and the same-date EP-0038
 addendum. The sentences above stand as the record of what v0 pre-registered.
 SSR *speed* stays off the bar, and "SSR as identity" stays in the deferred
-list — SSR is a required capability, not the product's identity. In progress as
-beads `rf2-2rtt6.84`–`.87`; nothing has landed yet.
+list — SSR is a required capability, not the product's identity. Four pieces have
+since landed on the now-closed beads `rf2-2rtt6.84`–`.87`: the hydration door,
+the `defhost` `:ssr` policy, the Node render entry, and the X1–X5 spike witness.
 
 **A. The everyday SPA spine** (where the bar lives)
 1. Ordinary views — the ~50-element form/list/layout shape.

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -65,10 +65,16 @@ the source. Keys go in the props map (no Reagent `^{:key}` metadata):
 
 A bare seq of boundary children needs keys. Forget one today and you get React's
 own key warning in development; a Hicasso-minted warning is planned but not
-built. Sugar that would derive the key from a `for` binding is **not yet** —
-you write `:key` yourself. Putting a plain `defn` in head position —
-`[badge {...}]` where `badge` was never minted by `defview` — raises
-`:rf.error/hicasso-bad-head`.
+built. Putting a plain `defn` in head position — `[badge {...}]` where `badge`
+was never minted by `defview` — raises `:rf.error/hicasso-bad-head`.
+
+**You write `:key` yourself, and that is the answer** rather than a gap waiting
+on sugar. A `for`-lowering would have to assume the binding value *is* the
+identity, which stops being true the moment you iterate whole entities: React
+coerces a non-primitive key to a string, so editing a row would quietly change
+its key and remount it. And it could not retire the explicit `:key` anyway, so
+every list would carry two spellings forever in exchange for saving about a dozen
+characters.
 
 ### The component ABI
 

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -55,7 +55,8 @@ of the view tree as data. Friction once; free at every use site. The Reagent
 
 | Default | Behaviour |
 |---|---|
-| Props | shallow camelCase — `:on-change` → `onChange` |
+| Prop names | shallow camelCase — `:on-change` → `onChange` |
+| Prop values | crossed whole — a keyword stays a keyword. Only `:class`, `:id`, `:role`, `data-*` and `aria-*` stringify, where an HTML attribute is the destination and a string is the only representation there is |
 | Children | hiccup → React elements |
 | Functions | pass through unconverted |
 | SSR | `:client-only` — nothing server-side until the client adopts. Override with `:ssr`: `:client-only`, or `{:fallback <hiccup>}` for placeholder markup. Bad policy → `:rf.error/hicasso-host-bad-ssr-policy` at mint. Full story: [Server-side rendering](10-server-side-rendering.md) |
@@ -67,9 +68,20 @@ that resolved to `nil` (classic `:default` against a library with no default
 export) also fail at the declaration — where your stack points at the line you
 wrote.
 
+**A keyword value crosses as a keyword.** `[picker {:variant :compact}]` hands
+the library `:compact`, not `"compact"`, and two keywords that differ only in
+namespace stay two distinct values. A native tag is the other way round —
+`:type :text` becomes `type="text"` — because a keyword there is always bound for
+an HTML attribute, which is the same reason a host's `:class` and `:id`
+stringify. If the library wants a string, write one at the call site, or
+`(name :compact)`.
+
 **No deep conversion.** Nested option maps are not camelCased for you. Guessing
 which nested maps are options and which are data is a support trap; convert those
-maps yourself when the library wants camelCase inside them.
+maps yourself when the library wants camelCase inside them. Values inside a
+collection are shallow in the same way: they go through `clj->js`, which takes a
+keyword's name and drops any namespace, so `{:opts {:mode :theme/dark}}` reaches
+the library holding `"dark"`.
 
 ## Callbacks: `:event`, `:handler`, `:render`
 
@@ -170,6 +182,7 @@ emit `defhost`, rewrite call sites. A codemod is planned and not built.
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | Prop arrives as `on-change` and the library ignores it | Nested keys expected camelCase; deep conversion is not offered | Convert the nested map yourself before it crosses |
+| The library ignored a keyword prop value | A keyword crosses a host prop unchanged; only HTML-attribute names stringify | Write the string at the call site — `"compact"`, or `(name :compact)` |
 | `:rf.error/hicasso-intent-at-a-non-event-contract` | Slot is `:handler` or `:render`; neither dispatches | Declare `:event`, or write an `h/fn` for the real work |
 | `:rf.error/hicasso-intent-needs-the-event` | Vector spelling needs the DOM event at arg one; library put something else there | Use `h/fn` — full argument list, library order |
 | Namespace won't load on the JVM | A JS require reached a `.cljc` file | Quarantine the require in a `.cljs` host ns |


### PR DESCRIPTION
Three records on one surface that had drifted from what shipped. Docs-only: `docs/design/hicasso/draft-guide/**` and `docs/design/hicasso/charter.md`. Net **+26 lines** (34 insertions, 8 deletions).

## `rf2-pdfbk` — the guide half of the prop-value fix

`rf2-vrvv9` (PR #7500) narrowed `front/codec.cljs`'s `host-prop-value` so a named value crosses a foreign crossing whole, with `(name v)` kept only where an HTML attribute is the destination — `className`, `id`, `role`, `data-*`, `aria-*`. It deliberately shipped **no dev warn-once**: `reagent-slim`'s warning is a migration net for an installed Reagent codebase, whereas after this fix a keyword at a host prop is the correct, taught spelling of HD-011's flagship case, and warning on the happy path is a nag. Teaching it is the other half. Without it the trap is moved, not deleted — `{:variant :compact}` used to reach a library as `"compact"` and now reaches it as a raw keyword.

Nothing in the guide was false, which is why `rf2-vrvv9` correctly stayed inside its fence: the Defaults table spoke only about prop **names**. Three changes in `05-interop.md`:

- **Defaults table** — `Props` renamed to `Prop names`; new `Prop values` row: crossed whole, a keyword stays a keyword, only `:class`/`:id`/`:role`/`data-*`/`aria-*` stringify because an HTML attribute has no other representation.
- **A paragraph after the table** naming the call-site fix (`"compact"`, or `(name :compact)`) and the native-tag contrast, so the rule the reader just learned in `02` about `:type :text` does not get carried across the crossing.
- **Troubleshooting row** — "The library ignored a keyword prop value" → "A keyword crosses a host prop unchanged; only HTML-attribute names stringify" → "Write the string at the call site".

Every claim was verified against the shipped code and its tests, not against the bead: `front/codec.cljs:1523-1603` (`html-attr-slots` = `#{"className" "id" "role"}` plus the two prefixes, tested against the emitted **slot**, so `:class` / `:className` / `"class"` are one position) and `front/codec_cljs_test.cljs:707-763` (`:theme/dark` crosses whole; `:theme/dark` and `:other/dark` stay two values; `:class :theme/dark` is still `"dark"`, matching the native walk).

### The two namespace-dropping positions left standing

The bead recorded both so the ruling would be made rather than inherited.

- **A keyword child** (`as-element`, `codec.cljs:1813`: `(keyword? x) (name x)`, so `[:div :theme/dark]` renders `dark`). **No guide words.** The destination is a DOM text node, so a string is the only representation and the only open question is `(name x)` vs `(str x)`. The guide never teaches a keyword in child position, and documenting the namespace behaviour of a spelling nobody should write would add a concept to defend for no reader.
- **A collection value** (`(coll? v) (clj->js v)`). **This one is taught, so it is now stated.** The "No deep conversion" paragraph gains a sentence: values inside a collection go through `clj->js`, which takes a keyword's name and drops any namespace, so `{:opts {:mode :theme/dark}}` reaches the library holding `"dark"`. This is exactly the incompleteness that made the original bug a trap — a reader told "a keyword stays a keyword" will otherwise assume a nested keyword does too, and a provider whose `:value` is a **map** is the same use case `rf2-vrvv9` was about. Verified against ClojureScript 1.12.145 (the repo's pin) `cljs/core.cljs:11130-11154`: `clj->js`'s recursive `thisfn` has `(keyword? x) (keyword-fn x)` with `keyword-fn` defaulting to `name` — so the drop applies to keywords anywhere in the collection, not only to keys.
- **The stale citations in `template.cljs`** are `implementation/**` and outside this PR's fence. Not touched, not re-cited here.

`h/as-element` does **not** exist in Hicasso (it lives only in `reagent-slim`), so it appears nowhere in these edits. `[:>]` is not built and gains no promise.

## `rf2-e7brp` — the charter's SSR amendment

`charter.md`'s 2026-08-04 operator-ruling amendment ended "In progress as beads `rf2-2rtt6.84`–`.87`; nothing has landed yet." All four are closed with merged PRs (#7495, #7468, #7470, #7475). **Only that progress clause moves.** The surrounding sentences are retained pre-registration history — the out-of-v0 posture, SSR *speed* staying off the bar, "SSR as identity" staying deferred — and survive verbatim. The replacement names what landed rather than only that beads closed, and keeps the ids: the charter's own idiom for a settled thing is to cite "the *closed* beads" (`charter.md:72`).

## `rf2-2rtt6.111` — the for-binding key verdict

**The verdict was verified, not inferred from the title.** `rf2-2rtt6.105` closed on a design + adversarial synthesis (0 FATAL / 4 MAJOR / 5 MINOR; the attack was briefed to force the build case and could not overturn it): **DO-NOT-BUILD**, ruled out on today's evidence, operator-overturnable, with a pre-agreed response class. So `.111` takes its do-not-build arm.

`02-views-and-reads.md:66-68`'s "Sugar that would derive the key from a `for` binding is **not yet**" becomes the taught permanent answer with the ruled reason, compressed to the two arguments that do not depend on anything unlanded: the binding value is only *sometimes* the identity (React string-coerces a non-primitive key, so iterating whole entities silently remounts an edited row), and the sugar could never retire the explicit `:key`, so every list would carry two spellings in exchange for about a dozen characters.

**Honest tense preserved.** `rf2-2rtt6.104`'s Hicasso-minted missing-key warning is designed and synthesized but **not landed**, so `02`'s "planned but not built" stands unchanged and the new reason does not lean on it. `rf2-2rtt6.110` still owns that true-up.

**Also delivered, from the ruling rather than from the dispatch brief.** `rf2-2rtt6.105`'s execution note assigns three artefacts to this branch, and two are inside this PR's fence. The charter pre-permits the sugar by name (`charter.md:121-122`, "a `for`-lowering that turns the binding into the `:key`"), and the ruling retires that permission **behind a door rather than deleting it**. The bullet gains a dated amendment in the charter's own supersession idiom (the pattern at `charter.md:109-114`): the permission stands as the record of what was pre-registered, the shelved shape is the scalar-refusing `h/for`, and its trigger is the dogfood preference test failing specifically on list ceremony.

The third artefact — a dated HD-016 addendum in `decisions.md` — is **outside this PR's fence** and is filed as a follow-up bead, together with a second instance of the same stale-progress class found while working: `decisions.md:740-742` carries the identical "nothing has landed" clause about `rf2-2rtt6.84`–`.87` that `rf2-e7brp` fixed in the charter. `HD-016:503` ("the `for`-lowering sugar is **not** v0") is not false today, only incomplete, which is why it is a follow-up rather than a blocker.

## Quality gates

| Gate | Command | Result |
|---|---|---|
| Docs link/anchor validator | `python scripts/check_doc_slugs.py` | **exit 0** |
| Fast-PR spine | `sh scripts/test-fast-pr.sh` | **exit 0** — `PASS fast PR spine` |
| Required-check gap | `python scripts/check_fast_pr_gap.py --list` | 88 required checks this spine does not decide; CI owns them |

`mkdocs build --strict` **is not nominated as the gate for this PR.** `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site, so the build exits 0 having verified nothing about these files. It ran inside the spine (lane `mkdocs --strict build`) and is reported only as spine coverage, not as evidence. The lane that does cover these files is `docs corpus anchor validator`, which is `check_doc_slugs.py`.

**Mutation proof of the slug checker** — the validator was proven to fail on this diff's own surface, not merely to pass. The heading `## Why declare` in `05-interop.md` was renamed to `## Why declare it`, breaking the intra-file link at `:166`:

```
$ python scripts/check_doc_slugs.py
1 broken anchor link(s) found:

  BROKEN ANCHOR: docs\design\hicasso\draft-guide\05-interop.md:166 -> #why-declare
      (target: docs\design\hicasso\draft-guide\05-interop.md)

Fix: confirm the heading still exists in the target file and update the link, or rename the heading and re-link.
MUTATED_EXIT=1
```

The heading was then restored and the validator re-run: `RESTORED_EXIT=0`, with `git diff --stat` unchanged.

**Hand-verified by the worker, because nothing automated covers it:**

- **Tables.** Every table row in all three touched files was column-counted outside fenced code blocks. `05-interop.md` — Defaults 2 cols (7 rows, including the new `Prop values`), Troubleshooting 3 cols (13 rows, including the new keyword row), "Not settled yet" 2 cols (7 rows). `02-views-and-reads.md` — component ABI 5 cols (6 rows), plus two untouched tables at 3 and 2 cols. `charter.md` — 2 cols (6 rows). **0 mismatches.** No cell contains a literal pipe.
- **Anchors.** **No heading was added, renamed, or removed** in the final diff, so no inbound-link sweep is owed. `05-interop.md`'s one intra-file anchor link, `[Why declare](#why-declare)`, is the anchor the mutation proof exercised. The slug trap does not apply: with no new heading there is no hyphen run for python-markdown's slugify to collapse differently from GitHub. No new file was added, so nothing is silently skipped by the checker's `git ls-files` walk.
- **Snippet truth.** No sample was added. Every inline shape is either taken verbatim from a shipped test (`:variant :compact`, `:theme/dark`) or already on the page.

## Beads

Closes `rf2-pdfbk`, `rf2-e7brp`, `rf2-2rtt6.111`. A follow-up is filed for the `decisions.md` half, which is outside this fence.
