### PR TITLE
docs(hicasso): the records stop naming a function that does not exist (rf2-2rtt6.120)

### DIFF
--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1082,7 +1082,7 @@ cost is **unmeasured** and is named here rather than claimed away.
 > "No auto-conversion" means the return crosses UNCONVERTED — `render-callback`
 > ends in a bare `(apply f args)`, so a string renders and a vector reaches React
 > and is refused there. The author therefore has to make the element, and
-> `codec/as-element` is the conversion that would: it is INTERNAL, and nothing on
+> `codec/as-element` is the conversion that would do it — but it is INTERNAL, and nothing on
 > the taught `h/` roster reaches it. **So the recovery has no spelling an author
 > can write today.** That is an open gap, not a missing sentence, and it is what
 > `rf2-2rtt6.120` holds. In particular **there is no `h/as-element`** — this

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -1042,8 +1042,8 @@ cost is **unmeasured** and is named here rather than claimed away.
 > sentence stays below as the record of what was ruled first.
 >
 > **The defect.** Lowering captures the same var the poison replaced, so the row a
-> `renderRow` prop exists to build — `(h/as-element [:li {:on-click [:row/pick
-> id]} …])` — closed over the poison and raised at the USER'S click, for a click:
+> `renderRow` prop exists to build — `[:li {:on-click [:row/pick id]} …]` — closed
+> over the poison and raised at the USER'S click, for a click:
 > a legitimate event position that merely happened to be lowered during a render.
 > A render prop producing a non-interactive row worked; one producing an
 > interactive row did not — which is most of what render props are for — and the
@@ -1077,6 +1077,19 @@ cost is **unmeasured** and is named here rather than claimed away.
 > (`arm1/host_hatch_dom_cljs_test`), by its closure-level twin and the no-owner
 > edge (`front/intent_cljs_test`); the two purity edges — a direct dispatch inside
 > the call, and a synchronous lower-and-fire — are unmodified and still raise.
+>
+> **What the fence leaves open, stated rather than implied (`rf2-2rtt6.120`).**
+> "No auto-conversion" means the return crosses UNCONVERTED — `render-callback`
+> ends in a bare `(apply f args)`, so a string renders and a vector reaches React
+> and is refused there. The author therefore has to make the element, and
+> `codec/as-element` is the conversion that would: it is INTERNAL, and nothing on
+> the taught `h/` roster reaches it. **So the recovery has no spelling an author
+> can write today.** That is an open gap, not a missing sentence, and it is what
+> `rf2-2rtt6.120` holds. In particular **there is no `h/as-element`** — this
+> addendum illustrated the row with one until 2026-08-05, copied from
+> `front/intent/render-callback`'s own docstring, and so did four of the `[:>]`
+> design records under `studio/`. The docstring is corrected; the spelling was
+> never real.
 
 **Ruling.** Hicasso ships **one** callback form — `h/fn` (spelling unfrozen) — and
 it is **an ordinary function**. The contract comes from the **position**, because

--- a/docs/design/hicasso/studio/raw-escape-design-a-minimal.md
+++ b/docs/design/hicasso/studio/raw-escape-design-a-minimal.md
@@ -326,9 +326,13 @@ HD-011's conversions convert *children*, not prop values, so `{:fallback [:div "
 at a `[:> react/Suspense …]` becomes a JS array and React throws. This is existing
 `defhost` behaviour, but the escape is where authors will meet it, because
 `Suspense`-with-a-`:fallback` is one of the shapes the escape newly makes reachable.
-The remedy is `h/as-element` at the call site, whose product is a JS object that
-`host-prop-value` crosses raw. **This owes a guide troubleshooting row**; it does not
-owe a mechanism.
+The remedy would be a hiccup→element conversion at the call site, whose product is a
+JS object that `host-prop-value` crosses raw — and **there is no such conversion an
+author can call.** `codec/as-element` is the mechanism and it is internal; nothing on
+the taught `h/` roster reaches it, and there is no `h/as-element` (an earlier revision
+of this section named one; see `rf2-2rtt6.120`). So this owes **a ruling** — export a
+spelling, or say in the guide that the position has no recovery — before it can owe a
+troubleshooting row. What it does not owe is a mechanism: the conversion exists.
 
 ### What it costs
 

