### PR TITLE
docs(hicasso): rename Below Hiccup chapter to Performance

### DIFF
--- a/docs/design/hicasso/defhost-ssr-provider-costing.md
+++ b/docs/design/hicasso/defhost-ssr-provider-costing.md
@@ -390,7 +390,7 @@ value" clause, and the operator's first choice is whether they stay in step.
 | `decisions.md` | a **new dated addendum** under HD-011 (the existing one is a dated record and stands as written); optionally the stale HD-020(d) "inert in v0" line |
 | `draft-guide/05-interop.md` | the Defaults table's SSR cell, the Providers section, the "Not settled" row |
 | `draft-guide/10-server-side-rendering.md` | the three-line policy block, the prose under it, the troubleshooting row |
-| `draft-guide/11-below-hiccup.md` | the `:ssr` code sample |
+| `draft-guide/11-performance.md` | the `:ssr` code sample |
 | `studio/raw-escape-spec.md` | the comparison table and R2 |
 | `production-server-arm.md` | the pieces table, and a line-range citation into `codec.cljs` that moves |
 | `EP-0038` | R5's status line |

--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -62,7 +62,7 @@ interpretation, not a better Reagent.*
 Reagent on the important rows — good enough to ship, not a speed-marketing
 product. **For about 98% of view code, performance is not an issue**; for the
 rest, there is a ladder down, not a dual mode
-([Below Hiccup](11-below-hiccup.md)). Prefer Hicasso for **authoring, testing
+([Performance](11-performance.md)). Prefer Hicasso for **authoring, testing
 shape, and re-frame integration**, not for winning a microbenchmark war.
 
 ## What you get (feature map)
@@ -89,7 +89,7 @@ finished product package.
 | **SSR participation** | Same pure bodies + framework hydration; experimental doors exist; production package still open | [Server-side rendering](10-server-side-rendering.md) |
 | **Xray-friendly UI** | UI state in app-db + named events shows up in app-db diffs and time-travel; not a special Hicasso Xray tab | framework Xray + this design |
 | **Performance** | Good / competitive goal vs Reagent; not "fastest UI library" | programme bar, not a guide claim |
-| **Going lower** | ~98% of view code needs nothing special; for the ~2%, a ladder (not a dual mode) | [Below Hiccup](11-below-hiccup.md) |
+| **Going lower** | ~98% of view code needs nothing special; for the ~2%, a ladder (not a dual mode) | [Performance](11-performance.md) |
 
 ## Your first app
 

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -275,7 +275,7 @@ and simpler. Reach for a boundary when you want something to update
 independently, not because the markup got long.
 
 When a measured island is in the **~2%** (cost, host edge, foreign component) —
-not the default 98% — see [Below Hiccup](11-below-hiccup.md).
+not the default 98% — see [Performance](11-performance.md).
 
 ## Advanced
 

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -36,7 +36,7 @@ another view's child.
 
 This page is the **foreign component** door. For the full ladder — still-Hiccup
 perf levers, host-edge hooks/refs, and what is not an escape — see
-[Below Hiccup](11-below-hiccup.md).
+[Performance](11-performance.md).
 
 ## Why declare
 

--- a/docs/design/hicasso/draft-guide/07-ephemeral-state.md
+++ b/docs/design/hicasso/draft-guide/07-ephemeral-state.md
@@ -23,7 +23,7 @@ pixel offset is arithmetic, so it is mechanics.
 A `defview` body is a real React function component. Hooks physically work in it.
 There is no lint police, and if you use one you take on React's hook rules
 yourself — including the loss of headless testability for that body
-([Testing](08-testing.md)). When hooks are for a measured hot path rather than placement, see [Below Hiccup](11-below-hiccup.md).
+([Testing](08-testing.md)). When hooks are for a measured hot path rather than placement, see [Performance](11-performance.md).
 
 ## The order to try
 

--- a/docs/design/hicasso/draft-guide/11-performance.md
+++ b/docs/design/hicasso/draft-guide/11-performance.md
@@ -1,4 +1,4 @@
-# Below Hiccup
+# Performance
 
 > **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Mechanisms are proven under `implementation/freehand/test/re_frame/bench/hicasso/`; product spellings and some call shapes are still settling.
 
@@ -17,7 +17,7 @@ where the pathological witness sat nearer **~1.5×**. So when you *do* optimise,
 you start with **where and how you read**, not with abandoning Hiccup.
 
 **For the other ~2%** — a measured hot path, a third-party React widget, an
-imperative SDK — you *can* go lower. There is **no second mode** that turns
+imperative SDK — you *can* go **below Hiccup**: closer to React, past the pure tier-1 walk, into a foreign component. There is **no second mode** that turns
 interpretation off for the whole app. There **are** deliberate steps down the
 stack. This page is the map for that minority.
 
@@ -41,7 +41,7 @@ You do not need Hicasso-private tooling.
 Name the boundary, the sub, or the event **before** changing architecture.
 "The app is slow" is still the 98% problem in disguise.
 
-## What "lower" is not
+## What "below Hiccup" is not
 
 | Wish | Reality |
 |---|---|
@@ -249,7 +249,7 @@ obviously a foreign/SDK boundary you never expected Hiccup to own.
 | SDK mounts twice / leaks | Ref attach without paired teardown | One attach, one cleanup (React 19 return-from-ref) — [Interop](05-interop.md) |
 | Still slow after dropping to React | Wrong layer | Measure again — often read shape or event volume, not Hiccup |
 
-## When not to go lower
+## When not to go below Hiccup
 
 - You are still in the **98%** — no profile, only a feeling, or a fear of
   interpretation.

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -18,7 +18,7 @@ programmer actually type?**
 | [Testing](08-testing.md) | Assert intents and trees as data today; know when you still need a browser |
 | [When a view throws](09-when-a-view-throws.md) | Keep one broken view from taking the page down with it |
 | [Server-side rendering](10-server-side-rendering.md) | Serve a page rendered from a db snapshot and adopt it live in the browser |
-| [Below Hiccup](11-below-hiccup.md) | 98% of views need no special path; for the ~2%, the ladder down (still Hiccup → host edge → `defhost`) |
+| [Performance](11-performance.md) | 98% of views need no special path; for the ~2%, the ladder down (still Hiccup → host edge → `defhost`) |
 
 ## How to read the markers
 


### PR DESCRIPTION
## Summary

**Rename + link sweep** for the draft-guide performance chapter (from #7515).

| Before | After |
|---|---|
| `11-below-hiccup.md` | `11-performance.md` |
| title `# Below Hiccup` | title `# Performance` |

`below Hiccup` remains the **internal ladder metaphor** on the page (going lower for the ~2%).

### Link sweep (`docs/design/hicasso/`)
Updated every inbound target from PR #7515 wiring:
- `draft-guide/README.md` (index row)
- `01-getting-started.md`
- `02-views-and-reads.md`
- `05-interop.md`
- `07-ephemeral-state.md`

Grep for `below-hiccup` / `11-below-hiccup` / `[Below Hiccup]` under `docs/design/hicasso/` is clean after the sweep.

### Gate
- [x] `python scripts/check_doc_slugs.py` exit 0 (validates these markdown link targets)

## Test plan
- [x] `check_doc_slugs.py`
- [x] grep `docs/design/hicasso` for stale `below-hiccup` paths