### PR TITLE
test(ssr): the shared HydrationPayload schema forbids a present-nil render-hash (rf2-2rtt6.91)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
@@ -539,7 +539,13 @@
    [:rf/app-db          :any]
    [:rf/runtime-db      {:optional true} [:maybe :map]]
    [:rf/ssr-rendered-at {:optional true} :int]
-   [:rf/render-hash     {:optional true} [:maybe :string]]
+   ;; rf2-2rtt6.91 — `:string`, NOT `[:maybe :string]`. Spec-Schemas types the
+   ;; slot `{:optional true} :string`, so a present-and-nil `:rf/render-hash`
+   ;; is not a legal spelling of absence: an ADOPTION-TIER root (compiled
+   ;; `re-frame.ui`, native UIx, Freehand) carries no hash at either end and
+   ;; needs the key OMITTED. A `[:maybe :string]` slot admitted the forbidden
+   ;; shape, so this schema could not prove the contract it calls canonical.
+   [:rf/render-hash     {:optional true} :string]
    [:rf/schema-digest   {:optional true} [:maybe :string]]])
 
 (deftest build-payload-conforms-to-hydration-payload-schema
@@ -572,3 +578,42 @@
           (is (m/validate HydrationPayload payload)
               (str "minimal payload must conform; explain: "
                    (pr-str (m/explain HydrationPayload payload)))))))))
+
+;; ---- the hash channel is OPTIONAL at the shared builder (rf2-2rtt6.91) ----
+;;
+;; `build-payload` is shared verbatim by the non-streaming and streaming SSR
+;; paths, so the adoption-tier contract belongs here and not only at the one
+;; Hicasso caller that exercises it today. Per Spec 011 §Hydration-mismatch
+;; detection the hash channel is the HICCUP tier's: a hiccup-tier host hands a
+;; real hash and it rides the wire, while a compiled `re-frame.ui`, native UIx
+;; or Freehand root verifies by React adoption and hands nil. Nil must leave
+;; the key ABSENT — a present-and-nil key is a degenerate value wearing the
+;; shape of evidence, and the `:string` slot does not admit it.
+
+(deftest build-payload-render-hash-is-optional
+  (testing "a real hash is preserved verbatim (hiccup tier)"
+    (let [payload (payload-policy/build-payload
+                    :rf/default {:public/page :dashboard} "deadbeef" {})]
+      (is (= "deadbeef" (:rf/render-hash payload))
+          "a supplied hash rides the payload unchanged")
+      (is (m/validate HydrationPayload payload)
+          (str "a hashed payload conforms; explain: "
+               (pr-str (m/explain HydrationPayload payload))))))
+
+  (testing "a nil hash OMITS the key rather than stamping nil (adoption tier)"
+    (let [payload (payload-policy/build-payload
+                    :rf/default {:public/page :dashboard} nil {})]
+      (is (not (contains? payload :rf/render-hash))
+          "a nil render-hash omits :rf/render-hash entirely")
+      (is (= {:public/page :dashboard} (:rf/app-db payload))
+          "the rest of the payload is unaffected by the omission")
+      (is (m/validate HydrationPayload payload)
+          (str "a hashless adoption-tier payload conforms; explain: "
+               (pr-str (m/explain HydrationPayload payload))))))
+
+  (testing "a present-and-nil :rf/render-hash is REJECTED by the schema — what
+            makes the omission load-bearing rather than cosmetic"
+    (is (not (m/validate HydrationPayload
+                         (assoc (payload-policy/build-payload :rf/default {} nil {})
+                                :rf/render-hash nil)))
+        "a hand-stamped nil :rf/render-hash must not validate")))


### PR DESCRIPTION
Discharges the **`MERGED-PR AUDIT #7510`** remainder on `rf2-2rtt6.91`, quoted verbatim:

> `implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc:542` calls its inline `HydrationPayload` schema canonical but types `:rf/render-hash` as `{:optional true} [:maybe :string]`, while `Spec-Schemas.md` types it `{:optional true} :string` and this PR explicitly depends on present-nil being illegal. No `implementation/ssr` test calls `build-payload` with a nil render-hash. The Hicasso entry test protects today's caller, but the shared conformance test would accept the forbidden present-nil shape and cannot prove the generic builder's adoption-tier contract. Align that one schema slot and add focused shared cases proving nil omits the key and a real string is preserved; do not broaden into a payload-schema rewrite.

Both halves verified before editing. `Spec-Schemas.md:3799` types the slot `{:optional true} :string`; every `build-payload` call in `implementation/ssr/test/` passed a real string (`"h"`, `"h1"`, `"deadbeef"`, `"server-hash-1"`), so the nil path was reachable in production and unexercised in the shared suite.

## What changed

One slot, `[:maybe :string]` → `:string`, and one new `deftest`. `build-payload` itself is untouched — its `cond->` already omitted the key on nil; only the test that claims to prove it was too loose to.

The new `build-payload-render-hash-is-optional` carries three cases. A real hash rides the payload verbatim (hiccup tier). A nil hash omits the key entirely and the resulting payload still conforms (adoption tier). A hand-stamped nil `:rf/render-hash` is **rejected** by the schema — that third assertion is what makes the slot alignment load-bearing rather than cosmetic, since it is the one that goes red if the `[:maybe …]` ever returns.

Scope held to the audited slot. `:rf/schema-digest` (`[:maybe :string]`) and `:rf/runtime-db` (`[:maybe :map]`) are loose against the same spec block, and `:rf/head-hash` is missing from the inline schema altogether; `build-payload` provably never emits present-nil for any of them. That is the same class of gap next door, but widening this diff to reach it is the "payload-schema rewrite" the audit fenced off, so it is filed as **`rf2-cc7c6`** instead.

## Not changed, deliberately

The audit's other remainder — the SSR chapter's structural-hash claim — **is already discharged on `main`** and needed no edit. `docs/design/hicasso/draft-guide/10-server-side-rendering.md:52-56` already says Hicasso is not in the hiccup tier, that **no `:rf/render-hash` rides the wire**, and that verification is React's own adoption surfaced as `:rf.ssr/hydration-mismatch`; lines 58-64 give the attribute-only bound and the troubleshooting table row at line 185 says "It carries no hashes — this tier has none". That is exactly what the `#7484` audit asked for, landed by PR #7510.

## Quality gates

| Gate | Exit |
|---|---|
| `clojure -M:test -n re-frame.ssr.payload-policy-cljs-test` (from `implementation/ssr`) — 31 tests, 79 assertions | **0** |
| `python scripts/check_doc_slugs.py` | see below |
| `sh scripts/test-fast-pr.sh` | see below |

**Mutation proof — two mutations, each grep-confirmed landed before the exit code was read.**

Reverting the slot to `[:maybe :string]` reds the new test (1 failure: "a hand-stamped nil `:rf/render-hash` must not validate"). Forcing the builder's `cond->` arm to `true` so it always stamps the key reds it again (2 failures: the `contains?` assertion and the conformance assertion, the latter explaining `{:path [:rf/render-hash], :schema :string, :value nil}`). Both restored; the suite is green at HEAD. The guard is non-vacuous on both the schema side and the builder side.

**Tables:** one table added, in this PR body only — 2 columns in the header, 2 in the separator, 2 in each of 3 body rows. No markdown table is added or altered in the tracked tree.

`mkdocs build --strict` is deliberately not nominated: it excludes `docs/design/**` and would exit 0 having verified nothing. No doc file is touched by this diff in any case.