### PR TITLE
fix(bench): the remaining page-error refusals fire, and a dead page reports sooner (rf2-va5nm, rf2-qv761)

### DIFF
--- a/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
+++ b/implementation/adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
@@ -330,10 +330,7 @@ async function main() {
   // back, and the property this one bypassed entirely by never being read.
   // `HN_ERROR` does not cover it: React 19.2 routes an uncaught render error
   // to `reportError` instead of rethrowing, so the app's own catch never runs
-  // and the page carries on to `HN_READY`. The sentinel wait below is
-  // deliberately NOT converted to `watch.race` — that is rf2-f5roa's separate
-  // "report it promptly" remedy, and the fault here is the page that throws
-  // AND STILL reaches its sentinel, which the wait returns from normally.
+  // and the page carries on to `HN_READY`.
   const watch = watchPage(page, 'hn');
 
   const { navigate, NAV_TIMEOUT_MS } = loadNavigate();
@@ -342,8 +339,14 @@ async function main() {
     timeoutMs: NAV_TIMEOUT_MS,
     budget: 'the 5-minute wait for `window.HN_READY`',
   });
-  await page.waitForFunction('window.HN_READY === true || window.HN_ERROR', null, {
-    timeout: 5 * 60 * 1000,
+  // RACED AGAINST THE PAGE DYING (rf2-qv761) — see `sentinel.cjs`. `race`
+  // rejects only on a failure `watch` recorded, and `verdict` below already
+  // refuses on exactly that array, so no run that would have passed is
+  // shortened. The rejection lands in `main`'s existing rejection handler,
+  // which is this driver's exit 1; its 2, 3 and 4 are untouched.
+  await watch.race('window.HN_READY === true || window.HN_ERROR', {
+    timeoutMs: 5 * 60 * 1000,
+    budget: 'the 5-minute wait for `window.HN_READY`',
   });
   const bootErr = await page.evaluate('window.HN_ERROR || null');
   if (bootErr) throw new Error(`page failed to initialise: ${bootErr}`);

--- a/implementation/core/test/re_frame/bench/p0_pageerror_probe.cljs
+++ b/implementation/core/test/re_frame/bench/p0_pageerror_probe.cljs
@@ -1,0 +1,75 @@
+(ns re-frame.bench.p0-pageerror-probe
+  "P0's page-error probe — **the real P0 app, plus one detached throw**.
+
+  rf2-va5nm, and the sibling of
+  `re-frame.freehand.bench.b7-pageerror-probe`. Not an instrument and not a
+  stub: this namespace exists so `p0_run.cjs`'s `pageerror` refusal can be
+  WATCHED FIRING in the driver's own process, end to end, against a real
+  `:advanced` bundle and a real headless Chromium.
+
+  ## Why it is the real app and not a fixture
+
+  rf2-sib23 wired the refusal into all nine bench drivers and could only
+  watch five of them fire. P0 was one of the four it could not, because its
+  exit is an enumerated inline block with no pure exported verdict AND its
+  page API is far too large to stub — four rows at one page per clock
+  round, `window.P0H`, `window.P0A`, `window.P0_ROUND`. rf2-va5nm records
+  the judgement: *a wrong stub is not a cheaper proof, it is a fiction that
+  can pass or fail for reasons that have nothing to do with the gate.*
+
+  So there is no stub. `-main` below calls `p0-app/-main` — the published
+  entry, unchanged — and then schedules a throw from a task the app does
+  not own. That is rf2-sib23's fault shape exactly: the page throws AND
+  STILL reaches its own completion sentinel, the case no page-side
+  `try`/`catch` can close under React 19.2.
+
+  ## The throw is DETACHED, and that is the whole point
+
+  A `setTimeout` callback is a task `p0-app/-main` has already returned
+  from. Its throw escapes the app's `(catch :default e ...)`, sets no
+  `window.P0_ERROR`, and rejects no `page.evaluate` — it reaches Playwright
+  as `pageerror` and nowhere else. `sentinel.cjs`'s header carries the
+  measured account of why.
+
+  rf2-sib23's false green is worth repeating here: **a page that finishes
+  before the throw can fire proves nothing in either direction.** Its first
+  throwing stub exited 0 — correctly — because the stub settled in
+  milliseconds and the timer never ran. Here the driver holds the heap page
+  open for a whole measurement row after `P0_READY` flips, so the task
+  queue is drained many times over. The exit code alone is not the proof:
+  `watchPage` prints `[p0] PAGE PAGEERROR: ...` when it records one, and
+  that line is what says the throw actually happened.
+
+  ## Reproducing it (rf2-va5nm's proof, both directions)
+
+      # 1. the CLEAN direction — the published entry, exit 0
+      cd implementation
+      node core/test/re_frame/bench/p0_run.cjs --only heap
+
+      # 2. the THROWING direction — same driver, same build id, same row,
+      #    one extra detached throw. Exit 1, naming the error.
+      P0_INIT_FN=re-frame.bench.p0-pageerror-probe/-main \\
+      P0_OUT_DIR=out/p0-pageerror-probe \\
+        node core/test/re_frame/bench/p0_run.cjs --only heap
+
+  `P0_INIT_FN` and `P0_OUT_DIR` are the driver's OWN seams and are already
+  recorded in its provenance (`out.initFn`), so nothing in `p0_run.cjs` had
+  to change to make its refusal observable. **No `--no-build` knob was
+  added**: direction 2 builds the bundle exactly as a published run does,
+  which is the point.
+
+  NOTHING SHIPS THIS. No driver names this namespace by default, no build
+  in `shadow-cljs.edn` points at it, and `pageerror_exit_path.test.cjs`
+  pins both facts."
+  (:require [re-frame.bench.p0-app :as p0-app]))
+
+(defn ^:export -main
+  []
+  (p0-app/-main)
+  ;; AFTER the app has returned, and therefore after the sentinel it set.
+  (js/setTimeout
+   (fn []
+     (js/console.log ";; P0 probe: throwing from a detached task (rf2-va5nm)")
+     (throw (js/Error. "rf2-va5nm p0 probe: a detached task threw after P0's sentinel was set")))
+   0)
+  nil)

--- a/implementation/core/test/re_frame/bench/p0_run.cjs
+++ b/implementation/core/test/re_frame/bench/p0_run.cjs
@@ -398,16 +398,17 @@ async function newPage(chromium, query) {
   // including why no page-side `try`/`catch` can close it under React 19.2.
   // ONE PAGE PER CLOCK ROUND is the reason these are collected rather than
   // held in a local: a throw in any round has to reach the one exit. The
-  // sentinel waits are deliberately NOT converted to `watch.race` — that is
-  // rf2-f5roa's separate "report it promptly" remedy, and the fault here is
-  // the page that throws AND STILL reaches its sentinel, which the waits
-  // return from normally.
-  PAGE_WATCHES.push(watchPage(page, 'p0'));
+  // watch is also RETURNED, because every caller races its own sentinel
+  // against it (rf2-qv761) — this driver's clock wait is the largest budget
+  // in the fleet at thirty minutes, and a page that dies at load used to
+  // spend all of it before saying so.
+  const watch = watchPage(page, 'p0');
+  PAGE_WATCHES.push(watch);
   await page.goto(`http://127.0.0.1:${PORT}/${query}`, {
     waitUntil: 'commit',
     timeout: 120000,
   });
-  return { browser, page };
+  return { browser, page, watch };
 }
 
 // ---------------------------------------------------------------------------
@@ -428,9 +429,16 @@ async function clockRow(chromium) {
   for (let r = 0; r < ROUNDS && !err; r++) {
     console.error(`[p0] clock round ${r + 1}/${ROUNDS} (fresh page) ...`);
     const q = `?round=${r}&samples=${SAMPLES}&warmup=${WARMUPS}`;
-    const { browser, page } = await newPage(chromium, q);
-    await page.waitForFunction('window.P0_DONE === true || window.P0_ERROR', null, {
-      timeout: CLOCK_TIMEOUT_MS,
+    const { browser, page, watch } = await newPage(chromium, q);
+    // RACED AGAINST THE PAGE DYING (rf2-qv761) — see `sentinel.cjs`. `race`
+    // rejects only on a failure `watch` recorded, and the exit block already
+    // folds exactly those failures into `failures`, so no run that would have
+    // passed is shortened. The rejection lands in the driver's existing
+    // `catch`, which pushes onto `failures` — this driver's exit 1. The
+    // arm-order guard keeps its 2.
+    await watch.race('window.P0_DONE === true || window.P0_ERROR', {
+      timeoutMs: CLOCK_TIMEOUT_MS,
+      budget: `the ${Math.round(CLOCK_TIMEOUT_MS / 60000)}-minute wait for window.P0_DONE (round ${r})`,
     });
     err = await page.evaluate('window.P0_ERROR || null');
     const edn = await page.evaluate('window.P0_ROUND || null');
@@ -452,9 +460,11 @@ async function clockRow(chromium) {
   // JavaScript. `adjudicate` is the ONLY door onto the fold: a driver that
   // could take the record without the verdicts is the hole this closed.
   console.error('[p0] aggregating ...');
-  const { browser, page } = await newPage(chromium, '?mode=aggregate');
-  await page.waitForFunction('window.P0_READY === true || window.P0_ERROR', null, {
-    timeout: 180000,
+  const { browser, page, watch } = await newPage(chromium, '?mode=aggregate');
+  // RACED AGAINST THE PAGE DYING (rf2-qv761) — see `sentinel.cjs`.
+  await watch.race('window.P0_READY === true || window.P0_ERROR', {
+    timeoutMs: 180000,
+    budget: 'the 180s wait for window.P0_READY (the aggregate page)',
   });
   const adj = await page.evaluate(
     ([e, s]) => window.P0A.adjudicate(e, s),
@@ -511,9 +521,11 @@ async function heapPass(
   chromium,
   { benchmark, bead, plan: planOf, roots, rounds: nRounds, preflight, analyse }
 ) {
-  const { browser, page } = await newPage(chromium, '?mode=heap');
-  await page.waitForFunction('window.P0_READY === true || window.P0_ERROR', null, {
-    timeout: 180000,
+  const { browser, page, watch } = await newPage(chromium, '?mode=heap');
+  // RACED AGAINST THE PAGE DYING (rf2-qv761) — see `sentinel.cjs`.
+  await watch.race('window.P0_READY === true || window.P0_ERROR', {
+    timeoutMs: 180000,
+    budget: 'the 180s wait for window.P0_READY (the heap page)',
   });
   const err = await page.evaluate('window.P0_ERROR || null');
   if (err) {

--- a/implementation/freehand/test/re_frame/freehand/bench/b10_prod_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b10_prod_run.cjs
@@ -148,8 +148,15 @@ async function run() {
     timeoutMs: NAV_TIMEOUT_MS,
     budget: 'the 20-minute wait for `window.B10_DONE`',
   });
-  await page.waitForFunction('window.B10_DONE === true || window.B10_ERROR', null, {
-    timeout: 20 * 60 * 1000,
+  // RACED AGAINST THE PAGE DYING (rf2-qv761), and this driver had the largest
+  // budget of the nine to burn: a page that died at load cost TWENTY MINUTES
+  // to report a `ReferenceError` from the first second. `race` rejects only
+  // on a failure `watch` recorded, and `verdict` below already refuses on
+  // exactly that array, so no run that would have passed is shortened. The
+  // rejection takes this driver's existing exit 1 via `drive`'s handler.
+  await watch.race('window.B10_DONE === true || window.B10_ERROR', {
+    timeoutMs: 20 * 60 * 1000,
+    budget: 'the 20-minute wait for `window.B10_DONE`',
   });
   const err = await page.evaluate('window.B10_ERROR || null');
   const results = await page.evaluate('window.B10_RESULTS || {}');

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_prod_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_prod_run.cjs
@@ -93,11 +93,7 @@ async function run() {
   // so an uncaught throw was announced on stderr and the run exited 0 beneath
   // it. `sentinel.cjs`'s header carries the whole finding — including why no
   // page-side `try`/`catch` can close it under React 19.2 — and this is the
-  // remedy its other callers already have: collect, then refuse. The sentinel
-  // wait below is deliberately NOT converted to `watch.race` here; that is
-  // rf2-f5roa's separate "report it promptly" remedy, and the fault this file
-  // has is the one where the page throws AND STILL reaches `B6_DONE`, which
-  // the wait returns from normally.
+  // remedy its other callers already have: collect, then refuse.
   const watch = watchPage(page, 'b6');
   // `'commit'`, not `'load'` (rf2-p9fa3). `b6-prod-app/-main` is this
   // bundle's `:init-fn`, so it runs inside the `<script>` — the parity pass
@@ -112,8 +108,16 @@ async function run() {
     timeoutMs: NAV_TIMEOUT_MS,
     budget: 'the 15-minute wait for `window.B6_DONE`',
   });
-  await page.waitForFunction('window.B6_DONE === true || window.B6_ERROR', null, {
-    timeout: 15 * 60 * 1000,
+  // RACED AGAINST THE PAGE DYING, not merely bounded by it (rf2-qv761). A
+  // page that throws at load never reaches `B6_DONE`, so the bare wait ran
+  // its whole budget and then reported `Timeout 900000ms exceeded` about a
+  // `ReferenceError` fifteen minutes earlier. This cannot shorten a run that
+  // would have passed: `race` rejects only on a failure `watch` recorded, and
+  // `verdict` below already refuses on exactly that array. The rejection is
+  // this driver's existing exit 1, taken by `drive`'s rejection handler.
+  await watch.race('window.B6_DONE === true || window.B6_ERROR', {
+    timeoutMs: 15 * 60 * 1000,
+    budget: 'the 15-minute wait for `window.B6_DONE`',
   });
   const err = await page.evaluate('window.B6_ERROR || null');
   const results = await page.evaluate('window.B6_RESULTS || {}');

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_profile_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_profile_run.cjs
@@ -113,8 +113,14 @@ async function run() {
     timeoutMs: NAV_TIMEOUT_MS,
     budget: 'the 5-minute wait for `window.B6_READY`',
   });
-  await page.waitForFunction('window.B6_READY === true || window.B6_ERROR', null, {
-    timeout: 5 * 60 * 1000,
+  // RACED AGAINST THE PAGE DYING (rf2-qv761) — see `sentinel.cjs`. A profile
+  // whose page died at load used to cost five minutes to say so. `race`
+  // rejects only on a failure `watch` recorded, which `verdict` below already
+  // refuses on, so no run that would have passed is shortened; the rejection
+  // takes this driver's existing exit 1 through `drive`'s rejection handler.
+  await watch.race('window.B6_READY === true || window.B6_ERROR', {
+    timeoutMs: 5 * 60 * 1000,
+    budget: 'the 5-minute wait for `window.B6_READY`',
   });
   const err = await page.evaluate('window.B6_ERROR || null');
   if (err) throw new Error(err);

--- a/implementation/freehand/test/re_frame/freehand/bench/b7_pageerror_probe.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b7_pageerror_probe.cljs
@@ -1,0 +1,83 @@
+(ns re-frame.freehand.bench.b7-pageerror-probe
+  "B7's page-error probe — **the real B7 app, plus one detached throw**.
+
+  rf2-va5nm. Not an instrument and not a stub: this namespace exists so
+  `b7_run.cjs`'s `pageerror` refusal can be WATCHED FIRING in the driver's
+  own process, end to end, against a real `:advanced` bundle and a real
+  headless Chromium.
+
+  ## Why it is the real app and not a fixture
+
+  rf2-sib23 wired the refusal into all nine bench drivers and could only
+  watch five of them fire. The four it could not — this driver, the reads
+  ladder, the spine ablation and P0 — have no `--no-build` knob, so their
+  refusal is unreachable without a release build, and their page APIs
+  (`window.B7H`'s reader surface here) are too large to stub faithfully.
+  rf2-va5nm records the judgement that mattered: *a wrong stub is not a
+  cheaper proof, it is a fiction that can pass or fail for reasons that
+  have nothing to do with the gate.*
+
+  So there is no stub. `-main` below calls `b7-app/-main` — the published
+  entry, unchanged, doing everything it always does — and then schedules a
+  throw from a task the app does not own. That is rf2-sib23's fault shape
+  exactly: the page throws AND STILL reaches its own completion sentinel,
+  which is the case no page-side `try`/`catch` can close under React 19.2
+  and which every one of the nine used to exit 0 underneath.
+
+  ## The throw is DETACHED, and that is the whole point
+
+  A `setTimeout` callback is a task the page's `-main` has already returned
+  from. Its throw escapes `b7-app/-main`'s `(catch :default e ...)`, sets no
+  `window.B7_ERROR`, and rejects no `page.evaluate` — it reaches Playwright
+  as `pageerror` and nowhere else. `sentinel.cjs`'s header carries the
+  measured account of why.
+
+  A note from rf2-sib23 that cost it a false green, kept here because this
+  file is where the next reader will need it: **a page that finishes before
+  the throw can fire proves nothing in either direction.** Its first
+  throwing stub exited 0 — correctly — because the stub settled in
+  milliseconds and the timer never ran. Here the sentinel is set inside the
+  `<script>` and the driver then makes two CDP round trips before it closes
+  the browser, so the task queue is drained long before the page goes away.
+  The proof is not the exit code alone: the driver prints
+  `[b7] PAGE PAGEERROR: ...` from `watchPage` when it records one, and that
+  line is what says the throw actually happened.
+
+  ## Reproducing it (rf2-va5nm's proof, both directions)
+
+      # 1. the CLEAN direction — the published entry, exit 0
+      cd implementation
+      B7_MOUNT_QUERY='&rounds=1&warmup=1&samples=2' \\
+        node freehand/test/re_frame/freehand/bench/b7_run.cjs --only mount-frame
+
+      # 2. the THROWING direction — same driver, same build id, same row,
+      #    one extra detached throw. Exit 1, naming the error.
+      B7_INIT_FN=re-frame.freehand.bench.b7-pageerror-probe/-main \\
+      B7_OUT_DIR=out/b7-pageerror-probe \\
+      B7_MOUNT_QUERY='&rounds=1&warmup=1&samples=2' \\
+        node freehand/test/re_frame/freehand/bench/b7_run.cjs --only mount-frame
+
+  `B7_INIT_FN` and `B7_OUT_DIR` are the driver's OWN published seams — they
+  exist so an ablation ladder can ride this collector rather than grow a
+  second one — so nothing in `b7_run.cjs` had to change to make its refusal
+  observable. **No `--no-build` knob was added**: direction 2 above builds
+  the bundle exactly as a published run does, which is the point.
+  `--only mount-frame` is used because that row's exit consults `B7_ERROR`
+  and the page's failures and NOTHING else, so a non-zero exit cannot be
+  the arm-order guard or the positive control wearing this gate's clothes.
+
+  NOTHING SHIPS THIS. No driver names this namespace by default, no build
+  in `shadow-cljs.edn` points at it, and `pageerror_exit_path.test.cjs`
+  pins both facts."
+  (:require [re-frame.freehand.bench.b7-app :as b7-app]))
+
+(defn ^:export -main
+  []
+  (b7-app/-main)
+  ;; AFTER the app has returned, and therefore after the sentinel it set.
+  (js/setTimeout
+   (fn []
+     (js/console.log ";; B7 probe: throwing from a detached task (rf2-va5nm)")
+     (throw (js/Error. "rf2-va5nm b7 probe: a detached task threw after B7's sentinel was set")))
+   0)
+  nil)

--- a/implementation/freehand/test/re_frame/freehand/bench/b7_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b7_run.cjs
@@ -200,11 +200,11 @@ async function newPage(chromium, query, budget) {
   // watches are collected rather than held in a local: a `pageerror` on
   // EITHER has to reach the one exit. `sentinel.cjs`'s header carries the
   // finding, including why no page-side `try`/`catch` can close it under
-  // React 19.2. The sentinel waits are deliberately NOT converted to
-  // `watch.race` — that is rf2-f5roa's separate "report it promptly" remedy,
-  // and the fault here is the page that throws AND STILL reaches its
-  // sentinel, which the waits return from normally.
-  PAGE_WATCHES.push(watchPage(page, 'b7'));
+  // React 19.2. The watch is also RETURNED, because each caller races its own
+  // sentinel against it (rf2-qv761) — a page that dies at load must not cost
+  // this row's whole budget to say so.
+  const watch = watchPage(page, 'b7');
+  PAGE_WATCHES.push(watch);
   // `'commit'`, not `'load'` (rf2-p9fa3), and this is the SHARPEST instance of
   // the class in the repo. `b7-app/-main` is the bundle's `:init-fn`, and in
   // `?mode=mount-frame` it runs `run-mount-frame!` — the parity pass plus six
@@ -219,7 +219,7 @@ async function newPage(chromium, query, budget) {
     timeoutMs: NAV_TIMEOUT_MS,
     budget,
   });
-  return { browser, page };
+  return { browser, page, watch };
 }
 
 // ---------------------------------------------------------------------------
@@ -334,10 +334,18 @@ function snapshotTotal(cdp) {
 // ---------------------------------------------------------------------------
 
 async function heapRow(chromium) {
-  const { browser, page } = await newPage(
+  const { browser, page, watch } = await newPage(
     chromium, '?mode=heap', 'the 120s wait for `window.B7_READY`'
   );
-  await page.waitForFunction('window.B7_READY === true || window.B7_ERROR', null, { timeout: 120000 });
+  // RACED AGAINST THE PAGE DYING (rf2-qv761) — see `sentinel.cjs`. `race`
+  // rejects only on a failure `watch` recorded, and `drive`'s exit already
+  // refuses on exactly those failures, so no run that would have passed is
+  // shortened. The rejection lands in `drive`'s existing `catch`, which sets
+  // `failed` — this driver's exit 1. The arm-order guard keeps its 2.
+  await watch.race('window.B7_READY === true || window.B7_ERROR', {
+    timeoutMs: 120000,
+    budget: 'the 120s wait for `window.B7_READY`',
+  });
   const err = await page.evaluate('window.B7_ERROR || null');
   if (err) {
     await browser.close();
@@ -510,11 +518,17 @@ async function heapRow(chromium) {
 
 async function mountFrameRow(chromium) {
   const q = process.env.B7_MOUNT_QUERY || '';
-  const { browser, page } = await newPage(
+  const { browser, page, watch } = await newPage(
     chromium, `?mode=mount-frame${q}`, 'the 15-minute wait for `window.B7_DONE`'
   );
-  await page.waitForFunction('window.B7_DONE === true || window.B7_ERROR', null, {
-    timeout: 15 * 60 * 1000,
+  // RACED AGAINST THE PAGE DYING (rf2-qv761) — see `sentinel.cjs`. This row's
+  // whole run happens inside the `<script>`, so a page that dies at load never
+  // reaches `B7_DONE` and used to cost the full fifteen minutes to report a
+  // fault from the first second. The rejection lands in `drive`'s existing
+  // `catch`, which is this driver's exit 1.
+  await watch.race('window.B7_DONE === true || window.B7_ERROR', {
+    timeoutMs: 15 * 60 * 1000,
+    budget: 'the 15-minute wait for `window.B7_DONE`',
   });
   const err = await page.evaluate('window.B7_ERROR || null');
   const results = await page.evaluate('window.B7_RESULTS || {}');

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
@@ -187,10 +187,7 @@ async function main() {
   // was a bare `page.on('pageerror', ...)` that logged and recorded nothing;
   // the array now reaches `verdict` below, which is the only seat this run's
   // exit code has. `sentinel.cjs`'s header carries the finding, including why
-  // no page-side `try`/`catch` can close it under React 19.2. The sentinel
-  // wait is deliberately NOT converted to `watch.race` — that is rf2-f5roa's
-  // separate "report it promptly" remedy, and the fault here is the page that
-  // throws AND STILL reaches `B8_READY`, which the wait returns from normally.
+  // no page-side `try`/`catch` can close it under React 19.2.
   const watch = watchPage(page, 'b8');
   // `'commit'`, not `'load'` (rf2-p9fa3). `b8-app/-main` is the bundle's
   // `:init-fn`: it mounts all four update arms and installs `window.B8`
@@ -206,8 +203,15 @@ async function main() {
     timeoutMs: NAV_TIMEOUT_MS,
     budget: 'the 5-minute wait for `window.B8_READY`',
   });
-  await page.waitForFunction('window.B8_READY === true || window.B8_ERROR', null, {
-    timeout: 5 * 60 * 1000,
+  // RACED AGAINST THE PAGE DYING (rf2-qv761) — see `sentinel.cjs`. `race`
+  // rejects only on a failure `watch` recorded, and `verdict` below already
+  // refuses on exactly that array, so no run that would have passed is
+  // shortened. The rejection folds into `drive`'s existing `failed` slot,
+  // which is this driver's exit 1 — no new code, and the arm-order guard's 2
+  // and the warm-up ceiling's 3 are untouched.
+  await watch.race('window.B8_READY === true || window.B8_ERROR', {
+    timeoutMs: 5 * 60 * 1000,
+    budget: 'the 5-minute wait for `window.B8_READY`',
   });
   const err = await page.evaluate('window.B8_ERROR || null');
   if (err) throw new Error(`page failed to initialise: ${err}`);

--- a/implementation/freehand/test/re_frame/freehand/bench/pageerror_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/pageerror_exit_path.test.cjs
@@ -472,7 +472,7 @@ test('every driver that uses the shared collector also READS its failures', () =
 // rf2-sib23 could watch five of the nine refuse and named the four it could
 // not: no pure exported verdict, so no unit test could reach the decision,
 // and no way to make the page throw, so no end-to-end run could either.
-// rf2-va5nm closed half of that — `b7_run.cjs` and `p0_run.cjs` have now BOTH
+// rf2-va5nm took three of those four. `b7_run.cjs` and `p0_run.cjs` have both
 // been watched exiting non-zero in their own processes, against a real
 // `:advanced` build and a real headless Chromium, and both exiting 0 on the
 // same row with the throw removed.
@@ -484,6 +484,22 @@ test('every driver that uses the shared collector also READS its failures', () =
 // that have nothing to do with the gate.* And `--no-build` was refused
 // outright — a knob that serves a stale bundle beside a published figure is a
 // new fail-open in the family this whole line of work exists to close.
+//
+// THE THIRD WAS NOT ARRANGED AT ALL, and it is the better evidence.
+// `reads_ladder_run.cjs` refused a REAL `pageerror` and exited 1 during this
+// work — `Cannot read properties of undefined (reading 'd')` — because `b7`,
+// the ladder and the ablation all merge a different `:init-fn` onto the one
+// `freehand-release` build id and none of them resets its cache the way
+// `p0_run.cjs` does (rf2-t4j7c, and `lane_cache.cjs` for the fault class).
+// A cleared cache and the identical command gave `[ladder] done`. So the
+// refusal fired on exactly the environmental fault `sentinel.cjs`'s header
+// names as the common one — and, because of section 5 below, said so in
+// seconds instead of after the 120s wait.
+//
+// `spine_ablation_run.cjs` alone remains unwatched: it has no `:init-fn`
+// seam, and adding one purely so a test could reach it would be a knob that
+// lets a published figure be measured on an entry nobody built on purpose.
+// rf2-va5nm stays open for it rather than the roster being padded.
 //
 // So the two things worth pinning are that the probe is not a stub, and that
 // nothing ships it.

--- a/implementation/freehand/test/re_frame/freehand/bench/pageerror_exit_path.test.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/pageerror_exit_path.test.cjs
@@ -260,7 +260,9 @@ const WIRED = [
   {
     id: 'b7_run.cjs',
     file: path.join(BENCH, 'b7_run.cjs'),
-    collects: /PAGE_WATCHES\.push\(watchPage\(page, 'b7'\)\)/,
+    // The collector is NAMED as well as collected since rf2-qv761, because
+    // each row races its own sentinel against this same watch.
+    collects: /const watch = watchPage\(page, 'b7'\);\s*PAGE_WATCHES\.push\(watch\);/,
     carries: /const pageErrors = pageFailures\(\);/,
     // b7 has no pure verdict: its exit reads one `failed` slot, so the
     // refusal joins that slot rather than growing a second reading.
@@ -278,7 +280,7 @@ const WIRED = [
   {
     id: 'reads_ladder_run.cjs',
     file: path.join(BENCH, 'reads_ladder_run.cjs'),
-    collects: /PAGE_WATCHES\.push\(watchPage\(page, 'ladder'\)\)/,
+    collects: /const watch = watchPage\(page, 'ladder'\);\s*PAGE_WATCHES\.push\(watch\);/,
     carries: /const pageErrors = pageFailures\(\);/,
     decides: /if \(pageErrors\.length\) \{[\s\S]{0,900}?process\.exit\(1\);/,
     green: /console\.error\('\[ladder\] done'\)/,
@@ -286,7 +288,7 @@ const WIRED = [
   {
     id: 'spine_ablation_run.cjs',
     file: path.join(BENCH, 'spine_ablation_run.cjs'),
-    collects: /PAGE_WATCHES\.push\(watchPage\(page, 'abl'\)\)/,
+    collects: /const watch = watchPage\(page, 'abl'\);\s*PAGE_WATCHES\.push\(watch\);/,
     carries: /const pageErrors = pageFailures\(\);/,
     decides: /if \(pageErrors\.length\) \{[\s\S]{0,900}?process\.exit\(1\);/,
     green: /console\.error\('\[abl\] done'\)/,
@@ -294,7 +296,7 @@ const WIRED = [
   {
     id: 'p0_run.cjs',
     file: path.join(CORE_BENCH, 'p0_run.cjs'),
-    collects: /PAGE_WATCHES\.push\(watchPage\(page, 'p0'\)\)/,
+    collects: /const watch = watchPage\(page, 'p0'\);\s*PAGE_WATCHES\.push\(watch\);/,
     carries: /for \(const e of pageFailures\(\)\) \{/,
     // p0 already collected EVERY failed gate into one list rather than one
     // slot, precisely so a later gate's silence could not overwrite an
@@ -460,6 +462,129 @@ test('every driver that uses the shared collector also READS its failures', () =
     }
   }
   assert.deepStrictEqual(offenders, [], 'a watcher nobody reads is not a watcher');
+});
+
+// ===========================================================================
+// 4. THE END-TO-END PROOFS — the probes that made two of the four watchable,
+//    and the two properties that keep them honest.
+// ===========================================================================
+//
+// rf2-sib23 could watch five of the nine refuse and named the four it could
+// not: no pure exported verdict, so no unit test could reach the decision,
+// and no way to make the page throw, so no end-to-end run could either.
+// rf2-va5nm closed half of that — `b7_run.cjs` and `p0_run.cjs` have now BOTH
+// been watched exiting non-zero in their own processes, against a real
+// `:advanced` build and a real headless Chromium, and both exiting 0 on the
+// same row with the throw removed.
+//
+// The lever was each driver's OWN published seam — `B7_INIT_FN`, `P0_INIT_FN`
+// — pointed at a namespace that requires the REAL app and adds one detached
+// throw. rf2-va5nm is explicit that the alternative was worse: *a wrong stub
+// is not a cheaper proof, it is a fiction that can pass or fail for reasons
+// that have nothing to do with the gate.* And `--no-build` was refused
+// outright — a knob that serves a stale bundle beside a published figure is a
+// new fail-open in the family this whole line of work exists to close.
+//
+// So the two things worth pinning are that the probe is not a stub, and that
+// nothing ships it.
+
+const PROBES = [
+  {
+    id: 'b7_pageerror_probe.cljs',
+    file: path.join(BENCH, 'b7_pageerror_probe.cljs'),
+    ns: 're-frame.freehand.bench.b7-pageerror-probe',
+    app: 're-frame.freehand.bench.b7-app',
+    call: /\(b7-app\/-main\)/,
+    driver: path.join(BENCH, 'b7_run.cjs'),
+    seam: /const INIT_FN = process\.env\.B7_INIT_FN \|\|/,
+  },
+  {
+    id: 'p0_pageerror_probe.cljs',
+    file: path.join(CORE_BENCH, 'p0_pageerror_probe.cljs'),
+    ns: 're-frame.bench.p0-pageerror-probe',
+    app: 're-frame.bench.p0-app',
+    call: /\(p0-app\/-main\)/,
+    driver: path.join(CORE_BENCH, 'p0_run.cjs'),
+    seam: /const INIT_FN = process\.env\.P0_INIT_FN \|\|/,
+  },
+];
+
+for (const p of PROBES) {
+  test(`${p.id}: it is the REAL app plus a throw, not a stub`, () => {
+    assert.ok(fs.existsSync(p.file), `${p.id} must exist at ${p.file}`);
+    const s = src(p.file);
+    assert.match(s, new RegExp(`\\(ns ${p.ns.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+    // It REQUIRES the published entry and CALLS it. A probe that reimplemented
+    // the page would be the stub rf2-va5nm refused, and it would prove nothing
+    // about the driver's gate.
+    assert.match(s, new RegExp(`:require \\[${p.app.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} :as`));
+    assert.match(s, p.call, `${p.id} must call the real app's -main`);
+    // And the throw is DETACHED — a task the app has already returned from.
+    // A throw inside `-main` would be caught by the app's own `catch`, set
+    // `window.*_ERROR`, and exercise a gate that was never broken.
+    assert.match(s, /js\/setTimeout/, `${p.id}'s throw must be detached`);
+    assert.match(s, /\(throw \(js\/Error\./, `${p.id} must actually throw`);
+  });
+
+  test(`${p.id}: NOTHING SHIPS IT — no driver default and no build points here`, () => {
+    // The probe is a way to make a real page throw, not a second entry. If a
+    // driver ever defaulted to it, or a build id named it, this file's whole
+    // claim — that the proof was taken on the published instrument — would be
+    // false, and a published figure could be measured on the probe.
+    const driver = code(src(p.driver));
+    assert.ok(
+      !driver.includes(p.ns),
+      `${path.basename(p.driver)} must not name ${p.ns} in code — it is an operator seam`
+    );
+    assert.match(src(p.driver), p.seam, `${path.basename(p.driver)} must keep its own INIT_FN seam`);
+    const shadow = fs.readFileSync(path.join(IMPL, 'shadow-cljs.edn'), 'utf8');
+    assert.ok(!shadow.includes(p.ns), `shadow-cljs.edn must not name ${p.ns}`);
+  });
+}
+
+// ===========================================================================
+// 5. EVERY SENTINEL WAIT IN THE COLLECTOR'S FLEET IS RACED (rf2-qv761)
+// ===========================================================================
+//
+// The other half of `sentinel.cjs`, and the half rf2-sib23 deliberately left
+// undone. A page that dies BEFORE its sentinel still satisfies section 2
+// above — the failure is recorded and the exit refuses on it — but the exit
+// is fifteen, twenty or thirty minutes away, because the bare
+// `page.waitForFunction` in front of it has no idea the page is gone. The
+// operator gets `Timeout 1200000ms exceeded` about a `ReferenceError` from
+// the first second.
+//
+// The rule is DERIVED and narrow: a driver that installs the shared collector
+// must not then wait on a bare `page.waitForFunction`, because it is holding
+// the very object that already knows. It deliberately says nothing about the
+// drivers that do not use `watchPage` — five in the hicasso tree collect into
+// a local array and wait bare, which is a different (and older) shape, and
+// converting them is not this bead.
+
+test('no driver holding the shared collector waits on a BARE page.waitForFunction', () => {
+  const offenders = [];
+  for (const { file, src: s } of benchDrivers()) {
+    if (!/watchPage\(/.test(s)) continue;
+    if (/page\.waitForFunction\(/.test(s)) offenders.push(path.relative(IMPL, file));
+  }
+  assert.deepStrictEqual(
+    offenders,
+    [],
+    'a driver that installed watchPage and then waited bare is asking a page that is already '
+      + 'dead to please finish — race the sentinel against it (sentinel.cjs, rf2-qv761)'
+  );
+});
+
+test('and every one of the nine actually races SOMETHING', () => {
+  // The inverse of the rule above: deleting a wait would satisfy it
+  // vacuously. Each of the nine must carry at least one `race` call, and its
+  // budget must be NAMED — `race` refuses an unnamed ceiling by construction
+  // (rf2-p9fa3), so this pins the intent rather than the mechanism.
+  for (const w of WIRED) {
+    const s = code(src(w.file));
+    assert.match(s, /\bwatch\.race\(/, `${w.id} must race its sentinel`);
+    assert.match(s, /budget:/, `${w.id}'s race must name the budget it did NOT spend`);
+  }
 });
 
 let failed = 0;

--- a/implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/reads_ladder_run.cjs
@@ -211,11 +211,10 @@ async function newPage(chromium, query, budget) {
   // the watches are collected rather than held in a local: a `pageerror` on
   // ANY substrate has to reach the one exit. `sentinel.cjs`'s header carries
   // the finding, including why no page-side `try`/`catch` can close it under
-  // React 19.2. The sentinel waits are deliberately NOT converted to
-  // `watch.race` — that is rf2-f5roa's separate "report it promptly" remedy,
-  // and the fault here is the page that throws AND STILL reaches
-  // `LADDER_READY`, which the waits return from normally.
-  PAGE_WATCHES.push(watchPage(page, 'ladder'));
+  // React 19.2. The watch is also RETURNED, because the caller races its own
+  // sentinel against it (rf2-qv761).
+  const watch = watchPage(page, 'ladder');
+  PAGE_WATCHES.push(watch);
   // `'commit'`, not `'load'` (rf2-p9fa3): the bundle's `:init-fn` runs
   // synchronously inside the `<script>`, so the load event is downstream of
   // work this driver budgets separately.
@@ -224,7 +223,7 @@ async function newPage(chromium, query, budget) {
     timeoutMs: NAV_TIMEOUT_MS,
     budget,
   });
-  return { browser, page };
+  return { browser, page, watch };
 }
 
 async function makeReaders(page) {
@@ -330,12 +329,19 @@ const floorFor = (arms, boundaries) =>
 // ---------------------------------------------------------------------------
 
 async function runSubstrate(chromium, substrate) {
-  const { browser, page } = await newPage(
+  const { browser, page, watch } = await newPage(
     chromium, `?adapter=${substrate}`, `the 120s wait for window.LADDER_READY (${substrate})`
   );
-  await page.waitForFunction(
-    'window.LADDER_READY === true || window.LADDER_ERROR', null, { timeout: 120000 }
-  );
+  // RACED AGAINST THE PAGE DYING (rf2-qv761) — see `sentinel.cjs`. `race`
+  // rejects only on a failure `watch` recorded, and `drive`'s exit already
+  // refuses on exactly those failures, so no run that would have passed is
+  // shortened. The rejection propagates out of `drive` into its existing
+  // rejection handler, which is this driver's exit 1 — the "not in a state to
+  // measure" family. The enumerated 2/3/4/5 are untouched.
+  await watch.race('window.LADDER_READY === true || window.LADDER_ERROR', {
+    timeoutMs: 120000,
+    budget: `the 120s wait for window.LADDER_READY (${substrate})`,
+  });
   const err = await page.evaluate('window.LADDER_ERROR || null');
   if (err) { await browser.close(); throw new Error(`${substrate} page failed to initialise: ${err}`); }
 

--- a/implementation/freehand/test/re_frame/freehand/bench/sentinel.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/sentinel.cjs
@@ -114,18 +114,46 @@
  *   ../../../../core/test/re_frame/bench/p0_run.cjs
  *   ../../../../adapters/reagent/test/re_frame/bench/hicasso_narrow_run.cjs
  *
- * WHAT WAS DELIBERATELY *NOT* DONE, so the next reader does not read the
- * absence as an oversight: none of the nine had its sentinel wait converted
- * from `page.waitForFunction` to `race` above. That conversion is the OTHER
- * half of this file — rf2-f5roa's "report it promptly" — and it is a change
- * to when a FAILING run reports, not to whether it reports. The fault
- * rf2-sib23 closed is the opposite case: the page throws and STILL reaches
- * its sentinel, so the wait returns normally and the exit block is where the
- * signal has to be read. Converting nine waits as well would have been nine
- * more behaviours nobody had watched.
+ * ...AND THE NINE NOW RACE, TOO (rf2-qv761, 2026-08-05)
+ * ---------------------------------------------------
+ * rf2-sib23 gave the nine the COLLECTOR and deliberately left their sentinel
+ * waits as `page.waitForFunction`, recording the absence so it would not be
+ * read as an oversight. All twelve of those waits are now `race` calls, which
+ * is the other half of this file finally reaching the drivers that needed it
+ * most: a page that dies at load under `b10_prod_run.cjs` cost TWENTY
+ * MINUTES to say so, and under `p0_run.cjs`'s clock row, thirty.
  *
- * `pageerror_exit_path.test.cjs` pins the class: each driver's refusal, and
- * the wiring from the handler to the exit code in all nine.
+ * TWO PROPERTIES MAKE THE CONVERSION SAFE, and they are worth stating because
+ * neither is obvious:
+ *
+ *   1. IT CANNOT SHORTEN A RUN THAT WOULD HAVE PASSED. `race` rejects only on
+ *      a recorded failure, and since rf2-sib23 every one of the nine already
+ *      refuses at its exit on exactly that array. So any run this reports on
+ *      early was already going to be non-zero; what changes is when, and the
+ *      failure line names the cause instead of naming the clock.
+ *   2. NO NEW EXIT CODE. Every rejection lands in a path each driver already
+ *      had — `drive()`'s rejection handler in `b6_prod`, `b6_profile` and
+ *      `b10_prod`; the existing `catch` in `b7`, `p0`, the ladder and the
+ *      ablation; `failed` in `b8`; `hicasso_narrow`'s `main` catch — and all
+ *      of those are that driver's existing 1.
+ *
+ * WHAT IT DOES COST, stated rather than discovered later. In rf2-sib23's own
+ * case — the page that throws and STILL reaches its sentinel — the run now
+ * fails AT THE WAIT rather than after printing its table, so the partial rows
+ * a late throw would have left behind are no longer printed. The verdict is
+ * identical either way (both are that driver's 1, both name the page error);
+ * what is lost is diagnostic residue in the narrow window between "some rows
+ * measured" and "sentinel set". The motivating case in rf2-f5roa and
+ * rf2-qv761 is a `ReferenceError` at page load, where there is no residue to
+ * lose and fifteen to thirty minutes to save. The exit-block refusals
+ * rf2-sib23 installed are NOT removed and are not dead: a failure recorded
+ * after the sentinel has already flipped — during the result `evaluate`s, the
+ * measurement loop that follows a READY wait, or teardown — still reaches the
+ * exit block and nowhere else.
+ *
+ * `pageerror_exit_path.test.cjs` pins both halves of the class: each driver's
+ * refusal, the wiring from the handler to the exit code in all nine, and that
+ * every sentinel wait in the fleet is raced rather than bare.
  */
 
 /**

--- a/implementation/freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/spine_ablation_run.cjs
@@ -233,11 +233,10 @@ async function newPage(chromium, query, budget) {
   // are collected rather than held in a local: a `pageerror` on ANY substrate
   // has to reach the one exit. `sentinel.cjs`'s header carries the finding,
   // including why no page-side `try`/`catch` can close it under React 19.2.
-  // The sentinel waits are deliberately NOT converted to `watch.race` — that
-  // is rf2-f5roa's separate "report it promptly" remedy, and the fault here is
-  // the page that throws AND STILL reaches `ABL_READY`, which the waits
-  // return from normally.
-  PAGE_WATCHES.push(watchPage(page, 'abl'));
+  // The watch is also RETURNED, because the caller races its own sentinel
+  // against it (rf2-qv761).
+  const watch = watchPage(page, 'abl');
+  PAGE_WATCHES.push(watch);
   // `'commit'`, not `'load'` (rf2-p9fa3): the bundle's `:init-fn` runs
   // synchronously inside the `<script>`, so the load event is downstream of
   // work this driver budgets separately.
@@ -246,7 +245,7 @@ async function newPage(chromium, query, budget) {
     timeoutMs: NAV_TIMEOUT_MS,
     budget,
   });
-  return { browser, page };
+  return { browser, page, watch };
 }
 
 async function makeReaders(page) {
@@ -352,12 +351,18 @@ const floorFor = (arms) => arms.find((a) => a.variant === 'floor');
 // ---------------------------------------------------------------------------
 
 async function runSubstrate(chromium, substrate) {
-  const { browser, page } = await newPage(
+  const { browser, page, watch } = await newPage(
     chromium, `?adapter=${substrate}`, `the 120s wait for window.ABL_READY (${substrate})`
   );
-  await page.waitForFunction(
-    'window.ABL_READY === true || window.ABL_ERROR', null, { timeout: 120000 }
-  );
+  // RACED AGAINST THE PAGE DYING (rf2-qv761) — see `sentinel.cjs`. `race`
+  // rejects only on a failure `watch` recorded, and the exit block already
+  // refuses on exactly those failures, so no run that would have passed is
+  // shortened. The rejection propagates into the top-level IIFE's existing
+  // `.catch`, which is this driver's exit 1; the enumerated 2/3/4 stand.
+  await watch.race('window.ABL_READY === true || window.ABL_ERROR', {
+    timeoutMs: 120000,
+    budget: `the 120s wait for window.ABL_READY (${substrate})`,
+  });
   const err = await page.evaluate('window.ABL_ERROR || null');
   if (err) { await browser.close(); throw new Error(`${substrate} page failed to initialise: ${err}`); }
 


### PR DESCRIPTION
Two bench-lane beads over the same nine drivers, one PR.

- **rf2-va5nm (P2)** — four of the nine `pageerror` refusals rf2-sib23 wired (#7505) had never been watched firing. **Three of the four now have been**, end to end, in the driver's own process, both directions.
- **rf2-qv761 (P3)** — all twelve sentinel waits in those nine now race the page dying instead of spending a 15/20/30-minute budget on a page that died at load.

## rf2-va5nm — per driver: proven, or why not

rf2-sib23's worker named four drivers it could not prove, and gave the reason: no pure exported verdict, so no unit test can reach the decision; and no way to make the page throw, so no end-to-end run can either. **The second half of that is what moved.** Two of the four already carry a published `:init-fn` seam, so a namespace that requires the REAL app and adds one detached throw makes the refusal reachable without touching the driver at all.

| driver | status | evidence |
|---|---|---|
| `b7_run.cjs` | **PROVEN end to end, both directions** | clean `--only mount-frame` → `[b7] ok`, **exit 0**. Same driver, same build id, same row, `B7_INIT_FN` pointed at the probe → `[b7] PAGE PAGEERROR: rf2-va5nm b7 probe: a detached task threw after B7's sentinel was set`, then `[b7] FAILED: the page threw and kept going`, **exit 1**. Both W1/W2 records printed *before* the refusal. |
| `p0_run.cjs` | **PROVEN end to end, both directions** | clean `--only heap` → `[p0] done`, **exit 0**. `P0_INIT_FN` pointed at the probe → `[p0] PAGE PAGEERROR: …`, then `[p0] FAILED: the page threw and kept going — pageerror: …`, **exit 1**. The heap table printed before the refusal. |
| `reads_ladder_run.cjs` | **PROVEN end to end, both directions — by accident, which makes it better** | a real run refused a real `pageerror` and **exited 1** with no probe involved; the matching clean run **exits 0**. See below. |
| `spine_ablation_run.cjs` | **NOT PROVEN** — say so rather than pad the roster | it alone has no `:init-fn` seam, and neither honest route reaches it. It *was* run under this diff (`ABL_SUBSTRATES=uix`): it passed through the raced `ABL_READY` wait normally, ran all four rounds and both snapshot rounds, wrote both artefacts, and refused with its **existing enumerated exit 4** on its fidelity control — which is the negative half of "no exit code shifted", but is not a page-error refusal. |

**Why the last one was not given the same seam.** Its `:init-fn` is a `const` with no override. Adding one would be a new knob on a measurement driver, added purely so a test could reach it — a knob that lets a published figure be measured on an entry nobody built on purpose, which is a cousin of the thing rf2-va5nm forbids. `--no-build` was never on the table: every direction above builds the bundle exactly as a published run does (the b7 throwing run's own line is `Build completed. (205 files, 1 compiled…)`). And stubbing `window.ABL` — the plan, the rounds, the read-back — was refused for rf2-va5nm's own reason: *a wrong stub is not a cheaper proof, it is a fiction that can pass or fail for reasons that have nothing to do with the gate.*

**rf2-va5nm therefore stays open, for one driver rather than four**, and its two remaining honest routes are unchanged.

### The unplanned live proof, which is worth more than the injected one

`reads_ladder_run.cjs`'s first clean run **refused a genuine `pageerror` and exited 1** — `Cannot read properties of undefined (reading 'd')` — with no probe involved. The cause is the fault class `lane_cache.cjs` records (rf2-2rtt6.20) and `p0_run.cjs` guards against and these three do not: `b7`, the ladder and the ablation all merge a *different* `:init-fn` onto the one `freehand-release` build id, so the ladder was served a bundle whose cache entry my earlier b7 runs had written. Rebuilding on a cleared cache gave `[ladder] done`, exit 0.

So the refusal fired on exactly the environmental fault `sentinel.cjs`'s header says is the common one — **and reported it in seconds rather than after the 120s wait**, which is the other bead, in the same lines of output:

```
[ladder] PAGE PAGEERROR: Cannot read properties of undefined (reading 'd')
Error: [ladder] THE PAGE DIED BEFORE IT FINISHED — the benchmark did not reach its own
completion sentinel, so nothing it may have recorded is a measurement. This is reported
now rather than after the 120s wait for window.LADDER_READY (uix), which had not yet run
out and would have said only that time passed (rf2-f5roa).
```

It reproduces on demand: run `b7_run.cjs`, then `reads_ladder_run.cjs`, without clearing `.shadow-cljs/builds/freehand-release`.

**Filed as a follow-up (rf2-t4j7c):** `b7_run.cjs`, `reads_ladder_run.cjs` and `spine_ablation_run.cjs` should take `p0_run.cjs`'s `resetLaneBuildCache` — one build id, N `:init-fn`s, no reset, and it bit a run in this PR.

### The probes

`b7_pageerror_probe.cljs` and `p0_pageerror_probe.cljs` are the *real* apps plus one `setTimeout` throw — the fault shape rf2-sib23 is about: a task the app has already returned from, invisible to its `(catch :default …)` and setting no `window.*_ERROR`. Each file carries the exact two-command reproduction. `pageerror_exit_path.test.cjs` pins that each requires and calls the published entry (not a stub), that the throw is detached, and that **nothing ships them** — no driver default, no build id in `shadow-cljs.edn`.

rf2-sib23's false green was the thing to avoid, and was avoided: its first throwing stub exited 0 *correctly*, because the stub settled before the timer ran. Here the exit code alone was never the proof — `watchPage`'s own `PAGE PAGEERROR` line is in every throwing log, so the throw demonstrably happened.

## rf2-qv761 — the twelve waits

**What `rf2-f5roa` decided, and whether I crossed it.** It is **closed**. It built `sentinel.cjs` and its `race`, and applied it to `hd8_run.cjs` and `p0_converge_run.cjs` after two merged-PR audits found a `pageerror` costing twenty minutes in each. It never reached these nine. So there is no seam to cross: this applies its remedy where it never landed, in the shape its own header prescribes and rf2-qv761's filer enumerated.

Converted: `b6_prod` (15m), `b6_profile` (5m), `b7` ×2 (120s + 15m), `b8` (5m), `b10_prod` (20m), `reads_ladder` (120s), `spine_ablation` (120s), `p0` ×3 (30m clock + 180s ×2), `hicasso_narrow` (5m). Same predicate, same timeout, plus the budget string each already wrote in its `navigate()` call.

**It cannot shorten a run that would have passed.** `race` rejects only on a failure `watchPage` recorded, and since #7505 every one of the nine already refuses at its exit on exactly that array. Any run reported early was already going to be non-zero; what changes is *when*, and that the line names the cause instead of naming the clock.

**No new exit code.** Every rejection lands in a path the driver already had — `drive()`'s rejection handler in `b6_prod`/`b6_profile`/`b10_prod`; the existing `catch` in `b7`, `p0`, the ladder and the ablation; `failed` in `b8`; `main`'s catch in `hicasso_narrow` — and all of those are that driver's existing `1`. The ladder's enumerated `[3,4,2,5]`, b7's `2`, b8's `2`/`3` and `hicasso_narrow`'s `2`/`3`/`4` are untouched, and `heap_control_exit_path.test.cjs` still passes unmodified.

**What it costs, stated rather than discovered later — read this bit.** In rf2-sib23's own case, the page that throws and *still* reaches its sentinel, the run now fails at the wait rather than after printing its table, so a *late* throw's partial rows are no longer printed. The verdict is identical either way (that driver's `1`, naming the page error); what is lost is diagnostic residue in the narrow window between "some rows measured" and "sentinel set". The motivating case in both beads is a `ReferenceError` at page load, where there is no residue to lose and up to thirty minutes to save — and the live ladder failure above is exactly that case. The exit-block refusals #7505 installed are **not** removed and are **not** dead: a failure recorded after the sentinel has flipped — during the result `evaluate`s, the measurement loop that follows a READY wait, or teardown — still reaches the exit block and nowhere else, which is how both probe runs above refused.

## What did not change

No row's measurement, no arm, no threshold, no knob default, nothing under `data/`. No new exit code anywhere. No refusal suppresses output — both probe runs printed their full tables before the refusal, and each clean/throwing pair is a byte-identical run apart from the injected throw.

## The gate that objected, and was right

`pageerror_exit_path.test.cjs`'s four `PAGE_WATCHES.push(watchPage(page, …))` regexes went red, because the collector is now *named* as well as collected (each row races against it). Told the policy about the new shape rather than loosening it: the pin still requires the collector to be installed and still forbids a second bare handler.

Two sections were added to that file rather than a parallel one:

- **the probes** — real app, real call, detached throw, and nothing ships them;
- **a derived class rule** — *no driver holding the shared collector may wait on a bare `page.waitForFunction`*, because it is holding the object that already knows. It deliberately says nothing about the five hicasso drivers that collect into a local array and wait bare: that is a different and older shape, and converting them is not this bead. Plus its inverse, so deleting a wait cannot satisfy it vacuously.

48 checks → 54.

## Quality gates

| gate | result |
|---|---|
| `sh scripts/test-fast-pr.sh` | **exit 0** — the runner's own terminal marker is `PASS fast PR spine`; CLJS node integration ran 12,585 tests / 63,097 assertions, 0 failures 0 errors |
| `npm run test:script-helpers` (the chained JS harness gate) | **exit 0** — every link, `pageerror_exit_path.test.cjs: 54 passed` among them |
| `npm run lint:js` | **exit 0** |
| `node .../pageerror_exit_path.test.cjs` | **exit 0** — 54 passed (was 48) |
| `node .../heap_control_exit_path.test.cjs` | **exit 0** — 33 passed, file unmodified |
| `node .../p0_ladder_structural.test.cjs` | **exit 0** — 14 passed, file unmodified |
| `node implementation/scripts/_navigation-ceiling-policy.test.cjs` | **exit 0** — 4 passed |

Live end-to-end runs — Playwright 1.59.1, react-dom 19.2.0, HeadlessChrome 147.0.7727.15, `:advanced` with `goog.DEBUG false`:

| run | exit |
|---|---|
| `b7_run.cjs --only mount-frame`, published entry | **0** |
| `b7_run.cjs --only mount-frame`, `B7_INIT_FN`=probe | **1**, naming the `pageerror` |
| `p0_run.cjs --only heap`, published entry | **0** |
| `p0_run.cjs --only heap`, `P0_INIT_FN`=probe | **1**, naming the `pageerror` |
| `reads_ladder_run.cjs`, contaminated shared cache | **1**, naming the `pageerror`, at once instead of after 120s |
| `reads_ladder_run.cjs`, cleared cache | **0** |
| `spine_ablation_run.cjs`, `ABL_SUBSTRATES=uix` | **4** — its own fidelity-control refusal, unchanged; not a page-error refusal |

Closes rf2-qv761. **rf2-va5nm stays open for `spine_ablation_run.cjs` alone**, with its roster corrected from four to one.
