### PR TITLE
fix(docs): a docstring cannot name a symbol that does not exist — measured, 7 sites fixed, no checker warranted (rf2-2rtt6.128)

### DIFF
--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -1259,7 +1259,7 @@
 ;;
 ;; `:adapter/after-render` for React-only substrates (UIx) per
 ;; rf2-334d9 (Mike decision rf2-neiqf 2026-05-19: publish via
-;; useLayoutEffect) — without this `(rf/after-render f)` under those
+;; useLayoutEffect) — without this `(interop/after-render f)` under those
 ;; adapters would be a silent no-op.
 ;;
 ;; Architecture. Per-adapter queue cell + a sentinel function component
@@ -1277,7 +1277,7 @@
 ;; root`, Helix's `(.render root …)`), which bypasses `make-render` —
 ;; so a natively-mounted UIx app NEVER has a sentinel in its tree.
 ;; Reagent's `r/after-render` is a global post-flush hook that works
-;; regardless of mount path; without parity, the SAME `(rf/after-render
+;; regardless of mount path; without parity, the SAME `(interop/after-render
 ;; f)` call has correct post-commit timing on Reagent but degraded
 ;; microtask timing on natively-mounted UIx — a silent substrate
 ;; divergence in a public primitive.
@@ -1389,7 +1389,7 @@
             (compare-and-set! set-tick-ref set-tick nil)))
         #js [set-tick])
       ;; No deps array — fires every commit, which is the contract
