### PR TITLE
fix(ssr-ring): the unresolved root form carries no render-hash on the server either (rf2-q1b96)

### DIFF
--- a/implementation/ssr-ring/src/re_frame/ssr/ring.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring.clj
@@ -113,6 +113,23 @@
                       (rf/view :id); a keyword head is an HTML element, never
                       a view — rf2-j81hs)
                       against the settled request frame.
+                      Two spellings emit byte-identical HTML but differ on
+                      the hydration hash channel (rf2-q1b96):
+
+                        (fn [] ((rf/view :app/root)))  ;; resolves → hashed
+                        [(rf/view :app/root)]          ;; a reference → no hash
+
+                      A root that stays a callable-headed vector is the
+                      UNRESOLVED root form; hashing it yields one constant
+                      for every application, so the handler emits no
+                      `data-rf-render-hash` and no payload `:rf/render-hash`
+                      for it. That is the shape an ADOPTION-TIER root
+                      (compiled `re-frame.ui`, native UIx, Freehand) can only
+                      ever be, and Spec 011 §Hydration-mismatch detection
+                      requires it to carry none. A hiccup-tier host that
+                      wants the channel passes the resolving form — the only
+                      one symmetric with the documented client
+                      `:render-tree-fn #((rf/view :app/root))`.
     :payload        — non-empty allowlist of top-level app-db keys, or the
                       explicit `:rf.ssr.payload/whole-app-db` opt-in. Missing
                       and unknown policies fail at handler construction.
@@ -125,7 +142,9 @@
     :ssr            — per-frame `:ssr` config map (e.g.
                       `{:dev-error-detail? true
                         :public-error-id   :myapp/projector}`).
-    :emit-hash?     — emit hydration hash markers (default true).
+    :emit-hash?     — emit hydration hash markers (default true). Gates the
+                      WIRE markers only; the payload's hash keys are driven
+                      by whether a hash exists at all (see `:root-view`).
     :client-frame-id — stable frame id stamped as the payload's WIRE
                       `:rf/frame-id`, when the deployment fixes one both
                       server and client agree on ahead of time. Default

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/lifecycle.clj
@@ -115,7 +115,29 @@
   lookup), so `:root-view [:app/root]` renders an empty `<root>` element
   rather than the application. Prefer the 0-arity fn form when the opts
   map is built before the view is registered, since `(rf/view :id)`
-  resolves where it is written."
+  resolves where it is written.
+
+  **The shape you pick decides whether this request gets a render hash at
+  all** (rf2-q1b96), and that consequence is sharper than the
+  registration-order one above. `render-document-hash` is a PURE
+  structural walk that never expands a callable head, so a root-view that
+  RESOLVES to the callable-headed form — `[(rf/view :id)]`, `[#'app/root]`,
+  `[app {props}]` — hands the hash channel a reference to the page rather
+  than the page. Such a root carries NO hash (see
+  `unresolved-root-form?` / `render-document-hash`). A host that wants the
+  hiccup-tier hash channel must hand over a root that resolves to a DOM-
+  rooted tree, which is the OUTER-CALL fn form:
+
+      :root-view (fn [] ((rf/view :app/root)))   ;; hashable — note the
+                                                 ;; outer call
+      :root-view [(rf/view :app/root)]           ;; renders identically,
+                                                 ;; carries no hash
+
+  Both spellings emit byte-identical HTML; only the first is symmetric
+  with the documented client `:render-tree-fn #((rf/view :app/root))`
+  (Spec 011 §Default flow step 3 — note ITS outer call too), which is the
+  pairing `ring_streaming_test/streaming-final-hash-matches-client-
+  resolved-tree` already pins."
   [root-view]
   (cond
     (vector? root-view) root-view
@@ -173,6 +195,25 @@
          :recovery  :no-recovery})
       {:head-html "" :html-attrs nil :body-attrs nil :head-model nil})))
 