--- a/docs/design/hicasso/studio/raw-escape-design-b-correctness.md
+++ b/docs/design/hicasso/studio/raw-escape-design-b-correctness.md
@@ -464,9 +464,9 @@ exists for:
    the arming gate set in a `finally` and ownership resolved to the supplying boundary's
    frame — but that machinery is installed by `render-callback`, which is installed by a
    **declared** `:render` contract. `[:>]` declares nothing, so no wrapper is installed,
-   so the gate is never armed. A function prop supplied through `[:>]` that calls
-   `h/as-element` to build an interactive row is therefore lowering with **no ambient
-   frame**, and raises `:rf.error/hicasso-intent-outside-boundary`.
+   so the gate is never armed. A function prop supplied through `[:>]` that converts an
+   interactive row to an element is therefore lowering with **no ambient frame**, and
+   raises `:rf.error/hicasso-intent-outside-boundary`.
 
 That fourth fact is loud, not silent, and it lands at the library's call rather than at a
 user's click — which is the fail-closed side of the .74 defect rather than a return of it.
@@ -488,8 +488,18 @@ belongs in the guide's troubleshooting row beside the error id.
 
 **Witness.** Two rows. First, a **two-frame** page — the shape `rf2-2rtt6.74` used — where
 an intent inside a `[:>]` child dispatches into the writing boundary's frame and **not**
-into the other. Second, an `h/as-element` inside a function prop at a `[:>]` crossing
-raising `:rf.error/hicasso-intent-outside-boundary`, asserted by id.
+into the other. Second, a hiccup→element conversion inside a function prop at a `[:>]`
+crossing raising `:rf.error/hicasso-intent-outside-boundary`, asserted by id.
+
+**The second row cannot be written from the authoring surface today, and that is a
+finding rather than a fixture detail (`rf2-2rtt6.120`).** What raises is the *lowering*,
+and lowering only happens if something converts the row. The only conversion is
+`codec/as-element`, which is internal — there is no `h/as-element` (this section named one
+until 2026-08-05). A fixture may reach for the internal var and the row is then honest
+about what it proves; what it must not do is assert an author-facing recovery, because
+without the conversion the body returns a bare vector, nothing lowers, and the failure is
+React's *"Objects are not valid as a React child"* rather than this design's error id — a
+different row entirely.
 
 **What would make it vacuous.** A single-frame page cannot distinguish "the right frame"
 from "any frame" — that is why the first row needs two, and why it must assert the negative

