### PR TITLE
perf(ci): the ambient durable-reads walk prunes what it never examined (rf2-mjfj9)

### DIFF
--- a/scripts/check_ambient_durable_reads.py
+++ b/scripts/check_ambient_durable_reads.py
@@ -118,6 +118,14 @@ so adding a durable-write namespace is a conscious one-line edit here. `.clj` /
 deliberately exercising the violating shape is correct, not drift);
 `--include-tests` lifts that for the self-test fixtures.
 
+The gate scans SOURCE trees. Generated and vendored copies are out of scope —
+a durable-write source file copied into a build cache (`out/`, `.shadow-cljs/`,
+`node_modules/`, `target/`, `.cpcache/`) is not a durable-write namespace, it is
+an artefact OF one, and the genuine violation is still flagged at its real
+authored path. That is the ruling on rf2-mjfj9, and it is what the eight
+sibling shared-walk checkers already assume; `_EXCLUDE_DIR_NAMES` below makes
+it explicit here rather than leaving it to the `endswith` accident.
+
 Exit code:
     0  no ambient durable read in any durable-write namespace
     1  at least one ambient durable read (results printed file:line)
@@ -129,8 +137,10 @@ Dependency-light — Python stdlib only.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
+import tempfile
 from pathlib import Path
 from typing import Iterable, NamedTuple
 
@@ -181,6 +191,20 @@ DURABLE_WRITE_SUFFIXES: tuple[str, ...] = (
 )
 
 _SOURCE_SUFFIXES = (".clj", ".cljc", ".cljs")
+
+# Directory names whose contents are generated or vendored, never authored
+# durable-write source. Matches the roster the eight sibling shared-walk
+# checkers carry. See the module docstring's SCAN SURFACE note for the scope
+# ruling (rf2-mjfj9) that put it here.
+_EXCLUDE_DIR_NAMES = frozenset({
+    "node_modules",
+    "target",
+    "out",
+    ".shadow-cljs",
+    ".git",
+    ".beads",
+    ".cpcache",
+})
 
 _TEST_DIR_NAMES = frozenset({"test", "tests"})
 