+(defn unresolved-root-form?
+  "True when `root` is the **unresolved root form** — a vector whose head is
+  a CALLABLE (a raw fn, or a Var reference) rather than a DOM-tag keyword.
+  `[(rf/view :app/root)]`, `[#'app/root]` and the adoption tier's
+  `[<component> {props}]` are all this shape.
+
+  Head grammar mirrors the emitter's own dispatch
+  (`re-frame.ssr.emit/emit-element`): a keyword head is a DOM / custom
+  element on every host (rf2-j81hs), so keywords are excluded FIRST; what
+  is left under `ifn?` is exactly fns and Var references, which is how
+  views are referenced. A Var is `ifn?` but NOT `fn?` on the JVM, so the
+  test has to be `ifn?` (rf2-wtd8z finding 2 made the same correction in
+  the emitter)."
+  [root]
+  (boolean
+    (and (vector? root)
+         (let [head (first root)]
+           (and (not (keyword? head)) (ifn? head))))))
+
 (defn render-document-hash
   "The canonical structural hash for the SSR **body** render tree — the
   wire hash carried as the root element's `data-rf-render-hash` marker and
@@ -180,9 +221,51 @@
 
   This channel is body-only because the client hashes the body tree returned
   by its render function. Head divergence uses the separate, reconstructible
-  `:rf/head-hash` channel."
+  `:rf/head-hash` channel.
+
+  **Returns nil — the channel is OMITTED — for the unresolved root form**
+  (rf2-q1b96), the same way `render-head-hash` below omits a head the
+  client cannot reconstruct. `rf/render-tree-hash` is a PURE structural
+  FNV-1a over canonical EDN: it never expands a callable head, and every
+  raw fn serialises to the identity-free token `#fn[]` (a ruled
+  requirement — no fn `.toString` is stable across JVM and CLJS,
+  rf2-jsa2ml). So the hash of a callable-headed root describes the
+  REFERENCE, not the page, and measurably so:
+
+  | resolved root                | canonical EDN     | hash       |
+  |------------------------------|-------------------|------------|
+  | `[(rf/view :anything)]`      | `[#fn[]]`         | `f1d63f7e` |
+  | `[<any component> {}]`       | `[#fn[] {}]`      | `83b865f8` |
+
+  — one constant per arity, identical for every application on earth.
+  Emitting it is worse than emitting nothing, because an absent key cannot
+  be mistaken for evidence while a constant one is a fail-open gate wearing
+  the shape of a check (Spec 011 §Hydration-mismatch detection, \"The
+  server end of the tier rule\"). This is the SERVER half of rf2-2rtt6.91,
+  which omitted the same key on the client.
+
+  **This is the tier discriminator, and it is structural rather than
+  brand-based** — which is what Spec 011 asks for (\"two tiers, keyed by
+  render-tree representation, not by adapter brand\"). The server cannot
+  see which substrate will hydrate its markup, and it does not need to: an
+  adoption-tier root (compiled `re-frame.ui`, native UIx, Freehand) can
+  only ever hand the server the unresolved form, because the tree is walked
+  inside React and no data tree describing the page ever exists on this
+  side. Asking instead whether a hashable data tree is PRESENT answers the
+  tier question wherever the tier question has an answer, and needs no new
+  opt for the host to declare.
+
+  The hiccup tier is bound by the same rule and is the reason it must be a
+  silent omission rather than a thrown error: `[(rf/view :app/root)]` is
+  structurally identical to an adoption-tier root, so nothing here can tell
+  a Reagent host that meant to opt in from a Freehand host that must carry
+  nothing. A hiccup-tier host keeps the channel by handing over a root that
+  RESOLVES — `(fn [] ((rf/view :app/root)))` — which is also the only
+  spelling symmetric with the documented client `:render-tree-fn
+  #((rf/view :app/root))`. See `resolve-root-view`."
   [body-hiccup]
-  (rf/render-tree-hash body-hiccup))
+  (when-not (unresolved-root-form? body-hiccup)
+    (rf/render-tree-hash body-hiccup)))
 
 (defn render-head-hash
   "The canonical structural hash for the CLIENT-RECONSTRUCTIBLE head

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/pipeline.clj
@@ -540,13 +540,20 @@
                              :body-attrs nil}
                             (lifecycle/resolve-head frame-id))
                 ;; Compute the body hash once for both emitted marker and payload.