--- a/docs/design/hicasso/studio/raw-escape-design-c-ergonomics.md
+++ b/docs/design/hicasso/studio/raw-escape-design-c-ergonomics.md
@@ -88,13 +88,15 @@ the entire subtree rather than bail out of it"* (`front/codec.cljs`, on
 (def Chart (react/lazy #(js/import "./chart.js")))
 
 (defview panel [_]
-  [:> react/Suspense {:fallback (h/as-element [:div.skeleton])}
+  [:> react/Suspense {:fallback [:div.skeleton]}   ; silently wrong — see below
    [:> Chart {:data (sub [:report/rows])}]])
 ```
 
 **What works.** `lazy` and `memo` products are JS objects React accepts as
 element types; the Component position passes them through (edge 4). `:data` is
-a collection, so it crosses via `clj->js`.
+a collection, so it crosses via `clj->js`. **`:fallback` does not**, and it is
+written above exactly as an author would write it, because the spelling that
+would have fixed it here does not exist — see below.
 
 **What goes wrong.** `{:fallback [:div.skeleton]}` — hiccup written in a **prop**
 — is the sharpest silent failure available at any foreign crossing. Hiccup
@@ -106,8 +108,17 @@ This is not new to `[:>]` — it is HD-011's shallow-conversion default and it
 bites identically at `defhost`. But `[:>]` is where a person meets an
 *unfamiliar* component, so it is where they are most likely to guess at a prop's
 shape. **Decision: no new machinery; one troubleshooting row** (§Diagnostics,
-row 9) and `h/as-element` named in it. Refusing "a vector at a non-event prop"
-is not available — a vector is legal data at a foreign prop and always will be.
+row 9). Refusing "a vector at a non-event prop" is not available — a vector is
+legal data at a foreign prop and always will be.
+
+**What that row can name is the gap, not a recovery (`rf2-2rtt6.120`).** The fix
+would be a hiccup→element conversion written at the call site. `codec/as-element`
+is that conversion, and it is INTERNAL: nothing on the taught `h/` roster reaches
+it, and **there is no `h/as-element`** — this section named one until 2026-08-05,
+a spelling copied from `front/intent/render-callback`'s docstring rather than
+resolved against the arm. Until the ruling lands, the row tells an author what
+went wrong and cannot tell them what to type, which is a weaker row than this
+design assumed when it priced the decision at "one troubleshooting row".
 
 ### 3. A component supplied through a render prop
 
@@ -115,20 +126,35 @@ is not available — a vector is legal data at a foreign prop and always will be
 (defview grid-panel [_]
   [:> DataGrid {:rows       (sub [:report/rows])
                 :renderRow  (h/fn [row]
-                              (h/as-element
-                                [:li {:on-click [:row/pick (:id row)]}
-                                 (:title row)]))}])
+                              ;; the return crosses UNCONVERTED, and this row is
+                              ;; a vector — see the incomplete note below
+                              [:li {:on-click [:row/pick (:id row)]}
+                               (:title row)])}])
 ```
 
-**What works — and this is the design's load-bearing claim.** `renderRow` is not
-event-spelled, so an `h/fn` there takes the **render contract**: `render-callback`
-captures both `*frame*` and `*dispatch*` at lowering time and rebinds them for
-each invocation, so the `:on-click` inside the row dispatches into *the boundary
-that supplied the callback*, however much later the grid calls it. That is
-`rf2-2rtt6.74`'s repair (PR #7449), and the escape inherits it **for free** —
-but only under edge 2's decision. Under the alternative (§Edge 2), an `h/fn`
-here would cross as a bare function with no contract at all, and the returned
-intent would silently never dispatch.
+**This example is INCOMPLETE, and it is the sharpest thing on the page
+(`rf2-2rtt6.120`).** `render-callback` ends in a bare `(apply f args)`, so a
+`:render` return crosses unconverted: a string renders, and the vector above
+reaches React and is refused with *"Objects are not valid as a React child"*.
+Something has to make an element of the row, and the only something is
+`codec/as-element`, which is internal — **there is no `h/as-element`**. This
+example was written with one until 2026-08-05, a spelling copied from
+`front/intent/render-callback`'s own docstring rather than resolved against
+`arm1/lang.clj` (which exports `defview`, `hfn` and `defhost`, and nothing else).
+The example is left in the shape an author would actually reach for, with the
+hole visible, rather than repaired with a call no reader can make.
+
+**What works — and this is the design's load-bearing claim — is orthogonal to
+that hole.** `renderRow` is not event-spelled, so an `h/fn` there takes the
+**render contract**: `render-callback` captures both `*frame*` and `*dispatch*`
+at lowering time and rebinds them for each invocation, so an `:on-click` inside
+the row dispatches into *the boundary that supplied the callback*, however much
+later the grid calls it. That is `rf2-2rtt6.74`'s repair (PR #7449), and the
+escape inherits it **for free** — but only under edge 2's decision. Under the
+alternative (§Edge 2), an `h/fn` here would cross as a bare function with no
+contract at all, and the returned intent would silently never dispatch. The claim
+is about *which frame the row's intent captures*, and it holds however the row
+comes to be an element.
 
 **What goes wrong.** The library spells its render prop `onRenderRow`. That
 matches `^on[A-Z]`, so the position is an *event* position, the `h/fn` takes the
@@ -521,9 +547,11 @@ lowering and throws when it is nil).
 A function child — `[:> Ctx.Consumer (fn [v] …)]`, the React context-consumer and
 headless-UI shape — passes through `as-element`'s `:else` branch and reaches the
 library as a function, which is correct. But the function's **return** is not
-walked: it must be an element, so the body writes `(h/as-element …)`. Getting
-that wrong hands React a ClojureScript vector as a child and React says
-*"Objects are not valid as a React child"*. §Diagnostics row 8.
+walked: it must already be an element. A body that returns hiccup hands React a
+ClojureScript vector as a child and React says *"Objects are not valid as a React
+child"* — and **the authoring surface has no conversion to reach for**, which is
+the same gap edges 2 and 3 hit and is tracked as `rf2-2rtt6.120`. §Diagnostics
+row 8.
 
 ### Reader cost
 
@@ -548,8 +576,8 @@ and are listed so a reviewer can see the escape adds three ids, not fifteen.
 | 5 | A `defhost` declaration in Component position | `:rf.error/hicasso-raw-hicasso-head` **new** | "`X` is a declaration — write `[X {…}]`" |
 | 6 | Empty `[:>]` — no component at all | `:rf.error/hicasso-raw-no-component` **new** | "`[:> Component props & children]` — the component is the second element" |
 | 7 | `h/fn` at an event-spelled prop the library treats as a render prop | *no new id* | Troubleshooting row: "a returned vector dispatches at an event position; `onRenderRow` is event-spelled. Declare the prop `:render` with `defhost`" |
-| 8 | A function child returning hiccup | React's own | Troubleshooting row: wrap with `h/as-element` |
-| 9 | Hiccup written in a **prop** | *none — silent* | Troubleshooting row: hiccup becomes elements in child position only; wrap the prop's value with `h/as-element` |
+| 8 | A function child returning hiccup | React's own | Troubleshooting row: the return is not walked and must already be an element — **and no taught spelling makes one** (`rf2-2rtt6.120`) |
+| 9 | Hiccup written in a **prop** | *none — silent* | Troubleshooting row: hiccup becomes elements in child position only — **and no taught spelling converts one here** (`rf2-2rtt6.120`) |
 | 10 | Node missing from server HTML | *none — by design* | Troubleshooting row: foreign regions are `:client-only`; `[:>]` has no declaration to say otherwise, so declare with `defhost` and set `:ssr` |
 | — | Intent vector outside a boundary | `:rf.error/hicasso-intent-outside-boundary` | inherited |
 | — | Vector at `:ref` | `:rf.error/hicasso-ref-vector-reserved` | inherited |

--- a/docs/design/hicasso/studio/raw-escape-spec.md
+++ b/docs/design/hicasso/studio/raw-escape-spec.md
@@ -523,12 +523,12 @@ every refusal message and guide row names what the arm actually exposes. Filed a
 > existed. **The implementation named a nonexistent function to explain itself**, and every
 > downstream document inherited it. Nothing gates the prose in a docstring against what its
 > module exports, which is how this reached four design records and one guide page before
-> anyone checked.
+> anyone checked — `rf2-2rtt6.128` asks whether that is worth a ratchet.
 >
-> Since corrected: the docstring (this PR), the guide's `05-interop.md` (PR #7523, which
+> Since corrected: the docstring (PR #7543), the guide's `05-interop.md` (PR #7523, which
 > also removed a `:render` hiccup return the page called "fine" — `render-callback` ends in
 > a bare `(apply f args)`, so the return crosses **unconverted** and a vector is refused by
-> React), and A, B, C and `decisions.md` above (this PR). **The arm ruling this clause asks
+> React), and A, B, C and `decisions.md` above (PR #7543). **The arm ruling this clause asks
 > for — export a spelling, or rule a different one — is still unmade**, so the records now
 > name the gap rather than a function; none of them invents a replacement. The parity
 > design is local-only and outside the tracked tree.

--- a/docs/design/hicasso/studio/raw-escape-spec.md
+++ b/docs/design/hicasso/studio/raw-escape-spec.md
@@ -501,18 +501,37 @@ neither made** — §3, the per-lowering wrapper destroying memo-bail-out identi
 **(d) The 12:06 comment ships a fork at the one edge whose argument is zero-fork**, while
 the same programme files `rf2-2rtt6.117` asking whether that fork should exist — §3.
 
-**(e) `h/as-element` is named as the recovery for the two sharpest silent traps at this
+**(e) `h/as-element` was named as the recovery for the two sharpest silent traps at this
 crossing, and it does not exist in the taught surface.** Designs A (hiccup in a prop), C
 (diagnostics rows 8 and 9, *and its entire render-prop worked example*), B (an edge-5
-witness) and the parity design (E5) all name it. Verified: **zero occurrences of
+witness) and the parity design (E5) all named it. Verified: **zero occurrences of
 `as-element` anywhere under `docs/design/hicasso/draft-guide/`**; the guide's taught `h/`
 roster is `h/hicasso`, `h/root`, `h/fn`, `h/render`, `h/defhost`, `h/presence`,
 `h/child-key` and `h/boundary`; `arm1/lang.clj` exports three macros — `defview`, `hfn`,
-`defhost` — and no `as-element`. The *mechanism* is public as `codec/as-element`
-(`codec.cljs:1708`); the *taught name* is not. **An error message naming a spelling the
-reader cannot call is worse than no message.** Either the arm exports the taught spelling in
-the same PR — one line — or every refusal message and guide row names what the arm actually
-exposes. Filed as `rf2-2rtt6.120`; the escape's PR must not be where this is discovered.
+`defhost` — and no `as-element`. The *mechanism* is public as `codec/as-element`; the
+*taught name* is not. **An error message naming a spelling the reader cannot call is worse
+than no message.** Either the arm exports the taught spelling in the same PR — one line — or
+every refusal message and guide row names what the arm actually exposes. Filed as
+`rf2-2rtt6.120`; the escape's PR must not be where this is discovered.
+
+> **Where it came from, and what has been done about it (2026-08-05, `rf2-2rtt6.120`).**
+> Four independent designs converging on a function that does not exist is not four
+> coincidences. The source is `front/intent/render-callback`'s **own docstring**, which
+> illustrated the row a `renderRow` prop exists to build with
+> `(h/as-element [:li {:on-click [:row/pick (:id row)]} (:title row)])` — so a designer
+> reading the function to understand the crossing reasonably concluded the spelling
+> existed. **The implementation named a nonexistent function to explain itself**, and every
+> downstream document inherited it. Nothing gates the prose in a docstring against what its
+> module exports, which is how this reached four design records and one guide page before
+> anyone checked.
+>
+> Since corrected: the docstring (this PR), the guide's `05-interop.md` (PR #7523, which
+> also removed a `:render` hiccup return the page called "fine" — `render-callback` ends in
+> a bare `(apply f args)`, so the return crosses **unconverted** and a vector is refused by
+> React), and A, B, C and `decisions.md` above (this PR). **The arm ruling this clause asks
+> for — export a spelling, or rule a different one — is still unmade**, so the records now
+> name the gap rather than a function; none of them invents a replacement. The parity
+> design is local-only and outside the tracked tree.
 
 **(f) The 12:06 comment drops two load-bearing carries**, both restored above: the X2
 body-run restatement (§8) and the `intent-outside-boundary` message repair (§5). A dispatcher
