### PR TITLE
perf(ci): the image-keys checker is fast and its self-test can fail (rf2-e1xx0)

### DIFF
--- a/scripts/check_retired_image_keys.py
+++ b/scripts/check_retired_image_keys.py
@@ -169,6 +169,12 @@ _IMAGE_CTX_RE = re.compile(r"\b(?:rf/image|image/image|make-frame|:images)\b")
 # A `make-frame` / image opts map can span several lines, so the anchoring token
 # may sit a few lines from the key. The co-occurrence window (lines on each side).
 _MAKE_FRAME_WINDOW = 4
+# Removed-context suppression window (lines each side). A retirement-discussing
+# `deftest` name / `testing` string / comment can sit a few lines above the
+# retired-key data line (e.g. a `doseq` over retired specs), so the window is
+# slightly wider than a bare neighbour pair.
+_REMOVED_CTX_WINDOW = 3
+
 # The gate's ADVERTISED contract — the exact token set the module docstring
 # promises, written out once so the self-test can hold the implementation to it.
 # `--self-test` asserts BOTH that the detectors emit exactly this set and that
@@ -211,12 +217,6 @@ _TOKEN_PREFILTER_RE = re.compile(
 # decoded at all. (Universal-newline translation only ever turns CR / CRLF into
 # LF; it cannot join characters across the break, so it cannot conjure a token.)
 _TOKEN_PREFILTER_BYTES_RE = re.compile(_TOKEN_PREFILTER_RE.pattern.encode("ascii"))
-
-# Removed-context suppression window (lines each side). A retirement-discussing
-# `deftest` name / `testing` string / comment can sit a few lines above the
-# retired-key data line (e.g. a `doseq` over retired specs), so the window is
-# slightly wider than a bare neighbour pair.
-_REMOVED_CTX_WINDOW = 3
 
 
 # --------------------------------------------------------------------------

--- a/scripts/check_retired_image_keys.py
+++ b/scripts/check_retired_image_keys.py
@@ -69,6 +69,7 @@ Dependency-light — Python stdlib only.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from pathlib import Path
@@ -178,6 +179,39 @@ _ADVERTISED_KINDS = frozenset({
     ":rf.image/requires", ":rf.gen/requires",
     ":replace", "make-frame :capabilities",
 })
+
+# THE PRE-FILTER (rf2-e1xx0) — a SUPERSET of every detector above, and the only
+# reason this gate is cheap.
+#
+# Each detector's pattern begins with one of these literal substrings, so text
+# containing none of them cannot match any of them. `:replace` is deliberately
+# listed bare: it is a prefix of `:replace-standard`, so one alternative covers
+# both. `:capabilities` is the literal key, never the bare word `capability`.
+#
+# WHY IT IS SOUND, and why it is NOT a narrowing of what the gate matches: the
+# filter is applied to the RAW text of a file and then to each MASKED line, and
+# every masking pass in this module only ever BLANKS characters (comments and
+# string literals become runs of spaces, length preserved). Blanking can remove a
+# token, never create one — so "no literal token anywhere in this text" implies
+# "no detector can fire here", exactly. Everything the filter skips would have
+# produced no finding; the verdicts are identical, and the equivalence is held to
+# the real corpus plus a per-token/per-context synthetic corpus in the PR.
+_TOKEN_PREFILTER_RE = re.compile(
+    r":replace"              # covers :replace AND :replace-standard
+    r"|:rf\.image/requires"
+    r"|:rf\.gen/requires"
+    r"|:include-ns"
+    r"|:exclude-ns"
+    r"|:capabilities"
+)
+# The same filter over undecoded bytes, derived from the pattern above so the two
+# cannot drift. Every token is pure ASCII and UTF-8 never encodes a non-ASCII
+# character using ASCII bytes, so a token is present in the bytes exactly when it
+# is present in the decoded text — which lets a file be ruled out before it is
+# decoded at all. (Universal-newline translation only ever turns CR / CRLF into
+# LF; it cannot join characters across the break, so it cannot conjure a token.)
+_TOKEN_PREFILTER_BYTES_RE = re.compile(_TOKEN_PREFILTER_RE.pattern.encode("ascii"))
+
 # Removed-context suppression window (lines each side). A retirement-discussing
 # `deftest` name / `testing` string / comment can sit a few lines above the
 # retired-key data line (e.g. a `doseq` over retired specs), so the window is
@@ -232,7 +266,6 @@ def _implemented_kinds() -> frozenset[str]:
 # --------------------------------------------------------------------------
 
 _FENCE_RE = re.compile(r"^(\s*)(`{3,}|~{3,})")
-_LINE_COMMENT_RE = re.compile(r";.*$")
 _INLINE_CODE_SPAN_RE = re.compile(r"(`+)(?:.+?)\1")
 # A double-quoted Clojure string literal (no escape handling needed for the
 # token search — masking only ever REMOVES potential matches). Masked so a
@@ -242,10 +275,16 @@ _CLJ_STRING_RE = re.compile(r'"[^"]*"')
 
 
 def _mask_clj_comment(line: str) -> str:
-    m = _LINE_COMMENT_RE.search(line)
-    if not m:
+    """Blank from the first `;` to end of line, length-preserving.
+
+    `str.find` rather than a `;.*$` regex: this runs on every line of every file
+    that reaches the scanner, and the regex was ~190k searches doing what an
+    index lookup does. `line` never carries its newline (it comes from
+    `splitlines`), so the first `;` to the end IS the whole comment.
+    """
+    start = line.find(";")
+    if start < 0:
         return line
-    start = m.start()
     return line[:start] + (" " * (len(line) - start))
 
 
@@ -283,35 +322,38 @@ def _code_fence_lines(text: str) -> list[tuple[int, str]]:
     return out
 
 
+# A whole Clojure string literal: the opening `"`, then any run of ordinary
+# characters or backslash-escaped pairs (so `\"` does not close early), then the
+# closing `"` — or the end of the text when the string is never closed, which
+# blanks to EOF exactly as the character scanner this replaced did. DOTALL so a
+# literal spans lines.
+_CLJ_STRING_SPAN_RE = re.compile(r'"(?:[^"\\]|\\.)*(?:"|\\?\Z)', re.DOTALL)
+
+
+def _blank_span(match: re.Match) -> str:
+    """Blank a matched span to spaces, keeping its newlines (and so its length,
+    and so every line number after it)."""
+    span = match.group(0)
+    if "\n" not in span:
+        return " " * len(span)
+    return "\n".join(" " * len(seg) for seg in span.split("\n"))
+
+
 def _mask_multiline_clj_strings(text: str) -> str:
     """Blank every double-quoted Clojure string literal across the WHOLE file,
     length-preserving (newlines kept), so a retired token named inside a
     MULTI-LINE docstring is not a live-code hit. A `"` opens a string; the next
     unescaped `"` closes it. Escapes (`\\"`) are honoured so an embedded quote
-    does not close early."""
-    out: list[str] = []
-    in_str = False
-    escaped = False
-    for ch in text:
-        if in_str:
-            if escaped:
-                escaped = False
-                out.append(" " if ch != "\n" else "\n")
-            elif ch == "\\":
-                escaped = True
-                out.append(" ")
-            elif ch == '"':
-                in_str = False
-                out.append(" ")
-            else:
-                out.append(" " if ch != "\n" else "\n")
-        else:
-            if ch == '"':
-                in_str = True
-                out.append(" ")
-            else:
-                out.append(ch)
-    return "".join(out)
+    does not close early.
+
+    One regex sweep, not a per-character loop: the loop was 12s of this gate's
+    runtime over the corpus, 2.6M `str.join` calls for a pass that blanks whole
+    spans (rf2-e1xx0). Newlines survive because the replacement blanks every
+    character EXCEPT `\\n`, which is what keeps line numbers honest downstream.
+    """
+    if '"' not in text:
+        return text
+    return _CLJ_STRING_SPAN_RE.sub(_blank_span, text)
 
 
 def _clj_code_lines(text: str) -> list[tuple[int, str]]:
@@ -371,6 +413,13 @@ def _scan_lines(lines: list[tuple[int, str]], path: Path,
     masked_by_no = {ln: s for ln, s in lines}
     findings: list[Finding] = []
     for line_no, masked in lines:
+        # PRE-FILTER (rf2-e1xx0). Every hit below requires one of the retired
+        # tokens to match THIS line, so a line carrying none of their literal
+        # substrings can be skipped whole — before the two context windows are
+        # joined and before the regex battery runs. That is the 9.4M searches and
+        # the 2.6M joins: the overwhelming majority of lines contain no token.
+        if not _TOKEN_PREFILTER_RE.search(masked):
+            continue
         raw_context = " ".join(
             raw[n - 1] if 0 <= n - 1 < len(raw) else ""
             for n in range(line_no - _REMOVED_CTX_WINDOW, line_no + _REMOVED_CTX_WINDOW + 1)
@@ -393,6 +442,12 @@ def _scan_lines(lines: list[tuple[int, str]], path: Path,
 
 def _scan_text(path: Path, text: str, rel_posix: str) -> list[Finding]:
     if _is_allowlisted(rel_posix):
+        return []
+    # PRE-FILTER (rf2-e1xx0). Masking only blanks characters, so a file whose RAW
+    # text carries no retired token cannot produce one after masking either. Most
+    # of the corpus lands here, and lands here before the fence walk and the
+    # string-masking pass have to touch it at all.
+    if not _TOKEN_PREFILTER_RE.search(text):
         return []
     raw = text.splitlines()
     if path.suffix in _DOC_SUFFIXES:
@@ -421,20 +476,37 @@ def _tool_spec_scan_dirs(repo_root: Path) -> list[str]:
 
 def _iter_files(scan_root: Path, repo_root: Path,
                 suffixes: tuple[str, ...]) -> Iterable[Path]:
+    """Every file under `scan_root` with one of `suffixes`, excluded trees
+    dropped, in sorted order.
+
+    PRUNED, not filtered-after (rf2-e1xx0). The excluded directory names are
+    removed from `os.walk`'s dirnames in place, so a checkout with
+    `implementation/node_modules` populated — which every worker worktree has —
+    never enumerates it. `rglob("*")` used to list all ~50k entries and discard
+    them one at a time. The surviving set is identical: nothing under an excluded
+    directory could pass the check below either.
+    """
     if scan_root.is_file():
         if scan_root.suffix in suffixes:
             yield scan_root
         return
-    for path in sorted(scan_root.rglob("*")):
-        if path.suffix not in suffixes:
+    scan_prefix_len = len(scan_root.as_posix()) + 1
+    repo_prefix = repo_root.as_posix() + "/"
+    matches: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(scan_root):
+        dirnames[:] = [d for d in dirnames if d not in _EXCLUDE_DIR_NAMES]
+        for name in filenames:
+            if os.path.splitext(name)[1] in suffixes:
+                matches.append(Path(dirpath) / name)
+    for path in sorted(matches):
+        # Kept as the belt to the pruning's braces, and now on string ops:
+        # `Path.relative_to` was half a second of pathlib object churn over the
+        # corpus, for a prefix strip.
+        posix = path.as_posix()
+        if set(posix[scan_prefix_len:].split("/")) & _EXCLUDE_DIR_NAMES:
             continue
-        parts = set(path.relative_to(scan_root).parts)
-        if parts & _EXCLUDE_DIR_NAMES:
-            continue
-        try:
-            rel_posix = path.relative_to(repo_root).as_posix()
-        except ValueError:
-            rel_posix = path.as_posix()
+        rel_posix = (posix[len(repo_prefix):]
+                     if posix.startswith(repo_prefix) else posix)
         if any(rel_posix.startswith(pre) for pre in _EXCLUDE_REL_PREFIXES):
             continue
         yield path
@@ -455,8 +527,7 @@ def scan(repo_root: Path,
             if path in seen:
                 continue
             seen.add(path)
-            rel = _rel(path, repo_root)
-            findings.extend(_scan_text(path, _read(path), rel))
+            findings.extend(_scan_file(path, repo_root))
     for d in source_dirs:
         root = repo_root / d
         if not root.exists():
@@ -465,16 +536,32 @@ def scan(repo_root: Path,
             if path in seen:
                 continue
             seen.add(path)
-            rel = _rel(path, repo_root)
-            findings.extend(_scan_text(path, _read(path), rel))
+            findings.extend(_scan_file(path, repo_root))
     return findings
 
 
+def _scan_file(path: Path, repo_root: Path) -> list[Finding]:
+    """Scan one file on disk.
+
+    The bytes are read first and filtered before anything is decoded: the vast
+    majority of the corpus carries no retired token at all, and there is no
+    reason to build a `str` for a file that cannot produce a finding. Files that
+    DO carry one are then read through `_read` exactly as before, so the decoding
+    (and its universal-newline translation) is untouched on the path that
+    actually scans.
+    """
+    rel = _rel(path, repo_root)
+    if _is_allowlisted(rel):
+        return []
+    if not _TOKEN_PREFILTER_BYTES_RE.search(path.read_bytes()):
+        return []
+    return _scan_text(path, _read(path), rel)
+
+
 def _rel(path: Path, repo_root: Path) -> str:
-    try:
-        return path.relative_to(repo_root).as_posix()
-    except ValueError:
-        return path.as_posix()
+    posix = path.as_posix()
+    prefix = repo_root.as_posix() + "/"
+    return posix[len(prefix):] if posix.startswith(prefix) else posix
 
 
 def _read(path: Path) -> str:

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -47,17 +47,19 @@ set -euo pipefail
 # STEP INSIDE A JOB THIS SPINE RUNS — the EP-0036 donor-boundary `git grep` is
 # the last step of `jvm-freehand`, so it reports as "JVM freehand (clojure
 # -M:test)" and is not a test; `npm run test:ui-isolation` is a step of the same
-# `cljs` job whose node-test build this spine does run; and thirty-seven of CI's
+# `cljs` job whose node-test build this spine does run; and thirty-eight of CI's
 # required `python scripts/check_*.py` invocations had no local lane at all until
 # rf2-ejm7m measured them and gave them one — twenty-nine in the always-on block
-# below, eight in the documentation tier.  None of those is a skipped TIER, so
+# below, nine in the documentation tier.  None of those is a skipped TIER, so
 # nothing above can see them.  Run `python scripts/check_fast_pr_gap.py --list`
 # for the local command for each of the ones that remain.
 #
-# EXACTLY ONE required checker was measured and DELIBERATELY left out:
-# `check_retired_image_keys.py --verbose`, at 37.7s, is more than double this
-# spine's entire documentation tier.  The report still names it, which is the
-# correct answer rather than a gap in this comment.
+# EVERY required python checker now has a local lane.  rf2-ejm7m left exactly one
+# out on measurement — `check_retired_image_keys.py --verbose` cost 37.7s, more
+# than double this spine's entire documentation tier — and rf2-e1xx0 made it
+# ~0.9s instead of accepting the hole, so it joined the tier rather than staying
+# named in the report.  Nothing here had to be edited to reflect that: the report
+# derives the gap by parsing this file's invocations.
 #
 # What it DOES mirror is CI's *tiering* — which tiers run for a given diff —
 # because that decision is delegated wholesale to the classifier CI uses.  Tier
@@ -109,8 +111,9 @@ set -euo pipefail
 #   5. python scripts/check_inject_cofx_residue.py       — retired inject-cofx
 #   6. python scripts/check_failure_corpus_residue.py    — retired failure spellings
 #   7. python scripts/check_retired_composition_vocab.py — retired composition vocab
-#   8. python scripts/check_retired_image_keys.py --self-test only (rf2-ejm7m;
-#      its 37.7s live corpus sweep stays CI-only, and the gap map names it)
+#   8. python scripts/check_retired_image_keys.py  — retired EP-0026 image keys,
+#      BOTH arms: --self-test (the guard has teeth) then the live corpus sweep,
+#      which rf2-e1xx0 took from 37.7s to ~0.9s
 #   9. mkdocs build --strict (console script, else `python -m mkdocs`)
 
 # The spine's own tree (scripts, gate commands, the shared classifier) is
@@ -325,9 +328,9 @@ is_doc_surface_path() {
     # neighbours above: a gate whose own script changed has to run.  The first
     # three are named IDENTICALLY in docs.yml's `detect` classifier, so this is
     # mirroring CI, not inventing a local surface.  `check_retired_image_keys.py`
-    # is the one CI does not list — added anyway because this spine now executes
-    # its self-test, and a gate that runs here should arm on its own source; the
-    # direction is the safe one (over-arming a 0.08s check).
+    # is the one CI's classifier does not list — added anyway because this spine
+    # executes both of its arms, and a gate that runs here should arm on its own
+    # source; the direction is the safe one (over-arming a ~1s check).
     scripts/check_inject_cofx_residue.py|scripts/check_failure_corpus_residue.py) return 0 ;;
     scripts/check_retired_composition_vocab.py|scripts/check_retired_image_keys.py) return 0 ;;
     scripts/_test_fixtures/check_inject_cofx_residue/*) return 0 ;;
@@ -953,27 +956,28 @@ if [ "$run_docs" = true ]; then
   run "retired composition vocab" "python scripts/check_retired_composition_vocab.py --verbose" \
     python "$spine_root/scripts/check_retired_composition_vocab.py" --verbose
 
-  # THE ONE THAT IS NOT CHEAP, and the one exception in this bead (rf2-ejm7m).
+  # THE ONE THAT WAS NOT CHEAP — and now is (rf2-ejm7m measured it, rf2-e1xx0
+  # fixed it).
   #
-  # `check_retired_image_keys.py --verbose` is 37.7s cold / ~42s warm on this
-  # checkout — 95% of that job's whole checker batch, and more than the entire
-  # documentation tier it would join.  Folding it in would take the docs tier
-  # from ~28s to ~66s: every worker touching a single `.md` file pays a 2.4x
-  # slowdown, which is a worse trade than the ambush it would prevent.  So the
-  # live scan stays CI-only ON PURPOSE, and `check_fast_pr_gap.py` keeps naming
-  # it — correctly, and derivedly, with no exception list anywhere.
+  # `check_retired_image_keys.py --verbose` was 37.7s cold / ~42s warm: 95% of
+  # that job's whole checker batch, more than this entire documentation tier, and
+  # the ONE required checker rf2-ejm7m deliberately left without a local lane.  A
+  # token pre-filter in front of the regex battery, a one-sweep string mask, and a
+  # pruned directory walk took it to ~0.9s on the same checkout (0.85s on one with
+  # `node_modules` populated) with byte-identical findings, so it has a lane here
+  # now and the `note_skipped` beside it is gone.
   #
-  # The cost is real work, not a pathology of this machine: the scan is 9.4M
-  # regex searches plus a per-character Clojure string-masking pass over 3,534
-  # files (`_mask_multiline_clj_strings` alone is 12s of it).  A token pre-filter
-  # would very likely make it a sub-second gate and earn it a lane here; that is
-  # rf2-e1xx0, not this bead.
-  #
-  # Its SELF-TEST arm is 0.08s, so that one is here: the thing that proves the
-  # guard still has teeth is cheap even when the corpus sweep is not.
+  # Both arms run, and they answer different questions.  The live scan is the
+  # gate; the SELF-TEST is what proves the gate still has teeth — it plants one
+  # retired token per fixture and asserts the EXACT kind set, so a detector that
+  # dies reds BY NAME rather than being covered for by a sibling finding.  A green
+  # live scan over a corpus that contains no retired spellings cannot tell you the
+  # difference between "clean" and "blind".
   run "retired image-keys self-test" "python scripts/check_retired_image_keys.py --self-test --verbose" \
     python "$spine_root/scripts/check_retired_image_keys.py" --self-test --verbose
-  note_skipped "check_retired_image_keys.py --verbose (docs.yml, required) — 37.7s measured, 95% of that job's checker batch and >2x this whole tier; self-test arm runs above, live corpus sweep is CI-only by measurement (rf2-ejm7m, perf follow-up rf2-e1xx0)"
+
+  run "retired image keys" "python scripts/check_retired_image_keys.py --verbose" \
+    python "$spine_root/scripts/check_retired_image_keys.py" --verbose
 
   # EP index status-sync guard (rf2-8cw3m7): docs/EP/README.md restates each
   # EP's Status: line in its index table; the two drift by hand (EP-0001 sat at


### PR DESCRIPTION
Closes rf2-e1xx0. **Second half** — PR #7504 merged the self-test repair while
this work was in flight; this PR carries the optimisation and the spine fold that
the repaired self-test was the prerequisite for.

`check_retired_image_keys.py` was the one required checker the fast-PR spine could
not afford: **37.7s**, against ≤0.36s for 35 of the other 37, which cost 6.4s
between them. rf2-ejm7m gave every other required python checker a local lane and
left this one out on measurement. It is now **~0.9s**, so it has a lane.

## Why the self-test came first (merged in #7504, recorded here for the record)

The brief's ordering was right and worth restating, because it is what makes this
PR trustworthy: a 9.4-million-call rewrite is exactly the change that can quietly
narrow what a regex matches, so the instrument had to work before the surgery.

The gate advertises seven retired EP-0026 spellings, and its self-test asserted
`>= 1 finding` over three fixtures, two of which carried multiple tokens — so a
sibling finding covered for any detector that died. The bead recorded **two**
blind tokens. Measured with a mutation matrix that kills one detector at a time,
it was **six of seven**:

| killed detector | before #7504 | now |
| --- | --- | --- |
| `:replace-standard` | **SURVIVED (green)** | CAUGHT — names `live_replace_standard_fenced.md` |
| `:rf.image/requires` | **SURVIVED (green)** | CAUGHT — names `live_image_requires_source.cljc` |
| `:rf.gen/requires` | **SURVIVED (green)** | CAUGHT — names `live_gen_requires_source.cljc` |
| `:include-ns` | CAUGHT | CAUGHT — names `live_include_ns_fenced.md` |
| `:exclude-ns` | **SURVIVED (green)** | CAUGHT — names `live_exclude_ns_fenced.md` |
| `:replace` | **SURVIVED (green)** | CAUGHT — names `live_replace_key_fenced.md` |
| `make-frame :capabilities` | **SURVIVED (green)** | CAUGHT — names `live_make_frame_capabilities_fenced.md` |

The bead's note says re-running the mutation against `:rf.gen/requires` "DID red
the spine" — that does not reproduce: deleting its entry from
`_IMAGE_ONLY_RETIRED` leaves `live_requires_source.cljc` still yielding its
`:rf.image/requires` finding, so `>= 1` holds and the run stays green. **The
matrix above was re-run against this PR's final tree: 7/7 caught, each naming its
own fixture.**

## The optimisation, and why it is not a narrowing

The gate ran ~9.4M regex searches and a per-character string-masking pass over
3,534 files to answer a question that is almost always *"this file contains none
of seven literal tokens"*.

Every detector's pattern begins with one of six literal substrings (`:replace`
covers `:replace-standard` as a prefix). Text containing none of them cannot
match any of them. Crucially, **every masking pass here only blanks characters** —
comments and string literals become runs of spaces, length preserved — so masking
can *remove* a token but never *create* one. "No literal token in the raw text"
therefore implies "no detector can fire", exactly, which lets the filter run
*before* the fence walk and the masking pass instead of after them. It is applied
at three levels: the undecoded bytes, the whole file, and each masked line.

| change | was |
| --- | --- |
| token pre-filter (bytes / file / line) | 9.4M `re.search` calls |
| `_mask_multiline_clj_strings` | per-character loop, 2.6M `str.join` calls |
| `_mask_clj_comment` | a `;.*$` regex per line; now `str.find` |
| `_iter_files` | `rglob("*")` enumerating ~50k paths to discard; now `os.walk` with excluded dirs **pruned in place** |
| `_rel` / `_iter_files` | `Path.relative_to` per file — ~0.5s of pathlib churn for a prefix strip |

**Not a cache.** Nothing remembers anything between runs and no result depends on
prior state. Every file is still read and every candidate line still goes through
the identical detector battery. The work that disappeared is work whose answer
was already determined.

**Nothing was weakened to make it fast.** The detector patterns, the context
windows, the suppression vocabulary and the allowlist are untouched — the diff to
the matching logic is zero.

### Timings, and how they were measured

Foreground, no pipes, `python scripts/check_retired_image_keys.py --verbose`
(CI's own invocation), wall clock via `time`, Python 3.14 on Windows.

| | before | after |
| --- | --- | --- |
| cold (fresh worktree, first touch) | 75.8s | — |
| warm, this worktree (3 runs) | 38.6 / 36.6 / 37.6s | **0.99 / 0.93 / 0.93s** |
| warm, a checkout **with `node_modules` populated** | 39.6s | **0.88 / 0.84 / 0.84s** |

~0.14s of the remaining wall time is bare interpreter startup; `scan()` itself is
~0.7s, and what is left is the filesystem read of 3,534 files, which cannot go
away without a cache.

## Evidence the finding sets are identical

Not "both exit 0" — the **finding sets** were compared against the pre-change
implementation, on two real corpora and a synthetic one:

- **`scan()` as shipped** — identical (0 findings).
- **`scan()` with the allowlist bypassed**, so the detectors fire hard on the
  `docs/EP/**` worked examples — identical, **28 findings across 6 kinds**.
- **Synthetic corpus, 315 files** — every token, plus eight sanctioned
  counterparts that must stay green (`str/replace`, `clojure.string/replace`,
  `replace-first`, `:rf.capability/*`, `:select-ns`, `:registrations`,
  `:rf.gen/shadows`, and longer-keyword neighbours like `:include-nsx`) × every
  context that decides a verdict: fenced with and without an image anchor,
  `make-frame` anchor, tilde / longer / unterminated fences, prose, inline span,
  removed-context, `;`-comment, live code, single- and multi-line docstrings,
  escaped quotes, unterminated strings, `.edn`. Identical, **65 findings across
  all 7 kinds**.
- **Intermediate passes byte-for-byte**: `_mask_multiline_clj_strings`,
  `_clj_code_lines` and `_code_fence_lines` on **all 3,534 corpus files**, plus
  **200k random** and 17 pathological inputs (`"\`, `"a\nb`, `""""`, `\"`,
  unterminated-with-token, escaped-quote-then-token) against the character
  scanner the regex replaces.
