### PR TITLE
docs(hicasso): reorganise Performance page as a how-to

### DIFF
--- a/docs/design/hicasso/draft-guide/11-performance.md
+++ b/docs/design/hicasso/draft-guide/11-performance.md
@@ -8,119 +8,117 @@ Most Hicasso screens do not need a performance strategy. Write ordinary Hiccup �
 > **For about 98% of view code, performance is not an issue.** Do not pre-optimise.
 > Do not invent a second architecture "just in case."
 
-Hicasso is Hiccup-first and interpreted. The walk is not free, but it is rarely
-what hurts you. Measured against Reagent, the Hiccup walk itself is about
-**parity (~0.96×)**. On the worst mounts we have seen, roughly **~70% of the
-extra cost was read shape** — many fine per-row subscriptions instead of a few
-coarse ones — not time spent turning vectors into elements. Screens that use
-coarser, more natural reads land nearer **~1.2×** where the pathological case
+The interpreter is not free, but it is rarely what hurts you. Against Reagent,
+the Hiccup walk itself is about **parity (~0.96×)**. On the worst mounts we have
+seen, roughly **~70% of the extra cost was read shape** — many fine per-row
+subscriptions instead of a few coarse ones — not time turning vectors into
+elements. Coarser, more natural reads land nearer **~1.2×** where the bad case
 sat nearer **~1.5×**. So when something *is* slow, you fix **where and how you
 read** (and who re-renders) long before you abandon Hiccup.
 
 **The other ~2%** is a measured island: a hot cell, a third-party React widget,
-an SDK that wants a DOM node. You can step **below Hiccup** for that island —
-closer to React, into a foreign component — without rewriting the app. There is
-no dual mode that "turns the interpreter off." There is a ladder.
+an SDK that wants a DOM node.
 
-> **Ninety-eight percent stays Hiccup. For the two percent: find the island, then
-> fix that island — do not rewrite the product.**
+So the job of this page is simple: **how to stay in the 98%**, and **what to do
+for the ~2%** when a profile names a real island.
 
-The 98/2 split is how you should write, not a lab certificate. Stay on the happy
-path until a profile names something specific.
+> **Ninety-eight percent stays Hiccup. For the two percent: fix that island —
+> do not rewrite the product.**
 
-## Find the island first
+The 98/2 split is how you should write, not a lab certificate. There is no dual
+mode that turns interpretation off. There is a ladder **below Hiccup** for the
+minority of cases that need it.
 
-You do not need Hicasso-private tooling.
+---
 
-- **React DevTools Profiler** — every Hicasso boundary is a real React function
-  component. See which components commit and how often.
-- **Xray** (or any Spec 009 consumer) — which **subscriptions** recomputed for
-  the event you care about. Often the problem is a high, coarse read, not a slow
-  walk.
+## The default path
 
-Name the boundary, the sub, or the event **before** changing architecture.
-"The app is slow" is still the 98% problem wearing a costume.
+Stay here until a profile says otherwise. Full mechanics live in
+[Views and reads](02-views-and-reads.md); the performance rules of thumb are:
 
-## What is not an escape
-
-| Wish | Reality |
-|---|---|
-| "Compile this view off the interpreter" | **No.** No dual mode, no second compiler product |
-| "Bare JS component in head position" | **Refused** — use `defhost` or `[:>]`, not silent auto-host |
-| "I'll switch this page to Reagent/UIx" | Only as **another root**, not a spelling inside one `defview` |
-| "Hooks everywhere so we're ready for the 2%" | That *is* rewriting the product. The 2% is an island |
-
-No profile yet? You are still in the 98%. Stay on tier-1 Hiccup
-([Views and reads](02-views-and-reads.md)).
-
-## The ladder
-
-### 1. Still Hiccup — fix reads and re-renders
-
-Same language, less cost. This step comes first **because that is where the cost
-usually lives** — not interpretation.
-
-**Boundaries only where re-render granularity matters.**
+**1. Boundaries only where re-render granularity matters.**
 
 ```clojure
 [todo-row {:key id :id id}]   ;; boundary — own re-render, own sub edge set
 (row-chrome {:id id})         ;; plain call — inlined; free at runtime
 ```
 