@@ -665,8 +684,10 @@ each names what would make it vacuous.
   HD-023(d), HD-024 and its Rationale.
 - [The SSR spike witness](ssr-spike-witness.md) — X1–X5 and X2's zero-mismatch obligation.
 - `implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs` — the snapshot
-  triple and `mint-host-gate!` (:1035–1066), `host-entry` (:1568–1613), `check-ref!`
-  (:624–654), `hiccup-tag?` / `vec->element` (:1664–1706), `as-element` (:1708).
+  triple and `mint-host-gate!`, `host-entry`, `check-ref!`, `hiccup-tag?`, `vec->element`,
+  `as-element`. **Cited by name, not by line.** This bullet carried line numbers until
+  2026-08-05 and three of the five were wrong by then, including the `as-element` citation
+  that clause (e) turns on; the file moves faster than a record of it can be trued up.
 - `arm1/hydrate_dom_cljs_test.cljs:414`; `arm1/lang.clj`; `docs/design/hicasso/draft-guide/`.
 - Beads: `rf2-2rtt6.106`, `.109`, `.115`, `.116`, `.117`, `.118`, `.119`, `.120`,
   `rf2-l0wfx`, `rf2-d03av`, `rf2-vrvv9`.

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs
@@ -562,12 +562,26 @@
   two different things, because lowering captures the same var the poison
   replaced. The row a `renderRow` prop exists to build —
 
