### PR TITLE
fix(hicasso): the h/frame DOM suite aborts the browser lane — #7522 merged before its fixture fix (rf2-841vn)

### DIFF
--- a/docs/design/hicasso/studio/hframe-design.md
+++ b/docs/design/hicasso/studio/hframe-design.md
@@ -217,7 +217,7 @@ Nine rows, re-grounded on the post-`rf2-2rtt6.122` tree.
 | W4 | Inside a `defhost` `:render` callback invocation → answers the **supplying** boundary's frame, not the invoker's | the `rf2-2rtt6.74` owner rule |
 | W5 | Not a tracked read: a body reading `(h/frame)` alone registers zero edges; adding it to a reading body changes no read set; the hook ledger still counts 2 (and 1 on the frame-prop shell) | |
 | W6 | StrictMode double-invoke: same value both runs, no additive effect | |
-| W7 | The `[:>]` value-first door dispatches through a plain closure over the capture | pairs with the `rf2-2rtt6.103` dev-warning row |
+| W7 | The `[:>]` value-first door dispatches through a plain closure over the capture | pairs with the `rf2-2rtt6.103` dev-warning row. **NOT BUILT** — the raw escape is unbuilt, so there is no door to drive; see §8a and `rf2-zllp8` |
 | W8 | SSR: the server body answers the per-request id; render-twice stays byte-identical while the id stays out of markup, and goes red when a witness deliberately renders it | |
 | W9 | An event-time read is not silently wrong: `(h/frame)` inside a `reg-event` handler body raises | the router binds core scope, not the arm's |
 
@@ -303,6 +303,8 @@ is blocked on `[:>]` in any case (`rf2-zllp8`).
 ---
 
 ## 9. What is NOT settled here — flagged for a ruling
+
+*Written before the implementation. §8a resolves (1) and (4); (2) and (3) stand.*
 
 1. **The error id.** The design pass proposed
    `:rf.error/hicasso-frame-outside-boundary`; the synthesis comment wrote

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/ambient_refusal_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/ambient_refusal_cljs_test.cljs
@@ -334,8 +334,17 @@
     (let [f (make-frame!)]
       (with-context-frame f
         (fn []
-          (let [data (outcome #(rt/render-body f (fn [_] (rf/capture-frame) [:li]) {}))]
-            (is (= (refusal-id f) (:rf.error/id data))
+          (let [data   (outcome #(rt/render-body f (fn [_] (rf/capture-frame) [:li]) {}))
+                anchor (refusal-id f)]
+            ;; The `some?` is not padding. Comparing two ids without it is
+            ;; green when NEITHER refuses — measured: with the fence
+            ;; removed from `intent/with-frame`, every other assertion in
+            ;; this row went red and the comparison alone stayed green,
+            ;; both sides nil.
+            (is (some? anchor)
+                "precondition: an ambient READ refuses here, and its id is
+                 what this row compares against")
+            (is (= anchor (:rf.error/id data))
                 (str "a carry must refuse with the SAME id a read does; got "
                      (pr-str data)))
             (is (= :capture-frame (:operation data))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/hframe_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/hframe_cljs_test.cljs
@@ -164,6 +164,11 @@
 
       (testing "invoked from outside any extent at all — the foreign
                component's own render"
+        (is (not (rt/rendering?))
+            "the premise, asserted rather than described: the arm's own
+             render slot is EMPTY at the moment the callback runs, so a
+             `h/frame` built on `rstate.frame` would answer nothing here.
+             This is design §3's load-bearing sentence, made measurable")
         (@callback)
         (is (= frame-a @seen)))
 

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/hframe_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/hframe_dom_cljs_test.cljs
@@ -52,6 +52,14 @@
      ;; would answer — so an isolation miss could read as a rendering
      ;; difference rather than as the failure it is.
      :ambient-frame nil
+     ;; The MAP shape, because W2 is `async`: the whole point of that row
+     ;; is a closure firing from a real macrotask, long after the render's
+     ;; dynamic extent has unwound, and `cljs.test` refuses an async test
+     ;; under a fn-form fixture outright — "Async tests require fixtures to
+     ;; be specified as maps. Testing aborted." — which aborts the WHOLE
+     ;; browser run at this namespace, not just this file. Same reason
+     ;; `arm1/generation_fence_dom_cljs_test` takes the map shape.
+     :async?        true
      :init-fn       (fn [] (rt/reset-runtime!))}))
 
 (def ^:private frame-a ::hframe-dom-a)


### PR DESCRIPTION
**RED ON MAIN — merge this first.** PR #7522 was merged at `49acc9a704` while its
worker was still finishing gates, so main carries `arm1/hframe_dom_cljs_test` **without
the fixture fix its own browser run required**. The four commits below were pushed to
`worker/hframe-841vn` after that point and did not travel.

## The breakage

`arm1/hframe_dom_cljs_test` has an `async` test (W2 fires its capture from a real
macrotask, which is the entire content of the row). `cljs.test` refuses an async test
under a fn-form fixture and **aborts the whole run at that namespace**:

```
[browser:pageerror] Async tests require fixtures to be specified as maps.  Testing aborted.
```

That is the required `cljs-browser` job, and it does not fail one row — it stops the
lane. Reproduced locally on the pre-fix tree: `npm run test:browser` **exit 1**, aborting
at `re-frame.bench.hicasso.arm1.hframe-dom-cljs-test`. With the fix: **exit 0, 1,097
tests / 6,792 assertions, 0 failures, 0 errors.** The fixture takes `:async? true` — the
map shape, exactly as `arm1/generation_fence_dom_cljs_test` does for the same reason.

## The other three

Small, and they were part of the same review pass:

- **`ambient_refusal_cljs_test` — a vacuity the mutation testing exposed.** The carry
  row compares its error id against a live ambient read's rather than repeating the
  provisional `:rf.error/ambient-frame-refused` spelling (rf2-k0rbk). But two nils
  compare equal: with the refusal removed from `intent/with-frame`, every *other*
  assertion in that row went red while the comparison alone stayed green, both sides
  nil. The anchor is now asserted present first.
- **`hframe_cljs_test` — W4's premise asserted instead of described.** The row said the
  runtime's own render slot is nil while a render callback runs, which is the design's
  §3 reason for reading `intent/*frame*` rather than `rstate.frame`. It is now read off
  `rt/rendering?` at the moment the callback fires.
- **The design record** marks W7 **NOT BUILT** in the witness table (the `[:>]` raw
  escape is unbuilt, rf2-zllp8) and points §9's open questions at §8a, which resolves
  two of them.

## Quality gates

| Gate | Exit | Result |
|---|---|---|
| `npm run test:browser` | 0 | **1,097 tests / 6,792 assertions — 0 failures, 0 errors** (exit **1** without this branch) |
| `npm run test:cljs` | 0 | 12,621 tests / 63,213 assertions — 0 failures, 0 errors |
| `npm run test:hicasso-compile` | 0 | 123 lane namespaces, zero warnings |
| `sh scripts/test-fast-pr.sh` | 0 | `PASS fast PR spine` |
| clj-kondo 2026.04.15 (the CI pin), CI's `--lint` set | 0 | errors: 0; zero findings in any touched file |
| `python scripts/check_doc_slugs.py` | 0 | design-record anchors and table validate |
| `sh scripts/check-no-hardcoded-paths.sh` | 0 | clean |

Every gate above was run on the exact tree these four commits produce, on
`worker/hframe-841vn`, before #7522 merged. Follows rf2-841vn / rf2-hnrww (both closed
by #7522).
