### PR TITLE
docs(hicasso): the fx-first route to a captured frame (rf2-cwmnz, rf2-2rtt6.102)

### DIFF
--- a/docs/design/hicasso/draft-guide/01-getting-started.md
+++ b/docs/design/hicasso/draft-guide/01-getting-started.md
@@ -211,7 +211,7 @@ No boot-path error ids are minted yet; this table names mechanisms.
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | `sub` throws outside a view | `sub` is render-scoped; there is no `@`-anywhere | Declare `:rf.cofx/requires` in an event handler; `rf/subscribe-once` with an explicit `{:frame …}` everywhere else |
-| Async callback dispatches and nothing happens | Bare `dispatch` from a timeout has no frame | Intent callbacks carry their [boundary](02-views-and-reads.md#boundaries-and-inlining)'s frame; hand-written async needs the frame explicitly |
+| Async callback dispatches and nothing happens | Bare `dispatch` from a timeout has no frame | Own the async work through `:fx` — an fx handler receives the frame id in its context. Intent callbacks carry their [boundary](02-views-and-reads.md#boundaries-and-inlining)'s frame; only a closure crossing to foreign code needs [the explicit carry](03-events-as-data.md#callbacks-carry-their-frame) |
 | First paint empty, then flickers | Seed raced first render | Seed through `:initial-events`, not a post-mount dispatch |
 | View renders twice on mount in dev | StrictMode double-invokes bodies | Expected — bodies are pure and re-runnable |
 | Second `h/root!` on the same node | Live root already owns the node | `defonce` the teardown; call it before re-rooting |

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -28,7 +28,9 @@ Hicasso's answer is a view that is a function from a props map to hiccup, and
 > **`sub` is legal anywhere in the body** — inside a `let`, a `when`, a helper
 > call. Read where you need the value.
 
-`sub` is the only read form. There is no second spelling for helpers.
+`sub` is the only read form. There is no second spelling for helpers, and a bare
+`rf/subscribe` in a body is not a fallback: it refuses, under every adapter,
+naming the collector it went around.
 
 ## Boundaries and inlining
 

--- a/docs/design/hicasso/draft-guide/02-views-and-reads.md
+++ b/docs/design/hicasso/draft-guide/02-views-and-reads.md
@@ -40,13 +40,14 @@ syntax:
 (todo-row {:id id})           ;; a call — INLINED into the enclosing boundary
 ```
 
-A **vector** in head position mints a React element, and that element is a
-**boundary** — Hicasso's unit of independent re-rendering. A boundary owns four
+A **view in head position** mints a **boundary** — Hicasso's unit of independent
+re-rendering, and the thing `defview` exists to make. A boundary owns four
 things: React's identity for it, the `sub` reads its body makes, its
 [value-equality bail-out](#boundaries-memoize-by-default), and the frame the
-intents in its hiccup dispatch to.
+intents in its hiccup dispatch to. Native tags, fragments and `defhost` heads are
+elements in vector position too, and none of them is a boundary.
 
-A **plain call** is just a function call, and owns none of them. Its hiccup is
+A **plain call** is just a function call, and owns none of the four. Its hiccup is
 spliced into the caller's tree, and any `sub` it performs donates that read
 *upward* to the enclosing boundary. Helpers cost nothing at runtime and buy no
 re-render granularity. Because reads are ordinary calls, **helpers can read**: a

--- a/docs/design/hicasso/draft-guide/03-events-as-data.md
+++ b/docs/design/hicasso/draft-guide/03-events-as-data.md
@@ -235,11 +235,43 @@ from the substrate's single internal context.
 That matters because the browser invokes the callback long after the render that
 created it, when the render's dynamic extent is gone. A hand-written
 `#(rf/dispatch …)` from an async context raises `:rf.error/no-frame-context` for
-exactly this reason. Intent vectors don't, because the frame was captured when
+exactly this reason; intent vectors don't, because the frame was captured when
 the callback was built.
 
-The rule of thumb: **intents are always safe; hand-written async needs the frame
-explicitly.**
+**Async work belongs in the event layer, which already has the frame.** A view
+that sets a timeout and dispatches when it fires is a mis-layered effect: an fx
+handler receives the frame id in its context, and `:dispatch-later` says the
+delay as data. Move the work and the carrying question goes with it.
+
+What survives the move is **a dispatching closure handed to a caller you do not
+control**: an SDK attached through a ref, a `defhost` slot declared `:handler`, a
+library that calls back with a value instead of an event. The frame is knowable
+during the render and nowhere else, so read it there.
+
+```clojure
+(defview map-panel [{:keys [id]}]
+  (let [{:keys [dispatch]} (rf/capture-frame (h/frame))]   ;; h/frame is [unfrozen]
+    [:div.map
+     {:ref (fn [node]                          ;; refs run after commit, not in render
+             (when node
+               (sdk/on-select node #(dispatch [:map/marker-selected id %]))))}]))
+```
+
+`(h/frame)` answers the frame id of the boundary currently rendering, and raises
+`:rf.error/hicasso-frame-outside-boundary` anywhere else. `rf/capture-frame` is
+core's one carry primitive; hand it an id and you get back
+`{:frame :dispatch :dispatch-sync :subscribe}` locked to that frame.
+
+The adapters spell this `(rf/capture-frame)`, in one step. Hicasso needs two
+because **ambient frame lookup is what its stricter body discipline withdraws**:
+inside a body an ambient `rf/subscribe` or `rf/dispatch` refuses rather than
+resolving. `rf/with-frame` and an explicit `{:frame …}` still carry — the
+discipline withdraws the ambient *find*, never the carrying — but both make you
+name the frame, which a reusable view mounted under several frames cannot do.
+That id is what `h/frame` supplies.
+
+The rule of thumb: **intents are always safe; async work goes through `:fx`; a
+closure crossing into foreign code carries `(rf/capture-frame (h/frame))`.**
 
 ## Troubleshooting
 
@@ -253,7 +285,8 @@ are named in the sections above.
 | Enter commits half-typed Japanese text | Composition handling written by hand | Use the `:on-key-down` key map — composition is centralised there |
 | A `route-link` refuses your `:on-click` intent vector | Click already produces the routing intent — bare second intent is one action, two events | Wrap it: `[::h/prevent [:app/event]]` |
 | `:rf.error/routing-artefact-missing` when rendering a `route-link` | Routing not on the classpath / not required at boot | Require `re-frame.routing` (and the rest of your routing setup) before the link renders |
-| `:rf.error/no-frame-context` from a timeout | Bare `dispatch` in async code | Capture the frame at the call site, or own the async work through `:fx` |
+| `:rf.error/no-frame-context` from a timeout | Bare `dispatch` in async code | Own the async work through `:fx`; a closure you hand to foreign code carries `(rf/capture-frame (h/frame))` |
+| `rf/subscribe` or `rf/dispatch` refuses inside a view body | Ambient frame lookup is withdrawn there, so neither resolves | Read with `sub`, dispatch through an intent at a handler position, carry with `(rf/capture-frame (h/frame))` |
 | An intent fires but no handler runs | Unregistered event id | Registration happens on namespace load; check the boot namespace requires it |
 
 ## When not to use an intent

--- a/docs/design/hicasso/draft-guide/06-theming.md
+++ b/docs/design/hicasso/draft-guide/06-theming.md
@@ -228,7 +228,7 @@ structural tests can see less of. Honest trade, stated once.
 | Symptom | What went wrong | Fix |
 |---|---|---|
 | The theme keyword changes in app-db and nothing on screen changes | No bridge is wired — app-db holds the choice; the cascade keys off a DOM attribute | Wire option A or B above; the event alone does nothing to the document |
-| Theme switch re-renders the whole app | Option A, with the themed content spliced in as a plain call rather than a `[boundary …]` vector | Put the content behind a boundary (children or a direct `[app {}]`), or use option B |
+| Theme switch re-renders the whole app | Option A, with the themed content spliced in as a plain call rather than an `[app {}]` vector | Put the content behind a boundary (children or a direct `[app {}]`), or use option B |
 | A time-travel rewind shows the old theme | Option B — the attribute was asserted by an effect, so it is not derived from the state you rewound | Expected under B; it is the price named above |
 | A controlled input's value gets clobbered by a theme | Should be impossible — law (a) | A runtime bug, not a usage error |
 | A part override doesn't take effect | Merge order: instance props beat app theme beat base | Check which layer you set it in |

--- a/docs/design/hicasso/draft-guide/09-when-a-view-throws.md
+++ b/docs/design/hicasso/draft-guide/09-when-a-view-throws.md
@@ -20,7 +20,7 @@ box around the broken component.
 If `article-body` throws, the header and footer stay up and the paragraph takes
 its place. Nothing else in the tree notices. `h/boundary` is a component you
 write; it is not the [rendering boundary](02-views-and-reads.md#boundaries-and-inlining)
-every vector child mints. Same word, different thing, and only this one catches.
+a `defview` mints. Same word, different thing, and only this one catches.
 
 ## The three keys
 


### PR DESCRIPTION
Two draft-guide beads, both in `docs/design/hicasso/draft-guide/**`. Net **+36 lines** (48 added, 12 removed) across five chapters. `11-performance.md` is untouched.

## `rf2-cwmnz` — the fx-first route to a captured frame

`h/frame` shipped in #7522 and the guide still ended three separate paragraphs with "hand-written async needs the frame explicitly" and no spelling to reach for. All three now lead with `:fx`.

**03's "Callbacks carry their frame"** is the mechanism's one home, rewritten in the order the ruling fixed. Async *work* belongs in the event layer, which already has the frame — an fx handler receives the frame id in its ctx (`spec/002-Frames.md:1516`) and `:dispatch-later` says the delay as data. What survives that move is the foreign edge, where a dispatching closure crosses to a caller you do not control, and that is the only place `(h/frame)` is taught. This honours the design's §6 compensation for the softening it records: `h/frame` makes mis-layered view async merely *work* where it used to fail loudly, so every row putting it on the page puts `:fx` first.

The carry spelling is `(rf/capture-frame (h/frame))`, destructured as the **map** `capture-frame` actually returns — `{:frame :dispatch :dispatch-sync :subscribe}`, verified at `implementation/core/src/re_frame/core.cljc:1464`, not a bare dispatch fn. The two-step against the adapters' one-step gets its one-sentence reason: ambient frame lookup is what Hicasso's stricter body discipline withdraws.

**The contract-force sentence** is stronger than the design pass wrote it, per `rf2-2rtt6.122`. Ambient `rf/subscribe` / `rf/dispatch` in a body do not "may work, may throw" — they **refuse**, under every adapter, and the refusal names the collector. 02 says it where a reader would go looking for a second read form; 03 carries the dispatch half plus a troubleshooting row.

**No provisional id is printed.** `:rf.error/ambient-frame-refused` stays out of the prose pending `rf2-k0rbk`; the row names the mechanism instead. `:rf.error/hicasso-frame-outside-boundary` *is* named — it is `h/frame`'s own id, shipped in #7522 and outside `rf2-k0rbk`'s scope.

The runnable sample is a native `:ref` handing a closure to an SDK. The `:ref` is legal there per 02's component ABI table (callback ref on a native tag); the capture sits in the body because that is the only place `h/frame` is legal, and the wiring sits in the ref because refs run after commit, not during render — so the body stays pure under StrictMode.

## `rf2-2rtt6.102` — NOT already discharged; the audit-reopen was the live work

The bead carries a `MERGED-PR AUDIT #7487 — REOPENED` note naming a precise remaining defect, and that is what this PR fixes. Items (1)–(3) did ship in #7487 (commit `1b664b19f2`), but the definition it introduced generalised one step too far:

- 02 said *"A **vector** in head position mints a React element, and that element is a **boundary**"*
- 09 sharpened that to *"the rendering boundary **every vector child** mints"*

Both are false for ordinary native hiccup, fragments, foreign `defhost` elements, and the class-based `h/boundary` — all legal vector children, none of which carries the four-property shell. The authoritative sources agree it belongs to `defview`:

- `docs/design/hicasso/authoring.md:31` — "**`defview` mints a boundary** — a real React function component"
- `docs/design/hicasso/architecture.md:88` — "A boundary is a **real React function component** minted by `defview`"
- `front/codec.cljs:912` `memoize-boundary!` — "Opt-in at the mint site rather than applied to every marked head, so heads that are not reactive boundaries — `h/boundary`'s error-boundary class, presence — keep the semantics they were written with." Only `runtime/mint-view!` and `mint-frame-prop-view!` call it; `mint-host!` does not.

Both sentences now name `defview` as the minter, and 02 keeps the useful four-property definition and its anchor (06's inbound link to `#boundaries-memoize-by-default` is unchanged and still resolves).

Item (4)'s grep sweep found one further ambiguity worth a word: 06's troubleshooting row wrote a placeholder view as a `[boundary …]` vector, which now reads as `h/boundary` — changed to an `[app {}]` vector, matching the prose four lines above it. 01's forward link and 05:132's frame-carrier sentence read correctly as written and are left alone.

## Flagged, not resolved

**`h/defhost` heads and the value-equality bail-out.** 05's "Memo and hosted components" teaches that the bail-out "reaches a hosted component the same way it reaches a native one" and that `hosted-row` "never re-enters the foreign component". But `codec/memoize-boundary!` is opt-in at the mint site and `codec/mint-host!` does not call it, so a hosted head carries no memo wrapper of its own. Either the claim needs a mechanism (React's own reconciliation? a `memo` product supplied by the library?) or it needs narrowing. Out of scope for both beads and a substantive correctness question rather than a wording one — filed as `rf2-u09ay` rather than decided here.

## Quality gates

| Gate | Command | Exit |
|---|---|---|
| Doc slug / anchor validator | `python scripts/check_doc_slugs.py` | **0** |
| Fast-PR spine | `sh scripts/test-fast-pr.sh` | **0** |
| Portability gate | `sh scripts/check-no-hardcoded-paths.sh` | **0** |

Both the slug validator and the portability gate were re-run after the rebase onto `863b3d428b`; both still 0.

**`mkdocs build --strict` is not nominated.** `mkdocs.yml`'s `exclude_docs` keeps `design/hicasso/` out of the site, so it would exit 0 having verified nothing on this diff.

**Mutation proof for the slug validator.** The one new cross-file anchor link is 01 → `03-events-as-data.md#callbacks-carry-their-frame`. Mutating that anchor to `…-MUTANT`, then grep-confirming the mutation landed in the file *before* reading any exit code:

```
docs/design/hicasso/draft-guide/01-getting-started.md:214: … [the explicit carry](03-events-as-data.md#callbacks-carry-their-frame-MUTANT) |
```

the validator then failed, naming that exact line:

```
1 broken anchor link(s) found:
  BROKEN ANCHOR: docs\design\hicasso\draft-guide\01-getting-started.md:214
      -> 03-events-as-data.md#callbacks-carry-their-frame-MUTANT
exit 1
```

Reverted; grep for `MUTANT` in `docs/` returns nothing and the validator is back to 0.

**Tables — hand-verified, since nothing validates them.** Every pipe-table block in the five touched files, counted cell-by-cell:

| File | Table (rows) | Columns |
|---|---|---|
| `01-getting-started.md` | feature map (73–92) | 3 |
| `01-getting-started.md` | **Troubleshooting (211–217)** — edited | 3 |
| `01-getting-started.md` | Not settled yet (240–246) | 2 |
| `02-views-and-reads.md` | component ABI (84–89) | 5 |
| `02-views-and-reads.md` | Troubleshooting (268–276) | 3 |
| `02-views-and-reads.md` | Not settled yet (316–320) | 2 |
| `03-events-as-data.md` | key map (85–91) | 2 |
| `03-events-as-data.md` | **Troubleshooting (281–290)** — edited, one row added | 3 |
| `03-events-as-data.md` | Not settled yet (315–317) | 2 |
| `06-theming.md` | **Troubleshooting (228–236)** — edited | 3 |
| `06-theming.md` | Not settled yet (250–258) | 2 |
| `09-when-a-view-throws.md` | the three keys (31–35) | 3 |
| `09-when-a-view-throws.md` | Troubleshooting (97–104) | 3 |
| `09-when-a-view-throws.md` | Not settled yet (115–119) | 2 |

Header, separator and every body row agree within each block; no block mixes widths.

**Anchors.** No heading was added, renamed or removed — `git diff origin/main -- docs/` has no `+`/`-` line beginning with a markdown heading marker — so no inbound-link sweep was needed. The one link added targets 03's pre-existing `## Callbacks carry their frame`.

## Fences

`docs/design/hicasso/draft-guide/**` only, and `11-performance.md` untouched (`docs/hicasso-performance-reorg` and `-framing` are open on it). Nothing under `implementation/`, `spec/`, `docs/design/hicasso/studio/`, `decisions.md` or `validation.md`. No `.beads/` path in either commit.
