### PR TITLE
docs(hicasso): Below Hiccup page (98% / 2%)

### DIFF
--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -60,8 +60,10 @@ interpretation, not a better Reagent.*
 
 **Not the pitch:** "stellar performance." The programme bar is competitive with
 Reagent on the important rows — good enough to ship, not a speed-marketing
-product. Prefer Hicasso for **authoring, testing shape, and re-frame integration**,
-not for winning a microbenchmark war.
+product. **For about 98% of view code, performance is not an issue**; for the
+rest, there is a ladder down, not a dual mode
+([Below Hiccup](11-below-hiccup.md)). Prefer Hicasso for **authoring, testing
+shape, and re-frame integration**, not for winning a microbenchmark war.
 
 ## What you get (feature map)
 
@@ -87,7 +89,7 @@ finished product package.
 | **SSR participation** | Same pure bodies + framework hydration; experimental doors exist; production package still open | [Server-side rendering](10-server-side-rendering.md) |
 | **Xray-friendly UI** | UI state in app-db + named events shows up in app-db diffs and time-travel; not a special Hicasso Xray tab | framework Xray + this design |
 | **Performance** | Good / competitive goal vs Reagent; not "fastest UI library" | programme bar, not a guide claim |
-| **Going lower** | No dual mode; still-Hiccup levers, then host-edge React / `defhost` | [Below Hiccup](11-below-hiccup.md) |
+| **Going lower** | ~98% of view code needs nothing special; for the ~2%, a ladder (not a dual mode) | [Below Hiccup](11-below-hiccup.md) |
 
 ## Your first app
 

--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -87,6 +87,7 @@ finished product package.
 | **SSR participation** | Same pure bodies + framework hydration; experimental doors exist; production package still open | [Server-side rendering](10-server-side-rendering.md) |
 | **Xray-friendly UI** | UI state in app-db + named events shows up in app-db diffs and time-travel; not a special Hicasso Xray tab | framework Xray + this design |
 | **Performance** | Good / competitive goal vs Reagent; not "fastest UI library" | programme bar, not a guide claim |
+| **Going lower** | No dual mode; still-Hiccup levers, then host-edge React / `defhost` | [Below Hiccup](11-below-hiccup.md) |
 
 ## Your first app
 

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -274,8 +274,8 @@ own and always re-renders with its parent anyway, a plain function is cheaper
 and simpler. Reach for a boundary when you want something to update
 independently, not because the markup got long.
 
-When the issue is **cost**, not only structure — host-edge React, foreign
-components, what is *not* an escape — see [Below Hiccup](11-below-hiccup.md).
+When a measured island is in the **~2%** (cost, host edge, foreign component) —
+not the default 98% — see [Below Hiccup](11-below-hiccup.md).
 
 ## Advanced
 

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -274,6 +274,9 @@ own and always re-renders with its parent anyway, a plain function is cheaper
 and simpler. Reach for a boundary when you want something to update
 independently, not because the markup got long.
 
+When the issue is **cost**, not only structure — host-edge React, foreign
+components, what is *not* an escape — see [Below Hiccup](11-below-hiccup.md).
+
 ## Advanced
 
 ### The sub collector

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -34,6 +34,10 @@ legal:
 Children cross as ordinary hiccup and lower where they render — including as
 another view's child.
 
+This page is the **foreign component** door. For the full ladder — still-Hiccup
+perf levers, host-edge hooks/refs, and what is not an escape — see
+[Below Hiccup](11-below-hiccup.md).
+
 ## Why declare
 
 Putting a raw JS component in the tree breaks three things at once:

--- a/docs/design/hicasso/draft-guide/07-ephemeral-state.md
+++ b/docs/design/hicasso/draft-guide/07-ephemeral-state.md
@@ -23,7 +23,7 @@ pixel offset is arithmetic, so it is mechanics.
 A `defview` body is a real React function component. Hooks physically work in it.
 There is no lint police, and if you use one you take on React's hook rules
 yourself — including the loss of headless testability for that body
