### PR TITLE
docs(hicasso): decisions.md true-ups, a stale finding retired, and the door's h/fn question answered (rf2-2rtt6.123, rf2-pca72, rf2-2rtt6.117)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -272,10 +272,9 @@ predecessors' pattern of building before measuring.
 > recorded door, not ad-hoc invention, and still never a state system. That
 > updates this entry's Reopens shape in place.
 >
-> **Status is honest tense.** The ruling is recorded; nothing has landed.
-> `h/reg-state`, `[::h/clear …]`, `h/child-key` and the refusals are in
-> implementation as `rf2-2rtt6.98`; the guide teaches the convention in the
-> same tense.
+> **Status.** `h/reg-state`, `[::h/clear …]`, `h/child-key` and the refusal
+> surface have since landed on the now-closed bead `rf2-2rtt6.98`; the guide
+> teaches the convention in the same tense.
 
 **Ruling.** No component-local reactive cell (`local`, ratom-equivalent, or
 `useState` for app state) exists in Hicasso. In order: CSS for hover/focus;
@@ -517,6 +516,49 @@ fallback is a lint, not a third convention. Note: helper-donated reads are
 settled rather than contingent. HD-002's ruling makes the ambient collector the
 one product read surface, so a `sub` performed inside a helper is an ordinary
 read that lands in the calling boundary's window.
+
+> **Addendum, 2026-08-04 (`rf2-2rtt6.105`) — the `for`-lowering sugar is ruled
+> out, and the door it retires behind is named.** The details list above pins
+> that the sugar "is **not** v0". That clause is not wrong; it was incomplete,
+> because a reader could learn the sugar was out of v0 without learning it was
+> subsequently ruled out for v-anything. A design pass plus an adversarial review
+> briefed to *force* the build case returned **DO-NOT-BUILD** — recorded at the
+> adjudicated strength and no stronger: ruled out **on today's evidence**,
+> **operator-overturnable**, with a pre-agreed response class. Never "never".
+>
+> **The door, by name.** The shelved shape is a **scalar-refusing `h/for`** —
+> `(h/for [id ids] [row {:id id}])`, with a loud refusal on a non-scalar binding
+> value, the refusal itself being the lesson. Its trigger is the dogfood
+> preference test failing **specifically on list ceremony**, which is HD-009's own
+> reopen shape. Until that gate fires authors write `:key` themselves, and that is
+> the taught answer rather than a gap waiting on sugar. The charter's by-name
+> pre-permission of the sugar is retired behind this same door rather than
+> deleted; [charter.md](charter.md)'s "No analyzer" bullet carries the matching
+> amendment, and the two records are meant to be read as one.
+>
+> **What the verdict rests on.** The cost case, and it survives independently of
+> how often the sugar would serve. The sugar would be the first control form in a
+> collector grammar whose *absence* of control forms is a marketed virtue, and it
+> could never retire the explicit `:key`, so every list would carry two spellings
+> forever. The binding value is only *sometimes* the identity: a destructured or
+> entity-valued binding is string-coerced by React through CLJS `toString` into
+> content-derived identity, so editing a row silently remounts it — and every
+> repair for that (refuse entities, add a `:key-fn` arm) collapses back toward the
+> explicit spelling, which is the instance-key programme's arc re-run. The
+> `defview`-macro-rewrite route is dead on the no-analyzer fence, where partial
+> coverage would be a silent-inconsistency factory. Against all of that, the
+> ceremony saved is roughly a dozen characters per list site. The dominating
+> repair the pass identified — a dev warning on a **non-primitive `:key` value**,
+> closing the same hazard in the explicit spelling at zero concept cost — is
+> designed but **not landed** (`rf2-2rtt6.104`), and this verdict deliberately
+> does not lean on it.
+>
+> **Corpus correction, binding on any record of this ruling.** The decisive
+> framing is **not** "wrong at two-thirds" — that ratio belongs to the v1-idiom
+> examples corpus. The governing Hicasso-idiom corpus, the charter's own `shapes/`
+> tree included, runs **~70% scalar binding-as-key**, which reads *for* the sugar
+> rather than against it. The verdict took that correction and stood, because it
+> never rested on serve rate.
 
 > **Note, 2026-08-05 (rf2-d03av): "callback refs only" states what v0 TEACHES,
 > not what it refuses.** The clause above reads as a prohibition, and it is not