-      (h/as-element [:li {:on-click [:row/pick (:id row)]} (:title row)])
+      [:li {:on-click [:row/pick (:id row)]} (:title row)]
 
   — closes over the poison and raises at the USER'S CLICK, for a click:
   a legitimate event position that merely happened to be LOWERED during a
   render (rf2-2rtt6.74). The law is \"dispatching from inside the call\",
   and a closure that will dispatch later is not that.
+
+  **The row above is written as hiccup, and hiccup is not what this
+  position returns.** This function ends in a bare `(apply f args)`, so a
+  `:render` return crosses UNCONVERTED: a string renders, a vector reaches
+  React and is refused there. Something has to turn the row into an
+  element, and the something is
+  [[re-frame.bench.hicasso.front.codec/as-element]] — which is INTERNAL.
+  Nothing on the authoring surface reaches it, so **the recovery this
+  paragraph describes has no spelling an author can write today**; that
+  gap is `rf2-2rtt6.120`, and it is a real gap rather than a missing
+  sentence. In particular there is **no `h/as-element`**: an earlier
+  revision of this docstring illustrated the row with one, and four design
+  documents copied the spelling out of here before anyone checked that it
+  resolved.
 
   So the wrapper captures the ambient dispatch AND frame at LOWERING
   time — the supplying boundary's, because the wrapper is minted during