-([Testing](08-testing.md)).
+([Testing](08-testing.md)). When hooks are for a measured hot path rather than placement, see [Below Hiccup](11-below-hiccup.md).
 
 ## The order to try
 

--- a/docs/design/hicasso/draft-guide/11-below-hiccup.md
+++ b/docs/design/hicasso/draft-guide/11-below-hiccup.md
@@ -2,17 +2,25 @@
 
 > **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Mechanisms are proven under `implementation/freehand/test/re_frame/bench/hicasso/`; product spellings and some call shapes are still settling.
 
-Hicasso is **Hiccup-first and interpreted**. Most of the app should stay that
-way: vectors and maps, `sub` at the point of use, intents as data. That is the
-product.
+> **For about 98% of view code, performance is not an issue.** Write ordinary
+> Hiccup: `defview`, `sub` at the point of use, intents as data. Do not
+> pre-optimise. Do not invent a second architecture "just in case."
 
-Sometimes a path is hot and you want to go **lower** — closer to React, past the
-interpreter, or into a third-party component. You can. There is **no second mode**
-that turns interpretation off for the whole app. There **are** deliberate steps
-down the stack. This page is the map.
+Hicasso is **Hiccup-first and interpreted**. That is the product for almost
+everything you ship. The interpreter is not free, but it is rarely the bill you
+are paying — re-render granularity, read placement, and how often you write
+app-db dominate more often than "we walked vectors into elements."
 
-> **Stay in Hiccup until you have a measured reason not to. Then isolate the
-> escape — do not rewrite the product.**
+**For the other ~2%** — a measured hot path, a third-party React widget, an
+imperative SDK — you *can* go lower. There is **no second mode** that turns
+interpretation off for the whole app. There **are** deliberate steps down the
+stack. This page is the map for that minority.
+
+> **Ninety-eight percent stays Hiccup. For the two percent: measure, then isolate
+> the escape — do not rewrite the product.**
+
+The percentages are a **product assertion**, not a lab result: write as if they
+were true until a profile proves a specific island is the exception.
 
 ## What "lower" is not
 
@@ -21,10 +29,11 @@ down the stack. This page is the map.
 | "Compile this view off the interpreter" | **No.** No dual mode, no analyzer, no ViewCell product path |
 | "Bare JS component in head position" | **Refused** — one door: `defhost` / `[:>]`, not silent auto-host |
 | "Drop to Reagent/UIx for one page" | Only as **another root / adapter**, not a Hicasso mode |
-| "Interpretation is the main perf problem" | Usually **not**. The charter prices interpretation as a small factor; re-render granularity and read placement dominate more often |
+| "I'll use hooks everywhere so we're ready for the 2%" | That *is* rewriting the product. The 2% is an island, not a lifestyle |
 
