### PR TITLE
perf(ci): the shared checker walk, measured — three pruned, six left alone (rf2-76c76)

### DIFF
--- a/scripts/check_keyword_catalogue_drift.py
+++ b/scripts/check_keyword_catalogue_drift.py
@@ -148,6 +148,7 @@ Python stdlib only.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from pathlib import Path
@@ -533,10 +534,33 @@ def reserved_namespaces(conventions_text: str) -> set[str]:
 
 
 def iter_impl_src(impl_root: Path) -> Iterable[Path]:
-    for path in sorted(impl_root.rglob("*")):
-        if path.suffix not in _SOURCE_SUFFIXES:
-            continue
-        parts = set(path.relative_to(impl_root).parts)
+    """Yield framework source files under `impl_root`.
+
+    PRUNED, not filtered-after (rf2-76c76; method proven by rf2-e1xx0 in
+    `check_retired_image_keys.py`). `_EXCLUDE_DIR_NAMES` is dropped from
+    `os.walk`'s dirnames IN PLACE, so a built checkout never descends into
+    `implementation/.shadow-cljs` (34.8k entries), `out` (9.7k) or
+    `node_modules` (3.4k). `rglob("*")` enumerated all 51.6k entries under
+    `implementation/` and discarded them one at a time: 4.2s of this gate's
+    3.8s-4.0s wall clock on a built tree.
+
+    The surviving sequence is IDENTICAL, set and order: pruning drops only
+    what the `_EXCLUDE_DIR_NAMES` test below already dropped, and the
+    collected matches go through ONE GLOBAL `sorted()`, reproducing
+    `sorted(rglob("*"))`'s whole-subtree ordering rather than os.walk's
+    directory-grouped order.
+    """
+    scan_prefix_len = len(impl_root.as_posix()) + 1
+    matches: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(impl_root):
+        dirnames[:] = [d for d in dirnames if d not in _EXCLUDE_DIR_NAMES]
+        for name in filenames:
+            if os.path.splitext(name)[1] in _SOURCE_SUFFIXES:
+                matches.append(Path(dirpath) / name)
+    for path in sorted(matches):
+        # Kept as the belt to the pruning's braces, and now on string ops:
+        # `Path.relative_to` was pure pathlib object churn for a prefix strip.
+        parts = set(path.as_posix()[scan_prefix_len:].split("/"))
         if parts & _EXCLUDE_DIR_NAMES:
             continue
         if parts & _TEST_DIR_NAMES:

--- a/scripts/check_retired_spellings.py
+++ b/scripts/check_retired_spellings.py
@@ -140,6 +140,7 @@ Dependency-light — Python stdlib only.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from pathlib import Path
@@ -379,16 +380,43 @@ def _iter_source_files(scan_root: Path, include_tests: bool) -> Iterable[Path]:
 
     Excludes generated/vendor dirs always, and `test`/`tests` dirs unless
     `include_tests` is set.
