### PR TITLE
fix(scripts): a partial worktree removal says so (rf2-k3j2w)

### DIFF
--- a/docs/the-mayor-method/README.md
+++ b/docs/the-mayor-method/README.md
@@ -178,9 +178,11 @@ project advanced."
 **Merge trap:** `gh pr merge --delete-branch` fails when the worker
 worktree still holds the branch. Use `gh pr merge --squash --admin` (no
 `--delete-branch`), then `git push origin --delete <branch>`, then leave
-local cleanup until the worker is closed and the worktree is verifiably
-clean. Full sequence in [`bootstrap.md`](bootstrap.md) (the PR-merge
-`/loop` block).
+local cleanup until the worker has **reported done**. Not until it looks
+done: a merged PR and a clean tree are both routinely true of a worker
+still running its gates, and reaping on either destroys that run. Full
+sequence in [`bootstrap.md`](bootstrap.md) (the PR-merge `/loop` block),
+and the reasoning in its "hard-won" list.
 
 ## Cross-review
 

--- a/docs/the-mayor-method/bootstrap.md
+++ b/docs/the-mayor-method/bootstrap.md
@@ -121,7 +121,24 @@ of a drain; the binding rule is hot-zone parallelism, not strict same-surface.
   commit to equal the worktree's HEAD, and read the worktree ↔ branch mapping from
   the tool rather than deriving either from the other. Beware that zero commits,
   clean tree, no PR describes both an abandoned worker and one that started a
-  minute ago; the discriminator is freshness, not shape.
+  minute ago — and freshness does not break that tie either, however reasonable
+  it sounds. Nothing observable about the tree does; see the next bullet.
+- *Only a worker's own report says it has finished.* Reap a worktree while its
+  agent is still running and you destroy that run — and the wreckage does not
+  announce itself as infrastructure. Gates die naming real, present files as
+  missing, which twice read as a genuine regression to the worker that received
+  it. Six proxies were adopted in a single session, each plausible when adopted,
+  each wrong: PR state (merged means the WORK landed, not that the worker
+  stopped); elapsed time; worktree mtime, which read 250 minutes stale on a tree
+  being committed to as it was read; worker shape; cleanliness — perversely,
+  because a worker that has pushed everything exactly as briefed shows a clean
+  tree throughout a twenty-minute gate, so the better the discipline the likelier
+  the kill; and finally "clean AND merged" together, which still took two spine
+  runs. The signals that have never lied are reads rather than inferences: the
+  agent's own completion report, and whether the messaging tool finds a live task
+  to deliver to. So wait for the report. A stale directory is the entire cost of
+  waiting. And one worker is not one worktree — it may build a second for its
+  gate run, so an unfamiliar worktree belongs to someone until its agent reports.
 - *Pushed commits are the only durable worker state.* Workers die mid-run for
   reasons unrelated to their work, so put "commit and push as you go, not at the
   end" in every brief, with the reason. The mayor may push a worker's existing

--- a/scripts/remove-worker-worktree.ps1
+++ b/scripts/remove-worker-worktree.ps1
@@ -59,10 +59,48 @@
 #     REMOVE_REFUSED_DIRTY=  git refused; the paths are listed and tagged
 #                            [build output] or [KEEP].
 #     REMOVE_REFUSED_KEEP=   -ForceDisposable stopped at unreviewed work.
-#     REMOVE_FAILED=         the tree is CLEAN, so this really is a file lock
-#                            and really is worth retrying.
+#     REMOVE_FAILED=         the tree is CLEAN and INTACT, so this really is a
+#                            file lock and really is worth retrying.
+#     REMOVE_PARTIAL=        a HUSK (rf2-k3j2w) - see below. Exit 3.
 #   -DryRun reports the same partition up front as WOULD_NEED_FORCE= (all
 #   build output, sweepable) or WOULD_REFUSE_KEEP= (needs a human first).