+                ;; nil for an unresolved root form — that root gets NO hash on
+                ;; either channel (rf2-q1b96; see `render-document-hash`).
                 hash-str  (lifecycle/render-document-hash hiccup)
                 ;; Hash the head model on its separate reconstructible channel.
                 head-hash (lifecycle/render-head-hash (:head-model head-bag))
                 body-html (ssr/render-to-string
                             hiccup
+                            ;; `:emit-hash?` must ALSO fall away with the hash:
+                            ;; `render-to-string` treats a true `:emit-hash?`
+                            ;; with no `:render-hash` as "compute it yourself"
+                            ;; (rf2-atmvj), which would re-stamp the very
+                            ;; constant this root is being spared.
                             {:doctype?    false
-                             :emit-hash?  emit-hash?
+                             :emit-hash?  (and emit-hash? (some? hash-str))
                              :render-hash (when emit-hash? hash-str)})
                 ;; Read after rendering and inside the frame scope. Optional
                 ;; resource projection uses the carried frame to apply derived

--- a/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
+++ b/implementation/ssr-ring/src/re_frame/ssr/ring/streaming.clj
@@ -130,14 +130,18 @@
      :html-attrs    {…} or nil                  ;; stamped on <html>
      :body-attrs    {…} or nil                  ;; stamped on <body>
      :head-hash     \"…\" or nil                  ;; client-reconstructible head-model hash
-     :doc-hash      \"…\"                         ;; BODY-ONLY structural hash
+     :doc-hash      \"…\" or nil                  ;; BODY-ONLY structural hash
      :shell-html    \"…\"                        ;; chunk 1 body
      :continuations [{:id … :subtree …} …]}     ;; drain queue (FIFO)
 
   `:doc-hash` is the body-only structural hash. It
   describes the PRE-drain shell — the exact tree streamed in chunk 1 — and
   drives the streaming root-element `data-rf-render-hash` marker (when
-  `:emit-hash?` is true). `:head-hash` is the SEPARATE client-
+  `:emit-hash?` is true). It is **nil when `:root-view` resolves to the
+  unresolved root form** — that root carries no hash on either channel
+  (rf2-q1b96; see `lifecycle/render-document-hash`), so neither the chunk-1
+  marker nor the final payload's `:rf/render-hash` appears.
+  `:head-hash` is the SEPARATE client-
   reconstructible head-model hash (`lifecycle/render-head-hash` over
   `resolve-head`'s `:head-model`) — nil when the head is not client-
   reconstructible (explicit `:head` string / degraded resolution). The
@@ -278,9 +282,16 @@
                             {:html-attrs  html-attrs
                              :body-attrs  body-attrs
                              ;; Mark the body tree actually streamed in chunk 1.
+                             ;; nil `doc-hash` (an unresolved root form —
+                             ;; rf2-q1b96) omits the marker as well as the
+                             ;; payload key; `default-streaming-prefix` stamps
+                             ;; only from `:render-hash` and never recomputes,
+                             ;; so no `:emit-hash?` gate is needed here.
                              :render-hash (when emit-hash? doc-hash)
-                             ;; Wire hash markers share the emit toggle; payload
-                             ;; hashes remain unconditional.
+                             ;; Wire hash markers share the emit toggle; the
+                             ;; payload's head hash stays unconditional (the
+                             ;; head model is client-reconstructible on every
+                             ;; tier, so it is never degenerate).
                              :head-hash   (when emit-hash? head-hash)})]
       ;; Chunk 1 — shell prefix + shell HTML (with template fallbacks) +
       ;; the app-root close. Stamp the phase before each write
@@ -360,7 +371,11 @@
       ;; shell hash and preserve exactly-once root resolution. The shell marker
       ;; remains pre-drain because it describes chunk 1; the head hash is
       ;; drain-invariant. Server `:root-view` and client `:render-tree-fn` must
-      ;; use symmetric expanded or unexpanded forms.
+      ;; use symmetric EXPANDED forms — `(fn [] ((rf/view :app/root)))` against
+      ;; `#((rf/view :app/root))`. "Symmetric unexpanded" is no longer a second
+      ;; way to agree: both sides would hash the constant `[#fn[]]`, a check
+      ;; that can never fail, so an unexpanded server root now carries no hash
+      ;; at all (rf2-q1b96).
       ;;
       ;; Set phase before both payload construction and its write.
       (vreset! phase [:final-payload nil])

