### PR TITLE
docs(hicasso): what a fallback may contain, measured and pinned — ruling still open (rf2-nv07k)

### DIFF
--- a/docs/design/hicasso/defhost-ssr-provider-costing.md
+++ b/docs/design/hicasso/defhost-ssr-provider-costing.md
@@ -173,6 +173,23 @@ context — so it is frame-correct, and it is the mechanism the workaround above
 rides on. Nobody has ruled whether that is a feature or a hole. Filed
 separately as `rf2-nv07k`; it is not part of this proposal.
 
+> **Addendum, 2026-08-05 (`rf2-nv07k`, PR #7525).** Two measurements taken since
+> make the workaround **worse than priced above**, and both bear on which
+> candidate wins here. First, the workaround's placeholder **is not a value**:
+> one declaration, walked once into one element, renders `ALPHA` in one frame,
+> `BRAVO` in another and `ALPHA-TWO` after a write — so `mint-host-gate!`'s own
+> justification for walking once (*"a placeholder that differs per site is not a
+> placeholder"*) is falsified by what it permits. Second, it **does not survive
+> this arm's other boundary variant**: a frame-fed head (`mark-frame-prop!`,
+> `rf2-2rtt6.39`) reads `intent/*frame*` at element-creation time, which in a
+> fallback is mint time, where the var is `nil` — so it bakes `nil` in and throws
+> `:rf.error/no-frame-prop` one render into the server response. Whether the
+> workaround works at all is therefore a property of which mint the head came
+> from. Every row is pinned in
+> `arm1/fallback_contents_cljs_test`. **Candidate D's cost rises accordingly** —
+> what D would document is this workaround, and it is variant-fragile rather than
+> merely ugly.
+
 ### 3. The guide citation is stale
 
 The provider example is at **`draft-guide/05-interop.md:153`**, under

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/fallback_contents_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/fallback_contents_cljs_test.cljs
@@ -1,0 +1,259 @@
+(ns re-frame.bench.hicasso.arm1.fallback-contents-cljs-test
+  "WHAT A `defhost` `:ssr` FALLBACK MAY CONTAIN — MEASURED, AND **UNRULED**
+  (rf2-nv07k).
+
+  [[re-frame.bench.hicasso.front.codec/mint-host-gate!]] used to state the
+  rule the guide teaches: *\"a fallback is inert markup — it is not a body,
+  so a subscription or an intent written there is the same loud error it
+  would be anywhere outside a boundary.\"* Both named cases hold, and
+  [[a-fallback-refuses-what-the-mint-time-walk-can-see]] pins them. The
+  CONCLUSION does not: a `defview` head written in a fallback is refused by
+  nothing, and it renders a live boundary in the server response.
+
+  ## The rule that is actually enforced is about the WALK, not the content
+
+  The fallback is walked into an element ONCE, at the declaration, outside
+  any frame. So what is refused is exactly *what that walk can evaluate*:
+
+  | Written in a fallback | At the declaration | In the server render |
+  |---|---|---|
+  | an intent vector | refused — `:rf.error/hicasso-intent-outside-boundary` | — |
+  | a `sub` call in the form | refused — `:rf.error/hicasso-sub-outside-render` | — |
+  | a `defview` head | **mints** | a LIVE boundary, subscription read included |
+  | a `defhost` head | **mints** | that host's own gate, and its own fallback |
+  | a FRAME-FED `defview` head | **mints** | throws `:rf.error/no-frame-prop` |
+
+  A boundary head is neither an intent nor a subscription: it is a React
+  element whose body runs later. The walk never looks inside it, so every
+  refusal it carries is deferred past the declaration — which is the one
+  thing the mint-time walk exists to prevent. The asymmetry is therefore
+  not a narrow rule and not a documented middle ground; it is the ABSENCE
+  of a rule, and rf2-nv07k is where it gets one.
+
+  ## Two facts that decide it, and neither was on the record
+
+  1. **The declared placeholder is not a value.**
+     [[the-declared-placeholder-is-therefore-not-one]] renders ONE
+     declaration in two isolated frames and again after a write, and gets
+     three different documents. `mint-host-gate!`'s own justification for
+     walking once — *\"a placeholder that differs per site is not a
+     placeholder\"* — is falsified by what it permits. The ELEMENT is
+     immutable; what it renders is not.
+
+  2. **It does not survive the arm's own other boundary variant.** This arm
+     ships two: [[re-frame.bench.hicasso.arm1.runtime/mint-view!]] (context-fed,
+     what `defview` mints) and
+     [[re-frame.bench.hicasso.arm1.runtime/mint-frame-prop-view!]]
+     (rf2-2rtt6.39, which frees a hook slot in a ≤2 budget that is fully
+     spent). A frame-fed head reads `intent/*frame*` when its ELEMENT is
+     created — which in a fallback is mint time, where the var is `nil` —
+     so it bakes `nil` in and throws one render into the server response
+     ([[a-frame-fed-boundary-head-fails-inside-the-server-response]]).
+     Whether a boundary head in a fallback works at all is therefore a
+     property of which mint the head came from, which is not a rule an
+     author can hold.
+
+  ## What this namespace is NOT
+
+  It is not a contract. Every row here that is not a refusal is written as
+  a record of TODAY, so that whichever way rf2-nv07k is ruled the change is
+  visible as an edit here rather than as a silence. `rf2-l0wfx` (P1, open)
+  currently has no recovery but the workaround these rows describe — write
+  the subtree a second time as the declaration's fallback — so the ruling
+  is not this namespace's to take.
+
+  ## The mutation witnesses
+
+  Bind a dispatch around `mint-host-gate!`'s `as-element` call — a fallback
+  as a LIVE region, the shape rf2-nv07k's option (a) implies — and
+  [[a-fallback-refuses-what-the-mint-time-walk-can-see]] goes red on the
+  intent that is no longer refused. Force that function's `placeholder` to
+  `nil` and both boundary-head rows go red on markup missing from the
+  server HTML. Make `boundary-element` refuse a frame-fed head minted with
+  no ambient frame — the repair option (b) implies — and
+  [[a-frame-fed-boundary-head-fails-inside-the-server-response]] goes red
+  because the throw moved to the declaration. Each was run.
+
+  Runtime: `-cljs-test`, not `-dom-`. Every claim is a `renderToString`, so
+  there is nothing here a DOM would add."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.bench.hicasso.arm1.mount :as mount]
+            [re-frame.bench.hicasso.arm1.runtime :as rt]
+            [re-frame.bench.hicasso.front.codec :as codec]
+            [re-frame.bench.hicasso.lane :as lane]
+            [re-frame.core :as rf]
+            [re-frame.test-support :as test-support]
+            ["react" :as react]
+            ["react-dom/server" :as react-dom-server])
+  (:require-macros [re-frame.bench.hicasso.arm1.lang :refer [defview defhost]]))
+
+(def ^:private frame-a ::fallback-contents-a)
+(def ^:private frame-b ::fallback-contents-b)
+
+;; Registered above `use-fixtures`, deliberately — the reset fixture
+;; captures its source-store baseline when the `use-fixtures` form is
+;; evaluated (the sibling suites' convention).
+
+(rf/reg-sub :fb/title (fn [db _] (:title db)))
+
+(rf/reg-event :fb/seed (fn [_ [_ title]] {:db {:title title}}))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :init-fn       (fn [] (rt/reset-runtime!))}))
+
+(defn- fresh!
+  "Two frames holding different values, because frame isolation is what
+  the placeholder rows are read against."
+  []
+  (lane/leave-act-environment!)
+  (rf/make-frame {:id frame-a})
+  (rf/make-frame {:id frame-b})
+  (rf/with-frame frame-a (rf/dispatch-sync [:fb/seed "ALPHA"]))
+  (rf/with-frame frame-b (rf/dispatch-sync [:fb/seed "BRAVO"])))
+
+;; ---------------------------------------------------------------------------
+;; The component behind the door, and the things a fallback might contain
+;; ---------------------------------------------------------------------------
+
+(def ^:private theme-context
+  "A context PROVIDER is the host used throughout, because it is the shape
+  that makes the fallback matter (rf2-l0wfx): a transparent wrapper
+  contributes no markup of its own, so an unadopted crossing renders the
+  fallback and nothing else."
+  (react/createContext "unset"))
+
+(defview fallback-view
+  "A `defview` head written into a fallback — the whole question."
+  [_]
+  [:section.fb-view [:h2.sub (rt/sub [:fb/title])]])
+
+(def ^:private frame-fed-view
+  "The SAME body, minted through the arm's other boundary variant
+  (rf2-2rtt6.39). Minted directly rather than through `defview` because
+  `lang.clj`'s macro mints the context-fed one — which is exactly the
+  point: the two are indistinguishable in hiccup and disagree here."
+  (rt/mint-frame-prop-view!
+    "fallback-contents/frame-fed-view"
+    (fn frame-fed-view-body [_]
+      [:section.fb-frame-fed [:h2.sub (rt/sub [:fb/title])]])))
+
+(defn- inner-component [_props]
+  (react/createElement "i" #js {:className "inner"} "INNER"))
+
+(defhost inner-host
+  "A `defhost` head written into a fallback — a second deferring head, so
+  the hole is not a `defview` fact."
+  inner-component
+  {:ssr {:fallback [:em.inner-fallback "INNER-FALLBACK"]}})
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn- error-id [f]
+  (try (f) ::did-not-throw (catch :default e (:rf.error/id (ex-data e)))))
+
+(defn- host-with-fallback
+  "One declaration, made HERE rather than at the top level, so a row that
+  is about the declaration can put its own hiccup in it."
+  [host-name fallback]
+  (codec/mint-host! host-name (.-Provider theme-context)
+                    {:ssr {:fallback fallback}}))
+
+(defn- server-html [frame hiccup]
+  (react-dom-server/renderToString
+    (mount/provider frame (codec/root-element frame hiccup))))
+
+;; ---------------------------------------------------------------------------
+;; 1 — what the mint-time walk CAN see, it refuses
+;; ---------------------------------------------------------------------------
+
+(deftest a-fallback-refuses-what-the-mint-time-walk-can-see
+  (fresh!)
+  (testing "an intent vector — the fallback is walked outside any frame, so
+            there is no frame-locked dispatch to lower it against, and it
+            is the same loud error it would be anywhere outside a boundary"
+    (is (= :rf.error/hicasso-intent-outside-boundary
+           (error-id #(host-with-fallback "fb/intent"
+                                          [:button {:on-click [:x/y]} "go"])))))
+  (testing "a `sub` call written in the fallback FORM — evaluated where the
+            declaration is, which is outside any render"
+    (is (= :rf.error/hicasso-sub-outside-render
+           (error-id #(host-with-fallback "fb/sub"
+                                          [:div (rt/sub [:fb/title])])))))
+  (testing "and hiccup that is not hiccup, which is the property the walk
+            was moved to the declaration FOR"
+    (is (= :rf.error/hicasso-empty-vector
+           (error-id #(host-with-fallback "fb/empty" []))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — what it cannot see, it does not refuse — AND THIS IS UNRULED
+;; ---------------------------------------------------------------------------
+
+(deftest a-boundary-head-in-a-fallback-is-refused-by-nothing
+  (fresh!)
+  (testing "a `defview` head mints — it is neither an intent nor a
+            subscription, it is an element whose body runs later, and the
+            walk does not look inside it"
+    (let [head (host-with-fallback "fb/view" [fallback-view {}])
+          html (server-html frame-a [:div.page [head {:value "dark"}]])]
+      (is (re-find #"class=\"fb-view\"" html)
+          (str "UNRULED (rf2-nv07k): the fallback rendered a LIVE boundary "
+               "in the server response: " html))
+      (is (re-find #"ALPHA" html)
+          (str "and its subscription READ — this is a body, not markup: "
+               html))))
+  (testing "and so does a `defhost` head, so the hole is about DEFERRAL and
+            not about `defview` — any head whose content the walk cannot
+            reach crosses the same way"
+    (let [head (host-with-fallback "fb/host" [inner-host {}])
+          html (server-html frame-a [:div.page [head {:value "dark"}]])]
+      (is (re-find #"INNER-FALLBACK" html)
+          (str "a gate inside a placeholder, rendering its own placeholder: "
+               html)))))
+
+(deftest the-declared-placeholder-is-therefore-not-one
+  (fresh!)
+  (testing "ONE declaration, walked ONCE into ONE element — and three
+            different server documents. `mint-host-gate!` walks once
+            because \"a placeholder that differs per site is not a
+            placeholder\"; a boundary head makes it differ per site and per
+            write, which is the reason the asymmetry is a defect and not a
+            feature nobody wrote down"
+    (let [head (host-with-fallback "fb/live" [fallback-view {}])
+          in-a (server-html frame-a [:div.page [head {:value "dark"}]])
+          in-b (server-html frame-b [:div.page [head {:value "dark"}]])]
+      (is (re-find #"ALPHA" in-a) (str "frame A's value: " in-a))
+      (is (re-find #"BRAVO" in-b)
+          (str "the SAME declared placeholder in frame B — frame-correct, "
+               "and not a constant: " in-b))
+      (rf/with-frame frame-a (rf/dispatch-sync [:fb/seed "ALPHA-TWO"]))
+      (let [after (server-html frame-a [:div.page [head {:value "dark"}]])]
+        (is (re-find #"ALPHA-TWO" after)
+            (str "and a write moved it, with nothing re-declared: " after))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — and it does not survive the arm's other boundary variant
+;; ---------------------------------------------------------------------------
+
+(deftest a-frame-fed-boundary-head-fails-inside-the-server-response
+  (fresh!)
+  (testing "the frame-fed variant reads `intent/*frame*` when its ELEMENT is
+            created. Everywhere else that is inside an ancestor body or
+            `root-element`; in a fallback it is MINT TIME, where the var is
+            nil — so the declaration mints happily"
+    (is (some? (host-with-fallback "fb/frame-fed" [frame-fed-view {}]))
+        "no refusal at the declaration, which is where the author's stack is"))
+  (testing "and then throws one render into the server response — the exact
+            failure the mint-time walk exists to prevent"
+    (let [head (host-with-fallback "fb/frame-fed-render" [frame-fed-view {}])]
+      (is (= :rf.error/no-frame-prop
+             (error-id #(server-html frame-a [:div.page [head {:value "dark"}]]))))))
+  (testing "while the SAME view inside an ordinary body renders — so this is
+            a property of the fallback position, not of the view"
+    (let [html (server-html frame-a [:div.page [frame-fed-view {}]])]
+      (is (re-find #"ALPHA" html) (str "control: " html)))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_ssr_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_ssr_dom_cljs_test.cljs
@@ -20,6 +20,12 @@
   has adopted the markup. `{:fallback <hiccup>}` renders that markup
   there instead. There is no third value.
 
+  WHAT MAY BE WRITTEN IN THAT FALLBACK is a separate and currently
+  UNRULED question — a boundary head written there is refused by
+  nothing and renders live in the server response. Measured in
+  [[re-frame.bench.hicasso.arm1.fallback-contents-cljs-test]]
+  (rf2-nv07k); nothing in this suite depends on the answer.
+
   ## The three places, and why ONE mechanism covers them
 
   A declaration mints one gate — a component whose single

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -1045,10 +1045,41 @@
   not hiccup fails with the author's own stack rather than one render
   into a server response. It is walked ONCE and the element is reused
   at every site of the host: React elements are immutable values, and a
-  placeholder that differs per site is not a placeholder. The corollary
-  is the rule the guide states: **a fallback is inert markup** — it is
-  not a body, so a subscription or an intent written there is the same
-  loud error it would be anywhere outside a boundary.
+  placeholder that differs per site is not a placeholder.
+
+  ## What that refuses is what the WALK CAN SEE — and no more (rf2-nv07k)
+
+  This docstring used to draw the corollary the guide teaches — *\"a
+  fallback is inert markup\"* — and half of it is enforced. The walk
+  runs outside any frame, so an intent vector written here raises
+  `:rf.error/hicasso-intent-outside-boundary` and a `sub` call in the
+  form raises `:rf.error/hicasso-sub-outside-render`, exactly as the
+  sentence says.
+
+  A BOUNDARY HEAD IS NEITHER. `[some-view {}]` is an element whose body
+  runs later, inside that boundary's own `with-frame`; the walk never
+  looks inside it, so it mints, and the \"placeholder\" is then a live
+  boundary that reads subscriptions in the server response. One
+  declaration renders a different document per frame and per write,
+  which is the justification above falsified by what it permits. A
+  `defhost` head crosses the same way, so the hole is deferral and not
+  `defview`.
+
+  **This is UNRULED, not a feature.** It is currently the only recovery
+  for `rf2-l0wfx` — a provider crossing deletes its subtree from the
+  server render, and writing that subtree a second time as the
+  declaration's fallback is the one thing that puts it back. It is also
+  variant-fragile: a frame-fed boundary head (`mark-frame-prop!`,
+  rf2-2rtt6.39) reads `intent/*frame*` at ELEMENT-creation time, which
+  here is mint time, where the var is nil — so it bakes nil in and
+  throws `:rf.error/no-frame-prop` one render into the server response.
+  Whether a boundary head in a fallback works is therefore a property
+  of which mint the head came from.
+
+  Every arm of this is pinned by
+  `arm1/fallback_contents_cljs_test`, which records today's behaviour
+  rather than asserting a contract, so that the ruling is an edit there
+  and never a silence.
 
   The gate hands its own props straight through to the foreign
   component, so the crossing's props object is exactly the one


### PR DESCRIPTION
Closes nothing. `rf2-nv07k` asks for a ruling, and this PR is the evidence that makes it a one-line decision — plus the witnesses that stop the facts being lost again, and a docstring that stops asserting something false.

## The question

`mint-host-gate!` stated the rule the guide teaches: *"a fallback is inert markup — it is not a body, so a subscription or an intent written there is the same loud error it would be anywhere outside a boundary."* An intent in a fallback is refused; a `defview` head is not. The bead asks whether that is a feature or a hole.

## The answer: none of the three — the rule is ABSENT, not narrow and not in-between

What is enforced is not a rule about **content**. It is a rule about the **walk**. The fallback is walked into an element once, at the declaration, outside any frame — so what is refused is exactly what that walk can *evaluate*:

| Written in a fallback | At the declaration | In the server render |
|---|---|---|
| an intent vector | refused — `:rf.error/hicasso-intent-outside-boundary` | — |
| a `sub` call in the form | refused — `:rf.error/hicasso-sub-outside-render` | — |
| hiccup that is not hiccup | refused — `:rf.error/hicasso-empty-vector` | — |
| a `defview` head | **mints** | a LIVE boundary, subscription read included |
| a `defhost` head | **mints** | that host's own gate, and its own fallback |
| a **frame-fed** `defview` head | **mints** | throws `:rf.error/no-frame-prop` |

Six columns of behaviour, all measured through real `renderToString`. A boundary head is neither an intent nor a subscription — it is an element whose body runs later — so the walk never looks inside it, and every refusal it carries is deferred past the declaration. That is precisely the one thing the mint-time walk exists to prevent.

## Two facts that decide it, and neither was on the record

**1. The declared placeholder is not a value.** One declaration, walked once into one element, renders three different documents:

```
frame A            <div class="page"><section class="fb-view"><h2 class="sub">ALPHA</h2></section></div>
frame B            <div class="page"><section class="fb-view"><h2 class="sub">BRAVO</h2></section></div>
frame A, one write <div class="page"><section class="fb-view"><h2 class="sub">ALPHA-TWO</h2></section></div>
```

`mint-host-gate!` walks once and reuses the element everywhere, and its stated reason is *"a placeholder that differs per site is not a placeholder."* A boundary head makes it differ per site **and per write**. The design's own justification is falsified by what the design permits. The element is immutable; what it renders is not.

**2. It does not survive the arm's own other boundary variant.** Arm 1 ships two mints side by side: `mint-view!` (context-fed, what `defview` mints) and `mint-frame-prop-view!` (rf2-2rtt6.39, which frees a hook slot in a ≤2 budget that is fully spent). A frame-fed head reads `intent/*frame*` when its **element** is created — which in a fallback is mint time, where the var is `nil`. So it bakes `nil` in, mints happily, and throws `:rf.error/no-frame-prop` one render into the server response. The two are indistinguishable in hiccup.

So whether a boundary head in a fallback works at all is a property of **which mint the head came from**. That is not a rule an author can hold, which is why "bless it as it stands" is not available: what you would be blessing is variant-dependent.

## Why no ruling is taken here

Both directions constrain `rf2-l0wfx` (P1, open, awaiting the operator on `:ssr`), so neither is this PR's to take:

- **Refusing** the boundary head deletes l0wfx's only recovery. The costing page's candidate D ("document the trap") would then be documenting nothing — its content *is* the workaround — which materially favours A or B.
- **Blessing** it makes "write your subtree twice" a sanctioned answer, which lowers the pressure for A or B and favours D.

The evidence does have a direction, and it is stated rather than hidden: the codec's own stated law — walk once, reuse everywhere, *because a placeholder that differs per site is not a placeholder* — **entails inert markup**, i.e. the bead's option (b). The measurements above are what make that a five-minute call rather than a taste. It is still the operator's.

The evidence also makes the workaround **worse than it was priced** in `defhost-ssr-provider-costing.md`: not merely duplication + wrong context value + remount, but variant-fragile and in violation of the placeholder invariant.

## What landed

- **`arm1/fallback_contents_cljs_test.cljs`** (new) — 4 tests, 12 assertions, every row above. Written as a record of **today**, explicitly not as a contract, so that whichever way the bead is ruled the change is an edit here and never a silence.
- **`front/codec.cljs`** — `mint-host-gate!`'s docstring. The two cases the old sentence names do hold and that stands; the corollary does not, and it now says so, says it is **UNRULED**, and names both the l0wfx dependency and the frame-fed fragility.
- **`arm1/host_ssr_dom_cljs_test.cljs`** — five lines of ns docstring pointing at the new suite, because "neither stated nor discoverable" was half the bead.

- **`defhost-ssr-provider-costing.md`** — a dated addendum under §2, because that page is where the l0wfx ruling gets read and its §2 now understates the workaround. No table added, no link added; `check_doc_slugs.py` exit 0, and the existing 2-column table above it is untouched.

**Docstrings only on the executable side.** Every changed line in `codec.cljs` is inside `mint-host-gate!`'s docstring string literal — **no executable form changed**. No hook added, no `:ssr` value added or removed, no refusal added or removed. The `≤2-hook` shell is untouched: `git diff origin/main...HEAD -- implementation/` contains no `use*` call on either side.

Nothing under `docs/design/hicasso/draft-guide/**`, `spec/**`, `decisions.md`, `validation.md` or `implementation/core/` is touched. The guide never made the false promise — it says "placeholder markup" / "a skeleton", not "refused" — so it needs an edit only if the ruling goes toward (b).

## Mutation proofs — each run, both directions

| Mutation | Shape it represents | Result |
|---|---|---|
| bind `intent/*dispatch*` around `mint-host-gate!`'s `as-element` | a fallback as a LIVE region — option (a) | **1 failure** — the intent is no longer refused |
| force `placeholder` to `nil` | the gate stops honouring the policy | **9 failures** — both boundary-head rows, the placeholder row, the frame-fed row |
| `boundary-element` refuses a frame-fed head with no ambient frame | the repair option (b) implies | **2 errors** — the throw moved to the declaration |

Every refusal asserted in this PR was personally made to fire, and every non-refusal row was personally made to go red. `codec.cljs` was restored from a byte copy after each and the suite re-verified green (`0 failures, 0 errors`).

The `reportError` trap does not apply: every row here is a `renderToString` in the Node lane, with the throw caught by the suite's own `error-id`, not a React commit handler. Nothing here reads `:rf/render-hash`, and nothing here names `h/as-element`.

## Quality gates

| Gate | Result |
|---|---|
| `sh scripts/test-fast-pr.sh` | runner marker `PASS fast PR spine`, exit **0** (run unpiped) |
| `npm run test:cljs` | `Ran 12604 tests containing 63164 assertions. 0 failures, 0 errors.` |
| `npm run test:browser` | **exit 0** — `Ran 1097 tests containing 6792 assertions. 0 failures, 0 errors.` (rebased onto `863b3d428b`; see note below) |
| `npm run test:hicasso-compile` | 121 lane namespaces, 428 files, **0 warnings** — PASS |
| `clj-kondo` (local 2025.10.23; CI pins 2026.04.15) | **errors: 0**, warnings: 0 — exit 0 |
| new suite, alone | `Ran 4 tests containing 12 assertions. 0 failures, 0 errors.` |

The single `clj-kondo` `info` in the linted set (`codec.cljs` "Single argument to str already is a string") is pre-existing on `origin/main` at the same form and is not in this diff.

### Note on the earlier `cljs-browser` red — it was `main`'s, and it is resolved

The earlier red on `CLJS (shadow-cljs :browser-test, headless Chromium)` was not this PR's. The suite is one process, so an abort in *any* namespace reports under the step rather than under the guilty `deftest`. The log's last line before the abort was:

```
Testing re-frame.bench.hicasso.arm1.hframe-dom-cljs-test
[browser:pageerror] Async tests require fixtures to be specified as maps.  Testing aborted.
```

`arm1/hframe_dom_cljs_test` is not in this diff — it reached `main` in `73f3fee548` pairing an `(async done …)` test with a fn-form fixture, which `cljs.test` refuses outright, leaving every later namespace unrun. Four measurements, each run locally, foreground, to completion:

| Tree | Result |
|---|---|
| this branch at its original base (no `hframe`) | **exit 0** — 1093 tests, 6773 assertions, 0 failures |
| this branch rebased onto the broken `main` | **exit 1** — aborts at `hframe-dom-cljs-test` |
| **pure `origin/main`, none of my commits** | **exit 1** — aborts identically. *The control.* |
| this branch rebased onto the repaired `main` (`863b3d428b`) | **exit 0** — 1097 tests, 6792 assertions, 0 failures |

The third row is what settles it: `main` was red on this lane on its own. The browser job had not actually *run* on `main` since `73f3fee548` — `skipped` on both subsequent main runs, and the last main run that genuinely executed it (`3151170f`) predates the merge and was green.

This suite could not have been involved in any case: `:browser-test` selects `-dom-cljs-test$` and it is `-cljs-test`, so it is **absent from `out/browser-test/`** (verified by `find`) while present in `out/node-test.js`. It is also fully synchronous — no `async`, no `setTimeout`, no `hydrate`, no mount, no `done` — and the only browser-lane edit here is 6 lines of ns docstring, adding and removing zero `deftest`.

No timeout, retry or `async` deadline was added anywhere.