- **File discovery**: `_iter_files` yields the **same paths in the same order**
  on every scan root — checked in a checkout **with `node_modules` populated**,
  which is where pruning actually changes the walk.

Re-run against a second corpus (a checkout with `node_modules`): EQUIVALENT on
both.

## The gap map

`check_fast_pr_gap.py` needed no edit and got none. It derives coverage by
parsing the spine's invocations, so adding the line **is** the change: **88**
unrun required checks becomes **87**, and the checker stops being named because
nothing names it. **Every required `python scripts/check_*.py` invocation now has
a local lane** — no python gap remains.

That derivation is also why the spine's invocations stay written **one per
line**; a loop over a variable would break the parse outright, and this PR does
not tidy them into one.

Both arms run in the docs tier, because they answer different questions. The live
scan is the gate; the self-test is what proves the gate can still fail. Over a
corpus with no retired spellings in it, a green live scan cannot distinguish
"clean" from "blind". Docs tier goes from ~28s to ~29s, not ~66s.

`.github/workflows/**` is untouched — docs.yml already runs both arms, so folding
this in needed no workflow change.

## Follow-up filed

**rf2-76c76** (P4). The bead expected the sibling
`check_retired_composition_vocab.py` to "come along for free" — measured, it does
not: it has no `_mask_multiline_clj_strings` at all, so it is a separate file
needing its own pre-filter and its own equivalence proof. What it *does* share,
with eight other checkers, is the `rglob` + `relative_to` walk. It is 1.3-1.5s,
now the most expensive single python checker in the spine; the whole remaining
prize is ~1s across the batch, which is why it is P4 and not P2.

## Quality gates

<!-- GATES -->