### PR DESCRIPTION
Fixes the `h/as-element` myth in the tracked design records, and — the part that
matters — in the docstring that taught it to them.

`h/as-element` is named as the recovery for the two sharpest silent traps at a
foreign crossing: hiccup written in a **prop** (crosses as `clj->js` data and
renders as text, no error) and a function child or `:render` body returning
hiccup (React: *"Objects are not valid as a React child"*). It does not exist.
`arm1/lang.clj` exports exactly `defview`, `hfn` and `defhost`. The mechanism is
real and public as `codec/as-element`, but it is internal to the codec and no
`h/` spelling reaches it.

## The upstream

`implementation/freehand/test/re_frame/bench/hicasso/front/intent.cljs` —
`render-callback`'s own docstring illustrated the row a `renderRow` prop exists
to build with `(h/as-element [:li {:on-click [:row/pick (:id row)]} (:title row)])`.
Four independent design documents copied it from there. **The implementation
named a nonexistent function to explain itself.** Correcting the records while
leaving that intact would have guaranteed the next reader re-derives it, so the
docstring is corrected here. **Docstring-only** — the diff is entirely inside the
string literal; no executable form changed.

## The arm ruling is still unmade, and nothing here pre-empts it

The bead was left open for `(a)` export the taught spelling from `arm1/lang.clj`
versus `(b)` rule a different name. That ruling is unmade. So no record here
invents a replacement spelling — **a record naming a real gap beats one naming a
function that does not exist.** Each site now says what is available (the
mechanism, inside the codec), what is not (any authoring-surface spelling), and
that `rf2-2rtt6.120` holds the question. Every remaining occurrence of the string
`h/as-element` in the tracked tree is now an explicit negation of it, or the
spec's quotation of the docstring that seeded it.

## What changed, site by site

| File | Was | Now |
|---|---|---|
| `front/intent.cljs` (docstring) | `(h/as-element [:li …])` as the row a `renderRow` builds | bare hiccup row, plus a paragraph: the return crosses UNCONVERTED, the conversion is `codec/as-element` and is internal, the recovery has no author spelling, and there is no `h/as-element` |
| `decisions.md` HD-024 addendum | `(h/as-element [:li …])` in the defect statement | bare hiccup row; new **What the fence leaves open** clause spelling out that "no auto-conversion" leaves the author with no spelling, dated, with the myth named as retired |
| `raw-escape-design-a-minimal.md` §(e) | "The remedy is `h/as-element` at the call site … owes a guide troubleshooting row" | the remedy would be a conversion and none is callable; owes **a ruling** before it can owe a row |
| `raw-escape-design-b-correctness.md` edge 5 + witness | a function prop "that calls `h/as-element`"; witness row built on it | describes the conversion without naming a spelling; new note that **the witness cannot be written from the authoring surface today** — without a conversion nothing lowers and the failure is React's, not this design's error id |
| `raw-escape-design-c-ergonomics.md` §2 `Suspense` sample | `{:fallback (h/as-element [:div.skeleton])}` | `{:fallback [:div.skeleton]}` — written as an author would, with the trap visible and the prose pointing at it |
| `raw-escape-design-c-ergonomics.md` §2 decision | "one troubleshooting row … and `h/as-element` named in it" | the row can name the gap, not a recovery — which is a weaker row than the decision priced |
| `raw-escape-design-c-ergonomics.md` §3 render-prop example | the design's whole worked example built on `h/as-element` | marked **INCOMPLETE**, hole left visible, with the load-bearing frame-capture claim separated out (it is orthogonal and still holds) |
| `raw-escape-design-c-ergonomics.md` edge 5 | "the body writes `(h/as-element …)`" | the return must already be an element and the surface has no conversion to reach for |
| `raw-escape-design-c-ergonomics.md` Diagnostics rows 8, 9 | "wrap with `h/as-element`" | name the gap and cite `rf2-2rtt6.120` |
| `raw-escape-spec.md` §6(e) | the finding, tensed as present, citing `codec.cljs:1708` | tensed as recorded-and-acted-on, line citation dropped, plus a **Where it came from** block naming the docstring as the source and listing what has been corrected and what remains |
| `raw-escape-spec.md` §10 sources | five codec line numbers | cited by name — three of the five were already wrong |

