### PR TITLE
test(ci): four self-tests prove what they assert (rf2-g1xpb, rf2-n6ijg, rf2-m147k, rf2-57vnc)

### DIFF
--- a/scripts/_test_fixtures/check_ambient_durable_reads/positive/every_ambient_read_form.cljc
+++ b/scripts/_test_fixtures/check_ambient_durable_reads/positive/every_ambient_read_form.cljc
@@ -1,0 +1,41 @@
+(ns fixtures.every-ambient-read-form
+  "POSITIVE fixture: every EXERCISABLE entry in `_AMBIENT_READ_FORMS`, one per
+  line, each written into the same durable `:instance-id` key so the only thing
+  that varies down the file is the read form itself. Fourteen findings, and the
+  self-test asserts the read forms BY NAME (rf2-g1xpb).
+
+  Two of the sixteen roster entries are absent, and deliberately — see
+  `_UNEXERCISABLE_READ_FORMS`: `js/crypto.getRandomValues` and
+  `(.getRandomValues js/crypto …)` carry the very text the allowlist window
+  searches for, so any line matching them exempts itself. The self-test holds
+  that pair to being uncoverable rather than merely uncovered.
+
+  The host-fact entries are written as BARE symbol values because that is the
+  shape the roster describes: the gate matches a read sitting immediately in a
+  durable key's value position, so `js/localStorage` fires there while a call
+  WRAPPING it does not. Idiomatic these lines are not; the roster entry they
+  witness is exactly this spelling."
+  (:require [re-frame.interop :as interop]))
+
+(def ^:private id-pool ["a" "b" "c"])
+
+(defn derive-instance-id-from-every-ambient-read
+  [rows]
+  [;; clock
+   (assoc (nth rows 0)  :instance-id (interop/now-ms))
+   (assoc (nth rows 1)  :instance-id (js/Date.now))
+   (assoc (nth rows 2)  :instance-id (.now js/Date))
+   ;; random — `(rand …)` also matches the two longer spellings below, so those
+   ;; two lines each witness a PAIR of roster entries, not one.
+   (assoc (nth rows 3)  :instance-id (rand 1000))
+   (assoc (nth rows 4)  :instance-id (rand-int 1000))
+   (assoc (nth rows 5)  :instance-id (rand-nth id-pool))
+   (assoc (nth rows 6)  :instance-id (random-uuid))
+   ;; browser / host facts
+   (assoc (nth rows 7)  :instance-id js/location)
+   (assoc (nth rows 8)  :instance-id js/navigator)
+   (assoc (nth rows 9)  :instance-id navigator.language)
+   (assoc (nth rows 10) :instance-id js/localStorage)
+   (assoc (nth rows 11) :instance-id js/sessionStorage)
+   (assoc (nth rows 12) :instance-id (.matchMedia js/window "(min-width: 40em)"))
+   (assoc (nth rows 13) :instance-id js/matchMedia)])