-A **vector** head is a boundary: React identity, its own `sub` reads, default
-value-equality bail-out. A **plain call** splices into the parent and donates
-reads upward. Markup that always re-renders with its parent should be a helper,
+A **vector** head is a boundary. A **plain call** splices into the parent and
+donates reads upward. Markup that always rides its parent should be a helper,
 not a `defview`.
 
-**Push reads down.** A `sub` high in the tree invalidates that boundary and
-everything the value is threaded through. The expensive mounts we measured spent
-most of their deficit on **too many fine per-instance reads**. Read at the point
-of use ([Views and reads](02-views-and-reads.md)).
+**2. Read at the point of use.** A `sub` high in the tree invalidates that
+boundary and everything the value is threaded through. Expensive mounts we
+measured spent most of their deficit on **too many fine per-instance reads**.
 
-**Stable keys and the default bail-out.** Every list of boundaries needs a
-stable `:key` in the props map (a Hicasso-minted missing-key warning is planned;
-until then you still get React's). If a child's props still `=` after a parent
-re-render, the body does not run. That is what makes a page-wide write cheap for
-unchanged cards — when keys and props are stable, **hundreds of bodies can skip**.
-What defeats the bail-out: threading a changing value as a prop instead of
-reading in the child; a fresh function or JS object every parent render;
-unstable keys that force remounts.
+**3. Stable keys and the default bail-out.** Every list of boundaries needs a
+stable `:key` in the props map. If a child's props still `=` after a parent
+re-render, the body does not run — a page-wide write can leave **hundreds of
+unchanged cards** unrun. What defeats that: threading a changing value as a prop
+instead of reading in the child; a fresh function or JS object every parent
+render; unstable keys that force remounts.
 
-**Keep high-rate motion out of app-db.** Drag and scroll are host mechanics until
-you commit ([Ephemeral state](07-ephemeral-state.md)).
+**4. Keep high-rate motion out of app-db.** Drag and scroll are host mechanics
+until you commit ([Ephemeral state](07-ephemeral-state.md)). Dense controlled
+grids are often an **event-volume** problem, not a Hiccup one
+([Controlled inputs](04-controlled-inputs.md)).
 
-### Big lists and broad commits (honest)
+If you only do this, you are done for most apps.
 
-One event that touches state **many** row boundaries care about — a big table or
-feed — is the shape where cost **can** bite. Outside measurements have shown
-about **1.4–1.6×** on broad bulk in outside measurements; we have not finished
-pricing that shape on our side yet. Big-list bulk is a known risk, not a solved
-win.
+---
 
-Work it in this order:
+## When something feels slow
 
-1. Keys + bail-out (above).
-2. Better-placed / coarser reads.
-3. A virtualized list via `defhost` when the list is really a React virtualizer.
-4. Another substrate only if that surface is React-first by design.
+### Name the island first
+
+You do not need Hicasso-private tooling.
+
+| Tool | What it shows |
+|---|---|
+| **React DevTools Profiler** | Which components commit (every Hicasso boundary is a real React FC) |
+| **Xray** (or Spec 009) | Which **subscriptions** recomputed for the event you care about |
+
+Name the boundary, the sub, or the event **before** changing architecture.
+"The app is slow" is still the 98% problem wearing a costume.
+
+### Then climb only as far as you must
+
+Work **top to bottom**. Most hot cases die on step 1 and return to the default path.
+
+#### Step 1 — Still Hiccup
+
+Re-check the default path on the named island: fewer boundaries, reads at point
+of use, stable keys, no high-rate `:db` writes. That step is first because
+**that is where the cost usually lives**, not interpretation.
+
+**Big lists (honest).** One event that many row boundaries care about — a large
+table or feed — is the shape where cost **can** bite. Outside measurements have
+shown about **1.4–1.6×** on broad bulk; we have not finished pricing that shape
+on our side. Treat big-list bulk as a known risk.
+
+Order for a big table:
+
+1. Keys + bail-out  
+2. Better-placed / coarser reads  
+3. Virtualized list via `defhost` (step 3) if the list is a React virtualizer  
+4. Another substrate (step 4) only if that surface is React-first by design  
 
 Do not jump to hooks on a 300-row table before keys, bail-out, and read shape.
 
-### 2. Host-edge React (one island)
+#### Step 2 — Host-edge React (one island)
 
 A `defview` body is a real React function component. Hooks and refs are fine for
 **mechanics**: measure, SDK handles, animation clocks that are not app state.
-Semantic state still belongs in app-db.
+Semantic state stays in app-db.
 
-**Do not use ambient `rf/dispatch` or ambient `rf/capture-frame` from a
-timeout and hope.** In a Hicasso body those ambient forms are **not a contract**
-— they may work, throw, or pick the wrong frame depending on adapter, renderer,
-and timing. Intent vectors already carry the frame. For hand-written async (SDK
-callbacks, value-first foreign handlers), prefer the **event layer** (`:fx` on
-the ctx, `:dispatch-later`). When you must close over a frame at the edge, the
-intended spelling is **`h/frame`** **[unfrozen]** composed with the platform
-carry: `(rf/capture-frame (h/frame))`. The shape is fixed; the product spelling
-may still be landing — check before you depend on it.
+**Do not bare `rf/dispatch` or ambient `rf/capture-frame` from a timeout and
+hope.** In a Hicasso body those ambient forms are **not a contract** — they may
+work, throw, or pick the wrong frame depending on adapter, renderer, and timing.
+Intent vectors already carry the frame. Prefer the **event layer** (`:fx`,
+`:dispatch-later`). When you must close over a frame at the edge, the intended
+spelling is **`h/frame`** **[unfrozen]** with the platform carry:
+`(rf/capture-frame (h/frame))`. Shape is fixed; product shipping may still be
+landing.
 
 ```clojure
 ;; .cljs host-edge namespace — not the whole app.
@@ -135,7 +133,8 @@ may still be landing — check before you depend on it.
     (react/useLayoutEffect
       (fn []
         (when-let [node (.-current ref)]
-          ;; Later, off the render: (rf/capture-frame frame) then work.
+          ;; Later, off the render: (rf/capture-frame frame) then work —
+          ;; not bare rf/dispatch.
           js/undefined))
       #js [])
     (into [:div {:ref ref}] children)))
@@ -143,20 +142,18 @@ may still be landing — check before you depend on it.
 
 | You gain | You give up |
 |---|---|
-| Full React toolkit for that island | Headless / data-tree tests for that body ([Testing](08-testing.md)) |
+| Full React toolkit for that island | Headless tests for that body ([Testing](08-testing.md)) |
 | Layout / SDK lifecycle control | Hook rules and StrictMode are yours |
 | Rest of the app stays Hicasso | That node is no longer pure data markup |
 
-Keep the island small. Callback refs for attach/teardown: [Interop](05-interop.md)
-Advanced.
+Keep the island **small**. Callback refs: [Interop](05-interop.md) Advanced.
 
-### 3. Foreign React (`defhost` / `[:>]`)
+#### Step 3 — Foreign React (`defhost` / `[:>]`)
 
-When the lower level is **someone else's** component (date picker, chart,
-virtualized list):
+Someone else's component — date picker, chart, **virtualized list**:
 
-- **`defhost`** — declare once; policies at the declaration ([Interop](05-interop.md)).
-- **`[:> Component …]`** — secondary raw escape; may lag `defhost` in the arm.
+- **`defhost`** — declare once ([Interop](05-interop.md))
+- **`[:> …]`** — secondary raw escape; may lag `defhost`
 
 ```clojure
 (h/defhost chart Chart
@@ -167,29 +164,30 @@ virtualized list):
    [chart {:series (sub [:metrics/series])}]])
 ```
 
-An existing React element is a legal child (pass-through). Keep JS requires in
+Existing React elements are legal children (pass-through). Keep JS requires in
 `.cljs` host namespaces.
 
-### 4. Another view layer
+#### Step 4 — Another view layer
 
-A whole screen in UIx or Reagent is **another adapter root**, not a Hicasso mode.
-Multi-frame isolation: [Getting started](01-getting-started.md).
+A whole screen in UIx or Reagent is **another adapter root**, not a Hicasso
+mode. Multi-frame: [Getting started](01-getting-started.md).
 
-## Order of operations (only for the 2%)
+### What is not on the ladder
 
-1. **Name the island** — Profiler and Xray ([above](#find-the-island-first)).
-2. **Still Hiccup** — keys, bail-out, fewer boundaries, reads at point of use.
-   Most "hot" cases die here.
-3. **Host-edge island** — one widget; async via event `:fx` or
-   `(rf/capture-frame (h/frame))`, never ambient hope.
-4. **`defhost`** — third-party / virtualized React.
-5. **Different substrate** — only if that is the product direction.
+| Wish | Reality |
+|---|---|
+| Compile off the interpreter | **No** dual mode |
+| Bare JS head `[DatePicker …]` | **Refused** — `defhost` / `[:>]` |
+| "Hooks everywhere for the 2%" | That rewrites the product |
+| Switch one page to Reagent inside `defview` | Only as another root |
 
-## What you keep
+---
+
+## What you keep at each level
 
 | Level | Data intents | Ambient `sub` | Headless-friendly | Lever |
 |---|---|---|---|---|
-| Tier-1 Hiccup | Yes | Yes | Intents today; full render later | Boundaries, reads, keys, bail-out |
+| Default Hiccup | Yes | Yes | Intents today; full render later | Boundaries, reads, keys, bail-out |
 | Host-edge hooks | Partial | Yes in that body | **No** for that body | React |
 | `defhost` | Opaque at the crossing | Via props / parents | Foreign region out | Leave work in the library |
 | Other adapter | That root's rules | That root's rules | That root's rules | Full switch |
@@ -204,15 +202,14 @@ Multi-frame isolation: [Getting started](01-getting-started.md).
 | Bare `rf/dispatch` from a timeout "sometimes works" | Ambient `rf/*` is not a contract in Hicasso bodies | Event `:fx`, or `(rf/capture-frame (h/frame))` when available |
 | Hooks in every cell "for speed" | Second architecture | One island; app-db for semantic state |
 | Structural test dies after a "perf fix" | Hooks or JS in a `.cljc` body | Quarantine host code in `.cljs` |
-| `[DatePicker …]` bare head | Not legal | `defhost` (or `[:>]` when available) |
+| Bare `[DatePicker …]` head | Not legal | `defhost` (or `[:>]` when available) |
 | SDK mounts twice / leaks | Ref without paired teardown | Attach + cleanup as one ref (React 19) — [Interop](05-interop.md) |
 | Still slow after dropping to React | Wrong layer | Profile again — often reads or event volume |
 
 ## When not to go below Hiccup
 
-- Still the **98%** — no profile, only anxiety about the interpreter.
-- The real issue is **event volume** (e.g. controlling every keystroke on a dense
-  grid) — [Controlled inputs](04-controlled-inputs.md).
+- Still the **98%** — no profile, only fear of the interpreter.
+- The real issue is **event volume** ([Controlled inputs](04-controlled-inputs.md)).
 - You are about to reimplement the app in hooks "for the 2%." That is a
   substrate change, not an escape hatch.
 
@@ -223,5 +220,5 @@ Multi-frame isolation: [Getting started](01-getting-started.md).
 | Compile / dual-mode path | **Not planned** — one interpreted Hiccup product |
 | `[:>]` availability | Ruled; may lag `defhost` — [Interop](05-interop.md) |
 | `h/frame` shipping | Shape fixed; spelling **[unfrozen]**; may still be landing |
-| Big-list bulk magnitudes on our side | Outside numbers show risk; full own pricing still open |
-| Perf-island scaffold / macro | **None** — plain React + `defview` |
+| Big-list bulk on our side | Outside numbers show risk; full own pricing still open |
+| Perf-island macro / scaffold | **None** — plain React + `defview` |

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -18,7 +18,7 @@ programmer actually type?**
 | [Testing](08-testing.md) | Assert intents and trees as data today; know when you still need a browser |
 | [When a view throws](09-when-a-view-throws.md) | Keep one broken view from taking the page down with it |
 | [Server-side rendering](10-server-side-rendering.md) | Serve a page rendered from a db snapshot and adopt it live in the browser |
-| [Performance](11-performance.md) | 98% of views need no special path; for the ~2%, the ladder down (still Hiccup → host edge → `defhost`) |
+| [Performance](11-performance.md) | Default path (98%); when something is slow, name the island and climb the ladder |
 
 ## How to read the markers
 


### PR DESCRIPTION
## Summary

Reorganises `docs/design/hicasso/draft-guide/11-performance.md` for progressive how-to pacing (`docs/AUTHORING.md`).

### Structure (after)
1. **Open** — 98% takeaway + short measured why (reads, not the walk)
2. **The default path** — unlabeled required path: boundaries, read placement, keys/bail-out, high-rate motion (ship with this)
3. **When something feels slow** — name island (Profiler + Xray) → single ladder (still Hiccup → host edge → defhost → other root), including bulk honesty and non-escapes
4. **What you keep** — tradeoff table
5. **Troubleshooting / When not / Not settled**

### Also
- Drops duplicated "order of operations" vs ladder sections
- Fixes a doubled clause on main ("Outside measurements have shown … on broad bulk **in outside measurements**")
- README index job line updated

## Rebased onto current `main`

This branch was opened before #7526 (the AUTHORING-voice pass) merged, so it needed a rebase. #7526's prose was already in this draft — it is a later pass over the same text — so the eleven conflict hunks were reconciled hunk-by-hunk rather than by taking a side. The reorganised structure is this branch's; three details only `main` carried were kept:

- the opening enumeration `defview`, `sub` where you use the value, intent vectors
- `**The other ~2%** is a measured island: a hot cell, a third-party React widget, an SDK that wants a DOM node`, and the `98/2 split is how you should write, not a lab certificate` sentence
- `Attach + cleanup as one **ref** (React 19)`, `off the render` in the host-edge comment, and `not ambient rf/*` on the `h/frame` binding

Nothing on `main` was dropped without being relocated, except the parenthetical `(a Hicasso-minted missing-key warning is planned; until then you still get React's)`. That is correct to drop on its own terms: `02-views-and-reads.md` documents `:rf.warning/hicasso-missing-key` as landed, so "is planned" was stale.

## Quality gates

- [x] `python scripts/check_doc_slugs.py` — exit 0
- [x] Hand-verified table column counts on the three touched files (nothing validates markdown tables): `11-performance.md` 6 tables — 2/2/2/5/3/2 columns, all rows matching their header; `README.md` 1 table (2 columns); `01-getting-started.md` untouched by this PR
- [x] Hand-verified anchors: no page links into a `11-performance.md#…` anchor, and this page has no intra-page anchors, so removing the `## Find the island first` heading dangles nothing. `06-theming.md`'s anchor into `02-views-and-reads.md#boundaries-memoize-by-default` is untouched and still resolves
- [x] No conflict markers remain; `git diff --numstat` shows +107/-110 on `11-performance.md`, not a whole-file CRLF rewrite
- [x] `mkdocs build --strict` **not** applicable — `exclude_docs` keeps `docs/design/**` out of the site, so it would verify nothing here
