### PR TITLE
docs(hicasso): the guide stops teaching a function that does not exist (rf2-2rtt6.120, rf2-2rtt6.64)

### DIFF
--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -44,8 +44,8 @@ interpretation, not a better Reagent.*
 **Vs Reagent**
 
 1. **The tree stays data, including clicks.** `{:on-click [:todo/toggle id]}`
-   instead of `#(rf/dispatch …)`. Tests and tools can `=` the tree; you do not
-   mount-and-click to learn what a button means.
+   instead of `#(rf/dispatch …)`. Tests and tools read the handler as a value; you
+   do not mount-and-click to learn what a button means.
 2. **Reads at the point of use, without a second local-state system.** `sub` is
    an ordinary call — legal in a `when`, a helper, a loop. Semantic UI state goes
    to app-db; no product `r/atom` for "is this open?"
@@ -210,7 +210,7 @@ No boot-path error ids are minted yet; this table names mechanisms.
 
 | Symptom | What went wrong | Fix |
 |---|---|---|
-| `sub` throws outside a view | `sub` is render-scoped; there is no `@`-anywhere | `rf/subscribe-once` in handlers and utilities |
+| `sub` throws outside a view | `sub` is render-scoped; there is no `@`-anywhere | Declare `:rf.cofx/requires` in an event handler; `rf/subscribe-once` with an explicit `{:frame …}` everywhere else |
 | Async callback dispatches and nothing happens | Bare `dispatch` from a timeout has no frame | Intent callbacks carry their [boundary](02-views-and-reads.md#boundaries-and-inlining)'s frame; hand-written async needs the frame explicitly |
 | First paint empty, then flickers | Seed raced first render | Seed through `:initial-events`, not a post-mount dispatch |
 | View renders twice on mount in dev | StrictMode double-invokes bodies | Expected — bodies are pure and re-runnable |

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -234,15 +234,20 @@ the collector mechanics.
 
 ## Rules every read obeys
 
-- **Reading outside a render is an error.** There is no `@`-anywhere. Handler
-  and utility code uses `rf/subscribe-once` — a one-shot read that retains no
-  reactive handle:
+- **Reading outside a render is an error.** There is no `@`-anywhere. In an event
+  handler, declare the read as a coeffect with `:rf.cofx/requires`, so it belongs
+  to the handler's contract rather than happening as a side effect in its body.
+  Free-standing code — a utility, an effect body — uses `rf/subscribe-once`, a
+  one-shot read that retains no reactive handle, and names the frame it wants:
 
   ```clojure
-  ;; Outside a render — e.g. a utility, or an effect body:
-  (let [rows (rf/subscribe-once [:report/rows])]
+  ;; Outside a render and outside any frame scope, so the frame is explicit.
+  (let [rows (rf/subscribe-once [:report/rows] {:frame :main})]
     (export/write! rows))
   ```
+
+  The one-argument form resolves an ambient frame instead, which is what a test
+  or a REPL session sitting inside a scope already has.
 - **Framework subscriptions read identically to your own** — machine tags,
   resource and mutation state, route identity. They are first-class in the
   index, not a special case.

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -7,7 +7,8 @@ legal:
 
 ```clojure
 ;; cf. implementation/freehand/test/re_frame/bench/hicasso/arm1/
-;;     host_hatch_dom_cljs_test.cljs — the witness for every claim on this page.
+;;     host_hatch_dom_cljs_test.cljs — the witness for the declaration and the
+;;     callback behaviour this example shows.
 (ns app.hosts.date-picker
   (:require [re-frame.hicasso :as h]
             ["react-datepicker" :default DatePicker]))
@@ -119,12 +120,16 @@ library's return goes back to that caller. Use this for imperative APIs
 (`open()`, `scrollTo()`): Hicasso does not invent meaning for those calls.
 
 **`:render`** — library calls you *during its own render* (`renderRow`,
-`renderItem`). The body must be pure: its return is what the library puts in its
-tree. Dispatching *while that call runs* raises
-`:rf.error/hicasso-dispatch-in-render-position`, naming the position. The row you
-build may still carry ordinary intents — `[:li {:on-click [:row/pick id]} title]`
-is fine; those fire later, on the user's click, under the frame of the boundary
-that supplied the callback.
+`renderItem`). The body must be pure, and its return goes into the library's tree
+**unconverted**: a string renders, hiccup does not. A returned vector reaches
+React as a vector and is refused there, and nothing on the taught `h/` roster
+converts one at this position — see [Not settled yet](#not-settled-yet).
+Dispatching *while the call runs* raises
+`:rf.error/hicasso-dispatch-in-render-position`, naming the position.
+
+Intents still work, which is most of what the position is for: a row built in the
+body carries them, and they fire later, on the user's click, under the frame of
+the boundary that *supplied* the callback rather than the one that invoked it.
 
 ### The declaration wins
 
@@ -197,6 +202,8 @@ emit `defhost`, rewrite call sites. A codemod is planned and not built.
 |---|---|---|
 | Prop arrives as `on-change` and the library ignores it | Nested keys expected camelCase; deep conversion is not offered | Convert the nested map yourself before it crosses |
 | The library ignored a keyword prop value | A keyword crosses a host prop unchanged; only HTML-attribute names stringify | Write the string at the call site — `"compact"`, or `(name :compact)` |
+| Hiccup passed *in a prop* renders as its own tag name and text | Only children lower; a prop value crosses as data, so `[:h2 "Tasks"]` arrives as the array `["h2" "Tasks"]` — silently, with no error | Pass the subtree as a child where the library takes one; at a prop there is nothing to reach for yet |
+| React refuses an object as a child, from a `:render` body | The body returned hiccup; a `:render` return crosses unconverted | Return a string, or keep the subtree on the Hicasso side of the crossing |
 | `:rf.error/hicasso-intent-at-a-non-event-contract` | Slot is `:handler` or `:render`; neither dispatches | Declare `:event`, or write an `h/fn` for the real work |
 | `:rf.error/hicasso-intent-needs-the-event` | Vector spelling needs the DOM event at arg one; library put something else there | Use `h/fn` — full argument list, library order |
 | Namespace won't load on the JVM | A JS require reached a `.cljc` file | Quarantine the require in a `.cljs` host ns |
@@ -320,6 +327,7 @@ path. Nothing in the reserved vector will rescue that later.
 
 | Question | Status |
 |---|---|
+| Turning hiccup into an element at a prop or a `:render` return | **Open, and a real gap.** The mechanism exists inside the codec; nothing on the taught `h/` roster reaches it, so today the answer is to write the subtree where children lower — or to write it twice |
 | Declarable conversion defaults on `defhost` | Open — `:callbacks` and `:ssr` are the two options today |
 | Migration codemod | Planned, unbuilt |
 | When `{:ref [id config]}` lands, and what registers an id | Reserved, not designed |

--- a/docs/design/hicasso/draft-guide/08-testing.md
+++ b/docs/design/hicasso/draft-guide/08-testing.md
@@ -15,20 +15,27 @@ lifecycle. A full headless *render* of a view body is designed but **not built**
 
 ## Assert as data (today)
 
+A helper that takes its data as arguments and reads nothing is an ordinary
+function. Call it, and assert on what it returned:
+
 ```clojure
-;; Intent on a button — pure data, no DOM.
-(is (= [:button {:on-click [:todo/toggle 7]} "✓"]
-       (some-lowered-or-hand-built-node)))
+(defn todo-row [{:keys [id title]}]
+  [:li [:span title]
+       [:button {:on-click [:todo/toggle id]} "✓"]])
 
-;; Prevent head is visible to `=` (metadata would not be).
-(is (= [::h/prevent [:conduit/show-your-feed]]
-       (-> anchor second :on-click)))
-
-;; route-link's click decision — closed navigate map (see Events as data).
-(let [click (:on-click attrs)]
-  (is (vector? click))
-  (is (= :re-frame.hicasso/navigate (first click))))
+(deftest todo-row-carries-the-intent
+  (is (= [:li [:span "Buy milk"]
+              [:button {:on-click [:todo/toggle 7]} "✓"]]
+         (todo-row {:id 7 :title "Buy milk"}))))
 ```
+
+The same move reaches the other data spellings, because each is a value sitting in
+the attrs map the helper returned: a `::h/prevent` head, a `route-link`'s closed
+navigate vector, a presence child's exit attrs. `=` is the whole assertion.
+
+A `defview` body is not callable this way. It is a React function component, and a
+body that calls `sub` needs a render extent to read in — which is what the unbuilt
+headless render under Advanced is for.
 
 Events and subscriptions stay ordinary: handlers are functions of coeffects →
 effects map, subs are functions of app-db — test those without any view layer.


### PR DESCRIPTION
Two draft-guide beads, one surface. **The briefing was wrong about the headline defect and I did not work it as briefed** — details below.

## `rf2-2rtt6.120` — the guide never taught `h/as-element`

The brief said the guide teaches `h/as-element` as a recovery. The bead's own VERIFIED line says the opposite, and the bead is right: **zero occurrences** under `docs/design/hicasso/draft-guide/`. Every occurrence lives in `docs/design/hicasso/studio/**` (the four `[:>]` designs, `raw-escape-spec.md`) and `decisions.md` — all outside this PR's fence.

So the guide never named the function. What it did instead is teach one of the two traps the function was supposed to recover, **with a broken sample marked "fine"**:

> The row you build may still carry ordinary intents — `[:li {:on-click [:row/pick id]} title]` is fine

That return is not fine. `render-callback` ends in a bare `(apply f args)` (`front/intent.cljs:506`) — the return crosses **unconverted**, so a hiccup vector reaches React as a vector and is refused. The only `:render` body witnessed in the arm returns a **string** (`host_hatch_dom_cljs_test.cljs:310`, `:792`), and the one test that builds an actual row wraps every return in `codec/as-element` explicitly (`:868`, `:871`).

**What replaced it: nothing, stated as nothing.** `arm1/lang.clj` exports exactly `defview`, `hfn`, `defhost`. The mechanism is real at `front/codec.cljs:1821` but no `h/` spelling reaches it. Per the bead's option (b), the page now says the recovery does not exist rather than naming one — a `Not settled yet` row carries the gap, and the `:render` prose says what actually renders (a string) and what does not.

I also recorded the **second** silent trap, which is live for `defhost` today and had no row: hiccup at a non-callback prop hits `(coll? v) (clj->js v)` (`codec.cljs:1611`) and arrives as `["h2" "Tasks"]` — rendered as text, no error. `refuse-undeclared-host-event!` only guards `on*`-spelled props.

**Flagged, not resolved:** `front/intent.cljs:437` — the implementation's own `render-callback` docstring writes `(h/as-element [:li ...])`. Same defect, `implementation/**` fence, two live workers. Left for `.120`'s arm-side half.

## `rf2-2rtt6.64` — 4 of 9 audit items needed a diff

| Audit | Item | Verdict |
|---|---|---|
| #7382 | 05 opening sample: ns missing `h`, no declared callback contract | **Already discharged** — ns requires `h`, `{:callbacks {:on-change :event}}` declared |
| #7396 | 05 stale "defhost not exercised" / `::h/value` unaddressed; `[:>]` and codemod as existing | **Already discharged** — no residue; both correctly "not built" / "planned, unbuilt" |
| #7398 | `::h/prevent` overclaim vs the event-first law | **Already discharged** — "Intent vectors are event-first" is correct |
| #7482, #7484 | 06 theming: top-level `:theme/apply!`, 1-arg `reg-fx`, no `:platforms` | **Already discharged** — `:fx` row, `(fn [_ctx theme])`, `#{:client}`, all three |
| #7493 | 05 calls one test "the witness for every claim on this page" | **Fixed** — narrowed to the declaration and callback behaviour it actually proves |
| #7501 (1) | `subscribe-once` taught 1-arity outside a render | **Fixed** — 1-arity resolves an ambient frame and raises `:rf.error/no-frame-context` out there (`subs.cljc:1844`). Now teaches `:rf.cofx/requires` for handlers (the docstring's own preference) and `{:frame :main}` for free-standing code |
| #7501 (2) | 08 examples depend on undefined `some-lowered-or-hand-built-node`, `anchor`, `attrs` | **Fixed** — replaced with a helper test that runs |
| #7506 | 01 "Tests and tools can `=` the tree" vs unbuilt headless render | **Mostly discharged** — the audited sentence was already gone; narrowed the surviving "`=` the tree" to "read the handler as a value" |

The 08-testing replacement is a pure helper called as a function — legal because a plain `defn` is spliced by call, not by head position (`[badge {...}]` on an unminted `defn` raises `:rf.error/hicasso-bad-head`). I verified the sample's expected value equals what the helper returns, term for term. It also now states the limit the #7506 audit cared about: a `defview` body is a React component and is not callable this way.

## Net delta

**+47 / −27, net +20** across four files (2,639 → 2,659). Not net-negative, and I think that is right here: the change deletes one false teaching and three undefined symbols, and what replaces them is a *runnable* test plus two troubleshooting rows for traps that were previously silent and undocumented. The `:render` paragraph grew by three lines to stop asserting something untrue. I found nothing worth cutting that a previous pass had not already cut.

## Not touched

`h/frame` (concurrent worker), `[:>]` beyond the existing "not built" prose, the provisional `:rf.error/ambient-frame-refused` id (not printed anywhere), `studio/**`, `implementation/**`, `spec/**`, `decisions.md`, `validation.md`. Zero `below-hiccup` references reintroduced (verified: repo-wide grep is empty).

## Quality gates

| Gate | Exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** |
| `sh scripts/test-fast-pr.sh` | **0** |

**`mkdocs build --strict` is not nominated** — `exclude_docs` keeps `design/hicasso/` off the site, so it would exit 0 having verified nothing. The fast-PR spine runs it regardless.

**Mutation proof.** Broke the one anchor this PR adds — `#not-settled-yet` → `#not-settled-yet-BOGUS` in `05-interop.md`. Confirmed the mutation landed (`grep` showed it at line 126) **before** reading the exit code; the checker then failed **exit 1**, naming `05-interop.md:126 -> #not-settled-yet-BOGUS`. Reverted, tree clean, re-run green.

**Tables hand-counted.** Every table in the two files carrying new or edited rows: 05 Troubleshooting 3 cells (2 rows added, both 3), 05 Not-settled 2 cells (1 row added, 2), 01 Troubleshooting 3 cells (1 row edited, 3), and all sibling rows match their headers. No new headings, so no inbound-link sweep was needed.