-If you have not measured, start with [step 1](#1-still-hiccup--spend-less) before
-any host-edge React.
+If you have not measured, you are still in the 98%. Stay on tier-1 Hiccup
+([Views and reads](02-views-and-reads.md)). When a profile names an island, start
+with [step 1](#1-still-hiccup--spend-less) before any host-edge React.
 
 ## The ladder (top → bottom)
 
@@ -130,12 +139,15 @@ on one page is the multi-app pattern ([Getting started](01-getting-started.md));
 mixing substrates is an architecture choice, not a spelling inside one
 `defview`.
 
-## Order of operations (when something feels slow)
+## Order of operations (the 2%)
 
-1. **Measure** — which boundary, which sub, which event. Guessing "the
-   interpreter" is usually wrong.
+You only enter this list after something is **measured** (or is obviously a
+foreign/SDK boundary you never expected Hiccup to own).
+
+1. **Name the island** — which boundary, which sub, which event, which widget.
+   "The app is slow" is still the 98% problem in disguise.
 2. **Still Hiccup** — fewer boundaries, reads at point of use, no high-rate
-   writes to app-db.
+   writes to app-db. Most "2%" cases die here and return to the 98%.
 3. **Host-edge island** — one measured widget, hooks/refs, frame captured for any
    async dispatch.
 4. **`defhost`** — if the cost is a third-party React component, not your markup.
@@ -164,10 +176,11 @@ mixing substrates is an architecture choice, not a spelling inside one
 
 ## When not to go lower
 
-- You have **no profile**, only a feeling.
+- You are still in the **98%** — no profile, only a feeling, or a fear of
+  interpretation.
 - The fix is really **event volume** (e.g. controlling every keystroke on a 100-cell
   grid) — see [Controlled inputs](04-controlled-inputs.md) when-not.
-- You are about to reimplement the app in hooks "for flexibility" — that is a
+- You are about to reimplement the app in hooks "for the 2%" — that is a
   substrate change, not a Hicasso escape.
 
 ## Not settled yet

--- a/docs/design/hicasso/draft-guide/11-below-hiccup.md
+++ b/docs/design/hicasso/draft-guide/11-below-hiccup.md
@@ -1,0 +1,180 @@
+# Below Hiccup
+
+> **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Mechanisms are proven under `implementation/freehand/test/re_frame/bench/hicasso/`; product spellings and some call shapes are still settling.
+
+Hicasso is **Hiccup-first and interpreted**. Most of the app should stay that
+way: vectors and maps, `sub` at the point of use, intents as data. That is the
+product.
+
+Sometimes a path is hot and you want to go **lower** — closer to React, past the
+interpreter, or into a third-party component. You can. There is **no second mode**
+that turns interpretation off for the whole app. There **are** deliberate steps
+down the stack. This page is the map.
+
+> **Stay in Hiccup until you have a measured reason not to. Then isolate the
+> escape — do not rewrite the product.**
+
+## What "lower" is not
+
+| Wish | Reality |
+|---|---|
+| "Compile this view off the interpreter" | **No.** No dual mode, no analyzer, no ViewCell product path |
+| "Bare JS component in head position" | **Refused** — one door: `defhost` / `[:>]`, not silent auto-host |
+| "Drop to Reagent/UIx for one page" | Only as **another root / adapter**, not a Hicasso mode |
+| "Interpretation is the main perf problem" | Usually **not**. The charter prices interpretation as a small factor; re-render granularity and read placement dominate more often |
+
+If you have not measured, start with [step 1](#1-still-hiccup--spend-less) before
+any host-edge React.
+
+## The ladder (top → bottom)
+
+### 1. Still Hiccup — spend less
+
+Same language, less cost. This is the first lever and the one that preserves
+testing and data trees.
+
+**Boundaries only where re-render granularity matters.**
+
+```clojure
+[todo-row {:key id :id id}]   ;; boundary — own re-render, own sub edge set
+(row-chrome {:id id})         ;; plain call — inlined; free at runtime
+```
+
+A **vector** head is a boundary (React identity, its own `sub` reads, default
+value-equality bail-out). A **plain call** splices hiccup into the parent and
+donates reads upward. Helpers that always re-render with their parent should be
+calls, not `defview`s.
+
+**Push reads down.** A `sub` high in the tree invalidates that boundary and
+everything the value is threaded through. Read at the point of use
+([Views and reads](02-views-and-reads.md)).
+
+**Do not invent a second state system for motion.** High-rate drag/scroll belongs
+at a host edge or off app-db until commit
+([Ephemeral state](07-ephemeral-state.md)).
+
+### 2. Real React inside a boundary (host edge)
+
+A `defview` body **is** an honest React function component. Hooks and refs are
+**legal** for host mechanics — geometry, measure-before-paint, SDK handles,
+animation clocks that are not app state.
+
+The rule is taught, not runtime-policed:
+
+> Semantic application state → app-db.  
+> Component mechanics → ordinary React at the edge.
+
+```clojure
+;; .cljs host-edge namespace — not the whole app.
+(ns app.hosts.measure-box
+  (:require [re-frame.hicasso :as h :refer [defview]]
+            ["react" :as react]))
+
+(defview measure-box [{:keys [children]}]
+  (let [ref (react/useRef nil)]
+    (react/useLayoutEffect
+      (fn []
+        (when-let [node (.-current ref)]
+          ;; measure, report via dispatch with a captured frame, etc.
+          js/undefined))
+      #js [])
+    (into [:div {:ref ref}] children)))
+```
+
+**What you pay**
+
+| You gain | You give up |
+|---|---|
+| Full React toolkit for that island | Headless / data-tree testing for that body ([Testing](08-testing.md)) |
+| Fine control of layout/measure/SDK lifecycle | You own hook rules and StrictMode yourself |
+| Rest of the app stays Hicasso | That node is no longer "pure data markup" |
+
+Keep the island **small**. The win is isolation, not "half the app in hooks."
+
+Callback **refs** (attach + teardown in one function) are the taught form for
+imperative DOM ownership; details live under [Interop](05-interop.md) Advanced.
+
+### 3. Foreign React components (`defhost` / `[:>]`)
+
+When the lower level is **someone else's** React component (npm date picker,
+chart, design-system primitive):
+
+- **`defhost`** — declare once, use as a view head; props conversion and callback
+  contracts at the declaration ([Interop](05-interop.md)).
+- **`[:> Component …]`** — secondary raw escape for cases a static declaration
+  cannot express; same conversion path, less identity for tools. Build status may
+  lag the ruling — check the interop page.
+
+```clojure
+(h/defhost chart Chart
+  {:ssr :client-only})   ;; or {:fallback […]}
+
+(defview dashboard [_]
+  [:div
+   [chart {:series (sub [:metrics/series])}]])
+```
+
+An **existing React element** is a legal child anywhere (pass-through). Something
+that already produced `createElement` output can sit under Hiccup without being
+re-interpreted as tags.
+
+**What you pay:** less structural `=` at that node, JS quarantined in `.cljs`,
+SSR policy explicit (`:client-only` / fallback). Do not smuggle a raw JS require
+into a `.cljc` view ns.
+
+### 4. A different view layer entirely
+
+If a whole screen wants UIx or Reagent authoring, that is **another adapter
+root**, not a Hiccup escape hatch. Hicasso does not embed "UIx mode." Two frames
+on one page is the multi-app pattern ([Getting started](01-getting-started.md));
+mixing substrates is an architecture choice, not a spelling inside one
+`defview`.
+
+## Order of operations (when something feels slow)
+
+1. **Measure** — which boundary, which sub, which event. Guessing "the
+   interpreter" is usually wrong.
+2. **Still Hiccup** — fewer boundaries, reads at point of use, no high-rate
+   writes to app-db.
+3. **Host-edge island** — one measured widget, hooks/refs, frame captured for any
+   async dispatch.
+4. **`defhost`** — if the cost is a third-party React component, not your markup.
+5. **Different substrate** — only if the product direction is React-first for that
+   surface.
+
+## What you keep / what you lose
+
+| Level | Data tree / `=` intents | `sub` ambient | Headless-friendly | Perf lever |
+|---|---|---|---|---|
+| Tier-1 Hiccup | Yes | Yes | Yes (when headless lands; intents today) | Boundaries + read placement |
+| Host-edge hooks in a view | Partial (surrounding tree yes) | Yes in that body | **No** for that body | React tools |
+| `defhost` / foreign | Crossing is opaque JS | Via props / parent reads | Foreign region out | Leave heavy work in the library |
+| Other adapter root | That root's rules | That root's rules | That root's rules | Full switch |
+
+## Troubleshooting
+
+| Symptom | What went wrong | Fix |
+|---|---|---|
+| Everything re-renders when one cell changes | Read too high, or everything is one boundary | Push `sub` down; split boundaries |
+| "I'll just use hooks everywhere for speed" | Second architecture | Isolate one island; keep app-db for semantic state |
+| Headless / structural test dies after a "perf fix" | Hooks or foreign JS entered a `.cljc` body | Quarantine host code in `.cljs`; keep semantic half pure |
+| Bare `[DatePicker …]` or raw JS head | Not legal | `defhost` (or `[:>]` once available) |
+| SDK mounts twice / leaks | Ref attach without paired teardown | One attach, one cleanup (React 19 return-from-ref) — [Interop](05-interop.md) |
+| Still slow after dropping to React | Wrong layer | Measure again — often the cost is data shape or event volume, not Hiccup |
+
+## When not to go lower
+
+- You have **no profile**, only a feeling.
+- The fix is really **event volume** (e.g. controlling every keystroke on a 100-cell
+  grid) — see [Controlled inputs](04-controlled-inputs.md) when-not.
+- You are about to reimplement the app in hooks "for flexibility" — that is a
+  substrate change, not a Hicasso escape.
+
+## Not settled yet
+
+| Question | Status |
+|---|---|
+| Whether product ever grows a compile / dual-mode path | **Not planned for v0** — single interpreted Hiccup product |
+| `[:>]` availability | Ruled; may lag `defhost` in the experimental arm — [Interop](05-interop.md) |
+| Official "perf island" macro or scaffold | **None** — host edge is plain React + `defview` |
+| How aggressively the guide should show host-edge examples | Open — this page stays the map; depth stays on interop / ephemeral |

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -18,7 +18,7 @@ programmer actually type?**
 | [Testing](08-testing.md) | Assert intents and trees as data today; know when you still need a browser |
 | [When a view throws](09-when-a-view-throws.md) | Keep one broken view from taking the page down with it |
 | [Server-side rendering](10-server-side-rendering.md) | Serve a page rendered from a db snapshot and adopt it live in the browser |
-| [Below Hiccup](11-below-hiccup.md) | When a path is hot: still-Hiccup levers, host-edge React, `defhost` — and what is *not* an escape |
+| [Below Hiccup](11-below-hiccup.md) | 98% of views need no special path; for the ~2%, the ladder down (still Hiccup → host edge → `defhost`) |
 
 ## How to read the markers
 

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -18,6 +18,7 @@ programmer actually type?**
 | [Testing](08-testing.md) | Assert intents and trees as data today; know when you still need a browser |
 | [When a view throws](09-when-a-view-throws.md) | Keep one broken view from taking the page down with it |
 | [Server-side rendering](10-server-side-rendering.md) | Serve a page rendered from a db snapshot and adopt it live in the browser |
+| [Below Hiccup](11-below-hiccup.md) | When a path is hot: still-Hiccup levers, host-edge React, `defhost` — and what is *not* an escape |
 
 ## How to read the markers
 


### PR DESCRIPTION
## Summary

Adds `docs/design/hicasso/draft-guide/11-below-hiccup.md` owned by the product assertion:

> **For about 98% of view code, performance is not an issue.**  
> **For the other ~2%:** measure, then isolate an escape — do not rewrite the product.

The 98/2 split is a **product assertion** (write as if true until a profile proves an island is the exception), not a lab metric.

### Ladder (for the 2%)
1. Still Hiccup (boundaries vs helpers, read placement) — most 'hot' cases die here
2. Host-edge React (hooks/refs islands)
3. `defhost` / `[:>]`
4. Different substrate only as another root

Explicit non-escapes: no compile dual-mode, no bare JS heads, no 'hooks everywhere for the 2%.'

### Wiring
README, getting started (feature map + 98% paragraph), views, interop, ephemeral state.

## Test plan
- [x] `python scripts/check_doc_slugs.py`