--- a/implementation/ssr-ring/test/re_frame/ssr/ring/render_hash_tier_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring/render_hash_tier_test.clj
@@ -1,0 +1,280 @@
+(ns re-frame.ssr.ring.render-hash-tier-test
+  "rf2-q1b96 — the SERVER end of Spec 011's tier rule for the render-hash
+  channel.
+
+  rf2-2rtt6.91 (PR #7510) closed the CLIENT half: a Freehand root stopped
+  emitting `:rf/render-hash`, because the only tree an adoption-tier root can
+  offer a hash is the unresolved root form `[<component> {props}]`, whose
+  canonical EDN `[#fn[] {props}]` is a constant. Spec 011 §Hydration-mismatch
+  detection now states the rule for both ends: a root that verifies by
+  React-native adoption MUST NOT carry `:rf/render-hash` in its payload nor
+  `data-rf-render-hash` on its root element.
+
+  `ssr-ring` hashed whatever `:root-view` resolved to, for any root shape.
+  These rows pin the repair and, just as importantly, the MEASUREMENT that
+  justifies it — the constants stay reproducible here rather than surviving
+  only in a commit message.
+
+  **The discriminator is structural, not brand-based.** The server cannot see
+  which substrate will hydrate its markup and does not need to: it asks
+  whether a hashable data render-tree is PRESENT at the root. That answers the
+  tier question wherever the tier question has an answer, and it binds the
+  hiccup tier identically — which is why the omission is silent rather than a
+  thrown error. `[(rf/view :app/root)]` and a Freehand `[app {}]` are the same
+  shape; nothing on this side can tell them apart."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.ssr :as ssr]
+            [re-frame.ssr.ring :as ssr-ring]
+            [re-frame.ssr.ring.lifecycle :as lifecycle]
+            [re-frame.ssr.ring.test-support :as ts]))
+
+(use-fixtures :each ts/reset-runtime)
+
+;; ---- extraction helpers ---------------------------------------------------
+
+(defn- payload-edn-of
+  "The `__rf_payload` script body of a rendered document string."
+  [body]
+  (second (re-find #"<script id=\"__rf_payload\"[^>]*>(.*?)</script>" body)))
+
+(defn- payload-render-hash
+  "The payload's `:rf/render-hash`, or nil when the key is absent. Matches the
+  `#:rf{…}` namespace-map shorthand `pr-str` emits too."
+  [body]
+  (when-let [edn (payload-edn-of body)]
+    (second (re-find #":(?:rf/)?render-hash \"([0-9a-f]{8})\"" edn))))
+
+(defn- payload-head-hash [body]
+  (when-let [edn (payload-edn-of body)]
+    (second (re-find #":(?:rf/)?head-hash \"([0-9a-f]{8})\"" edn))))
+
+(defn- wire-render-hash [body]
+  (second (re-find #"data-rf-render-hash=\"([0-9a-f]{8})\"" body)))
+
+(defn- drain-stream
+  "Read a streaming Ring body (an InputStream) to a String."
+  [body]
+  (if (string? body)
+    body
+    (with-open [in body]
+      (slurp in))))
+
+(defn- get-request [] {:uri "/" :request-method :get})
+
+;; ---- the app under test ---------------------------------------------------
+
+(defn- register-app! []
+  (rf/reg-event :rf.test.q1b96/init
+    {:platforms #{:server}}
+    (fn [_ _] {:db {:heading "Tier"}}))
+  (rf/reg-sub :q1b96/heading (fn [db _] (:heading db)))
+  (rf/reg-view* :q1b96/root
+    (fn []
+      (let [h (rf/subscribe-once [:q1b96/heading])]
+        [:main.page [:h1 h] [:p "body"]]))))
+
+;; ===========================================================================
+;; unresolved-root-form? — the discriminator itself
+;; ===========================================================================
+
+(defn- a-component [_props] [:div "a"])
+(defn- b-component [_props] [:section [:h2 "b"] [:p "different shape entirely"]])
+
+(deftest unresolved-root-form-recognises-callable-heads
+  (testing "rf2-q1b96: a vector whose head is a callable — a raw fn, a Var
+            reference, or `(rf/view :id)` — is the UNRESOLVED root form"
+    (register-app!)
+    (is (true? (lifecycle/unresolved-root-form? [(rf/view :q1b96/root)]))
+        "a registered-view reference is a reference, not a tree")
+    (is (true? (lifecycle/unresolved-root-form? [#'a-component]))
+        "a Var head too — a Var is `ifn?` but NOT `fn?` on the JVM, so the
+         test cannot be `fn?` (rf2-wtd8z finding 2 made the same correction
+         in the emitter)")
+    (is (true? (lifecycle/unresolved-root-form? [a-component {}]))
+        "the adoption tier's `[<component> {props}]` shape")))
+
+(deftest unresolved-root-form-excludes-real-render-trees
+  (testing "rf2-q1b96: keyword heads are DOM / custom elements on every host
+            (rf2-j81hs), so a keyword-headed vector is a real render tree —
+            and so is anything that is not a callable-headed vector"
+    (is (false? (lifecycle/unresolved-root-form? [:div.page [:h1 "x"]]))
+        "an ordinary DOM root")
+    (is (false? (lifecycle/unresolved-root-form? [:<> [:div "a"] [:div "b"]]))
+        "a fragment root — Spec 011 threads the marker through it onto the
+         first DOM child, so it must stay hashable")
+    (is (false? (lifecycle/unresolved-root-form? (list [:div "x"])))
+        "a lazy-seq / list root is threaded through likewise (rf2-a73idu)")
+    (is (false? (lifecycle/unresolved-root-form? []))
+        "an empty vector has no head to be callable")
+    (is (false? (lifecycle/unresolved-root-form? "just text")))
+    (is (false? (lifecycle/unresolved-root-form? nil)))))
+
+;; ===========================================================================
+;; The measurement — why a degenerate value is worse than an absent one
+;; ===========================================================================
+
+(deftest the-hash-an-unresolved-root-would-have-had-is-a-constant
+  (testing "rf2-q1b96 / rf2-2rtt6.91: hashing an unresolved root yields ONE
+            constant per arity, identical for every application — because
+            `render-tree-hash` is a pure structural walk that never expands a
+            callable head, and every raw fn serialises to the identity-free
+            token `#fn[]` (a ruled requirement: no fn `.toString` is stable
+            across JVM and CLJS — rf2-jsa2ml). Kept measured here so the
+            figures behind the repair stay reproducible."
+    (register-app!)
+    (rf/reg-view* :q1b96/other (fn [] [:aside "nothing like the other one"]))
+
+    ;; Arity 1 — `[<callable>]`, the shape `:root-view [(rf/view :id)]` takes.
+    (is (= "f1d63f7e"
+           (ssr/render-tree-hash [(rf/view :q1b96/root)])
+           (ssr/render-tree-hash [(rf/view :q1b96/other)]))
+        "two unrelated views hash IDENTICALLY as [#fn[]]")
+
+    ;; Arity 2 — `[<component> {props}]`, the adoption tier's root form. This
+    ;; is the same 83b865f8 rf2-2rtt6.91 measured on the Freehand bench.
+    (is (= "83b865f8"
+           (ssr/render-tree-hash [a-component {}])
+           (ssr/render-tree-hash [b-component {}]))
+        "two entirely different screens hash IDENTICALLY as [#fn[] {}] — a
+         client comparing that value would find the server agreed with it
+         about two different pages")
+
+    ;; The non-vacuity control: a real DOM-rooted tree does discriminate.
+    (is (not= (ssr/render-tree-hash [:div "a"])
+              (ssr/render-tree-hash [:div "b"]))
+        "a genuine render tree hashes differently for different content")))
+
+(deftest render-document-hash-omits-the-unresolved-root-form
+  (testing "rf2-q1b96: `render-document-hash` returns nil for the unresolved
+            root form — the same OMIT-rather-than-ship shape `render-head-hash`
+            already uses for a head the client cannot reconstruct"
+    (register-app!)
+    (is (nil? (lifecycle/render-document-hash [(rf/view :q1b96/root)])))
+    (is (nil? (lifecycle/render-document-hash [a-component {}])))
+    (is (some? (lifecycle/render-document-hash ((rf/view :q1b96/root))))
+        "the RESOLVED tree still hashes — the channel is not disabled, it is
+         conditioned on a hashable tree existing")))
+
+;; ===========================================================================
+;; ssr-handler — the wire
+;; ===========================================================================
+
+(deftest an-unresolved-root-view-ships-no-render-hash
+  (testing "rf2-q1b96: `:root-view [(rf/view :id)]` → NO data-rf-render-hash
+            on the root element and NO :rf/render-hash key in the payload,
+            even under the default `:emit-hash? true`"
+    (register-app!)
+    (let [handler (ssr-ring/ssr-handler
+                    {:initial-events [[:rf.test.q1b96/init]]
+                     :root-view      [(rf/view :q1b96/root)]
+                     :payload        :rf.ssr.payload/whole-app-db})
+          body    (:body (handler (get-request)))]
+      (is (str/includes? body "<h1>Tier</h1>")
+          "the page still renders — only the hash channel is affected")
+      (is (nil? (wire-render-hash body))
+          "no data-rf-render-hash marker")
+      (is (not (str/includes? body "render-hash"))
+          "the payload omits the KEY rather than stamping a nil: Spec-Schemas
+           types the slot `{:optional true} :string`, not `[:maybe :string]`,
+           so a present-and-nil key is not a legal spelling of absence")
+      (is (some? (payload-head-hash body))
+          "the SEPARATE head channel is untouched — the head model is
+           client-reconstructible on every tier via `active-head`, so it is
+           never degenerate and never omitted for tier reasons")
+      (is (str/includes? body "data-rf-head-hash")
+          "and its wire marker rides too"))))
+
+(deftest an-adoption-tier-root-form-ships-no-render-hash
+  (testing "rf2-q1b96: the `[<component> {props}]` root shape — what a
+            compiled `re-frame.ui`, native UIx, or Freehand root can only ever
+            be — carries no hash on either channel. This is the trap the bead
+            was filed for: nothing serves such a root through ssr-ring today,
+            so the first server arm that does must not re-create the fail-open
+            gate rf2-2rtt6.91 closed on the client."
+    (rf/reg-event :rf.test.q1b96/init {:platforms #{:server}} (fn [_ _] {:db {}}))
+    (let [handler (ssr-ring/ssr-handler
+                    {:initial-events [[:rf.test.q1b96/init]]
+                     :root-view      [a-component {}]
+                     :payload        :rf.ssr.payload/whole-app-db})
+          body    (:body (handler (get-request)))]
+      (is (str/includes? body "<div>a</div>") "the component still renders")
+      (is (nil? (wire-render-hash body)))
+      (is (not (str/includes? body "render-hash"))))))
+
+(deftest a-resolving-root-view-keeps-the-hash-channel
+  (testing "rf2-q1b96: the repair conditions the channel, it does not remove
+            it. A `:root-view` that RESOLVES to a DOM-rooted tree still
+            carries the hash — and that hash EQUALS the one the documented
+            client `:render-tree-fn #((rf/view :id))` computes, which the
+            unresolved form never could."
+    (register-app!)
+    (let [handler (ssr-ring/ssr-handler
+                    {:initial-events [[:rf.test.q1b96/init]]
+                     ;; Note the OUTER call, mirroring the client's `#(…)`.
+                     :root-view      (fn [] ((rf/view :q1b96/root)))
+                     :payload        :rf.ssr.payload/whole-app-db})
+          body    (:body (handler (get-request)))
+          wire    (wire-render-hash body)
+          shipped (payload-render-hash body)]
+      (is (some? wire) "the marker is stamped on the root element")
+      (is (some? shipped) "the payload carries :rf/render-hash")
+      (is (= wire shipped) "wire marker == payload key (one canonical hash)")
+      (is (not= "f1d63f7e" shipped)
+          "and it is not the unresolved-root constant"))))
+
+(deftest the-surviving-hash-matches-the-documented-client-tree
+  (testing "rf2-q1b96: the load-bearing equality. Server `:root-view
+            (fn [] ((rf/view :id)))` hashes the same tree the client's
+            `:render-tree-fn #((rf/view :id))` does. The unresolved server
+            form could never match it — it hashes `[#fn[]]` while the client
+            hashes the tree — so before this repair the documented pairing
+            mismatched on EVERY page while emitting byte-identical HTML."
+    (register-app!)
+    (let [fid (keyword "rf.frame" (str (gensym "q1b96")))]
+      (rf/make-frame {:id fid :platform :server
+                      :initial-events [[:rf.test.q1b96/init]]})
+      (try
+        (rf/with-frame fid
+          (let [server-resolved   (lifecycle/resolve-root-view
+                                    (fn [] ((rf/view :q1b96/root))))
+                server-unresolved (lifecycle/resolve-root-view
+                                    [(rf/view :q1b96/root)])
+                client-tree       ((rf/view :q1b96/root))]
+            (is (= (lifecycle/render-document-hash server-resolved)
+                   (ssr/render-tree-hash client-tree))
+                "resolving server root == client `#((rf/view :id))` hash")
+            (is (nil? (lifecycle/render-document-hash server-unresolved))
+                "the unresolved form now carries nothing rather than a
+                 never-matching constant")
+            (is (= (ssr/render-to-string server-resolved {})
+                   (ssr/render-to-string server-unresolved {}))
+                "both spellings emit byte-identical HTML — the choice is
+                 invisible on the page and decisive on the hash channel,
+                 which is why `resolve-root-view`'s docstring now says so")))
+        (finally (rf/destroy-frame! fid))))))
+
+;; ===========================================================================
+;; stream-handler — the same rule on the chunked path
+;; ===========================================================================
+
+(deftest streaming-unresolved-root-view-ships-no-render-hash
+  (testing "rf2-q1b96: `stream-handler` reaches the same answer — no
+            data-rf-render-hash on the streamed #app root and no
+            :rf/render-hash in the final payload. The streaming prefix stamps
+            only from `:render-hash` and never recomputes, so a nil hash is
+            enough there; only the non-streaming call site also had to drop
+            `:emit-hash?` (`render-to-string` reads a true `:emit-hash?` with
+            no supplied hash as 'compute it yourself' — rf2-atmvj)."
+    (register-app!)
+    (let [handler (ssr-ring/stream-handler
+                    {:initial-events [[:rf.test.q1b96/init]]
+                     :root-view      [(rf/view :q1b96/root)]
+                     :payload        :rf.ssr.payload/whole-app-db})
+          body    (drain-stream (:body (handler (get-request))))]
+      (is (str/includes? body "<h1>Tier</h1>") "the shell still streams")
+      (is (nil? (wire-render-hash body)))
+      (is (nil? (payload-render-hash body)))
+      (is (some? (payload-head-hash body))
+          "the separate head channel survives on the streamed payload too"))))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_e2e_validator_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_e2e_validator_test.clj
@@ -404,7 +404,11 @@
 
     (let [handler (ssr-ring/ssr-handler
                     {:initial-events [[:init/ok]]
-                     :root-view [(rf/view :pages/greeting)]
+                     ;; rf2-q1b96 — the RESOLVING root-view form. The
+                     ;; data-rf-render-hash assertion below is what forces
+                     ;; it: `[(rf/view :pages/greeting)]` renders the same
+                     ;; bytes but carries no hash on either channel.
+                     :root-view (fn [] ((rf/view :pages/greeting)))
                      :payload :rf.ssr.payload/whole-app-db})]
       (ts/with-jetty [port handler]
         (let [{:keys [status body headers]} (http-get port "/")]

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_streaming_test.clj
@@ -1211,7 +1211,9 @@
     (let [mk      (fn [head]
                     (ssr-ring/stream-handler
                       {:initial-events [[:rf.test.server/init]]
-                       :root-view [(rf/view :test/root)]
+                       ;; rf2-q1b96 — resolving form; the body-only-hash
+                       ;; assertions below need a hash to exist.
+                       :root-view (fn [] ((rf/view :test/root)))
                        :head      head
                        :payload   :rf.ssr.payload/whole-app-db}))
           body-a  (drain-stream (:body ((mk "<title>Alpha</title>")
@@ -1251,7 +1253,9 @@
     (let [mk      (fn [init]
                     (ssr-ring/stream-handler
                       {:initial-events [[:rf.test.server/init] [init]]
-                       :root-view [(rf/view :test/root)]
+                       ;; rf2-q1b96 — resolving form: `(= ha hb)` below would
+                       ;; hold vacuously (nil = nil) on an unresolved root.
+                       :root-view (fn [] ((rf/view :test/root)))
                        :payload   :rf.ssr.payload/whole-app-db}))
           body-a  (drain-stream (:body ((mk :test.stream/seed-head-a)
                                         {:uri "/" :request-method :get})))
@@ -1263,6 +1267,10 @@
           head-hb (stream-payload-head-hash body-b)]
       (is (str/includes? body-a "<title>Stream head A</title>"))
       (is (str/includes? body-b "<title>Stream head B</title>"))
+      ;; rf2-q1b96 — assert PRESENCE before equality. With the pre-fix
+      ;; unresolved `:root-view` this equality held vacuously as nil = nil.
+      (is (some? ha) "render A carries :rf/render-hash")
+      (is (some? hb) "render B carries :rf/render-hash")
       (is (= ha hb)
           "rf2-1oxjxk: different reg-head title (identical body) → SAME
            streamed :rf/render-hash (body-only)")
@@ -1282,7 +1290,9 @@
             with no explicit :head/:reg-head)."
     (let [handler  (ssr-ring/stream-handler
                      {:initial-events  [[:rf.test.server/init]]
-                      :root-view  [(rf/view :test/root)]
+                      ;; rf2-q1b96 — resolving form; an unresolved root
+                      ;; carries no hash on either channel.
+                      :root-view  (fn [] ((rf/view :test/root)))
                       :emit-hash? true
                       :payload    :rf.ssr.payload/whole-app-db})
           body     (drain-stream (:body (handler {:uri "/" :request-method :get})))
@@ -1313,7 +1323,11 @@
             wire (it was a no-op for the HTML path before)."
     (let [handler  (ssr-ring/stream-handler
                      {:initial-events  [[:rf.test.server/init]]
-                      :root-view  [(rf/view :test/root)]
+                      ;; rf2-q1b96 — resolving form, so this test still
+                      ;; isolates the `:emit-hash?` toggle: the payload keys
+                      ;; below are present BECAUSE a hash exists, proving the
+                      ;; opt gates the wire markers and nothing else.
+                      :root-view  (fn [] ((rf/view :test/root)))
                       :emit-hash? false
                       :payload    :rf.ssr.payload/whole-app-db})
           body     (drain-stream (:body (handler {:uri "/" :request-method :get})))]
@@ -1509,7 +1523,10 @@
     (let [counter   (atom 0)
           handler   (ssr-ring/stream-handler
                       {:initial-events [[:rf.test/init-noni]]
-                       :root-view (fn [] [(rf/view :pages/stream-noni) (swap! counter inc)])
+                       ;; rf2-q1b96 — outer call: RESOLVES the view instead of
+                       ;; handing back a reference, so a hash exists at all.
+                       ;; Still non-idempotent and still one invocation.
+                       :root-view (fn [] ((rf/view :pages/stream-noni) (swap! counter inc)))
                        :payload   :rf.ssr.payload/whole-app-db})
           response  (handler {:uri "/" :request-method :get})
           body      (drain-stream (:body response))

--- a/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
+++ b/implementation/ssr-ring/test/re_frame/ssr/ring_test.clj
@@ -355,8 +355,12 @@
                              {:id "b" :title "Article B"}])
 
     (let [handler (ssr-ring/ssr-handler
+                    ;; rf2-q1b96 — the RESOLVING root-view form. The hash
+                    ;; assertion below is what forces it: an unresolved
+                    ;; `[(rf/view :pages/articles)]` renders byte-identical
+                    ;; HTML but carries no hash on either channel.
                     {:initial-events    [[:rf/server-init]]
-                     :root-view    [(rf/view :pages/articles)]
+                     :root-view    (fn [] ((rf/view :pages/articles)))
                      :fx-overrides {:http/get :http/get.canned}
                      :payload :rf.ssr.payload/whole-app-db})
           request {:uri            "/articles"
@@ -788,8 +792,13 @@
 
       (let [handler  (ssr-ring/ssr-handler
                        {:initial-events [[:init/ok-noni]]
+                        ;; rf2-q1b96 — outer call: the fn RESOLVES the view
+                        ;; rather than handing back a reference to it, so the
+                        ;; hash channel exists at all. Still non-idempotent
+                        ;; (the counter rides into the tree) and still exactly
+                        ;; one invocation, which is what rf2-6t36h pins.
                         :root-view (fn []
-                                     [(rf/view :pages/noni) (swap! counter inc)])
+                                     ((rf/view :pages/noni) (swap! counter inc)))
                         :payload :rf.ssr.payload/whole-app-db})
             response (handler {:uri "/noni" :request-method :get})
             body     (:body response)
@@ -883,7 +892,9 @@
     (let [mk      (fn [head]
                     (ssr-ring/ssr-handler
                       {:initial-events [[:init/noop-head]]
-                       :root-view [(rf/view :pages/fixed-body)]
+                       ;; rf2-q1b96 — resolving form; the body-only-hash
+                       ;; assertions below need a hash to exist.
+                       :root-view (fn [] ((rf/view :pages/fixed-body)))
                        :head      head
                        :payload   :rf.ssr.payload/whole-app-db}))
           body-a  (:body ((mk "<title>Alpha</title>") {:uri "/" :request-method :get}))


### PR DESCRIPTION
Closes rf2-q1b96. Gates in progress — body updated before review.