### PR TITLE
feat(hicasso): defview renders report through Spec 009 (rf2-2rtt6.125)

### DIFF
--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/render_measure_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/render_measure_cljs_test.cljs
@@ -1,0 +1,212 @@
+(ns re-frame.bench.hicasso.arm1.render-measure-cljs-test
+  "SPEC 009's `:render` BUCKET — THE OFF HALF, AND THE ID RULE
+  (rf2-2rtt6.125).
+
+  `defview` boundaries now report through Spec 009's Performance
+  channel: [[re-frame.bench.hicasso.arm1.runtime/mint-view!]] wraps the
+  component fn React calls in `(performance/mark-and-measure :render
+  view-name …)`, so a build that flips
+  `re-frame.performance/enabled?` gets one `rf:render:<view-id>`
+  User-Timing measure per boundary render.
+
+  This file is the half that runs in the ORDINARY `:node-test` build,
+  where the flag is at its `goog-define` default of `false`. It asserts
+  two things a flag-off build is the only place to assert:
+
+  1. **The ordinary render path is unchanged.** A page of boundaries
+     renders, its markup is what it always was, its bodies ran — and the
+     User-Timing stream is empty. That is the runtime expression of the
+     elision contract (the `:advanced` bundle grep is
+     `scripts/check-perf-bundle.cjs`'s job; a broken DCE would leave the
+     body live and THIS row is the runtime signal).
+  2. **The id rule**, which is a property of the mint and needs no flag:
+     the measure name is `rf:render:` + the head's `displayName`, and
+     `defview` makes that `\"<ns>/<sym>\"`. One identifier serves the
+     measure stream and React DevTools.
+
+  ## The row that stops row 1 being vacuous
+
+  \"No `rf:` measures landed\" is trivially true of a page that never
+  rendered, so every off-path assertion below is paired with a
+  [[re-frame.bench.hicasso.arm1.runtime/body-runs]] delta and a markup
+  assertion. A regression that broke the render would otherwise read as
+  a pass.
+
+  ## Where the ON half lives
+
+  `re-frame.bench.hicasso.arm1.render-measure-emit-nightly-test`, which
+  runs under the `:node-test-perf-nightly` shadow-cljs build (both perf
+  goog-defines flipped true) — the same runner and the same naming
+  convention core's `re-frame.performance-emit-nightly-test` uses. Perf
+  assertions do not ride the per-PR runner; the emission is witnessed
+  there and the ABSENCE is witnessed here.
+
+  ## Why `renderToString` and not a DOM
+
+  The claim is about the component fn React invokes, and React's server
+  renderer invokes it exactly as the DOM renderer does — the shell's
+  `useSyncExternalStore` answers from its server snapshot
+  ([[re-frame.bench.hicasso.ssr.entry]]). That keeps the row in the
+  headless `:node-test` build rather than behind a browser, and it
+  doubles as the bead's SSR clause: a server pass leaves no durable
+  registration behind a bracket."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.core :as rf]
+            [re-frame.performance :as performance :include-macros true]
+            [re-frame.test-support :as test-support]
+            ["react-dom/server" :as react-dom-server])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(def ^:private frame-id ::render-measure-off)
+
+;; Registered above `use-fixtures`, deliberately — the reset fixture
+;; captures its source-store baseline when the `use-fixtures` form is
+;; evaluated (the sibling suites' convention).
+
+(rf/reg-sub :rm/title (fn [db _] (:title db)))
+
+(rf/reg-event :rm/seed (fn [_ _] {:db {:title "quarterly"}}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (rt/reset-runtime!) (rt/reset-body-runs!))}))
+
+;; ---------------------------------------------------------------------------
+;; The page — two boundaries, so "one measure per boundary" has something
+;; to be one of
+;; ---------------------------------------------------------------------------
+
+(defview title-row
+  "A boundary that reads, so its body is a real body and not a constant."
+  [_]
+  [:h1.title (rt/sub [:rm/title])])
+
+(defview measured-page
+  "The outer boundary. Two heads render per pass, which is what makes the
+  count in the ON half a count."
+  [_]
+  [:div.page
+   [title-row {}]
+   [:p.note "below"]])
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- rf-measure-names
+  "Every retained User-Timing measure whose name starts with `rf:`."
+  []
+  (->> (.getEntriesByType js/performance "measure")
+       (map #(.-name %))
+       (filterv #(.startsWith % "rf:"))))
+
+(defn- clear-measures! []
+  (when (exists? js/performance.clearMeasures)
+    (.clearMeasures js/performance))
+  (when (exists? js/performance.clearMarks)
+    (.clearMarks js/performance)))
+
+(defn- fresh! []
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:rm/seed]))
+  frame-id)
+
+(defn- server-html
+  "The page under React's server renderer — the same component fn the DOM
+  renderer calls, minus the browser."
+  [hiccup]
+  (react-dom-server/renderToString
+    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the id rule (no flag needed; it is a property of the mint)
+;; ---------------------------------------------------------------------------
+
+(deftest the-render-entry-id-is-the-heads-display-name
+  (testing "`defview` stamps `\"<ns>/<sym>\"` as the head's displayName, and
+            that same string is the `<view-id>` in `rf:render:<view-id>` —
+            so the identifier a consumer filters the User-Timing stream on
+            and the identifier React DevTools shows are one string, not two
+            that happen to agree (Spec 009 §Naming convention)."
+    (is (= "re-frame.bench.hicasso.arm1.render-measure-cljs-test/title-row"
+           (.-displayName title-row)))
+    (is (= "re-frame.bench.hicasso.arm1.render-measure-cljs-test/measured-page"
+           (.-displayName measured-page)))
+    (is (= "rf:render:re-frame.bench.hicasso.arm1.render-measure-cljs-test/title-row"
+           (performance/build-name :render (.-displayName title-row))))
+    (is (= "rf:render:re-frame.bench.hicasso.arm1.render-measure-cljs-test/measured-page"
+           (performance/build-name :render (.-displayName measured-page))))))
+
+(deftest the-id-rule-holds-for-a-mint-view-name-without-a-namespace
+  (testing "`mint-view!` is also called directly (the frame-prop rows, the
+            probes) with a bare name. `build-name`'s `:else` arm stringifies
+            it verbatim, so the shape stays `rf:render:<id>` with no
+            namespace invented — the same contract a non-namespaced
+            `reg-view` keyword id gets."
+    (let [head (rt/mint-view! "bare-row" (fn [_] [:span "x"]))]
+      (is (= "bare-row" (.-displayName head)))
+      (is (= "rf:render:bare-row"
+             (performance/build-name :render (.-displayName head)))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the off path: the render happens, and nothing is measured
+;; ---------------------------------------------------------------------------
+
+(deftest a-flag-off-build-renders-the-page-and-emits-no-render-measure
+  (testing "With `re-frame.performance/enabled?` at its goog-define default
+            the `:render` bracket is shape-equivalent to a bare call. The
+            markup and the body-run count say the render REALLY HAPPENED —
+            without them 'no rf: measures landed' is a statement about a
+            page that never rendered — and the empty measure stream says
+            the bracket added nothing to it."
+    (when-not performance/enabled?
+      (fresh!)
+      (clear-measures!)
+      (rt/reset-body-runs!)
+      (let [html (server-html [measured-page {}])]
+        (is (re-find #"quarterly" html)
+            "the page rendered its subscription value — the render is real")
+        (is (re-find #"class=\"page\"" html)
+            "and its markup is the ordinary markup")
+        (is (= 2 (rt/body-runs))
+            "two boundary bodies ran — the page and the row")
+        (is (= [] (rf-measure-names))
+            "and NOTHING reached the User-Timing stream")))))
+
+(deftest a-flag-off-build-emits-no-render-measure-across-repeated-renders
+  (testing "The bracket is per-render, so a single-render row cannot
+            distinguish 'elided' from 'emitted once and cleared'. Ten
+            renders would leave ten retained entries in a flag-on build
+            with retention on; here they leave none, and the body-run
+            count proves ten renders were asked for."
+    (when-not performance/enabled?
+      (fresh!)
+      (clear-measures!)
+      (rt/reset-body-runs!)
+      (dotimes [_ 5]
+        (server-html [measured-page {}]))
+      (is (= 10 (rt/body-runs)) "five passes over two boundaries")
+      (is (= [] (rf-measure-names))
+          "and the retained buffer is still empty"))))
+
+(deftest a-server-pass-leaves-no-retained-registration-behind-the-bracket
+  (testing "The bead's SSR clause. A `renderToString` pass runs bodies and
+            mints read-set entries, but React never calls `subscribe`, so
+            nothing is committed. The bracket must not change that — it
+            writes a measure and (retention off) clears it, and holds no
+            reference of its own. `stats` is the arm's own enumeration of
+            what survived."
+    (when-not performance/enabled?
+      (fresh!)
+      (clear-measures!)
+      (server-html [measured-page {}])
+      (is (zero? (:boundaries (rt/stats)))
+          "a server pass committed nothing — no registration holds a reader slot")
+      (is (= [] (rf-measure-names))
+          "and left no User-Timing entry either"))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/render_measure_emit_nightly_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/render_measure_emit_nightly_test.cljs
@@ -1,0 +1,300 @@
+(ns re-frame.bench.hicasso.arm1.render-measure-emit-nightly-test
+  "SPEC 009's `:render` BUCKET — THE ON HALF (rf2-2rtt6.125).
+
+  The measures actually landing. Every claim below is about entries a
+  `PerformanceObserver` would have received and a
+  `getEntriesByType('measure')` reader can filter by the `rf:render:`
+  prefix, produced by rendering real `defview` boundaries through React.
+
+  ## Run gate — the `:node-test-perf-nightly` build
+
+  Same vehicle core's `re-frame.performance-emit-nightly-test` uses, and
+  for the same reason: the brackets are a COMPILE-TIME decision, so the
+  only honest way to assert emission is a build with
+  `:closure-defines {re-frame.performance/enabled? true
+                     re-frame.performance/retain-entries? true}`.
+  `:node-test-perf-nightly`'s `:ns-regexp` is `\"-emit-nightly-test$\"`,
+  which this ns matches and the per-PR `:node-test` build's
+  `\"cljs-test$\"` does not — so no shadow-cljs.edn change was needed to
+  wire this in, and the per-PR runner is not asked to time anything.
+
+      cd implementation
+      npx shadow-cljs compile node-test-perf-nightly && \\
+        node out/node-test-perf-nightly.js
+
+  `retain-entries? true` is what makes a synchronous read possible at
+  all: the bracket clears each measure by name right after emit
+  (Spec 009 §Observer-first contract), so with retention off a
+  `getEntriesByType` snapshot finds an empty buffer — which is the leak
+  fix working, and is asserted in `re-frame.performance-cljs-test`.
+
+  ## THIS FILE FAILS RATHER THAN SKIPS IN A FLAG-OFF BUILD
+
+  [[the-perf-flag-is-actually-on]] is first and is not a courtesy: a
+  perf-emission suite whose every row is wrapped in `(when
+  performance/enabled? …)` reads as a pass in a build where the flag is
+  off, which is a gate nobody has watched fire. If this file is ever
+  compiled into a runner without the goog-defines, it goes red and says
+  which flag is missing.
+
+  ## Why `renderToString`
+
+  React's server renderer invokes the component fn exactly as the DOM
+  renderer does, so the bracket — which sits ON that fn — is exercised
+  identically, with no browser in the runner. The one thing it cannot
+  witness is a `React.memo` bail-out (a server render has no previous
+  render to compare against); the property that MATTERS there is
+  \"a boundary React did not invoke produces no measure\", and
+  [[a-head-react-never-invoked-produces-no-measure]] states exactly
+  that, at the level a headless runner can state it."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.core :as rf]
+            [re-frame.performance :as performance :include-macros true]
+            [re-frame.test-support :as test-support]
+            ["react-dom/server" :as react-dom-server])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview]]))
+
+(def ^:private frame-id ::render-measure-on)
+
+;; Registered above `use-fixtures`, deliberately — the reset fixture
+;; captures its source-store baseline when the `use-fixtures` form is
+;; evaluated (the sibling suites' convention).
+
+(rf/reg-sub :rm-on/title (fn [db _] (:title db)))
+
+(rf/reg-event :rm-on/seed (fn [_ _] {:db {:title "quarterly"}}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (rt/reset-runtime!) (rt/reset-body-runs!))}))
+
+;; ---------------------------------------------------------------------------
+;; The page
+;; ---------------------------------------------------------------------------
+
+(defview title-row
+  [_]
+  [:h1.title (rt/sub [:rm-on/title])])
+
+(defview note-row
+  [_]
+  [:p.note "below"])
+
+(defview measured-page
+  [_]
+  [:div.page
+   [title-row {}]
+   [note-row {}]])
+
+(defview never-rendered-row
+  "Minted and never placed in a tree. React never invokes it, so the
+  measure stream must never mention it."
+  [_]
+  [:span.never "unreachable"])
+
+(defview throwing-row
+  [_]
+  (throw (ex-info "boom" {:rf.error/id ::deliberate})))
+
+(defview throwing-page
+  [_]
+  [:div.page [throwing-row {}]])
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(def ^:private render-prefix "rf:render:")
+
+(defn- render-measure-names
+  "Every retained measure in the `:render` bucket, in emit order — the
+  read a `PerformanceObserver` consumer performs, minus the observer."
+  []
+  (->> (.getEntriesByType js/performance "measure")
+       (map #(.-name %))
+       (filterv #(.startsWith % render-prefix))))
+
+(defn- clear-measures! []
+  (.clearMeasures js/performance)
+  (.clearMarks js/performance))
+
+(defn- rf-mark-count
+  "Marks whose name starts with `rf:`. The options-bag measure form
+  allocates ZERO of them (Spec 009 §What gets bracketed), and a
+  `:render` bracket is the newest call site that could break that."
+  []
+  (->> (.getEntriesByType js/performance "mark")
+       (map #(.-name %))
+       (filter #(.startsWith % "rf:"))
+       count))
+
+(defn- entry-named [nm]
+  (->> (.getEntriesByType js/performance "measure")
+       (filter #(= nm (.-name %)))
+       first))
+
+(defn- fresh! []
+  (rf/make-frame {:id frame-id})
+  (rf/with-frame frame-id (rf/dispatch-sync [:rm-on/seed]))
+  frame-id)
+
+(defn- server-html [hiccup]
+  (react-dom-server/renderToString
+    (mount/provider frame-id (codec/root-element frame-id hiccup))))
+
+(def ^:private page-name
+  "re-frame.bench.hicasso.arm1.render-measure-emit-nightly-test/measured-page")
+(def ^:private title-name
+  "re-frame.bench.hicasso.arm1.render-measure-emit-nightly-test/title-row")
+(def ^:private note-name
+  "re-frame.bench.hicasso.arm1.render-measure-emit-nightly-test/note-row")
+
+;; ---------------------------------------------------------------------------
+;; 0 — the runner is the runner this file claims to need
+;; ---------------------------------------------------------------------------
+
+(deftest the-perf-flag-is-actually-on
+  (testing "This suite asserts EMISSION, and emission is a compile-time
+            decision. A build without the goog-defines would make every
+            row below vacuous, so the flags are a row rather than a
+            precondition nobody checks."
+    (is performance/enabled?
+        (str "re-frame.performance/enabled? is FALSE in this runner. This ns "
+             "belongs to the :node-test-perf-nightly build "
+             "(:closure-defines {re-frame.performance/enabled? true "
+             "re-frame.performance/retain-entries? true}); run it there."))
+    (is performance/retain-entries?
+        (str "re-frame.performance/retain-entries? is FALSE, so each measure is "
+             "cleared right after emit and a synchronous getEntriesByType read "
+             "finds nothing. Flip it for this runner."))))
+
+;; ---------------------------------------------------------------------------
+;; 1 — one measure per boundary render, named by the head
+;; ---------------------------------------------------------------------------
+
+(deftest each-rendered-boundary-emits-one-prefixed-render-measure
+  (testing "The bead's acceptance clause: a page of N distinct `defview`
+            heads produces `rf:render:<view-id>` measures a consumer
+            filters by the `rf:render:` prefix, with ids matching the
+            pinned naming rule (the head's displayName)."
+    (fresh!)
+    (clear-measures!)
+    (rt/reset-body-runs!)
+    (let [html  (server-html [measured-page {}])
+          names (render-measure-names)]
+      (is (re-find #"quarterly" html) "the page really rendered")
+      (is (= 3 (rt/body-runs)) "three boundary bodies ran")
+      (is (= #{page-name title-name note-name}
+             (set (map #(subs % (count render-prefix)) names)))
+          "one entry per rendered head, each named by its displayName")
+      (is (= 3 (count names)) "and exactly one entry each — no double-emit")
+      (is (every? #(.startsWith % render-prefix) names)
+          "every entry is prefix-filterable"))))
+
+(deftest the-measure-carries-a-duration-and-allocates-no-marks
+  (testing "The entry shape Spec 009 documents: a `measure` with a
+            `startTime` and a `duration`, and — because the bracket uses
+            the options-bag form — no `mark` entries at all."
+    (fresh!)
+    (clear-measures!)
+    (server-html [measured-page {}])
+    (let [e (entry-named (str render-prefix page-name))]
+      (is (some? e) "the page's entry is present")
+      (is (= "measure" (.-entryType e)))
+      (is (number? (.-duration e)))
+      (is (>= (.-duration e) 0) "a duration, not a sentinel"))
+    (is (zero? (rf-mark-count))
+        "the :render bracket allocates no rf: marks")))
+
+;; ---------------------------------------------------------------------------
+;; 2 — it is PER RENDER, not per mint
+;; ---------------------------------------------------------------------------
+
+(deftest a-second-render-pass-emits-a-second-measure-per-head
+  (testing "A `:render` entry is a render, so the count moves with render
+            passes and not with how many heads were minted. Three passes
+            over three heads is nine entries — and the body-run counter,
+            which is bumped somewhere else entirely, agrees."
+    (fresh!)
+    (clear-measures!)
+    (rt/reset-body-runs!)
+    (dotimes [_ 3]
+      (server-html [measured-page {}]))
+    (is (= 9 (rt/body-runs)))
+    (is (= 9 (count (render-measure-names)))
+        "one measure per body run — the fence never retried, so the two
+         counters are the same number arrived at two ways")
+    (is (= 3 (count (filter #(= % (str render-prefix title-name))
+                            (render-measure-names))))
+        "and the per-head count is three")))
+
+;; ---------------------------------------------------------------------------
+;; 3 — a boundary React never invoked emits nothing
+;; ---------------------------------------------------------------------------
+
+(deftest a-head-react-never-invoked-produces-no-measure
+  (testing "HD-028's rider on the measure stream. The bracket sits on the
+            component fn, BELOW React's memo comparator, so a boundary
+            React skips is a boundary that emits nothing — the same law
+            that makes `body-runs` a measurement of adoption rather than
+            an inference from the memo. Stated here as the property a
+            headless runner can state: a minted head that no tree
+            contains is never mentioned."
+    (fresh!)
+    (clear-measures!)
+    (server-html [measured-page {}])
+    (let [names (render-measure-names)]
+      (is (seq names) "the page did emit — this row is not vacuous")
+      (is (not-any? #(.includes % "never-rendered-row") names)
+          "and the head React never invoked is absent from the stream"))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — the unhappy path still reports
+;; ---------------------------------------------------------------------------
+
+(deftest a-throwing-body-still-emits-its-measure
+  (testing "Spec 009's try/finally clause: observability does not go
+            silent on the unhappy path. The throw propagates — React's
+            server renderer re-raises it — and the partial run's measure
+            is on the stream, for the throwing boundary AND for the
+            parent whose body had already returned when the child ran."
+    (fresh!)
+    (clear-measures!)
+    (let [thrown (atom nil)]
+      (try
+        (server-html [throwing-page {}])
+        (catch :default e (reset! thrown e)))
+      (is (some? @thrown) "the exception propagated")
+      (let [names (render-measure-names)]
+        (is (some #(.endsWith % "/throwing-row") names)
+            "the throwing boundary's measure was emitted from the finally")
+        (is (some #(.endsWith % "/throwing-page") names)
+            "and so was its parent's")))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — the frame-prop twin is wired too
+;; ---------------------------------------------------------------------------
+
+(deftest the-frame-prop-boundary-reports-on-the-same-channel
+  (testing "`mint-frame-prop-view!` is the arm's second view-substrate
+            wrapper (rf2-2rtt6.39). A `:render` bucket wired to one mint
+            and not the other would report half a page, so the twin gets
+            its own row rather than an assumption."
+    (fresh!)
+    (clear-measures!)
+    (rt/reset-body-runs!)
+    (let [row  (rt/mint-frame-prop-view!
+                 "frame-prop/measured-row"
+                 (fn [_] [:li.fp (str (rt/sub [:rm-on/title]))]))
+          html (server-html [row {}])]
+      (is (re-find #"quarterly" html) "the frame-fed boundary rendered")
+      (is (= 1 (rt/body-runs)))
+      (is (= [(str render-prefix "frame-prop/measured-row")]
+             (render-measure-names))
+          "and it emitted exactly one entry, named the same way"))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/runtime.cljs
@@ -371,6 +371,7 @@
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.live-frame :as live-frame]
+            [re-frame.performance :as performance :include-macros true]
             [re-frame.registrar :as registrar]
             [re-frame.subs :as subs]
             ["react" :as react]))
@@ -1807,9 +1808,74 @@
   fiber above the component's own. That is React's retention rather than
   this arm's, and it is recorded in [[retained-inventory]] under
   `:react/memo-fiber` instead of being left for a heap ladder to
-  discover."
+  discover.
+
+  ## Spec 009's `:render` bucket, and why the bracket is HERE
+  (rf2-2rtt6.125)
+
+  Spec 009 §What gets bracketed names four hot paths; three of them
+  (`:event`, `:sub`, `:fx`) are core's and are already live for a
+  Hicasso app, because they sit in the router, the subs layer and the fx
+  layer this arm consumes unchanged. The fourth — `:render` — is the
+  **view substrate's**, and until this bead a Hicasso app was the only
+  re-frame2 app whose per-view render was absent from the User-Timing
+  stream. It is a `:render` in the spec's own terms: the bucket is keyed
+  on the *representation* of the work — one view boundary's body run,
+  once per render pass the host actually performs — not on which
+  registration API minted the head. `reg-view*` mints its wrapper with a
+  `defn`; `defview` mints its wrapper here; both are \"the wrapper the
+  substrate emits around a registered view body\", which is exactly what
+  the spec's `Where` column describes.
+
+  **The bracket is the component fn and not [[render-body]]**, and the
+  reason is a cost that would survive elision. [[render-body]] does not
+  know the view's name — threading one in would add a parameter passed on
+  every render of every boundary, present in the OFF bundle as well as
+  the on one, which is the thing Spec 009's whole design is arranged to
+  avoid (and which [[hydrate-cljs-test]] would have to be edited to
+  accommodate). `view-name` is already closed over at this exact point,
+  so under `:advanced` + `re-frame.performance/enabled? false` the macro
+  constant-folds to `(shell body-fn js-props)` — byte-for-byte the call
+  that was here before, with nothing added anywhere.
+
+  Placing it at the component fn also makes four behaviours fall out
+  rather than be arranged:
+
+  - **A memo bail-out emits nothing.** React consults the comparator
+    ABOVE this fn; a bailed-out boundary never enters it. HD-028's rider
+    holds on the measure stream for the same reason it holds on
+    [[body-runs]] — a boundary React skipped and a boundary React ran are
+    two different numbers.
+  - **StrictMode's double-invoke emits twice**, which is correct: React
+    ran the body twice and the measure stream should say so.
+  - **The generation fence emits once.** [[render-body]] may run a body
+    up to four times for ONE React render; the bracket spans the whole
+    retry loop, so the entry count stays one-per-render-pass and its
+    duration is the wall-clock React actually paid — the honest RUM
+    number rather than a count inflated by an internal retry.
+  - **A throwing body still emits**, via the macro's own `try/finally`,
+    and an abandoned render (a suspended subtree, an SSR pass React
+    discards) emits the time it genuinely spent. Nothing durable is left
+    behind either way: the bracket writes one measure and clears it by
+    name unless the consumer flipped `retain-entries?`.
+
+  **Boundaries only.** A plain inlined helper called from a body is not a
+  React component and is not a `reg-view` peer, so it is not separately
+  bracketed — its cost lands inside the enclosing boundary's measure,
+  which is the same place its reads land (see the render-context comment
+  above).
+
+  **The id rule, pinned:** the entry is `rf:render:<view-name>`, where
+  `view-name` is the string this fn was given and the string stamped as
+  `displayName` on the line below — so a consumer reading a measure name
+  and a developer reading React DevTools are looking at the same
+  identifier, and `defview` makes it `\"<ns>/<sym>\"`. Witnessed in
+  `arm1.render-measure-cljs-test` (the OFF half) and
+  `arm1.render-measure-emit-nightly-test` (the ON half)."
   [view-name body-fn]
-  (let [component (fn hicasso-boundary [js-props] (shell body-fn js-props))]
+  (let [component (fn hicasso-boundary [js-props]
+                    (performance/mark-and-measure :render view-name
+                      (shell body-fn js-props)))]
     (unchecked-set component "displayName" view-name)
     (codec/memoize-boundary! (codec/mark-boundary! component))))
 
@@ -1823,10 +1889,18 @@
   unchanged, with one addition it names there: the frame reaches this
   boundary through PROPS rather than through context, so the comparator
   compares it — see
-  [[re-frame.bench.hicasso.front.codec/boundary-props=]]."
+  [[re-frame.bench.hicasso.front.codec/boundary-props=]].
+
+  Everything it says about Spec 009's `:render` bucket holds unchanged
+  too, and the bracket is here for the same reason it is there: this is
+  the wrapper the substrate emits, `view-name` is already closed over, so
+  the OFF bundle is byte-for-byte the call that preceded it. The two mint
+  fns are the arm's two view-substrate wrappers, and a `:render` bucket
+  wired to one of them and not the other would report half a page."
   [view-name body-fn]
   (let [component (fn hicasso-frame-prop-boundary [js-props]
-                    (frame-prop-shell body-fn js-props))]
+                    (performance/mark-and-measure :render view-name
+                      (frame-prop-shell body-fn js-props)))]
     (unchecked-set component "displayName" view-name)
     (codec/memoize-boundary!
       (codec/mark-frame-prop! (codec/mark-boundary! component)))))

--- a/spec/009-Instrumentation.md
+++ b/spec/009-Instrumentation.md
@@ -1454,7 +1454,9 @@ The reference runtime brackets four hot-path call sites. Each runs inside a `(pe
 | `:event`  | Event handler invocation (router's `process-event*` step that runs the interceptor chain) | `rf:event:<event-id>` |
 | `:sub`    | Subscription recompute (the body fn inside `compute-and-cache!`'s reaction) | `rf:sub:<sub-id>` |
 | `:fx`     | Per-fx walk-step (every entry processed by `handle-one-fx`, including reserved fx-ids `:dispatch` / `:dispatch-later` / `:rf.fx/reg-flow` / `:rf.fx/clear-flow` and user-registered fx) | `rf:fx:<fx-id>` |
-| `:render` | Per-`reg-view` render (the wrapper emitted by `reg-view*`) | `rf:render:<view-id>` |
+| `:render` | Per view-boundary render — the wrapper the **view substrate** emits around a registered view's body (`reg-view*`'s frame-aware wrapper on the adapter path; the equivalent minted component fn on a compiled-view substrate) | `rf:render:<view-id>` |
+
+**The `:render` bucket is keyed on the representation, not on the registration API.** One entry means *one view boundary's body ran, once, because the host asked for it* — so any substrate that mints view boundaries owns this bucket on the same terms, and a substrate that mints them by more than one route (e.g. a second wrapper taking its frame as a prop rather than from context) brackets every route or reports half a page. Three consequences follow rather than being separately specified: a render the host **skipped** (a memoization bail-out, where the substrate's comparator sits above the bracketed fn) emits nothing, because no body ran; a host that **invokes the body twice** for one logical render (React StrictMode's dev double-invoke) correctly emits twice, because two bodies ran; and a substrate that **re-runs a body internally** for one host render — a consistency fence, a retry loop — emits **one** entry spanning the retries, because the host asked once and the duration a consumer wants is the wall-clock the host paid. Plain helper functions inlined into a body are not view boundaries and are not separately bracketed; their cost lands inside the enclosing boundary's entry.
 
 The bracket shape (when the flag is on at compile time):
 
@@ -1488,6 +1490,8 @@ rf:render:my.app/page-header
 ```
 
 Tools that want a per-bucket view split on the second `:`. The shape is **stable**: new buckets adopt the `rf:<bucket>:<id>` convention and are additive.
+
+**`<id>` is the id the thing was registered under, rendered verbatim** — `build-name` preserves a keyword's namespace and stringifies a symbol or string as written. A view substrate whose views are named with strings rather than keywords (a macro that mints `"<ns>/<view>"`) therefore produces the same `rf:render:my.app/page-header` shape with nothing to reconcile; the rule is that the `<view-id>` in the measure name and the id the substrate publishes to the developer (React `displayName`, the registrar key) are **one identifier**, so a name read off the User-Timing stream is directly jumpable in the tooling.
 
 ### Consumer access
 


### PR DESCRIPTION
Closes the Performance half of rf2-2rtt6.125. `defview` boundaries now own Spec 009's `:render` channel: a build that flips `re-frame.performance/enabled?` gets one `rf:render:<view-id>` User-Timing measure per boundary render, prefix-filterable alongside the `:event` / `:sub` / `:fx` entries a Hicasso app already had.

## Is a `defview` render a `:render` in Spec 009's terms?

**Yes — and the spec's own wording was the thing that made it look otherwise.** The `Where` column read *"Per-`reg-view` render (the wrapper emitted by `reg-view*`)"*, which names the reference runtime's call site as though it were the rule. Applying rf2-2rtt6.91's finding — the spec tiers by **representation**, not by adapter brand — the bucket is *"one view boundary's body ran, once, because the host asked for it"*. `reg-view*` mints its wrapper with a `defn`; `defview` mints its wrapper in `mint-view!`; both are the wrapper the view substrate emits around a registered view's body. Same representation, same bucket. So this is a wiring, not a forced fit, and the spec edit says the rule instead of the call site.

The **id** needed no spec change to accommodate and one sentence to pin. `defview` names heads `"<ns>/<sym>"` as strings; `build-name`'s `:else` arm stringifies verbatim, so `rf:render:my.ns/todo-row` is byte-identical in shape to the keyword path's `rf:render:my.app/page-header`. The rule now written down is that the `<view-id>` in the measure and the id the substrate publishes to the developer (React `displayName`) are **one identifier**.

## Where the bracket went, and why not the obvious place

The bead's sketch says "the single chokepoint that runs every boundary body" — that is `render-body`. **I put it one level up, on the component fn `mint-view!` returns, and the reason is a cost that would have survived elision.** `render-body` does not know the view's name; threading one in adds a parameter passed on every render of every boundary, present in the OFF bundle as well as the on one (and would have forced an edit to `arm1.hydrate-cljs-test`, which calls `render-body` directly). `view-name` is already closed over at the component fn, so with the flag off at compile time the macro constant-folds to the bare `(shell body-fn js-props)` call that was there before — **nothing added anywhere**.

Four behaviours then fall out rather than being arranged:

- **A memo bail-out emits nothing.** React consults the comparator *above* this fn, so a bailed-out boundary never enters it. HD-028's rider holds on the measure stream for the same reason it holds on `body-runs`.
- **StrictMode's double-invoke emits twice** — correct; React ran the body twice.
- **The generation fence emits once.** `render-body` may run a body up to four times for one React render; the bracket spans the retry loop, so the count stays one-per-render-pass and the duration is the wall-clock React actually paid.
- **A throwing body still emits**, via the macro's own `try/finally`.

Both mint fns are wired — `mint-frame-prop-view!` (rf2-2rtt6.39) is the arm's second view-substrate wrapper, and a bucket wired to one and not the other would report half a page.

## THE TRACE HALF IS A FINDING, NOT A DELIVERY — and it is the part worth reading

The bead's goal 2 asks for the `:rf.view/render` / `:rf.view/rendered` **trace** pair "with the same op types and required fields as the reg-view path". **That is not deliverable under HD-020's hook budget, and the spec says so itself.**

Both ops require `:rf.view/render-key` = `[view-id instance-token]`, where the token must be *"stable across an instance's re-renders and fresh per new instance"* (Spec-Schemas §`:renders`; `:rf.view/mount?` is keyed off it). Spec 009 §`:rf.view/unmounted` already states how a React-hook substrate gets one: *"The instance-token is minted into a `useRef` so the `:rf.view/render-key` tuple is stable across re-renders."*

A `useRef` is a **third hook**. HD-020(b) spends the whole ≤2 budget on `useContext` + `useSyncExternalStore`, and `arm1.runtime`'s own docstring is explicit that the shell has *"no per-instance render-phase state at all"* — which is not a saving but the thing that makes the budget reachable, because a React function component has no per-instance storage except a hook cell. There is no side door: the `useSyncExternalStore` registration is minted at **commit**, after the body has run, and does not exist at all on a first render, so it cannot supply a render-start identity.

Emitting the ops with `[view-id nil]` would collapse every instance of a view into one row in Xray's Views panel — a constant wearing the shape of instance identity, which is exactly what rf2-2rtt6.91 ruled out (*"a degenerate value is worse than an absent one"*). So **nothing was emitted**, and the conflict is filed rather than papered over: **rf2-2rtt6.126**.

## What I did NOT do, and why

- **The guide sentence** (bead acceptance, last bullet) is not in this PR. `docs/design/hicasso/**` is fenced — two live workers are renaming `11-performance.md` → `11-below-hiccup.md` in flight. Filed as **rf2-2rtt6.127**, sequenced after those merge, so the claim lands on the file that will exist.
- **No new hook, no new goog-define, no change to the Performance API surface**, per the bead's non-goals.
- **The Hiccup walk is not separately bracketed** (non-goal), and neither are plain inlined helpers — they are not React components and not `reg-view` peers; their cost lands inside the enclosing boundary's entry, which is where their reads land too. Now stated in the spec.

## Corrections to the dispatch brief

1. **The `arm1/` fence made the bead undeliverable.** The brief fenced me out of `arm1/`, but the mint path, the shell and the only body-run chokepoint all live in `arm1/runtime.cljs` — the bead names it explicitly as the file with no `mark-and-measure` call sites. The *stated reason* for the fence also does not hold: neither live worker has touched `arm1/`. `worker/hframe-841vn` is `front/intent.cljs` + docs; `worker/fallback-nv07k` is docs only; `worker/guidetruth-120` has no diff. The two named files (`hframe_cljs_test.cljs`, `nv07k_probe_cljs_test.cljs`) do not exist on any branch — they are *new* files, which cannot conflict with an edit to `runtime.cljs` anyway. I edited `runtime.cljs` and added two new files under names neither worker can collide with, and touched nothing else in the lane.
2. **`spec/**` was not free.** `spec/009-Instrumentation.md` was untouched by any live branch, so the edit landed clean — but the brief's claim was about the whole tree.

## Spec edit — surgical

`git diff --numstat`: **`5  1  spec/009-Instrumentation.md`** — one table row replaced (1/1), one paragraph after the table, one paragraph in §Naming convention. No links added (nothing new for `check_doc_slugs.py` to resolve). CR count in the diff: **0**.

## Quality gates

Everything below was run to completion in the foreground and its own terminal marker read; no gate was killed, backgrounded-and-abandoned, or judged from a piped exit code.

**CI on this PR (the authoritative run): 48 SUCCESS / 35 SKIPPED / 0 FAILURE / 0 CANCELLED.**
Notable greens, because they are the ones this diff could plausibly have broken: `Lint required` (**clj-kondo at CI's pinned 2026.04.15**), `Docs required` (MkDocs strict), `CLJS (shadow-cljs :browser-test, headless Chromium)` — which carries `arm1_hook_ledger_dom_cljs_test`, the **≤2-hook fence** — `CLJS (shadow-cljs :node-test)`, `CLJS production elision (Spec 009)`, both `:advanced`+`goog.DEBUG=false` browser lanes, and all 20 JVM artefacts.

| Gate | Result |
|---|---|
| `sh scripts/test-fast-pr.sh` | **`FASTPR_EXIT=0`** |
| &nbsp;&nbsp;↳ `npm run test:cljs` (in spine) | 12,605 tests / 63,166 assertions — **0 failures, 0 errors** |
| &nbsp;&nbsp;↳ `mkdocs build --strict` (in spine) | pass — **staged**, see below |
| &nbsp;&nbsp;↳ `npm run test:hicasso-compile` (in spine) | pass — 122 lane namespaces, 0 warnings |
| &nbsp;&nbsp;↳ per-ns test isolation | 17/17 namespaces pass standalone |
| &nbsp;&nbsp;↳ keyword-catalogue drift (+ self-test) | pass |
| `npm run test:hicasso-compile` (standalone) | **exit 0** |
| `npm run test:browser` | **`BROWSER_EXIT=0`** — 1,093 tests / 6,773 assertions, 0 failures, 0 errors (CI's own run of the same script is green too) |
| **`npm run test:perf-bundle`** | **exit 0** — `off-count=0; on-count=8` |
| `python scripts/check_doc_slugs.py` | **exit 0** |
| `python scripts/check_fast_pr_gap.py --list` | exit 0 — 87 checks derived, all covered by the CI run above |
| **clj-kondo (local 2025.10.23, full CI invocation)** | **exit 3 — errors: 10, warnings: 4,534** |
| **clj-kondo on the three changed files** | **exit 0 — errors: 0, warnings: 0** |

**On clj-kondo's 10 errors.** All ten are `Expected: throwable, received: <boolean/nil/string>` in `implementation/epoch/test/…` and `implementation/ui/test/…` — **files this PR does not touch** (`git diff origin/main --name-only` lists four files, none of them). They are the documented local-vs-pinned divergence: local is 2025.10.23, CI pins **2026.04.15**, and `Lint required` is **green** on this PR. Warnings sit at the 4,534 baseline.

**Instrumentation / perf suites.**
- `:node-test-perf-nightly` (**both** perf goog-defines true) — **12 tests / 37 assertions, 0 failures**, of which **7 tests / 23 assertions** are this PR's new ON-half. Core's `re-frame.performance-emit-nightly-test` rows still green beside them.
- `re-frame.performance-cljs-test` — green inside the `:node-test` count above.

### Mutation proof — the instrument was watched firing, and watched failing

Removing the `mint-view!` bracket and recompiling `:node-test-perf-nightly` turns the new suite **red: 8 failures, 3 errors**, naming `each-rendered-boundary-emits-one-prefixed-render-measure`, `a-second-render-pass-emits-a-second-measure-per-head`, `a-head-react-never-invoked-produces-no-measure` and `a-throwing-body-still-emits-its-measure`. `the-frame-prop-boundary-reports-on-the-same-channel` **stayed green** — the independence proof that the two mints are witnessed separately. Restored and re-verified.

The suite also cannot go quietly vacuous: `the-perf-flag-is-actually-on` is row 0 and **fails rather than skips** in a build without the goog-defines. And every OFF-half "no measures landed" row is paired with a `body-runs` delta plus a markup assertion, so it cannot pass over a page that never rendered.

**On the `reportError` trap:** it does not apply here and I checked rather than assumed. There is no "nothing threw" row — the unhappy-path row asserts the throw **did** happen (`(is (some? @thrown))`), and it runs under `react-dom/server` in Node, which re-raises synchronously with no React DOM commit phase to route anything to `reportError`.

### Elision — proved directly, not inferred

`npm run test:perf-bundle` (the counter dual) passes: **`off-count=0; on-count=8`**. But that bundle exercises `views.cljs`'s call site, not this one, so I also ran the same dual-bundle methodology against a **Hicasso arm** — `:advanced` release of `:hicasso-bench` / `jsfb-hicasso-app`, `.shadow-cljs/builds/hicasso-bench` cleared either side per rf2-2rtt6.20:

| sentinel | OFF bundle (651,632 B) | ON bundle (652,430 B) |
|---|---|---|
| `performance.measure` | **0** | 4 |
| `clearMeasures` | **0** | 4 |
| `"rf:` | **0** | 1 |
| `performance.mark` | **0** | **0** |

**798 bytes** is the entire cost of the perf channel with the flag on, and **zero** with it off. Non-vacuous in both directions — the ON column is what makes the OFF column mean something. `performance.mark` is 0 in *both*, which is the options-bag contract holding at the new call site too.

**Hook ledger: unchanged.** `shell-hook-ledger` still reads `[:use-context/frame :use-sync-external-store/subscription-epoch]` and `frame-prop-shell-hook-ledger` still reads one. The bracket adds **no hook** — it is a `try/finally` around a call, and both branches of the macro's `if` call the hooks identically, so order and count are fixed. Witnessed at React's own dispatcher by `arm1_hook_ledger_dom_cljs_test`, green in CI's `:browser-test` job.

**Bundle isolation: holds.** The one require added is `[re-frame.performance :as performance :include-macros true]` — `implementation/core/src/re_frame/performance.cljc`. Nothing under `implementation/` gains a `tools/` require; the arm's full require list is `implementation/`-local plus `"react"`.

### Spec edit — surgical, staged, and CRLF-clean

`git diff --numstat`: **`5  1  spec/009-Instrumentation.md`**. CR count in the diff: **0** (`git diff | cat -A | grep -c '\^M'` → 0). No `sed -i` was used on any tracked file. No links added, so nothing new for `check_doc_slugs.py` to resolve — and it passes anyway.

**I confirmed the staging rather than trusting a bare build.** `docs/spec/009-Instrumentation.md` was grepped *after* the spine's mkdocs step and **does contain the new paragraph** — because `mkdocs_hooks.py`'s `on_pre_build` `rmtree`s and `copytree`s `spec/` into `docs/spec/` on **every** build (it is idempotent by construction, and `/docs/spec/` is gitignored). So `mkdocs build --strict` genuinely covered this file; the manual `cp -r spec docs/spec` that `docs.yml` performs is belt-and-braces, not the only path.

**`git grep -n 'Users/miket'` over the changed files: clean.** The worktree path appears nowhere in committed content.
