### PR TITLE
docs(xray): 017 says which tier proves a covered row + the rf2-rliq7 policy recommendation

### DIFF
--- a/tools/xray/spec/017-Test-Coverage-Matrix.md
+++ b/tools/xray/spec/017-Test-Coverage-Matrix.md
@@ -26,6 +26,29 @@ storms, buffer caps, and panel rendering budgets. Default CI should
 continue to run the lightweight unit/helper/view gates plus the normal
 smokes.
 
+**When a `covered` row is proved, and by which tier.** The owning
+command in the matrix below — the Xray browser feature gate — runs in
+two tiers, and the column does not distinguish them. `npm run
+test:xray-feature-gate:smoke` runs on every PR that touches a Story or
+Xray surface; it executes only the scenarios tagged `smoke: true` in
+`tools/xray/testbeds/feature_matrix/scenarios.cjs` and compiles only the
+surfaces those scenarios load. `npm run test:xray-feature-gate` — every
+scenario over every staged surface — runs nightly in
+`.github/workflows/expensive-tests.yml`, and that nightly sweep is the
+system of record. At the time of writing the split is 5 scenarios over
+4 surfaces on the PR path against 17 over 12 nightly, so **most
+`covered` rows in this matrix are proved once a day rather than on the
+change that could break them**, and a newly added non-smoke scenario
+merges without ever having run (rf2-rliq7 records the policy call and
+its costings). That is the deliberate cost decision in `TESTING.md`, not
+an accident — but read `covered` in that light: it means the row has a
+browser-level feature path, not that the path guards the PR that breaks
+it. Per `TESTING.md`, tag a scenario `smoke: true` only if it earns a
+slot on every PR **and** loads an already-staged smoke surface;
+everything else is nightly by default, and the author is expected to run
+the full gate locally (`scripts/test-rigorous-local.sh`) before merging
+a scenario the PR tier will not execute.
+
 ## Required shared testbed
 
 The feature gate should prefer one deterministic Xray feature testbed


### PR DESCRIPTION
**This PR does not fix rf2-rliq7. It brings back a recommendation and leaves the call to Mike.** The bead stays open; nothing is closed. The one committed change is an in-fence honesty fix to the coverage spec.

**Recommendation: option (1) — WONTFIX the merge-unrun gap — but only after `rf2-7jevo` is fixed.** Option (3) is not merely expensive right now, it is unsafe. Details below.

## What verifiably merges unrun today

Established by mutation, not by reading the bead. I added a sixth, non-smoke scenario to `scenarios.cjs` whose `run` throws unconditionally, and ran both tiers:

| Tier | Command | Exit | Runner's own terminal marker |
|---|---|---|---|
| PR | `test:xray-feature-gate:smoke` | **0** | `Ran 5 Xray feature scenarios (PR-smoke tier). 0 failures. Covered 10 matrix rows.` |
| Nightly | `test:xray-feature-gate` | **1** | `Ran 18 Xray feature scenarios (nightly-full sweep). 1 failures. Covered 14 matrix rows.` |

An always-throwing scenario passes the PR gate green. The probe was reverted and is not in this branch.

Scope of the gap, measured on `f89b8b5037`: **12 of 17 scenarios and 8 of 12 staged surfaces never execute at PR time.** `sh .github/scripts/report-changed-surfaces.sh tools/xray/testbeds/feature_matrix/scenarios.cjs` does arm `story_xray_browser=true`, and that job does load and validate the whole file — the bead's framing is correct — but it executes only the 5 `smoke: true` rows over 4 surfaces.

## The three options, re-costed against the current tree

**Option (3) — arm the full sweep on `scenarios.cjs` edits.** The bead calls this "trivial to implement" and it is. Two findings change its cost in opposite directions:

*Cheaper than the bead assumes.* Nightly full = **160s / 154s / 159s / 160s** on 2026-08-01..04; PR smoke = **91s / 80s / 109s**. Warm, the delta is **~+70s**, not the "~700s" the `test.yml` comment cites (that figure covered the old combined feature-load + matrix + static sweep — stale, filed as `rf2-ano54`). Cold it is worse: measured locally, the 8 extra surfaces compile in **+302s**, and a `scenarios.cjs` edit always busts the exact `.shadow-cljs` cache key.

*Far worse signal-to-noise than the bead assumes.* Over the last 10 weeks, **53 commits touched `scenarios.cjs`; only 5 added a scenario; 2 of those 5 were already `smoke: true`.** So **3 useful firings in 53 — 5.7%.** The other 48 are renames, vocabulary sweeps, comment de-historicising, dead-code deletion. The bead's worry about "a one-word rename" is empirically the normal case.

*And the disqualifier.* The nightly Xray gate has failed **4 of the last 14 nights**, every time on the same non-smoke scenario with the same signature — `FAIL static mode chrome and chord: locator.waitFor: Timeout 5000ms exceeded`. Arming the full sweep at PR time would red roughly **1 in 3 PRs touching `scenarios.cjs`** for a known unrelated flake. Filed as **`rf2-7jevo` (P1)**.