@@ -769,9 +811,9 @@ candidate second call site appears. The composition value path reopens on
 > (a)–(c) of the ruling below — frame plumbing, the hook ledger, the error
 > boundary — stand as written.
 >
-> **Status is honest tense.** The ruling is recorded; nothing has landed. The
-> hydration door, the `defhost` `:ssr` policy, the Node render entry, and the
-> X1–X5 spike witness are in progress as beads `rf2-2rtt6.84`–`.87`.
+> **Status.** Four pieces have since landed on the now-closed beads
+> `rf2-2rtt6.84`–`.87`: the hydration door, the `defhost` `:ssr` policy, the
+> Node render entry, and the X1–X5 spike witness.
 
 **Ruling.** (a) **Frame plumbing**: each boundary reads the frame once via the
 substrate's single internal context, then binds it ambiently for the render's

--- a/docs/design/hicasso/studio/raw-escape-design-a-minimal.md
+++ b/docs/design/hicasso/studio/raw-escape-design-a-minimal.md
@@ -455,6 +455,15 @@ of its scope for the declared form too.
   bead's fence and outside Hicasso, but it is a stale sentence a reader of this edge
   will trip over. Recorded as a finding, not actioned.
 
+  > **Fixed 2026-08-05 (`rf2-whfte`) — the finding was right, and 008 now says so.**
+  > The qualified-host bullet no longer claims the crossing is opaque. What is opaque
+  > is what the foreign component *renders beneath* the crossing — a host node's
+  > `:children` are the declared SSR projection, never the registered component's own
+  > output — while the crossing itself (`:rf.ui/host`, its declared `:rf.ui/host-ssr`
+  > policy, and its `:props`) is an ordinary headless read in the `jvm` and `browser`
+  > structural cells. The bullet above stands as the record of what was true when this
+  > page was written; the reader it warns about no longer trips.
+
 ---
 
 ## Edge 4 — the legal Component-value boundary, and where refusal falls

--- a/docs/design/hicasso/studio/raw-escape-spec.md
+++ b/docs/design/hicasso/studio/raw-escape-spec.md
@@ -281,6 +281,22 @@ escape's mechanism changes. This is a departure from the bead's 12:06 comment, w
 fork should exist. A fork at the one edge whose entire argument is zero-fork is the wrong
 default; deferring to the door costs nothing and cannot be wrong in any branch.
 
