### PR TITLE
fix(template): the SSR scaffold's :root-view resolves, so it keeps a render hash (rf2-qfct9)

### DIFF
--- a/tools/template/resources/day8/re_frame2_template/_reagent/core_with_ssr.cljc
+++ b/tools/template/resources/day8/re_frame2_template/_reagent/core_with_ssr.cljc
@@ -102,13 +102,28 @@
   must resolve AFTER the view is registered — a top-level `def` would
   capture the lookup at namespace-load time.
 
-  Note the head is the looked-up FN, not the keyword `:app/root`. A
-  keyword head in a render tree is an HTML element on every host, never a
-  view (Conventions §Render-tree shape vs runtime lookup): `[:app/root]`
-  would paint an empty `<root>` element. Views are referenced by the Var
-  `reg-view` defs, or by `(rf/view :id)` as here."
+  NOTE THE OUTER CALL: this INVOKES the view, returning the DOM-rooted
+  tree, where the tempting `[(rf/view :app/root)]` would return a
+  *reference* to it. Both spellings emit byte-identical HTML, and only
+  this one is hashable. `render-tree-hash` is a pure structural walk that
+  never expands a callable head, and every fn canonicalises to the same
+  identity-free `#fn[]` token, so a callable-headed root hashes to one
+  constant for every application on earth — ssr-ring therefore omits the
+  render hash entirely for that shape (rf2-q1b96), and the page ships with
+  no hydration tripwire. The outer call is also what makes this symmetric
+  with the client's `:render-tree-fn` below, which calls the view the same
+  way: the two ends must hash the SAME tree or every page reports a
+  hydration mismatch.
+
+  The React mount tree further down keeps the `[(rf/view :app/root)]`
+  reference form — that one is a component boundary React owns, not a tree
+  anyone hashes.
+
+  A keyword head would be worse still: it is an HTML element on every host,
+  never a view (Conventions §Render-tree shape vs runtime lookup), so
+  `[:app/root]` paints an empty `<root>` element."
   []
-  [(rf/view :app/root)])
+  ((rf/view :app/root)))
 
 ;; ============================================================================
 ;; CLIENT ENTRY POINT