@@ -428,15 +452,41 @@ def _iter_durable_write_files(
     Direct-file mode (scan_root.is_file()) bypasses the suffix allow-list — the
     self-test fixtures ARE the durable-write surface for the purposes of the
     test, so a fixture file is scanned regardless of its path.
+
+    PRUNED, not filtered-after (rf2-mjfj9; method proven by rf2-76c76 in the
+    three sibling gates it shipped). `_EXCLUDE_DIR_NAMES` is dropped from
+    `os.walk`'s dirnames IN PLACE, so a built checkout never descends into
+    `.shadow-cljs` (35.4k entries), `node_modules` (3.4k), `out` or `target`.
+    This gate scans the WHOLE repo root — `rglob("*")` enumerated ~48k entries
+    to reach 18 allow-listed files, 7.0s of its 8.4s wall clock on a built
+    tree.
+
+    Unlike the three gates rf2-76c76 shipped, the prune here is NOT a pure
+    no-op: this gate had no exclusion roster, so it reached a durable-write
+    source file COPIED into a build cache (the suffix allow-list is matched
+    with `endswith`, which matches the tail of a nested path). Dropping those
+    is a deliberate scope decision, ruled on rf2-mjfj9 — see the module
+    docstring. On the real tree it drops 0 of 18 files.
+
+    The surviving sequence is ordered IDENTICALLY: the collected matches go
+    through ONE GLOBAL `sorted()`, reproducing `sorted(rglob("*"))`'s whole-
+    subtree ordering rather than os.walk's directory-grouped order.
     """
     if scan_root.is_file():
         if scan_root.suffix in _SOURCE_SUFFIXES:
             yield scan_root
         return
-    for path in sorted(scan_root.rglob("*")):
-        if path.suffix not in _SOURCE_SUFFIXES:
+    scan_prefix_len = len(scan_root.as_posix()) + 1
+    matches: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(scan_root):
+        dirnames[:] = [d for d in dirnames if d not in _EXCLUDE_DIR_NAMES]
+        for name in filenames:
+            if os.path.splitext(name)[1] in _SOURCE_SUFFIXES:
+                matches.append(Path(dirpath) / name)
+    for path in sorted(matches):
+        parts = set(path.as_posix()[scan_prefix_len:].split("/"))
+        if parts & _EXCLUDE_DIR_NAMES:
             continue
-        parts = set(path.relative_to(scan_root).parts)
         if not include_tests and (parts & _TEST_DIR_NAMES):
             continue
         if _is_durable_write_file(path, repo_root):
@@ -732,6 +782,60 @@ _NEGATIVE_FIXTURES: tuple[str, ...] = (
 )
 
 
+_SCOPE_FIXTURE_TEXT = (
+    "(ns fixtures.scope\n"
+    '  "Cache-copy scope fixture — see _run_scope_self_test."\n'
+    "  (:require [re-frame.interop :as interop]))\n"
+    "\n"
+    "(defn install [entry] (assoc entry :loaded-at (interop/now-ms)))\n"
+)
+
+
+def _run_scope_self_test(verbose: bool = False) -> int:
+    """Prove BOTH halves of the rf2-mjfj9 scope ruling, per roster entry.
+
+    The authored durable-write path is scanned; a byte-identical copy of it
+    nested in a build cache is not. Both halves matter: dropping the first
+    would make the gate toothless, and the second is the scope narrowing the
+    prune introduced, so it is asserted rather than assumed.
+
+    Built in a temp tree because the real repo contains no cache-nested copy to
+    assert against — which is precisely why the old `endswith`-only reach went
+    unnoticed for so long. Every `_EXCLUDE_DIR_NAMES` entry is exercised, so a
+    roster entry can never be added without a witness (the hole rf2-g1xpb
+    closed for the key rosters, held here for the directory roster).
+    """
+    suffix = DURABLE_WRITE_SUFFIXES[0]
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp).resolve()
+        authored = root / suffix
+        authored.parent.mkdir(parents=True, exist_ok=True)
+        authored.write_text(_SCOPE_FIXTURE_TEXT, encoding="utf-8")
+        for cache_dir in sorted(_EXCLUDE_DIR_NAMES):
+            nested = root / "implementation" / cache_dir / suffix
+            nested.parent.mkdir(parents=True, exist_ok=True)
+            nested.write_text(_SCOPE_FIXTURE_TEXT, encoding="utf-8")
+
+        findings = scan(root, root)
+        flagged = sorted({f.path.resolve() for f in findings})
+
+    if flagged != [authored]:
+        sys.stderr.write(
+            "self-test FAIL: scope — the gate must flag the AUTHORED durable-"
+            "write path and no cache-nested copy of it (rf2-mjfj9).\n"
+            f"      expected exactly: {authored}\n"
+            f"      got {len(flagged)} path(s): "
+            f"{', '.join(str(p) for p in flagged) or '(none)'}\n"
+        )
+        return 1
+    if verbose:
+        sys.stderr.write(
+            "self-test PASS: scope (authored path flagged; a copy nested in "
+            f"each of the {len(_EXCLUDE_DIR_NAMES)} excluded dir(s) is not)\n"
+        )
+    return 0
+
+
 def _run_self_tests(verbose: bool = False) -> int:
     """Scan each fixture and assert the EXACT set of witnesses it yields.
 
@@ -740,7 +844,7 @@ def _run_self_tests(verbose: bool = False) -> int:
     finding. Direct-file scan mode is used so the suffix allow-list does not
     hide the fixtures (the fixture IS the durable-write surface under test).
 
-    Four assertions, each closing a different way for the gate to go quietly
+    Five assertions, each closing a different way for the gate to go quietly
     toothless (the shape `check_retired_image_keys` arrived at, rf2-e1xx0):
 
       1. Per positive fixture, the witness set must match EXACTLY, and the
@@ -754,6 +858,8 @@ def _run_self_tests(verbose: bool = False) -> int:
       4. Every read form in `_AMBIENT_READ_FORMS` owns a witness, except the
          declared-unexercisable pair — and a declared entry that DOES get
          covered fails too, so the exemption cannot go stale.
+      5. SCOPE (rf2-mjfj9): the authored durable-write path is scanned and a
+         cache-nested copy of it is not — see `_run_scope_self_test`.
     """
     failures = 0
     checked = 0
@@ -869,6 +975,8 @@ def _run_self_tests(verbose: bool = False) -> int:
             "self-test FAIL: _UNEXERCISABLE_READ_FORMS names form(s) that are "
             f"not in the roster at all: {', '.join(unknown)}\n"
         )
+
+    failures += _run_scope_self_test(verbose=verbose)
 
     if failures:
         sys.stderr.write(f"\n{failures} self-test failure(s).\n")


### PR DESCRIPTION
`check_ambient_durable_reads` is the biggest single win of the nine shared-walk checkers rf2-76c76 measured, and the only one it deliberately left on the table. It scans the **whole repo root**, so `sorted(rglob("*"))` enumerated ~48k entries on a built checkout to reach **18** allow-listed files.

It was left because, unlike its eight siblings, it had **no `_EXCLUDE_DIR_NAMES`**. It excluded build trees only *incidentally*, via `DURABLE_WRITE_SUFFIXES` matched with `str.endswith()` — which matches the **tail** of a nested path, so a durable-write source file copied into `out/` or `.shadow-cljs/` was scanned. Pruning therefore **narrows** the gate. That is a scope decision on a required invariant gate, not a perf change, and #7539 correctly reverted it and filed rf2-mjfj9 rather than making the call.

**rf2-mjfj9 rules it NO**: the gate scans SOURCE trees. A cache copy is an artefact *of* a durable-write namespace, not one, and the genuine violation is still flagged at its authored path.

## The change

The standard sibling shape — the roster dropped from `os.walk`'s `dirnames` **in place**, plus the belt-and-braces post-filter the three shipped siblings kept:

```python
_EXCLUDE_DIR_NAMES = frozenset({
    "node_modules", "target", "out", ".shadow-cljs", ".git", ".beads", ".cpcache",
})
```

Every entry is a generated or vendored tree that cannot contain authored durable-write source: `node_modules` (npm), `target` + `.cpcache` (Clojure build/classpath cache), `out` + `.shadow-cljs` (shadow-cljs compiler output), `.git` (object store), `.beads` (issue-tracker export). It is the roster the ruling enumerated and the same one the siblings carry.

**One `sorted()` after collection is load-bearing** and is retained: `os.walk`'s directory-grouped order is *not* `sorted(rglob("*"))`'s whole-subtree order.

## Equivalence — findings, not exit codes

Reusing #7539's harness method, since a faster gate that matches less is worse than a slow one.

**1. Path sequences, element by element** — old (`origin/main`, extracted with `git show`) vs new, on the built mayor checkout **and** the clean worktree, 16 scan roots x both `include_tests`: **identical in set AND order, 64/64 comparisons.** Root and `implementation` yield 18 both ways; `resources` 11, `core` 2, `machines` 2, `http`/`routing`/`ssr` 1 each.

**2. Full `--verbose` stdout+stderr, byte-identical**, old vs new as real subprocesses — built mayor checkout and clean worktree, both `include_tests` settings, **4/4 rc 0/0**. Both report `scanning 18 durable-write namespace file(s)...`.

**3. Synthetic corpus.** The whole tracked tree (**5,009 files**) plus **522 planted violating fixtures**: 18 appended to the authored durable-write paths, and **504 nested inside every excluded directory** (7 dirs x 4 depths x 18 suffixes), including the pathological `tools/<excluded>/vendored/implementation/resources/src/re_frame/resources/events.cljc` shape.

| | old | new |
|---|---:|---:|
| total findings | 1,044 | 36 |
| only-old | — | 1,008 |
| only-new | — | **0** |
| **LIVE findings (outside excluded dirs)** | **36** | **36** |

**Every one of the 1,008 divergent findings is a planted copy under an excluded directory** — the ruled scope change, exactly and only. **Live findings differ by 0.** On the real tree the prune drops **0 of 18** files and **0 of 0** findings; the gate is green before and after.

**4. The harness is non-vacuous.** Adding one word (`resources`) to the roster — a silent narrowing of a directory that genuinely holds durable-write source — drops 1,030 findings, **22 of them LIVE**, and the comparison catches it.

## Scope self-test (the ruling's rider)

The ruling welcomed "one focused scope self-test (authoritative path scanned, cache-nested copy not)". `_run_scope_self_test` builds a temp tree with the authored durable-write path and a byte-identical copy nested under **each of the seven** roster entries, and asserts the gate flags **exactly** the authored one. Holding it per-entry means a roster entry can never be added without a witness — the hole rf2-g1xpb closed for the key rosters, now held for the directory roster.

It lives in a temp tree because the real repo contains no cache-nested copy to assert against, which is precisely why the `endswith` reach went unnoticed.

**#7541's repair is intact and untouched**: 17 fixtures still assert their witness sets by name, expectations are still written out literally rather than derived from `_DURABLE_TIMESTAMP_KEYS`, and all 26 durable keys / 14 of 16 read forms are still covered with the 2 declared unexercisable. **rf2-vcjpx's scope is untouched** — those 2 declared-unexercisable forms are unchanged and the gate still does not reach a host read wrapped in a call.

## Measurement

Median of 5, live `--verbose` arm, real subprocess so interpreter startup is included, python 3.14, Windows.

| checkout | before | after | |
|---|---:|---:|---:|
| **built mayor checkout** | **6.92s** | **0.78s** | **8.8x, 6.14s saved** |
| clean worktree (**what CI runs**) | 0.71s | 0.46s | 1.5x |

**CI is unaffected either way.** These run in bare-checkout Python jobs with no `npm ci` and no build — CI's tree is the clean column. This is a local-lane fix, worth ~6s off every `test-fast-pr.sh` run on a long-lived checkout.

`test-fast-pr.sh` is **not touched**, so `check_gate_scheduling.py` / `check_fast_pr_gap.py`'s literal one-invocation-per-line derivation is intact — verified below, not tidied into a loop.

## Quality gates

Foreground to completion; exit codes read from each runner's own terminal marker, never through a pipe.

| gate | exit | note |
|---|---|---|
| `python scripts/check_ambient_durable_reads.py --self-test --verbose` | **0** | 17 fixtures + the new scope arm; 26/26 durable keys, 14/16 read forms (2 declared unexercisable) |
| `python scripts/check_ambient_durable_reads.py --verbose` (live) | **0** | `scanning 18 durable-write namespace file(s)...` |
| `python scripts/check_gate_scheduling.py --self-test` | **0** | `all checks passed` |
| `python scripts/check_gate_scheduling.py` (live) | **0** | 40 gate commands, 33 scheduled, 7 declared — derivation intact |
| `python scripts/check_fast_pr_gap.py --self-test` | **0** | `all self-tests passed` |
| equivalence harness (both directions) | **0** | 64 path comparisons + 4 byte-identical stdout runs + corpus + non-vacuity |
| `sh scripts/test-fast-pr.sh` | **1 — environmental, see below** | JVM core 2215 tests / 11527 assertions, 0 failures; CLJS `:node-test` build completed 2152 files, 0 warnings |

**The spine's single failure is environmental and is not attributable to this diff.** The run reached `CLJS node integration` and failed one test — `deliberately-failing-test-exits-nonzero`'s *negative control*, which spawns a subprocess and asserts it exits 0. That subprocess died with:

```
SHADOW import error ...shadow.js.shim.module$markdown_it.js
Error: Cannot find module 'markdown-it'
```

`markdown-it` is declared in `implementation/package.json` and present in the mayor checkout's `node_modules`. The worker worktree's `implementation/node_modules` junction was **removed out from under the running gate** when this PR merged and worktree hygiene reaped the checkout mid-run — the same reap de-registered the worktree and deleted the remote branch. Everything before that point passed, including the full `:node-test` compile that *needs* `node_modules`. A killed run's exit code carries no signal about the diff.

Two independent confirmations that the landed code is sound:

* **CI is fully green** — 15 checks pass, 0 fail, 69 correctly skipped for a single-Python-file diff. `Repo invariant checks` (which runs both arms of this gate) passed on Linux / python 3.12, printing `self-test PASS: scope ...`, `all 17 self-test fixture(s) passed`, and `scanning 18 durable-write namespace file(s)... / no ambient durable-world reads`. `No hardcoded personal/home paths` passed.
* **Every gate above was re-run against merged `main` in the built mayor checkout after the merge**, and the equivalence harness reproduces byte-for-byte: `old=1044 new=36 only-new=0`, live findings `36 = 36, 0 differing`.

The mayor checkout's `node_modules` was re-counted after the reap: **2,933 files / 103 top-level, identical to the pre-run baseline** — the reap unlinked the junction before removing the worktree, as designed, so nothing was followed into the real tree.