**Option (2) — run only added/changed rows.** Cheaper on the runner than the bead suggests: `surfaceForScenario()` plus the `ACTIVE_SCENARIOS`/`ACTIVE_SURFACES` pair already implement "run subset S, compile only S's surfaces" — smoke mode *is* that mechanism, and only the selector is missing. But it needs a `.github/workflows/**` change (base ref + a new arm) and a deliberate, mutation-proved replacement of the `_changed-surfaces.test.cjs:1864` pin. The diff-parsing is the fragile part: recovering scenario identity from a diff of a 4,000-line JS file turns any rename into an add+delete. Real but not trivial.

**Option (1) — WONTFIX.** Zero CI seconds. Its entire weight rests on one premise: *the nightly sweep is the system of record*. That premise is currently false, for two independent reasons — the flake above, and **`expensive-tests.yml` has no failure alerting at all** (`on: schedule` + `workflow_dispatch`, no notify step). 18 of the last 30 nightlies failed; 2026-07-09 through 07-21 was **13 consecutive red nights**. Filed as **`rf2-6sg25` (P2)**.

## Why option (1), and what it costs

The defect is real and it has bitten. `routes-epochs` and `machine-epochs` were both added non-smoke on 2026-05-31, both merged broken, and both stayed red until Mike fixed them on 2026-06-10 in `9bc9e6c9a2` — **10 days**. Two of the three reds in that commit were exactly this shape.

But the residual exposure today is small and the remedy is misaimed:

- **Frequency: ~3 non-smoke scenario additions per 10 weeks** — one every three-and-a-half weeks.
- **Blast radius is test code, not product.** A broken new scenario delays its own coverage; it cannot ship a user-facing regression. The real harm is that it reds the nightly, and *a red nightly is a fail-open instrument for the other 16 scenarios* — which is `rf2-7jevo`/`rf2-6sg25`, not this bead.
- **The existing mechanism already works when it matters.** The two highest-value scenarios added recently (`freehand-views` rf2-6pohj, `panel-gallery` rf2-azfct) were tagged `smoke: true` by their authors precisely because the arm earned a PR slot. The policy is being used correctly.
- **The escape hatch exists and is cheap.** `scripts/test-rigorous-local.sh` already runs the full gate; a warm local full sweep is ~170s.

Paying +70s to +302s on 53 firings a year to catch 3 events that a healthy nightly catches within 24h is a bad trade — *provided the nightly is healthy*. It isn't, and that is where the effort belongs. **Fix `rf2-7jevo`, wire `rf2-6sg25`, then take option (1).** If Mike wants belt-and-braces afterwards, build **(2)**, not (3).

I would not build a scenario-selection framework for this.

## What this PR actually changes

`tools/xray/spec/017-Test-Coverage-Matrix.md` names one owning command — "Xray browser feature gate" — for every `covered` row, and never says that command runs in two tiers. The word "nightly" appeared once, incidentally, at line 248. So the coverage contract reads as if every row were guarded at PR time when most are proved once a day. One preamble paragraph now states the split, the current 5/4-vs-17/12 numbers, and the local escape hatch. No row status changes; the policy is unchanged.

## Quality gates

Run from the worker worktree, foreground to completion, no piping through `tail`/`head`/`grep`.

| Gate | Exit | Wall | Terminal marker |
|---|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | 159s | `PASS fast PR spine` (classified `docs=true jvm=false node=false`) |
| `python scripts/check_fast_pr_gap.py --list` | **0** | — | `87 required checks unrun locally`; gap map derives correctly, spine invocations left one-per-line |
| `cd tools/xray && clojure -M:test` | **0** | 26s | `Ran 1271 tests containing 5909 assertions. 0 failures, 0 errors.` |
| `npm run test:xray-feature-gate:smoke` | **0** | 103s | `Ran 5 Xray feature scenarios (PR-smoke tier). 0 failures. Covered 10 matrix rows.` |

The spine classified this diff `jvm=false`, but `017-Test-Coverage-Matrix.md` is parsed by `coverage_matrix_metadata_test.clj`, so the `jvm-tools-xray` lane was run directly rather than trusted to the classifier. The new prose sits above the `## Coverage matrix` heading and outside the `| Surface |` block, so the row parse and the canonical covered-row count pin (13) are untouched.

Measured cost of anything added to a tier: **none — this PR adds nothing to any tier.**

`tools/xray/spec/*` — updated: this PR *is* the spec change (`017-Test-Coverage-Matrix.md`). No runtime or testbed code changed, so no other spec needed reconciling.

## Beads

Filed, none closed: **`rf2-7jevo`** (P1, the nightly flake — blocks the ruling), **`rf2-6sg25`** (P2, no nightly alerting), **`rf2-ano54`** (P3, stale costings in two fenced comments). `rf2-rliq7` stays open pending Mike's call.

Fences respected: only `tools/xray/**` written. `rf2-6sg25` and `rf2-ano54` both need `.github/workflows/**` and `implementation/**` — flagged for sequencing, not touched.
