### PR TITLE
fix(hicasso): three crossing laws enforced where they are stated (rf2-2rtt6.122, rf2-2rtt6.119, rf2-d03av)

### DIFF
--- a/docs/design/hicasso/authoring.md
+++ b/docs/design/hicasso/authoring.md
@@ -83,13 +83,21 @@ declared so it is scored from day one, not discovered mid-clock:
 An existing React element is a legal child anywhere (pass-through). A view may
 return `nil`, one root, or a fragment.
 
-`:ref` takes a **function** in v0. A **vector** is the reserved value-space for the
+`:ref` takes a **function** in v0 — the taught form, and the one the guide
+teaches, because React 19 makes attach and teardown structural there (whatever the
+callback returns is its cleanup). A **vector** is the reserved value-space for the
 later data spelling (`{:ref [registered-id config]}`) and is refused loudly —
 `:rf.error/hicasso-ref-vector-reserved` (HD-022). The reservation is one branch and
 one error id; it exists so the imperative escape can become data without minting a
 second attribute name, and it carries one honest limit that shapes what you write
 today: a ref callback fires on attach and detach and **never on config change**, so
 steady-state change belongs on an effect, not on the ref.
+
+The vector is the **only** value the codec refuses there. An object ref
+(`(react/createRef)`) is untaught rather than illegal: React 19 carries `ref` as an
+ordinary prop, so it crosses by identity at a native tag and at a `defhost`/`[:>]`
+crossing alike and behaves exactly as React documents (HD-016's 2026-08-05 note,
+rf2-d03av).
 
 ## Event intent as data
 

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -518,6 +518,38 @@ settled rather than contingent. HD-002's ruling makes the ambient collector the
 one product read surface, so a `sub` performed inside a helper is an ordinary
 read that lands in the calling boundary's window.
 