-      ;; (rf/after-render bumps the tick to force a commit, so the
+      ;; (interop/after-render bumps the tick to force a commit, so the
       ;; useLayoutEffect fires and drains).
       (React/useLayoutEffect
         (fn layout-effect []
@@ -3170,7 +3170,7 @@
 ;;     lifecycle question (when does the next commit complete?), not a
 ;;     reactive-atom one — so the "no reactive primitive" rationale that
 ;;     excludes the four hooks above does NOT apply. Without this hook
-;;     `(rf/after-render f)` under these adapters would be a silent
+;;     `(interop/after-render f)` under these adapters would be a silent
 ;;     no-op.
 ;;   :adapter/wrap-view — rf2-00li. Substrate-side source-coord injection
 ;;     via React.cloneElement (the views.cljs inline hiccup-walk would

--- a/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
+++ b/implementation/core/test/re_frame/adapter/react_shared_suite.cljs
@@ -2933,7 +2933,7 @@
   The defect this pins: the Fragment-wrap after-render sentinel only
   enters the tree on the `:render`-slot path. The documented idiom mounts
   natively (createRoot + .render), bypassing `make-render`, so a natively-
-  mounted UIx app had NO sentinel — `(rf/after-render f)` degraded
+  mounted UIx app had NO sentinel — `(interop/after-render f)` degraded
   to a bare microtask FOREVER, defeating the post-commit-timing contract
   Reagent's global `r/after-render` honours regardless of mount path. The
   fix arms a per-adapter SINGLETON DRIVER ROOT the first time after-render

--- a/implementation/flows/src/re_frame/flows/registry.cljc
+++ b/implementation/flows/src/re_frame/flows/registry.cljc
@@ -595,7 +595,7 @@
      ;; instead of trusting a bare nil-check, capture the live incarnation TOKEN
      ;; here and REVALIDATE it INSIDE the serialized mutation (below), under the
      ;; frame's `:drain-lock` — the SAME lock `destroy-frame!` flips liveness
-     ;; under (`frame/call-with-drain-lock-on-record!`). Registration and
+     ;; under (`frame/call-serialized-with-drain!`). Registration and
      ;; destruction therefore linearize on one frame-owned gate: a destroy that
      ;; wins makes the revalidation observe a nil / different token and refuse
      ;; (no ghost row); a registration that wins publishes its row, which the

--- a/implementation/flows/test/re_frame/flows_reg_flow_destroy_linearization_test.clj
+++ b/implementation/flows/test/re_frame/flows_reg_flow_destroy_linearization_test.clj
@@ -21,7 +21,7 @@
       token INSIDE the serialized mutation, under the frame's `:drain-lock`.
 
     - `destroy-frame!` flips liveness (`mark-frame-destroyed!`) under the SAME
-      `:drain-lock` (`frame/call-with-drain-lock-on-record!`, keyed on the
+      `:drain-lock` (`frame/call-serialized-with-drain!`, keyed on the
       captured record so it still serializes after the record is dissoc'd).
 
   Registration and destruction therefore linearize on one reentrant gate:


### PR DESCRIPTION
Closes rf2-2rtt6.128.

The bead asked whether anything can gate a docstring's prose against what
actually exists. **The deliverable is a measurement, seven fixes, and a
recommendation NOT to build the checker** — the general check scores 0%
precision and 0% recall on this tree, and the narrow ratchet the bead
proposed would be red against main's own fix for this very bead.

## What the sweep measured

Every tracked `.clj` / `.cljc` / `.cljs` file (3,110 files, 3,061
namespaces): extract docstrings, find every `prefix/name` token in them,
resolve `prefix` through the file's own `ns` `:require` map, and ask
whether the target namespace defines `name`.

| query | hits |
|---|---|
| docstring names a qualified symbol its resolved ns does not define | **2,983** |
| …restricted to a LOCAL alias (prefix is in this file's `ns` form) | 259 |
| …further restricted to an indented CODE BLOCK | 35 |
| …further minus a retirement/negation marker in the sentence | **19** |
| of those 19, genuine defects | **0** |

**Genuine phantom spellings in the whole tree: 3, across 8 prose sites.**
Extending the sweep from docstrings to `;;` comments found **no new
spelling** — only more sites of the same three.

## What this PR fixes

`h/as-element` (the bead's origin instance) was fixed on main
independently while this PR was in flight, so it is no longer in the diff.
The remaining two spellings — **7 of the 8 sites** — are fixed here:

1. **`rf/after-render` — 5 sites.** `react_shared_suite.cljs`'s
   `assert-after-render-fires-on-native-mount` spells one call two ways a
   paragraph apart: `(interop/after-render f)` in the summary,
   `(rf/after-render f)` in the defect note. The same phantom then appears
   in four `;;` comments in `substrate/spine.cljs` — the implementation
   that suite pins, which requires `re-frame.interop :as interop` and
   carries no `rf` alias at all. `re-frame.core` exports no `after-render`
   on either platform (JVM `ns-publics`: 116 publics, absent; zero
   occurrences of the string in `core.cljc`). All five now read
   `interop/after-render`.
2. **`frame/call-with-drain-lock-on-record!` — 2 sites.** A docstring in
   `flows_reg_flow_destroy_linearization_test.clj` and the `;;` comment in
   `flows/registry.cljc` that states the same fact. No such var:
   `:drain-lock` is a KEY on the frame record, not a function. The real one
   is `frame/call-serialized-with-drain!`, whose own docstring names exactly
   this caller ("the `destroy-frame!` liveness flip
   (`mark-frame-destroyed!`)"), and which `frame.cljc:1148` already spells
   correctly for the same fact.

## Why no checker (the measurement, not an opinion)

**The proposed ratchet would be red against main's own fix.** The bead
suggested a bare grep for `h/as-element` on the reasoning that the spelling
"is not sanctioned anywhere, so a bare git-grep has no false positives".
Main's fix, landed while this PR was in flight, writes into the very same
docstring:

> In particular there is **no `h/as-element`**: an earlier revision of this
> docstring illustrated the row with one, and four design documents copied
> the spelling out of here before anyone checked that it resolved.

That is the correct repair — and a `h/as-element` ratchet fires on it. The
gate and the fix cannot both be right.

**The discriminator cannot separate a mistake from a deliberate note.** The
dominant legitimate use of "a docstring naming a symbol that does not
exist" in this tree is a **retirement note** — this repo's EP-0007 "One
Name Per Fact" discipline *requires* naming retired spellings. Every one of
the ~14 `rf/*` candidates hand-verified was one:

- `rf/dispose-adapter!` — "→ `rf/destroy-adapter!`", a test PINNING the rename
- `rf/sub-topology` — "rf2-80mmlf **demoted** the `rf/sub-topology` facade alias"
- `rf/replace-app-db!` / `rf/handler-ids` / `rf/runtime-db-value` /
  `rf/snapshot-of` — "API-shrink #3 **retired** …", "the **removed** `rf/handler-ids`"
- `rf/epoch-listener-generation` / `-observing?` — quoting the OLD composite
  under a "## The defect this closes" heading

A gate on this class would fight the repo's own documentation discipline.

**The best available discriminator scores 0% precision and 0% recall.**
Applying the bead's own proposal (code-block position + local alias + no
negation marker) leaves 19 survivors, and hand-verification finds **zero**
defects among them — English word-pairs (`headers/cookies`, `frame/query`),
concept names (`frame/profile`), React component exports
(`machine-canvas/Chart`), `reg-view` ids (`shell/event-list`), and line-wrap
artefacts (`trace-state/current-state-`). Worse, the same filter catches
**neither** real instance: `h/as-element`'s prefix is not a local alias
(`intent.cljs` requires no `h`), and `rf/after-render` is inline prose, not
a code block. Widening to non-local prefixes to reach them re-admits 1,543
findings — `docs/core` (a path), `tools/call` (an MCP JSON-RPC method),
`request/reply` (English).

**Ground truth is not soundly computable statically.** "Does this namespace
export X?" is defeated three independent ways in this tree:

- **macro indirection** — `(rm/defreg-macro reg-flow …)`, `(defwrapper …)`,
  `(defui …)`, and `(def ^{:doc "…multi-line…"}\n  frame-provider …)`;
- **reader-conditional platform splits** — `frame-provider` is a real CLJS
  facade export and absent from JVM `ns-publics`;
- **optional-artefact conditional re-exports** — `clear-flow` /
  `machine-meta` are on the facade only when the artefact is on the
  classpath, so the same docstring is correct or wrong depending on deps.

A checker wrong on any of these reds a legitimate docstring, which is
strictly worse than no checker.

**And the ratchet would not have caught the propagation anyway.** The
spelling travelled docstring → **`.md` design records**
(`studio/raw-escape-design-{a,b,c}.md`, `raw-escape-spec.md`,
`decisions.md`), which no source-suffix gate scans. Extending it to `.md`
ships a gate red on arrival against 11 occurrences in
`docs/design/hicasso/**`. That tree needs no repair: `raw-escape-spec.md`
§(e) already rules the spelling out in terms — "`h/as-element` … does not
exist in the taught surface" — i.e. the synthesis caught it, which is the
studio process working. The rest are historical proposals and a quotation
of the defect, both correct as records.

**Nothing was weakened.** No existing checker was modified, relaxed, or
folded into. No gate was added, so `check_gate_scheduling.py`'s
reachability derivation and `check_fast_pr_gap.py`'s literal
one-invocation-per-line spine parse are untouched — both re-verified below.

## Quality gates

| gate | exit | note |
|---|---|---|
| `python scripts/check_gate_scheduling.py --self-test` | **0** | all checks passed |
| `python scripts/check_gate_scheduling.py --verbose` | **0** | |
| `python scripts/check_fast_pr_gap.py --self-test` | **0** | all self-tests passed |
| `python scripts/check_fast_pr_gap.py --check` | **0** | gap map clean; 76 required jobs / 3 workflows |
| `npm run test:hicasso-compile` | **0** | runner marker: "ok — 126 lane namespaces compiled with zero warnings" (re-run after the `spine.cljs` edit) |
| `npm run test:script-helpers` | **0** | |
| `npm run test:script-policy` | **0** | |
| `sh scripts/test-fast-pr.sh` | **0** | ran to completion; **0 `FAIL` lines**; runner's own marker: `PASS fast PR spine` |
| `clj-kondo` — 5 touched files | **0** | **errors 0**, 34 warnings, all pre-existing |
| `clj-kondo` — full CI lint surface | 3 | **errors 10, warnings 4534** — see below |

**clj-kondo.** The CI pin is **2026.04.15**; npm's newest published build is
**2025.10.23** (2026.04.15 is not on npm — CI installs it from the upstream
release script). Ran at 2025.10.23 over the exact CI lint surface. Warnings
**4,534**, at the ≈4,536 baseline. The 10 errors are all `Expected:
throwable, received: boolean/nil/string` in `implementation/ui/**` and
`implementation/epoch/**` test files — **none of which this PR touches**;
local-version type-inference skew, pre-existing. Linting the 5 touched files
alone is **errors 0**.

**Diff is prose-only.** Every hunk is inside a string literal or a `;;`
comment. No form, arity, or binding changes.

**`scripts/test-fast-pr.sh`.** Exit **0**, run to completion, zero `FAIL`
lines, terminal marker `PASS fast PR spine`. It ran against the pre-rebase
tree; the rebase changed only `intent.cljs` (dropped from this diff in
favour of main's own fix), so every file this PR still touches is byte-identical
to what the spine saw. On a
first attempt the `changed-surfaces` stage reported 132 failures whose
messages were child-process **spawn** failures
(`Error: Command failed: git ls-files -s -- scripts/check-beads-pr-boundary.sh`)
against files that plainly exist and assertions unrelated to this diff. Both
constituent stages pass standalone at exit 0 (`test:script-helpers`,
`test:script-policy`, above), and the same `git`/`bash` spawns succeed from
node directly — local Windows execution-environment contention, not a code
signal.