--- a/scripts/_test_fixtures/check_ambient_durable_reads/positive/every_durable_id_key.cljc
+++ b/scripts/_test_fixtures/check_ambient_durable_reads/positive/every_durable_id_key.cljc
@@ -1,0 +1,20 @@
+(ns fixtures.every-durable-id-key
+  "POSITIVE fixture: every key in `_DURABLE_ID_KEYS`, one per line, each minted
+  from an ambient generator. Eight findings, and the self-test asserts the eight
+  KEYS by name.
+
+  EP-0010 §Randomness is the rule these witness: a durable id must arrive as a
+  supplied recordable coeffect, never from `(random-uuid)` at the write site.
+  The read form is held constant so the only thing that varies is the key.")
+
+(defn mint-every-durable-id
+  [row]
+  (assoc row
+         :id             (random-uuid)
+         :entry-id       (random-uuid)
+         :request-id     (random-uuid)
+         :instance-id    (random-uuid)
+         :mutation-id    (random-uuid)
+         :temp-id        (random-uuid)
+         :correlation-id (random-uuid)
+         :resource-id    (random-uuid)))

--- a/scripts/_test_fixtures/check_ambient_durable_reads/positive/every_durable_timestamp_key.cljc
+++ b/scripts/_test_fixtures/check_ambient_durable_reads/positive/every_durable_timestamp_key.cljc
@@ -1,0 +1,33 @@
+(ns fixtures.every-durable-timestamp-key
+  "POSITIVE fixture: every key in `_DURABLE_TIMESTAMP_KEYS`, one per line, each
+  taking an ambient clock read as its value. Eighteen findings, and the
+  self-test asserts the eighteen KEYS by name — a count alone cannot tell a
+  live key roster from one with a typo in it, which is how twelve of these went
+  unexercised (rf2-g1xpb).
+
+  The read form is held constant at `(interop/now-ms)` so the only thing that
+  varies down the file is the durable key. The read-form roster is proven the
+  other way round, in `every_ambient_read_form.cljc`."
+  (:require [re-frame.interop :as interop]))
+
+(defn stamp-every-durable-timestamp
+  [row]
+  (assoc row
+         :started-at     (interop/now-ms)
+         :deadline-at    (interop/now-ms)
+         :loaded-at      (interop/now-ms)
+         :stale-at       (interop/now-ms)
+         :invalidated-at (interop/now-ms)
+         :settled-at     (interop/now-ms)
+         :created-at     (interop/now-ms)
+         :completed-at   (interop/now-ms)
+         :errored-at     (interop/now-ms)
+         :restored-at    (interop/now-ms)
+         :installed-at   (interop/now-ms)
+         :registered-at  (interop/now-ms)
+         :updated-at     (interop/now-ms)
+         :detected-at    (interop/now-ms)
+         :fetched-at     (interop/now-ms)
+         :cached-at      (interop/now-ms)
+         :expires-at     (interop/now-ms)
+         :refreshed-at   (interop/now-ms)))

--- a/scripts/_test_fixtures/check_retired_composition_vocab/positive/live_deleted_app_value_ns_read.md
+++ b/scripts/_test_fixtures/check_retired_composition_vocab/positive/live_deleted_app_value_ns_read.md
@@ -1,0 +1,9 @@
+# Deleted app-value namespace named as a live seam (positive fixture)
+
+This prose names the DELETED `re-frame.app-value` namespace as a current read
+seam, which is the same residue class as the realm-namespace fixture beside it.
+It must FIRE (one finding).
+
+Tooling resolves the bound generation by reading
+`re-frame.app-value/current-value` directly whenever it wants the value behind
+the frame.

--- a/scripts/_test_fixtures/check_retired_composition_vocab/positive/live_deleted_migration_map_read.md
+++ b/scripts/_test_fixtures/check_retired_composition_vocab/positive/live_deleted_migration_map_read.md
@@ -1,0 +1,8 @@
+# Deleted migration-map read named as a live seam (positive fixture)
+
+This prose names `re-frame.migration/migration-map` — the disposition source the
+retired manifest-hygiene gate tracked — as a live read. It must FIRE (one
+finding).
+
+The disposition of each entry still comes from
+`re-frame.migration/migration-map`, which tooling reads at startup.

--- a/scripts/_test_fixtures/check_retired_composition_vocab/positive/live_realm_readers_remain_claim.md
+++ b/scripts/_test_fixtures/check_retired_composition_vocab/positive/live_realm_readers_remain_claim.md
@@ -1,0 +1,8 @@
+# Realm readers survive (positive fixture)
+
+A survival claim phrased as continuity rather than retention. EP-0024 removed
+the substrate this sentence describes, so the claim is drift; the shape had no
+fixture before. It must FIRE (one finding).
+
+The realm-scoped readers remain the supported way to reach the host registry
+from a tool panel.

--- a/scripts/_test_fixtures/check_retired_composition_vocab/positive/live_remaining_strong_symbols.md
+++ b/scripts/_test_fixtures/check_retired_composition_vocab/positive/live_remaining_strong_symbols.md
@@ -1,0 +1,13 @@
+# Realm and app inspectors (positive fixture)
+
+Four live retired strong symbols, one per fenced line, on a teaching page:
+`realm-ids`, `app-registrations`, `app-requires` and `frame-realm`. Each is an
+EP-0013 composition reader that EP-0024 took with the substrate it read, and
+each MUST fire on its own — one finding per line, attributed to its own symbol.
+
+```clojure
+(rf/realm-ids)
+(rf/app-registrations app)
+(rf/app-requires app)
+(rf/frame-realm frame)
+```

--- a/scripts/_test_fixtures/check_retired_composition_vocab/positive/live_retained_substrate_noun_claim.md
+++ b/scripts/_test_fixtures/check_retired_composition_vocab/positive/live_retained_substrate_noun_claim.md
@@ -1,0 +1,10 @@
+# Retained-substrate claim, verb first (positive fixture)
+
+EP-0024 deleted the EP-0013 composition machinery in full, so nothing of it
+survives as a live read. This page claims otherwise in the ordering where the
+verb leads and the substrate noun follows — the sibling fixture carries the
+opposite ordering, and this one had no fixture at all. It must FIRE (one
+finding).
+
+Tooling still reaches through to the retained realm machinery whenever it wants
+the host registry.

--- a/scripts/_test_fixtures/check_retired_composition_vocab/positive/live_rf_app_call.md
+++ b/scripts/_test_fixtures/check_retired_composition_vocab/positive/live_rf_app_call.md
@@ -1,0 +1,9 @@
+# App constructor (positive fixture)
+
+A live `(rf/app ...)` facade-constructor call inside a fenced block on a
+teaching page. `app` is a retired composition noun (EP-0023 §Naming); an image
+is the public unit of composition. The `rf/`-facade call MUST fire.
+
+```clojure
+(def shop (rf/app {:frames [:cart :checkout]}))
+```

--- a/scripts/_test_fixtures/check_thrown_error_messages/negative/binder_heads_crossed_cleanly.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/negative/binder_heads_crossed_cleanly.cljc
@@ -1,0 +1,146 @@
+(ns fixture.binder-heads-crossed-cleanly)
+
+;; NEGATIVE (rf2-n6ijg) — one case per `_VECTOR_BINDER_HEADS` entry, each
+;; crossing that head between a conformant `let`-bound message and the `throw`
+;; WITHOUT the head's binding vector mentioning the message symbol. Every one
+;; must stay GREEN: the crossing is provably transparent, so the outer binding
+;; is still the one in scope. Zero findings expected.
+;;
+;; THIS IS THE DIRECTION THAT PROVES THE ROSTER. A head in
+;; `_VECTOR_BINDER_HEADS` earns its place by letting `_crossing_is_transparent`
+;; return True when the vector is clean; the SHADOWING fixtures next door prove
+;; nothing about membership, because an unrecognised head fails closed and
+;; refuses for exactly the same reason a recognised-but-shadowing one does.
+;; Delete any head below from the roster and its case here fires — which is what
+;; ten of the sixteen had no way of saying before.
+;;
+;; The bodies are minimal by design: each `defn` exists to place one head
+;; between the binding and the throw, and nothing else.
+
+;; `let` — an inner binding of a DIFFERENT name.
+(defn crossing-let
+  [ctx]
+  (let [msg (str "boom [:rf.error/binder-let]")]
+    (let [detail (pr-str ctx)]
+      (throw (ex-info msg {:rf.error/id :rf.error/binder-let
+                           :detail      detail})))))
+
+;; `loop`
+(defn crossing-loop
+  [xs]
+  (let [msg (str "boom [:rf.error/binder-loop]")]
+    (loop [remaining xs]
+      (throw (ex-info msg {:rf.error/id :rf.error/binder-loop
+                           :remaining   remaining})))))
+
+;; `fn` — clean parameter vector.
+(defn crossing-fn
+  []
+  (let [msg (str "boom [:rf.error/binder-fn]")]
+    (fn [x]
+      (throw (ex-info msg {:rf.error/id :rf.error/binder-fn
+                           :x           x})))))
+
+;; `if-let`
+(defn crossing-if-let
+  [ctx]
+  (let [msg (str "boom [:rf.error/binder-if-let]")]
+    (if-let [other (:other ctx)]
+      (throw (ex-info msg {:rf.error/id :rf.error/binder-if-let
+                           :other       other}))
+      nil)))
+
+;; `when-let`
+(defn crossing-when-let
+  [ctx]
+  (let [msg (str "boom [:rf.error/binder-when-let]")]
+    (when-let [other (:other ctx)]
+      (throw (ex-info msg {:rf.error/id :rf.error/binder-when-let
+                           :other       other})))))
+
+;; `if-some`
+(defn crossing-if-some
+  [ctx]
+  (let [msg (str "boom [:rf.error/binder-if-some]")]
+    (if-some [other (:other ctx)]
+      (throw (ex-info msg {:rf.error/id :rf.error/binder-if-some
+                           :other       other}))
+      nil)))
+
+;; `when-some`
+(defn crossing-when-some
+  [ctx]
+  (let [msg (str "boom [:rf.error/binder-when-some]")]
+    (when-some [other (:other ctx)]
+      (throw (ex-info msg {:rf.error/id :rf.error/binder-when-some
+                           :other       other})))))
+
+;; `when-first`
+(defn crossing-when-first
+  [xs]
+  (let [msg (str "boom [:rf.error/binder-when-first]")]
+    (when-first [head xs]
+      (throw (ex-info msg {:rf.error/id :rf.error/binder-when-first
+                           :head        head})))))
+
+;; `doseq`
+(defn crossing-doseq
+  [xs]
+  (let [msg (str "boom [:rf.error/binder-doseq]")]
+    (doseq [x xs]
+      (throw (ex-info msg {:rf.error/id :rf.error/binder-doseq
+                           :x           x})))))
+
+;; `for`
+(defn crossing-for
+  [xs]
+  (let [msg (str "boom [:rf.error/binder-for]")]
+    (for [x xs]
+      (throw (ex-info msg {:rf.error/id :rf.error/binder-for
+                           :x           x})))))
+
+;; `dotimes`
+(defn crossing-dotimes
+  [n]
+  (let [msg (str "boom [:rf.error/binder-dotimes]")]
+    (dotimes [i n]
+      (throw (ex-info msg {:rf.error/id :rf.error/binder-dotimes
+                           :i           i})))))
+
+;; `with-open`
+(defn crossing-with-open
+  [source]
+  (let [msg (str "boom [:rf.error/binder-with-open]")]
+    (with-open [reader source]
+      (throw (ex-info msg {:rf.error/id :rf.error/binder-with-open
+                           :reader      reader})))))
+
+;; `with-local-vars`
+(defn crossing-with-local-vars
+  []
+  (let [msg (str "boom [:rf.error/binder-with-local-vars]")]
+    (with-local-vars [counter 0]
+      (throw (ex-info msg {:rf.error/id :rf.error/binder-with-local-vars
+                           :counter     counter})))))
+
+;; `with-redefs`
+(defn crossing-with-redefs
+  [replacement]
+  (let [msg (str "boom [:rf.error/binder-with-redefs]")]
+    (with-redefs [pr-str replacement]
+      (throw (ex-info msg {:rf.error/id :rf.error/binder-with-redefs})))))
+
+;; `binding`
+(defn crossing-binding
+  [writer]
+  (let [msg (str "boom [:rf.error/binder-binding]")]
+    (binding [*out* writer]
+      (throw (ex-info msg {:rf.error/id :rf.error/binder-binding})))))
+
+;; `letfn` — the binding vector holds local fns, none of them the message.
+(defn crossing-letfn
+  []
+  (let [msg (str "boom [:rf.error/binder-letfn]")]
+    (letfn [(describe [x] (pr-str x))]
+      (throw (ex-info msg {:rf.error/id :rf.error/binder-letfn
+                           :described   (describe 1)})))))

--- a/scripts/_test_fixtures/check_thrown_error_messages/negative/transparent_heads_crossed.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/negative/transparent_heads_crossed.cljc
@@ -1,0 +1,162 @@
+(ns fixture.transparent-heads-crossed)
+
+;; NEGATIVE (rf2-n6ijg) — one case per `_TRANSPARENT_HEADS` entry, each placing
+;; that head between a conformant `let`-bound message and the `throw` it guards.
+;; Every one must stay GREEN: a head that introduces no bindings cannot change
+;; what the message symbol means, which is the whole claim the roster makes.
+;; Zero findings expected.
+;;
+;; Delete any head below from `_TRANSPARENT_HEADS` and its case fires, because
+;; the crossing then falls through to the fail-closed default. Thirteen of the
+;; nineteen entries had no case in either direction before this file; the
+;; pre-existing `bypass_let_bound_guarded.cljc` reaches six of them
+;; (do/if/when/cond/try/finally) as a side effect of the shapes it was written
+;; for, and keeps doing so — this file is the roster's own home.
+;;
+;; The bodies are minimal by design: each `defn` exists to place one head
+;; between the binding and the throw. Several of the entries — `not` and the
+;; threading macros especially — are in the roster as fail-open safety rather
+;; than because they commonly wrap a throw, so the smallest form that nests the
+;; throw inside them is the honest fixture, not a plausible-looking one.
+
+;; `do`
+(defn crossing-do
+  [reason]
+  (let [msg (str reason " [:rf.error/transparent-do]")]
+    (do
+      (prn :about-to-throw)
+      (throw (ex-info msg {:rf.error/id :rf.error/transparent-do})))))
+
+;; `throw` — the head every case crosses on its way in, stated once here too.
+(defn crossing-throw
+  [reason]
+  (let [msg (str reason " [:rf.error/transparent-throw]")]
+    (throw (ex-info msg {:rf.error/id :rf.error/transparent-throw}))))
+
+;; `if`
+(defn crossing-if
+  [ok? reason]
+  (let [msg (str reason " [:rf.error/transparent-if]")]
+    (if ok?
+      nil
+      (throw (ex-info msg {:rf.error/id :rf.error/transparent-if})))))
+
+;; `if-not`
+(defn crossing-if-not
+  [ok? reason]
+  (let [msg (str reason " [:rf.error/transparent-if-not]")]
+    (if-not ok?
+      (throw (ex-info msg {:rf.error/id :rf.error/transparent-if-not}))
+      nil)))
+
+;; `when`
+(defn crossing-when
+  [bad? reason]
+  (let [msg (str reason " [:rf.error/transparent-when]")]
+    (when bad?
+      (throw (ex-info msg {:rf.error/id :rf.error/transparent-when})))))
+
+;; `when-not`
+(defn crossing-when-not
+  [ok? reason]
+  (let [msg (str reason " [:rf.error/transparent-when-not]")]
+    (when-not ok?
+      (throw (ex-info msg {:rf.error/id :rf.error/transparent-when-not})))))
+
+;; `cond`
+(defn crossing-cond
+  [reason]
+  (let [msg (str reason " [:rf.error/transparent-cond]")]
+    (cond
+      :else (throw (ex-info msg {:rf.error/id :rf.error/transparent-cond})))))
+
+;; `condp`
+(defn crossing-condp
+  [k reason]
+  (let [msg (str reason " [:rf.error/transparent-condp]")]
+    (condp = k
+      :unsupported (throw (ex-info msg {:rf.error/id :rf.error/transparent-condp}))
+      nil)))
+
+;; `case`
+(defn crossing-case
+  [k reason]
+  (let [msg (str reason " [:rf.error/transparent-case]")]
+    (case k
+      :unsupported (throw (ex-info msg {:rf.error/id :rf.error/transparent-case}))
+      nil)))
+
+;; `try` and `finally` — two entries, two cases.
+(defn crossing-try
+  [reason]
+  (let [msg (str reason " [:rf.error/transparent-try]")]
+    (try
+      (throw (ex-info msg {:rf.error/id :rf.error/transparent-try}))
+      (catch #?(:clj Exception :cljs js/Error) _ nil))))
+
+(defn crossing-finally
+  [reason]
+  (let [msg (str reason " [:rf.error/transparent-finally]")]
+    (try
+      nil
+      (finally
+        (throw (ex-info msg {:rf.error/id :rf.error/transparent-finally}))))))
+
+;; `and`
+(defn crossing-and
+  [ok? reason]
+  (let [msg (str reason " [:rf.error/transparent-and]")]
+    (and ok?
+         (throw (ex-info msg {:rf.error/id :rf.error/transparent-and})))))
+
+;; `or`
+(defn crossing-or
+  [value reason]
+  (let [msg (str reason " [:rf.error/transparent-or]")]
+    (or value
+        (throw (ex-info msg {:rf.error/id :rf.error/transparent-or})))))
+
+;; `not`
+(defn crossing-not
+  [reason]
+  (let [msg (str reason " [:rf.error/transparent-not]")]
+    (not (throw (ex-info msg {:rf.error/id :rf.error/transparent-not})))))
+
+;; `->` — "get it, or throw" is the shape this actually takes.
+(defn crossing-thread-first
+  [ctx reason]
+  (let [msg (str reason " [:rf.error/transparent-thread-first]")]
+    (-> ctx
+        :items
+        (or (throw (ex-info msg {:rf.error/id :rf.error/transparent-thread-first}))))))
+
+;; `->>`
+(defn crossing-thread-last
+  [ctx reason]
+  (let [msg (str reason " [:rf.error/transparent-thread-last]")]
+    (->> ctx
+         :items
+         (or (throw (ex-info msg {:rf.error/id :rf.error/transparent-thread-last}))))))
+
+;; `some->`
+(defn crossing-some-thread-first
+  [ctx reason]
+  (let [msg (str reason " [:rf.error/transparent-some-thread-first]")]
+    (some-> ctx
+            :items
+            (or (throw (ex-info msg {:rf.error/id :rf.error/transparent-some-thread-first}))))))
+
+;; `some->>`
+(defn crossing-some-thread-last
+  [ctx reason]
+  (let [msg (str reason " [:rf.error/transparent-some-thread-last]")]
+    (some->> ctx
+             :items
+             (or (throw (ex-info msg {:rf.error/id :rf.error/transparent-some-thread-last}))))))
+
+;; `doto`
+(defn crossing-doto
+  [ctx reason]
+  (let [msg (str reason " [:rf.error/transparent-doto]")]
+    (doto ctx
+      (throw (ex-info msg {:rf.error/id :rf.error/transparent-doto})))))

--- a/scripts/_test_fixtures/check_thrown_error_messages/positive/str_remaining_err_var_names.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/positive/str_remaining_err_var_names.cljc
@@ -1,0 +1,22 @@
+(ns fixture.positive.str-remaining-err-var-names
+  "POSITIVE fixture (rf2-n6ijg): the three `_STR_ERR_VAR_RE` variable names that
+  had no fixture — `error-keyword`, `err-kw`, `err-id`. `error-kw` and
+  `error-id` are covered by their own files beside this one.
+
+  The var NAME is the load-bearing signal: it is what tells the gate the value
+  is a discriminator keyword rather than human text, so each accepted spelling
+  needs a case of its own. Delete any one of them from the alternation and
+  nothing here can be answered by another. Three findings expected, and each
+  site names itself in its ex-data so the self-test can say WHICH one died.")
+
+(defn validation-error-long-name [error-keyword reason]
+  (ex-info (str error-keyword) {:rf.error/id :rf.error/str-error-keyword-var
+                                :reason      reason}))
+
+(defn validation-error-short-kw [err-kw reason]
+  (ex-info (str err-kw) {:rf.error/id :rf.error/str-err-kw-var
+                         :reason      reason}))
+
+(defn validation-error-short-id [err-id reason]
+  (ex-info (str err-id) {:rf.error/id :rf.error/str-err-id-var
+                         :reason      reason}))

--- a/scripts/check_ambient_durable_reads.py
+++ b/scripts/check_ambient_durable_reads.py
@@ -216,27 +216,46 @@ _DURABLE_ID_KEYS = (
 #           js/crypto.getRandomValues  (.getRandomValues js/crypto)
 #   browser: js/location  js/navigator  navigator.  js/localStorage
 #            js/sessionStorage  (.matchMedia ...)  js/matchMedia
-_AMBIENT_READ_ALT = "|".join([
+# Each entry is NAMED so a finding can say which read form produced it and the
+# self-test can hold the roster to owning a fixture (rf2-g1xpb). The names are
+# the roster's identity; the joined alternation below is byte-for-byte the
+# union that was here before, so the gate matches exactly what it always did.
+_AMBIENT_READ_FORMS: tuple[tuple[str, str], ...] = (
     # clock
-    r"\(\s*(?:interop/)?(?:epoch-)?now-ms\b[^)]*\)",
-    r"\(\s*js/Date\.now\b[^)]*\)",
-    r"\(\s*\.now\s+js/Date\b[^)]*\)",
+    ("now-ms",       r"\(\s*(?:interop/)?(?:epoch-)?now-ms\b[^)]*\)"),
+    ("js/Date.now",  r"\(\s*js/Date\.now\b[^)]*\)"),
+    (".now js/Date", r"\(\s*\.now\s+js/Date\b[^)]*\)"),
     # random
-    r"\(\s*rand\b[^)]*\)",
-    r"\(\s*rand-int\b[^)]*\)",
-    r"\(\s*rand-nth\b[^)]*\)",
-    r"\(\s*random-uuid\b[^)]*\)",
-    r"js/crypto\.getRandomValues\b",
-    r"\(\s*\.getRandomValues\s+js/crypto\b",
+    ("rand",         r"\(\s*rand\b[^)]*\)"),
+    ("rand-int",     r"\(\s*rand-int\b[^)]*\)"),
+    ("rand-nth",     r"\(\s*rand-nth\b[^)]*\)"),
+    ("random-uuid",  r"\(\s*random-uuid\b[^)]*\)"),
+    ("js/crypto.getRandomValues",   r"js/crypto\.getRandomValues\b"),
+    (".getRandomValues js/crypto",  r"\(\s*\.getRandomValues\s+js/crypto\b"),
     # browser / host facts
-    r"js/location\b",
-    r"js/navigator\b",
-    r"navigator\.\w",
-    r"js/localStorage\b",
-    r"js/sessionStorage\b",
-    r"\(\s*\.matchMedia\b",
-    r"js/matchMedia\b",
-])
+    ("js/location",       r"js/location\b"),
+    ("js/navigator",      r"js/navigator\b"),
+    ("navigator.",        r"navigator\.\w"),
+    ("js/localStorage",   r"js/localStorage\b"),
+    ("js/sessionStorage", r"js/sessionStorage\b"),
+    (".matchMedia",       r"\(\s*\.matchMedia\b"),
+    ("js/matchMedia",     r"js/matchMedia\b"),
+)
+_AMBIENT_READ_ALT = "|".join(pattern for _name, pattern in _AMBIENT_READ_FORMS)
+
+# The same patterns, individually compiled, used ONLY to attribute a finding
+# (and only once one exists) — the hot path stays the single alternation above.
+# ALL matching names are reported, not the first: `rand` matches `(rand-nth …)`
+# and `(rand-int …)` too, so a fixture for either genuinely exercises two roster
+# entries and saying otherwise would overstate what it proves.
+_AMBIENT_READ_RES: tuple[tuple[str, re.Pattern[str]], ...] = tuple(
+    (name, re.compile(pattern)) for name, pattern in _AMBIENT_READ_FORMS
+)
+
+
+def _read_forms_of(text: str) -> frozenset[str]:
+    """Every roster read-form name that matches `text`."""
+    return frozenset(name for name, rx in _AMBIENT_READ_RES if rx.search(text))
 
 # A durable field-key immediately followed (same form, possibly across a line
 # break within the window) by an ambient read. We match line-locally on
@@ -246,16 +265,19 @@ _ALL_DURABLE_KEYS = _DURABLE_TIMESTAMP_KEYS + _DURABLE_ID_KEYS
 _DURABLE_KEY_ALT = "|".join(re.escape(k) for k in _ALL_DURABLE_KEYS)
 
 _VIOLATION_RE = re.compile(
-    r":(?:" + _DURABLE_KEY_ALT + r")\b(?!/)\s+(?:" + _AMBIENT_READ_ALT + r")"
+    r":(?P<key>" + _DURABLE_KEY_ALT + r")\b(?!/)\s+(?P<read>"
+    + _AMBIENT_READ_ALT + r")"
 )
 
 # Same shape but allowing the ambient read on the NEXT line (the common
 # multi-line map-entry shape). We detect the durable key at end-of-(masked)-form
 # and an ambient read opening the following line. Handled in the window pass.
 _DURABLE_KEY_TRAILING_RE = re.compile(
-    r":(?:" + _DURABLE_KEY_ALT + r")\b(?!/)\s*$"
+    r":(?P<key>" + _DURABLE_KEY_ALT + r")\b(?!/)\s*$"
 )
-_AMBIENT_READ_LEADING_RE = re.compile(r"^\s*(?:" + _AMBIENT_READ_ALT + r")")
+_AMBIENT_READ_LEADING_RE = re.compile(
+    r"^\s*(?P<read>" + _AMBIENT_READ_ALT + r")"
+)
 
 
 # --------------------------------------------------------------------------
@@ -305,6 +327,14 @@ class Finding(NamedTuple):
     line: int
     kind: str
     snippet: str
+    # WHICH durable key and WHICH ambient read form fired. The reported `kind`
+    # is one constant for every finding, so without these a fixture can only
+    # ever prove that SOMETHING matched — which is how 19 of the 26 keys and 12
+    # of the 16 read forms went unexercised (rf2-g1xpb). Attribution costs
+    # nothing on the live path: it is read off the match already made, and
+    # `_report` is unchanged.
+    key: str = ""
+    reads: frozenset[str] = frozenset()
 
 
 # --------------------------------------------------------------------------
@@ -440,20 +470,30 @@ def _scan_text(path: Path, text: str) -> list[Finding]:
         return raw[n - 1].strip() if 0 <= n - 1 < len(raw) else ""
 
     for line_no, line in enumerate(masked, start=1):
-        hit = False
+        key = ""
+        read_text = ""
         # Same-line shape: `:loaded-at (interop/now-ms)`.
-        if _VIOLATION_RE.search(line):
-            hit = True
+        m = _VIOLATION_RE.search(line)
+        if m:
+            key, read_text = m.group("key"), m.group("read")
         # Cross-line shape: durable key ends the line, ambient read opens next.
-        elif _DURABLE_KEY_TRAILING_RE.search(line) and line_no < len(masked):
-            if _AMBIENT_READ_LEADING_RE.search(masked[line_no]):
-                hit = True
-        if not hit:
+        elif line_no < len(masked):
+            trailing = _DURABLE_KEY_TRAILING_RE.search(line)
+            leading = (
+                _AMBIENT_READ_LEADING_RE.search(masked[line_no])
+                if trailing else None
+            )
+            if trailing and leading:
+                key, read_text = trailing.group("key"), leading.group("read")
+        if not key:
             continue
         if _window_allowlisted(masked, line_no):
             continue
         findings.append(
-            Finding(path, line_no, "ambient-durable-read", raw_snippet(line_no))
+            Finding(
+                path, line_no, "ambient-durable-read", raw_snippet(line_no),
+                key=key, reads=_read_forms_of(read_text),
+            )
         )
     return findings
 
@@ -599,47 +639,116 @@ _SELF_TEST_FIXTURE_ROOT = (
 )
 
 
+# The two roster read forms NO fixture can exercise, and why. Both carry the
+# literal text `getRandomValues`, which is itself an `_ALLOWLIST_WINDOW_RE`
+# wrapper — so any line matching either of them sits inside its own exemption
+# window and can never produce a finding. That is deliberate (rider c: effect-
+# side crypto is sanctioned), and it is stated here rather than left as a silent
+# gap in the coverage assertion. The self-test holds this roster BOTH ways: an
+# entry here that no fixture covers is fine, but an entry here that a fixture
+# DOES cover is a stale exemption and fails.
+_UNEXERCISABLE_READ_FORMS: dict[str, str] = {
+    "js/crypto.getRandomValues":
+        "the text `getRandomValues` is itself an _ALLOWLIST_WINDOW_RE wrapper, "
+        "so a line matching this form always exempts itself",
+    ".getRandomValues js/crypto":
+        "same — the form's own text is the allowlist wrapper",
+}
+
+# What each positive fixture must yield, as `key<-read-form` witnesses. A pair
+# is written once per (durable key, read form) the fixture proves; a fixture
+# planting N witnesses on N lines is asserted by NAME, not by the number N.
+_POSITIVE_WITNESSES: dict[str, frozenset[str]] = {
+    "positive/now_ms_into_loaded_at.cljc":
+        frozenset({"loaded-at<-now-ms"}),
+    "positive/date_now_into_started_at.cljc":
+        frozenset({"started-at<-.now js/Date"}),
+    "positive/epoch_now_into_settled_at.cljc":
+        frozenset({"settled-at<-now-ms"}),
+    "positive/random_uuid_into_id.cljc":
+        frozenset({"id<-random-uuid"}),
+    "positive/now_ms_multiline.cljc":
+        frozenset({"stale-at<-now-ms"}),
+    # `(rand-nth …)` matches the `rand` roster entry as well as its own, so this
+    # one line honestly witnesses two entries.
+    "positive/rand_nth_into_temp_id.cljc":
+        frozenset({"temp-id<-rand", "temp-id<-rand-nth"}),
+    "positive/durable_write_near_debug_probe.cljc":
+        frozenset({"updated-at<-now-ms"}),
+    "positive/every_durable_timestamp_key.cljc": frozenset(
+        f"{k}<-now-ms" for k in _DURABLE_TIMESTAMP_KEYS
+    ),
+    "positive/every_durable_id_key.cljc": frozenset(
+        f"{k}<-random-uuid" for k in _DURABLE_ID_KEYS
+    ),
+    "positive/every_ambient_read_form.cljc": frozenset({
+        "instance-id<-now-ms",
+        "instance-id<-js/Date.now",
+        "instance-id<-.now js/Date",
+        "instance-id<-rand",
+        "instance-id<-rand-int",
+        "instance-id<-rand-nth",
+        "instance-id<-random-uuid",
+        "instance-id<-js/location",
+        "instance-id<-js/navigator",
+        "instance-id<-navigator.",
+        "instance-id<-js/localStorage",
+        "instance-id<-js/sessionStorage",
+        "instance-id<-.matchMedia",
+        "instance-id<-js/matchMedia",
+    }),
+}
+
+_NEGATIVE_FIXTURES: tuple[str, ...] = (
+    # threaded causal time from the reply token (the correct pattern)
+    "negative/threaded_completed_at.cljc",
+    # effect-side crypto for a session token (rider c)
+    "negative/effect_side_crypto_token.cljc",
+    # a trace/diagnostic timestamp (allowlisted wrapper)
+    "negative/trace_diagnostic_timestamp.cljc",
+    # a perf probe gated on debug-enabled? (its reads bind locals + write no
+    # durable key; the durable :updated-at threads the causal token) — green on
+    # its own merits, NOT via a debug-proximity allowlist (rf2-nftz2s §3)
+    "negative/debug_enabled_perf_probe.cljc",
+    # the conscious #_:rf.world/ambient-ok escape
+    "negative/ambient_ok_escape.cljc",
+    # the symbol in a docstring / `;;` comment
+    "negative/now_ms_in_docstring.cljc",
+    # a freshness DECISION read (compared, not written durably)
+    "negative/freshness_decision_read.cljc",
+)
+
+
 def _run_self_tests(verbose: bool = False) -> int:
-    """Scan each fixture file and assert the expected finding count.
+    """Scan each fixture and assert the EXACT set of witnesses it yields.
 
-    Positive fixtures plant ONE ambient durable read (expected=1); negative
-    fixtures exercise the sanctioned counterparts that MUST stay green
-    (expected=0). Direct-file scan mode is used so the suffix allow-list does
-    not hide them (the fixture IS the durable-write surface under test).
+    A witness is `<durable key><-<ambient read form>` — the two halves of the
+    cross-product this gate detects, read off the match that produced the
+    finding. Direct-file scan mode is used so the suffix allow-list does not
+    hide the fixtures (the fixture IS the durable-write surface under test).
+
+    Four assertions, each closing a different way for the gate to go quietly
+    toothless (the shape `check_retired_image_keys` arrived at, rf2-e1xx0):
+
+      1. Per positive fixture, the witness set must match EXACTLY, and the
+         finding COUNT must equal it — so a dead detector reds by NAME rather
+         than being masked by a sibling witness in the same file, and two
+         witnesses collapsing onto one line cannot hide inside a set.
+      2. Every negative fixture stays green.
+      3. Every durable key in `_ALL_DURABLE_KEYS` owns a witness. Nineteen of
+         the twenty-six did not, so widening the roster carried no obligation
+         and a key added with a typo'd spelling was green forever (rf2-g1xpb).
+      4. Every read form in `_AMBIENT_READ_FORMS` owns a witness, except the
+         declared-unexercisable pair — and a declared entry that DOES get
+         covered fails too, so the exemption cannot go stale.
     """
-    cases: list[tuple[str, int]] = [
-        # --- positives: each planted ambient durable read must FLAG ---
-        ("positive/now_ms_into_loaded_at.cljc",        1),
-        ("positive/date_now_into_started_at.cljc",     1),
-        ("positive/epoch_now_into_settled_at.cljc",    1),
-        ("positive/random_uuid_into_id.cljc",          1),
-        ("positive/now_ms_multiline.cljc",             1),
-        ("positive/rand_nth_into_temp_id.cljc",        1),
-        # rf2-nftz2s §3: a real durable write near a debug probe now FLAGS
-        # (the old generic debug-window allowlist hid it — false negative).
-        ("positive/durable_write_near_debug_probe.cljc", 1),
-        # --- negatives: every sanctioned counterpart must stay GREEN ---
-        # threaded causal time from the reply token (the correct pattern)
-        ("negative/threaded_completed_at.cljc",        0),
-        # effect-side crypto for a session token (rider c)
-        ("negative/effect_side_crypto_token.cljc",     0),
-        # a trace/diagnostic timestamp (allowlisted wrapper)
-        ("negative/trace_diagnostic_timestamp.cljc",   0),
-        # a perf probe gated on debug-enabled? (its reads bind locals + write
-        # no durable key; the durable :updated-at threads the causal token) —
-        # green on its own merits, NOT via a debug-proximity allowlist (rf2-nftz2s §3)
-        ("negative/debug_enabled_perf_probe.cljc",     0),
-        # the conscious #_:rf.world/ambient-ok escape
-        ("negative/ambient_ok_escape.cljc",            0),
-        # the symbol in a docstring / `;;` comment
-        ("negative/now_ms_in_docstring.cljc",          0),
-        # a freshness DECISION read (compared, not written durably)
-        ("negative/freshness_decision_read.cljc",      0),
-    ]
-
     failures = 0
+    checked = 0
+    covered_keys: set[str] = set()
+    covered_reads: set[str] = set()
     fake_root = _SELF_TEST_FIXTURE_ROOT  # repo_root is unused in direct-file mode
-    for fixture, expected in cases:
+
+    for fixture, expected in _POSITIVE_WITNESSES.items():
         path = _SELF_TEST_FIXTURE_ROOT / fixture
         if not path.is_file():
             sys.stderr.write(
@@ -647,22 +756,118 @@ def _run_self_tests(verbose: bool = False) -> int:
             )
             failures += 1
             continue
-        got = len(scan(path, fake_root, include_tests=True))
-        if got == expected:
-            if verbose:
-                sys.stderr.write(f"self-test PASS: {fixture} (findings={got})\n")
-        else:
+        checked += 1
+        findings = scan(path, fake_root, include_tests=True)
+        actual = frozenset(
+            f"{f.key}<-{form}" for f in findings for form in f.reads
+        )
+        covered_keys |= {f.key for f in findings}
+        covered_reads |= {form for f in findings for form in f.reads}
+        if actual != expected:
+            failures += 1
+            sys.stderr.write(f"self-test FAIL: {fixture}\n")
+            missing = sorted(expected - actual)
+            extra = sorted(actual - expected)
+            if missing:
+                sys.stderr.write(
+                    "      DETECTOR DEAD — this fixture plants "
+                    f"{', '.join(missing)} and the gate did not see it\n"
+                )
+            if extra:
+                sys.stderr.write(f"      UNEXPECTED: {', '.join(extra)}\n")
+            continue
+        # A set hides duplicates, and a duplicate is a witness that can die
+        # unseen: if two findings attribute identically, either may vanish and
+        # the set is unchanged. Every finding must therefore be distinguishable.
+        # (Two witnesses on ONE line is fine and expected — `(rand-nth …)`
+        # matches the `rand` roster entry as well as its own.)
+        elif len({(f.key, f.reads) for f in findings}) != len(findings):
+            failures += 1
             sys.stderr.write(
-                f"self-test FAIL: {fixture} expected findings={expected}, "
-                f"got {got}\n"
+                f"self-test FAIL: {fixture} has {len(findings)} findings that "
+                "attribute to fewer distinct witnesses — a duplicate can die "
+                "without changing the set. Plant each witness once.\n"
+            )
+        elif verbose:
+            sys.stderr.write(
+                f"self-test PASS: {fixture} ({len(findings)} witness(es))\n"
+            )
+
+    for fixture in _NEGATIVE_FIXTURES:
+        path = _SELF_TEST_FIXTURE_ROOT / fixture
+        if not path.is_file():
+            sys.stderr.write(
+                f"self-test FAIL: fixture {fixture!r} missing at {path}\n"
             )
             failures += 1
+            continue
+        checked += 1
+        findings = scan(path, fake_root, include_tests=True)
+        if findings:
+            failures += 1
+            sys.stderr.write(
+                f"self-test FAIL: {fixture} is a sanctioned counterpart and "
+                f"must stay GREEN; got {len(findings)} finding(s):\n"
+            )
+            for f in findings:
+                sys.stderr.write(
+                    f"      line {f.line}: {f.key} <- "
+                    f"{', '.join(sorted(f.reads)) or '?'}: {f.snippet}\n"
+                )
+        elif verbose:
+            sys.stderr.write(f"self-test PASS: {fixture} (green)\n")
+
+    uncovered_keys = sorted(set(_ALL_DURABLE_KEYS) - covered_keys)
+    if uncovered_keys:
+        failures += 1
+        sys.stderr.write(
+            "self-test FAIL: durable key(s) in the roster with no positive "
+            f"witness: {', '.join(uncovered_keys)}\n"
+            "      Plant each one in a positive fixture and declare its witness "
+            "in _POSITIVE_WITNESSES.\n"
+        )
+
+    roster_reads = {name for name, _pattern in _AMBIENT_READ_FORMS}
+    uncovered_reads = sorted(
+        roster_reads - covered_reads - set(_UNEXERCISABLE_READ_FORMS)
+    )
+    if uncovered_reads:
+        failures += 1
+        sys.stderr.write(
+            "self-test FAIL: ambient read form(s) in the roster with no "
+            f"positive witness: {', '.join(uncovered_reads)}\n"
+            "      Plant each one in a positive fixture, or — if it genuinely "
+            "cannot fire — declare it in _UNEXERCISABLE_READ_FORMS with the "
+            "reason.\n"
+        )
+    stale = sorted(set(_UNEXERCISABLE_READ_FORMS) & covered_reads)
+    if stale:
+        failures += 1
+        sys.stderr.write(
+            "self-test FAIL: read form(s) declared unexercisable that a fixture "
+            f"DID exercise: {', '.join(stale)}\n"
+            "      The exemption is stale — delete the entry and keep the "
+            "witness.\n"
+        )
+    unknown = sorted(set(_UNEXERCISABLE_READ_FORMS) - roster_reads)
+    if unknown:
+        failures += 1
+        sys.stderr.write(
+            "self-test FAIL: _UNEXERCISABLE_READ_FORMS names form(s) that are "
+            f"not in the roster at all: {', '.join(unknown)}\n"
+        )
 
     if failures:
         sys.stderr.write(f"\n{failures} self-test failure(s).\n")
         return 1
     if verbose:
-        sys.stderr.write(f"all {len(cases)} self-tests passed.\n")
+        sys.stderr.write(
+            f"all {checked} self-test fixture(s) passed; all "
+            f"{len(_ALL_DURABLE_KEYS)} durable key(s) and "
+            f"{len(roster_reads) - len(_UNEXERCISABLE_READ_FORMS)} of "
+            f"{len(roster_reads)} ambient read form(s) covered "
+            f"({len(_UNEXERCISABLE_READ_FORMS)} declared unexercisable).\n"
+        )
     return 0
 
 

--- a/scripts/check_ambient_durable_reads.py
+++ b/scripts/check_ambient_durable_reads.py
@@ -675,12 +675,25 @@ _POSITIVE_WITNESSES: dict[str, frozenset[str]] = {
         frozenset({"temp-id<-rand", "temp-id<-rand-nth"}),
     "positive/durable_write_near_debug_probe.cljc":
         frozenset({"updated-at<-now-ms"}),
-    "positive/every_durable_timestamp_key.cljc": frozenset(
-        f"{k}<-now-ms" for k in _DURABLE_TIMESTAMP_KEYS
-    ),
-    "positive/every_durable_id_key.cljc": frozenset(
-        f"{k}<-random-uuid" for k in _DURABLE_ID_KEYS
-    ),
+    # Written out, NOT derived from `_DURABLE_TIMESTAMP_KEYS`. A comprehension
+    # over the roster shrinks in lockstep when a roster entry is deleted, so the
+    # fixture would keep passing having stopped testing that entry — the exact
+    # self-blindness this bead is about. Verified by deleting `deadline-at`:
+    # derived expectations stayed green, these red naming it.
+    "positive/every_durable_timestamp_key.cljc": frozenset({
+        "started-at<-now-ms", "deadline-at<-now-ms", "loaded-at<-now-ms",
+        "stale-at<-now-ms", "invalidated-at<-now-ms", "settled-at<-now-ms",
+        "created-at<-now-ms", "completed-at<-now-ms", "errored-at<-now-ms",
+        "restored-at<-now-ms", "installed-at<-now-ms", "registered-at<-now-ms",
+        "updated-at<-now-ms", "detected-at<-now-ms", "fetched-at<-now-ms",
+        "cached-at<-now-ms", "expires-at<-now-ms", "refreshed-at<-now-ms",
+    }),
+    "positive/every_durable_id_key.cljc": frozenset({
+        "id<-random-uuid", "entry-id<-random-uuid", "request-id<-random-uuid",
+        "instance-id<-random-uuid", "mutation-id<-random-uuid",
+        "temp-id<-random-uuid", "correlation-id<-random-uuid",
+        "resource-id<-random-uuid",
+    }),
     "positive/every_ambient_read_form.cljc": frozenset({
         "instance-id<-now-ms",
         "instance-id<-js/Date.now",

--- a/scripts/check_failure_corpus_residue.py
+++ b/scripts/check_failure_corpus_residue.py
@@ -411,7 +411,11 @@ def _run_self_tests(verbose: bool = False) -> int:
     """Scan each fixture file and assert the expected finding count.
 
     Positive fixtures plant a LIVE `:where :cofx` inside a markdown code fence
-    or in live testbed source (expected >= 1). Negative fixtures exercise the
+    or in live testbed source, and the assertion is EXACT — the count must be
+    the one declared, not merely non-zero. (The docstring advertised `>= 1`
+    long after the code stopped doing it; `>= 1` is the fail-open shape
+    rf2-e1xx0 removed, and prose describing it is an invitation to put it
+    back — rf2-57vnc.) Negative fixtures exercise the
     counterparts that MUST stay green: removed-context prose, an inline code
     span, a `;` comment in a fence, a source docstring / `;` comment mention,
     the bare `:cofx` data-key (no `:where` head), and the rewritten

--- a/scripts/check_freehand_conformance_index.py
+++ b/scripts/check_freehand_conformance_index.py
@@ -3351,38 +3351,59 @@ def _run_extent_self_tests(verbose: bool = False) -> int:
 
 
 def _run_self_tests(verbose: bool = False) -> int:
-    cases: list[tuple[str, int]] = [
-        ("clean", 0),
-        ("empty", 0),
-        ("clean_planned", 0),
-        ("clean_qualified_host", 0),
-        ("duplicate_id", 1),
-        ("ill_formed_id", 1),
-        ("unknown_area_in_id", 1),
-        ("area_mismatch", 1),
-        ("out_of_order_id", 1),
-        ("gap_in_area", 1),
-        ("citation_not_a_link", 1),
-        ("citation_no_anchor", 1),
-        ("citation_missing_file", 1),
-        ("citation_missing_anchor", 1),
-        ("citation_outside_spec", 1),
-        ("fixture_missing", 1),
-        ("fixture_absent_on_active", 1),
-        ("fixture_on_planned", 1),
-        ("applicability_unknown_token", 1),
-        ("applicability_two_modes", 1),
-        ("applicability_no_host", 1),
-        ("applicability_no_mode", 1),
-        ("bad_status", 1),
-        ("bad_row_shape", 1),
-        ("empty_law", 1),
-        ("missing_area_section", 1),
-        ("unknown_area_section", 1),
-        ("duplicate_area_section", 1),
-        ("bad_table_header", 1),
-        # A block before the first section orphans both its header and its row.
-        ("orphan_row", 2),
+    # Both arms pin the defect a case must red WITH, not merely how many.  The
+    # census arm below said why first, and the reasoning is not census-specific:
+    # a case that reds for a NEIGHBOUR reason is a detector proven by its
+    # neighbour.  Several of these 26 do exactly that when their own rule is
+    # deleted — `unknown_area_in_id` falls through to AREA MISMATCH and
+    # `citation_no_anchor` to the missing-anchor lookup, both still at one
+    # defect (rf2-m147k).  Each entry names substrings unique to ITS rule's
+    # diagnostic, so the case cannot be answered by the rule next door.
+    cases: list[tuple[str, int, tuple[str, ...] | None]] = [
+        ("clean", 0, None),
+        ("empty", 0, None),
+        ("clean_planned", 0, None),
+        ("clean_qualified_host", 0, None),
+        ("duplicate_id", 1, ("DUPLICATE ID", "already allocated at line")),
+        ("ill_formed_id", 1,
+         ("ILL-FORMED ID", "expected FH-<AREA>-<NNN> with a roster AREA")),
+        ("unknown_area_in_id", 1,
+         ("ILL-FORMED ID", "is not in the area roster")),
+        ("area_mismatch", 1, ("AREA MISMATCH", "filed under the FH-")),
+        ("out_of_order_id", 1, ("OUT-OF-ORDER ID", "ids ascend within an area")),
+        ("gap_in_area", 1, ("GAP IN AREA", "ordinals are DENSE within an area")),
+        ("citation_not_a_link", 1,
+         ("MISSING CITATION", "not a markdown link")),
+        ("citation_no_anchor", 1, ("BROKEN CITATION", "has no #anchor")),
+        ("citation_missing_file", 1, ("BROKEN CITATION", "- no such file (")),
+        ("citation_missing_anchor", 1, ("BROKEN CITATION", "has no anchor #")),
+        ("citation_outside_spec", 1,
+         ("BROKEN CITATION", "a canonical paragraph lives under spec/")),
+        ("fixture_missing", 1, ("MISSING FIXTURE", "- no such file")),
+        ("fixture_absent_on_active", 1,
+         ("MISSING FIXTURE", "must name the fixture that proves it")),
+        ("fixture_on_planned", 1,
+         ("MISPLACED FIXTURE", "must leave the fixture cell as")),
+        ("applicability_unknown_token", 1,
+         ("BAD APPLICABILITY", "unknown token(s)")),
+        ("applicability_two_modes", 1,
+         ("BAD APPLICABILITY", "2 mode token(s)")),
+        ("applicability_no_host", 1, ("BAD APPLICABILITY", "no host token")),
+        ("applicability_no_mode", 1,
+         ("BAD APPLICABILITY", "0 mode token(s)")),
+        ("bad_status", 1, ("BAD STATUS", "expected one of")),
+        ("bad_row_shape", 1, ("BAD ROW", "column(s), expected")),
+        ("empty_law", 1, ("BAD ROW", "empty Law cell")),
+        ("missing_area_section", 1, ("MISSING AREA SECTION",)),
+        ("unknown_area_section", 1, ("UNKNOWN AREA SECTION",)),
+        ("duplicate_area_section", 1, ("DUPLICATE AREA SECTION",)),
+        ("bad_table_header", 1, ("BAD TABLE HEADER", "expected | Id | Law |")),
+        # A block before the first section orphans both its header and its row,
+        # and the two are named separately — an aggregate 2 is equally satisfied
+        # by either one firing twice.
+        ("orphan_row", 2,
+         ("[Id] table row before the first area section",
+          "[`FH-CALL-001`] table row before the first area section")),
     ]
     # The census cases pin the defect KIND as well as the count, because this
     # guard exists to stop a green being read off the wrong evidence and a
@@ -3506,16 +3527,32 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("census_retired_row_answers_a_citation", 0, None),
     ]
     failures = _run_extent_self_tests(verbose)
+    # A case that expects a RED must say what it expects to red WITH.  Without
+    # this, the next case added to either arm can arrive kind-less and be back
+    # to proof-by-count on the day it lands — which is how all 26 check-arm
+    # cases got there (rf2-m147k).
+    undeclared = [
+        name for name, expected, kind in (*cases, *census_cases)
+        if expected and not kind
+    ]
+    if undeclared:
+        sys.stderr.write(
+            "self-test FAIL: case(s) expecting a defect but naming none: "
+            f"{', '.join(undeclared)}\n"
+            "      Name substring(s) unique to the rule's own diagnostic; a "
+            "bare count is answered by the rule next door.\n"
+        )
+        failures += 1
     with tempfile.TemporaryDirectory(prefix="fh_index_selftest_") as tmp:
         base = Path(tmp)
         _build_self_test_fixtures(base)
         _build_census_fixtures(base)
-        both: tuple[tuple, ...] = (
-            (check, [(name, n, None) for name, n in cases]),
-            (census, census_cases),
-        )
+        both: tuple[tuple, ...] = ((check, cases), (census, census_cases))
         for guard, guard_cases in both:
             for fixture, expected, kind in guard_cases:
+                # The census arm writes one string, the check arm a tuple of
+                # them; both mean "every one of these must appear".
+                wanted = (kind,) if isinstance(kind, str) else tuple(kind or ())
                 root = base / fixture
                 saved_stderr = sys.stderr
                 sys.stderr = captured = _Captured()
@@ -3523,13 +3560,14 @@ def _run_self_tests(verbose: bool = False) -> int:
                     got = guard(root, verbose=False)
                 finally:
                     sys.stderr = saved_stderr
+                absent = [k for k in wanted if k not in captured.text]
                 if got != expected:
                     sys.stderr.write(
                         f"self-test FAIL: {fixture} expected defects={expected}, "
                         f"got {got}\n"
                     )
                     failures += 1
-                elif kind and kind not in captured.text:
+                elif absent:
                     # The case red, but not for the reason it was written for —
                     # which is the same mistake the guard itself exists to catch.
                     fired = next(
@@ -3539,13 +3577,14 @@ def _run_self_tests(verbose: bool = False) -> int:
                     )
                     sys.stderr.write(
                         f"self-test FAIL: {fixture} red with the right COUNT and "
-                        f"the wrong defect: expected {kind}, got {fired!r}\n"
+                        f"the wrong defect: expected {'; '.join(absent)}, got "
+                        f"{fired!r}\n"
                     )
                     failures += 1
                 elif verbose:
                     sys.stderr.write(
                         f"self-test PASS: {fixture} (defects={got}"
-                        f"{', ' + kind if kind else ''})\n"
+                        f"{'; ' + '; '.join(wanted) if wanted else ''})\n"
                     )
     if failures:
         sys.stderr.write(f"\n{failures} self-test failure(s).\n")

--- a/scripts/check_inject_cofx_residue.py
+++ b/scripts/check_inject_cofx_residue.py
@@ -453,7 +453,11 @@ def _run_self_tests(verbose: bool = False) -> int:
     """Scan each fixture file and assert the expected finding count.
 
     Positive fixtures plant a LIVE retired spelling inside a code fence on a
-    non-allowlisted-shaped page (expected >= 1). Negative fixtures exercise the
+    non-allowlisted-shaped page, and the assertion is EXACT — the count must be
+    the one declared, not merely non-zero. (Third instance of the same stale
+    prose, found in the rf2-57vnc sweep: `>= 1` is the fail-open shape
+    rf2-e1xx0 removed, and a docstring still advertising it is an invitation to
+    re-implement it from the comment.) Negative fixtures exercise the
     counterparts that MUST stay green: removed-context prose, an inline code
     span, a masked `;` comment in a fence, and the rewritten `:rf.cofx/requires`
     teaching. Allowlist behaviour is covered by a dedicated case that scans a

--- a/scripts/check_retired_composition_vocab.py
+++ b/scripts/check_retired_composition_vocab.py
@@ -343,8 +343,13 @@ _STRONG_RE = re.compile(
 _FACADE_NS_QUALIFIERS = frozenset({"", "rf/"})
 
 
-def _strong_hits(line: str, tool_spec_surface: bool = False) -> bool:
-    """True iff `line` carries a retired strong-symbol drift (bare or `rf/`).
+def _strong_hits(line: str, tool_spec_surface: bool = False) -> str | None:
+    """The retired strong symbol `line` carries (bare or `rf/`), else None.
+
+    Returns the SYMBOL rather than a bare True so a finding can say which of the
+    nine roster entries produced it, and the self-test can hold each entry to
+    owning a fixture (rf2-57vnc). Still truthy/falsy, so every caller that only
+    asks "did it hit?" reads the same answer it always did.
 
     A match qualified by any namespace OTHER than `rf/` (e.g. the internal
     `re-frame.realm/`, or an app's own `counter/`) names a different symbol
@@ -362,8 +367,8 @@ def _strong_hits(line: str, tool_spec_surface: bool = False) -> bool:
             continue
         if tool_spec_surface and m.group("sym") in _TOOL_CONVENTION_SYMBOLS:
             continue
-        return True
-    return False
+        return m.group("sym")
+    return None
 
 # (b) Retired conceptual-noun facade CALLS: `(rf/app ...)`, `(rf/module ...)`,
 #     `(rf/realm ...)`. Scoped to the open-paren + `rf/`-qualified call form so
@@ -373,9 +378,21 @@ def _strong_hits(line: str, tool_spec_surface: bool = False) -> bool:
 #     are different symbols (and `rf/app-db` is not even a real export). We
 #     deliberately require the `(` so a bare `rf/realm` mentioned as a value
 #     does not fire; the retired API reintroduction is always a call.
+#     The three nouns are a NAMED roster so a finding says which one fired and
+#     the self-test can hold each to owning a fixture (rf2-57vnc) — `rf/app` had
+#     none, and deleting it from the alternation changed nothing.
+_RETIRED_FACADE_NOUNS: tuple[str, ...] = ("app", "module", "realm")
 _RETIRED_FACADE_CALL_RE = re.compile(
-    r"\(\s*rf/(?:app|module|realm)(?![\w.+!?<>=-])"
+    r"\(\s*rf/(?P<noun>" + "|".join(_RETIRED_FACADE_NOUNS)
+    + r")(?![\w.+!?<>=-])"
 )
+
+
+def _facade_noun_hits(line: str) -> str | None:
+    """The retired facade noun `line` calls (`rf/app` / `rf/module` /
+    `rf/realm`), else None."""
+    m = _RETIRED_FACADE_CALL_RE.search(line)
+    return f"rf/{m.group('noun')}" if m else None
 
 # (c) Retired ARCHITECTURE-TEACHING prose phrases (rf2-2c8zq6). The root-support
 #     surfaces (README, TESTING, the JVM gate comments) drifted not by planting
@@ -429,8 +446,10 @@ _REMOVED_CONTEXT_RE = re.compile(
 )
 
 
-def _prose_hits(line: str, context: str = "") -> bool:
-    """True iff `line` teaches a retired architecture phrase as LIVE model prose.
+def _prose_hits(line: str, context: str = "") -> str | None:
+    """The retired architecture phrase `line` teaches as LIVE model prose, else
+    None. Named, like the other families, so a finding says which of the two
+    phrases fired rather than merely that one did.
 
     A retired phrase (`event[- ]program` / `realm[- ]routing`) fires unless a
     removed-context marker (`retired`, `removed`, `no longer`, `no
@@ -441,10 +460,15 @@ def _prose_hits(line: str, context: str = "") -> bool:
     prose while staying narrow enough not to swallow an unrelated nearby
     sentence.
     """
-    if not _RETIRED_PROSE_RE.search(line):
-        return False
+    m = _RETIRED_PROSE_RE.search(line)
+    if not m:
+        return None
     haystack = context if context else line
-    return not _REMOVED_CONTEXT_RE.search(haystack)
+    if _REMOVED_CONTEXT_RE.search(haystack):
+        return None
+    # Normalise the spelling variants (`event program` / `event-program`) onto
+    # one roster name so the witness is the RULE, not the prose that tripped it.
+    return m.group(0).lower().replace(" ", "-")
 
 
 # (d) DELETED-SUBSTRATE-AS-LIVE prose families (rf2-lq99wc). The
@@ -495,14 +519,29 @@ def _prose_hits(line: str, context: str = "") -> bool:
 #      remain" — required to co-occur with a realm/app-value/module substrate
 #      noun on the same line so the EP-0018 reg-event-ctx "retained internally"
 #      note (no realm adjacency) stays green.
+#      Each alternative is NAMED so a finding says which claim shape fired and
+#      the self-test can hold each to owning a fixture (rf2-57vnc): the single
+#      positive matched only the first two, leaving three shapes unexercised.
+_RETAINED_CLAIM_FORMS: tuple[tuple[str, str], ...] = (
+    ("retained-internal",
+     r"retained[- ]internal"),
+    ("retained-as-internal-substrate",
+     r"retained\s+(?:as\s+)?(?:an?\s+)?internal\s+substrate"),
+    ("substrate-noun-retained",
+     r"(?:realm|app[- ]value|module)\s+(?:machinery|substrate|readers?|"
+     r"surface|reader)\b[^.\n]*?\bretain"),
+    ("retained-substrate-noun",
+     r"retained?\b[^.\n]*?\b(?:realm|app[- ]value)\s+(?:machinery|substrate)"),
+    ("realm-readers-remain",
+     r"(?:realm[- ]scoped|realm)\s+readers?\b[^.\n]*?\bremain"),
+)
 _RETAINED_CLAIM_RE = re.compile(
-    r"retained[- ]internal"
-    r"|retained\s+(?:as\s+)?(?:an?\s+)?internal\s+substrate"
-    r"|(?:realm|app[- ]value|module)\s+(?:machinery|substrate|readers?|"
-    r"surface|reader)\b[^.\n]*?\bretain"
-    r"|retained?\b[^.\n]*?\b(?:realm|app[- ]value)\s+(?:machinery|substrate)"
-    r"|(?:realm[- ]scoped|realm)\s+readers?\b[^.\n]*?\bremain",
+    "|".join(pattern for _name, pattern in _RETAINED_CLAIM_FORMS),
     re.IGNORECASE,
+)
+_RETAINED_CLAIM_RES = tuple(
+    (name, re.compile(pattern, re.IGNORECASE))
+    for name, pattern in _RETAINED_CLAIM_FORMS
 )
 
 # A realm/app-value/module SUBSTRATE noun the (d1) claim must touch — guards the
@@ -517,55 +556,79 @@ _SUBSTRATE_NOUN_RE = re.compile(
 #      EP-0024; naming one as a live seam is drift. `re-frame.migration/` is
 #      scoped to `migration-map` specifically (the disposition source the
 #      retired manifest-hygiene gate tracked) to keep the family tight.
+#      Named per namespace, same reason as the rosters above (rf2-57vnc): only
+#      `re-frame.realm/` was ever planted, so the other two could be deleted
+#      from the alternation without a single fixture noticing.
+_DELETED_NS_READS: tuple[tuple[str, str], ...] = (
+    ("re-frame.realm/",     r"re-frame\.realm/[\w.+!?<>=-]+"),
+    ("re-frame.app-value/", r"re-frame\.app-value/[\w.+!?<>=-]+"),
+    ("re-frame.migration/migration-map",
+     r"re-frame\.migration/migration-map\b"),
+)
 _DELETED_NS_READ_RE = re.compile(
-    r"re-frame\.realm/[\w.+!?<>=-]+"
-    r"|re-frame\.app-value/[\w.+!?<>=-]+"
-    r"|re-frame\.migration/migration-map\b",
+    "|".join(pattern for _name, pattern in _DELETED_NS_READS)
+)
+_DELETED_NS_READ_RES = tuple(
+    (name, re.compile(pattern)) for name, pattern in _DELETED_NS_READS
 )
 
 
-def _retained_substrate_hits(line: str, context: str = "") -> bool:
-    """True iff `line` claims the deleted realm/app-value substrate is live.
+def _retained_substrate_hits(line: str, context: str = "") -> str | None:
+    """The retained-substrate claim shape(s) `line` carries, else None.
 
     Fires on a `retained-internal` / "realm machinery … retained" / "readers …
     remain" claim that ALSO names a realm/app-value/module substrate noun (so
     the EP-0018 reg-event-ctx "retained internally" note stays green), UNLESS a
     removed-context marker appears in `context` (line + immediate neighbours).
+
+    The return names EVERY `_RETAINED_CLAIM_FORMS` entry that matched, `+`-
+    joined — several of the five overlap ("retained internal substrate" is both
+    the first and the second), and reporting only the first would credit a
+    fixture with proving an entry it never reached.
     """
-    if not _RETAINED_CLAIM_RE.search(line):
-        return False
+    matched = [n for n, rx in _RETAINED_CLAIM_RES if rx.search(line)]
+    if not matched:
+        return None
     if not _SUBSTRATE_NOUN_RE.search(line):
-        return False
+        return None
     haystack = context if context else line
-    return not _REMOVED_CONTEXT_RE.search(haystack)
+    if _REMOVED_CONTEXT_RE.search(haystack):
+        return None
+    return "+".join(matched)
 
 
-def _deleted_ns_read_hits(line: str, context: str = "") -> bool:
-    """True iff `line` names a DELETED namespace as a live read seam.
+def _deleted_ns_read_hits(line: str, context: str = "") -> str | None:
+    """The DELETED namespace(s) `line` names as a live read seam, else None.
 
     Fires on a `re-frame.realm/` / `re-frame.app-value/` /
     `re-frame.migration/migration-map` mention (raw line — inline spans are NOT
     masked, since a span naming a deleted ns as a live seam IS the residue),
     UNLESS a removed-context marker appears in `context`.
     """
-    if not _DELETED_NS_READ_RE.search(line):
-        return False
+    matched = [n for n, rx in _DELETED_NS_READ_RES if rx.search(line)]
+    if not matched:
+        return None
     haystack = context if context else line
-    return not _REMOVED_CONTEXT_RE.search(haystack)
+    if _REMOVED_CONTEXT_RE.search(haystack):
+        return None
+    return "+".join(matched)
 
 
 # Each family is a (kind, predicate) pair where the predicate maps a
-# (masked-line, tool_spec_surface) pair to True iff it carries that family's
-# drift. The strong family uses `_strong_hits` (capture + internal-namespace
-# filter + the tool-spec install!-convention exemption); the facade-noun family
-# is a plain regex search (surface-independent). The prose family (`_prose_hits`)
-# runs over PROSE lines (outside fenced code) on the root-support surfaces, not
-# the fenced-code lines the symbol families consume.
+# (masked-line, tool_spec_surface) pair to the ROSTER ENTRY it matched, or None.
+# It used to answer a bare True, which is why four of the nine strong symbols and
+# `rf/app` could sit in their rosters with no fixture at all: a finding could
+# only ever say that SOMETHING in the family fired (rf2-57vnc). The strong family
+# uses `_strong_hits` (capture + internal-namespace filter + the tool-spec
+# install!-convention exemption); the facade-noun family is a plain regex search
+# (surface-independent). The prose family (`_prose_hits`) runs over PROSE lines
+# (outside fenced code) on the root-support surfaces, not the fenced-code lines
+# the symbol families consume.
 _RETIRED_PATTERNS = (
     ("retired-construction-symbol",
      lambda line, tool_spec: _strong_hits(line, tool_spec_surface=tool_spec)),
     ("retired-facade-noun-call",
-     lambda line, _tool_spec: bool(_RETIRED_FACADE_CALL_RE.search(line))),
+     lambda line, _tool_spec: _facade_noun_hits(line)),
 )
 
 # The prose family is scanned separately (over non-fenced lines), so it is its
@@ -592,6 +655,12 @@ class Finding(NamedTuple):
     line: int
     kind: str
     snippet: str
+    # WHICH roster entry within the family fired. Four of the nine strong
+    # symbols, `rf/app`, two of the three deleted namespaces and three of the
+    # five retained-claim shapes had no fixture, and nothing could have said so:
+    # every finding in a family carried the same `kind` (rf2-57vnc). `_report`
+    # is unchanged — this exists for the self-test's roster-coverage assertion.
+    detail: str = ""
 
 
 # --------------------------------------------------------------------------
@@ -780,9 +849,13 @@ def _scan_text(path: Path, text: str, rel_posix: str) -> list[Finding]:
     tool_spec_surface = bool(_TOOL_SPEC_REL_RE.match(rel_posix))
     for line_no, masked in _code_fence_lines(text):
         for kind, predicate in _RETIRED_PATTERNS:
-            if predicate(masked, tool_spec_surface):
+            entry = predicate(masked, tool_spec_surface)
+            if entry:
                 snippet = raw[line_no - 1].strip() if 0 <= line_no - 1 < len(raw) else ""
-                findings.append(Finding(path, line_no, f"live-retired:{kind}", snippet))
+                findings.append(
+                    Finding(path, line_no, f"live-retired:{kind}", snippet,
+                            detail=entry)
+                )
     # The deleted-substrate prose families (rf2-lq99wc) run over the prose of
     # EVERY scanned file — markdown OR a non-markdown root-support script (whose
     # whole body is the prose surface). The residue the audit found lives on the
@@ -816,9 +889,13 @@ def _scan_deleted_substrate_prose(path: Path, text: str) -> list[Finding]:
             by_no.get(n, "") for n in (line_no - 1, line_no, line_no + 1)
         )
         for kind, predicate in _DELETED_SUBSTRATE_PATTERNS:
-            if predicate(line, context):
+            entry = predicate(line, context)
+            if entry:
                 snippet = raw[line_no - 1].strip() if 0 <= line_no - 1 < len(raw) else ""
-                findings.append(Finding(path, line_no, f"live-retired:{kind}", snippet))
+                findings.append(
+                    Finding(path, line_no, f"live-retired:{kind}", snippet,
+                            detail=entry)
+                )
     return findings
 
 
@@ -848,9 +925,13 @@ def _scan_root_support_prose(path: Path, text: str, rel_posix: str) -> list[Find
             masked_by_no.get(n, "")
             for n in (line_no - 1, line_no, line_no + 1)
         )
-        if _prose_hits(masked, context):
+        entry = _prose_hits(masked, context)
+        if entry:
             snippet = raw[line_no - 1].strip() if 0 <= line_no - 1 < len(raw) else ""
-            findings.append(Finding(path, line_no, f"live-retired:{kind}", snippet))
+            findings.append(
+                Finding(path, line_no, f"live-retired:{kind}", snippet,
+                        detail=entry)
+            )
     return findings
 
 
@@ -1094,68 +1175,131 @@ _SELF_TEST_FIXTURE_ROOT = (
 )
 
 
-def _run_self_tests(verbose: bool = False) -> int:
-    """Scan each fixture file and assert the expected finding count.
+def _witnesses(findings: list[Finding]) -> frozenset[str]:
+    """`<family>:<roster entry>` for each finding — what it PROVED, not how
+    many there were."""
+    return frozenset(
+        f"{f.kind.removeprefix('live-retired:')}:{f.detail}" for f in findings
+    )
 
-    Positive fixtures plant a LIVE retired symbol inside a code fence on a
-    non-allowlisted-shaped page (expected >= 1). Negative fixtures exercise the
-    counterparts that MUST stay green: removed-context prose, an inline code
-    span, a masked `;` comment in a fence, the sanctioned `app-db` term, the
-    rewritten image/frame teaching, and a non-facade namespace-qualified symbol
-    (an app's own `counter/install!` setup hook — the qualifier filter keeps a
-    non-`rf/` qualifier from firing). A dedicated allowlist case scans a positive
-    fixture AS IF it were an EP doc and asserts it does NOT fire.
+
+def _run_self_tests(verbose: bool = False) -> int:
+    """Scan each fixture file and assert the EXACT set of witnesses it yields.
+
+    A witness is `<family>:<roster entry>` — which of the family's alternatives
+    fired, not merely that the family did. Positive fixtures plant a LIVE
+    retired symbol inside a code fence on a non-allowlisted-shaped page;
+    negative fixtures exercise the counterparts that MUST stay green:
+    removed-context prose, an inline code span, a masked `;` comment in a fence,
+    the sanctioned `app-db` term, the rewritten image/frame teaching, and a
+    non-facade namespace-qualified symbol (an app's own `counter/install!` setup
+    hook — the qualifier filter keeps a non-`rf/` qualifier from firing). A
+    dedicated allowlist case scans a positive fixture AS IF it were an EP doc
+    and asserts it does NOT fire.
 
     A second block (rf2-2c8zq6) exercises the root-support PROSE-architecture
     family: it scans the prose fixtures AS IF they were a root-support file
     (rel_posix=README.md) so the prose family activates, asserting the live
     "event program" / "realm-routing" teaching FIRES and every removed-context
     / inline-span / in-fence counterpart stays GREEN.
+
+    The counts were already exact, and every fixture single-token — the hole was
+    one level down (rf2-57vnc): nothing obliged a ROSTER ENTRY to own a fixture,
+    so `realm-ids`, `app-registrations`, `app-requires`, `frame-realm`,
+    `rf/app`, two of the three deleted namespaces and three of the five
+    retained-claim shapes could each be deleted from their alternation without a
+    single case noticing. The coverage assertions at the end close that.
     """
-    cases: list[tuple[str, int]] = [
-        # (fixture relative to fixture-root, expected finding count)
+    failures = 0
+    covered: set[str] = set()
+
+    def run_case(fixture: str, rel_posix: str, expected: frozenset[str],
+                 label: str = "") -> None:
+        """Scan one fixture at one surface and assert its exact witness set."""
+        nonlocal failures
+        tag = f"{label} " if label else ""
+        path = _SELF_TEST_FIXTURE_ROOT / fixture
+        if not path.is_file():
+            sys.stderr.write(
+                f"self-test FAIL: {tag}fixture {fixture!r} missing at {path}\n"
+            )
+            failures += 1
+            return
+        text = path.read_text(encoding="utf-8", errors="replace")
+        findings = _scan_text(path, text, rel_posix=rel_posix)
+        actual = _witnesses(findings)
+        covered.update(actual)
+        if actual != expected:
+            failures += 1
+            sys.stderr.write(f"self-test FAIL: {tag}{fixture}\n")
+            missing = sorted(expected - actual)
+            extra = sorted(actual - expected)
+            if missing:
+                sys.stderr.write(
+                    "      DETECTOR DEAD — this fixture plants "
+                    f"{', '.join(missing)} and the gate did not see it\n"
+                )
+            if extra:
+                sys.stderr.write(f"      UNEXPECTED: {', '.join(extra)}\n")
+            return
+        # A set hides duplicates, and a duplicate witness can die unseen.
+        if len(findings) != len(actual):
+            failures += 1
+            sys.stderr.write(
+                f"self-test FAIL: {tag}{fixture} has {len(findings)} findings "
+                f"for {len(actual)} distinct witness(es) — a duplicate can die "
+                "without changing the set. Plant each witness once.\n"
+            )
+        elif verbose:
+            sys.stderr.write(
+                f"self-test PASS: {tag}{fixture} "
+                f"({', '.join(sorted(actual)) or 'green'})\n"
+            )
+
+    _SYMBOL = "retired-construction-symbol:"
+    _FACADE = "retired-facade-noun-call:"
+    cases: list[tuple[str, frozenset[str]]] = [
+        # (fixture relative to fixture-root, exact witness set)
         # --- positives: a LIVE retired symbol in a code fence must FIRE ---
-        ("positive/live_install_realm_app.md",         1),
-        ("positive/live_reinstall.md",                 1),
-        ("positive/live_app_owns_inspector.md",        1),
-        ("positive/live_rf_realm_call.md",             1),
-        ("positive/live_rf_module_call.md",            1),
-        ("positive/live_installed_app_read.md",        1),
+        ("positive/live_install_realm_app.md",
+         frozenset({_SYMBOL + "install!"})),
+        ("positive/live_reinstall.md",
+         frozenset({_SYMBOL + "reinstall!"})),
+        ("positive/live_app_owns_inspector.md",
+         frozenset({_SYMBOL + "app-owns"})),
+        ("positive/live_installed_app_read.md",
+         frozenset({_SYMBOL + "installed-app"})),
+        # The four strong symbols that had no fixture at all, one per fenced
+        # line, each attributed to itself.
+        ("positive/live_remaining_strong_symbols.md", frozenset({
+            _SYMBOL + "realm-ids",
+            _SYMBOL + "app-registrations",
+            _SYMBOL + "app-requires",
+            _SYMBOL + "frame-realm",
+        })),
+        ("positive/live_rf_realm_call.md",
+         frozenset({_FACADE + "rf/realm"})),
+        ("positive/live_rf_module_call.md",
+         frozenset({_FACADE + "rf/module"})),
+        # `rf/app` was in the alternation and in no fixture.
+        ("positive/live_rf_app_call.md",
+         frozenset({_FACADE + "rf/app"})),
         # --- negatives: removed-context / sanctioned forms must stay GREEN ---
-        ("negative/removed_context_prose.md",          0),
-        ("negative/inline_code_span_mention.md",       0),
-        ("negative/masked_clj_comment_in_fence.md",    0),
-        ("negative/app_db_sanctioned.md",              0),
-        ("negative/rewritten_image_frame_teaching.md", 0),
+        ("negative/removed_context_prose.md",          frozenset()),
+        ("negative/inline_code_span_mention.md",       frozenset()),
+        ("negative/masked_clj_comment_in_fence.md",    frozenset()),
+        ("negative/app_db_sanctioned.md",              frozenset()),
+        ("negative/rewritten_image_frame_teaching.md", frozenset()),
         # Non-facade namespace-qualified symbols: the internal substrate read
         # (`re-frame.realm/realm-ids`, `re-frame.realm/installed-app`) AND an
         # app's own `counter/install!` setup hook — all share a bare name with
         # a retired facade symbol but are different symbols. Must stay GREEN.
-        ("negative/internal_substrate_ns_reads.md",    0),
+        ("negative/internal_substrate_ns_reads.md",    frozenset()),
     ]
-
-    failures = 0
     for fixture, expected in cases:
-        path = _SELF_TEST_FIXTURE_ROOT / fixture
-        if not path.is_file():
-            sys.stderr.write(
-                f"self-test FAIL: fixture {fixture!r} missing at {path}\n"
-            )
-            failures += 1
-            continue
         # Direct-file scan; the fixture's own posix path is non-allowlisted
         # (it does not start with an allowlist prefix), so positives fire.
-        text = path.read_text(encoding="utf-8", errors="replace")
-        got = len(_scan_text(path, text, rel_posix=fixture))
-        if got == expected:
-            if verbose:
-                sys.stderr.write(f"self-test PASS: {fixture} (findings={got})\n")
-        else:
-            sys.stderr.write(
-                f"self-test FAIL: {fixture} expected findings={expected}, "
-                f"got {got}\n"
-            )
-            failures += 1
+        run_case(fixture, fixture, expected)
 
     # Dedicated allowlist case: the SAME live-residue fixture, scanned as if it
     # were an EP doc, must NOT fire (the docs/EP/ allowlist exempts it).
@@ -1187,37 +1331,21 @@ def _run_self_tests(verbose: bool = False) -> int:
     # rf2-2c8zq6 — the root-support PROSE-architecture family. Scanned AS IF the
     # fixture were a root-support file (rel_posix=README.md) so the prose family
     # activates (it is gated to `_ROOT_SUPPORT_PROSE_FILES`).
-    prose_cases: list[tuple[str, int]] = [
+    _PROSE = "retired-architecture-prose:"
+    prose_cases: list[tuple[str, frozenset[str]]] = [
         # --- positives: live retired architecture prose must FIRE ---
-        ("positive/live_event_program_prose.md",       1),
-        ("positive/live_realm_routing_prose.md",        1),
+        ("positive/live_event_program_prose.md",
+         frozenset({_PROSE + "event-program"})),
+        ("positive/live_realm_routing_prose.md",
+         frozenset({_PROSE + "realm-routing"})),
         # --- negatives: removed-context / inline-span / in-fence stay GREEN ---
-        ("negative/removed_context_prose_phrases.md",   0),
-        ("negative/inline_span_field_name.md",          0),
-        ("negative/phrase_in_fence_not_prose.md",       0),
+        ("negative/removed_context_prose_phrases.md",   frozenset()),
+        ("negative/inline_span_field_name.md",          frozenset()),
+        ("negative/phrase_in_fence_not_prose.md",       frozenset()),
     ]
     for fixture, expected in prose_cases:
-        path = _SELF_TEST_FIXTURE_ROOT / fixture
-        if not path.is_file():
-            sys.stderr.write(
-                f"self-test FAIL: prose fixture {fixture!r} missing at {path}\n"
-            )
-            failures += 1
-            continue
-        text = path.read_text(encoding="utf-8", errors="replace")
         # rel_posix=README.md makes _scan_text run the prose-architecture family.
-        got = len(_scan_text(path, text, rel_posix="README.md"))
-        if got == expected:
-            if verbose:
-                sys.stderr.write(
-                    f"self-test PASS: {fixture} (prose findings={got})\n"
-                )
-        else:
-            sys.stderr.write(
-                f"self-test FAIL: {fixture} expected prose findings={expected}, "
-                f"got {got}\n"
-            )
-            failures += 1
+        run_case(fixture, "README.md", expected, label="prose")
 
     # rf2-lq99wc — the DELETED-SUBSTRATE families (retained-internal claim +
     # deleted-namespace read). These run over the prose of EVERY scanned file in
@@ -1228,74 +1356,93 @@ def _run_self_tests(verbose: bool = False) -> int:
     # (spec/Conventions.md / the Xray specs / the api-manifest) GREEN, and that
     # the EP-0018 `reg-event-ctx` "retained internally" note (different subject,
     # no realm adjacency) does NOT fire.
-    deleted_substrate_cases: list[tuple[str, int]] = [
+    _CLAIM = "retired-substrate-retained-claim:"
+    _NSREAD = "retired-deleted-namespace-read:"
+    deleted_substrate_cases: list[tuple[str, frozenset[str]]] = [
         # --- positives: live deleted-substrate-as-live drift must FIRE ---
-        ("positive/live_retained_internal_substrate.md", 1),
-        ("positive/live_deleted_namespace_read.md",      1),
+        # One line, three overlapping claim shapes — the witness records all
+        # three rather than crediting the fixture with only the first.
+        ("positive/live_retained_internal_substrate.md",
+         frozenset({_CLAIM + "retained-internal+retained-as-internal-substrate"
+                    "+substrate-noun-retained"})),
+        # The two claim shapes that had no fixture: verb-first, and survival
+        # phrased as continuity.
+        ("positive/live_retained_substrate_noun_claim.md",
+         frozenset({_CLAIM + "retained-substrate-noun"})),
+        ("positive/live_realm_readers_remain_claim.md",
+         frozenset({_CLAIM + "realm-readers-remain"})),
+        ("positive/live_deleted_namespace_read.md",
+         frozenset({_NSREAD + "re-frame.realm/"})),
+        # The two deleted namespaces that had no fixture.
+        ("positive/live_deleted_app_value_ns_read.md",
+         frozenset({_NSREAD + "re-frame.app-value/"})),
+        ("positive/live_deleted_migration_map_read.md",
+         frozenset({_NSREAD + "re-frame.migration/migration-map"})),
         # --- negatives: removed-context / different-subject stay GREEN ---
-        ("negative/removed_context_deleted_substrate.md", 0),
-        ("negative/reg_event_ctx_retained_internally.md", 0),
+        ("negative/removed_context_deleted_substrate.md", frozenset()),
+        ("negative/reg_event_ctx_retained_internally.md", frozenset()),
         # the pre-existing internal-substrate fixture reads the LIVE namespaces
-        # (`re-frame.registrar/` / `re-frame.frame/`), NOT a deleted one — still 0.
-        ("negative/internal_substrate_ns_reads.md",       0),
+        # (`re-frame.registrar/` / `re-frame.frame/`), NOT a deleted one.
+        ("negative/internal_substrate_ns_reads.md",       frozenset()),
     ]
     for fixture, expected in deleted_substrate_cases:
-        path = _SELF_TEST_FIXTURE_ROOT / fixture
-        if not path.is_file():
-            sys.stderr.write(
-                f"self-test FAIL: deleted-substrate fixture {fixture!r} missing "
-                f"at {path}\n"
-            )
-            failures += 1
-            continue
-        text = path.read_text(encoding="utf-8", errors="replace")
         # A plain non-allowlisted rel_posix runs the deleted-substrate families.
-        got = len(_scan_text(path, text, rel_posix=fixture))
-        if got == expected:
-            if verbose:
-                sys.stderr.write(
-                    f"self-test PASS: {fixture} (deleted-substrate findings={got})\n"
-                )
-        else:
-            sys.stderr.write(
-                f"self-test FAIL: {fixture} expected deleted-substrate "
-                f"findings={expected}, got {got}\n"
-            )
-            failures += 1
+        run_case(fixture, fixture, expected, label="deleted-substrate")
 
     # rf2-7gmtz5 — the TOOL-SPEC install!-convention exemption. Scanned AS IF the
     # fixture lived under `tools/xray/spec/` so `_scan_text` lights the
     # tool_spec_surface flag: a bare `install!` / `reinstall!` panel convention
     # stays GREEN, but a realm-specific retired symbol still FIRES there.
-    tool_spec_cases: list[tuple[str, int]] = [
-        ("negative/tool_panel_install_convention.md",   0),
-        ("positive/tool_spec_realm_symbol_fires.md",    1),
+    tool_spec_cases: list[tuple[str, frozenset[str]]] = [
+        ("negative/tool_panel_install_convention.md",   frozenset()),
+        ("positive/tool_spec_realm_symbol_fires.md",
+         frozenset({_SYMBOL + "dispose-realm!"})),
     ]
     for fixture, expected in tool_spec_cases:
-        path = _SELF_TEST_FIXTURE_ROOT / fixture
-        if not path.is_file():
-            sys.stderr.write(
-                f"self-test FAIL: tool-spec fixture {fixture!r} missing at "
-                f"{path}\n"
-            )
-            failures += 1
-            continue
-        text = path.read_text(encoding="utf-8", errors="replace")
         # A tools/<tool>/spec/ rel_posix lights the tool_spec_surface flag.
-        got = len(_scan_text(
-            path, text, rel_posix=f"tools/xray/spec/{Path(fixture).name}"
-        ))
-        if got == expected:
-            if verbose:
-                sys.stderr.write(
-                    f"self-test PASS: {fixture} (tool-spec findings={got})\n"
-                )
-        else:
-            sys.stderr.write(
-                f"self-test FAIL: {fixture} expected tool-spec findings="
-                f"{expected}, got {got}\n"
-            )
+        run_case(fixture, f"tools/xray/spec/{Path(fixture).name}", expected,
+                 label="tool-spec")
+
+    # ----------------------------------------------------------------------
+    # ROSTER COVERAGE — a roster entry without a fixture is a hard failure.
+    # ----------------------------------------------------------------------
+    #
+    # This is the assertion the four families were missing (rf2-57vnc). Every
+    # case above already asserted an exact count over a single-token fixture;
+    # what nothing asserted was that each entry in each alternation had a case
+    # AT ALL. Deleting `realm-ids`, `frame-realm`, `rf/app` or two thirds of the
+    # deleted-namespace alternation left the whole self-test green.
+    #
+    # `covered` is accumulated from the witnesses the fixtures actually
+    # produced, and the joined multi-match details are split so a line matching
+    # three claim shapes credits all three.
+    covered_entries: set[str] = set()
+    for witness in covered:
+        family, _, detail = witness.partition(":")
+        for entry in detail.split("+"):
+            covered_entries.add(f"{family}:{entry}")
+
+    rosters: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+        ("_STRONG_SYMBOLS", "retired-construction-symbol", _STRONG_SYMBOLS),
+        ("_RETIRED_FACADE_NOUNS", "retired-facade-noun-call",
+         tuple(f"rf/{n}" for n in _RETIRED_FACADE_NOUNS)),
+        ("_DELETED_NS_READS", "retired-deleted-namespace-read",
+         tuple(n for n, _p in _DELETED_NS_READS)),
+        ("_RETAINED_CLAIM_FORMS", "retired-substrate-retained-claim",
+         tuple(n for n, _p in _RETAINED_CLAIM_FORMS)),
+    )
+    for roster_name, family, entries in rosters:
+        uncovered = [e for e in entries
+                     if f"{family}:{e}" not in covered_entries]
+        if uncovered:
             failures += 1
+            sys.stderr.write(
+                f"self-test FAIL: {roster_name} entr(y/ies) with no fixture of "
+                f"their own: {', '.join(uncovered)}\n"
+                "      Plant each one in a positive fixture and declare its "
+                "witness. An alternation entry no case reaches can be deleted, "
+                "or typo'd, and stay green forever.\n"
+            )
 
     if failures:
         sys.stderr.write(f"\n{failures} self-test failure(s).\n")
@@ -1303,7 +1450,10 @@ def _run_self_tests(verbose: bool = False) -> int:
     total = (len(cases) + 1 + len(prose_cases) + len(deleted_substrate_cases)
              + len(tool_spec_cases))
     if verbose:
-        sys.stderr.write(f"all {total} self-tests passed.\n")
+        sys.stderr.write(
+            f"all {total} self-tests passed; every entry in "
+            f"{', '.join(r for r, _f, _e in rosters)} owns a fixture.\n"
+        )
     return 0
 
 

--- a/scripts/check_thrown_error_messages.py
+++ b/scripts/check_thrown_error_messages.py
@@ -1249,32 +1249,33 @@ def _run_self_tests(verbose: bool = False) -> int:
       * every `_STR_ERR_VAR_NAMES` spelling appears in a positive fixture.
     """
     _NO_TOKEN = "positive/bypass_let_bound_no_token.cljc"
+    BYPASS = "builder-bypass-message|"
     cases: list[tuple[str, frozenset[str]]] = [
         # (fixture-file relative to fixture-root, exact set of site names)
         # --- positives: each bare-keyword message shape must FIRE ---
         ("positive/literal_keyword_string.cljc",
-         frozenset({"<positive/literal_keyword_string.cljc>"})),
+         frozenset({"literal-keyword-string|<positive/literal_keyword_string.cljc>"})),
         ("positive/literal_keyword_multiline.cljc",
-         frozenset({"<positive/literal_keyword_multiline.cljc>"})),
+         frozenset({"literal-keyword-string|<positive/literal_keyword_multiline.cljc>"})),
         ("positive/str_literal_keyword.cljc",
-         frozenset({"<positive/str_literal_keyword.cljc>"})),
+         frozenset({"str-literal-keyword|<positive/str_literal_keyword.cljc>"})),
         ("positive/str_error_kw_var.cljc",
-         frozenset({"<positive/str_error_kw_var.cljc>"})),
+         frozenset({"str-error-keyword-var|<positive/str_error_kw_var.cljc>"})),
         ("positive/str_error_id_var.cljc",
-         frozenset({"<positive/str_error_id_var.cljc>"})),
+         frozenset({"str-error-keyword-var|<positive/str_error_id_var.cljc>"})),
         # The three `_STR_ERR_VAR_NAMES` spellings that had no fixture.
         ("positive/str_remaining_err_var_names.cljc", frozenset({
-            ":rf.error/str-error-keyword-var",
-            ":rf.error/str-err-kw-var",
-            ":rf.error/str-err-id-var",
+            "str-error-keyword-var|:rf.error/str-error-keyword-var",
+            "str-error-keyword-var|:rf.error/str-err-kw-var",
+            "str-error-keyword-var|:rf.error/str-err-id-var",
         })),
         ("positive/str_id_of_payload.cljc",
-         frozenset({"<positive/str_id_of_payload.cljc>"})),
+         frozenset({"str-id-of-payload|<positive/str_id_of_payload.cljc>"})),
         # --- positives for the WIDENED builder-bypass rule (rf2-krrv87) ---
         ("positive/bypass_str_concat_no_token.cljc",
-         frozenset({"<positive/bypass_str_concat_no_token.cljc>"})),
+         frozenset({"builder-bypass-message|<positive/bypass_str_concat_no_token.cljc>"})),
         ("positive/bypass_plain_string_no_token.cljc",
-         frozenset({"<positive/bypass_plain_string_no_token.cljc>"})),
+         frozenset({"builder-bypass-message|<positive/bypass_plain_string_no_token.cljc>"})),
         # --- positives for the let-binding resolution (rf2-u3otj): resolving a
         #     local must not become a way to PASS. A bound form with no token,
         #     an unresolvable parameter, the computed discriminator, a sibling