+
+    PRUNED, not filtered-after (rf2-76c76; method proven by rf2-e1xx0 in
+    `check_retired_image_keys.py`). `_EXCLUDE_DIR_NAMES` is dropped from
+    `os.walk`'s dirnames IN PLACE, so a built checkout never descends into
+    `implementation/.shadow-cljs` (34.8k entries), `node_modules` (3.4k) or
+    `target`. `rglob("*")` enumerated all 51.6k entries under
+    `implementation/` and discarded them one at a time — 4.9s of this gate's
+    8.1s wall clock on a built tree.
+
+    The surviving sequence is IDENTICAL, set and order:
+      * pruning drops only what the `_EXCLUDE_DIR_NAMES` test below already
+        dropped — nothing under an excluded directory could survive either
+        path, so the sets match;
+      * the collected matches go through ONE GLOBAL `sorted()`, reproducing
+        `sorted(rglob("*"))`'s whole-subtree ordering rather than os.walk's
+        directory-grouped order.
+
+    Note `_EXCLUDE_DIR_NAMES` here deliberately does NOT carry `out` (unlike
+    the sibling gates) — adding it would narrow this gate's scope, which is a
+    scope decision and not this change's business.
     """
     if scan_root.is_file():
         # Direct-file mode (used by --self-test fixtures pointing at one file).
         if scan_root.suffix in _SOURCE_SUFFIXES:
             yield scan_root
         return
-    for path in sorted(scan_root.rglob("*")):
-        if path.suffix not in _SOURCE_SUFFIXES:
-            continue
-        parts = set(path.relative_to(scan_root).parts)
+    scan_prefix_len = len(scan_root.as_posix()) + 1
+    matches: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(scan_root):
+        dirnames[:] = [d for d in dirnames if d not in _EXCLUDE_DIR_NAMES]
+        for name in filenames:
+            if os.path.splitext(name)[1] in _SOURCE_SUFFIXES:
+                matches.append(Path(dirpath) / name)
+    for path in sorted(matches):
+        # Kept as the belt to the pruning's braces, and now on string ops:
+        # `Path.relative_to` was pure pathlib object churn for a prefix strip.
+        parts = set(path.as_posix()[scan_prefix_len:].split("/"))
         if parts & _EXCLUDE_DIR_NAMES:
             continue
         if not include_tests and (parts & _TEST_DIR_NAMES):

--- a/scripts/check_thrown_error_messages.py
+++ b/scripts/check_thrown_error_messages.py
@@ -130,6 +130,7 @@ Dependency-light — Python stdlib only.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from pathlib import Path
@@ -925,15 +926,36 @@ def _iter_source_files(scan_root: Path, include_tests: bool) -> Iterable[Path]:
     (`scan(<one .cljc fixture>)`). It is deliberately NOT reachable from the
     CLI: `main` requires every `--scan-dir` to be a directory (rf2-un9fk), so
     a file passed there is rejected with rc=2 rather than quietly scanning
-    one file — or, before that fix, zero."""
+    one file — or, before that fix, zero.
+
+    PRUNED, not filtered-after (rf2-76c76; method proven by rf2-e1xx0 in
+    `check_retired_image_keys.py`). `_EXCLUDE_DIR_NAMES` is dropped from
+    `os.walk`'s dirnames IN PLACE, so a built checkout never descends into
+    `implementation/.shadow-cljs` (34.8k entries), `out` (9.7k) or
+    `node_modules` (3.4k). `rglob("*")` enumerated all 51.6k entries under
+    `implementation/` — the whole scan root — and discarded them one at a
+    time: 3.2s of this gate's 3.4s wall clock on a built tree.
+
+    The surviving sequence is IDENTICAL, set and order: pruning drops only
+    what the `_EXCLUDE_DIR_NAMES` test below already dropped, and the
+    collected matches go through ONE GLOBAL `sorted()`, reproducing
+    `sorted(rglob("*"))`'s whole-subtree ordering rather than os.walk's
+    directory-grouped order."""
     if scan_root.is_file():
         if scan_root.suffix in _SOURCE_SUFFIXES:
             yield scan_root
         return
-    for path in sorted(scan_root.rglob("*")):
-        if path.suffix not in _SOURCE_SUFFIXES:
-            continue
-        parts = set(path.relative_to(scan_root).parts)
+    scan_prefix_len = len(scan_root.as_posix()) + 1
+    matches: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(scan_root):
+        dirnames[:] = [d for d in dirnames if d not in _EXCLUDE_DIR_NAMES]
+        for name in filenames:
+            if os.path.splitext(name)[1] in _SOURCE_SUFFIXES:
+                matches.append(Path(dirpath) / name)
+    for path in sorted(matches):
+        # Kept as the belt to the pruning's braces, and now on string ops:
+        # `Path.relative_to` was pure pathlib object churn for a prefix strip.
+        parts = set(path.as_posix()[scan_prefix_len:].split("/"))
         if parts & _EXCLUDE_DIR_NAMES:
             continue
         if not include_tests and (parts & _TEST_DIR_NAMES):


### PR DESCRIPTION
Nine required checkers share `sorted(scan_root.rglob("*"))` + `path.relative_to(...)` per entry. rf2-76c76 asked for the measurement and priced the remaining prize at "roughly one second", expecting "not worth it".

**The measurement splits the answer.** It is ~0.7s in CI — not worth it, exactly as the bead predicted. It is **8.6s on the mayor checkout**, because CI and the local lane are not the same tree.

## The measurement

Cost is dominated by how much *build output* a checkout has accumulated, not by `node_modules` as the bead assumed. Entries under `implementation/`:

| checkout | total entries | `.shadow-cljs` | `out` | `node_modules` | source kept |
|---|---:|---:|---:|---:|---:|
| clean checkout (**what CI runs**) | 2,365 | – | – | – | 2,365 |
| freshly built worker worktree | 13,839 | 7,192 | 868 | 3,410 | 2,365 |
| long-lived mayor checkout | 52,236 | 35,423 | 9,799 | 3,410 | 2,387 |

`rglob("*")` enumerates every one of those and discards the rest one at a time.

**In CI none of this applies.** All nine run in bare-checkout Python jobs (`test.yml` job `verify-skill-mcp-drift`; `freehand-conformance.yml`) — no `npm ci`, no build. That is the single most important fact in this measurement: CI's tree is the 2,365-entry column.

### Per-checker, live arm, median of 5, foreground

Measured as a real subprocess so interpreter startup is included as CI pays it. `--repo-root` pointed at each tree; python 3.14.0, Windows.

| checker | clean (CI shape) | built mayor | walk cost, mayor |
|---|---:|---:|---:|
| `check_ambient_durable_reads` (scans repo root) | 0.63s | **8.37s** | 7.00s |
| `check_retired_spellings` | 3.55s | **8.07s** | 4.77s |
| `check_keyword_catalogue_drift` | 1.39s | **3.76s** | 4.15s |
| `check_thrown_error_messages` | 1.17s | **3.44s** | 3.17s |
| `check_retired_composition_vocab` | 1.46s | 1.64s | 0.02s |
| `check_retired_image_keys` (done, rf2-e1xx0) | 1.06s | 1.25s | 0.02s |
| `check_inject_cofx_residue` | 0.42s | 0.39s | 0.02s |
| `check_failure_corpus_residue` | 0.15s | 0.15s | 0.00s |
| `check_freehand_conformance_index` (not in spine) | 6.71s | 10.51s | 0.01s |

**What a shared walk would actually save**, isolating the enumeration alone (`sorted(rglob) + relative_to` vs pruning `os.walk`, both with one global sort):

* clean checkout / **CI: 0.85s → 0.46s. A 0.38s prize across all nine.**
* built mayor checkout: **19.76s → 0.62s.**

Four checkers carry 19.08s of that 19.15s. **The other five save 0.07s between them** — they scan `docs/`, `spec/`, `skills/`, `testbeds/`, trees with no build output in them at all.

### Two corrections to the bead

1. **`check_retired_composition_vocab` is not "the most expensive python checker in the spine".** It is 1.46s; `check_retired_spellings` is 3.55s on the same clean tree and 8.07s built. Composition-vocab's walk is 0.02s — its cost is regex, not enumeration, so a shared walk does nothing for it.
2. **The culprit is `.shadow-cljs` (35.4k entries), not `node_modules` (3.4k).** The win therefore depends on having *built*, not merely having run `npm ci`.

## What changed, and what deliberately did not

Three checkers, each edited independently in place — **no shared abstraction**, per the bead's explicit instruction. Each already had an `_EXCLUDE_DIR_NAMES` roster, so pruning drops exactly what the post-filter dropped:

| checker | before | after |
|---|---:|---:|
| `check_retired_spellings` | 6.43s | **3.63s** (1.8x) |
| `check_keyword_catalogue_drift` | 4.76s | **1.46s** (3.3x) |
| `check_thrown_error_messages` | 3.81s | **1.29s** (3.0x) |
| **total (mayor checkout)** | **15.00s** | **6.38s — 8.62s saved** |

On a freshly built worktree the same three go 7.46s → 4.74s; on a clean checkout 6.55s → 5.88s. The saving scales with accumulated build cache.

`sorted()` is applied **once, globally, after collection** — os.walk's directory-grouped order is *not* `sorted(rglob("*"))`'s whole-subtree order, so the global sort is load-bearing.

**`check_ambient_durable_reads` was reverted, and it is the biggest single win (7.0s).** It has no `_EXCLUDE_DIR_NAMES` at all — it excludes build trees only incidentally, via the `DURABLE_WRITE_SUFFIXES` allow-list matched with `endswith`. Adding a prune therefore **narrows** it: a copy of a durable-write source file nested inside `out/` or `.shadow-cljs/` is scanned today and would not be. On the real built tree that drops **0 of 18** files — but it is a scope change to a required invariant gate, not a perf change, and it needs a ruling rather than a worker's judgement. Filed as **rf2-mjfj9** with the evidence and both branches of the ruling.

The five cheap checkers are untouched. Changing a required gate to save 20ms is the over-engineering this project rejects at triage.

**No caching was added.** Nothing was tidied into a loop — `test-fast-pr.sh` is not touched at all, so `check_fast_pr_gap.py`'s one-invocation-per-line derivation is intact (verified below: 75 required jobs, unchanged).

## Equivalence — finding sets, not exit codes

Per rf2-e1xx0's method, and because a faster checker that matches less is worse than a slow one.

**1. Path sequences, element by element.** Each checker's real iteration function against the built mayor tree, every scan root, both `include_tests` settings — **identical in set AND order**, 19 comparisons: `implementation` 415/1896, `examples` 88, `tools` 469/1007, `skills` 3/23, `testbeds` 13, `migration` 1/2, `docs/tools` 1, keyword-drift 384.

**2. Full `--verbose` stdout, old vs new, byte-identical** — origin/main versions extracted with `git show` and run side by side:

* the real built tree (rc=0 both);
* a **synthetic corpus**: the whole tracked tree (4,993 files) plus **495 planted known-violating fixtures** — 99 in live locations and **396 inside every excluded directory** (`node_modules`, `target`, `out`, `.shadow-cljs`, `.beads`, `.cpcache`) at several depths. Both sides rc=1, with **135 / 120 / 83 lines of findings**. Identical.

**3. The harness is not vacuous.** Adding one directory (`out`) to a prune roster without adding it to the post-filter — a one-word silent narrowing — drops 53 files and 18 findings, and the comparison catches it. The same harness independently caught the `check_ambient_durable_reads` divergence above, which is why that one was reverted rather than shipped.

## Self-test audit of all nine — the more valuable finding

The brief asked whether any of the nine repeats `check_retired_image_keys`' hole, where `>= 1 finding` could not say *which* detector fired. **The good news: none does.** Every self-test asserts exact equality (`got == expected`), not `>= 1`.

**The bad news is the same principle failing one level down** — exact counts over *aggregated* fixtures, and rosters whose entries have no fixture at all. Four are PARTIAL; each is filed separately:

| checker | hole | bead |
|---|---|---|
| `check_ambient_durable_reads` | **19 of 26** `_ALL_DURABLE_KEYS` and **12 of 16** `_AMBIENT_READ_ALT` never shown to fire | rf2-g1xpb |
| `check_thrown_error_messages` | **17 witnesses** aggregated under two counts; 10/16 binder heads, 13/19 transparent heads unproven | rf2-n6ijg |
| `check_retired_composition_vocab` | 4 of 9 `_STRONG_SYMBOLS` have no fixture; two stale `>= 1` docstrings | rf2-57vnc |
| `check_freehand_conformance_index` | **26** positive cases proven by count alone — the check arm hard-codes `kind=None` while the census arm beside it does it right | rf2-m147k |

Each carries the exact line numbers (pinned to `f89b8b5037`) and the worked fix: `check_retired_image_keys`' repaired self-test already contains the missing assertion — `missing = _ADVERTISED_KINDS - covered` at :734, which makes a roster entry without a fixture a hard failure.

`check_retired_image_keys`, `check_keyword_catalogue_drift`, `check_retired_spellings`, `check_inject_cofx_residue` are SOUND; `check_failure_corpus_residue` is single-detector.

## Quality gates

Foreground to completion; exit codes read from the runner's own marker file, never from a pipe.

| gate | exit | note |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | full spine, 1155 lines, `node_modules` present |
| `sh scripts/test-fast-pr.sh` (first run) | 1 | **environment only** — fresh worktree had no `node_modules`; sole failure `CLJS node integration`, `Cannot find module 'shadow-cljs/cli/runner.js'`. Green after junctioning. Diff is three Python files. |
| `python scripts/check_fast_pr_gap.py --self-test` | **0** | `all self-tests passed.` |
| `python scripts/check_fast_pr_gap.py --check` | **0** | 75 required jobs, 26 covered — derivation intact |
| `python scripts/check_fast_pr_gap.py --list` | **0** | one-invocation-per-line shape unchanged |

All nine checkers, both arms, in this worktree — `--self-test` and live `--verbose` each exit **0**: `check_ambient_durable_reads`, `check_retired_composition_vocab`, `check_failure_corpus_residue`, `check_retired_image_keys`, `check_freehand_conformance_index`, `check_retired_spellings`, `check_inject_cofx_residue`, `check_thrown_error_messages`, `check_keyword_catalogue_drift`.

The `node_modules` junction created for the spine re-run was removed with `rmdir` and the mayor checkout's `node_modules` re-counted: **103 entries before and after**.