+> **Note, 2026-08-05 (rf2-d03av): "callback refs only" states what v0 TEACHES,
+> not what it refuses.** The clause above reads as a prohibition, and it is not
+> enforced as one: `front.codec/check-ref!` refuses exactly one value — the
+> reserved **vector** — and passes everything else through. That is not a gap
+> in the check, it is [HD-022](#hd-022--refs-vector-value-space-is-reserved-now-and-refused-loudly-in-v0)
+> in as many words: *"That is the whole ruling — one refusal branch and one
+> error id."* HD-022 is later than this clause and is the ruling actually about
+> `:ref`'s value space, so where the two are read as disagreeing, HD-022 governs.
+>
+> The consequence, stated so it is a decision rather than an oversight: an
+> **object ref** (`(react/createRef)`) is legal at a native tag and at a
+> `defhost`/`[:>]` crossing. React 19 carries `ref` as an ordinary prop, so it
+> attaches and detaches exactly as React documents; nothing is silently dropped
+> and nothing needs repairing. It is **untaught, not illegal** — the guide
+> teaches the callback ref because attach and teardown are one thing there
+> (React 19 returns the cleanup from the callback), and that is an ergonomic
+> recommendation the codec does not police. Refusing a spelling that works
+> correctly would be friction rather than safety, and pre-alpha this project
+> trusts the programmer.
+>
+> Read the clause as: *`:ref` is legal on native tags and `defhost`/`[:>]`
+> crossings; the callback ref is the taught form; the reserved vector spelling
+> is refused; `:ref` is not a v0 surface on Hicasso views (use ids).*
+>
+> Design C's parity rule is what makes this the cheap answer as well as the
+> right one: whatever is decided applies to **both** crossing forms and to
+> native tags, and a rule enforced at one crossing and not the other is worse
+> than a rule enforced at neither. Doing nothing satisfies parity for free.
+> Pinned by `front/codec_cljs_test` →
+> `an-object-ref-crosses-by-identity-at-both-positions`, so a later refusal
+> cannot land silently.
+
 ## HD-017 — Code residence and graduation
 
 > **Note, 2026-07-31.** This entry's graduation clause was written as "the P2

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -57,6 +57,7 @@ of the view tree as data. Friction once; free at every use site. The Reagent
 |---|---|
 | Prop names | shallow camelCase — `:on-change` → `onChange` |
 | Prop values | crossed whole — a keyword stays a keyword. Only `:class`, `:id`, `:role`, `data-*` and `aria-*` stringify, where an HTML attribute is the destination and a string is the only representation there is |
+| `:class` values | the class slot's own coercion, exactly as at a native tag — a collection joins (`["btn" nil :on]` → `"btn on"`) and two spellings of the class compose rather than one overwriting the other |
 | Children | hiccup → React elements |
 | Functions | pass through unconverted |
 | SSR | `:client-only` — nothing server-side until the client adopts. Override with `:ssr`: `:client-only`, or `{:fallback <hiccup>}` for placeholder markup. Bad policy → `:rf.error/hicasso-host-bad-ssr-policy` at mint. Full story: [Server-side rendering](10-server-side-rendering.md) |
@@ -82,6 +83,15 @@ maps yourself when the library wants camelCase inside them. Values inside a
 collection are shallow in the same way: they go through `clj->js`, which takes a
 keyword's name and drops any namespace, so `{:opts {:mode :theme/dark}}` reaches
 the library holding `"dark"`.
+
+**`:class` is the one slot that does not follow that last sentence**, because a
+class list is not data on its way to a library — it is bound for the `class`
+attribute, where the only representation is one space-joined string. So a
+collection there is *joined* rather than `clj->js`'d, nils are dropped, and two
+spellings of the class compose: `{:class ["btn" nil :on] :className "wide"}`
+reaches the library as `"btn on wide"`. That is the same answer a native tag
+gives for the same hiccup, which is the point — one authored shape, one answer,
+whichever side of the crossing it lands on.
 
 ## Callbacks: `:event`, `:handler`, `:render`
 
@@ -252,6 +262,15 @@ what actually doubles.
 
 Hooks in a body take you outside headless testing scope ([Testing](08-testing.md))
 and put React's hook rules on you. Both are fine; both are yours.
+
+**An object ref works too, and is simply untaught.** `(react/createRef)` crosses
+by identity at a native tag and at a `defhost` crossing alike — React 19 carries
+`ref` as an ordinary prop — so a Reagent habit you bring with you will not break.
+The callback form is taught instead because it makes attach and teardown one
+thing, which is the property the four rules above are about. The *one* value
+`:ref` refuses is a **vector**: that spelling is reserved for a later data form,
+and writing it today raises `:rf.error/hicasso-ref-vector-reserved` rather than
+handing React an array it would ignore in silence.
 
 #### If you are not on React 19
 

--- a/docs/design/hicasso/studio/raw-escape-spec.md
+++ b/docs/design/hicasso/studio/raw-escape-spec.md
@@ -586,10 +586,18 @@ still fails if a body runs twice or a boundary is skipped.
 `[:> Component]` with no props and no children is legal. Bare `[:>]` reaches index 1 as
 `nil` and takes the no-component refusal, whose message covers both misspellings.
 
-**5. `check-ref!` refuses only a vector**, so an object ref passes today (`rf2-d03av`, open).
+**5. `check-ref!` refuses only a vector**, so an object ref passes.
 **Do not add a refusal at `[:>]` that `defhost` does not have** — a rule enforced at one
 crossing and not the other is worse than a rule enforced at neither, and conversion parity is
 the ruling.
+
+> **Settled 2026-08-05 (`rf2-d03av`), and it settles the way this paragraph wanted.** The
+> rule turned out to be narrower than it read, not the check: HD-022 rules that the whole of
+> the `:ref` value-space claim is *"one refusal branch and one error id"*, so an object ref is
+> **untaught rather than illegal** at every position. HD-016 carries a dated note saying so
+> and the guide's interop page teaches the distinction. Nothing changes at `[:>]`, and parity
+> holds for free — which is exactly the outcome this item asked for. Pinned by
+> `front/codec_cljs_test` → `an-object-ref-crosses-by-identity-at-both-positions`.
 
 **6. `host-entry` has no class branch**, so `{:class ["btn" nil "on"]}` at any foreign
 crossing crosses as a `clj->js` array and React renders `class="btn,,on"` — while the codec's
@@ -597,6 +605,15 @@ own slot law says the class slot is a position coerced by `class-names`. This is
 deviation, **inherited, not introduced**, and it is filed as `rf2-2rtt6.119`. Note the trap
 for the witness plan: **edge 3's canonical-parity row cannot catch it**, because both forms
 are identically wrong.
+
+> **Fixed 2026-08-05 (`rf2-2rtt6.119`) — at the DOOR, so the escape inherits it.** `host-entry`
+> now carries a `class?` arm that coerces and composes through `class-names`, exactly as
+> `convert-entry` does at a native tag, and it sits **below** the declared-contract arm so a
+> declaration still decides what a declared position means. Because §3 rules that `[:>]` props
+> take *"the landed unclaimed-slot conduct of `host-entry` … with no branch of its own"*, the
+> escape gets the repair by construction and the parity trap above never arms. The observation
+> that edge 3's canonical-parity row cannot catch it stands and is the reason the witness is
+> written as *native answer* vs *crossing answer* rather than as two spellings of the crossing.
 
 ---
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -114,7 +114,7 @@
   |---|---|---|---|
   | Native tag | attr map | trailing forms; seqs realized once and flattened one level; `nil`/`false` render nothing, `true` errors | `:key` in the attr map |
   | Boundary (a marked `defview` product) | one props map, every lazy sequence in it realized and every unforced `delay` in it refused ([[realize-deep]]) | trailing forms as `(:children props)`, a realized vector | `:key` in the props map, extracted before the body sees props |
-  | Host (a `defhost` declaration — HD-011) | attr map: declared `:callbacks` slots lowered by their DECLARED contract, `:ref` a callback ref (HD-022's vector refusal holds here), everything else converted shallowly ([[host-prop-value]]) | trailing forms converted hiccup→element, handed to the foreign component as React children | `:key` in the attr map |
+  | Host (a `defhost` declaration — HD-011) | attr map: declared `:callbacks` slots lowered by their DECLARED contract, `:ref` a callback ref (HD-022's vector refusal holds here), the class slot coerced and composed by [[class-names]] exactly as at a native tag (rf2-2rtt6.119), everything else converted shallowly ([[host-prop-value]]) | trailing forms converted hiccup→element, handed to the foreign component as React children | `:key` in the attr map |
   | Fragment `[:<> …]` | optional attr map | trailing forms | on the fragment's props map |
 
   A React element is a legal child anywhere. No metadata keys, no second
@@ -1587,6 +1587,15 @@
   ([[convert-prop-value]]) and the answer the server serializer gives, so
   the two crossings agree on every attribute both can carry.
 
+  **`className` no longer arrives here at all** (rf2-2rtt6.119).
+  [[host-entry]] takes the class slot ahead of this function and hands it
+  to [[class-names]], which is the coercion the native walk takes and the
+  only one that answers a COLLECTION correctly — the arm the named-value
+  rule above could never reach, since a collection is not a named value.
+  The slot stays on the roster because the roster states which SLOTS are
+  bound for HTML attributes, which is still true of `className` and is
+  what keeps this function's answer right if it is ever asked directly.
+
   **No dev warning accompanies this**, and the omission is deliberate.
   `reagent-slim` warns once per non-HTML keyword prop because it narrowed
   the rule underneath an installed Reagent codebase and the warning is
@@ -1648,7 +1657,35 @@
   than inferred; everything else crosses shallowly. `event?` is gated on
   `keyword?` for the same reason the native walk gates it — a symbol
   spelled `on-click` shares the cache entry and is not an event
-  position."
+  position.
+
+  ## The class slot is a POSITION here too (rf2-2rtt6.119)
+
+  `className` is the one slot whose value has a coercion of its own —
+  [[class-names]] — rather than the position's ordinary conversion, and
+  that coercion belongs to the SLOT rather than to either walk. It was
+  taken at the native position only, so the two crossings answered the
+  same authored shape differently: `{:class [\"a\" nil :b]}` reached a
+  native tag as `\"a b\"` and reached a declared foreign component as the
+  JS array `[\"a\", null, \"b\"]` — `clj->js`'s answer, and not a class
+  string at all. React writes that array to the DOM as `\"a,,b\"`
+  wherever the component passes it on, so nothing threw and the styling
+  was simply wrong.
+
+  rf2-vrvv9 already settled the principle and applied half of it: at
+  `className`, `id`, `role` and the `data-*`/`aria-*` families the value
+  is bound for an HTML attribute, so a named value keeps `(name v)` there
+  — *\"which is also the answer the NATIVE walk gives at the same
+  names\"* ([[host-prop-value]]). That sentence is the law; the
+  collection arm was the half of it still unwritten, because a collection
+  never reached the named-value branch. Asking `class?` here — the flag
+  the [[PropSlot]] already carries, so a declared-slot lookup pays one
+  property read and a string key one compare — makes the two crossings
+  agree at the class slot for **every** value shape.
+
+  It composes, for the reason [[convert-entry]] composes: two spellings
+  of one element's class are two map keys and one React slot, and letting
+  the last write win drops a class silently."
   [^js head declared o k v]
   (if (keyword-identical? :key k)
     o
@@ -1657,6 +1694,7 @@
           slot         (if keyword-ish? (.-js-name s) (cached-prop-name k))
           reserved?    (if keyword-ish? (.-reserved? s) (reserved-name? slot))
           ref?         (if keyword-ish? (.-ref? s) (= ref-slot slot))
+          class?       (if keyword-ish? (.-class? s) (identical? class-slot slot))
           event?       (if keyword-ish?
                          (and (.-event? s) (keyword? k))
                          (intent/event-prop? k))]
@@ -1668,6 +1706,15 @@
 
             (contains? declared slot)
             (intent/lower-declared-prop k v (get declared slot))
+
+            ;; The slot's own coercion, and the slot's own composition —
+            ;; the same law [[convert-entry]] takes at the native
+            ;; position, taken here so the two crossings agree
+            ;; (rf2-2rtt6.119). Below the declaration, because HD-011's
+            ;; whole point is that a DECLARED position means what the
+            ;; declaration says it means.
+            class?
+            (class-names (unchecked-get o class-slot) v)
 
             :else
             (do (when (and event? (or (vector? v) (map? v)))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
@@ -783,7 +783,12 @@
             React slot, so letting the last write win would drop a class
             silently"
     (let [e (codec/as-element [a-host {:class "a" :x/class ["b" :c]}])]
-      (is (= "a b c" (prop e "className")))))
+      (is (= "a b c" (prop e "className"))))
+    ;; the guide's own example, asserted verbatim so the page cannot drift
+    ;; from the door (draft-guide/05-interop.md §Defaults)
+    (is (= "btn on wide"
+           (prop (codec/as-element [a-host {:class ["btn" nil :on] :className "wide"}])
+                 "className"))))
   (testing "nothing else at the slot moves. A string is verbatim, a keyword
             still stringifies (rf2-vrvv9's rule, unchanged), and a
             namespaced keyword still drops its namespace HERE and only here"

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec_cljs_test.cljs
@@ -658,6 +658,7 @@
   (testing "and :ref is not an event position, so intent lowering never sees it"
     (is (false? (intent/event-prop? :ref)))))
 
+
 ;; ---------------------------------------------------------------------------
 ;; The codec's one policy call — intent lowering happens inside the walk
 ;; ---------------------------------------------------------------------------
@@ -746,6 +747,80 @@
     (is (= "dark" (prop (codec/as-element [:div {:class :theme/dark}]) "className"))
         "the native crossing, unchanged")))
 
+;; ---------------------------------------------------------------------------
+;; The class slot is a POSITION at the crossing too (rf2-2rtt6.119)
+;; ---------------------------------------------------------------------------
+
+(deftest a-class-collection-crosses-as-a-class-string-at-a-host-and-at-a-tag
+  (testing "THE DEVIATION rf2-2rtt6.119 names. The class slot has a coercion
+            of its own — `class-names` — and it was taken at the native
+            position only, so ONE authored shape got TWO answers. The
+            crossing sent `{:class [\"a\" nil :b]}` through `clj->js` and
+            handed the foreign component a JS array, which React writes to
+            the DOM as \"a,,b\" wherever the component passes it on: nothing
+            threw and the styling was simply wrong."
+    (let [crossed (host-prop :class ["a" nil :b] "className")
+          native  (prop (codec/as-element [:div {:class ["a" nil :b]}]) "className")]
+      (is (string? crossed)
+          "a class string, not the JS array clj->js used to build here")
+      (is (= "a b" crossed))
+      (is (= native crossed)
+          "and it is the SAME answer the native walk gives — which is the
+           rule rf2-vrvv9 already stated for the named value at this slot,
+           applied to the arm a collection takes")))
+  (testing "the coercion is on the SLOT, so it holds in every spelling of it
+            — the discipline `canonical-slot` and the owned-literal law
+            already use, and the reason a rule written against `:class`
+            would be one that `:className`, `\"class\"` and `:x/class` walk
+            past"
+    (doseq [k [:class :className "class" "className" 'class :x/class]]
+      (is (= "a b" (host-prop k ["a" nil :b] "className"))
+          (str "spelled " (pr-str k)))))
+  (testing "a nested collection joins one level down too, exactly as at a tag"
+    (is (= "a b c" (host-prop :class ["a" ["b" nil] :c] "className"))))
+  (testing "and it COMPOSES, for the reason the native position composes:
+            two spellings of one element's class are two map keys and one
+            React slot, so letting the last write win would drop a class
+            silently"
+    (let [e (codec/as-element [a-host {:class "a" :x/class ["b" :c]}])]
+      (is (= "a b c" (prop e "className")))))
+  (testing "nothing else at the slot moves. A string is verbatim, a keyword
+            still stringifies (rf2-vrvv9's rule, unchanged), and a
+            namespaced keyword still drops its namespace HERE and only here"
+    (is (= "primary" (host-prop :class "primary" "className")))
+    (is (= "primary" (host-prop :class :primary "className")))
+    (is (= "dark" (host-prop :class :theme/dark "className")))
+    (is (nil? (host-prop :class nil "className"))))
+  (testing "and the deviation was the class slot ALONE — `id` and `role`
+            hand a collection to `clj->js` at BOTH positions, so there is
+            nothing to reconcile there and nothing here that changed them"
+    (is (array? (host-prop :id ["a" "b"] "id")))
+    (is (array? (prop (codec/as-element [:div {:id ["a" "b"]}]) "id"))
+        "the native walk's own answer, quoted so the claim is not asserted
+         about a function nobody ran")))
+
+(deftest a-declared-contract-still-outranks-the-class-coercion
+  (testing "HD-011's whole point is that a DECLARED position means what the
+            declaration says it means, so the slot coercion sits BELOW the
+            declaration in the cond rather than above it. Nobody sensible
+            declares a contract on `className`; the row exists so the
+            precedence is pinned rather than incidental — and a vector is
+            the value that tells the two orders apart, because
+            `class-names` would quietly answer it \"a b\" where the
+            declaration refuses it."
+    (let [declared (codec/mint-host! "ClassContractHost" a-foreign-component
+                                     {:callbacks {:class :handler}})]
+      (try
+        (codec/as-element [declared {:class ["a" "b"]}])
+        (is false "should have thrown")
+        (catch :default e
+          (is (= :rf.error/hicasso-intent-at-a-non-event-contract
+                 (:rf.error/id (ex-data e)))
+              "the declaration decided, not the slot")))))
+  (testing "and an undeclared host is unaffected — the same value at the
+            same slot is an ordinary class collection"
+    (is (= "a b" (host-prop :class ["a" "b"] "className")))))
+
 (deftest every-other-host-prop-value-crosses-exactly-as-it-did
   (testing "functions by identity — `React.memo` and every downstream
             bail-out that compares handler identity"
@@ -760,6 +835,44 @@
     (is (= 7 (host-prop :count 7 "count")))
     (is (true? (host-prop :open true "open")))
     (is (nil? (host-prop :label nil "label")))))
+
+;; ---------------------------------------------------------------------------
+;; What "callback refs only" actually is (rf2-d03av)
+;; ---------------------------------------------------------------------------
+
+(deftest an-object-ref-crosses-by-identity-at-both-positions
+  (testing "rf2-d03av, settled as a RECORD rather than a refusal. HD-016
+            reads 'callback refs only', and HD-022 — later, and the ruling
+            that is actually about `:ref`'s value space — says the whole of
+            the claim is ONE refusal branch and one error id: the reserved
+            vector. An object ref is neither reserved nor broken. React 19
+            carries `ref` as an ordinary prop, so `(react/createRef)`
+            attaches and detaches exactly as React documents it. It is
+            untaught rather than illegal, and refusing a spelling that
+            works correctly is friction rather than safety.
+
+            This witness is what makes that a decision instead of an
+            oversight: a later refusal cannot land silently, because it has
+            to delete these rows first."
+    (let [r (react/createRef)]
+      (is (identical? r (prop (codec/as-element [:div {:ref r}]) "ref"))
+          "a native tag")
+      (is (identical? r (host-prop :ref r "ref"))
+          "and a defhost crossing — HD-011's conversion parity, which is
+           what makes 'enforced at one crossing and not the other' the
+           outcome design C ruled out")))
+  (testing "and it is one rule at one slot, so an alternate spelling of the
+            ref position answers the same way"
+    (let [r (react/createRef)]
+      (is (identical? r (prop (codec/as-element [:div {"ref" r}]) "ref")))
+      (is (identical? r (host-prop :x/ref r "ref")))))
+  (testing "the reserved VECTOR is still refused at both, which is the rule
+            that IS enforced — so the two questions stay separable"
+    (let [reserved [::autosize {:max-rows 8}]]
+      (is (thrown-with-msg? js/Error #"RESERVED"
+                            (codec/as-element [:div {:ref reserved}])))
+      (is (thrown-with-msg? js/Error #"RESERVED"
+                            (codec/as-element [a-host {:ref reserved}]))))))
 
 ;; ---------------------------------------------------------------------------
 ;; What the codec must NOT be


### PR DESCRIPTION
Three beads on one surface — the codec's crossing seam. **Two land; the third is a ruling and is reported rather than patched.**

| Bead | Verdict | What shipped |
|---|---|---|
| `rf2-2rtt6.119` (P3, bug) | **STILL LIVE — fixed** | one `class?` arm in `host-entry`, + witnesses + docs |
| `rf2-d03av` (P3) | **A RULING, not a bug — recorded** | HD-016 dated note, guide + `authoring.md` true-up, executable witness. No refusal added. |
| `rf2-2rtt6.122` (P2, bug) | **STILL LIVE — but NOT constructible in this lane** | no diff; the finding is on the bead. Stays open for an operator ruling. |

---

## `rf2-2rtt6.119` — the class slot is a position at the crossing too

**The deviation was real, and the mutation run printed it verbatim:** with the fix
disabled, `{:class ["a" nil :b]}` at a `defhost` crossing emits `#js ["a" nil "b"]`
where the same hiccup at a native tag emits `"a b"`. React writes that array to the
DOM as `class="a,,b"` wherever the component passes it on — nothing throws, the
styling is just wrong.

**What `rf2-vrvv9` (#7500, already on `main` when this branched) changed about the
bead.** It made the bead *sharper*, not stale. `rf2-vrvv9` narrowed `host-prop-value`
so a named value crosses whole, keeping `(name v)` only at `className`/`id`/`role`
and the `data-*`/`aria-*` families — and it stated the governing reason in its own
docstring: at those slots the value is bound for an HTML attribute, *"which is also
the answer the NATIVE walk gives at the same names."* That sentence is the law
`.119` is about. `rf2-vrvv9` applied it to the **named-value** arm; a collection is
not a named value, so it never reached that branch and the other half stayed
unwritten. This PR writes it.

It is also why the fix is one arm rather than a policy: `:class` is one of exactly
three names in `rf2-vrvv9`'s new set, and it is the only one of the three with a
coercion of its own.

**The change, in full — three executable lines, all inside `host-entry`:**

```clojure
class?       (if keyword-ish? (.-class? s) (identical? class-slot slot))
;; …
class?
(class-names (unchecked-get o class-slot) v)
```

- The flag is already on the cached `PropSlot`, so a keyword key pays **one property
  read** and a string key one compare.
- It sits **below** the declared-contract arm, because HD-011's whole point is that a
  declared position means what the declaration says. Pinned by its own test.
- It **composes**, for the reason `convert-entry` composes: two spellings of one
  element's class are two map keys and one React slot, and last-write-wins drops a
  class silently.

**`:class` was the only deviation, and the witness says so rather than assuming it.**
`id` and `role` hand a collection to `clj->js` at *both* positions, so there is
nothing to reconcile there — asserted in both directions so the claim is not made
about a function nobody ran.

**Inherited by `[:>]` for free.** `raw-escape-spec.md` §3 rules that `[:>]` props take
*"the landed unclaimed-slot conduct of `host-entry` … with no branch of its own"*, so
the escape gets the repair by construction. §8 item 6 is updated to record it.

## `rf2-d03av` — "callback refs only" is a teaching statement, not a refusal

**The rule turned out to be narrower than it reads, not the check.** HD-016's clause
reads as a prohibition; HD-022 — **later, and the ruling actually about `:ref`'s value
space** — says in as many words: *"That is the whole ruling — one refusal branch and
one error id."* `check-ref!` is exactly what HD-022 ruled. Later and more specific
governs.

So an object ref is **untaught, not illegal**. React 19 carries `ref` as an ordinary
prop; `(react/createRef)` attaches and detaches exactly as React documents, at a
native tag and at a `defhost` crossing alike. **Nothing is silently dropped and
nothing needs repairing** — which is the whole argument against adding a branch:
refusing a spelling that works correctly is friction, not safety, and pre-alpha this
project trusts the programmer.

Design C's parity rule is satisfied **for free**: whatever is decided applies to both
crossing forms and to native tags, and doing nothing is parity. No refusal was added
at `[:>]` that `defhost` lacks, as Design C directs.

Shipped instead: a dated note on HD-016, the enforced-vs-taught distinction in
`authoring.md` and the interop guide, `raw-escape-spec.md` §8 item 5 marked settled,
and — the part that makes it a decision rather than an oversight — **a witness pinning
both positions, so a later refusal cannot land silently.**

## `rf2-2rtt6.122` — live hazard, but the recommended fence is not buildable here

**The bead's trace verifies.** Re-checked file:line: `arm1/mount.cljs` mints the shared
Provider regardless; `adapter/context.cljs:306-341` is the reader the UIx/Freehand
adapters publish; `frame.cljc` `resolve-current-frame` calls it; `subs.cljc` and
`router.cljc` are the ambient doors. Ambient `rf/subscribe` in a Hicasso body *does*
resolve the Hicasso frame under those adapters, registers zero collector edges, and
freezes.

**But the RECOMMENDED SHAPE (i) cannot be built in the bench lane, and that is the
finding.** (i) says the body extent *"binds a refusing sentinel over the ambient
chain."* **The ambient chain has no refusing value to bind.** Its reader is exactly:

```clojure
(or frame/*current-frame*
    (context-value->current-frame (.-_currentValue frame-context)))
```

Tier 1 is consumed by a bare `or`, so any non-nil value Hicasso binds there comes back
**as the frame** — a Hicasso-side binding can say *which* frame, never *no frame is
legal in this extent*. Tier 2 is the context slot, which holds the Hicasso frame
precisely because Hicasso mounts the Provider — and that Provider is load-bearing (the
shell's hook 1 **is** `useContext(frame-context)`, plus the error boundary and the
presence tray). A refusal therefore needs a third tier or per-consumer discrimination:
**option (ii), core surgery**, which this bead fences behind a follow-up ruling. That
condition has been met, so the bead is escalated rather than patched.

The one in-lane alternative — writing React's internal `_currentValue` around each body
call — was costed and rejected: it charges the **ordinary render path** two property
writes per body, reaches into a React internal, is wrong under `renderToString`
(React 19.2 populates `_currentValue2`), and produces a *worse* diagnostic than the one
it replaces. Full argument, plus one favourable finding for whoever does build the
fence (the scoping row is free — React renders a child fiber only after the parent's
render function returns, so a body-scoped binding has already unwound before any
adapter island runs), is recorded on the bead.

Not written, deliberately: the guide sentence. `rf2-2rtt6.118` (`h/frame`) is still open
and unbuilt, and `.122` says to sequence the wording with it.

---

## What did not move

- **The ordinary render path is byte-for-byte unchanged.** Every executable line in
  this diff is inside `host-entry`. `convert-entry`, `convert-props`,
  `native-element`, `boundary-element`, `as-element` and `realize-deep` are untouched
  — no new per-element test anywhere.
- **The hook ledger is untouched.** No hook added or removed; `mint-host-gate!` and
  `memoize-boundary!` are unmodified, and `arm1/runtime.cljs` / `arm1/mount.cljs` are
  not in the diff. HD-020(b)'s ≤2 budget is not approached.

## Mutation proofs — both directions, both named

Each fix was disabled and the suite re-run in full. A test that cannot fail on the old
behaviour proves nothing.

| Mutation | Result |
|---|---|
| `host-entry`'s `class?` arm disabled | **12 failures**, all in `a-class-collection-crosses-as-a-class-string-at-a-host-and-at-a-tag` + `a-declared-contract-still-outranks-the-class-coercion`. Reported actual: `(not (string? #js ["a" nil "b"]))` — the deviation, printed. |
| `check-ref!` given an object-ref refusal | **4 errors**, all in `an-object-ref-crosses-by-identity-at-both-positions`, and **nothing else in 12,585 tests moved** — which is itself the proof that the behaviour was previously pinned nowhere, exactly as the bead described. |

Both mutations were reverted; the tree was confirmed byte-identical to the committed
state (`git diff` empty) before the final gate sweep.

## Docs verification (done by hand, as `docs/design/**` requires)

`mkdocs build --strict` does **not** cover `docs/design/**` — `exclude_docs` keeps it
out — so it is not nominated here. `scripts/check_doc_slugs.py` passes (exit 0), which
covers link targets and heading anchors including the new
`HD-016 → HD-022` cross-reference. **Table column counts checked by hand**: the ABI
table in `codec.cljs`'s docstring is 4 columns on every row (5 pipes, verified across
the header, rule and all four body rows) and only a cell's interior changed; the
interop Defaults table is 2 columns on every row (3 pipes) including the added
`` `:class` values `` row. No other table was touched.

The interop guide's Defaults section was the one rebase conflict, against #7502's
`Prop values` row. **Both intents were merged rather than either side taken**: #7502's
two rows are kept verbatim and a third refines them, since "stringify" is the
named-value rule and a collection is not a named value. #7502's "values inside a
collection go through `clj->js`" sentence stays true as written (its example is a
nested option map at an ordinary slot) and now carries the `:class` carve-out beside
it. The guide's worked example is asserted verbatim in the test file so page and door
cannot drift.

## Quality gates

All run locally to completion, foreground, on the rebased tree.

| Gate | Exit | Result |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | `0` | `PASS fast PR spine` |
| `npm run test:cljs` | `0` | 12,585 tests / 63,097 assertions — 0 failures, 0 errors |
| `npm run test:browser` | `0` | 1,091 tests / 6,766 assertions — 0 failures, 0 errors |
| `npm run test:hicasso-compile` | `0` | 118 lane namespaces, **0 warnings** |
| `clj-kondo` @ **2026.04.15** (the CI pin) | `0` | **errors: 0**, warnings: 4,534 (baseline) |
| `python scripts/check_doc_slugs.py` | `0` | clean |

clj-kondo was run with `lint.yml`'s exact invocation (`--parallel --fail-level error`
plus its twelve `--lint` paths) using the pinned 2026.04.15 binary, not the local
2025.10.23 — a pass from a differently-versioned binary proves nothing.

Not run locally, per `check_fast_pr_gap.py --brief`: the browser/bundle/adapter/tooling
lanes CI owns (prod-elision, bundle-isolation, perf gates, adapter smokes, Xray feature
matrix, mcp-conformance, tool JVM suites).

## Beads

- `rf2-2rtt6.119` — closed by this PR.
- `rf2-d03av` — closed by this PR (settled as a record; the decision and its reasoning
  are in HD-016's dated note, not only here).
- `rf2-2rtt6.122` — **left open**, annotated with the constructibility finding. It needs
  an operator ruling on whether the core gains a render-phase refusal tier; a bench
  worker cannot close it.