@@ -1283,12 +1284,12 @@ def _run_self_tests(verbose: bool = False) -> int:
         #     The computed-discriminator site builds its id across lines, so it
         #     is the one that answers to the file rather than to an id.
         (_NO_TOKEN, frozenset({
-            ":rf.error/bound-but-bare",
-            ":rf.error/param-message",
-            f"<{_NO_TOKEN}>",
-            ":rf.error/sibling-scope",
-            ":rf.error/shadowed-away",
-            ":rf.error/destructured",
+            BYPASS + ":rf.error/bound-but-bare",
+            BYPASS + ":rf.error/param-message",
+            BYPASS + f"<{_NO_TOKEN}>",
+            BYPASS + ":rf.error/sibling-scope",
+            BYPASS + ":rf.error/shadowed-away",
+            BYPASS + ":rf.error/destructured",
         })),
         # --- positives for the SCOPE PROOF (rf2-u3otj / the #7045 and #7064
         #     audits): a binder between the conformant outer `let` and the
@@ -1296,17 +1297,17 @@ def _run_self_tests(verbose: bool = False) -> int:
         #     fire — the #7045 nested-`fn`-parameter witness first, the #7064
         #     `fn` SELF-REFERENCE NAME (single- and multi-arity) last.
         ("positive/bypass_let_bound_shadowed.cljc", frozenset({
-            ":rf.error/fn-param-shadow",
-            ":rf.error/loop-shadow",
-            ":rf.error/if-let-shadow",
-            ":rf.error/doseq-shadow",
-            ":rf.error/catch-shadow",
-            ":rf.error/destructured-shadow",
-            ":rf.error/letfn-shadow",
-            ":rf.error/as-shadow",
-            ":rf.error/arity-shadow",
-            ":rf.error/fn-name-shadow",
-            ":rf.error/fn-name-arity-shadow",
+            BYPASS + ":rf.error/fn-param-shadow",
+            BYPASS + ":rf.error/loop-shadow",
+            BYPASS + ":rf.error/if-let-shadow",
+            BYPASS + ":rf.error/doseq-shadow",
+            BYPASS + ":rf.error/catch-shadow",
+            BYPASS + ":rf.error/destructured-shadow",
+            BYPASS + ":rf.error/letfn-shadow",
+            BYPASS + ":rf.error/as-shadow",
+            BYPASS + ":rf.error/arity-shadow",
+            BYPASS + ":rf.error/fn-name-shadow",
+            BYPASS + ":rf.error/fn-name-arity-shadow",
         })),
         # --- negatives: every conformant counterpart must stay GREEN ---
         ("negative/human_message_builder.cljc",      frozenset()),
