### PR TITLE
docs(hicasso): punch Performance as 98% fine / 2% do this

### DIFF
--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -60,8 +60,8 @@ interpretation, not a better Reagent.*
 
 **Not the pitch:** "stellar performance." The programme bar is competitive with
 Reagent on the important rows — good enough to ship, not a speed-marketing
-product. **For about 98% of view code, performance is not an issue**; for the
-rest, there is a ladder down, not a dual mode
+product. **98% of the time, Hiccup is completely fine**; about 2% of the view
+code is on the hot path, and for that there is a ladder — not a dual mode
 ([Performance](11-performance.md)). Prefer Hicasso for **authoring, testing
 shape, and re-frame integration**, not for winning a microbenchmark war.
 
@@ -89,7 +89,7 @@ finished product package.
 | **SSR participation** | Same pure bodies + framework hydration; experimental doors exist; production package still open | [Server-side rendering](10-server-side-rendering.md) |
 | **Xray-friendly UI** | UI state in app-db + named events shows up in app-db diffs and time-travel; not a special Hicasso Xray tab | framework Xray + this design |
 | **Performance** | Good / competitive goal vs Reagent; not "fastest UI library" | programme bar, not a guide claim |
-| **Going lower** | ~98% of view code needs nothing special; for the ~2%, a ladder (not a dual mode) | [Performance](11-performance.md) |
+| **Going lower** | 98% of the time Hiccup is completely fine; for the ~2% hot path, do the ladder (not a dual mode) | [Performance](11-performance.md) |
 
 ## Your first app
 

--- a/docs/design/hicasso/draft-guide/11-performance.md
+++ b/docs/design/hicasso/draft-guide/11-performance.md
@@ -48,12 +48,17 @@ performance rules of thumb are:
 
 ```clojure
 [todo-row {:key id :id id}]   ;; boundary — own re-render, own sub edge set
-(row-chrome {:id id})         ;; plain call — inlined; free at runtime
+(row-chrome {:id id})         ;; plain call — inlined; no boundary of its own
 ```
 
