### PR TITLE
feat(hicasso): defhost :ssr :render, and a fallback refuses at mint (rf2-l0wfx, rf2-nv07k)

### DIFF
--- a/docs/EP/EP-0038-the-hicasso-view-layer-programme.md
+++ b/docs/EP/EP-0038-the-hicasso-view-layer-programme.md
@@ -280,7 +280,12 @@ taken by the operator. The design record carries the matching HD-020 addendum
   - **R4 — the live page.** Events and the controlled door work
     post-hydration to the `rf2-2rtt6.67` equivalence standard.
   - **R5 — the `defhost` SSR policy is activated.** HD-011's declared
-    placeholder becomes the real `:ssr` option.
+    placeholder becomes the real `:ssr` option — **three values as of
+    2026-08-05** (`rf2-l0wfx`): `:client-only` (the default), a
+    `{:fallback …}`, and `:render`, which is the author asserting the
+    component is server-safe and is the only policy under which a crossing's
+    children reach the server response. A declared fallback is inert markup by
+    enforcement (`rf2-nv07k`).
   - **R6 — the ledger discipline holds server-side.** HD-002's discipline is
     unbroken on the server: a server render is an abandoned render, leaving
     zero durable registration.

--- a/docs/design/hicasso/decisions.md
+++ b/docs/design/hicasso/decisions.md
@@ -341,6 +341,102 @@ instance props can express.
 
 ## HD-011 — The interop door
 