@@ -1347,8 +1348,15 @@ def _run_self_tests(verbose: bool = False) -> int:
             continue
         lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
         findings = scan(path, include_tests=True)
+        # The KIND is half the witness. A site names WHERE the gate looked; the
+        # kind names WHICH RULE answered, and the two are independent: deleting
+        # three names from `_STR_ERR_VAR_NAMES` left every site in
+        # `str_remaining_err_var_names.cljc` still firing — as
+        # `builder-bypass-message` instead, since a bare `(str err-kw)` message
+        # carries no token either. Same lines, same count, same site names, a
+        # detector dead. Only the kind tells them apart.
         actual = frozenset(
-            _witness_of(lines, fixture, f.line) for f in findings
+            f"{f.kind}|{_witness_of(lines, fixture, f.line)}" for f in findings
         )
         if actual != expected:
             failures += 1

--- a/scripts/check_thrown_error_messages.py
+++ b/scripts/check_thrown_error_messages.py
@@ -261,8 +261,14 @@ _STR_LITERAL_KW_RE = re.compile(
 #     helper clones bind the keyword as `error-kw` / `error-id` /
 #     `error-keyword`. Scoped to those exact names so a `(str some-human-var)`
 #     never fires.
+#     The accepted spellings are a NAMED roster so the self-test can hold each
+#     to owning a fixture (rf2-n6ijg) — three of the five had none, and the
+#     alternation is built from it, so the pattern is unchanged.
+_STR_ERR_VAR_NAMES: tuple[str, ...] = (
+    "error-kw", "error-id", "error-keyword", "err-kw", "err-id",
+)
 _STR_ERR_VAR_RE = re.compile(
-    r"\(\s*ex-info\s+\(\s*str\s+(error-kw|error-id|error-keyword|err-kw|err-id)\s*\)"
+    r"\(\s*ex-info\s+\(\s*str\s+(" + "|".join(_STR_ERR_VAR_NAMES) + r")\s*\)"
 )
 
 # (d) (str (:rf.error/id <map>)) as the message — pull the discriminator off a
@@ -1196,54 +1202,138 @@ _SELF_TEST_FIXTURE_ROOT = (
 )
 
 
+# A planted site NAMES ITSELF in its ex-data. Every fixture already wrote a
+# distinct `:rf.error/id` on its `ex-info` line, which is the line a finding is
+# reported at — so the witness name was sitting there unread while two fixtures
+# aggregated seventeen sites under two counts (rf2-n6ijg).
+_WITNESS_ID_RE = re.compile(r":rf\.error/id\s+(:[\w.*+!?<>=/-]+)")
+
+
+def _witness_of(lines: list[str], fixture: str, line_no: int) -> str:
+    """The name of the site reported at `line_no`: its own `:rf.error/id` when
+    the ex-data opens on that line, else the fixture itself.
+
+    The fallback is what makes single-site fixtures need no ceremony — the file
+    IS the witness. It is also self-policing: two unnamed sites in one file
+    collapse onto the same name, and the distinctness check below reds.
+    """
+    raw = lines[line_no - 1] if 0 <= line_no - 1 < len(lines) else ""
+    m = _WITNESS_ID_RE.search(raw)
+    return m.group(1) if m else f"<{fixture}>"
+
+
+# Which fixture proves each roster, and (for the negative direction, where there
+# is no finding to read a name off) which entries it is claimed to cross.
+_BINDER_HEAD_FIXTURE = "negative/binder_heads_crossed_cleanly.cljc"
+_TRANSPARENT_HEAD_FIXTURE = "negative/transparent_heads_crossed.cljc"
+
+
 def _run_self_tests(verbose: bool = False) -> int:
-    cases: list[tuple[str, int]] = [
-        # (fixture-file relative to fixture-root, expected finding count)
+    """Scan each fixture and assert the EXACT set of sites that fired.
+
+    Counts were already exact. The hole was that a count cannot NAME a witness
+    (rf2-n6ijg): `bypass_let_bound_shadowed.cljc` plants eleven distinct binder-
+    family sites and `bypass_let_bound_no_token.cljc` six, and the whole proof
+    was the pair `(file, 11)` and `(file, 6)`. A dead site red anonymously —
+    "expected 11, got 10", with no way to say which — and any edit that made a
+    neighbouring site fire twice restored the count and greened it.
+
+    Each site is now asserted by NAME, read from the `:rf.error/id` it already
+    carried. Plus the two structural assertions:
+
+      * every `_VECTOR_BINDER_HEADS` and `_TRANSPARENT_HEADS` entry is crossed
+        by the negative fixture that owns its roster. This is the direction that
+        proves those rosters — a SHADOWING fixture cannot, because an
+        unrecognised head fails closed and refuses for the same reason a
+        recognised-but-shadowing one does, so deleting a head changed nothing.
+      * every `_STR_ERR_VAR_NAMES` spelling appears in a positive fixture.
+    """
+    _NO_TOKEN = "positive/bypass_let_bound_no_token.cljc"
+    cases: list[tuple[str, frozenset[str]]] = [
+        # (fixture-file relative to fixture-root, exact set of site names)
         # --- positives: each bare-keyword message shape must FIRE ---
-        ("positive/literal_keyword_string.cljc",     1),
-        ("positive/literal_keyword_multiline.cljc",  1),
-        ("positive/str_literal_keyword.cljc",        1),
-        ("positive/str_error_kw_var.cljc",           1),
-        ("positive/str_error_id_var.cljc",           1),
-        ("positive/str_id_of_payload.cljc",          1),
+        ("positive/literal_keyword_string.cljc",
+         frozenset({"<positive/literal_keyword_string.cljc>"})),
+        ("positive/literal_keyword_multiline.cljc",
+         frozenset({"<positive/literal_keyword_multiline.cljc>"})),
+        ("positive/str_literal_keyword.cljc",
+         frozenset({"<positive/str_literal_keyword.cljc>"})),
+        ("positive/str_error_kw_var.cljc",
+         frozenset({"<positive/str_error_kw_var.cljc>"})),
+        ("positive/str_error_id_var.cljc",
+         frozenset({"<positive/str_error_id_var.cljc>"})),
+        # The three `_STR_ERR_VAR_NAMES` spellings that had no fixture.
+        ("positive/str_remaining_err_var_names.cljc", frozenset({
+            ":rf.error/str-error-keyword-var",
+            ":rf.error/str-err-kw-var",
+            ":rf.error/str-err-id-var",
+        })),
+        ("positive/str_id_of_payload.cljc",
+         frozenset({"<positive/str_id_of_payload.cljc>"})),
         # --- positives for the WIDENED builder-bypass rule (rf2-krrv87) ---
-        ("positive/bypass_str_concat_no_token.cljc",     1),
-        ("positive/bypass_plain_string_no_token.cljc",   1),
+        ("positive/bypass_str_concat_no_token.cljc",
+         frozenset({"<positive/bypass_str_concat_no_token.cljc>"})),
+        ("positive/bypass_plain_string_no_token.cljc",
+         frozenset({"<positive/bypass_plain_string_no_token.cljc>"})),
         # --- positives for the let-binding resolution (rf2-u3otj): resolving a
         #     local must not become a way to PASS. A bound form with no token,
         #     an unresolvable parameter, the computed discriminator, a sibling
         #     (non-enclosing) scope, an inner binding that shadows a
         #     token-bearing outer one, and a destructured name all still fire.
-        ("positive/bypass_let_bound_no_token.cljc",      6),
+        #     The computed-discriminator site builds its id across lines, so it
+        #     is the one that answers to the file rather than to an id.
+        (_NO_TOKEN, frozenset({
+            ":rf.error/bound-but-bare",
+            ":rf.error/param-message",
+            f"<{_NO_TOKEN}>",
+            ":rf.error/sibling-scope",
+            ":rf.error/shadowed-away",
+            ":rf.error/destructured",
+        })),
         # --- positives for the SCOPE PROOF (rf2-u3otj / the #7045 and #7064
         #     audits): a binder between the conformant outer `let` and the
         #     `ex-info` shadows the name, and every binder family must still
         #     fire — the #7045 nested-`fn`-parameter witness first, the #7064
         #     `fn` SELF-REFERENCE NAME (single- and multi-arity) last.
-        ("positive/bypass_let_bound_shadowed.cljc",      11),
+        ("positive/bypass_let_bound_shadowed.cljc", frozenset({
+            ":rf.error/fn-param-shadow",
+            ":rf.error/loop-shadow",
+            ":rf.error/if-let-shadow",
+            ":rf.error/doseq-shadow",
+            ":rf.error/catch-shadow",
+            ":rf.error/destructured-shadow",
+            ":rf.error/letfn-shadow",
+            ":rf.error/as-shadow",
+            ":rf.error/arity-shadow",
+            ":rf.error/fn-name-shadow",
+            ":rf.error/fn-name-arity-shadow",
+        })),
         # --- negatives: every conformant counterpart must stay GREEN ---
-        ("negative/human_message_builder.cljc",      0),
-        ("negative/throw_error_bang.cljc",           0),
-        ("negative/str_concat_human_text.cljc",      0),
-        ("negative/keyword_as_reason_value.cljc",    0),
-        ("negative/keyword_in_exdata.cljc",          0),
-        ("negative/keyword_in_comment.cljc",         0),
-        ("negative/keyword_in_docstring.cljc",       0),
-        ("negative/inline_human_token_slim.cljc",    0),
+        ("negative/human_message_builder.cljc",      frozenset()),
+        ("negative/throw_error_bang.cljc",           frozenset()),
+        ("negative/str_concat_human_text.cljc",      frozenset()),
+        ("negative/keyword_as_reason_value.cljc",    frozenset()),
+        ("negative/keyword_in_exdata.cljc",          frozenset()),
+        ("negative/keyword_in_comment.cljc",         frozenset()),
+        ("negative/keyword_in_docstring.cljc",       frozenset()),
+        ("negative/inline_human_token_slim.cljc",    frozenset()),
         # --- negatives for the WIDENED builder-bypass rule (rf2-krrv87) ---
-        ("negative/bypass_inline_token_str_concat.cljc", 0),
-        ("negative/bypass_human_message_with_id.cljc",   0),
-        ("negative/bypass_marker_exempt.cljc",           0),
-        ("negative/bypass_no_error_id.cljc",             0),
+        ("negative/bypass_inline_token_str_concat.cljc", frozenset()),
+        ("negative/bypass_human_message_with_id.cljc",   frozenset()),
+        ("negative/bypass_marker_exempt.cljc",           frozenset()),
+        ("negative/bypass_no_error_id.cljc",             frozenset()),
         # --- negative for the let-binding resolution (rf2-u3otj): a conformant
         #     message bound one hop from the `ex-info` must stay GREEN.
-        ("negative/bypass_let_bound_token.cljc",         0),
+        ("negative/bypass_let_bound_token.cljc",         frozenset()),
         # --- negative for the SCOPE PROOF: crossing ordinary control flow (the
         #     `when` guard `re-frame.story/configure!` writes, an if/do/cond
         #     chain, a nested `let` binding another name, an `fn` self-named
         #     something else, a reader conditional) introduces nothing, so the
         #     resolution still holds.
-        ("negative/bypass_let_bound_guarded.cljc",       0),
+        ("negative/bypass_let_bound_guarded.cljc",       frozenset()),
+        # --- negatives that OWN a roster: one crossing per entry (rf2-n6ijg) ---
+        (_BINDER_HEAD_FIXTURE,      frozenset()),
+        (_TRANSPARENT_HEAD_FIXTURE, frozenset()),
     ]
 
     failures = 0
@@ -1255,17 +1345,41 @@ def _run_self_tests(verbose: bool = False) -> int:
             )
             failures += 1
             continue
-        got = len(scan(path, include_tests=True))
-        if got == expected:
-            if verbose:
-                sys.stderr.write(f"self-test PASS: {fixture} (findings={got})\n")
-        else:
-            sys.stderr.write(
-                f"self-test FAIL: {fixture} expected findings={expected}, "
-                f"got {got}\n"
-            )
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        findings = scan(path, include_tests=True)
+        actual = frozenset(
+            _witness_of(lines, fixture, f.line) for f in findings
+        )
+        if actual != expected:
             failures += 1
+            sys.stderr.write(f"self-test FAIL: {fixture}\n")
+            missing = sorted(expected - actual)
+            extra = sorted(actual - expected)
+            if missing:
+                sys.stderr.write(
+                    "      SITE DEAD — this fixture plants "
+                    f"{', '.join(missing)} and the gate did not flag it\n"
+                )
+            if extra:
+                sys.stderr.write(
+                    f"      UNEXPECTED site(s): {', '.join(extra)}\n"
+                )
+            continue
+        if len(findings) != len(actual):
+            failures += 1
+            sys.stderr.write(
+                f"self-test FAIL: {fixture} has {len(findings)} findings for "
+                f"{len(actual)} distinct site name(s) — a site that cannot be "
+                "told from its neighbour can die unseen. Give each planted "
+                "`ex-info` its own `:rf.error/id` on the `ex-info` line.\n"
+            )
+        elif verbose:
+            sys.stderr.write(
+                f"self-test PASS: {fixture} "
+                f"({', '.join(sorted(actual)) or 'green'})\n"
+            )
 
+    failures += _run_roster_self_tests(verbose=verbose)
     failures += _run_cli_self_tests(verbose=verbose)
 
     if failures:
@@ -1274,6 +1388,68 @@ def _run_self_tests(verbose: bool = False) -> int:
     if verbose:
         sys.stderr.write(f"all {len(cases)} fixture self-tests passed.\n")
     return 0
+
+
+def _crosses_head(text: str, head: str) -> bool:
+    """Does `text` open a `(<head> …)` form? The trailing class keeps `cond`
+    from answering for `condp` and `->` from answering for `->>`."""
+    return bool(re.search(r"\(" + re.escape(head) + r"[\s\[]", text))
+
+
+def _run_roster_self_tests(verbose: bool = False) -> int:
+    """Hold every roster entry to owning a case. Returns the failure count.
+
+    This is the assertion the fixtures could not make for themselves. Ten of the
+    sixteen `_VECTOR_BINDER_HEADS`, thirteen of the nineteen `_TRANSPARENT_HEADS`
+    and three of the five `_STR_ERR_VAR_NAMES` had no case at all, so each could
+    be deleted from its roster — or arrive misspelled — with the whole self-test
+    still green (rf2-n6ijg).
+    """
+    failures = 0
+    rosters: tuple[tuple[str, tuple[str, ...], tuple[str, ...], str], ...] = (
+        ("_VECTOR_BINDER_HEADS", tuple(sorted(_VECTOR_BINDER_HEADS)),
+         (_BINDER_HEAD_FIXTURE,),
+         "cross it with a clean binding vector; deleting the head must make "
+         "that case fire"),
+        ("_TRANSPARENT_HEADS", tuple(sorted(_TRANSPARENT_HEADS)),
+         (_TRANSPARENT_HEAD_FIXTURE,),
+         "nest a throw inside it; deleting the head must make that case fire"),
+        ("_STR_ERR_VAR_NAMES", _STR_ERR_VAR_NAMES,
+         ("positive/str_error_kw_var.cljc",
+          "positive/str_error_id_var.cljc",
+          "positive/str_remaining_err_var_names.cljc"),
+         "plant `(ex-info (str <name>) …)` in a positive fixture"),
+    )
+    for roster_name, entries, fixtures, remedy in rosters:
+        texts = []
+        for fixture in fixtures:
+            path = _SELF_TEST_FIXTURE_ROOT / fixture
+            if not path.is_file():
+                sys.stderr.write(
+                    f"self-test FAIL: {roster_name}'s fixture {fixture!r} is "
+                    f"missing at {path}\n"
+                )
+                failures += 1
+                continue
+            texts.append(path.read_text(encoding="utf-8", errors="replace"))
+        joined = "\n".join(texts)
+        if roster_name == "_STR_ERR_VAR_NAMES":
+            uncovered = [e for e in entries if f"(str {e})" not in joined]
+        else:
+            uncovered = [e for e in entries if not _crosses_head(joined, e)]
+        if uncovered:
+            failures += 1
+            sys.stderr.write(
+                f"self-test FAIL: {roster_name} entr(y/ies) no fixture "
+                f"exercises: {', '.join(uncovered)}\n"
+                f"      In {', '.join(fixtures)}: {remedy}.\n"
+            )
+        elif verbose:
+            sys.stderr.write(
+                f"self-test PASS: all {len(entries)} {roster_name} "
+                "entries have a case\n"
+            )
+    return failures
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Four self-tests whose assertions were already exact — and exact over the wrong thing. All four fixed, each mutation-proven before and after. Nothing weakened, no exclusion roster added to any live gate, and `check_ambient_durable_reads`' walk left exactly as it is (rf2-mjfj9's question, not this PR's).

**Method, per checker: kill exactly one detector, run `--self-test`, record the verdict. Before the fix and after.** Applied in-place with a byte-wise restore — an early run used `git checkout` to restore and silently reverted the fix under test, which is why the harness snapshots bytes.

## rf2-m147k — `check_freehand_conformance_index`: 26 cases proven by count alone

The census arm pinned a defect KIND per case and said in a comment why. The check arm beside it wrapped its cases as `[(name, n, None) for name, n in cases]`, hard-coding `kind=None`, so the same assertion was skipped for all 26.

| killed detector | before | after |
|---|---|---|
| the `area not in AREAS` roster check | **GREEN** | RED — `unknown_area_in_id red with the right COUNT and the wrong defect: expected ILL-FORMED ID; is not in the area roster, got 'AREA MISMATCH: …:7 [FH-BANANA-001] filed under the FH-CALL section'` |
| `_check_citation`'s no-`#anchor` rule | **GREEN** | RED — falls through to the missing-anchor lookup: `got '… spec/004-Views.md has no anchor #'` |
| the empty-Law rule | RED (count 1→0) | RED |
| the citation-outside-`spec/` rule | RED | RED |
| the duplicate-id rule | RED | RED |

Each of the 26 now names substrings unique to **its** rule — kind plus a reason fragment, because five citation cases and four applicability cases share a kind and differ only in the reason. `orphan_row`'s aggregate 2 is replaced by its two defects named separately. The `None`-forcing wrapper is gone, and a new `expected > 0` case that names no defect is itself a hard failure.

## rf2-g1xpb — `check_ambient_durable_reads`: 19/26 keys and 12/16 read forms never shown to fire

| killed roster entry | before | after |
|---|---|---|
| `deadline-at` | **GREEN** | RED — `this fixture plants deadline-at<-now-ms and the gate did not see it` |
| `created-at`…`installed-at` (5 keys) | **GREEN** | RED, naming all five |
| `js/location` | **GREEN** | RED — `instance-id<-js/location` |
| `(js/Date.now)` | **GREEN** | RED — `instance-id<-js/Date.now` |
| `navigator.` | **GREEN** | RED |
| `rand-nth` | **GREEN** | RED — `temp-id<-rand-nth` |
| `rand` | **GREEN** | RED — `temp-id<-rand` |
| `loaded-at` (had a fixture) | RED | RED |

Findings carry which key and which read form fired, read off the match already made. `_AMBIENT_READ_FORMS` names its sixteen entries and joins them into the identical alternation. Three fixtures carry the rosters — all 18 timestamp keys, all 8 id keys, the 14 exercisable read forms — asserted as an exact set of `key<-read-form` pairs.

**A trap I walked into, caught by re-running the matrix against the fix.** The first cut built the expected witness set as a comprehension over `_DURABLE_TIMESTAMP_KEYS`. Deleting `deadline-at` shrank the expectation in lockstep with the detector and the self-test stayed green — the bead's own bug, reproduced inside its fix. The expectations are written out literally now. A fixture's expectation must not be derived from the thing it checks.

**Two read forms cannot be exercised, and are declared rather than skipped.** `js/crypto.getRandomValues` and `(.getRandomValues js/crypto …)` both contain the literal text `getRandomValues`, which is itself an `_ALLOWLIST_WINDOW_RE` wrapper — a line matching either sits inside its own exemption window. Verified directly: both spellings written into a durable `:temp-id` yield **zero** findings. That is rider (c) working as designed. `_UNEXERCISABLE_READ_FORMS` records both with the reason, and the assertion runs both ways: an entry there that a fixture *does* cover fails as a stale exemption.

`rand-int` and `rand-nth` are subsumed by `rand` at the matching level — the finding survives either deletion. They are still provable, because attribution asks a stronger question: the roster entry stops *participating*, and its witness disappears. Tightening `rand` to exclude them would narrow a required gate, so it was not done.

## rf2-n6ijg — `check_thrown_error_messages`: 17 witnesses under two counts

| killed detector | before | after |
|---|---|---|
| `when-let` from `_VECTOR_BINDER_HEADS` | **GREEN** | RED — `UNEXPECTED site(s): builder-bypass-message\|:rf.error/binder-when-let` |
| `condp` from `_TRANSPARENT_HEADS` | **GREEN** | RED — names `transparent-condp` |
| `error-keyword`/`err-kw`/`err-id` from the var roster | **GREEN** | RED, naming all three |
| the `fn` self-reference-name check | RED **anonymously** — `expected findings=11, got 10` | RED — `this fixture plants builder-bypass-message\|:rf.error/fn-name-shadow and the gate did not flag it` |
| `let` / `do` (already had cases) | RED | RED |

**The witness name was already in the fixtures, unread.** Every planted `ex-info` carries a distinct `:rf.error/id` on the very line a finding is reported at, so each of the seventeen is asserted by name with no new marker syntax and no fixture churn. Single-site fixtures answer to their filename; two unnamed sites in one file collapse onto the same name and the distinctness check reds.

**One correction to the bead.** It counts `let/loop/fn/if-let/doseq/letfn` as exercised because the shadowing fixtures use them. They are not: `_crossing_is_transparent` fails **closed**, so an unrecognised head refuses for exactly the same reason a recognised-but-shadowing one does — a shadowing fixture cannot prove roster membership at all. A head earns its place by returning True when the vector is *clean*, so the proving case is a **negative** one. Two new negative fixtures own the two rosters, one case per entry, all 16 and all 19.

**Second trap, again caught by re-running the matrix.** Naming the site was not enough: deleting three names from `_STR_ERR_VAR_NAMES` came back green because every site kept firing as `builder-bypass-message` — a bare `(str err-kw)` message carries no token either. Same lines, same count, same site names, detector dead. A site names *where* the gate looked; the kind names *which rule answered*. The witness is `<kind>|<site>`.

## rf2-57vnc — `check_retired_composition_vocab`: 4/9 `_STRONG_SYMBOLS` with no fixture

| killed roster entry | before | after |
|---|---|---|
| `realm-ids` | **GREEN** | RED — `live_remaining_strong_symbols.md` names it |
| `frame-realm` | **GREEN** | RED |
| `rf/app` from the facade nouns | **GREEN** | RED — `live_rf_app_call.md` |
| `re-frame.app-value/` + `re-frame.migration/migration-map` | **GREEN** | RED, both named |
| `realm-readers-remain` claim shape | **GREEN** | RED |
| `app-owns` (had a fixture) | RED | RED |

The four family predicates returned a bare `True`, so every finding in a family was indistinguishable; they return the roster entry instead, still truthy/falsy so callers read the same answer. `_RETAINED_CLAIM_FORMS` and `_DELETED_NS_READS` report **every** matching alternative rather than the first — "retained internal substrate" matches three of the five claim shapes at once, and crediting a fixture with only the first would overstate it. Six fixtures added.

**Worth recording:** two of the new fixtures fired *twice* on first run — their own explanatory prose tripped the detector, because the deleted-substrate families read raw prose with inline spans unmasked, deliberately. Rewritten. A fixture that fires on its commentary is a fixture whose count means something other than what it says.

**Stale docstrings:** the bead named two `expected >= 1` docstrings; there are **three** — `check_inject_cofx_residue.py` carries the same sentence. All three assert `==`. Prose describing the fail-open shape rf2-e1xx0 removed is how it gets re-implemented, so all three now say the assertion is exact.

## Live behaviour is unchanged — finding sets, not exit codes

Each modified checker compared old-vs-new finding-by-finding (line, kind, snippet) over a wide corpus:

| checker | corpus | old | new | differing |
|---|---|---:|---:|---:|
| `check_ambient_durable_reads` | 3,106 source files, direct-file mode so the durable-write allow-list hides nothing | 56 | 56 | **0** |
| `check_thrown_error_messages` | 3,109 source files | 91 | 91 | **0** |
| `check_retired_composition_vocab` | 872 markdown files x 5 surfaces | 217 | 217 | **0** |

`check_freehand_conformance_index`'s change is confined to `_run_self_tests`. `_report` is untouched in every checker. The pruned `os.walk` from #7539 is untouched — the thrown-error live arm still enumerates the same 415 framework files, and `check_ambient_durable_reads` still scans its 18 durable-write namespaces with the walk exactly as rf2-mjfj9 left it.

## Quality gates

Foreground to completion, exit codes read from each runner.

| gate | exit | note |
|---|---|---|
| `sh scripts/test-fast-pr.sh` | **0** | 725 lines, terminal marker `PASS fast PR spine`, zero `FAIL` lines |
| `python scripts/check_fast_pr_gap.py --self-test` | **0** | `all self-tests passed.` |
| `python scripts/check_fast_pr_gap.py --check` | **0** | 75 required jobs, 26 covered — derivation intact |

All nine shared-walk checkers, both arms, in this worktree — `--self-test` and live each exit **0**: `check_ambient_durable_reads`, `check_thrown_error_messages`, `check_freehand_conformance_index`, `check_retired_composition_vocab`, `check_failure_corpus_residue`, `check_inject_cofx_residue`, `check_retired_image_keys`, `check_retired_spellings`, `check_keyword_catalogue_drift`.

The `node_modules` junction created for the spine was removed with `rmdir` and the mayor checkout re-counted: **101 entries before and after** (same counting method both times).

Closes rf2-g1xpb, rf2-n6ijg, rf2-m147k, rf2-57vnc.