+#
+#   THE FOURTH OUTCOME: A PARTIAL REMOVAL (rf2-k3j2w). `git worktree remove`
+#   is not atomic on Windows. It can deregister the worktree and delete its
+#   `.git`, then hit a file lock on the directory itself and stop - leaving a
+#   HUSK: every source file still on disk, no worktree behind it. Measured on
+#   Windows 11 against a throwaway worktree with one open file handle held
+#   inside it:
+#
+#     git worktree remove --force <wt>   ->  exit 255, "failed to delete
+#                                            '<wt>': Invalid argument"
+#     git worktree list                  ->  <wt> ALREADY GONE
+#     <wt>/.git                          ->  ALREADY DELETED
+#     <wt>/**                            ->  every other file still present
+#
+#   The state is genuinely hard to see, which is why it earned a name here:
+#     - `git worktree list` does not mention it - already deregistered;
+#     - `git worktree prune` does not clear it - prune drops ADMIN records for
+#       directories that vanished, and here the opposite happened;
+#     - `git -C <husk> status --porcelain` FAILS and prints nothing, which the
+#       clean/dirty split above read as "tree is CLEAN" and therefore as
+#       REMOVE_FAILED, "safe to retry once it clears". Retrying is futile: the
+#       registered-worktree check refuses it, forever;
+#     - to a human `ls` it is indistinguishable from a live worktree.
+#   And it is not a near-miss. A husk kills a running gate exactly as a
+#   completed removal does - "the removal failed" is NOT "the worker was
+#   unaffected". Both entry points report it: a removal that fails this way,
+#   and a later invocation handed a path that is already a husk.
+#
+#   Exit codes split on WHAT THE CALLER SHOULD DO NEXT:
+#     0  done.
+#     1  refused or failed, worktree INTACT - this script is still the right
+#        tool (retry when the lock clears; -ForceDisposable for build output;
+#        a human for [KEEP] paths).
+#     2  usage error.
+#     3  PARTIAL - already gutted and deregistered; this script can do nothing
+#        more with it. 3 wins over 1 when both occur in one run, because it is
+#        the outcome needing a different remedy.
 param(
   # Position = 0 is load-bearing: ValueFromRemainingArguments alone does NOT
   # make a parameter positional, so an unnamed path would otherwise bind to
@@ -82,6 +120,32 @@ $ErrorActionPreference = "Stop"
 
 function Normalize-Path([string]$Path) {
   return [System.IO.Path]::GetFullPath($Path).TrimEnd('\', '/')
+}
+
+# Run git and hand back its output and exit code, NEVER throwing.
+#
+# This script's whole job is to handle git commands that fail — a refused
+# removal, a status inside a directory that is no longer a repository — so a
+# failing git is normal control flow here, not an exception. Windows PowerShell
+# disagrees: with $ErrorActionPreference = "Stop" (set above, and wanted for
+# every cmdlet) a native command that writes ANYTHING to stderr raises a
+# terminating NativeCommandError, and neither `2>$null` nor `2>&1` reliably
+# suppresses it. Observed while adding the husk probes: `git status` inside a
+# husk aborted the script with a NativeCommandError instead of returning empty,
+# and the same latent trap sat under `git worktree remove` — the one call in
+# this file guaranteed to write to stderr on the very path that must be
+# classified rather than crashed on (rf2-k3j2w).
+#
+# Lowering the preference INSIDE a function is scoped to that function's
+# dynamic extent, so the strict setting is restored on return with no
+# bookkeeping, and cmdlet errors elsewhere keep terminating as before.
+function Invoke-GitQuiet([string[]]$GitArgs) {
+  $ErrorActionPreference = 'Continue'
+  $out = & git @GitArgs 2>&1
+  return [pscustomobject]@{
+    Output   = @($out | ForEach-Object { [string]$_ })
+    ExitCode = $LASTEXITCODE
+  }
 }
 
 # Paths inside a node_modules whose disappearance is damage on its own, whatever
@@ -122,9 +186,42 @@ function Get-NodeModulesSignature([string]$Path) {
 # and `.Count` on it throws under Set-StrictMode - which is exactly the
 # one-leftover-log case this function exists to report. An @() inside the
 # function cannot prevent that; one at the call site can.
+#
+# ONLY MEANINGFUL ON AN INTACT WORKTREE. On a husk the git call fails, prints
+# nothing, and this returns empty - identical to clean. Every caller therefore
+# checks Test-WorktreeIsIntact FIRST.
+# The EXIT CODE decides, not the output: on a husk the merged output holds
+# git's fatal text, which is not a list of dirty paths. See Invoke-GitQuiet.
 function Get-WorktreeDirt([string]$Path) {
-  return @(& git -C $Path status --porcelain 2>$null) |
-    Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  $r = Invoke-GitQuiet @('-C', $Path, 'status', '--porcelain')
+  if ($r.ExitCode -ne 0) { return @() }
+  return @($r.Output) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+}
+
+# Is there still a git worktree behind this directory?
+#
+# The one honest discriminator for a HUSK (rf2-k3j2w): a partially failed
+# `git worktree remove` deletes the worktree's `.git` before it deletes the
+# files, so a husk's files survive with nothing behind them. Seen in the wild
+# at C:/Users/miket/code/re-frame2-worktrees/procpair on 2026-08-05 - `ls`
+# shows a full checkout, `rev-parse` exits 128, `git worktree list` has never
+# heard of it and `git worktree prune` reports nothing to do.
+#
+# Note this is a READ of git's own state, not a guess about who is using the
+# tree. Whether an AGENT is still alive is not knowable from here and this
+# script does not try - see the reaping rule in docs/the-mayor-method.
+#
+# BOTH halves are load-bearing. `rev-parse` alone walks UP the directory tree,
+# so a husk sitting inside another checkout would answer with THAT repo and
+# read as intact; the Test-Path catches it, because a linked worktree always
+# has a `.git` file at its root and a husk is exactly the tree that lost one.
+# And Test-Path alone would accept a dangling or truncated `.git`. -SelfTest
+# proves each clause against the husk shape only that clause can see.
+function Test-WorktreeIsIntact([string]$Path) {
+  if (-not (Test-Path -LiteralPath (Join-Path $Path '.git'))) { return $false }
+  # Via Invoke-GitQuiet: the dangling-`.git` case reaches this line with git
+  # about to write a fatal to stderr.
+  return ((Invoke-GitQuiet @('-C', $Path, 'rev-parse', '--git-dir')).ExitCode -eq 0)
 }
 
 # Is one `git status --porcelain` line safe to delete unreviewed?
@@ -234,6 +331,38 @@ function Disarm-Link([string]$Path) {
   return (-not (Test-Path -LiteralPath $Path))
 }
 
+# Disarm every node_modules link under one worktree, before anything recursive
+# runs over it.
+#
+# Extracted from the main loop so the HUSK path gets the identical protection
+# (rf2-k3j2w). A husk left behind by a bare `git worktree remove` - one that
+# never went through this script - can still hold an ARMED junction, and the
+# only remedy left for a husk is a plain recursive delete, which is precisely
+# what empties the target. Disarming before we recommend that delete is the
+# difference between advice and a loaded gun. Measured against the husk of a
+# throwaway worktree carrying a junction: this script reported DISARMED and
+# the junction's target still held all 5 of its files afterwards, where the
+# previous version refused the path and left the junction armed.
+function Disarm-WorktreeLinks([string]$Root) {
+  $foundAny = $false
+  foreach ($nm in (Find-NodeModules $Root)) {
+    if (-not (Test-IsLink $nm)) { continue }
+    $foundAny = $true
+    $item = Get-Item -LiteralPath $nm -Force -ErrorAction SilentlyContinue
+    $linkTarget = if ($null -ne $item -and $null -ne $item.Target) { ($item.Target | Select-Object -First 1) } else { '<unresolved>' }
+    if ($DryRun) {
+      Write-Output "WOULD_DISARM=$nm -> $linkTarget"
+      continue
+    }
+    if (-not (Disarm-Link $nm)) {
+      Write-Error "Failed to remove the link $nm - it is still present. ABORTING before 'git worktree remove', which would delete THROUGH it into $linkTarget."
+      exit 1
+    }
+    Write-Output "DISARMED=$nm -> $linkTarget"
+  }
+  if (-not $foundAny) { Write-Output "NO_LINKS=$Root" }
+}
+
 # Say WHY the removal failed instead of guessing (rf2-p0m6m).
 #
 # `git worktree remove` has two failure modes with OPPOSITE remedies:
@@ -250,17 +379,53 @@ function Disarm-Link([string]$Path) {
 # a full session of other workers; every one of them was simply dirty, holding
 # a single untracked `logs/`, `bench-logs/`, `PRBODY.md` or `*-exit.txt` the
 # worker left behind. Telling the two apart is the whole fix.
+# A partially removed worktree - a HUSK. Says what was already done TO the
+# tree, and why this script is the wrong tool from here on (rf2-k3j2w).
+function Write-Husk([string]$Path) {
+  Write-Warning "REMOVE_PARTIAL=$Path"
+  # One Write-Warning per line: a multi-line string gets the WARNING prefix
+  # only on its first line and a blank line between every other.
+  foreach ($line in @(
+      'The worktree is already GUTTED: git deregistered it and deleted its .git,',
+      'then could not delete the directory - a file lock taken mid-removal. The',
+      'files you can still see have no worktree behind them.',
+      'THIS IS A DESTROYED TREE, NOT AN UNTOUCHED ONE. If an agent was using it,',
+      'its build or gate run has already been broken; a partial removal kills a',
+      'running gate exactly as a complete one does (rf2-k3j2w).',
+      'Retrying this script will not finish the job - there is no registered',
+      'worktree left to remove, and `git worktree prune` has nothing to clear.',
+      'Any node_modules link has been disarmed, so what remains is an ordinary',
+      'directory delete, once whatever holds the lock has exited:',
+      "  Remove-Item -Recurse -Force $Path")) {
+    Write-Warning $line
+  }
+}
+
 function Write-RemoveFailure([string]$Path) {
+  # A husk reads as CLEAN below - the git call fails and prints nothing - so
+  # it has to be ruled out before the dirty/locked split runs (rf2-k3j2w).
+  if (-not (Test-WorktreeIsIntact $Path)) {
+    Write-Husk $Path
+    $script:partial = $true
+    return
+  }
   $dirt = @(Get-WorktreeDirt $Path)
   if ($dirt.Count -eq 0) {
-    Write-Warning "REMOVE_FAILED=$Path (tree is CLEAN, so this is a file lock: links are already disarmed; safe to retry once it clears)"
+    Write-Warning "REMOVE_FAILED=$Path (tree is CLEAN and still INTACT, so this is a file lock: links are already disarmed; safe to retry once it clears)"
     return
   }
   Write-Warning "REMOVE_REFUSED_DIRTY=$Path"
   Write-AnnotatedDirt $dirt -AsWarning
   # One Write-Warning per line: a multi-line string gets the WARNING prefix
   # only on its first line and a blank line between every other.
-  $tail = if ((Get-UndisposableLines $dirt).Count -eq 0) {
+  # @() around the call, exactly as Get-WorktreeDirt's header demands: the
+  # function returns @(), PowerShell UNROLLS it on the way out, an empty result
+  # arrives as $null, and `$null.Count` is a terminating error under
+  # Set-StrictMode. Without the wrapper this line threw on every dirty tree, so
+  # on Windows the REMOVE_REFUSED_DIRTY report died immediately after listing
+  # the paths — swallowing the one sentence that tells a hygiene sweep whether
+  # -ForceDisposable will clear the tree. Reproduced against main, 2026-08-05.
+  $tail = if (@(Get-UndisposableLines $dirt).Count -eq 0) {
     @('All of it is build/gate output: -ForceDisposable will sweep the tree.')
   } else {
     @('The [KEEP] paths are NOT build output - an uncommitted edit, a note, a draft.',
@@ -336,7 +501,63 @@ if ($SelfTest) {
     }
     Write-Output "SELF_TEST nested_loss top_level_entries_unchanged=$shallowBefore signature $nBefore -> $nAfter"
 
-    Write-Output "SELF_TEST=PASSED link unlinked with its target intact ($after), and the canary caught nested-only loss."
+    # The HUSK detector (rf2-k3j2w), in a throwaway repo; never touches this one.
+    #
+    # THREE fixtures, because Test-WorktreeIsIntact has two clauses and each
+    # catches a husk the other misses:
+    #   outside  - a husk with no repo above it (the shape seen in the wild).
+    #              rev-parse fails; this is the one whose dirt reads EMPTY, i.e.
+    #              identical to a clean tree, which is how a gutted worktree
+    #              came to be reported as a retryable file lock.
+    #   nested   - a husk inside another checkout. rev-parse WALKS UP, finds the
+    #              enclosing repo and answers happily; only the missing `.git`
+    #              gives it away.
+    #   dangling - `.git` present but naming an admin dir that is gone. The
+    #              Test-Path check calls that intact; only rev-parse sees it.
+    $stRepo = Join-Path $stRoot 'husk-repo'
+    $stOutside = Join-Path $stRoot 'husk-outside'
+    $stNested = Join-Path $stRepo 'husk-nested'
+    New-Item -ItemType Directory -Force -Path $stRepo | Out-Null
+    Push-Location $stRepo
+    try {
+      $null = Invoke-GitQuiet @('init', '-q', '.')
+      $null = Invoke-GitQuiet @('-c', 'user.email=selftest@example.invalid', '-c', 'user.name=selftest',
+                                'commit', '-q', '--allow-empty', '-m', 'init')
+      $null = Invoke-GitQuiet @('worktree', 'add', '-q', $stOutside, '-b', 'husk-probe-outside')
+      $null = Invoke-GitQuiet @('worktree', 'add', '-q', $stNested, '-b', 'husk-probe-nested')
+    }
+    finally { Pop-Location }
+
+    if ((Test-Path -LiteralPath (Join-Path $stOutside '.git')) -and
+        (Test-Path -LiteralPath (Join-Path $stNested '.git'))) {
+      foreach ($stWt in @($stOutside, $stNested)) {
+        if (-not (Test-WorktreeIsIntact $stWt)) {
+          Write-Error "SELF_TEST=FAILED a live worktree read as not-intact: $stWt"
+          exit 1
+        }
+        # Precisely what a partial removal leaves behind.
+        Remove-Item -LiteralPath (Join-Path $stWt '.git') -Force
+        if (Test-WorktreeIsIntact $stWt) {
+          Write-Error "SELF_TEST=FAILED a husk read as INTACT: $stWt - it would be classified as a clean tree and a retryable lock."
+          exit 1
+        }
+      }
+      if (@(Get-WorktreeDirt $stOutside).Count -ne 0) {
+        Write-Error "SELF_TEST=FAILED the husk fixture does not reproduce the ambiguity it exists to test."
+        exit 1
+      }
+      Set-Content -LiteralPath (Join-Path $stOutside '.git') -Value "gitdir: $(Join-Path $stRoot 'no-such-admin-dir')"
+      if (Test-WorktreeIsIntact $stOutside) {
+        Write-Error "SELF_TEST=FAILED a dangling .git read as INTACT; the Test-Path check alone cannot see it."
+        exit 1
+      }
+      Write-Output "SELF_TEST husk detected=yes for all three shapes (outside a repo, where Get-WorktreeDirt reads EMPTY - the trap; nested inside one, where rev-parse walks up and is fooled; and a dangling .git, where the Test-Path check is fooled)"
+    }
+    else {
+      Write-Output "SELF_TEST husk=SKIPPED (no throwaway worktrees could be built here)"
+    }
+
+    Write-Output "SELF_TEST=PASSED link unlinked with its target intact ($after), the canary caught nested-only loss, and a husk is not mistaken for a clean tree."
     exit 0
   }
   finally {
@@ -397,6 +618,7 @@ foreach ($line in @(& git -C $mayorRootPath worktree list --porcelain 2>$null)) 
 # Per worktree: disarm, verify, THEN remove.
 # ---------------------------------------------------------------------------
 $failed = $false
+$script:partial = $false
 
 foreach ($rawTarget in $Worktree) {
   if ([string]::IsNullOrWhiteSpace($rawTarget)) { continue }
@@ -411,29 +633,25 @@ foreach ($rawTarget in $Worktree) {
 
   # Refuse anything git does not know as a linked worktree. This script never
   # deletes a directory itself; if git will not remove it, neither will we.
+  #
+  # One unregistered path is NOT a mistyped argument, and saying so is the
+  # difference between an actionable message and a wild goose chase: a HUSK
+  # left by an earlier partial removal is deregistered BY DEFINITION, so the
+  # old advice here ("run 'git worktree prune'") sent the caller after an
+  # entry that had already been cleared (rf2-k3j2w). Disarm it and name it.
   if ($roster -notcontains $wt.ToLowerInvariant()) {
+    if ((Test-Path -LiteralPath $wt -PathType Container) -and (-not (Test-WorktreeIsIntact $wt))) {
+      Disarm-WorktreeLinks $wt
+      Write-Husk $wt
+      $script:partial = $true
+      continue
+    }
     Write-Error "Not a registered worktree of ${mayorRootPath}: $wt (run 'git worktree list'; 'git worktree prune' clears stale entries)."
     exit 1
   }
 
   # 1. Disarm every link, before anything recursive runs over the tree.
-  $foundAny = $false
-  foreach ($nm in (Find-NodeModules $wt)) {
-    if (-not (Test-IsLink $nm)) { continue }
-    $foundAny = $true
-    $item = Get-Item -LiteralPath $nm -Force -ErrorAction SilentlyContinue
-    $linkTarget = if ($null -ne $item -and $null -ne $item.Target) { ($item.Target | Select-Object -First 1) } else { '<unresolved>' }
-    if ($DryRun) {
-      Write-Output "WOULD_DISARM=$nm -> $linkTarget"
-      continue
-    }
-    if (-not (Disarm-Link $nm)) {
-      Write-Error "Failed to remove the link $nm - it is still present. ABORTING before 'git worktree remove', which would delete THROUGH it into $linkTarget."
-      exit 1
-    }
-    Write-Output "DISARMED=$nm -> $linkTarget"
-  }
-  if (-not $foundAny) { Write-Output "NO_LINKS=$wt" }
+  Disarm-WorktreeLinks $wt
 
   # 2. Only now remove the worktree. Never chained with the disarm.
   $dirt = @(Get-WorktreeDirt $wt)
@@ -469,9 +687,17 @@ foreach ($rawTarget in $Worktree) {
     $failed = $true
   }
   else {
-    if ($Force -or $ForceDisposable) { & git -C $mayorRootPath worktree remove --force $wt }
-    else { & git -C $mayorRootPath worktree remove $wt }
-    if ($LASTEXITCODE -eq 0) {
+    $removeArgs = if ($Force -or $ForceDisposable) {
+      @('-C', $mayorRootPath, 'worktree', 'remove', '--force', $wt)
+    } else {
+      @('-C', $mayorRootPath, 'worktree', 'remove', $wt)
+    }
+    $removeResult = Invoke-GitQuiet $removeArgs
+    # git's own diagnosis, verbatim and unprefixed, exactly where the POSIX
+    # primary puts it. It is the first thing a reader wants and it is not ours
+    # to reword.
+    foreach ($l in $removeResult.Output) { [Console]::Error.WriteLine($l) }
+    if ($removeResult.ExitCode -eq 0) {
       Write-Output "REMOVED=$wt"
     }
     else {
@@ -503,6 +729,10 @@ run from $mayorRootPath, then re-check the counts before dispatching anything.
 "@
   exit 1
 }
+
+# A partial removal outranks a plain failure: both are non-zero, but only one
+# of them means "stop calling this script about that path" (rf2-k3j2w).
+if ($script:partial) { exit 3 }
 
 if ($failed) { exit 1 }
 

--- a/scripts/remove-worker-worktree.ps1
+++ b/scripts/remove-worker-worktree.ps1
@@ -203,9 +203,9 @@ function Get-WorktreeDirt([string]$Path) {
 # The one honest discriminator for a HUSK (rf2-k3j2w): a partially failed
 # `git worktree remove` deletes the worktree's `.git` before it deletes the
 # files, so a husk's files survive with nothing behind them. Seen in the wild
-# at C:/Users/miket/code/re-frame2-worktrees/procpair on 2026-08-05 - `ls`
-# shows a full checkout, `rev-parse` exits 128, `git worktree list` has never
-# heard of it and `git worktree prune` reports nothing to do.
+# twice on 2026-08-05, sitting in a worktree parent - `ls` shows a full
+# checkout, `rev-parse` exits 128, `git worktree list` has never heard of them
+# and `git worktree prune` reports nothing to do.
 #
 # Note this is a READ of git's own state, not a guess about who is using the
 # tree. Whether an AGENT is still alive is not knowable from here and this

--- a/scripts/remove-worker-worktree.ps1
+++ b/scripts/remove-worker-worktree.ps1
@@ -520,6 +520,12 @@ if ($SelfTest) {
     New-Item -ItemType Directory -Force -Path $stRepo | Out-Null
     Push-Location $stRepo
     try {
+      # An inherited GIT_DIR (CI runners and some hook contexts set one) would
+      # point `git init` / `git worktree add` at the CALLER's repository instead
+      # of this throwaway.
+      foreach ($v in @('GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE')) {
+        Remove-Item -LiteralPath "Env:$v" -ErrorAction SilentlyContinue
+      }
       $null = Invoke-GitQuiet @('init', '-q', '.')
       $null = Invoke-GitQuiet @('-c', 'user.email=selftest@example.invalid', '-c', 'user.name=selftest',
                                 'commit', '-q', '--allow-empty', '-m', 'init')
@@ -554,7 +560,13 @@ if ($SelfTest) {
       Write-Output "SELF_TEST husk detected=yes for all three shapes (outside a repo, where Get-WorktreeDirt reads EMPTY - the trap; nested inside one, where rev-parse walks up and is fooled; and a dangling .git, where the Test-Path check is fooled)"
     }
     else {
-      Write-Output "SELF_TEST husk=SKIPPED (no throwaway worktrees could be built here)"
+      # NOT a SKIP - see the POSIX primary. The junction fixture above may
+      # legitimately skip on a platform that cannot make one; there is no
+      # platform where git can run this script and yet cannot build a worktree
+      # in a temp directory. A husk fixture that will not build means the
+      # detector went untested, and an untested detector must red.
+      Write-Error "SELF_TEST=FAILED could not build the throwaway husk fixtures under $stRepo, so the husk detector was never exercised."
+      exit 1
     }
 
     Write-Output "SELF_TEST=PASSED link unlinked with its target intact ($after), the canary caught nested-only loss, and a husk is not mistaken for a clean tree."

--- a/scripts/remove-worker-worktree.ps1
+++ b/scripts/remove-worker-worktree.ps1
@@ -393,7 +393,7 @@ function Write-Husk([string]$Path) {
       'its build or gate run has already been broken; a partial removal kills a',
       'running gate exactly as a complete one does (rf2-k3j2w).',
       'Retrying this script will not finish the job - there is no registered',
-      'worktree left to remove, and `git worktree prune` has nothing to clear.',
+      "worktree left to remove, and 'git worktree prune' has nothing to clear.",
       'Any node_modules link has been disarmed, so what remains is an ordinary',
       'directory delete, once whatever holds the lock has exited:',
       "  Remove-Item -Recurse -Force $Path")) {

--- a/scripts/remove-worker-worktree.sh
+++ b/scripts/remove-worker-worktree.sh
@@ -505,16 +505,17 @@ if [ "$SELF_TEST" -eq 1 ]; then
 
   # The HUSK detector (rf2-k3j2w), in a throwaway repo; never touches this one.
   #
-  # TWO fixtures, because worktree_is_intact has two clauses and each catches a
-  # husk the other misses:
-  #   outside — a husk with no repo above it (the shape seen in the wild here).
-  #             `rev-parse` fails; this is the one whose dirt reads EMPTY, i.e.
-  #             identical to a clean tree, which is how a gutted worktree came
-  #             to be reported as a retryable file lock.
-  #   nested  — a husk sitting inside another checkout. `rev-parse` WALKS UP,
-  #             finds the enclosing repo and answers happily; only the missing
-  #             `.git` gives it away. Drop that clause and this fixture is the
-  #             one that fails.
+  # THREE fixtures, because worktree_is_intact has two clauses and each catches
+  # a husk the other cannot see. Drop either clause and one fixture reds:
+  #   outside  — a husk with no repo above it (the shape seen in the wild).
+  #              `rev-parse` fails; this is the one whose dirt reads EMPTY, i.e.
+  #              identical to a clean tree, which is how a gutted worktree came
+  #              to be reported as a retryable file lock.
+  #   nested   — a husk sitting inside another checkout. `rev-parse` WALKS UP,
+  #              finds the enclosing repo and answers happily; only the missing
+  #              `.git` gives it away.
+  #   dangling — `.git` present but naming an admin dir that is gone. The `-e`
+  #              check calls that intact; only `rev-parse` sees through it.
   ST_REPO="$WORK_DIR/husk-repo"
   mkdir -p "$ST_REPO"
   ( cd "$ST_REPO" \

--- a/scripts/remove-worker-worktree.sh
+++ b/scripts/remove-worker-worktree.sh
@@ -56,8 +56,21 @@
 #   REMOVED=<worktree path>
 #   CANARY_AFTER=<path> <signature>
 #   OK: worktree removal complete.
-#   Exit 0 on success, 1 on failure, 2 on usage error. A moved canary prints
-#   CANARY_FAILED to stderr with the npm ci recovery command.
+#   Exit 0 on success, 1 on failure, 2 on usage error, 3 on a PARTIAL removal
+#   (below). A moved canary prints CANARY_FAILED to stderr with the npm ci
+#   recovery command.
+#
+#   The exit codes split on WHAT THE CALLER SHOULD DO NEXT, which is the only
+#   thing a caller can act on:
+#     0  done.
+#     1  refused or failed, and the worktree is INTACT — this script is still
+#        the right tool (retry when the lock clears; --force-disposable for
+#        build output; a human for [KEEP] paths).
+#     2  usage error.
+#     3  PARTIAL — the tree is already gutted and deregistered. This script
+#        can do nothing more with it; see REMOVE_PARTIAL below. 3 wins over 1
+#        when both occur in one run, because it is the outcome needing a
+#        different remedy.
 #
 #   A <signature> is `<immediate-entries>/<recursive-files>/<sentinels-present>`,
 #   e.g. `103/2933/2`. The recursive count and the sentinels are load-bearing:
@@ -70,10 +83,29 @@
 #     REMOVE_REFUSED_DIRTY=  git refused; the paths are listed and tagged
 #                            [build output] or [KEEP].
 #     REMOVE_REFUSED_KEEP=   --force-disposable stopped at unreviewed work.
-#     REMOVE_FAILED=         the tree is CLEAN, so this really is a file lock
-#                            and really is worth retrying.
+#     REMOVE_FAILED=         the tree is CLEAN and INTACT, so this really is a
+#                            file lock and really is worth retrying.
+#     REMOVE_PARTIAL=        a HUSK (rf2-k3j2w) — see below. Exit 3.
 #   --dry-run reports the same partition up front as WOULD_NEED_FORCE= (all
 #   build output, sweepable) or WOULD_REFUSE_KEEP= (needs a human first).
+#
+#   THE FOURTH OUTCOME: A PARTIAL REMOVAL (rf2-k3j2w). `git worktree remove`
+#   is not atomic on Windows. It can deregister the worktree and delete its
+#   `.git`, then hit a file lock on the directory itself and stop — leaving a
+#   HUSK: every source file still on disk, no worktree behind it. The state is
+#   genuinely hard to see, which is why it earned a name here:
+#     - `git worktree list` does not mention it — already deregistered;
+#     - `git worktree prune` does not clear it — prune drops ADMIN records for
+#       directories that vanished, and here the opposite happened;
+#     - `git -C <husk> status --porcelain` FAILS and prints nothing, which the
+#       clean/dirty split above read as "tree is CLEAN" and therefore as
+#       REMOVE_FAILED, "safe to retry once it clears". Retrying is futile: the
+#       registered-worktree check refuses it, forever;
+#     - to a human `ls` it is indistinguishable from a live worktree.
+#   And it is not a near-miss. A husk kills a running gate exactly as a
+#   completed removal does — "the removal failed" is NOT "the worker was
+#   unaffected". Both entry points report it: a removal that fails this way,
+#   and a later invocation handed a path that is already a husk.
 #
 # Cross-platform: POSIX sh; runs under Git Bash on Windows, macOS, Linux.
 # No bashisms (`[[`, arrays, `<<<`).
@@ -193,8 +225,36 @@ signature() {
 # What `git worktree remove` will refuse over: modified or untracked files.
 # Empty output means clean. This is the discriminator behind a failed removal
 # (rf2-p0m6m) — see report_remove_failure.
+#
+# ONLY MEANINGFUL ON AN INTACT WORKTREE. On a husk the git call fails, prints
+# nothing, and this returns empty — identical to clean. Every caller therefore
+# checks worktree_is_intact FIRST.
 worktree_dirt() {
   git -C "$1" status --porcelain 2>/dev/null || true
+}
+
+# Is there still a git worktree behind this directory?
+#
+# The one honest discriminator for a HUSK (rf2-k3j2w): a partially failed
+# `git worktree remove` deletes the worktree's `.git` before it deletes the
+# files, so a husk's files survive with nothing behind them. Verified against
+# C:/Users/miket/code/re-frame2-worktrees/procpair on 2026-08-05 — `ls` shows
+# a full checkout, `rev-parse --git-dir` exits 128, `git worktree list` has
+# never heard of it and `git worktree prune` reports nothing to do.
+#
+# Note this is a READ of git's own state, not a guess about who is using the
+# tree. Whether an AGENT is still alive is not knowable from here and this
+# script does not try — see the reaping rule in docs/the-mayor-method.
+#
+# BOTH halves are load-bearing. `rev-parse` alone walks UP the directory tree,
+# so a husk sitting inside another checkout would answer with THAT repo and
+# read as intact; the `-e` catches it, because a linked worktree always has a
+# `.git` file at its root and a husk is exactly the tree that lost one. And
+# `-e` alone would accept a dangling or truncated `.git`. Neither is compared
+# against a path shape: under Git Bash `git` prints `C:/Users/...` where `pwd`
+# prints `/c/Users/...`, and a textual compare of the two never matches.
+worktree_is_intact() {
+  [ -e "$1/.git" ] && git -C "$1" rev-parse --git-dir >/dev/null 2>&1
 }
 
 # Is one `git status --porcelain` line safe to delete unreviewed?
@@ -282,6 +342,39 @@ disarm_link() {
   return 0
 }
 
+# Disarm every node_modules link under one worktree, before anything recursive
+# runs over it.
+#
+# Extracted from the main loop so the HUSK path gets the identical protection
+# (rf2-k3j2w). A husk left behind by a bare `git worktree remove` — one that
+# never went through this script — can still hold an ARMED junction, and the
+# only remedy left for a husk is a plain `rm -rf`, which is precisely the
+# recursive delete that empties the target. Disarming before we recommend that
+# delete is the difference between advice and a loaded gun.
+disarm_worktree_links() {
+  _dwl_wt="$1"
+  find_node_modules "$_dwl_wt" > "$WORK_DIR/wt-nm"
+  _dwl_found=0
+  while IFS= read -r nm; do
+    [ -n "$nm" ] || continue
+    if [ ! -L "$nm" ]; then
+      continue
+    fi
+    _dwl_found=1
+    link_target=$(readlink "$nm" 2>/dev/null || printf '<unresolved>')
+    if [ "$DRY_RUN" -eq 1 ]; then
+      printf 'WOULD_DISARM=%s -> %s\n' "$nm" "$link_target"
+      continue
+    fi
+    disarm_link "$nm" \
+      || die "Failed to unlink $nm — it is still present. ABORTING before 'git worktree remove', which would delete THROUGH it into $link_target."
+    printf 'DISARMED=%s -> %s\n' "$nm" "$link_target"
+  done < "$WORK_DIR/wt-nm"
+  if [ "$_dwl_found" -eq 0 ]; then
+    printf 'NO_LINKS=%s\n' "$_dwl_wt"
+  fi
+}
+
 # Say WHY the removal failed instead of guessing (rf2-p0m6m).
 #
 # `git worktree remove` has two failure modes with OPPOSITE remedies:
@@ -298,11 +391,35 @@ disarm_link() {
 # a full session of other workers; every one of them was simply dirty, holding
 # a single untracked `logs/`, `bench-logs/`, `PRBODY.md` or `*-exit.txt` the
 # worker left behind. Telling the two apart is the whole fix.
+# A partially removed worktree — a HUSK. Says what was already done TO the
+# tree, and why this script is the wrong tool from here on (rf2-k3j2w).
+report_husk() {
+  printf 'REMOVE_PARTIAL=%s\n' "$1" >&2
+  printf 'The worktree is already GUTTED: git deregistered it and deleted its .git,\n' >&2
+  printf 'then could not delete the directory — a file lock taken mid-removal. The\n' >&2
+  printf 'files you can still see have no worktree behind them.\n' >&2
+  printf 'THIS IS A DESTROYED TREE, NOT AN UNTOUCHED ONE. If an agent was using it,\n' >&2
+  printf 'its build or gate run has already been broken; a partial removal kills a\n' >&2
+  printf 'running gate exactly as a complete one does (rf2-k3j2w).\n' >&2
+  printf 'Retrying this script will not finish the job — there is no registered\n' >&2
+  printf 'worktree left to remove, and `git worktree prune` has nothing to clear.\n' >&2
+  printf 'Any node_modules link has been disarmed, so what remains is an ordinary\n' >&2
+  printf 'directory delete, once whatever holds the lock has exited:\n' >&2
+  printf '  rm -rf %s\n' "$1" >&2
+}
+
 report_remove_failure() {
   _rf_wt="$1"
+  # A husk reads as CLEAN below — the git call fails and prints nothing — so
+  # it has to be ruled out before the dirty/locked split runs (rf2-k3j2w).
+  if ! worktree_is_intact "$_rf_wt"; then
+    report_husk "$_rf_wt"
+    PARTIAL=1
+    return
+  fi
   _rf_dirt=$(worktree_dirt "$_rf_wt")
   if [ -z "$_rf_dirt" ]; then
-    printf 'REMOVE_FAILED=%s (tree is CLEAN, so this is a file lock: links are already disarmed; safe to retry once it clears)\n' "$_rf_wt" >&2
+    printf 'REMOVE_FAILED=%s (tree is CLEAN and still INTACT, so this is a file lock: links are already disarmed; safe to retry once it clears)\n' "$_rf_wt" >&2
     return
   fi
   printf 'REMOVE_REFUSED_DIRTY=%s\n' "$_rf_wt" >&2
@@ -386,7 +503,54 @@ if [ "$SELF_TEST" -eq 1 ]; then
   printf 'SELF_TEST nested_loss top_level_entries_unchanged=%s signature %s -> %s\n' \
     "${ST_N_BEFORE%%/*}" "$ST_N_BEFORE" "$ST_N_AFTER"
 
-  printf 'SELF_TEST=PASSED link unlinked with its target intact (%s), and the canary caught nested-only loss.\n' "$ST_AFTER"
+  # The HUSK detector (rf2-k3j2w), in a throwaway repo; never touches this one.
+  #
+  # TWO fixtures, because worktree_is_intact has two clauses and each catches a
+  # husk the other misses:
+  #   outside — a husk with no repo above it (the shape seen in the wild here).
+  #             `rev-parse` fails; this is the one whose dirt reads EMPTY, i.e.
+  #             identical to a clean tree, which is how a gutted worktree came
+  #             to be reported as a retryable file lock.
+  #   nested  — a husk sitting inside another checkout. `rev-parse` WALKS UP,
+  #             finds the enclosing repo and answers happily; only the missing
+  #             `.git` gives it away. Drop that clause and this fixture is the
+  #             one that fails.
+  ST_REPO="$WORK_DIR/husk-repo"
+  mkdir -p "$ST_REPO"
+  ( cd "$ST_REPO" \
+      && git init -q . \
+      && git -c user.email=selftest@example.invalid -c user.name=selftest \
+             commit -q --allow-empty -m init \
+      && git worktree add -q "$WORK_DIR/husk-outside" -b husk-probe-outside \
+      && git worktree add -q "$ST_REPO/husk-nested"   -b husk-probe-nested ) >/dev/null 2>&1 || true
+
+  if [ -e "$WORK_DIR/husk-outside/.git" ] && [ -e "$ST_REPO/husk-nested/.git" ]; then
+    for ST_WT in "$WORK_DIR/husk-outside" "$ST_REPO/husk-nested"; do
+      worktree_is_intact "$ST_WT" \
+        || die "SELF_TEST=FAILED a live worktree read as not-intact: $ST_WT"
+      rm -f "$ST_WT/.git"   # precisely what a partial removal leaves behind
+      if worktree_is_intact "$ST_WT"; then
+        die "SELF_TEST=FAILED a husk read as INTACT: $ST_WT — it would be classified as a clean tree and a retryable lock."
+      fi
+    done
+    if [ -n "$(worktree_dirt "$WORK_DIR/husk-outside")" ]; then
+      die "SELF_TEST=FAILED the husk fixture does not reproduce the ambiguity it exists to test."
+    fi
+
+    # A THIRD shape, and the one that keeps the other clause honest: `.git` is
+    # PRESENT but dangling — it names an admin directory that is gone. The `-e`
+    # check calls that intact; only rev-parse sees through it.
+    printf 'gitdir: %s\n' "$WORK_DIR/no-such-admin-dir" > "$WORK_DIR/husk-outside/.git"
+    if worktree_is_intact "$WORK_DIR/husk-outside"; then
+      die "SELF_TEST=FAILED a dangling .git read as INTACT; the -e check alone cannot see it."
+    fi
+
+    printf 'SELF_TEST husk detected=yes for all three shapes (outside a repo, where worktree_dirt reads EMPTY — the trap; nested inside one, where rev-parse walks up and is fooled; and a dangling .git, where the -e check is fooled)\n'
+  else
+    printf 'SELF_TEST husk=SKIPPED (no throwaway worktrees could be built here)\n'
+  fi
+
+  printf 'SELF_TEST=PASSED link unlinked with its target intact (%s), the canary caught nested-only loss, and a husk is not mistaken for a clean tree.\n' "$ST_AFTER"
   exit 0
 fi
 
@@ -451,6 +615,7 @@ done < "$WORK_DIR/roster-raw"
 # Per worktree: disarm, verify, THEN remove.
 # ---------------------------------------------------------------------------
 FAILED=0
+PARTIAL=0
 
 while IFS= read -r raw_target; do
   [ -n "$raw_target" ] || continue
@@ -464,31 +629,24 @@ while IFS= read -r raw_target; do
 
   # Refuse anything git does not know as a linked worktree. This script never
   # deletes a directory itself; if git will not remove it, neither will we.
+  #
+  # One unregistered path is NOT a mistyped argument, and saying so is the
+  # difference between an actionable message and a wild goose chase: a HUSK
+  # left by an earlier partial removal is deregistered BY DEFINITION, so the
+  # old advice here ("run 'git worktree prune'") sent the caller after an
+  # entry that had already been cleared (rf2-k3j2w). Disarm it and name it.
   if ! grep -Fxq "$(to_lower "$WT")" "$WORK_DIR/roster"; then
+    if [ -d "$WT" ] && ! worktree_is_intact "$WT"; then
+      disarm_worktree_links "$WT"
+      report_husk "$WT"
+      PARTIAL=1
+      continue
+    fi
     die "Not a registered worktree of $MAYOR_ROOT: $WT (run 'git worktree list'; 'git worktree prune' clears stale entries)."
   fi
 
   # 1. Disarm every link, before anything recursive runs over the tree.
-  find_node_modules "$WT" > "$WORK_DIR/wt-nm"
-  found_any=0
-  while IFS= read -r nm; do
-    [ -n "$nm" ] || continue
-    if [ ! -L "$nm" ]; then
-      continue
-    fi
-    found_any=1
-    link_target=$(readlink "$nm" 2>/dev/null || printf '<unresolved>')
-    if [ "$DRY_RUN" -eq 1 ]; then
-      printf 'WOULD_DISARM=%s -> %s\n' "$nm" "$link_target"
-      continue
-    fi
-    disarm_link "$nm" \
-      || die "Failed to unlink $nm — it is still present. ABORTING before 'git worktree remove', which would delete THROUGH it into $link_target."
-    printf 'DISARMED=%s -> %s\n' "$nm" "$link_target"
-  done < "$WORK_DIR/wt-nm"
-  if [ "$found_any" -eq 0 ]; then
-    printf 'NO_LINKS=%s\n' "$WT"
-  fi
+  disarm_worktree_links "$WT"
 
   # 2. Only now remove the worktree. Never chained with the disarm.
   wt_dirt=$(worktree_dirt "$WT")
@@ -556,6 +714,12 @@ if [ "$CANARY_BAD" -eq 1 ]; then
   printf '  npm ci --prefix implementation\n' >&2
   printf 'run from %s, then re-check the counts before dispatching anything.\n' "$MAYOR_ROOT" >&2
   exit 1
+fi
+
+# A partial removal outranks a plain failure: both are non-zero, but only one
+# of them means "stop calling this script about that path" (rf2-k3j2w).
+if [ "$PARTIAL" -ne 0 ]; then
+  exit 3
 fi
 
 if [ "$FAILED" -ne 0 ]; then

--- a/scripts/remove-worker-worktree.sh
+++ b/scripts/remove-worker-worktree.sh
@@ -238,9 +238,9 @@ worktree_dirt() {
 # The one honest discriminator for a HUSK (rf2-k3j2w): a partially failed
 # `git worktree remove` deletes the worktree's `.git` before it deletes the
 # files, so a husk's files survive with nothing behind them. Verified against
-# C:/Users/miket/code/re-frame2-worktrees/procpair on 2026-08-05 — `ls` shows
-# a full checkout, `rev-parse --git-dir` exits 128, `git worktree list` has
-# never heard of it and `git worktree prune` reports nothing to do.
+# two husks found sitting in a worktree parent on 2026-08-05: `ls` shows a full
+# checkout, `rev-parse --git-dir` exits 128, `git worktree list` has never
+# heard of them and `git worktree prune` reports nothing to do.
 #
 # Note this is a READ of git's own state, not a guess about who is using the
 # tree. Whether an AGENT is still alive is not knowable from here and this

--- a/scripts/remove-worker-worktree.sh
+++ b/scripts/remove-worker-worktree.sh
@@ -402,7 +402,7 @@ report_husk() {
   printf 'its build or gate run has already been broken; a partial removal kills a\n' >&2
   printf 'running gate exactly as a complete one does (rf2-k3j2w).\n' >&2
   printf 'Retrying this script will not finish the job — there is no registered\n' >&2
-  printf 'worktree left to remove, and `git worktree prune` has nothing to clear.\n' >&2
+  printf "worktree left to remove, and 'git worktree prune' has nothing to clear.\n" >&2
   printf 'Any node_modules link has been disarmed, so what remains is an ordinary\n' >&2
   printf 'directory delete, once whatever holds the lock has exited:\n' >&2
   printf '  rm -rf %s\n' "$1" >&2

--- a/scripts/remove-worker-worktree.sh
+++ b/scripts/remove-worker-worktree.sh
@@ -518,7 +518,11 @@ if [ "$SELF_TEST" -eq 1 ]; then
   #              check calls that intact; only `rev-parse` sees through it.
   ST_REPO="$WORK_DIR/husk-repo"
   mkdir -p "$ST_REPO"
-  ( cd "$ST_REPO" \
+  # GIT_DIR and friends are unset for the subshell: an inherited one (CI runners
+  # and some hook contexts set them) would point `git init` and `git worktree
+  # add` at the CALLER's repository instead of this throwaway.
+  ( unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+    cd "$ST_REPO" \
       && git init -q . \
       && git -c user.email=selftest@example.invalid -c user.name=selftest \
              commit -q --allow-empty -m init \
@@ -548,7 +552,12 @@ if [ "$SELF_TEST" -eq 1 ]; then
 
     printf 'SELF_TEST husk detected=yes for all three shapes (outside a repo, where worktree_dirt reads EMPTY — the trap; nested inside one, where rev-parse walks up and is fooled; and a dangling .git, where the -e check is fooled)\n'
   else
-    printf 'SELF_TEST husk=SKIPPED (no throwaway worktrees could be built here)\n'
+    # NOT a SKIP. The link fixture above may legitimately skip — some platforms
+    # cannot produce a link to test against. There is no platform where git can
+    # run this script and yet cannot build a worktree in a temp directory, so a
+    # husk fixture that will not build means the detector went untested, and an
+    # untested detector must red rather than certify itself.
+    die "SELF_TEST=FAILED could not build the throwaway husk fixtures under $ST_REPO, so the husk detector was never exercised."
   fi
 
   printf 'SELF_TEST=PASSED link unlinked with its target intact (%s), the canary caught nested-only loss, and a husk is not mistaken for a clean tree.\n' "$ST_AFTER"


### PR DESCRIPTION
Closes rf2-k3j2w.

The bead records six reaps that destroyed a live worker's gate run, each keyed on a
fresh proxy that looked sound when adopted. This PR does **not** add a seventh. It
fixes the one thing the tooling genuinely got wrong, and corrects two sentences in the
method that still recommend proxies which have since failed.

## What was actually broken

`git worktree remove` is not atomic on Windows. Holding a single open file handle
inside a throwaway worktree reproduces the failure exactly:

```
git worktree remove --force <wt>  ->  exit 255, "failed to delete '<wt>': Invalid argument"
git worktree list                 ->  <wt> ALREADY GONE
<wt>/.git                         ->  ALREADY DELETED
<wt>/**                           ->  every other file still present
```

The leftover is a **husk**, and every signal a caller had pointed the wrong way:

- `git worktree prune` does not clear it — prune drops admin records for directories
  that vanished, and here the opposite happened.
- `git status --porcelain` inside it **fails and prints nothing**, which the
  clean/dirty split read as *"tree is CLEAN"* and reported as
  `REMOVE_FAILED= ... safe to retry once it clears`. Retrying is futile: the
  registered-worktree check now refuses the path forever.
- To a human `ls` it is indistinguishable from a live worktree.

This is not a near miss. **A husk kills a running gate exactly as a completed removal
does** — "the removal failed" is not "the worker was unaffected".

Two husks were live in the worktree parent when this started (one a full checkout with
no `.git`, one an emptied shell). Both left in place — per the bead, an unfamiliar
worktree belongs to someone until its agent reports.

## What changed

**A partial removal now says so.** `REMOVE_PARTIAL=<path>` and **exit 3**, joining
`REMOVE_REFUSED_DIRTY` / `REMOVE_REFUSED_KEEP` / `REMOVE_FAILED`. Exit codes now split
on what the caller should do next: `1` = the worktree is **intact** and this script is
still the right tool; `3` = already gutted, only an ordinary directory delete remains.
Both entry points report it — a removal that fails this way, and a later invocation
handed a path that is already a husk.

**The disarm now runs on the husk path.** Previously a husk was refused *with its
junction still armed*, while the message recommended `git worktree prune`. Since the
only remedy left for a husk is `rm -rf`, that combination is a loaded gun pointed at
the mayor's `node_modules`. The disarm is factored out and runs before anything
recommends a delete.

**Two pre-existing Windows defects, both reproduced against `main` first:**

- The `.ps1` **crashed instead of classifying**. With `$ErrorActionPreference = "Stop"`,
  a native command writing to stderr raises a terminating `NativeCommandError`, and
  neither `2>$null` nor `2>&1` suppresses it. `git status` in a husk aborted the
  script, and the same trap sat under `git worktree remove` — the one call guaranteed
  to write to stderr on the very path that must be classified rather than crashed on.
  Native git now goes through `Invoke-GitQuiet`.
- `(Get-UndisposableLines $dirt).Count` threw on **every dirty tree**: PowerShell
  unrolls the returned array, empty arrives as `$null`, and `$null.Count` is fatal
  under `StrictMode` — the exact trap `Get-WorktreeDirt`'s own header warns about. So
  `REMOVE_REFUSED_DIRTY` died right after listing the paths, swallowing the one
  sentence that tells a hygiene sweep whether `-ForceDisposable` will clear the tree.
  Windows never saw the guidance rf2-p0m6m added.

**Method docs — two sentences corrected, no new section.** `bootstrap.md` ended its
identity-vs-name bullet with *"the discriminator is freshness, not shape"*; freshness
has since failed twice (elapsed time, and mtime reading 250 minutes stale on a tree
being committed to as it was read). `README.md` said to leave cleanup until the
worktree is *"verifiably clean"* — the sixth and most perverse failed proxy, since a
worker that has pushed everything as briefed shows a clean tree for a whole
twenty-minute gate. A new `bootstrap.md` bullet carries the roster of six and the two
signals that have never lied.

## What this deliberately does NOT do

**No liveness detection.** No process ancestry, no lock probing, no mtime heuristics.
Whether an agent is still using a tree is the caller's knowledge, not the script's —
and that class of proxy is precisely what failed six times. `worktree_is_intact` is a
**read of git's own state**, not an inference about who is using the tree.

**The canary is unchanged.** Still a recursive **file** count read as a before/after
delta, alongside immediate entries and sentinels (`103/2933/2` here). Not made
stricter. Note the two correct-but-different top-level measures: `Get-ChildItem -Force`
reports 103 and `ls` reports 101; the signature's first field uses the **`-Force` /
`find -maxdepth 1` measure (103)**, which counts dotfiles.

`remove-worker-worktree.sh` was not rewritten — the disarm-before-remove ordering, the
refuse-rather-than-force posture and the honest failure reporting were already right.

## Follow-up filed

**rf2-40d9d (P1)** — `.claude/commands/mayor-hygiene.md`, which is what the loop
actually executes, still says *"only if state==MERGED, prune it"*: the first of the six
failed proxies, verbatim, and outside this PR's fence. Correcting the method doc does
not correct the command body.

## Quality gates

| gate | exit |
|---|---|
| `sh scripts/test-fast-pr.sh` (final head `0c8ad39032`) | 0 |
| `npm run test:script-policy && npm run test:script-helpers` (chained JS harness) | 0 |
| `sh scripts/remove-worker-worktree.sh --self-test` | 0 |
| `powershell -File scripts/remove-worker-worktree.ps1 -SelfTest` | 0 |
| `--self-test` with the fixture build broken (must fail) | 1 |
| `sh -n scripts/remove-worker-worktree.sh` (syntax) | 0 |
| `sh scripts/check-no-hardcoded-paths.sh` | 0 |
| `python scripts/check_doc_slugs.py` | 0 |
| `python scripts/check_doc_slugs.py` (mutated link, must fail) | 1 |
| `python scripts/check_fast_pr_gap.py --list` | 0 |

The spine's own run reports `mkdocs --strict build` green, which is the gate that
matters for `docs/the-mayor-method/**` — that tree **is** in the site (unlike
`docs/design/**`). The JVM and CLJS/node tiers auto-skipped as surface-unchanged; this
diff touches no Clojure and no JS.

`shellcheck` is not installed in this environment, so `sh -n` plus `--self-test` were
the local proxies and **CI owns the shellcheck verdict**. It earned its keep: the first
push tripped `SC2016` on backticks inside a single-quoted `printf` in the new husk
message. Fixed, and the file swept for the genuinely dangerous shape — a backtick
inside a *double*-quoted `die`/`printf`, which really would run a command — of which
there are none.

### `--self-test` now proves the husk detector rather than asserting it

Three fixtures, because the detector has two clauses and each catches a husk the other
cannot see — **each mutation-proved**:

| fixture | what it catches | drop `-e "$1/.git"` | drop `rev-parse` |
|---|---|---|---|
| outside a repo (the shape seen in the wild) | dirt reads EMPTY — *the trap* | pass | pass |
| nested inside another checkout | `rev-parse` walks up and is fooled | **FAIL** | pass |
| dangling `.git` | the file-exists check is fooled | pass | **FAIL** |

### Destructive testing

Every destructive test ran against **throwaway worktrees created for the purpose**
(`k3j2w-probe1`..`probe8`), never a live one and never the mayor checkout. The mayor's
`implementation/node_modules` was counted before and after **every** destructive step:

**2933 files / 103 top-level entries, unmoved throughout.** All probes and their
branches removed; `git worktree list` and the worktree parent verified clean afterwards.

Head-to-head on a real husk carrying an armed junction pointed at a dummy target:

| | old (`main`) | new |
|---|---|---|
| classification | `Not a registered worktree ... run 'git worktree prune'` | `REMOVE_PARTIAL=` |
| exit | 1 | 3 |
| junction afterwards | **still armed** | `DISARMED=` |
| dummy target | — | intact (7/7 files) |

Same-invocation partial failure (registered worktree + real file lock), old vs new:

- old: `REMOVE_FAILED= ... (tree is CLEAN, so this is a file lock ... safe to retry once it clears)`, exit 1
- new: `REMOVE_PARTIAL= ...`, exit 3, with git's own `error: failed to delete ...` passed through verbatim

No-regression checks, both implementations: happy-path removal (exit 0), `--dry-run`
(`WOULD_REMOVE`, exit 0), dirty tree refused (`REMOVE_REFUSED_DIRTY`, exit 1),
`--force-disposable` sweep (exit 0), and `[KEEP]` refusal leaving the file on disk
(`REMOVE_REFUSED_KEEP`, exit 1).