+> **Addendum, 2026-08-05 — there is a THIRD `:ssr` value, `:render`, and a
+> declared fallback is inert markup by enforcement (`rf2-l0wfx`, `rf2-nv07k`,
+> ruled together).** This amends the 2026-08-04 addendum immediately below,
+> which stands as the dated record it is; what it got wrong it got wrong for a
+> reason worth keeping, which is that the provider witness did not yet exist.
+>
+> **What the two-value ruling could not express.** Both of its values answer
+> *"what stands in for this component until the client takes over"*, and both
+> return something that is not the component — so `props.children` is dropped
+> on that arm. For a leaf widget that is correct; there are no children. For a
+> **transparent wrapper** it deletes the application. A context provider —
+> *"providers an ecosystem library hands you"*, one of this decision's five
+> named use cases — contributes no markup of its own and exists solely to carry
+> a subtree, so a provider at a crossing takes every descendant out of the
+> server response. Measured through `renderToString` on the arm1 bench: the
+> page's `<h1>` sibling present, `<p class="body">` and the whole subtree under
+> it simply gone. And **silent by construction** — the gate's server snapshot
+> is what hydration's first client pass reads too, so the two agree, no
+> mismatch is reported and nothing reaches the diagnostic bus.
+>
+> **The third value is `:ssr :render`, and it is an assertion**: *this
+> component is safe to render on the server*. For that policy `mint-host!`
+> mints **no gate** — the head's `gate` slot carries the foreign component
+> itself, which is this decision's original zero-wrapper, zero-fiber, zero-hook
+> shape restored for the hosts that can take it. Same component, same props,
+> same children, on the server, on hydration's first pass and on a fresh
+> `createRoot` mount: **one tree everywhere**, so zero mismatch by identity
+> rather than by a snapshot pair agreeing, no adoption event, and no remount.
+> For the case that filed it the assertion is trivially true — a
+> `Context.Provider` is React's own component and the server renderer supports
+> context fully, so consumers below read the **declared** value in the server
+> HTML.
+>
+> **Why not `:ssr :children`** — render `props.children` in place of the
+> component — which is the reading most authors reach for and what the design
+> record recommended. Three defects, the first measured: it restores the markup
+> and **not the value**, so every consumer below reads the context DEFAULT
+> server-side (`unset` against the provider's `dark`) and silent-absent becomes
+> silent-wrong; it **remounts at adoption**, because React reconciles a
+> position by element type and the position's type goes from the children to
+> the Provider, destroying and rebuilding the subtree it just hydrated; and on
+> a non-transparent wrapper it emits HTML structurally unlike the client render
+> while both passes agree, so nothing reports it. `:children`, `:transparent`,
+> `:passthrough` and `:server` all stay refused. The spelling `:render` names
+> both the conduct (the component renders) and the assertion (it is safe to).
+>
+> **`:client-only` remains the DEFAULT** and the conservative reason below
+> stands unamended: a foreign React component is exactly the node whose render
+> may reach for `window`, and the door cannot know. `:render` is the author
+> saying, which is a different thing from the door guessing — a policy that
+> inferred the answer from whether a call site passed children was rejected on
+> exactly that law.
+>
+> **The fallback half (`rf2-nv07k`).** The addendum below says a fallback is
+> walked once at the declaration; the corollary the guide teaches from that —
+> *a fallback is inert markup* — was **stated and not enforced**. What the walk
+> refused was what it could EVALUATE: an intent vector, a `sub` call in the
+> form, hiccup that is not hiccup. A boundary head is none of those — it is an
+> element whose body runs later — so the walk never looked inside it, and the
+> "placeholder" was a live boundary reading subscriptions in the server
+> response. Two measurements made that a defect rather than a narrow rule:
+> **the declared placeholder was not a value** (one declaration rendering
+> `ALPHA`, `BRAVO` and `ALPHA-TWO` — the walk-once law's own justification
+> falsified by what it permitted), and **it did not survive this arm's other
+> boundary variant** (a frame-fed head bakes a `nil` frame at mint and throws
+> mid-server-render, so whether it worked at all depended on which mint the
+> head came from). The mint now walks a declared fallback **structurally** and
+> refuses a `defview` or `defhost` head at any position —
+> `:rf.error/hicasso-host-fallback-boundary-head`, naming the host, the head's
+> `displayName` and its index route into the form. Walk-scoped, so it covers
+> the frame-fed variant without knowing it exists.
+>
+> The workaround this deletes — writing a provider's subtree a second time as
+> the declaration's fallback, which was `rf2-l0wfx`'s only recovery — is
+> **superseded**, not merely removed: `:render` renders the real subtree, with
+> the real context value, once.
+>
+> **What `:render` does NOT solve, recorded rather than glossed.** A provider
+> whose *value* is genuinely client-only — `window`-derived — still has no
+> server story: that value is computed in the caller's body, so such a host
+> stays `:client-only` and everything below it is client-only too. No candidate
+> solved that case, and `:children` would have solved it wrongly by rendering
+> the subtree under the default value.
+>
+> **`[:>]` is unchanged.** The escape carries no declaration, so it carries no
+> server-safety assertion either: it renders nothing server-side, and it must
+> never grow an `:ssr` spelling of its own. The answer to *"my provider
+> vanished server-side"* is now "declare it, with `{:ssr :render}`" — which
+> finally works.
+>
+> Witnessed in `arm1/host_ssr_dom_cljs_test` (the refusal roster, the
+> server-render children and context rows, and the hydration row that counts
+> mounts), `arm1/fallback_contents_cljs_test` (the refusal, both directions,
+> with every legitimate fallback position proven individually) and
+> `ssr/entry_cljs_test` (the corpus row, at a handed-in and a nested position).
+
 > **Addendum, 2026-08-04 — the SSR placeholder listed among the defaults below
 > is BUILT, and it is a declaration option with two values (`rf2-2rtt6.85`).**
 > HD-020(d) held this default "declared policy for later phases, inert in v0";
@@ -826,7 +922,10 @@ boundary**: the runtime ships one internal class-based boundary exposed as
 "real error boundary". (d) **SSR is out of v0**, explicitly: `defview` bodies
 are `.cljc`-compatible by construction (no JS in tier-1 forms), but no JVM/SSR
 render path ships in v0; `defhost`'s SSR-placeholder default is declared policy
-for later phases, inert in v0.
+for later phases, inert in v0. *(Superseded 2026-08-04: the operator's SSR
+ruling makes SSR required scope, and `defhost`'s `:ssr` is built — see HD-011's
+2026-08-04 addendum, and its 2026-08-05 one for the third value. The clause is
+kept as the dated record of what v0 was scoped to.)*
 **Rationale.** Each is a decision a v0 implementer would otherwise have to make
 ad hoc mid-spike; none is reversible for free once witnesses pin behaviour.
 **(a) reaches further than a boundary shell, and (c) is what proved it**

--- a/docs/design/hicasso/defhost-ssr-provider-costing.md
+++ b/docs/design/hicasso/defhost-ssr-provider-costing.md
@@ -1,5 +1,23 @@
 # Pricing the provider SSR hole (`rf2-l0wfx`)
 
+> **RULED 2026-08-05 — candidate B won, and the page below is now the dated
+> record of how it was priced rather than a live question.** The operator ruled
+> `rf2-l0wfx` and `rf2-nv07k` together: `defhost`'s `:ssr` gains a third value,
+> **`:ssr :render`** (this page's candidate B), and a declared fallback becomes
+> inert markup by enforcement. **A was refused** on the two defects measured
+> below — the wrong context value server-side and the remount at adoption — and
+> **C** on the door-does-not-guess law, exactly as this page recommended
+> against; **D** contradicts the required-scope SSR ruling. The full ruling and
+> its conduct are the 2026-08-05 addendum under HD-011 in
+> [`decisions.md`](decisions.md); the implementation is `front/codec.cljs`'s
+> `declared-ssr` / `mint-host!` / `refuse-deferring-heads-in-fallback!`.
+>
+> Two things below are now stale and are left as written rather than patched,
+> because a dated pricing that has been edited is no longer evidence: the
+> workaround in §"A workaround exists" is **deleted** by the fallback refusal,
+> and the bill's Freehand roster stands — `v/defhost` did not move, and the
+> two doors diverge for the reason the bill gives.
+
 > **A costed proposal. No contract changed, no ruling taken.** `defhost`'s `:ssr`
 > is public surface on a shipped declaration form, so the choice below is the
 > operator's. This page exists to make it cheap and safe to take: what actually

--- a/docs/design/hicasso/draft-guide/05-interop.md
+++ b/docs/design/hicasso/draft-guide/05-interop.md
@@ -65,7 +65,7 @@ of the view tree as data. Friction once; free at every use site. The Reagent
 | `:class` values | the class slot's own coercion, exactly as at a native tag — a collection joins (`["btn" nil :on]` → `"btn on"`) and two spellings of the class compose rather than one overwriting the other |
 | Children | hiccup → React elements |
 | Functions | pass through unconverted |
-| SSR | `:client-only` — nothing server-side until the client adopts. Override with `:ssr`: `:client-only`, or `{:fallback <hiccup>}` for placeholder markup. Bad policy → `:rf.error/hicasso-host-bad-ssr-policy` at mint. Full story: [Server-side rendering](10-server-side-rendering.md) |
+| SSR | `:client-only` — nothing server-side until the client adopts. Override with `:ssr`: `:client-only`, `{:fallback <hiccup>}` for placeholder markup, or `:render` to assert the component is server-safe and let it render there with its children. Bad policy → `:rf.error/hicasso-host-bad-ssr-policy` at mint. Full story: [Server-side rendering](10-server-side-rendering.md) |
 
 Two options today: `:callbacks` (next section) and `:ssr`. An unknown option is
 refused at mint (`:rf.error/hicasso-host-unknown-option`), not ignored. Bad
@@ -155,11 +155,35 @@ An intent with neither a marker nor `::h/prevent` never touches its arguments, s
 A library provider is just a component:
 
 ```clojure
-(h/defhost themed (.-Provider some-context))
+(h/defhost themed (.-Provider some-context) {:ssr :render})
 ```
 
 Consumers below the crossing read context correctly — the node is a real React
 element, so React's plumbing runs through.
+
+**Write the `{:ssr :render}`.** A provider is a *transparent wrapper*: it
+contributes no markup of its own and exists solely to carry a subtree. Under the
+default `:client-only` policy a crossing renders nothing until the client adopts
+it — and "nothing" includes the children, so on a server-rendered page the
+provider takes the whole subtree beneath it out of the response. Nothing reports
+that: the server HTML and hydration's first client pass agree, so there is no
+mismatch and no warning, and the page simply appears after hydration.
+
+`:ssr :render` is you asserting that this component is safe to run on a server,
+and a context provider is the case where that is trivially true — it is React's
+own component, and React's server renderer supports context fully. The
+declaration then mints no gate at all: the component *is* the element, so the
+server render, hydration's first pass and a fresh mount are all one tree, and
+consumers below read the value you declared rather than the context default.
+
+If the provider's *value* is genuinely client-only — derived from `window`, say
+— `:render` cannot help you, because that value is computed in the caller's body.
+Keep such a provider `:client-only` and accept that everything below it is too.
+
+A fallback is not the way out of this. `{:fallback …}` renders *instead of* the
+crossing rather than around it, and it is inert markup: a `defview` or `defhost`
+head written into one is refused at the declaration
+(`:rf.error/hicasso-host-fallback-boundary-head`).
 
 ## Memo and hosted components
 
@@ -329,6 +353,7 @@ path. Nothing in the reserved vector will rescue that later.
 |---|---|
 | Turning hiccup into an element at a prop or a `:render` return | **Open, and a real gap.** The mechanism exists inside the codec; nothing on the taught `h/` roster reaches it, so today the answer is to write the subtree where children lower — or to write it twice |
 | Declarable conversion defaults on `defhost` | Open — `:callbacks` and `:ssr` are the two options today |
+| A provider whose *value* is client-only | Open, and named rather than solved. `:ssr :render` renders the component server-side, but the value it carries is computed in the caller's body — so a `window`-derived value has no server story and the host stays `:client-only` |
 | Migration codemod | Planned, unbuilt |
 | When `{:ref [id config]}` lands, and what registers an id | Reserved, not designed |
 | Which React version the product pins | Not pinned by the product; cleanup-returning refs need React 19; this repo currently pins 19.2 |

--- a/docs/design/hicasso/draft-guide/10-server-side-rendering.md
+++ b/docs/design/hicasso/draft-guide/10-server-side-rendering.md
@@ -157,6 +157,7 @@ page replays an entrance.
 (h/defhost chart Chart)                                 ;; :client-only — the default
 (h/defhost chart Chart {:ssr :client-only})             ;; the same, said out loud
 (h/defhost chart Chart {:ssr {:fallback [:div.skel]}})  ;; that markup until adoption
+(h/defhost themed (.-Provider ctx) {:ssr :render})      ;; run it on the server
 ```
 
 `:client-only` renders nothing in that slot until the client has adopted;
@@ -165,6 +166,39 @@ declaration (`:rf.error/hicasso-host-bad-ssr-policy`); unknown options fail too
 (`:rf.error/hicasso-host-unknown-option`). One declaration covers server render,
 the first client pass after hydration, and a fresh client-only mount (which mounts
 the foreign component immediately, with no placeholder flash).
+
+### `:render` — when the region has to be in the response
+
+The first two policies both answer "what stands in for this component until the
+client takes over", and both of them drop the crossing's **children**. For a leaf
+widget — a chart, a date picker — that is right; there are no children. For a
+*transparent wrapper* it deletes the page. A context provider contributes no
+markup of its own and exists solely to carry a subtree, so a provider at a
+crossing takes every descendant out of the server response with it, and nothing
+reports it: the server HTML and hydration's first client pass agree by
+construction, so there is no mismatch to warn about.
+
+`:ssr :render` is the third policy, and it is an **assertion**: this component is
+safe to run on a server. Write it and the declaration mints no gate at all — the
+component *is* the element's type — so the server render, hydration's first pass
+and a fresh mount are one tree with the same props, the same context and the same
+children. Consumers below a `:render` provider read the value you declared rather
+than the context default, the first paint is the real thing rather than a
+stand-in, and because the element type never changes there is no swap at adoption
+and therefore no remount of the subtree you just hydrated.
+
+The default stays `:client-only`, and deliberately: a foreign React component is
+exactly the node whose render may reach for `window`, and the door cannot know.
+`:render` is you saying, not the door guessing. If the assertion is false you find
+out loudly — see the troubleshooting rows below.
+
+**A fallback is inert markup, and that is enforced.** It is walked into a single
+element at the declaration, outside any frame, and that one element is reused at
+every use site — so a `defview` or `defhost` head written into a fallback (an
+element whose body runs *later*, and would therefore render differently per frame
+and per write) is refused at the declaration with
+`:rf.error/hicasso-host-fallback-boundary-head`. Write plain hiccup there, or use
+`:render` and render the real subtree.
 
 Do all of that — write idiomatic Hicasso — and SSR is not a rewrite waiting to
 happen. The app that is easiest to write is also the app that serves.
@@ -185,6 +219,9 @@ snapshot, adopted whole by the client.
 | `:rf.ssr/hydration-mismatch` from the framework, with a `:where` and an `:error` | The same React adoption divergence, surfaced onto the diagnostic bus. It carries no hashes — this tier has none | Read the `:error`; the cause is the row above. Hydrate before anything renders, so the first client render is against the server's state |
 | A divergence React never reported at all | It was **attribute-only** — a stale `class`, `style` or ARIA value under a matching tag and text. React makes no guarantee to patch those and calls no production callback | Not traceable on this tier by construction. Find it the way you would any other stale value: the attribute came from state the two sides disagreed on |
 | A foreign component throws `window is not defined` on the server | Its render reached for the browser, and a bare component name says nothing about that | Declare `:ssr :client-only` (default) or `{:fallback …}` on `defhost` |
+| A foreign component throws `window is not defined` **under `:ssr :render`** | The assertion that declaration makes is false: the component is not server-safe | Drop back to `:client-only`, or give it a `{:fallback …}`. This is the loud failure mode `:render` was chosen for — the alternative candidates failed silently |
+| A `defhost` region's **children** are missing from the server HTML | The crossing is `:client-only` or has a `{:fallback …}`, and both render *instead of* the component — a transparent wrapper such as a provider takes its whole subtree with it | Declare `{:ssr :render}` if the component is server-safe. A fallback cannot recover this: it replaces the subtree, it does not wrap it |
+| `:rf.error/hicasso-host-fallback-boundary-head` at a declaration | A `defview` or `defhost` head was written into an `:ssr` fallback. A fallback is walked once, at the declaration, and reused everywhere — so a head whose body runs later is not a placeholder | Write plain hiccup in the fallback, or declare `{:ssr :render}` and render the real subtree |
 | A controlled input's text jumps just after adoption | Not this design: hydration does not converge controlled text | If you see it under another stack, the server markup and the model disagreed — fix the shared state |
 | Frames accumulate on a long-running server | A request path skipped teardown | Destroy the per-request frame in a `finally`, throw path included — copy the reference example |
 

--- a/docs/design/hicasso/production-server-arm.md
+++ b/docs/design/hicasso/production-server-arm.md
@@ -62,7 +62,7 @@ under-count from the bead text alone.
 | Structural tree → HTML, react-dom 19.2.0-pinned | `implementation/ssr/src/re_frame/ssr/ui_tree.cljc` (1,040 lines) | shipped; pure, deterministic, JVM-runnable |
 | A live two-sided emitter parity apparatus | `implementation/ui/test/re_frame/ui/parity_fixtures.cljc` (643 lines, 66 cases) + `parity_corpus_cljs_test.cljs` + `parity_html.cljc` | shipped and running |
 | An interpreted structural walk that runs on the JVM | `implementation/freehand/src/re_frame/freehand/tree.cljc` (678) + `node.cljc` (1,438) + `conversion.cljc` (906) | shipped, cross-host |
-| Hicasso's hydration door, `defhost` `:ssr` policy, Node render entry | `rf2-2rtt6.84` / `.85` / `.86` | shipped in the bench lane |
+| Hicasso's hydration door, `defhost` `:ssr` policy (three values, incl. `:render`), Node render entry | `rf2-2rtt6.84` / `.85` / `.86` / `rf2-l0wfx` | shipped in the bench lane |
 | Five hydration correctness rows on the dogfood screen | `rf2-2rtt6.87` | published |
 
 Two entries in that table carry more weight than their line counts suggest.
@@ -198,8 +198,11 @@ the one-slot-per-spelling family `canonical-slot`/`structural-slot?`/
 (HD-023's `:&` owned-literal law, 571–618), `check-ref!` (HD-022's vector
 reservation, 624–654), `convert-entry`/`convert-props` (656–791), the head
 marks (797–845), `boundary-props=`/`memoize-boundary!` (847–945),
-`mint-host!`/`declared-ssr`/`mint-host-gate!` (HD-011 plus `rf2-2rtt6.85`'s
-`:ssr` policy, 1039–1173), the lazy-seq forcing walk
+`mint-host!`/`declared-ssr`/`mint-host-gate!`/
+`refuse-deferring-heads-in-fallback!` (HD-011 plus `rf2-2rtt6.85`'s `:ssr`
+policy and `rf2-l0wfx`/`rf2-nv07k`'s third value and fallback refusal — cited
+by symbol rather than by line, because this block has moved twice since it was
+written), the lazy-seq forcing walk
 `realize-children`/`realize-deep`/`refuse-deferred!` (1201–1414), the emission
 dispatch `expand-seq`/`native-element`/`boundary-element`/`host-element`/
 `fragment-element` (1420–1673), `vec->element` (1677–1706), `as-element`'s

--- a/docs/design/hicasso/studio/raw-escape-design-c-ergonomics.md
+++ b/docs/design/hicasso/studio/raw-escape-design-c-ergonomics.md
@@ -690,6 +690,20 @@ reading of what a transparent wrapper *is*, it costs one row in a table that
 exists, and without it the escape's provider use case has no recovery at all.
 This is `defhost`'s question; the escape only inherits the answer.
 
+> **Addendum, 2026-08-05 — ruled, and not the way this recommendation went.**
+> A third value exists and it is **`:ssr :render`**, not `:children` /
+> `:transparent`. `:children` was refuted on measurement: rendering the children
+> with no provider above them puts every consumer on the context **default**
+> server-side (silent-absent becoming silent-wrong), and swapping the position's
+> element type at adoption destroys and rebuilds the subtree React just
+> hydrated. `:render` runs the component itself server-side on the author's
+> assertion, so the context value is right and the type never changes. Priced in
+> [`../defhost-ssr-provider-costing.md`](../defhost-ssr-provider-costing.md)
+> (candidate B); ruled in the 2026-08-05 addendum under HD-011. The escape still
+> only inherits the answer, which this paragraph got right. Also stale above:
+> the guide's provider example is under `05-interop.md`'s `## Providers`, not at
+> `:120`.
+
 **R2 — does the escape read the carrier, or only the declaration?**
 §Edge 2 recommends `lower-prop` (position selects the contract) and gives the
 argument. The literal reading of "the same foreign path as `defhost`" gives the

--- a/docs/design/hicasso/studio/raw-escape-spec.md
+++ b/docs/design/hicasso/studio/raw-escape-spec.md
@@ -78,7 +78,7 @@ which is the only way "declare what you use twice" has teeth.
 |---|---|---|
 | An author-chosen crossing name | yes, on the gate's `displayName` | no — one constant, `"[:>]"` |
 | `:callbacks` contracts | yes, exact, per slot | none — every prop is unclaimed |
-| An `:ssr` policy | yes, author's choice | fixed `:client-only`, unspellable |
+| An `:ssr` policy | yes, author's choice of three — `:client-only`, `{:fallback …}`, `:render` | fixed `:client-only`, unspellable |
 | A mint-time site for refusals | yes — the author's stack, once | render-time, every render |
 | A crossing identity for tooling | minted once, per crossing | one generic marker for all crossings |
 | A `.cljc` quarantine for the JS require | yes, in one host namespace | no — the require lands in the view ns |
@@ -187,7 +187,9 @@ minimal design found *in that design's favour*:
 `mint-host!` accepts any non-nil component; the wrapper's gate renders the declared fallback
 while unadopted and the children after adoption. Policy stays on a declaration, which is the
 whole argument. **Say precisely what it buys**: a *placeholder*, not server-rendered content.
-Server-rendered content under a crossing is `rf2-l0wfx`'s question (§7).
+Server-rendered content under a crossing was `rf2-l0wfx`'s question and is now `{:ssr :render}`
+(§7 R2) — which this wrapper cannot borrow, because the thing it wraps is `[:>]`, and the
+escape carries no declaration to assert server-safety with.
 
 ---
 
@@ -555,19 +557,31 @@ leaving:* a silent dead return on the guide's own taught path for value-first in
 posture. **The escape works under all three.**
 
 **R2 — `defhost`'s `:ssr` has no value that renders children (`rf2-l0wfx`, P1).**
-`mint-host-gate!` returns a single pre-walked placeholder when unadopted and never consults
-`props.children`, so an unadopted crossing **drops its subtree**. For a leaf widget that is
-right; for a **provider** — one of HD-011's five named use cases, and the guide's own example
-at `05-interop.md:120` — it deletes the application from the server response. *Recommendation
-(Design C's):* a third `:ssr` value meaning "render the children in place of the component",
-because it is the honest reading of what a transparent wrapper is, it costs one row in a
-table that exists, and without it the provider use case has no recovery at all. *A second
-route, from the attack on the local minimal design:* a **Context-head carve-out** — a React 19
-Context is detectable at the crossing by `$$typeof`, and its server render is React's own
-context machinery, deterministic and with no `window` risk, so the "nobody can vouch for the
-server render" defence is **false for providers specifically**. *Cost of neither:* providers
-are ruled out of SSR and the guide must say so. **This is the door's question and the escape
-only inherits the answer — the escape must never grow an `:ssr` spelling of its own.**
+**RULED 2026-08-05, and the escape is unchanged.** `mint-host-gate!` returned a single
+pre-walked placeholder when unadopted and never consulted `props.children`, so an unadopted
+crossing **dropped its subtree**. For a leaf widget that is right; for a **provider** — one of
+HD-011's five named use cases, and the guide's own example under `05-interop.md`'s `##
+Providers` — it deleted the application from the server response, silently.
+
+The ruling is a third `:ssr` value, **`:render`**, and *not* Design C's `:children`. `:render`
+is an assertion that the component is server-safe; the declaration then mints no gate, so the
+component is the element's own type and the server render, hydration's first pass and a fresh
+mount are one tree — the children reach the response, consumers below read the **declared**
+context value, and there is no adoption swap and therefore no remount. `:children` was refuted
+on the repo's own measured record: it would have restored the markup under the context
+DEFAULT (silent-absent becoming silent-wrong) and remounted the just-hydrated subtree at
+adoption. The **Context-head carve-out** was refused for the same reason `:client-only` stays
+the default — it is the door guessing, where `:render` is the author saying.
+
+Paired with it, `rf2-nv07k` was ruled `(b')`: a declared fallback is inert markup by
+enforcement, and a `defview`/`defhost` head written into one is refused at the declaration
+(`:rf.error/hicasso-host-fallback-boundary-head`). That deletes the "write your subtree twice"
+workaround, which `:render` supersedes.
+
+**The escape is untouched: it carries no declaration, so it carries no server-safety assertion
+either — it renders nothing server-side, and it must never grow an `:ssr` spelling of its
+own.** Clause 6 is unchanged. The answer to "my provider vanished server-side" is now
+"declare it: `(h/defhost themed (.-Provider ctx) {:ssr :render})`".
 
 **R3 — refusing a Hicasso view or host head in Component position exceeds clause 5's
 letter.** Both are values React accepts. *Recommendation:* refuse. A `defview` head is

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/fallback_contents_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/fallback_contents_cljs_test.cljs
@@ -1,81 +1,80 @@
 (ns re-frame.bench.hicasso.arm1.fallback-contents-cljs-test
-  "WHAT A `defhost` `:ssr` FALLBACK MAY CONTAIN — MEASURED, AND **UNRULED**
-  (rf2-nv07k).
+  "WHAT A `defhost` `:ssr` FALLBACK MAY CONTAIN — **THE CONTRACT**
+  (rf2-nv07k, ruled 2026-08-05).
 
-  [[re-frame.bench.hicasso.front.codec/mint-host-gate!]] used to state the
-  rule the guide teaches: *\"a fallback is inert markup — it is not a body,
-  so a subscription or an intent written there is the same loud error it
-  would be anywhere outside a boundary.\"* Both named cases hold, and
-  [[a-fallback-refuses-what-the-mint-time-walk-can-see]] pins them. The
-  CONCLUSION does not: a `defview` head written in a fallback is refused by
-  nothing, and it renders a live boundary in the server response.
+  [[re-frame.bench.hicasso.front.codec/mint-host-gate!]] states the rule
+  the guide teaches: *\"a fallback is inert markup — it is not a body, so
+  a subscription or an intent written there is the same loud error it
+  would be anywhere outside a boundary.\"* This namespace used to record
+  that half of it was enforced and half was not. It is now enforced, and
+  these rows are what enforces it.
 
-  ## The rule that is actually enforced is about the WALK, not the content
+  ## What was wrong, and it was the ABSENCE of a rule rather than a narrow one
 
-  The fallback is walked into an element ONCE, at the declaration, outside
-  any frame. So what is refused is exactly *what that walk can evaluate*:
+  The fallback is walked into an element ONCE, at the declaration,
+  outside any frame. So what was refused was exactly *what that walk
+  could evaluate* — an intent vector, a `sub` call in the form, hiccup
+  that is not hiccup. A boundary head is none of those: it is a React
+  element whose body runs LATER, so the walk never looked inside it and
+  every refusal it carried was deferred past the declaration, which is
+  the one thing a mint-time walk exists to prevent. It was not a rule
+  about content at all; it was a property of the walk.
 
-  | Written in a fallback | At the declaration | In the server render |
-  |---|---|---|
-  | an intent vector | refused — `:rf.error/hicasso-intent-outside-boundary` | — |
-  | a `sub` call in the form | refused — `:rf.error/hicasso-sub-outside-render` | — |
-  | a `defview` head | **mints** | a LIVE boundary, subscription read included |
-  | a `defhost` head | **mints** | that host's own gate, and its own fallback |
-  | a FRAME-FED `defview` head | **mints** | throws `:rf.error/no-frame-prop` |
+  ## Two measurements decided it, and both are kept below
 
-  A boundary head is neither an intent nor a subscription: it is a React
-  element whose body runs later. The walk never looks inside it, so every
-  refusal it carries is deferred past the declaration — which is the one
-  thing the mint-time walk exists to prevent. The asymmetry is therefore
-  not a narrow rule and not a documented middle ground; it is the ABSENCE
-  of a rule, and rf2-nv07k is where it gets one.
-
-  ## Two facts that decide it, and neither was on the record
-
-  1. **The declared placeholder is not a value.**
-     [[the-declared-placeholder-is-therefore-not-one]] renders ONE
-     declaration in two isolated frames and again after a write, and gets
-     three different documents. `mint-host-gate!`'s own justification for
-     walking once — *\"a placeholder that differs per site is not a
-     placeholder\"* — is falsified by what it permits. The ELEMENT is
-     immutable; what it renders is not.
-
-  2. **It does not survive the arm's own other boundary variant.** This arm
-     ships two: [[re-frame.bench.hicasso.arm1.runtime/mint-view!]] (context-fed,
+  1. **The declared placeholder was not a value.** `mint-host-gate!`
+     walks once and reuses the element everywhere, and its stated reason
+     is *\"a placeholder that differs per site is not a placeholder\"*.
+     One declaration carrying a boundary head rendered `ALPHA` in one
+     frame, `BRAVO` in another and `ALPHA-TWO` after a write — the
+     justification falsified by what it permitted.
+     [[a-declared-placeholder-is-a-placeholder-again]] keeps that
+     measurement, taken now against an INERT fallback, where all three
+     documents are the same one.
+  2. **It did not survive the arm's own other boundary variant.** This
+     arm ships two mints:
+     [[re-frame.bench.hicasso.arm1.runtime/mint-view!]] (context-fed,
      what `defview` mints) and
      [[re-frame.bench.hicasso.arm1.runtime/mint-frame-prop-view!]]
-     (rf2-2rtt6.39, which frees a hook slot in a ≤2 budget that is fully
-     spent). A frame-fed head reads `intent/*frame*` when its ELEMENT is
-     created — which in a fallback is mint time, where the var is `nil` —
-     so it bakes `nil` in and throws one render into the server response
-     ([[a-frame-fed-boundary-head-fails-inside-the-server-response]]).
-     Whether a boundary head in a fallback works at all is therefore a
-     property of which mint the head came from, which is not a rule an
-     author can hold.
+     (rf2-2rtt6.39). A frame-fed head reads `intent/*frame*` when its
+     ELEMENT is created — which in a fallback is mint time, where the
+     var is `nil` — so it baked `nil` in, minted happily, and threw
+     `:rf.error/no-frame-prop` one render into the server response.
+     Whether a boundary head in a fallback worked at all was therefore a
+     property of which mint it came from, which is not a rule an author
+     can hold. The refusal is walk-scoped and asks the MARKER, so it
+     catches that variant for free —
+     [[the-frame-fed-variant-is-caught-by-the-same-refusal]].
 
-  ## What this namespace is NOT
+  ## The ruling, and the recovery it points at
 
-  It is not a contract. Every row here that is not a refusal is written as
-  a record of TODAY, so that whichever way rf2-nv07k is ruled the change is
-  visible as an edit here rather than as a silence. `rf2-l0wfx` (P1, open)
-  currently has no recovery but the workaround these rows describe — write
-  the subtree a second time as the declaration's fallback — so the ruling
-  is not this namespace's to take.
+  `:rf.error/hicasso-host-fallback-boundary-head`, at the declaration,
+  naming the host, the offending head and its position in the declared
+  form. The workaround this deletes — writing a provider's subtree a
+  second time as the declaration's fallback, which was `rf2-l0wfx`'s only
+  recovery — is SUPERSEDED rather than merely removed: `:ssr :render` now
+  renders the real subtree on the server, with the real context value and
+  no duplication ([[re-frame.bench.hicasso.arm1.host-ssr-dom-cljs-test]]).
 
-  ## The mutation witnesses
+  ## The mutation witnesses — both directions
 
-  Bind a dispatch around `mint-host-gate!`'s `as-element` call — a fallback
-  as a LIVE region, the shape rf2-nv07k's option (a) implies — and
-  [[a-fallback-refuses-what-the-mint-time-walk-can-see]] goes red on the
-  intent that is no longer refused. Force that function's `placeholder` to
-  `nil` and both boundary-head rows go red on markup missing from the
-  server HTML. Make `boundary-element` refuse a frame-fed head minted with
-  no ambient frame — the repair option (b) implies — and
-  [[a-frame-fed-boundary-head-fails-inside-the-server-response]] goes red
-  because the throw moved to the declaration. Each was run.
+  **Remove the refusal** (delete `mint-host-gate!`'s call to
+  `refuse-deferring-heads-in-fallback!`) and every row in §2 and §3 goes
+  red: the heads mint again, and the frame-fed one goes back to throwing
+  mid-render rather than at the declaration.
 
-  Runtime: `-cljs-test`, not `-dom-`. Every claim is a `renderToString`, so
-  there is nothing here a DOM would add."
+  **Over-refuse** (make `deferring-head-kind` answer a kind for anything
+  non-nil, the shape a walk that confused \"an element\" with \"a
+  deferring head\" would have) and every row in §4 goes red — one row per
+  legitimate fallback position, so the failure names which position was
+  taken away. §1 stays green under BOTH mutations, which is why it is
+  separate: it is about the walk's own evaluation and not about this
+  refusal at all.
+
+  Both were run, `codec.cljs` restored from a byte copy after each.
+
+  Runtime: `-cljs-test`, not `-dom-`. Every claim is a declaration or a
+  `renderToString`, so there is nothing here a DOM would add."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.adapter.uix :as uix-adapter]
             [re-frame.bench.hicasso.arm1.mount :as mount]
@@ -135,7 +134,8 @@
   "The SAME body, minted through the arm's other boundary variant
   (rf2-2rtt6.39). Minted directly rather than through `defview` because
   `lang.clj`'s macro mints the context-fed one — which is exactly the
-  point: the two are indistinguishable in hiccup and disagree here."
+  point: the two are indistinguishable in hiccup and used to disagree
+  here."
   (rt/mint-frame-prop-view!
     "fallback-contents/frame-fed-view"
     (fn frame-fed-view-body [_]
@@ -146,7 +146,7 @@
 
 (defhost inner-host
   "A `defhost` head written into a fallback — a second deferring head, so
-  the hole is not a `defview` fact."
+  the rule is not a `defview` fact."
   inner-component
   {:ssr {:fallback [:em.inner-fallback "INNER-FALLBACK"]}})
 
@@ -156,6 +156,9 @@
 
 (defn- error-id [f]
   (try (f) ::did-not-throw (catch :default e (:rf.error/id (ex-data e)))))
+
+(defn- error-data [f]
+  (try (f) {::did-not-throw true} (catch :default e (ex-data e))))
 
 (defn- host-with-fallback
   "One declaration, made HERE rather than at the top level, so a row that
@@ -169,7 +172,12 @@
     (mount/provider frame (codec/root-element frame hiccup))))
 
 ;; ---------------------------------------------------------------------------
-;; 1 — what the mint-time walk CAN see, it refuses
+;; 1 — what the mint-time WALK can see, it refuses (unchanged by the ruling)
+;;
+;; These three rows are about `as-element`'s own evaluation and not about
+;; the structural refusal beside it. They were green before rf2-nv07k was
+;; ruled and they are green after, under both mutations named in the ns
+;; docstring — which is why they are a separate deftest.
 ;; ---------------------------------------------------------------------------
 
 (deftest a-fallback-refuses-what-the-mint-time-walk-can-see
@@ -191,69 +199,178 @@
            (error-id #(host-with-fallback "fb/empty" []))))))
 
 ;; ---------------------------------------------------------------------------
-;; 2 — what it cannot see, it does not refuse — AND THIS IS UNRULED
+;; 2 — and what it CANNOT see is now refused structurally, ahead of it
 ;; ---------------------------------------------------------------------------
 
-(deftest a-boundary-head-in-a-fallback-is-refused-by-nothing
+(deftest a-deferring-head-in-a-fallback-is-refused-at-the-declaration
   (fresh!)
-  (testing "a `defview` head mints — it is neither an intent nor a
-            subscription, it is an element whose body runs later, and the
-            walk does not look inside it"
-    (let [head (host-with-fallback "fb/view" [fallback-view {}])
-          html (server-html frame-a [:div.page [head {:value "dark"}]])]
-      (is (re-find #"class=\"fb-view\"" html)
-          (str "UNRULED (rf2-nv07k): the fallback rendered a LIVE boundary "
-               "in the server response: " html))
-      (is (re-find #"ALPHA" html)
-          (str "and its subscription READ — this is a body, not markup: "
-               html))))
-  (testing "and so does a `defhost` head, so the hole is about DEFERRAL and
+  (testing "a `defview` head — an element whose body runs later, so the
+            evaluating walk never looks inside it. The structural walk
+            does, and refuses it where the author's stack is"
+    (is (= :rf.error/hicasso-host-fallback-boundary-head
+           (error-id #(host-with-fallback "fb/view" [fallback-view {}])))))
+  (testing "and so does a `defhost` head, so the rule is about DEFERRAL and
             not about `defview` — any head whose content the walk cannot
-            reach crosses the same way"
-    (let [head (host-with-fallback "fb/host" [inner-host {}])
-          html (server-html frame-a [:div.page [head {:value "dark"}]])]
-      (is (re-find #"INNER-FALLBACK" html)
-          (str "a gate inside a placeholder, rendering its own placeholder: "
-               html)))))
+            reach is refused the same way"
+    (is (= :rf.error/hicasso-host-fallback-boundary-head
+           (error-id #(host-with-fallback "fb/host" [inner-host {}])))))
+  (testing "a bare head, with no vector around it at all — a fallback is a
+            hiccup FORM, so the refusal is written against the form and
+            not against head position"
+    (is (= :rf.error/hicasso-host-fallback-boundary-head
+           (error-id #(host-with-fallback "fb/bare" fallback-view)))))
+  (testing "and a head nested arbitrarily deep, because \"inert markup\"
+            is a claim about the whole form"
+    (is (= :rf.error/hicasso-host-fallback-boundary-head
+           (error-id #(host-with-fallback
+                        "fb/deep"
+                        [:div.skeleton
+                         [:p "loading"]
+                         [:section [:span [fallback-view {}]]]]))))
+    (is (= :rf.error/hicasso-host-fallback-boundary-head
+           (error-id #(host-with-fallback
+                        "fb/seq"
+                        [:ul (for [i (range 2)]
+                               [:li {:key i} [fallback-view {}]])]))))))
 
-(deftest the-declared-placeholder-is-therefore-not-one
+(deftest the-refusal-names-the-host-the-head-and-the-position
   (fresh!)
-  (testing "ONE declaration, walked ONCE into ONE element — and three
-            different server documents. `mint-host-gate!` walks once
-            because \"a placeholder that differs per site is not a
-            placeholder\"; a boundary head makes it differ per site and per
-            write, which is the reason the asymmetry is a defect and not a
-            feature nobody wrote down"
-    (let [head (host-with-fallback "fb/live" [fallback-view {}])
+  (testing "a message that says only \"a boundary head\" leaves an author
+            grepping a fallback they wrote three screens ago. All three
+            facts are in the ex-data and all three are in the message"
+    (let [data (error-data #(host-with-fallback
+                              "fb/named"
+                              [:div.skeleton [:span [fallback-view {}]]]))]
+      (is (= :rf.error/hicasso-host-fallback-boundary-head (:rf.error/id data)))
+      (is (= "fb/named" (:host data)) "the host whose declaration is at fault")
+      (is (= "re-frame.bench.hicasso.arm1.fallback-contents-cljs-test/fallback-view"
+             (:head data))
+          "the offending head, by the displayName its mint stamped")
+      (is (= "defview" (:kind data)) "and which door minted it")
+      (is (= [1 1 0] (:position data))
+          "the index route into the DECLARED form — the div's child 1 is the
+           span, whose child 1 is the offending vector, whose head is at 0")
+      (is (= :write-inert-hiccup-or-declare-ssr-render (:recovery data))
+          "and the recovery names the supersession, not just the ban")
+      (is (re-find #"fb/named" (ex-message (try (host-with-fallback
+                                                  "fb/named"
+                                                  [:div.skeleton
+                                                   [:span [fallback-view {}]]])
+                                                (catch :default e e))))
+          "and the MESSAGE carries them too — ex-data is for a test, the
+           message is for the author")))
+  (testing "the `defhost` case names its own door"
+    (let [data (error-data #(host-with-fallback "fb/named-host" [inner-host {}]))]
+      (is (= "defhost" (:kind data)))
+      (is (= "re-frame.bench.hicasso.arm1.fallback-contents-cljs-test/inner-host"
+             (:head data)))
+      (is (= [0] (:position data)) "head position of the fallback itself"))))
+
+(deftest a-declared-placeholder-is-a-placeholder-again
+  (fresh!)
+  (testing "THE MEASUREMENT THAT DECIDED IT, kept and inverted. One
+            declaration is walked ONCE into ONE element and reused at
+            every site, and `mint-host-gate!`'s reason for that is \"a
+            placeholder that differs per site is not a placeholder\". A
+            boundary head made it differ per site AND per write — three
+            different documents from one declaration. With the head
+            refused, the reason holds: the SAME document in two isolated
+            frames and again after a write"
+    (let [head (host-with-fallback "fb/inert" [:section.fb-inert "SKELETON"])
           in-a (server-html frame-a [:div.page [head {:value "dark"}]])
           in-b (server-html frame-b [:div.page [head {:value "dark"}]])]
-      (is (re-find #"ALPHA" in-a) (str "frame A's value: " in-a))
-      (is (re-find #"BRAVO" in-b)
-          (str "the SAME declared placeholder in frame B — frame-correct, "
-               "and not a constant: " in-b))
+      (is (re-find #"SKELETON" in-a) (str "the placeholder rendered: " in-a))
+      (is (= in-a in-b)
+          (str "the SAME declared placeholder in a frame holding a different "
+               "value — identical bytes, which is what a placeholder is: "
+               in-a " vs " in-b))
       (rf/with-frame frame-a (rf/dispatch-sync [:fb/seed "ALPHA-TWO"]))
       (let [after (server-html frame-a [:div.page [head {:value "dark"}]])]
-        (is (re-find #"ALPHA-TWO" after)
-            (str "and a write moved it, with nothing re-declared: " after))))))
+        (is (= in-a after)
+            (str "and a write moved nothing, because there is nothing there "
+                 "to read a frame: " after)))
+      ;; The non-vacuity control: those frames really do differ, so the
+      ;; equality above is a fact about the placeholder and not about a
+      ;; fixture that never varied.
+      (is (not= (server-html frame-a [:div.page [fallback-view {}]])
+                (server-html frame-b [:div.page [fallback-view {}]]))
+          "the same body in an ordinary POSITION still differs per frame —
+           the two frames are genuinely distinguishable"))))
 
 ;; ---------------------------------------------------------------------------
-;; 3 — and it does not survive the arm's other boundary variant
+;; 3 — the frame-fed variant, caught by the same refusal
 ;; ---------------------------------------------------------------------------
 
-(deftest a-frame-fed-boundary-head-fails-inside-the-server-response
+(deftest the-frame-fed-variant-is-caught-by-the-same-refusal
   (fresh!)
   (testing "the frame-fed variant reads `intent/*frame*` when its ELEMENT is
             created. Everywhere else that is inside an ancestor body or
             `root-element`; in a fallback it is MINT TIME, where the var is
-            nil — so the declaration mints happily"
-    (is (some? (host-with-fallback "fb/frame-fed" [frame-fed-view {}]))
-        "no refusal at the declaration, which is where the author's stack is"))
-  (testing "and then throws one render into the server response — the exact
-            failure the mint-time walk exists to prevent"
-    (let [head (host-with-fallback "fb/frame-fed-render" [frame-fed-view {}])]
-      (is (= :rf.error/no-frame-prop
-             (error-id #(server-html frame-a [:div.page [head {:value "dark"}]]))))))
-  (testing "while the SAME view inside an ordinary body renders — so this is
-            a property of the fallback position, not of the view"
+            nil — so it used to bake nil in, mint happily, and throw
+            `:rf.error/no-frame-prop` one render into the server response.
+            The refusal is walk-scoped and asks the boundary MARKER, so it
+            covers this variant without knowing it exists"
+    (is (= :rf.error/hicasso-host-fallback-boundary-head
+           (error-id #(host-with-fallback "fb/frame-fed" [frame-fed-view {}])))))
+  (testing "and the throw has MOVED to the declaration, which is the whole
+            point — an author's stack now names the line they wrote"
+    (is (not= :rf.error/no-frame-prop
+              (error-id #(host-with-fallback "fb/frame-fed-2"
+                                             [frame-fed-view {}])))))
+  (testing "while the SAME view inside an ordinary body still renders — so
+            the refusal is about the fallback POSITION and not about the
+            view, and the variant is not collateral damage"
     (let [html (server-html frame-a [:div.page [frame-fed-view {}]])]
       (is (re-find #"ALPHA" html) (str "control: " html)))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — every legitimate fallback position, proven ONE AT A TIME
+;;
+;; A refusal is only as good as what it leaves alone. One row per shape a
+;; real placeholder is written in, so an over-broad walk fails by NAME
+;; rather than as a wall of red.
+;; ---------------------------------------------------------------------------
+
+(deftest inert-hiccup-in-every-position-still-mints
+  (fresh!)
+  (testing "a bare tag"
+    (is (some? (host-with-fallback "ok/tag" [:div.skel]))))
+  (testing "a tag with a props map"
+    (is (some? (host-with-fallback "ok/props" [:div.skel {:data-live "no"} "loading"]))))
+  (testing "nested vectors, arbitrarily deep"
+    (is (some? (host-with-fallback "ok/nested"
+                                   [:div.skel [:p [:span [:em "loading"]]]]))))
+  (testing "a seq child — the lazy position, which the walk has to descend
+            into by hand because a seq is not a vector"
+    (is (some? (host-with-fallback "ok/seq"
+                                   [:ul (for [i (range 3)] [:li {:key i} i])]))))
+  (testing "a fragment"
+    (is (some? (host-with-fallback "ok/fragment" [:<> [:span "a"] [:span "b"]]))))
+  (testing "string, number, nil and false children — every scalar
+            `as-element` accepts, none of which is a head"
+    (is (some? (host-with-fallback "ok/scalars" [:div "text" 42 nil false]))))
+  (testing "a bare string, which is legal hiccup and is not a vector at all"
+    (is (some? (host-with-fallback "ok/string" "loading"))))
+  (testing "an already-built React element, which the walk must pass over
+            rather than descend into"
+    (is (some? (host-with-fallback
+                 "ok/element"
+                 (react/createElement "div" #js {:className "skel"} "loading")))))
+  (testing "a props map whose VALUES are collections — the walk descends
+            through renderable positions, and a props map is not one"
+    (is (some? (host-with-fallback "ok/prop-values"
+                                   [:div.skel {:class ["a" "b"] :data-n 3}])))))
+
+(deftest an-inert-fallback-still-renders-what-it-always-rendered
+  (fresh!)
+  (testing "the refusal is a declaration-time check and changes nothing
+            about what a legal fallback puts in the server response"
+    (let [head (host-with-fallback "ok/render"
+                                   [:div.skel {:data-live "no"}
+                                    [:span.a "loading"]
+                                    (for [i (range 2)] [:i.dot {:key i} "."])])
+          html (server-html frame-a [:div.page [head {:value "dark"}]])]
+      (is (re-find #"class=\"skel\"" html) (str "the fallback is there: " html))
+      (is (re-find #"loading" html))
+      (is (= 2 (count (re-seq #"class=\"dot\"" html)))
+          (str "including both rows of the seq: " html)))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_ssr_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/host_ssr_dom_cljs_test.cljs
@@ -15,24 +15,30 @@
       (defhost chart Chart)                                ; :client-only
       (defhost chart Chart {:ssr :client-only})            ; the same, said
       (defhost chart Chart {:ssr {:fallback [:div.skel]}}) ; markup instead
+      (defhost themed (.-Provider ctx) {:ssr :render})     ; run it, server-side
 
   `:client-only` renders nothing where the host sits until the client
   has adopted the markup. `{:fallback <hiccup>}` renders that markup
-  there instead. There is no third value.
+  there instead. `:render` is the author asserting that the component
+  is safe to run on the server, and it is the ONLY policy under which a
+  crossing's CHILDREN reach the server response — §3 below. There is no
+  fourth value.
 
-  WHAT MAY BE WRITTEN IN THAT FALLBACK is a separate and currently
-  UNRULED question — a boundary head written there is refused by
-  nothing and renders live in the server response. Measured in
-  [[re-frame.bench.hicasso.arm1.fallback-contents-cljs-test]]
-  (rf2-nv07k); nothing in this suite depends on the answer.
+  WHAT MAY BE WRITTEN IN THAT FALLBACK is settled (rf2-nv07k, ruled
+  2026-08-05): a fallback is inert markup, enforced — a `defview` or
+  `defhost` head written there is refused at the declaration with
+  `:rf.error/hicasso-host-fallback-boundary-head`. The contract is
+  [[re-frame.bench.hicasso.arm1.fallback-contents-cljs-test]]; nothing
+  in this suite depends on it beyond the one refusal row below.
 
-  ## The three places, and why ONE mechanism covers them
+  ## The three places, and why ONE mechanism covers the first two policies
 
-  A declaration mints one gate — a component whose single
-  `useSyncExternalStore` answers `false` from its SERVER snapshot and
-  `true` from its client one. React reads the server snapshot under
-  `renderToString` AND again on hydration's first client pass, then
-  re-renders with the client snapshot once adoption completes. So:
+  A `:client-only` or `{:fallback …}` declaration mints one gate — a
+  component whose single `useSyncExternalStore` answers `false` from its
+  SERVER snapshot and `true` from its client one. React reads the server
+  snapshot under `renderToString` AND again on hydration's first client
+  pass, then re-renders with the client snapshot once adoption
+  completes. So:
 
   1. **The server render** honours the policy without a server walk
      that knows anything about it — it honours it by rendering.
@@ -47,6 +53,23 @@
      the placeholder never flashes. Asserted on the line after
      `root!` returns, which is inside its own `flushSync`.
 
+  ## And why `:render` needs NO mechanism at all (rf2-l0wfx)
+
+  Under `:render` the declaration mints no gate: the head's type IS the
+  foreign component. So all three places above render the SAME element
+  type with the same props, the same context and the same children —
+  one tree everywhere. There is no snapshot pair, so no mismatch by
+  identity; no adoption event, so nothing to wait for; and no type swap,
+  so NO REMOUNT.
+
+  That last one is the law that priced every rejected candidate. React
+  reconciles a position by element type, and under a gate the gate is
+  the type — so any policy whose unadopted branch returns something
+  other than the component pays a full subtree destroy-and-rebuild the
+  moment adoption swaps it. Free for a skeleton; not free for the
+  application. [[a-render-crossing-hydrates-once-and-never-remounts]] is
+  where that is measured rather than argued.
+
   ## The mutation witnesses
 
   Make `:client-only` render something — `gate-unadopted` answering
@@ -55,8 +78,14 @@
   goes red on React's own mismatch report. Make `{:fallback …}` render
   nothing — `mint-host-gate!`'s `placeholder` forced to `nil` — and
   [[the-server-render-honours-the-policy]] goes red on the fallback
-  markup missing from the server HTML. Neither mutation is visible to
-  the other row, which is why there are two.
+  markup missing from the server HTML. Route `:render` through
+  `mint-host-gate!` like the other two — `mint-host!`'s
+  `keyword-identical?` branch removed — and
+  [[the-server-render-honours-the-policy]] goes red on the subtree
+  missing from the server HTML, while
+  [[a-render-crossing-hydrates-once-and-never-remounts]] goes red on the
+  second child mount the adoption swap causes. No mutation is visible to
+  more than one row, which is why there are four.
 
   Runtime: `-dom-cljs-test`, so `:browser-test` runs it against a real
   React DOM. The declaration rows and the `renderToString` rows need no
@@ -138,6 +167,53 @@
 (defhost fallback-chart chart
   {:ssr {:fallback [:div.chart-skeleton {:data-live "no"} "loading"]}})
 
+;; --- the `:render` fixtures: a provider, and something that reads it -------
+;;
+;; A context PROVIDER is the shape that filed rf2-l0wfx, and it is the
+;; shape that makes the policy legible: it contributes no markup of its
+;; own, so under a gate its unadopted arm returns something that is not
+;; the component and the ENTIRE subtree leaves the server response with
+;; it. It is also the case where the author's assertion is trivially
+;; true — a Provider is React's own component and React's server
+;; renderer supports context fully.
+
+(def ^:private theme-context (react/createContext "unset"))
+
+(def ^:private !child-mounts
+  "How many times the counted child's mount effect ran. One is an
+  adoption; two is the destroy-and-rebuild that the type swap under a
+  gate would cause. `useEffect` never runs on the server, so a server
+  render leaves this alone and the count is purely about the client."
+  (atom 0))
+
+(defn- theme-reader
+  "A consumer BELOW the provider. The whole discriminator between
+  `:ssr :render` and the rejected `:ssr :children`: with the provider
+  above it this reads `dark`, and with only the children rendered it
+  reads the context DEFAULT."
+  [_props]
+  (react/createElement "span" #js {:className "theme-reader"}
+                       (react/useContext theme-context)))
+
+(defn- counted-reader [props]
+  (react/useEffect (fn [] (swap! !child-mounts inc) js/undefined) #js [])
+  (theme-reader props))
+
+(defhost themed
+  "The guide's own provider example, declared the way the ruling says to
+  declare it."
+  (.-Provider theme-context)
+  {:ssr :render})
+
+(defhost themed-client-only
+  "The SAME provider under the default policy — the control that keeps
+  the row below a fact about the policy rather than about the page."
+  (.-Provider theme-context))
+
+(defhost reader-host theme-reader {:ssr :render})
+
+(defhost counted-reader-host counted-reader {:ssr :render})
+
 ;; ---------------------------------------------------------------------------
 ;; The pages
 ;; ---------------------------------------------------------------------------
@@ -164,6 +240,45 @@
   [:div.page
    [fallback-chart {:label (rt/sub [:ssr/title])}
     [:span.kid "slotted"]]])
+
+(defview provider-page
+  "THE PAGE THAT FILED rf2-l0wfx, under the policy that answers it. A
+  native sibling above the crossing so \"the subtree is absent\" stays
+  distinguishable from \"nothing rendered\", markup inside it so the
+  subtree is visible, and a consumer inside it so the context VALUE is
+  visible too."
+  [_]
+  [:div.page
+   [:h1.title (rt/sub [:ssr/title])]
+   [themed {:value "dark"}
+    [:p.body "THE ENTIRE APPLICATION"]
+    [reader-host {}]]])
+
+(defview provider-page-client-only
+  "The same page under the default policy — the defect, kept live."
+  [_]
+  [:div.page
+   [:h1.title (rt/sub [:ssr/title])]
+   [themed-client-only {:value "dark"}
+    [:p.body "THE ENTIRE APPLICATION"]
+    [reader-host {}]]])
+
+(defview unprovided-page
+  "The consumer with NO provider above it — what a policy that rendered
+  the children alone would have emitted, so the `dark` below is a
+  measured contrast and not an assumed one."
+  [_]
+  [:div.page [reader-host {}]])
+
+(defview counted-provider-page
+  "[[provider-page]] with a mount-counting consumer, for the hydration
+  row. Same shape, one extra effect."
+  [_]
+  [:div.page
+   [:h1.title (rt/sub [:ssr/title])]
+   [themed {:value "dark"}
+    [:p.body "THE ENTIRE APPLICATION"]
+    [counted-reader-host {}]]])
 
 ;; ---------------------------------------------------------------------------
 ;; Helpers
@@ -226,12 +341,41 @@
     (is (= {:fallback [:div.chart-skeleton {:data-live "no"} "loading"]}
            (codec/host-ssr fallback-chart)))))
 
+(deftest the-third-policy-is-render-and-it-is-an-assertion
+  (testing "rf2-l0wfx. `:render` is accepted as a bare keyword, alongside
+            the two — the author asserting that this component is safe to
+            run on the server"
+    (is (= :render (codec/host-ssr themed)))
+    (is (= :render (codec/host-ssr reader-host))))
+  (testing "and it reads back as data like every other policy, so a server
+            walk that wants to state what it is honouring still can"
+    (is (= :client-only (codec/host-ssr themed-client-only)))
+    (is (some? (codec/mint-host! "ssr/render-plus-callbacks" chart
+                                 {:callbacks {:on-pick :event} :ssr :render}))
+        "and it composes with :callbacks, which is the other option")))
+
 (deftest the-declaration-refuses-a-policy-it-cannot-honour
-  (testing "a third value is refused at the declaration, naming the two"
+  (testing "a fourth value is refused at the declaration, naming the three"
     (is (= :rf.error/hicasso-host-bad-ssr-policy
            (error-id #(codec/mint-host! "ssr/server" chart {:ssr :server}))))
     (is (= :rf.error/hicasso-host-bad-ssr-policy
            (error-id #(codec/mint-host! "ssr/true" chart {:ssr true})))))
+  (testing "and the three spellings an author reaches for INSTEAD of
+            `:render` stay refused, every one of them (rf2-l0wfx). They
+            assert a structural property nobody can check — that the
+            component is transparent — and they deliver the subtree under
+            the WRONG context value, which turns a silent absence into a
+            silent wrongness"
+    (doseq [v [:children :transparent :passthrough]]
+      (is (= :rf.error/hicasso-host-bad-ssr-policy
+             (error-id #(codec/mint-host! (str "ssr/" (name v)) chart {:ssr v})))
+          (str (pr-str v) " must stay refused"))))
+  (testing "a fallback MAP spelling of it is not a spelling of it either —
+            `:render` is a bare keyword, and a policy that admitted both
+            would be two ways to say one thing"
+    (is (= :rf.error/hicasso-host-bad-ssr-policy
+           (error-id #(codec/mint-host! "ssr/render-map" chart
+                                        {:ssr {:render true}})))))
   (testing "an explicit nil is a value, not an absence — `:client-only` is
             the default of an ABSENT key, and inferring it from nil is how
             a typo becomes a policy"
@@ -249,7 +393,16 @@
             declaration, rather than one render into a server response —
             it is walked once at mint, where the author's stack is"
     (is (= :rf.error/hicasso-empty-vector
-           (error-id #(codec/mint-host! "ssr/bad-fb" chart {:ssr {:fallback []}}))))))
+           (error-id #(codec/mint-host! "ssr/bad-fb" chart {:ssr {:fallback []}})))))
+  (testing "as does a `defview` head written into a fallback — a fallback
+            is inert markup and that is enforced (rf2-nv07k). The full
+            contract, both directions, is
+            `arm1/fallback_contents_cljs_test`; this row is here because
+            the two halves were ruled together and the refusal is one of
+            this declaration's own"
+    (is (= :rf.error/hicasso-host-fallback-boundary-head
+           (error-id #(codec/mint-host! "ssr/live-fb" chart
+                                        {:ssr {:fallback [client-only-page {}]}}))))))
 
 (deftest the-declaration-refuses-an-option-it-does-not-know
   (testing "`mint-host!` read :callbacks and IGNORED the rest, so a
@@ -295,7 +448,67 @@
           "nor did its body run"))))
 
 ;; ---------------------------------------------------------------------------
-;; 3 — a fresh mount: no placeholder, ever
+;; 3 — `:ssr :render`: the component runs, and so do its CHILDREN
+;;
+;; The defect rf2-l0wfx filed and the ruling that answers it, in one
+;; place. Every row here is a `renderToString`, so they run under
+;; `:node-test` as well.
+;; ---------------------------------------------------------------------------
+
+(deftest a-client-only-provider-deletes-its-subtree-from-the-server-render
+  (fresh!)
+  (testing "THE DEFECT, kept live (rf2-l0wfx). A provider contributes no
+            markup of its own, so under a gate its unadopted arm returns
+            something that is not the component and the whole subtree
+            leaves the server response with it — silently, because the
+            server snapshot and hydration's first client pass agree by
+            construction. This row is what `:ssr :render` exists to make
+            unnecessary, and it stays green because the DEFAULT is
+            unchanged: the door still does not guess"
+    (let [html (server-html [provider-page-client-only {}])]
+      (is (re-find #"quarterly" html)
+          (str "the page DID render — the sibling above the crossing is
+                there, so an absent subtree is an absent subtree: " html))
+      (is (not (re-find #"THE ENTIRE APPLICATION" html))
+          (str "and the provider took its children with it: " html))
+      (is (not (re-find #"theme-reader" html))
+          (str "including the consumer below it: " html)))))
+
+(deftest a-render-crossing-puts-the-component-and-its-children-on-the-server
+  (fresh!)
+  (testing "the component itself renders server-side — the assertion the
+            declaration makes, honoured"
+    (let [html (server-html [provider-page {}])]
+      (is (re-find #"quarterly" html) (str "sanity — the page rendered: " html))
+      (is (re-find #"THE ENTIRE APPLICATION" html)
+          (str "THE SUBTREE IS IN THE SERVER RESPONSE. This is the whole of
+                rf2-l0wfx: " html))
+      (is (re-find #"class=\"body\"" html)
+          (str "as markup, not as stray text: " html))))
+  (testing "AND THE CONTEXT VALUE IS THE DECLARED ONE, which is what
+            separates this policy from `:ssr :children`. A consumer under
+            the provider reads `dark`; the same consumer with no provider
+            above it reads the context DEFAULT, and a policy that rendered
+            only the children would have emitted exactly that"
+    (let [provided   (server-html [provider-page {}])
+          unprovided (server-html [unprovided-page {}])]
+      (is (re-find #"<span class=\"theme-reader\">dark</span>" provided)
+          (str "the consumer read the DECLARED value: " provided))
+      (is (re-find #"<span class=\"theme-reader\">unset</span>" unprovided)
+          (str "the contrast, measured rather than assumed — with no
+                provider above it the same consumer reads the default: "
+               unprovided))
+      (is (not= provided unprovided)
+          "so the two are genuinely distinguishable in the bytes")))
+  (testing "and a `:render` host with no children of its own is not a
+            special case — the policy is about the TYPE, not about arity"
+    (let [html (server-html [unprovided-page {}])]
+      (is (re-find #"class=\"theme-reader\"" html)
+          (str "a childless `:render` crossing rendered its component: "
+               html)))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — a fresh mount: no placeholder, ever
 ;; ---------------------------------------------------------------------------
 
 (deftest a-fresh-mount-renders-the-component-on-its-first-pass
@@ -339,7 +552,7 @@
             (finally (mount/release! h))))))))
 
 ;; ---------------------------------------------------------------------------
-;; 4 — hydration: the first client pass matches, and adoption swaps
+;; 5 — hydration: the first client pass matches, and adoption swaps
 ;; ---------------------------------------------------------------------------
 
 (defn- hydration-row
@@ -415,3 +628,43 @@
           (is (some? (q container ".chart"))
               "replaced by the foreign component")
           (done))))))
+
+(deftest a-render-crossing-hydrates-once-and-never-remounts
+  (async done
+    (if-not (mount/browser?)
+      (do (skip! ":node-test has no DOM") (done))
+      (do
+        (reset! !child-mounts 0)
+        (hydration-row
+          [counted-provider-page {}]
+          (fn [container seen html]
+            (is (re-find #"THE ENTIRE APPLICATION" html)
+                (str "the markup hydrated FROM carries the provider's whole
+                      subtree — the row's own restatement of the policy, so
+                      a `:render` that stopped rendering is red HERE and not
+                      only in the server-render row: " html))
+            (is (re-find #"<span class=\"theme-reader\">dark</span>" html)
+                (str "under the DECLARED context value: " html))
+            (is (empty? seen)
+                (str "REACT FOUND NOTHING TO RECONCILE. Server render,
+                      hydration's first pass and a fresh mount are one tree
+                      under this policy — the same element type, the same
+                      props, the same children — so there is zero mismatch
+                      by identity rather than by a snapshot pair agreeing: "
+                     (pr-str seen)))
+            (is (some? (q container ".theme-reader"))
+                "the consumer is mounted after hydration")
+            (is (= "dark" (.-textContent (q container ".theme-reader")))
+                "still reading the declared value on the client")
+            (is (some? (q container ".body"))
+                "and the subtree around it is the SERVER'S markup, adopted")
+            (is (= 1 @!child-mounts)
+                (str "**ONE MOUNT.** This is the closing measurement
+                      (rf2-l0wfx): the child's effect ran exactly once, so
+                      the adopted subtree was never destroyed and rebuilt.
+                      Any policy whose unadopted branch returns something
+                      other than the component swaps the position's element
+                      TYPE at adoption, and React reconciles a position by
+                      type — so it would read 2 here. Read "
+                     @!child-mounts))
+            (done)))))))

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/hydrate_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/hydrate_dom_cljs_test.cljs
@@ -137,7 +137,30 @@
    [:h1.title (rt/sub [:hyd/title])]
    [:ul.rows (for [i (range 3)] [row {:key i :i i}])]])
 
-(def ^:private boundary-count 4)
+(def ^:private boundary-count
+  "Four: [[screen]] and its three [[row]]s.
+
+  **WHAT THIS CONSTANT IS AND IS NOT** (`studio/raw-escape-spec.md` §8.3,
+  restated here rather than loosened). It is the number of boundary
+  BODIES on the page, read by
+  [[the-body-run-count-across-adoption-is-counted-and-not-inferred]]
+  after adoption resolves. It is green because [[screen]] carries no
+  foreign crossing — and it goes red **on correct code** the moment one
+  is added under a policy that renders nothing on the server, because
+  such a crossing legitimately runs a body the server never ran. The two
+  obvious readings when that happens — \"my change is wrong\" and \"this
+  test is wrong\" — are both wrong. Do not delete the assertion and do
+  not loosen it to a range: restate it as this count PLUS the number of
+  crossings on the page that the server did not render, so it still
+  fails if a body runs twice or a boundary is skipped.
+
+  `:ssr :render` is the policy that does NOT move it (rf2-l0wfx). Under
+  `:render` the declaration mints no gate, the component is the
+  element's own type, and the same tree renders on the server and on
+  hydration's first pass — so the crossing adds no body run to adopt and
+  no adoption swap afterwards. The arithmetic above applies to
+  `:client-only` and `{:fallback …}` crossings only."
+  4)
 
 (defview toast-tray
   "A presence tray whose children carry BOTH override maps, so a child

--- a/implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj
+++ b/implementation/freehand/test/re_frame/bench/hicasso/arm1/lang.clj
@@ -84,19 +84,41 @@
 
   `opts` is optional and carries `:callbacks` — a FINITE map from exact
   prop names to `:event`, `:handler` or `:render`, never inferred from an
-  `on*` spelling — and `:ssr`, the placeholder policy:
+  `on*` spelling — and `:ssr`, the server policy:
 
       (defhost chart Chart
         {:ssr {:fallback [:div.chart-skeleton]}})
+
+      (defhost themed (.-Provider theme-context)
+        {:ssr :render})
 
   `:ssr :client-only` is the DEFAULT and needs no writing: the host
   region renders nothing on the server and nothing on hydration's first
   client pass, and the foreign component mounts once the markup is
   adopted. `{:fallback <hiccup>}` renders that markup there instead.
   A fresh (non-hydrated) mount renders the foreign component on its
-  first pass under either policy — the placeholder never flashes. There
-  is no third value, and an option `defhost` does not know is refused
-  rather than ignored.
+  first pass under either policy — the placeholder never flashes.
+
+  `:ssr :render` is the third value and it is an ASSERTION: *this
+  component is safe to render on the server*. The declaration then mints
+  no gate at all — the component is the element's own type — so the same
+  component, the same props, the same context and the same CHILDREN
+  render on the server, on hydration's first pass and on a fresh mount.
+  One tree everywhere: no mismatch, no adoption swap, no remount. It is
+  the only policy under which a crossing's children reach the server
+  response, which is what a transparent wrapper such as a context
+  provider needs. If the assertion is false the server render throws —
+  `window is not defined` — loudly and at the crossing.
+
+  There is no fourth value, and an option `defhost` does not know is
+  refused rather than ignored.
+
+  **A declared fallback is INERT MARKUP, and that is enforced.** It is
+  walked into one element at the declaration and reused at every use
+  site, so a `defview` or `defhost` head written there — an element
+  whose body runs later — is refused with
+  `:rf.error/hicasso-host-fallback-boundary-head`. Write plain hiccup,
+  or declare `:ssr :render` and render the real subtree.
 
   Policy lives on the declaration, so every use site inherits it; the
   defaults, the refusals and the crossing itself are

--- a/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/front/codec.cljs
@@ -44,9 +44,12 @@
   head is the fourth element class, §Host heads below (rf2-2rtt6.65).
   Neither is HD-011's SSR placeholder, which HD-020(d) left inert until
   the operator ruled SSR into scope: `:ssr` is a declaration option
-  with two values, and [[mint-host-gate!]] is the one mechanism that
-  serves the server render, hydration's first client pass and a fresh
-  `createRoot` mount alike (rf2-2rtt6.85).
+  with three values (rf2-2rtt6.85, rf2-l0wfx). For the two gated ones
+  [[mint-host-gate!]] is the one mechanism that serves the server
+  render, hydration's first client pass and a fresh `createRoot` mount
+  alike; `:ssr :render` mints no gate and renders the component itself
+  server-side, which is the only policy under which a crossing's
+  CHILDREN reach the server response at all.
 
   ## Codec-work caching only (HD-004)
 
@@ -974,39 +977,83 @@
 ;;
 ;; HD-011 listed "SSR placeholder" among `defhost`'s strong defaults and
 ;; HD-020(d) left it inert; the operator's 2026-08-04 ruling makes SSR
-;; required scope, so the placeholder is now real. TWO VALUES, and the
+;; required scope, so the placeholder is now real. THREE VALUES, and the
 ;; author writes at most one of them:
 ;;
 ;;     :ssr :client-only        ; THE DEFAULT — omit :ssr and this is it
 ;;     :ssr {:fallback <hiccup>}
+;;     :ssr :render             ; "this component is safe on the server"
 ;;
 ;; `:client-only` renders NOTHING where the host sits until the client
 ;; has adopted the markup; `{:fallback …}` renders that hiccup there
-;; instead. Anything else is refused at the declaration. The default is
-;; the conservative one because a foreign React component is exactly the
-;; node whose render may reach for `window` — the door cannot know, so it
-;; does not guess.
+;; instead; `:render` runs the component itself, server-side, with its
+;; real props and its real children. Anything else is refused at the
+;; declaration. The DEFAULT is the conservative one because a foreign
+;; React component is exactly the node whose render may reach for
+;; `window` — the door cannot know, so it does not guess. `:render` is
+;; the AUTHOR saying, which is a different thing from the door guessing.
 ;;
-;; **ONE mechanism serves the server, the hydration pass and the fresh
-;; mount**, and it is [[mint-host-gate!]]: a one-hook component whose
-;; `useSyncExternalStore` answers `false` from its SERVER snapshot and
-;; `true` from its client one. React reads the server snapshot under
-;; `renderToString` and again on hydration's first client pass, then
-;; re-renders with the client snapshot once adoption completes — so the
-;; server HTML and the first client pass agree BY CONSTRUCTION (no
-;; mismatch to reconcile), and a `createRoot` mount, which never consults
-;; a server snapshot at all, renders the foreign component on its very
-;; first pass with no placeholder flash. A server walk therefore does not
-;; have to consult the policy separately; it consults it by rendering.
+;; **The third value is rf2-l0wfx's ruling** (2026-08-05), and the case
+;; that filed it is a context PROVIDER: a transparent wrapper that
+;; contributes no markup of its own and exists solely to carry a
+;; subtree. Under either of the first two policies the unadopted arm
+;; returns something that is not the component, so the crossing's
+;; CHILDREN are dropped and the provider deletes the whole application
+;; from the server response — silently, because the server snapshot and
+;; hydration's first client pass agree by construction. `:render` is the
+;; one policy under which the children reach the server at all.
+;;
+;; ## Two shapes, and which one a declaration mints
+;;
+;; For `:client-only` and `{:fallback …}` **ONE mechanism serves the
+;; server, the hydration pass and the fresh mount**, and it is
+;; [[mint-host-gate!]]: a one-hook component whose `useSyncExternalStore`
+;; answers `false` from its SERVER snapshot and `true` from its client
+;; one. React reads the server snapshot under `renderToString` and again
+;; on hydration's first client pass, then re-renders with the client
+;; snapshot once adoption completes — so the server HTML and the first
+;; client pass agree BY CONSTRUCTION (no mismatch to reconcile), and a
+;; `createRoot` mount, which never consults a server snapshot at all,
+;; renders the foreign component on its very first pass with no
+;; placeholder flash. A server walk therefore does not have to consult
+;; the policy separately; it consults it by rendering.
+;;
+;; For `:render` there is NO GATE — the head's `gate` slot carries the
+;; foreign component itself, which is HD-011's original zero-wrapper,
+;; zero-fiber, zero-hook shape restored for the hosts that can take it.
+;; One tree everywhere: the server render, hydration's first pass and a
+;; fresh `createRoot` mount all render the SAME element type with the
+;; same props, the same context and the same children. So there is zero
+;; mismatch by identity, no snapshot pair, no adoption event to wait
+;; for, and — the fact that separates this policy from every rejected
+;; candidate — NO REMOUNT.
+;;
+;; **Why a remount is the law and not a detail.** React reconciles a
+;; position by element TYPE, and under a gate the gate IS the type. Any
+;; policy whose unadopted branch returns something other than the
+;; component therefore pays a full subtree destroy-and-rebuild the moment
+;; adoption swaps the type. That is free when the thing torn down is an
+;; inert skeleton; it is not free when it is the application, and it is
+;; why `:ssr :children` — "render `props.children` in place of the
+;; component" — was refused rather than adopted: it restores the markup
+;; without the provider above it, so every consumer below reads the
+;; context DEFAULT server-side (silent-absent becomes silent-wrong), and
+;; then remounts the whole just-hydrated subtree at adoption.
 ;;
 ;; **The price, stated because it changed** (rf2-2rtt6.85): the door used
 ;; to mint no wrapper, no fiber and no hook — the foreign component was
-;; the element's own type. It now mints ONE gate per declaration, so a
-;; crossing costs one fiber and one hook. HD-020(b)'s ≤2 budget is a
-;; statement about Hicasso's BOUNDARY shells and is untouched: the gate
+;; the element's own type. A gated declaration mints ONE gate, so a
+;; crossing under the first two policies costs one fiber and one hook; a
+;; `:render` crossing costs neither. HD-020(b)'s ≤2 budget is a statement
+;; about Hicasso's BOUNDARY shells and is untouched either way: the gate
 ;; is not a boundary, holds no subscription, and reads no frame.
 
 (def ^:private host-marker "hicassoHost")
+
+;; [[host-head?]] is the predicate over that marker and reads naturally
+;; beside [[host-ssr]], at the end of this section. The fallback walk
+;; below needs it three definitions earlier.
+(declare host-head?)
 
 (def ^:private callback-contracts
   "The three contracts a declaration may name — the position table's
@@ -1036,9 +1083,107 @@
 (def ^:private gate-adopted (fn [] true))
 (def ^:private gate-unadopted (fn [] false))
 
+(defn- deferring-head-kind
+  "Which DEFERRING head `x` is — the door that minted it, named the way
+  an author wrote it — or `nil` if it is not one.
+
+  A deferring head is one whose body does not run when its element is
+  created: `defview`'s product runs inside its own boundary's
+  `with-frame`, and `defhost`'s runs behind its own gate. Those are
+  exactly the two heads a hiccup walk cannot see through, which is why
+  they are the two heads a fallback may not contain."
+  [x]
+  (cond
+    (boundary-head? x) "defview"
+    (host-head? x)     "defhost"
+    :else              nil))
+
+(defn- head-name
+  "The `displayName` both mints stamp on their product, for a message
+  that has to name the offending head. Never assumed present."
+  [x]
+  (or (unchecked-get x "displayName") "<unnamed>"))
+
+(defn- refuse-deferring-heads-in-fallback!
+  "A DECLARED FALLBACK IS INERT MARKUP, ENFORCED (rf2-nv07k). Walks
+  `form` structurally and refuses a `defview` or `defhost` head at any
+  position, naming the host, the head and where it sits.
+
+  Structural rather than evaluating, and that is the whole repair. The
+  fallback's other refusals are what [[as-element]] happens to evaluate
+  on its way to an element — an intent vector raises
+  `:rf.error/hicasso-intent-outside-boundary` because there is no
+  frame-locked dispatch to lower it against, a `sub` call in the form
+  raises `:rf.error/hicasso-sub-outside-render` because it is evaluated
+  where the declaration is. A boundary head is neither: it is an element
+  whose body runs LATER, so that walk never looks inside it and every
+  refusal it carries is deferred past the declaration, which is the one
+  thing a mint-time walk exists to prevent. What was enforced was
+  therefore never a rule about content; it was a property of the walk.
+
+  Two facts made the absence a defect rather than a narrow rule
+  (measured, `arm1/fallback_contents_cljs_test`):
+
+  1. **The declared placeholder is not a value.** [[mint-host-gate!]]
+     walks once and reuses the element everywhere, and its stated reason
+     is *\"a placeholder that differs per site is not a placeholder\"*.
+     One declaration carrying a boundary head renders `ALPHA` in one
+     frame, `BRAVO` in another and `ALPHA-TWO` after a write — the
+     justification falsified by what it permitted.
+  2. **It did not survive the arm's other boundary variant.** A
+     frame-fed head ([[mark-frame-prop!]]) reads `intent/*frame*` at
+     ELEMENT-creation time, which in a fallback is mint time, where the
+     var is `nil` — so it baked `nil` in, minted happily, and threw
+     `:rf.error/no-frame-prop` one render into the server response.
+     Whether a boundary head in a fallback worked at all was a property
+     of which mint it came from, which is not a rule an author can hold.
+
+  The refusal is walk-scoped, so it catches that frame-fed variant for
+  free: a frame-fed head is a boundary head, and the walk asks the
+  marker rather than the mint.
+
+  **The workaround it deletes is superseded, not merely removed.**
+  Writing a provider's subtree a second time as the declaration's
+  fallback was `rf2-l0wfx`'s only recovery; `:ssr :render` is now the
+  honest one, and it renders the real subtree with the real context
+  value and no duplication.
+
+  `path` is the index route into the declared form — `[]` is the
+  fallback itself, `[0]` its head position, `[2 0]` the head of its
+  third element."
+  [host-name path form]
+  (if-some [kind (deferring-head-kind form)]
+    (fail! :rf.error/hicasso-host-fallback-boundary-head
+           'front.codec/mint-host!
+           (str "defhost " host-name " declares an :ssr fallback carrying the "
+                kind " head " (head-name form) " at position " (pr-str path)
+                ". A fallback is INERT MARKUP: it is walked into ONE element "
+                "at the declaration, outside any frame, and that element is "
+                "reused at every site of the host — so a head whose body runs "
+                "later makes one declared placeholder render a different "
+                "document per frame and per write, which is not a "
+                "placeholder. Write plain hiccup there, or declare "
+                ":ssr :render and render the real subtree on the server.")
+           :write-inert-hiccup-or-declare-ssr-render
+           {:host host-name :head (head-name form) :position path :kind kind})
+    (cond
+      (vector? form)
+      (dotimes [i (count form)]
+        (refuse-deferring-heads-in-fallback! host-name (conj path i) (nth form i)))
+
+      (seq? form)
+      (loop [i 0 s (seq form)]
+        (when s
+          (refuse-deferring-heads-in-fallback! host-name (conj path i) (first s))
+          (recur (inc i) (next s))))
+
+      :else nil)))
+
 (defn- mint-host-gate!
-  "The one component a declaration mints: the foreign component behind
-  its `:ssr` policy.
+  "The one component a GATED declaration mints: the foreign component
+  behind its `:ssr` policy. `:client-only` and `{:fallback …}` mint one
+  of these; `:ssr :render` mints none, and the head's `gate` slot
+  carries the foreign component itself.
 
   `fallback` is walked into an element HERE, at the declaration —
   which is where every other host refusal fires, so a fallback that is
@@ -1047,39 +1192,16 @@
   at every site of the host: React elements are immutable values, and a
   placeholder that differs per site is not a placeholder.
 
-  ## What that refuses is what the WALK CAN SEE — and no more (rf2-nv07k)
+  ## And that is now ENFORCED rather than merely stated (rf2-nv07k)
 
   This docstring used to draw the corollary the guide teaches — *\"a
-  fallback is inert markup\"* — and half of it is enforced. The walk
-  runs outside any frame, so an intent vector written here raises
-  `:rf.error/hicasso-intent-outside-boundary` and a `sub` call in the
-  form raises `:rf.error/hicasso-sub-outside-render`, exactly as the
-  sentence says.
-
-  A BOUNDARY HEAD IS NEITHER. `[some-view {}]` is an element whose body
-  runs later, inside that boundary's own `with-frame`; the walk never
-  looks inside it, so it mints, and the \"placeholder\" is then a live
-  boundary that reads subscriptions in the server response. One
-  declaration renders a different document per frame and per write,
-  which is the justification above falsified by what it permits. A
-  `defhost` head crosses the same way, so the hole is deferral and not
-  `defview`.
-
-  **This is UNRULED, not a feature.** It is currently the only recovery
-  for `rf2-l0wfx` — a provider crossing deletes its subtree from the
-  server render, and writing that subtree a second time as the
-  declaration's fallback is the one thing that puts it back. It is also
-  variant-fragile: a frame-fed boundary head (`mark-frame-prop!`,
-  rf2-2rtt6.39) reads `intent/*frame*` at ELEMENT-creation time, which
-  here is mint time, where the var is nil — so it bakes nil in and
-  throws `:rf.error/no-frame-prop` one render into the server response.
-  Whether a boundary head in a fallback works is therefore a property
-  of which mint the head came from.
-
-  Every arm of this is pinned by
-  `arm1/fallback_contents_cljs_test`, which records today's behaviour
-  rather than asserting a contract, so that the ruling is an edit there
-  and never a silence.
+  fallback is inert markup\"* — while only half of it held: the walk
+  refused what it could EVALUATE (an intent vector, a `sub` call in the
+  form, hiccup that is not hiccup) and never looked inside a head whose
+  body runs later. [[refuse-deferring-heads-in-fallback!]] closes that,
+  structurally and ahead of the walk, so the sentence is true as
+  written. Its docstring carries the two measurements that decided it;
+  `arm1/fallback_contents_cljs_test` is the contract.
 
   The gate hands its own props straight through to the foreign
   component, so the crossing's props object is exactly the one
@@ -1087,6 +1209,8 @@
   ordinary prop — and `:key` never reaches here, because
   `createElement` took it off the gate's own element."
   [host-name component fallback]
+  (when (some? fallback)
+    (refuse-deferring-heads-in-fallback! host-name [] fallback))
   (let [placeholder (when (some? fallback) (as-element fallback))
         gate        (fn [props]
                       (if (react/useSyncExternalStore
@@ -1100,10 +1224,19 @@
   "The `:ssr` policy this declaration carries, validated. Absent means
   `:client-only` — the ruled default, so an author who writes nothing
   gets the conservative answer and an author who writes the default
-  explicitly gets the same one."
+  explicitly gets the same one.
+
+  `:render` is the third value (rf2-l0wfx, 2026-08-05) and it is an
+  ASSERTION: *this component is safe to render on the server*. The two
+  spellings an author reaches for instead — `:children` and
+  `:transparent` — stay refused, and so do `:passthrough` and `:server`.
+  They assert a structural property nobody can check and deliver the
+  subtree under the WRONG context value; `:render` names both the
+  conduct (the component renders) and the claim (it is safe to)."
   [host-name opts]
   (let [policy (get opts :ssr :client-only)]
     (if (or (keyword-identical? :client-only policy)
+            (keyword-identical? :render policy)
             (and (map? policy)
                  (= 1 (count policy))
                  (some? (:fallback policy))))
@@ -1114,8 +1247,10 @@
                   ". The policy is :client-only — the default, meaning the "
                   "host region renders nothing until the client adopts it — "
                   "or {:fallback <hiccup>}, meaning that markup renders "
-                  "there instead. There is no third value.")
-             :declare-client-only-or-a-fallback
+                  "there instead, or :render, meaning the component itself "
+                  "is safe to run on the server and does. There is no "
+                  "fourth value.")
+             :declare-client-only-a-fallback-or-render
              {:host host-name :ssr policy}))))
 
 (defn mint-host!
@@ -1132,14 +1267,28 @@
   nothing the author wrote.
 
   `opts` carries `:callbacks` — the finite contract map above — and
-  `:ssr`, the placeholder policy (`:client-only` by default, or
-  `{:fallback <hiccup>}`). Each callback key is normalized to its
-  canonical slot at MINT time, so the lookup the crossing performs per
-  prop is one `get`; a contract outside the roster, a declaration on a
-  structural slot (`key`/`ref` are React's, not positions), two
-  spellings landing on one slot, an `:ssr` value outside the two, and
+  `:ssr`, the server policy (`:client-only` by default,
+  `{:fallback <hiccup>}`, or `:render`). Each callback key is normalized
+  to its canonical slot at MINT time, so the lookup the crossing
+  performs per prop is one `get`; a contract outside the roster, a
+  declaration on a structural slot (`key`/`ref` are React's, not
+  positions), two spellings landing on one slot, an `:ssr` value outside
+  the three, a `defview` or `defhost` head written into a fallback, and
   an option key outside `#{:callbacks :ssr}` are all refused at the
-  declaration, where the author's stack is the declaration site."
+  declaration, where the author's stack is the declaration site.
+
+  ## What the `gate` slot holds, and why it is not always a gate
+
+  The head's `gate` slot is the React TYPE [[host-element]] creates
+  every crossing from, and the `:ssr` policy is expressed by choosing
+  it. Under `:client-only` and `{:fallback …}` it is
+  [[mint-host-gate!]]'s product — one fiber, one hook, and the foreign
+  component behind it. Under `:render` it is the foreign component
+  ITSELF: HD-011's original zero-wrapper, zero-fiber, zero-hook shape,
+  and the reason that policy has no adoption event, no snapshot pair and
+  no remount. `displayName` is not stamped onto the foreign object in
+  that case — it belongs to somebody else's component, and the head map
+  already carries the crossing's name."
   ([host-name component] (mint-host! host-name component {}))
   ([host-name component opts]
    (when (nil? component)
@@ -1194,9 +1343,15 @@
                (assoc m slot contract)))
            {}
            (or (:callbacks opts) {}))
+         ;; The policy IS the type. `:render` mints no gate at all —
+         ;; the foreign component is the element's own type, so the
+         ;; server render, hydration's first pass and a fresh mount are
+         ;; one tree and there is nothing to swap at adoption.
          ^js head #js {"component"   component
-                       "gate"        (mint-host-gate! host-name component
-                                                      (:fallback ssr))
+                       "gate"        (if (keyword-identical? :render ssr)
+                                       component
+                                       (mint-host-gate! host-name component
+                                                        (:fallback ssr)))
                        "callbacks"   declared
                        "ssr"         ssr
                        "displayName" host-name}]
@@ -1210,12 +1365,13 @@
   (and (some? v) (true? (unchecked-get v host-marker))))
 
 (defn host-ssr
-  "The `:ssr` policy `head` was declared with — `:client-only` or
-  `{:fallback <hiccup>}`. The declaration read back as data, for a
-  server walk that wants to state the policy it is honouring
-  (rf2-2rtt6.86) and for the witnesses that assert on it. Nothing on
-  the render path reads it: the policy is enforced by the gate, which
-  is the element's type."
+  "The `:ssr` policy `head` was declared with — `:client-only`,
+  `{:fallback <hiccup>}` or `:render`. The declaration read back as
+  data, for a server walk that wants to state the policy it is
+  honouring (rf2-2rtt6.86) and for the witnesses that assert on it.
+  Nothing on the render path reads it: the policy is enforced by WHICH
+  TYPE the declaration mints — a gate for the first two, the foreign
+  component itself for `:render`."
   [^js head]
   (unchecked-get head "ssr"))
 
@@ -1779,16 +1935,19 @@
   Children are trailing forms converted hiccup→element and handed to the
   foreign component as ordinary React children — HD-011's third default.
 
-  The element's TYPE is the declaration's gate ([[mint-host-gate!]]),
-  which is one fiber and one hook, and the foreign component is what
-  the gate renders once the markup is adopted. Everything else is
-  unchanged by that: the props object built here is the object the
-  foreign component receives, `:key` is React's on the gate's element
-  where it always was, and the component's hooks, state and refs stay
-  React's affair under React's rules — which is the whole point of the
-  door, and what keeps HD-020's ≤2-hook budget a statement about
-  Hicasso's BOUNDARIES. The gate is not one: no frame, no subscription,
-  no body."
+  The element's TYPE is whatever the declaration put in its `gate`
+  slot, and that is where the `:ssr` policy lives: under `:client-only`
+  and `{:fallback …}` it is the gate ([[mint-host-gate!]]), one fiber
+  and one hook, with the foreign component behind it once the markup is
+  adopted; under `:ssr :render` it is the foreign component itself and
+  the crossing costs neither. Everything else is unchanged by that
+  choice: the props object built here is the object the foreign
+  component receives either way, `:key` is React's on the crossing's
+  element where it always was, and the component's hooks, state and
+  refs stay React's affair under React's rules — which is the whole
+  point of the door, and what keeps HD-020's ≤2-hook budget a statement
+  about Hicasso's BOUNDARIES. A gate is not one: no frame, no
+  subscription, no body."
   [argv]
   (let [^js head   (nth argv 0)
         declared   (unchecked-get head "callbacks")

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/entry_cljs_test.cljs
@@ -312,6 +312,27 @@
       ;; regions rather than pruning the tree.
       (is (str/includes? html "<h1>hosts</h1>")))))
 
+(deftest a-host-declaring-render-renders-the-component-and-its-children
+  (testing ":ssr :render (rf2-l0wfx) — the third policy, through the same
+           entry as the other two. It is the ONLY one under which a
+           crossing's children reach the server response at all: under a
+           gate the unadopted arm returns something that is not the
+           component, so a transparent wrapper such as a context provider
+           takes its whole subtree out of the HTML with it"
+    (is (= :render (codec/host-ssr fixtures/render-host))
+        "read back from the declaration, like every other policy")
+    (let [{:keys [html]} (entry/render (fixtures/row "defhost-ssr-render"))]
+      (is (str/includes? html "RENDER-SUBTREE")
+          "the crossing's CHILDREN are in the server HTML")
+      (is (str/includes? html "class=\"render-subtree\"")
+          "as markup, not as stray text")
+      (is (str/includes? html "<em class=\"context-reader\">dark</em>")
+          "and a consumer below the provider read the DECLARED context
+           value — the property that separates :render from the rejected
+           :children, which would have emitted the context DEFAULT")
+      (is (not (str/includes? html "<em class=\"context-reader\">unset</em>"))
+          "so the default is nowhere in the bytes"))))
+
 (defn- walk-reachable-host-heads
   "Every minted host head reachable from `form` through vectors and seqs
   — which is exactly what the retired `ssr.host-policy/apply-policy`
@@ -373,7 +394,15 @@
             "the declared placeholder is what the server wrote there")
         (is (= 1 (count (re-seq #"loading" html)))
             "exactly one — this row has one fallback host, so a count is a
-             real assertion and not a presence check in disguise")))))
+             real assertion and not a presence check in disguise"))
+
+      (testing ":render, at a nested use site (rf2-l0wfx)"
+        (is (str/includes? html "NESTED-RENDER-SUBTREE")
+            "the crossing's children reached the server response from
+             inside a boundary body too")
+        (is (str/includes? html "<em class=\"context-reader\">dark</em>")
+            "with the declared context value, which is a claim about
+             React's own server renderer and not about this codec")))))
 
 ;; ---------------------------------------------------------------------------
 ;; The corpus renders at all — the bake's own precondition

--- a/implementation/freehand/test/re_frame/bench/hicasso/ssr/fixtures.cljs
+++ b/implementation/freehand/test/re_frame/bench/hicasso/ssr/fixtures.cljs
@@ -18,13 +18,16 @@
   - **A tier-1 bulk shape** — the ~1,200-element Conduit feed page, which
     is the size the charter's bar rows are taken at and the only row here
     whose markup is a port of a real application's.
-  - **`defhost`'s `:ssr` policy**, both meanings and both USE-SITE
+  - **`defhost`'s `:ssr` policy**, all three meanings and both USE-SITE
     positions: a host with no declared policy (the ruled `:client-only`
-    default — its component's markup MUST be absent from the server HTML)
-    and a host declaring a fallback (whose placeholder markup MUST be
-    present), each rendered once from the hiccup the entry is handed and
-    once from inside a `defview` body. See [[host-screen]] and
-    [[nested-host-screen]].
+    default — its component's markup MUST be absent from the server
+    HTML), a host declaring a fallback (whose placeholder markup MUST be
+    present), and a host declaring `:render` (whose component, CHILDREN
+    and declared context value MUST all be present — rf2-l0wfx), each
+    rendered once from the hiccup the entry is handed and once from
+    inside a `defview` body. See [[host-screen]],
+    [[render-host-screen]] — separate for the reason its docstring
+    gives — and [[nested-host-screen]], which carries all three.
   - **Presence's `::h/mounting` overrides** — and that row is a PINNED
     DEFECT rather than a feature. See [[presence-tray]].
   - **The instance-key payload obligation, TWICE** — one page whose boot
@@ -84,9 +87,37 @@
   client-widget
   {:ssr {:fallback [:span.host-fallback "loading…"]}})
 
+(def ^:private corpus-context
+  "A React context, so the `:render` row can carry the shape that filed
+  rf2-l0wfx — a transparent wrapper whose whole job is a subtree."
+  (react/createContext "unset"))
+
+(defn- context-reader
+  "A consumer BELOW the provider. Its text is the corpus's evidence that
+  `:ssr :render` puts the DECLARED context value in the server bytes and
+  not the default — the one property that separated the ruled policy
+  from the rejected `:ssr :children`."
+  [_js-props]
+  (react/createElement "em" #js {"className" "context-reader"}
+                       (react/useContext corpus-context)))
+
+(defhost render-host
+  "A declaration whose policy is `:render`: the author asserts the
+  component is safe on the server, so the declaration mints no gate and
+  the component IS the element's type. A context provider is the case
+  where that assertion is trivially true."
+  (.-Provider corpus-context)
+  {:ssr :render})
+
+(defhost render-reader-host
+  "The consumer, also `:render`, because a consumer that did not render
+  server-side could not witness the value."
+  context-reader
+  {:ssr :render})
+
 (def host-screen
-  "One page carrying both hosts at HANDED-IN positions — nested inside
-  ordinary markup and inside a `for`, the lazy position."
+  "One page carrying both GATED hosts at HANDED-IN positions — nested
+  inside ordinary markup and inside a `for`, the lazy position."
   [:div.hosts
    [:h1 "hosts"]
    [default-host {:kind "default"}]
@@ -94,22 +125,46 @@
     (for [i (range 2)]
       [:li {:key i} [fallback-host {:kind "fallback" :i i}]])]])
 
+(def render-host-screen
+  "The `:render` policy's own row, and it is separate from
+  [[host-screen]] for a reason that is a fact about React rather than a
+  taste. React 19's `ctx.Provider` **is the context object**, and that
+  object carries a `Provider` key pointing back at itself — a cycle. Any
+  walk that descends into a hiccup form's JS values therefore recurses
+  forever on this head, and
+  `re-frame.ssr.hash/render-tree-hash` is one such walk
+  (`entry_cljs_test` → `the-hash-this-root-would-have-had-is-a-constant`
+  takes it over [[host-screen]] as its non-vacuity control). Nothing on
+  a live path hashes an interpreted root — this tier deliberately ships
+  no `:rf/render-hash` at either end (rf2-2rtt6.91) — so the cycle is
+  filed rather than worked around, and this row keeps the measurement
+  row's input free of it."
+  [:div.render-hosts
+   [:h1 "render"]
+   [render-host {:value "dark"}
+    [:p.render-subtree "RENDER-SUBTREE"]
+    [render-reader-host {}]]])
+
 (defview nested-host-panel
-  "THE POSITION NO PRE-WALK CAN REACH. Both hosts are used inside a
+  "THE POSITION NO PRE-WALK CAN REACH. All three hosts are used inside a
   BOUNDARY BODY, so their elements do not exist when the render entry is
   handed its hiccup: this body runs inside `renderToString`, and the
   codec's own crossing creates them there.
 
   The `:ssr` policy is honoured all the same, because it is enforced at
-  the element's TYPE — `mint-host!` mints a gate whose
-  `useSyncExternalStore` answers `false` from its server snapshot. That
-  is the argument; [[nested-host-screen]] rendered through the entry is
-  the witness."
+  the element's TYPE — for the two gated policies `mint-host!` mints a
+  gate whose `useSyncExternalStore` answers `false` from its server
+  snapshot, and for `:render` it mints no gate at all and the component
+  is the type. That is the argument; [[nested-host-screen]] rendered
+  through the entry is the witness."
   [_]
   [:div.nested-hosts
    [:h2 "nested"]
    [default-host {:kind "nested-default"}]
-   [fallback-host {:kind "nested-fallback"}]])
+   [fallback-host {:kind "nested-fallback"}]
+   [render-host {:value "dark"}
+    [:p.nested-render-subtree "NESTED-RENDER-SUBTREE"]
+    [render-reader-host {}]]])
 
 (def nested-host-screen
   "[[nested-host-panel]] under an ordinary root, so \"the host region is
@@ -202,15 +257,23 @@
     :script-src "/main.js"}
 
    {:id     "defhost-ssr-policy"
-    :why    "defhost regions honour the :ssr policy server-side — default :client-only renders nothing, {:fallback} renders the fallback"
+    :why    "defhost regions honour the :ssr policy server-side — default :client-only renders nothing, {:fallback} renders the fallback, :render renders the component with its children under the declared context value"
     :hiccup host-screen
     :snapshot {}
     :payload  :rf.ssr.payload/whole-app-db
     :title    "Hicasso SSR — defhost :ssr policy"
     :script-src "/main.js"}
 
+   {:id     "defhost-ssr-render"
+    :why    "the third policy (rf2-l0wfx) — :render mints no gate, so the component, its CHILDREN and the declared context value are all in the server bytes; the only policy under which a crossing's subtree reaches the response at all"
+    :hiccup render-host-screen
+    :snapshot {}
+    :payload  :rf.ssr.payload/whole-app-db
+    :title    "Hicasso SSR — defhost :ssr :render"
+    :script-src "/main.js"}
+
    {:id     "defhost-ssr-nested"
-    :why    "the SAME two declarations used INSIDE a defview body — the position no walk over the handed-in hiccup could reach, honoured because the policy is the element's own type"
+    :why    "the SAME declarations used INSIDE a defview body — the position no walk over the handed-in hiccup could reach, honoured because the policy is the element's own type"
     :hiccup nested-host-screen
     :snapshot {}
     :payload  :rf.ssr.payload/whole-app-db


### PR DESCRIPTION
Implements the coupled operator ruling of 2026-08-05 20:02 AUSEST recorded on `rf2-l0wfx`. Both halves in one PR because they share the gate region and constrain each other in both directions.

> **Note on sequencing.** This PR was merged while the worker was still running gates, and its worktree was reaped. Everything under **Quality gates** was re-run against `origin/main` **after** the merge, in a fresh checkout containing both commits.

## `rf2-l0wfx` — `:ssr :render`

The declaration asserts *"this component is safe to render on the server"*. `declared-ssr` accepts the bare keyword `:render` as a third policy, and `mint-host!` then mints **no gate**: the head's `gate` slot — the React type `host-element` creates every crossing from — carries the foreign component itself. That is HD-011's original zero-wrapper / zero-fiber / zero-hook shape restored for this policy. `displayName` is deliberately **not** stamped onto the foreign object; the head map already carries the crossing's name.

Consequence: the server render, hydration's first client pass and a fresh `createRoot` mount all render the same element type with the same props, context and children. One tree everywhere — zero mismatch by identity rather than by a snapshot pair agreeing, no adoption event, no type swap, **no remount**. It is the only policy under which a crossing's **children** reach the server response at all, which is what a transparent wrapper such as a context provider needs.

`:children`, `:transparent`, `:passthrough` and `:server` stay refused; `:client-only` stays the default.

## `rf2-nv07k` — a fallback refuses at mint

`refuse-deferring-heads-in-fallback!` walks a declared `:ssr` fallback **structurally**, ahead of the evaluating walk, and refuses a `defview` or `defhost` head at any position with `:rf.error/hicasso-host-fallback-boundary-head` — naming the host, the head's `displayName`, which door minted it, and its index route into the declared form (`[1 1 0]`). It is walk-scoped and asks the boundary *marker*, so it catches the frame-fed nil-bake variant for free without knowing that variant exists.

The workaround it deletes — writing a provider's subtree a second time as the declaration's fallback — is superseded by `:render`, not merely removed.

## Mutation proofs — both halves, both directions

`codec.cljs` restored from a byte copy after each; the working tree was verified clean before the gates.

| Mutation | Effect |
|---|---|
| Route `:render` through `mint-host-gate!` (the branch removed) | `host_ssr_dom_cljs_test` **5 failures**, `ssr/entry_cljs_test` **5 failures** — the subtree missing from the server HTML and the consumer reading nothing. `fallback_contents_cljs_test` **0**, so the mutation is not visible to the other half |
| Remove `:render` from `declared-ssr` | The bundle fails to LOAD: `defhost …/themed declares :ssr :render … There is no fourth value. [:rf.error/hicasso-host-bad-ssr-policy]` — the acceptance is load-bearing at the declaration |
| Remove the fallback refusal | `fallback_contents_cljs_test` **15 failures + 1 error**, `host_ssr_dom_cljs_test` **1 failure**. `ssr/entry_cljs_test` **0**, so again not visible to the other half |
| Over-refuse everything non-nil | Bundle load failure on `inner-host`'s own ordinary fallback — an over-broad walk is instantly fatal, because ordinary fallbacks are everywhere |
| Over-refuse *numbers* only — narrow, so failures land per row | Exactly two rows go red, each at its own `is`: `ok/seq` and `ok/scalars`. Every other legitimate position stays green |

Each legitimate fallback position is proven **individually**, one `is` per shape, so an over-broad walk fails by name rather than as a wall of red: a bare tag, a tag with a props map, nested vectors, a seq child (the lazy position), a fragment, string/number/nil/false children, a bare string, an already-built React element, and a props map whose values are collections.

## What did not move

- **The ordinary render path is unchanged** where no crossing applies. `host-element` chooses a type from the `gate` slot exactly as before; only *what the declaration put there* changed.
- **No hook was added anywhere.** The `≤2-hook` shell is untouched — `hook_ledger_dom_cljs_test` measures the boundary shell, not the host gate, and `:render` *removes* a hook rather than adding one. Nothing in this diff goes near a shell.
- **Freehand's `v/defhost` takes zero edits**, deliberately: its "counted, not walked" SSR projection rests on the JVM never executing the React component, and that rationale genuinely does not transfer. The two doors diverge honestly.
- **Spec 011, Spec 009 and the Spec 009 error catalogue take zero edits** — re-verified: no `hicasso-host-*` id appears in Spec 009, and Spec 011 names neither `hicasso` nor `defhost`.
- **`draft-guide/11-performance.md` and `draft-guide/README.md` untouched**, because PRs #7527 and #7528 are open on both and conflict with each other. The delta that page would want is one optional line beside its existing `{:ssr :client-only}` sample, and that sample is not made wrong by this ruling. **Left for the operator to sequence.**

## Co-edit bill (costing doc §"If the fix is scoped to Hicasso")

Covered: `front/codec.cljs` (all five named sites plus the new refusal), `arm1/lang.clj`, `arm1/host_ssr_dom_cljs_test.cljs`, `arm1/fallback_contents_cljs_test.cljs`, `arm1/hydrate_dom_cljs_test.cljs`, `ssr/fixtures.cljs`, `ssr/entry_cljs_test.cljs`, `decisions.md` (dated HD-011 addendum plus the stale HD-020(d) line), `draft-guide/05-interop.md`, `draft-guide/10-server-side-rendering.md`, `studio/raw-escape-spec.md`, `studio/raw-escape-design-c-ergonomics.md`, `production-server-arm.md`, `EP-0038`, and a dated ruling banner on the costing doc itself.

Not needed: `ssr/driver.cjs` and `ssr/bake_bytes.test.cjs`. That file pins the byte **arithmetic** (`utf8Bytes` vs `String.length`) over its own escaped fixtures, not per-row budgets, and no baked fixture is committed — so a corpus row does not move it. Its `485`/`491` figures are prose in a comment describing a historical defect.

`production-server-arm.md`'s citation into `codec.cljs` was converted from a line range to **symbol names**, because that block has now moved twice since it was written.

## A finding, filed rather than worked around — `rf2-56iys`

React 19's `ctx.Provider` **is the context object**, and that object carries a `Provider` key pointing back at itself. Any walk that descends into a hiccup form's JS values therefore recurses forever on a `defhost` head whose component is a provider — `re-frame.ssr.hash/render-tree-hash` is one such walk, and putting the provider into `host-screen` blew the stack in `entry_cljs_test`'s `the-hash-this-root-would-have-had-is-a-constant`. Nothing on a live path hashes an interpreted root (this tier ships no `:rf/render-hash` at either end, `rf2-2rtt6.91`), so the `:render` corpus row is a **separate screen** and the cycle is filed rather than papered over. `render-host-screen`'s docstring records why.

## Documentation verification (by hand — nothing validates these)

`mkdocs build --strict` does not cover `docs/design/hicasso/**`; `scripts/check_doc_slugs.py` does, and it was **mutation-proven**: a deliberate `#no-such-anchor-l0wfx` link was injected into `10-server-side-rendering.md`, confirmed present by grep, and the gate reported `1 broken anchor link(s) found` at that exact line before the injection was reverted. Every markdown table in every edited file was hand-counted for column consistency — 33 tables, 0 mismatches — since nothing validates tables.

## Quality gates

All run in a fresh worktree off `origin/main` **containing both merged commits**, foreground to completion, never piped through `tail`/`head`/`grep` — output was redirected to a file and read afterwards.

| Gate | Exit | Result |
|---|---|---|
| `npm run test:cljs` (full `node-test`) | **0** | Ran 12639 tests containing 63317 assertions. **0 failures, 0 errors** |
| `npm run test:hicasso-compile` | **0** | `[hicasso-compile] ok — 126 lane namespaces compiled with zero warnings` |
| `npm run test:browser` | **0** | Ran 1101 tests containing 6818 assertions. **0 failures, 0 errors.** `host_ssr_dom_cljs_test` (incl. the new `a-render-crossing-hydrates-once-and-never-remounts` row), `hook_ledger_dom_cljs_test`, `hydrate_dom_cljs_test` and `host_hatch_dom_cljs_test` all verified present in the compiled browser bundle, so the row genuinely ran against a real React DOM |
| `sh scripts/test-fast-pr.sh` | **0** | `PASS fast PR spine`. Post-merge the checkout has no diff, so the spine self-classified `docs=false jvm=false node=false` and ran static checks only |
| `sh scripts/test-fast-pr.sh --all` | **0** | `PASS fast PR spine`. Re-run with `--all` to force `docs=true jvm=true node=true`, since the tier above would otherwise have skipped the docs lane that the `EP-0038` edit needs. `mkdocs --strict` **built clean in 24.11s**; JVM core **2215 tests / 11527 assertions, 0 failures 0 errors**; node lane **12639 tests / 63317 assertions, 0 failures 0 errors** |
| `python scripts/check_doc_slugs.py` | **0** | Clean, and mutation-proven as above |
| clj-kondo `2026.04.15` (CI pin, CI's exact `--lint` roster) | **0** | **errors: 0**, warnings **4536** — the stated baseline exactly |
| SSR suites (`ssr/entry-cljs-test`, `ssr/hframe-ssr-cljs-test`, `ssr/spike-cljs-test`, `ssr/instance-key-payload-dom-cljs-test`) | **0** | Inside `test:cljs` above |

clj-kondo was run at the CI pin via `clojure -Sdeps '{:deps {clj-kondo/clj-kondo {:mvn/version "2026.04.15"}}}'` because the local binary is `v2025.10.23`; the JVM invocation reports `clj-kondo v2026.04.15`.

Closes `rf2-l0wfx`. Closes `rf2-nv07k`.
