### PR TITLE
fix(xray): openXray settles auto-open before touching the toggle chord (rf2-7jevo)

### DIFF
--- a/tools/xray/testbeds/feature_matrix/scenarios.cjs
+++ b/tools/xray/testbeds/feature_matrix/scenarios.cjs
@@ -180,11 +180,62 @@ const STAGED_SURFACES = [
   },
 ];
 
+// How long `openXray` waits for the preload's auto-open to reach a
+// terminal state before it touches the toggle chord — see the race note
+// in `openXray` (rf2-7jevo). This is `mount/auto-open-inline!`'s OWN
+// retry budget (120 attempts × 50ms), not a guess: after it elapses the
+// tick has either mounted the shell or reported `:no-substrate-adapter`
+// and stopped for good, so at that point auto-open provably cannot fire
+// again. Any smaller number would only make the race rarer.
+const AUTO_OPEN_SETTLE_MS = 120 * 50;
+
+// Ensure the Xray shell is OPEN, leaving it open for the caller.
+//
+// ## Why this settles before pressing the chord (rf2-7jevo)
+//
+// `Ctrl+Shift+C` is a TOGGLE (`mount/toggle!`), and Xray's preload runs
+// a second, concurrent opener: `mount/auto-open-inline!` polls every
+// 50ms until the host's `rf/init!` has installed the substrate adapter,
+// then calls `open!`. Sampling the shell once and pressing the chord on
+// a miss races that tick — when auto-open lands in the gap between the
+// sample and the keydown, the chord arrives at an ALREADY-OPEN shell
+// and `toggle!` takes its `close!` branch. `close!` hides the container
+// and leaves the React tree mounted, so the wait below then burns its
+// whole budget on a shell this helper hid itself.
+//
+// That is not a hypothesis. The 2026-07-31 nightly (run 30645068521)
+// failed here with `15 × locator resolved to hidden <div ...
+// data-testid="rf-xray-shell">` and diagnostics reading
+// `mounted=true visible=none` — the shell present, inline-mounted by
+// auto-open, and hidden for the full 5000ms. A longer timeout could
+// never have gone green: nothing was ever going to un-hide it.
+//
+// The fix is one ordering guarantee, not a longer wait. Presence is the
+// right thing to settle on because `mount-state` is a monotone latch:
+// once the shell is mounted, auto-open's tick short-circuits on
+// `@mount-state` forever, so after this wait nothing but us can move
+// the shell. Presence is NOT a proxy for open, though — `close!` keeps
+// the node — so the decision below reads VISIBILITY, the same condition
+// the assertion uses. (Pre-fix those two disagreed: a mounted-but-
+// hidden shell read as "already open", skipped the chord, and then
+// failed the visible-wait with no way to recover.)
 async function openXray(page) {
-  if ((await page.locator('[data-testid="rf-xray-shell"]').count()) === 0) {
+  const shell = page.locator('[data-testid="rf-xray-shell"]');
+
+  try {
+    await shell.waitFor({ state: 'attached', timeout: AUTO_OPEN_SETTLE_MS });
+  } catch (_) {
+    // Auto-open never landed — it is disabled on this surface, or no
+    // substrate adapter ever appeared. Not an error here: the chord
+    // below is then the genuine open path, and the assertion that the
+    // shell really did open is the `expectVisible` at the end, which
+    // still has to hold.
+  }
+
+  if (!(await shell.isVisible())) {
     await page.keyboard.press('Control+Shift+C');
   }
-  await expectVisible(page.locator('[data-testid="rf-xray-shell"]'), 5000);
+  await expectVisible(shell, 5000);
 }
 
 // The L3 tab bar's tabs expose `data-testid="rf-xray-tab-<id>"` for the


### PR DESCRIPTION
## What was wrong

The nightly Xray feature-matrix gate's `static mode chrome and chord` scenario failed **4 of the last 14 nights**, always with `FAIL static mode chrome and chord: locator.waitFor: Timeout 5000ms exceeded`.

It is not a short timeout, and it is not CI slowness. The 2026-07-31 nightly (run `30645068521`) captured the whole mechanism:

```
at expectVisible (examples/scripts/spec-helpers.cjs:55:17)
at openXray (tools/xray/testbeds/feature_matrix/scenarios.cjs:191:9)
at async Object.runStaticModeChromeAndChord (.../scenarios.cjs:2327:3)

  - waiting for locator('[data-testid="rf-xray-shell"]') to be visible
    15 x locator resolved to hidden <div role="region" class="mode-dynamic"
         data-rf-xray-mode="inline" data-testid="rf-xray-shell" ...>

xray state:
  mounted=true visible=none
  epochCount=1
```

The shell was **present and hidden** for the entire 5000ms — inline-mounted by the preload's auto-open (`data-rf-xray-mode="inline"`), with **zero `pageerror`s**. Playwright resolved the same hidden element 15 times running. `openXray` had hidden it itself.

## Mechanism

`Ctrl+Shift+C` is a **toggle** (`mount/toggle!`), and Xray's preload runs a second, concurrent opener: `mount/auto-open-inline!` polls every 50ms until the host's `rf/init!` has installed the substrate adapter, then calls `open!`.

`openXray` sampled the shell's presence **once** and pressed the chord on a miss:

```js
if ((await page.locator('[data-testid="rf-xray-shell"]').count()) === 0) {
  await page.keyboard.press('Control+Shift+C');
}
await expectVisible(page.locator('[data-testid="rf-xray-shell"]'), 5000);
```

When auto-open landed in the gap between that sample and the keydown, the chord arrived at an **already-open** shell, `toggle!` took its `close!` branch, and `close!` hid the container while leaving the React tree mounted. The visible-wait then had nothing left that could ever satisfy it.

Two defects, one line apart:

1. **The decision races a concurrent actor.** Classic TOCTOU against a 50ms tick.
2. **It reads the wrong condition.** `count()` asks "is it in the DOM", but `close!` keeps the node — presence never meant *open*. The failure state (`mounted=true visible=none`) is itself a state the old code would misread as "already open", skip the chord for, and then fail the visible-wait on.

**Raising the 5000ms could never have gone green** — nothing was going to un-hide that shell. That is the fail-open-in-a-new-suit fix this change deliberately avoids.

## Reproduced under control

The mechanism is not inferred from the log alone. A scratchpad A/B (repo untouched) serves the staged gate root and forces the exact interleaving deterministically, by widening the window a loaded runner widens by accident: take the presence sample early (at `domcontentloaded`, before auto-open's tick), sleep so auto-open lands inside the gap, then run each variant's decision logic.

```
OLD #1   sample=1  -> PASS  final(mounted=true,display=block)
OLD #2   sample=0  -> FAIL  locator.waitFor: Timeout 5000ms exceeded.
                            resolvedToHidden=true  final(mounted=true,display=none)
OLD #3   sample=0  -> FAIL  ... resolvedToHidden=true  final(mounted=true,display=none)
NEW #1-3 sample=0  -> PASS  final(mounted=true,display=block)

Across 11 trials:  OLD failures 6/11   NEW failures 0/11
```

Two things to note. The reproduced failure is byte-identical to CI — same message, same `resolved to hidden`, same terminal `mounted=true / display=none`. And the correlation is **perfect**: every OLD failure had `sample=0`, every OLD pass had `sample=1`. The stale sample fully determines the outcome; nothing else varies. NEW passed all 11, including the 10 trials on the interleaving that kills OLD.

### Ruled out, with evidence

| Candidate | Verdict |
| --- | --- |
| Timeout too short / CI-runner slowness | **No.** The element was present and hidden for all 15 poll attempts — not slow to arrive, and never going to flip. |
| Race with the chord handler's registration | **No.** `keybinding/attach!` runs synchronously at preload, *before* `auto-open-inline!`. The keydown was plainly received — receiving it is what hid the shell. |
| Selector matching something transiently present | **No.** The selector matched exactly one stable element for the full 5s. |
| Real ordering bug in the product | **No.** Zero `pageerror`s, `epochCount=1`, clean boot. This is the test helper, not Xray. |
| The historic real failure (`rf2-wxu4l3`, `:rf.error/no-frame-context`, fixed in `9bc9e6c9a2`) | **No.** That one crashed the surface and surfaced as an uncaught error; here the diagnostics carry only two benign React-DevTools infos and two `missing-doc` warnings. |

### Why only this scenario, out of ~14 that call `openXray`

It is the **sole navigate/reload site in the file** (line 2165 — the only `navigate(page, ...)` call in 3991 lines). On the harness's cold `page.goto` the adapter is installed long before `load` resolves, so auto-open has always already won by the time `openXray` peeks. On a warm reload the JS is cache- and code-cache-warm, the two converge, and the race opens.

The nightly record bears the split out: ~180 cold-path `openXray` calls across 14 nights, zero failures; 14 warm-path calls, four failures.

## The fix

One ordering guarantee, not a longer wait.

- **Settle on presence first.** `mount-state` is a monotone latch — once the shell is mounted, auto-open's tick short-circuits on `@mount-state` forever, so after this wait nothing but the helper can move the shell.
- **Then decide on visibility**, the same condition the assertion uses. Decision predicate and assertion predicate now agree.
- **Settle budget = auto-open's own retry bound** (`120 x 50ms`), the point at which it has provably stopped and reported `:no-substrate-adapter`. Not a guess, and it makes the fallback path safe too. On every healthy surface it resolves in tens of milliseconds — all staged gate surfaces have auto-open enabled (the two `:rf.xray/auto-open? false` hosts are Story pages, not staged here).

No duration was raised. The `5000` on the assertion is untouched.

## What did not change

- **No assertion weakened.** Every existing assertion is byte-identical; the chord still fires, still at most once.
- **No `--retry`, no retry loop.** The chord press is not repeated.
- **`implementation/` still requires nothing from `tools/`.** No import graph change.
- **No `*.spec.cjs` under `examples/`.**
- Diff is 53 insertions / 2 deletions in one file, all inside the `tools/xray/**` fence.

## On the two weeks

The gate's diagnostics were **already good enough** to diagnose this from the first failure — `mounted=true visible=none` plus `15 x locator resolved to hidden` is the complete answer, and it was sitting in the log on 2026-07-22. No instrumentation was missing, so none was added. What was missing was anyone being told: `expensive-tests.yml` has no failure alerting (`rf2-6sg25`, dispatched separately). That is the whole reason this survived two weeks, and it is worth recording that the fix for "a flake that reports nothing" was, here, not more reporting.

## Spec

`tools/xray/spec/*` **unchanged, because** this touches no Xray contract or covered behaviour — only a Playwright helper's ordering. Spec 017's `Static mode mount + chord` row describes what the scenario asserts (mode dropdown, `Ctrl+Shift+M` flip, Static silhouette, dropdown restore, localStorage round-trip); every one of those assertions is unchanged, and the row's `Xray browser feature gate (runStaticModeChromeAndChord ...)` evidence pointer stays accurate.

## Quality gates

All foreground to completion, on `worker/xrayflake-7jevo`. Terminal marker read from each runner, not from the shell's compound exit.

| Gate | Marker | Exit |
| --- | --- | --- |
| `sh scripts/test-fast-pr.sh` | `PASS fast PR spine` | `0` |
| `cd tools/xray && clojure -M:test` | `Ran 1271 tests containing 5909 assertions. 0 failures, 0 errors.` | `0` |
| `npm run test:xray-feature-gate:smoke` | `Ran 5 Xray feature scenarios (PR-smoke tier). 0 failures. Covered 10 matrix rows.` | `0` |
| `npx eslint tools/xray/testbeds/feature_matrix/scenarios.cjs` | clean | `0` |

**Full sweep, run five times** (the flake's own gate) — `npm run test:xray-feature-gate`:

| Run | Marker | Exit |
| --- | --- | --- |
| 1 (cold compile) | `Ran 17 Xray feature scenarios (nightly-full sweep). 0 failures. Covered 14 matrix rows.` | `0` |
| 2 | same | `0` |
| 3 | same | `0` |
| 4 | same | `0` |
| 5 | same | `0` |

**85 scenario executions across 5 full sweeps, 0 failures.**

Stated plainly: five green local sweeps are *weak* evidence on their own — the bead records a green local full sweep on 2026-08-05 while the flake was live, because the race needs a loaded runner to open. The load-bearing evidence is the controlled A/B above (OLD 6/11 fail with the exact CI signature, NEW 0/11), plus the mechanism being visible in the source. The five sweeps establish only that the fix regresses nothing.

Pre-existing, unrelated: every gate run ends `http-server exited unexpectedly (code=1, signal=null)` during harness teardown, after the verdict line and without affecting the exit code. Present on `main` too; not introduced here.