--- a/tools/template/resources/day8/re_frame2_template/_shared/ssr_test.clj
+++ b/tools/template/resources/day8/re_frame2_template/_shared/ssr_test.clj
@@ -72,7 +72,17 @@
               "render-tree-hash is an 8-char lowercase-hex FNV-1a digest")
           (is (string/includes? html "data-rf-render-hash")
               "the root element carries the render-hash tripwire for the
-               client-side hydration-mismatch check"))))))
+               client-side hydration-mismatch check")
+          ;; The pairing this tripwire depends on. `render-tree-hash` never
+          ;; expands a callable head, so the reference form
+          ;; `[(rf/view :app/root)]` hashes one constant for every app on
+          ;; earth — ssr-ring omits the hash entirely for it (rf2-q1b96).
+          ;; `root-view` must therefore resolve to the same DOM-rooted tree
+          ;; the client's `:render-tree-fn` hashes, or the two ends compare
+          ;; different trees and every page reports a mismatch.
+          (is (= render-hash (rf/render-tree-hash (app/root-view)))
+              "the server's :root-view hashes the SAME tree the client's
+               :render-tree-fn does — note the outer call in both"))))))
 
 (deftest ssr-handler-renders-through-the-real-production-path
   (testing "server.clj's OWN make-handler (the composite Ring handler


### PR DESCRIPTION
`JVM tools/template (clojure -M:test)` was failing on unrelated branches, on three
rows that assert `data-rf-render-hash` is present in the emitted SSR scaffold's
markup.

## Which outcome this is

**The template's root IS in the hiccup tier and should still carry a hash — and
the template was spelling `:root-view` the one way that cannot have one.**
`rf2-q1b96` did **not** over-remove; nothing in `implementation/ssr-ring/**` is
touched here.

Spec 011 tiers by render-tree representation. The hash channel is the HICCUP
tier's, and this template is a Reagent host, so the channel is exactly its. But
the scaffold's two ends declared the root differently:

```clojure
;; server — core_with_ssr.cljc
(defn root-view [] [(rf/view :app/root)])            ;; a REFERENCE to the tree

;; client — ssr/hydrate! :render-tree-fn
(fn [] (rf/with-frame app-frame ((rf/view :app/root))))   ;; the TREE
```

`render-tree-hash` is a pure structural walk that never expands a callable head,
and every fn canonicalises to the identity-free `#fn[]` token, so the server form
hashes a constant. **Measured in the emitted project:** the client tree hashes
`a2aa3d1d`; the server's unresolved root hashes `f1d63f7e` — the exact per-arity
constant `implementation/ssr-ring/test/re_frame/ssr/ring/render_hash_tier_test.clj`
pins for `[(rf/view :anything)]`.

So this scaffold was already broken in a worse way than the red tests suggest:
**before** rf2-q1b96 it shipped a hash that mismatched on **every** page; **after**
it, the hash is simply absent. `resolve-root-view`'s own docstring names the
repair — "a hiccup-tier host keeps the channel by handing over a root that
RESOLVES … `(fn [] ((rf/view :app/root)))`, which is also the only spelling
symmetric with the documented client `:render-tree-fn #((rf/view :app/root))`".
Hence the outer call. Both spellings emit byte-identical HTML.

This is also the **second, separable hazard** rf2-q1b96's description flagged
"VERIFY BEFORE FIXING", and which its close note recorded as unknown — "whether
the `:root-view [#'app/root]` vector reportedly making the server hash shallow
while the client hashes deep reproduced". **It reproduces, and `tools/template`
is the instance.** That unknown is now closed.

## What the tests assert

No assertion was deleted or weakened. The three `data-rf-render-hash` rows stand
unchanged — with the fix they are true again, and they now also fail-closed
against a regression to the reference spelling (which produces no marker at all).

One row is **added**, pinning the rule rather than its symptom:

```clojure
(is (= render-hash (rf/render-tree-hash (app/root-view)))
    "the server's :root-view hashes the SAME tree the client's
     :render-tree-fn does — note the outer call in both")
```

The existing rows could only ever say "a hash is present". This one says the
**right** hash is present, which is the property that was silently false.

The React mount trees keep the `[(rf/view :app/root)]` reference form — those are
component boundaries React owns, not trees anyone hashes. The `root-view`
docstring now says which is which and why.

## Mutation proof

`root-view` reverted to `[(rf/view :app/root)]`, gate re-run:

```
FAIL in (ssr-render-produces-hydration-ready-html) (ssr_test.clj:83)
expected: (= render-hash (rf/render-tree-hash (app/root-view)))
  actual: (not (= "a2aa3d1d" "f1d63f7e"))
```

plus the three originally-reported failures reproduced verbatim
(`ssr-live-shell-loads-and-serves-the-css-scaffold`,
`ssr-handler-renders-through-the-real-production-path`, and the
`reagent-ssr…-emitted-tests-run-test` wrapper) — `Ran 4 tests containing 29
assertions. 3 failures, 0 errors.` Restored → 0 failures.

## Quality gates

| gate | exit | result |
|---|---|---|
| `cd tools/template && clojure -M:test` | `0` | 60 tests, 633 assertions, **0 failures, 0 errors** |
| `RF2_TEMPLATE_RUN_EMITTED_TESTS=1 … -v reagent-ssr-emitted-tests-run-test` | `0` | 1 test, 13 assertions, **0 failures, 0 errors** — includes the browser DOM-adoption proof (`server-painted #app node adopted (hydrate-root) and its handler went live (0 -> 1)`) |
| `RF2_TEMPLATE_RUN_EMITTED_TESTS=1 … -v reagent-ssr-tailwind-emitted-tests-run-test` | `0` | 1 test, 10 assertions, **0 failures, 0 errors** |
| `scripts/test-fast-pr.sh` | `0` | `PASS fast PR spine` |

The two emitted cells are run explicitly because the default `clojure -M:test`
lane skips them behind `RF2_TEMPLATE_RUN_EMITTED_TESTS`, and they are the rows CI
reported red. The spine classified docs / JVM-implementation / CLJS surfaces as
unchanged and skipped them, which is correct for a diff confined to
`tools/template/resources/**`; `jvm-tools-template` has no spine lane at all,
hence the explicit runs above.

Both changed files live under `tools/template/resources/`, which `lint.yml` and
`.clj-kondo/config.edn` exclude by design (they carry `{{mustache}}` placeholders
and are not readable Clojure).

Bead: **rf2-qfct9**.