+> **Answered 2026-08-05 (`rf2-2rtt6.117`) — no, and the question inverted before it could be
+> put.** `.117` was spun out as a *parity* question: the escape had just been given a dev-only
+> warning, so does the door get the same one? The pin above retracts that grant. There is now
+> no warning at `[:>]` to be at parity with — `[:>]` is unbuilt, and by this section's ruling
+> it will never carry a diagnostic the door lacks — so the answer to the question as asked is
+> **no**, on the premise rather than on the merits. The second horn the bead offers ("or is the
+> door's declaration story sufficient signal?") is not the reason either; it was never reached.
+>
+> What survives of `.117` is not a second decision. It is the **warn** arm of the one
+> three-way ruling §7 R1 states as *refuse, warn, or leave* — the ruling `rf2-2rtt6.116`
+> escalates, on the ground that it turns a shipped accept at a declared door into something
+> else. That is the operator's, and nothing here anticipates it: if the door refuses, a warning
+> is moot; if the door leaves the crossing alone, warn-versus-leave is live and is still one
+> question, not two. Whichever way it goes, the escape does what the door does and no line of
+> the mechanism above changes.
+
 ---
 
 ## 4. Edge 3 — what "reduced structural identity" concretely means


### PR DESCRIPTION
Three design-record beads on one surface. Docs-only, `docs/design/hicasso/**`.

**Net +74 / −7 across three files.** Net-positive is right here: two of the three items are
*additions the record was found to be missing* (a dated addendum a closed verdict assigned,
and an answer to an open question), and only the two stale status clauses were replacements.

---

## `rf2-2rtt6.123` — three bounded true-ups in `decisions.md`

**1. HD-016 gains its dated addendum** — the third artefact `rf2-2rtt6.105`'s closing verdict
comment names. Guide 02 and the charter's `h/for` mention landed in #7502; `decisions.md` was
outside that PR's fence, so this is the remainder.

HD-016's details list pins *"the `for`-lowering sugar is **not** v0"*. That clause was never
false — only incomplete — so it is **preserved verbatim and completed in place** by a dated
addendum rather than rewritten. The addendum records the **DO-NOT-BUILD** verdict at the
adjudicated strength (*ruled out on today's evidence, operator-overturnable, with a pre-agreed
response class, never "never"*), **the door by name** (the scalar-refusing `h/for`, triggered
by the dogfood preference test failing specifically on list ceremony — HD-009's own reopen
shape), and the cost case the verdict actually rests on.

It carries the **corpus correction** the same comment makes binding on all record text: the
decisive framing is *not* "wrong at two-thirds" — that ratio belongs to the v1-idiom examples
corpus — and the governing Hicasso-idiom corpus (the charter's own `shapes/` tree included)
runs **~70% scalar binding-as-key**, which reads *for* the sugar. The verdict took that
correction and stood, because it never rested on serve rate.

Honest tense throughout: `rf2-2rtt6.104`'s non-primitive-`:key` warning is named as the
dominating repair and explicitly marked **designed but not landed**, and the addendum states
that the verdict does not lean on it — following the precedent `rf2-2rtt6.111` set in guide 02.
Wording is kept consistent with the charter's landed "No analyzer" amendment, and the addendum
links the two so they read as one record.

**2. HD-009's status clause (`:275-278`)** said *"nothing has landed"* while `h/reg-state`,
`[::h/clear …]`, `h/child-key` and the refusal surface had merged on `rf2-2rtt6.98` (#7479) —
already false at #7502's base, which is why the bead folded it here rather than reopening
`.100`. **Only the status sentence moves.** The HD-009 ruling, the four taught-not-policed
rules, the SSR payload obligation, the `useId` autopsy and the ambient-door response class are
untouched. Verified against the tree before writing "landed": `front/state.cljc:150` `child-key`,
`:210` `reg-state`, `:96-100` + `:183-190` the `::h/clear` event and its registration,
`:138` `:rf.error/hicasso-state-bad-key`.

**3. HD-020's addendum carried the identical stale SSR progress clause** the charter fix could
not reach — all four of `rf2-2rtt6.84`–`.87` closed on merged PRs. Replaced with the charter's
own landed wording, **same four pieces in the same order**, so the two records agree:

> **Status.** Four pieces have since landed on the now-closed beads `rf2-2rtt6.84`–`.87`: the
> hydration door, the `defhost` `:ssr` policy, the Node render entry, and the X1–X5 spike witness.

**Bounded exactly as the charter's filer bounded it.** The surrounding blockquote is retained
pre-registration history and survives verbatim — the R0–R8 requirement pointer, the operator's
verbatim quotes, *"What does not move"* (SSR speed off the bar; clauses (a)–(c) standing).
Unscoped deletion is what that bead's filer deliberately avoided, and this follows it.

## `rf2-pca72` — a finding that went stale in the other direction

`raw-escape-design-a-minimal.md`'s Edge 3 "How it could be wrong" list said `spec/008-Testing.md`
*"still says"* a foreign crossing is opaque because *"the v1 node set carries no host variant"*.
`rf2-whfte` (#7496) actioned it: 008's qualified-host bullet now says the opposite in terms —
what is opaque is what the foreign component *renders beneath* the crossing, while the crossing
itself (`:rf.ui/host`, `:rf.ui/host-ssr`, `:props`) is an ordinary headless read. Verified at
`spec/008-Testing.md:770-778`.

The bead offered "dropped, or reduced to a one-line note". Taken the **records** way instead:
the bullet is **preserved as the record of what was true when the page was written**, and
carries a dated `Fixed 2026-08-05 (rf2-whfte)` note beneath it — the same pattern
`raw-escape-spec.md` already uses for its own settled §8 items 5 and 6. Deleting it would erase
the provenance of a spec change that this page caused.

**Swept for other spellings of the finding**: `grep` for `008`, `opaque`, `host variant` and
`v1 node set` across all of `docs/design/hicasso/**` returns this bullet as the **only**
instance. No sibling design or the synthesized spec repeats it.

## `rf2-2rtt6.117` — answered **no**, recorded as a note, no code

**No warning was added, and none should be.** The bead asks whether the door's undeclared
marked-`h/fn` slot gets *"the same dev-warning `[:>]` **now carries**"*. It does not carry one.
The merged synthesized spec **retracted that grant**: §3's *"The diagnostic, pinned to the door
rather than forked from it"* rules that the escape's conduct and its diagnostic are *whatever
`rf2-2rtt6.116` and `rf2-2rtt6.117` rule for the door*, and says so while explicitly naming its
departure from the 12:06 comment that shipped a dev-only warning at `[:>]` only — *"a fork at
the one edge whose entire argument is zero-fork is the wrong default"*.

So the question inverted before it could be put. There is nothing to be at parity with, `[:>]`
is unbuilt (`front/codec.cljs:961` still records it as deliberately unbuilt), and by that same
pin it will never carry a diagnostic the door lacks. **The answer as asked is no — on the
premise, not on the merits.** The bead's own second horn ("or is the door's declaration story
sufficient signal?") is *not* the reason; it was never reached.

What survives of `.117` is **not a second decision**. It is the **warn** arm of the one
three-way ruling §7 R1 states as *refuse, warn, or leave* — the ruling `rf2-2rtt6.116`
escalates, on the ground that it turns a shipped accept at a declared door into something else.
That is the operator's. **`.116` is untouched and unresolved here**, and the note says so: if
the door refuses, a warning is moot; if the door leaves the crossing alone, warn-versus-leave is
live and is still one question, not two.

This is the shape `rf2-d03av` closed in — a ruling recorded as a record, with no code, because
refusing or nagging a spelling that works correctly is friction rather than safety.

---

## Quality gates

Docs-only, confined to `docs/design/hicasso/**`.

**`mkdocs build --strict` is NOT nominated as the gate for this diff.** `mkdocs.yml`'s
`exclude_docs` keeps `design/hicasso/` out of the site, so it verifies nothing here. The
fast-PR spine runs it anyway inside its docs lane and it passed — but that pass is not evidence
about these three files, and it is recorded that way so its green is not mistaken for coverage.

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** — mutation-proved below |
| `sh scripts/test-fast-pr.sh` | **0** — `PASS fast PR spine`, docs lane classified in (`docs=true`) |

*(2 columns, 2 body rows.)*

**Mutation proof of the slug checker** — it is a fail-open instrument on this tree, so it was
proved to fail before it was trusted:

1. Baseline — `python scripts/check_doc_slugs.py` → **exit 0**.
2. Broke one anchor on a line **this PR adds**: `[charter.md](charter.md)` at
   `decisions.md:536` → `[charter.md](charter.md#records-probe-no-such-anchor)`.
   → **exit 1**, `BROKEN ANCHOR: docs\design\hicasso\decisions.md:536 -> charter.md#records-probe-no-such-anchor`.
   It named the file, the line and the anchor.
3. Restored → **exit 0**.

All three files are already tracked, so the `git ls-files` skip-untracked hole does not apply;
no new files were added.

**Anchors, hand-verified.** One link is added in the whole diff — `[charter.md](charter.md)`,
a target-only link with no anchor, whose target the checker validates and step 2 above proves
it is reading. **No heading was added, renamed or removed** in any of the three files, so no
inbound-link sweep is owed; a `git grep` for inbound links to the touched sections confirms
none exist to break.

**Tables, hand-counted** (nothing validates them). No table row was added, removed or edited.
The two tables adjacent to the edits were counted by hand and are intact:

- `raw-escape-spec.md` §3 position table — **2 columns, 7 body rows**, matching its own
  `*(7 rows, 2 columns.)*` caption.
- `raw-escape-design-a-minimal.md` Edge 4 refusal table — **2 columns, 6 body rows**.
- The gate table in this PR body — **2 columns, 2 body rows**.

**Rendering, by eye.** The HD-016 addendum and the existing `rf2-d03av` note are separated by a
blank unprefixed line so they render as two distinct blockquotes, in date order (2026-08-04
then 2026-08-05). The `rf2-pca72` note is an indented blockquote nested under its list item.

## Beads

`rf2-2rtt6.123` delivered · `rf2-pca72` delivered · `rf2-2rtt6.117` answered as a ruling with
no code. `rf2-2rtt6.116` deliberately untouched.