-A **vector** head is a boundary. A **plain call** splices into the parent and
-donates reads upward. Markup that always rides its parent should be a helper,
-not a `defview`.
+A **view in head position** mints a boundary — React identity, its own `sub`
+reads, its own bail-out
+([Views and reads](02-views-and-reads.md#boundaries-and-inlining)). Native tags,
+fragments and `defhost` heads sit in vector position too and mint none of that.
+A **plain call** still runs and still builds markup; what it does not buy is
+re-render granularity, and its hiccup splices into the parent while its reads
+donate upward. Markup that always rides its parent should be a helper, not a
+`defview`.
 
 **2. Read at the point of use.** A `sub` high in the tree invalidates that
 boundary and everything the value is threaded through. Expensive mounts we
@@ -119,14 +124,23 @@ A `defview` body is a real React function component. Hooks and refs are fine for
 **mechanics**: measure, SDK handles, animation clocks that are not app state.
 Semantic state stays in app-db.
 
-**Do not bare `rf/dispatch` or ambient `rf/capture-frame` from a timeout and
-hope.** In a Hicasso body those ambient forms are **not a contract** — they may
-work, throw, or pick the wrong frame depending on adapter, renderer, and timing.
-Intent vectors already carry the frame. Prefer the **event layer** (`:fx`,
-`:dispatch-later`). When you must close over a frame at the edge, the intended
-spelling is **`h/frame`** **[unfrozen]** with the platform carry:
-`(rf/capture-frame (h/frame))`. Shape is fixed; product shipping may still be
-landing.
+**Async work belongs in the event layer, which already has the frame.** An fx
+handler receives the frame id in its context and `:dispatch-later` says the
+delay as data, so a `setTimeout` in a view that dispatches is mis-layered before
+it is anything else. Move the work and the carrying question goes with it.
+
+Intent vectors need none of this — they already carry their boundary's frame.
+What survives the move is the **foreign edge**: a dispatching closure handed to
+a caller you do not control — an SDK attached through a ref, a `defhost` callback
+slot, a library that calls back with a value. There the frame is knowable during
+the render and nowhere else, so read it there with **`h/frame`** **[unfrozen]**
+and compose it with the platform carry: `(rf/capture-frame (h/frame))`.
+
+Do not reach for an ambient `rf/dispatch` or a bare `rf/capture-frame` instead.
+Ambient frame lookup is exactly what Hicasso's stricter body discipline
+withdraws: inside a body those forms **refuse**, under every adapter, naming the
+collector they went around — deterministically, not "sometimes"
+([Events as data](03-events-as-data.md#callbacks-carry-their-frame)).
 
 ```clojure
 ;; .cljs host-edge namespace — not the whole app.
@@ -136,7 +150,7 @@ landing.
             ["react" :as react]))
 
 (defview measure-box [{:keys [children]}]
-  (let [frame (h/frame)   ;; [unfrozen] — may still be landing; not ambient rf/*
+  (let [frame (h/frame)   ;; [unfrozen] name; not an ambient rf/* lookup
         ref   (react/useRef nil)]
     (react/useLayoutEffect
       (fn []
@@ -207,7 +221,7 @@ mode. Multi-frame: [Getting started](01-getting-started.md).
 | One cell change re-renders everything | Read too high, or one giant boundary | Push `sub` down; split boundaries |
 | Page-wide write re-runs every card | Props not `=` or keys unstable | Stable `:key`; read in the child; intent data not fresh fns |
 | Big table feels ~1.5× | Broad commit fan-out — known hard shape | Keys + bail-out + read shape; then virtualized `defhost` |
-| Bare `rf/dispatch` from a timeout "sometimes works" | Ambient `rf/*` is not a contract in Hicasso bodies | Event `:fx`, or `(rf/capture-frame (h/frame))` when available |
+| Bare `rf/dispatch` from a timeout | An ambient `rf/*` in a body refuses, naming the collector — it never "sometimes works" | Own the async work through `:fx`; only a closure crossing to foreign code carries `(rf/capture-frame (h/frame))` |
 | Hooks in every cell "for speed" | Second architecture | One island; app-db for semantic state |
 | Structural test dies after a "perf fix" | Hooks or JS in a `.cljc` body | Quarantine host code in `.cljs` |
 | Bare `[DatePicker …]` head | Not legal | `defhost` (or `[:>]` when available) |
@@ -227,6 +241,6 @@ mode. Multi-frame: [Getting started](01-getting-started.md).
 |---|---|
 | Compile / dual-mode path | **Not planned** — one interpreted Hiccup product |
 | `[:>]` availability | Ruled; may lag `defhost` — [Interop](05-interop.md) |
-| `h/frame` shipping | Shape fixed; spelling **[unfrozen]**; may still be landing |
+| `h/frame` spelling | Behaviour settled and proven in the arm; the product name is **[unfrozen]** |
 | Big-list bulk on our side | Outside numbers show risk; full own pricing still open |
 | Perf-island macro / scaffold | **None** — plain React + `defview` |

--- a/docs/design/hicasso/draft-guide/11-performance.md
+++ b/docs/design/hicasso/draft-guide/11-performance.md
@@ -2,39 +2,47 @@
 
 > **Draft.** No `implementation/hicasso/` package yet. Names marked **[unfrozen]** may change. Mechanisms are proven under `implementation/freehand/test/re_frame/bench/hicasso/`; product spellings and some call shapes are still settling.
 
-Most Hicasso screens do not need a performance strategy. Write ordinary Hiccup —
-`defview`, `sub` where you use the value, intent vectors — and ship.
+**98% of the time, Hiccup is completely fine.**
 
-> **For about 98% of view code, performance is not an issue.** Do not pre-optimise.
-> Do not invent a second architecture "just in case."
+Write ordinary `defview`, `sub` at the point of use, intents as data. Ship it.
+Do not pre-optimise. Do not invent a second architecture "just in case."
 
-The interpreter is not free, but it is rarely what hurts you. Against Reagent,
-the Hiccup walk itself is about **parity (~0.96×)**. On the worst mounts we have
-seen, roughly **~70% of the extra cost was read shape** — many fine per-row
-subscriptions instead of a few coarse ones — not time turning vectors into
-elements. Coarser, more natural reads land nearer **~1.2×** where the bad case
-sat nearer **~1.5×**. So when something *is* slow, you fix **where and how you
-read** (and who re-renders) long before you abandon Hiccup.
+**About 2% of the view code is on the hot path** — a cell that re-renders
+constantly, a large table under a broad write, a foreign React widget, an SDK
+that wants a DOM node. When a profile names that island, **do this** (top →
+bottom; stop as soon as the island is fixed):
 
-**The other ~2%** is a measured island: a hot cell, a third-party React widget,
-an SDK that wants a DOM node.
+1. **Still Hiccup** — keys, bail-out, fewer boundaries, reads at point of use  
+2. **Host-edge React** — one measured island, hooks/refs for mechanics only  
+3. **`defhost` / `[:>]`** — someone else's React component  
+4. **Another root** — a whole screen on Reagent/UIx by product choice, not a
+   Hicasso mode  
 
-So the job of this page is simple: **how to stay in the 98%**, and **what to do
-for the ~2%** when a profile names a real island.
-
-> **Ninety-eight percent stays Hiccup. For the two percent: fix that island —
-> do not rewrite the product.**
-
-The 98/2 split is how you should write, not a lab certificate. There is no dual
-mode that turns interpretation off. There is a ladder **below Hiccup** for the
-minority of cases that need it.
+There is no dual mode that turns interpretation off for the app. The 2% is an
+island, not a lifestyle.
 
 ---
 
-## The default path
+## Why Hiccup is usually enough
 
-Stay here until a profile says otherwise. Full mechanics live in
-[Views and reads](02-views-and-reads.md); the performance rules of thumb are:
+The interpreter is not free, but it is rarely the bill. Against Reagent, the
+Hiccup walk itself is about **parity (~0.96×)**. On the worst mounts we have
+seen, roughly **~70% of the extra cost was read shape** — many fine per-row
+subscriptions instead of a few coarse ones — not time turning vectors into
+elements. Coarser, more natural reads land nearer **~1.2×** where the bad case
+sat nearer **~1.5×**.
+
+So when something *is* slow, you fix **where and how you read** (and who
+re-renders) long before you abandon Hiccup. The 98/2 split is how you should
+write until a profile names a specific exception — not a lab certificate that
+every screen has been timed.
+
+---
+
+## The default path (the 98%)
+
+Stay here. Full mechanics live in [Views and reads](02-views-and-reads.md); the
+performance rules of thumb are:
 
 **1. Boundaries only where re-render granularity matters.**
 
@@ -67,7 +75,10 @@ If you only do this, you are done for most apps.
 
 ---
 
-## When something feels slow
+## The hot path (the 2%) — do this
+
+You only enter this section after something is **named** (Profiler / Xray) or is
+obviously a foreign/SDK boundary you never expected Hiccup to own.
 
 ### Name the island first
 
@@ -81,15 +92,12 @@ You do not need Hicasso-private tooling.
 Name the boundary, the sub, or the event **before** changing architecture.
 "The app is slow" is still the 98% problem wearing a costume.
 
-### Then climb only as far as you must
-
-Work **top to bottom**. Most hot cases die on step 1 and return to the default path.
-
-#### Step 1 — Still Hiccup
+### Step 1 — Still Hiccup
 
 Re-check the default path on the named island: fewer boundaries, reads at point
-of use, stable keys, no high-rate `:db` writes. That step is first because
-**that is where the cost usually lives**, not interpretation.
+of use, stable keys, no high-rate `:db` writes. Most hot-path cases die here and
+return to the 98%. That step is first because **that is where the cost usually
+lives**, not interpretation.
 
 **Big lists (honest).** One event that many row boundaries care about — a large
 table or feed — is the shape where cost **can** bite. Outside measurements have
@@ -105,7 +113,7 @@ Order for a big table:
 
 Do not jump to hooks on a 300-row table before keys, bail-out, and read shape.
 
-#### Step 2 — Host-edge React (one island)
+### Step 2 — Host-edge React (one island)
 
 A `defview` body is a real React function component. Hooks and refs are fine for
 **mechanics**: measure, SDK handles, animation clocks that are not app state.
@@ -148,7 +156,7 @@ landing.
 
 Keep the island **small**. Callback refs: [Interop](05-interop.md) Advanced.
 
-#### Step 3 — Foreign React (`defhost` / `[:>]`)
+### Step 3 — Foreign React (`defhost` / `[:>]`)
 
 Someone else's component — date picker, chart, **virtualized list**:
 
@@ -167,7 +175,7 @@ Someone else's component — date picker, chart, **virtualized list**:
 Existing React elements are legal children (pass-through). Keep JS requires in
 `.cljs` host namespaces.
 
-#### Step 4 — Another view layer
+### Step 4 — Another view layer
 
 A whole screen in UIx or Reagent is **another adapter root**, not a Hicasso
 mode. Multi-frame: [Getting started](01-getting-started.md).
@@ -187,7 +195,7 @@ mode. Multi-frame: [Getting started](01-getting-started.md).
 
 | Level | Data intents | Ambient `sub` | Headless-friendly | Lever |
 |---|---|---|---|---|
-| Default Hiccup | Yes | Yes | Intents today; full render later | Boundaries, reads, keys, bail-out |
+| Default Hiccup (98%) | Yes | Yes | Intents today; full render later | Boundaries, reads, keys, bail-out |
 | Host-edge hooks | Partial | Yes in that body | **No** for that body | React |
 | `defhost` | Opaque at the crossing | Via props / parents | Foreign region out | Leave work in the library |
 | Other adapter | That root's rules | That root's rules | That root's rules | Full switch |
@@ -206,9 +214,9 @@ mode. Multi-frame: [Getting started](01-getting-started.md).
 | SDK mounts twice / leaks | Ref without paired teardown | Attach + cleanup as one ref (React 19) — [Interop](05-interop.md) |
 | Still slow after dropping to React | Wrong layer | Profile again — often reads or event volume |
 
-## When not to go below Hiccup
+## When not to leave the 98%
 
-- Still the **98%** — no profile, only fear of the interpreter.
+- No profile — only a feeling, or a fear of the interpreter.
 - The real issue is **event volume** ([Controlled inputs](04-controlled-inputs.md)).
 - You are about to reimplement the app in hooks "for the 2%." That is a
   substrate change, not an escape hatch.

--- a/docs/design/hicasso/draft-guide/README.md
+++ b/docs/design/hicasso/draft-guide/README.md
@@ -18,7 +18,7 @@ programmer actually type?**
 | [Testing](08-testing.md) | Assert intents and trees as data today; know when you still need a browser |
 | [When a view throws](09-when-a-view-throws.md) | Keep one broken view from taking the page down with it |
 | [Server-side rendering](10-server-side-rendering.md) | Serve a page rendered from a db snapshot and adopt it live in the browser |
-| [Performance](11-performance.md) | Default path (98%); when something is slow, name the island and climb the ladder |
+| [Performance](11-performance.md) | 98% of the time Hiccup is completely fine; for the ~2% hot path, do this (ladder) |
 
 ## How to read the markers
 


### PR DESCRIPTION
## Summary

Reframes the Hicasso Performance chapter so the point is impossible to miss:

1. **98% of the time, Hiccup is completely fine** — ordinary `defview` / `sub` / intents; ship it.
2. **About 2% of the view code is on the hot path.**
3. **In that case, do this** — the ladder (still Hiccup → host edge → `defhost` → other root), after naming the island.

### Structure

- Open: bold claim + numbered "do this" list (stop as soon as the island is fixed)
- Why Hiccup is usually enough (measured walk parity / read-shape bill — supporting, not lead)
- Default path (the 98%)
- Hot path (the 2%) — name island, then steps 1–4
- Tradeoffs / troubleshooting / when not / not settled

Also aligns Getting Started and the guide index job line with the same wording.

## Rebased onto current `main`, which now carries #7527

This branch was opened three minutes after #7527 and before #7526 merged, so it needed a rebase over both. It is a **later pass over #7527's text**, not a competing draft: outside the intro and the heading levels, the two files were byte-identical. #7527's own reconciliation is now the base rather than part of this diff, which is why the diff is +74/−52 rather than the +140/−121 it showed while #7527 was still open.

Rebasing onto post-merge `main` was clean — git recognised the reorganisation commit as already applied and skipped it, and the two remaining commits replayed with **zero conflicts**. The resulting tree is byte-identical to the reviewed pre-merge state on all three files.

Everything reconciled during the earlier passes is preserved, now arriving via `main` rather than via this diff: the `defview` / `sub` / intents enumeration (this PR states it in its own voice), "**The other ~2%** is a measured island…" (restated here as "**About 2% of the view code is on the hot path**"), the "98/2 split … not a lab certificate" sentence, `Attach + cleanup as one **ref** (React 19)`, `off the render` in the host-edge comment, and the "not an ambient `rf/*`" note on the `h/frame` binding.

`01-getting-started.md` still auto-merges cleanly — this PR's two wording edits and `main`'s fx-first troubleshooting row (from `5ae20edda5`) sit in different regions and both survive.

## Second commit: the three settled contracts (rf2-2rtt6.102, rf2-cwmnz)

`11-performance.md` carries three claims the tree has outgrown, and **both drafts moved them rather than fixing them** — so the corrections ride here as the **last** commit, where a later rebase cannot overwrite them. Each was re-verified against source, not against the beads' paraphrase.

| Claim on the page | Why it is wrong | Authority |
|---|---|---|
| "A **vector** head is a boundary" | Native tags, fragments, `defhost` heads and `h/boundary` all sit in vector position and mint none of the four things a boundary owns | `02-views-and-reads.md:45-50` — "A **view in head position** mints a **boundary** … none of them is a boundary"; `09-when-a-view-throws.md:21-23` |
| "plain call — inlined; **free at runtime**" | The helper still executes and still builds markup on each parent render; what it does not buy is re-render granularity | `02-views-and-reads.md:52-54` |
| Ambient `rf/*` "may work, throw, or pick the wrong frame" | Since the refusal tier landed they **refuse**, under every adapter, naming the collector — deterministically | `02-views-and-reads.md:31-33`; `03-events-as-data.md:265-271`; `arm1/ambient_refusal_cljs_test.cljs:19` |

The `h/frame` half is rewritten **fx-first**, matching `01-getting-started.md:214` and `03-events-as-data.md:273-274`, and the arm's own note that "every guide row putting `h/frame` on the page puts `:fx` first" (`front/intent.cljs:410-417`).

Three deliberate non-changes:

- **The error id stays off the page.** `:rf.error/ambient-frame-refused` is provisional (`ambient_refusal_cljs_test.cljs:315`, rf2-k0rbk may rename it) — `02` and `03` describe the behaviour without printing it, and this page now does the same.
- **`[unfrozen]` stays; "may still be landing" goes.** #7522 landed `h/frame` with witnesses in the arm, so the pre-landing hedges ("may still be landing", "when available", "check before you depend on it") are stale. What is unfrozen is the product *name*, not the availability — `03:253` and `09:15,27` still mark it, and the page banner says so.
- **"(a Hicasso-minted missing-key warning is planned…)" is not restored.** Both drafts dropped it and they are right: `02:69-77` documents `:rf.warning/hicasso-missing-key` as landed, so "is planned" was itself stale.

## Quality gates

- [x] `python scripts/check_doc_slugs.py` — exit 0 (validates this tree's link targets and heading anchors; runs in the fast-PR spine)
- [x] Hand-verified table column counts on all three touched files (nothing validates markdown tables): `11-performance.md` 6 tables — 2/2/2/5/3/2 columns (2/3/4/4/9/5 data rows), every row matching its header; `README.md` 1 table (2 columns, 11 rows); `01-getting-started.md` 3 tables (3/3/2 columns). 0 mismatches
- [x] Hand-verified anchors: the two new deep links resolve — `02-views-and-reads.md#boundaries-and-inlining` (heading at 02:35) and `03-events-as-data.md#callbacks-carry-their-frame` (heading at 03:230). `06-theming.md`'s existing anchor into `02-views-and-reads.md#boundaries-memoize-by-default` is untouched and still resolves. No page links into a `11-performance.md#…` anchor, and the page has no intra-page anchors
- [x] Not digest-pinned — the `docs/core/freehand/` code-block digest roster does not cover this tree; the only `draft-guide` mention under `implementation/` is a prose citation of `05-interop.md` in `codec_cljs_test.cljs:788`
- [x] No conflict markers remain; plain `git add` used throughout, `git diff --numstat` shows line-level diffs (+74/-52, +3/-3, +1/-1), not a whole-file CRLF rewrite
- [x] `mkdocs build --strict` **not** applicable — `exclude_docs` keeps `docs/design/**` out of the site, so it would verify nothing here
