### PR TITLE
feat(hicasso): h/frame, and a carry is pinned under refusal (rf2-841vn, rf2-hnrww)

### DIFF
--- a/docs/design/hicasso/studio/hframe-design.md
+++ b/docs/design/hicasso/studio/hframe-design.md
@@ -235,6 +235,73 @@ The contrast still holds; its explanation changed.
 
 ---
 
+## 8a. What was actually built (`rf2-841vn`)
+
+`(h/frame)` is `intent/hframe` in `front/intent.cljs` — the var's own namespace,
+the first home §10 offers. Spelled `hframe` for the reason `lang/hfn` is spelled
+`hfn`: the product name is qualified, and a bare `frame` would shadow the
+`re-frame.frame` alias every namespace in this arm carries. No core edits, no
+codec/shell/collector changes, no new React hook.
+
+**W10 was inverted, and here is what the row now asserts.** `(rf/capture-frame)`
+0-arity inside a body refuses, with `:operation :capture-frame`,
+`:substrate :hicasso` and `:extent 'hicasso/boundary-render`. The *"under every
+adapter"* half is settled **structurally rather than by trying adapters** — Spec
+006 allows one substrate per process, so a row that tried three would still not
+be the claim. Instead the `:adapter/current-frame` hook is wrapped with a counter:
+inside a refused body it is reached **zero** times, and a control one call outside
+the body proves it is reached there. The only part of the resolution chain that
+differs between adapters is the tier that is withdrawn, so no adapter can change
+the answer. The rows live with their siblings in `arm1/ambient_refusal_cljs_test`,
+because a carry refusing is a fact about the refusal (`rf2-hnrww`) rather than
+about this primitive.
+
+**The error id is `:rf.error/hicasso-frame-outside-boundary`** — §9's
+recommendation, matching the arm's `:rf.error/hicasso-intent-outside-boundary`.
+Confirming it against Spec 009 was the instruction, and the answer is that **no
+Hicasso arm error id is catalogued there**: `git grep 'rf.error/hicasso' -- spec/`
+is empty, which is what HD-017's bench-lane residence implies. So no catalogue
+row is owed, and the question reopens if and when the arm graduates.
+
+**The provisional id did not leak.** `:rf.error/ambient-frame-refused` is written
+in exactly one place in the new work — nowhere. The carry rows pin *"the same id
+an ambient read gets"*, taken live from a sibling row, so `rf2-k0rbk`'s rename
+touches the one pre-existing anchor rather than five new sites.
+
+**W7 could not be built, and it is not a shortfall.** The row needs the `[:>]`
+value-first door; `front/codec.cljs` says at the site that the raw escape *"stays
+unbuilt here, deliberately"*, so a witness would have had to mint its own
+`[:>]`-shaped thing and would then be witnessing the test's construction.
+Filed as `rf2-zllp8` against whichever bead ships the escape. Everything W7
+depends on is pinned elsewhere — the composition firing after the extent unwinds,
+and `(h/frame)` answering the supplying boundary inside a render callback, which
+is the closest live analogue of a foreign value-first invoker.
+
+**One new finding, pinned but not endorsed.** The refusal withdraws the ambient
+find and never the carrying — so an enclosing `rf/with-frame` still answers
+inside a body, and `(rf/capture-frame)` there captures the **outer scope's**
+frame while the boundary renders a different one. Core is correct per EP-0002:
+that stamp *was* carried. But the same body's collector reads and lowered intents
+all target the boundary's frame, so one body ends up with two frames selected by
+which spelling the author reached for. `(rf/capture-frame (h/frame))` is immune,
+which is the sharpest available statement of what §2(3) buys. The design question
+is `rf2-nqj22`. It is also how the SSR rows were grounded: the shared test fixture
+root-binds `*current-frame*` to `:rf/default`, so the SSR witnesses opt out with
+`:ambient-frame nil` rather than measure the fixture.
+
+**Spec 009's catalogue row for the refusal is behind the code** — it enumerates
+`:operation` as `(:dispatch / :subscribe)`, and at least `:capture-frame` and
+`:current-frame-id` also reach `require-current-frame!`. Filed as `rf2-e28wl`,
+to sequence with `rf2-k0rbk`.
+
+**The guide half is still owed.** §10's guide bullet was fenced out of the
+implementation PR — a rename was landing in `draft-guide/` at the time — so the
+fx-first troubleshooting row, the contract-force sentence, and the `[:>]`
+dev-warning's "plain closure" spelling have not been written. The last of those
+is blocked on `[:>]` in any case (`rf2-zllp8`).
+
+---
+
 ## 9. What is NOT settled here — flagged for a ruling
 
 1. **The error id.** The design pass proposed

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/ambient_refusal_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/ambient_refusal_cljs_test.cljs
@@ -34,14 +34,24 @@
   where `cljs.test` cannot see it, and a row that cannot see its own
   exception is a row that cannot go red. The real-React half — the
   adapter island rendering under a Hicasso tree, which must keep its
-  ambient resolution — is `arm1/ambient_refusal_dom_cljs_test`."
+  ambient resolution — is `arm1/ambient_refusal_dom_cljs_test`.
+
+  THE DOOR HAS THREE CONSUMERS AND THIS FILE ONCE COVERED TWO
+  (rf2-hnrww). Ambient `subscribe`, ambient `dispatch` — and
+  `rf/capture-frame`, Spec 002's *one public carry primitive*, whose
+  0-arity resolves ambiently because it means to CAPTURE rather than to
+  read or to dispatch. Its behaviour inside a body was a consequence of
+  the refusal rather than a contract; the closing section below makes it
+  one, together with each legitimate carry spelling proved individually."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.adapter.context :as adapter-context]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.intent :as intent]
             [re-frame.core :as rf]
             [re-frame.error-emit :as error-emit]
             [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
             [re-frame.live-frame :as live-frame]
             [re-frame.test-support :as test-support]))
 
@@ -284,3 +294,147 @@
         (fn [] (rf/with-frame f
                  (is (= f (frame/resolve-current-frame))
                      "tier 1 still wins over tier 2")))))))