## Two related facts the records now carry correctly

- **A `:render` return crosses UNCONVERTED.** `render-callback` ends in a bare
  `(apply f args)`, so returned hiccup reaches React and is refused. PR #7523
  removed this from the guide; design C's example carried the same error and now
  says so.
- **`[:>]` is not built.** Nothing here implies otherwise: the studio pages
  remain design records, and the corrections are all phrased as what the design
  *would* need, not as shipped behaviour.

## Quality gates

- **`sh scripts/test-fast-pr.sh` — exit 0**, `PASS fast PR spine`. Ran to
  completion (it outlived the 600s foreground cap and finished detached; the
  exit code is the real one, not a killed run's). Tiers armed: docs, JVM
  `core` + `freehand`, CLJS node. 12,630 tests / 63,251 assertions, 0 failures,
  0 errors; per-ns isolation 17/17; hicasso bench-lane compile 126 namespaces,
  0 warnings.
- **`python scripts/check_doc_slugs.py` — exit 0, and MUTATION-PROVED.** A
  broken file target and a broken anchor were appended to `raw-escape-spec.md`,
  **grep-confirmed present in the file before the run**, and the run failed
  naming both (`BROKEN TARGET … raw-escape-spec.md:695`, `BROKEN ANCHOR …
  raw-escape-spec.md:695`), exit 1. Reverted, grep-confirmed gone, exit 0 again.
- **`npm run test:hicasso-compile` — exit 0** (`intent.cljs` touched): 126 lane
  namespaces, 0 warnings. The spine runs it too, and it passed there as well.
- **clj-kondo on `intent.cljs` — 0 errors, 0 warnings.** Local binary is
  2025.10.23 against CI's pinned 2026.04.15, and the spine's own gap report says
  a differently-versioned local pass proves nothing — so the load-bearing result
  is **CI's `clj-kondo (fail on errors, warnings informational)` job.** The diff
  is inside a docstring literal, so no form reaches the linter differently.
- **The spine ran on the first commit**; the two commits after it change four
  lines of markdown prose in `docs/design/hicasso/` ("this PR" to `PR #7543`, a
  bead cross-reference, one dangling clause). `check_doc_slugs.py` and
  `check_readme_links.py` were both re-run green on the final commit, and CI's
  full matrix runs on the final SHA.
- `mkdocs build --strict` **deliberately not nominated**: `exclude_docs` keeps
  `docs/design/hicasso/**` out of the site, so it would exit 0 having verified
  nothing about this diff. (It runs inside the spine anyway, and passed — for
  the rest of the corpus.)
- **Tables hand-counted** (nothing validates them): design C's Diagnostics table
  header is `# | Trigger | Id | What it tells them to do` — **4 columns** — its
  separator row is 4, and edited rows 8 and 9 are **4 cells each**, unchanged in
  shape. A rectangularity sweep over all 23 tables in the five touched files
  found none ragged. The table in this PR body is 3 columns throughout.
- `git grep -n 'Users/miket'` over the tracked tree — no matches.

## Flagged, not resolved

- **The arm ruling `(a)` vs `(b)` remains open**, so `rf2-2rtt6.120` is not
  closed. The records and the guide are now truthful under either answer.
- **Filed `rf2-2rtt6.128`** — nothing gates a docstring's prose against what its
  module exports. Every executable surface is gated and a docstring is a string
  literal, which is how one docstring seeded four design records and a guide page
  while staying green. `scripts/check_retired_spellings.py` is the right home in
  kind; the wrinkle is that this PR deliberately leaves negations in the records,
  so a bare grep will not do.
- **Stale line citations into `codec.cljs` are a recurring class.**
  `as-element` is at `:1852` on main today; the bead says `:1708`, and `:1821`
  was correct only until this morning.
  `docs/design/hicasso/production-server-arm.md:205` carries the same class
  (`fragment-element (1420–1673)`, `vec->element (1677–1706)`) and is outside
  this PR's fence.