+
+;; ---------------------------------------------------------------------------
+;; THE CARRY — the door's THIRD consumer (rf2-hnrww; the design's W10,
+;; INVERTED)
+;; ---------------------------------------------------------------------------
+;;
+;; THE ROW PLANNED HERE SAID THE OPPOSITE, and that is worth recording
+;; rather than quietly fixing. rf2-2rtt6.118's witness list pinned "the
+;; accidental door": 0-arity `rf/capture-frame` inside a Hicasso body
+;; SUCCEEDS on the dominant configurations — through the raw React-context
+;; read the UIx and Freehand adapters publish — recorded so that a future
+;; change to the accident would be seen rather than silent.
+;; **rf2-2rtt6.122 IS that change.** Built as designed, the row would
+;; assert a behaviour the tree no longer has, so it is inverted: the carry
+;; refuses, and each spelling that still carries is proved on its own.
+;;
+;; THE ERROR ID IS NOT REPEATED IN THESE ROWS, deliberately.
+;; `:rf.error/ambient-frame-refused` is PROVISIONAL (rf2-k0rbk may rename
+;; it), so a carry's refusal is pinned as *the same id an ambient read
+;; gets*, taken live from [[refusal-id]]. The literal is anchored ONCE in
+;; this file — by `ambient-subscribe-inside-a-body-refuses-by-name` above —
+;; so a rename touches one row rather than five, and these rows go on
+;; saying the thing that is actually interesting: that a carry and a read
+;; refuse identically.
+
+(defn- refusal-id
+  "The id core raises for an ambient READ refused inside a body. Taken
+  live, so it is the anchor rather than a second copy of the spelling."
+  [f]
+  (:rf.error/id
+    (outcome #(rt/render-body f (fn [_] @(rf/subscribe [:rt122/v]) [:li]) {}))))
+
+(deftest a-carry-inside-a-body-refuses-exactly-as-a-read-does
+  (testing "`(rf/capture-frame)` in a body is the platform keystone
+           resolving ambiently, so the extent refuses it — under the same
+           context publication that makes the read rows non-vacuous, and
+           with the operation naming the carry rather than a read"
+    (let [f (make-frame!)]
+      (with-context-frame f
+        (fn []
+          (let [data (outcome #(rt/render-body f (fn [_] (rf/capture-frame) [:li]) {}))]
+            (is (= (refusal-id f) (:rf.error/id data))
+                (str "a carry must refuse with the SAME id a read does; got "
+                     (pr-str data)))
+            (is (= :capture-frame (:operation data))
+                "and the payload must say which door was tried, or the advice
+                 cannot be read against the right recovery")
+            (is (= :hicasso (:substrate data)))
+            (is (= 'hicasso/boundary-render (:extent data)))
+            (is (= 're-frame.core/capture-frame (:where data)))))))))
+
+(deftest the-refusal-never-consults-the-adapter-which-is-why-it-is-adapter-independent
+  (testing "the claim 'it refuses under EVERY adapter' cannot be settled by
+           trying adapters — Spec 006 allows one per process. It is settled
+           structurally: under refusal the resolver collapses to the CARRIED
+           tier, which is exactly the `:clj` branch, so the
+           `:adapter/current-frame` hook — the only part of the chain that
+           differs between adapters — is not reached at all. Counted here
+           rather than reasoned about"
+    (let [f        (make-frame!)
+          original (late-bind/get-fn :adapter/current-frame)
+          calls    (volatile! 0)]
+      (is (some? original)
+          "precondition: an adapter has published the hook, so a zero below
+           means 'not consulted' rather than 'nothing to consult'")
+      (late-bind/set-fn! :adapter/current-frame
+                         (fn [] (vswap! calls inc) (original)))
+      (try
+        (with-context-frame f
+          (fn []
+            (vreset! calls 0)
+            (outcome #(rt/render-body f (fn [_] (rf/capture-frame) [:li]) {}))
+            (is (zero? @calls)
+                "the refused carry never asked the adapter")
+
+            (vreset! calls 0)
+            (is (= f (frame/resolve-current-frame))
+                "control: one call outside the body")
+            (is (pos? @calls)
+                "and THAT read did ask it — so the zero above is the tier
+                 being withdrawn, not a hook that is never called")))
+        (finally (late-bind/set-fn! :adapter/current-frame original))))))
+
+(deftest the-refusal-tells-a-carry-what-to-write
+  (testing "rf2-hnrww's first half. The advice was written for a read and a
+           dispatch — 'read through the collector, dispatch through an
+           intent' — and an author who arrived through `rf/capture-frame`
+           is doing neither, so it named nothing they could write. A carry
+           is a third thing and the sentence has to say so"
+    (let [f (make-frame!)]
+      (with-context-frame f
+        (fn []
+          (let [data   (outcome #(rt/render-body f (fn [_] (rf/capture-frame) [:li]) {}))
+                reason (:reason data)]
+            (is (string? reason))
+            (is (re-find #"CARRYING" reason)
+                "the third door is named as a third door")
+            (is (re-find #"capture-frame <frame-id>" reason)
+                "and the 1-arity — the spelling that never consults the
+                 resolver — is the recovery it points at")
+            (is (re-find #"\(rf/capture-frame \(h/frame\)\)" reason)
+                "with the composed spelling written out, which is the
+                 sentence an author can paste")))))))
+
+;; ---------------------------------------------------------------------------
+;; The legitimate CARRY positions, each proven on its own
+;; ---------------------------------------------------------------------------
+
+(deftest the-one-arity-carry-still-carries-inside-a-body
+  (testing "`(rf/capture-frame <id>)` never consults the resolver, so the
+           refusal cannot touch it. That is the honest recovery available
+           to an author who already knows the id, and it is asserted all
+           the way through to a dispatch that lands after the extent is
+           gone — a capture that merely constructed would prove nothing"
+    (let [f    (make-frame!)
+          held (volatile! nil)]
+      (with-context-frame f
+        (fn []
+          (rt/render-body f (fn [_] (vreset! held (rf/capture-frame f)) [:li]) {})))
+      (is (= f (:frame @held)))
+      (is (nil? frame/*ambient-frame-refusal*) "the extent has unwound")
+      ((:dispatch-sync @held) [:rt122/bump])
+      (is (= 8 @(rf/subscribe [:rt122/v] {:frame f}))
+          "the carried api dispatched into its own frame"))))
+
+(deftest the-composed-carry-is-refusal-immune
+  (testing "the ruled spelling — `(rf/capture-frame (h/frame))`. It is the
+           answer for the author the 1-arity cannot serve: a reusable view
+           mounted under N frames, which does not know its own id. `h/frame`
+           supplies the id the carrying spellings presuppose, and it reads
+           the arm's own binding rather than core's chain, so the
+           composition never reaches the refused tier at all"
+    (let [f    (make-frame!)
+          held (volatile! nil)]
+      (with-context-frame f
+        (fn []
+          (rt/render-body f
+                          (fn [_]
+                            (vreset! held (rf/capture-frame (intent/hframe)))
+                            [:li])
+                          {})))
+      (is (= f (:frame @held)))
+      ((:dispatch-sync @held) [:rt122/bump])
+      (is (= 8 @(rf/subscribe [:rt122/v] {:frame f}))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/hframe_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/hframe_cljs_test.cljs
@@ -275,6 +275,48 @@
             "frames are isolated contexts — the sibling must not have moved")))))
 
 ;; ---------------------------------------------------------------------------
+;; The one configuration where the ambient carry still answers — and
+;; answers the WRONG frame
+;; ---------------------------------------------------------------------------
+
+(deftest a-carried-outer-scope-makes-the-ambient-carry-answer-the-wrong-frame
+  (frames!)
+  (testing "FOUND while grounding the SSR rows, and pinned because it is
+           the residual case the whole primitive is for. rf2-2rtt6.122's
+           refusal withdraws the ambient FIND and never the CARRYING, so a
+           tier-1 stamp — an enclosing `rf/with-frame` — still answers
+           inside a body. Core is behaving exactly as EP-0002 specifies:
+           frame identity is carried, and that stamp WAS carried.
+
+           But the boundary is rendering under a different frame, and
+           everything else in the body targets THAT one: the collector's
+           reads, the lowered intents, the presence tray. So one body ends
+           up with two frames depending on which spelling the author
+           reached for, and the ambient one is silently the outer scope's.
+
+           `(rf/capture-frame (h/frame))` is immune, because `h/frame`
+           reads the boundary's own binding. Behaviour is PINNED here, not
+           endorsed — whether the refusal should also withdraw a MISMATCHED
+           carried stamp inside a substrate render extent is a design
+           question filed separately (rf2-nqj22)"
+    (let [seen (volatile! ::unset)]
+      (rf/with-frame frame-b
+        (rt/render-body frame-a
+                        (fn [_]
+                          (vreset! seen {:ambient  (rf/capture-frame)
+                                         :composed (rf/capture-frame (intent/hframe))
+                                         :hframe   (intent/hframe)})
+                          [:li])
+                        {}))
+      (is (= frame-b (:frame (:ambient @seen)))
+          "the ambient carry answered the ENCLOSING scope, not the boundary")
+      (is (= frame-a (:hframe @seen))
+          "while the boundary is unambiguously rendering under its own frame")
+      (is (= frame-a (:frame (:composed @seen)))
+          "and the composed spelling carries the boundary's — which is the
+           whole of what `h/frame` buys here"))))
+
+;; ---------------------------------------------------------------------------
 ;; W9 — an event-time read is not silently wrong
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/hframe_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/hframe_cljs_test.cljs
@@ -1,0 +1,308 @@
+(ns re-frame.bench.hicasso.arm1.hframe-cljs-test
+  "`h/frame` — THE AUTHOR-FACING FRAME READ (rf2-841vn).
+
+  The design is tracked at `docs/design/hicasso/studio/hframe-design.md`,
+  ruled BUILD. This file is its node half: everything the primitive does
+  that is not React's is answerable here, and the `-dom` sibling
+  (`arm1/hframe_dom_cljs_test`) then proves React drives *this* seam
+  rather than re-proving what the seam does.
+
+  ## The one thing worth saying about why these rows are not vacuous
+
+  Two of them are claims of ABSENCE — that `h/frame` is not a tracked
+  read, and that it never enters core's ambient resolution chain — and an
+  absence proved by a green row that would have been green anyway is not
+  proof. So each is paired with the positive reading that would have
+  moved: [[the-frame-read-registers-no-edge]] takes the read set of a body
+  that reads a subscription and shows adding `h/frame` leaves it
+  identical, and [[the-frame-read-does-not-go-through-cores-ambient-chain]]
+  asserts core's own resolver answering **nil** in the very extent where
+  `h/frame` answers — which is the refusal (rf2-2rtt6.122) doing its job
+  one line away from the value being read.
+
+  The CARRY under refusal — `rf/capture-frame` inside a body — lives with
+  its siblings in `arm1/ambient_refusal_cljs_test`, because it is a fact
+  about the refusal rather than about this primitive (rf2-hnrww)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.context :as adapter-context]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     ;; `:ambient-frame nil` for the reason the refusal suite gives: the
+     ;; fixture's default leaves a dynamic-var stamp in scope, and tier 1
+     ;; wins over everything — so a row claiming core's chain answers
+     ;; nothing inside a body would pass for the wrong reason.
+     :ambient-frame nil
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-a ::hframe-a)
+(def ^:private frame-b ::hframe-b)
+
+(defn- frames! []
+  (dogfood/make-frame! frame-a 3)
+  (dogfood/make-frame! frame-b 3)
+  (dogfood/reseed! frame-a 3)
+  (dogfood/reseed! frame-b 3)
+  nil)
+
+(defn- outcome
+  "The thrown ex-data, or `::no-throw` with the value — so a row that
+  silently succeeds fails with what it silently produced."
+  [thunk]
+  (try [::no-throw (thunk)]
+       (catch :default e (ex-data e))))
+
+(defn- read-in-body
+  "Run `body-fn` as a boundary body for `frame-kw` and answer whatever it
+  put in the volatile it was handed. `rt/render-body` is the shell's own
+  fence minus React, which contributes nothing to any claim here."
+  [frame-kw body-fn]
+  (let [seen (volatile! ::unset)]
+    (rt/render-body frame-kw (fn [_] (body-fn seen) [:li]) {})
+    @seen))
+
+(defn- with-context-frame
+  "Publish `frame-kw` on the SHARED React frame-context slot for `thunk`'s
+  extent, then restore — the tier-2 publication React performs while
+  rendering under a `frame-provider`, and what the installed adapter's
+  `:adapter/current-frame` reader reads.
+
+  Only one row needs it, and that row needs it badly: without the slot
+  published, core's resolver answers nil inside a body *anyway*, so
+  [[the-frame-read-does-not-go-through-cores-ambient-chain]] would be
+  green against a tree with no refusal in it at all. Lifted in shape from
+  `arm1/ambient_refusal_cljs_test`, which makes the same argument at
+  length."
+  [frame-kw thunk]
+  (let [^js ctx  adapter-context/frame-context
+        original (.-_currentValue ctx)]
+    (set! (.-_currentValue ctx) frame-kw)
+    (try (thunk)
+         (finally (set! (.-_currentValue ctx) original)))))
+
+;; ---------------------------------------------------------------------------
+;; W1 — it answers the rendering boundary's frame
+;; ---------------------------------------------------------------------------
+
+(deftest the-frame-read-answers-the-rendering-boundarys-frame
+  (frames!)
+  (testing "the whole primitive, in one line: inside a body it is the id
+           keyword of the boundary React is rendering"
+    (is (= frame-a (read-in-body frame-a (fn [seen] (vreset! seen (intent/hframe)))))))
+
+  (testing "and it FOLLOWS the boundary — the same body run for a second
+           frame answers the second frame. A read that was constant per
+           process, or per first-mount, would pass the row above and be
+           useless to the case the primitive exists for: one reusable view
+           mounted under N frames"
+    (is (= frame-b (read-in-body frame-b (fn [seen] (vreset! seen (intent/hframe))))))))
+
+;; ---------------------------------------------------------------------------
+;; W3 — outside a render extent it is loud, and the text is layer-routed
+;; ---------------------------------------------------------------------------
+
+(deftest the-frame-read-outside-a-render-extent-is-loud
+  (frames!)
+  (testing "no extent, no answer — never a guessed frame and never nil"
+    (let [data (outcome intent/hframe)]
+      (is (= :rf.error/hicasso-frame-outside-boundary (:rf.error/id data))
+          (str "expected the loud error; got " (pr-str data)))
+      (is (= :read-the-frame-inside-a-boundary-render (:recovery data)))
+      (is (= 'front.intent/hframe (:where data)))))
+
+  (testing "and the message ROUTES BY LAYER rather than saying 'do it
+           inside a body'. The overwhelmingly common way to reach this
+           error is mis-layered async work, whose fix is not to move the
+           call — it is to move the work"
+    (let [reason (:reason (outcome intent/hframe))]
+      (is (string? reason))
+      (is (re-find #"EVENT layer" reason)
+          "the first thing it names is where async work belongs")
+      (is (re-find #":dispatch-later" reason)
+          "with the framework's own spelling for a delay")
+      (is (re-find #"capture-frame <frame-id>" reason)
+          "and the scope-free door for code that already knows its frame")))
+
+  (testing "the same read inside a body is fine, so the row above is
+           pinning the boundary of the extent rather than a broken call"
+    (is (= frame-a (read-in-body frame-a (fn [seen] (vreset! seen (intent/hframe))))))))
+
+;; ---------------------------------------------------------------------------
+;; W4 — inside a render callback it answers the SUPPLYING boundary
+;; ---------------------------------------------------------------------------
+
+(deftest a-render-callback-reads-the-supplying-boundarys-frame
+  (frames!)
+  (testing "rf2-2rtt6.74's owner rule, reached through `h/frame`. A render
+           callback is minted during the supplying boundary's body and
+           INVOKED later by a foreign component — so the frame it must
+           answer is the owner's. This is the position that makes the
+           choice of `intent/*frame*` over the runtime's own render slot
+           load-bearing: the runtime slot is nil here, because the foreign
+           render runs outside the arm's render pass"
+    (let [callback (volatile! nil)
+          seen     (volatile! ::unset)]
+      ;; Lowered at a NON-event position inside frame-a's body, which is
+      ;; what gives it the render contract.
+      (rt/render-body frame-a
+                      (fn [_]
+                        (vreset! callback
+                                 (intent/lower-prop
+                                   :render-row
+                                   (intent/callback (fn [] (vreset! seen (intent/hframe))))))
+                        [:li])
+                      {})
+      (is (some? @callback) "precondition: the render position lowered a wrapper")
+
+      (testing "invoked from outside any extent at all — the foreign
+               component's own render"
+        (@callback)
+        (is (= frame-a @seen)))
+
+      (testing "and invoked while a DIFFERENT frame is the ambient one, it
+               still answers the owner's. A foreign component has no frame
+               of its own and frames are isolated contexts, so the
+               supplying boundary is the only frame that can own this call"
+        (vreset! seen ::unset)
+        (intent/with-frame frame-b (rt/frame-dispatch frame-b) (fn [] (@callback)))
+        (is (= frame-a @seen)
+            "the invoker's frame must not colonise the owner's callback")))))
+
+;; ---------------------------------------------------------------------------
+;; W5 (the edge half) — not a tracked read
+;; ---------------------------------------------------------------------------
+
+(deftest the-frame-read-registers-no-edge
+  (frames!)
+  (testing "a body whose ONLY read is `h/frame` records no sub-key at all.
+           Reads become edges because they are sub-KEYS; the frame is not
+           one — it is render-constant per boundary and resolved once by
+           the shell"
+    (rt/render-body frame-a (fn [_] [:li (str (intent/hframe))]) {})
+    (is (= [] (vec (rt/reads-of (rt/last-reads))))))
+
+  (testing "and adding it to a READING body changes the read set not at
+           all — same keys, same order. The control is the point: the
+           first row alone would be green for a body that read nothing
+           for any reason"
+    (rt/render-body frame-a (fn [_] [:li (str (rt/sub [:dogfood/done? 0]))]) {})
+    (let [without (vec (rt/reads-of (rt/last-reads)))]
+      (rt/render-body frame-a
+                      (fn [_] [:li (str (intent/hframe)) (str (rt/sub [:dogfood/done? 0]))])
+                      {})
+      (let [with (vec (rt/reads-of (rt/last-reads)))]
+        (is (= 1 (count without)) "precondition: the control body read exactly one key")
+        (is (= without with)
+            (str "the frame read must contribute nothing to the collector: "
+                 (pr-str without) " vs " (pr-str with)))))))
+
+;; ---------------------------------------------------------------------------
+;; It is not core's ambient chain, which is what makes it deterministic
+;; ---------------------------------------------------------------------------
+
+(deftest the-frame-read-does-not-go-through-cores-ambient-chain
+  (frames!)
+  (testing "the two answers taken in the SAME extent, one line apart:
+           core's resolver says 'no ambient frame' — rf2-2rtt6.122's
+           refusal, doing exactly its job — while `h/frame` answers the
+           boundary's id. That gap is the whole reason this primitive is
+           deterministic where the ambient chain was not: it reads the
+           arm's own binding and never enters the resolution chain, so no
+           adapter, renderer or hook publication can change its answer.
+
+           THE CONTEXT SLOT IS PUBLISHED FOR THE WHOLE ROW, and it has to
+           be. Without it core answers nil inside a body for the boring
+           reason that it would answer nil anywhere, and the row would be
+           green against a tree carrying no refusal at all — the vacuity
+           the refusal suite's own control row exists to rule out"
+    (let [seen (volatile! ::unset)]
+      (with-context-frame frame-a
+        (fn []
+          (is (= frame-a (frame/resolve-current-frame))
+              "control: tier 2 is genuinely answering out here, so the nil
+               below is the withdrawal and not an empty chain")
+          (rt/render-body frame-a
+                          (fn [_]
+                            (vreset! seen {:core   (frame/resolve-current-frame)
+                                           :hframe (intent/hframe)})
+                            [:li])
+                          {})))
+      (is (nil? (:core @seen))
+          "core's ambient resolver is withdrawn for the extent")
+      (is (= frame-a (:hframe @seen))
+          "and `h/frame` answers anyway"))))
+
+;; ---------------------------------------------------------------------------
+;; The composition — the ruled carry spelling (design §2(3))
+;; ---------------------------------------------------------------------------
+
+(deftest the-composed-carry-fires-into-its-own-frame-after-the-render
+  (frames!)
+  (testing "`(rf/capture-frame (h/frame))` is the ruled spelling, and this
+           is what it buys: a closure built during a body and fired long
+           after the render's dynamic extent has unwound still dispatches
+           into the boundary's own frame. Two frames side by side, one
+           body, so a capture that reached for an ambient frame at FIRE
+           time — or captured a process-wide one — lands in the wrong
+           place and this row says so"
+    (let [carry (fn [frame-kw]
+                  (let [held (volatile! nil)]
+                    (rt/render-body frame-kw
+                                    (fn [_]
+                                      (vreset! held (rf/capture-frame (intent/hframe)))
+                                      [:li])
+                                    {})
+                    @held))
+          a     (carry frame-a)
+          b     (carry frame-b)]
+      (is (= frame-a (:frame a)))
+      (is (= frame-b (:frame b)))
+
+      (testing "and each dispatches into ITS OWN frame, after the extent
+               has gone"
+        (is (nil? intent/*frame*) "precondition: no render extent is live here")
+        ((:dispatch-sync a) [:dogfood/toggle 0])
+        (is (true? @(rf/subscribe [:dogfood/done? 0] {:frame frame-a})))
+        (is (false? @(rf/subscribe [:dogfood/done? 0] {:frame frame-b}))
+            "frames are isolated contexts — the sibling must not have moved")))))
+
+;; ---------------------------------------------------------------------------
+;; W9 — an event-time read is not silently wrong
+;; ---------------------------------------------------------------------------
+
+(deftest a-frame-read-inside-an-event-handler-raises
+  (frames!)
+  (testing "the router binds CORE's scope for a handler, not the arm's, so
+           a handler that reaches for `h/frame` has no render extent and
+           gets the loud error rather than a stale or guessed frame. This
+           is the mis-layering the error text routes: the handler already
+           has its frame, in its ctx"
+    (let [caught (volatile! ::unset)]
+      (rf/reg-event :hframe/at-event-time
+                    (fn [_ctx _e]
+                      (vreset! caught (outcome intent/hframe))
+                      {}))
+      (rf/with-frame frame-a (rf/dispatch-sync [:hframe/at-event-time]))
+      (is (= :rf.error/hicasso-frame-outside-boundary (:rf.error/id @caught))
+          (str "expected the loud error inside the handler; got " (pr-str @caught)))))
+
+  (testing "and CORE's scope WAS live inside that same handler the whole
+           time — so the row above pins that the two scopes are different
+           things, not that the dispatch happened to be frameless"
+    (let [seen (volatile! ::unset)]
+      (rf/reg-event :hframe/core-scope-at-event-time
+                    (fn [_ctx _e]
+                      (vreset! seen (frame/resolve-current-frame))
+                      {}))
+      (rf/with-frame frame-a (rf/dispatch-sync [:hframe/core-scope-at-event-time]))
+      (is (= frame-a @seen)
+          "the router binds core's per-handler scope; the arm's render
+           binding is a different var with a different extent"))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/hframe_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/hframe_dom_cljs_test.cljs
@@ -1,0 +1,285 @@
+(ns re-frame.bench.hicasso.arm1.hframe-dom-cljs-test
+  "`h/frame` AGAINST A REAL REACT ROOT (rf2-841vn).
+
+  The node sibling (`arm1/hframe_cljs_test`) settles what the primitive
+  does. Four claims are left over, and each is a claim about REACT rather
+  than about the read, which is why they are asserted against a live
+  `createRoot` rather than reasoned about:
+
+  1. **It answers under BOTH shell variants** (W1). The context shell
+     resolves its frame through `useContext`; the frame-prop shell takes
+     it as an ordinary prop and spends one hook fewer. `h/frame` reads
+     neither — it reads the ambient the runtime binds either way — and
+     that identity is the thing worth pinning, because a variant that
+     answered differently would make the read a property of the shell.
+  2. **The documented trap, made green, plus the isolation law** (W2).
+     ONE reusable view, mounted under TWO frames, each instance building
+     `(rf/capture-frame (h/frame))` and firing it from a `setTimeout`
+     after its render has unwound. This is the case the primitive exists
+     for and the case nothing else in the arm can spell: `with-frame` and
+     `{:frame …}` both presuppose knowing the id, which a reusable view
+     does not.
+  3. **The hook ledger does not move** (W5's other half). Counted at
+     React's own dispatcher by the same probe the ≤2-hook budget uses, on
+     both shells. The ledger is a hard fence; a read that spent a hook
+     would be a finding rather than a price.
+  4. **StrictMode's double-invoke is not additive** (W6) — the same value
+     on both runs, and no second edge, entry or registration.
+
+  Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
+  React DOM; under `:node-test` every claim degrades to a stated skip."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures async]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.hook-probe :as probe]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.front.dogfood :as dogfood]
+            [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     ;; The hook-ledger fixture's reason, and it bites harder here: the
+     ;; default leaves a dynamic-var frame stamp in scope, which tier 1
+     ;; would answer — so an isolation miss could read as a rendering
+     ;; difference rather than as the failure it is.
+     :ambient-frame nil
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(def ^:private frame-a ::hframe-dom-a)
+(def ^:private frame-b ::hframe-dom-b)
+
+(def ^:private todos 4)
+
+(defn- skip! [why] (is true (str "this claim needs a real React DOM — " why)))
+
+(defn- unwitnessed! []
+  (is false (str "React's internals slot was not found, so the hook count is "
+                 "UNWITNESSED on this build. A gate nobody has watched fire is "
+                 "not evidence — fix "
+                 (pr-str 're-frame.bench.hicasso.arm1.hook-probe)
+                 " rather than reading this as a pass.")))
+
+(defn- frames! []
+  (lane/leave-act-environment!)
+  (dogfood/make-frame! frame-a todos)
+  (dogfood/make-frame! frame-b todos)
+  (dogfood/reseed! frame-a todos)
+  (dogfood/reseed! frame-b todos)
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; The two variants of ONE body — the frame-prop suite's own construction
+;; ---------------------------------------------------------------------------
+
+(defn- printing-body
+  "Prints the frame `h/frame` answered, and reads one subscription beside
+  it so the boundary is an ordinary reading boundary rather than a
+  degenerate one."
+  [{:keys [id]}]
+  [:span.row {:data-frame (str (intent/hframe))
+              :data-done  (str (rt/sub [:dogfood/done? id]))}])
+
+(defview context-row
+  "The incumbent shell: the frame arrives through `useContext`."
+  [props]
+  (printing-body props))
+
+(def frame-prop-row
+  "The challenger shell: the frame arrives as `rfFrame` on the element,
+  and the shell spends one hook fewer."
+  (rt/mint-frame-prop-view! "hframe-frame-prop-row" printing-body))
+
+(defn- frame-attr [handle]
+  (some-> (.querySelector (:container handle) ".row") (.getAttribute "data-frame")))
+
+;; ---------------------------------------------------------------------------
+;; W1 — the same answer under both shells
+;; ---------------------------------------------------------------------------
+
+(deftest the-frame-read-answers-under-both-shell-variants
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (frames!)
+      (testing "the context shell"
+        (let [handle (mount/root! (mount/fresh-container!) frame-a [context-row {:id 0}])]
+          (try (is (= (str frame-a) (frame-attr handle)))
+               (finally (mount/release! handle)))))
+
+      (testing "the frame-prop shell — a different route to the frame, one
+               hook fewer, and the SAME answer. `h/frame` reads the ambient
+               the runtime binds either way, so a difference here would mean
+               the read had become a property of the shell"
+        (let [handle (mount/root! (mount/fresh-container!) frame-a [frame-prop-row {:id 0}])]
+          (try (is (= (str frame-a) (frame-attr handle)))
+               (finally (mount/release! handle)))))
+
+      (testing "and both FOLLOW the frame — mounted under a second frame
+               each answers the second. A constant would have passed every
+               row above"
+        (doseq [[label view] [["context" context-row] ["frame-prop" frame-prop-row]]]
+          (let [handle (mount/root! (mount/fresh-container!) frame-b [view {:id 0}])]
+            (try (is (= (str frame-b) (frame-attr handle)) label)
+                 (finally (mount/release! handle)))))))))
+
+;; ---------------------------------------------------------------------------
+;; W5's other half — the hook ledger does not move
+;; ---------------------------------------------------------------------------
+
+(deftest the-frame-read-spends-no-hook-on-either-shell
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (if-not (probe/install!)
+      (unwitnessed!)
+      (do
+        (frames!)
+        (testing "the ≤2-hook shell is a hard fence, so this is counted at
+                 React's own dispatcher rather than declared. A boundary
+                 reading `h/frame` costs exactly what the ledger declares —
+                 the frame is render-constant per boundary and already
+                 resolved, so there is nothing for a hook to hold"
+          (let [handle (volatile! nil)
+                names  (probe/record!
+                         (fn [] (vreset! handle
+                                         (mount/root! (mount/fresh-container!)
+                                                      frame-a [context-row {:id 0}]))))]
+            (mount/release! @handle)
+            (is (= ["useContext" "useSyncExternalStore"] names)
+                (str "hooks React was asked for: " (pr-str names)))
+            (is (= (count rt/shell-hook-ledger) (count names))
+                "and the declared ledger is still the measured one")))
+
+        (testing "and one fewer on the frame-fed shell, unchanged — a read
+                 that had quietly taken a hook would show up as two here"
+          (let [handle (volatile! nil)
+                names  (probe/record!
+                         (fn [] (vreset! handle
+                                         (mount/root! (mount/fresh-container!)
+                                                      frame-a [frame-prop-row {:id 0}]))))]
+            (mount/release! @handle)
+            (is (= ["useSyncExternalStore"] names)
+                (str "hooks React was asked for: " (pr-str names)))
+            (is (= (count rt/frame-prop-shell-hook-ledger) (count names)))))))))
+
+;; ---------------------------------------------------------------------------
+;; W2 — the documented trap made green, and the isolation law
+;; ---------------------------------------------------------------------------
+
+(def ^:private !captures
+  "Where each mounted instance parks the capture it built. Keyed by the
+  frame it believes it is in — so an instance that read the WRONG frame
+  overwrites its sibling's slot and the row goes red on the count before
+  it ever gets to the dispatch."
+  (atom {}))
+
+(defview reusable
+  "ONE view, mounted under N frames — the case the primitive exists for.
+  It does not know its own frame id, which is exactly why neither
+  `rf/with-frame` nor a `{:frame …}` opt can serve it: both presuppose the
+  id. `h/frame` supplies it, and `capture-frame`'s 1-arity — which never
+  consults the ambient resolver — carries it out of the render."
+  [{:keys [id]}]
+  (let [f (intent/hframe)]
+    (swap! !captures assoc f (rf/capture-frame f))
+    [:span.row {:data-frame (str f)
+                :data-done  (str (rt/sub [:dogfood/done? id]))}]))
+
+(deftest a-capture-built-in-a-body-fires-into-its-own-frame-after-the-render
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (async done
+      (frames!)
+      (reset! !captures {})
+      (let [a (mount/root! (mount/fresh-container!) frame-a [reusable {:id 0}])
+            b (mount/root! (mount/fresh-container!) frame-b [reusable {:id 0}])]
+        (is (= #{frame-a frame-b} (set (keys @!captures)))
+            (str "two mounts of ONE view must have read two different frames; got "
+                 (pr-str (keys @!captures))))
+        (is (= (str frame-a) (frame-attr a)))
+        (is (= (str frame-b) (frame-attr b)))
+        ;; A real macrotask, which is the whole point: the render's dynamic
+        ;; extent is long gone by the time these fire, and an ambient read
+        ;; taken HERE would find nothing at all.
+        (js/setTimeout
+          (fn []
+            (try
+              (is (nil? intent/*frame*)
+                  "precondition: no render extent is live inside the timeout")
+              ((:dispatch-sync (get @!captures frame-a)) [:dogfood/toggle 0])
+              (mount/settle!)
+              (is (= "true" (.getAttribute (.querySelector (:container a) ".row") "data-done"))
+                  "the closure dispatched into the frame its own boundary rendered under")
+              (is (= "false" (.getAttribute (.querySelector (:container b) ".row") "data-done"))
+                  "and the sibling frame did not move — frames are isolated
+                   contexts, and a capture that had resolved a process-wide
+                   or a last-rendered frame would have moved both")
+              (finally
+                (mount/release! a)
+                (mount/release! b)
+                (done))))
+          0)))))
+
+;; ---------------------------------------------------------------------------
+;; W6 — StrictMode's double-invoke
+;; ---------------------------------------------------------------------------
+
+(def ^:private !runs (atom 0))
+(def ^:private !seen (atom []))
+
+(defview strict-reader
+  "Records the frame `h/frame` answered on EVERY body run, so the
+  double-invoke is a measured premise rather than an assumed one."
+  [{:keys [id]}]
+  (swap! !runs inc)
+  (swap! !seen conj (intent/hframe))
+  [:span.row {:data-done (str (rt/sub [:dogfood/done? id]))}])
+
+(defn- strict-root!
+  "`mount/root!`, wrapped in `React.StrictMode`. Written here rather than
+  in the shared mount door for the reason `arm1/lifecycle_dom_cljs_test`
+  gives: StrictMode is this row's variable, and every other suite in the
+  arm must keep measuring the ordinary tree."
+  [container frame-kw hiccup]
+  (let [root (react-dom-client/createRoot container)]
+    (react-dom/flushSync
+      (fn [] (.render root (react/createElement
+                             react/StrictMode nil
+                             (mount/provider frame-kw (codec/as-element hiccup))))))
+    {:root root :frame frame-kw :container container}))
+
+(deftest strictmodes-double-invoke-reads-the-same-frame-and-adds-nothing
+  (if-not (mount/browser?)
+    (skip! ":node-test has no DOM")
+    (do
+      (frames!)
+      (reset! !runs 0)
+      (reset! !seen [])
+      (let [handle (strict-root! (mount/fresh-container!) frame-a [strict-reader {:id 0}])]
+        (try
+          (testing "the premise: React really did invoke the body twice"
+            (is (= 2 @!runs)
+                "if this reads 1 the build is not double-invoking and the
+                 assertions below are a green gate over nothing — fix the
+                 build, do not relax this"))
+          (testing "both invocations read the same frame — the ambient is
+                   bound per body RUN, so a second run re-establishes it
+                   rather than inheriting a stale or half-unwound one"
+            (is (= [frame-a frame-a] @!seen)))
+          (testing "and the read adds nothing on the second pass: one entry,
+                   one boundary, one edge per read. `h/frame` appends no
+                   sub-key, so a double-invoke cannot double anything it
+                   contributes — because it contributes nothing"
+            (let [{:keys [entries boundaries edges]} (rt/stats)]
+              (is (= 1 entries))
+              (is (= 1 boundaries))
+              (is (= 1 edges) "the one real read, counted once")))
+          (finally (mount/release! handle)))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -135,6 +135,11 @@
   A vector at an event position with no ambient frame is a loud error,
   never a silently inert handler.
 
+  [[hframe]] (`h/frame` in the authoring surface) is the AUTHOR-facing
+  half of the same binding — the one door an author has to the frame
+  identity the lowering reads implicitly. See its docstring; the design
+  record is `docs/design/hicasso/studio/hframe-design.md` (rf2-841vn).
+
   A RENDER callback ([[render-callback]]) re-establishes that ambient
   context for its own invocation, out of what it captured when it was
   lowered, so a row built inside a foreign `renderRow` belongs to the
@@ -274,7 +279,18 @@
   point of the tier is that the generic `:rf.error/no-frame-context` advice
   — establish a scope — is WRONG here: a body always sits under a frame
   boundary, so following it would change nothing and the boundary would go
-  on quietly not re-rendering."
+  on quietly not re-rendering.
+
+  IT HAS TO ADDRESS THREE DOORS, NOT TWO (rf2-hnrww). The ambient scope is
+  one door with three consumers — a read, a dispatch, and a CARRY — and
+  this text was written for the first two. An author who trips the refusal
+  through `rf/capture-frame` is doing neither: `capture-frame` is Spec
+  002's *one public carry primitive*, and the reason its 0-arity resolves
+  ambiently is to CAPTURE, not to read and not to dispatch. Advice that
+  says \"read through the collector, dispatch through an intent\" names
+  nothing they can write. So the carry gets its own sentence, and it is a
+  different sentence — not the collector and not an intent, but the
+  1-arity, which never consults the resolver at all."
   {:substrate :hicasso
    :extent    'hicasso/boundary-render
    :recovery  :read-through-the-boundary-collector
@@ -288,7 +304,14 @@
                    "never re-renders when that subscription moves, which is HD-002 "
                    "clause (a)'s forbidden class. It used to succeed silently under "
                    "some adapters and throw under others; now it refuses under all "
-                   "of them.")})
+                   "of them. "
+                   "CARRYING a frame out of the render is a THIRD thing, and its "
+                   "recovery is neither of the above: `(rf/capture-frame)` resolves "
+                   "ambiently, so it refuses here, but `(rf/capture-frame <frame-id>)` "
+                   "never consults the resolver at all. Write "
+                   "`(rf/capture-frame (h/frame))` — h/frame is this substrate's own "
+                   "deterministic read of the rendering boundary's frame id, and the "
+                   "composition is refusal-immune by construction.")})
 
 (defn with-frame
   "Run `body-fn` with the boundary's render context bound ambiently. Two
@@ -339,6 +362,111 @@
                        :reason      "No frame-locked dispatch is bound for this render."
                        :recovery    :lower-intents-inside-a-boundary-render
                        :intent      intent}))))
+
+;; ---------------------------------------------------------------------------
+;; The author-facing frame read — `h/frame` (rf2-841vn)
+;; ---------------------------------------------------------------------------
+
+(defn hframe
+  "**`h/frame` in the authoring surface.** The frame id KEYWORD of the
+  boundary currently rendering. A plain function call, legal anywhere in
+  a body, and a loud error outside a render extent.
+
+  Spelled `hframe` here for exactly the reason
+  [[re-frame.bench.hicasso.arm1.lang/hfn]] is spelled `hfn`: the product
+  name is qualified (`h/frame`), and a bare `frame` would shadow the
+  `re-frame.frame` alias that this namespace — and every other namespace
+  in the arm — already carries.
+
+  ## What it is FOR, and the honest layering (design §6)
+
+  It serves ONE author: someone at a foreign edge who must hand a
+  dispatching closure to a caller they do not control — an SDK attach
+  ref, a value-first callback on a foreign component, a `defhost`
+  callback slot. What that author captures is not time; it is **frame
+  identity at the one moment it is knowable**.
+
+  Hand-written async *work* is a different problem and this is not its
+  answer. An fx handler already receives the frame id in its ctx and
+  `:dispatch-later` already expresses delay as data; a `setTimeout` in a
+  view that dispatches is mis-layered, and no primitive here is designed
+  for it. `h/frame` does make that spelling *work* where it used to fail
+  — that softening is stated on the design record rather than argued
+  away, and the compensation is that every guide row putting `h/frame` on
+  the page puts `:fx` first.
+
+  ## The carry spelling is COMPOSITION, not a second primitive
+
+      (rf/capture-frame (h/frame))
+
+  Hicasso contributes the deterministic frame READ; core keeps
+  `capture-frame` as what Spec 002 calls *the ONE public carry
+  primitive*. The two-step spelling, against the adapters' one-step
+  `(rf/capture-frame)`, is the taught asymmetry, and it has a one-
+  sentence reason: **ambient frame lookup is what Hicasso's stricter body
+  discipline withdraws** (rf2-2rtt6.122 — see [[ambient-frame-refusal]]).
+
+  THE LOAD-BEARING FACT is narrower than it looks. The refusal deletes
+  the ambient FIND, never the carrying, so `rf/with-frame` and
+  `{:frame <id>}` both still answer inside a body — but neither is the
+  author-facing answer, because both *presuppose knowing the frame id*,
+  which is exactly what a reusable view mounted under N frames cannot
+  know. What makes the composition work is that **`capture-frame`'s
+  1-arity never consults the resolver at all**, so
+  `(rf/capture-frame (h/frame))` is refusal-immune by construction, and
+  `h/frame` supplies the id the carrying spellings presuppose.
+
+  ## Why it reads [[*frame*]] and not the runtime's render slot
+
+  Load-bearing, and the difference is visible in one position. The
+  rf2-2rtt6.74 render-position work rebinds [[*frame*]] to the
+  **supplying** boundary while a foreign component invokes a render
+  callback ([[render-callback]]), where the runtime's own `rstate.frame`
+  is nil — the foreign render runs outside the arm's render pass. So
+  reading the binding answers the OWNER's frame inside a render callback
+  for free, and answers it immune to tree position, adapter, renderer and
+  timing. [[re-frame.bench.hicasso.front.route-link/route-link]] is the
+  internal consumer already doing exactly this.
+
+  ## NOT a tracked read, and it must not become one
+
+  Reads become collector edges because they are sub-KEYS. The frame is
+  not one: it is render-constant per boundary, resolved once by the shell
+  and bound ambiently. This is one dynamic-var read. It appends nothing
+  to the collector scratch, registers no edge and takes no React hook —
+  so the ≤2-hook shell ledger is untouched, and the frame-prop shell
+  variant answers identically because the same ambient is bound either
+  way. Reactivity needs no edge: a frame change is a context change or a
+  remount, and React propagates context to consumers ahead of the memo
+  comparator.
+
+  ## SSR
+
+  Server frames are per-request gensyms destroyed in the render's
+  `finally`, and the body runs on Node through this same path — so this
+  answers the per-request frame id and per-request isolation holds by
+  construction. **The value is process-local identity, carried in
+  closures, and must never be placed in markup**: two same-process
+  renders take two gensyms, so rendering it would break the render-twice
+  determinism the SSR witnesses assert."
+  []
+  (or *frame*
+      (fail! :rf.error/hicasso-frame-outside-boundary
+             'front.intent/hframe
+             (str "h/frame was called with no Hicasso render extent in scope. It "
+                  "answers the frame of the boundary currently rendering, so it is "
+                  "legal only during a boundary body — or inside a render callback "
+                  "that boundary supplied, where it answers the SUPPLYING "
+                  "boundary's frame. Where the call came from decides the fix. "
+                  "Hand-written async work belongs in the EVENT layer, which "
+                  "already has the frame: an fx handler receives it in its ctx, and "
+                  ":dispatch-later expresses the delay as data. An event handler is "
+                  "already running under its own frame and should take it from "
+                  "there rather than read it here. And code that already knows "
+                  "which frame it means should say so: (rf/capture-frame <frame-id>) "
+                  "needs no scope at all.")
+             :read-the-frame-inside-a-boundary-render
+             {})))
 
 ;; ---------------------------------------------------------------------------
 ;; The one callback form (HD-024)

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/hframe_ssr_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/hframe_ssr_cljs_test.cljs
@@ -1,0 +1,175 @@
+(ns re-frame.bench.hicasso.ssr.hframe-ssr-cljs-test
+  "`h/frame` ON THE SERVER (rf2-841vn — the design's W8 and W11).
+
+  The body runs on Node through the same shell path, so `h/frame` answers
+  the request's own per-request gensym and per-request isolation holds by
+  construction. Two things follow, and the second is the interesting one.
+
+  **W8 — the id is process-local identity, and must never reach markup.**
+  Two same-process renders take two different gensyms, so a body that
+  RENDERS the value makes the document nondeterministic. That is an
+  authorable hazard rather than a framework one, and it is already
+  instrumented: `entry/render-twice`'s byte comparison is the standing
+  determinism check. Both halves are asserted here — a body that reads
+  the id and keeps it out of markup renders byte-identical documents, and
+  a body that deliberately prints it does not. The second row is what
+  stops the first from being a green gate over a check that could not
+  fail.
+
+  **W11 — RE-GROUNDED on the post-rf2-2rtt6.122 tree.** As designed the
+  row contrasted `h/frame` answering against the ambient chain throwing
+  *server-side for a renderer-specific reason*: the raw React-context read
+  the adapters publish is client-renderer-only. That contrast no longer
+  describes the tree. Since rf2-2rtt6.122 the ambient chain refuses on
+  BOTH sides for ONE reason — the arm's own refusal, established by
+  `intent/with-frame` over every render extent, client or server. The
+  contrast survives; its explanation changed, and a row asserting a
+  renderer-specific server-side throw would now be asserting the wrong
+  fact for the wrong reason.
+
+  Runtime: `-cljs-test`, i.e. the consolidated `:node-test` build, which
+  is where `react-dom/server` resolves and where the rest of the SSR entry
+  is proved (`ssr/entry_cljs_test`)."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [clojure.string :as str]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.intent :as intent]
+            [re-frame.bench.hicasso.ssr.entry :as entry]
+            [re-frame.bench.hicasso.ssr.fixtures :as fixtures]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter uix-adapter/adapter
+     ;; `:ambient-frame nil`, where the rest of the SSR suite takes the
+     ;; fixture's default — and it is load-bearing rather than tidiness.
+     ;; The default root-binds `frame/*current-frame*` to `:rf/default`,
+     ;; which is a CARRIED tier-1 stamp; the refusal withdraws the ambient
+     ;; FIND and never the carrying, so an ambient carry inside a body
+     ;; would resolve `:rf/default` and succeed. That is core behaving
+     ;; exactly as specified, and it is not the configuration a server
+     ;; request has: `entry/render` establishes no scope and a host calls
+     ;; it at top of stack. Measuring the refusal against the fixture's own
+     ;; stamp would be measuring the fixture. (The mismatched-scope case is
+     ;; interesting in its own right and is pinned deliberately, in
+     ;; `arm1/hframe_cljs_test`.)
+     :ambient-frame nil
+     :init-fn       (fn [] (fixtures/register!) (rt/reset-runtime!))}))
+
+(def ^:private !seen
+  "Every frame id a server body read, newest last."
+  (atom []))
+
+(def ^:private !ambient
+  "What the ambient carry answered inside a server body — the ex-data of
+  its refusal, or `::no-throw` with the value it produced."
+  (atom ::unset))
+
+(defview discreet
+  "Reads the request's frame and keeps it OUT of the markup — the
+  documented correct shape. What it renders is a subscription value, so
+  the boundary is an ordinary one."
+  [_]
+  (swap! !seen conj (intent/hframe))
+  [:span.row (str (rt/sub [:dogfood/remaining]))])
+
+(defview indiscreet
+  "Renders the per-request id INTO the markup. This is the authorable
+  hazard the docstring warns about, written on purpose so the
+  determinism check can be watched failing."
+  [_]
+  [:span.row {:data-frame (str (intent/hframe))}])
+
+(defview carrying
+  "Tries the AMBIENT carry — `(rf/capture-frame)`, 0-arity — inside a
+  server body, and records what it got. It catches its own throw so the
+  render completes and the row can read the payload rather than a
+  `renderToString` failure."
+  [_]
+  (reset! !ambient
+          (try [::no-throw (rf/capture-frame)]
+               (catch :default e (ex-data e))))
+  [:span.row (str (intent/hframe))])
+
+(defn- request [hiccup]
+  {:hiccup   hiccup
+   :snapshot (:snapshot (fixtures/row "dogfood-snapshot"))
+   :payload  fixtures/dogfood-payload-keys})
+
+;; ---------------------------------------------------------------------------
+;; W8 — the per-request id, and the one authorable hazard
+;; ---------------------------------------------------------------------------
+
+(deftest a-server-body-reads-the-requests-own-frame
+  (testing "the frame `h/frame` answers on the server IS the request's
+           per-request gensym, and two requests answer two different ones —
+           which is what per-request isolation means when the id is the
+           thing being read"
+    (reset! !seen [])
+    (let [a (entry/render (request [discreet {}]))
+          b (entry/render (request [discreet {}]))]
+      (is (= 2 (count @!seen)) "one read per request")
+      (is (= [(:frame-id a) (:frame-id b)] @!seen)
+          "each body read its OWN request's id, in order")
+      (is (not= (:frame-id a) (:frame-id b))
+          "precondition: the two requests really did take different frames,
+           so the row above is not comparing a constant to itself"))))
+
+(deftest a-body-that-reads-the-id-and-keeps-it-out-of-markup-is-deterministic
+  (testing "the correct shape. Two renders take two gensyms, and the
+           documents are byte-identical anyway — because the value went
+           into a read and not into the page"
+    (let [{:keys [identical? differs-at] a :first b :second}
+          (entry/render-twice (request [discreet {}]))]
+      (is identical? (str "the two documents differ at index " differs-at))
+      (is (not= (:frame-id a) (:frame-id b))
+          "and they were different requests — this is the whole point")
+      (is (not (str/includes? (:document a) (name (:frame-id a))))
+          "the id is nowhere in the markup"))))
+
+(deftest a-body-that-renders-the-id-breaks-determinism-and-the-check-says-so
+  (testing "THE ROW THAT MAKES THE ONE ABOVE MEAN SOMETHING. Rendering the
+           per-request id is an authorable hazard, and the claim is that
+           the existing render-twice byte comparison catches it. A claim
+           about a check that has never been watched failing is not a
+           check, so here it is failing"
+    (let [{:keys [identical? differs-at] a :first} (entry/render-twice (request [indiscreet {}]))]
+      (is (not identical?)
+          "a document carrying the per-request gensym cannot be
+           deterministic, and the determinism witness must say so")
+      (is (some? differs-at) "with a diagnosable diff position")
+      (is (str/includes? (:document a) (name (:frame-id a)))
+          "and the id is visibly in the markup, which is the mistake"))))
+
+;; ---------------------------------------------------------------------------
+;; W11 — the ambient chain refuses on BOTH sides, for ONE reason
+;; ---------------------------------------------------------------------------
+
+(deftest the-ambient-carry-refuses-server-side-for-the-substrates-own-reason
+  (testing "re-grounded (rf2-2rtt6.122). The designed row contrasted
+           `h/frame` answering against a renderer-specific server-side
+           throw; the arm's refusal now covers the server render extent
+           exactly as it covers the client's, so what the server reports is
+           the SUBSTRATE's refusal — same operation, same substrate, same
+           extent — and not a fact about `react-dom/server`"
+    (reset! !ambient ::unset)
+    (let [{:keys [document]} (entry/render (request [carrying {}]))
+          data               @!ambient]
+      (is (= :capture-frame (:operation data))
+          (str "expected the arm's refusal for the carry; got " (pr-str data)))
+      (is (= :hicasso (:substrate data))
+          "the substrate refused, not the renderer — which is what makes
+           this the same answer the browser gives")
+      (is (= 'hicasso/boundary-render (:extent data)))
+      (is (str/includes? document "class=\"row\"")
+          "and the render completed: the refusal is the carry's, not the
+           page's")))
+
+  (testing "while `h/frame` answers in the same body — the contrast the
+           design's W11 exists for, with its explanation updated"
+    (reset! !seen [])
+    (let [{:keys [frame-id]} (entry/render (request [discreet {}]))]
+      (is (= [frame-id] @!seen)))))


### PR DESCRIPTION
Implements the ruled `h/frame` design (`docs/design/hicasso/studio/hframe-design.md`,
rf2-841vn) and closes the diagnostic gap `rf2-2rtt6.122` left behind (rf2-hnrww).

Fenced to the Hicasso bench lane and `docs/design/hicasso/studio/`. **No core edit**
— `frame.cljc` is untouched, and so are the hook, `resolve-current-frame`, the hook
router, the codec, the shell and the collector. Nothing under `implementation/*/src`
requires this tree, so no adapter or production bundle can see any of it.

## `h/frame`

`intent/hframe` in `front/intent.cljs` — the var's own namespace, the first home the
design offers, and the one that puts the read next to the binding that backs it and
next to `render-callback`'s owner rebinding. Spelled `hframe` for the reason
`lang/hfn` is spelled `hfn`: the product name is qualified, and a bare `frame` would
shadow the `re-frame.frame` alias every namespace in this arm carries.

It is one `or` over `intent/*frame*` — no scratch append, no collector edge, no React
hook, no second carry primitive. The carry spelling stays composition with the
keystone, `(rf/capture-frame (h/frame))`, because `capture-frame`'s 1-arity never
consults the resolver and so is refusal-immune while the 0-arity is not. Outside a
render extent it raises `:rf.error/hicasso-frame-outside-boundary` — the design's own
recommendation, matching the arm's `:rf.error/hicasso-intent-outside-boundary` — with
recovery text that routes by LAYER: the event layer first (`:fx` ctx,
`:dispatch-later`), then the handler's own frame, then the scope-free 1-arity.

**No Spec 009 catalogue row is owed.** The design asked for the id to be confirmed
rather than picked silently. `git grep 'rf.error/hicasso' -- spec/` is empty: no
Hicasso arm error id is catalogued, which is what HD-017's bench-lane residence
implies. The question reopens if the arm graduates.

## rf2-hnrww — two gaps, and the second was the real one

1. The refusal's advice text spoke only of a read and a dispatch. A carry is a third
   thing and its recovery is neither sentence, so it now has its own — naming the
   1-arity and writing out `(rf/capture-frame (h/frame))`.
2. **No witness pinned `capture-frame` under refusal at all.** That gap is why the
   design's W10 was able to go stale unnoticed, so closing it is the larger half.

## W10 is INVERTED

The designed row pinned "the accidental door" — that 0-arity `rf/capture-frame` in a
body SUCCEEDS, recorded so a future change to the accident would be seen rather than
silent. `rf2-2rtt6.122` **is** that change; built as written the row would have
asserted a behaviour the tree no longer has. It now pins the refusal
(`:operation :capture-frame`, `:substrate :hicasso`,
`:extent 'hicasso/boundary-render`), and every carry spelling that still works is
proved on its own — the 1-arity, and the composed `(rf/capture-frame (h/frame))`,
each carried through to a dispatch that lands after the extent has unwound.

**"Under every adapter" is settled structurally, not by trying adapters.** Spec 006
allows one substrate per process, so a row that tried three would still not be the
claim. The `:adapter/current-frame` hook is wrapped with a counter instead: inside a
refused body it is reached **zero** times, with a control one call outside the body
proving it is reached there. The adapter tier is the only part of the chain that
differs between adapters, and it is the tier that is withdrawn.

**The provisional id did not leak.** `:rf.error/ambient-frame-refused` appears nowhere
in the new rows — a carry's refusal is pinned as *the same id an ambient read gets*,
taken live from the sibling row that already anchors the literal. `rf2-k0rbk`'s rename
touches one pre-existing site rather than five new ones.

## Witnesses

W1-W6 and W8-W11 built. Node: `arm1/hframe_cljs_test`. Real React:
`arm1/hframe_dom_cljs_test` (both shell variants; one reusable view mounted under two
frames with each capture fired from a real `setTimeout`; the hook ledger counted at
React's own dispatcher — still two on the context shell, still one on the frame-prop
shell; StrictMode). Server: `ssr/hframe_ssr_cljs_test`.

W8 asserts **both** halves — a body that reads the id and keeps it out of markup
renders byte-identical documents, and a body that deliberately prints it does not.
The second row is what stops the first from being a green gate over a check that could
not fail. W11 is **re-grounded**: as designed it contrasted `h/frame` answering
against a renderer-specific server-side throw, and since `rf2-2rtt6.122` the ambient
chain refuses on both sides for one reason, so the row pins the substrate's own
refusal reaching the server.

No DOM row expects a render-phase throw, so the `reportError` trap does not bite here:
every exception-shaped claim is taken in the node suites through `rt/render-body`,
where `cljs.test` can see it.

**W7 could not be built.** It needs the `[:>]` value-first door, and `front/codec.cljs`
says at the site that the raw escape "stays unbuilt here, deliberately" — a witness
would have had to mint its own `[:>]`-shaped thing and would then be witnessing the
test's construction. Filed as **rf2-zllp8**. Everything W7 depends on is pinned
elsewhere in this PR.

## Mutation proof, both directions

- **Fence removed** (drop `frame/*ambient-frame-refusal*` from `intent/with-frame`):
  the carry rows go red — the refusal row, the advice row, and the adapter-hook count
  — while **both legitimate carry spellings stay green**, individually. A refusal that
  also refused a valid carry would be worse than the silence it replaced.
- **`h/frame` broken** (point it at `frame/resolve-current-frame`, and move its error
  id): every `h/frame` row goes red — W1, W3's id assertion, W4, W5, the chain row,
  the composition row, W9's id assertion, and the composed-carry row in the refusal
  suite.
- **The read set moved** (one extra `rt/sub` in the control body): the "not a tracked
  read" comparison goes red, so it is a live comparison rather than two empty vectors.
- The chain row was found **vacuous** by the first mutation and fixed: it now publishes
  the frame on the shared context slot and asserts tier 2 answering one call outside
  the body, so the nil inside it is the withdrawal rather than an empty chain.

## The ordinary path, and the hook ledger

`runtime.cljs` is untouched (`shell-hook-ledger` and `frame-prop-shell-hook-ledger`
are byte-identical), and the hook counts are re-asserted at React's dispatcher on both
shells with `h/frame` in the body. The only deletions anywhere in `intent.cljs` are the
two lines replaced when extending a docstring and a module-level string constant —
`with-frame`, `require-dispatch`, `render-callback`, `lower-prop` and `lower-props` are
unchanged, and the refusal detail is still built once at load, so the render path pays
nothing new. Reagent, reagent-slim and UIx cannot reach this tree at all.

## Findings filed

- **rf2-nqj22** (bug, P3) — an enclosing `rf/with-frame` makes the ambient carry answer
  the **outer scope's** frame inside a body whose boundary renders a different one.
  Core is correct per EP-0002 — that stamp *was* carried, and the refusal deletes the
  find and never the carrying — but the same body's collector reads and lowered intents
  all target the boundary's frame, so one body ends up with two frames selected by which
  spelling the author reached for, with no diagnostic. `(rf/capture-frame (h/frame))` is
  immune. **Pinned in this PR, not endorsed**; the design question is genuinely open.
  This is also how the SSR rows were grounded: `test-support`'s fixture root-binds
  `*current-frame*` to `:rf/default`, so the SSR witnesses opt out with
  `:ambient-frame nil` rather than measure the fixture.
- **rf2-e28wl** (bug, P3) — Spec 009's `:rf.error/ambient-frame-refused` row enumerates
  `:operation` as `(:dispatch / :subscribe)`, and at least `:capture-frame` and
  `:current-frame-id` also reach `require-current-frame!`. `spec/**` is fenced out of
  this PR; sequence it with rf2-k0rbk.
- **rf2-zllp8** (task, P3) — W7, plus the `[:>]` dev-warning's promised "plain closure"
  spelling in the guide, which is blocked on `[:>]` for the same reason.
- **rf2-cwmnz** (task, P3) — **the rest of the guide half, which this PR owes and does
  not deliver.** The ruling sequences guide prose with the design and says it rides the
  same PR; the guide lives only in `docs/design/hicasso/draft-guide/`, which was fenced
  out because a rename was landing there. The fx-first troubleshooting row and the
  contract-force sentence are not blocked on anything but that rename.

## Quality gates

Every gate run to completion in this worktree, with the exit code read from the
runner's own terminal marker. Nothing piped through `tail`/`head`/`grep` for its
verdict. `npm ci` in both root and `implementation/`; no junction — the mayor
checkout's `implementation/node_modules` is still 2,933 files.

| Gate | Exit | Result |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | 0 | `PASS fast PR spine` — docs tier + JVM `implementation/core` (2,215 tests / 11,527 assertions) and `implementation/freehand` (the artefact this diff touches) + node tier + isolation gate |
| `npm run test:cljs` | 0 | **12,621 tests / 63,213 assertions — 0 failures, 0 errors** |
| `npm run test:browser` | 0 | **1,097 tests / 6,792 assertions — 0 failures, 0 errors** |
| `npm run test:hicasso-compile` | 0 | 123 lane namespaces, **zero warnings** (all three new namespaces verified present in the gate's bundle) |
| `implementation/adapters/reagent` — `clojure -M:test` | 0 | 0 tests / 0 assertions |
| `implementation/adapters/reagent-slim` — `clojure -M:test` | 0 | 11 tests / 12 assertions — 0 failures, 0 errors |
| `implementation/adapters/uix` — `clojure -M:test` | 0 | 0 tests / 0 assertions |
| clj-kondo **2026.04.15** (the CI pin), CI's exact `--lint` set | 0 | **errors: 0**, warnings 4,536 — and **zero findings of any level in any file this PR touches** |
| `sh scripts/check-no-hardcoded-paths.sh` | 0 | no hardcoded personal paths in tracked files |
| `python scripts/check_doc_slugs.py` | 0 | the design record's anchors, link targets and table validate |

Three notes, because a green number is not the same as coverage.

**The browser gate earned its place — it found a real defect.** The first run came
back **exit 1**: `Async tests require fixtures to be specified as maps. Testing
aborted.` W2 fires its capture from a real macrotask, so it is an `async` test, and
`cljs.test` refuses an async test under a fn-form fixture — aborting the **whole**
browser run at that namespace rather than failing one row. Fixed with `:async? true`
(the shape `arm1/generation_fence_dom_cljs_test` takes for the same reason) and re-run
clean. The first run had already reached the namespace, so the re-run's exit 0 with no
abort is the evidence that the four DOM rows executed.

**clj-kondo's 4,536 is two above the ~4,534 quoted for main**, and none of the findings
is in a file this PR touches, so the delta is not attributable here.

**The reagent and uix JVM aliases run zero tests**, which is worth saying out loud
rather than reporting as a green: those adapters are CLJS-only, and their real coverage
is the node build and the browser lanes, both of which ran. Since nothing under
`implementation/*/src` requires this tree, no adapter surface is reachable from this
diff at all.

Closes rf2-841vn, rf2-hnrww.
